### PR TITLE
chore: apply byte5ai engineering-standards (initial bootstrap)

### DIFF
--- a/.github/engineering-standards.yml
+++ b/.github/engineering-standards.yml
@@ -1,0 +1,9 @@
+# Engineering-Standards-Status dieses Repos.
+# Single source of truth, gilt host- und agent-übergreifend.
+# Schema: siehe byte5ai/engineering-standards.
+
+status: applied
+source: byte5ai/engineering-standards
+decided_on: 2026-05-17
+reviewed_on: 2026-05-17
+reason: ""

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Pre-push hook: block direct pushes to main/master.
+# Override: ALLOW_PUSH_TO_MAIN=1 git push origin main
+
+if [ "$ALLOW_PUSH_TO_MAIN" = "1" ]; then
+  exit 0
+fi
+
+while read -r _local_ref _local_sha remote_ref _remote_sha; do
+  remote_branch="${remote_ref##refs/heads/}"
+  if [[ "$remote_branch" =~ ^(main|master)$ ]]; then
+    echo ""
+    echo "  BLOCKED: Direct push to '$remote_branch' is not allowed."
+    echo "  Create a feature branch and open a pull request instead."
+    echo ""
+    echo "  Override (emergencies only):"
+    echo "    ALLOW_PUSH_TO_MAIN=1 git push origin $remote_branch"
+    echo ""
+    exit 1
+  fi
+done
+
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Ohne mindestens Punkte 1–3 darf kein Code geändert werden.
 
 - **Fly-Deploys sind nicht atomar.** Wenn ein anderer Agent gerade deployt, abwarten (30-60s), sonst trittst du ihm auf den Zeh.
 - **Secrets-Rotation synchronisieren.** Nicht unangekündigt Secrets überschreiben — ein Agent deployt einen Proxy-Token-Rename, ein anderer Agent hält noch den alten im Skill. Kommuniziere solche Änderungen im CHANGELOG, bevor du die `fly secrets set`-Kommandos tippst.
-- **Git gibt es aktuell nicht** — das Repo ist **nicht git-tracked** (Stand 2026-04-19). Dein einziger Rollback-Schutz ist saubere Dokumentation und kleine, verifizierbare Schritte. Niemals zwei große Änderungen mischen.
+- **Git-Workflow ernst nehmen.** Das Repo liegt seit `2026-05` öffentlich auf `github.com/byte5ai/omadia`. Keine direkten Pushes auf `main` (lokal vom `.hooks/pre-push`-Guard blockiert, serverseitig von Branch Protection). Alle Änderungen über Feature-Branch + PR. Conventional-Commits-Konvention gilt (siehe unten). Niemals zwei große Änderungen in einem Commit mischen — kleine, verifizierbare Schritte sind weiterhin Pflicht.
 
 ## Anti-Pattern, die wir schon bezahlt haben
 
@@ -47,8 +47,41 @@ Ohne mindestens Punkte 1–3 darf kein Code geändert werden.
 - **Token in Agent-Config-YAML**: `agent-config-confluence.yaml` enthielt den Atlassian-Token direkt im System-Prompt. Policy: Credentials gehören **ausschließlich** in Fly Secrets — siehe `docs/security-migration-plan.md` §3.
 - **Build-Artefakt vergessen**: `tsc` kopiert keine `.sql`-Files. Fix via `middleware/scripts/copy-build-assets.mjs`. Generell: Non-TS-Assets brauchen immer einen expliziten Build-Schritt.
 
+## Git Workflow & Engineering Standards
+
+Diese Regeln gelten für alle AI-Agenten (Claude, Codex, Copilot, …) und für menschliche Contributors gleichermaßen. Source of truth: `byte5ai/engineering-standards`. Status dieses Repos: `.github/engineering-standards.yml` (`status: applied`).
+
+- **Niemals direkt auf `main` pushen.** Feature-Branch + PR. Lokal blockt `.hooks/pre-push`, serverseitig Branch Protection.
+- **Branch-Naming:** `feat/<desc>`, `fix/<desc>`, `refactor/<desc>`, `docs/<desc>`, `chore/<desc>`, `test/<desc>`, `ci/<desc>`, `perf/<desc>`, `release/vX.Y`, `dev/vX.Y.devN`.
+- **Conventional Commits:** `feat:`, `fix:`, `refactor:`, `docs:`, `chore:`, `test:`, `ci:`, `perf:`, `release:`, `dev:`. Subject < 70 Zeichen, Body erklärt das **Warum** (das *Was* steht im Diff).
+- **Keine `Co-Authored-By:`-Trailer für Claude, Codex, Copilot oder andere KI-Agenten.** Commits werden unter der konfigurierten Git-Identität erstellt, ohne Model-Attribution-Footer. Auch nicht als empfohlenes Format in Templates oder Hilfetexten auftauchen lassen.
+- **Niemals force-push** auf geteilte Branches (besonders `main`).
+- **Niemals Secrets committen** (`.env`, API-Keys, Tokens). Bei Treffer: rotiert das betroffene Secret sofort.
+- **Niemals `--no-verify`.** Wenn ein Hook fehlschlägt, erst die Ursache fixen.
+
+### Pre-push-Hook aktivieren
+
+Der Hook ist in `.hooks/pre-push` versioniert. Aktivierung pro Working-Tree:
+
+```bash
+git config core.hooksPath .hooks   # erledigt auch script/setup
+```
+
+Override für Notfälle (sehr selten gerechtfertigt):
+
+```bash
+ALLOW_PUSH_TO_MAIN=1 git push origin main
+```
+
+### PR-Regeln
+
+- PR-Titel < 70 Zeichen, Conventional-Prefix.
+- Eine logische Änderung pro PR — kein "While I'm at it…"-Stacking.
+- CI muss grün sein vor Merge. Status-Checks (`middleware`, `web-ui`, `schema`, `audit`) sind Required.
+- Squash-Merge ist Default; der PR-Titel wird zur Commit-Subject-Zeile.
+
 ## Meta
 
 Dieses Dokument wird selbst im CHANGELOG geführt, wenn sich die Regeln ändern. Kein stilles Ändern der Regeln ohne Doku.
 
-— Stand 2026-04-19, byte5
+— Stand 2026-05-17, byte5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,11 @@ incremental.
 
 ## Verification before pushing
 
+> The repo ships a `.hooks/pre-push` guard that blocks direct pushes to
+> `main`/`master`. `script/setup` activates it automatically (`git config
+> core.hooksPath .hooks`); if you skipped the setup script, run that
+> single command manually.
+
 ```bash
 # In middleware/
 npm run typecheck    # TypeScript --noEmit, runs across all workspaces
@@ -79,6 +84,9 @@ for everyone.
    - `test(scope): subject`, `perf(scope): subject`
    - Body explains the **why**, not the **what** — the diff already
      explains the what.
+   - **No `Co-Authored-By:` trailers for AI agents** (Claude, Codex,
+     Copilot, etc.). Commits are made under the contributor's configured
+     git identity, with no model-attribution footer.
 3. **Pull request** — describe the change, link the issue if applicable,
    include manual-test notes for anything that touches a UI or a runtime
    path. Mark draft PRs early to invite feedback before the change is

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# One-command dev bootstrap for byte5ai/omadia.
+# Mirrors the manual steps in CONTRIBUTING.md and activates the
+# repo-local pre-push hook (which blocks direct pushes to main).
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+echo "==> Configuring git hooks (.hooks/pre-push blocks direct pushes to main)..."
+git config core.hooksPath .hooks
+
+echo "==> Installing middleware deps..."
+( cd middleware && npm install )
+
+echo "==> Installing web-ui deps..."
+( cd web-ui && npm install )
+
+cat <<'NEXT'
+
+Setup complete. Next steps:
+  cp middleware/.env.example middleware/.env   # set ANTHROPIC_API_KEY
+  docker compose up -d minio kroki ollama     # local sidecars
+  ( cd middleware && npm run dev )            # API on :8080
+  ( cd web-ui && npm run dev )                # admin UI on :3000
+
+NEXT


### PR DESCRIPTION
## Summary

Bringt das Repo auf den byte5ai-Engineering-Standard. Additive Änderung — kein bestehendes Verhalten wird ersetzt.

- **`.github/engineering-standards.yml`** (neu): expliziter `status: applied`-Marker, Source `byte5ai/engineering-standards`, decided/reviewed 2026-05-17.
- **`.hooks/pre-push`** (neu, +x): blockiert direkte Pushes auf `main`/`master`. Override via `ALLOW_PUSH_TO_MAIN=1` für Notfälle.
- **`script/setup`** (neu, +x): One-Command-Bootstrap — `core.hooksPath = .hooks`, `npm install` in `middleware/` und `web-ui/`. Spiegelt die manuellen Schritte in CONTRIBUTING.md.
- **`AGENTS.md`**: neue Section "Git Workflow & Engineering Standards" (Branch-Naming, Conventional Commits, Verbot von `Co-Authored-By:`-Trailern für KI-Agenten, kein Force-Push, kein `--no-verify`). Veralteter Satz "Git gibt es aktuell nicht — Stand 2026-04-19" korrigiert (Repo ist seit `2026-05` öffentlich auf GitHub).
- **`CONTRIBUTING.md`**: Pre-Push-Guard-Hinweis im Verification-Block; Verbot von `Co-Authored-By:`-Trailern im PR-Workflow.

Branch Protection auf `main` wird in einem **separaten Schritt nach dem Merge** per GitHub-API gesetzt — danach sind die CI-Status-Check-Kontexte registriert und können als Required Checks gepinnt werden:
`middleware (lint + typecheck + test)`, `web-ui (lint + typecheck + vitest)`, `schema (migrations on pgvector)`, `audit (high+critical block) (middleware|web-ui)`.

Hinweis: Required Status Checks haken sich an Job-Namen. Wenn `ci.yml`-Job-`name:`-Felder geändert werden, muss das Branch-Protection-PUT entsprechend nachgezogen werden.

## Test plan

- [x] Hook-Smoke lokal: `refs/heads/main`-Push → `BLOCKED`, Exit 1
- [x] Hook-Override: `ALLOW_PUSH_TO_MAIN=1` → Exit 0
- [x] Hook-Passthrough für Feature-Branch (`chore/foo`) → Exit 0
- [ ] CI grün: middleware, web-ui, schema, audit (×2 Matrix)
- [ ] Manuell: `bash script/setup` läuft lokal durch (middleware-/web-ui-`npm install` + `core.hooksPath`)
- [ ] Nach Merge: Branch Protection auf `main` per API (separater Step)