### PR TITLE
fix(ci): bump setup-node to v22 to match middleware engines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: middleware/package-lock.json
 
@@ -75,7 +75,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web-ui/package-lock.json
 
@@ -182,7 +182,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: ${{ matrix.workspace }}/package-lock.json
 


### PR DESCRIPTION
## Summary

- `middleware/package.json` declares `engines.node ">=22 <23"`, but `.github/workflows/ci.yml` pinned all three `actions/setup-node@v4` steps to `node-version: '20'`.
- After reactivating GitHub Actions, this surfaced as `EBADENGINE` during `npm ci` in the `middleware (lint + typecheck + test)` and `audit (high+critical block) (middleware)` jobs.
- Bumps all three `setup-node` invocations (middleware job line 44, web-ui job line 78, audit matrix job line 185) from `'20'` to `'22'`. No other files touched.

Root-level `.nvmrc` already pins `22.12.0` and was left untouched.

The schema-smoke failures (stale migration paths) are out-of-scope here and being handled in a parallel PR.

## Test plan

- [ ] Required checks `middleware (lint + typecheck + test)` and `audit (high+critical block) (middleware)` turn green (were red with EBADENGINE).
- [ ] `web-ui (lint + typecheck + vitest)` and `audit (high+critical block) (web-ui)` stay green.
- [ ] `schema (migrations on pgvector)` remains red until the parallel migration-path PR lands — expected and out-of-scope.