### PR TITLE
fix(ci): resurrect CI after Actions reactivation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,12 @@
 name: CI
 
 on:
+  # Pull-request trigger accepts any base branch so that cluster-fix
+  # PRs stacked on the test-suite resurrection branch (#35 / #37)
+  # still run CI. Once #35 merges and the cluster work is done, this
+  # can return to `branches: [main]`.
   pull_request:
-    branches: [main]
+    branches: ['**']
   push:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 # PR + main-branch quality gate.
 #
 # Runs lint + typecheck + test on both workspaces, plus a schema smoke
-# that applies all 9 migrations against a real pgvector container. Audit
-# enforces a high-severity ceiling so a CVE-bumping dep can't slip in
-# unnoticed.
+# that applies every migration in the repo against a real pgvector
+# container. Audit enforces a high-severity ceiling so a CVE-bumping
+# dep can't slip in unnoticed.
 #
 # Naming-independent — no secrets, no GHCR/npm push. Release-flow lives
 # in release.yml (currently placeholder; activates once OB-30 Block 2
@@ -104,8 +104,11 @@ jobs:
         run: npm run test
 
   # ------------------------------------------------------------------
-  # Schema smoke: apply all 9 migrations against pgvector. Catches
-  # SQL-only regressions before they hit prod-or-OSS-demo deploys.
+  # Schema smoke: apply every migration in the repo against pgvector.
+  # Catches SQL-only regressions before they hit prod-or-OSS-demo
+  # deploys. Domains are listed explicitly in dependency order; files
+  # inside a domain are applied in lexical (numbered) order, so newly
+  # added migrations are picked up automatically.
   # ------------------------------------------------------------------
   schema:
     name: schema (migrations on pgvector)
@@ -124,6 +127,17 @@ jobs:
           --health-interval 5s
           --health-timeout 3s
           --health-retries 20
+    env:
+      # Schema domains in apply order. Within each domain, files apply
+      # in lexical (file-name) order — which matches the numbered
+      # migration convention. Newline-separated so the shell loop can
+      # iterate cleanly.
+      MIGRATION_DOMAINS: |
+        middleware/packages/harness-knowledge-graph-neon/src/migrations
+        middleware/src/auth/migrations
+        middleware/src/plugins/routines/migrations
+        middleware/src/profileSnapshots/migrations
+        middleware/src/profileStorage/migrations
     steps:
       - uses: actions/checkout@v4
 
@@ -132,45 +146,30 @@ jobs:
           PGPASSWORD=omadia-ci psql -h localhost -U omadia -d omadia \
             -c "CREATE EXTENSION IF NOT EXISTS vector;"
 
-      - name: Apply 9 migrations in order
+      - name: Apply all migrations
         run: |
           set -euo pipefail
-          declare -a MIGRATIONS=(
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0001_graph_init.sql"
-            "middleware/src/services/graph/migrations/0002_user_scoping.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0003_agentic_graph.sql"
-            "middleware/src/services/graph/migrations/0004_turn_fts.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0005_turn_embeddings_768.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0006_embedding_backfill_state.sql"
-            "middleware/src/services/graph/migrations/0007_verifier_tables.sql"
-            "middleware/src/services/graph/migrations/0008_teams_attachments.sql"
-            "middleware/src/plugins/routines/migrations/0001_routines.sql"
-          )
-          for m in "${MIGRATIONS[@]}"; do
-            echo "--- applying $(basename "$m")"
-            PGPASSWORD=omadia-ci psql -h localhost -U omadia -d omadia \
-              -v ON_ERROR_STOP=1 -f "$m"
-          done
+          while IFS= read -r dir; do
+            [ -z "$dir" ] && continue
+            echo "==> domain: $dir"
+            for f in "$dir"/*.sql; do
+              echo "  applying $(basename "$f")"
+              PGPASSWORD=omadia-ci psql -h localhost -U omadia -d omadia \
+                -v ON_ERROR_STOP=1 -f "$f"
+            done
+          done <<< "$MIGRATION_DOMAINS"
 
       - name: Re-apply migrations (idempotency check)
         run: |
           set -euo pipefail
-          declare -a MIGRATIONS=(
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0001_graph_init.sql"
-            "middleware/src/services/graph/migrations/0002_user_scoping.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0003_agentic_graph.sql"
-            "middleware/src/services/graph/migrations/0004_turn_fts.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0005_turn_embeddings_768.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0006_embedding_backfill_state.sql"
-            "middleware/src/services/graph/migrations/0007_verifier_tables.sql"
-            "middleware/src/services/graph/migrations/0008_teams_attachments.sql"
-            "middleware/src/plugins/routines/migrations/0001_routines.sql"
-          )
-          for m in "${MIGRATIONS[@]}"; do
-            PGPASSWORD=omadia-ci psql -h localhost -U omadia -d omadia \
-              -v ON_ERROR_STOP=1 -f "$m" > /dev/null
-            echo "✓ idempotent: $(basename "$m")"
-          done
+          while IFS= read -r dir; do
+            [ -z "$dir" ] && continue
+            for f in "$dir"/*.sql; do
+              PGPASSWORD=omadia-ci psql -h localhost -U omadia -d omadia \
+                -v ON_ERROR_STOP=1 -f "$f" > /dev/null
+              echo "✓ idempotent: $(basename "$f")"
+            done
+          done <<< "$MIGRATION_DOMAINS"
 
   # ------------------------------------------------------------------
   # Dependency audit. Enforces a "no high or critical" floor — moderate


### PR DESCRIPTION
## Summary

Consolidates the three pre-existing CI bugs that surfaced when GitHub Actions were re-enabled (see PR #31), plus the missed CHANGELOG entry for the standards rollout. Replaces the three separately opened PRs #32, #33, #34, none of which could merge on its own under the strict branch protection — each had at least one red required check dependent on one of the others.

## What's included

| Commit | What |
|---|---|
| `fix(ci): align schema-smoke with current migrations layout` | From #34. Replaces the hardcoded migrations array in `ci.yml` with a glob over five migration domains. Coverage grew 9 → 20 migrations. |
| `fix(ci): bump setup-node to v22 to match middleware engines` | From #33. `node-version: '20'` → `'22'` in three places. Resolves EBADENGINE in `middleware` and `audit (middleware)`. |
| `fix(lint): silence prefer-const on intentional forward reference` | New. `middleware/src/index.ts:398` — eslint doesn't trace the reassignment ~1300 lines later. Single-line disable with explanatory comment. |
| `docs(changelog): record byte5ai engineering-standards bootstrap` | From #32. Initial entry for the standards bootstrap that was missed in PR #31. |
| `docs(changelog): record CI resurrection fixes` | New. `### Fixed` block for the three CI bugs in this PR. |

## Background

- Actions were disabled on this repo since 2026-05-11. Re-enabled today as part of the engineering-standards rollout.
- The first post-reactivation run showed 3/5 required checks red. None of the causes are caused by the standards work — they're drift since the last successful run (migration refactor, Node major bump in `package.json`, a lint false-positive).
- Three individual fix PRs (#33, #34, plus the planned prefer-const PR) could not merge independently: with `strict: true` required checks, each had to wait on the others before being green.

## Test plan

- [ ] All 5 required status checks green on this PR:
  - `middleware (lint + typecheck + test)`
  - `web-ui (lint + typecheck + vitest)`
  - `schema (migrations on pgvector)`
  - `audit (high+critical block) (middleware)`
  - `audit (high+critical block) (web-ui)`
- [ ] Schema smoke now applies 20 migrations (up from 9); idempotency re-apply stays green

## Cleanup after merge

- Close PRs #32, #33, #34 with a pointer back here (already done)
- Remove the three local worktrees + branches under `.claude/worktrees/` (already done)