### PR TITLE
feat(builder): multi-partial slots for large skill markdowns

### DIFF
--- a/middleware/assets/boilerplate/agent-integration/template.yaml
+++ b/middleware/assets/boilerplate/agent-integration/template.yaml
@@ -40,6 +40,11 @@ slots:
     target_file: skills/{{AGENT_SLUG}}-expert.md
     required: true
     description: System prompt body (frontmatter is generated automatically)
+    # Allow splitting large skill markdowns across up to 4 additional
+    # partials (skill-prompt-1 … skill-prompt-4). Each fill_slot call stays
+    # under the Anthropic tool-call argument-size limit (~30 KB); the
+    # runtime concatenates all partials with `\n\n---\n\n` separators.
+    max_partials: 4
   - key: admin-ui-body
     target_file: assets/admin-ui/index.html
     required: false

--- a/middleware/src/plugins/builder/boilerplateSource.ts
+++ b/middleware/src/plugins/builder/boilerplateSource.ts
@@ -32,6 +32,13 @@ const SlotDefSchema = z
     target_file: z.string().min(1),
     required: z.boolean().default(false),
     description: z.string().optional(),
+    // Additional partial slots permitted under `<key>-1`, …, `<key>-N`.
+    // Codegen synthesises one output file per non-empty partial (target_file
+    // with the index inserted before the last extension) and lists all
+    // partials in manifest.skills[]. Lets large markdowns be split across
+    // multiple fill_slot calls (each call stays under the Anthropic tool-
+    // call argument-size limit). Default 0 = classic single-slot behaviour.
+    max_partials: z.number().int().min(0).max(20).default(0),
   })
   .strict();
 

--- a/middleware/src/plugins/builder/codegen.ts
+++ b/middleware/src/plugins/builder/codegen.ts
@@ -85,6 +85,37 @@ function deriveAgentSlug(spec: AgentSpec): string {
   return spec.id.split(/[./]/).pop() ?? spec.id;
 }
 
+// Insert a numeric suffix before the last extension of a target file path.
+//   skills/foo-expert.md, 1 → skills/foo-expert-1.md
+//   skills/foo-expert,    2 → skills/foo-expert-2  (no extension)
+//   skills/{{SLUG}}-expert.md, 1 → skills/{{SLUG}}-expert-1.md
+// Used by the partial-slot pipeline to derive output paths for synthesised
+// partial files from a base slot's target_file.
+export function partialTargetFile(baseTarget: string, n: number): string {
+  const lastSlash = baseTarget.lastIndexOf('/');
+  const dir = lastSlash >= 0 ? baseTarget.slice(0, lastSlash + 1) : '';
+  const filename = lastSlash >= 0 ? baseTarget.slice(lastSlash + 1) : baseTarget;
+  const lastDot = filename.lastIndexOf('.');
+  if (lastDot < 0) return `${dir}${filename}-${String(n)}`;
+  return `${dir}${filename.slice(0, lastDot)}-${String(n)}${filename.slice(lastDot)}`;
+}
+
+// Collect the indices of non-empty partial slots for a given base slot.
+// Returns numerically-ascending indices in [1, slot.max_partials] whose
+// `<slot.key>-<n>` entry is non-empty in allSlots.
+function filledPartialIndices(
+  slot: SlotDef,
+  allSlots: Readonly<Record<string, string>>,
+): number[] {
+  if (slot.max_partials <= 0) return [];
+  const out: number[] = [];
+  for (let n = 1; n <= slot.max_partials; n++) {
+    const v = allSlots[`${slot.key}-${String(n)}`];
+    if (v !== undefined && v.length > 0) out.push(n);
+  }
+  return out;
+}
+
 function resolveSource(spec: AgentSpec, source: string): string | undefined {
   if (source.startsWith('__derived__/')) {
     const key = source.slice('__derived__/'.length);
@@ -288,8 +319,50 @@ function injectSlots(
 function reproduceManifestCapabilities(
   manifestText: string,
   spec: AgentSpec,
+  manifestSlots: readonly SlotDef[],
+  allSlots: Readonly<Record<string, string>>,
 ): string {
   const doc = yaml.parseDocument(manifestText);
+
+  // Skills-array expansion (multi-partial slots). For each declared slot
+  // with `max_partials > 0`, clone the matching skill entry (matched by
+  // its `path` against `slot.target_file`) once per non-empty partial.
+  // Clones land immediately after the base entry, in ascending numeric
+  // order. Done before string substitution so the cloned paths still
+  // carry `{{AGENT_SLUG}}` etc. — the later placeholder pass resolves them.
+  const skillsNode = doc.get('skills', true);
+  if (yaml.isSeq(skillsNode) && skillsNode.items.length > 0) {
+    for (const slot of manifestSlots) {
+      const indices = filledPartialIndices(slot, allSlots);
+      if (indices.length === 0) continue;
+      const baseIdx = skillsNode.items.findIndex((item) => {
+        if (!yaml.isMap(item)) return false;
+        const pathNode = item.get('path');
+        return typeof pathNode === 'string' && pathNode === slot.target_file;
+      });
+      if (baseIdx < 0) continue;
+      const baseJson = (skillsNode.items[baseIdx] as yaml.Node).toJSON() as Record<
+        string,
+        unknown
+      >;
+      const clones: unknown[] = [];
+      for (const n of indices) {
+        const cloneJson = JSON.parse(JSON.stringify(baseJson)) as Record<string, unknown>;
+        cloneJson['path'] = partialTargetFile(slot.target_file, n);
+        const idVal = cloneJson['id'];
+        if (typeof idVal === 'string') {
+          cloneJson['id'] = `${idVal}_${String(n)}`;
+        }
+        clones.push(cloneJson);
+      }
+      const cloneNodes = clones.map((c) => doc.createNode(c));
+      skillsNode.items.splice(
+        baseIdx + 1,
+        0,
+        ...(cloneNodes as typeof skillsNode.items),
+      );
+    }
+  }
 
   // depends_on overwrite (B.6-9.1) — the boilerplate ships
   // `depends_on: []` as a static placeholder; we replace it with
@@ -694,7 +767,7 @@ export async function generate(
 
     // 5a. manifest.yaml — capability reproduction before string mangling
     if (origPath === 'manifest.yaml') {
-      text = reproduceManifestCapabilities(text, spec);
+      text = reproduceManifestCapabilities(text, spec, manifest.slots, allSlots);
     }
 
     // 5a.2. package.json — peerDependencies merge for Theme A. Done before
@@ -727,6 +800,54 @@ export async function generate(
     }
 
     out.set(outPath, Buffer.from(text, 'utf-8'));
+  }
+
+  // 6. Partial-slot file synthesis. For every declared slot with
+  //    `max_partials > 0`, materialise one output file per filled partial
+  //    (`<slot.key>-1`, …, `<slot.key>-N`). The output path is derived from
+  //    the base slot's target_file via `partialTargetFile()`. The file's
+  //    frontmatter is cloned from the base bundle file (so `kind`,
+  //    `description`, etc. stay aligned) with the `id` suffixed by `_<n>`.
+  //    The slot body is wrapped in matching marker comments so a future
+  //    re-edit cycle can re-locate the slot region.
+  for (const slot of manifest.slots) {
+    const indices = filledPartialIndices(slot, allSlots);
+    if (indices.length === 0) continue;
+    const baseBuf = bundle.files.get(slot.target_file);
+    let baseFrontmatter = '';
+    if (baseBuf) {
+      const baseText = baseBuf.toString('utf-8');
+      const fmMatch = /^---\n([\s\S]*?)\n---/.exec(baseText);
+      if (fmMatch) baseFrontmatter = fmMatch[1] ?? '';
+    }
+    for (const n of indices) {
+      const partialKey = `${slot.key}-${String(n)}`;
+      const body = allSlots[partialKey] ?? '';
+      const fmLines = (baseFrontmatter || 'kind: prompt_partial')
+        .split('\n')
+        .map((line) => {
+          const m = /^id:\s*(.+)$/.exec(line);
+          if (m) return `id: ${m[1]}_${String(n)}`;
+          return line;
+        });
+      const trimmedBody = body.endsWith('\n') ? body.slice(0, -1) : body;
+      const partialPath = partialTargetFile(slot.target_file, n);
+      const outPath = substitutePlaceholders(partialPath, placeholderMap);
+      let text =
+        `---\n${fmLines.join('\n')}\n---\n\n` +
+        `<!-- #region builder:${partialKey} -->\n` +
+        `${trimmedBody}\n` +
+        `<!-- #endregion -->\n`;
+      text = substitutePlaceholders(text, placeholderMap);
+      const residue = collectResidue(text);
+      if (residue.length > 0) {
+        issues.push({
+          code: 'placeholder_residue',
+          detail: `Unresolved placeholders in partial '${outPath}': ${residue.join(', ')}`,
+        });
+      }
+      out.set(outPath, Buffer.from(text, 'utf-8'));
+    }
   }
 
   if (issues.length > 0) throw new CodegenError(issues);

--- a/middleware/src/plugins/builder/prompts/builder-system.md
+++ b/middleware/src/plugins/builder/prompts/builder-system.md
@@ -129,6 +129,25 @@ Pflicht (per `patch_spec`):
   Module-Top-Level-Imports (die kommen aus dem Boilerplate-Template).
   Wenn du ein `import { z } from 'zod'` schreibst und tsc meldet
   `Duplicate identifier 'z'`, hast du den Slot-Bereich überschritten.
+- **Partial-Slots für große Markdowns.** Manche Slots erlauben das
+  Aufsplitten auf bis zu N+1 `fill_slot`-Calls — der Boilerplate-Slot
+  deklariert dann `max_partials: N`. Aktuell betroffen: `skill-prompt`
+  (max_partials 4) im `agent-integration`-Template. Wenn der Skill-
+  Markdown >~25 KB wird, splitte ihn an Section-/Heading-Boundaries
+  (nicht mid-paragraph):
+
+    1. `fill_slot({ slotKey: "skill-prompt",   source: "<chunk-1>" })`
+    2. `fill_slot({ slotKey: "skill-prompt-1", source: "<chunk-2>" })`
+    3. `fill_slot({ slotKey: "skill-prompt-2", source: "<chunk-3>" })`
+    4. … bis zu `skill-prompt-4`.
+
+  Codegen synthesiert pro gefülltem Partial eine eigene Datei
+  (`skills/<slug>-expert-1.md`, …) und listet sie in `manifest.skills[]`.
+  Der Runtime concatenated die Partials beim Load mit `\n\n---\n\n`-
+  Trenner — Reihenfolge ist `<key>` zuerst, dann numerisch aufsteigend.
+  Halte jeden einzelnen `fill_slot`-Call unter ~25 KB (Anthropic-Tool-
+  Call-Argument-Limit), sonst kommt `source` als `undefined` auf der
+  Bridge an und der Slot bleibt leer.
 
 ## Cross-Integration-Pflicht-Workflow
 

--- a/middleware/src/plugins/builder/tools/fillSlot.ts
+++ b/middleware/src/plugins/builder/tools/fillSlot.ts
@@ -1,9 +1,49 @@
 import { z } from 'zod';
 
+import { loadBoilerplate } from '../boilerplateSource.js';
 import type { BuildError } from '../buildErrorParser.js';
 import type { SlotTypecheckReason } from '../slotTypecheckPipeline.js';
 import { annotateAll } from '../tscErrorHints.js';
 import type { BuilderTool } from './types.js';
+
+/**
+ * Validate a slot key against the template's slot declarations when it
+ * looks like a partial of a declared slot (`<base>-<n>`). Direct hits on
+ * declared slot keys, and keys that don't match the partial shape, pass
+ * through unchanged — preserving today's lenient behaviour for ad-hoc
+ * slot keys. Only out-of-range partial indices are rejected, since the
+ * partial-slot contract (`max_partials`) is what codegen relies on to
+ * know which files to synthesise.
+ */
+async function validatePartialKeyShape(
+  slotKey: string,
+  templateId: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  let bundle;
+  try {
+    bundle = await loadBoilerplate(templateId);
+  } catch {
+    return { ok: true };
+  }
+  if (bundle.manifest.slots.some((s) => s.key === slotKey)) return { ok: true };
+  const m = /^(.+)-(\d+)$/.exec(slotKey);
+  if (!m) return { ok: true };
+  const base = m[1] ?? '';
+  const n = Number(m[2]);
+  const baseSlot = bundle.manifest.slots.find((s) => s.key === base);
+  if (!baseSlot) return { ok: true };
+  if (n < 1 || baseSlot.max_partials < n) {
+    return {
+      ok: false,
+      error:
+        `Slot '${slotKey}' looks like a partial of '${base}' but template ` +
+        `'${templateId}' declares max_partials=${String(baseSlot.max_partials)} ` +
+        `for that slot. Use indices in [1, ${String(baseSlot.max_partials)}], ` +
+        `or fill the base slot '${base}' instead.`,
+    };
+  }
+  return { ok: true };
+}
 
 const InputSchema = z
   .object({
@@ -69,6 +109,13 @@ export const fillSlotTool: BuilderTool<Input, Result> = {
     const draft = await ctx.draftStore.load(ctx.userEmail, ctx.draftId);
     if (!draft) {
       return { ok: false, error: `draft ${ctx.draftId} not found for user` };
+    }
+
+    if (draft.spec.template) {
+      const partialCheck = await validatePartialKeyShape(slotKey, draft.spec.template);
+      if (!partialCheck.ok) {
+        return { ok: false, error: partialCheck.error };
+      }
     }
 
     const nextSlots: Record<string, string> = { ...draft.slots, [slotKey]: source };

--- a/middleware/test/builder/codegen.test.ts
+++ b/middleware/test/builder/codegen.test.ts
@@ -611,4 +611,84 @@ describe('codegen.generate', () => {
     assert.match(pluginText, /__mapped\["count"\] = __src\?\.\["length"\];/);
     assert.match(pluginText, /return __mapped;/);
   });
+
+  describe('partial slots (large skill markdowns)', () => {
+    it('synthesises one output file per filled partial of skill-prompt', async () => {
+      const { spec, slots } = loadFixture();
+      const augmented: Record<string, string> = {
+        ...slots,
+        'skill-prompt-1': '## Chunk 2\n\nSecond section body.',
+        'skill-prompt-2': '## Chunk 3\n\nThird section body.',
+      };
+      const out = await generate({ spec, slots: augmented });
+
+      assert.ok(out.has('skills/weather-expert.md'), 'base skill file');
+      assert.ok(out.has('skills/weather-expert-1.md'), 'partial 1 file');
+      assert.ok(out.has('skills/weather-expert-2.md'), 'partial 2 file');
+      assert.equal(
+        out.has('skills/weather-expert-3.md'),
+        false,
+        'unfilled partial must not produce a file',
+      );
+
+      const p1 = out.get('skills/weather-expert-1.md')!.toString('utf-8');
+      assert.match(p1, /^---\n/, 'partial has frontmatter');
+      assert.match(p1, /id:\s*weather_expert_system_1/);
+      assert.match(p1, /kind:\s*prompt_partial/);
+      assert.match(p1, /<!-- #region builder:skill-prompt-1 -->/);
+      assert.match(p1, /## Chunk 2/);
+
+      const p2 = out.get('skills/weather-expert-2.md')!.toString('utf-8');
+      assert.match(p2, /id:\s*weather_expert_system_2/);
+      assert.match(p2, /## Chunk 3/);
+      // No residual placeholders allowed in synthesised files.
+      assert.equal(p1.includes('{{'), false);
+      assert.equal(p2.includes('{{'), false);
+    });
+
+    it('lists partials in manifest.skills[] in ascending order', async () => {
+      const { spec, slots } = loadFixture();
+      const augmented: Record<string, string> = {
+        ...slots,
+        'skill-prompt-1': '## Chunk 2',
+        'skill-prompt-2': '## Chunk 3',
+      };
+      const out = await generate({ spec, slots: augmented });
+      const manifest = yaml.parse(
+        out.get('manifest.yaml')!.toString('utf-8'),
+      ) as { skills: Array<{ id: string; path: string; kind: string }> };
+
+      const ids = manifest.skills.map((s) => s.id);
+      const paths = manifest.skills.map((s) => s.path);
+      assert.deepEqual(ids, [
+        'weather_expert_system',
+        'weather_expert_system_1',
+        'weather_expert_system_2',
+      ]);
+      assert.deepEqual(paths, [
+        'skills/weather-expert.md',
+        'skills/weather-expert-1.md',
+        'skills/weather-expert-2.md',
+      ]);
+      for (const s of manifest.skills) {
+        assert.equal(s.kind, 'prompt_partial');
+      }
+    });
+
+    it('leaves manifest and file layout unchanged when no partials are filled', async () => {
+      const { spec, slots } = loadFixture();
+      const out = await generate({ spec, slots });
+
+      assert.ok(out.has('skills/weather-expert.md'));
+      assert.equal(out.has('skills/weather-expert-1.md'), false);
+      assert.equal(out.has('skills/weather-expert-2.md'), false);
+
+      const manifest = yaml.parse(
+        out.get('manifest.yaml')!.toString('utf-8'),
+      ) as { skills: Array<{ id: string; path: string }> };
+      assert.equal(manifest.skills.length, 1);
+      assert.equal(manifest.skills[0]!.id, 'weather_expert_system');
+      assert.equal(manifest.skills[0]!.path, 'skills/weather-expert.md');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes the BuilderAgent's inability to ingest skill markdowns larger than the Anthropic tool-call argument-size limit (~30 KB), which previously caused `fill_slot`'s `source` parameter to arrive as `undefined` on the bridge — silently dropping the slot. Observed at ~99 KB for `byte5ai/claude-agent-readiness-skill` flattened.

## Design

- New optional `max_partials: N` field on `SlotDef`. When set, the builder may fill `<key>-1`, …, `<key>-N` alongside the base `<key>`.
- Codegen synthesises one output file per filled partial (`skills/<slug>-expert-1.md`, …), and expands `manifest.skills[]` by cloning the matching skill entry in ascending numeric order. The Runtime concat-loop in `dynamicAgentRuntime.ts:460-500` already handles multiple `prompt_partial`s — no runtime change needed.
- `agent-integration` template enables it for `skill-prompt` with `max_partials: 4` (covers 5×25 KB ≈ 125 KB).
- `fill_slot` rejects partial keys whose index exceeds the declared `max_partials`. Declared base keys and ad-hoc keys keep today's lenient pass-through.
- Builder system prompt documents the workflow so the LLM splits at section boundaries.

Variants considered: `fill_slot_append` (rejected — breaks idempotency and miscounts the cross-slot Stop-Budget), out-of-band REST upload (rejected for this PR — doesn't satisfy the in-band "agent stays on the platform" requirement; could land as a follow-up for bulk-edit UX).

## Files

- `middleware/src/plugins/builder/boilerplateSource.ts` — `SlotDef.max_partials`
- `middleware/assets/boilerplate/agent-integration/template.yaml` — declare `max_partials: 4` on `skill-prompt`
- `middleware/src/plugins/builder/codegen.ts` — `partialTargetFile()`, `filledPartialIndices()`, partial-file synthesis, manifest skills-array expansion
- `middleware/src/plugins/builder/tools/fillSlot.ts` — `validatePartialKeyShape()` against the template
- `middleware/src/plugins/builder/prompts/builder-system.md` — split-large-skills workflow doc
- `middleware/test/builder/codegen.test.ts` — synthesis + manifest ordering + single-slot regression

## Test plan

- [x] `node --import tsx --test test/builder/codegen.test.ts` — 26/26 pass (3 new partial-slot tests)
- [x] `node --import tsx --test test/builder/boilerplateSource.test.ts` — pass (schema change tolerated)
- [x] `node --import tsx --test test/builder/builderChatRoutes.test.ts` — 14/14 pass (fillSlot wiring intact)
- [x] `tsc --noEmit` clean on all six touched files (other errors in the repo are pre-existing unbuilt workspaces)
- [ ] End-to-end: Builder session ingests `byte5ai/claude-agent-readiness-skill` flattened (~99 KB) split across 4 partials → `build_status: ok`, runtime concatenates correctly. (Requires a local middleware spin-up — out of scope for this PR.)