### PR TITLE
fix(ci): install sharp's optional linux-x64 binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           cache-dependency-path: middleware/package-lock.json
 
       - name: npm ci (middleware + workspaces)
-        run: npm ci --no-audit --no-fund
+        run: npm ci --include=optional --no-audit --no-fund
 
       - name: Build workspace packages (compiled dist/ for cross-package imports)
         run: npm run build
@@ -80,7 +80,7 @@ jobs:
           cache-dependency-path: web-ui/package-lock.json
 
       - name: npm ci
-        run: npm ci --no-audit --no-fund
+        run: npm ci --include=optional --no-audit --no-fund
 
       - name: Lint
         run: npm run lint
@@ -187,7 +187,7 @@ jobs:
           cache-dependency-path: ${{ matrix.workspace }}/package-lock.json
 
       - name: npm ci
-        run: npm ci --no-audit --no-fund
+        run: npm ci --include=optional --no-audit --no-fund
 
       - name: npm audit (--audit-level=high)
         run: npm audit --audit-level=high


### PR DESCRIPTION
## Problem

`npm ci --no-audit --no-fund` skips platform-specific optional dependencies. On the Linux-x64 GitHub Actions runner this means sharp's prebuilt binary is never installed, causing 41 diagram test files to bail at startup:

```
Error: Could not load the "sharp" module using the linux-x64 runtime
- Ensure optional dependencies can be installed:
    npm install --include=optional sharp
```

This is cluster 1 of the CI failure investigation tracked in #37 (243 total failures on PR #35, 41 of which are attributable to the missing sharp binary).

## Fix

Add `--include=optional` to all three `npm ci` calls in `.github/workflows/ci.yml` (middleware, web-ui, and audit jobs) so the prebuilt linux-x64 binary lands on disk during CI.

## Expected outcome

This PR should drive the 41 diagram-test failures to zero. The remaining ~200 failures in `middleware (lint + typecheck + test)` are tracked separately in #37 and will be addressed in follow-up cluster fixes.

Only `.github/workflows/ci.yml` is touched — 3 lines changed.

Closes part of #37.