### PR TITLE
fix(builder): resolve assets and test refs after public-release rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: middleware/package-lock.json
 
@@ -75,7 +75,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web-ui/package-lock.json
 
@@ -181,7 +181,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: ${{ matrix.workspace }}/package-lock.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 # PR + main-branch quality gate.
 #
 # Runs lint + typecheck + test on both workspaces, plus a schema smoke
-# that applies all 9 migrations against a real pgvector container. Audit
-# enforces a high-severity ceiling so a CVE-bumping dep can't slip in
-# unnoticed.
+# that applies every migration in the repo against a real pgvector
+# container. Audit enforces a high-severity ceiling so a CVE-bumping
+# dep can't slip in unnoticed.
 #
 # Naming-independent — no secrets, no GHCR/npm push. Release-flow lives
 # in release.yml (currently placeholder; activates once OB-30 Block 2
@@ -92,8 +92,11 @@ jobs:
         run: npm run test
 
   # ------------------------------------------------------------------
-  # Schema smoke: apply all 9 migrations against pgvector. Catches
-  # SQL-only regressions before they hit prod-or-OSS-demo deploys.
+  # Schema smoke: apply every migration in the repo against pgvector.
+  # Catches SQL-only regressions before they hit prod-or-OSS-demo
+  # deploys. Domains are listed explicitly in dependency order; files
+  # inside a domain are applied in lexical (numbered) order, so newly
+  # added migrations are picked up automatically.
   # ------------------------------------------------------------------
   schema:
     name: schema (migrations on pgvector)
@@ -112,6 +115,17 @@ jobs:
           --health-interval 5s
           --health-timeout 3s
           --health-retries 20
+    env:
+      # Schema domains in apply order. Within each domain, files apply
+      # in lexical (file-name) order — which matches the numbered
+      # migration convention. Newline-separated so the shell loop can
+      # iterate cleanly.
+      MIGRATION_DOMAINS: |
+        middleware/packages/harness-knowledge-graph-neon/src/migrations
+        middleware/src/auth/migrations
+        middleware/src/plugins/routines/migrations
+        middleware/src/profileSnapshots/migrations
+        middleware/src/profileStorage/migrations
     steps:
       - uses: actions/checkout@v4
 
@@ -120,45 +134,30 @@ jobs:
           PGPASSWORD=omadia-ci psql -h localhost -U omadia -d omadia \
             -c "CREATE EXTENSION IF NOT EXISTS vector;"
 
-      - name: Apply 9 migrations in order
+      - name: Apply all migrations
         run: |
           set -euo pipefail
-          declare -a MIGRATIONS=(
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0001_graph_init.sql"
-            "middleware/src/services/graph/migrations/0002_user_scoping.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0003_agentic_graph.sql"
-            "middleware/src/services/graph/migrations/0004_turn_fts.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0005_turn_embeddings_768.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0006_embedding_backfill_state.sql"
-            "middleware/src/services/graph/migrations/0007_verifier_tables.sql"
-            "middleware/src/services/graph/migrations/0008_teams_attachments.sql"
-            "middleware/src/plugins/routines/migrations/0001_routines.sql"
-          )
-          for m in "${MIGRATIONS[@]}"; do
-            echo "--- applying $(basename "$m")"
-            PGPASSWORD=omadia-ci psql -h localhost -U omadia -d omadia \
-              -v ON_ERROR_STOP=1 -f "$m"
-          done
+          while IFS= read -r dir; do
+            [ -z "$dir" ] && continue
+            echo "==> domain: $dir"
+            for f in "$dir"/*.sql; do
+              echo "  applying $(basename "$f")"
+              PGPASSWORD=omadia-ci psql -h localhost -U omadia -d omadia \
+                -v ON_ERROR_STOP=1 -f "$f"
+            done
+          done <<< "$MIGRATION_DOMAINS"
 
       - name: Re-apply migrations (idempotency check)
         run: |
           set -euo pipefail
-          declare -a MIGRATIONS=(
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0001_graph_init.sql"
-            "middleware/src/services/graph/migrations/0002_user_scoping.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0003_agentic_graph.sql"
-            "middleware/src/services/graph/migrations/0004_turn_fts.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0005_turn_embeddings_768.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0006_embedding_backfill_state.sql"
-            "middleware/src/services/graph/migrations/0007_verifier_tables.sql"
-            "middleware/src/services/graph/migrations/0008_teams_attachments.sql"
-            "middleware/src/plugins/routines/migrations/0001_routines.sql"
-          )
-          for m in "${MIGRATIONS[@]}"; do
-            PGPASSWORD=omadia-ci psql -h localhost -U omadia -d omadia \
-              -v ON_ERROR_STOP=1 -f "$m" > /dev/null
-            echo "✓ idempotent: $(basename "$m")"
-          done
+          while IFS= read -r dir; do
+            [ -z "$dir" ] && continue
+            for f in "$dir"/*.sql; do
+              PGPASSWORD=omadia-ci psql -h localhost -U omadia -d omadia \
+                -v ON_ERROR_STOP=1 -f "$f" > /dev/null
+              echo "✓ idempotent: $(basename "$f")"
+            done
+          done <<< "$MIGRATION_DOMAINS"
 
   # ------------------------------------------------------------------
   # Dependency audit. Enforces a "no high or critical" floor — moderate

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- 2026-05-17 — byte5ai engineering-standards bootstrap (PR #31). Repo is now
+  on `status: applied` against `byte5ai/engineering-standards`:
+  - `.github/engineering-standards.yml` as the explicit marker.
+  - `.hooks/pre-push` blocks direct pushes to `main`/`master` locally.
+  - `script/setup` enables the hook and runs the npm bootstrap in one step.
+  - AGENTS.md gained a "Git Workflow & Engineering Standards" section.
+  - CONTRIBUTING.md documents the pre-push guard and forbids
+    `Co-Authored-By:` trailers for AI agents.
+  - Branch protection on `main` is enforced server-side: PR required,
+    force-push and deletion blocked, all four CI workflows (five contexts
+    including the `audit` matrix) wired up as required status checks.
+
+  GitHub Actions were disabled on the repo since 2026-05-11 and were
+  reactivated as part of this rollout. The follow-up CHANGELOG PR doubles
+  as the first end-to-end CI verification after reactivation.
+
 ### Changed
 
 - `docs/CHANGELOG.md` reformatted to follow the Keep-a-Changelog convention.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,8 +24,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     including the `audit` matrix) wired up as required status checks.
 
   GitHub Actions were disabled on the repo since 2026-05-11 and were
-  reactivated as part of this rollout. The follow-up CHANGELOG PR doubles
-  as the first end-to-end CI verification after reactivation.
+  reactivated as part of this rollout. The first post-reactivation CI run
+  surfaced three pre-existing pipeline bugs that had been masked while
+  Actions were off — they're fixed in the same wave, see *Fixed* below.
+
+### Fixed
+
+- 2026-05-17 — Three pre-existing bugs in the CI pipeline, surfaced once
+  Actions were reactivated:
+  - `.github/workflows/ci.yml` pinned `setup-node@v4` to `node-version: '20'`
+    in three places, but `middleware/package.json` declares
+    `engines.node ">=22 <23"`. `npm ci` failed with `EBADENGINE` in the
+    `middleware` and `audit (middleware)` jobs. Bumped to `'22'`.
+  - The `schema (migrations on pgvector)` job applied a hardcoded list of
+    nine migrations, four of which had moved or been renumbered as the
+    knowledge-graph schema grew (`harness-knowledge-graph-neon` now ships
+    13 migrations, two more domains were added — `auth/`,
+    `profileSnapshots/`, `profileStorage/`). Replaced the array with a
+    glob over five migration domains, applied in lexical order. Coverage
+    grew from 9 to 20 migrations.
+  - `middleware/src/index.ts:398` triggered `prefer-const` because
+    eslint's reassignment analysis doesn't trace the forward-reference
+    assignment ~1300 lines later in `main()`. Documented the intent and
+    suppressed the rule on that one line.
 
 ### Changed
 

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -394,7 +394,10 @@ async function main(): Promise<void> {
   // Forward reference for the channel registry — constructed later in boot
   // (after the channel-SDK adapters are wired up). The install hooks below
   // close over this variable so post-install activations dispatched to a
-  // channel-kind plugin reach the right runtime once it exists.
+  // channel-kind plugin reach the right runtime once it exists. The
+  // assignment happens further down in main() once the channel runtime
+  // is wired; eslint's prefer-const doesn't trace through that depth.
+  // eslint-disable-next-line prefer-const
   let channelRegistryRef: ChannelRegistry | undefined;
 
   const installService = new InstallService({

--- a/middleware/src/platform/assets.ts
+++ b/middleware/src/platform/assets.ts
@@ -25,7 +25,6 @@ import { fileURLToPath } from 'node:url';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const MIDDLEWARE_ROOT = path.resolve(HERE, '..', '..'); // <repo>/middleware
-const REPO_ROOT = path.resolve(MIDDLEWARE_ROOT, '..'); // <repo>
 
 export interface AssetBundle {
   /** Logical id, e.g. 'boilerplate'. Surfaced in error messages. */
@@ -97,26 +96,25 @@ export function resolveAssetBundle(opts: ResolveOpts): AssetBundle {
  * boilerplateSource.ts).
  */
 export const ASSETS = {
-  /** docs/harness-platform/boilerplate/ — codegen template tree. */
+  /** middleware/assets/boilerplate/ — codegen template tree. */
   boilerplate: resolveAssetBundle({
     id: 'boilerplate',
     envVar: 'BUILDER_BOILERPLATE_DIR',
-    devFallback: path.join(REPO_ROOT, 'docs', 'harness-platform', 'boilerplate'),
-    prodHint: 'COPY docs/harness-platform/boilerplate ./boilerplate (Dockerfile)',
+    devFallback: path.join(MIDDLEWARE_ROOT, 'assets', 'boilerplate'),
+    prodHint: 'COPY middleware/assets/boilerplate ./boilerplate (Dockerfile)',
     kind: 'directory',
   }),
-  /** docs/harness-platform/entity-registry.v1.yaml — vocabulary autocomplete. */
+  /** middleware/assets/entity-registry.v1.yaml — vocabulary autocomplete. */
   entityRegistry: resolveAssetBundle({
     id: 'entityRegistry',
     envVar: 'BUILDER_ENTITY_REGISTRY_PATH',
     devFallback: path.join(
-      REPO_ROOT,
-      'docs',
-      'harness-platform',
+      MIDDLEWARE_ROOT,
+      'assets',
       'entity-registry.v1.yaml',
     ),
     prodHint:
-      'COPY docs/harness-platform/entity-registry.v1.yaml ./entity-registry.v1.yaml (Dockerfile)',
+      'COPY middleware/assets/entity-registry.v1.yaml ./entity-registry.v1.yaml (Dockerfile)',
     kind: 'file',
   }),
   /** middleware/packages/agent-reference-maximum — Builder pattern source. */
@@ -163,21 +161,20 @@ export function _rebuildAssetsForTests(): void {
     boilerplate: resolveAssetBundle({
       id: 'boilerplate',
       envVar: 'BUILDER_BOILERPLATE_DIR',
-      devFallback: path.join(REPO_ROOT, 'docs', 'harness-platform', 'boilerplate'),
-      prodHint: 'COPY docs/harness-platform/boilerplate ./boilerplate (Dockerfile)',
+      devFallback: path.join(MIDDLEWARE_ROOT, 'assets', 'boilerplate'),
+      prodHint: 'COPY middleware/assets/boilerplate ./boilerplate (Dockerfile)',
       kind: 'directory',
     }),
     entityRegistry: resolveAssetBundle({
       id: 'entityRegistry',
       envVar: 'BUILDER_ENTITY_REGISTRY_PATH',
       devFallback: path.join(
-        REPO_ROOT,
-        'docs',
-        'harness-platform',
+        MIDDLEWARE_ROOT,
+        'assets',
         'entity-registry.v1.yaml',
       ),
       prodHint:
-        'COPY docs/harness-platform/entity-registry.v1.yaml ./entity-registry.v1.yaml (Dockerfile)',
+        'COPY middleware/assets/entity-registry.v1.yaml ./entity-registry.v1.yaml (Dockerfile)',
       kind: 'file',
     }),
     referencePackage: resolveAssetBundle({

--- a/middleware/test/builder/buildTemplate.test.ts
+++ b/middleware/test/builder/buildTemplate.test.ts
@@ -63,7 +63,7 @@ describe('buildTemplate', () => {
       assert.equal(result.reused, false);
       assert.ok(existsSync(path.join(templateRoot, 'package.json')));
       assert.ok(existsSync(path.join(templateRoot, '.harness-build-template.hash')));
-      const linkPath = path.join(templateRoot, 'node_modules', '@byte5', 'harness-plugin-api');
+      const linkPath = path.join(templateRoot, 'node_modules', '@omadia', 'plugin-api');
       assert.ok(lstatSync(linkPath).isSymbolicLink());
     });
 
@@ -168,15 +168,14 @@ describe('buildTemplate', () => {
       const linkPath = path.join(
         templateRoot,
         'node_modules',
-        '@byte5',
-        'harness-plugin-api',
+        '@omadia',
+        'plugin-api',
       );
       const pkgJson = JSON.parse(
         readFileSync(path.join(linkPath, 'package.json'), 'utf-8'),
       ) as { name: string };
-      assert.equal(pkgJson.name, '@omadia/plugin-api');
       // Same name, but resolves through wsNew (not wsOld).
-      assert.match(pkgJson.name, /@byte5\/harness-plugin-api/);
+      assert.equal(pkgJson.name, '@omadia/plugin-api');
     });
 
     it('reports ready=false with reason when no node_modules exists', async () => {


### PR DESCRIPTION
## Summary

Fixes the builder-pipeline cluster from #37 (~100 failures) by repairing the **single release-time root cause** that was misclassified as multi-cluster drift in the original triage.

### Finding

The cluster framing in #37 assumed test-vs-code drift since the 2026-05-11 baseline (`65a70d5`). Empirically wrong: only one commit on `middleware/src/plugins/builder` or `middleware/test/builder` has landed since baseline (`f48cae4`, pure comment translation, net 1:1 line swap). PR #31 touched zero middleware files. The failures predate the public release; CI being disabled until 2026-05-17 hid them.

Reading the actual error output (run 25988273696) instead of the test names reveals two release-time bugs introduced by the byte5→omadia rebrand:

**A — Asset devFallback paths point at a tree excluded from the public release**
`middleware/src/platform/assets.ts` resolved the `boilerplate` and `entityRegistry` bundles via `<repo>/docs/harness-platform/...`. That tree is internal-only. The actual shipped assets are at `middleware/assets/boilerplate/` and `middleware/assets/entity-registry.v1.yaml`. CI sets neither `BUILDER_BOILERPLATE_DIR` nor `BUILDER_ENTITY_REGISTRY_PATH`, so the broken fallback was hit unconditionally and cascaded into every test touching `loadBoilerplate`, `discoverTemplates`, `loadBuildTemplateConfig`, `ensureBuildTemplate`, `BuildPipeline`, codegen, preview routes, the BuilderAgent system-prompt seed, and `SlotTypecheckPipeline`.

**B — One test still asserts the pre-rename package name**
`middleware/test/builder/buildTemplate.test.ts` expected a workspace symlink at `node_modules/@byte5/harness-plugin-api`. The workspace package is `@omadia/plugin-api`; `workspaceDeps` is keyed accordingly. All other call sites already handle both prefixes; this single test missed the rename.

### Changes

- `middleware/src/platform/assets.ts` — both `devFallback` paths and `prodHint` strings (plus their mirrors inside `_rebuildAssetsForTests`) switched from `docs/harness-platform/…` to `middleware/assets/…`. `REPO_ROOT` becomes unused and is removed.
- `middleware/test/builder/buildTemplate.test.ts` — symlink-path constants and the now-dead `assert.match(pkgJson.name, /@byte5\/harness-plugin-api/)` aligned to `@omadia/plugin-api`.

### Expected impact

Drives the bulk of the ~100 builder-pipeline failures from #37 to zero — every test whose stack ends in `loadBoilerplate` (i.e. the entire `boilerplateSource`, `discoverTemplates`, `ensureBuildTemplate`, `loadBuildTemplateConfig`, `BuildPipeline`, `BuilderAgent` system-prompt seed, builder preview routes ENOENT bucket) plus the three `buildTemplate.test.ts` rename failures.

Any residual builder failure that survives the fix is a real next-layer issue that only becomes visible once boilerplate loading actually works — to be triaged in a follow-up PR scoped narrowly.

### Out of scope

- `test/diagram*` — Session 1 / sharp linux-x64 (PR #38).
- `agent-reference` array-order assertions — separate cluster.
- `profileLoader` / profile-routes YAML `@`-char failures — separate cluster.
- `test/agents/resolveAgentForTool.test.ts` — imports `vitest` in a middleware test, separate cluster.
- Plugin registry, manifest, verifier — separate clusters.

### Base branch

Stacked on `fix/ci-resurrection` (PR #35), not `main`. `main` still carries Node-20 + stale migrations + the `prefer-const` lint bug; a CI run on a `main`-based branch would die in EBADENGINE before it could measure this fix. PR #38 (sharp) is stacked the same way. When PR #35 merges, GitHub will rebase this onto `main` automatically.

## Test plan

- [ ] CI green on the new run (or: builder-cluster failures drop from ~100 to a small residual).
- [ ] Verify zero ENOENT failures rooted in `BoilerplateSource: template '<id>' not found`.
- [ ] Verify `buildTemplate.test.ts` symlink + pkgJson assertions pass.

Refs #37, #35.