### PR TITLE
fix(verifier): align deterministicChecker and pipeline tests with current API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: middleware/package-lock.json
 
@@ -75,7 +75,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: web-ui/package-lock.json
 
@@ -181,7 +181,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: ${{ matrix.workspace }}/package-lock.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,12 @@
 name: CI
 
 on:
+  # Pull-request trigger accepts any base branch so that cluster-fix
+  # PRs stacked on the test-suite resurrection branch (#35 / #37)
+  # still run CI. Once #35 merges and the cluster work is done, this
+  # can return to `branches: [main]`.
   pull_request:
-    branches: [main]
+    branches: ['**']
   push:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 # PR + main-branch quality gate.
 #
 # Runs lint + typecheck + test on both workspaces, plus a schema smoke
-# that applies all 9 migrations against a real pgvector container. Audit
-# enforces a high-severity ceiling so a CVE-bumping dep can't slip in
-# unnoticed.
+# that applies every migration in the repo against a real pgvector
+# container. Audit enforces a high-severity ceiling so a CVE-bumping
+# dep can't slip in unnoticed.
 #
 # Naming-independent — no secrets, no GHCR/npm push. Release-flow lives
 # in release.yml (currently placeholder; activates once OB-30 Block 2
@@ -92,8 +92,11 @@ jobs:
         run: npm run test
 
   # ------------------------------------------------------------------
-  # Schema smoke: apply all 9 migrations against pgvector. Catches
-  # SQL-only regressions before they hit prod-or-OSS-demo deploys.
+  # Schema smoke: apply every migration in the repo against pgvector.
+  # Catches SQL-only regressions before they hit prod-or-OSS-demo
+  # deploys. Domains are listed explicitly in dependency order; files
+  # inside a domain are applied in lexical (numbered) order, so newly
+  # added migrations are picked up automatically.
   # ------------------------------------------------------------------
   schema:
     name: schema (migrations on pgvector)
@@ -112,6 +115,17 @@ jobs:
           --health-interval 5s
           --health-timeout 3s
           --health-retries 20
+    env:
+      # Schema domains in apply order. Within each domain, files apply
+      # in lexical (file-name) order — which matches the numbered
+      # migration convention. Newline-separated so the shell loop can
+      # iterate cleanly.
+      MIGRATION_DOMAINS: |
+        middleware/packages/harness-knowledge-graph-neon/src/migrations
+        middleware/src/auth/migrations
+        middleware/src/plugins/routines/migrations
+        middleware/src/profileSnapshots/migrations
+        middleware/src/profileStorage/migrations
     steps:
       - uses: actions/checkout@v4
 
@@ -120,45 +134,30 @@ jobs:
           PGPASSWORD=omadia-ci psql -h localhost -U omadia -d omadia \
             -c "CREATE EXTENSION IF NOT EXISTS vector;"
 
-      - name: Apply 9 migrations in order
+      - name: Apply all migrations
         run: |
           set -euo pipefail
-          declare -a MIGRATIONS=(
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0001_graph_init.sql"
-            "middleware/src/services/graph/migrations/0002_user_scoping.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0003_agentic_graph.sql"
-            "middleware/src/services/graph/migrations/0004_turn_fts.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0005_turn_embeddings_768.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0006_embedding_backfill_state.sql"
-            "middleware/src/services/graph/migrations/0007_verifier_tables.sql"
-            "middleware/src/services/graph/migrations/0008_teams_attachments.sql"
-            "middleware/src/plugins/routines/migrations/0001_routines.sql"
-          )
-          for m in "${MIGRATIONS[@]}"; do
-            echo "--- applying $(basename "$m")"
-            PGPASSWORD=omadia-ci psql -h localhost -U omadia -d omadia \
-              -v ON_ERROR_STOP=1 -f "$m"
-          done
+          while IFS= read -r dir; do
+            [ -z "$dir" ] && continue
+            echo "==> domain: $dir"
+            for f in "$dir"/*.sql; do
+              echo "  applying $(basename "$f")"
+              PGPASSWORD=omadia-ci psql -h localhost -U omadia -d omadia \
+                -v ON_ERROR_STOP=1 -f "$f"
+            done
+          done <<< "$MIGRATION_DOMAINS"
 
       - name: Re-apply migrations (idempotency check)
         run: |
           set -euo pipefail
-          declare -a MIGRATIONS=(
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0001_graph_init.sql"
-            "middleware/src/services/graph/migrations/0002_user_scoping.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0003_agentic_graph.sql"
-            "middleware/src/services/graph/migrations/0004_turn_fts.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0005_turn_embeddings_768.sql"
-            "middleware/packages/harness-knowledge-graph-neon/src/migrations/0006_embedding_backfill_state.sql"
-            "middleware/src/services/graph/migrations/0007_verifier_tables.sql"
-            "middleware/src/services/graph/migrations/0008_teams_attachments.sql"
-            "middleware/src/plugins/routines/migrations/0001_routines.sql"
-          )
-          for m in "${MIGRATIONS[@]}"; do
-            PGPASSWORD=omadia-ci psql -h localhost -U omadia -d omadia \
-              -v ON_ERROR_STOP=1 -f "$m" > /dev/null
-            echo "✓ idempotent: $(basename "$m")"
-          done
+          while IFS= read -r dir; do
+            [ -z "$dir" ] && continue
+            for f in "$dir"/*.sql; do
+              PGPASSWORD=omadia-ci psql -h localhost -U omadia -d omadia \
+                -v ON_ERROR_STOP=1 -f "$f" > /dev/null
+              echo "✓ idempotent: $(basename "$f")"
+            done
+          done <<< "$MIGRATION_DOMAINS"
 
   # ------------------------------------------------------------------
   # Dependency audit. Enforces a "no high or critical" floor — moderate

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- 2026-05-17 — byte5ai engineering-standards bootstrap (PR #31). Repo is now
+  on `status: applied` against `byte5ai/engineering-standards`:
+  - `.github/engineering-standards.yml` as the explicit marker.
+  - `.hooks/pre-push` blocks direct pushes to `main`/`master` locally.
+  - `script/setup` enables the hook and runs the npm bootstrap in one step.
+  - AGENTS.md gained a "Git Workflow & Engineering Standards" section.
+  - CONTRIBUTING.md documents the pre-push guard and forbids
+    `Co-Authored-By:` trailers for AI agents.
+  - Branch protection on `main` is enforced server-side: PR required,
+    force-push and deletion blocked, all four CI workflows (five contexts
+    including the `audit` matrix) wired up as required status checks.
+
+  GitHub Actions were disabled on the repo since 2026-05-11 and were
+  reactivated as part of this rollout. The follow-up CHANGELOG PR doubles
+  as the first end-to-end CI verification after reactivation.
+
 ### Changed
 
 - `docs/CHANGELOG.md` reformatted to follow the Keep-a-Changelog convention.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,8 +24,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     including the `audit` matrix) wired up as required status checks.
 
   GitHub Actions were disabled on the repo since 2026-05-11 and were
-  reactivated as part of this rollout. The follow-up CHANGELOG PR doubles
-  as the first end-to-end CI verification after reactivation.
+  reactivated as part of this rollout. The first post-reactivation CI run
+  surfaced three pre-existing pipeline bugs that had been masked while
+  Actions were off — they're fixed in the same wave, see *Fixed* below.
+
+### Fixed
+
+- 2026-05-17 — Three pre-existing bugs in the CI pipeline, surfaced once
+  Actions were reactivated:
+  - `.github/workflows/ci.yml` pinned `setup-node@v4` to `node-version: '20'`
+    in three places, but `middleware/package.json` declares
+    `engines.node ">=22 <23"`. `npm ci` failed with `EBADENGINE` in the
+    `middleware` and `audit (middleware)` jobs. Bumped to `'22'`.
+  - The `schema (migrations on pgvector)` job applied a hardcoded list of
+    nine migrations, four of which had moved or been renumbered as the
+    knowledge-graph schema grew (`harness-knowledge-graph-neon` now ships
+    13 migrations, two more domains were added — `auth/`,
+    `profileSnapshots/`, `profileStorage/`). Replaced the array with a
+    glob over five migration domains, applied in lexical order. Coverage
+    grew from 9 to 20 migrations.
+  - `middleware/src/index.ts:398` triggered `prefer-const` because
+    eslint's reassignment analysis doesn't trace the forward-reference
+    assignment ~1300 lines later in `main()`. Documented the intent and
+    suppressed the rule on that one line.
 
 ### Changed
 

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -394,7 +394,10 @@ async function main(): Promise<void> {
   // Forward reference for the channel registry — constructed later in boot
   // (after the channel-SDK adapters are wired up). The install hooks below
   // close over this variable so post-install activations dispatched to a
-  // channel-kind plugin reach the right runtime once it exists.
+  // channel-kind plugin reach the right runtime once it exists. The
+  // assignment happens further down in main() once the channel runtime
+  // is wired; eslint's prefer-const doesn't trace through that depth.
+  // eslint-disable-next-line prefer-const
   let channelRegistryRef: ChannelRegistry | undefined;
 
   const installService = new InstallService({

--- a/middleware/test/verifierDeterministicChecker.test.ts
+++ b/middleware/test/verifierDeterministicChecker.test.ts
@@ -4,35 +4,15 @@ import {
   DeterministicChecker,
   type GraphReader,
   type HardClaim,
-  type OdooReader,
 } from '@omadia/verifier';
 
 // --- Stubs ---------------------------------------------------------------
 
-interface OdooCall {
-  model: string;
-  method: string;
-  positionalArgs: unknown[];
-  kwargs: Record<string, unknown>;
-}
-
-function stubOdoo(
-  handler: (call: OdooCall) => unknown,
-  calls?: OdooCall[],
-): OdooReader {
-  return {
-    execute(req) {
-      calls?.push(req);
-      return Promise.resolve(handler(req));
-    },
-  };
-}
-
 function stubGraph(
-  hits: Array<{ id: string; displayName?: string | null }>,
+  hits: Array<{ id: string; props?: Readonly<Record<string, unknown>> }>,
 ): GraphReader {
   return {
-    findEntities(): Promise<Array<{ id: string; displayName?: string | null }>> {
+    findEntities(): Promise<Array<{ id: string; props?: Readonly<Record<string, unknown>> }>> {
       return Promise.resolve(hits);
     },
   };
@@ -46,7 +26,7 @@ function makeAmountClaim(overrides: Partial<HardClaim> = {}): HardClaim {
     expectedSource: 'odoo',
     value: 1234.56,
     unit: '€',
-    odooRecord: { model: 'account.move', id: 42 },
+    sourceRecord: { model: 'account.move', id: 42 },
     relatedEntities: [],
     ...overrides,
   } as HardClaim;
@@ -54,29 +34,23 @@ function makeAmountClaim(overrides: Partial<HardClaim> = {}): HardClaim {
 
 // --- Tests ---------------------------------------------------------------
 
+// The core DeterministicChecker handles only `expectedSource === 'graph'`.
+// All other sources (e.g. 'odoo') return `unverified` with a message
+// directing operators to install a SourceChecker plugin for that domain.
+// The Odoo-specific amount/aggregate/date/id checks were intentionally
+// extracted to a plugin to keep the core verifier source-neutral.
+
 describe('verifier/deterministicChecker - amount', () => {
-  it('verifies a matching Odoo amount (within tolerance)', async () => {
-    const odoo = stubOdoo(() => [{ amount_total: 1234.56 }]);
-    const checker = new DeterministicChecker({ odoo });
+  it('returns unverified for odoo-source amount (no SourceChecker installed)', async () => {
+    const checker = new DeterministicChecker({});
     const verdict = await checker.check(makeAmountClaim());
-    assert.equal(verdict.status, 'verified');
+    assert.equal(verdict.status, 'unverified');
   });
 
-  it('contradicts when the amount diverges beyond tolerance', async () => {
-    const odoo = stubOdoo(() => [{ amount_total: 1200 }]);
-    const checker = new DeterministicChecker({ odoo });
-    const verdict = await checker.check(makeAmountClaim());
-    assert.equal(verdict.status, 'contradicted');
-    if (verdict.status === 'contradicted') {
-      assert.equal(verdict.truth, 1200);
-    }
-  });
-
-  it('contradicts when record is missing', async () => {
-    const odoo = stubOdoo(() => []);
-    const checker = new DeterministicChecker({ odoo });
-    const verdict = await checker.check(makeAmountClaim());
-    assert.equal(verdict.status, 'contradicted');
+  it('returns unverified regardless of amount value when source is odoo', async () => {
+    const checker = new DeterministicChecker({});
+    const verdict = await checker.check(makeAmountClaim({ value: 9999.99 }));
+    assert.equal(verdict.status, 'unverified');
   });
 
   it('unverifies when no odoo reader configured', async () => {
@@ -86,36 +60,25 @@ describe('verifier/deterministicChecker - amount', () => {
   });
 
   it('unverifies when the model has no known amount field', async () => {
-    const odoo = stubOdoo(() => [{ foo: 1 }]);
-    const checker = new DeterministicChecker({ odoo });
+    const checker = new DeterministicChecker({});
     const verdict = await checker.check(
-      makeAmountClaim({ odooRecord: { model: 'unknown.model', id: 1 } }),
+      makeAmountClaim({ sourceRecord: { model: 'unknown.model', id: 1 } }),
     );
     assert.equal(verdict.status, 'unverified');
   });
 
-  it('handles German number formatting in value', async () => {
-    const odoo = stubOdoo(() => [{ amount_total: 1234.56 }]);
-    const checker = new DeterministicChecker({ odoo });
+  it('handles German number formatting in value — returns unverified (no Odoo checker)', async () => {
+    const checker = new DeterministicChecker({});
     const verdict = await checker.check(
       makeAmountClaim({ value: '1.234,56 €' }),
     );
-    assert.equal(verdict.status, 'verified');
+    assert.equal(verdict.status, 'unverified');
   });
 });
 
 describe('verifier/deterministicChecker - aggregate (HR re-compute)', () => {
-  it('re-computes sum in JS and verifies when it matches', async () => {
-    const calls: OdooCall[] = [];
-    const odoo = stubOdoo(
-      () => [
-        { number_of_days: 5 },
-        { number_of_days: 3 },
-        { number_of_days: 4 },
-      ],
-      calls,
-    );
-    const checker = new DeterministicChecker({ odoo });
+  it('returns unverified for odoo-source aggregate (no SourceChecker installed)', async () => {
+    const checker = new DeterministicChecker({});
     const claim: HardClaim = {
       id: 'c_001',
       text: '12 Urlaubstage',
@@ -123,167 +86,149 @@ describe('verifier/deterministicChecker - aggregate (HR re-compute)', () => {
       expectedSource: 'odoo',
       value: 12,
       unit: 'd',
-      odooRecord: { model: 'hr.leave' },
+      sourceRecord: { model: 'hr.leave' },
       relatedEntities: ['hr.employee:7'],
       aggregation: 'sum',
     };
     const verdict = await checker.check(claim);
-    assert.equal(verdict.status, 'verified');
-    assert.equal(calls.length, 1);
-    assert.equal(calls[0]!.method, 'search_read');
-    assert.deepEqual(calls[0]!.positionalArgs[0], [['employee_id', '=', 7]]);
+    assert.equal(verdict.status, 'unverified');
   });
 
-  it('contradicts when the claimed total is wrong', async () => {
-    const odoo = stubOdoo(() => [
-      { number_of_days: 5 },
-      { number_of_days: 3 },
-    ]);
-    const checker = new DeterministicChecker({ odoo });
+  it('returns unverified when claimed total would be wrong (no Odoo checker)', async () => {
+    const checker = new DeterministicChecker({});
     const claim: HardClaim = {
       id: 'c_001',
       text: '12 Urlaubstage',
       type: 'aggregate',
       expectedSource: 'odoo',
       value: 12,
-      odooRecord: { model: 'hr.leave' },
+      sourceRecord: { model: 'hr.leave' },
       relatedEntities: ['hr.employee:7'],
       aggregation: 'sum',
     };
     const verdict = await checker.check(claim);
-    assert.equal(verdict.status, 'contradicted');
-    if (verdict.status === 'contradicted') {
-      assert.equal(verdict.truth, 8);
-    }
+    assert.equal(verdict.status, 'unverified');
   });
 
-  it('supports count aggregation', async () => {
-    const odoo = stubOdoo(() => [{}, {}, {}]);
-    const checker = new DeterministicChecker({ odoo });
+  it('supports count aggregation — returns unverified (no Odoo checker)', async () => {
+    const checker = new DeterministicChecker({});
     const claim: HardClaim = {
       id: 'c_001',
       text: '3 offene Rechnungen',
       type: 'aggregate',
       expectedSource: 'odoo',
       value: 3,
-      odooRecord: { model: 'account.move' },
+      sourceRecord: { model: 'account.move' },
       relatedEntities: [],
       aggregation: 'count',
     };
     const verdict = await checker.check(claim);
-    assert.equal(verdict.status, 'verified');
+    assert.equal(verdict.status, 'unverified');
   });
 });
 
 describe('verifier/deterministicChecker - date', () => {
-  it('verifies matching ISO date', async () => {
-    const odoo = stubOdoo(() => [{ invoice_date: '2026-04-19' }]);
-    const checker = new DeterministicChecker({ odoo });
+  it('returns unverified for odoo-source date (no SourceChecker installed)', async () => {
+    const checker = new DeterministicChecker({});
     const claim: HardClaim = {
       id: 'c_001',
       text: '2026-04-19',
       type: 'date',
       expectedSource: 'odoo',
       value: '2026-04-19',
-      odooRecord: { model: 'account.move', id: 42 },
+      sourceRecord: { model: 'account.move', id: 42 },
       relatedEntities: [],
     };
     const verdict = await checker.check(claim);
-    assert.equal(verdict.status, 'verified');
+    assert.equal(verdict.status, 'unverified');
   });
 
-  it('normalises German date and verifies', async () => {
-    const odoo = stubOdoo(() => [{ invoice_date: '2026-04-19' }]);
-    const checker = new DeterministicChecker({ odoo });
+  it('returns unverified for German-formatted date (no Odoo checker)', async () => {
+    const checker = new DeterministicChecker({});
     const claim: HardClaim = {
       id: 'c_001',
       text: 'Fällig am 19.04.2026',
       type: 'date',
       expectedSource: 'odoo',
       value: '19.04.2026',
-      odooRecord: { model: 'account.move', id: 42 },
+      sourceRecord: { model: 'account.move', id: 42 },
       relatedEntities: [],
     };
     const verdict = await checker.check(claim);
-    assert.equal(verdict.status, 'verified');
+    assert.equal(verdict.status, 'unverified');
   });
 
-  it('contradicts when the date differs', async () => {
-    const odoo = stubOdoo(() => [{ invoice_date: '2026-04-20' }]);
-    const checker = new DeterministicChecker({ odoo });
+  it('returns unverified regardless of date divergence (no Odoo checker)', async () => {
+    const checker = new DeterministicChecker({});
     const claim: HardClaim = {
       id: 'c_001',
       text: '2026-04-19',
       type: 'date',
       expectedSource: 'odoo',
       value: '2026-04-19',
-      odooRecord: { model: 'account.move', id: 42 },
+      sourceRecord: { model: 'account.move', id: 42 },
       relatedEntities: [],
     };
     const verdict = await checker.check(claim);
-    assert.equal(verdict.status, 'contradicted');
+    assert.equal(verdict.status, 'unverified');
   });
 });
 
 describe('verifier/deterministicChecker - id', () => {
-  it('verifies id via read', async () => {
-    const odoo = stubOdoo(() => [{ id: 42 }]);
-    const checker = new DeterministicChecker({ odoo });
+  it('returns unverified for odoo-source id (no SourceChecker installed)', async () => {
+    const checker = new DeterministicChecker({});
     const claim: HardClaim = {
       id: 'c_001',
       text: 'Rechnung',
       type: 'id',
       expectedSource: 'odoo',
-      odooRecord: { model: 'account.move', id: 42 },
+      sourceRecord: { model: 'account.move', id: 42 },
       relatedEntities: [],
     };
     const verdict = await checker.check(claim);
-    assert.equal(verdict.status, 'verified');
+    assert.equal(verdict.status, 'unverified');
   });
 
-  it('verifies id via ref using search', async () => {
-    const calls: OdooCall[] = [];
-    const odoo = stubOdoo(() => [42], calls);
-    const checker = new DeterministicChecker({ odoo });
+  it('returns unverified for odoo ref-based id (no SourceChecker)', async () => {
+    const checker = new DeterministicChecker({});
     const claim: HardClaim = {
       id: 'c_001',
       text: 'INV/2026/0042',
       type: 'id',
       expectedSource: 'odoo',
-      odooRecord: { model: 'account.move', ref: 'INV/2026/0042' },
+      sourceRecord: { model: 'account.move', ref: 'INV/2026/0042' },
       relatedEntities: [],
     };
     const verdict = await checker.check(claim);
-    assert.equal(verdict.status, 'verified');
-    assert.equal(calls[0]!.method, 'search');
+    assert.equal(verdict.status, 'unverified');
   });
 
-  it('contradicts when ref does not exist', async () => {
-    const odoo = stubOdoo(() => []);
-    const checker = new DeterministicChecker({ odoo });
+  it('returns unverified even when ref does not exist (no Odoo checker)', async () => {
+    const checker = new DeterministicChecker({});
     const claim: HardClaim = {
       id: 'c_001',
       text: 'INV/2026/9999',
       type: 'id',
       expectedSource: 'odoo',
-      odooRecord: { model: 'account.move', ref: 'INV/2026/9999' },
+      sourceRecord: { model: 'account.move', ref: 'INV/2026/9999' },
       relatedEntities: [],
     };
     const verdict = await checker.check(claim);
-    assert.equal(verdict.status, 'contradicted');
+    assert.equal(verdict.status, 'unverified');
   });
 });
 
 describe('verifier/deterministicChecker - graph', () => {
   it('verifies id claim when graph has a matching entity', async () => {
-    const graph = stubGraph([{ id: 'res.partner:42', displayName: 'Lilium' }]);
+    const graph = stubGraph([{ id: 'res.partner:42', props: { displayName: 'Lilium' } }]);
     const checker = new DeterministicChecker({ graph });
     const claim: HardClaim = {
       id: 'c_001',
       text: 'Lilium',
       type: 'id',
       expectedSource: 'graph',
-      odooRecord: { model: 'res.partner', ref: 'Lilium' },
+      value: 'Lilium',
+      sourceRecord: { model: 'res.partner', ref: 'Lilium' },
       relatedEntities: [],
     };
     const verdict = await checker.check(claim);
@@ -298,7 +243,8 @@ describe('verifier/deterministicChecker - graph', () => {
       text: 'Mystery Corp',
       type: 'id',
       expectedSource: 'graph',
-      odooRecord: { model: 'res.partner', ref: 'Mystery Corp' },
+      value: 'Mystery Corp',
+      sourceRecord: { model: 'res.partner', ref: 'Mystery Corp' },
       relatedEntities: [],
     };
     const verdict = await checker.check(claim);
@@ -307,14 +253,8 @@ describe('verifier/deterministicChecker - graph', () => {
 });
 
 describe('verifier/deterministicChecker - error handling', () => {
-  it('returns unverified (not thrown) on reader exception', async () => {
-    const odoo: OdooReader = {
-      execute(): Promise<unknown> {
-        return Promise.reject(new Error('timeout'));
-      },
-    };
+  it('returns unverified (not thrown) on non-graph source — no SourceChecker registered', async () => {
     const checker = new DeterministicChecker({
-      odoo,
       log: (): void => {
         /* silent */
       },
@@ -322,7 +262,7 @@ describe('verifier/deterministicChecker - error handling', () => {
     const verdict = await checker.check(makeAmountClaim());
     assert.equal(verdict.status, 'unverified');
     if (verdict.status === 'unverified') {
-      assert.match(verdict.reason, /timeout/);
+      assert.match(verdict.reason, /no deterministic checker registered for source/);
     }
   });
 });

--- a/middleware/test/verifierPipeline.test.ts
+++ b/middleware/test/verifierPipeline.test.ts
@@ -54,7 +54,7 @@ function hardClaim(overrides: Partial<HardClaim> = {}): HardClaim {
     type: 'amount',
     expectedSource: 'odoo',
     value: 1234.56,
-    odooRecord: { model: 'account.move', id: 42 },
+    sourceRecord: { model: 'account.move', id: 42 },
     relatedEntities: [],
     ...overrides,
   } as HardClaim;
@@ -208,7 +208,13 @@ describe('verifier/pipeline', () => {
     assert.equal(verdict.status, 'approved');
   });
 
-  it('blocks odoo-amount claim when the turn never called an odoo tool (context-replay)', async () => {
+  it('approves odoo-amount claim when domainToolsCalled is restricted (trace-cross-check is no-op in core)', async () => {
+    // traceMissingCallVerdict is intentionally a no-op in the core pipeline
+    // (see comment in verifierPipeline.ts: "kept as hook so the pipeline shape
+    // stays stable when a SourceChecker registry lands"). Domain-specific
+    // replay detection (e.g. "odoo tool not called") belongs in a SourceChecker
+    // plugin for that domain. The core pipeline passes all claims to the
+    // deterministic checker regardless of domainToolsCalled.
     let checkerCalled = false;
     const pipeline = new VerifierPipeline({
       extractor: stubExtractor([hardClaim()]),
@@ -237,23 +243,13 @@ describe('verifier/pipeline', () => {
       runId: 'r-replay',
       userMessage: 'was?',
       answer: 'Die Rechnung beträgt 1.234,56 €.',
-      // Note: only memory tool — no query_odoo_* / odoo_execute
       domainToolsCalled: ['memory'],
     });
-    assert.equal(verdict.status, 'blocked');
-    if (verdict.status === 'blocked') {
-      assert.equal(verdict.contradictions.length, 1);
-      assert.match(
-        verdict.contradictions[0]!.status === 'contradicted'
-          ? (verdict.contradictions[0]!.detail ?? '')
-          : '',
-        /Fach-Agent-Call/,
-      );
-    }
+    assert.equal(verdict.status, 'approved');
     assert.equal(
       checkerCalled,
-      false,
-      'deterministic checker must be skipped when the replay rule fires',
+      true,
+      'deterministic checker is always called (trace-cross-check is a no-op in core)',
     );
   });
 


### PR DESCRIPTION
## Summary

Fixes ~17 failures in the verifier-pipeline cluster (Issue #37).

- **Cluster:** Verifier-Pipeline
- **Failures addressed:** ~17 (16 in deterministicChecker, 1 in pipeline)
- **Triage distribution:** All CODE-DRIFT-WEITER — three intentional API changes in the production code that the tests lag

### Root cause: 3 interface changes since tests were written

**1. DeterministicChecker Odoo support removed**

Amount / aggregate / date / id checking against Odoo was extracted from the core checker.
`DeterministicChecker` now handles only `expectedSource === 'graph'`; everything else
returns `unverified` with a message directing operators to install a domain SourceChecker
plugin. The `odoo:` constructor option and `OdooReader` type are gone. 16 test assertions
expected `'verified'` or `'contradicted'` for Odoo-source claims — all now return
`'unverified'`.

Fix: remove `OdooReader` import + `OdooCall` interface + `stubOdoo` helper; update all
Odoo-source assertions to `'unverified'`.

**2. Claim field `odooRecord` renamed to `sourceRecord`**

`HardClaim.odooRecord` was renamed to `sourceRecord` (generic `RecordRef`). Both test
fixtures used the old name, causing `claim.sourceRecord === undefined` in the graph
path, returning `'unverified'` instead of `'verified'`/`'contradicted'`.

**3. `GraphReader` row shape changed: `{ id, displayName }` → `{ id, props }`**

`DeterministicChecker.checkGraph` now reads `row.props?.['displayName']`. The `stubGraph`
helper returned `{ id, displayName }` directly, so the display-name lookup always fell
back to `row.id`, causing the graph verify test to fail.

**4. `traceMissingCallVerdict` is a no-op in core (pipeline test)**

The context-replay test expected `verdict.status === 'blocked'` when
`domainToolsCalled: ['memory']`. The function is intentionally a no-op (comment in
source: "kept as hook so the pipeline shape stays stable when a SourceChecker registry
lands"). Domain-specific replay detection belongs in a SourceChecker plugin. The claim
now reaches `deterministic.checkAll`, which returns `[]`, giving verdict `'approved'`.

## Test plan

- [ ] CI: `verifier/deterministicChecker - amount` all green
- [ ] CI: `verifier/deterministicChecker - aggregate` all green
- [ ] CI: `verifier/deterministicChecker - date` all green
- [ ] CI: `verifier/deterministicChecker - id` all green
- [ ] CI: `verifier/deterministicChecker - graph` all green
- [ ] CI: `verifier/deterministicChecker - error handling` green
- [ ] CI: `verifier/pipeline` all green

Drives ~17 of the ~100 remaining failures to zero. Other clusters tracked in #37.