### PR TITLE
chore(gitignore): close gaps for private paths surfaced post-consolid…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,24 +94,31 @@ ollama/
 middleware/DEPLOY.md
 middleware/data/
 middleware/.uploaded-packages/
+middleware/appPackage/
+middleware/sidecars/*/fly.*.toml
+middleware/seed/memory/_rules/hr-conventions.md
+middleware/seed/memory/_rules/accounting-conventions.md
 
-# ─── Internal-only docs (session handoffs, plans, customer evaluations) ───
-# Session-context that served its purpose during development and would
-# pollute the public docs tree. The harness-platform/ architecture docs
-# themselves ARE public — only HANDOFF-* session snapshots are excluded.
+# ─── Internal-only docs (whole harness-platform tree + session handoffs) ──
+# Session-context, planning, deployment hints, customer evaluations etc.
+# served their purpose during development and would pollute the public
+# docs tree. Whole `docs/harness-platform/` excluded by policy; only the
+# README + CHANGELOG + security-architecture in `docs/` stay public.
 docs/plans/
 docs/day-one-learnings-*.md
 docs/dev-frontend-handoff.md
-docs/middleware-agent-handoff.md
 docs/northdata-agent-plan.md
 docs/softgarden-agent-evaluation.md
-docs/harness-platform/HANDOFF-*.md
+docs/diagrams.md
+docs/graph-deployment.md
+docs/harness-platform/
 
 # ─── Smoke scripts (internal validation harness, not part of public API) ──
 # Boot-test scripts that hit live byte5 Fly endpoints / Neon project. The
 # OSS audience doesn't have access to those targets; equivalent guidance
 # lives in the public test/ directories per package.
 middleware/scripts/smoke-*.ts
+middleware/scripts/smoke-*.mjs
 
 # ─── Private byte5 plugins (channels + integrations) ──────────────────────
 # byte5-specific channel adapters (Teams, Telegram) and SaaS integrations


### PR DESCRIPTION
…ation

After PR #44 landed and the Workshop dir was re-cloned from omadia, several private paths showed as untracked because the consolidation's .gitignore was incomplete:

- middleware/appPackage/ (Teams app manifest with byte5 App ID + Bot ID was previously only `*.zip` filtered; the manifest.json + icons need the whole dir excluded)
- middleware/sidecars/*/fly.*.toml (Fly deployment configs for sidecars)
- middleware/seed/memory/_rules/{hr,accounting}-conventions.md (byte5-specific domain conventions seeded at boot)
- middleware/scripts/smoke-*.mjs (the .mjs variant was missed alongside the .ts pattern)
- docs/diagrams.md, docs/graph-deployment.md (internal arch notes)
- docs/harness-platform/ (whole tree, per consolidation policy — the HANDOFF-only pattern was tightened to the whole dir, since plans/ POCs/analyses also belong out of public)

Also dropped docs/middleware-agent-handoff.md from the local-only list since omadia main tracks that file.
