### PR TITLE
fix(builder): IMPORT_FORBIDDEN false-positive on JSDoc import samples

### DIFF
--- a/middleware/src/plugins/builder/workspaceImportResolver.ts
+++ b/middleware/src/plugins/builder/workspaceImportResolver.ts
@@ -82,9 +82,37 @@ function isNodeBuiltinSpecifier(specifier: string): boolean {
  * double-quoted strings; backticks (template strings) are rare for
  * import paths and skipping them avoids false-positives from inline
  * code samples in JSDoc-adjacent strings.
+ *
+ * Comments are stripped from the input before this regex runs (see
+ * `stripCommentsForImportScan` below). The `[\w*${}\s,]+` class would
+ * otherwise span newlines and JSDoc asterisks, and JSDoc bodies
+ * frequently embed example imports as a hint for the reader — e.g. the
+ * boilerplate `types.ts` documents an `import type` sample from
+ * `@omadia/plugin-api` inside a JSDoc block. Without the strip step
+ * that example would trip IMPORT_FORBIDDEN against the standalone-compile
+ * contract on every fill_slot turn that processes the boilerplate.
  */
 const IMPORT_RE =
   /(?<=^|[^.\w])(?:import\s*(?:[\w*${}\s,]+\s*from\s*)?|import\s*\(\s*|require\s*\(\s*)["']([^"']+)["']/gm;
+
+/**
+ * Replaces JS/TS comment bodies with spaces so the import regex cannot
+ * match code samples embedded in JSDoc or trailing `//` notes. Newlines
+ * are preserved so the line-offset table built from the original text
+ * still maps match indices to the correct source line.
+ *
+ * Approximate by design — it does not track string or template-literal
+ * state, so a comment sentinel inside a string (e.g. `"/* not a comment *\/"`)
+ * is treated as a real comment. That is acceptable: the import regex
+ * would not match a genuine bare-specifier import nested inside a string
+ * either, and the gate's only mandate is to catch real imports.
+ */
+export function stripCommentsForImportScan(text: string): string {
+  const blocksStripped = text.replace(/\/\*[\s\S]*?\*\//g, (m) =>
+    m.replace(/[^\n]/g, ' '),
+  );
+  return blocksStripped.replace(/\/\/[^\n]*/g, (m) => ' '.repeat(m.length));
+}
 
 interface ImportFinding {
   specifier: string;
@@ -99,9 +127,10 @@ export function extractImports(text: string): ImportFinding[] {
   for (let i = 0; i < text.length; i++) {
     if (text.charCodeAt(i) === 10 /* \n */) lineOffsets.push(i + 1);
   }
+  const scanText = stripCommentsForImportScan(text);
   IMPORT_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
-  while ((m = IMPORT_RE.exec(text)) !== null) {
+  while ((m = IMPORT_RE.exec(scanText)) !== null) {
     const specifier = m[1];
     if (typeof specifier !== 'string' || specifier.length === 0) continue;
     // Skip relative imports — they're resolved by tsc via rootDir,

--- a/middleware/test/builder/workspaceImportResolver.test.ts
+++ b/middleware/test/builder/workspaceImportResolver.test.ts
@@ -11,6 +11,8 @@ import {
   packageRootOf,
   validateBundleImports,
 } from '../../src/plugins/builder/workspaceImportResolver.js';
+import { generate } from '../../src/plugins/builder/codegen.js';
+import { parseAgentSpec } from '../../src/plugins/builder/agentSpec.js';
 
 describe('workspaceImportResolver', () => {
   beforeEach(() => {
@@ -63,6 +65,36 @@ describe('workspaceImportResolver', () => {
     it('does not match the word import inside identifiers', () => {
       const src = "const importer = 'not-an-import';";
       assert.deepEqual(extractImports(src), []);
+    });
+
+    it('does not match import-like example code embedded in JSDoc blocks', () => {
+      // Reproduces the regression where the boilerplate `types.ts` tripped
+      // IMPORT_FORBIDDEN at line 307 because the regex spanned the JSDoc's
+      // `*  ` continuation prefix and matched a code-sample sentence. The
+      // strip pass must zero out the comment body before the regex runs.
+      const src = [
+        '/**',
+        ' * Read-only: full-text Turn search. Returns implementation-specific',
+        ' * hits — the boilerplate keeps the row type opaque (`unknown`) to',
+        ' * avoid pulling in the whole KG type surface from `@omadia/plugin-api`.',
+        " * Plugins that need the structured shape: `import type { TurnSearchHit }",
+        " * from '@omadia/plugin-api'` and add the package as a peerDep.",
+        ' */',
+        "import { z } from 'zod';",
+      ].join('\n');
+      assert.deepEqual(extractImports(src), [
+        { specifier: 'zod', line: 8 },
+      ]);
+    });
+
+    it('does not match imports referenced in line comments', () => {
+      const src = [
+        "// see also: import { foo } from '@omadia/plugin-api'",
+        "import { real } from 'lodash';",
+      ].join('\n');
+      assert.deepEqual(extractImports(src), [
+        { specifier: 'lodash', line: 2 },
+      ]);
     });
   });
 
@@ -119,6 +151,90 @@ describe('workspaceImportResolver', () => {
       const issue = issues[0]!;
       assert.equal(issue.code, 'IMPORT_UNRESOLVED');
       assert.match(issue.message, /peerDependencies/);
+    });
+
+    it('end-to-end: three react-ssr ui_routes produce a bundle that passes the gate', async () => {
+      // Original user-reported failure: `patch_spec` with three react-ssr
+      // ui_routes followed by `fill_slot` reproduces IMPORT_FORBIDDEN
+      // types.ts(307,1). The false-positive lives in the boilerplate
+      // types.ts JSDoc and trips regardless of route count; route count
+      // only changed which other pipeline step ran first. This test drives
+      // the same path: build a 3-route spec → generate() → run the gate
+      // on the full output and assert zero IMPORT_FORBIDDEN issues. The
+      // 2-route counterpart below confirms parity.
+      const makeRoute = (id: string) => ({
+        id,
+        path: `/${id}`,
+        tab_label: id,
+        page_title: `${id} Page`,
+        refresh_seconds: 30,
+        render_mode: 'react-ssr' as const,
+        interactive: false,
+        data_binding: { source: 'tool' as const, tool_id: 'list_items' },
+      });
+      const baseSpec = {
+        id: 'de.byte5.agent.test',
+        name: 'Test Agent',
+        description: 'Test agent description',
+        category: 'productivity',
+        domain: 'dev.test',
+        skill: { role: 'tester' },
+        playbook: {
+          when_to_use: 'when testing',
+          not_for: ['not used for unit tests'],
+          example_prompts: ['test prompt 1', 'test prompt 2'],
+        },
+        network: { outbound: ['api.example.com'] },
+        tools: [{ id: 'list_items', description: 'List things', input: {} }],
+      };
+      const buildAndCheck = async (routeCount: number) => {
+        const routes = ['alpha', 'beta', 'gamma'].slice(0, routeCount).map(makeRoute);
+        const spec = parseAgentSpec({ ...baseSpec, ui_routes: routes });
+        const slots: Record<string, string> = {
+          'client-impl':
+            '// client stub\nreturn { async ping() {}, async dispose() {} } as unknown as Client;',
+          'toolkit-impl':
+            '// toolkit stub\nconst tools: ToolDescriptor<unknown, unknown>[] = [];\nreturn { tools, async close() {} };',
+          'skill-prompt': '# Test Skill\nTest prompt body.',
+        };
+        for (const r of routes) {
+          slots[`ui-${r.id}-component`] =
+            'export default function P() { return <div>Hi</div>; }';
+        }
+        const files = await generate({ spec, slots });
+        const issues = validateBundleImports(files, allowAll);
+        return issues.filter((i) => i.code === 'IMPORT_FORBIDDEN');
+      };
+      const threeRouteForbidden = await buildAndCheck(3);
+      assert.deepEqual(
+        threeRouteForbidden,
+        [],
+        'three-route bundle must produce zero IMPORT_FORBIDDEN issues',
+      );
+      const twoRouteForbidden = await buildAndCheck(2);
+      assert.deepEqual(
+        twoRouteForbidden,
+        [],
+        'two-route bundle must also produce zero IMPORT_FORBIDDEN issues (parity check)',
+      );
+    });
+
+    it('does not flag the boilerplate types.ts JSDoc that documents @omadia/plugin-api as a peer', async () => {
+      // End-to-end reproducer for the IMPORT_FORBIDDEN types.ts(307,1)
+      // false-positive: scan the on-disk boilerplate file via the bundle
+      // gate and assert no issues — proves the strip pass shields legit
+      // JSDoc examples without weakening the gate against real imports.
+      const { readFile } = await import('node:fs/promises');
+      const url = await import('node:url');
+      const here = path.dirname(url.fileURLToPath(import.meta.url));
+      const boilerplate = path.resolve(
+        here,
+        '../../assets/boilerplate/agent-integration/types.ts',
+      );
+      const buf = await readFile(boilerplate);
+      const files = new Map<string, Buffer>([['types.ts', buf]]);
+      const issues = validateBundleImports(files, allowAll);
+      assert.deepEqual(issues, []);
     });
 
     it('passes installed packages through silently', () => {


### PR DESCRIPTION
## Summary

- The pre-tsc import gate's regex scanned raw file text, so any JSDoc that embedded an `import type { ... } from '@omadia/plugin-api'` example tripped `IMPORT_FORBIDDEN`. The boilerplate `agent-integration/types.ts` carries exactly that pattern at line 307 to point plugin authors at the optional peerDep.
- Surface was reported externally as "builds with 3 react-ssr `ui_routes` fail with `IMPORT_FORBIDDEN types.ts(307,1)`". The added 2-route parity check confirms the gate trips on the same JSDoc with 2 routes too — route count only changed which other pipeline step ran first.
- Fix: `stripCommentsForImportScan()` zeros out block- and line-comment bodies before the regex runs, preserving newlines so reported line numbers still map to the original source.

## Test plan

- [x] `npx tsx --test test/builder/workspaceImportResolver.test.ts` — 21/22 pass, 1 pre-existing skip (symlink test predates single-repo consolidation)
- [x] Full builder suite `npx tsx --test test/builder/*.test.ts` — 782/784 pass, 0 fail, 2 pre-existing skips
- [x] Empirical regression check: stashed the fix, re-ran the new E2E reproducer → 4 fails including the user's `IMPORT_FORBIDDEN` case; restored the fix → all green
- [x] `npx eslint` on touched files — clean
- [x] `npx tsc --noEmit` — 0 errors

## Notes

- `stripCommentsForImportScan` is intentionally approximate — it does not track string or template-literal state, so a comment sentinel inside a string would be wrongly stripped. The trade-off is documented in JSDoc on the helper. A real bare-specifier import nested inside a string would have produced a false positive in the previous regex too, so this is no net regression.
- The new E2E test (`end-to-end: three react-ssr ui_routes produce a bundle that passes the gate`) drives `generate()` with both 3- and 2-route specs through `validateBundleImports`. This is the regression guard if the JSDoc body in the boilerplate `types.ts` is ever edited again.