### PR TITLE
fix(builder): install no longer aborted by debounced preview rebuild

### DIFF
--- a/middleware/src/plugins/builder/buildPipeline.ts
+++ b/middleware/src/plugins/builder/buildPipeline.ts
@@ -63,6 +63,19 @@ export interface BuildPipelineDeps {
 export interface PipelineRunOptions {
   userEmail: string;
   draftId: string;
+  /**
+   * What this build is for. Controls the BuildQueue coalesce key:
+   *   - `'preview'` (default): coalesces by `draftId` so the latest debounced
+   *     rebuild wins — successive PATCH-driven rebuilds drop stale work.
+   *   - `'install'`: coalesces by `${draftId}:install` so an explicit
+   *     install-commit is NOT aborted by a debounced preview rebuild
+   *     that happens to fire while tsc is still running. Without this
+   *     separation an install kicked off right after a spec patch
+   *     (e.g. the version-bump retry path in InstallDiffModal) raced
+   *     the 2s-debounced rebuild and surfaced as
+   *     `builder.build_failed.abort` (reason=abort, exit=null).
+   */
+  kind?: 'preview' | 'install';
 }
 
 export interface PipelineRunResult {
@@ -187,6 +200,10 @@ export class BuildPipeline {
       );
     }
 
+    const kind = opts.kind ?? 'preview';
+    const coalesceKey =
+      kind === 'install' ? `${opts.draftId}:install` : opts.draftId;
+
     try {
       const buildResult = await this.buildQueue.enqueue(
         opts.draftId,
@@ -198,6 +215,7 @@ export class BuildPipeline {
               ? { timeoutMs: this.buildTimeoutMs }
               : {}),
           }),
+        { coalesceKey },
       );
       this.log(
         `[build-pipeline] draft=${opts.draftId} buildN=${String(buildN)} ok=${String(buildResult.ok)} reason=${buildResult.ok ? 'ok' : buildResult.reason} duration_ms=${String(buildResult.durationMs)}`,

--- a/middleware/src/plugins/builder/buildQueue.ts
+++ b/middleware/src/plugins/builder/buildQueue.ts
@@ -1,21 +1,32 @@
 import type { BuildResult, BuildFailure } from './buildSandbox.js';
 
 /**
- * BuildQueue — global FIFO queue with concurrency cap and per-draft
+ * BuildQueue — global FIFO queue with concurrency cap and per-coalesce-key
  * coalescing for the builder pipeline.
  *
  * Semantics:
  *   - **Concurrency cap** (default 3): never more than `concurrency` builds
  *     running at once; the rest wait FIFO.
- *   - **Coalescing**: a fresh `enqueue(draftId, …)` for a draft id that is
- *     already queued or running aborts the prior entry (`AbortController.abort`)
- *     and takes its slot. The displaced entry's promise resolves with a
- *     BuildFailure of reason `'abort'`. Build functions are expected to
- *     observe the signal — buildSandbox does (its `executeBuild` is
- *     abort-aware).
+ *   - **Coalescing**: a fresh `enqueue(draftId, …, { coalesceKey })` whose
+ *     `coalesceKey` matches an already-queued-or-running entry aborts the
+ *     prior entry (`AbortController.abort`) and takes its slot. The
+ *     displaced entry's promise resolves with a BuildFailure of reason
+ *     `'abort'`. Build functions are expected to observe the signal —
+ *     buildSandbox does (its `executeBuild` is abort-aware).
+ *
+ *     `coalesceKey` defaults to `draftId`, which is the right semantic for
+ *     debounced preview rebuilds: the latest spec wins, stale rebuilds drop.
+ *     Callers that must NOT be aborted by parallel operations on the same
+ *     draft (install commit; manual rebuild kicked off while a debounced
+ *     rebuild is in flight) pass a distinct key like `${draftId}:install`,
+ *     so the queue treats the two operations as independent entries that
+ *     can run side-by-side under the concurrency cap.
  *   - **State callbacks**: optional `onStateChange(draftId, phase, queuePos?)`
  *     fires for `'queued' | 'building' | 'ok' | 'failed' | 'aborted'`. Used
  *     by the SSE bridge in B.3/B.5 to surface progress to the workspace UI.
+ *     Notifications always carry the bare `draftId`, regardless of which
+ *     coalesce key the entry was enqueued under, so the SSE consumer keeps
+ *     a single per-draft event stream.
  *   - **Graceful drain**: `drain(timeoutMs)` rejects all waiters, lets
  *     running builds finish up to the timeout, then force-aborts. Hook into
  *     `SIGTERM` / Fly machine stop.
@@ -37,9 +48,21 @@ export interface DrainResult {
 
 interface BaseEntry {
   draftId: string;
+  coalesceKey: string;
   buildFn: QueueBuildFn;
   resolve: (r: BuildResult) => void;
   abortCtrl: AbortController;
+}
+
+export interface EnqueueOptions {
+  /**
+   * Identifier used for queue coalescing. A fresh enqueue whose
+   * `coalesceKey` matches an existing entry aborts that entry. Defaults
+   * to `draftId`. Pass `${draftId}:install` (etc.) when the operation
+   * must coexist with a debounced preview rebuild for the same draft
+   * instead of being killed by it.
+   */
+  coalesceKey?: string;
 }
 
 interface QueuedEntry extends BaseEntry {
@@ -71,8 +94,8 @@ function abortFailure(): BuildFailure {
 export class BuildQueue {
   private readonly waiting: QueuedEntry[] = [];
   private readonly running = new Map<string, RunningEntry>();
-  /** Either-or index: a draftId points to its waiting OR running entry. */
-  private readonly byDraft = new Map<string, Entry>();
+  /** Either-or index: a coalesce key points to its waiting OR running entry. */
+  private readonly byKey = new Map<string, Entry>();
   private readonly concurrency: number;
   private readonly onStateChange?: BuildQueueOptions['onStateChange'];
   private draining = false;
@@ -82,16 +105,24 @@ export class BuildQueue {
     this.onStateChange = opts.onStateChange;
   }
 
-  enqueue(draftId: string, buildFn: QueueBuildFn): Promise<BuildResult> {
+  enqueue(
+    draftId: string,
+    buildFn: QueueBuildFn,
+    opts: EnqueueOptions = {},
+  ): Promise<BuildResult> {
     if (this.draining) {
       return Promise.resolve(abortFailure());
     }
 
+    const coalesceKey = opts.coalesceKey ?? draftId;
+
     return new Promise<BuildResult>((resolve) => {
       const abortCtrl = new AbortController();
 
-      // Coalesce against any existing entry for this draftId.
-      const existing = this.byDraft.get(draftId);
+      // Coalesce against any existing entry that shares this coalesceKey.
+      // Entries on the same draft but different keys (e.g. install vs
+      // preview rebuild) are independent and do not abort each other.
+      const existing = this.byKey.get(coalesceKey);
       if (existing) {
         existing.abortCtrl.abort();
         if (existing.state === 'queued') {
@@ -108,12 +139,13 @@ export class BuildQueue {
 
       const queued: QueuedEntry = {
         draftId,
+        coalesceKey,
         buildFn,
         resolve,
         abortCtrl,
         state: 'queued',
       };
-      this.byDraft.set(draftId, queued);
+      this.byKey.set(coalesceKey, queued);
       this.waiting.push(queued);
 
       this.notifyState(draftId, 'queued', this.computeQueuePos(queued));
@@ -130,20 +162,21 @@ export class BuildQueue {
       const next = this.waiting.shift()!;
       const running: RunningEntry = {
         draftId: next.draftId,
+        coalesceKey: next.coalesceKey,
         buildFn: next.buildFn,
         resolve: next.resolve,
         abortCtrl: next.abortCtrl,
         state: 'running',
         startedAt: Date.now(),
       };
-      this.running.set(next.draftId, running);
-      // byDraft was pointing at the queued entry — overwrite with running.
-      // (If a coalesce happened in the meantime, byDraft already points at
+      this.running.set(next.coalesceKey, running);
+      // byKey was pointing at the queued entry — overwrite with running.
+      // (If a coalesce happened in the meantime, byKey already points at
       // the newer queued entry; in that case `next` is the displaced one
       // whose promise was already settled, but we still drained it from
       // `waiting` above, so this is just defensive.)
-      if (this.byDraft.get(next.draftId) === next) {
-        this.byDraft.set(next.draftId, running);
+      if (this.byKey.get(next.coalesceKey) === next) {
+        this.byKey.set(next.coalesceKey, running);
       }
       this.notifyState(next.draftId, 'building');
       void this.runEntry(running);
@@ -175,9 +208,9 @@ export class BuildQueue {
       result = { ...result, reason: 'abort' };
     }
 
-    this.running.delete(entry.draftId);
-    if (this.byDraft.get(entry.draftId) === entry) {
-      this.byDraft.delete(entry.draftId);
+    this.running.delete(entry.coalesceKey);
+    if (this.byKey.get(entry.coalesceKey) === entry) {
+      this.byKey.delete(entry.coalesceKey);
     }
 
     entry.resolve(result);
@@ -211,8 +244,8 @@ export class BuildQueue {
     // Settle all waiters as aborted.
     for (const w of this.waiting) {
       w.resolve(abortFailure());
-      if (this.byDraft.get(w.draftId) === w) {
-        this.byDraft.delete(w.draftId);
+      if (this.byKey.get(w.coalesceKey) === w) {
+        this.byKey.delete(w.coalesceKey);
       }
     }
     this.waiting.length = 0;

--- a/middleware/src/plugins/builder/installCommit.ts
+++ b/middleware/src/plugins/builder/installCommit.ts
@@ -93,7 +93,11 @@ export async function installDraft(
   // Step 1: build pipeline (load draft → codegen → sandbox).
   let pipelineResult;
   try {
-    pipelineResult = await deps.buildPipeline.run({ userEmail, draftId });
+    pipelineResult = await deps.buildPipeline.run({
+      userEmail,
+      draftId,
+      kind: 'install',
+    });
   } catch (err) {
     if (err instanceof BuildPipelineError) {
       return mapPipelineError(err);

--- a/middleware/test/builder/buildPipelineService.test.ts
+++ b/middleware/test/builder/buildPipelineService.test.ts
@@ -332,6 +332,83 @@ describe('BuildPipeline', () => {
     assert.equal(observedSignal?.aborted, false);
   });
 
+  it('runs install + preview rebuild for the same draft in parallel (kind separates coalesce keys)', async () => {
+    // Regression for `builder.build_failed.abort` after a version bump:
+    // before the fix, an install in flight got aborted by a debounced
+    // preview rebuild that happened to fire while tsc was still running,
+    // because BuildQueue coalesced by draftId alone. Now `kind: 'install'`
+    // uses coalesceKey `${draftId}:install`, so the two coexist.
+    const { spec, slots } = loadFixtureSpec();
+    const draft = await store.create('alice@example.com', 'Weather');
+    await store.update('alice@example.com', draft.id, { spec, slots });
+
+    const queue = new BuildQueue({ concurrency: 3 });
+
+    // Gate both sandbox calls so they're "running" concurrently — that's
+    // the exact race condition that used to abort the install.
+    let releaseInstall!: () => void;
+    let releasePreview!: () => void;
+    const installRunning = new Promise<void>((r) => (releaseInstall = r));
+    const previewRunning = new Promise<void>((r) => (releasePreview = r));
+    let installSandboxCalls = 0;
+    let previewSandboxCalls = 0;
+    let installAborted = false;
+    let previewAborted = false;
+    let installEntered = false;
+    let previewEntered = false;
+
+    const pipeline = new BuildPipeline({
+      draftStore: store,
+      buildQueue: queue,
+      templateRoot,
+      stagingBaseDir,
+      buildSandbox: async (opts) => {
+        // First call = install (started first below); second = preview.
+        const isInstall = !installEntered;
+        if (isInstall) {
+          installEntered = true;
+          installSandboxCalls += 1;
+          await installRunning;
+          installAborted = opts.signal?.aborted ?? false;
+        } else {
+          previewEntered = true;
+          previewSandboxCalls += 1;
+          await previewRunning;
+          previewAborted = opts.signal?.aborted ?? false;
+        }
+        return makeBuildSuccess();
+      },
+      logger: () => {},
+    });
+
+    const pInstall = pipeline.run({
+      userEmail: 'alice@example.com',
+      draftId: draft.id,
+      kind: 'install',
+    });
+    // Wait until the install is actually inside buildSandbox, then race
+    // a preview rebuild against it. Without the kind/coalesceKey fix the
+    // preview enqueue would abort the install at this exact point.
+    while (!installEntered) await new Promise((r) => setImmediate(r));
+    const pPreview = pipeline.run({
+      userEmail: 'alice@example.com',
+      draftId: draft.id,
+      // kind defaults to 'preview'
+    });
+    while (!previewEntered) await new Promise((r) => setImmediate(r));
+
+    releaseInstall();
+    releasePreview();
+
+    const [rInstall, rPreview] = await Promise.all([pInstall, pPreview]);
+    assert.equal(installSandboxCalls, 1);
+    assert.equal(previewSandboxCalls, 1);
+    assert.equal(installAborted, false, 'install must not be aborted by preview');
+    assert.equal(previewAborted, false, 'preview must not be aborted by install');
+    assert.equal(rInstall.buildResult.ok, true);
+    assert.equal(rPreview.buildResult.ok, true);
+  });
+
   it('does not leak staging dirs when many runs happen in parallel', async () => {
     const { spec, slots } = loadFixtureSpec();
     const draft = await store.create('alice@example.com', 'Weather');

--- a/middleware/test/builder/buildQueue.test.ts
+++ b/middleware/test/builder/buildQueue.test.ts
@@ -161,6 +161,100 @@ describe('BuildQueue', () => {
       await pNew;
     });
 
+    it('does NOT abort across distinct coalesceKeys on the same draftId', async () => {
+      // Regression: an install (kind='install', coalesceKey='d1:install')
+      // running alongside a debounced preview rebuild (kind='preview',
+      // coalesceKey='d1') used to abort one another because both shared
+      // the per-draft slot. Now they coexist under the concurrency cap
+      // and only coalesce against entries with the same coalesceKey.
+      const q = new BuildQueue({ concurrency: 3 });
+      const install = controlledBuild();
+      const preview = controlledBuild();
+
+      const pInstall = q.enqueue('d1', install.fn, { coalesceKey: 'd1:install' });
+      const pPreview = q.enqueue('d1', preview.fn);
+      await tick();
+
+      assert.equal(install.started(), true);
+      assert.equal(preview.started(), true);
+      assert.equal(install.signal()?.aborted, false);
+      assert.equal(preview.signal()?.aborted, false);
+      assert.equal(q.runningSize, 2);
+
+      install.finishOk();
+      preview.finishOk();
+      const [ri, rp] = await Promise.all([pInstall, pPreview]);
+      assert.equal(ri.ok, true);
+      assert.equal(rp.ok, true);
+    });
+
+    it('still coalesces preview rebuilds with each other (default key)', async () => {
+      // Two debounced preview rebuilds for the same draft should still
+      // coalesce — the latest spec wins, the older one drops as 'abort'.
+      const q = new BuildQueue({ concurrency: 2 });
+      const oldRebuild = controlledBuild();
+      const newRebuild = controlledBuild();
+
+      const pOld = q.enqueue('d1', oldRebuild.fn);
+      await tick();
+      assert.equal(oldRebuild.started(), true);
+
+      const pNew = q.enqueue('d1', newRebuild.fn);
+      await tick();
+      assert.equal(oldRebuild.signal()?.aborted, true);
+
+      oldRebuild.finish({
+        ok: false,
+        errors: [],
+        exitCode: null,
+        stdoutTail: '',
+        stderrTail: '',
+        durationMs: 1,
+        reason: 'abort',
+      });
+      const ro = await pOld;
+      assert.equal(ro.ok, false);
+      if (!ro.ok) assert.equal(ro.reason, 'abort');
+
+      newRebuild.finishOk();
+      const rn = await pNew;
+      assert.equal(rn.ok, true);
+    });
+
+    it('coalesces two installs against each other (same install key)', async () => {
+      // Defensive: if the operator clicks "Install" twice in rapid
+      // succession, the newer install replaces the older one.
+      const q = new BuildQueue({ concurrency: 2 });
+      const first = controlledBuild();
+      const second = controlledBuild();
+      const opts = { coalesceKey: 'd1:install' };
+
+      const pFirst = q.enqueue('d1', first.fn, opts);
+      await tick();
+      assert.equal(first.started(), true);
+
+      const pSecond = q.enqueue('d1', second.fn, opts);
+      await tick();
+      assert.equal(first.signal()?.aborted, true);
+
+      first.finish({
+        ok: false,
+        errors: [],
+        exitCode: null,
+        stdoutTail: '',
+        stderrTail: '',
+        durationMs: 1,
+        reason: 'abort',
+      });
+      const rf = await pFirst;
+      assert.equal(rf.ok, false);
+      if (!rf.ok) assert.equal(rf.reason, 'abort');
+
+      second.finishOk();
+      const rs = await pSecond;
+      assert.equal(rs.ok, true);
+    });
+
     it('re-tags non-abort failures as abort when the signal was aborted', async () => {
       const q = new BuildQueue({ concurrency: 1 });
       const old = controlledBuild();

--- a/middleware/test/builder/installCommit.test.ts
+++ b/middleware/test/builder/installCommit.test.ts
@@ -45,10 +45,18 @@ function makeFakePipeline(opts: {
   /** Custom zip buffer to return on success. */
   zipBytes?: Buffer;
 }): FakePipelineHandle {
-  const calls: Array<{ userEmail: string; draftId: string }> = [];
+  const calls: Array<{
+    userEmail: string;
+    draftId: string;
+    kind?: 'install' | 'preview';
+  }> = [];
   let buildN = 0;
   const fake = {
-    run: async (input: { userEmail: string; draftId: string }) => {
+    run: async (input: {
+      userEmail: string;
+      draftId: string;
+      kind?: 'install' | 'preview';
+    }) => {
       calls.push(input);
       buildN += 1;
       if (opts.pipelineDraftMissing) {
@@ -259,6 +267,10 @@ describe('installDraft (B.6-1 orchestrator)', () => {
 
     // Pipeline + ingest each saw exactly one call.
     assert.equal(pipeline.buildCalls().length, 1);
+    // Regression: install must pass `kind: 'install'` so BuildQueue uses
+    // a distinct coalesce key and a debounced preview rebuild cannot
+    // abort the install (builder.build_failed.abort).
+    assert.equal(pipeline.buildCalls()[0]?.kind, 'install');
     const ingestCall = ingest.ingestCalls()[0];
     assert.ok(ingestCall);
     assert.equal(ingestCall.uploadedBy, h.userEmail);


### PR DESCRIPTION
## Summary

- **Bug**: After a version bump, the next install fails with `BUILDER.BUILD_FAILED.ABORT` (`tsc/build failed reason=abort, exit=null`). Re-installing without a rebuild succeeds.
- **Root cause**: `InstallDiffModal` PATCHes `spec.version` then immediately POSTs install. The PATCH schedules a 2s-debounced preview rebuild (`builderEdit.ts:91`). While the install's tsc is still running, the rebuild fires and `BuildQueue.enqueue` coalesces by `draftId` → aborts the running install. The second install hits no pending rebuild, so it succeeds.
- **Fix**: Give install and preview their own queue coalesce keys so they coexist under the concurrency cap. `BuildQueue.enqueue` gains an optional `{ coalesceKey }` (defaults to `draftId`); `BuildPipeline.run` gains `kind?: 'preview' | 'install'`; install uses `${draftId}:install`. Preview-vs-preview coalescing (latest spec wins) is preserved.

## Test plan

- [x] 4 new regression tests cover: distinct coalesceKeys coexist, default key still coalesces preview rebuilds, two installs still coalesce, install passes `kind: 'install'` through the pipeline, and an end-to-end pipeline test that races install + preview rebuild on the same draft.
- [x] **TDD verified**: reverted the `BuildPipeline.run` change and confirmed the new pipeline test fails with `install must not be aborted by preview — true !== false` (`signal.aborted=true` on the install's child process — the upstream of `reason=abort, exit=null`). Re-applied the fix; test passes.
- [x] Full builder test suite **874/874 pass** (2 pre-existing skips), `npx tsc --noEmit` clean, ESLint clean.
- [ ] Live smoke: version bump in InstallDiffModal → install → success on first try.