### PR TITLE
docs(changelog): record engineering-standards rollout and CI resurrection

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- byte5ai engineering-standards applied to the repo
+  (`status: applied` in `.github/engineering-standards.yml`):
+  - `.hooks/pre-push` blocks direct pushes to `main`/`master` locally.
+  - `script/setup` activates the hook and runs the npm bootstrap in one step.
+  - AGENTS.md gained a "Git Workflow & Engineering Standards" section.
+  - CONTRIBUTING.md documents the pre-push guard and forbids
+    `Co-Authored-By:` trailers for AI agents.
+  - Server-side branch protection on `main`: pull request required,
+    force-push and deletion blocked, all five CI workflow contexts wired
+    up as required status checks.
+- GitHub Actions re-enabled after the 2026-05-11 outage; first
+  post-reactivation runs landed green on the same day.
+
 ### Changed
 
 - `docs/CHANGELOG.md` reformatted to follow the Keep-a-Changelog convention.
@@ -19,6 +34,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without incident-specific identifiers.
 - Sanitised `middleware/packages/harness-diagrams` package metadata to remove
   internal hostnames and branding.
+
+### Fixed
+
+- CI pipeline brought back to green after the Actions outage:
+  - `actions/setup-node` bumped from `20` to `22` to match
+    `middleware/package.json` `engines.node ">=22 <23"`.
+  - `schema (migrations on pgvector)` job moved from a stale hardcoded
+    list to a glob over five migration domains; coverage went from 9 to
+    20 migrations and is now self-updating.
+  - `sharp` linux-x64 native binary installed explicitly so the diagram
+    test suite can load on CI runners.
+  - `middleware/src/index.ts` `prefer-const` false-positive on an
+    intentional forward reference suppressed with a documented disable.
+- Middleware test suite cleared of stale workshop-vs-public drift: back
+  to 2168 passing / 0 failing (7 tests carry `it.skip()` with TODO
+  comments documenting root cause — tracked separately for follow-up
+  if/when operationally relevant).
 
 ---
 


### PR DESCRIPTION
## Summary

Backfills the `Unreleased` section of `docs/CHANGELOG.md` with the operational changes that landed on 2026-05-17 but were never captured in the changelog:

- **Added** — byte5ai engineering-standards adoption (PR #31): pre-push hook, setup script, AGENTS.md / CONTRIBUTING.md updates, server-side branch protection. Plus the GitHub Actions re-enable after the 2026-05-11 outage.
- **Fixed** — CI pipeline resurrection: node-version bump 20→22, schema-smoke glob over five migration domains, sharp linux-x64 native binary install, prefer-const false-positive in `middleware/src/index.ts`. Plus the broader test-suite consolidation that cleared the workshop-vs-public drift (back to 2168 passing / 0 failing, 7 documented `it.skip`s).

The earlier consolidated CI PR (#35) had a cherry-pick of these CHANGELOG edits on its branch, but only the `ci.yml` commits survived the squash-merge into `main`. This PR re-applies the docs portion against the current main.

Pure docs change — no impact on code, tests, or runtime behaviour. The existing `Changed` block is left untouched.

## Test plan

- [ ] All 5 required status checks green (no changes outside `docs/CHANGELOG.md` — should be a clean pass)