### PR TITLE
fix(privacy-guard): restore Platz/Rang/Position/Rank self-anonymization labels

### DIFF
--- a/middleware/packages/harness-plugin-privacy-guard/src/selfAnonymization.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/selfAnonymization.ts
@@ -57,6 +57,13 @@
  *   - `Employee\s+\d+`         — English form
  *   - `Person\s+\d+`           — Language-neutral form
  *   - `Anonym\s+\d+`           — German "Anonym 1/2/3" pattern
+ *   - `Platz\s+\d+`            — German "Platz 1/2/3" (ranking tables —
+ *                                live HR-Urlaubsranking failure mode
+ *                                2026-05-17 where the LLM rewrote
+ *                                tokens to positional ranks)
+ *   - `Rang\s+\d+`             — German "Rang 1/2/3" alt-spelling
+ *   - `Position\s+\d+`         — German/English "Position 1/2/3"
+ *   - `Rank\s+\d+`             — English "Rank 1/2/3" form
  *
  * Numbered-letter variants (`Mitarbeiter A/B/C`, `Person A/B/C`) are
  * intentionally NOT covered in this version — they are observed less
@@ -125,6 +132,10 @@ const PATTERNS: ReadonlyArray<{ readonly keyword: string; readonly regex: RegExp
   { keyword: 'employee', regex: /\bEmployee\s+(\d+)\b/g },
   { keyword: 'person', regex: /\bPerson\s+(\d+)\b/g },
   { keyword: 'anonym', regex: /\bAnonym\s+(\d+)\b/g },
+  { keyword: 'platz', regex: /\bPlatz\s+(\d+)\b/g },
+  { keyword: 'rang', regex: /\bRang\s+(\d+)\b/g },
+  { keyword: 'position', regex: /\bPosition\s+(\d+)\b/g },
+  { keyword: 'rank', regex: /\bRank\s+(\d+)\b/g },
 ];
 
 /**

--- a/middleware/packages/harness-plugin-privacy-guard/src/service.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/service.ts
@@ -1587,8 +1587,8 @@ Your job with tokens is to pass them through verbatim. You are NOT the
 privacy actor — the shield is. Specifically:
 
   - Never replace \`«PERSON_N»\` with self-invented labels like
-    "Mitarbeiter 1", "Employee A", "Person X", "Platz 1", "Rang 1",
-    "Position 1", or "Rank 1". Use the literal token.
+    "Mitarbeiter 1", "Employee A", "Person X", or "Platz 1". Use the
+    literal token.
   - Never append a privacy / DSGVO / GDPR disclaimer explaining why
     names were "withheld" or "filtered". The user already knows.
 
@@ -1601,22 +1601,6 @@ privacy actor — the shield is. Specifically:
     assistant (correct):
         | «PERSON_1»    | …
         | «PERSON_2»    | …
-        — tokens verbatim; the shield restores after you finish.
-
-  Example 7 — observed live (HR Urlaubsranking, 2026-05-17):
-    tool result: [
-      { "name": "«PERSON_1»", "days": 17 },
-      { "name": "«PERSON_2»", "days": 16.69 }
-    ]
-    assistant (WRONG) — uses positional ranking labels:
-        | Rang | Mitarbeiter | PTO-Tage |
-        | 1    | Platz 1     | 17.00    |   ← invented positional label
-        | 2    | Platz 2     | 16.69    |   ← invented positional label
-        Der HR-Agent hat die Namen intern anonymisiert.  ← do not write
-    assistant (correct):
-        | Rang | Mitarbeiter | PTO-Tage |
-        | 1    | «PERSON_1»  | 17.00    |
-        | 2    | «PERSON_2»  | 16.69    |
         — tokens verbatim; the shield restores after you finish.
 
 Degenerate-case handling — Token-Storm:

--- a/middleware/packages/harness-plugin-privacy-guard/src/service.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/service.ts
@@ -1587,7 +1587,8 @@ Your job with tokens is to pass them through verbatim. You are NOT the
 privacy actor — the shield is. Specifically:
 
   - Never replace \`«PERSON_N»\` with self-invented labels like
-    "Mitarbeiter 1", "Employee A", or "Person X". Use the literal token.
+    "Mitarbeiter 1", "Employee A", "Person X", "Platz 1", "Rang 1",
+    "Position 1", or "Rank 1". Use the literal token.
   - Never append a privacy / DSGVO / GDPR disclaimer explaining why
     names were "withheld" or "filtered". The user already knows.
 
@@ -1600,6 +1601,22 @@ privacy actor — the shield is. Specifically:
     assistant (correct):
         | «PERSON_1»    | …
         | «PERSON_2»    | …
+        — tokens verbatim; the shield restores after you finish.
+
+  Example 7 — observed live (HR Urlaubsranking, 2026-05-17):
+    tool result: [
+      { "name": "«PERSON_1»", "days": 17 },
+      { "name": "«PERSON_2»", "days": 16.69 }
+    ]
+    assistant (WRONG) — uses positional ranking labels:
+        | Rang | Mitarbeiter | PTO-Tage |
+        | 1    | Platz 1     | 17.00    |   ← invented positional label
+        | 2    | Platz 2     | 16.69    |   ← invented positional label
+        Der HR-Agent hat die Namen intern anonymisiert.  ← do not write
+    assistant (correct):
+        | Rang | Mitarbeiter | PTO-Tage |
+        | 1    | «PERSON_1»  | 17.00    |
+        | 2    | «PERSON_2»  | 16.69    |
         — tokens verbatim; the shield restores after you finish.
 
 Degenerate-case handling — Token-Storm:

--- a/middleware/test/privacySelfAnonymization.test.ts
+++ b/middleware/test/privacySelfAnonymization.test.ts
@@ -206,6 +206,53 @@ describe('selfAnonymization · restoreSelfAnonymization (Phase A)', () => {
     assert.equal(result.restored, 2);
     assert.deepEqual([...result.patternsHit].sort(), ['employee', 'mitarbeiter']);
   });
+
+  // Live HR-Urlaubsranking failure 2026-05-17: the LLM rewrote tokenised
+  // person rows into positional ranking labels ("Platz 1", "Platz 2", …)
+  // when emitting a Markdown ranking table. The directive forbids the
+  // anti-pattern; this restorer is the mechanical safety net.
+  it('restores Platz/Rang/Position/Rank positional labels (HR ranking case)', () => {
+    const map = createTokenizeMap();
+    const tMarvin = map.tokenFor('Marvin Vomberg', 'pii.name');
+    const tSophie = map.tokenFor('Sophie Neumann', 'pii.name');
+    const tMarcel = map.tokenFor('Marcel Wege', 'pii.name');
+    const tDennis = map.tokenFor('Dennis Zille', 'pii.name');
+    const tokenOrder = [tMarvin, tSophie, tMarcel, tDennis];
+    const text =
+      '| Rang | Mitarbeiter | PTO-Tage |\n' +
+      '| 1 | Platz 1 | 17,00 |\n' +
+      '| 2 | Rang 2 | 16,69 |\n' +
+      '| 3 | Position 3 | 12,00 |\n' +
+      '| 4 | Rank 4 | 10,00 |';
+    const result = restoreSelfAnonymization(text, tokenOrder, map);
+    assert.equal(result.detected, 4);
+    assert.equal(result.restored, 4);
+    assert.ok(result.text.includes('Marvin Vomberg'));
+    assert.ok(result.text.includes('Sophie Neumann'));
+    assert.ok(result.text.includes('Marcel Wege'));
+    assert.ok(result.text.includes('Dennis Zille'));
+    assert.ok(!result.text.includes('Platz 1'));
+    assert.ok(!result.text.includes('Rang 2'));
+    assert.ok(!result.text.includes('Position 3'));
+    assert.ok(!result.text.includes('Rank 4'));
+    assert.deepEqual(
+      [...result.patternsHit].sort(),
+      ['platz', 'position', 'rang', 'rank'].sort(),
+    );
+  });
+
+  it('detects Platz/Rang/Position/Rank in detectSelfAnonymizationLabels', () => {
+    const text = 'Tabelle: Platz 1, Rang 2, Position 3, Rank 4.';
+    const hits = detectSelfAnonymizationLabels(text);
+    assert.deepEqual(
+      hits.map((h) => h.keyword),
+      ['platz', 'rang', 'position', 'rank'],
+    );
+    assert.deepEqual(
+      hits.map((h) => h.index),
+      [1, 2, 3, 4],
+    );
+  });
 });
 
 describe('selfAnonymization · restoreUnresolvedPersonTokens (Phase A.1)', () => {


### PR DESCRIPTION
## Summary

- Smoke-test of HR-Urlaubsranking surfaced unrestored `«PERSON_N»` tokens beside leaked surnames (e.g. `«PERSON_53» Vomberg`) in the assistant's iteration text, and a final user answer that replaced the data rows with self-invented positional labels (`Platz 1`, `Platz 2`, …) instead of tokens that the privacy shield could resolve.
- The mechanical positional restorer (`restoreSelfAnonymization`) already covers `Mitarbeiter / Mitarbeiterin / Kollege / Kollegin / Employee / Person / Anonym` but did not know about ranking variants — so once the LLM evaded the directive with `Platz N`, no restorer was on duty.
- Adds `Platz / Rang / Position / Rank` to the pattern set, hardens the privacy directive with an explicit Example 7 (live failure 2026-05-17), and locks the behaviour in with two regression tests.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npx tsx --test test/privacySelfAnonymization.test.ts` → 27/27 (incl. 2 new)
- [x] Adjacent suites: `privacyValidatorRetry`, `privacyOutputValidator`, `privacyToolRoundtrip`, `privacyEgressFilter` → 33/33 + 1 pre-existing skip
- [ ] Live smoke: re-run the HR-Urlaubsranking-Routine in production after deploy, confirm the table shows real names from the Odoo tool call (no `Platz N`, no surviving `«PERSON_N»`).