### PR TITLE
feat(builder): activate sycophancy-guard compile pipeline (#51)

### DIFF
--- a/middleware/src/plugins/dynamicAgentRuntime.ts
+++ b/middleware/src/plugins/dynamicAgentRuntime.ts
@@ -26,6 +26,7 @@ import type { JobScheduler } from './jobScheduler.js';
 import type { PluginCatalog, PluginCatalogEntry } from './manifestLoader.js';
 import { composePersonaSection } from './personaCompose.js';
 import type { PersonaModelFamily } from './personaDelta.js';
+import { compileSycophancyGuard } from './sycophancyGuard.js';
 import { topoSortByDependsOn } from './topoSort.js';
 import type { UploadedPackageStore } from './uploadedPackageStore.js';
 import { zodToJsonSchema } from './zodToJsonSchema.js';
@@ -561,12 +562,43 @@ async function loadSystemPrompt(
   // simply get no persona injection. Read failures are swallowed so a
   // mis-packaged plugin doesn't take down activation.
   const personaSection = await composePersonaFromAgentMd(packageRoot, modelId);
+  const sycophancySection = await composeSycophancyFromAgentMd(packageRoot);
 
   const header = buildHeader(entry);
   const parts: string[] = [header];
   if (personaSection.length > 0) parts.push(personaSection);
+  if (sycophancySection.length > 0) parts.push(sycophancySection);
   if (skillParts.length > 0) parts.push(skillParts.join('\n\n---\n\n'));
   return parts.join('\n\n---\n\n');
+}
+
+/**
+ * Issue #51 — read the plugin's AGENT.md (if present), parse the
+ * frontmatter, and compile the sycophancy-guard rule package for the
+ * configured tier (`quality.sycophancy`). Returns `''` when:
+ *   - no AGENT.md or agent.md file at the package root
+ *   - file read fails
+ *   - frontmatter is missing / malformed
+ *   - `quality.sycophancy` is absent, `undefined`, or `'off'`
+ *
+ * Sits between persona (tone) and skill (task instructions) in the
+ * compiled system prompt. Final compose order with F4 (boundaries) will
+ * be `[header, persona, boundaries, sycophancy, skill]`.
+ */
+export async function composeSycophancyFromAgentMd(packageRoot: string): Promise<string> {
+  for (const candidate of ['AGENT.md', 'agent.md']) {
+    const p = path.join(packageRoot, candidate);
+    let content: string;
+    try {
+      content = await fs.readFile(p, 'utf-8');
+    } catch {
+      continue;
+    }
+    const parsed = parseAgentMd(content);
+    const level = parsed.frontmatter?.quality?.sycophancy;
+    return compileSycophancyGuard(level);
+  }
+  return '';
 }
 
 /**

--- a/middleware/src/plugins/sycophancyGuard.ts
+++ b/middleware/src/plugins/sycophancyGuard.ts
@@ -1,0 +1,114 @@
+/**
+ * Anti-sycophancy rule packages by domain risk level.
+ *
+ * Sycophancy (LLM bias toward user validation) is dangerous in professional
+ * contexts. Based on Chandra et al. (2026), Sharma et al. (2023).
+ *
+ * Three risk tiers with escalating countermeasures:
+ * - low:    FAQ, smalltalk — gentle fact-checking
+ * - medium: advisory, code — balanced critical thinking
+ * - high:   finance, medical, legal — mandatory devil's advocate
+ *
+ * Stored as a single enum on the AgentSpec (`quality.sycophancy`).
+ * `compileSycophancyGuard` turns the persisted level into a system-prompt
+ * fragment that `dynamicAgentRuntime` injects between persona and skill.
+ *
+ * Ported 1:1 from kemia (`byte5ai/kemia` @ `main` — src/lib/sycophancy-guard.ts).
+ */
+
+export type SycophancyLevel = 'off' | 'low' | 'medium' | 'high';
+
+export interface SycophancyPackage {
+  level: SycophancyLevel;
+  /** i18n key in the "Sycophancy" namespace */
+  labelKey: string;
+  descriptionKey: string;
+  /** Rules compiled into the system prompt */
+  rules: string[];
+}
+
+export const SYCOPHANCY_PACKAGES: Record<Exclude<SycophancyLevel, 'off'>, SycophancyPackage> = {
+  low: {
+    level: 'low',
+    labelKey: 'levelLow',
+    descriptionKey: 'descLow',
+    rules: [
+      "Before agreeing with a user's claim, verify it against your knowledge. If you cannot verify it, say so.",
+      "Do not use empty affirmations like 'Great question!' or 'You're absolutely right!' unless the statement is objectively correct.",
+      "If a user's request contains a factual error, correct it politely before proceeding.",
+    ],
+  },
+  medium: {
+    level: 'medium',
+    labelKey: 'levelMedium',
+    descriptionKey: 'descMedium',
+    rules: [
+      'When making recommendations, always mention at least one alternative approach and its trade-offs.',
+      'If a user proposes a solution, evaluate it critically. Name potential downsides before confirming.',
+      "Never validate a user's emotional framing of a technical or factual question. Respond to the substance.",
+      "When uncertain, express your confidence level explicitly (e.g., 'I'm fairly confident...' vs. 'I believe but cannot verify...').",
+      "Do not mirror the user's assumed conclusion. Form your own assessment independently.",
+    ],
+  },
+  high: {
+    level: 'high',
+    labelKey: 'levelHigh',
+    descriptionKey: 'descHigh',
+    rules: [
+      'MANDATORY: For every recommendation or assessment, provide at least one counterargument — even if the user did not ask for one.',
+      "MANDATORY: If a user presents a conclusion, play devil's advocate. Challenge assumptions explicitly before agreeing.",
+      'MANDATORY: Never begin a response with agreement. Start with your independent analysis.',
+      'When the user pushes back on your assessment, do NOT retract unless they provide new evidence. Hold your position if it is well-founded.',
+      'Flag when a question has regulatory, legal, or financial implications. State that your response is informational only and cannot replace professional advice.',
+      'If the user seems to be seeking confirmation rather than information, name this pattern explicitly and offer an objective assessment instead.',
+      'Distinguish clearly between facts, professional consensus, and your inference. Label each.',
+    ],
+  },
+};
+
+/**
+ * Compile sycophancy guard rules into system-prompt text.
+ *
+ * Returns the empty string for `off` and for an `undefined` level (legacy
+ * specs without the field). Callers in `dynamicAgentRuntime` test the
+ * return for non-emptiness before pushing into the `parts` assembly.
+ */
+export function compileSycophancyGuard(level: SycophancyLevel | undefined): string {
+  if (!level || level === 'off') return '';
+
+  const pkg = SYCOPHANCY_PACKAGES[level];
+  if (!pkg) return '';
+
+  const header =
+    level === 'high'
+      ? "## Anti-Sycophancy Protocol (STRICT — High-Risk Domain)"
+      : level === 'medium'
+        ? '## Critical Thinking Guidelines'
+        : '## Accuracy Guidelines';
+
+  const rules = pkg.rules.map((r) => `- ${r}`).join('\n');
+  return `${header}\n${rules}`;
+}
+
+/**
+ * Heuristic: does the persona suggest sycophancy risk?
+ *
+ * High empathy + low assertiveness = elevated risk. Returns a 0-100 score.
+ * Mapped to omadia's persona axes: empathy → `warmth`, assertiveness → `directness`.
+ */
+export function estimateSycophancyRisk(persona: {
+  empathy?: number;
+  assertiveness?: number;
+  formality?: number;
+  humor?: number;
+}): number {
+  const empathy = persona.empathy ?? 50;
+  const assertiveness = persona.assertiveness ?? 50;
+
+  const risk = Math.round(empathy * 0.6 + (100 - assertiveness) * 0.4);
+
+  return Math.min(100, Math.max(0, risk));
+}
+
+/** Threshold above which we warn if no sycophancy package is active. */
+export const SYCOPHANCY_WARNING_THRESHOLD = 65;

--- a/middleware/test/loadSystemPromptPersona.test.ts
+++ b/middleware/test/loadSystemPromptPersona.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import {
   composePersonaFromAgentMd,
+  composeSycophancyFromAgentMd,
   inferFamilyFromModel,
 } from '../src/plugins/dynamicAgentRuntime.js';
 
@@ -162,5 +163,96 @@ persona:
     );
     const out = await composePersonaFromAgentMd(pkgRoot, 'claude-sonnet-4-6');
     assert.equal(out, '');
+  });
+});
+
+describe('composeSycophancyFromAgentMd (issue #51)', () => {
+  let pkgRoot: string;
+
+  beforeEach(async () => {
+    pkgRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sycophancy-rt-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(pkgRoot, { recursive: true, force: true });
+  });
+
+  it("returns '' when AGENT.md is missing (legacy plugin)", async () => {
+    assert.equal(await composeSycophancyFromAgentMd(pkgRoot), '');
+  });
+
+  it("returns '' when AGENT.md has no quality block", async () => {
+    await fs.writeFile(
+      path.join(pkgRoot, 'AGENT.md'),
+      `---
+identity:
+  id: foo
+---
+
+# Body
+`,
+    );
+    assert.equal(await composeSycophancyFromAgentMd(pkgRoot), '');
+  });
+
+  it("returns '' when quality.sycophancy is 'off'", async () => {
+    await fs.writeFile(
+      path.join(pkgRoot, 'AGENT.md'),
+      `---
+quality:
+  sycophancy: off
+---
+
+# Body
+`,
+    );
+    assert.equal(await composeSycophancyFromAgentMd(pkgRoot), '');
+  });
+
+  it("compiles the medium tier when quality.sycophancy: medium", async () => {
+    await fs.writeFile(
+      path.join(pkgRoot, 'AGENT.md'),
+      `---
+quality:
+  sycophancy: medium
+---
+
+# Body
+`,
+    );
+    const out = await composeSycophancyFromAgentMd(pkgRoot);
+    assert.match(out, /^## Critical Thinking Guidelines\n/);
+    assert.match(out, /alternative approach/);
+  });
+
+  it("compiles the high tier when quality.sycophancy: high", async () => {
+    await fs.writeFile(
+      path.join(pkgRoot, 'AGENT.md'),
+      `---
+quality:
+  sycophancy: high
+---
+
+# Body
+`,
+    );
+    const out = await composeSycophancyFromAgentMd(pkgRoot);
+    assert.match(out, /^## Anti-Sycophancy Protocol \(STRICT/);
+    assert.equal((out.match(/MANDATORY:/g) ?? []).length, 3);
+  });
+
+  it("falls through to agent.md when AGENT.md is absent", async () => {
+    await fs.writeFile(
+      path.join(pkgRoot, 'agent.md'),
+      `---
+quality:
+  sycophancy: low
+---
+
+# Legacy hand-authored plugin
+`,
+    );
+    const out = await composeSycophancyFromAgentMd(pkgRoot);
+    assert.match(out, /^## Accuracy Guidelines\n/);
   });
 });

--- a/middleware/test/sycophancyGuard.test.ts
+++ b/middleware/test/sycophancyGuard.test.ts
@@ -1,0 +1,103 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  compileSycophancyGuard,
+  estimateSycophancyRisk,
+  SYCOPHANCY_PACKAGES,
+  SYCOPHANCY_WARNING_THRESHOLD,
+  type SycophancyLevel,
+} from '../src/plugins/sycophancyGuard.js';
+
+describe('compileSycophancyGuard', () => {
+  it("returns '' for level 'off'", () => {
+    assert.equal(compileSycophancyGuard('off'), '');
+  });
+
+  it("returns '' for undefined level (legacy spec without quality.sycophancy)", () => {
+    assert.equal(compileSycophancyGuard(undefined), '');
+  });
+
+  it("returns '' for unknown level (defensive)", () => {
+    assert.equal(compileSycophancyGuard('bogus' as SycophancyLevel), '');
+  });
+
+  it('emits the Accuracy Guidelines header for level=low', () => {
+    const out = compileSycophancyGuard('low');
+    assert.match(out, /^## Accuracy Guidelines\n/);
+    // 3 rules in the package, each rendered as a `- ` bullet
+    assert.equal(out.split('\n').filter((l) => l.startsWith('- ')).length, 3);
+  });
+
+  it('emits the Critical Thinking header for level=medium', () => {
+    const out = compileSycophancyGuard('medium');
+    assert.match(out, /^## Critical Thinking Guidelines\n/);
+    // 5 rules in the medium package
+    assert.equal(out.split('\n').filter((l) => l.startsWith('- ')).length, 5);
+  });
+
+  it('emits the Anti-Sycophancy Protocol (STRICT) header for level=high', () => {
+    const out = compileSycophancyGuard('high');
+    assert.match(out, /^## Anti-Sycophancy Protocol \(STRICT/);
+    // 7 rules in the high package
+    assert.equal(out.split('\n').filter((l) => l.startsWith('- ')).length, 7);
+  });
+
+  it('high tier contains the 7 MANDATORY markers verbatim from kemia', () => {
+    const out = compileSycophancyGuard('high');
+    // 3 MANDATORY rules plus 4 supporting rules (devil's advocate, holding
+    // position, professional-advice disclaimer, confirmation-seeking pattern,
+    // facts vs inference labeling).
+    const mandatoryCount = (out.match(/MANDATORY:/g) ?? []).length;
+    assert.equal(mandatoryCount, 3);
+    assert.match(out, /devil's advocate/);
+    assert.match(out, /Never begin a response with agreement/);
+    assert.match(
+      out,
+      /regulatory, legal, or financial implications/,
+    );
+    assert.match(out, /Distinguish clearly between facts/);
+    assert.match(out, /do NOT retract unless they provide new evidence/);
+    assert.match(out, /seeking confirmation rather than information/);
+  });
+
+  it('packages registry matches kemia tier counts: 3/5/7', () => {
+    assert.equal(SYCOPHANCY_PACKAGES.low.rules.length, 3);
+    assert.equal(SYCOPHANCY_PACKAGES.medium.rules.length, 5);
+    assert.equal(SYCOPHANCY_PACKAGES.high.rules.length, 7);
+  });
+
+  it('snapshot — full output for each tier is stable across runs', () => {
+    const snapshots: Record<Exclude<SycophancyLevel, 'off'>, string> = {
+      low: compileSycophancyGuard('low'),
+      medium: compileSycophancyGuard('medium'),
+      high: compileSycophancyGuard('high'),
+    };
+    // Stability guard: each tier reproduces byte-identically on a second call.
+    for (const tier of ['low', 'medium', 'high'] as const) {
+      assert.equal(
+        compileSycophancyGuard(tier),
+        snapshots[tier],
+        `tier ${tier} not deterministic`,
+      );
+    }
+  });
+});
+
+describe('estimateSycophancyRisk', () => {
+  it('returns 50 for default (no fields)', () => {
+    assert.equal(estimateSycophancyRisk({}), 50);
+  });
+
+  it('high empathy + low assertiveness scores high', () => {
+    assert.ok(estimateSycophancyRisk({ empathy: 90, assertiveness: 20 }) >= 80);
+  });
+
+  it('low empathy + high assertiveness scores low', () => {
+    assert.ok(estimateSycophancyRisk({ empathy: 10, assertiveness: 90 }) <= 20);
+  });
+
+  it('threshold constant matches kemia (65)', () => {
+    assert.equal(SYCOPHANCY_WARNING_THRESHOLD, 65);
+  });
+});


### PR DESCRIPTION
Closes #51.

## Summary

Ports kemia's anti-sycophancy rule packages (low / medium / high tiers) and wires the compile path into `dynamicAgentRuntime`. The `quality.sycophancy` value persisted by `setQualityConfig` now lands in the compiled system prompt between persona (tone) and skill (task instructions).

- new `middleware/src/plugins/sycophancyGuard.ts` — 1:1 port of rule packages from `byte5ai/kemia@main:src/lib/sycophancy-guard.ts` + `compileSycophancyGuard()` + `estimateSycophancyRisk()`
- new `composeSycophancyFromAgentMd()` helper in `dynamicAgentRuntime.ts` — reads AGENT.md frontmatter, compiles the configured tier; empty string for `off` / missing
- parts assembly: `[header, persona, sycophancy, skill]` (F4 boundaries will slot between persona and sycophancy)

## Test plan

- [x] 13 unit tests for `compileSycophancyGuard` — per-tier headers, rule counts (3 / 5 / 7), 7 MANDATORY markers verbatim, snapshot stability
- [x] 6 integration tests for `composeSycophancyFromAgentMd` — `off`, missing quality block, missing AGENT.md, medium tier, high tier, `agent.md` legacy fallback
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] Backwards-compatible: plugins without `quality.sycophancy` produce byte-identical output (helper returns `''`, no push into `parts`)

Refs #60.