### PR TITLE
feat(builder): boundary preset library + section UI (#54)

### DIFF
--- a/middleware/src/plugins/builder/boundaryPresets.ts
+++ b/middleware/src/plugins/builder/boundaryPresets.ts
@@ -1,0 +1,205 @@
+/**
+ * Structured boundary presets for agent role configuration.
+ *
+ * Each preset maps to a kemia-curated prompt wording that
+ * `dynamicAgentRuntime` compiles into the system prompt between persona
+ * and sycophancy (compose order `[header, persona, boundaries, sycophancy, skill]`).
+ *
+ * Operators pick from this structured registry via the Builder UI;
+ * unknown IDs (legacy persisted values, future presets) are surfaced
+ * back as warnings rather than silently dropped.
+ *
+ * Ported 1:1 from `byte5ai/kemia` @ `main` (src/lib/boundary-presets.ts).
+ * The kemia source currently ships 12 presets across 4 categories:
+ *   - data:           4 (no-financial-data, no-pii, no-medical-data, no-legal-advice)
+ *   - scope:          3 (own-domain-only, no-code-execution, no-external-links)
+ *   - authority:      3 (no-discount-authority, no-commitments, no-personnel-decisions)
+ *   - communication:  2 (no-speculation, no-competitor-discussion)
+ *
+ * (Issue #54 mentions 14 presets in the design; the kemia registry as of
+ * `@main` carries 12. The integer is informational — the snapshot AC
+ * asserts byte-identical output for whatever kemia currently ships.)
+ *
+ * @see Issue #54
+ */
+
+export type BoundaryCategory = 'data' | 'scope' | 'authority' | 'communication';
+
+export interface BoundaryPreset {
+  /** Stable key, stored in the spec */
+  id: string;
+  /** Category for UI grouping */
+  category: BoundaryCategory;
+  /** i18n key in the "Boundaries" namespace */
+  labelKey: string;
+  /** Compiled prompt wording — kemia controls this, not the operator */
+  prompt: string;
+}
+
+export const BOUNDARY_PRESETS: readonly BoundaryPreset[] = [
+  // ── data ────────────────────────────────────────────────────────────────
+  {
+    id: 'no-financial-data',
+    category: 'data',
+    labelKey: 'presetNoFinancial',
+    prompt:
+      'You must NEVER access, process, or provide specific financial data, account balances, or transaction details. If asked, redirect to the appropriate financial department.',
+  },
+  {
+    id: 'no-pii',
+    category: 'data',
+    labelKey: 'presetNoPii',
+    prompt:
+      'You must NEVER collect, store, or process personally identifiable information (PII) such as names, addresses, phone numbers, social security numbers, or similar. If a user shares PII unsolicited, do not repeat or store it.',
+  },
+  {
+    id: 'no-medical-data',
+    category: 'data',
+    labelKey: 'presetNoMedical',
+    prompt:
+      'You must NEVER provide medical diagnoses, treatment recommendations, or interpret health data. Always redirect medical questions to qualified healthcare professionals.',
+  },
+  {
+    id: 'no-legal-advice',
+    category: 'data',
+    labelKey: 'presetNoLegal',
+    prompt:
+      'You must NEVER provide legal advice, interpret laws or contracts, or make recommendations that could be construed as legal counsel. Always recommend consulting a qualified attorney.',
+  },
+  // ── scope ───────────────────────────────────────────────────────────────
+  {
+    id: 'own-domain-only',
+    category: 'scope',
+    labelKey: 'presetOwnDomain',
+    prompt:
+      'You must strictly stay within your assigned domain and expertise area. If a question falls outside your scope, clearly state that it is outside your area of responsibility and suggest who might help.',
+  },
+  {
+    id: 'no-code-execution',
+    category: 'scope',
+    labelKey: 'presetNoCode',
+    prompt:
+      'You must NEVER generate, execute, or assist with writing code, scripts, or technical commands. Redirect technical requests to the development team.',
+  },
+  {
+    id: 'no-external-links',
+    category: 'scope',
+    labelKey: 'presetNoExternal',
+    prompt:
+      'You must NEVER provide external URLs, links, or references to third-party websites. Only reference internal documentation and resources.',
+  },
+  // ── authority ───────────────────────────────────────────────────────────
+  {
+    id: 'no-discount-authority',
+    category: 'authority',
+    labelKey: 'presetNoDiscount',
+    prompt:
+      'You do NOT have authority to offer, promise, or negotiate discounts, refunds, or pricing changes. All pricing decisions must be escalated to authorized personnel.',
+  },
+  {
+    id: 'no-commitments',
+    category: 'authority',
+    labelKey: 'presetNoCommitments',
+    prompt:
+      'You must NEVER make binding commitments, promises, or guarantees on behalf of the organization. You may provide information but not enter agreements.',
+  },
+  {
+    id: 'no-personnel-decisions',
+    category: 'authority',
+    labelKey: 'presetNoPersonnel',
+    prompt:
+      'You must NEVER make, suggest, or imply decisions about hiring, firing, promotions, or other personnel matters. These are strictly human-authority decisions.',
+  },
+  // ── communication ───────────────────────────────────────────────────────
+  {
+    id: 'no-speculation',
+    category: 'communication',
+    labelKey: 'presetNoSpeculation',
+    prompt:
+      "You must NEVER speculate or guess when you are uncertain. If you don't have confirmed information, say so explicitly rather than providing potentially incorrect answers.",
+  },
+  {
+    id: 'no-competitor-discussion',
+    category: 'communication',
+    labelKey: 'presetNoCompetitor',
+    prompt:
+      'You must NEVER discuss, compare, or comment on competitor products or services. If asked, politely redirect the conversation to your own offerings.',
+  },
+] as const;
+
+/**
+ * German label mapping — the resolver in `PersonaPillar.tsx` falls back
+ * to this when no i18n bundle is loaded. Keys mirror `labelKey` above.
+ *
+ * Kept inline (rather than a separate i18n bundle) for the Phase B.5
+ * port; a follow-up issue can move it to the proper translation layer.
+ */
+export const BOUNDARY_LABELS_DE: Readonly<Record<string, string>> = {
+  presetNoFinancial: 'Keine Finanzdaten',
+  presetNoPii: 'Keine personenbezogenen Daten (PII)',
+  presetNoMedical: 'Keine medizinischen Daten',
+  presetNoLegal: 'Keine Rechtsberatung',
+  presetOwnDomain: 'Nur eigene Domäne',
+  presetNoCode: 'Keine Code-Ausführung',
+  presetNoExternal: 'Keine externen Links',
+  presetNoDiscount: 'Keine Rabatt-Befugnis',
+  presetNoCommitments: 'Keine bindenden Zusagen',
+  presetNoPersonnel: 'Keine Personalentscheidungen',
+  presetNoSpeculation: 'Keine Spekulationen',
+  presetNoCompetitor: 'Keine Wettbewerber-Diskussion',
+};
+
+export function getBoundaryPreset(id: string): BoundaryPreset | undefined {
+  return BOUNDARY_PRESETS.find((p) => p.id === id);
+}
+
+/**
+ * Compile a list of boundary preset IDs + custom lines into prompt text.
+ *
+ * Unknown IDs are reported via `droppedIds`, not silently dropped, so the
+ * preview/quality panel and the `setQualityConfig` tool result can surface
+ * them to the operator.
+ */
+export function compileBoundaries(
+  presetIds: readonly string[],
+  customLines: readonly string[],
+): { text: string; droppedIds: string[] } {
+  const lines: string[] = [];
+  const droppedIds: string[] = [];
+
+  for (const id of presetIds) {
+    const preset = getBoundaryPreset(id);
+    if (preset) {
+      lines.push(preset.prompt);
+    } else {
+      droppedIds.push(id);
+    }
+  }
+
+  for (const custom of customLines) {
+    const trimmed = custom.trim();
+    if (trimmed.length > 0) {
+      lines.push(`You must NOT: ${trimmed}`);
+    }
+  }
+
+  return { text: lines.join('\n'), droppedIds };
+}
+
+/**
+ * Format `compileBoundaries` output as a system-prompt section.
+ * Returns `''` when there is no effective content so the caller can skip
+ * the section entirely and preserve byte-identical output for legacy
+ * specs without a `quality.boundaries` block.
+ */
+export function compileBoundariesSection(
+  presetIds: readonly string[],
+  customLines: readonly string[],
+): { text: string; droppedIds: string[] } {
+  const { text, droppedIds } = compileBoundaries(presetIds, customLines);
+  if (text.length === 0) return { text: '', droppedIds };
+  return {
+    text: `## Boundaries\n${text}`,
+    droppedIds,
+  };
+}

--- a/middleware/src/plugins/builder/tools/setQualityConfig.ts
+++ b/middleware/src/plugins/builder/tools/setQualityConfig.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { SycophancyLevelSpecSchema } from '../agentSpec.js';
+import { getBoundaryPreset } from '../boundaryPresets.js';
 import type { AgentSpecSkeleton } from '../types.js';
 import {
   IllegalSpecState,
@@ -53,6 +54,13 @@ interface OkResult {
   /** Echo of the persisted block — useful for the BuilderAgent's
    *  follow-up reasoning ("OK, sycophancy is now medium"). */
   quality: Input;
+  /**
+   * Non-fatal validation warnings — currently surfaces unknown boundary
+   * preset IDs. The spec is persisted as-submitted (forward compatible
+   * with future preset IDs); the UI renders an inline badge so the
+   * operator can correct typos before shipping. Absent when no warnings.
+   */
+  warnings?: string[];
 }
 
 interface ErrResult {
@@ -98,10 +106,21 @@ export const setQualityConfigTool: BuilderTool<Input, Result> = {
     });
     ctx.rebuildScheduler.schedule(ctx.userEmail, ctx.draftId);
 
-    return {
+    // Issue #54 — surface unknown boundary preset IDs as warnings (not as
+    // errors, so the spec round-trips for forward compatibility).
+    const unknownPresets =
+      input.boundaries?.presets?.filter((id) => !getBoundaryPreset(id)) ?? [];
+    const warnings =
+      unknownPresets.length > 0
+        ? unknownPresets.map((id) => `unknown preset: ${id}`)
+        : undefined;
+
+    const result: OkResult = {
       ok: true,
       applied: [...patches],
       quality: input,
     };
+    if (warnings) result.warnings = warnings;
+    return result;
   },
 };

--- a/middleware/src/plugins/dynamicAgentRuntime.ts
+++ b/middleware/src/plugins/dynamicAgentRuntime.ts
@@ -26,6 +26,7 @@ import type { JobScheduler } from './jobScheduler.js';
 import type { PluginCatalog, PluginCatalogEntry } from './manifestLoader.js';
 import { composePersonaSection } from './personaCompose.js';
 import type { PersonaModelFamily } from './personaDelta.js';
+import { compileBoundariesSection } from './builder/boundaryPresets.js';
 import { compileSycophancyGuard } from './sycophancyGuard.js';
 import { topoSortByDependsOn } from './topoSort.js';
 import type { UploadedPackageStore } from './uploadedPackageStore.js';
@@ -562,11 +563,13 @@ async function loadSystemPrompt(
   // simply get no persona injection. Read failures are swallowed so a
   // mis-packaged plugin doesn't take down activation.
   const personaSection = await composePersonaFromAgentMd(packageRoot, modelId);
+  const boundariesSection = await composeBoundariesFromAgentMd(packageRoot);
   const sycophancySection = await composeSycophancyFromAgentMd(packageRoot);
 
   const header = buildHeader(entry);
   const parts: string[] = [header];
   if (personaSection.length > 0) parts.push(personaSection);
+  if (boundariesSection.length > 0) parts.push(boundariesSection);
   if (sycophancySection.length > 0) parts.push(sycophancySection);
   if (skillParts.length > 0) parts.push(skillParts.join('\n\n---\n\n'));
   return parts.join('\n\n---\n\n');
@@ -597,6 +600,45 @@ export async function composeSycophancyFromAgentMd(packageRoot: string): Promise
     const parsed = parseAgentMd(content);
     const level = parsed.frontmatter?.quality?.sycophancy;
     return compileSycophancyGuard(level);
+  }
+  return '';
+}
+
+/**
+ * Issue #54 — read the plugin's AGENT.md (if present), parse the
+ * frontmatter, and compile the boundaries section (preset prompts +
+ * custom `You must NOT: …` lines). Returns `''` when:
+ *   - no AGENT.md or agent.md file at the package root
+ *   - file read fails
+ *   - frontmatter is missing / malformed
+ *   - `quality.boundaries` is absent or both `presets` and `custom` are empty
+ *
+ * Sits between persona (tone) and sycophancy (style) — boundaries are
+ * hard limits, sycophancy is stylistic. Final compose order:
+ * `[header, persona, boundaries, sycophancy, skill]`.
+ *
+ * Unknown preset IDs (legacy persisted values, or future kemia presets
+ * not yet ported) are silently skipped at runtime — the `setQualityConfig`
+ * tool surfaces them as warnings at edit time so the operator can act on
+ * them before they ship.
+ */
+export async function composeBoundariesFromAgentMd(packageRoot: string): Promise<string> {
+  for (const candidate of ['AGENT.md', 'agent.md']) {
+    const p = path.join(packageRoot, candidate);
+    let content: string;
+    try {
+      content = await fs.readFile(p, 'utf-8');
+    } catch {
+      continue;
+    }
+    const parsed = parseAgentMd(content);
+    const boundaries = parsed.frontmatter?.quality?.boundaries;
+    if (!boundaries) return '';
+    const { text } = compileBoundariesSection(
+      boundaries.presets ?? [],
+      boundaries.custom ?? [],
+    );
+    return text;
   }
   return '';
 }

--- a/middleware/test/boundaryPresets.test.ts
+++ b/middleware/test/boundaryPresets.test.ts
@@ -1,0 +1,120 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  BOUNDARY_PRESETS,
+  BOUNDARY_LABELS_DE,
+  compileBoundaries,
+  compileBoundariesSection,
+  getBoundaryPreset,
+} from '../src/plugins/builder/boundaryPresets.ts';
+
+describe('boundary preset registry (issue #54)', () => {
+  it('ships 12 presets across 4 categories (kemia @ main)', () => {
+    // The issue description mentions "14"; kemia currently ships 12.
+    // The byte-identical AC asserts whatever kemia carries — locking
+    // the count here to flag drift on either side.
+    assert.equal(BOUNDARY_PRESETS.length, 12);
+
+    const byCategory = {
+      data: 0,
+      scope: 0,
+      authority: 0,
+      communication: 0,
+    } as Record<string, number>;
+    for (const p of BOUNDARY_PRESETS) {
+      byCategory[p.category] = (byCategory[p.category] ?? 0) + 1;
+    }
+    assert.deepEqual(byCategory, {
+      data: 4,
+      scope: 3,
+      authority: 3,
+      communication: 2,
+    });
+  });
+
+  it('every preset id is unique', () => {
+    const ids = BOUNDARY_PRESETS.map((p) => p.id);
+    assert.equal(new Set(ids).size, ids.length, 'duplicate preset id');
+  });
+
+  it('every preset has a non-empty prompt and matching label key', () => {
+    for (const p of BOUNDARY_PRESETS) {
+      assert.ok(p.prompt.length > 0, `${p.id}: empty prompt`);
+      assert.match(p.labelKey, /^preset[A-Z]/, `${p.id}: bad labelKey`);
+      assert.ok(
+        BOUNDARY_LABELS_DE[p.labelKey],
+        `${p.id}: missing DE label for ${p.labelKey}`,
+      );
+    }
+  });
+
+  it('getBoundaryPreset returns undefined for unknown id', () => {
+    assert.equal(getBoundaryPreset('does-not-exist'), undefined);
+    assert.ok(getBoundaryPreset('no-pii'));
+  });
+});
+
+describe('compileBoundaries (issue #54)', () => {
+  it('returns empty text and no drops for empty input', () => {
+    const { text, droppedIds } = compileBoundaries([], []);
+    assert.equal(text, '');
+    assert.deepEqual(droppedIds, []);
+  });
+
+  it('joins preset prompts in input order, line-separated', () => {
+    const { text, droppedIds } = compileBoundaries(['no-pii', 'no-medical-data'], []);
+    assert.deepEqual(droppedIds, []);
+    assert.match(text, /personally identifiable information/);
+    assert.match(text, /medical diagnoses/);
+    // Ordering: no-pii prompt comes before no-medical-data prompt
+    const piiIdx = text.indexOf('personally identifiable');
+    const medIdx = text.indexOf('medical diagnoses');
+    assert.ok(piiIdx >= 0 && piiIdx < medIdx, 'preset order not preserved');
+  });
+
+  it('renders custom lines with the "You must NOT:" prefix, trimming whitespace', () => {
+    const { text } = compileBoundaries([], ['  promise refunds  ', '', 'leak internal data']);
+    assert.match(text, /You must NOT: promise refunds/);
+    assert.match(text, /You must NOT: leak internal data/);
+    // Empty / whitespace-only entries are skipped (do not produce a "You must NOT: " bare line)
+    assert.equal(text.split('You must NOT:').length - 1, 2);
+  });
+
+  it('reports unknown preset IDs via droppedIds instead of silently dropping', () => {
+    const { text, droppedIds } = compileBoundaries(
+      ['no-pii', 'unknown-thing', 'also-not-real', 'no-commitments'],
+      [],
+    );
+    assert.deepEqual(droppedIds, ['unknown-thing', 'also-not-real']);
+    // The two valid presets still made it through
+    assert.match(text, /personally identifiable information/);
+    assert.match(text, /binding commitments/);
+  });
+
+  it('snapshot — compileBoundaries output is deterministic across calls', () => {
+    const a = compileBoundaries(['no-pii', 'no-speculation'], ['be honest']);
+    const b = compileBoundaries(['no-pii', 'no-speculation'], ['be honest']);
+    assert.deepEqual(a, b);
+  });
+});
+
+describe('compileBoundariesSection (issue #54)', () => {
+  it("returns '' (and no droppedIds churn) when no presets and no custom lines", () => {
+    const { text, droppedIds } = compileBoundariesSection([], []);
+    assert.equal(text, '');
+    assert.deepEqual(droppedIds, []);
+  });
+
+  it('prepends a "## Boundaries" header when content is present', () => {
+    const { text } = compileBoundariesSection(['no-pii'], []);
+    assert.match(text, /^## Boundaries\n/);
+    assert.match(text, /personally identifiable information/);
+  });
+
+  it('byte-identical output for the same inputs (cache stability AC)', () => {
+    const a = compileBoundariesSection(['no-pii', 'no-legal-advice'], ['no off-topic chitchat']);
+    const b = compileBoundariesSection(['no-pii', 'no-legal-advice'], ['no off-topic chitchat']);
+    assert.equal(a.text, b.text);
+  });
+});

--- a/middleware/test/builder/tools/setQualityConfig.test.ts
+++ b/middleware/test/builder/tools/setQualityConfig.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { setQualityConfigTool } from '../../../src/plugins/builder/tools/setQualityConfig.js';
+import {
+  createBuilderToolHarness,
+  type BuilderToolHarness,
+} from '../fixtures/builderToolHarness.js';
+
+/**
+ * `set_quality_config` Builder-Tool tests.
+ *
+ * Covers the Phase-1 Kemia surface (sycophancy level + boundary presets
+ * + custom lines) plus the F4 (#54) warnings-for-unknown-presets path.
+ */
+describe('setQualityConfigTool', () => {
+  let harness: BuilderToolHarness;
+
+  beforeEach(async () => {
+    harness = await createBuilderToolHarness();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  it('writes spec.quality on the active draft + emits spec_patch + schedules rebuild', async () => {
+    const result = await setQualityConfigTool.run(
+      {
+        sycophancy: 'medium',
+        boundaries: {
+          presets: ['no-pii', 'no-medical-data'],
+          custom: ['no PII please'],
+        },
+      },
+      harness.context(),
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+
+    assert.deepEqual(result.applied, [
+      {
+        op: 'add',
+        path: '/quality',
+        value: {
+          sycophancy: 'medium',
+          boundaries: {
+            presets: ['no-pii', 'no-medical-data'],
+            custom: ['no PII please'],
+          },
+        },
+      },
+    ]);
+    assert.equal(result.warnings, undefined, 'no warnings expected for known IDs');
+
+    const reloaded = await harness.draftStore.load(
+      harness.userEmail,
+      harness.draftId,
+    );
+    assert.ok(reloaded);
+    assert.deepEqual(reloaded.spec.quality, {
+      sycophancy: 'medium',
+      boundaries: {
+        presets: ['no-pii', 'no-medical-data'],
+        custom: ['no PII please'],
+      },
+    });
+
+    assert.equal(harness.events.length, 1);
+    assert.equal(harness.events[0]!.type, 'spec_patch');
+    assert.equal(harness.rebuilds.length, 1);
+  });
+
+  it('persists as-submitted even when boundary preset IDs are unknown (forward compat)', async () => {
+    const result = await setQualityConfigTool.run(
+      {
+        boundaries: {
+          presets: ['no-pii', 'not-a-real-preset', 'also-bogus'],
+          custom: [],
+        },
+      },
+      harness.context(),
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+
+    // Spec persists exactly what was submitted — the unknown IDs survive
+    // so future kemia presets land cleanly without a migration.
+    const reloaded = await harness.draftStore.load(
+      harness.userEmail,
+      harness.draftId,
+    );
+    assert.ok(reloaded);
+    assert.deepEqual(reloaded.spec.quality?.boundaries?.presets, [
+      'no-pii',
+      'not-a-real-preset',
+      'also-bogus',
+    ]);
+  });
+
+  it('surfaces unknown preset IDs via warnings[]', async () => {
+    const result = await setQualityConfigTool.run(
+      {
+        boundaries: {
+          presets: ['no-pii', 'not-a-real-preset', 'also-bogus'],
+          custom: [],
+        },
+      },
+      harness.context(),
+    );
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.deepEqual(result.warnings, [
+      'unknown preset: not-a-real-preset',
+      'unknown preset: also-bogus',
+    ]);
+  });
+
+  it('emits no warnings when all preset IDs are known', async () => {
+    const result = await setQualityConfigTool.run(
+      {
+        sycophancy: 'high',
+        boundaries: { presets: ['no-pii', 'no-commitments'], custom: [] },
+      },
+      harness.context(),
+    );
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.warnings, undefined);
+  });
+
+  it('emits no warnings when boundaries block is absent', async () => {
+    const result = await setQualityConfigTool.run(
+      { sycophancy: 'low' },
+      harness.context(),
+    );
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.warnings, undefined);
+  });
+});

--- a/middleware/test/loadSystemPromptPersona.test.ts
+++ b/middleware/test/loadSystemPromptPersona.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import {
+  composeBoundariesFromAgentMd,
   composePersonaFromAgentMd,
   composeSycophancyFromAgentMd,
   inferFamilyFromModel,
@@ -254,5 +255,112 @@ quality:
     );
     const out = await composeSycophancyFromAgentMd(pkgRoot);
     assert.match(out, /^## Accuracy Guidelines\n/);
+  });
+});
+
+describe('composeBoundariesFromAgentMd (issue #54)', () => {
+  let pkgRoot: string;
+
+  beforeEach(async () => {
+    pkgRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'boundaries-rt-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(pkgRoot, { recursive: true, force: true });
+  });
+
+  it("returns '' when AGENT.md is missing (legacy plugin)", async () => {
+    assert.equal(await composeBoundariesFromAgentMd(pkgRoot), '');
+  });
+
+  it("returns '' when AGENT.md has no quality.boundaries block", async () => {
+    await fs.writeFile(
+      path.join(pkgRoot, 'AGENT.md'),
+      `---
+identity:
+  id: foo
+---
+
+# Body
+`,
+    );
+    assert.equal(await composeBoundariesFromAgentMd(pkgRoot), '');
+  });
+
+  it("returns '' when quality.boundaries has both presets and custom empty", async () => {
+    await fs.writeFile(
+      path.join(pkgRoot, 'AGENT.md'),
+      `---
+quality:
+  boundaries:
+    presets: []
+    custom: []
+---
+
+# Body
+`,
+    );
+    assert.equal(await composeBoundariesFromAgentMd(pkgRoot), '');
+  });
+
+  it('compiles the boundaries section from preset IDs', async () => {
+    await fs.writeFile(
+      path.join(pkgRoot, 'AGENT.md'),
+      `---
+quality:
+  boundaries:
+    presets:
+      - no-pii
+      - no-medical-data
+    custom: []
+---
+
+# Body
+`,
+    );
+    const out = await composeBoundariesFromAgentMd(pkgRoot);
+    assert.match(out, /^## Boundaries\n/);
+    assert.match(out, /personally identifiable information/);
+    assert.match(out, /medical diagnoses/);
+  });
+
+  it('includes custom "You must NOT:" lines after preset prompts', async () => {
+    await fs.writeFile(
+      path.join(pkgRoot, 'AGENT.md'),
+      `---
+quality:
+  boundaries:
+    presets:
+      - no-pii
+    custom:
+      - reveal staff names
+---
+
+# Body
+`,
+    );
+    const out = await composeBoundariesFromAgentMd(pkgRoot);
+    assert.match(out, /personally identifiable information/);
+    assert.match(out, /You must NOT: reveal staff names/);
+  });
+
+  it('silently skips unknown preset IDs at runtime (warnings are edit-time only)', async () => {
+    await fs.writeFile(
+      path.join(pkgRoot, 'AGENT.md'),
+      `---
+quality:
+  boundaries:
+    presets:
+      - no-pii
+      - does-not-exist
+    custom: []
+---
+
+# Body
+`,
+    );
+    const out = await composeBoundariesFromAgentMd(pkgRoot);
+    assert.match(out, /personally identifiable information/);
+    assert.equal(out.includes('does-not-exist'), false);
   });
 });

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -913,6 +913,27 @@ export async function setPersonaConfig(
 }
 
 /**
+ * Issue #54 — set the per-profile quality block (sycophancy level +
+ * boundary presets + custom lines) on a draft. Thin wrapper over
+ * `patchBuilderSpec`, mirroring the `setPersonaConfig` ergonomics.
+ *
+ * Unknown boundary preset IDs are not validated server-side here — the
+ * UI uses `findUnknownBoundaryPresets` (`boundaryPresets.ts`) against
+ * the local registry to surface the same warning before save. A future
+ * issue may add a dedicated `PATCH /drafts/:id/quality` route that
+ * round-trips the tool result (with warnings) instead of writing via
+ * the JSON-Patch surface.
+ */
+export async function setQualityConfig(
+  draftId: string,
+  config: import('./builderTypes').QualityConfig,
+): Promise<DraftEnvelope> {
+  return patchBuilderSpec(draftId, [
+    { op: 'add', path: '/quality', value: config },
+  ]);
+}
+
+/**
  * B.11-9: Server-side render of manifest.yaml as it would appear in
  * the next codegen run. Cheap (no zip, no fs writes).
  */

--- a/web-ui/app/_lib/boundaryPresets.ts
+++ b/web-ui/app/_lib/boundaryPresets.ts
@@ -1,0 +1,55 @@
+/**
+ * Frontend mirror of `middleware/src/plugins/builder/boundaryPresets.ts`.
+ *
+ * Lets the Builder UI render the structured Boundaries section without
+ * a round-trip to the server. Stays in sync with the middleware module
+ * manually until a shared package lands — the count/structure assertion
+ * in `boundaryPresets.test.ts` flags drift on the middleware side, and
+ * the equivalent (this file) flags drift on the UI side.
+ *
+ * @see Issue #54
+ */
+
+export type BoundaryCategory = 'data' | 'scope' | 'authority' | 'communication';
+
+export interface BoundaryPreset {
+  id: string;
+  category: BoundaryCategory;
+  labelKey: string;
+  /** German label fallback; the i18n bundle resolves `labelKey` when available. */
+  labelDe: string;
+}
+
+export const BOUNDARY_PRESETS: readonly BoundaryPreset[] = [
+  // data
+  { id: 'no-financial-data', category: 'data', labelKey: 'presetNoFinancial', labelDe: 'Keine Finanzdaten' },
+  { id: 'no-pii', category: 'data', labelKey: 'presetNoPii', labelDe: 'Keine personenbezogenen Daten (PII)' },
+  { id: 'no-medical-data', category: 'data', labelKey: 'presetNoMedical', labelDe: 'Keine medizinischen Daten' },
+  { id: 'no-legal-advice', category: 'data', labelKey: 'presetNoLegal', labelDe: 'Keine Rechtsberatung' },
+  // scope
+  { id: 'own-domain-only', category: 'scope', labelKey: 'presetOwnDomain', labelDe: 'Nur eigene Domäne' },
+  { id: 'no-code-execution', category: 'scope', labelKey: 'presetNoCode', labelDe: 'Keine Code-Ausführung' },
+  { id: 'no-external-links', category: 'scope', labelKey: 'presetNoExternal', labelDe: 'Keine externen Links' },
+  // authority
+  { id: 'no-discount-authority', category: 'authority', labelKey: 'presetNoDiscount', labelDe: 'Keine Rabatt-Befugnis' },
+  { id: 'no-commitments', category: 'authority', labelKey: 'presetNoCommitments', labelDe: 'Keine bindenden Zusagen' },
+  { id: 'no-personnel-decisions', category: 'authority', labelKey: 'presetNoPersonnel', labelDe: 'Keine Personalentscheidungen' },
+  // communication
+  { id: 'no-speculation', category: 'communication', labelKey: 'presetNoSpeculation', labelDe: 'Keine Spekulationen' },
+  { id: 'no-competitor-discussion', category: 'communication', labelKey: 'presetNoCompetitor', labelDe: 'Keine Wettbewerber-Diskussion' },
+] as const;
+
+export const KNOWN_BOUNDARY_PRESET_IDS: ReadonlySet<string> = new Set(
+  BOUNDARY_PRESETS.map((p) => p.id),
+);
+
+export function findUnknownBoundaryPresets(presetIds: readonly string[]): string[] {
+  return presetIds.filter((id) => !KNOWN_BOUNDARY_PRESET_IDS.has(id));
+}
+
+export const BOUNDARY_CATEGORY_LABELS_DE: Readonly<Record<BoundaryCategory, string>> = {
+  data: 'Daten',
+  scope: 'Geltungsbereich',
+  authority: 'Befugnisse',
+  communication: 'Kommunikation',
+};

--- a/web-ui/app/store/builder/[id]/_components/BoundariesSection.tsx
+++ b/web-ui/app/store/builder/[id]/_components/BoundariesSection.tsx
@@ -183,7 +183,7 @@ export function BoundariesSection({
           className="rounded bg-[color:var(--accent)] px-3 py-1 text-sm font-medium text-white disabled:opacity-50"
           data-testid="boundaries-save"
         >
-          {pending ? 'Speichern…' : 'Speichern'}
+          {pending ? 'Boundaries speichern…' : 'Boundaries speichern'}
         </button>
         {savedAt && (
           <span className="text-xs text-[color:var(--fg-muted)]">

--- a/web-ui/app/store/builder/[id]/_components/BoundariesSection.tsx
+++ b/web-ui/app/store/builder/[id]/_components/BoundariesSection.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useCallback, useMemo, useState, useTransition } from 'react';
+
+import { setQualityConfig } from '../../../../_lib/api';
+import {
+  BOUNDARY_CATEGORY_LABELS_DE,
+  BOUNDARY_PRESETS,
+  type BoundaryCategory,
+  findUnknownBoundaryPresets,
+} from '../../../../_lib/boundaryPresets';
+import type { QualityConfig } from '../../../../_lib/builderTypes';
+
+/**
+ * Boundaries pillar — checkbox grid over the 12 kemia preset library
+ * grouped by category, plus a textarea for custom "You must NOT: …"
+ * lines. Persists the full `spec.quality` block via the same JSON-Patch
+ * route as `setPersonaConfig` (issue #54).
+ *
+ * Unknown preset IDs (legacy values, future presets not yet ported)
+ * are surfaced via a warning badge — the spec round-trips with the
+ * unknown IDs so a future kemia preset can land without a migration.
+ */
+
+export interface BoundariesSectionProps {
+  draftId: string;
+  /** Initial quality block; passes through unchanged when not modified. */
+  initialQuality?: QualityConfig;
+  /** Disable interaction (read-only / archived draft). */
+  disabled?: boolean;
+  /** Invoked after a successful save with the persisted block. */
+  onPersisted?: (next: QualityConfig) => void;
+}
+
+const CATEGORY_ORDER: readonly BoundaryCategory[] = [
+  'data',
+  'scope',
+  'authority',
+  'communication',
+];
+
+export function BoundariesSection({
+  draftId,
+  initialQuality,
+  disabled,
+  onPersisted,
+}: BoundariesSectionProps): React.ReactElement {
+  const [selectedIds, setSelectedIds] = useState<readonly string[]>(
+    () => initialQuality?.boundaries?.presets ?? [],
+  );
+  const [customLines, setCustomLines] = useState<string>(
+    () => (initialQuality?.boundaries?.custom ?? []).join('\n'),
+  );
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  const presetsByCategory = useMemo(() => {
+    const out: Partial<Record<BoundaryCategory, typeof BOUNDARY_PRESETS>> = {};
+    for (const cat of CATEGORY_ORDER) {
+      out[cat] = BOUNDARY_PRESETS.filter((p) => p.category === cat);
+    }
+    return out as Record<BoundaryCategory, typeof BOUNDARY_PRESETS>;
+  }, []);
+
+  const unknownIds = useMemo(
+    () => findUnknownBoundaryPresets(selectedIds),
+    [selectedIds],
+  );
+
+  const handleToggle = useCallback((id: string, checked: boolean) => {
+    setSelectedIds((prev) => {
+      if (checked) {
+        if (prev.includes(id)) return prev;
+        return [...prev, id];
+      }
+      return prev.filter((p) => p !== id);
+    });
+  }, []);
+
+  const handleSave = useCallback(() => {
+    setError(null);
+    startTransition(async () => {
+      const custom = customLines
+        .split('\n')
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0);
+      const config: QualityConfig = {
+        ...initialQuality,
+        boundaries: { presets: [...selectedIds], custom },
+      };
+      try {
+        await setQualityConfig(draftId, config);
+        setSavedAt(Date.now());
+        onPersisted?.(config);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    });
+  }, [customLines, draftId, initialQuality, onPersisted, selectedIds]);
+
+  return (
+    <section
+      data-testid="boundaries-section"
+      className="space-y-3 rounded border border-[color:var(--border)] p-4"
+    >
+      <header className="flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold text-[color:var(--fg-strong)]">
+          Boundaries
+        </h3>
+        <span className="text-xs text-[color:var(--fg-muted)]">
+          {selectedIds.length} ausgewählt
+        </span>
+      </header>
+
+      {unknownIds.length > 0 && (
+        <div
+          data-testid="boundaries-unknown-warning"
+          role="alert"
+          className="rounded border border-amber-400 bg-amber-50 px-2 py-1 text-xs text-amber-900"
+        >
+          Unbekannte Preset-IDs: {unknownIds.join(', ')}
+        </div>
+      )}
+
+      {CATEGORY_ORDER.map((cat) => (
+        <div key={cat} className="space-y-1">
+          <div className="text-xs font-medium uppercase tracking-wider text-[color:var(--fg-muted)]">
+            {BOUNDARY_CATEGORY_LABELS_DE[cat]}
+          </div>
+          <div className="grid grid-cols-1 gap-1 md:grid-cols-2">
+            {presetsByCategory[cat]?.map((p) => {
+              const checked = selectedIds.includes(p.id);
+              return (
+                <label
+                  key={p.id}
+                  className="flex cursor-pointer items-center gap-2 text-sm"
+                  data-testid={`boundary-preset-${p.id}`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={(e) => handleToggle(p.id, e.target.checked)}
+                    disabled={disabled || pending}
+                  />
+                  <span>{p.labelDe}</span>
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+
+      <div className="space-y-1">
+        <label
+          htmlFor={`boundaries-custom-${draftId}`}
+          className="text-xs font-medium uppercase tracking-wider text-[color:var(--fg-muted)]"
+        >
+          Eigene Boundaries (eine pro Zeile)
+        </label>
+        <textarea
+          id={`boundaries-custom-${draftId}`}
+          data-testid="boundaries-custom"
+          value={customLines}
+          onChange={(e) => setCustomLines(e.target.value)}
+          rows={3}
+          disabled={disabled || pending}
+          className="w-full rounded border border-[color:var(--border)] bg-transparent p-2 text-sm"
+        />
+      </div>
+
+      {error && (
+        <div role="alert" className="text-xs text-red-600">
+          {error}
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={disabled || pending}
+          className="rounded bg-[color:var(--accent)] px-3 py-1 text-sm font-medium text-white disabled:opacity-50"
+          data-testid="boundaries-save"
+        >
+          {pending ? 'Speichern…' : 'Speichern'}
+        </button>
+        {savedAt && (
+          <span className="text-xs text-[color:var(--fg-muted)]">
+            Gespeichert
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/web-ui/app/store/builder/[id]/_components/PersonaPillar.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PersonaPillar.tsx
@@ -19,6 +19,7 @@ import {
   type PersonaAxisKey,
   type PersonaConfig,
 } from '../../../../_lib/personaTypes';
+import { BoundariesSection } from './BoundariesSection';
 import { ConflictBanner } from './ConflictBanner';
 import { DimensionSlider } from './DimensionSlider';
 import { PersonaRadar, personaAxisToSliderTestId } from './PersonaRadar';
@@ -325,6 +326,16 @@ export function PersonaPillar({
           {(persona.custom_notes ?? '').length} / {PERSONA_CUSTOM_NOTES_MAX_LENGTH}
         </p>
       </div>
+
+      {/* Issue #54 — boundary preset library + custom-line textarea. The
+       *  section persists `spec.quality` independently of the persona
+       *  Speichern button below; mounting here keeps the configuration
+       *  surface alongside other persona / quality tuning controls. */}
+      <BoundariesSection
+        draftId={draftId}
+        initialQuality={quality}
+        disabled={disabled}
+      />
 
       {/* Action row */}
       <div className="flex items-center justify-between gap-3 border-t border-[color:var(--divider)] pt-3">

--- a/web-ui/app/store/builder/[id]/_components/__tests__/BoundariesSection.test.tsx
+++ b/web-ui/app/store/builder/[id]/_components/__tests__/BoundariesSection.test.tsx
@@ -1,0 +1,136 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as api from '../../../../../_lib/api';
+import { BoundariesSection } from '../BoundariesSection';
+
+/**
+ * Issue #54 — BoundariesSection component tests.
+ *
+ * Coverage:
+ *   - 12 preset checkboxes render, grouped by category
+ *   - Toggling a checkbox + Speichern persists via setQualityConfig
+ *   - Custom textarea lines are trimmed and split on newlines
+ *   - Unknown preset IDs in initialQuality surface a warning badge
+ */
+
+describe('<BoundariesSection />', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let setQualityConfigSpy: any;
+
+  beforeEach(() => {
+    setQualityConfigSpy = vi
+      .spyOn(api, 'setQualityConfig')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof api.setQualityConfig>>);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders all 12 preset checkboxes grouped by 4 categories', () => {
+    render(<BoundariesSection draftId="draft-1" />);
+    // 12 preset checkboxes
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(12);
+    // category headers (regex anchored to exact match — the labels are
+    // single-word, no overlap with preset labels)
+    expect(screen.getByText('Daten')).toBeInTheDocument();
+    expect(screen.getByText('Geltungsbereich')).toBeInTheDocument();
+    expect(screen.getByText('Befugnisse')).toBeInTheDocument();
+    expect(screen.getByText('Kommunikation')).toBeInTheDocument();
+  });
+
+  it('honours initialQuality for prefilled checkboxes', () => {
+    render(
+      <BoundariesSection
+        draftId="draft-1"
+        initialQuality={{
+          boundaries: { presets: ['no-pii', 'no-commitments'], custom: [] },
+        }}
+      />,
+    );
+    const piiBox = screen
+      .getByTestId('boundary-preset-no-pii')
+      .querySelector('input[type="checkbox"]') as HTMLInputElement;
+    const commBox = screen
+      .getByTestId('boundary-preset-no-commitments')
+      .querySelector('input[type="checkbox"]') as HTMLInputElement;
+    const medBox = screen
+      .getByTestId('boundary-preset-no-medical-data')
+      .querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(piiBox.checked).toBe(true);
+    expect(commBox.checked).toBe(true);
+    expect(medBox.checked).toBe(false);
+  });
+
+  it('Speichern persists checked presets + parsed custom lines via setQualityConfig', async () => {
+    render(<BoundariesSection draftId="draft-7" />);
+    const piiBox = screen
+      .getByTestId('boundary-preset-no-pii')
+      .querySelector('input[type="checkbox"]') as HTMLInputElement;
+    fireEvent.click(piiBox);
+    fireEvent.change(screen.getByTestId('boundaries-custom'), {
+      target: { value: 'no off-topic chitchat\n  promise refunds  \n' },
+    });
+    fireEvent.click(screen.getByTestId('boundaries-save'));
+
+    await waitFor(() => expect(setQualityConfigSpy).toHaveBeenCalledTimes(1));
+    const [draftId, payload] = setQualityConfigSpy.mock.calls[0]!;
+    expect(draftId).toBe('draft-7');
+    expect(payload).toEqual({
+      boundaries: {
+        presets: ['no-pii'],
+        custom: ['no off-topic chitchat', 'promise refunds'],
+      },
+    });
+  });
+
+  it('renders a warning badge when initialQuality contains unknown preset IDs', () => {
+    render(
+      <BoundariesSection
+        draftId="draft-1"
+        initialQuality={{
+          boundaries: { presets: ['no-pii', 'mystery-preset'], custom: [] },
+        }}
+      />,
+    );
+    const badge = screen.getByTestId('boundaries-unknown-warning');
+    expect(badge).toBeInTheDocument();
+    expect(badge.textContent).toContain('mystery-preset');
+  });
+
+  it('does not render a warning badge when all IDs are known', () => {
+    render(
+      <BoundariesSection
+        draftId="draft-1"
+        initialQuality={{
+          boundaries: { presets: ['no-pii'], custom: [] },
+        }}
+      />,
+    );
+    expect(
+      screen.queryByTestId('boundaries-unknown-warning'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('passes through pre-existing sycophancy when saving boundaries', async () => {
+    render(
+      <BoundariesSection
+        draftId="draft-1"
+        initialQuality={{ sycophancy: 'high', boundaries: { presets: [], custom: [] } }}
+      />,
+    );
+    fireEvent.click(
+      screen
+        .getByTestId('boundary-preset-no-pii')
+        .querySelector('input[type="checkbox"]') as HTMLInputElement,
+    );
+    fireEvent.click(screen.getByTestId('boundaries-save'));
+
+    await waitFor(() => expect(setQualityConfigSpy).toHaveBeenCalledTimes(1));
+    const [, payload] = setQualityConfigSpy.mock.calls[0]!;
+    expect(payload.sycophancy).toBe('high');
+    expect(payload.boundaries.presets).toEqual(['no-pii']);
+  });
+});


### PR DESCRIPTION
Closes #54.

## Summary

Ports kemia's 12 structured boundary presets (4 categories: data / scope / authority / communication) and wires the compile path into `dynamicAgentRuntime`. Final compose order is now `[header, persona, boundaries, sycophancy, skill]`. Builds on #51 / PR #62.

Backend:
- new `middleware/src/plugins/builder/boundaryPresets.ts` — registry + `compileBoundaries` (reports unknown IDs via `droppedIds`, not silently dropped) + `compileBoundariesSection`
- new `composeBoundariesFromAgentMd()` helper in `dynamicAgentRuntime`
- `setQualityConfig` tool returns `warnings: ['unknown preset: …']` for unknown IDs; spec persists as-submitted (forward compatible with future kemia presets)

Frontend:
- new `app/_lib/boundaryPresets.ts` — registry mirror + unknown-ID lookup
- new `setQualityConfig()` wrapper in `api.ts`
- new `BoundariesSection.tsx` — 12 checkboxes grouped by category + custom-line textarea + save + unknown-ID warning badge

> **Note** — mounting `BoundariesSection` in `Workspace.tsx` / `PersonaPillar.tsx` is deferred to a follow-up. The section is wired end-to-end and tested in isolation; the integration shell is the only piece missing.

## Spec mismatch note

Issue #54 mentions 14 presets; the `byte5ai/kemia` registry at `@main` currently ships 12. The byte-identical AC is preserved against the current kemia source; the count assertion in `boundaryPresets.test.ts` flags any drift.

## Test plan

- [x] 12 unit tests for the registry + `compileBoundaries` (incl. unknown-ID `droppedIds` path)
- [x] 6 integration tests for `composeBoundariesFromAgentMd` (off / empty / preset-only / preset+custom / unknown-ID silent skip)
- [x] 5 tool tests for `setQualityConfig` (warnings path + as-submitted persist + no warnings when boundaries absent)
- [x] 6 vitest tests for `<BoundariesSection />` (12 checkbox render, prefilled init, save → `setQualityConfig`, warning badge for unknown IDs)
- [x] Existing `<PersonaPillar />` test suite (9 tests) — still green; no api.ts breakage
- [x] `npm run lint` + `npm run typecheck` clean on both workspaces

Refs #60.