### PR TITLE
feat(builder): multi-family persona baselines data asset (#58)

### DIFF
--- a/middleware/src/plugins/basePersonas.ts
+++ b/middleware/src/plugins/basePersonas.ts
@@ -1,0 +1,331 @@
+/**
+ * Multi-family persona baseline profiles (data asset).
+ *
+ * Each model family ships a `BaseProfile` describing how the model
+ * behaves along the 12 persona dimensions *before* omadia configures
+ * anything. The compile algorithm (kemia + omadia's `personaDelta`)
+ * uses this as the reference point: only deltas relative to the base
+ * are emitted as instructions.
+ *
+ * Issue #58 ports the kemia data set 1:1 (`byte5ai/kemia@main:src/lib/base-personas.ts`)
+ * **without** touching omadia's `BuilderModelId`, the model picker, the
+ * runtime routing, or any inference call. The registry is a data asset
+ * prepared for future multi-provider expansion; today the runtime still
+ * resolves only the three Claude families via `personaDelta.ts`.
+ *
+ * Key adaptation: kemia uses camelCase axis keys (`riskTolerance`),
+ * omadia uses snake_case (`risk_tolerance`). The conversion is mechanical
+ * and lives in this file's profile literals.
+ *
+ * @see Issue #58
+ */
+
+import type { PersonaAxes } from './builder/agentSpec.js';
+
+/**
+ * Confidence tier — how much kemia trusts a profile's numeric values.
+ *
+ *  • `qualitative-from-sources` — values inferred from official model
+ *    docs (model spec, constitution, safety docs). Defensible per
+ *    dimension, not an authoritative number.
+ *  • `empirical` — values measured by kemia's probing benchmark.
+ *  • `estimated` — initial educated guess pending empirical measurement.
+ */
+export type ProfileConfidence =
+  | 'qualitative-from-sources'
+  | 'empirical'
+  | 'estimated';
+
+/**
+ * Stable family identifier, matches kemia's `ModelFamilyId` string union.
+ * Kept as a string so the registry can grow without a TypeScript change
+ * downstream — the runtime falls back to `unknown` for unrecognized ids.
+ */
+export type PersonaFamilyId =
+  | 'anthropic-claude'
+  | 'openai-gpt'
+  | 'google-gemini'
+  | 'meta-llama'
+  | 'mistral'
+  | 'alibaba-qwen'
+  | 'deepseek'
+  | 'moonshot-kimi'
+  | 'zhipu-glm'
+  | '01ai-yi'
+  | 'google-gemma'
+  | 'microsoft-phi'
+  | 'unknown';
+
+export interface BaseProfile {
+  family: PersonaFamilyId;
+  /** All 12 axes set — every profile is "complete" for delta math. */
+  dimensions: Required<PersonaAxes>;
+  confidence: ProfileConfidence;
+  /** URLs to model spec, paper, constitution, or probing run id. */
+  sources: string[];
+  /** Quirks or constraints worth surfacing in UI tooltips. */
+  notes?: string;
+  /** Compliance hints (e.g. `cn-content-policy`). Free-form strings. */
+  regulatoryConstraints?: string[];
+  /** ISO date the profile was last updated. */
+  updatedAt: string;
+}
+
+// ─── Tier A — Qualitative-from-sources ────────────────────────────────
+
+const CLAUDE: BaseProfile = {
+  family: 'anthropic-claude',
+  dimensions: {
+    formality: 35,
+    directness: 65,
+    warmth: 80,
+    humor: 55,
+    sarcasm: 15,
+    conciseness: 45,
+    proactivity: 70,
+    autonomy: 50,
+    risk_tolerance: 30,
+    creativity: 65,
+    drama: 35,
+    philosophy: 65,
+  },
+  confidence: 'qualitative-from-sources',
+  sources: [
+    'https://www.anthropic.com/news/claudes-constitution',
+    'https://docs.anthropic.com/en/release-notes/system-prompts',
+    'https://arxiv.org/abs/2212.08073',
+  ],
+  notes:
+    "Constitutional AI training resists overrides on core ethical traits. Pushing warmth or directness extremely low fights the model.",
+  updatedAt: '2026-04-26',
+};
+
+const GPT: BaseProfile = {
+  family: 'openai-gpt',
+  dimensions: {
+    formality: 50,
+    directness: 70,
+    warmth: 55,
+    humor: 45,
+    sarcasm: 10,
+    conciseness: 55,
+    proactivity: 60,
+    autonomy: 55,
+    risk_tolerance: 40,
+    creativity: 55,
+    drama: 30,
+    philosophy: 50,
+  },
+  confidence: 'qualitative-from-sources',
+  sources: [
+    'https://model-spec.openai.com/',
+    'https://platform.openai.com/docs/guides/text-generation',
+  ],
+  notes:
+    'Model Spec is highly explicit. Behavior is consistent and strongly steerable, but core honesty/safety traits are non-negotiable.',
+  updatedAt: '2026-04-26',
+};
+
+const GEMINI: BaseProfile = {
+  family: 'google-gemini',
+  dimensions: {
+    formality: 50,
+    directness: 60,
+    warmth: 60,
+    humor: 40,
+    sarcasm: 10,
+    conciseness: 50,
+    proactivity: 55,
+    autonomy: 45,
+    risk_tolerance: 25,
+    creativity: 60,
+    drama: 35,
+    philosophy: 55,
+  },
+  confidence: 'qualitative-from-sources',
+  sources: [
+    'https://ai.google.dev/gemini-api/docs/safety-guidance',
+    'https://ai.google.dev/gemini-api/docs/safety-settings',
+  ],
+  notes:
+    "Safety classifiers are configurable via API but constitutional traits aren't. Lowest risk tolerance among Tier A; expect refusals on edge cases other models would handle.",
+  updatedAt: '2026-04-26',
+};
+
+// ─── Tier B — Estimated, awaiting probing benchmark ───────────────────
+
+const NEUTRAL_TIER_B: Required<PersonaAxes> = {
+  formality: 50,
+  directness: 55,
+  warmth: 50,
+  humor: 40,
+  sarcasm: 10,
+  conciseness: 50,
+  proactivity: 50,
+  autonomy: 50,
+  risk_tolerance: 50,
+  creativity: 50,
+  drama: 40,
+  philosophy: 45,
+};
+
+const LLAMA: BaseProfile = {
+  family: 'meta-llama',
+  dimensions: { ...NEUTRAL_TIER_B, directness: 60, risk_tolerance: 50 },
+  confidence: 'estimated',
+  sources: ['https://www.llama.com/responsible-use-guide/'],
+  notes:
+    'Estimated; awaits empirical probing. Llama is more shapeable than Tier A — most dimensions respond cleanly to system-prompt instruction.',
+  updatedAt: '2026-04-26',
+};
+
+const MISTRAL: BaseProfile = {
+  family: 'mistral',
+  dimensions: { ...NEUTRAL_TIER_B, conciseness: 60, directness: 60 },
+  confidence: 'estimated',
+  sources: ['https://docs.mistral.ai/'],
+  notes:
+    'Estimated; awaits empirical probing. Mistral models are notably terse and direct by default.',
+  updatedAt: '2026-04-26',
+};
+
+const QWEN: BaseProfile = {
+  family: 'alibaba-qwen',
+  dimensions: { ...NEUTRAL_TIER_B, formality: 55 },
+  confidence: 'estimated',
+  sources: ['https://qwen.readthedocs.io/'],
+  notes:
+    'Estimated; awaits empirical probing. Subject to CN content regulations on politically sensitive topics — orthogonal to persona, not configurable via omadia.',
+  regulatoryConstraints: ['cn-content-policy'],
+  updatedAt: '2026-04-26',
+};
+
+const DEEPSEEK: BaseProfile = {
+  family: 'deepseek',
+  dimensions: { ...NEUTRAL_TIER_B, philosophy: 55, conciseness: 55 },
+  confidence: 'estimated',
+  sources: [
+    'https://github.com/deepseek-ai/DeepSeek-V3',
+    'https://github.com/deepseek-ai/DeepSeek-R1',
+  ],
+  notes:
+    'Estimated; awaits empirical probing. R1 reasoning traces are visible by default. Subject to CN content regulations.',
+  regulatoryConstraints: ['cn-content-policy'],
+  updatedAt: '2026-04-26',
+};
+
+const KIMI: BaseProfile = {
+  family: 'moonshot-kimi',
+  dimensions: { ...NEUTRAL_TIER_B, formality: 55, warmth: 55 },
+  confidence: 'estimated',
+  sources: ['https://platform.moonshot.ai/docs/'],
+  notes:
+    'Estimated; awaits empirical probing. Long context strength. Subject to CN content regulations.',
+  regulatoryConstraints: ['cn-content-policy'],
+  updatedAt: '2026-04-26',
+};
+
+const GLM: BaseProfile = {
+  family: 'zhipu-glm',
+  dimensions: { ...NEUTRAL_TIER_B },
+  confidence: 'estimated',
+  sources: ['https://github.com/THUDM/GLM-4'],
+  notes:
+    'Estimated; awaits empirical probing. Subject to CN content regulations.',
+  regulatoryConstraints: ['cn-content-policy'],
+  updatedAt: '2026-04-26',
+};
+
+const YI: BaseProfile = {
+  family: '01ai-yi',
+  dimensions: { ...NEUTRAL_TIER_B },
+  confidence: 'estimated',
+  sources: ['https://github.com/01-ai/Yi'],
+  notes:
+    'Estimated; awaits empirical probing. Subject to CN content regulations.',
+  regulatoryConstraints: ['cn-content-policy'],
+  updatedAt: '2026-04-26',
+};
+
+const GEMMA: BaseProfile = {
+  family: 'google-gemma',
+  dimensions: { ...NEUTRAL_TIER_B, risk_tolerance: 35, warmth: 55 },
+  confidence: 'estimated',
+  sources: ['https://ai.google.dev/gemma/docs'],
+  notes:
+    'Estimated; awaits empirical probing. Inherits some Gemini safety priors — somewhat lower risk tolerance than peers.',
+  updatedAt: '2026-04-26',
+};
+
+const PHI: BaseProfile = {
+  family: 'microsoft-phi',
+  dimensions: {
+    ...NEUTRAL_TIER_B,
+    formality: 55,
+    risk_tolerance: 35,
+    warmth: 45,
+  },
+  confidence: 'estimated',
+  sources: [
+    'https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-featured#microsoft',
+  ],
+  notes:
+    'Estimated; awaits empirical probing. Trained to be corporate-safe — conservative defaults, lower risk tolerance.',
+  updatedAt: '2026-04-26',
+};
+
+// ─── Fallback ─────────────────────────────────────────────────────────
+
+const UNKNOWN: BaseProfile = {
+  family: 'unknown',
+  dimensions: {
+    formality: 50,
+    directness: 50,
+    warmth: 50,
+    humor: 50,
+    sarcasm: 0,
+    conciseness: 50,
+    proactivity: 50,
+    autonomy: 50,
+    risk_tolerance: 50,
+    creativity: 50,
+    drama: 50,
+    philosophy: 50,
+  },
+  confidence: 'estimated',
+  sources: [],
+  notes:
+    "Unrecognized model. The persona compiler emits as if no base shaping exists. Output may be inconsistent — consider adding this model's family to basePersonas.ts.",
+  updatedAt: '2026-04-26',
+};
+
+// ─── Registry ─────────────────────────────────────────────────────────
+
+export const BASE_PROFILES: Readonly<Record<PersonaFamilyId, BaseProfile>> = {
+  'anthropic-claude': CLAUDE,
+  'openai-gpt': GPT,
+  'google-gemini': GEMINI,
+  'meta-llama': LLAMA,
+  mistral: MISTRAL,
+  'alibaba-qwen': QWEN,
+  deepseek: DEEPSEEK,
+  'moonshot-kimi': KIMI,
+  'zhipu-glm': GLM,
+  '01ai-yi': YI,
+  'google-gemma': GEMMA,
+  'microsoft-phi': PHI,
+  unknown: UNKNOWN,
+};
+
+/**
+ * Resolve a base profile by family id. Unrecognized strings fall back
+ * to the `unknown` profile — kemia's chosen behavior, and the safe one
+ * for a runtime that may receive a model id ahead of a profile entry.
+ *
+ * This function is the only public entry point — callers should never
+ * index `BASE_PROFILES` directly with a `string` because TypeScript
+ * cannot guarantee the key is one of the listed `PersonaFamilyId`s.
+ */
+export function getBaseProfile(family: string): BaseProfile {
+  return BASE_PROFILES[family as PersonaFamilyId] ?? UNKNOWN;
+}

--- a/middleware/src/plugins/personaDelta.ts
+++ b/middleware/src/plugins/personaDelta.ts
@@ -1,3 +1,4 @@
+import { getBaseProfile } from './basePersonas.js';
 import {
   CORE_PERSONA_AXES,
   EXTENDED_PERSONA_AXES,
@@ -112,13 +113,20 @@ export interface PersonaAxisDelta {
  * intentionally chose to inherit the family default. Axes whose delta
  * is within `NEUTRAL_THRESHOLD` are also skipped at the call site
  * (compose) — they are still returned here for telemetry / preview.
+ *
+ * The default Claude family path (haiku|sonnet|opus) is unchanged.
+ * Issue #58 — callers may also pass a `string` family id (e.g.
+ * `'openai-gpt'`) to opt into the multi-family `BASE_PROFILES` registry
+ * from `basePersonas.ts`. Unknown ids fall back to the `'unknown'`
+ * profile. This is preparation only — omadia's runtime still resolves
+ * exclusively to Claude, so no existing call site uses the string path.
  */
 export function computePersonaDeltas(
   axes: PersonaAxes | undefined,
-  family: PersonaModelFamily,
+  family: PersonaModelFamily | string,
 ): PersonaAxisDelta[] {
   if (!axes) return [];
-  const base = FAMILY_DEFAULTS[family];
+  const base = resolveBaseAxes(family);
   const out: PersonaAxisDelta[] = [];
 
   for (const axis of [...CORE_PERSONA_AXES, ...EXTENDED_PERSONA_AXES]) {
@@ -153,4 +161,20 @@ export function significantDeltas(
   deltas: readonly PersonaAxisDelta[],
 ): PersonaAxisDelta[] {
   return deltas.filter((d) => d.magnitude !== 'neutral');
+}
+
+/**
+ * Issue #58 — resolve the per-axis baseline for either the Claude tiers
+ * (`haiku` / `sonnet` / `opus`, current runtime path) or a multi-family
+ * id from the `BASE_PROFILES` registry (preparation for future
+ * non-Anthropic providers). The lookup is a static discriminator — a
+ * `PersonaModelFamily` literal short-circuits to `FAMILY_DEFAULTS`, any
+ * other string consults the new registry, and an unknown id falls back
+ * to the `unknown` profile.
+ */
+function resolveBaseAxes(family: PersonaModelFamily | string): Required<PersonaAxes> {
+  if (family === 'haiku' || family === 'sonnet' || family === 'opus') {
+    return FAMILY_DEFAULTS[family];
+  }
+  return getBaseProfile(family).dimensions;
 }

--- a/middleware/test/basePersonas.test.ts
+++ b/middleware/test/basePersonas.test.ts
@@ -1,0 +1,123 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  BASE_PROFILES,
+  getBaseProfile,
+  type BaseProfile,
+  type PersonaFamilyId,
+} from '../src/plugins/basePersonas.ts';
+
+describe('basePersonas registry (issue #58)', () => {
+  it('ships 13 family profiles (12 explicit + unknown fallback)', () => {
+    assert.equal(Object.keys(BASE_PROFILES).length, 13);
+    const expected: PersonaFamilyId[] = [
+      'anthropic-claude',
+      'openai-gpt',
+      'google-gemini',
+      'meta-llama',
+      'mistral',
+      'alibaba-qwen',
+      'deepseek',
+      'moonshot-kimi',
+      'zhipu-glm',
+      '01ai-yi',
+      'google-gemma',
+      'microsoft-phi',
+      'unknown',
+    ];
+    for (const id of expected) {
+      assert.ok(BASE_PROFILES[id], `missing profile: ${id}`);
+    }
+  });
+
+  it('Claude carries qualitative-from-sources confidence + sources[]', () => {
+    const claude = BASE_PROFILES['anthropic-claude'];
+    assert.equal(claude.confidence, 'qualitative-from-sources');
+    assert.ok(claude.sources.length >= 1, 'Claude must have at least one source URL');
+    // Sanity: constitution + system-prompts release notes referenced in kemia
+    assert.ok(claude.sources.some((s) => s.includes('claudes-constitution')));
+  });
+
+  it('GPT and Gemini also Tier A (qualitative-from-sources)', () => {
+    assert.equal(BASE_PROFILES['openai-gpt'].confidence, 'qualitative-from-sources');
+    assert.equal(BASE_PROFILES['google-gemini'].confidence, 'qualitative-from-sources');
+  });
+
+  it('open-weights families ship as Tier B (estimated)', () => {
+    const tierB: PersonaFamilyId[] = [
+      'meta-llama',
+      'mistral',
+      'alibaba-qwen',
+      'deepseek',
+      'moonshot-kimi',
+      'zhipu-glm',
+      '01ai-yi',
+      'google-gemma',
+      'microsoft-phi',
+    ];
+    for (const id of tierB) {
+      assert.equal(BASE_PROFILES[id].confidence, 'estimated', `${id} must be estimated`);
+    }
+  });
+
+  it('every profile has all 12 axis dimensions set as numbers', () => {
+    const axes = [
+      'formality',
+      'directness',
+      'warmth',
+      'humor',
+      'sarcasm',
+      'conciseness',
+      'proactivity',
+      'autonomy',
+      'risk_tolerance',
+      'creativity',
+      'drama',
+      'philosophy',
+    ] as const;
+    for (const id of Object.keys(BASE_PROFILES) as PersonaFamilyId[]) {
+      const p: BaseProfile = BASE_PROFILES[id];
+      for (const axis of axes) {
+        const v = p.dimensions[axis];
+        assert.equal(typeof v, 'number', `${id}.${axis}: expected number, got ${v}`);
+        assert.ok(v >= 0 && v <= 100, `${id}.${axis}: ${v} out of [0,100]`);
+      }
+    }
+  });
+
+  it('CN-policy families carry regulatoryConstraints', () => {
+    const cn: PersonaFamilyId[] = ['alibaba-qwen', 'deepseek', 'moonshot-kimi', 'zhipu-glm', '01ai-yi'];
+    for (const id of cn) {
+      const p = BASE_PROFILES[id];
+      assert.ok(
+        p.regulatoryConstraints?.includes('cn-content-policy'),
+        `${id} missing cn-content-policy constraint`,
+      );
+    }
+  });
+
+  it('every profile has a non-empty updatedAt (ISO date)', () => {
+    for (const id of Object.keys(BASE_PROFILES) as PersonaFamilyId[]) {
+      assert.match(BASE_PROFILES[id].updatedAt, /^\d{4}-\d{2}-\d{2}$/, `${id}.updatedAt`);
+    }
+  });
+});
+
+describe('getBaseProfile (issue #58)', () => {
+  it('resolves known family ids', () => {
+    assert.equal(getBaseProfile('anthropic-claude').family, 'anthropic-claude');
+    assert.equal(getBaseProfile('openai-gpt').family, 'openai-gpt');
+    assert.equal(getBaseProfile('mistral').family, 'mistral');
+  });
+
+  it('falls back to unknown profile for unrecognized id', () => {
+    const p = getBaseProfile('does-not-exist-yet');
+    assert.equal(p.family, 'unknown');
+    assert.equal(p.confidence, 'estimated');
+  });
+
+  it('falls back for empty string', () => {
+    assert.equal(getBaseProfile('').family, 'unknown');
+  });
+});

--- a/middleware/test/personaDelta.test.ts
+++ b/middleware/test/personaDelta.test.ts
@@ -157,3 +157,36 @@ describe('significantDeltas', () => {
     assert.deepEqual(out, []);
   });
 });
+
+describe('computePersonaDeltas — multi-family (issue #58)', () => {
+  it('accepts an arbitrary string family id without throwing', () => {
+    const out = computePersonaDeltas(
+      { directness: 90, warmth: 10 },
+      'openai-gpt',
+    );
+    assert.equal(out.length, 2);
+  });
+
+  it('falls back to the unknown profile for unrecognized strings', () => {
+    // unknown profile has directness=50; input 70 → delta=20 (slightly)
+    const out = computePersonaDeltas(
+      { directness: 70, warmth: 50 },
+      'mythical-llm',
+    );
+    const directness = out.find((d) => d.axis === 'directness');
+    assert.ok(directness);
+    assert.equal(directness.base, 50);
+    assert.equal(directness.delta, 20);
+    assert.equal(directness.magnitude, 'slightly');
+  });
+
+  it('Claude family literals still resolve via FAMILY_DEFAULTS (byte-identical AC)', () => {
+    // Sonnet warmth defaults to 60; input 60 → neutral delta.
+    const out = computePersonaDeltas({ warmth: 60 }, 'sonnet');
+    assert.equal(out.length, 1);
+    const w = out[0]!;
+    assert.equal(w.base, 60);
+    assert.equal(w.delta, 0);
+    assert.equal(w.magnitude, 'neutral');
+  });
+});


### PR DESCRIPTION
Closes #58.

## Summary

Ports kemia's 13 family base profiles (12 explicit + `unknown` fallback) as a data asset for future multi-provider work, **without** touching `BuilderModelId`, the model picker, the runtime routing, or any inference call. Today the runtime still resolves only to Claude.

- new `middleware/src/plugins/basePersonas.ts` — registry, `ProfileConfidence` type, `getBaseProfile(family)` with unknown fallback
  - Tier A (`qualitative-from-sources`): anthropic-claude (with kemia's 3-URL source list), openai-gpt, google-gemini
  - Tier B (`estimated`): meta-llama, mistral, alibaba-qwen, deepseek, moonshot-kimi, zhipu-glm, 01ai-yi, google-gemma, microsoft-phi
  - CN-content-policy `regulatoryConstraints` on the 5 CN families
- `personaDelta.ts` — `computePersonaDeltas()` now accepts `PersonaModelFamily | string`; `haiku|sonnet|opus` literals still resolve via `FAMILY_DEFAULTS` (byte-identical AC), other strings hit the new registry

## Key adaptation

kemia uses camelCase (`riskTolerance`), omadia uses snake_case (`risk_tolerance`). The conversion is mechanical and inline in the profile literals.

## Test plan

- [x] 9 unit tests for `basePersonas` — 13-profile count, tier assignment, axis coverage, CN regulatory constraints, ISO date format
- [x] 3 new tests in `personaDelta.test.ts` — string-family path works, unknown id falls back, Claude tiers untouched (byte-identical AC)
- [x] `npm run lint`, `npm run typecheck` clean
- [x] No regression in existing `personaDelta.test.ts` (16 + 3 new = all green)

Refs #60.