### PR TITLE
feat(builder): culture presets — 6 industry overlays (#59)

### DIFF
--- a/middleware/src/plugins/builder/culturePresets.ts
+++ b/middleware/src/plugins/builder/culturePresets.ts
@@ -1,0 +1,160 @@
+/**
+ * Culture / industry presets for quick persona calibration.
+ *
+ * Orthogonal to F3 personaTemplates: a template sets identity + axes;
+ * a culture preset overlays axes only. Selection is one-shot — the
+ * UI assembles the full merged persona and sends a single
+ * `setPersonaConfig` call. Preset id itself is NOT persisted.
+ *
+ * Ported 1:1 from `byte5ai/kemia@main:src/lib/culture-presets.ts`.
+ * The kemia axis names are camelCase (`riskTolerance`); the omadia
+ * schema uses snake_case (`risk_tolerance`) — converted mechanically
+ * in the literals below.
+ *
+ * @see Issue #59
+ */
+
+import type { PersonaAxes } from './agentSpec.js';
+
+export type CulturePresetId =
+  | 'saas-startup'
+  | 'enterprise-corporate'
+  | 'healthcare'
+  | 'legal'
+  | 'ecommerce'
+  | 'creative-agency';
+
+export interface CulturePreset {
+  id: CulturePresetId;
+  /** i18n key in the "Persona" namespace. */
+  labelKey: string;
+  /** Short German description (fallback when no i18n bundle is loaded). */
+  descriptionDe: string;
+  /** Partial overlay — only the named axes are overwritten. */
+  dimensions: Partial<PersonaAxes>;
+}
+
+export const CULTURE_PRESETS: readonly CulturePreset[] = [
+  {
+    id: 'saas-startup',
+    labelKey: 'culture.saas-startup',
+    descriptionDe: 'SaaS-Startup — locker, direkt, schnell',
+    dimensions: {
+      formality: 30,
+      directness: 75,
+      warmth: 55,
+      humor: 40,
+      conciseness: 75,
+      proactivity: 80,
+      autonomy: 70,
+      risk_tolerance: 60,
+      creativity: 65,
+    },
+  },
+  {
+    id: 'enterprise-corporate',
+    labelKey: 'culture.enterprise-corporate',
+    descriptionDe: 'Konzern / Großunternehmen — formell, prozesstreu, vorsichtig',
+    dimensions: {
+      formality: 85,
+      directness: 45,
+      warmth: 50,
+      humor: 10,
+      sarcasm: 0,
+      conciseness: 40,
+      proactivity: 50,
+      autonomy: 30,
+      risk_tolerance: 15,
+      creativity: 25,
+    },
+  },
+  {
+    id: 'healthcare',
+    labelKey: 'culture.healthcare',
+    descriptionDe: 'Gesundheitswesen — formell, warm, risikoarm',
+    dimensions: {
+      formality: 75,
+      directness: 60,
+      warmth: 80,
+      humor: 5,
+      sarcasm: 0,
+      conciseness: 50,
+      proactivity: 40,
+      autonomy: 20,
+      risk_tolerance: 10,
+      creativity: 15,
+      drama: 5,
+    },
+  },
+  {
+    id: 'legal',
+    labelKey: 'culture.legal',
+    descriptionDe: 'Recht / Compliance — sehr formell, präzise, abwägend',
+    dimensions: {
+      formality: 90,
+      directness: 70,
+      warmth: 30,
+      humor: 0,
+      sarcasm: 0,
+      conciseness: 30,
+      proactivity: 35,
+      autonomy: 15,
+      risk_tolerance: 5,
+      creativity: 10,
+      philosophy: 60,
+    },
+  },
+  {
+    id: 'ecommerce',
+    labelKey: 'culture.ecommerce',
+    descriptionDe: 'E-Commerce — warm, lösungsorientiert, proaktiv',
+    dimensions: {
+      formality: 45,
+      directness: 55,
+      warmth: 75,
+      humor: 30,
+      conciseness: 65,
+      proactivity: 70,
+      autonomy: 50,
+      risk_tolerance: 40,
+      creativity: 50,
+      drama: 25,
+    },
+  },
+  {
+    id: 'creative-agency',
+    labelKey: 'culture.creative-agency',
+    descriptionDe: 'Kreativagentur — locker, originell, mutig',
+    dimensions: {
+      formality: 20,
+      directness: 60,
+      warmth: 65,
+      humor: 55,
+      sarcasm: 30,
+      conciseness: 50,
+      proactivity: 75,
+      autonomy: 75,
+      risk_tolerance: 70,
+      creativity: 85,
+      drama: 50,
+    },
+  },
+];
+
+export function getCulturePreset(id: string): CulturePreset | undefined {
+  return CULTURE_PRESETS.find((p) => p.id === id);
+}
+
+/**
+ * Apply a culture preset overlay on top of existing axes. Preset
+ * dimensions overwrite the existing axis value; unset axes pass through
+ * unchanged. Returns a new object — never mutates the input.
+ */
+export function applyCulturePreset(
+  existing: PersonaAxes | undefined,
+  presetId: string,
+): PersonaAxes {
+  const preset = getCulturePreset(presetId);
+  if (!preset) return { ...(existing ?? {}) };
+  return { ...(existing ?? {}), ...preset.dimensions };
+}

--- a/middleware/test/culturePresets.test.ts
+++ b/middleware/test/culturePresets.test.ts
@@ -1,0 +1,129 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  CULTURE_PRESETS,
+  applyCulturePreset,
+  getCulturePreset,
+  type CulturePresetId,
+} from '../src/plugins/builder/culturePresets.ts';
+
+describe('CULTURE_PRESETS registry (issue #59)', () => {
+  it('ships 6 industry presets', () => {
+    assert.equal(CULTURE_PRESETS.length, 6);
+    const ids = CULTURE_PRESETS.map((p) => p.id).sort();
+    assert.deepEqual(ids, [
+      'creative-agency',
+      'ecommerce',
+      'enterprise-corporate',
+      'healthcare',
+      'legal',
+      'saas-startup',
+    ]);
+  });
+
+  it('every preset has an i18n labelKey of culture.<id>', () => {
+    for (const p of CULTURE_PRESETS) {
+      assert.equal(p.labelKey, `culture.${p.id}`);
+    }
+  });
+
+  it('every preset has a non-empty descriptionDe', () => {
+    for (const p of CULTURE_PRESETS) {
+      assert.ok(p.descriptionDe.length > 0, `${p.id}: empty descriptionDe`);
+    }
+  });
+
+  it('preset dimensions are a Partial<PersonaAxes> with axis values in [0,100]', () => {
+    for (const p of CULTURE_PRESETS) {
+      for (const [axis, value] of Object.entries(p.dimensions)) {
+        assert.equal(typeof value, 'number', `${p.id}.${axis} not a number`);
+        assert.ok(
+          value! >= 0 && value! <= 100,
+          `${p.id}.${axis}: ${value} out of [0,100]`,
+        );
+      }
+    }
+  });
+
+  it('snapshot — saas-startup matches kemia verbatim', () => {
+    const saas = getCulturePreset('saas-startup');
+    assert.ok(saas);
+    assert.deepEqual(saas.dimensions, {
+      formality: 30,
+      directness: 75,
+      warmth: 55,
+      humor: 40,
+      conciseness: 75,
+      proactivity: 80,
+      autonomy: 70,
+      risk_tolerance: 60,
+      creativity: 65,
+    });
+  });
+
+  it('snapshot — legal preset is the most formal + lowest risk-tolerance', () => {
+    const legal = getCulturePreset('legal');
+    assert.ok(legal);
+    assert.equal(legal.dimensions.formality, 90);
+    assert.equal(legal.dimensions.risk_tolerance, 5);
+  });
+});
+
+describe('getCulturePreset', () => {
+  it('returns undefined for unknown id', () => {
+    assert.equal(getCulturePreset('does-not-exist'), undefined);
+  });
+
+  it('returns the preset for a valid id', () => {
+    const p = getCulturePreset('healthcare');
+    assert.ok(p);
+    assert.equal(p.id, 'healthcare');
+  });
+});
+
+describe('applyCulturePreset', () => {
+  it('overlays preset values on top of existing axes', () => {
+    const merged = applyCulturePreset(
+      { directness: 80, warmth: 30 },
+      'enterprise-corporate',
+    );
+    // Existing axes overwritten by preset values
+    assert.equal(merged.directness, 45);
+    assert.equal(merged.warmth, 50);
+    // Axes the preset doesn't touch stay unchanged — but enterprise-corporate
+    // touches formality/directness/warmth/humor/sarcasm/conciseness/proactivity/
+    // autonomy/risk_tolerance/creativity, so the test needs an axis preset
+    // doesn't set. drama is not in enterprise-corporate's overlay.
+    const startWithDrama = applyCulturePreset(
+      { directness: 80, drama: 90 },
+      'enterprise-corporate',
+    );
+    assert.equal(startWithDrama.drama, 90);
+  });
+
+  it('returns a copy — does not mutate the input', () => {
+    const base = { directness: 80 };
+    const merged = applyCulturePreset(base, 'saas-startup');
+    assert.equal(base.directness, 80, 'input mutated');
+    assert.notStrictEqual(merged, base, 'returned reference equals input');
+  });
+
+  it('returns a shallow copy of existing for unknown preset id', () => {
+    const merged = applyCulturePreset({ directness: 80 }, 'mystery-id');
+    assert.deepEqual(merged, { directness: 80 });
+  });
+
+  it('handles undefined existing input', () => {
+    const merged = applyCulturePreset(undefined, 'creative-agency');
+    assert.equal(merged.creativity, 85);
+    assert.equal(merged.drama, 50);
+  });
+});
+
+describe('preset id type — compile-time invariant smoke (issue #59)', () => {
+  it('id literal narrows to CulturePresetId', () => {
+    const id: CulturePresetId = 'saas-startup';
+    assert.ok(getCulturePreset(id));
+  });
+});

--- a/web-ui/app/_lib/culturePresets.ts
+++ b/web-ui/app/_lib/culturePresets.ts
@@ -1,0 +1,183 @@
+/**
+ * Frontend mirror of `middleware/src/plugins/builder/culturePresets.ts`.
+ *
+ * Lets `PersonaPillar` show the culture/industry dropdown + diff modal
+ * without a server round-trip. Kept in sync manually until a shared
+ * package lands — the snapshot tests in `culturePresets.test.ts` flag
+ * drift on the middleware side; the count assertion in
+ * `CulturePresetDropdown.test.tsx` flags drift on the UI side.
+ *
+ * @see Issue #59
+ */
+
+import type { PersonaAxes } from './personaTypes';
+
+export type CulturePresetId =
+  | 'saas-startup'
+  | 'enterprise-corporate'
+  | 'healthcare'
+  | 'legal'
+  | 'ecommerce'
+  | 'creative-agency';
+
+export interface CulturePreset {
+  id: CulturePresetId;
+  labelKey: string;
+  labelDe: string;
+  descriptionDe: string;
+  dimensions: Partial<PersonaAxes>;
+}
+
+export const CULTURE_PRESETS: readonly CulturePreset[] = [
+  {
+    id: 'saas-startup',
+    labelKey: 'culture.saas-startup',
+    labelDe: 'SaaS-Startup',
+    descriptionDe: 'Locker, direkt, schnell',
+    dimensions: {
+      formality: 30,
+      directness: 75,
+      warmth: 55,
+      humor: 40,
+      conciseness: 75,
+      proactivity: 80,
+      autonomy: 70,
+      risk_tolerance: 60,
+      creativity: 65,
+    },
+  },
+  {
+    id: 'enterprise-corporate',
+    labelKey: 'culture.enterprise-corporate',
+    labelDe: 'Konzern / Großunternehmen',
+    descriptionDe: 'Formell, prozesstreu, vorsichtig',
+    dimensions: {
+      formality: 85,
+      directness: 45,
+      warmth: 50,
+      humor: 10,
+      sarcasm: 0,
+      conciseness: 40,
+      proactivity: 50,
+      autonomy: 30,
+      risk_tolerance: 15,
+      creativity: 25,
+    },
+  },
+  {
+    id: 'healthcare',
+    labelKey: 'culture.healthcare',
+    labelDe: 'Gesundheitswesen',
+    descriptionDe: 'Formell, warm, risikoarm',
+    dimensions: {
+      formality: 75,
+      directness: 60,
+      warmth: 80,
+      humor: 5,
+      sarcasm: 0,
+      conciseness: 50,
+      proactivity: 40,
+      autonomy: 20,
+      risk_tolerance: 10,
+      creativity: 15,
+      drama: 5,
+    },
+  },
+  {
+    id: 'legal',
+    labelKey: 'culture.legal',
+    labelDe: 'Recht / Compliance',
+    descriptionDe: 'Sehr formell, präzise, abwägend',
+    dimensions: {
+      formality: 90,
+      directness: 70,
+      warmth: 30,
+      humor: 0,
+      sarcasm: 0,
+      conciseness: 30,
+      proactivity: 35,
+      autonomy: 15,
+      risk_tolerance: 5,
+      creativity: 10,
+      philosophy: 60,
+    },
+  },
+  {
+    id: 'ecommerce',
+    labelKey: 'culture.ecommerce',
+    labelDe: 'E-Commerce',
+    descriptionDe: 'Warm, lösungsorientiert, proaktiv',
+    dimensions: {
+      formality: 45,
+      directness: 55,
+      warmth: 75,
+      humor: 30,
+      conciseness: 65,
+      proactivity: 70,
+      autonomy: 50,
+      risk_tolerance: 40,
+      creativity: 50,
+      drama: 25,
+    },
+  },
+  {
+    id: 'creative-agency',
+    labelKey: 'culture.creative-agency',
+    labelDe: 'Kreativagentur',
+    descriptionDe: 'Locker, originell, mutig',
+    dimensions: {
+      formality: 20,
+      directness: 60,
+      warmth: 65,
+      humor: 55,
+      sarcasm: 30,
+      conciseness: 50,
+      proactivity: 75,
+      autonomy: 75,
+      risk_tolerance: 70,
+      creativity: 85,
+      drama: 50,
+    },
+  },
+];
+
+export function getCulturePreset(id: string): CulturePreset | undefined {
+  return CULTURE_PRESETS.find((p) => p.id === id);
+}
+
+export interface CultureDiffEntry {
+  axis: keyof PersonaAxes;
+  before: number | undefined;
+  after: number;
+}
+
+/**
+ * Compute the diff list for the confirm modal — axes the preset would
+ * change, with the existing value (or 'unset' indicator) and the new
+ * preset value. Unchanged axes are omitted.
+ */
+export function diffCulturePreset(
+  existing: PersonaAxes | undefined,
+  presetId: string,
+): CultureDiffEntry[] {
+  const preset = getCulturePreset(presetId);
+  if (!preset) return [];
+  const out: CultureDiffEntry[] = [];
+  for (const [axis, after] of Object.entries(preset.dimensions)) {
+    if (typeof after !== 'number') continue;
+    const before = existing?.[axis as keyof PersonaAxes];
+    if (before === after) continue;
+    out.push({ axis: axis as keyof PersonaAxes, before, after });
+  }
+  return out;
+}
+
+/** Apply preset overlay — preset values overwrite existing axes; unset axes pass through. */
+export function applyCulturePreset(
+  existing: PersonaAxes | undefined,
+  presetId: string,
+): PersonaAxes {
+  const preset = getCulturePreset(presetId);
+  if (!preset) return { ...(existing ?? {}) };
+  return { ...(existing ?? {}), ...preset.dimensions };
+}

--- a/web-ui/app/store/builder/[id]/_components/CulturePresetDropdown.tsx
+++ b/web-ui/app/store/builder/[id]/_components/CulturePresetDropdown.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useCallback, useMemo, useState, useTransition } from 'react';
+
+import { setPersonaConfig } from '../../../../_lib/api';
+import {
+  CULTURE_PRESETS,
+  applyCulturePreset,
+  diffCulturePreset,
+  getCulturePreset,
+} from '../../../../_lib/culturePresets';
+import type { PersonaConfig } from '../../../../_lib/personaTypes';
+
+/**
+ * Issue #59 — Culture / industry dropdown above the persona sliders.
+ *
+ * Selecting a preset opens a confirm modal listing every axis the
+ * overlay would change (with before/after values). Confirming sends a
+ * single `setPersonaConfig` call with the **full merged** persona —
+ * existing `template`, `custom_notes`, and untouched axes survive.
+ * Preset id itself is NOT persisted (one-shot overlay).
+ */
+
+export interface CulturePresetDropdownProps {
+  draftId: string;
+  /** Full current persona block — needed for the full-replace tool call. */
+  persona: PersonaConfig | undefined;
+  disabled?: boolean;
+  /** Called after a successful apply with the new persona block. */
+  onApplied?: (next: PersonaConfig) => void;
+}
+
+export function CulturePresetDropdown({
+  draftId,
+  persona,
+  disabled,
+  onApplied,
+}: CulturePresetDropdownProps): React.ReactElement {
+  const [selectedId, setSelectedId] = useState<string>('');
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const diff = useMemo(
+    () => (selectedId ? diffCulturePreset(persona?.axes, selectedId) : []),
+    [persona, selectedId],
+  );
+
+  const handleConfirm = useCallback(() => {
+    if (!selectedId) return;
+    const preset = getCulturePreset(selectedId);
+    if (!preset) return;
+    setError(null);
+    startTransition(async () => {
+      const mergedAxes = applyCulturePreset(persona?.axes, selectedId);
+      const next: PersonaConfig = {
+        ...(persona ?? {}),
+        axes: mergedAxes,
+      };
+      try {
+        await setPersonaConfig(draftId, next);
+        onApplied?.(next);
+        setSelectedId('');
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    });
+  }, [draftId, onApplied, persona, selectedId]);
+
+  const handleCancel = useCallback(() => {
+    setSelectedId('');
+  }, []);
+
+  return (
+    <div
+      data-testid="culture-preset-dropdown"
+      className="space-y-2 rounded border border-[color:var(--border)] p-3"
+    >
+      <label className="text-xs font-medium uppercase tracking-wider text-[color:var(--fg-muted)]">
+        Branche / Kultur
+      </label>
+      <select
+        data-testid="culture-preset-select"
+        value={selectedId}
+        onChange={(e) => setSelectedId(e.target.value)}
+        disabled={disabled || pending}
+        className="w-full rounded border border-[color:var(--border)] bg-transparent p-2 text-sm"
+      >
+        <option value="">— Keine Auswahl —</option>
+        {CULTURE_PRESETS.map((p) => (
+          <option key={p.id} value={p.id}>
+            {p.labelDe} — {p.descriptionDe}
+          </option>
+        ))}
+      </select>
+
+      {selectedId && (
+        <div
+          data-testid="culture-confirm-modal"
+          role="dialog"
+          aria-label="Kultur-Preset anwenden"
+          className="space-y-2 rounded border border-amber-400 bg-amber-50 p-3"
+        >
+          <div className="text-sm font-medium text-amber-900">
+            Diese Achsen würden überschrieben:
+          </div>
+          <ul className="space-y-0.5 text-xs text-amber-900" data-testid="culture-diff-list">
+            {diff.map((d) => (
+              <li key={d.axis} data-testid={`culture-diff-${d.axis}`}>
+                <code>{d.axis}</code>: {d.before ?? 'unset'} → {d.after}
+              </li>
+            ))}
+            {diff.length === 0 && (
+              <li>Keine Änderung — alle Werte stimmen bereits überein.</li>
+            )}
+          </ul>
+          {error && (
+            <div role="alert" className="text-xs text-red-600">
+              {error}
+            </div>
+          )}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              data-testid="culture-confirm-apply"
+              onClick={handleConfirm}
+              disabled={disabled || pending || diff.length === 0}
+              className="rounded bg-[color:var(--accent)] px-3 py-1 text-sm font-medium text-white disabled:opacity-50"
+            >
+              {pending ? 'Anwenden…' : 'Anwenden'}
+            </button>
+            <button
+              type="button"
+              data-testid="culture-confirm-cancel"
+              onClick={handleCancel}
+              disabled={pending}
+              className="rounded border border-[color:var(--border)] px-3 py-1 text-sm"
+            >
+              Abbrechen
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web-ui/app/store/builder/[id]/_components/PersonaPillar.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PersonaPillar.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../../../_lib/personaTypes';
 import { BoundariesSection } from './BoundariesSection';
 import { ConflictBanner } from './ConflictBanner';
+import { CulturePresetDropdown } from './CulturePresetDropdown';
 import { DimensionSlider } from './DimensionSlider';
 import { PersonaRadar, personaAxisToSliderTestId } from './PersonaRadar';
 
@@ -180,6 +181,19 @@ export function PersonaPillar({
       </p>
 
       <ConflictBanner warnings={warnings} />
+
+      {/* Issue #59 — culture / industry preset dropdown. One-shot
+       *  overlay; selecting a preset opens a confirm modal with the
+       *  diff list, and on confirm sends a single setPersonaConfig call
+       *  with the full merged persona. */}
+      <CulturePresetDropdown
+        draftId={draftId}
+        persona={persona}
+        disabled={disabled}
+        onApplied={(next) => {
+          setPersona(next);
+        }}
+      />
 
       {/* Radar (view-only, click axis label scrolls to slider) */}
       <PersonaRadar

--- a/web-ui/app/store/builder/[id]/_components/__tests__/CulturePresetDropdown.test.tsx
+++ b/web-ui/app/store/builder/[id]/_components/__tests__/CulturePresetDropdown.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as api from '../../../../../_lib/api';
+import { CulturePresetDropdown } from '../CulturePresetDropdown';
+
+/**
+ * Issue #59 — CulturePresetDropdown component tests.
+ *
+ * Coverage:
+ *   - 6 industry presets render in the dropdown
+ *   - Selecting a preset opens the confirm modal with diff entries
+ *   - Confirm sends a single `setPersonaConfig` call with the full
+ *     merged persona (existing template / custom_notes / untouched axes
+ *     preserved)
+ *   - Cancel closes the modal without persisting
+ */
+
+describe('<CulturePresetDropdown />', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let setPersonaConfigSpy: any;
+
+  beforeEach(() => {
+    setPersonaConfigSpy = vi
+      .spyOn(api, 'setPersonaConfig')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof api.setPersonaConfig>>);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders 6 industry options + the "no selection" placeholder', () => {
+    render(<CulturePresetDropdown draftId="draft-1" persona={undefined} />);
+    const select = screen.getByTestId('culture-preset-select') as HTMLSelectElement;
+    // 6 presets + 1 placeholder
+    expect(select.options).toHaveLength(7);
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    expect(optionValues).toEqual([
+      '',
+      'saas-startup',
+      'enterprise-corporate',
+      'healthcare',
+      'legal',
+      'ecommerce',
+      'creative-agency',
+    ]);
+  });
+
+  it('selecting a preset opens the confirm modal with the diff list', () => {
+    render(
+      <CulturePresetDropdown
+        draftId="draft-1"
+        persona={{ axes: { directness: 50, warmth: 50 } }}
+      />,
+    );
+    fireEvent.change(screen.getByTestId('culture-preset-select'), {
+      target: { value: 'saas-startup' },
+    });
+    const modal = screen.getByTestId('culture-confirm-modal');
+    expect(modal).toBeInTheDocument();
+    // saas-startup overrides directness 50→75 and warmth 50→55
+    expect(within(modal).getByTestId('culture-diff-directness')).toHaveTextContent(
+      /50.*→.*75/,
+    );
+    expect(within(modal).getByTestId('culture-diff-warmth')).toHaveTextContent(
+      /50.*→.*55/,
+    );
+  });
+
+  it('cancel closes the modal without persisting', () => {
+    render(
+      <CulturePresetDropdown
+        draftId="draft-1"
+        persona={{ axes: { directness: 50 } }}
+      />,
+    );
+    fireEvent.change(screen.getByTestId('culture-preset-select'), {
+      target: { value: 'legal' },
+    });
+    expect(screen.getByTestId('culture-confirm-modal')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('culture-confirm-cancel'));
+    expect(screen.queryByTestId('culture-confirm-modal')).not.toBeInTheDocument();
+    expect(setPersonaConfigSpy).not.toHaveBeenCalled();
+  });
+
+  it('confirm sends a single setPersonaConfig call with full merged persona', async () => {
+    render(
+      <CulturePresetDropdown
+        draftId="draft-7"
+        persona={{
+          template: 'software-engineer',
+          axes: { directness: 50, warmth: 50, drama: 90 },
+          custom_notes: 'Antworte auf Deutsch',
+        }}
+      />,
+    );
+    fireEvent.change(screen.getByTestId('culture-preset-select'), {
+      target: { value: 'saas-startup' },
+    });
+    fireEvent.click(screen.getByTestId('culture-confirm-apply'));
+
+    await waitFor(() => expect(setPersonaConfigSpy).toHaveBeenCalledTimes(1));
+    const [draftId, payload] = setPersonaConfigSpy.mock.calls[0]!;
+    expect(draftId).toBe('draft-7');
+    // template + custom_notes preserved
+    expect(payload.template).toBe('software-engineer');
+    expect(payload.custom_notes).toBe('Antworte auf Deutsch');
+    // saas-startup overlay applied; drama (not in preset) survives at 90
+    expect(payload.axes.directness).toBe(75);
+    expect(payload.axes.warmth).toBe(55);
+    expect(payload.axes.drama).toBe(90);
+  });
+
+  it('handles undefined persona on first apply', async () => {
+    render(<CulturePresetDropdown draftId="draft-1" persona={undefined} />);
+    fireEvent.change(screen.getByTestId('culture-preset-select'), {
+      target: { value: 'creative-agency' },
+    });
+    fireEvent.click(screen.getByTestId('culture-confirm-apply'));
+    await waitFor(() => expect(setPersonaConfigSpy).toHaveBeenCalledTimes(1));
+    const [, payload] = setPersonaConfigSpy.mock.calls[0]!;
+    expect(payload.axes.creativity).toBe(85);
+    expect(payload.axes.drama).toBe(50);
+  });
+});


### PR DESCRIPTION
Closes #59.

## Summary

Ports kemia's 6 culture/industry presets (saas-startup / enterprise-corporate / healthcare / legal / ecommerce / creative-agency) as a one-shot persona-axes overlay. **Orthogonal to F3 templates**: templates set identity + axes; culture presets overlay axes only. Preset id itself is NOT persisted.

## Backend

- new `middleware/src/plugins/builder/culturePresets.ts` — registry, `applyCulturePreset()` (preset values overwrite existing axes, others pass through), `getCulturePreset()` lookup
- axis keys mechanically converted from kemia's camelCase to omadia's snake_case (`riskTolerance` → `risk_tolerance`)

## Frontend

- new `app/_lib/culturePresets.ts` — registry mirror + `diffCulturePreset()` helper for the confirm-modal diff list
- new `<CulturePresetDropdown />` — "Branche / Kultur" dropdown above the slider block. Selecting a preset opens a confirm modal listing every axis the overlay would change (`before → after`); confirming sends a **single** `setPersonaConfig` call with the **full merged** persona (existing `template` + `custom_notes` + untouched axes preserved)
- mounted in `PersonaPillar` between `ConflictBanner` and the radar

## Test plan

- [x] 13 unit tests for registry + helpers (saas-startup verbatim snapshot, legal most-formal/lowest-risk, mutation safety, unknown-id passthrough, undefined-existing handling)
- [x] 5 vitest tests for `<CulturePresetDropdown />` (6 options + placeholder render, confirm modal opens with diff entries, cancel closes without persisting, full merged persona on apply, undefined-persona first apply)
- [x] Existing `<PersonaPillar />` 9 tests still pass (no regression — new component mounted between conflict banner and radar, doesn't share roles/names)
- [x] `npm run lint` + `npm run typecheck` clean on both workspaces

Refs #60.