### PR TITLE
feat(builder): audit log backend — schema + tools + API (#56)

### DIFF
--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -1711,6 +1711,8 @@ async function main(): Promise<void> {
             builderRebuildScheduler.schedule(userEmail, draftId),
         },
       },
+      // Issue #56 — paginated audit-log surface
+      audit: { draftStore },
       // Install endpoint is only wired when the package-upload subsystem is
       // enabled — otherwise the underlying ingest service does not exist.
       // BuilderRouterDeps.install is optional so the route stays absent.

--- a/middleware/src/plugins/builder/audit.ts
+++ b/middleware/src/plugins/builder/audit.ts
@@ -1,0 +1,78 @@
+import type { DraftStore } from './draftStore.js';
+
+/**
+ * Builder audit-log helper (issue #56).
+ *
+ * Fire-and-forget logging surface for mutating Builder tools. Every
+ * write is wrapped in a try/catch so a logging failure can never break
+ * the calling tool — the operator's persona / quality / spec edit still
+ * lands; only the audit row is lost. Errors are swallowed silently
+ * (intentional — there is no actionable signal for the operator).
+ *
+ * Schema lives in `draftStore.ts` (v1 → v2 migration, `builder_audit`
+ * table). The API surface is in `routes/builderAudit.ts`.
+ */
+
+export interface AuditLogger {
+  /**
+   * Append an audit event for a draft mutation. Fire-and-forget:
+   * resolves to void regardless of underlying DB success.
+   */
+  log(
+    draftId: string,
+    userEmail: string,
+    action: string,
+    details?: Readonly<Record<string, unknown>>,
+  ): Promise<void>;
+}
+
+export interface AuditEvent {
+  id: number;
+  draftId: string;
+  userEmail: string;
+  action: string;
+  details: Readonly<Record<string, unknown>>;
+  createdAt: number;
+}
+
+export interface AuditListOptions {
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * Build an AuditLogger backed by `DraftStore`'s SQLite handle. The
+ * store exposes `appendAudit()` and `listAudit()` (added in v2);
+ * this thin wrapper isolates the rest of the codebase from the
+ * DraftStore surface so future log sinks (file, syslog, OTel) can
+ * swap in cleanly.
+ */
+export function createAuditLogger(store: DraftStore): AuditLogger {
+  return {
+    async log(draftId, userEmail, action, details) {
+      try {
+        await store.appendAudit({
+          draftId,
+          userEmail,
+          action,
+          details: details ?? {},
+        });
+      } catch {
+        // Fire-and-forget — never throw on audit failure. The operator
+        // mutation already landed; losing the audit row is preferable
+        // to bubbling a logging error back up to the tool result.
+      }
+    },
+  };
+}
+
+/**
+ * No-op logger for tests / harnesses that don't care about audit rows.
+ * Existing BuilderToolHarness tests can plug this in without touching
+ * the SQLite store, which keeps the test suite fast.
+ */
+export const noopAuditLogger: AuditLogger = {
+  async log() {
+    /* discard */
+  },
+};

--- a/middleware/src/plugins/builder/auditActions.ts
+++ b/middleware/src/plugins/builder/auditActions.ts
@@ -1,0 +1,21 @@
+/**
+ * Audit-action constants for issue #56 (F6a scope).
+ *
+ * Centralised so downstream readers (UI timeline F6b, future analytics)
+ * can do exhaustive switch-cases over the action string. Action strings
+ * are stable identifiers — never rename without a migration that
+ * rewrites existing rows.
+ *
+ * Router-mutation actions (INSTALLED / ARCHIVED / RESTORED /
+ * SNAPSHOT_CREATED) are deferred to F6c per the issue scoping decision.
+ */
+
+export const BuilderAuditAction = {
+  PERSONA_UPDATED: 'persona_updated',
+  QUALITY_UPDATED: 'quality_updated',
+  SPEC_PATCHED: 'spec_patched',
+  SLOT_FILLED: 'slot_filled',
+} as const;
+
+export type BuilderAuditActionId =
+  (typeof BuilderAuditAction)[keyof typeof BuilderAuditAction];

--- a/middleware/src/plugins/builder/builderAgent.ts
+++ b/middleware/src/plugins/builder/builderAgent.ts
@@ -13,6 +13,7 @@ import {
 
 import { ASSETS } from '../../platform/assets.js';
 import { zodToJsonSchema } from '../zodToJsonSchema.js';
+import { type AuditLogger, createAuditLogger } from './audit.js';
 import { loadBoilerplate, type SlotDef } from './boilerplateSource.js';
 import type { DraftStore } from './draftStore.js';
 import type { SlotTypecheckService } from './slotTypecheckPipeline.js';
@@ -238,6 +239,13 @@ export interface BuilderAgentDeps {
    * `<templateRoot>/node_modules`. Required.
    */
   templateRoot: string;
+  /**
+   * Issue #56 — optional audit logger override. When omitted, the
+   * default `createAuditLogger(draftStore)` is wired so every mutating
+   * tool call lands in `builder_audit`. Tests can pass a spy to
+   * observe calls without touching SQLite.
+   */
+  audit?: AuditLogger;
   logger?: (...args: unknown[]) => void;
 }
 
@@ -264,6 +272,7 @@ export class BuilderAgent {
   private readonly catalogToolNames: CatalogToolNamesProvider;
   private readonly knownPluginIds: KnownPluginIdsProvider;
   private readonly slotTypechecker: SlotTypecheckService;
+  private readonly audit: AuditLogger;
   private readonly referenceCatalog: Readonly<
     Record<string, { root: string; description: string }>
   >;
@@ -287,6 +296,7 @@ export class BuilderAgent {
     this.knownPluginIds = deps.knownPluginIds;
     this.slotTypechecker = deps.slotTypechecker;
     this.referenceCatalog = deps.referenceCatalog;
+    this.audit = deps.audit ?? createAuditLogger(deps.draftStore);
     this.systemPromptSeed = deps.systemPromptSeed ?? defaultSystemPromptSeed;
     this.buildSubAgent = deps.buildSubAgent ?? defaultBuildSubAgent;
     this.tools = deps.tools ?? builderTools();
@@ -371,6 +381,7 @@ export class BuilderAgent {
       buildFailureBudget,
       templateRoot: this.templateRoot,
       userMessage: opts.userMessage,
+      audit: this.audit,
     };
 
     const subAgentTools = this.tools.map((tool) => bridgeBuilderTool(tool, toolCtx));

--- a/middleware/src/plugins/builder/draftStore.ts
+++ b/middleware/src/plugins/builder/draftStore.ts
@@ -36,7 +36,7 @@ import { DEFAULT_BUILDER_MODEL, BuilderModelRegistry } from './modelRegistry.js'
  * for a future worker-thread migration if we ever need it.
  */
 
-const CURRENT_SCHEMA_VERSION = 1;
+const CURRENT_SCHEMA_VERSION = 2;
 
 const SCHEMA_V1_SQL = `
 CREATE TABLE IF NOT EXISTS drafts (
@@ -59,6 +59,25 @@ CREATE INDEX IF NOT EXISTS idx_drafts_user_active
   ON drafts(user_email, deleted_at, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_drafts_installed_purge
   ON drafts(status, deleted_at);
+`;
+
+// Issue #56 — v2 adds the builder_audit fire-and-forget table. Idempotent
+// `CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS` so re-running
+// against an already-v2 DB is a no-op; mid-flight upgrade from v1 picks up
+// the table without losing existing drafts.
+const SCHEMA_V2_SQL = `
+CREATE TABLE IF NOT EXISTS builder_audit (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  draft_id      TEXT NOT NULL,
+  user_email    TEXT NOT NULL,
+  action        TEXT NOT NULL,
+  details_json  TEXT NOT NULL DEFAULT '{}',
+  created_at    INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_builder_audit_draft
+  ON builder_audit(draft_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_builder_audit_user
+  ON builder_audit(user_email, created_at DESC);
 `;
 
 export interface DraftUpdate {
@@ -460,18 +479,116 @@ export class DraftStore {
     const current = db.pragma('user_version', { simple: true }) as number;
     if (current < 1) {
       db.exec(SCHEMA_V1_SQL);
+      db.exec(SCHEMA_V2_SQL);
       db.pragma(`user_version = ${String(CURRENT_SCHEMA_VERSION)}`);
       return;
     }
-    // Future schema bumps land here as `if (current < 2) { … }` branches. For
-    // now the schema version is pinned at 1 and we trust `CREATE TABLE IF NOT
-    // EXISTS` to keep fresh DBs aligned with existing ones.
+    if (current < 2) {
+      // Issue #56 — mid-flight upgrade: an existing v1 DB picks up the
+      // builder_audit table without touching the drafts table. Existing
+      // rows survive unchanged; the audit log starts empty.
+      db.exec(SCHEMA_V2_SQL);
+      db.pragma(`user_version = ${String(CURRENT_SCHEMA_VERSION)}`);
+      return;
+    }
     if (current > CURRENT_SCHEMA_VERSION) {
       throw new Error(
         `drafts.db schema version ${String(current)} is newer than this middleware supports ` +
           `(max ${String(CURRENT_SCHEMA_VERSION)}). Refusing to open — downgrade would corrupt data.`,
       );
     }
+  }
+
+  // ── audit log (issue #56) ─────────────────────────────────────────────────
+
+  /**
+   * Append a single audit event. Synchronous SQLite write under the hood;
+   * wrapped in a Promise for the AuditLogger surface. Throws on DB errors
+   * — callers (e.g. `audit.ts`) swallow exceptions because the audit log
+   * is fire-and-forget.
+   */
+  async appendAudit(event: {
+    draftId: string;
+    userEmail: string;
+    action: string;
+    details: Readonly<Record<string, unknown>>;
+  }): Promise<void> {
+    const db = this.required();
+    db.prepare(
+      `INSERT INTO builder_audit (draft_id, user_email, action, details_json, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(
+      event.draftId,
+      event.userEmail,
+      event.action,
+      JSON.stringify(event.details ?? {}),
+      Date.now(),
+    );
+    return Promise.resolve();
+  }
+
+  /**
+   * Paginated audit listing for a draft, newest-first. Returns a tuple of
+   * `events` and `total` so the UI can render the "X of Y" footer without
+   * a second round-trip. Owner-scoped: events are filtered by the calling
+   * `userEmail` to mirror the draft-load access pattern.
+   */
+  async listAudit(
+    userEmail: string,
+    draftId: string,
+    opts: { limit?: number; offset?: number } = {},
+  ): Promise<{
+    events: {
+      id: number;
+      draftId: string;
+      userEmail: string;
+      action: string;
+      details: Record<string, unknown>;
+      createdAt: number;
+    }[];
+    total: number;
+  }> {
+    const db = this.required();
+    const limit = Math.max(1, Math.min(200, opts.limit ?? 30));
+    const offset = Math.max(0, opts.offset ?? 0);
+
+    const total = (
+      db
+        .prepare(
+          `SELECT COUNT(*) as n FROM builder_audit
+             WHERE draft_id = ? AND user_email = ?`,
+        )
+        .get(draftId, userEmail) as { n: number }
+    ).n;
+
+    const rows = db
+      .prepare(
+        `SELECT id, draft_id, user_email, action, details_json, created_at
+           FROM builder_audit
+          WHERE draft_id = ? AND user_email = ?
+          ORDER BY created_at DESC, id DESC
+          LIMIT ? OFFSET ?`,
+      )
+      .all(draftId, userEmail, limit, offset) as {
+      id: number;
+      draft_id: string;
+      user_email: string;
+      action: string;
+      details_json: string;
+      created_at: number;
+    }[];
+
+    return Promise.resolve({
+      total,
+      events: rows.map((r) => ({
+        id: r.id,
+        draftId: r.draft_id,
+        userEmail: r.user_email,
+        action: r.action,
+        details: JSON.parse(r.details_json) as Record<string, unknown>,
+        createdAt: r.created_at,
+      })),
+    });
   }
 
   private required(): SqliteDatabase {

--- a/middleware/src/plugins/builder/tools/fillSlot.ts
+++ b/middleware/src/plugins/builder/tools/fillSlot.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { BuilderAuditAction } from '../auditActions.js';
 import { loadBoilerplate } from '../boilerplateSource.js';
 import type { BuildError } from '../buildErrorParser.js';
 import type { SlotTypecheckReason } from '../slotTypecheckPipeline.js';
@@ -198,6 +199,14 @@ export const fillSlotTool: BuilderTool<Input, Result> = {
     ctx.slotRetryTracker.reset(slotKey);
     ctx.buildFailureBudget.reset();
     ctx.rebuildScheduler.schedule(ctx.userEmail, ctx.draftId);
+
+    // Issue #56 — fire-and-forget audit log
+    void ctx.audit.log(ctx.draftId, ctx.userEmail, BuilderAuditAction.SLOT_FILLED, {
+      slotKey,
+      bytes: source.length,
+      typecheckMs: tc.durationMs,
+    });
+
     return { ok: true, slotKey, bytes: source.length, typecheckMs: tc.durationMs };
   },
 };

--- a/middleware/src/plugins/builder/tools/patchSpec.ts
+++ b/middleware/src/plugins/builder/tools/patchSpec.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { safeParseAgentSpec } from '../agentSpec.js';
+import { BuilderAuditAction } from '../auditActions.js';
 import {
   checkSpecDelta,
   formatViolations as formatContentGuardViolations,
@@ -133,6 +134,11 @@ export const patchSpecTool: BuilderTool<Input, Result> = {
       cause: 'agent',
     });
     ctx.rebuildScheduler.schedule(ctx.userEmail, ctx.draftId);
+
+    // Issue #56 — fire-and-forget audit log
+    void ctx.audit.log(ctx.draftId, ctx.userEmail, BuilderAuditAction.SPEC_PATCHED, {
+      ops: patches.map((p) => ({ op: p.op, path: p.path })),
+    });
 
     return { ok: true, applied: [...patches] };
   },

--- a/middleware/src/plugins/builder/tools/setPersonaConfig.ts
+++ b/middleware/src/plugins/builder/tools/setPersonaConfig.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { BuilderAuditAction } from '../auditActions.js';
 import type { AgentSpecSkeleton } from '../types.js';
 import {
   IllegalSpecState,
@@ -126,6 +127,13 @@ export const setPersonaConfigTool: BuilderTool<Input, Result> = {
       cause: 'agent',
     });
     ctx.rebuildScheduler.schedule(ctx.userEmail, ctx.draftId);
+
+    // Issue #56 — fire-and-forget audit log
+    void ctx.audit.log(ctx.draftId, ctx.userEmail, BuilderAuditAction.PERSONA_UPDATED, {
+      template: sanitized.template ?? null,
+      axes: Object.keys(sanitized.axes ?? {}),
+      hasCustomNotes: typeof sanitized.custom_notes === 'string' && sanitized.custom_notes.length > 0,
+    });
 
     return {
       ok: true,

--- a/middleware/src/plugins/builder/tools/setQualityConfig.ts
+++ b/middleware/src/plugins/builder/tools/setQualityConfig.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { SycophancyLevelSpecSchema } from '../agentSpec.js';
+import { BuilderAuditAction } from '../auditActions.js';
 import { getBoundaryPreset } from '../boundaryPresets.js';
 import type { AgentSpecSkeleton } from '../types.js';
 import {
@@ -114,6 +115,14 @@ export const setQualityConfigTool: BuilderTool<Input, Result> = {
       unknownPresets.length > 0
         ? unknownPresets.map((id) => `unknown preset: ${id}`)
         : undefined;
+
+    // Issue #56 — fire-and-forget audit log
+    void ctx.audit.log(ctx.draftId, ctx.userEmail, BuilderAuditAction.QUALITY_UPDATED, {
+      sycophancy: input.sycophancy ?? null,
+      presets: input.boundaries?.presets ?? [],
+      customCount: input.boundaries?.custom?.length ?? 0,
+      ...(warnings ? { warnings } : {}),
+    });
 
     const result: OkResult = {
       ok: true,

--- a/middleware/src/plugins/builder/tools/types.ts
+++ b/middleware/src/plugins/builder/tools/types.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod';
 
+import type { AuditLogger } from '../audit.js';
 import type { DraftStore } from '../draftStore.js';
 import type { SlotTypecheckService } from '../slotTypecheckPipeline.js';
 import type { SpecEventBus } from '../specEventBus.js';
@@ -128,6 +129,13 @@ export interface BuilderToolContext {
    * guard is bypassed.
    */
   readonly userMessage?: string;
+  /**
+   * Issue #56 — fire-and-forget audit logger. Mutating tools (`set_persona_config`,
+   * `set_quality_config`, `patch_spec`, `fill_slot`) call `ctx.audit.log(...)`
+   * to append a row to the `builder_audit` table. Read-only tools (`lint_spec`,
+   * `read_reference`, …) leave it untouched.
+   */
+  readonly audit: AuditLogger;
 }
 
 /**

--- a/middleware/src/routes/builder.ts
+++ b/middleware/src/routes/builder.ts
@@ -28,6 +28,10 @@ import {
   type BuilderChatDeps,
 } from './builderChat.js';
 import {
+  registerBuilderAuditRoute,
+  type BuilderAuditDeps,
+} from './builderAudit.js';
+import {
   registerBuilderEditRoutes,
   type BuilderEditDeps,
 } from './builderEdit.js';
@@ -71,6 +75,9 @@ export interface BuilderRouterDeps {
    *  /drafts/:id/{spec,slot,model} endpoints stay absent. Wired by
    *  `index.ts` alongside the chat surface. */
   editing?: BuilderEditDeps;
+  /** Audit-log GET surface (issue #56). When omitted, the
+   *  GET /drafts/:id/audit endpoint stays absent. */
+  audit?: BuilderAuditDeps;
   /** SSE event-bus stream (B.5-4). When omitted, the
    *  GET /drafts/:id/events endpoint stays absent. Wired by `index.ts`
    *  alongside the chat + edit surfaces — a single SpecEventBus instance
@@ -441,6 +448,11 @@ export function createBuilderRouter(deps: BuilderRouterDeps): Router {
   // ── Builder inline-edit routes (B.4-4) ─────────────────────────────────
   if (deps.editing) {
     registerBuilderEditRoutes(router, deps.editing);
+  }
+
+  // ── Builder audit-log GET (issue #56) ──────────────────────────────────
+  if (deps.audit) {
+    registerBuilderAuditRoute(router, deps.audit);
   }
 
   // ── Builder SSE event stream (B.5-4) ──────────────────────────────────

--- a/middleware/src/routes/builderAudit.ts
+++ b/middleware/src/routes/builderAudit.ts
@@ -1,0 +1,90 @@
+import type { Router, Request, Response } from 'express';
+
+import type { DraftStore } from '../plugins/builder/draftStore.js';
+
+/**
+ * Issue #56 — paginated audit-log surface.
+ *
+ *   GET /v1/builder/drafts/:id/audit?limit=30&offset=0
+ *
+ * Owner-scoped: the DraftStore.listAudit filter pins to the calling
+ * session's `userEmail`, so cross-user lookups return an empty page
+ * rather than another operator's audit trail. The route is mounted
+ * via `routes/builder.ts`, picking up the existing auth gate around
+ * the entire `/v1/builder/*` mount.
+ */
+
+export interface BuilderAuditDeps {
+  draftStore: DraftStore;
+}
+
+export function registerBuilderAuditRoute(
+  router: Router,
+  deps: BuilderAuditDeps,
+): void {
+  router.get('/drafts/:id/audit', async (req: Request, res: Response) => {
+    const email = readEmail(req);
+    if (!email) {
+      return sendJson(res, 401, { code: 'auth.missing', message: 'no session' });
+    }
+    const draftId = readId(req);
+    if (!draftId) {
+      return sendJson(res, 400, {
+        code: 'builder.invalid_id',
+        message: 'missing :id',
+      });
+    }
+
+    const limit = clampInt(req.query['limit'], 1, 200, 30);
+    const offset = clampInt(req.query['offset'], 0, 100_000, 0);
+
+    // Confirm the draft is reachable by this user before listing audit
+    // events. Without this, a leaked draft id would still return 200
+    // with an empty page; 404 is the friendlier signal.
+    const draft = await deps.draftStore.load(email, draftId);
+    if (!draft) {
+      return sendJson(res, 404, {
+        code: 'builder.draft_not_found',
+        message: `kein Draft mit id '${draftId}'`,
+      });
+    }
+
+    const page = await deps.draftStore.listAudit(email, draftId, { limit, offset });
+    res.json({
+      draftId,
+      total: page.total,
+      limit,
+      offset,
+      events: page.events,
+    });
+  });
+}
+
+function readEmail(req: Request): string | null {
+  const email = req.session?.email;
+  return typeof email === 'string' && email.length > 0 ? email : null;
+}
+
+function readId(req: Request): string | null {
+  const raw = req.params['id'];
+  return typeof raw === 'string' && raw.length > 0 ? raw : null;
+}
+
+function sendJson(
+  res: Response,
+  status: number,
+  body: Record<string, unknown>,
+): void {
+  res.status(status).json(body);
+}
+
+function clampInt(
+  raw: unknown,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  const n = typeof raw === 'string' ? Number.parseInt(raw, 10) : NaN;
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(max, Math.max(min, n));
+}

--- a/middleware/test/builder/audit.test.ts
+++ b/middleware/test/builder/audit.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
+import { createAuditLogger, noopAuditLogger } from '../../src/plugins/builder/audit.js';
+import { DraftStore } from '../../src/plugins/builder/draftStore.js';
+
+/**
+ * Issue #56 — audit-log backend tests.
+ *
+ * Coverage:
+ *   - DraftStore v2 schema migration (user_version=2, builder_audit table exists)
+ *   - Mid-flight v1 → v2 upgrade keeps existing drafts intact
+ *   - createAuditLogger.log writes a row with correct columns
+ *   - listAudit returns newest-first paginated events with `total`
+ *   - Fire-and-forget: log against broken store swallows the error
+ *   - noopAuditLogger is a valid AuditLogger instance
+ */
+
+describe('audit log — DraftStore v2 migration (issue #56)', () => {
+  let tmpRoot: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(path.join(tmpdir(), 'audit-migration-'));
+    dbPath = path.join(tmpRoot, 'drafts.db');
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('fresh DB initialises at user_version=2 with both tables', async () => {
+    const store = new DraftStore({ dbPath });
+    await store.open();
+    const db = new Database(dbPath);
+    try {
+      const version = db.pragma('user_version', { simple: true }) as number;
+      assert.equal(version, 2);
+      // both tables exist
+      const tables = (
+        db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as {
+          name: string;
+        }[]
+      ).map((r) => r.name);
+      assert.ok(tables.includes('drafts'), 'drafts table missing');
+      assert.ok(tables.includes('builder_audit'), 'builder_audit table missing');
+    } finally {
+      db.close();
+      await store.close();
+    }
+  });
+
+  it('mid-flight v1 → v2 upgrade keeps existing drafts intact and adds the audit table', async () => {
+    // Seed a v1 DB by hand: drafts table + a row + user_version=1.
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE drafts (
+        id TEXT PRIMARY KEY,
+        user_email TEXT NOT NULL,
+        name TEXT NOT NULL,
+        spec_json TEXT NOT NULL,
+        slots_json TEXT NOT NULL DEFAULT '{}',
+        transcript_json TEXT NOT NULL DEFAULT '[]',
+        preview_transcript_json TEXT NOT NULL DEFAULT '[]',
+        codegen_model TEXT NOT NULL DEFAULT 'sonnet',
+        preview_model TEXT NOT NULL DEFAULT 'sonnet',
+        status TEXT NOT NULL DEFAULT 'draft',
+        installed_agent_id TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        deleted_at INTEGER
+      );
+    `);
+    db.prepare(
+      `INSERT INTO drafts (id, user_email, name, spec_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run('legacy-draft', 'alice@example.com', 'Legacy', '{"template":"agent-integration"}', 1000, 1000);
+    db.pragma('user_version = 1');
+    db.close();
+
+    // Open via DraftStore — migration to v2 should run.
+    const store = new DraftStore({ dbPath });
+    await store.open();
+    const post = new Database(dbPath);
+    try {
+      assert.equal(post.pragma('user_version', { simple: true }) as number, 2);
+      const draft = post
+        .prepare("SELECT id, name FROM drafts WHERE id = 'legacy-draft'")
+        .get() as { id: string; name: string };
+      assert.equal(draft.id, 'legacy-draft');
+      assert.equal(draft.name, 'Legacy');
+      // audit table now exists + is empty for the legacy draft
+      const auditCount = (
+        post.prepare('SELECT COUNT(*) as n FROM builder_audit').get() as {
+          n: number;
+        }
+      ).n;
+      assert.equal(auditCount, 0);
+    } finally {
+      post.close();
+      await store.close();
+    }
+  });
+});
+
+describe('audit log — appendAudit + listAudit (issue #56)', () => {
+  let tmpRoot: string;
+  let store: DraftStore;
+  let draftId: string;
+
+  beforeEach(async () => {
+    tmpRoot = mkdtempSync(path.join(tmpdir(), 'audit-rw-'));
+    store = new DraftStore({ dbPath: path.join(tmpRoot, 'drafts.db') });
+    await store.open();
+    const d = await store.create('alice@example.com', 'Weather');
+    draftId = d.id;
+  });
+
+  afterEach(async () => {
+    await store.close();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('writes a row visible via listAudit', async () => {
+    const logger = createAuditLogger(store);
+    await logger.log(draftId, 'alice@example.com', 'persona_updated', {
+      template: 'software-engineer',
+    });
+
+    const page = await store.listAudit('alice@example.com', draftId);
+    assert.equal(page.total, 1);
+    assert.equal(page.events.length, 1);
+    const ev = page.events[0]!;
+    assert.equal(ev.draftId, draftId);
+    assert.equal(ev.userEmail, 'alice@example.com');
+    assert.equal(ev.action, 'persona_updated');
+    assert.deepEqual(ev.details, { template: 'software-engineer' });
+    assert.ok(typeof ev.createdAt === 'number' && ev.createdAt > 0);
+  });
+
+  it('listAudit returns newest-first', async () => {
+    const logger = createAuditLogger(store);
+    await logger.log(draftId, 'alice@example.com', 'persona_updated', { n: 1 });
+    await logger.log(draftId, 'alice@example.com', 'quality_updated', { n: 2 });
+    await logger.log(draftId, 'alice@example.com', 'spec_patched', { n: 3 });
+
+    const page = await store.listAudit('alice@example.com', draftId);
+    assert.equal(page.total, 3);
+    assert.deepEqual(
+      page.events.map((e) => e.action),
+      ['spec_patched', 'quality_updated', 'persona_updated'],
+    );
+  });
+
+  it('listAudit paginates with limit + offset', async () => {
+    const logger = createAuditLogger(store);
+    for (let i = 0; i < 5; i++) {
+      await logger.log(draftId, 'alice@example.com', 'spec_patched', { n: i });
+    }
+
+    const first = await store.listAudit('alice@example.com', draftId, { limit: 2, offset: 0 });
+    const second = await store.listAudit('alice@example.com', draftId, { limit: 2, offset: 2 });
+    assert.equal(first.total, 5);
+    assert.equal(first.events.length, 2);
+    assert.equal(second.events.length, 2);
+    assert.notDeepEqual(
+      first.events.map((e) => e.id),
+      second.events.map((e) => e.id),
+      'first and second pages must be disjoint',
+    );
+  });
+
+  it('owner-scoped: a different user sees an empty page', async () => {
+    const logger = createAuditLogger(store);
+    await logger.log(draftId, 'alice@example.com', 'persona_updated', {});
+    const otherPage = await store.listAudit('bob@example.com', draftId);
+    assert.equal(otherPage.total, 0);
+    assert.equal(otherPage.events.length, 0);
+  });
+});
+
+describe('audit log — resilience (issue #56)', () => {
+  it('fire-and-forget: appendAudit failure does not throw out of logger', async () => {
+    // Build a logger backed by an unopened store so appendAudit throws
+    // ("DraftStore.open() must be called before use"). The logger should
+    // catch and resolve silently.
+    const tmpRoot = mkdtempSync(path.join(tmpdir(), 'audit-broken-'));
+    const store = new DraftStore({ dbPath: path.join(tmpRoot, 'drafts.db') });
+    // intentionally not opened
+    const logger = createAuditLogger(store);
+    await logger.log('any', 'any@example.com', 'persona_updated', {});
+    // If we got here without throwing, the fire-and-forget contract holds.
+    assert.ok(true);
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('noopAuditLogger satisfies the AuditLogger contract', async () => {
+    await noopAuditLogger.log('any', 'any@example.com', 'persona_updated', {});
+    assert.ok(true);
+  });
+});

--- a/middleware/test/builder/fixtures/builderToolHarness.ts
+++ b/middleware/test/builder/fixtures/builderToolHarness.ts
@@ -214,6 +214,13 @@ export async function createBuilderToolHarness(
             description: 'test reference',
           },
         },
+        // Issue #56 — default no-op audit logger. Tests that need to
+        // observe audit calls swap this for a spy via context override.
+        audit: {
+          async log() {
+            /* discard */
+          },
+        },
       };
       return harnessState.userMessage !== undefined
         ? { ...base, userMessage: harnessState.userMessage }

--- a/middleware/test/builder/tools/setQualityConfig.test.ts
+++ b/middleware/test/builder/tools/setQualityConfig.test.ts
@@ -1,11 +1,31 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import { strict as assert } from 'node:assert';
 
+import type { AuditLogger } from '../../../src/plugins/builder/audit.js';
 import { setQualityConfigTool } from '../../../src/plugins/builder/tools/setQualityConfig.js';
 import {
   createBuilderToolHarness,
   type BuilderToolHarness,
 } from '../fixtures/builderToolHarness.js';
+
+interface AuditCall {
+  draftId: string;
+  userEmail: string;
+  action: string;
+  details: Record<string, unknown>;
+}
+
+function createAuditSpy(): { logger: AuditLogger; calls: AuditCall[] } {
+  const calls: AuditCall[] = [];
+  return {
+    calls,
+    logger: {
+      async log(draftId, userEmail, action, details) {
+        calls.push({ draftId, userEmail, action, details: { ...(details ?? {}) } });
+      },
+    },
+  };
+}
 
 /**
  * `set_quality_config` Builder-Tool tests.
@@ -140,5 +160,36 @@ describe('setQualityConfigTool', () => {
     assert.equal(result.ok, true);
     if (!result.ok) return;
     assert.equal(result.warnings, undefined);
+  });
+
+  it('issue #56 — calls audit.log with QUALITY_UPDATED action on success', async () => {
+    const spy = createAuditSpy();
+    const ctx = { ...harness.context(), audit: spy.logger };
+    await setQualityConfigTool.run(
+      {
+        sycophancy: 'medium',
+        boundaries: { presets: ['no-pii'], custom: ['no PII'] },
+      },
+      ctx,
+    );
+    assert.equal(spy.calls.length, 1);
+    const call = spy.calls[0]!;
+    assert.equal(call.action, 'quality_updated');
+    assert.equal(call.draftId, harness.draftId);
+    assert.equal(call.userEmail, harness.userEmail);
+    assert.equal(call.details.sycophancy, 'medium');
+    assert.deepEqual(call.details.presets, ['no-pii']);
+    assert.equal(call.details.customCount, 1);
+  });
+
+  it('issue #56 — audit details carry warnings when unknown preset IDs are submitted', async () => {
+    const spy = createAuditSpy();
+    const ctx = { ...harness.context(), audit: spy.logger };
+    await setQualityConfigTool.run(
+      { boundaries: { presets: ['bogus'], custom: [] } },
+      ctx,
+    );
+    assert.equal(spy.calls.length, 1);
+    assert.deepEqual(spy.calls[0]!.details.warnings, ['unknown preset: bogus']);
   });
 });


### PR DESCRIPTION
Closes #56.

## Summary

Ports kemia's fire-and-forget audit log for mutating Builder tools. Schema-bumps `drafts.db` to v2 with a `builder_audit` table, wires `audit.log(...)` into the 4 in-scope mutating tools (`setPersonaConfig`, `setQualityConfig`, `patchSpec`, `fillSlot`), and adds a paginated `GET /v1/builder/drafts/:id/audit` endpoint.

## Backend

### Schema (`draftStore.ts`)
- `CURRENT_SCHEMA_VERSION` 1 → 2
- new `builder_audit` table (id PK / draft_id / user_email / action / details_json / created_at)
- indexes `(draft_id, created_at DESC)` and `(user_email, created_at DESC)`
- migration `v1 → v2` is idempotent (CREATE TABLE / INDEX IF NOT EXISTS); existing drafts survive, audit table starts empty
- new `appendAudit()` / `listAudit()` methods on `DraftStore`

### Module
- new `audit.ts` — `AuditLogger` interface, `createAuditLogger(store)` (try/catch swallow → fire-and-forget), `noopAuditLogger` for test contexts
- new `auditActions.ts` — `BuilderAuditAction` constants (`PERSONA_UPDATED`, `QUALITY_UPDATED`, `SPEC_PATCHED`, `SLOT_FILLED`); router-mutation actions (`INSTALLED` / `ARCHIVED` / `RESTORED` / `SNAPSHOT_CREATED`) deferred to F6c per the issue scoping

### Tool integration
- `BuilderToolContext` extended with `audit: AuditLogger`
- 4 mutating tools call `void ctx.audit.log(...)` at the end of the success path with per-action detail blobs:
  - `setPersonaConfig`: `{ template, axes (keys), hasCustomNotes }`
  - `setQualityConfig`: `{ sycophancy, presets, customCount, warnings? }`
  - `patchSpec`: `{ ops: [{op, path}] }`
  - `fillSlot`: `{ slotKey, bytes, typecheckMs }`
- `BuilderAgent` defaults `audit` to `createAuditLogger(draftStore)`; overridable via `deps.audit`
- `BuilderToolHarness` ships a no-op logger so existing tool tests do not break

### API
- new `GET /v1/builder/drafts/:id/audit?limit=30&offset=0`
- owner-scoped (filter by session `user_email`); 404 when draft is not reachable to that user
- returns `{ draftId, total, limit, offset, events[] }` newest-first
- mounted via `routes/builder.ts` (`deps.audit = { draftStore }` wired in `index.ts`)

## Test plan

- [x] 8 backend tests in `middleware/test/builder/audit.test.ts`
  - fresh DB initialises at `user_version = 2` with both tables
  - mid-flight `v1 → v2` upgrade keeps existing drafts intact and adds the audit table
  - `appendAudit` row visible via `listAudit` with correct columns
  - newest-first ordering
  - `limit + offset` pagination yields disjoint pages
  - owner-scoped: different user gets empty page
  - fire-and-forget resilience: logger backed by unopened store does not throw
  - `noopAuditLogger` satisfies the contract
- [x] 2 new tests in `setQualityConfig.test.ts` asserting `audit.log` is called with `QUALITY_UPDATED` + correct details (and the `warnings` field surfaces in the audit payload)
- [x] `BuilderToolHarness` ships a no-op `audit` mock — existing tool tests stay green
- [x] `npm run lint` + `npm run typecheck` clean

## Scope notes

Per the issue:
- Router mutations (`INSTALLED` / `ARCHIVED` / `RESTORED` / `SNAPSHOT_CREATED`) are deferred to F6c (separate ticket).
- `lintSpec` is read-only → no audit event (explicitly excluded).
- F6b (timeline UI) lands as the next issue (#57).

Refs #60.