### PR TITLE
feat(builder): audit timeline UI (#57)

### DIFF
--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -1950,3 +1950,40 @@ export async function runOperatorPrivacyLiveTest(
     text,
   });
 }
+
+// ── Builder audit log (issue #57) ───────────────────────────────────────────
+
+export interface BuilderAuditEvent {
+  id: number;
+  draftId: string;
+  userEmail: string;
+  action: string;
+  details: Record<string, unknown>;
+  createdAt: number;
+}
+
+export interface BuilderAuditPage {
+  draftId: string;
+  total: number;
+  limit: number;
+  offset: number;
+  events: BuilderAuditEvent[];
+}
+
+/**
+ * Paginated audit-log fetch for a draft. Backed by the `GET /v1/builder/
+ * drafts/:id/audit` route added in #56. Newest-first; default page size
+ * is 30 (server clamps 1..200).
+ */
+export async function listBuilderAudit(
+  draftId: string,
+  opts: { limit?: number; offset?: number } = {},
+): Promise<BuilderAuditPage> {
+  const q = new URLSearchParams();
+  if (typeof opts.limit === 'number') q.set('limit', String(opts.limit));
+  if (typeof opts.offset === 'number') q.set('offset', String(opts.offset));
+  const suffix = q.toString() ? `?${q.toString()}` : '';
+  return getJson<BuilderAuditPage>(
+    `/v1/builder/drafts/${encodeURIComponent(draftId)}/audit${suffix}`,
+  );
+}

--- a/web-ui/app/store/builder/[id]/_components/AuditTimelinePane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/AuditTimelinePane.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { listBuilderAudit, type BuilderAuditEvent } from '../../../../_lib/api';
+
+/**
+ * Issue #57 — paginated audit timeline view.
+ *
+ * Renders the result of `GET /v1/builder/drafts/:id/audit` newest-first
+ * with action-specific icons, action label, a mini-diff line from the
+ * persisted `details_json`, and a relative timestamp. Pagination is
+ * "Load more" — appends the next 30-row page on click.
+ */
+
+const PAGE_SIZE = 30;
+
+const ACTION_LABEL_DE: Readonly<Record<string, string>> = {
+  persona_updated: 'Persona geändert',
+  quality_updated: 'Quality / Boundaries geändert',
+  spec_patched: 'Spec gepatcht',
+  slot_filled: 'Slot befüllt',
+};
+
+const ACTION_ICON: Readonly<Record<string, string>> = {
+  persona_updated: '🎭',
+  quality_updated: '🛡',
+  spec_patched: '🔧',
+  slot_filled: '📝',
+};
+
+function relTime(ts: number): string {
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return 'vor wenigen Sekunden';
+  if (diff < 3_600_000) return `vor ${Math.floor(diff / 60_000)} min`;
+  if (diff < 86_400_000) return `vor ${Math.floor(diff / 3_600_000)} h`;
+  return `vor ${Math.floor(diff / 86_400_000)} Tagen`;
+}
+
+function detailSummary(ev: BuilderAuditEvent): string {
+  const d = ev.details ?? {};
+  switch (ev.action) {
+    case 'persona_updated': {
+      const axes = Array.isArray(d['axes']) ? (d['axes'] as string[]) : [];
+      const template =
+        typeof d['template'] === 'string' && d['template'] ? d['template'] : null;
+      const parts: string[] = [];
+      if (template) parts.push(`Template: ${template}`);
+      if (axes.length > 0) parts.push(`${axes.length} Achsen`);
+      if (d['hasCustomNotes']) parts.push('Custom notes');
+      return parts.join(' • ') || '—';
+    }
+    case 'quality_updated': {
+      const parts: string[] = [];
+      if (d['sycophancy']) parts.push(`Sycophancy: ${String(d['sycophancy'])}`);
+      const presets = Array.isArray(d['presets']) ? (d['presets'] as string[]) : [];
+      if (presets.length > 0) parts.push(`${presets.length} Presets`);
+      const c = typeof d['customCount'] === 'number' ? d['customCount'] : 0;
+      if (c > 0) parts.push(`${c} Custom`);
+      return parts.join(' • ') || '—';
+    }
+    case 'spec_patched': {
+      const ops = Array.isArray(d['ops']) ? d['ops'] : [];
+      return `${ops.length} Operation${ops.length === 1 ? '' : 'en'}`;
+    }
+    case 'slot_filled': {
+      const slot = typeof d['slotKey'] === 'string' ? d['slotKey'] : '?';
+      const bytes = typeof d['bytes'] === 'number' ? d['bytes'] : 0;
+      return `${slot} — ${bytes} bytes`;
+    }
+    default:
+      return '—';
+  }
+}
+
+export interface AuditTimelinePaneProps {
+  draftId: string;
+}
+
+export function AuditTimelinePane({ draftId }: AuditTimelinePaneProps): React.ReactElement {
+  const [events, setEvents] = useState<BuilderAuditEvent[]>([]);
+  const [total, setTotal] = useState<number>(0);
+  const [offset, setOffset] = useState<number>(0);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadPage = useCallback(
+    async (off: number, append: boolean) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const page = await listBuilderAudit(draftId, { limit: PAGE_SIZE, offset: off });
+        setTotal(page.total);
+        setEvents((prev) => (append ? [...prev, ...page.events] : page.events));
+        setOffset(off + page.events.length);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [draftId],
+  );
+
+  useEffect(() => {
+    void loadPage(0, false);
+  }, [loadPage]);
+
+  const hasMore = events.length < total;
+
+  return (
+    <section data-testid="audit-timeline" className="space-y-2 p-3">
+      <header className="flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold text-[color:var(--fg-strong)]">Verlauf</h3>
+        <span className="text-xs text-[color:var(--fg-muted)]">
+          {events.length} von {total}
+        </span>
+      </header>
+
+      {error && (
+        <div role="alert" className="text-xs text-red-600" data-testid="audit-error">
+          {error}
+        </div>
+      )}
+
+      {events.length === 0 && !loading && (
+        <div className="text-xs text-[color:var(--fg-muted)]" data-testid="audit-empty">
+          Noch keine Änderungen verzeichnet.
+        </div>
+      )}
+
+      <ul className="space-y-1" data-testid="audit-list">
+        {events.map((ev) => (
+          <li
+            key={ev.id}
+            data-testid={`audit-event-${String(ev.id)}`}
+            className="flex items-baseline gap-2 rounded border border-[color:var(--border)] px-2 py-1 text-sm"
+          >
+            <span aria-hidden>{ACTION_ICON[ev.action] ?? '•'}</span>
+            <span className="font-medium">
+              {ACTION_LABEL_DE[ev.action] ?? ev.action}
+            </span>
+            <span className="text-xs text-[color:var(--fg-muted)]">
+              {detailSummary(ev)}
+            </span>
+            <span className="ml-auto text-xs text-[color:var(--fg-subtle)]">
+              {relTime(ev.createdAt)}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {hasMore && (
+        <button
+          type="button"
+          data-testid="audit-load-more"
+          onClick={() => {
+            void loadPage(offset, true);
+          }}
+          disabled={loading}
+          className="rounded border border-[color:var(--border)] px-3 py-1 text-xs"
+        >
+          {loading ? 'Lade…' : 'Mehr laden'}
+        </button>
+      )}
+    </section>
+  );
+}

--- a/web-ui/app/store/builder/[id]/_components/Workspace.tsx
+++ b/web-ui/app/store/builder/[id]/_components/Workspace.tsx
@@ -55,6 +55,7 @@ import { SlotEditor } from './SlotEditor';
 import { SpecEditor } from './SpecEditor';
 import { SpecOverview } from './SpecOverview';
 import { UiSurfacesTabPane } from './UiSurfacesTabPane';
+import { AuditTimelinePane } from './AuditTimelinePane';
 import { VersionsTab } from './VersionsTab';
 import { useSpecEvents } from './useSpecEvents';
 
@@ -659,7 +660,15 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
                 />
               </div>
             )}
-            {tab === 'versions' && <VersionsTab draftId={draft.id} />}
+            {tab === 'versions' && (
+              <>
+                <VersionsTab draftId={draft.id} />
+                {/* Issue #57 — audit timeline as a sidebar inside the
+                 *  Versions tab. Operators see snapshots above and the
+                 *  audit trail below. */}
+                <AuditTimelinePane draftId={draft.id} />
+              </>
+            )}
           </>
         );
         const previewPaneBody = (

--- a/web-ui/app/store/builder/[id]/_components/__tests__/AuditTimelinePane.test.tsx
+++ b/web-ui/app/store/builder/[id]/_components/__tests__/AuditTimelinePane.test.tsx
@@ -1,0 +1,133 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as api from '../../../../../_lib/api';
+import { AuditTimelinePane } from '../AuditTimelinePane';
+
+/**
+ * Issue #57 — AuditTimelinePane component tests.
+ *
+ * Coverage:
+ *   - Initial fetch on mount → events render with action label + icon
+ *   - Mini-diff line surfaces meaningful detail (template, axes count, …)
+ *   - Empty state ("Noch keine Änderungen verzeichnet")
+ *   - "Mehr laden" pagination → second fetch with offset
+ *   - API error renders an alert
+ */
+
+describe('<AuditTimelinePane />', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let listAuditSpy: any;
+
+  beforeEach(() => {
+    listAuditSpy = vi.spyOn(api, 'listBuilderAudit');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeEvent(
+    id: number,
+    action: string,
+    details: Record<string, unknown> = {},
+    age = 1000,
+  ): api.BuilderAuditEvent {
+    return {
+      id,
+      draftId: 'draft-1',
+      userEmail: 'alice@example.com',
+      action,
+      details,
+      createdAt: Date.now() - age,
+    };
+  }
+
+  it('renders empty-state when listBuilderAudit returns no events', async () => {
+    listAuditSpy.mockResolvedValueOnce({
+      draftId: 'draft-1',
+      total: 0,
+      limit: 30,
+      offset: 0,
+      events: [],
+    });
+    render(<AuditTimelinePane draftId="draft-1" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('audit-empty')).toBeInTheDocument();
+    });
+  });
+
+  it('renders events with action label, icon, and detail summary', async () => {
+    listAuditSpy.mockResolvedValueOnce({
+      draftId: 'draft-1',
+      total: 2,
+      limit: 30,
+      offset: 0,
+      events: [
+        makeEvent(1, 'persona_updated', {
+          template: 'software-engineer',
+          axes: ['directness', 'warmth'],
+          hasCustomNotes: true,
+        }),
+        makeEvent(2, 'quality_updated', {
+          sycophancy: 'medium',
+          presets: ['no-pii'],
+          customCount: 1,
+        }),
+      ],
+    });
+    render(<AuditTimelinePane draftId="draft-1" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('audit-event-1')).toBeInTheDocument();
+    });
+    const event1 = screen.getByTestId('audit-event-1');
+    expect(event1).toHaveTextContent('Persona geändert');
+    expect(event1).toHaveTextContent('Template: software-engineer');
+    expect(event1).toHaveTextContent('2 Achsen');
+
+    const event2 = screen.getByTestId('audit-event-2');
+    expect(event2).toHaveTextContent('Quality');
+    expect(event2).toHaveTextContent('medium');
+  });
+
+  it('Mehr laden fetches the next page with offset', async () => {
+    listAuditSpy
+      .mockResolvedValueOnce({
+        draftId: 'draft-1',
+        total: 4,
+        limit: 30,
+        offset: 0,
+        events: [makeEvent(4, 'spec_patched'), makeEvent(3, 'persona_updated')],
+      })
+      .mockResolvedValueOnce({
+        draftId: 'draft-1',
+        total: 4,
+        limit: 30,
+        offset: 2,
+        events: [makeEvent(2, 'slot_filled', { slotKey: 's', bytes: 10, typecheckMs: 1 }), makeEvent(1, 'quality_updated')],
+      });
+    render(<AuditTimelinePane draftId="draft-1" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('audit-event-3')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('audit-load-more')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('audit-load-more'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('audit-event-1')).toBeInTheDocument();
+    });
+    expect(listAuditSpy).toHaveBeenCalledTimes(2);
+    expect(listAuditSpy.mock.calls[1]![1]).toMatchObject({ limit: 30, offset: 2 });
+    // Load-more is hidden once all events are loaded
+    expect(screen.queryByTestId('audit-load-more')).not.toBeInTheDocument();
+  });
+
+  it('renders an inline alert when the API call fails', async () => {
+    listAuditSpy.mockRejectedValueOnce(new Error('boom'));
+    render(<AuditTimelinePane draftId="draft-1" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('audit-error')).toHaveTextContent('boom');
+    });
+  });
+});


### PR DESCRIPTION
Closes #57.

## Summary

Wires #56's audit-log backend into a paginated timeline view mounted inside the Versions tab. Operators see snapshots above and the audit trail below.

- new `listBuilderAudit(draftId, opts)` API wrapper (+ `BuilderAuditEvent` / `BuilderAuditPage` types)
- new `<AuditTimelinePane />` — 30-row pages, newest-first, action-specific icons (🎭 persona, 🛡 quality, 🔧 spec, 📝 slot), German action labels, per-action detail summary, relative timestamps
- "Mehr laden" pagination — appends next page, hides when complete
- Empty-state message "Noch keine Änderungen verzeichnet."
- API error inline alert

## Test plan

- [x] 4 vitest cases for `<AuditTimelinePane />` (empty state, event rendering with action label + icon + detail summary, pagination via "Mehr laden" with offset, API error alert)
- [x] `npm run lint` + `npm run typecheck` clean

Refs #60.