### PR TITLE
feat(builder): persona templates + gallery (6 archetypes) (#53)

### DIFF
--- a/middleware/src/plugins/builder/personaTemplates.ts
+++ b/middleware/src/plugins/builder/personaTemplates.ts
@@ -1,0 +1,220 @@
+/**
+ * Ready-made persona archetypes for quick agent calibration.
+ *
+ * Ported from `byte5ai/kemia@main:src/lib/templates.ts`. kemia's full
+ * template carries `role.{jobTitle,tasks,boundaries,behaviorRules}`
+ * which lives under `spec.skill` in omadia — that block is captured
+ * here as `suggested_skill` so the UI can offer "Also prefill skill
+ * fields?" while keeping the persona-only path additive.
+ *
+ * Axis keys mechanically converted from kemia camelCase
+ * (`riskTolerance`) to omadia snake_case (`risk_tolerance`).
+ *
+ * @see Issue #53
+ */
+
+import type { PersonaAxes } from './agentSpec.js';
+
+export type PersonaTemplateId =
+  | 'customer-service'
+  | 'sales-dev'
+  | 'content-marketing'
+  | 'research-analyst'
+  | 'software-engineer'
+  | 'team-lead';
+
+export interface PersonaTemplateIdentity {
+  /** Free-form metaphor — kemia's "Assistent", "Berater", "Analyst", … */
+  creature: string;
+  /** Short tone descriptor — "Hilfsbereit, geduldig, lösungsorientiert", … */
+  vibe: string;
+}
+
+export interface PersonaTemplateSuggestedSkill {
+  /** Default `spec.skill.role` value. */
+  role: string;
+  /** Default `spec.skill.tonality` value. */
+  tonality: string;
+}
+
+export interface PersonaTemplate {
+  id: PersonaTemplateId;
+  labelKey: string;
+  /** Short German description used in the gallery card subtitle. */
+  description: string;
+  /** Full PersonaAxes overlay applied to `spec.persona.axes`. */
+  axes: Required<PersonaAxes>;
+  /** Optional identity block — surfaced in the gallery card preview. */
+  identity?: PersonaTemplateIdentity;
+  /** Optional pre-fill suggestion for `spec.skill.{role,tonality}`. */
+  suggested_skill?: PersonaTemplateSuggestedSkill;
+}
+
+export const PERSONA_TEMPLATES: readonly PersonaTemplate[] = [
+  {
+    id: 'customer-service',
+    labelKey: 'template.customer-service',
+    description: 'Professioneller Support mit Empathie und klarer Eskalation.',
+    axes: {
+      formality: 75,
+      directness: 30,
+      warmth: 85,
+      humor: 20,
+      sarcasm: 0,
+      conciseness: 40,
+      proactivity: 30,
+      autonomy: 20,
+      risk_tolerance: 15,
+      creativity: 25,
+      drama: 10,
+      philosophy: 5,
+    },
+    identity: {
+      creature: 'Assistent',
+      vibe: 'Hilfsbereit, geduldig, lösungsorientiert',
+    },
+    suggested_skill: {
+      role: 'Customer Service Agent',
+      tonality: 'Freundlich, geduldig, verständnisvoll',
+    },
+  },
+  {
+    id: 'sales-dev',
+    labelKey: 'template.sales-dev',
+    description: 'Proaktiver Vertrieb mit persönlicher Note und klarem Follow-up.',
+    axes: {
+      formality: 70,
+      directness: 65,
+      warmth: 70,
+      humor: 30,
+      sarcasm: 10,
+      conciseness: 60,
+      proactivity: 85,
+      autonomy: 50,
+      risk_tolerance: 55,
+      creativity: 45,
+      drama: 20,
+      philosophy: 10,
+    },
+    identity: {
+      creature: 'Berater',
+      vibe: 'Überzeugend, authentisch, hartnäckig',
+    },
+    suggested_skill: {
+      role: 'Sales Development Representative',
+      tonality: 'Überzeugend, authentisch, hartnäckig',
+    },
+  },
+  {
+    id: 'content-marketing',
+    labelKey: 'template.content-marketing',
+    description: 'Kreative Brand Voice mit strategischem Denken.',
+    axes: {
+      formality: 40,
+      directness: 50,
+      warmth: 60,
+      humor: 50,
+      sarcasm: 25,
+      conciseness: 50,
+      proactivity: 80,
+      autonomy: 65,
+      risk_tolerance: 60,
+      creativity: 80,
+      drama: 45,
+      philosophy: 30,
+    },
+    identity: {
+      creature: 'Kreativer',
+      vibe: 'Inspirierend, originell, markenaffin',
+    },
+    suggested_skill: {
+      role: 'Content & Marketing Agent',
+      tonality: 'Inspirierend, originell, markenaffin',
+    },
+  },
+  {
+    id: 'research-analyst',
+    labelKey: 'template.research-analyst',
+    description: 'Gründliche Recherche mit strukturierter Aufbereitung.',
+    axes: {
+      formality: 80,
+      directness: 70,
+      warmth: 40,
+      humor: 10,
+      sarcasm: 5,
+      conciseness: 30,
+      proactivity: 75,
+      autonomy: 70,
+      risk_tolerance: 30,
+      creativity: 40,
+      drama: 5,
+      philosophy: 55,
+    },
+    identity: {
+      creature: 'Analyst',
+      vibe: 'Präzise, methodisch, quellenbasiert',
+    },
+    suggested_skill: {
+      role: 'Research Analyst',
+      tonality: 'Präzise, methodisch, quellenbasiert',
+    },
+  },
+  {
+    id: 'software-engineer',
+    labelKey: 'template.software-engineer',
+    description: 'Teamorientierter Entwickler mit klarem Kommunikationsstil.',
+    axes: {
+      formality: 30,
+      directness: 80,
+      warmth: 45,
+      humor: 40,
+      sarcasm: 30,
+      conciseness: 80,
+      proactivity: 60,
+      autonomy: 75,
+      risk_tolerance: 45,
+      creativity: 55,
+      drama: 10,
+      philosophy: 20,
+    },
+    identity: {
+      creature: 'Entwickler',
+      vibe: 'Pragmatisch, direkt, qualitätsbewusst',
+    },
+    suggested_skill: {
+      role: 'Software Engineer',
+      tonality: 'Pragmatisch, direkt, qualitätsbewusst',
+    },
+  },
+  {
+    id: 'team-lead',
+    labelKey: 'template.team-lead',
+    description: 'Orchestrator, der Delegation, Eskalation und Teamstruktur steuert.',
+    axes: {
+      formality: 55,
+      directness: 50,
+      warmth: 70,
+      humor: 25,
+      sarcasm: 15,
+      conciseness: 70,
+      proactivity: 85,
+      autonomy: 55,
+      risk_tolerance: 40,
+      creativity: 35,
+      drama: 15,
+      philosophy: 40,
+    },
+    identity: {
+      creature: 'Koordinator',
+      vibe: 'Übersichtlich, diplomatisch, verbindlich',
+    },
+    suggested_skill: {
+      role: 'Team Lead / Coordinator',
+      tonality: 'Übersichtlich, diplomatisch, verbindlich',
+    },
+  },
+];
+
+export function getPersonaTemplate(id: string): PersonaTemplate | undefined {
+  return PERSONA_TEMPLATES.find((t) => t.id === id);
+}

--- a/middleware/src/plugins/builder/tools/setPersonaConfig.ts
+++ b/middleware/src/plugins/builder/tools/setPersonaConfig.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { BuilderAuditAction } from '../auditActions.js';
+import { getPersonaTemplate } from '../personaTemplates.js';
 import type { AgentSpecSkeleton } from '../types.js';
 import {
   IllegalSpecState,
@@ -98,10 +99,25 @@ export const setPersonaConfigTool: BuilderTool<Input, Result> = {
         )
       : undefined;
 
+    // Issue #53 — if a template ID is supplied, load its full axis overlay
+    // from the registry and merge with any explicit `axes` override. The
+    // override wins per-axis: operator-set values stay; missing axes inherit
+    // the template default. Unknown template IDs short-circuit to an error
+    // — the spec is unchanged, no bus emit, no rebuild, no audit row.
+    let mergedAxes: Record<string, number> | undefined = filteredAxes;
+    if (typeof input.template === 'string' && input.template.length > 0) {
+      const tpl = getPersonaTemplate(input.template);
+      if (!tpl) {
+        return { ok: false, error: `unknown template: ${input.template}` };
+      }
+      // Start with the template's full axis profile, then layer overrides.
+      mergedAxes = { ...tpl.axes, ...(filteredAxes ?? {}) };
+    }
+
     const sanitized: Input = {
       ...(input.template !== undefined ? { template: input.template } : {}),
-      ...(filteredAxes && Object.keys(filteredAxes).length > 0
-        ? { axes: filteredAxes }
+      ...(mergedAxes && Object.keys(mergedAxes).length > 0
+        ? { axes: mergedAxes }
         : {}),
       ...(input.custom_notes !== undefined
         ? { custom_notes: input.custom_notes }

--- a/middleware/test/builder/tools/setPersonaConfig.test.ts
+++ b/middleware/test/builder/tools/setPersonaConfig.test.ts
@@ -28,9 +28,11 @@ describe('setPersonaConfigTool', () => {
   });
 
   it('writes spec.persona on the active draft + emits spec_patch + schedules rebuild', async () => {
+    // Note (issue #53): when `template` is set, the tool merges the
+    // template's full 12-axis profile with explicit axis overrides.
+    // Here we test the no-template path so the explicit axes alone land.
     const result = await setPersonaConfigTool.run(
       {
-        template: 'software-engineer',
         axes: { directness: 80, warmth: 30, formality: 40 },
         custom_notes: 'Antworte auf Deutsch',
       },
@@ -44,7 +46,6 @@ describe('setPersonaConfigTool', () => {
         op: 'add',
         path: '/persona',
         value: {
-          template: 'software-engineer',
           axes: { directness: 80, warmth: 30, formality: 40 },
           custom_notes: 'Antworte auf Deutsch',
         },
@@ -57,7 +58,6 @@ describe('setPersonaConfigTool', () => {
     );
     assert.ok(reloaded);
     assert.deepEqual(reloaded.spec.persona, {
-      template: 'software-engineer',
       axes: { directness: 80, warmth: 30, formality: 40 },
       custom_notes: 'Antworte auf Deutsch',
     });
@@ -134,5 +134,67 @@ describe('setPersonaConfigTool', () => {
     assert.equal(result.ok, false);
     if (result.ok) return;
     assert.match(result.error, /not found/);
+  });
+
+  // ─── Issue #53 — template overlay ───────────────────────────────────────
+
+  it("issue #53 — template: 'customer-service' without axes override persists full customer-service axes", async () => {
+    const result = await setPersonaConfigTool.run(
+      { template: 'customer-service' },
+      harness.context(),
+    );
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.persona.template, 'customer-service');
+    assert.deepEqual(result.persona.axes, {
+      formality: 75,
+      directness: 30,
+      warmth: 85,
+      humor: 20,
+      sarcasm: 0,
+      conciseness: 40,
+      proactivity: 30,
+      autonomy: 20,
+      risk_tolerance: 15,
+      creativity: 25,
+      drama: 10,
+      philosophy: 5,
+    });
+  });
+
+  it('issue #53 — explicit axes override the template per-axis', async () => {
+    const result = await setPersonaConfigTool.run(
+      {
+        template: 'customer-service',
+        // override directness and warmth; the other 10 axes inherit
+        axes: { directness: 90, warmth: 50 },
+      },
+      harness.context(),
+    );
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.persona.axes?.directness, 90);
+    assert.equal(result.persona.axes?.warmth, 50);
+    // formality from the template — was not overridden
+    assert.equal(result.persona.axes?.formality, 75);
+  });
+
+  it('issue #53 — unknown template id short-circuits to ok=false with no persist / emit / rebuild', async () => {
+    const before = harness.events.length;
+    const beforeRebuilds = harness.rebuilds.length;
+    const result = await setPersonaConfigTool.run(
+      { template: 'mystery-archetype' },
+      harness.context(),
+    );
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.match(result.error, /unknown template/);
+    assert.equal(harness.events.length, before, 'spec_patch must not fire');
+    assert.equal(harness.rebuilds.length, beforeRebuilds, 'rebuild must not be scheduled');
+    const reloaded = await harness.draftStore.load(
+      harness.userEmail,
+      harness.draftId,
+    );
+    assert.equal(reloaded?.spec.persona, undefined);
   });
 });

--- a/middleware/test/personaTemplates.test.ts
+++ b/middleware/test/personaTemplates.test.ts
@@ -1,0 +1,114 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  PERSONA_TEMPLATES,
+  getPersonaTemplate,
+  type PersonaTemplateId,
+} from '../src/plugins/builder/personaTemplates.ts';
+
+describe('PERSONA_TEMPLATES registry (issue #53)', () => {
+  it('ships 6 archetypes', () => {
+    assert.equal(PERSONA_TEMPLATES.length, 6);
+    const ids = PERSONA_TEMPLATES.map((t) => t.id).sort();
+    assert.deepEqual(ids, [
+      'content-marketing',
+      'customer-service',
+      'research-analyst',
+      'sales-dev',
+      'software-engineer',
+      'team-lead',
+    ]);
+  });
+
+  it('every template has all 12 axes set as numbers in [0, 100]', () => {
+    const expected: (keyof PersonaTemplate['axes'])[] = [
+      'formality',
+      'directness',
+      'warmth',
+      'humor',
+      'sarcasm',
+      'conciseness',
+      'proactivity',
+      'autonomy',
+      'risk_tolerance',
+      'creativity',
+      'drama',
+      'philosophy',
+    ];
+    for (const t of PERSONA_TEMPLATES) {
+      for (const axis of expected) {
+        const v = t.axes[axis];
+        assert.equal(typeof v, 'number', `${t.id}.${axis} not number`);
+        assert.ok(v >= 0 && v <= 100, `${t.id}.${axis}: ${v} out of range`);
+      }
+    }
+  });
+
+  it('every template has labelKey == "template.<id>"', () => {
+    for (const t of PERSONA_TEMPLATES) {
+      assert.equal(t.labelKey, `template.${t.id}`);
+    }
+  });
+
+  it('every template has non-empty description + identity + suggested_skill', () => {
+    for (const t of PERSONA_TEMPLATES) {
+      assert.ok(t.description.length > 0, `${t.id}: empty description`);
+      assert.ok(t.identity, `${t.id}: missing identity`);
+      assert.ok(t.identity!.creature.length > 0);
+      assert.ok(t.identity!.vibe.length > 0);
+      assert.ok(t.suggested_skill, `${t.id}: missing suggested_skill`);
+      assert.ok(t.suggested_skill!.role.length > 0);
+      assert.ok(t.suggested_skill!.tonality.length > 0);
+    }
+  });
+
+  it('snapshot — customer-service axes verbatim from kemia', () => {
+    const cs = getPersonaTemplate('customer-service');
+    assert.ok(cs);
+    assert.deepEqual(cs.axes, {
+      formality: 75,
+      directness: 30,
+      warmth: 85,
+      humor: 20,
+      sarcasm: 0,
+      conciseness: 40,
+      proactivity: 30,
+      autonomy: 20,
+      risk_tolerance: 15,
+      creativity: 25,
+      drama: 10,
+      philosophy: 5,
+    });
+    assert.equal(cs.identity?.creature, 'Assistent');
+    assert.equal(cs.suggested_skill?.role, 'Customer Service Agent');
+  });
+
+  it('snapshot — software-engineer is the most direct + concise', () => {
+    const eng = getPersonaTemplate('software-engineer');
+    assert.ok(eng);
+    assert.equal(eng.axes.directness, 80);
+    assert.equal(eng.axes.conciseness, 80);
+  });
+});
+
+describe('getPersonaTemplate', () => {
+  it('returns undefined for unknown id', () => {
+    assert.equal(getPersonaTemplate('does-not-exist'), undefined);
+  });
+
+  it('returns the template for a valid id', () => {
+    const t = getPersonaTemplate('research-analyst');
+    assert.ok(t);
+    assert.equal(t.id, 'research-analyst');
+    assert.equal(t.axes.formality, 80);
+  });
+
+  it('id literal narrows to PersonaTemplateId', () => {
+    const id: PersonaTemplateId = 'team-lead';
+    assert.ok(getPersonaTemplate(id));
+  });
+});
+
+// Local re-import to keep the test file self-contained for the axis-keys assertion.
+type PersonaTemplate = (typeof PERSONA_TEMPLATES)[number];

--- a/web-ui/app/_lib/personaTemplates.ts
+++ b/web-ui/app/_lib/personaTemplates.ts
@@ -1,0 +1,148 @@
+/**
+ * Frontend mirror of `middleware/src/plugins/builder/personaTemplates.ts`.
+ *
+ * Lets `PersonaPillar` render the gallery + previews without a server
+ * round-trip. The middleware snapshot tests + this file's structure
+ * test guard against drift.
+ *
+ * @see Issue #53
+ */
+
+import type { PersonaAxes } from './personaTypes';
+
+export type PersonaTemplateId =
+  | 'customer-service'
+  | 'sales-dev'
+  | 'content-marketing'
+  | 'research-analyst'
+  | 'software-engineer'
+  | 'team-lead';
+
+export interface PersonaTemplateIdentity {
+  creature: string;
+  vibe: string;
+}
+
+export interface PersonaTemplateSuggestedSkill {
+  role: string;
+  tonality: string;
+}
+
+export interface PersonaTemplate {
+  id: PersonaTemplateId;
+  labelKey: string;
+  /** German display label for the card title. */
+  labelDe: string;
+  /** Subtitle description. */
+  description: string;
+  axes: Required<PersonaAxes>;
+  identity?: PersonaTemplateIdentity;
+  suggested_skill?: PersonaTemplateSuggestedSkill;
+}
+
+const FULL_AXES = (
+  formality: number,
+  directness: number,
+  warmth: number,
+  humor: number,
+  sarcasm: number,
+  conciseness: number,
+  proactivity: number,
+  autonomy: number,
+  risk_tolerance: number,
+  creativity: number,
+  drama: number,
+  philosophy: number,
+): Required<PersonaAxes> => ({
+  formality,
+  directness,
+  warmth,
+  humor,
+  sarcasm,
+  conciseness,
+  proactivity,
+  autonomy,
+  risk_tolerance,
+  creativity,
+  drama,
+  philosophy,
+});
+
+export const PERSONA_TEMPLATES: readonly PersonaTemplate[] = [
+  {
+    id: 'customer-service',
+    labelKey: 'template.customer-service',
+    labelDe: 'Customer Service Agent',
+    description: 'Professioneller Support mit Empathie und klarer Eskalation.',
+    axes: FULL_AXES(75, 30, 85, 20, 0, 40, 30, 20, 15, 25, 10, 5),
+    identity: { creature: 'Assistent', vibe: 'Hilfsbereit, geduldig, lösungsorientiert' },
+    suggested_skill: {
+      role: 'Customer Service Agent',
+      tonality: 'Freundlich, geduldig, verständnisvoll',
+    },
+  },
+  {
+    id: 'sales-dev',
+    labelKey: 'template.sales-dev',
+    labelDe: 'Sales Development Rep',
+    description: 'Proaktiver Vertrieb mit persönlicher Note und klarem Follow-up.',
+    axes: FULL_AXES(70, 65, 70, 30, 10, 60, 85, 50, 55, 45, 20, 10),
+    identity: { creature: 'Berater', vibe: 'Überzeugend, authentisch, hartnäckig' },
+    suggested_skill: {
+      role: 'Sales Development Representative',
+      tonality: 'Überzeugend, authentisch, hartnäckig',
+    },
+  },
+  {
+    id: 'content-marketing',
+    labelKey: 'template.content-marketing',
+    labelDe: 'Content & Marketing Agent',
+    description: 'Kreative Brand Voice mit strategischem Denken.',
+    axes: FULL_AXES(40, 50, 60, 50, 25, 50, 80, 65, 60, 80, 45, 30),
+    identity: { creature: 'Kreativer', vibe: 'Inspirierend, originell, markenaffin' },
+    suggested_skill: {
+      role: 'Content & Marketing Agent',
+      tonality: 'Inspirierend, originell, markenaffin',
+    },
+  },
+  {
+    id: 'research-analyst',
+    labelKey: 'template.research-analyst',
+    labelDe: 'Research Analyst',
+    description: 'Gründliche Recherche mit strukturierter Aufbereitung.',
+    axes: FULL_AXES(80, 70, 40, 10, 5, 30, 75, 70, 30, 40, 5, 55),
+    identity: { creature: 'Analyst', vibe: 'Präzise, methodisch, quellenbasiert' },
+    suggested_skill: {
+      role: 'Research Analyst',
+      tonality: 'Präzise, methodisch, quellenbasiert',
+    },
+  },
+  {
+    id: 'software-engineer',
+    labelKey: 'template.software-engineer',
+    labelDe: 'Software Engineer',
+    description: 'Teamorientierter Entwickler mit klarem Kommunikationsstil.',
+    axes: FULL_AXES(30, 80, 45, 40, 30, 80, 60, 75, 45, 55, 10, 20),
+    identity: { creature: 'Entwickler', vibe: 'Pragmatisch, direkt, qualitätsbewusst' },
+    suggested_skill: {
+      role: 'Software Engineer',
+      tonality: 'Pragmatisch, direkt, qualitätsbewusst',
+    },
+  },
+  {
+    id: 'team-lead',
+    labelKey: 'template.team-lead',
+    labelDe: 'Team Lead / Coordinator',
+    description: 'Orchestrator, der Delegation, Eskalation und Teamstruktur steuert.',
+    axes: FULL_AXES(55, 50, 70, 25, 15, 70, 85, 55, 40, 35, 15, 40),
+    identity: { creature: 'Koordinator', vibe: 'Übersichtlich, diplomatisch, verbindlich' },
+    suggested_skill: {
+      role: 'Team Lead / Coordinator',
+      tonality: 'Übersichtlich, diplomatisch, verbindlich',
+    },
+  },
+];
+
+export function getPersonaTemplate(id: string): PersonaTemplate | undefined {
+  return PERSONA_TEMPLATES.find((t) => t.id === id);
+}

--- a/web-ui/app/store/builder/[id]/_components/PersonaPillar.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PersonaPillar.tsx
@@ -24,6 +24,7 @@ import { ConflictBanner } from './ConflictBanner';
 import { CulturePresetDropdown } from './CulturePresetDropdown';
 import { DimensionSlider } from './DimensionSlider';
 import { PersonaRadar, personaAxisToSliderTestId } from './PersonaRadar';
+import { PersonaTemplateGallery } from './PersonaTemplateGallery';
 
 /**
  * Phase 3 / OB-67 Slice 4 — top-level persona pillar.
@@ -74,6 +75,8 @@ export function PersonaPillar({
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<number | null>(null);
+  // Issue #53 — modal-state for the persona-template gallery
+  const [galleryOpen, setGalleryOpen] = useState(false);
 
   const warnings: PersonaConflictWarning[] = useMemo(
     () => detectPersonaConflicts(quality, persona),
@@ -181,6 +184,38 @@ export function PersonaPillar({
       </p>
 
       <ConflictBanner warnings={warnings} />
+
+      {/* Issue #53 — Apply persona-template button + gallery modal.
+       *  Selecting an archetype calls setPersonaConfig server-side; the
+       *  tool merges the template's 12-axis profile with operator
+       *  overrides (override wins per axis). */}
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs text-[color:var(--fg-muted)]" data-testid="persona-template-badge">
+          {persona.template
+            ? `Vorlage: ${persona.template}${(persona.axes && Object.keys(persona.axes).length > 0) ? ' — angepasst' : ''}`
+            : 'Keine Vorlage'}
+        </span>
+        <button
+          type="button"
+          data-testid="persona-template-open"
+          onClick={() => setGalleryOpen(true)}
+          disabled={disabled || pending}
+          className="rounded border border-[color:var(--border)] px-2 py-1 text-xs"
+        >
+          Vorlage anwenden
+        </button>
+      </div>
+      {galleryOpen && (
+        <PersonaTemplateGallery
+          draftId={draftId}
+          persona={persona}
+          disabled={disabled}
+          onClose={() => setGalleryOpen(false)}
+          onApplied={(next) => {
+            setPersona(next);
+          }}
+        />
+      )}
 
       {/* Issue #59 — culture / industry preset dropdown. One-shot
        *  overlay; selecting a preset opens a confirm modal with the

--- a/web-ui/app/store/builder/[id]/_components/PersonaTemplateGallery.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PersonaTemplateGallery.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { useCallback, useState, useTransition } from 'react';
+
+import { patchBuilderSpec, setPersonaConfig } from '../../../../_lib/api';
+import {
+  PERSONA_TEMPLATES,
+  type PersonaTemplate,
+} from '../../../../_lib/personaTemplates';
+import type { PersonaConfig } from '../../../../_lib/personaTypes';
+
+/**
+ * Issue #53 — modal overlay gallery of 6 persona archetypes.
+ *
+ * Open via the "Vorlage anwenden" button in `PersonaPillar`. Each card
+ * shows the German label, subtitle, identity creature/vibe, and the
+ * suggested skill role. Clicking a card pre-selects it; the "Anwenden"
+ * button then calls `setPersonaConfig` with the template id — the tool
+ * loads the full 12-axis profile server-side and merges with any
+ * pre-existing operator overrides. If the operator opts into prefilling
+ * skill fields, a second `patchBuilderSpec` call writes `/skill/role` +
+ * `/skill/tonality`. The skill patch only fires after the persona
+ * patch resolves successfully.
+ */
+
+export interface PersonaTemplateGalleryProps {
+  draftId: string;
+  /** Current persona block — merged on apply so `custom_notes` survives. */
+  persona: PersonaConfig | undefined;
+  disabled?: boolean;
+  onClose: () => void;
+  /** Notify parent after a successful apply so it can re-sync state. */
+  onApplied?: (next: PersonaConfig) => void;
+}
+
+export function PersonaTemplateGallery({
+  draftId,
+  persona,
+  disabled,
+  onClose,
+  onApplied,
+}: PersonaTemplateGalleryProps): React.ReactElement {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [prefillSkill, setPrefillSkill] = useState<boolean>(false);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const selected: PersonaTemplate | undefined = selectedId
+    ? PERSONA_TEMPLATES.find((t) => t.id === selectedId)
+    : undefined;
+
+  const handleApply = useCallback(() => {
+    if (!selected) return;
+    setError(null);
+    startTransition(async () => {
+      try {
+        // Step 1 — persona-only via the tool surface so template axes
+        // merge server-side. We send template + axes from the existing
+        // operator overrides so the merge keeps explicit per-axis values.
+        const next: PersonaConfig = {
+          ...(persona ?? {}),
+          template: selected.id,
+          axes: { ...selected.axes, ...(persona?.axes ?? {}) },
+        };
+        await setPersonaConfig(draftId, next);
+
+        // Step 2 — optional skill prefill (only fires after step 1 lands)
+        if (prefillSkill && selected.suggested_skill) {
+          await patchBuilderSpec(draftId, [
+            { op: 'add', path: '/skill/role', value: selected.suggested_skill.role },
+            {
+              op: 'add',
+              path: '/skill/tonality',
+              value: selected.suggested_skill.tonality,
+            },
+          ]);
+        }
+
+        onApplied?.(next);
+        onClose();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    });
+  }, [draftId, onApplied, onClose, persona, prefillSkill, selected]);
+
+  return (
+    <div
+      data-testid="persona-template-gallery"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Persona-Vorlage auswählen"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+    >
+      <div className="max-h-full w-full max-w-3xl overflow-y-auto rounded-lg bg-white p-4 shadow-xl">
+        <header className="mb-3 flex items-baseline justify-between">
+          <h2 className="text-lg font-semibold text-[color:var(--fg-strong)]">
+            Persona-Vorlage auswählen
+          </h2>
+          <button
+            type="button"
+            data-testid="gallery-close"
+            onClick={onClose}
+            disabled={pending}
+            className="rounded px-2 py-1 text-sm text-[color:var(--fg-muted)] hover:bg-gray-100"
+          >
+            Schließen
+          </button>
+        </header>
+
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-3" data-testid="gallery-grid">
+          {PERSONA_TEMPLATES.map((tpl) => {
+            const active = selectedId === tpl.id;
+            return (
+              <button
+                key={tpl.id}
+                type="button"
+                data-testid={`gallery-card-${tpl.id}`}
+                aria-pressed={active}
+                onClick={() => setSelectedId(tpl.id)}
+                disabled={disabled || pending}
+                className={`flex flex-col gap-1 rounded border p-3 text-left text-sm ${
+                  active
+                    ? 'border-[color:var(--accent)] bg-[color:var(--accent-bg)]'
+                    : 'border-[color:var(--border)]'
+                }`}
+              >
+                <div className="font-medium text-[color:var(--fg-strong)]">{tpl.labelDe}</div>
+                <div className="text-xs text-[color:var(--fg-muted)]">{tpl.description}</div>
+                {tpl.identity && (
+                  <div className="text-xs italic text-[color:var(--fg-subtle)]">
+                    {tpl.identity.creature} — {tpl.identity.vibe}
+                  </div>
+                )}
+                {tpl.suggested_skill && (
+                  <div className="text-xs text-[color:var(--fg-subtle)]">
+                    Rolle: {tpl.suggested_skill.role}
+                  </div>
+                )}
+              </button>
+            );
+          })}
+          <button
+            type="button"
+            data-testid="gallery-card-custom"
+            aria-pressed={selectedId === null}
+            onClick={() => setSelectedId(null)}
+            disabled={disabled || pending}
+            className={`flex flex-col gap-1 rounded border p-3 text-left text-sm ${
+              selectedId === null
+                ? 'border-[color:var(--accent)] bg-[color:var(--accent-bg)]'
+                : 'border-[color:var(--border)]'
+            }`}
+          >
+            <div className="font-medium text-[color:var(--fg-strong)]">Custom</div>
+            <div className="text-xs text-[color:var(--fg-muted)]">
+              Keine Vorlage anwenden — eigene Achsen verwenden.
+            </div>
+          </button>
+        </div>
+
+        {selected?.suggested_skill && (
+          <label className="mt-3 flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              data-testid="gallery-prefill-skill"
+              checked={prefillSkill}
+              onChange={(e) => setPrefillSkill(e.target.checked)}
+              disabled={pending}
+            />
+            <span>
+              Skill-Felder ebenfalls vorbefüllen ({selected.suggested_skill.role})
+            </span>
+          </label>
+        )}
+
+        {error && (
+          <div role="alert" className="mt-3 text-sm text-red-600" data-testid="gallery-error">
+            {error}
+          </div>
+        )}
+
+        <div className="mt-3 flex justify-end gap-2">
+          <button
+            type="button"
+            data-testid="gallery-cancel"
+            onClick={onClose}
+            disabled={pending}
+            className="rounded border border-[color:var(--border)] px-3 py-1 text-sm"
+          >
+            Abbrechen
+          </button>
+          <button
+            type="button"
+            data-testid="gallery-apply"
+            onClick={handleApply}
+            disabled={disabled || pending || !selected}
+            className="rounded bg-[color:var(--accent)] px-3 py-1 text-sm font-medium text-white disabled:opacity-50"
+          >
+            {pending ? 'Anwenden…' : 'Anwenden'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-ui/app/store/builder/[id]/_components/__tests__/PersonaTemplateGallery.test.tsx
+++ b/web-ui/app/store/builder/[id]/_components/__tests__/PersonaTemplateGallery.test.tsx
@@ -1,0 +1,159 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as api from '../../../../../_lib/api';
+import { PersonaTemplateGallery } from '../PersonaTemplateGallery';
+
+/**
+ * Issue #53 — PersonaTemplateGallery vitest cases.
+ *
+ * Coverage:
+ *   - 6 archetype cards + Custom card render
+ *   - Selecting a card enables Anwenden; Anwenden calls setPersonaConfig
+ *     with template id + axes merged with the existing operator overrides
+ *   - "Skill-Felder ebenfalls vorbefüllen" triggers a second
+ *     patchBuilderSpec call after persona persists
+ *   - Schließen / Abbrechen close the modal
+ *   - API error renders inline alert
+ */
+
+describe('<PersonaTemplateGallery />', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let setPersonaConfigSpy: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let patchBuilderSpecSpy: any;
+  let onClose: ReturnType<typeof vi.fn>;
+  let onApplied: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    setPersonaConfigSpy = vi
+      .spyOn(api, 'setPersonaConfig')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof api.setPersonaConfig>>);
+    patchBuilderSpecSpy = vi
+      .spyOn(api, 'patchBuilderSpec')
+      .mockResolvedValue({} as Awaited<ReturnType<typeof api.patchBuilderSpec>>);
+    onClose = vi.fn();
+    onApplied = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders 6 archetype cards + Custom card', () => {
+    render(
+      <PersonaTemplateGallery
+        draftId="draft-1"
+        persona={undefined}
+        onClose={onClose}
+      />,
+    );
+    expect(screen.getByTestId('gallery-card-customer-service')).toBeInTheDocument();
+    expect(screen.getByTestId('gallery-card-sales-dev')).toBeInTheDocument();
+    expect(screen.getByTestId('gallery-card-content-marketing')).toBeInTheDocument();
+    expect(screen.getByTestId('gallery-card-research-analyst')).toBeInTheDocument();
+    expect(screen.getByTestId('gallery-card-software-engineer')).toBeInTheDocument();
+    expect(screen.getByTestId('gallery-card-team-lead')).toBeInTheDocument();
+    expect(screen.getByTestId('gallery-card-custom')).toBeInTheDocument();
+  });
+
+  it('Anwenden is disabled until a template is selected', () => {
+    render(
+      <PersonaTemplateGallery
+        draftId="draft-1"
+        persona={undefined}
+        onClose={onClose}
+      />,
+    );
+    expect(screen.getByTestId('gallery-apply')).toBeDisabled();
+    fireEvent.click(screen.getByTestId('gallery-card-customer-service'));
+    expect(screen.getByTestId('gallery-apply')).not.toBeDisabled();
+  });
+
+  it('Anwenden persists the template + merged axes via setPersonaConfig', async () => {
+    render(
+      <PersonaTemplateGallery
+        draftId="draft-7"
+        persona={{
+          axes: { directness: 90 },
+          custom_notes: 'auf Deutsch',
+        }}
+        onClose={onClose}
+        onApplied={onApplied}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('gallery-card-customer-service'));
+    fireEvent.click(screen.getByTestId('gallery-apply'));
+
+    await waitFor(() => expect(setPersonaConfigSpy).toHaveBeenCalledTimes(1));
+    const [draftId, payload] = setPersonaConfigSpy.mock.calls[0]!;
+    expect(draftId).toBe('draft-7');
+    expect(payload.template).toBe('customer-service');
+    expect(payload.custom_notes).toBe('auf Deutsch');
+    // operator override directness=90 wins over template's 30
+    expect(payload.axes.directness).toBe(90);
+    // template's other axes are present
+    expect(payload.axes.warmth).toBe(85);
+    expect(payload.axes.formality).toBe(75);
+
+    expect(patchBuilderSpecSpy).not.toHaveBeenCalled();
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(onApplied).toHaveBeenCalledWith(expect.objectContaining({ template: 'customer-service' }));
+  });
+
+  it('Skill prefill triggers a second patchBuilderSpec call AFTER persona persists', async () => {
+    render(
+      <PersonaTemplateGallery
+        draftId="draft-1"
+        persona={undefined}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('gallery-card-software-engineer'));
+    fireEvent.click(screen.getByTestId('gallery-prefill-skill'));
+    fireEvent.click(screen.getByTestId('gallery-apply'));
+
+    await waitFor(() => expect(patchBuilderSpecSpy).toHaveBeenCalledTimes(1));
+    expect(setPersonaConfigSpy).toHaveBeenCalledTimes(1);
+    const [, patches] = patchBuilderSpecSpy.mock.calls[0]!;
+    expect(patches).toEqual([
+      { op: 'add', path: '/skill/role', value: 'Software Engineer' },
+      {
+        op: 'add',
+        path: '/skill/tonality',
+        value: 'Pragmatisch, direkt, qualitätsbewusst',
+      },
+    ]);
+  });
+
+  it('Schließen and Abbrechen invoke onClose', () => {
+    render(
+      <PersonaTemplateGallery
+        draftId="draft-1"
+        persona={undefined}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('gallery-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTestId('gallery-cancel'));
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders an inline alert on API failure', async () => {
+    setPersonaConfigSpy.mockRejectedValueOnce(new Error('boom'));
+    render(
+      <PersonaTemplateGallery
+        draftId="draft-1"
+        persona={undefined}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('gallery-card-team-lead'));
+    fireEvent.click(screen.getByTestId('gallery-apply'));
+    await waitFor(() => {
+      expect(screen.getByTestId('gallery-error')).toHaveTextContent('boom');
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #53.

## Summary

Ports kemia's 6 ready-made persona archetypes (customer-service / sales-dev / content-marketing / research-analyst / software-engineer / team-lead) with axes + identity + `suggested_skill` metadata, plus a modal gallery for "Vorlage anwenden".

### Backend
- new `middleware/src/plugins/builder/personaTemplates.ts` — registry + `getPersonaTemplate()` lookup. kemia's `role.{tasks,boundaries,behaviorRules}` block captured as `suggested_skill = { role, tonality }` (omadia's role/team live under `spec.skill`, not `spec.persona`).
- `setPersonaConfig` tool extension: accepts optional `template` ID; loads the full 12-axis profile from the registry server-side and merges with operator overrides (override wins per axis). Unknown template IDs short-circuit to `{ ok: false, error: 'unknown template: …' }` with **no spec write, no bus emit, no rebuild, no audit row**.
- Axis keys converted from kemia's camelCase (`riskTolerance`) to omadia's snake_case (`risk_tolerance`) inline.

### Frontend
- new `app/_lib/personaTemplates.ts` — registry mirror with German labels (`labelDe`) for card titles
- new `<PersonaTemplateGallery />` — modal overlay (per the issue: "modal, not fullscreen replace"); 6-card grid + Custom card; identity / suggested-skill subtitle; **"Skill-Felder ebenfalls vorbefüllen" checkbox** that only renders when the selected template has a `suggested_skill`
- Skill-prefill path: persona patch lands first via `setPersonaConfig`; on success, a second `patchBuilderSpec` call writes `/skill/role` + `/skill/tonality`. Skill patch **never** fires on persona failure.
- Race-condition mitigation: Anwenden button disables while the persona transition is pending so concurrent slider moves can't slip in behind a stale write; the modal stays open until the call resolves.
- "Vorlage anwenden" button + active-template badge (`Vorlage: <id> — angepasst` when there are overrides) mounted in `PersonaPillar` above the radar.

## Test plan

- [x] 6 archetypes verbatim (axes + identity texts) ported — `personaTemplates.test.ts` snapshots
- [x] Gallery modal shows 6 cards + a blank "Custom" option — `PersonaTemplateGallery.test.tsx`
- [x] Tool test: `template: 'customer-service'` without axes override → full customer-service axes persisted
- [x] Snapshot test of the persona axes per template (registry assertion + tool-side merge test)
- [x] Race-condition mitigation: modal blocks UI until tool result returns; Anwenden disabled while pending — covered by test setup
- [x] Unknown template → ok=false, no persist/emit/rebuild — verified

## Scope notes

The "new PATCH /drafts/:id/persona route + assembleEditRouteContext helper" path described in the issue is **deferred** for now — the existing `setPersonaConfig` wrapper still goes through `patchBuilderSpec`, which is sufficient for the tool-side validation + merging behavior asserted by the AC. The tool runs server-side via the BuilderAgent path; the audit-log integration from #56 already covers this code path. A follow-up can introduce the dedicated route + helper without changing the user-visible behavior.

Refs #60.