### PR TITLE
feat(builder): preview-prompt panel (live compiled system-prompt) (#55)

### DIFF
--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -1713,6 +1713,8 @@ async function main(): Promise<void> {
       },
       // Issue #56 — paginated audit-log surface
       audit: { draftStore },
+      // Issue #55 — live compiled-prompt preview
+      previewPrompt: { draftStore },
       // Install endpoint is only wired when the package-upload subsystem is
       // enabled — otherwise the underlying ingest service does not exist.
       // BuilderRouterDeps.install is optional so the route stays absent.

--- a/middleware/src/routes/builder.ts
+++ b/middleware/src/routes/builder.ts
@@ -36,6 +36,10 @@ import {
   type BuilderEditDeps,
 } from './builderEdit.js';
 import {
+  registerBuilderPreviewPromptRoute,
+  type BuilderPreviewPromptDeps,
+} from './builderPreviewPrompt.js';
+import {
   registerBuilderEventsRoutes,
   type BuilderEventsDeps,
 } from './builderEvents.js';
@@ -78,6 +82,9 @@ export interface BuilderRouterDeps {
   /** Audit-log GET surface (issue #56). When omitted, the
    *  GET /drafts/:id/audit endpoint stays absent. */
   audit?: BuilderAuditDeps;
+  /** Preview-prompt POST surface (issue #55). When omitted, the
+   *  POST /drafts/:id/preview-prompt endpoint stays absent. */
+  previewPrompt?: BuilderPreviewPromptDeps;
   /** SSE event-bus stream (B.5-4). When omitted, the
    *  GET /drafts/:id/events endpoint stays absent. Wired by `index.ts`
    *  alongside the chat + edit surfaces — a single SpecEventBus instance
@@ -453,6 +460,11 @@ export function createBuilderRouter(deps: BuilderRouterDeps): Router {
   // ── Builder audit-log GET (issue #56) ──────────────────────────────────
   if (deps.audit) {
     registerBuilderAuditRoute(router, deps.audit);
+  }
+
+  // ── Builder preview-prompt POST (issue #55) ────────────────────────────
+  if (deps.previewPrompt) {
+    registerBuilderPreviewPromptRoute(router, deps.previewPrompt);
   }
 
   // ── Builder SSE event stream (B.5-4) ──────────────────────────────────

--- a/middleware/src/routes/builderPreviewPrompt.ts
+++ b/middleware/src/routes/builderPreviewPrompt.ts
@@ -1,0 +1,161 @@
+import type { Router, Request, Response } from 'express';
+
+import type { DraftStore } from '../plugins/builder/draftStore.js';
+import {
+  compileBoundariesSection,
+} from '../plugins/builder/boundaryPresets.js';
+import { composePersonaSection } from '../plugins/personaCompose.js';
+import {
+  inferFamilyFromModel,
+} from '../plugins/dynamicAgentRuntime.js';
+import { compileSycophancyGuard } from '../plugins/sycophancyGuard.js';
+
+/**
+ * Issue #55 — preview-prompt route.
+ *
+ *   POST /v1/builder/drafts/:id/preview-prompt
+ *
+ * Composes the system prompt **directly from the draft spec** (not from
+ * AGENT.md files or preview-build artifacts) so the operator can see
+ * the live compiled prompt as soon as the spec mutates. Matches the
+ * runtime compose order from `dynamicAgentRuntime`:
+ *
+ *   [header, persona, boundaries, sycophancy, skill]
+ *
+ * Returns `{ systemPrompt, tokens, sections[] }`. Token count uses a
+ * deterministic `chars / 4` approximator; an Anthropic-roundtrip
+ * counter remains out of scope (separate feature flag if/when needed).
+ */
+
+export interface BuilderPreviewPromptDeps {
+  draftStore: DraftStore;
+}
+
+interface PreviewSection {
+  label: string;
+  content: string;
+  kind: 'header' | 'persona' | 'boundaries' | 'sycophancy' | 'skill' | 'custom_notes';
+}
+
+const APPROX_CHARS_PER_TOKEN = 4;
+
+export function registerBuilderPreviewPromptRoute(
+  router: Router,
+  deps: BuilderPreviewPromptDeps,
+): void {
+  router.post('/drafts/:id/preview-prompt', async (req: Request, res: Response) => {
+    const email = readEmail(req);
+    if (!email) {
+      return sendJson(res, 401, { code: 'auth.missing', message: 'no session' });
+    }
+    const draftId = readId(req);
+    if (!draftId) {
+      return sendJson(res, 400, { code: 'builder.invalid_id', message: 'missing :id' });
+    }
+    const draft = await deps.draftStore.load(email, draftId);
+    if (!draft) {
+      return sendJson(res, 404, {
+        code: 'builder.draft_not_found',
+        message: `kein Draft mit id '${draftId}'`,
+      });
+    }
+
+    const family = inferFamilyFromModel(draft.previewModel);
+    const sections: PreviewSection[] = [];
+
+    // Header — minimal placeholder; runtime builds a richer header from
+    // the install-catalog entry, but the preview only has the draft.
+    const headerText = `# ${draft.spec.id || draft.name}`;
+    sections.push({ label: 'Header', content: headerText, kind: 'header' });
+
+    // Persona section
+    if (draft.spec.persona) {
+      const personaText = composePersonaSection({
+        persona: draft.spec.persona,
+        family,
+      });
+      if (personaText.length > 0) {
+        sections.push({ label: 'Persona', content: personaText, kind: 'persona' });
+      }
+      if (
+        typeof draft.spec.persona.custom_notes === 'string' &&
+        draft.spec.persona.custom_notes.length > 0
+      ) {
+        sections.push({
+          label: 'Custom Notes',
+          content: draft.spec.persona.custom_notes,
+          kind: 'custom_notes',
+        });
+      }
+    }
+
+    // Boundaries section
+    const boundaries = draft.spec.quality?.boundaries;
+    if (boundaries) {
+      const { text } = compileBoundariesSection(
+        boundaries.presets ?? [],
+        boundaries.custom ?? [],
+      );
+      if (text.length > 0) {
+        sections.push({ label: 'Boundaries', content: text, kind: 'boundaries' });
+      }
+    }
+
+    // Sycophancy section
+    const sycophancy = draft.spec.quality?.sycophancy;
+    const sycophancyText = compileSycophancyGuard(sycophancy);
+    if (sycophancyText.length > 0) {
+      sections.push({
+        label: 'Sycophancy Guard',
+        content: sycophancyText,
+        kind: 'sycophancy',
+      });
+    }
+
+    // Skill block — render the description + role/tonality, mirroring
+    // what the codegen path emits.
+    if (draft.spec.description || draft.spec.skill) {
+      const skillParts: string[] = [];
+      if (typeof draft.spec.description === 'string' && draft.spec.description.length > 0) {
+        skillParts.push(`## Mission\n${draft.spec.description}`);
+      }
+      const skill = draft.spec.skill;
+      if (skill?.role || skill?.tonality) {
+        const lines: string[] = [];
+        if (skill?.role) lines.push(`- Rolle: ${skill.role}`);
+        if (skill?.tonality) lines.push(`- Tonalität: ${skill.tonality}`);
+        skillParts.push(`## Skill\n${lines.join('\n')}`);
+      }
+      if (skillParts.length > 0) {
+        sections.push({
+          label: 'Skill',
+          content: skillParts.join('\n\n'),
+          kind: 'skill',
+        });
+      }
+    }
+
+    const systemPrompt = sections.map((s) => s.content).join('\n\n---\n\n');
+    const tokens = Math.ceil(systemPrompt.length / APPROX_CHARS_PER_TOKEN);
+
+    res.json({ systemPrompt, tokens, sections });
+  });
+}
+
+function readEmail(req: Request): string | null {
+  const email = req.session?.email;
+  return typeof email === 'string' && email.length > 0 ? email : null;
+}
+
+function readId(req: Request): string | null {
+  const raw = req.params['id'];
+  return typeof raw === 'string' && raw.length > 0 ? raw : null;
+}
+
+function sendJson(
+  res: Response,
+  status: number,
+  body: Record<string, unknown>,
+): void {
+  res.status(status).json(body);
+}

--- a/middleware/test/builder/builderPreviewPromptRoute.test.ts
+++ b/middleware/test/builder/builderPreviewPromptRoute.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import express from 'express';
+
+import { DraftStore } from '../../src/plugins/builder/draftStore.js';
+import { registerBuilderPreviewPromptRoute } from '../../src/routes/builderPreviewPrompt.js';
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    session?: { email?: string };
+  }
+}
+
+interface SessionFixture {
+  email: string;
+}
+
+async function bootServer(
+  draftStore: DraftStore,
+  session: SessionFixture,
+): Promise<{ url: string; server: Server }> {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.session = { email: session.email };
+    next();
+  });
+  const router = express.Router();
+  registerBuilderPreviewPromptRoute(router, { draftStore });
+  app.use('/v1/builder', router);
+
+  return new Promise((resolve) => {
+    const server = createServer(app);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ url: `http://127.0.0.1:${port}`, server });
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+describe('builderPreviewPrompt route (issue #55)', () => {
+  let tmpRoot: string;
+  let store: DraftStore;
+  let server: Server;
+  let baseUrl: string;
+  let draftId: string;
+  const userEmail = 'alice@example.com';
+
+  beforeEach(async () => {
+    tmpRoot = mkdtempSync(path.join(tmpdir(), 'preview-prompt-'));
+    store = new DraftStore({ dbPath: path.join(tmpRoot, 'drafts.db') });
+    await store.open();
+    const d = await store.create(userEmail, 'Weather');
+    draftId = d.id;
+    const boot = await bootServer(store, { email: userEmail });
+    server = boot.server;
+    baseUrl = boot.url;
+  });
+
+  afterEach(async () => {
+    await closeServer(server);
+    await store.close();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('returns sections, systemPrompt, and tokens for an empty draft', async () => {
+    const res = await fetch(`${baseUrl}/v1/builder/drafts/${draftId}/preview-prompt`, {
+      method: 'POST',
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as {
+      systemPrompt: string;
+      tokens: number;
+      sections: { kind: string; content: string }[];
+    };
+    // Empty draft → just a header section
+    assert.ok(Array.isArray(body.sections));
+    assert.ok(body.sections.length >= 1);
+    assert.equal(body.sections[0]!.kind, 'header');
+    assert.ok(body.tokens >= 1, 'token count must be at least 1 for the header');
+  });
+
+  it('emits sections in compose order [header, persona, boundaries, sycophancy, skill]', async () => {
+    const draft = await store.load(userEmail, draftId);
+    assert.ok(draft);
+    await store.update(userEmail, draftId, {
+      spec: {
+        ...draft.spec,
+        description: 'Beantwortet Wetteranfragen.',
+        skill: { role: 'Weather Agent', tonality: 'freundlich' },
+        persona: {
+          template: 'customer-service',
+          axes: { directness: 90 },
+          custom_notes: 'auf Deutsch antworten',
+        },
+        quality: {
+          sycophancy: 'medium',
+          boundaries: { presets: ['no-pii'], custom: ['keine Spekulationen'] },
+        },
+      },
+    });
+
+    const res = await fetch(`${baseUrl}/v1/builder/drafts/${draftId}/preview-prompt`, {
+      method: 'POST',
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as {
+      systemPrompt: string;
+      tokens: number;
+      sections: { kind: string; content: string }[];
+    };
+    const kinds = body.sections.map((s) => s.kind);
+    // First entry must be header; remaining respect the issue's compose order
+    assert.equal(kinds[0], 'header');
+    // Each kind appears at most once and the relative order is preserved
+    const order: Record<string, number> = {
+      header: 0,
+      persona: 1,
+      custom_notes: 2,
+      boundaries: 3,
+      sycophancy: 4,
+      skill: 5,
+    };
+    let lastIdx = -1;
+    for (const kind of kinds) {
+      const idx = order[kind];
+      assert.ok(idx !== undefined, `unexpected section kind: ${kind}`);
+      assert.ok(idx >= lastIdx, `out-of-order kind: ${kind}`);
+      lastIdx = idx;
+    }
+    // All key sections present
+    assert.ok(kinds.includes('persona'));
+    assert.ok(kinds.includes('boundaries'));
+    assert.ok(kinds.includes('sycophancy'));
+    assert.ok(kinds.includes('skill'));
+    // systemPrompt is non-empty and includes content from each section.
+    // Sycophancy=medium renders the "Critical Thinking" header.
+    assert.match(body.systemPrompt, /Boundaries/);
+    assert.match(body.systemPrompt, /Critical Thinking Guidelines/);
+    assert.ok(body.tokens > 10);
+  });
+
+  it('omits missing sections silently', async () => {
+    // Default draft has no persona / boundaries / sycophancy → only the
+    // header and (after seeding skill) the skill block are present.
+    const draft = await store.load(userEmail, draftId);
+    assert.ok(draft);
+    await store.update(userEmail, draftId, {
+      spec: { ...draft.spec, skill: { role: 'Just a role' } },
+    });
+
+    const res = await fetch(`${baseUrl}/v1/builder/drafts/${draftId}/preview-prompt`, {
+      method: 'POST',
+    });
+    const body = (await res.json()) as {
+      sections: { kind: string }[];
+    };
+    const kinds = body.sections.map((s) => s.kind);
+    assert.equal(kinds.includes('persona'), false);
+    assert.equal(kinds.includes('boundaries'), false);
+    assert.equal(kinds.includes('sycophancy'), false);
+    assert.equal(kinds.includes('skill'), true);
+  });
+
+  it('404 when the draft is unreachable by the calling user', async () => {
+    const res = await fetch(`${baseUrl}/v1/builder/drafts/does-not-exist/preview-prompt`, {
+      method: 'POST',
+    });
+    assert.equal(res.status, 404);
+  });
+});

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -1951,6 +1951,49 @@ export async function runOperatorPrivacyLiveTest(
   });
 }
 
+// ── Builder preview prompt (issue #55) ──────────────────────────────────────
+
+export interface PreviewPromptSection {
+  label: string;
+  content: string;
+  kind: 'header' | 'persona' | 'boundaries' | 'sycophancy' | 'skill' | 'custom_notes';
+}
+
+export interface BuilderPreviewPrompt {
+  systemPrompt: string;
+  tokens: number;
+  sections: PreviewPromptSection[];
+}
+
+/**
+ * Issue #55 — render the live compiled system prompt for a draft.
+ * POST so the route can carry future options (token-count mode, etc.)
+ * without breaking the GET surface.
+ */
+export async function fetchBuilderPreviewPrompt(
+  draftId: string,
+): Promise<BuilderPreviewPrompt> {
+  const forwarded = await forwardCookieHeader();
+  const res = await fetch(
+    botApi(`/v1/builder/drafts/${encodeURIComponent(draftId)}/preview-prompt`),
+    {
+      method: 'POST',
+      headers: { accept: 'application/json', ...forwarded },
+      credentials: 'include',
+      cache: 'no-store',
+    },
+  );
+  const text = await res.text();
+  if (!res.ok) {
+    throw new ApiError(
+      res.status,
+      `POST /v1/builder/drafts/${draftId}/preview-prompt failed: ${res.status}`,
+      text,
+    );
+  }
+  return JSON.parse(text) as BuilderPreviewPrompt;
+}
+
 // ── Builder audit log (issue #57) ───────────────────────────────────────────
 
 export interface BuilderAuditEvent {

--- a/web-ui/app/store/builder/[id]/_components/PreviewPromptPanel.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PreviewPromptPanel.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  fetchBuilderPreviewPrompt,
+  type BuilderPreviewPrompt,
+  type PreviewPromptSection,
+} from '../../../../_lib/api';
+
+/**
+ * Issue #55 — live compiled-prompt preview panel.
+ *
+ * Subscribes to draft mutations via a manual refetch (parent passes
+ * `refetchKey` from the SpecEventBus debounce). Renders the compiled
+ * sections newest-first with per-section background highlighting, a
+ * total token count with health indicator, and a Copy button.
+ */
+
+const KIND_BG: Record<PreviewPromptSection['kind'], string> = {
+  header: 'bg-slate-50',
+  persona: 'bg-amber-50',
+  custom_notes: 'bg-amber-50/50',
+  boundaries: 'bg-rose-50',
+  sycophancy: 'bg-violet-50',
+  skill: 'bg-emerald-50',
+};
+
+const KIND_LABEL: Record<PreviewPromptSection['kind'], string> = {
+  header: 'Header',
+  persona: 'Persona',
+  custom_notes: 'Custom Notes',
+  boundaries: 'Boundaries',
+  sycophancy: 'Sycophancy',
+  skill: 'Skill',
+};
+
+function tokenHealth(tokens: number): { color: string; label: string } {
+  if (tokens < 2000) return { color: 'text-emerald-600', label: 'gut' };
+  if (tokens < 3500) return { color: 'text-amber-600', label: 'mittel' };
+  if (tokens < 5000) return { color: 'text-orange-600', label: 'hoch' };
+  return { color: 'text-red-600', label: 'kritisch' };
+}
+
+export interface PreviewPromptPanelProps {
+  draftId: string;
+  /** Optional refetch trigger — bumping the value re-runs the fetch. */
+  refetchKey?: number;
+}
+
+export function PreviewPromptPanel({
+  draftId,
+  refetchKey,
+}: PreviewPromptPanelProps): React.ReactElement {
+  const [data, setData] = useState<BuilderPreviewPrompt | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState<boolean>(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await fetchBuilderPreviewPrompt(draftId);
+      setData(next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [draftId]);
+
+  useEffect(() => {
+    void load();
+  }, [load, refetchKey]);
+
+  const handleCopy = useCallback(async () => {
+    if (!data) return;
+    try {
+      if (
+        typeof navigator !== 'undefined' &&
+        navigator.clipboard?.writeText
+      ) {
+        await navigator.clipboard.writeText(data.systemPrompt);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
+    } catch {
+      /* clipboard denied — silently ignore */
+    }
+  }, [data]);
+
+  const health = data ? tokenHealth(data.tokens) : null;
+
+  return (
+    <section
+      data-testid="preview-prompt-panel"
+      className="space-y-2 rounded border border-[color:var(--border)] p-3"
+    >
+      <header className="flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold text-[color:var(--fg-strong)]">
+          Preview Prompt
+        </h3>
+        <div className="flex items-center gap-2 text-xs">
+          {data && (
+            <span data-testid="preview-prompt-tokens" className={health!.color}>
+              {data.tokens} Tokens ({health!.label})
+            </span>
+          )}
+          <button
+            type="button"
+            data-testid="preview-prompt-refresh"
+            onClick={() => {
+              void load();
+            }}
+            disabled={loading}
+            className="rounded border border-[color:var(--border)] px-2 py-1"
+          >
+            {loading ? 'Lade…' : 'Aktualisieren'}
+          </button>
+          <button
+            type="button"
+            data-testid="preview-prompt-copy"
+            onClick={handleCopy}
+            disabled={!data || loading}
+            className="rounded border border-[color:var(--border)] px-2 py-1"
+          >
+            {copied ? 'Kopiert ✓' : 'Kopieren'}
+          </button>
+        </div>
+      </header>
+
+      {error && (
+        <div role="alert" className="text-xs text-red-600" data-testid="preview-prompt-error">
+          {error}
+        </div>
+      )}
+
+      <div className="space-y-1 font-mono text-xs" data-testid="preview-prompt-sections">
+        {data?.sections.map((s, i) => (
+          <pre
+            // Index is fine here — sections are deterministic per draft state
+            // eslint-disable-next-line react/no-array-index-key
+            key={i}
+            data-testid={`preview-prompt-section-${s.kind}`}
+            className={`overflow-x-auto whitespace-pre-wrap rounded p-2 ${KIND_BG[s.kind]}`}
+          >
+            <span className="block text-[10px] font-semibold uppercase text-[color:var(--fg-muted)]">
+              {KIND_LABEL[s.kind]}
+            </span>
+            {s.content}
+          </pre>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/web-ui/app/store/builder/[id]/_components/Workspace.tsx
+++ b/web-ui/app/store/builder/[id]/_components/Workspace.tsx
@@ -56,6 +56,7 @@ import { SpecEditor } from './SpecEditor';
 import { SpecOverview } from './SpecOverview';
 import { UiSurfacesTabPane } from './UiSurfacesTabPane';
 import { AuditTimelinePane } from './AuditTimelinePane';
+import { PreviewPromptPanel } from './PreviewPromptPanel';
 import { VersionsTab } from './VersionsTab';
 import { useSpecEvents } from './useSpecEvents';
 
@@ -657,6 +658,12 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
                       spec: { ...prev.spec, persona: next },
                     }));
                   }}
+                />
+                {/* Issue #55 — live compiled-prompt preview panel.
+                 *  Refetches whenever the draft state changes. */}
+                <PreviewPromptPanel
+                  draftId={draft.id}
+                  refetchKey={draft.updatedAt}
                 />
               </div>
             )}

--- a/web-ui/app/store/builder/[id]/_components/__tests__/PreviewPromptPanel.test.tsx
+++ b/web-ui/app/store/builder/[id]/_components/__tests__/PreviewPromptPanel.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as api from '../../../../../_lib/api';
+import { PreviewPromptPanel } from '../PreviewPromptPanel';
+
+/**
+ * Issue #55 — PreviewPromptPanel vitest cases.
+ *
+ * Coverage:
+ *   - Mount triggers a fetch and renders sections per kind
+ *   - Token count + health label render
+ *   - Aktualisieren button refetches
+ *   - Bumping `refetchKey` refetches
+ *   - API error surfaces inline alert
+ */
+
+describe('<PreviewPromptPanel />', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fetchSpy: any;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(api, 'fetchBuilderPreviewPrompt');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches on mount and renders all sections by kind', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      systemPrompt: '# Hi\n\n---\n\n<persona>...</persona>',
+      tokens: 124,
+      sections: [
+        { label: 'Header', content: '# Hi', kind: 'header' },
+        { label: 'Persona', content: '<persona>...</persona>', kind: 'persona' },
+        { label: 'Sycophancy Guard', content: '## Critical Thinking', kind: 'sycophancy' },
+      ],
+    });
+    render(<PreviewPromptPanel draftId="draft-1" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('preview-prompt-section-header')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('preview-prompt-section-persona')).toBeInTheDocument();
+    expect(screen.getByTestId('preview-prompt-section-sycophancy')).toBeInTheDocument();
+    expect(screen.getByTestId('preview-prompt-tokens')).toHaveTextContent('124 Tokens');
+  });
+
+  it('Aktualisieren button refetches the prompt', async () => {
+    fetchSpy.mockResolvedValue({
+      systemPrompt: '# Hi',
+      tokens: 1,
+      sections: [{ label: 'Header', content: '# Hi', kind: 'header' }],
+    });
+    render(<PreviewPromptPanel draftId="draft-1" />);
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByTestId('preview-prompt-refresh'));
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+  });
+
+  it('bumping refetchKey refetches', async () => {
+    fetchSpy.mockResolvedValue({
+      systemPrompt: '# Hi',
+      tokens: 1,
+      sections: [{ label: 'Header', content: '# Hi', kind: 'header' }],
+    });
+    const { rerender } = render(<PreviewPromptPanel draftId="draft-1" refetchKey={0} />);
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    rerender(<PreviewPromptPanel draftId="draft-1" refetchKey={1} />);
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+  });
+
+  it('renders inline alert when fetch fails', async () => {
+    fetchSpy.mockRejectedValueOnce(new Error('boom'));
+    render(<PreviewPromptPanel draftId="draft-1" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('preview-prompt-error')).toHaveTextContent('boom');
+    });
+  });
+
+  it('token-health label tracks token thresholds', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      systemPrompt: 'x'.repeat(10),
+      tokens: 1500,
+      sections: [{ label: 'Header', content: '# Hi', kind: 'header' }],
+    });
+    render(<PreviewPromptPanel draftId="draft-1" />);
+    await waitFor(() => {
+      expect(screen.getByTestId('preview-prompt-tokens')).toHaveTextContent('gut');
+    });
+  });
+});


### PR DESCRIPTION
Closes #55.

## Summary

Live compiled-prompt preview. Composes from the draft spec directly (not AGENT.md files or build artifacts) so the operator sees the final system prompt while editing.

### Backend
- new `POST /v1/builder/drafts/:id/preview-prompt`
- compose order matches the runtime: `[header, persona, boundaries, sycophancy, skill]`
- response: `{ systemPrompt, tokens, sections[{label, content, kind}] }`
- token count via deterministic `chars/4` approximator (Anthropic round-trip out of scope per the issue's mandatory AC)
- owner-scoped via `DraftStore.load`; 404 on unreachable drafts

### Frontend
- new `fetchBuilderPreviewPrompt()` API wrapper + types
- new `<PreviewPromptPanel />` — per-kind section highlighting (slate header / amber persona+custom_notes / rose boundaries / violet sycophancy / emerald skill), token-count health label (gut / mittel / hoch / kritisch with the AC's 2000/3500/5000 thresholds), Aktualisieren + Kopieren buttons, inline error alert
- Mounted in the Persona tab below `<PersonaPillar />`; refetches when `draft.updatedAt` bumps (manual `refetchKey` prop)

## Test plan

- [x] **4 route tests**: empty draft → header-only response, fully-configured draft → all sections in compose order, missing sections silently omitted, 404 on unreachable draft
- [x] **5 vitest cases** for `<PreviewPromptPanel />`: mount fetch + per-kind render, Aktualisieren refetches, `refetchKey` bump refetches, inline alert on rejection, token-health label tracks 1500 → "gut"
- [x] `npm run lint` + `npm run typecheck` clean

## Scope notes

The "helper refactor" splitting `compose*FromAgentMd` into inner/outer layers is deferred — the preview route already uses the same inner-layer helpers (`composePersonaSection`, `compileBoundariesSection`, `compileSycophancyGuard`) that `dynamicAgentRuntime` calls, so the single-source guarantee holds without a refactor. A follow-up can DRY the AGENT.md-reading layer if needed.

Refs #60.