### PR TITLE
test(builder): per-bar ±5 tolerance fixture snapshots (#52 follow-up)

### DIFF
--- a/middleware/test/qualityScore.test.ts
+++ b/middleware/test/qualityScore.test.ts
@@ -23,6 +23,29 @@ function withRules(
   return { ...spec, ...overrides };
 }
 
+/**
+ * Per-bar tolerance assertion (issue #52 follow-up). Asserts that
+ * `actual` is within `tolerance` of `expected`, inclusive. The default
+ * tolerance ±5 matches the AC; tightening individual fixtures is fine
+ * once the heuristic stabilises.
+ */
+function assertWithin(actual: number, expected: number, tolerance = 5): void {
+  assert.ok(
+    Math.abs(actual - expected) <= tolerance,
+    `expected ${actual} to be within ±${tolerance} of ${expected}`,
+  );
+}
+
+// Per-fixture expected dimension snapshots — measured against the live
+// implementation on commit-time and kept here as the AC's ±5-tolerance
+// snapshots. Heuristic drift in qualityScore.ts that pushes any bar past
+// the band flags as a test failure for human review.
+const EXPECTED_BARS = {
+  empty: { completeness: 0, tokenEfficiency: 0, ruleQuality: 0, specificity: 0 },
+  minimal: { completeness: 25, tokenEfficiency: 100, ruleQuality: 0, specificity: 13 },
+  sweet: { completeness: 94, tokenEfficiency: 100, ruleQuality: 100, specificity: 65 },
+} as const;
+
 describe('computeQualityScore (issue #52)', () => {
   it('fixture: empty-spec → score ≤ 10, sweetspot=under, surfaces missing_field + no_boundaries + no_starters', () => {
     const result: QualityResult = computeQualityScore(emptyAgentSpec());
@@ -32,6 +55,11 @@ describe('computeQualityScore (issue #52)', () => {
     assert.ok(codes.includes('missing_field'), 'expected missing_field suggestion');
     assert.ok(codes.includes('no_boundaries'));
     assert.ok(codes.includes('no_starters'));
+    // Per-bar ±5 tolerance snapshot (AC follow-up)
+    assertWithin(result.dimensions.completeness, EXPECTED_BARS.empty.completeness);
+    assertWithin(result.dimensions.tokenEfficiency, EXPECTED_BARS.empty.tokenEfficiency);
+    assertWithin(result.dimensions.ruleQuality, EXPECTED_BARS.empty.ruleQuality);
+    assertWithin(result.dimensions.specificity, EXPECTED_BARS.empty.specificity);
   });
 
   it('fixture: minimal-spec (description + 1 tool) → 25 ≤ score ≤ 50, sweetspot=under', () => {
@@ -42,6 +70,11 @@ describe('computeQualityScore (issue #52)', () => {
     const result = computeQualityScore(spec);
     assert.ok(result.score >= 25 && result.score <= 50, `score ${result.score} out of [25,50]`);
     assert.equal(result.sweetspot, 'under');
+    // Per-bar ±5 tolerance snapshot (AC follow-up)
+    assertWithin(result.dimensions.completeness, EXPECTED_BARS.minimal.completeness);
+    assertWithin(result.dimensions.tokenEfficiency, EXPECTED_BARS.minimal.tokenEfficiency);
+    assertWithin(result.dimensions.ruleQuality, EXPECTED_BARS.minimal.ruleQuality);
+    assertWithin(result.dimensions.specificity, EXPECTED_BARS.minimal.specificity);
   });
 
   it('fixture: sweet-spec (persona + 2 tools + 5 rules + 2 boundaries + 2 starters) → score ≥ 70, sweetspot=sweet', () => {
@@ -78,6 +111,11 @@ describe('computeQualityScore (issue #52)', () => {
     assert.ok(result.score >= 70, `expected score ≥ 70, got ${result.score}`);
     assert.equal(result.sweetspot, 'sweet');
     assert.equal(result.tokenHealth, 'ok');
+    // Per-bar ±5 tolerance snapshot (AC follow-up)
+    assertWithin(result.dimensions.completeness, EXPECTED_BARS.sweet.completeness);
+    assertWithin(result.dimensions.tokenEfficiency, EXPECTED_BARS.sweet.tokenEfficiency);
+    assertWithin(result.dimensions.ruleQuality, EXPECTED_BARS.sweet.ruleQuality);
+    assertWithin(result.dimensions.specificity, EXPECTED_BARS.sweet.specificity);
   });
 
   it('surfaces vague_rule when a when_to_use is < 15 chars', () => {


### PR DESCRIPTION
Follow-up to [#52](https://github.com/byte5ai/omadia/issues/52). Closes the last open AC item: per-bar snapshot tests with ±5-point tolerance for each fixture.

## What changed

- New local `assertWithin(actual, expected, tolerance=5)` helper in `qualityScore.test.ts`
- New `EXPECTED_BARS` table with measured centers per fixture:
  - `empty`: 0 / 0 / 0 / 0
  - `minimal`: 25 / 100 / 0 / 13
  - `sweet`: 94 / 100 / 100 / 65
- 12 new per-bar assertions (4 dimensions × 3 fixtures) inlined into the existing fixture tests

## Why

Heuristic drift in `qualityScore.ts` that pushes any single bar out of the ±5 band will now fail loudly. The current band centers are wide enough that the AC's "±5 tolerance" doesn't make the tests brittle.

Refs #60.