### PR TITLE
test+chore(builder): preview-prompt parity + JSDoc + 500ms debounce (#55 follow-up)

### DIFF
--- a/middleware/src/plugins/dynamicAgentRuntime.ts
+++ b/middleware/src/plugins/dynamicAgentRuntime.ts
@@ -576,9 +576,19 @@ async function loadSystemPrompt(
 }
 
 /**
- * Issue #51 — read the plugin's AGENT.md (if present), parse the
- * frontmatter, and compile the sycophancy-guard rule package for the
- * configured tier (`quality.sycophancy`). Returns `''` when:
+ * Issue #51 — **outer layer** of the sycophancy-section compose helper.
+ * Reads the plugin's AGENT.md (if present), parses the frontmatter, and
+ * delegates to the **inner layer** `compileSycophancyGuard(level)` for
+ * the actual prompt-text rendering.
+ *
+ * The same inner layer is called directly by the preview-prompt route
+ * (issue #55, `routes/builderPreviewPrompt.ts`) with the spec-side
+ * `quality.sycophancy` value — guaranteeing byte-identical output
+ * between the runtime compose path and the live preview without a
+ * dedicated refactor. Parity is enforced by
+ * `test/builder/previewPromptParity.test.ts`.
+ *
+ * Returns `''` when:
  *   - no AGENT.md or agent.md file at the package root
  *   - file read fails
  *   - frontmatter is missing / malformed
@@ -605,9 +615,17 @@ export async function composeSycophancyFromAgentMd(packageRoot: string): Promise
 }
 
 /**
- * Issue #54 — read the plugin's AGENT.md (if present), parse the
- * frontmatter, and compile the boundaries section (preset prompts +
- * custom `You must NOT: …` lines). Returns `''` when:
+ * Issue #54 — **outer layer** of the boundaries-section compose helper.
+ * Reads the plugin's AGENT.md (if present), parses the frontmatter, and
+ * delegates to the **inner layer** `compileBoundariesSection(presets,
+ * customLines)` for the actual prompt-text rendering.
+ *
+ * The same inner layer is called directly by the preview-prompt route
+ * (issue #55) with the spec-side `quality.boundaries` value —
+ * guaranteeing byte-identical output between runtime and preview.
+ * Parity is enforced by `test/builder/previewPromptParity.test.ts`.
+ *
+ * Returns `''` when:
  *   - no AGENT.md or agent.md file at the package root
  *   - file read fails
  *   - frontmatter is missing / malformed
@@ -644,8 +662,17 @@ export async function composeBoundariesFromAgentMd(packageRoot: string): Promise
 }
 
 /**
- * Phase 3 (OB-67) — read the plugin's AGENT.md (if present), parse the
- * frontmatter, and compose the `<persona>` system-prompt section.
+ * Phase 3 (OB-67) — **outer layer** of the persona-section compose
+ * helper. Reads the plugin's AGENT.md (if present), parses the
+ * frontmatter, and delegates to the **inner layer**
+ * `composePersonaSection({ persona, family })` from `personaCompose.ts`
+ * for the actual `<persona>`-XML rendering.
+ *
+ * The same inner layer is called directly by the preview-prompt route
+ * (issue #55) with the spec-side `persona` block — guaranteeing
+ * byte-identical output between runtime and preview. Parity is enforced
+ * by `test/builder/previewPromptParity.test.ts`.
+ *
  * Returns `''` when:
  *   - no AGENT.md or agent.md file at the package root
  *   - file read fails

--- a/middleware/test/builder/previewPromptParity.test.ts
+++ b/middleware/test/builder/previewPromptParity.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { promises as fs, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  composeBoundariesFromAgentMd,
+  composePersonaFromAgentMd,
+  composeSycophancyFromAgentMd,
+} from '../../src/plugins/dynamicAgentRuntime.js';
+import { compileBoundariesSection } from '../../src/plugins/builder/boundaryPresets.js';
+import { composePersonaSection } from '../../src/plugins/personaCompose.js';
+import { compileSycophancyGuard } from '../../src/plugins/sycophancyGuard.js';
+
+/**
+ * Issue #55 follow-up — byte-identical guarantee between the runtime
+ * compose path (reads AGENT.md → parse → call inner helpers) and the
+ * preview-prompt route (calls the same inner helpers directly with the
+ * draft spec).
+ *
+ * Both paths share the inner helpers `composePersonaSection`,
+ * `compileBoundariesSection`, `compileSycophancyGuard`. This test
+ * makes the equivalence explicit: serialise a fixture spec to an
+ * AGENT.md, run the AGENT.md-backed outer helpers, run the spec-backed
+ * inner helpers, assert byte-equality.
+ */
+
+const FIXTURES = [
+  {
+    name: 'persona-only',
+    persona: { axes: { directness: 80, warmth: 30 }, custom_notes: 'Antworte auf Deutsch.' },
+    quality: undefined as unknown as { sycophancy?: string; boundaries?: { presets?: string[]; custom?: string[] } } | undefined,
+  },
+  {
+    name: 'boundaries+sycophancy',
+    persona: undefined as unknown as { axes?: Record<string, number>; custom_notes?: string } | undefined,
+    quality: {
+      sycophancy: 'medium' as const,
+      boundaries: { presets: ['no-pii', 'no-medical-data'], custom: ['no Spekulationen'] },
+    },
+  },
+  {
+    name: 'fully-configured',
+    persona: {
+      template: 'customer-service',
+      axes: { directness: 80, warmth: 70, formality: 60 },
+      custom_notes: 'Antworte auf Deutsch.',
+    },
+    quality: {
+      sycophancy: 'high' as const,
+      boundaries: { presets: ['no-pii'], custom: ['no PII'] },
+    },
+  },
+];
+
+function yamlize(obj: unknown, indent = 0): string {
+  const pad = '  '.repeat(indent);
+  if (obj === null || obj === undefined) return '~';
+  if (typeof obj === 'string') return JSON.stringify(obj);
+  if (typeof obj === 'number') return String(obj);
+  if (typeof obj === 'boolean') return obj ? 'true' : 'false';
+  if (Array.isArray(obj)) {
+    if (obj.length === 0) return '[]';
+    return '\n' + obj.map((v) => `${pad}- ${yamlize(v, indent + 1).trim()}`).join('\n');
+  }
+  if (typeof obj === 'object') {
+    const entries = Object.entries(obj).filter(([, v]) => v !== undefined);
+    if (entries.length === 0) return '{}';
+    return '\n' + entries.map(([k, v]) => `${pad}${k}: ${yamlize(v, indent + 1)}`).join('\n');
+  }
+  return '';
+}
+
+describe('preview-prompt parity vs runtime (issue #55 follow-up)', () => {
+  let pkgRoot: string;
+
+  beforeEach(async () => {
+    pkgRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'preview-parity-'));
+  });
+
+  afterEach(() => {
+    rmSync(pkgRoot, { recursive: true, force: true });
+  });
+
+  for (const fixture of FIXTURES) {
+    it(`fixture ${fixture.name}: AGENT.md-backed runtime output is byte-identical to spec-backed inner output`, async () => {
+      const frontmatter: Record<string, unknown> = {};
+      if (fixture.persona) frontmatter['persona'] = fixture.persona;
+      if (fixture.quality) frontmatter['quality'] = fixture.quality;
+      const yaml = yamlize(frontmatter).replace(/^\n/, '');
+      const agentMd = `---\n${yaml}\n---\n\n# Body\n`;
+      await fs.writeFile(path.join(pkgRoot, 'AGENT.md'), agentMd);
+
+      // Outer (runtime) path — reads AGENT.md, parses frontmatter, calls inner.
+      const runtimePersona = await composePersonaFromAgentMd(pkgRoot, 'claude-sonnet-4-6');
+      const runtimeBoundaries = await composeBoundariesFromAgentMd(pkgRoot);
+      const runtimeSycophancy = await composeSycophancyFromAgentMd(pkgRoot);
+
+      // Inner (preview-route) path — calls the inner helpers directly with the spec.
+      const previewPersona = fixture.persona
+        ? composePersonaSection({ persona: fixture.persona, family: 'sonnet' })
+        : '';
+      const previewBoundaries = fixture.quality?.boundaries
+        ? compileBoundariesSection(
+            fixture.quality.boundaries.presets ?? [],
+            fixture.quality.boundaries.custom ?? [],
+          ).text
+        : '';
+      const previewSycophancy = compileSycophancyGuard(
+        fixture.quality?.sycophancy as 'off' | 'low' | 'medium' | 'high' | undefined,
+      );
+
+      assert.equal(runtimePersona, previewPersona, 'persona section diverged');
+      assert.equal(runtimeBoundaries, previewBoundaries, 'boundaries section diverged');
+      assert.equal(runtimeSycophancy, previewSycophancy, 'sycophancy section diverged');
+    });
+  }
+});

--- a/web-ui/app/store/builder/[id]/_components/PreviewPromptPanel.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PreviewPromptPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import {
   fetchBuilderPreviewPrompt,
@@ -70,8 +70,24 @@ export function PreviewPromptPanel({
     }
   }, [draftId]);
 
+  // First mount: fetch immediately so the panel never shows an empty
+  // skeleton on tab-switch. Subsequent `refetchKey` bumps are 500 ms-
+  // debounced — operator slider-saves come in bursts, debouncing keeps
+  // the route calls bounded without losing per-edit feedback. (#55 AC:
+  // "Prompt updates within ~500 ms after a persisted spec patch".)
+  const initialLoadDoneRef = useRef(false);
   useEffect(() => {
-    void load();
+    if (!initialLoadDoneRef.current) {
+      initialLoadDoneRef.current = true;
+      void load();
+      return;
+    }
+    const handle = setTimeout(() => {
+      void load();
+    }, 500);
+    return () => {
+      clearTimeout(handle);
+    };
   }, [load, refetchKey]);
 
   const handleCopy = useCallback(async () => {
@@ -139,9 +155,7 @@ export function PreviewPromptPanel({
       <div className="space-y-1 font-mono text-xs" data-testid="preview-prompt-sections">
         {data?.sections.map((s, i) => (
           <pre
-            // Index is fine here — sections are deterministic per draft state
-            // eslint-disable-next-line react/no-array-index-key
-            key={i}
+            key={`${s.kind}-${String(i)}`}
             data-testid={`preview-prompt-section-${s.kind}`}
             className={`overflow-x-auto whitespace-pre-wrap rounded p-2 ${KIND_BG[s.kind]}`}
           >

--- a/web-ui/app/store/builder/[id]/_components/__tests__/PreviewPromptPanel.test.tsx
+++ b/web-ui/app/store/builder/[id]/_components/__tests__/PreviewPromptPanel.test.tsx
@@ -58,16 +58,53 @@ describe('<PreviewPromptPanel />', () => {
     await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
   });
 
-  it('bumping refetchKey refetches', async () => {
-    fetchSpy.mockResolvedValue({
-      systemPrompt: '# Hi',
-      tokens: 1,
-      sections: [{ label: 'Header', content: '# Hi', kind: 'header' }],
-    });
-    const { rerender } = render(<PreviewPromptPanel draftId="draft-1" refetchKey={0} />);
-    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
-    rerender(<PreviewPromptPanel draftId="draft-1" refetchKey={1} />);
-    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+  it('bumping refetchKey refetches after the 500ms debounce', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      fetchSpy.mockResolvedValue({
+        systemPrompt: '# Hi',
+        tokens: 1,
+        sections: [{ label: 'Header', content: '# Hi', kind: 'header' }],
+      });
+      const { rerender } = render(<PreviewPromptPanel draftId="draft-1" refetchKey={0} />);
+      // Initial mount fetches immediately
+      await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+      rerender(<PreviewPromptPanel draftId="draft-1" refetchKey={1} />);
+      // Before debounce: still 1 call
+      await vi.advanceTimersByTimeAsync(250);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      // After 500ms total: the second call fires
+      await vi.advanceTimersByTimeAsync(300);
+      await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('coalesces a burst of refetchKey bumps into one debounced fetch', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      fetchSpy.mockResolvedValue({
+        systemPrompt: '# Hi',
+        tokens: 1,
+        sections: [{ label: 'Header', content: '# Hi', kind: 'header' }],
+      });
+      const { rerender } = render(<PreviewPromptPanel draftId="draft-1" refetchKey={0} />);
+      await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+      // Three rapid bumps within 250ms each — only the last one survives
+      // the debounce
+      rerender(<PreviewPromptPanel draftId="draft-1" refetchKey={1} />);
+      await vi.advanceTimersByTimeAsync(100);
+      rerender(<PreviewPromptPanel draftId="draft-1" refetchKey={2} />);
+      await vi.advanceTimersByTimeAsync(100);
+      rerender(<PreviewPromptPanel draftId="draft-1" refetchKey={3} />);
+      // Still only the initial mount fetch
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(600);
+      await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('renders inline alert when fetch fails', async () => {


### PR DESCRIPTION
Follow-up to [#55](https://github.com/byte5ai/omadia/issues/55). Closes the three open AC items.

## What changed

1. **Inner / outer compose-helper split documented** — JSDoc on `composePersonaFromAgentMd`, `composeBoundariesFromAgentMd`, `composeSycophancyFromAgentMd` now states explicitly that they are the outer layer; the inner layer is the runtime-shared `composePersonaSection` / `compileBoundariesSection` / `compileSycophancyGuard`. The split already existed in code — this PR makes it discoverable from the file.

2. **Byte-identical parity test** — `middleware/test/builder/previewPromptParity.test.ts` (new). 3 fixtures (persona-only / boundaries+sycophancy / fully-configured). Each writes the spec to an AGENT.md, runs the runtime path, runs the spec-side inner path, asserts byte-equality. Would fail if either layer drifts.

3. **Frontend 500 ms debounce** on `<PreviewPromptPanel />` — initial mount fetches immediately, subsequent `refetchKey` bumps debounce. Two new vitest cases verify the debounce window and the burst-coalescing behavior.

No runtime behavior change.

Refs #60.