### PR TITLE
feat(builder): PATCH /drafts/:id/{persona,quality} with tool roundtrip (#53+#54 follow-up)

### DIFF
--- a/middleware/src/routes/builderEdit.ts
+++ b/middleware/src/routes/builderEdit.ts
@@ -1,7 +1,10 @@
 import type { Router, Request, Response } from 'express';
 
+import { type AuditLogger, createAuditLogger } from '../plugins/builder/audit.js';
 import type { DraftStore } from '../plugins/builder/draftStore.js';
 import { BuilderModelRegistry } from '../plugins/builder/modelRegistry.js';
+import { setPersonaConfigTool } from '../plugins/builder/tools/setPersonaConfig.js';
+import { setQualityConfigTool } from '../plugins/builder/tools/setQualityConfig.js';
 import {
   IllegalSpecState,
   JsonPatchSchema,
@@ -9,7 +12,7 @@ import {
   type JsonPatch,
 } from '../plugins/builder/specPatcher.js';
 import type { SpecEventBus } from '../plugins/builder/specEventBus.js';
-import type { RebuildScheduler } from '../plugins/builder/tools/index.js';
+import type { BuilderToolContext, RebuildScheduler } from '../plugins/builder/tools/index.js';
 import type {
   AgentSpecSkeleton,
   BuilderModelId,
@@ -39,6 +42,61 @@ export interface BuilderEditDeps {
   draftStore: DraftStore;
   bus: SpecEventBus;
   rebuildScheduler: RebuildScheduler;
+  /**
+   * Override for the audit logger (test-only). Default: `createAuditLogger(deps.draftStore)`
+   * — so PATCH /persona and PATCH /quality emit `builder_audit` rows
+   * identically to BuilderAgent-initiated tool calls.
+   */
+  audit?: AuditLogger;
+}
+
+/**
+ * Issue #53 + #54 — assemble a `BuilderToolContext` for the route-side
+ * tool invocation path. The edit routes only need 6 fields (`userEmail`,
+ * `draftId`, `draftStore`, `bus`, `rebuildScheduler`, `audit`); the
+ * other `BuilderToolContext` fields are required by the type but never
+ * touched by the mutating tools (`set_persona_config` / `set_quality_config`
+ * / `patch_spec` / `fill_slot` collectively).
+ *
+ * Unused fields are filled with **thrower stubs** so any future tool
+ * that reaches for one fails loudly with a clear "not available in
+ * edit-route context" error — preventing silent contract violations.
+ * The accompanying test `builderEditRoutesTool.test.ts` exercises this:
+ * if `set_persona_config` is ever extended to call e.g.
+ * `ctx.slotTypechecker.check()`, the test fails the moment the route
+ * runs.
+ */
+export function assembleEditRouteContext(
+  deps: BuilderEditDeps,
+  userEmail: string,
+  draftId: string,
+): BuilderToolContext {
+  const audit = deps.audit ?? createAuditLogger(deps.draftStore);
+  const notAvailable = (field: string) => (): never => {
+    throw new Error(`${field} is not available in the edit-route BuilderToolContext`);
+  };
+  return {
+    userEmail,
+    draftId,
+    draftStore: deps.draftStore,
+    bus: deps.bus,
+    rebuildScheduler: deps.rebuildScheduler,
+    audit,
+    catalogToolNames: notAvailable('catalogToolNames'),
+    knownPluginIds: notAvailable('knownPluginIds'),
+    slotRetryTracker: {
+      recordFail: notAvailable('slotRetryTracker.recordFail'),
+      reset: notAvailable('slotRetryTracker.reset'),
+    },
+    buildFailureBudget: {
+      recordFail: notAvailable('buildFailureBudget.recordFail'),
+      reset: notAvailable('buildFailureBudget.reset'),
+      limit: 0,
+    },
+    templateRoot: '',
+    referenceCatalog: {},
+    slotTypechecker: notAvailable('slotTypechecker') as never,
+  };
 }
 
 export function registerBuilderEditRoutes(
@@ -187,6 +245,91 @@ export function registerBuilderEditRoutes(
     // Model switch deliberately does NOT trigger a rebuild — codegen/preview
     // model selection is a runtime knob, the built artifact does not change.
     res.json({ draft: updated });
+  });
+
+  // ── PATCH /drafts/:id/persona (issue #53) ─────────────────────────────
+  // Routes the request through `setPersonaConfigTool` so the UI-side
+  // call gets tool-side validation, `SpecEventBus.cause='agent'`, and a
+  // `builder_audit` row (#56) — parity with BuilderAgent-initiated edits.
+  router.patch('/drafts/:id/persona', async (req: Request, res: Response) => {
+    const email = readEmail(req);
+    if (!email) return sendJson(res, 401, { code: 'auth.missing', message: 'no session' });
+    const draftId = readId(req);
+    if (!draftId) return sendJson(res, 400, { code: 'builder.invalid_id', message: 'missing :id' });
+
+    const inputParsed = setPersonaConfigTool.input.safeParse(req.body ?? {});
+    if (!inputParsed.success) {
+      return sendJson(res, 400, {
+        code: 'builder.invalid_persona',
+        message: inputParsed.error.issues
+          .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+          .join('; '),
+      });
+    }
+
+    const ctx = assembleEditRouteContext(deps, email, draftId);
+    const result = await setPersonaConfigTool.run(inputParsed.data, ctx);
+    if (!result.ok) {
+      // Tool surfaces the same `not found` path as the route's other
+      // endpoints. Map to 404 when the tool didn't find the draft.
+      const code = /not found/.test(result.error)
+        ? 'builder.draft_not_found'
+        : 'builder.illegal_patch';
+      const status = code === 'builder.draft_not_found' ? 404 : 400;
+      return sendJson(res, status, { code, message: result.error });
+    }
+    const draft = await deps.draftStore.load(email, draftId);
+    if (!draft) {
+      return sendJson(res, 404, {
+        code: 'builder.draft_not_found',
+        message: `kein Draft mit id '${draftId}'`,
+      });
+    }
+    res.json({ draft });
+  });
+
+  // ── PATCH /drafts/:id/quality (issue #54) ─────────────────────────────
+  // Same pattern as /persona above. The tool result also carries
+  // `warnings` for unknown boundary preset IDs; we surface them as a
+  // sibling field so the UI can render the inline badge from the live
+  // tool call rather than a client-side mirror.
+  router.patch('/drafts/:id/quality', async (req: Request, res: Response) => {
+    const email = readEmail(req);
+    if (!email) return sendJson(res, 401, { code: 'auth.missing', message: 'no session' });
+    const draftId = readId(req);
+    if (!draftId) return sendJson(res, 400, { code: 'builder.invalid_id', message: 'missing :id' });
+
+    const inputParsed = setQualityConfigTool.input.safeParse(req.body ?? {});
+    if (!inputParsed.success) {
+      return sendJson(res, 400, {
+        code: 'builder.invalid_quality',
+        message: inputParsed.error.issues
+          .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
+          .join('; '),
+      });
+    }
+
+    const ctx = assembleEditRouteContext(deps, email, draftId);
+    const result = await setQualityConfigTool.run(inputParsed.data, ctx);
+    if (!result.ok) {
+      const code = /not found/.test(result.error)
+        ? 'builder.draft_not_found'
+        : 'builder.illegal_patch';
+      const status = code === 'builder.draft_not_found' ? 404 : 400;
+      return sendJson(res, status, { code, message: result.error });
+    }
+    const draft = await deps.draftStore.load(email, draftId);
+    if (!draft) {
+      return sendJson(res, 404, {
+        code: 'builder.draft_not_found',
+        message: `kein Draft mit id '${draftId}'`,
+      });
+    }
+    const responseBody: { draft: typeof draft; warnings?: string[] } = { draft };
+    if (result.warnings && result.warnings.length > 0) {
+      responseBody.warnings = result.warnings;
+    }
+    res.json(responseBody);
   });
 }
 

--- a/middleware/test/builder/builderEditPersonaQualityRoutes.test.ts
+++ b/middleware/test/builder/builderEditPersonaQualityRoutes.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import express from 'express';
+
+import { DraftStore } from '../../src/plugins/builder/draftStore.js';
+import { SpecEventBus, type SpecBusEvent } from '../../src/plugins/builder/specEventBus.js';
+import {
+  assembleEditRouteContext,
+  registerBuilderEditRoutes,
+} from '../../src/routes/builderEdit.js';
+import { setPersonaConfigTool } from '../../src/plugins/builder/tools/setPersonaConfig.js';
+import { setQualityConfigTool } from '../../src/plugins/builder/tools/setQualityConfig.js';
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    session?: { email?: string };
+  }
+}
+
+/**
+ * Issue #53 + #54 follow-up — verify the new PATCH /persona and
+ * PATCH /quality routes:
+ *   - run the corresponding Builder tool (so spec validation runs)
+ *   - emit a `spec_patch` event with cause='agent'
+ *   - schedule a preview rebuild
+ *   - write a `builder_audit` row (#56)
+ *   - surface tool-side `warnings` for unknown preset IDs (quality only)
+ */
+
+async function boot(
+  store: DraftStore,
+  bus: SpecEventBus,
+  email: string,
+  rebuilds: { userEmail: string; draftId: string }[],
+): Promise<{ url: string; server: Server }> {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.session = { email };
+    next();
+  });
+  const router = express.Router();
+  registerBuilderEditRoutes(router, {
+    draftStore: store,
+    bus,
+    rebuildScheduler: {
+      schedule(userEmail: string, draftId: string) {
+        rebuilds.push({ userEmail, draftId });
+      },
+    },
+  });
+  app.use('/v1/builder', router);
+  return new Promise((resolve) => {
+    const server = createServer(app);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({ url: `http://127.0.0.1:${port}`, server });
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+describe('PATCH /drafts/:id/{persona,quality} (issues #53 + #54)', () => {
+  let tmpRoot: string;
+  let store: DraftStore;
+  let bus: SpecEventBus;
+  let busEvents: { draftId: string; event: SpecBusEvent }[];
+  let rebuilds: { userEmail: string; draftId: string }[];
+  let server: Server;
+  let baseUrl: string;
+  let draftId: string;
+  const userEmail = 'alice@example.com';
+
+  beforeEach(async () => {
+    tmpRoot = mkdtempSync(path.join(tmpdir(), 'edit-tool-routes-'));
+    store = new DraftStore({ dbPath: path.join(tmpRoot, 'drafts.db') });
+    await store.open();
+    bus = new SpecEventBus();
+    busEvents = [];
+    rebuilds = [];
+    const d = await store.create(userEmail, 'Weather');
+    draftId = d.id;
+    // Subscribe after we know the draftId
+    bus.subscribe(draftId, (event: SpecBusEvent) => {
+      busEvents.push({ draftId, event });
+    });
+    const boot1 = await boot(store, bus, userEmail, rebuilds);
+    server = boot1.server;
+    baseUrl = boot1.url;
+  });
+
+  afterEach(async () => {
+    await closeServer(server);
+    await store.close();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('PATCH /persona writes the persona block, emits cause=agent, schedules rebuild, audits', async () => {
+    const res = await fetch(`${baseUrl}/v1/builder/drafts/${draftId}/persona`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        template: 'customer-service',
+        custom_notes: 'auf Deutsch',
+      }),
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { draft: { spec: { persona?: unknown } } };
+    assert.ok(body.draft.spec.persona);
+
+    // Bus emit with cause='agent'
+    const patchEvents = busEvents
+      .map((e) => e.event)
+      .filter((e): e is Extract<SpecBusEvent, { type: 'spec_patch' }> => e.type === 'spec_patch');
+    assert.equal(patchEvents.length, 1);
+    assert.equal(patchEvents[0]!.cause, 'agent');
+
+    // Rebuild scheduled
+    assert.equal(rebuilds.length, 1);
+    assert.equal(rebuilds[0]!.draftId, draftId);
+
+    // Audit row written
+    const audit = await store.listAudit(userEmail, draftId);
+    assert.equal(audit.total, 1);
+    assert.equal(audit.events[0]!.action, 'persona_updated');
+  });
+
+  it('PATCH /quality writes the quality block, emits cause=agent, schedules rebuild, audits', async () => {
+    const res = await fetch(`${baseUrl}/v1/builder/drafts/${draftId}/quality`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        sycophancy: 'medium',
+        boundaries: { presets: ['no-pii'], custom: ['no PII'] },
+      }),
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { draft: { spec: { quality?: unknown } }; warnings?: string[] };
+    assert.ok(body.draft.spec.quality);
+    assert.equal(body.warnings, undefined, 'no warnings expected for known preset');
+
+    const patchEvents = busEvents
+      .map((e) => e.event)
+      .filter((e): e is Extract<SpecBusEvent, { type: 'spec_patch' }> => e.type === 'spec_patch');
+    assert.equal(patchEvents.length, 1);
+    assert.equal(patchEvents[0]!.cause, 'agent');
+
+    assert.equal(rebuilds.length, 1);
+    const audit = await store.listAudit(userEmail, draftId);
+    assert.equal(audit.total, 1);
+    assert.equal(audit.events[0]!.action, 'quality_updated');
+  });
+
+  it('PATCH /quality surfaces tool-side warnings for unknown preset IDs', async () => {
+    const res = await fetch(`${baseUrl}/v1/builder/drafts/${draftId}/quality`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        boundaries: { presets: ['no-pii', 'bogus-preset'], custom: [] },
+      }),
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { warnings?: string[] };
+    assert.deepEqual(body.warnings, ['unknown preset: bogus-preset']);
+  });
+
+  it('PATCH /persona returns 400 on Zod validation failure (unknown axis is dropped, so trigger via bad type)', async () => {
+    const res = await fetch(`${baseUrl}/v1/builder/drafts/${draftId}/persona`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ custom_notes: 12345 }),
+    });
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as { code: string };
+    assert.equal(body.code, 'builder.invalid_persona');
+  });
+
+  it('PATCH /quality returns 401 without a session', async () => {
+    // Mount a parallel server without the session middleware to assert 401
+    const app = express();
+    app.use(express.json());
+    const router = express.Router();
+    registerBuilderEditRoutes(router, {
+      draftStore: store,
+      bus,
+      rebuildScheduler: { schedule() {} },
+    });
+    app.use('/v1/builder', router);
+    const noAuth = await new Promise<Server>((resolve) => {
+      const s = createServer(app);
+      s.listen(0, '127.0.0.1', () => resolve(s));
+    });
+    try {
+      const { port } = noAuth.address() as AddressInfo;
+      const res = await fetch(`http://127.0.0.1:${String(port)}/v1/builder/drafts/${draftId}/quality`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ sycophancy: 'low' }),
+      });
+      assert.equal(res.status, 401);
+    } finally {
+      await closeServer(noAuth);
+    }
+  });
+});
+
+describe('assembleEditRouteContext (issue #53 + #54)', () => {
+  let tmpRoot: string;
+  let store: DraftStore;
+
+  beforeEach(async () => {
+    tmpRoot = mkdtempSync(path.join(tmpdir(), 'assemble-ctx-'));
+    store = new DraftStore({ dbPath: path.join(tmpRoot, 'drafts.db') });
+    await store.open();
+  });
+
+  afterEach(async () => {
+    await store.close();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('thrower stubs catch silent contract violations from unused tool fields', () => {
+    const bus = new SpecEventBus();
+    const ctx = assembleEditRouteContext(
+      {
+        draftStore: store,
+        bus,
+        rebuildScheduler: { schedule() {} },
+      },
+      'alice@example.com',
+      'draft-1',
+    );
+    // Real fields are populated
+    assert.equal(ctx.userEmail, 'alice@example.com');
+    assert.equal(ctx.draftId, 'draft-1');
+    assert.ok(ctx.audit);
+    // Thrower stubs all throw with a clear message
+    assert.throws(() => ctx.catalogToolNames(), /not available/);
+    assert.throws(() => ctx.knownPluginIds(), /not available/);
+    assert.throws(() => ctx.slotRetryTracker.recordFail('s'), /not available/);
+    assert.throws(() => ctx.buildFailureBudget.recordFail(), /not available/);
+  });
+
+  it('the two in-scope tools (set_persona_config, set_quality_config) never reach the thrower stubs', () => {
+    // The tools' run() bodies are pure — they only touch the 6 real
+    // fields. If a future PR adds a `ctx.knownPluginIds()` call, this
+    // test will fail at runtime as soon as the route invokes the tool.
+    const text = setPersonaConfigTool.run.toString() + setQualityConfigTool.run.toString();
+    const stubFields = [
+      'catalogToolNames',
+      'knownPluginIds',
+      'slotRetryTracker',
+      'buildFailureBudget',
+      'templateRoot',
+      'referenceCatalog',
+      'slotTypechecker',
+    ];
+    for (const field of stubFields) {
+      assert.equal(
+        text.includes(`ctx.${field}`),
+        false,
+        `${field} reference found in tool body — assembleEditRouteContext stub will throw`,
+      );
+    }
+  });
+});

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -897,40 +897,82 @@ export async function patchBuilderSpec(
 }
 
 /**
- * Phase 3 / OB-67 — set the per-profile persona block on a draft. Thin
- * ergonomic wrapper over `patchBuilderSpec` so the Browser-View slider
- * pillar can call a single, structurally-shaped function instead of
- * hand-crafting JSON-Patch ops in every onChange handler. Replaces any
- * existing `spec.persona` block in full; pass `{}` to clear.
+ * Phase 3 / OB-67 — set the per-profile persona block on a draft.
+ *
+ * Issue #53 follow-up — calls the dedicated `PATCH /drafts/:id/persona`
+ * route which routes through `setPersonaConfigTool` server-side. That
+ * gives us tool-side validation, `SpecEventBus.cause='agent'`, and a
+ * `builder_audit` row — parity with BuilderAgent-initiated edits.
+ *
+ * Replaces any existing `spec.persona` block in full; pass `{}` to clear.
  */
 export async function setPersonaConfig(
   draftId: string,
   config: PersonaConfig,
 ): Promise<DraftEnvelope> {
-  return patchBuilderSpec(draftId, [
-    { op: 'add', path: '/persona', value: config },
-  ]);
+  const forwarded = await forwardCookieHeader();
+  const res = await fetch(
+    botApi(`/v1/builder/drafts/${encodeURIComponent(draftId)}/persona`),
+    {
+      method: 'PATCH',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+        ...forwarded,
+      },
+      body: JSON.stringify(config),
+      credentials: 'include',
+      cache: 'no-store',
+    },
+  );
+  const text = await res.text();
+  if (!res.ok) {
+    throw new ApiError(
+      res.status,
+      `PATCH builder/drafts/${draftId}/persona failed: ${res.status}`,
+      text,
+    );
+  }
+  return JSON.parse(text) as DraftEnvelope;
 }
 
 /**
  * Issue #54 — set the per-profile quality block (sycophancy level +
- * boundary presets + custom lines) on a draft. Thin wrapper over
- * `patchBuilderSpec`, mirroring the `setPersonaConfig` ergonomics.
+ * boundary presets + custom lines) on a draft.
  *
- * Unknown boundary preset IDs are not validated server-side here — the
- * UI uses `findUnknownBoundaryPresets` (`boundaryPresets.ts`) against
- * the local registry to surface the same warning before save. A future
- * issue may add a dedicated `PATCH /drafts/:id/quality` route that
- * round-trips the tool result (with warnings) instead of writing via
- * the JSON-Patch surface.
+ * Issue #54 follow-up — calls the dedicated `PATCH /drafts/:id/quality`
+ * route which routes through `setQualityConfigTool` server-side. The
+ * tool's `warnings` for unknown preset IDs are surfaced as an optional
+ * sibling field on the response.
  */
 export async function setQualityConfig(
   draftId: string,
   config: import('./builderTypes').QualityConfig,
-): Promise<DraftEnvelope> {
-  return patchBuilderSpec(draftId, [
-    { op: 'add', path: '/quality', value: config },
-  ]);
+): Promise<DraftEnvelope & { warnings?: string[] }> {
+  const forwarded = await forwardCookieHeader();
+  const res = await fetch(
+    botApi(`/v1/builder/drafts/${encodeURIComponent(draftId)}/quality`),
+    {
+      method: 'PATCH',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+        ...forwarded,
+      },
+      body: JSON.stringify(config),
+      credentials: 'include',
+      cache: 'no-store',
+    },
+  );
+  const text = await res.text();
+  if (!res.ok) {
+    throw new ApiError(
+      res.status,
+      `PATCH builder/drafts/${draftId}/quality failed: ${res.status}`,
+      text,
+    );
+  }
+  return JSON.parse(text) as DraftEnvelope & { warnings?: string[] };
 }
 
 /**


### PR DESCRIPTION
Follow-up to [#53](https://github.com/byte5ai/omadia/issues/53) and [#54](https://github.com/byte5ai/omadia/issues/54). Closes the architectural gap noted in both PRs: the UI-side persona/quality edits now route through the canonical Builder tools (`setPersonaConfigTool` / `setQualityConfigTool`) instead of `patchBuilderSpec`. That gives:

- **Tool-side spec validation** (e.g. unknown `template` → `ok=false`, no persist, no rebuild, no audit)
- **`SpecEventBus.cause='agent'`** for UI edits (was `'user'` on the old patch path)
- **`builder_audit` rows for UI-initiated edits** — #56's audit hooks now cover the UI surface, not only BuilderAgent calls
- **Tool warnings round-trip** — unknown boundary preset IDs surface as `response.warnings: string[]` instead of needing client-side mirror logic

## Backend

- new `assembleEditRouteContext(deps, userEmail, draftId)` in `builderEdit.ts`
  - Real fields: `userEmail` / `draftId` / `draftStore` / `bus` / `rebuildScheduler` / `audit` (auto-wired via `createAuditLogger`)
  - Unused fields (`catalogToolNames` / `knownPluginIds` / `slotRetryTracker` / `buildFailureBudget` / `templateRoot` / `referenceCatalog` / `slotTypechecker`) are **thrower stubs** with clear messages — silent contract violations get caught at runtime
- new `PATCH /drafts/:id/persona` route — invokes `setPersonaConfigTool` via the assembled context
- new `PATCH /drafts/:id/quality` route — same pattern; response surfaces `warnings?: string[]` from the tool
- `BuilderEditDeps` gets optional `audit?: AuditLogger` override (test-only)

## Frontend

- `setPersonaConfig` wrapper → `PATCH /drafts/:id/persona`
- `setQualityConfig` wrapper → `PATCH /drafts/:id/quality`; return type widened to `DraftEnvelope & { warnings?: string[] }`

## Test plan

- [x] 5 route tests (`builderEditPersonaQualityRoutes.test.ts`): cause='agent' on bus, rebuild scheduled, audit row appears, warnings field surfaces, 401 without session
- [x] 2 `assembleEditRouteContext` tests: thrower stubs throw with clear messages, in-scope tools never reach the stubs (static body inspection)
- [x] All 17 pre-existing `builderEditRoutes.test.ts` tests green (no regression)
- [x] All 26 web-ui vitest cases that mock `setPersonaConfig`/`setQualityConfig` still pass (`<PersonaPillar />`, `<BoundariesSection />`, `<CulturePresetDropdown />`, `<PersonaTemplateGallery />`)
- [x] `npm run lint` + `npm run typecheck` clean on both workspaces

Refs #60.