### PR TITLE
fix(builder): dark-theme readability for kemia-port UI surfaces

### DIFF
--- a/web-ui/app/store/builder/[id]/_components/PersonaTemplateGallery.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PersonaTemplateGallery.tsx
@@ -92,7 +92,7 @@ export function PersonaTemplateGallery({
       aria-label="Persona-Vorlage auswählen"
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
     >
-      <div className="max-h-full w-full max-w-3xl overflow-y-auto rounded-lg bg-white p-4 shadow-xl">
+      <div className="max-h-full w-full max-w-3xl overflow-y-auto rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-elevated,var(--bg))] p-4 text-[color:var(--fg)] shadow-xl">
         <header className="mb-3 flex items-baseline justify-between">
           <h2 className="text-lg font-semibold text-[color:var(--fg-strong)]">
             Persona-Vorlage auswählen
@@ -102,7 +102,7 @@ export function PersonaTemplateGallery({
             data-testid="gallery-close"
             onClick={onClose}
             disabled={pending}
-            className="rounded px-2 py-1 text-sm text-[color:var(--fg-muted)] hover:bg-gray-100"
+            className="rounded border border-[color:var(--border)] px-2 py-1 text-sm text-[color:var(--fg-muted)] hover:bg-[color:var(--accent-bg)]"
           >
             Schließen
           </button>

--- a/web-ui/app/store/builder/[id]/_components/PreviewPromptPanel.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PreviewPromptPanel.tsx
@@ -17,13 +17,16 @@ import {
  * total token count with health indicator, and a Copy button.
  */
 
+// Pastel section backgrounds carry their own explicit dark text color
+// so they stay readable on a dark theme (without it, the page's light
+// foreground inherits and the text disappears against the light pastel).
 const KIND_BG: Record<PreviewPromptSection['kind'], string> = {
-  header: 'bg-slate-50',
-  persona: 'bg-amber-50',
-  custom_notes: 'bg-amber-50/50',
-  boundaries: 'bg-rose-50',
-  sycophancy: 'bg-violet-50',
-  skill: 'bg-emerald-50',
+  header: 'bg-slate-50 text-slate-900',
+  persona: 'bg-amber-50 text-amber-950',
+  custom_notes: 'bg-amber-50/70 text-amber-950',
+  boundaries: 'bg-rose-50 text-rose-950',
+  sycophancy: 'bg-violet-50 text-violet-950',
+  skill: 'bg-emerald-50 text-emerald-950',
 };
 
 const KIND_LABEL: Record<PreviewPromptSection['kind'], string> = {
@@ -159,7 +162,7 @@ export function PreviewPromptPanel({
             data-testid={`preview-prompt-section-${s.kind}`}
             className={`overflow-x-auto whitespace-pre-wrap rounded p-2 ${KIND_BG[s.kind]}`}
           >
-            <span className="block text-[10px] font-semibold uppercase text-[color:var(--fg-muted)]">
+            <span className="block text-[10px] font-semibold uppercase opacity-70">
               {KIND_LABEL[s.kind]}
             </span>
             {s.content}

--- a/web-ui/app/store/builder/[id]/_components/QualityPanel.tsx
+++ b/web-ui/app/store/builder/[id]/_components/QualityPanel.tsx
@@ -87,12 +87,18 @@ export function QualityPanel({ draftId, refetchKey }: QualityPanelProps): React.
         </button>
         <div className="flex items-center gap-2 text-xs">
           {data && (
-            <span data-testid="quality-sweetspot" className="rounded bg-slate-100 px-2 py-0.5">
+            <span
+              data-testid="quality-sweetspot"
+              className="rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-0.5 text-[color:var(--fg)]"
+            >
               {sweetspotLabelDe(data.sweetspot)}
             </span>
           )}
           {data && (
-            <span data-testid="quality-token-health" className="rounded bg-slate-100 px-2 py-0.5">
+            <span
+              data-testid="quality-token-health"
+              className="rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-0.5 text-[color:var(--fg)]"
+            >
               Tokens: {tokenHealthLabelDe(data.tokenHealth)}
             </span>
           )}
@@ -128,7 +134,7 @@ export function QualityPanel({ draftId, refetchKey }: QualityPanelProps): React.
                       <span>{DIMENSION_LABEL_DE[key]}</span>
                       <span>{v}/100</span>
                     </div>
-                    <div className="h-1.5 w-full rounded bg-slate-100">
+                    <div className="h-1.5 w-full rounded bg-[color:var(--border)]">
                       <div
                         data-testid={`quality-bar-${key}`}
                         className={`h-full rounded ${scoreColor(v)}`}


### PR DESCRIPTION
Bug-fix follow-up: kemia ports shipped pastel/light backgrounds with hardcoded `bg-slate-100`, `bg-white`, etc. without explicit text colors. On a dark theme the light foreground inherits and text becomes invisible (verified: QualityPanel pills "Sweet Spot" / "Tokens: OK").

Changes:
- **QualityPanel**: header pills now use `var(--bg)` + `var(--fg)` + border; dimension-bar track uses `bg-[color:var(--border)]`
- **PersonaTemplateGallery**: modal surface now uses theme tokens instead of `bg-white`
- **PreviewPromptPanel**: each pastel section background gets a paired dark-text color (`text-<color>-950`); section labels use `opacity-70` instead of `var(--fg-muted)`

All 17 vitest cases for the three components still green (data-testids unchanged).