### PR TITLE
feat(privacy-guard): stable-id tokenization — complete (Slices 1-3)

### DIFF
--- a/middleware/packages/harness-orchestrator/src/localSubAgent.ts
+++ b/middleware/packages/harness-orchestrator/src/localSubAgent.ts
@@ -480,11 +480,45 @@ export class LocalSubAgent {
         );
       }
     }
+    // Privacy-Shield v3 (slice 1) — Stable-id tokenization pre-pass.
+    // When the dispatched tool declared `piiFields`, run the tool-aware
+    // pre-pass BEFORE the NER-based `processToolResult`. See the twin
+    // wiring in `Orchestrator.dispatchTool` for the design rationale.
+    let resultForPrivacy = result;
     if (privacy !== undefined && typeof result === 'string' && result.length > 0) {
+      const piiFields = tool.piiFields;
+      if (piiFields !== undefined && piiFields.length > 0) {
+        try {
+          const prepass = await privacy.applyStableIdPrepass({
+            toolName,
+            text: result,
+            piiFields,
+          });
+          resultForPrivacy = prepass.text;
+          if (prepass.replaced > 0 || prepass.skipped > 0) {
+            console.log(
+              `[sub-agent ${this.name}] stable-id prepass on '${toolName}': replaced=${String(
+                prepass.replaced,
+              )} skipped=${String(prepass.skipped)} parsed=${String(prepass.parsed)}`,
+            );
+          }
+        } catch (err) {
+          console.warn(
+            `[sub-agent ${this.name}] privacy.applyStableIdPrepass threw on '${toolName}' — falling through to NER-only:`,
+            err,
+          );
+        }
+      }
+    }
+    if (
+      privacy !== undefined &&
+      typeof resultForPrivacy === 'string' &&
+      resultForPrivacy.length > 0
+    ) {
       try {
         const tokenised = await privacy.processToolResult({
           toolName,
-          text: result,
+          text: resultForPrivacy,
         });
         return tokenised.text;
       } catch (err) {
@@ -494,7 +528,7 @@ export class LocalSubAgent {
         );
       }
     }
-    return result;
+    return resultForPrivacy;
   }
 }
 

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -2399,11 +2399,50 @@ export class Orchestrator {
         );
       }
     }
+    // Privacy-Shield v3 (slice 1) — Stable-id tokenization pre-pass.
+    // When the dispatched tool is a DomainTool that declared
+    // `piiFields`, run the tool-aware pre-pass BEFORE the NER-based
+    // `processToolResult`. The pre-pass parses the JSON result,
+    // rewrites annotated leaves into stable tokens, and re-serialises;
+    // NER then runs on top as defense-in-depth for unannotated free
+    // text. Strictly additive — annotations missing / parse failure /
+    // empty piiFields all degrade to the slice-2.2 byte-identical
+    // behaviour.
+    let resultForPrivacy = result;
     if (privacy !== undefined && typeof result === 'string' && result.length > 0) {
+      const piiFields = this.domainToolsByName.get(name)?.piiFields;
+      if (piiFields !== undefined && piiFields.length > 0) {
+        try {
+          const prepass = await privacy.applyStableIdPrepass({
+            toolName: name,
+            text: result,
+            piiFields,
+          });
+          resultForPrivacy = prepass.text;
+          if (prepass.replaced > 0 || prepass.skipped > 0) {
+            console.log(
+              `[orchestrator.dispatchTool:${name}] stable-id prepass: replaced=${String(
+                prepass.replaced,
+              )} skipped=${String(prepass.skipped)} parsed=${String(prepass.parsed)}`,
+            );
+          }
+        } catch (err) {
+          console.warn(
+            `[orchestrator.dispatchTool:${name}] privacy.applyStableIdPrepass threw — falling through to NER-only:`,
+            err,
+          );
+        }
+      }
+    }
+    if (
+      privacy !== undefined &&
+      typeof resultForPrivacy === 'string' &&
+      resultForPrivacy.length > 0
+    ) {
       try {
         const tokenised = await privacy.processToolResult({
           toolName: name,
-          text: result,
+          text: resultForPrivacy,
         });
         return tokenised.text;
       } catch (err) {
@@ -2413,7 +2452,7 @@ export class Orchestrator {
         );
       }
     }
-    return result;
+    return resultForPrivacy;
   }
 
   private async dispatchToolInner(

--- a/middleware/packages/harness-orchestrator/src/privacyHandle.ts
+++ b/middleware/packages/harness-orchestrator/src/privacyHandle.ts
@@ -24,6 +24,8 @@ import type {
   PrivacyPostEgressScrubResult,
   PrivacyReceipt,
   PrivacySelfAnonymizationResult,
+  PrivacyStableIdPiiField,
+  PrivacyStableIdPrepassResult,
   Routing,
 } from '@omadia/plugin-api';
 
@@ -76,6 +78,19 @@ export interface PrivacyTurnHandle {
     readonly text: string;
     readonly transformed: boolean;
   }>;
+  /**
+   * Privacy-Shield v3 (slice 1) — Stable-id tokenization pre-pass.
+   * Runs BEFORE `processToolResult` when a tool declares `piiFields`
+   * annotations. JSON-parses the text, rewrites annotated leaves to
+   * stable tokens via the same turn-scoped TokenizeMap the rest of
+   * the pipeline reads, and re-serialises. Strictly additive: empty
+   * annotations or non-JSON input pass through unchanged.
+   */
+  applyStableIdPrepass(input: {
+    readonly toolName: string;
+    readonly text: string;
+    readonly piiFields: ReadonlyArray<PrivacyStableIdPiiField>;
+  }): Promise<PrivacyStableIdPrepassResult>;
   /**
    * Privacy-Shield v2 (Slice S-6) — run the Egress Filter against the
    * final channel-bound text slots before the answer is handed to the
@@ -173,6 +188,16 @@ export function createPrivacyTurnHandle(deps: {
         text: input.text,
       });
       return { text: r.text, transformed: r.transformed };
+    },
+
+    async applyStableIdPrepass(input) {
+      return deps.service.applyStableIdPrepass({
+        sessionId: deps.sessionId,
+        turnId: deps.turnId,
+        toolName: input.toolName,
+        text: input.text,
+        piiFields: input.piiFields,
+      });
     },
 
     async egressFilter(input) {

--- a/middleware/packages/harness-orchestrator/src/tools/domainQueryTool.ts
+++ b/middleware/packages/harness-orchestrator/src/tools/domainQueryTool.ts
@@ -71,12 +71,29 @@ export interface Askable {
  * orchestrator threads it onto every emitted `ReadonlyToolTraceEntry` so
  * the Nudge-Pipeline's multi-domain trigger can count distinct domains.
  */
+import type { ToolPIIField } from '@omadia/plugin-api';
+
 export interface DomainTool {
   name: string;
   spec: DomainToolSpec;
   /** OB-77 — see `PLUGIN_DOMAIN_REGEX` for the naming convention. */
   domain: string;
   handle(input: unknown, observer?: AskObserver): Promise<string>;
+  /**
+   * Privacy-Shield v3 (stable-id tokenization, slice 1) — optional PII
+   * field annotations. When present, the orchestrator's
+   * `dispatchTool` runs a stable-id tokenization pass on the tool's
+   * raw result JSON BEFORE serialising to string and BEFORE the
+   * NER-based detectors run. Each annotated field gets a stable token
+   * of the form `«<TYPE>_<id>»` where `<id>` is the value at `idPath`.
+   *
+   * Annotations live on the wrapper (not on `spec`) because Anthropic
+   * rejects unknown fields on a tool spec and PII metadata is a
+   * runtime concern of the harness, not a model-facing one.
+   *
+   * See `@omadia/plugin-api`'s `piiAnnotation.ts` for the full schema.
+   */
+  piiFields?: readonly ToolPIIField[];
 }
 
 export interface DomainToolSpec {

--- a/middleware/packages/harness-plugin-privacy-guard/src/index.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/index.ts
@@ -51,3 +51,8 @@ export {
   type AllowlistMatch,
   type AllowlistSource,
 } from './allowlist.js';
+
+export {
+  applyStableIdTokenization,
+  type StableIdTokenizationOutcome,
+} from './stableIdTokenization.js';

--- a/middleware/packages/harness-plugin-privacy-guard/src/service.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/service.ts
@@ -57,6 +57,8 @@ import type {
   PrivacyReceipt,
   PrivacySelfAnonymizationRequest,
   PrivacySelfAnonymizationResult,
+  PrivacyStableIdPrepassRequest,
+  PrivacyStableIdPrepassResult,
   PrivacyToolInputRequest,
   PrivacyToolInputResult,
   PrivacyToolResultRequest,
@@ -73,6 +75,7 @@ import {
   restoreSelfAnonymization,
   restoreUnresolvedPersonTokens,
 } from './selfAnonymization.js';
+import { applyStableIdTokenization } from './stableIdTokenization.js';
 import { extendHitsToWordBoundary } from './spanHelpers.js';
 import { createRegexDetector } from './regexDetector.js';
 import { TOKEN_REGEX, createTokenizeMap, type TokenizeMap } from './tokenizeMap.js';
@@ -808,6 +811,58 @@ export function createPrivacyGuardService(
       acc.originalChunks.push(`TOOL_RESULT(${request.toolName}):${request.text}`);
 
       return { text: transformed.text, transformed: wasTransformed };
+    },
+
+    // Privacy-Shield v3 (slice 1) — Stable-id tokenization pre-pass.
+    // Runs BEFORE `processToolResult` for tools that declared `piiFields`
+    // annotations. Parses the result string as JSON, walks the
+    // annotated leaves via `applyStableIdTokenization` against the
+    // same turn-scoped TokenizeMap that NER + processInbound use, and
+    // re-serialises. Non-JSON input or empty annotation list degrades
+    // to byte-identical pass-through — NER then runs as it always did.
+    //
+    // The pass touches the SAME map the rest of the pipeline reads,
+    // so a stable-id-minted token is indistinguishable from an NER-
+    // minted token at restoration time. That's the slice-1 contract:
+    // strictly additive, never breaks existing behaviour.
+    async applyStableIdPrepass(
+      request: PrivacyStableIdPrepassRequest,
+    ): Promise<PrivacyStableIdPrepassResult> {
+      // Empty input or empty annotations — pass-through. Still mark
+      // `parsed: true` so the caller doesn't log a false negative.
+      if (request.text.length === 0 || request.piiFields.length === 0) {
+        return { text: request.text, replaced: 0, skipped: 0, parsed: true };
+      }
+
+      let raw: unknown;
+      try {
+        raw = JSON.parse(request.text);
+      } catch {
+        // Tool returned a non-JSON string (status message, free-form
+        // narrative, …). NER will handle it as before.
+        return { text: request.text, replaced: 0, skipped: 0, parsed: false };
+      }
+
+      const map = mapFor(request.turnId);
+      const outcome = applyStableIdTokenization(raw, request.piiFields, map);
+      if (outcome.replaced === 0) {
+        // Nothing rewritten — preserve the original string verbatim to
+        // avoid re-serialisation drift (key order, whitespace) that the
+        // LLM could otherwise interpret as a change.
+        return {
+          text: request.text,
+          replaced: 0,
+          skipped: outcome.skipped,
+          parsed: true,
+        };
+      }
+
+      return {
+        text: JSON.stringify(outcome.value),
+        replaced: outcome.replaced,
+        skipped: outcome.skipped,
+        parsed: true,
+      };
     },
 
     // Privacy-Shield v2 (Slice S-5) — Output Validator. Re-runs the

--- a/middleware/packages/harness-plugin-privacy-guard/src/stableIdTokenization.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/stableIdTokenization.ts
@@ -1,0 +1,273 @@
+/**
+ * Stable-id tokenization — Privacy-Shield v3, slice 1.
+ *
+ * Tool-aware pre-pass that runs BEFORE the NER detectors (Presidio,
+ * regex) inside `processToolResult`. Tools that declare `piiFields`
+ * annotations (see `@omadia/plugin-api`'s `piiAnnotation.ts`) hand the
+ * walker their structured result and a list of (path, idPath, type)
+ * tuples; the walker:
+ *
+ *   1. Resolves each `path` to a list of "leaf positions" — pairs of
+ *      `(parent, key)` so the leaf can be overwritten in place.
+ *   2. Resolves the parallel `idPath` to a list of stable identifiers
+ *      drawn from the same array spreads.
+ *   3. For each (leaf, id) pair: when the leaf is a non-empty string
+ *      and the id is non-null/undefined, mints a whole-value token
+ *      via `map.tokenFor(leafValue, displayType)` and writes the
+ *      token back into the JSON at the leaf position.
+ *
+ * The slice-1 walker uses `tokenFor`'s value-keyed dedup, so the same
+ * leaf value within a turn always yields the same token (no row
+ * doubling for the same employee name). The `idPath` is consumed for
+ * shape-alignment validation but the id value itself is NOT yet baked
+ * into the token name — that escalation lives in slice 1.5 once we
+ * have telemetry on homonym cases (`"Müller" + employee_id=12` vs
+ * `"Müller" + employee_id=88` would collapse in slice 1; in slice 1.5
+ * they get distinct stable-id tokens).
+ *
+ * Failure modes (slice 1):
+ *
+ *   - Shape mismatch (path and idPath disagree on `[]` spread count,
+ *     or the parallel arrays have different lengths): the annotation
+ *     is skipped, the rest of the result remains untouched, a
+ *     `skipped` counter increments. NER then runs on the unmodified
+ *     value as a defense-in-depth net.
+ *   - Non-string leaf: skipped silently. PII annotations target
+ *     string fields; numbers and booleans aren't tokenization targets.
+ *   - Missing path segment: skipped silently. A tool that sometimes
+ *     omits a field doesn't break the walker.
+ *
+ * The walker never throws — every defensive branch returns a no-op
+ * outcome so tokenisation failures degrade to "NER does what it
+ * always did". That's the slice-1 safety property: stable-id is
+ * strictly additive on the privacy-guard pipeline.
+ */
+
+import type { PIIFieldType, ToolPIIField } from '@omadia/plugin-api';
+
+import type { TokenizeMap } from './tokenizeMap.js';
+
+export interface StableIdTokenizationOutcome {
+  /** Deep-cloned tool result with annotated leaves rewritten to tokens. */
+  readonly value: unknown;
+  /** Number of leaf string fields actually replaced with stable tokens. */
+  readonly replaced: number;
+  /**
+   * Number of annotations skipped because the (path, idPath) pair did
+   * not align in shape against the raw result. Telemetry signal — when
+   * non-zero, the operator should re-check the tool's PII annotations
+   * against the live response shape.
+   */
+  readonly skipped: number;
+}
+
+interface PathSegment {
+  readonly key: string;
+  /** `true` when the segment ended with `[]`, signalling an array spread. */
+  readonly isArray: boolean;
+}
+
+interface LeafAddress {
+  readonly parent: Record<string, unknown>;
+  readonly key: string;
+}
+
+/**
+ * Entry point. Walks `raw` once per annotation; never mutates the
+ * input. Annotations of arity zero or with malformed paths are skipped
+ * defensively.
+ *
+ * When the input is anything other than a plain object (string,
+ * number, null, array at top level), the call returns `{value, 0, 0}`
+ * — slice-1 schema only models top-level-object payloads, which is
+ * what every Odoo / Confluence tool currently emits.
+ */
+export function applyStableIdTokenization(
+  raw: unknown,
+  annotations: readonly ToolPIIField[],
+  map: TokenizeMap,
+): StableIdTokenizationOutcome {
+  if (annotations.length === 0) {
+    return { value: raw, replaced: 0, skipped: 0 };
+  }
+  if (!isPlainObject(raw)) {
+    return { value: raw, replaced: 0, skipped: 0 };
+  }
+
+  // Deep-clone via JSON round-trip. The walker mutates the clone, not
+  // the caller's reference. JSON-clone is sufficient because every
+  // tool result this walker sees is already JSON-serialisable (it's
+  // about to be `JSON.stringify`ed for the LLM).
+  const work = JSON.parse(JSON.stringify(raw)) as Record<string, unknown>;
+
+  let replaced = 0;
+  let skipped = 0;
+
+  for (const ann of annotations) {
+    const type: PIIFieldType = ann.type ?? 'PERSON';
+    const pathSegs = parsePath(ann.path);
+    const idSegs = parsePath(ann.idPath);
+    if (pathSegs.length === 0 || idSegs.length === 0) {
+      skipped += 1;
+      continue;
+    }
+    if (countArraySpreads(pathSegs) !== countArraySpreads(idSegs)) {
+      skipped += 1;
+      continue;
+    }
+    const addresses = collectAddresses(work, pathSegs);
+    const ids = collectValues(work, idSegs);
+    if (addresses.length !== ids.length) {
+      skipped += 1;
+      continue;
+    }
+    for (let i = 0; i < addresses.length; i += 1) {
+      const addr = addresses[i];
+      const id = ids[i];
+      if (!addr) continue;
+      if (id === null || id === undefined) continue;
+      const leaf = addr.parent[addr.key];
+      if (typeof leaf !== 'string' || leaf.length === 0) continue;
+      // Slice-1: value-keyed dedup. The id is validated above
+      // (shape-aligned, non-null) but its concrete value does not yet
+      // alter the token name. Slice 1.5 will swap this to a true
+      // stable-id mint that disambiguates homonyms.
+      const token = map.tokenFor(leaf, typeToDetectorHint(type));
+      addr.parent[addr.key] = token;
+      replaced += 1;
+    }
+  }
+
+  return { value: work, replaced, skipped };
+}
+
+/**
+ * Parse a dotted path like `"employees[].partner.name"` into segments.
+ * Empty input or empty segments produce an empty array — caller treats
+ * that as "malformed annotation, skip".
+ */
+function parsePath(path: string): readonly PathSegment[] {
+  if (path.length === 0) return [];
+  const parts = path.split('.');
+  const out: PathSegment[] = [];
+  for (const raw of parts) {
+    if (raw.length === 0) return [];
+    if (raw.endsWith('[]')) {
+      const key = raw.slice(0, -2);
+      if (key.length === 0) return [];
+      out.push({ key, isArray: true });
+    } else {
+      out.push({ key: raw, isArray: false });
+    }
+  }
+  return out;
+}
+
+function countArraySpreads(segs: readonly PathSegment[]): number {
+  let n = 0;
+  for (const s of segs) if (s.isArray) n += 1;
+  return n;
+}
+
+/**
+ * Walk `obj` along `segs`, returning the writable `(parent, key)`
+ * positions of every leaf the path resolves to. Missing intermediate
+ * segments yield an empty slice for that branch — never throws.
+ */
+function collectAddresses(
+  obj: unknown,
+  segs: readonly PathSegment[],
+): readonly LeafAddress[] {
+  if (segs.length === 0) return [];
+  const head = segs[0];
+  if (!head) return [];
+  const rest = segs.slice(1);
+
+  if (head.isArray) {
+    if (!isPlainObject(obj)) return [];
+    const arr = obj[head.key];
+    if (!Array.isArray(arr)) return [];
+    if (rest.length === 0) {
+      // `field[]` with no further segment — slice 1 does not support
+      // arrays of leaves directly; only arrays of objects with a
+      // subsequent key. Skip silently.
+      return [];
+    }
+    const out: LeafAddress[] = [];
+    for (const item of arr) {
+      out.push(...collectAddresses(item, rest));
+    }
+    return out;
+  }
+
+  if (!isPlainObject(obj)) return [];
+  if (rest.length === 0) {
+    return [{ parent: obj, key: head.key }];
+  }
+  return collectAddresses(obj[head.key], rest);
+}
+
+/**
+ * Walk `obj` along `segs`, returning the leaf VALUES the path resolves
+ * to. Mirror of `collectAddresses` for the read side (used to pluck
+ * stable ids out of `idPath`).
+ */
+function collectValues(obj: unknown, segs: readonly PathSegment[]): readonly unknown[] {
+  if (segs.length === 0) return [];
+  const head = segs[0];
+  if (!head) return [];
+  const rest = segs.slice(1);
+
+  if (head.isArray) {
+    if (!isPlainObject(obj)) return [];
+    const arr = obj[head.key];
+    if (!Array.isArray(arr)) return [];
+    if (rest.length === 0) return arr; // raw array-of-leaves
+    const out: unknown[] = [];
+    for (const item of arr) {
+      out.push(...collectValues(item, rest));
+    }
+    return out;
+  }
+
+  if (!isPlainObject(obj)) return [];
+  if (rest.length === 0) return [obj[head.key]];
+  return collectValues(obj[head.key], rest);
+}
+
+function isPlainObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === 'object' && x !== null && !Array.isArray(x);
+}
+
+/**
+ * Map the public `PIIFieldType` literal to the detector-hint string
+ * the existing `TokenizeMap.tokenFor` knows about (`pii.name`,
+ * `pii.email`, …). Keeps the token's display type aligned with the
+ * NER detector taxonomy so a stable-id-minted token and an
+ * NER-minted token of the same type are visually indistinguishable
+ * to the LLM.
+ */
+function typeToDetectorHint(type: PIIFieldType): string {
+  switch (type) {
+    case 'PERSON':
+      return 'pii.name';
+    case 'EMAIL':
+      return 'pii.email';
+    case 'PHONE':
+      return 'pii.phone';
+    case 'IBAN':
+      return 'pii.iban';
+    case 'CARD':
+      return 'pii.credit_card';
+    case 'ADDRESS':
+      return 'pii.address';
+    case 'ORG':
+      return 'pii.organization';
+    case 'APIKEY':
+      return 'pii.api_key';
+    default:
+      // Exhaustiveness guard — TS will catch a new variant at compile
+      // time, but at runtime fall back to a generic name hint.
+      return 'pii.name';
+  }
+}

--- a/middleware/packages/harness-plugin-privacy-guard/src/stableIdTokenization.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/stableIdTokenization.ts
@@ -1,5 +1,5 @@
 /**
- * Stable-id tokenization — Privacy-Shield v3, slice 1.
+ * Stable-id tokenization — Privacy-Shield v3.
  *
  * Tool-aware pre-pass that runs BEFORE the NER detectors (Presidio,
  * regex) inside `processToolResult`. Tools that declare `piiFields`
@@ -7,8 +7,9 @@
  * walker their structured result and a list of (path, idPath, type)
  * tuples; the walker:
  *
- *   1. Resolves each `path` to a list of "leaf positions" — pairs of
- *      `(parent, key)` so the leaf can be overwritten in place.
+ *   1. Resolves each `path` to a list of "leaf positions" — writable
+ *      slots (object key OR array index) so the leaf can be overwritten
+ *      in place.
  *   2. Resolves the parallel `idPath` to a list of stable identifiers
  *      drawn from the same array spreads.
  *   3. For each (leaf, id) pair: when the leaf is a non-empty string
@@ -16,31 +17,51 @@
  *      via `map.tokenFor(leafValue, displayType)` and writes the
  *      token back into the JSON at the leaf position.
  *
- * The slice-1 walker uses `tokenFor`'s value-keyed dedup, so the same
- * leaf value within a turn always yields the same token (no row
- * doubling for the same employee name). The `idPath` is consumed for
- * shape-alignment validation but the id value itself is NOT yet baked
- * into the token name — that escalation lives in slice 1.5 once we
- * have telemetry on homonym cases (`"Müller" + employee_id=12` vs
- * `"Müller" + employee_id=88` would collapse in slice 1; in slice 1.5
- * they get distinct stable-id tokens).
+ * Path grammar (slice 2 — extended for real Odoo shapes)
+ * ------------------------------------------------------
+ * A path is a sequence of steps:
  *
- * Failure modes (slice 1):
+ *   - `key`   — descend into an object property (`name`, `partner`).
+ *   - `[]`    — spread across every element of an array. May appear at
+ *               the head of the path when the tool result is itself a
+ *               top-level array (Odoo `search_read` returns `[{…}]`).
+ *   - `[N]`   — descend into a fixed array index. The motivating case
+ *               is Odoo's many2one wire format `field: [id, label]` —
+ *               `field[1]` is the human label, `field[0]` the id.
  *
- *   - Shape mismatch (path and idPath disagree on `[]` spread count,
- *     or the parallel arrays have different lengths): the annotation
- *     is skipped, the rest of the result remains untouched, a
- *     `skipped` counter increments. NER then runs on the unmodified
- *     value as a defense-in-depth net.
- *   - Non-string leaf: skipped silently. PII annotations target
- *     string fields; numbers and booleans aren't tokenization targets.
- *   - Missing path segment: skipped silently. A tool that sometimes
- *     omits a field doesn't break the walker.
+ * Examples:
  *
- * The walker never throws — every defensive branch returns a no-op
- * outcome so tokenisation failures degrade to "NER does what it
- * always did". That's the slice-1 safety property: stable-id is
- * strictly additive on the privacy-guard pipeline.
+ *   - `"name"`                       — top-level object field
+ *   - `"user.name"`                  — nested object
+ *   - `"employees[].name"`           — array of objects, one per row
+ *   - `"[].name"`                    — TOP-LEVEL array of objects
+ *   - `"[].employee_id[1]"`          — top-level array, many2one label
+ *   - `"[].employee_id[0]"`          — top-level array, many2one id
+ *   - `"absences[].partner.name"`    — array of nested objects
+ *
+ * `path` and `idPath` must contain the SAME number of `[]` spreads in
+ * the same nesting order so the two leaf lists zip 1:1. Fixed `[N]`
+ * indices do not multiply, so they need not align in count.
+ *
+ * Slice-1 dedup semantics carry over: the walker uses `tokenFor`'s
+ * value-keyed dedup, so the same leaf value within a turn always
+ * yields the same token (no row doubling for the same employee name).
+ * The `idPath` is consumed for shape-alignment validation but the id
+ * value itself is not yet baked into the token name — homonym
+ * disambiguation (`"Müller" + id=12` vs `"Müller" + id=88`) lands in
+ * slice 1.5.
+ *
+ * Failure modes
+ * -------------
+ *   - Shape mismatch (path / idPath disagree on `[]` spread count, or
+ *     the two leaf lists differ in length): the annotation is skipped,
+ *     the rest of the result is untouched, `skipped` increments. NER
+ *     then runs on the unmodified value as a defense-in-depth net.
+ *   - Non-string leaf / null id / missing segment: skipped silently.
+ *
+ * The walker never throws — every defensive branch returns a no-op so
+ * tokenisation failures degrade to "NER does what it always did".
+ * Stable-id is strictly additive on the privacy-guard pipeline.
  */
 
 import type { PIIFieldType, ToolPIIField } from '@omadia/plugin-api';
@@ -61,26 +82,24 @@ export interface StableIdTokenizationOutcome {
   readonly skipped: number;
 }
 
-interface PathSegment {
-  readonly key: string;
-  /** `true` when the segment ended with `[]`, signalling an array spread. */
-  readonly isArray: boolean;
-}
+/** One parsed step of a path expression. */
+type PathSegment =
+  | { readonly kind: 'key'; readonly key: string }
+  | { readonly kind: 'spread' }
+  | { readonly kind: 'index'; readonly index: number };
 
-interface LeafAddress {
-  readonly parent: Record<string, unknown>;
-  readonly key: string;
-}
+/** A writable leaf position — either an object property or an array slot. */
+type LeafAddress =
+  | { readonly kind: 'objKey'; readonly parent: Record<string, unknown>; readonly key: string }
+  | { readonly kind: 'arrIndex'; readonly parent: unknown[]; readonly index: number };
 
 /**
  * Entry point. Walks `raw` once per annotation; never mutates the
- * input. Annotations of arity zero or with malformed paths are skipped
- * defensively.
+ * input. Annotations with malformed paths are skipped defensively.
  *
- * When the input is anything other than a plain object (string,
- * number, null, array at top level), the call returns `{value, 0, 0}`
- * — slice-1 schema only models top-level-object payloads, which is
- * what every Odoo / Confluence tool currently emits.
+ * `raw` may be a top-level object (`{absences: [...]}`) OR a top-level
+ * array (Odoo `search_read` → `[{…}]`). Primitives pass through
+ * untouched.
  */
 export function applyStableIdTokenization(
   raw: unknown,
@@ -90,15 +109,17 @@ export function applyStableIdTokenization(
   if (annotations.length === 0) {
     return { value: raw, replaced: 0, skipped: 0 };
   }
-  if (!isPlainObject(raw)) {
+  if (raw === null || typeof raw !== 'object') {
+    // Primitive top-level payload — nothing structured to walk.
     return { value: raw, replaced: 0, skipped: 0 };
   }
 
   // Deep-clone via JSON round-trip. The walker mutates the clone, not
   // the caller's reference. JSON-clone is sufficient because every
   // tool result this walker sees is already JSON-serialisable (it's
-  // about to be `JSON.stringify`ed for the LLM).
-  const work = JSON.parse(JSON.stringify(raw)) as Record<string, unknown>;
+  // about to be `JSON.stringify`ed for the LLM). Works for both
+  // top-level objects and top-level arrays.
+  const work = JSON.parse(JSON.stringify(raw)) as unknown;
 
   let replaced = 0;
   let skipped = 0;
@@ -111,7 +132,7 @@ export function applyStableIdTokenization(
       skipped += 1;
       continue;
     }
-    if (countArraySpreads(pathSegs) !== countArraySpreads(idSegs)) {
+    if (countSpreads(pathSegs) !== countSpreads(idSegs)) {
       skipped += 1;
       continue;
     }
@@ -126,14 +147,14 @@ export function applyStableIdTokenization(
       const id = ids[i];
       if (!addr) continue;
       if (id === null || id === undefined) continue;
-      const leaf = addr.parent[addr.key];
+      const leaf = readLeaf(addr);
       if (typeof leaf !== 'string' || leaf.length === 0) continue;
-      // Slice-1: value-keyed dedup. The id is validated above
-      // (shape-aligned, non-null) but its concrete value does not yet
-      // alter the token name. Slice 1.5 will swap this to a true
-      // stable-id mint that disambiguates homonyms.
+      // Value-keyed dedup: the same string in this turn yields the
+      // same token. The id is validated above (shape-aligned,
+      // non-null) but its concrete value does not yet alter the token
+      // name — slice 1.5 will add homonym disambiguation.
       const token = map.tokenFor(leaf, typeToDetectorHint(type));
-      addr.parent[addr.key] = token;
+      writeLeaf(addr, token);
       replaced += 1;
     }
   }
@@ -141,38 +162,98 @@ export function applyStableIdTokenization(
   return { value: work, replaced, skipped };
 }
 
+// ---------------------------------------------------------------------------
+// Path parsing.
+// ---------------------------------------------------------------------------
+
 /**
- * Parse a dotted path like `"employees[].partner.name"` into segments.
- * Empty input or empty segments produce an empty array — caller treats
- * that as "malformed annotation, skip".
+ * Parse a path expression into segments. Returns an empty array for any
+ * malformed input — the caller treats that as "skip this annotation".
+ *
+ * Grammar (informal):
+ *
+ *   path    := step (sep step)*
+ *   step    := key | spread | index
+ *   sep     := '.'        (required before a `key`, never before `[...]`)
+ *   spread  := '[]'
+ *   index   := '[' digits ']'
+ *   key     := [^.[\]]+
+ *
+ * A `key` needs a preceding `.` unless it is the very first step.
+ * `[]` / `[N]` attach directly (no dot). Leading `.`, trailing `.`,
+ * `..`, unclosed `[`, stray `]`, and `[non-digit]` are all rejected.
  */
 function parsePath(path: string): readonly PathSegment[] {
   if (path.length === 0) return [];
-  const parts = path.split('.');
-  const out: PathSegment[] = [];
-  for (const raw of parts) {
-    if (raw.length === 0) return [];
-    if (raw.endsWith('[]')) {
-      const key = raw.slice(0, -2);
-      if (key.length === 0) return [];
-      out.push({ key, isArray: true });
-    } else {
-      out.push({ key: raw, isArray: false });
+  const segs: PathSegment[] = [];
+  let i = 0;
+  let started = false;
+  let lastWasDot = false;
+
+  while (i < path.length) {
+    const ch = path[i];
+
+    if (ch === '.') {
+      if (!started || lastWasDot) return []; // leading or doubled dot
+      lastWasDot = true;
+      i += 1;
+      continue;
     }
+
+    if (ch === '[') {
+      const close = path.indexOf(']', i);
+      if (close < 0) return []; // unclosed bracket
+      const inner = path.slice(i + 1, close);
+      if (inner.length === 0) {
+        segs.push({ kind: 'spread' });
+      } else if (/^\d+$/.test(inner)) {
+        segs.push({ kind: 'index', index: Number.parseInt(inner, 10) });
+      } else {
+        return []; // `[foo]` — only `[]` and `[digits]` are valid
+      }
+      started = true;
+      lastWasDot = false;
+      i = close + 1;
+      continue;
+    }
+
+    if (ch === ']') return []; // stray close bracket
+
+    // Identifier run — a `key` segment. Valid only at the head of the
+    // path or directly after a `.` separator.
+    if (started && !lastWasDot) return [];
+    let j = i;
+    while (j < path.length) {
+      const c = path[j];
+      if (c === '.' || c === '[' || c === ']') break;
+      j += 1;
+    }
+    const key = path.slice(i, j);
+    if (key.length === 0) return [];
+    segs.push({ kind: 'key', key });
+    started = true;
+    lastWasDot = false;
+    i = j;
   }
-  return out;
+
+  if (lastWasDot) return []; // trailing dot
+  return segs;
 }
 
-function countArraySpreads(segs: readonly PathSegment[]): number {
+function countSpreads(segs: readonly PathSegment[]): number {
   let n = 0;
-  for (const s of segs) if (s.isArray) n += 1;
+  for (const s of segs) if (s.kind === 'spread') n += 1;
   return n;
 }
 
+// ---------------------------------------------------------------------------
+// Walkers.
+// ---------------------------------------------------------------------------
+
 /**
- * Walk `obj` along `segs`, returning the writable `(parent, key)`
- * positions of every leaf the path resolves to. Missing intermediate
- * segments yield an empty slice for that branch — never throws.
+ * Walk `obj` along `segs`, returning the writable leaf positions every
+ * path resolves to. Missing intermediate segments yield an empty slice
+ * for that branch — never throws.
  */
 function collectAddresses(
   obj: unknown,
@@ -182,57 +263,88 @@ function collectAddresses(
   const head = segs[0];
   if (!head) return [];
   const rest = segs.slice(1);
+  const isLast = rest.length === 0;
 
-  if (head.isArray) {
-    if (!isPlainObject(obj)) return [];
-    const arr = obj[head.key];
-    if (!Array.isArray(arr)) return [];
-    if (rest.length === 0) {
-      // `field[]` with no further segment — slice 1 does not support
-      // arrays of leaves directly; only arrays of objects with a
-      // subsequent key. Skip silently.
-      return [];
+  if (head.kind === 'spread') {
+    if (!Array.isArray(obj)) return [];
+    if (isLast) {
+      // `…[]` as the final step — every element of the array is itself
+      // a leaf (array-of-strings, e.g. `emails[]`).
+      return obj.map(
+        (_, index): LeafAddress => ({ kind: 'arrIndex', parent: obj, index }),
+      );
     }
     const out: LeafAddress[] = [];
-    for (const item of arr) {
+    for (const item of obj) {
       out.push(...collectAddresses(item, rest));
     }
     return out;
   }
 
+  if (head.kind === 'index') {
+    if (!Array.isArray(obj)) return [];
+    if (head.index >= obj.length) return [];
+    if (isLast) {
+      return [{ kind: 'arrIndex', parent: obj, index: head.index }];
+    }
+    return collectAddresses(obj[head.index], rest);
+  }
+
+  // head.kind === 'key'
   if (!isPlainObject(obj)) return [];
-  if (rest.length === 0) {
-    return [{ parent: obj, key: head.key }];
+  if (isLast) {
+    return [{ kind: 'objKey', parent: obj, key: head.key }];
   }
   return collectAddresses(obj[head.key], rest);
 }
 
 /**
- * Walk `obj` along `segs`, returning the leaf VALUES the path resolves
- * to. Mirror of `collectAddresses` for the read side (used to pluck
- * stable ids out of `idPath`).
+ * Walk `obj` along `segs`, returning the leaf VALUES every path
+ * resolves to. Read-side mirror of `collectAddresses` — used to pluck
+ * stable ids out of `idPath`.
  */
 function collectValues(obj: unknown, segs: readonly PathSegment[]): readonly unknown[] {
   if (segs.length === 0) return [];
   const head = segs[0];
   if (!head) return [];
   const rest = segs.slice(1);
+  const isLast = rest.length === 0;
 
-  if (head.isArray) {
-    if (!isPlainObject(obj)) return [];
-    const arr = obj[head.key];
-    if (!Array.isArray(arr)) return [];
-    if (rest.length === 0) return arr; // raw array-of-leaves
+  if (head.kind === 'spread') {
+    if (!Array.isArray(obj)) return [];
+    if (isLast) return obj;
     const out: unknown[] = [];
-    for (const item of arr) {
+    for (const item of obj) {
       out.push(...collectValues(item, rest));
     }
     return out;
   }
 
+  if (head.kind === 'index') {
+    if (!Array.isArray(obj)) return [];
+    if (head.index >= obj.length) return [];
+    if (isLast) return [obj[head.index]];
+    return collectValues(obj[head.index], rest);
+  }
+
+  // head.kind === 'key'
   if (!isPlainObject(obj)) return [];
-  if (rest.length === 0) return [obj[head.key]];
+  if (isLast) return [obj[head.key]];
   return collectValues(obj[head.key], rest);
+}
+
+function readLeaf(addr: LeafAddress): unknown {
+  return addr.kind === 'objKey'
+    ? addr.parent[addr.key]
+    : addr.parent[addr.index];
+}
+
+function writeLeaf(addr: LeafAddress, value: string): void {
+  if (addr.kind === 'objKey') {
+    addr.parent[addr.key] = value;
+  } else {
+    addr.parent[addr.index] = value;
+  }
 }
 
 function isPlainObject(x: unknown): x is Record<string, unknown> {

--- a/middleware/packages/harness-plugin-privacy-guard/src/stableIdTokenization.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/stableIdTokenization.ts
@@ -43,13 +43,12 @@
  * the same nesting order so the two leaf lists zip 1:1. Fixed `[N]`
  * indices do not multiply, so they need not align in count.
  *
- * Slice-1 dedup semantics carry over: the walker uses `tokenFor`'s
- * value-keyed dedup, so the same leaf value within a turn always
- * yields the same token (no row doubling for the same employee name).
- * The `idPath` is consumed for shape-alignment validation but the id
- * value itself is not yet baked into the token name — homonym
- * disambiguation (`"Müller" + id=12` vs `"Müller" + id=88`) lands in
- * slice 1.5.
+ * Dedup semantics (slice 1.5): the walker mints tokens via
+ * `TokenizeMap.tokenForStableId`, keyed by the entity id resolved
+ * from `idPath` — NOT by the string value. The same entity yields one
+ * token across every row of the result; two homonyms that share a
+ * value but differ in id (`"Müller" + id=12` vs `"Müller" + id=88`)
+ * get DISTINCT tokens, so a ranking table never silently merges them.
  *
  * Failure modes
  * -------------
@@ -149,11 +148,16 @@ export function applyStableIdTokenization(
       if (id === null || id === undefined) continue;
       const leaf = readLeaf(addr);
       if (typeof leaf !== 'string' || leaf.length === 0) continue;
-      // Value-keyed dedup: the same string in this turn yields the
-      // same token. The id is validated above (shape-aligned,
-      // non-null) but its concrete value does not yet alter the token
-      // name — slice 1.5 will add homonym disambiguation.
-      const token = map.tokenFor(leaf, typeToDetectorHint(type));
+      // Stable-id dedup (slice 1.5): the token is keyed by the entity
+      // identity at `idPath`, not by the string value. The same
+      // employee yields one token across every row; two homonyms
+      // ("Thomas Müller" id 12 vs id 88) get distinct tokens so a
+      // ranking table never silently merges their rows.
+      const token = map.tokenForStableId(
+        leaf,
+        typeToDetectorHint(type),
+        String(id),
+      );
       writeLeaf(addr, token);
       replaced += 1;
     }

--- a/middleware/packages/harness-plugin-privacy-guard/src/tokenizeMap.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/tokenizeMap.ts
@@ -54,6 +54,27 @@ export interface TokenizeMap {
    *  `typeHint` only steers the initial mint and is ignored on
    *  subsequent lookups. */
   tokenFor(value: string, typeHint?: string): string;
+  /**
+   * Privacy-Shield v3 (stable-id tokenization, slice 1.5) — mint a
+   * token keyed by a STABLE ENTITY IDENTITY rather than by the string
+   * value.
+   *
+   * The dedup key is `(displayType, stableId)`. Two consequences:
+   *
+   *   - The same entity (same `stableId`) yields the same token across
+   *     every row / call within the turn, even if the tool reports the
+   *     value slightly differently ("Marvin Vomberg" vs "M. Vomberg").
+   *   - Two DIFFERENT entities that happen to share a value — homonyms
+   *     like two employees both named "Thomas Müller" — get DISTINCT
+   *     tokens, so a ranking table never silently merges their rows.
+   *
+   * The token number is still a map-local counter (collision-free with
+   * `tokenFor`), not the id itself — the id stays off the wire. The
+   * value is registered in the reverse map so `resolve()` works, and
+   * in the value-keyed map (first-writer-wins for a homonym) so
+   * `hasOriginalValue()` stays correct for the Output Validator.
+   */
+  tokenForStableId(value: string, typeHint: string, stableId: string): string;
   /** Look up the original value behind a token. `undefined` for unknown
    *  tokens so the caller can decide what to do (Output Validator
    *  flags hallucinated tokens, restoreTokens leaves them in place). */
@@ -155,16 +176,48 @@ class InMemoryTokenizeMap implements TokenizeMap {
    *  but `«EMAIL_1»` starts independently — readability over global
    *  ordering. */
   private readonly counters = new Map<string, number>();
+  /** Slice 1.5 — `(displayType, stableId)` composite key to token.
+   *  Separate from `forward` (value-keyed) so two homonyms with the
+   *  same value but different ids still get distinct tokens. */
+  private readonly stableForward = new Map<string, string>();
+
+  /** Mint the next `«TYPE_N»` token for `type` and register the reverse
+   *  binding. Shared by `tokenFor` and `tokenForStableId` so both draw
+   *  from the same per-type counter — no token-number collisions. */
+  private mint(type: string, value: string): string {
+    const next = (this.counters.get(type) ?? 0) + 1;
+    this.counters.set(type, next);
+    const token = `«${type}_${String(next)}»`;
+    this.reverse.set(token, value);
+    return token;
+  }
 
   tokenFor(value: string, typeHint?: string): string {
     const existing = this.forward.get(value);
     if (existing !== undefined) return existing;
     const type = displayTypeFor(typeHint);
-    const next = (this.counters.get(type) ?? 0) + 1;
-    this.counters.set(type, next);
-    const token = `«${type}_${String(next)}»`;
+    const token = this.mint(type, value);
     this.forward.set(value, token);
-    this.reverse.set(token, value);
+    return token;
+  }
+
+  tokenForStableId(value: string, typeHint: string, stableId: string): string {
+    const type = displayTypeFor(typeHint);
+    // Composite key joined by a colon. `displayTypeFor` guarantees
+    // `type` is `[A-Z0-9_]+`, so it can never contain the colon — the
+    // first colon always delimits type from stableId and the
+    // `(type, stableId)` pair stays collision-free for any stableId.
+    const stableKey = type.concat(':', stableId);
+    const existing = this.stableForward.get(stableKey);
+    if (existing !== undefined) return existing;
+    const token = this.mint(type, value);
+    this.stableForward.set(stableKey, token);
+    // Register the value-keyed binding too (first-writer-wins for a
+    // homonym) so `hasOriginalValue` stays correct for the Output
+    // Validator and a later NER hit on the same string reuses the token.
+    if (!this.forward.has(value)) {
+      this.forward.set(value, token);
+    }
     return token;
   }
 
@@ -180,6 +233,7 @@ class InMemoryTokenizeMap implements TokenizeMap {
     this.forward.clear();
     this.reverse.clear();
     this.counters.clear();
+    this.stableForward.clear();
   }
 
   get size(): number {

--- a/middleware/packages/plugin-api/src/index.ts
+++ b/middleware/packages/plugin-api/src/index.ts
@@ -1,6 +1,7 @@
 export * from './pluginContext.js';
 export * from './conversation.js';
 export * from './localSubAgentTool.js';
+export * from './piiAnnotation.js';
 
 // S+11-1: Knowledge-graph capability contract (interface + DTOs + node-id
 // helpers) lives on the plugin-api surface. Both the in-memory and the Neon

--- a/middleware/packages/plugin-api/src/localSubAgentTool.ts
+++ b/middleware/packages/plugin-api/src/localSubAgentTool.ts
@@ -9,6 +9,8 @@
  * to keep the seam loose (no plugin-api consumer needs to depend on the
  * Anthropic SDK).
  */
+import type { ToolPIIField } from './piiAnnotation.js';
+
 export interface LocalSubAgentToolSpec {
   name: string;
   description: string;
@@ -22,4 +24,20 @@ export interface LocalSubAgentToolSpec {
 export interface LocalSubAgentTool {
   spec: LocalSubAgentToolSpec;
   handle(input: unknown): Promise<string>;
+  /**
+   * Privacy-Shield v3 (stable-id tokenization, slice 1) — optional PII
+   * field annotations. When present, the harness runs a stable-id
+   * tokenization pass on the tool's raw result JSON BEFORE serialising
+   * to string and BEFORE the NER-based detectors run. Each annotated
+   * field gets a stable token of the form `«<TYPE>_<id>»` where
+   * `<id>` is the value at `idPath`.
+   *
+   * Annotations live on the wrapper (not on `spec`) because Anthropic's
+   * tool-spec contract rejects unknown fields and PII metadata is a
+   * runtime concern, not a model-facing one.
+   *
+   * See `@omadia/plugin-api`'s `piiAnnotation.ts` for the full schema
+   * and path-syntax rationale.
+   */
+  piiFields?: readonly ToolPIIField[];
 }

--- a/middleware/packages/plugin-api/src/piiAnnotation.ts
+++ b/middleware/packages/plugin-api/src/piiAnnotation.ts
@@ -1,0 +1,87 @@
+/**
+ * Tool-side PII field annotations — Privacy-Shield v3 (stable-id
+ * tokenization, slice 1).
+ *
+ * Motivation
+ * ----------
+ * The Slice-3 NER detector (Presidio) tokenizes PII *after* a tool has
+ * already serialized its result to a string. German names trip
+ * Presidio in three failure modes that surfaced in the live HR-routine
+ * v149..v152:
+ *
+ *   - Partial-name leaks: NER hits "Marvin" → `«PERSON_N»` but leaves
+ *     "Vomberg" plaintext, producing rows like `«PERSON_53» Vomberg`.
+ *   - Counter drift: every NER hit mints a fresh token, so the same
+ *     employee can end up as `«PERSON_3»` in one row and `«PERSON_47»`
+ *     in another within the same tool call — restoration aligns to
+ *     positions, not identities, and table cells get the wrong name.
+ *   - False-positive cascades: "Krankheit" → ADDRESS,
+ *     "Abwesenheitstyp" → PERSON. Allowlists patch case-by-case but
+ *     never exhaustively.
+ *
+ * Stable-id tokenization sidesteps all three: tools whose underlying
+ * data store gives them a stable identifier per entity (e.g. Odoo
+ * `employee_id`, Confluence `accountId`) declare the JSON path to
+ * that identifier alongside the PII-bearing field. The privacy-guard
+ * mints `«PERSON_<id>»` tokens *before* NER runs, so:
+ *
+ *   1. The whole value is masked as a single unit (no partial leak).
+ *   2. The same identifier yields the same token across rows /
+ *      paragraphs / tool calls within a turn (no doubles).
+ *   3. NER becomes defense-in-depth for unannotated free-text only;
+ *      false positives stay confined to the prose surface.
+ *
+ * Annotations live on the *tool wrapper*, never on the spec sent to
+ * the public LLM. Anthropic's `messages.create({ tools })` rejects
+ * unknown fields on a tool spec — and PII metadata is a runtime
+ * concern of the harness, not something the model needs to see.
+ *
+ * Path syntax
+ * -----------
+ * `path` and `idPath` use a dotted notation with `[]` as the
+ * array-spread marker. Supported shapes (slice 1):
+ *
+ *   - `"name"`                            — top-level field
+ *   - `"user.name"`                       — nested object
+ *   - `"employees[].name"`                — array of objects, one per row
+ *   - `"employees[].partner.name"`        — array of nested objects
+ *
+ * Not supported in slice 1: array indices (`employees[0].name`),
+ * wildcards across object keys, or non-uniform shapes. Both `path`
+ * and `idPath` must walk through the same `[]` spreads in the same
+ * order — `employees[].name` pairs with `employees[].employee_id`,
+ * not `employees[].partner.id`.
+ *
+ * Type vocabulary
+ * ---------------
+ * Mirrors the `«TYPE_N»` token type set the LLM directive describes
+ * (`PERSON`, `EMAIL`, `PHONE`, `IBAN`, `CARD`, `ADDRESS`, `ORG`,
+ * `APIKEY`). Default is `PERSON` because that is by far the most
+ * common annotation in HR / CRM tool results — the place stable-id
+ * tokenization pays off most.
+ */
+
+export type PIIFieldType =
+  | 'PERSON'
+  | 'EMAIL'
+  | 'PHONE'
+  | 'IBAN'
+  | 'CARD'
+  | 'ADDRESS'
+  | 'ORG'
+  | 'APIKEY';
+
+export interface ToolPIIField {
+  /** JSON path to the PII-bearing field, e.g. `"employees[].name"`. */
+  readonly path: string;
+  /**
+   * JSON path to the stable identifier the privacy-guard should use
+   * when minting tokens, e.g. `"employees[].employee_id"`. Must walk
+   * through the same `[]` spreads as `path`. The identifier is
+   * stringified before being embedded in the token name, so numeric
+   * ids (Odoo) and opaque strings (Confluence `accountId`) both work.
+   */
+  readonly idPath: string;
+  /** PII type. Defaults to `PERSON` when omitted. */
+  readonly type?: PIIFieldType;
+}

--- a/middleware/packages/plugin-api/src/piiAnnotation.ts
+++ b/middleware/packages/plugin-api/src/piiAnnotation.ts
@@ -90,11 +90,14 @@ export interface ToolPIIField {
   /** JSON path to the PII-bearing field, e.g. `"employees[].name"`. */
   readonly path: string;
   /**
-   * JSON path to the stable identifier the privacy-guard should use
-   * when minting tokens, e.g. `"employees[].employee_id"`. Must walk
+   * JSON path to the stable identifier the privacy-guard uses as the
+   * token DEDUP KEY, e.g. `"employees[].employee_id"`. Must walk
    * through the same `[]` spreads as `path`. The identifier is
-   * stringified before being embedded in the token name, so numeric
-   * ids (Odoo) and opaque strings (Confluence `accountId`) both work.
+   * stringified, so numeric ids (Odoo) and opaque strings (Confluence
+   * `accountId`) both work. Same id → same token across rows; two
+   * homonyms with different ids → distinct tokens. The id itself is
+   * never embedded in the token name (the token stays `«TYPE_N»` with
+   * a map-local counter), so it never crosses the wire.
    */
   readonly idPath: string;
   /** PII type. Defaults to `PERSON` when omitted. */

--- a/middleware/packages/plugin-api/src/piiAnnotation.ts
+++ b/middleware/packages/plugin-api/src/piiAnnotation.ts
@@ -1,6 +1,6 @@
 /**
  * Tool-side PII field annotations — Privacy-Shield v3 (stable-id
- * tokenization, slice 1).
+ * tokenization).
  *
  * Motivation
  * ----------
@@ -38,19 +38,34 @@
  *
  * Path syntax
  * -----------
- * `path` and `idPath` use a dotted notation with `[]` as the
- * array-spread marker. Supported shapes (slice 1):
+ * `path` and `idPath` are step sequences. Each step is one of:
  *
- *   - `"name"`                            — top-level field
- *   - `"user.name"`                       — nested object
- *   - `"employees[].name"`                — array of objects, one per row
- *   - `"employees[].partner.name"`        — array of nested objects
+ *   - `key`   — descend into an object property (`name`, `partner`).
+ *   - `[]`    — spread across every element of an array. May appear at
+ *               the head of the path when the tool result is itself a
+ *               top-level array (Odoo `search_read` → `[{…}]`).
+ *   - `[N]`   — descend into a fixed array index. The motivating case
+ *               is Odoo's many2one wire format `field: [id, label]`,
+ *               where `field[1]` is the label and `field[0]` the id.
  *
- * Not supported in slice 1: array indices (`employees[0].name`),
- * wildcards across object keys, or non-uniform shapes. Both `path`
- * and `idPath` must walk through the same `[]` spreads in the same
- * order — `employees[].name` pairs with `employees[].employee_id`,
- * not `employees[].partner.id`.
+ * Supported shapes:
+ *
+ *   - `"name"`                       — top-level object field
+ *   - `"user.name"`                  — nested object
+ *   - `"employees[].name"`           — array of objects, one per row
+ *   - `"employees[].partner.name"`   — array of nested objects
+ *   - `"[].name"`                    — TOP-LEVEL array of objects
+ *   - `"[].employee_id[1]"`          — top-level array + many2one label
+ *   - `"emails[]"`                   — array of leaf strings
+ *
+ * Both `path` and `idPath` must walk through the SAME number of `[]`
+ * spreads in the same order so the two leaf lists zip 1:1 — e.g.
+ * `[].employee_id[1]` pairs with `[].employee_id[0]`. Fixed `[N]`
+ * indices do not multiply, so they need not match in count.
+ *
+ * For Odoo many2one fields, use the {@link odooMany2OnePiiField} and
+ * {@link odooSearchReadPiiFields} helpers below instead of spelling
+ * the `[id, label]` index paths out by hand.
  *
  * Type vocabulary
  * ---------------
@@ -84,4 +99,80 @@ export interface ToolPIIField {
   readonly idPath: string;
   /** PII type. Defaults to `PERSON` when omitted. */
   readonly type?: PIIFieldType;
+}
+
+// ---------------------------------------------------------------------------
+// Odoo many2one helpers.
+//
+// Odoo's `search_read` returns a top-level array of records; every
+// many2one field is serialised as a two-element tuple `[id, label]`
+// (an empty relation is `false`, which the walker skips gracefully).
+// Spelling the `[1]` / `[0]` index paths out by hand for every PII
+// field is noisy and error-prone — these helpers centralise the
+// convention so an Odoo tool annotates its result with a one-liner.
+// ---------------------------------------------------------------------------
+
+export interface OdooMany2OneOptions {
+  /** PII type for the many2one label. Defaults to `PERSON`. */
+  readonly type?: PIIFieldType;
+  /**
+   * Object path to the array of Odoo records. Defaults to `''` — the
+   * records ARE the top-level array, which is what `search_read`
+   * returns directly. Pass e.g. `"records"` when the tool wraps the
+   * rows in an envelope: `{ records: [{…}], meta: {…} }`.
+   */
+  readonly recordsAt?: string;
+}
+
+/**
+ * Build a {@link ToolPIIField} for a single Odoo many2one field.
+ *
+ * `odooMany2OnePiiField("employee_id")` →
+ *   `{ path: "[].employee_id[1]", idPath: "[].employee_id[0]" }`
+ *
+ * The label (index 1) is the PII leaf that gets tokenised; the id
+ * (index 0) is the stable identifier. A record whose relation is
+ * empty (`employee_id: false`) contributes no leaf on either path,
+ * so the 1:1 zip stays aligned and the record is simply skipped.
+ */
+export function odooMany2OnePiiField(
+  field: string,
+  options: OdooMany2OneOptions = {},
+): ToolPIIField {
+  const prefix =
+    options.recordsAt !== undefined && options.recordsAt.length > 0
+      ? `${options.recordsAt}[]`
+      : '[]';
+  return {
+    path: `${prefix}.${field}[1]`,
+    idPath: `${prefix}.${field}[0]`,
+    ...(options.type !== undefined ? { type: options.type } : {}),
+  };
+}
+
+/**
+ * Build a {@link ToolPIIField} list for several Odoo many2one fields
+ * at once. The common case for an HR / CRM `search_read` tool:
+ *
+ * ```ts
+ * piiFields: odooSearchReadPiiFields({
+ *   employee_id: 'PERSON',
+ *   user_id: 'PERSON',
+ *   partner_id: 'PERSON',
+ * })
+ * ```
+ *
+ * Pass `{ recordsAt: 'records' }` as the second argument when the
+ * tool wraps the rows in an envelope object.
+ */
+export function odooSearchReadPiiFields(
+  fields: Readonly<Record<string, PIIFieldType>>,
+  options: Pick<OdooMany2OneOptions, 'recordsAt'> = {},
+): ToolPIIField[] {
+  return Object.entries(fields).map(([field, type]) =>
+    odooMany2OnePiiField(field, {
+      type,
+      ...(options.recordsAt !== undefined ? { recordsAt: options.recordsAt } : {}),
+    }),
+  );
 }

--- a/middleware/packages/plugin-api/src/privacyReceipt.ts
+++ b/middleware/packages/plugin-api/src/privacyReceipt.ts
@@ -493,6 +493,61 @@ export interface PrivacyToolResultResult {
 }
 
 // ---------------------------------------------------------------------------
+// Privacy-Shield v3 (slice 1) — Stable-id tokenization pre-pass.
+//
+// Runs BEFORE `processToolResult` for tools that declare `piiFields`
+// annotations. The provider parses the tool's text result as JSON,
+// walks the annotated leaves with `applyStableIdTokenization`, and
+// re-serialises so `processToolResult`'s NER pass sees pre-tokenized
+// PII fields. Eliminates the partial-name leak ("«PERSON_5» Vomberg")
+// and the row-doubling failure mode of NER-only tokenization.
+//
+// Strictly additive: a tool without annotations skips this hook, and
+// a parse failure degrades silently to "NER does what it always did".
+// ---------------------------------------------------------------------------
+
+/** A single PII annotation tuple — mirrors `@omadia/plugin-api`'s
+ *  `ToolPIIField` but inlined into the request so providers can be
+ *  package-internal. */
+export interface PrivacyStableIdPiiField {
+  readonly path: string;
+  readonly idPath: string;
+  readonly type?:
+    | 'PERSON'
+    | 'EMAIL'
+    | 'PHONE'
+    | 'IBAN'
+    | 'CARD'
+    | 'ADDRESS'
+    | 'ORG'
+    | 'APIKEY';
+}
+
+export interface PrivacyStableIdPrepassRequest {
+  readonly sessionId: string;
+  readonly turnId: string;
+  readonly toolName: string;
+  /** The tool handler's raw text return value. The provider parses it
+   *  as JSON; non-JSON input degrades to pass-through. */
+  readonly text: string;
+  /** Tool-declared annotations. Empty array degrades to pass-through. */
+  readonly piiFields: ReadonlyArray<PrivacyStableIdPiiField>;
+}
+
+export interface PrivacyStableIdPrepassResult {
+  /** Re-serialised text with annotated leaves rewritten to stable
+   *  tokens. Equals input on parse failure / empty annotations. */
+  readonly text: string;
+  /** Number of leaf string fields actually replaced with tokens. */
+  readonly replaced: number;
+  /** Number of annotations skipped (shape mismatch or malformed path). */
+  readonly skipped: number;
+  /** `false` when the input could not be JSON-parsed; the caller may
+   *  log this for telemetry but should still forward `text` to NER. */
+  readonly parsed: boolean;
+}
+
+// ---------------------------------------------------------------------------
 // Privacy-Shield v2 (Slice S-5) — Output Validator.
 //
 // Defense-in-depth between processInbound and channel.send. The host
@@ -753,6 +808,17 @@ export interface PrivacyGuardService {
    * tool roundtrips don't fragment the user-facing summary.
    */
   processToolResult(request: PrivacyToolResultRequest): Promise<PrivacyToolResultResult>;
+  /**
+   * Privacy-Shield v3 (slice 1) — Stable-id tokenization pre-pass.
+   * Runs BEFORE `processToolResult` for tools that declare PII field
+   * annotations. Parses the text as JSON, rewrites annotated leaves
+   * via `applyStableIdTokenization`, and re-serialises. On parse
+   * failure or empty annotations: byte-identical pass-through. Hits
+   * land in the SAME turn-accumulator as the NER pass.
+   */
+  applyStableIdPrepass(
+    request: PrivacyStableIdPrepassRequest,
+  ): Promise<PrivacyStableIdPrepassResult>;
   /**
    * Privacy-Shield v2 (Slice S-5) — Output Validator. Optional host
    * hook called between `processInbound` and channel send. Computes

--- a/middleware/test/privacyStableIdTokenization.test.ts
+++ b/middleware/test/privacyStableIdTokenization.test.ts
@@ -1,0 +1,277 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { applyStableIdTokenization } from '@omadia/plugin-privacy-guard/dist/stableIdTokenization.js';
+import { createTokenizeMap } from '@omadia/plugin-privacy-guard/dist/tokenizeMap.js';
+
+// ---------------------------------------------------------------------------
+// Privacy-Shield v3 (stable-id tokenization, slice 1) — tool-aware PII
+// pre-pass. Walks a tool's structured result against operator-declared
+// `piiFields` annotations and rewrites annotated leaves into stable
+// tokens BEFORE the NER detectors run. Replaces partial-name leaks
+// ("«PERSON_5» Vomberg") with whole-field tokenization, and avoids
+// the row-doubling failure mode where the same employee yields two
+// different counter tokens within the same tool call.
+// ---------------------------------------------------------------------------
+
+describe('applyStableIdTokenization · slice 1', () => {
+  it('rewrites a top-level field by path', () => {
+    const map = createTokenizeMap();
+    const raw = { employee_id: 162, name: 'Marvin Vomberg', dept: 'Backend' };
+    const result = applyStableIdTokenization(
+      raw,
+      [{ path: 'name', idPath: 'employee_id', type: 'PERSON' }],
+      map,
+    );
+    assert.equal(result.replaced, 1);
+    assert.equal(result.skipped, 0);
+    const v = result.value as Record<string, unknown>;
+    assert.ok(typeof v.name === 'string');
+    assert.match(v.name as string, /^«PERSON_\d+»$/);
+    assert.equal(v.dept, 'Backend'); // unrelated fields untouched
+    // Restoration via the same map yields the original string.
+    assert.equal(map.resolve(v.name as string), 'Marvin Vomberg');
+  });
+
+  it('rewrites an array-spread (HR-Urlaubsranking shape)', () => {
+    const map = createTokenizeMap();
+    const raw = {
+      employees: [
+        { employee_id: 162, name: 'Marvin Vomberg', days: 17 },
+        { employee_id: 103, name: 'Dennis Zille', days: 16.69 },
+        { employee_id: 198, name: 'Sophie Neumann', days: 13 },
+      ],
+    };
+    const result = applyStableIdTokenization(
+      raw,
+      [
+        {
+          path: 'employees[].name',
+          idPath: 'employees[].employee_id',
+          type: 'PERSON',
+        },
+      ],
+      map,
+    );
+    assert.equal(result.replaced, 3);
+    assert.equal(result.skipped, 0);
+    const employees = (result.value as { employees: Array<Record<string, unknown>> })
+      .employees;
+    for (const emp of employees) {
+      assert.match(emp.name as string, /^«PERSON_\d+»$/);
+    }
+    // Numeric fields and ids stay untouched.
+    assert.equal(employees[0]?.employee_id, 162);
+    assert.equal(employees[0]?.days, 17);
+  });
+
+  it('value-dedup: the same name across rows yields the same token (slice 1)', () => {
+    // Slice 1 uses value-keyed dedup. Two rows referencing the same
+    // employee by the same string get the same token (good for the
+    // typical case). Slice 1.5 will additionally disambiguate
+    // homonyms via idPath.
+    const map = createTokenizeMap();
+    const raw = {
+      bookings: [
+        { id: 1257, name: 'Marvin Vomberg' },
+        { id: 1085, name: 'Marvin Vomberg' },
+        { id: 1077, name: 'Dennis Zille' },
+      ],
+    };
+    const result = applyStableIdTokenization(
+      raw,
+      [{ path: 'bookings[].name', idPath: 'bookings[].id', type: 'PERSON' }],
+      map,
+    );
+    assert.equal(result.replaced, 3);
+    const bookings = (result.value as { bookings: Array<Record<string, unknown>> })
+      .bookings;
+    assert.equal(bookings[0]?.name, bookings[1]?.name);
+    assert.notEqual(bookings[0]?.name, bookings[2]?.name);
+  });
+
+  it('skips leaves that are missing, null, undefined, or non-string', () => {
+    const map = createTokenizeMap();
+    const raw = {
+      items: [
+        { id: 1, name: 'Real Name' },
+        { id: 2, name: null }, // null leaf
+        { id: 3 }, // missing field
+        { id: 4, name: 42 }, // wrong type
+        { id: 5, name: '' }, // empty string
+        { id: 6, name: 'Other Name' },
+      ],
+    };
+    const result = applyStableIdTokenization(
+      raw,
+      [{ path: 'items[].name', idPath: 'items[].id', type: 'PERSON' }],
+      map,
+    );
+    // Only the two real string leaves get tokenised.
+    assert.equal(result.replaced, 2);
+    const items = (result.value as { items: Array<Record<string, unknown>> }).items;
+    assert.match(items[0]?.name as string, /^«PERSON_\d+»$/);
+    assert.equal(items[1]?.name, null);
+    assert.equal(items[2]?.name, undefined);
+    assert.equal(items[3]?.name, 42);
+    assert.equal(items[4]?.name, '');
+    assert.match(items[5]?.name as string, /^«PERSON_\d+»$/);
+  });
+
+  it('skips the annotation entirely when path/idPath shapes disagree', () => {
+    const map = createTokenizeMap();
+    const raw = {
+      employees: [{ employee_id: 1, name: 'Anna' }],
+      meta: { batch_id: 42 },
+    };
+    // path goes through one `[]`, idPath through none — must reject.
+    const result = applyStableIdTokenization(
+      raw,
+      [{ path: 'employees[].name', idPath: 'meta.batch_id', type: 'PERSON' }],
+      map,
+    );
+    assert.equal(result.replaced, 0);
+    assert.equal(result.skipped, 1);
+    // The data is unchanged on shape-mismatch.
+    const employees = (result.value as { employees: Array<Record<string, unknown>> })
+      .employees;
+    assert.equal(employees[0]?.name, 'Anna');
+  });
+
+  it('skips when parallel arrays have different lengths', () => {
+    const map = createTokenizeMap();
+    // Build a shape where `employees[]` resolves to 3 leaves but
+    // `partners[]` resolves to 2 — the walker cannot zip them.
+    const raw = {
+      employees: [
+        { name: 'Anna' },
+        { name: 'Beate' },
+        { name: 'Clara' },
+      ],
+      partners: [{ id: 1 }, { id: 2 }],
+    };
+    const result = applyStableIdTokenization(
+      raw,
+      [{ path: 'employees[].name', idPath: 'partners[].id', type: 'PERSON' }],
+      map,
+    );
+    assert.equal(result.replaced, 0);
+    assert.equal(result.skipped, 1);
+  });
+
+  it('returns the input untouched when annotations are empty', () => {
+    const map = createTokenizeMap();
+    const raw = { name: 'Alice' };
+    const result = applyStableIdTokenization(raw, [], map);
+    assert.equal(result.replaced, 0);
+    assert.equal(result.skipped, 0);
+    assert.strictEqual(result.value, raw); // same reference — no clone
+  });
+
+  it('returns input untouched when raw is not a plain object', () => {
+    const map = createTokenizeMap();
+    const result = applyStableIdTokenization(
+      'just a string',
+      [{ path: 'name', idPath: 'id', type: 'PERSON' }],
+      map,
+    );
+    assert.equal(result.replaced, 0);
+    assert.equal(result.skipped, 0);
+    assert.equal(result.value, 'just a string');
+  });
+
+  it('does not mutate the caller-supplied object', () => {
+    const map = createTokenizeMap();
+    const raw = {
+      employees: [{ employee_id: 162, name: 'Marvin Vomberg' }],
+    };
+    const before = JSON.stringify(raw);
+    applyStableIdTokenization(
+      raw,
+      [
+        {
+          path: 'employees[].name',
+          idPath: 'employees[].employee_id',
+          type: 'PERSON',
+        },
+      ],
+      map,
+    );
+    assert.equal(JSON.stringify(raw), before);
+  });
+
+  it('defaults type to PERSON when omitted', () => {
+    const map = createTokenizeMap();
+    const raw = { name: 'Anna Müller', id: 1 };
+    const result = applyStableIdTokenization(
+      raw,
+      [{ path: 'name', idPath: 'id' }],
+      map,
+    );
+    assert.equal(result.replaced, 1);
+    const v = result.value as Record<string, unknown>;
+    assert.match(v.name as string, /^«PERSON_\d+»$/);
+  });
+
+  it('handles non-PERSON types (EMAIL)', () => {
+    const map = createTokenizeMap();
+    const raw = { user_id: 7, email: 'anna@example.com' };
+    const result = applyStableIdTokenization(
+      raw,
+      [{ path: 'email', idPath: 'user_id', type: 'EMAIL' }],
+      map,
+    );
+    assert.equal(result.replaced, 1);
+    const v = result.value as Record<string, unknown>;
+    assert.match(v.email as string, /^«EMAIL_\d+»$/);
+    assert.equal(map.resolve(v.email as string), 'anna@example.com');
+  });
+
+  it('walks nested objects (user.name shape)', () => {
+    const map = createTokenizeMap();
+    const raw = { record: { user: { name: 'Jane Doe', age: 30 } } };
+    const result = applyStableIdTokenization(
+      raw,
+      [{ path: 'record.user.name', idPath: 'record.user.age', type: 'PERSON' }],
+      map,
+    );
+    assert.equal(result.replaced, 1);
+    const name = (result.value as { record: { user: { name: string } } }).record.user
+      .name;
+    assert.match(name, /^«PERSON_\d+»$/);
+  });
+
+  it('applies multiple annotations independently', () => {
+    const map = createTokenizeMap();
+    const raw = {
+      employees: [{ id: 1, name: 'Anna', email: 'anna@x.de' }],
+    };
+    const result = applyStableIdTokenization(
+      raw,
+      [
+        { path: 'employees[].name', idPath: 'employees[].id', type: 'PERSON' },
+        { path: 'employees[].email', idPath: 'employees[].id', type: 'EMAIL' },
+      ],
+      map,
+    );
+    assert.equal(result.replaced, 2);
+    const emp = (result.value as { employees: Array<Record<string, unknown>> })
+      .employees[0]!;
+    assert.match(emp.name as string, /^«PERSON_\d+»$/);
+    assert.match(emp.email as string, /^«EMAIL_\d+»$/);
+  });
+
+  it('silently skips on missing intermediate segments', () => {
+    const map = createTokenizeMap();
+    const raw = { other: { unrelated: true } };
+    const result = applyStableIdTokenization(
+      raw,
+      [{ path: 'missing[].name', idPath: 'missing[].id', type: 'PERSON' }],
+      map,
+    );
+    assert.equal(result.replaced, 0);
+    // Zero leaves found on either side, lengths match (both 0), so
+    // not counted as a shape-mismatch — annotation no-ops.
+    assert.equal(result.skipped, 0);
+  });
+});

--- a/middleware/test/privacyStableIdTokenization.test.ts
+++ b/middleware/test/privacyStableIdTokenization.test.ts
@@ -1,6 +1,10 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
+import {
+  odooMany2OnePiiField,
+  odooSearchReadPiiFields,
+} from '@omadia/plugin-api';
 import { applyStableIdTokenization } from '@omadia/plugin-privacy-guard/dist/stableIdTokenization.js';
 import { createTokenizeMap } from '@omadia/plugin-privacy-guard/dist/tokenizeMap.js';
 
@@ -273,5 +277,226 @@ describe('applyStableIdTokenization · slice 1', () => {
     // Zero leaves found on either side, lengths match (both 0), so
     // not counted as a shape-mismatch — annotation no-ops.
     assert.equal(result.skipped, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slice 2 — extended path grammar: top-level arrays + array indices.
+// Odoo `search_read` returns a top-level array whose many2one fields
+// are `[id, label]` tuples — neither shape was walkable in slice 1.
+// ---------------------------------------------------------------------------
+
+describe('applyStableIdTokenization · slice 2 — top-level arrays', () => {
+  it('rewrites a field on a top-level array of objects', () => {
+    const map = createTokenizeMap();
+    const raw = [
+      { id: 1, name: 'Anna Müller' },
+      { id: 2, name: 'Bossity Schmidt' },
+    ];
+    const result = applyStableIdTokenization(
+      raw,
+      [{ path: '[].name', idPath: '[].id', type: 'PERSON' }],
+      map,
+    );
+    assert.equal(result.replaced, 2);
+    assert.equal(result.skipped, 0);
+    const rows = result.value as Array<Record<string, unknown>>;
+    assert.match(rows[0]?.name as string, /^«PERSON_\d+»$/);
+    assert.match(rows[1]?.name as string, /^«PERSON_\d+»$/);
+    assert.equal(map.resolve(rows[0]?.name as string), 'Anna Müller');
+  });
+
+  it('rewrites an array-of-leaf-strings via a trailing spread', () => {
+    const map = createTokenizeMap();
+    const raw = { emails: ['a@x.de', 'b@y.de'] };
+    const result = applyStableIdTokenization(
+      raw,
+      [{ path: 'emails[]', idPath: 'emails[]', type: 'EMAIL' }],
+      map,
+    );
+    assert.equal(result.replaced, 2);
+    const emails = (result.value as { emails: string[] }).emails;
+    assert.match(emails[0] as string, /^«EMAIL_\d+»$/);
+    assert.match(emails[1] as string, /^«EMAIL_\d+»$/);
+  });
+});
+
+describe('applyStableIdTokenization · slice 2 — array indices (Odoo many2one)', () => {
+  // The exact shape from the live HR-Urlaubsranking trace: Odoo
+  // `hr.leave` search_read, where `employee_id` is a `[id, name]`
+  // many2one tuple and `holiday_status_id` is a `[id, label]` tuple.
+  const hrLeaveRows = (): unknown => [
+    {
+      id: 1257,
+      employee_id: [116, 'Jonathan Rüsche'],
+      holiday_status_id: [1, 'Paid Time Off'],
+      number_of_days: 1,
+    },
+    {
+      id: 1085,
+      employee_id: [162, 'Marvin Vomberg'],
+      holiday_status_id: [1, 'Paid Time Off'],
+      number_of_days: 1,
+    },
+    {
+      id: 1192,
+      employee_id: [190, 'Phillip Kalusek'],
+      holiday_status_id: [1, 'Paid Time Off'],
+      number_of_days: 0.5,
+    },
+  ];
+
+  it('tokenises the label half of a many2one tuple, keeps the id', () => {
+    const map = createTokenizeMap();
+    const result = applyStableIdTokenization(
+      hrLeaveRows(),
+      [
+        {
+          path: '[].employee_id[1]',
+          idPath: '[].employee_id[0]',
+          type: 'PERSON',
+        },
+      ],
+      map,
+    );
+    assert.equal(result.replaced, 3);
+    assert.equal(result.skipped, 0);
+    const rows = result.value as Array<Record<string, unknown>>;
+    for (const row of rows) {
+      const m2o = row.employee_id as unknown[];
+      assert.equal(typeof m2o[0], 'number'); // id untouched
+      assert.match(m2o[1] as string, /^«PERSON_\d+»$/); // label tokenised
+    }
+    // Restoration yields the original names.
+    const firstLabel = (rows[0]?.employee_id as unknown[])[1] as string;
+    assert.equal(map.resolve(firstLabel), 'Jonathan Rüsche');
+  });
+
+  it('handles an empty many2one relation (Odoo emits `false`)', () => {
+    const map = createTokenizeMap();
+    const raw = [
+      { id: 1, employee_id: [116, 'Jonathan Rüsche'] },
+      { id: 2, employee_id: false }, // unassigned relation
+      { id: 3, employee_id: [190, 'Phillip Kalusek'] },
+    ];
+    const result = applyStableIdTokenization(
+      raw,
+      [{ path: '[].employee_id[1]', idPath: '[].employee_id[0]', type: 'PERSON' }],
+      map,
+    );
+    // The `false` row contributes no leaf to either path — counts
+    // stay aligned, the two real rows tokenise.
+    assert.equal(result.replaced, 2);
+    assert.equal(result.skipped, 0);
+    const rows = result.value as Array<Record<string, unknown>>;
+    assert.equal(rows[1]?.employee_id, false);
+  });
+
+  it('tokenises two many2one fields independently in one pass', () => {
+    const map = createTokenizeMap();
+    const result = applyStableIdTokenization(
+      hrLeaveRows(),
+      [
+        { path: '[].employee_id[1]', idPath: '[].employee_id[0]', type: 'PERSON' },
+        {
+          path: '[].holiday_status_id[1]',
+          idPath: '[].holiday_status_id[0]',
+          type: 'ORG',
+        },
+      ],
+      map,
+    );
+    assert.equal(result.replaced, 6); // 3 people + 3 status labels
+    const rows = result.value as Array<Record<string, unknown>>;
+    assert.match((rows[0]?.employee_id as unknown[])[1] as string, /^«PERSON_\d+»$/);
+    assert.match(
+      (rows[0]?.holiday_status_id as unknown[])[1] as string,
+      /^«ORG_\d+»$/,
+    );
+  });
+
+  it('skips the annotation on a malformed many2one (missing label)', () => {
+    const map = createTokenizeMap();
+    const raw = [
+      { id: 1, employee_id: [116, 'Jonathan Rüsche'] },
+      { id: 2, employee_id: [162] }, // malformed — no label slot
+    ];
+    const result = applyStableIdTokenization(
+      raw,
+      [{ path: '[].employee_id[1]', idPath: '[].employee_id[0]', type: 'PERSON' }],
+      map,
+    );
+    // path[1] resolves 1 leaf (row 1 only), idPath[0] resolves 2 —
+    // counts disagree, conservative skip of the whole annotation.
+    assert.equal(result.replaced, 0);
+    assert.equal(result.skipped, 1);
+  });
+
+  it('rejects malformed path strings (unclosed bracket, [foo], double dot)', () => {
+    const map = createTokenizeMap();
+    const raw = [{ employee_id: [1, 'Anna'] }];
+    for (const bad of ['[].employee_id[1', '[].employee_id[foo]', '[]..name']) {
+      const result = applyStableIdTokenization(
+        raw,
+        [{ path: bad, idPath: '[].employee_id[0]', type: 'PERSON' }],
+        map,
+      );
+      assert.equal(result.replaced, 0, `path '${bad}' must not tokenise`);
+      assert.equal(result.skipped, 1, `path '${bad}' must be skipped`);
+    }
+  });
+});
+
+describe('odooMany2OnePiiField / odooSearchReadPiiFields helpers', () => {
+  it('odooMany2OnePiiField builds the [1]/[0] index paths', () => {
+    const field = odooMany2OnePiiField('employee_id');
+    assert.equal(field.path, '[].employee_id[1]');
+    assert.equal(field.idPath, '[].employee_id[0]');
+    assert.equal(field.type, undefined); // defaults to PERSON downstream
+  });
+
+  it('odooMany2OnePiiField honours type and recordsAt envelope', () => {
+    const field = odooMany2OnePiiField('partner_id', {
+      type: 'ORG',
+      recordsAt: 'records',
+    });
+    assert.equal(field.path, 'records[].partner_id[1]');
+    assert.equal(field.idPath, 'records[].partner_id[0]');
+    assert.equal(field.type, 'ORG');
+  });
+
+  it('odooSearchReadPiiFields expands a field map', () => {
+    const fields = odooSearchReadPiiFields({
+      employee_id: 'PERSON',
+      user_id: 'PERSON',
+    });
+    assert.equal(fields.length, 2);
+    assert.deepEqual(fields[0], {
+      path: '[].employee_id[1]',
+      idPath: '[].employee_id[0]',
+      type: 'PERSON',
+    });
+  });
+
+  it('end-to-end: helper output tokenises the live hr.leave shape', () => {
+    const map = createTokenizeMap();
+    const raw = [
+      { id: 1257, employee_id: [116, 'Jonathan Rüsche'] },
+      { id: 1249, employee_id: [103, 'Dennis Zille'] },
+      { id: 1253, employee_id: [198, 'Sophie Neumann'] },
+    ];
+    const result = applyStableIdTokenization(
+      raw,
+      odooSearchReadPiiFields({ employee_id: 'PERSON' }),
+      map,
+    );
+    assert.equal(result.replaced, 3);
+    assert.equal(result.skipped, 0);
+    const rows = result.value as Array<Record<string, unknown>>;
+    // No partial-name leak: the WHOLE name "Jonathan Rüsche" is one
+    // token, not "«PERSON_N» Rüsche".
+    const label = (rows[0]?.employee_id as unknown[])[1] as string;
+    assert.match(label, /^«PERSON_\d+»$/);
+    assert.equal(map.resolve(label), 'Jonathan Rüsche');
   });
 });

--- a/middleware/test/privacyStableIdTokenization.test.ts
+++ b/middleware/test/privacyStableIdTokenization.test.ts
@@ -69,29 +69,65 @@ describe('applyStableIdTokenization · slice 1', () => {
     assert.equal(employees[0]?.days, 17);
   });
 
-  it('value-dedup: the same name across rows yields the same token (slice 1)', () => {
-    // Slice 1 uses value-keyed dedup. Two rows referencing the same
-    // employee by the same string get the same token (good for the
-    // typical case). Slice 1.5 will additionally disambiguate
-    // homonyms via idPath.
+  it('keys tokens by entity id: same employee across rows yields one token', () => {
+    // Slice 1.5 — dedup is keyed by the id at `idPath`, not the value.
+    // Two leave bookings by the SAME employee (employee_id 162) get
+    // the SAME token even though their booking ids differ.
     const map = createTokenizeMap();
     const raw = {
       bookings: [
-        { id: 1257, name: 'Marvin Vomberg' },
-        { id: 1085, name: 'Marvin Vomberg' },
-        { id: 1077, name: 'Dennis Zille' },
+        { booking_id: 1257, employee_id: 162, name: 'Marvin Vomberg' },
+        { booking_id: 1085, employee_id: 162, name: 'Marvin Vomberg' },
+        { booking_id: 1077, employee_id: 103, name: 'Dennis Zille' },
       ],
     };
     const result = applyStableIdTokenization(
       raw,
-      [{ path: 'bookings[].name', idPath: 'bookings[].id', type: 'PERSON' }],
+      [
+        {
+          path: 'bookings[].name',
+          idPath: 'bookings[].employee_id',
+          type: 'PERSON',
+        },
+      ],
       map,
     );
     assert.equal(result.replaced, 3);
     const bookings = (result.value as { bookings: Array<Record<string, unknown>> })
       .bookings;
-    assert.equal(bookings[0]?.name, bookings[1]?.name);
-    assert.notEqual(bookings[0]?.name, bookings[2]?.name);
+    assert.equal(bookings[0]?.name, bookings[1]?.name); // same employee id
+    assert.notEqual(bookings[0]?.name, bookings[2]?.name); // different employee
+  });
+
+  it('disambiguates homonyms: same name + different id yields distinct tokens', () => {
+    // The exact failure the slice-1 value-dedup would have caused in a
+    // ranking: two genuinely different employees who share a name.
+    const map = createTokenizeMap();
+    const raw = {
+      employees: [
+        { employee_id: 12, name: 'Thomas Müller' },
+        { employee_id: 88, name: 'Thomas Müller' },
+      ],
+    };
+    const result = applyStableIdTokenization(
+      raw,
+      [
+        {
+          path: 'employees[].name',
+          idPath: 'employees[].employee_id',
+          type: 'PERSON',
+        },
+      ],
+      map,
+    );
+    assert.equal(result.replaced, 2);
+    const employees = (result.value as { employees: Array<Record<string, unknown>> })
+      .employees;
+    // Distinct ids → distinct tokens, even though the name is identical.
+    assert.notEqual(employees[0]?.name, employees[1]?.name);
+    // Both tokens still resolve to the real name.
+    assert.equal(map.resolve(employees[0]?.name as string), 'Thomas Müller');
+    assert.equal(map.resolve(employees[1]?.name as string), 'Thomas Müller');
   });
 
   it('skips leaves that are missing, null, undefined, or non-string', () => {


### PR DESCRIPTION
## Summary

Tool-aware PII tokenization that runs BEFORE the NER detectors. Tools annotated with `piiFields` get whole-field, identity-stable tokens; NER stays as defense-in-depth for unannotated free-text.

Fixes the live HR-routine failure modes (2026-05-18):
- `«PERSON_53» Vomberg` partial-name leaks (Presidio catches only the first name)
- Row doubling (same employee → different counter tokens across rows)
- `Goerres (2. Person)` style invented labels

This PR carries the **complete public-repo solution** across 4 slices.

## Slice 1 — infrastructure
- `ToolPIIField { path, idPath, type? }` in `@omadia/plugin-api`; optional `piiFields` slot on `LocalSubAgentTool` + `DomainTool` (on the wrapper, not the spec — Anthropic rejects unknown spec fields)
- `applyStableIdTokenization` JSON-walker + `applyStableIdPrepass` service method
- Wired into `Orchestrator.dispatchTool` + `LocalSubAgent.dispatch`, BETWEEN `captureRawToolResult` and `processToolResult`

## Slice 2 — path grammar for real Odoo shapes
- Path segments are now `key | spread | index`
- `[]` may lead a path → **top-level array** support (Odoo `search_read` returns `[{…}]`)
- `[N]` → **array index** access, walks Odoo many2one `[id, label]` tuples
- Malformed paths + empty many2one relations (`false`) handled defensively

## Slice 3 — Odoo annotation helpers
- `odooMany2OnePiiField()` / `odooSearchReadPiiFields()` in `@omadia/plugin-api`
- A private Odoo tool annotates with a one-liner: `piiFields: odooSearchReadPiiFields({ employee_id: 'PERSON' })`

## Slice 1.5 — id-keyed tokens (homonyms)
- `TokenizeMap.tokenForStableId()` keys dedup by `(type, stableId)` instead of by value
- Same entity → one token across all rows; two employees who share a name ("Thomas Müller" id 12 vs 88) → **distinct tokens**, so a ranking never silently merges their rows
- The id never crosses the wire — tokens stay `«TYPE_N»` with a map-local counter

## Test plan
- [x] 26 stable-id unit tests (top-level arrays, many2one tuples, empty relations, malformed paths, homonym disambiguation, helper output, live `hr.leave` shape)
- [x] Workspace lint + typecheck clean
- [x] Privacy regression + HR integration: 163/163 pass (3 pre-existing skips)
- [ ] Final step outside this repo: one-line `piiFields:` annotation on the private `odoo_execute` tool (`query_odoo_hr` returns prose, not JSON — `odoo_execute` is the JSON-returning target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)