### PR TITLE
chore(deps): migrate zod 3 → 4 across all middleware workspaces

### DIFF
--- a/middleware/assets/boilerplate/agent-integration/package.json
+++ b/middleware/assets/boilerplate/agent-integration/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "description": "{{AGENT_DESCRIPTION_DE}}",
   "peerDependencies": {
-    "zod": "^3.23.8",
+    "zod": "^4.0.0",
     "express": "^5.1.0",
     "@omadia/plugin-ui-helpers": "*"
   },

--- a/middleware/assets/boilerplate/agent-pure-llm/package.json
+++ b/middleware/assets/boilerplate/agent-pure-llm/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "description": "{{AGENT_DESCRIPTION_DE}}",
   "peerDependencies": {
-    "zod": "^3.23.8"
+    "zod": "^4.0.0"
   },
   "engines": {
     "node": ">=20"

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -40,7 +40,7 @@
         "yaml": "^2.6.1",
         "yauzl": "^3.3.0",
         "yazl": "^3.3.1",
-        "zod": "^3.23.8"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -3488,6 +3488,15 @@
         "zod": "^3.23.8"
       }
     },
+    "node_modules/botbuilder-core/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/botbuilder-dialogs-adaptive-runtime-core": {
       "version": "4.23.3-preview",
       "license": "MIT",
@@ -3505,6 +3514,15 @@
         "@azure/core-http-compat": "^2.1.2",
         "@azure/core-rest-pipeline": "^1.18.1",
         "@azure/core-tracing": "^1.2.0"
+      }
+    },
+    "node_modules/botbuilder/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/botframework-connector": {
@@ -3529,6 +3547,15 @@
         "zod": "^3.23.8"
       }
     },
+    "node_modules/botframework-connector/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/botframework-schema": {
       "version": "4.23.3",
       "license": "MIT",
@@ -3536,6 +3563,15 @@
         "adaptivecards": "1.2.3",
         "uuid": "^10.0.0",
         "zod": "^3.23.8"
+      }
+    },
+    "node_modules/botframework-schema/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/botframework-streaming": {
@@ -6642,7 +6678,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -6659,7 +6697,7 @@
         "@omadia/plugin-api": "*",
         "@omadia/plugin-ui-helpers": "*",
         "express": "^5.1.0",
-        "zod": "^3.23.8"
+        "zod": "^4.0.0"
       }
     },
     "packages/agent-seo-analyst": {
@@ -6671,7 +6709,7 @@
       },
       "peerDependencies": {
         "@omadia/plugin-api": "*",
-        "zod": "^3.23.8"
+        "zod": "^4.0.0"
       }
     },
     "packages/harness-channel-sdk": {
@@ -6734,7 +6772,7 @@
       "peerDependencies": {
         "@omadia/plugin-api": "*",
         "express": "^5.1.0",
-        "zod": "^3.23.8"
+        "zod": "^4.0.0"
       }
     },
     "packages/harness-embeddings": {
@@ -6812,7 +6850,7 @@
         "@omadia/embeddings": "*",
         "@omadia/plugin-api": "*",
         "pg": "^8.13.0",
-        "zod": "^3.23.8"
+        "zod": "^4.0.0"
       }
     },
     "packages/harness-memory": {
@@ -6842,7 +6880,7 @@
         "@omadia/orchestrator-extras": "*",
         "@omadia/plugin-api": "*",
         "@omadia/verifier": "*",
-        "zod": "*"
+        "zod": "^4.0.0"
       }
     },
     "packages/harness-orchestrator-extras": {
@@ -6868,7 +6906,7 @@
       "peerDependencies": {
         "@omadia/plugin-api": "*",
         "undici": "^7.25.0",
-        "zod": "^3.23.8"
+        "zod": "^4.0.0"
       }
     },
     "packages/harness-plugin-privacy-detector-presidio": {
@@ -6903,7 +6941,7 @@
       },
       "peerDependencies": {
         "@omadia/plugin-api": "*",
-        "zod": "^3.23.8"
+        "zod": "^4.0.0"
       }
     },
     "packages/harness-plugin-web-search": {
@@ -6915,7 +6953,7 @@
       },
       "peerDependencies": {
         "@omadia/plugin-api": "*",
-        "zod": "^3.23.8"
+        "zod": "^4.0.0"
       }
     },
     "packages/harness-ui-helpers": {
@@ -6957,7 +6995,7 @@
         "@anthropic-ai/sdk": "*",
         "@omadia/plugin-api": "*",
         "pg": "^8.13.0",
-        "zod": "*"
+        "zod": "^4.0.0"
       }
     },
     "packages/plugin-api": {

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -62,7 +62,7 @@
     "yaml": "^2.6.1",
     "yauzl": "^3.3.0",
     "yazl": "^3.3.1",
-    "zod": "^3.23.8"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/middleware/packages/agent-reference-maximum/package.json
+++ b/middleware/packages/agent-reference-maximum/package.json
@@ -14,7 +14,7 @@
     "@omadia/plugin-api": "*",
     "@omadia/plugin-ui-helpers": "*",
     "express": "^5.1.0",
-    "zod": "^3.23.8"
+    "zod": "^4.0.0"
   },
   "engines": {
     "node": ">=20"

--- a/middleware/packages/agent-seo-analyst/package.json
+++ b/middleware/packages/agent-seo-analyst/package.json
@@ -12,7 +12,7 @@
   },
   "peerDependencies": {
     "@omadia/plugin-api": "*",
-    "zod": "^3.23.8"
+    "zod": "^4.0.0"
   },
   "engines": {
     "node": ">=20"

--- a/middleware/packages/harness-diagrams/package.json
+++ b/middleware/packages/harness-diagrams/package.json
@@ -17,7 +17,7 @@
   "peerDependencies": {
     "@omadia/plugin-api": "*",
     "express": "^5.1.0",
-    "zod": "^3.23.8"
+    "zod": "^4.0.0"
   },
   "engines": {
     "node": ">=20"

--- a/middleware/packages/harness-knowledge-graph-neon/package.json
+++ b/middleware/packages/harness-knowledge-graph-neon/package.json
@@ -14,7 +14,7 @@
   "peerDependencies": {
     "@omadia/embeddings": "*",
     "@omadia/plugin-api": "*",
-    "zod": "^3.23.8",
+    "zod": "^4.0.0",
     "pg": "^8.13.0"
   },
   "engines": {

--- a/middleware/packages/harness-orchestrator/package.json
+++ b/middleware/packages/harness-orchestrator/package.json
@@ -19,7 +19,7 @@
     "@omadia/orchestrator-extras": "*",
     "@omadia/plugin-api": "*",
     "@omadia/verifier": "*",
-    "zod": "*"
+    "zod": "^4.0.0"
   },
   "engines": {
     "node": ">=20"

--- a/middleware/packages/harness-plugin-privacy-detector-ollama/package.json
+++ b/middleware/packages/harness-plugin-privacy-detector-ollama/package.json
@@ -14,7 +14,7 @@
   "peerDependencies": {
     "@omadia/plugin-api": "*",
     "undici": "^7.25.0",
-    "zod": "^3.23.8"
+    "zod": "^4.0.0"
   },
   "engines": {
     "node": ">=20"

--- a/middleware/packages/harness-plugin-quality-guard/package.json
+++ b/middleware/packages/harness-plugin-quality-guard/package.json
@@ -13,7 +13,7 @@
   },
   "peerDependencies": {
     "@omadia/plugin-api": "*",
-    "zod": "^3.23.8"
+    "zod": "^4.0.0"
   },
   "engines": {
     "node": ">=20"

--- a/middleware/packages/harness-plugin-web-search/package.json
+++ b/middleware/packages/harness-plugin-web-search/package.json
@@ -13,7 +13,7 @@
   },
   "peerDependencies": {
     "@omadia/plugin-api": "*",
-    "zod": "^3.23.8"
+    "zod": "^4.0.0"
   },
   "engines": {
     "node": ">=20"

--- a/middleware/packages/harness-verifier/package.json
+++ b/middleware/packages/harness-verifier/package.json
@@ -14,7 +14,7 @@
   "peerDependencies": {
     "@anthropic-ai/sdk": "*",
     "@omadia/plugin-api": "*",
-    "zod": "*",
+    "zod": "^4.0.0",
     "pg": "^8.13.0"
   },
   "engines": {

--- a/middleware/src/config.ts
+++ b/middleware/src/config.ts
@@ -93,7 +93,7 @@ const ConfigSchema = z.object({
   DEV_ENDPOINTS_ENABLED: z
     .enum(['true', 'false'])
     .transform((v) => v === 'true')
-    .default('false'),
+    .default(false),
 
   // Postgres connection string for the Neon-backed knowledge graph.
   // When set, `bootstrapKnowledgeGraphFromEnv` installs the
@@ -163,7 +163,7 @@ const ConfigSchema = z.object({
   ODOO_INSECURE_TLS: z
     .enum(['true', 'false'])
     .transform((v) => v === 'true')
-    .default('false'),
+    .default(false),
 
   // Diagram rendering (Kroki + Tigris/MinIO). When all required fields are
   // present, the orchestrator exposes `render_diagram` and the middleware
@@ -194,7 +194,7 @@ const ConfigSchema = z.object({
   VAULT_BACKUP_ENABLED: z
     .enum(['true', 'false'])
     .transform((v) => v === 'true')
-    .default('false'),
+    .default(false),
   VAULT_BACKUP_PREFIX: z.string().min(1).default('backups/vault/'),
   VAULT_BACKUP_RETENTION: z.coerce.number().int().min(1).max(365).default(30),
   VAULT_BACKUP_INTERVAL_HOURS: z.coerce.number().min(1).max(168).default(24),
@@ -216,7 +216,7 @@ const ConfigSchema = z.object({
   ODOO_ENTITY_SYNC_ENABLED: z
     .enum(['true', 'false'])
     .transform((v) => v === 'true')
-    .default('false'),
+    .default(false),
   ODOO_ENTITY_SYNC_INTERVAL_HOURS: z.coerce.number().min(1).max(168).default(6),
   ODOO_ENTITY_SYNC_PAGE_SIZE: z.coerce.number().int().positive().default(100),
   ODOO_ENTITY_SYNC_MAX_PER_MODEL: z.coerce.number().int().positive().default(5000),
@@ -225,7 +225,7 @@ const ConfigSchema = z.object({
   CONFLUENCE_ENTITY_SYNC_ENABLED: z
     .enum(['true', 'false'])
     .transform((v) => v === 'true')
-    .default('false'),
+    .default(false),
   CONFLUENCE_ENTITY_SYNC_INTERVAL_HOURS: z.coerce.number().min(1).max(168).default(12),
   CONFLUENCE_ENTITY_SYNC_PAGE_SIZE: z.coerce.number().int().positive().default(50),
   CONFLUENCE_ENTITY_SYNC_MAX_PAGES: z.coerce.number().int().positive().default(2000),
@@ -238,7 +238,7 @@ const ConfigSchema = z.object({
   GRAPH_EMBEDDING_BACKFILL_ENABLED: z
     .enum(['true', 'false'])
     .transform((v) => v === 'true')
-    .default('true'),
+    .default(true),
   GRAPH_EMBEDDING_BACKFILL_INTERVAL_MINUTES: z.coerce.number().min(1).max(360).default(5),
   GRAPH_EMBEDDING_BACKFILL_BATCH_SIZE: z.coerce.number().int().positive().max(200).default(20),
   GRAPH_EMBEDDING_BACKFILL_MAX_ATTEMPTS: z.coerce.number().int().positive().max(50).default(5),
@@ -256,7 +256,7 @@ const ConfigSchema = z.object({
   NORTHDATA_ENABLED: z
     .enum(['true', 'false'])
     .transform((v) => v === 'true')
-    .default('false'),
+    .default(false),
   NORTHDATA_API_KEY: z.string().optional(),
   NORTHDATA_BASE_URL: z.string().url().default('https://www.northdata.com/_api'),
   NORTHDATA_RATE_LIMIT_RPS: z.coerce.number().positive().default(2),
@@ -266,7 +266,7 @@ const ConfigSchema = z.object({
   NORTHDATA_WATCHLIST_ENABLED: z
     .enum(['true', 'false'])
     .transform((v) => v === 'true')
-    .default('false'),
+    .default(false),
   NORTHDATA_WATCHLIST_INTERVAL_HOURS: z.coerce.number().min(1).max(168).default(24),
 
   // OpenRegister (https://openregister.de) — active enrichment provider. When
@@ -277,7 +277,7 @@ const ConfigSchema = z.object({
   OPENREGISTER_ENABLED: z
     .enum(['true', 'false'])
     .transform((v) => v === 'true')
-    .default('false'),
+    .default(false),
   OPENREGISTER_API_KEY: z.string().optional(),
   OPENREGISTER_BASE_URL: z.string().url().default('https://api.openregister.de'),
   OPENREGISTER_RATE_LIMIT_RPS: z.coerce.number().positive().default(2),
@@ -301,7 +301,7 @@ const ConfigSchema = z.object({
   TEAMS_ATTACHMENT_STORAGE_ENABLED: z
     .enum(['true', 'false'])
     .transform((v) => v === 'true')
-    .default('false'),
+    .default(false),
   TEAMS_ATTACHMENT_KEY_PREFIX: z.string().min(1).default('teams-attachments'),
   /** Per-file cap. Larger uploads are logged + skipped. */
   TEAMS_ATTACHMENT_MAX_BYTES: z.coerce.number().int().positive().default(25_000_000),
@@ -333,7 +333,7 @@ const ConfigSchema = z.object({
   VERIFIER_ENABLED: z
     .enum(['true', 'false'])
     .transform((v) => v === 'true')
-    .default('false'),
+    .default(false),
   VERIFIER_MODE: z.enum(['shadow', 'enforce']).default('shadow'),
   VERIFIER_MODEL: z.string().min(1).default('claude-haiku-4-5-20251001'),
   VERIFIER_MAX_CLAIMS: z.coerce.number().int().positive().default(20),
@@ -347,7 +347,7 @@ const ConfigSchema = z.object({
   PACKAGE_UPLOAD_ENABLED: z
     .enum(['true', 'false'])
     .transform((v) => v === 'true')
-    .default('true'),
+    .default(true),
   UPLOADED_PACKAGES_DIR: z.string().min(1).default('./.uploaded-packages'),
   PACKAGE_UPLOAD_MAX_BYTES: z.coerce.number().int().positive().default(15 * 1024 * 1024),
   PACKAGE_UPLOAD_MAX_EXTRACTED_BYTES: z.coerce.number().int().positive().default(80 * 1024 * 1024),

--- a/middleware/src/plugins/builder/agentSpec.ts
+++ b/middleware/src/plugins/builder/agentSpec.ts
@@ -571,7 +571,7 @@ export function parseAgentSpec(input: unknown): AgentSpec {
  */
 export function safeParseAgentSpec(
   input: unknown,
-): z.SafeParseReturnType<unknown, AgentSpec> {
+): ReturnType<typeof AgentSpecSchema.safeParse> {
   return AgentSpecSchema.safeParse(migrateMissingDomain(input));
 }
 

--- a/middleware/src/plugins/builder/tools/lintSpec.ts
+++ b/middleware/src/plugins/builder/tools/lintSpec.ts
@@ -55,7 +55,7 @@ export const lintSpecTool: BuilderTool<Input, Result> = {
     // 1. Zod validation
     const parsed = safeParseAgentSpec(draft.spec);
     if (!parsed.success) {
-      for (const zerr of parsed.error.errors) {
+      for (const zerr of parsed.error.issues) {
         issues.push({
           severity: 'error',
           code: `zod.${zerr.code}`,

--- a/middleware/src/plugins/builder/tools/patchSpec.ts
+++ b/middleware/src/plugins/builder/tools/patchSpec.ts
@@ -145,10 +145,13 @@ export const patchSpecTool: BuilderTool<Input, Result> = {
 };
 
 function formatZodErrors(
-  issues: ReadonlyArray<{ path: ReadonlyArray<string | number>; message: string }>,
+  issues: ReadonlyArray<{ path: ReadonlyArray<PropertyKey>; message: string }>,
 ): string {
   return issues
     .slice(0, 5)
-    .map((i) => `${i.path.length > 0 ? `/${i.path.join('/')}` : '/'}: ${i.message}`)
+    .map(
+      (i) =>
+        `${i.path.length > 0 ? `/${i.path.map(String).join('/')}` : '/'}: ${i.message}`,
+    )
     .join('; ');
 }

--- a/middleware/test/builder/codegen.test.ts
+++ b/middleware/test/builder/codegen.test.ts
@@ -549,7 +549,7 @@ describe('codegen.generate', () => {
     // tsc time (codegen-emitted UiRouter imports them). Plugins WITHOUT
     // ui_routes carry them in peerDeps but never import them at runtime.
     assert.deepEqual(pkgJson.peerDependencies, {
-      zod: '^3.23.8',
+      zod: '^4.0.0',
       express: '^5.1.0',
       '@omadia/plugin-ui-helpers': '*',
     });
@@ -608,7 +608,7 @@ describe('codegen.generate', () => {
       pkgJson.peerDependencies?.['@omadia/integration-odoo'],
       '*',
     );
-    assert.equal(pkgJson.peerDependencies?.['zod'], '^3.23.8');
+    assert.equal(pkgJson.peerDependencies?.['zod'], '^4.0.0');
   });
 
   it('emits one service-lookup block when two external_reads share a service', async () => {

--- a/middleware/test/manageRoutineTool.test.ts
+++ b/middleware/test/manageRoutineTool.test.ts
@@ -271,7 +271,7 @@ describe('ManageRoutineTool — list / pause / resume / delete', () => {
   });
 
   it('pause requires id and forwards it', async () => {
-    const id = '11111111-1111-1111-1111-111111111111';
+    const id = '11111111-1111-4111-a111-111111111111';
     const { runner, calls } = stubRunner();
     const tool = new ManageRoutineTool({ runner, resolveContext: () => ctx });
     const result = await tool.handle({ action: 'pause', id });
@@ -282,7 +282,7 @@ describe('ManageRoutineTool — list / pause / resume / delete', () => {
   });
 
   it('delete reports not_found when the runner returns false', async () => {
-    const id = '22222222-2222-2222-2222-222222222222';
+    const id = '22222222-2222-4222-a222-222222222222';
     const { runner } = stubRunner({ deleteImpl: async () => false });
     const tool = new ManageRoutineTool({ runner, resolveContext: () => ctx });
     const result = await tool.handle({ action: 'delete', id });


### PR DESCRIPTION
## Summary

Replaces Dependabot PR #77 (which was blocked by a transitive peer-dep on `@omadia/agent-reference-maximum`) with a full repo-wide migration to zod 4.

- Root `middleware/package.json`: `zod ^3.23.8 → ^4.4.3`
- 9 workspace packages: peer `zod ^3.23.8 → ^4.0.0` (incl. `@omadia/orchestrator` and `@omadia/verifier` which previously declared `"*"`)
- `data/builder/build-template` + 2 boilerplate templates aligned so builder-generated agents ship zod 4 by default

## Breaking-change fixes

| File | Pattern | Fix |
|---|---|---|
| `src/config.ts` (12x) | `.transform(v=>v==='true').default('false')` | output-typed: `.default(false)` |
| `src/plugins/builder/agentSpec.ts` | `z.SafeParseReturnType<I,O>` (removed in v4) | `ReturnType<typeof AgentSpecSchema.safeParse>` |
| `src/plugins/builder/tools/lintSpec.ts` | `error.errors` | `error.issues` |
| `src/plugins/builder/tools/patchSpec.ts` | `formatZodErrors` path type `string\|number` | `PropertyKey` + `.map(String)` for `$ZodIssue.path` |

## Test updates

- `test/builder/codegen.test.ts` (2x): expected peer `zod` bumped to `^4.0.0` (codegen consumes the boilerplate template)
- `test/manageRoutineTool.test.ts` (2x): fixture UUIDs `"1111-..."` / `"2222-..."` → valid RFC-4122 v4 (zod 4 `z.string().uuid()` is now strict and rejects invalid variant/version bits)

## Validation

- `npm run typecheck` — 0 errors
- `npm run lint` — 0 errors
- `npm test` — 2311/2319 pass

The one failing test (`builderEventsRoutes › forwards agent-cause events too`, SSE timeout 1500ms) is **pre-existing flaky test pollution** — passes 6/6 in isolation. Tracked in `CLAUDE.local.md` "Bekannte offene Themen". Unrelated to zod.

## Test plan

- [ ] CI green (required: middleware lint+typecheck+test, schema, audit)
- [ ] Verify locally that `npm install` resolves to zod@4.4.3
- [ ] Spot-check that builder-generated agent packages declare `zod: ^4.0.0` in `peerDependencies`

Closes #77.