### PR TITLE
chore(deps): migrate react-resizable-panels 2 → 4 (closes #80)

### DIFF
--- a/web-ui/app/store/builder/[id]/_components/Workspace.tsx
+++ b/web-ui/app/store/builder/[id]/_components/Workspace.tsx
@@ -17,11 +17,12 @@ import {
   ChevronUp,
 } from 'lucide-react';
 import {
+  Group,
   Panel,
-  PanelGroup,
-  PanelResizeHandle,
-  type ImperativePanelGroupHandle,
-  type ImperativePanelHandle,
+  Separator,
+  useDefaultLayout,
+  useGroupRef,
+  usePanelRef,
 } from 'react-resizable-panels';
 
 import {
@@ -180,13 +181,24 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
   // react-resizable-panels imperative refs (B.6-4). Each Panel exposes
   // collapse() / expand() / resize() — we drive them from the existing
   // collapsed state so the rail click remains the canonical gesture, and
-  // mirror the panel's own onCollapse/onExpand callbacks back into state
-  // so dragging the handle past the threshold also collapses cleanly.
-  const chatPanelRef = useRef<ImperativePanelHandle | null>(null);
-  const editorPanelRef = useRef<ImperativePanelHandle | null>(null);
-  const previewPanelRef = useRef<ImperativePanelHandle | null>(null);
-  const uiSurfacesPanelRef = useRef<ImperativePanelHandle | null>(null);
-  const panelGroupRef = useRef<ImperativePanelGroupHandle | null>(null);
+  // mirror the panel's `onResize` callback back into state (rrp v4 removed
+  // the dedicated onCollapse/onExpand props — we derive collapse from size
+  // crossing the collapsedSize threshold instead).
+  const chatPanelRef = usePanelRef();
+  const editorPanelRef = usePanelRef();
+  const previewPanelRef = usePanelRef();
+  const uiSurfacesPanelRef = usePanelRef();
+  const panelGroupRef = useGroupRef();
+
+  // rrp v4 layout persistence — replaces v2's `autoSaveId` Panel prop.
+  // `useDefaultLayout` reads from localStorage on mount, returns a
+  // defaultLayout to seed the Group, plus an onLayoutChanged callback that
+  // writes back on every settled drag. Keep the storage key in sync with
+  // the v2 autoSaveId so existing users don't lose their saved layout.
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+    id: 'builder-workspace-panes-v2',
+    panelIds: ['chat', 'editor', 'preview', 'ui-surfaces'],
+  });
 
   // Maximize-helper: sets the whole 3-pane layout in a single atomic
   // setLayout call so two simultaneous collapses don't fight each other.
@@ -203,29 +215,36 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
       // 4-pane layout: chat | editor | preview | ui-surfaces.
       // Restore default keeps ui-surfaces collapsed at 3% — matches
       // the initial-mount default. Maximize one = collapse the other three.
+      // rrp v4: setLayout signature changed from positional array to an
+      // object keyed by panel id.
       if (restore) {
-        group?.setLayout([30, 32, 32, 6]);
+        group?.setLayout({
+          chat: 30,
+          editor: 32,
+          preview: 32,
+          'ui-surfaces': 6,
+        });
         setChatCollapsed(false);
         setEditorCollapsed(false);
         setPreviewCollapsed(false);
         setUiSurfacesCollapsed(true);
         return;
       }
-      const layout =
+      const layout: Record<string, number> =
         which === 'chat'
-          ? [91, 3, 3, 3]
+          ? { chat: 91, editor: 3, preview: 3, 'ui-surfaces': 3 }
           : which === 'editor'
-            ? [3, 91, 3, 3]
+            ? { chat: 3, editor: 91, preview: 3, 'ui-surfaces': 3 }
             : which === 'preview'
-              ? [3, 3, 91, 3]
-              : [3, 3, 3, 91];
+              ? { chat: 3, editor: 3, preview: 91, 'ui-surfaces': 3 }
+              : { chat: 3, editor: 3, preview: 3, 'ui-surfaces': 91 };
       group?.setLayout(layout);
       setChatCollapsed(which !== 'chat');
       setEditorCollapsed(which !== 'editor');
       setPreviewCollapsed(which !== 'preview');
       setUiSurfacesCollapsed(which !== 'ui-surfaces');
     },
-    [],
+    [panelGroupRef],
   );
 
   // Option-C, C-2: shared "Fix mit Builder"-trigger reused by both error
@@ -490,25 +509,25 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
     if (!r) return;
     if (chatCollapsed) r.collapse();
     else r.expand();
-  }, [chatCollapsed]);
+  }, [chatCollapsed, chatPanelRef]);
   useEffect(() => {
     const r = editorPanelRef.current;
     if (!r) return;
     if (editorCollapsed) r.collapse();
     else r.expand();
-  }, [editorCollapsed]);
+  }, [editorCollapsed, editorPanelRef]);
   useEffect(() => {
     const r = previewPanelRef.current;
     if (!r) return;
     if (previewCollapsed) r.collapse();
     else r.expand();
-  }, [previewCollapsed]);
+  }, [previewCollapsed, previewPanelRef]);
   useEffect(() => {
     const r = uiSurfacesPanelRef.current;
     if (!r) return;
     if (uiSurfacesCollapsed) r.collapse();
     else r.expand();
-  }, [uiSurfacesCollapsed]);
+  }, [uiSurfacesCollapsed, uiSurfacesPanelRef]);
   const installEnabled =
     editorWarningTotal === 0 &&
     missingRequiredCredentials === 0 &&
@@ -706,23 +725,27 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
         if (isDesktop) {
           return (
             <LayoutGroup>
-              <PanelGroup
-                ref={panelGroupRef}
-                direction="horizontal"
-                autoSaveId="builder-workspace-panes-v2"
+              <Group
+                groupRef={panelGroupRef}
+                orientation="horizontal"
+                defaultLayout={defaultLayout}
+                onLayoutChanged={onLayoutChanged}
                 className="flex min-h-[640px] gap-0"
                 style={{ height: 'calc(100vh - 240px)' }}
               >
                 <Panel
                   id="chat"
-                  order={1}
-                  ref={chatPanelRef}
+                  panelRef={chatPanelRef}
                   collapsible
-                  collapsedSize={3}
-                  minSize={18}
-                  defaultSize={30}
-                  onCollapse={() => setChatCollapsed(true)}
-                  onExpand={() => setChatCollapsed(false)}
+                  collapsedSize="3%"
+                  minSize="18%"
+                  defaultSize="30%"
+                  onResize={(size) =>
+                    setChatCollapsed((prev) => {
+                      const next = size.asPercentage <= 3.5;
+                      return prev === next ? prev : next;
+                    })
+                  }
                   className="flex"
                 >
                   <PaneCard
@@ -755,14 +778,17 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
 
                 <Panel
                   id="editor"
-                  order={2}
-                  ref={editorPanelRef}
+                  panelRef={editorPanelRef}
                   collapsible
-                  collapsedSize={3}
-                  minSize={18}
-                  defaultSize={32}
-                  onCollapse={() => setEditorCollapsed(true)}
-                  onExpand={() => setEditorCollapsed(false)}
+                  collapsedSize="3%"
+                  minSize="18%"
+                  defaultSize="32%"
+                  onResize={(size) =>
+                    setEditorCollapsed((prev) => {
+                      const next = size.asPercentage <= 3.5;
+                      return prev === next ? prev : next;
+                    })
+                  }
                   className="flex"
                 >
                   <PaneCard
@@ -802,14 +828,17 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
 
                 <Panel
                   id="preview"
-                  order={3}
-                  ref={previewPanelRef}
+                  panelRef={previewPanelRef}
                   collapsible
-                  collapsedSize={3}
-                  minSize={18}
-                  defaultSize={32}
-                  onCollapse={() => setPreviewCollapsed(true)}
-                  onExpand={() => setPreviewCollapsed(false)}
+                  collapsedSize="3%"
+                  minSize="18%"
+                  defaultSize="32%"
+                  onResize={(size) =>
+                    setPreviewCollapsed((prev) => {
+                      const next = size.asPercentage <= 3.5;
+                      return prev === next ? prev : next;
+                    })
+                  }
                   className="flex"
                 >
                   <PaneCard
@@ -843,14 +872,17 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
 
                 <Panel
                   id="ui-surfaces"
-                  order={4}
-                  ref={uiSurfacesPanelRef}
+                  panelRef={uiSurfacesPanelRef}
                   collapsible
-                  collapsedSize={3}
-                  minSize={18}
-                  defaultSize={6}
-                  onCollapse={() => setUiSurfacesCollapsed(true)}
-                  onExpand={() => setUiSurfacesCollapsed(false)}
+                  collapsedSize="3%"
+                  minSize="18%"
+                  defaultSize="6%"
+                  onResize={(size) =>
+                    setUiSurfacesCollapsed((prev) => {
+                      const next = size.asPercentage <= 3.5;
+                      return prev === next ? prev : next;
+                    })
+                  }
                   className="flex"
                 >
                   <PaneCard
@@ -883,7 +915,7 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
                     />
                   </PaneCard>
                 </Panel>
-              </PanelGroup>
+              </Group>
             </LayoutGroup>
           );
         }
@@ -1095,12 +1127,12 @@ function MobilePaneTabs({
  */
 function ResizeHandle(): React.ReactElement {
   return (
-    <PanelResizeHandle className="group relative w-1 cursor-col-resize bg-transparent transition-colors data-[resize-handle-state=hover]:bg-[color:var(--accent)]/40 data-[resize-handle-state=drag]:bg-[color:var(--accent)]">
+    <Separator className="group relative w-1 cursor-col-resize bg-transparent transition-colors data-[resize-handle-state=hover]:bg-[color:var(--accent)]/40 data-[resize-handle-state=drag]:bg-[color:var(--accent)]">
       <span
         aria-hidden
         className="absolute inset-y-0 -inset-x-1 group-hover:bg-[color:var(--accent)]/0"
       />
-    </PanelResizeHandle>
+    </Separator>
   );
 }
 

--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -30,6 +30,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.0",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -2733,6 +2734,26 @@
         "tailwindcss": "4.3.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -2812,6 +2833,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2945,7 +2973,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3737,6 +3764,29 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -4400,7 +4450,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cytoscape": {
@@ -4642,6 +4691,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.2.7",
@@ -7127,6 +7183,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -8684,6 +8750,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -8764,6 +8845,13 @@
       "peerDependencies": {
         "react": "^19.2.6"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "9.1.0",

--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -24,7 +24,7 @@
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-markdown": "^9.0.3",
-        "react-resizable-panels": "^2.1.9",
+        "react-resizable-panels": "^4.11.1",
         "remark-gfm": "^4.0.0",
         "tailwind-merge": "^3.5.0"
       },
@@ -2733,27 +2733,6 @@
         "tailwindcss": "4.3.0"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -2833,14 +2812,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2974,6 +2945,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3765,31 +3737,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -4453,6 +4400,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cytoscape": {
@@ -4694,14 +4642,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.2.7",
@@ -7187,17 +7127,6 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -8755,22 +8684,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -8852,14 +8765,6 @@
         "react": "^19.2.6"
       }
     },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/react-markdown": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
@@ -8898,13 +8803,13 @@
       }
     },
     "node_modules/react-resizable-panels": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-2.1.9.tgz",
-      "integrity": "sha512-z77+X08YDIrgAes4jl8xhnUu1LNIRp4+E7cv4xHmLOxxUPO/ML7PSrE813b90vj7xvQ1lcf7g2uA9GeMZonjhQ==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.11.1.tgz",
+      "integrity": "sha512-kA4w58V6wYdRLm2rg9pzroZwGlqBLul1FjMP0J8kqTo3zSHtjeH+LXmZaldCo6+HWqs1e5hOcPoajKXdOze37Q==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
-        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/redent": {

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.0",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -31,7 +31,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-markdown": "^9.0.3",
-    "react-resizable-panels": "^2.1.9",
+    "react-resizable-panels": "^4.11.1",
     "remark-gfm": "^4.0.0",
     "tailwind-merge": "^3.5.0"
   },


### PR DESCRIPTION
## Summary

Replaces Dependabot PR #80 (which CI-failed because rrp 4 ships an entirely renamed/restructured API with no backward-compat aliases) with a full migration of the only file consuming the library: `web-ui/app/store/builder/[id]/_components/Workspace.tsx`.

## API rename + restructure

| v2 | v4 |
|---|---|
| `<PanelGroup direction="…" ref={…} autoSaveId="…">` | `<Group orientation="…" groupRef={…} defaultLayout={…} onLayoutChanged={…}>` |
| `<PanelResizeHandle>` | `<Separator>` |
| `<Panel order={N} ref={…} defaultSize={30} minSize={18} collapsedSize={3}>` | `<Panel panelRef={…} defaultSize="30%" minSize="18%" collapsedSize="3%">` (no `order`) |
| `useRef<ImperativePanelHandle>(null)` | `usePanelRef()` |
| `useRef<ImperativePanelGroupHandle>(null)` | `useGroupRef()` |
| `group.setLayout([30,32,32,6])` (positional array) | `group.setLayout({chat:30, editor:32, preview:32, 'ui-surfaces':6})` (object keyed by panel id) |

## Behavioural rewrite

- **`onCollapse` / `onExpand` props removed in v4.** Collapse state is now derived from `onResize({asPercentage})` crossing the `collapsedSize` threshold (3.5% with a small buffer above the 3% collapsed size). Functional `setState` guards against feedback loops with the per-pane sync `useEffect` that calls `.collapse()/.expand()`.
- **`autoSaveId` Panel prop removed.** Replaced by `useDefaultLayout({id, panelIds})` hook + `defaultLayout` / `onLayoutChanged` Group props. Same storage key (`builder-workspace-panes-v2`) so existing operators keep their persisted layout.

## Validation

- `web-ui` typecheck — 0 errors
- `web-ui` lint — 0 errors, 20 warnings (baseline; same as `main`)

⚠️ `web-ui` vitest currently fails to load 11/18 test files due to a missing `@testing-library/dom` transitive peer. **Pre-existing on main** (verified by checking out main and running the same `npm test` — same 11 failures). Not introduced by this PR. Should be filed as a separate ticket.

## Test plan

- [ ] CI green (required: web-ui lint+typecheck+vitest, build, audit)
- [ ] Manual browser smoke: open `/store/builder/<id>` on desktop, verify:
  - [ ] All 4 panes (chat / editor / preview / ui-surfaces) render with the right default widths
  - [ ] Resize handles work (drag, hover, accent color)
  - [ ] Rail-button collapse/expand for each pane
  - [ ] Maximize button (PaneCard) toggles correctly
  - [ ] Layout persists across page reload (localStorage key `react-resizable-panels:builder-workspace-panes-v2`)

Closes #80.