### PR TITLE
chore: refresh engineering-standards templates

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Pre-commit hook for engineering-standards repos.
+#
+# Two checks, both run on every commit:
+#
+#   1) Main-tree discipline (mandatory engineering standard, see SKILL.md §3)
+#      The main clone never receives commits — every change lands in a
+#      worktree. This is branch-agnostic: an agent whose HEAD got switched
+#      to main by a parallel session is caught here too, not just one that
+#      created a feature branch in the wrong tree.
+#
+#      Bypass (one-off):    ALLOW_MAIN_TREE_BRANCH=1 git commit ...
+#      Opt-out (per repo):  git config engineering-standards.main-tree-discipline false
+#      Global opt-out:      status: exempt in .github/engineering-standards.yml
+#
+#   2) Per-branch path-guard (optional backstop)
+#      Refuses commits that stage paths inconsistent with the current
+#      branch's scope. No-op for branches without a rule in the case
+#      statement below — add per-branch rules as needed.
+#
+# Activated automatically when the repo runs:
+#   git config core.hooksPath .hooks
+
+set -e
+
+# --- (1) Main-tree discipline -------------------------------------------------
+
+mtd_enabled=$(git config --bool --get engineering-standards.main-tree-discipline 2>/dev/null || echo true)
+
+if [ "$mtd_enabled" != "false" ] && [ "${ALLOW_MAIN_TREE_BRANCH:-}" != "1" ]; then
+  main_tree=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')
+  current_tree=$(git rev-parse --show-toplevel 2>/dev/null)
+  current_branch=$(git branch --show-current 2>/dev/null)
+
+  if [ -n "$main_tree" ] && [ -n "$current_tree" ] && \
+     [ "$main_tree" = "$current_tree" ]; then
+    echo "pre-commit: commits from the main clone are not allowed." >&2
+    echo "Convention: every change — even single-line fixes — lands in a worktree." >&2
+    echo "Reason: the main clone's HEAD can be switched by parallel sessions; commits" >&2
+    echo "from here have unreliable branch attribution." >&2
+    echo "" >&2
+    if [ -n "$current_branch" ] && [ "$current_branch" != "main" ] && [ "$current_branch" != "master" ]; then
+      echo "  git worktree add ../$(basename "$current_tree")-${current_branch//\//-} $current_branch" >&2
+    else
+      echo "  git worktree add ../$(basename "$current_tree")-<feature> -b <branch> main" >&2
+    fi
+    echo "" >&2
+    echo "Bypass (one-off):  ALLOW_MAIN_TREE_BRANCH=1 git commit ..." >&2
+    echo "Opt-out per repo:  git config engineering-standards.main-tree-discipline false" >&2
+    exit 1
+  fi
+fi
+
+# --- (2) Per-branch path-guard ------------------------------------------------
+
+branch="$(git branch --show-current)"
+
+case "$branch" in
+  # --- examples; delete and replace with your own rules ---
+  #
+  # research/foo)
+  #   allow='^(experiments/foo/|docs/foo/)'
+  #   ;;
+  # main)
+  #   forbid='^experiments/'
+  #   ;;
+  # ---------------------------------------------------------
+  *)
+    exit 0
+    ;;
+esac
+
+staged="$(git diff --cached --name-only)"
+
+if [ -n "${allow:-}" ]; then
+  bad="$(printf '%s\n' "$staged" | grep -vE "$allow" || true)"
+  if [ -n "$bad" ]; then
+    echo "pre-commit: branch '$branch' should not stage these paths:" >&2
+    printf '  %s\n' $bad >&2
+    echo "Use a worktree for this branch (see AGENTS.md) to avoid the drift class entirely." >&2
+    exit 1
+  fi
+fi
+
+if [ -n "${forbid:-}" ]; then
+  bad="$(printf '%s\n' "$staged" | grep -E "$forbid" || true)"
+  if [ -n "$bad" ]; then
+    echo "pre-commit: branch '$branch' must not stage these paths:" >&2
+    printf '  %s\n' $bad >&2
+    exit 1
+  fi
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,35 @@ Wenn die Zuordnung unklar ist: lieber in CHANGELOG notieren als gar nicht — sp
 
 Ohne mindestens Punkte 1–3 darf kein Code geändert werden.
 
+## Working in a multi-session repo
+
+**Convention (enforced):** the main clone never receives commits. Every change — even a single-line typo fix — lands in a worktree. This is branch-agnostic: an agent whose HEAD got switched to `main` by a parallel session is caught here too, not just one that created a feature branch in the wrong tree. Enforced by the `.hooks/pre-commit` hook shipped via the engineering-standards skill.
+
+~~~bash
+git worktree add ../<repo>-<feature> -b <branch> main   # create with new branch
+git worktree add ../<repo>-<feature> <existing-branch>  # or attach existing
+# work in ../<repo>-<feature>/
+git worktree remove ../<repo>-<feature>                 # remove the tree
+git branch -D <feature>                                 # remove the branch ref (after merge or discard)
+git worktree list                                       # inspect
+~~~
+
+Build artefacts (`target/`, `node_modules/`, etc.) live per worktree — first build per tree is full cost, subsequent builds are independent.
+
+**Bypass levels** (in increasing persistence):
+
+| Level | Effect | How |
+|---|---|---|
+| One-off | this commit only | `ALLOW_MAIN_TREE_BRANCH=1 git commit ...` |
+| Per repo | persistent disable, other standards still apply | `git config engineering-standards.main-tree-discipline false` |
+| Repo exempt | all engineering-standards disabled for this repo | `status: exempt` in `.github/engineering-standards.yml` |
+
+### Drift signals (for any unusual main-tree work that is allowed)
+
+- Run `git branch --show-current` before each commit and confirm it matches what you intended.
+- Treat `git status` anomalies as drift signals: directories you didn't touch showing as `??`, unexpected `M` on files you didn't edit. Don't commit through that — `git reflog | head -20` first to see who moved your HEAD.
+- Don't reach for `git reset --hard` reflexively; another session may have uncommitted work in the shared tree. Inspect `git stash list` and `git diff --stat` first.
+
 ## Parallele Arbeit — Kollisionen vermeiden
 
 - **Fly-Deploys sind nicht atomar.** Wenn ein anderer Agent gerade deployt, abwarten (30-60s), sonst trittst du ihm auf den Zeh.

--- a/script/setup
+++ b/script/setup
@@ -1,26 +1,14 @@
 #!/usr/bin/env bash
-# One-command dev bootstrap for byte5ai/omadia.
-# Mirrors the manual steps in CONTRIBUTING.md and activates the
-# repo-local pre-push hook (which blocks direct pushes to main).
-
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-echo "==> Configuring git hooks (.hooks/pre-push blocks direct pushes to main)..."
+echo "Installing dependencies..."
+# Anpassen je nach Projekt:
+# Python:  pip install -e ".[dev]"
+# Node:    npm install
+# Swift:   swift package resolve
+
+echo "Configuring git hooks..."
 git config core.hooksPath .hooks
 
-echo "==> Installing middleware deps..."
-( cd middleware && npm install )
-
-echo "==> Installing web-ui deps..."
-( cd web-ui && npm install )
-
-cat <<'NEXT'
-
-Setup complete. Next steps:
-  cp middleware/.env.example middleware/.env   # set ANTHROPIC_API_KEY
-  docker compose up -d minio kroki ollama     # local sidecars
-  ( cd middleware && npm run dev )            # API on :8080
-  ( cd web-ui && npm run dev )                # admin UI on :3000
-
-NEXT
+echo "Done."


### PR DESCRIPTION
Applies the updated engineering-standards templates (fix(repo-setup): drift-gap + opt-out #6):

- `.hooks/pre-commit` — new; mandatorischer Main-Tree-Discipline-Check (blockiert Commits aus dem Haupt-Klon, branch-agnostisch; Bypass via `ALLOW_MAIN_TREE_BRANCH=1` oder `git config engineering-standards.main-tree-discipline false`)
- `.hooks/pre-push` — unchanged (template identical)
- `script/setup` — refreshed
- `AGENTS.md` — neue Section `## Working in a multi-session repo` mit Worktree-Konventionen, Bypass-Levels und Drift-Signals