### PR TITLE
fix(web-ui): hold scope chip until hydration to fix mismatch (#95)

### DIFF
--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -492,7 +492,10 @@ export default function ChatPage(): React.ReactElement {
               {t('streamLabel')} <code className="font-mono">/bot-api/chat/stream</code>
             </span>
             <span className="truncate font-mono text-[11px] text-neutral-400">
-              scope={activeId}
+              {/* `activeId` is a client-only minted UUID — rendering it during
+                  SSR produces a hydration mismatch (#95). Hold a placeholder
+                  until `useChatSessions` finishes hydrating. */}
+              scope={hydrating ? '…' : activeId}
             </span>
             <button
               type="button"


### PR DESCRIPTION
## Summary

Fixes #95 — hydration mismatch in the ChatPage `scope={…}` debug chip.

`app/page.tsx` rendered `scope={activeId}` directly. During the hydrating window `useChatSessions` returns an ephemeral `emptySession()` whose id is a fresh `crypto.randomUUID()` minted **per render** — so SSR emitted one UUID and the client's first render emitted another, tripping a hydration mismatch on every fresh page load (loud red console error under Next 16 / React 19, no functional impact).

## Fix

Gate the chip on the existing `hydrating` flag (Option A from the issue — smallest change). `hydrating` is `true` for both the SSR render and the client's first render (initial `useState(true)`), flipping to `false` only after the hydration effect runs — so SSR and client-first-render agree on a `…` placeholder. The real `activeId` appears once hydration completes.

Pure display change to a debug chip — no behaviour, API, or storage impact.

## Verification

- `npm run lint` — 0 errors, 53 warnings (all pre-existing, tracked in #94; no new warning)
- `npm run typecheck` — clean
- `npm run test` — 129/129 pass

## Test plan

- [ ] Fresh load on `/` → no "Hydration failed" error in browser console
- [ ] `scope={…}` chip shows `…` briefly, then the real `activeId` UUID after hydration

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>