### PR TITLE
fix(web-ui): clear React-Compiler refs/immutability/error-boundaries warnings (#94)

### DIFF
--- a/web-ui/app/_lib/chatSessions.ts
+++ b/web-ui/app/_lib/chatSessions.ts
@@ -677,6 +677,21 @@ export function useChatSessions(): UseChatSessionsResult {
     [activeId],
   );
 
+  // Refs kept in sync with state so persistActive reads the latest snapshot
+  // without forcing callers to resubscribe on every message delta. Declared —
+  // and synced — *before* persistActive so the React-Compiler `immutability`
+  // rule sees the `.current` writes happen before the useCallback closes over
+  // the refs. Initialised with throwaway literals (identical to the `useState`
+  // initial values); the effects below own the actual sync.
+  const sessionsRef = useRef<ChatSession[]>([]);
+  const activeIdRef = useRef<string>('');
+  useEffect(() => {
+    sessionsRef.current = sessions;
+  }, [sessions]);
+  useEffect(() => {
+    activeIdRef.current = activeId;
+  }, [activeId]);
+
   const persistActive = useCallback(async (): Promise<void> => {
     const snapshot = sessionsRef.current.find((s) => s.id === activeIdRef.current);
     if (!snapshot) return;
@@ -689,17 +704,6 @@ export function useChatSessions(): UseChatSessionsResult {
       );
     }
   }, []);
-
-  // Refs kept in sync with state so persistActive reads the latest snapshot
-  // without forcing callers to resubscribe on every message delta.
-  const sessionsRef = useRef(sessions);
-  const activeIdRef = useRef(activeId);
-  useEffect(() => {
-    sessionsRef.current = sessions;
-  }, [sessions]);
-  useEffect(() => {
-    activeIdRef.current = activeId;
-  }, [activeId]);
 
   // Always return *some* active session so the caller doesn't have to guard.
   // Build an ephemeral empty one during the brief hydrating window.

--- a/web-ui/app/graph/_components/GraphCanvas.tsx
+++ b/web-ui/app/graph/_components/GraphCanvas.tsx
@@ -323,7 +323,12 @@ export default function GraphCanvas({
     () => buildElements(session, extraSessions, runs, expansions, filter),
     [session, extraSessions, runs, expansions, filter],
   );
-  nodesRef.current = nodes;
+  // Synced via a post-render effect (never during render) to satisfy the
+  // React-Compiler `refs` rule; the only reader is the cytoscape `tap` handler,
+  // which fires on user clicks long after commit.
+  useEffect(() => {
+    nodesRef.current = nodes;
+  });
   const sparse = !filter.showTrace;
 
   useEffect(() => {

--- a/web-ui/app/store/builder/[id]/_components/SlotEditor.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SlotEditor.tsx
@@ -109,10 +109,15 @@ export function SlotEditor({
   );
   const [status, setStatus] = useState<SaveStatus>({ kind: 'idle' });
   const debounceRef = useRef<number | null>(null);
-  const draftRef = useRef(draft);
+  // Lazily initialised + synced via a post-render effect so the React-Compiler
+  // `refs`/`immutability` rules are satisfied. `draftRef` is only read inside
+  // `flush`, which runs on debounce/blur — always after commit.
+  const draftRef = useRef<string>('');
   const lastSavedRef = useRef<string>(slotKeys[0] ? (slots[slotKeys[0]] ?? '') : '');
   const selectId = useId();
-  draftRef.current = draft;
+  useEffect(() => {
+    draftRef.current = draft;
+  });
 
   // Switch to the first slot when the slot list changes from empty → non-
   // empty (initial load) or shrinks below the current selection.

--- a/web-ui/app/store/builder/[id]/_components/useSpecEvents.ts
+++ b/web-ui/app/store/builder/[id]/_components/useSpecEvents.ts
@@ -27,10 +27,18 @@ export function useSpecEvents(
   handler: (ev: SpecBusEvent) => void,
   opts: UseSpecEventsOptions = {},
 ): void {
-  const handlerRef = useRef(handler);
-  const onStatusRef = useRef(opts.onStatus);
-  handlerRef.current = handler;
-  onStatusRef.current = opts.onStatus;
+  // Latest-value refs so the subscription effect below doesn't tear down the
+  // EventSource on every render. Synced via a post-render effect (never during
+  // render) to satisfy the React-Compiler `refs` rule; lazily initialised so
+  // `.current` isn't treated as a frozen hook argument by `immutability`. Every
+  // consumer (`dispatch`, `onOpen`/`onError`, cleanup) runs asynchronously
+  // after commit, so the ref is always populated by the time it is read.
+  const handlerRef = useRef<((ev: SpecBusEvent) => void) | null>(null);
+  const onStatusRef = useRef<UseSpecEventsOptions['onStatus']>(undefined);
+  useEffect(() => {
+    handlerRef.current = handler;
+    onStatusRef.current = opts.onStatus;
+  });
 
   const enabled = opts.enabled !== false;
 
@@ -51,7 +59,7 @@ export function useSpecEvents(
       onStatusRef.current?.(source.readyState === 2 ? 'closed' : 'error');
     };
     const dispatch = (ev: SpecBusEvent): void => {
-      handlerRef.current(ev);
+      handlerRef.current?.(ev);
     };
 
     const onSpecPatch = (e: MessageEvent<string>): void => {

--- a/web-ui/app/store/builder/[id]/page.tsx
+++ b/web-ui/app/store/builder/[id]/page.tsx
@@ -20,9 +20,12 @@ export default async function BuilderWorkspacePage({
 }): Promise<React.ReactElement> {
   const { id } = await params;
 
+  // Only the data fetch is wrapped — constructing the <Workspace> JSX inside
+  // the try would (correctly) trip the React-Compiler `error-boundaries` rule:
+  // render errors from <Workspace> are not caught by a try/catch around it.
+  let envelope: Awaited<ReturnType<typeof getBuilderDraft>>;
   try {
-    const envelope = await getBuilderDraft(id);
-    return <Workspace initialDraft={envelope.draft} />;
+    envelope = await getBuilderDraft(id);
   } catch (err) {
     if (err instanceof ApiError && err.status === 404) {
       notFound();
@@ -30,6 +33,7 @@ export default async function BuilderWorkspacePage({
     await redirectIfUnauthorized(err);
     return <LoadErrorState id={id} error={err} />;
   }
+  return <Workspace initialDraft={envelope.draft} />;
 }
 
 function LoadErrorState({

--- a/web-ui/eslint.config.mjs
+++ b/web-ui/eslint.config.mjs
@@ -20,23 +20,14 @@ const eslintConfig = [
   ...nextTypescript,
 
   // eslint-plugin-react-hooks v6 (shipped with eslint-config-next 16) added
-  // three React-19-era strict rules that are correct in principle but flag
-  // dozens of pre-existing call sites in this codebase. Downgrade to `warn`
-  // so the next-16 migration stays a pure-dep PR; refactor the call sites
-  // in a follow-up ticket.
-  //   - set-state-in-effect: cascading-render anti-pattern; many of ours
-  //     are legitimate (sync external state into React).
-  //   - refs: forbids any access to `.current` during render; we have a
-  //     handful of intentional ref-as-cache patterns.
-  //   - error-boundaries: forbids JSX inside try/catch; one current usage
-  //     in app/store/builder/[id]/page.tsx wraps a child component whose
-  //     own data fetch is intentionally inside the try to catch ApiError.
+  // React-19-era strict rules. `refs`, `immutability` and `error-boundaries`
+  // were cleaned up in #94 and now run at their default `error` severity.
+  // `set-state-in-effect` still flags ~26 pre-existing call sites — many are
+  // legitimate "sync external state into React" patterns needing per-site
+  // judgement — so it stays `warn` until the follow-up batch lands (#94).
   {
     rules: {
       'react-hooks/set-state-in-effect': 'warn',
-      'react-hooks/refs': 'warn',
-      'react-hooks/immutability': 'warn',
-      'react-hooks/error-boundaries': 'warn',
     },
   },
 ];


### PR DESCRIPTION
Batch 1 of #94 — clears the 7 sites under three of the four React-Compiler strict rules that PR #89 downgraded to `warn`, and restores those rules to `error`.

## Changes

| Rule | Sites | Fix |
|---|---|---|
| `refs` | 4 | `GraphCanvas.nodesRef`, `SlotEditor.draftRef`, `useSpecEvents.handlerRef`/`onStatusRef` assigned `.current` during render → moved into post-render effects. Every reader (cytoscape `tap` handler, `flush` on debounce/blur, SSE `dispatch`/status callbacks) runs async after commit, so the ref is always populated when read — no timing change. |
| `immutability` | 2 | `chatSessions.sessionsRef`/`activeIdRef` are closed over by the `persistActive` `useCallback` (which freezes them); the effects then mutated a frozen value. Relocated the ref declarations + sync effects ahead of `persistActive` so the writes precede the capture — pure hook reorder, same order `SlotEditor` already uses. |
| `error-boundaries` | 1 | builder `[id]/page.tsx` built the `<Workspace>` element inside the try/catch wrapping the draft fetch; render errors would escape the catch. Only `await getBuilderDraft` stays in the try; the `<Workspace>` return is hoisted out. |

`set-state-in-effect` (26 sites) stays `warn` — handled in **batch 2** (separate PR, per-site judgement).

## Verification

- `npm run lint` — 0 errors, 46 warnings (down from 53; the 7 batch-1 violations are gone)
- `npm run typecheck` — clean
- `npm run test` — 129/129 pass

All four changes are behaviour-preserving by construction. Interactive smoke of the graph node-tap and slot-save paths needs the full middleware stack and is not covered here.

## Test plan

- [ ] Builder workspace `/store/builder/<id>` loads; 404 draft still renders the not-found page
- [ ] Graph node click still selects the node
- [ ] Slot editor still autosaves on debounce/blur
- [ ] Two tabs on one draft still see each other's live spec/slot patches (SSE)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>