### PR TITLE
fix(web-ui): annotate fetch-on-mount effects in admin pages (#94 batch 2a)

### DIFF
--- a/web-ui/app/admin/auth/page.tsx
+++ b/web-ui/app/admin/auth/page.tsx
@@ -45,6 +45,9 @@ export default function AdminAuthPage(): React.ReactElement {
   }
 
   useEffect(() => {
+    // Fetch-on-mount: reload() touches state only after the awaited
+    // network round-trip — no synchronous cascading render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void reload();
   }, []);
 

--- a/web-ui/app/admin/kg-lifecycle/page.tsx
+++ b/web-ui/app/admin/kg-lifecycle/page.tsx
@@ -96,6 +96,9 @@ export default function KgLifecyclePage(): JSX.Element {
   }, []);
 
   useEffect(() => {
+    // Fetch-on-mount: reload()'s only synchronous setState is setError(null),
+    // a same-value no-op on mount; the data lands after the awaited fetch.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void reload();
   }, [reload]);
 

--- a/web-ui/app/admin/kg-priorities/page.tsx
+++ b/web-ui/app/admin/kg-priorities/page.tsx
@@ -61,6 +61,9 @@ export default function KgPrioritiesPage(): React.ReactElement {
   }, [agentId]);
 
   useEffect(() => {
+    // Fetch-on-mount: reload()'s only synchronous setState is setError(null),
+    // a same-value no-op on mount; the data lands after the awaited fetch.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void reload();
   }, [reload]);
 

--- a/web-ui/app/admin/users/[id]/page.tsx
+++ b/web-ui/app/admin/users/[id]/page.tsx
@@ -54,6 +54,9 @@ export default function AdminUserEditPage(): React.ReactElement {
   }
 
   useEffect(() => {
+    // Fetch-on-mount: load() touches state only after the awaited network
+    // round-trip — no synchronous cascading render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);

--- a/web-ui/app/admin/users/page.tsx
+++ b/web-ui/app/admin/users/page.tsx
@@ -37,6 +37,9 @@ export default function AdminUsersPage(): React.ReactElement {
   }
 
   useEffect(() => {
+    // Fetch-on-mount: reload() touches state only after the awaited
+    // network round-trip — no synchronous cascading render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void reload();
   }, []);
 


### PR DESCRIPTION
Batch 2a of #94 — the admin-pages slice of the `react-hooks/set-state-in-effect` cleanup.

## Context

The five admin pages each kick off a data fetch from a mount effect. `set-state-in-effect` flags the `void reload()` / `void load()` call because it traces a `setState` inside the called function — it cannot tell that those updates only run *after* an `await`.

## Triage

| Page | `reload`/`load` shape | Verdict |
|---|---|---|
| `admin/auth` | `await getAdminAuthProviders()` → setState | post-await only |
| `admin/users` | `await listAdminUsers()` → setState | post-await only |
| `admin/users/[id]` | `await getAdminUser(id)` → setState | post-await only |
| `admin/kg-lifecycle` | sync `setError(null)` then `await Promise.all(...)` → setState | `setError(null)` is a same-value no-op on mount; data post-await |
| `admin/kg-priorities` | sync `setError(null)` then `await fetch(...)` → setState | same as above |

All five are legitimate fetch-on-mount effects with no synchronous cascading render. Each gets a scoped `eslint-disable-next-line react-hooks/set-state-in-effect` with the rationale inline. **No behaviour change.**

## Progress

26 → 21 `set-state-in-effect` sites. The rule stays `warn` until the final batch-2 PR clears the remainder and flips it to `error`.

## Verification

- `npm run typecheck` — clean
- `npm run test` — 129/129 pass

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>