### PR TITLE
fix(web-ui): annotate data-loading effects in graph + memory (#94 batch 2b)

### DIFF
--- a/web-ui/app/graph/page.tsx
+++ b/web-ui/app/graph/page.tsx
@@ -57,6 +57,9 @@ export default function GraphPage(): React.ReactElement {
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const mql = window.matchMedia('(prefers-color-scheme: dark)');
+    // Initial read of a browser API unavailable during SSR; the `change`
+    // listener below handles every subsequent update.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setDark(mql.matches);
     const handler = (e: MediaQueryListEvent): void => setDark(e.matches);
     mql.addEventListener('change', handler);
@@ -91,6 +94,9 @@ export default function GraphPage(): React.ReactElement {
   }, []);
 
   useEffect(() => {
+    // Fetch-on-mount: refresh()'s only synchronous setState is setError(null),
+    // a same-value no-op on mount; the data lands after the awaited fetch.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void refresh();
   }, [refresh]);
 
@@ -124,6 +130,9 @@ export default function GraphPage(): React.ReactElement {
   // Load the active session's own view on demand.
   useEffect(() => {
     if (selected === ALL) return;
+    // Load-on-selection: loadSessionView marks the scope 'loading' (one
+    // intended render) before fetching — not a cascading-render anti-pattern.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (!sessionViews[selected]) void loadSessionView(selected);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selected]);
@@ -132,6 +141,9 @@ export default function GraphPage(): React.ReactElement {
   useEffect(() => {
     if (selected !== ALL) return;
     for (const s of sessions) {
+      // loadSessionView marks each scope 'loading' (one intended render)
+      // before fetching — not a cascading-render anti-pattern.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       if (!sessionViews[s.scope]) void loadSessionView(s.scope);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -164,6 +176,9 @@ export default function GraphPage(): React.ReactElement {
     const view = sessionViews[selected];
     if (!view || view === 'loading' || view === 'missing') return;
     for (const t of view.turns) {
+      // loadRun marks the turn 'loading' (one intended render) before
+      // fetching — not a cascading-render anti-pattern.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       if (!runCache[t.turn.id]) void loadRun(t.turn.id);
     }
   }, [mode, selected, sessionViews, runCache, loadRun]);

--- a/web-ui/app/memory/page.tsx
+++ b/web-ui/app/memory/page.tsx
@@ -96,10 +96,16 @@ export default function MemoryPage(): React.ReactElement {
   }, []);
 
   useEffect(() => {
+    // Load-on-change: loadDir marks the list 'loading' (one intended render)
+    // before fetching the directory — not a cascading-render anti-pattern.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void loadDir(cwd);
   }, [cwd, loadDir]);
 
   useEffect(() => {
+    // Load-on-selection: loadFile marks the file 'loading' (one intended
+    // render) before fetching — not a cascading-render anti-pattern.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (selected) void loadFile(selected);
   }, [selected, loadFile]);
 


### PR DESCRIPTION
Batch 2b of #94 — the graph-explorer + memory-browser slice of the `react-hooks/set-state-in-effect` cleanup.

## Triage

**`graph/page.tsx` (5 sites)**

| Effect | Why it is fine |
|---|---|
| dark-mode | `setDark(mql.matches)` is the initial read of `matchMedia` (unavailable during SSR); the `change` listener is the sanctioned subscription. |
| `refresh` mount | setState only post-await; `setError(null)` is a same-value no-op on mount. |
| `loadSessionView` ×2, `loadRun` | load-on-change — the loader marks its target `'loading'` (one intended render), then fetches. |

**`memory/page.tsx` (2 sites)** — `loadDir` / `loadFile` load-on-change effects, same shape: mark `'loading'`, then fetch.

All seven are legitimate external-data / browser-API sync effects, not the cascading-render anti-pattern the rule targets. Each gets a scoped `eslint-disable-next-line` with the rationale inline. **No behaviour change.**

## Progress

21 → 14 `set-state-in-effect` sites. Rule stays `warn` until the final batch-2 PR.

## Verification

- `npm run typecheck` — clean
- `npm run test` — 129/129 pass

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>