### PR TITLE
fix(web-ui): annotate set-state effects in builder components (#94 batch 2c)

### DIFF
--- a/web-ui/app/store/builder/[id]/_components/AuditTimelinePane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/AuditTimelinePane.tsx
@@ -103,6 +103,9 @@ export function AuditTimelinePane({ draftId }: AuditTimelinePaneProps): React.Re
   );
 
   useEffect(() => {
+    // Fetch-on-mount: loadPage() touches state only after the awaited
+    // page fetch — no synchronous cascading render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void loadPage(0, false);
   }, [loadPage]);
 

--- a/web-ui/app/store/builder/[id]/_components/BuilderChatPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/BuilderChatPane.tsx
@@ -419,6 +419,9 @@ export function BuilderChatPane({
       return;
     }
     if (pendingInput.autoSubmit) {
+      // Consuming a one-shot command prop from the parent: mirror the
+      // pending input into the controlled textarea — not a render cascade.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setInput('');
       void onSend(pendingInput.text);
     } else {

--- a/web-ui/app/store/builder/[id]/_components/InlineSlotEditor.tsx
+++ b/web-ui/app/store/builder/[id]/_components/InlineSlotEditor.tsx
@@ -59,6 +59,8 @@ export function InlineSlotEditor({
 
   // Re-seed when slotKey changes (operator switched to a different page row).
   useEffect(() => {
+    // Intentional state reset when the slotKey prop changes.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setValue(initialValue);
     setStatus({ kind: 'idle' });
   }, [slotKey, initialValue]);

--- a/web-ui/app/store/builder/[id]/_components/PagePreviewFrame.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PagePreviewFrame.tsx
@@ -72,6 +72,9 @@ export function PagePreviewFrame({
   }, [previewUrl]);
 
   useEffect(() => {
+    // Probe-on-mount: probe() touches state only after the awaited fetch —
+    // no synchronous cascading render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void probe();
     return () => {
       inFlight.current?.abort();

--- a/web-ui/app/store/builder/[id]/_components/QualityPanel.tsx
+++ b/web-ui/app/store/builder/[id]/_components/QualityPanel.tsx
@@ -67,6 +67,9 @@ export function QualityPanel({ draftId, refetchKey }: QualityPanelProps): React.
   }, [draftId]);
 
   useEffect(() => {
+    // Fetch-on-mount / refetch: load() touches state only after the awaited
+    // fetch — no synchronous cascading render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void load();
   }, [load, refetchKey]);
 

--- a/web-ui/app/store/builder/[id]/_components/SecretsDrawer.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SecretsDrawer.tsx
@@ -73,6 +73,8 @@ export function SecretsDrawer({
   // in React state longer than necessary.
   useEffect(() => {
     if (!open) {
+      // Intentional form-state reset when the drawer closes.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDraftValues({});
       setError(null);
     }

--- a/web-ui/app/store/builder/[id]/_components/SlotEditor.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SlotEditor.tsx
@@ -124,6 +124,9 @@ export function SlotEditor({
   useEffect(() => {
     if (active && slotKeys.includes(active)) return;
     const next = slotKeys[0] ?? '';
+    // Intentional: adjust the active slot when the slot list changes
+    // (initial load, or the current slot was removed).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setActive(next);
     const value = next ? (slots[next] ?? '') : '';
     setDraft(value);
@@ -140,6 +143,9 @@ export function SlotEditor({
     if (canonical === lastSavedRef.current) return;
     lastSavedRef.current = canonical;
     if (status.kind !== 'dirty' && status.kind !== 'pending') {
+      // Mirror the server-canonical slot value into the local draft when it
+      // changes and the user has no in-flight edit.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDraft(canonical);
     }
   }, [active, slots, status.kind]);

--- a/web-ui/app/store/builder/[id]/_components/SpecEditor.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SpecEditor.tsx
@@ -73,6 +73,10 @@ export function SpecEditor({ draftId, spec, agentStuck }: SpecEditorProps): Reac
   // When the server-canonical spec catches up with our dirty edit, clear
   // the dirty entry so the input goes back to mirroring the server.
   useEffect(() => {
+    // Reconcile dirty edits against the server-canonical spec when it
+    // changes; the functional updater returns `prev` unchanged when there
+    // is nothing to clear, so React bails out of any redundant render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setDirty((prev) => {
       let next: Partial<Record<string, string>> | null = null;
       for (const [path, value] of Object.entries(prev)) {

--- a/web-ui/app/store/builder/[id]/_components/ToolTemplatesModal.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolTemplatesModal.tsx
@@ -32,6 +32,9 @@ export function ToolTemplatesModal({
   const curated = listCuratedTemplates();
 
   useEffect(() => {
+    // Reads the operator's personal templates from localStorage — deferred
+    // to client mount because localStorage is unavailable during SSR.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setPersonal(listPersonalTemplates());
   }, []);
 

--- a/web-ui/app/store/builder/[id]/_components/VersionsTab.tsx
+++ b/web-ui/app/store/builder/[id]/_components/VersionsTab.tsx
@@ -70,6 +70,9 @@ export function VersionsTab({ draftId }: VersionsTabProps): React.ReactElement {
   }, [draftId]);
 
   useEffect(() => {
+    // Fetch-on-mount: refresh() touches state only after the awaited
+    // snapshot-list fetch — no synchronous cascading render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void refresh();
   }, [refresh]);
 


### PR DESCRIPTION
Batch 2c of #94 — the builder-components slice of the `react-hooks/set-state-in-effect` cleanup. Eleven sites across ten components, all legitimate effects the rule over-flags.

## Triage

| Category | Components | Why it is fine |
|---|---|---|
| data-load / probe-on-mount | AuditTimelinePane, PagePreviewFrame, QualityPanel, VersionsTab | state touched only post-await |
| props → state sync | SlotEditor ×2, InlineSlotEditor, SecretsDrawer, SpecEditor | intentional reset/adjust/mirror when a prop changes; SpecEditor's functional updater returns `prev` unchanged when there is nothing to do |
| command-prop consumption | BuilderChatPane | mirrors a one-shot pending-input prop into the controlled textarea |
| external-store read | ToolTemplatesModal | localStorage read deferred to client mount |

Each gets a scoped `eslint-disable-next-line` with the rationale inline. **No behaviour change.**

## Verification

- `npm run typecheck` — clean
- `npm run test` — 129/129 pass
- no unused-disable-directive warnings introduced

## Progress

This is the largest batch-2 slice. After this + the already-merged 2a (#107) and the open 2b (#108), only **3 `set-state-in-effect` sites remain** (ChatTabs, CredentialsEditor, useMediaQuery) — the final batch 2d will clear them and flip the rule back to `error`, closing #94.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>