### PR TITLE
fix(web-ui): finish set-state-in-effect cleanup, restore rule (#94 batch 2d)

### DIFF
--- a/web-ui/app/_components/ChatTabs.tsx
+++ b/web-ui/app/_components/ChatTabs.tsx
@@ -97,6 +97,9 @@ function Tab({
 
   useEffect(() => {
     if (editing) {
+      // Seed the rename draft from the current title when entering edit
+      // mode; the focus/select below needs the input mounted first.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setDraft(session.title);
       // `select()` after a microtask so the input is actually mounted and focused.
       queueMicrotask(() => {

--- a/web-ui/app/_components/store/CredentialsEditor.tsx
+++ b/web-ui/app/_components/store/CredentialsEditor.tsx
@@ -98,6 +98,9 @@ export function CredentialsEditor({
   }, [pluginId]);
 
   useEffect(() => {
+    // Fetch-on-mount: refreshKeys() touches state only after the awaited
+    // fetch — no synchronous cascading render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     void refreshKeys();
   }, [refreshKeys]);
 

--- a/web-ui/app/_lib/useMediaQuery.ts
+++ b/web-ui/app/_lib/useMediaQuery.ts
@@ -1,30 +1,37 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 
 /**
  * SSR-safe useMediaQuery hook. Returns `false` on the server (no
- * `window`) and during the first browser render so the markup matches —
- * then re-evaluates against the live `MediaQueryList` once mounted.
+ * `window`) and during hydration so the markup matches — then
+ * re-evaluates against the live `MediaQueryList` once mounted.
  *
- * Re-uses the `MediaQueryList.addEventListener('change', …)` API rather
- * than polling so subscriptions piggy-back on the browser's own layout-
- * boundary notifications. The `change` callback only fires when the
- * boolean *flips*, so this is cheap to mount in many components.
+ * Backed by `useSyncExternalStore`: the `MediaQueryList` `change` event is
+ * the subscription and `mql.matches` is the snapshot, so the boolean is
+ * read directly during render instead of being mirrored into an effect.
+ * The `change` callback only fires when the boolean *flips*, so this is
+ * cheap to mount in many components.
  */
 export function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState(false);
+  const subscribe = useCallback(
+    (onStoreChange: () => void): (() => void) => {
+      if (typeof window === 'undefined' || !window.matchMedia) {
+        return () => {};
+      }
+      const mql = window.matchMedia(query);
+      mql.addEventListener('change', onStoreChange);
+      return () => mql.removeEventListener('change', onStoreChange);
+    },
+    [query],
+  );
 
-  useEffect(() => {
-    if (typeof window === 'undefined' || !window.matchMedia) return;
-    const mql = window.matchMedia(query);
-    setMatches(mql.matches);
-    const listener = (ev: MediaQueryListEvent): void => setMatches(ev.matches);
-    mql.addEventListener('change', listener);
-    return () => mql.removeEventListener('change', listener);
+  const getSnapshot = useCallback((): boolean => {
+    if (typeof window === 'undefined' || !window.matchMedia) return false;
+    return window.matchMedia(query).matches;
   }, [query]);
 
-  return matches;
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
 }
 
 /**

--- a/web-ui/eslint.config.mjs
+++ b/web-ui/eslint.config.mjs
@@ -18,18 +18,6 @@ const eslintConfig = [
   },
   ...nextCoreWebVitals,
   ...nextTypescript,
-
-  // eslint-plugin-react-hooks v6 (shipped with eslint-config-next 16) added
-  // React-19-era strict rules. `refs`, `immutability` and `error-boundaries`
-  // were cleaned up in #94 and now run at their default `error` severity.
-  // `set-state-in-effect` still flags ~26 pre-existing call sites — many are
-  // legitimate "sync external state into React" patterns needing per-site
-  // judgement — so it stays `warn` until the follow-up batch lands (#94).
-  {
-    rules: {
-      'react-hooks/set-state-in-effect': 'warn',
-    },
-  },
 ];
 
 export default eslintConfig;


### PR DESCRIPTION
Final batch of #94. Clears the last 3 `set-state-in-effect` sites and removes the `warn` downgrade so the rule — and `eslint.config.mjs` as a whole — runs every `react-hooks/*` rule at its default `error` severity.

## Changes

| Site | Fix |
|---|---|
| `useMediaQuery` | **Rewritten on `useSyncExternalStore`** — the `MediaQueryList` `change` event is the subscription, `mql.matches` the snapshot; the boolean is read during render instead of mirrored into an effect. SSR snapshot stays `false`, so hydration is unchanged. The canonical media-query pattern — removes the effect entirely. |
| `ChatTabs` | Seeds the rename draft when entering edit mode; the focus/select genuinely needs the input mounted, so the effect stays. Scoped `eslint-disable` with rationale. |
| `CredentialsEditor` | Fetch-on-mount, state touched only post-await. Scoped `eslint-disable` with rationale. |

## Closes #94

All 26 `set-state-in-effect` sites are resolved across batches 2a–2d (#107, #108, #109, this); `refs` / `immutability` / `error-boundaries` were cleared in batch 1 (#106). `eslint.config.mjs` no longer downgrades any `react-hooks` rule.

## Verification

- `npm run lint` — **0 errors, 0 warnings** from all four `react-hooks` rules (total warnings 53 → 20; the remainder is `react-hooks/exhaustive-deps` + unrelated, out of #94 scope)
- `npm run typecheck` — clean
- `npm run test` — 129/129 pass

The `useMediaQuery` rewrite is behaviour-equivalent; an interactive smoke of the responsive 3-pane/single-pane layout switch needs the running stack and is not covered here.

## Test plan

- [ ] Resize across the 1280px breakpoint → layout still switches between 3-pane and single-pane
- [ ] Rename a chat tab → draft still seeds from the current title, input still focuses + selects

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>