### PR TITLE
feat(plugins): dynamic host allowlist for audit plugins (#91)

### DIFF
--- a/middleware/packages/agent-seo-analyst/fetcher.ts
+++ b/middleware/packages/agent-seo-analyst/fetcher.ts
@@ -1,3 +1,5 @@
+import type { HttpAccessor } from '@omadia/plugin-api';
+
 export interface FetchResult {
   url: string;
   finalUrl: string;
@@ -7,20 +9,35 @@ export interface FetchResult {
   bytes: number;
   contentType: string | null;
   redirected: boolean;
+  /** #91 — set when ctx.http refused the host (manifest allow-list or the
+   *  SSRF guard). Carries the permission-error message; `status` stays 0
+   *  so existing callers keep treating it as a failed fetch, while
+   *  honesty-aware callers can surface the precise reason. */
+  blocked?: string;
 }
 
 export interface FetcherOptions {
   userAgent: string;
   timeoutMs: number;
   log: (...args: unknown[]) => void;
+  /** #91 — the per-plugin ctx.http accessor. Every outbound request goes
+   *  through it so the manifest allow-list and the operator-selected
+   *  audit mode are enforced (no raw global `fetch`). */
+  http: HttpAccessor;
 }
+
+/** Error names thrown by ctx.http when a host is not permitted. */
+const PERMISSION_ERROR_NAMES = new Set([
+  'HttpForbiddenError',
+  'HttpBlockedAddressError',
+]);
 
 export function createFetcher(opts: FetcherOptions) {
   async function get(url: string, acceptHtml = true): Promise<FetchResult> {
     const ctrl = new AbortController();
     const t = setTimeout(() => ctrl.abort(), opts.timeoutMs);
     try {
-      const res = await fetch(url, {
+      const res = await opts.http.fetch(url, {
         method: 'GET',
         redirect: 'follow',
         signal: ctrl.signal,
@@ -47,7 +64,18 @@ export function createFetcher(opts: FetcherOptions) {
         redirected: res.redirected,
       };
     } catch (err) {
-      opts.log('fetch error', { url, err: String(err) });
+      // #91 — a permission rejection from ctx.http is a distinct outcome
+      // from a network failure: surface its message so callers never
+      // silently substitute a different URL than the one requested.
+      const blocked =
+        err instanceof Error && PERMISSION_ERROR_NAMES.has(err.name)
+          ? err.message
+          : undefined;
+      opts.log('fetch error', {
+        url,
+        err: String(err),
+        blocked: blocked !== undefined,
+      });
       return {
         url,
         finalUrl: url,
@@ -57,6 +85,7 @@ export function createFetcher(opts: FetcherOptions) {
         bytes: 0,
         contentType: null,
         redirected: false,
+        ...(blocked !== undefined ? { blocked } : {}),
       };
     } finally {
       clearTimeout(t);

--- a/middleware/packages/agent-seo-analyst/plugin.ts
+++ b/middleware/packages/agent-seo-analyst/plugin.ts
@@ -16,7 +16,18 @@ export interface AgentHandle {
 }
 
 export async function activate(ctx: PluginContext): Promise<AgentHandle> {
-  ctx.log('activating');
+  // #91 — all outbound traffic must go through ctx.http so the manifest
+  // allow-list + audit mode are enforced. Without it the plugin cannot run.
+  if (!ctx.http) {
+    throw new Error(
+      'seo-analyst: ctx.http is unavailable — the manifest must declare ' +
+        'permissions.network.outbound so the kernel provisions the HTTP accessor.',
+    );
+  }
+  // #91 — operator-selected audit mode. Surfaced in the blocked-host error
+  // path so the agent never silently substitutes a different URL.
+  const auditMode = ctx.config.get<string>('audit_mode') ?? 'single-host';
+  ctx.log('activating', { auditMode });
 
   const targetBaseUrl = ctx.config.get<string>('target_base_url') ?? DEFAULT_BASE_URL;
   const userAgent = ctx.config.get<string>('user_agent') ?? DEFAULT_USER_AGENT;
@@ -28,11 +39,16 @@ export async function activate(ctx: PluginContext): Promise<AgentHandle> {
     userAgent,
     timeoutMs,
     log: ctx.log,
+    http: ctx.http,
   });
 
   // Self-Test: is the target URL reachable? HEAD would suffice, but many
   // websites answer HEAD with 405. So GET with a short timeout.
   const ping = await fetcher.get(targetBaseUrl, true);
+  if (ping.blocked !== undefined) {
+    ctx.log('self-test blocked', { targetBaseUrl, auditMode });
+    throw new Error(`seo-analyst: ${ping.blocked}`);
+  }
   if (ping.status === 0) {
     ctx.log('self-test failed', { targetBaseUrl });
     throw new Error(`seo-analyst: Ziel-URL nicht erreichbar (${targetBaseUrl})`);
@@ -45,6 +61,7 @@ export async function activate(ctx: PluginContext): Promise<AgentHandle> {
     userAgent,
     crawlMaxPages,
     crawlMaxDepth,
+    auditMode,
     log: ctx.log,
   });
 

--- a/middleware/packages/agent-seo-analyst/toolkit.ts
+++ b/middleware/packages/agent-seo-analyst/toolkit.ts
@@ -30,6 +30,9 @@ export interface ToolkitOptions {
   userAgent: string;
   crawlMaxPages: number;
   crawlMaxDepth: number;
+  /** #91 — operator-selected audit mode, woven into the blocked-host error
+   *  message so the agent reports honestly instead of substituting a URL. */
+  auditMode: string;
   log: (...args: unknown[]) => void;
 }
 
@@ -58,6 +61,13 @@ export function createToolkit(opts: ToolkitOptions): Toolkit {
         const { url } = analyzePageInput.parse(raw);
         opts.log('tool:analyze_page', { url });
         const res = await opts.fetcher.get(url, true);
+        if (res.blocked !== undefined) {
+          throw new Error(
+            `${res.blocked} (audit mode: ${opts.auditMode}). The requested ` +
+              'URL was NOT analysed — ask the operator to widen the audit ' +
+              'mode or add the host to the allow-list.',
+          );
+        }
         if (res.status === 0) {
           throw new Error(`fetch failed for ${url}`);
         }

--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -40,7 +40,10 @@ export type SetupFieldType =
   | 'oauth'
   | 'enum'
   | 'boolean'
-  | 'integer';
+  | 'integer'
+  /** #91: operator-curated list of bare hostnames. Values are unioned into
+   *  the plugin's effective `ctx.http` allowlist at runtime (Option B). */
+  | 'host_list';
 
 export interface PluginSetupField {
   key: string;
@@ -50,8 +53,9 @@ export interface PluginSetupField {
    *  editor so the operator sees the same hint as in the install wizard. */
   help?: string;
   /** Manifest default. Forwarded so the post-install editor can pre-select
-   *  the default option in an `enum` dropdown when no value is stored yet. */
-  default?: string;
+   *  the default option in an `enum` dropdown when no value is stored yet.
+   *  A `string[]` for `type === 'host_list'`, a `string` otherwise. */
+  default?: string | string[];
   /** Allowed values for `type === 'enum'`. Mirrors the install-wizard
    *  schema so the post-install editor can render a `<select>` instead of
    *  a free-text input. */
@@ -64,6 +68,13 @@ export interface PluginPermissionsSummary {
   graph_reads: EntityURI[];
   graph_writes: EntityURI[];
   network_outbound: string[];
+  /** #91: when true the plugin is an audit/scanner — its `ctx.http` may
+   *  contact arbitrary public hosts at runtime (target URLs are supplied
+   *  by the end user and unknown at build time). The runtime egress filter
+   *  still hard-blocks private IP ranges and cloud-metadata endpoints, and
+   *  the operator must confirm at install time. Optional; the loader
+   *  defaults to `false`. */
+  network_web_scanner?: boolean;
   /** OB-29-1: agentId whitelist this plugin may call via `ctx.subAgent.ask`.
    *  Wildcards allowed (`'de.byte5.agent.*'`). Optional to keep legacy
    *  fixtures buildable; the loader always populates with `[]` when the

--- a/middleware/src/platform/httpAccessor.ts
+++ b/middleware/src/platform/httpAccessor.ts
@@ -1,33 +1,85 @@
+import { isIP } from 'node:net';
+
 import {
   HttpForbiddenError,
   HttpRateLimitError,
   type HttpAccessor,
 } from '@omadia/plugin-api';
 
+import {
+  HttpBlockedAddressError,
+  createGuardedAgent,
+  isPublicIp,
+} from './ssrfGuard.js';
+
 /**
- * Per-plugin HTTP accessor. Built from the manifest's outbound allow-list.
- * Enforces:
- *   - Hostname whitelist with leading-wildcard support (`*.example.com`).
- *   - Per-minute rolling rate limit via a simple token bucket.
+ * Per-plugin HTTP accessor. Enforces:
+ *   - An effective outbound allow-list resolved from the manifest plus the
+ *     operator-selected audit mode (#91).
+ *   - A per-minute rolling rate limit via a simple token bucket.
+ *   - http(s) only — other URL schemes are rejected.
  *
- * Returns `undefined` (at the caller seam) when the manifest declares no
- * outbound hosts — in that case `ctx.http` is left unset and plugins that
- * try `ctx.http!.fetch(...)` get a runtime error at the language level
- * rather than a silent network call.
+ * #91 audit modes (only honoured when the manifest declares
+ * `permissions.network.web_scanner`):
+ *   - `single-host`  — manifest `network.outbound[]` only (the default; also
+ *                      the forced mode for every non-web_scanner plugin).
+ *   - `allowlist`    — manifest hosts ∪ operator-curated `host_list` hosts.
+ *   - `public-web`   — any public host; the SSRF guard (see ssrfGuard.ts)
+ *                      hard-blocks private / loopback / link-local / metadata
+ *                      addresses at connect time.
+ *
+ * Returns `undefined` (at the caller seam) when the plugin declares neither
+ * outbound hosts nor `web_scanner` — in that case `ctx.http` is left unset.
  */
 
 const DEFAULT_RATE_LIMIT_PER_MINUTE = 60;
 
+export type AuditMode = 'single-host' | 'allowlist' | 'public-web';
+
+export function isAuditMode(value: unknown): value is AuditMode {
+  return (
+    value === 'single-host' ||
+    value === 'allowlist' ||
+    value === 'public-web'
+  );
+}
+
 export function createHttpAccessor(opts: {
   agentId: string;
   outbound: readonly string[];
+  /** #91 — true iff the manifest declares `permissions.network.web_scanner`.
+   *  A non-web_scanner plugin is always confined to `single-host`. */
+  webScanner?: boolean;
+  /** #91 — operator-selected audit mode. Honoured only when `webScanner`. */
+  auditMode?: AuditMode;
+  /** #91 — operator-curated extra hosts (from `host_list` setup fields).
+   *  Unioned into the effective allow-list only in `allowlist` mode. */
+  extraHosts?: readonly string[];
   /** Override the default 60 req/min cap. Tests only — not wired to manifest yet. */
   rateLimitPerMinute?: number;
 }): HttpAccessor {
   const { agentId, outbound } = opts;
   const limit = opts.rateLimitPerMinute ?? DEFAULT_RATE_LIMIT_PER_MINUTE;
-  const matchers = outbound.map(buildHostMatcher);
+
+  // A non-web_scanner plugin is always confined to its manifest allow-list,
+  // whatever an `audit_mode` config entry might say.
+  const mode: AuditMode = opts.webScanner
+    ? (opts.auditMode ?? 'single-host')
+    : 'single-host';
+
+  // Effective static allow-list: manifest outbound, plus operator-curated
+  // extras only in `allowlist` mode.
+  const staticHosts =
+    mode === 'allowlist'
+      ? [...outbound, ...(opts.extraHosts ?? [])]
+      : [...outbound];
+  const matchers = staticHosts.map(buildHostMatcher);
+
   const bucket = new TokenBucket(limit, 60_000);
+
+  // The rebinding-safe dispatcher is built once and reused. Only public-web
+  // mode needs it — the static-allow-list modes trust the named hosts.
+  const guardedAgent = mode === 'public-web' ? createGuardedAgent() : undefined;
 
   return {
     async fetch(url: string, init?: RequestInit): Promise<Response> {
@@ -35,12 +87,44 @@ export function createHttpAccessor(opts: {
       if (!parsed) {
         throw new TypeError(`ctx.http: invalid URL '${url}'`);
       }
-      const host = parsed.hostname.toLowerCase();
-      if (!matchers.some((m) => m(host))) {
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        throw new HttpBlockedAddressError(
+          agentId,
+          parsed.protocol,
+          'only http and https URLs are permitted via ctx.http',
+        );
+      }
+      // `URL.hostname` brackets IPv6 literals (`[::1]`); strip them so the
+      // host is a bare address for matching and SSRF classification.
+      const rawHost = parsed.hostname.toLowerCase();
+      const host =
+        rawHost.startsWith('[') && rawHost.endsWith(']')
+          ? rawHost.slice(1, -1)
+          : rawHost;
+
+      if (mode === 'public-web') {
+        // Any public host is permitted; the guarded dispatcher enforces the
+        // private-range blocklist at connect time. A literal-IP host never
+        // triggers DNS, so reject non-public literal IPs here, up front.
+        if (isIP(host) !== 0 && !isPublicIp(host)) {
+          throw new HttpBlockedAddressError(
+            agentId,
+            host,
+            'is a private, loopback, link-local or otherwise non-public address',
+          );
+        }
+      } else if (!matchers.some((m) => m(host))) {
         throw new HttpForbiddenError(agentId, host);
       }
+
       if (!bucket.tryConsume()) {
         throw new HttpRateLimitError(agentId);
+      }
+
+      if (guardedAgent) {
+        // Node's global fetch (undici) honours `dispatcher`; the DOM
+        // RequestInit type does not declare it, hence the cast.
+        return fetch(url, { ...init, dispatcher: guardedAgent } as RequestInit);
       }
       return fetch(url, init);
     },

--- a/middleware/src/platform/pluginContext.ts
+++ b/middleware/src/platform/pluginContext.ts
@@ -50,7 +50,7 @@ import type { NativeToolRegistry } from '@omadia/orchestrator';
 import type { PluginRouteRegistry } from './pluginRouteRegistry.js';
 import type { NotificationRouter } from './notificationRouter.js';
 import type { UiRouteCatalog } from './uiRouteCatalog.js';
-import { createHttpAccessor } from './httpAccessor.js';
+import { createHttpAccessor, isAuditMode, type AuditMode } from './httpAccessor.js';
 import { createMemoryAccessor } from './memoryAccessor.js';
 import { SCRATCH_DIR } from './paths.js';
 import type { ServiceRegistry } from './serviceRegistry.js';
@@ -196,16 +196,28 @@ export function createPluginContext(
     ? createScratchAccessor(agentId)
     : undefined;
 
-  // HTTP accessor: gated on `manifest.permissions.network.outbound` being
-  // non-empty. When absent, ctx.http is undefined and plugins that didn't
-  // declare network access can't make outbound calls via the accessor.
-  // Today the global `fetch` is still reachable — future hardening will
-  // sandbox that. Plugins should use ctx.http exclusively to stay
-  // forward-compatible.
+  // HTTP accessor: present when the manifest declares outbound hosts OR the
+  // plugin is a #91 web_scanner (audit/scanner plugins fetch user-supplied
+  // URLs and may declare no static hosts at all). The effective allow-list
+  // is resolved from the manifest plus the operator-selected audit mode +
+  // host_list config. Today the global `fetch` is still reachable — a future
+  // hardening pass will sandbox it; plugins should use ctx.http exclusively.
   const outboundHosts = extractOutboundAllowlist(agentId, catalog);
+  const webScanner =
+    catalog.get(agentId)?.plugin.permissions_summary.network_web_scanner ===
+    true;
+  const auditConfig = extractAuditConfig(agentId, catalog, registry);
   const http: HttpAccessor | undefined =
-    outboundHosts.length > 0
-      ? createHttpAccessor({ agentId, outbound: outboundHosts })
+    outboundHosts.length > 0 || webScanner
+      ? createHttpAccessor({
+          agentId,
+          outbound: outboundHosts,
+          webScanner,
+          extraHosts: auditConfig.extraHosts,
+          ...(auditConfig.auditMode
+            ? { auditMode: auditConfig.auditMode }
+            : {}),
+        })
       : undefined;
 
   // Memory accessor: present when the manifest declares memory permissions
@@ -729,6 +741,36 @@ function extractOutboundAllowlist(
   const outbound = network?.['outbound'];
   if (!Array.isArray(outbound)) return [];
   return outbound.filter((h): h is string => typeof h === 'string');
+}
+
+/**
+ * #91 — resolve the operator-set audit config for a plugin: the selected
+ * `audit_mode` and the union of every `host_list` setup field's value. Both
+ * live in the plugin's own InstalledRegistry config (written by the admin
+ * mode-switch UI); unset or malformed entries are simply ignored, so a
+ * fresh install defaults to `single-host` with no extra hosts.
+ */
+function extractAuditConfig(
+  agentId: string,
+  catalog: PluginCatalog,
+  registry: InstalledRegistry,
+): { auditMode?: AuditMode; extraHosts: string[] } {
+  const config = registry.get(agentId)?.config ?? {};
+  const extraHosts: string[] = [];
+  const fields = catalog.get(agentId)?.plugin.required_secrets ?? [];
+  for (const field of fields) {
+    if (field.type !== 'host_list') continue;
+    const value = config[field.key];
+    if (!Array.isArray(value)) continue;
+    for (const host of value) {
+      if (typeof host === 'string' && host.length > 0) extraHosts.push(host);
+    }
+  }
+  const rawMode = config['audit_mode'];
+  return {
+    ...(isAuditMode(rawMode) ? { auditMode: rawMode } : {}),
+    extraHosts,
+  };
 }
 
 function scratchEnabled(agentId: string, catalog: PluginCatalog): boolean {

--- a/middleware/src/platform/ssrfGuard.ts
+++ b/middleware/src/platform/ssrfGuard.ts
@@ -1,0 +1,181 @@
+import { lookup as dnsLookup } from 'node:dns';
+import { isIP } from 'node:net';
+import { Agent } from 'undici';
+
+/**
+ * SSRF guard for #91 — protects audit/scanner plugins running in
+ * `public-web` mode, where `ctx.http` may reach arbitrary user-supplied
+ * hosts.
+ *
+ * A hostname allow-check alone is not enough: a public hostname can resolve
+ * to a private address (DNS rebinding). The defence has two layers:
+ *
+ *   1. A literal-IP pre-check in the accessor — `http://10.0.0.5/` never
+ *      triggers DNS, so the accessor rejects non-public literal IPs up front.
+ *   2. `createGuardedAgent()` — an undici dispatcher whose custom `lookup`
+ *      resolves the hostname, rejects the connection if ANY resolved address
+ *      is non-public, and hands undici exactly the validated address. undici
+ *      then connects to that address, so a rebind between validation and
+ *      connect cannot happen.
+ */
+
+export class HttpBlockedAddressError extends Error {
+  constructor(agentId: string, host: string, reason: string) {
+    super(`plugin '${agentId}' is not permitted to reach '${host}' — ${reason}`);
+    this.name = 'HttpBlockedAddressError';
+  }
+}
+
+/**
+ * True iff `ip` is a literal, globally-routable public address. Loopback,
+ * private, link-local, ULA, CGNAT, multicast, reserved and unspecified
+ * ranges return false. A string that is not a literal IP returns false.
+ */
+export function isPublicIp(ip: string): boolean {
+  const kind = isIP(ip);
+  if (kind === 4) {
+    const v4 = parseIpv4(ip);
+    return v4 !== null && isPublicIpv4(v4);
+  }
+  if (kind === 6) {
+    const bytes = parseIpv6(ip);
+    return bytes !== null && isPublicIpv6(bytes);
+  }
+  return false;
+}
+
+function isPublicIpv4(o: readonly [number, number, number, number]): boolean {
+  const [a, b] = o;
+  if (a === 0) return false; // 0.0.0.0/8 — "this network"
+  if (a === 10) return false; // 10.0.0.0/8 — private
+  if (a === 127) return false; // 127.0.0.0/8 — loopback
+  if (a === 169 && b === 254) return false; // 169.254.0.0/16 — link-local + cloud metadata
+  if (a === 172 && b >= 16 && b <= 31) return false; // 172.16.0.0/12 — private
+  if (a === 192 && b === 168) return false; // 192.168.0.0/16 — private
+  if (a === 192 && b === 0 && o[2] === 0) return false; // 192.0.0.0/24 — IETF protocol
+  if (a === 100 && b >= 64 && b <= 127) return false; // 100.64.0.0/10 — CGNAT
+  if (a === 198 && (b === 18 || b === 19)) return false; // 198.18.0.0/15 — benchmarking
+  if (a >= 224) return false; // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved + broadcast
+  return true;
+}
+
+function isPublicIpv6(b: Uint8Array): boolean {
+  // IPv4-mapped (::ffff:a.b.c.d) — classify the embedded IPv4.
+  if (isAllZero(b, 0, 10) && b[10] === 0xff && b[11] === 0xff) {
+    return isPublicIpv4([b[12]!, b[13]!, b[14]!, b[15]!]);
+  }
+  if (isAllZero(b, 0, 16)) return false; // :: — unspecified
+  if (isAllZero(b, 0, 15) && b[15] === 1) return false; // ::1 — loopback
+  if (b[0] === 0xfe && (b[1]! & 0xc0) === 0x80) return false; // fe80::/10 — link-local
+  if ((b[0]! & 0xfe) === 0xfc) return false; // fc00::/7 — unique-local
+  if (b[0] === 0xff) return false; // ff00::/8 — multicast
+  return true;
+}
+
+function isAllZero(b: Uint8Array, from: number, to: number): boolean {
+  for (let i = from; i < to; i++) {
+    if (b[i] !== 0) return false;
+  }
+  return true;
+}
+
+function parseIpv4(ip: string): [number, number, number, number] | null {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+  const out: number[] = [];
+  for (const p of parts) {
+    if (!/^\d{1,3}$/.test(p)) return null;
+    const n = Number(p);
+    if (n > 255) return null;
+    out.push(n);
+  }
+  return [out[0]!, out[1]!, out[2]!, out[3]!];
+}
+
+/**
+ * Parse a literal IPv6 address into its 16 bytes. Handles `::` compression,
+ * an embedded IPv4 tail (`::ffff:1.2.3.4`) and a zone id (`fe80::1%eth0`).
+ * Returns null on anything malformed. Callers should pass strings already
+ * confirmed as IPv6 by `node:net.isIP`.
+ */
+function parseIpv6(ip: string): Uint8Array | null {
+  const zone = ip.indexOf('%');
+  let s = zone >= 0 ? ip.slice(0, zone) : ip;
+
+  // Rewrite an embedded IPv4 tail into two hex groups.
+  const lastColon = s.lastIndexOf(':');
+  const tail = s.slice(lastColon + 1);
+  if (tail.includes('.')) {
+    const v4 = parseIpv4(tail);
+    if (v4 === null) return null;
+    const hi = ((v4[0] << 8) | v4[1]).toString(16);
+    const lo = ((v4[2] << 8) | v4[3]).toString(16);
+    s = `${s.slice(0, lastColon + 1)}${hi}:${lo}`;
+  }
+
+  const halves = s.split('::');
+  if (halves.length > 2) return null;
+  const head = halves[0] ? halves[0].split(':') : [];
+  let groups: string[];
+  if (halves.length === 2) {
+    const rear = halves[1] ? halves[1].split(':') : [];
+    const missing = 8 - head.length - rear.length;
+    if (missing < 0) return null;
+    groups = [...head, ...new Array<string>(missing).fill('0'), ...rear];
+  } else {
+    groups = head;
+  }
+  if (groups.length !== 8) return null;
+
+  const bytes = new Uint8Array(16);
+  for (let i = 0; i < 8; i++) {
+    const g = groups[i]!;
+    if (!/^[0-9a-fA-F]{1,4}$/.test(g)) return null;
+    const v = Number.parseInt(g, 16);
+    bytes[i * 2] = (v >> 8) & 0xff;
+    bytes[i * 2 + 1] = v & 0xff;
+  }
+  return bytes;
+}
+
+/**
+ * An undici dispatcher whose connect step refuses any hostname that resolves
+ * to a non-public address. Pass it as the `dispatcher` of a `fetch` call.
+ * Used only in `public-web` audit mode — the static-allow-list modes trust
+ * the operator/manifest to have named their hosts deliberately.
+ */
+export function createGuardedAgent(): Agent {
+  return new Agent({
+    connect: {
+      lookup(hostname, options, callback) {
+        dnsLookup(hostname, { all: true, verbatim: true }, (err, addresses) => {
+          if (err) {
+            callback(err, '', 0);
+            return;
+          }
+          if (addresses.length === 0) {
+            callback(new Error(`no address for '${hostname}'`), '', 0);
+            return;
+          }
+          for (const a of addresses) {
+            if (!isPublicIp(a.address)) {
+              callback(
+                new Error(
+                  `SSRF guard: '${hostname}' resolves to non-public address ${a.address}`,
+                ),
+                '',
+                0,
+              );
+              return;
+            }
+          }
+          if (options.all === true) {
+            callback(null, addresses);
+          } else {
+            callback(null, addresses[0]!.address, addresses[0]!.family);
+          }
+        });
+      },
+    },
+  });
+}

--- a/middleware/src/plugins/builder/agentSpec.ts
+++ b/middleware/src/plugins/builder/agentSpec.ts
@@ -110,7 +110,16 @@ export type TestCase = z.infer<typeof TestCaseSchema>;
 const SetupFieldSchema = z
   .object({
     key: z.string().regex(/^[a-z][a-z0-9_]*$/),
-    type: z.enum(['string', 'url', 'secret', 'oauth', 'enum', 'boolean', 'integer']),
+    type: z.enum([
+      'string',
+      'url',
+      'secret',
+      'oauth',
+      'enum',
+      'boolean',
+      'integer',
+      'host_list',
+    ]),
     required: z.boolean().optional(),
     description: z.string().optional(),
     default: z.unknown().optional(),
@@ -476,6 +485,10 @@ export const AgentSpecSchema = z
     network: z
       .object({
         outbound: z.array(z.string()).default([]),
+        // #91 — audit/scanner capability. When true the runtime egress
+        // filter may widen the allow-list per the operator-selected
+        // audit_mode; codegen emits it as permissions.network.web_scanner.
+        web_scanner: z.boolean().optional(),
       })
       .strict()
       .default({ outbound: [] }),

--- a/middleware/src/plugins/builder/codegen.ts
+++ b/middleware/src/plugins/builder/codegen.ts
@@ -475,6 +475,24 @@ function reproduceManifestCapabilities(
     }
   }
 
+  // #91 — web_scanner lives on spec.network (not spec.permissions); emit it
+  // as permissions.network.web_scanner so the runtime egress filter can
+  // widen the allow-list for this audit/scanner plugin.
+  if (spec.network.web_scanner === true) {
+    const permsNode = doc.get('permissions', true);
+    if (yaml.isMap(permsNode)) {
+      const netNode = permsNode.get('network', true);
+      if (yaml.isMap(netNode)) {
+        netNode.set('web_scanner', true);
+      } else {
+        permsNode.set(
+          'network',
+          doc.createNode({ outbound: [], web_scanner: true }),
+        );
+      }
+    }
+  }
+
   const capsNode = doc.get('capabilities', true);
   if (!yaml.isSeq(capsNode) || capsNode.items.length === 0) {
     return doc.toString();

--- a/middleware/src/plugins/builder/manifestLinter.ts
+++ b/middleware/src/plugins/builder/manifestLinter.ts
@@ -165,20 +165,24 @@ export function validateSpec(
   const outbound = Array.isArray(network?.outbound) ? network.outbound : [];
   outbound.forEach((host, i) => {
     if (typeof host !== 'string') return;
+    // #91 — a leading `*.` subdomain wildcard is permitted (the runtime
+    // egress matcher supports it); strip it before the bare-host check.
+    // Any other `*` remains invalid.
+    const bare = host.startsWith('*.') ? host.slice(2) : host;
     const invalid =
       host.length === 0 ||
       host.includes('://') ||
-      host.includes('*') ||
       host.includes('/') ||
-      !HOST_RE.test(host);
+      bare.includes('*') ||
+      !HOST_RE.test(bare);
     if (invalid) {
       violations.push({
         kind: 'network_outbound_invalid',
         path: `/network/outbound/${String(i)}`,
         message:
           `network.outbound[${String(i)}] '${host}' must be a bare hostname ` +
-          `(no protocol, no wildcards, no path; must contain a TLD). ` +
-          `E.g. 'api.example.com'.`,
+          `or a leading-wildcard host (no protocol, no path; must contain a ` +
+          `TLD). E.g. 'api.example.com' or '*.example.com'.`,
       });
     }
   });

--- a/middleware/src/plugins/builder/prompts/builder-system.md
+++ b/middleware/src/plugins/builder/prompts/builder-system.md
@@ -525,7 +525,20 @@ if (ctx.http) {
 
 **Wann nutzen:** statt globalem `fetch`. Globales fetch wird in einer
 zukünftigen Härtung blockiert; `ctx.http` ist der zukunftssichere Pfad.
-**Voraussetzung:** mindestens ein Host in `spec.network.outbound`.
+**Voraussetzung:** mindestens ein Host in `spec.network.outbound` ODER
+`spec.network.web_scanner: true`.
+
+**Audit-/Scanner-Plugins** (URL-Auditor, Link-Checker, Web-Research) deren
+Ziel-Hosts erst zur Laufzeit aus User-Input kommen und beim Build NICHT
+bekannt sind: setz `spec.network.web_scanner: true`. Der Operator wählt
+dann im Admin-UI den `audit_mode` (`single-host` | `allowlist` |
+`public-web`). In `public-web` darf das Plugin beliebige öffentliche Hosts
+erreichen — private Netzbereiche und Cloud-Metadata-Endpoints bleiben hart
+geblockt (SSRF-Guard). Für eine operator-kuratierte Zusatz-Hostliste: ein
+`setup_field` vom Typ `host_list`. Das Plugin liest den aktiven Modus über
+`ctx.config.get<string>('audit_mode')` und darf eine vom User angefragte
+URL **nie still durch einen Default-Host ersetzen** — wird ein Host
+geblockt, ehrlich melden statt eine andere URL zu auditieren.
 
 ### `ctx.subAgent` — Delegation an andere Agents
 
@@ -708,9 +721,12 @@ generierten Code/Spec automatisch und kann mit `ok: false` antworten:
       vorher installieren.
     - `tool_id_invalid_syntax`: Tool-IDs müssen `snake_case` sein
       (`get_forecast`, NICHT `getForecast` oder `get-forecast`).
-    - `network_outbound_invalid`: Bare hostnames ohne Protokoll und
-      Wildcards (`api.example.com`, NICHT `https://api.example.com` oder
-      `*.example.com`).
+    - `network_outbound_invalid`: Bare hostnames ohne Protokoll/Pfad
+      (`api.example.com`). Ein führender Subdomain-Wildcard ist erlaubt
+      (`*.example.com`); andere Wildcard-Positionen NICHT (`api.*.com`).
+      `https://api.example.com` ist ungültig (kein Protokoll). Für
+      Audit-Plugins mit unbekannten Ziel-Hosts: kein Wildcard-Stuffing —
+      `spec.network.web_scanner: true` setzen.
 
 **Retry-Limit**: maximal **3 Re-Tries pro Slot pro Turn**. Wenn nach 3
 Versuchen `fill_slot` für denselben `slotKey` immer noch ok=false

--- a/middleware/src/plugins/installService.ts
+++ b/middleware/src/plugins/installService.ts
@@ -618,6 +618,45 @@ function coerce(field: InstallSetupField, raw: unknown): CoerceResult {
       }
       return { value: raw };
     }
+    case 'host_list': {
+      // #91 Option B — operator-curated list of bare hostnames. Unioned
+      // into the plugin's effective ctx.http allowlist at runtime. Stored
+      // as config (non-secret). Entries are normalised (trim + lowercase);
+      // protocol prefixes and paths are rejected. A subdomain wildcard
+      // (`*.example.com`) is permitted — the egress matcher supports it.
+      if (raw === undefined || raw === null) return { value: [] };
+      if (!Array.isArray(raw)) {
+        return {
+          error: {
+            code: 'wrong_type',
+            message: `"${field.label}" muss eine Liste von Hostnamen sein.`,
+          },
+        };
+      }
+      const hosts: string[] = [];
+      for (const h of raw) {
+        if (typeof h !== 'string') {
+          return {
+            error: {
+              code: 'wrong_type',
+              message: `"${field.label}" darf nur Text-Hostnamen enthalten.`,
+            },
+          };
+        }
+        const host = h.trim().toLowerCase();
+        if (host.length === 0) continue;
+        if (host.includes('://') || host.includes('/') || /\s/.test(host)) {
+          return {
+            error: {
+              code: 'invalid_host',
+              message: `"${host}" ist kein gültiger Hostname (kein Protokoll, kein Pfad).`,
+            },
+          };
+        }
+        hosts.push(host);
+      }
+      return { value: hosts };
+    }
     case 'oauth':
       return {
         error: {
@@ -662,6 +701,7 @@ const SUPPORTED_TYPES = new Set<string>([
   'enum',
   'boolean',
   'integer',
+  'host_list',
 ]);
 
 function isSupportedType(t: string): t is InstallSetupField['type'] {

--- a/middleware/src/plugins/manifestLoader.ts
+++ b/middleware/src/plugins/manifestLoader.ts
@@ -189,8 +189,19 @@ function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
     const entry: PluginSetupField = { key, label, type };
     const help = asString(f['help']);
     if (help) entry.help = help;
-    const defaultValue = asString(f['default']);
-    if (defaultValue !== undefined) entry.default = defaultValue;
+    if (type === 'host_list') {
+      // #91 Option B — the default for a host_list is an array of bare
+      // hostnames, not a scalar string.
+      const rawDefault = f['default'];
+      if (Array.isArray(rawDefault)) {
+        entry.default = rawDefault.filter(
+          (h): h is string => typeof h === 'string',
+        );
+      }
+    } else {
+      const defaultValue = asString(f['default']);
+      if (defaultValue !== undefined) entry.default = defaultValue;
+    }
     if (type === 'enum') {
       const enumRaw = f['enum'];
       if (Array.isArray(enumRaw)) {
@@ -502,6 +513,7 @@ function extractPermissions(
     graph_reads: extractStringArray(graph?.['reads']),
     graph_writes: extractStringArray(graph?.['writes']),
     network_outbound: extractStringArray(network?.['outbound']),
+    network_web_scanner: network?.['web_scanner'] === true,
     sub_agents_calls: extractStringArray(subAgents?.['calls']),
     sub_agents_calls_per_invocation: parsedBudget,
     graph_entity_systems: entitySystems,
@@ -587,6 +599,7 @@ function isSetupFieldType(value: string): value is PluginSetupField['type'] {
     value === 'oauth' ||
     value === 'enum' ||
     value === 'boolean' ||
-    value === 'integer'
+    value === 'integer' ||
+    value === 'host_list'
   );
 }

--- a/middleware/src/routes/runtime.ts
+++ b/middleware/src/routes/runtime.ts
@@ -6,6 +6,7 @@ import type { ChatAgentWrapIntrospection } from '../platform/chatAgentWrapRegist
 import type { PromptContributionRegistry } from '../platform/promptContributionRegistry.js';
 import type { ServiceRegistry } from '../platform/serviceRegistry.js';
 import type { TurnHookRegistry } from '../platform/turnHookRegistry.js';
+import { isAuditMode } from '../platform/httpAccessor.js';
 import { extractSetupSchema } from '../plugins/installService.js';
 import type { InstalledRegistry } from '../plugins/installedRegistry.js';
 import type { PluginCatalog } from '../plugins/manifestLoader.js';
@@ -120,6 +121,68 @@ export function createRuntimeRouter(deps: RuntimeDeps): Router {
         res
           .status(500)
           .json({ code: 'runtime.update_failed', message });
+      }
+    },
+  );
+
+  // PATCH /installed/:id/audit-mode — #91 operator mode switch for an
+  // audit/scanner plugin. Body: { mode: 'single-host'|'allowlist'|'public-web' }.
+  // Rejected unless the manifest declares permissions.network.web_scanner.
+  // Merges `audit_mode` into the registry config (other keys untouched) and
+  // re-activates so the egress filter picks up the new mode.
+  router.patch(
+    '/installed/:id/audit-mode',
+    async (req: Request, res: Response) => {
+      const rawId = req.params['id'];
+      const id = typeof rawId === 'string' ? rawId : undefined;
+      if (!id) {
+        res
+          .status(400)
+          .json({ code: 'runtime.invalid_id', message: 'missing id' });
+        return;
+      }
+      const body = req.body as { mode?: unknown } | null;
+      const mode = body?.mode;
+      if (!isAuditMode(mode)) {
+        res.status(400).json({
+          code: 'runtime.invalid_audit_mode',
+          message:
+            "mode must be one of 'single-host', 'allowlist', 'public-web'",
+        });
+        return;
+      }
+      const installed = deps.installedRegistry.get(id);
+      if (!installed) {
+        res.status(404).json({
+          code: 'runtime.not_installed',
+          message: `agent '${id}' is not installed`,
+        });
+        return;
+      }
+      const isWebScanner =
+        deps.catalog?.get(id)?.plugin.permissions_summary.network_web_scanner ===
+        true;
+      if (!isWebScanner) {
+        res.status(400).json({
+          code: 'runtime.not_web_scanner',
+          message:
+            `agent '${id}' does not declare permissions.network.web_scanner — ` +
+            'audit_mode applies only to audit/scanner plugins',
+        });
+        return;
+      }
+      try {
+        await deps.installedRegistry.updateConfig(id, {
+          ...installed.config,
+          audit_mode: mode,
+        });
+        if (deps.reactivate) {
+          await deps.reactivate(id);
+        }
+        res.json({ id, audit_mode: mode });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        res.status(500).json({ code: 'runtime.update_failed', message });
       }
     },
   );

--- a/middleware/src/routes/runtime.ts
+++ b/middleware/src/routes/runtime.ts
@@ -160,8 +160,8 @@ export function createRuntimeRouter(deps: RuntimeDeps): Router {
         return;
       }
       const isWebScanner =
-        deps.catalog?.get(id)?.plugin.permissions_summary.network_web_scanner ===
-        true;
+        deps.catalog?.get(id)?.plugin.permissions_summary
+          ?.network_web_scanner === true;
       if (!isWebScanner) {
         res.status(400).json({
           code: 'runtime.not_web_scanner',

--- a/middleware/test/agentSeoAnalystFetcher.test.ts
+++ b/middleware/test/agentSeoAnalystFetcher.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import type { HttpAccessor } from '@omadia/plugin-api';
+
+import { createFetcher } from '../packages/agent-seo-analyst/fetcher.js';
+
+/**
+ * #91 — agent-seo-analyst routes every request through `ctx.http` (no raw
+ * global fetch) and surfaces a permission rejection as `FetchResult.blocked`
+ * so the toolkit can report honestly instead of silently substituting a URL.
+ */
+
+const noopLog = (): void => {};
+
+function fetcherWith(http: HttpAccessor): ReturnType<typeof createFetcher> {
+  return createFetcher({ userAgent: 'ua', timeoutMs: 5000, log: noopLog, http });
+}
+
+describe('agent-seo-analyst fetcher — #91 ctx.http migration', () => {
+  it('routes requests through ctx.http and returns a normal result', async () => {
+    const seen: string[] = [];
+    const fetcher = fetcherWith({
+      async fetch(url: string): Promise<Response> {
+        seen.push(url);
+        return new Response('<html><head><title>Hi</title></head></html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+        });
+      },
+    });
+    const res = await fetcher.get('https://omadia.ai/');
+    assert.deepEqual(seen, ['https://omadia.ai/']);
+    assert.equal(res.status, 200);
+    assert.equal(res.blocked, undefined);
+  });
+
+  it('surfaces a permission rejection as `blocked`', async () => {
+    const fetcher = fetcherWith({
+      async fetch(): Promise<Response> {
+        const err = new Error(
+          "plugin 'x' is not permitted to reach 'wikipedia.org'",
+        );
+        err.name = 'HttpForbiddenError';
+        throw err;
+      },
+    });
+    const res = await fetcher.get('https://wikipedia.org/');
+    assert.equal(res.status, 0);
+    assert.ok(res.blocked?.includes('not permitted to reach'));
+  });
+
+  it('treats a generic network error as a plain failure (no `blocked`)', async () => {
+    const fetcher = fetcherWith({
+      async fetch(): Promise<Response> {
+        throw new Error('ECONNRESET');
+      },
+    });
+    const res = await fetcher.get('https://omadia.ai/');
+    assert.equal(res.status, 0);
+    assert.equal(res.blocked, undefined);
+  });
+});

--- a/middleware/test/builder/agentSpec.test.ts
+++ b/middleware/test/builder/agentSpec.test.ts
@@ -60,6 +60,18 @@ describe('agentSpec', () => {
       assert.equal(spec.setup_fields[0]?.type, 'secret');
     });
 
+    it('accepts #91 network.web_scanner + host_list setup field', () => {
+      const spec = parseAgentSpec({
+        ...validBase,
+        network: { outbound: [], web_scanner: true },
+        setup_fields: [
+          { key: 'audit_hosts', type: 'host_list', required: false },
+        ],
+      });
+      assert.equal(spec.network.web_scanner, true);
+      assert.equal(spec.setup_fields[0]?.type, 'host_list');
+    });
+
     it('rejects an unknown template id', () => {
       assert.throws(() =>
         parseAgentSpec({ ...validBase, template: 'nonexistent-template' }),

--- a/middleware/test/builder/manifestLinter.test.ts
+++ b/middleware/test/builder/manifestLinter.test.ts
@@ -194,12 +194,26 @@ describe('manifestLinter.validateSpec — network.outbound checks', () => {
     assert.equal(result.violations[0]?.kind, 'network_outbound_invalid');
   });
 
-  it('rejects wildcards', () => {
+  it('accepts a leading-wildcard subdomain host (#91)', () => {
     const result = validateSpec(
       { ...validSpec, network: { outbound: ['*.example.com'] } },
       { knownPluginIds: knownPlugins },
     );
-    assert.equal(result.violations[0]?.kind, 'network_outbound_invalid');
+    assert.equal(result.ok, true);
+  });
+
+  it('rejects non-leading wildcards', () => {
+    for (const host of ['api.*.example.com', '*example.com', 'a.*.b.com']) {
+      const result = validateSpec(
+        { ...validSpec, network: { outbound: [host] } },
+        { knownPluginIds: knownPlugins },
+      );
+      assert.equal(
+        result.violations[0]?.kind,
+        'network_outbound_invalid',
+        host,
+      );
+    }
   });
 
   it('rejects bare strings without TLD', () => {
@@ -287,7 +301,7 @@ describe('manifestLinter.validateSpec — multi-violation aggregation', () => {
         { id: 'BadName', description: 'a' },
         { id: 'BadName', description: 'b' },
       ],
-      network: { outbound: ['*.bad.com'] },
+      network: { outbound: ['https://bad.com'] },
     };
     const result = validateSpec(broken, { knownPluginIds: knownPlugins });
     const kinds = new Set(result.violations.map((v) => v.kind));

--- a/middleware/test/httpAccessor.test.ts
+++ b/middleware/test/httpAccessor.test.ts
@@ -1,0 +1,186 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { HttpForbiddenError, HttpRateLimitError } from '@omadia/plugin-api';
+
+import { createHttpAccessor } from '../src/platform/httpAccessor.js';
+import { HttpBlockedAddressError, isPublicIp } from '../src/platform/ssrfGuard.js';
+
+// ---------------------------------------------------------------------------
+// isPublicIp — the SSRF classifier
+// ---------------------------------------------------------------------------
+
+describe('isPublicIp', () => {
+  it('accepts globally-routable IPv4', () => {
+    for (const ip of ['93.184.216.34', '8.8.8.8', '1.1.1.1', '172.15.0.1', '172.32.0.1']) {
+      assert.equal(isPublicIp(ip), true, ip);
+    }
+  });
+
+  it('rejects private / loopback / link-local / CGNAT IPv4', () => {
+    for (const ip of [
+      '10.0.0.1',
+      '172.16.0.1',
+      '172.31.255.255',
+      '192.168.1.1',
+      '127.0.0.1',
+      '169.254.169.254', // cloud metadata
+      '169.254.0.1',
+      '100.64.0.1', // CGNAT
+      '0.0.0.0',
+      '192.0.0.1',
+      '224.0.0.1', // multicast
+      '255.255.255.255',
+    ]) {
+      assert.equal(isPublicIp(ip), false, ip);
+    }
+  });
+
+  it('classifies IPv6', () => {
+    assert.equal(isPublicIp('2606:4700:4700::1111'), true);
+    assert.equal(isPublicIp('::1'), false); // loopback
+    assert.equal(isPublicIp('::'), false); // unspecified
+    assert.equal(isPublicIp('fe80::1'), false); // link-local
+    assert.equal(isPublicIp('fc00::1'), false); // ULA
+    assert.equal(isPublicIp('fd12:3456:789a::1'), false); // ULA
+    assert.equal(isPublicIp('ff02::1'), false); // multicast
+  });
+
+  it('classifies IPv4-mapped IPv6 by the embedded address', () => {
+    assert.equal(isPublicIp('::ffff:10.0.0.1'), false);
+    assert.equal(isPublicIp('::ffff:169.254.169.254'), false);
+    assert.equal(isPublicIp('::ffff:8.8.8.8'), true);
+  });
+
+  it('returns false for non-IP strings', () => {
+    assert.equal(isPublicIp('example.com'), false);
+    assert.equal(isPublicIp(''), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createHttpAccessor — static-allow-list modes
+// ---------------------------------------------------------------------------
+
+describe('createHttpAccessor — static modes', () => {
+  it('rejects an undeclared host in single-host mode', async () => {
+    const http = createHttpAccessor({ agentId: 'a', outbound: ['api.example.com'] });
+    await assert.rejects(() => http.fetch('https://evil.com/'), HttpForbiddenError);
+  });
+
+  it('confines a non-web_scanner plugin even when audit_mode says public-web', async () => {
+    const http = createHttpAccessor({
+      agentId: 'a',
+      outbound: ['api.example.com'],
+      webScanner: false,
+      auditMode: 'public-web',
+    });
+    await assert.rejects(() => http.fetch('https://wikipedia.org/'), HttpForbiddenError);
+  });
+
+  it('ignores extraHosts in single-host mode', async () => {
+    const http = createHttpAccessor({
+      agentId: 'a',
+      outbound: ['api.example.com'],
+      webScanner: true,
+      auditMode: 'single-host',
+      extraHosts: ['curated.example.org'],
+    });
+    await assert.rejects(
+      () => http.fetch('https://curated.example.org/'),
+      HttpForbiddenError,
+    );
+  });
+
+  it('unions extraHosts into the allow-list in allowlist mode', async (t) => {
+    const seen: string[] = [];
+    t.mock.method(globalThis, 'fetch', async (u: string | URL) => {
+      seen.push(String(u));
+      return new Response('ok');
+    });
+    const http = createHttpAccessor({
+      agentId: 'a',
+      outbound: ['api.example.com'],
+      webScanner: true,
+      auditMode: 'allowlist',
+      extraHosts: ['curated.example.org'],
+    });
+    await http.fetch('https://curated.example.org/x');
+    await http.fetch('https://api.example.com/y');
+    await assert.rejects(() => http.fetch('https://other.com/'), HttpForbiddenError);
+    assert.deepEqual(seen, [
+      'https://curated.example.org/x',
+      'https://api.example.com/y',
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createHttpAccessor — public-web mode + SSRF guard
+// ---------------------------------------------------------------------------
+
+describe('createHttpAccessor — public-web', () => {
+  it('blocks literal private / link-local / metadata IPs up front', async () => {
+    const http = createHttpAccessor({
+      agentId: 'a',
+      outbound: [],
+      webScanner: true,
+      auditMode: 'public-web',
+    });
+    for (const url of [
+      'http://169.254.169.254/latest/meta-data/',
+      'http://10.0.0.5/',
+      'http://127.0.0.1:8080/',
+      'http://[::1]/',
+      'http://192.168.1.1/',
+    ]) {
+      await assert.rejects(() => http.fetch(url), HttpBlockedAddressError, url);
+    }
+  });
+
+  it('reaches fetch for an arbitrary public hostname', async (t) => {
+    const seen: string[] = [];
+    t.mock.method(globalThis, 'fetch', async (u: string | URL) => {
+      seen.push(String(u));
+      return new Response('ok');
+    });
+    const http = createHttpAccessor({
+      agentId: 'a',
+      outbound: [],
+      webScanner: true,
+      auditMode: 'public-web',
+    });
+    const res = await http.fetch('https://wikipedia.org/wiki/Main_Page');
+    assert.equal(await res.text(), 'ok');
+    assert.equal(seen.length, 1);
+  });
+
+  it('rejects non-http(s) URL schemes', async () => {
+    const http = createHttpAccessor({ agentId: 'a', outbound: ['x.example.com'] });
+    await assert.rejects(
+      () => http.fetch('file:///etc/passwd'),
+      HttpBlockedAddressError,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rate limiting
+// ---------------------------------------------------------------------------
+
+describe('createHttpAccessor — rate limit', () => {
+  it('throws HttpRateLimitError past the per-minute cap', async (t) => {
+    t.mock.method(globalThis, 'fetch', async () => new Response('ok'));
+    const http = createHttpAccessor({
+      agentId: 'a',
+      outbound: ['x.example.com'],
+      rateLimitPerMinute: 2,
+    });
+    await http.fetch('https://x.example.com/1');
+    await http.fetch('https://x.example.com/2');
+    await assert.rejects(
+      () => http.fetch('https://x.example.com/3'),
+      HttpRateLimitError,
+    );
+  });
+});

--- a/middleware/test/runtimeAuditModeRoute.test.ts
+++ b/middleware/test/runtimeAuditModeRoute.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import express from 'express';
+import type { Express } from 'express';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { createRuntimeRouter } from '../src/routes/runtime.js';
+import { InMemoryInstalledRegistry } from '../src/plugins/installedRegistry.js';
+import type {
+  PluginCatalog,
+  PluginCatalogEntry,
+} from '../src/plugins/manifestLoader.js';
+
+/**
+ * #91 — PATCH /installed/:id/audit-mode. The operator mode switch for an
+ * audit/scanner plugin. The endpoint validates the mode enum, gates on the
+ * manifest's `permissions.network.web_scanner` flag, and merges `audit_mode`
+ * into the InstalledRegistry config.
+ */
+
+const TEST_ID = 'de.byte5.agent.scanner';
+
+interface Harness {
+  server: Server;
+  baseUrl: string;
+  registry: InMemoryInstalledRegistry;
+  close(): Promise<void>;
+}
+
+async function makeHarness(opts: {
+  webScanner: boolean;
+  initialConfig?: Record<string, unknown>;
+}): Promise<Harness> {
+  const registry = new InMemoryInstalledRegistry();
+  await registry.register({
+    id: TEST_ID,
+    installed_version: '0.1.0',
+    installed_at: new Date().toISOString(),
+    status: 'active',
+    config: opts.initialConfig ?? {},
+  });
+
+  const stubEntry: PluginCatalogEntry = {
+    plugin: {
+      id: TEST_ID,
+      name: 'Scanner Agent',
+      version: '0.1.0',
+      permissions_summary: { network_web_scanner: opts.webScanner },
+    } as never,
+    manifest: {},
+    source_path: '<test>',
+    source_kind: 'manifest-v1',
+  };
+  const catalog = {
+    get: (id: string): PluginCatalogEntry | undefined =>
+      id === TEST_ID ? stubEntry : undefined,
+  } as unknown as PluginCatalog;
+
+  const stubReg = { names: () => [], counts: () => ({}) };
+  const router = createRuntimeRouter({
+    installedRegistry: registry,
+    serviceRegistry: stubReg as never,
+    turnHookRegistry: stubReg as never,
+    backgroundJobRegistry: stubReg as never,
+    chatAgentWrapRegistry: { labels: () => [], count: () => 0 } as never,
+    promptContributionRegistry: { labels: () => [], count: () => 0 } as never,
+    catalog,
+  });
+
+  const app: Express = express();
+  app.use(express.json());
+  app.use('/api/v1/admin/runtime', router);
+
+  const server: Server = await new Promise((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const port = (server.address() as AddressInfo).port;
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${String(port)}`,
+    registry,
+    async close() {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+function patchMode(
+  baseUrl: string,
+  id: string,
+  body: unknown,
+): Promise<Response> {
+  return fetch(
+    `${baseUrl}/api/v1/admin/runtime/installed/${encodeURIComponent(id)}/audit-mode`,
+    {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+describe('runtime audit-mode route — PATCH /installed/:id/audit-mode', () => {
+  let h: Harness;
+  afterEach(async () => {
+    if (h) await h.close();
+  });
+
+  it('sets the mode for a web_scanner plugin and persists audit_mode', async () => {
+    h = await makeHarness({ webScanner: true, initialConfig: { other: 'keep' } });
+    const res = await patchMode(h.baseUrl, TEST_ID, { mode: 'public-web' });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { audit_mode: string };
+    assert.equal(body.audit_mode, 'public-web');
+    const stored = h.registry.get(TEST_ID)?.config;
+    assert.equal(stored?.['audit_mode'], 'public-web');
+    // unrelated config keys survive the merge
+    assert.equal(stored?.['other'], 'keep');
+  });
+
+  it('rejects an invalid mode with 400', async () => {
+    h = await makeHarness({ webScanner: true });
+    const res = await patchMode(h.baseUrl, TEST_ID, { mode: 'wide-open' });
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as { code: string };
+    assert.equal(body.code, 'runtime.invalid_audit_mode');
+  });
+
+  it('rejects a plugin that does not declare web_scanner with 400', async () => {
+    h = await makeHarness({ webScanner: false });
+    const res = await patchMode(h.baseUrl, TEST_ID, { mode: 'public-web' });
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as { code: string };
+    assert.equal(body.code, 'runtime.not_web_scanner');
+  });
+
+  it('returns 404 for an uninstalled plugin', async () => {
+    h = await makeHarness({ webScanner: true });
+    const res = await patchMode(h.baseUrl, 'de.byte5.agent.absent', {
+      mode: 'allowlist',
+    });
+    assert.equal(res.status, 404);
+  });
+});

--- a/web-ui/app/_components/store/AuditModeSwitch.tsx
+++ b/web-ui/app/_components/store/AuditModeSwitch.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+/**
+ * #91 — operator mode switch for an installed audit/scanner plugin.
+ *
+ * Three egress modes, widening top-to-bottom:
+ *   single-host — only the host(s) declared in the manifest.
+ *   allowlist   — manifest hosts + the operator-curated host_list.
+ *   public-web  — any public host (private ranges + cloud-metadata stay
+ *                 hard-blocked by the runtime SSRF guard).
+ *
+ * Switching to a wider mode requires an explicit confirm. The current
+ * mode is read from the plugin's registry config (`audit_mode`); the
+ * middleware rejects the call unless the manifest declares
+ * `permissions.network.web_scanner`.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Loader2, ShieldAlert } from 'lucide-react';
+
+import { ApiError, listInstalledSecretKeys, setAuditMode } from '../../_lib/api';
+import type { AuditMode } from '../../_lib/storeTypes';
+
+const MODES: ReadonlyArray<{ value: AuditMode; label: string; help: string }> = [
+  {
+    value: 'single-host',
+    label: 'Single-Host',
+    help: 'Nur die im Manifest deklarierten Hosts.',
+  },
+  {
+    value: 'allowlist',
+    label: 'Allowlist',
+    help: 'Manifest-Hosts plus die vom Operator gepflegte Host-Liste.',
+  },
+  {
+    value: 'public-web',
+    label: 'Public-Web',
+    help: 'Beliebige öffentliche Hosts. Private Netzbereiche und Cloud-Metadata-Endpoints bleiben blockiert.',
+  },
+];
+
+type Status =
+  | { kind: 'loading' }
+  | { kind: 'ready' }
+  | { kind: 'saving' }
+  | { kind: 'saved' }
+  | { kind: 'error'; message: string };
+
+export function AuditModeSwitch({
+  pluginId,
+}: {
+  pluginId: string;
+}): React.ReactElement {
+  const [mode, setMode] = useState<AuditMode>('single-host');
+  const [status, setStatus] = useState<Status>({ kind: 'loading' });
+
+  const load = useCallback(async (): Promise<void> => {
+    try {
+      const state = await listInstalledSecretKeys(pluginId);
+      const raw = state.config_values['audit_mode'];
+      if (raw === 'allowlist' || raw === 'public-web' || raw === 'single-host') {
+        setMode(raw);
+      }
+      setStatus({ kind: 'ready' });
+    } catch (err) {
+      setStatus({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, [pluginId]);
+
+  useEffect(() => {
+    // Fetch-on-mount: load() touches state only after the awaited fetch —
+    // no synchronous cascading render.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void load();
+  }, [load]);
+
+  const onSelect = useCallback(
+    async (next: AuditMode): Promise<void> => {
+      if (next === mode) return;
+      const widening =
+        next === 'public-web' ||
+        (next === 'allowlist' && mode === 'single-host');
+      if (widening) {
+        const ok = window.confirm(
+          next === 'public-web'
+            ? 'Public-Web erlaubt diesem Plugin, beliebige öffentliche Hosts zu kontaktieren. Private Netzbereiche und Cloud-Metadata-Endpoints bleiben blockiert. Fortfahren?'
+            : 'Allowlist erlaubt diesem Plugin zusätzlich die operator-gepflegte Host-Liste. Fortfahren?',
+        );
+        if (!ok) return;
+      }
+      setStatus({ kind: 'saving' });
+      try {
+        const res = await setAuditMode(pluginId, next);
+        setMode(res.audit_mode);
+        setStatus({ kind: 'saved' });
+      } catch (err) {
+        setStatus({
+          kind: 'error',
+          message:
+            err instanceof ApiError
+              ? `${String(err.status)}: ${err.message}`
+              : err instanceof Error
+                ? err.message
+                : String(err),
+        });
+      }
+    },
+    [mode, pluginId],
+  );
+
+  const busy = status.kind === 'loading' || status.kind === 'saving';
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-start gap-2 text-[13px] text-[color:var(--fg-muted)]">
+        <ShieldAlert className="mt-0.5 size-4 shrink-0" aria-hidden />
+        <p>
+          Steuert, welche Hosts dieses Audit-Plugin über <code>ctx.http</code>{' '}
+          erreichen darf. Standard ist <strong>Single-Host</strong>.
+        </p>
+      </div>
+      <div className="flex flex-col gap-2">
+        {MODES.map((m) => (
+          <label
+            key={m.value}
+            className={[
+              'flex cursor-pointer items-start gap-3 rounded-[10px] border p-3',
+              mode === m.value
+                ? 'border-[color:var(--accent)]'
+                : 'border-[color:var(--rule)]',
+            ].join(' ')}
+          >
+            <input
+              type="radio"
+              name="audit-mode"
+              value={m.value}
+              checked={mode === m.value}
+              disabled={busy}
+              onChange={() => void onSelect(m.value)}
+              className="mt-0.5"
+            />
+            <span className="flex flex-col">
+              <span className="text-[14px] font-semibold text-[color:var(--fg-strong)]">
+                {m.label}
+              </span>
+              <span className="text-[12px] text-[color:var(--fg-muted)]">
+                {m.help}
+              </span>
+            </span>
+          </label>
+        ))}
+      </div>
+      <div className="min-h-[20px] text-[12px]">
+        {status.kind === 'loading' && (
+          <span className="inline-flex items-center gap-1.5 text-[color:var(--fg-muted)]">
+            <Loader2 className="size-3 animate-spin" aria-hidden /> lädt …
+          </span>
+        )}
+        {status.kind === 'saving' && (
+          <span className="inline-flex items-center gap-1.5 text-[color:var(--fg-muted)]">
+            <Loader2 className="size-3 animate-spin" aria-hidden /> speichert …
+          </span>
+        )}
+        {status.kind === 'saved' && (
+          <span className="text-[color:var(--accent)]">Modus gespeichert.</span>
+        )}
+        {status.kind === 'error' && (
+          <span className="text-[color:var(--danger)]">
+            Fehler: {status.message}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -1,4 +1,5 @@
 import type {
+  AuditMode,
   InstallConfigureResponse,
   InstallCreateResponse,
   InstallJob,
@@ -1617,6 +1618,43 @@ export async function patchInstalledSecrets(
     );
   }
   return (await res.json()) as InstalledSecretsState;
+}
+
+/**
+ * #91 — set the audit egress mode for an installed web_scanner plugin.
+ * The middleware validates the mode enum and rejects the call when the
+ * plugin does not declare `permissions.network.web_scanner`.
+ */
+export async function setAuditMode(
+  pluginId: string,
+  mode: AuditMode,
+): Promise<{ id: string; audit_mode: AuditMode }> {
+  const forwarded = await forwardCookieHeader();
+  const res = await fetch(
+    botApi(
+      `/v1/admin/runtime/installed/${encodeURIComponent(pluginId)}/audit-mode`,
+    ),
+    {
+      method: 'PATCH',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+        ...forwarded,
+      },
+      body: JSON.stringify({ mode }),
+      credentials: 'include',
+      cache: 'no-store',
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new ApiError(
+      res.status,
+      `PATCH installed/${pluginId}/audit-mode failed: ${res.status}`,
+      text,
+    );
+  }
+  return (await res.json()) as { id: string; audit_mode: AuditMode };
 }
 
 // -----------------------------------------------------------------------------

--- a/web-ui/app/_lib/storeTypes.ts
+++ b/web-ui/app/_lib/storeTypes.ts
@@ -11,7 +11,12 @@ export type SetupFieldType =
   | 'oauth'
   | 'enum'
   | 'boolean'
-  | 'integer';
+  | 'integer'
+  /** #91 — operator-curated list of bare hostnames. */
+  | 'host_list';
+
+/** #91 — operator-selected egress mode for an audit/scanner plugin. */
+export type AuditMode = 'single-host' | 'allowlist' | 'public-web';
 
 export interface PluginSetupField {
   key: string;
@@ -34,6 +39,10 @@ export interface PluginPermissionsSummary {
   graph_reads: string[];
   graph_writes: string[];
   network_outbound: string[];
+  /** #91 — true when the plugin is an audit/scanner whose `ctx.http` may
+   *  reach arbitrary public hosts (gated by the operator-selected
+   *  `audit_mode`). Optional: absent on pre-#91 store payloads. */
+  network_web_scanner?: boolean;
 }
 
 export type PluginInstallState =

--- a/web-ui/app/store/[id]/page.tsx
+++ b/web-ui/app/store/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
   KeyRound,
   Network,
   Plug,
+  ShieldAlert,
   ShieldCheck,
 } from 'lucide-react';
 
@@ -21,6 +22,7 @@ import {
   AdminUiToggle,
 } from '../../_components/store/AdminUiPanel';
 import { Chip } from '../../_components/store/Chip';
+import { AuditModeSwitch } from '../../_components/store/AuditModeSwitch';
 import { CredentialsEditor } from '../../_components/store/CredentialsEditor';
 import { EditFromStoreButton } from '../../_components/store/EditFromStoreButton';
 import { InstallButton } from '../../_components/store/InstallButton';
@@ -183,6 +185,20 @@ export default async function PluginDetailPage({
                 pluginId={plugin.id}
                 setupFields={plugin.required_secrets}
               />
+            </Section>
+          ) : null}
+
+          {/* #91 — audit egress mode switch. Surfaced only for an installed
+              audit/scanner plugin (one declaring permissions.network.web_scanner). */}
+          {(plugin.install_state === 'installed' ||
+            plugin.install_state === 'update-available') &&
+          plugin.permissions_summary.network_web_scanner === true ? (
+            <Section
+              label="Audit-Modus"
+              numeral="II.c"
+              icon={<ShieldAlert className="size-4" aria-hidden />}
+            >
+              <AuditModeSwitch pluginId={plugin.id} />
             </Section>
           ) : null}
 


### PR DESCRIPTION
Closes #91. Gives audit/scanner plugins — whose target hosts are user-supplied at runtime and unknown at build time — a clean, future-proof egress path before the planned global-`fetch` hardening pass.

Architecture: **Option C** (`web_scanner` capability) as the primary mechanism, **Option B** (`host_list` setup field) as the operator-curated complement, plus a leading-`*.` wildcard relaxation (Option A). 7 commits, one per phase.

## Phases

**1 — Manifest schema** · `permissions.network.web_scanner: boolean` + setup-field type `host_list` (array default). `installService.coerce` handles `host_list`; both flow through the loader into `PluginPermissionsSummary` / `PluginSetupField`.

**2 — Egress filter + SSRF guard** · `createHttpAccessor` resolves an effective allow-list per audit mode — `single-host` (manifest only; also forced for every non-web_scanner plugin), `allowlist` (manifest ∪ operator host_list), `public-web` (any public host). `public-web` rejects literal private/loopback/link-local/metadata IPs up front and routes through a rebinding-safe undici dispatcher whose custom DNS lookup blocks any hostname resolving to a non-public address. Non-http(s) schemes rejected.

**3 — Builder support** · the Agent-Builder spec schema (`agentSpec` Zod) accepts `web_scanner` + `host_list`; codegen emits `permissions.network.web_scanner`; the manifest linter accepts a leading `*.` subdomain wildcard.

**4 — Admin API + UI** · `PATCH /admin/runtime/installed/:id/audit-mode` — server-validated mode switch, gated on the `web_scanner` flag, merges `audit_mode` into the registry config + re-activates. `AuditModeSwitch` web-ui component on the plugin store-detail page (only rendered for an installed web_scanner plugin) with an explicit confirm when widening.

**5 — Reference migration** · `agent-seo-analyst` moved off raw global `fetch` to `ctx.http`; a permission rejection surfaces as `FetchResult.blocked` so the toolkit reports honestly (`audit mode: single-host … the requested URL was NOT analysed`) instead of silently substituting the configured default — closing the observed honesty bug. Manifest keeps `omadia.ai` + `*.omadia.ai`.

**6 — Builder prompt** · the BuilderAgent system prompt now teaches the `web_scanner` / `audit_mode` / `host_list` pattern and the honesty rule.

## SSRF guard

Blocked in `public-web`: IPv4 `0/8`,`10/8`,`100.64/10`,`127/8`,`169.254/16` (incl. the cloud-metadata endpoint),`172.16/12`,`192.0.0/24`,`192.168/16`,`198.18/15`,`≥224/4`; IPv6 `::`,`::1`,`fc00::/7`,`fe80::/10`,`ff00::/8`, IPv4-mapped (classified by the embedded v4). The connect-time check defeats DNS-rebinding.

## Verification

- middleware — typecheck + lint clean, **2428 tests pass / 0 fail** (incl. 13 egress-filter/SSRF, 4 audit-mode-route, 3 seo-analyst-fetcher tests added here)
- web-ui — typecheck + lint clean (0 errors), **129 tests pass**

## Not covered / notes

- `docs/harness-platform/manifest-schema.v1.yaml` is gitignored in this repo; it was updated locally but is not part of the diff.
- The `AuditModeSwitch` section only renders for an installed `web_scanner` plugin, so an interactive browser smoke needs the full stack with such a plugin installed — not exercised in CI.
- The global-`fetch` hardening pass itself remains out of scope; #91 is its prerequisite.

## Test plan

- [ ] Install a `web_scanner` plugin → store-detail page shows the "Audit-Modus" section; switching to `public-web` prompts a confirm
- [ ] In `public-web`, `ctx.http.fetch` to a public host succeeds; to `169.254.169.254` / a private IP throws `HttpBlockedAddressError`
- [ ] In `single-host`, an undeclared host throws `HttpForbiddenError`
- [ ] seo-analyst `analyze_page` on an undeclared host returns the honest mode-aware error, not a silent substitution

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>