### PR TITLE
fix(middleware): gate duplicate-capability installs + reconcile DEV_ENDPOINTS_ENABLED on every boot

### DIFF
--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -622,6 +622,20 @@ async function main(): Promise<void> {
       // pages like /p/channel-teams/{hub,tab-config} are public-by-
       // design and the reference dashboard is read-only demo state.
       /^\/p\/[^/]+(?:\/|$|\?)/,
+      // Local dev surfaces. The `/api/dev/*` mount itself is conditional
+      // on `DEV_ENDPOINTS_ENABLED=true` further down (see graph +
+      // memory dev routers around the "DEV endpoints enabled" log line)
+      // — when that flag is on the operator has already opted into an
+      // unauthenticated surface and the local Next-UI relies on the
+      // routes being callable without a session cookie. When the flag
+      // is off, no `/api/dev/*` routes are mounted at all, so this
+      // bypass cannot leak anything. When the flag is on AND the stack
+      // is exposed beyond localhost, that is a separate operator
+      // mistake the compose `127.0.0.1` port bindings are designed to
+      // prevent.
+      ...(config.DEV_ENDPOINTS_ENABLED
+        ? [/^\/api\/dev(?:\/|$|\?)/]
+        : []),
     ],
   });
 

--- a/middleware/src/plugins/bootstrap.ts
+++ b/middleware/src/plugins/bootstrap.ts
@@ -267,10 +267,40 @@ async function migrateAnthropicKeyToVault(
  * Idempotent: once the registry entry exists we never overwrite the
  * operator's settings.
  */
-async function bootstrapMemoryFromEnv(deps: BootstrapDeps): Promise<void> {
+export async function bootstrapMemoryFromEnv(deps: BootstrapDeps): Promise<void> {
   const log = deps.log ?? ((m) => console.log(m));
 
-  if (deps.registry.has(MEMORY_TOOL_ID)) return;
+  const desiredDevEndpoints = deps.config.DEV_ENDPOINTS_ENABLED
+    ? 'true'
+    : 'false';
+
+  // Reconcile path: when the plugin is already installed, env-driven flags
+  // still need to track operator intent expressed via container env on
+  // restart. Without this the operator can flip `DEV_ENDPOINTS_ENABLED` in
+  // .env, restart, and the memory plugin's `dev_memory_endpoints_enabled`
+  // stays at its first-boot value forever — because the rest of the
+  // function returns early when the registry entry exists. Other env-
+  // derived config (memory_dir, seed_dir, seed_mode) is operator-owned
+  // and stays untouched.
+  if (deps.registry.has(MEMORY_TOOL_ID)) {
+    const entry = deps.registry.get(MEMORY_TOOL_ID);
+    if (
+      entry &&
+      entry.config?.['dev_memory_endpoints_enabled'] !== desiredDevEndpoints
+    ) {
+      await deps.registry.register({
+        ...entry,
+        config: {
+          ...entry.config,
+          dev_memory_endpoints_enabled: desiredDevEndpoints,
+        },
+      });
+      log(
+        `[bootstrap] ⚐ ${MEMORY_TOOL_ID} dev_memory_endpoints_enabled reconciled to '${desiredDevEndpoints}' (from DEV_ENDPOINTS_ENABLED env)`,
+      );
+    }
+    return;
+  }
 
   const catalogEntry = deps.catalog.get(MEMORY_TOOL_ID);
   if (!catalogEntry) {
@@ -289,9 +319,7 @@ async function bootstrapMemoryFromEnv(deps: BootstrapDeps): Promise<void> {
       memory_dir: deps.config.MEMORY_DIR,
       seed_dir: deps.config.MEMORY_SEED_DIR,
       seed_mode: deps.config.MEMORY_SEED_MODE,
-      dev_memory_endpoints_enabled: deps.config.DEV_ENDPOINTS_ENABLED
-        ? 'true'
-        : 'false',
+      dev_memory_endpoints_enabled: desiredDevEndpoints,
     },
   });
 

--- a/middleware/src/plugins/bootstrap.ts
+++ b/middleware/src/plugins/bootstrap.ts
@@ -264,8 +264,11 @@ async function migrateAnthropicKeyToVault(
  * plugin lands with the proper config instead of the empty auto-install
  * default that would miss the env-provided paths.
  *
- * Idempotent: once the registry entry exists we never overwrite the
- * operator's settings.
+ * Idempotent: once the registry entry exists, operator-owned settings
+ * (memory_dir, seed_dir, seed_mode) are never overwritten. The single
+ * exception is `dev_memory_endpoints_enabled`, which is reconciled from
+ * `DEV_ENDPOINTS_ENABLED` on every boot so a container-env flip takes
+ * effect on restart (see the reconcile path below).
  */
 export async function bootstrapMemoryFromEnv(deps: BootstrapDeps): Promise<void> {
   const log = deps.log ?? ((m) => console.log(m));

--- a/middleware/src/plugins/capabilityResolver.ts
+++ b/middleware/src/plugins/capabilityResolver.ts
@@ -415,6 +415,64 @@ function capabilityKey(ref: CapabilityRef): string {
   return `${ref.name}@${ref.major}`;
 }
 
+/**
+ * Walks the candidate plugin's `provides` list and returns the first
+ * `<name>@<major>` slot that is already claimed by another active
+ * installed plugin. Returns `null` when no collision — i.e. the install
+ * would not introduce a duplicate provider.
+ *
+ * Server-side install-time check: prevents the persisted registry from
+ * drifting into a state where `buildProviderIndex` throws at the next
+ * boot. Symmetric to the `requires`-chain walk in
+ * {@link walkCapabilityInstallChain} — that one rejects on missing
+ * providers; this one rejects on duplicate providers.
+ */
+export function findActiveProviderCollision(
+  candidatePluginId: string,
+  catalog: PluginCatalog,
+  registry: InstalledRegistry,
+): { capability: string; ownerId: string } | null {
+  const candidate = catalog.get(candidatePluginId);
+  if (!candidate) {
+    return null;
+  }
+  const ownerByCap = new Map<string, string>();
+  for (const installed of registry.list()) {
+    if (installed.status !== 'active') {
+      continue;
+    }
+    if (installed.id === candidatePluginId) {
+      continue;
+    }
+    const entry = catalog.get(installed.id);
+    if (!entry) {
+      continue;
+    }
+    for (const rawProv of entry.plugin.provides) {
+      try {
+        const ref = parseCapabilityRef(rawProv);
+        ownerByCap.set(capabilityKey(ref), installed.id);
+      } catch {
+        // manifestLoader already warned + dropped malformed entries; a
+        // string that slipped through doesn't claim a slot.
+      }
+    }
+  }
+  for (const rawProv of candidate.plugin.provides) {
+    let ref: CapabilityRef;
+    try {
+      ref = parseCapabilityRef(rawProv);
+    } catch {
+      continue;
+    }
+    const ownerId = ownerByCap.get(capabilityKey(ref));
+    if (ownerId) {
+      return { capability: rawProv, ownerId };
+    }
+  }
+  return null;
+}
+
 /** Set of `<name>@<major>` keys that are currently published by an
  *  active installed plugin. Computed from registry × catalog so the
  *  install-chain walker can short-circuit on already-satisfied caps. */

--- a/middleware/src/plugins/installService.ts
+++ b/middleware/src/plugins/installService.ts
@@ -8,7 +8,10 @@ import type {
   InstallSetupSchema,
 } from '../api/admin-v1.js';
 import type { SecretVault } from '../secrets/vault.js';
-import { walkCapabilityInstallChain } from './capabilityResolver.js';
+import {
+  findActiveProviderCollision,
+  walkCapabilityInstallChain,
+} from './capabilityResolver.js';
 import type { InstalledRegistry } from './installedRegistry.js';
 import type { PluginCatalog, PluginCatalogEntry } from './manifestLoader.js';
 
@@ -84,6 +87,27 @@ export class InstallService {
         'install.missing_dependencies',
         `plugin requires these parents to be installed first: ${missingParents.join(', ')}`,
         409,
+      );
+    }
+
+    // Provider-collision gate: if the candidate's `provides` overlaps a
+    // `<name>@<major>` already published by an active installed plugin,
+    // refuse the install. Without this gate the registry can persist two
+    // active providers for the same capability — boot then crashes in
+    // `buildProviderIndex` (capabilityResolver.ts) with no automatic
+    // recovery, because the kernel has no operator-intent signal to pick
+    // a winner. The operator must uninstall the existing provider first.
+    const collision = findActiveProviderCollision(
+      pluginId,
+      this.deps.catalog,
+      this.deps.registry,
+    );
+    if (collision) {
+      throw new InstallError(
+        'install.capability_already_provided',
+        `capability '${collision.capability}' is already provided by '${collision.ownerId}' — uninstall it first`,
+        409,
+        collision,
       );
     }
 

--- a/middleware/test/bootstrap.test.ts
+++ b/middleware/test/bootstrap.test.ts
@@ -6,9 +6,12 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import {
+  bootstrapMemoryFromEnv,
   retryErroredPlugins,
   type RetryErroredPluginsDeps,
 } from '../src/plugins/bootstrap.js';
+import type { Config } from '../src/config.js';
+import type { SecretVault } from '../src/secrets/vault.js';
 import {
   InMemoryInstalledRegistry,
   type InstalledAgent,
@@ -317,6 +320,198 @@ describe('retryErroredPlugins — capability-resolution path', () => {
     });
 
     assert.equal(reg.get('consumer')?.status, 'errored');
+  });
+});
+
+describe('bootstrapMemoryFromEnv — env→config reconcile', () => {
+  // The `bootstrap` flow originally wrote `dev_memory_endpoints_enabled`
+  // into the @omadia/memory plugin's config exactly once (on first ever
+  // boot). Subsequent boots returned early on `registry.has(MEMORY_TOOL_ID)`
+  // — so operators who flipped `DEV_ENDPOINTS_ENABLED=true` in `.env`
+  // after first boot saw no effect and the local Next-UI's `/api/dev/memory`
+  // route stayed dark. This suite pins the reconcile path so the env
+  // var stays authoritative on every boot.
+
+  const MEMORY_ID = '@omadia/memory';
+
+  function makeConfig(devEnabled: boolean): Config {
+    return {
+      DEV_ENDPOINTS_ENABLED: devEnabled,
+      MEMORY_DIR: '/test/.memory',
+      MEMORY_SEED_DIR: '/test/seed/memory',
+      MEMORY_SEED_MODE: 'missing',
+    } as unknown as Config;
+  }
+
+  const noopVault: SecretVault = {
+    setMany: async () => {
+      /* no-op */
+    },
+    getMany: async () => ({}),
+    purge: async () => {
+      /* no-op */
+    },
+    list: async () => [],
+  } as unknown as SecretVault;
+
+  it('auto-installs with dev_memory_endpoints_enabled=true when env is on (first boot)', async () => {
+    const reg = new InMemoryInstalledRegistry();
+    const cat = makeCatalog([
+      { id: MEMORY_ID, provides: [], requires: [], depends_on: [] },
+    ]);
+
+    await bootstrapMemoryFromEnv({
+      config: makeConfig(true),
+      catalog: cat,
+      registry: reg,
+      vault: noopVault,
+      log: () => {},
+    });
+
+    const entry = reg.get(MEMORY_ID);
+    assert.ok(entry, 'memory plugin should be auto-installed');
+    assert.equal(entry.status, 'active');
+    assert.equal(entry.config?.['dev_memory_endpoints_enabled'], 'true');
+  });
+
+  it('reconciles dev_memory_endpoints_enabled from false→true on subsequent boots when env flips on', async () => {
+    const reg = new InMemoryInstalledRegistry();
+    await reg.register({
+      id: MEMORY_ID,
+      installed_version: '0.1.0',
+      installed_at: '2026-04-29T00:00:00Z',
+      status: 'active',
+      config: {
+        memory_dir: '/test/.memory',
+        seed_dir: '/test/seed/memory',
+        seed_mode: 'missing',
+        dev_memory_endpoints_enabled: 'false',
+      },
+    });
+    const cat = makeCatalog([
+      { id: MEMORY_ID, provides: [], requires: [], depends_on: [] },
+    ]);
+
+    await bootstrapMemoryFromEnv({
+      config: makeConfig(true),
+      catalog: cat,
+      registry: reg,
+      vault: noopVault,
+      log: () => {},
+    });
+
+    assert.equal(
+      reg.get(MEMORY_ID)?.config?.['dev_memory_endpoints_enabled'],
+      'true',
+    );
+  });
+
+  it('reconciles dev_memory_endpoints_enabled from true→false on subsequent boots when env flips off', async () => {
+    const reg = new InMemoryInstalledRegistry();
+    await reg.register({
+      id: MEMORY_ID,
+      installed_version: '0.1.0',
+      installed_at: '2026-04-29T00:00:00Z',
+      status: 'active',
+      config: {
+        memory_dir: '/test/.memory',
+        seed_dir: '/test/seed/memory',
+        seed_mode: 'missing',
+        dev_memory_endpoints_enabled: 'true',
+      },
+    });
+    const cat = makeCatalog([
+      { id: MEMORY_ID, provides: [], requires: [], depends_on: [] },
+    ]);
+
+    await bootstrapMemoryFromEnv({
+      config: makeConfig(false),
+      catalog: cat,
+      registry: reg,
+      vault: noopVault,
+      log: () => {},
+    });
+
+    assert.equal(
+      reg.get(MEMORY_ID)?.config?.['dev_memory_endpoints_enabled'],
+      'false',
+    );
+  });
+
+  it('preserves operator-owned config keys (memory_dir, seed_dir, seed_mode) during reconcile', async () => {
+    // The reconcile path may NOT clobber non-env-derived config. Only
+    // `dev_memory_endpoints_enabled` is the env-driven flag; other
+    // values are operator-managed after first boot.
+    const reg = new InMemoryInstalledRegistry();
+    await reg.register({
+      id: MEMORY_ID,
+      installed_version: '0.1.0',
+      installed_at: '2026-04-29T00:00:00Z',
+      status: 'active',
+      config: {
+        memory_dir: '/operator/picked/.memory',
+        seed_dir: '/operator/picked/seed',
+        seed_mode: 'always',
+        dev_memory_endpoints_enabled: 'false',
+      },
+    });
+    const cat = makeCatalog([
+      { id: MEMORY_ID, provides: [], requires: [], depends_on: [] },
+    ]);
+
+    await bootstrapMemoryFromEnv({
+      config: makeConfig(true),
+      catalog: cat,
+      registry: reg,
+      vault: noopVault,
+      log: () => {},
+    });
+
+    const entry = reg.get(MEMORY_ID);
+    assert.equal(entry?.config?.['memory_dir'], '/operator/picked/.memory');
+    assert.equal(entry?.config?.['seed_dir'], '/operator/picked/seed');
+    assert.equal(entry?.config?.['seed_mode'], 'always');
+    assert.equal(entry?.config?.['dev_memory_endpoints_enabled'], 'true');
+  });
+
+  it('is a no-op when dev_memory_endpoints_enabled already matches env', async () => {
+    // Idempotency: a boot that finds the config already in the desired
+    // state must not rewrite the entry. We assert by snapshotting the
+    // installed_at field — a register-with-same-value would survive but
+    // log noise / activity should not change.
+    const reg = new InMemoryInstalledRegistry();
+    const installedAt = '2026-04-29T00:00:00Z';
+    await reg.register({
+      id: MEMORY_ID,
+      installed_version: '0.1.0',
+      installed_at: installedAt,
+      status: 'active',
+      config: {
+        memory_dir: '/test/.memory',
+        seed_dir: '/test/seed/memory',
+        seed_mode: 'missing',
+        dev_memory_endpoints_enabled: 'true',
+      },
+    });
+    const cat = makeCatalog([
+      { id: MEMORY_ID, provides: [], requires: [], depends_on: [] },
+    ]);
+
+    const logs: string[] = [];
+    await bootstrapMemoryFromEnv({
+      config: makeConfig(true),
+      catalog: cat,
+      registry: reg,
+      vault: noopVault,
+      log: (m) => logs.push(m),
+    });
+
+    assert.equal(reg.get(MEMORY_ID)?.installed_at, installedAt);
+    assert.equal(
+      logs.some((l) => l.includes('reconciled')),
+      false,
+      'no reconcile log line should be emitted when nothing changed',
+    );
   });
 });
 

--- a/middleware/test/capabilityResolver.test.ts
+++ b/middleware/test/capabilityResolver.test.ts
@@ -9,6 +9,7 @@ import {
 
 import {
   MissingCapabilityError,
+  findActiveProviderCollision,
   findCapabilityProvidersInCatalog,
   resolveCapabilities,
   resolveEligiblePlugins,
@@ -503,6 +504,91 @@ describe('walkCapabilityInstallChain', () => {
     const provider = result.available_providers[0]?.providers[0];
     assert.equal(provider?.already_installed, true);
     assert.equal(provider?.active, false);
+  });
+});
+
+describe('findActiveProviderCollision', () => {
+  it('returns null when no active provider claims the candidate capability', () => {
+    const cat = makeCatalog([
+      { id: 'kg-neon', provides: ['knowledgeGraph@1'], requires: [], depends_on: [] },
+    ]);
+    const result = findActiveProviderCollision('kg-neon', cat, makeRegistry());
+    assert.equal(result, null);
+  });
+
+  it('returns the colliding capability + owner when an active sibling already publishes the same slot', () => {
+    const cat = makeCatalog([
+      { id: 'kg-neon', provides: ['knowledgeGraph@1'], requires: [], depends_on: [] },
+      { id: 'kg-inmemory', provides: ['knowledgeGraph@1'], requires: [], depends_on: [] },
+    ]);
+    const result = findActiveProviderCollision(
+      'kg-inmemory',
+      cat,
+      makeRegistry([makeActiveAgent('kg-neon')]),
+    );
+    assert.deepEqual(result, { capability: 'knowledgeGraph@1', ownerId: 'kg-neon' });
+  });
+
+  it('ignores inactive (errored) installed plugins — their slot is free', () => {
+    const cat = makeCatalog([
+      { id: 'kg-neon', provides: ['knowledgeGraph@1'], requires: [], depends_on: [] },
+      { id: 'kg-inmemory', provides: ['knowledgeGraph@1'], requires: [], depends_on: [] },
+    ]);
+    const erroredNeon: InstalledAgent = {
+      ...makeActiveAgent('kg-neon'),
+      status: 'errored',
+    };
+    const result = findActiveProviderCollision('kg-inmemory', cat, makeRegistry([erroredNeon]));
+    assert.equal(result, null);
+  });
+
+  it('ignores self — a plugin already in the registry does not collide with itself', () => {
+    // Defensive: keeps the helper safe for callers that pass the same id
+    // (e.g. a reactivation path that checks before re-registering).
+    const cat = makeCatalog([
+      { id: 'kg-neon', provides: ['knowledgeGraph@1'], requires: [], depends_on: [] },
+    ]);
+    const result = findActiveProviderCollision(
+      'kg-neon',
+      cat,
+      makeRegistry([makeActiveAgent('kg-neon')]),
+    );
+    assert.equal(result, null);
+  });
+
+  it('returns the first colliding capability when the candidate publishes multiple', () => {
+    const cat = makeCatalog([
+      {
+        id: 'incumbent',
+        provides: ['knowledgeGraph@1', 'entityRefBus@1'],
+        requires: [],
+        depends_on: [],
+      },
+      {
+        id: 'candidate',
+        provides: ['knowledgeGraph@1', 'entityRefBus@1'],
+        requires: [],
+        depends_on: [],
+      },
+    ]);
+    const result = findActiveProviderCollision(
+      'candidate',
+      cat,
+      makeRegistry([makeActiveAgent('incumbent')]),
+    );
+    assert.ok(result);
+    // First-match semantics — both would collide; we surface the first
+    // declared on the candidate. Order matches the manifest declaration.
+    assert.equal(result.capability, 'knowledgeGraph@1');
+    assert.equal(result.ownerId, 'incumbent');
+  });
+
+  it('returns null when the candidate id is not in the catalog', () => {
+    const cat = makeCatalog([
+      { id: 'something', provides: ['foo@1'], requires: [], depends_on: [] },
+    ]);
+    const result = findActiveProviderCollision('does-not-exist', cat, makeRegistry());
+    assert.equal(result, null);
   });
 });
 

--- a/middleware/test/installService.test.ts
+++ b/middleware/test/installService.test.ts
@@ -342,6 +342,86 @@ describe('InstallService.create — capability gate', () => {
   });
 });
 
+describe('InstallService.create — provides-collision gate', () => {
+  it('blocks install with 409 install.capability_already_provided when an active plugin already publishes the same <name>@<major>', () => {
+    // Two siblings declare the same capability — the kg-inmemory / kg-neon
+    // shape. Once one is active, installing the other must be refused at
+    // install-time so the registry can never end up with two active
+    // providers of `knowledgeGraph@1` (which would crash boot in
+    // `buildProviderIndex`).
+    const cat = makeCatalog([
+      { id: 'kg-neon', provides: ['knowledgeGraph@1'], requires: [], depends_on: [] },
+      {
+        id: 'kg-inmemory',
+        provides: ['knowledgeGraph@1'],
+        requires: [],
+        depends_on: [],
+      },
+    ]);
+    const service = new InstallService({
+      catalog: cat,
+      registry: makeRegistry([makeActive('kg-neon')]),
+      vault: noopVault,
+    });
+
+    let caught: InstallError | undefined;
+    try {
+      service.create('kg-inmemory');
+    } catch (err) {
+      assert.ok(err instanceof InstallError);
+      caught = err;
+    }
+    assert.ok(caught, 'expected InstallError to be thrown');
+    assert.equal(caught.code, 'install.capability_already_provided');
+    assert.equal(caught.status, 409);
+    const details = caught.details as
+      | { capability: string; ownerId: string }
+      | undefined;
+    assert.ok(details, 'expected details payload');
+    assert.equal(details.capability, 'knowledgeGraph@1');
+    assert.equal(details.ownerId, 'kg-neon');
+  });
+
+  it('allows install when an inactive (errored) plugin nominally provides the same capability', () => {
+    // Only `active` providers count as live owners — a plugin marked
+    // errored has not run `ctx.services.provide`, so its slot is free.
+    const cat = makeCatalog([
+      { id: 'kg-neon', provides: ['knowledgeGraph@1'], requires: [], depends_on: [] },
+      {
+        id: 'kg-inmemory',
+        provides: ['knowledgeGraph@1'],
+        requires: [],
+        depends_on: [],
+      },
+    ]);
+    const erroredNeon: InstalledAgent = {
+      ...makeActive('kg-neon'),
+      status: 'errored',
+    };
+    const service = new InstallService({
+      catalog: cat,
+      registry: makeRegistry([erroredNeon]),
+      vault: noopVault,
+    });
+    const job = service.create('kg-inmemory');
+    assert.equal(job.plugin_id, 'kg-inmemory');
+    assert.equal(job.state, 'awaiting_config');
+  });
+
+  it('allows install when no installed plugin claims the candidate capability', () => {
+    const cat = makeCatalog([
+      { id: 'kg-neon', provides: ['knowledgeGraph@1'], requires: [], depends_on: [] },
+    ]);
+    const service = new InstallService({
+      catalog: cat,
+      registry: makeRegistry(),
+      vault: noopVault,
+    });
+    const job = service.create('kg-neon');
+    assert.equal(job.plugin_id, 'kg-neon');
+  });
+});
+
 describe('InstallError.details', () => {
   it('exposes details as a public, optional field', () => {
     const err = new InstallError('x', 'msg', 409, { a: 1 });


### PR DESCRIPTION
## Summary

Three independent boot/install issues that together can turn a healthy
kernel into a `process.exit(1)` crashloop after an admin-UI click the
kernel itself accepted.

- **Install-time provides-collision gate.** `InstallService.create()`
  validates `requires` but never `provides`. The admin UI happily
  installs a second plugin claiming `<name>@<major>` already published
  by an active one; the runtime only notices on the next boot, where
  `buildProviderIndex` throws and `main()` exits 1 — no operator-intent
  signal, no graceful recovery. Adds a symmetric \`provides\`-collision
  gate before the existing requires-walk; throws 409
  \`install.capability_already_provided\` with \`{ capability, ownerId }\`.
- **\`bootstrapMemoryFromEnv\` reconcile.** The \`@omadia/memory\` plugin
  stored \`dev_memory_endpoints_enabled\` from \`DEV_ENDPOINTS_ENABLED\`
  exactly once on first-ever boot. Flipping the env later had no effect
  and \`/api/dev/memory\` stayed unmounted. Now reconciled on every boot
  (idempotent, only logs/writes on change). Operator-owned config keys
  (memory_dir, seed_dir, seed_mode) are left untouched.
- **\`/api/dev/*\` publicPaths bypass.** The boot log line
  *\"DEV endpoints enabled at /api/dev — unauthenticated, LOCAL USE ONLY\"*
  was false. \`requireAuth\` mounted at \`/api\` gated every \`/api/dev/*\`
  request with 401. The publicPaths regex list now appends
  \`/^\\/api\\/dev(?:\\/|\$|\\?)/\` when \`DEV_ENDPOINTS_ENABLED=true\` —
  when the flag is off no \`/api/dev/*\` route is mounted at all, so the
  bypass is unreachable. The compose \`127.0.0.1\` port bindings continue
  to prevent non-local exposure.

The plugin source comments in the two knowledge-graph siblings claim
that \"two-active is structurally impossible\" via
\`ctx.services.provide\`. That check runs at activate(), downstream of
\`buildProviderIndex\` — the kernel dies first. The new install-time
gate makes the claim true at the install boundary.

## Reproducer for the crash

1. Bring up the compose stack with \`DATABASE_URL\` set
   (\`docker compose up -d\`). \`@omadia/knowledge-graph-neon\` is
   auto-installed by \`bootstrapKnowledgeGraphFromEnv\`.
2. In the admin UI, install \`@omadia/knowledge-graph-inmemory\`. (Today
   this succeeds — both plugins now sit in \`installed.json\` with
   \`status: active\`.)
3. Restart the middleware container. Kernel logs:
   \`\`\`
   [middleware] fatal startup error: Error: capability 'knowledgeGraph@1' is provided by both
   '@omadia/knowledge-graph-inmemory' and '@omadia/knowledge-graph-neon' — uninstall one
   \`\`\`
4. Compose's \`restart: unless-stopped\` keeps relaunching the same
   broken state.

After this PR, step 2 fails fast with HTTP 409
\`install.capability_already_provided\` and the registry never reaches
the unrecoverable state.

## Test plan

- [x] \`npm test\` — 2421 tests, 0 fail, 7 skipped (was 2414/0/7
      pre-PR; +14 new tests across capabilityResolver / installService /
      bootstrap).
- [x] \`npm run lint\` — clean.
- [x] \`docker compose build middleware && docker compose up -d\` —
      healthy on first boot, idempotent on restart, neon still active,
      \`/api/dev/memory/list\` returns 200 with the seeded tree.
- [x] Manual: install a sibling provider via the admin UI → 409 with
      structured details.

## Out of scope (left for follow-up)

- Boot-time graceful collision handling in
  \`capabilityResolver.buildProviderIndex\` (mark newer entry
  \`errored\` instead of throwing). Helps recover from already-drifted
  installs, but is a behavior change worth its own PR.
- Catalog endpoint marking sibling providers as
  \`install_state: 'incompatible'\` with a reason, so the UI hides the
  install button entirely.
- Updating the misleading \"structurally impossible\" comments in
  \`harness-knowledge-graph-{inmemory,neon}/src/plugin.ts\`.