### PR TITLE
feat(web-ui): visible session-expiry handling (warning + auto-logout)

### DIFF
--- a/middleware/src/auth/sessionJwt.ts
+++ b/middleware/src/auth/sessionJwt.ts
@@ -20,6 +20,21 @@ export interface SessionClaims {
 }
 
 /**
+ * The result of verifying a session token: the signed identity claims plus
+ * the JWT registered timestamps. `exp`/`iat` are intentionally NOT part of
+ * `SessionClaims` because that type doubles as the *input* to
+ * `signSession`, which mints those timestamps itself. Identity-only callers
+ * keep using `SessionClaims`; expiry-aware paths (GET /me, the UI session
+ * watcher) read `exp` to drive the visible countdown / auto-logout.
+ */
+export interface VerifiedSession extends SessionClaims {
+  /** Expiry — Unix epoch **seconds** (JWT `exp`). */
+  exp: number;
+  /** Issued-at — Unix epoch **seconds** (JWT `iat`). */
+  iat: number;
+}
+
+/**
  * Sign a session token. Default lifetime is the 4h access window from the
  * plan; callers can override for short-lived side-channel tokens (e.g. the
  * PKCE verifier cookie).
@@ -40,11 +55,16 @@ export async function signSession(
 export async function verifySession(
   token: string,
   key: Uint8Array,
-): Promise<SessionClaims> {
+): Promise<VerifiedSession> {
   const { payload } = await jwtVerify(token, key, {
     issuer: ISSUER,
     algorithms: [ALG],
   });
+  // `jwtVerify` already rejects an expired token; these reads only surface
+  // the timestamps for callers. Both are always present on tokens minted
+  // by `signSession` (it sets iat + expiration), but narrow defensively.
+  const exp = typeof payload['exp'] === 'number' ? payload['exp'] : 0;
+  const iat = typeof payload['iat'] === 'number' ? payload['iat'] : 0;
   const sub = typeof payload['sub'] === 'string' ? payload['sub'] : '';
   const email = typeof payload['email'] === 'string' ? payload['email'] : '';
   const displayName =
@@ -68,5 +88,7 @@ export async function verifySession(
     display_name: displayName,
     role,
     provider,
+    exp,
+    iat,
   };
 }

--- a/middleware/src/routes/auth.ts
+++ b/middleware/src/routes/auth.ts
@@ -278,6 +278,13 @@ export function createAuthRouter(deps: AuthDeps): Router {
           role: claims.role,
           provider: claims.provider,
         },
+        // Expiry timestamps let the Admin UI render a visible countdown
+        // and a deliberate auto-logout instead of the session silently
+        // dying. `server_now` is the server clock at response time so the
+        // client can correct for clock skew rather than trusting its own.
+        // Both are Unix epoch SECONDS, matching the JWT `exp` convention.
+        expires_at: claims.exp,
+        server_now: Math.floor(Date.now() / 1000),
       });
     } catch {
       res.status(401).json({ code: 'auth.invalid' });

--- a/middleware/test/auth/sessionJwt.test.ts
+++ b/middleware/test/auth/sessionJwt.test.ts
@@ -1,0 +1,44 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { signSession, verifySession } from '../../src/auth/sessionJwt.js';
+
+/**
+ * Guards the OB session-expiry-UX change: `verifySession` must surface the
+ * JWT `exp`/`iat` timestamps so GET /api/v1/auth/me can hand the Admin UI
+ * a real expiry to count down to. Identity-only callers are unaffected.
+ */
+
+// HS512 requires a key of at least 64 bytes.
+const KEY = new TextEncoder().encode('x'.repeat(64));
+
+describe('sessionJwt — verifySession surfaces JWT timestamps', () => {
+  it('returns numeric exp/iat alongside the identity claims', async () => {
+    const beforeSign = Math.floor(Date.now() / 1000);
+    const token = await signSession(
+      {
+        sub: 'u1',
+        email: 'admin@example.de',
+        display_name: 'Admin Example',
+        role: 'admin',
+        provider: 'entra',
+      },
+      KEY,
+      '4h',
+    );
+
+    const verified = await verifySession(token, KEY);
+
+    assert.equal(verified.sub, 'u1');
+    assert.equal(verified.email, 'admin@example.de');
+    assert.equal(verified.provider, 'entra');
+
+    assert.equal(typeof verified.exp, 'number');
+    assert.equal(typeof verified.iat, 'number');
+    // `iat` is stamped at signing time.
+    assert.ok(verified.iat >= beforeSign);
+    // `exp` is the 4h window past `iat` — allow ±2s scheduling slack.
+    const FOUR_HOURS_S = 4 * 60 * 60;
+    assert.ok(Math.abs(verified.exp - verified.iat - FOUR_HOURS_S) <= 2);
+  });
+});

--- a/web-ui/app/_components/AuthBadge.tsx
+++ b/web-ui/app/_components/AuthBadge.tsx
@@ -2,18 +2,20 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 
 import { ApiError, getAuthMe, postAuthLogout, type AuthUser } from '../_lib/api';
 
 type State =
   | { kind: 'loading' }
-  | { kind: 'authed'; user: AuthUser }
+  | { kind: 'authed'; user: AuthUser; expiresAt: number }
   | { kind: 'anon' }
   | { kind: 'error'; message: string };
 
 export function AuthBadge(): React.ReactElement | null {
   const t = useTranslations('authBadge');
+  const tSession = useTranslations('session');
+  const locale = useLocale();
   const [state, setState] = useState<State>({ kind: 'loading' });
   const [menuOpen, setMenuOpen] = useState(false);
   const [signingOut, setSigningOut] = useState(false);
@@ -24,7 +26,12 @@ export function AuthBadge(): React.ReactElement | null {
     (async () => {
       try {
         const res = await getAuthMe();
-        if (!cancelled) setState({ kind: 'authed', user: res.user });
+        if (!cancelled)
+          setState({
+            kind: 'authed',
+            user: res.user,
+            expiresAt: res.expires_at,
+          });
       } catch (err) {
         if (cancelled) return;
         if (err instanceof ApiError && err.status === 401) {
@@ -111,6 +118,10 @@ export function AuthBadge(): React.ReactElement | null {
 
   const { user } = state;
   const initials = getInitials(user.display_name || user.email);
+  const expiryLabel = new Date(state.expiresAt * 1000).toLocaleTimeString(
+    locale,
+    { hour: '2-digit', minute: '2-digit' },
+  );
   return (
     <div ref={menuRef} className="relative">
       <motion.button
@@ -160,6 +171,12 @@ export function AuthBadge(): React.ReactElement | null {
               </div>
               <div className="font-mono text-[11px] text-[color:var(--fg-muted)]">
                 {user.email}
+              </div>
+              <div className="mt-2 flex items-center gap-1.5 text-[10px] uppercase tracking-[0.14em] text-[color:var(--fg-subtle)]">
+                {tSession('expiresAtLabel')}
+                <span className="font-mono normal-case tracking-normal text-[color:var(--fg-muted)]">
+                  {expiryLabel}
+                </span>
               </div>
             </div>
             <div className="border-t border-[color:var(--border)] pt-2">

--- a/web-ui/app/_components/SessionWatcher.tsx
+++ b/web-ui/app/_components/SessionWatcher.tsx
@@ -1,0 +1,274 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Clock, LogIn } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+import { getSessionStatus } from '../_lib/api';
+
+/**
+ * SessionWatcher — turns the previously *silent* session logout into a
+ * visible one.
+ *
+ * The `omadia_session` cookie is a 4h JWT with no refresh. The edge proxy
+ * catches an expired cookie on navigation and `api.ts` catches it on a 401
+ * from an API call — but a tab that is sitting idle (no navigation, no API
+ * call) just goes dead with no signal. This component closes that gap:
+ *
+ *   - It learns the session's `exp` from GET /api/v1/auth/me (skew-corrected
+ *     against the server clock) and schedules two transitions: a warning
+ *     ~5 min before expiry and the hard logout at expiry.
+ *   - A 60s heartbeat (plus an immediate re-check whenever the tab regains
+ *     focus) also catches server-side revocation — account disabled, key
+ *     rotation — which the local expiry clock alone cannot see.
+ *   - At expiry it shows a blocking overlay instead of leaving the operator
+ *     staring at a frozen UI. No silent auto-extend: re-login is explicit.
+ *
+ * Mounted once in the root layout. Renders nothing on the /login + /setup
+ * pages (no session to watch there).
+ */
+
+/** How long before expiry the (non-blocking) warning card appears. */
+const WARN_BEFORE_MS = 5 * 60 * 1000;
+/** Heartbeat cadence — the only thing that can see server-side revocation. */
+const HEARTBEAT_MS = 60 * 1000;
+
+type Phase = 'normal' | 'warning' | 'expired';
+const PHASE_RANK: Record<Phase, number> = { normal: 0, warning: 1, expired: 2 };
+
+function isAuthPage(pathname: string): boolean {
+  return pathname === '/login' || pathname === '/setup';
+}
+
+/** Format a millisecond duration as `M:SS` (clamped at zero). */
+function formatClock(ms: number): string {
+  const total = Math.max(0, Math.ceil(ms / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes.toString()}:${seconds.toString().padStart(2, '0')}`;
+}
+
+/** Bounce to the login page, preserving the current location as `return`. */
+function relogin(): void {
+  const target = window.location.pathname + window.location.search;
+  window.location.assign(`/login?return=${encodeURIComponent(target)}`);
+}
+
+export function SessionWatcher(): React.ReactElement | null {
+  const pathname = usePathname();
+  const onAuthPage = isAuthPage(pathname);
+
+  const [phase, setPhase] = useState<Phase>('normal');
+  // Session expiry translated into THIS browser's clock (skew-corrected).
+  // null until the first probe resolves.
+  const [expiresAtLocal, setExpiresAtLocal] = useState<number | null>(null);
+  const [warningDismissed, setWarningDismissed] = useState(false);
+
+  // Phase only ever advances. A warn-timer that fires late (e.g. after the
+  // heartbeat already detected revocation and jumped to 'expired') must not
+  // pull the state backwards.
+  const advancePhase = useCallback((next: Phase) => {
+    setPhase((cur) => (PHASE_RANK[next] > PHASE_RANK[cur] ? next : cur));
+  }, []);
+
+  // ── Initial probe + heartbeat + focus re-check ─────────────────────────
+  useEffect(() => {
+    if (onAuthPage) return;
+    let cancelled = false;
+
+    const probe = async (): Promise<void> => {
+      try {
+        const status = await getSessionStatus();
+        if (cancelled) return;
+        if (
+          !status.authenticated ||
+          status.expiresAt === null ||
+          status.serverNow === null
+        ) {
+          advancePhase('expired');
+          return;
+        }
+        // Re-express the server's expiry in the local clock so the
+        // countdown is correct even when this machine's clock drifts.
+        const skewMs = Date.now() - status.serverNow * 1000;
+        const nextExpiry = status.expiresAt * 1000 + skewMs;
+        setExpiresAtLocal((prev) =>
+          prev !== null && Math.abs(prev - nextExpiry) < 2000
+            ? prev
+            : nextExpiry,
+        );
+        // Catch up if the tab was loaded (or woke from sleep) already
+        // inside a warning/expired window — the scheduled timers below
+        // only cover transitions that are still in the future.
+        const remaining = nextExpiry - Date.now();
+        if (remaining <= 0) advancePhase('expired');
+        else if (remaining <= WARN_BEFORE_MS) advancePhase('warning');
+      } catch {
+        // Network blip — leave state intact; the next heartbeat retries.
+      }
+    };
+
+    void probe();
+    const heartbeat = window.setInterval(() => void probe(), HEARTBEAT_MS);
+    const onVisibility = (): void => {
+      if (document.visibilityState === 'visible') void probe();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(heartbeat);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [onAuthPage, advancePhase]);
+
+  // ── Schedule the warning + expiry transitions ──────────────────────────
+  // Only arms future-dated timers; the probe above handles the case where
+  // the page is already inside a window. Keeping setState out of the effect
+  // body (timer callbacks run asynchronously) avoids cascading renders.
+  useEffect(() => {
+    if (onAuthPage || expiresAtLocal === null) return;
+
+    const remaining = expiresAtLocal - Date.now();
+    const timers: number[] = [];
+    if (remaining > WARN_BEFORE_MS) {
+      timers.push(
+        window.setTimeout(
+          () => advancePhase('warning'),
+          remaining - WARN_BEFORE_MS,
+        ),
+      );
+    }
+    if (remaining > 0) {
+      timers.push(window.setTimeout(() => advancePhase('expired'), remaining));
+    }
+    return () => timers.forEach((id) => window.clearTimeout(id));
+  }, [onAuthPage, expiresAtLocal, advancePhase]);
+
+  if (onAuthPage) return null;
+
+  return (
+    <AnimatePresence>
+      {phase === 'expired' ? (
+        <SessionExpiredOverlay key="expired" />
+      ) : phase === 'warning' &&
+        !warningDismissed &&
+        expiresAtLocal !== null ? (
+        <SessionWarningCard
+          key="warning"
+          expiresAtLocal={expiresAtLocal}
+          onDismiss={() => setWarningDismissed(true)}
+        />
+      ) : null}
+    </AnimatePresence>
+  );
+}
+
+/** Non-blocking bottom-right card with a live countdown to expiry. */
+function SessionWarningCard({
+  expiresAtLocal,
+  onDismiss,
+}: {
+  expiresAtLocal: number;
+  onDismiss: () => void;
+}): React.ReactElement {
+  const t = useTranslations('session');
+  const [remaining, setRemaining] = useState(
+    () => expiresAtLocal - Date.now(),
+  );
+
+  useEffect(() => {
+    const tick = window.setInterval(() => {
+      setRemaining(expiresAtLocal - Date.now());
+    }, 1000);
+    return () => window.clearInterval(tick);
+  }, [expiresAtLocal]);
+
+  return (
+    <motion.div
+      role="alert"
+      initial={{ opacity: 0, y: 24 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 24 }}
+      transition={{ duration: 0.2, ease: 'easeOut' }}
+      className="fixed bottom-5 right-5 z-[90] w-[min(92vw,22rem)] border border-[color:var(--rule-strong)] bg-[color:var(--paper)] p-5 shadow-[0_24px_60px_-20px_rgba(0,0,0,0.45)]"
+    >
+      <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.2em] text-[color:var(--accent)]">
+        <Clock className="size-3.5" aria-hidden />
+        {t('warningTitle')}
+      </div>
+      <p className="mt-2 text-[13px] leading-relaxed text-[color:var(--ink)]">
+        {t('warningBody', { time: formatClock(remaining) })}
+      </p>
+      <div className="mt-4 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={relogin}
+          className="flex-1 border border-[color:var(--ink)] bg-[color:var(--ink)] px-3 py-2 text-[11px] uppercase tracking-[0.16em] text-[color:var(--paper)] transition hover:border-[color:var(--accent)] hover:bg-[color:var(--accent)]"
+        >
+          {t('warningCta')}
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="border border-[color:var(--rule-strong)] px-3 py-2 text-[11px] uppercase tracking-[0.16em] text-[color:var(--muted-ink)] transition hover:text-[color:var(--ink)]"
+        >
+          {t('warningDismiss')}
+        </button>
+      </div>
+    </motion.div>
+  );
+}
+
+/** Blocking full-screen overlay shown once the session is gone. */
+function SessionExpiredOverlay(): React.ReactElement {
+  const t = useTranslations('session');
+  const ctaRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    ctaRef.current?.focus();
+  }, []);
+
+  return (
+    <motion.div
+      role="alertdialog"
+      aria-modal="true"
+      aria-label={t('expiredTitle')}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.2 }}
+      className="fixed inset-0 z-[100] flex items-center justify-center px-4 py-6"
+    >
+      <div className="absolute inset-0 bg-[color:var(--ink)]/55 backdrop-blur-sm" />
+      <motion.div
+        initial={{ opacity: 0, scale: 0.96, y: 8 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        transition={{ duration: 0.2, ease: 'easeOut' }}
+        className="relative z-10 w-full max-w-md border border-[color:var(--rule-strong)] bg-[color:var(--paper)] p-7 shadow-[0_30px_80px_-20px_rgba(0,0,0,0.5)]"
+      >
+        <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.2em] text-[color:var(--accent)]">
+          <Clock className="size-3.5" aria-hidden />
+          {t('expiredKicker')}
+        </div>
+        <h2 className="font-display mt-1 text-2xl font-medium leading-tight text-[color:var(--ink)]">
+          {t('expiredTitle')}
+        </h2>
+        <p className="mt-2 text-[13px] leading-relaxed text-[color:var(--muted-ink)]">
+          {t('expiredBody')}
+        </p>
+        <button
+          ref={ctaRef}
+          type="button"
+          onClick={relogin}
+          className="mt-5 flex w-full items-center justify-center gap-2 border border-[color:var(--ink)] bg-[color:var(--ink)] px-4 py-2.5 text-[12px] uppercase tracking-[0.16em] text-[color:var(--paper)] transition hover:border-[color:var(--accent)] hover:bg-[color:var(--accent)]"
+        >
+          <LogIn className="size-3.5" aria-hidden />
+          {t('expiredCta')}
+        </button>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/web-ui/app/_components/__tests__/SessionWatcher.test.tsx
+++ b/web-ui/app/_components/__tests__/SessionWatcher.test.tsx
@@ -1,0 +1,117 @@
+import { act, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithIntl } from '../../_lib/test-utils';
+import { SessionWatcher } from '../SessionWatcher';
+
+/**
+ * Deterministic coverage for the SessionWatcher time-state-machine:
+ * normal → warning → expired, plus the heartbeat-detected revocation
+ * path and the /login no-op guard. Fake timers stand in for the real
+ * 4h clock so the transitions are testable in milliseconds.
+ */
+
+const { mockUsePathname, mockGetSessionStatus } = vi.hoisted(() => ({
+  mockUsePathname: vi.fn(() => '/'),
+  mockGetSessionStatus: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({ usePathname: mockUsePathname }));
+vi.mock('../../_lib/api', () => ({ getSessionStatus: mockGetSessionStatus }));
+
+const WARNING_TITLE = 'Sitzung läuft bald ab';
+const EXPIRED_TITLE = 'Sitzung abgelaufen';
+
+/**
+ * Make getSessionStatus behave like the real endpoint: a FIXED absolute
+ * expiry, with `serverNow` tracking the (faked) wall clock so the
+ * skew-correction nets to ~0 as time advances.
+ */
+function mockAuthedSession(expiresInSeconds: number): void {
+  const expiresAtSec = Math.floor(Date.now() / 1000) + expiresInSeconds;
+  mockGetSessionStatus.mockImplementation(() =>
+    Promise.resolve({
+      authenticated: true,
+      user: null,
+      expiresAt: expiresAtSec,
+      serverNow: Math.floor(Date.now() / 1000),
+    }),
+  );
+}
+
+/** Advance fake time AND flush the probe's pending promises. */
+async function flush(ms = 0): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-05-21T12:00:00Z'));
+  mockUsePathname.mockReturnValue('/');
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe('<SessionWatcher />', () => {
+  it('renders no dialog while the session is comfortably valid', async () => {
+    mockAuthedSession(60 * 60); // 1h left
+    renderWithIntl(<SessionWatcher />, { locale: 'de' });
+    await flush();
+
+    expect(screen.queryByText(WARNING_TITLE)).not.toBeInTheDocument();
+    expect(screen.queryByText(EXPIRED_TITLE)).not.toBeInTheDocument();
+  });
+
+  it('shows the warning card immediately when loaded inside the warn window', async () => {
+    mockAuthedSession(2 * 60); // 2 min left — inside the 5-min warn window
+    renderWithIntl(<SessionWatcher />, { locale: 'de' });
+    await flush();
+
+    expect(screen.getByText(WARNING_TITLE)).toBeInTheDocument();
+    expect(screen.queryByText(EXPIRED_TITLE)).not.toBeInTheDocument();
+  });
+
+  it('schedules the warning, then the expiry overlay, as time advances', async () => {
+    mockAuthedSession(6 * 60); // warn fires at +1min, expiry at +6min
+    renderWithIntl(<SessionWatcher />, { locale: 'de' });
+    await flush();
+    expect(screen.queryByText(WARNING_TITLE)).not.toBeInTheDocument();
+
+    await flush(61_000); // cross the warn threshold
+    expect(screen.getByText(WARNING_TITLE)).toBeInTheDocument();
+    expect(screen.queryByText(EXPIRED_TITLE)).not.toBeInTheDocument();
+
+    await flush(5 * 60_000); // reach expiry
+    expect(screen.getByText(EXPIRED_TITLE)).toBeInTheDocument();
+  });
+
+  it('jumps straight to the expired overlay when the heartbeat sees no session', async () => {
+    mockGetSessionStatus.mockResolvedValue({
+      authenticated: false,
+      user: null,
+      expiresAt: null,
+      serverNow: null,
+    });
+    renderWithIntl(<SessionWatcher />, { locale: 'de' });
+    await flush();
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    expect(screen.getByText(EXPIRED_TITLE)).toBeInTheDocument();
+  });
+
+  it('renders nothing and never probes on the /login page', async () => {
+    mockUsePathname.mockReturnValue('/login');
+    mockAuthedSession(2 * 60);
+    const { container } = renderWithIntl(<SessionWatcher />, { locale: 'de' });
+    await flush();
+
+    expect(container).toBeEmptyDOMElement();
+    expect(mockGetSessionStatus).not.toHaveBeenCalled();
+  });
+});

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -562,6 +562,25 @@ export interface AuthUser {
 
 export interface AuthMeResponse {
   user: AuthUser;
+  /** Session expiry — Unix epoch SECONDS (JWT `exp`). */
+  expires_at: number;
+  /** Server clock at response time — Unix epoch SECONDS. Lets the client
+   *  correct for local clock skew instead of trusting its own `Date.now()`. */
+  server_now: number;
+}
+
+/**
+ * Outcome of a `getSessionStatus` probe. A missing/expired session is a
+ * normal result here (`authenticated: false`), not an error — the caller
+ * (SessionWatcher) decides how to surface it.
+ */
+export interface SessionStatus {
+  authenticated: boolean;
+  user: AuthUser | null;
+  /** Session expiry, Unix epoch seconds — null when unauthenticated. */
+  expiresAt: number | null;
+  /** Server clock at probe time, Unix epoch seconds — null when unauthenticated. */
+  serverNow: number | null;
 }
 
 export interface AuthProviderSummary {
@@ -601,6 +620,44 @@ export interface AuthSetupSuccess {
 
 export async function getAuthMe(): Promise<AuthMeResponse> {
   return getJson<AuthMeResponse>('/v1/auth/me');
+}
+
+/**
+ * Browser-only session probe for the SessionWatcher heartbeat. Unlike
+ * `getAuthMe` (via `getJson`), this deliberately does NOT call
+ * `maybeNavigateToLogin` on a 401 — the watcher must render its own
+ * visible "session expired" overlay first instead of an abrupt redirect.
+ * A 401 is therefore an expected outcome, returned as `authenticated:false`.
+ */
+export async function getSessionStatus(): Promise<SessionStatus> {
+  const res = await fetch(botApi('/v1/auth/me'), {
+    headers: { accept: 'application/json' },
+    cache: 'no-store',
+    credentials: 'include',
+  });
+  if (res.status === 401) {
+    return {
+      authenticated: false,
+      user: null,
+      expiresAt: null,
+      serverNow: null,
+    };
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new ApiError(
+      res.status,
+      `GET /v1/auth/me failed: ${res.status}`,
+      text,
+    );
+  }
+  const data = (await res.json()) as AuthMeResponse;
+  return {
+    authenticated: true,
+    user: data.user,
+    expiresAt: data.expires_at,
+    serverNow: data.server_now,
+  };
 }
 
 export async function getAuthProviders(): Promise<AuthProvidersResponse> {

--- a/web-ui/app/layout.tsx
+++ b/web-ui/app/layout.tsx
@@ -11,6 +11,7 @@ import { getLocale, getMessages, getTranslations } from 'next-intl/server';
 import { AuthBadge } from './_components/AuthBadge';
 import { LocaleSwitcher } from './_components/LocaleSwitcher';
 import { Nav } from './_components/Nav';
+import { SessionWatcher } from './_components/SessionWatcher';
 import './globals.css';
 
 /**
@@ -103,6 +104,7 @@ export default async function RootLayout({
             </div>
           </header>
           <div className="min-h-0 flex-1">{children}</div>
+          <SessionWatcher />
         </NextIntlClientProvider>
       </body>
     </html>

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -89,6 +89,17 @@
     "signedInAs": "Angemeldet als",
     "signOut": "Abmelden"
   },
+  "session": {
+    "expiresAtLabel": "Sitzung gültig bis",
+    "warningTitle": "Sitzung läuft bald ab",
+    "warningBody": "Deine Sitzung endet in {time}. Melde dich jetzt neu an, damit du nicht mitten in der Arbeit unterbrochen wirst.",
+    "warningCta": "Jetzt neu anmelden",
+    "warningDismiss": "Später",
+    "expiredKicker": "Sitzung",
+    "expiredTitle": "Sitzung abgelaufen",
+    "expiredBody": "Deine Sitzung ist abgelaufen. Bitte melde dich erneut an, um weiterzuarbeiten.",
+    "expiredCta": "Neu anmelden"
+  },
   "agentDetailsModal": {
     "ariaLabelTitle": "{label} Tool-Aufrufe",
     "ariaCloseBackdrop": "Schließen",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -89,6 +89,17 @@
     "signedInAs": "Signed in as",
     "signOut": "Sign out"
   },
+  "session": {
+    "expiresAtLabel": "Session valid until",
+    "warningTitle": "Session expiring soon",
+    "warningBody": "Your session ends in {time}. Sign in again now so you are not interrupted in the middle of your work.",
+    "warningCta": "Sign in now",
+    "warningDismiss": "Later",
+    "expiredKicker": "Session",
+    "expiredTitle": "Session expired",
+    "expiredBody": "Your session has expired. Please sign in again to continue working.",
+    "expiredCta": "Sign in again"
+  },
   "agentDetailsModal": {
     "ariaLabelTitle": "{label} tool calls",
     "ariaCloseBackdrop": "Close",


### PR DESCRIPTION
## Summary

Entra ID sessions previously logged out **silently**. The `omadia_session`
cookie is a 4h JWT with no refresh; the edge proxy catches an expired
cookie on navigation and `api.ts` catches it on a 401 from an API call —
but an **idle tab** (no navigation, no API call) just went dead with no
signal. The next interaction either bounced the operator out mid-action
or left the UI looking frozen.

This makes the session lifecycle visible.

### Backend
- `GET /api/v1/auth/me` now returns `expires_at` + `server_now` (Unix
  epoch seconds). `server_now` lets the client correct for clock skew.
- `verifySession` surfaces the JWT `exp`/`iat` timestamps via a new
  `VerifiedSession` type. Identity-only callers are unaffected
  (`VerifiedSession extends SessionClaims`).

### Frontend
- New `SessionWatcher`, mounted once in the root layout:
  - Skew-corrected timers raise a **non-blocking warning card** ~5 min
    before expiry (live `M:SS` countdown, "sign in now" / "later").
  - At expiry, a **blocking overlay** replaces the silent freeze.
  - A 60s heartbeat + a tab-refocus re-check also catch **server-side
    revocation** (account disabled, key rotation) that the local clock
    cannot see.
- `AuthBadge` dropdown shows the session-valid-until time.
- No silent auto-extend — re-login is always explicit (hard logout).

## Test plan

- [x] `middleware` typecheck + `web-ui` typecheck
- [x] `lint:fix` both packages (0 errors in new code)
- [x] middleware: new `sessionJwt` unit test + full auth suite (51/51)
- [x] web-ui: new `SessionWatcher` component test (5/5) — deterministic
      coverage of normal → warning → expired, heartbeat-detected
      revocation, and the `/login` no-op guard (fake timers)
- [x] web-ui dev server (Next 16 Turbopack) compiles all changed files
      cleanly; `/login` renders 200 through the modified layout
- [ ] Authed click-through of the live modals — needs an Entra/local
      login; behaviour is covered by the deterministic component test

## Notes

- The 9 new `session.*` i18n keys were added directly to
  `messages/{en,de}.json`. These must also be entered into **i18nexus**
  or they will be overwritten on the next pull.
