### PR TITLE
fix(builder): emit @omadia/agent-* namespace for new agents

### DIFF
--- a/middleware/assets/boilerplate/agent-integration/manifest.yaml
+++ b/middleware/assets/boilerplate/agent-integration/manifest.yaml
@@ -9,7 +9,7 @@ schema_version: "1"
 # ===========================================================================
 
 identity:
-  id: "{{AGENT_ID}}"                     # z.B. de.byte5.agent.sharepoint
+  id: "{{AGENT_ID}}"                     # z.B. @omadia/agent-sharepoint
   kind: "agent"
   domain: "{{AGENT_DOMAIN}}"             # z.B. m365.sharepoint, odoo.hr — lowercase, dotted, kebab-case mid-segment OK
   name: "{{AGENT_NAME}}"

--- a/middleware/src/plugins/builder/agentSpec.ts
+++ b/middleware/src/plugins/builder/agentSpec.ts
@@ -36,11 +36,18 @@ const ToolIdSchema = z
   .string()
   .regex(/^[a-z][a-z0-9_]*$/, 'Tool ID must be snake_case (lowercase, digits, underscore)');
 
-// DNS-label compatible — agent IDs become URL-safe directory names and
-// flow into the manifest as the package id.
+// Builder-generated agents are npm-scoped (`@omadia/agent-<slug>`), matching
+// the hand-coded platform agents (`@omadia/agent-seo-analyst`). The scope +
+// slug flow into the manifest as the package id; `deriveAgentSlug` strips the
+// scope down to a URL-safe directory name. The legacy reverse-FQDN form
+// (`de.byte5.agent.<slug>`) stays accepted so drafts created before the
+// namespace migration still parse.
 const AgentIdSchema = z
   .string()
-  .regex(/^[a-z][a-z0-9.-]*$/, 'Agent ID must be a DNS-label-compatible reverse-FQDN');
+  .regex(
+    /^(?:@[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*|[a-z][a-z0-9.-]*)$/,
+    'Agent ID must be npm-scoped (`@omadia/agent-foo`) or a reverse-FQDN (`de.byte5.agent.foo`)',
+  );
 
 // `depends_on` and (transitively) downstream cross-plugin references must
 // also accept npm-scoped IDs (`@omadia/agent-seo-analyst`, `@omadia/memory`)
@@ -49,9 +56,8 @@ const AgentIdSchema = z
 // existing platform plugin at all — Zod rejects the `@`/`/` characters at
 // parse time, long before the manifestLinter's catalog check runs.
 //
-// `spec.id` itself stays restricted to reverse-FQDN (Builder-convention) —
-// only depends_on (and capability/service refs that ride on the same naming
-// space) is widened.
+// `spec.id` accepts the same widened shape (see AgentIdSchema above) — the
+// Builder now emits npm-scoped ids by default.
 const DependsOnIdSchema = z
   .string()
   .regex(

--- a/middleware/src/plugins/builder/codegen.ts
+++ b/middleware/src/plugins/builder/codegen.ts
@@ -196,7 +196,7 @@ function placeholderHintFor(source: string): string {
       'de.byte5.integration.confluence) — the agent-integration template ' +
       'requires at least one entry to wire the vault scope.';
   }
-  if (source === 'id') return 'Set spec.id to a reverse-FQDN (e.g. de.byte5.agent.example).';
+  if (source === 'id') return 'Set spec.id to an npm-scoped name (e.g. @omadia/agent-example).';
   if (source === 'name') return 'Set spec.name to a human-readable agent name.';
   if (source === 'category') return 'Set spec.category (e.g. "communication", "analytics").';
   if (source === 'skill.role') return 'Set spec.skill.role to describe the agent\'s persona.';

--- a/middleware/src/plugins/builder/manifestLinter.ts
+++ b/middleware/src/plugins/builder/manifestLinter.ts
@@ -97,7 +97,7 @@ export function validateSpec(
           path: '/id',
           message:
             `spec.id '${specId}' is in the reserved namespace '${prefix}*'. ` +
-            'Pick a different prefix (e.g. `de.byte5.agent.<your-name>`).',
+            'Pick a different prefix (e.g. `@omadia/agent-<your-name>`).',
         });
         break;
       }

--- a/middleware/src/plugins/builder/prompts/builder-system.md
+++ b/middleware/src/plugins/builder/prompts/builder-system.md
@@ -95,7 +95,7 @@ sonst meldet `lint_spec` `severity: "error"`-Issues und der Turn endet
 ohne Codegen.
 
 Pflicht (per `patch_spec`):
-- **`spec.id`** — reverse-FQDN (`de.byte5.agent.<slug>`).
+- **`spec.id`** — npm-scoped (`@omadia/agent-<slug>`).
 - **`spec.name`** — human-readable (`Microsoft SharePoint Agent`).
 - **`spec.description`** — eine Zeile, was der Agent tut.
 - **`spec.category`** — productivity | crm | documents | communication | analysis | other.

--- a/middleware/test/builder/agentSpec.test.ts
+++ b/middleware/test/builder/agentSpec.test.ts
@@ -39,6 +39,14 @@ describe('agentSpec', () => {
       assert.throws(() => parseAgentSpec({ ...validBase, id: '1foo' }));
     });
 
+    it('accepts an npm-scoped agent id (`@omadia/agent-<slug>`)', () => {
+      // Builder now emits npm-scoped ids by default, analogous to the
+      // hand-coded `@omadia/agent-seo-analyst`. The legacy reverse-FQDN
+      // form stays accepted (see `validBase` above).
+      const spec = parseAgentSpec({ ...validBase, id: '@omadia/agent-weather' });
+      assert.equal(spec.id, '@omadia/agent-weather');
+    });
+
     it('rejects unknown top-level keys via strict()', () => {
       assert.throws(() => parseAgentSpec({ ...validBase, extra_field: 'x' }));
     });

--- a/middleware/test/builder/codegen.test.ts
+++ b/middleware/test/builder/codegen.test.ts
@@ -101,6 +101,30 @@ describe('codegen.generate', () => {
     assert.match(pluginText, /AGENT_ID = 'de\.byte5\.agent\.weather'/);
   });
 
+  it('generates a valid package for an npm-scoped agent id (`@omadia/agent-*`)', async () => {
+    const { spec: base, slots } = loadFixture();
+    const spec = parseAgentSpec({
+      ...base,
+      id: '@omadia/agent-monty-python',
+      name: 'Entertainer',
+    });
+    const out = await generate({ spec, slots });
+
+    // Manifest carries the scoped id verbatim; the `agent:<id>:*` permission
+    // scopes derive from it (mirrors the hand-coded @omadia/agent-seo-analyst).
+    const manifestText = out.get('manifest.yaml')!.toString('utf-8');
+    assert.match(manifestText, /id:\s*"@omadia\/agent-monty-python"/);
+    assert.match(manifestText, /agent:@omadia\/agent-monty-python:\*/);
+
+    // plugin.ts AGENT_ID constant gets the scoped id.
+    const pluginText = out.get('plugin.ts')!.toString('utf-8');
+    assert.match(pluginText, /AGENT_ID = '@omadia\/agent-monty-python'/);
+
+    // deriveAgentSlug strips the npm scope → URL-safe directory/file name.
+    assert.ok(out.has('skills/agent-monty-python-expert.md'));
+    assert.equal(out.has('skills/{{AGENT_SLUG}}-expert.md'), false);
+  });
+
   it('injects the toolkit-impl slot between markers', async () => {
     const { spec, slots } = loadFixture();
     const out = await generate({ spec, slots });


### PR DESCRIPTION
## Problem

New Builder-generated agents were created in the **wrong namespace** — reverse-FQDN `de.byte5.agent.<slug>` (e.g. the `Entertainer` agent showed up as `de.byte5.agent.monty-python`). The hand-coded platform agents already use the npm-scoped form (`@omadia/agent-seo-analyst`, with `id: "@omadia/agent-seo-analyst"` in their manifest). The namespace migration was only half-applied: the Builder system prompt and the spec schema still pinned the legacy shape.

## Changes

- **`agentSpec.ts`** — `AgentIdSchema` widened to accept npm-scoped ids (`@omadia/agent-foo`). Legacy reverse-FQDN stays accepted so drafts created before the migration still parse.
- **`builder-system.md`** — the Builder LLM is now instructed to emit `spec.id` as `@omadia/agent-<slug>`.
- **`manifestLinter.ts` / `codegen.ts`** — example strings in hint/error messages updated to the npm-scoped form.
- **`agent-integration/manifest.yaml`** — boilerplate `id` comment example updated.

`deriveAgentSlug` already split on `/`, so the scoped id flows cleanly with no further plumbing.

## Concrete verification

Ran the real codegen pipeline with `id: "@omadia/agent-monty-python"`:

```
spec.id accepted by Zod schema : @omadia/agent-monty-python

identity:
  id: "@omadia/agent-monty-python"
  kind: "agent"
  name: "Entertainer"
permissions:
  memory:
    reads: [ "session:*", "agent:@omadia/agent-monty-python:*" ]
    writes: [ "agent:@omadia/agent-monty-python:*" ]

plugin.ts  -> export const AGENT_ID = '@omadia/agent-monty-python' as const;
skill file -> skills/agent-monty-python-expert.md   (scope stripped by deriveAgentSlug)
```

This matches the hand-coded `@omadia/agent-seo-analyst` shape exactly — and that agent already proves install + runtime accept scoped ids in production.

## Scope notes

- **Existing agents are not migrated** — the id is persisted, so already-built agents (e.g. `de.byte5.agent.monty-python`) keep their id. Only newly built agents change. A migration path can follow if desired.
- `suggestDependsOn.ts` and two `depends_on` examples in the Builder prompt still reference `de.byte5.integration.*`. Whether that is wrong depends on the (gitignored) integration manifest ids — out of scope here; flagged for a separate look.

## Tests

- `agentSpec.test.ts` — new case: `@omadia/agent-*` is accepted as `spec.id`.
- `codegen.test.ts` — new case: codegen produces a valid package for `@omadia/agent-*` (manifest id, `agent:<id>:*` scopes, `plugin.ts` AGENT_ID, slug derivation).
- Full builder suite: 904 pass, 0 fail. Typecheck + lint clean.

## Test plan

- [ ] Live Builder smoke test: create a new agent through the Builder UI, confirm the resulting `spec.id` / manifest id is `@omadia/agent-<slug>`.
