### PR TITLE
fix(privacy): harden outbound payload against lone UTF-16 surrogates

### DIFF
--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -73,6 +73,7 @@ import {
 import {
   applyPrivacyOutboundToParams,
   createPrivacyTurnHandle,
+  ensureWellFormedParams,
   restorePrivacyInResponse,
 } from './privacyHandle.js';
 import { RunTraceCollector, type InvocationHandle } from './runTraceCollector.js';
@@ -1603,9 +1604,13 @@ export class Orchestrator {
         const outboundParams = privacy
           ? await applyPrivacyOutboundToParams(baseParams, privacy, 'orchestrator')
           : baseParams;
+        // Last-resort guard: repair any lone UTF-16 surrogate before the
+        // SDK serialises the body — the Anthropic API rejects it as
+        // invalid JSON. See ensureWellFormedParams.
+        const safeParams = ensureWellFormedParams(outboundParams);
 
         const response: Message = await this.client.messages.create(
-          outboundParams,
+          safeParams,
           { headers: { 'anthropic-beta': MEMORY_BETA_HEADER } },
         );
 

--- a/middleware/packages/harness-orchestrator/src/privacyHandle.ts
+++ b/middleware/packages/harness-orchestrator/src/privacyHandle.ts
@@ -336,6 +336,65 @@ export async function applyPrivacyOutboundToParams(
   return { ...params, system: newSystem, messages: newMessages };
 }
 
+// ---------------------------------------------------------------------------
+// Outbound surrogate hardening — last-resort guard before the API call.
+//
+// A JS string may legally hold a lone UTF-16 surrogate, but JSON cannot.
+// The Anthropic SDK `JSON.stringify`s the request body, and the API
+// rejects a lone surrogate with `400 invalid_request_error: invalid high
+// surrogate in string`. Detector-driven span replacement in the privacy
+// guard can split a surrogate pair when an upstream offset is off, and
+// corrupt upstream data can carry one in directly — this guard repairs
+// the payload so one bad character in a large tool result can't fail the
+// whole turn.
+// ---------------------------------------------------------------------------
+
+const ANY_SURROGATE = /[\uD800-\uDFFF]/;
+const LONE_SURROGATE =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+
+/**
+ * Replace every lone UTF-16 surrogate in `value` with U+FFFD. Returns a
+ * value-equal string when the input is already well-formed — well-formed
+ * strings (the overwhelming majority) skip the rewrite entirely.
+ */
+function toWellFormed(value: string): string {
+  if (!ANY_SURROGATE.test(value)) return value;
+  return value.replace(LONE_SURROGATE, '�');
+}
+
+/**
+ * Deep-walk an Anthropic-API-shape `params` object and repair every
+ * reachable string so the serialised request body is valid JSON.
+ * Structurally shares everything that needed no change — when the whole
+ * payload is well-formed the original reference is returned untouched.
+ */
+export function ensureWellFormedParams<T>(value: T): T {
+  if (typeof value === 'string') {
+    return toWellFormed(value) as T;
+  }
+  if (Array.isArray(value)) {
+    let changed = false;
+    const out = value.map((item) => {
+      const next = ensureWellFormedParams(item);
+      if (next !== item) changed = true;
+      return next;
+    });
+    return (changed ? out : value) as T;
+  }
+  if (value !== null && typeof value === 'object') {
+    let changed = false;
+    const out: Record<string, unknown> = {};
+    for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+      const next = ensureWellFormedParams(v);
+      if (next !== v) changed = true;
+      out[key] = next;
+    }
+    return (changed ? out : value) as T;
+  }
+  return value;
+}
+
 /**
  * Walk an Anthropic-API-shape response message and restore tokens in
  * every `text` content block. Mutates in place. Safe to call when the

--- a/middleware/packages/harness-orchestrator/src/streaming.ts
+++ b/middleware/packages/harness-orchestrator/src/streaming.ts
@@ -2,6 +2,7 @@ import type Anthropic from '@anthropic-ai/sdk';
 import type { AskObserver } from './tools/domainQueryTool.js';
 import {
   applyPrivacyOutboundToParams,
+  ensureWellFormedParams,
   restorePrivacyInResponse,
   streamingTokenBoundary,
 } from './privacyHandle.js';
@@ -66,9 +67,12 @@ export async function* streamMessageEvents(args: {
 
   // Privacy-Proxy outbound transform.
   const privacy = turnContext.current()?.privacyHandle;
-  const params = privacy
+  const transformedParams = privacy
     ? await applyPrivacyOutboundToParams(args.params, privacy, streamLabel)
     : args.params;
+  // Last-resort guard: repair any lone UTF-16 surrogate so the request
+  // body is valid JSON for the Anthropic API. See ensureWellFormedParams.
+  const params = ensureWellFormedParams(transformedParams);
 
   safe(
     () => observer?.onIterationPhase?.({ iteration, phase: 'thinking' }),

--- a/middleware/packages/harness-plugin-privacy-detector-presidio/src/presidioDetector.ts
+++ b/middleware/packages/harness-plugin-privacy-detector-presidio/src/presidioDetector.ts
@@ -14,11 +14,13 @@
  *   - The detector is safe to call concurrently. The Presidio sidecar
  *     handles concurrent /analyze requests internally; the client adds
  *     no shared state.
- *   - Span offsets returned by Presidio are byte-accurate (computed in
- *     Python from the same UTF-16 string we sent). We still re-anchor
- *     defensively via `text.indexOf(value, cursor)` to stay symmetric
- *     with the Slice-3.2 Ollama detector and survive any future
- *     surrogate-pair mismatches.
+ *   - Span offsets returned by Presidio are Unicode CODE-POINT indices
+ *     (Python `str` semantics), not UTF-16 code units. They coincide
+ *     for BMP-only text but diverge by one per astral character (emoji,
+ *     …); `mapHits` translates them to UTF-16 offsets before slicing so
+ *     a span boundary can never fall inside a surrogate pair. A leftover
+ *     lone surrogate would otherwise reach the Anthropic request body
+ *     and fail the whole turn with `400 invalid high surrogate`.
  */
 
 import type {
@@ -152,6 +154,39 @@ export function createPresidioDetector(
 }
 
 /**
+ * Build a code-point-index → UTF-16-code-unit-index lookup table.
+ *
+ * `map[i]` is the UTF-16 offset of the i-th Unicode code point;
+ * `map[cpCount]` is `text.length` (sentinel, so exclusive end offsets
+ * resolve). Presidio reports spans in Python `str` semantics — code
+ * points — while JS `string.slice` indexes UTF-16 code units; applying
+ * a code-point offset directly can split a surrogate pair.
+ */
+function buildCodePointToUnitMap(text: string): number[] {
+  const map: number[] = [];
+  let unit = 0;
+  for (const ch of text) {
+    map.push(unit);
+    unit += ch.length; // 1 for a BMP char, 2 for an astral char
+  }
+  map.push(unit);
+  return map;
+}
+
+/**
+ * True when `text` carries a UTF-16 high surrogate — i.e. an astral
+ * character (or a lone surrogate). BMP-only text needs no offset
+ * translation, so the common path stays allocation-free.
+ */
+function hasHighSurrogate(text: string): boolean {
+  for (let i = 0; i < text.length; i += 1) {
+    const c = text.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) return true;
+  }
+  return false;
+}
+
+/**
  * Map raw Presidio hits to canonical `PrivacyDetectorHit`s.
  *
  *   - Drops hits whose entity type is on the exclude list (DATE_TIME,
@@ -159,8 +194,10 @@ export function createPresidioDetector(
  *   - Drops hits below `scoreThreshold` (defence in depth — the
  *     sidecar already filters but the operator's plugin-side
  *     threshold may be stricter than the sidecar's process-wide one).
- *   - Re-anchors spans via `indexOf` if the byte offsets don't slice
- *     to the expected substring (extra robustness).
+ *   - Translates Presidio's code-point offsets to UTF-16 code-unit
+ *     offsets so a span boundary can never split a surrogate pair.
+ *   - Re-anchors spans via `indexOf` if the slice carries stray
+ *     whitespace (extra robustness).
  *   - Computes the matched substring from the source text since the
  *     sidecar response intentionally omits it (smaller wire payload,
  *     PII-free transport).
@@ -174,30 +211,48 @@ function mapHits(
 ): PrivacyDetectorHit[] {
   const out: PrivacyDetectorHit[] = [];
   let cursor = 0;
+
+  // Presidio offsets are Python code-point indices. Translate them to
+  // UTF-16 code-unit indices when the text contains astral characters,
+  // so a span boundary can never land inside a surrogate pair — a split
+  // pair leaves a lone surrogate that fails the Anthropic request body.
+  const cpToUnit = hasHighSurrogate(text)
+    ? buildCodePointToUnitMap(text)
+    : undefined;
+  const maxOffset = cpToUnit ? cpToUnit.length - 1 : text.length;
+
   for (const raw of rawHits) {
     if (raw.score < scoreThreshold) continue;
     const mappedType = mapPresidioType(raw.entity_type, language);
     if (mappedType === undefined) continue;
 
-    const len = text.length;
     let { start, end } = raw;
     if (
       !Number.isInteger(start) ||
       !Number.isInteger(end) ||
       start < 0 ||
-      end > len ||
+      end > maxOffset ||
       start >= end
     ) {
       // Out-of-range — drop the hit, we can't trust the value.
       continue;
     }
 
+    // Translate code-point offsets → UTF-16 code-unit offsets.
+    if (cpToUnit) {
+      const unitStart = cpToUnit[start];
+      const unitEnd = cpToUnit[end];
+      if (unitStart === undefined || unitEnd === undefined) continue;
+      start = unitStart;
+      end = unitEnd;
+    }
+
     let value = text.slice(start, end);
     if (value.length === 0) continue;
 
-    // Defensive re-anchor: if the slice somehow doesn't read like a
-    // proper match (e.g. UTF-16 surrogate-pair edge case), try to
-    // realign via indexOf from the cursor.
+    // Defensive re-anchor: if the slice carries stray leading/trailing
+    // whitespace, realign to the trimmed match via indexOf from the
+    // cursor.
     const trimmed = value.trim();
     if (trimmed.length === 0) continue;
     if (trimmed !== value) {

--- a/middleware/test/privacyDetectorPresidio.test.ts
+++ b/middleware/test/privacyDetectorPresidio.test.ts
@@ -227,6 +227,56 @@ describe('createPresidioDetector · adapter contract (Slice 3.4)', () => {
     assert.equal(text.slice(...outcome.hits[0]!.span), 'John');
   });
 
+  it('translates Presidio code-point offsets to UTF-16 for astral-char input', async () => {
+    // 😀 (U+1F600) is one Unicode code point but two UTF-16 code units.
+    // Presidio runs on a Python `str` and reports code-point offsets:
+    // "John Müller" sits at code points [1, 12).
+    const text = '😀John Müller ist da.';
+    const detector = createPresidioDetector({
+      client: stubClient(() => ({ hits: [rawHit('PERSON', 1, 12, 0.9)] })),
+      language: 'de',
+      detectorId: 'presidio:test',
+      maxInputChars: 100_000,
+      timeoutMs: 3000,
+      scoreThreshold: 0.4,
+      log: () => {},
+    });
+    const outcome = await detector.detect(text);
+    assert.equal(outcome.hits.length, 1);
+    const hit = outcome.hits[0]!;
+    // The span is UTF-16 — slicing the original text yields the real name.
+    assert.equal(text.slice(...hit.span), 'John Müller');
+    assert.equal(hit.value, 'John Müller');
+  });
+
+  it('astral offset never leaves a lone surrogate after span replacement', async () => {
+    // Reproduces the production `400 invalid high surrogate` failure: a
+    // span boundary that — read as a UTF-16 offset — falls between the
+    // high and low surrogate of an emoji. The privacy guard rebuilds the
+    // text as `slice(0,start) + token + slice(end)`; it must stay
+    // well-formed.
+    const text = '😀John';
+    const detector = createPresidioDetector({
+      client: stubClient(() => ({ hits: [rawHit('PERSON', 1, 5, 0.9)] })),
+      language: 'de',
+      detectorId: 'presidio:test',
+      maxInputChars: 100_000,
+      timeoutMs: 3000,
+      scoreThreshold: 0.4,
+      log: () => {},
+    });
+    const outcome = await detector.detect(text);
+    assert.equal(outcome.hits.length, 1);
+    const [start, end] = outcome.hits[0]!.span;
+    const rebuilt = text.slice(0, start) + '«PERSON_1»' + text.slice(end);
+    assert.doesNotMatch(
+      rebuilt,
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
+      'rebuilt text must contain no lone surrogate',
+    );
+    assert.equal(rebuilt, '😀«PERSON_1»');
+  });
+
   it('declares scanTargets={systemPrompt:false, userMessages:true, assistantMessages:true} — Slice 3.4.3', () => {
     // Slice 3.4 boot-smoke surfaced 270+ hits in one turn (memory
     // recall in the system prompt). 3.4.2 narrowed to user-only, but

--- a/middleware/test/requestWellFormed.test.ts
+++ b/middleware/test/requestWellFormed.test.ts
@@ -1,0 +1,78 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { ensureWellFormedParams } from '@omadia/orchestrator/dist/privacyHandle.js';
+
+// ---------------------------------------------------------------------------
+// Outbound surrogate hardening — `ensureWellFormedParams`.
+//
+// A lone UTF-16 surrogate is legal in a JS string but not in JSON; the
+// Anthropic SDK serialises the request body and the API rejects it with
+// `400 invalid_request_error: invalid high surrogate in string`. This
+// guard repairs the payload as a last resort before the API call —
+// detector-driven span replacement can split a surrogate pair, and
+// corrupt upstream tool-result data can carry one in directly.
+// ---------------------------------------------------------------------------
+
+const LONE_SURROGATE =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
+describe('ensureWellFormedParams', () => {
+  it('replaces a lone high surrogate nested in a tool_result block', () => {
+    const params = {
+      model: 'claude',
+      max_tokens: 1024,
+      system: 'system prompt',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_1',
+              content: 'Erlöse 2025\uD83Dabgeschnitten', // lone high surrogate
+            },
+          ],
+        },
+      ],
+    };
+    const safe = ensureWellFormedParams(params);
+    // The whole payload now serialises without throwing.
+    assert.doesNotThrow(() => JSON.stringify(safe));
+    const fixed = safe.messages[0]!.content[0]!.content;
+    assert.doesNotMatch(fixed, LONE_SURROGATE);
+    assert.equal(fixed, 'Erlöse 2025�abgeschnitten');
+  });
+
+  it('repairs a split surrogate pair across separate messages', () => {
+    // 😀 is U+D83D U+DE00. A bad slice can leave the high half at the end
+    // of one string and the low half at the start of another.
+    const params = {
+      messages: [
+        { role: 'assistant', content: 'pre\uD83D' }, // dangling high
+        { role: 'user', content: '\uDE00post' }, // dangling low
+      ],
+    };
+    const safe = ensureWellFormedParams(params);
+    assert.equal(safe.messages[0]!.content, 'pre�');
+    assert.equal(safe.messages[1]!.content, '�post');
+  });
+
+  it('returns the input untouched when every string is well-formed', () => {
+    const params = {
+      system: 'plain ASCII',
+      messages: [
+        { role: 'user', content: 'Erlöse, Müller, 😀 emoji, 日本語' },
+      ],
+    };
+    // No lone surrogates → same reference back, zero allocation.
+    assert.equal(ensureWellFormedParams(params), params);
+  });
+
+  it('preserves a valid (paired) astral character', () => {
+    const params = { messages: [{ role: 'user', content: '😀 ok' }] };
+    const safe = ensureWellFormedParams(params);
+    assert.equal(safe.messages[0]!.content, '😀 ok');
+    assert.doesNotMatch(safe.messages[0]!.content, LONE_SURROGATE);
+  });
+});


### PR DESCRIPTION
## Summary

A lone UTF-16 surrogate is legal in a JS string but not in JSON. The Anthropic SDK serialises the request body and the API rejects a lone surrogate with `400 invalid_request_error: invalid high surrogate in string` — failing the whole turn over one bad character.

Two layers of defense against the same failure:

**Root cause — Presidio span offsets.** `presidioDetector.ts` mapped hit spans using code-point offsets directly. With astral characters (emoji) in a tool result, a code-point offset can land inside a UTF-16 surrogate pair, so span-replacement splits the pair. New `buildCodePointToUnitMap` / `hasHighSurrogate` translate to code-unit offsets; BMP-only text skips the remap.

**Last-resort guard — `ensureWellFormedParams`.** A deep walk over the Anthropic-API-shape `params` that replaces every reachable lone surrogate with U+FFFD, sharing structure where nothing changed. Wired into `streaming.ts` after the privacy outbound transform and into the non-streaming `orchestrator.ts` path. Catches detector-split pairs and corrupt upstream tool-result data alike.

## Context

This was uncommitted work-in-progress found on `main` when picking up the privacy-guard line of work; extracted into its own branch so it lands as a reviewable unit (independent of the stable-id PR #86).

## Test plan
- [x] New `requestWellFormed.test.ts` — lone surrogate in tool_result blocks, well-formed pass-through identity, astral round-trip
- [x] `privacyDetectorPresidio.test.ts` astral-offset regression reproducing the production `400`
- [x] 24 tests in the two files pass
- [x] Privacy regression 88/88 (2 pre-existing skips); lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)