### PR TITLE
fix(middleware): Anthropic maxRetries=5 + log orchestrator turn failures

### DIFF
--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -2401,6 +2401,15 @@ export class Orchestrator {
         message: `Orchestrator exceeded maxToolIterations (${String(this.maxIterations)}) without reaching a final answer.`,
       };
     } catch (err) {
+      // This catch did not log before — a turn failing on a transient
+      // provider error (e.g. Anthropic `overloaded_error` / HTTP 529) was
+      // invisible in the server logs. Log the technical detail here. The
+      // user-facing error-message wording is handled separately (Privacy
+      // Shield v4).
+      console.error(
+        '[orchestrator] turn failed:',
+        err instanceof Error ? (err.stack ?? err.message) : err,
+      );
       yield {
         type: 'error',
         message: err instanceof Error ? err.message : String(err),

--- a/middleware/packages/harness-orchestrator/src/plugin.ts
+++ b/middleware/packages/harness-orchestrator/src/plugin.ts
@@ -311,8 +311,13 @@ export async function activate(
     ctx.config.get<string>('graph_tenant_id') ??
     'default';
 
-  // Anthropic client + storage layer
-  const client = new Anthropic({ apiKey });
+  // Anthropic client + storage layer.
+  //
+  // maxRetries: the Anthropic SDK auto-retries 408/409/429/500/529 with
+  // exponential backoff. The SDK default is 2; bumped to 5 so a transient
+  // `overloaded_error` (HTTP 529) burst is far more likely to ride out
+  // inside the SDK instead of surfacing as a failed turn.
+  const client = new Anthropic({ apiKey, maxRetries: 5 });
   const chatSessionStore = new ChatSessionStore(memoryStore);
   const sessionLogger = new SessionLogger(
     memoryStore,

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -230,7 +230,15 @@ async function main(): Promise<void> {
   // calls) and the Teams channel (anthropicClient dep). The orchestrator-
   // plugin constructs ITS OWN client from `anthropic_api_key` setup-field —
   // they're functionally equivalent but separate instances.
-  const client = new Anthropic({ apiKey: config.ANTHROPIC_API_KEY });
+  //
+  // maxRetries: the Anthropic SDK auto-retries 408/409/429/500/529 with
+  // exponential backoff. The SDK default is 2; bumped to 5 so a transient
+  // `overloaded_error` (HTTP 529) burst is far more likely to ride out
+  // inside the SDK instead of surfacing as a failed turn.
+  const client = new Anthropic({
+    apiKey: config.ANTHROPIC_API_KEY,
+    maxRetries: 5,
+  });
 
   // Phase 5B: publish the raw Anthropic client so dynamic-imported channel
   // plugins (Teams, future) can late-resolve it via ctx.services.get(...)


### PR DESCRIPTION
## Kontext

Ein GEO-Check über die Chat-UI (`https://omadia.ai`) ist mit einem rohen Anthropic-Fehler abgebrochen:

```json
{"type":"error","error":{"details":null,"type":"overloaded_error","message":"Overloaded"},"request_id":"req_011CbGzBPUZuLKa8rB1r53ar"}
```

`overloaded_error` (HTTP 529) ist ein **transienter Anthropic-seitiger Fehler** — kein Bug im Middleware-Code. Die Untersuchung legte zwei Robustheits-Lücken offen.

## Änderungen

- **Explizites `maxRetries: 5`** auf beiden `new Anthropic(...)`-Clients (Middleware-Kernel `index.ts` + Orchestrator-Plugin `plugin.ts`). Das SDK retried 408/409/429/500/529 automatisch mit exponential backoff; der Default ist nur `2`. Mit `5` reitet ein transienter 529-Burst deutlich wahrscheinlicher innerhalb des SDK aus, statt den Turn fehlschlagen zu lassen.
- **Server-seitiges Logging** im `catch` der Orchestrator-Hauptschleife. Dieser Pfad `yield`ete bisher ein `type: 'error'`-Event **ganz ohne Log** — Turn-Failures (inkl. Provider-529s) waren in den Middleware-Logs unsichtbar. Jetzt `console.error` mit Stacktrace.

## Bewusst NICHT enthalten

Die **User-facing-Fehlermeldung** (freundlicher Text statt Raw-JSON in der Chat-UI) bleibt unangetastet — diese UX wird separat in **Privacy Shield v4** umgesetzt.

## Test plan

- [x] `npm run lint:fix` — grün, keine Auto-Fixes
- [x] `npm run typecheck` — grün
- [ ] Reviewer: GEO-Check gegen `https://omadia.ai` erneut auslösen — sollte jetzt durchlaufen (529 war transient)