### PR TITLE
fix(orchestrator): retry mid-stream Anthropic overloaded_error

### DIFF
--- a/middleware/packages/harness-orchestrator/src/index.ts
+++ b/middleware/packages/harness-orchestrator/src/index.ts
@@ -27,6 +27,9 @@ export type {
 export { Orchestrator, parseToolEmittedChoice } from './orchestrator.js';
 export type { OrchestratorOptions } from './orchestrator.js';
 
+// Streaming retry predicate (exported for unit coverage)
+export { isRetryableStreamError } from './streaming.js';
+
 // Verifier wrapper (couples verifier@1 pipeline + Orchestrator + toSemanticAnswer)
 export { VerifierService } from './verifierService.js';
 

--- a/middleware/packages/harness-orchestrator/src/streaming.ts
+++ b/middleware/packages/harness-orchestrator/src/streaming.ts
@@ -16,6 +16,73 @@ export type StreamMessageEvent =
   | { type: 'text_delta'; text: string }
   | { type: 'final'; message: Message };
 
+/** Max attempts for a single streamed iteration (1 initial + 4 retries). */
+const MAX_STREAM_ATTEMPTS = 5;
+
+/** Anthropic error-body `type` discriminators that are worth retrying. */
+const RETRYABLE_ERROR_TYPES = [
+  'overloaded_error',
+  'rate_limit_error',
+  'api_error',
+];
+
+/** HTTP statuses that are worth retrying when the error carries one. */
+const RETRYABLE_STATUS = new Set([408, 409, 429, 500, 502, 503, 529]);
+
+/**
+ * Detects the mid-stream errors that are safe + worthwhile to retry.
+ *
+ * The Anthropic API can return HTTP 200, begin the SSE stream, and only THEN
+ * inject an `{"type":"error","error":{"type":"overloaded_error"}}` event when
+ * the backend gets overloaded after the request was accepted. That event
+ * never reaches the SDK's HTTP-level `maxRetries` (the request already
+ * "succeeded" with 200), so it surfaces as a thrown error during stream
+ * iteration — see `Stream.iterator` in `@anthropic-ai/sdk/core/streaming`.
+ *
+ * Transient provider states (`overloaded_error`, `rate_limit_error`,
+ * `api_error`, 5xx, 429) are retryable; everything else (e.g.
+ * `invalid_request_error`) is a hard failure and must NOT be retried.
+ */
+export function isRetryableStreamError(err: unknown): boolean {
+  // Property reads below would throw on null/undefined — normalise first so
+  // those fall through to the (non-matching) message-text scan.
+  const e: Record<string, unknown> =
+    typeof err === 'object' && err !== null
+      ? (err as Record<string, unknown>)
+      : {};
+
+  const status = e['status'];
+  if (typeof status === 'number' && RETRYABLE_STATUS.has(status)) return true;
+
+  // Anthropic error bodies nest as `{ type:'error', error:{ type:'...' } }`;
+  // the SDK has also shipped a flattened `{ type:'...' }`. Probe both.
+  const body = e['error'];
+  for (const candidate of [body, (body as { error?: unknown } | undefined)?.error]) {
+    const type = (candidate as { type?: unknown } | undefined)?.type;
+    if (typeof type === 'string' && RETRYABLE_ERROR_TYPES.includes(type)) {
+      return true;
+    }
+  }
+
+  // Last resort: a mid-stream error surfaces as `new Error(<raw JSON body>)`,
+  // so the discriminator is only reachable by scanning the message text.
+  const text = err instanceof Error ? err.message : String(err);
+  return RETRYABLE_ERROR_TYPES.some((type) => text.includes(type));
+}
+
+/**
+ * Exponential backoff with full jitter: base ~1s, 2s, 4s, 8s (capped). Jitter
+ * spreads the retry burst so many turns failing on the same overload window
+ * do not all hammer the API back in lockstep.
+ */
+function streamRetryDelayMs(attempt: number): number {
+  const base = Math.min(1000 * 2 ** (attempt - 1), 8000);
+  return Math.round(base * (0.5 + Math.random() * 0.5));
+}
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
 /**
  * Streams a single iteration through `client.messages.stream` and yields
  * progress events. Phase transitions (`thinking` → `streaming` →
@@ -30,6 +97,12 @@ export type StreamMessageEvent =
  *
  * `streamLabel` is used as the prefix for observer-callback warnings so the
  * caller (sub-agent vs. orchestrator) can be identified in logs.
+ *
+ * Retry: a mid-stream `overloaded_error` (see {@link isRetryableStreamError})
+ * is retried with exponential backoff, but ONLY while no `text_delta` has been
+ * forwarded to the caller yet — re-running the request after partial output
+ * would duplicate visible text in the UI. A start-of-stream overload (the
+ * common case) always fails before the first delta, so it is fully covered.
  *
  * Privacy Shield v4 keeps no outbound/inbound transform on this path — raw
  * tool results are interned at the tool-dispatch seam, never on the wire,
@@ -58,111 +131,147 @@ export async function* streamMessageEvents(args: {
   // body is valid JSON for the Anthropic API. See ensureWellFormedParams.
   const params = ensureWellFormedParams(args.params);
 
-  safe(
-    () => observer?.onIterationPhase?.({ iteration, phase: 'thinking' }),
-    'onIterationPhase',
-  );
+  for (let attempt = 1; ; attempt++) {
+    // `forwardedText` gates the retry: once a `text_delta` has been yielded
+    // it has already been streamed to the UI, so re-running the request
+    // would duplicate visible output. We only retry while the stream failed
+    // before producing any forwarded text — exactly how a start-of-stream
+    // `overloaded_error` behaves.
+    let forwardedText = false;
+    try {
+      safe(
+        () => observer?.onIterationPhase?.({ iteration, phase: 'thinking' }),
+        'onIterationPhase',
+      );
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const stream: any = requestOptions
-    ? client.messages.stream(params, requestOptions)
-    : client.messages.stream(params);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const stream: any = requestOptions
+        ? client.messages.stream(params, requestOptions)
+        : client.messages.stream(params);
 
-  let cumulativeApprox = 0;
-  let windowStart = Date.now();
-  let windowTokens = 0;
-  let lastTokensPerSec = 0;
-  let phase: 'thinking' | 'streaming' | 'tool_running' = 'thinking';
+      let cumulativeApprox = 0;
+      let windowStart = Date.now();
+      let windowTokens = 0;
+      let lastTokensPerSec = 0;
+      let phase: 'thinking' | 'streaming' | 'tool_running' = 'thinking';
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  for await (const event of stream as AsyncIterable<any>) {
-    if (event?.type === 'message_start') {
-      if (phase === 'thinking') {
-        phase = 'streaming';
-        safe(
-          () => observer?.onIterationPhase?.({ iteration, phase: 'streaming' }),
-          'onIterationPhase',
-        );
-      }
-    } else if (event?.type === 'content_block_start') {
-      const block = event.content_block;
-      if (block?.type === 'tool_use' && phase !== 'tool_running') {
-        phase = 'tool_running';
-        safe(
-          () =>
-            observer?.onIterationPhase?.({ iteration, phase: 'tool_running' }),
-          'onIterationPhase',
-        );
-      }
-    } else if (event?.type === 'content_block_delta') {
-      const delta = event.delta;
-      let deltaText = '';
-      if (delta?.type === 'text_delta' && typeof delta.text === 'string') {
-        deltaText = delta.text;
-      } else if (
-        delta?.type === 'input_json_delta' &&
-        typeof delta.partial_json === 'string'
-      ) {
-        deltaText = delta.partial_json;
-      }
-      if (deltaText.length > 0) {
-        const deltaTokens = Math.ceil(deltaText.length / 4);
-        cumulativeApprox += deltaTokens;
-        windowTokens += deltaTokens;
-        const now = Date.now();
-        const windowMs = now - windowStart;
-        if (windowMs >= 500) {
-          lastTokensPerSec = (windowTokens / windowMs) * 1000;
-          windowStart = now;
-          windowTokens = 0;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      for await (const event of stream as AsyncIterable<any>) {
+        if (event?.type === 'message_start') {
+          if (phase === 'thinking') {
+            phase = 'streaming';
+            safe(
+              () =>
+                observer?.onIterationPhase?.({ iteration, phase: 'streaming' }),
+              'onIterationPhase',
+            );
+          }
+        } else if (event?.type === 'content_block_start') {
+          const block = event.content_block;
+          if (block?.type === 'tool_use' && phase !== 'tool_running') {
+            phase = 'tool_running';
+            safe(
+              () =>
+                observer?.onIterationPhase?.({
+                  iteration,
+                  phase: 'tool_running',
+                }),
+              'onIterationPhase',
+            );
+          }
+        } else if (event?.type === 'content_block_delta') {
+          const delta = event.delta;
+          let deltaText = '';
+          if (delta?.type === 'text_delta' && typeof delta.text === 'string') {
+            deltaText = delta.text;
+          } else if (
+            delta?.type === 'input_json_delta' &&
+            typeof delta.partial_json === 'string'
+          ) {
+            deltaText = delta.partial_json;
+          }
+          if (deltaText.length > 0) {
+            const deltaTokens = Math.ceil(deltaText.length / 4);
+            cumulativeApprox += deltaTokens;
+            windowTokens += deltaTokens;
+            const now = Date.now();
+            const windowMs = now - windowStart;
+            if (windowMs >= 500) {
+              lastTokensPerSec = (windowTokens / windowMs) * 1000;
+              windowStart = now;
+              windowTokens = 0;
+            }
+            safe(
+              () =>
+                observer?.onTokenChunk?.({
+                  iteration,
+                  deltaTokens,
+                  cumulativeOutputTokens: cumulativeApprox,
+                  tokensPerSec: lastTokensPerSec,
+                }),
+              'onTokenChunk',
+            );
+          }
+          // Forward only assistant-text deltas to the caller; tool-use input
+          // JSON deltas are intentionally swallowed (the full `tool_use` block
+          // is emitted once the content block closes, which is both cheaper
+          // and more usable for the UI).
+          if (delta?.type === 'text_delta' && typeof delta.text === 'string') {
+            forwardedText = true;
+            yield { type: 'text_delta', text: delta.text };
+          }
         }
+      }
+
+      const response: Message = await stream.finalMessage();
+
+      const usage = response?.usage;
+      if (usage) {
         safe(
           () =>
-            observer?.onTokenChunk?.({
+            observer?.onIterationUsage?.({
               iteration,
-              deltaTokens,
-              cumulativeOutputTokens: cumulativeApprox,
-              tokensPerSec: lastTokensPerSec,
+              inputTokens:
+                typeof usage.input_tokens === 'number' ? usage.input_tokens : 0,
+              outputTokens:
+                typeof usage.output_tokens === 'number'
+                  ? usage.output_tokens
+                  : 0,
+              cacheReadInputTokens:
+                typeof usage.cache_read_input_tokens === 'number'
+                  ? usage.cache_read_input_tokens
+                  : 0,
+              cacheCreationInputTokens:
+                typeof usage.cache_creation_input_tokens === 'number'
+                  ? usage.cache_creation_input_tokens
+                  : 0,
             }),
-          'onTokenChunk',
+          'onIterationUsage',
         );
       }
-      // Forward only assistant-text deltas to the caller; tool-use input
-      // JSON deltas are intentionally swallowed (the full `tool_use` block
-      // is emitted once the content block closes, which is both cheaper
-      // and more usable for the UI).
-      if (delta?.type === 'text_delta' && typeof delta.text === 'string') {
-        yield { type: 'text_delta', text: delta.text };
+
+      yield { type: 'final', message: response };
+      return;
+    } catch (err) {
+      // Non-retryable, retries exhausted, or text already streamed to the
+      // UI → propagate. The orchestrator's catch logs + surfaces it.
+      if (
+        forwardedText ||
+        attempt >= MAX_STREAM_ATTEMPTS ||
+        !isRetryableStreamError(err)
+      ) {
+        throw err;
       }
+      const delayMs = streamRetryDelayMs(attempt);
+      console.warn(
+        `[${streamLabel}] streamed iteration ${iteration} hit a retryable ` +
+          `provider error (attempt ${attempt}/${MAX_STREAM_ATTEMPTS}) — ` +
+          `retrying in ${delayMs}ms:`,
+        err instanceof Error ? err.message : err,
+      );
+      await sleep(delayMs);
     }
   }
-
-  const response: Message = await stream.finalMessage();
-
-  const usage = response?.usage;
-  if (usage) {
-    safe(
-      () =>
-        observer?.onIterationUsage?.({
-          iteration,
-          inputTokens:
-            typeof usage.input_tokens === 'number' ? usage.input_tokens : 0,
-          outputTokens:
-            typeof usage.output_tokens === 'number' ? usage.output_tokens : 0,
-          cacheReadInputTokens:
-            typeof usage.cache_read_input_tokens === 'number'
-              ? usage.cache_read_input_tokens
-              : 0,
-          cacheCreationInputTokens:
-            typeof usage.cache_creation_input_tokens === 'number'
-              ? usage.cache_creation_input_tokens
-              : 0,
-        }),
-      'onIterationUsage',
-    );
-  }
-
-  yield { type: 'final', message: response };
 }
 
 /**

--- a/middleware/test/orchestrator/streamingRetry.test.ts
+++ b/middleware/test/orchestrator/streamingRetry.test.ts
@@ -1,0 +1,80 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { isRetryableStreamError } from '@omadia/orchestrator';
+
+/**
+ * Coverage for {@link isRetryableStreamError} — the predicate that decides
+ * whether a streamed-iteration failure should be retried by
+ * `streamMessageEvents`. The motivating case is a mid-stream
+ * `overloaded_error`: Anthropic returns HTTP 200, begins the SSE stream, and
+ * then injects an `error` event — which the SDK rethrows as a plain
+ * `Error(<raw JSON body>)` during iteration.
+ */
+describe('isRetryableStreamError', () => {
+  it('retries a mid-stream overloaded_error surfaced as a raw-JSON Error', () => {
+    // Exactly the shape observed in production: the SDK rethrows the SSE
+    // error event's body as the Error message, with no `status` field.
+    const err = new Error(
+      '{"type":"error","error":{"details":null,"type":"overloaded_error",' +
+        '"message":"Overloaded"},"request_id":"req_011CbH2tebHZNU59XQAwrq2m"}',
+    );
+    assert.equal(isRetryableStreamError(err), true);
+  });
+
+  it('retries a rate_limit_error surfaced in the message text', () => {
+    const err = new Error('{"type":"error","error":{"type":"rate_limit_error"}}');
+    assert.equal(isRetryableStreamError(err), true);
+  });
+
+  it('retries when a nested error body carries a retryable type', () => {
+    const err = Object.assign(new Error('stream failed'), {
+      error: { type: 'error', error: { type: 'overloaded_error' } },
+    });
+    assert.equal(isRetryableStreamError(err), true);
+  });
+
+  it('retries when a flattened error body carries a retryable type', () => {
+    const err = Object.assign(new Error('stream failed'), {
+      error: { type: 'api_error' },
+    });
+    assert.equal(isRetryableStreamError(err), true);
+  });
+
+  it('retries on a retryable HTTP status', () => {
+    for (const status of [408, 409, 429, 500, 502, 503, 529]) {
+      const err = Object.assign(new Error(`HTTP ${String(status)}`), {
+        status,
+      });
+      assert.equal(
+        isRetryableStreamError(err),
+        true,
+        `status ${String(status)} should be retryable`,
+      );
+    }
+  });
+
+  it('does NOT retry a non-transient invalid_request_error', () => {
+    const err = Object.assign(new Error('bad request'), {
+      status: 400,
+      error: { type: 'error', error: { type: 'invalid_request_error' } },
+    });
+    assert.equal(isRetryableStreamError(err), false);
+  });
+
+  it('does NOT retry an authentication_error', () => {
+    const err = Object.assign(new Error('{"type":"authentication_error"}'), {
+      status: 401,
+    });
+    assert.equal(isRetryableStreamError(err), false);
+  });
+
+  it('does NOT retry a generic non-provider error', () => {
+    assert.equal(
+      isRetryableStreamError(new Error('stream ended without a final message')),
+      false,
+    );
+    assert.equal(isRetryableStreamError('plain string'), false);
+    assert.equal(isRetryableStreamError(undefined), false);
+  });
+});


### PR DESCRIPTION
## Problem

Ein GEO-Check über die Chat-UI schlug weiterhin mit rohem `overloaded_error` (HTTP 529) fehl — **auch nach PR #121** (`maxRetries: 5`). Der Stacktrace aus #121s neuem Logging zeigte den echten Failure-Mode:

```
Error: {"type":"error",...,"type":"overloaded_error",...}
    at Stream.iterator (@anthropic-ai/sdk/core/streaming.mjs:62)
    at async MessageStream._createMessage (.../MessageStream.mjs:150)
```

Der Fehler wird **während der Stream-Iteration** geworfen, nicht beim HTTP-Request. Anthropic antwortet **HTTP 200**, startet den SSE-Stream, und injiziert dann ein `error`-Event in den Stream, sobald das Backend überlastet ist.

Das SDK-`maxRetries` deckt **nur non-200-HTTP-Responses** ab — ein Mid-Stream-Overload wird vom SDK nie retried und lässt den Turn fehlschlagen. Die ~3s Antwortzeit bestätigte es: kein einziger Backoff-Delay fand statt.

→ **PR #121 zielte auf den falschen Failure-Mode.**

## Fix

App-Level-Retry in `streamMessageEvents` — dem einzigen Chokepoint für jeden Stream-Call (Orchestrator-Hauptschleife **+ alle Sub-Agents**):

- **`isRetryableStreamError()`** klassifiziert transiente Provider-Fehler (`overloaded_error` / `rate_limit_error` / `api_error` / HTTP 408/409/429/5xx).
- Der Stream wird bis zu **5 Versuche** mit exponential backoff + full jitter (~1/2/4/8s) retried — **aber nur solange noch kein `text_delta` an den Caller weitergegeben wurde**. Re-Streaming nach Teil-Output würde sichtbaren Text in der UI duplizieren. Ein Start-of-Stream-Overload (der beobachtete Fall) schlägt immer vor dem ersten Delta fehl.
- `maxRetries: 5` aus #121 bleibt — deckt weiterhin echte pre-stream HTTP 429/529 ab.

## Bewusst NICHT enthalten

Die User-facing-Fehlermeldung (freundlicher Text statt Raw-JSON) bleibt Privacy-Shield-v4-Scope.

## Test plan

- [x] `npm run lint` + `npm run typecheck` — grün
- [x] Neuer Test `test/orchestrator/streamingRetry.test.ts` — 8/8 grün (deckt exakte Raw-JSON-Production-Shape, nested/flattened Bodies, Status-Codes, null/undefined + nicht-transiente Negativfälle — fing einen Null-Deref-Bug in der ersten Implementierung)
- [ ] Reviewer: GEO-Check gegen `https://omadia.ai` erneut auslösen