### PR TITLE
fix(manifests): use canonical key/help in setup fields so secrets render

### DIFF
--- a/middleware/packages/harness-knowledge-graph-inmemory/manifest.yaml
+++ b/middleware/packages/harness-knowledge-graph-inmemory/manifest.yaml
@@ -43,11 +43,11 @@ requires: []
 
 setup:
   fields:
-    - id: "graph_tenant_id"
+    - key: "graph_tenant_id"
       label: "Graph Tenant ID"
       type: "text"
       required: false
-      description: "Tenant-Schlüssel für die in-memory-Graph-Instanz (kosmetisch — bei in-memory gibt es nur einen Tenant pro Prozess). Default: 'default'."
+      help: "Tenant-Schlüssel für die in-memory-Graph-Instanz (kosmetisch — bei in-memory gibt es nur einen Tenant pro Prozess). Default: 'default'."
 
 playbook:
   when_to_use: |

--- a/middleware/packages/harness-knowledge-graph-neon/manifest.yaml
+++ b/middleware/packages/harness-knowledge-graph-neon/manifest.yaml
@@ -54,133 +54,133 @@ requires:
 
 setup:
   fields:
-    - id: "database_url"
+    - key: "database_url"
       label: "Database URL"
       type: "secret"
       required: false
-      description: "Postgres-Connection-String (Neon serverless URL). Ohne Wert publiziert das Plugin KEINE Capabilities — der Capability-Resolver droppt downstream-Konsumenten aus der eligible-Menge oder Boot fail't. Bootstrap migriert DATABASE_URL aus dem legacy .env in den Vault. (S+12.5-3: type: secret — DSN wird im Vault gespeichert, nicht in installed.json config.)"
-    - id: "graph_tenant_id"
+      help: "Postgres-Connection-String (Neon serverless URL). Ohne Wert publiziert das Plugin KEINE Capabilities — der Capability-Resolver droppt downstream-Konsumenten aus der eligible-Menge oder Boot fail't. Bootstrap migriert DATABASE_URL aus dem legacy .env in den Vault. (S+12.5-3: type: secret — DSN wird im Vault gespeichert, nicht in installed.json config.)"
+    - key: "graph_tenant_id"
       label: "Graph Tenant ID"
       type: "text"
       required: false
-      description: "Tenant-Schlüssel für die Neon-Tabellen (graph_nodes.tenant_id-Spalte). Migriert aus GRAPH_TENANT_ID. Default: 'default'."
-    - id: "graph_embedding_backfill_enabled"
+      help: "Tenant-Schlüssel für die Neon-Tabellen (graph_nodes.tenant_id-Spalte). Migriert aus GRAPH_TENANT_ID. Default: 'default'."
+    - key: "graph_embedding_backfill_enabled"
       label: "Embedding Backfill Enabled"
       type: "text"
       required: false
-      description: "'true' aktiviert den in-process Embedding-Backfill-Scheduler (re-embedded Turns deren post-commit `embedAndStoreTurn` failed). Default: 'true'. Migriert aus GRAPH_EMBEDDING_BACKFILL_ENABLED. No-op ohne `embeddingClient`."
-    - id: "graph_embedding_backfill_interval_minutes"
+      help: "'true' aktiviert den in-process Embedding-Backfill-Scheduler (re-embedded Turns deren post-commit `embedAndStoreTurn` failed). Default: 'true'. Migriert aus GRAPH_EMBEDDING_BACKFILL_ENABLED. No-op ohne `embeddingClient`."
+    - key: "graph_embedding_backfill_interval_minutes"
       label: "Backfill Interval (minutes)"
       type: "number"
       required: false
-      description: "Sweep-Intervall des Backfill-Schedulers. Default: 5. Migriert aus GRAPH_EMBEDDING_BACKFILL_INTERVAL_MINUTES."
-    - id: "graph_embedding_backfill_batch_size"
+      help: "Sweep-Intervall des Backfill-Schedulers. Default: 5. Migriert aus GRAPH_EMBEDDING_BACKFILL_INTERVAL_MINUTES."
+    - key: "graph_embedding_backfill_batch_size"
       label: "Backfill Batch Size"
       type: "number"
       required: false
-      description: "Maximale Anzahl Turns pro Sweep. Default: 20. Migriert aus GRAPH_EMBEDDING_BACKFILL_BATCH_SIZE."
-    - id: "graph_embedding_backfill_max_attempts"
+      help: "Maximale Anzahl Turns pro Sweep. Default: 20. Migriert aus GRAPH_EMBEDDING_BACKFILL_BATCH_SIZE."
+    - key: "graph_embedding_backfill_max_attempts"
       label: "Backfill Max Attempts"
       type: "number"
       required: false
-      description: "Hard cap auf Retries pro Turn. Default: 5. Migriert aus GRAPH_EMBEDDING_BACKFILL_MAX_ATTEMPTS."
+      help: "Hard cap auf Retries pro Turn. Default: 5. Migriert aus GRAPH_EMBEDDING_BACKFILL_MAX_ATTEMPTS."
     # OB-73 (Phase 4): Tiering-Lifecycle. Decay-Score-Update + HOT/WARM/COLD
     # rotation + Done-Task-TTL run as an hourly cron (decay-rotation), GC + hard
     # limits as a daily cron (gc-quotas — Slice C). This job USES the columns
     # from Migration 0007 — no new migration. Default values mirror
     # palaia-ADR-004: λ=0.05/d (~14d half-life), HOT→WARM at score<0.5+7d
     # idle, WARM→COLD at score<0.1+30d, Done-Tasks hard-deleted after 24h.
-    - id: "graph_decay_enabled"
+    - key: "graph_decay_enabled"
       label: "Decay & Tier-Rotation Enabled"
       type: "text"
       required: false
-      description: "'true' aktiviert den hourly Decay+Rotation-Job. Default: 'true'. 'false' lässt das Plugin laufen, ohne den Cron zu registrieren — sinnvoll für CI/Smoke."
-    - id: "graph_decay_interval_minutes"
+      help: "'true' aktiviert den hourly Decay+Rotation-Job. Default: 'true'. 'false' lässt das Plugin laufen, ohne den Cron zu registrieren — sinnvoll für CI/Smoke."
+    - key: "graph_decay_interval_minutes"
       label: "Decay Interval (minutes)"
       type: "number"
       required: false
-      description: "Sweep-Intervall des Decay+Rotation-Jobs. Default: 60 (1×/h)."
-    - id: "graph_decay_lambda"
+      help: "Sweep-Intervall des Decay+Rotation-Jobs. Default: 60 (1×/h)."
+    - key: "graph_decay_lambda"
       label: "Decay Lambda (per day)"
       type: "number"
       required: false
-      description: "Daily decay-rate constant in `score = exp(-λ · age_days) · (1 + ln(1 + access_count))`. Default: 0.05 (~14d Halbwertszeit). Höher = schnellerer Decay."
-    - id: "graph_decay_hot_to_warm_score"
+      help: "Daily decay-rate constant in `score = exp(-λ · age_days) · (1 + ln(1 + access_count))`. Default: 0.05 (~14d Halbwertszeit). Höher = schnellerer Decay."
+    - key: "graph_decay_hot_to_warm_score"
       label: "HOT→WARM Score Threshold"
       type: "number"
       required: false
-      description: "decay_score-Schwelle für die HOT→WARM-Rotation (additionally idle ≥ hot_to_warm_idle_days). Default: 0.5."
-    - id: "graph_decay_hot_to_warm_idle_days"
+      help: "decay_score-Schwelle für die HOT→WARM-Rotation (additionally idle ≥ hot_to_warm_idle_days). Default: 0.5."
+    - key: "graph_decay_hot_to_warm_idle_days"
       label: "HOT→WARM Idle Days"
       type: "number"
       required: false
-      description: "Idle-Days-Gate für HOT→WARM (gegen `COALESCE(accessed_at, created_at)`). Default: 7."
-    - id: "graph_decay_warm_to_cold_score"
+      help: "Idle-Days-Gate für HOT→WARM (gegen `COALESCE(accessed_at, created_at)`). Default: 7."
+    - key: "graph_decay_warm_to_cold_score"
       label: "WARM→COLD Score Threshold"
       type: "number"
       required: false
-      description: "decay_score-Schwelle für die WARM→COLD-Rotation. Default: 0.1."
-    - id: "graph_decay_warm_to_cold_idle_days"
+      help: "decay_score-Schwelle für die WARM→COLD-Rotation. Default: 0.1."
+    - key: "graph_decay_warm_to_cold_idle_days"
       label: "WARM→COLD Idle Days"
       type: "number"
       required: false
-      description: "Idle-Days-Gate für WARM→COLD. Default: 30."
-    - id: "graph_decay_done_task_ttl_hours"
+      help: "Idle-Days-Gate für WARM→COLD. Default: 30."
+    - key: "graph_decay_done_task_ttl_hours"
       label: "Done-Task TTL (hours)"
       type: "number"
       required: false
-      description: "TTL für `entry_type='task' AND task_status='done'`-Rows. Nach Ablauf hard-DELETE. Default: 24. Markdown-Audit-Transkript bleibt unberührt."
+      help: "TTL für `entry_type='task' AND task_status='done'`-Rows. Nach Ablauf hard-DELETE. Default: 24. Markdown-Audit-Transkript bleibt unberührt."
     # OB-73 (Phase 4 / Slice C): GC + hard-limits per scope. Daily cron
     # (default 04:00 UTC). Eviction-Order: type-weight × decay_score ASC,
     # ties broken by created_at ASC. Type-weights from palaia-ADR-004:
     # process > task > memory. `done-task-TTL` runs separately in the hourly
     # decay-job, not here.
-    - id: "graph_gc_enabled"
+    - key: "graph_gc_enabled"
       label: "GC & Hard-Limits Enabled"
       type: "text"
       required: false
-      description: "'true' aktiviert den daily GC-Job (count + char Quota per scope). Default: 'true'."
-    - id: "graph_gc_cron"
+      help: "'true' aktiviert den daily GC-Job (count + char Quota per scope). Default: 'true'."
+    - key: "graph_gc_cron"
       label: "GC Cron"
       type: "text"
       required: false
-      description: "5-stelliger Cron für den GC-Sweep. Default: '0 4 * * *' (täglich 04:00 UTC). Bei intervalMs-Override: graph_gc_interval_minutes (überschreibt cron)."
-    - id: "graph_gc_interval_minutes"
+      help: "5-stelliger Cron für den GC-Sweep. Default: '0 4 * * *' (täglich 04:00 UTC). Bei intervalMs-Override: graph_gc_interval_minutes (überschreibt cron)."
+    - key: "graph_gc_interval_minutes"
       label: "GC Interval Override (minutes)"
       type: "number"
       required: false
-      description: "Optional: Statt Cron einen festen Intervall fahren (für Tests / hot-Loops). Default: leer (Cron wird verwendet)."
-    - id: "graph_gc_hot_max_entries"
+      help: "Optional: Statt Cron einen festen Intervall fahren (für Tests / hot-Loops). Default: leer (Cron wird verwendet)."
+    - key: "graph_gc_hot_max_entries"
       label: "Hot-Tier Max Entries (per scope)"
       type: "number"
       required: false
-      description: "Per-scope Obergrenze für Turn-Count. Über dem Limit werden die niedrig-priorisierten Excess-Rows pro Sweep evicted. Default: 50."
-    - id: "graph_gc_max_total_chars"
+      help: "Per-scope Obergrenze für Turn-Count. Über dem Limit werden die niedrig-priorisierten Excess-Rows pro Sweep evicted. Default: 50."
+    - key: "graph_gc_max_total_chars"
       label: "Max Total Chars (per scope)"
       type: "number"
       required: false
-      description: "Per-scope Obergrenze für SUM(LENGTH(userMessage)+LENGTH(assistantAnswer)). Default: 500000 (~125k Tokens)."
-    - id: "graph_gc_type_weight_memory"
+      help: "Per-scope Obergrenze für SUM(LENGTH(userMessage)+LENGTH(assistantAnswer)). Default: 500000 (~125k Tokens)."
+    - key: "graph_gc_type_weight_memory"
       label: "GC Type-Weight (memory)"
       type: "number"
       required: false
-      description: "Eviction-Priorität-Gewicht für entry_type='memory'. Default: 1.0 (baseline). Höher = wird länger behalten."
-    - id: "graph_gc_type_weight_process"
+      help: "Eviction-Priorität-Gewicht für entry_type='memory'. Default: 1.0 (baseline). Höher = wird länger behalten."
+    - key: "graph_gc_type_weight_process"
       label: "GC Type-Weight (process)"
       type: "number"
       required: false
-      description: "Default: 2.0. Process-Knowledge wird länger behalten als generic memory."
-    - id: "graph_gc_type_weight_task"
+      help: "Default: 2.0. Process-Knowledge wird länger behalten als generic memory."
+    - key: "graph_gc_type_weight_task"
       label: "GC Type-Weight (task)"
       type: "number"
       required: false
-      description: "Default: 1.5."
+      help: "Default: 1.5."
     # OB-76 (Phase 7) Process-Memory: Dedup-First-Write threshold.
-    - id: "process_dedup_threshold"
+    - key: "process_dedup_threshold"
       label: "Process Dedup Threshold"
       type: "number"
       required: false
-      description: "Cosine-similarity-Schwelle für `write_process`-Dedup. Default: 0.9. Tiefer = aggressiveres Blocken; höher = mehr near-duplicates erlaubt."
+      help: "Cosine-similarity-Schwelle für `write_process`-Dedup. Default: 0.9. Tiefer = aggressiveres Blocken; höher = mehr near-duplicates erlaubt."
 
 playbook:
   when_to_use: |

--- a/middleware/packages/harness-orchestrator-extras/manifest.yaml
+++ b/middleware/packages/harness-orchestrator-extras/manifest.yaml
@@ -58,101 +58,101 @@ requires:
 
 setup:
   fields:
-    - id: "anthropic_api_key"
+    - key: "anthropic_api_key"
       label: "Anthropic API Key"
       type: "secret"
       required: false
-      description: "Erforderlich für FactExtractor + TopicDetector (Haiku-Klassifikator). Ohne Key konstruiert das Plugin nur den ContextRetriever — Orchestrator-Fact-Ingest und Teams-Topic-Routing degradieren auf no-op. (S+12.6: type: secret — Key wird im Vault gespeichert, nicht in installed.json config.)"
-    - id: "fact_extractor_model"
+      help: "Erforderlich für FactExtractor + TopicDetector (Haiku-Klassifikator). Ohne Key konstruiert das Plugin nur den ContextRetriever — Orchestrator-Fact-Ingest und Teams-Topic-Routing degradieren auf no-op. (S+12.6: type: secret — Key wird im Vault gespeichert, nicht in installed.json config.)"
+    - key: "fact_extractor_model"
       label: "Fact Extractor Model"
       type: "text"
       required: false
-      description: "Anthropic-Model-ID für die Fact-Extraction-Calls. Default: claude-haiku-4-5-20251001."
-    - id: "topic_classifier_model"
+      help: "Anthropic-Model-ID für die Fact-Extraction-Calls. Default: claude-haiku-4-5-20251001."
+    - key: "topic_classifier_model"
       label: "Topic Classifier Model"
       type: "text"
       required: false
-      description: "Anthropic-Model-ID für die Topic-Detection-Klassifikation. Default: claude-haiku-4-5-20251001."
-    - id: "topic_upper_threshold"
+      help: "Anthropic-Model-ID für die Topic-Detection-Klassifikation. Default: claude-haiku-4-5-20251001."
+    - key: "topic_upper_threshold"
       label: "Topic Upper Threshold"
       type: "number"
       required: false
-      description: "Cosine-Similarity-Schwelle für auto-continue. Default: 0.55."
-    - id: "topic_lower_threshold"
+      help: "Cosine-Similarity-Schwelle für auto-continue. Default: 0.55."
+    - key: "topic_lower_threshold"
       label: "Topic Lower Threshold"
       type: "number"
       required: false
-      description: "Cosine-Similarity-Schwelle für auto-reset. Default: 0.15."
+      help: "Cosine-Similarity-Schwelle für auto-reset. Default: 0.15."
     # OB-72 (Phase 3): hybrid-retrieval knobs for `searchTurnsByEmbedding`.
     # Default values reproduce pre-OB-72 behaviour, so a workspace that never
     # touches these stays unchanged. Tune via the setup wizard.
-    - id: "recall_min_score"
+    - key: "recall_min_score"
       label: "Recall Min-Score"
       type: "number"
       required: false
-      description: "Hybrid-Score-Schwelle in [0,1] — Treffer darunter werden verworfen. Default: 0 (kein Threshold)."
-    - id: "recall_recency_boost"
+      help: "Hybrid-Score-Schwelle in [0,1] — Treffer darunter werden verworfen. Default: 0 (kein Threshold)."
+    - key: "recall_recency_boost"
       label: "Recall Recency Boost"
       type: "number"
       required: false
-      description: "Decay-Rate (pro Tag) für Recency-Boost: Treffer werden mit `exp(-rate · age_days)` multipliziert. Default: 0.05 (~14 Tage Halbwertszeit). 0 deaktiviert."
-    - id: "recall_type_weight_memory"
+      help: "Decay-Rate (pro Tag) für Recency-Boost: Treffer werden mit `exp(-rate · age_days)` multipliziert. Default: 0.05 (~14 Tage Halbwertszeit). 0 deaktiviert."
+    - key: "recall_type_weight_memory"
       label: "Recall Type-Weight (memory)"
       type: "number"
       required: false
-      description: "Multiplikator für entry_type='memory'. Default: 1.0 (neutral)."
-    - id: "recall_type_weight_process"
+      help: "Multiplikator für entry_type='memory'. Default: 1.0 (neutral)."
+    - key: "recall_type_weight_process"
       label: "Recall Type-Weight (process)"
       type: "number"
       required: false
-      description: "Multiplikator für entry_type='process'. Default: 1.0 (neutral). Operatoren können >1 setzen, sobald Phase 2 process-Klassifikationen liefert."
-    - id: "recall_type_weight_task"
+      help: "Multiplikator für entry_type='process'. Default: 1.0 (neutral). Operatoren können >1 setzen, sobald Phase 2 process-Klassifikationen liefert."
+    - key: "recall_type_weight_task"
       label: "Recall Type-Weight (task)"
       type: "number"
       required: false
-      description: "Multiplikator für entry_type='task'. Default: 1.0 (neutral)."
+      help: "Multiplikator für entry_type='task'. Default: 1.0 (neutral)."
     # OB-74 (Phase 5): Token-Budget-Assembler-Konfiguration. Defaults spiegeln
     # palaia-Standardwerte. Operator kann via Setup-Wizard fine-tunen.
-    - id: "context_default_budget_tokens"
+    - key: "context_default_budget_tokens"
       label: "Context Default Token-Budget"
       type: "number"
       required: false
-      description: "Default-Token-Budget für ContextRetriever.assembleForBudget. Default: 6000 (~24k chars bei chars/token=4). Caller können per Aufruf überschreiben."
-    - id: "context_chars_per_token"
+      help: "Default-Token-Budget für ContextRetriever.assembleForBudget. Default: 6000 (~24k chars bei chars/token=4). Caller können per Aufruf überschreiben."
+    - key: "context_chars_per_token"
       label: "Chars-per-Token Heuristik"
       type: "number"
       required: false
-      description: "Faustregel für Token-Schätzung in `chars / charsPerToken`. Default: 4. Tunen wenn deutsche Texte (~3.5) oder code-heavy (~5)."
-    - id: "context_manual_boost_factor"
+      help: "Faustregel für Token-Schätzung in `chars / charsPerToken`. Default: 4. Tunen wenn deutsche Texte (~3.5) oder code-heavy (~5)."
+    - key: "context_manual_boost_factor"
       label: "Manual-Authored Boost Factor"
       type: "number"
       required: false
-      description: "Score-Multiplier für `manually_authored=true`-Rows. Default: 1.3 (palaia-Default). Wirkt zusätzlich zum agent_priorities-Boost."
-    - id: "context_compact_mode_threshold"
+      help: "Score-Multiplier für `manually_authored=true`-Rows. Default: 1.3 (palaia-Default). Wirkt zusätzlich zum agent_priorities-Boost."
+    - key: "context_compact_mode_threshold"
       label: "Compact-Mode Threshold"
       type: "number"
       required: false
-      description: "Über dieser Anzahl Recall-Hits aktiviert sich der Compact-Snippet-Mode (~120 char/Hit statt full-body). Default: 100."
+      help: "Über dieser Anzahl Recall-Hits aktiviert sich der Compact-Snippet-Mode (~120 char/Hit statt full-body). Default: 100."
     # OB-71 (Phase 2): capture-pipeline knobs. Default level=minimal runs the
     # deterministic Privacy-Strip + Hint-Parse without any LLM call (no
     # persistence-volume change vs. Phase 1). `normal`/`aggressive` activate
     # the Haiku Significance-Scorer; `off` is the explicit escape-hatch
     # for backup-replay (NO cleanup, ungestripped text into the index).
-    - id: "capture_level"
+    - key: "capture_level"
       label: "Capture-Level"
       type: "text"
       required: false
-      description: "off | minimal | normal | aggressive. Default: minimal (privacy + hints automatisch, kein LLM, kein Drop). normal: + Significance-Scoring, drop bei score < 0.2. aggressive: drop bei score < 0.5. off: Escape-Hatch — KEIN Cleanup, ungestripped text in den Index."
-    - id: "capture_default_visibility"
+      help: "off | minimal | normal | aggressive. Default: minimal (privacy + hints automatisch, kein LLM, kein Drop). normal: + Significance-Scoring, drop bei score < 0.2. aggressive: drop bei score < 0.5. off: Escape-Hatch — KEIN Cleanup, ungestripped text in den Index."
+    - key: "capture_default_visibility"
       label: "Capture Default-Visibility"
       type: "text"
       required: false
-      description: "private | team | public. Default: team. Wird verwendet, wenn weder palaia-hint noch der Scorer eine Visibility liefert."
-    - id: "capture_significance_threshold"
+      help: "private | team | public. Default: team. Wird verwendet, wenn weder palaia-hint noch der Scorer eine Visibility liefert."
+    - key: "capture_significance_threshold"
       label: "Significance-Threshold (overrides level-default)"
       type: "number"
       required: false
-      description: "Grenze in [0,1]. Default = level-spezifisch (normal=0.2, aggressive=0.5). Nur relevant ab capture_level=normal."
+      help: "Grenze in [0,1]. Default = level-spezifisch (normal=0.2, aggressive=0.5). Nur relevant ab capture_level=normal."
 
 playbook:
   when_to_use: |

--- a/middleware/packages/harness-orchestrator/manifest.yaml
+++ b/middleware/packages/harness-orchestrator/manifest.yaml
@@ -63,26 +63,26 @@ provides:
 
 setup:
   fields:
-    - id: "anthropic_api_key"
+    - key: "anthropic_api_key"
       label: "Anthropic API Key"
       type: "secret"
       required: false
-      description: "Anthropic-API-Key für die Haupt-Claude-Loop des Orchestrators. Ohne Key publiziert das Plugin KEIN `chatAgent@1` — Kernel + Channels degradieren auf no-chat. Geteilt mit @omadia/orchestrator-extras + @omadia/verifier (gleicher Anthropic-Account). Bootstrap migriert ANTHROPIC_API_KEY aus dem legacy .env in den Vault. (S+12.6: type: secret — Key wird im Vault gespeichert, nicht in installed.json config.)"
-    - id: "orchestrator_model"
+      help: "Anthropic-API-Key für die Haupt-Claude-Loop des Orchestrators. Ohne Key publiziert das Plugin KEIN `chatAgent@1` — Kernel + Channels degradieren auf no-chat. Geteilt mit @omadia/orchestrator-extras + @omadia/verifier (gleicher Anthropic-Account). Bootstrap migriert ANTHROPIC_API_KEY aus dem legacy .env in den Vault. (S+12.6: type: secret — Key wird im Vault gespeichert, nicht in installed.json config.)"
+    - key: "orchestrator_model"
       label: "Orchestrator Model"
       type: "text"
       required: false
-      description: "Anthropic-Model-ID für die Haupt-Loop. Default: claude-sonnet-4-5-20251022. Migriert aus ORCHESTRATOR_MODEL."
-    - id: "orchestrator_max_tokens"
+      help: "Anthropic-Model-ID für die Haupt-Loop. Default: claude-sonnet-4-5-20251022. Migriert aus ORCHESTRATOR_MODEL."
+    - key: "orchestrator_max_tokens"
       label: "Max Output Tokens"
       type: "number"
       required: false
-      description: "Maximum response-Tokens pro Turn. Default: 4096. Migriert aus ORCHESTRATOR_MAX_TOKENS."
-    - id: "max_tool_iterations"
+      help: "Maximum response-Tokens pro Turn. Default: 4096. Migriert aus ORCHESTRATOR_MAX_TOKENS."
+    - key: "max_tool_iterations"
       label: "Max Tool-Loop Iterations"
       type: "number"
       required: false
-      description: "Hard cap auf den agentic tool-loop pro Turn. Aborts den Turn wenn überschritten. Default: 12. Migriert aus MAX_TOOL_ITERATIONS."
+      help: "Hard cap auf den agentic tool-loop pro Turn. Aborts den Turn wenn überschritten. Default: 12. Migriert aus MAX_TOOL_ITERATIONS."
 
 playbook:
   when_to_use: |

--- a/middleware/packages/harness-verifier/manifest.yaml
+++ b/middleware/packages/harness-verifier/manifest.yaml
@@ -65,46 +65,46 @@ requires:
 
 setup:
   fields:
-    - id: "anthropic_api_key"
+    - key: "anthropic_api_key"
       label: "Anthropic API Key"
       type: "secret"
       required: false
-      description: "Erforderlich für ClaimExtractor + EvidenceJudge (Haiku-LLM-Calls). Ohne Key publiziert das Plugin KEIN `verifier@1` — der Kernel fällt auf den Orchestrator ohne Verifier-Wrapper zurück. Geteilt mit @omadia/orchestrator-extras (gleicher Anthropic-Account). Bootstrap migriert ANTHROPIC_API_KEY aus dem legacy .env in den Vault. (S+12.6: type: secret — Key wird im Vault gespeichert, nicht in installed.json config.)"
-    - id: "verifier_enabled"
+      help: "Erforderlich für ClaimExtractor + EvidenceJudge (Haiku-LLM-Calls). Ohne Key publiziert das Plugin KEIN `verifier@1` — der Kernel fällt auf den Orchestrator ohne Verifier-Wrapper zurück. Geteilt mit @omadia/orchestrator-extras (gleicher Anthropic-Account). Bootstrap migriert ANTHROPIC_API_KEY aus dem legacy .env in den Vault. (S+12.6: type: secret — Key wird im Vault gespeichert, nicht in installed.json config.)"
+    - key: "verifier_enabled"
       label: "Verifier Enabled"
       type: "text"
       required: false
-      description: "'true' aktiviert die Verifier-Pipeline; jeder andere Wert (oder leer) lässt sie aus. Migriert aus VERIFIER_ENABLED. Default: 'false' (per env-default + Plugin-Default)."
-    - id: "verifier_mode"
+      help: "'true' aktiviert die Verifier-Pipeline; jeder andere Wert (oder leer) lässt sie aus. Migriert aus VERIFIER_ENABLED. Default: 'false' (per env-default + Plugin-Default)."
+    - key: "verifier_mode"
       label: "Verifier Mode"
       type: "text"
       required: false
-      description: "'shadow' loggt nur (kein Block / kein Retry). 'enforce' triggert bei Contradictions einen einmaligen Retry mit Correction-Prompt. Default: 'shadow'."
-    - id: "verifier_model"
+      help: "'shadow' loggt nur (kein Block / kein Retry). 'enforce' triggert bei Contradictions einen einmaligen Retry mit Correction-Prompt. Default: 'shadow'."
+    - key: "verifier_model"
       label: "Verifier Model"
       type: "text"
       required: false
-      description: "Anthropic-Model-ID für ClaimExtractor + EvidenceJudge. Default: claude-haiku-4-5-20251001."
-    - id: "verifier_max_claims"
+      help: "Anthropic-Model-ID für ClaimExtractor + EvidenceJudge. Default: claude-haiku-4-5-20251001."
+    - key: "verifier_max_claims"
       label: "Max Claims per Answer"
       type: "number"
       required: false
-      description: "Hard cap auf die Anzahl extrahierter Claims pro Answer. Default: 20."
-    - id: "verifier_amount_tolerance"
+      help: "Hard cap auf die Anzahl extrahierter Claims pro Answer. Default: 20."
+    - key: "verifier_amount_tolerance"
       label: "Amount Tolerance"
       type: "number"
       required: false
-      description: "Relative Toleranz für Betragsvergleiche im DeterministicChecker (0.01 = 1%). Default: 0.01."
-    - id: "verifier_max_retries"
+      help: "Relative Toleranz für Betragsvergleiche im DeterministicChecker (0.01 = 1%). Default: 0.01."
+    - key: "verifier_max_retries"
       label: "Max Retries (enforce mode)"
       type: "number"
       required: false
-      description: "Maximale Retry-Anzahl im enforce-Mode bei detektierter Contradiction. Default: 1, Max: 2 (vom Kernel-Schema clamped)."
-    - id: "graph_tenant_id"
+      help: "Maximale Retry-Anzahl im enforce-Mode bei detektierter Contradiction. Default: 1, Max: 2 (vom Kernel-Schema clamped)."
+    - key: "graph_tenant_id"
       label: "Graph Tenant ID"
       type: "text"
       required: false
-      description: "Tenant-Schlüssel für die VerifierStore-Persistenz (verifier_verdicts + verifier_contradictions Tabellen). Migriert aus GRAPH_TENANT_ID. Default: 'default'."
+      help: "Tenant-Schlüssel für die VerifierStore-Persistenz (verifier_verdicts + verifier_contradictions Tabellen). Migriert aus GRAPH_TENANT_ID. Default: 'default'."
 
 playbook:
   when_to_use: |


### PR DESCRIPTION
## Problem

Die Setup-Felder von **5 built-in Plugin-Manifesten** sind mit `id:` + `description:` deklariert — der Parser (`manifestLoader.ts`) liest aber `f['key']` und `f['help']`:

```ts
const key = asString(f['key']);
if (!key || !type) continue;   // ← Feld wird stillschweigend verworfen
```

Jedes Setup-Feld dieser 5 Plugins wurde dadurch beim Parsen verworfen → catalog `required_secrets` leer → die Admin-UI rendert **kein Eingabefeld**. Operator-Konsequenz: ein rotierter `anthropic_api_key` / `database_url` lässt sich gar nicht über die UI neu eintragen.

## Fix

In allen 5 Manifesten in `setup.fields[]`: `id:` → `key:`, `description:` → `help:`. Identity-`description` und der 2-Space-`links`-Block bleiben unangetastet.

| Manifest | freigeschaltete kritische Felder |
|---|---|
| `harness-orchestrator` | `anthropic_api_key` + 3 |
| `harness-verifier` | `anthropic_api_key` + 7 |
| `harness-orchestrator-extras` | `anthropic_api_key` + 16 |
| `harness-knowledge-graph-neon` | `database_url` + 22 |
| `harness-knowledge-graph-inmemory` | `graph_tenant_id` |

Kein Runtime-Verhalten ändert sich — die Plugins lesen Config/Secrets via `ctx.config`/`ctx.secrets` unabhängig vom Manifest. Der Fix stellt nur UI-Rendering + `hasRequiredSecret`-Klassifikation wieder her. Die 7 bereits korrekten Manifeste nutzen `key:`/`help:` — das richtet die 5 Ausreißer aus.

## Test plan

- [x] Alle 5 Manifeste parsen, jedes Feld exponiert `key`+`help`, Secret-Felder (`anthropic_api_key` ×3, `database_url`) erkannt
- [x] `npm run typecheck` — grün
- [x] `npm test` — 2486/2486 grün, 0 Fehler
- [ ] Nach Deploy: Admin-UI → die 3 LLM-Plugins zeigen das `anthropic_api_key`-Feld → rotierten Key eintragen