### PR TITLE
fix(privacy-guard): v4 — render real names instead of a privacy disclaimer

### DIFF
--- a/middleware/packages/harness-plugin-privacy-guard/src/v4/digest.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/v4/digest.ts
@@ -122,11 +122,27 @@ export function buildDigest(dataset: Dataset): Digest {
  * (US6), keyed by `datasetId`.
  */
 export function digestToToolResultText(digest: Digest): string {
-  const header =
-    '[privacy-shield-v4] The raw tool result is held server-side. ' +
-    'You receive a structural digest only — no row data. Operate on it ' +
-    'through the verb tools (filter/sort/group/aggregate/top_n/select/' +
-    'count/join) keyed by datasetId, then emit a render directive for the ' +
-    'final answer. Masked fields carry no values; never invent them.';
+  const header = [
+    '[privacy-shield-v4] The raw tool result is held server-side; you',
+    'receive this structural digest only — no row data. Work on it through',
+    'the verb tools (filter/sort/group/aggregate/top_n/select/count/join)',
+    'keyed by datasetId, then call v4_render_answer to produce the final',
+    'answer.',
+    '',
+    'A field whose digest shows "classification":"sensitive-masked" is',
+    'hidden from YOU only — its real value exists server-side and the end',
+    'user IS authorised to see it. Therefore:',
+    '- To show masked values (names, e-mails, …) in the answer, INCLUDE',
+    '  that column in v4_render_answer.columns — the server fills in the',
+    '  real values for the user.',
+    '- The final data answer MUST be a v4_render_answer call. Never write',
+    '  the table/list yourself, never drop an identity column, and never',
+    '  tell the user the data is "filtered" or "cannot be shown" — they',
+    '  receive the real values, not "[masked]".',
+    '- Never invent or guess a masked value yourself.',
+    '- aggregate/group keep only the key + aggregate columns; to keep a',
+    '  name on aggregated rows, join the result back to a dataset that',
+    '  still carries the identity column.',
+  ].join('\n');
   return `${header}\n\n${JSON.stringify(digest)}`;
 }

--- a/middleware/packages/harness-plugin-privacy-guard/src/v4/toolDefs.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/v4/toolDefs.ts
@@ -165,9 +165,12 @@ export const VERB_TOOL_SPECS: ReadonlyArray<V4ToolSpec> = [
 export const RENDER_TOOL_SPEC: V4ToolSpec = {
   name: 'v4_render_answer',
   description:
-    'Produce the final answer. Provide PII-free prose plus the datasetId, ' +
-    'the columns to show, and a format (table/list/scalar). The server ' +
-    'renders the real values into the user-facing answer.',
+    'Produce the final answer — ALWAYS end a data question with this call; ' +
+    'never write the data table/list yourself. Provide PII-free prose plus ' +
+    'the datasetId, the columns to show, and a format (table/list/scalar). ' +
+    '`columns` SHOULD include identity / sensitive-masked fields (names, ' +
+    'e-mails): the server fills in their real values for the authorised ' +
+    'user. The rendered answer never returns through you.',
   inputSchema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## The bug

The live HR-agent test surfaced a Privacy Shield v4 acceptance failure. Asked *"Wer hat dieses Jahr den meisten Urlaub?"*, the agent replied with **"⚠️ Datenschutzfilter aktiv — Namen können nicht angezeigt werden"** and a name-less ranking table (Rang 1–5, no people).

That is wrong. v4's design (FR-016/FR-017): the LLM never sees identity values, but the **Materializer fills the real values into the final answer server-side** for the authorised end user — the asker *is* allowed to see the names.

## Root cause — guidance, not engine

The digest header the LLM receives said:

> *"Masked fields carry no values; never invent them."*

So the model concluded the names were genuinely unavailable, **skipped `v4_render_answer`**, and authored its own apologetic prose answer. The v4 engine is correct — `privacyV4Acceptance` proves `intern → aggregate → join → sort → v4_render_answer` yields the real, complete names.

## Fix (guidance-only — no engine change)

- **digest header** (`v4/digest.ts`): a `[masked]` field is hidden from the *LLM only* — the real value exists server-side and the user is authorised to see it. To show it, include the column in `v4_render_answer.columns`; the final data answer MUST be a `v4_render_answer` call; never tell the user data is "filtered" or "cannot be shown"; `aggregate`/`group` drop non-key columns, so `join` back to recover identity columns.
- **`v4_render_answer` description** (`v4/toolDefs.ts`): always end a data question with this call; `columns` should include identity / `sensitive-masked` fields.

## Test plan

- [x] `plugin-privacy-guard` build clean
- [x] 92 v4 `node:test` tests pass
- [x] lint clean
- [ ] **Operator step:** re-run the live HR-agent test — verify the ranking now shows real, complete employee names (violet-highlighted), no "Datenschutzfilter"-disclaimer
