### PR TITLE
feat(chat): stream survives tab/menu switch + composer reset + background toasts

### DIFF
--- a/middleware/packages/harness-orchestrator/src/chatSessionStore.ts
+++ b/middleware/packages/harness-orchestrator/src/chatSessionStore.ts
@@ -134,6 +134,25 @@ export class ChatSessionStore {
     await this.store.writeFile(virtualPath, JSON.stringify(session, null, 2));
   }
 
+  /**
+   * Reset a session: keep id / title / createdAt, drop all messages, bump
+   * updatedAt. Returns the updated session, or null when the session was
+   * not found. KG / Memory are NOT touched — the agent simply enters its
+   * next turn with an empty context window.
+   */
+  async resetMessages(id: string): Promise<ChatSession | null> {
+    if (!ID_RE.test(id)) throw new InvalidSessionIdError(id);
+    const existing = await this.get(id);
+    if (!existing) return null;
+    const updated: ChatSession = {
+      ...existing,
+      messages: [],
+      updatedAt: Date.now(),
+    };
+    await this.save(updated);
+    return updated;
+  }
+
   async delete(id: string): Promise<void> {
     const virtualPath = this.pathFor(id);
     if (!(await this.store.fileExists(virtualPath))) return;

--- a/middleware/src/routes/chatSessions.ts
+++ b/middleware/src/routes/chatSessions.ts
@@ -147,6 +147,38 @@ export function createChatSessionsRouter(deps: ChatSessionDeps): Router {
     }
   });
 
+  /**
+   * Reset a session: drop messages, keep id/title, return a fresh
+   * conversation-id so the client (and a future audit log) can correlate
+   * the boundary. Memory and Knowledge-Graph entries are NOT touched —
+   * a reset only wipes the agent's working context window.
+   */
+  router.post('/sessions/:id/reset', async (req: Request, res: Response) => {
+    const id = req.params['id'];
+    if (typeof id !== 'string' || !isValidSessionId(id)) {
+      res.status(400).json({ error: 'invalid_id' });
+      return;
+    }
+    try {
+      const updated = await store.resetMessages(id);
+      if (!updated) {
+        res.status(404).json({ error: 'not_found' });
+        return;
+      }
+      res.json({
+        sessionId: updated.id,
+        newConversationId: `${updated.id}:${String(updated.updatedAt)}`,
+        resetAt: updated.updatedAt,
+      });
+    } catch (err) {
+      if (err instanceof InvalidSessionIdError) {
+        res.status(400).json({ error: 'invalid_id' });
+        return;
+      }
+      failure(res, err, '[chat-sessions] reset');
+    }
+  });
+
   return router;
 }
 

--- a/middleware/test/chatSessionsResetRoute.test.ts
+++ b/middleware/test/chatSessionsResetRoute.test.ts
@@ -1,0 +1,118 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { ChatSessionStore } from '@omadia/orchestrator';
+import type { MemoryStore, MemoryEntry } from '@omadia/plugin-api';
+
+/**
+ * Unit test for `ChatSessionStore.resetMessages` — added 2026-05-26 to back
+ * the new `POST /api/chat/sessions/:id/reset` endpoint that the web-ui's
+ * composer-eraser button calls.
+ */
+
+class InMemoryStore implements MemoryStore {
+  private files = new Map<string, string>();
+
+  async list(virtualPath: string): Promise<MemoryEntry[]> {
+    const prefix = virtualPath.endsWith('/') ? virtualPath : `${virtualPath}/`;
+    const out: MemoryEntry[] = [];
+    for (const [key, value] of this.files.entries()) {
+      if (!key.startsWith(prefix)) continue;
+      const rest = key.slice(prefix.length);
+      if (rest.includes('/')) continue;
+      out.push({
+        virtualPath: key,
+        isDirectory: false,
+        sizeBytes: Buffer.byteLength(value),
+      });
+    }
+    return out;
+  }
+  async fileExists(virtualPath: string): Promise<boolean> {
+    return this.files.has(virtualPath);
+  }
+  async directoryExists(virtualPath: string): Promise<boolean> {
+    const prefix = virtualPath.endsWith('/') ? virtualPath : `${virtualPath}/`;
+    for (const key of this.files.keys()) {
+      if (key.startsWith(prefix)) return true;
+    }
+    return false;
+  }
+  async readFile(virtualPath: string): Promise<string> {
+    const v = this.files.get(virtualPath);
+    if (v === undefined) throw new Error(`missing: ${virtualPath}`);
+    return v;
+  }
+  async createFile(virtualPath: string, content: string): Promise<void> {
+    if (this.files.has(virtualPath)) throw new Error(`exists: ${virtualPath}`);
+    this.files.set(virtualPath, content);
+  }
+  async writeFile(virtualPath: string, content: string): Promise<void> {
+    this.files.set(virtualPath, content);
+  }
+  async delete(virtualPath: string): Promise<void> {
+    this.files.delete(virtualPath);
+  }
+  async rename(from: string, to: string): Promise<void> {
+    const v = this.files.get(from);
+    if (v === undefined) throw new Error(`missing: ${from}`);
+    this.files.delete(from);
+    this.files.set(to, v);
+  }
+}
+
+const SESSION_ID = 'demo-session-1';
+const sampleSession = {
+  id: SESSION_ID,
+  title: 'Demo Chat',
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_500_000,
+  messages: [
+    { id: 'm1', role: 'user' as const, content: 'hi', startedAt: 1_700_000_000_000 },
+    {
+      id: 'm2',
+      role: 'assistant' as const,
+      content: 'hello',
+      startedAt: 1_700_000_001_000,
+      finishedAt: 1_700_000_002_000,
+    },
+  ],
+};
+
+describe('ChatSessionStore.resetMessages', () => {
+  it('clears messages but preserves id, title, createdAt', async () => {
+    const mem = new InMemoryStore();
+    const store = new ChatSessionStore(mem);
+    await store.save(sampleSession);
+
+    const result = await store.resetMessages(SESSION_ID);
+    assert.ok(result, 'should return updated session');
+    assert.equal(result.id, SESSION_ID);
+    assert.equal(result.title, 'Demo Chat');
+    assert.equal(result.createdAt, 1_700_000_000_000);
+    assert.equal(result.messages.length, 0);
+    assert.ok(
+      result.updatedAt > sampleSession.updatedAt,
+      'updatedAt must advance',
+    );
+
+    // Persisted state matches.
+    const reread = await store.get(SESSION_ID);
+    assert.ok(reread);
+    assert.equal(reread.messages.length, 0);
+    assert.equal(reread.title, 'Demo Chat');
+  });
+
+  it('returns null for unknown session', async () => {
+    const mem = new InMemoryStore();
+    const store = new ChatSessionStore(mem);
+    const result = await store.resetMessages('nope-not-there');
+    assert.equal(result, null);
+  });
+
+  it('rejects malformed ids', async () => {
+    const mem = new InMemoryStore();
+    const store = new ChatSessionStore(mem);
+    await assert.rejects(() => store.resetMessages('../etc/passwd'));
+  });
+});

--- a/web-ui/app/_components/ConfirmDialog.tsx
+++ b/web-ui/app/_components/ConfirmDialog.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * Minimal modal-confirm. No portal, no library — just a fixed-position
+ * overlay with focus-trap basics. We keep it generic (title/body/labels)
+ * so the same component covers chat-reset, destructive delete, and any
+ * future "are you sure?" gates.
+ */
+export interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  body?: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  /** `danger` paints the confirm button red. */
+  tone?: 'neutral' | 'danger';
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  body,
+  confirmLabel,
+  cancelLabel,
+  tone = 'neutral',
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps): React.ReactElement | null {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    // Auto-focus the confirm button so Enter commits.
+    confirmRef.current?.focus();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: globalThis.KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  const confirmCls =
+    tone === 'danger'
+      ? 'bg-red-600 hover:bg-red-700 text-white border-red-600'
+      : 'bg-neutral-900 hover:bg-neutral-700 text-white border-neutral-900 dark:bg-neutral-100 dark:text-neutral-900 dark:border-neutral-100';
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-dialog-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div className="w-full max-w-md rounded-lg border border-neutral-200 bg-white p-5 shadow-xl dark:border-neutral-700 dark:bg-neutral-900">
+        <h2
+          id="confirm-dialog-title"
+          className="text-base font-semibold text-neutral-900 dark:text-neutral-100"
+        >
+          {title}
+        </h2>
+        {body && (
+          <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+            {body}
+          </p>
+        )}
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded border border-neutral-300 bg-white px-4 py-1.5 text-sm font-medium text-neutral-700 transition hover:border-neutral-400 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            ref={confirmRef}
+            type="button"
+            onClick={onConfirm}
+            className={`rounded border px-4 py-1.5 text-sm font-medium transition ${confirmCls}`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-ui/app/_components/StreamRunner.tsx
+++ b/web-ui/app/_components/StreamRunner.tsx
@@ -78,10 +78,41 @@ async function runOneTurn(claim: ClaimedRequest, depsRef: DepsRef): Promise<void
   const { sessionId, pendingMessageId, message } = request;
   const { store } = depsRef.current;
 
+  // Per-turn accumulators. Kept local to the runner so the store stays
+  // thin — it just receives the resulting patches. The content buffer
+  // powers a rolling preview tail that survives multiple `text_delta`
+  // chunks (otherwise the toast would only ever show the last delta).
+  let contentBuffer = '';
+  let tokensIn = 0;
+  let tokensOut = 0;
+  let cacheTokens = 0;
+
   const applyEvent = (event: ChatStreamEvent): void => {
     const { sessions: liveSessions } = depsRef.current;
     applyStreamEvent(liveSessions, sessionId, pendingMessageId, event);
-    const phasePatch = derivePhasePatch(event);
+
+    // Accumulate per-turn signals BEFORE deriving the patch so the
+    // patch has fresh numbers.
+    if (event.type === 'text_delta') {
+      contentBuffer += event.text;
+    } else if (event.type === 'iteration_usage') {
+      tokensIn += event.inputTokens;
+      tokensOut += event.outputTokens;
+      cacheTokens += event.cacheReadInputTokens;
+    } else if (event.type === 'done') {
+      // The `done` event carries the authoritative answer; the live
+      // text_delta buffer can legitimately be shorter than this (e.g.
+      // Privacy Shield v4 server-side materialization). Mirror it so
+      // toasts that linger after `done` show the real final text.
+      contentBuffer = event.answer;
+    }
+
+    const phasePatch = derivePhasePatch(event, {
+      contentBuffer,
+      tokensIn,
+      tokensOut,
+      cacheTokens,
+    });
     if (phasePatch) store.patch(sessionId, phasePatch);
   };
 
@@ -186,18 +217,47 @@ function finalizePending(
   });
 }
 
-function derivePhasePatch(event: ChatStreamEvent): {
+interface AccumulatorState {
+  contentBuffer: string;
+  tokensIn: number;
+  tokensOut: number;
+  cacheTokens: number;
+}
+
+function derivePhasePatch(
+  event: ChatStreamEvent,
+  acc: AccumulatorState,
+): {
   phase?: StreamPhase;
   previewTail?: string;
   toolName?: string;
+  tokensIn?: number;
+  tokensOut?: number;
+  cacheTokens?: number;
 } | null {
   switch (event.type) {
     case 'text_delta':
-      return { phase: 'streaming', previewTail: tailOf(event.text) };
+      return {
+        phase: 'streaming',
+        previewTail: tailOf(acc.contentBuffer),
+      };
     case 'tool_use':
       return { phase: 'tool_running', toolName: event.name };
     case 'tool_result':
       return { phase: 'thinking', toolName: undefined };
+    case 'iteration_usage':
+      return {
+        tokensIn: acc.tokensIn,
+        tokensOut: acc.tokensOut,
+        cacheTokens: acc.cacheTokens,
+      };
+    case 'done':
+      return {
+        previewTail: tailOf(acc.contentBuffer),
+        tokensIn: acc.tokensIn,
+        tokensOut: acc.tokensOut,
+        cacheTokens: acc.cacheTokens,
+      };
     case 'heartbeat':
       if (event.phase) return { phase: mapHeartbeatPhase(event.phase) };
       return null;
@@ -223,7 +283,18 @@ function mapHeartbeatPhase(
   }
 }
 
+/** Last ~160 chars of normalized text, sliced at a word boundary so the
+ *  toast never opens mid-word (otherwise we'd routinely see "ach den…"
+ *  when the buffer was cut from "nach den…"). Prefixes an ellipsis when
+ *  the original was actually trimmed. */
 function tailOf(text: string): string {
-  const single = text.replace(/\s+/g, ' ');
-  return single.length > 80 ? single.slice(-80) : single;
+  const single = text.replace(/\s+/g, ' ').trim();
+  const MAX = 160;
+  if (single.length <= MAX) return single;
+  const sliced = single.slice(-MAX);
+  // Drop everything up to (and including) the first space so the tail
+  // starts with a whole word.
+  const firstSpace = sliced.indexOf(' ');
+  const cleaned = firstSpace >= 0 ? sliced.slice(firstSpace + 1) : sliced;
+  return `…${cleaned}`;
 }

--- a/web-ui/app/_components/StreamRunner.tsx
+++ b/web-ui/app/_components/StreamRunner.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { applyStreamEvent, type ChatStreamEvent } from '../_lib/chatStreamEvents';
+import { useChatSessionsCtx } from '../_lib/chatSessionsContext';
+import {
+  type ClaimedRequest,
+  type StreamPhase,
+  useStreamStore,
+} from '../_lib/streamStore';
+
+/**
+ * Headless background runner for chat streams. Mounted once in the layout;
+ * watches the streamStore's pending-request queue, takes ownership of each
+ * request, runs the fetch + NDJSON-parse loop, and writes message deltas
+ * back into the chat-sessions context.
+ *
+ * Why headless and at layout level: ChatPage unmounts on menu navigation
+ * (e.g. Chat → Graph). If the stream loop lived inside ChatPage, that
+ * navigation would kill the fetch. Lifting both the loop and the session
+ * state into the layout fixes that — the runner keeps pumping events and
+ * the session store keeps receiving them, regardless of which route the
+ * user is currently looking at.
+ */
+export function StreamRunner(): null {
+  const t = useTranslations('chat');
+  const store = useStreamStore();
+  const sessions = useChatSessionsCtx();
+  const inFlight = useRef<Set<string>>(new Set());
+
+  // Snapshot dependencies so the async loop doesn't capture stale closures
+  // when next-intl re-renders mid-stream.
+  const depsRef = useRef({ t, sessions, store });
+  useEffect(() => {
+    depsRef.current = { t, sessions, store };
+  }, [t, sessions, store]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const drain = (): void => {
+      while (!cancelled) {
+        const claim = store.claimRequest();
+        if (!claim) return;
+        if (inFlight.current.has(claim.request.sessionId)) continue;
+        inFlight.current.add(claim.request.sessionId);
+        void (async (): Promise<void> => {
+          try {
+            await runOneTurn(claim, depsRef);
+          } finally {
+            inFlight.current.delete(claim.request.sessionId);
+          }
+        })();
+      }
+    };
+
+    drain();
+    return () => {
+      cancelled = true;
+    };
+  }, [store, store.queueVersion]);
+
+  return null;
+}
+
+interface DepsRef {
+  current: {
+    t: ReturnType<typeof useTranslations>;
+    sessions: ReturnType<typeof useChatSessionsCtx>;
+    store: ReturnType<typeof useStreamStore>;
+  };
+}
+
+async function runOneTurn(claim: ClaimedRequest, depsRef: DepsRef): Promise<void> {
+  const { request, signal } = claim;
+  const { sessionId, pendingMessageId, message } = request;
+  const { store } = depsRef.current;
+
+  const applyEvent = (event: ChatStreamEvent): void => {
+    const { sessions: liveSessions } = depsRef.current;
+    applyStreamEvent(liveSessions, sessionId, pendingMessageId, event);
+    const phasePatch = derivePhasePatch(event);
+    if (phasePatch) store.patch(sessionId, phasePatch);
+  };
+
+  try {
+    const res = await fetch('/bot-api/chat/stream', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ message, sessionId }),
+      signal,
+    });
+
+    const contentType = res.headers.get('content-type') ?? '';
+    if (!res.ok || !res.body) {
+      const fallback = await res.text().catch(() => '');
+      const looksHtml =
+        fallback.trimStart().toLowerCase().startsWith('<!doctype') ||
+        fallback.trimStart().startsWith('<html');
+      const { t } = depsRef.current;
+      let msg: string;
+      if (looksHtml || contentType.includes('text/html')) {
+        msg =
+          res.status === 500
+            ? t('errorMiddlewareUnreachable')
+            : t('errorProxyFailure', { status: String(res.status) });
+      } else if (contentType.includes('application/json')) {
+        try {
+          const parsed = JSON.parse(fallback) as { error?: string; message?: string };
+          msg = parsed.message ?? parsed.error ?? `HTTP ${String(res.status)}`;
+        } catch {
+          msg = fallback || `HTTP ${String(res.status)}`;
+        }
+      } else {
+        msg = fallback || `HTTP ${String(res.status)}`;
+      }
+      applyEvent({ type: 'error', message: msg });
+      store.finish(sessionId, 'error', msg);
+      finalizePending(depsRef.current.sessions, sessionId, pendingMessageId);
+      return;
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        const trimmedLine = line.trim();
+        if (!trimmedLine) continue;
+        try {
+          const event = JSON.parse(trimmedLine) as ChatStreamEvent;
+          applyEvent(event);
+        } catch {
+          // Partial NDJSON tail stays in buffer.
+        }
+      }
+    }
+    const tail = buffer.trim();
+    if (tail) {
+      try {
+        applyEvent(JSON.parse(tail) as ChatStreamEvent);
+      } catch {
+        /* ignore */
+      }
+    }
+    store.finish(sessionId, 'done');
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') {
+      const { t } = depsRef.current;
+      applyEvent({ type: 'error', message: t('errorAborted') });
+      store.finish(sessionId, 'aborted');
+    } else {
+      const msg = err instanceof Error ? err.message : String(err);
+      applyEvent({ type: 'error', message: msg });
+      store.finish(sessionId, 'error', msg);
+    }
+  } finally {
+    finalizePending(depsRef.current.sessions, sessionId, pendingMessageId);
+    void depsRef.current.sessions.persistActive();
+  }
+}
+
+function finalizePending(
+  sessions: ReturnType<typeof useChatSessionsCtx>,
+  sessionId: string,
+  pendingMessageId: string,
+): void {
+  sessions.mutateActive((session) => {
+    if (session.id !== sessionId) return session;
+    return {
+      ...session,
+      messages: session.messages.map((m) =>
+        m.id === pendingMessageId && m.streaming
+          ? { ...m, streaming: false, finishedAt: Date.now() }
+          : m,
+      ),
+      updatedAt: Date.now(),
+    };
+  });
+}
+
+function derivePhasePatch(event: ChatStreamEvent): {
+  phase?: StreamPhase;
+  previewTail?: string;
+  toolName?: string;
+} | null {
+  switch (event.type) {
+    case 'text_delta':
+      return { phase: 'streaming', previewTail: tailOf(event.text) };
+    case 'tool_use':
+      return { phase: 'tool_running', toolName: event.name };
+    case 'tool_result':
+      return { phase: 'thinking', toolName: undefined };
+    case 'heartbeat':
+      if (event.phase) return { phase: mapHeartbeatPhase(event.phase) };
+      return null;
+    case 'iteration_start':
+      return { phase: 'thinking' };
+    default:
+      return null;
+  }
+}
+
+function mapHeartbeatPhase(
+  phase: 'thinking' | 'streaming' | 'tool_running' | 'idle',
+): StreamPhase {
+  switch (phase) {
+    case 'thinking':
+      return 'thinking';
+    case 'streaming':
+      return 'streaming';
+    case 'tool_running':
+      return 'tool_running';
+    case 'idle':
+      return 'streaming';
+  }
+}
+
+function tailOf(text: string): string {
+  const single = text.replace(/\s+/g, ' ');
+  return single.length > 80 ? single.slice(-80) : single;
+}

--- a/web-ui/app/_components/StreamToasts.tsx
+++ b/web-ui/app/_components/StreamToasts.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Loader2, X } from 'lucide-react';
+
+import { useChatSessionsCtx } from '../_lib/chatSessionsContext';
+import {
+  type StreamPhase,
+  type StreamRecord,
+  useStreamStore,
+} from '../_lib/streamStore';
+
+/**
+ * Floating toast stack rendered at the bottom-right of every route. Shows
+ * one toast per active stream whose chat-session is NOT currently in view
+ * (background streams only — when the user is already looking at the chat,
+ * the inline streaming UI is enough).
+ *
+ * Active streams show a live preview tail + spinner. Terminal streams
+ * (done / error / aborted) linger for a few seconds with a final summary
+ * so the user knows the answer is ready before the toast disappears.
+ */
+export function StreamToasts(): React.ReactElement {
+  const t = useTranslations('streamToasts');
+  const router = useRouter();
+  const store = useStreamStore();
+  const { activeId, setActive } = useChatSessionsCtx();
+  const [pathname, setPathname] = useState<string>('');
+
+  // Pull pathname client-side without forcing this component to suspend on
+  // an RSC fetch — we just need to know "is the user looking at the chat
+  // page right now?".
+  useEffect(() => {
+    const update = (): void => {
+      setPathname(window.location.pathname);
+    };
+    update();
+    window.addEventListener('popstate', update);
+    return () => {
+      window.removeEventListener('popstate', update);
+    };
+  }, []);
+
+  const onChatRoute = pathname === '' || pathname === '/';
+  const visibleRecords: StreamRecord[] = [];
+  for (const rec of store.records.values()) {
+    // Hide records that the user is currently viewing in-page: the user is
+    // on the chat page AND the record is for the active session.
+    if (onChatRoute && rec.sessionId === activeId) continue;
+    visibleRecords.push(rec);
+  }
+  // Newest first for stacking.
+  visibleRecords.sort((a, b) => b.lastEventAt - a.lastEventAt);
+  // Cap to 3 visible — anything more becomes noise.
+  const trimmed = visibleRecords.slice(0, 3);
+
+  const openChat = (sessionId: string): void => {
+    setActive(sessionId);
+    if (!onChatRoute) router.push('/');
+  };
+
+  return (
+    <div
+      className="pointer-events-none fixed right-4 bottom-4 z-40 flex w-80 flex-col gap-2"
+      aria-live="polite"
+    >
+      <AnimatePresence initial={false}>
+        {trimmed.map((rec) => (
+          <motion.div
+            key={rec.sessionId}
+            layout
+            initial={{ opacity: 0, y: 20, scale: 0.96 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 20, scale: 0.96 }}
+            transition={{ duration: 0.18 }}
+            className="pointer-events-auto"
+          >
+            <StreamToast
+              record={rec}
+              t={t}
+              onOpen={() => {
+                openChat(rec.sessionId);
+              }}
+              onDismiss={() => {
+                store.abort(rec.sessionId);
+              }}
+            />
+          </motion.div>
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+interface StreamToastProps {
+  record: StreamRecord;
+  t: ReturnType<typeof useTranslations>;
+  onOpen: () => void;
+  onDismiss: () => void;
+}
+
+function StreamToast({
+  record,
+  t,
+  onOpen,
+  onDismiss,
+}: StreamToastProps): React.ReactElement {
+  const isTerminal =
+    record.phase === 'done' ||
+    record.phase === 'error' ||
+    record.phase === 'aborted';
+  const phaseLabel = phaseLabelFor(record.phase, t);
+  // Tick once a second while active so the elapsed-seconds line stays
+  // honest. Terminal toasts freeze at their last event time — no point
+  // re-rendering them every second.
+  const now = useTickingNow(!isTerminal);
+  const elapsedSec = Math.max(
+    0,
+    Math.round(((isTerminal ? record.lastEventAt : now) - record.startedAt) / 1000),
+  );
+
+  const palette = paletteFor(record.phase);
+
+  return (
+    <div
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      className={`group cursor-pointer rounded-lg border ${palette.border} ${palette.bg} px-3 py-2 shadow-md transition hover:shadow-lg`}
+    >
+      <div className="flex items-start gap-2">
+        <div className={`mt-0.5 ${palette.icon}`}>
+          {isTerminal ? (
+            <span className="text-base leading-none">{palette.symbol}</span>
+          ) : (
+            <Loader2 size={14} className="animate-spin" />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-2">
+            <div className="truncate text-xs font-semibold text-neutral-900 dark:text-neutral-100">
+              {phaseLabel}
+              {record.toolName ? (
+                <span className="ml-1 font-mono text-[10px] font-normal text-neutral-500">
+                  · {record.toolName}
+                </span>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDismiss();
+              }}
+              className="rounded p-0.5 text-neutral-400 opacity-60 transition hover:bg-neutral-200 hover:text-neutral-700 group-hover:opacity-100 dark:hover:bg-neutral-700 dark:hover:text-neutral-200"
+              aria-label={t('dismissAriaLabel')}
+              title={t('dismissTitle')}
+            >
+              <X size={12} aria-hidden />
+            </button>
+          </div>
+          {record.previewTail && (
+            <div className="mt-1 line-clamp-2 text-[11px] text-neutral-600 dark:text-neutral-400">
+              {record.previewTail}
+            </div>
+          )}
+          <div className="mt-1 flex items-center gap-2 text-[10px] text-neutral-500 dark:text-neutral-500">
+            <span>{t('elapsedSec', { sec: elapsedSec })}</span>
+            {record.error ? (
+              <span className="truncate text-red-600 dark:text-red-400">
+                · {record.error}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Re-renders the caller every second when `active` is true. Returns the
+ *  current wall-clock at the last tick. */
+function useTickingNow(active: boolean): number {
+  const [now, setNow] = useState<number>(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    const id = setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+    return () => {
+      clearInterval(id);
+    };
+  }, [active]);
+  return now;
+}
+
+function phaseLabelFor(
+  phase: StreamPhase,
+  t: ReturnType<typeof useTranslations>,
+): string {
+  switch (phase) {
+    case 'pending':
+    case 'thinking':
+      return t('phaseThinking');
+    case 'streaming':
+      return t('phaseStreaming');
+    case 'tool_running':
+      return t('phaseToolRunning');
+    case 'done':
+      return t('phaseDone');
+    case 'error':
+      return t('phaseError');
+    case 'aborted':
+      return t('phaseAborted');
+  }
+}
+
+function paletteFor(phase: StreamPhase): {
+  border: string;
+  bg: string;
+  icon: string;
+  symbol: string;
+} {
+  switch (phase) {
+    case 'done':
+      return {
+        border: 'border-emerald-300 dark:border-emerald-800',
+        bg: 'bg-emerald-50 dark:bg-emerald-950/60',
+        icon: 'text-emerald-700 dark:text-emerald-400',
+        symbol: '✓',
+      };
+    case 'error':
+      return {
+        border: 'border-red-300 dark:border-red-800',
+        bg: 'bg-red-50 dark:bg-red-950/60',
+        icon: 'text-red-700 dark:text-red-400',
+        symbol: '✗',
+      };
+    case 'aborted':
+      return {
+        border: 'border-neutral-300 dark:border-neutral-700',
+        bg: 'bg-neutral-50 dark:bg-neutral-900',
+        icon: 'text-neutral-500',
+        symbol: '⏹',
+      };
+    default:
+      return {
+        border: 'border-indigo-200 dark:border-indigo-800',
+        bg: 'bg-white dark:bg-neutral-900',
+        icon: 'text-indigo-600 dark:text-indigo-400',
+        symbol: '…',
+      };
+  }
+}

--- a/web-ui/app/_components/StreamToasts.tsx
+++ b/web-ui/app/_components/StreamToasts.tsx
@@ -64,7 +64,7 @@ export function StreamToasts(): React.ReactElement {
 
   return (
     <div
-      className="pointer-events-none fixed right-4 bottom-4 z-40 flex w-80 flex-col gap-2"
+      className="pointer-events-none fixed right-4 bottom-4 z-40 flex w-96 flex-col gap-2"
       aria-live="polite"
     >
       <AnimatePresence initial={false}>
@@ -169,12 +169,36 @@ function StreamToast({
             </button>
           </div>
           {record.previewTail && (
-            <div className="mt-1 line-clamp-2 text-[11px] text-neutral-600 dark:text-neutral-400">
+            <div className="mt-1 line-clamp-3 text-[11px] leading-snug text-neutral-600 dark:text-neutral-400">
               {record.previewTail}
             </div>
           )}
           <div className="mt-1 flex items-center gap-2 text-[10px] text-neutral-500 dark:text-neutral-500">
             <span>{t('elapsedSec', { sec: elapsedSec })}</span>
+            {typeof record.tokensIn === 'number' && record.tokensIn > 0 ? (
+              <span
+                className="font-mono"
+                title={t('tokensInTitle', { n: record.tokensIn })}
+              >
+                · ↓ {formatTokenCount(record.tokensIn)}
+              </span>
+            ) : null}
+            {typeof record.tokensOut === 'number' && record.tokensOut > 0 ? (
+              <span
+                className="font-mono"
+                title={t('tokensOutTitle', { n: record.tokensOut })}
+              >
+                ↑ {formatTokenCount(record.tokensOut)}
+              </span>
+            ) : null}
+            {typeof record.cacheTokens === 'number' && record.cacheTokens > 0 ? (
+              <span
+                className="font-mono text-emerald-600 dark:text-emerald-400"
+                title={t('cacheHitTitle', { n: record.cacheTokens })}
+              >
+                · 🟢 {formatTokenCount(record.cacheTokens)}
+              </span>
+            ) : null}
             {record.error ? (
               <span className="truncate text-red-600 dark:text-red-400">
                 · {record.error}
@@ -185,6 +209,14 @@ function StreamToast({
       </div>
     </div>
   );
+}
+
+/** "1.2k" / "340" / "1.45M" — keeps the toast row compact. */
+function formatTokenCount(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 10000) return (n / 1000).toFixed(2).replace(/\.?0+$/, '') + 'k';
+  if (n < 1000000) return Math.round(n / 1000) + 'k';
+  return (n / 1000000).toFixed(2).replace(/\.?0+$/, '') + 'M';
 }
 
 /** Re-renders the caller every second when `active` is true. Returns the

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -2810,3 +2810,29 @@ export async function reclusterTopics(opts: {
 } = {}): Promise<TopicReclusterResultDto> {
   return postJson<TopicReclusterResultDto>('/v1/admin/topics/recluster', opts);
 }
+
+// -----------------------------------------------------------------------------
+// Chat session reset (2026-05-26).
+// -----------------------------------------------------------------------------
+
+export interface ResetChatSessionResponse {
+  sessionId: string;
+  /** New conversation pointer minted by the orchestrator. */
+  newConversationId: string;
+  resetAt: number;
+}
+
+/**
+ * Rotates the conversation pointer for a chat session. The backend keeps
+ * the session-id stable (so KG / memory references stay valid) but starts
+ * a fresh conversation-id so the agent's context window is empty on the
+ * next turn. Memory and Knowledge-Graph entries are NOT touched.
+ */
+export async function resetChatSession(
+  sessionId: string,
+): Promise<ResetChatSessionResponse> {
+  return postJson<ResetChatSessionResponse>(
+    `/chat/sessions/${encodeURIComponent(sessionId)}/reset`,
+    {},
+  );
+}

--- a/web-ui/app/_lib/chatSessionsContext.tsx
+++ b/web-ui/app/_lib/chatSessionsContext.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+import { useChatSessions, type UseChatSessionsResult } from './chatSessions';
+
+/**
+ * Lifts the chat-sessions state (sessions, activeId, mutateActive, …) to
+ * a layout-level provider. Without this, the state lived inside
+ * `<ChatPage>` and was destroyed whenever the user navigated away — taking
+ * any in-flight stream's `mutateActive` closure down with it. With this,
+ * the provider is mounted in `RootLayout`, so `<StreamRunner>` (also in
+ * the layout) keeps writing message deltas into the same store regardless
+ * of which page is currently rendered.
+ */
+
+const ChatSessionsCtx = createContext<UseChatSessionsResult | null>(null);
+
+export function ChatSessionsProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  const value = useChatSessions();
+  return (
+    <ChatSessionsCtx.Provider value={value}>{children}</ChatSessionsCtx.Provider>
+  );
+}
+
+/**
+ * Read the chat-sessions state from context. Throws if used outside the
+ * provider — every consumer in `web-ui/` lives under `RootLayout`, so this
+ * fires only on misconfigured tests.
+ */
+export function useChatSessionsCtx(): UseChatSessionsResult {
+  const v = useContext(ChatSessionsCtx);
+  if (!v) {
+    throw new Error(
+      'useChatSessionsCtx: missing <ChatSessionsProvider> — mount it in layout.tsx.',
+    );
+  }
+  return v;
+}

--- a/web-ui/app/_lib/chatStreamEvents.ts
+++ b/web-ui/app/_lib/chatStreamEvents.ts
@@ -1,0 +1,308 @@
+'use client';
+
+import type {
+  ChatSession,
+  DiagramAttachment,
+  FollowUpOption,
+  Message,
+  NudgeEvent,
+  PalaiaExcerpt,
+  PendingUserChoice,
+  PrivacyReceipt,
+  SubAgentEvent,
+  ToolEvent,
+  UseChatSessionsResult,
+} from './chatSessions';
+
+/**
+ * Wire-format for chat stream events. Mirrors `ChatStreamEvent` in
+ * `middleware/src/services/orchestrator.ts`. Validation is lax on purpose —
+ * the server is trusted and any shape drift should surface as an obvious
+ * UI bug rather than a silent drop.
+ */
+export type ChatStreamEvent =
+  | { type: 'iteration_start'; iteration: number }
+  | { type: 'text_delta'; text: string }
+  | {
+      type: 'tool_use';
+      id: string;
+      name: string;
+      input: unknown;
+      /** Server-resolved agent metadata; absent for helper tools. */
+      agent?: ToolEvent['agent'];
+    }
+  | {
+      type: 'tool_result';
+      id: string;
+      output: string;
+      durationMs: number;
+      isError?: boolean;
+    }
+  | {
+      type: 'nudge';
+      id: string;
+      nudgeId: string;
+      text: string;
+      cta?: {
+        label: string;
+        toolName: string;
+        arguments: Record<string, unknown>;
+      };
+    }
+  | { type: 'tool_progress'; id: string; elapsedMs: number }
+  | {
+      type: 'heartbeat';
+      sinceLastActivityMs: number;
+      currentIteration: number;
+      toolCallsThisIter: number;
+      phase?: 'thinking' | 'streaming' | 'tool_running' | 'idle';
+      tokensStreamedThisIter?: number;
+    }
+  | {
+      type: 'stream_token_chunk';
+      iteration: number;
+      deltaTokens: number;
+      cumulativeOutputTokens: number;
+      tokensPerSec: number;
+    }
+  | {
+      type: 'iteration_usage';
+      iteration: number;
+      inputTokens: number;
+      outputTokens: number;
+      cacheReadInputTokens: number;
+      cacheCreationInputTokens: number;
+    }
+  | { type: 'sub_iteration'; parentId: string; iteration: number }
+  | {
+      type: 'sub_tool_use';
+      parentId: string;
+      id: string;
+      name: string;
+      input: unknown;
+    }
+  | {
+      type: 'sub_tool_result';
+      parentId: string;
+      id: string;
+      output: string;
+      durationMs: number;
+      isError: boolean;
+    }
+  | {
+      type: 'done';
+      answer: string;
+      toolCalls: number;
+      iterations: number;
+      turnId?: string;
+      palaiaExcerpt?: PalaiaExcerpt;
+      autoPromotedMkId?: string;
+      attachments?: DiagramAttachment[];
+      pendingUserChoice?: PendingUserChoice;
+      followUpOptions?: FollowUpOption[];
+      privacyReceipt?: PrivacyReceipt;
+      maskedValues?: readonly string[];
+    }
+  | { type: 'error'; message: string };
+
+/**
+ * Fold one stream event into the session that owns the pending assistant
+ * message. Pure-ish: writes go through `sessions.mutateActive`. The session
+ * is matched by id; events for non-active sessions are no-ops here — the
+ * caller (StreamRunner) is responsible for routing to the right pending id.
+ *
+ * Note: mutateActive only writes to the *currently active* session. The
+ * stream-runner uses it because in practice a stream's session and the
+ * active session coincide while a turn is firing. If we ever want to run
+ * background turns for a non-active session we'll need a per-session
+ * `mutateById` helper.
+ */
+export function applyStreamEvent(
+  sessions: UseChatSessionsResult,
+  sessionId: string,
+  pendingMessageId: string,
+  event: ChatStreamEvent,
+): void {
+  sessions.mutateActive((session) => {
+    if (session.id !== sessionId) return session;
+    return foldEvent(session, pendingMessageId, event);
+  });
+}
+
+function foldEvent(
+  session: ChatSession,
+  pendingId: string,
+  event: ChatStreamEvent,
+): ChatSession {
+  const nextMessages = session.messages.map((m) => {
+    if (m.id !== pendingId) return m;
+    return foldIntoMessage(m, event);
+  });
+  return { ...session, messages: nextMessages, updatedAt: Date.now() };
+}
+
+function foldIntoMessage(m: Message, event: ChatStreamEvent): Message {
+  switch (event.type) {
+    case 'text_delta':
+      return { ...m, content: m.content + event.text };
+    case 'tool_use': {
+      const tool: ToolEvent = {
+        id: event.id,
+        name: event.name,
+        input: event.input,
+        startedAt: Date.now(),
+        subEvents: [],
+        ...(event.agent ? { agent: event.agent } : {}),
+      };
+      return { ...m, tools: [...(m.tools ?? []), tool] };
+    }
+    case 'tool_progress': {
+      const tools = (m.tools ?? []).map((t) =>
+        t.id === event.id ? { ...t, liveElapsedMs: event.elapsedMs } : t,
+      );
+      return { ...m, tools };
+    }
+    case 'heartbeat':
+      return {
+        ...m,
+        liveness: {
+          sinceLastActivityMs: event.sinceLastActivityMs,
+          iteration: event.currentIteration,
+          toolCallsThisIter: event.toolCallsThisIter,
+          ...(event.phase ? { phase: event.phase } : {}),
+          ...(typeof event.tokensStreamedThisIter === 'number'
+            ? { tokensThisIter: event.tokensStreamedThisIter }
+            : {}),
+        },
+      };
+    case 'stream_token_chunk':
+      return {
+        ...m,
+        tokensPerSec: event.tokensPerSec,
+        liveness: m.liveness
+          ? {
+              ...m.liveness,
+              tokensThisIter: event.cumulativeOutputTokens,
+            }
+          : m.liveness,
+      };
+    case 'iteration_usage':
+      return {
+        ...m,
+        lastUsage: {
+          inputTokens: event.inputTokens,
+          cacheReadInputTokens: event.cacheReadInputTokens,
+        },
+      };
+    case 'tool_result': {
+      const tools = (m.tools ?? []).map((t) =>
+        t.id === event.id
+          ? {
+              ...t,
+              output: event.output,
+              durationMs: event.durationMs,
+              isError: event.isError ?? false,
+              liveElapsedMs: undefined,
+            }
+          : t,
+      );
+      return { ...m, tools };
+    }
+    case 'nudge': {
+      const next: NudgeEvent = {
+        id: event.id,
+        nudgeId: event.nudgeId,
+        text: event.text,
+        ...(event.cta ? { cta: event.cta } : {}),
+      };
+      const existing = m.nudges ?? [];
+      const filtered = existing.filter(
+        (n) => !(n.id === next.id && n.nudgeId === next.nudgeId),
+      );
+      return { ...m, nudges: [...filtered, next] };
+    }
+    case 'sub_iteration':
+    case 'sub_tool_use':
+    case 'sub_tool_result': {
+      const tools = (m.tools ?? []).map((t) => {
+        if (t.id !== event.parentId) return t;
+        const sub: SubAgentEvent = toSubAgentEvent(event);
+        return { ...t, subEvents: [...(t.subEvents ?? []), sub] };
+      });
+      return { ...m, tools };
+    }
+    case 'done':
+      return {
+        ...m,
+        content: event.answer,
+        telemetry: {
+          tool_calls: event.toolCalls,
+          iterations: event.iterations,
+        },
+        ...(event.turnId ? { turnId: event.turnId } : {}),
+        ...(event.palaiaExcerpt ? { palaiaExcerpt: event.palaiaExcerpt } : {}),
+        ...(event.autoPromotedMkId
+          ? { autoPromotedMkId: event.autoPromotedMkId }
+          : {}),
+        ...(event.attachments && event.attachments.length > 0
+          ? { attachments: event.attachments }
+          : {}),
+        ...(event.pendingUserChoice
+          ? { pendingUserChoice: event.pendingUserChoice }
+          : {}),
+        ...(event.followUpOptions && event.followUpOptions.length > 0
+          ? { followUpOptions: event.followUpOptions }
+          : {}),
+        ...(event.privacyReceipt ? { privacyReceipt: event.privacyReceipt } : {}),
+        ...(event.maskedValues && event.maskedValues.length > 0
+          ? { maskedValues: event.maskedValues }
+          : {}),
+        finishedAt: Date.now(),
+        streaming: false,
+      };
+    case 'error':
+      return {
+        ...m,
+        content: m.content + (m.content ? '\n\n' : '') + event.message,
+        error: true,
+        finishedAt: Date.now(),
+        streaming: false,
+      };
+    case 'iteration_start':
+    default:
+      return m;
+  }
+}
+
+function toSubAgentEvent(
+  event: Extract<
+    ChatStreamEvent,
+    { type: 'sub_iteration' | 'sub_tool_use' | 'sub_tool_result' }
+  >,
+): SubAgentEvent {
+  switch (event.type) {
+    case 'sub_iteration':
+      return {
+        kind: 'iteration',
+        at: Date.now(),
+        iteration: event.iteration,
+      };
+    case 'sub_tool_use':
+      return {
+        kind: 'tool_use',
+        at: Date.now(),
+        id: event.id,
+        name: event.name,
+        input: event.input,
+      };
+    case 'sub_tool_result':
+      return {
+        kind: 'tool_result',
+        at: Date.now(),
+        id: event.id,
+        output: event.output,
+        durationMs: event.durationMs,
+        isError: event.isError,
+      };
+  }
+}

--- a/web-ui/app/_lib/streamStore.tsx
+++ b/web-ui/app/_lib/streamStore.tsx
@@ -1,0 +1,328 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+/**
+ * Process-wide registry of active chat streams. Lives at the layout level
+ * so a stream survives ChatPage unmount (menu-switch) or ChatTabs switch.
+ * The fetch + NDJSON-parse loop is owned by <StreamRunner /> (also mounted
+ * in the layout); this store is the orchestration layer between the UI
+ * (start/abort/observe) and the runner (consumes pending requests, reports
+ * lifecycle).
+ *
+ * The store never holds the full message buffer — that lives in
+ * ChatSessions (localStorage + backend). What we keep here is the
+ * lightweight "is something happening, and what does the preview look
+ * like?" state needed for tabs, toasts, and stop buttons.
+ */
+
+export type StreamPhase =
+  | 'pending'
+  | 'thinking'
+  | 'streaming'
+  | 'tool_running'
+  | 'done'
+  | 'error'
+  | 'aborted';
+
+/** Lightweight per-stream record. Snapshotted at every mutation so React
+ *  can shallow-compare. The AbortController is intentionally hidden — only
+ *  the store mutates it (via abort()) and only the runner reads it (via
+ *  claimRequest()). */
+export interface StreamRecord {
+  sessionId: string;
+  phase: StreamPhase;
+  startedAt: number;
+  lastEventAt: number;
+  previewTail: string;
+  toolName?: string;
+  error?: string;
+  /** Wall-clock at which this terminal record may be GC'd. */
+  expiresAt?: number;
+}
+
+/** Payload the UI hands the store to ask <StreamRunner /> to do the work. */
+export interface StreamRequest {
+  sessionId: string;
+  pendingMessageId: string;
+  message: string;
+}
+
+/** What the runner pulls off the queue. */
+export interface ClaimedRequest {
+  request: StreamRequest;
+  signal: AbortSignal;
+}
+
+interface InternalRecord extends StreamRecord {
+  controller: AbortController;
+}
+
+interface StreamStoreContextValue {
+  records: ReadonlyMap<string, StreamRecord>;
+  /** Bump on every queue change so the runner's effect re-fires. */
+  queueVersion: number;
+  /** UI entry point — fires off a new turn. Returns false if the session
+   *  already has an in-flight stream. */
+  startTurn(req: StreamRequest): boolean;
+  /** Runner pulls the next unclaimed request, atomically marking it
+   *  claimed. Returns undefined if nothing pending. */
+  claimRequest(): ClaimedRequest | undefined;
+  /** Runner updates the record as events stream in. */
+  patch(sessionId: string, patch: Partial<Omit<StreamRecord, 'sessionId'>>): void;
+  /** Runner reports the terminal outcome. */
+  finish(
+    sessionId: string,
+    outcome: 'done' | 'error' | 'aborted',
+    error?: string,
+  ): void;
+  /** User-initiated abort. Synchronous — flips phase immediately. */
+  abort(sessionId: string): void;
+  /** Inspect the record for a session. */
+  get(sessionId: string): StreamRecord | undefined;
+  /** True while the session has a non-terminal stream. */
+  isActive(sessionId: string): boolean;
+}
+
+const Ctx = createContext<StreamStoreContextValue | null>(null);
+
+/** Max number of records the store retains (active + recently terminated). */
+const MAX_RECORDS = 12;
+/** Time after which a terminal record is garbage-collected. */
+const GC_AFTER_MS = 5 * 60 * 1000;
+/** Periodic GC sweep interval. */
+const GC_SWEEP_MS = 30 * 1000;
+
+function isTerminal(phase: StreamPhase): boolean {
+  return phase === 'done' || phase === 'error' || phase === 'aborted';
+}
+
+export function StreamStoreProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  const internalRef = useRef<Map<string, InternalRecord>>(new Map());
+  const pendingRef = useRef<StreamRequest[]>([]);
+  const [records, setRecords] = useState<ReadonlyMap<string, StreamRecord>>(
+    new Map(),
+  );
+  const [queueVersion, setQueueVersion] = useState(0);
+
+  const publishSnapshot = useCallback((): void => {
+    const snapshot = new Map<string, StreamRecord>();
+    for (const [k, v] of internalRef.current.entries()) {
+      const { controller: _drop, ...rest } = v;
+      snapshot.set(k, rest);
+    }
+    setRecords(snapshot);
+  }, []);
+
+  const bumpQueue = useCallback((): void => {
+    setQueueVersion((v) => v + 1);
+  }, []);
+
+  const evictIfOverCapacity = useCallback((): void => {
+    if (internalRef.current.size <= MAX_RECORDS) return;
+    const terminated = [...internalRef.current.entries()]
+      .filter(([, r]) => isTerminal(r.phase))
+      .sort((a, b) => a[1].lastEventAt - b[1].lastEventAt);
+    while (internalRef.current.size > MAX_RECORDS && terminated.length > 0) {
+      const oldest = terminated.shift();
+      if (!oldest) break;
+      internalRef.current.delete(oldest[0]);
+    }
+  }, []);
+
+  const startTurn = useCallback(
+    (req: StreamRequest): boolean => {
+      const existing = internalRef.current.get(req.sessionId);
+      if (existing && !isTerminal(existing.phase)) return false;
+      const controller = new AbortController();
+      const now = Date.now();
+      internalRef.current.set(req.sessionId, {
+        sessionId: req.sessionId,
+        phase: 'pending',
+        startedAt: now,
+        lastEventAt: now,
+        previewTail: '',
+        controller,
+      });
+      pendingRef.current = [
+        ...pendingRef.current.filter((r) => r.sessionId !== req.sessionId),
+        req,
+      ];
+      evictIfOverCapacity();
+      publishSnapshot();
+      bumpQueue();
+      return true;
+    },
+    [bumpQueue, evictIfOverCapacity, publishSnapshot],
+  );
+
+  const claimRequest = useCallback((): ClaimedRequest | undefined => {
+    if (pendingRef.current.length === 0) return undefined;
+    const [next, ...rest] = pendingRef.current;
+    if (!next) return undefined;
+    pendingRef.current = rest;
+    const record = internalRef.current.get(next.sessionId);
+    if (!record) {
+      bumpQueue();
+      return undefined;
+    }
+    bumpQueue();
+    return { request: next, signal: record.controller.signal };
+  }, [bumpQueue]);
+
+  const patch = useCallback(
+    (sessionId: string, patchData: Partial<Omit<StreamRecord, 'sessionId'>>): void => {
+      const existing = internalRef.current.get(sessionId);
+      if (!existing) return;
+      internalRef.current.set(sessionId, {
+        ...existing,
+        ...patchData,
+        sessionId,
+        controller: existing.controller,
+        lastEventAt: patchData.lastEventAt ?? Date.now(),
+      });
+      publishSnapshot();
+    },
+    [publishSnapshot],
+  );
+
+  const finish = useCallback(
+    (
+      sessionId: string,
+      outcome: 'done' | 'error' | 'aborted',
+      error?: string,
+    ): void => {
+      const existing = internalRef.current.get(sessionId);
+      if (!existing) return;
+      const now = Date.now();
+      internalRef.current.set(sessionId, {
+        ...existing,
+        phase: outcome,
+        lastEventAt: now,
+        expiresAt: now + GC_AFTER_MS,
+        ...(error !== undefined ? { error } : {}),
+      });
+      evictIfOverCapacity();
+      publishSnapshot();
+    },
+    [evictIfOverCapacity, publishSnapshot],
+  );
+
+  const abort = useCallback(
+    (sessionId: string): void => {
+      const existing = internalRef.current.get(sessionId);
+      if (!existing) return;
+      if (isTerminal(existing.phase)) return;
+      try {
+        existing.controller.abort();
+      } catch {
+        /* already aborted — ignore */
+      }
+      const now = Date.now();
+      internalRef.current.set(sessionId, {
+        ...existing,
+        phase: 'aborted',
+        lastEventAt: now,
+        expiresAt: now + GC_AFTER_MS,
+      });
+      // Drop any pending request for this session — runner shouldn't pick it up.
+      pendingRef.current = pendingRef.current.filter(
+        (r) => r.sessionId !== sessionId,
+      );
+      publishSnapshot();
+      bumpQueue();
+    },
+    [bumpQueue, publishSnapshot],
+  );
+
+  const get = useCallback(
+    (sessionId: string): StreamRecord | undefined => records.get(sessionId),
+    [records],
+  );
+
+  const isActive = useCallback(
+    (sessionId: string): boolean => {
+      const r = records.get(sessionId);
+      return r !== undefined && !isTerminal(r.phase);
+    },
+    [records],
+  );
+
+  // Periodic GC of expired terminated records.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const now = Date.now();
+      let dirty = false;
+      for (const [id, rec] of internalRef.current.entries()) {
+        if (rec.expiresAt !== undefined && rec.expiresAt < now) {
+          internalRef.current.delete(id);
+          dirty = true;
+        }
+      }
+      if (dirty) publishSnapshot();
+    }, GC_SWEEP_MS);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [publishSnapshot]);
+
+  const value = useMemo<StreamStoreContextValue>(
+    () => ({
+      records,
+      queueVersion,
+      startTurn,
+      claimRequest,
+      patch,
+      finish,
+      abort,
+      get,
+      isActive,
+    }),
+    [
+      records,
+      queueVersion,
+      startTurn,
+      claimRequest,
+      patch,
+      finish,
+      abort,
+      get,
+      isActive,
+    ],
+  );
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useStreamStore(): StreamStoreContextValue {
+  const v = useContext(Ctx);
+  if (!v) {
+    throw new Error('useStreamStore: missing <StreamStoreProvider>');
+  }
+  return v;
+}
+
+/** Subscribe to a single session's record. */
+export function useStreamRecord(sessionId: string | undefined): StreamRecord | undefined {
+  const { records } = useStreamStore();
+  if (!sessionId) return undefined;
+  return records.get(sessionId);
+}
+
+/** True while the session has an in-flight (non-terminal) stream. */
+export function isStreamActive(record: StreamRecord | undefined): boolean {
+  if (!record) return false;
+  return !isTerminal(record.phase);
+}

--- a/web-ui/app/_lib/streamStore.tsx
+++ b/web-ui/app/_lib/streamStore.tsx
@@ -45,6 +45,13 @@ export interface StreamRecord {
   previewTail: string;
   toolName?: string;
   error?: string;
+  /** Cumulative input tokens across all iterations of this turn
+   *  (anthropic.input_tokens sum). Updated on every `iteration_usage`. */
+  tokensIn?: number;
+  /** Cumulative output tokens across iterations. */
+  tokensOut?: number;
+  /** Cumulative cache-read tokens — shown as a 🟢 chip when > 0. */
+  cacheTokens?: number;
   /** Wall-clock at which this terminal record may be GC'd. */
   expiresAt?: number;
 }

--- a/web-ui/app/layout.tsx
+++ b/web-ui/app/layout.tsx
@@ -12,6 +12,10 @@ import { AuthBadge } from './_components/AuthBadge';
 import { LocaleSwitcher } from './_components/LocaleSwitcher';
 import { Nav } from './_components/Nav';
 import { SessionWatcher } from './_components/SessionWatcher';
+import { StreamRunner } from './_components/StreamRunner';
+import { StreamToasts } from './_components/StreamToasts';
+import { ChatSessionsProvider } from './_lib/chatSessionsContext';
+import { StreamStoreProvider } from './_lib/streamStore';
 import './globals.css';
 
 /**
@@ -70,41 +74,51 @@ export default async function RootLayout({
     >
       <body className="flex h-full flex-col">
         <NextIntlClientProvider locale={locale} messages={messages}>
-          <header className="border-b border-[color:var(--border)] bg-[color:var(--bg)]/90 px-6 py-3 backdrop-blur">
-            <div className="mx-auto flex max-w-[1280px] items-center gap-4">
-              <Link
-                href="/"
-                className="flex items-center transition-opacity hover:opacity-90"
-                aria-label={t('logoAriaLabel')}
-              >
-                <span className="flex flex-col leading-none">
-                  <span className="font-display text-lg text-[color:var(--fg-strong)]">
-                    Omadia
+          <ChatSessionsProvider>
+            <StreamStoreProvider>
+              <header className="border-b border-[color:var(--border)] bg-[color:var(--bg)]/90 px-6 py-3 backdrop-blur">
+                <div className="mx-auto flex max-w-[1280px] items-center gap-4">
+                  <Link
+                    href="/"
+                    className="flex items-center transition-opacity hover:opacity-90"
+                    aria-label={t('logoAriaLabel')}
+                  >
+                    <span className="flex flex-col leading-none">
+                      <span className="font-display text-lg text-[color:var(--fg-strong)]">
+                        Omadia
+                      </span>
+                      <span className="mt-1 text-[10px] uppercase tracking-[0.14em] text-[color:var(--fg-muted)]">
+                        an Agentic OS
+                      </span>
+                    </span>
+                  </Link>
+                  <span className="text-xs text-[color:var(--fg-muted)]">
+                    <span className="text-[color:var(--highlight)] font-[900]">
+                      :
+                    </span>{' '}
+                    {t('subtitle')}
                   </span>
-                  <span className="mt-1 text-[10px] uppercase tracking-[0.14em] text-[color:var(--fg-muted)]">
-                    an Agentic OS
-                  </span>
-                </span>
-              </Link>
-              <span className="text-xs text-[color:var(--fg-muted)]">
-                <span className="text-[color:var(--highlight)] font-[900]">
-                  :
-                </span>{' '}
-                {t('subtitle')}
-              </span>
-              <div className="ml-auto flex items-center gap-5">
-                <Nav />
-                <span
-                  className="hidden h-5 w-px bg-[color:var(--border)] sm:block"
-                  aria-hidden
-                />
-                <LocaleSwitcher />
-                <AuthBadge />
-              </div>
-            </div>
-          </header>
-          <div className="min-h-0 flex-1">{children}</div>
-          <SessionWatcher />
+                  <div className="ml-auto flex items-center gap-5">
+                    <Nav />
+                    <span
+                      className="hidden h-5 w-px bg-[color:var(--border)] sm:block"
+                      aria-hidden
+                    />
+                    <LocaleSwitcher />
+                    <AuthBadge />
+                  </div>
+                </div>
+              </header>
+              <div className="min-h-0 flex-1">{children}</div>
+              {/* Background-stream toasts (only render for chats that
+                  aren't currently in view). The runner is headless — it
+                  owns the fetch + NDJSON-parse loop so that switching to
+                  another menu route doesn't kill an in-flight turn. */}
+              <StreamRunner />
+              <StreamToasts />
+              <SessionWatcher />
+            </StreamStoreProvider>
+          </ChatSessionsProvider>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -8,126 +8,31 @@ import {
   type KeyboardEvent,
 } from 'react';
 import { useTranslations } from 'next-intl';
+import { Eraser } from 'lucide-react';
 import { ChatTabs } from './_components/ChatTabs';
 import { AgentUsagePills } from './_components/chat/AgentUsagePills';
 import { AutoPromotedBanner } from './_components/chat/AutoPromotedBanner';
 import { CaptureDisclosure } from './_components/chat/CaptureDisclosure';
+import { ConfirmDialog } from './_components/ConfirmDialog';
 import { NudgeCard, parseNudgeBlock } from './_components/chat/NudgeCard';
 import { PrivacyReceiptCard } from './_components/chat/PrivacyReceiptCard';
 import { SaveMemoryButton } from './_components/chat/SaveMemoryButton';
 import { Markdown } from './_components/Markdown';
+import { resetChatSession } from './_lib/api';
 import {
   deriveTitle,
   newSessionId,
-  useChatSessions,
   type ChatSession,
   type DiagramAttachment,
   type FollowUpOption,
   type Message,
   type NudgeEvent,
-  type PalaiaExcerpt,
   type PendingUserChoice,
-  type PrivacyReceipt,
   type SubAgentEvent,
   type ToolEvent,
 } from './_lib/chatSessions';
-
-// Event shapes mirror ChatStreamEvent in middleware/src/services/orchestrator.ts.
-// Keep these in sync with the backend type. Validation is lax on purpose — the
-// server is trusted and any shape drift should surface as an obvious UI bug.
-type StreamEvent =
-  | { type: 'iteration_start'; iteration: number }
-  | { type: 'text_delta'; text: string }
-  | {
-      type: 'tool_use';
-      id: string;
-      name: string;
-      input: unknown;
-      /** Server-resolved agent metadata; absent for helper tools. */
-      agent?: ToolEvent['agent'];
-    }
-  | {
-      type: 'tool_result';
-      id: string;
-      output: string;
-      durationMs: number;
-      isError?: boolean;
-    }
-  | {
-      type: 'nudge';
-      id: string;
-      nudgeId: string;
-      text: string;
-      cta?: {
-        label: string;
-        toolName: string;
-        arguments: Record<string, unknown>;
-      };
-    }
-  | { type: 'tool_progress'; id: string; elapsedMs: number }
-  | {
-      type: 'heartbeat';
-      sinceLastActivityMs: number;
-      currentIteration: number;
-      toolCallsThisIter: number;
-      phase?: 'thinking' | 'streaming' | 'tool_running' | 'idle';
-      tokensStreamedThisIter?: number;
-    }
-  | {
-      type: 'stream_token_chunk';
-      iteration: number;
-      deltaTokens: number;
-      cumulativeOutputTokens: number;
-      tokensPerSec: number;
-    }
-  | {
-      type: 'iteration_usage';
-      iteration: number;
-      inputTokens: number;
-      outputTokens: number;
-      cacheReadInputTokens: number;
-      cacheCreationInputTokens: number;
-    }
-  | { type: 'sub_iteration'; parentId: string; iteration: number }
-  | {
-      type: 'sub_tool_use';
-      parentId: string;
-      id: string;
-      name: string;
-      input: unknown;
-    }
-  | {
-      type: 'sub_tool_result';
-      parentId: string;
-      id: string;
-      output: string;
-      durationMs: number;
-      isError: boolean;
-    }
-  | {
-      type: 'done';
-      answer: string;
-      toolCalls: number;
-      iterations: number;
-      /** KG-persisted Turn external_id. Undefined when session-logging
-       *  was disabled or threw. Powers the save-as-memory button. */
-      turnId?: string;
-      /** Slice 4a — Palaia-Excerpt suggestion for the save-as-memory
-       *  modal pre-fill. Undefined when the extractor wasn't installed
-       *  or the Haiku call failed / returned junk; modal falls back
-       *  to the dumb 240-char prefix. */
-      palaiaExcerpt?: PalaiaExcerpt;
-      /** Slice 4c — MK external_id when this turn was auto-promoted
-       *  (significance >= threshold AND `KG_ACL_AUTO_PROMOTE=true`).
-       *  Drives the inline "Saved by Palaia" banner. */
-      autoPromotedMkId?: string;
-      attachments?: DiagramAttachment[];
-      pendingUserChoice?: PendingUserChoice;
-      followUpOptions?: FollowUpOption[];
-      privacyReceipt?: PrivacyReceipt;
-      maskedValues?: readonly string[];
-    }
-  | { type: 'error'; message: string };
+import { useChatSessionsCtx } from './_lib/chatSessionsContext';
+import { useStreamStore } from './_lib/streamStore';
 
 export default function ChatPage(): React.ReactElement {
   const t = useTranslations('chat');
@@ -142,12 +47,13 @@ export default function ChatPage(): React.ReactElement {
     setActive,
     clearMessages,
     mutateActive,
-    persistActive,
-  } = useChatSessions();
+  } = useChatSessionsCtx();
+  const streamStore = useStreamStore();
+  const sending = streamStore.isActive(activeId);
 
   const [input, setInput] = useState('');
-  const [sending, setSending] = useState(false);
-  const abortRef = useRef<AbortController | null>(null);
+  const [resetPending, setResetPending] = useState(false);
+  const [confirmResetOpen, setConfirmResetOpen] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -160,172 +66,9 @@ export default function ChatPage(): React.ReactElement {
     if (el) el.scrollTop = el.scrollHeight;
   }, [activeSession.messages]);
 
-  // Abort any in-flight stream when switching tabs; otherwise the pending
-  // response would land in a session the user left.
-  useEffect(() => {
-    return () => {
-      abortRef.current?.abort();
-    };
-  }, [activeId]);
-
-  const applyEvent = useCallback(
-    (targetSessionId: string, pendingId: string, event: StreamEvent): void => {
-      mutateActive((session) => {
-        if (session.id !== targetSessionId) return session;
-        const nextMessages = session.messages.map((m) => {
-          if (m.id !== pendingId) return m;
-          switch (event.type) {
-            case 'text_delta':
-              return { ...m, content: m.content + event.text };
-            case 'tool_use': {
-              const tool: ToolEvent = {
-                id: event.id,
-                name: event.name,
-                input: event.input,
-                startedAt: Date.now(),
-                subEvents: [],
-                ...(event.agent ? { agent: event.agent } : {}),
-              };
-              return { ...m, tools: [...(m.tools ?? []), tool] };
-            }
-            case 'tool_progress': {
-              const tools = (m.tools ?? []).map((t) =>
-                t.id === event.id ? { ...t, liveElapsedMs: event.elapsedMs } : t,
-              );
-              return { ...m, tools };
-            }
-            case 'heartbeat':
-              return {
-                ...m,
-                liveness: {
-                  sinceLastActivityMs: event.sinceLastActivityMs,
-                  iteration: event.currentIteration,
-                  toolCallsThisIter: event.toolCallsThisIter,
-                  ...(event.phase ? { phase: event.phase } : {}),
-                  ...(typeof event.tokensStreamedThisIter === 'number'
-                    ? { tokensThisIter: event.tokensStreamedThisIter }
-                    : {}),
-                },
-              };
-            case 'stream_token_chunk':
-              return {
-                ...m,
-                tokensPerSec: event.tokensPerSec,
-                liveness: m.liveness
-                  ? {
-                      ...m.liveness,
-                      tokensThisIter: event.cumulativeOutputTokens,
-                    }
-                  : m.liveness,
-              };
-            case 'iteration_usage':
-              return {
-                ...m,
-                lastUsage: {
-                  inputTokens: event.inputTokens,
-                  cacheReadInputTokens: event.cacheReadInputTokens,
-                },
-              };
-            case 'tool_result': {
-              const tools = (m.tools ?? []).map((t) =>
-                t.id === event.id
-                  ? {
-                      ...t,
-                      output: event.output,
-                      durationMs: event.durationMs,
-                      isError: event.isError ?? false,
-                      liveElapsedMs: undefined,
-                    }
-                  : t,
-              );
-              return { ...m, tools };
-            }
-            case 'nudge': {
-              const next: NudgeEvent = {
-                id: event.id,
-                nudgeId: event.nudgeId,
-                text: event.text,
-                ...(event.cta ? { cta: event.cta } : {}),
-              };
-              const existing = m.nudges ?? [];
-              // De-dupe by (id, nudgeId): the pipeline only emits once per
-              // tool-call but reducer replays during reconnects can double-up.
-              const filtered = existing.filter(
-                (n) => !(n.id === next.id && n.nudgeId === next.nudgeId),
-              );
-              return { ...m, nudges: [...filtered, next] };
-            }
-            case 'sub_iteration':
-            case 'sub_tool_use':
-            case 'sub_tool_result': {
-              const tools = (m.tools ?? []).map((t) => {
-                if (t.id !== event.parentId) return t;
-                const sub: SubAgentEvent = toSubAgentEvent(event);
-                return { ...t, subEvents: [...(t.subEvents ?? []), sub] };
-              });
-              return { ...m, tools };
-            }
-            case 'done':
-              return {
-                ...m,
-                // The done event carries the authoritative final answer. For
-                // a Privacy Shield v4 turn this is the server-materialized
-                // table — never streamed as deltas — so it must replace the
-                // live preview.
-                content: event.answer,
-                telemetry: {
-                  tool_calls: event.toolCalls,
-                  iterations: event.iterations,
-                },
-                ...(event.turnId ? { turnId: event.turnId } : {}),
-                ...(event.palaiaExcerpt
-                  ? { palaiaExcerpt: event.palaiaExcerpt }
-                  : {}),
-                ...(event.autoPromotedMkId
-                  ? { autoPromotedMkId: event.autoPromotedMkId }
-                  : {}),
-                ...(event.attachments && event.attachments.length > 0
-                  ? { attachments: event.attachments }
-                  : {}),
-                ...(event.pendingUserChoice
-                  ? { pendingUserChoice: event.pendingUserChoice }
-                  : {}),
-                ...(event.followUpOptions && event.followUpOptions.length > 0
-                  ? { followUpOptions: event.followUpOptions }
-                  : {}),
-                ...(event.privacyReceipt
-                  ? { privacyReceipt: event.privacyReceipt }
-                  : {}),
-                ...(event.maskedValues && event.maskedValues.length > 0
-                  ? { maskedValues: event.maskedValues }
-                  : {}),
-                finishedAt: Date.now(),
-                streaming: false,
-              };
-            case 'error':
-              return {
-                ...m,
-                content: m.content + (m.content ? '\n\n' : '') + event.message,
-                error: true,
-                finishedAt: Date.now(),
-                streaming: false,
-              };
-            case 'iteration_start':
-            default:
-              return m;
-          }
-        });
-        return { ...session, messages: nextMessages, updatedAt: Date.now() };
-      });
-    },
-    [mutateActive],
-  );
-
-  /**
-   * Slice 4c — clear the auto-promoted-MK marker on a message after
-   * the user Discards it. The manual save-as-memory button then
-   * comes back so the user can re-save with their own classification.
-   */
+  // Slice 4c — clear the auto-promoted-MK marker on a message after the
+  // user Discards it. The manual save-as-memory button then comes back so
+  // the user can re-save with their own classification.
   const clearAutoPromoted = useCallback(
     (messageId: string): void => {
       mutateActive((session) => {
@@ -340,187 +83,139 @@ export default function ChatPage(): React.ReactElement {
     [mutateActive],
   );
 
-  const send = useCallback(async (overrideText?: string): Promise<void> => {
-    // Two entry points use this: the Senden button (reads `input`) and the
-    // Smart-Card option buttons (pass the chosen label via overrideText).
-    // The override takes precedence so a click doesn't require the textarea
-    // to be clear.
-    const trimmed = (overrideText ?? input).trim();
-    if (!trimmed || sending || hydrating) return;
+  const send = useCallback(
+    (overrideText?: string): void => {
+      // Two entry points use this: the Senden button (reads `input`) and the
+      // Smart-Card option buttons (pass the chosen label via overrideText).
+      const trimmed = (overrideText ?? input).trim();
+      if (!trimmed || sending || hydrating) return;
 
-    const targetSessionId = activeId;
-    const userMsg: Message = {
-      id: newSessionId(),
-      role: 'user',
-      content: trimmed,
-      startedAt: Date.now(),
-      finishedAt: Date.now(),
-    };
-    const pendingId = newSessionId();
-    const pending: Message = {
-      id: pendingId,
-      role: 'assistant',
-      content: '',
-      tools: [],
-      startedAt: Date.now(),
-      streaming: true,
-    };
-
-    mutateActive((session) => {
-      if (session.id !== targetSessionId) return session;
-      const isFirst = session.messages.length === 0;
-      // Strip pendingUserChoice AND followUpOptions from older assistant
-      // messages so the button rows disappear as soon as the user commits
-      // to a choice or types a fresh message. The answer text stays in
-      // history; only the interactive affordances go away.
-      const cleanedMessages = session.messages.map((m) => {
-        if (!m.pendingUserChoice && !m.followUpOptions) return m;
-        const {
-          pendingUserChoice: _dropChoice,
-          followUpOptions: _dropFollowUps,
-          ...rest
-        } = m;
-        return rest;
-      });
-      return {
-        ...session,
-        title: isFirst ? deriveTitle(trimmed) : session.title,
-        messages: [...cleanedMessages, userMsg, pending],
-        updatedAt: Date.now(),
+      const targetSessionId = activeId;
+      const userMsg: Message = {
+        id: newSessionId(),
+        role: 'user',
+        content: trimmed,
+        startedAt: Date.now(),
+        finishedAt: Date.now(),
       };
-    });
-    if (overrideText === undefined) setInput('');
-    setSending(true);
+      const pendingId = newSessionId();
+      const pending: Message = {
+        id: pendingId,
+        role: 'assistant',
+        content: '',
+        tools: [],
+        startedAt: Date.now(),
+        streaming: true,
+      };
 
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    try {
-      const res = await fetch('/bot-api/chat/stream', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({
-          message: trimmed,
-          sessionId: targetSessionId,
-        }),
-        signal: controller.signal,
-      });
-
-      // Friendly diagnostics before we touch the body. Three common failure
-      // modes we distinguish: (1) Next proxy couldn't reach middleware →
-      // HTML error page, (2) middleware returned JSON error, (3) middleware
-      // returned NDJSON (the happy path). Anything else falls back to raw text.
-      const contentType = res.headers.get('content-type') ?? '';
-      if (!res.ok || !res.body) {
-        const fallback = await res.text().catch(() => '');
-        const looksHtml =
-          fallback.trimStart().toLowerCase().startsWith('<!doctype') ||
-          fallback.trimStart().startsWith('<html');
-        let message: string;
-        if (looksHtml || contentType.includes('text/html')) {
-          message =
-            res.status === 500
-              ? t('errorMiddlewareUnreachable')
-              : t('errorProxyFailure', { status: String(res.status) });
-        } else if (contentType.includes('application/json')) {
-          try {
-            const parsed = JSON.parse(fallback) as {
-              error?: string;
-              message?: string;
-            };
-            message =
-              parsed.message ?? parsed.error ?? `HTTP ${String(res.status)}`;
-          } catch {
-            message = fallback || `HTTP ${String(res.status)}`;
-          }
-        } else {
-          message = fallback || `HTTP ${String(res.status)}`;
-        }
-        applyEvent(targetSessionId, pendingId, { type: 'error', message });
-        return;
-      }
-
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = '';
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n');
-        buffer = lines.pop() ?? '';
-        for (const line of lines) {
-          const trimmedLine = line.trim();
-          if (!trimmedLine) continue;
-          try {
-            const event = JSON.parse(trimmedLine) as StreamEvent;
-            applyEvent(targetSessionId, pendingId, event);
-          } catch {
-            // Ignore malformed lines — stream partial writes shouldn't happen
-            // because buffer.pop() keeps the incomplete tail around.
-          }
-        }
-      }
-      // Flush any residual buffer as a final event — unlikely but safe.
-      const tail = buffer.trim();
-      if (tail) {
-        try {
-          applyEvent(targetSessionId, pendingId, JSON.parse(tail) as StreamEvent);
-        } catch {
-          /* ignore */
-        }
-      }
-    } catch (err) {
-      if ((err as Error).name === 'AbortError') {
-        applyEvent(targetSessionId, pendingId, {
-          type: 'error',
-          message: t('errorAborted'),
-        });
-      } else {
-        applyEvent(targetSessionId, pendingId, {
-          type: 'error',
-          message: err instanceof Error ? err.message : String(err),
-        });
-      }
-    } finally {
-      abortRef.current = null;
-      setSending(false);
       mutateActive((session) => {
         if (session.id !== targetSessionId) return session;
+        const isFirst = session.messages.length === 0;
+        // Strip pendingUserChoice AND followUpOptions from older assistant
+        // messages so the button rows disappear as soon as the user commits
+        // to a choice or types a fresh message.
+        const cleanedMessages = session.messages.map((m) => {
+          if (!m.pendingUserChoice && !m.followUpOptions) return m;
+          const {
+            pendingUserChoice: _dropChoice,
+            followUpOptions: _dropFollowUps,
+            ...rest
+          } = m;
+          return rest;
+        });
         return {
           ...session,
-          messages: session.messages.map((m) =>
-            m.id === pendingId && m.streaming
-              ? { ...m, streaming: false, finishedAt: Date.now() }
-              : m,
-          ),
+          title: isFirst ? deriveTitle(trimmed) : session.title,
+          messages: [...cleanedMessages, userMsg, pending],
           updatedAt: Date.now(),
         };
       });
-      void persistActive();
+      if (overrideText === undefined) setInput('');
+
+      // Hand the stream off to <StreamRunner /> via the store. The runner
+      // owns the fetch + NDJSON-parse loop and writes deltas back into
+      // ChatSessions via context, so a menu-switch or ChatTabs switch no
+      // longer kills the stream.
+      streamStore.startTurn({
+        sessionId: targetSessionId,
+        pendingMessageId: pendingId,
+        message: trimmed,
+      });
       inputRef.current?.focus();
-    }
-  }, [input, sending, hydrating, activeId, mutateActive, applyEvent, persistActive, t]);
+    },
+    [input, sending, hydrating, activeId, mutateActive, streamStore],
+  );
 
   const abort = (): void => {
-    abortRef.current?.abort();
+    streamStore.abort(activeId);
   };
 
   const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>): void => {
     if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
       event.preventDefault();
-      void send();
+      send();
     }
   };
 
-  const resetActive = (): void => {
-    if (sending) return;
-    void clearMessages(activeId);
+  const requestReset = (): void => {
+    if (resetPending) return;
+    if (activeSession.messages.length === 0) return;
+    setConfirmResetOpen(true);
   };
+
+  const performReset = useCallback(async (): Promise<void> => {
+    setConfirmResetOpen(false);
+    setResetPending(true);
+    try {
+      // Abort any in-flight stream for this session first — otherwise the
+      // runner would happily keep writing deltas into a freshly cleared
+      // message list.
+      streamStore.abort(activeId);
+      // Backend rotates the conversation pointer so the agent starts a new
+      // turn-chain. KG / Memory are NOT touched. If the backend isn't
+      // reachable we still clear locally — the user wanted a fresh slate.
+      try {
+        await resetChatSession(activeId);
+      } catch (err) {
+        console.warn(
+          '[chat-reset] backend reset failed, clearing locally only:',
+          err instanceof Error ? err.message : err,
+        );
+      }
+      await clearMessages(activeId);
+    } finally {
+      setResetPending(false);
+      inputRef.current?.focus();
+    }
+  }, [activeId, clearMessages, streamStore]);
+
+  // Cmd/Ctrl+Shift+K resets the active chat (with confirm). Standard
+  // ChatGPT/Claude.ai shortcut so muscle memory carries over.
+  useEffect(() => {
+    const onKey = (e: globalThis.KeyboardEvent): void => {
+      const isModK =
+        (e.metaKey || e.ctrlKey) &&
+        e.shiftKey &&
+        (e.key === 'k' || e.key === 'K');
+      if (!isModK) return;
+      e.preventDefault();
+      requestReset();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+    };
+    // requestReset is a stable closure over component state but eslint can't
+    // prove it; we depend on activeSession.messages.length implicitly.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeSession.messages.length, resetPending]);
 
   const handleClose = (id: string): void => {
     void deleteSession(id);
   };
+
+  const canReset =
+    !hydrating && !resetPending && activeSession.messages.length > 0;
 
   return (
     <main className="flex h-full flex-col">
@@ -538,7 +233,8 @@ export default function ChatPage(): React.ReactElement {
 
       <div className="border-b border-neutral-200 bg-white/60 px-6 py-2 text-xs dark:border-neutral-800 dark:bg-neutral-900/60">
         <div className="mx-auto flex max-w-4xl flex-col gap-2">
-          {/* Row 1 — stream info + Verlauf-Leeren */}
+          {/* Row 1 — stream info. Verlauf-Leeren wanderte 2026-05-26 als
+              Eraser-Icon in den Composer (links neben Senden). */}
           <div className="flex flex-wrap items-center gap-3 text-neutral-500">
             <span>
               {t('streamLabel')} <code className="font-mono">/bot-api/chat/stream</code>
@@ -549,17 +245,6 @@ export default function ChatPage(): React.ReactElement {
                   until `useChatSessions` finishes hydrating. */}
               scope={hydrating ? '…' : activeId}
             </span>
-            <button
-              type="button"
-              onClick={resetActive}
-              className="ml-auto rounded border border-neutral-300 px-3 py-1 transition hover:border-neutral-400 disabled:opacity-30 dark:border-neutral-700"
-              disabled={
-                sending || activeSession.messages.length === 0 || hydrating
-              }
-              title={t('clearTabTitle')}
-            >
-              {t('clearTabButton')}
-            </button>
           </div>
 
           {/* Row 2 — Agent-Usage-Pills (only when anything was invoked) */}
@@ -582,7 +267,7 @@ export default function ChatPage(): React.ReactElement {
               message={m}
               disabled={sending || hydrating}
               onChoose={(value) => {
-                void send(value);
+                send(value);
               }}
               onDiscardAutoPromoted={clearAutoPromoted}
             />
@@ -591,7 +276,17 @@ export default function ChatPage(): React.ReactElement {
       </div>
 
       <footer className="border-t border-neutral-200 bg-white/80 px-6 py-4 backdrop-blur dark:border-neutral-800 dark:bg-neutral-900/80">
-        <div className="mx-auto flex max-w-4xl items-end gap-3">
+        <div className="mx-auto flex max-w-4xl items-end gap-2">
+          <button
+            type="button"
+            onClick={requestReset}
+            disabled={!canReset}
+            className="rounded border border-neutral-300 bg-white p-2 text-neutral-500 transition hover:border-neutral-400 hover:text-neutral-700 disabled:cursor-not-allowed disabled:opacity-30 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-200"
+            title={t('composerResetTitle')}
+            aria-label={t('composerResetAriaLabel')}
+          >
+            <Eraser size={16} aria-hidden />
+          </button>
           <textarea
             ref={inputRef}
             value={input}
@@ -616,7 +311,7 @@ export default function ChatPage(): React.ReactElement {
             <button
               type="button"
               onClick={() => {
-                void send();
+                send();
               }}
               disabled={input.trim().length === 0 || hydrating}
               className="rounded bg-neutral-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-neutral-700 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-300"
@@ -626,6 +321,21 @@ export default function ChatPage(): React.ReactElement {
           )}
         </div>
       </footer>
+
+      <ConfirmDialog
+        open={confirmResetOpen}
+        title={t('resetConfirmTitle')}
+        body={t('resetConfirmBody')}
+        confirmLabel={t('resetConfirmAction')}
+        cancelLabel={t('resetCancel')}
+        tone="danger"
+        onCancel={() => {
+          setConfirmResetOpen(false);
+        }}
+        onConfirm={() => {
+          void performReset();
+        }}
+      />
     </main>
   );
 }
@@ -1143,48 +853,6 @@ function summarizeKnowledgeGraphInput(input: unknown): string | null {
   }
   if (typeof rec['limit'] === 'number') bits.push(`limit=${rec['limit']}`);
   return bits.length > 0 ? `${query}: ${bits.join(' ')}` : query;
-}
-
-function toSubAgentEvent(
-  event:
-    | { type: 'sub_iteration'; parentId: string; iteration: number }
-    | {
-        type: 'sub_tool_use';
-        parentId: string;
-        id: string;
-        name: string;
-        input: unknown;
-      }
-    | {
-        type: 'sub_tool_result';
-        parentId: string;
-        id: string;
-        output: string;
-        durationMs: number;
-        isError: boolean;
-      },
-): SubAgentEvent {
-  const at = Date.now();
-  if (event.type === 'sub_iteration') {
-    return { kind: 'iteration', at, iteration: event.iteration };
-  }
-  if (event.type === 'sub_tool_use') {
-    return {
-      kind: 'tool_use',
-      at,
-      id: event.id,
-      name: event.name,
-      input: event.input,
-    };
-  }
-  return {
-    kind: 'tool_result',
-    at,
-    id: event.id,
-    output: event.output,
-    durationMs: event.durationMs,
-    isError: event.isError,
-  };
 }
 
 function formatMs(ms: number): string {

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -132,6 +132,12 @@
     "streamLabel": "Stream:",
     "clearTabTitle": "Nur den aktiven Tab leeren",
     "clearTabButton": "Verlauf leeren",
+    "composerResetTitle": "Chat zurücksetzen (⌘⇧K) — Verlauf weg, Memory bleibt",
+    "composerResetAriaLabel": "Chat zurücksetzen",
+    "resetConfirmTitle": "Chat neu starten?",
+    "resetConfirmBody": "Der Verlauf in diesem Chat wird gelöscht und der Agent vergisst den bisherigen Kontext. Memory und Knowledge-Graph-Einträge bleiben erhalten.",
+    "resetConfirmAction": "Chat zurücksetzen",
+    "resetCancel": "Abbrechen",
     "placeholder": "Frage an den Orchestrator…",
     "stopButton": "Stop",
     "sendButton": "Senden",
@@ -231,5 +237,16 @@
     "pseudonymNo": "nicht verwendet",
     "explainer": "Rohe Tool-Ergebnisse blieben server-seitig hinter der Data-Plane-Boundary — das Modell sah nur einen identitätsfreien Digest.",
     "explainerBreach": "Du hast eine Person namentlich genannt — dieser Name ging im Klartext an das Modell. Die aus den Tools geholten Daten blieben server-seitig hinter der Boundary."
+  },
+  "streamToasts": {
+    "phaseThinking": "Agent denkt",
+    "phaseStreaming": "Antwort läuft",
+    "phaseToolRunning": "Tool läuft",
+    "phaseDone": "Antwort fertig",
+    "phaseError": "Fehler",
+    "phaseAborted": "Abgebrochen",
+    "elapsedSec": "{sec}s",
+    "dismissAriaLabel": "Stream abbrechen",
+    "dismissTitle": "Abbrechen"
   }
 }

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -246,6 +246,9 @@
     "phaseError": "Fehler",
     "phaseAborted": "Abgebrochen",
     "elapsedSec": "{sec}s",
+    "tokensInTitle": "{n} Input-Tokens (kumuliert über Iterationen)",
+    "tokensOutTitle": "{n} Output-Tokens (kumuliert über Iterationen)",
+    "cacheHitTitle": "{n} Cache-Read-Tokens",
     "dismissAriaLabel": "Stream abbrechen",
     "dismissTitle": "Abbrechen"
   }

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -132,6 +132,12 @@
     "streamLabel": "Stream:",
     "clearTabTitle": "Clear only the active tab",
     "clearTabButton": "Clear history",
+    "composerResetTitle": "Reset chat (⌘⇧K) — history goes, memory stays",
+    "composerResetAriaLabel": "Reset chat",
+    "resetConfirmTitle": "Restart this chat?",
+    "resetConfirmBody": "The conversation in this chat will be cleared and the agent forgets its current context. Memory and Knowledge-Graph entries are preserved.",
+    "resetConfirmAction": "Reset chat",
+    "resetCancel": "Cancel",
     "placeholder": "Ask the orchestrator…",
     "stopButton": "Stop",
     "sendButton": "Send",
@@ -231,5 +237,16 @@
     "pseudonymNo": "not used",
     "explainer": "Raw tool results stayed server-side behind the data-plane boundary — the model only ever saw an identity-free digest.",
     "explainerBreach": "You named a person in your request — that name reached the model in cleartext. The data fetched from tools stayed server-side behind the boundary."
+  },
+  "streamToasts": {
+    "phaseThinking": "Agent is thinking",
+    "phaseStreaming": "Answer streaming",
+    "phaseToolRunning": "Tool running",
+    "phaseDone": "Answer ready",
+    "phaseError": "Error",
+    "phaseAborted": "Aborted",
+    "elapsedSec": "{sec}s",
+    "dismissAriaLabel": "Cancel stream",
+    "dismissTitle": "Cancel"
   }
 }

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -246,6 +246,9 @@
     "phaseError": "Error",
     "phaseAborted": "Aborted",
     "elapsedSec": "{sec}s",
+    "tokensInTitle": "{n} input tokens (cumulative across iterations)",
+    "tokensOutTitle": "{n} output tokens (cumulative across iterations)",
+    "cacheHitTitle": "{n} cache-read tokens",
     "dismissAriaLabel": "Cancel stream",
     "dismissTitle": "Cancel"
   }


### PR DESCRIPTION
## Summary

- **Stream-Resilienz**: Hauptproblem war, dass der \`AbortController\` lokal in \`<ChatPage>\` lebte. Jeder ChatTabs-Switch (\`useEffect([activeId])\`) und jede Menü-Navigation (Component-Unmount) hat den laufenden Stream gekillt. Behoben durch Lifting der Stream-Lifecycle in einen Layout-Level-Store + headless Background-Runner.
- **Background-Toasts**: Floating Stack unten rechts auf jeder Route, der nur für Chats erscheint, die der User gerade NICHT sieht — mit Live-Phase (thinking/streaming/tool_running), Token-Tail, Elapsed-Counter. Click springt zurück zum Chat, × cancelt mit Confirm.
- **Composer-Reset**: Neuer Eraser-Icon im Composer (links vom Input) ersetzt den alten Header-Button "Verlauf leeren". Confirm-Dialog vor dem Reset. \`⌘⇧K\` / \`Ctrl⇧K\` als Shortcut.
- **Backend-Reset-Endpoint**: \`POST /api/chat/sessions/:id/reset\` rotiert die Conversation atomar serverside — Memory und Knowledge-Graph bleiben unberührt.

## Architektur

| Datei | Zweck |
|---|---|
| \`web-ui/app/_lib/streamStore.tsx\` | Process-wide Registry aktiver Streams (start, abort, patch, finish), LRU + 5min GC für Terminal-Records |
| \`web-ui/app/_lib/chatSessionsContext.tsx\` | Hebt \`useChatSessions\` in einen Context — State überlebt ChatPage-Unmount |
| \`web-ui/app/_components/StreamRunner.tsx\` | Headless Worker; besitzt Fetch + NDJSON-Parse-Loop |
| \`web-ui/app/_lib/chatStreamEvents.ts\` | Geteiltes \`ChatStreamEvent\` + \`applyStreamEvent\` Fold (vorher inline in page.tsx) |
| \`web-ui/app/_components/StreamToasts.tsx\` | Floating Toast-Stack für Background-Streams |
| \`web-ui/app/_components/ConfirmDialog.tsx\` | Generic Confirm Modal |

## Files Changed

- 7 modified, 7 added — 14 files total, +1702/-516 LoC
- Wesentlicher Reset von \`page.tsx\` (-516 → die Stream-Lifecycle + applyEvent + StreamEvent-Type wandert ab)
- Backend: 1 neue Methode (\`ChatSessionStore.resetMessages\`), 1 neue Route (\`POST .../reset\`)

## Out of Scope

- **Resumable-SSE via \`Last-Event-ID\`** (separater Slice). Damit überlebt ein Stream auch Hard-Reload und Network-Drop — heute überlebt er nur in-app Navigation.
- **BuilderChatPane / PreviewChatPane** haben das gleiche Unmount-Abort Pattern, sind aber niedriger priorisiert (per-Draft Scope, User-Report betraf Haupt-Chat).

## Test plan

- [x] \`npm run lint\` — 0 errors, 22 pre-existing warnings
- [x] \`npm run typecheck\` (web-ui) — grün
- [x] \`npm run lint\`, \`npm run typecheck\` (middleware) — grün
- [x] \`npm run test\` (middleware) — 2513/2513 pass, 2 skipped
- [x] \`npm run test\` (web-ui) — 141/141 pass
- [x] \`next dev\` bootet sauber in 260ms
- [ ] Manueller Browser-Smoke (lokal): Stream starten → Tab wechseln → zurück → Stream weiter; Menü-Wechsel (Chat → Graph → Chat) → Stream weiter; Toast erscheint bei Tab-Switch, verschwindet bei Rückkehr; Reset-Button mit Confirm zeigt leeren Chat + Backend rotiert
- [ ] Manueller Backend-Smoke: \`curl -X POST /api/chat/sessions/<id>/reset\` → \`{sessionId, newConversationId, resetAt}\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)