### PR TITLE
feat(operator/channels): A+B — channel-key directory + /operator/channels dashboard

### DIFF
--- a/middleware/packages/harness-channel-sdk/src/channelKeyDirectory.ts
+++ b/middleware/packages/harness-channel-sdk/src/channelKeyDirectory.ts
@@ -1,0 +1,64 @@
+/**
+ * Channel-key directory contract — opt-in by each channel-kind plugin.
+ *
+ * The operator dashboard's `/operator/channels` page needs to know which
+ * `(channel_type, channel_key)` pairs actually exist on the platform so it
+ * can present them as pickable entries instead of asking the operator to
+ * memorise cryptic strings ("28:bot-app-id:guid" for Teams,
+ * "@bot_username" for Telegram, …).
+ *
+ * Each channel-kind plugin owns this knowledge: it knows its own bot
+ * registration, its installed-app conversation references, its
+ * Telegram-bot-token-derived username, etc. A plugin contributes a
+ * `ChannelKeyDirectory` during activate(); the kernel's
+ * `ChannelDirectoryRegistry` aggregates them and exposes the union to the
+ * operator-channels REST surface.
+ *
+ * **No platform-level discovery via Graph / external APIs.** Discovery
+ * lives inside the plugin that owns the channel — that keeps generic
+ * platform code free of channel-specific permissions, and avoids the
+ * "M365-only" cliff that would block Telegram / Slack / Email
+ * integrations from ever using the same UX. A Teams plugin MAY use
+ * Graph internally for label enrichment; that is its choice, not the
+ * platform's.
+ */
+
+/** One concrete (channel_type, channel_key) entry the plugin recognises. */
+export interface ChannelKeyEntry {
+  /** The opaque key stored in `channel_bindings.channel_key`. Stable across
+   *  registrations. Format is channel-specific:
+   *   - Teams: `28:<bot-app-id>:<service-url-token>` or the conversation id
+   *   - Telegram: `@bot_username` or the numeric chat id
+   *   - Email: the bot-inbox address
+   *
+   *  The platform never parses this — it is treated as an opaque routing
+   *  selector. The plugin that produced it is the only thing that knows
+   *  how to dispatch on it. */
+  readonly key: string;
+  /** Operator-facing label for the picker. Should be self-describing
+   *  enough that two adjacent rows are distinguishable without consulting
+   *  the key (e.g. "Omadia Production Bot · Marketing team" rather than
+   *  bare "Production Bot"). */
+  readonly label: string;
+  /** Free-form context shown beside the label — environment, tenant
+   *  hint, conversation name. Optional. */
+  readonly hint?: string;
+}
+
+export interface ChannelKeyDirectory {
+  /** The channel-type string used in `channel_bindings.channel_type`. The
+   *  plugin owns the canonical spelling — the platform never derives it
+   *  from the plugin id. */
+  readonly channelType: string;
+  /** Display name of the contributing plugin, for the dashboard's
+   *  per-row "via @omadia/channel-teams" hint. */
+  readonly originPluginId: string;
+  /** Returns the keys this plugin can route. Called once per
+   *  `/operator/channels` page load — keep it synchronous-fast (read
+   *  from in-memory state set at activate()), or memoise inside the
+   *  plugin if a remote call is needed.
+   *
+   *  Errors are caught + logged by the registry; an offline plugin
+   *  degrades to "no keys" without breaking the page. */
+  listKeys(): Promise<readonly ChannelKeyEntry[]>;
+}

--- a/middleware/packages/harness-channel-sdk/src/index.ts
+++ b/middleware/packages/harness-channel-sdk/src/index.ts
@@ -81,3 +81,11 @@ export {
 // NO_REPLY sentinel: agent emits this literal when it has nothing to say,
 // channel adapters drop the message before forwarding to the provider.
 export { NO_REPLY_SENTINEL, isNoReply, logNoReplyDrop } from './noReply.js';
+
+// Phase B+ — channel-key discovery for the /operator/channels dashboard.
+// Each channel-kind plugin contributes a ChannelKeyDirectory during
+// activate(); the kernel aggregates them and exposes the union over REST.
+export type {
+  ChannelKeyDirectory,
+  ChannelKeyEntry,
+} from './channelKeyDirectory.js';

--- a/middleware/src/channels/channelDirectoryRegistry.ts
+++ b/middleware/src/channels/channelDirectoryRegistry.ts
@@ -1,0 +1,124 @@
+import type {
+  ChannelKeyDirectory,
+  ChannelKeyEntry,
+} from '@omadia/channel-sdk';
+
+/**
+ * Aggregator over every channel-plugin's `ChannelKeyDirectory`. One
+ * singleton per process; populated by `channelRegistry.activate(...)` when
+ * a channel plugin's `register()` (or its install handler) hands a
+ * directory to the kernel. Read by `/api/v1/operator/channels`.
+ *
+ * Why not a `serviceRegistry.provide('channelKeyDirectory@1', ...)`-style
+ * single capability: there is one directory PER channel type, not one
+ * total. The ServiceRegistry is keyed by capability name; the second
+ * plugin to register would silently replace the first. A dedicated
+ * registry preserves the union and lets each entry carry its
+ * `originPluginId` for the dashboard's "via …" hint.
+ *
+ * Per-plugin failures (offline backend, missing config) are isolated:
+ * `listAll()` catches per-plugin throws and degrades to "no entries from
+ * this plugin" rather than failing the whole page.
+ */
+export class ChannelDirectoryRegistry {
+  private readonly directories = new Map<string, ChannelKeyDirectory>();
+
+  /** Plugin handle string for telemetry. */
+  constructor(
+    private readonly log: (msg: string, fields?: Record<string, unknown>) => void = () =>
+      undefined,
+  ) {}
+
+  /**
+   * Register a directory contribution. If the same channel-type is
+   * already registered (e.g. two Teams instances), the new one replaces
+   * the old — channel types are unique by design (one plugin owns the
+   * routing for "teams", another can own "telegram", but two plugins
+   * cannot both own "teams" since `channel_bindings.channel_type` is the
+   * routing selector).
+   */
+  register(directory: ChannelKeyDirectory): void {
+    const before = this.directories.get(directory.channelType);
+    this.directories.set(directory.channelType, directory);
+    this.log(
+      before
+        ? `channelDirectoryRegistry: replaced directory for ${directory.channelType}`
+        : `channelDirectoryRegistry: registered directory for ${directory.channelType}`,
+      {
+        channelType: directory.channelType,
+        originPluginId: directory.originPluginId,
+        replaced: !!before,
+      },
+    );
+  }
+
+  /**
+   * Drop a directory contribution. Called when a channel plugin
+   * deactivates (uninstall, restart with new config). Idempotent — a
+   * second unregister for the same type is a no-op.
+   */
+  unregister(channelType: string): void {
+    const removed = this.directories.delete(channelType);
+    if (removed) {
+      this.log(`channelDirectoryRegistry: unregistered ${channelType}`, {
+        channelType,
+      });
+    }
+  }
+
+  /** Number of known channel types. */
+  size(): number {
+    return this.directories.size;
+  }
+
+  /** Snapshot of currently-registered channel types. */
+  types(): readonly string[] {
+    return Array.from(this.directories.keys()).sort();
+  }
+
+  /**
+   * Walk every registered directory and return the union of their keys.
+   * Each entry is annotated with `channelType` (for binding lookup) and
+   * `originPluginId` (for the dashboard's per-row hint).
+   *
+   * Per-plugin failures are caught + logged. The page degrades to "fewer
+   * entries" rather than "page broken" if one plugin's directory throws.
+   */
+  async listAll(): Promise<readonly EnrichedChannelKey[]> {
+    const out: EnrichedChannelKey[] = [];
+    for (const directory of this.directories.values()) {
+      try {
+        const entries = await directory.listKeys();
+        for (const entry of entries) {
+          out.push({
+            channelType: directory.channelType,
+            originPluginId: directory.originPluginId,
+            key: entry.key,
+            label: entry.label,
+            ...(entry.hint !== undefined ? { hint: entry.hint } : {}),
+          });
+        }
+      } catch (err) {
+        this.log(
+          `channelDirectoryRegistry: ${directory.channelType} listKeys() FAILED — skipping`,
+          {
+            channelType: directory.channelType,
+            originPluginId: directory.originPluginId,
+            error: (err as Error).message,
+          },
+        );
+      }
+    }
+    out.sort((a, b) => {
+      const t = a.channelType.localeCompare(b.channelType);
+      return t !== 0 ? t : a.label.localeCompare(b.label);
+    });
+    return out;
+  }
+}
+
+/** A channel-key enriched with its origin metadata. */
+export interface EnrichedChannelKey extends ChannelKeyEntry {
+  readonly channelType: string;
+  readonly originPluginId: string;
+}

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -10,6 +10,7 @@ import type { MemoryStore } from '@omadia/plugin-api';
 import { createAdminRouter } from './routes/admin.js';
 import { createChatRouter } from './routes/chat.js';
 import { createOperatorAgentsRouter } from './routes/operatorAgents.js';
+import { createOperatorChannelsRouter } from './routes/operatorChannels.js';
 import type {
   ConfigStore as MultiOrchestratorConfigStore,
   OrchestratorRegistry as MultiOrchestratorRegistry,
@@ -165,6 +166,7 @@ import { ROUTINES_INTEGRATION_SERVICE_NAME } from '@omadia/plugin-api';
 import { createRoutinesRouter } from './routes/routines.js';
 import { ExpressRouteRegistry } from './channels/routeRegistry.js';
 import { createCoreApi } from './channels/coreApi.js';
+import { ChannelDirectoryRegistry } from './channels/channelDirectoryRegistry.js';
 import { DefaultChannelRegistry } from './channels/channelRegistry.js';
 import type { ChannelRegistry } from '@omadia/channel-sdk';
 import { DynamicChannelPluginResolver } from './channels/dynamicChannelResolver.js';
@@ -223,6 +225,14 @@ async function main(): Promise<void> {
   serviceRegistry.provide('nativeToolRegistry', nativeToolRegistry);
   const pluginRouteRegistry = new PluginRouteRegistry();
   const notificationRouter = new NotificationRouter();
+
+  // Phase B+ — directory aggregator for the /operator/channels dashboard.
+  // Channel-kind plugins register their ChannelKeyDirectory contributions
+  // during activate(); the kernel exposes the union over REST.
+  const channelDirectoryRegistry = new ChannelDirectoryRegistry((msg, fields) =>
+    console.log(`[middleware] ${msg}${fields ? ' ' + JSON.stringify(fields) : ''}`),
+  );
+  serviceRegistry.provide('channelDirectoryRegistry', channelDirectoryRegistry);
   const uiRouteCatalog = new UiRouteCatalog();
   // Publish the catalogue so plugin code (notably channel-teams' Hub +
   // Tab-Config) can read it via `ctx.services.get<UiRouteCatalog>(
@@ -1184,6 +1194,22 @@ async function main(): Promise<void> {
   );
   console.log(
     '[middleware] operator-agents endpoints ready at /api/v1/operator/agents/* (auth-gated)',
+  );
+
+  // Phase B+ — operator channels dashboard.
+  app.use(
+    '/api/v1/operator/channels',
+    requireAuth,
+    createOperatorChannelsRouter({
+      getConfigStore: () =>
+        serviceRegistry.get<MultiOrchestratorConfigStore>('configStore'),
+      getRegistry: () =>
+        serviceRegistry.get<MultiOrchestratorRegistry>('orchestratorRegistry'),
+      getDirectoryRegistry: () => channelDirectoryRegistry,
+    }),
+  );
+  console.log(
+    '[middleware] operator-channels endpoints ready at /api/v1/operator/channels/* (auth-gated)',
   );
 
   // Slice 10 — near-duplicate MK workflow. Mirrors the Slice 9

--- a/middleware/src/routes/operatorChannels.ts
+++ b/middleware/src/routes/operatorChannels.ts
@@ -1,0 +1,261 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { z } from 'zod';
+
+import {
+  ConfigValidationError,
+  type ConfigStore,
+  type OrchestratorRegistry,
+} from '@omadia/orchestrator';
+
+import type { ChannelDirectoryRegistry } from '../channels/channelDirectoryRegistry.js';
+
+/**
+ * Operator-facing channel dashboard (`/operator/channels`).
+ *
+ * Inverts the perspective of the per-Agent bindings editor: instead of
+ * "this Agent attaches these bindings", show "this channel-key is handled
+ * by which Agent". Operators think in terms of "my Teams bot routes to
+ * agent X", not "agent X has these cryptic keys attached"; this surface
+ * matches that mental model.
+ *
+ *   GET    /api/v1/operator/channels             list known channels + current binding
+ *   PUT    /api/v1/operator/channels/binding     set / replace a single binding
+ *   DELETE /api/v1/operator/channels/binding     drop a single binding
+ *
+ * The directory side is read-only — it comes from each channel plugin's
+ * `ChannelKeyDirectory.listKeys()` contribution. The binding side
+ * mutates `channel_bindings` through the same `ConfigStore` that the
+ * per-Agent editor uses, so the registry's hot-reload pipeline picks
+ * the change up automatically (no separate reload trigger needed).
+ */
+
+const SetBindingSchema = z.object({
+  channel_type: z.string().min(1).max(64),
+  channel_key: z.string().min(1).max(500),
+  /** null = clear the binding (route falls back to platform fallback). */
+  agent_slug: z.string().min(1).max(64).nullable(),
+});
+
+const DeleteBindingSchema = z.object({
+  channel_type: z.string().min(1).max(64),
+  channel_key: z.string().min(1).max(500),
+});
+
+export interface OperatorChannelsRouterOptions {
+  readonly getConfigStore: () => ConfigStore | undefined;
+  readonly getRegistry: () => OrchestratorRegistry | undefined;
+  readonly getDirectoryRegistry: () => ChannelDirectoryRegistry | undefined;
+}
+
+interface OperatorChannelDto {
+  readonly channel_type: string;
+  readonly channel_key: string;
+  readonly label: string;
+  readonly hint?: string;
+  readonly origin_plugin_id: string;
+  readonly bound_agent_slug: string | null;
+  /** True when this row is only known from the binding table (the channel
+   *  plugin no longer lists it, e.g. uninstalled / config changed). The
+   *  dashboard surfaces these as "stale binding" so the operator can
+   *  decide whether to clear them. */
+  readonly stale: boolean;
+}
+
+export function createOperatorChannelsRouter(
+  options: OperatorChannelsRouterOptions,
+): Router {
+  const router = Router();
+
+  function svc(): {
+    store: ConfigStore;
+    registry: OrchestratorRegistry;
+    directory: ChannelDirectoryRegistry;
+  } | undefined {
+    const store = options.getConfigStore();
+    const registry = options.getRegistry();
+    const directory = options.getDirectoryRegistry();
+    if (!store || !registry || !directory) return undefined;
+    return { store, registry, directory };
+  }
+
+  function unavailable(res: Response): void {
+    res.status(503).json({
+      error: 'multi_orchestrator_unavailable',
+      message:
+        'orchestratorRegistry / configStore / channelDirectoryRegistry not all available — DATABASE_URL must be set and the orchestrator plugin must be active.',
+    });
+  }
+
+  function badRequest(res: Response, err: unknown): void {
+    if (err instanceof ConfigValidationError) {
+      res
+        .status(409)
+        .json({ error: 'config_validation', message: err.message });
+      return;
+    }
+    if (err instanceof z.ZodError) {
+      res.status(400).json({
+        error: 'invalid_body',
+        issues: err.issues.map((i) => ({
+          path: i.path.join('.'),
+          message: i.message,
+        })),
+      });
+      return;
+    }
+    console.error('[operator-channels]', err);
+    res
+      .status(500)
+      .json({ error: 'internal', message: (err as Error).message });
+  }
+
+  // ── list ────────────────────────────────────────────────────────────
+  // Joins the channel-plugin directories with the current
+  // `channel_bindings` table. Rows are sorted by channel_type then label.
+  router.get('/', async (_req: Request, res: Response) => {
+    const live = svc();
+    if (!live) return unavailable(res);
+    try {
+      const [directoryEntries, agents, bindings, settings] = await Promise.all([
+        live.directory.listAll(),
+        live.store.listAgents(),
+        live.store.listChannelBindings(),
+        live.store.getPlatformSettings(),
+      ]);
+
+      const agentById = new Map(agents.map((a) => [a.id, a]));
+      const bindingByKey = new Map<string, { agentId: string }>();
+      for (const b of bindings) {
+        bindingByKey.set(`${b.channelType}:${b.channelKey}`, {
+          agentId: b.agentId,
+        });
+      }
+
+      const seen = new Set<string>();
+      const channels: OperatorChannelDto[] = directoryEntries.map((entry) => {
+        const k = `${entry.channelType}:${entry.key}`;
+        seen.add(k);
+        const bound = bindingByKey.get(k);
+        const slug = bound ? agentById.get(bound.agentId)?.slug ?? null : null;
+        return {
+          channel_type: entry.channelType,
+          channel_key: entry.key,
+          label: entry.label,
+          ...(entry.hint !== undefined ? { hint: entry.hint } : {}),
+          origin_plugin_id: entry.originPluginId,
+          bound_agent_slug: slug,
+          stale: false,
+        };
+      });
+
+      // Surface bindings whose key is NOT in any directory — the channel
+      // plugin no longer reports it (uninstalled / config drift). The
+      // operator should decide whether to clear them.
+      for (const b of bindings) {
+        const k = `${b.channelType}:${b.channelKey}`;
+        if (seen.has(k)) continue;
+        const slug = agentById.get(b.agentId)?.slug ?? null;
+        channels.push({
+          channel_type: b.channelType,
+          channel_key: b.channelKey,
+          label: b.channelKey,
+          origin_plugin_id: '',
+          bound_agent_slug: slug,
+          stale: true,
+        });
+      }
+
+      const fallback_slug =
+        agents.find((a) => a.id === settings.fallbackAgentId)?.slug ?? null;
+
+      res.json({
+        channels,
+        agents: agents
+          .filter((a) => a.status === 'enabled')
+          .map((a) => ({ slug: a.slug, name: a.name })),
+        fallback_slug,
+        directory_types: live.directory.types(),
+      });
+    } catch (err) {
+      badRequest(res, err);
+    }
+  });
+
+  // ── set / replace one binding ───────────────────────────────────────
+  router.put('/binding', async (req: Request, res: Response) => {
+    const live = svc();
+    if (!live) return unavailable(res);
+    try {
+      const body = SetBindingSchema.parse(req.body);
+      // Find the current binding (if any) for this (type, key) — single
+      // PUT either re-points an existing binding or creates a new row.
+      const all = await live.store.listChannelBindings();
+      const existing = all.find(
+        (b) =>
+          b.channelType === body.channel_type &&
+          b.channelKey === body.channel_key,
+      );
+
+      if (body.agent_slug === null) {
+        if (existing) {
+          await live.store.removeChannelBinding(
+            body.channel_type,
+            body.channel_key,
+          );
+        }
+        await live.registry.reload();
+        res.json({ ok: true, cleared: !!existing });
+        return;
+      }
+
+      const target = await live.store.getAgentBySlug(body.agent_slug);
+      if (!target) {
+        res.status(404).json({ error: 'agent_not_found', slug: body.agent_slug });
+        return;
+      }
+
+      if (existing && existing.agentId === target.id) {
+        // Idempotent re-binding to the same agent — no write, no reload.
+        res.json({ ok: true, unchanged: true });
+        return;
+      }
+
+      // Remove + add. We don't have a direct "move binding" primitive in
+      // the ConfigStore; the trigger fires on each row change anyway.
+      if (existing) {
+        await live.store.removeChannelBinding(
+          body.channel_type,
+          body.channel_key,
+        );
+      }
+      await live.store.createChannelBinding(target.id, {
+        channelType: body.channel_type,
+        channelKey: body.channel_key,
+      });
+      await live.registry.reload();
+      res.json({ ok: true, bound_to: target.slug });
+    } catch (err) {
+      badRequest(res, err);
+    }
+  });
+
+  // ── drop one binding ────────────────────────────────────────────────
+  router.delete('/binding', async (req: Request, res: Response) => {
+    const live = svc();
+    if (!live) return unavailable(res);
+    try {
+      const body = DeleteBindingSchema.parse(req.body);
+      await live.store.removeChannelBinding(
+        body.channel_type,
+        body.channel_key,
+      );
+      await live.registry.reload();
+      res.json({ ok: true });
+    } catch (err) {
+      badRequest(res, err);
+    }
+  });
+
+  return router;
+}

--- a/web-ui/app/_components/Nav.tsx
+++ b/web-ui/app/_components/Nav.tsx
@@ -31,6 +31,7 @@ const NAV: readonly NavItem[] = [
     key: 'agentsCluster',
     children: [
       { kind: 'link', href: '/operator/agents', key: 'agentsOverview' },
+      { kind: 'link', href: '/operator/channels', key: 'channels' },
       { kind: 'link', href: '/memory', key: 'memory' },
       { kind: 'link', href: '/memories', key: 'memories' },
       { kind: 'link', href: '/graph', key: 'graph' },

--- a/web-ui/app/_lib/channels.ts
+++ b/web-ui/app/_lib/channels.ts
@@ -1,0 +1,107 @@
+import { ApiError } from './api';
+
+/**
+ * Typed client for the operator channels REST surface (Phase B+).
+ *
+ * Mirrors the agents.ts pattern: each export wraps the corresponding
+ * `/api/v1/operator/channels/*` endpoint. `botApi` + `forwardCookieHeader`
+ * are inlined here (same reason as in `agents.ts` — `_lib/api.ts` keeps
+ * those file-private).
+ */
+
+function botApi(path: string): string {
+  if (typeof window !== 'undefined') {
+    return `/bot-api${path}`;
+  }
+  const base = process.env['MIDDLEWARE_URL'] ?? 'http://localhost:3979';
+  return `${base}/api${path}`;
+}
+
+async function forwardCookieHeader(): Promise<Record<string, string>> {
+  if (typeof window !== 'undefined') return {};
+  try {
+    const mod = await import('next/headers');
+    const jar = await mod.cookies();
+    const cookieHeader = jar
+      .getAll()
+      .map((c) => `${c.name}=${c.value}`)
+      .join('; ');
+    return cookieHeader ? { cookie: cookieHeader } : {};
+  } catch {
+    return {};
+  }
+}
+
+export interface OperatorChannelDto {
+  channel_type: string;
+  channel_key: string;
+  label: string;
+  hint?: string;
+  origin_plugin_id: string;
+  bound_agent_slug: string | null;
+  stale: boolean;
+}
+
+export interface ChannelsListDto {
+  channels: OperatorChannelDto[];
+  agents: Array<{ slug: string; name: string }>;
+  fallback_slug: string | null;
+  directory_types: string[];
+}
+
+async function callJson<T>(
+  path: string,
+  init?: RequestInit & { method?: string },
+): Promise<T> {
+  const forwarded = await forwardCookieHeader();
+  const res = await fetch(botApi(path), {
+    ...init,
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      ...forwarded,
+      ...(init?.headers ?? {}),
+    },
+    cache: 'no-store',
+    credentials: 'include',
+  });
+  if (res.status === 204) return undefined as T;
+  const text = await res.text();
+  if (!res.ok) {
+    throw new ApiError(
+      res.status,
+      `${init?.method ?? 'GET'} ${path} failed: ${res.status}`,
+      text,
+    );
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return undefined as T;
+  }
+}
+
+export async function listOperatorChannels(): Promise<ChannelsListDto> {
+  return callJson<ChannelsListDto>('/v1/operator/channels');
+}
+
+export async function setChannelBinding(
+  channel_type: string,
+  channel_key: string,
+  agent_slug: string | null,
+): Promise<void> {
+  await callJson('/v1/operator/channels/binding', {
+    method: 'PUT',
+    body: JSON.stringify({ channel_type, channel_key, agent_slug }),
+  });
+}
+
+export async function clearChannelBinding(
+  channel_type: string,
+  channel_key: string,
+): Promise<void> {
+  await callJson('/v1/operator/channels/binding', {
+    method: 'DELETE',
+    body: JSON.stringify({ channel_type, channel_key }),
+  });
+}

--- a/web-ui/app/operator/channels/_components/ChannelsDashboard.tsx
+++ b/web-ui/app/operator/channels/_components/ChannelsDashboard.tsx
@@ -1,0 +1,217 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+
+import { ApiError } from '../../../_lib/api';
+import {
+  clearChannelBinding,
+  setChannelBinding,
+  type ChannelsListDto,
+  type OperatorChannelDto,
+} from '../../../_lib/channels';
+
+interface Props {
+  initial: ChannelsListDto;
+}
+
+/**
+ * One-row-per-channel-key list. The directory side is read-only (comes
+ * from each channel plugin's contribution); the binding side mutates
+ * `channel_bindings` through the operator REST surface. The dropdown's
+ * "(none)" option clears the binding so the channel falls through to the
+ * platform fallback Agent.
+ *
+ * "Stale" rows are bindings whose key is not in any plugin directory —
+ * the channel plugin no longer reports it (uninstalled, config drift).
+ * The operator can clear them with one click.
+ */
+export function ChannelsDashboard({ initial }: Props): React.ReactElement {
+  const t = useTranslations('operatorChannels');
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+
+  function run(label: string, op: () => Promise<unknown>): void {
+    setError(null);
+    setBusy(label);
+    op()
+      .then(() => {
+        startTransition(() => router.refresh());
+      })
+      .catch((err: unknown) => {
+        setError(humanizeApiError(err));
+      })
+      .finally(() => setBusy(null));
+  }
+
+  const groups = groupByChannelType(initial.channels);
+
+  if (initial.channels.length === 0) {
+    return (
+      <div className="space-y-4">
+        {error && (
+          <div className="rounded border border-red-400 bg-red-50 p-3 text-sm text-red-800">
+            {error}
+          </div>
+        )}
+        <div className="rounded border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-8 text-sm text-neutral-600 dark:text-neutral-300">
+          <p className="mb-2 font-medium">{t('emptyHeading')}</p>
+          <p>{t('emptyExplain')}</p>
+          {initial.directory_types.length > 0 && (
+            <p className="mt-3 text-xs text-neutral-500 dark:text-neutral-400">
+              {t('emptyDirectoriesKnown', {
+                types: initial.directory_types.join(', '),
+              })}
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <div className="rounded border border-red-400 bg-red-50 p-3 text-sm text-red-800">
+          {error}
+        </div>
+      )}
+      <p className="text-xs text-neutral-500 dark:text-neutral-400">
+        {t('fallbackHint', {
+          fallback: initial.fallback_slug ?? t('fallbackHintNone'),
+        })}
+      </p>
+      {groups.map((group) => (
+        <section
+          key={group.type}
+          className="rounded border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900"
+        >
+          <header className="border-b border-neutral-200 dark:border-neutral-800 px-5 py-3">
+            <h2 className="text-base font-semibold uppercase tracking-wide text-neutral-800 dark:text-neutral-100">
+              {group.type}{' '}
+              <span className="ml-1 text-xs font-normal text-neutral-500 dark:text-neutral-400">
+                ({group.channels.length})
+              </span>
+            </h2>
+          </header>
+          <ul className="divide-y divide-neutral-200 dark:divide-neutral-800">
+            {group.channels.map((c) => (
+              <li
+                key={`${c.channel_type}:${c.channel_key}`}
+                className="flex flex-wrap items-center gap-3 px-5 py-3"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium text-neutral-800 dark:text-neutral-100">
+                      {c.label}
+                    </span>
+                    {c.hint && (
+                      <span className="rounded bg-neutral-100 dark:bg-neutral-800 px-1.5 py-0 text-[11px] text-neutral-600 dark:text-neutral-300">
+                        {c.hint}
+                      </span>
+                    )}
+                    {c.stale && (
+                      <span className="rounded bg-amber-100 px-1.5 py-0 text-[10px] uppercase tracking-wide text-amber-800">
+                        {t('staleBadge')}
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-neutral-500 dark:text-neutral-400">
+                    <code className="font-mono">{c.channel_key}</code>
+                    {c.origin_plugin_id && (
+                      <span>
+                        {t('originLabel')}{' '}
+                        <code className="font-mono">{c.origin_plugin_id}</code>
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <label className="flex items-center gap-2 text-xs text-neutral-600 dark:text-neutral-300">
+                  <span>{t('routesTo')}</span>
+                  <select
+                    value={c.bound_agent_slug ?? ''}
+                    disabled={pending || !!busy}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      const key = `${c.channel_type}:${c.channel_key}`;
+                      run(`bind:${key}`, () =>
+                        v === ''
+                          ? clearChannelBinding(c.channel_type, c.channel_key)
+                          : setChannelBinding(c.channel_type, c.channel_key, v),
+                      );
+                    }}
+                    className="rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-2 py-1 text-xs"
+                  >
+                    <option value="">
+                      {t('routesToFallback', {
+                        fallback: initial.fallback_slug ?? '—',
+                      })}
+                    </option>
+                    {initial.agents.map((a) => (
+                      <option key={a.slug} value={a.slug}>
+                        {a.slug}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                {c.stale && (
+                  <button
+                    type="button"
+                    className="rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs text-amber-800 hover:bg-amber-100"
+                    disabled={pending || !!busy}
+                    onClick={() => {
+                      const key = `${c.channel_type}:${c.channel_key}`;
+                      run(`clear:${key}`, () =>
+                        clearChannelBinding(c.channel_type, c.channel_key),
+                      );
+                    }}
+                  >
+                    {t('clearStale')}
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+interface Grouped {
+  readonly type: string;
+  readonly channels: readonly OperatorChannelDto[];
+}
+
+function groupByChannelType(
+  channels: readonly OperatorChannelDto[],
+): Grouped[] {
+  const m = new Map<string, OperatorChannelDto[]>();
+  for (const c of channels) {
+    const list = m.get(c.channel_type) ?? [];
+    list.push(c);
+    m.set(c.channel_type, list);
+  }
+  return Array.from(m.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([type, list]) => ({ type, channels: list }));
+}
+
+function humanizeApiError(err: unknown): string {
+  if (err instanceof ApiError) {
+    try {
+      const parsed = err.body ? JSON.parse(err.body) : null;
+      const m =
+        parsed && typeof parsed === 'object' && 'message' in parsed
+          ? String((parsed as { message?: unknown }).message ?? '')
+          : '';
+      if (m) return `${m} (HTTP ${err.status})`;
+    } catch {
+      /* ignore */
+    }
+  }
+  return err instanceof Error ? err.message : String(err);
+}

--- a/web-ui/app/operator/channels/page.tsx
+++ b/web-ui/app/operator/channels/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+
+import { redirectIfUnauthorized } from '../../_lib/authRedirect';
+import {
+  listOperatorChannels,
+  type ChannelsListDto,
+} from '../../_lib/channels';
+import { ChannelsDashboard } from './_components/ChannelsDashboard';
+
+/**
+ * Phase B+ — operator-facing channels dashboard.
+ *
+ * Inverts the per-Agent bindings editor: instead of "Agent X attaches
+ * these keys", show "these keys exist on the platform; here's who handles
+ * each". Read side is built from each channel-kind plugin's
+ * `ChannelKeyDirectory` contribution.
+ */
+
+export const metadata: Metadata = {
+  title: 'Channels · Omadia',
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function OperatorChannelsPage(): Promise<React.ReactElement> {
+  const t = await getTranslations('operatorChannels');
+  let initial: ChannelsListDto | null = null;
+  let loadError: string | null = null;
+  try {
+    initial = await listOperatorChannels();
+  } catch (err) {
+    await redirectIfUnauthorized(err);
+    loadError = err instanceof Error ? err.message : t('loadError');
+  }
+
+  return (
+    <main className="mx-auto w-full max-w-[1400px] px-6 py-12 lg:px-10 lg:py-16">
+      <header className="mb-10">
+        <h1 className="text-3xl font-semibold tracking-tight">{t('title')}</h1>
+        <p className="mt-2 max-w-2xl text-sm text-neutral-600 dark:text-neutral-300">
+          {t('subtitle')}
+        </p>
+      </header>
+      {loadError ? (
+        <div className="rounded border border-red-400 bg-red-50 p-4 text-sm text-red-800">
+          {loadError}
+        </div>
+      ) : (
+        <ChannelsDashboard initial={initial!} />
+      )}
+    </main>
+  );
+}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -11,8 +11,24 @@
     "system": "System",
     "agentsCluster": "Agents",
     "agentsOverview": "Übersicht",
+    "channels": "Channels",
     "pluginsCluster": "Plugins",
     "adminCluster": "Admin"
+  },
+  "operatorChannels": {
+    "title": "Channels",
+    "subtitle": "Eingehende Webhooks pro Channel-Key auf einen Agent routen. Jeder Channel-Plugin meldet seine eigenen Keys — du wählst nur, welcher Agent sie beantwortet.",
+    "loadError": "Konnte Channels nicht laden",
+    "emptyHeading": "Noch keine Channels bekannt.",
+    "emptyExplain": "Channel-Plugins (Teams, Telegram, …) melden ihre Keys während der Plugin-Aktivierung. Sobald ein Channel-Plugin installiert + aktiv ist, erscheinen seine Keys hier.",
+    "emptyDirectoriesKnown": "Registrierte Channel-Typen: {types}",
+    "fallbackHint": "Channels ohne explizite Zuordnung landen beim Fallback-Agent ({fallback}).",
+    "fallbackHintNone": "kein Fallback gesetzt",
+    "originLabel": "via",
+    "staleBadge": "veraltet",
+    "routesTo": "→ Agent:",
+    "routesToFallback": "(Fallback · {fallback})",
+    "clearStale": "Binding entfernen"
   },
   "layout": {
     "logoAriaLabel": "Omadia · Startseite",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -11,8 +11,24 @@
     "system": "System",
     "agentsCluster": "Agents",
     "agentsOverview": "Overview",
+    "channels": "Channels",
     "pluginsCluster": "Plugins",
     "adminCluster": "Admin"
+  },
+  "operatorChannels": {
+    "title": "Channels",
+    "subtitle": "Route inbound webhooks per channel-key to an Agent. Each channel plugin reports its own keys — you only pick which Agent answers them.",
+    "loadError": "Failed to load channels",
+    "emptyHeading": "No channels known yet.",
+    "emptyExplain": "Channel plugins (Teams, Telegram, …) report their keys during activation. As soon as a channel plugin is installed and active, its keys appear here.",
+    "emptyDirectoriesKnown": "Registered channel types: {types}",
+    "fallbackHint": "Channels without an explicit binding fall through to the fallback Agent ({fallback}).",
+    "fallbackHintNone": "no fallback set",
+    "originLabel": "via",
+    "staleBadge": "stale",
+    "routesTo": "→ Agent:",
+    "routesToFallback": "(fallback · {fallback})",
+    "clearStale": "Clear binding"
   },
   "layout": {
     "logoAriaLabel": "Omadia · Home",


### PR DESCRIPTION
## Summary

A+B from the post-#146 operator review: invert the channel-binding UX from "Agent attaches keys" to "this channel-key routes to which Agent".

Each channel-kind plugin (Teams, Telegram, …) contributes a `ChannelKeyDirectory` during `activate()`; the kernel aggregates the union; the new `/operator/channels` page joins the directory with `channel_bindings` and gives the operator a one-dropdown-per-channel pick.

## Why plugin-local discovery, not M365-only AutoLookup

- M365 only covers Teams — Telegram/Slack/Email would still need cryptic-key entry.
- `Application.Read.All` is a tenant-wide consent for one bot.
- The Teams plugin already knows its bot_app_id from its own setup config. Asking M365 for info the plugin already holds is wasted complexity.
- M365 stays available as an OPTIONAL label enricher inside the Teams plugin (e.g. "Production Bot · Marketing team" instead of bare guid). That choice lives inside the plugin, not on the platform.

## Wire-level

- SDK: `ChannelKeyDirectory` + `ChannelKeyEntry` in `@omadia/channel-sdk`.
- Kernel: `ChannelDirectoryRegistry` aggregator (per-plugin failure isolation), published as `channelDirectoryRegistry@1`.
- REST: `GET /api/v1/operator/channels`, `PUT /binding`, `DELETE /binding`.
- UI: `/operator/channels` page; Nav cluster Agents▾ gains "Channels".
- "Stale" detection: bindings whose key is no longer in any directory (uninstall, config drift) surface with a clear-button.

## Test plan

- [x] Middleware: `tsc --noEmit` clean.
- [x] Web-UI: `tsc --noEmit` clean.
- [x] i18n parity: 360 keys, OK.
- [x] Empty state verified — page works fine when no channel plugin contributes a directory yet (Teams/Telegram contributions land in the byte5-plugins repo separately).

## Carry-forward

1. `omadia-byte5-plugins`: Teams + Telegram channel plugins need to start contributing their `ChannelKeyDirectory`. Until then `/operator/channels` shows the empty state with a "no channels reported yet" explainer.
2. Per-Agent card's bindings editor — once channel plugins contribute, switch its bindings section to read-only with a link to `/operator/channels`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
