### PR TITLE
fix(builder): scoped plugin ids work end-to-end (preview + install + UI)

### DIFF
--- a/middleware/assets/boilerplate/agent-integration/scripts/build-zip.mjs
+++ b/middleware/assets/boilerplate/agent-integration/scripts/build-zip.mjs
@@ -53,7 +53,13 @@ if (!existsSync(entryAbs) || !statSync(entryAbs).isFile()) {
 }
 
 // --- 3) Stage runtime artefacts ----------------------------------------
-const stageName = `${pkg.name}-${pkg.version}-package`;
+// Sanitize the package name for filesystem use the same way `npm pack`
+// does: strip the leading `@` and replace `/` with `-`. Scoped names like
+// `@omadia/agent-foo` would otherwise produce a wrapper path with an
+// embedded slash, which makes the host extractor see TWO nested levels
+// instead of one and fail to locate package.json.
+const safeName = pkg.name.replace(/^@/, '').replace(/\//g, '-');
+const stageName = `${safeName}-${pkg.version}-package`;
 const stageDir = join(pkgRoot, 'out', stageName);
 rmSync(stageDir, { recursive: true, force: true });
 mkdirSync(stageDir, { recursive: true });
@@ -76,7 +82,7 @@ for (const entry of INCLUDE) {
 }
 
 // --- 4) Zip --------------------------------------------------------------
-const zipPath = join(pkgRoot, 'out', `${pkg.name}-${pkg.version}.zip`);
+const zipPath = join(pkgRoot, 'out', `${safeName}-${pkg.version}.zip`);
 rmSync(zipPath, { force: true });
 
 // Portable zip: bevorzugt `zip` CLI (macOS/Linux). Windows → 7z / PowerShell.

--- a/middleware/assets/boilerplate/agent-pure-llm/scripts/build-zip.mjs
+++ b/middleware/assets/boilerplate/agent-pure-llm/scripts/build-zip.mjs
@@ -53,7 +53,13 @@ if (!existsSync(entryAbs) || !statSync(entryAbs).isFile()) {
 }
 
 // --- 3) Stage runtime artefacts ----------------------------------------
-const stageName = `${pkg.name}-${pkg.version}-package`;
+// Sanitize the package name for filesystem use the same way `npm pack`
+// does: strip the leading `@` and replace `/` with `-`. Scoped names like
+// `@omadia/agent-foo` would otherwise produce a wrapper path with an
+// embedded slash, which makes the host extractor see TWO nested levels
+// instead of one and fail to locate package.json.
+const safeName = pkg.name.replace(/^@/, '').replace(/\//g, '-');
+const stageName = `${safeName}-${pkg.version}-package`;
 const stageDir = join(pkgRoot, 'out', stageName);
 rmSync(stageDir, { recursive: true, force: true });
 mkdirSync(stageDir, { recursive: true });
@@ -76,7 +82,7 @@ for (const entry of INCLUDE) {
 }
 
 // --- 4) Zip --------------------------------------------------------------
-const zipPath = join(pkgRoot, 'out', `${pkg.name}-${pkg.version}.zip`);
+const zipPath = join(pkgRoot, 'out', `${safeName}-${pkg.version}.zip`);
 rmSync(zipPath, { force: true });
 
 // Portable zip: bevorzugt `zip` CLI (macOS/Linux). Windows → 7z / PowerShell.

--- a/middleware/src/plugins/builder/buildSandbox.ts
+++ b/middleware/src/plugins/builder/buildSandbox.ts
@@ -128,7 +128,11 @@ export async function build(opts: BuildSandboxOptions): Promise<BuildResult> {
     return failure(result, durationMs, 'package_json_missing');
   }
 
-  const zipPath = path.join(stagingDir, 'out', `${pkg.name}-${pkg.version}.zip`);
+  // Match the sanitization performed by scripts/build-zip.mjs: strip the
+  // leading `@` and replace `/` with `-` so scoped names (`@omadia/agent-x`)
+  // resolve to the same flat filename the builder produces.
+  const safeName = pkg.name.replace(/^@/, '').replace(/\//g, '-');
+  const zipPath = path.join(stagingDir, 'out', `${safeName}-${pkg.version}.zip`);
   let zip: Buffer;
   try {
     zip = await fs.readFile(zipPath);

--- a/middleware/src/plugins/builder/codegenUiRoute.ts
+++ b/middleware/src/plugins/builder/codegenUiRoute.ts
@@ -138,7 +138,12 @@ export function buildUiRouteArtifacts(
       `// ui_route: ${route.id} (mode=${route.render_mode}, path=${route.path})`,
       `const __uiRoute_${camelize(route.id)} = ${factoryName}({ runTool: __runTool, pluginId: AGENT_ID });`,
       `__uiRouteDisposers.push(`,
-      `  ctx.routes.register('/p/' + AGENT_ID, __uiRoute_${camelize(route.id)}),`,
+      // Strip the `@scope/` prefix so the mount path matches the URL
+      // convention used by channel-teams' Hub + Tab-Config (uiRouter.ts:56,
+      // `pluginId.replace(/^@[^/]+\\//, '')`). Without this, scoped plugin
+      // ids like `@omadia/agent-foo` mount at `/p/@omadia/agent-foo/...`
+      // while consumers GET `/p/agent-foo/...` → 404.
+      `  ctx.routes.register('/p/' + AGENT_ID.replace(/^@[^/]+\\//, ''), __uiRoute_${camelize(route.id)}),`,
       `);`,
       `__uiRouteDisposers.push(`,
       `  ctx.uiRoutes.register({`,

--- a/middleware/src/plugins/builder/previewRuntime.ts
+++ b/middleware/src/plugins/builder/previewRuntime.ts
@@ -257,7 +257,7 @@ export class PreviewRuntime {
     if (!packageRoot) {
       await fs.rm(previewDir, { recursive: true, force: true });
       throw new Error(
-        `preview: no package.json found in extracted zip (looked at ${previewDir} and one nested level)`,
+        `preview: no package.json found in extracted zip (looked at ${previewDir} and up to two nested levels)`,
       );
     }
 
@@ -425,38 +425,47 @@ function createStubContext(opts: {
 }
 
 /**
- * Walks one directory level deep to locate the directory that holds
- * `package.json`. The boilerplate's build-zip.mjs wraps the package in
- * `<id>-<version>-package/` so the extracted layout is one level deeper
- * than the preview dir; an old-style flat zip lives directly at the root.
+ * Walks the extracted preview directory to locate the directory that
+ * holds `package.json`. Producers should write a single-level wrapper
+ * (`<safe-name>-<version>-package/`, npm-pack style), but a stray
+ * unsanitized scoped name in an older builder leaves a two-level layout
+ * (`@scope/<wrapper>/package.json`). We probe up to two levels so a
+ * partially-fixed producer still surfaces here.
  *
- * Returns the resolved package root (== previewDir for flat zips), or
- * null when no package.json is found in either layout.
+ * Returns the resolved package root, or null when no package.json is
+ * found within the depth budget.
  */
 async function resolvePackageRoot(previewDir: string): Promise<string | null> {
-  try {
-    await fs.access(path.join(previewDir, 'package.json'));
-    return previewDir;
-  } catch {
-    /* fall through to wrapper-detection */
-  }
-  let entries: Dirent[];
-  try {
-    entries = await fs.readdir(previewDir, { withFileTypes: true });
-  } catch {
-    return null;
-  }
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const candidate = path.join(previewDir, entry.name);
-    try {
-      await fs.access(path.join(candidate, 'package.json'));
-      return candidate;
-    } catch {
-      /* keep scanning */
+  if (await hasPackageJson(previewDir)) return previewDir;
+  const level1 = await readSubdirs(previewDir);
+  for (const l1 of level1) {
+    const candidate = path.join(previewDir, l1.name);
+    if (await hasPackageJson(candidate)) return candidate;
+    const level2 = await readSubdirs(candidate);
+    for (const l2 of level2) {
+      const nested = path.join(candidate, l2.name);
+      if (await hasPackageJson(nested)) return nested;
     }
   }
   return null;
+}
+
+async function hasPackageJson(dir: string): Promise<boolean> {
+  try {
+    await fs.access(path.join(dir, 'package.json'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readSubdirs(dir: string): Promise<Dirent[]> {
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    return entries.filter((e) => e.isDirectory());
+  } catch {
+    return [];
+  }
 }
 
 async function defaultExtractZip(zipBuffer: Buffer, destDir: string): Promise<void> {

--- a/middleware/src/plugins/packageUploadService.ts
+++ b/middleware/src/plugins/packageUploadService.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { promises as fs } from 'node:fs';
+import { promises as fs, type Dirent } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -376,17 +376,38 @@ async function resolvePackageRoot(stagingRoot: string): Promise<string | null> {
   if (await fileExists(path.join(stagingRoot, 'manifest.yaml'))) {
     return stagingRoot;
   }
-  const entries = await fs.readdir(stagingRoot, { withFileTypes: true });
-  const dirs = entries.filter((e) => e.isDirectory());
-  if (dirs.length === 1) {
-    const sub = dirs[0];
+  const level1 = await readSubdirs(stagingRoot);
+  // Single-wrapper case is the npm-pack norm. We also tolerate one extra
+  // level so a hand-uploaded ZIP built by a producer that did not sanitize
+  // a scoped package name (`@scope/<wrapper>/manifest.yaml`) still ingests
+  // — at this depth there is no plausible legitimate alternative layout.
+  if (level1.length === 1) {
+    const sub = level1[0];
     if (!sub) return null;
     const candidate = path.join(stagingRoot, sub.name);
     if (await fileExists(path.join(candidate, 'manifest.yaml'))) {
       return candidate;
     }
+    const level2 = await readSubdirs(candidate);
+    if (level2.length === 1) {
+      const sub2 = level2[0];
+      if (!sub2) return null;
+      const nested = path.join(candidate, sub2.name);
+      if (await fileExists(path.join(nested, 'manifest.yaml'))) {
+        return nested;
+      }
+    }
   }
   return null;
+}
+
+async function readSubdirs(dir: string): Promise<Dirent[]> {
+  try {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    return entries.filter((e) => e.isDirectory());
+  } catch {
+    return [];
+  }
 }
 
 async function fileExists(p: string): Promise<boolean> {


### PR DESCRIPTION
## Summary

Builder-generated plugins with scoped npm names (`@scope/name`) failed at three places — each surfaced after the previous one was unblocked while shipping the GitHub-Issues demo plugin for tonight's release launch.

- **Preview** never started — `build-zip.mjs` emitted a wrapper path with an embedded `/` (`out/@omadia/agent-foo-0.1.0-package/`), so the host extractor couldn't locate `package.json`. Now sanitised like `npm pack` (strip `@`, replace `/` with `-`).
- **Install** had the same root cause in `packageUploadService.resolvePackageRoot` (one-level walk only).
- **UI routes 404'd** in the Teams Hub iframe — codegen mounted `/p/<full-scoped-id>` but Hub built URLs as `/p/<stripped-scope>` (`channel-teams/src/uiRouter.ts:56`). Codegen now applies the same strip rule.

Defensive 2-level walks in both `previewRuntime` and `packageUploadService` so partially-fixed older ZIPs still ingest.

## Test plan

- [x] Local: 1012/1014 builder tests green (2 pre-existing skips, 0 fails)
- [x] Local: `npm run lint:fix` + `npm run typecheck` clean for touched files (pre-existing operatorAgents/operatorChannels TS errors unchanged)
- [x] Reproduced bug locally: `@omadia/agent-test` boilerplate build → wrapper now flat (`omadia-agent-test-0.1.0-package/`)
- [x] Deployed to production (v219); GitHub-Issues plugin preview + install + Teams-Hub dashboard verified working
- [x] `GET /p/agent-github-issues/dashboard/open-issues` → 200 (was 404)
