### PR TITLE
fix(builder): stop setup_field slot-fill loop (label/placeholder/help)

### DIFF
--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -52,6 +52,10 @@ export interface PluginSetupField {
   /** Manifest-defined help text. Surfaced on the post-install credentials
    *  editor so the operator sees the same hint as in the install wizard. */
   help?: string;
+  /** Manifest-defined input placeholder. Optional UI hint surfaced by the
+   *  install wizard and post-install editor; loader passes it through
+   *  unchanged. */
+  placeholder?: string;
   /** Manifest default. Forwarded so the post-install editor can pre-select
    *  the default option in an `enum` dropdown when no value is stored yet.
    *  A `string[]` for `type === 'host_list'`, a `string` otherwise. */

--- a/middleware/src/plugins/builder/agentSpec.ts
+++ b/middleware/src/plugins/builder/agentSpec.ts
@@ -113,6 +113,13 @@ export type TestCase = z.infer<typeof TestCaseSchema>;
 
 // Mirrors PluginSetupField['type'] from manifestLoader.isSetupFieldType.
 // `password` is intentionally NOT a member — secrets use `type: 'secret'`.
+//
+// `label`, `placeholder`, `help` are accepted as optional UI hints (the LLM
+// reaches for these by reflex because they are universal form-field
+// conventions). Codegen prefers them over the derived/legacy fields:
+//   spec.label       → manifest.label   (else: humanized key)
+//   spec.help        → manifest.help    (else: spec.description)
+//   spec.placeholder → manifest.placeholder (passthrough; no fallback)
 const SetupFieldSchema = z
   .object({
     key: z.string().regex(/^[a-z][a-z0-9_]*$/),
@@ -130,6 +137,9 @@ const SetupFieldSchema = z
     description: z.string().optional(),
     default: z.unknown().optional(),
     enum_values: z.array(z.string()).optional(),
+    label: z.string().optional(),
+    placeholder: z.string().optional(),
+    help: z.string().optional(),
   })
   .strict();
 
@@ -601,6 +611,81 @@ export function safeParseAgentSpec(
   input: unknown,
 ): ReturnType<typeof AgentSpecSchema.safeParse> {
   return AgentSpecSchema.safeParse(migrateMissingDomain(input));
+}
+
+/**
+ * Walks `AgentSpecSchema` along a Zod issue path and, if the destination
+ * is a ZodObject, returns its declared keys. Used by `patch_spec` to
+ * enrich `unrecognized_keys` errors so the LLM sees what IS allowed
+ * instead of only what was rejected.
+ *
+ * Returns `null` when the path cannot be resolved to a ZodObject — e.g.
+ * the issue sits on an array element of a non-object schema, or zod's
+ * shape changed in a future major version. Caller treats `null` as "no
+ * hint available" and falls back to the bare message.
+ */
+export function getAllowedKeysAtPath(
+  path: ReadonlyArray<PropertyKey>,
+): readonly string[] | null {
+  let node: unknown = AgentSpecSchema;
+  for (const segment of path) {
+    node = unwrap(node);
+    if (node === null) return null;
+    if (isZodObject(node)) {
+      if (typeof segment !== 'string') return null;
+      const shape = node.shape;
+      const next = shape[segment];
+      if (next === undefined) return null;
+      node = next;
+      continue;
+    }
+    if (isZodArray(node)) {
+      if (typeof segment !== 'number') return null;
+      node = node.element;
+      continue;
+    }
+    return null;
+  }
+  node = unwrap(node);
+  if (isZodObject(node)) return Object.keys(node.shape);
+  return null;
+}
+
+function isZodObject(
+  node: unknown,
+): node is { shape: Record<string, unknown> } {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    'shape' in node &&
+    typeof (node as { shape: unknown }).shape === 'object'
+  );
+}
+
+function isZodArray(node: unknown): node is { element: unknown } {
+  return (
+    typeof node === 'object' &&
+    node !== null &&
+    'element' in node &&
+    (node as { element: unknown }).element !== undefined &&
+    // ZodObject also has properties, but it doesn't have `element`.
+    !isZodObject(node)
+  );
+}
+
+function unwrap(node: unknown): unknown {
+  let current = node;
+  while (
+    current &&
+    typeof current === 'object' &&
+    'unwrap' in current &&
+    typeof (current as { unwrap: unknown }).unwrap === 'function' &&
+    !isZodObject(current) &&
+    !isZodArray(current)
+  ) {
+    current = (current as { unwrap: () => unknown }).unwrap();
+  }
+  return current;
 }
 
 // --- Higher-level validation (post-parse) ---------------------------------

--- a/middleware/src/plugins/builder/codegen.ts
+++ b/middleware/src/plugins/builder/codegen.ts
@@ -533,23 +533,25 @@ function reproduceManifestCapabilities(
 /**
  * Maps an AgentSpec.setup_fields[] entry to the shape expected by the
  * platform manifest schema (`docs/harness-platform/manifest-schema.v1.yaml`):
- *   spec.description       → manifest.help
+ *   spec.label              → manifest.label (else: humanized spec.key)
+ *   spec.help|description   → manifest.help  (spec.help wins when both set)
+ *   spec.placeholder        → manifest.placeholder (passthrough)
  *   spec.enum_values        → manifest.enum: [{ value, label }]
- *   manifest.label          → derived from spec.key when not set in spec
- *                             (Title-Case, underscores → spaces)
  * Required-flag defaults to true (matches boilerplate convention).
  */
 function mapSetupFieldSpecToManifest(
   field: AgentSpec['setup_fields'][number],
 ): Record<string, unknown> {
-  const label = humanizeKey(field.key);
+  const label = field.label ?? humanizeKey(field.key);
   const out: Record<string, unknown> = {
     key: field.key,
     type: field.type,
     label,
     required: field.required ?? true,
   };
-  if (field.description) out['help'] = field.description;
+  const help = field.help ?? field.description;
+  if (help) out['help'] = help;
+  if (field.placeholder) out['placeholder'] = field.placeholder;
   if (field.default !== undefined) out['default'] = field.default;
   if (field.enum_values && field.enum_values.length > 0) {
     out['enum'] = field.enum_values.map((value) => ({ value, label: value }));

--- a/middleware/src/plugins/builder/tools/patchSpec.ts
+++ b/middleware/src/plugins/builder/tools/patchSpec.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { safeParseAgentSpec } from '../agentSpec.js';
+import { getAllowedKeysAtPath, safeParseAgentSpec } from '../agentSpec.js';
 import { BuilderAuditAction } from '../auditActions.js';
 import {
   checkSpecDelta,
@@ -145,13 +145,37 @@ export const patchSpecTool: BuilderTool<Input, Result> = {
 };
 
 function formatZodErrors(
-  issues: ReadonlyArray<{ path: ReadonlyArray<PropertyKey>; message: string }>,
+  issues: ReadonlyArray<{
+    path: ReadonlyArray<PropertyKey>;
+    message: string;
+    code?: string;
+  }>,
 ): string {
   return issues
     .slice(0, 5)
-    .map(
-      (i) =>
-        `${i.path.length > 0 ? `/${i.path.map(String).join('/')}` : '/'}: ${i.message}`,
-    )
+    .map((i) => {
+      const pointer = i.path.length > 0 ? `/${i.path.map(String).join('/')}` : '/';
+      const enriched =
+        i.code === 'unrecognized_keys' ? enrichUnrecognizedKeys(i) : null;
+      const message = enriched ?? i.message;
+      return `${pointer}: ${message}`;
+    })
     .join('; ');
+}
+
+/**
+ * Appends the schema's allowed-keys list to the bare "Unrecognized keys: …"
+ * Zod message so the next LLM iteration can correct the patch instead of
+ * blindly guessing. The path always points at the *parent object* of the
+ * unknown keys (one level above the offending field), so we can look up its
+ * declared shape directly via `getAllowedKeysAtPath`.
+ */
+function enrichUnrecognizedKeys(issue: {
+  path: ReadonlyArray<PropertyKey>;
+  message: string;
+}): string | null {
+  const allowed = getAllowedKeysAtPath(issue.path);
+  if (!allowed || allowed.length === 0) return null;
+  const list = allowed.join(', ');
+  return `${issue.message} — allowed keys at this path: ${list}`;
 }

--- a/middleware/src/plugins/manifestLoader.ts
+++ b/middleware/src/plugins/manifestLoader.ts
@@ -189,6 +189,8 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
     const entry: PluginSetupField = { key, label, type };
     const help = asString(f['help']);
     if (help) entry.help = help;
+    const placeholder = asString(f['placeholder']);
+    if (placeholder) entry.placeholder = placeholder;
     if (type === 'host_list') {
       // #91 Option B — the default for a host_list is an array of bare
       // hostnames, not a scalar string.

--- a/middleware/test/builder/agentSpec.test.ts
+++ b/middleware/test/builder/agentSpec.test.ts
@@ -6,6 +6,7 @@ import {
   validateSpecForCodegen,
   registerAgentTemplate,
   getKnownAgentTemplates,
+  getAllowedKeysAtPath,
 } from '../../src/plugins/builder/agentSpec.js';
 
 const validBase = {
@@ -66,6 +67,31 @@ describe('agentSpec', () => {
         setup_fields: [{ key: 'api_key', type: 'secret', required: true }],
       });
       assert.equal(spec.setup_fields[0]?.type, 'secret');
+    });
+
+    it('accepts optional label/placeholder/help on setup_fields', () => {
+      // The Builder LLM reaches for label/placeholder/help by reflex —
+      // they are universal form-field conventions. Schema accepts them as
+      // optional UI hints so the agent does not loop on `unrecognized_keys`.
+      const spec = parseAgentSpec({
+        ...validBase,
+        setup_fields: [
+          {
+            key: 'api_token',
+            type: 'secret',
+            required: true,
+            label: 'API Token',
+            placeholder: 'ghp_…',
+            help: 'GitHub Personal Access Token with repo:read scope',
+          },
+        ],
+      });
+      assert.equal(spec.setup_fields[0]?.label, 'API Token');
+      assert.equal(spec.setup_fields[0]?.placeholder, 'ghp_…');
+      assert.equal(
+        spec.setup_fields[0]?.help,
+        'GitHub Personal Access Token with repo:read scope',
+      );
     });
 
     it('accepts #91 network.web_scanner + host_list setup field', () => {
@@ -442,6 +468,46 @@ describe('agentSpec', () => {
 
     it('rejects an empty template id at register-time', () => {
       assert.throws(() => registerAgentTemplate(''));
+    });
+  });
+
+  describe('getAllowedKeysAtPath', () => {
+    it('returns the SetupFieldSchema keys for /setup_fields/<i>', () => {
+      const keys = getAllowedKeysAtPath(['setup_fields', 0]);
+      assert.ok(keys, 'expected allowed-keys list');
+      // Must contain the LLM-friendly hints AND the canonical fields so
+      // patchSpec error messages teach the agent what to use.
+      for (const expected of [
+        'key',
+        'type',
+        'required',
+        'description',
+        'default',
+        'enum_values',
+        'label',
+        'placeholder',
+        'help',
+      ]) {
+        assert.ok(
+          keys.includes(expected),
+          `expected '${expected}' in allowed keys; got: ${keys.join(', ')}`,
+        );
+      }
+    });
+
+    it('returns top-level AgentSpec keys for an empty path', () => {
+      const keys = getAllowedKeysAtPath([]);
+      assert.ok(keys);
+      assert.ok(keys.includes('id'));
+      assert.ok(keys.includes('setup_fields'));
+      assert.ok(keys.includes('tools'));
+    });
+
+    it('returns null when the path does not resolve to an object', () => {
+      // /name is a string, not an object — no shape to list.
+      assert.equal(getAllowedKeysAtPath(['name']), null);
+      // /tools is an array; without an index we land on the array itself.
+      assert.equal(getAllowedKeysAtPath(['tools']), null);
     });
   });
 });

--- a/middleware/test/builder/codegen.test.ts
+++ b/middleware/test/builder/codegen.test.ts
@@ -306,6 +306,78 @@ describe('codegen.generate', () => {
     assert.ok(!text.includes('{{DEPENDS_ON_YAML}}'));
   });
 
+  it('propagates spec.setup_fields[].label/placeholder/help to manifest.yaml', async () => {
+    // When the Builder LLM provides UI-hint fields, codegen must honour them
+    // rather than fall back to the auto-derived label / description-as-help.
+    const { slots } = loadFixture();
+    const spec = parseAgentSpec({
+      id: 'de.byte5.agent.github',
+      name: 'GitHub',
+      description: 'fixture',
+      category: 'other',
+      depends_on: [],
+      tools: [{ id: 'do_thing', description: 'x', input: { type: 'object' } }],
+      skill: { role: 'x' },
+      playbook: { when_to_use: 'x', not_for: ['x'], example_prompts: ['x', 'y'] },
+      network: { outbound: ['api.github.com'] },
+      setup_fields: [
+        {
+          key: 'api_token',
+          type: 'secret',
+          required: true,
+          label: 'GitHub PAT',
+          placeholder: 'ghp_…',
+          help: 'Personal Access Token with repo:read scope',
+          // description is the legacy alias for help — when help is set it
+          // wins, so the manifest must carry the help value, not this one.
+          description: 'LEGACY-FALLBACK',
+        },
+      ],
+    });
+    const files = await generate({ spec, slots });
+    const manifest = files.get('manifest.yaml');
+    assert.ok(manifest);
+    const doc = yaml.parse(manifest.toString('utf-8')) as {
+      setup?: { fields?: Array<Record<string, unknown>> };
+    };
+    const field = doc.setup?.fields?.[0];
+    assert.ok(field, 'expected one setup field in manifest');
+    assert.equal(field['label'], 'GitHub PAT');
+    assert.equal(field['placeholder'], 'ghp_…');
+    assert.equal(field['help'], 'Personal Access Token with repo:read scope');
+  });
+
+  it('derives manifest setup_field.label from the key when spec.label is absent', async () => {
+    // Backwards-compat: existing drafts that only set `key`/`type` must
+    // still get a humanized label without changes from the agent.
+    const { slots } = loadFixture();
+    const spec = parseAgentSpec({
+      id: 'de.byte5.agent.github',
+      name: 'GitHub',
+      description: 'fixture',
+      category: 'other',
+      depends_on: [],
+      tools: [{ id: 'do_thing', description: 'x', input: { type: 'object' } }],
+      skill: { role: 'x' },
+      playbook: { when_to_use: 'x', not_for: ['x'], example_prompts: ['x', 'y'] },
+      network: { outbound: ['api.github.com'] },
+      setup_fields: [
+        { key: 'api_token', type: 'secret', description: 'help-via-description' },
+      ],
+    });
+    const files = await generate({ spec, slots });
+    const manifest = files.get('manifest.yaml');
+    assert.ok(manifest);
+    const doc = yaml.parse(manifest.toString('utf-8')) as {
+      setup?: { fields?: Array<Record<string, unknown>> };
+    };
+    const field = doc.setup?.fields?.[0];
+    assert.ok(field);
+    assert.equal(field['label'], 'Api Token');
+    assert.equal(field['help'], 'help-via-description');
+    assert.equal(field['placeholder'], undefined);
+  });
+
   it('emits top-level admin_ui_path in manifest.yaml when spec sets it (S+7.7)', async () => {
     // Optional Operator-Admin-UI: when the spec carries `admin_ui_path`,
     // codegen must inject it as a top-level YAML field so manifestLoader

--- a/middleware/test/builder/tools/patchSpec.test.ts
+++ b/middleware/test/builder/tools/patchSpec.test.ts
@@ -211,6 +211,47 @@ describe('patchSpecTool', () => {
       );
       assert.deepEqual(reloaded?.spec.network.outbound, ['api.openweather.org']);
     });
+
+    it('enriches unrecognized_keys errors with the allowed-keys list', async () => {
+      // Recurring Builder failure mode: the LLM writes `setup_fields` with
+      // `label`/`placeholder`/`help` keys that pre-existed only as UI-form
+      // conventions, then loops because the bare Zod message tells it what
+      // was rejected but not what would be accepted. The enriched error
+      // must list the allowed shape so the next iteration can correct.
+      // (`label`/`placeholder`/`help` are now accepted — `foo_bar` here is
+      // a stand-in for any genuinely unknown key.)
+      await seedValidSpec();
+      const result = await patchSpecTool.run(
+        {
+          patches: [
+            {
+              op: 'replace',
+              path: '/setup_fields',
+              value: [
+                {
+                  key: 'api_token',
+                  type: 'secret',
+                  required: true,
+                  foo_bar: 'unknown-key',
+                },
+              ],
+            },
+          ],
+        },
+        harness.context(),
+      );
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.match(result.error, /strict-mode rejected/);
+      assert.match(result.error, /allowed keys at this path/);
+      // The hint must include both the canonical and the LLM-friendly aliases.
+      assert.match(result.error, /\bkey\b/);
+      assert.match(result.error, /\btype\b/);
+      assert.match(result.error, /\bdescription\b/);
+      assert.match(result.error, /\blabel\b/);
+      assert.match(result.error, /\bhelp\b/);
+      assert.match(result.error, /\bplaceholder\b/);
+    });
   });
 
   describe('B.7-3 content-guard (silent capability loss)', () => {


### PR DESCRIPTION
## Why

The Builder agent keeps re-attempting `spec_patch` 12+ times per turn when populating `setup_fields[]` because the LLM reaches for `label`, `placeholder`, `help` by reflex — they are universal form-field conventions and the model can't suppress them. The strict Zod schema rejected each attempt with a message that listed only the bad keys; the agent had no signal of what *would* be accepted, so it kept guessing until the build-failure budget tripped.

Screenshot from a recent draft run: 4 × `spec_patch` + 8 × `fill_slot` in 9.6 s tool-time, all `ERROR`s rooted in `Unrecognized keys: "label", "placeholder", "help"` at `/setup_fields/i`.

## What changed

**A — Self-documenting Zod errors** ([patchSpec.ts](middleware/src/plugins/builder/tools/patchSpec.ts))
`formatZodErrors` now enriches `unrecognized_keys` issues with the declared keys at that path, via a new `getAllowedKeysAtPath` walker in [agentSpec.ts](middleware/src/plugins/builder/agentSpec.ts). Generic fix — every `.strict()` object in the spec (jobs, network, tools, …) gets the same treatment.

**D — Accept the hint fields** ([agentSpec.ts](middleware/src/plugins/builder/agentSpec.ts), [codegen.ts](middleware/src/plugins/builder/codegen.ts), [manifestLoader.ts](middleware/src/plugins/manifestLoader.ts), [admin-v1.ts](middleware/src/api/admin-v1.ts))
`SetupFieldSchema` learns optional `label`, `placeholder`, `help`. Codegen's manifest mapping prefers them over the legacy fallbacks (`description` → `help`, humanized `key` → `label`). `manifestLoader` parses `placeholder` so the runtime model carries the hint end-to-end; the install / post-install UI can adopt it without another spec/manifest round-trip.

## Test plan

- [x] `agentSpec.test.ts` — new optional fields accepted; `getAllowedKeysAtPath` smoke tests
- [x] `patchSpec.test.ts` — `unrecognized_keys` error contains `allowed keys at this path` + the SetupField schema's keys
- [x] `codegen.test.ts` — manifest YAML carries `label`/`placeholder`/`help` when set in spec, falls back to humanized key + `description` when not
- [x] Adjacent suites (contentGuard, manifestLinter, runtimeSmoke, draftStore, builderManifestExtension) — unchanged
- [x] `npx eslint` clean on all touched files
- [x] `tsc --noEmit` clean on all touched files (pre-existing unrelated errors in routes/* and index.ts not addressed here)