### PR TITLE
fix(builder): render ask_user_choice smart-card + default to agent-integration

### DIFF
--- a/middleware/src/plugins/builder/types.ts
+++ b/middleware/src/plugins/builder/types.ts
@@ -212,15 +212,13 @@ export interface DraftSummary {
 
 export function emptyAgentSpec(): AgentSpecSkeleton {
   return {
-    // Default to the pure-LLM template. The integration template hardcodes
+    // Default to the integration template: most fresh drafts call an
+    // external API and start from there. The boilerplate's
     // `ctx.secrets.require('API_TOKEN')` + `ctx.config.require('base_url')`
-    // in its boilerplate, so a fresh draft from that template fails to
-    // activate until the operator wires real API credentials — surprising
-    // for "I just want to build a pure-prompting agent". Pure-LLM has no
-    // such requirement; operators flip to `agent-integration` (via the
-    // Workspace header template-switcher) the moment they need an
-    // external API call.
-    template: 'agent-pure-llm',
+    // give the operator concrete setup-field anchors to fill in via the
+    // SecretsDrawer; pure-LLM remains one click away in the Workspace
+    // header template-switcher for prompting-only drafts.
+    template: 'agent-integration',
     id: '',
     name: '',
     version: '0.1.0',

--- a/web-ui/app/_components/ChoiceCard.tsx
+++ b/web-ui/app/_components/ChoiceCard.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import type React from 'react';
+import { useTranslations } from 'next-intl';
+
+import type { PendingUserChoice } from '../_lib/chatSessions';
+
+export type { PendingUserChoice };
+
+/**
+ * Smart-Card clarification question with 2-4 option buttons.
+ *
+ * Used by every surface that wants to render the `ask_user_choice`
+ * (orchestrator) or `user_choice_required` (builder spec-event-bus)
+ * flow — main chat, BuilderChatPane and PreviewChatPane all reuse
+ * this component so the look and accessibility behaviour stay in
+ * sync. The caller owns the `onChoose` semantics (post to resolver
+ * endpoint vs. submit a fresh user turn).
+ */
+export function ChoiceCard({
+  choice,
+  disabled,
+  onChoose,
+}: {
+  choice: PendingUserChoice;
+  disabled: boolean;
+  onChoose: (value: string) => void;
+}): React.ReactElement {
+  const t = useTranslations('chat');
+  return (
+    <div className="mt-3 rounded border border-indigo-200 bg-indigo-50/60 p-3 dark:border-indigo-800 dark:bg-indigo-950/40">
+      <div className="mb-1 text-xs font-semibold text-indigo-700 dark:text-indigo-300">
+        {t('clarifyKicker')}
+      </div>
+      <div className="mb-2 text-sm text-neutral-900 dark:text-neutral-100">
+        {choice.question}
+      </div>
+      {choice.rationale && (
+        <div className="mb-2 text-xs text-neutral-500 italic dark:text-neutral-400">
+          {choice.rationale}
+        </div>
+      )}
+      <div className="flex flex-wrap gap-2">
+        {choice.options.map((opt, idx) => (
+          <button
+            key={`${opt.value}-${String(idx)}`}
+            type="button"
+            onClick={() => {
+              onChoose(opt.value);
+            }}
+            disabled={disabled}
+            className={[
+              'rounded border px-3 py-1.5 text-xs font-medium transition',
+              idx === 0
+                ? 'border-indigo-600 bg-indigo-600 text-white hover:bg-indigo-700 dark:border-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-600'
+                : 'border-neutral-300 bg-white text-neutral-700 hover:border-neutral-500 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200',
+              'disabled:cursor-not-allowed disabled:opacity-40',
+            ].join(' ')}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web-ui/app/_lib/builderTypes.ts
+++ b/web-ui/app/_lib/builderTypes.ts
@@ -270,6 +270,34 @@ export type SpecBusEvent =
       kind: 'build_failed' | 'smoke_failed';
       buildN: number;
       identicalCount?: number;
+    }
+  | {
+      /**
+       * Builder-Agent invoked `ask_user_choice`. The UI renders a
+       * Smart-Card with 2-4 buttons; the operator's pick is POSTed to
+       * `/drafts/:id/user-choice/:choiceId` which resolves the pending
+       * tool call on the server. Mirror of `user_choice_required` in
+       * middleware/src/plugins/builder/specEventBus.ts.
+       */
+      type: 'user_choice_required';
+      choiceId: string;
+      question: string;
+      options: ReadonlyArray<{
+        value: string;
+        label: string;
+        description?: string;
+      }>;
+    }
+  | {
+      /**
+       * Companion to `user_choice_required` — emitted once the choice
+       * has resolved (operator clicked, dismissed, or timed out). The
+       * UI clears the Smart-Card on every open tab. `value` is `null`
+       * when the choice was cancelled or timed out.
+       */
+      type: 'user_choice_resolved';
+      choiceId: string;
+      value: string | null;
     };
 
 // -----------------------------------------------------------------------------

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -29,12 +29,12 @@ import {
   type FollowUpOption,
   type Message,
   type NudgeEvent,
-  type PendingUserChoice,
   type SubAgentEvent,
   type ToolEvent,
 } from './_lib/chatSessions';
 import { useChatSessionsCtx } from './_lib/chatSessionsContext';
 import { useStreamStore } from './_lib/streamStore';
+import { ChoiceCard } from './_components/ChoiceCard';
 
 export default function ChatPage(): React.ReactElement {
   const t = useTranslations('chat');
@@ -968,63 +968,6 @@ function AttachmentGrid({
   );
 }
 
-/**
- * Renders a Smart-Card clarification-question with 2–4 option buttons.
- * Click fires a fresh user turn via `onChoose(value)` — identical to the
- * user typing the label. Disabled while another turn is streaming so the
- * user can't double-click through the card.
- *
- * In the web-ui UI a "card" is just a stacked box below the streamed
- * answer; the Teams adapter ships the same `pendingUserChoice` payload as
- * a real Adaptive Card.
- */
-function ChoiceCard({
-  choice,
-  disabled,
-  onChoose,
-}: {
-  choice: PendingUserChoice;
-  disabled: boolean;
-  onChoose: (value: string) => void;
-}): React.ReactElement {
-  const t = useTranslations('chat');
-  return (
-    <div className="mt-3 rounded border border-indigo-200 bg-indigo-50/60 p-3 dark:border-indigo-800 dark:bg-indigo-950/40">
-      <div className="mb-1 text-xs font-semibold text-indigo-700 dark:text-indigo-300">
-        {t('clarifyKicker')}
-      </div>
-      <div className="mb-2 text-sm text-neutral-900 dark:text-neutral-100">
-        {choice.question}
-      </div>
-      {choice.rationale && (
-        <div className="mb-2 text-xs text-neutral-500 italic dark:text-neutral-400">
-          {choice.rationale}
-        </div>
-      )}
-      <div className="flex flex-wrap gap-2">
-        {choice.options.map((opt, idx) => (
-          <button
-            key={`${opt.value}-${String(idx)}`}
-            type="button"
-            onClick={() => {
-              onChoose(opt.value);
-            }}
-            disabled={disabled}
-            className={[
-              'rounded border px-3 py-1.5 text-xs font-medium transition',
-              idx === 0
-                ? 'border-indigo-600 bg-indigo-600 text-white hover:bg-indigo-700 dark:border-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-600'
-                : 'border-neutral-300 bg-white text-neutral-700 hover:border-neutral-500 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200',
-              'disabled:cursor-not-allowed disabled:opacity-40',
-            ].join(' ')}
-          >
-            {opt.label}
-          </button>
-        ))}
-      </div>
-    </div>
-  );
-}
 
 /**
  * Non-blocking 1-click refinement buttons rendered below the answer. The

--- a/web-ui/app/store/builder/[id]/_components/BuilderChatPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/BuilderChatPane.tsx
@@ -18,7 +18,11 @@ import {
   Wrench,
 } from 'lucide-react';
 
-import { ApiError, streamBuilderTurn } from '../../../../_lib/api';
+import {
+  ApiError,
+  resolveBuilderUserChoice,
+  streamBuilderTurn,
+} from '../../../../_lib/api';
 import type {
   BuilderModelId,
   BuilderTurnEvent,
@@ -27,6 +31,7 @@ import type {
   TranscriptEntry,
 } from '../../../../_lib/builderTypes';
 import { cn } from '../../../../_lib/cn';
+import { ChoiceCard } from '../../../../_components/ChoiceCard';
 
 import { BuilderMarkdown } from './BuilderMarkdown';
 
@@ -85,6 +90,22 @@ interface BuilderChatPaneProps {
   /** Called once the pending input has been applied so the parent can
    *  reset its state and avoid re-applying the same value. */
   onPendingInputConsumed?: () => void;
+  /** Pending `ask_user_choice` smart-card, hoisted by Workspace from
+   *  the SpecEventBus. Rendered below the latest assistant message. */
+  pendingUserChoice?: {
+    choiceId: string;
+    question: string;
+    options: ReadonlyArray<{
+      value: string;
+      label: string;
+      description?: string;
+    }>;
+  } | null;
+  /** Called optimistically after the operator picks an option, so the
+   *  parent can clear the card without waiting for the bus echo. The
+   *  `user_choice_resolved` event still arrives later for sibling-tab
+   *  consistency, but the local pane reacts instantly. */
+  onUserChoiceResolved?: () => void;
 }
 
 /**
@@ -107,6 +128,8 @@ export function BuilderChatPane({
   onAgentMutation,
   pendingInput,
   onPendingInputConsumed,
+  pendingUserChoice,
+  onUserChoiceResolved,
 }: BuilderChatPaneProps): React.ReactElement {
   const [items, setItems] = useState<ChatItem[]>(() =>
     initialTranscript.map((entry, idx) => ({
@@ -442,6 +465,38 @@ export function BuilderChatPane({
 
   const empty = items.length === 0;
 
+  // ask_user_choice → operator pick. Lock the buttons while the POST is
+  // in flight so an antsy double-click doesn't fire the resolver twice
+  // (the second call returns 404 once the coordinator has cleared, but
+  // we still want a single source of UI feedback). The card is cleared
+  // optimistically; if the resolver errors out, the bus echo will
+  // re-instate it on the next `user_choice_required` and the operator
+  // can retry.
+  const [choiceSubmitting, setChoiceSubmitting] = useState(false);
+  const onChooseUserChoice = useCallback(
+    async (value: string) => {
+      if (!pendingUserChoice || choiceSubmitting) return;
+      const { choiceId } = pendingUserChoice;
+      setChoiceSubmitting(true);
+      setError(null);
+      onUserChoiceResolved?.();
+      try {
+        await resolveBuilderUserChoice({ draftId, choiceId, value });
+      } catch (err) {
+        if (err instanceof ApiError) {
+          setError(humanizeApiError(err));
+        } else if (err instanceof Error) {
+          setError(`Auswahl konnte nicht gespeichert werden: ${err.message}`);
+        } else {
+          setError('Auswahl konnte nicht gespeichert werden.');
+        }
+      } finally {
+        setChoiceSubmitting(false);
+      }
+    },
+    [pendingUserChoice, choiceSubmitting, draftId, onUserChoiceResolved],
+  );
+
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div
@@ -453,6 +508,21 @@ export function BuilderChatPane({
         ) : (
           items.map((item) => <ChatItemView key={item.key} item={item} />)
         )}
+        {pendingUserChoice ? (
+          <ChoiceCard
+            choice={{
+              question: pendingUserChoice.question,
+              options: pendingUserChoice.options.map((o) => ({
+                value: o.value,
+                label: o.label,
+              })),
+            }}
+            disabled={choiceSubmitting}
+            onChoose={(v) => {
+              void onChooseUserChoice(v);
+            }}
+          />
+        ) : null}
       </div>
 
       {error ? (
@@ -636,6 +706,10 @@ function ChatItemView({ item }: { item: ChatItem }): React.ReactElement | null {
   }
 
   if (item.kind === 'tool') {
+    // `ask_user_choice` is rendered as a Smart-Card (ChoiceCard) by the
+    // pane root — hide the raw JSON ToolCard so the operator does not
+    // see the same question twice (once as a card, once as a pre-block).
+    if (item.toolId === 'ask_user_choice') return null;
     return <ToolCard item={item} />;
   }
 

--- a/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
@@ -37,6 +37,10 @@ import type {
   TranscriptEntry,
 } from '../../../../_lib/builderTypes';
 import { cn } from '../../../../_lib/cn';
+import {
+  ChoiceCard,
+  type PendingUserChoice,
+} from '../../../../_components/ChoiceCard';
 
 import { BuilderMarkdown } from './BuilderMarkdown';
 import { SecretsDrawer } from './SecretsDrawer';
@@ -221,15 +225,15 @@ export function PreviewChatPane({
     };
   }, []);
 
-  const onSend = useCallback(async () => {
-    const trimmed = input.trim();
+  const onSend = useCallback(async (override?: string) => {
+    const trimmed = (override ?? input).trim();
     if (!trimmed || inflight) return;
     const controller = new AbortController();
     abortRef.current = controller;
     setError(null);
     setInflight(true);
     setTurnStartedAt(Date.now());
-    setInput('');
+    if (override === undefined) setInput('');
 
     try {
       for await (const ev of streamPreviewTurn(draftId, trimmed, {
@@ -485,7 +489,29 @@ export function PreviewChatPane({
         {items.length === 0 ? (
           <EmptyHint />
         ) : (
-          items.map((item) => <ChatItemView key={item.key} item={item} />)
+          items.map((item) => {
+            // Render an `ask_user_choice` tool_use as a real Smart-Card
+            // instead of the generic ToolCard's raw JSON dump. The
+            // preview-agent doesn't pause server-side — clicking just
+            // submits the chosen value as a fresh user turn (same as
+            // typing the option label).
+            if (item.kind === 'tool' && item.toolId === 'ask_user_choice') {
+              const parsed = parseAskUserChoiceInput(item.input);
+              if (parsed) {
+                return (
+                  <ChoiceCard
+                    key={item.key}
+                    choice={parsed}
+                    disabled={inflight}
+                    onChoose={(v) => {
+                      void onSend(v);
+                    }}
+                  />
+                );
+              }
+            }
+            return <ChatItemView key={item.key} item={item} />;
+          })
         )}
       </div>
 
@@ -824,6 +850,41 @@ function lastIndexWhere<T>(arr: T[], pred: (item: T) => boolean): number {
     if (item !== undefined && pred(item)) return i;
   }
   return -1;
+}
+
+/**
+ * Validate the JSON shape of an `ask_user_choice` tool_use input so we
+ * can render a Smart-Card instead of the raw JSON. Returns `null` when
+ * the payload does not match `{ question, options[{value,label}] }` —
+ * caller falls back to the generic ToolCard. `rationale` is optional
+ * and only forwarded when it is a non-empty string.
+ */
+function parseAskUserChoiceInput(input: unknown): PendingUserChoice | null {
+  if (typeof input !== 'object' || input === null) return null;
+  const obj = input as Record<string, unknown>;
+  if (typeof obj['question'] !== 'string' || obj['question'].length === 0) {
+    return null;
+  }
+  if (!Array.isArray(obj['options']) || obj['options'].length === 0) {
+    return null;
+  }
+  const options: Array<{ label: string; value: string }> = [];
+  for (const raw of obj['options']) {
+    if (typeof raw !== 'object' || raw === null) continue;
+    const o = raw as Record<string, unknown>;
+    if (typeof o['value'] !== 'string' || typeof o['label'] !== 'string') {
+      continue;
+    }
+    options.push({ value: o['value'], label: o['label'] });
+  }
+  if (options.length === 0) return null;
+  const rationale =
+    typeof obj['rationale'] === 'string' && obj['rationale'].length > 0
+      ? obj['rationale']
+      : undefined;
+  return rationale !== undefined
+    ? { question: obj['question'], rationale, options }
+    : { question: obj['question'], options };
 }
 
 function jsonPreview(input: unknown): string {

--- a/web-ui/app/store/builder/[id]/_components/Workspace.tsx
+++ b/web-ui/app/store/builder/[id]/_components/Workspace.tsx
@@ -158,6 +158,19 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
     text: string;
     autoSubmit?: boolean;
   } | null>(null);
+  // Pending `ask_user_choice` smart-card. Fed by the SpecEventBus
+  // (`user_choice_required`) and cleared on `user_choice_resolved`
+  // (sibling-tab or own click). The BuilderChatPane reads this to
+  // render a ChoiceCard under the latest assistant turn.
+  const [pendingUserChoice, setPendingUserChoice] = useState<{
+    choiceId: string;
+    question: string;
+    options: ReadonlyArray<{
+      value: string;
+      label: string;
+      description?: string;
+    }>;
+  } | null>(null);
   // Pane collapse state — chat is the only pane that starts open. Editor +
   // Preview start collapsed so the user has the maximum width for the
   // initial conversation; expanding either is one click on the rail.
@@ -447,6 +460,22 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
           prev && prev.slotKey === ev.slotKey ? null : prev,
         );
       }
+      if (ev.type === 'user_choice_required') {
+        setPendingUserChoice({
+          choiceId: ev.choiceId,
+          question: ev.question,
+          options: ev.options,
+        });
+        // No re-fetch — the spec is unchanged, the agent is just blocked
+        // on operator input.
+        return;
+      }
+      if (ev.type === 'user_choice_resolved') {
+        setPendingUserChoice((prev) =>
+          prev && prev.choiceId === ev.choiceId ? null : prev,
+        );
+        return;
+      }
       scheduleRefetch();
     },
     { onStatus: setBusStatus },
@@ -631,6 +660,8 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
             initialTranscript={draft.transcript}
             pendingInput={pendingChatInput}
             onPendingInputConsumed={() => setPendingChatInput(null)}
+            pendingUserChoice={pendingUserChoice}
+            onUserChoiceResolved={() => setPendingUserChoice(null)}
           />
         );
         const editorPaneBody = (

--- a/web-ui/app/store/builder/[id]/_components/useSpecEvents.ts
+++ b/web-ui/app/store/builder/[id]/_components/useSpecEvents.ts
@@ -81,6 +81,19 @@ export function useSpecEvents(
     // different event name so callers can route it to the build-status
     // surface without poking at the union discriminator twice.
     source.addEventListener('build_status', onSpecPatch as EventListener);
+    // Smart-Card clarification (ask_user_choice): the SpecEventBus
+    // emits `user_choice_required` when the builder agent needs a
+    // pick, and `user_choice_resolved` once any tab has answered (so
+    // multi-tab clients can dismiss the card everywhere). Both arrive
+    // as the same JSON envelope as every other bus event.
+    source.addEventListener(
+      'user_choice_required',
+      onSpecPatch as EventListener,
+    );
+    source.addEventListener(
+      'user_choice_resolved',
+      onSpecPatch as EventListener,
+    );
 
     return () => {
       source.removeEventListener('open', onOpen);
@@ -89,6 +102,14 @@ export function useSpecEvents(
       source.removeEventListener('slot_patch', onSlotPatch as EventListener);
       source.removeEventListener('lint_result', onLint as EventListener);
       source.removeEventListener('build_status', onSpecPatch as EventListener);
+      source.removeEventListener(
+        'user_choice_required',
+        onSpecPatch as EventListener,
+      );
+      source.removeEventListener(
+        'user_choice_resolved',
+        onSpecPatch as EventListener,
+      );
       source.close();
       onStatusRef.current?.('closed');
     };


### PR DESCRIPTION
## Summary

Two builder-UX fixes bundled because both surfaced in the same screenshot review.

### 1. Smart-Card rendering for `ask_user_choice` (the reported bug)

The Builder-Agent's `ask_user_choice` invocation streamed as a raw JSON `tool_use` card in the workspace, so the operator never saw the buttons. The pending `Promise` inside `UserChoiceCoordinator` then hung 30 min until timeout.

**Backend was already complete** (SpecEventBus `user_choice_required` / `_resolved` events, `POST /drafts/:id/user-choice/:choiceId` resolver). The fix wires the frontend:
- `SpecBusEvent` union extended with the two variants
- `useSpecEvents` registers `addEventListener` for both event names
- `Workspace` lifts `pendingUserChoice` into state, passes to `BuilderChatPane`
- `BuilderChatPane` renders a `<ChoiceCard>` under the latest turn — click POSTs to the resolver so the agent's tool call returns and the turn continues. Raw `ask_user_choice` `ToolCard` suppressed to avoid double-rendering.
- `ChoiceCard` extracted from `app/page.tsx` to `app/_components/ChoiceCard.tsx` (shared between main chat, Builder, Preview)
- `PreviewChatPane` parses `ask_user_choice` `tool_use` input and renders the same card inline; click submits the chosen value as a fresh user turn (forward-looking — preview-agent toolkit can adopt the tool without further UI work)

### 2. Default template → `agent-integration`

`emptyAgentSpec()` now returns `template: 'agent-integration'` (was `agent-pure-llm`). Most fresh drafts call an external API, so the integration boilerplate's `ctx.secrets.require('API_TOKEN')` + `ctx.config.require('base_url')` give the operator concrete setup-field anchors instead of a blank slate. Pure-LLM remains one click away in the Workspace header template-switcher.

## Test plan

- [x] web-ui `tsc --noEmit` clean
- [x] web-ui `eslint` 0 errors (6 pre-existing warnings unchanged)
- [x] middleware `tsc` no errors in touched files
- [x] `next dev` compile, `GET /` and `GET /store/builder/<id>` both 200, no Module-not-found / React errors
- [x] Live deploy verified on Fly (`odoo-bot-middleware`, `odoo-bot-harness`)
- [ ] CI green
- [ ] Operator-level click-through on https://odoo-bot-harness.fly.dev/store/builder/<draft>: builder-agent fires `ask_user_choice` → Smart-Card visible → click → builder turn continues with chosen value