### PR TITLE
feat(privacy): operator-owned per-plugin Privacy Mode (Slice 2.5)

### DIFF
--- a/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
@@ -78,6 +78,16 @@ export interface OrchestratorDeps {
   readonly responseGuard: () => ResponseGuardService | undefined;
   /** Late-bound `privacy.redact@1` lookup (see `OrchestratorOptions`). */
   readonly privacyGuard: () => PrivacyGuardService | undefined;
+  /**
+   * Slice 2.5 — cross-plugin runtime-config lookup for the privacy bypass
+   * resolver (see `OrchestratorOptions.pluginConfigGet`). Wired from the
+   * harness runtime that owns the installed-plugin registry. Optional —
+   * when absent, only kernel-tool bypass works.
+   */
+  readonly pluginConfigGet?: (
+    agentId: string,
+    configKey: string,
+  ) => unknown | undefined;
   readonly contextRetriever?: ContextRetriever;
   readonly sessionBriefing?: SessionBriefingService;
   readonly factExtractor?: FactExtractor;
@@ -167,6 +177,9 @@ export function buildOrchestratorForAgent(
     ...(deps.embeddingClient ? { embeddingClient: deps.embeddingClient } : {}),
     responseGuard: deps.responseGuard,
     privacyGuard: deps.privacyGuard,
+    ...(deps.pluginConfigGet
+      ? { pluginConfigGet: deps.pluginConfigGet }
+      : {}),
     nudgeRegistry: deps.nudgeRegistry,
     ...(deps.nudgeStateStore ? { nudgeStateStore: deps.nudgeStateStore } : {}),
     ...(deps.processMemory ? { nudgeProcessMemory: deps.processMemory } : {}),

--- a/middleware/packages/harness-orchestrator/src/localSubAgent.ts
+++ b/middleware/packages/harness-orchestrator/src/localSubAgent.ts
@@ -455,9 +455,33 @@ export class LocalSubAgent {
         );
       }
     }
-    // Intern the raw result server-side and hand the LLM only the
-    // identity-free digest — the raw rows never reach the LLM wire.
     if (privacy !== undefined && typeof result === 'string') {
+      // Slice 2.5 — same operator-owned bypass check the orchestrator's
+      // outer dispatch consults. If the tool's plugin opted into `bypass`,
+      // the sub-agent's LLM sees real values (not `[masked]`), record a
+      // receipt entry, AND flip the parent scope's bypass flag so the
+      // parent doesn't re-intern this sub-agent's narration.
+      const bypass = privacy.checkBypass(toolName);
+      if (bypass !== undefined) {
+        const flag = turnContext.current()?.subAgentBypassFlag;
+        if (flag) flag.value = true;
+        try {
+          await privacy.recordBypassedTool({
+            toolName,
+            pluginId: bypass.pluginId,
+            reason: 'operator_setting',
+            bytes: Buffer.byteLength(result, 'utf8'),
+          });
+        } catch (err) {
+          console.warn(
+            `[sub-agent ${this.name}] privacy.recordBypassedTool threw on '${toolName}' — bypass still applied:`,
+            err,
+          );
+        }
+        return result;
+      }
+      // Intern the raw result server-side and hand the LLM only the
+      // identity-free digest — the raw rows never reach the LLM wire.
       try {
         const v4 = await privacy.internToolResultV4({
           toolName,

--- a/middleware/packages/harness-orchestrator/src/nativeToolRegistry.ts
+++ b/middleware/packages/harness-orchestrator/src/nativeToolRegistry.ts
@@ -52,6 +52,22 @@ export interface NativeToolRegistration {
    * count toward multi-domain triggers).
    */
   readonly domain?: string;
+  /**
+   * Slice 2.5 — originating plugin's agent-id (manifest `identity.id`).
+   * Set by the `ToolsAccessor.register` shim in pluginContext at
+   * registration time. Used by the orchestrator dispatch hook to attribute
+   * a bypass receipt entry. Absent for marker-only kernel registrations.
+   */
+  readonly agentId?: string;
+  /**
+   * Slice 2.5 — closure that reads the originating plugin's runtime
+   * config, scoped to the plugin's own ConfigAccessor chain (same one
+   * the plugin sees via `ctx.config.get(key)`). Used by the orchestrator
+   * dispatch hook to resolve `_privacy_mode` / `_privacy_bypass_scopes`
+   * at dispatch time so the operator's choice takes effect immediately
+   * without restart. Absent for marker-only kernel registrations.
+   */
+  readonly readConfig?: (key: string) => unknown | undefined;
 }
 
 export interface NativeToolRegistrationOptions {
@@ -62,6 +78,12 @@ export interface NativeToolRegistrationOptions {
   /** OB-77 — see `NativeToolRegistration.domain`. Resolved by the kernel
    *  before calling `register`. */
   domain?: string;
+  /** Slice 2.5 — see `NativeToolRegistration.agentId`. Set by
+   *  `ToolsAccessor.register` from the activating plugin's context. */
+  agentId?: string;
+  /** Slice 2.5 — see `NativeToolRegistration.readConfig`. Set by
+   *  `ToolsAccessor.register` as `(k) => config.get(k)`. */
+  readConfig?: (key: string) => unknown | undefined;
 }
 
 /**
@@ -110,6 +132,10 @@ export class NativeToolRegistry {
             ? { attachmentSink: options.attachmentSink }
             : {}),
           ...(options.domain !== undefined ? { domain: options.domain } : {}),
+          ...(options.agentId !== undefined ? { agentId: options.agentId } : {}),
+          ...(options.readConfig !== undefined
+            ? { readConfig: options.readConfig }
+            : {}),
         }
       : { name };
     this.entries.set(name, entry);
@@ -174,6 +200,16 @@ export class NativeToolRegistry {
    */
   getDomain(name: string): string | undefined {
     return this.entries.get(name)?.domain;
+  }
+
+  /**
+   * Slice 2.5 — originating-plugin lookup for the orchestrator's privacy
+   * dispatch hook. Returns the agent-id (manifest `identity.id`) of the
+   * plugin that contributed this tool, or `undefined` for marker-only
+   * kernel entries.
+   */
+  getAgentId(name: string): string | undefined {
+    return this.entries.get(name)?.agentId;
   }
 
   /** All entries, in registration order. */

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -66,6 +66,11 @@ import type {
   SessionBriefingService,
 } from '@omadia/plugin-api';
 import {
+  PRIVACY_BYPASS_SCOPES_CONFIG_KEY,
+  PRIVACY_MODE_CONFIG_KEY,
+  resolveEffectivePrivacyMode,
+} from '@omadia/plugin-api';
+import {
   createNudgeTurnCounter,
   runNudgePipeline,
   type NudgeTurnCounter,
@@ -228,6 +233,26 @@ export interface OrchestratorOptions {
    * attached to the returned `ChatTurnResult.privacyReceipt`.
    */
   privacyGuard?: () => PrivacyGuardService | undefined;
+  /**
+   * Slice 2.5 — cross-plugin runtime-config lookup for the privacy
+   * dispatch hook. Given `(agentId, configKey)` returns the operator-set
+   * value stored on that installed plugin's registry entry. Used by the
+   * bypass resolver to look up `_privacy_mode` on:
+   *   - a domain tool's owning agent plugin (via DomainTool.agentId)
+   *   - a sub-agent's owning agent plugin (via
+   *     turnContext.subAgentOwnerPluginId)
+   * neither of which is reachable through the per-tool `readConfig`
+   * closure attached to NativeToolRegistry entries.
+   *
+   * Caller (the harness runtime) wires this as
+   * `(agentId, key) => installedRegistry.get(agentId)?.config?.[key]`.
+   * Absent ⇒ only kernel-tool bypass works (pre-Slice-2.5-extension
+   * behaviour), domain/sub-agent tools always run guarded.
+   */
+  pluginConfigGet?: (
+    agentId: string,
+    configKey: string,
+  ) => unknown | undefined;
   /**
    * Palaia Phase 8 (OB-77) — Nudge-Pipeline registry. Plugin-contributed
    * `NudgeProvider`s register against this registry; the orchestrator
@@ -748,6 +773,10 @@ export class Orchestrator {
   private readonly bookMeetingTool: BookMeetingTool | undefined;
   private readonly responseGuard: (() => ResponseGuardService | undefined) | undefined;
   private readonly privacyGuard: (() => PrivacyGuardService | undefined) | undefined;
+  /** Slice 2.5 — cross-plugin runtime-config lookup (see OrchestratorOptions). */
+  private readonly pluginConfigGet:
+    | ((agentId: string, configKey: string) => unknown | undefined)
+    | undefined;
   private readonly nudgeRegistry: NudgeRegistry | undefined;
   private readonly nudgeStateStore: NudgeStateStore | undefined;
   private readonly nudgeProcessMemory: ProcessMemoryService | undefined;
@@ -793,6 +822,7 @@ export class Orchestrator {
     this.bookMeetingTool = options.bookMeetingTool;
     this.responseGuard = options.responseGuard;
     this.privacyGuard = options.privacyGuard;
+    this.pluginConfigGet = options.pluginConfigGet;
     this.nudgeRegistry = options.nudgeRegistry;
     this.nudgeStateStore = options.nudgeStateStore;
     this.nudgeProcessMemory = options.nudgeProcessMemory;
@@ -1318,11 +1348,7 @@ export class Orchestrator {
     const sessionId = input.sessionScope ?? turnId;
     const privacyService = this.privacyGuard?.();
     const privacyHandle = privacyService
-      ? createPrivacyTurnHandle({
-          service: privacyService,
-          sessionId,
-          turnId,
-        })
+      ? this.buildPrivacyHandle(privacyService, sessionId, turnId)
       : undefined;
 
     return turnContext.run(
@@ -1715,11 +1741,7 @@ export class Orchestrator {
     const sessionId = input.sessionScope ?? turnId;
     const privacyService = this.privacyGuard?.();
     const privacyHandle = privacyService
-      ? createPrivacyTurnHandle({
-          service: privacyService,
-          sessionId,
-          turnId,
-        })
+      ? this.buildPrivacyHandle(privacyService, sessionId, turnId)
       : undefined;
 
     turnContext.enter({
@@ -2294,14 +2316,31 @@ export class Orchestrator {
     // into it, and below we hand the parent agent the digests of those REAL
     // datasets by reference instead of re-interning the prose.
     const subAgentSink: string[] = [];
+    // Slice 2.5 — mutable flag that captures whether any tool call inside
+    // a domain-tool dispatch honored the operator's per-plugin `bypass`
+    // setting. Read after the sub-agent loop returns so we can decide
+    // whether to pass the narration through raw (sub-agent already saw
+    // real values, its synthesis carries them) or intern as before.
+    const subAgentBypassFlag = { value: false };
     let result: string;
     if (
       privacy !== undefined &&
       ctx !== undefined &&
       this.domainToolsByName.has(name)
     ) {
+      // Slice 2.5 — stash the domain tool's owning agent plugin id so
+      // the sub-agent's inner tool calls can resolve bypass via the
+      // same plugin's `_privacy_mode` setting.
+      const domainToolAgentId = this.domainToolsByName.get(name)?.agentId;
       result = await turnContext.run(
-        { ...ctx, subAgentDatasetSink: subAgentSink },
+        {
+          ...ctx,
+          subAgentDatasetSink: subAgentSink,
+          subAgentBypassFlag,
+          ...(domainToolAgentId !== undefined
+            ? { subAgentOwnerPluginId: domainToolAgentId }
+            : {}),
+        },
         () => this.dispatchToolInner(name, input, observer),
       );
     } else {
@@ -2323,6 +2362,33 @@ export class Orchestrator {
       }
     }
     if (privacy !== undefined && typeof result === 'string') {
+      // Slice 2.5 — Operator-owned per-plugin bypass. If the originating
+      // plugin's `_privacy_mode` is `bypass` (or per-tool whitelist hits
+      // this name), pass the raw result through unmasked AND record an
+      // entry on the receipt for transparency. Org-policy override
+      // (`OMADIA_PRIVACY_FORCE_GUARDED=true`) clamps every plugin back
+      // to `guarded` inside the resolver.
+      const bypass = privacy.checkBypass(name);
+      if (bypass !== undefined) {
+        // Mark the enclosing sub-agent scope (if any) so the parent
+        // dispatch knows the sub-agent saw real values.
+        const flag = turnContext.current()?.subAgentBypassFlag;
+        if (flag) flag.value = true;
+        try {
+          await privacy.recordBypassedTool({
+            toolName: name,
+            pluginId: bypass.pluginId,
+            reason: 'operator_setting',
+            bytes: Buffer.byteLength(result, 'utf8'),
+          });
+        } catch (err) {
+          console.warn(
+            `[orchestrator.dispatchTool:${name}] privacy.recordBypassedTool threw — bypass still applied:`,
+            err,
+          );
+        }
+        return result;
+      }
       // Sub-agent bridge: the sub-agent interned ≥1 dataset this dispatch —
       // pass those REAL datasets up by reference so the parent agent's
       // `v4_render_answer` resolves ground truth, not the `[masked]` prose.
@@ -2340,6 +2406,13 @@ export class Orchestrator {
           );
         }
       }
+      // Slice 2.5 — sub-agent ran in bypass mode for at least one of its
+      // tool calls. Its narration already carries real values (the sub-
+      // agent's LLM read them directly), so re-interning the prose would
+      // mask the synthesis the user actually asked for. Pass raw.
+      if (subAgentBypassFlag.value && subAgentSink.length === 0) {
+        return result;
+      }
       // Intern the raw result server-side and hand the LLM only the
       // identity-free digest — the raw rows never reach the LLM wire.
       try {
@@ -2356,6 +2429,105 @@ export class Orchestrator {
       }
     }
     return result;
+  }
+
+  /**
+   * Slice 2.5 — build the per-turn `PrivacyTurnHandle` with the bypass
+   * resolver baked in. Shared by both `runTurn` and `chatStream` so the
+   * resolver wiring lives in one place.
+   *
+   * The resolver consults the native-tool registration for `(agentId,
+   * readConfig)` — both set by `ToolsAccessor.register` from the
+   * activating plugin's context. Marker-only kernel registrations carry
+   * neither, so they always go through `guarded`. The readConfig closure
+   * routes through the plugin's own ConfigAccessor chain, so an
+   * operator setting saved via the install UI is visible to the very
+   * next dispatch (no restart).
+   */
+  private buildPrivacyHandle(
+    service: PrivacyGuardService,
+    sessionId: string,
+    turnId: string,
+  ): ReturnType<typeof createPrivacyTurnHandle> {
+    const nativeTools = this.nativeTools;
+    const domainTools = this.domainToolsByName;
+    const pluginConfigGet = this.pluginConfigGet;
+
+    // Slice 2.5 — three-tier bypass lookup:
+    //   1. kernel tools (via `ctx.tools.register`) carry their own
+    //      `(agentId, readConfig)` closure on the NativeToolRegistry entry
+    //   2. domain tools (delegation wrappers for sub-agents) carry an
+    //      `agentId` set by `dynamicAgentRuntime` — resolved via
+    //      `pluginConfigGet(agentId, key)` against the kernel registry
+    //   3. sub-agent INNER tool calls (LocalSubAgentTools fetched from a
+    //      `*.toolkit` service) — the orchestrator stashes the owning
+    //      agent plugin id in turnContext before running the sub-agent;
+    //      the resolver reads it back via turnContext and looks up the
+    //      same `_privacy_mode` setting as path #2
+    //
+    // The org-policy override (`OMADIA_PRIVACY_FORCE_GUARDED=true`) is
+    // honoured inside `resolveEffectivePrivacyMode` for all three paths.
+    const lookupByAgentId = (
+      agentId: string,
+      toolName: string,
+    ): { pluginId: string } | undefined => {
+      if (pluginConfigGet === undefined) return undefined;
+      const storedMode = pluginConfigGet(agentId, PRIVACY_MODE_CONFIG_KEY);
+      const storedScopes = pluginConfigGet(
+        agentId,
+        PRIVACY_BYPASS_SCOPES_CONFIG_KEY,
+      );
+      const effective = resolveEffectivePrivacyMode({
+        storedMode,
+        storedScopes,
+        toolName,
+        env: process.env,
+      });
+      return effective === 'bypass' ? { pluginId: agentId } : undefined;
+    };
+
+    const resolveBypass = (
+      toolName: string,
+    ): { pluginId: string } | undefined => {
+      // Path 1 — kernel tool with attached config closure.
+      const reg = nativeTools.get(toolName);
+      if (reg?.agentId !== undefined && reg.readConfig !== undefined) {
+        const storedMode = reg.readConfig(PRIVACY_MODE_CONFIG_KEY);
+        const storedScopes = reg.readConfig(PRIVACY_BYPASS_SCOPES_CONFIG_KEY);
+        const effective = resolveEffectivePrivacyMode({
+          storedMode,
+          storedScopes,
+          toolName,
+          env: process.env,
+        });
+        if (effective === 'bypass') return { pluginId: reg.agentId };
+        // Kernel tool with explicit guarded — don't fall through to other
+        // paths (kernel registration is authoritative for kernel tools).
+        return undefined;
+      }
+      // Path 2 — domain tool with attached agent plugin id.
+      const domainTool = domainTools.get(toolName);
+      if (domainTool?.agentId !== undefined) {
+        const hit = lookupByAgentId(domainTool.agentId, toolName);
+        if (hit) return hit;
+      }
+      // Path 3 — sub-agent inner tool. The orchestrator's domain-tool
+      // dispatch installs `subAgentOwnerPluginId` in the nested turn
+      // scope before running the sub-agent loop; every inner tool call
+      // reads back here.
+      const subAgentOwner = turnContext.current()?.subAgentOwnerPluginId;
+      if (subAgentOwner !== undefined) {
+        const hit = lookupByAgentId(subAgentOwner, toolName);
+        if (hit) return hit;
+      }
+      return undefined;
+    };
+    return createPrivacyTurnHandle({
+      service,
+      sessionId,
+      turnId,
+      resolveBypass,
+    });
   }
 
   private async dispatchToolInner(

--- a/middleware/packages/harness-orchestrator/src/plugin.ts
+++ b/middleware/packages/harness-orchestrator/src/plugin.ts
@@ -299,6 +299,16 @@ export async function activate(
   const privacyGuardGetter = (): PrivacyGuardService | undefined =>
     ctx.services.get<PrivacyGuardService>(PRIVACY_REDACT_SERVICE_NAME);
 
+  // Slice 2.5 — cross-plugin runtime-config reader for the privacy
+  // bypass resolver. Published by the kernel at boot
+  // (`middleware/src/index.ts:installedPluginConfigReader`). When absent
+  // (legacy hosts, unit tests) the resolver falls back to kernel-tool
+  // bypass only — domain and sub-agent inner tools then always run
+  // guarded.
+  const pluginConfigGet = ctx.services.get<
+    (agentId: string, configKey: string) => unknown | undefined
+  >('installedPluginConfigReader');
+
   // Setup-field config (with defaults)
   const model =
     (ctx.config.get<string>('orchestrator_model') ?? '').trim() ||
@@ -432,6 +442,7 @@ export async function activate(
     nudgeRegistry,
     responseGuard: responseGuardGetter,
     privacyGuard: privacyGuardGetter,
+    ...(pluginConfigGet ? { pluginConfigGet } : {}),
     ...(contextRetriever ? { contextRetriever } : {}),
     ...(sessionBriefing ? { sessionBriefing } : {}),
     ...(factExtractor ? { factExtractor } : {}),

--- a/middleware/packages/harness-orchestrator/src/privacyHandle.ts
+++ b/middleware/packages/harness-orchestrator/src/privacyHandle.ts
@@ -28,6 +28,29 @@ export interface PrivacyTurnHandle {
     readonly rawResult: string;
   }): Promise<{ readonly digestText: string; readonly datasetId: string }>;
   /**
+   * Slice 2.5 — record that a tool's raw result was passed through
+   * unmasked this turn (operator set the originating plugin's
+   * `_privacy_mode` to `bypass`). Drained into the user-facing receipt
+   * at turn end.
+   */
+  recordBypassedTool(input: {
+    readonly toolName: string;
+    readonly pluginId: string;
+    readonly reason: 'operator_setting';
+    readonly bytes: number;
+  }): Promise<void>;
+  /**
+   * Slice 2.5 — synchronous decision: should this tool's result bypass
+   * the data-plane boundary? Resolves the originating plugin's
+   * `_privacy_mode` (and `_privacy_bypass_scopes` in per-tool mode),
+   * honors the `OMADIA_PRIVACY_FORCE_GUARDED` org override. Returns the
+   * plugin's agent-id when bypass fires (caller attributes the receipt
+   * entry with it), `undefined` otherwise. Both the orchestrator's
+   * `dispatchTool` and `LocalSubAgent.dispatchToolToTool` consult this
+   * so a sub-agent's inner tool calls honor the same per-plugin setting.
+   */
+  checkBypass(toolName: string): { readonly pluginId: string } | undefined;
+  /**
    * Run a v4 verb tool or the terminal render tool the LLM called; returns
    * the `tool_result` text.
    */
@@ -68,6 +91,16 @@ export function createPrivacyTurnHandle(deps: {
   readonly service: PrivacyGuardService;
   readonly sessionId: string;
   readonly turnId: string;
+  /**
+   * Slice 2.5 — synchronous resolver that maps a tool name to the
+   * originating plugin's agent-id IF the operator selected `bypass` for
+   * that plugin (or whitelisted the tool in per-tool mode). `undefined`
+   * means "guard as usual". Wired by the orchestrator from
+   * `pluginConfigGet` + `nativeToolRegistry.getAgentId` +
+   * `resolveEffectivePrivacyMode`; absent in tests/legacy hosts ⇒ no
+   * tool ever bypasses (byte-identical pre-Slice-2.5 behaviour).
+   */
+  readonly resolveBypass?: (toolName: string) => { pluginId: string } | undefined;
 }): PrivacyTurnHandle {
   return {
     async internToolResultV4(input) {
@@ -77,6 +110,20 @@ export function createPrivacyTurnHandle(deps: {
         toolName: input.toolName,
         rawResult: input.rawResult,
       });
+    },
+
+    async recordBypassedTool(input) {
+      return deps.service.recordBypassedTool({
+        turnId: deps.turnId,
+        toolName: input.toolName,
+        pluginId: input.pluginId,
+        reason: input.reason,
+        bytes: input.bytes,
+      });
+    },
+
+    checkBypass(toolName) {
+      return deps.resolveBypass?.(toolName);
     },
 
     async runV4Tool(input) {

--- a/middleware/packages/harness-orchestrator/src/tools/domainQueryTool.ts
+++ b/middleware/packages/harness-orchestrator/src/tools/domainQueryTool.ts
@@ -78,6 +78,15 @@ export interface DomainTool {
   spec: DomainToolSpec;
   /** OB-77 — see `PLUGIN_DOMAIN_REGEX` for the naming convention. */
   domain: string;
+  /**
+   * Slice 2.5 — originating agent plugin's id (manifest `identity.id`),
+   * e.g. `@omadia/agent-confluence`. Used by the orchestrator's privacy
+   * bypass resolver to look up the operator-set `_privacy_mode` on the
+   * agent that owns this domain tool — so `bypass` on the agent applies
+   * BOTH to the domain tool itself AND to every sub-agent inner tool
+   * call that runs within its dispatch.
+   */
+  agentId?: string;
   handle(input: unknown, observer?: AskObserver): Promise<string>;
   /**
    * Privacy-Shield v3 (stable-id tokenization, slice 1) — optional PII
@@ -120,6 +129,14 @@ interface DomainToolOptions {
    * Nudge-Pipeline can detect multi-domain workflows.
    */
   domain: string;
+  /**
+   * Slice 2.5 — owning agent plugin id (manifest `identity.id`).
+   * Optional for back-compat with existing callers; when present, the
+   * orchestrator's privacy bypass resolver consults the operator's
+   * `_privacy_mode` setting on this plugin for BOTH the domain tool
+   * dispatch AND every sub-agent inner tool call within it.
+   */
+  agentId?: string;
 }
 
 export function createDomainTool(options: DomainToolOptions): DomainTool {
@@ -143,6 +160,7 @@ export function createDomainTool(options: DomainToolOptions): DomainTool {
     name: options.name,
     spec,
     domain: options.domain,
+    ...(options.agentId !== undefined ? { agentId: options.agentId } : {}),
     async handle(input: unknown, observer?: AskObserver): Promise<string> {
       if (typeof input !== 'object' || input === null) {
         return 'Error: tool input must be an object.';

--- a/middleware/packages/harness-orchestrator/src/turnContext.ts
+++ b/middleware/packages/harness-orchestrator/src/turnContext.ts
@@ -70,6 +70,37 @@ export interface TurnContextValue {
    * dispatch — sub-agent interning then behaves byte-identically to before.
    */
   subAgentDatasetSink?: string[];
+  /**
+   * Slice 2.5 — sub-agent bypass flag. Set by the orchestrator in a
+   * nested scope around a single domain-tool dispatch (alongside
+   * `subAgentDatasetSink`). Flipped to `true` by `dispatchTool` whenever
+   * a tool call inside that scope honors the operator's per-plugin
+   * `bypass` setting and returns raw. The parent dispatch reads this at
+   * the end of the sub-agent run: if set AND `subAgentDatasetSink` is
+   * empty, it passes the sub-agent's narration through raw (instead of
+   * interning it) — because the sub-agent already saw real values for
+   * the bypassed tools, its narration already carries real content and
+   * re-interning would mask the synthesis the user is asking for.
+   *
+   * Mutable holder so the inner scope's writes are visible to the outer
+   * scope's reader after `turnContext.run(...)` returns. Undefined
+   * outside a domain-tool dispatch.
+   */
+  subAgentBypassFlag?: { value: boolean };
+  /**
+   * Slice 2.5 — agent plugin id (manifest `identity.id`) of the
+   * currently-executing sub-agent's owning agent. Set by the
+   * orchestrator in the nested scope around a domain-tool dispatch
+   * (alongside `subAgentDatasetSink` and `subAgentBypassFlag`) BEFORE
+   * the sub-agent's tool loop runs. Read by the privacy bypass resolver
+   * inside `LocalSubAgent.dispatchToolToTool` to look up the operator's
+   * `_privacy_mode` on the OWNING agent — so a single bypass setting
+   * on (e.g.) `@omadia/agent-confluence` applies to every
+   * `confluence_search` / `confluence_get_page` call the sub-agent
+   * makes, regardless of which integration plugin contributed the
+   * underlying tool. Undefined outside a domain-tool dispatch.
+   */
+  subAgentOwnerPluginId?: string;
 }
 
 const storage = new AsyncLocalStorage<TurnContextValue>();

--- a/middleware/packages/harness-plugin-privacy-guard/src/service.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/service.ts
@@ -16,6 +16,8 @@
  */
 
 import type {
+  BypassedToolEntry,
+  PrivacyBypassedToolRequest,
   PrivacyGuardService,
   PrivacyReceipt,
   PrivacyRenderedAnswer,
@@ -98,6 +100,11 @@ export function createPrivacyGuardService(deps?: {
   // server-side; only the count of those the user named themselves reaches
   // the receipt (`identityValuesOnWire`). Dropped by `finalizeTurn`.
   const turnPiiValues = new Map<string, Set<string>>();
+  // Slice 2.5 — per-turn list of tools whose raw results bypassed the
+  // boundary (operator set `_privacy_mode=bypass` on the originating
+  // plugin). Drained into the receipt by `finalizeTurn`. Entries carry
+  // only tool/plugin names + a byte count (no values).
+  const bypassedTools = new Map<string, BypassedToolEntry[]>();
   // Slice 2 — cached, Haiku-backed schema PII classifier. Process-scoped
   // (its cache spans turns — schema verdicts are tool-shape-stable). Absent
   // when no host LLM is wired.
@@ -206,6 +213,27 @@ export function createPrivacyGuardService(deps?: {
         }
       }
       return result;
+    },
+
+    async recordBypassedTool(
+      request: PrivacyBypassedToolRequest,
+    ): Promise<void> {
+      let list = bypassedTools.get(request.turnId);
+      if (list === undefined) {
+        list = [];
+        bypassedTools.set(request.turnId, list);
+      }
+      list.push({
+        toolName: request.toolName,
+        pluginId: request.pluginId,
+        reason: request.reason,
+        bytes: request.bytes,
+      });
+      console.log(
+        `[privacy-guard v4] bypass turn=${request.turnId} ` +
+          `tool=${request.toolName} plugin=${request.pluginId} ` +
+          `bytes=${String(request.bytes)} reason=${request.reason}`,
+      );
     },
 
     async runV4Tool(
@@ -327,9 +355,14 @@ export function createPrivacyGuardService(deps?: {
       receipts.delete(turnId);
       const piiValues = turnPiiValues.get(turnId);
       turnPiiValues.delete(turnId);
-      // No receipt for a turn that interned nothing — there is nothing to
-      // report and a zero receipt is just noise in the channel UI.
-      if (accum === undefined || accum.datasetsInterned === 0) return undefined;
+      const bypassed = bypassedTools.get(turnId);
+      bypassedTools.delete(turnId);
+      // No receipt for a turn that touched neither the boundary nor a
+      // bypass — there is nothing to report and a zero receipt is just
+      // noise in the channel UI.
+      const hasInterned = accum !== undefined && accum.datasetsInterned > 0;
+      const hasBypassed = bypassed !== undefined && bypassed.length > 0;
+      if (!hasInterned && !hasBypassed) return undefined;
       // identityValuesOnWire — personal-identity values the requester named
       // in their own message text. A transparency notice (the user put a
       // real identity on the wire), NOT a leak of tool data.
@@ -341,19 +374,21 @@ export function createPrivacyGuardService(deps?: {
       }
       console.log(
         `[privacy-guard v4] finalize turn=${turnId} ` +
-          `datasets=${String(accum.datasetsInterned)} ` +
-          `masked=${String(accum.fieldsMasked)} ` +
-          `cleartext=${String(accum.fieldsCleartext)} ` +
-          `verbs=[${accum.verbsExecuted.join(',')}] ` +
+          `datasets=${String(accum?.datasetsInterned ?? 0)} ` +
+          `masked=${String(accum?.fieldsMasked ?? 0)} ` +
+          `cleartext=${String(accum?.fieldsCleartext ?? 0)} ` +
+          `verbs=[${(accum?.verbsExecuted ?? []).join(',')}] ` +
+          `bypassed=${String(bypassed?.length ?? 0)} ` +
           `identityOnWire=${String(identityValuesOnWire)}`,
       );
       return {
-        datasetsInterned: accum.datasetsInterned,
-        fieldsMasked: accum.fieldsMasked,
-        fieldsCleartext: accum.fieldsCleartext,
-        verbsExecuted: [...accum.verbsExecuted],
-        pseudonymProjectionUsed: accum.pseudonymProjectionUsed,
+        datasetsInterned: accum?.datasetsInterned ?? 0,
+        fieldsMasked: accum?.fieldsMasked ?? 0,
+        fieldsCleartext: accum?.fieldsCleartext ?? 0,
+        verbsExecuted: accum ? [...accum.verbsExecuted] : [],
+        pseudonymProjectionUsed: accum?.pseudonymProjectionUsed ?? false,
         identityValuesOnWire,
+        ...(hasBypassed ? { bypassedTools: [...bypassed] } : {}),
       };
     },
   };

--- a/middleware/packages/plugin-api/src/index.ts
+++ b/middleware/packages/plugin-api/src/index.ts
@@ -32,6 +32,12 @@ export * from './agentPriorities.js';
 export * from './privacyReceipt.js';
 export * from './privacyReceiptFixtures.js';
 
+// Slice 2.5 — operator-owned per-plugin Privacy Mode contract. Shared by
+// the orchestrator dispatch hook (resolves mode at dispatch time) and the
+// install service (injects synthetic `_privacy_mode` field into every
+// plugin's setup schema).
+export * from './privacyMode.js';
+
 // Palaia-Phase-6 (OB-75): Session-Continuity Briefings. Lazy summary
 // + open tasks for bootstrap system messages. Provider lives in
 // `harness-orchestrator-extras` (needs KG + ContextRetriever +

--- a/middleware/packages/plugin-api/src/privacyMode.ts
+++ b/middleware/packages/plugin-api/src/privacyMode.ts
@@ -1,0 +1,119 @@
+/**
+ * Slice 2.5 — Operator-owned per-plugin Privacy Mode contract.
+ *
+ * Every installed plugin that contributes tools picks up a synthetic
+ * `_privacy_mode` setup field (kernel-injected by `extractSetupSchema`).
+ * The operator selects how the orchestrator's dispatch hook should treat
+ * raw tool results from that plugin:
+ *
+ *   - `guarded`  default — every raw result is interned behind the
+ *                Privacy Shield v4 Data-Plane Boundary; the LLM sees only
+ *                an identity-free digest. Safe-by-default.
+ *   - `bypass`   the orchestrator passes raw results through unmasked;
+ *                the LLM sees real values. Operator opt-in for sources
+ *                the operator trusts AND whose shape v4 cannot usefully
+ *                summarise (document-shaped pages, binary blobs, …).
+ *                A `BypassedToolEntry` lands in the receipt for every
+ *                dispatch so the user sees a transparency notice.
+ *   - `per_tool` advanced — the operator picks specific tool names via
+ *                `_privacy_bypass_scopes`; non-listed tools stay
+ *                `guarded`. Use when one plugin contributes both
+ *                v4-friendly (search hits, row-shape) and v4-incompatible
+ *                (document bodies) tools.
+ *
+ * Compliance override — the org-level env var
+ * `OMADIA_PRIVACY_FORCE_GUARDED=true` clamps every plugin to `guarded`
+ * regardless of operator settings. UI MUST surface the override as a
+ * "Locked by org policy" badge.
+ *
+ * The constants here are imported by both the orchestrator dispatch hook
+ * (to resolve the mode at dispatch time) AND the install service (to
+ * inject the synthetic field into every plugin's setup schema).
+ */
+
+/** Config-key the operator-UI writes the selected mode into. Leading
+ *  underscore marks it as kernel-synthetic (not authored by the plugin). */
+export const PRIVACY_MODE_CONFIG_KEY = '_privacy_mode';
+
+/** Config-key for the per-tool override list (only meaningful when
+ *  `_privacy_mode === 'per_tool'`). Stored as a `string[]` of tool names. */
+export const PRIVACY_BYPASS_SCOPES_CONFIG_KEY = '_privacy_bypass_scopes';
+
+/** Org-policy env var. When `'true'`, every plugin is clamped to
+ *  `guarded` regardless of the operator's per-plugin setting. */
+export const PRIVACY_FORCE_GUARDED_ENV_VAR = 'OMADIA_PRIVACY_FORCE_GUARDED';
+
+/** Allowed values for `_privacy_mode`. Order is the UI-display order. */
+export const PRIVACY_MODE_VALUES = ['guarded', 'bypass', 'per_tool'] as const;
+
+export type PrivacyMode = (typeof PRIVACY_MODE_VALUES)[number];
+
+/** Universal default. Picked when the operator never opened the dropdown. */
+export const PRIVACY_MODE_DEFAULT: PrivacyMode = 'guarded';
+
+/**
+ * Resolve the effective mode for a tool given (a) the plugin's stored
+ * config and (b) the org-policy env var. Pure — no IO. Callable from the
+ * orchestrator dispatch hook AND from tests with synthetic inputs.
+ *
+ * `toolName` is consulted only for `per_tool` mode; ignored otherwise.
+ */
+export function resolveEffectivePrivacyMode(input: {
+  /** The value stored at `config[_privacy_mode]`, or `undefined` if the
+   *  operator never set one. */
+  readonly storedMode: unknown;
+  /** The value stored at `config[_privacy_bypass_scopes]`, or `undefined`.
+   *  Consulted only when `storedMode === 'per_tool'`. */
+  readonly storedScopes: unknown;
+  /** The tool name being dispatched. */
+  readonly toolName: string;
+  /** Process env — pass `process.env` from the caller. The hook reads
+   *  `PRIVACY_FORCE_GUARDED_ENV_VAR`; everything else is ignored. */
+  readonly env: NodeJS.ProcessEnv;
+}): 'guarded' | 'bypass' {
+  // Org-policy override is absolute — it short-circuits before any other
+  // resolution so the audit story is simple: "FORCE_GUARDED was on → no
+  // bypass ever fired this turn, end of story".
+  if (input.env[PRIVACY_FORCE_GUARDED_ENV_VAR] === 'true') return 'guarded';
+  const mode = isPrivacyMode(input.storedMode)
+    ? input.storedMode
+    : PRIVACY_MODE_DEFAULT;
+  if (mode === 'guarded') return 'guarded';
+  if (mode === 'bypass') return 'bypass';
+  // per_tool — bypass iff the tool name is in the operator's whitelist.
+  // Tolerant parsing — accept both forms the install flow may produce:
+  //   - array of strings (programmatic API write)
+  //   - comma- or whitespace-separated string (manual operator entry
+  //     via the install UI, which uses a plain `string` field for
+  //     simplicity in Slice 2.5d MVP)
+  for (const tool of parseScopes(input.storedScopes)) {
+    if (tool === input.toolName) return 'bypass';
+  }
+  return 'guarded';
+}
+
+/** Parse the scope-list config value to a flat tool-name array. Trims
+ *  entries and drops empty/non-string items. Idempotent across both
+ *  array and string inputs. Exported for the install-service validator. */
+export function parseScopes(stored: unknown): readonly string[] {
+  if (Array.isArray(stored)) {
+    return stored
+      .filter((s): s is string => typeof s === 'string')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  }
+  if (typeof stored === 'string' && stored.length > 0) {
+    return stored
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  }
+  return [];
+}
+
+function isPrivacyMode(v: unknown): v is PrivacyMode {
+  return (
+    typeof v === 'string' &&
+    (PRIVACY_MODE_VALUES as readonly string[]).includes(v)
+  );
+}

--- a/middleware/packages/plugin-api/src/privacyReceipt.ts
+++ b/middleware/packages/plugin-api/src/privacyReceipt.ts
@@ -17,6 +17,32 @@ export const PRIVACY_REDACT_SERVICE_NAME = 'privacyRedact';
 export const PRIVACY_REDACT_CAPABILITY = 'privacy.redact@1';
 
 /**
+ * One tool whose raw result the orchestrator passed through UNINTERNED this
+ * turn — i.e. the LLM saw real values, not a `[masked]` digest — because
+ * the operator set the originating plugin's `_privacy_mode` to `bypass`
+ * (Slice 2.5). Surfaced in the receipt so the user sees a transparency
+ * notice for every bypass decision the operator made.
+ *
+ * MUST stay PII-free — tool name + plugin id + count of bytes only, never
+ * the raw value that crossed the boundary.
+ */
+export interface BypassedToolEntry {
+  /** The tool name as it appears in the LLM's `tool_use` block, e.g.
+   *  `confluence_get_page`. */
+  readonly toolName: string;
+  /** The originating plugin's agent-id (its manifest `identity.id`), e.g.
+   *  `@omadia/integration-confluence`. */
+  readonly pluginId: string;
+  /** Why the bypass fired this turn. `operator_setting` — the operator
+   *  picked `bypass` (or scoped this tool via per-tool override) on the
+   *  plugin's `_privacy_mode` setting. */
+  readonly reason: 'operator_setting';
+  /** Byte length of the raw result that bypassed the boundary — i.e.
+   *  the LLM-visible payload size. For UI transparency only. */
+  readonly bytes: number;
+}
+
+/**
  * The per-turn user-facing privacy report. Emitted by `finalizeTurn` and
  * attached to the assistant message metadata; channel renderers (Teams
  * card, Web disclosure) consume it to build their collapsible UI.
@@ -46,6 +72,14 @@ export interface PrivacyReceipt {
    * (status codes, model names) can never inflate it.
    */
   readonly identityValuesOnWire?: number;
+  /**
+   * Slice 2.5 — tools whose raw results bypassed the data-plane boundary
+   * this turn, per the operator's per-plugin `_privacy_mode` setting.
+   * Absent / empty when no bypass fired (the universal default is
+   * `guarded`). PII-free: entries carry tool name + plugin id + a byte
+   * count, never a raw value.
+   */
+  readonly bypassedTools?: readonly BypassedToolEntry[];
 }
 
 // ---------------------------------------------------------------------------
@@ -133,6 +167,21 @@ export interface PrivacyRenderedAnswer {
 }
 
 /**
+ * Slice 2.5 — record that a tool's raw result was passed through unmasked
+ * this turn because the operator set the originating plugin's
+ * `_privacy_mode` to `bypass`. The entry lands in the per-turn receipt
+ * verbatim — no transformation, no aggregation — so the user sees one
+ * line per bypass decision.
+ */
+export interface PrivacyBypassedToolRequest {
+  readonly turnId: string;
+  readonly toolName: string;
+  readonly pluginId: string;
+  readonly reason: 'operator_setting';
+  readonly bytes: number;
+}
+
+/**
  * Service surface published by the `privacy.redact@1` provider plugin.
  */
 export interface PrivacyGuardService {
@@ -144,6 +193,14 @@ export interface PrivacyGuardService {
   internToolResultV4(
     request: PrivacyToolResultV4Request,
   ): Promise<PrivacyToolResultV4Result>;
+  /**
+   * Slice 2.5 — record that the orchestrator passed a tool's raw result
+   * through unmasked this turn (operator opted into `bypass` for the
+   * originating plugin). The entry surfaces in the user-facing receipt
+   * emitted by `finalizeTurn`. Idempotent within a turn: the orchestrator
+   * may call this for every bypassed dispatch and every entry is kept.
+   */
+  recordBypassedTool(request: PrivacyBypassedToolRequest): Promise<void>;
   /**
    * Privacy Shield v4 — run a v4 verb tool or the terminal render tool the
    * LLM called. Returns the text to place in the `tool_result` block. A

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -451,6 +451,20 @@ async function main(): Promise<void> {
     },
   });
 
+  // Slice 2.5 — cross-plugin runtime-config reader. Published as a kernel
+  // service so the orchestrator plugin (which activates BEFORE most tool
+  // plugins) can resolve any other installed plugin's `_privacy_mode`
+  // setting at dispatch time without having to import the installed
+  // registry directly. Reads only the non-secret config bag; secrets are
+  // never exposed via this surface. Returns `undefined` for both unknown
+  // plugins and unknown keys — the caller treats both as "no override".
+  serviceRegistry.provide(
+    'installedPluginConfigReader',
+    (agentId: string, configKey: string): unknown => {
+      return installedRegistry.get(agentId)?.config?.[configKey];
+    },
+  );
+
   // Kernel-wide background-job scheduler. Plugin-contributed jobs (cron or
   // interval) register here via `ctx.jobs.register(...)`. Bulk teardown on
   // plugin deactivate is owned by each runtime, so a leaked dispose handle

--- a/middleware/src/platform/pluginContext.ts
+++ b/middleware/src/platform/pluginContext.ts
@@ -298,6 +298,14 @@ export function createPluginContext(
         spec,
         handler,
         domain: resolvedDomain,
+        // Slice 2.5 — carry plugin ownership AND a config-reader closure
+        // into the registry so the orchestrator dispatch hook can resolve
+        // `_privacy_mode` / `_privacy_bypass_scopes` for this tool at
+        // dispatch time. `config.get(...)` resolves through the plugin's
+        // own ConfigAccessor chain, so an operator setting saved via the
+        // install UI takes effect on the very next dispatch.
+        agentId,
+        readConfig: (key: string) => config.get(key),
         ...(options?.promptDoc !== undefined
           ? { promptDoc: options.promptDoc }
           : {}),

--- a/middleware/src/plugins/dynamicAgentRuntime.ts
+++ b/middleware/src/plugins/dynamicAgentRuntime.ts
@@ -380,6 +380,11 @@ export class DynamicAgentRuntime {
       description,
       agent: subAgent,
       domain: catalogEntry.plugin.domain,
+      // Slice 2.5 — owning agent plugin id. The orchestrator's privacy
+      // bypass resolver uses this to look up `_privacy_mode` on the
+      // agent for BOTH the domain tool dispatch AND every sub-agent
+      // inner tool call within it.
+      agentId,
     });
 
     // OB-29-1 — publish the DomainTool as a `subAgent:<agentId>` service

--- a/middleware/src/plugins/installService.ts
+++ b/middleware/src/plugins/installService.ts
@@ -1,5 +1,12 @@
 import { randomUUID } from 'node:crypto';
 
+import {
+  PRIVACY_BYPASS_SCOPES_CONFIG_KEY,
+  PRIVACY_MODE_CONFIG_KEY,
+  PRIVACY_MODE_DEFAULT,
+  PRIVACY_MODE_VALUES,
+} from '@omadia/plugin-api';
+
 import type {
   ApiError,
   InstallJob,
@@ -477,7 +484,125 @@ export function extractSetupSchema(
     }
     fields.push(field);
   }
+  // Slice 2.5 — kernel-injected synthetic `_privacy_mode` field. Appears
+  // on every plugin's install form regardless of whether the manifest
+  // declares it. The operator picks how the orchestrator's dispatch hook
+  // should treat raw tool results from this plugin (`guarded` default,
+  // `bypass`, or `per_tool` for the advanced override). The chosen value
+  // lands in `installedRegistry.get(id).config['_privacy_mode']` via the
+  // standard `configure()` validation path and is read back at dispatch
+  // time by the orchestrator's `resolveBypass` resolver.
+  //
+  // Skipped for plugins that contribute no tools — they have nothing to
+  // privacy-route. We approximate "contributes tools" as "any catalog
+  // entry whose manifest has a non-empty `tools` block or whose `kind`
+  // is `tool` / `integration` / `agent`". Channels with kind `channel`
+  // do not contribute LLM-visible tools and skip the field.
+  if (pluginContributesTools(entry)) {
+    fields.push(privacyModeField(entry));
+    // Slice 2.5d — per-tool whitelist for advanced operators. Consulted
+    // by `resolveEffectivePrivacyMode` only when `_privacy_mode = 'per_tool'`;
+    // the resolver tolerates both comma-separated strings (manual entry)
+    // and arrays (programmatic API). Optional string field — operators
+    // using `guarded` or `bypass` simply leave it empty.
+    fields.push(privacyBypassScopesField());
+  }
   return { fields };
+}
+
+function pluginContributesTools(entry: PluginCatalogEntry): boolean {
+  const manifest = entry.manifest as Record<string, unknown> | undefined;
+  if (!manifest) return false;
+  const kind = typeof manifest['kind'] === 'string' ? manifest['kind'] : '';
+  // Channels never expose LLM-callable tools; everything else may. We
+  // err on the inclusive side — adding a guarded-by-default dropdown
+  // to a plugin without tools is harmless (the dispatch hook simply
+  // never consults it). Excluding channels keeps the install UI tidy
+  // for the most common no-tool case.
+  return kind !== 'channel';
+}
+
+function privacyModeField(entry: PluginCatalogEntry): InstallSetupField {
+  const baseHelp =
+    'Wie behandelt der Privacy Shield die Tool-Ergebnisse dieses Plugins? ' +
+    '"Geschützt" (Default) interniert jedes rohe Tool-Ergebnis hinter dem ' +
+    'Privacy Shield v4 — der LLM sieht nur einen identitätsfreien Digest. ' +
+    '"Bypass" reicht rohe Ergebnisse unmaskiert durch (für vertrauenswürdige ' +
+    'interne Quellen, deren Inhalte v4 strukturell nicht sinnvoll digestieren ' +
+    'kann — z.B. Confluence-Seiten-Bodies). "Per-Tool" erlaubt eine ' +
+    'Whitelist einzelner Tools (Advanced).';
+  // Slice 2.5c — Plugin-author recommendation. Optional block on the
+  // manifest (`privacy.recommendation: { mode, reason }`). When present
+  // and the mode is valid, prepend it as a 📌 hint to the help text so
+  // the operator sees the author's intent before choosing. NOT a
+  // constraint — the operator is always free to override.
+  const recommendation = readPrivacyRecommendation(entry);
+  const help = recommendation
+    ? `📌 Plugin-Autor empfiehlt: »${privacyModeLabel(recommendation.mode)}«` +
+      (recommendation.reason ? ` — ${recommendation.reason}` : '') +
+      `\n\n${baseHelp}`
+    : baseHelp;
+  return {
+    key: PRIVACY_MODE_CONFIG_KEY,
+    type: 'enum',
+    label: 'Privacy Mode',
+    required: false,
+    default: PRIVACY_MODE_DEFAULT,
+    help,
+    enum: PRIVACY_MODE_VALUES.map((value) => ({
+      value,
+      label: privacyModeLabel(value),
+    })),
+  };
+}
+
+function readPrivacyRecommendation(
+  entry: PluginCatalogEntry,
+): { mode: (typeof PRIVACY_MODE_VALUES)[number]; reason: string } | undefined {
+  const manifest = entry.manifest as Record<string, unknown> | undefined;
+  if (!manifest) return undefined;
+  const privacy = manifest['privacy'];
+  if (!privacy || typeof privacy !== 'object') return undefined;
+  const rec = (privacy as Record<string, unknown>)['recommendation'];
+  if (!rec || typeof rec !== 'object') return undefined;
+  const mode = (rec as Record<string, unknown>)['mode'];
+  const reason = (rec as Record<string, unknown>)['reason'];
+  if (typeof mode !== 'string') return undefined;
+  if (!(PRIVACY_MODE_VALUES as readonly string[]).includes(mode)) {
+    return undefined;
+  }
+  return {
+    mode: mode as (typeof PRIVACY_MODE_VALUES)[number],
+    reason: typeof reason === 'string' ? reason : '',
+  };
+}
+
+function privacyBypassScopesField(): InstallSetupField {
+  return {
+    key: PRIVACY_BYPASS_SCOPES_CONFIG_KEY,
+    type: 'string',
+    label: 'Bypass-Tool-Whitelist (nur bei Privacy Mode = Per-Tool)',
+    required: false,
+    help:
+      'Komma- oder Leerzeichen-getrennte Liste von Tool-Namen, die bei ' +
+      'Privacy Mode "Per-Tool" unmaskiert durchgelassen werden. Beispiel: ' +
+      '"confluence_get_page, confluence_get_page_by_title". Tools die hier ' +
+      'NICHT stehen bleiben "guarded". Wird ignoriert wenn Privacy Mode auf ' +
+      '"Geschützt" oder "Bypass" steht.',
+  };
+}
+
+function privacyModeLabel(value: string): string {
+  switch (value) {
+    case 'guarded':
+      return 'Geschützt (Default — Privacy Shield v4)';
+    case 'bypass':
+      return 'Bypass (Roh durchlassen — Operator übernimmt Verantwortung)';
+    case 'per_tool':
+      return 'Per-Tool (Advanced — Tool-Whitelist)';
+    default:
+      return value;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/middleware/src/routes/runtime.ts
+++ b/middleware/src/routes/runtime.ts
@@ -67,11 +67,51 @@ export function createRuntimeRouter(deps: RuntimeDeps): Router {
     res.json({ items: rows, total: rows.length });
   });
 
-  // PATCH /installed/:id/config — replaces non-secret config values. Caller
-  // supplies the FULL next config as request body. Secrets stay in the vault
-  // and are not touched here. Some plugins cache config at activate-time; a
-  // restart/re-activate may be needed for those to see the change. The
-  // response echoes the updated entry so the UI can refresh inline.
+  // GET /installed/:id — full entry for ONE installed plugin including
+  // its non-secret `config`. Slice 2.5 — used by the Operator-UI's
+  // Privacy-Mode quick-picker to read the current `_privacy_mode` value
+  // so the dropdown can initialise with the stored selection.
+  router.get('/installed/:id', (req: Request, res: Response) => {
+    const rawId = req.params['id'];
+    const id = typeof rawId === 'string' ? rawId : undefined;
+    if (!id) {
+      res
+        .status(400)
+        .json({ code: 'runtime.invalid_id', message: 'missing id' });
+      return;
+    }
+    const entry = deps.installedRegistry.get(id);
+    if (!entry) {
+      res.status(404).json({
+        code: 'runtime.not_installed',
+        message: `agent '${id}' is not installed`,
+      });
+      return;
+    }
+    res.json({
+      id: entry.id,
+      installed_version: entry.installed_version,
+      installed_at: entry.installed_at,
+      status: entry.status,
+      config: entry.config,
+      activation_failure_count: entry.activation_failure_count ?? 0,
+      last_activation_error: entry.last_activation_error ?? null,
+      last_activation_error_at: entry.last_activation_error_at ?? null,
+    });
+  });
+
+  // PATCH /installed/:id/config — merges into non-secret config values.
+  // Caller supplies a PARTIAL config patch as request body; the patch is
+  // shallow-merged into the existing config (only the keys present in the
+  // body are touched). To explicitly clear a key, send it with `null`.
+  // Secrets stay in the vault and are not touched here. Some plugins cache
+  // config at activate-time; a restart/re-activate may be needed for those
+  // to see the change. The response echoes the updated entry so the UI can
+  // refresh inline.
+  //
+  // Slice 2.5 — Used by the Operator-UI's Privacy-Mode quick-picker on
+  // an installed plugin to send `{ _privacy_mode: 'bypass' }` without
+  // having to round-trip the entire setup_schema.
   router.patch(
     '/installed/:id/config',
     async (req: Request, res: Response) => {
@@ -91,18 +131,27 @@ export function createRuntimeRouter(deps: RuntimeDeps): Router {
         });
         return;
       }
-      if (!deps.installedRegistry.has(id)) {
+      const installed = deps.installedRegistry.get(id);
+      if (!installed) {
         res.status(404).json({
           code: 'runtime.not_installed',
           message: `agent '${id}' is not installed`,
         });
         return;
       }
+      // Shallow merge: existing config + body patch. `null` values clear
+      // the key, anything else overwrites or adds.
+      const patch = body as Record<string, unknown>;
+      const nextConfig: Record<string, unknown> = { ...installed.config };
+      for (const [k, v] of Object.entries(patch)) {
+        if (v === null) {
+          delete nextConfig[k];
+        } else {
+          nextConfig[k] = v;
+        }
+      }
       try {
-        await deps.installedRegistry.updateConfig(
-          id,
-          body as Record<string, unknown>,
-        );
+        await deps.installedRegistry.updateConfig(id, nextConfig);
         if (deps.reactivate) {
           await deps.reactivate(id);
         }

--- a/middleware/test/installServicePrivacyMode.test.ts
+++ b/middleware/test/installServicePrivacyMode.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Slice 2.5 — Verify `extractSetupSchema` auto-injects the synthetic
+ * `_privacy_mode` and `_privacy_bypass_scopes` fields into every
+ * tool-contributing plugin's setup schema, and that a manifest
+ * `privacy.recommendation` block surfaces in the help text.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  PRIVACY_BYPASS_SCOPES_CONFIG_KEY,
+  PRIVACY_MODE_CONFIG_KEY,
+  PRIVACY_MODE_DEFAULT,
+} from '@omadia/plugin-api';
+
+import { extractSetupSchema } from '../src/plugins/installService.js';
+import type { PluginCatalogEntry } from '../src/plugins/manifestLoader.js';
+
+function entry(manifest: Record<string, unknown>): PluginCatalogEntry {
+  // Cast — we only exercise the manifest-reading code paths; the rest
+  // of the catalog-entry shape is irrelevant to `extractSetupSchema`.
+  return { manifest } as unknown as PluginCatalogEntry;
+}
+
+describe('extractSetupSchema — synthetic _privacy_mode field', () => {
+  it('injects _privacy_mode + _privacy_bypass_scopes for integration kind', () => {
+    const schema = extractSetupSchema(
+      entry({
+        kind: 'integration',
+        setup: { fields: [{ key: 'api_key', type: 'secret', label: 'API' }] },
+      }),
+    );
+    assert.ok(schema);
+    const keys = schema.fields.map((f) => f.key);
+    assert.ok(keys.includes('api_key'), 'preserves author-declared fields');
+    assert.ok(keys.includes(PRIVACY_MODE_CONFIG_KEY));
+    assert.ok(keys.includes(PRIVACY_BYPASS_SCOPES_CONFIG_KEY));
+  });
+
+  it('_privacy_mode is enum/guarded-by-default, not required', () => {
+    const schema = extractSetupSchema(entry({ kind: 'tool', setup: { fields: [] } }));
+    assert.ok(schema);
+    const f = schema.fields.find((x) => x.key === PRIVACY_MODE_CONFIG_KEY);
+    assert.ok(f);
+    assert.equal(f.type, 'enum');
+    assert.equal(f.default, PRIVACY_MODE_DEFAULT);
+    assert.equal(f.required, false);
+    const values = (f.enum ?? []).map((o) => o.value);
+    assert.deepEqual(values, ['guarded', 'bypass', 'per_tool']);
+  });
+
+  it('skips injection for channel-kind plugins (no tools)', () => {
+    const schema = extractSetupSchema(
+      entry({ kind: 'channel', setup: { fields: [] } }),
+    );
+    assert.ok(schema);
+    const keys = schema.fields.map((f) => f.key);
+    assert.ok(
+      !keys.includes(PRIVACY_MODE_CONFIG_KEY),
+      'channel plugins have no LLM tools — no privacy field needed',
+    );
+  });
+
+  it('surfaces manifest.privacy.recommendation in the help text', () => {
+    const schema = extractSetupSchema(
+      entry({
+        kind: 'integration',
+        setup: { fields: [] },
+        privacy: {
+          recommendation: {
+            mode: 'bypass',
+            reason: 'Document-shaped bodies; v4 cannot summarize structurally.',
+          },
+        },
+      }),
+    );
+    const f = schema?.fields.find((x) => x.key === PRIVACY_MODE_CONFIG_KEY);
+    assert.ok(f?.help);
+    assert.ok(f.help.includes('📌'), 'help text marks the author recommendation');
+    assert.ok(f.help.includes('Bypass'), 'help text names the recommended mode');
+    assert.ok(
+      f.help.includes('Document-shaped bodies'),
+      'help text includes the author reason',
+    );
+  });
+
+  it('ignores malformed privacy.recommendation gracefully', () => {
+    for (const garbage of [
+      { recommendation: { mode: 'guarded' } }, // missing reason ok
+      { recommendation: { mode: 'INVALID' } }, // bad mode
+      { recommendation: 'not-an-object' },
+      { recommendation: { mode: 42 } },
+    ]) {
+      const schema = extractSetupSchema(
+        entry({ kind: 'integration', setup: { fields: [] }, privacy: garbage }),
+      );
+      const f = schema?.fields.find((x) => x.key === PRIVACY_MODE_CONFIG_KEY);
+      assert.ok(f);
+      // For invalid recommendations the help text falls back to the base
+      // text (no 📌 prefix). For the lone valid `{mode: 'guarded'}` case
+      // a 📌 IS present (mode is a valid value) — assert via mode check.
+      const rec = (garbage as { recommendation?: { mode?: unknown } })
+        .recommendation;
+      const validMode =
+        typeof rec === 'object' &&
+        rec !== null &&
+        typeof rec.mode === 'string' &&
+        ['guarded', 'bypass', 'per_tool'].includes(rec.mode);
+      if (!validMode) {
+        assert.ok(
+          !(f.help ?? '').includes('📌'),
+          'invalid recommendation must not surface as a hint',
+        );
+      }
+    }
+  });
+});

--- a/middleware/test/privacyV4Bypass.test.ts
+++ b/middleware/test/privacyV4Bypass.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Slice 2.5 — Operator-owned per-plugin Privacy Mode tests.
+ *
+ * Covers the contract layer end-to-end:
+ *   - `resolveEffectivePrivacyMode` pure-function semantics (default,
+ *     bypass, per-tool whitelist, org-policy override)
+ *   - `parseScopes` tolerates both array and comma-separated string
+ *   - `PrivacyGuardService.recordBypassedTool` accumulates entries and
+ *     drains them into the receipt at `finalizeTurn`
+ *   - `PrivacyGuardService.finalizeTurn` emits a receipt for bypass-only
+ *     turns (datasetsInterned === 0) — previously short-circuited.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  PRIVACY_FORCE_GUARDED_ENV_VAR,
+  parseScopes,
+  resolveEffectivePrivacyMode,
+} from '@omadia/plugin-api';
+import { createPrivacyGuardService } from '@omadia/plugin-privacy-guard/dist/index.js';
+
+describe('resolveEffectivePrivacyMode', () => {
+  it('defaults to guarded when no mode is stored', () => {
+    const eff = resolveEffectivePrivacyMode({
+      storedMode: undefined,
+      storedScopes: undefined,
+      toolName: 'confluence_search',
+      env: {},
+    });
+    assert.equal(eff, 'guarded');
+  });
+
+  it('honors stored guarded explicitly', () => {
+    assert.equal(
+      resolveEffectivePrivacyMode({
+        storedMode: 'guarded',
+        storedScopes: undefined,
+        toolName: 't',
+        env: {},
+      }),
+      'guarded',
+    );
+  });
+
+  it('honors stored bypass for every tool name', () => {
+    for (const toolName of ['a', 'b', 'confluence_get_page']) {
+      assert.equal(
+        resolveEffectivePrivacyMode({
+          storedMode: 'bypass',
+          storedScopes: undefined,
+          toolName,
+          env: {},
+        }),
+        'bypass',
+      );
+    }
+  });
+
+  it('per_tool: bypass iff tool name is in the array whitelist', () => {
+    const scopes = ['confluence_get_page', 'confluence_get_page_by_title'];
+    assert.equal(
+      resolveEffectivePrivacyMode({
+        storedMode: 'per_tool',
+        storedScopes: scopes,
+        toolName: 'confluence_get_page',
+        env: {},
+      }),
+      'bypass',
+    );
+    assert.equal(
+      resolveEffectivePrivacyMode({
+        storedMode: 'per_tool',
+        storedScopes: scopes,
+        toolName: 'confluence_search',
+        env: {},
+      }),
+      'guarded',
+    );
+  });
+
+  it('per_tool: bypass iff tool name is in the comma-separated string whitelist', () => {
+    const scopes = 'confluence_get_page, confluence_get_page_by_title';
+    assert.equal(
+      resolveEffectivePrivacyMode({
+        storedMode: 'per_tool',
+        storedScopes: scopes,
+        toolName: 'confluence_get_page_by_title',
+        env: {},
+      }),
+      'bypass',
+    );
+    assert.equal(
+      resolveEffectivePrivacyMode({
+        storedMode: 'per_tool',
+        storedScopes: scopes,
+        toolName: 'confluence_search',
+        env: {},
+      }),
+      'guarded',
+    );
+  });
+
+  it('OMADIA_PRIVACY_FORCE_GUARDED overrides bypass back to guarded', () => {
+    assert.equal(
+      resolveEffectivePrivacyMode({
+        storedMode: 'bypass',
+        storedScopes: undefined,
+        toolName: 't',
+        env: { [PRIVACY_FORCE_GUARDED_ENV_VAR]: 'true' },
+      }),
+      'guarded',
+    );
+    assert.equal(
+      resolveEffectivePrivacyMode({
+        storedMode: 'per_tool',
+        storedScopes: ['t'],
+        toolName: 't',
+        env: { [PRIVACY_FORCE_GUARDED_ENV_VAR]: 'true' },
+      }),
+      'guarded',
+    );
+  });
+
+  it('FORCE_GUARDED only triggers on the literal string "true"', () => {
+    for (const v of ['1', 'yes', 'True', 'TRUE', '']) {
+      assert.equal(
+        resolveEffectivePrivacyMode({
+          storedMode: 'bypass',
+          storedScopes: undefined,
+          toolName: 't',
+          env: { [PRIVACY_FORCE_GUARDED_ENV_VAR]: v },
+        }),
+        'bypass',
+        `value "${v}" should NOT force guarded — only literal "true" does`,
+      );
+    }
+  });
+
+  it('falls back to guarded on garbage stored modes', () => {
+    for (const garbage of [42, null, {}, [], 'GUARDED', 'YES']) {
+      assert.equal(
+        resolveEffectivePrivacyMode({
+          storedMode: garbage,
+          storedScopes: undefined,
+          toolName: 't',
+          env: {},
+        }),
+        'guarded',
+      );
+    }
+  });
+});
+
+describe('parseScopes', () => {
+  it('parses an array of strings', () => {
+    assert.deepEqual(parseScopes(['a', 'b']), ['a', 'b']);
+  });
+
+  it('trims and drops empty entries from an array', () => {
+    assert.deepEqual(parseScopes([' a ', '', ' b']), ['a', 'b']);
+  });
+
+  it('splits a comma- and whitespace-separated string', () => {
+    assert.deepEqual(parseScopes('a,b, c   d'), ['a', 'b', 'c', 'd']);
+  });
+
+  it('returns [] for non-array, non-string input', () => {
+    for (const v of [undefined, null, 42, {}, true]) {
+      assert.deepEqual(parseScopes(v), []);
+    }
+  });
+
+  it('returns [] for an empty string', () => {
+    assert.deepEqual(parseScopes(''), []);
+  });
+});
+
+describe('PrivacyGuardService.recordBypassedTool', () => {
+  it('accumulates entries and emits them on finalizeTurn', async () => {
+    const svc = createPrivacyGuardService();
+    const turnId = 't-bypass-1';
+    await svc.recordBypassedTool({
+      turnId,
+      toolName: 'confluence_get_page',
+      pluginId: '@omadia/integration-confluence',
+      reason: 'operator_setting',
+      bytes: 1024,
+    });
+    await svc.recordBypassedTool({
+      turnId,
+      toolName: 'confluence_get_page_by_title',
+      pluginId: '@omadia/integration-confluence',
+      reason: 'operator_setting',
+      bytes: 2048,
+    });
+    const receipt = await svc.finalizeTurn(turnId);
+    assert.ok(receipt, 'bypass-only turn must still emit a receipt');
+    assert.equal(receipt.datasetsInterned, 0);
+    assert.equal(receipt.fieldsMasked, 0);
+    assert.equal(receipt.fieldsCleartext, 0);
+    assert.deepEqual(receipt.verbsExecuted, []);
+    assert.equal(receipt.pseudonymProjectionUsed, false);
+    assert.ok(receipt.bypassedTools);
+    assert.equal(receipt.bypassedTools.length, 2);
+    assert.equal(receipt.bypassedTools[0]?.toolName, 'confluence_get_page');
+    assert.equal(receipt.bypassedTools[0]?.bytes, 1024);
+    assert.equal(receipt.bypassedTools[1]?.bytes, 2048);
+    // PII-free check — the receipt carries no raw values, only metadata.
+    for (const entry of receipt.bypassedTools) {
+      assert.equal(entry.reason, 'operator_setting');
+      assert.equal(typeof entry.toolName, 'string');
+      assert.equal(typeof entry.pluginId, 'string');
+      assert.equal(typeof entry.bytes, 'number');
+    }
+  });
+
+  it('drops bypass state on finalizeTurn (no leakage to next turn)', async () => {
+    const svc = createPrivacyGuardService();
+    await svc.recordBypassedTool({
+      turnId: 't-a',
+      toolName: 't',
+      pluginId: 'p',
+      reason: 'operator_setting',
+      bytes: 1,
+    });
+    await svc.finalizeTurn('t-a');
+    const receipt2 = await svc.finalizeTurn('t-a');
+    assert.equal(receipt2, undefined, 'second finalize of same turn is idempotent');
+  });
+
+  it('co-exists with internToolResultV4: receipt carries both counts and bypassed list', async () => {
+    const svc = createPrivacyGuardService();
+    const turnId = 't-mix';
+    await svc.internToolResultV4({
+      sessionId: 's',
+      turnId,
+      toolName: 'confluence_search',
+      rawResult: JSON.stringify([
+        { id: 1, title: 'OKR' },
+        { id: 2, title: 'Vacation' },
+      ]),
+    });
+    await svc.recordBypassedTool({
+      turnId,
+      toolName: 'confluence_get_page',
+      pluginId: '@omadia/integration-confluence',
+      reason: 'operator_setting',
+      bytes: 8192,
+    });
+    const receipt = await svc.finalizeTurn(turnId);
+    assert.ok(receipt);
+    assert.equal(receipt.datasetsInterned, 1);
+    assert.ok((receipt.bypassedTools ?? []).length === 1);
+  });
+
+  it('returns undefined when a turn neither intern nor bypassed', async () => {
+    const svc = createPrivacyGuardService();
+    const receipt = await svc.finalizeTurn('t-empty');
+    assert.equal(receipt, undefined);
+  });
+});

--- a/web-ui/app/_components/chat/PrivacyReceiptCard.tsx
+++ b/web-ui/app/_components/chat/PrivacyReceiptCard.tsx
@@ -35,11 +35,24 @@ export function PrivacyReceiptCard({
 }: PrivacyReceiptCardProps): React.ReactElement {
   const t = useTranslations('privacyReceipt');
   const verbs = receipt.verbsExecuted;
+  const bypassed = receipt.bypassedTools ?? [];
 
-  // A real identity value the requester named themselves reached the model
-  // → flip the whole card to the red palette.
+  // Palette precedence: identity-breach (red) wins over bypass-warning
+  // (amber) wins over default (emerald). Breach is a transparency notice
+  // the user MUST see; bypass is a conscious operator decision but still
+  // worth highlighting; default is the boring "boundary did its job".
   const breached = (receipt.identityValuesOnWire ?? 0) > 0;
-  const palette = breached ? PALETTE_BREACH : PALETTE_OK;
+  const hasBypass = bypassed.length > 0;
+  const palette = breached
+    ? PALETTE_BREACH
+    : hasBypass
+      ? PALETTE_BYPASS
+      : PALETTE_OK;
+
+  // Which explainer line to show under the facts grid. Bypass explainer
+  // is its own line BELOW the default/breach explainer because they can
+  // co-occur (a turn can both intern AND bypass).
+  const explainerKey = breached ? 'explainerBreach' : 'explainer';
 
   return (
     <details
@@ -96,9 +109,42 @@ export function PrivacyReceiptCard({
             />
           )}
         </dl>
+        {hasBypass && (
+          <div>
+            <div
+              className={[
+                'text-[10px] font-semibold uppercase tracking-wider',
+                palette.label,
+              ].join(' ')}
+            >
+              {t('factBypassed')}
+            </div>
+            <ul className="mt-1 space-y-0.5">
+              {bypassed.map((entry, i) => (
+                <li
+                  key={`${entry.pluginId}-${entry.toolName}-${String(i)}`}
+                  className="font-mono-num flex flex-wrap items-baseline gap-x-2"
+                >
+                  <span className="font-medium">{entry.toolName}</span>
+                  <span className={palette.label}>{entry.pluginId}</span>
+                  <span className={['text-[10px]', palette.label].join(' ')}>
+                    {t('bypassedBytes', {
+                      kb: (entry.bytes / 1024).toFixed(1),
+                    })}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
         <div className={['text-[11px] italic', palette.muted].join(' ')}>
-          {t(breached ? 'explainerBreach' : 'explainer')}
+          {t(explainerKey)}
         </div>
+        {hasBypass && (
+          <div className={['text-[11px] italic', palette.muted].join(' ')}>
+            {t('explainerBypassed')}
+          </div>
+        )}
       </div>
     </details>
   );
@@ -127,6 +173,19 @@ const PALETTE_BREACH = {
   muted: 'text-red-900/80 dark:text-red-200/90',
 } as const;
 
+// Slice 2.5 — operator opted into bypass on at least one plugin this turn.
+// Amber sits between calm-emerald (boundary did its job) and loud-red (real
+// identity reached the model). Bypass is a conscious choice, but the user
+// should still see it loud enough to notice.
+const PALETTE_BYPASS = {
+  container:
+    'bg-amber-50/70 ring-amber-200 dark:bg-amber-950/30 dark:ring-amber-800/60',
+  summary: 'font-medium text-amber-800 dark:text-amber-200',
+  body: 'text-amber-900 dark:text-amber-100',
+  label: 'text-amber-700/80 dark:text-amber-300/80',
+  muted: 'text-amber-900/80 dark:text-amber-200/90',
+} as const;
+
 /**
  * Build the one-line summary shown in the collapsed card. Pure — pass a
  * translator so it stays unit-testable without React. `datasetsInterned` is
@@ -134,9 +193,12 @@ const PALETTE_BREACH = {
  * so the dataset clause always renders.
  */
 export function summarisePrivacyReceipt(r: PrivacyReceipt, t: TFn): string {
-  const parts: string[] = [
-    t('summaryDatasets', { count: r.datasetsInterned }),
-  ];
+  const parts: string[] = [];
+  // Slice 2.5: drop the dataset clause entirely when the turn interned
+  // nothing (pure-bypass turn) — the receipt now also surfaces for those.
+  if (r.datasetsInterned > 0) {
+    parts.push(t('summaryDatasets', { count: r.datasetsInterned }));
+  }
   if (r.fieldsMasked > 0) {
     parts.push(t('summaryMasked', { count: r.fieldsMasked }));
   }
@@ -145,6 +207,10 @@ export function summarisePrivacyReceipt(r: PrivacyReceipt, t: TFn): string {
   }
   if (r.pseudonymProjectionUsed) {
     parts.push(t('summaryPseudonyms'));
+  }
+  const bypassed = r.bypassedTools ?? [];
+  if (bypassed.length > 0) {
+    parts.push(t('summaryBypassed', { count: bypassed.length }));
   }
   const onWire = r.identityValuesOnWire ?? 0;
   if (onWire > 0) {

--- a/web-ui/app/_components/store/InstallButton.tsx
+++ b/web-ui/app/_components/store/InstallButton.tsx
@@ -1,15 +1,17 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { ArrowRight, Check, Loader2, Lock, Trash2 } from 'lucide-react';
+import { ArrowRight, Check, Loader2, Lock, Shield, Trash2 } from 'lucide-react';
 
 import { cn } from '../../_lib/cn';
 import {
   configureInstallJob,
   createInstallJob,
   deleteUploadedPackage,
+  getInstalledPlugin,
   uninstallPlugin,
+  updateInstalledPluginConfig,
   ApiError,
 } from '../../_lib/api';
 import type {
@@ -345,6 +347,15 @@ function InstalledPanel({
         </span>
       </div>
 
+      {/* Slice 2.5 — Privacy-Mode quick-picker. Operator-owned per-plugin
+          setting that decides whether the orchestrator dispatch hook
+          interns raw tool results behind the Privacy Shield v4 boundary
+          (`guarded`, default) or passes them through unmasked (`bypass`).
+          Reconfiguration via the full install form is not yet wired for
+          installed plugins; this dedicated picker covers the single
+          most-actionable setting without a full reconfigure flow. */}
+      <PrivacyModePicker pluginId={pluginId} />
+
       {state.kind === 'idle' && (
         <button
           type="button"
@@ -627,4 +638,162 @@ function tryParseErrorBody(body: string): {
 function safeMessage(body: string): string | null {
   const parsed = tryParseErrorBody(body);
   return parsed?.message ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// PrivacyModePicker — Slice 2.5 quick-picker for the operator-owned
+// `_privacy_mode` setting on an installed plugin. Reads the current value
+// via GET /installed/:id and PATCHes back on change. Optimistic UI: the
+// dropdown reflects the new value immediately, error state rolls back.
+// ---------------------------------------------------------------------------
+
+type PrivacyMode = 'guarded' | 'bypass' | 'per_tool';
+
+const PRIVACY_MODE_LABELS: Record<PrivacyMode, string> = {
+  guarded: 'Geschützt (Privacy Shield)',
+  bypass: 'Bypass (roh durchlassen)',
+  per_tool: 'Per-Tool (Whitelist)',
+};
+
+function isPrivacyMode(v: unknown): v is PrivacyMode {
+  return v === 'guarded' || v === 'bypass' || v === 'per_tool';
+}
+
+function PrivacyModePicker({
+  pluginId,
+}: {
+  pluginId: string;
+}): React.ReactElement | null {
+  // `null` initial state → "loading". Once loaded we know what mode the
+  // backend currently has stored (default 'guarded' when unset).
+  const [mode, setMode] = useState<PrivacyMode | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Tracks whether the GET succeeded at all — without it we render
+  // nothing rather than a confusing dropdown over nothing.
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const entry = await getInstalledPlugin(pluginId);
+        if (cancelled) return;
+        const current = entry.config['_privacy_mode'];
+        setMode(isPrivacyMode(current) ? current : 'guarded');
+        setLoaded(true);
+      } catch (err) {
+        if (cancelled) return;
+        const msg =
+          err instanceof ApiError
+            ? safeMessage(err.body) ?? err.message
+            : err instanceof Error
+              ? err.message
+              : String(err);
+        setError(msg);
+        setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [pluginId]);
+
+  async function handleChange(next: PrivacyMode): Promise<void> {
+    const previous = mode;
+    setMode(next);
+    setSaving(true);
+    setError(null);
+    try {
+      await updateInstalledPluginConfig(pluginId, { _privacy_mode: next });
+    } catch (err) {
+      // Roll back to the previous value so the dropdown reflects what
+      // the backend actually has stored.
+      setMode(previous);
+      const msg =
+        err instanceof ApiError
+          ? safeMessage(err.body) ?? err.message
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      setError(msg);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!loaded) {
+    return (
+      <div className="rounded-[10px] border border-[color:var(--border)] bg-[color:var(--bg-soft)] px-3 py-2.5">
+        <div className="flex items-center gap-2 text-[11px] text-[color:var(--fg-subtle)]">
+          <Loader2 className="size-3.5 animate-spin" aria-hidden />
+          Privacy-Mode wird geladen …
+        </div>
+      </div>
+    );
+  }
+  if (mode === null) {
+    return (
+      <div className="rounded-[10px] border border-[color:var(--danger,#b03030)]/40 bg-[color:var(--danger,#b03030)]/5 px-3 py-2">
+        <p className="text-[12px] text-[color:var(--danger,#b03030)]">
+          Privacy-Mode konnte nicht geladen werden{error ? `: ${error}` : '.'}
+        </p>
+      </div>
+    );
+  }
+
+  const tone =
+    mode === 'bypass'
+      ? 'border-amber-300 bg-amber-50/50 dark:border-amber-800/60 dark:bg-amber-950/20'
+      : 'border-[color:var(--border)] bg-[color:var(--bg-soft)]';
+
+  return (
+    <div className={cn('rounded-[10px] border px-3 py-2.5', tone)}>
+      <label
+        htmlFor={`privacy-mode-${pluginId}`}
+        className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)]"
+      >
+        <Shield className="size-3.5" aria-hidden />
+        Privacy Mode
+      </label>
+      <select
+        id={`privacy-mode-${pluginId}`}
+        value={mode}
+        disabled={saving}
+        onChange={(e) => void handleChange(e.target.value as PrivacyMode)}
+        className={cn(
+          'mt-1.5 w-full rounded border px-2 py-1.5 text-[13px]',
+          'border-[color:var(--border)] bg-[color:var(--bg)]',
+          'focus:outline-none focus:ring-1 focus:ring-[color:var(--accent)]',
+          saving ? 'opacity-60' : '',
+        )}
+      >
+        {(Object.entries(PRIVACY_MODE_LABELS) as Array<[PrivacyMode, string]>).map(
+          ([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ),
+        )}
+      </select>
+      <p className="mt-1.5 text-[11px] leading-relaxed text-[color:var(--fg-subtle)]">
+        {mode === 'guarded'
+          ? 'Tool-Ergebnisse werden serverseitig hinter dem Privacy Shield v4 maskiert; der LLM sieht nur identitätsfreie Digests.'
+          : mode === 'bypass'
+            ? 'Rohe Tool-Ergebnisse erreichen den LLM unmaskiert. Geeignet für vertrauenswürdige interne Quellen, deren Inhalte der Privacy Shield strukturell nicht digestieren kann (z. B. Confluence-Seiten-Bodies).'
+            : 'Per-Tool-Whitelist: nur explizit gelistete Tools werden bypassed. Liste über das Feld `_privacy_bypass_scopes` setzen (Komma-getrennt).'}
+      </p>
+      {saving && (
+        <div className="mt-1.5 flex items-center gap-1.5 text-[11px] text-[color:var(--fg-subtle)]">
+          <Loader2 className="size-3 animate-spin" aria-hidden />
+          Speichere …
+        </div>
+      )}
+      {error && (
+        <p className="font-mono-num mt-1.5 text-[11px] text-[color:var(--danger,#b03030)]">
+          {error}
+        </p>
+      )}
+    </div>
+  );
 }

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -288,6 +288,74 @@ export async function cancelInstallJob(jobId: string): Promise<void> {
  * (DomainTool wird aus dem Orchestrator entfernt, handle.close() läuft),
  * purgt den Vault-Namespace und entfernt den Registry-Eintrag. 204 = OK.
  */
+/**
+ * Slice 2.5 — GET full installed-plugin entry including its non-secret
+ * config. Used by the Operator-UI's Privacy-Mode quick-picker on the
+ * plugin detail page to read the current `_privacy_mode` so the dropdown
+ * can initialise with the stored value.
+ */
+export interface InstalledPluginDetail {
+  id: string;
+  installed_version: string;
+  installed_at: string;
+  status: string;
+  config: Record<string, unknown>;
+  activation_failure_count: number;
+  last_activation_error: string | null;
+  last_activation_error_at: string | null;
+}
+
+export async function getInstalledPlugin(
+  pluginId: string,
+): Promise<InstalledPluginDetail> {
+  return getJson<InstalledPluginDetail>(
+    `/v1/admin/runtime/installed/${encodeURIComponent(pluginId)}`,
+  );
+}
+
+/**
+ * Slice 2.5 — PATCH the non-secret config of an installed plugin.
+ * Shallow-merges the patch into the existing config: only keys in `patch`
+ * are touched, `null` clears a key. Secrets stay in the vault. Used by
+ * the Privacy-Mode quick-picker to send `{ _privacy_mode: 'bypass' }`
+ * without round-tripping the entire setup_schema.
+ */
+export async function updateInstalledPluginConfig(
+  pluginId: string,
+  patch: Record<string, unknown>,
+): Promise<{
+  updated: { id: string; config: Record<string, unknown>; status: string } | null;
+}> {
+  const forwarded = await forwardCookieHeader();
+  const res = await fetch(
+    botApi(
+      `/v1/admin/runtime/installed/${encodeURIComponent(pluginId)}/config`,
+    ),
+    {
+      method: 'PATCH',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+        ...forwarded,
+      },
+      credentials: 'include',
+      cache: 'no-store',
+      body: JSON.stringify(patch),
+    },
+  );
+  if (res.ok) {
+    return (await res.json()) as {
+      updated: { id: string; config: Record<string, unknown>; status: string } | null;
+    };
+  }
+  const text = await res.text().catch(() => '');
+  throw new ApiError(
+    res.status,
+    `PATCH installed/${pluginId}/config failed: ${res.status}`,
+    text,
+  );
+}
+
 export async function uninstallPlugin(pluginId: string): Promise<void> {
   const forwarded = await forwardCookieHeader();
   const res = await fetch(

--- a/web-ui/app/_lib/chatSessions.ts
+++ b/web-ui/app/_lib/chatSessions.ts
@@ -141,6 +141,21 @@ export interface PrivacyReceipt {
    * `0` / absent when the user named no one.
    */
   identityValuesOnWire?: number;
+  /**
+   * Slice 2.5 — tools whose raw results bypassed the data-plane boundary
+   * this turn (operator set the originating plugin's `_privacy_mode` to
+   * `bypass`). Surfaced as a dedicated "not masked" section in the card.
+   * Absent / empty when no bypass fired. PII-free.
+   */
+  bypassedTools?: readonly BypassedToolEntry[];
+}
+
+/** Slice 2.5 — one entry in `PrivacyReceipt.bypassedTools`. */
+export interface BypassedToolEntry {
+  toolName: string;
+  pluginId: string;
+  reason: 'operator_setting';
+  bytes: number;
 }
 
 /**

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -256,7 +256,12 @@
     "pseudonymYes": "verwendet",
     "pseudonymNo": "nicht verwendet",
     "explainer": "Rohe Tool-Ergebnisse blieben server-seitig hinter der Data-Plane-Boundary — das Modell sah nur einen identitätsfreien Digest.",
-    "explainerBreach": "Du hast eine Person namentlich genannt — dieser Name ging im Klartext an das Modell. Die aus den Tools geholten Daten blieben server-seitig hinter der Boundary."
+    "explainerBreach": "Du hast eine Person namentlich genannt — dieser Name ging im Klartext an das Modell. Die aus den Tools geholten Daten blieben server-seitig hinter der Boundary.",
+    "summaryBypassed": "{count, plural, one {# Tool nicht maskiert} other {# Tools nicht maskiert}}",
+    "factBypassed": "Nicht maskiert (Operator-Entscheidung)",
+    "bypassedReasonOperatorSetting": "Operator-Setting: Bypass",
+    "bypassedBytes": "{kb} KB roh",
+    "explainerBypassed": "Der Operator hat für mindestens ein Plugin den Privacy-Mode auf »Bypass« gestellt — dessen Tool-Ergebnisse erreichten das Modell unmaskiert. Eingesetzt für vertrauenswürdige interne Quellen, deren Inhalte der Privacy Shield strukturell nicht sinnvoll digestieren kann."
   },
   "privacyOperator": {
     "eyebrow": "Privacy Operator",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -256,7 +256,12 @@
     "pseudonymYes": "used",
     "pseudonymNo": "not used",
     "explainer": "Raw tool results stayed server-side behind the data-plane boundary — the model only ever saw an identity-free digest.",
-    "explainerBreach": "You named a person in your request — that name reached the model in cleartext. The data fetched from tools stayed server-side behind the boundary."
+    "explainerBreach": "You named a person in your request — that name reached the model in cleartext. The data fetched from tools stayed server-side behind the boundary.",
+    "summaryBypassed": "{count, plural, one {# tool not masked} other {# tools not masked}}",
+    "factBypassed": "Not masked (operator decision)",
+    "bypassedReasonOperatorSetting": "Operator setting: bypass",
+    "bypassedBytes": "{kb} KB raw",
+    "explainerBypassed": "The operator set Privacy Mode to »Bypass« for at least one plugin — its tool results reached the model unmasked. Used for trusted internal sources whose content the Privacy Shield cannot usefully digest structurally."
   },
   "privacyOperator": {
     "eyebrow": "Privacy Operator",


### PR DESCRIPTION
## Summary

Operator-owned per-plugin Privacy Mode setting. Lets operators flip a plugin between `guarded` (default — Privacy Shield v4 interns raw tool results behind the data-plane boundary), `bypass` (raw passthrough — for trusted internal sources whose shape v4 can't usefully digest), or `per_tool` (whitelist).

**Motivation:** Confluence-page bodies are document-shaped — v4 deny-by-defaults them to `sensitive-masked` and the sub-agent only ever sees `[masked]`, producing link-list answers instead of inhalt-driven syntheses. Operator needs a per-plugin override.

## What's covered

- **Generic across all plugins** — kernel auto-injects `_privacy_mode` enum field via `extractSetupSchema` for every non-channel plugin
- **3-tier bypass resolver** in orchestrator:
  1. Kernel tools (NativeToolRegistry per-tool closure)
  2. Domain tools (`DomainTool.agentId`)
  3. Sub-agent inner tools (`turnContext.subAgentOwnerPluginId`)
- **UI quick-picker** on each installed plugin's detail page (PATCH /installed/:id/config now merge-semantics)
- **PrivacyReceiptCard** gets amber "Nicht maskiert" section with per-bypassed-tool entries
- **Org-policy override**: `OMADIA_PRIVACY_FORCE_GUARDED=true`
- **Manifest hint**: `privacy.recommendation: { mode, reason }` surfaces as 📌 in dropdown help
- **i18n** DE + EN

## Deferred

- **Slice 2.5e** PII-classifier-active masking — requires inverting deny-by-default shape classifier; own design slice
- **Per-tool conditional UI** (show scope field only when mode=per_tool); today both fields always visible with help text

## Test plan

- [x] Unit tests: `privacyV4Bypass.test.ts` (17 cases) + `installServicePrivacyMode.test.ts` (5 cases)
- [x] Full v4 regression: 125/125 existing privacy tests pass
- [x] Typecheck + lint clean
- [x] Deployed to fly: `odoo-bot-middleware` + `odoo-bot-harness`
- [ ] Manual smoke-test: Confluence with bypass → inhaltliche Synthese (not link list)
- [ ] Receipt-card shows amber bypass section