### PR TITLE
fix(builder): show ask_user_choice pick as user-message in transcript

### DIFF
--- a/web-ui/app/store/builder/[id]/_components/BuilderChatPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/BuilderChatPane.tsx
@@ -476,7 +476,25 @@ export function BuilderChatPane({
   const onChooseUserChoice = useCallback(
     async (value: string) => {
       if (!pendingUserChoice || choiceSubmitting) return;
-      const { choiceId } = pendingUserChoice;
+      const { choiceId, options } = pendingUserChoice;
+      // Surface the operator's pick as a user chat-message so the
+      // transcript shows what they answered — the resolver does NOT fire
+      // a `chat_message` event back (the choice goes through the tool
+      // Promise, not a fresh turn), so the optimistic insert is the
+      // only way to keep the conversation readable. Prefer the option's
+      // label over the raw value so the transcript reads naturally.
+      const picked = options.find((o) => o.value === value);
+      const transcriptText = picked?.label ?? value;
+      setItems((prev) => [
+        ...prev,
+        {
+          kind: 'message',
+          key: nextKey('msg'),
+          role: 'user',
+          text: transcriptText,
+          ts: Date.now(),
+        },
+      ]);
       setChoiceSubmitting(true);
       setError(null);
       onUserChoiceResolved?.();
@@ -494,7 +512,13 @@ export function BuilderChatPane({
         setChoiceSubmitting(false);
       }
     },
-    [pendingUserChoice, choiceSubmitting, draftId, onUserChoiceResolved],
+    [
+      pendingUserChoice,
+      choiceSubmitting,
+      draftId,
+      nextKey,
+      onUserChoiceResolved,
+    ],
   );
 
   return (


### PR DESCRIPTION
Follow-up to #152. After the operator clicked a Smart-Card option, the choice resolved silently — the POST to /drafts/:id/user-choice/:choiceId went through, the Builder turn continued, but the transcript never recorded what the operator answered. Hard to follow the conversation in retrospect.

The resolver does not fire a chat_message event back (value travels through the tool Promise, not a fresh user turn), so an optimistic insert in onChooseUserChoice is the only way to keep the transcript readable. Prefer the option's label over the raw value so the transcript reads naturally.

PreviewChatPane already does this implicitly (its onChoose calls onSend(value) which emits a chat_message:user event server-side).

Test plan: tsc clean, eslint 0 errors, live click-through verifies option label appears as user-bubble above the next agent response.