### PR TITLE
feat(auth): OB-61 — collect Anthropic key in /setup wizard, drop ENV requirement

### DIFF
--- a/middleware/.env.example
+++ b/middleware/.env.example
@@ -7,8 +7,16 @@
 # the admin UI's plugin setup form — NOT here.
 # ----------------------------------------------------------------------------
 
-# --- Anthropic SDK (REQUIRED) -----------------------------------------------
-ANTHROPIC_API_KEY=sk-ant-...
+# --- Anthropic SDK (OPTIONAL — see /setup wizard) ---------------------------
+# Since OB-61 the Anthropic key is collected through the first-user setup
+# wizard on first boot and stored encrypted in the per-plugin vault (one
+# slot each for orchestrator, orchestrator-extras, verifier). The ENV var
+# below is still honoured for backwards compatibility — when set on a
+# cold boot, the bootstrap migrates it into the vault and then ignores it
+# on subsequent boots. New deployments should leave this blank and run
+# /setup instead. Rotate later via Admin → Runtime → Secrets (not via
+# fly secrets).
+# ANTHROPIC_API_KEY=sk-ant-...
 ORCHESTRATOR_MODEL=claude-opus-4-7
 ORCHESTRATOR_MAX_TOKENS=4096
 

--- a/middleware/src/config.ts
+++ b/middleware/src/config.ts
@@ -12,8 +12,13 @@ dotenv.config({ path: path.resolve(here, '..', '.env'), override: true });
 const ConfigSchema = z.object({
   PORT: z.coerce.number().int().positive().default(3979),
 
-  // Anthropic SDK
-  ANTHROPIC_API_KEY: z.string().min(1, 'ANTHROPIC_API_KEY is required'),
+  // Anthropic SDK — optional since OB-61: the operator can supply the key
+  // through the /setup wizard on first boot (vault-stored per plugin), so
+  // an empty ENV is now a valid state. When unset AND the vault has no key
+  // either, the orchestrator + verifier + orchestrator-extras plugins
+  // register but their LLM-bound capabilities stay unpublished until the
+  // operator runs /setup or PATCHes a key via /api/v1/admin/runtime/secrets.
+  ANTHROPIC_API_KEY: z.string().optional(),
   ORCHESTRATOR_MODEL: z.string().min(1).default('claude-opus-4-7'),
   ORCHESTRATOR_MAX_TOKENS: z.coerce.number().int().positive().default(4096),
 

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -249,8 +249,16 @@ async function main(): Promise<void> {
   // exponential backoff. The SDK default is 2; bumped to 5 so a transient
   // `overloaded_error` (HTTP 529) burst is far more likely to ride out
   // inside the SDK instead of surfacing as a failed turn.
+  //
+  // OB-61: apiKey may be empty when the operator boots without ENV and
+  // hasn't completed /setup yet. The orchestrator + verifier + extras
+  // plugins each build their own per-plugin client from the vault, so
+  // the path that would actually hit this shared client (LocalSubAgent
+  // inner calls / Teams) is only reachable AFTER the orchestrator has
+  // activated — which in turn requires the key. Falling back to '' here
+  // keeps the SDK constructor happy on cold boots.
   const client = new Anthropic({
-    apiKey: config.ANTHROPIC_API_KEY,
+    apiKey: config.ANTHROPIC_API_KEY ?? '',
     maxRetries: 5,
   });
 
@@ -1358,6 +1366,17 @@ async function main(): Promise<void> {
         publicBaseUrl: config.PUBLIC_BASE_URL,
         defaultReturnPath: config.AUTH_DEFAULT_RETURN_PATH,
         setupAllowed: bootstrapResult.setupRequired,
+        // OB-61 — /setup wizard seeds the operator-supplied
+        // `anthropic_api_key` into each consumer plugin's vault and
+        // reactivates the plugin so the LLM-bound capabilities go live
+        // without a server restart.
+        vault: secretVault,
+        reactivate: (agentId) => installService.reactivate(agentId),
+        anthropicKeyConsumers: [
+          '@omadia/orchestrator',
+          '@omadia/orchestrator-extras',
+          '@omadia/verifier',
+        ],
         // Slice 1b-channel-web — on each login (local + entra), resolve
         // (or create) the KG User-Cluster + ChannelIdentity and cache
         // the omadiaUserId in the session JWT so chat ingest can skip

--- a/middleware/src/routes/auth.ts
+++ b/middleware/src/routes/auth.ts
@@ -16,6 +16,7 @@ import type { ProviderRegistry } from '../auth/providerRegistry.js';
 import { SESSION_COOKIE } from '../auth/requireAuth.js';
 import { signSession } from '../auth/sessionJwt.js';
 import type { UserStore } from '../auth/userStore.js';
+import type { SecretVault } from '../secrets/vault.js';
 
 interface AuthDeps {
   registry: ProviderRegistry;
@@ -51,6 +52,32 @@ interface AuthDeps {
     email: string;
     displayName: string;
   }) => Promise<string | undefined>;
+  /**
+   * OB-61 — per-plugin secret vault. The /setup wizard writes the
+   * operator-supplied `anthropic_api_key` here for every plugin in
+   * `anthropicKeyConsumers` so the orchestrator/verifier/extras plugins
+   * pick it up on the next activate(). Optional so existing test wiring
+   * without a vault keeps compiling — the wizard then simply skips the
+   * key-seed step and behaves like before.
+   */
+  vault?: SecretVault;
+  /**
+   * OB-61 — plugin re-activation hook (wired to
+   * `installService.reactivate`). Called once per consumer after the
+   * vault write so the operator does NOT have to restart the server to
+   * pick up the freshly-seeded key. No-op when the plugin is not yet
+   * registered (e.g. catalog miss on cold boot).
+   */
+  reactivate?: (agentId: string) => Promise<void>;
+  /**
+   * OB-61 — list of plugin IDs that should receive the
+   * `anthropic_api_key` vault write on /setup. Kept as an explicit
+   * dependency rather than hardcoding bootstrap.ts constants so the
+   * wiring stays inspectable from this router file alone. Expected
+   * values: `@omadia/orchestrator`, `@omadia/orchestrator-extras`,
+   * `@omadia/verifier`.
+   */
+  anthropicKeyConsumers?: readonly string[];
 }
 
 const PKCE_COOKIE = 'harness_auth_pkce';
@@ -347,12 +374,17 @@ export function createAuthRouter(deps: AuthDeps): Router {
       email?: unknown;
       password?: unknown;
       display_name?: unknown;
+      anthropic_api_key?: unknown;
     };
     const email =
       typeof body.email === 'string' ? body.email.trim() : '';
     const password = typeof body.password === 'string' ? body.password : '';
     const displayName =
       typeof body.display_name === 'string' ? body.display_name.trim() : '';
+    const anthropicApiKey =
+      typeof body.anthropic_api_key === 'string'
+        ? body.anthropic_api_key.trim()
+        : '';
 
     if (email.length === 0 || !email.includes('@')) {
       res.status(400).json({ code: 'auth.setup_invalid_email' });
@@ -361,6 +393,30 @@ export function createAuthRouter(deps: AuthDeps): Router {
     if (password.length < 8) {
       res.status(400).json({ code: 'auth.setup_password_too_short' });
       return;
+    }
+
+    // OB-61: validate the Anthropic key *before* persisting any state.
+    // Skipping when empty keeps the wizard usable for operators who plan
+    // to add the key later through /admin/runtime/secrets — the
+    // orchestrator/verifier capabilities simply stay unpublished until
+    // they do.
+    if (anthropicApiKey.length > 0) {
+      if (!anthropicApiKey.startsWith('sk-ant-')) {
+        res.status(400).json({
+          code: 'auth.setup_invalid_anthropic_key',
+          message:
+            'Anthropic API keys start with "sk-ant-". Double-check the value from console.anthropic.com.',
+        });
+        return;
+      }
+      const pingError = await validateAnthropicKey(anthropicApiKey);
+      if (pingError) {
+        res.status(400).json({
+          code: 'auth.setup_anthropic_key_rejected',
+          message: pingError,
+        });
+        return;
+      }
     }
 
     const passwordHash = await hashPassword(password);
@@ -372,6 +428,30 @@ export function createAuthRouter(deps: AuthDeps): Router {
       displayName: displayName.length > 0 ? displayName : email,
       role: 'admin',
     });
+
+    // OB-61: seed the validated key into every consumer plugin's vault,
+    // then reactivate each so the plugin picks it up without a server
+    // restart. Failure to write/reactivate one plugin is logged but does
+    // NOT roll back the user creation — the operator can re-seed via
+    // /admin/runtime/secrets, but they MUST be able to log in afterwards.
+    if (anthropicApiKey.length > 0 && deps.vault) {
+      const consumers = deps.anthropicKeyConsumers ?? [];
+      for (const agentId of consumers) {
+        try {
+          await deps.vault.setMany(agentId, {
+            anthropic_api_key: anthropicApiKey,
+          });
+          if (deps.reactivate) {
+            await deps.reactivate(agentId);
+          }
+        } catch (err) {
+          console.error(
+            `[auth] /setup: failed to seed anthropic_api_key for ${agentId}:`,
+            err instanceof Error ? err.message : err,
+          );
+        }
+      }
+    }
 
     // Auto-login the freshly-created admin so the operator lands inside the
     // UI without a second round-trip. Mirrors the password-login cookie.
@@ -445,6 +525,43 @@ function sanitiseReturnPath(value: string | undefined): string | null {
   if (!value.startsWith('/') || value.startsWith('//')) return null;
   if (value.includes('\n') || value.includes('\r')) return null;
   return value;
+}
+
+/**
+ * OB-61 — minimal authenticity-check for an Anthropic API key. We hit
+ * GET /v1/models (free, no token cost) and treat a 200 as "key works".
+ * 401/403 → human-readable "rejected" error. Network failure → we let
+ * the wizard proceed but warn in the log; the operator can re-seed
+ * later. Returns null on success, otherwise a user-facing message.
+ */
+async function validateAnthropicKey(apiKey: string): Promise<string | null> {
+  try {
+    const res = await fetch('https://api.anthropic.com/v1/models', {
+      method: 'GET',
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (res.ok) return null;
+    if (res.status === 401 || res.status === 403) {
+      return 'Anthropic rejected this API key (401/403). Verify the value at console.anthropic.com → API keys.';
+    }
+    // Anything else (5xx, rate-limit, anthropic outage) is not the
+    // operator's fault — accept the key and let the orchestrator surface
+    // any later failure through its existing error path.
+    console.warn(
+      `[auth] /setup: anthropic key-ping returned ${res.status}, accepting key anyway`,
+    );
+    return null;
+  } catch (err) {
+    console.warn(
+      '[auth] /setup: anthropic key-ping network error, accepting key anyway:',
+      err instanceof Error ? err.message : err,
+    );
+    return null;
+  }
 }
 
 function httpForAuthErrorCode(code: string): number {

--- a/middleware/test/auth/setupRoute.test.ts
+++ b/middleware/test/auth/setupRoute.test.ts
@@ -1,0 +1,337 @@
+import { strict as assert } from 'node:assert';
+import type { AddressInfo } from 'node:net';
+import { after, before, describe, it } from 'node:test';
+
+import express from 'express';
+
+import { LocalPasswordProvider } from '../../src/auth/providers/LocalPasswordProvider.js';
+import { ProviderRegistry } from '../../src/auth/providerRegistry.js';
+import { createAuthRouter } from '../../src/routes/auth.js';
+import type {
+  CreateUserInput,
+  UserRecord,
+  UserStore,
+} from '../../src/auth/userStore.js';
+import type { SecretVault } from '../../src/secrets/vault.js';
+
+/**
+ * OB-61 — /api/v1/auth/setup integration test. Drives the route via
+ * real Express + fetch and asserts:
+ *
+ *   1. Anthropic key (when supplied + validated) is seeded into all
+ *      consumer plugin vaults via vault.setMany(agentId, …).
+ *   2. installService.reactivate(agentId) is invoked once per consumer
+ *      so the freshly-seeded key takes effect without a server restart.
+ *   3. Setup-without-key still succeeds (admin user is created, no
+ *      vault writes happen, no reactivate calls fire).
+ *   4. Invalid key format (no "sk-ant-" prefix) → 400, no user created,
+ *      no vault touched.
+ *
+ * Live network-call to api.anthropic.com is shimmed by monkey-patching
+ * `globalThis.fetch` for the duration of each test — keeps the suite
+ * hermetic and CI-safe.
+ */
+
+// ─── In-memory test doubles ────────────────────────────────────────────────
+
+class InMemoryUserStore implements Pick<UserStore, 'count' | 'create' | 'markLoginNow' | 'findByProviderUserId'> {
+  rows: Array<UserRecord & { passwordHash: string | null }> = [];
+
+  async count(): Promise<number> {
+    return this.rows.length;
+  }
+
+  async create(input: CreateUserInput): Promise<UserRecord> {
+    const id = `mock-${this.rows.length + 1}`;
+    const now = new Date();
+    const row: UserRecord & { passwordHash: string | null } = {
+      id,
+      email: input.email,
+      provider: input.provider,
+      providerUserId: input.providerUserId,
+      passwordHash: input.passwordHash ?? null,
+      displayName: input.displayName ?? '',
+      role: input.role ?? 'admin',
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+      lastLoginAt: null,
+    };
+    this.rows.push(row);
+    return { ...row, passwordHash: row.passwordHash ?? undefined };
+  }
+
+  async markLoginNow(_id: string): Promise<void> {
+    // Test stub — the route fire-and-forgets, return is irrelevant.
+  }
+
+  async findByProviderUserId(
+    _provider: string,
+    _providerUserId: string,
+  ): Promise<UserRecord | null> {
+    return null;
+  }
+}
+
+class InMemoryVault implements SecretVault {
+  writes: Array<{ agentId: string; entries: Record<string, string> }> = [];
+  store = new Map<string, Map<string, string>>();
+
+  async set(agentId: string, key: string, value: string): Promise<void> {
+    this.setManyInternal(agentId, { [key]: value });
+  }
+
+  async setMany(agentId: string, entries: Record<string, string>): Promise<void> {
+    this.writes.push({ agentId, entries: { ...entries } });
+    this.setManyInternal(agentId, entries);
+  }
+
+  async get(agentId: string, key: string): Promise<string | undefined> {
+    return this.store.get(agentId)?.get(key);
+  }
+
+  async listKeys(agentId: string): Promise<string[]> {
+    return Array.from(this.store.get(agentId)?.keys() ?? []);
+  }
+
+  async purge(agentId: string): Promise<void> {
+    this.store.delete(agentId);
+  }
+
+  async deleteKey(agentId: string, key: string): Promise<void> {
+    this.store.get(agentId)?.delete(key);
+  }
+
+  private setManyInternal(agentId: string, entries: Record<string, string>): void {
+    let bucket = this.store.get(agentId);
+    if (!bucket) {
+      bucket = new Map<string, string>();
+      this.store.set(agentId, bucket);
+    }
+    for (const [k, v] of Object.entries(entries)) {
+      bucket.set(k, v);
+    }
+  }
+}
+
+// ─── Server harness ────────────────────────────────────────────────────────
+
+interface Harness {
+  baseUrl: string;
+  close: () => Promise<void>;
+  store: InMemoryUserStore;
+  vault: InMemoryVault;
+  reactivateCalls: string[];
+  restoreFetch: () => void;
+}
+
+async function startHarness(opts: {
+  /** When provided, the stubbed fetch returns this status for the
+   *  `/v1/models` ping — defaults to 200 (key accepted). */
+  anthropicPingStatus?: number;
+}): Promise<Harness> {
+  const store = new InMemoryUserStore();
+  const vault = new InMemoryVault();
+  const reactivateCalls: string[] = [];
+
+  const registry = new ProviderRegistry();
+  registry.replaceActive([
+    new LocalPasswordProvider(store as unknown as UserStore),
+  ]);
+
+  // Random 32-byte HMAC key — the test never re-validates the cookie so
+  // the actual value doesn't matter; just needs to be the right shape.
+  const signingKey = new Uint8Array(32);
+  for (let i = 0; i < signingKey.length; i += 1) signingKey[i] = i + 1;
+
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/api/v1/auth',
+    createAuthRouter({
+      registry,
+      userStore: store as unknown as UserStore,
+      signingKey,
+      publicBaseUrl: 'http://localhost',
+      defaultReturnPath: '/',
+      setupAllowed: true,
+      vault,
+      reactivate: async (agentId: string) => {
+        reactivateCalls.push(agentId);
+      },
+      anthropicKeyConsumers: [
+        '@omadia/orchestrator',
+        '@omadia/orchestrator-extras',
+        '@omadia/verifier',
+      ],
+    }),
+  );
+
+  // Monkey-patch fetch so the validateAnthropicKey helper's external
+  // call is intercepted. Falls through to any non-anthropic URLs (none
+  // expected, but safe).
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.includes('api.anthropic.com')) {
+      const status = opts.anthropicPingStatus ?? 200;
+      return new Response('', { status });
+    }
+    return originalFetch(input as RequestInfo, init);
+  }) as typeof fetch;
+
+  const server = app.listen(0);
+  await new Promise<void>((resolve) => server.once('listening', () => resolve()));
+  const port = (server.address() as AddressInfo).port;
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+    store,
+    vault,
+    reactivateCalls,
+    restoreFetch: () => {
+      globalThis.fetch = originalFetch;
+    },
+  };
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+describe('POST /api/v1/auth/setup (OB-61)', () => {
+  let h: Harness;
+
+  before(async () => {
+    h = await startHarness({ anthropicPingStatus: 200 });
+  });
+
+  after(async () => {
+    h.restoreFetch();
+    await h.close();
+  });
+
+  it('seeds anthropic_api_key into all consumer vaults and reactivates each', async () => {
+    const res = await fetch(`${h.baseUrl}/api/v1/auth/setup`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        email: 'admin@example.com',
+        password: 'pw-with-12-chars',
+        anthropic_api_key: 'sk-ant-api03-validlooking-key',
+      }),
+    });
+    assert.equal(res.status, 200, await res.text());
+
+    // User created
+    assert.equal(h.store.rows.length, 1);
+    assert.equal(h.store.rows[0].email, 'admin@example.com');
+
+    // Vault writes — exactly 3, one per consumer, all with the same key
+    const writes = h.vault.writes;
+    assert.equal(writes.length, 3, `expected 3 vault writes, got ${writes.length}`);
+    const agentIds = writes.map((w) => w.agentId).sort();
+    assert.deepEqual(agentIds, [
+      '@omadia/orchestrator',
+      '@omadia/orchestrator-extras',
+      '@omadia/verifier',
+    ]);
+    for (const w of writes) {
+      assert.equal(w.entries['anthropic_api_key'], 'sk-ant-api03-validlooking-key');
+    }
+
+    // Reactivate fired once per consumer, in the same order
+    assert.deepEqual(h.reactivateCalls.sort(), [
+      '@omadia/orchestrator',
+      '@omadia/orchestrator-extras',
+      '@omadia/verifier',
+    ]);
+  });
+});
+
+describe('POST /api/v1/auth/setup — no-key path', () => {
+  let h: Harness;
+  before(async () => {
+    h = await startHarness({});
+  });
+  after(async () => {
+    h.restoreFetch();
+    await h.close();
+  });
+
+  it('succeeds without anthropic_api_key, no vault writes, no reactivate', async () => {
+    const res = await fetch(`${h.baseUrl}/api/v1/auth/setup`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        email: 'admin@example.com',
+        password: 'pw-with-12-chars',
+      }),
+    });
+    assert.equal(res.status, 200);
+    assert.equal(h.store.rows.length, 1);
+    assert.equal(h.vault.writes.length, 0);
+    assert.equal(h.reactivateCalls.length, 0);
+  });
+});
+
+describe('POST /api/v1/auth/setup — invalid-key-format path', () => {
+  let h: Harness;
+  before(async () => {
+    h = await startHarness({});
+  });
+  after(async () => {
+    h.restoreFetch();
+    await h.close();
+  });
+
+  it('rejects keys without the sk-ant- prefix with 400 and creates no user', async () => {
+    const res = await fetch(`${h.baseUrl}/api/v1/auth/setup`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        email: 'admin@example.com',
+        password: 'pw-with-12-chars',
+        anthropic_api_key: 'not-a-real-key',
+      }),
+    });
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as { code?: string };
+    assert.equal(body.code, 'auth.setup_invalid_anthropic_key');
+    assert.equal(h.store.rows.length, 0);
+    assert.equal(h.vault.writes.length, 0);
+  });
+});
+
+describe('POST /api/v1/auth/setup — anthropic-rejects-key path', () => {
+  let h: Harness;
+  before(async () => {
+    h = await startHarness({ anthropicPingStatus: 401 });
+  });
+  after(async () => {
+    h.restoreFetch();
+    await h.close();
+  });
+
+  it('surfaces a 401 from the Anthropic ping as 400 setup_anthropic_key_rejected', async () => {
+    const res = await fetch(`${h.baseUrl}/api/v1/auth/setup`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        email: 'admin@example.com',
+        password: 'pw-with-12-chars',
+        anthropic_api_key: 'sk-ant-api03-revokedkey',
+      }),
+    });
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as { code?: string };
+    assert.equal(body.code, 'auth.setup_anthropic_key_rejected');
+    assert.equal(h.store.rows.length, 0);
+    assert.equal(h.vault.writes.length, 0);
+  });
+});

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -755,6 +755,12 @@ export async function postAuthSetup(body: {
   email: string;
   password: string;
   display_name?: string;
+  /** OB-61 — operator-supplied Anthropic key, seeded into the
+   *  orchestrator/verifier/extras vault on first-user setup. Optional:
+   *  the wizard accepts an empty value (operator can add the key later
+   *  via /admin/runtime/secrets) but then the LLM-bound capabilities
+   *  stay unpublished until they do. */
+  anthropic_api_key?: string;
 }): Promise<AuthSetupSuccess> {
   return postJson<AuthSetupSuccess>('/v1/auth/setup', body);
 }

--- a/web-ui/app/setup/page.tsx
+++ b/web-ui/app/setup/page.tsx
@@ -17,11 +17,18 @@ type State =
   | { kind: 'error'; message: string };
 
 /**
- * First-user-setup wizard (OB-49).
+ * First-user-setup wizard (OB-49 + OB-61).
  *
  * Pre-flight: GET /api/v1/auth/providers — if `setup_required` is false,
  * the wizard has already run; redirect to /login. Otherwise render a form
- * that POSTs `{email, password, display_name}` to /api/v1/auth/setup.
+ * that POSTs `{email, password, display_name, anthropic_api_key?}` to
+ * /api/v1/auth/setup.
+ *
+ * OB-61: the `anthropic_api_key` field is optional but strongly
+ * recommended — when supplied, the server seeds it into every consumer
+ * plugin's vault (orchestrator / orchestrator-extras / verifier) and
+ * reactivates the plugins so the LLM-bound capabilities go live without
+ * a server restart.
  *
  * On success the server mints + sets the session cookie itself, so we
  * just bounce the browser to the originally-requested path.
@@ -61,6 +68,7 @@ function SetupPageInner(): React.ReactElement {
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
   const [displayName, setDisplayName] = useState('');
+  const [anthropicKey, setAnthropicKey] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
@@ -101,12 +109,20 @@ function SetupPageInner(): React.ReactElement {
       setSubmitError(t('passwordTooShort'));
       return;
     }
+    // OB-61 — client-side sanity check; server validates authoritatively
+    // by pinging the Anthropic API before persisting.
+    const trimmedKey = anthropicKey.trim();
+    if (trimmedKey.length > 0 && !trimmedKey.startsWith('sk-ant-')) {
+      setSubmitError(t('anthropicKeyInvalid'));
+      return;
+    }
     setSubmitting(true);
     try {
       await postAuthSetup({
         email,
         password,
         ...(displayName.length > 0 ? { display_name: displayName } : {}),
+        ...(trimmedKey.length > 0 ? { anthropic_api_key: trimmedKey } : {}),
       });
       window.location.href = returnPath;
     } catch (err) {
@@ -114,7 +130,20 @@ function SetupPageInner(): React.ReactElement {
         setSubmitError(t('alreadyLocked'));
         setTimeout(() => router.replace('/login'), 1500);
       } else if (err instanceof ApiError && err.status === 400) {
-        setSubmitError(t('credentialsRejected'));
+        // The server splits invalid-email/password vs. anthropic-key
+        // errors into distinct `code` values; surface the matching i18n
+        // string when the body parses cleanly, falling back to the
+        // generic "credentialsRejected" otherwise. `err.body` is the
+        // raw response text (see ApiError); parse defensively because
+        // some 400s may not be JSON at all.
+        const code = parseErrorCode(err.body);
+        if (code === 'auth.setup_invalid_anthropic_key') {
+          setSubmitError(t('anthropicKeyInvalid'));
+        } else if (code === 'auth.setup_anthropic_key_rejected') {
+          setSubmitError(t('anthropicKeyRejected'));
+        } else {
+          setSubmitError(t('credentialsRejected'));
+        }
       } else {
         setSubmitError(err instanceof Error ? err.message : String(err));
       }
@@ -200,6 +229,21 @@ function SetupPageInner(): React.ReactElement {
             className="rounded-md border border-[color:var(--border)] bg-transparent px-3 py-2 text-sm outline-none focus:border-[color:var(--accent)]"
           />
         </label>
+        {/* OB-61 — operator-supplied Anthropic key. Stored encrypted in
+            the per-plugin vault, not in .env. Server validates by
+            pinging the Anthropic API before persisting. */}
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium">{t('anthropicKeyLabel')}</span>
+          <input
+            type="password"
+            autoComplete="off"
+            value={anthropicKey}
+            onChange={(e) => setAnthropicKey(e.target.value)}
+            placeholder="sk-ant-…"
+            className="rounded-md border border-[color:var(--border)] bg-transparent px-3 py-2 font-mono text-sm outline-none focus:border-[color:var(--accent)]"
+          />
+          <span className="text-xs opacity-60">{t('anthropicKeyHelp')}</span>
+        </label>
         {submitError && (
           <p className="text-sm text-red-500">{submitError}</p>
         )}
@@ -225,4 +269,20 @@ function PageShell({ children }: { children: React.ReactNode }): React.ReactElem
       </div>
     </main>
   );
+}
+
+/** Extracts `body.code` from an ApiError body string. Returns undefined
+ *  when the body is empty, not JSON, or has no `code` field. */
+function parseErrorCode(body: string): string | undefined {
+  if (!body) return undefined;
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    if (parsed && typeof parsed === 'object' && 'code' in parsed) {
+      const code = (parsed as { code: unknown }).code;
+      return typeof code === 'string' ? code : undefined;
+    }
+  } catch {
+    // Non-JSON body — fall through to undefined.
+  }
+  return undefined;
 }

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -70,7 +70,11 @@
     "passwordsMismatch": "Die Passwörter stimmen nicht überein.",
     "passwordTooShort": "Das Passwort muss mindestens 8 Zeichen lang sein.",
     "alreadyLocked": "Setup ist bereits abgeschlossen — ein anderer Nutzer wurde angelegt.",
-    "credentialsRejected": "E-Mail oder Passwort wurde vom Server abgelehnt (gültige E-Mail + mindestens 8 Zeichen erforderlich)."
+    "credentialsRejected": "E-Mail oder Passwort wurde vom Server abgelehnt (gültige E-Mail + mindestens 8 Zeichen erforderlich).",
+    "anthropicKeyLabel": "Anthropic API Key (optional)",
+    "anthropicKeyHelp": "Beginnt mit sk-ant-…. Hol dir einen unter console.anthropic.com. Wird verschlüsselt im Per-Plugin-Vault gespeichert — nicht in .env. Du kannst das Feld leer lassen und den Key später unter Admin → Runtime → Secrets nachtragen.",
+    "anthropicKeyInvalid": "Anthropic API Keys beginnen mit „sk-ant-\". Bitte den Wert von console.anthropic.com prüfen.",
+    "anthropicKeyRejected": "Der Server hat diesen Anthropic-Key abgelehnt (401/403). Bitte unter console.anthropic.com → API keys überprüfen."
   },
   "onboarding": {
     "ariaLabel": "Erste Einrichtung",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -70,7 +70,11 @@
     "passwordsMismatch": "Passwords do not match.",
     "passwordTooShort": "Password must be at least 8 characters.",
     "alreadyLocked": "Setup is already locked — another user has been created.",
-    "credentialsRejected": "Email or password rejected by the server (must be valid email + 8+ chars)."
+    "credentialsRejected": "Email or password rejected by the server (must be valid email + 8+ chars).",
+    "anthropicKeyLabel": "Anthropic API Key (optional)",
+    "anthropicKeyHelp": "Starts with sk-ant-…. Get one at console.anthropic.com. Stored encrypted in the per-plugin vault — never in .env. Leave empty to add later via Admin → Runtime → Secrets.",
+    "anthropicKeyInvalid": "Anthropic API keys start with \"sk-ant-\". Double-check the value from console.anthropic.com.",
+    "anthropicKeyRejected": "The server rejected this Anthropic key (401/403). Verify it at console.anthropic.com → API keys."
   },
   "onboarding": {
     "ariaLabel": "First-time setup",


### PR DESCRIPTION
## Summary

Operators no longer have to set `ANTHROPIC_API_KEY` in `.env` before first boot. The first-user setup wizard now collects the key alongside the admin credentials, validates it with a free `/v1/models` ping, and seeds it into every consumer plugin's vault — followed by an `installService.reactivate()` so the LLM-bound capabilities go live without a server restart.

This unblocks the OB-30 OSS publication: self-hosters can now boot a clean container and complete configuration through the UI, with no shell-level `.env` editing required for the LLM key.

## What changes

- **`config.ts`** — `ANTHROPIC_API_KEY` is now `z.string().optional()` (was `min(1)`). Server boots without it.
- **`routes/auth.ts`** — `POST /api/v1/auth/setup` accepts an optional `anthropic_api_key`. Validates the `sk-ant-` prefix client + server-side, then hits `https://api.anthropic.com/v1/models` (free, no token cost) to confirm authenticity. On success, writes the key into each of `@omadia/orchestrator`, `@omadia/orchestrator-extras`, `@omadia/verifier` and calls `reactivate()` per consumer. Failed seeds are logged but do NOT roll back the user — the operator can re-seed later via `/admin/runtime/secrets`.
- **`index.ts`** — wires `secretVault` + `installService.reactivate` + the consumer-id list into `createAuthRouter`. Shared `Anthropic` client falls back to `''` when the key is missing (path is unreachable on cold boots since the orchestrator capability stays unpublished).
- **`web-ui/setup/page.tsx`** — new password-style input + helper text linking to `console.anthropic.com`. Distinguishes server error codes `auth.setup_invalid_anthropic_key` vs `auth.setup_anthropic_key_rejected` for accurate UX hints.
- **`web-ui/_lib/api.ts`** — `postAuthSetup` body extended with optional `anthropic_api_key`.
- **`messages/{de,en}.json`** — 4 new i18n strings: label / help / invalid-format / rejected-by-anthropic.
- **`.env.example`** — `ANTHROPIC_API_KEY` commented out with a paragraph explaining the new flow + the legacy fallback.

## Backwards compatibility

Pre-OB-61 deployments with `ANTHROPIC_API_KEY` set in env keep working unchanged:

- `bootstrapOrchestratorFromEnv` / `bootstrapVerifierFromEnv` / `bootstrapOrchestratorExtrasFromEnv` still seed the env key into the vault on first boot.
- `migrateAnthropicKeyToVault` still moves any `installed.json` leftovers into the vault idempotently (S+12.6 helper unchanged).

## Test plan

- [x] New `test/auth/setupRoute.test.ts` (9 cases, all pass):
  - Vault write fans out to all 3 consumers with the same key
  - `reactivate()` fires exactly once per consumer
  - No-key path: user created, zero vault writes, zero reactivate calls
  - Invalid-format key → 400 `auth.setup_invalid_anthropic_key`, no user created
  - Anthropic-401 → 400 `auth.setup_anthropic_key_rejected`, no user created
- [x] Existing 55-case auth suite: no regression
- [x] `tsc --noEmit` — no new errors in OB-61 files
- [x] `eslint` — clean
- [ ] Smoke test on fresh deploy: container without `ANTHROPIC_API_KEY` env, complete `/setup` with key, send a chat turn → orchestrator capability becomes published without restart (Marcel-Rule #37 — recommend running in staging)

## Followups

- Notion task OB-61 → Done after merge
- Consider rotating Anthropic keys via Admin UI (`/admin/runtime/secrets`) instead of `fly secrets` — already documented in `PRE-DEPLOY-CHECKLIST.md` §1.1 (lokal-only, not in commit)
