### PR TITLE
feat(verifier): tool-output postcondition validation + correctionPrompt retry (#130)

### DIFF
--- a/middleware/packages/harness-channel-sdk/src/chatAgent.ts
+++ b/middleware/packages/harness-channel-sdk/src/chatAgent.ts
@@ -125,6 +125,13 @@ export interface RunToolCall {
   /** External ids of entities produced by this call (odoo://…, confluence://…).
    *  Wired by the entity-ref bus, same source as `TurnIngest.entityRefs`. */
   producedEntityIds?: string[];
+  /** #130 — set when the bridge ran an optional output Zod schema on the
+   *  tool's return value and it failed. Structural copy of KG-side
+   *  `RunToolCall.postcondition`; the verifier reads this to raise a
+   *  `tool_postcondition` claim. */
+  postcondition?: {
+    issues: readonly string[];
+  };
 }
 
 /** Per-sub-agent invocation entry in a run trace. */

--- a/middleware/packages/harness-orchestrator/src/index.ts
+++ b/middleware/packages/harness-orchestrator/src/index.ts
@@ -99,7 +99,11 @@ export { VerifierService } from './verifierService.js';
 
 // Sub-agent runtime
 export { LocalSubAgent } from './localSubAgent.js';
-export type { LocalSubAgentTool, AskOptions } from './localSubAgent.js';
+export type {
+  LocalSubAgentTool,
+  LocalSubAgentToolResult,
+  AskOptions,
+} from './localSubAgent.js';
 
 // Knowledge-graph native tool (moved from harness-knowledge-graph in S+12.5-1)
 export {

--- a/middleware/packages/harness-orchestrator/src/localSubAgent.ts
+++ b/middleware/packages/harness-orchestrator/src/localSubAgent.ts
@@ -1,6 +1,7 @@
 import type Anthropic from '@anthropic-ai/sdk';
 import type {
   LocalSubAgentTool,
+  LocalSubAgentToolResult,
   LocalSubAgentToolSpec,
 } from '@omadia/plugin-api';
 import { streamMessageWithObserver } from './streaming.js';
@@ -13,7 +14,11 @@ import { buildDateHeader, turnContext } from './turnContext.js';
 // can produce values of those shapes without reaching back into kernel
 // source. Re-exported for kernel-internal consumers that previously
 // imported from `./localSubAgent.js`.
-export type { LocalSubAgentTool, LocalSubAgentToolSpec };
+export type {
+  LocalSubAgentTool,
+  LocalSubAgentToolResult,
+  LocalSubAgentToolSpec,
+};
 
 interface LocalSubAgentOptions {
   /** Label used in logs — typically the domain, e.g. `odoo-hr`. */
@@ -351,9 +356,12 @@ export class LocalSubAgent {
             console.warn(`[sub-agent ${this.name}] observer.onSubToolUse threw:`, err);
           }
           const started = Date.now();
-          const output = await this.dispatch(use.name, use.input);
+          const { output, postcondition } = await this.dispatch(
+            use.name,
+            use.input,
+          );
           const elapsed = Date.now() - started;
-          const isError = output.startsWith('Error:');
+          const isError = output.startsWith('Error:') || postcondition !== undefined;
           console.log(
             `[sub-agent ${this.name}] ${String(use.name)} ${isError ? '→ ERR' : '→ ok'} (${String(elapsed)}ms, ${String(output.length)} chars)`,
           );
@@ -363,6 +371,7 @@ export class LocalSubAgent {
               output,
               durationMs: elapsed,
               isError,
+              ...(postcondition ? { postcondition } : {}),
             });
           } catch (err) {
             console.warn(`[sub-agent ${this.name}] observer.onSubToolResult threw:`, err);
@@ -431,16 +440,25 @@ export class LocalSubAgent {
     }
   }
 
-  private async dispatch(toolName: string, input: unknown): Promise<string> {
+  private async dispatch(
+    toolName: string,
+    input: unknown,
+  ): Promise<{ output: string; postcondition?: { issues: readonly string[] } }> {
     const tool = this.toolsByName.get(toolName);
-    if (!tool) return `Error: unknown tool \`${toolName}\`.`;
+    if (!tool) return { output: `Error: unknown tool \`${toolName}\`.` };
 
     // Privacy Shield v4 — Data-Plane Boundary for sub-agent inner calls.
     // The privacy handle is threaded through `turnContext.privacyHandle`;
     // sub-agents inherit it from the parent orchestrator's turn scope.
     // Absent ⇒ no privacy provider installed and the result flows through.
     const privacy = turnContext.current()?.privacyHandle;
-    const result = await tool.handle(input);
+    // #130 — unwrap the structured tool-result union at the boundary so
+    // every privacy / capture path downstream keeps seeing a plain string,
+    // while we still surface the optional postcondition marker upward to
+    // the observer (which the RunTraceCollector copies onto the trace).
+    const raw = await tool.handle(input);
+    const result = typeof raw === 'string' ? raw : raw.output;
+    const postcondition = typeof raw === 'string' ? undefined : raw.postcondition;
     // Phase C.2 — Raw tool-result capture (parallel to orchestrator.dispatchTool).
     // Sub-agent tool calls also feed routine templates, so the capture
     // hook must fire here too. Absent callback ⇒ no capture.
@@ -478,7 +496,7 @@ export class LocalSubAgent {
             err,
           );
         }
-        return result;
+        return { output: result, ...(postcondition ? { postcondition } : {}) };
       }
       // Intern the raw result server-side and hand the LLM only the
       // identity-free digest — the raw rows never reach the LLM wire.
@@ -493,7 +511,10 @@ export class LocalSubAgent {
         // installed by the parent's dispatchTool scope; absent ⇒ this
         // sub-agent is not running under a domain-tool bridge.
         turnContext.current()?.subAgentDatasetSink?.push(v4.datasetId);
-        return v4.digestText;
+        return {
+          output: v4.digestText,
+          ...(postcondition ? { postcondition } : {}),
+        };
       } catch (err) {
         console.warn(
           `[sub-agent ${this.name}] privacy.internToolResultV4 threw on '${toolName}' — sending raw result:`,
@@ -501,7 +522,7 @@ export class LocalSubAgent {
         );
       }
     }
-    return result;
+    return { output: result, ...(postcondition ? { postcondition } : {}) };
   }
 }
 

--- a/middleware/packages/harness-orchestrator/src/runTraceCollector.ts
+++ b/middleware/packages/harness-orchestrator/src/runTraceCollector.ts
@@ -96,6 +96,7 @@ export class RunTraceCollector {
           durationMs: ev.durationMs,
           isError: ev.isError,
           agentContext: agentName,
+          ...(ev.postcondition ? { postcondition: ev.postcondition } : {}),
         });
         toolCallStarts.delete(ev.id);
       },

--- a/middleware/packages/harness-orchestrator/src/tools/domainQueryTool.ts
+++ b/middleware/packages/harness-orchestrator/src/tools/domainQueryTool.ts
@@ -15,6 +15,12 @@ export interface AskObserver {
     output: string;
     durationMs: number;
     isError: boolean;
+    /** #130 — present when the bridge ran an optional output Zod schema
+     * on the tool's return value and it failed. RunTraceCollector copies
+     * the issues onto the RunToolCall so the verifier can pick them up. */
+    postcondition?: {
+      issues: readonly string[];
+    };
   }): void;
   onIterationPhase?(ev: {
     iteration: number;

--- a/middleware/packages/harness-orchestrator/src/verifierService.ts
+++ b/middleware/packages/harness-orchestrator/src/verifierService.ts
@@ -228,12 +228,16 @@ export class VerifierService implements ChatAgent {
     runTrace: RunTracePayload | undefined,
   ): Promise<VerifierVerdict> {
     const domainToolsCalled = extractToolsCalled(runTrace);
+    const toolPostconditionViolations = extractPostconditionViolations(runTrace);
     try {
       return await this.pipeline.verify({
         runId,
         userMessage: input.userMessage,
         answer,
         ...(domainToolsCalled ? { domainToolsCalled } : {}),
+        ...(toolPostconditionViolations.length > 0
+          ? { toolPostconditionViolations }
+          : {}),
       });
     } catch (err) {
       this.log(`[verifier/service] pipeline FAIL: ${errMsg(err)}`);
@@ -358,4 +362,50 @@ function extractToolsCalled(
     names.add(call.toolName);
   }
   return [...names];
+}
+
+/**
+ * #130 — collect every postcondition violation the bridgeTool stamped onto
+ * the runTrace. The verifier turns each entry into a synthetic
+ * `tool_postcondition` ClaimVerdict (status='contradicted'), which flips the
+ * verdict to `blocked` and drives the existing correctionPrompt retry loop.
+ */
+function extractPostconditionViolations(
+  trace: RunTracePayload | undefined,
+): {
+  toolName: string;
+  callId: string;
+  agentContext: string;
+  issues: readonly string[];
+}[] {
+  if (!trace) return [];
+  const out: {
+    toolName: string;
+    callId: string;
+    agentContext: string;
+    issues: readonly string[];
+  }[] = [];
+  for (const invocation of trace.agentInvocations) {
+    for (const call of invocation.toolCalls) {
+      if (call.postcondition) {
+        out.push({
+          toolName: call.toolName,
+          callId: call.callId,
+          agentContext: call.agentContext,
+          issues: call.postcondition.issues,
+        });
+      }
+    }
+  }
+  for (const call of trace.orchestratorToolCalls) {
+    if (call.postcondition) {
+      out.push({
+        toolName: call.toolName,
+        callId: call.callId,
+        agentContext: call.agentContext,
+        issues: call.postcondition.issues,
+      });
+    }
+  }
+  return out;
 }

--- a/middleware/packages/harness-verifier/src/claimTypes.ts
+++ b/middleware/packages/harness-verifier/src/claimTypes.ts
@@ -15,7 +15,12 @@ export type ClaimType =
   | 'date'        // concrete calendar date or period boundary
   | 'name'        // person / customer / vendor name with contextual assertion
   | 'aggregate'   // sum / count / avg over a set (especially HR leave)
-  | 'qualitative';// non-numeric statement about an entity ("X ist Kunde seit …")
+  | 'qualitative' // non-numeric statement about an entity ("X ist Kunde seit …")
+  | 'tool_postcondition'; // #130 — synthetic claim: a tool returned a value
+                          // that didn't match its declared output Zod schema.
+                          // Never produced by the LLM-side claim extractor;
+                          // verifierPipeline manufactures one per violation
+                          // it scans out of the runTrace before extraction.
 
 /** Which subsystem is authoritative for this claim. */
 export type ClaimSource = 'odoo' | 'graph' | 'confluence' | 'unknown';
@@ -111,6 +116,19 @@ export interface VerifierInput {
    * pipeline then falls back to deterministic re-query (the existing path).
    */
   domainToolsCalled?: readonly string[];
+  /**
+   * #130 — postcondition violations the bridge detected on tool returns
+   * (output Zod schema mismatch). Extracted from the runTrace before the
+   * pipeline runs; the pipeline manufactures a synthetic `tool_postcondition`
+   * ClaimVerdict with status='contradicted' for each entry. Drives the
+   * existing correctionPrompt retry loop.
+   */
+  toolPostconditionViolations?: readonly {
+    toolName: string;
+    callId: string;
+    agentContext: string;
+    issues: readonly string[];
+  }[];
 }
 
 /** Badge used by the Teams card to communicate verifier status. */

--- a/middleware/packages/harness-verifier/src/correctionPrompt.ts
+++ b/middleware/packages/harness-verifier/src/correctionPrompt.ts
@@ -15,10 +15,28 @@ export function buildCorrectionPrompt(
 ): string | undefined {
   if (verdict.status !== 'blocked') return undefined;
 
-  const replayItems = verdict.contradictions.filter(isReplay);
-  const dataItems = verdict.contradictions.filter((v) => !isReplay(v));
+  const postconditionItems = verdict.contradictions.filter(isPostcondition);
+  const replayItems = verdict.contradictions.filter(
+    (v) => !isPostcondition(v) && isReplay(v),
+  );
+  const dataItems = verdict.contradictions.filter(
+    (v) => !isPostcondition(v) && !isReplay(v),
+  );
 
   const sections: string[] = ['# Verifier hat Widersprüche erkannt', ''];
+
+  if (postconditionItems.length > 0) {
+    sections.push(
+      '## Tool-Output nicht spec-konform',
+      '',
+      'Ein Tool-Call hat ein Ergebnis zurückgeliefert, das nicht seinem deklarierten Output-Schema entspricht. Die Antwort darf sich auf diesen Wert NICHT verlassen.',
+      '',
+      '**Jetzt bitte:** rufe das gleiche Tool mit korrigierten Argumenten erneut auf (z.B. fehlende Felder ergänzen, Filter präzisieren) ODER nutze ein anderes Tool, das die benötigten Daten liefern kann. Wenn das Tool strukturell broken ist und kein Re-Call hilft, sag dem User ehrlich: "Tool X liefert kein verwertbares Ergebnis für Y".',
+      '',
+      ...postconditionItems.map(formatPostcondition),
+      '',
+    );
+  }
 
   if (replayItems.length > 0) {
     sections.push(
@@ -48,9 +66,22 @@ export function buildCorrectionPrompt(
   return sections.join('\n');
 }
 
+function isPostcondition(v: ClaimVerdict): boolean {
+  if (v.status !== 'contradicted') return false;
+  return v.claim.type === 'tool_postcondition';
+}
+
 function isReplay(v: ClaimVerdict): boolean {
   if (v.status !== 'contradicted') return false;
   return v.source === 'unknown' || v.claim.id.startsWith('c_replay');
+}
+
+function formatPostcondition(v: ClaimVerdict): string {
+  if (v.status !== 'contradicted') return '';
+  // claim.id format: `c_postcond_<callId>` — strip the prefix for display.
+  const callId = v.claim.id.replace(/^c_postcond_/, '');
+  const detail = v.detail ? ` — Issues: ${v.detail}` : '';
+  return `- ${v.claim.text} (callId=${callId})${detail}`;
 }
 
 function formatContradiction(v: ClaimVerdict): string {

--- a/middleware/packages/harness-verifier/src/verifierPipeline.ts
+++ b/middleware/packages/harness-verifier/src/verifierPipeline.ts
@@ -63,10 +63,20 @@ export class VerifierPipeline {
     // contradiction.
     const replayVerdicts = detectFailureReplay(input);
 
+    // #130 — postcondition violations the bridgeTool detected on tool
+    // returns (output Zod schema mismatch). Same shape as replayVerdicts:
+    // synthetic contradicted verdicts that don't need answer extraction.
+    // The presence of any of these flips the aggregate to `blocked` and
+    // drives the existing correctionPrompt retry loop.
+    const postconditionVerdicts = buildPostconditionVerdicts(input);
+
     const trigger = shouldTriggerVerifier(input.answer);
     if (!trigger.shouldVerify) {
-      // Only the replay verdicts matter here.
-      return aggregate(replayVerdicts, started);
+      // Only the synthetic (no-extraction-needed) verdicts matter here.
+      return aggregate(
+        [...replayVerdicts, ...postconditionVerdicts],
+        started,
+      );
     }
 
     let claims: Claim[];
@@ -77,14 +87,20 @@ export class VerifierPipeline {
       });
     } catch (err) {
       this.log(`[verifier/pipeline] extractor FAIL: ${errMsg(err)}`);
-      return aggregate(replayVerdicts, started);
+      return aggregate(
+        [...replayVerdicts, ...postconditionVerdicts],
+        started,
+      );
     }
 
     if (claims.length === 0) {
       this.log(
         `[verifier/pipeline] no claims extracted (trigger=${trigger.reasons.join(',')})`,
       );
-      return aggregate(replayVerdicts, started);
+      return aggregate(
+        [...replayVerdicts, ...postconditionVerdicts],
+        started,
+      );
     }
 
     const { hard, soft } = classify(claims);
@@ -116,12 +132,39 @@ export class VerifierPipeline {
 
     const all: ClaimVerdict[] = [
       ...replayVerdicts,
+      ...postconditionVerdicts,
       ...traceVerdicts,
       ...hardVerdicts,
       ...softVerdicts,
     ];
     return aggregate(all, started);
   }
+}
+
+/**
+ * #130 — turn each postcondition violation reported on the runTrace into a
+ * synthetic contradicted ClaimVerdict. The verifier never asks the extractor
+ * about these (they don't live in the answer text) and the deterministic
+ * checker never sees them either; they go straight into the aggregate.
+ */
+function buildPostconditionVerdicts(input: VerifierInput): ClaimVerdict[] {
+  const violations = input.toolPostconditionViolations;
+  if (!violations || violations.length === 0) return [];
+  return violations.map(
+    (v): ClaimVerdict => ({
+      status: 'contradicted',
+      claim: {
+        id: `c_postcond_${v.callId}`,
+        text: `Tool '${v.toolName}' returned a value that did not conform to its declared output schema.`,
+        type: 'tool_postcondition',
+        expectedSource: 'unknown',
+        relatedEntities: [],
+      },
+      truth: { issues: v.issues },
+      source: 'unknown',
+      detail: v.issues.join('; '),
+    }),
+  );
 }
 
 // --- helpers --------------------------------------------------------------

--- a/middleware/packages/plugin-api/src/knowledgeGraph.ts
+++ b/middleware/packages/plugin-api/src/knowledgeGraph.ts
@@ -1204,6 +1204,13 @@ export interface RunToolCall {
   /** External ids of entities produced by this call (odoo://…, confluence://…).
    * Wired by the entity-ref bus, same source as TurnIngest.entityRefs. */
   producedEntityIds?: string[];
+  /** #130 — set when the bridge ran an optional output Zod schema on the
+   * tool's return value and it failed. The verifier converts this into a
+   * `tool_postcondition` claim which drives the existing correctionPrompt
+   * retry loop. Absent on every successful call. */
+  postcondition?: {
+    issues: readonly string[];
+  };
 }
 
 export interface RunAgentInvocation {

--- a/middleware/packages/plugin-api/src/localSubAgentTool.ts
+++ b/middleware/packages/plugin-api/src/localSubAgentTool.ts
@@ -21,9 +21,24 @@ export interface LocalSubAgentToolSpec {
   };
 }
 
+/**
+ * Structured tool-result with optional postcondition-violation marker
+ * (#130). `handle` returns either a bare string (legacy contract — all
+ * existing plugins do this) or this shape when the bridge has run the
+ * optional `output` Zod schema and detected a mismatch. The verifier
+ * picks up `postcondition` and raises a `tool_postcondition` claim that
+ * drives the existing correctionPrompt retry loop.
+ */
+export interface LocalSubAgentToolResult {
+  readonly output: string;
+  readonly postcondition?: {
+    readonly issues: readonly string[];
+  };
+}
+
 export interface LocalSubAgentTool {
   spec: LocalSubAgentToolSpec;
-  handle(input: unknown): Promise<string>;
+  handle(input: unknown): Promise<string | LocalSubAgentToolResult>;
   /**
    * Privacy-Shield v3 (stable-id tokenization, slice 1) — optional PII
    * field annotations. When present, the harness runs a stable-id

--- a/middleware/src/plugins/dynamicAgentRuntime.ts
+++ b/middleware/src/plugins/dynamicAgentRuntime.ts
@@ -12,7 +12,11 @@ import type { UiRouteCatalog } from '../platform/uiRouteCatalog.js';
 import type { ServiceRegistry } from '../platform/serviceRegistry.js';
 import type { SecretVault } from '../secrets/vault.js';
 import type { NativeToolRegistry } from '@omadia/orchestrator';
-import { LocalSubAgent, type LocalSubAgentTool } from '@omadia/orchestrator';
+import {
+  LocalSubAgent,
+  type LocalSubAgentTool,
+  type LocalSubAgentToolResult,
+} from '@omadia/orchestrator';
 import type { Orchestrator } from '@omadia/orchestrator';
 import {
   createDomainTool,
@@ -67,6 +71,12 @@ interface UploadedToolkit {
         readonly id: string;
         readonly description: string;
         readonly input: z.ZodType<unknown>;
+        // Optional postcondition: when defined, bridgeTool validates the
+        // tool's return value against this schema before it lands in the
+        // conversation state. A mismatch surfaces as a structured marker
+        // the verifier turns into a `tool_postcondition` claim, which
+        // triggers the existing correctionPrompt retry loop.
+        readonly output?: z.ZodType<unknown>;
         run(input: unknown): Promise<unknown>;
       }
     | LocalSubAgentTool
@@ -526,10 +536,30 @@ function bridgeTool(
         required,
       },
     },
-    async handle(input: unknown): Promise<string> {
+    async handle(
+      input: unknown,
+    ): Promise<string | LocalSubAgentToolResult> {
       try {
         const parsed = td.input.parse(input);
         const result = await td.run(parsed);
+        if (td.output) {
+          const outCheck = td.output.safeParse(result);
+          if (!outCheck.success) {
+            // #130 — structured postcondition result. The output string is
+            // what the LLM sees as `tool_result` content; the `postcondition`
+            // field rides the AskObserver up to the RunTraceCollector, which
+            // stamps the `RunToolCall.postcondition` so the verifier raises
+            // a `tool_postcondition` claim and drives the existing
+            // correctionPrompt retry loop.
+            const issues = outCheck.error.issues.map(
+              (i) => `${i.path.join('.') || '<root>'}: ${i.message}`,
+            );
+            return {
+              output: `[POSTCONDITION_FAILED] tool=${td.id} issues=${issues.join('; ')}`,
+              postcondition: { issues },
+            };
+          }
+        }
         return typeof result === 'string'
           ? result
           : JSON.stringify(result, null, 2);

--- a/middleware/test/correctionPromptPostcondition.test.ts
+++ b/middleware/test/correctionPromptPostcondition.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import {
+  buildCorrectionPrompt,
+  type ClaimVerdict,
+  type VerifierVerdict,
+} from '@omadia/verifier';
+
+// #130 — buildCorrectionPrompt must surface a dedicated postcondition
+// section so the orchestrator's retry knows the tool's output didn't
+// match its declared schema. This is parallel to the existing replay/
+// data sections but with its own remediation: re-call the tool with
+// corrected args (or pick a different tool) instead of restating the
+// already-measured value.
+
+function postconditionVerdict(callId: string, issues: string[]): ClaimVerdict {
+  return {
+    status: 'contradicted',
+    claim: {
+      id: `c_postcond_${callId}`,
+      text: "Tool 'list_products' returned a value that did not conform to its declared output schema.",
+      type: 'tool_postcondition',
+      expectedSource: 'unknown',
+      relatedEntities: [],
+    },
+    truth: { issues },
+    source: 'unknown',
+    detail: issues.join('; '),
+  };
+}
+
+function blockedVerdictWith(
+  contradictions: ClaimVerdict[],
+): VerifierVerdict {
+  return {
+    status: 'blocked',
+    claims: contradictions,
+    contradictions,
+    latencyMs: 0,
+  };
+}
+
+describe('buildCorrectionPrompt — postcondition', () => {
+  it('emits a Postcondition section for tool_postcondition contradictions', () => {
+    const verdict = blockedVerdictWith([
+      postconditionVerdict('call_a', ['<root>: expected array, received object']),
+    ]);
+    const prompt = buildCorrectionPrompt(verdict);
+    assert.ok(prompt, 'prompt should be returned for blocked verdict');
+    assert.match(prompt, /## Tool-Output nicht spec-konform/);
+    assert.match(prompt, /callId=call_a/);
+    assert.match(prompt, /expected array, received object/);
+  });
+
+  it('keeps postcondition items out of the data/replay sections', () => {
+    const verdict = blockedVerdictWith([
+      postconditionVerdict('call_b', ['amount.value: required']),
+    ]);
+    const prompt = buildCorrectionPrompt(verdict);
+    assert.ok(prompt);
+    assert.doesNotMatch(prompt, /## Falsche \/ widerlegte Daten/);
+    assert.doesNotMatch(prompt, /## Replay aus Kontext-Block erkannt/);
+  });
+
+  it('returns undefined for non-blocked verdicts', () => {
+    const verdict: VerifierVerdict = {
+      status: 'approved',
+      claims: [],
+      latencyMs: 0,
+    };
+    assert.equal(buildCorrectionPrompt(verdict), undefined);
+  });
+});

--- a/middleware/test/verifierPipeline.test.ts
+++ b/middleware/test/verifierPipeline.test.ts
@@ -331,4 +331,79 @@ describe('verifier/pipeline', () => {
     });
     assert.equal(verdict.status, 'approved');
   });
+
+  // #130 — postcondition violation flips the verdict to blocked even when
+  // the answer text has no claims of its own. The synthetic claim never
+  // hits the extractor; it is manufactured from the runTrace marker.
+  it('blocks on tool_postcondition violation without invoking extractor', async () => {
+    let extractorCalled = false;
+    const extractor = {
+      extract(): Promise<Claim[]> {
+        extractorCalled = true;
+        return Promise.resolve([]);
+      },
+    } as unknown as ClaimExtractor;
+    const pipeline = new VerifierPipeline({
+      extractor,
+      deterministic: stubDeterministic(() => ({
+        status: 'verified',
+        claim: hardClaim(),
+        source: 'odoo',
+      })),
+      judge: stubJudge(() => ({
+        status: 'verified',
+        claim: softClaim(),
+        source: 'graph',
+      })),
+      log: SILENT_LOG,
+    });
+    const verdict = await pipeline.verify({
+      runId: 'r7',
+      userMessage: 'List products',
+      answer: 'Hier sind sie: Foo, Bar.',
+      toolPostconditionViolations: [
+        {
+          toolName: 'list_products',
+          callId: 'call_xyz',
+          agentContext: 'agent-shop',
+          issues: ['<root>: expected array, received object'],
+        },
+      ],
+    });
+    assert.equal(verdict.status, 'blocked');
+    if (verdict.status === 'blocked') {
+      assert.equal(verdict.contradictions.length, 1);
+      assert.equal(verdict.contradictions[0]?.claim.type, 'tool_postcondition');
+      assert.equal(verdict.contradictions[0]?.claim.id, 'c_postcond_call_xyz');
+    }
+    // Verifier never asked the extractor — the synthetic claim doesn't need
+    // answer parsing. (Trigger router may also short-circuit if the answer
+    // doesn't look factual; either way extractor stays untouched.)
+    assert.equal(extractorCalled, false);
+  });
+
+  // Backwards-compat: no postcondition violations + clean claims → still
+  // approves. Guards against accidental tightening of the verdict-builder.
+  it('approves cleanly when toolPostconditionViolations is absent', async () => {
+    const pipeline = new VerifierPipeline({
+      extractor: stubExtractor([hardClaim()]),
+      deterministic: stubDeterministic((c) => ({
+        status: 'verified',
+        claim: c,
+        source: 'odoo',
+      })),
+      judge: stubJudge((c) => ({
+        status: 'verified',
+        claim: c,
+        source: 'graph',
+      })),
+      log: SILENT_LOG,
+    });
+    const verdict = await pipeline.verify({
+      runId: 'r8',
+      userMessage: 'was?',
+      answer: 'Die Rechnung beträgt 1.234,56 €.',
+    });
+    assert.equal(verdict.status, 'approved');
+  });
 });


### PR DESCRIPTION
Closes #130.

## Summary
- Plugins declare an optional Zod `output` schema on each tool. The bridge validates the tool's return against the schema; a mismatch is stamped on the `RunTrace` as `RunToolCall.postcondition`.
- The verifier picks up that marker and produces a synthetic `tool_postcondition` ClaimVerdict (`status='contradicted'`), flipping the verdict to `blocked`.
- The existing `VerifierService` retry loop fires automatically; `buildCorrectionPrompt` adds a new German `## Tool-Output nicht spec-konform` section that instructs the model to re-call the tool with corrected args (or pick a different tool).
- Backwards-compatible: tools without an `output` schema behave exactly as today. `LocalSubAgentTool.handle` returns a `string | LocalSubAgentToolResult` union — existing plugins return strings unchanged.

## What this enables
Once #127 (deterministic calculator tool) and #128 (logic-inference tools) land, they will be the first real consumers of `output` schemas. Until then this PR is a no-op at runtime for existing tools but unblocks the deterministic-tools slice.

## Files
- `plugin-api`: `LocalSubAgentToolResult` union + `RunToolCall.postcondition`
- `channel-sdk`: mirror `RunToolCall.postcondition` (structural copy from S+10-2 lift)
- `harness-orchestrator`: bridgeTool result unwrap in `localSubAgent.dispatch`, `AskObserver.onSubToolResult` event extension, `RunTraceCollector` copies marker, `verifierService.extractPostconditionViolations`
- `harness-verifier`: `ClaimType` adds `'tool_postcondition'`, `VerifierInput.toolPostconditionViolations`, pipeline builds synthetic verdicts before extraction, `buildCorrectionPrompt` emits the new section
- `dynamicAgentRuntime`: bridgeTool runs the postcondition schema after `td.run(parsed)` and returns the structured shape on mismatch
- Tests: `verifierPipeline.test.ts` +2 (blocks-on-violation, backward-compat); new `correctionPromptPostcondition.test.ts` +3

## Test plan
- [x] `npm run build` clean across plugin-api, channel-sdk, orchestrator, verifier
- [x] `npx tsc --noEmit -p tsconfig.json` → exit 0
- [x] Full middleware suite: 2629/2634 pass (3 preexisting `privacyV4Bypass` fails unrelated to #130)
- [x] Dev-server boot reaches all relevant subsystems (Memory, KG-Neon, Orchestrator-Extras, Verifier) without #130-related crash
- [ ] Wire up first real consumer in #127 deterministic-tools slice to verify the full retry loop end-to-end

Addresses Recommendation #4 from the May 2026 LLM-harness audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)