### PR TITLE
feat(verifier): citation enforcement for knowledge-graph-grounded answers (#131)

### DIFF
--- a/middleware/packages/harness-orchestrator/src/verifierService.ts
+++ b/middleware/packages/harness-orchestrator/src/verifierService.ts
@@ -229,6 +229,7 @@ export class VerifierService implements ChatAgent {
   ): Promise<VerifierVerdict> {
     const domainToolsCalled = extractToolsCalled(runTrace);
     const toolPostconditionViolations = extractPostconditionViolations(runTrace);
+    const knowledgeGraphToolsCalled = extractKnowledgeGraphToolsCalled(runTrace);
     try {
       return await this.pipeline.verify({
         runId,
@@ -237,6 +238,9 @@ export class VerifierService implements ChatAgent {
         ...(domainToolsCalled ? { domainToolsCalled } : {}),
         ...(toolPostconditionViolations.length > 0
           ? { toolPostconditionViolations }
+          : {}),
+        ...(knowledgeGraphToolsCalled !== undefined
+          ? { knowledgeGraphToolsCalled }
           : {}),
       });
     } catch (err) {
@@ -362,6 +366,28 @@ function extractToolsCalled(
     names.add(call.toolName);
   }
   return [...names];
+}
+
+/**
+ * #131 — true when this turn invoked the knowledge-graph (or any of the
+ * KG-backed sub-agent / orchestrator tools the verifier counts as
+ * "fetched evidence"). The pipeline uses this as the gate for the
+ * citation-missing check: no KG call ⇒ citations are irrelevant.
+ */
+function extractKnowledgeGraphToolsCalled(
+  trace: RunTracePayload | undefined,
+): boolean | undefined {
+  if (!trace) return undefined;
+  const KG_NAMES: ReadonlySet<string> = new Set(['query_knowledge_graph']);
+  for (const call of trace.orchestratorToolCalls) {
+    if (KG_NAMES.has(call.toolName)) return true;
+  }
+  for (const inv of trace.agentInvocations) {
+    for (const call of inv.toolCalls) {
+      if (KG_NAMES.has(call.toolName)) return true;
+    }
+  }
+  return false;
 }
 
 /**

--- a/middleware/packages/harness-verifier/src/claimTypes.ts
+++ b/middleware/packages/harness-verifier/src/claimTypes.ts
@@ -16,11 +16,17 @@ export type ClaimType =
   | 'name'        // person / customer / vendor name with contextual assertion
   | 'aggregate'   // sum / count / avg over a set (especially HR leave)
   | 'qualitative' // non-numeric statement about an entity ("X ist Kunde seit …")
-  | 'tool_postcondition'; // #130 — synthetic claim: a tool returned a value
+  | 'tool_postcondition' // #130 — synthetic claim: a tool returned a value
                           // that didn't match its declared output Zod schema.
                           // Never produced by the LLM-side claim extractor;
                           // verifierPipeline manufactures one per violation
                           // it scans out of the runTrace before extraction.
+  | 'citation_missing'; // #131 — synthetic claim: the turn called a
+                        // knowledge-graph tool but the answer contains no
+                        // `[ref:nodeId]` markers, so any KG-grounded
+                        // statement in the answer is structurally
+                        // unattributable. Drives the correctionPrompt
+                        // retry to force the model to add citations.
 
 /** Which subsystem is authoritative for this claim. */
 export type ClaimSource = 'odoo' | 'graph' | 'confluence' | 'unknown';
@@ -129,6 +135,18 @@ export interface VerifierInput {
     agentContext: string;
     issues: readonly string[];
   }[];
+  /**
+   * #131 — true when the turn called the knowledge-graph (or any KG-backed
+   * fetch tool). When set, the verifier scans the answer for
+   * `[ref:nodeId]` citation markers; an answer with KG evidence but no
+   * markers produces a synthetic `citation_missing` claim that drives the
+   * correctionPrompt retry loop.
+   *
+   * Extracted from the runTrace in `verifierService` alongside
+   * `domainToolsCalled`. Undefined ⇒ "no trace evidence" (dev CLI etc.);
+   * the pipeline skips the citation check in that case.
+   */
+  knowledgeGraphToolsCalled?: boolean;
 }
 
 /** Badge used by the Teams card to communicate verifier status. */

--- a/middleware/packages/harness-verifier/src/correctionPrompt.ts
+++ b/middleware/packages/harness-verifier/src/correctionPrompt.ts
@@ -16,14 +16,27 @@ export function buildCorrectionPrompt(
   if (verdict.status !== 'blocked') return undefined;
 
   const postconditionItems = verdict.contradictions.filter(isPostcondition);
+  const citationItems = verdict.contradictions.filter(isCitationMissing);
   const replayItems = verdict.contradictions.filter(
-    (v) => !isPostcondition(v) && isReplay(v),
+    (v) => !isPostcondition(v) && !isCitationMissing(v) && isReplay(v),
   );
   const dataItems = verdict.contradictions.filter(
-    (v) => !isPostcondition(v) && !isReplay(v),
+    (v) =>
+      !isPostcondition(v) && !isCitationMissing(v) && !isReplay(v),
   );
 
   const sections: string[] = ['# Verifier hat Widersprüche erkannt', ''];
+
+  if (citationItems.length > 0) {
+    sections.push(
+      '## Fehlende Citations',
+      '',
+      'Du hast in diesem Turn die Wissens-Datenbank (knowledge graph) abgefragt, aber deine Antwort enthält keinen `[ref:nodeId]`-Marker. Jede Aussage, die du aus den Graph-Ergebnissen ableitest, muss mit der nodeId der Quelle versehen sein — sonst ist sie für den User nicht nachvollziehbar.',
+      '',
+      '**Jetzt bitte:** schreibe die Antwort neu und hänge nach jeder graph-basierten Aussage `[ref:<nodeId>]` an (die nodeIds findest du in den vorherigen `query_knowledge_graph`-Tool-Results). Wenn eine Aussage nicht aus dem Graph kommt (z.B. allgemeines Wissen oder eine direkte Tool-Antwort), brauchst du dort keine Citation. Der Channel-Layer entfernt die Marker vor der Anzeige — du musst dir um die Optik keine Sorgen machen, der Marker dient nur der Verifizierung.',
+      '',
+    );
+  }
 
   if (postconditionItems.length > 0) {
     sections.push(
@@ -69,6 +82,11 @@ export function buildCorrectionPrompt(
 function isPostcondition(v: ClaimVerdict): boolean {
   if (v.status !== 'contradicted') return false;
   return v.claim.type === 'tool_postcondition';
+}
+
+function isCitationMissing(v: ClaimVerdict): boolean {
+  if (v.status !== 'contradicted') return false;
+  return v.claim.type === 'citation_missing';
 }
 
 function isReplay(v: ClaimVerdict): boolean {

--- a/middleware/packages/harness-verifier/src/verifierPipeline.ts
+++ b/middleware/packages/harness-verifier/src/verifierPipeline.ts
@@ -70,13 +70,23 @@ export class VerifierPipeline {
     // drives the existing correctionPrompt retry loop.
     const postconditionVerdicts = buildPostconditionVerdicts(input);
 
+    // #131 — turn fetched knowledge-graph evidence but the answer carries
+    // no `[ref:nodeId]` citations. Synthetic contradicted verdict, same
+    // retry path. Skipped when `knowledgeGraphToolsCalled` is undefined
+    // (no trace evidence — e.g. dev CLI) or false (turn didn't touch the
+    // graph at all, so citations are irrelevant).
+    const citationVerdicts = buildCitationMissingVerdicts(input);
+
+    const synthetic = [
+      ...replayVerdicts,
+      ...postconditionVerdicts,
+      ...citationVerdicts,
+    ];
+
     const trigger = shouldTriggerVerifier(input.answer);
     if (!trigger.shouldVerify) {
       // Only the synthetic (no-extraction-needed) verdicts matter here.
-      return aggregate(
-        [...replayVerdicts, ...postconditionVerdicts],
-        started,
-      );
+      return aggregate(synthetic, started);
     }
 
     let claims: Claim[];
@@ -87,20 +97,14 @@ export class VerifierPipeline {
       });
     } catch (err) {
       this.log(`[verifier/pipeline] extractor FAIL: ${errMsg(err)}`);
-      return aggregate(
-        [...replayVerdicts, ...postconditionVerdicts],
-        started,
-      );
+      return aggregate(synthetic, started);
     }
 
     if (claims.length === 0) {
       this.log(
         `[verifier/pipeline] no claims extracted (trigger=${trigger.reasons.join(',')})`,
       );
-      return aggregate(
-        [...replayVerdicts, ...postconditionVerdicts],
-        started,
-      );
+      return aggregate(synthetic, started);
     }
 
     const { hard, soft } = classify(claims);
@@ -131,14 +135,47 @@ export class VerifierPipeline {
     ]);
 
     const all: ClaimVerdict[] = [
-      ...replayVerdicts,
-      ...postconditionVerdicts,
+      ...synthetic,
       ...traceVerdicts,
       ...hardVerdicts,
       ...softVerdicts,
     ];
     return aggregate(all, started);
   }
+}
+
+/**
+ * #131 — turn fetched knowledge-graph evidence but the answer carries no
+ * `[ref:nodeId]` citations. Same shape as the postcondition synthesiser:
+ * skip when no trace evidence, no KG calls, or citations are present;
+ * otherwise emit one contradicted ClaimVerdict that flips the aggregate
+ * to blocked and drives the correctionPrompt retry.
+ *
+ * Detector is a flat regex over the answer text — node-id-shape is loose
+ * on purpose so plugins that mint their own node-ids (Confluence /
+ * Odoo prefixes) don't need to update this file.
+ */
+const CITATION_MARKER_REGEX = /\[ref:[\w-]+\]/i;
+
+function buildCitationMissingVerdicts(input: VerifierInput): ClaimVerdict[] {
+  if (input.knowledgeGraphToolsCalled !== true) return [];
+  if (CITATION_MARKER_REGEX.test(input.answer)) return [];
+  return [
+    {
+      status: 'contradicted',
+      claim: {
+        id: 'c_citation_missing',
+        text: 'Answer pulled knowledge-graph evidence but contains no [ref:nodeId] citations.',
+        type: 'citation_missing',
+        expectedSource: 'graph',
+        relatedEntities: [],
+      },
+      truth: null,
+      source: 'graph',
+      detail:
+        'Add `[ref:<nodeId>]` after every assertion grounded in the knowledge graph so the verifier can attribute the claim to a source.',
+    },
+  ];
 }
 
 /**

--- a/middleware/src/plugins/citationGuard.ts
+++ b/middleware/src/plugins/citationGuard.ts
@@ -1,0 +1,48 @@
+/**
+ * #131 — Citation-Guard system-prompt fragment.
+ *
+ * Mandates that every assertion grounded in knowledge-graph evidence
+ * carries an inline `[ref:<nodeId>]` marker so the verifier can attribute
+ * the claim to its source. The verifier-pipeline (see
+ * `harness-verifier/src/verifierPipeline.ts#buildCitationMissingVerdicts`)
+ * checks the answer for these markers when the runTrace shows a
+ * `query_knowledge_graph` call; an answer with KG evidence but no
+ * markers fails the verifier with a `citation_missing` claim and the
+ * existing correctionPrompt retry loop fires.
+ *
+ * Pattern parallel to `compileSycophancyGuard` and the
+ * Math-Delegation rule shipped by `@omadia/plugin-deterministic-tools`:
+ * a small German prompt section the kernel splices into every system
+ * prompt. Always-on — no per-agent toggle.
+ *
+ * The channel layer (web-ui markdown renderer, Teams card renderer)
+ * strips the `[ref:...]` markers before the user sees the answer.
+ */
+
+export const CITATION_GUARD_HEADING = '## Knowledge-Graph Citation-Pflicht';
+
+const BODY = `Wenn du in diesem Turn Daten aus der Wissens-Datenbank (Tool \`query_knowledge_graph\`) verwendest, MUSST du jede daraus abgeleitete Aussage mit einem \`[ref:<nodeId>]\`-Marker versehen. Die nodeId kommt aus den \`nodeId\`-Feldern der Tool-Results.
+
+Beispiel:
+- ❌ "Die Rechnung INV/2026/0042 ist offen."  (keine Quelle → wird vom Verifier zurückgewiesen)
+- ✅ "Die Rechnung INV/2026/0042 ist offen [ref:n_invoice_42]."
+
+Wenn eine Aussage NICHT aus dem Graph stammt (allgemeines Wissen, direkte Tool-Antwort, vom User mitgegebene Information), brauchst du dort keine Citation.
+
+Der Channel-Layer entfernt \`[ref:...]\`-Marker vor der Darstellung beim User — du musst dir um die Optik keine Sorgen machen. Die Marker dienen ausschließlich der internen Verifizierung.
+
+Ohne Citations wird die Antwort blockiert und du wirst aufgefordert, sie mit Marker neu zu schreiben (Cost: ein zusätzlicher Turn). Daher gleich beim ersten Versuch ergänzen.`;
+
+/**
+ * Returns the citation-guard prompt section. Always-on — no per-agent
+ * configuration. The orchestrator simply concatenates the result into
+ * the compiled system prompt next to sycophancy + boundaries.
+ *
+ * Returns an empty string when called with the explicit `'off'` level
+ * to support a future Per-Agent override pattern; today there is no
+ * such override and the call site passes nothing.
+ */
+export function compileCitationGuard(level: 'on' | 'off' = 'on'): string {
+  if (level === 'off') return '';
+  return `${CITATION_GUARD_HEADING}\n\n${BODY}`;
+}

--- a/middleware/src/plugins/dynamicAgentRuntime.ts
+++ b/middleware/src/plugins/dynamicAgentRuntime.ts
@@ -31,6 +31,7 @@ import type { PluginCatalog, PluginCatalogEntry } from './manifestLoader.js';
 import { composePersonaSection } from './personaCompose.js';
 import type { PersonaModelFamily } from './personaDelta.js';
 import { compileBoundariesSection } from './builder/boundaryPresets.js';
+import { compileCitationGuard } from './citationGuard.js';
 import { compileSycophancyGuard } from './sycophancyGuard.js';
 import { topoSortByDependsOn } from './topoSort.js';
 import type { UploadedPackageStore } from './uploadedPackageStore.js';
@@ -648,12 +649,17 @@ async function loadSystemPrompt(
   const personaSection = await composePersonaFromAgentMd(packageRoot, modelId);
   const boundariesSection = await composeBoundariesFromAgentMd(packageRoot);
   const sycophancySection = await composeSycophancyFromAgentMd(packageRoot);
+  // #131 — Citation-Guard is always-on. It only changes the answer shape
+  // for turns that actually call `query_knowledge_graph`; the verifier
+  // ignores the citation check for turns that don't.
+  const citationSection = compileCitationGuard();
 
   const header = buildHeader(entry);
   const parts: string[] = [header];
   if (personaSection.length > 0) parts.push(personaSection);
   if (boundariesSection.length > 0) parts.push(boundariesSection);
   if (sycophancySection.length > 0) parts.push(sycophancySection);
+  if (citationSection.length > 0) parts.push(citationSection);
   if (skillParts.length > 0) parts.push(skillParts.join('\n\n---\n\n'));
   return parts.join('\n\n---\n\n');
 }

--- a/middleware/test/verifierPipelineCitation.test.ts
+++ b/middleware/test/verifierPipelineCitation.test.ts
@@ -1,0 +1,184 @@
+/**
+ * #131 — Citation Enforcement. The pipeline must:
+ *   - Emit a synthetic `citation_missing` ClaimVerdict (status='contradicted')
+ *     when the turn called the knowledge-graph AND the answer contains no
+ *     `[ref:nodeId]` markers.
+ *   - Stay silent when the turn didn't touch the graph (flag=false).
+ *   - Stay silent when the answer carries at least one `[ref:...]` marker.
+ *   - Stay silent when no trace evidence is available (flag=undefined).
+ */
+
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  VerifierPipeline,
+  type Claim,
+  type ClaimExtractor,
+  type ClaimVerdict,
+  type DeterministicChecker,
+  type EvidenceJudge,
+  type HardClaim,
+  type SoftClaim,
+} from '@omadia/verifier';
+
+function stubExtractor(claims: Claim[]): ClaimExtractor {
+  return {
+    extract(): Promise<Claim[]> {
+      return Promise.resolve(claims);
+    },
+  } as unknown as ClaimExtractor;
+}
+
+function stubDeterministic(
+  verdictFor: (c: HardClaim) => ClaimVerdict,
+): DeterministicChecker {
+  return {
+    check(c: HardClaim): Promise<ClaimVerdict> {
+      return Promise.resolve(verdictFor(c));
+    },
+    checkAll(claims: HardClaim[]): Promise<ClaimVerdict[]> {
+      return Promise.all(claims.map((c) => Promise.resolve(verdictFor(c))));
+    },
+  } as unknown as DeterministicChecker;
+}
+
+function stubJudge(
+  verdictFor: (c: SoftClaim) => ClaimVerdict,
+): EvidenceJudge {
+  return {
+    check(c: SoftClaim): Promise<ClaimVerdict> {
+      return Promise.resolve(verdictFor(c));
+    },
+    checkAll(claims: SoftClaim[]): Promise<ClaimVerdict[]> {
+      return Promise.all(claims.map((c) => Promise.resolve(verdictFor(c))));
+    },
+  } as unknown as EvidenceJudge;
+}
+
+function hardClaim(): HardClaim {
+  return {
+    id: 'c_h',
+    text: '1.234,56 €',
+    type: 'amount',
+    expectedSource: 'odoo',
+    value: 1234.56,
+    odooRecord: { model: 'account.move', id: 42 },
+    relatedEntities: [],
+  };
+}
+
+function softClaim(): SoftClaim {
+  return {
+    id: 'c_s',
+    text: 'Foo ist Senior Dev',
+    type: 'qualitative',
+    expectedSource: 'graph',
+    relatedEntities: [],
+  };
+}
+
+const SILENT_LOG = (): void => {
+  /* silent */
+};
+
+function makePipeline(): VerifierPipeline {
+  return new VerifierPipeline({
+    extractor: stubExtractor([hardClaim()]),
+    deterministic: stubDeterministic((c) => ({
+      status: 'verified',
+      claim: c,
+      source: 'odoo',
+    })),
+    judge: stubJudge((c) => ({
+      status: 'verified',
+      claim: c,
+      source: 'graph',
+    })),
+    log: SILENT_LOG,
+  });
+}
+
+describe('verifier/pipeline — citation enforcement (#131)', () => {
+  it('blocks when KG was called and the answer has no [ref:nodeId] marker', async () => {
+    const pipeline = makePipeline();
+    const verdict = await pipeline.verify({
+      runId: 'r_cite_a',
+      userMessage: 'Who is foo?',
+      answer: 'Foo is a senior developer.',
+      knowledgeGraphToolsCalled: true,
+    });
+    assert.equal(verdict.status, 'blocked');
+    if (verdict.status === 'blocked') {
+      const citation = verdict.contradictions.find(
+        (v) => v.status === 'contradicted' && v.claim.type === 'citation_missing',
+      );
+      assert.ok(citation, 'citation_missing claim should be present');
+      assert.equal(citation?.claim.id, 'c_citation_missing');
+    }
+  });
+
+  it('approves when KG was called and the answer carries [ref:nodeId]', async () => {
+    const pipeline = makePipeline();
+    const verdict = await pipeline.verify({
+      runId: 'r_cite_b',
+      userMessage: 'Who is foo?',
+      answer: 'Foo is a senior developer [ref:n_user_42].',
+      knowledgeGraphToolsCalled: true,
+    });
+    assert.equal(verdict.status, 'approved');
+  });
+
+  it('approves when the turn never called the knowledge graph', async () => {
+    const pipeline = makePipeline();
+    const verdict = await pipeline.verify({
+      runId: 'r_cite_c',
+      userMessage: 'Was?',
+      answer: 'Die Rechnung beträgt 1.234,56 €.',
+      knowledgeGraphToolsCalled: false,
+    });
+    assert.equal(verdict.status, 'approved');
+  });
+
+  it('approves when no trace evidence is available (knowledgeGraphToolsCalled=undefined)', async () => {
+    const pipeline = makePipeline();
+    const verdict = await pipeline.verify({
+      runId: 'r_cite_d',
+      userMessage: 'Was?',
+      answer: 'Die Rechnung beträgt 1.234,56 €.',
+    });
+    assert.equal(verdict.status, 'approved');
+  });
+});
+
+describe('verifier/correctionPrompt — citation_missing section (#131)', () => {
+  it('emits a Fehlende-Citations section when citation_missing contradictions are present', async () => {
+    const { buildCorrectionPrompt } = await import('@omadia/verifier');
+    const verdict = {
+      status: 'blocked' as const,
+      claims: [],
+      contradictions: [
+        {
+          status: 'contradicted' as const,
+          claim: {
+            id: 'c_citation_missing',
+            text: 'Answer pulled knowledge-graph evidence but contains no [ref:nodeId] citations.',
+            type: 'citation_missing' as const,
+            expectedSource: 'graph' as const,
+            relatedEntities: [],
+          },
+          truth: null,
+          source: 'graph' as const,
+          detail: 'Add `[ref:<nodeId>]` …',
+        },
+      ],
+      latencyMs: 0,
+    };
+    const prompt = buildCorrectionPrompt(verdict);
+    assert.ok(prompt);
+    assert.match(prompt, /## Fehlende Citations/);
+    assert.match(prompt, /\[ref:<nodeId>\]/);
+    assert.doesNotMatch(prompt, /## Tool-Output nicht spec-konform/);
+    assert.doesNotMatch(prompt, /## Falsche \/ widerlegte Daten/);
+  });
+});

--- a/web-ui/app/_components/Markdown.tsx
+++ b/web-ui/app/_components/Markdown.tsx
@@ -4,6 +4,8 @@ import { useMemo, type ComponentProps } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
+import { stripCitationMarkers } from '../_lib/citations';
+
 /**
  * Thin wrapper that renders GitHub-flavored markdown with our project-local
  * `.md-view` class. Global styles in globals.css handle typography. Keeping
@@ -110,10 +112,13 @@ export function Markdown({
         : undefined,
     [highlightTerms],
   );
+  // #131 — strip `[ref:nodeId]` citation markers before render. The verifier
+  // uses them to attribute KG-evidence claims; the user just sees the prose.
+  const displayed = useMemo(() => stripCitationMarkers(source), [source]);
   return (
     <div className="md-view">
       <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={rehypePlugins}>
-        {source}
+        {displayed}
       </ReactMarkdown>
     </div>
   );

--- a/web-ui/app/_lib/__tests__/citations.test.ts
+++ b/web-ui/app/_lib/__tests__/citations.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { stripCitationMarkers } from '../citations';
+
+describe('stripCitationMarkers (#131)', () => {
+  it('removes a single inline citation marker', () => {
+    expect(
+      stripCitationMarkers('Foo is a senior dev [ref:n_user_42].'),
+    ).toBe('Foo is a senior dev.');
+  });
+
+  it('removes multiple markers in one string', () => {
+    expect(
+      stripCitationMarkers(
+        'A [ref:n_a] and B [ref:n_b] and C [ref:n_c].',
+      ),
+    ).toBe('A and B and C.');
+  });
+
+  it('accepts node ids with hyphens, underscores and digits', () => {
+    expect(
+      stripCitationMarkers('Result [ref:confluence-page-89].'),
+    ).toBe('Result.');
+    expect(stripCitationMarkers('Result [ref:n_42-foo_bar].')).toBe(
+      'Result.',
+    );
+  });
+
+  it('is a no-op when no markers are present', () => {
+    const src = 'Plain prose without any marker.';
+    expect(stripCitationMarkers(src)).toBe(src);
+  });
+
+  it('is idempotent', () => {
+    const src = 'Foo [ref:n_42] and bar [ref:n_99].';
+    const once = stripCitationMarkers(src);
+    expect(stripCitationMarkers(once)).toBe(once);
+  });
+
+  it('leaves bracketed text without the `ref:` prefix untouched', () => {
+    const src = 'See [docs] and [example].';
+    expect(stripCitationMarkers(src)).toBe(src);
+  });
+});

--- a/web-ui/app/_lib/citations.ts
+++ b/web-ui/app/_lib/citations.ts
@@ -1,0 +1,21 @@
+/**
+ * #131 — strip `[ref:<nodeId>]` citation markers from an answer string
+ * before it lands in the markdown renderer. The orchestrator's verifier
+ * uses the markers to prove KG-evidence-grounded claims; the user just
+ * sees the prose.
+ *
+ * Pure function — no I/O, no side effects — so callers can pipe the
+ * source through it inline (`<Markdown source={stripCitationMarkers(raw)} />`)
+ * without memoising. Idempotent: stripping twice is a no-op.
+ *
+ * NodeId shape is loose on purpose: plugins mint their own prefixes
+ * (`n_invoice_42`, `confluence-page-89`, `odoo://res.partner/7`) and a
+ * tight regex here would break with the next backend addition. The
+ * verifier's detection regex (`harness-verifier/src/verifierPipeline.ts`)
+ * uses the same loose pattern, so the two stay in lock-step.
+ */
+const CITATION_MARKER_REGEX = /\s?\[ref:[\w-]+\]/gi;
+
+export function stripCitationMarkers(source: string): string {
+  return source.replace(CITATION_MARKER_REGEX, '');
+}

--- a/web-ui/app/store/builder/[id]/_components/BuilderMarkdown.tsx
+++ b/web-ui/app/store/builder/[id]/_components/BuilderMarkdown.tsx
@@ -4,6 +4,8 @@ import { Children, isValidElement, type ReactElement, type ReactNode } from 'rea
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
+import { stripCitationMarkers } from '../../../../_lib/citations';
+
 /**
  * Workspace-Markdown.
  *
@@ -18,6 +20,9 @@ import remarkGfm from 'remark-gfm';
  * Markdown surface without auditing every other consumer first.
  */
 export function BuilderMarkdown({ source }: { source: string }): React.ReactElement {
+  // #131 — strip `[ref:nodeId]` citation markers before render. Same
+  // contract as the main-chat Markdown component.
+  const displayed = stripCitationMarkers(source);
   return (
     <div className="md-view">
       <ReactMarkdown
@@ -31,7 +36,7 @@ export function BuilderMarkdown({ source }: { source: string }): React.ReactElem
           },
         }}
       >
-        {source}
+        {displayed}
       </ReactMarkdown>
     </div>
   );


### PR DESCRIPTION
Closes #131.

## Summary
Every assertion the LLM makes from `query_knowledge_graph` results must now carry an inline \`[ref:<nodeId>]\` marker. Without it, the verifier blocks the answer and the existing correctionPrompt retry forces the model to rewrite with citations.

Mechanism is the same shape as #130's \`tool_postcondition\`: a synthetic \`citation_missing\` ClaimVerdict, manufactured pre-extraction, flips the verdict to \`blocked\` and feeds back into the orchestrator's existing retry path. No new retry loop introduced.

## How it composes
- **System-prompt** (always-on, kernel-side): \`compileCitationGuard()\` ships a German Citation-Pflicht fragment with one example pair (✅/❌). Spliced into every agent's system prompt next to sycophancy + boundaries.
- **Verifier**:
  - \`ClaimType\` += \`'citation_missing'\`
  - \`VerifierInput.knowledgeGraphToolsCalled?: boolean\` (extracted from runTrace in \`verifierService\`)
  - \`verifierPipeline.buildCitationMissingVerdicts\` runs a regex over the answer; KG-called + no marker → contradicted ClaimVerdict
  - \`buildCorrectionPrompt\` emits a \"## Fehlende Citations\" section with worked example
- **Channel-Layer** (web-ui): \`stripCitationMarkers\` removes \`[ref:...]\` before render in both \`Markdown.tsx\` and \`BuilderMarkdown.tsx\`. User sees clean prose; verifier still gets the unstripped string.

## NodeId shape
Loose regex \`\\[ref:[\\w-]+\\]\` — plugins mint their own prefixes (\`n_invoice_42\`, \`confluence-page-89\`, \`odoo://res.partner/7\` — well, slash isn't in the loose set; future plugins may need to URL-encode if they want full external refs). Verifier detection and channel strip use the **same** regex, so they stay in lock-step.

## Files
- \`middleware/packages/harness-verifier/src/{claimTypes,verifierPipeline,correctionPrompt}.ts\` — synthetic claim + retry section
- \`middleware/packages/harness-orchestrator/src/verifierService.ts\` — \`extractKnowledgeGraphToolsCalled\` helper
- \`middleware/src/plugins/{citationGuard,dynamicAgentRuntime}.ts\` — system-prompt fragment + composer wiring
- \`web-ui/app/_lib/citations.ts\` + both Markdown components — display strip
- \`middleware/test/verifierPipelineCitation.test.ts\` — 5 new tests
- \`web-ui/app/_lib/__tests__/citations.test.ts\` — 6 new tests

## Test plan
- [x] middleware: \`npm test\` → 2637/2639 pass (0 fail)
- [x] web-ui: \`vitest citations.test.ts\` → 6/6 pass
- [x] Full typecheck: \`exit=0\`
- [x] Lint clean (0 errors)
- [x] Boot smoke: kernel reaches plugin catalog without citation-related crash
- [ ] **Manual e2e after merge**: trigger a turn that hits \`query_knowledge_graph\`, confirm answer carries \`[ref:...]\` markers, confirm web-ui hides them

## Notes
- Behavior gracefully degrades: \`knowledgeGraphToolsCalled\` undefined ⇒ skip the citation check (e.g. dev CLI without sessionScope). Today only the kernel KG tool counts — sub-agent / domain-tool wrappers that fetch from KG transitively would need an explicit opt-in (deferrable).
- The system-prompt fragment is always-on. If we later need to disable for certain agents, \`compileCitationGuard('off')\` returns an empty string — wire-up is one line in \`dynamicAgentRuntime\`.

Addresses Recommendation #5 (factual hallucination / citation grounding) from the May 2026 LLM-harness audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)