### PR TITLE
feat(registry): plugin store MVP — admin-managed remote registries, remote install + depends_on chaining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,15 @@ tmp/
 # harness platform sources. See marketing-site/docs/00-isolation.md.
 marketing-site/
 
+# ─── Plugin hub / registry service (NEVER commit — separate repo) ─────────
+# hub.omadia.ai — the registry SERVICE (Blob + metadata + /api/publish) and
+# its human storefront UI. byte5-hosted, outside OSS-Core scope. Lives in its
+# own repo (byte5ai/omadia-hub), mirrored here as a gitignored folder exactly
+# like marketing-site. NOTE: the registry *client* (RegistryClient, remote
+# install, store merge) IS OSS-Core and lives in middleware/src/ — only the
+# hosted service is private.
+hub/
+
 # ─── byte5-specific agent + deployment configs (private) ──────────────────
 # These describe a specific byte5 deployment (Fly app, Neon project, kroki
 # sidecars, customer-specific agent configs) and must never land in public

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Dieser Ordner ist das kollektive Gedächtnis des Omadia-Projekts. Mehrere Agents
 | [`middleware-agent-handoff.md`](middleware-agent-handoff.md) | Architektur, Layout, Commands, Config, Roadmap — der **primäre** Tech-Einstieg | Bei jeder strukturellen Änderung | Feature-Agents |
 | [`CHANGELOG.md`](CHANGELOG.md) | Rolling chronologische Chronik aller signifikanten Änderungen | Nach jeder Aufgabe | Der Agent, der die Änderung macht |
 | [`security-architecture.md`](security-architecture.md) | Security-Design-Patterns (Vault-Credentials, Proxy-Routes, Scope-Locked Sub-Agents, signed URLs) | Bei Security-Architektur-Änderungen | Security-Thread |
+| [`creating-plugins.md`](creating-plugins.md) | HowTo: Plugin bauen (Scaffold → Manifest → ZIP) + Publish auf den Hub | Bei Änderungen am Package-Contract / Publish-Flow | Plugin-/Registry-Thread |
 
 ## Lebende Docs (öffentliche Untermenge)
 

--- a/docs/creating-plugins.md
+++ b/docs/creating-plugins.md
@@ -1,0 +1,246 @@
+# Ein Plugin bauen & im Hub veröffentlichen
+
+Diese Anleitung führt von „leeres Verzeichnis" bis „installierbar aus dem Hub".
+Ein Plugin ist ein **standalone Package**, das als `.zip` hochgeladen wird — der
+Server validiert das Manifest, prüft Peer-Dependencies und registriert es im
+Katalog. Es gibt drei `kind`s:
+
+| kind | Was es ist | Beispiel |
+|---|---|---|
+| `agent` | Capability-Anbieter mit Toolkit (Zod-Tools) + System-Prompt | `agent-seo-analyst` |
+| `integration` | reiner Credential-/HTTP-Client, kein Toolkit | `de.byte5.integration.odoo` |
+| `channel` | User-Surface (Teams, Telegram, …) mit Transport + Adaptern | `harness-channel-teams` |
+
+> **Quellen der Wahrheit (nicht halluzinieren):**
+> Referenz-Agent `middleware/packages/agent-seo-analyst/`,
+> Boilerplate `middleware/assets/boilerplate/{agent-pure-llm,agent-integration}/`,
+> Package-Contract `middleware/assets/boilerplate/agent-pure-llm/CLAUDE.md`
+> (die 10 Checkliste-Punkte), Runtime-Contract
+> `middleware/src/platform/pluginContext.ts`.
+
+---
+
+## 0. Voraussetzungen
+
+- Node `>=20` (das Repo pinnt `22.x` in `.nvmrc` → `nvm use`).
+- Zugang zur Admin-UI (`https://odoo-bot-harness.fly.dev`) für den Upload.
+- Zum **Publishen** auf den Hub: das `HUB_PUBLISH_TOKEN` (Bearer-Token, liegt
+  im Vercel-Env des Hub-Projekts — write-only, nicht im Chat leaken).
+
+---
+
+## 1. Scaffold aus der Boilerplate
+
+Wähle das Template nach Bedarf: `agent-pure-llm` (kein externes API, reines
+Prompting) oder `agent-integration` (echter HTTP-Client + Secrets).
+
+```bash
+cp -R middleware/assets/boilerplate/agent-pure-llm \
+      middleware/packages/agent-<slug>
+cd middleware/packages/agent-<slug>
+
+# Skill-Datei umbenennen
+mv skills/{{AGENT_SLUG}}-expert.md skills/<slug>-expert.md
+```
+
+Package-Layout (flach, am Root):
+
+```
+agent-<slug>/
+├── manifest.yaml         # deklarative Definition (Schema v1) — Pflicht
+├── package.json          # name === manifest.identity.id, "type":"module", "private":true
+├── tsconfig.json         # NodeNext, rootDir:"./", outDir:"./dist"
+├── types.ts              # lokales PluginContext-Duplikat (KEIN Cross-Import!)
+├── plugin.ts             # activate(ctx) → { toolkit, close() }
+├── toolkit.ts            # Capability → ToolDescriptor[] (Zod-Input + run)
+├── client.ts             # externe API (LLM-frei, testbar) — nur agent-integration
+├── index.ts              # Barrel
+├── skills/<slug>-expert.md   # System-Prompt-Partial (YAML-Frontmatter)
+├── assets/               # icon.png etc. (optional)
+└── scripts/build-zip.mjs # tsc + stage + zip → out/<id>-<version>.zip
+```
+
+---
+
+## 2. Manifest ausfüllen (`manifest.yaml`)
+
+Ersetze alle `{{PLATZHALTER}}`. Die **`identity`**-Felder + `compat.core` sind
+das, was Hub und Katalog für die Listing-Kachel lesen — der Rest wird beim
+Install voll validiert.
+
+```yaml
+schema_version: "1"
+
+identity:
+  id: "de.byte5.agent.<slug>"      # lowercase, dotted; === package.json "name"
+  kind: "agent"                    # agent | integration | channel
+  domain: "<domain>"               # z.B. coaching, m365.sharepoint
+  name: "<Anzeigename>"
+  version: "0.1.0"                 # SemVer; === package.json "version"
+  description: "<Beschreibung DE>"
+  authors:
+    - name: "byte5 GmbH"
+      email: "info@omadia.ai"
+  license: "Proprietary"           # oder MIT, …
+  icon: "./assets/icon.png"
+  categories: ["<kategorie>"]
+
+compat:
+  core: ">=1.0 <2.0"
+  node: ">=20"
+
+multi_instance: true
+privacy_class: "strict"
+depends_on: []                     # IDs von Parent-Integrations (Secret-Chain)
+
+setup:
+  fields: []                       # Setup-Felder → rendern automatisch im Install-Drawer
+  self_test: false
+
+capabilities: []                   # Tools liefert das toolkit; [] = pure-LLM
+
+skills:
+  - id: "<slug>_expert_system"
+    kind: "prompt_partial"
+    path: "skills/<slug>-expert.md"
+    description: "Rolle & Arbeitsweise."
+
+permissions:
+  memory:
+    reads: ["session:*", "agent:de.byte5.agent.<slug>:*"]
+    writes: ["agent:de.byte5.agent.<slug>:*"]
+  network:
+    outbound: []                   # erlaubte Hosts (leer = pure-LLM)
+```
+
+**Regeln, die sonst erst zur Install-/Ingest-Zeit knallen:**
+- `package.json` `name`/`version` müssen **exakt** `identity.id`/`identity.version` spiegeln.
+- Deps via `peerDependencies` (nicht `dependencies`) — Ingest warnt sonst via `peers_missing`.
+- `setup.fields` nur deklarieren, wenn der Parent (`depends_on`) sie **nicht** schon hat (sonst silent override).
+
+---
+
+## 3. Implementieren
+
+- **`activate(ctx)`** gibt fix zurück:
+  `{ toolkit: { tools: ToolDescriptor[]; close() }, close() }`.
+  `ToolDescriptor = { id, description, input: ZodSchema, run(input) }`.
+- Kein eigener LLM-Client, keine eigene Tool-Loop — die Runtime macht
+  SubAgent-Wrap, Tool-Bridge, Tool-Name-Derivation (`…agent.<slug>` →
+  `query_<slug>`) und System-Prompt-Concat aus `skills/*.md`.
+- Secrets/Config nur über `ctx`:
+  `await ctx.secrets.get(k)` / `.require(k)` (async), `ctx.config.get<T>(k)` (sync).
+- System-Prompt gehört in `skills/<slug>-expert.md` (Markdown + YAML-Frontmatter),
+  **nicht** in den Code.
+
+Details + Zod-Support-Matrix + Lifecycle-Budgets: die 10 Punkte in
+`middleware/assets/boilerplate/agent-pure-llm/CLAUDE.md`. Kanonische Vorlage:
+`middleware/packages/agent-seo-analyst/`.
+
+```bash
+npm install
+npm run lint:fix && npm run typecheck   # nicht bauen — nur prüfen
+```
+
+---
+
+## 4. ZIP bauen
+
+```bash
+node scripts/build-zip.mjs
+# ▶ tsc … ✓ built out/de.byte5.agent.<slug>-0.1.0.zip
+```
+
+Das Script: `tsc` → `dist/`, kopiert Runtime-Artefakte (`manifest.yaml`,
+`package.json`, `README.md`, `dist/`, `skills/`, `assets/`) nach
+`out/<id>-<version>-package/`, verifiziert dass der `dist/`-Entry existiert,
+und zippt nach `out/<id>-<version>.zip`. **Im ZIP sind nur Runtime-Artefakte**
+— keine `*.ts`-Quellen außerhalb `dist/`, kein `node_modules`, kein `.env`.
+
+---
+
+## 5. Lokal installieren (Smoke-Test vor dem Publish)
+
+In der Admin-UI: **Store → Tab „Lokal" → Upload-Dropzone** → `out/<id>-<version>.zip`
+hineinziehen. Der Server validiert das Manifest und registriert das Package im
+Katalog; es erscheint als **Verfügbar** im Lokal-Tab. Ein Klick auf die Kachel →
+Detailseite → **Jetzt installieren** (Setup-Felder rendern automatisch aus
+`setup.fields`).
+
+Äquivalent per Admin-API (alle JWT-gated):
+`POST /api/v1/install/plugins/:id` → `POST /api/v1/install/jobs/:id/configure`.
+
+---
+
+## 6. Auf den Hub veröffentlichen
+
+Der Hub (`hub.omadia.ai`) ist eine **dumme Registry**: ein Publish schreibt nur
+Artefakt + `index.json` um, **kein Redeploy**. Der nächste Index-Read enthält
+das Plugin. Versionen sind **immutable**.
+
+```bash
+HUB=https://hub.omadia.ai
+ZIP=out/de.byte5.agent.<slug>-0.1.0.zip
+
+curl -sS -X POST "$HUB/api/publish" \
+  -H "Authorization: Bearer $HUB_PUBLISH_TOKEN" \
+  -F "file=@${ZIP}"
+# → 201 { "ok": true, "id": "...", "version": { ... } }
+```
+
+- Auth: `Authorization: Bearer <HUB_PUBLISH_TOKEN>` (timing-safe geprüft).
+- Body: multipart `file=<zip>` **oder** roher `Content-Type: application/zip`.
+- Max 50 MiB (= Core's Artefakt-Cap).
+- Re-publish derselben `(id, version)` → **409 `publish.version_exists`**.
+  Zum Überschreiben (nur dev): `?overwrite=true` anhängen. Sonst:
+  Version in `manifest.yaml` + `package.json` bumpen, neu bauen, neu publishen.
+- Der Hub extrahiert `manifest.yaml` + `package.json`, validiert leicht (`schema_version: "1"`,
+  `identity.*`, gültiger `kind`), rechnet sha256 über die **exakten** Upload-Bytes
+  und legt den Index-Eintrag an.
+
+Index + Artefakt prüfen:
+
+```bash
+curl -sS "$HUB/registry/index.json" | jq '.plugins[].id'
+# → "de.byte5.agent.<slug>"
+# Artefakt-URL (host-gepinnt, wird beim Read auf HUB_PUBLIC_URL umgeschrieben):
+#   $HUB/registry/<id>/<version>/plugin.zip
+```
+
+---
+
+## 7. Im Hub-Tab erscheinen lassen
+
+In der Admin-UI ist die Default-Registry `hub.omadia.ai` bereits geseedet
+(verwalten unter **Admin → Registries**). **Store → Tab „Hub"** zieht
+`index.json` und zeigt dein Plugin als **Verfügbar** mit dem Badge
+`Hub · <registry>`. „Jetzt installieren" lädt das ZIP, prüft sha256, ingestet
+es lokal und startet dann den normalen Install-Job.
+
+**Zwei harte Constraints** (aus dem Core-Client — sonst schlägt der Install fehl):
+1. Die ZIP-Route **streamt** das Artefakt (kein 302-Redirect) — der Client
+   fetcht mit `redirect: 'error'`.
+2. Der `download_url`-Host muss == registrierter Registry-Host sein
+   (**Host-Pinning**) — nie eine Blob-/`*.vercel.app`-URL.
+
+---
+
+## 8. Troubleshooting
+
+| Symptom | Ursache / Fix |
+|---|---|
+| Plugin taucht nicht im **Hub**-Tab auf, obwohl publiziert | Eine **lokale** Kopie gleicher `id` ist installiert → der Merge bevorzugt lokal (local-wins) und droppt den Remote-Eintrag. Built-in-Plugins (z.B. `@omadia/plugin-office`) sind deshalb nie im Hub-Tab sichtbar — zum Test ein **Nicht-Built-in** publishen. |
+| `409 publish.version_exists` | Version existiert schon (immutable). Version bumpen oder `?overwrite=true` (dev). |
+| `401 publish.unauthorized` | `HUB_PUBLISH_TOKEN` falsch/fehlt. |
+| Ingest warnt `peers_missing` | Deps stehen unter `dependencies` statt `peerDependencies`. |
+| Install scheitert mit `install.missing_capability` | `requires:` im Manifest hat keinen aktiven Provider → der Install-Wizard zeigt die zu installierende Chain. |
+
+---
+
+## Referenzen
+
+- Package-Contract (10 Punkte): `middleware/assets/boilerplate/agent-pure-llm/CLAUDE.md`
+- Kanonischer Agent: `middleware/packages/agent-seo-analyst/`
+- Runtime-Contract: `middleware/src/platform/pluginContext.ts`
+- Store-/Install-Routen: `middleware/src/routes/{store,install,registryInstall}.ts`
+- Registry-Client (Hub-Konsum): `middleware/src/plugins/registryClient.ts`

--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -188,6 +188,16 @@ export interface Plugin {
   integrations_summary: string[];
   install_state: PluginInstallState;
   incompatibility_reasons?: string[];
+  /** Present only for entries sourced from a remote registry that are not yet
+   *  downloaded/ingested locally. Its presence is what tells the install flow
+   *  to fetch-then-ingest (POST /api/v1/install/registry/:id) before the
+   *  normal install-job. Structurally mirrors `RegistrySource` in
+   *  `api/registry-v1.ts`. */
+  source?: {
+    registry: string;
+    download_url: string;
+    sha256: string;
+  };
   /** Parent plugin identities this one inherits secrets/config from. */
   depends_on: AgentId[];
   /** Background jobs the plugin contributes via its manifest. Always

--- a/middleware/src/api/registry-v1.ts
+++ b/middleware/src/api/registry-v1.ts
@@ -1,0 +1,98 @@
+// ===========================================================================
+// Registry API v1 — the `index.json` contract shared between omadia Core and
+// a remote plugin registry (hub.omadia.ai and any private/customer hub).
+// ---------------------------------------------------------------------------
+// The registry is intentionally DUMB (npm-style): it serves a machine-readable
+// catalog + ZIP artifacts. The smart client is omadia Core (`RegistryClient`),
+// which fetches this index, verifies sha256 on download, and feeds the ZIP
+// into the EXISTING `PackageUploadService.ingest` pipeline.
+//
+// Trust model (MVP): sha256 pinned here + HTTPS/TLS. No per-artifact signing
+// yet — `Plugin.signed` stays false for registry-sourced entries.
+//
+// SOURCE OF TRUTH for this shape: keep in sync with the hub's
+// `GET /registry/index.json` implementation.
+// ===========================================================================
+
+import type { ISO8601, PluginKind } from './admin-v1.js';
+
+/** A single installable version of a plugin, as advertised by a registry. */
+export interface RegistryVersionEntry {
+  version: string;
+  /** Harness-core semver constraint from the manifest's `compat.core`. */
+  compat_core: string;
+  /** Lowercase hex SHA-256 of the ZIP artifact. Verified post-download. */
+  sha256: string;
+  size_bytes: number;
+  /** Absolute URL to the ZIP. Same-origin with the registry url by convention,
+   *  but may point at a CDN/Blob host — only the host allowlist is enforced. */
+  download_url: string;
+  published_at: ISO8601;
+  /** Enough manifest detail for the store UI to render an install preview
+   *  WITHOUT downloading the ZIP. Heavy validation still happens at Core
+   *  install-time inside `PackageUploadService.ingest`. */
+  manifest_summary: RegistryManifestSummary;
+}
+
+/** Lightweight manifest projection surfaced in the index. All fields optional
+ *  so the contract tolerates older/sparser registries. */
+export interface RegistryManifestSummary {
+  provides?: string[];
+  requires?: string[];
+  depends_on?: string[];
+  /** Setup fields the operator must fill at install-time. Mirrors
+   *  `PluginSetupField` but kept loose here to avoid a hard schema coupling. */
+  setup_fields?: Array<Record<string, unknown>>;
+  permissions?: Record<string, unknown>;
+}
+
+/** One plugin (all of its published versions) in a registry index. */
+export interface RegistryPluginEntry {
+  id: string;
+  name: string;
+  kind: PluginKind;
+  domain: string;
+  description: string;
+  categories: string[];
+  authors: Array<{ name: string; email?: string; url?: string }>;
+  license: string;
+  icon_url: string | null;
+  latest_version: string;
+  /** Newest-first by convention; the client does not rely on ordering. */
+  versions: RegistryVersionEntry[];
+}
+
+/** Top-level shape of `GET /registry/index.json`. */
+export interface RegistryIndexV1 {
+  schema_version: '1';
+  registry: { name: string; url: string };
+  generated_at: ISO8601;
+  plugins: RegistryPluginEntry[];
+}
+
+/**
+ * One configured upstream registry. Multi-registry from day one: Core holds a
+ * list of these. `token`, when present, is sent as `Authorization: Bearer` on
+ * both index and artifact fetches — this is how a private byte5/customer hub
+ * is consumed.
+ */
+export interface RegistryConfigEntry {
+  /** Base URL, e.g. `https://hub.omadia.ai`. Doubles as the host allowlist. */
+  url: string;
+  /** Stable short name used to namespace entries + label the source. */
+  name: string;
+  /** Optional bearer token for private registries. */
+  token?: string;
+}
+
+/**
+ * Discriminator attached to a `Plugin` whose artifact lives on a remote
+ * registry (not yet downloaded/uploaded locally). Its presence is what tells
+ * the install flow to fetch-then-ingest rather than activate directly.
+ */
+export interface RegistrySource {
+  /** `name` of the originating `RegistryConfigEntry`. */
+  registry: string;
+  download_url: string;
+  sha256: string;
+}

--- a/middleware/src/config.ts
+++ b/middleware/src/config.ts
@@ -3,6 +3,8 @@ import { fileURLToPath } from 'node:url';
 import dotenv from 'dotenv';
 import { z } from 'zod';
 
+import type { RegistryConfigEntry } from './api/registry-v1.js';
+
 // Resolve .env relative to this file so the server works from any CWD.
 const here = path.dirname(fileURLToPath(import.meta.url));
 // From src/ or dist/ the project root is always one directory up.
@@ -325,6 +327,21 @@ const ConfigSchema = z.object({
    *  author can shadow a built-in or uploaded plugin without packing/
    *  zipping/uploading every iteration. Default is unset (disabled). */
   PLUGIN_DEV_DIR: z.string().optional(),
+
+  // Remote plugin registries (the plugin "store"). JSON array of
+  // {url,name,token?} entries — Core fetches each registry's `index.json`,
+  // merges them (first-wins on id collision), and installs ZIPs through the
+  // EXISTING upload pipeline. Empty/unset → no remote registry: OSS instances
+  // run standalone and manual ZIP upload still works. `token`, when present,
+  // is sent as `Authorization: Bearer` (how a private byte5/customer hub is
+  // consumed). Example:
+  //   REGISTRY_URLS='[{"name":"omadia-public","url":"https://hub.omadia.ai"}]'
+  REGISTRY_URLS: z.string().optional(),
+  REGISTRY_FETCH_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(15_000),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;
@@ -359,3 +376,62 @@ function loadConfig(): Config {
 }
 
 export const config: Config = loadConfig();
+
+/**
+ * Parse `REGISTRY_URLS` into a validated list of registry config entries.
+ * Defensive by design: malformed JSON or invalid entries are logged and
+ * dropped rather than crashing boot — a misconfigured registry must never
+ * take the whole middleware down, it just means "no remote store".
+ * Exported standalone so it is unit-testable without booting the server.
+ */
+export function parseRegistries(
+  raw: string | undefined,
+  log: (msg: string) => void = (m) => console.warn(m),
+): RegistryConfigEntry[] {
+  if (!raw || raw.trim() === '') return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    log(
+      `[config] REGISTRY_URLS is not valid JSON — ignoring (no remote registry): ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return [];
+  }
+  if (!Array.isArray(parsed)) {
+    log('[config] REGISTRY_URLS must be a JSON array — ignoring.');
+    return [];
+  }
+  const out: RegistryConfigEntry[] = [];
+  const seenNames = new Set<string>();
+  for (const item of parsed) {
+    if (typeof item !== 'object' || item === null) continue;
+    const rec = item as Record<string, unknown>;
+    const url = typeof rec['url'] === 'string' ? rec['url'].trim() : '';
+    const name = typeof rec['name'] === 'string' ? rec['name'].trim() : '';
+    if (!url || !name) {
+      log('[config] REGISTRY_URLS entry missing url/name — skipped.');
+      continue;
+    }
+    try {
+       
+      new URL(url);
+    } catch {
+      log(`[config] REGISTRY_URLS entry '${name}' has a malformed url — skipped.`);
+      continue;
+    }
+    if (seenNames.has(name)) {
+      log(`[config] REGISTRY_URLS duplicate name '${name}' — skipped.`);
+      continue;
+    }
+    seenNames.add(name);
+    const entry: RegistryConfigEntry = { url, name };
+    if (typeof rec['token'] === 'string' && rec['token']) {
+      entry.token = rec['token'];
+    }
+    out.push(entry);
+  }
+  return out;
+}

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import Anthropic from '@anthropic-ai/sdk';
 import express from 'express';
 import cookieParser from 'cookie-parser';
-import { config } from './config.js';
+import { config, parseRegistries } from './config.js';
 import { createTigrisStore } from '@omadia/diagrams';
 import type { MemoryStore } from '@omadia/plugin-api';
 import { createAdminRouter } from './routes/admin.js';
@@ -43,8 +43,17 @@ import type {
 import { createHarnessAdminUiRouter } from './routes/harnessAdminUi.js';
 import { createStoreRouter } from './routes/store.js';
 import { createInstallRouter } from './routes/install.js';
+import { createAdminRegistriesRouter } from './routes/adminRegistries.js';
+import { RegistryClient } from './plugins/registryClient.js';
+import {
+  VaultBackedRegistryConfigStore,
+  InMemoryRegistrySettings,
+  seedRegistriesIfEmpty,
+  type RegistrySettingsKV,
+} from './plugins/registryConfigStore.js';
 import { createProfilesRouter } from './routes/profiles.js';
 import { createPackagesRouter } from './routes/packages.js';
+import { createRegistryInstallRouter } from './routes/registryInstall.js';
 import { createRuntimeRouter } from './routes/runtime.js';
 import { createVaultStatusRouter } from './routes/vaultStatus.js';
 import { createBuilderRouter } from './routes/builder.js';
@@ -1454,10 +1463,53 @@ async function main(): Promise<void> {
     });
   }
 
+  // ── Plugin registries (the "store sources") ───────────────────────────────
+  // Admin-managed, persistent: the non-secret list lives in platform_settings
+  // (Postgres) when a graphPool is present, else an in-memory KV (DB-less boot
+  // re-seeds the default each start). Bearer tokens live in the encrypted
+  // vault. Seeded on first boot from REGISTRY_URLS, else the public default
+  // hub.omadia.ai. The live RegistryClient is reloaded from the store here and
+  // again after every admin mutation, so changes apply without a restart.
+  const registrySettings: RegistrySettingsKV = graphPool
+    ? new PlatformSettingsStore(graphPool)
+    : new InMemoryRegistrySettings();
+  const registryConfigStore = new VaultBackedRegistryConfigStore({
+    settings: registrySettings,
+    vault: secretVault,
+  });
+  await seedRegistriesIfEmpty(
+    registryConfigStore,
+    parseRegistries(config.REGISTRY_URLS),
+    (m) => console.log(m),
+  );
+  const registryClient = new RegistryClient({
+    registries: await registryConfigStore.list(),
+    timeoutMs: config.REGISTRY_FETCH_TIMEOUT_MS,
+    log: (m) => console.log(m),
+  });
+  app.use(
+    '/api/v1/admin/registries',
+    requireAuth,
+    createAdminRegistriesRouter({
+      store: registryConfigStore,
+      client: registryClient,
+      log: (m) => console.log(m),
+    }),
+  );
+  console.log(
+    `[middleware] registry admin endpoints ready at /api/v1/admin/registries (auth: required, sources: ${
+      registryClient.registryNames().join(', ') || 'none'
+    })`,
+  );
+
   app.use(
     '/api/v1/store/plugins',
     requireAuth,
-    createStoreRouter({ catalog: pluginCatalog, registry: installedRegistry }),
+    createStoreRouter({
+      catalog: pluginCatalog,
+      registry: installedRegistry,
+      client: registryClient,
+    }),
   );
   console.log('[middleware] plugin store endpoints ready at /api/v1/store/plugins (auth: required)');
 
@@ -1633,6 +1685,22 @@ async function main(): Promise<void> {
     );
     console.log(
       `[middleware] package upload endpoints ready at /api/v1/install/packages (maxBytes=${config.PACKAGE_UPLOAD_MAX_BYTES}, auth: required)`,
+    );
+
+    // Remote-install: fetch a ZIP from a configured registry and feed it into
+    // the same ingest pipeline. Gated by PACKAGE_UPLOAD_ENABLED because it
+    // reuses packageUploadService.
+    app.use(
+      '/api/v1/install/registry',
+      requireAuth,
+      createRegistryInstallRouter({
+        client: registryClient,
+        packageUpload: packageUploadService,
+        log: (msg) => console.log(msg),
+      }),
+    );
+    console.log(
+      '[middleware] registry install endpoint ready at /api/v1/install/registry (auth: required)',
     );
   } else {
     console.log('[middleware] package upload DISABLED (PACKAGE_UPLOAD_ENABLED=false)');

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -1696,6 +1696,8 @@ async function main(): Promise<void> {
       createRegistryInstallRouter({
         client: registryClient,
         packageUpload: packageUploadService,
+        catalog: pluginCatalog,
+        registry: installedRegistry,
         log: (msg) => console.log(msg),
       }),
     );

--- a/middleware/src/plugins/dependencyChainResolver.ts
+++ b/middleware/src/plugins/dependencyChainResolver.ts
@@ -1,0 +1,172 @@
+// ===========================================================================
+// Remote depends_on chain resolver (Slice C5).
+// ---------------------------------------------------------------------------
+// A plugin's `depends_on` parents are a STRICT install-time dependency: Core's
+// install service refuses to install a child whose parent isn't installed
+// (`install.missing_dependencies`), because the child inherits the parent's
+// vault secrets/config (e.g. channel-teams reads the microsoft365 integration's
+// Bot-Framework + Graph credentials).
+//
+// When installing from a remote registry, those parents may themselves be
+// remote-only (not yet in the local catalog). This resolver walks the target's
+// `depends_on` transitively, FETCHES + INGESTS any remote-only parent so it
+// becomes locally installable, and returns the missing parents as an
+// `InstallChainResolution` — the SAME shape the capability-chain wizard
+// consumes, so the operator UI walks "parents → target" with no new component.
+//
+// It ingests (makes available) but never activates: each parent still gets its
+// own setup form in the wizard. Topo-ordered, parents-first.
+// ===========================================================================
+
+import type { PluginCatalog } from './manifestLoader.js';
+import type { InstalledRegistry } from './installedRegistry.js';
+import type { RegistryClient } from './registryClient.js';
+import { RegistryError } from './registryClient.js';
+import type { PackageUploadService } from './packageUploadService.js';
+import type {
+  InstallChainResolution,
+  UnresolvedCapabilityEntry,
+} from './capabilityResolver.js';
+
+export interface DependencyChainDeps {
+  catalog: PluginCatalog;
+  registry: InstalledRegistry;
+  client: RegistryClient;
+  packageUpload: PackageUploadService;
+  log?: (msg: string) => void;
+}
+
+export interface DependencyChainResult {
+  /** Missing-parent chain for the UI wizard (topo: parents-first), each parent
+   *  modelled as a single-provider entry. Empty when the target's parents are
+   *  all already installed. */
+  chain: InstallChainResolution;
+  /** Parent ids that could not be resolved in the catalog or any registry —
+   *  surfaced (with empty providers) so the wizard shows the blocker. */
+  unresolvable: string[];
+}
+
+const EMPTY: DependencyChainResult = {
+  chain: { unresolved_requires: [], available_providers: [] },
+  unresolvable: [],
+};
+
+/**
+ * Resolve + ingest the transitive `depends_on` parents of an ALREADY-INGESTED
+ * target. Returns the missing (not-yet-installed) parents as a wizard chain.
+ */
+export async function resolveDependencyParents(
+  targetId: string,
+  deps: DependencyChainDeps,
+): Promise<DependencyChainResult> {
+  const log = deps.log ?? (() => {});
+  const targetEntry = deps.catalog.get(targetId);
+  if (!targetEntry) return EMPTY;
+  const directParents = targetEntry.plugin.depends_on ?? [];
+  if (directParents.length === 0) return EMPTY;
+
+  // Snapshot the remote catalogs once for resolution.
+  const remote = deps.client.hasRegistries()
+    ? (await deps.client.listAll()).plugins
+    : [];
+  const findRemote = (id: string) =>
+    remote.find((p) => p.entry.id === id);
+
+  const visited = new Set<string>();
+  const order: string[] = []; // post-order DFS → parents before dependents
+  const unresolvable: string[] = [];
+
+  // Ingest `id` from a registry iff it isn't already in the local catalog.
+  // Returns true once the plugin is locally available.
+  const ensurePresent = async (id: string): Promise<boolean> => {
+    if (deps.catalog.get(id)) return true;
+    const r = findRemote(id);
+    if (!r) return false;
+    const ver =
+      r.entry.versions.find((v) => v.version === r.entry.latest_version) ??
+      r.entry.versions[0];
+    if (!ver) return false;
+    const { buffer, sha256 } = await deps.client.fetchPackage({
+      registry: r.registry,
+      downloadUrl: ver.download_url,
+      sha256: ver.sha256,
+    });
+    const res = await deps.packageUpload.ingest({
+      fileBuffer: buffer,
+      originalFilename: `${sanitize(id)}-${ver.version}.zip`,
+      uploadedBy: `registry:${r.registry}`,
+      sha256,
+    });
+    if (!res.ok) {
+      // A duplicate-version failure means the package is already on disk —
+      // treat as present if the catalog now resolves it. Anything else is a
+      // genuine ingest error.
+      if (deps.catalog.get(id)) return true;
+      throw new DependencyChainError(res.code, res.message);
+    }
+    log(`[registry] ingested dependency ${id}@${ver.version} from '${r.registry}'`);
+    return true;
+  };
+
+  const visit = async (id: string): Promise<void> => {
+    if (visited.has(id)) return;
+    visited.add(id);
+    const present = await ensurePresent(id);
+    if (!present) {
+      unresolvable.push(id);
+      order.push(id);
+      return;
+    }
+    const entry = deps.catalog.get(id);
+    for (const parent of entry?.plugin.depends_on ?? []) {
+      await visit(parent);
+    }
+    order.push(id);
+  };
+
+  for (const p of directParents) await visit(p);
+
+  // Missing = resolved parents not yet installed. Already-installed parents
+  // drop out (the install gate is satisfied for them).
+  const missing = order.filter((id) => !deps.registry.has(id));
+  const available_providers: UnresolvedCapabilityEntry[] = missing.map((id) => {
+    const plugin = deps.catalog.get(id)?.plugin;
+    return {
+      capability: id, // the parent id doubles as the chain-step label
+      providers: plugin
+        ? [
+            {
+              id,
+              name: plugin.name,
+              kind: plugin.kind,
+              version: plugin.version,
+              install_state: 'available' as const,
+              already_installed: false,
+              active: false,
+            },
+          ]
+        : [], // unresolvable → wizard renders the blocker
+    };
+  });
+
+  return {
+    chain: { unresolved_requires: missing, available_providers },
+    unresolvable,
+  };
+}
+
+export class DependencyChainError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'DependencyChainError';
+    this.code = code;
+  }
+}
+
+/** Re-export so the route can distinguish upstream fetch failures. */
+export { RegistryError };
+
+function sanitize(id: string): string {
+  return id.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+}

--- a/middleware/src/plugins/registryClient.ts
+++ b/middleware/src/plugins/registryClient.ts
@@ -1,0 +1,457 @@
+// ===========================================================================
+// RegistryClient — OSS-Core consumer of remote plugin registries.
+// ---------------------------------------------------------------------------
+// Fetches `index.json` from one or more configured registries, merges them
+// (first-registry-wins on id collision), and downloads + sha256-verifies a
+// specific ZIP artifact for installation. The downloaded buffer is handed
+// straight to the EXISTING `PackageUploadService.ingest` pipeline — this
+// client adds no validation/activation logic of its own.
+//
+// Trust model (MVP): sha256 pinned in the index + HTTPS/TLS. The artifact
+// host is pinned to the registry host (a tampered index cannot redirect the
+// download to an arbitrary origin). No per-artifact signing yet.
+//
+// Multi-registry from day one: `registries` is a list; private hubs are
+// consumed by attaching a bearer `token`.
+// ===========================================================================
+
+import { createHash } from 'node:crypto';
+
+import type {
+  RegistryConfigEntry,
+  RegistryIndexV1,
+  RegistryManifestSummary,
+  RegistryPluginEntry,
+  RegistryVersionEntry,
+} from '../api/registry-v1.js';
+import type { PluginKind } from '../api/admin-v1.js';
+
+const INDEX_PATH = '/registry/index.json';
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_INDEX_BYTES = 5 * 1024 * 1024; // 5 MiB
+const DEFAULT_MAX_ARTIFACT_BYTES = 50 * 1024 * 1024; // 50 MiB
+
+const VALID_KINDS: ReadonlySet<string> = new Set([
+  'agent',
+  'integration',
+  'channel',
+  'tool',
+  'extension',
+]);
+
+export class RegistryError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'RegistryError';
+    this.code = code;
+  }
+}
+
+/** A plugin entry tagged with the config-name of the registry it came from. */
+export interface ResolvedRegistryPlugin {
+  registry: string;
+  entry: RegistryPluginEntry;
+}
+
+/** Non-fatal per-registry failure surfaced by `listAll` for graceful degrade. */
+export interface RegistryFetchError {
+  registry: string;
+  code: string;
+  message: string;
+}
+
+export interface RegistryListResult {
+  plugins: ResolvedRegistryPlugin[];
+  errors: RegistryFetchError[];
+}
+
+export interface RegistryClientDeps {
+  registries: RegistryConfigEntry[];
+  /** Injectable for tests; defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+  log?: (msg: string) => void;
+  timeoutMs?: number;
+  maxIndexBytes?: number;
+  maxArtifactBytes?: number;
+}
+
+export class RegistryClient {
+  private registries: RegistryConfigEntry[];
+  private readonly fetchImpl: typeof fetch;
+  private readonly log: (msg: string) => void;
+  private readonly timeoutMs: number;
+  private readonly maxIndexBytes: number;
+  private readonly maxArtifactBytes: number;
+
+  constructor(deps: RegistryClientDeps) {
+    this.registries = deps.registries;
+    this.fetchImpl = deps.fetchImpl ?? globalThis.fetch;
+    this.log = deps.log ?? ((m) => console.log(m));
+    this.timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.maxIndexBytes = deps.maxIndexBytes ?? DEFAULT_MAX_INDEX_BYTES;
+    this.maxArtifactBytes = deps.maxArtifactBytes ?? DEFAULT_MAX_ARTIFACT_BYTES;
+  }
+
+  hasRegistries(): boolean {
+    return this.registries.length > 0;
+  }
+
+  /**
+   * Replace the configured registry list at runtime. Called at boot and after
+   * every admin mutation of the `RegistryConfigStore`, so the client reflects
+   * the current admin state without a process restart.
+   */
+  setRegistries(registries: RegistryConfigEntry[]): void {
+    this.registries = registries;
+  }
+
+  /** Snapshot of the configured registry names (display/diagnostics only). */
+  registryNames(): string[] {
+    return this.registries.map((r) => r.name);
+  }
+
+  /** Lookup a configured registry by its stable `name`. */
+  getRegistry(name: string): RegistryConfigEntry | undefined {
+    return this.registries.find((r) => r.name === name);
+  }
+
+  /**
+   * Fetch + parse one registry's `index.json`. Throws `RegistryError` on a
+   * network/HTTP/parse failure. Callers that must degrade gracefully should
+   * use `listAll` instead.
+   */
+  async fetchIndex(reg: RegistryConfigEntry): Promise<RegistryIndexV1> {
+    const url = joinUrl(reg.url, INDEX_PATH);
+    const res = await this.doFetch(url, reg.token, 'index');
+
+    if (!res.ok) {
+      throw new RegistryError(
+        'registry.index_http',
+        `${reg.name}: GET ${INDEX_PATH} → ${res.status}`,
+      );
+    }
+
+    const buf = await this.readCapped(res, this.maxIndexBytes, 'index');
+    let raw: unknown;
+    try {
+      raw = JSON.parse(buf.toString('utf8'));
+    } catch (err) {
+      throw new RegistryError(
+        'registry.index_parse',
+        `${reg.name}: index.json is not valid JSON (${errMsg(err)})`,
+      );
+    }
+    return this.parseIndex(raw, reg.name);
+  }
+
+  /**
+   * Fetch every configured registry in parallel and merge. First registry in
+   * the configured order wins on plugin-id collision (the loser is dropped
+   * with a warning). A registry that fails is recorded in `errors`, not
+   * thrown — the store must still render the registries that are reachable.
+   */
+  async listAll(): Promise<RegistryListResult> {
+    const settled = await Promise.allSettled(
+      this.registries.map(async (reg) => ({
+        reg,
+        index: await this.fetchIndex(reg),
+      })),
+    );
+
+    const plugins: ResolvedRegistryPlugin[] = [];
+    const errors: RegistryFetchError[] = [];
+    const seen = new Map<string, string>(); // plugin id → winning registry name
+
+    for (let i = 0; i < settled.length; i++) {
+      const outcome = settled[i]!;
+      const reg = this.registries[i]!;
+      if (outcome.status === 'rejected') {
+        const err = outcome.reason;
+        const code = err instanceof RegistryError ? err.code : 'registry.fetch';
+        errors.push({ registry: reg.name, code, message: errMsg(err) });
+        this.log(`[registry] ${reg.name} unreachable: ${errMsg(err)}`);
+        continue;
+      }
+      for (const entry of outcome.value.index.plugins) {
+        const owner = seen.get(entry.id);
+        if (owner) {
+          this.log(
+            `[registry] id collision: '${entry.id}' from '${reg.name}' ignored (already provided by '${owner}')`,
+          );
+          continue;
+        }
+        seen.set(entry.id, reg.name);
+        plugins.push({ registry: reg.name, entry });
+      }
+    }
+
+    return { plugins, errors };
+  }
+
+  /**
+   * Download a specific artifact and verify its sha256 against the expected
+   * value from the index. The download host is pinned to the registry host.
+   * Returns the verified buffer ready for `PackageUploadService.ingest`.
+   */
+  async fetchPackage(args: {
+    registry: string;
+    downloadUrl: string;
+    sha256: string;
+  }): Promise<{ buffer: Buffer; sha256: string }> {
+    const reg = this.getRegistry(args.registry);
+    if (!reg) {
+      throw new RegistryError(
+        'registry.unknown',
+        `no configured registry named '${args.registry}'`,
+      );
+    }
+
+    this.assertHostPinned(reg, args.downloadUrl);
+
+    const res = await this.doFetch(args.downloadUrl, reg.token, 'artifact');
+    if (!res.ok) {
+      throw new RegistryError(
+        'registry.artifact_http',
+        `${reg.name}: GET ${args.downloadUrl} → ${res.status}`,
+      );
+    }
+
+    const buffer = await this.readCapped(
+      res,
+      this.maxArtifactBytes,
+      'artifact',
+    );
+    const actual = createHash('sha256').update(buffer).digest('hex');
+    if (actual.toLowerCase() !== args.sha256.toLowerCase()) {
+      throw new RegistryError(
+        'registry.sha256_mismatch',
+        `${reg.name}: artifact sha256 mismatch (expected ${args.sha256.slice(0, 12)}…, got ${actual.slice(0, 12)}…)`,
+      );
+    }
+    return { buffer, sha256: actual };
+  }
+
+  // ----- internals --------------------------------------------------------
+
+  /** Reject a download_url whose host differs from the registry's host. */
+  private assertHostPinned(reg: RegistryConfigEntry, downloadUrl: string): void {
+    let regHost: string;
+    let dlHost: string;
+    try {
+      regHost = new URL(reg.url).host;
+      dlHost = new URL(downloadUrl).host;
+    } catch {
+      throw new RegistryError(
+        'registry.bad_url',
+        `${reg.name}: malformed registry or download URL`,
+      );
+    }
+    if (regHost !== dlHost) {
+      throw new RegistryError(
+        'registry.host_mismatch',
+        `${reg.name}: download host '${dlHost}' does not match registry host '${regHost}'`,
+      );
+    }
+  }
+
+  private async doFetch(
+    url: string,
+    token: string | undefined,
+    kind: 'index' | 'artifact',
+  ): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const headers: Record<string, string> = {
+        Accept:
+          kind === 'index' ? 'application/json' : 'application/octet-stream',
+      };
+      if (token) headers['Authorization'] = `Bearer ${token}`;
+      return await this.fetchImpl(url, {
+        method: 'GET',
+        headers,
+        signal: controller.signal,
+        redirect: 'error',
+      });
+    } catch (err) {
+      const aborted =
+        err instanceof Error && err.name === 'AbortError';
+      throw new RegistryError(
+        aborted ? 'registry.timeout' : 'registry.network',
+        aborted
+          ? `${kind} fetch timed out after ${this.timeoutMs}ms`
+          : `${kind} fetch failed: ${errMsg(err)}`,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** Read a response body, rejecting once it would exceed `cap` bytes. */
+  private async readCapped(
+    res: Response,
+    cap: number,
+    kind: 'index' | 'artifact',
+  ): Promise<Buffer> {
+    const declared = Number(res.headers.get('content-length') ?? '');
+    if (Number.isFinite(declared) && declared > cap) {
+      throw new RegistryError(
+        'registry.too_large',
+        `${kind} declares ${declared} bytes, exceeds cap ${cap}`,
+      );
+    }
+    const ab = await res.arrayBuffer();
+    if (ab.byteLength > cap) {
+      throw new RegistryError(
+        'registry.too_large',
+        `${kind} is ${ab.byteLength} bytes, exceeds cap ${cap}`,
+      );
+    }
+    return Buffer.from(ab);
+  }
+
+  /**
+   * Defensive parse of a raw index payload. The top-level shape is enforced
+   * strictly; individual plugin/version entries that are malformed are
+   * dropped with a warning so one bad entry cannot break the whole catalog.
+   */
+  private parseIndex(raw: unknown, registryName: string): RegistryIndexV1 {
+    if (!isObject(raw)) {
+      throw new RegistryError(
+        'registry.index_shape',
+        `${registryName}: index is not an object`,
+      );
+    }
+    if (raw['schema_version'] !== '1') {
+      throw new RegistryError(
+        'registry.index_version',
+        `${registryName}: unsupported schema_version ${String(raw['schema_version'])}`,
+      );
+    }
+    const reg = isObject(raw['registry']) ? raw['registry'] : {};
+    const rawPlugins = Array.isArray(raw['plugins']) ? raw['plugins'] : [];
+
+    const plugins: RegistryPluginEntry[] = [];
+    let dropped = 0;
+    for (const p of rawPlugins) {
+      const entry = this.parsePluginEntry(p);
+      if (entry) plugins.push(entry);
+      else dropped++;
+    }
+    if (dropped > 0) {
+      this.log(
+        `[registry] ${registryName}: dropped ${dropped} malformed plugin entr${dropped === 1 ? 'y' : 'ies'}`,
+      );
+    }
+
+    return {
+      schema_version: '1',
+      registry: {
+        name: asString(reg['name'], registryName),
+        url: asString(reg['url'], ''),
+      },
+      generated_at: asString(raw['generated_at'], ''),
+      plugins,
+    };
+  }
+
+  private parsePluginEntry(raw: unknown): RegistryPluginEntry | null {
+    if (!isObject(raw)) return null;
+    const id = asString(raw['id'], '');
+    const name = asString(raw['name'], '');
+    const kind = asString(raw['kind'], '');
+    if (!id || !name || !VALID_KINDS.has(kind)) return null;
+
+    const versions: RegistryVersionEntry[] = [];
+    const rawVersions = Array.isArray(raw['versions']) ? raw['versions'] : [];
+    for (const v of rawVersions) {
+      const parsed = this.parseVersionEntry(v);
+      if (parsed) versions.push(parsed);
+    }
+    if (versions.length === 0) return null;
+
+    const latest =
+      asString(raw['latest_version'], '') ||
+      versions[0]!.version;
+
+    return {
+      id,
+      name,
+      kind: kind as PluginKind,
+      domain: asString(raw['domain'], `unknown.${id}`),
+      description: asString(raw['description'], ''),
+      categories: asStringArray(raw['categories']),
+      authors: parseAuthors(raw['authors']),
+      license: asString(raw['license'], 'Unknown'),
+      icon_url: typeof raw['icon_url'] === 'string' ? raw['icon_url'] : null,
+      latest_version: latest,
+      versions,
+    };
+  }
+
+  private parseVersionEntry(raw: unknown): RegistryVersionEntry | null {
+    if (!isObject(raw)) return null;
+    const version = asString(raw['version'], '');
+    const sha256 = asString(raw['sha256'], '');
+    const download_url = asString(raw['download_url'], '');
+    if (!version || !/^[0-9a-f]{64}$/i.test(sha256) || !download_url) {
+      return null;
+    }
+    const summary = isObject(raw['manifest_summary'])
+      ? (raw['manifest_summary'] as RegistryManifestSummary)
+      : {};
+    return {
+      version,
+      compat_core: asString(raw['compat_core'], '>=1.0 <2.0'),
+      sha256,
+      size_bytes: asNumber(raw['size_bytes'], 0),
+      download_url,
+      published_at: asString(raw['published_at'], ''),
+      manifest_summary: summary,
+    };
+  }
+}
+
+// ----- small helpers -------------------------------------------------------
+
+function joinUrl(base: string, path: string): string {
+  return `${base.replace(/\/+$/, '')}${path}`;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function asString(v: unknown, fallback: string): string {
+  return typeof v === 'string' ? v : fallback;
+}
+
+function asNumber(v: unknown, fallback: number): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+}
+
+function asStringArray(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+}
+
+function parseAuthors(
+  v: unknown,
+): Array<{ name: string; email?: string; url?: string }> {
+  if (!Array.isArray(v)) return [];
+  const out: Array<{ name: string; email?: string; url?: string }> = [];
+  for (const a of v) {
+    if (!isObject(a)) continue;
+    const name = asString(a['name'], '');
+    if (!name) continue;
+    const author: { name: string; email?: string; url?: string } = { name };
+    if (typeof a['email'] === 'string') author.email = a['email'];
+    if (typeof a['url'] === 'string') author.url = a['url'];
+    out.push(author);
+  }
+  return out;
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/middleware/src/plugins/registryConfigStore.ts
+++ b/middleware/src/plugins/registryConfigStore.ts
@@ -1,0 +1,257 @@
+// ===========================================================================
+// RegistryConfigStore — admin-managed, persistent registry configuration.
+// ---------------------------------------------------------------------------
+// The set of plugin registries Core pulls from is RUNTIME config, managed via
+// the admin UI (not an immutable env var). The non-secret view (name + url)
+// lives in the platform_settings KV (Postgres); bearer tokens are secrets and
+// live in the encrypted SecretVault under a synthetic owner namespace — never
+// in plaintext jsonb, never returned in a listing.
+//
+// On first boot the store is seeded: from `REGISTRY_URLS` if the operator set
+// it, otherwise with the public default `hub.omadia.ai`. After seeding the
+// list is fully admin-editable and the env var is no longer consulted.
+//
+// Backend-agnostic: the same logic runs against Postgres (PlatformSettingsStore
+// structurally satisfies `RegistrySettingsKV`) or an in-memory KV for DB-less
+// boots and tests.
+// ===========================================================================
+
+import type { RegistryConfigEntry } from '../api/registry-v1.js';
+import type { SecretVault } from '../secrets/vault.js';
+
+/** Public default registry seeded when nothing else is configured. */
+export const DEFAULT_REGISTRY: { name: string; url: string } = {
+  name: 'omadia-public',
+  url: 'https://hub.omadia.ai',
+};
+
+/** Synthetic SecretVault owner namespace for registry bearer tokens. Not a
+ *  real agent id, so it never surfaces in any per-agent secret listing. */
+export const REGISTRY_VAULT_OWNER = '__registries__';
+
+/** platform_settings key holding the non-secret registry list. */
+export const SETTING_REGISTRY_LIST = 'registry.list';
+
+const NAME_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/i;
+
+/** Persisted, non-secret view of a configured registry. */
+export interface StoredRegistry {
+  name: string;
+  url: string;
+  /** True iff a bearer token is stored in the vault for this registry. */
+  has_token: boolean;
+}
+
+/** Minimal KV the store needs. `PlatformSettingsStore` satisfies this. */
+export interface RegistrySettingsKV {
+  get<T>(key: string): Promise<T | null>;
+  set(key: string, value: unknown): Promise<void>;
+}
+
+export class RegistryConfigError extends Error {
+  readonly code: string;
+  readonly status: number;
+  constructor(code: string, message: string, status: number) {
+    super(message);
+    this.name = 'RegistryConfigError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export interface RegistryConfigStore {
+  /** Resolved entries incl. tokens — feeds the RegistryClient. */
+  list(): Promise<RegistryConfigEntry[]>;
+  /** Non-secret listing for the admin UI (never leaks tokens). */
+  listPublic(): Promise<StoredRegistry[]>;
+  add(input: { name: string; url: string; token?: string }): Promise<void>;
+  update(
+    name: string,
+    patch: { url?: string; token?: string | null },
+  ): Promise<void>;
+  remove(name: string): Promise<void>;
+}
+
+export interface VaultBackedRegistryConfigStoreDeps {
+  settings: RegistrySettingsKV;
+  vault: SecretVault;
+}
+
+/**
+ * Default `RegistryConfigStore` — non-secret list in the KV, tokens in the
+ * vault. Works over any `RegistrySettingsKV` (Postgres or in-memory).
+ */
+export class VaultBackedRegistryConfigStore implements RegistryConfigStore {
+  constructor(private readonly deps: VaultBackedRegistryConfigStoreDeps) {}
+
+  private async readList(): Promise<StoredRegistry[]> {
+    const raw = await this.deps.settings.get<StoredRegistry[]>(
+      SETTING_REGISTRY_LIST,
+    );
+    return Array.isArray(raw) ? raw : [];
+  }
+
+  private async writeList(list: StoredRegistry[]): Promise<void> {
+    await this.deps.settings.set(SETTING_REGISTRY_LIST, list);
+  }
+
+  async listPublic(): Promise<StoredRegistry[]> {
+    return this.readList();
+  }
+
+  async list(): Promise<RegistryConfigEntry[]> {
+    const stored = await this.readList();
+    const out: RegistryConfigEntry[] = [];
+    for (const r of stored) {
+      const entry: RegistryConfigEntry = { name: r.name, url: r.url };
+      if (r.has_token) {
+        const token = await this.deps.vault.get(REGISTRY_VAULT_OWNER, r.name);
+        if (token) entry.token = token;
+      }
+      out.push(entry);
+    }
+    return out;
+  }
+
+  async add(input: {
+    name: string;
+    url: string;
+    token?: string;
+  }): Promise<void> {
+    assertName(input.name);
+    assertUrl(input.url);
+    const list = await this.readList();
+    if (list.some((r) => r.name === input.name)) {
+      throw new RegistryConfigError(
+        'registry_config.duplicate',
+        `a registry named '${input.name}' already exists`,
+        409,
+      );
+    }
+    const hasToken = typeof input.token === 'string' && input.token.length > 0;
+    if (hasToken) {
+      await this.deps.vault.set(REGISTRY_VAULT_OWNER, input.name, input.token!);
+    }
+    list.push({ name: input.name, url: input.url, has_token: hasToken });
+    await this.writeList(list);
+  }
+
+  async update(
+    name: string,
+    patch: { url?: string; token?: string | null },
+  ): Promise<void> {
+    const list = await this.readList();
+    const idx = list.findIndex((r) => r.name === name);
+    if (idx < 0) throw notFound(name);
+    const row = { ...list[idx]! };
+
+    if (patch.url !== undefined) {
+      assertUrl(patch.url);
+      row.url = patch.url;
+    }
+    if (patch.token !== undefined) {
+      if (patch.token === null || patch.token === '') {
+        await this.deps.vault.deleteKey(REGISTRY_VAULT_OWNER, name);
+        row.has_token = false;
+      } else {
+        await this.deps.vault.set(REGISTRY_VAULT_OWNER, name, patch.token);
+        row.has_token = true;
+      }
+    }
+    list[idx] = row;
+    await this.writeList(list);
+  }
+
+  async remove(name: string): Promise<void> {
+    const list = await this.readList();
+    const next = list.filter((r) => r.name !== name);
+    if (next.length === list.length) throw notFound(name);
+    await this.deps.vault.deleteKey(REGISTRY_VAULT_OWNER, name);
+    await this.writeList(next);
+  }
+}
+
+/** In-memory `RegistrySettingsKV` for DB-less boots and tests. JSON round-trips
+ *  on read to mimic Postgres jsonb (no aliasing of the stored value). */
+export class InMemoryRegistrySettings implements RegistrySettingsKV {
+  private readonly map = new Map<string, string>();
+  async get<T>(key: string): Promise<T | null> {
+    const raw = this.map.get(key);
+    return raw === undefined ? null : (JSON.parse(raw) as T);
+  }
+  async set(key: string, value: unknown): Promise<void> {
+    this.map.set(key, JSON.stringify(value));
+  }
+}
+
+/**
+ * Seed the store on first boot. No-op if any registry already exists, so it is
+ * safe to call on every boot. `seed` is the parsed `REGISTRY_URLS` (env); when
+ * empty, the public default `hub.omadia.ai` is used.
+ */
+export async function seedRegistriesIfEmpty(
+  store: RegistryConfigStore,
+  seed: RegistryConfigEntry[],
+  log: (msg: string) => void = (m) => console.log(m),
+): Promise<void> {
+  const existing = await store.listPublic();
+  if (existing.length > 0) return;
+  const toSeed: RegistryConfigEntry[] =
+    seed.length > 0 ? seed : [{ ...DEFAULT_REGISTRY }];
+  for (const r of toSeed) {
+    try {
+      await store.add({ name: r.name, url: r.url, token: r.token });
+    } catch (err) {
+      log(
+        `[registry] seed skipped '${r.name}': ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  log(
+    `[registry] seeded ${toSeed.length} default registr${
+      toSeed.length === 1 ? 'y' : 'ies'
+    } (${toSeed.map((r) => r.name).join(', ')})`,
+  );
+}
+
+// ----- validation ----------------------------------------------------------
+
+function assertName(name: string): void {
+  if (typeof name !== 'string' || !NAME_RE.test(name)) {
+    throw new RegistryConfigError(
+      'registry_config.invalid_name',
+      "name must match /^[a-z0-9][a-z0-9._-]{0,63}$/i",
+      400,
+    );
+  }
+}
+
+function assertUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new RegistryConfigError(
+      'registry_config.invalid_url',
+      `'${url}' is not a valid URL`,
+      400,
+    );
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new RegistryConfigError(
+      'registry_config.invalid_url',
+      'registry url must be http(s)',
+      400,
+    );
+  }
+}
+
+function notFound(name: string): RegistryConfigError {
+  return new RegistryConfigError(
+    'registry_config.not_found',
+    `no registry named '${name}'`,
+    404,
+  );
+}

--- a/middleware/src/routes/adminRegistries.ts
+++ b/middleware/src/routes/adminRegistries.ts
@@ -1,0 +1,129 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+
+import type { RegistryClient } from '../plugins/registryClient.js';
+import type { RegistryConfigStore } from '../plugins/registryConfigStore.js';
+import { RegistryConfigError } from '../plugins/registryConfigStore.js';
+
+export interface AdminRegistriesDeps {
+  store: RegistryConfigStore;
+  /** Live client refreshed after every mutation so changes apply without a
+   *  process restart. */
+  client: RegistryClient;
+  log?: (msg: string) => void;
+}
+
+/**
+ * Admin CRUD for the plugin registries Core pulls from (the "store sources").
+ * Mounted at /api/v1/admin/registries behind requireAuth.
+ *
+ *   GET    /            list configured registries (tokens NEVER returned)
+ *   POST   /            add { name, url, token? }
+ *   PATCH  /:name       update { url?, token? }   (token:null clears it)
+ *   DELETE /:name       remove
+ *
+ * The bearer `token` is write-only: it is stored in the encrypted vault and is
+ * never echoed back — the listing only reports `has_token`. After each
+ * mutation the live `RegistryClient` is reloaded from the store.
+ */
+export function createAdminRegistriesRouter(deps: AdminRegistriesDeps): Router {
+  const router = Router();
+  const log = deps.log ?? (() => {});
+
+  const refresh = async (): Promise<void> => {
+    deps.client.setRegistries(await deps.store.list());
+  };
+
+  router.get('/', async (_req: Request, res: Response) => {
+    await withStore(res, async () => {
+      const registries = await deps.store.listPublic();
+      res.json({ registries });
+    });
+  });
+
+  router.post('/', async (req: Request, res: Response) => {
+    await withStore(res, async () => {
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const name = asString(body['name']);
+      const url = asString(body['url']);
+      if (!name || !url) {
+        res.status(400).json({
+          code: 'registry_config.missing_fields',
+          message: 'name and url are required',
+        });
+        return;
+      }
+      const token = asString(body['token']);
+      await deps.store.add(token ? { name, url, token } : { name, url });
+      await refresh();
+      log(`[registry] admin added registry '${name}' (${url})`);
+      res.status(201).json({ ok: true });
+    });
+  });
+
+  router.patch('/:name', async (req: Request, res: Response) => {
+    await withStore(res, async () => {
+      const name = readParam(req, 'name');
+      if (!name) {
+        res.status(400).json({ code: 'registry_config.missing_name' });
+        return;
+      }
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const patch: { url?: string; token?: string | null } = {};
+      if ('url' in body) patch.url = asString(body['url']);
+      if ('token' in body) {
+        // explicit null / "" clears the token; a string sets it
+        patch.token = body['token'] === null ? null : asString(body['token']);
+      }
+      if (patch.url === undefined && patch.token === undefined) {
+        res.status(400).json({
+          code: 'registry_config.empty_patch',
+          message: 'provide at least one of url, token',
+        });
+        return;
+      }
+      await deps.store.update(name, patch);
+      await refresh();
+      log(`[registry] admin updated registry '${name}'`);
+      res.json({ ok: true });
+    });
+  });
+
+  router.delete('/:name', async (req: Request, res: Response) => {
+    await withStore(res, async () => {
+      const name = readParam(req, 'name');
+      if (!name) {
+        res.status(400).json({ code: 'registry_config.missing_name' });
+        return;
+      }
+      await deps.store.remove(name);
+      await refresh();
+      log(`[registry] admin removed registry '${name}'`);
+      res.json({ ok: true });
+    });
+  });
+
+  return router;
+}
+
+async function withStore(res: Response, fn: () => Promise<void>): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    if (err instanceof RegistryConfigError) {
+      res.status(err.status).json({ code: err.code, message: err.message });
+      return;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    res.status(500).json({ code: 'registry_config.internal', message });
+  }
+}
+
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v.trim() : '';
+}
+
+function readParam(req: Request, key: string): string | undefined {
+  const v = (req.params as Record<string, string | string[] | undefined>)[key];
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}

--- a/middleware/src/routes/registryInstall.ts
+++ b/middleware/src/routes/registryInstall.ts
@@ -4,11 +4,19 @@ import type { Request, Response } from 'express';
 import type { RegistryClient } from '../plugins/registryClient.js';
 import { RegistryError } from '../plugins/registryClient.js';
 import type { PackageUploadService } from '../plugins/packageUploadService.js';
+import type { PluginCatalog } from '../plugins/manifestLoader.js';
+import type { InstalledRegistry } from '../plugins/installedRegistry.js';
+import { resolveDependencyParents } from '../plugins/dependencyChainResolver.js';
 
 export interface RegistryInstallDeps {
   client: RegistryClient;
   /** Existing ZIP-ingest pipeline — remote install just feeds it a buffer. */
   packageUpload: PackageUploadService;
+  /** Catalog + installed-registry — needed to resolve the target's
+   *  `depends_on` parents (C5): remote-only parents get fetched + ingested so
+   *  the operator wizard can install "parents → target" in one chained flow. */
+  catalog: PluginCatalog;
+  registry: InstalledRegistry;
   log?: (msg: string) => void;
 }
 
@@ -89,11 +97,27 @@ export function createRegistryInstallRouter(deps: RegistryInstallDeps): Router {
       log(
         `[registry] installed ${result.plugin_id}@${result.version} from '${resolved.registry}'`,
       );
+
+      // C5 — resolve + ingest the target's transitive depends_on parents.
+      // `chain` lists the missing (not-yet-installed) parents so the operator
+      // wizard installs them before the target (the install gate is strict on
+      // depends_on because the child inherits the parent's vault credentials).
+      const { chain } = await resolveDependencyParents(result.plugin_id, {
+        catalog: deps.catalog,
+        registry: deps.registry,
+        client: deps.client,
+        packageUpload: deps.packageUpload,
+        log,
+      });
+
       res.status(201).json({
         ok: true,
         plugin_id: result.plugin_id,
         version: result.version,
         registry: resolved.registry,
+        // Missing depends_on parents to install first (empty → install target
+        // directly). Same shape as the capability-chain wizard consumes.
+        chain,
         // hint the next step in the install flow
         next: {
           install: `/api/v1/install/plugins/${encodeURIComponent(result.plugin_id)}`,

--- a/middleware/src/routes/registryInstall.ts
+++ b/middleware/src/routes/registryInstall.ts
@@ -1,0 +1,127 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+
+import type { RegistryClient } from '../plugins/registryClient.js';
+import { RegistryError } from '../plugins/registryClient.js';
+import type { PackageUploadService } from '../plugins/packageUploadService.js';
+
+export interface RegistryInstallDeps {
+  client: RegistryClient;
+  /** Existing ZIP-ingest pipeline — remote install just feeds it a buffer. */
+  packageUpload: PackageUploadService;
+  log?: (msg: string) => void;
+}
+
+/**
+ * Remote-install endpoint — fetch a plugin ZIP from a configured registry and
+ * feed it into the EXISTING upload pipeline. Mounted at
+ * /api/v1/install/registry behind requireAuth, only when PACKAGE_UPLOAD_ENABLED
+ * (it reuses `PackageUploadService.ingest`).
+ *
+ *   POST /:id            install the latest version of `<id>` from the registry
+ *   POST /:id?version=X  install a specific version
+ *
+ * `:id` is URL-encoded (scoped names like `@omadia%2Fplugin-office`). On
+ * success the package is ingested + catalogued locally; the caller then drives
+ * the normal install-job flow (POST /api/v1/install/plugins/:id) for the setup
+ * form + activation. This route deliberately does NOT activate — it only makes
+ * the remote package locally available, identical to a manual ZIP upload.
+ */
+export function createRegistryInstallRouter(deps: RegistryInstallDeps): Router {
+  const router = Router();
+  const log = deps.log ?? (() => {});
+
+  router.post('/:id', async (req: Request, res: Response) => {
+    const id = readParam(req, 'id');
+    if (!id) {
+      res.status(400).json({ code: 'registry_install.missing_id' });
+      return;
+    }
+    if (!deps.client.hasRegistries()) {
+      res.status(409).json({
+        code: 'registry_install.no_registries',
+        message: 'no plugin registries are configured',
+      });
+      return;
+    }
+
+    try {
+      const { plugins } = await deps.client.listAll();
+      const resolved = plugins.find((p) => p.entry.id === id);
+      if (!resolved) {
+        res.status(404).json({
+          code: 'registry_install.plugin_not_found',
+          message: `no plugin '${id}' in any configured registry`,
+        });
+        return;
+      }
+
+      const wanted = asString(req.query['version']) || resolved.entry.latest_version;
+      const verEntry = resolved.entry.versions.find((v) => v.version === wanted);
+      if (!verEntry) {
+        res.status(404).json({
+          code: 'registry_install.version_not_found',
+          message: `plugin '${id}' has no version '${wanted}'`,
+        });
+        return;
+      }
+
+      const { buffer, sha256 } = await deps.client.fetchPackage({
+        registry: resolved.registry,
+        downloadUrl: verEntry.download_url,
+        sha256: verEntry.sha256,
+      });
+
+      const result = await deps.packageUpload.ingest({
+        fileBuffer: buffer,
+        originalFilename: `${sanitize(id)}-${verEntry.version}.zip`,
+        uploadedBy: `registry:${resolved.registry}`,
+        sha256,
+      });
+
+      if (!result.ok) {
+        // ingest failures are caller-fixable (bad manifest, id conflict, dup
+        // version) → 422, with the pipeline's own code/message.
+        res.status(422).json({ code: result.code, message: result.message });
+        return;
+      }
+
+      log(
+        `[registry] installed ${result.plugin_id}@${result.version} from '${resolved.registry}'`,
+      );
+      res.status(201).json({
+        ok: true,
+        plugin_id: result.plugin_id,
+        version: result.version,
+        registry: resolved.registry,
+        // hint the next step in the install flow
+        next: {
+          install: `/api/v1/install/plugins/${encodeURIComponent(result.plugin_id)}`,
+        },
+      });
+    } catch (err) {
+      if (err instanceof RegistryError) {
+        // network / sha256 / host-pin failures are upstream problems → 502
+        res.status(502).json({ code: err.code, message: err.message });
+        return;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ code: 'registry_install.internal', message });
+    }
+  });
+
+  return router;
+}
+
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v.trim() : '';
+}
+
+function sanitize(id: string): string {
+  return id.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function readParam(req: Request, key: string): string | undefined {
+  const v = (req.params as Record<string, string | string[] | undefined>)[key];
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}

--- a/middleware/src/routes/store.ts
+++ b/middleware/src/routes/store.ts
@@ -57,21 +57,39 @@ export function createStoreRouter(deps: StoreDeps): Router {
         .filter((plugin) => matchesSearch(plugin, search))
         .filter((plugin) => matchesCategory(plugin, category));
 
-      // Merge remote-registry plugins (the "store sources"). Local entries win
-      // on id collision; a registry hiccup degrades to local-only, never 500s.
+      // Merge remote-registry plugins (the "store sources"). On an id collision
+      // the LOCAL entry wins on content (version, install_state, permissions),
+      // but we tag it with the hub `source` so it still surfaces in the store's
+      // "Hub" view alongside its real install_state — an already-installed or
+      // built-in plugin that the hub also offers must not vanish from the Hub
+      // tab. A registry hiccup degrades to local-only, never 500s.
       if (deps.client?.hasRegistries()) {
-        const seen = new Set(items.map((p) => p.id));
+        // id → index into `items`, so a colliding remote entry can enrich the
+        // local plugin in place rather than being dropped.
+        const indexById = new Map(items.map((p, i) => [p.id, i]));
         try {
           const { plugins, errors } = await deps.client.listAll();
           for (const resolved of plugins) {
-            if (seen.has(resolved.entry.id)) continue;
+            const existingIdx = indexById.get(resolved.entry.id);
+            if (existingIdx !== undefined) {
+              const existing = items[existingIdx]!;
+              if (!existing.source) {
+                // Replace with a copy — catalog plugin objects are shared
+                // across requests and must not be mutated.
+                items[existingIdx] = {
+                  ...existing,
+                  source: registrySource(resolved),
+                };
+              }
+              continue;
+            }
             const remote = registryEntryToPlugin(resolved);
             if (
               matchesSearch(remote, search) &&
               matchesCategory(remote, category)
             ) {
+              indexById.set(remote.id, items.length);
               items.push(remote);
-              seen.add(remote.id);
             }
           }
           for (const e of errors) {
@@ -205,13 +223,26 @@ async function resolveRemotePlugin(
   }
 }
 
+/** The `source` marker for a remote registry entry: the download coordinates
+ *  of its latest advertised version. Reused to (a) build a fully-remote Plugin
+ *  and (b) tag a colliding local plugin with its hub origin. */
+function registrySource(
+  resolved: ResolvedRegistryPlugin,
+): NonNullable<Plugin['source']> {
+  const { registry, entry } = resolved;
+  const ver =
+    entry.versions.find((v) => v.version === entry.latest_version) ??
+    entry.versions[0]!;
+  return { registry, download_url: ver.download_url, sha256: ver.sha256 };
+}
+
 /** Map a remote registry entry → the `Plugin` shape the store list returns.
  *  Uses the latest advertised version. Permissions/integrations are left
  *  minimal here — the registry's `manifest_summary` is a display teaser; the
  *  authoritative summary is computed from the real manifest after the package
  *  is fetched + ingested (the install wizard shows that). */
 function registryEntryToPlugin(resolved: ResolvedRegistryPlugin): Plugin {
-  const { registry, entry } = resolved;
+  const { entry } = resolved;
   const ver =
     entry.versions.find((v) => v.version === entry.latest_version) ??
     entry.versions[0]!;
@@ -245,11 +276,7 @@ function registryEntryToPlugin(resolved: ResolvedRegistryPlugin): Plugin {
     requires: Array.isArray(summary.requires) ? summary.requires : [],
     multi_instance: true,
     privacy_class: 'default',
-    source: {
-      registry,
-      download_url: ver.download_url,
-      sha256: ver.sha256,
-    },
+    source: registrySource(resolved),
   };
 }
 

--- a/middleware/src/routes/store.ts
+++ b/middleware/src/routes/store.ts
@@ -3,15 +3,26 @@ import type { Request, Response } from 'express';
 
 import type {
   Plugin,
+  PluginPermissionsSummary,
+  PluginSetupField,
   StoreGetResponse,
   StoreListResponse,
 } from '../api/admin-v1.js';
 import type { InstalledRegistry } from '../plugins/installedRegistry.js';
 import type { PluginCatalog } from '../plugins/manifestLoader.js';
+import type {
+  RegistryClient,
+  ResolvedRegistryPlugin,
+} from '../plugins/registryClient.js';
 
 interface StoreDeps {
   catalog: PluginCatalog;
   registry: InstalledRegistry;
+  /** Optional remote registries. When present, their plugins are merged into
+   *  the list with `install_state: 'available'` + a `source` marker so the
+   *  operator can install from the hub. A local plugin of the same id wins;
+   *  a registry fetch failure never breaks the local listing. */
+  client?: RegistryClient;
 }
 
 /**
@@ -46,6 +57,35 @@ export function createStoreRouter(deps: StoreDeps): Router {
         .filter((plugin) => matchesSearch(plugin, search))
         .filter((plugin) => matchesCategory(plugin, category));
 
+      // Merge remote-registry plugins (the "store sources"). Local entries win
+      // on id collision; a registry hiccup degrades to local-only, never 500s.
+      if (deps.client?.hasRegistries()) {
+        const seen = new Set(items.map((p) => p.id));
+        try {
+          const { plugins, errors } = await deps.client.listAll();
+          for (const resolved of plugins) {
+            if (seen.has(resolved.entry.id)) continue;
+            const remote = registryEntryToPlugin(resolved);
+            if (
+              matchesSearch(remote, search) &&
+              matchesCategory(remote, category)
+            ) {
+              items.push(remote);
+              seen.add(remote.id);
+            }
+          }
+          for (const e of errors) {
+            console.warn(`[store] registry '${e.registry}' skipped: ${e.message}`);
+          }
+        } catch (err) {
+          console.warn(
+            `[store] remote registry merge skipped: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+      }
+
       const body: StoreListResponse = {
         items,
         next_cursor: null,
@@ -69,6 +109,18 @@ export function createStoreRouter(deps: StoreDeps): Router {
 
       const entry = deps.catalog.get(id);
       if (!entry) {
+        // Not local — try the remote registries so a hub-only plugin's detail
+        // page resolves (otherwise the store list would link to a 404).
+        const remote = await resolveRemotePlugin(deps.client, id);
+        if (remote) {
+          const body: StoreGetResponse = {
+            plugin: remote,
+            manifest: remote.source ? { source: remote.source } : {},
+            install_available: true,
+          };
+          res.json(body);
+          return;
+        }
         res
           .status(404)
           .json({ code: 'store.plugin_not_found', message: `no plugin with id '${id}'` });
@@ -135,4 +187,78 @@ function matchesSearch(plugin: Plugin, search: string | undefined): boolean {
 function matchesCategory(plugin: Plugin, category: string | undefined): boolean {
   if (!category) return true;
   return plugin.categories.includes(category);
+}
+
+/** Resolve a single plugin id against the remote registries (for the detail
+ *  endpoint). Returns null if absent or any registry is unreachable. */
+async function resolveRemotePlugin(
+  client: RegistryClient | undefined,
+  id: string,
+): Promise<Plugin | null> {
+  if (!client?.hasRegistries()) return null;
+  try {
+    const { plugins } = await client.listAll();
+    const resolved = plugins.find((p) => p.entry.id === id);
+    return resolved ? registryEntryToPlugin(resolved) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Map a remote registry entry → the `Plugin` shape the store list returns.
+ *  Uses the latest advertised version. Permissions/integrations are left
+ *  minimal here — the registry's `manifest_summary` is a display teaser; the
+ *  authoritative summary is computed from the real manifest after the package
+ *  is fetched + ingested (the install wizard shows that). */
+function registryEntryToPlugin(resolved: ResolvedRegistryPlugin): Plugin {
+  const { registry, entry } = resolved;
+  const ver =
+    entry.versions.find((v) => v.version === entry.latest_version) ??
+    entry.versions[0]!;
+  const summary = ver.manifest_summary ?? {};
+  const setupFields = Array.isArray(summary.setup_fields)
+    ? (summary.setup_fields as unknown as PluginSetupField[])
+    : [];
+
+  return {
+    id: entry.id,
+    kind: entry.kind,
+    name: entry.name,
+    version: ver.version,
+    latest_version: entry.latest_version,
+    description: entry.description,
+    authors: entry.authors,
+    license: entry.license,
+    icon_url: entry.icon_url,
+    categories: entry.categories,
+    domain: entry.domain,
+    compat_core: ver.compat_core,
+    signed: false,
+    signed_by: null,
+    required_secrets: setupFields,
+    permissions_summary: emptyPermissionsSummary(),
+    integrations_summary: [],
+    install_state: 'available',
+    depends_on: Array.isArray(summary.depends_on) ? summary.depends_on : [],
+    jobs: [],
+    provides: Array.isArray(summary.provides) ? summary.provides : [],
+    requires: Array.isArray(summary.requires) ? summary.requires : [],
+    multi_instance: true,
+    privacy_class: 'default',
+    source: {
+      registry,
+      download_url: ver.download_url,
+      sha256: ver.sha256,
+    },
+  };
+}
+
+function emptyPermissionsSummary(): PluginPermissionsSummary {
+  return {
+    memory_reads: [],
+    memory_writes: [],
+    graph_reads: [],
+    graph_writes: [],
+    network_outbound: [],
+  };
 }

--- a/middleware/test/dependencyChainResolver.test.ts
+++ b/middleware/test/dependencyChainResolver.test.ts
@@ -1,0 +1,204 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  resolveDependencyParents,
+  type DependencyChainDeps,
+} from '../src/plugins/dependencyChainResolver.js';
+import type { Plugin, PluginKind } from '../src/api/admin-v1.js';
+import type { PluginCatalog } from '../src/plugins/manifestLoader.js';
+import type { InstalledRegistry } from '../src/plugins/installedRegistry.js';
+import type { RegistryClient } from '../src/plugins/registryClient.js';
+import type {
+  PackageUploadService,
+  IngestInput,
+} from '../src/plugins/packageUploadService.js';
+
+const SHA = 'a'.repeat(64);
+
+function mkPlugin(
+  id: string,
+  depends_on: string[] = [],
+  kind: PluginKind = 'integration',
+): Plugin {
+  return {
+    id,
+    kind,
+    name: id,
+    version: '1.0.0',
+    latest_version: '1.0.0',
+    description: '',
+    authors: [],
+    license: 'MIT',
+    icon_url: null,
+    categories: [],
+    domain: 'x.y',
+    compat_core: '>=1.0 <2.0',
+    signed: false,
+    signed_by: null,
+    required_secrets: [],
+    permissions_summary: {
+      memory_reads: [],
+      memory_writes: [],
+      graph_reads: [],
+      graph_writes: [],
+      network_outbound: [],
+    },
+    integrations_summary: [],
+    install_state: 'available',
+    depends_on,
+    jobs: [],
+    provides: [],
+    requires: [],
+    multi_instance: true,
+    privacy_class: 'default',
+  };
+}
+
+/**
+ * Build a stateful test harness:
+ *  - `local`   = id → depends_on for plugins already in the local catalog
+ *  - `remote`  = id → depends_on for plugins available in the registry index
+ *  - `installed` = ids currently in the installed-registry
+ * The fake `ingest` ADDS the fetched plugin to the local catalog (with its
+ * remote depends_on), so the resolver's transitive walk sees it post-ingest.
+ */
+function harness(opts: {
+  local: Record<string, string[]>;
+  remote?: Record<string, string[]>;
+  installed?: string[];
+}): {
+  deps: DependencyChainDeps;
+  fetched: string[];
+  isLocal: (id: string) => boolean;
+} {
+  const present = new Map<string, string[]>(Object.entries(opts.local));
+  const remoteMap = new Map<string, string[]>(Object.entries(opts.remote ?? {}));
+  const installedSet = new Set<string>(opts.installed ?? []);
+  const fetched: string[] = [];
+
+  const catalog = {
+    get: (id: string) =>
+      present.has(id) ? { plugin: mkPlugin(id, present.get(id)!), manifest: {} } : undefined,
+    list: () =>
+      [...present].map(([id, d]) => ({ plugin: mkPlugin(id, d), manifest: {} })),
+  } as unknown as PluginCatalog;
+
+  const registry = {
+    has: (id: string) => installedSet.has(id),
+  } as unknown as InstalledRegistry;
+
+  const client = {
+    hasRegistries: () => remoteMap.size > 0,
+    listAll: async () => ({
+      plugins: [...remoteMap].map(([id, d]) => ({
+        registry: 'pub',
+        entry: {
+          id,
+          name: id,
+          kind: 'integration' as PluginKind,
+          domain: 'x.y',
+          description: '',
+          categories: [],
+          authors: [],
+          license: 'MIT',
+          icon_url: null,
+          latest_version: '1.0.0',
+          versions: [
+            {
+              version: '1.0.0',
+              compat_core: '>=1.0 <2.0',
+              sha256: SHA,
+              size_bytes: 1,
+              download_url: `https://hub.test/dl/${encodeURIComponent(id)}.zip`,
+              published_at: '',
+              manifest_summary: { depends_on: d },
+            },
+          ],
+        },
+      })),
+      errors: [],
+    }),
+    fetchPackage: async ({ downloadUrl }: { downloadUrl: string }) => {
+      const id = decodeURIComponent(
+        downloadUrl.replace('https://hub.test/dl/', '').replace('.zip', ''),
+      );
+      fetched.push(id);
+      return { buffer: Buffer.from(id, 'utf8'), sha256: SHA };
+    },
+  } as unknown as RegistryClient;
+
+  const packageUpload = {
+    ingest: async (input: IngestInput) => {
+      const id = input.fileBuffer.toString('utf8');
+      present.set(id, remoteMap.get(id) ?? []);
+      return { ok: true, plugin_id: id, version: '1.0.0', package: {} as never };
+    },
+  } as unknown as PackageUploadService;
+
+  return {
+    deps: { catalog, registry, client, packageUpload, log: () => {} },
+    fetched,
+    isLocal: (id) => present.has(id),
+  };
+}
+
+const TEAMS = '@omadia/channel-teams';
+const M365 = '@omadia/integration-microsoft365';
+
+describe('resolveDependencyParents (C5)', () => {
+  it('returns an empty chain when the target has no depends_on', async () => {
+    const h = harness({ local: { [TEAMS]: [] }, remote: { [M365]: [] } });
+    const { chain, unresolvable } = await resolveDependencyParents(TEAMS, h.deps);
+    assert.deepEqual(chain.unresolved_requires, []);
+    assert.deepEqual(chain.available_providers, []);
+    assert.deepEqual(unresolvable, []);
+    assert.deepEqual(h.fetched, [], 'no registry calls when nothing to resolve');
+  });
+
+  it('fetches + ingests a remote-only parent and returns it as a single-provider chain', async () => {
+    const h = harness({ local: { [TEAMS]: [M365] }, remote: { [M365]: [] } });
+    const { chain } = await resolveDependencyParents(TEAMS, h.deps);
+
+    assert.deepEqual(chain.unresolved_requires, [M365]);
+    assert.equal(chain.available_providers.length, 1);
+    const entry = chain.available_providers[0]!;
+    assert.equal(entry.capability, M365);
+    assert.equal(entry.providers.length, 1);
+    assert.equal(entry.providers[0]!.id, M365);
+    assert.equal(entry.providers[0]!.already_installed, false);
+
+    // the parent was actually pulled + ingested → now locally installable
+    assert.deepEqual(h.fetched, [M365]);
+    assert.ok(h.isLocal(M365), 'parent ingested into the catalog');
+  });
+
+  it('drops a parent that is already installed (gate satisfied)', async () => {
+    const h = harness({
+      local: { [TEAMS]: [M365], [M365]: [] },
+      installed: [M365],
+    });
+    const { chain } = await resolveDependencyParents(TEAMS, h.deps);
+    assert.deepEqual(chain.unresolved_requires, []);
+    assert.deepEqual(h.fetched, [], 'installed parent needs no fetch');
+  });
+
+  it('resolves transitively, deepest parent first (topo order)', async () => {
+    // A (local) → B (remote) → C (remote)
+    const h = harness({
+      local: { '@x/A': ['@x/B'] },
+      remote: { '@x/B': ['@x/C'], '@x/C': [] },
+    });
+    const { chain } = await resolveDependencyParents('@x/A', h.deps);
+    assert.deepEqual(chain.unresolved_requires, ['@x/C', '@x/B']);
+    assert.deepEqual(h.fetched.sort(), ['@x/B', '@x/C']);
+  });
+
+  it('surfaces an unresolvable parent with empty providers', async () => {
+    const h = harness({ local: { [TEAMS]: ['@x/ghost'] }, remote: {} });
+    const { chain, unresolvable } = await resolveDependencyParents(TEAMS, h.deps);
+    assert.deepEqual(chain.unresolved_requires, ['@x/ghost']);
+    assert.equal(chain.available_providers[0]!.providers.length, 0);
+    assert.deepEqual(unresolvable, ['@x/ghost']);
+  });
+});

--- a/middleware/test/registryClient.test.ts
+++ b/middleware/test/registryClient.test.ts
@@ -1,0 +1,358 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { createHash } from 'node:crypto';
+
+import {
+  RegistryClient,
+  RegistryError,
+  type RegistryClientDeps,
+} from '../src/plugins/registryClient.js';
+import { parseRegistries } from '../src/config.js';
+import type { RegistryIndexV1 } from '../src/api/registry-v1.js';
+
+// --- helpers ---------------------------------------------------------------
+
+const ZIP = Buffer.from('PK\x03\x04 fake zip payload');
+const ZIP_SHA = createHash('sha256').update(ZIP).digest('hex');
+
+function indexFixture(overrides: Partial<RegistryIndexV1> = {}): RegistryIndexV1 {
+  return {
+    schema_version: '1',
+    registry: { name: 'omadia-public', url: 'https://hub.test' },
+    generated_at: '2026-05-29T12:00:00Z',
+    plugins: [
+      {
+        id: '@omadia/plugin-office',
+        name: 'Headless Office',
+        kind: 'tool',
+        domain: 'productivity.office',
+        description: 'xlsx/docx',
+        categories: ['productivity'],
+        authors: [{ name: 'byte5' }],
+        license: 'MIT',
+        icon_url: null,
+        latest_version: '0.1.0',
+        versions: [
+          {
+            version: '0.1.0',
+            compat_core: '>=1.0 <2.0',
+            sha256: ZIP_SHA,
+            size_bytes: ZIP.byteLength,
+            download_url: 'https://hub.test/registry/@omadia/plugin-office/0.1.0/plugin.zip',
+            published_at: '2026-05-29T11:00:00Z',
+            manifest_summary: { provides: ['office@1'] },
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+/** Build a fetch mock from a url→responder map. */
+function mockFetch(
+  routes: Record<string, () => Response>,
+): RegistryClientDeps['fetchImpl'] {
+  return async (input) => {
+    const url = typeof input === 'string' ? input : String(input);
+    const responder = routes[url];
+    if (!responder) {
+      return new Response('not found', { status: 404 });
+    }
+    return responder();
+  };
+}
+
+const silent = () => {};
+
+/** assert.rejects matcher that checks the RegistryError `.code` contract. */
+function hasCode(code: string) {
+  return (e: unknown): true => {
+    assert.ok(e instanceof RegistryError, `expected RegistryError, got ${String(e)}`);
+    assert.equal((e as RegistryError).code, code);
+    return true;
+  };
+}
+
+function client(deps: Partial<RegistryClientDeps>): RegistryClient {
+  return new RegistryClient({
+    registries: [{ name: 'omadia-public', url: 'https://hub.test' }],
+    log: silent,
+    ...deps,
+  });
+}
+
+// --- parseRegistries -------------------------------------------------------
+
+describe('parseRegistries', () => {
+  it('returns [] for unset / empty', () => {
+    assert.deepEqual(parseRegistries(undefined, silent), []);
+    assert.deepEqual(parseRegistries('', silent), []);
+    assert.deepEqual(parseRegistries('   ', silent), []);
+  });
+
+  it('parses a valid array with optional token', () => {
+    const out = parseRegistries(
+      '[{"name":"pub","url":"https://hub.test"},{"name":"priv","url":"https://x.io","token":"secret"}]',
+      silent,
+    );
+    assert.equal(out.length, 2);
+    assert.deepEqual(out[0], { name: 'pub', url: 'https://hub.test' });
+    assert.equal(out[1]!.token, 'secret');
+  });
+
+  it('drops malformed JSON, non-array, bad entries, dup names', () => {
+    assert.deepEqual(parseRegistries('{not json', silent), []);
+    assert.deepEqual(parseRegistries('{"name":"x"}', silent), []); // not array
+    assert.deepEqual(
+      parseRegistries('[{"name":"x"},{"url":"https://y.io"}]', silent),
+      [],
+    ); // each missing the other field
+    assert.deepEqual(
+      parseRegistries('[{"name":"x","url":"not a url"}]', silent),
+      [],
+    );
+    const dup = parseRegistries(
+      '[{"name":"x","url":"https://a.io"},{"name":"x","url":"https://b.io"}]',
+      silent,
+    );
+    assert.equal(dup.length, 1);
+    assert.equal(dup[0]!.url, 'https://a.io');
+  });
+});
+
+// --- fetchIndex ------------------------------------------------------------
+
+describe('RegistryClient.fetchIndex', () => {
+  const reg = { name: 'omadia-public', url: 'https://hub.test' };
+
+  it('fetches and parses a well-formed index', async () => {
+    const c = client({
+      fetchImpl: mockFetch({
+        'https://hub.test/registry/index.json': () =>
+          new Response(JSON.stringify(indexFixture())),
+      }),
+    });
+    const idx = await c.fetchIndex(reg);
+    assert.equal(idx.schema_version, '1');
+    assert.equal(idx.plugins.length, 1);
+    assert.equal(idx.plugins[0]!.id, '@omadia/plugin-office');
+    assert.equal(idx.plugins[0]!.versions[0]!.sha256, ZIP_SHA);
+  });
+
+  it('drops malformed plugin and version entries but keeps good ones', async () => {
+    const idx = indexFixture();
+    // a plugin with no valid versions, a plugin missing id, a junk version
+    (idx.plugins as unknown[]).push(
+      { id: '@x/broken', name: 'Broken', kind: 'tool', versions: [] },
+      { name: 'No Id', kind: 'tool', versions: [{ version: '1', sha256: ZIP_SHA, download_url: 'https://hub.test/x' }] },
+      {
+        id: '@x/badsha',
+        name: 'Bad Sha',
+        kind: 'tool',
+        versions: [{ version: '1', sha256: 'nothex', download_url: 'https://hub.test/x' }],
+      },
+    );
+    const c = client({
+      fetchImpl: mockFetch({
+        'https://hub.test/registry/index.json': () =>
+          new Response(JSON.stringify(idx)),
+      }),
+    });
+    const out = await c.fetchIndex(reg);
+    assert.equal(out.plugins.length, 1, 'only the well-formed office plugin survives');
+    assert.equal(out.plugins[0]!.id, '@omadia/plugin-office');
+  });
+
+  it('throws on non-2xx', async () => {
+    const c = client({
+      fetchImpl: mockFetch({
+        'https://hub.test/registry/index.json': () =>
+          new Response('boom', { status: 500 }),
+      }),
+    });
+    await assert.rejects(() => c.fetchIndex(reg), (e: unknown) => {
+      assert.ok(e instanceof RegistryError);
+      assert.equal((e as RegistryError).code, 'registry.index_http');
+      return true;
+    });
+  });
+
+  it('throws on invalid JSON and wrong schema_version', async () => {
+    const badJson = client({
+      fetchImpl: mockFetch({
+        'https://hub.test/registry/index.json': () => new Response('{nope'),
+      }),
+    });
+    await assert.rejects(() => badJson.fetchIndex(reg), hasCode('registry.index_parse'));
+
+    const badVer = client({
+      fetchImpl: mockFetch({
+        'https://hub.test/registry/index.json': () =>
+          new Response(JSON.stringify({ schema_version: '2', plugins: [] })),
+      }),
+    });
+    await assert.rejects(() => badVer.fetchIndex(reg), hasCode('registry.index_version'));
+  });
+
+  it('rejects an oversized index via content-length', async () => {
+    const c = client({
+      maxIndexBytes: 10,
+      fetchImpl: mockFetch({
+        'https://hub.test/registry/index.json': () =>
+          new Response(JSON.stringify(indexFixture()), {
+            headers: { 'content-length': '999999' },
+          }),
+      }),
+    });
+    await assert.rejects(() => c.fetchIndex(reg), hasCode('registry.too_large'));
+  });
+});
+
+// --- listAll ---------------------------------------------------------------
+
+describe('RegistryClient.listAll', () => {
+  it('merges registries, first-wins on id collision, records errors', async () => {
+    const pubIdx = indexFixture();
+    const privIdx = indexFixture({
+      registry: { name: 'priv', url: 'https://priv.test' },
+      plugins: [
+        // same id as public → should be dropped (public wins)
+        { ...indexFixture().plugins[0]! },
+        // a unique plugin
+        {
+          ...indexFixture().plugins[0]!,
+          id: '@priv/secret',
+          name: 'Secret',
+          versions: [
+            {
+              ...indexFixture().plugins[0]!.versions[0]!,
+              download_url: 'https://priv.test/registry/@priv/secret/0.1.0/plugin.zip',
+            },
+          ],
+        },
+      ],
+    });
+
+    const c = new RegistryClient({
+      log: silent,
+      registries: [
+        { name: 'omadia-public', url: 'https://hub.test' },
+        { name: 'priv', url: 'https://priv.test', token: 'tk' },
+        { name: 'down', url: 'https://down.test' },
+      ],
+      fetchImpl: mockFetch({
+        'https://hub.test/registry/index.json': () =>
+          new Response(JSON.stringify(pubIdx)),
+        'https://priv.test/registry/index.json': () =>
+          new Response(JSON.stringify(privIdx)),
+        'https://down.test/registry/index.json': () =>
+          new Response('err', { status: 503 }),
+      }),
+    });
+
+    const { plugins, errors } = await c.listAll();
+    const ids = plugins.map((p) => p.entry.id).sort();
+    assert.deepEqual(ids, ['@omadia/plugin-office', '@priv/secret']);
+    // office came from the public registry (first wins)
+    const office = plugins.find((p) => p.entry.id === '@omadia/plugin-office');
+    assert.equal(office!.registry, 'omadia-public');
+    // the unreachable registry is reported, not thrown
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0]!.registry, 'down');
+  });
+
+  it('passes the bearer token for private registries', async () => {
+    let seenAuth: string | null = null;
+    const c = new RegistryClient({
+      log: silent,
+      registries: [{ name: 'priv', url: 'https://priv.test', token: 'sekret' }],
+      fetchImpl: async (_url, init) => {
+        seenAuth =
+          (init?.headers as Record<string, string> | undefined)?.[
+            'Authorization'
+          ] ?? null;
+        return new Response(
+          JSON.stringify(
+            indexFixture({ registry: { name: 'priv', url: 'https://priv.test' } }),
+          ),
+        );
+      },
+    });
+    await c.listAll();
+    assert.equal(seenAuth, 'Bearer sekret');
+  });
+});
+
+// --- fetchPackage ----------------------------------------------------------
+
+describe('RegistryClient.fetchPackage', () => {
+  const downloadUrl =
+    'https://hub.test/registry/@omadia/plugin-office/0.1.0/plugin.zip';
+
+  it('downloads and verifies sha256', async () => {
+    const c = client({
+      fetchImpl: mockFetch({ [downloadUrl]: () => new Response(ZIP) }),
+    });
+    const out = await c.fetchPackage({
+      registry: 'omadia-public',
+      downloadUrl,
+      sha256: ZIP_SHA,
+    });
+    assert.equal(out.sha256, ZIP_SHA);
+    assert.ok(out.buffer.equals(ZIP));
+  });
+
+  it('throws on sha256 mismatch', async () => {
+    const c = client({
+      fetchImpl: mockFetch({ [downloadUrl]: () => new Response(ZIP) }),
+    });
+    await assert.rejects(
+      () =>
+        c.fetchPackage({
+          registry: 'omadia-public',
+          downloadUrl,
+          sha256: 'a'.repeat(64),
+        }),
+      hasCode('registry.sha256_mismatch'),
+    );
+  });
+
+  it('pins the download host to the registry host', async () => {
+    const c = client({
+      fetchImpl: mockFetch({
+        'https://evil.test/x.zip': () => new Response(ZIP),
+      }),
+    });
+    await assert.rejects(
+      () =>
+        c.fetchPackage({
+          registry: 'omadia-public',
+          downloadUrl: 'https://evil.test/x.zip',
+          sha256: ZIP_SHA,
+        }),
+      hasCode('registry.host_mismatch'),
+    );
+  });
+
+  it('throws for an unknown registry name', async () => {
+    const c = client({ fetchImpl: mockFetch({}) });
+    await assert.rejects(
+      () =>
+        c.fetchPackage({ registry: 'nope', downloadUrl, sha256: ZIP_SHA }),
+      hasCode('registry.unknown'),
+    );
+  });
+
+  it('rejects an oversized artifact', async () => {
+    const c = client({
+      maxArtifactBytes: 4,
+      fetchImpl: mockFetch({ [downloadUrl]: () => new Response(ZIP) }),
+    });
+    await assert.rejects(
+      () =>
+        c.fetchPackage({ registry: 'omadia-public', downloadUrl, sha256: ZIP_SHA }),
+      hasCode('registry.too_large'),
+    );
+  });
+});

--- a/middleware/test/registryConfig.test.ts
+++ b/middleware/test/registryConfig.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, before, after, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import express from 'express';
+
+import {
+  VaultBackedRegistryConfigStore,
+  InMemoryRegistrySettings,
+  RegistryConfigError,
+  seedRegistriesIfEmpty,
+  DEFAULT_REGISTRY,
+  REGISTRY_VAULT_OWNER,
+  SETTING_REGISTRY_LIST,
+  type RegistryConfigStore,
+} from '../src/plugins/registryConfigStore.js';
+import { InMemorySecretVault } from '../src/secrets/vault.js';
+import { RegistryClient } from '../src/plugins/registryClient.js';
+import { createAdminRegistriesRouter } from '../src/routes/adminRegistries.js';
+
+function freshStore(): {
+  store: VaultBackedRegistryConfigStore;
+  settings: InMemoryRegistrySettings;
+  vault: InMemorySecretVault;
+} {
+  const settings = new InMemoryRegistrySettings();
+  const vault = new InMemorySecretVault();
+  const store = new VaultBackedRegistryConfigStore({ settings, vault });
+  return { store, settings, vault };
+}
+
+// --- store -----------------------------------------------------------------
+
+describe('VaultBackedRegistryConfigStore', () => {
+  it('adds a registry and lists it (no token)', async () => {
+    const { store } = freshStore();
+    await store.add({ name: 'pub', url: 'https://hub.test' });
+    assert.deepEqual(await store.listPublic(), [
+      { name: 'pub', url: 'https://hub.test', has_token: false },
+    ]);
+    assert.deepEqual(await store.list(), [{ name: 'pub', url: 'https://hub.test' }]);
+  });
+
+  it('stores a token in the vault, never in settings', async () => {
+    const { store, settings, vault } = freshStore();
+    await store.add({ name: 'priv', url: 'https://priv.test', token: 'sek' });
+
+    // listPublic only flags presence
+    assert.deepEqual(await store.listPublic(), [
+      { name: 'priv', url: 'https://priv.test', has_token: true },
+    ]);
+    // list() resolves the token for the client
+    assert.equal((await store.list())[0]!.token, 'sek');
+    // the token lives in the vault under the synthetic owner
+    assert.equal(await vault.get(REGISTRY_VAULT_OWNER, 'priv'), 'sek');
+    // the persisted settings blob contains NO token
+    const raw = await settings.get<unknown>(SETTING_REGISTRY_LIST);
+    assert.ok(!JSON.stringify(raw).includes('sek'), 'token must not be in settings');
+  });
+
+  it('rejects duplicates, bad names and bad urls', async () => {
+    const { store } = freshStore();
+    await store.add({ name: 'pub', url: 'https://hub.test' });
+    await assert.rejects(
+      () => store.add({ name: 'pub', url: 'https://other.test' }),
+      (e: unknown) => e instanceof RegistryConfigError && e.status === 409,
+    );
+    await assert.rejects(
+      () => store.add({ name: 'bad name!', url: 'https://x.test' }),
+      (e: unknown) => e instanceof RegistryConfigError && e.code === 'registry_config.invalid_name',
+    );
+    await assert.rejects(
+      () => store.add({ name: 'ok', url: 'ftp://nope' }),
+      (e: unknown) => e instanceof RegistryConfigError && e.code === 'registry_config.invalid_url',
+    );
+  });
+
+  it('updates url and toggles the token', async () => {
+    const { store, vault } = freshStore();
+    await store.add({ name: 'r', url: 'https://a.test' });
+
+    await store.update('r', { url: 'https://b.test' });
+    assert.equal((await store.listPublic())[0]!.url, 'https://b.test');
+
+    await store.update('r', { token: 'tok' });
+    assert.equal((await store.listPublic())[0]!.has_token, true);
+    assert.equal(await vault.get(REGISTRY_VAULT_OWNER, 'r'), 'tok');
+
+    await store.update('r', { token: null });
+    assert.equal((await store.listPublic())[0]!.has_token, false);
+    assert.equal(await vault.get(REGISTRY_VAULT_OWNER, 'r'), undefined);
+  });
+
+  it('404s on update/remove of an unknown registry', async () => {
+    const { store } = freshStore();
+    await assert.rejects(
+      () => store.update('ghost', { url: 'https://x.test' }),
+      (e: unknown) => e instanceof RegistryConfigError && e.status === 404,
+    );
+    await assert.rejects(
+      () => store.remove('ghost'),
+      (e: unknown) => e instanceof RegistryConfigError && e.status === 404,
+    );
+  });
+
+  it('removes a registry and its token', async () => {
+    const { store, vault } = freshStore();
+    await store.add({ name: 'r', url: 'https://a.test', token: 'tok' });
+    await store.remove('r');
+    assert.deepEqual(await store.listPublic(), []);
+    assert.equal(await vault.get(REGISTRY_VAULT_OWNER, 'r'), undefined);
+  });
+});
+
+// --- seeding ---------------------------------------------------------------
+
+describe('seedRegistriesIfEmpty', () => {
+  it('seeds the public default when empty and no env seed', async () => {
+    const { store } = freshStore();
+    await seedRegistriesIfEmpty(store, [], () => {});
+    const list = await store.listPublic();
+    assert.equal(list.length, 1);
+    assert.equal(list[0]!.name, DEFAULT_REGISTRY.name);
+    assert.equal(list[0]!.url, DEFAULT_REGISTRY.url);
+  });
+
+  it('seeds from the env seed when provided', async () => {
+    const { store } = freshStore();
+    await seedRegistriesIfEmpty(
+      store,
+      [{ name: 'corp', url: 'https://corp.hub', token: 't' }],
+      () => {},
+    );
+    const list = await store.listPublic();
+    assert.deepEqual(list, [{ name: 'corp', url: 'https://corp.hub', has_token: true }]);
+  });
+
+  it('is a no-op when registries already exist', async () => {
+    const { store } = freshStore();
+    await store.add({ name: 'existing', url: 'https://x.test' });
+    await seedRegistriesIfEmpty(store, [], () => {});
+    const list = await store.listPublic();
+    assert.equal(list.length, 1);
+    assert.equal(list[0]!.name, 'existing');
+  });
+});
+
+// --- admin router ----------------------------------------------------------
+
+describe('createAdminRegistriesRouter', () => {
+  let server: Server;
+  let baseUrl: string;
+  let store: RegistryConfigStore;
+  let client: RegistryClient;
+
+  before(() => {
+    const settings = new InMemoryRegistrySettings();
+    const vault = new InMemorySecretVault();
+    store = new VaultBackedRegistryConfigStore({ settings, vault });
+    client = new RegistryClient({ registries: [], log: () => {} });
+
+    const app = express();
+    app.use(express.json());
+    app.use('/api/v1/admin/registries', createAdminRegistriesRouter({ store, client }));
+    server = app.listen(0);
+    baseUrl = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}/api/v1/admin/registries`;
+  });
+
+  after(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  beforeEach(async () => {
+    // reset between cases
+    for (const r of await store.listPublic()) await store.remove(r.name);
+    client.setRegistries([]);
+  });
+
+  const post = (body: unknown) =>
+    fetch(baseUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+  it('POST adds and refreshes the live client; GET never leaks the token', async () => {
+    const res = await post({ name: 'pub', url: 'https://hub.test', token: 'sek' });
+    assert.equal(res.status, 201);
+    // live client picked up the change (no restart)
+    assert.deepEqual(client.registryNames(), ['pub']);
+
+    const list = await (await fetch(baseUrl)).json();
+    assert.deepEqual(list, {
+      registries: [{ name: 'pub', url: 'https://hub.test', has_token: true }],
+    });
+    assert.ok(!JSON.stringify(list).includes('sek'), 'token must never be returned');
+  });
+
+  it('POST 400 on missing fields, 409 on duplicate', async () => {
+    assert.equal((await post({ name: 'x' })).status, 400);
+    assert.equal((await post({ name: 'x', url: 'https://x.test' })).status, 201);
+    assert.equal((await post({ name: 'x', url: 'https://y.test' })).status, 409);
+  });
+
+  it('PATCH updates url, 404 unknown, 400 empty', async () => {
+    await post({ name: 'r', url: 'https://a.test' });
+    const ok = await fetch(`${baseUrl}/r`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ url: 'https://b.test' }),
+    });
+    assert.equal(ok.status, 200);
+    assert.equal((await store.listPublic())[0]!.url, 'https://b.test');
+
+    const empty = await fetch(`${baseUrl}/r`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(empty.status, 400);
+
+    const ghost = await fetch(`${baseUrl}/ghost`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ url: 'https://z.test' }),
+    });
+    assert.equal(ghost.status, 404);
+  });
+
+  it('DELETE removes and refreshes the client; 404 unknown', async () => {
+    await post({ name: 'r', url: 'https://a.test' });
+    assert.deepEqual(client.registryNames(), ['r']);
+    const del = await fetch(`${baseUrl}/r`, { method: 'DELETE' });
+    assert.equal(del.status, 200);
+    assert.deepEqual(client.registryNames(), []);
+    assert.equal((await fetch(`${baseUrl}/ghost`, { method: 'DELETE' })).status, 404);
+  });
+});

--- a/middleware/test/registryInstallMerge.test.ts
+++ b/middleware/test/registryInstallMerge.test.ts
@@ -1,0 +1,360 @@
+import { describe, it, before, after } from 'node:test';
+import { strict as assert } from 'node:assert';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { createHash } from 'node:crypto';
+import express from 'express';
+
+import { RegistryClient, type RegistryClientDeps } from '../src/plugins/registryClient.js';
+import { createStoreRouter } from '../src/routes/store.js';
+import { createRegistryInstallRouter } from '../src/routes/registryInstall.js';
+import type { Plugin } from '../src/api/admin-v1.js';
+import type { PluginCatalog } from '../src/plugins/manifestLoader.js';
+import type { InstalledRegistry } from '../src/plugins/installedRegistry.js';
+import type {
+  PackageUploadService,
+  IngestInput,
+  IngestResult,
+} from '../src/plugins/packageUploadService.js';
+
+const HUB = 'https://hub.test';
+const ZIP = Buffer.from('PK\x03\x04 office plugin zip');
+const ZIP_SHA = createHash('sha256').update(ZIP).digest('hex');
+
+function indexJson(extraPlugins: unknown[] = []): string {
+  return JSON.stringify({
+    schema_version: '1',
+    registry: { name: 'omadia-public', url: HUB },
+    generated_at: '2026-05-29T12:00:00Z',
+    plugins: [
+      {
+        id: '@omadia/plugin-office',
+        name: 'Headless Office',
+        kind: 'tool',
+        domain: 'productivity.office',
+        description: 'xlsx/docx',
+        categories: ['productivity'],
+        authors: [{ name: 'byte5' }],
+        license: 'MIT',
+        icon_url: null,
+        latest_version: '0.1.0',
+        versions: [
+          {
+            version: '0.1.0',
+            compat_core: '>=1.0 <2.0',
+            sha256: ZIP_SHA,
+            size_bytes: ZIP.byteLength,
+            download_url: `${HUB}/registry/@omadia/plugin-office/0.1.0/plugin.zip`,
+            published_at: '2026-05-29T11:00:00Z',
+            manifest_summary: { provides: ['office@1'], requires: [] },
+          },
+        ],
+      },
+      ...extraPlugins,
+    ],
+  });
+}
+
+function mockFetch(routes: Record<string, () => Response>): RegistryClientDeps['fetchImpl'] {
+  return async (input) => {
+    const url = typeof input === 'string' ? input : String(input);
+    return routes[url]?.() ?? new Response('nf', { status: 404 });
+  };
+}
+
+function plugin(id: string, over: Partial<Plugin> = {}): Plugin {
+  return {
+    id,
+    kind: 'tool',
+    name: id,
+    version: '1.0.0',
+    latest_version: '1.0.0',
+    description: '',
+    authors: [],
+    license: 'MIT',
+    icon_url: null,
+    categories: [],
+    domain: 'x.y',
+    compat_core: '>=1.0 <2.0',
+    signed: false,
+    signed_by: null,
+    required_secrets: [],
+    permissions_summary: {
+      memory_reads: [],
+      memory_writes: [],
+      graph_reads: [],
+      graph_writes: [],
+      network_outbound: [],
+    },
+    integrations_summary: [],
+    install_state: 'available',
+    depends_on: [],
+    jobs: [],
+    provides: [],
+    requires: [],
+    multi_instance: true,
+    privacy_class: 'default',
+    ...over,
+  };
+}
+
+function fakeCatalog(plugins: Plugin[]): PluginCatalog {
+  return {
+    list: () => plugins.map((p) => ({ plugin: p, manifest: {} })),
+    get: (id: string) => {
+      const p = plugins.find((x) => x.id === id);
+      return p ? { plugin: p, manifest: {} } : undefined;
+    },
+  } as unknown as PluginCatalog;
+}
+
+const fakeRegistry = { has: () => false } as unknown as InstalledRegistry;
+
+// --- C3: store merge -------------------------------------------------------
+
+describe('store router · remote registry merge (C3)', () => {
+  let server: Server;
+  let base: string;
+
+  before(() => {
+    const client = new RegistryClient({
+      registries: [{ name: 'omadia-public', url: HUB }],
+      log: () => {},
+      fetchImpl: mockFetch({
+        [`${HUB}/registry/index.json`]: () =>
+          new Response(
+            indexJson([
+              // collides with a LOCAL plugin → local must win, no dup
+              {
+                id: '@x/dup',
+                name: 'Dup Remote',
+                kind: 'tool',
+                domain: 'x.y',
+                description: 'remote copy',
+                categories: [],
+                authors: [],
+                license: 'MIT',
+                icon_url: null,
+                latest_version: '2.0.0',
+                versions: [
+                  {
+                    version: '2.0.0',
+                    compat_core: '>=1.0 <2.0',
+                    sha256: ZIP_SHA,
+                    size_bytes: 1,
+                    download_url: `${HUB}/registry/@x/dup/2.0.0/plugin.zip`,
+                    published_at: '',
+                    manifest_summary: {},
+                  },
+                ],
+              },
+            ]),
+          ),
+      }),
+    });
+
+    const catalog = fakeCatalog([
+      plugin('@x/dup', { name: 'Dup Local', install_state: 'installed' }),
+      plugin('@x/localonly', { name: 'Local Only' }),
+    ]);
+
+    const app = express();
+    app.use('/store', createStoreRouter({ catalog, registry: fakeRegistry, client }));
+    server = app.listen(0);
+    base = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}/store`;
+  });
+
+  after(async () => {
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  it('merges remote plugins, local wins on collision, marks source', async () => {
+    const body = (await (await fetch(base)).json()) as { items: Plugin[]; total: number };
+    const byId = new Map(body.items.map((p) => [p.id, p]));
+
+    // local-only + local-dup + remote office = 3, dup not doubled
+    assert.equal(body.items.length, 3);
+    assert.equal(byId.size, 3);
+
+    // collision: the LOCAL dup survived (name + state), remote dropped
+    assert.equal(byId.get('@x/dup')!.name, 'Dup Local');
+    assert.equal(byId.get('@x/dup')!.install_state, 'installed');
+    assert.equal(byId.get('@x/dup')!.source, undefined);
+
+    // remote-only office carries a source marker + available state
+    const office = byId.get('@omadia/plugin-office')!;
+    assert.equal(office.install_state, 'available');
+    assert.equal(office.signed, false);
+    assert.equal(office.source?.registry, 'omadia-public');
+    assert.equal(office.source?.sha256, ZIP_SHA);
+    assert.deepEqual(office.provides, ['office@1']);
+  });
+
+  it('respects ?search across merged remote entries', async () => {
+    const body = (await (await fetch(`${base}?search=headless`)).json()) as { items: Plugin[] };
+    assert.deepEqual(
+      body.items.map((p) => p.id),
+      ['@omadia/plugin-office'],
+    );
+  });
+});
+
+describe('store router · degrades when a registry is down', () => {
+  it('returns local items even if the registry fetch fails', async () => {
+    const client = new RegistryClient({
+      registries: [{ name: 'down', url: 'https://down.test' }],
+      log: () => {},
+      fetchImpl: mockFetch({}), // every fetch 404s
+    });
+    const catalog = fakeCatalog([plugin('@x/localonly')]);
+    const app = express();
+    app.use('/store', createStoreRouter({ catalog, registry: fakeRegistry, client }));
+    const server = app.listen(0);
+    const base = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}/store`;
+    try {
+      const res = await fetch(base);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as { items: Plugin[] };
+      assert.deepEqual(body.items.map((p) => p.id), ['@x/localonly']);
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+});
+
+describe('store router · detail resolves a remote-only plugin (C3)', () => {
+  it('GET /:id returns the hub plugin with source; 404 for unknown', async () => {
+    const client = new RegistryClient({
+      registries: [{ name: 'omadia-public', url: HUB }],
+      log: () => {},
+      fetchImpl: mockFetch({
+        [`${HUB}/registry/index.json`]: () => new Response(indexJson()),
+      }),
+    });
+    const app = express();
+    app.use('/store', createStoreRouter({ catalog: fakeCatalog([]), registry: fakeRegistry, client }));
+    const server = app.listen(0);
+    const base = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}/store`;
+    try {
+      const res = await fetch(`${base}/${encodeURIComponent('@omadia/plugin-office')}`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as { plugin: Plugin; install_available: boolean };
+      assert.equal(body.plugin.id, '@omadia/plugin-office');
+      assert.equal(body.plugin.source?.registry, 'omadia-public');
+      assert.equal(body.install_available, true);
+
+      const miss = await fetch(`${base}/${encodeURIComponent('@x/ghost')}`);
+      assert.equal(miss.status, 404);
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+});
+
+// --- C2: remote install ----------------------------------------------------
+
+describe('registry install router (C2)', () => {
+  let server: Server;
+  let base: string;
+  let ingestCalls: IngestInput[];
+  let ingestResult: IngestResult;
+
+  const makeClient = () =>
+    new RegistryClient({
+      registries: [{ name: 'omadia-public', url: HUB }],
+      log: () => {},
+      fetchImpl: mockFetch({
+        [`${HUB}/registry/index.json`]: () => new Response(indexJson()),
+        [`${HUB}/registry/@omadia/plugin-office/0.1.0/plugin.zip`]: () => new Response(ZIP),
+      }),
+    });
+
+  const fakeUpload = {
+    ingest: async (input: IngestInput): Promise<IngestResult> => {
+      ingestCalls.push(input);
+      return ingestResult;
+    },
+  } as unknown as PackageUploadService;
+
+  before(() => {
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/install/registry',
+      createRegistryInstallRouter({ client: makeClient(), packageUpload: fakeUpload }),
+    );
+    server = app.listen(0);
+    base = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}/install/registry`;
+  });
+
+  after(async () => {
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  const reset = () => {
+    ingestCalls = [];
+    ingestResult = {
+      ok: true,
+      plugin_id: '@omadia/plugin-office',
+      version: '0.1.0',
+      // the router only reads ok/plugin_id/version; package shape is irrelevant
+      package: {} as never,
+    };
+  };
+
+  const post = (idPath: string) =>
+    fetch(`${base}/${idPath}`, { method: 'POST', headers: { 'content-type': 'application/json' } });
+
+  it('fetches, verifies sha256, ingests, returns the next step', async () => {
+    reset();
+    const res = await post(encodeURIComponent('@omadia/plugin-office'));
+    assert.equal(res.status, 201);
+    const body = (await res.json()) as Record<string, unknown>;
+    assert.equal(body['plugin_id'], '@omadia/plugin-office');
+    assert.equal(body['version'], '0.1.0');
+    assert.equal(body['registry'], 'omadia-public');
+    assert.match(String((body['next'] as Record<string, string>)['install']), /\/api\/v1\/install\/plugins\//);
+
+    // ingest got the verified bytes + a registry-attributed uploadedBy
+    assert.equal(ingestCalls.length, 1);
+    assert.ok(ingestCalls[0]!.fileBuffer.equals(ZIP));
+    assert.equal(ingestCalls[0]!.sha256, ZIP_SHA);
+    assert.equal(ingestCalls[0]!.uploadedBy, 'registry:omadia-public');
+  });
+
+  it('404 for an unknown plugin and an unknown version', async () => {
+    reset();
+    assert.equal((await post(encodeURIComponent('@x/ghost'))).status, 404);
+    assert.equal(
+      (await fetch(`${base}/${encodeURIComponent('@omadia/plugin-office')}?version=9.9.9`, { method: 'POST' })).status,
+      404,
+    );
+    assert.equal(ingestCalls.length, 0, 'no ingest on resolution failure');
+  });
+
+  it('422 when the ingest pipeline rejects the package', async () => {
+    reset();
+    ingestResult = { ok: false, code: 'package.id_conflict', message: 'collides with a built-in' };
+    const res = await post(encodeURIComponent('@omadia/plugin-office'));
+    assert.equal(res.status, 422);
+    assert.equal((await res.json() as Record<string, unknown>)['code'], 'package.id_conflict');
+  });
+});
+
+describe('registry install router · no registries configured', () => {
+  it('409 when nothing is configured', async () => {
+    const client = new RegistryClient({ registries: [], log: () => {} });
+    const fakeUpload = { ingest: async () => ({ ok: true }) } as unknown as PackageUploadService;
+    const app = express();
+    app.use(express.json());
+    app.use('/install/registry', createRegistryInstallRouter({ client, packageUpload: fakeUpload }));
+    const server = app.listen(0);
+    const base = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}/install/registry`;
+    try {
+      const res = await fetch(`${base}/${encodeURIComponent('@omadia/plugin-office')}`, { method: 'POST' });
+      assert.equal(res.status, 409);
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+});

--- a/middleware/test/registryInstallMerge.test.ts
+++ b/middleware/test/registryInstallMerge.test.ts
@@ -283,7 +283,12 @@ describe('registry install router (C2)', () => {
     app.use(express.json());
     app.use(
       '/install/registry',
-      createRegistryInstallRouter({ client: makeClient(), packageUpload: fakeUpload }),
+      createRegistryInstallRouter({
+        client: makeClient(),
+        packageUpload: fakeUpload,
+        catalog: fakeCatalog([]),
+        registry: fakeRegistry,
+      }),
     );
     server = app.listen(0);
     base = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}/install/registry`;
@@ -349,7 +354,15 @@ describe('registry install router · no registries configured', () => {
     const fakeUpload = { ingest: async () => ({ ok: true }) } as unknown as PackageUploadService;
     const app = express();
     app.use(express.json());
-    app.use('/install/registry', createRegistryInstallRouter({ client, packageUpload: fakeUpload }));
+    app.use(
+      '/install/registry',
+      createRegistryInstallRouter({
+        client,
+        packageUpload: fakeUpload,
+        catalog: fakeCatalog([]),
+        registry: fakeRegistry,
+      }),
+    );
     const server = app.listen(0);
     const base = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}/install/registry`;
     try {

--- a/middleware/test/registryInstallMerge.test.ts
+++ b/middleware/test/registryInstallMerge.test.ts
@@ -168,7 +168,7 @@ describe('store router · remote registry merge (C3)', () => {
     await new Promise<void>((r) => server.close(() => r()));
   });
 
-  it('merges remote plugins, local wins on collision, marks source', async () => {
+  it('merges remote plugins, local wins on collision but is tagged with hub source', async () => {
     const body = (await (await fetch(base)).json()) as { items: Plugin[]; total: number };
     const byId = new Map(body.items.map((p) => [p.id, p]));
 
@@ -176,10 +176,12 @@ describe('store router · remote registry merge (C3)', () => {
     assert.equal(body.items.length, 3);
     assert.equal(byId.size, 3);
 
-    // collision: the LOCAL dup survived (name + state), remote dropped
+    // collision: the LOCAL dup wins on content (name + install_state), but is
+    // now tagged with the hub `source` so it still surfaces in the Hub view.
     assert.equal(byId.get('@x/dup')!.name, 'Dup Local');
     assert.equal(byId.get('@x/dup')!.install_state, 'installed');
-    assert.equal(byId.get('@x/dup')!.source, undefined);
+    assert.equal(byId.get('@x/dup')!.source?.registry, 'omadia-public');
+    assert.equal(byId.get('@x/dup')!.source?.sha256, ZIP_SHA);
 
     // remote-only office carries a source marker + available state
     const office = byId.get('@omadia/plugin-office')!;

--- a/web-ui/app/_components/store/InstallButton.tsx
+++ b/web-ui/app/_components/store/InstallButton.tsx
@@ -166,11 +166,18 @@ export function InstallButton({
     setPhase({ kind: 'creating' });
     setFieldErrors({});
     try {
-      // Remote plugin: pull + sha256-verify + ingest the ZIP locally first,
-      // then the install job runs against the now-local package. Idempotent
-      // after the first fetch (the package becomes a local catalog entry).
+      // Remote plugin: pull + sha256-verify + ingest the ZIP locally first
+      // (C2). The server also resolves + ingests the target's depends_on
+      // parents (C5): when any are missing, it returns a `chain` and we open
+      // the chained wizard (parents → target) instead of installing the
+      // target directly — the install gate is strict on depends_on because the
+      // child inherits the parent's vault credentials.
       if (remote) {
-        await installFromRegistry(pluginId);
+        const reg = await installFromRegistry(pluginId);
+        if (reg.chain && reg.chain.available_providers.length > 0) {
+          setPhase({ kind: 'wizard', resolution: reg.chain });
+          return;
+        }
       }
       const resp = await createInstallJob(pluginId);
       setPhase({ kind: 'form', job: resp.job });

--- a/web-ui/app/_components/store/InstallButton.tsx
+++ b/web-ui/app/_components/store/InstallButton.tsx
@@ -10,6 +10,7 @@ import {
   createInstallJob,
   deleteUploadedPackage,
   getInstalledPlugin,
+  installFromRegistry,
   uninstallPlugin,
   updateInstalledPluginConfig,
   ApiError,
@@ -29,6 +30,10 @@ interface InstallButtonProps {
   installState: 'available' | 'installed' | 'update-available' | 'incompatible';
   enabled: boolean;
   blockingReasons?: string[];
+  /** When true the plugin lives on a remote registry and is not yet ingested
+   *  locally: install first fetches + ingests the ZIP (POST /install/registry),
+   *  then proceeds with the normal install job. */
+  remote?: boolean;
 }
 
 type Phase =
@@ -46,6 +51,7 @@ export function InstallButton({
   installState,
   enabled,
   blockingReasons,
+  remote = false,
 }: InstallButtonProps): React.ReactElement {
   const router = useRouter();
   const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
@@ -160,6 +166,12 @@ export function InstallButton({
     setPhase({ kind: 'creating' });
     setFieldErrors({});
     try {
+      // Remote plugin: pull + sha256-verify + ingest the ZIP locally first,
+      // then the install job runs against the now-local package. Idempotent
+      // after the first fetch (the package becomes a local catalog entry).
+      if (remote) {
+        await installFromRegistry(pluginId);
+      }
       const resp = await createInstallJob(pluginId);
       setPhase({ kind: 'form', job: resp.job });
     } catch (err) {

--- a/web-ui/app/_components/store/PluginCard.tsx
+++ b/web-ui/app/_components/store/PluginCard.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { ArrowUpRight } from 'lucide-react';
+import { ArrowUpRight, Store } from 'lucide-react';
 
 import type { Plugin } from '../../_lib/storeTypes';
 import { Chip } from './Chip';
@@ -57,6 +57,15 @@ export function PluginCard({
       {/* Metadata row */}
       <div className="mt-5 flex flex-wrap items-center gap-1.5">
         <StateBadge state={plugin.install_state} isLegacy={isLegacy} />
+        {/* Origin marker — present only on remote-registry (Hub) entries that
+            are not yet ingested locally. Lets the Hub view distinguish a
+            hub-sourced plugin from a local catalog package at a glance. */}
+        {plugin.source ? (
+          <Chip tone="accent">
+            <Store className="mr-1 size-3" aria-hidden />
+            Hub · {plugin.source.registry}
+          </Chip>
+        ) : null}
         {visibleCategories.map((cat) => (
           <Chip key={cat} tone="muted">
             {cat}

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -1,5 +1,6 @@
 import type {
   AuditMode,
+  InstallChainResolution,
   InstallConfigureResponse,
   InstallCreateResponse,
   InstallJob,
@@ -662,6 +663,10 @@ export interface RegistryInstallResponse {
   plugin_id: string;
   version: string;
   registry: string;
+  /** C5 — missing `depends_on` parents (already fetched + ingested) the
+   *  operator must install before the target. Empty/absent → install the
+   *  target directly. Same shape the RequiresWizard consumes. */
+  chain?: InstallChainResolution;
   next: { install: string };
 }
 

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -588,6 +588,100 @@ export async function deleteUploadedPackage(id: string): Promise<void> {
 }
 
 // -----------------------------------------------------------------------------
+// Plugin registries (admin) + remote install
+// -----------------------------------------------------------------------------
+
+/** Non-secret view of a configured registry (the bearer token is write-only
+ *  and never returned — only `has_token` flags its presence). */
+export interface StoredRegistry {
+  name: string;
+  url: string;
+  has_token: boolean;
+}
+
+export interface RegistryListResponse {
+  registries: StoredRegistry[];
+}
+
+export async function listRegistries(): Promise<RegistryListResponse> {
+  return getJson<RegistryListResponse>('/v1/admin/registries');
+}
+
+export async function addRegistry(body: {
+  name: string;
+  url: string;
+  token?: string;
+}): Promise<void> {
+  await postJson<void>('/v1/admin/registries', body);
+}
+
+export async function updateRegistry(
+  name: string,
+  patch: { url?: string; token?: string | null },
+): Promise<void> {
+  const forwarded = await forwardCookieHeader();
+  const res = await fetch(
+    botApi(`/v1/admin/registries/${encodeURIComponent(name)}`),
+    {
+      method: 'PATCH',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+        ...forwarded,
+      },
+      body: JSON.stringify(patch),
+      credentials: 'include',
+      cache: 'no-store',
+    },
+  );
+  if (res.ok || res.status === 204) return;
+  const text = await res.text().catch(() => '');
+  maybeNavigateToLogin(res.status);
+  throw new ApiError(res.status, `PATCH registry failed: ${res.status}`, text);
+}
+
+export async function deleteRegistry(name: string): Promise<void> {
+  const forwarded = await forwardCookieHeader();
+  const res = await fetch(
+    botApi(`/v1/admin/registries/${encodeURIComponent(name)}`),
+    {
+      method: 'DELETE',
+      headers: { accept: 'application/json', ...forwarded },
+      credentials: 'include',
+      cache: 'no-store',
+    },
+  );
+  if (res.ok || res.status === 204) return;
+  const text = await res.text().catch(() => '');
+  maybeNavigateToLogin(res.status);
+  throw new ApiError(res.status, `DELETE registry failed: ${res.status}`, text);
+}
+
+export interface RegistryInstallResponse {
+  ok: true;
+  plugin_id: string;
+  version: string;
+  registry: string;
+  next: { install: string };
+}
+
+/**
+ * Fetch a plugin ZIP from a configured registry and ingest it locally (C2).
+ * Returns the ingested plugin id; the caller then drives the normal install
+ * job (`createInstallJob` → `configureInstallJob`) for setup + activation.
+ */
+export async function installFromRegistry(
+  id: string,
+  version?: string,
+): Promise<RegistryInstallResponse> {
+  const suffix = version ? `?version=${encodeURIComponent(version)}` : '';
+  return postJson<RegistryInstallResponse>(
+    `/v1/install/registry/${encodeURIComponent(id)}${suffix}`,
+    undefined,
+  );
+}
+
+// -----------------------------------------------------------------------------
 // System / vault-status
 // -----------------------------------------------------------------------------
 

--- a/web-ui/app/_lib/storeTypes.ts
+++ b/web-ui/app/_lib/storeTypes.ts
@@ -137,6 +137,14 @@ export interface Plugin {
    * channel-SDK's `core.registerRouter`.
    */
   admin_ui_path?: string;
+  /** Present only for entries sourced from a remote registry that are not yet
+   *  ingested locally. Drives the remote-install flow (fetch-then-ingest
+   *  before the normal install job). Mirrors middleware admin-v1. */
+  source?: {
+    registry: string;
+    download_url: string;
+    sha256: string;
+  };
 }
 
 export interface StoreListResponse {

--- a/web-ui/app/admin/page.tsx
+++ b/web-ui/app/admin/page.tsx
@@ -45,6 +45,11 @@ export default function AdminIndexPage(): React.ReactElement {
           description="Übersicht aller registrierten Plugins gruppiert nach Domain (z.B. odoo, m365.calendar, core.knowledge-graph). Read-only — Curation kommt mit Phase 9."
         />
         <AdminCard
+          href="/admin/registries"
+          title="Plugin-Registries"
+          description="Store-Quellen verwalten (Standard: hub.omadia.ai). Private Registries mit Token. Änderungen wirken ohne Neustart."
+        />
+        <AdminCard
           href="/admin/bulk-promote"
           title="Memory · Bulk-Promotion"
           description="Historische Turns nachträglich auf Significance scoren und bei hoher Bewertung als MemorableKnowledge promoten. Idempotent."

--- a/web-ui/app/admin/registries/page.tsx
+++ b/web-ui/app/admin/registries/page.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import {
+  ApiError,
+  StoredRegistry,
+  addRegistry,
+  deleteRegistry,
+  listRegistries,
+  updateRegistry,
+} from '../../_lib/api';
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ready'; registries: StoredRegistry[] }
+  | { kind: 'error'; message: string };
+
+/**
+ * Admin UI for the plugin registries Core pulls from (the "store sources").
+ *
+ * Backend: /api/v1/admin/registries (CRUD). The bearer token is write-only —
+ * the listing only flags `has_token`. Changes apply without a restart (the
+ * live RegistryClient is reloaded server-side after each mutation). A fresh
+ * install is seeded with the public default `hub.omadia.ai`.
+ */
+export default function AdminRegistriesPage(): React.ReactElement {
+  const [state, setState] = useState<State>({ kind: 'loading' });
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  // add-form
+  const [name, setName] = useState('');
+  const [url, setUrl] = useState('');
+  const [token, setToken] = useState('');
+  const [adding, setAdding] = useState(false);
+
+  // per-row pending + edit state
+  const [pending, setPending] = useState<string | null>(null);
+  const [editing, setEditing] = useState<string | null>(null);
+  const [editUrl, setEditUrl] = useState('');
+  const [editToken, setEditToken] = useState('');
+
+  async function reload(): Promise<void> {
+    try {
+      const res = await listRegistries();
+      setState({ kind: 'ready', registries: res.registries });
+    } catch (err) {
+      setState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void reload();
+  }, []);
+
+  async function onAdd(): Promise<void> {
+    setActionError(null);
+    setAdding(true);
+    try {
+      await addRegistry({
+        name: name.trim(),
+        url: url.trim(),
+        ...(token.trim() ? { token: token.trim() } : {}),
+      });
+      setName('');
+      setUrl('');
+      setToken('');
+      await reload();
+    } catch (err) {
+      setActionError(toFriendlyError(err));
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  function startEdit(r: StoredRegistry): void {
+    setActionError(null);
+    setEditing(r.name);
+    setEditUrl(r.url);
+    setEditToken('');
+  }
+
+  async function onSaveEdit(r: StoredRegistry): Promise<void> {
+    setActionError(null);
+    setPending(r.name);
+    try {
+      const patch: { url?: string; token?: string | null } = {};
+      if (editUrl.trim() && editUrl.trim() !== r.url) patch.url = editUrl.trim();
+      if (editToken.trim()) patch.token = editToken.trim();
+      if (Object.keys(patch).length > 0) await updateRegistry(r.name, patch);
+      setEditing(null);
+      await reload();
+    } catch (err) {
+      setActionError(toFriendlyError(err));
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function onClearToken(r: StoredRegistry): Promise<void> {
+    setActionError(null);
+    setPending(r.name);
+    try {
+      await updateRegistry(r.name, { token: null });
+      await reload();
+    } catch (err) {
+      setActionError(toFriendlyError(err));
+    } finally {
+      setPending(null);
+    }
+  }
+
+  async function onDelete(r: StoredRegistry): Promise<void> {
+    if (!confirm(`Registry „${r.name}" wirklich entfernen?`)) return;
+    setActionError(null);
+    setPending(r.name);
+    try {
+      await deleteRegistry(r.name);
+      await reload();
+    } catch (err) {
+      setActionError(toFriendlyError(err));
+    } finally {
+      setPending(null);
+    }
+  }
+
+  const canAdd = name.trim().length > 0 && url.trim().length > 0 && !adding;
+
+  return (
+    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-10 lg:py-16">
+      <header className="mb-8">
+        <h1 className="font-display text-[clamp(1.75rem,3.5vw,2.5rem)] leading-[1.1] text-[color:var(--fg-strong)]">
+          Plugin-Registries
+        </h1>
+        <p className="mt-3 max-w-2xl text-[15px] leading-[1.55] text-[color:var(--fg-muted)]">
+          Quellen, aus denen Plugins in den Store gezogen werden. Neue Instanzen
+          starten mit{' '}
+          <code className="rounded bg-[color:var(--card)] px-1 py-0.5 text-[12px]">
+            hub.omadia.ai
+          </code>
+          . Der Token wird verschlüsselt gespeichert und nie wieder angezeigt —
+          nur, ob einer hinterlegt ist. Änderungen wirken ohne Neustart.
+        </p>
+      </header>
+
+      {/* Add form */}
+      <section className="mb-8 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+        <h2 className="mb-4 text-[15px] font-semibold text-[color:var(--fg-strong)]">
+          Registry hinzufügen
+        </h2>
+        <div className="grid gap-3 sm:grid-cols-[1fr_2fr_1.5fr_auto] sm:items-end">
+          <Field label="Name">
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="omadia-public"
+              className={inputCls}
+            />
+          </Field>
+          <Field label="URL">
+            <input
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://hub.omadia.ai"
+              className={inputCls}
+            />
+          </Field>
+          <Field label="Token (optional)">
+            <input
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              placeholder="nur für private Registries"
+              type="password"
+              className={inputCls}
+            />
+          </Field>
+          <button
+            type="button"
+            onClick={() => void onAdd()}
+            disabled={!canAdd}
+            className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-black disabled:opacity-50"
+          >
+            {adding ? '…' : 'Hinzufügen'}
+          </button>
+        </div>
+      </section>
+
+      {state.kind === 'loading' ? (
+        <p className="text-sm opacity-70">Lädt …</p>
+      ) : state.kind === 'error' ? (
+        <p className="text-sm text-red-500">Fehler beim Laden: {state.message}</p>
+      ) : state.registries.length === 0 ? (
+        <p className="text-sm text-[color:var(--fg-muted)]">
+          Keine Registries konfiguriert.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {state.registries.map((r) => (
+            <li
+              key={r.name}
+              className="rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-4">
+                <div className="flex flex-1 flex-col gap-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[15px] font-semibold text-[color:var(--fg-strong)]">
+                      {r.name}
+                    </span>
+                    <TokenBadge hasToken={r.has_token} />
+                  </div>
+                  <code className="text-[13px] text-[color:var(--fg-muted)]">
+                    {r.url}
+                  </code>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      editing === r.name ? setEditing(null) : startEdit(r)
+                    }
+                    disabled={pending === r.name}
+                    className="rounded-md border border-[color:var(--border)] px-3 py-2 text-sm font-medium text-[color:var(--fg-strong)] hover:bg-[color:var(--card)] disabled:opacity-50"
+                  >
+                    {editing === r.name ? 'Abbrechen' : 'Bearbeiten'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void onDelete(r)}
+                    disabled={pending === r.name}
+                    className="rounded-md border border-[color:var(--border)] px-3 py-2 text-sm font-medium text-red-500 hover:bg-red-500/10 disabled:opacity-50"
+                  >
+                    {pending === r.name ? '…' : 'Entfernen'}
+                  </button>
+                </div>
+              </div>
+
+              {editing === r.name && (
+                <div className="mt-4 grid gap-3 border-t border-[color:var(--border)] pt-4 sm:grid-cols-[2fr_1.5fr_auto] sm:items-end">
+                  <Field label="URL">
+                    <input
+                      value={editUrl}
+                      onChange={(e) => setEditUrl(e.target.value)}
+                      className={inputCls}
+                    />
+                  </Field>
+                  <Field label="Token ersetzen">
+                    <input
+                      value={editToken}
+                      onChange={(e) => setEditToken(e.target.value)}
+                      placeholder={r.has_token ? '•••••• (unverändert)' : 'keiner'}
+                      type="password"
+                      className={inputCls}
+                    />
+                  </Field>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => void onSaveEdit(r)}
+                      disabled={pending === r.name}
+                      className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-black disabled:opacity-50"
+                    >
+                      Speichern
+                    </button>
+                    {r.has_token && (
+                      <button
+                        type="button"
+                        onClick={() => void onClearToken(r)}
+                        disabled={pending === r.name}
+                        className="rounded-md border border-[color:var(--border)] px-3 py-2 text-sm font-medium text-[color:var(--fg-muted)] hover:bg-[color:var(--card)] disabled:opacity-50"
+                      >
+                        Token entfernen
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {actionError && <p className="mt-4 text-sm text-red-500">{actionError}</p>}
+    </main>
+  );
+}
+
+const inputCls =
+  'w-full rounded-md border border-[color:var(--border)] bg-transparent px-3 py-2 text-sm outline-none focus:border-[color:var(--accent)]';
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function TokenBadge({ hasToken }: { hasToken: boolean }): React.ReactElement {
+  return (
+    <span
+      className={[
+        'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em]',
+        hasToken
+          ? 'bg-emerald-500/10 text-emerald-500'
+          : 'bg-[color:var(--border)]/40 text-[color:var(--fg-muted)]',
+      ].join(' ')}
+    >
+      {hasToken ? 'Token gesetzt' : 'öffentlich'}
+    </span>
+  );
+}
+
+function toFriendlyError(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.body.includes('registry_config.duplicate')) {
+      return 'Eine Registry mit diesem Namen existiert bereits.';
+    }
+    if (err.body.includes('invalid_url')) {
+      return 'Die URL ist ungültig (http(s) erforderlich).';
+    }
+    if (err.body.includes('invalid_name')) {
+      return 'Der Name darf nur Buchstaben, Zahlen, . _ - enthalten.';
+    }
+    if (err.body.includes('not_found')) {
+      return 'Registry nicht gefunden — Liste neu geladen.';
+    }
+    if (err.body.includes('missing_fields')) {
+      return 'Name und URL sind erforderlich.';
+    }
+    return `Fehler ${err.status}.`;
+  }
+  return err instanceof Error ? err.message : String(err);
+}

--- a/web-ui/app/store/[id]/page.tsx
+++ b/web-ui/app/store/[id]/page.tsx
@@ -265,6 +265,7 @@ export default async function PluginDetailPage({
             pluginName={plugin.name}
             installState={plugin.install_state}
             enabled={install_available}
+            remote={Boolean(plugin.source)}
             {...(blocking_reasons ? { blockingReasons: blocking_reasons } : {})}
           />
 

--- a/web-ui/app/store/page.tsx
+++ b/web-ui/app/store/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { PackageCheck, Store } from 'lucide-react';
 
 import { listProfiles, listStorePlugins } from '../_lib/api';
 import { redirectIfUnauthorized } from '../_lib/authRedirect';
@@ -18,6 +19,10 @@ export const dynamic = 'force-dynamic';
 
 type CategoryFilter = 'all' | PluginKind;
 
+/** Top-level view switch: locally installed plugins vs. plugins available to
+ *  install — both from the remote Hub registries and the local catalog. */
+type SourceFilter = 'installed' | 'hub';
+
 const FILTER_LABEL: Record<CategoryFilter, string> = {
   all: 'Alle',
   integration: 'Integrations',
@@ -30,9 +35,10 @@ const FILTER_LABEL: Record<CategoryFilter, string> = {
 export default async function StorePage({
   searchParams,
 }: {
-  searchParams: Promise<{ kind?: string }>;
+  searchParams: Promise<{ kind?: string; source?: string }>;
 }): Promise<React.ReactElement> {
   const params = await searchParams;
+  const source = parseSource(params.source);
   const filter = parseFilter(params.kind);
 
   let plugins: Plugin[] = [];
@@ -60,13 +66,21 @@ export default async function StorePage({
     profiles = [];
   }
 
-  const installedCount = plugins.filter(
+  // Partition once: "installed" is everything already in the runtime registry,
+  // "hub" is everything available to install. The hub bucket holds both remote
+  // registry entries (`plugin.source` set) and any local-but-uninstalled
+  // catalog packages — the store router (routes/store.ts) merges both lists.
+  const installedPlugins = plugins.filter(
     (p) => p.install_state === 'installed',
-  ).length;
+  );
+  const hubPlugins = plugins.filter((p) => p.install_state !== 'installed');
+  const installedCount = installedPlugins.length;
+  const hubCount = hubPlugins.length;
 
-  const countsByKind = countByKind(plugins);
+  const scoped = source === 'installed' ? installedPlugins : hubPlugins;
+  const countsByKind = countByKind(scoped);
   const visible =
-    filter === 'all' ? plugins : plugins.filter((p) => p.kind === filter);
+    filter === 'all' ? scoped : scoped.filter((p) => p.kind === filter);
 
   return (
     <main className="mx-auto max-w-[1280px] px-6 py-12 lg:px-10 lg:py-16">
@@ -94,34 +108,45 @@ export default async function StorePage({
           und Abhängigkeiten vor der Installation.
         </p>
 
-        {/* Stats strip — three plugin kinds + total */}
+        {/* Stats strip — installed vs. hub split + total */}
         <dl className="mt-10 grid max-w-2xl grid-cols-4 gap-6 border-t border-[color:var(--divider)] pt-5 text-sm">
           <Stat label="Plugins" value={plugins.length} />
-          <Stat label="Integrations" value={countsByKind.integration} />
-          <Stat label="Agents" value={countsByKind.agent} />
-          <Stat label="Channels" value={countsByKind.channel} />
+          <Stat label="Installiert" value={installedCount} accent />
+          <Stat label="Im Hub" value={hubCount} />
+          <Stat label="Integrations" value={countByKind(plugins).integration} />
         </dl>
       </header>
 
-      {/* Upload dropzone — lives above the filter tabs so the "here's how to add one" path is visible before scanning the catalog. */}
-      <div className="mt-8">
-        <UploadDropzone />
-      </div>
+      {/* Source switch — the primary view toggle: installed runtime plugins vs.
+          the Hub catalog of plugins available to install. */}
+      <SourceTabs
+        source={source}
+        installedCount={installedCount}
+        hubCount={hubCount}
+      />
 
-      {/* Category filter tabs */}
+      {/* Upload dropzone — only in the Hub view, where "add a plugin" belongs.
+          An uploaded package surfaces here as an installable catalog entry. */}
+      {source === 'hub' ? (
+        <div className="mt-6">
+          <UploadDropzone />
+        </div>
+      ) : null}
+
+      {/* Category filter tabs — scoped to the active source. */}
       <nav
-        className="mt-10 flex flex-wrap items-center gap-2"
+        className="mt-8 flex flex-wrap items-center gap-2"
         aria-label="Kategorie filtern"
       >
         {(['all', 'integration', 'agent', 'channel'] as CategoryFilter[]).map(
           (f) => {
             const count =
-              f === 'all' ? plugins.length : countsByKind[f as PluginKind];
+              f === 'all' ? scoped.length : countsByKind[f as PluginKind];
             const active = f === filter;
             return (
               <Link
                 key={f}
-                href={f === 'all' ? '/store' : `/store?kind=${f}`}
+                href={buildHref(source, f)}
                 className={cn(
                   'inline-flex items-center gap-2 rounded-full px-4 py-1.5',
                   'text-[12px] font-semibold transition-colors duration-[140ms]',
@@ -154,7 +179,7 @@ export default async function StorePage({
         {loadError ? (
           <LoadErrorState message={loadError} />
         ) : visible.length === 0 ? (
-          <EmptyState filter={filter} />
+          <EmptyState source={source} filter={filter} />
         ) : (
           <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
             {visible.map((plugin, idx) => (
@@ -211,30 +236,136 @@ function Stat({
   );
 }
 
+/**
+ * Source switch — segmented control toggling between the installed-runtime
+ * view and the Hub catalog. Server-rendered as two `<Link>`s so the active
+ * view is sharable/bookmarkable via `?source=`.
+ */
+function SourceTabs({
+  source,
+  installedCount,
+  hubCount,
+}: {
+  source: SourceFilter;
+  installedCount: number;
+  hubCount: number;
+}): React.ReactElement {
+  const tabs: Array<{
+    key: SourceFilter;
+    label: string;
+    count: number;
+    icon: React.ReactNode;
+  }> = [
+    {
+      key: 'hub',
+      label: 'Hub',
+      count: hubCount,
+      icon: <Store className="size-4" aria-hidden />,
+    },
+    {
+      key: 'installed',
+      label: 'Installiert',
+      count: installedCount,
+      icon: <PackageCheck className="size-4" aria-hidden />,
+    },
+  ];
+
+  return (
+    <nav
+      className="mt-8 inline-flex rounded-full border border-[color:var(--border)] bg-[color:var(--bg-soft)] p-1"
+      aria-label="Quelle wählen"
+    >
+      {tabs.map((tab) => {
+        const active = tab.key === source;
+        return (
+          <Link
+            key={tab.key}
+            href={buildHref(tab.key, 'all')}
+            aria-current={active ? 'page' : undefined}
+            className={cn(
+              'inline-flex items-center gap-2 rounded-full px-5 py-2',
+              'text-[13px] font-semibold transition-colors duration-[140ms]',
+              'ease-[cubic-bezier(0.22,0.61,0.36,1)]',
+              active
+                ? 'bg-[color:var(--accent)] text-white shadow-[var(--shadow-cta)]'
+                : 'text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]',
+            )}
+          >
+            {tab.icon}
+            <span>{tab.label}</span>
+            <span
+              className={cn(
+                'font-mono-num tabular-nums rounded-full px-1.5 text-[10px]',
+                active
+                  ? 'bg-white/25 text-white'
+                  : 'bg-[color:var(--bg)] text-[color:var(--fg-subtle)]',
+              )}
+            >
+              {tab.count}
+            </span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
 function EmptyState({
+  source,
   filter,
 }: {
+  source: SourceFilter;
   filter: CategoryFilter;
 }): React.ReactElement {
-  const headline =
-    filter === 'all'
-      ? 'Noch keine Plugins im Katalog.'
-      : `Keine ${FILTER_LABEL[filter]} installiert oder verfügbar.`;
+  // Kind-filtered-into-emptiness inside a non-empty source: keep it short.
+  if (filter !== 'all') {
+    return (
+      <div className="rounded-[14px] border border-dashed border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-12 text-center">
+        <p className="font-display text-[22px] text-[color:var(--fg-strong)]">
+          Keine {FILTER_LABEL[filter]} in dieser Ansicht.
+        </p>
+        <p className="mt-3 text-sm leading-relaxed text-[color:var(--fg-muted)]">
+          Wechsle die Kategorie oder die Quelle oben.
+        </p>
+      </div>
+    );
+  }
+
+  if (source === 'installed') {
+    return (
+      <div className="rounded-[14px] border border-dashed border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-12 text-center">
+        <p className="font-display text-[22px] text-[color:var(--fg-strong)]">
+          Noch keine Plugins installiert.
+        </p>
+        <p className="mt-3 text-sm leading-relaxed text-[color:var(--fg-muted)]">
+          Wechsle zum{' '}
+          <Link
+            href={buildHref('hub', 'all')}
+            className="font-semibold text-[color:var(--accent)] underline-offset-4 hover:underline"
+          >
+            Hub
+          </Link>
+          , um verfügbare Plugins zu durchsuchen und zu installieren.
+        </p>
+      </div>
+    );
+  }
+
+  // source === 'hub' and empty — usually means no registry is reachable.
   return (
     <div className="rounded-[14px] border border-dashed border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-12 text-center">
       <p className="font-display text-[22px] text-[color:var(--fg-strong)]">
-        {headline}
+        Keine Plugins im Hub verfügbar.
       </p>
       <p className="mt-3 text-sm leading-relaxed text-[color:var(--fg-muted)]">
-        Lege ein{' '}
-        <span className="font-mono-num text-[color:var(--fg)]">
-          *.manifest.yaml
-        </span>{' '}
-        unter{' '}
-        <span className="font-mono-num text-[color:var(--fg)]">
-          docs/harness-platform/examples/
-        </span>{' '}
-        ab und starte die Middleware neu.
+        Verbinde eine Registry unter{' '}
+        <Link
+          href="/admin/registries"
+          className="font-semibold text-[color:var(--accent)] underline-offset-4 hover:underline"
+        >
+          Admin · Registries
+        </Link>{' '}
+        — oder lade ein Plugin-Paket per Drag-&-Drop oben hoch.
       </p>
     </div>
   );
@@ -271,6 +402,20 @@ function LoadErrorState({ message }: { message: string }): React.ReactElement {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+function parseSource(raw: string | undefined): SourceFilter {
+  return raw === 'installed' ? 'installed' : 'hub';
+}
+
+/** Build a `/store` href preserving the source/kind pair. `hub` + `all` are
+ *  the defaults, so they are omitted to keep the canonical URL clean. */
+function buildHref(source: SourceFilter, kind: CategoryFilter): string {
+  const params = new URLSearchParams();
+  if (source !== 'hub') params.set('source', source);
+  if (kind !== 'all') params.set('kind', kind);
+  const qs = params.toString();
+  return qs ? `/store?${qs}` : '/store';
+}
 
 function parseFilter(raw: string | undefined): CategoryFilter {
   if (

--- a/web-ui/app/store/page.tsx
+++ b/web-ui/app/store/page.tsx
@@ -66,15 +66,22 @@ export default async function StorePage({
     profiles = [];
   }
 
-  // Partition once: "installed" is everything already in the runtime registry,
-  // "hub" is everything available to install. The hub bucket holds both remote
-  // registry entries (`plugin.source` set) and any local-but-uninstalled
-  // catalog packages — the store router (routes/store.ts) merges both lists.
+  // "Installiert" is a filtered view of everything already in the runtime
+  // registry. "Hub" is the FULL catalog — every plugin available to browse,
+  // *including* ones already installed, which keep their green "Installiert"
+  // flag (StateBadge) so you can spot what you already have. Not-yet-installed
+  // entries sort first so newly discoverable plugins surface at the top;
+  // Array.sort is stable, so the catalog's name order is preserved per group.
   const installedPlugins = plugins.filter(
     (p) => p.install_state === 'installed',
   );
-  const hubPlugins = plugins.filter((p) => p.install_state !== 'installed');
+  const hubPlugins = [...plugins].sort(
+    (a, b) =>
+      Number(a.install_state === 'installed') -
+      Number(b.install_state === 'installed'),
+  );
   const installedCount = installedPlugins.length;
+  const notInstalledCount = plugins.length - installedCount;
   const hubCount = hubPlugins.length;
 
   const scoped = source === 'installed' ? installedPlugins : hubPlugins;
@@ -112,7 +119,7 @@ export default async function StorePage({
         <dl className="mt-10 grid max-w-2xl grid-cols-4 gap-6 border-t border-[color:var(--divider)] pt-5 text-sm">
           <Stat label="Plugins" value={plugins.length} />
           <Stat label="Installiert" value={installedCount} accent />
-          <Stat label="Im Hub" value={hubCount} />
+          <Stat label="Verfügbar" value={notInstalledCount} />
           <Stat label="Integrations" value={countByKind(plugins).integration} />
         </dl>
       </header>

--- a/web-ui/app/store/page.tsx
+++ b/web-ui/app/store/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { PackageCheck, Store } from 'lucide-react';
+import { HardDrive, PackageCheck, Store } from 'lucide-react';
 
 import { listProfiles, listStorePlugins } from '../_lib/api';
 import { redirectIfUnauthorized } from '../_lib/authRedirect';
@@ -19,9 +19,10 @@ export const dynamic = 'force-dynamic';
 
 type CategoryFilter = 'all' | PluginKind;
 
-/** Top-level view switch: locally installed plugins vs. plugins available to
- *  install — both from the remote Hub registries and the local catalog. */
-type SourceFilter = 'installed' | 'hub';
+/** Top-level view switch by plugin origin: `hub` = advertised by a remote
+ *  registry, `local` = local catalog package (not installed), `installed` =
+ *  already in the runtime registry. */
+type SourceFilter = 'hub' | 'local' | 'installed';
 
 const FILTER_LABEL: Record<CategoryFilter, string> = {
   all: 'Alle',
@@ -66,25 +67,31 @@ export default async function StorePage({
     profiles = [];
   }
 
-  // "Installiert" is a filtered view of everything already in the runtime
-  // registry. "Hub" is the FULL catalog — every plugin available to browse,
-  // *including* ones already installed, which keep their green "Installiert"
-  // flag (StateBadge) so you can spot what you already have. Not-yet-installed
-  // entries sort first so newly discoverable plugins surface at the top;
-  // Array.sort is stable, so the catalog's name order is preserved per group.
+  // Three origins, partitioned so every plugin lands in exactly one bucket:
+  //   • Hub         — advertised by a remote registry (`plugin.source` set),
+  //                   available to fetch + install. An installed hub plugin
+  //                   becomes local and leaves this bucket (the store router's
+  //                   local-wins merge drops the remote entry on id collision).
+  //   • Lokal       — local catalog packages (examples / uploaded ZIPs) that
+  //                   are not yet installed.
+  //   • Installiert — anything already in the runtime registry.
+  const hubPlugins = plugins.filter((p) => p.source != null);
   const installedPlugins = plugins.filter(
     (p) => p.install_state === 'installed',
   );
-  const hubPlugins = [...plugins].sort(
-    (a, b) =>
-      Number(a.install_state === 'installed') -
-      Number(b.install_state === 'installed'),
+  const localPlugins = plugins.filter(
+    (p) => p.source == null && p.install_state !== 'installed',
   );
-  const installedCount = installedPlugins.length;
-  const notInstalledCount = plugins.length - installedCount;
   const hubCount = hubPlugins.length;
+  const localCount = localPlugins.length;
+  const installedCount = installedPlugins.length;
 
-  const scoped = source === 'installed' ? installedPlugins : hubPlugins;
+  const scoped =
+    source === 'installed'
+      ? installedPlugins
+      : source === 'local'
+        ? localPlugins
+        : hubPlugins;
   const countsByKind = countByKind(scoped);
   const visible =
     filter === 'all' ? scoped : scoped.filter((p) => p.kind === filter);
@@ -118,23 +125,23 @@ export default async function StorePage({
         {/* Stats strip — installed vs. hub split + total */}
         <dl className="mt-10 grid max-w-2xl grid-cols-4 gap-6 border-t border-[color:var(--divider)] pt-5 text-sm">
           <Stat label="Plugins" value={plugins.length} />
-          <Stat label="Installiert" value={installedCount} accent />
-          <Stat label="Verfügbar" value={notInstalledCount} />
-          <Stat label="Integrations" value={countByKind(plugins).integration} />
+          <Stat label="Hub" value={hubCount} accent />
+          <Stat label="Lokal" value={localCount} />
+          <Stat label="Installiert" value={installedCount} />
         </dl>
       </header>
 
-      {/* Source switch — the primary view toggle: installed runtime plugins vs.
-          the Hub catalog of plugins available to install. */}
+      {/* Source switch — the primary view selector by plugin origin. */}
       <SourceTabs
         source={source}
-        installedCount={installedCount}
         hubCount={hubCount}
+        localCount={localCount}
+        installedCount={installedCount}
       />
 
-      {/* Upload dropzone — only in the Hub view, where "add a plugin" belongs.
-          An uploaded package surfaces here as an installable catalog entry. */}
-      {source === 'hub' ? (
+      {/* Upload dropzone — only in the Lokal view: an uploaded ZIP becomes a
+          local catalog package, which is exactly what this view lists. */}
+      {source === 'local' ? (
         <div className="mt-6">
           <UploadDropzone />
         </div>
@@ -250,12 +257,14 @@ function Stat({
  */
 function SourceTabs({
   source,
-  installedCount,
   hubCount,
+  localCount,
+  installedCount,
 }: {
   source: SourceFilter;
-  installedCount: number;
   hubCount: number;
+  localCount: number;
+  installedCount: number;
 }): React.ReactElement {
   const tabs: Array<{
     key: SourceFilter;
@@ -268,6 +277,12 @@ function SourceTabs({
       label: 'Hub',
       count: hubCount,
       icon: <Store className="size-4" aria-hidden />,
+    },
+    {
+      key: 'local',
+      label: 'Lokal',
+      count: localCount,
+      icon: <HardDrive className="size-4" aria-hidden />,
     },
     {
       key: 'installed',
@@ -351,6 +366,13 @@ function EmptyState({
             className="font-semibold text-[color:var(--accent)] underline-offset-4 hover:underline"
           >
             Hub
+          </Link>{' '}
+          oder{' '}
+          <Link
+            href={buildHref('local', 'all')}
+            className="font-semibold text-[color:var(--accent)] underline-offset-4 hover:underline"
+          >
+            Lokal
           </Link>
           , um verfügbare Plugins zu durchsuchen und zu installieren.
         </p>
@@ -358,7 +380,23 @@ function EmptyState({
     );
   }
 
-  // source === 'hub' and empty — usually means no registry is reachable.
+  if (source === 'local') {
+    return (
+      <div className="rounded-[14px] border border-dashed border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-12 text-center">
+        <p className="font-display text-[22px] text-[color:var(--fg-strong)]">
+          Keine lokalen Pakete.
+        </p>
+        <p className="mt-3 text-sm leading-relaxed text-[color:var(--fg-muted)]">
+          Lade ein Plugin-Paket per Drag-&-Drop oben hoch — der Server validiert
+          das Manifest und registriert es im Katalog.
+        </p>
+      </div>
+    );
+  }
+
+  // source === 'hub' and empty — no remote registry advertises an installable
+  // (not-yet-local) plugin. Either no registry is reachable, or every hub
+  // entry is already installed locally (the merge drops those).
   return (
     <div className="rounded-[14px] border border-dashed border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-12 text-center">
       <p className="font-display text-[22px] text-[color:var(--fg-strong)]">
@@ -372,7 +410,14 @@ function EmptyState({
         >
           Admin · Registries
         </Link>{' '}
-        — oder lade ein Plugin-Paket per Drag-&-Drop oben hoch.
+        — oder lade ein eigenes Paket im{' '}
+        <Link
+          href={buildHref('local', 'all')}
+          className="font-semibold text-[color:var(--accent)] underline-offset-4 hover:underline"
+        >
+          Lokal
+        </Link>
+        -Tab hoch.
       </p>
     </div>
   );
@@ -411,7 +456,9 @@ function LoadErrorState({ message }: { message: string }): React.ReactElement {
 // ---------------------------------------------------------------------------
 
 function parseSource(raw: string | undefined): SourceFilter {
-  return raw === 'installed' ? 'installed' : 'hub';
+  if (raw === 'installed') return 'installed';
+  if (raw === 'local') return 'local';
+  return 'hub';
 }
 
 /** Build a `/store` href preserving the source/kind pair. `hub` + `all` are


### PR DESCRIPTION
## Plugin store / registry MVP

Adds the **consumer half** of a plugin registry (npm-style: dumb hub, smart core client) plus the operator **store UI**. The hub service itself lives in a separate repo (`byte5ai/omadia-hub`, deployed to `hub.omadia.ai`); this PR is everything that ships in OSS-Core + the web-ui.

Extends the existing store/install machinery (`/api/v1/store/plugins`, `/api/v1/install/*`, `PackageUploadService.ingest`) — no rewrite, all additive.

### Backend (middleware)
- **RegistryClient** — fetch `index.json`, sha256-verified ZIP download, multi-registry first-wins merge, host-pinned downloads, graceful per-registry degrade.
- **Admin-managed registries** — persistent (`platform_settings`), tokens in the encrypted vault (write-only), default-seeded with `hub.omadia.ai`. CRUD at `/api/v1/admin/registries` with live client reload (no restart). `REGISTRY_URLS` env is a first-boot seed only.
- **Remote install** — `POST /api/v1/install/registry/:id` → fetch → existing ingest pipeline.
- **Store merge** — list + detail endpoints surface remote-registry plugins (`source` marker); a local plugin wins on id collision but is still tagged so it shows in the Hub view.
- **depends_on chaining (C5)** — installing a plugin from the hub auto-resolves + ingests its strict `depends_on` parents (credential inheritance, e.g. `channel-teams` ← `integration-microsoft365`) and returns them as an `InstallChainResolution` so the operator installs "parents → target" in one chained flow.

### Frontend (web-ui)
- `/admin/registries` — registries CRUD page (token write-only).
- Store **origin selector** (Hub / Lokal / Installiert) with a `Hub · <registry>` badge.
- Remote install: `InstallButton` fetch→ingest, then drives the existing `RequiresWizard` for the dependency chain.

### Trust model
sha256 pinned in the index + HTTPS/TLS. No per-artifact signing in the MVP (`Plugin.signed` stays false for remote entries).

### Testing
- 41 unit/integration tests (RegistryClient, registry config store + admin CRUD, store merge, remote install, dependency-chain resolver).
- tsc + lint clean (both repos); boot smoke-tested.
- Deployed + verified on Fly (`odoo-bot-middleware`, `odoo-bot-harness`); hub live with `plugin-office`, `channel-teams`, `integration-microsoft365` published.