### PR TITLE
feat(registry): update detection + store-card update Störer

### DIFF
--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -198,6 +198,10 @@ export interface Plugin {
     download_url: string;
     sha256: string;
   };
+  /** C6 — set when `install_state === 'update-available'`: the newer version a
+   *  configured registry advertises vs the installed one. The `version` field
+   *  still reflects what is installed. */
+  available_version?: string;
   /** Parent plugin identities this one inherits secrets/config from. */
   depends_on: AgentId[];
   /** Background jobs the plugin contributes via its manifest. Always

--- a/middleware/src/routes/store.ts
+++ b/middleware/src/routes/store.ts
@@ -72,15 +72,15 @@ export function createStoreRouter(deps: StoreDeps): Router {
           for (const resolved of plugins) {
             const existingIdx = indexById.get(resolved.entry.id);
             if (existingIdx !== undefined) {
-              const existing = items[existingIdx]!;
-              if (!existing.source) {
-                // Replace with a copy — catalog plugin objects are shared
-                // across requests and must not be mutated.
-                items[existingIdx] = {
-                  ...existing,
-                  source: registrySource(resolved),
-                };
-              }
+              // Enrich the local entry with the hub `source` and, when the hub
+              // advertises a newer version than what's installed, flag it as
+              // `update-available` (C6). Replace with a copy — catalog plugin
+              // objects are shared across requests and must not be mutated.
+              items[existingIdx] = enrichWithRegistry(
+                items[existingIdx]!,
+                resolved,
+                deps.registry,
+              );
               continue;
             }
             const remote = registryEntryToPlugin(resolved);
@@ -154,7 +154,30 @@ export function createStoreRouter(deps: StoreDeps): Router {
         return;
       }
 
-      const plugin = applyInstallState(entry.plugin, deps.registry);
+      let plugin = applyInstallState(entry.plugin, deps.registry);
+      // C6 — update detection on the detail page: if this installed plugin is
+      // also advertised by a registry with a newer version, flag it (+ source).
+      if (plugin.install_state === 'installed' && deps.client?.hasRegistries()) {
+        try {
+          const remote = await resolveRemotePlugin(deps.client, id);
+          if (remote?.source) {
+            const installedVersion =
+              deps.registry.get(id)?.installed_version ?? plugin.version;
+            if (isNewerVersion(remote.version, installedVersion)) {
+              plugin = {
+                ...plugin,
+                install_state: 'update-available',
+                available_version: remote.version,
+                source: remote.source,
+              };
+            } else if (!plugin.source) {
+              plugin = { ...plugin, source: remote.source };
+            }
+          }
+        } catch {
+          // registry hiccup → keep the local 'installed' view, never 500
+        }
+      }
       const installAvailable = plugin.install_state === 'available';
       const body: StoreGetResponse = {
         plugin,
@@ -234,6 +257,61 @@ function registrySource(
     entry.versions.find((v) => v.version === entry.latest_version) ??
     entry.versions[0]!;
   return { registry, download_url: ver.download_url, sha256: ver.sha256 };
+}
+
+/** Enrich a local store entry with its hub `source`, and flag it as
+ *  `update-available` (C6) when the hub advertises a newer version than the
+ *  installed one. Only installed plugins are eligible — an `available` or
+ *  `incompatible` entry keeps its state. Returns a copy (catalog objects are
+ *  shared across requests and must not be mutated). */
+function enrichWithRegistry(
+  existing: Plugin,
+  resolved: ResolvedRegistryPlugin,
+  registry: InstalledRegistry,
+): Plugin {
+  const source = existing.source ?? registrySource(resolved);
+  if (existing.install_state === 'installed') {
+    const hubLatest = resolved.entry.latest_version;
+    const installedVersion =
+      registry.get(existing.id)?.installed_version ?? existing.version;
+    if (isNewerVersion(hubLatest, installedVersion)) {
+      return {
+        ...existing,
+        source,
+        install_state: 'update-available',
+        available_version: hubLatest,
+      };
+    }
+  }
+  return { ...existing, source };
+}
+
+/** Parse the numeric `X.Y.Z` core of a semver (pre-release/build stripped).
+ *  Returns null when any segment is non-numeric — callers treat that as
+ *  "can't compare" and never recommend an update. */
+function parseSemver(v: string): number[] | null {
+  const core = v.trim().split(/[-+]/)[0] ?? '';
+  const parts = core.split('.');
+  const nums = parts.map((p) => Number(p));
+  if (nums.length === 0 || nums.some((n) => !Number.isInteger(n) || n < 0)) {
+    return null;
+  }
+  return nums;
+}
+
+/** True iff `candidate` is a strictly newer version than `current`. Conservative:
+ *  unparseable inputs → false (no spurious update prompts). */
+function isNewerVersion(candidate: string, current: string): boolean {
+  const a = parseSemver(candidate);
+  const b = parseSemver(current);
+  if (!a || !b) return false;
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    const x = a[i] ?? 0;
+    const y = b[i] ?? 0;
+    if (x !== y) return x > y;
+  }
+  return false;
 }
 
 /** Map a remote registry entry → the `Plugin` shape the store list returns.

--- a/middleware/test/registryInstallMerge.test.ts
+++ b/middleware/test/registryInstallMerge.test.ts
@@ -108,7 +108,10 @@ function fakeCatalog(plugins: Plugin[]): PluginCatalog {
   } as unknown as PluginCatalog;
 }
 
-const fakeRegistry = { has: () => false } as unknown as InstalledRegistry;
+const fakeRegistry = {
+  has: () => false,
+  get: () => undefined,
+} as unknown as InstalledRegistry;
 
 // --- C3: store merge -------------------------------------------------------
 
@@ -135,14 +138,16 @@ describe('store router · remote registry merge (C3)', () => {
                 authors: [],
                 license: 'MIT',
                 icon_url: null,
-                latest_version: '2.0.0',
+                // same version as the local @x/dup → collision tags source but
+                // does NOT trigger C6 update-detection (that has its own tests)
+                latest_version: '1.0.0',
                 versions: [
                   {
-                    version: '2.0.0',
+                    version: '1.0.0',
                     compat_core: '>=1.0 <2.0',
                     sha256: ZIP_SHA,
                     size_bytes: 1,
-                    download_url: `${HUB}/registry/@x/dup/2.0.0/plugin.zip`,
+                    download_url: `${HUB}/registry/@x/dup/1.0.0/plugin.zip`,
                     published_at: '',
                     manifest_summary: {},
                   },
@@ -247,6 +252,127 @@ describe('store router · detail resolves a remote-only plugin (C3)', () => {
 
       const miss = await fetch(`${base}/${encodeURIComponent('@x/ghost')}`);
       assert.equal(miss.status, 404);
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+});
+
+// --- C6: update detection --------------------------------------------------
+
+function fakeInstalled(map: Record<string, string>): InstalledRegistry {
+  return {
+    has: (id: string) => id in map,
+    get: (id: string) =>
+      id in map ? { id, installed_version: map[id]! } : undefined,
+  } as unknown as InstalledRegistry;
+}
+
+function indexWith(id: string, latest: string): string {
+  return JSON.stringify({
+    schema_version: '1',
+    registry: { name: 'omadia-public', url: HUB },
+    generated_at: '2026-05-29T12:00:00Z',
+    plugins: [
+      {
+        id,
+        name: id,
+        kind: 'channel',
+        domain: 'x.y',
+        description: '',
+        categories: [],
+        authors: [],
+        license: 'Proprietary',
+        icon_url: null,
+        latest_version: latest,
+        versions: [
+          {
+            version: latest,
+            compat_core: '>=1.0 <2.0',
+            sha256: ZIP_SHA,
+            size_bytes: 1,
+            download_url: `${HUB}/registry/${id}/${latest}/plugin.zip`,
+            published_at: '',
+            manifest_summary: {},
+          },
+        ],
+      },
+    ],
+  });
+}
+
+const TEAMS = '@omadia/channel-teams';
+
+function storeServer(catalogPlugins: Plugin[], installed: Record<string, string>, hubLatest: string) {
+  const client = new RegistryClient({
+    registries: [{ name: 'omadia-public', url: HUB }],
+    log: () => {},
+    fetchImpl: mockFetch({
+      [`${HUB}/registry/index.json`]: () => new Response(indexWith(TEAMS, hubLatest)),
+    }),
+  });
+  const app = express();
+  app.use(
+    '/store',
+    createStoreRouter({
+      catalog: fakeCatalog(catalogPlugins),
+      registry: fakeInstalled(installed),
+      client,
+    }),
+  );
+  const server = app.listen(0);
+  const base = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}/store`;
+  return { server, base };
+}
+
+describe('store router · update detection (C6)', () => {
+  it('flags update-available + available_version when the hub is newer', async () => {
+    const { server, base } = storeServer(
+      [plugin(TEAMS, { version: '0.10.1', kind: 'channel' })],
+      { [TEAMS]: '0.10.1' },
+      '0.11.0',
+    );
+    try {
+      const body = (await (await fetch(base)).json()) as { items: Plugin[] };
+      const t = body.items.find((p) => p.id === TEAMS)!;
+      assert.equal(t.install_state, 'update-available');
+      assert.equal(t.available_version, '0.11.0');
+      assert.equal(t.source?.registry, 'omadia-public');
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
+  it('stays installed when the hub is NOT newer (numeric semver: 0.10.1 > 0.2.0)', async () => {
+    const { server, base } = storeServer(
+      [plugin(TEAMS, { version: '0.10.1', kind: 'channel' })],
+      { [TEAMS]: '0.10.1' },
+      '0.2.0',
+    );
+    try {
+      const body = (await (await fetch(base)).json()) as { items: Plugin[] };
+      const t = body.items.find((p) => p.id === TEAMS)!;
+      assert.equal(t.install_state, 'installed');
+      assert.equal(t.available_version, undefined);
+      assert.equal(t.source?.registry, 'omadia-public', 'still tagged with hub source');
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
+  it('detail endpoint flags update-available for an installed plugin', async () => {
+    const { server, base } = storeServer(
+      [plugin(TEAMS, { version: '0.10.1', kind: 'channel' })],
+      { [TEAMS]: '0.10.1' },
+      '0.11.0',
+    );
+    try {
+      const res = await fetch(`${base}/${encodeURIComponent(TEAMS)}`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as { plugin: Plugin; install_available: boolean };
+      assert.equal(body.plugin.install_state, 'update-available');
+      assert.equal(body.plugin.available_version, '0.11.0');
+      assert.equal(body.install_available, false);
     } finally {
       await new Promise<void>((r) => server.close(() => r()));
     }

--- a/web-ui/app/_components/store/InstallButton.tsx
+++ b/web-ui/app/_components/store/InstallButton.tsx
@@ -2,7 +2,15 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { ArrowRight, Check, Loader2, Lock, Shield, Trash2 } from 'lucide-react';
+import {
+  ArrowRight,
+  Check,
+  Loader2,
+  Lock,
+  RefreshCw,
+  Shield,
+  Trash2,
+} from 'lucide-react';
 
 import { cn } from '../../_lib/cn';
 import {
@@ -34,6 +42,11 @@ interface InstallButtonProps {
    *  locally: install first fetches + ingests the ZIP (POST /install/registry),
    *  then proceeds with the normal install job. */
   remote?: boolean;
+  /** C6 — the installed version (shown in the update banner as "from"). */
+  installedVersion?: string;
+  /** C6 — the newer version a registry advertises, when
+   *  `installState === 'update-available'`. */
+  availableVersion?: string;
 }
 
 type Phase =
@@ -52,6 +65,8 @@ export function InstallButton({
   enabled,
   blockingReasons,
   remote = false,
+  installedVersion,
+  availableVersion,
 }: InstallButtonProps): React.ReactElement {
   const router = useRouter();
   const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
@@ -67,8 +82,16 @@ export function InstallButton({
 
   // --- visual dispatch -----------------------------------------------------
 
-  if (installState === 'installed') {
-    return <InstalledPanel pluginId={pluginId} pluginName={pluginName} />;
+  if (installState === 'installed' || installState === 'update-available') {
+    return (
+      <InstalledPanel
+        pluginId={pluginId}
+        pluginName={pluginName}
+        {...(installState === 'update-available' && availableVersion
+          ? { update: { from: installedVersion ?? '', to: availableVersion } }
+          : {})}
+      />
+    );
   }
 
   if (!enabled) {
@@ -298,9 +321,12 @@ export function InstallButton({
 function InstalledPanel({
   pluginId,
   pluginName,
+  update,
 }: {
   pluginId: string;
   pluginName: string;
+  /** C6 — present when a registry advertises a newer version. */
+  update?: { from: string; to: string };
 }): React.ReactElement {
   const router = useRouter();
   const [state, setState] = useState<
@@ -310,6 +336,32 @@ function InstalledPanel({
     | { kind: 'error'; message: string }
   >({ kind: 'idle' });
   const [alsoDeletePackage, setAlsoDeletePackage] = useState(false);
+
+  // C6 — in-place update: re-ingest the newer version from the registry. The
+  // upload pipeline's migrate/re-activate hooks swap the active version; a
+  // refresh re-reads the (now updated) install state.
+  const [updating, setUpdating] = useState(false);
+  const [updateError, setUpdateError] = useState<string | null>(null);
+
+  async function doUpdate(): Promise<void> {
+    if (!update) return;
+    setUpdating(true);
+    setUpdateError(null);
+    try {
+      await installFromRegistry(pluginId, update.to);
+      router.refresh();
+    } catch (err) {
+      setUpdateError(
+        err instanceof ApiError
+          ? (safeMessage(err.body) ?? err.message)
+          : err instanceof Error
+            ? err.message
+            : String(err),
+      );
+    } finally {
+      setUpdating(false);
+    }
+  }
 
   const working = state.kind === 'working';
 
@@ -352,6 +404,33 @@ function InstalledPanel({
 
   return (
     <div className="space-y-3">
+      {update ? (
+        <div className="rounded-[10px] border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/5 px-4 py-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <span className="flex items-center gap-2 text-[13px] text-[color:var(--fg)]">
+              <RefreshCw className="size-4 text-[color:var(--accent)]" aria-hidden />
+              Update verfügbar
+              <span className="font-mono-num text-[color:var(--fg-muted)]">
+                {update.from ? `${update.from} → ${update.to}` : `→ ${update.to}`}
+              </span>
+            </span>
+            <button
+              type="button"
+              onClick={() => void doUpdate()}
+              disabled={updating}
+              className="inline-flex items-center gap-1.5 rounded-full bg-[color:var(--accent)] px-4 py-1.5 text-[12px] font-semibold text-[color:var(--accent-fg)] disabled:opacity-60"
+            >
+              {updating ? <Loader2 className="size-3.5 animate-spin" aria-hidden /> : null}
+              {updating ? 'Aktualisiere …' : 'Aktualisieren'}
+            </button>
+          </div>
+          {updateError ? (
+            <p className="font-mono-num mt-2 text-[11px] text-[color:var(--danger,#b03030)]">
+              {updateError}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
       <div
         className={cn(
           'flex w-full items-center gap-3 rounded-full px-6 py-3.5',

--- a/web-ui/app/_components/store/PluginCard.tsx
+++ b/web-ui/app/_components/store/PluginCard.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { ArrowUpRight, Store } from 'lucide-react';
+import { ArrowUpRight, RefreshCw, Store } from 'lucide-react';
 
 import type { Plugin } from '../../_lib/storeTypes';
 import { Chip } from './Chip';
@@ -8,28 +8,42 @@ import { StateBadge } from './StateBadge';
 
 interface PluginCardProps {
   plugin: Plugin;
-  index: number;
 }
 
-export function PluginCard({
-  plugin,
-  index,
-}: PluginCardProps): React.ReactElement {
+export function PluginCard({ plugin }: PluginCardProps): React.ReactElement {
   const isLegacy = plugin.categories.includes('legacy');
   const visibleCategories = plugin.categories
     .filter((c) => c !== 'legacy')
     .slice(0, 3);
   const visibleIntegrations = plugin.integrations_summary.slice(0, 2);
+  const hasUpdate = plugin.install_state === 'update-available';
 
   return (
     <Link
       href={`/store/${encodeURIComponent(plugin.id)}`}
       className="group relative flex flex-col rounded-[14px] bg-[color:var(--bg-elevated)] p-6 shadow-[0_2px_6px_rgba(0,75,115,0.08)] transition-[transform,box-shadow] duration-[var(--dur-base)] ease-[var(--ease-out)] hover:-translate-y-0.5 hover:shadow-[0_8px_24px_rgba(0,75,115,0.10)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent)]"
     >
-      {/* Card index — subtle tick */}
-      <span className="font-mono-num absolute right-4 top-4 text-[10px] text-[color:var(--fg-subtle)]">
-        № {formatIndex(index)}
-      </span>
+      {/* Update "Störer" — prominent top-right sticker. Only on plugins where a
+          configured registry advertises a newer version than the installed one
+          (C6). Overhangs the corner slightly for attention. */}
+      {hasUpdate ? (
+        <span
+          className="absolute -right-2 -top-2 z-10 inline-flex items-center gap-1 rounded-full bg-[color:var(--accent)] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.12em] text-[color:var(--accent-fg)] shadow-[0_4px_12px_rgba(0,75,115,0.35)] ring-2 ring-[color:var(--bg-elevated)]"
+          title={
+            plugin.available_version
+              ? `Update verfügbar: ${plugin.version} → ${plugin.available_version}`
+              : 'Update verfügbar'
+          }
+        >
+          <RefreshCw className="size-3" aria-hidden />
+          Update
+          {plugin.available_version ? (
+            <span className="font-mono-num font-semibold normal-case tracking-normal opacity-90">
+              {plugin.available_version}
+            </span>
+          ) : null}
+        </span>
+      ) : null}
 
       <div className="flex items-start gap-4">
         <PluginIcon
@@ -54,9 +68,13 @@ export function PluginCard({
         {plugin.description || <em>Keine Beschreibung hinterlegt.</em>}
       </p>
 
-      {/* Metadata row */}
+      {/* Metadata row. An update-available plugin IS installed — show that
+          inline; the update itself is the top-right Störer. */}
       <div className="mt-5 flex flex-wrap items-center gap-1.5">
-        <StateBadge state={plugin.install_state} isLegacy={isLegacy} />
+        <StateBadge
+          state={hasUpdate ? 'installed' : plugin.install_state}
+          isLegacy={isLegacy}
+        />
         {/* Origin marker — present only on remote-registry (Hub) entries that
             are not yet ingested locally. Lets the Hub view distinguish a
             hub-sourced plugin from a local catalog package at a glance. */}
@@ -100,8 +118,4 @@ export function PluginCard({
       />
     </Link>
   );
-}
-
-function formatIndex(n: number): string {
-  return String(n).padStart(2, '0');
 }

--- a/web-ui/app/_lib/storeTypes.ts
+++ b/web-ui/app/_lib/storeTypes.ts
@@ -145,6 +145,9 @@ export interface Plugin {
     download_url: string;
     sha256: string;
   };
+  /** C6 — newer version a registry advertises when `install_state ===
+   *  'update-available'`. `version` still reflects what is installed. */
+  available_version?: string;
 }
 
 export interface StoreListResponse {

--- a/web-ui/app/store/[id]/page.tsx
+++ b/web-ui/app/store/[id]/page.tsx
@@ -266,6 +266,10 @@ export default async function PluginDetailPage({
             installState={plugin.install_state}
             enabled={install_available}
             remote={Boolean(plugin.source)}
+            installedVersion={plugin.version}
+            {...(plugin.available_version
+              ? { availableVersion: plugin.available_version }
+              : {})}
             {...(blocking_reasons ? { blockingReasons: blocking_reasons } : {})}
           />
 

--- a/web-ui/app/store/page.tsx
+++ b/web-ui/app/store/page.tsx
@@ -196,12 +196,8 @@ export default async function StorePage({
           <EmptyState source={source} filter={filter} />
         ) : (
           <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-            {visible.map((plugin, idx) => (
-              <PluginCard
-                key={plugin.id}
-                plugin={plugin}
-                index={idx + 1}
-              />
+            {visible.map((plugin) => (
+              <PluginCard key={plugin.id} plugin={plugin} />
             ))}
           </div>
         )}


### PR DESCRIPTION
Follow-up to the plugin store MVP (#162). Two changes, branched clean off main.

## C6 — update detection
The store flags an installed plugin as `update-available` when a configured registry advertises a newer version than the installed one.

- Backend (`store.ts`): list merge + detail endpoint compare hub `latest_version` (numeric semver — `0.10.1 > 0.2.0`, no dep added) vs `installedRegistry.installed_version`. Newer → `install_state: 'update-available'` + `available_version`; else stays `installed` (still tagged with hub `source`). Degrades gracefully on registry errors.
- UI: `InstallButton` shows an update banner (`from → to`) + "Aktualisieren" button (re-ingest via `installFromRegistry`; the upload pipeline's migrate/re-activate hooks swap the active version).
- Tests: newer→update, not-newer stays installed (numeric semver edge), detail endpoint.

## Store-card UX
- Update flag is now a prominent top-right **Störer** (accent corner badge `↻ Update` + target version) instead of an inline pill; inline `StateBadge` shows `Installiert`.
- Removed the per-card `№` index numbering (+ unused `index` prop).

44/44 registry tests green, tsc + lint clean (both repos). Already deployed to Fly (`odoo-bot-middleware` v248, `odoo-bot-harness` v81) and verified live.