### PR TITLE
chore: ignore channel-whatsapp + office 0.1.1 bump + plugin HowTo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,14 @@ marketing-site/
 # hosted service is private.
 hub/
 
+# ─── WhatsApp channel plugin (separate PUBLIC repo) ───────────────────────
+# @omadia/channel-whatsapp — a standalone WhatsApp Web channel (Baileys +
+# QR-linked-device). Unlike hub/ and marketing-site/ this one is a PUBLIC
+# OSS repo (byte5ai/omadia-channel-whatsapp), but it is still developed in
+# its own git repo and shipped as a Hub ZIP, so it is mirrored here as a
+# gitignored folder exactly like the others — never committed into core.
+channel-whatsapp/
+
 # ─── byte5-specific agent + deployment configs (private) ──────────────────
 # These describe a specific byte5 deployment (Fly app, Neon project, kroki
 # sidecars, customer-specific agent configs) and must never land in public

--- a/docs/creating-plugins.md
+++ b/docs/creating-plugins.md
@@ -3,43 +3,67 @@
 Diese Anleitung führt von „leeres Verzeichnis" bis „installierbar aus dem Hub".
 Ein Plugin ist ein **standalone Package**, das als `.zip` hochgeladen wird — der
 Server validiert das Manifest, prüft Peer-Dependencies und registriert es im
-Katalog. Es gibt drei `kind`s:
+Katalog. Es gibt drei `kind`s, und sie unterscheiden sich **nicht nur im
+Manifest, sondern auch im Code-Contract**:
 
-| kind | Was es ist | Beispiel |
-|---|---|---|
-| `agent` | Capability-Anbieter mit Toolkit (Zod-Tools) + System-Prompt | `agent-seo-analyst` |
-| `integration` | reiner Credential-/HTTP-Client, kein Toolkit | `de.byte5.integration.odoo` |
-| `channel` | User-Surface (Teams, Telegram, …) mit Transport + Adaptern | `harness-channel-teams` |
+| kind | Was es ist | `activate()` gibt zurück | Beispiel |
+|---|---|---|---|
+| `agent` | Capability-Anbieter mit Toolkit (Zod-Tools) + System-Prompt | `{ toolkit, close }` | `agent-seo-analyst` |
+| `integration` | reiner Credential-/HTTP-Client, kein Toolkit | (kein Toolkit; nur Secrets/Config-Container) | `de.byte5.integration.odoo` |
+| `channel` | User-Surface (WhatsApp, Teams, Telegram, …) mit Transport + Adaptern | **`ChannelHandle` über `activate(ctx, core)`** | `@omadia/channel-whatsapp` |
 
 > **Quellen der Wahrheit (nicht halluzinieren):**
-> Referenz-Agent `middleware/packages/agent-seo-analyst/`,
-> Boilerplate `middleware/assets/boilerplate/{agent-pure-llm,agent-integration}/`,
-> Package-Contract `middleware/assets/boilerplate/agent-pure-llm/CLAUDE.md`
-> (die 10 Checkliste-Punkte), Runtime-Contract
-> `middleware/src/platform/pluginContext.ts`.
+> - Agent: Referenz `middleware/packages/agent-seo-analyst/`, Boilerplate
+>   `middleware/assets/boilerplate/{agent-pure-llm,agent-integration}/`,
+>   Package-Contract (10 Punkte) `…/agent-pure-llm/CLAUDE.md`.
+> - Channel: SDK-Contract `middleware/packages/harness-channel-sdk/src/`,
+>   öffentliches Referenz-Plugin **`byte5ai/omadia-channel-whatsapp`**
+>   (Teams/Telegram-Quelle liegt privat). Resolver
+>   `middleware/src/channels/dynamicChannelResolver.ts`.
+> - Runtime-Contract `middleware/packages/plugin-api/src/pluginContext.ts`
+>   (das Package `@omadia/plugin-api`).
+> - Manifest-Schema `docs/harness-platform/manifest-schema.v1.yaml`
+>   (`channel:`-Block = Section 14).
 
 ---
 
 ## 0. Voraussetzungen
 
-- Node `>=20` (das Repo pinnt `22.x` in `.nvmrc` → `nvm use`).
-- Zugang zur Admin-UI (`https://odoo-bot-harness.fly.dev`) für den Upload.
-- Zum **Publishen** auf den Hub: das `HUB_PUBLISH_TOKEN` (Bearer-Token, liegt
-  im Vercel-Env des Hub-Projekts — write-only, nicht im Chat leaken).
+- Node `>=20` (das Repo pinnt die genaue Version in `.nvmrc` → `nvm use`).
+- Zugang zur Admin-UI (`https://odoo-bot-harness.fly.dev`) für den lokalen Upload.
+- Zum **Publishen** auf den Hub: das `HUB_PUBLISH_TOKEN` (Bearer-Token; liegt im
+  Vercel-Env des Hub-Projekts bzw. lokal in `hub/.env.local` — **write-only,
+  nie im Chat/Log leaken**).
+- Wenn dein Plugin eine **Nicht-Host-Dependency** braucht (z.B. ein Channel,
+  der `@whiskeysockets/baileys` nutzt): zusätzlich `esbuild` als devDependency
+  zum Bundlen (siehe §5).
 
 ---
 
-## 1. Scaffold aus der Boilerplate
+## 1. Welchen `kind` baust du?
 
-Wähle das Template nach Bedarf: `agent-pure-llm` (kein externes API, reines
-Prompting) oder `agent-integration` (echter HTTP-Client + Secrets).
+Bei vagem „Plugin" zuerst klären — die drei kinds teilen Manifest-Schema +
+Zip-Flow, aber der Code-Contract ist verschieden:
+
+- **`agent`** — liefert Tools (Zod-Toolkit) + einen System-Prompt-Partial. Die
+  Runtime macht SubAgent-Wrap, Tool-Bridge und Prompt-Concat. → §2–§4a.
+- **`integration`** — nur Secrets/Config-Container, von dem `agent`s via
+  `depends_on` erben. Kein Toolkit.
+- **`channel`** — User-Surface. Empfängt native Events, übersetzt sie in den
+  `IncomingTurn`-Shape, ruft `core.handleTurnStream(turn)` und rendert die
+  Antwort zurück. **Keine** `capabilities`/`playbook`/`skills`. → §4b.
+
+---
+
+## 2. Scaffold aus der Boilerplate (agent)
+
+Wähle `agent-pure-llm` (kein externes API, reines Prompting) oder
+`agent-integration` (echter HTTP-Client + Secrets):
 
 ```bash
 cp -R middleware/assets/boilerplate/agent-pure-llm \
       middleware/packages/agent-<slug>
 cd middleware/packages/agent-<slug>
-
-# Skill-Datei umbenennen
 mv skills/{{AGENT_SLUG}}-expert.md skills/<slug>-expert.md
 ```
 
@@ -60,9 +84,13 @@ agent-<slug>/
 └── scripts/build-zip.mjs # tsc + stage + zip → out/<id>-<version>.zip
 ```
 
+> Ein **Channel** wird i.d.R. NICHT aus der Agent-Boilerplate gescaffoldet —
+> es gibt (noch) keine Channel-Boilerplate. Nimm `byte5ai/omadia-channel-whatsapp`
+> als Vorlage; das Layout steht in §4b.
+
 ---
 
-## 2. Manifest ausfüllen (`manifest.yaml`)
+## 3. Manifest ausfüllen (`manifest.yaml`)
 
 Ersetze alle `{{PLATZHALTER}}`. Die **`identity`**-Felder + `compat.core` sind
 das, was Hub und Katalog für die Listing-Kachel lesen — der Rest wird beim
@@ -72,17 +100,18 @@ Install voll validiert.
 schema_version: "1"
 
 identity:
-  id: "de.byte5.agent.<slug>"      # lowercase, dotted; === package.json "name"
+  id: "de.byte5.agent.<slug>"      # === package.json "name". byte5-privat: reverse-DNS;
+                                   # public OSS: "@omadia/<slug>" (wie @omadia/plugin-office)
   kind: "agent"                    # agent | integration | channel
-  domain: "<domain>"               # z.B. coaching, m365.sharepoint
+  domain: "<domain>"               # z.B. coaching, m365.sharepoint, whatsapp — lowercase, dotted
   name: "<Anzeigename>"
   version: "0.1.0"                 # SemVer; === package.json "version"
   description: "<Beschreibung DE>"
   authors:
     - name: "byte5 GmbH"
       email: "info@omadia.ai"
-  license: "Proprietary"           # oder MIT, …
-  icon: "./assets/icon.png"
+  license: "Proprietary"           # oder MIT (public OSS)
+  icon: "./assets/icon.png"        # PNG oder SVG
   categories: ["<kategorie>"]
 
 compat:
@@ -97,7 +126,7 @@ setup:
   fields: []                       # Setup-Felder → rendern automatisch im Install-Drawer
   self_test: false
 
-capabilities: []                   # Tools liefert das toolkit; [] = pure-LLM
+capabilities: []                   # Tools liefert das toolkit; [] = pure-LLM (NICHT für channel)
 
 skills:
   - id: "<slug>_expert_system"
@@ -115,12 +144,16 @@ permissions:
 
 **Regeln, die sonst erst zur Install-/Ingest-Zeit knallen:**
 - `package.json` `name`/`version` müssen **exakt** `identity.id`/`identity.version` spiegeln.
-- Deps via `peerDependencies` (nicht `dependencies`) — Ingest warnt sonst via `peers_missing`.
-- `setup.fields` nur deklarieren, wenn der Parent (`depends_on`) sie **nicht** schon hat (sonst silent override).
+- **Shared/Host-Deps via `peerDependencies`** (nicht `dependencies`) — Ingest warnt sonst
+  via `peers_missing`. Eigene, nicht-Host-Deps werden gebundelt (siehe **§5**).
+- `setup.fields` nur deklarieren, wenn der Parent (`depends_on`) sie **nicht** schon
+  hat (sonst silent override).
+- `setup.fields[].type`: `string | url | secret | oauth | enum | boolean | integer | host_list`.
+  `enum` braucht `enum: [{value,label}]`, `oauth` braucht `provider` + `scopes`.
 
 ---
 
-## 3. Implementieren
+## 4a. Implementieren — Agent
 
 - **`activate(ctx)`** gibt fix zurück:
   `{ toolkit: { tools: ToolDescriptor[]; close() }, close() }`.
@@ -133,9 +166,9 @@ permissions:
 - System-Prompt gehört in `skills/<slug>-expert.md` (Markdown + YAML-Frontmatter),
   **nicht** in den Code.
 
-Details + Zod-Support-Matrix + Lifecycle-Budgets: die 10 Punkte in
-`middleware/assets/boilerplate/agent-pure-llm/CLAUDE.md`. Kanonische Vorlage:
-`middleware/packages/agent-seo-analyst/`.
+Details + Zod-Support-Matrix + Lifecycle-Budgets (`activate` ≤10s, `close` ≤5s):
+die 10 Punkte in `middleware/assets/boilerplate/agent-pure-llm/CLAUDE.md`.
+Kanonische Vorlage: `middleware/packages/agent-seo-analyst/`.
 
 ```bash
 npm install
@@ -144,78 +177,222 @@ npm run lint:fix && npm run typecheck   # nicht bauen — nur prüfen
 
 ---
 
-## 4. ZIP bauen
+## 4b. Implementieren — Channel
 
-```bash
-node scripts/build-zip.mjs
-# ▶ tsc … ✓ built out/de.byte5.agent.<slug>-0.1.0.zip
+Ein Channel ist ein **Plattform-Adapter**: er hält Transport (WebSocket /
+Webhook / Long-Poll) offen, übersetzt native Events in `IncomingTurn`, fährt den
+Orchestrator-Turn und rendert die Antwort zurück. Quelle: `@omadia/channel-sdk`
+(`middleware/packages/harness-channel-sdk/src/`). Öffentliche Referenz:
+**`byte5ai/omadia-channel-whatsapp`**.
+
+**Export-Contract (≠ agent!).** Der Kernel-Resolver
+(`middleware/src/channels/dynamicChannelResolver.ts` → `pickChannelPlugin`)
+importiert `dist/plugin.js` und akzeptiert drei Export-Shapes, in dieser
+Priorität:
+
+1. **`export async function activate(ctx, core)`** — bare function. ← **bevorzugt**
+2. `export default { activate(ctx, core) {…} }` — Default-Objekt mit Methode.
+3. `export default <ChannelPlugin-Instanz>`.
+
+Es gibt **keinen** Konstruktor mit Deps — alles kommt über `ctx` (PluginContext)
+und `core` (CoreApi):
+
+```ts
+import type { CoreApi, ChannelHandle, IncomingTurn } from '@omadia/channel-sdk';
+import { isNoReply, logNoReplyDrop } from '@omadia/channel-sdk';
+import type { PluginContext } from '@omadia/plugin-api';
+
+export async function activate(ctx: PluginContext, core: CoreApi): Promise<ChannelHandle> {
+  // 1. Transport öffnen (NICHT awaiten bis "verbunden" — activate-Budget = 10s).
+  // 2. Auf inbound Events: IncomingTurn bauen → core.handleTurnStream(turn)
+  //    → Stream zu `done` folden → rendern → zurücksenden.
+  // 3. Optionale Admin-/Status-UI via ctx.routes.register (siehe unten).
+  return { async close() { /* Sockets/Timer freigeben (≤5s) */ } };
+}
 ```
 
-Das Script: `tsc` → `dist/`, kopiert Runtime-Artefakte (`manifest.yaml`,
-`package.json`, `README.md`, `dist/`, `skills/`, `assets/`) nach
-`out/<id>-<version>-package/`, verifiziert dass der `dist/`-Entry existiert,
-und zippt nach `out/<id>-<version>.zip`. **Im ZIP sind nur Runtime-Artefakte**
-— keine `*.ts`-Quellen außerhalb `dist/`, kein `node_modules`, kein `.env`.
+**`core` (CoreApi)** — was der Channel auf dem Kernel aufruft:
+- `handleTurnStream(turn): AsyncIterable<ChatStreamEvent>` — Turn fahren; das
+  `done`-Event trägt `answer` + Sidecars (`pendingUserChoice`, `followUpOptions`,
+  `attachments`, …). `toSemanticAnswer()`/`isNoReply()` helfen beim Rendern.
+- `registerRoute` / `registerRouter` — channel-scoped Express-Routen
+  (auto-503 bei deactivate).
+- `resolveIdentity(ref)`, `log(level, msg, ctx?)`.
+
+**Inbound → Turn.** `IncomingTurn = { channelId, conversationId, userRef:{ kind,
+id, displayName? }, text, attachments?, metadata?, rawEvent? }`. `userRef.kind`
+ist ein geschlossener Union — WhatsApp = `'whatsapp-phone'`, Telegram =
+`'telegram-chat'`, Teams = `'teams-aad'`, Slack/Discord/`custom`.
+
+**Manifest-Besonderheiten (channel).** Keine `capabilities`/`playbook`/`skills`.
+Dafür der `channel:`-Block (Schema Section 14):
+
+```yaml
+identity:
+  kind: "channel"
+lifecycle:
+  entry: "dist/plugin.js"          # exportiert activate(ctx, core)
+admin_ui_path: "/api/<slug>/admin/index.html"   # Top-Level → web-ui rendert iframe
+channel:
+  transport:
+    kind: "websocket"              # webhook | websocket | long-poll
+    routes: []                     # nur für kind=webhook nötig
+  capabilities: ["text", "typing_indicator"]   # text|attachments|interactive_cards|user_sso|…
+  adapters: ["text", "markdown"]   # text|markdown|adaptive_card|telegram_keyboard|…
+```
+
+**Admin-UI / Auth-Surface (z.B. QR-Code).** Das generische Pattern: einen
+Express-Router mit `ctx.routes.register('/api/<slug>/admin', router)` mounten
+(static `index.html` + JSON-API), und im Manifest `admin_ui_path` auf
+`…/index.html` zeigen. web-ui rendert dann automatisch ein
+`<iframe src="/bot-api{admin_ui_path}">` auf der Store-Detail-Page — **ohne
+web-ui-Änderung**. Harte Regeln (siehe
+`middleware/assets/boilerplate/agent-integration/assets/admin-ui/CLAUDE.md`):
+- `fetch()` im UI **relativ** (`api/status`, nicht `/api/...`) — sonst 404 hinter
+  dem `/bot-api`-Rewrite.
+- Jede Antwort `{ ok: true, … }` / `{ ok: false, error }`; das Frontend prüft `data.ok`.
+- Stylesheet `/bot-api/_harness/admin-ui.css`, nur `var(--*)`-Tokens, keine externen Scripts/Fonts, kein `position: fixed`.
+
+`omadia-channel-whatsapp` nutzt genau das, um den WhatsApp-Pairing-QR (als
+data-URL-`<img>`) anzuzeigen; State (Status + QR) wird im RAM gehalten und über
+`api/status` gepollt. Auth-State persistiert es über `ctx.memory` (überlebt
+Restart) — daher `permissions.memory.{reads,writes}` deklarieren.
 
 ---
 
-## 5. Lokal installieren (Smoke-Test vor dem Publish)
+## 5. Dependencies & Bundling — die wichtigste Falle
+
+**Der Host installiert KEINE Plugin-Dependencies.** Ein hochgeladenes Package
+wird unter `<packagesDir>/<id>/<version>/` entpackt (kein `npm install`,
+`middleware/src/plugins/packageUploadService.ts`) und zur Laufzeit per
+dynamischem `import()` **in-process** geladen. Bare Specifier (`import x from
+'foo'`) werden gegen das **Host-`node_modules`** aufgelöst — ein Symlink
+`<packagesDir>/node_modules → <host>/node_modules`
+(`uploadedPackageStore.ensureHostNodeModulesLink`) bridged das.
+
+Folge — **zwei disjunkte Klassen von Deps:**
+
+| Klasse | Wohin in `package.json` | Beim Build |
+|---|---|---|
+| **Host-bereitgestellt** (`@omadia/*`, `express`, `zod`, …) | `peerDependencies` | `external` lassen (NICHT bundeln) |
+| **Eigene, nicht-Host** (`@whiskeysockets/baileys`, `qrcode`, …) | `dependencies` | **in `dist/` bundeln** |
+
+Ein Plugin, das eine Dep importiert, die der Host **nicht** schon hat, crasht
+zur Laufzeit mit `Cannot find package 'X'` — **`tsc` allein reicht dann nicht**,
+weil `tsc` nur transpiliert, nicht bündelt. Lösung: ein `esbuild`-Bundle-Step im
+Build (siehe `omadia-channel-whatsapp/scripts/build-zip.mjs`):
+
+```js
+import { build } from 'esbuild';
+await build({
+  entryPoints: ['src/plugin.ts'],
+  outfile: 'dist/plugin.js',
+  bundle: true, platform: 'node', format: 'esm', target: 'node20',
+  // Host-Peers NICHT inlinen; alles andere (Baileys, qrcode, …) wird gebundelt:
+  external: ['@omadia/channel-sdk', '@omadia/plugin-api', 'express'],
+  // ESM-Banner, damit gebundelter CJS-Code require/__dirname hat:
+  banner: { js: "import{createRequire}from'node:module';const require=createRequire(import.meta.url);" },
+});
+```
+
+Hinweise:
+- **Type-only Imports** (`import type { … }`) verschwinden im Bundle von selbst —
+  `@omadia/plugin-api` taucht z.B. gar nicht als Runtime-Import auf, wenn nur Typen
+  daraus genutzt werden.
+- `typecheck` läuft separat (`tsc --noEmit`). Für ein standalone-Repo, das nicht
+  neben dem Core-Checkout liegt, die `@omadia/*`-Typen via `tsconfig.paths` auf die
+  gebauten `.d.ts` mappen (siehe channel-whatsapp `tsconfig.json`).
+- Peer-`@omadia/*` sind nicht auf npm → `npm install` mit
+  `legacy-peer-deps=true` (`.npmrc`), sonst 404 beim Peer-Auto-Install.
+
+---
+
+## 6. ZIP bauen
+
+```bash
+node scripts/build-zip.mjs
+# agent (tsc):     ▶ tsc … ✓ built out/de.byte5.agent.<slug>-0.1.0.zip
+# channel (esbuild): ▶ esbuild bundle … ✓ built out/omadia-channel-whatsapp-0.1.0.zip
+```
+
+Das Script: kompiliert/bundelt nach `dist/`, kopiert Runtime-Artefakte
+(`manifest.yaml`, `package.json`, `README.md`, `dist/`, `skills/`, `assets/`,
+`LICENSE`) nach `out/<id>-<version>-package/`, verifiziert dass der `dist/`-Entry
+existiert, und zippt nach `out/<id>-<version>.zip`. **Im ZIP sind nur
+Runtime-Artefakte** — keine `*.ts`-Quellen außerhalb `dist/`, kein
+`node_modules`, kein `.env`. Der `safeName` strippt `@` und ersetzt `/` durch `-`
+(`@omadia/channel-whatsapp` → `omadia-channel-whatsapp`).
+
+Extension-Allowlist im Host-Extractor: `.yaml .md .json .js .mjs .cjs .map .png
+.svg .jpg .txt` + `LICENSE / README / NOTICE`. Ein gebundeltes `dist/plugin.js`
+(auch mehrere MB) ist nur eine `.js`-Datei — passt.
+
+---
+
+## 7. Lokal installieren (Smoke-Test vor dem Publish)
 
 In der Admin-UI: **Store → Tab „Lokal" → Upload-Dropzone** → `out/<id>-<version>.zip`
 hineinziehen. Der Server validiert das Manifest und registriert das Package im
 Katalog; es erscheint als **Verfügbar** im Lokal-Tab. Ein Klick auf die Kachel →
 Detailseite → **Jetzt installieren** (Setup-Felder rendern automatisch aus
-`setup.fields`).
+`setup.fields`; bei Channels öffnet sich nach Install die Admin-UI/QR-Sektion).
 
 Äquivalent per Admin-API (alle JWT-gated):
 `POST /api/v1/install/plugins/:id` → `POST /api/v1/install/jobs/:id/configure`.
 
 ---
 
-## 6. Auf den Hub veröffentlichen
+## 8. Auf den Hub veröffentlichen (Deployment)
 
 Der Hub (`hub.omadia.ai`) ist eine **dumme Registry**: ein Publish schreibt nur
-Artefakt + `index.json` um, **kein Redeploy**. Der nächste Index-Read enthält
-das Plugin. Versionen sind **immutable**.
+Artefakt + `index.json` um, **kein Redeploy**. Der nächste Index-Read enthält das
+Plugin. Versionen sind **immutable**. Contract: `hub/app/api/publish/route.ts`
+(Service-Seite) ↔ `middleware/src/plugins/registryClient.ts` (Core-Konsum).
+
+**Schritt für Schritt:**
 
 ```bash
-HUB=https://hub.omadia.ai
-ZIP=out/de.byte5.agent.<slug>-0.1.0.zip
+# 1. Token bereitstellen — NICHT echoen. Aus dem Hub-Env lesen:
+export HUB_PUBLISH_TOKEN="$(grep -E '^HUB_PUBLISH_TOKEN=' hub/.env.local | cut -d= -f2-)"
+export HUB=https://hub.omadia.ai
+export ZIP=out/omadia-channel-whatsapp-0.1.0.zip
 
+# 2. Publish (multipart):
 curl -sS -X POST "$HUB/api/publish" \
   -H "Authorization: Bearer $HUB_PUBLISH_TOKEN" \
   -F "file=@${ZIP}"
-# → 201 { "ok": true, "id": "...", "version": { ... } }
-```
+# → 201 { "ok": true, "id": "@omadia/channel-whatsapp", "kind": "channel",
+#         "storage": "blob", "version": { "version": "0.1.0", "sha256": "…", … } }
 
-- Auth: `Authorization: Bearer <HUB_PUBLISH_TOKEN>` (timing-safe geprüft).
-- Body: multipart `file=<zip>` **oder** roher `Content-Type: application/zip`.
-- Max 50 MiB (= Core's Artefakt-Cap).
-- Re-publish derselben `(id, version)` → **409 `publish.version_exists`**.
-  Zum Überschreiben (nur dev): `?overwrite=true` anhängen. Sonst:
-  Version in `manifest.yaml` + `package.json` bumpen, neu bauen, neu publishen.
-- Der Hub extrahiert `manifest.yaml` + `package.json`, validiert leicht (`schema_version: "1"`,
-  `identity.*`, gültiger `kind`), rechnet sha256 über die **exakten** Upload-Bytes
-  und legt den Index-Eintrag an.
-
-Index + Artefakt prüfen:
-
-```bash
+# 3. Verifizieren, dass der Index das Plugin trägt:
 curl -sS "$HUB/registry/index.json" | jq '.plugins[].id'
-# → "de.byte5.agent.<slug>"
-# Artefakt-URL (host-gepinnt, wird beim Read auf HUB_PUBLIC_URL umgeschrieben):
-#   $HUB/registry/<id>/<version>/plugin.zip
 ```
+
+- **Auth:** `Authorization: Bearer <HUB_PUBLISH_TOKEN>` (timing-safe geprüft).
+  Fehlt/falsch → **401 `publish.unauthorized`**; Hub ohne Token konfiguriert →
+  **503 `publish.disabled`**.
+- **Body:** multipart `file=<zip>` **oder** roher `Content-Type: application/zip`.
+- **Max 50 MiB** (= Core's Artefakt-Cap) → sonst **413 `publish.too_large`**.
+- **Immutable:** Re-publish derselben `(id, version)` → **409
+  `publish.version_exists`**. Zum Überschreiben (nur dev): `?overwrite=true`.
+  Sonst: Version in `manifest.yaml` **+** `package.json` bumpen, neu bauen, neu
+  publishen.
+- Der Hub extrahiert `manifest.yaml` + `package.json`, validiert leicht
+  (`schema_version: "1"`, `identity.*`, gültiger `kind`), rechnet sha256 über die
+  **exakten** Upload-Bytes und legt/aktualisiert den Index-Eintrag.
+
+Artefakt-URL (host-gepinnt, wird beim Read auf `HUB_PUBLIC_URL` umgeschrieben):
+`$HUB/registry/<id>/<version>/plugin.zip`.
 
 ---
 
-## 7. Im Hub-Tab erscheinen lassen
+## 9. Im Hub-Tab erscheinen lassen
 
 In der Admin-UI ist die Default-Registry `hub.omadia.ai` bereits geseedet
 (verwalten unter **Admin → Registries**). **Store → Tab „Hub"** zieht
 `index.json` und zeigt dein Plugin als **Verfügbar** mit dem Badge
-`Hub · <registry>`. „Jetzt installieren" lädt das ZIP, prüft sha256, ingestet
-es lokal und startet dann den normalen Install-Job.
+`Hub · <registry>`. „Jetzt installieren" lädt das ZIP, prüft sha256, ingestet es
+lokal und startet dann den normalen Install-Job.
 
 **Zwei harte Constraints** (aus dem Core-Client — sonst schlägt der Install fehl):
 1. Die ZIP-Route **streamt** das Artefakt (kein 302-Redirect) — der Client
@@ -225,22 +402,33 @@ es lokal und startet dann den normalen Install-Job.
 
 ---
 
-## 8. Troubleshooting
+## 10. Troubleshooting
 
 | Symptom | Ursache / Fix |
 |---|---|
-| Plugin taucht nicht im **Hub**-Tab auf, obwohl publiziert | Eine **lokale** Kopie gleicher `id` ist installiert → der Merge bevorzugt lokal (local-wins) und droppt den Remote-Eintrag. Built-in-Plugins (z.B. `@omadia/plugin-office`) sind deshalb nie im Hub-Tab sichtbar — zum Test ein **Nicht-Built-in** publishen. |
-| `409 publish.version_exists` | Version existiert schon (immutable). Version bumpen oder `?overwrite=true` (dev). |
-| `401 publish.unauthorized` | `HUB_PUBLISH_TOKEN` falsch/fehlt. |
-| Ingest warnt `peers_missing` | Deps stehen unter `dependencies` statt `peerDependencies`. |
+| Channel aktiviert nicht / `activate is not a function` | Falscher Export-Shape. `dist/plugin.js` muss `export async function activate(ctx, core)` (oder `export default {activate}`) liefern — siehe §4b. |
+| Plugin crasht zur Laufzeit mit `Cannot find package 'X'` | `X` ist nicht im Host-`node_modules` und wurde nicht gebundelt. Entweder `X` in `dist/` bundeln (esbuild, §5) oder — wenn host-bereitgestellt — als `peerDependencies` deklarieren. |
+| Ingest warnt `peers_missing` | Eine deklarierte Peer-Dep fehlt im Host. Host-Dep ergänzen, oder (für eigene Deps) auf `dependencies` + Bundle umstellen. |
+| `npm install` schlägt mit 404 auf `@omadia/*` fehl | Peers sind privat/nicht-npm. `.npmrc` mit `legacy-peer-deps=true`; `@omadia/*`-Typen via `tsconfig.paths` resolven. |
+| Plugin taucht nicht im **Hub**-Tab auf, obwohl publiziert | Eine **lokale** Kopie gleicher `id` ist installiert → Merge bevorzugt lokal (local-wins). Built-ins (z.B. `@omadia/plugin-office`) sind deshalb nie im Hub-Tab — zum Test ein Nicht-Built-in publishen. |
+| `409 publish.version_exists` | Version existiert (immutable). Version bumpen oder `?overwrite=true` (dev). |
+| `401 publish.unauthorized` / `503 publish.disabled` | `HUB_PUBLISH_TOKEN` falsch/fehlt bzw. im Hub-Env nicht gesetzt. |
+| Admin-UI/QR lädt nicht im Store-iframe | `fetch()` war absolut statt relativ, oder Response ohne `{ ok }`, oder `admin_ui_path` zeigt nicht auf `…/index.html`. Siehe §4b + admin-ui CLAUDE.md. |
 | Install scheitert mit `install.missing_capability` | `requires:` im Manifest hat keinen aktiven Provider → der Install-Wizard zeigt die zu installierende Chain. |
 
 ---
 
 ## Referenzen
 
-- Package-Contract (10 Punkte): `middleware/assets/boilerplate/agent-pure-llm/CLAUDE.md`
+- Package-Contract Agent (10 Punkte): `middleware/assets/boilerplate/agent-pure-llm/CLAUDE.md`
+- Admin-UI-Constraints: `middleware/assets/boilerplate/agent-integration/assets/admin-ui/CLAUDE.md`
 - Kanonischer Agent: `middleware/packages/agent-seo-analyst/`
-- Runtime-Contract: `middleware/src/platform/pluginContext.ts`
+- Channel-SDK: `middleware/packages/harness-channel-sdk/src/` (`@omadia/channel-sdk`)
+- Öffentliches Channel-Referenz-Plugin: `byte5ai/omadia-channel-whatsapp`
+- Runtime-Contract: `middleware/packages/plugin-api/src/pluginContext.ts` (`@omadia/plugin-api`)
+- Manifest-Schema (inkl. `channel:`-Block §14): `docs/harness-platform/manifest-schema.v1.yaml`
+- Channel-Resolver (Export-Shapes): `middleware/src/channels/dynamicChannelResolver.ts`
+- Dep-Resolution / Symlink-Bridge: `middleware/src/plugins/{packageUploadService,uploadedPackageStore}.ts`
 - Store-/Install-Routen: `middleware/src/routes/{store,install,registryInstall}.ts`
 - Registry-Client (Hub-Konsum): `middleware/src/plugins/registryClient.ts`
+- Hub-Publish-Route (Service): `hub/app/api/publish/route.ts`

--- a/middleware/packages/harness-plugin-office/manifest.yaml
+++ b/middleware/packages/harness-plugin-office/manifest.yaml
@@ -3,7 +3,7 @@ schema_version: "1"
 identity:
   id: "@omadia/plugin-office"
   name: "Headless Office"
-  version: "0.1.0"
+  version: "0.1.1"
   kind: "tool"
   domain: "productivity.office"
   description: "Erzeugt .xlsx/.docx-Dokumente deterministisch aus JSON-Descriptoren, legt sie in Tigris ab und liefert signierte /documents-URLs, die Channels als Datei-Anhang rendern."

--- a/middleware/packages/harness-plugin-office/package.json
+++ b/middleware/packages/harness-plugin-office/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omadia/plugin-office",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Loose ends recovered from a stash after the registry merges (#162/#163).

- `chore(plugin-office)`: bump `@omadia/plugin-office` 0.1.0 → 0.1.1 (manifest + package.json).
- `chore`: add `channel-whatsapp/` to `.gitignore` — the WhatsApp channel is a separate (public) repo shipped as a Hub ZIP, mirrored as a gitignored folder like `hub/` and `marketing-site/`. Plus an expanded plugin-creation HowTo (`docs/creating-plugins.md`).

No code/runtime changes beyond the office version string.