### PR TITLE
feat(channel-sdk): additive Omadia UI canvas interface surface

### DIFF
--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -547,6 +547,37 @@ aus `anthropic.messages.stream` (nicht `.create`). Tool-Use-Deltas werden
 nicht weitergeleitet — stattdessen emittiert das `tool_use`-Event einmal
 den vollen Input, sobald der Content-Block schließt.
 
+### 11.1 Omadia UI — Canvas-Surface-Events (additiv)
+
+Für die Omadia-UI-Canvas-Fläche (Spec: `byte5ai/omadia-ui` `CONCEPT.md` v0.15 /
+`docs/implementation-plan.md`) wurde die SDK-Typ-Fläche **rein additiv**
+erweitert. Bestehende Channels sind unberührt — sie deklarieren die neue
+`'canvas'`-Capability nie und ignorieren die `surface_*`-Arme per Default
+(kein exhaustiver `assertNever`-Consumer in der middleware). Konkret:
+
+- **`ChatStreamEvent`** (`harness-channel-sdk/src/chatAgent.ts`) bekommt die
+  `surface_*`-Familie via `| SurfaceStreamEvent` (`surface.ts`):
+  `surface_snapshot`, `surface_patch`, `surface_data_ref_created`,
+  `surface_data_ref_invalidated`, `surface_action_result`,
+  `surface_local_action`, `surface_error`, `surface_mutation_resolved`. Jedes
+  trägt `{ canvasSessionId, surfaceSeq }`; Revisions sind ein **opakes,
+  branded `RevisionId`** (nur Gleichheit, keine Arithmetik); Bulk-Daten via
+  `DataRef`.
+- **`IncomingTurn`** (`incoming.ts`): additive `tenantId?` /
+  `target?: TargetRef` / `viewState?: CanvasViewState` / `viewStateTruncated?`.
+- **`SemanticAnswer.surface?: OutgoingSurface`** (`outgoing.ts`) +
+  `ChatTurnResult.surface?` (`chatAgent.ts`), durchgereicht in
+  `toSemanticAnswer`.
+- **`TargetRef`** (neuer Shared-Typ in `@omadia/plugin-api`, `targetRef.ts`) —
+  die kanonische Ziel-Adressierung (10 Varianten, Stable-IDs statt Positionen).
+- Channel-Manifest-Enum **`ChannelCapability`** (`admin-v1.ts` +
+  `manifestLoader.ts` `CHANNEL_CAPABILITIES`) bekommt `'canvas'`.
+
+Noch **nicht** in diesem Schritt: Boot-Dispatch (`channel.dispatchService`),
+die Canvas-Sentinel-Extractoren (`_pendingCanvasTree` etc.), das
+`structured?`/`writeCapabilities`-Tool-Manifest und die zwei neuen Plugins
+(`omadia-ui-orchestrator`, `omadia-ui-channel`) — separate Folge-PRs.
+
 ---
 
 ## 12. Red-Line-Enforcement (HR)

--- a/middleware/packages/harness-channel-sdk/src/chatAgent.ts
+++ b/middleware/packages/harness-channel-sdk/src/chatAgent.ts
@@ -1,5 +1,6 @@
 import type { PrivacyReceipt } from '@omadia/plugin-api';
 import type { FollowUpOption, SemanticAnswer } from './outgoing.js';
+import type { SurfaceStreamEvent, PendingCanvasSurface } from './surface.js';
 
 /**
  * Orchestrator surface contract — the duck-typed interface every chat-handling
@@ -360,6 +361,13 @@ export interface ChatTurnResult {
    * channels to highlight. Omitted when no server-materialized answer ran.
    */
   maskedValues?: readonly string[];
+  /**
+   * Omadia UI canvas surface payload (omadia-canvas-protocol/1.0). Present when a
+   * canvas-aware turn produced an initial primitive tree; `toSemanticAnswer`
+   * forwards it to `SemanticAnswer.surface`. Channels not declaring the
+   * `'canvas'` capability ignore it. Sidecar — does NOT short-circuit the turn.
+   */
+  surface?: PendingCanvasSurface;
 }
 
 /**
@@ -538,4 +546,9 @@ export type ChatStreamEvent =
    * event. Never emitted by the base orchestrator.
    */
   | { type: 'verifier'; summary: VerifierResultSummary }
-  | { type: 'error'; message: string };
+  | { type: 'error'; message: string }
+  /**
+   * Omadia UI canvas surface events (omadia-canvas-protocol/1.0). Additive;
+   * channels not declaring the `'canvas'` capability default-ignore these.
+   */
+  | SurfaceStreamEvent;

--- a/middleware/packages/harness-channel-sdk/src/incoming.ts
+++ b/middleware/packages/harness-channel-sdk/src/incoming.ts
@@ -1,3 +1,5 @@
+import type { TargetRef } from '@omadia/plugin-api';
+
 /**
  * Inbound message shape. Populated by the channel adapter from the native
  * event (Bot-Framework Activity / Slack event / Telegram update / …) and
@@ -17,7 +19,71 @@ export interface IncomingTurn {
   metadata?: Record<string, unknown>;
   /** The original platform event, for adapters that need it on the way back. */
   rawEvent?: unknown;
+  /**
+   * Per-deployment tenant id. Additive (Omadia UI). Classic channels leave it
+   * unset; the canvas channel populates it, and the core defaults it to
+   * `"default"` at the call site, not here.
+   */
+  tenantId?: string;
+  /**
+   * Canvas target for this turn (Omadia UI). Absent (or a
+   * `{ kind: 'canvas', canvasSessionId }` target) means a canvas-level prompt;
+   * any other `kind` scopes the turn to that target's subtree (container-scoped
+   * prompt / beam granularity). Classic channels never set it.
+   */
+  target?: TargetRef;
+  /**
+   * Per-container client view-state snapshot (sort / filter / group / selection
+   * / …) carried for referential continuity (Omadia UI). Tier 2 reads it,
+   * never writes it. Classic channels never set it.
+   */
+  viewState?: CanvasViewState;
+  /**
+   * `true` when the `viewState` blob (or a container's `selection`) was
+   * truncated to stay within the payload budget (Omadia UI). Tier 2's skill
+   * requires explicit confirmation before mutating across a truncated
+   * selection. Classic channels never set it.
+   */
+  viewStateTruncated?: boolean;
 }
+
+/**
+ * A container's current selection in `viewState`. Normally the full set of
+ * selected {@link TargetRef}s; when the selection exceeds the per-container cap
+ * it is shipped as a clearly-marked truncated sample so Tier 2 can decide
+ * whether to fetch the full set via a Tier-3 lookup.
+ */
+export type CanvasSelection =
+  | TargetRef[]
+  | {
+      kind: 'truncated';
+      includedCount: number;
+      totalCount: number;
+      /** first `includedCount` ids by viewState ordering */
+      sample: TargetRef[];
+    };
+
+/**
+ * Per-container view-state the Omadia UI client ships alongside a turn so the
+ * agent can resolve references ("of them", "this row") against stable ids. Keyed
+ * by `containerId`. Selection lives here (each entry is a {@link TargetRef}), not
+ * in the agent-owned tree.
+ */
+export type CanvasViewState = Record<
+  string,
+  {
+    sort?: { columnKey: string; direction: 'asc' | 'desc' };
+    filter?: { predicate: string };
+    group?: { columnKey: string };
+    hiddenColumns?: string[];
+    page?: { index: number; size: number };
+    selection?: CanvasSelection;
+    /** tree nodes / accordion-open rows, by stable item key */
+    expanded?: string[];
+    /** optional; only when referentially meaningful */
+    scrollTop?: number;
+  }
+>;
 
 export interface ChannelUserRef {
   /** Namespace identifying the channel-user space. */

--- a/middleware/packages/harness-channel-sdk/src/index.ts
+++ b/middleware/packages/harness-channel-sdk/src/index.ts
@@ -26,10 +26,31 @@ export type {
   ChannelUserKind,
   IncomingAttachment,
   PlatformIdentity,
+  CanvasViewState,
+  CanvasSelection,
 } from './incoming.js';
 
 // Orchestrator → channel stream envelope (back-compat re-export)
 export type { ChatStreamEvent } from './streamEvent.js';
+
+// Omadia UI canvas surface contracts (omadia-canvas-protocol/1.0). Additive —
+// the `surface_*` family is folded into `ChatStreamEvent`; classic channels
+// default-ignore it.
+export type {
+  RevisionId,
+  DataRef,
+  OutgoingSurface,
+  PendingCanvasSurface,
+  SurfaceStreamEvent,
+  SurfaceSnapshotEvent,
+  SurfacePatchEvent,
+  SurfaceDataRefCreatedEvent,
+  SurfaceDataRefInvalidatedEvent,
+  SurfaceActionResultEvent,
+  SurfaceLocalActionEvent,
+  SurfaceErrorEvent,
+  SurfaceMutationResolvedEvent,
+} from './surface.js';
 
 // Orchestrator surface contract — lifted from the kernel in S+10-2 so
 // channel-plugins-final (S+11) and the orchestrator-plugin (S+10-3/4) can

--- a/middleware/packages/harness-channel-sdk/src/outgoing.ts
+++ b/middleware/packages/harness-channel-sdk/src/outgoing.ts
@@ -11,6 +11,7 @@
  */
 
 import type { CaptureDisclosure, PrivacyReceipt } from '@omadia/plugin-api';
+import type { OutgoingSurface } from './surface.js';
 
 export type { CaptureDisclosure, PrivacyReceipt };
 
@@ -87,6 +88,14 @@ export interface SemanticAnswer {
    * produced no server-materialized answer or exposed no masked field.
    */
   maskedValues?: readonly string[];
+
+  /**
+   * Omadia UI canvas surface payload (omadia-canvas-protocol/1.0). Present when a
+   * canvas-aware turn produced an initial primitive tree. Channels not declaring
+   * the `'canvas'` capability ignore it. Additive optional field (see stability
+   * contract above) — sidecar, does NOT short-circuit the answer.
+   */
+  surface?: OutgoingSurface;
 }
 
 /** Image/file side-channel. `url` must be reachable by the channel. */

--- a/middleware/packages/harness-channel-sdk/src/surface.ts
+++ b/middleware/packages/harness-channel-sdk/src/surface.ts
@@ -1,0 +1,161 @@
+/**
+ * Omadia UI canvas surface contracts (omadia-canvas-protocol/1.0).
+ *
+ * These types are ADDITIVE to the channel SDK: the `SurfaceStreamEvent` family
+ * is folded into `ChatStreamEvent` (chatAgent.ts) as new discriminated arms, and
+ * `OutgoingSurface` rides on `SemanticAnswer`. Classic channels never declare
+ * the `'canvas'` capability and default-ignore every `surface_*` event, so this
+ * surface is inert for them.
+ *
+ * Nothing here changes an existing type — it only adds new ones.
+ */
+
+import type { TargetRef } from '@omadia/plugin-api';
+
+/**
+ * Opaque revision identifier for a canvas tree. Compared by EQUALITY ONLY — never
+ * with `<` / `>` / arithmetic. v1 implements it as a monotonic integer rendered
+ * as a string (single-writer model); v2+ shared canvases may use Lamport
+ * timestamps / vector clocks / CRDT op-ids without any wire-format change. The
+ * brand prevents accidental arithmetic or cross-use with a plain string.
+ */
+export type RevisionId = string & { readonly __brand: 'RevisionId' };
+
+/**
+ * Canonical reference to bulk data behind a primitive. Content-addressed id,
+ * HMAC-signed token, expiry. The single shape used by every trait/event that
+ * references bulk data.
+ */
+export interface DataRef {
+  /** content-addressed identifier, e.g. `"pixel-<sha256[:16]>"` */
+  id: string;
+  /** HMAC signature (see Security Surface for input composition) */
+  signedToken: string;
+  /** ISO 8601 timestamp */
+  expiresAt: string;
+}
+
+/** Fields every surface event carries. `surfaceSeq` is server-assigned, monotonic per canvasSessionId. */
+interface SurfaceEventBase {
+  canvasSessionId: string;
+  surfaceSeq: number;
+}
+
+/** Initial render / full replace; starts a new revision. */
+export interface SurfaceSnapshotEvent extends SurfaceEventBase {
+  type: 'surface_snapshot';
+  producesRevision: RevisionId;
+  /** full primitive tree (validated against the protocol whitelist by Tier 1) */
+  tree: unknown;
+  protocolVersion: string;
+  opsCatalogVersion: string;
+}
+
+/** Incremental update; client rejects + requests a snapshot if `basedOnRevision` mismatches. */
+export interface SurfacePatchEvent extends SurfaceEventBase {
+  type: 'surface_patch';
+  basedOnRevision: RevisionId;
+  producesRevision: RevisionId;
+  /** tree-path-targeted mutations */
+  patches: unknown[];
+}
+
+/** Bulk data available behind a signed reference. */
+export interface SurfaceDataRefCreatedEvent extends SurfaceEventBase {
+  type: 'surface_data_ref_created';
+  revision: RevisionId;
+  dataRef: DataRef;
+  schema?: unknown;
+  sizeHint?: number;
+}
+
+/** A reference expired / changed. */
+export interface SurfaceDataRefInvalidatedEvent extends SurfaceEventBase {
+  type: 'surface_data_ref_invalidated';
+  revision: RevisionId;
+  id: string;
+  reason: string;
+}
+
+/** Result of a user-triggered action. */
+export interface SurfaceActionResultEvent extends SurfaceEventBase {
+  type: 'surface_action_result';
+  forActionId: string;
+  basedOnRevision: RevisionId;
+  status: string;
+  message?: string;
+  followUpPatch?: unknown;
+}
+
+/**
+ * Tier 2 instructs Tier 1 to execute a Local Operations Catalog operation.
+ * `effect: 'preview'` does NOT mutate the revision (transient, locally undo-able);
+ * `effect: 'durable'` is always followed by a `surface_patch` that mutates it.
+ */
+export interface SurfaceLocalActionEvent extends SurfaceEventBase {
+  type: 'surface_local_action';
+  revision: RevisionId;
+  effect: 'preview' | 'durable';
+  operation: string;
+  params: unknown;
+  target: TargetRef;
+}
+
+/** Render-side validation / dataRef denied / catalog op unknown / protocol mismatch. */
+export interface SurfaceErrorEvent extends SurfaceEventBase {
+  type: 'surface_error';
+  revision: RevisionId;
+  severity: string;
+  message: string;
+  scope?: unknown;
+}
+
+/**
+ * Resolution of a Class-D mutation, correlated to its `_pendingMutation` by
+ * `forMutationId`. v2+ multi-user reserves `originAuthor` / `originSession` so a
+ * member can be shown who applied a change and from which session — empty in v1.
+ */
+export interface SurfaceMutationResolvedEvent extends SurfaceEventBase {
+  type: 'surface_mutation_resolved';
+  revision: RevisionId;
+  forMutationId: string;
+  status: 'success' | 'modified' | 'rejected' | 'invalid' | 'conflict';
+  /** present when modified or conflict */
+  actualValue?: unknown;
+  /** present when rejected or invalid */
+  error?: { message: string; code?: string };
+  /** v2+ multi-user provenance — empty in v1 single-user */
+  originAuthor?: string;
+  originSession?: string;
+}
+
+/**
+ * The `surface_*` event family added to `ChatStreamEvent`. Folded in as new arms
+ * in chatAgent.ts via `| SurfaceStreamEvent`.
+ */
+export type SurfaceStreamEvent =
+  | SurfaceSnapshotEvent
+  | SurfacePatchEvent
+  | SurfaceDataRefCreatedEvent
+  | SurfaceDataRefInvalidatedEvent
+  | SurfaceActionResultEvent
+  | SurfaceLocalActionEvent
+  | SurfaceErrorEvent
+  | SurfaceMutationResolvedEvent;
+
+/**
+ * Canvas surface payload carried on a `SemanticAnswer` (and as
+ * `ChatTurnResult.surface`) when a canvas-aware turn produced an initial tree.
+ * Channels not declaring `'canvas'` ignore it.
+ */
+export interface OutgoingSurface {
+  canvasSessionId: string;
+  producesRevision: RevisionId;
+  /** full primitive tree */
+  tree: unknown;
+  protocolVersion: string;
+  opsCatalogVersion: string;
+}
+
+/** Kernel-shaped counterpart of `OutgoingSurface` on `ChatTurnResult`. */
+export type PendingCanvasSurface = OutgoingSurface;

--- a/middleware/packages/harness-channel-sdk/src/toSemanticAnswer.ts
+++ b/middleware/packages/harness-channel-sdk/src/toSemanticAnswer.ts
@@ -100,5 +100,8 @@ export function toSemanticAnswer(r: ChatTurnResult): SemanticAnswer {
     ...(r.maskedValues && r.maskedValues.length > 0
       ? { maskedValues: r.maskedValues }
       : {}),
+    // Omadia UI: forward the canvas surface payload so converter-based channels
+    // reach the initial primitive tree. Sidecar — ignored by non-canvas channels.
+    ...(r.surface ? { surface: r.surface } : {}),
   };
 }

--- a/middleware/packages/plugin-api/src/index.ts
+++ b/middleware/packages/plugin-api/src/index.ts
@@ -3,6 +3,11 @@ export * from './conversation.js';
 export * from './localSubAgentTool.js';
 export * from './piiAnnotation.js';
 
+// Omadia UI canvas: the shared `TargetRef` discriminated union (beam / mutation
+// / local-op / suggested-action targets) and its `TextRangeAnchor` / `BufferRegion`
+// helpers. Consumed by the channel-sdk (`IncomingTurn.target`, `surface_local_action`).
+export * from './targetRef.js';
+
 // S+11-1: Knowledge-graph capability contract (interface + DTOs + node-id
 // helpers) lives on the plugin-api surface. Both the in-memory and the Neon
 // `knowledgeGraph@1` provider plugins (S+11-2 split of @omadia/knowledge-graph)

--- a/middleware/packages/plugin-api/src/targetRef.ts
+++ b/middleware/packages/plugin-api/src/targetRef.ts
@@ -1,0 +1,93 @@
+/**
+ * `TargetRef` — the single canonical way to address "a target" anywhere in the
+ * Omadia UI canvas protocol. Beam targets, Class-D `_pendingMutation.target`,
+ * `suggestedActions.target`, `surface_local_action.target` and
+ * `surface_mutation_resolved` correlation all use this one discriminated union.
+ *
+ * Targets address data by STABLE id/hash, never by view position ("row 3 on
+ * screen" is not addressable). Tier 1 resolves a `TargetRef` against its current
+ * tree + view-state by switching on `kind`; an unknown `kind` is rejected.
+ *
+ * Additive: new to the plugin-api surface. No existing type references it; it is
+ * a fresh shared contract consumed by the channel-sdk (`IncomingTurn.target`,
+ * `surface_local_action`) and future canvas plugins.
+ */
+export type TargetRef =
+  | { kind: 'canvas'; canvasSessionId: string }
+  | { kind: 'container'; containerId: string }
+  /** any non-data primitive (heading, divider, status, …) */
+  | { kind: 'element'; elementId: string }
+  | { kind: 'rowField'; containerId: string; rowKey: string; fieldKey: string }
+  /** list / tree node */
+  | { kind: 'item'; containerId: string; itemKey: string }
+  /** chart data point */
+  | { kind: 'point'; containerId: string; pointKey: string }
+  | { kind: 'textRange'; anchor: TextRangeAnchor }
+  /** pixel / canvas-region region */
+  | { kind: 'region'; region: BufferRegion }
+  /** whole-buffer reference (canvas-region / media) */
+  | { kind: 'buffer'; primitiveId: string; bufferContentHash: string }
+  /**
+   * media / timeline trim / splice / scrub. `trackId` scopes to one track on a
+   * multi-track timeline; `clipId` targets a specific clip on that track rather
+   * than a raw time interval. For single-buffer media omit both; for a
+   * multi-track timeline `trackId` is required and `clipId` optional.
+   */
+  | {
+      kind: 'timeRange';
+      primitiveId: string;
+      bufferContentHash: string;
+      start: number;
+      end: number;
+      unit: 'seconds' | 'samples' | 'frames';
+      trackId?: string;
+      clipId?: string;
+    };
+
+/**
+ * Stable anchor for a range within a `text` primitive. Naked numeric offsets are
+ * unstable as soon as the text is patched, so the offsets are bound to a content
+ * hash; on a hash miss the client re-anchors via `fallbackSegment`.
+ */
+export interface TextRangeAnchor {
+  /** the text primitive's containerId or elementId */
+  primitiveId: string;
+  /** sha256[:16] of the text primitive's content at anchoring time */
+  contentHash: string;
+  /** byte offset within that exact content */
+  start: number;
+  /** byte offset within that exact content */
+  end: number;
+  /** optional string snippets for re-resolution on a hash miss */
+  fallbackSegment?: {
+    /** ~32 chars of context before the selection */
+    before: string;
+    /** the selected text itself */
+    selection: string;
+    /** ~32 chars of context after the selection */
+    after: string;
+  };
+}
+
+/**
+ * Region addressing on `canvas-region` and `media` buffers, in buffer-native
+ * (not viewport / display) coordinates so zoom + pan do not invalidate it. A
+ * `bufferContentHash` mismatch means the buffer changed and the region can no
+ * longer be safely interpreted.
+ */
+export interface BufferRegion {
+  /** the canvas-region or media primitive's elementId */
+  primitiveId: string;
+  /** sha256[:16] of the buffer at anchoring time (resolution fails on mismatch) */
+  bufferContentHash: string;
+  /** axis-aligned bounding box in buffer pixels */
+  bbox: { x: number; y: number; w: number; h: number };
+  /** optional shape for non-rect selections (lasso, magic-wand) */
+  shape?: {
+    kind: 'rect' | 'polygon' | 'mask';
+    /** for 'polygon' */
+    points?: Array<[number, number]>;
+    /** for 'mask' — content-hash of a binary mask sized to bbox */
+    maskHash?: string;
+  };
+}

--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -132,7 +132,10 @@ export type ChannelCapability =
   | 'interactive_cards'
   | 'user_sso'
   | 'file_upload'
-  | 'typing_indicator';
+  | 'typing_indicator'
+  /** Omadia UI canvas surface — channel renders the live primitive tree and the
+   *  `surface_*` event family. Additive; classic channels never declare it. */
+  | 'canvas';
 
 export type ChannelAdapter =
   | 'text'

--- a/middleware/src/plugins/manifestLoader.ts
+++ b/middleware/src/plugins/manifestLoader.ts
@@ -440,6 +440,7 @@ const CHANNEL_CAPABILITIES: ReadonlySet<ChannelCapability> = new Set([
   'user_sso',
   'file_upload',
   'typing_indicator',
+  'canvas',
 ]);
 
 const CHANNEL_ADAPTERS: ReadonlySet<ChannelAdapter> = new Set([


### PR DESCRIPTION
## What

Additive SDK **interface** surface for the Omadia UI canvas channel — the type foundation (PR-1..PR-5 of the omadia-ui implementation plan), landed as one cohesive types-only change. Nothing consumes these yet; the orchestrator/channel plugins, boot dispatch, sentinel extractors and `structured?`/`writeCapabilities` are separate follow-up PRs.

Purely additive — new optional fields, new union arms, new files only. No existing field, signature, or behaviour changed.

- `'canvas'` `ChannelCapability` (`admin-v1.ts` union + `manifestLoader.ts` `CHANNEL_CAPABILITIES`, both sites).
- `TargetRef` discriminated union (ten variants) + `TextRangeAnchor`/`BufferRegion` in `@omadia/plugin-api` (`targetRef.ts`).
- `IncomingTurn`: additive `tenantId?` / `target?: TargetRef` / `viewState?: CanvasViewState` / `viewStateTruncated?`.
- `ChatStreamEvent`: the `surface_*` family + `surface_mutation_resolved` via `| SurfaceStreamEvent`; opaque branded `RevisionId` + `DataRef` (`surface.ts`).
- `SemanticAnswer.surface` / `OutgoingSurface` + `ChatTurnResult.surface`, forwarded through `toSemanticAnswer`.

Spec: `byte5ai/omadia-ui` `CONCEPT.md` v0.15 / `docs/implementation-plan.md` §3. Handoff doc updated in the same PR (§11.1, per AGENTS.md docs-in-the-same-PR).

## Test plan

From `middleware/` under Node 22:

- `npm run build` ✅
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test` ✅

`web-ui` is unaffected (it has no `@omadia/channel-sdk` dependency and defines its own client-side stream-event types). No SQL migrations and no new dependencies, so the `schema` and `audit` checks are unaffected.

## Intentionally unchanged

- Existing channels (Teams / Slack / Telegram): they never declare `'canvas'` and default-ignore the `surface_*` arms (there is no exhaustive `assertNever` consumer in the middleware), so their behaviour is byte-for-byte identical.
- No runtime wiring: `channel.dispatchService`, the canvas sentinel extractors (`_pendingCanvasTree` etc.), the `structured?`/`writeCapabilities` tool manifest, and the `omadia-ui-orchestrator` / `omadia-ui-channel` plugins are deferred to follow-up PRs.

## Note

`surface_mutation_resolved` uses `forMutationId` (matching the event-grammar table in CONCEPT.md §787 and the sibling `surface_action_result.forActionId`); the concept's Class-D snippet (§621) calls it `mutationId` — a concept-internal inconsistency flagged for a CONCEPT.md fix, not a code issue.
