### PR TITLE
feat(channels): per-channel dispatch_service routing (Omadia UI)

### DIFF
--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -165,6 +165,29 @@ User → Orchestrator.chatStream
                           └─ entityRefBus.publish (tagged mit turnId)
 ```
 
+### Channel → Orchestrator-Dispatch (per-Channel, Omadia UI)
+
+Ein Channel-Turn erreicht den Orchestrator über den **`orchestratorDispatcher`**
+(`TurnDispatcher` in `src/channels/coreApi.ts`, verdrahtet in `index.ts`).
+`CoreApi.handleTurnStream(turn)` reicht `channelId` durch; der Dispatcher löst
+**pro Turn lazy** den Ziel-Service aus der Service-Registry auf:
+
+```
+dispatchService = pluginCatalog.get(channelId)?.plugin.channel?.dispatch_service ?? 'chatAgent'
+agent           = serviceRegistry.get<ChatAgentBundle>(dispatchService)?.agent
+```
+
+`resolveDispatchService` (`src/channels/dispatchService.ts`) kapselt den
+Fallback. **Klassische Channels deklarieren kein `channel.dispatch_service`** und
+landen unverändert bei `'chatAgent'`. Omadia UI setzt im Channel-Manifest
+`dispatch_service: canvasChatAgent` (**bare Key, kein `@N`** — die Registry
+strippt keine Versionen) und routet so seine Turns an den
+`omadia-ui-orchestrator` (publiziert `canvasChatAgent@1`, runtime-Key
+`canvasChatAgent`). Annahme: `IncomingTurn.channelId` == Plugin-Catalog-Id des
+Channels; trifft das nicht zu, greift sicher der `'chatAgent'`-Default.
+Zusätzliches additives Manifest-Feld: `channel.canvas_protocol_version`
+(informativ; die echte Version wird im Boot-Handshake verhandelt).
+
 ---
 
 ## 4. Migration Managed Agents → Lokal

--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -156,6 +156,20 @@ export interface ChannelManifestBlock {
   };
   capabilities: ChannelCapability[];
   adapters: ChannelAdapter[];
+  /**
+   * Omadia UI (additive): the bare service-registry key this channel's turns
+   * dispatch to. Absent → the shared 'chatAgent' orchestrator (classic
+   * behaviour). The canvas channel sets `canvasChatAgent`. NOTE: a bare key,
+   * not `name@N` — the service registry does not strip versions; `@N` lives
+   * only in the provider's `provides:`/`requires:` capability list.
+   */
+  dispatch_service?: string;
+  /**
+   * Omadia UI (additive): the omadia-canvas-protocol version this channel
+   * speaks (e.g. `"1.0"`). Informational at the manifest layer; the actual
+   * version is negotiated in the boot handshake.
+   */
+  canvas_protocol_version?: string;
 }
 
 export interface Plugin {

--- a/middleware/src/channels/coreApi.ts
+++ b/middleware/src/channels/coreApi.ts
@@ -19,6 +19,12 @@ import type { ExpressRouteRegistry } from './routeRegistry.js';
 export interface TurnDispatcher {
   streamTurn(input: {
     scope: string;
+    /**
+     * Originating channel id (= the channel plugin's catalog id). The
+     * dispatcher uses it to resolve the channel's configured `dispatch_service`
+     * (Omadia UI); absent-from-manifest falls back to the shared 'chatAgent'.
+     */
+    channelId: string;
     userRef: ChannelUserRef;
     text: string;
     metadata?: Record<string, unknown>;
@@ -49,6 +55,7 @@ export function createCoreApi(opts: CreateCoreApiOptions): CoreApi {
       const scope = `${turn.channelId}::${turn.conversationId}`;
       return opts.dispatcher.streamTurn({
         scope,
+        channelId: turn.channelId,
         userRef: turn.userRef,
         text: turn.text,
         ...(turn.metadata ? { metadata: turn.metadata } : {}),

--- a/middleware/src/channels/dispatchService.ts
+++ b/middleware/src/channels/dispatchService.ts
@@ -1,0 +1,23 @@
+import { CHAT_AGENT_SERVICE } from '@omadia/channel-sdk';
+
+import type { ChannelManifestBlock } from '../api/admin-v1.js';
+
+/**
+ * Resolve the bare service-registry key a channel's turns dispatch to.
+ *
+ * A channel manifest may declare `channel.dispatch_service` to route its turns
+ * to an alternate orchestrator (Omadia UI's `canvasChatAgent`). When absent —
+ * every classic channel — turns dispatch to the shared `chatAgent` orchestrator,
+ * exactly as before. The returned value is a BARE registry key: the service
+ * registry looks up by exact string and does not strip an `@N` suffix (that
+ * lives only in the provider's `provides:`/`requires:` capability list), so a
+ * manifest must declare the bare name (`canvasChatAgent`, not `canvasChatAgent@1`).
+ *
+ * Additive + zero-regression: with no `dispatch_service` declared the result is
+ * `CHAT_AGENT_SERVICE`, the same key the dispatcher used unconditionally before.
+ */
+export function resolveDispatchService(
+  channel: ChannelManifestBlock | undefined,
+): string {
+  return channel?.dispatch_service ?? CHAT_AGENT_SERVICE;
+}

--- a/middleware/src/channels/orchestratorDispatcher.ts
+++ b/middleware/src/channels/orchestratorDispatcher.ts
@@ -1,0 +1,49 @@
+import type { ChatAgentBundle } from '@omadia/channel-sdk';
+
+import type { ChannelManifestBlock } from '../api/admin-v1.js';
+import type { TurnDispatcher } from './coreApi.js';
+import { resolveDispatchService } from './dispatchService.js';
+
+/**
+ * Minimal structural dependencies of the orchestrator dispatcher, injected so
+ * the routing logic is unit-testable without standing up the full boot graph.
+ * At boot these are backed by `pluginCatalog` and the `serviceRegistry`.
+ */
+export interface OrchestratorDispatcherDeps {
+  /** A loaded channel plugin's manifest `channel` block, by channel id. */
+  getChannelBlock(channelId: string): ChannelManifestBlock | undefined;
+  /** The ChatAgentBundle registered under a bare service key, or undefined. */
+  getAgentBundle(service: string): ChatAgentBundle | undefined;
+}
+
+/**
+ * Build the real `TurnDispatcher`: per turn, resolve the channel's configured
+ * `dispatch_service` (default `chatAgent`), fetch that orchestrator bundle from
+ * the registry, and stream its events back. Resolution is lazy per turn so the
+ * currently-active orchestrator is always used. Classic channels declare no
+ * `dispatch_service` and dispatch to `chatAgent` exactly as before.
+ */
+export function createOrchestratorDispatcher(
+  deps: OrchestratorDispatcherDeps,
+): TurnDispatcher {
+  return {
+    async *streamTurn(input) {
+      const dispatchService = resolveDispatchService(
+        deps.getChannelBlock(input.channelId),
+      );
+      const agent = deps.getAgentBundle(dispatchService)?.agent;
+      if (!agent) {
+        console.warn(
+          `[channels] no '${dispatchService}' agent registered — turn ignored (scope=${input.scope})`,
+        );
+        yield { type: 'error', message: 'orchestrator unavailable' };
+        return;
+      }
+      yield* agent.chatStream({
+        userMessage: input.text,
+        sessionScope: input.scope,
+        userId: input.userRef.id,
+      });
+    },
+  };
+}

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -180,6 +180,7 @@ import { DefaultChannelRegistry } from './channels/channelRegistry.js';
 import type { ChannelRegistry } from '@omadia/channel-sdk';
 import { DynamicChannelPluginResolver } from './channels/dynamicChannelResolver.js';
 import type { TurnDispatcher } from './channels/coreApi.js';
+import { createOrchestratorDispatcher } from './channels/orchestratorDispatcher.js';
 import type { FactExtractor } from '@omadia/orchestrator-extras';
 import { backfillGraph } from '@omadia/orchestrator-extras';
 import { turnContext } from '@omadia/orchestrator';
@@ -2339,30 +2340,22 @@ async function main(): Promise<void> {
   // ────────────────────────────────────────────────────────────────────────
   const routeRegistry = new ExpressRouteRegistry(app);
 
-  // Real TurnDispatcher: drive the orchestrator's ChatAgent (published as a
-  // ChatAgentBundle under 'chatAgent') and stream its events straight back to
-  // the channel adapter. Resolved lazily per turn from the service registry so
-  // it always uses the currently-active orchestrator. This makes
+  // Real TurnDispatcher: drive a ChatAgent (published as a ChatAgentBundle)
+  // and stream its events straight back to the channel adapter. The orchestrator
+  // service is resolved lazily per turn from the service registry so it always
+  // uses the currently-active orchestrator. The service KEY is the channel's
+  // configured `dispatch_service` (Omadia UI) — classic channels declare none
+  // and resolve to the shared 'chatAgent', exactly as before. This makes
   // `CoreApi.handleTurnStream` real for EVERY channel — channels no longer have
   // to reach into the service registry themselves to answer a turn.
-  const orchestratorDispatcher: TurnDispatcher = {
-    async *streamTurn(input) {
-      const bundle = serviceRegistry.get<ChatAgentBundle>('chatAgent');
-      const agent = bundle?.agent;
-      if (!agent) {
-        console.warn(
-          `[channels] no chatAgent registered — turn ignored (scope=${input.scope})`,
-        );
-        yield { type: 'error', message: 'orchestrator unavailable' };
-        return;
-      }
-      yield* agent.chatStream({
-        userMessage: input.text,
-        sessionScope: input.scope,
-        userId: input.userRef.id,
-      });
-    },
-  };
+  // channelId == the channel plugin's catalog id; read its manifest `channel`
+  // block (loaded into pluginCatalog at boot) to pick the dispatch service.
+  const orchestratorDispatcher: TurnDispatcher = createOrchestratorDispatcher({
+    getChannelBlock: (channelId) =>
+      pluginCatalog.get(channelId)?.plugin.channel,
+    getAgentBundle: (service) =>
+      serviceRegistry.get<ChatAgentBundle>(service),
+  });
 
   const channelCoreApi = createCoreApi({
     dispatcher: orchestratorDispatcher,

--- a/middleware/src/plugins/manifestLoader.ts
+++ b/middleware/src/plugins/manifestLoader.ts
@@ -497,6 +497,11 @@ function extractChannelBlock(
     }
   }
 
+  // Omadia UI (additive): optional canvas-channel fields. Classic channels
+  // omit both; absent `dispatch_service` falls back to 'chatAgent' at dispatch.
+  const dispatchService = asString(rec['dispatch_service']);
+  const canvasProtocolVersion = asString(rec['canvas_protocol_version']);
+
   return {
     transport: {
       kind: transportKind,
@@ -505,6 +510,10 @@ function extractChannelBlock(
     },
     capabilities,
     adapters,
+    ...(dispatchService ? { dispatch_service: dispatchService } : {}),
+    ...(canvasProtocolVersion
+      ? { canvas_protocol_version: canvasProtocolVersion }
+      : {}),
   };
 }
 

--- a/middleware/test/dispatchService.test.ts
+++ b/middleware/test/dispatchService.test.ts
@@ -1,0 +1,39 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { CHAT_AGENT_SERVICE } from '@omadia/channel-sdk';
+
+import type { ChannelManifestBlock } from '../src/api/admin-v1.js';
+import { resolveDispatchService } from '../src/channels/dispatchService.js';
+
+/**
+ * PR-6 — per-channel dispatch resolution. A channel manifest may declare
+ * `channel.dispatch_service` to route its turns to an alternate orchestrator
+ * (Omadia UI's `canvasChatAgent`); classic channels declare none and must keep
+ * resolving to the shared `chatAgent`, with zero behaviour change.
+ */
+describe('resolveDispatchService', () => {
+  const baseChannel: ChannelManifestBlock = {
+    transport: { kind: 'websocket', routes: [], verify_signature: false },
+    capabilities: ['text'],
+    adapters: ['text'],
+  };
+
+  it('falls back to chatAgent when the channel block is undefined', () => {
+    assert.equal(resolveDispatchService(undefined), CHAT_AGENT_SERVICE);
+    assert.equal(resolveDispatchService(undefined), 'chatAgent');
+  });
+
+  it('falls back to chatAgent when no dispatch_service is declared', () => {
+    assert.equal(resolveDispatchService(baseChannel), CHAT_AGENT_SERVICE);
+  });
+
+  it('returns the declared bare dispatch_service when present', () => {
+    const canvas: ChannelManifestBlock = {
+      ...baseChannel,
+      capabilities: ['text', 'canvas'],
+      dispatch_service: 'canvasChatAgent',
+    };
+    assert.equal(resolveDispatchService(canvas), 'canvasChatAgent');
+  });
+});

--- a/middleware/test/orchestratorDispatcher.test.ts
+++ b/middleware/test/orchestratorDispatcher.test.ts
@@ -1,0 +1,86 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { ChatAgentBundle, ChatStreamEvent } from '@omadia/channel-sdk';
+
+import type { ChannelManifestBlock } from '../src/api/admin-v1.js';
+import { createOrchestratorDispatcher } from '../src/channels/orchestratorDispatcher.js';
+
+/**
+ * PR-6 — the orchestrator dispatcher routes a turn to the channel's configured
+ * `dispatch_service` (default `chatAgent`), fetches that bundle from the
+ * registry, and streams its events. Classic channels (no `dispatch_service`)
+ * must keep hitting `chatAgent`; the canvas channel routes to `canvasChatAgent`.
+ */
+
+function stubBundle(events: ChatStreamEvent[]): ChatAgentBundle {
+  return {
+    agent: {
+      chat: () => Promise.resolve({ text: '' }),
+      async *chatStream() {
+        await Promise.resolve();
+        for (const e of events) yield e;
+      },
+    },
+  };
+}
+
+async function collect(
+  it: AsyncIterable<ChatStreamEvent>,
+): Promise<ChatStreamEvent[]> {
+  const out: ChatStreamEvent[] = [];
+  for await (const e of it) out.push(e);
+  return out;
+}
+
+const turn = {
+  scope: 'ch::conv',
+  userRef: { kind: 'custom' as const, id: 'u1' },
+  text: 'hi',
+};
+
+const canvasBlock: ChannelManifestBlock = {
+  transport: { kind: 'websocket', routes: [], verify_signature: false },
+  capabilities: ['text', 'canvas'],
+  adapters: ['text'],
+  dispatch_service: 'canvasChatAgent',
+};
+
+describe('createOrchestratorDispatcher', () => {
+  it('routes a classic channel (no dispatch_service) to chatAgent', async () => {
+    const asked: string[] = [];
+    const dispatcher = createOrchestratorDispatcher({
+      getChannelBlock: () => undefined,
+      getAgentBundle: (service) => {
+        asked.push(service);
+        return stubBundle([{ type: 'done', answer: 'ok', toolCalls: 0, iterations: 1 }]);
+      },
+    });
+    const events = await collect(dispatcher.streamTurn({ ...turn, channelId: 'de.byte5.channel.teams' }));
+    assert.deepEqual(asked, ['chatAgent']);
+    assert.equal(events.at(-1)?.type, 'done');
+  });
+
+  it('routes a canvas channel to its declared dispatch_service', async () => {
+    const asked: string[] = [];
+    const dispatcher = createOrchestratorDispatcher({
+      getChannelBlock: () => canvasBlock,
+      getAgentBundle: (service) => {
+        asked.push(service);
+        return stubBundle([{ type: 'text_delta', text: 'x' }]);
+      },
+    });
+    const events = await collect(dispatcher.streamTurn({ ...turn, channelId: 'de.byte5.channel.omadia-ui' }));
+    assert.deepEqual(asked, ['canvasChatAgent']);
+    assert.equal(events[0]?.type, 'text_delta');
+  });
+
+  it('yields a single error event when no orchestrator is registered', async () => {
+    const dispatcher = createOrchestratorDispatcher({
+      getChannelBlock: () => undefined,
+      getAgentBundle: () => undefined,
+    });
+    const events = await collect(dispatcher.streamTurn({ ...turn, channelId: 'x' }));
+    assert.deepEqual(events, [{ type: 'error', message: 'orchestrator unavailable' }]);
+  });
+});


### PR DESCRIPTION
## What

Per-channel orchestrator dispatch (PR-6 of the omadia-ui plan). A channel manifest may now declare `channel.dispatch_service` to route its turns to an alternate orchestrator; the Omadia UI canvas channel uses it to reach `canvasChatAgent`. **Zero regression** — classic channels declare none and resolve to the shared `chatAgent` exactly as before.

- `admin-v1.ts`: additive `dispatch_service?` + `canvas_protocol_version?` on `ChannelManifestBlock` (snake_case, matching the existing `verify_signature`).
- `manifestLoader.ts` `extractChannelBlock`: parse both (optional; omitted when absent).
- `channels/coreApi.ts`: thread `channelId` through `TurnDispatcher.streamTurn`; `handleTurnStream` passes `turn.channelId`. Internal interface — the only implementer is the orchestrator dispatcher.
- `channels/dispatchService.ts` (new): `resolveDispatchService(block) => block?.dispatch_service ?? CHAT_AGENT_SERVICE`. **Bare key** — the service registry does not strip `@N`, so the manifest declares `canvasChatAgent`, not `canvasChatAgent@1`.
- `channels/orchestratorDispatcher.ts` (new): `createOrchestratorDispatcher(deps)` — the boot dispatcher extracted from `index.ts` behind a small structural-deps interface so the routing is unit-testable.
- `index.ts`: the boot dispatcher is now `createOrchestratorDispatcher({ getChannelBlock: id => pluginCatalog.get(id)?.plugin.channel, getAgentBundle: svc => serviceRegistry.get(svc) })`.

### Design note (why a static field, not the registry)

main already ships `OrchestratorRegistry` + `channelResolver@1` for per-channel orchestrator selection, but it is **DB-gated on `DATABASE_URL`**. The self-hostable canvas target cannot assume a DB, so this lightweight static manifest field is the v1 choice. See omadia-ui `docs/implementation-plan.md` §3.1.

## Test plan

From `middleware/` under Node 22: `npm run build` + `typecheck` + `lint` + `test` all green. New tests:

- `dispatchService.test.ts`: absent/undefined → `chatAgent`; declared → the bare value.
- `orchestratorDispatcher.test.ts`: classic channel routes to `chatAgent`; canvas channel routes to its `dispatch_service`; no registered agent → a single `{type:'error'}` event.

`web-ui` / `schema` / `audit` unaffected (no web-ui dependency, no migrations, no new dependencies).

## Intentionally unchanged

- Classic channels (Teams / Slack / Telegram): no `dispatch_service` → identical `chatAgent` routing.
- Assumption: `IncomingTurn.channelId` == the channel plugin's catalog id (used for the `pluginCatalog.get` lookup). If ever violated, the lookup misses and safely defaults to `chatAgent` — no throw, no regression.

## Note

The dispatcher's "no orchestrator registered" warning text is now dynamic (`no '<service>' agent registered` instead of the old `no chatAgent registered`). Nothing in the repo scrapes that string; the error *event* (`{ type: 'error', message: 'orchestrator unavailable' }`) is unchanged. Handoff doc §3 updated (AGENTS.md docs-in-same-PR).
