### PR TITLE
feat(orchestrator): canvas sentinel parsers + canvas-output gate

### DIFF
--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -165,6 +165,23 @@ User → Orchestrator.chatStream
                           └─ entityRefBus.publish (tagged mit turnId)
 ```
 
+### Canvas-Sentinels (Omadia UI, PR-7a)
+
+Canvas-aware Tier-3-Tools (und der Canvas-Client für `_pendingMutation`)
+emittieren strukturierte Payloads als **In-Band-JSON-Sentinels** im Tool-Result-
+String — dasselbe Muster wie `_pendingUserChoice` / `_pendingRoutineList`
+(`parseToolEmittedChoice` in `orchestrator.ts`). Neu in
+`harness-orchestrator/src/canvasSentinels.ts`: die reinen Parser
+`parseToolEmitted{StructuredPayload,CanvasTree,Mutation}` plus der
+**`canvas-output`-Gate** (`isCanvasOutputAuthorized`, **deny-by-default**) —
+ein Tool-Sentinel wird nur akzeptiert, wenn das Plugin die `canvas-output`-
+Capability deklariert. Parser sind tolerant (malformed JSON / Shape-Mismatch →
+`undefined`). **Noch nicht** in den Tool-Loop verdrahtet: das Enforcement plus
+das beim Boot aus dem `pluginCatalog` berechnete Allow-Set (welche Tools
+`canvas-output` führen) kommt mit dem Canvas-Orchestrator (PR-9), zusammen mit
+den Tools, die diese Sentinels überhaupt erst erzeugen. Bis dahin emittiert
+niemand sie — Wiring jetzt wäre spekulativ.
+
 ---
 
 ## 4. Migration Managed Agents → Lokal

--- a/middleware/packages/harness-orchestrator/src/canvasSentinels.ts
+++ b/middleware/packages/harness-orchestrator/src/canvasSentinels.ts
@@ -1,0 +1,140 @@
+/**
+ * Omadia UI canvas sentinels (PR-7a) — pure parsers + the `canvas-output` gate.
+ *
+ * Tier-3 tools (and, for `_pendingMutation`, the canvas client) emit structured
+ * canvas payloads as in-band JSON sentinels embedded in their result string —
+ * the same mechanism as `_pendingUserChoice` / `_pendingRoutineList`
+ * (`parseToolEmittedChoice` / `parseToolEmittedRoutineList` in orchestrator.ts).
+ *
+ * This module ships the PARSERS and the authorization GATE only. They are NOT
+ * yet wired into the orchestrator tool loop: enforcing the gate needs the
+ * boot-computed set of `canvas-output`-authorised tools threaded into the
+ * orchestrator (cross-layer), which lands with the canvas orchestrator (PR-9),
+ * alongside the actual tools that emit these sentinels. Until then nothing emits
+ * them, so wiring the gate now would be speculative.
+ *
+ * Parsers are tolerant: malformed JSON or a shape mismatch yields `undefined`,
+ * so a plain-text tool result stays a plain-text tool result. Types are
+ * intentionally loose where the strong types live in the not-yet-merged canvas
+ * SDK surface — `target` and `tree` stay `unknown` and are narrowed by the
+ * consumer once `TargetRef` / the surface types land.
+ */
+
+/** Capability a tool/plugin must declare to be allowed to emit canvas sentinels. */
+export const CANVAS_OUTPUT_CAPABILITY = 'canvas-output';
+
+/**
+ * Origin gate, **deny-by-default**. A canvas sentinel from a tool is only
+ * honoured when that tool's plugin declared {@link CANVAS_OUTPUT_CAPABILITY}.
+ * Undeclared / unknown origin → rejected. The authorised capability list is
+ * supplied by the caller (computed at boot from the plugin catalog in PR-9).
+ */
+export function isCanvasOutputAuthorized(
+  declaredCapabilities: readonly string[] | undefined,
+): boolean {
+  return declaredCapabilities?.includes(CANVAS_OUTPUT_CAPABILITY) ?? false;
+}
+
+/** Structured data payload a canvas-aware Tier-3 tool hands to Tier 2. */
+export interface PendingStructuredPayload {
+  prose: string;
+  data: unknown;
+  dataRefId: string;
+  actions?: unknown[];
+}
+
+/** A full primitive tree a canvas-aware Tier-3 tool hands to Tier 2. */
+export interface PendingCanvasTree {
+  /** primitive tree (validated against the protocol whitelist by Tier 1). */
+  tree: unknown;
+}
+
+/** A client-originated Class-D optimistic mutation awaiting resolution. */
+export interface PendingMutation {
+  mutationId: string;
+  /** A `TargetRef` once the canvas SDK surface lands; `unknown` until consumed. */
+  target: unknown;
+  oldValue: unknown;
+  newValue: unknown;
+  /** Opaque `RevisionId` — a string at the wire layer. */
+  basedOnRevision: string;
+}
+
+/** JSON.parse `content` and return the value at `key`, or `undefined`. Tolerant. */
+function readSentinel(content: string, key: string): unknown {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return undefined;
+  return (parsed as Record<string, unknown>)[key];
+}
+
+/** Parse a tool result for a `_pendingStructuredPayload` sidecar, or `undefined`. */
+export function parseToolEmittedStructuredPayload(
+  content: string,
+): PendingStructuredPayload | undefined {
+  const raw = readSentinel(content, '_pendingStructuredPayload');
+  if (typeof raw !== 'object' || raw === null) return undefined;
+  const r = raw as {
+    prose?: unknown;
+    data?: unknown;
+    dataRefId?: unknown;
+    actions?: unknown;
+  };
+  if (typeof r.prose !== 'string') return undefined;
+  if (typeof r.dataRefId !== 'string' || r.dataRefId.length === 0) {
+    return undefined;
+  }
+  if (!('data' in r)) return undefined;
+  return {
+    prose: r.prose,
+    data: r.data,
+    dataRefId: r.dataRefId,
+    ...(Array.isArray(r.actions) ? { actions: r.actions } : {}),
+  };
+}
+
+/** Parse a tool result for a `_pendingCanvasTree` sidecar, or `undefined`. */
+export function parseToolEmittedCanvasTree(
+  content: string,
+): PendingCanvasTree | undefined {
+  const raw = readSentinel(content, '_pendingCanvasTree');
+  if (typeof raw !== 'object' || raw === null) return undefined;
+  const r = raw as { tree?: unknown };
+  if (typeof r.tree !== 'object' || r.tree === null) return undefined;
+  return { tree: r.tree };
+}
+
+/** Parse a `_pendingMutation` sidecar (client → orchestrator), or `undefined`. */
+export function parseToolEmittedMutation(
+  content: string,
+): PendingMutation | undefined {
+  const raw = readSentinel(content, '_pendingMutation');
+  if (typeof raw !== 'object' || raw === null) return undefined;
+  const r = raw as {
+    mutationId?: unknown;
+    target?: unknown;
+    oldValue?: unknown;
+    newValue?: unknown;
+    basedOnRevision?: unknown;
+  };
+  if (typeof r.mutationId !== 'string' || r.mutationId.length === 0) {
+    return undefined;
+  }
+  if (typeof r.basedOnRevision !== 'string') return undefined;
+  if (r.target === undefined || r.target === null) return undefined;
+  // oldValue / newValue are required by the optimistic-update contract
+  // (CONCEPT.md). The VALUE may legitimately be null (e.g. clearing a field),
+  // so require key presence, not a non-null value.
+  if (!('oldValue' in r) || !('newValue' in r)) return undefined;
+  return {
+    mutationId: r.mutationId,
+    target: r.target,
+    oldValue: r.oldValue,
+    newValue: r.newValue,
+    basedOnRevision: r.basedOnRevision,
+  };
+}

--- a/middleware/packages/harness-orchestrator/src/index.ts
+++ b/middleware/packages/harness-orchestrator/src/index.ts
@@ -91,6 +91,21 @@ export type {
 export { Orchestrator, parseToolEmittedChoice } from './orchestrator.js';
 export type { OrchestratorOptions } from './orchestrator.js';
 
+// Omadia UI canvas sentinels (PR-7a) — pure parsers + the canvas-output gate.
+// Not yet wired into the tool loop; the canvas orchestrator (PR-9) consumes them.
+export {
+  CANVAS_OUTPUT_CAPABILITY,
+  isCanvasOutputAuthorized,
+  parseToolEmittedStructuredPayload,
+  parseToolEmittedCanvasTree,
+  parseToolEmittedMutation,
+} from './canvasSentinels.js';
+export type {
+  PendingStructuredPayload,
+  PendingCanvasTree,
+  PendingMutation,
+} from './canvasSentinels.js';
+
 // Streaming retry predicate (exported for unit coverage)
 export { isRetryableStreamError } from './streaming.js';
 

--- a/middleware/test/canvasSentinels.test.ts
+++ b/middleware/test/canvasSentinels.test.ts
@@ -1,0 +1,134 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  CANVAS_OUTPUT_CAPABILITY,
+  isCanvasOutputAuthorized,
+  parseToolEmittedStructuredPayload,
+  parseToolEmittedCanvasTree,
+  parseToolEmittedMutation,
+} from '../packages/harness-orchestrator/src/canvasSentinels.js';
+
+/**
+ * PR-7a — pure canvas-sentinel parsers + the deny-by-default `canvas-output`
+ * gate. Mirrors the tolerance contract of `parseToolEmittedChoice`: malformed
+ * JSON or a shape mismatch yields `undefined`.
+ */
+
+describe('isCanvasOutputAuthorized (deny-by-default)', () => {
+  it('denies undefined / empty / unrelated capabilities', () => {
+    assert.equal(isCanvasOutputAuthorized(undefined), false);
+    assert.equal(isCanvasOutputAuthorized([]), false);
+    assert.equal(isCanvasOutputAuthorized(['memoryStore@1']), false);
+  });
+  it('allows only when canvas-output is declared', () => {
+    assert.equal(isCanvasOutputAuthorized([CANVAS_OUTPUT_CAPABILITY]), true);
+    assert.equal(isCanvasOutputAuthorized(['x', 'canvas-output']), true);
+  });
+});
+
+describe('parseToolEmittedStructuredPayload', () => {
+  it('parses a well-formed payload', () => {
+    const out = parseToolEmittedStructuredPayload(
+      JSON.stringify({
+        _pendingStructuredPayload: {
+          prose: '12 open tickets',
+          data: { rows: [{ owner: 'Anna' }] },
+          dataRefId: 'jira-q1',
+        },
+      }),
+    );
+    assert.deepEqual(out, {
+      prose: '12 open tickets',
+      data: { rows: [{ owner: 'Anna' }] },
+      dataRefId: 'jira-q1',
+    });
+  });
+  it('keeps an actions array when present', () => {
+    const out = parseToolEmittedStructuredPayload(
+      JSON.stringify({
+        _pendingStructuredPayload: { prose: 'p', data: null, dataRefId: 'd', actions: [{ id: 'a' }] },
+      }),
+    );
+    assert.deepEqual(out?.actions, [{ id: 'a' }]);
+  });
+  it('returns undefined on malformed JSON / wrong key / missing fields', () => {
+    assert.equal(parseToolEmittedStructuredPayload('not json'), undefined);
+    assert.equal(parseToolEmittedStructuredPayload(JSON.stringify({ other: 1 })), undefined);
+    assert.equal(
+      parseToolEmittedStructuredPayload(JSON.stringify({ _pendingStructuredPayload: { prose: 'p', dataRefId: 'd' } })),
+      undefined, // no `data`
+    );
+    assert.equal(
+      parseToolEmittedStructuredPayload(JSON.stringify({ _pendingStructuredPayload: { data: 1, dataRefId: 'd' } })),
+      undefined, // no prose
+    );
+  });
+});
+
+describe('parseToolEmittedCanvasTree', () => {
+  it('parses a tree object', () => {
+    const out = parseToolEmittedCanvasTree(
+      JSON.stringify({ _pendingCanvasTree: { tree: { type: 'container', children: [] } } }),
+    );
+    assert.deepEqual(out, { tree: { type: 'container', children: [] } });
+  });
+  it('returns undefined when tree is missing or not an object', () => {
+    assert.equal(parseToolEmittedCanvasTree(JSON.stringify({ _pendingCanvasTree: {} })), undefined);
+    assert.equal(parseToolEmittedCanvasTree(JSON.stringify({ _pendingCanvasTree: { tree: 'x' } })), undefined);
+    assert.equal(parseToolEmittedCanvasTree('{'), undefined);
+  });
+});
+
+describe('parseToolEmittedMutation', () => {
+  it('parses a well-formed mutation', () => {
+    const out = parseToolEmittedMutation(
+      JSON.stringify({
+        _pendingMutation: {
+          mutationId: 'm1',
+          target: { kind: 'rowField', containerId: 'c', rowKey: 'anna', fieldKey: 'status' },
+          oldValue: 'open',
+          newValue: 'done',
+          basedOnRevision: 'R3',
+        },
+      }),
+    );
+    assert.equal(out?.mutationId, 'm1');
+    assert.equal(out?.basedOnRevision, 'R3');
+    assert.deepEqual(out?.newValue, 'done');
+  });
+  it('accepts a null newValue (clearing a field) when both keys are present', () => {
+    const out = parseToolEmittedMutation(
+      JSON.stringify({
+        _pendingMutation: { mutationId: 'm', target: {}, oldValue: 'x', newValue: null, basedOnRevision: 'R1' },
+      }),
+    );
+    assert.equal(out?.mutationId, 'm');
+    assert.equal(out?.newValue, null);
+  });
+  it('returns undefined on malformed JSON / wrong key / missing fields', () => {
+    const both = { oldValue: 1, newValue: 2 };
+    assert.equal(parseToolEmittedMutation('}{'), undefined); // malformed JSON
+    assert.equal(parseToolEmittedMutation(JSON.stringify({ other: {} })), undefined); // wrong key
+    assert.equal(
+      parseToolEmittedMutation(JSON.stringify({ _pendingMutation: { target: {}, basedOnRevision: 'R1', ...both } })),
+      undefined, // no mutationId
+    );
+    assert.equal(
+      parseToolEmittedMutation(JSON.stringify({ _pendingMutation: { mutationId: 'm', target: {}, ...both } })),
+      undefined, // no basedOnRevision
+    );
+    assert.equal(
+      parseToolEmittedMutation(JSON.stringify({ _pendingMutation: { mutationId: 'm', target: null, basedOnRevision: 'R1', ...both } })),
+      undefined, // null target
+    );
+    assert.equal(
+      parseToolEmittedMutation(JSON.stringify({ _pendingMutation: { mutationId: 'm', target: {}, newValue: 2, basedOnRevision: 'R1' } })),
+      undefined, // no oldValue
+    );
+    assert.equal(
+      parseToolEmittedMutation(JSON.stringify({ _pendingMutation: { mutationId: 'm', target: {}, oldValue: 1, basedOnRevision: 'R1' } })),
+      undefined, // no newValue
+    );
+  });
+});


### PR DESCRIPTION
## What

Safe first slice of PR-7 (omadia-ui plan) — the **building blocks** for canvas sentinel handling, with **no behaviour change** to the orchestrator.

New `harness-orchestrator/src/canvasSentinels.ts`:

- `parseToolEmittedStructuredPayload` / `parseToolEmittedCanvasTree` / `parseToolEmittedMutation` — pure JSON-sentinel parsers mirroring the tolerance contract of `parseToolEmittedChoice` (malformed JSON / shape mismatch → `undefined`).
- `CANVAS_OUTPUT_CAPABILITY` + `isCanvasOutputAuthorized(declaredCapabilities)` — the origin gate, **deny-by-default**: a tool's canvas sentinel is only honoured when its plugin declared `canvas-output`.
- Exported from the package barrel for the canvas orchestrator (PR-9) to consume.

### Deliberately deferred

The parsers/gate are **not yet wired into the orchestrator tool loop**. Enforcing the gate needs the boot-computed set of `canvas-output`-authorised tools threaded into the orchestrator (cross-layer), which lands with the canvas orchestrator (PR-9) — alongside the actual tools that emit these sentinels. Nothing emits them today, so wiring now would be speculative (this scope was chosen deliberately; see omadia-ui plan §3 PR-7).

Types `target` / `tree` stay `unknown` here — they narrow to `TargetRef` / the surface types once the canvas SDK surface (#167) merges and the consumer lands.

## Test plan

From `middleware/` under Node 22: `build` + `typecheck` + `lint` + `test` all green. `canvasSentinels.test.ts` covers each parser (well-formed + malformed-JSON + wrong-key + missing-field) and the gate (deny undefined/empty/unrelated; allow only on `canvas-output`).

`web-ui` / `schema` / `audit` unaffected (no web-ui dependency, no migrations, no new dependencies).

## Intentionally unchanged

- `orchestrator.ts` and the live tool loop: untouched. Zero behaviour change — this PR only adds a new module + its barrel export + a test.
- Existing sentinels `_pendingUserChoice` / `_pendingRoutineList`: untouched.

Handoff doc §3 updated (AGENTS.md docs-in-same-PR).
