### PR TITLE
feat(plugin-api): structured? output + writeCapabilities contract

### DIFF
--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -165,6 +165,27 @@ User → Orchestrator.chatStream
                           └─ entityRefBus.publish (tagged mit turnId)
 ```
 
+### Write-Capabilities + `structured?`-Tool-Output (Omadia UI, PR-8)
+
+`plugin-api` additiv: `LocalSubAgentToolResult.structured?`
+(`StructuredToolOutput` — die **getypte Alternative** zum
+`_pendingStructuredPayload`-Sentinel-im-String) und der `WriteCapability`-
+Vertrag (ein Tool deklariert pro `dataClass`/`operation`, was es mutieren darf).
+**Wichtig:** `writeCapabilities` ist **kein** Feld auf `NativeToolSpec` — der
+Spec geht via `buildToolsList` verbatim in die Anthropic-Tool-Liste, und
+Anthropic lehnt unbekannte Felder ab (gleicher Grund, warum `piiFields` am
+LocalSubAgentTool-**Wrapper** hängt, nicht am Spec). Der Anbindungspunkt
+(Manifest-Annotation / Registration-Metadata, non-model-facing) wird mit dem
+ersten Consumer (PR-9) verdrahtet. `deriveMutabilityCapabilities(caps, dataClass)` in
+`plugin-api/src/writeCapabilities.ts` leitet daraus **deterministisch** (kein
+LLM-Call) `editable` / `canAddItems` / `canRemoveItems` / `canReorder` ab:
+`update`→editierbare Felder, `create`→`canAddItems` + Required-Fields,
+`delete`→`canRemoveItems`, `reorder`→`canReorder`. **Fehlende Annotation ⇒
+read-only** (strenger Default gegen Rollback-Hölle). Noch **nicht** verdrahtet:
+Manifest-Loader-Parsing von `writeCapabilities` + System-Prompt-Emission +
+das Threading von `structured` durch `localSubAgent.ts` kommen mit dem
+Canvas-Orchestrator (PR-9, erster Consumer).
+
 ---
 
 ## 4. Migration Managed Agents → Lokal

--- a/middleware/packages/plugin-api/src/index.ts
+++ b/middleware/packages/plugin-api/src/index.ts
@@ -3,6 +3,10 @@ export * from './conversation.js';
 export * from './localSubAgentTool.js';
 export * from './piiAnnotation.js';
 
+// Omadia UI — write-tool capability contract + the deterministic Tier-2
+// mutability derivation. Consumed by the canvas orchestrator (PR-9).
+export * from './writeCapabilities.js';
+
 // S+11-1: Knowledge-graph capability contract (interface + DTOs + node-id
 // helpers) lives on the plugin-api surface. Both the in-memory and the Neon
 // `knowledgeGraph@1` provider plugins (S+11-2 split of @omadia/knowledge-graph)

--- a/middleware/packages/plugin-api/src/localSubAgentTool.ts
+++ b/middleware/packages/plugin-api/src/localSubAgentTool.ts
@@ -34,6 +34,27 @@ export interface LocalSubAgentToolResult {
   readonly postcondition?: {
     readonly issues: readonly string[];
   };
+  /**
+   * Optional structured output (Omadia UI, additive). Ignored by the existing
+   * `string | LocalSubAgentToolResult` downcast in the sub-agent runner; the
+   * canvas orchestrator (PR-9) is the first consumer that threads it.
+   */
+  readonly structured?: StructuredToolOutput;
+}
+
+/**
+ * Optional structured-output envelope (Omadia UI, additive). The typed
+ * alternative to embedding a `_pendingStructuredPayload` JSON sentinel inside
+ * the `output` string: a canvas-aware tool can hand Tier 2 structured data
+ * directly. Classic consumers read `output`; canvas-aware consumers read
+ * `structured`. `kind` discriminates the payload so the consumer can narrow
+ * `data` (e.g. `'structuredPayload'`, `'canvasTree'`).
+ */
+export interface StructuredToolOutput {
+  readonly kind: string;
+  readonly data: unknown;
+  /** optional human-facing prose (rendered by non-canvas consumers). */
+  readonly prose?: string;
 }
 
 export interface LocalSubAgentTool {

--- a/middleware/packages/plugin-api/src/pluginContext.ts
+++ b/middleware/packages/plugin-api/src/pluginContext.ts
@@ -363,6 +363,14 @@ export interface NativeToolSpec {
    */
   readonly domain?: string;
 }
+// NOTE (Omadia UI): a tool's `writeCapabilities` annotation is deliberately NOT
+// a field on `NativeToolSpec` — the whole spec is sent verbatim into the
+// Anthropic tools list (`buildToolsList`), and Anthropic's tool-spec contract
+// rejects unknown fields (same reason `piiFields` lives on the LocalSubAgentTool
+// wrapper, not on its spec). The `WriteCapability` contract + the deterministic
+// `deriveMutabilityCapabilities` derivation live in `./writeCapabilities.ts`;
+// their attachment to a non-model-facing carrier (manifest annotation /
+// registration metadata) is wired with the first consumer (PR-9).
 
 /**
  * OB-77 (Palaia Phase 8) — Naming-Convention für Plugin-Domains.

--- a/middleware/packages/plugin-api/src/writeCapabilities.ts
+++ b/middleware/packages/plugin-api/src/writeCapabilities.ts
@@ -1,0 +1,106 @@
+/**
+ * Omadia UI — write-tool capability contract (additive, plugin-api).
+ *
+ * A Tier-3 tool that mutates data declares its write capabilities in its
+ * manifest so Tier 2 can derive inline-edit affordances (`editable` /
+ * `canAddItems` / `canRemoveItems` / `canReorder`) DETERMINISTICALLY — without
+ * guessing from free-form tool names, which produces silent rollback-hell. A
+ * tool that lacks this annotation is simply not exposed for direct manipulation
+ * (it still works via beam, which routes through the agent's full reasoning).
+ *
+ * This module ships the TYPES + the pure derivation helper. Wiring (manifest-
+ * loader parsing into the tool spec + system-prompt emission) lands with the
+ * canvas orchestrator (PR-9), which is the first consumer.
+ */
+
+export type WriteOperation = 'update' | 'create' | 'delete' | 'reorder';
+
+/** Per-field editability + client-checkable constraints (for `update`). */
+export interface WriteCapabilityField {
+  name: string;
+  /** client-checkable type hint (e.g. `'string'`, `'integer'`, `'enum'`). */
+  type?: string;
+  /** whether the client may inline-edit this field. */
+  editable: boolean;
+  /** allowed values, when `type === 'enum'`. */
+  values?: readonly unknown[];
+  pattern?: string;
+  min?: number;
+  max?: number;
+  maxLength?: number;
+}
+
+/** One write capability a tool declares for a data class. */
+export interface WriteCapability {
+  /** the data class this applies to (e.g. `"jira.ticket"`). */
+  dataClass: string;
+  operation: WriteOperation;
+  targetSchema?: {
+    /** primary-key field, for `update` / `delete`. */
+    idField?: string;
+    /** per-field editability + constraints, for `update`. */
+    fields?: readonly WriteCapabilityField[];
+    /** preferred container primitive, for `create` / `reorder`. */
+    containerHint?: string;
+    /** required fields of the new-item template, for `create`. */
+    requiredFields?: readonly string[];
+    /** field carrying display order, for `reorder`. */
+    orderField?: string;
+  };
+}
+
+/** Deterministic Tier-2 derivation of mutability from a tool's write capabilities. */
+export interface DerivedMutability {
+  canAddItems: boolean;
+  canRemoveItems: boolean;
+  canReorder: boolean;
+  /** new-item template required fields (from a `create` capability). */
+  requiredFields: readonly string[];
+  /** editable fields by name (from `update` capabilities, `editable: true` only). */
+  editableFields: Record<string, WriteCapabilityField>;
+}
+
+/**
+ * Derive container/field mutability for one `dataClass` from a tool's declared
+ * write capabilities — the deterministic mapping from "Tier 3 can do this" to
+ * "the client may offer this", with NO LLM call. Capabilities for other data
+ * classes are ignored. With no matching capability, everything stays read-only
+ * (the strict default that avoids rollback-hell).
+ */
+export function deriveMutabilityCapabilities(
+  capabilities: readonly WriteCapability[],
+  dataClass: string,
+): DerivedMutability {
+  const result: DerivedMutability = {
+    canAddItems: false,
+    canRemoveItems: false,
+    canReorder: false,
+    requiredFields: [],
+    editableFields: {},
+  };
+  for (const cap of capabilities) {
+    if (cap.dataClass !== dataClass) continue;
+    switch (cap.operation) {
+      case 'update':
+        for (const f of cap.targetSchema?.fields ?? []) {
+          // clone so a caller mutating the result can't reach back into the
+          // tool's (shared) manifest/spec state by reference.
+          if (f.editable) result.editableFields[f.name] = { ...f };
+        }
+        break;
+      case 'create':
+        result.canAddItems = true;
+        if (cap.targetSchema?.requiredFields) {
+          result.requiredFields = [...cap.targetSchema.requiredFields];
+        }
+        break;
+      case 'delete':
+        result.canRemoveItems = true;
+        break;
+      case 'reorder':
+        result.canReorder = true;
+        break;
+    }
+  }
+  return result;
+}

--- a/middleware/test/writeCapabilities.test.ts
+++ b/middleware/test/writeCapabilities.test.ts
@@ -1,0 +1,97 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type {
+  LocalSubAgentToolResult,
+  WriteCapability,
+} from '../packages/plugin-api/src/index.js';
+import { deriveMutabilityCapabilities } from '../packages/plugin-api/src/writeCapabilities.js';
+
+/**
+ * PR-8 — the write-tool capability contract + the deterministic Tier-2
+ * mutability derivation, plus the additive `structured?` envelope. Derivation
+ * is pure: update→editable fields, create→canAddItems, delete→canRemoveItems,
+ * reorder→canReorder; unmatched dataClass / no capability ⇒ read-only.
+ */
+
+const JIRA: readonly WriteCapability[] = [
+  {
+    dataClass: 'jira.ticket',
+    operation: 'update',
+    targetSchema: {
+      idField: 'ticket_id',
+      fields: [
+        { name: 'status', type: 'enum', values: ['open', 'done'], editable: true },
+        { name: 'key', type: 'string', editable: false }, // read-only PK
+      ],
+    },
+  },
+  { dataClass: 'jira.ticket', operation: 'create', targetSchema: { requiredFields: ['title', 'assignee'] } },
+  { dataClass: 'jira.ticket', operation: 'delete', targetSchema: { idField: 'ticket_id' } },
+  { dataClass: 'jira.ticket', operation: 'reorder', targetSchema: { orderField: 'sequence' } },
+];
+
+describe('deriveMutabilityCapabilities', () => {
+  it('derives the full container + field mutability for the matching dataClass', () => {
+    const d = deriveMutabilityCapabilities(JIRA, 'jira.ticket');
+    assert.equal(d.canAddItems, true);
+    assert.equal(d.canRemoveItems, true);
+    assert.equal(d.canReorder, true);
+    assert.deepEqual(d.requiredFields, ['title', 'assignee']);
+    assert.deepEqual(Object.keys(d.editableFields), ['status']); // only editable:true
+    assert.equal(d.editableFields['status']?.type, 'enum');
+    assert.equal('key' in d.editableFields, false); // read-only field excluded
+  });
+
+  it('is strict-read-only for an unmatched dataClass', () => {
+    const d = deriveMutabilityCapabilities(JIRA, 'erp.budget');
+    assert.deepEqual(d, {
+      canAddItems: false,
+      canRemoveItems: false,
+      canReorder: false,
+      requiredFields: [],
+      editableFields: {},
+    });
+  });
+
+  it('is strict-read-only for an empty capability list', () => {
+    const d = deriveMutabilityCapabilities([], 'jira.ticket');
+    assert.equal(d.canAddItems, false);
+    assert.equal(d.canRemoveItems, false);
+    assert.equal(d.canReorder, false);
+    assert.deepEqual(d.requiredFields, []);
+    assert.deepEqual(d.editableFields, {});
+  });
+
+  it('clones derived field objects (no aliasing of shared manifest state)', () => {
+    const d = deriveMutabilityCapabilities(JIRA, 'jira.ticket');
+    const original = JIRA[0]?.targetSchema?.fields?.[0];
+    assert.notEqual(d.editableFields['status'], original); // distinct object
+    assert.deepEqual(d.editableFields['status'], original); // same contents
+  });
+
+  it('only derives from the matching dataClass in a mixed list', () => {
+    const mixed: WriteCapability[] = [
+      ...JIRA,
+      { dataClass: 'erp.budget', operation: 'update', targetSchema: { fields: [{ name: 'hours', editable: true }] } },
+    ];
+    const jira = deriveMutabilityCapabilities(mixed, 'jira.ticket');
+    assert.equal('hours' in jira.editableFields, false);
+    const erp = deriveMutabilityCapabilities(mixed, 'erp.budget');
+    assert.deepEqual(Object.keys(erp.editableFields), ['hours']);
+    assert.equal(erp.canAddItems, false); // erp has no create capability
+  });
+});
+
+describe('additive plugin-api fields', () => {
+  it('LocalSubAgentToolResult accepts an optional structured envelope', () => {
+    const r: LocalSubAgentToolResult = {
+      output: 'plain text for classic channels',
+      structured: { kind: 'structuredPayload', data: { rows: [] }, prose: 'p' },
+    };
+    assert.equal(r.structured?.kind, 'structuredPayload');
+    // legacy bare result still type-checks
+    const legacy: LocalSubAgentToolResult = { output: 'x' };
+    assert.equal(legacy.structured, undefined);
+  });
+});


### PR DESCRIPTION
## What

Additive plugin-api contract for Omadia UI (PR-8) — the typed escape from sentinel-in-string output + the write-capability contract for inline editing. **No behaviour change.**

- `LocalSubAgentToolResult.structured?` (new `StructuredToolOutput`) — the TYPED alternative to embedding a `_pendingStructuredPayload` JSON sentinel in the `output` string. It sits on the tool RESULT (not the model-facing spec) and is ignored by the existing `string | LocalSubAgentToolResult` downcast.
- `WriteCapability` contract + `deriveMutabilityCapabilities(caps, dataClass)` — the deterministic Tier-2 mapping from a tool's declared write capabilities to inline-edit affordances (`update`→editable fields, `create`→`canAddItems` + required fields, `delete`→`canRemoveItems`, `reorder`→`canReorder`); a missing capability ⇒ read-only (strict default). Pure, no LLM call; clones derived objects so a caller can't alias shared manifest state.
- Exported from the plugin-api barrel.

### `writeCapabilities` is deliberately NOT on `NativeToolSpec`

The concept's PR-8 sketch put `writeCapabilities` on `NativeToolSpec`, but the whole spec is pushed verbatim into the Anthropic tools list (`buildToolsList` → `tools.push(entry.spec)`), and Anthropic's tool-spec contract rejects unknown fields — the same reason `piiFields` lives on the `LocalSubAgentTool` *wrapper*, not on its spec. So `writeCapabilities` stays a standalone contract here; its attachment to a non-model-facing carrier (manifest annotation / registration metadata) wires with the first consumer (PR-9). **Concept feed-back:** the concept should move `writeCapabilities` off `NativeToolSpec`.

### Deliberately deferred to PR-9 (first consumer)

Manifest-loader parsing of `writeCapabilities`, system-prompt emission, and threading `structured` through `localSubAgent.ts`. Native tools keep the `Promise<string>` + `_pendingX` idiom (the native-handler extension was dropped in the single-repo migration).

## Test plan

From `middleware/` under Node 22: `build` + `typecheck` + `lint` + `test` all green. `writeCapabilities.test.ts` covers the derivation (read-only-field exclusion, unmatched dataClass, mixed list, clone-no-aliasing, strict read-only baseline) and the `structured?` additive smoke. `web-ui` / `schema` / `audit` unaffected (no web-ui dependency, no migrations, no new dependencies).

## Intentionally unchanged

- The model-facing `NativeToolSpec` and `buildToolsList`: untouched.
- Existing `LocalSubAgentToolResult` consumers: the `string | LocalSubAgentToolResult` downcast ignores `structured`.

Handoff §3 updated (AGENTS.md docs-in-same-PR).
