### PR TITLE
chore(node): consolidate runtime on Node 22.22.3 LTS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,6 +80,13 @@ updates:
     labels: ['deps', 'docker']
     commit-message:
       prefix: 'chore(deps,docker)'
+    ignore:
+      # Stay on Node 22 LTS: the middleware ABI guard (check-node-version.mjs)
+      # hard-pins NODE_MODULE_VERSION 127 for better-sqlite3, so a major Node
+      # bump silently breaks the native binary. Major Node moves are a
+      # deliberate migration, not a weekly bot PR — 22.x patch/minor still flow.
+      - dependency-name: 'node'
+        update-types: ['version-update:semver-major']
   - package-ecosystem: 'docker'
     directory: '/web-ui'
     schedule:
@@ -91,3 +98,8 @@ updates:
     labels: ['deps', 'docker', 'web-ui']
     commit-message:
       prefix: 'chore(deps,docker,web-ui)'
+    ignore:
+      # Keep web-ui on the same Node 22 line as the middleware image; major
+      # Node bumps go through a deliberate migration, not a weekly bot PR.
+      - dependency-name: 'node'
+        update-types: ['version-update:semver-major']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
           cache-dependency-path: middleware/package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # botbuilder (@azure/msal-node family) have post-install hooks that break on
 # Alpine's musl libc without extra build tools. Slim keeps the image small
 # while staying on glibc.
-FROM node:22.12.0-slim AS builder
+FROM node:22.22.3-slim AS builder
 ARG TARGETARCH
 WORKDIR /app
 
@@ -38,7 +38,7 @@ COPY middleware/scripts ./scripts
 RUN npm run build
 
 # --- runtime ----------------------------------------------------------------
-FROM node:22.12.0-slim AS runtime
+FROM node:22.22.3-slim AS runtime
 ARG TARGETARCH
 WORKDIR /app
 

--- a/web-ui/Dockerfile
+++ b/web-ui/Dockerfile
@@ -2,16 +2,16 @@
 #
 # Omadia Admin UI — Next.js standalone build for Docker / Fly.io.
 # Multi-stage: install deps → build standalone → copy thin runtime image.
-# Final image ~150 MB (node 20 slim + standalone server + static assets).
+# Final image ~150 MB (node 22 slim + standalone server + static assets).
 
 # --- deps -------------------------------------------------------------------
-FROM node:20-slim AS deps
+FROM node:22.22.3-slim AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --no-audit --no-fund
 
 # --- builder ----------------------------------------------------------------
-FROM node:20-slim AS builder
+FROM node:22.22.3-slim AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -26,7 +26,7 @@ ENV MIDDLEWARE_URL=${MIDDLEWARE_URL}
 RUN npm run build
 
 # --- runtime ----------------------------------------------------------------
-FROM node:20-slim AS runtime
+FROM node:22.22.3-slim AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1


### PR DESCRIPTION
## What

Consolidates the Node version across all build/deploy surfaces onto **Node 22.22.3 LTS** (matching `.nvmrc`). No major jump — deliberately staying on 22 because `middleware/scripts/check-node-version.mjs` hard-pins the ABI (`NODE_MODULE_VERSION 127`) for `better-sqlite3`.

## Why

The Node landscape had drifted out of sync:

| Location | Before | After |
|---|---|---|
| `Dockerfile` (builder + runtime) | `22.12.0` | `22.22.3` |
| `web-ui/Dockerfile` (3 stages) | `node:20` | `22.22.3-slim` |
| `release.yml` setup-node | `20` | `22` |
| `dependabot.yml` (docker `/` + `/web-ui`) | — | ignore Node semver-major |

- **`Dockerfile` 22.12.0 was below the engines floor** `>=22.13.0`. With `middleware/.npmrc` `engine-strict=true`, a fresh `npm ci` in the builder stage fails — so this is a real build fix, not just cosmetics.
- **Node 20 is EOL** (~April 2026) → `web-ui/Dockerfile` and `release.yml` were no longer receiving security patches.
- **Dependabot ignore** for Docker Node majors: stops #143-style jumps to Node 23/24/26 (which break the ABI guard and `engines <23`). Patch/minor bumps within 22.x still flow.

## Verification

- `node:22.22.3-slim` confirmed as a published tag on Docker Hub (2026-05-20).
- YAML of both workflow/config files validated.
- CI jobs `middleware (build, no push)` and `web-ui (build, no push)` build both images under the new Node version — that is the build smoke test.

## Follow-up

- #143 (Docker Node 22→26) will be closed once this PR is green and merged.