### PR TITLE
fix(web-ui): pin @swc/helpers via overrides to fix dependabot lockfiles

### DIFF
--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -2851,9 +2851,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -8897,17 +8897,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -53,5 +53,8 @@
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.3",
     "vitest": "^2.1.9"
+  },
+  "overrides": {
+    "@swc/helpers": "0.5.21"
   }
 }


### PR DESCRIPTION
## Problem

Every **web-ui Dependabot PR** fails CI (`web-ui (lint + typecheck + vitest)`, `web-ui (build)`, `audit`) with:

```
npm error Missing: @swc/helpers@0.5.21 from lock file
```

(the version drifts — 0.5.21, 0.5.23 — but the failure is constant.) `main` is green, so this is **not** a code problem.

## Root cause

`@swc/helpers` is a transitive dep with a **version conflict**:

- `next@16` pins `@swc/helpers@0.5.15` (exact)
- `next-intl@4` → `@swc/core` wants `@swc/helpers >=0.5.17`

`main`'s lockfile resolves this correctly with **two** entries:
- `node_modules/@swc/helpers` → `0.5.15`
- `node_modules/next-intl/node_modules/@swc/helpers` → `0.5.21`

When Dependabot regenerates the lockfile for an unrelated bump, its npm run mishandles the nested dedup and drops/desyncs one entry. Strict `npm ci` then refuses to install. A `@dependabot rebase` does **not** help — it reproduces the same broken lockfile.

## Fix

Pin `@swc/helpers` to a single version via `overrides`, collapsing the duplication so the lockfile is deterministic (and Dependabot's regen stays consistent):

```json
"overrides": { "@swc/helpers": "0.5.21" }
```

`0.5.21` satisfies `next-intl`'s `>=0.5.17`, and `next` builds fine with it.

## Verification (local, Node 22.22.3)

- `npm install` → lockfile collapses to one `@swc/helpers@0.5.21`
- `npm ci` (strict) → passes (611 packages)
- `npm run build` (`next build`) → succeeds, full route table emitted

## Impact

Unblocks all open web-ui Dependabot PRs (#134, #136, #137, #139, #81) once they rebase onto this, plus every future web-ui dep bump.