### PR TITLE
chore(deps): ignore upstream-pinned major bumps (react, eslint)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,15 @@ updates:
         applies-to: 'version-updates'
         dependency-type: 'production'
         update-types: ['patch']
+    ignore:
+      # react/react-dom are pinned to 18.3.1 — react-dom's peer range and the
+      # workspace UI packages (@omadia/plugin-ui-helpers, agent-reference-maximum)
+      # all require react@18.3.1, so a react major bump alone fails to resolve
+      # (ERESOLVE). Treat React majors as a coordinated upgrade, not a weekly bot PR.
+      - dependency-name: 'react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-dom'
+        update-types: ['version-update:semver-major']
 
   # Web-dev (Next.js admin UI)
   - package-ecosystem: 'npm'
@@ -54,6 +63,12 @@ updates:
         applies-to: 'version-updates'
         dependency-type: 'production'
         update-types: ['patch']
+    ignore:
+      # eslint majors are gated by eslint-config-next@16, whose bundled plugins
+      # (eslint-plugin-import, eslint-plugin-jsx-a11y) cap their peer at eslint 9.
+      # Revisit once the Next.js lint stack supports eslint 10+.
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
 
   # GitHub Actions versions in workflow files
   - package-ecosystem: 'github-actions'


### PR DESCRIPTION
## What

Adds Dependabot `ignore` rules for two major bumps that **cannot resolve** and were re-opening every week.

| Dep | Ecosystem | Why it can't merge |
|---|---|---|
| `react` / `react-dom` | `/middleware` | `react-dom`'s peer range + workspace UI packages (`@omadia/plugin-ui-helpers`, `agent-reference-maximum`) all pin `react@18.3.1`. A react major alone → `ERESOLVE`. (was #142) |
| `eslint` | `/web-ui` | `eslint-config-next@16` bundles `eslint-plugin-import` / `eslint-plugin-jsx-a11y`, whose peer caps at `eslint@9`. eslint 10 breaks the lint job. (was #81) |

Both are `version-update:semver-major` ignores only — **patch/minor bumps still flow** (e.g. `@types/react` patches, eslint 9.x).

## Why

Same pattern as the Node major ignore (#143 → #174): pin-driven majors are coordinated upgrades, not weekly bot PRs. This stops the churn until the upstream constraints lift (React-19 migration / Next.js shipping eslint-10 support).

## Follow-up

#142 and #81 are closed referencing this rule.