### PR TITLE
feat(orchestrator): cross-session KG-recall probe (plans, processes, team insights)

### DIFF
--- a/middleware/packages/harness-channel-sdk/src/chatAgent.ts
+++ b/middleware/packages/harness-channel-sdk/src/chatAgent.ts
@@ -1,4 +1,4 @@
-import type { PrivacyReceipt } from '@omadia/plugin-api';
+import type { PrivacyReceipt, RecalledContext } from '@omadia/plugin-api';
 import type { FollowUpOption, SemanticAnswer } from './outgoing.js';
 import type { SurfaceStreamEvent, PendingCanvasSurface } from './surface.js';
 
@@ -376,6 +376,14 @@ export interface ChatTurnResult {
    * provenance) without re-deriving the id.
    */
   turnId?: string;
+  /**
+   * Cross-session recall probe — plans/processes/insights surfaced from PRIOR
+   * sessions for this turn. `toSemanticAnswer` forwards it to
+   * `SemanticAnswer.recalled` so non-streaming channels (Teams) can render a
+   * recall card; the streaming path also emits it as a `kg_recall` annotation.
+   * Omitted when nothing was recalled.
+   */
+  recalled?: RecalledContext;
 }
 
 /**

--- a/middleware/packages/harness-channel-sdk/src/outgoing.ts
+++ b/middleware/packages/harness-channel-sdk/src/outgoing.ts
@@ -10,10 +10,14 @@
  * a coordinated update across all connector packages.
  */
 
-import type { CaptureDisclosure, PrivacyReceipt } from '@omadia/plugin-api';
+import type {
+  CaptureDisclosure,
+  PrivacyReceipt,
+  RecalledContext,
+} from '@omadia/plugin-api';
 import type { OutgoingSurface } from './surface.js';
 
-export type { CaptureDisclosure, PrivacyReceipt };
+export type { CaptureDisclosure, PrivacyReceipt, RecalledContext };
 
 /**
  * The top-level shape the orchestrator hands to a connector for rendering.
@@ -96,6 +100,15 @@ export interface SemanticAnswer {
    * contract above) — sidecar, does NOT short-circuit the answer.
    */
   surface?: OutgoingSurface;
+
+  /**
+   * Cross-session recall probe — plans/processes/insights the per-turn probe
+   * surfaced from PRIOR sessions. Connectors that can render rich UI show it
+   * as a collapsible "from earlier sessions" card (web-ui RecalledContextCard,
+   * Teams Adaptive Card); others MAY ignore it. Omitted when nothing was
+   * recalled. Sidecar — does NOT short-circuit the answer.
+   */
+  recalled?: RecalledContext;
 }
 
 /** Image/file side-channel. `url` must be reachable by the channel. */

--- a/middleware/packages/harness-channel-sdk/src/toSemanticAnswer.ts
+++ b/middleware/packages/harness-channel-sdk/src/toSemanticAnswer.ts
@@ -103,5 +103,13 @@ export function toSemanticAnswer(r: ChatTurnResult): SemanticAnswer {
     // Omadia UI: forward the canvas surface payload so converter-based channels
     // reach the initial primitive tree. Sidecar — ignored by non-canvas channels.
     ...(r.surface ? { surface: r.surface } : {}),
+    // Cross-session recall probe — forward to connectors that render a recall
+    // card (web-ui, Teams). Only when at least one leg surfaced something.
+    ...(r.recalled &&
+    (r.recalled.plans.length > 0 ||
+      r.recalled.processes.length > 0 ||
+      r.recalled.insights.length > 0)
+      ? { recalled: r.recalled }
+      : {}),
   };
 }

--- a/middleware/packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.ts
+++ b/middleware/packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.ts
@@ -1322,7 +1322,14 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
       const owners = Array.isArray(node.props['acl_owners'])
         ? (node.props['acl_owners'] as string[])
         : [];
-      if (!owners.includes(opts.viewerOmadiaUserId)) continue;
+      const ownerMatch = owners.includes(opts.viewerOmadiaUserId);
+      // Mirror neon's `COALESCE(visibility, 'team')`: an MK with no explicit
+      // visibility is team-visible by default; `private` is never admitted
+      // by the team branch.
+      const teamMatch =
+        opts.teamVisibility === true &&
+        ['team', 'public'].includes(node.visibility ?? 'team');
+      if (!ownerMatch && !teamMatch) continue;
       const vector = this.embeddings.get(node.id);
       if (!vector) continue;
       const sim = cosine(opts.queryEmbedding, vector);
@@ -1358,7 +1365,12 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
       const owners = Array.isArray(parent.props['acl_owners'])
         ? (parent.props['acl_owners'] as string[])
         : [];
-      if (!owners.includes(opts.viewerOmadiaUserId)) continue;
+      const ownerMatch = owners.includes(opts.viewerOmadiaUserId);
+      // Excerpts inherit the parent MK's ACL + visibility.
+      const teamMatch =
+        opts.teamVisibility === true &&
+        ['team', 'public'].includes(parent.visibility ?? 'team');
+      if (!ownerMatch && !teamMatch) continue;
       const sim = cosine(opts.queryEmbedding, vector);
       if (!Number.isFinite(sim) || sim < minSimilarity) continue;
       hits.push({
@@ -2613,6 +2625,11 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
       props: {
         planId: input.planId,
         scope: input.scope,
+        // Neon stores userId in the `user_id` column; the in-memory backend
+        // has no such column, so it rides in props to keep `listRecentPlans`
+        // userId-filtering at parity. Conditional so plans ingested without a
+        // userId keep their existing prop shape.
+        ...(input.userId ? { userId: input.userId } : {}),
         ...(input.turnExternalId ? { turnId: input.turnExternalId } : {}),
         ...(input.strategy ? { strategy: input.strategy } : {}),
         ...(input.createdBy ? { createdBy: input.createdBy } : {}),
@@ -2718,6 +2735,39 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
           String(a.props['createdAt'] ?? ''),
         ),
       );
+  }
+
+  async listRecentPlans(opts: {
+    userId?: string;
+    limit?: number;
+    openOnly?: boolean;
+  }): Promise<GraphNode[]> {
+    const limit = Math.max(1, Math.min(opts.limit ?? 5, 50));
+    let plans = [...this.nodes.values()].filter((n) => n.type === 'Plan');
+    if (opts.userId !== undefined) {
+      plans = plans.filter((n) => n.props['userId'] === opts.userId);
+    }
+    if (opts.openOnly === true) {
+      plans = plans.filter((p) => {
+        const steps = [...this.edges.values()]
+          .filter((e) => e.type === 'STEP_OF' && e.to === p.id)
+          .map((e) => this.nodes.get(e.from))
+          .filter(
+            (n): n is GraphNode => n !== undefined && n.type === 'PlanStep',
+          );
+        return steps.some((s) => {
+          const st = s.props['status'];
+          return st === 'pending' || st === 'in_progress';
+        });
+      });
+    }
+    return plans
+      .sort((a, b) =>
+        String(b.props['createdAt'] ?? '').localeCompare(
+          String(a.props['createdAt'] ?? ''),
+        ),
+      )
+      .slice(0, limit);
   }
 
   private upsertNode(node: GraphNode): void {

--- a/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
+++ b/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
@@ -1037,6 +1037,39 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
     return res.rows.map((r) => rowToNode(r));
   }
 
+  async listRecentPlans(opts: {
+    userId?: string;
+    limit?: number;
+    openOnly?: boolean;
+  }): Promise<GraphNode[]> {
+    const limit = Math.max(1, Math.min(opts.limit ?? 5, 50));
+    // `user_id` lives in its own column (set on ingest), not in props.
+    // `openOnly` rolls up step state: a plan counts as "open" when it owns
+    // at least one PlanStep still pending/in_progress (failed/skipped are
+    // historical — superseded by replan — and don't keep a plan open).
+    const res = await this.pool.query<NodeRow>(
+      `SELECT ${NODE_COLUMNS}
+         FROM graph_nodes p
+        WHERE p.tenant_id = $1
+          AND p.type = 'Plan'
+          AND ($2::text IS NULL OR p.user_id = $2)
+          AND ($3::boolean = false OR EXISTS (
+            SELECT 1
+              FROM graph_nodes s
+              JOIN graph_edges e ON e.from_node = s.id
+             WHERE e.tenant_id = $1
+               AND e.type = 'STEP_OF'
+               AND e.to_node = p.id
+               AND s.type = 'PlanStep'
+               AND s.properties->>'status' IN ('pending', 'in_progress')
+          ))
+        ORDER BY (p.properties->>'createdAt') DESC NULLS LAST
+        LIMIT $4`,
+      [this.tenantId, opts.userId ?? null, opts.openOnly === true, limit],
+    );
+    return res.rows.map((r) => rowToNode(r));
+  }
+
   async getRunForTurn(turnExternalId: string): Promise<RunTraceView | null> {
     const runExtId = runNodeId(turnExternalId);
 
@@ -2332,6 +2365,8 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
     const minSimilarity = opts.minSimilarity ?? 0.3;
     const queryLit = vectorLiteral(opts.queryEmbedding);
 
+    // ACL: owner-list containment OR (opt-in) team/public visibility within
+    // the tenant. `private` is never admitted by the team branch.
     const sql = `
       SELECT ${NODE_COLUMNS},
              CASE
@@ -2343,7 +2378,10 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
       WHERE tenant_id = $2
         AND type = 'MemorableKnowledge'
         AND embedding IS NOT NULL
-        AND properties->'acl_owners' @> jsonb_build_array($3::text)
+        AND (
+          properties->'acl_owners' @> jsonb_build_array($3::text)
+          OR ($5::boolean AND COALESCE(visibility, 'team') IN ('team', 'public'))
+        )
       ORDER BY cosine_sim DESC
       LIMIT $4
     `;
@@ -2352,6 +2390,7 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
       this.tenantId,
       opts.viewerOmadiaUserId,
       limit,
+      opts.teamVisibility === true,
     ]);
     return rows.rows
       .filter((r) => Number(r.cosine_sim) >= minSimilarity)
@@ -2387,7 +2426,10 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
         AND ex.type = 'PalaiaExcerpt'
         AND ex.embedding IS NOT NULL
         AND mk.tenant_id = $2
-        AND mk.properties->'acl_owners' @> jsonb_build_array($3::text)
+        AND (
+          mk.properties->'acl_owners' @> jsonb_build_array($3::text)
+          OR ($5::boolean AND COALESCE(mk.visibility, 'team') IN ('team', 'public'))
+        )
       ORDER BY cosine_sim DESC
       LIMIT $4
     `;
@@ -2401,7 +2443,13 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
       };
       mk_external_id: string;
       cosine_sim: number;
-    }>(sql, [queryLit, this.tenantId, opts.viewerOmadiaUserId, limit]);
+    }>(sql, [
+      queryLit,
+      this.tenantId,
+      opts.viewerOmadiaUserId,
+      limit,
+      opts.teamVisibility === true,
+    ]);
 
     return rows.rows
       .filter((r) => Number(r.cosine_sim) >= minSimilarity)

--- a/middleware/packages/harness-orchestrator-extras/src/captureFilteringKnowledgeGraph.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/captureFilteringKnowledgeGraph.ts
@@ -193,6 +193,14 @@ export class CaptureFilteringKnowledgeGraph implements KnowledgeGraph {
     return this.inner.listPlansForScope(scope);
   }
 
+  listRecentPlans(opts: {
+    userId?: string;
+    limit?: number;
+    openOnly?: boolean;
+  }): Promise<GraphNode[]> {
+    return this.inner.listRecentPlans(opts);
+  }
+
   getRunForTurn(turnExternalId: string): Promise<RunTraceView | null> {
     return this.inner.getRunForTurn(turnExternalId);
   }

--- a/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
@@ -10,6 +10,7 @@ import {
   type MemorableKnowledgeHit,
   type PalaiaExcerptHit,
   type PalaiaExcerptNode,
+  type ProcessMemoryService,
   type TurnSearchHit,
 } from '@omadia/plugin-api';
 
@@ -60,6 +61,28 @@ export interface ContextRetrieverOptions {
   /** Score multiplier for memory-origin hits in the assembler. Default
    *  1.2 — curated memory ranks above raw FTS hits at similar cosine. */
   memoryBoostFactor?: number;
+
+  // Cross-session recall probe — Plan + Process + team-scoped insights.
+  /**
+   * Opt-in team-scope recall. When true, the curated-memory leg admits
+   * `team`/`public` MemorableKnowledge across the tenant (not just rows the
+   * viewer owns). `private` stays owner-only. Default false. Forwarded to
+   * `searchMemorableKnowledgeByEmbedding` / `searchExcerptsByEmbedding`.
+   */
+  teamVisibility?: boolean;
+  /** Disable the cross-session plan-recall leg. Default false. */
+  planRecallDisabled?: boolean;
+  /** Max prior-session plans surfaced per turn. Default 3. */
+  planLimit?: number;
+  /** Only surface plans with ≥1 pending/in_progress step. Default true. */
+  planOpenOnly?: boolean;
+  /** Disable the process-memory recall leg. Default false (= enabled
+   *  whenever a ProcessMemoryService is wired). */
+  processRecallDisabled?: boolean;
+  /** Max stored processes surfaced per turn. Default 3. */
+  processLimit?: number;
+  /** Min hybrid score for a process to be surfaced. Default 0.3. */
+  processMinScore?: number;
 }
 
 export interface ContextBuildInput {
@@ -161,12 +184,61 @@ export interface AssembledExclusion {
   reason: 'budget-exceeded' | 'agent-blocked';
 }
 
+/**
+ * Cross-session recall probe — one resumable plan from a PRIOR session.
+ * `openStepGoals` are the goals of its still-pending/in-progress steps.
+ */
+export interface RecalledPlan {
+  /** External id `plan:<planId>`. */
+  planId: string;
+  scope: string;
+  strategy?: string;
+  createdAt?: string;
+  openStepGoals: string[];
+  doneCount: number;
+  totalCount: number;
+}
+
+/** Cross-session recall probe — one stored process matching the message. */
+export interface RecalledProcess {
+  /** External id `process:<scope>:<slug>`. */
+  id: string;
+  title: string;
+  scope: string;
+  stepCount: number;
+  score: number;
+}
+
+/** Cross-session recall probe — one curated insight (MemorableKnowledge). */
+export interface RecalledInsight {
+  mkId: string;
+  kind: string;
+  summary: string;
+  score: number;
+}
+
+/**
+ * Structured payload of what the cross-session probe surfaced this turn.
+ * Powers both the prompt-injected recall blocks and the visible
+ * `kg_recall` annotation card. Empty arrays when a leg found nothing or
+ * was disabled.
+ */
+export interface RecalledContext {
+  plans: RecalledPlan[];
+  processes: RecalledProcess[];
+  insights: RecalledInsight[];
+}
+
 export interface AssembledContext {
   /** Final-rendered prose, ≤ budget tokens (best-effort, based on
    *  `chars/charsPerToken`). Empty string when nothing fit. */
   text: string;
   included: AssembledHit[];
   excluded: AssembledExclusion[];
+  /** Cross-session probe payload — plans/processes/insights from prior
+   *  sessions. Same content as the rendered recall blocks, structured for
+   *  the visible recall card. */
+  recalled: RecalledContext;
   stats: {
     /** Size of the candidate pool BEFORE the greedy-fill. */
     candidatePool: number;
@@ -212,6 +284,14 @@ const DEFAULTS: Required<
   excerptsPerMemory: 2,
   memoryMinSimilarity: 0.5,
   memoryBoostFactor: 1.2,
+  // Cross-session recall probe defaults.
+  teamVisibility: false,
+  planRecallDisabled: false,
+  planLimit: 3,
+  planOpenOnly: true,
+  processRecallDisabled: false,
+  processLimit: 3,
+  processMinScore: 0.3,
 };
 
 // Tiny, language-agnostic stopword list. We keep it short because the real
@@ -288,6 +368,10 @@ export class ContextRetriever {
      *  publish the `agentPriorities@1` capability, the assembler runs
      *  without Block/Boost (manual_authored × 1.3 stays active). */
     private readonly agentPriorities?: AgentPrioritiesStore,
+    /** Cross-session recall probe — optional. When wired, the assembler adds
+     *  a stored-process recall leg (semantic query over the `processes`
+     *  store). Absent → the leg is skipped, plan + memory legs still run. */
+    private readonly processMemory?: ProcessMemoryService,
   ) {
     this.opts = { ...DEFAULTS, ...opts };
   }
@@ -382,11 +466,22 @@ export class ContextRetriever {
       ...(input.currentTurnId ? { currentTurnId: input.currentTurnId } : {}),
     };
 
-    const [tail, entityHits, ftsHits, prioritiesIndex] = await Promise.all([
+    const [
+      tail,
+      entityHits,
+      ftsHits,
+      prioritiesIndex,
+      planHits,
+      processHits,
+      memoryHits,
+    ] = await Promise.all([
       this.loadTail(buildInput),
       this.loadEntityHits(buildInput, extractedTerms),
       this.loadFtsHits(buildInput),
       this.loadAgentPriorities(input.agentId),
+      this.loadPlanHits(buildInput),
+      this.loadProcessHits(buildInput),
+      this.loadMemoryHits(buildInput),
     ]);
 
     // Build candidate pool. Tail first (chronological → fills first).
@@ -487,17 +582,43 @@ export class ContextRetriever {
       });
     const fillOrder = [...tailTurns, ...nonTail];
 
+    // Cross-session recall blocks (plans / processes / insights) are NOT
+    // turn-shaped, so they render outside the turn greedy-fill as their own
+    // prepended section. They are the headline of the recall probe → they
+    // get first claim on up to half the budget; the turn pool fills the
+    // remainder. When every recall leg is empty the blocks render to '' and
+    // the turn budget is untouched (byte-identical to pre-probe behaviour).
+    const insights: RecalledInsight[] = memoryHits.map((h) => ({
+      mkId: h.mk.id,
+      kind: String(h.mk.props['kind'] ?? 'memory'),
+      summary: truncate(String(h.mk.props['summary'] ?? ''), 300),
+      score: h.score,
+    }));
+    const recalled: RecalledContext = {
+      plans: planHits,
+      processes: processHits,
+      insights,
+    };
+    const recallBudgetChars = Math.floor(budgetChars * 0.5);
+    const recallBlocksText = renderRecallBlocks(recalled, recallBudgetChars);
+    const recallTokens =
+      recallBlocksText.length > 0
+        ? Math.ceil(recallBlocksText.length / charsPerToken)
+        : 0;
+    const turnBudgetTokens = Math.max(0, budgetTokens - recallTokens);
+    const turnBudgetChars = turnBudgetTokens * charsPerToken;
+
     const included: AssembledHit[] = [];
-    let tokensUsed = 0;
+    let turnTokensUsed = 0;
     for (const c of fillOrder) {
       const chunk = renderHitChunk(c, compactMode);
       const chunkChars = chunk.length;
       const chunkTokens = Math.ceil(chunkChars / charsPerToken);
-      if (tokensUsed + chunkTokens > budgetTokens) {
+      if (turnTokensUsed + chunkTokens > turnBudgetTokens) {
         excluded.push({ turnId: c.turnId, reason: 'budget-exceeded' });
         continue;
       }
-      tokensUsed += chunkTokens;
+      turnTokensUsed += chunkTokens;
       included.push({
         turnId: c.turnId,
         score: c.rawScore,
@@ -506,20 +627,28 @@ export class ContextRetriever {
       });
       // Defensive: budget check on chars too (rounding can edge out the
       // token estimate by 1-2 tokens; chars cap is the hard ceiling).
-      if (chunkChars > budgetChars) break;
+      if (chunkChars > turnBudgetChars) break;
     }
 
-    const text = renderAssembled(fillOrder, included, compactMode);
+    const turnText = renderAssembled(fillOrder, included, compactMode);
+    const text =
+      recallBlocksText.length > 0
+        ? turnText.length > 0
+          ? `${recallBlocksText}\n\n${turnText}`
+          : recallBlocksText
+        : turnText;
+    const tokensUsed = turnTokensUsed + recallTokens;
 
     const scope = input.sessionScope ?? '<no-scope>';
     console.error(
-      `[context:assembled] scope=${scope} agent=${input.agentId} pool=${String(filtered.length)} included=${String(included.length)} excluded=${String(excluded.length)} compact=${String(compactMode)} tokens=${String(tokensUsed)}/${String(budgetTokens)}`,
+      `[context:assembled] scope=${scope} agent=${input.agentId} pool=${String(filtered.length)} included=${String(included.length)} excluded=${String(excluded.length)} compact=${String(compactMode)} plans=${String(recalled.plans.length)} processes=${String(recalled.processes.length)} insights=${String(recalled.insights.length)} tokens=${String(tokensUsed)}/${String(budgetTokens)}`,
     );
 
     return {
       text,
       included,
       excluded,
+      recalled,
       stats: {
         candidatePool: filtered.length,
         compactMode,
@@ -630,6 +759,99 @@ export class ContextRetriever {
   }
 
   /**
+   * Cross-session recall probe — resumable plans from PRIOR sessions.
+   * Tenant-wide (the team scope) recency-ordered; the current session's own
+   * plan is excluded (the tail already covers it). Plans carry no embedding,
+   * so this leg is recency/open-based rather than semantic. On any error
+   * returns [] — a degraded recall path must not kill the turn.
+   */
+  private async loadPlanHits(
+    input: ContextBuildInput,
+  ): Promise<RecalledPlan[]> {
+    if (this.opts.planRecallDisabled) return [];
+    const limit = Math.max(1, this.opts.planLimit);
+    try {
+      // Over-fetch a little so dropping the current-session plan still leaves
+      // a full page of cross-session plans.
+      const plans = await this.graph.listRecentPlans({
+        limit: limit + 2,
+        openOnly: this.opts.planOpenOnly,
+      });
+      const crossSession = plans.filter(
+        (p) => p.props['scope'] !== input.sessionScope,
+      );
+      const out: RecalledPlan[] = [];
+      for (const p of crossSession.slice(0, limit)) {
+        const steps = await this.graph.getPlanSteps(p.id);
+        const openStepGoals: string[] = [];
+        let doneCount = 0;
+        for (const s of steps) {
+          const status = s.props['status'];
+          if (status === 'done') doneCount += 1;
+          else if (status === 'pending' || status === 'in_progress') {
+            openStepGoals.push(String(s.props['goal'] ?? ''));
+          }
+        }
+        out.push({
+          planId: p.id,
+          scope: String(p.props['scope'] ?? ''),
+          ...(typeof p.props['strategy'] === 'string'
+            ? { strategy: p.props['strategy'] }
+            : {}),
+          ...(typeof p.props['createdAt'] === 'string'
+            ? { createdAt: p.props['createdAt'] }
+            : {}),
+          openStepGoals: openStepGoals.filter((g) => g.length > 0),
+          doneCount,
+          totalCount: steps.length,
+        });
+      }
+      return out;
+    } catch (err) {
+      console.error(
+        '[context:plan] plan recall failed — continuing without:',
+        err instanceof Error ? err.message : err,
+      );
+      return [];
+    }
+  }
+
+  /**
+   * Cross-session recall probe — stored processes semantically matching the
+   * user message (`processMemory@1` hybrid query, tenant-wide = team). Skipped
+   * when no ProcessMemoryService is wired or the leg is disabled. `private`
+   * processes are dropped (the store does not filter visibility itself). On
+   * any error returns [].
+   */
+  private async loadProcessHits(
+    input: ContextBuildInput,
+  ): Promise<RecalledProcess[]> {
+    if (this.opts.processRecallDisabled || !this.processMemory) return [];
+    try {
+      const hits = await this.processMemory.query({
+        query: input.userMessage,
+        limit: this.opts.processLimit,
+      });
+      return hits
+        .filter((h) => h.score >= this.opts.processMinScore)
+        .filter((h) => (h.record.visibility || 'team') !== 'private')
+        .map((h) => ({
+          id: h.record.id,
+          title: h.record.title,
+          scope: h.record.scope,
+          stepCount: h.record.steps.length,
+          score: h.score,
+        }));
+    } catch (err) {
+      console.error(
+        '[context:process] process recall failed — continuing without:',
+        err instanceof Error ? err.message : err,
+      );
+      return [];
+    }
+  }
+
+  /**
    * Slice 7 — semantic recall over curated memories + their verbatim
    * excerpts. Skipped when:
    *   - no embeddingClient is wired (the legs need a query vector)
@@ -680,12 +902,14 @@ export class ContextRetriever {
           viewerOmadiaUserId: input.userId,
           limit: overshoot,
           minSimilarity: this.opts.memoryMinSimilarity,
+          teamVisibility: this.opts.teamVisibility,
         }),
         this.graph.searchExcerptsByEmbedding({
           queryEmbedding: queryVector,
           viewerOmadiaUserId: input.userId,
           limit: excerptOvershoot,
           minSimilarity: this.opts.memoryMinSimilarity,
+          teamVisibility: this.opts.teamVisibility,
         }),
       ]);
     } catch (err) {
@@ -907,6 +1131,65 @@ function renderMemoryChunk(hit: MemoryRecallHit): string {
 function truncate(s: string, max: number): string {
   if (s.length <= max) return s;
   return `${s.slice(0, max - 1)}…`;
+}
+
+/**
+ * Cross-session recall probe — render the plan / process / insight blocks
+ * that precede the turn context in the assembled prompt. Budget-aware via a
+ * char cap; returns '' when nothing was recalled so the turn budget stays
+ * untouched (byte-identical to pre-probe behaviour).
+ */
+function renderRecallBlocks(
+  recalled: RecalledContext,
+  maxChars: number,
+): string {
+  if (
+    recalled.plans.length === 0 &&
+    recalled.processes.length === 0 &&
+    recalled.insights.length === 0
+  ) {
+    return '';
+  }
+  const parts: string[] = [];
+  let budget = maxChars;
+  const push = (s: string): boolean => {
+    if (s.length + 1 > budget) return false;
+    parts.push(s);
+    budget -= s.length + 1;
+    return true;
+  };
+
+  if (recalled.plans.length > 0) {
+    push('## Aus früheren Sessions — offene Pläne');
+    for (const p of recalled.plans) {
+      const label = p.strategy ? truncate(p.strategy, 120) : 'Plan';
+      const open =
+        p.openStepGoals.length > 0
+          ? ` · offen: ${truncate(p.openStepGoals.join('; '), 300)}`
+          : '';
+      const when = p.createdAt ? ` · ${p.createdAt}` : '';
+      const chunk = `- ${label} (${p.doneCount}/${p.totalCount} Schritte erledigt)${open}${when}`;
+      if (!push(chunk)) break;
+    }
+  }
+
+  if (recalled.processes.length > 0 && budget > 200) {
+    push('\n## Aus früheren Sessions — gespeicherte Prozesse');
+    for (const pr of recalled.processes) {
+      const chunk = `- ${truncate(pr.title, 160)} (${String(pr.stepCount)} Schritte, score ${pr.score.toFixed(2)})`;
+      if (!push(chunk)) break;
+    }
+  }
+
+  if (recalled.insights.length > 0 && budget > 200) {
+    push('\n## Aus früheren Sessions — verwandte Erkenntnisse');
+    for (const ins of recalled.insights) {
+      const chunk = `- ${ins.kind}: ${truncate(ins.summary, 300)} (score ${ins.score.toFixed(2)})`;
+      if (!push(chunk)) break;
+    }
+  }
+
+  return parts.join('\n');
 }
 
 // ---------------------------------------------------------------------------

--- a/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
@@ -11,6 +11,10 @@ import {
   type PalaiaExcerptHit,
   type PalaiaExcerptNode,
   type ProcessMemoryService,
+  type RecalledContext,
+  type RecalledInsight,
+  type RecalledPlan,
+  type RecalledProcess,
   type TurnSearchHit,
 } from '@omadia/plugin-api';
 
@@ -184,50 +188,10 @@ export interface AssembledExclusion {
   reason: 'budget-exceeded' | 'agent-blocked';
 }
 
-/**
- * Cross-session recall probe — one resumable plan from a PRIOR session.
- * `openStepGoals` are the goals of its still-pending/in-progress steps.
- */
-export interface RecalledPlan {
-  /** External id `plan:<planId>`. */
-  planId: string;
-  scope: string;
-  strategy?: string;
-  createdAt?: string;
-  openStepGoals: string[];
-  doneCount: number;
-  totalCount: number;
-}
-
-/** Cross-session recall probe — one stored process matching the message. */
-export interface RecalledProcess {
-  /** External id `process:<scope>:<slug>`. */
-  id: string;
-  title: string;
-  scope: string;
-  stepCount: number;
-  score: number;
-}
-
-/** Cross-session recall probe — one curated insight (MemorableKnowledge). */
-export interface RecalledInsight {
-  mkId: string;
-  kind: string;
-  summary: string;
-  score: number;
-}
-
-/**
- * Structured payload of what the cross-session probe surfaced this turn.
- * Powers both the prompt-injected recall blocks and the visible
- * `kg_recall` annotation card. Empty arrays when a leg found nothing or
- * was disabled.
- */
-export interface RecalledContext {
-  plans: RecalledPlan[];
-  processes: RecalledProcess[];
-  insights: RecalledInsight[];
-}
+// Cross-session recall payload types (RecalledContext / RecalledPlan /
+// RecalledProcess / RecalledInsight) live in @omadia/plugin-api so the
+// channel-facing answer contract can reference them without a circular
+// dependency. Imported at the top of this file and re-exported via index.ts.
 
 export interface AssembledContext {
   /** Final-rendered prose, ≤ budget tokens (best-effort, based on

--- a/middleware/packages/harness-orchestrator-extras/src/inconsistencyTriggeringKnowledgeGraph.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/inconsistencyTriggeringKnowledgeGraph.ts
@@ -190,6 +190,13 @@ export class InconsistencyTriggeringKnowledgeGraph implements KnowledgeGraph {
   listPlansForScope(scope: string): Promise<GraphNode[]> {
     return this.inner.listPlansForScope(scope);
   }
+  listRecentPlans(opts: {
+    userId?: string;
+    limit?: number;
+    openOnly?: boolean;
+  }): Promise<GraphNode[]> {
+    return this.inner.listRecentPlans(opts);
+  }
   getRunForTurn(turnExternalId: string): Promise<RunTraceView | null> {
     return this.inner.getRunForTurn(turnExternalId);
   }

--- a/middleware/packages/harness-orchestrator-extras/src/index.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/index.ts
@@ -25,11 +25,16 @@ export type {
   AssembledHit,
   AssembledHitReason,
   AssembledExclusion,
+} from './contextRetriever.js';
+// Cross-session recall payload types are canonically defined in
+// @omadia/plugin-api; re-exported here for back-compat with consumers that
+// import them alongside `AssembledContext` from this package.
+export type {
   RecalledContext,
   RecalledPlan,
   RecalledProcess,
   RecalledInsight,
-} from './contextRetriever.js';
+} from '@omadia/plugin-api';
 
 // OB-75 — palaia Phase 6 Session-Continuity (Briefings + Summaries).
 export {

--- a/middleware/packages/harness-orchestrator-extras/src/index.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/index.ts
@@ -25,6 +25,10 @@ export type {
   AssembledHit,
   AssembledHitReason,
   AssembledExclusion,
+  RecalledContext,
+  RecalledPlan,
+  RecalledProcess,
+  RecalledInsight,
 } from './contextRetriever.js';
 
 // OB-75 — palaia Phase 6 Session-Continuity (Briefings + Summaries).

--- a/middleware/packages/harness-orchestrator-extras/src/mergeTriggeringKnowledgeGraph.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/mergeTriggeringKnowledgeGraph.ts
@@ -281,6 +281,13 @@ export class MergeTriggeringKnowledgeGraph implements KnowledgeGraph {
   listPlansForScope(scope: string): Promise<GraphNode[]> {
     return this.inner.listPlansForScope(scope);
   }
+  listRecentPlans(opts: {
+    userId?: string;
+    limit?: number;
+    openOnly?: boolean;
+  }): Promise<GraphNode[]> {
+    return this.inner.listRecentPlans(opts);
+  }
   getRunForTurn(turnExternalId: string): Promise<RunTraceView | null> {
     return this.inner.getRunForTurn(turnExternalId);
   }

--- a/middleware/packages/harness-orchestrator-extras/src/plugin.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/plugin.ts
@@ -212,6 +212,43 @@ export async function activate(
     1.2,
   );
 
+  // Cross-session recall probe — Plan + Process recall + team-scoped
+  // insights. `teamVisibility` defaults ON (operator-chosen team scope):
+  // the memory-recall leg then admits `team`/`public` MemorableKnowledge
+  // tenant-wide, not just rows the viewer owns. Set
+  // kg_recall_team_visibility=false (or env KG_RECALL_TEAM_VISIBILITY=false)
+  // to revert to owner-only. Plan + process legs default ON; disable with
+  // kg_recall_plan_enabled=false / kg_recall_process_enabled=false.
+  const teamVisibilityRaw =
+    ctx.config.get<unknown>('kg_recall_team_visibility') ??
+    process.env['KG_RECALL_TEAM_VISIBILITY'];
+  const teamVisibility =
+    typeof teamVisibilityRaw === 'string'
+      ? teamVisibilityRaw.toLowerCase() !== 'false'
+      : teamVisibilityRaw !== false;
+  const planRecallEnabledRaw =
+    ctx.config.get<unknown>('kg_recall_plan_enabled') ??
+    process.env['KG_RECALL_PLAN_ENABLED'];
+  const planRecallDisabled =
+    typeof planRecallEnabledRaw === 'string'
+      ? planRecallEnabledRaw.toLowerCase() === 'false'
+      : planRecallEnabledRaw === false;
+  const planLimit = parseNumberOrDefault(
+    ctx.config.get<unknown>('kg_recall_plan_limit'),
+    3,
+  );
+  const processRecallEnabledRaw =
+    ctx.config.get<unknown>('kg_recall_process_enabled') ??
+    process.env['KG_RECALL_PROCESS_ENABLED'];
+  const processRecallDisabled =
+    typeof processRecallEnabledRaw === 'string'
+      ? processRecallEnabledRaw.toLowerCase() === 'false'
+      : processRecallEnabledRaw === false;
+  const processLimit = parseNumberOrDefault(
+    ctx.config.get<unknown>('kg_recall_process_limit'),
+    3,
+  );
+
   let anthropic: Anthropic | undefined;
   if (apiKey) {
     anthropic = new Anthropic({ apiKey });
@@ -325,6 +362,15 @@ export async function activate(
     `[harness-orchestrator-extras] capture-filter activated (level=${captureLevel}, threshold=${captureSignificanceThreshold.toFixed(2)}, visibility=${captureDefaultVisibility}, scorer=${captureLevel === 'minimal' || captureLevel === 'off' ? 'disabled-by-level' : anthropic ? 'haiku' : 'unavailable-no-key'})`,
   );
 
+  // OB-76 — Process-Memory handle, resolved once and reused below (the
+  // nudge side-channel at the bottom of this activate() reuses the same
+  // const). Optional capability: absent when the KG provider has no
+  // `processes` table (in-memory / no database_url) → the process-recall
+  // leg is skipped, plan + memory legs still run.
+  const processMemory = ctx.services.get<ProcessMemoryService>(
+    PROCESS_MEMORY_SERVICE_NAME,
+  );
+
   // Downstream consumers inside this package use the wrapped KG too — keeps
   // ContextRetriever's reads consistent with the swapped registry entry.
   const contextRetriever = new ContextRetriever(
@@ -342,12 +388,19 @@ export async function activate(
       excerptsPerMemory: memoryExcerptsPerMemory,
       memoryMinSimilarity,
       memoryBoostFactor,
+      // Cross-session recall probe.
+      teamVisibility,
+      planRecallDisabled,
+      planLimit,
+      processRecallDisabled,
+      processLimit,
     },
     embeddingClient,
     agentPriorities,
+    processMemory,
   );
   ctx.log(
-    `[harness-orchestrator-extras] context-assembler ready (budget=${String(contextDefaultBudgetTokens)}tk, chars/tk=${String(contextCharsPerToken)}, manual-boost=${contextManualBoostFactor.toFixed(2)}, compact>${String(contextCompactModeThreshold)}, agentPriorities=${agentPriorities ? 'on' : 'off'}, memoryRecall=${embeddingClient && !memoryRecallDisabled ? `on(limit=${String(memoryLimit)},excerpts=${String(memoryExcerptsPerMemory)},minSim=${memoryMinSimilarity.toFixed(2)})` : 'off'})`,
+    `[harness-orchestrator-extras] context-assembler ready (budget=${String(contextDefaultBudgetTokens)}tk, chars/tk=${String(contextCharsPerToken)}, manual-boost=${contextManualBoostFactor.toFixed(2)}, compact>${String(contextCompactModeThreshold)}, agentPriorities=${agentPriorities ? 'on' : 'off'}, memoryRecall=${embeddingClient && !memoryRecallDisabled ? `on(limit=${String(memoryLimit)},excerpts=${String(memoryExcerptsPerMemory)},minSim=${memoryMinSimilarity.toFixed(2)})` : 'off'}, teamVisibility=${teamVisibility ? 'on' : 'off'}, planRecall=${planRecallDisabled ? 'off' : `on(limit=${String(planLimit)})`}, processRecall=${processMemory && !processRecallDisabled ? `on(limit=${String(processLimit)})` : 'off'})`,
   );
   const disposeContext = ctx.services.provide(
     CONTEXT_RETRIEVER_SERVICE,
@@ -541,10 +594,8 @@ export async function activate(
   // Side-channel design solves the activation-order problem: this plugin
   // activates BEFORE `harness-orchestrator` (orchestrator depends on
   // `contextRetriever@1` published here), so a direct registry.register
-  // would race against an empty registry.
-  const processMemory = ctx.services.get<ProcessMemoryService>(
-    PROCESS_MEMORY_SERVICE_NAME,
-  );
+  // would race against an empty registry. (`processMemory` was resolved
+  // once above for the context-retriever and is reused here.)
   const processPromoteProvider = new ProcessPromoteProvider({
     ...(processMemory ? { processMemory } : {}),
     log: (msg) => { console.error(msg); },

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -15,6 +15,7 @@ import type { EmbeddingClient } from '@omadia/embeddings';
 import type {
   ContextRetriever,
   FactExtractor,
+  RecalledContext,
 } from '@omadia/orchestrator-extras';
 import { promoteTurnIfSignificant } from '@omadia/orchestrator-extras';
 import type { AskObserver, DomainTool } from './tools/domainQueryTool.js';
@@ -1303,21 +1304,21 @@ export class Orchestrator {
    */
   private async retrievePriorContext(
     input: ChatTurnInput,
-  ): Promise<string | undefined> {
+  ): Promise<{ text: string | undefined; recalled: RecalledContext | undefined }> {
     // Use console.error so the trace lands on stderr — Fly's log aggregator
     // has been observed to drop some stdout INFO lines under load, and this
     // is the one pathway we cannot afford to lose visibility on.
     if (input.freshCheck) {
       console.error('[context] SKIP fresh-check');
-      return undefined;
+      return { text: undefined, recalled: undefined };
     }
     if (!this.contextRetriever) {
       console.error('[context] SKIP no-retriever');
-      return undefined;
+      return { text: undefined, recalled: undefined };
     }
     if (!input.sessionScope && !input.userId) {
       console.error('[context] SKIP no-scope-no-user');
-      return undefined;
+      return { text: undefined, recalled: undefined };
     }
     try {
       // OB-74 (Palaia Phase 5) — switch to the token-budget assembler. The
@@ -1372,14 +1373,40 @@ export class Orchestrator {
           : briefingText.length > 0
             ? briefingText
             : result.text;
-      return merged.length > 0 ? merged : undefined;
+      return {
+        text: merged.length > 0 ? merged : undefined,
+        recalled: result.recalled,
+      };
     } catch (err) {
       console.error(
         '[context] retrieval FAILED — continuing without:',
         err instanceof Error ? err.message : err,
       );
-      return undefined;
+      return { text: undefined, recalled: undefined };
     }
+  }
+
+  /** Cross-session recall probe — map the assembled `recalled` payload to a
+   *  `kg_recall` turn-annotation event when it carries anything. Returns []
+   *  (no event) when every leg was empty so cold-start turns stay quiet. */
+  private toRecallAnnotationEvents(
+    recalled: RecalledContext | undefined,
+  ): ChatStreamEvent[] {
+    if (
+      !recalled ||
+      (recalled.plans.length === 0 &&
+        recalled.processes.length === 0 &&
+        recalled.insights.length === 0)
+    ) {
+      return [];
+    }
+    return [
+      {
+        type: 'turn_annotation' as const,
+        channel: 'kg_recall',
+        payload: recalled,
+      },
+    ];
   }
 
   /**
@@ -1566,7 +1593,9 @@ export class Orchestrator {
     await this.fireTurnHook('onBeforeTurn', turnId, input, {
       userMessage: input.userMessage,
     });
-    const priorContext = await this.retrievePriorContext(input);
+    // Non-streaming path: only the prompt-injected text is consumed; the
+    // structured `recalled` payload has no annotation channel here.
+    const { text: priorContext } = await this.retrievePriorContext(input);
     const effectiveExtraSystemHint = composeExtraSystemHint(input);
     // Palaia Phase 8 (OB-77) — per-turn nudge counter (shared across all
     // tool-call iterations of this turn so NUDGE_MAX_PER_TURN is enforced).
@@ -2062,7 +2091,12 @@ export class Orchestrator {
     turnId: string,
     observer: AskObserver | undefined,
   ): AsyncGenerator<ChatStreamEvent> {
-    const priorContext = await this.retrievePriorContext(input);
+    const { text: priorContext, recalled } =
+      await this.retrievePriorContext(input);
+    // Cross-session recall probe — surface plans/processes/insights pulled
+    // from prior sessions as a visible `kg_recall` card before the answer
+    // streams in. No-op when every recall leg was empty.
+    yield* this.toRecallAnnotationEvents(recalled);
     const effectiveExtraSystemHint = composeExtraSystemHint(input);
     // Palaia Phase 8 (OB-77) — see chatInContextInner for rationale.
     const nudgeCounter = createNudgeTurnCounter();

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -1593,9 +1593,12 @@ export class Orchestrator {
     await this.fireTurnHook('onBeforeTurn', turnId, input, {
       userMessage: input.userMessage,
     });
-    // Non-streaming path: only the prompt-injected text is consumed; the
-    // structured `recalled` payload has no annotation channel here.
-    const { text: priorContext } = await this.retrievePriorContext(input);
+    // Non-streaming path: `priorContext` is injected into the prompt; the
+    // structured `recalled` payload rides out on the ChatTurnResult so
+    // non-streaming channels (Teams) can render a recall card (the streaming
+    // path emits it as a `kg_recall` annotation instead).
+    const { text: priorContext, recalled } =
+      await this.retrievePriorContext(input);
     const effectiveExtraSystemHint = composeExtraSystemHint(input);
     // Palaia Phase 8 (OB-77) — per-turn nudge counter (shared across all
     // tool-call iterations of this turn so NUDGE_MAX_PER_TURN is enforced).
@@ -1786,6 +1789,7 @@ export class Orchestrator {
             ...(pendingSlotCard ? { pendingSlotCard } : {}),
             ...(pendingRoutineList ? { pendingRoutineList } : {}),
             ...(pendingOAuthConsent ? { pendingOAuthConsent: true } : {}),
+            ...(recalled ? { recalled } : {}),
           };
         }
 
@@ -1935,6 +1939,7 @@ export class Orchestrator {
             pendingUserChoice,
             ...(persistedTurnId ? { turnId: persistedTurnId } : {}),
             ...(runTrace ? { runTrace } : {}),
+            ...(recalled ? { recalled } : {}),
           };
         }
       }

--- a/middleware/packages/plugin-api/src/knowledgeGraph.ts
+++ b/middleware/packages/plugin-api/src/knowledgeGraph.ts
@@ -90,6 +90,20 @@ export interface KnowledgeGraph {
    */
   listPlansForScope(scope: string): Promise<GraphNode[]>;
   /**
+   * Cross-session plan recall — list `Plan` nodes tenant-wide (the team
+   * scope), optionally narrowed to a single `userId`, most-recent first
+   * (by `props.createdAt`). When `openOnly` is set, only plans that still
+   * have at least one `pending`/`in_progress` step are returned — i.e.
+   * unfinished work worth resuming. Powers the per-turn KG-recall probe;
+   * `listPlansForScope` is the single-session variant. `limit` is clamped
+   * to [1, 50] and defaults to 5.
+   */
+  listRecentPlans(opts: {
+    userId?: string;
+    limit?: number;
+    openOnly?: boolean;
+  }): Promise<GraphNode[]>;
+  /**
    * Structured run-subgraph for a single Turn: Run node + AgentInvocations
    * with their ToolCalls + orchestrator-level ToolCalls + produced entities.
    * Returns `null` when no Run has been ingested yet for the given turn.
@@ -655,6 +669,14 @@ export interface MemorableKnowledgeSearchOptions {
   limit?: number;
   /** Hits below this cosine similarity dropped. Default 0.3. */
   minSimilarity?: number;
+  /**
+   * Opt-in team-scope recall. When true, the ACL gate also admits rows
+   * whose `visibility` is `team` or `public` within the same tenant — not
+   * just rows the viewer directly owns via `acl_owners`. `visibility`
+   * `private` stays strictly owner-only regardless. Default false (the
+   * historical owner-only behaviour).
+   */
+  teamVisibility?: boolean;
 }
 
 /** Slice 7 — single MK hit from semantic search. */
@@ -670,6 +692,12 @@ export interface ExcerptSearchOptions {
   viewerOmadiaUserId: string;
   limit?: number;
   minSimilarity?: number;
+  /**
+   * Opt-in team-scope recall — mirrors
+   * {@link MemorableKnowledgeSearchOptions.teamVisibility}. The gate runs
+   * against the parent MK's `visibility`. Default false.
+   */
+  teamVisibility?: boolean;
 }
 
 /** Slice 7 — single excerpt hit, carries the parent-MK external_id

--- a/middleware/packages/plugin-api/src/knowledgeGraph.ts
+++ b/middleware/packages/plugin-api/src/knowledgeGraph.ts
@@ -708,6 +708,54 @@ export interface PalaiaExcerptHit {
   cosineSim: number;
 }
 
+// ---------------------------------------------------------------------------
+// Cross-session recall probe — structured payload of what the per-turn probe
+// surfaced from PRIOR sessions. Defined here (the lowest common type package)
+// so both the recall producer (@omadia/orchestrator-extras) and the
+// channel-facing answer contract (@omadia/channel-sdk · SemanticAnswer /
+// ChatTurnResult) can reference it without a circular dependency.
+// ---------------------------------------------------------------------------
+
+/** One resumable plan from a PRIOR session. `openStepGoals` are the goals of
+ *  its still-pending/in-progress steps. */
+export interface RecalledPlan {
+  /** External id `plan:<planId>`. */
+  planId: string;
+  scope: string;
+  strategy?: string;
+  createdAt?: string;
+  openStepGoals: string[];
+  doneCount: number;
+  totalCount: number;
+}
+
+/** One stored process matching the current message. */
+export interface RecalledProcess {
+  /** External id `process:<scope>:<slug>`. */
+  id: string;
+  title: string;
+  scope: string;
+  stepCount: number;
+  score: number;
+}
+
+/** One curated insight (MemorableKnowledge) recalled cross-session. */
+export interface RecalledInsight {
+  mkId: string;
+  kind: string;
+  summary: string;
+  score: number;
+}
+
+/** What the cross-session probe surfaced this turn. Empty arrays when a leg
+ *  found nothing or was disabled. Powers both the prompt-injected recall
+ *  blocks and the visible recall card / Teams Adaptive Card. */
+export interface RecalledContext {
+  plans: RecalledPlan[];
+  processes: RecalledProcess[];
+  insights: RecalledInsight[];
+}
+
 /** Slice 5 — partial content-patch on a MemorableKnowledge. All fields
  *  optional; `rationale: null` removes the field. */
 export interface MemorableKnowledgeUpdate {

--- a/middleware/test/recallProbe.test.ts
+++ b/middleware/test/recallProbe.test.ts
@@ -1,0 +1,313 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { EmbeddingClient } from '@omadia/embeddings';
+import { InMemoryKnowledgeGraph } from '@omadia/knowledge-graph-inmemory';
+import { ContextRetriever } from '@omadia/orchestrator-extras';
+import type {
+  ProcessMemoryService,
+  ProcessQueryHit,
+} from '@omadia/plugin-api';
+
+// Cross-session KG-recall probe — R0 (listRecentPlans), R1 (team-visibility
+// for curated-memory recall), R2 (ContextRetriever plan/process/insight legs).
+
+const ALIGNED: number[] = [1, 0, 0, 0];
+
+/** Embedding stub — every text maps to the same aligned vector so cosine ≈ 1
+ *  against a MK seeded with the same vector. */
+const stubEmbedder: EmbeddingClient = {
+  async embed(): Promise<number[]> {
+    return [...ALIGNED];
+  },
+};
+
+/** ProcessMemoryService stub — only `query` is exercised by the retriever. */
+function stubProcessMemory(
+  hits: readonly ProcessQueryHit[],
+): ProcessMemoryService {
+  return {
+    async query(): Promise<readonly ProcessQueryHit[]> {
+      return hits;
+    },
+  } as unknown as ProcessMemoryService;
+}
+
+describe('R0 · listRecentPlans', () => {
+  it('returns plans most-recent first, clamped to limit, tenant-wide', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    await kg.ingestPlan({
+      planId: 'p-old',
+      scope: 'sess-A',
+      createdAt: '2026-06-01T10:00:00.000Z',
+    });
+    await kg.ingestPlan({
+      planId: 'p-new',
+      scope: 'sess-B',
+      createdAt: '2026-06-01T12:00:00.000Z',
+    });
+    await kg.ingestPlan({
+      planId: 'p-mid',
+      scope: 'sess-C',
+      createdAt: '2026-06-01T11:00:00.000Z',
+    });
+
+    const all = await kg.listRecentPlans({ limit: 10 });
+    assert.deepEqual(
+      all.map((p) => p.props['planId']),
+      ['p-new', 'p-mid', 'p-old'],
+    );
+
+    const top1 = await kg.listRecentPlans({ limit: 1 });
+    assert.equal(top1.length, 1);
+    assert.equal(top1[0]!.props['planId'], 'p-new');
+  });
+
+  it('openOnly filters to plans with ≥1 pending/in_progress step', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    // Open plan: one done + one pending step.
+    await kg.ingestPlan({
+      planId: 'open',
+      scope: 'sess-A',
+      createdAt: '2026-06-01T10:00:00.000Z',
+    });
+    await kg.upsertPlanStep({
+      stepId: 'open-s1',
+      planId: 'open',
+      scope: 'sess-A',
+      goal: 'done step',
+      order: 0,
+      status: 'done',
+    });
+    await kg.upsertPlanStep({
+      stepId: 'open-s2',
+      planId: 'open',
+      scope: 'sess-A',
+      goal: 'pending step',
+      order: 1,
+      status: 'pending',
+    });
+    // Closed plan: all steps done.
+    await kg.ingestPlan({
+      planId: 'closed',
+      scope: 'sess-A',
+      createdAt: '2026-06-01T11:00:00.000Z',
+    });
+    await kg.upsertPlanStep({
+      stepId: 'closed-s1',
+      planId: 'closed',
+      scope: 'sess-A',
+      goal: 'all done',
+      order: 0,
+      status: 'done',
+    });
+
+    const open = await kg.listRecentPlans({ openOnly: true, limit: 10 });
+    assert.deepEqual(
+      open.map((p) => p.props['planId']),
+      ['open'],
+    );
+    const any = await kg.listRecentPlans({ openOnly: false, limit: 10 });
+    assert.equal(any.length, 2);
+  });
+
+  it('filters by userId when provided', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    await kg.ingestPlan({
+      planId: 'mine',
+      scope: 'sess-A',
+      userId: 'alice',
+      createdAt: '2026-06-01T10:00:00.000Z',
+    });
+    await kg.ingestPlan({
+      planId: 'theirs',
+      scope: 'sess-B',
+      userId: 'bob',
+      createdAt: '2026-06-01T11:00:00.000Z',
+    });
+
+    const mine = await kg.listRecentPlans({ userId: 'alice', limit: 10 });
+    assert.deepEqual(
+      mine.map((p) => p.props['planId']),
+      ['mine'],
+    );
+  });
+});
+
+describe('R1 · team-visibility for curated-memory recall', () => {
+  async function seedTeamMk(kg: InMemoryKnowledgeGraph): Promise<string> {
+    const created = await kg.createMemorableKnowledge({
+      kind: 'reference',
+      summary: 'shared team knowledge',
+      createdBy: 'web:bob',
+      involvedOmadiaUserIds: [],
+      aclOwners: ['bob'], // owned by bob, default (team) visibility
+    });
+    kg.setEmbedding(created.memorableKnowledgeNodeId, ALIGNED);
+    return created.memorableKnowledgeNodeId;
+  }
+
+  it('owner-only by default: a non-owner does NOT see a team MK', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    await seedTeamMk(kg);
+    const hits = await kg.searchMemorableKnowledgeByEmbedding({
+      queryEmbedding: ALIGNED,
+      viewerOmadiaUserId: 'alice', // not in acl_owners
+    });
+    assert.equal(hits.length, 0);
+  });
+
+  it('teamVisibility=true: a non-owner DOES see a team MK', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const mkId = await seedTeamMk(kg);
+    const hits = await kg.searchMemorableKnowledgeByEmbedding({
+      queryEmbedding: ALIGNED,
+      viewerOmadiaUserId: 'alice',
+      teamVisibility: true,
+    });
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0]!.mk.id, mkId);
+  });
+
+  it('owner still sees their own MK regardless of teamVisibility', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    await seedTeamMk(kg);
+    const hits = await kg.searchMemorableKnowledgeByEmbedding({
+      queryEmbedding: ALIGNED,
+      viewerOmadiaUserId: 'bob',
+    });
+    assert.equal(hits.length, 1);
+  });
+});
+
+describe('R2 · ContextRetriever cross-session recall legs', () => {
+  it('surfaces cross-session plans, processes, and team insights', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+
+    // Prior-session plan with one open step.
+    await kg.ingestPlan({
+      planId: 'prior',
+      scope: 'sess-prior',
+      strategy: 'Migrate the billing module',
+      createdAt: '2026-06-01T10:00:00.000Z',
+    });
+    await kg.upsertPlanStep({
+      stepId: 'prior-s1',
+      planId: 'prior',
+      scope: 'sess-prior',
+      goal: 'write migration',
+      order: 0,
+      status: 'done',
+    });
+    await kg.upsertPlanStep({
+      stepId: 'prior-s2',
+      planId: 'prior',
+      scope: 'sess-prior',
+      goal: 'run migration in staging',
+      order: 1,
+      status: 'pending',
+    });
+
+    // Team-visible insight owned by someone else.
+    const mk = await kg.createMemorableKnowledge({
+      kind: 'reference',
+      summary: 'staging DSN is in the vault under billing/staging',
+      createdBy: 'web:bob',
+      involvedOmadiaUserIds: [],
+      aclOwners: ['bob'],
+    });
+    kg.setEmbedding(mk.memorableKnowledgeNodeId, ALIGNED);
+
+    const processMemory = stubProcessMemory([
+      {
+        record: {
+          id: 'process:sess-x:backend-deploy',
+          scope: 'sess-x',
+          title: 'Backend: Deploy to staging',
+          steps: ['build', 'migrate', 'smoke'],
+          visibility: 'team',
+          version: 1,
+          createdAt: '2026-06-01T09:00:00.000Z',
+          updatedAt: '2026-06-01T09:00:00.000Z',
+        },
+        score: 0.82,
+      },
+    ]);
+
+    const retriever = new ContextRetriever(
+      kg,
+      { teamVisibility: true },
+      stubEmbedder,
+      undefined,
+      processMemory,
+    );
+
+    const result = await retriever.assembleForBudget({
+      userMessage: 'how do I deploy the billing migration to staging?',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now', // different from sess-prior
+      userId: 'alice',
+    });
+
+    assert.equal(result.recalled.plans.length, 1, 'one prior-session plan');
+    assert.equal(result.recalled.plans[0]!.openStepGoals.length, 1);
+    assert.equal(result.recalled.plans[0]!.doneCount, 1);
+    assert.equal(result.recalled.plans[0]!.totalCount, 2);
+
+    assert.equal(result.recalled.processes.length, 1, 'one stored process');
+    assert.equal(
+      result.recalled.processes[0]!.title,
+      'Backend: Deploy to staging',
+    );
+
+    assert.equal(result.recalled.insights.length, 1, 'one team insight');
+
+    // The recall blocks are prepended into the injected prompt text.
+    assert.match(result.text, /Aus früheren Sessions — offene Pläne/);
+    assert.match(result.text, /Aus früheren Sessions — gespeicherte Prozesse/);
+    assert.match(result.text, /Aus früheren Sessions — verwandte Erkenntnisse/);
+  });
+
+  it('excludes the current session’s own plan from recall', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    await kg.ingestPlan({
+      planId: 'current',
+      scope: 'sess-now',
+      createdAt: '2026-06-01T10:00:00.000Z',
+    });
+    await kg.upsertPlanStep({
+      stepId: 'current-s1',
+      planId: 'current',
+      scope: 'sess-now',
+      goal: 'do the thing',
+      order: 0,
+      status: 'pending',
+    });
+
+    const retriever = new ContextRetriever(kg, { teamVisibility: true });
+    const result = await retriever.assembleForBudget({
+      userMessage: 'continue',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    assert.equal(result.recalled.plans.length, 0);
+  });
+
+  it('empty recall legs leave the assembler output untouched', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const retriever = new ContextRetriever(kg, { teamVisibility: true });
+    const result = await retriever.assembleForBudget({
+      userMessage: 'hello',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    assert.deepEqual(result.recalled, {
+      plans: [],
+      processes: [],
+      insights: [],
+    });
+    assert.doesNotMatch(result.text, /Aus früheren Sessions/);
+  });
+});

--- a/middleware/test/recallProbe.test.ts
+++ b/middleware/test/recallProbe.test.ts
@@ -1,12 +1,15 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
+import { toSemanticAnswer } from '@omadia/channel-sdk';
+import type { ChatTurnResult } from '@omadia/channel-sdk';
 import type { EmbeddingClient } from '@omadia/embeddings';
 import { InMemoryKnowledgeGraph } from '@omadia/knowledge-graph-inmemory';
 import { ContextRetriever } from '@omadia/orchestrator-extras';
 import type {
   ProcessMemoryService,
   ProcessQueryHit,
+  RecalledContext,
 } from '@omadia/plugin-api';
 
 // Cross-session KG-recall probe — R0 (listRecentPlans), R1 (team-visibility
@@ -309,5 +312,47 @@ describe('R2 · ContextRetriever cross-session recall legs', () => {
       insights: [],
     });
     assert.doesNotMatch(result.text, /Aus früheren Sessions/);
+  });
+});
+
+describe('T1 · toSemanticAnswer forwards recalled (non-stream / Teams path)', () => {
+  const recalled: RecalledContext = {
+    plans: [
+      {
+        planId: 'plan:prior',
+        scope: 'sess-prior',
+        openStepGoals: ['ship it'],
+        doneCount: 1,
+        totalCount: 2,
+      },
+    ],
+    processes: [],
+    insights: [],
+  };
+
+  it('carries recalled onto the SemanticAnswer when non-empty', () => {
+    const result: ChatTurnResult = {
+      answer: 'hi',
+      toolCalls: 0,
+      iterations: 1,
+      recalled,
+    };
+    const answer = toSemanticAnswer(result);
+    assert.deepEqual(answer.recalled, recalled);
+  });
+
+  it('omits recalled when all legs are empty', () => {
+    const result: ChatTurnResult = {
+      answer: 'hi',
+      toolCalls: 0,
+      iterations: 1,
+      recalled: { plans: [], processes: [], insights: [] },
+    };
+    assert.equal(toSemanticAnswer(result).recalled, undefined);
+  });
+
+  it('omits recalled when absent', () => {
+    const result: ChatTurnResult = { answer: 'hi', toolCalls: 0, iterations: 1 };
+    assert.equal(toSemanticAnswer(result).recalled, undefined);
   });
 });

--- a/web-ui/app/_components/chat/RecalledContextCard.tsx
+++ b/web-ui/app/_components/chat/RecalledContextCard.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import type { RecalledContextSnapshot } from '../../_lib/chatSessions';
+
+/**
+ * Cross-session recall probe — inline card showing what the per-turn KG
+ * probe pulled from PRIOR sessions (open plans, stored processes, curated
+ * insights), rendered straight from the turn stream.
+ *
+ * The orchestrator emits a `turn_annotation` (channel `kg_recall`) carrying a
+ * {@link RecalledContextSnapshot} before the answer tokens. The chat store
+ * folds it onto `message.recalledContext`, so this is a pure render — no
+ * fetch, no poll. Collapsed by default (it's supporting context, not the
+ * answer). Returns null when every section is empty.
+ */
+
+interface Props {
+  recalled: RecalledContextSnapshot;
+}
+
+export function RecalledContextCard({
+  recalled,
+}: Props): React.ReactElement | null {
+  const t = useTranslations('recalledContext');
+
+  const { plans, processes, insights } = recalled;
+  if (plans.length === 0 && processes.length === 0 && insights.length === 0) {
+    return null;
+  }
+
+  return (
+    <details className="mb-2 rounded-md border border-sky-200 bg-sky-50/50 text-xs dark:border-sky-900/50 dark:bg-sky-950/20">
+      <summary className="flex cursor-pointer items-center gap-2 px-2.5 py-1.5 font-medium text-sky-700 dark:text-sky-300">
+        <span aria-hidden>🧠</span>
+        <span>{t('heading')}</span>
+        <span className="font-normal text-sky-500 dark:text-sky-400">
+          {t('summary', {
+            plans: plans.length,
+            processes: processes.length,
+            insights: insights.length,
+          })}
+        </span>
+      </summary>
+      <div className="flex flex-col gap-2 px-2.5 pb-2 pt-0.5">
+        {plans.length > 0 && (
+          <section>
+            <h4 className="text-[10px] uppercase tracking-wide text-sky-600 dark:text-sky-400">
+              {t('plansHeading')}
+            </h4>
+            <ul className="flex flex-col gap-0.5">
+              {plans.map((p) => (
+                <li
+                  key={p.planId}
+                  className="text-neutral-700 dark:text-neutral-300"
+                >
+                  {p.strategy ? `${p.strategy} — ` : ''}
+                  <span className="text-neutral-400 dark:text-neutral-500">
+                    {t('stepsProgress', {
+                      done: p.doneCount,
+                      total: p.totalCount,
+                    })}
+                  </span>
+                  {p.openStepGoals.length > 0 && (
+                    <span>
+                      {' · '}
+                      {t('openLabel')}: {p.openStepGoals.join('; ')}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+        {processes.length > 0 && (
+          <section>
+            <h4 className="text-[10px] uppercase tracking-wide text-sky-600 dark:text-sky-400">
+              {t('processesHeading')}
+            </h4>
+            <ul className="flex flex-col gap-0.5">
+              {processes.map((pr) => (
+                <li
+                  key={pr.id}
+                  className="text-neutral-700 dark:text-neutral-300"
+                >
+                  {pr.title}{' '}
+                  <span className="text-neutral-400 dark:text-neutral-500">
+                    ({t('stepCount', { count: pr.stepCount })})
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+        {insights.length > 0 && (
+          <section>
+            <h4 className="text-[10px] uppercase tracking-wide text-sky-600 dark:text-sky-400">
+              {t('insightsHeading')}
+            </h4>
+            <ul className="flex flex-col gap-0.5">
+              {insights.map((ins) => (
+                <li
+                  key={ins.mkId}
+                  className="text-neutral-700 dark:text-neutral-300"
+                >
+                  <span className="text-neutral-400 dark:text-neutral-500">
+                    {ins.kind}:
+                  </span>{' '}
+                  {ins.summary}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+      </div>
+    </details>
+  );
+}

--- a/web-ui/app/_lib/chatSessions.ts
+++ b/web-ui/app/_lib/chatSessions.ts
@@ -222,6 +222,40 @@ export interface PlanSnapshot {
   steps: PlanStepSnapshot[];
 }
 
+/** Cross-session recall probe — payload of the `kg_recall` turn_annotation.
+ *  Mirrors the middleware's `RecalledContext` (crosses the boundary as
+ *  `unknown`). Surfaces what the per-turn probe pulled from PRIOR sessions. */
+export interface RecalledPlanSnapshot {
+  planId: string;
+  scope: string;
+  strategy?: string;
+  createdAt?: string;
+  openStepGoals: string[];
+  doneCount: number;
+  totalCount: number;
+}
+
+export interface RecalledProcessSnapshot {
+  id: string;
+  title: string;
+  scope: string;
+  stepCount: number;
+  score: number;
+}
+
+export interface RecalledInsightSnapshot {
+  mkId: string;
+  kind: string;
+  summary: string;
+  score: number;
+}
+
+export interface RecalledContextSnapshot {
+  plans: RecalledPlanSnapshot[];
+  processes: RecalledProcessSnapshot[];
+  insights: RecalledInsightSnapshot[];
+}
+
 export interface Message {
   id: string;
   role: 'user' | 'assistant';
@@ -230,6 +264,10 @@ export interface Message {
    *  annotation: present from the first event and re-emitted on every step
    *  change + replan. Persisted, so a reloaded session keeps the plan. */
   plan?: PlanSnapshot;
+  /** Cross-session recall probe — plans/processes/insights the per-turn probe
+   *  pulled from PRIOR sessions, streamed in as a `kg_recall` annotation
+   *  before the answer. Persisted with the turn. */
+  recalledContext?: RecalledContextSnapshot;
   /** KG-persisted Turn external_id (e.g. `turn:<sessionId>:<ts>`). Set
    *  from the orchestrator's `done` event when session-logging succeeded.
    *  Drives the save-as-memory affordance — without it there's no

--- a/web-ui/app/_lib/chatStreamEvents.ts
+++ b/web-ui/app/_lib/chatStreamEvents.ts
@@ -11,6 +11,7 @@ import type {
   PendingUserChoice,
   PlanSnapshot,
   PrivacyReceipt,
+  RecalledContextSnapshot,
   SubAgentEvent,
   ToolEvent,
   UseChatSessionsResult,
@@ -156,6 +157,14 @@ function foldIntoMessage(m: Message, event: ChatStreamEvent): Message {
       // we just replace, so the card reflects the latest state.
       if (event.channel === 'plan' && event.payload) {
         return { ...m, plan: event.payload as PlanSnapshot };
+      }
+      // Cross-session recall probe — what the per-turn probe pulled from
+      // prior sessions. Emitted once, before the answer.
+      if (event.channel === 'kg_recall' && event.payload) {
+        return {
+          ...m,
+          recalledContext: event.payload as RecalledContextSnapshot,
+        };
       }
       return m;
     case 'tool_use': {

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -18,6 +18,7 @@ import { CaptureDisclosure } from './_components/chat/CaptureDisclosure';
 import { ConfirmDialog } from './_components/ConfirmDialog';
 import { NudgeCard, parseNudgeBlock } from './_components/chat/NudgeCard';
 import { PlanProgressCard } from './_components/chat/PlanProgressCard';
+import { RecalledContextCard } from './_components/chat/RecalledContextCard';
 import { PrivacyReceiptCard } from './_components/chat/PrivacyReceiptCard';
 import { SaveMemoryButton } from './_components/chat/SaveMemoryButton';
 import { Markdown } from './_components/Markdown';
@@ -472,6 +473,9 @@ function MessageRow({
           <div className="whitespace-pre-wrap text-sm">{message.content}</div>
         ) : (
           <>
+            {message.recalledContext && (
+              <RecalledContextCard recalled={message.recalledContext} />
+            )}
             {message.plan && (
               <PlanProgressCard
                 plan={message.plan}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -8,6 +8,16 @@
     "statusFailed": "fehlgeschlagen",
     "statusSkipped": "übersprungen"
   },
+  "recalledContext": {
+    "heading": "Aus früheren Sessions",
+    "summary": "{plans} Pläne · {processes} Prozesse · {insights} Erkenntnisse",
+    "plansHeading": "Offene Pläne",
+    "processesHeading": "Gespeicherte Prozesse",
+    "insightsHeading": "Verwandte Erkenntnisse",
+    "stepsProgress": "{done}/{total} Schritte erledigt",
+    "stepCount": "{count} Schritte",
+    "openLabel": "offen"
+  },
   "nav": {
     "chat": "Chat",
     "store": "Store",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -8,6 +8,16 @@
     "statusFailed": "failed",
     "statusSkipped": "skipped"
   },
+  "recalledContext": {
+    "heading": "From earlier sessions",
+    "summary": "{plans} plans · {processes} processes · {insights} insights",
+    "plansHeading": "Open plans",
+    "processesHeading": "Saved processes",
+    "insightsHeading": "Related insights",
+    "stepsProgress": "{done}/{total} steps done",
+    "stepCount": "{count} steps",
+    "openLabel": "open"
+  },
   "nav": {
     "chat": "Chat",
     "store": "Store",


### PR DESCRIPTION
## Cross-Session KG-Recall Probe

Starting a new session previously surfaced no prior-session knowledge. The per-turn probe (`retrievePriorContext` → `ContextRetriever.assembleForBudget`) now recalls relevant **plans, processes, and (team-visible) insights** from earlier sessions every turn — injecting them into the prompt **and** showing them as an "Aus früheren Sessions" card (🧠) above the answer.

### What's included
- **Plan recall** — new `KnowledgeGraph.listRecentPlans({ userId?, limit, openOnly })`: cross-session, tenant-wide, with open-step roll-up. Interface + neon + inmemory + 3 decorator wrappers.
- **Process recall** — `ContextRetriever` now consumes `ProcessMemoryService.query` (BM25/embedding hybrid).
- **Team-scoped insights** — `searchMemorableKnowledgeByEmbedding` / `searchExcerptsByEmbedding` gain an opt-in `teamVisibility` flag that admits `team`/`public` MemorableKnowledge tenant-wide; `private` stays owner-only. Also fixes that the budget assembler never loaded the curated-memory leg at all.
- **Two new ContextRetriever legs** (`loadPlanHits`, `loadProcessHits`) folded into `assembleForBudget` as budget-reserved recall blocks; structured `recalled` payload.
- **Surfacing** — the orchestrator emits a `kg_recall` turn annotation; the web-ui renders `RecalledContextCard`.
- **Config-gated** (`kg_recall_*`), `teamVisibility` defaults on.

### Scope model
"Team" = `tenant_id`-wide (no human-team model needed). `private` stays protected; toggle off via `kg_recall_team_visibility=false`.

### No migration
Pure code — reuses the existing `visibility` column (migration 0007) and existing Plan nodes (#133).

### Tests / verification
- 9 new tests (`middleware/test/recallProbe.test.ts`) for R0/R1/R2.
- Full suite: **2793/2793** green.
- Typecheck (middleware + web-ui) + `lint:fix` clean.
- Verified in prod: the card renders correctly (plans + insights).
