### PR TITLE
fix(orchestrator-extras): relevance-filter cross-session plan recall

### DIFF
--- a/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
@@ -723,54 +723,81 @@ export class ContextRetriever {
   }
 
   /**
-   * Cross-session recall probe — resumable plans from PRIOR sessions.
-   * Tenant-wide (the team scope) recency-ordered; the current session's own
-   * plan is excluded (the tail already covers it). Plans carry no embedding,
-   * so this leg is recency/open-based rather than semantic. On any error
-   * returns [] — a degraded recall path must not kill the turn.
+   * Cross-session recall probe — resumable plans from PRIOR sessions,
+   * **relevance-filtered** against the current message. Tenant-wide (the team
+   * scope); the current session's own plan is excluded (the tail covers it).
+   *
+   * Plans carry no embedding, so relevance is lexical: a plan only surfaces
+   * when its text (strategy + step goals) shares a candidate term with the
+   * user message — the same term extractor the entity leg uses. Recency alone
+   * is wrong (a question about onboarding must not resurface last week's
+   * diagram plan); ranked by term-overlap, recency as the tiebreak. When the
+   * message yields no candidate terms (a bare "weiter") we fall back to
+   * recency so a contentless continuation still resumes recent open work.
+   * On any error returns [] — a degraded recall path must not kill the turn.
    */
   private async loadPlanHits(
     input: ContextBuildInput,
   ): Promise<RecalledPlan[]> {
     if (this.opts.planRecallDisabled) return [];
     const limit = Math.max(1, this.opts.planLimit);
+    const terms = extractCandidateTerms(input.userMessage).map((t) =>
+      t.toLowerCase(),
+    );
     try {
-      // Over-fetch a little so dropping the current-session plan still leaves
-      // a full page of cross-session plans.
+      // Over-fetch a wider candidate window so the relevance filter has
+      // something to choose from (recency-only would pick the latest N).
       const plans = await this.graph.listRecentPlans({
-        limit: limit + 2,
+        limit: Math.max(limit * 4, 12),
         openOnly: this.opts.planOpenOnly,
       });
-      const crossSession = plans.filter(
-        (p) => p.props['scope'] !== input.sessionScope,
-      );
-      const out: RecalledPlan[] = [];
-      for (const p of crossSession.slice(0, limit)) {
+      const scored: Array<{ hit: RecalledPlan; score: number }> = [];
+      for (const p of plans) {
+        if (p.props['scope'] === input.sessionScope) continue; // cross-session only
         const steps = await this.graph.getPlanSteps(p.id);
         const openStepGoals: string[] = [];
+        const goalTexts: string[] = [];
         let doneCount = 0;
         for (const s of steps) {
           const status = s.props['status'];
+          const goal = String(s.props['goal'] ?? '');
+          if (goal.length > 0) goalTexts.push(goal);
           if (status === 'done') doneCount += 1;
           else if (status === 'pending' || status === 'in_progress') {
-            openStepGoals.push(String(s.props['goal'] ?? ''));
+            if (goal.length > 0) openStepGoals.push(goal);
           }
         }
-        out.push({
-          planId: p.id,
-          scope: String(p.props['scope'] ?? ''),
-          ...(typeof p.props['strategy'] === 'string'
-            ? { strategy: p.props['strategy'] }
-            : {}),
-          ...(typeof p.props['createdAt'] === 'string'
-            ? { createdAt: p.props['createdAt'] }
-            : {}),
-          openStepGoals: openStepGoals.filter((g) => g.length > 0),
-          doneCount,
-          totalCount: steps.length,
+        // Relevance = how many query terms appear in strategy + step goals.
+        const haystack =
+          `${String(p.props['strategy'] ?? '')} ${goalTexts.join(' ')}`.toLowerCase();
+        const score =
+          terms.length === 0
+            ? 0
+            : terms.filter((t) => haystack.includes(t)).length;
+        // Drop topically-unrelated plans. With no query terms (bare
+        // continuation) every plan scores 0 → keep the recency fallback.
+        if (terms.length > 0 && score === 0) continue;
+        scored.push({
+          hit: {
+            planId: p.id,
+            scope: String(p.props['scope'] ?? ''),
+            ...(typeof p.props['strategy'] === 'string'
+              ? { strategy: p.props['strategy'] }
+              : {}),
+            ...(typeof p.props['createdAt'] === 'string'
+              ? { createdAt: p.props['createdAt'] }
+              : {}),
+            openStepGoals,
+            doneCount,
+            totalCount: steps.length,
+          },
+          score,
         });
       }
-      return out;
+      // Rank by term-overlap DESC; `listRecentPlans` already returned
+      // createdAt-desc, so a stable sort keeps recency as the tiebreak.
+      scored.sort((a, b) => b.score - a.score);
+      return scored.slice(0, limit).map((s) => s.hit);
     } catch (err) {
       console.error(
         '[context:plan] plan recall failed — continuing without:',

--- a/middleware/test/recallProbe.test.ts
+++ b/middleware/test/recallProbe.test.ts
@@ -315,6 +315,108 @@ describe('R2 · ContextRetriever cross-session recall legs', () => {
   });
 });
 
+describe('R6 · relevance-filtered plan recall', () => {
+  async function seedVacationPlan(kg: InMemoryKnowledgeGraph): Promise<void> {
+    // A prior-session plan about VACATION RULES with an open mermaid step.
+    await kg.ingestPlan({
+      planId: 'vacation',
+      scope: 'sess-vacation',
+      strategy: 'Urlaubsregeln zusammenfassen',
+      createdAt: '2026-06-01T10:00:00.000Z',
+    });
+    await kg.upsertPlanStep({
+      stepId: 'vac-s1',
+      planId: 'vacation',
+      scope: 'sess-vacation',
+      goal: 'Die drei wichtigsten Punkte herausarbeiten',
+      order: 0,
+      status: 'done',
+    });
+    await kg.upsertPlanStep({
+      stepId: 'vac-s2',
+      planId: 'vacation',
+      scope: 'sess-vacation',
+      goal: 'Erstelle ein Mermaid-Diagramm der drei wichtigsten Punkte',
+      order: 1,
+      status: 'pending',
+    });
+  }
+
+  it('does NOT surface a topically-unrelated open plan (the reported bug)', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    await seedVacationPlan(kg);
+    const retriever = new ContextRetriever(kg, { teamVisibility: true });
+    const result = await retriever.assembleForBudget({
+      userMessage: 'Wo waren wir beim Mitarbeiter-Onboarding in Odoo?',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    assert.equal(result.recalled.plans.length, 0);
+  });
+
+  it('surfaces an open plan when the query shares a term with it', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    await seedVacationPlan(kg);
+    const retriever = new ContextRetriever(kg, { teamVisibility: true });
+    const result = await retriever.assembleForBudget({
+      userMessage: 'Wie waren nochmal die Urlaubsregeln?',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    assert.equal(result.recalled.plans.length, 1);
+    assert.equal(result.recalled.plans[0]!.planId, 'plan:vacation');
+  });
+
+  it('ranks the more-relevant plan first (term-overlap count)', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    // Two plans; the query "Rechnung Odoo buchen" overlaps 1 vs 2 terms.
+    await kg.ingestPlan({
+      planId: 'one',
+      scope: 'sess-a',
+      strategy: 'Rechnung erfassen',
+      createdAt: '2026-06-01T12:00:00.000Z',
+    });
+    await kg.upsertPlanStep({
+      stepId: 'one-s1', planId: 'one', scope: 'sess-a',
+      goal: 'Rechnung anlegen', order: 0, status: 'pending',
+    });
+    await kg.ingestPlan({
+      planId: 'two',
+      scope: 'sess-b',
+      strategy: 'Rechnung in Odoo buchen',
+      createdAt: '2026-06-01T11:00:00.000Z', // older, but more relevant
+    });
+    await kg.upsertPlanStep({
+      stepId: 'two-s1', planId: 'two', scope: 'sess-b',
+      goal: 'Buchung in Odoo durchführen', order: 0, status: 'pending',
+    });
+    const retriever = new ContextRetriever(kg, { teamVisibility: true });
+    const result = await retriever.assembleForBudget({
+      userMessage: 'Rechnung in Odoo buchen — wo standen wir?',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    assert.equal(result.recalled.plans[0]!.planId, 'plan:two'); // 3 terms > 1
+  });
+
+  it('falls back to recency when the message has no candidate terms', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    await seedVacationPlan(kg);
+    const retriever = new ContextRetriever(kg, { teamVisibility: true });
+    // "ok" / punctuation only → no extractable terms → recency fallback.
+    const result = await retriever.assembleForBudget({
+      userMessage: 'ok?',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    assert.equal(result.recalled.plans.length, 1);
+  });
+});
+
 describe('T1 · toSemanticAnswer forwards recalled (non-stream / Teams path)', () => {
   const recalled: RecalledContext = {
     plans: [


### PR DESCRIPTION
## Relevance filter for cross-session plan recall

Follow-up fix to #189. During the live Teams test the "Aus früheren Sessions" card showed a topically-unrelated open plan: a question about employee onboarding surfaced the open "Mermaid diagram of the vacation rules" plan — because plan recall was **recency-only** (most recent open plan, regardless of topic). The card then contradicted the agent's honest "no matching thread" answer.

### Fix
`loadPlanHits` now filters by **relevance**: a plan only surfaces when its text (strategy + step goals) shares a candidate term with the user message (the same `extractCandidateTerms` the entity leg uses). Ranked by term overlap, recency as the tiebreak.

- Plans have no embedding → relevance is **lexical** (deterministic, no per-turn embedding call).
- **Bare-continuation fallback:** if the message yields no candidate terms (e.g. just "weiter"), the recency fallback is kept so a contentless continuation still resumes recent open work.
- Topically-unrelated plans (zero term overlap) are dropped → no more misleading card.

### Tests
+4 tests (`R6`), incl. the reported case: an onboarding query no longer surfaces the vacation-rules plan; a matching term surfaces it; ranking by overlap; recency fallback without terms. Full suite green; typecheck (orchestrator-extras) clean.

### Known limitation / follow-up
Lexical ⇒ synonyms won't match (query "approval process" vs plan "request workflow"). A semantic upgrade — embedding-at-ingest on the Plan node (`graph_nodes` already has an `embedding` column) + `searchPlansByEmbedding`, instead of a per-turn embedding storm — is deliberately deferred to a separate slice.
