### PR TITLE
feat(plugins): localized third-party setup guides (setup.guide)

### DIFF
--- a/middleware/packages/harness-plugin-web-search/manifest.yaml
+++ b/middleware/packages/harness-plugin-web-search/manifest.yaml
@@ -31,6 +31,49 @@ lifecycle:
 # filling the new key, and re-installing.
 # ---------------------------------------------------------------------------
 setup:
+  guide:
+    en: |
+      ## Get a web-search API key
+
+      This plugin needs an API key from **one** search provider. Pick the
+      provider below and fill in **only** its key.
+
+      ### Option A — Tavily (default, built for AI)
+      1. Create an account at [tavily.com](https://tavily.com).
+      2. **Dashboard → API Keys → Create** → copy the key.
+      3. Keep **Search provider** = *Tavily* below, paste the key into **Tavily API key**.
+
+      Tavily returns structured snippets and optionally extracted full text —
+      ideal for agents. A free tier is available to get started.
+
+      ### Option B — Brave Search (independent crawler)
+      1. Register at [api-dashboard.search.brave.com](https://api-dashboard.search.brave.com).
+      2. Subscribe to a plan (free tier available) → copy the **Subscription Token**.
+      3. Set **Search provider** = *Brave Search* below, paste the token into **Brave Search API key**.
+
+      > The key is stored encrypted in the vault. Use **Cache TTL** to protect
+      > your request quota: higher values = fewer API calls.
+    de: |
+      ## Web-Search-API-Key besorgen
+
+      Dieses Plugin braucht einen API-Key **eines** Such-Providers. Wähle unten
+      den Provider und fülle **nur** den dazugehörigen Key aus.
+
+      ### Option A — Tavily (Standard, für KI gebaut)
+      1. Konto erstellen auf [tavily.com](https://tavily.com).
+      2. **Dashboard → API Keys → Create** → Key kopieren.
+      3. Unten **Search-Provider** = *Tavily* lassen, Key in **Tavily API-Key** einsetzen.
+
+      Tavily liefert strukturierte Snippets und optional extrahierten Volltext —
+      ideal für Agenten. Kostenloses Kontingent für den Einstieg vorhanden.
+
+      ### Option B — Brave Search (unabhängiger Crawler)
+      1. Registrieren auf [api-dashboard.search.brave.com](https://api-dashboard.search.brave.com).
+      2. Einen Plan abonnieren (Free-Tier verfügbar) → **Subscription Token** kopieren.
+      3. Unten **Search-Provider** = *Brave Search* wählen, Token in **Brave Search API-Key** einsetzen.
+
+      > Der Key wird verschlüsselt im Vault gespeichert. Über **Cache-TTL** schonst
+      > du dein Anfrage-Kontingent: höhere Werte = weniger API-Calls.
   fields:
     - key: "provider"
       type: "enum"

--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -175,6 +175,13 @@ export interface ChannelManifestBlock {
   canvas_protocol_version?: string;
 }
 
+/**
+ * A short piece of UI text available in several languages, keyed by locale
+ * (`en`, `de`, …). Used for the manifest-declared `setup.guide`. The renderer
+ * picks the active locale and falls back to another when it is missing.
+ */
+export type LocalizedMarkdown = Record<string, string>;
+
 export interface Plugin {
   id: AgentId;
   kind: PluginKind;
@@ -267,6 +274,16 @@ export interface Plugin {
    * a later privacy workstream; not enforced today. Defaults to `default`.
    */
   privacy_class: 'strict' | 'default';
+  /**
+   * Localized markdown installation guide for the plugin's third-party system,
+   * declared in the manifest's `setup.guide` as a `{ <locale>: markdown }` map
+   * (e.g. `{ en, de }`). Answers "how do I get this running" questions (create
+   * a Discord bot, register an Azure AD app, …). Optional; the UI picks the
+   * active-locale string (falling back to another locale) and renders it as
+   * markdown on the store detail page and in the install drawer. Display-only —
+   * never parsed for behaviour.
+   */
+  setup_guide?: LocalizedMarkdown;
 }
 
 /**

--- a/middleware/src/api/registry-v1.ts
+++ b/middleware/src/api/registry-v1.ts
@@ -14,7 +14,7 @@
 // `GET /registry/index.json` implementation.
 // ===========================================================================
 
-import type { ISO8601, PluginKind } from './admin-v1.js';
+import type { ISO8601, LocalizedMarkdown, PluginKind } from './admin-v1.js';
 
 /** A single installable version of a plugin, as advertised by a registry. */
 export interface RegistryVersionEntry {
@@ -43,6 +43,12 @@ export interface RegistryManifestSummary {
   /** Setup fields the operator must fill at install-time. Mirrors
    *  `PluginSetupField` but kept loose here to avoid a hard schema coupling. */
   setup_fields?: Array<Record<string, unknown>>;
+  /** Localized markdown installation guide for the plugin's third-party system
+   *  (e.g. "how to create a Discord bot", "how to get Microsoft 365
+   *  credentials"). A `{ <locale>: markdown }` map from the manifest's
+   *  `setup.guide`. Display-only — rendered on the hub detail page and the
+   *  Omadia store; never parsed for behaviour. */
+  setup_guide?: LocalizedMarkdown;
   permissions?: Record<string, unknown>;
 }
 

--- a/middleware/src/plugins/manifestLoader.ts
+++ b/middleware/src/plugins/manifestLoader.ts
@@ -304,6 +304,8 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
   const privacyClass: 'strict' | 'default' =
     privacyClassRaw === 'strict' ? 'strict' : 'default';
 
+  const setupGuide = asLocalizedGuide(setup?.['guide']);
+
   const base: Plugin = {
     id,
     kind,
@@ -331,6 +333,7 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
     privacy_class: privacyClass,
   };
   let result: Plugin = base;
+  if (setupGuide) result = { ...result, setup_guide: setupGuide };
   if (channel) result = { ...result, channel };
   if (adminUiPath) result = { ...result, admin_ui_path: adminUiPath };
   if (isReferenceOnly) result = { ...result, is_reference_only: true };
@@ -610,6 +613,26 @@ function asArray(value: unknown): unknown[] {
 
 function asString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Normalise a manifest `setup.guide` into a `{ <locale>: markdown }` map.
+ * Accepts the canonical object form (`{ en: "…", de: "…" }`) and tolerates a
+ * bare string (treated as English). Empty strings and non-string values are
+ * dropped; returns undefined when nothing usable remains.
+ */
+function asLocalizedGuide(value: unknown): Record<string, string> | undefined {
+  if (typeof value === 'string') {
+    const s = value.trim();
+    return s.length > 0 ? { en: value } : undefined;
+  }
+  const rec = asRecord(value);
+  if (!rec) return undefined;
+  const out: Record<string, string> = {};
+  for (const [locale, text] of Object.entries(rec)) {
+    if (typeof text === 'string' && text.trim().length > 0) out[locale] = text;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 function extractStringArray(value: unknown): string[] {

--- a/middleware/src/routes/store.ts
+++ b/middleware/src/routes/store.ts
@@ -328,6 +328,10 @@ function registryEntryToPlugin(resolved: ResolvedRegistryPlugin): Plugin {
   const setupFields = Array.isArray(summary.setup_fields)
     ? (summary.setup_fields as unknown as PluginSetupField[])
     : [];
+  const setupGuide =
+    summary.setup_guide && Object.keys(summary.setup_guide).length > 0
+      ? summary.setup_guide
+      : undefined;
 
   return {
     id: entry.id,
@@ -354,6 +358,7 @@ function registryEntryToPlugin(resolved: ResolvedRegistryPlugin): Plugin {
     requires: Array.isArray(summary.requires) ? summary.requires : [],
     multi_instance: true,
     privacy_class: 'default',
+    ...(setupGuide ? { setup_guide: setupGuide } : {}),
     source: registrySource(resolved),
   };
 }

--- a/middleware/test/registryInstallMerge.test.ts
+++ b/middleware/test/registryInstallMerge.test.ts
@@ -258,6 +258,96 @@ describe('store router · detail resolves a remote-only plugin (C3)', () => {
   });
 });
 
+describe('store router · setup_guide flows from the registry manifest_summary', () => {
+  const GUIDE = {
+    en: '## Create a Discord bot\n1. Open the Developer Portal …',
+    de: '## Discord-Bot anlegen\n1. Developer Portal öffnen …',
+  };
+
+  function indexWithGuide(): string {
+    return JSON.stringify({
+      schema_version: '1',
+      registry: { name: 'omadia-public', url: HUB },
+      generated_at: '2026-06-03T12:00:00Z',
+      plugins: [
+        {
+          id: '@omadia/channel-discord',
+          name: 'Discord',
+          kind: 'channel',
+          domain: 'discord',
+          description: 'Discord channel',
+          categories: ['communication'],
+          authors: [{ name: 'byte5' }],
+          license: 'MIT',
+          icon_url: null,
+          latest_version: '0.1.0',
+          versions: [
+            {
+              version: '0.1.0',
+              compat_core: '>=1.0 <2.0',
+              sha256: ZIP_SHA,
+              size_bytes: 1,
+              download_url: `${HUB}/registry/@omadia/channel-discord/0.1.0/plugin.zip`,
+              published_at: '2026-06-03T11:00:00Z',
+              manifest_summary: {
+                setup_fields: [
+                  { key: 'discord_bot_token', type: 'secret', label: 'Token', required: true },
+                ],
+                setup_guide: GUIDE,
+              },
+            },
+          ],
+        },
+      ],
+    });
+  }
+
+  it('GET /:id surfaces plugin.setup_guide for a hub-only plugin', async () => {
+    const client = new RegistryClient({
+      registries: [{ name: 'omadia-public', url: HUB }],
+      log: () => {},
+      fetchImpl: mockFetch({
+        [`${HUB}/registry/index.json`]: () => new Response(indexWithGuide()),
+      }),
+    });
+    const app = express();
+    app.use('/store', createStoreRouter({ catalog: fakeCatalog([]), registry: fakeRegistry, client }));
+    const server = app.listen(0);
+    const base = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}/store`;
+    try {
+      const res = await fetch(`${base}/${encodeURIComponent('@omadia/channel-discord')}`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as { plugin: Plugin };
+      assert.deepEqual(body.plugin.setup_guide, GUIDE);
+      assert.equal(body.plugin.required_secrets.length, 1);
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
+  it('omits setup_guide when the registry advertises none', async () => {
+    const client = new RegistryClient({
+      registries: [{ name: 'omadia-public', url: HUB }],
+      log: () => {},
+      fetchImpl: mockFetch({
+        [`${HUB}/registry/index.json`]: () => new Response(indexJson()),
+      }),
+    });
+    const app = express();
+    app.use('/store', createStoreRouter({ catalog: fakeCatalog([]), registry: fakeRegistry, client }));
+    const server = app.listen(0);
+    const base = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}/store`;
+    try {
+      const res = await fetch(`${base}/${encodeURIComponent('@omadia/plugin-office')}`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as { plugin: Plugin };
+      assert.equal(body.plugin.setup_guide, undefined);
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+});
+
 // --- C6: update detection --------------------------------------------------
 
 function fakeInstalled(map: Record<string, string>): InstalledRegistry {

--- a/middleware/test/setupGuide.test.ts
+++ b/middleware/test/setupGuide.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { adaptManifestV1 } from '../src/plugins/manifestLoader.js';
+
+// The manifest's `setup.guide` (a `{ <locale>: markdown }` map) must reach the
+// store `Plugin` so the web-ui can render a localized third-party installation
+// guide. This covers the LOCAL plugin path (adaptManifestV1); the
+// remote/registry path is covered in registryInstallMerge.test.ts.
+
+function baseManifest(setup: Record<string, unknown>): Record<string, unknown> {
+  return {
+    schema_version: '1',
+    identity: {
+      id: '@omadia/channel-discord',
+      name: 'Discord',
+      version: '0.1.0',
+      kind: 'channel',
+      domain: 'discord',
+    },
+    compat: { core: '>=1.0 <2.0' },
+    setup,
+  };
+}
+
+describe('adaptManifestV1 · setup.guide', () => {
+  it('lifts a localized setup.guide map onto Plugin.setup_guide', () => {
+    const guide = {
+      en: '## Create a Discord bot\n1. Open the Developer Portal',
+      de: '## Discord-Bot anlegen\n1. Developer Portal öffnen',
+    };
+    const plugin = adaptManifestV1(
+      baseManifest({
+        guide,
+        fields: [
+          { key: 'discord_bot_token', type: 'secret', label: 'Token', required: true },
+        ],
+      }),
+    );
+    assert.ok(plugin);
+    assert.deepEqual(plugin.setup_guide, guide);
+    // Coexists with the existing per-field hints.
+    assert.equal(plugin.required_secrets.length, 1);
+  });
+
+  it('drops empty-string locales and keeps the rest', () => {
+    const plugin = adaptManifestV1(
+      baseManifest({ guide: { en: 'real guide', de: '   ' }, fields: [] }),
+    );
+    assert.ok(plugin);
+    assert.deepEqual(plugin.setup_guide, { en: 'real guide' });
+  });
+
+  it('tolerates a bare string by treating it as English', () => {
+    const plugin = adaptManifestV1(
+      baseManifest({ guide: '## Just one language', fields: [] }),
+    );
+    assert.ok(plugin);
+    assert.deepEqual(plugin.setup_guide, { en: '## Just one language' });
+  });
+
+  it('leaves setup_guide undefined when the manifest declares none', () => {
+    const plugin = adaptManifestV1(baseManifest({ fields: [] }));
+    assert.ok(plugin);
+    assert.equal(plugin.setup_guide, undefined);
+  });
+
+  it('treats an all-empty guide map as absent', () => {
+    const plugin = adaptManifestV1(baseManifest({ guide: { en: '', de: '' }, fields: [] }));
+    assert.ok(plugin);
+    assert.equal(plugin.setup_guide, undefined);
+  });
+});

--- a/web-ui/app/_components/store/InstallButton.tsx
+++ b/web-ui/app/_components/store/InstallButton.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useLocale } from 'next-intl';
 import {
   ArrowRight,
   Check,
@@ -28,9 +29,12 @@ import type {
   InstallJob,
   InstallSetupField,
   InstallValidationError,
+  LocalizedMarkdown,
 } from '../../_lib/storeTypes';
+import { pickLocalized } from '../../_lib/localized';
 import { RequiresWizard } from './RequiresWizard';
 import { FieldRow, extractValues } from './setupForm';
+import { Markdown } from '../Markdown';
 
 interface InstallButtonProps {
   pluginId: string;
@@ -47,6 +51,11 @@ interface InstallButtonProps {
   /** C6 — the newer version a registry advertises, when
    *  `installState === 'update-available'`. */
   availableVersion?: string;
+  /** Localized markdown setup guide from the manifest (`setup.guide`). When
+   *  present, the active-locale string is rendered at the top of the install
+   *  drawer, above the credential fields, so the operator sees how to obtain
+   *  those values before filling them in. */
+  setupGuide?: LocalizedMarkdown;
 }
 
 type Phase =
@@ -67,8 +76,11 @@ export function InstallButton({
   remote = false,
   installedVersion,
   availableVersion,
+  setupGuide,
 }: InstallButtonProps): React.ReactElement {
   const router = useRouter();
+  const locale = useLocale();
+  const setupGuideText = pickLocalized(setupGuide, locale);
   const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
   const [fieldErrors, setFieldErrors] = useState<
     Record<string, string>
@@ -171,6 +183,7 @@ export function InstallButton({
           fieldErrors={fieldErrors}
           onClose={handleClose}
           onSubmit={handleSubmit}
+          {...(setupGuideText ? { setupGuide: setupGuideText } : {})}
         />
       ) : null}
 
@@ -550,6 +563,8 @@ interface InstallDrawerProps {
   fieldErrors: Record<string, string>;
   onClose: () => void;
   onSubmit: (values: Record<string, unknown>) => void | Promise<void>;
+  /** Markdown setup guide rendered above the fields. */
+  setupGuide?: string;
 }
 
 function InstallDrawer({
@@ -558,6 +573,7 @@ function InstallDrawer({
   fieldErrors,
   onClose,
   onSubmit,
+  setupGuide,
 }: InstallDrawerProps): React.ReactElement {
   const jobFromPhase =
     phase.kind === 'form'
@@ -639,6 +655,15 @@ function InstallDrawer({
             }}
           >
             <div className="flex-1 overflow-y-auto px-8 py-6">
+              {setupGuide ? (
+                <div className="mb-6 border-b border-[color:var(--rule)] pb-6">
+                  <div className="mb-3 text-[11px] uppercase tracking-[0.22em] text-[color:var(--faint-ink)]">
+                    Installationsanleitung
+                  </div>
+                  <Markdown source={setupGuide} />
+                </div>
+              ) : null}
+
               {fields.length === 0 ? (
                 <p className="text-sm italic text-[color:var(--muted-ink)]">
                   Dieses Plugin erfordert keine Konfiguration — bestätige die

--- a/web-ui/app/_lib/localized.ts
+++ b/web-ui/app/_lib/localized.ts
@@ -1,0 +1,24 @@
+import type { LocalizedMarkdown } from './storeTypes';
+
+/**
+ * Pick the best string from a `{ <locale>: text }` map for the given active
+ * locale. Falls back to English, then German, then any remaining locale, so a
+ * guide that ships only one language still renders. Returns undefined when the
+ * map is empty or absent.
+ */
+export function pickLocalized(
+  map: LocalizedMarkdown | undefined,
+  locale: string,
+): string | undefined {
+  if (!map) return undefined;
+  const direct = map[locale];
+  if (direct && direct.trim().length > 0) return direct;
+  for (const fallback of ['en', 'de']) {
+    const v = map[fallback];
+    if (v && v.trim().length > 0) return v;
+  }
+  for (const v of Object.values(map)) {
+    if (v && v.trim().length > 0) return v;
+  }
+  return undefined;
+}

--- a/web-ui/app/_lib/storeTypes.ts
+++ b/web-ui/app/_lib/storeTypes.ts
@@ -148,7 +148,17 @@ export interface Plugin {
   /** C6 — newer version a registry advertises when `install_state ===
    *  'update-available'`. `version` still reflects what is installed. */
   available_version?: string;
+  /** Localized markdown installation guide for the plugin's third-party system,
+   *  from the manifest's `setup.guide` as a `{ <locale>: markdown }` map. The
+   *  UI picks the active locale (with fallback) and renders it on the detail
+   *  page and in the install drawer ("how to create a Discord bot", "how to get
+   *  M365 credentials"). Mirrors middleware admin-v1. */
+  setup_guide?: LocalizedMarkdown;
 }
+
+/** UI text available in several languages, keyed by locale (`en`, `de`, …).
+ *  Mirrors `LocalizedMarkdown` in middleware admin-v1. */
+export type LocalizedMarkdown = Record<string, string>;
 
 export interface StoreListResponse {
   items: Plugin[];

--- a/web-ui/app/store/[id]/page.tsx
+++ b/web-ui/app/store/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import {
   ArrowLeft,
   BookCheck,
+  BookOpen,
   Database,
   Globe,
   KeyRound,
@@ -12,6 +13,11 @@ import {
   ShieldAlert,
   ShieldCheck,
 } from 'lucide-react';
+
+import { getLocale } from 'next-intl/server';
+
+import { Markdown } from '../../_components/Markdown';
+import { pickLocalized } from '../../_lib/localized';
 
 import { ApiError, getStorePlugin } from '../../_lib/api';
 import { redirectIfUnauthorized } from '../../_lib/authRedirect';
@@ -65,6 +71,11 @@ export default async function PluginDetailPage({
   const { plugin, install_available, blocking_reasons } = detail;
   const isLegacy = plugin.categories.includes('legacy');
   const visibleCategories = plugin.categories.filter((c) => c !== 'legacy');
+
+  // Localized setup guide — pick the active UI locale, fall back to another
+  // language so a single-language guide still renders.
+  const locale = await getLocale();
+  const setupGuideText = pickLocalized(plugin.setup_guide, locale);
 
   // S+7.7 / 2026-05-04 — admin-ui mount path. Conditional on the manifest
   // declaring `admin_ui_path` AND the plugin being installed (or having an
@@ -149,6 +160,20 @@ export default async function PluginDetailPage({
               )}
             </p>
           </Section>
+
+          {/* Installationsanleitung — Markdown-Guide aus dem Manifest
+              (`setup.guide`). Erklärt das Aufsetzen des Drittsystems: Discord-
+              Bot anlegen, Microsoft-365-Credentials beschaffen, Slack-App
+              registrieren, … Display-only. */}
+          {setupGuideText ? (
+            <Section
+              label="Installationsanleitung"
+              numeral="I.b"
+              icon={<BookOpen className="size-4" aria-hidden />}
+            >
+              <Markdown source={setupGuideText} />
+            </Section>
+          ) : null}
 
           {plugin.required_secrets.length > 0 ? (
             <Section
@@ -267,6 +292,7 @@ export default async function PluginDetailPage({
             enabled={install_available}
             remote={Boolean(plugin.source)}
             installedVersion={plugin.version}
+            {...(plugin.setup_guide ? { setupGuide: plugin.setup_guide } : {})}
             {...(plugin.available_version
               ? { availableVersion: plugin.available_version }
               : {})}


### PR DESCRIPTION
## What

Plugins can now ship a **localized third-party setup guide** that renders
automatically wherever the plugin is shown — answering the "how do I actually
get this running?" questions (create a Discord bot, register a Slack app, get a
Microsoft 365 / API credential, …).

A new optional manifest field:

```yaml
setup:
  guide:            # { <locale>: markdown } — ship at least `en`
    en: |
      ## Create a Discord bot
      1. Open the Developer Portal …
    de: |
      ## Discord-Bot anlegen
      1. Öffne das Developer Portal …
  fields:           # unchanged — short per-field hints stay in `help`
    - { key: bot_token, type: secret, label: Bot Token }
```

## How it flows

The guide is a `{ <locale>: markdown }` map (`LocalizedMarkdown`). It rides
**inline** in the registry `manifest_summary`, so it reaches every Omadia
instance with **no new registry route** and renders without an extra fetch:

- **Local plugins** → `manifestLoader.adaptManifestV1`
- **Remote/hub plugins** → store router `registryEntryToPlugin`
- **web-ui store** → detail page + install drawer, in the operator's **active
  next-intl locale** (fallback `en → de → first`).
- **hub detail page** (separate repo) → rendered with an **EN/DE toggle**.

The parser tolerates a bare string (wrapped as `{ en }`) and drops empty
locales.

## Files

- `api/admin-v1.ts`, `api/registry-v1.ts` — `setup_guide?: LocalizedMarkdown` on
  `Plugin` + `RegistryManifestSummary`.
- `plugins/manifestLoader.ts`, `routes/store.ts` — project the field on both
  plugin paths.
- web-ui: `storeTypes.ts`, new `_lib/localized.ts` (`pickLocalized`),
  `store/[id]/page.tsx`, `store/InstallButton.tsx`.
- `harness-plugin-web-search/manifest.yaml` — first OSS-core bilingual guide.

## Tests

`test/setupGuide.test.ts` (loader: map, empty-drop, bare-string tolerance) and
new cases in `test/registryInstallMerge.test.ts` (store-router propagation from
a registry `manifest_summary`). All green; all three surfaces type-check + lint
clean. Hub render verified end-to-end (EN/DE toggle).

## Follow-ups (separate PRs / repos)

- Hub render + publish projection live in the `omadia-hub` repo (mirrors this
  contract; already implemented locally).
- Bilingual guides for the private channel/integration plugins
  (teams, telegram, odoo, confluence, m365) land in `omadia-byte5-plugins`.
- The `omadia-plugin-starter` template now scaffolds a `setup.guide` in both
  example manifests and documents it (EN + DE).
