### PR TITLE
feat(plugin-api): widen EntityRef.op to 'read' | 'write'

### DIFF
--- a/middleware/packages/plugin-api/src/entityRef.ts
+++ b/middleware/packages/plugin-api/src/entityRef.ts
@@ -19,6 +19,15 @@ export interface EntityRef {
   id: string | number;
   /** Human-friendly label if the response carried one (`name`, `title`, …). */
   displayName?: string;
-  /** Always `read` for now — proxy only exposes read operations. */
-  op: 'read';
+  /**
+   * The operation that produced this reference.
+   *
+   * `'read'` for every observed entity (the common case — proxy reads,
+   * search hits, page fetches). `'write'` for entities a plugin created or
+   * mutated, e.g. the gated Confluence write tools
+   * (`@omadia/integration-confluence` >= 0.3.0: create page / update page /
+   * add comment). Consumers that don't care about the distinction can ignore
+   * the field; the EntityRefBus forwards refs without inspecting `op`.
+   */
+  op: 'read' | 'write';
 }


### PR DESCRIPTION
## Summary

`EntityRef.op` was hard-typed `'read'` with the note *"proxy only exposes read operations"*. Plugins can now mutate upstream entities — e.g. the gated Confluence write tools (`@omadia/integration-confluence` >= 0.3.0: create page / update page / add comment) — so the union gains `'write'`, letting a plugin mark the entities it creates or changes when it publishes onto the `EntityRefBus`.

```diff
-  /** Always `read` for now — proxy only exposes read operations. */
-  op: 'read';
+  op: 'read' | 'write';
```

## Why it's safe

- **Every existing producer** emits `op: 'read'` — still valid under the wider union (transcript parser, both knowledge-graph backends).
- **No consumer branches on `op`** — `EntityRefBus.publish()` forwards refs without inspecting it, so widening adds a possible value without changing any control flow.
- Purely additive type change.

## Verification

Full workspace typecheck: **21 packages + root `tsc --noEmit`, exit 0, 0 errors.**

## Context

This is the type-side prerequisite for plugins that perform writes and want their mutations reflected in the session transcript / knowledge-graph ingest. Runtime already tolerates `'write'` (the bus does not validate `op`); this change makes it type-correct so future kernel consumers can branch on the distinction if needed.