### PR TITLE
docs(adr): add initial architecture decision records

### DIFF
--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,54 @@
+# NNNN — <short decision title>
+
+## Status
+
+Proposed | Accepted | Deprecated | Superseded by [ADR-NNNN](NNNN-....md)
+
+- **Date:** YYYY-MM-DD
+- **Deciders:** <roles / people>
+- **Supersedes:** <ADR refs, if any>
+
+## Context and Problem Statement
+
+<Describe the architectural force in 2–4 sentences. What problem are we
+solving? What makes a decision necessary now? State it as a question.>
+
+## Decision Drivers
+
+- <driver / constraint 1>
+- <driver / constraint 2>
+- <driver / constraint 3>
+
+## Considered Options
+
+- **A — <name>**
+- **B — <name>**
+- **C — <name>**
+
+## Decision Outcome
+
+Chosen option: **<A>**, because <justification — how it best satisfies the
+decision drivers>.
+
+### Consequences
+
+- 🟢 **Good:** <positive consequence>
+- 🟢 **Good:** <positive consequence>
+- 🔴 **Bad:** <cost / trade-off / risk we accept>
+- ⚪ **Neutral:** <follow-up work this implies>
+
+## Pros and Cons of the Options
+
+### A — <name>
+
+- 🟢 <argument for>
+- 🔴 <argument against>
+
+### B — <name>
+
+- 🟢 <argument for>
+- 🔴 <argument against>
+
+## More Information
+
+<Links to related ADRs, specs, or discussion. Implementation pointers.>

--- a/docs/adr/0001-plugin-distribution-via-signed-zip.md
+++ b/docs/adr/0001-plugin-distribution-via-signed-zip.md
@@ -1,0 +1,101 @@
+# 0001 — Plugin distribution via signed ZIP packages
+
+## Status
+
+Accepted
+
+- **Date:** 2026-06-03
+- **Deciders:** Core maintainers
+- **Supersedes:** —
+
+## Context and Problem Statement
+
+Omadia is extended by **plugins**: agents, channels, and integrations that the
+core middleware loads at runtime. Operators need a way to discover, install, and
+update these plugins — including third-party and private ones — without
+rebuilding or redeploying the core.
+
+How should a plugin be packaged, distributed, and installed so that the model is
+simple, self-hostable, and does not couple the product to any single package
+ecosystem?
+
+## Decision Drivers
+
+- **Self-hostable:** an operator must be able to run the whole system, including
+  plugin distribution, without depending on a vendor-controlled service.
+- **Ecosystem-neutral:** plugins are not all JavaScript libraries; tying
+  distribution to the public npm registry would leak an implementation detail
+  and exclude private/closed plugins.
+- **Integrity & trust:** installs must be verifiable (the bytes installed are the
+  bytes published) and served over a secure transport.
+- **Low operational surface:** the distribution server should be as "dumb" as
+  possible; intelligence belongs in the client that the core already ships.
+- **Multiple sources:** operators must be able to mix a public registry with
+  internal/private registries.
+
+## Considered Options
+
+- **A — Signed ZIP packages installed via a thin registry client**
+  Plugins are built into a self-contained ZIP whose manifest carries metadata
+  (name, version, license, author). A "dumb" registry serves package bytes plus
+  an index; the smart client in the core verifies a `sha256` over TLS and
+  installs. Registries are admin-managed and can be stacked (public + private).
+- **B — npm-based discovery and install**
+  Discover plugins by scanning the public npm registry / installing npm packages
+  at runtime.
+- **C — Git-clone / source-build at install time**
+  Pull plugin source from a Git URL and build it in place on the host.
+
+## Decision Outcome
+
+Chosen option: **A — Signed ZIP packages installed via a thin registry client**,
+because it keeps the distribution server trivial to self-host, is neutral to the
+language a plugin is written in, supports private plugins by construction, and
+gives a verifiable supply chain (`sha256` + TLS) without binding the product to
+npm's trust and availability model.
+
+### Consequences
+
+- 🟢 **Good:** Plugins are self-contained artifacts; installing one is a single
+  verified download + unpack, with no transitive resolution at install time.
+- 🟢 **Good:** Private and commercial plugins are first-class — they live in a
+  private registry the operator controls, alongside the public one.
+- 🟢 **Good:** The registry can be backed by anything that serves bytes (object
+  storage or a local filesystem), so the hosted hub and an air-gapped install
+  use the same mechanism.
+- 🔴 **Bad:** Plugin authors must run a packaging step that produces a bundled
+  ZIP (dependencies vendored into the artifact) rather than relying on a package
+  manager to resolve them.
+- 🔴 **Bad:** Canonical metadata lives in the plugin **manifest**, not in
+  `package.json`; authors and tooling must treat the manifest as source of truth
+  for license/author/version.
+- ⚪ **Neutral:** Version artifacts are immutable — a change ships as a new
+  version bump, never an in-place overwrite.
+
+## Pros and Cons of the Options
+
+### A — Signed ZIP + thin registry client
+
+- 🟢 Self-hostable, ecosystem-neutral, verifiable, supports private plugins.
+- 🟢 Server stays a static byte-store; all logic is in the client we already ship.
+- 🔴 Requires a bundling/packaging step per plugin.
+
+### B — npm discovery/install
+
+- 🟢 Familiar tooling for JS authors; dependency resolution "for free".
+- 🔴 Couples the product to npm availability and trust; excludes non-JS and
+  private/closed plugins; runtime install of arbitrary npm trees is a large,
+  hard-to-audit supply-chain surface.
+
+### C — Git-clone / source-build
+
+- 🟢 No registry to operate; works with any Git host.
+- 🔴 Build toolchain must exist on every host; non-reproducible installs; no
+  natural integrity check; slow and failure-prone in production.
+
+## More Information
+
+See [ADR-0003](0003-capability-based-multi-provider-middleware.md) for how loaded
+plugins register themselves as capability providers, and
+[ADR-0002](0002-mit-license-for-oss-core.md) for licensing of the core vs.
+distributed plugins.

--- a/docs/adr/0002-mit-license-for-oss-core.md
+++ b/docs/adr/0002-mit-license-for-oss-core.md
@@ -1,0 +1,86 @@
+# 0002 — MIT license for the open-source core
+
+## Status
+
+Accepted
+
+- **Date:** 2026-06-03
+- **Deciders:** Core maintainers
+- **Supersedes:** —
+
+## Context and Problem Statement
+
+Omadia is released as open source. The license choice shapes who can adopt it,
+how plugins (including commercial ones) may build on top, and how much friction
+enterprises face when embedding it. We need an explicit, deliberate license
+decision rather than an implicit default.
+
+Which license should the open-source core ship under?
+
+## Decision Drivers
+
+- **Maximize adoption:** lower the barrier for companies to try, embed, and ship
+  products on top of the core.
+- **Enable a plugin ecosystem, including commercial plugins:** third parties must
+  be able to build proprietary plugins without a copyleft obligation forcing
+  their source open.
+- **Low legal-review friction:** a license enterprises' legal teams already know
+  and approve by reflex.
+- **Compatibility:** must combine cleanly with the permissive licenses of the
+  core's dependencies.
+
+## Considered Options
+
+- **A — MIT** — short, permissive, ubiquitous.
+- **B — Apache-2.0** — permissive with an explicit patent grant and NOTICE
+  requirements.
+- **C — AGPL-3.0** — strong copyleft, including over a network boundary.
+
+## Decision Outcome
+
+Chosen option: **A — MIT**, because it imposes the least friction on adoption and
+on building plugins (commercial included), is instantly recognizable to
+enterprise legal review, and matches the permissive licensing of the surrounding
+ecosystem. The product's value is in the agentic platform and the hosted/managed
+experience, not in license-enforced exclusivity, so copyleft would cost adoption
+without protecting what matters.
+
+### Consequences
+
+- 🟢 **Good:** Anyone can embed, fork, and ship — including in closed-source
+  products — which is the right incentive for a young platform seeking adoption.
+- 🟢 **Good:** Plugin authors can license their own plugins however they like
+  (MIT-permissive core does not infect them); the distribution model in
+  [ADR-0001](0001-plugin-distribution-via-signed-zip.md) already supports private
+  artifacts.
+- 🔴 **Bad:** No reciprocity — downstream forks are not obligated to contribute
+  improvements back, and a competitor could build a closed offering on the core.
+- 🔴 **Bad:** No explicit patent grant (unlike Apache-2.0); patent protection
+  relies on the implied license only.
+- ⚪ **Neutral:** Each distributed plugin declares its own license in its
+  manifest; the core's MIT choice does not dictate plugin licensing.
+
+## Pros and Cons of the Options
+
+### A — MIT
+
+- 🟢 Maximal adoption, trivial compliance, ecosystem-standard.
+- 🔴 No reciprocity; no explicit patent grant.
+
+### B — Apache-2.0
+
+- 🟢 Explicit patent grant; still permissive and enterprise-friendly.
+- 🔴 NOTICE/attribution mechanics add minor friction; longer text; marginally
+  less ubiquitous than MIT for a small core.
+
+### C — AGPL-3.0
+
+- 🟢 Forces network-deployed derivatives to publish source — protects against a
+  closed SaaS competitor.
+- 🔴 Copyleft (especially network copyleft) is an adoption-killer for many
+  enterprises and is incompatible with a thriving commercial-plugin ecosystem.
+
+## More Information
+
+License metadata for distributed plugins lives in their manifest — see
+[ADR-0001](0001-plugin-distribution-via-signed-zip.md).

--- a/docs/adr/0003-capability-based-multi-provider-middleware.md
+++ b/docs/adr/0003-capability-based-multi-provider-middleware.md
@@ -1,0 +1,97 @@
+# 0003 — Capability-based, multi-provider middleware
+
+## Status
+
+Accepted
+
+- **Date:** 2026-06-03
+- **Deciders:** Core maintainers
+- **Supersedes:** —
+
+## Context and Problem Statement
+
+The middleware that runs an Omadia agent needs many concrete services: an LLM,
+embeddings, a knowledge-graph store, diagram rendering, document generation, and
+so on. Early on these risked being wired in as hard-coded dependencies, which
+would make the core impossible to run without a specific vendor and impossible to
+extend without editing the core.
+
+How should the core depend on these services so that it stays "empty" — shipping
+no mandatory provider — while operators and plugins supply concrete
+implementations?
+
+## Decision Drivers
+
+- **Empty core:** the middleware should boot with *no* baked-in provider and let
+  the operator choose what backs each service.
+- **Pluggable per service:** swapping the LLM, the embedder, or the graph store
+  must not touch unrelated code.
+- **Multiple providers per service:** more than one implementation of the same
+  service may be installed at once (e.g. different LLMs for different agents).
+- **Plugin-supplied:** the same plugin mechanism
+  ([ADR-0001](0001-plugin-distribution-via-signed-zip.md)) that adds channels and
+  integrations should also add these service providers.
+- **Discoverable & testable:** the core must resolve a provider for a given
+  service through one consistent contract, easy to fake in tests.
+
+## Considered Options
+
+- **A — Capability registry with multiple providers per capability**
+  Define each service as a named **capability** (a typed interface). Providers
+  register against a capability; the core resolves a provider by capability at
+  runtime. Several providers may coexist for the same capability, selected by
+  configuration.
+- **B — Single hard-coded provider per service**
+  Pick one implementation per service, compiled into the core.
+- **C — One provider per capability (single-binding registry)**
+  A registry, but each capability can have at most one bound provider.
+
+## Decision Outcome
+
+Chosen option: **A — Capability registry with multiple providers per
+capability**, because it keeps the core empty and vendor-neutral, lets operators
+mix providers (including several implementations of the same capability), and
+reuses the plugin system as the delivery vehicle for providers. The core depends
+only on capability *interfaces*, never on concrete vendors.
+
+### Consequences
+
+- 🟢 **Good:** The core boots with no mandatory provider; an operator assembles a
+  working system by installing the plugins they want.
+- 🟢 **Good:** Any service — LLM, embeddings, graph store, renderers, document
+  tools — is swappable in isolation and faked easily in tests.
+- 🟢 **Good:** Several providers of the same capability can be active at once, so
+  different agents or tenants can use different backends.
+- 🔴 **Bad:** Indirection cost — every service call goes through capability
+  resolution, and a misconfigured install can boot with an unsatisfied
+  capability that only fails when first exercised.
+- 🔴 **Bad:** Capability interfaces are now a public contract; changing one is a
+  breaking change for every provider implementing it.
+- ⚪ **Neutral:** Selection logic (which provider answers a capability when
+  several are registered) becomes configuration the operator must understand.
+
+## Pros and Cons of the Options
+
+### A — Multi-provider capability registry
+
+- 🟢 Empty, vendor-neutral core; per-service pluggability; multiple coexisting
+  providers; reuses the plugin system.
+- 🔴 Resolution indirection; capability interfaces become a stable public API.
+
+### B — Hard-coded single provider
+
+- 🟢 Simplest to read; no resolution layer; fails fast at compile time.
+- 🔴 Couples the core to vendors; not self-hostable on a different stack; every
+  swap edits the core.
+
+### C — Single-binding registry
+
+- 🟢 Pluggable and testable, with simpler resolution than A.
+- 🔴 Cannot run two implementations of one capability simultaneously — blocks
+  per-agent / per-tenant provider choice.
+
+## More Information
+
+The knowledge-graph store is one such capability — see
+[ADR-0004](0004-knowledge-graph-as-memory-substrate.md). Providers are delivered
+as plugins per [ADR-0001](0001-plugin-distribution-via-signed-zip.md).

--- a/docs/adr/0004-knowledge-graph-as-memory-substrate.md
+++ b/docs/adr/0004-knowledge-graph-as-memory-substrate.md
@@ -1,0 +1,101 @@
+# 0004 — Knowledge graph as the agent memory substrate
+
+## Status
+
+Accepted
+
+- **Date:** 2026-06-03
+- **Deciders:** Core maintainers
+- **Supersedes:** —
+
+## Context and Problem Statement
+
+Omadia agents need durable memory that survives across turns, sessions, and
+channels: facts learned, plans made, processes followed, and team insights. They
+also need to retrieve the *relevant* slice of that memory at answer time. A flat
+vector store alone loses the relationships between entities; a pure relational
+schema alone loses semantic similarity search.
+
+What should back agent memory and retrieval?
+
+## Decision Drivers
+
+- **Relationships matter:** the knowledge is graph-shaped — entities (people,
+  plans, processes, documents) connected by typed edges — and retrieval often
+  needs to walk those connections, not just match text.
+- **Semantic retrieval:** answer-time recall needs similarity search over
+  embeddings, not only exact lookup.
+- **Cross-session, cross-channel:** memory must persist and be recallable
+  regardless of which session or channel produced it.
+- **Operable on standard infrastructure:** prefer a store an operator can run and
+  back up with ordinary Postgres tooling, not a bespoke graph engine.
+- **Capability-pluggable:** the store must slot in as a capability provider
+  ([ADR-0003](0003-capability-based-multi-provider-middleware.md)), not a
+  hard-coded dependency.
+
+## Considered Options
+
+- **A — Knowledge graph over Postgres + vector extension**
+  Model memory as a typed graph (entities + relationships) stored in Postgres,
+  with embeddings via a pgvector-style extension for semantic search. Exposed to
+  agents through graph read paths (a retrieval helper, a query tool, and a
+  query-building sub-agent).
+- **B — Vector store only**
+  Embed everything; retrieve purely by similarity. No first-class relationships.
+- **C — Dedicated graph database**
+  Use a purpose-built graph DB (e.g. a Cypher-native engine) as a separate
+  datastore.
+
+## Decision Outcome
+
+Chosen option: **A — Knowledge graph over Postgres + vector extension**, because
+it captures both the relationships *and* the semantics of agent memory in a
+single store that runs on standard, operator-friendly Postgres infrastructure,
+and plugs in cleanly as a capability provider. It gives multiple retrieval paths
+(similarity, direct query, and relationship walks) over one source of truth.
+
+### Consequences
+
+- 🟢 **Good:** Memory keeps its structure — plans, processes, and team insights
+  are entities with typed edges, so retrieval can follow relationships, not just
+  match strings.
+- 🟢 **Good:** Semantic recall and relational/graph queries live in one store;
+  one backup and one operational story.
+- 🟢 **Good:** Runs on managed or self-hosted Postgres with a vector extension —
+  no separate graph-engine to operate; the store is swappable as a capability.
+- 🔴 **Bad:** Graph traversal expressed over a relational schema is more work to
+  model and tune than in a native graph engine; deep walks need care to stay
+  performant.
+- 🔴 **Bad:** Multiple read paths (retrieval helper, query tool, query sub-agent)
+  mean the system must guide *which* path to use for a given question, or risk
+  inconsistent recall.
+- ⚪ **Neutral:** The store's connection secret is held in a vault rather than
+  passed as plain configuration.
+
+## Pros and Cons of the Options
+
+### A — Graph over Postgres + vectors
+
+- 🟢 Relationships + semantics in one operable store; capability-pluggable;
+  standard backup/ops.
+- 🔴 Graph traversal on a relational schema needs modeling/perf care; several
+  retrieval paths to coordinate.
+
+### B — Vector-only
+
+- 🟢 Simplest; great at "find similar text".
+- 🔴 No first-class relationships — can't answer "what depends on / belongs to /
+  follows from" without bolting structure back on.
+
+### C — Dedicated graph DB
+
+- 🟢 Native, expressive traversal.
+- 🔴 A second datastore to run, secure, and back up; weaker/extra path for vector
+  search; higher operational burden, against the "standard infrastructure"
+  driver.
+
+## More Information
+
+The store is registered as a capability per
+[ADR-0003](0003-capability-based-multi-provider-middleware.md). Retrieval-path
+selection heuristics are documented alongside the orchestrator.

--- a/docs/adr/0005-two-phase-confirmation-for-writes.md
+++ b/docs/adr/0005-two-phase-confirmation-for-writes.md
@@ -1,0 +1,95 @@
+# 0005 — Two-phase confirmation for write-capable connectors
+
+## Status
+
+Accepted
+
+- **Date:** 2026-06-03
+- **Deciders:** Core maintainers
+- **Supersedes:** —
+
+## Context and Problem Statement
+
+Integrations started out read-only, but agents increasingly need to *act* in
+external systems — create a page, update a record, post a comment. A language
+model deciding to mutate a system of record carries real risk: a hallucinated or
+misjudged write can damage data a human did not intend to change.
+
+How should the platform expose write capability so that agents can be useful
+*and* an erroneous write cannot silently take effect?
+
+## Decision Drivers
+
+- **Human-in-the-loop for mutations:** a person should be able to see and approve
+  what an agent is about to change before it is applied.
+- **Reversible / low-blast-radius by default:** the default path must not commit
+  an irreversible change to a live system on the model's say-so.
+- **Explicit, typed intent:** the system must distinguish a *read* from a *write*
+  in the connector contract, not infer it.
+- **Consistent across connectors:** the same safety model should apply to any
+  write-capable integration, not be reinvented per connector.
+- **Honest UX:** the agent must tell the user that what it produced is a proposal,
+  not a fait accompli.
+
+## Considered Options
+
+- **A — Two-phase confirm + draft-by-default**
+  Writes are typed explicitly in the connector contract. A write is a two-step
+  flow: the agent first presents a preview of the exact change; only after
+  confirmation is it sent. Where the target system supports it, the write lands
+  as an unpublished **draft** requiring human review rather than going live.
+- **B — Direct writes with post-hoc audit log**
+  Apply writes immediately; record them so a human can review/undo afterwards.
+- **C — No writes (stay read-only)**
+  Disallow mutation entirely; humans perform all changes.
+
+## Decision Outcome
+
+Chosen option: **A — Two-phase confirm + draft-by-default**, because it lets
+agents do useful work while guaranteeing a human checkpoint before anything
+changes a system of record, and degrades safely: even after confirmation, writes
+prefer a reviewable draft state over a live publish wherever the target system
+offers one. Intent is explicit in the contract, so the platform can enforce the
+safety model uniformly across connectors.
+
+### Consequences
+
+- 🟢 **Good:** No agent-initiated write reaches a live system without a human
+  seeing the exact change first.
+- 🟢 **Good:** Where supported, the result is a draft a human still has to
+  publish — a second, system-native safety net beyond the confirm step.
+- 🟢 **Good:** Read vs. write is a typed distinction in the connector contract,
+  so capability and auditing are explicit rather than inferred.
+- 🔴 **Bad:** Every write is at least two interactions — slower than a direct
+  apply, and unsuitable for high-volume autonomous mutation.
+- 🔴 **Bad:** "Draft-by-default" depends on the target system supporting an
+  unpublished state; connectors to systems without one must fall back to the
+  confirm step alone.
+- ⚪ **Neutral:** Agent instructions and preview copy must clearly state the
+  draft/proposal nature so users are not misled into thinking a change is live.
+
+## Pros and Cons of the Options
+
+### A — Two-phase confirm + draft-by-default
+
+- 🟢 Human checkpoint before any change; native draft as a second net; explicit
+  typed intent; uniform across connectors.
+- 🔴 Extra round-trip per write; draft state not available in every target system.
+
+### B — Direct writes + audit log
+
+- 🟢 Fast; fully autonomous; complete history for review.
+- 🔴 Damage is already done by the time a human looks; undo is best-effort and
+  impossible for some operations — wrong default for systems of record.
+
+### C — Read-only
+
+- 🟢 Zero write risk.
+- 🔴 Severely limits agent usefulness; pushes all action back onto humans.
+
+## More Information
+
+The first write-capable connector to adopt this model demonstrated the pattern:
+writes are presented as a preview, confirmed, and then created as drafts for
+human review. The read/write intent distinction is part of the connector entity
+contract.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,39 @@
+# Architecture Decision Records
+
+This directory records the significant architecture decisions behind **Omadia**,
+an agentic operating system for building and running teams of AI agents across
+channels, integrations, and a shared knowledge graph.
+
+We use the [MADR](https://adr.github.io/madr/) format. Each record captures a
+single decision: the problem, the options we weighed, what we chose, and the
+consequences we accepted. ADRs are immutable once **Accepted** — to change a
+decision, write a new ADR and mark the old one **Superseded by …**.
+
+## Why we keep ADRs
+
+- Make the *reasoning* behind the architecture durable, not just the code.
+- Give new contributors the "why", not only the "what".
+- Avoid re-litigating settled trade-offs.
+
+## Writing a new ADR
+
+1. Copy [`0000-template.md`](0000-template.md) to the next free number:
+   `NNNN-short-kebab-title.md`.
+2. Fill in Context, Decision Drivers, Considered Options, Decision Outcome,
+   and Consequences.
+3. Open it as **Proposed**; flip to **Accepted** once agreed.
+4. Add a row to the index below.
+
+## Index
+
+| #    | Title                                                              | Status   | Date       |
+| ---- | ------------------------------------------------------------------ | -------- | ---------- |
+| 0001 | [Plugin distribution via signed ZIP packages](0001-plugin-distribution-via-signed-zip.md) | Accepted | 2026-06-03 |
+| 0002 | [MIT license for the open-source core](0002-mit-license-for-oss-core.md) | Accepted | 2026-06-03 |
+| 0003 | [Capability-based, multi-provider middleware](0003-capability-based-multi-provider-middleware.md) | Accepted | 2026-06-03 |
+| 0004 | [Knowledge graph as the agent memory substrate](0004-knowledge-graph-as-memory-substrate.md) | Accepted | 2026-06-03 |
+| 0005 | [Two-phase confirmation for write-capable connectors](0005-two-phase-confirmation-for-writes.md) | Accepted | 2026-06-03 |
+
+> These first records are written *retroactively* — they document decisions that
+> were already implemented and proven in the product. New decisions should be
+> recorded *before* or *while* they are implemented.


### PR DESCRIPTION
## Summary

Introduces a MADR-format Architecture Decision Records directory under `docs/adr/`, capturing the significant architecture decisions behind Omadia. These first records are written **retroactively** — they document decisions already implemented and proven in the product, so the *reasoning* behind the architecture is durable, not just the code.

## Records

| #    | Title | Status |
| ---- | ----- | ------ |
| 0001 | Plugin distribution via signed ZIP packages | Accepted |
| 0002 | MIT license for the open-source core | Accepted |
| 0003 | Capability-based, multi-provider middleware | Accepted |
| 0004 | Knowledge graph as the agent memory substrate | Accepted |
| 0005 | Two-phase confirmation for write-capable connectors | Accepted |

Also adds:
- `README.md` — the ADR process (MADR, immutability, how to write a new one) and the index.
- `0000-template.md` — the template for future records.

## Notes

Docs-only change; no code paths touched. New decisions going forward should be recorded *before* or *while* they are implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)