### PR TITLE
fix(orchestrator): quarantine uninstalled plugins instead of aborting registry boot

### DIFF
--- a/middleware/packages/harness-orchestrator/src/registry/index.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/index.ts
@@ -177,9 +177,10 @@ export class OrchestratorRegistry {
    * identical to the hot-reload path.
    */
   applySnapshot(snap: ConfigSnapshot): void {
-    validateSnapshot(snap, this.options.pluginLookup);
-    const plan = diffSnapshots(this.snapshot, snap);
-    this.applyDiffActions(plan, snap);
+    const safe = this.quarantineUnsatisfiablePlugins(snap);
+    validateSnapshot(safe, this.options.pluginLookup);
+    const plan = diffSnapshots(this.snapshot, safe);
+    this.applyDiffActions(plan, safe);
   }
 
   /**
@@ -195,14 +196,61 @@ export class OrchestratorRegistry {
    */
   async reload(): Promise<DiffPlan> {
     const snap = await this.store.loadSnapshot();
-    validateSnapshot(snap, this.options.pluginLookup);
-    const plan = diffSnapshots(this.snapshot, snap);
+    const safe = this.quarantineUnsatisfiablePlugins(snap);
+    validateSnapshot(safe, this.options.pluginLookup);
+    const plan = diffSnapshots(this.snapshot, safe);
     if (plan.actions.length === 0 && !plan.platformChanged) {
-      this.snapshot = snap;
+      this.snapshot = safe;
       return plan;
     }
-    this.applyDiffActions(plan, snap);
+    this.applyDiffActions(plan, safe);
     return plan;
+  }
+
+  /**
+   * Graceful degradation for plugins that disappeared from the platform
+   * (uninstalled / unbundled between boots). Without this, a single Agent
+   * with a still-enabled binding to a now-uninstalled plugin makes
+   * `validateSnapshot` throw and aborts the ENTIRE registry boot — taking
+   * every other Agent (including the fallback) and the operator dashboards
+   * (`multi_orchestrator_unavailable` 503) down with it.
+   *
+   * Instead we demote only the offending binding to `enabled: false` and log
+   * it loudly; the rest of the snapshot validates and publishes, and the
+   * Agent keeps all of its still-installed plugins. This mirrors the
+   * per-Agent build isolation (T022) one layer earlier — at the validation
+   * gate that runs before the diff.
+   *
+   * Only a definite `isInstalled === false` is quarantined. `undefined`
+   * ("the platform has no opinion") and a missing `pluginLookup` are left
+   * untouched, so test / legacy boots without a catalog behave exactly as
+   * before. `validateSnapshot` itself stays strict — direct callers that
+   * want to reject an impossible config still get the throw.
+   */
+  private quarantineUnsatisfiablePlugins(
+    snap: ConfigSnapshot,
+  ): ConfigSnapshot {
+    const lookup = this.options.pluginLookup;
+    const isInstalled = lookup?.isInstalled?.bind(lookup);
+    if (!isInstalled) return snap;
+
+    let demoted = 0;
+    const agentPlugins = snap.agentPlugins.map((row) => {
+      if (!row.enabled) return row;
+      if (isInstalled(row.pluginId) !== false) return row;
+      demoted += 1;
+      this.log(`registry: plugin not installed — disabling binding`, {
+        agentId: row.agentId,
+        pluginId: row.pluginId,
+      });
+      return { ...row, enabled: false };
+    });
+
+    if (demoted === 0) return snap;
+    this.log(`registry: quarantined unsatisfiable plugin binding(s)`, {
+      count: demoted,
+    });
+    return { ...snap, agentPlugins };
   }
 
   /**

--- a/middleware/test/orchestratorRegistry.test.ts
+++ b/middleware/test/orchestratorRegistry.test.ts
@@ -296,6 +296,55 @@ test('US4-4c: validateSnapshot rejects a snapshot with an uninstalled plugin', (
   );
 });
 
+test('US4-4d: registry.start() quarantines an uninstalled plugin instead of aborting the whole boot', async () => {
+  // Regression: the fallback Agent had `de.byte5.agent.github-prs` enabled
+  // after that plugin was unbundled from the deployment. `validateSnapshot`
+  // threw on the missing plugin, which aborted `registry.start()` and left
+  // the orchestratorRegistry / configStore / channelResolver unpublished —
+  // every `/operator/*` route then returned `multi_orchestrator_unavailable`
+  // (503). The registry must instead disable just the offending binding and
+  // come up with the rest.
+  const logged: Array<{ msg: string; fields?: Record<string, unknown> }> = [];
+  const lookup: PluginCapabilityLookup = {
+    isMultiInstance: () => true,
+    // The `general` Agent's only plugin is no longer installed.
+    isInstalled: (id) => (id === '@omadia/agent-odoo-hr' ? false : true),
+  };
+  const registry = new OrchestratorRegistry(
+    fakeStore(twoAgentSnapshot),
+    deps(),
+    {
+      defaultRuntimeConfig: { model: 'm', maxTokens: 100, maxToolIterations: 4 },
+      pluginLookup: lookup,
+      log: (msg, fields) => logged.push({ msg, ...(fields ? { fields } : {}) }),
+    },
+  );
+
+  // Boot does NOT throw — the snapshot is sanitised before validation.
+  await registry.start();
+
+  // Both Agents come up; the offending binding is dropped, not the Agent.
+  assert.equal(registry.size(), 2);
+  assert.ok(registry.get('public'), 'public agent present');
+  const general = registry.get('general');
+  assert.ok(general, 'general agent still present despite its missing plugin');
+  assert.deepEqual(
+    general.plugins.filter((p) => p.enabled).map((p) => p.pluginId),
+    [],
+    'the uninstalled plugin is quarantined off the general Agent',
+  );
+
+  // The quarantine is surfaced loudly so an operator can fix the manifest.
+  assert.ok(
+    logged.some(
+      (l) =>
+        l.msg.includes('plugin not installed') &&
+        l.fields?.['pluginId'] === '@omadia/agent-odoo-hr',
+    ),
+    'a per-binding warning is logged',
+  );
+});
+
 test('SC-007 / T018: a build-time failure for Agent B does NOT prevent Agent A', async () => {
   // Inject a faulty `nativeToolRegistry` that throws once — Orchestrator
   // construction calls `register` for each native-tool name; failing one of


### PR DESCRIPTION
## What

A single Agent bound to a plugin that is no longer installed no longer aborts the entire multi-orchestrator boot. The offending plugin binding is quarantined (`enabled:false`, logged) and the rest of the snapshot publishes — recovering every `/operator/*` route from `multi_orchestrator_unavailable` (503).

## Why

The auto-hydrated **Fallback Agent** had `de.byte5.agent.github-prs` enabled. After that plugin was unbundled from the deployment image, `validateSnapshot()` threw inside `registry.start()`, which left `configStore` / `orchestratorRegistry` / `channelResolver` unpublished — so `/operator/channels` and `/operator/agents` returned 503. One missing plugin on one Agent took down the whole agentic runtime and all operator dashboards, defeating the per-Agent build isolation (`T022`) that runs *after* this validation gate. The fix sanitizes the snapshot before validation in both `applySnapshot()` (boot) and `reload()` (hot-reload); `validateSnapshot()` itself stays strict for direct callers.

## Test plan

- [x] `npm run lint` (middleware) — clean
- [x] `npm run typecheck` (middleware, all workspaces + root `tsc --noEmit`) — clean
- [x] `node --import tsx --test test/orchestratorRegistry.test.ts` — 9/9 pass, incl. new `US4-4d` (boots both Agents with the uninstalled binding quarantined instead of throwing)
- [x] manual: disabled the stale binding on the live Fly DB + restarted → boot logs `orchestratorRegistry@1 published (agents=2)` and `channelResolver@1 published`; `/operator/channels` + `/operator/agents` return 401 (alive) instead of 503

## Risk / blast radius

- Changes behavior on a **core boot/reload path** (orchestrator registry): a now-uninstalled plugin is gracefully demoted rather than hard-failing the snapshot.
- Backward-compatible: only a definite `isInstalled === false` is quarantined; `undefined` ("no opinion") and a missing `pluginLookup` are untouched, so test/legacy boots behave exactly as before.
- No schema change, no public-API change, no new env-var, no CI/release tooling touched.