### PR TITLE
feat(builder): service-type auto-discovery for integration-backed agents

### DIFF
--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -243,6 +243,18 @@ export interface Plugin {
    *  to empty array). The kernel rejects boot if any `requires` has no
    *  matching `provides` across the installed plugin set. */
   requires: string[];
+  /**
+   * Builder service-type declarations (OB — service-type auto-discovery).
+   * Integration plugins list every `ctx.services.provide(...)` surface they
+   * expose, mapped to the TypeScript type a consuming agent imports. When
+   * such a plugin activates, the kernel registers each entry into the
+   * agent-builder's runtime `serviceTypeRegistry` so a generated agent that
+   * declares `external_reads` against this service typechecks + resolves at
+   * activate-time — and unregisters on deactivation. Empty/absent for
+   * plugins that expose no builder-consumable services. Distinct from
+   * `provides` (capability-refs like `graph@1`): these carry the concrete
+   * `import type` target codegen needs. */
+  service_types?: ServiceTypeDecl[];
   /** Channel-specific block. Present iff kind === 'channel'. */
   channel?: ChannelManifestBlock;
   /**
@@ -284,6 +296,30 @@ export interface Plugin {
    * never parsed for behaviour.
    */
   setup_guide?: LocalizedMarkdown;
+}
+
+/**
+ * A single builder service-type declaration from a plugin's manifest
+ * `service_types:` block. Mirrors `ServiceTypeRegistration` in the
+ * agent-builder's `serviceTypeRegistry.ts` (kept inline here so `admin-v1.ts`
+ * stays import-free, consistent with the rest of this module). The kernel
+ * translates each entry into a `registerServiceType(service, { providedBy,
+ * typeImport })` call when the providing plugin activates.
+ */
+export interface ServiceTypeDecl {
+  /** Service-registry key the plugin publishes via `ctx.services.provide`,
+   *  e.g. `"odoo.client"`. This is what a consuming agent passes to
+   *  `ctx.services.get(...)` and lists in `spec.external_reads[].service`. */
+  service: string;
+  /** The TypeScript type a consumer imports for this service. */
+  type: {
+    /** npm/workspace package id the type is imported `from`, e.g.
+     *  `"@omadia/integration-odoo"`. Codegen also emits this as the
+     *  generated agent's `peerDependencies` entry. */
+    from: string;
+    /** Exported type name, e.g. `"OdooClient"`. */
+    name: string;
+  };
 }
 
 /**

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -76,8 +76,15 @@ import {
 import { WorkaroundStateStore } from './plugins/builder/workaroundStateStore.js';
 import { SpecEventBus } from './plugins/builder/specEventBus.js';
 import { BuilderTurnRingBuffer } from './plugins/builder/turnRingBuffer.js';
-import { ensureBuildTemplate } from './plugins/builder/buildTemplate.js';
+import {
+  ensureBuildTemplate,
+  linkWorkspacePackageIntoTemplate,
+} from './plugins/builder/buildTemplate.js';
 import { loadBuildTemplateConfig } from './plugins/builder/buildTemplateConfig.js';
+import {
+  registerServiceType,
+  unregisterServiceType,
+} from './plugins/builder/serviceTypeRegistry.js';
 import { BuildPipeline } from './plugins/builder/buildPipeline.js';
 import { RuntimeSmokeOrchestrator } from './plugins/builder/runtimeSmokeOrchestrator.js';
 import { AutoFixOrchestrator } from './plugins/builder/autoFixOrchestrator.js';
@@ -520,6 +527,11 @@ async function main(): Promise<void> {
   // a toolkit like agent plugins — their activate() registers directly into
   // the kernel's native-tool / route registries. Same package sources as
   // DynamicAgentRuntime; the two runtimes coordinate by kind-filtering.
+  // Service-type auto-discovery (no-restart): tracks which `serviceTypeRegistry`
+  // names each plugin registered at activation, so deactivation can
+  // unregister EXACTLY those — independent of whether the catalog entry still
+  // exists (uninstall may have reloaded the catalog and dropped it first).
+  const registeredServiceTypesByPlugin = new Map<string, string[]>();
   const toolPluginRuntime = new ToolPluginRuntime({
     catalog: pluginCatalog,
     registry: installedRegistry,
@@ -532,6 +544,56 @@ async function main(): Promise<void> {
     notificationRouter,
     uiRouteCatalog,
     jobScheduler,
+    // When an integration plugin activates — at boot OR via a live hot-
+    // install — register every `manifest.service_types` entry into the
+    // agent-builder's `serviceTypeRegistry`, and link its package into the
+    // shared build template so generated agents that `external_reads`
+    // against it typecheck. `lookupServiceType()` is read live by the
+    // manifest-linter and codegen, so a newly-online platform becomes
+    // buildable immediately, with no middleware restart.
+    onActivated: async (entry, packagePath) => {
+      const serviceTypes = entry.plugin.service_types ?? [];
+      if (serviceTypes.length === 0) return;
+      for (const st of serviceTypes) {
+        registerServiceType(st.service, {
+          providedBy: entry.plugin.id,
+          typeImport: { from: st.type.from, name: st.type.name },
+        });
+      }
+      registeredServiceTypesByPlugin.set(
+        entry.plugin.id,
+        serviceTypes.map((st) => st.service),
+      );
+      // The type packages a consumer imports `from` are — by the manifest
+      // convention — exported by the activating plugin's own package, whose
+      // on-disk root is `packagePath`. Link each unique `from` so tsc
+      // resolves `import type { X } from '<from>'`. A no-op before the build
+      // template exists (boot ordering) — the boot reconciliation below then
+      // links it once node_modules is provisioned.
+      const uniqueFroms = new Set(serviceTypes.map((st) => st.type.from));
+      for (const from of uniqueFroms) {
+        const res = await linkWorkspacePackageIntoTemplate(
+          BUILDER_BUILD_TEMPLATE_DIR,
+          from,
+          packagePath,
+        );
+        if (!res.linked) {
+          console.log(
+            `[builder] service-type package '${from}' not linked into build ` +
+              `template (${res.reason ?? 'unknown'}); boot pass will cover it.`,
+          );
+        }
+      }
+      console.log(
+        `[builder] registered ${serviceTypes.length} service-type(s) from ${entry.plugin.id}`,
+      );
+    },
+    onDeactivated: (agentId) => {
+      const names = registeredServiceTypesByPlugin.get(agentId);
+      if (!names) return;
+      for (const service of names) unregisterServiceType(service);
+      registeredServiceTypesByPlugin.delete(agentId);
+    },
     log: (msg) => console.log(msg),
   });
 
@@ -1824,7 +1886,7 @@ async function main(): Promise<void> {
     npmDeps: buildTemplateConfig.npmDeps,
     workspaceDeps: buildTemplateConfig.workspaceDeps,
   })
-    .then((result) => {
+    .then(async (result) => {
       if (!result.ready) {
         throw new Error(
           `[builder] build template not ready: ${result.reason ?? 'unknown reason'}`,
@@ -1833,6 +1895,38 @@ async function main(): Promise<void> {
       console.log(
         `[builder] build template ready (reused=${String(result.reused)}, took ${String(result.durationMs)}ms, npmDeps=${String(Object.keys(buildTemplateConfig.npmDeps).length)}, workspaceDeps=${String(Object.keys(buildTemplateConfig.workspaceDeps).length)})`,
       );
+      // Service-type auto-discovery — boot reconciliation. The activation
+      // hook (toolPluginRuntime.onActivated) ran during
+      // `activateAllInstalled()` ABOVE, before this template existed, so its
+      // per-package link was a no-op. Now that node_modules is provisioned,
+      // link every active integration's service-type packages by their REAL
+      // on-disk path (path.dirname(source_path)) — this covers uploaded /
+      // hot-installed integrations and name↔folder drift that
+      // `loadBuildTemplateConfig`'s workspace-folder heuristic can't resolve.
+      // Post-boot hot-installs are handled live by the activation hook
+      // itself (template exists by then). Idempotent; failures are logged,
+      // not fatal — a build that needs a missing link fails loudly at tsc.
+      for (const entry of pluginCatalog.list()) {
+        const serviceTypes = entry.plugin.service_types ?? [];
+        if (serviceTypes.length === 0) continue;
+        if (!toolPluginRuntime.isActive(entry.plugin.id)) continue;
+        const packageRoot = path.dirname(entry.source_path);
+        const uniqueFroms = new Set(serviceTypes.map((st) => st.type.from));
+        for (const from of uniqueFroms) {
+          try {
+            await linkWorkspacePackageIntoTemplate(
+              BUILDER_BUILD_TEMPLATE_DIR,
+              from,
+              packageRoot,
+              { requireTemplate: true },
+            );
+          } catch (err) {
+            console.error(
+              `[builder] boot-reconcile: failed to link '${from}' (${entry.plugin.id}): ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
+      }
     })
     .catch((err: unknown) => {
       // Re-raise lazily — BuildPipeline.run awaits templateReady and any
@@ -2126,7 +2220,12 @@ async function main(): Promise<void> {
     // installed integration plugin auto-registers under
     // `integration-<tail>`. The LLM reads each one's `INTEGRATION.md` for
     // the canonical service surface — no more drift on integration patches.
-    referenceCatalog: resolveBuilderReferenceCatalog(pluginCatalog),
+    //
+    // Passed as a per-turn thunk (not a boot snapshot) so an integration
+    // hot-installed mid-session — the catalog is reloaded on upload — shows
+    // up in `read_reference`/`list_references` immediately, retiring the old
+    // "not visible until next restart" caveat.
+    referenceCatalog: () => resolveBuilderReferenceCatalog(pluginCatalog),
     templateRoot: BUILDER_BUILD_TEMPLATE_DIR,
     // OB-31 follow-up: a single fill_slot routinely generates whole TS
     // slot bodies (5–15k tokens). The 4096 LocalSubAgent default hit

--- a/middleware/src/plugins/builder/buildTemplate.ts
+++ b/middleware/src/plugins/builder/buildTemplate.ts
@@ -101,14 +101,9 @@ export async function ensureBuildTemplate(
   // means we make it ourselves).
   await fs.mkdir(nodeModulesPath, { recursive: true });
   for (const [name, srcPath] of Object.entries(workspaceDeps)) {
-    const linkPath = path.join(nodeModulesPath, name);
-    await fs.mkdir(path.dirname(linkPath), { recursive: true });
-    try {
-      await fs.rm(linkPath, { recursive: true, force: true });
-    } catch {
-      /* ignore — may not exist */
-    }
-    await fs.symlink(path.resolve(srcPath), linkPath, 'dir');
+    await linkWorkspacePackageIntoTemplate(templateRoot, name, srcPath, {
+      requireTemplate: true,
+    });
   }
 
   await fs.writeFile(hashPath, newHash, 'utf-8');
@@ -119,6 +114,61 @@ export async function ensureBuildTemplate(
     durationMs: Date.now() - start,
     installedAt: new Date().toISOString(),
   };
+}
+
+export interface LinkWorkspacePackageResult {
+  linked: boolean;
+  /** Populated when `linked` is false — why the link was skipped. */
+  reason?: string;
+}
+
+/**
+ * Symlink a single workspace/integration package into the build template's
+ * shared `node_modules`, idempotently. This is the per-package primitive
+ * `ensureBuildTemplate` uses for its boot-time pass, AND the live hook the
+ * service-type auto-discovery wiring calls when an integration plugin
+ * activates AFTER boot — so a generated agent that `import type`s the
+ * integration's surface typechecks at the tsc gate without rebuilding the
+ * whole template or running `npm install` again.
+ *
+ * No npm work, no hash bump: just `rm -f` the stale link + recreate it. The
+ * `dir` symlink resolves `import type { OdooClient } from '@omadia/
+ * integration-odoo'` against the package's own `types` field.
+ *
+ * When the template's `node_modules` does not exist yet (the boot ordering
+ * where integration activation runs BEFORE `ensureBuildTemplate`), the call
+ * is a no-op returning `linked: false` — the boot pass then picks the package
+ * up via `serviceTypeRegistry` → `getKnownServicePackages()`. Pass
+ * `requireTemplate: true` to turn that into a thrown error instead (used by
+ * `ensureBuildTemplate` itself, which has just created the directory).
+ */
+export async function linkWorkspacePackageIntoTemplate(
+  templateRoot: string,
+  name: string,
+  srcPath: string,
+  opts: { requireTemplate?: boolean } = {},
+): Promise<LinkWorkspacePackageResult> {
+  const nodeModulesPath = path.join(templateRoot, 'node_modules');
+  if (!existsSync(nodeModulesPath)) {
+    if (opts.requireTemplate) {
+      throw new Error(
+        `linkWorkspacePackageIntoTemplate: template node_modules missing at ${nodeModulesPath}`,
+      );
+    }
+    return {
+      linked: false,
+      reason: 'build template node_modules not provisioned yet',
+    };
+  }
+  const linkPath = path.join(nodeModulesPath, name);
+  await fs.mkdir(path.dirname(linkPath), { recursive: true });
+  try {
+    await fs.rm(linkPath, { recursive: true, force: true });
+  } catch {
+    /* ignore — may not exist */
+  }
+  await fs.symlink(path.resolve(srcPath), linkPath, 'dir');
+  return { linked: true };
 }
 
 function renderPackageJson(npmDeps: Readonly<Record<string, string>>): string {

--- a/middleware/src/plugins/builder/buildTemplateConfig.ts
+++ b/middleware/src/plugins/builder/buildTemplateConfig.ts
@@ -189,6 +189,18 @@ export async function loadBuildTemplateConfig(
   // workspace deps win on conflict. Tests opt out via
   // `includeServiceTypeRegistryDeps: false` since their tmpdir fixtures
   // don't ship the integration package directories.
+  //
+  // Service-type auto-discovery (no-restart): the registry is now populated
+  // live at plugin-activation time, so it can name packages that do NOT live
+  // under `middleware/packages/<folder>` — uploaded/hot-installed
+  // integrations, or first-party ones whose on-disk folder drifts from the
+  // package name (e.g. `harness-integration-odoo` vs `@omadia/integration-
+  // odoo`). Those resolve by their REAL path via the activation hook's
+  // `linkWorkspacePackageIntoTemplate` + the boot reconciliation in
+  // index.ts. So a name we can't resolve to a workspace folder here is no
+  // longer fatal — warn + skip and let the hook path handle it. We still
+  // pre-resolve the ones that DO live in `middleware/packages/` so they land
+  // in the template hash and survive a `node_modules` rebuild.
   if (includeRegistryDeps) {
     for (const pkgName of getKnownServicePackages()) {
       // Phase 5B: accept any scoped package (@omadia/x, @byte5/x,
@@ -202,11 +214,12 @@ export async function loadBuildTemplateConfig(
       try {
         await fs.access(abs);
       } catch {
-        throw new Error(
-          `loadBuildTemplateConfig: serviceTypeRegistry references '${pkgName}' but ` +
-            `'${abs}' does not exist — drop the entry from serviceTypeRegistry or ` +
-            'install the integration package.',
+        console.warn(
+          `loadBuildTemplateConfig: serviceTypeRegistry references '${pkgName}' ` +
+            `which is not a '${workspaceRoot}' workspace package — relying on the ` +
+            'activation-time build-template link for it.',
         );
+        continue;
       }
       workspaceDeps[pkgName] = abs;
     }

--- a/middleware/src/plugins/builder/builderAgent.ts
+++ b/middleware/src/plugins/builder/builderAgent.ts
@@ -192,6 +192,15 @@ export interface BuilderSubAgentBuildOptions {
   tools: LocalSubAgentTool[];
 }
 
+/**
+ * Reference-implementation catalog shape: short-name → on-disk package root
+ * + human description, served by the `read_reference` / `list_references`
+ * builder tools. Matches the return type of `resolveBuilderReferenceCatalog`.
+ */
+export type BuilderReferenceCatalog = Readonly<
+  Record<string, { root: string; description: string }>
+>;
+
 export interface BuilderAgentDeps {
   anthropic: Anthropic;
   draftStore: DraftStore;
@@ -213,8 +222,15 @@ export interface BuilderAgentDeps {
    * `list_references` can serve multiple agents (SEO-analyst,
    * integration-confluence, integration-odoo, …) plus the boilerplate
    * template, instead of a single hard-coded path.
+   *
+   * Accepts either a static map OR a provider thunk. Pass a thunk
+   * (`() => resolveBuilderReferenceCatalog(catalog)`) so an integration
+   * installed mid-session is readable via `read_reference` immediately —
+   * the catalog is re-resolved per turn against the live PluginCatalog,
+   * with no middleware restart. A plain object is treated as a constant
+   * (kept for tests + callers that don't need live discovery).
    */
-  referenceCatalog: Readonly<Record<string, { root: string; description: string }>>;
+  referenceCatalog: BuilderReferenceCatalog | (() => BuilderReferenceCatalog);
   /**
    * Override the system-prompt seed (test-only). Default reads
    * `prompts/builder-system.md` next to this file plus the boilerplate
@@ -293,9 +309,7 @@ export class BuilderAgent {
   private readonly knownPluginIds: KnownPluginIdsProvider;
   private readonly slotTypechecker: SlotTypecheckService;
   private readonly audit: AuditLogger;
-  private readonly referenceCatalog: Readonly<
-    Record<string, { root: string; description: string }>
-  >;
+  private readonly resolveReferenceCatalog: () => BuilderReferenceCatalog;
   private readonly systemPromptSeed: () => Promise<string>;
   private readonly buildSubAgent: (opts: BuilderSubAgentBuildOptions) => Askable;
   private readonly tools: ReadonlyArray<BuilderTool<unknown, unknown>>;
@@ -323,7 +337,10 @@ export class BuilderAgent {
     this.catalogToolNames = deps.catalogToolNames;
     this.knownPluginIds = deps.knownPluginIds;
     this.slotTypechecker = deps.slotTypechecker;
-    this.referenceCatalog = deps.referenceCatalog;
+    this.resolveReferenceCatalog =
+      typeof deps.referenceCatalog === 'function'
+        ? deps.referenceCatalog
+        : () => deps.referenceCatalog as BuilderReferenceCatalog;
     this.audit = deps.audit ?? createAuditLogger(deps.draftStore);
     this.systemPromptSeed = deps.systemPromptSeed ?? defaultSystemPromptSeed;
     this.buildSubAgent = deps.buildSubAgent ?? defaultBuildSubAgent;
@@ -427,7 +444,7 @@ export class BuilderAgent {
       rebuildScheduler: this.rebuildScheduler,
       catalogToolNames: this.catalogToolNames,
       knownPluginIds: this.knownPluginIds,
-      referenceCatalog: this.referenceCatalog,
+      referenceCatalog: this.resolveReferenceCatalog(),
       slotTypechecker: this.slotTypechecker,
       slotRetryTracker,
       buildFailureBudget,

--- a/middleware/src/plugins/manifestLoader.ts
+++ b/middleware/src/plugins/manifestLoader.ts
@@ -20,6 +20,7 @@ import type {
   PluginKind,
   PluginPermissionsSummary,
   PluginSetupField,
+  ServiceTypeDecl,
 } from '../api/admin-v1.js';
 
 /**
@@ -236,6 +237,7 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
   const jobs = extractJobs(doc['jobs']);
   const provides = extractCapabilityList(doc['provides'], id, 'provides');
   const requires = extractCapabilityList(doc['requires'], id, 'requires');
+  const serviceTypes = extractServiceTypes(doc['service_types'], id);
   const channel =
     kind === 'channel' ? extractChannelBlock(doc['channel']) : undefined;
   // S+7.7 — plugins can ship their own operator-admin UI and announce
@@ -333,6 +335,9 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
     privacy_class: privacyClass,
   };
   let result: Plugin = base;
+  if (serviceTypes.length > 0) {
+    result = { ...result, service_types: serviceTypes };
+  }
   if (setupGuide) result = { ...result, setup_guide: setupGuide };
   if (channel) result = { ...result, channel };
   if (adminUiPath) result = { ...result, admin_ui_path: adminUiPath };
@@ -372,6 +377,43 @@ function extractCapabilityList(
         `[catalog] plugin '${pluginId}' ${field}: ${msg} (entry dropped)`,
       );
     }
+  }
+  return out;
+}
+
+/**
+ * Parses the `service_types:` array from an integration manifest. Each entry
+ * is `{service: string, type: {from: string, name: string}}`. These map a
+ * plugin-published `ctx.services.provide(...)` surface to the TypeScript type
+ * a consuming agent imports — the kernel registers them into the agent-
+ * builder's `serviceTypeRegistry` on activation (see index.ts wiring).
+ *
+ * Malformed entries (missing/empty `service`, `type.from`, or `type.name`)
+ * are dropped with a `console.warn`, matching this loader's graceful-
+ * degradation contract: one bad entry must not break catalog-load for the
+ * rest of the manifest. A wholly-absent block yields `[]`.
+ */
+function extractServiceTypes(
+  raw: unknown,
+  pluginId: string,
+): ServiceTypeDecl[] {
+  const arr = asArray(raw);
+  const out: ServiceTypeDecl[] = [];
+  for (const item of arr) {
+    const r = asRecord(item);
+    if (!r) continue;
+    const service = asString(r['service'])?.trim();
+    const type = asRecord(r['type']);
+    const from = asString(type?.['from'])?.trim();
+    const name = asString(type?.['name'])?.trim();
+    if (!service || !from || !name) {
+      console.warn(
+        `[catalog] plugin '${pluginId}' service_types: entry must have ` +
+          `non-empty 'service', 'type.from', and 'type.name' (entry dropped)`,
+      );
+      continue;
+    }
+    out.push({ service, type: { from, name } });
   }
   return out;
 }

--- a/middleware/src/plugins/toolPluginRuntime.ts
+++ b/middleware/src/plugins/toolPluginRuntime.ts
@@ -62,6 +62,23 @@ export interface ToolPluginRuntimeDeps {
   notificationRouter: NotificationRouter;
   uiRouteCatalog: UiRouteCatalog;
   jobScheduler: JobScheduler;
+  /**
+   * Fired after a plugin's activate() succeeds and it is recorded active.
+   * Used to register the plugin's manifest-declared `service_types` into the
+   * agent-builder's `serviceTypeRegistry` (and link its package into the
+   * build template) without a middleware restart — see the wiring in
+   * index.ts. Receives the catalog entry plus the resolved on-disk package
+   * root (symlink target for the build-template node_modules). Hook failures
+   * are logged, never propagated: a builder-registry hiccup must not flip a
+   * healthy plugin to errored.
+   */
+  onActivated?: (
+    entry: PluginCatalogEntry,
+    packagePath: string,
+  ) => void | Promise<void>;
+  /** Counterpart to `onActivated`: fired after a plugin is removed from the
+   *  active set, so the wiring can `unregisterServiceType` its entries. */
+  onDeactivated?: (agentId: string) => void | Promise<void>;
   log?: (msg: string) => void;
 }
 
@@ -218,6 +235,16 @@ export class ToolPluginRuntime {
         `[tool-runtime] registry markActivationSucceeded FAILED for ${agentId}: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
+
+    if (this.deps.onActivated) {
+      try {
+        await this.deps.onActivated(catalogEntry, packagePath);
+      } catch (err) {
+        log(
+          `[tool-runtime] onActivated hook FAILED for ${agentId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
     log(
       `[tool-runtime] ACTIVATED ${agentId} (${catalogEntry.plugin.kind}, entry=${entryRel})`,
     );
@@ -245,6 +272,16 @@ export class ToolPluginRuntime {
     this.deps.jobScheduler.stopForPlugin(agentId);
     this.deps.uiRouteCatalog.disposeBySource(agentId);
     this.active.delete(agentId);
+
+    if (this.deps.onDeactivated) {
+      try {
+        await this.deps.onDeactivated(agentId);
+      } catch (err) {
+        log(
+          `[tool-runtime] onDeactivated hook FAILED for ${agentId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
     log(`[tool-runtime] DEACTIVATED ${agentId}`);
     return true;
   }

--- a/middleware/test/builder/buildTemplate.test.ts
+++ b/middleware/test/builder/buildTemplate.test.ts
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readlinkSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -15,6 +16,7 @@ import path from 'node:path';
 import {
   cleanupStagingDir,
   ensureBuildTemplate,
+  linkWorkspacePackageIntoTemplate,
   prepareStagingDir,
 } from '../../src/plugins/builder/buildTemplate.js';
 
@@ -201,6 +203,101 @@ describe('buildTemplate', () => {
       });
       assert.equal(second.reused, false);
       assert.equal(second.ready, true);
+    });
+  });
+
+  describe('linkWorkspacePackageIntoTemplate', () => {
+    it('links a package into an existing template node_modules', async () => {
+      const templateRoot = freshTemplateRoot('link-1');
+      await ensureBuildTemplate({
+        templateRoot,
+        npmDeps: {},
+        workspaceDeps: {},
+        skipNpmInstall: true,
+      });
+      const pkg = fakeWorkspacePkg('@omadia/integration-odoo', '-link-1');
+
+      const res = await linkWorkspacePackageIntoTemplate(
+        templateRoot,
+        '@omadia/integration-odoo',
+        pkg,
+      );
+
+      assert.equal(res.linked, true);
+      const linkPath = path.join(
+        templateRoot,
+        'node_modules',
+        '@omadia',
+        'integration-odoo',
+      );
+      assert.ok(lstatSync(linkPath).isSymbolicLink());
+      const linked = JSON.parse(
+        readFileSync(path.join(linkPath, 'package.json'), 'utf-8'),
+      ) as { name: string };
+      assert.equal(linked.name, '@omadia/integration-odoo');
+    });
+
+    it('is idempotent — re-linking replaces the stale symlink', async () => {
+      const templateRoot = freshTemplateRoot('link-2');
+      await ensureBuildTemplate({
+        templateRoot,
+        npmDeps: {},
+        workspaceDeps: {},
+        skipNpmInstall: true,
+      });
+      const old = fakeWorkspacePkg('@omadia/integration-odoo', '-link-2a');
+      const fresh = fakeWorkspacePkg('@omadia/integration-odoo', '-link-2b');
+
+      await linkWorkspacePackageIntoTemplate(templateRoot, '@omadia/integration-odoo', old);
+      const second = await linkWorkspacePackageIntoTemplate(
+        templateRoot,
+        '@omadia/integration-odoo',
+        fresh,
+      );
+
+      assert.equal(second.linked, true);
+      const linkPath = path.join(
+        templateRoot,
+        'node_modules',
+        '@omadia',
+        'integration-odoo',
+      );
+      // Resolves through `fresh`, not `old`.
+      assert.ok(lstatSync(linkPath).isSymbolicLink());
+      assert.equal(path.resolve(readlinkSync(linkPath)), path.resolve(fresh));
+    });
+
+    it('no-ops (linked=false) when the template node_modules does not exist yet', async () => {
+      const templateRoot = freshTemplateRoot('link-3-missing');
+      const pkg = fakeWorkspacePkg('@omadia/integration-odoo', '-link-3');
+
+      const res = await linkWorkspacePackageIntoTemplate(
+        templateRoot,
+        '@omadia/integration-odoo',
+        pkg,
+      );
+
+      assert.equal(res.linked, false);
+      assert.ok(res.reason);
+      assert.equal(
+        existsSync(path.join(templateRoot, 'node_modules', '@omadia', 'integration-odoo')),
+        false,
+      );
+    });
+
+    it('throws with requireTemplate when node_modules is missing', async () => {
+      const templateRoot = freshTemplateRoot('link-4-require');
+      const pkg = fakeWorkspacePkg('@omadia/integration-odoo', '-link-4');
+      await assert.rejects(
+        () =>
+          linkWorkspacePackageIntoTemplate(
+            templateRoot,
+            '@omadia/integration-odoo',
+            pkg,
+            { requireTemplate: true },
+          ),
+        /template node_modules missing/,
+      );
     });
   });
 

--- a/middleware/test/manifestServiceTypes.test.ts
+++ b/middleware/test/manifestServiceTypes.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Service-type auto-discovery — verifies `adaptManifestV1` parses an
+ * integration manifest's `service_types:` block onto the loaded `Plugin`,
+ * defaults to absent when omitted, and graceful-degrades (warn + skip) on
+ * malformed entries instead of breaking catalog-load.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { adaptManifestV1 } from '../src/plugins/manifestLoader.js';
+
+function manifest(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schema_version: '1',
+    identity: {
+      id: '@omadia/integration-odoo',
+      kind: 'integration',
+      domain: 'odoo',
+      name: 'Odoo Integration',
+      version: '1.0.0',
+    },
+    ...extra,
+  };
+}
+
+test('service_types is absent when the manifest omits the block', () => {
+  const plugin = adaptManifestV1(manifest());
+  assert.ok(plugin);
+  assert.equal(plugin.service_types, undefined);
+});
+
+test('parses a well-formed service_types block', () => {
+  const plugin = adaptManifestV1(
+    manifest({
+      service_types: [
+        { service: 'odoo.client', type: { from: '@omadia/integration-odoo', name: 'OdooClient' } },
+        { service: 'odoo.cache', type: { from: '@omadia/integration-odoo', name: 'OdooResponseCache' } },
+      ],
+    }),
+  );
+  assert.ok(plugin);
+  assert.deepEqual(plugin.service_types, [
+    { service: 'odoo.client', type: { from: '@omadia/integration-odoo', name: 'OdooClient' } },
+    { service: 'odoo.cache', type: { from: '@omadia/integration-odoo', name: 'OdooResponseCache' } },
+  ]);
+});
+
+test('trims surrounding whitespace on service / from / name', () => {
+  const plugin = adaptManifestV1(
+    manifest({
+      service_types: [
+        { service: '  odoo.client  ', type: { from: ' @omadia/integration-odoo ', name: ' OdooClient ' } },
+      ],
+    }),
+  );
+  assert.ok(plugin);
+  assert.deepEqual(plugin.service_types, [
+    { service: 'odoo.client', type: { from: '@omadia/integration-odoo', name: 'OdooClient' } },
+  ]);
+});
+
+test('drops malformed entries (missing service / type.from / type.name) but keeps the valid ones', () => {
+  const plugin = adaptManifestV1(
+    manifest({
+      service_types: [
+        { service: 'odoo.client', type: { from: '@omadia/integration-odoo', name: 'OdooClient' } },
+        { type: { from: '@omadia/integration-odoo', name: 'NoService' } }, // no service
+        { service: 'odoo.broken', type: { name: 'NoFrom' } }, // no type.from
+        { service: 'odoo.broken2', type: { from: '@omadia/integration-odoo' } }, // no type.name
+        { service: 'odoo.broken3' }, // no type at all
+        'not-an-object', // wrong shape
+      ],
+    }),
+  );
+  assert.ok(plugin);
+  assert.deepEqual(plugin.service_types, [
+    { service: 'odoo.client', type: { from: '@omadia/integration-odoo', name: 'OdooClient' } },
+  ]);
+});
+
+test('a service_types block with only malformed entries yields absent (no empty array)', () => {
+  const plugin = adaptManifestV1(
+    manifest({ service_types: [{ service: 'x' }, 'bad'] }),
+  );
+  assert.ok(plugin);
+  assert.equal(plugin.service_types, undefined);
+});
+
+test('a non-array service_types value is ignored', () => {
+  const plugin = adaptManifestV1(manifest({ service_types: { service: 'x' } }));
+  assert.ok(plugin);
+  assert.equal(plugin.service_types, undefined);
+});


### PR DESCRIPTION
## What
Service-type auto-discovery so the agent-builder can build agents that depend on an installed integration (e.g. an HR agent reading Odoo via `ctx.services.get('odoo.client')`). Integrations declare their builder-consumable services in the manifest; the plugin activation lifecycle registers them live — no middleware restart.

## Why
`serviceTypeRegistry` was empty in production (`registerServiceType()` was only called from tests), so every builder spec with `external_reads` failed the manifest-linter (`external_read_unknown_service`) and codegen. Integration-backed agents were unbuildable.

New: manifests carry `service_types: [{service, type:{from,name}}]`. On activation (boot or hot-install) the kernel registers each entry into `serviceTypeRegistry` and symlinks the integration package into the shared build template, so the generated agent typechecks and resolves the service. Registry lookups are live, the catalog reloads on upload, and the builder reference catalog is now resolved per-turn — a newly-online integration is buildable immediately.

## Test plan
- [x] `tsc --noEmit` in `middleware` (clean)
- [x] `eslint --fix` on all changed files (clean)
- [x] `node --test` for new tests: `test/manifestServiceTypes.test.ts` (7) + `linkWorkspacePackageIntoTemplate` cases in `test/builder/buildTemplate.test.ts` (4) — 21 pass
- [x] regression: `builderAgent`, `buildTemplateConfig`, `builderReferenceCatalog`, `codegen`, `manifestLinter`, `readReference`, `manifestMultiInstance` — 127 pass, 0 fail
- [ ] not run: full `npm run test` suite

## Risk / blast radius
- New optional manifest field (`service_types`) — additive, defaults to absent; existing manifests unaffected.
- `loadBuildTemplateConfig` now warns + skips unresolvable registry packages instead of throwing (was a hard boot-fail path; only reachable once the registry is non-empty, which it never was before).
- `BuilderAgent.referenceCatalog` accepts a thunk in addition to a static map (backward compatible).
- End-to-end requires a follow-up PR in the byte5 plugins repo adding `service_types` to the integration manifests (`integration-odoo`, `integration-confluence`, `integration-microsoft365`).
