### PR TITLE
fix(orchestrator): scope per-Agent domain tools to enabled plugins

### DIFF
--- a/middleware/src/agents/scopeDomainTools.ts
+++ b/middleware/src/agents/scopeDomainTools.ts
@@ -1,0 +1,49 @@
+/**
+ * Per-Agent domain-tool isolation.
+ *
+ * The kernel collects every sub-agent query tool (`query_odoo_accounting`,
+ * `query_confluence_playbook`, the X agent's tool, Builder-uploaded agents,
+ * …) into a single `DomainTool[]` and hydrates the multi-orchestrator
+ * registry's per-Agent orchestrators with them. Hydrating EVERY Agent with
+ * the full set leaks capability: a scoped Agent (e.g. "marketing", which
+ * only enables the X plugin) could call `query_odoo_accounting` and reach
+ * Odoo — a connector it was never granted.
+ *
+ * A `DomainTool` carries `agentId` — the manifest id of the agent-plugin
+ * that exposes it (set by `createDomainTool` / `dynamicAgentRuntime`),
+ * e.g. `query_odoo_accounting` → `de.byte5.agent.odoo-accounting`. An Agent
+ * may use a tool only when that backing plugin is ENABLED on it. A tool
+ * with no `agentId` is a core helper (memory, ask_user_choice, …) available
+ * to everyone.
+ *
+ * The fallback Agent has every installed plugin enabled, so it still
+ * receives the full set — preserving the original boot-hydration intent of
+ * day-1, route-anything chat.
+ */
+
+import type { DomainTool } from '@omadia/orchestrator';
+
+/** Minimal shape of an Agent's plugin row needed for scoping. */
+export interface AgentPluginScope {
+  readonly pluginId: string;
+  readonly enabled: boolean;
+}
+
+/**
+ * Return the subset of `tools` an Agent with the given plugin rows may use.
+ *
+ * - `agentId === undefined` → core helper, always included.
+ * - `agentId` ∈ the Agent's enabled plugin ids → included.
+ * - otherwise → withheld.
+ */
+export function scopeDomainToolsToPlugins(
+  tools: readonly DomainTool[],
+  plugins: readonly AgentPluginScope[],
+): DomainTool[] {
+  const enabled = new Set(
+    plugins.filter((p) => p.enabled).map((p) => p.pluginId),
+  );
+  return tools.filter(
+    (t) => t.agentId === undefined || enabled.has(t.agentId),
+  );
+}

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -21,6 +21,7 @@ import { createInconsistenciesRouter } from './routes/inconsistencies.js';
 import { createDuplicatesRouter } from './routes/duplicates.js';
 import { createTopicsRouter } from './routes/topics.js';
 import { createAgentResolver } from './agents/resolveAgentForTool.js';
+import { scopeDomainToolsToPlugins } from './agents/scopeDomainTools.js';
 // `/attachments/<signed-key>` is now mounted by the de.byte5.channel.teams
 // plugin via ctx.routes.register (see packages/harness-channel-teams/src/plugin.ts,
 // phase-3.1-4). No kernel-side attachment router import needed anymore.
@@ -1065,9 +1066,20 @@ async function main(): Promise<void> {
   const registryForHydrate =
     serviceRegistry.get<MultiOrchestratorRegistry>('orchestratorRegistry');
   if (registryForHydrate) {
+    // Per-Agent tool isolation. A domain tool's `agentId` is the id of the
+    // agent-plugin that exposes it (set by `createDomainTool` /
+    // `dynamicAgentRuntime`), e.g. `query_odoo_accounting` →
+    // `de.byte5.agent.odoo-accounting`. An Agent may only reach a sub-agent
+    // query tool when that backing plugin is ENABLED on it; a tool with no
+    // `agentId` is a core helper available to everyone. The fallback Agent
+    // has every plugin enabled, so it still receives the full set
+    // (preserving the original Phase-B hydration intent) — but a scoped
+    // Agent (e.g. "marketing", which only enables the X plugin) no longer
+    // inherits `query_odoo_accounting` et al. it was never granted.
+    // See `scopeDomainToolsToPlugins` for the rule.
     let attached = 0;
     for (const entry of registryForHydrate.list()) {
-      for (const t of domainTools) {
+      for (const t of scopeDomainToolsToPlugins(domainTools, entry.plugins)) {
         if (!entry.built.orchestrator.hasDomainTool(t.name)) {
           entry.built.orchestrator.registerDomainTool(t);
           attached += 1;
@@ -1075,20 +1087,26 @@ async function main(): Promise<void> {
       }
     }
     console.log(
-      `[middleware] registry orchestrators: hydrated with ${String(attached)} domain-tool registrations across ${String(registryForHydrate.list().length)} agent(s)`,
+      `[middleware] registry orchestrators: hydrated with ${String(attached)} domain-tool registrations across ${String(registryForHydrate.list().length)} agent(s) (per-Agent plugin-scoped)`,
     );
     // Persist the wiring so a later `registry.reload()` that REBUILDS an
-    // Agent (privacy_profile flip, etc.) re-hydrates the new orchestrator.
-    // Without this, the rebuilt Agent goes back to `domainTools: []` and
-    // the operator's next chat turn cannot reach the sub-agents.
+    // Agent (privacy_profile flip, plugin enable/disable, etc.) re-hydrates
+    // the new orchestrator — still scoped to the Agent's enabled plugins.
+    // The entry is in the registry map before `onAgentBuilt` fires (both the
+    // `add` and `rebuild` actions set it first), so the plugin lookup is
+    // available here. Without this, the rebuilt Agent goes back to
+    // `domainTools: []` and the operator's next chat turn cannot reach its
+    // sub-agents.
     registryForHydrate.setOnAgentBuilt((slug, built) => {
-      for (const t of domainTools) {
+      const entry = registryForHydrate.get(slug);
+      const tools = entry ? scopeDomainToolsToPlugins(domainTools, entry.plugins) : [];
+      for (const t of tools) {
         if (!built.orchestrator.hasDomainTool(t.name)) {
           built.orchestrator.registerDomainTool(t);
         }
       }
       console.log(
-        `[middleware] registry: orchestrator for "${slug}" hydrated with ${String(domainTools.length)} domain-tool(s)`,
+        `[middleware] registry: orchestrator for "${slug}" hydrated with ${String(tools.length)} domain-tool(s) (per-Agent plugin-scoped)`,
       );
     });
   }

--- a/middleware/test/scopeDomainTools.test.ts
+++ b/middleware/test/scopeDomainTools.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Per-Agent domain-tool isolation (`scopeDomainToolsToPlugins`).
+ *
+ * Regression: the "marketing" Agent — whose only enabled plugin was
+ * `de.byte5.agent.x` — could call `query_odoo_accounting` and reach Odoo,
+ * because the kernel hydrated EVERY per-Agent orchestrator with the full
+ * domain-tool set. An Agent must only receive sub-agent tools whose backing
+ * plugin is enabled on it; the fallback (all plugins) still gets everything.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { DomainTool } from '../packages/harness-orchestrator/src/tools/domainQueryTool.js';
+import {
+  scopeDomainToolsToPlugins,
+  type AgentPluginScope,
+} from '../src/agents/scopeDomainTools.js';
+
+function tool(name: string, agentId?: string): DomainTool {
+  return {
+    name,
+    domain: 'test',
+    ...(agentId !== undefined ? { agentId } : {}),
+    spec: {
+      name,
+      description: name,
+      input_schema: { type: 'object', properties: {}, required: [] },
+    },
+    handle: () => Promise.resolve('ok'),
+  };
+}
+
+const ODOO = tool('query_odoo_accounting', 'de.byte5.agent.odoo-accounting');
+const X = tool('query_x', 'de.byte5.agent.x');
+const CONFLUENCE = tool('query_confluence_playbook', 'de.byte5.agent.confluence');
+const MEMORY = tool('memory'); // core helper, no agentId
+const ALL = [ODOO, X, CONFLUENCE, MEMORY];
+
+function plugin(pluginId: string, enabled = true): AgentPluginScope {
+  return { pluginId, enabled };
+}
+
+test('a scoped Agent only receives tools for its enabled plugins (+ core helpers)', () => {
+  // "marketing" enables only the X plugin.
+  const scoped = scopeDomainToolsToPlugins(ALL, [plugin('de.byte5.agent.x')]);
+  const names = scoped.map((t) => t.name).sort();
+  assert.deepEqual(names, ['memory', 'query_x']);
+  // The leak this fixes: Odoo must NOT be reachable.
+  assert.ok(!names.includes('query_odoo_accounting'));
+});
+
+test('the fallback Agent (all plugins enabled) still receives the full set', () => {
+  const fallbackPlugins = [
+    plugin('de.byte5.agent.odoo-accounting'),
+    plugin('de.byte5.agent.x'),
+    plugin('de.byte5.agent.confluence'),
+  ];
+  const scoped = scopeDomainToolsToPlugins(ALL, fallbackPlugins);
+  assert.equal(scoped.length, ALL.length);
+});
+
+test('a disabled plugin row does NOT grant its tool', () => {
+  const scoped = scopeDomainToolsToPlugins(ALL, [
+    plugin('de.byte5.agent.odoo-accounting', false), // disabled / quarantined
+    plugin('de.byte5.agent.x', true),
+  ]);
+  const names = scoped.map((t) => t.name).sort();
+  assert.deepEqual(names, ['memory', 'query_x']);
+});
+
+test('core helper tools (no agentId) are always included, even for a plugin-less Agent', () => {
+  const scoped = scopeDomainToolsToPlugins(ALL, []);
+  assert.deepEqual(
+    scoped.map((t) => t.name),
+    ['memory'],
+  );
+});


### PR DESCRIPTION
## What

Scope the multi-orchestrator's per-Agent domain-tool hydration to each Agent's **enabled plugins**, so an Agent can no longer call sub-agent query tools it was never granted.

## Why

The kernel collects every sub-agent query tool (`query_odoo_accounting`, `query_confluence_playbook`, the X agent's tool, Builder agents, …) into one `DomainTool[]` and hydrated **every** per-Agent orchestrator with the full set. That leaked capability across the Agent boundary: the `marketing` Agent — whose only enabled plugin is `de.byte5.agent.x` — could call `query_odoo_accounting` and reach Odoo (observed live: `marketing` → `query_odoo_accounting` → `odoo_execute account.move`). A `DomainTool` already carries `agentId` (its owning agent-plugin id, set by `createDomainTool` / `dynamicAgentRuntime`), so the fix registers a tool on an Agent only when that backing plugin is enabled on it; tools with no `agentId` are core helpers and stay available to all. The fallback Agent has every plugin enabled, so it still receives the full set — preserving the original day-1 hydration intent. Applies to both the initial hydrate loop and the `onAgentBuilt` rebuild path.

## Test plan

- [x] `npm run typecheck` (root `tsc --noEmit`, covers `src/`) — clean
- [x] `eslint src/index.ts src/agents/scopeDomainTools.ts` — clean
- [x] `node --import tsx --test test/scopeDomainTools.test.ts` — 4/4 pass (scoped Agent excludes Odoo; fallback keeps all; disabled plugin grants nothing; core helpers always included)
- [ ] manual on Fly after deploy: select `marketing`, ask an Odoo question → no `query_odoo_accounting` call

## Risk / blast radius

- Behavior change on a **core boot path** (per-Agent orchestrator hydration): scoped Agents now expose fewer tools. The fallback Agent is unaffected (all plugins enabled → full set).
- Tools with no `agentId` (core helpers) remain available to every Agent.
- No schema change, no public-API change, no new env-var, no CI/release tooling touched.