### PR TITLE
fix(builder): build integration-backed agents with empty network.outbound

### DIFF
--- a/middleware/assets/boilerplate/agent-integration/manifest.yaml
+++ b/middleware/assets/boilerplate/agent-integration/manifest.yaml
@@ -133,8 +133,11 @@ permissions:
     reads: []
     writes: []
   network:
-    outbound:
-      - "{{OUTBOUND_HOST}}"              # z.B. graph.microsoft.com
+    # Static default — codegen overwrites this from spec.network.outbound via
+    # the YAML AST. Stays `[]` for integration-backed agents that egress only
+    # through a depended-on service (e.g. odoo.client); self-contained agents
+    # that call an external API directly get their host(s) written here.
+    outbound: []
   filesystem:
     scratch: false
 

--- a/middleware/assets/boilerplate/agent-integration/template.yaml
+++ b/middleware/assets/boilerplate/agent-integration/template.yaml
@@ -150,7 +150,13 @@ placeholders:
   NOT_FOR_CASE_1: playbook.not_for[0]
   EXAMPLE_PROMPT_1: playbook.example_prompts[0]
   EXAMPLE_PROMPT_2: playbook.example_prompts[1]
-  OUTBOUND_HOST: network.outbound[0]
+  # Removed OUTBOUND_HOST (network.outbound[0]). Codegen now writes
+  # spec.network.outbound directly into permissions.network.outbound via the
+  # YAML AST (same pattern as depends_on above), so an integration-backed
+  # agent that reaches external systems THROUGH a depended-on service (e.g.
+  # ctx.services.get('odoo.client')) and has an empty network.outbound builds
+  # without a placeholder-residue error. See `reproduceManifestCapabilities`
+  # in codegen.ts for the AST-level outbound overwrite.
 
 skip_files:
   - CLAUDE.md

--- a/middleware/src/plugins/builder/codegen.ts
+++ b/middleware/src/plugins/builder/codegen.ts
@@ -485,6 +485,30 @@ function reproduceManifestCapabilities(
     }
   }
 
+  // network.outbound overwrite — write spec.network.outbound into
+  // permissions.network.outbound at the AST level (mirroring the depends_on
+  // overwrite above), instead of the boilerplate carrying a mandatory
+  // `{{OUTBOUND_HOST}}` placeholder. An integration-backed agent reaches
+  // external systems THROUGH a depended-on integration's service (e.g.
+  // `ctx.services.get('odoo.client')`) and makes no direct egress of its own,
+  // so spec.network.outbound is legitimately empty — the old placeholder
+  // failed the residue check for exactly those agents. Empty list →
+  // `outbound: []`; self-contained agents that DO call out get their hosts.
+  {
+    const permsNode = doc.get('permissions', true);
+    if (yaml.isMap(permsNode)) {
+      const netNode = permsNode.get('network', true);
+      if (yaml.isMap(netNode)) {
+        netNode.set('outbound', doc.createNode(spec.network.outbound));
+      } else {
+        permsNode.set(
+          'network',
+          doc.createNode({ outbound: spec.network.outbound }),
+        );
+      }
+    }
+  }
+
   // #91 — web_scanner lives on spec.network (not spec.permissions); emit it
   // as permissions.network.web_scanner so the runtime egress filter can
   // widen the allow-list for this audit/scanner plugin.

--- a/middleware/test/builder/codegen.test.ts
+++ b/middleware/test/builder/codegen.test.ts
@@ -412,19 +412,24 @@ describe('codegen.generate', () => {
     // token appeared in (manifest.yaml + README.md + …), burying the
     // signal. The fix collapses to a single actionable issue per missing
     // manifest source. depends_on used to be the regression case; with
-    // B.6-9.1 (DEPENDS_ON_YAML derived placeholder) it no longer fails,
-    // so we exercise the same path via OUTBOUND_HOST (network.outbound[0]).
+    // B.6-9.1 (DEPENDS_ON_YAML derived placeholder) it no longer fails, and
+    // OUTBOUND_HOST (network.outbound[0]) is likewise now AST-written from
+    // spec.network.outbound (integration-backed agents legitimately have an
+    // empty outbound) — so we exercise the fail-fast path via EXAMPLE_PROMPT_2
+    // (playbook.example_prompts[1]) with only one prompt supplied.
     const { slots } = loadFixture();
     const spec = parseAgentSpec({
       id: 'de.byte5.agent.lonely',
       name: 'Lonely',
-      description: 'no outbound',
+      description: 'one prompt only',
       category: 'other',
       depends_on: [],
       tools: [{ id: 'do_thing', description: 'x', input: { type: 'object' } }],
       skill: { role: 'x' },
-      playbook: { when_to_use: 'x', not_for: ['x'], example_prompts: ['x', 'y'] },
-      network: { outbound: [] }, // <-- OUTBOUND_HOST resolves to undefined
+      // Only one example prompt → EXAMPLE_PROMPT_2 (example_prompts[1]) is
+      // unresolved; everything else resolves.
+      playbook: { when_to_use: 'x', not_for: ['x'], example_prompts: ['x'] },
+      network: { outbound: [] }, // now AST-written as `outbound: []`, no residue
     });
     await assert.rejects(
       () => generate({ spec, slots }),
@@ -433,15 +438,59 @@ describe('codegen.generate', () => {
         const residues = err.issues.filter(
           (i) => i.code === 'placeholder_residue',
         );
-        // Exactly one residue per missing source (here: network.outbound[0] →
-        // OUTBOUND_HOST), not one per file the placeholder appears in.
+        // Exactly one residue per missing source (here: example_prompts[1] →
+        // EXAMPLE_PROMPT_2), not one per file the placeholder appears in.
         assert.equal(residues.length, 1);
         const detail = residues[0]!.detail;
-        assert.match(detail, /\{\{OUTBOUND_HOST\}\}/);
-        assert.match(detail, /network\.outbound\[0\]/);
+        assert.match(detail, /\{\{EXAMPLE_PROMPT_2\}\}/);
+        assert.match(detail, /playbook\.example_prompts\[1\]/);
         return true;
       },
     );
+  });
+
+  it('renders network.outbound: [] for an integration-backed agent (empty outbound)', async () => {
+    // Regression for the builder.codegen_failed blocker: an agent that reaches
+    // an external system THROUGH a depended-on integration service (e.g.
+    // ctx.services.get('odoo.client')) has an empty spec.network.outbound.
+    // The old `{{OUTBOUND_HOST}}` placeholder failed the residue check; codegen
+    // now AST-writes spec.network.outbound, so an empty list is valid.
+    const { slots } = loadFixture();
+    const spec = parseAgentSpec({
+      id: 'de.byte5.agent.odoo-consumer',
+      name: 'Odoo Consumer',
+      description: 'reads odoo via the odoo.client service, no direct egress',
+      category: 'other',
+      depends_on: ['@omadia/integration-odoo'],
+      tools: [{ id: 'do_thing', description: 'x', input: { type: 'object' } }],
+      skill: { role: 'x' },
+      playbook: { when_to_use: 'x', not_for: ['x'], example_prompts: ['x', 'y'] },
+      network: { outbound: [] },
+    });
+    const out = await generate({ spec, slots });
+    const manifest = out.get('manifest.yaml')!.toString('utf-8');
+    assert.doesNotMatch(manifest, /\{\{OUTBOUND_HOST\}\}/);
+    assert.match(manifest, /outbound:\s*\[\s*\]/);
+  });
+
+  it('AST-writes spec.network.outbound hosts into the manifest', async () => {
+    // A self-contained agent that calls an external API directly still gets
+    // its host(s) written into permissions.network.outbound.
+    const { slots } = loadFixture();
+    const spec = parseAgentSpec({
+      id: 'de.byte5.agent.direct',
+      name: 'Direct Caller',
+      description: 'calls an external API directly',
+      category: 'other',
+      depends_on: [],
+      tools: [{ id: 'do_thing', description: 'x', input: { type: 'object' } }],
+      skill: { role: 'x' },
+      playbook: { when_to_use: 'x', not_for: ['x'], example_prompts: ['x', 'y'] },
+      network: { outbound: ['api.example.com'] },
+    });
+    const out = await generate({ spec, slots });
+    const manifest = out.get('manifest.yaml')!.toString('utf-8');
+    assert.match(manifest, /outbound:[\s\S]*api\.example\.com/);
   });
 
   it('renders depends_on: [] when spec.depends_on is empty (B.6-9.1)', async () => {


### PR DESCRIPTION
## What
Fix `BuildPipeline: codegen failed (1 issue)` for **integration-backed agents** in the builder. Codegen now writes `spec.network.outbound` into `permissions.network.outbound` via the YAML AST; the `agent-integration` boilerplate ships a static `outbound: []` default instead of a mandatory `{{OUTBOUND_HOST}}` placeholder.

## Why
An agent that reaches an external system **through a depended-on integration service** (e.g. `ctx.services.get('odoo.client')`) makes no direct egress of its own, so `spec.network.outbound` is legitimately empty. The boilerplate's `{{OUTBOUND_HOST}}` placeholder (sourced from `network.outbound[0]`) then stayed unresolved → `placeholder_residue` → codegen failed. This is the same class of fix as the earlier `depends_on` one (B.6-9.1), which switched from a placeholder to an AST overwrite for exactly this reason.

Reproduced against the real failing draft (an Odoo HR agent): codegen now produces the full file set with `outbound: []`.

## Test plan
- [x] `tsc --noEmit` in `middleware` (clean)
- [x] `eslint --fix` on changed files (clean)
- [x] `node --test test/builder/codegen.test.ts` — 43 pass, incl. 2 new regression tests (empty outbound → `outbound: []`; non-empty outbound → hosts written) and the updated fail-fast residue test (now exercised via `EXAMPLE_PROMPT_2`, since `OUTBOUND_HOST` is no longer a placeholder)
- [x] reproduced end-to-end against the real draft spec+slots → codegen OK

## Risk / blast radius
- Boilerplate + codegen change only; additive AST write mirrors the existing `depends_on`/`web_scanner` handling. Self-contained agents that call an API directly still get their hosts written into the manifest.
