### PR TITLE
feat(builder): preview reads through to live ServiceRegistry for integration-backed agents

### DIFF
--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -1861,6 +1861,11 @@ async function main(): Promise<void> {
   const previewRuntime = new PreviewRuntime({
     previewsRoot: BUILDER_PREVIEWS_DIR,
     templateNodeModulesPath: path.join(BUILDER_BUILD_TEMPLATE_DIR, 'node_modules'),
+    // Solution B: read through to the live kernel ServiceRegistry so an
+    // integration-backed agent under test resolves the real services its
+    // depends_on integrations provide (e.g. odoo.client) — preview goes green
+    // and the agent is testable before install, no middleware restart.
+    serviceRegistry,
     logger: () => {},
   });
   const orphanResult = await previewRuntime

--- a/middleware/src/plugins/builder/previewRuntime.ts
+++ b/middleware/src/plugins/builder/previewRuntime.ts
@@ -99,13 +99,15 @@ export interface PreviewPluginContext {
   readonly uiRoutes: {
     register(descriptor: PreviewUiRouteDescriptorInput): () => void;
   };
-  /** Theme A: stub-only ServicesAccessor. Preview wires no real
-   *  ServiceRegistry, so every lookup returns `undefined`. Agents using
-   *  `spec.external_reads` will hit their codegen-emitted
-   *  `if (!svc) throw …` guard, which is the correct failure mode for
-   *  preview — real services land at install-time when the host kernel
-   *  wires up `dynamicAgentRuntime`'s ServiceRegistry. Solving B (real
-   *  preview registry) is its own theme; see
+  /** ServicesAccessor (solution B). When the runtime is wired with the live
+   *  kernel ServiceRegistry (`PreviewRuntimeDeps.serviceRegistry`), `get`/`has`
+   *  read through to it, so an integration-backed agent under test resolves
+   *  the real services its `depends_on` integrations provide (e.g.
+   *  `odoo.client`) and runs against the live integration. Without a wired
+   *  registry, `get` returns `undefined` and `spec.external_reads`/service
+   *  consumers hit their codegen-emitted `if (!svc) throw …` guard (the legacy
+   *  stub fallback). Services the previewed agent itself `provide`s stay
+   *  preview-local and never mutate the kernel registry. Background:
    *  `docs/harness-platform/HANDOFF-2026-05-04-preview-services-undefined.md`. */
   readonly services: {
     get<T>(name: string): T | undefined;
@@ -158,12 +160,37 @@ export interface PreviewHandle {
   close(): Promise<void>;
 }
 
+/**
+ * Read-through host service surface. Structural subset of the kernel's
+ * `ServiceRegistry` — only the lookups the preview needs. Kept structural so
+ * previewRuntime stays decoupled from the platform ServiceRegistry type.
+ */
+export interface PreviewHostServices {
+  get<T>(name: string): T | undefined;
+  has(name: string): boolean;
+}
+
 export interface PreviewRuntimeDeps {
   /** Absolute path to `data/builder/.previews/`. */
   previewsRoot: string;
   /** Default: 10s — same budget as activate() in dynamicAgentRuntime. */
   activateTimeoutMs?: number;
   logger?: (...args: unknown[]) => void;
+  /**
+   * Live kernel ServiceRegistry. When set, the preview's `ctx.services.get/has`
+   * read through to it, so an integration-backed agent under test resolves the
+   * real services its `depends_on` integrations provide (e.g. `odoo.client`) —
+   * the previewed agent runs against the live, already-configured integration
+   * instead of hitting its own `if (!svc) throw` guard. Without it, lookups
+   * return undefined (legacy stub behaviour). Services the previewed agent
+   * itself `provide`s stay preview-local and never mutate the kernel registry.
+   *
+   * Note: the agent then makes REAL calls through those services during a
+   * preview test (e.g. live Odoo reads with the installed integration's
+   * credentials) — which is the point of "test the agent", and safe for the
+   * read-only integrations this targets.
+   */
+  serviceRegistry?: PreviewHostServices;
   /** Absolute path to the shared build-template's `node_modules`. When set,
    *  the runtime symlinks it into the extracted package root before activate
    *  so dynamic-import calls resolve `zod` etc. The build-zip step ships the
@@ -186,6 +213,7 @@ export class PreviewRuntime {
   private readonly activateTimeoutMs: number;
   private readonly log: (...args: unknown[]) => void;
   private readonly templateNodeModulesPath: string | undefined;
+  private readonly hostServices: PreviewHostServices | undefined;
   private readonly extractZip: (zipBuffer: Buffer, destDir: string) => Promise<void>;
   private readonly activateModule: (
     entryAbs: string,
@@ -197,6 +225,7 @@ export class PreviewRuntime {
     this.activateTimeoutMs = deps.activateTimeoutMs ?? DEFAULT_ACTIVATE_TIMEOUT_MS;
     this.log = deps.logger ?? ((...args) => console.log('[preview]', ...args));
     this.templateNodeModulesPath = deps.templateNodeModulesPath;
+    this.hostServices = deps.serviceRegistry;
     this.extractZip = deps.extractZip ?? defaultExtractZip;
     this.activateModule = deps.activateModule ?? defaultActivateModule;
   }
@@ -307,6 +336,7 @@ export class PreviewRuntime {
       secretValues: opts.secretValues,
       smokeMode: opts.smokeMode === true,
       routeCaptures,
+      hostServices: this.hostServices,
       logger: (...args) => this.log(`[${agentId}]`, ...args),
     });
 
@@ -351,8 +381,16 @@ function createStubContext(opts: {
   secretValues: Readonly<Record<string, string>>;
   smokeMode: boolean;
   routeCaptures: PreviewRouteCapture[];
+  hostServices?: PreviewHostServices;
   logger: (...args: unknown[]) => void;
 }): PreviewPluginContext {
+  // Services the previewed agent provides itself stay isolated to this
+  // preview activation — they never leak into the live kernel ServiceRegistry.
+  // Lookups check this local layer first, then read through to the host
+  // registry (when wired) so cross-plugin services from `depends_on`
+  // integrations resolve.
+  const localServices = new Map<string, unknown>();
+  const host = opts.hostServices;
   return {
     agentId: opts.agentId,
     secrets: {
@@ -407,17 +445,33 @@ function createStubContext(opts: {
     uiRoutes: {
       register: (_descriptor) => () => {},
     },
-    // Theme A: no-op ServicesAccessor stub. Preview never wires a real
-    // ServiceRegistry, so external_reads-driven `ctx.services.get(...)`
-    // calls return undefined, the codegen-emitted null-guard throws
-    // a descriptive `service '<name>' is not registered` error, and the
-    // operator sees a real failure message instead of a TypeError. See
-    // `HANDOFF-2026-05-04-preview-services-undefined.md` (solution A).
+    // ServicesAccessor (solution B): read through to the live kernel
+    // ServiceRegistry when one is wired, so an integration-backed agent under
+    // test resolves the real services its `depends_on` integrations provide
+    // (e.g. `odoo.client`). When no host registry is wired (legacy / unit
+    // tests), `get` returns undefined and the agent hits its own
+    // `if (!svc) throw` guard — the previous stub behaviour. Provides made by
+    // the previewed agent stay in `localServices` and are checked first, so
+    // they neither leak into the kernel registry nor get shadowed by it.
     services: {
-      get: <T,>(_name: string): T | undefined => undefined,
-      has: (_name: string): boolean => false,
-      provide: <T,>(_name: string, _impl: T): (() => void) => () => {},
-      replace: <T,>(_name: string, _impl: T): (() => void) => () => {},
+      get: <T,>(name: string): T | undefined => {
+        if (localServices.has(name)) return localServices.get(name) as T;
+        return host ? host.get<T>(name) : undefined;
+      },
+      has: (name: string): boolean =>
+        localServices.has(name) || (host ? host.has(name) : false),
+      provide: <T,>(name: string, impl: T): (() => void) => {
+        localServices.set(name, impl);
+        return () => {
+          localServices.delete(name);
+        };
+      },
+      replace: <T,>(name: string, impl: T): (() => void) => {
+        localServices.set(name, impl);
+        return () => {
+          localServices.delete(name);
+        };
+      },
     },
     smokeMode: opts.smokeMode,
     log: opts.logger,

--- a/middleware/test/builder/previewRuntime.test.ts
+++ b/middleware/test/builder/previewRuntime.test.ts
@@ -14,6 +14,7 @@ import { z } from 'zod';
 import {
   PreviewRuntime,
   type PreviewAgentHandle,
+  type PreviewHostServices,
   type PreviewPluginContext,
 } from '../../src/plugins/builder/previewRuntime.js';
 import { PreviewStore } from '../../src/plugins/builder/previewStore.js';
@@ -44,10 +45,12 @@ describe('PreviewRuntime', () => {
     handle?: PreviewAgentHandle;
     onActivate?: (ctx: PreviewPluginContext) => void;
     activateThrows?: Error;
+    serviceRegistry?: PreviewHostServices;
   }): PreviewRuntime {
     return new PreviewRuntime({
       previewsRoot: opts.previewsRoot,
       logger: () => {},
+      ...(opts.serviceRegistry ? { serviceRegistry: opts.serviceRegistry } : {}),
       extractZip: async (_zipBuf, destDir) => {
         mkdirSync(destDir, { recursive: true });
         writeFileSync(
@@ -204,7 +207,7 @@ describe('PreviewRuntime', () => {
       assert.equal(typeof captured!.routes.register, 'function');
     });
 
-    it('exposes ctx.services as a no-op ServicesAccessor stub so external_reads plugins activate to a clean throw, not TypeError', async () => {
+    it('falls back to undefined lookups when no host ServiceRegistry is wired (legacy stub behaviour)', async () => {
       // Theme A regression: previewRuntime previously had no `services`
       // field on its stub context, so codegen-emitted
       // `ctx.services.get<…>('odoo.client')` calls in plugins using
@@ -237,6 +240,49 @@ describe('PreviewRuntime', () => {
       // Calling the dispose handle is a no-op — must not throw even
       // though no real registration ever happened.
       dispose();
+    });
+
+    it('reads through to the host ServiceRegistry so integration-backed agents resolve real services (solution B)', async () => {
+      // The blocker: an integration-backed agent does
+      // `ctx.services.get('odoo.client')`; with the old stub that always
+      // returned undefined, the preview hit the agent's null-guard and could
+      // never go green → never installable. Wiring the live registry lets the
+      // previewed agent resolve the real service its depends_on integration
+      // provides.
+      const odooClient = { execute: () => 'ok' };
+      const host: PreviewHostServices = {
+        get: <T,>(name: string): T | undefined =>
+          name === 'odoo.client' ? (odooClient as T) : undefined,
+        has: (name: string): boolean => name === 'odoo.client',
+      };
+      const root = freshRoot('services-readthrough');
+      let captured: PreviewPluginContext | undefined;
+      const runtime = buildRuntime({
+        previewsRoot: root,
+        serviceRegistry: host,
+        onActivate: (ctx) => {
+          captured = ctx;
+        },
+      });
+      await runtime.activate({
+        zipBuffer: Buffer.alloc(0),
+        draftId: 'd1',
+        rev: 1,
+        configValues: {},
+        secretValues: {},
+      });
+      assert.ok(captured);
+      // Read-through to the host registry.
+      assert.equal(captured!.services.get('odoo.client'), odooClient);
+      assert.equal(captured!.services.has('odoo.client'), true);
+      assert.equal(captured!.services.get('not.there'), undefined);
+      // Agent-provided services stay preview-local and do NOT mutate the host
+      // registry; local entries are checked before the host.
+      const dispose = captured!.services.provide('local.only', { y: 2 });
+      assert.deepEqual(captured!.services.get('local.only'), { y: 2 });
+      assert.equal(host.has('local.only'), false);
+      dispose();
+      assert.equal(captured!.services.get('local.only'), undefined);
     });
 
     it('throws when secrets.require is called for a missing key', async () => {


### PR DESCRIPTION
## What
Wire the builder **preview** sandbox to the live kernel `ServiceRegistry`. `ctx.services.get/has` now read through to it, so an **integration-backed agent under test** resolves the real services its `depends_on` integrations provide (e.g. `odoo.client`) and runs against the live, already-configured integration.

## Why
The preview's `ServicesAccessor` was a no-op stub that always returned `undefined`. Any agent doing `ctx.services.get('odoo.client')` therefore hit its own `if (!svc) throw` guard in preview (`odoo.client unavailable …`). The preview could never go green for integration-backed agents → the agent was never installable. This is the last gap in the "build agents on top of installed integrations" flow (companion to #196 service-type autodiscovery and #198 empty-outbound codegen).

Services the previewed agent itself `provide`s stay **preview-local** (checked before the host) and never mutate the kernel registry. With no host registry wired, lookups return `undefined` — the legacy stub behaviour, preserved for unit tests.

> Note: a preview test now makes **real calls** through those services (e.g. live Odoo reads with the installed integration's credentials) — which is the point of "test the agent", and safe for the read-only integrations this targets.

## Test plan
- [x] `tsc --noEmit` (clean)
- [x] `eslint --fix` on changed files (clean)
- [x] `node --test test/builder/previewRuntime.test.ts` — 16 pass, incl. a new read-through test (host get/has delegated; agent-provided services stay local + dispose) and the retained no-registry fallback test

## Risk / blast radius
- Additive: `serviceRegistry` is an optional `PreviewRuntimeDeps` field; omitting it preserves the old stub behaviour. Only the builder preview path is affected.
- The previewed agent can read any registered service (not scoped to its `depends_on`) — matches real runtime, where the ServiceRegistry is global.
