### PR TITLE
feat(channels): per-binding agent routing + channelType autodiscovery (US7)

### DIFF
--- a/middleware/packages/harness-channel-sdk/src/channelRouting.ts
+++ b/middleware/packages/harness-channel-sdk/src/channelRouting.ts
@@ -1,0 +1,91 @@
+import type { PluginContext } from '@omadia/plugin-api';
+
+import type { ChatAgent } from './chatAgent.js';
+import { getChatAgent } from './chatAgentService.js';
+
+/**
+ * Per-binding channel routing seam (US7).
+ *
+ * The platform's multi-orchestrator registry builds one *scoped* orchestrator
+ * per Agent — each carrying only the domain tools its enabled plugins grant.
+ * Inbound channel turns must reach the Agent the operator *bound* to their
+ * `(channel_type, channel_key)`, not the shared, fully-tooled `chatAgent`
+ * singleton. The orchestrator plugin publishes a {@link ChannelBindingResolver}
+ * under {@link CHANNEL_RESOLVER_SERVICE} that does exactly that lookup.
+ *
+ * A channel adapter that holds a *single* agent across many conversations
+ * (Teams, Telegram) must therefore resolve the agent **per turn** — keyed by
+ * the conversation's `(channelType, channelKey)` — rather than caching
+ * `getChatAgent(ctx)` once at activate(). {@link resolveChatAgentForChannel}
+ * is the blessed way to do that: it consults the resolver and degrades to the
+ * shared singleton when no binding (and no platform fallback Agent) matches, so
+ * deployments without the multi-orchestrator registry behave exactly as before.
+ */
+
+/**
+ * Service-registry key under which the orchestrator plugin publishes its
+ * channel resolver. Stable contract — channels resolve it by this name.
+ */
+export const CHANNEL_RESOLVER_SERVICE = 'channelResolver';
+
+export type ChannelResolveDecision = 'bound' | 'fallback' | 'reject';
+
+/** What {@link ChannelBindingResolver.resolve} returns for a lookup. */
+export interface ChannelResolveResult {
+  readonly decision: ChannelResolveDecision;
+  /**
+   * The bound (or platform-fallback) Agent's scoped {@link ChatAgent}. Present
+   * iff `decision !== 'reject'`.
+   */
+  readonly chatAgent?: ChatAgent;
+}
+
+/**
+ * Structural view of the orchestrator's `ChannelResolver` — the only surface a
+ * channel plugin consumes. Kept structural so the SDK does not take a build
+ * dependency on `@omadia/orchestrator`.
+ */
+export interface ChannelBindingResolver {
+  resolve(channelType: string, channelKey: string): ChannelResolveResult;
+}
+
+/**
+ * Resolve the {@link ChatAgent} bound to a given `(channelType, channelKey)`
+ * via the platform {@link CHANNEL_RESOLVER_SERVICE}, falling back to the shared
+ * singleton agent ({@link getChatAgent}) when:
+ *   - the resolver service is not published (no multi-orchestrator registry —
+ *     e.g. a Postgres-less minimal deployment), or
+ *   - the resolver rejects the route (no binding AND no platform fallback
+ *     Agent configured).
+ *
+ * Call this **per turn**. A channel adapter that caches the result at
+ * activate() defeats per-binding routing and hot config reloads — the whole
+ * point of the seam.
+ *
+ * Returns `undefined` only when neither a bound agent nor the singleton is
+ * available (orchestrator plugin inactive); callers SHOULD surface a clear
+ * "orchestrator unavailable" message rather than silently dropping the turn.
+ *
+ * @example
+ * // Teams: channelType is constant for the plugin; channelKey is the
+ * // conversation id the operator binds in the dashboard.
+ * const agent = resolveChatAgentForChannel(ctx, 'teams', conversationId);
+ * if (!agent) throw new Error('orchestrator unavailable');
+ * const answer = await agent.chat({ userMessage, sessionScope, userId });
+ */
+export function resolveChatAgentForChannel(
+  ctx: PluginContext,
+  channelType: string,
+  channelKey: string,
+): ChatAgent | undefined {
+  const resolver = ctx.services.get<ChannelBindingResolver>(
+    CHANNEL_RESOLVER_SERVICE,
+  );
+  if (resolver) {
+    const result = resolver.resolve(channelType, channelKey);
+    if (result.decision !== 'reject' && result.chatAgent) {
+      return result.chatAgent;
+    }
+  }
+  return getChatAgent(ctx);
+}

--- a/middleware/packages/harness-channel-sdk/src/incoming.ts
+++ b/middleware/packages/harness-channel-sdk/src/incoming.ts
@@ -10,6 +10,24 @@ export interface IncomingTurn {
   channelId: string;
   /** channel-specific thread/chat id */
   conversationId: string;
+  /**
+   * Routing selector — the `channel_bindings.channel_type` this turn belongs
+   * to (e.g. `"teams"`, `"telegram"`). Additive (US7 per-binding routing): a
+   * channel adapter MAY set it so the core routes the turn to the bound
+   * Agent's scoped orchestrator. When absent, the core derives it from
+   * `channelId` (manifest `channel.channel_type`, else the last dotted segment
+   * of the id). Classic adapters that never set it keep dispatching to the
+   * shared `chatAgent`.
+   */
+  channelType?: string;
+  /**
+   * Routing selector — the `channel_bindings.channel_key` for this turn. The
+   * opaque per-binding key the operator bound to an Agent (Teams conversation
+   * id, Telegram chat id / `@bot_username`, …). Additive: when absent the core
+   * falls back to `conversationId`. Paired with {@link channelType} to look up
+   * the bound Agent via the platform `channelResolver`.
+   */
+  channelKey?: string;
   /** channel-native user ref */
   userRef: ChannelUserRef;
   /** user's message as plain text (mentions resolved, markup stripped) */

--- a/middleware/packages/harness-channel-sdk/src/index.ts
+++ b/middleware/packages/harness-channel-sdk/src/index.ts
@@ -19,6 +19,18 @@ export {
   type ChatAgentBundle,
 } from './chatAgentService.js';
 
+// US7 per-binding routing — resolve the *scoped* ChatAgent bound to a turn's
+// (channelType, channelKey) via the platform channelResolver. Direct-agent
+// channels (Teams, Telegram) MUST call this per turn instead of caching
+// getChatAgent(ctx), so each conversation reaches the Agent it was bound to.
+export {
+  CHANNEL_RESOLVER_SERVICE,
+  resolveChatAgentForChannel,
+  type ChannelBindingResolver,
+  type ChannelResolveResult,
+  type ChannelResolveDecision,
+} from './channelRouting.js';
+
 // Inbound message shape
 export type {
   IncomingTurn,

--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -168,6 +168,14 @@ export interface ChannelManifestBlock {
    */
   dispatch_service?: string;
   /**
+   * US7 per-binding routing (additive): the short `channel_bindings.channel_type`
+   * selector this channel's turns route under (`"teams"`, `"telegram"`, …).
+   * Absent → the core derives it from the last dotted segment of the plugin id
+   * (`de.byte5.channel.teams` → `teams`). Declare it only when the id does not
+   * follow the `*.channel.<type>` convention. See `deriveChannelType`.
+   */
+  channel_type?: string;
+  /**
    * Omadia UI (additive): the omadia-canvas-protocol version this channel
    * speaks (e.g. `"1.0"`). Informational at the manifest layer; the actual
    * version is negotiated in the boot handshake.

--- a/middleware/src/channels/channelType.ts
+++ b/middleware/src/channels/channelType.ts
@@ -1,0 +1,48 @@
+import type { ChannelManifestBlock } from '../api/admin-v1.js';
+
+/**
+ * Channel-type autodiscovery (US7).
+ *
+ * Inbound turns carry a `channelId` (the plugin's catalog id, e.g.
+ * `"de.byte5.channel.teams"`), but `channel_bindings` key on a short
+ * `channel_type` (`"teams"`, `"telegram"` — the convention operators type in
+ * the dashboard and `agents-apply`). This bridges the two so the dispatcher can
+ * look a turn up against the binding table without any per-channel wiring.
+ *
+ * Resolution order — first hit wins:
+ *   1. The channel manifest's declared `channel.channel_type` (explicit,
+ *      authoritative — a plugin that needs a non-derivable type sets it).
+ *   2. The last dotted segment of the `channelId`
+ *      (`de.byte5.channel.teams` → `teams`). Covers every channel that follows
+ *      the reverse-DNS `*.channel.<type>` id convention with zero config.
+ *
+ * The derived value is lowercased + trimmed so a manifest typo
+ * (`"Teams"`) and the operator's `"teams"` still match.
+ */
+export interface DeriveChannelTypeSources {
+  /** The channel's manifest `channel` block, if loaded in the catalog. */
+  readonly manifest?: ChannelManifestBlock | undefined;
+}
+
+export function deriveChannelType(
+  channelId: string,
+  sources: DeriveChannelTypeSources = {},
+): string {
+  const declared = sources.manifest?.channel_type;
+  if (typeof declared === 'string' && declared.trim().length > 0) {
+    return normalize(declared);
+  }
+  return normalize(lastSegment(channelId));
+}
+
+function lastSegment(channelId: string): string {
+  const trimmed = channelId.trim();
+  const dot = trimmed.lastIndexOf('.');
+  return dot >= 0 && dot < trimmed.length - 1
+    ? trimmed.slice(dot + 1)
+    : trimmed;
+}
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}

--- a/middleware/src/channels/coreApi.ts
+++ b/middleware/src/channels/coreApi.ts
@@ -25,6 +25,17 @@ export interface TurnDispatcher {
      * (Omadia UI); absent-from-manifest falls back to the shared 'chatAgent'.
      */
     channelId: string;
+    /**
+     * US7 per-binding routing — the `channel_bindings.channel_type` selector
+     * for this turn. Absent → the dispatcher derives it from `channelId`.
+     */
+    channelType?: string;
+    /**
+     * US7 per-binding routing — the `channel_bindings.channel_key` for this
+     * turn (defaulted to the conversation id by the core). Paired with
+     * `channelType` to look up the bound Agent's scoped orchestrator.
+     */
+    channelKey?: string;
     userRef: ChannelUserRef;
     text: string;
     metadata?: Record<string, unknown>;
@@ -53,9 +64,16 @@ export function createCoreApi(opts: CreateCoreApiOptions): CoreApi {
       // chat thread per channel, survives restarts (same mapping yields the
       // same scope, so memory/graph continue to accumulate context).
       const scope = `${turn.channelId}::${turn.conversationId}`;
+      // US7 per-binding routing selectors. The adapter MAY set channelType /
+      // channelKey explicitly; otherwise the dispatcher derives the type from
+      // channelId and the key defaults to the conversation id (the value an
+      // operator binds for conversation-scoped channels like Teams).
+      const channelKey = turn.channelKey ?? turn.conversationId;
       return opts.dispatcher.streamTurn({
         scope,
         channelId: turn.channelId,
+        channelKey,
+        ...(turn.channelType ? { channelType: turn.channelType } : {}),
         userRef: turn.userRef,
         text: turn.text,
         ...(turn.metadata ? { metadata: turn.metadata } : {}),

--- a/middleware/src/channels/orchestratorDispatcher.ts
+++ b/middleware/src/channels/orchestratorDispatcher.ts
@@ -1,4 +1,5 @@
-import type { ChatAgentBundle } from '@omadia/channel-sdk';
+import { CHAT_AGENT_SERVICE } from '@omadia/channel-sdk';
+import type { ChatAgent, ChatAgentBundle } from '@omadia/channel-sdk';
 
 import type { ChannelManifestBlock } from '../api/admin-v1.js';
 import type { TurnDispatcher } from './coreApi.js';
@@ -7,31 +8,78 @@ import { resolveDispatchService } from './dispatchService.js';
 /**
  * Minimal structural dependencies of the orchestrator dispatcher, injected so
  * the routing logic is unit-testable without standing up the full boot graph.
- * At boot these are backed by `pluginCatalog` and the `serviceRegistry`.
+ * At boot these are backed by `pluginCatalog`, the multi-orchestrator
+ * `channelResolver`, and the `serviceRegistry`.
  */
 export interface OrchestratorDispatcherDeps {
   /** A loaded channel plugin's manifest `channel` block, by channel id. */
   getChannelBlock(channelId: string): ChannelManifestBlock | undefined;
   /** The ChatAgentBundle registered under a bare service key, or undefined. */
   getAgentBundle(service: string): ChatAgentBundle | undefined;
+  /**
+   * US7 per-binding routing: resolve the *scoped* ChatAgent bound to a turn's
+   * `(channelType, channelKey)` via the multi-orchestrator `channelResolver`.
+   * Returns `undefined` when no binding (and no platform fallback Agent)
+   * matches, OR when the resolver is not wired (Postgres-less deployment) — the
+   * dispatcher then falls back to the static `dispatch_service`. Optional so the
+   * legacy single-Agent boot and unit tests work without it.
+   */
+  resolveBinding?(channelType: string, channelKey: string): ChatAgent | undefined;
+  /**
+   * Map a `channelId` (plugin catalog id) to its `channel_bindings.channel_type`
+   * selector (`de.byte5.channel.teams` → `teams`). Optional — paired with
+   * `resolveBinding`; absent disables per-binding routing.
+   */
+  channelTypeFor?(channelId: string): string;
 }
 
 /**
- * Build the real `TurnDispatcher`: per turn, resolve the channel's configured
- * `dispatch_service` (default `chatAgent`), fetch that orchestrator bundle from
- * the registry, and stream its events back. Resolution is lazy per turn so the
- * currently-active orchestrator is always used. Classic channels declare no
- * `dispatch_service` and dispatch to `chatAgent` exactly as before.
+ * Build the real `TurnDispatcher`. Per turn:
+ *
+ *   1. **Per-binding routing (US7).** When the channel routes to the shared
+ *      `chatAgent` (i.e. declares no explicit `dispatch_service`) and a
+ *      `channelKey` is known, resolve the Agent the operator *bound* to this
+ *      `(channelType, channelKey)` via the `channelResolver`. This is what
+ *      makes a Teams/web turn reach its scoped orchestrator instead of the
+ *      fully-tooled singleton.
+ *   2. **Static dispatch_service fallback.** No binding match (or no resolver,
+ *      or an explicit `dispatch_service` like Omadia UI's `canvasChatAgent`) →
+ *      fetch that bundle from the registry exactly as before. An explicit
+ *      `dispatch_service` is an intentional override and is NEVER re-routed by
+ *      the binding resolver.
+ *
+ * Resolution is lazy per turn so the currently-active orchestrator (and the
+ * live binding table, post hot-reload) is always used. Classic channels with no
+ * bindings and no `dispatch_service` dispatch to `chatAgent` exactly as before.
  */
 export function createOrchestratorDispatcher(
   deps: OrchestratorDispatcherDeps,
 ): TurnDispatcher {
   return {
     async *streamTurn(input) {
-      const dispatchService = resolveDispatchService(
-        deps.getChannelBlock(input.channelId),
-      );
-      const agent = deps.getAgentBundle(dispatchService)?.agent;
+      const block = deps.getChannelBlock(input.channelId);
+      const dispatchService = resolveDispatchService(block);
+
+      let agent: ChatAgent | undefined;
+
+      // (1) Per-binding routing — only for channels that would otherwise hit
+      // the shared chatAgent. An explicit dispatch_service (canvas) opts out.
+      if (
+        dispatchService === CHAT_AGENT_SERVICE &&
+        deps.resolveBinding &&
+        deps.channelTypeFor &&
+        input.channelKey
+      ) {
+        const channelType =
+          input.channelType ?? deps.channelTypeFor(input.channelId);
+        agent = deps.resolveBinding(channelType, input.channelKey);
+      }
+
+      // (2) Static dispatch_service fallback (legacy + canvas).
+      if (!agent) {
+        agent = deps.getAgentBundle(dispatchService)?.agent;
+      }
+
       if (!agent) {
         console.warn(
           `[channels] no '${dispatchService}' agent registered — turn ignored (scope=${input.scope})`,

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -185,10 +185,11 @@ import { ExpressRouteRegistry } from './channels/routeRegistry.js';
 import { createCoreApi } from './channels/coreApi.js';
 import { ChannelDirectoryRegistry } from './channels/channelDirectoryRegistry.js';
 import { DefaultChannelRegistry } from './channels/channelRegistry.js';
-import type { ChannelRegistry } from '@omadia/channel-sdk';
+import type { ChannelRegistry, ChannelBindingResolver } from '@omadia/channel-sdk';
 import { DynamicChannelPluginResolver } from './channels/dynamicChannelResolver.js';
 import type { TurnDispatcher } from './channels/coreApi.js';
 import { createOrchestratorDispatcher } from './channels/orchestratorDispatcher.js';
+import { deriveChannelType } from './channels/channelType.js';
 import type { FactExtractor } from '@omadia/orchestrator-extras';
 import { backfillGraph } from '@omadia/orchestrator-extras';
 import { turnContext } from '@omadia/orchestrator';
@@ -2480,6 +2481,25 @@ async function main(): Promise<void> {
       pluginCatalog.get(channelId)?.plugin.channel,
     getAgentBundle: (service) =>
       serviceRegistry.get<ChatAgentBundle>(service),
+    // US7 — channelType autodiscovery: prefer the manifest's declared
+    // channel_type, else derive it from the channel id's last dotted segment
+    // (de.byte5.channel.teams → teams), the convention operators bind under.
+    channelTypeFor: (channelId) =>
+      deriveChannelType(channelId, {
+        manifest: pluginCatalog.get(channelId)?.plugin.channel,
+      }),
+    // US7 — per-binding routing: resolve the scoped ChatAgent the operator
+    // bound to (channelType, channelKey) via the multi-orchestrator
+    // channelResolver. Resolved lazily so hot config reloads take effect and
+    // so a Postgres-less deployment (no resolver published) degrades to the
+    // shared chatAgent via the static dispatch_service path.
+    resolveBinding: (channelType, channelKey) => {
+      const resolver =
+        serviceRegistry.get<ChannelBindingResolver>('channelResolver');
+      if (!resolver) return undefined;
+      const result = resolver.resolve(channelType, channelKey);
+      return result.decision !== 'reject' ? result.chatAgent : undefined;
+    },
   });
 
   const channelCoreApi = createCoreApi({

--- a/middleware/test/channelRouting.test.ts
+++ b/middleware/test/channelRouting.test.ts
@@ -1,0 +1,102 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { PluginContext } from '@omadia/plugin-api';
+import type {
+  ChannelBindingResolver,
+  ChatAgent,
+} from '@omadia/channel-sdk';
+import {
+  CHANNEL_RESOLVER_SERVICE,
+  CHAT_AGENT_SERVICE,
+  resolveChatAgentForChannel,
+} from '@omadia/channel-sdk';
+
+/**
+ * US7 — `resolveChatAgentForChannel` is the per-turn seam direct-agent channels
+ * (Teams, Telegram) call so each conversation reaches the Agent the operator
+ * bound to its (channelType, channelKey) instead of the shared singleton.
+ */
+
+function agent(tag: string): ChatAgent {
+  return {
+    chat: () => Promise.resolve({ text: tag }),
+    async *chatStream() {
+      await Promise.resolve();
+    },
+  } as unknown as ChatAgent;
+}
+
+/** Minimal PluginContext whose service registry is a plain key→value map. */
+function ctxWith(services: Record<string, unknown>): PluginContext {
+  return {
+    services: { get: (key: string) => services[key] },
+  } as unknown as PluginContext;
+}
+
+function resolver(
+  result: ReturnType<ChannelBindingResolver['resolve']>,
+  seen?: Array<[string, string]>,
+): ChannelBindingResolver {
+  return {
+    resolve(channelType, channelKey) {
+      seen?.push([channelType, channelKey]);
+      return result;
+    },
+  };
+}
+
+describe('resolveChatAgentForChannel', () => {
+  it('returns the bound Agent when the resolver matches a binding', () => {
+    const bound = agent('bound');
+    const ctx = ctxWith({
+      [CHANNEL_RESOLVER_SERVICE]: resolver({ decision: 'bound', chatAgent: bound }),
+      [CHAT_AGENT_SERVICE]: { agent: agent('singleton') },
+    });
+    assert.equal(resolveChatAgentForChannel(ctx, 'teams', 'c1'), bound);
+  });
+
+  it('returns the platform fallback Agent on a fallback decision', () => {
+    const fallback = agent('fallback');
+    const ctx = ctxWith({
+      [CHANNEL_RESOLVER_SERVICE]: resolver({
+        decision: 'fallback',
+        chatAgent: fallback,
+      }),
+      [CHAT_AGENT_SERVICE]: { agent: agent('singleton') },
+    });
+    assert.equal(resolveChatAgentForChannel(ctx, 'teams', 'c1'), fallback);
+  });
+
+  it('degrades to the shared singleton when the resolver rejects', () => {
+    const singleton = agent('singleton');
+    const ctx = ctxWith({
+      [CHANNEL_RESOLVER_SERVICE]: resolver({ decision: 'reject' }),
+      [CHAT_AGENT_SERVICE]: { agent: singleton },
+    });
+    assert.equal(resolveChatAgentForChannel(ctx, 'teams', 'c1'), singleton);
+  });
+
+  it('degrades to the shared singleton when no resolver is published', () => {
+    const singleton = agent('singleton');
+    const ctx = ctxWith({ [CHAT_AGENT_SERVICE]: { agent: singleton } });
+    assert.equal(resolveChatAgentForChannel(ctx, 'teams', 'c1'), singleton);
+  });
+
+  it('passes the exact (channelType, channelKey) through to the resolver', () => {
+    const seen: Array<[string, string]> = [];
+    const ctx = ctxWith({
+      [CHANNEL_RESOLVER_SERVICE]: resolver(
+        { decision: 'bound', chatAgent: agent('b') },
+        seen,
+      ),
+    });
+    resolveChatAgentForChannel(ctx, 'telegram', '@my_bot');
+    assert.deepEqual(seen, [['telegram', '@my_bot']]);
+  });
+
+  it('returns undefined when neither a binding nor the singleton is available', () => {
+    const ctx = ctxWith({});
+    assert.equal(resolveChatAgentForChannel(ctx, 'teams', 'c1'), undefined);
+  });
+});

--- a/middleware/test/channelType.test.ts
+++ b/middleware/test/channelType.test.ts
@@ -1,0 +1,53 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { ChannelManifestBlock } from '../src/api/admin-v1.js';
+import { deriveChannelType } from '../src/channels/channelType.js';
+
+/**
+ * US7 — channelType autodiscovery bridges an inbound turn's `channelId`
+ * (catalog id) to the short `channel_bindings.channel_type` selector operators
+ * bind under, with no per-channel wiring.
+ */
+
+function block(channel_type?: string): ChannelManifestBlock {
+  return {
+    transport: { kind: 'webhook', routes: [], verify_signature: false },
+    capabilities: ['text'],
+    adapters: ['text'],
+    ...(channel_type ? { channel_type } : {}),
+  };
+}
+
+describe('deriveChannelType', () => {
+  it('derives the last dotted segment of the channel id', () => {
+    assert.equal(deriveChannelType('de.byte5.channel.teams'), 'teams');
+    assert.equal(deriveChannelType('de.byte5.channel.telegram'), 'telegram');
+  });
+
+  it('prefers a manifest-declared channel_type over the derived segment', () => {
+    assert.equal(
+      deriveChannelType('de.byte5.channel.teams-eu', { manifest: block('teams') }),
+      'teams',
+    );
+  });
+
+  it('normalises case + whitespace so manifest and operator input match', () => {
+    assert.equal(
+      deriveChannelType('x', { manifest: block('  Teams  ') }),
+      'teams',
+    );
+    assert.equal(deriveChannelType('de.byte5.channel.TELEGRAM'), 'telegram');
+  });
+
+  it('falls back to the whole id when there is no dot', () => {
+    assert.equal(deriveChannelType('teams'), 'teams');
+  });
+
+  it('ignores an empty/whitespace manifest channel_type and derives instead', () => {
+    assert.equal(
+      deriveChannelType('de.byte5.channel.teams', { manifest: block('   ') }),
+      'teams',
+    );
+  });
+});

--- a/middleware/test/orchestratorDispatcher.test.ts
+++ b/middleware/test/orchestratorDispatcher.test.ts
@@ -83,4 +83,109 @@ describe('createOrchestratorDispatcher', () => {
     const events = await collect(dispatcher.streamTurn({ ...turn, channelId: 'x' }));
     assert.deepEqual(events, [{ type: 'error', message: 'orchestrator unavailable' }]);
   });
+
+  // ── US7 per-binding routing ───────────────────────────────────────────────
+
+  it('routes a classic-channel turn to the bound Agent (channelResolver wins over the chatAgent singleton)', async () => {
+    const asked: string[] = [];
+    const resolved: Array<[string, string]> = [];
+    const boundAgent = stubBundle([
+      { type: 'done', answer: 'scoped', toolCalls: 0, iterations: 1 },
+    ]).agent;
+    const dispatcher = createOrchestratorDispatcher({
+      getChannelBlock: () => undefined, // classic — no dispatch_service
+      getAgentBundle: (service) => {
+        asked.push(service); // must NOT be hit when a binding matches
+        return stubBundle([{ type: 'done', answer: 'singleton', toolCalls: 0, iterations: 1 }]);
+      },
+      channelTypeFor: (channelId) => channelId.split('.').pop() ?? channelId,
+      resolveBinding: (channelType, channelKey) => {
+        resolved.push([channelType, channelKey]);
+        return boundAgent;
+      },
+    });
+    const events = await collect(
+      dispatcher.streamTurn({
+        ...turn,
+        channelId: 'de.byte5.channel.teams',
+        channelKey: 'conv-42',
+      }),
+    );
+    assert.deepEqual(resolved, [['teams', 'conv-42']]);
+    assert.deepEqual(asked, []); // singleton never consulted
+    assert.equal(
+      (events.at(-1) as { answer?: string }).answer,
+      'scoped',
+    );
+  });
+
+  it('falls back to the static dispatch_service when no binding matches', async () => {
+    const asked: string[] = [];
+    const dispatcher = createOrchestratorDispatcher({
+      getChannelBlock: () => undefined,
+      getAgentBundle: (service) => {
+        asked.push(service);
+        return stubBundle([{ type: 'done', answer: 'singleton', toolCalls: 0, iterations: 1 }]);
+      },
+      channelTypeFor: (channelId) => channelId.split('.').pop() ?? channelId,
+      resolveBinding: () => undefined, // resolver rejects / no fallback Agent
+    });
+    const events = await collect(
+      dispatcher.streamTurn({
+        ...turn,
+        channelId: 'de.byte5.channel.teams',
+        channelKey: 'conv-42',
+      }),
+    );
+    assert.deepEqual(asked, ['chatAgent']);
+    assert.equal((events.at(-1) as { answer?: string }).answer, 'singleton');
+  });
+
+  it('never re-routes a channel with an explicit dispatch_service (canvas opt-out)', async () => {
+    const asked: string[] = [];
+    let bindingConsulted = false;
+    const dispatcher = createOrchestratorDispatcher({
+      getChannelBlock: () => canvasBlock, // dispatch_service: canvasChatAgent
+      getAgentBundle: (service) => {
+        asked.push(service);
+        return stubBundle([{ type: 'text_delta', text: 'x' }]);
+      },
+      channelTypeFor: (channelId) => channelId.split('.').pop() ?? channelId,
+      resolveBinding: () => {
+        bindingConsulted = true;
+        return stubBundle([]).agent;
+      },
+    });
+    await collect(
+      dispatcher.streamTurn({
+        ...turn,
+        channelId: 'de.byte5.channel.omadia-ui',
+        channelKey: 'canvas-1',
+      }),
+    );
+    assert.equal(bindingConsulted, false);
+    assert.deepEqual(asked, ['canvasChatAgent']);
+  });
+
+  it('skips binding routing when the turn carries no channelKey', async () => {
+    const asked: string[] = [];
+    let bindingConsulted = false;
+    const dispatcher = createOrchestratorDispatcher({
+      getChannelBlock: () => undefined,
+      getAgentBundle: (service) => {
+        asked.push(service);
+        return stubBundle([{ type: 'done', answer: 'ok', toolCalls: 0, iterations: 1 }]);
+      },
+      channelTypeFor: () => 'teams',
+      resolveBinding: () => {
+        bindingConsulted = true;
+        return undefined;
+      },
+    });
+    await collect(
+      dispatcher.streamTurn({ ...turn, channelId: 'de.byte5.channel.teams' }),
+    );
+    assert.equal(bindingConsulted, false);
+    assert.deepEqual(asked, ['chatAgent']);
+  });
 });


### PR DESCRIPTION
## Problem

Inbound channel turns reached the shared, fully-tooled `chatAgent` singleton **regardless of which Agent the operator bound** to the channel — so every turn could reach every domain tool (`query_odoo_accounting`, …) no matter the binding. The scoped per-Agent orchestrators and the `ChannelResolver` already existed, but nothing routed live turns through them:

- **CoreApi dispatcher path** (web channel, omadia-ui) resolved a *static* `dispatch_service` key, never a `(channel_type, channel_key)` binding.
- The `channelResolver@1` service was published but consumed only by the `/resolve-channel` dry-run tester.
- Nothing bridged a turn's `channelId` (`de.byte5.channel.teams`) to the short `channel_bindings.channel_type` selector (`teams`).

## What this does

Makes the dispatch path binding-aware, end to end, additively (zero regression on deployments without the multi-orchestrator registry).

- **SDK (`@omadia/channel-sdk`)** — `resolveChatAgentForChannel()` + `CHANNEL_RESOLVER_SERVICE` + `ChannelBindingResolver`: the per-turn seam direct-agent channels (Teams, Telegram) call to reach their bound, *scoped* Agent. Degrades to the singleton when no binding (and no platform fallback Agent) matches. Additive `IncomingTurn.channelType/channelKey`.
- **Dispatcher** — consults the `channelResolver` for any channel that would otherwise hit the shared `chatAgent`; an explicit `dispatch_service` (canvas) is an intentional override and is never re-routed; static resolution stays as the fallback. Fixes the web channel and any future classic channel for free.
- **Autodiscovery (`deriveChannelType`)** — bridges `channelId` → `channel_type`: manifest `channel.channel_type`, else the last dotted segment (`de.byte5.channel.teams` → `teams`, the convention used in `agents-apply`). New channels need zero wiring. Adds `channel_type` to `ChannelManifestBlock`.

## Companion PR

Direct-agent channels (Teams, Telegram) consume the new SDK seam — migrated in `byte5ai/omadia-byte5-plugins` (Telegram gains per-turn resolution; Teams refactored onto the shared `ChannelBindingResolver` type). Their built `dist/` must be re-vendored for the change to reach runtime.

## Testing

`lint` + `typecheck` clean. New/extended tests cover binding routing, the canvas opt-out, the no-key fallback, channelType derivation, and the SDK helper (18 passing); existing `channelResolver` / `operatorAgents` / web / ui-channel suites stay green.