### PR TITLE
feat(orchestrator): strict per-orchestrator memory + Knowledge-Graph isolation

### DIFF
--- a/middleware/packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.ts
+++ b/middleware/packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.ts
@@ -90,6 +90,24 @@ import {
 } from '@omadia/plugin-api';
 
 /**
+ * Per-orchestrator KG isolation parity with the Neon backend's
+ * `scope LIKE $prefix || '%' OR ($prefix='default::' AND scope NOT LIKE '%::%')`
+ * clause. Returns true when the scope belongs to the Agent identified by
+ * `prefix` (`<agentSlug>::`). `undefined` prefix = legacy cross-agent view
+ * (matches everything). The `default::` branch admits legacy unqualified
+ * scopes (no `::` separator) so pre-isolation data stays reachable.
+ */
+function matchesAgentScopePrefix(
+  scope: string,
+  prefix: string | undefined,
+): boolean {
+  if (!prefix) return true;
+  if (scope.startsWith(prefix)) return true;
+  if (prefix === 'default::' && !scope.includes('::')) return true;
+  return false;
+}
+
+/**
  * In-memory knowledge graph. Lives in the middleware process, lost on
  * restart — the session transcripts on disk remain the source of truth, a
  * backfill job can rebuild the graph on demand. Good enough for local dev,
@@ -540,6 +558,7 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
       if (excludeTurnIds.has(node.id)) continue;
       const scope = String(node.props['scope'] ?? '');
       if (opts.excludeScope && scope === opts.excludeScope) continue;
+      if (!matchesAgentScopePrefix(scope, opts.agentScopePrefix)) continue;
       if (opts.userId && node.props['userId'] !== opts.userId) continue;
 
       const haystack = (
@@ -609,6 +628,7 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
       if (excludeTurnIds.has(node.id)) continue;
       const scope = String(node.props['scope'] ?? '');
       if (opts.excludeScope && scope === opts.excludeScope) continue;
+      if (!matchesAgentScopePrefix(scope, opts.agentScopePrefix)) continue;
       if (opts.userId && node.props['userId'] !== opts.userId) continue;
 
       const entryType = (node.entryType ?? 'memory') as 'memory' | 'process' | 'task';
@@ -835,6 +855,7 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
         ...(input.significance !== undefined
           ? { significance: input.significance }
           : {}),
+        ...(input.originAgent ? { origin_agent: input.originAgent } : {}),
         acl_owners: initialOwners,
         created_at: now,
         created_by: input.createdBy,
@@ -1322,7 +1343,16 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
       const owners = Array.isArray(node.props['acl_owners'])
         ? (node.props['acl_owners'] as string[])
         : [];
-      const ownerMatch = owners.includes(opts.viewerOmadiaUserId);
+      // Per-orchestrator isolation: owner-gated MK is additionally constrained
+      // to the viewing Agent. Legacy MK with no origin_agent stays visible to
+      // the owner; team/public bypasses (cross-agent sharing preserved).
+      const originAgent = node.props['origin_agent'];
+      const agentMatch =
+        opts.viewerAgentSlug === undefined ||
+        !originAgent ||
+        originAgent === opts.viewerAgentSlug;
+      const ownerMatch =
+        owners.includes(opts.viewerOmadiaUserId) && agentMatch;
       // Mirror neon's `COALESCE(visibility, 'team')`: an MK with no explicit
       // visibility is team-visible by default; `private` is never admitted
       // by the team branch.
@@ -1365,7 +1395,14 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
       const owners = Array.isArray(parent.props['acl_owners'])
         ? (parent.props['acl_owners'] as string[])
         : [];
-      const ownerMatch = owners.includes(opts.viewerOmadiaUserId);
+      // Per-orchestrator isolation against the parent MK's origin_agent.
+      const originAgent = parent.props['origin_agent'];
+      const agentMatch =
+        opts.viewerAgentSlug === undefined ||
+        !originAgent ||
+        originAgent === opts.viewerAgentSlug;
+      const ownerMatch =
+        owners.includes(opts.viewerOmadiaUserId) && agentMatch;
       // Excerpts inherit the parent MK's ACL + visibility.
       const teamMatch =
         opts.teamVisibility === true &&
@@ -2588,6 +2625,14 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
           if (!turnNode || turnNode.type !== 'Turn') continue;
           if (opts.userId && turnNode.props['userId'] !== opts.userId) continue;
           if (opts.excludeScope && turnNode.props['scope'] === opts.excludeScope) continue;
+          // Entity node stays global; entity-anchored recall is agent-isolated.
+          if (
+            !matchesAgentScopePrefix(
+              String(turnNode.props['scope'] ?? ''),
+              opts.agentScopePrefix,
+            )
+          )
+            continue;
           capturingTurns.push(turnNode);
         }
       }
@@ -2741,11 +2786,20 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
     userId?: string;
     limit?: number;
     openOnly?: boolean;
+    agentScopePrefix?: string;
   }): Promise<GraphNode[]> {
     const limit = Math.max(1, Math.min(opts.limit ?? 5, 50));
     let plans = [...this.nodes.values()].filter((n) => n.type === 'Plan');
     if (opts.userId !== undefined) {
       plans = plans.filter((n) => n.props['userId'] === opts.userId);
+    }
+    if (opts.agentScopePrefix !== undefined) {
+      plans = plans.filter((n) =>
+        matchesAgentScopePrefix(
+          String(n.props['scope'] ?? ''),
+          opts.agentScopePrefix,
+        ),
+      );
     }
     if (opts.openOnly === true) {
       plans = plans.filter((p) => {

--- a/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
+++ b/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
@@ -1041,6 +1041,7 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
     userId?: string;
     limit?: number;
     openOnly?: boolean;
+    agentScopePrefix?: string;
   }): Promise<GraphNode[]> {
     const limit = Math.max(1, Math.min(opts.limit ?? 5, 50));
     // `user_id` lives in its own column (set on ingest), not in props.
@@ -1053,6 +1054,12 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
         WHERE p.tenant_id = $1
           AND p.type = 'Plan'
           AND ($2::text IS NULL OR p.user_id = $2)
+          -- Per-orchestrator isolation: Plan.scope is the qualified
+          -- agentSlug::conversation (top-level column). Restrict to the
+          -- active Agent; the 'default::' branch keeps legacy plans reachable.
+          AND ($5::text IS NULL
+            OR p.scope LIKE $5 || '%'
+            OR ($5 = 'default::' AND p.scope NOT LIKE '%::%'))
           AND ($3::boolean = false OR EXISTS (
             SELECT 1
               FROM graph_nodes s
@@ -1065,7 +1072,13 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
           ))
         ORDER BY (p.properties->>'createdAt') DESC NULLS LAST
         LIMIT $4`,
-      [this.tenantId, opts.userId ?? null, opts.openOnly === true, limit],
+      [
+        this.tenantId,
+        opts.userId ?? null,
+        opts.openOnly === true,
+        limit,
+        opts.agentScopePrefix ?? null,
+      ],
     );
     return res.rows.map((r) => rowToNode(r));
   }
@@ -1169,6 +1182,7 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
     const limit = Math.max(1, Math.min(opts.limit ?? 5, 50));
     const userIdFilter = opts.userId ?? null;
     const excludeScope = opts.excludeScope ?? null;
+    const agentScopePrefix = opts.agentScopePrefix ?? null;
     const excludeTurnIds = opts.excludeTurnIds?.length
       ? Array.from(opts.excludeTurnIds)
       : null;
@@ -1205,6 +1219,13 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
         AND ($2::text IS NULL OR user_id = $2)
         AND ($4::text IS NULL OR scope <> $4)
         AND ($5::text[] IS NULL OR external_id <> ALL($5::text[]))
+        -- Per-orchestrator isolation: when a prefix is given, restrict to the
+        -- Agent's own scopes. The 'default::' branch also admits legacy
+        -- unqualified rows (no '::' separator) so pre-isolation data stays
+        -- reachable for the default Agent without a migration.
+        AND ($7::text IS NULL
+          OR scope LIKE $7 || '%'
+          OR ($7 = 'default::' AND scope NOT LIKE '%::%'))
         AND to_tsvector(
           'simple',
           coalesce(properties->>'userMessage', '') || ' ' ||
@@ -1213,7 +1234,15 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
       ORDER BY rank DESC, (properties->>'time') DESC
       LIMIT $6
       `,
-      [this.tenantId, userIdFilter, query, excludeScope, excludeTurnIds, limit],
+      [
+        this.tenantId,
+        userIdFilter,
+        query,
+        excludeScope,
+        excludeTurnIds,
+        limit,
+        agentScopePrefix,
+      ],
     );
 
     // ts_rank_cd is unbounded; normalise via rank / (rank + 1) so callers get
@@ -1245,6 +1274,7 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
     const minSimilarity = opts.minSimilarity ?? 0.3;
     const userIdFilter = opts.userId ?? null;
     const excludeScope = opts.excludeScope ?? null;
+    const agentScopePrefix = opts.agentScopePrefix ?? null;
     const excludeTurnIds = opts.excludeTurnIds?.length
       ? Array.from(opts.excludeTurnIds)
       : null;
@@ -1289,6 +1319,7 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
     //   $11 weight process
     //   $12 weight task
     //   $13 LIMIT (overshoot)
+    //   $14 agentScopePrefix (nullable) — per-orchestrator isolation
     const sql = `
       WITH scored AS (
         SELECT
@@ -1329,6 +1360,11 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
           AND ($3::text IS NULL OR user_id = $3)
           AND ($4::text IS NULL OR scope <> $4)
           AND ($5::text[] IS NULL OR external_id <> ALL($5::text[]))
+          -- Per-orchestrator isolation (see searchTurns): own prefix, plus
+          -- legacy unqualified rows for the default Agent.
+          AND ($14::text IS NULL
+            OR scope LIKE $14 || '%'
+            OR ($14 = 'default::' AND scope NOT LIKE '%::%'))
           AND ($7::text[] IS NULL OR entry_type = ANY($7::text[]))
           AND ($8::boolean = TRUE OR tier IN ('HOT', 'WARM'))
           AND (
@@ -1412,6 +1448,7 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
       weightProcess,
       weightTask,
       overshoot,
+      agentScopePrefix,
     ]);
 
     return result.rows
@@ -1667,6 +1704,9 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
         ...(input.significance !== undefined
           ? { significance: input.significance }
           : {}),
+        // Per-orchestrator isolation: stamp the producing Agent so recall can
+        // default-isolate by origin (team/public visibility still shares).
+        ...(input.originAgent ? { origin_agent: input.originAgent } : {}),
         acl_owners: initialOwners,
         created_at: now,
         created_by: input.createdBy,
@@ -2379,8 +2419,19 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
         AND type = 'MemorableKnowledge'
         AND embedding IS NOT NULL
         AND (
-          properties->'acl_owners' @> jsonb_build_array($3::text)
-          OR ($5::boolean AND COALESCE(visibility, 'team') IN ('team', 'public'))
+          -- team/public-promoted MK stays shareable across Agents.
+          ($5::boolean AND COALESCE(visibility, 'team') IN ('team', 'public'))
+          OR (
+            properties->'acl_owners' @> jsonb_build_array($3::text)
+            -- Per-orchestrator isolation: owner-gated MK is additionally
+            -- constrained to the viewing Agent. Legacy MK without an
+            -- origin_agent stays visible to the owner.
+            AND (
+              $6::text IS NULL
+              OR COALESCE(properties->>'origin_agent', '') = ''
+              OR properties->>'origin_agent' = $6
+            )
+          )
         )
       ORDER BY cosine_sim DESC
       LIMIT $4
@@ -2391,6 +2442,7 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
       opts.viewerOmadiaUserId,
       limit,
       opts.teamVisibility === true,
+      opts.viewerAgentSlug ?? null,
     ]);
     return rows.rows
       .filter((r) => Number(r.cosine_sim) >= minSimilarity)
@@ -2427,8 +2479,17 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
         AND ex.embedding IS NOT NULL
         AND mk.tenant_id = $2
         AND (
-          mk.properties->'acl_owners' @> jsonb_build_array($3::text)
-          OR ($5::boolean AND COALESCE(mk.visibility, 'team') IN ('team', 'public'))
+          -- team/public-promoted parent MK stays shareable across Agents.
+          ($5::boolean AND COALESCE(mk.visibility, 'team') IN ('team', 'public'))
+          OR (
+            mk.properties->'acl_owners' @> jsonb_build_array($3::text)
+            -- Per-orchestrator isolation against the parent MK's origin_agent.
+            AND (
+              $6::text IS NULL
+              OR COALESCE(mk.properties->>'origin_agent', '') = ''
+              OR mk.properties->>'origin_agent' = $6
+            )
+          )
         )
       ORDER BY cosine_sim DESC
       LIMIT $4
@@ -2449,6 +2510,7 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
       opts.viewerOmadiaUserId,
       limit,
       opts.teamVisibility === true,
+      opts.viewerAgentSlug ?? null,
     ]);
 
     return rows.rows
@@ -4143,6 +4205,7 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
     const entityLimit = Math.max(1, Math.min(opts.entityLimit ?? 5, 25));
     const userIdFilter = opts.userId ?? null;
     const excludeScope = opts.excludeScope ?? null;
+    const agentScopePrefix = opts.agentScopePrefix ?? null;
     const likeTerms = terms.map((t) => `%${t}%`);
     const exactTerms = terms;
 
@@ -4183,10 +4246,23 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
           AND t.type = 'Turn'
           AND ($3::text IS NULL OR t.user_id = $3)
           AND ($4::text IS NULL OR t.scope <> $4)
+          -- Per-orchestrator isolation: the entity NODE stays global (shared
+          -- vocabulary), but entity-anchored recall only surfaces turns of
+          -- the active Agent. Closes the cross-agent entity-recall leak.
+          AND ($6::text IS NULL
+            OR t.scope LIKE $6 || '%'
+            OR ($6 = 'default::' AND t.scope NOT LIKE '%::%'))
         ORDER BY (t.properties->>'time') DESC
         LIMIT $5
         `,
-        [this.tenantId, row.id, userIdFilter, excludeScope, perEntityLimit],
+        [
+          this.tenantId,
+          row.id,
+          userIdFilter,
+          excludeScope,
+          perEntityLimit,
+          agentScopePrefix,
+        ],
       );
 
       if (turnRows.rows.length === 0) continue;

--- a/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
@@ -95,6 +95,22 @@ export interface ContextBuildInput {
   userId?: string;
   /** External id of the turn currently being answered — excluded from hits. */
   currentTurnId?: string;
+  /**
+   * Per-orchestrator KG isolation — the `<agentSlug>::` prefix that selects
+   * the recalling Agent's own turns/plans. Forwarded to every scope-filtered
+   * KG read (`searchTurns`, `searchTurnsByEmbedding`, `findEntityCapturedTurns`,
+   * `listRecentPlans`). Undefined → legacy cross-agent recall (no regression
+   * for callers that don't set it).
+   */
+  agentScopePrefix?: string;
+  /**
+   * Per-orchestrator KG isolation — the recalling Agent's slug, forwarded to
+   * curated-memory reads (`searchMemorableKnowledgeByEmbedding` /
+   * `searchExcerptsByEmbedding`) as `viewerAgentSlug` so owner-gated MK is
+   * constrained to this Agent's `origin_agent`. team/public-promoted MK still
+   * crosses Agents. Undefined → no agent constraint.
+   */
+  agentSlug?: string;
 }
 
 export interface ContextBuildResult {
@@ -160,6 +176,15 @@ export interface AssembleForBudgetInput {
   currentTurnId?: string;
   /** Who is asking — driver for agent_priorities lookup. */
   agentId: string;
+  /**
+   * Per-orchestrator KG isolation (opt-in). When set (the orchestrator passes
+   * `<agentSlug>::`), every recall leg is constrained to this Agent's own
+   * turns/plans, and curated-memory recall is constrained to its `origin_agent`
+   * (`agentId` becomes the `viewerAgentSlug`). The orchestrator also passes an
+   * already-qualified `sessionScope`. Omitted → legacy cross-scope recall
+   * (direct-retriever callers and sub-agents are unaffected).
+   */
+  agentScopePrefix?: string;
   /** Optional override; otherwise `defaultBudgetTokens` from ContextRetriever-Opts. */
   budget?: { tokens: number };
 }
@@ -428,6 +453,16 @@ export class ContextRetriever {
       ...(input.sessionScope ? { sessionScope: input.sessionScope } : {}),
       ...(input.userId ? { userId: input.userId } : {}),
       ...(input.currentTurnId ? { currentTurnId: input.currentTurnId } : {}),
+      // Per-orchestrator KG isolation is OPT-IN: only when the caller (the
+      // orchestrator) passes an agent prefix do we constrain recall to that
+      // Agent. Its `sessionScope` then already arrives qualified, so
+      // getSession / turnNodeId stay consistent with the ingest side.
+      ...(input.agentScopePrefix
+        ? {
+            agentScopePrefix: input.agentScopePrefix,
+            agentSlug: input.agentId,
+          }
+        : {}),
     };
 
     const [
@@ -717,6 +752,9 @@ export class ContextRetriever {
       terms,
       ...(input.userId ? { userId: input.userId } : {}),
       ...(input.sessionScope ? { excludeScope: input.sessionScope } : {}),
+      ...(input.agentScopePrefix
+        ? { agentScopePrefix: input.agentScopePrefix }
+        : {}),
       perEntityLimit: 2,
       entityLimit: this.opts.entityLimit,
     });
@@ -750,6 +788,9 @@ export class ContextRetriever {
       const plans = await this.graph.listRecentPlans({
         limit: Math.max(limit * 4, 12),
         openOnly: this.opts.planOpenOnly,
+        ...(input.agentScopePrefix
+          ? { agentScopePrefix: input.agentScopePrefix }
+          : {}),
       });
       const scored: Array<{ hit: RecalledPlan; score: number }> = [];
       for (const p of plans) {
@@ -894,6 +935,7 @@ export class ContextRetriever {
           limit: overshoot,
           minSimilarity: this.opts.memoryMinSimilarity,
           teamVisibility: this.opts.teamVisibility,
+          ...(input.agentSlug ? { viewerAgentSlug: input.agentSlug } : {}),
         }),
         this.graph.searchExcerptsByEmbedding({
           queryEmbedding: queryVector,
@@ -901,6 +943,7 @@ export class ContextRetriever {
           limit: excerptOvershoot,
           minSimilarity: this.opts.memoryMinSimilarity,
           teamVisibility: this.opts.teamVisibility,
+          ...(input.agentSlug ? { viewerAgentSlug: input.agentSlug } : {}),
         }),
       ]);
     } catch (err) {
@@ -987,6 +1030,9 @@ export class ContextRetriever {
             ...(input.currentTurnId
               ? { excludeTurnIds: [input.currentTurnId] }
               : {}),
+            ...(input.agentScopePrefix
+              ? { agentScopePrefix: input.agentScopePrefix }
+              : {}),
             limit: this.opts.ftsLimit,
             recallMinScore: this.opts.recallMinScore,
             recallRecencyBoost: this.opts.recallRecencyBoost,
@@ -1006,6 +1052,9 @@ export class ContextRetriever {
       ...(input.userId ? { userId: input.userId } : {}),
       ...(input.sessionScope ? { excludeScope: input.sessionScope } : {}),
       ...(input.currentTurnId ? { excludeTurnIds: [input.currentTurnId] } : {}),
+      ...(input.agentScopePrefix
+        ? { agentScopePrefix: input.agentScopePrefix }
+        : {}),
       limit: this.opts.ftsLimit,
     });
   }

--- a/middleware/packages/harness-orchestrator-extras/src/promotion.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/promotion.ts
@@ -59,6 +59,13 @@ export interface PromoteTurnInput {
   /** Fallback summary source — typically the cleaned assistant answer.
    *  Only used when `palaiaExcerpt` is absent. */
   fallbackAssistantAnswer: string;
+  /**
+   * Per-orchestrator KG isolation — the Agent (orchestrator) slug that
+   * produced this turn. Stamped as `origin_agent` on the resulting MK so
+   * recall default-isolates it to this Agent (team/public promotion stays
+   * cross-agent). Omit on legacy / single-agent boots.
+   */
+  originAgent?: string;
   /** Optional log sink. Defaults to `console.error`. */
   log?: (msg: string) => void;
 }
@@ -167,6 +174,7 @@ export async function promoteTurnIfSignificant(
       createdBy: `auto:${input.userId}`,
       involvedOmadiaUserIds: [input.userId],
       aclOwners: [input.userId],
+      ...(input.originAgent ? { originAgent: input.originAgent } : {}),
       derivedFromTurnIds: [input.turnId],
       // Slice 6.5 — symmetric to manual save: persist the verbatim
       // source-snippets so the auto-promoted MK has the same

--- a/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
@@ -36,10 +36,17 @@ import type {
 import type { VerifierBundle } from '@omadia/verifier';
 import type { Pool } from 'pg';
 
+import { MemoryToolHandler } from '@omadia/memory';
+
 import { ChatSessionStore } from './chatSessionStore.js';
 import type { Microsoft365Accessor } from './microsoft365-shim.js';
 import type { NativeToolRegistry } from './nativeToolRegistry.js';
 import { Orchestrator } from './orchestrator.js';
+import { OrchestratorMemoryNamespacer } from './orchestratorMemoryNamespacer.js';
+import {
+  ScopedMemoryStore,
+  orchestratorMemoryScope,
+} from './registry/scopedMemoryStore.js';
 import type { TurnHookRunner } from './turnHooks.js';
 import type { ChatAgentBundle } from './plugin.js';
 import { SessionLogger } from './sessionLogger.js';
@@ -126,11 +133,29 @@ export function buildOrchestratorForAgent(
   config: AgentRuntimeConfig,
   deps: OrchestratorDeps,
 ): BuiltOrchestrator {
-  const chatSessionStore = new ChatSessionStore(deps.memoryStore);
+  // Per-orchestrator memory isolation. The shared kernel `MemoryStore` is
+  // wrapped so this Agent can only touch its own tree (`orchestrator:<slug>:*`)
+  // plus the shared `core` namespace — enforced by `ScopedMemoryStore`.
+  //   - ChatSessionStore + SessionLogger write to the shared `core`
+  //     `sessions`/`chat-sessions` paths (session transcripts stay common,
+  //     decision A3a), so they use the scoped store directly.
+  //   - The model-facing `memory` tool additionally goes through the
+  //     namespacer, which rewrites its arbitrary `/memories/<x>` notes into
+  //     the Agent-private `/memories/orchestrators/<slug>/<x>` tree.
+  const scopedStore = new ScopedMemoryStore({
+    agentSlug: config.agentId,
+    scope: orchestratorMemoryScope(config.agentId),
+    inner: deps.memoryStore,
+  });
+  const chatSessionStore = new ChatSessionStore(scopedStore);
   const sessionLogger = new SessionLogger(
-    deps.memoryStore,
+    scopedStore,
     deps.knowledgeGraph,
     chatSessionStore,
+    config.agentId,
+  );
+  const memoryToolHandler = new MemoryToolHandler(
+    new OrchestratorMemoryNamespacer(config.agentId, scopedStore),
   );
 
   // Native-tool instances (channel-coupled UI cards + calendar). The calendar
@@ -163,6 +188,7 @@ export function buildOrchestratorForAgent(
     maxToolIterations: config.maxToolIterations,
     domainTools: [],
     nativeToolRegistry: deps.nativeToolRegistry,
+    memoryToolHandler,
     sessionLogger,
     entityRefBus: deps.entityRefBus,
     knowledgeGraph: deps.knowledgeGraph,

--- a/middleware/packages/harness-orchestrator/src/index.ts
+++ b/middleware/packages/harness-orchestrator/src/index.ts
@@ -144,7 +144,7 @@ export type {
 export type { RunTracePayload } from '@omadia/channel-sdk';
 
 // Session logger + chat-session store
-export { SessionLogger } from './sessionLogger.js';
+export { SessionLogger, graphScopeFor } from './sessionLogger.js';
 export type { SessionLogEntry } from './sessionLogger.js';
 export {
   ChatSessionStore,

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -30,6 +30,7 @@ import {
   KNOWLEDGE_GRAPH_TOOL_NAME,
   knowledgeGraphToolSpec,
 } from './knowledgeGraphTool.js';
+import type { MemoryToolHandler } from '@omadia/memory';
 import type { ChatParticipantsTool } from './tools/chatParticipantsTool.js';
 import {
   CHAT_PARTICIPANTS_TOOL_NAME,
@@ -74,6 +75,7 @@ import type {
   SessionBriefingService,
 } from '@omadia/plugin-api';
 import {
+  agentScopePrefix,
   PRIVACY_BYPASS_SCOPES_CONFIG_KEY,
   PRIVACY_MODE_CONFIG_KEY,
   resolveEffectivePrivacyMode,
@@ -89,7 +91,7 @@ import {
 } from './privacyHandle.js';
 import { RunTraceCollector, type InvocationHandle } from './runTraceCollector.js';
 import type { NativeToolRegistry } from './nativeToolRegistry.js';
-import type { SessionLogger } from './sessionLogger.js';
+import { graphScopeFor, type SessionLogger } from './sessionLogger.js';
 import { streamMessageEvents } from './streaming.js';
 import { buildDateHeader, today, turnContext } from './turnContext.js';
 
@@ -160,6 +162,16 @@ export interface OrchestratorOptions {
   /** Optional. When set, exposes the `query_knowledge_graph` tool so Claude
    * can look up prior turns and entity context before delegating. */
   knowledgeGraph?: KnowledgeGraph;
+  /**
+   * Per-orchestrator memory isolation — a `MemoryToolHandler` bound to THIS
+   * Agent's scoped (+ namespaced) MemoryStore. When set, the orchestrator
+   * dispatches the model-facing `memory` tool through it INSTEAD of the
+   * globally-registered handler, so every `view`/`create`/`str_replace`/…
+   * lands under `/memories/orchestrators/<slug>/` and can never read or write
+   * another Agent's memory. Absent (legacy direct construction) → the global
+   * handler is used exactly as before. Wired by `buildOrchestratorForAgent`.
+   */
+  memoryToolHandler?: MemoryToolHandler;
   /**
    * Optional. When set, retrieves conversational context (verbatim tail of
    * the active chat + entity-anchored and full-text hits from other chats of
@@ -774,6 +786,8 @@ export class Orchestrator {
   private readonly model: string;
   private readonly maxTokens: number;
   private readonly maxIterations: number;
+  /** Per-Agent scoped memory-tool handler; overrides the global one. */
+  private readonly memoryToolHandler: MemoryToolHandler | undefined;
   private readonly domainToolsByName: Map<string, DomainTool>;
   // systemPrompt is rebuilt live per turn from `buildSystemPrompt()` —
   // so hot-registered DomainTools show up in the preamble. Prompt caching
@@ -831,6 +845,7 @@ export class Orchestrator {
     this.model = options.model;
     this.maxTokens = options.maxTokens;
     this.maxIterations = options.maxToolIterations;
+    this.memoryToolHandler = options.memoryToolHandler;
     this.domainToolsByName = new Map(options.domainTools.map((t) => [t.name, t]));
     this.knowledgeGraph = options.knowledgeGraph;
     this.knowledgeGraphTool = options.knowledgeGraph
@@ -907,6 +922,9 @@ export class Orchestrator {
       userId: opts.userId,
       threshold: this.autoPromoteThreshold,
       fallbackAssistantAnswer: opts.fallbackAssistantAnswer,
+      // Per-orchestrator isolation: stamp the producing Agent so auto-promoted
+      // MK default-isolates to it (team/public promotion stays cross-agent).
+      originAgent: this.agentId,
       ...(opts.palaiaExcerpt ? { palaiaExcerpt: opts.palaiaExcerpt } : {}),
     };
     try {
@@ -1331,8 +1349,16 @@ export class Orchestrator {
       // priorities apply.
       const result = await this.contextRetriever.assembleForBudget({
         userMessage: input.userMessage,
-        agentId: 'orchestrator-default',
-        ...(input.sessionScope ? { sessionScope: input.sessionScope } : {}),
+        // Per-orchestrator isolation: the real Agent identity drives the KG
+        // scope-prefix filter (and agent_priorities). The retriever expects
+        // the sessionScope already agent-qualified — `graphScopeFor` is the
+        // SAME formula SessionLogger writes with, so `turnNodeId`/`getSession`
+        // agree on both the ingest and recall sides.
+        agentId: this.agentId,
+        agentScopePrefix: agentScopePrefix(this.agentId),
+        ...(input.sessionScope
+          ? { sessionScope: graphScopeFor(this.agentId, input.sessionScope) }
+          : {}),
         ...(input.userId ? { userId: input.userId } : {}),
       });
       console.error(
@@ -1348,8 +1374,9 @@ export class Orchestrator {
       if (this.sessionBriefing && input.sessionScope) {
         try {
           const briefing = await this.sessionBriefing.loadSessionBriefing({
-            scope: input.sessionScope,
-            agentId: 'orchestrator-default',
+            // Qualified scope so the briefing reads THIS Agent's turns only.
+            scope: graphScopeFor(this.agentId, input.sessionScope),
+            agentId: this.agentId,
             ...(input.userId ? { userId: input.userId } : {}),
           });
           if (briefing.mode === 'briefing' && briefing.text.length > 0) {
@@ -1445,6 +1472,9 @@ export class Orchestrator {
       {
         turnId,
         turnDate: today(),
+        // Per-orchestrator isolation: expose THIS Agent's identity to the
+        // per-call MemoryAccessor (plugin/sub-agent memory namespacing).
+        agentSlug: this.agentId,
         ...(parent?.chatParticipants
           ? { chatParticipants: parent.chatParticipants }
           : {}),
@@ -1527,6 +1557,9 @@ export class Orchestrator {
             turnId,
             ...(input.sessionScope ? { sessionScope: input.sessionScope } : {}),
             ...(input.userId ? { userId: input.userId } : {}),
+            // Per-orchestrator isolation: hooks that persist scope-keyed KG
+            // artefacts (plan-runner) qualify their scope with this.
+            agentSlug: this.agentId,
           },
           payload,
         ),
@@ -1987,6 +2020,8 @@ export class Orchestrator {
     turnContext.enter({
       turnId,
       turnDate: today(),
+      // Per-orchestrator isolation: see the matching `turnContext.run` above.
+      agentSlug: this.agentId,
       ...(parent?.chatParticipants
         ? { chatParticipants: parent.chatParticipants }
         : {}),
@@ -2869,6 +2904,14 @@ export class Orchestrator {
     input: unknown,
     observer?: AskObserver,
   ): Promise<string> {
+    // Per-orchestrator memory isolation: when this Agent has a scoped
+    // memory-tool handler, it MUST shadow the globally-registered `memory`
+    // handler (which wraps the unscoped FilesystemMemoryStore). Checked
+    // before the generic `reg?.handler` dispatch below, since `memory` is a
+    // plugin-registered native tool and would otherwise win here unscoped.
+    if (name === MEMORY_TOOL_NAME && this.memoryToolHandler) {
+      return this.memoryToolHandler.handle(input);
+    }
     // Plugin-contributed handlers win first. Kernel branches below are the
     // legacy path for tools that have not yet been converted to
     // plugin-registration (memory, knowledge_graph, …). As each kernel tool

--- a/middleware/packages/harness-orchestrator/src/orchestratorMemoryNamespacer.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestratorMemoryNamespacer.ts
@@ -1,0 +1,113 @@
+import type { MemoryEntry, MemoryStore } from '@omadia/plugin-api';
+
+/**
+ * Per-orchestrator memory namespacer.
+ *
+ * The model-facing `memory` tool emits absolute `/memories/...` paths and is
+ * unaware that several Agents share one physical store. This wrapper makes
+ * each Agent see a PRIVATE `/memories` root that is physically backed by
+ * `/memories/orchestrators/<slug>/...`, while a small allow-list of shared
+ * namespaces (`core`, `sessions`, `chat-sessions`, brand `_*`) passes through
+ * untouched so cross-agent kernel data (session transcripts, brand files,
+ * system rules) stays common.
+ *
+ * It is a transparent bijection:
+ *   - inbound paths are rewritten into the private tree (`toInner`)
+ *   - outbound `list` entries are rewritten back out (`toOuter`)
+ * so the model only ever sees `/memories/...` and can never address another
+ * Agent's tree by construction.
+ *
+ * Layering (set up in `buildOrchestratorForAgent`):
+ *   OrchestratorMemoryNamespacer  (rewrite to private tree)
+ *     → ScopedMemoryStore         (enforce `orchestrator:<slug>:*` + `core`)
+ *       → FilesystemMemoryStore   (physical I/O)
+ * The ScopedMemoryStore is the hard backstop: a rewrite bug surfaces as a
+ * `MemoryScopeViolation` rather than a cross-agent leak.
+ */
+
+const MEMORIES_ROOT = '/memories';
+
+/**
+ * First-segment names under `/memories` that are SHARED across Agents and
+ * therefore pass through the namespacer unchanged. Mirrors the `core`
+ * pattern in `ScopedMemoryStore` (which also permits top-level `_*` dirs).
+ */
+const SHARED_SEGMENTS = new Set(['core', 'sessions', 'chat-sessions']);
+
+function firstSegment(rest: string): string {
+  // `rest` starts with '/', e.g. '/core/x.md' → 'core'.
+  const trimmed = rest.replace(/^\/+/, '');
+  const slash = trimmed.indexOf('/');
+  return slash === -1 ? trimmed : trimmed.slice(0, slash);
+}
+
+function isShared(rest: string): boolean {
+  const seg = firstSegment(rest);
+  return seg.startsWith('_') || SHARED_SEGMENTS.has(seg);
+}
+
+export class OrchestratorMemoryNamespacer implements MemoryStore {
+  private readonly privateRoot: string;
+
+  constructor(
+    private readonly agentSlug: string,
+    private readonly inner: MemoryStore,
+  ) {
+    this.privateRoot = `${MEMORIES_ROOT}/orchestrators/${agentSlug}`;
+  }
+
+  /** Model-facing `/memories/...` → physical path in the private tree. */
+  private toInner(path: string): string {
+    if (path === MEMORIES_ROOT) return this.privateRoot;
+    if (!path.startsWith(`${MEMORIES_ROOT}/`)) return path; // not ours; leave it
+    const rest = path.slice(MEMORIES_ROOT.length); // '/...'
+    if (isShared(rest)) return path; // shared namespace — passthrough
+    return `${this.privateRoot}${rest}`;
+  }
+
+  /** Physical path → model-facing `/memories/...` (inverse of `toInner`). */
+  private toOuter(path: string): string {
+    if (path === this.privateRoot) return MEMORIES_ROOT;
+    if (path.startsWith(`${this.privateRoot}/`)) {
+      return `${MEMORIES_ROOT}${path.slice(this.privateRoot.length)}`;
+    }
+    return path; // shared / unmapped — already in the outer namespace
+  }
+
+  list(virtualPath: string): Promise<MemoryEntry[]> {
+    return this.inner.list(this.toInner(virtualPath)).then((entries) =>
+      entries.map((e) => ({ ...e, virtualPath: this.toOuter(e.virtualPath) })),
+    );
+  }
+
+  fileExists(virtualPath: string): Promise<boolean> {
+    return this.inner.fileExists(this.toInner(virtualPath));
+  }
+
+  directoryExists(virtualPath: string): Promise<boolean> {
+    return this.inner.directoryExists(this.toInner(virtualPath));
+  }
+
+  readFile(virtualPath: string): Promise<string> {
+    return this.inner.readFile(this.toInner(virtualPath));
+  }
+
+  createFile(virtualPath: string, content: string): Promise<void> {
+    return this.inner.createFile(this.toInner(virtualPath), content);
+  }
+
+  writeFile(virtualPath: string, content: string): Promise<void> {
+    return this.inner.writeFile(this.toInner(virtualPath), content);
+  }
+
+  delete(virtualPath: string): Promise<void> {
+    return this.inner.delete(this.toInner(virtualPath));
+  }
+
+  rename(fromVirtualPath: string, toVirtualPath: string): Promise<void> {
+    return this.inner.rename(
+      this.toInner(fromVirtualPath),
+      this.toInner(toVirtualPath),
+    );
+  }
+}

--- a/middleware/packages/harness-orchestrator/src/registry/index.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/index.ts
@@ -21,6 +21,7 @@ import {
   type ConfigStore,
   type PlatformSettingsRow,
 } from './configStore.js';
+import { orchestratorMemoryScope } from './scopedMemoryStore.js';
 
 /**
  * OrchestratorRegistry (US4 / T015).
@@ -136,13 +137,12 @@ export interface ActiveAgent {
   readonly bindings: readonly ChannelBindingRow[];
   readonly built: BuiltOrchestrator;
   /**
-   * Memory scope = union of enabled plugins' `permissions.memory.{reads,
-   * writes}` plus `core` (US8 / T033). Computed from `pluginLookup` at
-   * snapshot-apply time; empty arrays when no `pluginLookup` is wired
-   * (legacy boot — no per-Agent enforcement).
-   *
-   * The `core` entry is always present and is the convention for shared
-   * agent-agnostic memory (sessions, run traces, system prompts).
+   * Strict per-orchestrator memory scope: `['core', 'orchestrator:<slug>:*']`
+   * (see {@link computeMemoryScope}). The Agent may touch only its own
+   * orchestrator tree plus the shared `core` namespace — never another
+   * Agent's, and never a shared per-plugin namespace. Enforced at runtime by
+   * the `ScopedMemoryStore` that `buildOrchestratorForAgent` wraps around the
+   * shared `MemoryStore`.
    */
   readonly memoryScope: readonly string[];
 }
@@ -299,10 +299,7 @@ export class OrchestratorRegistry {
         );
         const plugins = pluginsByAgent.get(action.agent.id) ?? [];
         const bindings = bindingsByAgent.get(action.agent.id) ?? [];
-        const memoryScope = computeMemoryScope(
-          plugins,
-          this.options.pluginLookup,
-        );
+        const memoryScope = computeMemoryScope(action.agent.slug);
         this.active.set(action.agent.slug, {
           agent: action.agent,
           plugins,
@@ -342,10 +339,7 @@ export class OrchestratorRegistry {
         );
         const plugins = pluginsByAgent.get(action.agent.id) ?? [];
         const bindings = bindingsByAgent.get(action.agent.id) ?? [];
-        const memoryScope = computeMemoryScope(
-          plugins,
-          this.options.pluginLookup,
-        );
+        const memoryScope = computeMemoryScope(action.agent.slug);
         this.active.set(action.agent.slug, {
           agent: action.agent,
           plugins,
@@ -367,10 +361,7 @@ export class OrchestratorRegistry {
         if (!before) return;
         const plugins = pluginsByAgent.get(action.agent.id) ?? [];
         const bindings = bindingsByAgent.get(action.agent.id) ?? [];
-        const memoryScope = computeMemoryScope(
-          plugins,
-          this.options.pluginLookup,
-        );
+        const memoryScope = computeMemoryScope(action.agent.slug);
         this.active.set(action.agent.slug, {
           ...before,
           agent: action.agent,
@@ -637,32 +628,28 @@ function actionSlug(action: DiffAction): string {
 }
 
 /**
- * Compute an Agent's effective memory scope (US8 / T033) as the union of:
- *   - its enabled plugins' `permissions.memory.{reads, writes}` declarations
- *     (looked up via the optional `PluginCapabilityLookup.getMemoryScope`)
- *   - the constant `core` namespace (always present — shared agent-agnostic
- *     memory: sessions, run traces, system prompts)
+ * Compute an Agent's effective memory scope.
  *
- * `core` is a stable convention used by the `ScopedMemoryStore` wrapper to
- * permit shared paths even for Agents with otherwise-empty plugin lists.
+ * STRICT per-orchestrator isolation (supersedes the original US8/T033
+ * plugin-union model): an Agent may touch only its own orchestrator tree
+ * plus the shared `core` namespace — never another Agent's, and never a
+ * shared per-plugin namespace (`agent:<pluginId>:*`). Two Agents that both
+ * enable the same plugin therefore do NOT share that plugin's memory; each
+ * plugin's notes live under the Agent-private
+ * `/memories/orchestrators/<slug>/plugins/<pluginId>/` sub-tree, all covered
+ * by the single `orchestrator:<slug>:*` pattern.
  *
- * When `lookup` is undefined OR the lookup returns undefined for every
- * plugin, the scope degrades to `['core']` — no per-Agent enforcement
- * beyond the shared namespace.
+ *  - `core`                 — shared agent-agnostic memory (sessions, run
+ *                             traces, brand `_*` files, system prompts).
+ *  - `orchestrator:<slug>:*` — the Agent's entire private tree.
+ *
+ * Plugin manifest `permissions.memory` declarations no longer widen an
+ * Agent's scope; cross-agent knowledge sharing now flows exclusively through
+ * the KG ACL model (team/public-promoted MemorableKnowledge), not the
+ * filesystem memory store.
  */
-export function computeMemoryScope(
-  plugins: readonly AgentPluginRow[],
-  lookup: PluginCapabilityLookup | undefined,
-): readonly string[] {
-  const out = new Set<string>(['core']);
-  if (!lookup?.getMemoryScope) return Array.from(out);
-  for (const p of plugins) {
-    if (!p.enabled) continue;
-    const scope = lookup.getMemoryScope(p.pluginId);
-    if (!scope) continue;
-    for (const s of scope) out.add(s);
-  }
-  return Array.from(out);
+export function computeMemoryScope(agentSlug: string): readonly string[] {
+  return orchestratorMemoryScope(agentSlug);
 }
 
 function groupBy<T, K>(

--- a/middleware/packages/harness-orchestrator/src/registry/scopedMemoryStore.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/scopedMemoryStore.ts
@@ -23,6 +23,10 @@ import type { MemoryEntry, MemoryStore } from '@omadia/plugin-api';
  *                              `/memories/chat-sessions/...`, `/memories/_*\/...`
  *                              (the shared kernel namespaces).
  *   - `agent:<id>:*`         — matches `/memories/agents/<id>/...`.
+ *   - `orchestrator:<slug>:*` — matches `/memories/orchestrators/<slug>/...`
+ *                              (strict per-orchestrator isolation: the
+ *                              Agent's own model-notes + its per-plugin
+ *                              sub-trees under `.../plugins/<pluginId>/`).
  *   - `session:*`            — matches `/memories/sessions/...`.
  *   - `/memories/foo`        — exact path match.
  *   - `/memories/foo/*`      — prefix match (everything under `/memories/foo/`).
@@ -31,6 +35,18 @@ import type { MemoryEntry, MemoryStore } from '@omadia/plugin-api';
  * and the constructor surfaces them as a warning so a typo in a manifest
  * shows up in the log without breaking the boot.
  */
+
+/**
+ * The strict per-orchestrator memory scope for an Agent: its own private
+ * orchestrator tree plus the shared `core` namespace. Single source of truth
+ * used both by the registry (metadata / snapshot) and by
+ * `buildOrchestratorForAgent` (the store that actually enforces it). Lives in
+ * this leaf module so `buildOrchestrator` can import it without a cycle
+ * through `registry/index`.
+ */
+export function orchestratorMemoryScope(agentSlug: string): readonly string[] {
+  return ['core', `orchestrator:${agentSlug}:*`];
+}
 
 export class MemoryScopeViolation extends Error {
   readonly agentSlug: string;
@@ -77,6 +93,18 @@ function compilePattern(pattern: string): CompiledPattern | undefined {
   if (agentMatch) {
     const id = agentMatch[1]!;
     const prefix = `/memories/agents/${id}/`;
+    return {
+      source: pattern,
+      match: (p) => p === prefix.slice(0, -1) || p.startsWith(prefix),
+    };
+  }
+  // Per-orchestrator isolation (strict): an Agent's own private tree —
+  // `/memories/orchestrators/<slug>/...` — covering both its model-level
+  // notes and its per-plugin sub-trees (`.../plugins/<pluginId>/...`).
+  const orchMatch = /^orchestrator:([^:]+):\*$/.exec(pattern);
+  if (orchMatch) {
+    const slug = orchMatch[1]!;
+    const prefix = `/memories/orchestrators/${slug}/`;
     return {
       source: pattern,
       match: (p) => p === prefix.slice(0, -1) || p.startsWith(prefix),

--- a/middleware/packages/harness-orchestrator/src/sessionLogger.ts
+++ b/middleware/packages/harness-orchestrator/src/sessionLogger.ts
@@ -1,5 +1,10 @@
 import type { MemoryStore } from '@omadia/plugin-api';
-import { turnNodeId, type EntityRef, type KnowledgeGraph } from '@omadia/plugin-api';
+import {
+  qualifyScope,
+  turnNodeId,
+  type EntityRef,
+  type KnowledgeGraph,
+} from '@omadia/plugin-api';
 import { isValidSessionId, type ChatSessionStore } from './chatSessionStore.js';
 import type { RunTracePayload } from './runTraceCollector.js';
 
@@ -56,6 +61,19 @@ export class SessionLogger {
      * is mirrored into the store so a mid-stream reload still recovers the
      * assistant answer without needing the client to PUT. */
     private readonly chatSessionStore?: ChatSessionStore,
+    /**
+     * Per-orchestrator KG isolation — the Agent (orchestrator) slug owning
+     * this logger (= `config.agentId`). When set, every Turn is ingested
+     * under the qualified graph scope `<agentSlug>::<scope>` so recall can
+     * constrain to this Agent's own turns. The MARKDOWN transcript path is
+     * left on the raw (sanitized) scope — it is a shared, conversation-keyed
+     * human/recovery artifact (decision A3a). When undefined (legacy
+     * single-agent boot / tests), the graph scope stays unqualified exactly
+     * as before. MUST match the qualification the orchestrator applies to the
+     * retriever's `sessionScope` (same `qualifyScope(agentSlug, rawScope)`),
+     * so `turnNodeId` agrees on both the write and the recall side.
+     */
+    private readonly agentSlug?: string,
   ) {}
 
   async log(entry: SessionLogEntry): Promise<{ turnExternalId: string }> {
@@ -65,9 +83,14 @@ export class SessionLogger {
     // Millisecond-precision time so back-to-back turns have unique ids. Trade
     // a few characters of header noise for collision-free graph backfill.
     const time = iso.slice(11, 23);
+    // Markdown path: raw (sanitized) conversation scope — shared, human/
+    // recovery artifact (decision A3a). Graph: agent-qualified so recall is
+    // per-orchestrator. `graphScopeFor` is the single source of truth the
+    // orchestrator also uses for the retriever's sessionScope/excludeScope.
     const scope = sanitizeScope(entry.scope);
+    const gScope = graphScopeFor(this.agentSlug, entry.scope);
     const entityRefs = dedupeEntityRefs(entry.entityRefs ?? []);
-    const earlyTurnId = turnNodeId(scope, iso);
+    const earlyTurnId = turnNodeId(gScope, iso);
 
     const startedAt = now.getTime();
 
@@ -126,10 +149,10 @@ export class SessionLogger {
     }
 
     if (this.graph) {
-      const turnExternalId = turnNodeId(scope, iso);
+      const turnExternalId = turnNodeId(gScope, iso);
       try {
         await this.graph.ingestTurn({
-          scope,
+          scope: gScope,
           time: iso,
           userMessage: entry.userMessage,
           assistantAnswer: entry.assistantAnswer,
@@ -163,8 +186,24 @@ export class SessionLogger {
       }
       return { turnExternalId };
     }
-    return { turnExternalId: turnNodeId(scope, iso) };
+    return { turnExternalId: turnNodeId(gScope, iso) };
   }
+}
+
+/**
+ * The canonical graph scope for a turn — `sanitizeScope`d conversation id,
+ * agent-qualified when an Agent slug is supplied. Exported so the orchestrator
+ * computes the retriever's `sessionScope`/`excludeScope` with the EXACT same
+ * formula the logger writes, keeping `turnNodeId` consistent across the
+ * write (ingest) and read (recall) sides. `undefined` slug = legacy
+ * unqualified scope (single-agent boot / tests), byte-identical to pre-isolation.
+ */
+export function graphScopeFor(
+  agentSlug: string | undefined,
+  rawScope: string,
+): string {
+  const base = sanitizeScope(rawScope);
+  return agentSlug !== undefined ? qualifyScope(agentSlug, base) : base;
 }
 
 function sanitizeScope(scope: string): string {

--- a/middleware/packages/harness-orchestrator/src/turnContext.ts
+++ b/middleware/packages/harness-orchestrator/src/turnContext.ts
@@ -34,6 +34,16 @@ import type { PrivacyTurnHandle } from './privacyHandle.js';
 export interface TurnContextValue {
   turnId: string;
   turnDate: string;
+  /**
+   * Per-orchestrator isolation — slug of the Agent (orchestrator) handling
+   * this turn. Set by the orchestrator at turn start (= `this.agentId`).
+   * Read by the per-call MemoryAccessor so a plugin's notes land under the
+   * active orchestrator's namespace, and available to any other turn-scoped
+   * consumer that needs the Agent identity. Undefined outside a turn (ad-hoc
+   * invocations, activate-time plugin writes) → callers fall back to
+   * `'default'`.
+   */
+  agentSlug?: string;
   chatParticipants?: ChatParticipantsProvider;
   /**
    * Privacy-Proxy Slice 2.1: per-turn privacy handle threaded through the
@@ -135,6 +145,7 @@ export const turnContext = {
       {
         turnId: prev?.turnId ?? '',
         turnDate: prev?.turnDate ?? today(),
+        ...(prev?.agentSlug ? { agentSlug: prev.agentSlug } : {}),
         chatParticipants,
         ...(prev?.privacyHandle ? { privacyHandle: prev.privacyHandle } : {}),
         ...(prev?.captureRawToolResult
@@ -151,6 +162,13 @@ export const turnContext = {
   /** Convenience accessor. Undefined outside any turn context. */
   currentTurnId(): string | undefined {
     return storage.getStore()?.turnId;
+  },
+  /**
+   * The Agent (orchestrator) slug handling the active turn, or undefined
+   * outside any turn context. Used for per-orchestrator memory/KG isolation.
+   */
+  currentAgentSlug(): string | undefined {
+    return storage.getStore()?.agentSlug;
   },
   /**
    * The turn's frozen date as `YYYY-MM-DD`. Falls back to a fresh

--- a/middleware/packages/harness-orchestrator/src/turnHooks.ts
+++ b/middleware/packages/harness-orchestrator/src/turnHooks.ts
@@ -30,6 +30,16 @@ export interface TurnHookContext {
   readonly turnId: string;
   readonly sessionScope?: string;
   readonly userId?: string;
+  /**
+   * Per-orchestrator isolation — the Agent (orchestrator) slug handling this
+   * turn (= the orchestrator's `agentId`). Hooks that persist scope-keyed KG
+   * artefacts (e.g. the plan-runner's Plan nodes) MUST qualify their scope
+   * with it (`<agentSlug>::<sessionScope>`, via `qualifyScope`) so recall
+   * stays per-Agent — matching what `SessionLogger` writes for Turns.
+   * Undefined on legacy / single-agent boots → callers fall back to the raw
+   * scope (the `default::` dual-clause keeps it reachable).
+   */
+  readonly agentSlug?: string;
 }
 
 /**

--- a/middleware/packages/harness-orchestrator/src/verifierService.ts
+++ b/middleware/packages/harness-orchestrator/src/verifierService.ts
@@ -129,6 +129,10 @@ export class VerifierService implements ChatAgent {
           turnId: scope,
           sessionScope: scope,
           ...(input.userId ? { userId: input.userId } : {}),
+          // Per-orchestrator isolation: same Agent slug the orchestrator
+          // stamps on its hooks, so the plan-runner qualifies the scope
+          // identically and finds this Agent's plan.
+          agentSlug: this.orchestrator.agentId,
         },
         { blockReason: reason },
       )

--- a/middleware/packages/harness-plugin-plan-runner/src/plugin.ts
+++ b/middleware/packages/harness-plugin-plan-runner/src/plugin.ts
@@ -1,5 +1,6 @@
 import type { KnowledgeGraph, PluginContext } from '@omadia/plugin-api';
 import type { TurnAnnotation, TurnHookRegistrar } from '@omadia/orchestrator';
+import { graphScopeFor } from '@omadia/orchestrator';
 
 import { shouldPlan } from './gate.js';
 import { buildPlanSnapshot } from './snapshot.js';
@@ -159,7 +160,14 @@ export async function activate(
         const userMessage = payload.userMessage?.trim();
         if (!userMessage) return;
         if (!(await shouldPlan(userMessage, llm))) return;
-        const scope = hookCtx.sessionScope ?? hookCtx.turnId;
+        // Per-orchestrator isolation: qualify the plan scope with the Agent
+        // slug (same `graphScopeFor` formula SessionLogger uses for Turns) so
+        // `listRecentPlans` recall stays per-Agent. `agentSlug` is undefined
+        // on legacy boots → raw scope (the `default::` dual-clause covers it).
+        const scope = graphScopeFor(
+          hookCtx.agentSlug,
+          hookCtx.sessionScope ?? hookCtx.turnId,
+        );
         const nowMs = Date.now();
         const createdAt = new Date(nowMs).toISOString();
         const result = await materializePlan({
@@ -336,8 +344,9 @@ export async function activate(
       label: 'plan-runner:onVerifierBlocked',
       priority: 10,
       hook: async (hookCtx, payload): Promise<void> => {
-        const scope = hookCtx.sessionScope;
-        if (!scope) return;
+        if (!hookCtx.sessionScope) return;
+        // Qualify identically to the write side so the plan is found.
+        const scope = graphScopeFor(hookCtx.agentSlug, hookCtx.sessionScope);
         const marked = await markLatestPlanVerifierBlocked(
           scope,
           payload.blockReason ?? 'contradiction',

--- a/middleware/packages/plugin-api/src/knowledgeGraph.ts
+++ b/middleware/packages/plugin-api/src/knowledgeGraph.ts
@@ -102,6 +102,12 @@ export interface KnowledgeGraph {
     userId?: string;
     limit?: number;
     openOnly?: boolean;
+    /**
+     * Restrict recall to plans whose `scope` begins with this agent prefix
+     * (`<agentSlug>::`). Omit for the legacy global view. See
+     * {@link agentScopePrefix} — per-orchestrator KG isolation.
+     */
+    agentScopePrefix?: string;
   }): Promise<GraphNode[]>;
   /**
    * Structured run-subgraph for a single Turn: Run node + AgentInvocations
@@ -677,6 +683,15 @@ export interface MemorableKnowledgeSearchOptions {
    * historical owner-only behaviour).
    */
   teamVisibility?: boolean;
+  /**
+   * Per-orchestrator isolation — the recalling Agent's slug. When set,
+   * owner-gated MK is additionally constrained to rows the viewing Agent
+   * produced (`origin_agent = viewerAgentSlug`); MK with no `origin_agent`
+   * (legacy / single-agent) stays visible to the owner. team/public rows
+   * bypass this constraint (cross-agent sharing preserved). Omit on legacy
+   * callers → no agent constraint.
+   */
+  viewerAgentSlug?: string;
 }
 
 /** Slice 7 — single MK hit from semantic search. */
@@ -698,6 +713,12 @@ export interface ExcerptSearchOptions {
    * against the parent MK's `visibility`. Default false.
    */
   teamVisibility?: boolean;
+  /**
+   * Per-orchestrator isolation — mirrors
+   * {@link MemorableKnowledgeSearchOptions.viewerAgentSlug}. Constrains the
+   * owner branch to the parent MK's `origin_agent`. Omit on legacy callers.
+   */
+  viewerAgentSlug?: string;
 }
 
 /** Slice 7 — single excerpt hit, carries the parent-MK external_id
@@ -1050,6 +1071,15 @@ export interface MemorableKnowledgeIngest {
    * regardless of whether owners are set.
    */
   aclOwners?: string[];
+  /**
+   * Per-orchestrator isolation — the Agent slug that produced this MK,
+   * stamped as the `origin_agent` property. Recall default-isolates by
+   * origin agent (an Agent only sees its own MK) while team/public-promoted
+   * MK stays shareable across Agents. Omit on legacy / single-agent boots →
+   * the MK has no origin agent and is matched only via the team/public or
+   * user-ACL branches.
+   */
+  originAgent?: string;
   /**
    * Slice 3 — cluster-root that triggered the create. Audited as the
    * `actor_omadia_user_id` of the `create` row. Falls back to
@@ -1476,6 +1506,12 @@ export interface SearchTurnsOptions {
   excludeScope?: string;
   /** Drop specific Turn external ids (usually the current turn). */
   excludeTurnIds?: readonly string[];
+  /**
+   * Restrict to turns whose `scope` begins with this agent prefix
+   * (`<agentSlug>::`). Omit for the legacy cross-agent view. See
+   * {@link agentScopePrefix} — per-orchestrator KG isolation.
+   */
+  agentScopePrefix?: string;
   /** Hard cap on returned hits. Defaults to 5. */
   limit?: number;
 }
@@ -1506,6 +1542,12 @@ export interface SearchTurnsByEmbeddingOptions {
   excludeScope?: string;
   /** Drop specific Turn external ids. */
   excludeTurnIds?: readonly string[];
+  /**
+   * Restrict to turns whose `scope` begins with this agent prefix
+   * (`<agentSlug>::`). Omit for the legacy cross-agent view. See
+   * {@link agentScopePrefix} — per-orchestrator KG isolation.
+   */
+  agentScopePrefix?: string;
   /** Hard cap on returned hits. Defaults to 5. */
   limit?: number;
   /** Drop matches with cosine similarity below this threshold. Default 0.3. */
@@ -1569,6 +1611,13 @@ export interface EntityCapturedTurnsOptions {
   userId?: string;
   /** Drop capturing turns from this scope. */
   excludeScope?: string;
+  /**
+   * Restrict the capturing turns to those whose `scope` begins with this
+   * agent prefix (`<agentSlug>::`). Entity NODES stay global (shared
+   * vocabulary); only the CAPTURED→Turn recall is agent-isolated. Omit for
+   * the legacy cross-agent view. See {@link agentScopePrefix}.
+   */
+  agentScopePrefix?: string;
   /** Max turns to return per matched entity. Default 2. */
   perEntityLimit?: number;
   /** Hard cap on distinct entities to return. Default 5. */
@@ -1593,6 +1642,35 @@ export interface EntityCapturedTurnsHit {
     userMessage: string;
     assistantAnswer: string;
   }>;
+}
+
+// ---------------------------------------------------------------------------
+// Per-orchestrator KG scope qualification.
+//
+// Each Agent (orchestrator) owns a slice of the single-tenant graph. We carry
+// the Agent identity inside the existing free-string `scope` (reusing the
+// `(tenant_id, scope, type)` index — no schema migration) by prefixing the
+// conversation scope with `<agentSlug>::`. Reads then constrain to
+// `scope LIKE '<agentSlug>::%'`, so Orchestrator A never recalls Orchestrator
+// B's turns/plans while WITHIN-agent cross-conversation recall still works
+// (the current conversation is dropped via `excludeScope`).
+//
+// CRITICAL: qualify exactly ONCE, at the orchestrator boundary. `turnNodeId`
+// / `sessionNodeId` derive node ids FROM the scope, so an unqualified scope at
+// any write/read site silently breaks recall (no error, just misses).
+// ---------------------------------------------------------------------------
+
+/** Separator between the agent slug and the conversation scope. */
+export const AGENT_SCOPE_SEP = '::';
+
+/** Build the graph scope an Agent writes: `<agentSlug>::<conversationScope>`. */
+export function qualifyScope(agentSlug: string, conversationScope: string): string {
+  return `${agentSlug}${AGENT_SCOPE_SEP}${conversationScope}`;
+}
+
+/** The `LIKE` prefix (`<agentSlug>::`) that selects one Agent's scopes. */
+export function agentScopePrefix(agentSlug: string): string {
+  return `${agentSlug}${AGENT_SCOPE_SEP}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/middleware/src/platform/memoryAccessor.ts
+++ b/middleware/src/platform/memoryAccessor.ts
@@ -6,29 +6,54 @@ import {
 } from '@omadia/plugin-api';
 
 /**
- * Builds a MemoryAccessor that routes all reads/writes into a fixed
- * `/memories/agents/<agentId>/...` subtree of the host's MemoryStore.
+ * Builds a MemoryAccessor that routes all reads/writes into a per-plugin,
+ * **per-orchestrator** subtree of the host's MemoryStore:
  *
- * Isolation is **structural**: the accessor simply cannot produce an
- * absolute path outside the plugin's scope. Plugins cannot see each
- * other's memory because the accessor they receive has no API to ask for
- * it. That's stronger than an ACL check (no check to forget to enforce).
+ *   /memories/orchestrators/<agentSlug>/plugins/<pluginId>/...
  *
- * Path rules:
+ * The owning orchestrator (Agent) is resolved at CALL time via
+ * `resolveAgentSlug` (backed by the turn-context Agent slug), so the same
+ * plugin invoked under two different Agents writes to two disjoint trees —
+ * strict per-orchestrator isolation, even for a plugin both Agents enable.
+ * Outside a turn (activate-time writes, ad-hoc) the slug falls back to
+ * `'default'`, preserving single-agent behaviour.
+ *
+ * Isolation is **structural**: the accessor cannot produce an absolute path
+ * outside the plugin's per-orchestrator scope. Plugins cannot see each
+ * other's — or another orchestrator's — memory because the accessor they
+ * receive has no API to ask for it.
+ *
+ * Back-compat: before per-orchestrator isolation, plugin memory lived at
+ * `/memories/agents/<pluginId>/...` (orchestrator-agnostic). For the default
+ * Agent only, READ operations fall back to that legacy tree on a miss so
+ * pre-isolation data stays reachable without a migration. Writes always go to
+ * the new per-orchestrator path.
+ *
+ * Path rules (unchanged):
  *   - Input is relative (`notes.md`, `subdir/a.txt`).
  *   - Leading `/` is rejected — plugins must not think in absolute terms.
- *   - `..` segments are rejected (underlying store would reject too, but
- *     fail-fast with a plugin-api error gives a cleaner diagnostic).
+ *   - `..` segments are rejected.
  *   - Empty / dot-only paths resolve to the scope root (for `list`/`exists`).
  */
 export function createMemoryAccessor(opts: {
-  agentId: string;
+  pluginId: string;
   store: MemoryStore;
+  /**
+   * Resolves the active orchestrator (Agent) slug for the current turn —
+   * typically `() => turnContext.currentAgentSlug()`. `undefined` (no turn
+   * context) falls back to the `'default'` Agent.
+   */
+  resolveAgentSlug?: () => string | undefined;
 }): MemoryAccessor {
-  const { agentId, store } = opts;
-  const scopePrefix = `/memories/agents/${agentId}`;
+  const { pluginId, store } = opts;
+  const resolveAgentSlug = opts.resolveAgentSlug ?? ((): undefined => undefined);
+  const legacyPrefix = `/memories/agents/${pluginId}`;
 
-  const resolveScoped = (relPath: string): string => {
+  const currentSlug = (): string => resolveAgentSlug() ?? 'default';
+  const scopePrefixFor = (slug: string): string =>
+    `/memories/orchestrators/${slug}/plugins/${pluginId}`;
+
+  const normalize = (relPath: string): string => {
     if (typeof relPath !== 'string') {
       throw new MemoryPathError('memory path must be a string');
     }
@@ -38,70 +63,104 @@ export function createMemoryAccessor(opts: {
       );
     }
     if (relPath.includes('..')) {
-      throw new MemoryPathError(
-        `memory path must not contain '..': ${relPath}`,
-      );
+      throw new MemoryPathError(`memory path must not contain '..': ${relPath}`);
     }
     if (relPath.includes('\u0000')) {
       throw new MemoryPathError('memory path must not contain null bytes');
     }
-    // Normalize — empty / '.' / './' all point to scope root.
-    const trimmed = relPath.replace(/^\.\/?|^$/, '');
-    if (trimmed.length === 0) return scopePrefix;
-    return `${scopePrefix}/${trimmed}`;
+    // Empty / '.' / './' all point to the scope root.
+    return relPath.replace(/^\.\/?|^$/, '');
   };
 
-  const toRel = (abs: string): string => {
-    if (abs === scopePrefix) return '';
-    if (abs.startsWith(scopePrefix + '/')) {
-      return abs.slice(scopePrefix.length + 1);
-    }
-    // Shouldn't happen with a well-behaved MemoryStore, but stay defensive:
-    // don't leak out-of-scope paths back to plugin code.
+  /** Resolve a relative path against a given scope prefix. */
+  const resolveAt = (prefix: string, relPath: string): string => {
+    const trimmed = normalize(relPath);
+    return trimmed.length === 0 ? prefix : `${prefix}/${trimmed}`;
+  };
+
+  const toRel = (prefix: string, abs: string): string => {
+    if (abs === prefix) return '';
+    if (abs.startsWith(prefix + '/')) return abs.slice(prefix.length + 1);
+    // Stay defensive: don't leak out-of-scope paths back to plugin code.
     throw new MemoryPathError(`store returned out-of-scope path: ${abs}`);
   };
 
+  /** Legacy read-through is only offered for the default Agent. */
+  const legacyEnabled = (slug: string): boolean => slug === 'default';
+
   return {
     async readFile(relPath: string): Promise<string> {
-      return store.readFile(resolveScoped(relPath));
+      const slug = currentSlug();
+      const prefix = scopePrefixFor(slug);
+      try {
+        return await store.readFile(resolveAt(prefix, relPath));
+      } catch (err) {
+        if (legacyEnabled(slug)) {
+          // Pre-isolation data lived under /memories/agents/<pluginId>/.
+          const legacyAbs = resolveAt(legacyPrefix, relPath);
+          if (await store.fileExists(legacyAbs)) {
+            return store.readFile(legacyAbs);
+          }
+        }
+        throw err;
+      }
     },
 
     async writeFile(relPath: string, content: string): Promise<void> {
-      await store.writeFile(resolveScoped(relPath), content);
+      await store.writeFile(resolveAt(scopePrefixFor(currentSlug()), relPath), content);
     },
 
     async createFile(relPath: string, content: string): Promise<void> {
-      await store.createFile(resolveScoped(relPath), content);
+      await store.createFile(resolveAt(scopePrefixFor(currentSlug()), relPath), content);
     },
 
     async delete(relPath: string): Promise<void> {
-      await store.delete(resolveScoped(relPath));
+      await store.delete(resolveAt(scopePrefixFor(currentSlug()), relPath));
     },
 
     async list(relPath: string): Promise<readonly MemoryEntryInfo[]> {
-      const absDir = resolveScoped(relPath);
-      const scopeExists = await store.directoryExists(scopePrefix);
-      if (!scopeExists) {
-        // Plugin never wrote to its scope yet — surface as empty list
-        // rather than a confusing "path not found" error on the implicit
-        // scope root.
-        return [];
+      const slug = currentSlug();
+      const prefix = scopePrefixFor(slug);
+      if (await store.directoryExists(prefix)) {
+        const entries = await store.list(resolveAt(prefix, relPath));
+        return entries.map(
+          (e): MemoryEntryInfo => ({
+            relPath: toRel(prefix, e.virtualPath),
+            isDirectory: e.isDirectory,
+            sizeBytes: e.sizeBytes,
+          }),
+        );
       }
-      const entries = await store.list(absDir);
-      return entries.map(
-        (e): MemoryEntryInfo => ({
-          relPath: toRel(e.virtualPath),
-          isDirectory: e.isDirectory,
-          sizeBytes: e.sizeBytes,
-        }),
-      );
+      // New scope empty — fall back to legacy data for the default Agent.
+      if (legacyEnabled(slug) && (await store.directoryExists(legacyPrefix))) {
+        const entries = await store.list(resolveAt(legacyPrefix, relPath));
+        return entries.map(
+          (e): MemoryEntryInfo => ({
+            relPath: toRel(legacyPrefix, e.virtualPath),
+            isDirectory: e.isDirectory,
+            sizeBytes: e.sizeBytes,
+          }),
+        );
+      }
+      // Plugin never wrote to its scope yet — surface as empty list rather
+      // than a confusing "path not found" on the implicit scope root.
+      return [];
     },
 
     async exists(relPath: string): Promise<boolean> {
-      const abs = resolveScoped(relPath);
-      return (
-        (await store.fileExists(abs)) || (await store.directoryExists(abs))
-      );
+      const slug = currentSlug();
+      const abs = resolveAt(scopePrefixFor(slug), relPath);
+      if ((await store.fileExists(abs)) || (await store.directoryExists(abs))) {
+        return true;
+      }
+      if (legacyEnabled(slug)) {
+        const legacyAbs = resolveAt(legacyPrefix, relPath);
+        return (
+          (await store.fileExists(legacyAbs)) ||
+          (await store.directoryExists(legacyAbs))
+        );
+      }
+      return false;
     },
   };
 }

--- a/middleware/src/platform/pluginContext.ts
+++ b/middleware/src/platform/pluginContext.ts
@@ -41,6 +41,7 @@ import {
   type ToolsAccessor,
 } from '@omadia/plugin-api';
 import type { DomainTool } from '@omadia/orchestrator';
+import { turnContext } from '@omadia/orchestrator';
 
 import type { InstalledRegistry } from '../plugins/installedRegistry.js';
 import type { JobScheduler } from '../plugins/jobScheduler.js';
@@ -221,16 +222,20 @@ export function createPluginContext(
       : undefined;
 
   // Memory accessor: present when the manifest declares memory permissions
-  // AND the memory provider plugin (`@omadia/memory`) has published
-  // its store into the service registry. The accessor is scoped to
-  // /memories/agents/<agentId>/ — plugins cannot see each other's memory.
-  // The manifest's permissions.memory.reads/writes fields are parsed but
-  // not currently used for intra-scope ACL enforcement — scope isolation
-  // itself is the primary boundary.
+  // AND the memory provider plugin (`@omadia/memory`) has published its store
+  // into the service registry. The accessor is scoped per-plugin AND
+  // per-orchestrator to /memories/orchestrators/<agentSlug>/plugins/<pluginId>/
+  // — the active Agent slug is resolved from the turn context at call time, so
+  // the same plugin invoked under two Agents writes to two disjoint trees.
+  // Plugins cannot see each other's — or another orchestrator's — memory.
   const memoryStoreService = serviceRegistry.get<MemoryStore>('memoryStore');
   const memory: MemoryAccessor | undefined =
     memoryStoreService && memoryDeclared(agentId, catalog)
-      ? createMemoryAccessor({ agentId, store: memoryStoreService })
+      ? createMemoryAccessor({
+          pluginId: agentId,
+          store: memoryStoreService,
+          resolveAgentSlug: () => turnContext.currentAgentSlug(),
+        })
       : undefined;
 
   const secrets: SecretsAccessor = {

--- a/middleware/test/kgAgentScopeIsolation.test.ts
+++ b/middleware/test/kgAgentScopeIsolation.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Per-orchestrator Knowledge-Graph isolation (in-memory backend).
+ *
+ * Cross-agent leak regression: two Agents share one single-tenant graph;
+ * recall must NOT surface another Agent's turns. Scope is agent-qualified
+ * (`<agentSlug>::<conversation>`); reads constrain to the asking Agent's
+ * prefix. Legacy unqualified rows fall through to the `default::` Agent
+ * (zero-migration dual-clause).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemoryKnowledgeGraph } from '@omadia/knowledge-graph-inmemory';
+import { qualifyScope, type EntityRef } from '@omadia/plugin-api';
+
+const widget = (): EntityRef => ({
+  system: 'odoo',
+  model: 'res.partner',
+  id: 1,
+  displayName: 'widgetco',
+  op: 'read',
+});
+
+async function seed(): Promise<InMemoryKnowledgeGraph> {
+  const g = new InMemoryKnowledgeGraph();
+  await g.ingestTurn({
+    scope: qualifyScope('agent-a', 'c1'),
+    time: '2026-04-18T10:00:00Z',
+    userMessage: 'budget alpha for widgetco',
+    assistantAnswer: 'A',
+    entityRefs: [widget()],
+  });
+  await g.ingestTurn({
+    scope: qualifyScope('agent-b', 'c2'),
+    time: '2026-04-18T11:00:00Z',
+    userMessage: 'budget beta for widgetco',
+    assistantAnswer: 'B',
+    entityRefs: [widget()],
+  });
+  // Legacy unqualified turn (pre-isolation).
+  await g.ingestTurn({
+    scope: 'oldconv',
+    time: '2026-04-18T09:00:00Z',
+    userMessage: 'budget legacy for widgetco',
+    assistantAnswer: 'L',
+    entityRefs: [widget()],
+  });
+  return g;
+}
+
+test('searchTurns: agent prefix returns only the asking Agent\'s turns', async () => {
+  const g = await seed();
+  const a = await g.searchTurns({ query: 'budget', agentScopePrefix: 'agent-a::' });
+  assert.deepEqual(
+    a.map((h) => h.userMessage),
+    ['budget alpha for widgetco'],
+  );
+  const b = await g.searchTurns({ query: 'budget', agentScopePrefix: 'agent-b::' });
+  assert.deepEqual(
+    b.map((h) => h.userMessage),
+    ['budget beta for widgetco'],
+  );
+});
+
+test('searchTurns: default:: prefix matches legacy unqualified rows (dual-clause)', async () => {
+  const g = await seed();
+  const hits = await g.searchTurns({
+    query: 'budget',
+    agentScopePrefix: 'default::',
+  });
+  // Only the legacy row (no '::'); NOT agent-a / agent-b qualified rows.
+  assert.deepEqual(
+    hits.map((h) => h.userMessage),
+    ['budget legacy for widgetco'],
+  );
+});
+
+test('searchTurns: no prefix preserves legacy cross-agent recall', async () => {
+  const g = await seed();
+  const hits = await g.searchTurns({ query: 'budget' });
+  assert.equal(hits.length, 3);
+});
+
+test('listRecentPlans: agent prefix returns only the asking Agent\'s plans', async () => {
+  const g = new InMemoryKnowledgeGraph();
+  await g.ingestPlan({
+    planId: 'p-a',
+    scope: qualifyScope('agent-a', 'c1'),
+    strategy: 'alpha plan',
+    createdAt: '2026-04-18T10:00:00Z',
+  });
+  await g.ingestPlan({
+    planId: 'p-b',
+    scope: qualifyScope('agent-b', 'c2'),
+    strategy: 'beta plan',
+    createdAt: '2026-04-18T11:00:00Z',
+  });
+
+  const a = await g.listRecentPlans({ agentScopePrefix: 'agent-a::' });
+  assert.deepEqual(
+    a.map((p) => p.props['strategy']),
+    ['alpha plan'],
+  );
+  const b = await g.listRecentPlans({ agentScopePrefix: 'agent-b::' });
+  assert.deepEqual(
+    b.map((p) => p.props['strategy']),
+    ['beta plan'],
+  );
+  // No prefix → legacy cross-agent (both visible).
+  assert.equal((await g.listRecentPlans({})).length, 2);
+});
+
+test('findEntityCapturedTurns: entity is global, recall is agent-isolated', async () => {
+  const g = await seed();
+  const a = await g.findEntityCapturedTurns({
+    terms: ['widgetco'],
+    agentScopePrefix: 'agent-a::',
+  });
+  const turns = a.flatMap((h) => h.turns.map((t) => t.userMessage));
+  assert.deepEqual(turns, ['budget alpha for widgetco']);
+  // Agent A cannot reach Agent B's turn via the shared entity. (Leak #1.)
+  assert.ok(!turns.some((m) => m.includes('beta')));
+});

--- a/middleware/test/memoryAccessorIsolation.test.ts
+++ b/middleware/test/memoryAccessorIsolation.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Per-orchestrator plugin-memory isolation (`createMemoryAccessor`).
+ *
+ * The SAME plugin invoked under two different Agents must write to two
+ * disjoint trees (`/memories/orchestrators/<slug>/plugins/<pluginId>/`), so
+ * Orchestrator A never sees Orchestrator B's plugin memory — even for a
+ * plugin both Agents enable. Legacy `/memories/agents/<pluginId>/` data stays
+ * readable for the default Agent only.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { FilesystemMemoryStore } from '@omadia/memory';
+
+import { createMemoryAccessor } from '../src/platform/memoryAccessor.js';
+
+async function freshStore(): Promise<FilesystemMemoryStore> {
+  return new FilesystemMemoryStore(await mkdtemp(join(tmpdir(), 'omadia-acc-')));
+}
+
+test('same plugin under two Agents writes to disjoint trees', async () => {
+  const store = await freshStore();
+  let slug = 'agent-a';
+  const acc = createMemoryAccessor({
+    pluginId: 'p',
+    store,
+    resolveAgentSlug: () => slug,
+  });
+
+  await acc.writeFile('notes.md', 'A-secret');
+  slug = 'agent-b';
+  // Agent B does not see Agent A's note at the same relative path.
+  assert.equal(await acc.exists('notes.md'), false);
+  await acc.writeFile('notes.md', 'B-secret');
+
+  // Physically disjoint.
+  assert.equal(
+    await store.readFile('/memories/orchestrators/agent-a/plugins/p/notes.md'),
+    'A-secret',
+  );
+  assert.equal(
+    await store.readFile('/memories/orchestrators/agent-b/plugins/p/notes.md'),
+    'B-secret',
+  );
+
+  // Back to A — still sees only its own.
+  slug = 'agent-a';
+  assert.equal(await acc.readFile('notes.md'), 'A-secret');
+});
+
+test('legacy /memories/agents/<plugin>/ data is read-through for default only', async () => {
+  const store = await freshStore();
+  await store.writeFile('/memories/agents/p/old.md', 'legacy');
+
+  let slug = 'default';
+  const acc = createMemoryAccessor({
+    pluginId: 'p',
+    store,
+    resolveAgentSlug: () => slug,
+  });
+  // Default Agent reads pre-isolation data.
+  assert.equal(await acc.exists('old.md'), true);
+  assert.equal(await acc.readFile('old.md'), 'legacy');
+
+  // A non-default Agent does NOT get the legacy read-through.
+  slug = 'agent-b';
+  assert.equal(await acc.exists('old.md'), false);
+  await assert.rejects(() => acc.readFile('old.md'));
+});
+
+test('outside a turn the accessor falls back to the default Agent tree', async () => {
+  const store = await freshStore();
+  const acc = createMemoryAccessor({
+    pluginId: 'p',
+    store,
+    resolveAgentSlug: () => undefined, // no turn context
+  });
+  await acc.writeFile('boot.md', 'x');
+  assert.equal(
+    await store.readFile('/memories/orchestrators/default/plugins/p/boot.md'),
+    'x',
+  );
+});

--- a/middleware/test/memoryScoping.test.ts
+++ b/middleware/test/memoryScoping.test.ts
@@ -103,28 +103,47 @@ const lookup: PluginCapabilityLookup = {
   getMemoryScope: (id) => PLUGIN_SCOPES[id],
 };
 
-test('T033: computeMemoryScope unions enabled plugin scopes + core', () => {
-  const scope = computeMemoryScope(
-    [
-      plugin('a-id', '@omadia/agent-confluence'),
-      plugin('a-id', '@omadia/agent-odoo-hr', /* enabled */ false),
-      plugin('a-id', '@omadia/agent-shared'),
-    ],
-    lookup,
-  );
-  assert.deepEqual([...scope].sort(), [
-    'agent:@omadia/agent-confluence:*',
-    'agent:@omadia/agent-shared:*',
+test('strict: computeMemoryScope is core + the Agent\'s own orchestrator tree', () => {
+  // Per-orchestrator isolation supersedes the old plugin-union model: the
+  // scope is fully determined by the Agent slug and never widens with plugins.
+  assert.deepEqual([...computeMemoryScope('public')].sort(), [
     'core',
+    'orchestrator:public:*',
+  ]);
+  assert.deepEqual([...computeMemoryScope('marketing')].sort(), [
+    'core',
+    'orchestrator:marketing:*',
   ]);
 });
 
-test('T033: computeMemoryScope without a lookup degrades to [core]', () => {
-  const scope = computeMemoryScope(
-    [plugin('a-id', '@omadia/agent-confluence')],
-    undefined,
+test('strict: orchestrator:<slug>:* grants the Agent its own tree, denies another\'s', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'omadia-mem-'));
+  const inner = new FilesystemMemoryStore(dir);
+  await inner.writeFile('/memories/orchestrators/public/plugins/p/n.md', 'mine');
+  await inner.writeFile('/memories/orchestrators/marketing/plugins/p/n.md', 'theirs');
+
+  const pub = new ScopedMemoryStore({
+    agentSlug: 'public',
+    scope: computeMemoryScope('public'),
+    inner,
+  });
+  assert.equal(
+    await pub.readFile('/memories/orchestrators/public/plugins/p/n.md'),
+    'mine',
   );
-  assert.deepEqual([...scope], ['core']);
+  // Another orchestrator's tree is invisible (soft-deny read) + write-denied.
+  assert.equal(
+    await pub.fileExists('/memories/orchestrators/marketing/plugins/p/n.md'),
+    false,
+  );
+  await assert.rejects(
+    () => pub.readFile('/memories/orchestrators/marketing/plugins/p/n.md'),
+    MemoryScopeViolation,
+  );
+  await assert.rejects(
+    () => pub.writeFile('/memories/orchestrators/marketing/leak.md', 'no'),
+    MemoryScopeViolation,
+  );
 });
 
 test('SC-003: a Public Agent reads Confluence memory but NOT Odoo-HR memory', async () => {
@@ -280,14 +299,14 @@ test('T035: SessionConfigSnapshot.memoryScope matches the Agent\'s computed scop
   const active = registry.get('public');
   assert.ok(active);
   assert.deepEqual([...active.memoryScope].sort(), [
-    'agent:@omadia/agent-confluence:*',
     'core',
+    'orchestrator:public:*',
   ]);
 
   const sessionSnap = registry.snapshotForAgent('public');
   assert.deepEqual([...sessionSnap!.memoryScope].sort(), [
-    'agent:@omadia/agent-confluence:*',
     'core',
+    'orchestrator:public:*',
   ]);
 
   // Capture-on-first-use carries the scope through to the persisted session.
@@ -302,7 +321,7 @@ test('T035: SessionConfigSnapshot.memoryScope matches the Agent\'s computed scop
     Promise.resolve(sessionSnap!),
   );
   assert.deepEqual([...captured!.memoryScope].sort(), [
-    'agent:@omadia/agent-confluence:*',
     'core',
+    'orchestrator:public:*',
   ]);
 });

--- a/middleware/test/mkAgentIsolation.test.ts
+++ b/middleware/test/mkAgentIsolation.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Per-orchestrator isolation of curated MemorableKnowledge (in-memory KG).
+ *
+ * Owner-gated MK is additionally constrained to the producing Agent
+ * (`origin_agent`): Agent A does not recall Agent B's MK even for the same
+ * owning user. team/public-promoted MK still crosses Agents (the existing ACL
+ * sharing model is preserved). Legacy MK without an `origin_agent` stays
+ * visible to the owner.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { InMemoryKnowledgeGraph } from '@omadia/knowledge-graph-inmemory';
+
+const USER = 'user-1';
+
+async function mk(
+  g: InMemoryKnowledgeGraph,
+  summary: string,
+  originAgent: string | undefined,
+): Promise<string> {
+  const res = await g.createMemorableKnowledge({
+    kind: 'insight',
+    summary,
+    createdBy: `auto:${USER}`,
+    aclOwners: [USER],
+    ...(originAgent ? { originAgent } : {}),
+  });
+  // Seed an identical embedding so cosine = 1 for the query below.
+  g.setEmbedding(res.memorableKnowledgeNodeId, [1, 0, 0]);
+  return res.memorableKnowledgeNodeId;
+}
+
+test('owner-gated recall is constrained to the viewing Agent\'s origin_agent', async () => {
+  const g = new InMemoryKnowledgeGraph();
+  await mk(g, 'A insight', 'agent-a');
+  await mk(g, 'B insight', 'agent-b');
+  await mk(g, 'legacy insight', undefined); // no origin_agent
+
+  const seenBy = async (slug: string): Promise<string[]> => {
+    const hits = await g.searchMemorableKnowledgeByEmbedding({
+      queryEmbedding: [1, 0, 0],
+      viewerOmadiaUserId: USER,
+      viewerAgentSlug: slug,
+      teamVisibility: false,
+    });
+    return hits.map((h) => String(h.mk.props['summary'])).sort();
+  };
+
+  // Agent A sees its own MK + the legacy (origin-less) one — never Agent B's.
+  assert.deepEqual(await seenBy('agent-a'), ['A insight', 'legacy insight']);
+  assert.deepEqual(await seenBy('agent-b'), ['B insight', 'legacy insight']);
+});
+
+test('team/public visibility bypasses origin_agent (sharing preserved)', async () => {
+  const g = new InMemoryKnowledgeGraph();
+  await mk(g, 'A insight', 'agent-a');
+  await mk(g, 'B insight', 'agent-b');
+
+  // With teamVisibility on, default-`team` MK is shared across Agents.
+  const hits = await g.searchMemorableKnowledgeByEmbedding({
+    queryEmbedding: [1, 0, 0],
+    viewerOmadiaUserId: USER,
+    viewerAgentSlug: 'agent-a',
+    teamVisibility: true,
+  });
+  assert.deepEqual(
+    hits.map((h) => String(h.mk.props['summary'])).sort(),
+    ['A insight', 'B insight'],
+  );
+});
+
+test('no viewerAgentSlug → legacy owner-only behaviour (no agent constraint)', async () => {
+  const g = new InMemoryKnowledgeGraph();
+  await mk(g, 'A insight', 'agent-a');
+  await mk(g, 'B insight', 'agent-b');
+
+  const hits = await g.searchMemorableKnowledgeByEmbedding({
+    queryEmbedding: [1, 0, 0],
+    viewerOmadiaUserId: USER,
+    teamVisibility: false,
+  });
+  assert.deepEqual(
+    hits.map((h) => String(h.mk.props['summary'])).sort(),
+    ['A insight', 'B insight'],
+  );
+});

--- a/middleware/test/orchestratorMemoryNamespacer.test.ts
+++ b/middleware/test/orchestratorMemoryNamespacer.test.ts
@@ -1,0 +1,74 @@
+/**
+ * `OrchestratorMemoryNamespacer` — the model-facing `memory` tool sees a
+ * private `/memories` root physically backed by
+ * `/memories/orchestrators/<slug>/`, while shared namespaces (core, sessions,
+ * chat-sessions, brand `_*`) pass through untouched. `list` round-trips paths
+ * back into the model's namespace.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { FilesystemMemoryStore } from '@omadia/memory';
+
+import { OrchestratorMemoryNamespacer } from '../packages/harness-orchestrator/src/orchestratorMemoryNamespacer.js';
+
+async function ns(slug: string): Promise<{
+  store: FilesystemMemoryStore;
+  nsr: OrchestratorMemoryNamespacer;
+}> {
+  const store = new FilesystemMemoryStore(
+    await mkdtemp(join(tmpdir(), 'omadia-nsr-')),
+  );
+  return { store, nsr: new OrchestratorMemoryNamespacer(slug, store) };
+}
+
+test('model /memories/<x> notes are physically privatized per orchestrator', async () => {
+  const { store, nsr } = await ns('public');
+  await nsr.createFile('/memories/notes.md', 'hi');
+  assert.equal(
+    await store.readFile('/memories/orchestrators/public/notes.md'),
+    'hi',
+  );
+  // The model still addresses it at the un-namespaced path.
+  assert.equal(await nsr.readFile('/memories/notes.md'), 'hi');
+  assert.equal(await nsr.fileExists('/memories/notes.md'), true);
+});
+
+test('shared namespaces (core, sessions, chat-sessions, _brand) pass through', async () => {
+  const { store, nsr } = await ns('public');
+  await nsr.writeFile('/memories/core/rules.md', 'shared');
+  await nsr.writeFile('/memories/_brand/logo.md', 'brand');
+  // Physically NOT under the private tree.
+  assert.equal(await store.readFile('/memories/core/rules.md'), 'shared');
+  assert.equal(await store.readFile('/memories/_brand/logo.md'), 'brand');
+});
+
+test('list round-trips entries back into the model namespace', async () => {
+  const { nsr } = await ns('public');
+  await nsr.createFile('/memories/a.md', '1');
+  await nsr.createFile('/memories/sub/b.md', '2');
+  const entries = await nsr.list('/memories');
+  const paths = entries.map((e) => e.virtualPath).sort();
+  // The model only ever sees the `/memories` namespace — never the physical
+  // `orchestrators/<slug>` prefix — and its files round-trip back out.
+  assert.ok(paths.every((p) => p === '/memories' || p.startsWith('/memories/')));
+  assert.ok(!paths.some((p) => p.includes('/orchestrators/')));
+  assert.ok(paths.includes('/memories/a.md'));
+  assert.ok(paths.includes('/memories/sub'));
+});
+
+test('two orchestrators do not collide at the same model path', async () => {
+  const store = new FilesystemMemoryStore(
+    await mkdtemp(join(tmpdir(), 'omadia-nsr-')),
+  );
+  const a = new OrchestratorMemoryNamespacer('a', store);
+  const b = new OrchestratorMemoryNamespacer('b', store);
+  await a.createFile('/memories/shared-name.md', 'from-a');
+  await b.createFile('/memories/shared-name.md', 'from-b');
+  assert.equal(await a.readFile('/memories/shared-name.md'), 'from-a');
+  assert.equal(await b.readFile('/memories/shared-name.md'), 'from-b');
+});

--- a/middleware/test/sessionLoggerGraphScope.test.ts
+++ b/middleware/test/sessionLoggerGraphScope.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Per-orchestrator KG isolation at the write side (`SessionLogger`).
+ *
+ * An agent-bound logger ingests Turns under the agent-qualified graph scope
+ * `<agentSlug>::<conversation>` (so recall can constrain to the Agent), while
+ * the markdown transcript path stays on the raw conversation id (shared
+ * human/recovery artifact). `graphScopeFor` is the shared write/read formula.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { FilesystemMemoryStore } from '@omadia/memory';
+import { InMemoryKnowledgeGraph } from '@omadia/knowledge-graph-inmemory';
+// Import from source: `graphScopeFor` was added after the last dist build,
+// so the built `@omadia/orchestrator` barrel doesn't re-export it yet.
+import {
+  SessionLogger,
+  graphScopeFor,
+} from '../packages/harness-orchestrator/src/sessionLogger.js';
+
+test('graphScopeFor qualifies with the agent slug; sanitizes the base; undefined = legacy', () => {
+  assert.equal(graphScopeFor('agent-a', 'conv'), 'agent-a::conv');
+  // Base is sanitized (lowercased, punctuation → '-').
+  assert.equal(graphScopeFor('agent-a', 'Conv X'), 'agent-a::conv-x');
+  // No slug → unqualified (single-agent / legacy), byte-identical to before.
+  assert.equal(graphScopeFor(undefined, 'conv'), 'conv');
+});
+
+test('an agent-bound SessionLogger ingests Turns under the qualified scope', async () => {
+  const store = new FilesystemMemoryStore(
+    mkdtempSync(join(tmpdir(), 'sl-scope-')),
+  );
+  await store.init();
+  const graph = new InMemoryKnowledgeGraph();
+  const logger = new SessionLogger(store, graph, undefined, 'agent-a');
+
+  const { turnExternalId } = await logger.log({
+    scope: 'conv1',
+    userMessage: 'hi',
+    assistantAnswer: 'yo',
+    entityRefs: [],
+  });
+
+  // Graph: Turn lives under the qualified scope; the returned id agrees.
+  assert.ok(await graph.getSession('agent-a::conv1'));
+  assert.equal(await graph.getSession('conv1'), null);
+  assert.ok(turnExternalId.startsWith('turn:agent-a::conv1:'));
+
+  // Markdown transcript stays on the raw (sanitized) conversation id.
+  const files = await store.list('/memories/sessions/conv1');
+  assert.ok(files.some((e) => !e.isDirectory));
+});
+
+test('a different Agent logging the same conversation id does not collide in the graph', async () => {
+  const store = new FilesystemMemoryStore(
+    mkdtempSync(join(tmpdir(), 'sl-scope-')),
+  );
+  await store.init();
+  const graph = new InMemoryKnowledgeGraph();
+
+  await new SessionLogger(store, graph, undefined, 'agent-a').log({
+    scope: 'shared', userMessage: 'a', assistantAnswer: 'A', entityRefs: [],
+  });
+  await new SessionLogger(store, graph, undefined, 'agent-b').log({
+    scope: 'shared', userMessage: 'b', assistantAnswer: 'B', entityRefs: [],
+  });
+
+  const a = await graph.getSession('agent-a::shared');
+  const b = await graph.getSession('agent-b::shared');
+  assert.equal(a?.turns.length, 1);
+  assert.equal(b?.turns.length, 1);
+  assert.equal(a?.turns[0]?.turn.props['userMessage'], 'a');
+  assert.equal(b?.turns[0]?.turn.props['userMessage'], 'b');
+});


### PR DESCRIPTION
## Context

With the multi-orchestrator registry, one deployment runs several Agents (e.g. "Public", "marketing", domain agents). Domain tools are scoped per Agent (#197), but **knowledge was not**: the filesystem memory store and the Knowledge Graph were effectively shared, so Orchestrator A could read/recall Orchestrator B's data. This PR closes that — strictly, for **both** surfaces.

## Memory (filesystem) — strict per orchestrator

- `ScopedMemoryStore` gains an `orchestrator:<slug>:*` pattern; `computeMemoryScope` now returns `['core', 'orchestrator:<slug>:*']` (the old plugin-union model is gone — two Agents that enable the same plugin no longer share its memory).
- New `OrchestratorMemoryNamespacer`: the model-facing `memory` tool sees a private `/memories` root physically backed by `/memories/orchestrators/<slug>/`; shared namespaces (`core`, `sessions`, `chat-sessions`, brand `_*`) pass through. `list` round-trips paths back into the model namespace.
- `buildOrchestratorForAgent` wraps the shared store (`Namespacer → ScopedMemoryStore → FilesystemStore`); the orchestrator dispatches `memory` through the scoped handler **before** the global one. `ChatSessionStore`/`SessionLogger` use the scoped store directly (shared `core` paths).
- `MemoryAccessor` (plugins/sub-agents) resolves the active Agent slug from the turn context **at call time** → `/memories/orchestrators/<slug>/plugins/<pluginId>/`, with lazy legacy read-through (`/memories/agents/<pluginId>/`) for the default Agent only.

## Knowledge Graph — agent-qualified scope (no DB migration)

- New `qualifyScope` / `agentScopePrefix` helpers; `SessionLogger` ingests Turns under `<agentSlug>::<conversation>` (markdown transcript stays on the raw scope — shared, human/recovery artifact).
- Agent-prefix `WHERE` filter + **zero-migration dual-clause** (`scope LIKE '<slug>::%' OR ('<slug>::'='default::' AND scope NOT LIKE '%::%')`) on `searchTurns`, `searchTurnsByEmbedding`, `findEntityCapturedTurns` (entity **nodes** stay global; entity-anchored **recall** is agent-isolated → closes the cross-agent entity leak) and `listRecentPlans` — mirrored in **both** the Neon and in-memory backends.
- `MemorableKnowledge` gains an `origin_agent`; owner-gated recall is constrained to the producing Agent, while `team`/`public`-promoted knowledge stays shareable (existing ACL model preserved).
- The hardcoded `agentId: 'orchestrator-default'` is replaced by the real per-Agent identity. Retriever isolation is **opt-in**: only the orchestrator passes the prefix, so direct-retriever callers / sub-agents keep their cross-scope behaviour.
- `plan-runner` qualifies `Plan.scope` via a new `agentSlug` on the turn-hook context (populated by the orchestrator and `VerifierService`), so plan recall is per-Agent too.

## Validation

- `tsc` (all packages), `lint`, and the full test suite — **2843 tests pass, 0 fail**.
- New isolation suites: memory accessor / namespacer / scoping, KG agent-scope (turns, entity recall, plans), MemorableKnowledge origin, SessionLogger scope.

## Known limitations (fail-closed, documented)

- **Legacy default-Agent model-`memory` notes** previously at `/memories/<x>` are not auto-migrated into the private tree (plugin memory has read-through; the model tool does not).
- **Manual MK save** does not yet stamp `origin_agent` (user-ACL as before); only auto-promote does.
- KG legacy (pre-isolation) rows are reachable via the `default::` dual-clause; no backfill is performed.

The isolation guarantee (no cross-agent leak) holds in all cases; the limitations are recall-completeness trade-offs, not leaks.
