### PR TITLE
fix(web-ui): make plugin install drawer scrollable for long config forms

### DIFF
--- a/web-ui/app/_components/store/InstallButton.tsx
+++ b/web-ui/app/_components/store/InstallButton.tsx
@@ -603,7 +603,7 @@ function InstallDrawer({
 
       <aside
         className={cn(
-          'relative z-10 flex w-full max-w-xl flex-col',
+          'relative z-10 flex h-full max-h-screen w-full max-w-xl flex-col',
           'border-l border-[color:var(--rule-strong)] bg-[color:var(--paper)]',
           'shadow-[-20px_0_60px_-20px_rgba(0,0,0,0.3)]',
         )}
@@ -640,12 +640,12 @@ function InstallDrawer({
             <span className="text-sm">Job wird erstellt …</span>
           </div>
         ) : phase.kind === 'error' && !jobFromPhase ? (
-          <div className="flex-1 p-10">
+          <div className="min-h-0 flex-1 overflow-y-auto p-10">
             <InstallErrorBlock message={phase.message} />
           </div>
         ) : (
           <form
-            className="flex flex-1 flex-col"
+            className="flex min-h-0 flex-1 flex-col"
             onSubmit={(e) => {
               e.preventDefault();
               if (submitting) return;
@@ -654,7 +654,7 @@ function InstallDrawer({
               void onSubmit(values);
             }}
           >
-            <div className="flex-1 overflow-y-auto px-8 py-6">
+            <div className="min-h-0 flex-1 overflow-y-auto px-8 py-6">
               {setupGuide ? (
                 <div className="mb-6 border-b border-[color:var(--rule)] pb-6">
                   <div className="mb-3 text-[11px] uppercase tracking-[0.22em] text-[color:var(--faint-ink)]">


### PR DESCRIPTION
## Problem

When installing a plugin with many configuration fields (e.g. **Connect Microsoft Teams Channel**), the right-side install drawer could not be scrolled. The form overflowed the viewport, pushing the **"Installation bestätigen"** submit button below the fold with no way to reach it.

## Root cause

Classic flexbox overflow trap in `InstallDrawer` (`web-ui/app/_components/store/InstallButton.tsx`):

- The `<aside>` panel had **no height constraint**.
- The inner scroll container (`flex-1 overflow-y-auto`) and its `<form>` parent defaulted to `min-height: auto`, so they refused to shrink below their content's intrinsic height — `overflow-y-auto` never engaged.

Result: content grew the panel past the viewport instead of scrolling internally.

## Fix

- `<aside>`: add `h-full max-h-screen` -> panel pinned to viewport height.
- `<form>` + scroll container: add `min-h-0` -> flex children can shrink, so `overflow-y-auto` engages. Fields scroll; the footer (submit button) stays pinned and reachable.
- Same `min-h-0 overflow-y-auto` treatment for the long-error branch.

4-line diff. No behavioural change beyond scrolling.

## Verification

- `eslint --fix` -> 0 errors (one pre-existing unrelated unused-import warning)
- `tsc --noEmit` -> exit 0

Generated with Claude Code