### PR TITLE
fix(privacy-guard): expand "summary + detail" tool results into per-record rows

### DIFF
--- a/middleware/packages/harness-plugin-privacy-guard/src/v4/datasetStore.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/v4/datasetStore.ts
@@ -63,6 +63,64 @@ function rowHasNested(row: Record<string, unknown>): boolean {
   return Object.values(row).some((v) => Array.isArray(v) || isPlainObject(v));
 }
 
+/** A non-empty array whose every element is a plain object — i.e. detail rows
+ *  hiding inside a wrapper object's field. */
+function isRecordArray(v: unknown): v is Record<string, unknown>[] {
+  return Array.isArray(v) && v.length > 0 && v.every(isPlainObject);
+}
+
+/**
+ * Is `v` a scalar safe to broadcast as a summary column onto every promoted
+ * detail row? Primitives, plus the Odoo many2one `[id, "label"]` tuple, which
+ * is a scalar-equivalent reference (the materializer already flattens it to
+ * the label). Genuine nested values are NOT broadcast — they would only
+ * reintroduce the per-cell JSON dump the expansion exists to remove.
+ */
+function isBroadcastable(v: unknown): boolean {
+  if (v === null) return true;
+  const t = typeof v;
+  if (t === 'string' || t === 'number' || t === 'boolean') return true;
+  return (
+    Array.isArray(v) &&
+    v.length === 2 &&
+    typeof v[0] === 'number' &&
+    typeof v[1] === 'string'
+  );
+}
+
+/**
+ * Recognize the "summary + detail" object shape and promote its detail rows.
+ *
+ * Tools often return a single object that wraps the real per-record table in
+ * one field alongside scalar summary fields — e.g. a timesheet result
+ * `{ jahr, kw, …, abweichungen_pro_ma: [ {employee…}, … ] }`. Left as one
+ * `nested` row, the detail array stays one opaque field: the materializer can
+ * only render its real value (for the authorised user) by JSON-stringifying
+ * the whole array into a single cell — the unreadable blob from the timesheet
+ * view. (The array never reaches the LLM — it is masked in the digest — so
+ * this is a rendering defect, not a data leak.) Here we promote the detail
+ * array to BE the dataset rows so every record is classified and rendered
+ * individually, broadcasting the scalar summary fields onto each row (a
+ * record's own field always wins a key collision).
+ *
+ * Conservative by design: only fires when the object has EXACTLY ONE
+ * record-array field. Zero record-arrays is an ordinary object; more than one
+ * is ambiguous (which is the detail table?) — both are left untouched.
+ */
+function expandSummaryDetail(
+  obj: Record<string, unknown>,
+): Record<string, unknown>[] | undefined {
+  const detailKeys = Object.keys(obj).filter((k) => isRecordArray(obj[k]));
+  if (detailKeys.length !== 1) return undefined;
+  const detailKey = detailKeys[0] as string;
+  const detail = obj[detailKey] as Record<string, unknown>[];
+  const summary: Record<string, unknown> = {};
+  for (const [k, val] of Object.entries(obj)) {
+    if (k !== detailKey && isBroadcastable(val)) summary[k] = val;
+  }
+  return detail.map((rec) => ({ ...summary, ...rec }));
+}
+
 /** Normalize an arbitrary JS value into a uniform row array + a shape tag.
  *  Non-tabular values are wrapped so the store and the Verb API always
  *  operate on `Record<string, unknown>[]`. */
@@ -80,6 +138,14 @@ function normalizeValue(v: unknown): {
     return { rows: v.map((e) => ({ value: e })), shape: 'rows' };
   }
   if (isPlainObject(v)) {
+    // "Summary + detail" wrapper → promote the detail rows (timesheet etc.).
+    const expanded = expandSummaryDetail(v);
+    if (expanded !== undefined) {
+      return {
+        rows: expanded,
+        shape: expanded.some(rowHasNested) ? 'nested' : 'rows',
+      };
+    }
     return { rows: [v], shape: rowHasNested(v) ? 'nested' : 'object' };
   }
   return { rows: [{ value: v }], shape: 'scalar' };

--- a/middleware/packages/harness-plugin-privacy-guard/src/v4/materializer.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/v4/materializer.ts
@@ -70,7 +70,28 @@ function cell(value: unknown): string {
   ) {
     return value[1];
   }
-  return JSON.stringify(value);
+  // A remaining array of scalars is safe to join (e.g. tags/codes).
+  if (
+    Array.isArray(value) &&
+    value.every(
+      (e) =>
+        e === null ||
+        typeof e === 'string' ||
+        typeof e === 'number' ||
+        typeof e === 'boolean',
+    )
+  ) {
+    return value.map((e) => cell(e)).join(', ');
+  }
+  // Any other nested structure (array of records, plain object) is NEVER
+  // dumped as raw JSON: that produced the unreadable blob in the timesheet
+  // view (a rendering defect — the data is masked from the LLM and only
+  // materialized here for the authorised user). The Dataset Store promotes the
+  // common "summary + detail" shape to real rows; anything that still reaches
+  // here (e.g. two competing record-arrays) gets a compact, structure-only
+  // marker instead.
+  if (Array.isArray(value)) return `[${String(value.length)} records]`;
+  return '[nested]';
 }
 
 /** Escape a value for a Markdown table cell. */

--- a/middleware/test/privacyV4DatasetStore.test.ts
+++ b/middleware/test/privacyV4DatasetStore.test.ts
@@ -79,9 +79,58 @@ describe('parseToolResult', () => {
     assert.equal(r.rows.length, 1);
   });
 
-  it('treats an object with nested values as shape "nested"', () => {
-    const r = parseToolResult({ employee: 'X', history: [{ y: 1 }] }, 100_000);
+  it('treats an object with a nested object value as shape "nested"', () => {
+    // A nested *object* (not a record-array) is not a summary+detail wrapper,
+    // so it stays a single nested row.
+    const r = parseToolResult({ employee: 'X', meta: { y: 1 } }, 100_000);
     assert.equal(r.shape, 'nested');
+    assert.equal(r.rows.length, 1);
+  });
+
+  it('promotes a "summary + detail" wrapper to the detail rows', () => {
+    // A single object wrapping exactly one array-of-records is the common
+    // "summary + detail" shape (e.g. a timesheet result). The detail array
+    // becomes the dataset rows so each record is classified + rendered
+    // individually instead of dumped as one masked JSON blob.
+    const r = parseToolResult(
+      {
+        jahr: 2026,
+        kw: 22,
+        abweichungen_pro_ma: [
+          { employee: 'Alexandra Hochhaus', delta_hours: -40 },
+          { employee: 'Christian Köhler', delta_hours: -39.87 },
+        ],
+      },
+      100_000,
+    );
+    assert.equal(r.shape, 'rows');
+    assert.equal(r.rows.length, 2);
+    // Detail fields are present...
+    assert.equal(r.rows[0]?.employee, 'Alexandra Hochhaus');
+    assert.equal(r.rows[0]?.delta_hours, -40);
+    // ...and the scalar summary fields are broadcast onto every row.
+    assert.equal(r.rows[0]?.jahr, 2026);
+    assert.equal(r.rows[1]?.kw, 22);
+    // The detail array key itself is never broadcast as a column.
+    assert.equal('abweichungen_pro_ma' in (r.rows[0] ?? {}), false);
+  });
+
+  it('leaves an object with two record-arrays untouched (ambiguous)', () => {
+    // More than one array-of-records is ambiguous — which is the detail
+    // table? — so the object is kept as a single nested row.
+    const r = parseToolResult({ a: [{ x: 1 }], b: [{ y: 2 }] }, 100_000);
+    assert.equal(r.shape, 'nested');
+    assert.equal(r.rows.length, 1);
+  });
+
+  it('a record in the detail wins a key collision over the summary', () => {
+    const r = parseToolResult(
+      { name: 'Report', rows: [{ name: 'Anna', n: 1 }] },
+      100_000,
+    );
+    assert.equal(r.rows.length, 1);
+    // The detail record's own `name` is kept, not the summary's "Report".
+    assert.equal(r.rows[0]?.name, 'Anna');
   });
 
   it('interns an empty array as zero rows', () => {

--- a/middleware/test/privacyV4Materializer.test.ts
+++ b/middleware/test/privacyV4Materializer.test.ts
@@ -192,6 +192,66 @@ describe('Materializer — display polish', () => {
     assert.ok(maskedValues.includes('Sophie Neumann'));
   });
 
+  it('never dumps a nested record array as raw JSON into a cell', () => {
+    const { store } = harness();
+    // Two record-arrays => the store does NOT expand (ambiguous), so a nested
+    // array can still reach the cell renderer. It must render a compact marker
+    // rather than a raw JSON blob (the unreadable timesheet rendering).
+    const { datasetId } = store.internToolResult('x', [
+      { id: 1, a: [{ inner: 'x1' }], b: [{ inner: 'x2' }] },
+    ]);
+    const { text } = materialize(store, {
+      datasetId,
+      columns: cols('id', 'a'),
+      format: 'table',
+    });
+    assert.ok(!text.includes('"inner"'), 'no raw JSON keys are emitted');
+    assert.ok(!text.includes('x1'), 'nested record values are not dumped raw');
+    assert.ok(text.includes('[1 records]'), 'shows a compact structure-only marker');
+  });
+
+  it('joins a scalar array into a readable cell', () => {
+    const { store } = harness();
+    const { datasetId } = store.internToolResult('x', [
+      { id: 1, tags: ['urgent', 'hr', 'q2'] },
+    ]);
+    const { text } = materialize(store, {
+      datasetId,
+      columns: cols('tags'),
+      format: 'table',
+    });
+    assert.ok(text.includes('urgent, hr, q2'));
+  });
+
+  it('renders a "summary + detail" tool result as a per-record table', () => {
+    const { store } = harness();
+    // The real timesheet shape: one summary object wrapping the per-employee
+    // detail array. The store promotes it to one row per employee.
+    const { datasetId, digest } = store.internToolResult(
+      'query_odoo_timesheet_analyzer',
+      {
+        jahr: 2026,
+        kw: 22,
+        abweichungen_pro_ma: [
+          { employee_name: 'Alexandra Hochhaus', delta_hours: -40 },
+          { employee_name: 'Christian Köhler', delta_hours: -39.87 },
+        ],
+      },
+    );
+    // The names are masked from the LLM's digest...
+    assert.ok(!JSON.stringify(digest).includes('Hochhaus'));
+    // ...but rendered as real values for the authorised user, as a real table.
+    const { text, rowCount } = materialize(store, {
+      datasetId,
+      columns: cols('employee_name', 'delta_hours', 'kw'),
+      format: 'table',
+    });
+    assert.equal(rowCount, 2);
+    assert.ok(text.includes('Alexandra Hochhaus'));
+    assert.ok(text.includes('Christian Köhler'));
+    assert.ok(!text.includes('"employee_name"'), 'no raw JSON blob');
+  });
+
   it('uses each column label as the table header', () => {
     const { store } = harness();
     const { datasetId } = store.internToolResult('hr.leave', HR_LEAVE);


### PR DESCRIPTION
Fixes the `v4_render_answer` timesheet rendering: the "Abweichungen pro MA" column showed a raw JSON array of all employee objects in a single cell instead of a clean per-employee table.

## What this is (and isn't)
This is a **rendering defect, not a data leak.** The nested array `abweichungen_pro_ma` was correctly classified `sensitive-masked`, so the LLM only ever received a placeholder + `distinctCount` in the digest — **no row data, no names**. The LLM merely referenced the column by name in `v4_render_answer`; the **server** then materialized the real value for the **authorised** user (which is intended — the internal user is entitled to see it). The bug is purely that a nested array was JSON-stringified into one cell instead of being rendered as rows.

## Root cause
`query_odoo_timesheet_analyzer` returns a single **summary object** wrapping the per-employee detail as a nested array. Privacy Shield v4 interned it as **one** `nested` row, so the whole array stayed a single opaque field. With no unnest verb available, the materializer fell through to `JSON.stringify(value)` when filling in that column's real value — the unreadable blob.

## Fix
- **Dataset Store** (`datasetStore.ts`): detect the "summary + detail" shape — a single object with **exactly one** array-of-records field — and promote that array to the dataset rows, broadcasting the scalar summary fields onto each row (a record's own field wins on key collisions). Every record is now classified (identity fields masked from the LLM at field granularity) and rendered as its own table row. Conservative: zero record-arrays = ordinary object; two or more = ambiguous → both left untouched.
- **Materializer** (`materializer.ts`): defense-in-depth — `cell()` never `JSON.stringify`s a nested value into a cell again. Scalar arrays join readably (`a, b, c`); any remaining nested structure gets a compact `[n records]` / `[nested]` marker.

## Tests
- 7 new tests (store expansion + ambiguity guard + collision; materializer no-raw-JSON + summary→table render).
- **131/131** privacy-v4 tests pass; `tsc` + `eslint` clean.

## Deploy
Already deployed to `odoo-bot-middleware` as **v265** for live review (uploaded plugins on the volume untouched).