### PR TITLE
fix(builder): ctx.memory in preview runtime, accessor permission lint, and setup_fields rename

### DIFF
--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -215,7 +215,12 @@ export interface Plugin {
   compat_core: string;
   signed: boolean;
   signed_by: string | null;
-  required_secrets: PluginSetupField[];
+  /** All declared setup fields (secret AND non-secret config) from the
+   *  manifest's `setup.fields`. Named `setup_fields` because the list is not
+   *  secrets-only — it carries `string`/`url`/`enum`/`boolean`/`integer`
+   *  config alongside `secret`/`oauth` credentials. Consumers split the two
+   *  by each field's `type`. */
+  setup_fields: PluginSetupField[];
   permissions_summary: PluginPermissionsSummary;
   integrations_summary: string[];
   install_state: PluginInstallState;

--- a/middleware/src/platform/pluginContext.ts
+++ b/middleware/src/platform/pluginContext.ts
@@ -770,7 +770,7 @@ function extractAuditConfig(
 ): { auditMode?: AuditMode; extraHosts: string[] } {
   const config = registry.get(agentId)?.config ?? {};
   const extraHosts: string[] = [];
-  const fields = catalog.get(agentId)?.plugin.required_secrets ?? [];
+  const fields = catalog.get(agentId)?.plugin.setup_fields ?? [];
   for (const field of fields) {
     if (field.type !== 'host_list') continue;
     const value = config[field.key];

--- a/middleware/src/plugins/bootstrap.ts
+++ b/middleware/src/plugins/bootstrap.ts
@@ -952,7 +952,7 @@ async function bootstrapBuiltInPackages(deps: BootstrapDeps): Promise<void> {
     // If the package declares required secrets, we cannot auto-install — the
     // user must run the setup flow first. Leave it uninstalled; the UI shows
     // it as "available" and the install endpoint handles it normally.
-    const hasRequiredSecret = catalogEntry.plugin.required_secrets.some(
+    const hasRequiredSecret = catalogEntry.plugin.setup_fields.some(
       (f) => f.type === 'secret' || f.type === 'oauth',
     );
     if (hasRequiredSecret) {
@@ -971,7 +971,7 @@ async function bootstrapBuiltInPackages(deps: BootstrapDeps): Promise<void> {
     // them here. Operators can override any of these later via the
     // post-install editor.
     const defaultConfig: Record<string, unknown> = {};
-    for (const field of catalogEntry.plugin.required_secrets) {
+    for (const field of catalogEntry.plugin.setup_fields) {
       if (field.type === 'secret' || field.type === 'oauth') continue;
       if (field.default !== undefined) {
         defaultConfig[field.key] = field.default;

--- a/middleware/src/plugins/builder/codegen.ts
+++ b/middleware/src/plugins/builder/codegen.ts
@@ -413,7 +413,7 @@ function reproduceManifestCapabilities(
     setupNode.set('fields', doc.createNode(fieldsForManifest));
   } else {
     // No setup block in template — create one so the install path can
-    // still surface required_secrets.
+    // still surface the plugin's setup_fields.
     doc.set(
       'setup',
       doc.createNode({

--- a/middleware/src/plugins/builder/previewMemoryStore.ts
+++ b/middleware/src/plugins/builder/previewMemoryStore.ts
@@ -1,0 +1,222 @@
+/**
+ * Ephemeral, in-memory MemoryAccessor for the Builder preview runtime.
+ *
+ * Why this exists
+ * ---------------
+ * In a *real* install the kernel hands plugins a `ctx.memory` accessor backed
+ * by the `@omadia/memory` provider plugin's MemoryStore (see
+ * `platform/memoryAccessor.ts` + `platform/pluginContext.ts`). The preview
+ * runtime, by design, wires NONE of the real platform services — it stands in
+ * its own in-memory replacements for secrets and config and a no-op stub for
+ * the ServiceRegistry. Memory was simply missing from that surface, so any
+ * agent that calls `ctx.memory.{readFile,writeFile,exists,list,…}` in its
+ * `activate-body` hit its own `if (!ctx.memory) throw …` null-guard the moment
+ * preview-chat tried to activate it — surfacing as
+ * `builder.preview_chat_failed: <id>: ctx.memory is required but unavailable`.
+ * The manifest was correct the whole time; the preview context just had no
+ * memory accessor to give.
+ *
+ * This module closes that gap with a Map-backed store that mirrors the
+ * behaviour of `FilesystemMemoryStore` + `createMemoryAccessor` (relative-path
+ * validation, structural scoping, 2-level `list` walk) WITHOUT importing the
+ * provider plugin or plugin-api — keeping `previewRuntime.ts` self-contained
+ * (same principle as the inline `PreviewUiRouteDescriptorInput` copy).
+ *
+ * Lifetime: one store per preview activation. Isolation between agents is
+ * implicit — each activation constructs a fresh accessor over a fresh Map, so
+ * there is nothing to leak across previews. The Map is dropped (and GC'd) when
+ * the preview handle and its context go away; no explicit teardown needed.
+ */
+
+/** Mirror of `MemoryAccessor` from `@omadia/plugin-api` (and the boilerplate's
+ *  `types.ts`). Inline-copied to keep the preview runtime free of a plugin-api
+ *  dependency. */
+export interface PreviewMemoryAccessor {
+  readFile(relPath: string): Promise<string>;
+  writeFile(relPath: string, content: string): Promise<void>;
+  /** Create, fail-if-exists. */
+  createFile(relPath: string, content: string): Promise<void>;
+  delete(relPath: string): Promise<void>;
+  list(relPath: string): Promise<readonly PreviewMemoryEntryInfo[]>;
+  exists(relPath: string): Promise<boolean>;
+}
+
+export interface PreviewMemoryEntryInfo {
+  readonly relPath: string;
+  readonly isDirectory: boolean;
+  readonly sizeBytes: number;
+}
+
+/** `list` walks at most this many levels below the requested directory —
+ *  identical to `FilesystemMemoryStore`'s depth budget so preview output
+ *  matches install. */
+const LIST_MAX_DEPTH = 2;
+
+/**
+ * Normalize + validate a plugin-supplied relative memory path into a canonical
+ * key (no leading/trailing slash, `.`/`./`/`''` → root `''`). Mirrors the
+ * validation in `platform/memoryAccessor.ts:resolveScoped` so a path the real
+ * accessor would reject is rejected here too (fail-fast, identical diagnostics
+ * shape) rather than silently "working" only in preview.
+ */
+function normalizeRel(relPath: string): string {
+  if (typeof relPath !== 'string') {
+    throw new Error('memory path must be a string');
+  }
+  if (relPath.startsWith('/')) {
+    throw new Error(`memory path must be relative (got absolute): ${relPath}`);
+  }
+  if (relPath.includes('..')) {
+    throw new Error(`memory path must not contain '..': ${relPath}`);
+  }
+  if (relPath.includes('\u0000')) {
+    throw new Error('memory path must not contain null bytes');
+  }
+  // Strip a leading './' and collapse empty / '.' to the scope root.
+  const trimmed = relPath.replace(/^\.\/?|^$/, '').replace(/\/+$/, '');
+  return trimmed;
+}
+
+/**
+ * Build an ephemeral in-memory MemoryAccessor for one preview activation.
+ */
+export function createPreviewMemoryAccessor(): PreviewMemoryAccessor {
+  // Map<normalized-relative-file-path, content>. Directories are implicit:
+  // a directory "exists" iff some file key sits under it.
+  const files = new Map<string, string>();
+
+  const isDir = (key: string): boolean => {
+    if (key === '') return files.size > 0; // root
+    const prefix = key + '/';
+    for (const k of files.keys()) {
+      if (k.startsWith(prefix)) return true;
+    }
+    return false;
+  };
+
+  return {
+    async readFile(relPath: string): Promise<string> {
+      const key = normalizeRel(relPath);
+      const content = files.get(key);
+      if (content === undefined) {
+        throw new Error(`Path not found: ${relPath}`);
+      }
+      return content;
+    },
+
+    async writeFile(relPath: string, content: string): Promise<void> {
+      const key = normalizeRel(relPath);
+      if (key === '') {
+        throw new Error('memory path must point at a file, not the scope root');
+      }
+      // A key that is an implicit directory (some other file sits under it)
+      // must not become a file too — otherwise the same path is both a
+      // file key and a directory prefix, and `list()` would shadow the
+      // children. FilesystemMemoryStore fails this write with EISDIR.
+      if (isDir(key)) {
+        throw new Error(`Path is a directory, not a file: ${relPath}`);
+      }
+      files.set(key, content);
+    },
+
+    async createFile(relPath: string, content: string): Promise<void> {
+      const key = normalizeRel(relPath);
+      if (key === '') {
+        throw new Error('memory path must point at a file, not the scope root');
+      }
+      // Reject both an existing file and an existing implicit directory at
+      // this path — mirrors FilesystemMemoryStore's fail-if-exists on a
+      // path already taken by a directory.
+      if (files.has(key) || isDir(key)) {
+        throw new Error(`Path already exists: ${relPath}`);
+      }
+      files.set(key, content);
+    },
+
+    async delete(relPath: string): Promise<void> {
+      const key = normalizeRel(relPath);
+      if (key === '') {
+        throw new Error('Refusing to delete the scope root.');
+      }
+      if (files.delete(key)) return; // single file
+      // Directory delete — drop every descendant file.
+      const prefix = key + '/';
+      let removed = false;
+      for (const k of [...files.keys()]) {
+        if (k.startsWith(prefix)) {
+          files.delete(k);
+          removed = true;
+        }
+      }
+      if (!removed) {
+        throw new Error(`Path not found: ${relPath}`);
+      }
+    },
+
+    async exists(relPath: string): Promise<boolean> {
+      const key = normalizeRel(relPath);
+      if (key === '') return files.size > 0;
+      return files.has(key) || isDir(key);
+    },
+
+    async list(relPath: string): Promise<readonly PreviewMemoryEntryInfo[]> {
+      // Mirror `createMemoryAccessor.list`: an unwritten scope lists as empty
+      // rather than throwing a confusing "not found" on the implicit root.
+      if (files.size === 0) return [];
+
+      const base = normalizeRel(relPath);
+
+      // A file path lists as a single file entry (matches FilesystemMemoryStore).
+      if (base !== '' && files.has(base)) {
+        return [
+          {
+            relPath: base,
+            isDirectory: false,
+            sizeBytes: Buffer.byteLength(files.get(base)!, 'utf8'),
+          },
+        ];
+      }
+
+      const dirExists = base === '' || isDir(base);
+      if (!dirExists) {
+        throw new Error(`Path not found: ${relPath}`);
+      }
+
+      const prefix = base === '' ? '' : base + '/';
+      // Deduplicate emitted entries by relPath; always include the listed dir.
+      const entries = new Map<string, PreviewMemoryEntryInfo>();
+      entries.set(base, { relPath: base, isDirectory: true, sizeBytes: 0 });
+
+      for (const [key, value] of files) {
+        if (prefix !== '' && !key.startsWith(prefix)) continue;
+        const relToBase = key.slice(prefix.length);
+        if (relToBase === '') continue;
+        const segs = relToBase.split('/');
+        // Intermediate directories at depth 1..min(depth-1, MAX) below base.
+        const dirDepth = Math.min(segs.length - 1, LIST_MAX_DEPTH);
+        for (let d = 1; d <= dirDepth; d++) {
+          const dirRel = prefix + segs.slice(0, d).join('/');
+          if (!entries.has(dirRel)) {
+            entries.set(dirRel, {
+              relPath: dirRel,
+              isDirectory: true,
+              sizeBytes: 0,
+            });
+          }
+        }
+        // The file itself only when within the depth budget.
+        if (segs.length <= LIST_MAX_DEPTH) {
+          entries.set(key, {
+            relPath: key,
+            isDirectory: false,
+            sizeBytes: Buffer.byteLength(value, 'utf8'),
+          });
+        }
+      }
+
+      return [...entries.values()].sort((a, b) =>
+        a.relPath < b.relPath ? -1 : a.relPath > b.relPath ? 1 : 0,
+      );
+    },
+  };
+}

--- a/middleware/src/plugins/builder/previewRuntime.ts
+++ b/middleware/src/plugins/builder/previewRuntime.ts
@@ -1,9 +1,14 @@
 import { promises as fs, type Dirent } from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import yaml from 'yaml';
 import type { z } from 'zod';
 
 import { extractZipToDir, type ExtractLimits } from '../zipExtractor.js';
+import {
+  createPreviewMemoryAccessor,
+  type PreviewMemoryAccessor,
+} from './previewMemoryStore.js';
 
 /**
  * PreviewRuntime — activates a builder-built ZIP into an ephemeral, in-memory
@@ -115,6 +120,16 @@ export interface PreviewPluginContext {
     provide<T>(name: string, impl: T): () => void;
     replace<T>(name: string, impl: T): () => void;
   };
+  /** Per-plugin memory store, present exactly when the manifest declares
+   *  `permissions.memory.{reads,writes}` with at least one entry — the same
+   *  gate the kernel applies post-install (`pluginContext.ts:memoryDeclared`).
+   *  Preview backs it with an ephemeral in-memory store (one per activation,
+   *  dropped on close), so agents that persist project state via `ctx.memory`
+   *  activate and run in preview instead of crashing on their own
+   *  `if (!ctx.memory) throw …` null-guard. Absent when the manifest omits the
+   *  block, so a permissions-stripped manifest fails preview the same way it
+   *  would fail a real install — no false "works in preview" signal. */
+  readonly memory?: PreviewMemoryAccessor;
   readonly smokeMode: boolean;
   log(...args: unknown[]): void;
 }
@@ -329,6 +344,13 @@ export class PreviewRuntime {
       }
     }
 
+    // Memory accessor is gated on the manifest declaring memory permissions —
+    // exactly like the kernel's `memoryDeclared` check post-install. Reading
+    // the manifest here (we already have packageRoot) keeps preview faithful:
+    // a correct manifest gets a working ephemeral store, a stripped one gets
+    // `ctx.memory === undefined` and fails the same way install would.
+    const provideMemory = await manifestDeclaresMemory(packageRoot);
+
     const routeCaptures: PreviewRouteCapture[] = [];
     const ctx = createStubContext({
       agentId,
@@ -337,6 +359,7 @@ export class PreviewRuntime {
       smokeMode: opts.smokeMode === true,
       routeCaptures,
       hostServices: this.hostServices,
+      provideMemory,
       logger: (...args) => this.log(`[${agentId}]`, ...args),
     });
 
@@ -375,6 +398,40 @@ export class PreviewRuntime {
   }
 }
 
+/**
+ * Reads the package's `manifest.yaml` and reports whether it declares memory
+ * permissions (`permissions.memory.reads` OR `.writes` with ≥1 entry). This is
+ * a 1:1 mirror of `pluginContext.ts:memoryDeclared`, the gate the kernel uses
+ * to decide whether to hand a plugin `ctx.memory` after install. A missing or
+ * unparsable manifest reports `false` (no memory) rather than throwing — the
+ * preview test harness writes packages without a manifest, and a real build
+ * always ships one.
+ */
+async function manifestDeclaresMemory(packageRoot: string): Promise<boolean> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(path.join(packageRoot, 'manifest.yaml'), 'utf-8');
+  } catch {
+    return false;
+  }
+  let parsed: unknown;
+  try {
+    parsed = yaml.parse(raw);
+  } catch {
+    return false;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return false;
+  const permissions = (parsed as Record<string, unknown>)['permissions'];
+  if (typeof permissions !== 'object' || permissions === null) return false;
+  const mem = (permissions as Record<string, unknown>)['memory'];
+  if (typeof mem !== 'object' || mem === null) return false;
+  const reads = (mem as Record<string, unknown>)['reads'];
+  const writes = (mem as Record<string, unknown>)['writes'];
+  const readsLen = Array.isArray(reads) ? reads.length : 0;
+  const writesLen = Array.isArray(writes) ? writes.length : 0;
+  return readsLen > 0 || writesLen > 0;
+}
+
 function createStubContext(opts: {
   agentId: string;
   configValues: Readonly<Record<string, unknown>>;
@@ -382,6 +439,7 @@ function createStubContext(opts: {
   smokeMode: boolean;
   routeCaptures: PreviewRouteCapture[];
   hostServices?: PreviewHostServices;
+  provideMemory: boolean;
   logger: (...args: unknown[]) => void;
 }): PreviewPluginContext {
   // Services the previewed agent provides itself stay isolated to this
@@ -391,6 +449,9 @@ function createStubContext(opts: {
   // integrations resolve.
   const localServices = new Map<string, unknown>();
   const host = opts.hostServices;
+  const memory: PreviewMemoryAccessor | undefined = opts.provideMemory
+    ? createPreviewMemoryAccessor()
+    : undefined;
   return {
     agentId: opts.agentId,
     secrets: {
@@ -473,6 +534,11 @@ function createStubContext(opts: {
         };
       },
     },
+    // Ephemeral per-activation memory accessor, gated on the manifest's
+    // memory permissions (see `manifestDeclaresMemory`). Spread so the field
+    // is simply absent — not `memory: undefined` — when the manifest omits
+    // the block, matching the kernel's optional `ctx.memory`.
+    ...(memory ? { memory } : {}),
     smokeMode: opts.smokeMode,
     log: opts.logger,
   };

--- a/middleware/src/plugins/builder/prompts/builder-system.md
+++ b/middleware/src/plugins/builder/prompts/builder-system.md
@@ -429,9 +429,17 @@ ui_routes Slots" — solange dort ✗ missing steht, wirft codegen einen
 ## Plattform-Accessoren auf `ctx`
 
 Über die Standard-Surface (`secrets`, `config`, `services`, `routes`, `uiRoutes`)
-hinaus exposed die Plattform zwei weitere Accessoren, die du im
+hinaus exposed die Plattform weitere Accessoren, die du im
 `activate-body` direkt nutzen kannst — KEIN `(ctx as any)`-Hack nötig,
-beide sind in der Boilerplate-`types.ts` ausgewiesen.
+alle sind in der Boilerplate-`types.ts` ausgewiesen.
+
+**Gating-Vertrag.** Außer `ctx.memory` (Plattform-Default, s.u.) und
+`ctx.jobs` (immer da) ist jeder Accessor **opt-in**: fehlt die zugehörige
+Deklaration in der Spec, ist der Accessor zur Laufzeit `undefined` und ein
+`ctx.X.foo()`-Call wirft. `lint_spec` warnt deshalb mit
+`accessor_permission_undeclared`, wenn ein Slot einen gegateten Accessor
+nutzt ohne die passende Permission — erst freischalten (`patch_spec` auf das
+jeweils unten genannte Spec-Feld), dann den Slot füllen.
 
 ### `ctx.memory` — Persistenter Plugin-Storage
 
@@ -455,9 +463,20 @@ if (ctx.memory) {
 
 **Wann nutzen:** wo immer in-process-Arrays vorhin reichten (Reports,
 History, Cache, Audit-Logs) — Persistenz übersteht Plugin-Restart und
-Re-Deploys. Boilerplate-Manifest deklariert `permissions.memory.reads:
+Re-Deploys.
+
+**KEINE Spec-Pflicht — Plattform-Default.** Anders als alle anderen
+gegateten Accessoren unten (`ctx.http`, `ctx.subAgent`, `ctx.llm`,
+`ctx.knowledgeGraph`), die du explizit über `spec.permissions.*` bzw.
+`spec.network.outbound` freischalten MUSST, ist `ctx.memory` IMMER da:
+das Boilerplate-`manifest.yaml` deklariert `permissions.memory.reads:
 ['session:*', 'agent:<id>:*']` + `writes: ['agent:<id>:*']` automatisch,
-also ist `ctx.memory` zur Laufzeit für jeden Builder-Plugin **da**.
+und der Spec-Schema-Block `spec.permissions` kennt gar kein `memory`-Feld.
+Versuch NICHT, es zu setzen — `patch_spec({ op: 'add', path:
+'/permissions/memory', ... })` schlägt mit Zod-Fail fehl. Einfach
+`ctx.memory` direkt nutzen; der Manifest-Block kommt von der Plattform.
+(`if (ctx.memory)`-Guard trotzdem defensiv setzen, falls ein Operator das
+Manifest nachträglich von Hand strippt.)
 
 **Wann NICHT nutzen:** für strukturierte Cross-Plugin-Daten →
 Knowledge-Graph (Phase 2, noch nicht exposed). Für rohe Cross-Plugin-

--- a/middleware/src/plugins/builder/tools/lintSpec.ts
+++ b/middleware/src/plugins/builder/tools/lintSpec.ts
@@ -98,6 +98,13 @@ export const lintSpecTool: BuilderTool<Input, Result> = {
     // 4. Slot quality
     issues.push(...lintSlots(draft.slots));
 
+    // 5. ctx.<accessor> ↔ permission consistency. Catches the
+    //    "slot uses a gated accessor but the spec never granted it" class of
+    //    bug at lint time instead of as a runtime `undefined` crash inside a
+    //    tool handler. Needs the parsed spec (permissions/network), so it
+    //    only runs on the success path.
+    issues.push(...lintAccessorPermissions(spec, draft.slots));
+
     return { ok: issues.every((i) => i.severity !== 'error'), issues };
   },
 };
@@ -123,6 +130,89 @@ function lintNameCollision(
     }
   }
   return [];
+}
+
+/**
+ * One gated `ctx.*` accessor and the spec declaration that turns it on.
+ *
+ * `ctx.memory` is deliberately absent: unlike the accessors below it is a
+ * PLATFORM DEFAULT, not spec-gated. The boilerplate `manifest.yaml` always
+ * ships `permissions.memory.{reads,writes}` with `agent:<id>:*`, the spec
+ * schema (`PermissionsSchema`) can't even express memory permissions, and
+ * codegen never strips the block — so `ctx.memory` is always available and a
+ * reference to it can never be a misconfiguration. (The historical
+ * "ctx.memory unavailable" crash was a *preview-runtime* gap, since fixed in
+ * previewRuntime.ts — never a missing manifest permission.) Flagging
+ * `ctx.memory` here would only produce false positives on every memory-using
+ * agent, so it is omitted by design.
+ */
+interface GatedAccessor {
+  /** Accessor property on `ctx`, e.g. 'subAgent'. */
+  readonly accessor: string;
+  /** Human-readable spec field the operator must set to grant it. */
+  readonly specField: string;
+  /** Returns true when the spec grants the accessor (non-empty declaration). */
+  readonly granted: (spec: AgentSpec) => boolean;
+}
+
+const GATED_ACCESSORS: readonly GatedAccessor[] = [
+  {
+    accessor: 'subAgent',
+    specField: 'permissions.subAgents.calls',
+    granted: (s) => (s.permissions?.subAgents?.calls?.length ?? 0) > 0,
+  },
+  {
+    accessor: 'llm',
+    specField: 'permissions.llm.models_allowed',
+    granted: (s) => (s.permissions?.llm?.models_allowed?.length ?? 0) > 0,
+  },
+  {
+    accessor: 'knowledgeGraph',
+    specField: 'permissions.graph.entity_systems',
+    granted: (s) => (s.permissions?.graph?.entity_systems?.length ?? 0) > 0,
+  },
+  {
+    accessor: 'http',
+    specField: 'network.outbound',
+    granted: (s) => (s.network?.outbound?.length ?? 0) > 0,
+  },
+];
+
+/**
+ * Warn when a slot actually *uses* a gated accessor (`ctx.<accessor>.foo`,
+ * `ctx.<accessor>!.foo`, or `ctx.<accessor>?.foo`) but the spec never granted
+ * the matching permission — at runtime that accessor is `undefined`, so the
+ * handler throws (or, with optional chaining, silently no-ops). A bare
+ * boolean guard like `if (ctx.subAgent)` is intentionally NOT matched: the
+ * trailing-dot requirement keeps the check to real usage and lets defensive
+ * guards pass.
+ *
+ * Severity is `warning`, consistent with the other correctness smells here:
+ * the spec still builds, and an over-eager match (e.g. an accessor named in a
+ * comment) should not hard-block codegen.
+ */
+function lintAccessorPermissions(
+  spec: AgentSpec,
+  slots: Record<string, string | undefined>,
+): LintIssue[] {
+  const issues: LintIssue[] = [];
+  for (const { accessor, specField, granted } of GATED_ACCESSORS) {
+    if (granted(spec)) continue;
+    // ctx.<accessor> followed by `.`, `!.`, or `?.` then a member name.
+    const usage = new RegExp(`\\bctx\\.${accessor}\\s*[!?]?\\s*\\.\\s*\\w`);
+    for (const [key, source] of Object.entries(slots)) {
+      if (typeof source !== 'string' || !usage.test(source)) continue;
+      issues.push({
+        severity: 'warning',
+        code: 'accessor_permission_undeclared',
+        message:
+          `slot '${key}' uses ctx.${accessor} but the spec does not grant it — ` +
+          `set ${specField} (the accessor is undefined at runtime otherwise)`,
+        path: `/slots/${key}`,
+      });
+    }
+  }
+  return issues;
 }
 
 function lintSlots(slots: Record<string, string | undefined>): LintIssue[] {

--- a/middleware/src/plugins/manifestLoader.ts
+++ b/middleware/src/plugins/manifestLoader.ts
@@ -177,9 +177,9 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
   const permissions = asRecord(doc['permissions']);
   const integrations = asArray(doc['integrations']);
 
-  const requiredSecrets: PluginSetupField[] = [];
-  const setupFields = asArray(setup?.['fields']);
-  for (const field of setupFields) {
+  const setupFields: PluginSetupField[] = [];
+  const setupFieldsRaw = asArray(setup?.['fields']);
+  for (const field of setupFieldsRaw) {
     const f = asRecord(field);
     if (!f) continue;
     const key = asString(f['key']);
@@ -219,7 +219,7 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
         if (options.length > 0) entry.enum = options;
       }
     }
-    requiredSecrets.push(entry);
+    setupFields.push(entry);
   }
 
   const rawKind = asString(identity['kind']);
@@ -323,7 +323,7 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
     compat_core: asString(compat?.['core']) ?? '>=1.0 <2.0',
     signed: false,
     signed_by: null,
-    required_secrets: requiredSecrets,
+    setup_fields: setupFields,
     permissions_summary: extractPermissions(permissions),
     integrations_summary: extractIntegrationTargets(integrations),
     install_state: 'available',

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -22,10 +22,9 @@ import type { InstalledRegistry } from '../plugins/installedRegistry.js';
  * Filtered server-side to `install_state === 'installed'` so the UI does
  * not have to know which plugins are actually live.
  *
- * Note: the manifest's `setup.fields[]` lands on `Plugin.required_secrets`
- * (the field name is historical — pre-OB-29 every setup field was a
- * secret). Surfaced here as `setup_fields` so the B3c editor reads from
- * an intent-named property.
+ * Note: the manifest's `setup.fields[]` lands on `Plugin.setup_fields`,
+ * carrying secret AND non-secret config alike. Surfaced here under the
+ * same `setup_fields` key for the B3c editor.
  */
 interface AgentPluginCatalogEntry {
   readonly id: string;
@@ -554,7 +553,7 @@ export function createOperatorAgentsRouter(
             memory_reads: summary?.memory_reads ?? [],
             memory_writes: summary?.memory_writes ?? [],
             network_outbound: summary?.network_outbound ?? [],
-            setup_fields: p.required_secrets ?? [],
+            setup_fields: p.setup_fields ?? [],
             depends_on: p.depends_on ?? [],
           } satisfies AgentPluginCatalogEntry;
         });

--- a/middleware/src/routes/store.ts
+++ b/middleware/src/routes/store.ts
@@ -348,7 +348,7 @@ function registryEntryToPlugin(resolved: ResolvedRegistryPlugin): Plugin {
     compat_core: ver.compat_core,
     signed: false,
     signed_by: null,
-    required_secrets: setupFields,
+    setup_fields: setupFields,
     permissions_summary: emptyPermissionsSummary(),
     integrations_summary: [],
     install_state: 'available',

--- a/middleware/test/agent-reference-maximum/kgAccessor.test.ts
+++ b/middleware/test/agent-reference-maximum/kgAccessor.test.ts
@@ -63,7 +63,7 @@ function makePlugin(
     compat_core: '>=1.0 <2.0',
     signed: false,
     signed_by: null,
-    required_secrets: [],
+    setup_fields: [],
     permissions_summary: {
       memory_reads: [],
       memory_writes: [],

--- a/middleware/test/agent-reference-maximum/llmAccessor.test.ts
+++ b/middleware/test/agent-reference-maximum/llmAccessor.test.ts
@@ -64,7 +64,7 @@ function makePlugin(
     compat_core: '>=1.0 <2.0',
     signed: false,
     signed_by: null,
-    required_secrets: [],
+    setup_fields: [],
     permissions_summary: {
       memory_reads: [],
       memory_writes: [],

--- a/middleware/test/agent-reference-maximum/storeFilter.test.ts
+++ b/middleware/test/agent-reference-maximum/storeFilter.test.ts
@@ -27,7 +27,7 @@ function makePlugin(id: string, overrides: Partial<Plugin> = {}): Plugin {
     compat_core: '>=1.0 <2.0',
     signed: false,
     signed_by: null,
-    required_secrets: [],
+    setup_fields: [],
     permissions_summary: {
       memory: { reads: [], writes: [] },
       graph: { reads: [], writes: [] },

--- a/middleware/test/agent-reference-maximum/subAgentAccessor.test.ts
+++ b/middleware/test/agent-reference-maximum/subAgentAccessor.test.ts
@@ -69,7 +69,7 @@ function makePlugin(
     compat_core: '>=1.0 <2.0',
     signed: false,
     signed_by: null,
-    required_secrets: [],
+    setup_fields: [],
     permissions_summary: {
       memory_reads: [],
       memory_writes: [],

--- a/middleware/test/bootstrap.test.ts
+++ b/middleware/test/bootstrap.test.ts
@@ -65,7 +65,7 @@ function makeCatalog(plugins: Partial_Plugin[]): PluginCatalog {
         compat_core: '>=1.0 <2.0',
         signed: false,
         signed_by: null,
-        required_secrets: [],
+        setup_fields: [],
         permissions_summary: {
           memory_reads: [],
           memory_writes: [],

--- a/middleware/test/builder/previewRuntime.test.ts
+++ b/middleware/test/builder/previewRuntime.test.ts
@@ -43,9 +43,12 @@ describe('PreviewRuntime', () => {
   function buildRuntime(opts: {
     previewsRoot: string;
     handle?: PreviewAgentHandle;
-    onActivate?: (ctx: PreviewPluginContext) => void;
+    onActivate?: (ctx: PreviewPluginContext) => void | Promise<void>;
     activateThrows?: Error;
     serviceRegistry?: PreviewHostServices;
+    /** When set, written as `manifest.yaml` into the extracted package so
+     *  `manifestDeclaresMemory` can gate `ctx.memory`. */
+    manifestYaml?: string;
   }): PreviewRuntime {
     return new PreviewRuntime({
       previewsRoot: opts.previewsRoot,
@@ -61,6 +64,9 @@ describe('PreviewRuntime', () => {
             main: 'dist/index.js',
           }),
         );
+        if (opts.manifestYaml !== undefined) {
+          writeFileSync(path.join(destDir, 'manifest.yaml'), opts.manifestYaml);
+        }
         // Touch the entry path so default-activate's fs.access wouldn't fail
         // (we override activateModule anyway, so its existence isn't used).
         mkdirSync(path.join(destDir, 'dist'), { recursive: true });
@@ -68,7 +74,7 @@ describe('PreviewRuntime', () => {
       },
       activateModule: async (_entry, ctx) => {
         if (opts.activateThrows) throw opts.activateThrows;
-        opts.onActivate?.(ctx);
+        await opts.onActivate?.(ctx);
         return (
           opts.handle ?? {
             toolkit: { tools: [] },
@@ -78,6 +84,19 @@ describe('PreviewRuntime', () => {
       },
     });
   }
+
+  /** Minimal manifest declaring agent-scoped memory permissions, matching the
+   *  boilerplate's `permissions.memory` block. */
+  const MEMORY_MANIFEST = [
+    'schema_version: "1"',
+    'identity:',
+    '  id: "@omadia/agent-test"',
+    'permissions:',
+    '  memory:',
+    '    reads: ["session:*", "agent:@omadia/agent-test:*"]',
+    '    writes: ["agent:@omadia/agent-test:*"]',
+    '',
+  ].join('\n');
 
   beforeEach(() => {});
 
@@ -283,6 +302,132 @@ describe('PreviewRuntime', () => {
       assert.equal(host.has('local.only'), false);
       dispose();
       assert.equal(captured!.services.get('local.only'), undefined);
+    });
+
+    it('exposes ctx.memory when the manifest declares memory permissions, backed by an ephemeral store', async () => {
+      // Regression: previewRuntime had no `memory` accessor on its stub
+      // context, so any agent whose activate-body calls `ctx.memory` (project
+      // persistence) hit its own `if (!ctx.memory) throw …` guard and failed
+      // preview-chat with `ctx.memory is required but unavailable`, even
+      // though its manifest correctly declared permissions.memory. Preview now
+      // provides an ephemeral in-memory store gated on the same manifest field
+      // the kernel checks post-install.
+      const root = freshRoot('memory-present');
+      let captured: PreviewPluginContext | undefined;
+      const runtime = buildRuntime({
+        previewsRoot: root,
+        manifestYaml: MEMORY_MANIFEST,
+        onActivate: (ctx) => {
+          captured = ctx;
+        },
+      });
+      await runtime.activate({
+        zipBuffer: Buffer.alloc(0),
+        draftId: 'd1',
+        rev: 1,
+        configValues: {},
+        secretValues: {},
+      });
+      assert.ok(captured);
+      assert.ok(captured!.memory, 'ctx.memory must be present');
+      const mem = captured!.memory!;
+
+      // Empty scope: exists/list are well-behaved, not throwing.
+      assert.equal(await mem.exists('projects/p1.json'), false);
+      assert.deepEqual(await mem.list('.'), []);
+
+      // Write → read round-trip.
+      await mem.writeFile('projects/p1.json', '{"name":"alpha"}');
+      assert.equal(await mem.readFile('projects/p1.json'), '{"name":"alpha"}');
+      assert.equal(await mem.exists('projects/p1.json'), true);
+      assert.equal(await mem.exists('projects'), true);
+
+      // createFile is fail-if-exists.
+      await assert.rejects(() => mem.createFile('projects/p1.json', 'x'));
+      await mem.createFile('projects/p2.json', '{"name":"beta"}');
+
+      // A path that is an implicit directory cannot be written or created as
+      // a file — mirrors FilesystemMemoryStore (EISDIR / already-exists), and
+      // keeps `list()` from being shadowed by a file/dir key collision.
+      await assert.rejects(() => mem.writeFile('projects', 'x'));
+      await assert.rejects(() => mem.createFile('projects', 'x'));
+
+      // list returns the dir + its files (relative paths).
+      const listed = await mem.list('projects');
+      const rels = listed.map((e) => e.relPath).sort();
+      assert.deepEqual(rels, ['projects', 'projects/p1.json', 'projects/p2.json']);
+      const p1 = listed.find((e) => e.relPath === 'projects/p1.json');
+      assert.equal(p1?.isDirectory, false);
+      assert.ok((p1?.sizeBytes ?? 0) > 0);
+
+      // delete removes the file.
+      await mem.delete('projects/p1.json');
+      assert.equal(await mem.exists('projects/p1.json'), false);
+      await assert.rejects(() => mem.readFile('projects/p1.json'));
+
+      // Relative-path validation mirrors the real accessor.
+      await assert.rejects(() => mem.readFile('/abs/path'));
+      await assert.rejects(() => mem.readFile('../escape'));
+    });
+
+    it('leaves ctx.memory undefined when the manifest omits memory permissions (mirrors install gate)', async () => {
+      const root = freshRoot('memory-absent');
+      let captured: PreviewPluginContext | undefined;
+      const runtime = buildRuntime({
+        previewsRoot: root,
+        // Manifest present but with an empty memory block → not declared.
+        manifestYaml: [
+          'schema_version: "1"',
+          'permissions:',
+          '  memory:',
+          '    reads: []',
+          '    writes: []',
+          '',
+        ].join('\n'),
+        onActivate: (ctx) => {
+          captured = ctx;
+        },
+      });
+      await runtime.activate({
+        zipBuffer: Buffer.alloc(0),
+        draftId: 'd1',
+        rev: 1,
+        configValues: {},
+        secretValues: {},
+      });
+      assert.ok(captured);
+      assert.equal(captured!.memory, undefined);
+    });
+
+    it('memory stores from two separate activations are isolated', async () => {
+      const root = freshRoot('memory-isolation');
+      const captured: PreviewPluginContext[] = [];
+      const runtime = buildRuntime({
+        previewsRoot: root,
+        manifestYaml: MEMORY_MANIFEST,
+        onActivate: (ctx) => {
+          captured.push(ctx);
+        },
+      });
+      const h1 = await runtime.activate({
+        zipBuffer: Buffer.alloc(0),
+        draftId: 'd1',
+        rev: 1,
+        configValues: {},
+        secretValues: {},
+      });
+      await captured[0]!.memory!.writeFile('notes.md', 'first');
+      const h2 = await runtime.activate({
+        zipBuffer: Buffer.alloc(0),
+        draftId: 'd2',
+        rev: 1,
+        configValues: {},
+        secretValues: {},
+      });
+      // Second activation's store must not see the first's data.
+      assert.equal(await captured[1]!.memory!.exists('notes.md'), false);
+      await h1.close();
+      await h2.close();
     });
 
     it('throws when secrets.require is called for a missing key', async () => {

--- a/middleware/test/builder/tools/lintSpec.test.ts
+++ b/middleware/test/builder/tools/lintSpec.test.ts
@@ -161,6 +161,91 @@ describe('lintSpecTool', () => {
     assert.ok(result.issues.some((i) => i.code === 'inline_system_prompt'));
   });
 
+  it('warns when a slot uses a gated accessor without granting the permission', async () => {
+    await patchSpecTool.run({ patches: validBaseline }, harness.context());
+    await fillSlotTool.run(
+      {
+        slotKey: 'activate-body',
+        source:
+          "const answer = await ctx.subAgent.ask('@omadia/agent-seo-analyst', 'q');",
+      },
+      harness.context(),
+    );
+    const result = await lintSpecTool.run({}, harness.context());
+    const warns = result.issues.filter(
+      (i) => i.code === 'accessor_permission_undeclared',
+    );
+    assert.equal(warns.length, 1);
+    assert.equal(warns[0].severity, 'warning');
+    assert.match(warns[0].message, /ctx\.subAgent/);
+    assert.match(warns[0].message, /permissions\.subAgents\.calls/);
+    // It's a smell, not a build-breaker.
+    assert.equal(result.ok, true);
+  });
+
+  it('does not warn when the gated accessor permission IS granted', async () => {
+    await patchSpecTool.run(
+      {
+        patches: [
+          ...validBaseline,
+          {
+            op: 'add',
+            path: '/permissions',
+            value: { subAgents: { calls: ['@omadia/agent-seo-analyst'] } },
+          },
+        ],
+      },
+      harness.context(),
+    );
+    await fillSlotTool.run(
+      {
+        slotKey: 'activate-body',
+        source:
+          "const answer = await ctx.subAgent.ask('@omadia/agent-seo-analyst', 'q');",
+      },
+      harness.context(),
+    );
+    const result = await lintSpecTool.run({}, harness.context());
+    assert.ok(
+      !result.issues.some((i) => i.code === 'accessor_permission_undeclared'),
+      'permission is declared, so no accessor warning should fire',
+    );
+  });
+
+  it('does not warn on ctx.memory usage — memory is a platform default, not spec-gated', async () => {
+    await patchSpecTool.run({ patches: validBaseline }, harness.context());
+    await fillSlotTool.run(
+      {
+        slotKey: 'activate-body',
+        source:
+          "if (ctx.memory) { await ctx.memory.writeFile('state.json', '{}'); }",
+      },
+      harness.context(),
+    );
+    const result = await lintSpecTool.run({}, harness.context());
+    assert.ok(
+      !result.issues.some((i) => i.code === 'accessor_permission_undeclared'),
+      'ctx.memory is always available — referencing it must never be flagged',
+    );
+  });
+
+  it('does not match a bare boolean guard like `if (ctx.subAgent)` without a member access', async () => {
+    await patchSpecTool.run({ patches: validBaseline }, harness.context());
+    await fillSlotTool.run(
+      {
+        slotKey: 'activate-body',
+        source:
+          'const hasDelegation = Boolean(ctx.subAgent); // capability probe only',
+      },
+      harness.context(),
+    );
+    const result = await lintSpecTool.run({}, harness.context());
+    assert.ok(
+      !result.issues.some((i) => i.code === 'accessor_permission_undeclared'),
+      'a bare reference without a `.member` access is not real usage',
+    );
+  });
+
   it('flags empty slot source', async () => {
     await patchSpecTool.run({ patches: validBaseline }, harness.context());
     // fillSlot won't accept empty, so go through DraftStore directly to seed

--- a/middleware/test/capabilityResolver.test.ts
+++ b/middleware/test/capabilityResolver.test.ts
@@ -54,7 +54,7 @@ function makeCatalog(plugins: Partial_Plugin[]): PluginCatalog {
         compat_core: '>=1.0 <2.0',
         signed: false,
         signed_by: null,
-        required_secrets: [],
+        setup_fields: [],
         permissions_summary: {
           memory_reads: [],
           memory_writes: [],

--- a/middleware/test/dependencyChainResolver.test.ts
+++ b/middleware/test/dependencyChainResolver.test.ts
@@ -36,7 +36,7 @@ function mkPlugin(
     compat_core: '>=1.0 <2.0',
     signed: false,
     signed_by: null,
-    required_secrets: [],
+    setup_fields: [],
     permissions_summary: {
       memory_reads: [],
       memory_writes: [],

--- a/middleware/test/installService.test.ts
+++ b/middleware/test/installService.test.ts
@@ -51,7 +51,7 @@ function makePlugin(p: Partial_Plugin): Plugin {
     compat_core: '>=1.0 <2.0',
     signed: false,
     signed_by: null,
-    required_secrets: [],
+    setup_fields: [],
     permissions_summary: {
       memory_reads: [],
       memory_writes: [],

--- a/middleware/test/profilesRouter.test.ts
+++ b/middleware/test/profilesRouter.test.ts
@@ -51,7 +51,7 @@ function makeCatalog(plugins: Partial_Plugin[]): PluginCatalog {
         compat_core: '>=1.0 <2.0',
         signed: false,
         signed_by: null,
-        required_secrets: [],
+        setup_fields: [],
         permissions_summary: {
           memory_reads: [],
           memory_writes: [],

--- a/middleware/test/registryInstallMerge.test.ts
+++ b/middleware/test/registryInstallMerge.test.ts
@@ -78,7 +78,7 @@ function plugin(id: string, over: Partial<Plugin> = {}): Plugin {
     compat_core: '>=1.0 <2.0',
     signed: false,
     signed_by: null,
-    required_secrets: [],
+    setup_fields: [],
     permissions_summary: {
       memory_reads: [],
       memory_writes: [],
@@ -319,7 +319,7 @@ describe('store router · setup_guide flows from the registry manifest_summary',
       assert.equal(res.status, 200);
       const body = (await res.json()) as { plugin: Plugin };
       assert.deepEqual(body.plugin.setup_guide, GUIDE);
-      assert.equal(body.plugin.required_secrets.length, 1);
+      assert.equal(body.plugin.setup_fields.length, 1);
     } finally {
       await new Promise<void>((r) => server.close(() => r()));
     }

--- a/middleware/test/setupGuide.test.ts
+++ b/middleware/test/setupGuide.test.ts
@@ -40,7 +40,7 @@ describe('adaptManifestV1 · setup.guide', () => {
     assert.ok(plugin);
     assert.deepEqual(plugin.setup_guide, guide);
     // Coexists with the existing per-field hints.
-    assert.equal(plugin.required_secrets.length, 1);
+    assert.equal(plugin.setup_fields.length, 1);
   });
 
   it('drops empty-string locales and keeps the rest', () => {

--- a/web-ui/app/_components/store/CredentialsEditor.tsx
+++ b/web-ui/app/_components/store/CredentialsEditor.tsx
@@ -169,11 +169,12 @@ export function CredentialsEditor({
   return (
     <div className="space-y-4">
       <div className="text-[12px] leading-relaxed text-[color:var(--muted-ink)]">
-        Secrets (Passwörter, OAuth-Tokens) werden verschlüsselt im Vault
-        gespeichert und nur als „gespeichert&ldquo; angezeigt — niemals der
-        eigentliche Wert. Nicht-sensitive Setup-Werte (Enum, URL, Flags) zeigen
-        die aktuelle Auswahl. Tippe oder wähle einen neuen Wert um zu
-        überschreiben, oder klicke auf <Trash2 className="inline size-3 align-text-bottom" aria-hidden /> um eine Credential zu löschen.
+        Felder mit <span className="font-semibold text-[color:var(--accent)]">Secret · Vault</span> (Passwörter,
+        OAuth-Tokens) werden verschlüsselt im Vault gespeichert und nur als
+        „gespeichert&ldquo; angezeigt — niemals der eigentliche Wert. Felder mit
+        <span className="font-semibold"> Config</span> (Enum, URL, Flags) sind
+        nicht-sensitiv und zeigen die aktuelle Auswahl. Tippe oder wähle einen
+        neuen Wert um zu überschreiben, oder klicke auf <Trash2 className="inline size-3 align-text-bottom" aria-hidden /> um den Wert zu löschen.
       </div>
 
       <ul className="divide-y divide-[color:var(--rule)] border-y border-[color:var(--rule)]">
@@ -206,6 +207,24 @@ export function CredentialsEditor({
                   </span>
                   <span className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--faint-ink)]">
                     {field.type}
+                  </span>
+                  {/* Storage classification — makes the Secret-vs-Config split
+                      explicit so plain config fields aren't read as
+                      "credentials". Secrets/OAuth land in the encrypted vault;
+                      everything else is instance config. */}
+                  <span
+                    className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${
+                      isSecret
+                        ? 'bg-[color:var(--accent)]/12 text-[color:var(--accent)]'
+                        : 'bg-[color:var(--rule)]/50 text-[color:var(--muted-ink)]'
+                    }`}
+                    title={
+                      isSecret
+                        ? 'Secret — verschlüsselt im per-Agent-Vault'
+                        : 'Config — nicht-sensitiver Wert in der Instanz-Konfiguration'
+                    }
+                  >
+                    {isSecret ? 'Secret · Vault' : 'Config'}
                   </span>
                 </div>
                 {field.label ? (
@@ -315,7 +334,9 @@ export function CredentialsEditor({
                     title={
                       state.pendingDelete
                         ? 'Löschung abbrechen'
-                        : 'Credential beim nächsten Speichern löschen'
+                        : isSecret
+                          ? 'Secret beim nächsten Speichern löschen'
+                          : 'Config-Wert beim nächsten Speichern löschen'
                     }
                     className={`inline-flex size-7 shrink-0 items-center justify-center rounded-md border transition-colors disabled:opacity-50 ${
                       state.pendingDelete

--- a/web-ui/app/_lib/storeTypes.ts
+++ b/web-ui/app/_lib/storeTypes.ts
@@ -113,7 +113,10 @@ export interface Plugin {
   compat_core: string;
   signed: boolean;
   signed_by: string | null;
-  required_secrets: PluginSetupField[];
+  /** All declared setup fields (secret AND non-secret config) from the
+   *  manifest's `setup.fields`. Not secrets-only — split by each field's
+   *  `type` (secret/oauth → vault, everything else → instance config). */
+  setup_fields: PluginSetupField[];
   permissions_summary: PluginPermissionsSummary;
   integrations_summary: string[];
   install_state: PluginInstallState;

--- a/web-ui/app/store/[id]/page.tsx
+++ b/web-ui/app/store/[id]/page.tsx
@@ -175,17 +175,17 @@ export default async function PluginDetailPage({
             </Section>
           ) : null}
 
-          {plugin.required_secrets.length > 0 ? (
+          {plugin.setup_fields.length > 0 ? (
             <Section
-              label="Benötigte Secrets"
+              label="Setup-Felder"
               numeral="II"
-              meta={`${plugin.required_secrets.length} Feld${
-                plugin.required_secrets.length === 1 ? '' : 'er'
+              meta={`${plugin.setup_fields.length} Feld${
+                plugin.setup_fields.length === 1 ? '' : 'er'
               }`}
               icon={<KeyRound className="size-4" aria-hidden />}
             >
               <div className="divide-y divide-[color:var(--rule)] border-y border-[color:var(--rule)]">
-                {plugin.required_secrets.map((field) => (
+                {plugin.setup_fields.map((field) => (
                   <SecretRow key={field.key} field={field} />
                 ))}
               </div>
@@ -200,15 +200,15 @@ export default async function PluginDetailPage({
               provider post-registration). */}
           {(plugin.install_state === 'installed' ||
             plugin.install_state === 'update-available') &&
-          plugin.required_secrets.length > 0 ? (
+          plugin.setup_fields.length > 0 ? (
             <Section
-              label="Credentials editieren"
+              label="Setup-Felder editieren"
               numeral="II.b"
               icon={<KeyRound className="size-4" aria-hidden />}
             >
               <CredentialsEditor
                 pluginId={plugin.id}
-                setupFields={plugin.required_secrets}
+                setupFields={plugin.setup_fields}
               />
             </Section>
           ) : null}


### PR DESCRIPTION
## Summary

Investigates and fixes a bug where a freshly built agent that uses `ctx.memory`
in its `activate-body` crashed at preview-chat start with
`ctx.memory is required but unavailable` — despite a correct manifest — then
addresses three follow-ups surfaced by the investigation.

### Root cause — none of the manifest hypotheses

The manifest was never the problem. `codegen` merges `spec.permissions` into the
boilerplate block and preserves `permissions.memory`; the kernel's
`memoryDeclared` gate only checks the block is non-empty and never parses or
compares the `agent:<id>:*` string against `ctx.agentId`. So a real install
would have provided `ctx.memory`. The crash was **preview-only**:
`createStubContext` wired `secrets`/`config`/`routes`/`uiRoutes`/`services` but
no memory accessor, so the agent hit its own `if (!ctx.memory) throw` guard —
the same class as the already-documented services-stub gap (Theme A).

## Changes

1. **fix(builder): provide `ctx.memory` in preview runtime** — ephemeral,
   per-activation in-memory store (`previewMemoryStore.ts`) mirroring
   `FilesystemMemoryStore`'s path/scope/`list` semantics, gated on the manifest
   declaring `permissions.memory` — the same gate the kernel applies
   post-install. A correct manifest gets a working store; a stripped one fails
   preview the same way it fails a real install.

2. **feat(builder): lint gated `ctx` accessors against declared permissions** —
   `lint_spec` warns (`accessor_permission_undeclared`) when a slot uses
   `ctx.subAgent` / `ctx.llm` / `ctx.knowledgeGraph` / `ctx.http` without
   granting the matching permission (undefined at runtime otherwise).
   `ctx.memory` is deliberately excluded — it is a platform default and can
   never be a misconfiguration.

3. **docs(builder): clarify `permissions.memory` is a platform default** — and
   document the gating contract + the new lint up front in the builder system
   prompt.

4. **refactor(api,web-ui): rename `Plugin.required_secrets` → `setup_fields`** —
   the `/api/v1/store/plugins` DTO field carries ALL setup fields (non-secret
   config as well as secret/oauth), so the name was a misnomer. Renamed across
   the internal monorepo contract (producer, API type, consumers, web-ui type,
   test fixtures). Output-only field, no backwards-compat shim. Plus
   Config-vs-Secret clarity in the store UI (per-field Vault/Config badge,
   type-aware wording, `Setup-Felder` instead of generic `Credentials`).

## Verification

| | tsc | eslint | tests |
|---|---|---|---|
| middleware | 0 | 0 | builder suite 928 pass · affected non-builder 133 pass |
| web-ui | 0 | 0 | — |

## Notes

- Two boilerplate `CLAUDE.md` prose lines still mention `required_secrets` while
  describing `docs/harness-platform/manifest-schema.v1.yaml` (a file not present
  in this tree). Left untouched to avoid speculating about a schema not visible
  here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
