### PR TITLE
refactor(builder): user-facing 'Veröffentlichen' → 'Bereitstellen'

### DIFF
--- a/web-ui/app/store/builder/[id]/_components/InstallDiffModal.tsx
+++ b/web-ui/app/store/builder/[id]/_components/InstallDiffModal.tsx
@@ -137,7 +137,7 @@ export function InstallDiffModal({
       className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6"
       role="dialog"
       aria-modal="true"
-      aria-label="Plugin installieren"
+      aria-label="Plugin veröffentlichen"
     >
       <button
         type="button"
@@ -159,13 +159,13 @@ export function InstallDiffModal({
           <div className="min-w-0">
             <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.22em] text-[color:var(--accent)]">
               <ShieldCheck className="size-3.5" aria-hidden />
-              Install-Diff-Gate
+              Veröffentlichungs-Diff-Gate
             </div>
             <h2 className="font-display mt-1 text-2xl font-medium leading-tight text-[color:var(--ink)]">
-              Plugin installieren
+              Plugin veröffentlichen
             </h2>
             <p className="mt-2 text-[12px] leading-relaxed text-[color:var(--muted-ink)]">
-              Diese Surface wird in den Plugin-Store geschrieben. Nach „Installieren&ldquo;
+              Diese Surface wird in den Plugin-Store geschrieben. Nach „Veröffentlichen&ldquo;
               ist <span className="font-mono-num">{draft.spec.id}</span> v
               {draft.spec.version} für alle Agents im Tenant verfügbar.
             </p>
@@ -266,7 +266,7 @@ export function InstallDiffModal({
             {busy ? (
               <>
                 <Loader2 className="size-3.5 animate-spin" aria-hidden />
-                Installiere …
+                Veröffentliche …
               </>
             ) : phase.kind === 'succeeded' ? (
               <>
@@ -274,7 +274,7 @@ export function InstallDiffModal({
                 Erfolgreich
               </>
             ) : (
-              'Installieren'
+              'Veröffentlichen'
             )}
           </button>
         </footer>
@@ -501,7 +501,7 @@ function FailureBanner({
   currentVersion: string;
   onBumpAndRetry: () => void | Promise<void>;
 }): React.ReactElement {
-  const heading = HEADINGS[failure.reason] ?? 'Installation fehlgeschlagen';
+  const heading = HEADINGS[failure.reason] ?? 'Veröffentlichung fehlgeschlagen';
   const hint = HINTS[failure.reason];
   // Theme C: only the duplicate_version sub-case of `conflict` is fixable
   // by bumping. We can't reliably distinguish from `id` collisions on
@@ -545,7 +545,7 @@ function FailureBanner({
                 onClick={() => void onBumpAndRetry()}
                 className="inline-flex items-center gap-2 rounded-md bg-[color:var(--accent)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-white shadow-sm transition-opacity hover:opacity-90"
               >
-                Version anheben ({currentVersion} → {bumped}) + Installieren
+                Version anheben ({currentVersion} → {bumped}) + Veröffentlichen
               </button>
             ) : null}
             <button
@@ -662,7 +662,7 @@ function SuccessBanner({
         />
         <div className="min-w-0 flex-1">
           <p className="font-display text-[13px] font-semibold text-[color:var(--success)]">
-            Plugin installiert
+            Plugin veröffentlicht
           </p>
           <p className="mt-1 text-[12px] text-[color:var(--fg-strong)]">
             <span className="font-mono-num">{publishedAgentId}</span> v{version}{' '}

--- a/web-ui/app/store/builder/[id]/_components/InstallDiffModal.tsx
+++ b/web-ui/app/store/builder/[id]/_components/InstallDiffModal.tsx
@@ -137,7 +137,7 @@ export function InstallDiffModal({
       className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6"
       role="dialog"
       aria-modal="true"
-      aria-label="Plugin veröffentlichen"
+      aria-label="Plugin bereitstellen"
     >
       <button
         type="button"
@@ -159,15 +159,15 @@ export function InstallDiffModal({
           <div className="min-w-0">
             <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.22em] text-[color:var(--accent)]">
               <ShieldCheck className="size-3.5" aria-hidden />
-              Veröffentlichungs-Diff-Gate
+              Bereitstellungs-Diff-Gate
             </div>
             <h2 className="font-display mt-1 text-2xl font-medium leading-tight text-[color:var(--ink)]">
-              Plugin veröffentlichen
+              Plugin bereitstellen
             </h2>
             <p className="mt-2 text-[12px] leading-relaxed text-[color:var(--muted-ink)]">
-              Diese Surface wird in den Plugin-Store geschrieben. Nach „Veröffentlichen&ldquo;
-              ist <span className="font-mono-num">{draft.spec.id}</span> v
-              {draft.spec.version} für alle Agents im Tenant verfügbar.
+              Diese Surface wird in die Plugin-Registry deiner Instanz geschrieben.
+              Nach „Bereitstellen&ldquo; ist <span className="font-mono-num">{draft.spec.id}</span> v
+              {draft.spec.version} für alle Agents in deinem Tenant verfügbar — nicht öffentlich.
             </p>
           </div>
           <button
@@ -266,7 +266,7 @@ export function InstallDiffModal({
             {busy ? (
               <>
                 <Loader2 className="size-3.5 animate-spin" aria-hidden />
-                Veröffentliche …
+                Stelle bereit …
               </>
             ) : phase.kind === 'succeeded' ? (
               <>
@@ -274,7 +274,7 @@ export function InstallDiffModal({
                 Erfolgreich
               </>
             ) : (
-              'Veröffentlichen'
+              'Bereitstellen'
             )}
           </button>
         </footer>
@@ -501,7 +501,7 @@ function FailureBanner({
   currentVersion: string;
   onBumpAndRetry: () => void | Promise<void>;
 }): React.ReactElement {
-  const heading = HEADINGS[failure.reason] ?? 'Veröffentlichung fehlgeschlagen';
+  const heading = HEADINGS[failure.reason] ?? 'Bereitstellung fehlgeschlagen';
   const hint = HINTS[failure.reason];
   // Theme C: only the duplicate_version sub-case of `conflict` is fixable
   // by bumping. We can't reliably distinguish from `id` collisions on
@@ -545,7 +545,7 @@ function FailureBanner({
                 onClick={() => void onBumpAndRetry()}
                 className="inline-flex items-center gap-2 rounded-md bg-[color:var(--accent)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-white shadow-sm transition-opacity hover:opacity-90"
               >
-                Version anheben ({currentVersion} → {bumped}) + Veröffentlichen
+                Version anheben ({currentVersion} → {bumped}) + Bereitstellen
               </button>
             ) : null}
             <button
@@ -662,11 +662,11 @@ function SuccessBanner({
         />
         <div className="min-w-0 flex-1">
           <p className="font-display text-[13px] font-semibold text-[color:var(--success)]">
-            Plugin veröffentlicht
+            Plugin bereitgestellt
           </p>
           <p className="mt-1 text-[12px] text-[color:var(--fg-strong)]">
             <span className="font-mono-num">{publishedAgentId}</span> v{version}{' '}
-            ist im Store sichtbar. Weiterleitung läuft …
+            ist in deiner Instanz verfügbar. Weiterleitung läuft …
           </p>
         </div>
       </div>

--- a/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
@@ -504,7 +504,7 @@ export function PreviewChatPane({
               <div className="mt-1 text-[11px] text-[color:var(--fg-muted)]">
                 Preview führt Cross-Integration-Lookups (<code>spec.external_reads</code>)
                 nicht aus — der Agent erkennt den fehlenden Service korrekt
-                und wirft. Installiere den Agent in den Plattform-Store, um
+                und wirft. Veröffentliche den Agent in den Plattform-Store, um
                 den echten Datenpfad zu testen.
               </div>
             </div>

--- a/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
@@ -504,8 +504,8 @@ export function PreviewChatPane({
               <div className="mt-1 text-[11px] text-[color:var(--fg-muted)]">
                 Preview führt Cross-Integration-Lookups (<code>spec.external_reads</code>)
                 nicht aus — der Agent erkennt den fehlenden Service korrekt
-                und wirft. Veröffentliche den Agent in den Plattform-Store, um
-                den echten Datenpfad zu testen.
+                und wirft. Stelle den Agent in deiner Instanz bereit, um den
+                echten Datenpfad zu testen.
               </div>
             </div>
           </div>

--- a/web-ui/app/store/builder/[id]/_components/Workspace.tsx
+++ b/web-ui/app/store/builder/[id]/_components/Workspace.tsx
@@ -1227,7 +1227,7 @@ function WorkspaceHeader({
         )}
       >
         <Rocket className="size-3.5" aria-hidden />
-        Installieren
+        Veröffentlichen
       </button>
     </header>
   );

--- a/web-ui/app/store/builder/[id]/_components/Workspace.tsx
+++ b/web-ui/app/store/builder/[id]/_components/Workspace.tsx
@@ -84,7 +84,7 @@ const MODEL_LABEL: Record<BuilderModelId, string> = {
 
 const STATUS_LABEL: Record<Draft['status'], string> = {
   draft: 'Entwurf',
-  published: 'Veröffentlicht',
+  published: 'Bereitgestellt',
   archived: 'Archiviert',
 };
 
@@ -1227,7 +1227,7 @@ function WorkspaceHeader({
         )}
       >
         <Rocket className="size-3.5" aria-hidden />
-        Veröffentlichen
+        Bereitstellen
       </button>
     </header>
   );

--- a/web-ui/app/store/builder/_components/DraftRow.tsx
+++ b/web-ui/app/store/builder/_components/DraftRow.tsx
@@ -31,7 +31,7 @@ const MODEL_LABEL: Record<BuilderModelId, string> = {
 
 const STATUS_LABEL: Record<DraftSummary['status'], string> = {
   draft: 'Entwurf',
-  published: 'Veröffentlicht',
+  published: 'Bereitgestellt',
   archived: 'Archiviert',
 };
 

--- a/web-ui/app/store/builder/page.tsx
+++ b/web-ui/app/store/builder/page.tsx
@@ -23,7 +23,7 @@ type ScopeFilter = 'draft' | 'published' | 'deleted';
 
 const SCOPE_LABEL: Record<ScopeFilter, string> = {
   draft: 'Entwurf',
-  published: 'Veröffentlicht',
+  published: 'Bereitgestellt',
   deleted: 'Gelöscht',
 };
 
@@ -114,7 +114,7 @@ export default async function BuilderDashboardPage({
 
         <dl className="mt-10 grid max-w-2xl grid-cols-4 gap-6 border-t border-[color:var(--divider)] pt-5 text-sm">
           <Stat label="Entwürfe" value={counts.draft} />
-          <Stat label="Veröffentlicht" value={counts.published} />
+          <Stat label="Bereitgestellt" value={counts.published} />
           <Stat label="Gelöscht" value={counts.deleted} />
           <Stat label="Limit" value={quota.cap} />
         </dl>
@@ -214,13 +214,13 @@ function EmptyState({ scope }: { scope: ScopeFilter }): React.ReactElement {
     scope === 'draft'
       ? 'Noch keine Entwürfe.'
       : scope === 'published'
-        ? 'Noch nichts veröffentlicht.'
+        ? 'Noch nichts bereitgestellt.'
         : 'Papierkorb ist leer.';
   const hint =
     scope === 'draft'
       ? 'Klicke rechts oben auf „Neuer Agent" um deinen ersten Entwurf anzulegen.'
       : scope === 'published'
-        ? 'Veröffentlichte Agents erscheinen hier, sobald du einen Entwurf über den Workspace in die Plattform gepackt hast.'
+        ? 'Bereitgestellte Agents erscheinen hier, sobald du einen Entwurf in die Plattform-Registry deiner Instanz übernommen hast.'
         : 'Gelöschte Entwürfe tauchen hier auf und können wiederhergestellt werden, bis du sie endgültig löschst.';
   return (
     <div className="rounded-[14px] border border-dashed border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-12 text-center">


### PR DESCRIPTION
## Background

The previous two passes (#98, #112) renamed "Installieren" → "Veröffentlichen" across the builder. **That choice doesn't survive the marketplace roadmap:** with a public agent/plugin marketplace coming, the German verb "veröffentlichen" wrongly implies the agent is exposed there. It isn't — pushing to a marketplace would be a separate, manual step. The current flow only adds the agent to the **operator's own tenant registry**.

## Decision

- **New verb:** "Bereitstellen" (status: "Bereitgestellt"). Neutral, technically clear, no public-publication connotation. German equivalent of "Deploy".
- **Future English pendant** (when i18n lands): "Deploy / Deployed".
- **Scope:** user-facing strings only. The internal API/DB value \`'published'\` stays — it is neutral in English tech-speak, and a second DB migration on top of the still-sunset-pending v1→v2 would be hectic without payoff.

## Touched surfaces

All under \`web-ui/app/store/builder/\`:

- **page.tsx** — tab label, Stat tile, EmptyState headline + hint
- **_components/DraftRow.tsx** — STATUS_LABEL badge
- **[id]/_components/Workspace.tsx** — STATUS_LABEL + header CTA button "Bereitstellen"
- **[id]/_components/InstallDiffModal.tsx** — aria-label, eyebrow ("Bereitstellungs-Diff-Gate"), heading, body copy (now explicit: _"Diese Surface wird in die Plugin-Registry deiner Instanz geschrieben … für alle Agents in deinem Tenant verfügbar — **nicht öffentlich**."_), primary CTA + busy state, retry-with-bump button, failure-banner default ("Bereitstellung fehlgeschlagen"), success-banner ("Plugin bereitgestellt", _"ist in deiner Instanz verfügbar"_ instead of _"im Store sichtbar"_)
- **[id]/_components/PreviewChatPane.tsx** — external_reads warning hint

## Not touched (intentional)

- \`DraftStatus\` enum, DB schema (\`published_agent_id\`), API responses, route params, URL scope param (\`?scope=published\`), component / function / file names
- Tests — all assertions use the internal \`'published'\` value
- \`/store\` and \`/store/[id]\` plugin-detail pages — they use \`plugin.install_state\`, not \`DraftStatus\` (separate concept)

## Test plan

- [x] \`web-ui\` typecheck clean
- [ ] Manual UI: confirm tab + stat label "Bereitgestellt", header CTA "Bereitstellen", modal heading + body + buttons, success banner reads "Plugin bereitgestellt … in deiner Instanz verfügbar"

🤖 Generated with [Claude Code](https://claude.com/claude-code)