### PR TITLE
feat(ui-channel): canvas WebSocket transport — handshake + turn + surface fan-out (PR-10b)

### DIFF
--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -307,6 +307,61 @@ Test: `test/webSocketRegistry.test.ts` fährt einen echten `http.Server` + echte
 Transport bereit für **PR-10b** (echter Canvas-Channel: Handshake-`offer→select→
 ack`, `IncomingTurn`-Bildung, `surface_*`-Fan-out).
 
+### Canvas WebSocket-Channel (Omadia UI, PR-10b)
+
+Macht aus dem `omadia-ui-channel`-Skeleton (PR-10a) den echten Transport, auf
+PR-11s `CoreApi.registerWebSocket` aufsetzend. Drei neue Module im Package
+`packages/omadia-ui-channel/src/`:
+
+- **`protocol.ts`** — die Wire-Nachrichten des Channels:
+  Server→Client `handshake_offer`/`handshake_error`/`handshake_ack` +
+  die Turn-Lifecycle-Envelopes `agent_text_delta`/`turn_complete`/`turn_error`;
+  Client→Server `handshake_select` + `turn`. Die `surface_*`-Events selbst
+  werden **nicht** re-deklariert — sie sind `SurfaceStreamEvent` aus dem SDK und
+  werden 1:1 weitergereicht. Plus ein toleranter `parseClientMessage`
+  (Nicht-JSON / unbekannter `type` → verworfen).
+- **`canvasConnection.ts`** — `handleCanvasSocket(socket, session, deps)`, die
+  per-Verbindungs-State-Machine (DI-freundlich, ohne echten Socket testbar):
+  1. **Handshake:** server-initiiertes `handshake_offer` beim Connect; auf
+     `handshake_select` Versions-Match (Protokoll **und** Ops-Catalog) → mintet/
+     übernimmt `canvasSessionId` und schickt `handshake_ack`; Mismatch →
+     `handshake_error` (eine Downgrade-Chance, zweiter Mismatch → `close`).
+  2. **Turn-Bildung:** je `turn`-Nachricht ein `IncomingTurn` —
+     `channelId`, `userRef` (`kind: 'custom'`, `id = session.subject`), `text`,
+     optional `target`/`viewState`/`viewStateTruncated`, `tenantId` aus
+     `ctx.services.get('graphTenantId')` (sonst Core-Default `'default'`).
+     **`conversationId = `${session.subject}::${canvasSessionId}``** — der
+     Core-Scope ist `${channelId}::${conversationId}` und **nicht** user-gescopet,
+     darum wird die client-gelieferte `canvasSessionId` unter dem
+     authentifizierten Subject genamespacet (sonst Cross-User-Canvas-Zugriff,
+     Codex-Blocker). Der rohe `canvasSessionId` bleibt in `metadata` + im Ack.
+     `target`/`viewState` werden vor Dispatch leichtgewichtig shape-geprüft
+     (Objekt + `target.kind` String) — Vollvalidierung der 10 TargetRef-Varianten
+     ist Tier-2-Whitelist; malformed → `turn_error`, kein Dispatch.
+  3. **Fan-out:** iteriert `core.handleTurnStream(turn)` und reicht `surface_*`
+     **1:1** an den Client (gegen ein explizites Typ-Set, nicht per
+     `surface_`-Prefix), faltet `text_delta` → `agent_text_delta`; ein `error`
+     **terminiert** den Turn (`turn_error` statt, nicht zusätzlich zu,
+     `turn_complete`). Orchestrator-Telemetrie (`iteration_start`, `tool_*`,
+     `verifier`, …) wird **verworfen**. Turns sind **pro Verbindung
+     serialisiert** (Promise-Chain), damit Surface-Frames nicht interleaven.
+- **`plugin.ts`** — `activate` registriert zusätzlich zur Discovery-Route
+  (`GET /omadia-ui/info`, jetzt `websocket: /omadia-ui/canvas`) den WS-Endpoint
+  via `core.registerWebSocket` — **feature-detected**: fehlt die Methode (kein
+  WS-Registry verdrahtet), degradiert der Channel auf Discovery-only, inert. Die
+  Auth macht der Kernel **vor** dem Handler (PR-11); `session` ist verifiziert.
+  Teardown: Routes + WS-Registrierungen + Live-Sockets räumt der Kernel pro
+  `channelId` beim Deactivate ab.
+
+Test: `test/uiChannelWebSocket.test.ts` treibt `handleCanvasSocket` mit
+Mock-`ChannelSocket` + Mock-`handleTurnStream` (offer; matching select → ack mit
+client-`canvasSessionId`; Versions-Mismatch → error, zweiter → close; Turn →
+korrekt geformter `IncomingTurn` + `surface_*`/`agent_text_delta`/`turn_complete`
+Fan-out; Turn vor Handshake wird verworfen). Real-Socket-Pfad ist durch PR-11s
+`webSocketRegistry.test.ts` abgedeckt. **Damit kann der Agent live UI über den
+Canvas synthetisieren, sobald Tier 2 (`omadia-ui-orchestrator`) `surface_*`
+emittiert** — der Transport ist vollständig.
+
 ---
 
 ## 4. Migration Managed Agents → Lokal

--- a/middleware/packages/omadia-ui-channel/manifest.yaml
+++ b/middleware/packages/omadia-ui-channel/manifest.yaml
@@ -6,7 +6,7 @@ identity:
   version: "0.1.0"
   kind: "channel"
   domain: "omadia.ui"
-  description: "Omadia UI Tier-1 server-side channel (skeleton). Declares the canvas surface — capabilities [text, canvas] and dispatch_service canvasChatAgent — so a turn routes to the omadia-ui-orchestrator (#168/#171). v0 registers a discovery endpoint advertising the omadia-canvas-protocol + ops-catalog versions and capabilities. The bidirectional WebSocket transport (handshake offer→select→ack, IncomingTurn forming, surface_* event fan-out) is DEFERRED: the CoreApi exposes only Express route/router registration, not a WebSocket upgrade, so hosting the canvas WebSocket needs a CoreApi SDK extension that the concept's SDK-changes list omitted."
+  description: "Omadia UI Tier-1 server-side channel. Declares the canvas surface — capabilities [text, canvas] and dispatch_service canvasChatAgent — so a turn routes to the omadia-ui-orchestrator (#168/#171). Mounts a pre-connect discovery endpoint (GET /omadia-ui/info) advertising the omadia-canvas-protocol + ops-catalog versions and capabilities, plus the bidirectional canvas WebSocket (/omadia-ui/canvas) over PR-11's CoreApi.registerWebSocket: server-initiated handshake (offer→select→ack), IncomingTurn forming per client turn, and 1:1 surface_* fan-out of the orchestrator stream. The WebSocket is feature-detected — degrades to discovery-only when no WS registry is wired into the CoreApi."
   authors:
     - name: "byte5 GmbH"
       email: "info@omadia.ai"
@@ -25,8 +25,9 @@ lifecycle:
 
 channel:
   transport:
-    # Target transport. The WebSocket server itself is not yet wired (see
-    # description) — v0 mounts the discovery route below over plain HTTP.
+    # Canvas transport is a WebSocket at /omadia-ui/canvas (registered via
+    # CoreApi.registerWebSocket — kernel-authenticated upgrade). The HTTP route
+    # below is the pre-connect discovery endpoint a client reads first.
     kind: "websocket"
     routes:
       - path: "/omadia-ui/info"

--- a/middleware/packages/omadia-ui-channel/package.json
+++ b/middleware/packages/omadia-ui-channel/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "description": "Omadia UI Tier-1 server-side channel (skeleton). kind: channel; capabilities [text, canvas]; dispatch_service canvasChatAgent. v0 advertises the canvas protocol via a discovery endpoint; the bidirectional WebSocket transport (handshake + surface_* fan-out + IncomingTurn forming) is deferred to a CoreApi WS-transport extension.",
+  "description": "Omadia UI Tier-1 server-side channel. kind: channel; capabilities [text, canvas]; dispatch_service canvasChatAgent. Advertises the canvas protocol via a discovery endpoint and hosts the bidirectional canvas WebSocket (handshake offer→select→ack, IncomingTurn forming, surface_* fan-out) over CoreApi.registerWebSocket; feature-detected, degrades to discovery-only when no WS registry is wired.",
   "license": "MIT",
   "scripts": {
     "build": "tsc",

--- a/middleware/packages/omadia-ui-channel/src/canvasConnection.ts
+++ b/middleware/packages/omadia-ui-channel/src/canvasConnection.ts
@@ -1,0 +1,241 @@
+import type {
+  CanvasViewState,
+  ChannelSessionClaims,
+  ChannelSocket,
+  ChatStreamEvent,
+  IncomingTurn,
+} from '@omadia/channel-sdk';
+import type { TargetRef } from '@omadia/plugin-api';
+
+import {
+  parseClientMessage,
+  SURFACE_EVENT_TYPES,
+  type ClientTurn,
+  type HandshakeAck,
+  type HandshakeError,
+  type HandshakeOffer,
+} from './protocol.js';
+
+/**
+ * Everything one canvas connection needs from the host, injected so the state
+ * machine is testable without a live WebSocket or kernel.
+ */
+export interface CanvasConnectionDeps {
+  /** the channel plugin's catalog id — becomes `IncomingTurn.channelId`. */
+  channelId: string;
+  /** protocol versions this server offers (e.g. `['1.0']`). */
+  protocolVersions: string[];
+  /** ops-catalog versions this server offers (e.g. `['1.0']`). */
+  opsCatalogVersions: string[];
+  /** drive an orchestrator turn — `core.handleTurnStream`. */
+  handleTurnStream: (turn: IncomingTurn) => AsyncIterable<ChatStreamEvent>;
+  /** per-deployment tenant id (from `graphTenantId`); omit → core defaults it. */
+  tenantId?: string;
+  /** mint a handshakeId / canvasSessionId / turnId. Injected for deterministic tests. */
+  mintId: () => string;
+  log?: (msg: string) => void;
+}
+
+type Phase = 'awaiting_select' | 'ready' | 'closed';
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Drive one authenticated canvas WebSocket: server-initiated handshake
+ * (`offer` → `select` → `ack`, with a single version-mismatch downgrade chance
+ * before close), then a turn loop that forms an {@link IncomingTurn} per client
+ * `turn` message and fans the orchestrator stream back out — `surface_*` events
+ * 1:1, agent prose as `agent_text_delta`, terminated by `turn_complete` /
+ * `turn_error`.
+ *
+ * The socket is already authenticated by the kernel WebSocketRegistry (PR-11);
+ * `session` is the verified identity. Turns are serialised per connection so
+ * their surface frames never interleave.
+ */
+export function handleCanvasSocket(
+  socket: ChannelSocket,
+  session: ChannelSessionClaims,
+  deps: CanvasConnectionDeps,
+): void {
+  let phase: Phase = 'awaiting_select';
+  let downgradeAttempts = 0;
+  /** the client-facing canvas id (client-supplied or server-minted). */
+  let canvasSessionId = '';
+  const handshakeId = deps.mintId();
+  // Per-connection turn queue — serialises turns so two in-flight turns can't
+  // interleave surface frames on the same socket.
+  let turnChain: Promise<void> = Promise.resolve();
+
+  const send = (msg: unknown): void => {
+    if (phase === 'closed') return;
+    socket.send(JSON.stringify(msg));
+  };
+
+  socket.onClose(() => {
+    phase = 'closed';
+  });
+
+  // 1. Server-initiated offer.
+  const offer: HandshakeOffer = {
+    type: 'handshake_offer',
+    handshakeId,
+    protocolVersions: deps.protocolVersions,
+    opsCatalogVersions: deps.opsCatalogVersions,
+  };
+  send(offer);
+
+  socket.onMessage((raw) => {
+    if (phase === 'closed') return;
+    const msg = parseClientMessage(raw);
+    if (!msg) {
+      deps.log?.('[ui-channel] dropped unparseable client frame');
+      return;
+    }
+
+    if (phase === 'awaiting_select') {
+      if (msg.type !== 'handshake_select') return; // ignore traffic pre-handshake
+      // Correlate to the offer we minted — a select for a different handshake is
+      // a confused/replayed client; ignore it.
+      if (msg.handshakeId !== handshakeId) {
+        deps.log?.('[ui-channel] handshake_select with mismatched handshakeId');
+        return;
+      }
+      const protoOk = deps.protocolVersions.includes(msg.protocolVersion);
+      const opsOk = deps.opsCatalogVersions.includes(msg.opsCatalogVersion);
+      if (!protoOk || !opsOk) {
+        const err: HandshakeError = {
+          type: 'handshake_error',
+          handshakeId,
+          reason: !protoOk
+            ? 'protocol-version-unsupported'
+            : 'ops-catalog-version-unsupported',
+          supported: {
+            protocolVersions: deps.protocolVersions,
+            opsCatalogVersions: deps.opsCatalogVersions,
+          },
+        };
+        send(err);
+        downgradeAttempts += 1;
+        // One downgrade chance; a second mismatch closes the connection.
+        if (downgradeAttempts >= 2) {
+          phase = 'closed';
+          socket.close(1002, 'handshake version mismatch');
+        }
+        return;
+      }
+      canvasSessionId =
+        msg.canvasSessionId && msg.canvasSessionId.length > 0
+          ? msg.canvasSessionId
+          : deps.mintId();
+      const ack: HandshakeAck = {
+        type: 'handshake_ack',
+        handshakeId,
+        canvasSessionId,
+      };
+      send(ack);
+      phase = 'ready';
+      return;
+    }
+
+    // phase === 'ready'
+    if (msg.type !== 'turn') return;
+    const turnId =
+      msg.turnId && msg.turnId.length > 0 ? msg.turnId : deps.mintId();
+    // Validate client-controlled shapes before dispatch — the channel is a
+    // transport, but it must not push obviously-malformed target/viewState into
+    // the orchestrator. Full structural validation (the 10 TargetRef variants,
+    // the viewState budget) is the Tier-2 protocol whitelist's job.
+    const invalid = validateTurnInput(msg);
+    if (invalid) {
+      send({ type: 'turn_error', forTurn: turnId, message: invalid });
+      return;
+    }
+    // Serialise: each turn runs to completion before the next starts.
+    turnChain = turnChain.then(() => runTurn(msg, turnId)).catch(() => {
+      /* runTurn never rejects (it sends turn_error); guard the chain anyway. */
+    });
+  });
+
+  function validateTurnInput(msg: ClientTurn): string | null {
+    if (
+      msg.target !== undefined &&
+      !(isPlainObject(msg.target) && typeof msg.target['kind'] === 'string')
+    ) {
+      return 'invalid target: expected an object with a string `kind`';
+    }
+    if (msg.viewState !== undefined && !isPlainObject(msg.viewState)) {
+      return 'invalid viewState: expected an object keyed by containerId';
+    }
+    return null;
+  }
+
+  async function runTurn(msg: ClientTurn, turnId: string): Promise<void> {
+    const turn = formIncomingTurn(msg, turnId);
+    let terminated = false;
+    try {
+      for await (const ev of deps.handleTurnStream(turn)) {
+        if (phase === 'closed') return;
+        if (SURFACE_EVENT_TYPES.has(ev.type)) {
+          send(ev); // forward the surface_* event 1:1
+        } else if (ev.type === 'text_delta') {
+          send({ type: 'agent_text_delta', forTurn: turnId, text: ev.text });
+        } else if (ev.type === 'error') {
+          // A mid-stream error terminates the turn — `turn_error` instead of,
+          // not in addition to, `turn_complete`.
+          send({ type: 'turn_error', forTurn: turnId, message: ev.message });
+          terminated = true;
+          break;
+        }
+        // iteration_start / tool_* / sub_* / verifier / turn_annotation are
+        // internal orchestrator telemetry — not part of the canvas wire.
+      }
+      if (!terminated && phase !== 'closed') {
+        send({ type: 'turn_complete', forTurn: turnId });
+      }
+    } catch (err) {
+      send({
+        type: 'turn_error',
+        forTurn: turnId,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  function formIncomingTurn(msg: ClientTurn, turnId: string): IncomingTurn {
+    const turn: IncomingTurn = {
+      channelId: deps.channelId,
+      // SECURITY: the orchestrator scope is `${channelId}::${conversationId}`
+      // and is NOT user-scoped by the core, so the client-supplied
+      // canvasSessionId is namespaced under the authenticated subject. Without
+      // this, user A supplying user B's canvasSessionId would join B's canvas
+      // memory scope. The raw client id stays in metadata + the handshake ack.
+      conversationId: `${session.subject}::${canvasSessionId}`,
+      userRef: {
+        kind: 'custom',
+        id: session.subject,
+        ...(session.displayName ? { displayName: session.displayName } : {}),
+        ...(session.email ? { email: session.email } : {}),
+      },
+      text: typeof msg.text === 'string' ? msg.text : '',
+      metadata: {
+        canvasSessionId,
+        turnId,
+        provider: session.provider,
+        ...(session.omadiaUserId ? { omadiaUserId: session.omadiaUserId } : {}),
+      },
+    };
+    // tenantId: populate when the host published one; otherwise leave unset so
+    // the core call-site defaults it to 'default' (single-tenant v1). Real
+    // multi-tenant derivation (per host / per session) is a later slice.
+    if (deps.tenantId) turn.tenantId = deps.tenantId;
+    // Shape already guarded by validateTurnInput; full whitelist is Tier 2's.
+    if (msg.target !== undefined) turn.target = msg.target as TargetRef;
+    if (msg.viewState !== undefined) {
+      turn.viewState = msg.viewState as CanvasViewState;
+    }
+    if (msg.viewStateTruncated === true) turn.viewStateTruncated = true;
+    return turn;
+  }
+}

--- a/middleware/packages/omadia-ui-channel/src/index.ts
+++ b/middleware/packages/omadia-ui-channel/src/index.ts
@@ -4,4 +4,10 @@ export {
   CANVAS_PROTOCOL_VERSION,
   OPS_CATALOG_VERSION,
   INFO_PATH,
+  CANVAS_PATH,
 } from './plugin.js';
+
+export {
+  handleCanvasSocket,
+  type CanvasConnectionDeps,
+} from './canvasConnection.js';

--- a/middleware/packages/omadia-ui-channel/src/plugin.ts
+++ b/middleware/packages/omadia-ui-channel/src/plugin.ts
@@ -1,22 +1,31 @@
+import { randomUUID } from 'node:crypto';
+
 import type { PluginContext } from '@omadia/plugin-api';
 import type { ChannelHandle, CoreApi } from '@omadia/channel-sdk';
 
+import { handleCanvasSocket } from './canvasConnection.js';
+
 /**
- * @omadia/ui-channel — Omadia UI Tier-1 server-side channel, skeleton (PR-10a).
+ * @omadia/ui-channel — Omadia UI Tier-1 server-side channel (PR-10b).
  *
  * `kind: channel`. The manifest declares the canvas surface — `capabilities:
  * [text, canvas]` and `dispatch_service: canvasChatAgent` — so a turn routes to
  * the omadia-ui-orchestrator (#168 dispatch + #171 canvasChatAgent).
  *
- * v0 registers a DISCOVERY endpoint that advertises the omadia-canvas-protocol
- * + ops-catalog versions and the channel's capabilities (what a client reads
- * before connecting). The bidirectional WebSocket transport — handshake
- * (offer→select→ack), turn intake (`IncomingTurn` forming), and `surface_*`
- * event fan-out — is DEFERRED: the {@link CoreApi} exposes only Express
- * route/router registration, not a WebSocket upgrade, so hosting the canvas
- * WebSocket needs a CoreApi SDK extension that the concept's SDK-changes list
- * omitted (documented as plan feed-back). The dispatch wiring
- * (`dispatch_service` → `canvasChatAgent`) is already validated by #168.
+ * Two surfaces:
+ *   - a pre-connect DISCOVERY route (`GET /omadia-ui/info`) advertising the
+ *     omadia-canvas-protocol + ops-catalog versions and capabilities (what a
+ *     client reads before connecting); and
+ *   - the bidirectional canvas WebSocket (`/omadia-ui/canvas`) over PR-11's
+ *     `CoreApi.registerWebSocket`: a server-initiated handshake
+ *     (`offer→select→ack`), `IncomingTurn` forming per client `turn`, and a 1:1
+ *     `surface_*` fan-out of the orchestrator stream. The connection logic lives
+ *     in {@link handleCanvasSocket}; the kernel authenticates each upgrade
+ *     before the handler runs.
+ *
+ * The WebSocket is feature-detected: if the kernel CoreApi has no
+ * `registerWebSocket` (no WS registry wired), the channel degrades to the
+ * discovery route only, inert and non-failing.
  */
 
 export const CANVAS_PROTOCOL_VERSION = '1.0';
@@ -25,11 +34,16 @@ export const OPS_CATALOG_VERSION = '1.0';
 /** Pre-connect discovery route — transport-agnostic capability advertisement. */
 export const INFO_PATH = '/omadia-ui/info';
 
+/** Bidirectional canvas WebSocket path (registered via CoreApi.registerWebSocket). */
+export const CANVAS_PATH = '/omadia-ui/canvas';
+
 export async function activate(
   ctx: PluginContext,
   core: CoreApi,
 ): Promise<ChannelHandle> {
-  ctx.log('activating omadia-ui-channel (skeleton)');
+  ctx.log('activating omadia-ui-channel');
+
+  const wsAvailable = typeof core.registerWebSocket === 'function';
 
   core.registerRoute(ctx.agentId, 'GET', INFO_PATH, (_req, res) => {
     res.json({
@@ -39,17 +53,43 @@ export async function activate(
       capabilities: ['text', 'canvas'],
       dispatchService: 'canvasChatAgent',
       transport: 'websocket',
-      websocket: 'not-yet-implemented',
+      websocket: wsAvailable ? CANVAS_PATH : 'unavailable',
     });
   });
-
   ctx.log(`[omadia-ui-channel] discovery endpoint at GET ${INFO_PATH}`);
+
+  // Bidirectional canvas transport. Feature-detected: present only when the
+  // kernel wired a WebSocket registry into the CoreApi (PR-11). The kernel
+  // authenticates each upgrade before this handler runs — `session` is the
+  // verified identity; each connection is one canvas.
+  if (wsAvailable) {
+    const tenantId = ctx.services.get<string>('graphTenantId');
+    core.registerWebSocket?.(ctx.agentId, CANVAS_PATH, (socket, session) => {
+      handleCanvasSocket(socket, session, {
+        channelId: ctx.agentId,
+        protocolVersions: [CANVAS_PROTOCOL_VERSION],
+        opsCatalogVersions: [OPS_CATALOG_VERSION],
+        handleTurnStream: (turn) => core.handleTurnStream(turn),
+        ...(tenantId ? { tenantId } : {}),
+        mintId: () => randomUUID(),
+        log: (msg) => {
+          ctx.log(msg);
+        },
+      });
+    });
+    ctx.log(`[omadia-ui-channel] canvas WebSocket at ${CANVAS_PATH}`);
+  } else {
+    ctx.log(
+      '[omadia-ui-channel] core has no registerWebSocket — canvas WS inactive (discovery route only)',
+    );
+  }
 
   return {
     async close(): Promise<void> {
       ctx.log('deactivating omadia-ui-channel');
-      // Channel-scoped routes are torn down by the kernel per channelId on
-      // deactivate (CoreApi.registerRoute contract) — nothing else to release.
+      // Channel-scoped routes AND WebSocket registrations are torn down by the
+      // kernel per channelId on deactivate (CoreApi contract) — the kernel also
+      // closes this channel's live canvas sockets. Nothing else to release.
     },
   };
 }

--- a/middleware/packages/omadia-ui-channel/src/protocol.ts
+++ b/middleware/packages/omadia-ui-channel/src/protocol.ts
@@ -1,0 +1,135 @@
+/**
+ * omadia-canvas-protocol/1.0 — the wire messages the Tier-1 server channel
+ * exchanges with the canvas client over the WebSocket.
+ *
+ *   server → client:  handshake_offer · handshake_error · handshake_ack,
+ *                     then the surface_* event family (forwarded 1:1 from
+ *                     Tier 2 — defined in @omadia/channel-sdk as
+ *                     SurfaceStreamEvent, NOT re-declared here) plus the
+ *                     agent_text_delta / turn_complete / turn_error envelopes
+ *                     that fold the non-surface stream events for the client.
+ *   client → server:  handshake_select, then `turn`.
+ *
+ * Only the channel-owned envelopes + the client-input messages live here; the
+ * versioned canvas tree / surface-event shapes are the SDK's.
+ *
+ * Orchestrator-internal stream events (`iteration_start`, `tool_use`,
+ * `tool_result`, `tool_progress`, `sub_*`, `verifier`, `turn_annotation`) are
+ * deliberately NOT forwarded — they are server telemetry, not canvas wire. Only
+ * `surface_*` (1:1), `text_delta` (→ `agent_text_delta`), and `error`
+ * (→ `turn_error`) cross to the client, terminated by `turn_complete`.
+ */
+
+// ───────────────────────── server → client ─────────────────────────
+
+export interface HandshakeOffer {
+  type: 'handshake_offer';
+  handshakeId: string;
+  protocolVersions: string[];
+  opsCatalogVersions: string[];
+  serverFeatures?: string[];
+}
+
+export type HandshakeErrorReason =
+  | 'protocol-version-unsupported'
+  | 'ops-catalog-version-unsupported'
+  | 'local-ops-incomplete';
+
+export interface HandshakeError {
+  type: 'handshake_error';
+  handshakeId: string;
+  reason: HandshakeErrorReason;
+  supported: { protocolVersions: string[]; opsCatalogVersions: string[] };
+}
+
+export interface HandshakeAck {
+  type: 'handshake_ack';
+  handshakeId: string;
+  /** the resolved canvas session id (client-supplied or server-minted) */
+  canvasSessionId: string;
+}
+
+/** A non-surface stream event (agent prose) folded for the canvas client. */
+export interface AgentTextDelta {
+  type: 'agent_text_delta';
+  forTurn: string;
+  text: string;
+}
+
+export interface TurnComplete {
+  type: 'turn_complete';
+  forTurn: string;
+}
+
+export interface TurnError {
+  type: 'turn_error';
+  forTurn?: string;
+  message: string;
+}
+
+// ───────────────────────── client → server ─────────────────────────
+
+export interface HandshakeSelect {
+  type: 'handshake_select';
+  handshakeId: string;
+  protocolVersion: string;
+  opsCatalogVersion: string;
+  clientFeatures?: string[];
+  /** the catalog ops this client actually implements (Tier-2 Class-B routing
+   *  truth). Not enforced for completeness in v1 — Tier 2 degrades gracefully. */
+  localOperations?: string[];
+  /** optional — the client persists this across reconnects to resume a canvas;
+   *  absent → the server mints one and returns it in handshake_ack. */
+  canvasSessionId?: string;
+}
+
+export interface ClientTurn {
+  type: 'turn';
+  /** optional client-supplied correlation id; the server mints one if absent */
+  turnId?: string;
+  text?: string;
+  /** a `TargetRef` (canvas/container/element/…); validated downstream by Tier 2. */
+  target?: unknown;
+  /** a `CanvasViewState`; passed through for referential continuity. */
+  viewState?: unknown;
+  viewStateTruncated?: boolean;
+}
+
+export type ClientMessage = HandshakeSelect | ClientTurn;
+
+/**
+ * The surface_* event types forwarded 1:1 to the canvas client — the runtime
+ * mirror of the SDK's `SurfaceStreamEvent` union. Forwarding is gated on this
+ * explicit set (not a `surface_` prefix) so an unknown / internal event can
+ * never masquerade as a protocol surface frame.
+ */
+export const SURFACE_EVENT_TYPES: ReadonlySet<string> = new Set([
+  'surface_snapshot',
+  'surface_patch',
+  'surface_data_ref_created',
+  'surface_data_ref_invalidated',
+  'surface_action_result',
+  'surface_local_action',
+  'surface_error',
+  'surface_mutation_resolved',
+]);
+
+/**
+ * Tolerant parse of a raw client frame. Returns null for non-JSON, non-object,
+ * or an unrecognised `type` — the connection drops those silently rather than
+ * trusting arbitrary input.
+ */
+export function parseClientMessage(raw: string): ClientMessage | null {
+  let obj: unknown;
+  try {
+    obj = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof obj !== 'object' || obj === null) return null;
+  const type = (obj as { type?: unknown }).type;
+  if (type === 'handshake_select' || type === 'turn') {
+    return obj as ClientMessage;
+  }
+  return null;
+}

--- a/middleware/test/uiChannelWebSocket.test.ts
+++ b/middleware/test/uiChannelWebSocket.test.ts
@@ -1,0 +1,359 @@
+/**
+ * PR-10b — the omadia-ui-channel canvas WebSocket transport.
+ *
+ * Drives `handleCanvasSocket` with a mock ChannelSocket + mock handleTurnStream
+ * (no live socket — PR-11's WebSocketRegistry test owns the real-socket path):
+ *   - server-initiated handshake_offer on connect;
+ *   - handshake_select (matching versions) → handshake_ack with the resolved
+ *     canvasSessionId (client-supplied id is honoured);
+ *   - version mismatch → handshake_error, and a second mismatch closes;
+ *   - after ack, a `turn` forms a well-shaped IncomingTurn and the orchestrator
+ *     stream fans out — surface_* 1:1, text_delta → agent_text_delta, then
+ *     turn_complete.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type {
+  ChannelSessionClaims,
+  ChannelSocket,
+  ChatStreamEvent,
+  IncomingTurn,
+} from '../packages/harness-channel-sdk/src/index.js';
+import { handleCanvasSocket } from '../packages/omadia-ui-channel/src/canvasConnection.js';
+
+const SESSION: ChannelSessionClaims = {
+  subject: 'u1',
+  email: 'u1@example.com',
+  displayName: 'User One',
+  provider: 'local',
+};
+
+interface SentFrame {
+  type: string;
+  [k: string]: unknown;
+}
+
+function makeSocket(): {
+  socket: ChannelSocket;
+  sent: SentFrame[];
+  client: (m: unknown) => void;
+  closed: () => { code?: number; reason?: string } | null;
+} {
+  const sent: SentFrame[] = [];
+  let onMsg: (raw: string) => void = () => {};
+  let onClose: () => void = () => {};
+  let closeInfo: { code?: number; reason?: string } | null = null;
+  const socket: ChannelSocket = {
+    send: (data: string) => {
+      sent.push(JSON.parse(data) as SentFrame);
+    },
+    onMessage: (cb: (data: string) => void) => {
+      onMsg = cb;
+    },
+    onClose: (cb: () => void) => {
+      onClose = cb;
+    },
+    close: (code?: number, reason?: string) => {
+      closeInfo = { code, reason };
+      onClose();
+    },
+    request: { url: '/omadia-ui/canvas', headers: {} },
+  };
+  return {
+    socket,
+    sent,
+    client: (m: unknown) => {
+      onMsg(JSON.stringify(m));
+    },
+    closed: () => closeInfo,
+  };
+}
+
+/** Deterministic id minter: id-1, id-2, … */
+function idMinter(): () => string {
+  let n = 0;
+  return () => `id-${(n += 1)}`;
+}
+
+const flush = (): Promise<void> =>
+  new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+
+function emptyStream(): AsyncIterable<ChatStreamEvent> {
+  return (async function* () {
+    await Promise.resolve();
+  })();
+}
+
+describe('omadia-ui-channel canvas WebSocket — handshake', () => {
+  it('sends a handshake_offer on connect', () => {
+    const m = makeSocket();
+    handleCanvasSocket(m.socket, SESSION, {
+      channelId: '@omadia/ui-channel',
+      protocolVersions: ['1.0'],
+      opsCatalogVersions: ['1.0'],
+      handleTurnStream: () => emptyStream(),
+      mintId: idMinter(),
+    });
+    assert.equal(m.sent.length, 1);
+    assert.equal(m.sent[0]?.type, 'handshake_offer');
+    assert.deepEqual(m.sent[0]?.protocolVersions, ['1.0']);
+    assert.deepEqual(m.sent[0]?.opsCatalogVersions, ['1.0']);
+  });
+
+  it('acks a matching select and honours a client-supplied canvasSessionId', () => {
+    const m = makeSocket();
+    handleCanvasSocket(m.socket, SESSION, {
+      channelId: '@omadia/ui-channel',
+      protocolVersions: ['1.0'],
+      opsCatalogVersions: ['1.0'],
+      handleTurnStream: () => emptyStream(),
+      mintId: idMinter(),
+    });
+    const offer = m.sent[0] as SentFrame;
+    m.client({
+      type: 'handshake_select',
+      handshakeId: offer.handshakeId,
+      protocolVersion: '1.0',
+      opsCatalogVersion: '1.0',
+      canvasSessionId: 'canvas-abc',
+    });
+    const ack = m.sent.find((f) => f.type === 'handshake_ack');
+    assert.ok(ack, 'handshake_ack sent');
+    assert.equal(ack?.canvasSessionId, 'canvas-abc');
+  });
+
+  it('rejects a version mismatch and closes after a second mismatch', () => {
+    const m = makeSocket();
+    handleCanvasSocket(m.socket, SESSION, {
+      channelId: '@omadia/ui-channel',
+      protocolVersions: ['1.0'],
+      opsCatalogVersions: ['1.0'],
+      handleTurnStream: () => emptyStream(),
+      mintId: idMinter(),
+    });
+    const hid = (m.sent[0] as SentFrame).handshakeId as string;
+    m.client({
+      type: 'handshake_select',
+      handshakeId: hid,
+      protocolVersion: '9.9',
+      opsCatalogVersion: '1.0',
+    });
+    const err = m.sent.find((f) => f.type === 'handshake_error');
+    assert.ok(err, 'handshake_error sent');
+    assert.equal(err?.reason, 'protocol-version-unsupported');
+    assert.equal(m.closed(), null, 'not closed after first mismatch (downgrade chance)');
+    // second mismatch → close
+    m.client({
+      type: 'handshake_select',
+      handshakeId: hid,
+      protocolVersion: '9.9',
+      opsCatalogVersion: '1.0',
+    });
+    assert.ok(m.closed(), 'closed after the second mismatch');
+  });
+
+  it('accepts a valid select after a first version mismatch (downgrade)', () => {
+    const m = makeSocket();
+    handleCanvasSocket(m.socket, SESSION, {
+      channelId: '@omadia/ui-channel',
+      protocolVersions: ['1.0'],
+      opsCatalogVersions: ['1.0'],
+      handleTurnStream: () => emptyStream(),
+      mintId: idMinter(),
+    });
+    const hid = (m.sent[0] as SentFrame).handshakeId as string;
+    m.client({
+      type: 'handshake_select',
+      handshakeId: hid,
+      protocolVersion: '9.9',
+      opsCatalogVersion: '1.0',
+    });
+    assert.ok(m.sent.find((f) => f.type === 'handshake_error'), 'first mismatch errored');
+    m.client({
+      type: 'handshake_select',
+      handshakeId: hid,
+      protocolVersion: '1.0',
+      opsCatalogVersion: '1.0',
+      canvasSessionId: 'cs1',
+    });
+    const ack = m.sent.find((f) => f.type === 'handshake_ack');
+    assert.ok(ack, 'downgraded select acked');
+    assert.equal(ack?.canvasSessionId, 'cs1');
+    assert.equal(m.closed(), null, 'not closed');
+  });
+
+  it('ignores a select carrying a mismatched handshakeId', () => {
+    const m = makeSocket();
+    handleCanvasSocket(m.socket, SESSION, {
+      channelId: '@omadia/ui-channel',
+      protocolVersions: ['1.0'],
+      opsCatalogVersions: ['1.0'],
+      handleTurnStream: () => emptyStream(),
+      mintId: idMinter(),
+    });
+    m.client({
+      type: 'handshake_select',
+      handshakeId: 'bogus',
+      protocolVersion: '1.0',
+      opsCatalogVersion: '1.0',
+    });
+    assert.equal(m.sent.length, 1, 'only the offer — mismatched-handshakeId select ignored');
+  });
+});
+
+describe('omadia-ui-channel canvas WebSocket — turn fan-out', () => {
+  it('forms an IncomingTurn and fans out surface_* + text_delta + turn_complete', async () => {
+    const m = makeSocket();
+    let captured: IncomingTurn | undefined;
+    const stream = (turn: IncomingTurn): AsyncIterable<ChatStreamEvent> => {
+      captured = turn;
+      return (async function* () {
+        await Promise.resolve();
+        yield {
+          type: 'surface_snapshot',
+          canvasSessionId: 'canvas-abc',
+          surfaceSeq: 1,
+          producesRevision: '1',
+          tree: { type: 'p_text' },
+          protocolVersion: '1.0',
+          opsCatalogVersion: '1.0',
+        } as unknown as ChatStreamEvent;
+        yield { type: 'text_delta', text: 'hello' } as ChatStreamEvent;
+      })();
+    };
+
+    handleCanvasSocket(m.socket, SESSION, {
+      channelId: '@omadia/ui-channel',
+      protocolVersions: ['1.0'],
+      opsCatalogVersions: ['1.0'],
+      handleTurnStream: stream,
+      tenantId: 'acme',
+      mintId: idMinter(),
+    });
+    const offer = m.sent[0] as SentFrame;
+    m.client({
+      type: 'handshake_select',
+      handshakeId: offer.handshakeId,
+      protocolVersion: '1.0',
+      opsCatalogVersion: '1.0',
+      canvasSessionId: 'canvas-abc',
+    });
+    m.client({ type: 'turn', turnId: 't1', text: 'draw me a table' });
+    await flush();
+    await flush();
+
+    // IncomingTurn shape
+    assert.ok(captured, 'handleTurnStream was called');
+    assert.equal(captured?.channelId, '@omadia/ui-channel');
+    // conversationId is namespaced under the authenticated subject (cross-user
+    // scope isolation); the raw client canvasSessionId stays in metadata.
+    assert.equal(captured?.conversationId, 'u1::canvas-abc');
+    assert.equal(
+      (captured?.metadata as Record<string, unknown> | undefined)?.canvasSessionId,
+      'canvas-abc',
+    );
+    assert.equal(captured?.text, 'draw me a table');
+    assert.equal(captured?.tenantId, 'acme');
+    assert.equal(captured?.userRef.kind, 'custom');
+    assert.equal(captured?.userRef.id, 'u1');
+
+    // fan-out
+    const snapshot = m.sent.find((f) => f.type === 'surface_snapshot');
+    assert.ok(snapshot, 'surface_snapshot forwarded 1:1');
+    assert.equal(snapshot?.surfaceSeq, 1);
+    const textDelta = m.sent.find((f) => f.type === 'agent_text_delta');
+    assert.ok(textDelta, 'text_delta folded to agent_text_delta');
+    assert.equal(textDelta?.forTurn, 't1');
+    assert.equal(textDelta?.text, 'hello');
+    const complete = m.sent.find((f) => f.type === 'turn_complete');
+    assert.ok(complete, 'turn_complete sent');
+    assert.equal(complete?.forTurn, 't1');
+  });
+
+  it('ignores a turn sent before the handshake completes', () => {
+    const m = makeSocket();
+    let called = false;
+    handleCanvasSocket(m.socket, SESSION, {
+      channelId: '@omadia/ui-channel',
+      protocolVersions: ['1.0'],
+      opsCatalogVersions: ['1.0'],
+      handleTurnStream: () => {
+        called = true;
+        return emptyStream();
+      },
+      mintId: idMinter(),
+    });
+    m.client({ type: 'turn', text: 'too early' });
+    assert.equal(called, false, 'no turn dispatched before handshake_ack');
+  });
+
+  it('drops orchestrator telemetry (iteration/tool) from the canvas wire', async () => {
+    const m = makeSocket();
+    const stream = (): AsyncIterable<ChatStreamEvent> =>
+      (async function* () {
+        await Promise.resolve();
+        yield { type: 'iteration_start', iteration: 1 } as ChatStreamEvent;
+        yield {
+          type: 'tool_use',
+          id: 't',
+          name: 'x',
+          input: {},
+        } as unknown as ChatStreamEvent;
+        yield { type: 'text_delta', text: 'hi' } as ChatStreamEvent;
+      })();
+    handleCanvasSocket(m.socket, SESSION, {
+      channelId: '@omadia/ui-channel',
+      protocolVersions: ['1.0'],
+      opsCatalogVersions: ['1.0'],
+      handleTurnStream: stream,
+      mintId: idMinter(),
+    });
+    const hid = (m.sent[0] as SentFrame).handshakeId as string;
+    m.client({
+      type: 'handshake_select',
+      handshakeId: hid,
+      protocolVersion: '1.0',
+      opsCatalogVersion: '1.0',
+      canvasSessionId: 'c',
+    });
+    m.client({ type: 'turn', turnId: 't1', text: 'go' });
+    await flush();
+    await flush();
+    const types = m.sent.map((f) => f.type);
+    assert.ok(!types.includes('iteration_start'), 'iteration_start not forwarded');
+    assert.ok(!types.includes('tool_use'), 'tool_use not forwarded');
+    assert.ok(types.includes('agent_text_delta'), 'text forwarded');
+    assert.ok(types.includes('turn_complete'), 'turn_complete sent');
+  });
+
+  it('rejects a turn with a malformed target (orchestrator not invoked)', () => {
+    const m = makeSocket();
+    let called = false;
+    handleCanvasSocket(m.socket, SESSION, {
+      channelId: '@omadia/ui-channel',
+      protocolVersions: ['1.0'],
+      opsCatalogVersions: ['1.0'],
+      handleTurnStream: () => {
+        called = true;
+        return emptyStream();
+      },
+      mintId: idMinter(),
+    });
+    const hid = (m.sent[0] as SentFrame).handshakeId as string;
+    m.client({
+      type: 'handshake_select',
+      handshakeId: hid,
+      protocolVersion: '1.0',
+      opsCatalogVersion: '1.0',
+      canvasSessionId: 'c',
+    });
+    m.client({ type: 'turn', turnId: 't1', text: 'go', target: 'not-an-object' });
+    const err = m.sent.find((f) => f.type === 'turn_error');
+    assert.ok(err, 'turn_error for malformed target');
+    assert.equal(called, false, 'orchestrator not invoked');
+  });
+});


### PR DESCRIPTION
## What

Turns the omadia-ui-channel skeleton (#173) into the **real Tier-1 canvas transport** on PR-11's `CoreApi.registerWebSocket` (#205). The agent can synthesise live UI over the canvas once Tier 2 emits `surface_*`.

Three new modules in `middleware/packages/omadia-ui-channel/src/`:

- **`protocol.ts`** — the channel's wire messages (server `handshake_offer`/`_error`/`_ack` + `agent_text_delta`/`turn_complete`/`turn_error`; client `handshake_select` + `turn`) + a tolerant `parseClientMessage` + the explicit `SURFACE_EVENT_TYPES` allow-set. `surface_*` shapes are the SDK's `SurfaceStreamEvent`, forwarded verbatim.
- **`canvasConnection.ts`** — `handleCanvasSocket(socket, session, deps)`, the per-connection state machine (DI-friendly, unit-tested without a live socket).
- **`plugin.ts`** — `activate` registers `/omadia-ui/canvas` via `core.registerWebSocket`, **feature-detected** (no WS registry → discovery route only, inert).

## Behaviour

- **Handshake:** server-initiated `offer`; on `select` it validates the echoed `handshakeId` + the versions (protocol **and** ops-catalog), mints/adopts a `canvasSessionId`, sends `ack`; a mismatch sends `handshake_error` with **one downgrade chance** before close.
- **Turn:** validates the client `target`/`viewState` shape, forms an `IncomingTurn`, fans `core.handleTurnStream` out — `surface_*` 1:1, `text_delta` → `agent_text_delta`, a mid-stream `error` **terminates** the turn, else `turn_complete`. Telemetry (`iteration_start`/`tool_*`/`verifier`/…) is dropped. Turns are **serialised per connection** so surface frames never interleave.

## Security

The kernel scopes the orchestrator turn as `${channelId}::${conversationId}` — **not** user-scoped. So the client-supplied `canvasSessionId` is **namespaced under the authenticated subject**: `conversationId = ${session.subject}::${canvasSessionId}`. Without this, user A supplying user B's `canvasSessionId` would join B's canvas memory scope. The raw client id stays in `metadata` + the `ack`. (This was the Codex review **BLOCKER**.)

## Verification

- `build` ✓ · `lint` ✓ · `typecheck` ✓ · full `test` suite ✓ (2881 pass, 0 fail).
- `test/uiChannelWebSocket.test.ts` (mock socket + mock stream): offer; matching select → ack with client `canvasSessionId`; version mismatch → error then close; downgrade-then-valid → ack; mismatched `handshakeId` ignored; turn → subject-namespaced `conversationId` + `surface_*`/`agent_text_delta`/`turn_complete` fan-out; telemetry dropped; malformed target → `turn_error`; pre-handshake turn dropped. The real-socket path is covered by PR-11's `webSocketRegistry.test.ts`.
- **Codex-reviewed:** 1 BLOCKER (cross-user `canvasSessionId` scope — fixed), 6 SHOULD-FIX (handshakeId validation, error-terminates-turn, turn serialisation, target/viewState shape-guard, explicit surface allow-set, telemetry docs+tests — all fixed), 1 rejected with rationale (`require-await` on interface-mandated async `activate`/`close` — lint is green). 2 NITs fixed.

## Scope

Additive; inert for every non-canvas channel. Per AGENTS.md, `docs/middleware-agent-handoff.md` updated in the same PR; no `Co-Authored-By` trailer. Unblocks the real Tier-2 canvas composition (PR-9b: UI Skill + `surface_*` synthesis).