### PR TITLE
refactor(builder): user-facing 'Veröffentlichen' → 'Bereitstellen' (i18n de, redo of #208)

### DIFF
--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -497,14 +497,14 @@
     },
     "workspace": {
       "backToDrafts": "Drafts",
-      "publish": "Veröffentlichen",
+      "publish": "Bereitstellen",
       "viewModeAriaLabel": "Ansicht wählen",
       "viewModeSimple": "Einfach",
       "viewModeExtended": "Erweitert",
       "viewModeSimpleTitle": "Geführte No-Code-Ansicht — beschreiben, ansehen, ausprobieren",
       "viewModeExtendedTitle": "Voller Builder — Spec, Slots, Quellcode, Build-Status",
       "statusDraft": "Entwurf",
-      "statusPublished": "Veröffentlicht",
+      "statusPublished": "Bereitgestellt",
       "statusArchived": "Archiviert",
       "tabOverview": "Übersicht",
       "tabSpec": "Spec",
@@ -714,7 +714,7 @@
           "connectionLost": "Verbindung verloren: {message}",
           "unknownTurn": "Unbekannter Fehler beim Preview-Turn"
         },
-        "externalReadsHint": "Preview führt Cross-Integration-Lookups (<code>spec.external_reads</code>) nicht aus — der Agent erkennt den fehlenden Service korrekt und wirft. Veröffentliche den Agent in den Plattform-Store, um den echten Datenpfad zu testen.",
+        "externalReadsHint": "Preview führt Cross-Integration-Lookups (<code>spec.external_reads</code>) nicht aus — der Agent erkennt den fehlenden Service korrekt und wirft. Stelle den Agent in deiner Instanz bereit, um den echten Datenpfad zu testen.",
         "agentStuck": {
           "title": "Builder-Agent kommt bei Slot {slot} nicht weiter ({attempts, plural, one {# Versuch} other {# Versuche}})",
           "body": "{summary}. Öffne den Slot-Editor, prüf die Errors manuell und korrigier den Code — der Agent versucht es nicht von alleine erneut.",
@@ -1110,16 +1110,16 @@
       "closeAria": "Schließen"
     },
     "install": {
-      "publishTitle": "Plugin veröffentlichen",
+      "publishTitle": "Plugin bereitstellen",
       "closeModalAria": "Modal schließen",
       "closeAria": "Schließen",
-      "diffGateEyebrow": "Veröffentlichungs-Diff-Gate",
-      "publishLeadPrefix": "Diese Surface wird in den Plugin-Store geschrieben. Nach „Veröffentlichen“ ist",
-      "publishLeadSuffix": "für alle Agents im Tenant verfügbar.",
+      "diffGateEyebrow": "Bereitstellungs-Diff-Gate",
+      "publishLeadPrefix": "Diese Surface wird in die Plugin-Registry deiner Instanz geschrieben. Nach „Bereitstellen“ ist",
+      "publishLeadSuffix": "für alle Agents in deinem Tenant verfügbar — nicht öffentlich.",
       "back": "Zurück",
-      "publishing": "Veröffentliche …",
+      "publishing": "Stelle bereit …",
       "succeeded": "Erfolgreich",
-      "publish": "Veröffentlichen",
+      "publish": "Bereitstellen",
       "sectionIdentity": "Identität",
       "kvId": "ID",
       "kvName": "Name",
@@ -1145,7 +1145,7 @@
       "sectionSetupFieldsSubtitle": "vom Operator beim Aktivieren auszufüllen",
       "noSetupNeeded": "Kein Setup nötig.",
       "required": "required",
-      "failureGenericHeading": "Veröffentlichung fehlgeschlagen",
+      "failureGenericHeading": "Bereitstellung fehlgeschlagen",
       "headingConflict": "Plugin-ID-Konflikt",
       "headingBuildFailed": "Build fehlgeschlagen (tsc)",
       "headingCodegenFailed": "Codegen fehlgeschlagen",
@@ -1161,12 +1161,12 @@
       "hintSpecInvalid": "Die Spec hat ein Schema-Problem. Prüfe Pflichtfelder im Spec-Editor.",
       "hintTooLarge": "Reduziere Slot-Inhalte oder Asset-Größen — der Server-Limit ist erreicht.",
       "bumpInvalidSemver": "Version '{version}' ist kein Semver — manuell anpassen im Spec-Editor.",
-      "bumpAndPublish": "Version anheben ({current} → {next}) + Veröffentlichen",
+      "bumpAndPublish": "Version anheben ({current} → {next}) + Bereitstellen",
       "retry": "Erneut versuchen",
       "typescriptErrors": "{count, plural, one {# TypeScript-Fehler} other {# TypeScript-Fehler}}",
       "codegenIssues": "{count, plural, one {# Codegen-Issue} other {# Codegen-Issues}}",
-      "successHeading": "Plugin veröffentlicht",
-      "successBody": "ist im Store sichtbar. Weiterleitung läuft …",
+      "successHeading": "Plugin bereitgestellt",
+      "successBody": "ist in deiner Instanz verfügbar. Weiterleitung läuft …",
       "conflictLabel": "Konflikt",
       "dismissConflictAria": "Konflikt-Hinweis ausblenden",
       "manifestPreviewOpenAria": "Manifest-Vorschau öffnen",
@@ -1192,13 +1192,13 @@
         "lede": "Lege Drafts an, iteriere parallel an mehreren Agents und installiere sie per Klick in die Plattform. Jeder Draft lebt in deinem persönlichen Arbeitsbereich — keiner sieht deine Entwürfe außer dir.",
         "scope": {
           "draft": "Entwurf",
-          "published": "Veröffentlicht",
+          "published": "Bereitgestellt",
           "deleted": "Gelöscht"
         },
         "scopeFilterLabel": "Bereichsfilter",
         "stats": {
           "drafts": "Entwürfe",
-          "published": "Veröffentlicht",
+          "published": "Bereitgestellt",
           "deleted": "Gelöscht",
           "limit": "Limit"
         },
@@ -1208,8 +1208,8 @@
             "hint": "Klicke rechts oben auf „Neuer Agent\" um deinen ersten Entwurf anzulegen."
           },
           "published": {
-            "headline": "Noch nichts veröffentlicht.",
-            "hint": "Veröffentlichte Agents erscheinen hier, sobald du einen Entwurf über den Workspace in die Plattform gepackt hast."
+            "headline": "Noch nichts bereitgestellt.",
+            "hint": "Bereitgestellte Agents erscheinen hier, sobald du einen Entwurf über den Workspace in deiner Instanz bereitgestellt hast."
           },
           "deleted": {
             "headline": "Papierkorb ist leer.",
@@ -1236,7 +1236,7 @@
       "row": {
         "status": {
           "draft": "Entwurf",
-          "published": "Veröffentlicht",
+          "published": "Bereitgestellt",
           "archived": "Archiviert"
         },
         "save": "Speichern",


### PR DESCRIPTION
## Background

Redo of #208. The previous two passes (#98, #112) renamed "Installieren" → "Veröffentlichen". #208 then renamed "Veröffentlichen" → "Bereitstellen" — but it edited **hardcoded TSX strings**, and `main` has since been refactored to **next-intl**: the builder UI now reads its German wording from `web-ui/messages/de.json`. #208's diff no longer applies.

This PR lands the exact same user-facing rename as **translation-value edits** in `de.json`, against the post-refactor `main`.

## Why "Bereitstellen"

With a public agent/plugin marketplace on the roadmap, "veröffentlichen" wrongly implies the agent is exposed there. It isn't — the flow only adds the agent to the **operator's own tenant registry**. "Bereitstellen" / "Bereitgestellt" (≈ "Deploy"/"Deployed") is neutral and technically clear.

## Scope

`builder.*` namespaces only (`workspace`, `install`, `drafts`):

- **workspace**: header CTA `publish`, `statusPublished`
- **install**: `publishTitle`, `diffGateEyebrow`, `publishLeadPrefix` (now "Plugin-Registry deiner Instanz"), `publishLeadSuffix` (now "in deinem Tenant verfügbar — nicht öffentlich"), `publishing`, `publish`, `failureGenericHeading`, `bumpAndPublish`, `successHeading`, `successBody` ("in deiner Instanz verfügbar")
- **drafts**: `scope.published`, `stats.published`, `empty.published.headline` + `hint`, `row.status.published`
- **preview**: `externalReadsHint`

## Not touched (intentional)

- `/store` & `/store/[id]` plugin-detail strings — separate concept (`plugin.install_state`), as in #208
- Internal `'published'` DB/API/enum/route value stays
- **Keys & ICU placeholders unchanged** — only German values. `en.json` (Publish → future "Deploy"/"Deployed") left for the i18n-managed English pass.

## Verification

- `web-ui` typecheck: 0 errors
- `i18n-parity.test.ts`: 4/4 pass (locale key-parity preserved)

Closes #208.
