### PR TITLE
fix(ci): set git identity before annotated release tag

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -70,6 +70,10 @@ jobs:
           fi
 
           echo "Releasing $new (bump=$bump)"
+          # Annotated tags need a committer identity; the runner has none.
+          # Use the GitHub Actions bot so the tagger is attributable.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$new" -m "omadia $new"
           git push origin "$new"
           gh release create "$new" --generate-notes --title "omadia $new" --latest


### PR DESCRIPTION
## Problem

The `auto-release` workflow fails on every run at **"Compute bump, tag, and release"**:

```
Releasing v0.2.1 (bump=patch)
Committer identity unknown
*** Please tell me who you are.
fatal: empty ident name (for <runner@...>) not allowed
Error: Process completed with exit code 128.
```

`git tag -a "$new" -m "omadia $new"` creates an **annotated** tag, which requires a committer identity. The runner has none configured, so tagging aborts — and since the tag is the version of record, **no release can ship**.

## Fix

Set the standard `github-actions[bot]` identity immediately before the tag is created:

```sh
git config user.name "github-actions[bot]"
git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
```

Scoped to the repo (no `--global`), placed after the "already exists" guard so it only runs when a release is actually being cut.

## Notes

- `release.yml` is intentionally fully commented-out (manual), so it needs no change.
- No bump-logic / permissions changes — `GITHUB_TOKEN` with `contents: write` already covers tag push + release creation.
