### PR TITLE
fix(knowledge-graph): survive first-boot Postgres race instead of crash-looping

### DIFF
--- a/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
+++ b/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
@@ -163,6 +163,90 @@ export function createNeonPool(connectionString: string, poolMax = 5): Pool {
 }
 
 /**
+ * Connection-level failures that mean Postgres is *not yet reachable* — as
+ * opposed to a permanent misconfiguration (bad credentials, missing
+ * database). During a `docker compose up` the middleware regularly wins the
+ * start race against Postgres' DNS-alias registration on the shared network,
+ * so the very first connection surfaces a transient
+ * `getaddrinfo ENOTFOUND postgres` even though the service is healthy a
+ * moment later. These are worth retrying; auth/db-existence errors are not.
+ */
+const TRANSIENT_DB_ERROR_CODES = new Set<string>([
+  'ENOTFOUND', // DNS name not yet resolvable
+  'EAI_AGAIN', // DNS temporary failure
+  'ECONNREFUSED', // server not yet accepting connections
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  '57P03', // cannot_connect_now — server is starting up
+]);
+
+function isTransientDbError(err: unknown): boolean {
+  const code = (err as { code?: unknown } | null)?.code;
+  if (typeof code === 'string' && TRANSIENT_DB_ERROR_CODES.has(code)) {
+    return true;
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  return /ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ECONNRESET|ETIMEDOUT|EHOSTUNREACH|ENETUNREACH|getaddrinfo|Connection terminated|the database system is starting up/i.test(
+    msg,
+  );
+}
+
+/**
+ * Pings the pool until it answers `SELECT 1`, retrying transient connection
+ * failures with capped exponential backoff. Bounded by `budgetMs` so the
+ * whole wait stays well within the tool-runtime's 10s `activate()` timeout —
+ * leaving headroom for the migrations that run right after.
+ *
+ * Why this exists: without it, the first-boot Postgres-startup race latches
+ * the knowledge-graph plugin into a permanent `errored` state (the kernel
+ * treats the KG service as required and hard-fatals when it is missing,
+ * producing an unrecoverable crash-loop). A short readiness wait rides out
+ * the race so the common case never errors. Genuinely unreachable Postgres
+ * still throws after the budget — the registry circuit-breaker + the
+ * transient-error auto-reset in `retryErroredPlugins` then handle recovery
+ * on subsequent boots.
+ */
+export async function waitForPostgres(
+  pool: Pool,
+  opts: { budgetMs?: number; log?: (msg: string) => void } = {},
+): Promise<void> {
+  const budgetMs = opts.budgetMs ?? 6_000;
+  const log = opts.log ?? (() => {});
+  const deadline = Date.now() + budgetMs;
+  let delayMs = 250;
+  let attempt = 0;
+
+  for (;;) {
+    attempt += 1;
+    try {
+      const client = await pool.connect();
+      try {
+        await client.query('SELECT 1');
+      } finally {
+        client.release();
+      }
+      if (attempt > 1) {
+        log(
+          `[harness-knowledge-graph-neon] postgres reachable after ${String(attempt)} attempt(s)`,
+        );
+      }
+      return;
+    } catch (err) {
+      const remaining = deadline - Date.now();
+      if (!isTransientDbError(err) || remaining <= 0) throw err;
+      const wait = Math.min(delayMs, remaining);
+      log(
+        `[harness-knowledge-graph-neon] postgres not ready (${err instanceof Error ? err.message : String(err)}) — retry in ${String(wait)}ms`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, wait));
+      delayMs = Math.min(delayMs * 2, 2_000);
+    }
+  }
+}
+
+/**
  * Postgres-backed knowledge graph (Neon serverless).
  *
  * Identity model: every node has a stable `external_id` (session:<scope>,

--- a/middleware/packages/harness-knowledge-graph-neon/src/plugin.ts
+++ b/middleware/packages/harness-knowledge-graph-neon/src/plugin.ts
@@ -3,7 +3,11 @@ import { EntityRefBus } from '@omadia/plugin-api';
 import type { EmbeddingClient } from '@omadia/embeddings';
 import type { Pool } from 'pg';
 
-import { NeonKnowledgeGraph, createNeonPool } from './neonKnowledgeGraph.js';
+import {
+  NeonKnowledgeGraph,
+  createNeonPool,
+  waitForPostgres,
+} from './neonKnowledgeGraph.js';
 import { runGraphMigrations } from './migrator.js';
 import {
   startEmbeddingBackfill,
@@ -136,6 +140,13 @@ export async function activate(
     'default';
 
   const graphPool: Pool = createNeonPool(databaseUrl);
+  // Ride out the first-boot Postgres-startup race (e.g. `docker compose up`,
+  // where the DNS alias for the `postgres` service can lag the middleware's
+  // first connection by a second or two). Without this a transient
+  // `getaddrinfo ENOTFOUND` would fail activate(), and since the kernel
+  // treats knowledgeGraph as a required service the whole middleware
+  // crash-loops. Bounded to stay inside the 10s activate() timeout.
+  await waitForPostgres(graphPool, { log: (msg) => { ctx.log(msg); } });
   await runGraphMigrations(graphPool, (msg) => { console.log(msg); });
 
   // OB-73 (Phase 4 / Slice B) — read-path access tracker. Reads queue

--- a/middleware/src/plugins/bootstrap.ts
+++ b/middleware/src/plugins/bootstrap.ts
@@ -118,6 +118,9 @@ export async function retryErroredPlugins(
     const capReason = maybeCapResolutionReason(deps, entry);
     if (capReason) reasons.push(capReason);
 
+    const transientReason = maybeTransientErrorReason(entry);
+    if (transientReason) reasons.push(transientReason);
+
     if (reasons.length === 0) continue;
 
     try {
@@ -150,6 +153,30 @@ async function maybeMtimeReason(
   } catch {
     // Missing manifest — stay stuck. Operator may have removed the
     // package entirely; unrelated cleanup will surface that.
+  }
+  return null;
+}
+
+// Connection-level failure fingerprints. A plugin that errored because an
+// infra dependency (Postgres, Ollama, …) was momentarily unreachable is
+// self-healing: once the dependency is up, the next boot should re-attempt
+// activation rather than leave the entry latched in `errored`. This matters
+// most for REQUIRED built-ins like the knowledge-graph provider — the kernel
+// hard-fatals when its service is missing, so a permanently-errored KG turns
+// a transient `docker compose up` race into an unrecoverable crash-loop.
+//
+// Worst case (a non-transient error that happens to match): the entry is
+// reset and re-attempted once per boot, re-tripping the circuit breaker —
+// no worse than the pre-existing crash-loop, and it recovers the instant the
+// dependency comes back.
+const TRANSIENT_ACTIVATION_ERROR_RE =
+  /ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ECONNRESET|ETIMEDOUT|EHOSTUNREACH|ENETUNREACH|getaddrinfo|Connection terminated|connection refused|the database system is starting up|timed out/i;
+
+function maybeTransientErrorReason(entry: InstalledAgent): string | null {
+  const err = entry.last_activation_error;
+  if (!err) return null;
+  if (TRANSIENT_ACTIVATION_ERROR_RE.test(err)) {
+    return `last_activation_error looks transient (infra dependency unreachable): "${err}"`;
   }
   return null;
 }

--- a/middleware/test/bootstrap.test.ts
+++ b/middleware/test/bootstrap.test.ts
@@ -323,6 +323,75 @@ describe('retryErroredPlugins — capability-resolution path', () => {
   });
 });
 
+describe('retryErroredPlugins — transient-error path', () => {
+  function erroredWithMessage(id: string, message: string): InstalledAgent {
+    return {
+      id,
+      installed_version: '0.1.0',
+      installed_at: '2026-04-20T00:00:00Z',
+      status: 'errored',
+      config: {},
+      activation_failure_count: 3,
+      last_activation_error: message,
+      last_activation_error_at: '2026-04-29T05:00:00Z',
+    };
+  }
+
+  it('resets when last_activation_error is a transient DNS failure (KG provider crash-loop recovery)', async () => {
+    const reg = new InMemoryInstalledRegistry();
+    await reg.register(
+      erroredWithMessage(
+        '@omadia/knowledge-graph-neon',
+        'getaddrinfo ENOTFOUND postgres',
+      ),
+    );
+    const cat = makeCatalog([
+      {
+        id: '@omadia/knowledge-graph-neon',
+        provides: [],
+        requires: [],
+        depends_on: [],
+      },
+    ]);
+
+    await retryErroredPlugins({ catalog: cat, registry: reg, log: () => {} });
+
+    const got = reg.get('@omadia/knowledge-graph-neon');
+    assert.equal(got?.status, 'active');
+    assert.equal(got?.last_activation_error, undefined);
+    assert.equal(got?.activation_failure_count, undefined);
+  });
+
+  it('resets on ECONNREFUSED / "Connection terminated" as well', async () => {
+    const reg = new InMemoryInstalledRegistry();
+    await reg.register(erroredWithMessage('a', 'connect ECONNREFUSED 10.0.0.5:5432'));
+    await reg.register(erroredWithMessage('b', 'Connection terminated unexpectedly'));
+    const cat = makeCatalog([
+      { id: 'a', provides: [], requires: [], depends_on: [] },
+      { id: 'b', provides: [], requires: [], depends_on: [] },
+    ]);
+
+    await retryErroredPlugins({ catalog: cat, registry: reg, log: () => {} });
+
+    assert.equal(reg.get('a')?.status, 'active');
+    assert.equal(reg.get('b')?.status, 'active');
+  });
+
+  it('does NOT reset a non-transient (code/config) error', async () => {
+    const reg = new InMemoryInstalledRegistry();
+    await reg.register(
+      erroredWithMessage('p1', 'TypeError: cannot read properties of undefined'),
+    );
+    const cat = makeCatalog([
+      { id: 'p1', provides: [], requires: [], depends_on: [] },
+    ]);
+
+    await retryErroredPlugins({ catalog: cat, registry: reg, log: () => {} });
+
+    assert.equal(reg.get('p1')?.status, 'errored');
+  });
+});
+
 describe('bootstrapMemoryFromEnv — env→config reconcile', () => {
   // The `bootstrap` flow originally wrote `dev_memory_endpoints_enabled`
   // into the @omadia/memory plugin's config exactly once (on first ever


### PR DESCRIPTION
## Problem

Running the image directly (`docker compose up`) crash-loops the middleware with:

```
[tool-runtime] activate FAILED for @omadia/knowledge-graph-neon: getaddrinfo ENOTFOUND postgres
[middleware] fatal startup error: knowledgeGraph service missing after tool-plugin activation
```

Root cause is a **first-boot race + sticky errored-state**:

1. On the very first `compose up`, Postgres' `postgres` DNS alias can lag the middleware's first connection by a second or two → KG-neon `activate()` (which opens its first connection in `runGraphMigrations`) fails with a transient `getaddrinfo ENOTFOUND`.
2. After 3 failures the registry circuit-breaker latches the entry to `status: errored` in `/data/installed.json`. Errored plugins are skipped on every subsequent boot — `retryErroredPlugins` did not cover transient infra failures.
3. The kernel treats `knowledgeGraph` as a **required** built-in and hard-fatals when its service is missing → unrecoverable crash-loop, even after Postgres is healthy.

## Fix (two complementary layers)

- **`waitForPostgres()`** (`harness-knowledge-graph-neon`): pings the pool (`SELECT 1`) with capped exponential backoff before running migrations, bounded to stay inside the tool-runtime's 10s `activate()` timeout. Rides out the common sub-10s race so the happy path never errors. Auth / missing-database errors still throw immediately.
- **Transient-error reset in `retryErroredPlugins()`** (`bootstrap.ts`): errored entries whose `last_activation_error` matches a transient infra fingerprint (`ENOTFOUND`/`ECONNREFUSED`/`ETIMEDOUT`/`Connection terminated`/…) are reset on each boot, so the crash-loop self-heals once the dependency is reachable instead of latching forever. This also recovers an already-stuck data volume on the next boot.

## Tests

`middleware/test/bootstrap.test.ts` — new `retryErroredPlugins — transient-error path` block (DNS / ECONNREFUSED / "Connection terminated" reset; non-transient code/config errors are NOT reset). Suite: 16/16 pass. neon package + middleware `src` typecheck clean; eslint clean.