### PR TITLE
fix(builder): raise report_platform_issue summary cap 280→500

### DIFF
--- a/middleware/src/plugins/builder/tools/reportPlatformIssue.ts
+++ b/middleware/src/plugins/builder/tools/reportPlatformIssue.ts
@@ -41,8 +41,18 @@ const InputSchema = z
     title: z.string().min(8).max(180),
     body: z.string().min(1).max(200_000),
     fingerprint: z.string().min(8).max(64),
-    /** Human-readable one-liner ("Workaround removed double-encoding"). */
-    summary: z.string().min(1).max(280),
+    /**
+     * Human-readable headline ("Workaround removed double-encoding").
+     * Internal triage-log label only — not the GitHub issue title (that
+     * is `title`). Capped at 500 chars so a full sentence fits without
+     * hard-failing the report; the `.describe()` surfaces the cap into
+     * the tool's JSON schema so the agent generates a compliant value.
+     */
+    summary: z
+      .string()
+      .min(1)
+      .max(500)
+      .describe('One-line headline for the triage log (≤500 chars, keep it concise).'),
     severity: z.enum(['bug', 'gap', 'inconsistency']),
   })
   .strict();

--- a/middleware/test/builder/reportPlatformIssueTool.test.ts
+++ b/middleware/test/builder/reportPlatformIssueTool.test.ts
@@ -166,6 +166,28 @@ describe('reportPlatformIssueTool', () => {
     assert.match(result.sanitizedBody ?? '', /\[REDACTED:internal-url\]/);
   });
 
+  it('input schema accepts a summary longer than the old 280-char cap (regression)', () => {
+    // The agent realistically generates a full-sentence summary. The
+    // previous max(280) rejected anything longer with a Zod too_big,
+    // which crashed the report tool (see omadia_report_core_bug).
+    const longSummary = 'Builder-Surface: '.padEnd(300, 'x');
+    assert.ok(longSummary.length > 280 && longSummary.length <= 500);
+    const input = {
+      title: 'Builder surface lacks codegen observability',
+      body: 'Repro details.',
+      fingerprint: 'observ1234',
+      summary: longSummary,
+      severity: 'gap' as const,
+    };
+    // Parses cleanly now; would have thrown a too_big ZodError before.
+    const parsed = reportPlatformIssueTool.input.parse(input);
+    assert.equal(parsed.summary, longSummary);
+    // Still enforces an upper bound — 501 chars is rejected.
+    assert.throws(() =>
+      reportPlatformIssueTool.input.parse({ ...input, summary: 'x'.repeat(501) }),
+    );
+  });
+
   it('returns mode=created-pending (sanitized, no GitHub URL) and emits issue_report_pending', async () => {
     const fetch: CacheFetch = () =>
       Promise.resolve(mockResponse({ status: 200, body: { items: [] } }));


### PR DESCRIPTION
## Problem

The GitHub reporter (`omadia_report_core_bug`) crashed: the Builder agent's call to `report_platform_issue` failed with a hard Zod `too_big` error because the `summary` field was capped at **≤280 chars**. The agent generated a longer summary → validation threw → the operator could not file the issue at all.

```
{ "code": "too_big", "maximum": 280, "path": ["summary"],
  "message": "Too big: expected string to have ≤280 characters" }
```

## Why 280 was wrong

`summary` is an **internal** triage-log / UI label (`platformIssueTriage.ts`, builder UI event). It **never reaches the GitHub issue** — only `title` (max 180, under GitHub's 256) and `body` go to GitHub. So 280 was an arbitrary tweet-length cap, not a technical bound. The agent also had no way to know the limit because the field carried no `.describe()` in the tool's JSON schema.

## Fix

- Raise `summary` cap **280 → 500** so a full sentence fits without hard-failing the report.
- Add `.describe(...)` so the cap is surfaced to the agent.
- `title` / `body` limits left untouched (those genuinely guard the GitHub-bound + URL-encoded values).

## Tests

- New regression test: schema accepts a 300-char summary, still rejects 501.
- Full `reportPlatformIssueTool` suite: **9/9 green**. ESLint clean, `tsc --noEmit` clean.