### PR TITLE
fix(web-ui): survive stale/foreign chat-session shapes instead of a blank crash

### DIFF
--- a/web-ui/app/_lib/__tests__/chatSessions.coerce.test.ts
+++ b/web-ui/app/_lib/__tests__/chatSessions.coerce.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { coerceSession } from '../chatSessions';
+
+/**
+ * Regression: chat sessions persisted by an older schema crashed the whole
+ * app. `isSession` only checked the top-level `messages` array, so a message
+ * missing `content` slipped through and the render threw
+ * `Cannot read properties of undefined (reading 'length')` on
+ * `message.content.length` — surfacing as the browser's cryptic
+ * "This page couldn't load" page. `coerceSession` normalises on read so stale
+ * localStorage / a foreign backend payload can never take the render down.
+ */
+describe('coerceSession', () => {
+  it('returns null for non-objects and entries without an id', () => {
+    expect(coerceSession(null)).toBeNull();
+    expect(coerceSession('nope')).toBeNull();
+    expect(coerceSession({ title: 'x' })).toBeNull();
+  });
+
+  it('defaults a message missing `content` to an empty string', () => {
+    const out = coerceSession({
+      id: 's1',
+      title: 't',
+      createdAt: 1,
+      updatedAt: 2,
+      messages: [{ id: 'm1', role: 'assistant', startedAt: 1 }], // no content
+    });
+    expect(out).not.toBeNull();
+    expect(out?.messages[0]?.content).toBe('');
+    // The exact access that used to throw must now be safe.
+    expect(out?.messages[0]?.content.length).toBe(0);
+  });
+
+  it('coerces a non-array `tools`/`nudges` field to []', () => {
+    const out = coerceSession({
+      id: 's1',
+      title: 't',
+      createdAt: 1,
+      updatedAt: 2,
+      messages: [
+        { id: 'm1', role: 'user', content: 'hi', startedAt: 1, tools: 'oops' },
+      ],
+    });
+    expect(out?.messages[0]?.tools).toEqual([]);
+  });
+
+  it('defaults a missing `messages` array to []', () => {
+    const out = coerceSession({ id: 's1', title: 't', createdAt: 1, updatedAt: 2 });
+    expect(out?.messages).toEqual([]);
+  });
+
+  it('drops malformed messages (no id) but keeps valid ones', () => {
+    const out = coerceSession({
+      id: 's1',
+      title: 't',
+      createdAt: 1,
+      updatedAt: 2,
+      messages: [
+        { role: 'user', content: 'no id' },
+        { id: 'm2', role: 'user', content: 'ok', startedAt: 1 },
+      ],
+    });
+    expect(out?.messages).toHaveLength(1);
+    expect(out?.messages[0]?.id).toBe('m2');
+  });
+
+  it('preserves a valid session and normalises role', () => {
+    const out = coerceSession({
+      id: 's1',
+      title: 'Hello',
+      createdAt: 10,
+      updatedAt: 20,
+      messages: [{ id: 'm1', role: 'weird', content: 'x', startedAt: 5 }],
+      snapshot: { agentSlug: 'fallback', capturedAt: 1 },
+    });
+    expect(out?.title).toBe('Hello');
+    expect(out?.messages[0]?.role).toBe('user'); // unknown role → 'user'
+    expect(out?.snapshot?.agentSlug).toBe('fallback');
+  });
+});

--- a/web-ui/app/_lib/chatSessions.ts
+++ b/web-ui/app/_lib/chatSessions.ts
@@ -444,22 +444,84 @@ function readLocalSessions(): ChatSession[] {
     if (!raw) return [];
     const parsed = JSON.parse(raw) as unknown;
     if (!Array.isArray(parsed)) return [];
-    return parsed.filter(isSession);
+    // Coerce rather than just filter: sessions persisted by an OLDER schema
+    // (e.g. a message without `content`) used to pass the top-level guard yet
+    // crash the render on `message.content.length`. Normalising on read keeps
+    // stale localStorage from taking the whole app down with the browser's
+    // cryptic "This page couldn't load" page (there's no SSR error to log).
+    return parsed
+      .map(coerceSession)
+      .filter((s): s is ChatSession => s !== null);
   } catch {
     return [];
   }
 }
 
-function isSession(v: unknown): v is ChatSession {
-  if (typeof v !== 'object' || v === null) return false;
+/**
+ * Coerce an untrusted value (old localStorage, a backend response from a
+ * different build) into a render-safe ChatSession, or null when it lacks the
+ * identity fields. Every field the UI reads with `.length` / `.map` / `for…of`
+ * is guaranteed present with a safe default. The complement of the optimistic
+ * `as ChatSession` casts that previously trusted these inputs blindly.
+ */
+export function coerceSession(v: unknown): ChatSession | null {
+  if (typeof v !== 'object' || v === null) return null;
   const s = v as Record<string, unknown>;
-  return (
-    typeof s['id'] === 'string' &&
-    typeof s['title'] === 'string' &&
-    typeof s['createdAt'] === 'number' &&
-    typeof s['updatedAt'] === 'number' &&
-    Array.isArray(s['messages'])
-  );
+  if (typeof s['id'] !== 'string') return null;
+  const now = Date.now();
+  const messages = Array.isArray(s['messages'])
+    ? (s['messages'] as unknown[])
+        .map(coerceMessage)
+        .filter((m): m is Message => m !== null)
+    : [];
+  const session: ChatSession = {
+    id: s['id'],
+    title: typeof s['title'] === 'string' ? s['title'] : 'Neuer Chat',
+    createdAt: typeof s['createdAt'] === 'number' ? s['createdAt'] : now,
+    updatedAt: typeof s['updatedAt'] === 'number' ? s['updatedAt'] : now,
+    messages,
+  };
+  const snapshot = s['snapshot'];
+  if (
+    typeof snapshot === 'object' &&
+    snapshot !== null &&
+    typeof (snapshot as Record<string, unknown>)['agentSlug'] === 'string'
+  ) {
+    session.snapshot = snapshot as SessionAgentSnapshot;
+  }
+  return session;
+}
+
+/**
+ * Coerce an untrusted message into a render-safe shape. Drops entries without
+ * an id; defaults `content` to '' and the array-typed fields the UI iterates
+ * (`tools`, `nudges`, …) to [] when a stale/foreign payload carries a non-array
+ * there. Unknown extra fields are preserved.
+ */
+function coerceMessage(v: unknown): Message | null {
+  if (typeof v !== 'object' || v === null) return null;
+  const m = v as Record<string, unknown>;
+  if (typeof m['id'] !== 'string') return null;
+  const arrayFields = [
+    'tools',
+    'nudges',
+    'attachments',
+    'fileAttachments',
+    'followUpOptions',
+    'maskedValues',
+  ] as const;
+  const arrayDefaults: Record<string, unknown[]> = {};
+  for (const key of arrayFields) {
+    if (m[key] !== undefined && !Array.isArray(m[key])) arrayDefaults[key] = [];
+  }
+  return {
+    ...(m as unknown as Message),
+    id: m['id'],
+    role: m['role'] === 'assistant' ? 'assistant' : 'user',
+    content: typeof m['content'] === 'string' ? m['content'] : '',
+    startedAt: typeof m['startedAt'] === 'number' ? m['startedAt'] : Date.now(),
+    ...arrayDefaults,
+  };
 }
 
 function writeLocalSessions(sessions: ChatSession[]): void {
@@ -484,7 +546,9 @@ async function fetchRemoteSession(id: string): Promise<ChatSession | null> {
   const res = await fetch(`/bot-api/chat/sessions/${encodeURIComponent(id)}`);
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`GET session: HTTP ${String(res.status)}`);
-  return (await res.json()) as ChatSession;
+  // Coerce: a session persisted by a different build can arrive with a
+  // drifted message shape; normalising here keeps it from crashing the render.
+  return coerceSession(await res.json());
 }
 
 async function putRemoteSession(session: ChatSession): Promise<void> {

--- a/web-ui/app/error.tsx
+++ b/web-ui/app/error.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useTranslations } from 'next-intl';
+
+/**
+ * Route-level error boundary. Without it, a thrown error during render of the
+ * chat page (e.g. a chat session persisted by an older schema, whose drifted
+ * shape crashed on `message.content.length`) bubbled up to the browser's
+ * cryptic "This page couldn't load" page with no recovery path and nothing
+ * logged server-side. This renders an in-app fallback with two recoveries:
+ *   - Reload — retry the render (fixes transient errors).
+ *   - Reset local chat data — clears this browser's locally-stored chats, the
+ *     usual culprit after a schema bump, then reloads. Server-side data is
+ *     untouched.
+ */
+
+// Mirrors the keys in app/_lib/chatSessions.ts. Kept inline so the boundary has
+// no dependency on the module that may have thrown.
+const LOCAL_CHAT_KEYS = [
+  'odoo-bot-chat-sessions',
+  'odoo-bot-chat-active-id',
+  'odoo-bot-scope',
+];
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}): React.ReactElement {
+  const t = useTranslations('error');
+
+  useEffect(() => {
+    console.error('[web-ui] route error boundary caught:', error);
+  }, [error]);
+
+  const resetLocalData = (): void => {
+    try {
+      for (const key of LOCAL_CHAT_KEYS) window.localStorage.removeItem(key);
+    } catch {
+      // localStorage may be unavailable (private mode) — reload anyway.
+    }
+    window.location.reload();
+  };
+
+  return (
+    <main className="flex h-full flex-col items-center justify-center px-6 py-16 text-center">
+      <div className="mx-auto flex max-w-md flex-col items-center gap-4">
+        <h1 className="font-display text-2xl text-[color:var(--fg-strong)]">
+          {t('title')}
+        </h1>
+        <p className="text-sm text-[color:var(--fg-muted)]">{t('description')}</p>
+        <div className="mt-2 flex flex-wrap items-center justify-center gap-3">
+          <button
+            type="button"
+            onClick={() => {
+              reset();
+            }}
+            className="rounded bg-neutral-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-neutral-700 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-300"
+          >
+            {t('reload')}
+          </button>
+          <button
+            type="button"
+            onClick={resetLocalData}
+            className="rounded border border-neutral-300 bg-white px-4 py-2 text-sm font-medium text-neutral-700 transition hover:border-neutral-400 hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+          >
+            {t('resetData')}
+          </button>
+        </div>
+        <p className="mt-1 text-xs text-[color:var(--fg-muted)]">
+          {t('resetDataHint')}
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/web-ui/app/global-error.tsx
+++ b/web-ui/app/global-error.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Last-resort boundary for errors thrown in the ROOT LAYOUT itself (e.g.
+ * next-intl `getMessages()` failing) — at that point the NextIntlClientProvider
+ * isn't mounted, so this file cannot use `useTranslations`. Strings are
+ * therefore hardcoded: this is the one documented exception to the web-ui i18n
+ * rule (see web-ui/CLAUDE.md), because the provider that would translate them
+ * is the very thing that failed. Bilingual to stay useful for both locales.
+ *
+ * global-error replaces the whole document, so it must render <html>/<body>.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}): React.ReactElement {
+  useEffect(() => {
+    console.error('[web-ui] global error boundary caught:', error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          fontFamily: 'system-ui, sans-serif',
+          display: 'flex',
+          minHeight: '100vh',
+          alignItems: 'center',
+          justifyContent: 'center',
+          margin: 0,
+          padding: '2rem',
+          textAlign: 'center',
+        }}
+      >
+        <div style={{ maxWidth: '28rem' }}>
+          <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>
+            Something went wrong · Etwas ist schiefgelaufen
+          </h1>
+          <p style={{ color: '#666', fontSize: '0.875rem', marginBottom: '1rem' }}>
+            The app failed to load. Try reloading. · Die App konnte nicht geladen
+            werden. Bitte neu laden.
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              reset();
+            }}
+            style={{
+              padding: '0.5rem 1rem',
+              borderRadius: '0.375rem',
+              border: 'none',
+              background: '#171717',
+              color: '#fff',
+              fontSize: '0.875rem',
+              cursor: 'pointer',
+            }}
+          >
+            Reload · Neu laden
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -132,6 +132,13 @@
     "signedInAs": "Angemeldet als",
     "signOut": "Abmelden"
   },
+  "error": {
+    "title": "Etwas ist schiefgelaufen",
+    "description": "Diese Seite hat einen unerwarteten Fehler ausgelöst und konnte nicht vollständig geladen werden.",
+    "reload": "Neu laden",
+    "resetData": "Lokale Chat-Daten zurücksetzen",
+    "resetDataHint": "Löscht die lokal in diesem Browser gespeicherten Chats und lädt neu. Deine serverseitigen Daten bleiben unberührt — nutze dies, wenn ein Neu-Laden allein nicht hilft."
+  },
   "session": {
     "expiresAtLabel": "Sitzung gültig bis",
     "warningTitle": "Sitzung läuft bald ab",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -132,6 +132,13 @@
     "signedInAs": "Signed in as",
     "signOut": "Sign out"
   },
+  "error": {
+    "title": "Something went wrong",
+    "description": "This page hit an unexpected error and couldn't finish loading.",
+    "reload": "Reload",
+    "resetData": "Reset local chat data",
+    "resetDataHint": "Clears chats stored locally in this browser, then reloads. Your server-side data is untouched — use this if reloading alone doesn't help."
+  },
   "session": {
     "expiresAtLabel": "Session valid until",
     "warningTitle": "Session expiring soon",


### PR DESCRIPTION
## Problem

After setup (create user → enter ANTHROPIC_API_KEY in the wizard), the web-ui landed on `localhost:3333/` with the browser's cryptic **"This page couldn't load"** page — no in-app error, nothing logged server-side.

Root cause: a chat session persisted in `localStorage` by an **older schema** (e.g. a message without `content`) passed the top-level `isSession` guard, but the render then threw `Cannot read properties of undefined (reading 'length')` on `message.content.length`. With **no route error boundary**, that bubbled to the blank browser page; the only workaround was `localStorage.clear()` in the console.

(The middleware was healthy — the orchestrator hot-published `chatAgent@1` + `orchestratorRegistry@1` on wizard key entry, no restart. This is purely web-ui.)

## Fix

- **`chatSessions.ts`** — replace the optimistic `as ChatSession` casts with `coerceSession` / `coerceMessage` on every untrusted load (localStorage **and** the remote `GET /chat/sessions/:id`). Drops entries without an id; defaults `content` to `''`, `messages` and the array-typed message fields the UI iterates (`tools`, `nudges`, `attachments`, `fileAttachments`, `followUpOptions`, `maskedValues`) to `[]`. Unknown fields preserved.
- **`app/error.tsx`** — route-level boundary with **Reload** + **Reset local chat data** (clears this browser's chat keys, leaves server data untouched). Future schema drift now degrades to a recoverable in-app screen, not a blank page.
- **`app/global-error.tsx`** — last-resort boundary for root-layout failures (no i18n provider available there — the documented exception to the web-ui i18n rule).
- **`messages/{en,de}.json`** — `error.*` keys (i18n parity OK, 1040 keys).

## Tests

`web-ui/app/_lib/__tests__/chatSessions.coerce.test.ts` — covers the exact drift cases (missing `content`, non-array `tools`, missing `messages`, malformed message dropped, role normalised). 6/6 pass. `tsc --noEmit` clean; eslint 0 errors; `i18n:check` OK.
