### PR TITLE
fix(builder): prevent message loss when toggling simple/extended view (#224)

### DIFF
--- a/web-ui/app/store/builder/[id]/_components/BuilderChatPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/BuilderChatPane.tsx
@@ -107,6 +107,11 @@ interface BuilderChatPaneProps {
    *  `user_choice_resolved` event still arrives later for sibling-tab
    *  consistency, but the local pane reacts instantly. */
   onUserChoiceResolved?: () => void;
+  /** Issue #224 — lifts the in-flight turn flag to the Workspace so it can
+   *  lock the simple/extended view toggle while a reply streams (toggling
+   *  unmounts this pane and would abort the stream + drop the live message).
+   *  Fires `false` on unmount so a stale `true` never wedges the toggle. */
+  onStreamingChange?: (streaming: boolean) => void;
 }
 
 /**
@@ -131,6 +136,7 @@ export function BuilderChatPane({
   onPendingInputConsumed,
   pendingUserChoice,
   onUserChoiceResolved,
+  onStreamingChange,
 }: BuilderChatPaneProps): React.ReactElement {
   const t = useTranslations('builder.chat');
   const [items, setItems] = useState<ChatItem[]>(() =>
@@ -214,6 +220,13 @@ export function BuilderChatPane({
       abortRef.current?.abort();
     };
   }, []);
+
+  // Issue #224 — mirror the in-flight flag up to the Workspace, and force it
+  // back to `false` on unmount so the view toggle never stays locked.
+  useEffect(() => {
+    onStreamingChange?.(inflight);
+    return () => onStreamingChange?.(false);
+  }, [inflight, onStreamingChange]);
 
   const onSend = useCallback(async (messageOverride?: string) => {
     const source = messageOverride ?? input;

--- a/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
@@ -126,6 +126,12 @@ interface PreviewChatPaneProps {
   /** Live-fix: lifted from local state so the Workspace can also derive
    *  its missingRequiredCredentials counter from the same source. */
   onBufferedSecretKeysChange?: (keys: readonly string[]) => void;
+  /** Issue #224 — lifts the in-flight turn flag to the Workspace so it can
+   *  lock the simple/extended view toggle while a test reply streams
+   *  (toggling unmounts this pane and would abort the stream + drop the live
+   *  message). Fires `false` on unmount so a stale `true` never wedges the
+   *  toggle. */
+  onStreamingChange?: (streaming: boolean) => void;
 }
 
 /**
@@ -148,6 +154,7 @@ export function PreviewChatPane({
   runtimeSmoke,
   onFixSmokeWithBuilder,
   onBufferedSecretKeysChange,
+  onStreamingChange,
 }: PreviewChatPaneProps): React.ReactElement {
   const t = useTranslations('builder.preview.chat');
   const [items, setItems] = useState<ChatItem[]>(() =>
@@ -226,6 +233,13 @@ export function PreviewChatPane({
       abortRef.current?.abort();
     };
   }, []);
+
+  // Issue #224 — mirror the in-flight flag up to the Workspace, and force it
+  // back to `false` on unmount so the view toggle never stays locked.
+  useEffect(() => {
+    onStreamingChange?.(inflight);
+    return () => onStreamingChange?.(false);
+  }, [inflight, onStreamingChange]);
 
   const onSend = useCallback(async (override?: string) => {
     const trimmed = (override ?? input).trim();

--- a/web-ui/app/store/builder/[id]/_components/SimpleIntakePane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SimpleIntakePane.tsx
@@ -46,6 +46,11 @@ interface SimpleIntakePaneProps {
   /** Called optimistically after the operator picks an option so the
    *  parent can clear the card without waiting for the bus echo. */
   onUserChoiceResolved?: () => void;
+  /** Issue #224 — lifts the in-flight turn flag to the Workspace so it can
+   *  lock the simple/extended view toggle while a reply streams (toggling
+   *  unmounts this pane and would abort the stream + drop the live message).
+   *  Fires `false` on unmount so a stale `true` never wedges the toggle. */
+  onStreamingChange?: (streaming: boolean) => void;
 }
 
 const EASE_OUT = [0.22, 0.61, 0.36, 1] as const;
@@ -73,6 +78,7 @@ export function SimpleIntakePane({
   initialTranscript,
   pendingUserChoice,
   onUserChoiceResolved,
+  onStreamingChange,
 }: SimpleIntakePaneProps): React.ReactElement {
   const t = useTranslations('builder.simple.intake');
   const [messages, setMessages] = useState<SimpleMessage[]>(() =>
@@ -85,6 +91,12 @@ export function SimpleIntakePane({
   const [input, setInput] = useState('');
   const [inflight, setInflight] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Issue #224 — mirror the in-flight flag up to the Workspace, and force it
+  // back to `false` on unmount so the view toggle never stays locked.
+  useEffect(() => {
+    onStreamingChange?.(inflight);
+    return () => onStreamingChange?.(false);
+  }, [inflight, onStreamingChange]);
   // Single human-readable status line shown under the breathing dots while
   // the agent works. Replaced (never appended) as events arrive so the
   // operator always sees one calm "what's happening now" sentence.

--- a/web-ui/app/store/builder/[id]/_components/SimpleWorkspace.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SimpleWorkspace.tsx
@@ -33,6 +33,12 @@ interface SimpleWorkspaceProps {
     }>;
   } | null;
   onUserChoiceResolved?: () => void;
+  /** Issue #224 — lifts the intake pane's in-flight flag so the Workspace
+   *  can lock the view toggle while a build reply streams. */
+  onIntakeStreamingChange?: (streaming: boolean) => void;
+  /** Issue #224 — lifts the reduced preview pane's in-flight flag so the
+   *  Workspace can lock the view toggle while a test reply streams. */
+  onPreviewStreamingChange?: (streaming: boolean) => void;
 }
 
 // byte5 ease-out curve (mirrors --ease-out token) for entrance motion.
@@ -67,6 +73,8 @@ export function SimpleWorkspace({
   onPersonaPersisted,
   pendingUserChoice,
   onUserChoiceResolved,
+  onIntakeStreamingChange,
+  onPreviewStreamingChange,
 }: SimpleWorkspaceProps): React.ReactElement {
   const t = useTranslations('builder.simple');
   const [personaOpen, setPersonaOpen] = useState(false);
@@ -120,6 +128,9 @@ export function SimpleWorkspace({
               initialTranscript={draft.transcript}
               pendingUserChoice={pendingUserChoice}
               onUserChoiceResolved={onUserChoiceResolved}
+              {...(onIntakeStreamingChange
+                ? { onStreamingChange: onIntakeStreamingChange }
+                : {})}
             />
           </div>
         </SimpleStepCard>
@@ -138,6 +149,9 @@ export function SimpleWorkspace({
               initialTranscript={draft.previewTranscript}
               setupFields={spec.setup_fields ?? []}
               onBuildStatus={onBuildStatus}
+              {...(onPreviewStreamingChange
+                ? { onStreamingChange: onPreviewStreamingChange }
+                : {})}
             />
           </div>
         </SimpleStepCard>

--- a/web-ui/app/store/builder/[id]/_components/Workspace.tsx
+++ b/web-ui/app/store/builder/[id]/_components/Workspace.tsx
@@ -137,14 +137,67 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
       // localStorage unavailable (private mode / SSR) — keep the default.
     }
   }, []);
-  const handleViewModeChange = useCallback((next: 'simple' | 'extended') => {
-    setViewMode(next);
-    try {
-      window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, next);
-    } catch {
-      // Non-fatal — the preference just won't persist across reloads.
-    }
-  }, []);
+  // Issue #224 — the simple and extended views are separate React subtrees
+  // (SimpleWorkspace's SimpleIntakePane vs the extended BuilderChatPane; each
+  // view also mounts its own PreviewChatPane). Toggling unmounts the active
+  // pane, which aborts any in-flight NDJSON turn and drops the live message
+  // that only lived in that pane's local state. Each chat pane lifts its
+  // in-flight flag up here; while either a build OR a test reply streams we
+  // lock the toggle so a half-streamed turn can never be lost.
+  const [builderChatStreaming, setBuilderChatStreaming] = useState(false);
+  const [previewChatStreaming, setPreviewChatStreaming] = useState(false);
+  const chatStreaming = builderChatStreaming || previewChatStreaming;
+  // Brief refetch-in-progress flag — also disables the toggle so a fast
+  // double-click can't fire a second switch mid-refetch.
+  const [viewSwitching, setViewSwitching] = useState(false);
+  // Read the freshest values inside the async handler without widening the
+  // callback's dep array (which would rebuild it on every keystroke-driven
+  // re-render of the workspace). Synced in an effect — mutating a ref during
+  // render is disallowed by react-hooks/refs.
+  const chatStreamingRef = useRef(chatStreaming);
+  const viewModeRef = useRef(viewMode);
+  useEffect(() => {
+    chatStreamingRef.current = chatStreaming;
+    viewModeRef.current = viewMode;
+  }, [chatStreaming, viewMode]);
+  const handleViewModeChange = useCallback(
+    async (next: 'simple' | 'extended'): Promise<void> => {
+      if (next === viewModeRef.current) return;
+      // Never switch mid-stream — the unmount would abort the turn and the
+      // live message would be lost. The UI disables the toggle while
+      // streaming; this guard defends against a click that races a
+      // just-started turn.
+      if (chatStreamingRef.current) return;
+      // The target pane seeds its transcript from `draft` exactly once, on
+      // mount. Refetch the persisted draft FIRST so the freshly-mounted pane
+      // shows every turn that completed in the view we're leaving — including
+      // one whose SSE-debounced refetch (250ms) may not have landed yet.
+      // Both `transcript` and `previewTranscript` are persisted per turn
+      // server-side, so this recovers build- and test-chat messages alike.
+      setViewSwitching(true);
+      try {
+        const env = await getBuilderDraft(initialDraft.id);
+        setDraft(env.draft);
+      } catch {
+        // Refetch failed — switch anyway. The new pane seeds from the current
+        // (possibly slightly stale) draft; the stream-lock already prevented
+        // the unrecoverable mid-stream loss.
+      } finally {
+        setViewSwitching(false);
+      }
+      // A turn may have started in the still-mounted current pane during the
+      // refetch window — re-check before committing the switch so we never
+      // unmount mid-stream.
+      if (chatStreamingRef.current) return;
+      setViewMode(next);
+      try {
+        window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, next);
+      } catch {
+        // Non-fatal — the preference just won't persist across reloads.
+      }
+    },
+    [initialDraft.id],
+  );
   const tw = useTranslations('builder.workspace');
   const [busStatus, setBusStatus] = useState<'open' | 'closed' | 'error'>(
     'closed',
@@ -625,6 +678,7 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
         draft={draft}
         viewMode={viewMode}
         onViewModeChange={handleViewModeChange}
+        viewToggleDisabled={chatStreaming || viewSwitching}
         installEnabled={installEnabled}
         installDisabledReason={
           buildStatus.phase !== 'ok'
@@ -719,6 +773,8 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
           }
           pendingUserChoice={pendingUserChoice}
           onUserChoiceResolved={() => setPendingUserChoice(null)}
+          onIntakeStreamingChange={setBuilderChatStreaming}
+          onPreviewStreamingChange={setPreviewChatStreaming}
         />
       ) : (
         <>
@@ -743,6 +799,7 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
             onPendingInputConsumed={() => setPendingChatInput(null)}
             pendingUserChoice={pendingUserChoice}
             onUserChoiceResolved={() => setPendingUserChoice(null)}
+            onStreamingChange={setBuilderChatStreaming}
           />
         );
         const editorPaneBody = (
@@ -831,6 +888,7 @@ export function Workspace({ initialDraft }: WorkspaceProps): React.ReactElement 
                 : undefined
             }
             onBufferedSecretKeysChange={handleBufferedSecretKeysChange}
+            onStreamingChange={setPreviewChatStreaming}
           />
         );
 
@@ -1259,6 +1317,7 @@ function WorkspaceHeader({
   draft,
   viewMode,
   onViewModeChange,
+  viewToggleDisabled,
   installEnabled,
   installDisabledReason,
   onInstallClick,
@@ -1273,7 +1332,11 @@ function WorkspaceHeader({
 }: {
   draft: Draft;
   viewMode: ViewMode;
-  onViewModeChange: (next: ViewMode) => void;
+  onViewModeChange: (next: ViewMode) => void | Promise<void>;
+  /** Issue #224 — true while a chat reply streams or the post-toggle
+   *  refetch is in flight; the segmented control is locked so switching
+   *  views can't abort a turn or seed a pane from a stale transcript. */
+  viewToggleDisabled: boolean;
   installEnabled: boolean;
   installDisabledReason: string | null;
   onInstallClick: () => void;
@@ -1338,7 +1401,11 @@ function WorkspaceHeader({
         </dl>
       ) : null}
 
-      <ViewModeToggle value={viewMode} onChange={onViewModeChange} />
+      <ViewModeToggle
+        value={viewMode}
+        onChange={onViewModeChange}
+        disabled={viewToggleDisabled}
+      />
 
       <button
         type="button"
@@ -1367,9 +1434,13 @@ function WorkspaceHeader({
 function ViewModeToggle({
   value,
   onChange,
+  disabled = false,
 }: {
   value: ViewMode;
-  onChange: (next: ViewMode) => void;
+  onChange: (next: ViewMode) => void | Promise<void>;
+  /** Issue #224 — locks the control while a chat reply streams (or the
+   *  post-toggle refetch runs) so switching can't lose in-flight messages. */
+  disabled?: boolean;
 }): React.ReactElement {
   const tw = useTranslations('builder.workspace');
   const items: Array<{ id: ViewMode; label: string; title: string }> = [
@@ -1388,23 +1459,37 @@ function ViewModeToggle({
     <div
       role="tablist"
       aria-label={tw('viewModeAriaLabel')}
-      className="inline-flex shrink-0 items-center gap-1 rounded-full border border-[color:var(--divider)] bg-[color:var(--bg-soft)] p-1"
+      aria-busy={disabled || undefined}
+      className={cn(
+        'inline-flex shrink-0 items-center gap-1 rounded-full border border-[color:var(--divider)] bg-[color:var(--bg-soft)] p-1',
+        disabled && 'opacity-60',
+      )}
     >
       {items.map((it) => {
         const active = it.id === value;
+        // While locked, only the inactive tab is truly disabled — keeping the
+        // active tab clickable would be a no-op anyway, but a uniform locked
+        // look reads clearer, so we disable both and surface the reason via
+        // the tooltip on the inactive one.
+        const lockedTitle = disabled ? tw('viewModeLockedTitle') : it.title;
         return (
           <button
             key={it.id}
             type="button"
             role="tab"
             aria-selected={active}
-            title={it.title}
-            onClick={() => onChange(it.id)}
+            disabled={disabled && !active}
+            title={lockedTitle}
+            onClick={() => {
+              if (disabled) return;
+              void onChange(it.id);
+            }}
             className={cn(
               'rounded-full px-3 py-1 text-[12px] font-semibold transition-colors',
               active
                 ? 'bg-[color:var(--accent)] text-white shadow-[var(--shadow-cta)]'
                 : 'text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]',
+              disabled && !active && 'cursor-not-allowed',
             )}
           >
             {it.label}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -520,6 +520,7 @@
       "viewModeExtended": "Erweitert",
       "viewModeSimpleTitle": "Geführte No-Code-Ansicht — beschreiben, ansehen, ausprobieren",
       "viewModeExtendedTitle": "Voller Builder — Spec, Slots, Quellcode, Build-Status",
+      "viewModeLockedTitle": "Bitte warte, bis die aktuelle Antwort fertig ist, bevor du die Ansicht wechselst",
       "statusDraft": "Entwurf",
       "statusPublished": "Bereitgestellt",
       "statusArchived": "Archiviert",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -520,6 +520,7 @@
       "viewModeExtended": "Advanced",
       "viewModeSimpleTitle": "Guided no-code view — describe, review, try out",
       "viewModeExtendedTitle": "Full builder — spec, slots, source code, build status",
+      "viewModeLockedTitle": "Please wait for the current reply to finish before switching views",
       "statusDraft": "Draft",
       "statusPublished": "Published",
       "statusArchived": "Archived",


### PR DESCRIPTION
## Problem

Closes #224. The simple/extended view toggle in the assistant builder lost chat messages: clicking it mid-build, or while an LLM reply streamed, dropped the in-flight message — for both the build chat and the test/preview chat.

## Root cause

The two views are **separate React subtrees** (`SimpleWorkspace`'s `SimpleIntakePane` vs the extended `BuilderChatPane`; each view also mounts its own `PreviewChatPane`). Toggling `viewMode` unmounts the active pane, which:

1. Aborts the in-flight NDJSON turn via its `AbortController`, and
2. Drops the live assistant message that only existed in that pane's local state.

The freshly mounted pane re-seeds its transcript from `draft.transcript` / `draft.previewTranscript`, but that draft is **stale** — the SSE-driven refetch is debounced 250 ms — so even just-finished messages disappear.

## Fix — two layers, no message loss

1. **Stream lock.** All three chat panes (`SimpleIntakePane`, `BuilderChatPane`, `PreviewChatPane`) lift their `inflight` flag to the `Workspace` via a new `onStreamingChange` prop. While a build **or** test reply streams, the view toggle is disabled (`disabled` + `aria-busy` + tooltip). The lift effect fires `false` on unmount so a stale `true` can never wedge the toggle.

2. **Refetch-before-switch.** `handleViewModeChange` is now async: it refetches the persisted draft (`getBuilderDraft`) and `setDraft` **before** flipping `viewMode`, so the newly mounted pane seeds from the persisted transcript. Both `transcript` and `previewTranscript` are persisted per turn server-side (`previewChatService.ts`), so this recovers build- and test-chat messages alike. A post-`await` re-check of the stream lock plus a `viewSwitching` flag close the race / double-click windows.

Adds i18n key `builder.workspace.viewModeLockedTitle` (en + de).

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅ (only a pre-existing `onBuildStatus` exhaustive-deps warning, untouched)
- `npm run i18n:check` ✅
- Builder component tests: 61/61 ✅
