### PR TITLE
fix(web-ui): install drawer overlays render above global header

### DIFF
--- a/web-ui/app/layout.tsx
+++ b/web-ui/app/layout.tsx
@@ -76,7 +76,7 @@ export default async function RootLayout({
         <NextIntlClientProvider locale={locale} messages={messages}>
           <ChatSessionsProvider>
             <StreamStoreProvider>
-              <header className="relative z-50 border-b border-[color:var(--border)] bg-[color:var(--bg)]/90 px-6 py-3 backdrop-blur">
+              <header className="relative z-40 border-b border-[color:var(--border)] bg-[color:var(--bg)]/90 px-6 py-3 backdrop-blur">
                 <div className="mx-auto flex max-w-[1280px] items-center gap-4">
                   <Link
                     href="/"


### PR DESCRIPTION
## Problem

The install screen (`InstallDrawer`) rendered **underneath** the global app header — the plugin title and "Warte auf Konfiguration" subtitle scrolled through the header bar.

## Root cause

The global header (`app/layout.tsx`) used `z-50` — the same layer as every full-screen overlay (`InstallDrawer`, `RequiresWizard`, `OnboardingModal`, `AgentDetailsModal`, `ConfirmDialog`, all `fixed inset-0 z-50`). With equal z-index plus the header's `backdrop-blur` stacking context, the header won the paint order and covered the overlays.

## Fix

Drop the header to `z-40` so the modal/overlay layer (`z-50`) sits cleanly above it. One-line change that also fixes the identical latent bug in the other full-screen overlays. In-header dropdowns (`Nav`, `AuthBadge`, each `z-50`) stay correct — they render within the header's own stacking context, still above page content.

## Verification

- `npm run lint` -> 0 errors
- `npm run typecheck` -> clean
- Merged latest `main` (#230) — no conflicts
- No competing sticky/fixed top bars in the codebase -> no regression from lowering the header layer