### PR TITLE
fix(builder): author plugins from spec.author, not hardcoded "byte5 GmbH" (#225)

### DIFF
--- a/middleware/assets/boilerplate/agent-integration/manifest.yaml
+++ b/middleware/assets/boilerplate/agent-integration/manifest.yaml
@@ -16,8 +16,7 @@ identity:
   version: "{{AGENT_VERSION}}"
   description: "{{AGENT_DESCRIPTION_DE}}"
   authors:
-    - name: "byte5 GmbH"
-      email: "info@omadia.ai"
+    - name: "{{AGENT_AUTHOR}}"
   license: "Proprietary"
   icon: "./assets/icon.png"
   categories:

--- a/middleware/assets/boilerplate/agent-integration/template.yaml
+++ b/middleware/assets/boilerplate/agent-integration/template.yaml
@@ -137,6 +137,7 @@ placeholders:
   AGENT_NAME: name
   AGENT_SLUG: __derived__/agentSlug
   AGENT_DESCRIPTION_DE: description
+  AGENT_AUTHOR: author
   AGENT_VERSION: version
   AGENT_DOMAIN: domain
   CATEGORY: category

--- a/middleware/assets/boilerplate/agent-pure-llm/manifest.yaml
+++ b/middleware/assets/boilerplate/agent-pure-llm/manifest.yaml
@@ -21,8 +21,7 @@ identity:
   version: "{{AGENT_VERSION}}"
   description: "{{AGENT_DESCRIPTION_DE}}"
   authors:
-    - name: "byte5 GmbH"
-      email: "info@omadia.ai"
+    - name: "{{AGENT_AUTHOR}}"
   license: "Proprietary"
   icon: "./assets/icon.png"
   categories:

--- a/middleware/assets/boilerplate/agent-pure-llm/template.yaml
+++ b/middleware/assets/boilerplate/agent-pure-llm/template.yaml
@@ -31,6 +31,7 @@ placeholders:
   AGENT_NAME: name
   AGENT_SLUG: __derived__/agentSlug
   AGENT_DESCRIPTION_DE: description
+  AGENT_AUTHOR: author
   AGENT_VERSION: version
   AGENT_DOMAIN: domain
   CATEGORY: category

--- a/middleware/src/plugins/builder/agentSpec.ts
+++ b/middleware/src/plugins/builder/agentSpec.ts
@@ -440,6 +440,13 @@ export const AgentSpecSchema = z
     name: z.string().min(1),
     version: SemverSchema.default('0.1.0'),
     description: z.string().min(1),
+    // #225 — operator-entered author/publisher attribution. Codegen maps
+    // this to `identity.authors[0].name` in the generated manifest via the
+    // AGENT_AUTHOR placeholder. Default '' (no attribution) replaces the
+    // old hardcoded "byte5 GmbH" boilerplate author — an empty name is
+    // filtered out by manifestLoader.extractAuthors, so the store-detail
+    // page shows no author until the operator sets one.
+    author: z.string().default(''),
     category: z.enum([
       'productivity',
       'crm',

--- a/middleware/src/plugins/builder/types.ts
+++ b/middleware/src/plugins/builder/types.ts
@@ -42,6 +42,11 @@ export interface AgentSpecSkeleton {
   version: string;
   description: string;
   category: string;
+  /** #225 — operator-entered author/publisher. Optional in the skeleton
+   *  because legacy drafts predate the field; Zod parse fills the default
+   *  ''. Codegen maps it to `identity.authors[0].name` (AGENT_AUTHOR
+   *  placeholder); empty → no author rendered on the store-detail page. */
+  author?: string;
   /** OB-77 (Palaia Phase 8) — first-class plugin Domain. Optional in the
    *  skeleton because legacy drafts predate the field; parseAgentSpec
    *  injects an `unknown.<id>` fallback at parse-time before the Zod
@@ -223,6 +228,9 @@ export function emptyAgentSpec(): AgentSpecSkeleton {
     name: '',
     version: '0.1.0',
     description: '',
+    // #225 — empty until the operator sets an author; replaces the old
+    // hardcoded "byte5 GmbH" boilerplate attribution.
+    author: '',
     category: 'other',
     // OB-77 — placeholder, the Builder agent is required to elicit a real
     // domain via patch_spec before fill_slot runs. Validated on save via

--- a/middleware/test/builder/codegen.test.ts
+++ b/middleware/test/builder/codegen.test.ts
@@ -101,6 +101,27 @@ describe('codegen.generate', () => {
     assert.match(pluginText, /AGENT_ID = 'de\.byte5\.agent\.weather'/);
   });
 
+  // #225 — author must come from spec.author, NOT the old hardcoded
+  // "byte5 GmbH" boilerplate value. Empty author → empty manifest name
+  // (filtered out at load time by extractAuthors so no false attribution).
+  it('maps spec.author to manifest authors[].name and never emits "byte5 GmbH"', async () => {
+    const { spec: base, slots } = loadFixture();
+
+    const authored = await generate({
+      spec: { ...base, author: 'Acme Corp' },
+      slots,
+    });
+    const authoredManifest = authored.get('manifest.yaml')!.toString('utf-8');
+    assert.match(authoredManifest, /name:\s*"Acme Corp"/);
+    assert.doesNotMatch(authoredManifest, /byte5 GmbH/);
+
+    // Default (empty) author → `name: ""`, no hardcoded fallback.
+    const anon = await generate({ spec: base, slots });
+    const anonManifest = anon.get('manifest.yaml')!.toString('utf-8');
+    assert.match(anonManifest, /authors:\s*\n\s*-\s*name:\s*""/);
+    assert.doesNotMatch(anonManifest, /byte5 GmbH/);
+  });
+
   it('generates a valid package for an npm-scoped agent id (`@omadia/agent-*`)', async () => {
     const { spec: base, slots } = loadFixture();
     const spec = parseAgentSpec({

--- a/web-ui/app/_lib/builderTypes.ts
+++ b/web-ui/app/_lib/builderTypes.ts
@@ -131,6 +131,10 @@ export interface AgentSpecSkeleton {
   version: string;
   description: string;
   category: string;
+  /** #225 — operator-entered author/publisher. Optional in the type
+   *  because legacy drafts predate the field; codegen maps it to
+   *  `identity.authors[0].name`. Empty → no author on the store page. */
+  author?: string;
   /** OB-77 (Palaia Phase 8) — first-class plugin Domain. Required at the
    *  manifest level; the spec form surfaces it next to category. Same
    *  PLUGIN_DOMAIN_REGEX validation as middleware. */

--- a/web-ui/app/store/builder/[id]/_components/SpecOverview.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SpecOverview.tsx
@@ -28,6 +28,7 @@ export function SpecOverview({ spec, slots }: SpecOverviewProps): React.ReactEle
     <div className="grid grid-cols-1 gap-4 p-5 md:grid-cols-2">
       <Field label={t('fields.agentId')} value={spec.id || '—'} mono />
       <Field label={t('fields.name')} value={spec.name || '—'} />
+      <Field label={t('fields.author')} value={spec.author || '—'} />
       <Field label={t('fields.version')} value={spec.version || '—'} mono />
       <Field label={t('fields.template')} value={spec.template ?? 'agent-integration'} mono />
       <Field label={t('fields.category')} value={spec.category || '—'} />

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -811,6 +811,7 @@
         "fields": {
           "agentId": "Agent-ID",
           "name": "Name",
+          "author": "Autor",
           "version": "Version",
           "template": "Template",
           "category": "Kategorie",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -811,6 +811,7 @@
         "fields": {
           "agentId": "Agent ID",
           "name": "Name",
+          "author": "Author",
           "version": "Version",
           "template": "Template",
           "category": "Category",


### PR DESCRIPTION
## Problem

Closes #225. Plugins created in the builder were marked as authored by **"byte5 GmbH"**. Both boilerplate manifests (`agent-pure-llm`, `agent-integration`) hardcoded `authors: - name: "byte5 GmbH"` with **no placeholder**, so codegen copied it verbatim into every generated plugin's `identity.authors`. That value flows through `manifestLoader.extractAuthors` → store entry → the store-detail page's "by …" line.

## Fix

Wire the author through the existing placeholder system so it comes from the operator's spec:

- **`agentSpec.ts`** — add optional `author` field (`z.string().default('')`).
- **boilerplate `agent-pure-llm` + `agent-integration`** — replace the hardcoded author with `{{AGENT_AUTHOR}}`, mapped to `author` in each `template.yaml`.
- **`types.ts`** — `author?` on `AgentSpecSkeleton` + `author: ''` in `emptyAgentSpec()`.
- **web-ui** — mirror `author` on the spec type, surface it read-only in `SpecOverview`, add `fields.author` (en: "Author", de: "Autor").

## Why it's safe

- Empty author → `name: ""`, which `extractAuthors`/`parseAuthors` filter out at load time → no author shown (no false byte5 attribution) until the operator sets one.
- `patch_spec` validates against `AgentSpecSchema`, so `/author` is settable from the chat-driven builder.
- `parseAgentSpec()` applies the `''` default before `generate()` (in `buildPipeline` + `manifestPreview`), so legacy drafts can't trip the unresolved-placeholder fail-fast check.

## Verification

- `middleware` typecheck: changed files clean (the 8 errors in `coreApi.ts`/`webSocketRegistry.ts` are pre-existing unbuilt-`dist` env issues, untouched here).
- `web-ui` typecheck: clean.
- `npm run i18n:check`: OK — 1036 keys, en/de parity.
- eslint `--fix`: clean on all changed files.
- builder tests: **44/44 pass**, incl. a new test asserting `spec.author` → `authors[].name` and that `"byte5 GmbH"` is never emitted.
