### PR TITLE
feat(ui-orchestrator): Tier-2 surface synthesis in canvasChatAgent (PR-9b-1)

### DIFF
--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -240,7 +240,43 @@ Plugin zurück und degradiert sauber). CCM ist **kein** hartes `requires`. Die
 echte Canvas-Arbeit — UI Skill (Kompositions-Idiom-Bibliothek), `surface_*`-
 Synthese, per-`canvasSessionId`-Mutex, Cache — plus die aufgeschobenen Wirings
 (PR-7b Sentinel-Gating, `writeCapabilities`-Anbindung, `structured`-Threading)
-sind Folge-Slices.
+sind Folge-Slices. **Surface-Synthese aufgelöst durch PR-9b-1 (unten).**
+
+### Tier-2 Surface-Synthese (Omadia UI, PR-9b-1)
+
+Macht `canvasChatAgent` zum echten Stream-Transformer — **ohne den geteilten
+Base-Orchestrator-Tool-Loop anzufassen**. Für einen **Canvas-Turn** (einen, der
+`input.canvasSessionId` trägt) wickelt `canvasChatAgent` den `base.chatStream`-
+Event-Stream in `synthesizeSurfaceEvents` (`packages/omadia-ui-orchestrator/src/
+surfaceSynthesis.ts`): pro `tool_result` eines **autorisierten** Tools wird die
+Ausgabe mit `parseToolEmittedCanvasTree` (#169) gescannt; bei einem
+`_pendingCanvasTree`-Sentinel wird ein `surface_snapshot` synthetisiert und in
+den Stream injiziert (per-Stream monotone `surfaceSeq` + Revision, gestempelt mit
+`canvasSessionId`). Alle anderen Events passieren unverändert; Nicht-Canvas-Turns
+und der `chat()`-Pfad gehen byte-genau durch.
+
+- **Gate (deny-by-default):** nur Tools in `authorizedToolNames` werden gescannt.
+  Das Set ist **heute leer** — die boot-berechnete canvas-output-Allow-Liste wird
+  mit dem ersten Producer-Tool (PR-9b-2) verdrahtet; bis dahin ist der
+  Synthesizer in Produktion korrekt inert (secure-by-construction). Der
+  Gate-Mechanismus selbst ist live + getestet.
+- **`canvasSessionId`-Threading** (2 geteilte Dateien, additiv): `ChatTurnInput`
+  bekommt ein optionales `canvasSessionId`; der `orchestratorDispatcher` liest es
+  aus den Turn-Metadaten (vom Canvas-Channel gesetzt, PR-10b) und reicht es in
+  `chatStream` durch. Klassische Channels setzen es nie → unverändert.
+- **Dependency:** `@omadia/orchestrator` als peerDep des ui-orchestrator (für die
+  #169-Parser).
+
+**Noch offen (spätere 9b-Slices):** der **Producer** (canvas-output-Tool / UI
+Skill, das `_pendingCanvasTree` tatsächlich emittiert — bis dahin läuft die
+Synthese nur in Tests) + das Allow-Set-Boot-Wiring (9b-2);
+`_pendingStructuredPayload` → `surface_data_ref_created` (braucht DataRef-HMAC);
+per-`canvasSessionId`-Mutex + cross-turn-`surfaceSeq`-Kontinuität + Cache (9b-3).
+
+Test: `test/uiOrchestratorSurface.test.ts` treibt `synthesizeSurfaceEvents` mit
+einem Fake-Base-Stream (autorisierter Sentinel → `surface_snapshot`; leeres
+Allow-Set → nichts; kein Sentinel → nichts; Nicht-Tool-Events unverändert;
+monotone `surfaceSeq`/Revision).
 
 ### omadia-ui-channel (Tier-1 Server, Skeleton, PR-10a)
 

--- a/middleware/packages/harness-channel-sdk/src/chatAgent.ts
+++ b/middleware/packages/harness-channel-sdk/src/chatAgent.ts
@@ -261,6 +261,14 @@ export interface ChatTurnInput {
    * (Telegram); otherwise the orchestrator fetches `url` itself.
    */
   attachments?: ChatTurnAttachment[];
+  /**
+   * Omadia UI canvas session id for this turn. Set only by the canvas channel
+   * (threaded from the channel's `IncomingTurn` metadata through the dispatcher);
+   * classic channels leave it unset. A canvas-aware orchestrator
+   * (`canvasChatAgent`) stamps it onto the `surface_*` events it synthesises so
+   * Tier 1 can correlate them to the right canvas. Never reaches the model prompt.
+   */
+  canvasSessionId?: string;
 }
 
 /**

--- a/middleware/packages/omadia-ui-orchestrator/package.json
+++ b/middleware/packages/omadia-ui-orchestrator/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "description": "Omadia UI Tier-2 orchestrator (skeleton). kind: extension; publishes canvasChatAgent@1 — the service a canvas channel dispatches to (channel.dispatch_service). v0 delegates to the base chatAgent; the canvas composition (UI Skill, surface_* synthesis, per-canvasSession mutex, cache) plus the deferred sentinel/writeCapabilities/structured wiring land in follow-ups.",
+  "description": "Omadia UI Tier-2 orchestrator. kind: extension; publishes canvasChatAgent@1 — the service a canvas channel dispatches to (channel.dispatch_service). Wraps the base chatAgent and, for a canvas turn, synthesises surface_* events from an authorised tool's canvas sentinels (PR-9b-1). The producer tool / UI Skill, the canvas-output allow-set wiring, structured-payload DataRefs, and the per-canvasSession mutex land in follow-up slices.",
   "license": "MIT",
   "scripts": {
     "build": "tsc",
@@ -13,6 +13,7 @@
   },
   "peerDependencies": {
     "@omadia/channel-sdk": "*",
+    "@omadia/orchestrator": "*",
     "@omadia/plugin-api": "*"
   },
   "engines": {

--- a/middleware/packages/omadia-ui-orchestrator/src/index.ts
+++ b/middleware/packages/omadia-ui-orchestrator/src/index.ts
@@ -4,3 +4,8 @@ export {
   CANVAS_CHAT_AGENT_SERVICE,
   type UiOrchestratorPluginHandle,
 } from './plugin.js';
+
+export {
+  synthesizeSurfaceEvents,
+  type SurfaceSynthesisConfig,
+} from './surfaceSynthesis.js';

--- a/middleware/packages/omadia-ui-orchestrator/src/plugin.ts
+++ b/middleware/packages/omadia-ui-orchestrator/src/plugin.ts
@@ -6,20 +6,27 @@ import {
   type ChatStreamEvent,
 } from '@omadia/channel-sdk';
 
+import { synthesizeSurfaceEvents } from './surfaceSynthesis.js';
+
 /**
- * @omadia/ui-orchestrator — Omadia UI Tier-2 orchestrator, skeleton (PR-9a).
+ * @omadia/ui-orchestrator — Omadia UI Tier-2 orchestrator (PR-9b-1).
  *
  * `kind: extension`. On activate it publishes the `canvasChatAgent` service —
  * the bundle a canvas channel reaches via `channel.dispatch_service` (PR-6).
  *
- * v0 is a thin DELEGATING skeleton: `canvasChatAgent` forwards `chat` /
- * `chatStream` to the base `chatAgent`, resolved lazily per call so a
- * hot-reloaded orchestrator is always used. This is the integration seam where
- * the real canvas work lands in follow-ups — the UI Skill (composition-idiom
- * library), `surface_*` synthesis, the per-`canvasSessionId` mutex, the data
- * cache, and the deferred wiring (PR-7b sentinel gating, `writeCapabilities`
- * attachment, `structured` threading). It does NOT yet synthesise any canvas
- * surface; routing a canvas channel to it today yields plain chat behaviour.
+ * `canvasChatAgent` resolves the base `chatAgent` lazily per call (so a
+ * hot-reloaded orchestrator is always used) and, for a **canvas turn** (one that
+ * carries `input.canvasSessionId`), wraps the base event stream in
+ * {@link synthesizeSurfaceEvents}: an authorised tool's `_pendingCanvasTree`
+ * sentinel becomes an injected `surface_snapshot`. Non-canvas turns (and the
+ * `chat()` path) pass straight through. The base orchestrator tool loop is
+ * untouched.
+ *
+ * Still to land (later 9b slices): the producer (a canvas-output tool / UI Skill
+ * that actually emits the sentinel — until then the synthesiser is inert in
+ * production), the boot-computed canvas-output allow-set wiring,
+ * `_pendingStructuredPayload` → `surface_data_ref_created`, and the
+ * per-`canvasSessionId` write mutex + cross-turn `surfaceSeq` continuity.
  */
 
 /**
@@ -29,6 +36,17 @@ import {
  * `dispatch_service` must carry this exact bare string.
  */
 export const CANVAS_CHAT_AGENT_SERVICE = 'canvasChatAgent';
+
+const CANVAS_PROTOCOL_VERSION = '1.0';
+const OPS_CATALOG_VERSION = '1.0';
+
+/**
+ * Deny-by-default canvas-output allow-set. EMPTY until the boot-computed set of
+ * canvas-output-authorised tools is wired alongside the first producer tool
+ * (PR-9b-2); until then no tool is trusted to emit canvas sentinels, so the
+ * synthesiser is correctly inert in production. The gate mechanism is live.
+ */
+const CANVAS_OUTPUT_TOOLS: ReadonlySet<string> = new Set<string>();
 
 export interface UiOrchestratorPluginHandle {
   close(): Promise<void>;
@@ -51,7 +69,16 @@ export async function activate(
     chatStream(input, observer) {
       const base = resolveBase();
       if (!base) return errorStream();
-      return base.chatStream(input, observer);
+      const stream = base.chatStream(input, observer);
+      // Only a canvas turn (channel-threaded canvasSessionId) gets surface
+      // synthesis; classic turns pass straight through, byte-for-byte.
+      if (!input.canvasSessionId) return stream;
+      return synthesizeSurfaceEvents(stream, {
+        canvasSessionId: input.canvasSessionId,
+        authorizedToolNames: CANVAS_OUTPUT_TOOLS,
+        protocolVersion: CANVAS_PROTOCOL_VERSION,
+        opsCatalogVersion: OPS_CATALOG_VERSION,
+      });
     },
   };
 

--- a/middleware/packages/omadia-ui-orchestrator/src/surfaceSynthesis.ts
+++ b/middleware/packages/omadia-ui-orchestrator/src/surfaceSynthesis.ts
@@ -1,0 +1,80 @@
+import type { ChatStreamEvent, RevisionId } from '@omadia/channel-sdk';
+import { parseToolEmittedCanvasTree } from '@omadia/orchestrator';
+
+/**
+ * Tier-2 surface synthesis (PR-9b-1).
+ *
+ * The `canvasChatAgent` wraps the base orchestrator's event stream and turns it
+ * canvas-aware: when an AUTHORISED tool returns a `_pendingCanvasTree` sentinel
+ * (#169 parser), a `surface_snapshot` event is synthesised and injected into the
+ * stream; every other event passes through unchanged. Pure transformer — no
+ * shared state, and the base orchestrator tool loop is untouched.
+ *
+ * What is intentionally NOT here yet (later 9b slices):
+ *   - the producer: no tool emits `_pendingCanvasTree` today, so in production
+ *     this is inert until PR-9b-2 ships a canvas-output tool / UI Skill;
+ *   - `_pendingStructuredPayload` → `surface_data_ref_created` (needs DataRef
+ *     HMAC signing);
+ *   - cross-turn `surfaceSeq` continuity + the per-canvasSession write mutex
+ *     (PR-9b-3) — `surfaceSeq` here is per-stream.
+ */
+
+export interface SurfaceSynthesisConfig {
+  /** the canvas session this turn belongs to — stamped onto every surface event. */
+  canvasSessionId: string;
+  /**
+   * Deny-by-default gate: only a tool result from a tool in this set is scanned
+   * for canvas sentinels. EMPTY until the boot-computed canvas-output allow-set
+   * is wired alongside the first producer tool (PR-9b-2), so in production today
+   * nothing is synthesised — the correct secure-by-construction default. The
+   * gate mechanism itself is live and tested.
+   */
+  authorizedToolNames: ReadonlySet<string>;
+  protocolVersion: string;
+  opsCatalogVersion: string;
+}
+
+/**
+ * Transform a base orchestrator `ChatStreamEvent` stream into a canvas-aware one.
+ * Builds its own `tool_use.id → name` map (the `tool_result` event carries only
+ * the id) so the gate can be enforced by tool name.
+ */
+export async function* synthesizeSurfaceEvents(
+  base: AsyncIterable<ChatStreamEvent>,
+  config: SurfaceSynthesisConfig,
+): AsyncGenerator<ChatStreamEvent> {
+  const toolNameById = new Map<string, string>();
+  let surfaceSeq = 0;
+  let revision = 0;
+
+  for await (const ev of base) {
+    if (ev.type === 'tool_use') {
+      toolNameById.set(ev.id, ev.name);
+      yield ev;
+      continue;
+    }
+
+    if (ev.type === 'tool_result') {
+      yield ev;
+      const name = toolNameById.get(ev.id);
+      if (name !== undefined && config.authorizedToolNames.has(name)) {
+        const parsed = parseToolEmittedCanvasTree(ev.output);
+        if (parsed) {
+          const snapshot: ChatStreamEvent = {
+            type: 'surface_snapshot',
+            canvasSessionId: config.canvasSessionId,
+            surfaceSeq: surfaceSeq++,
+            producesRevision: String(revision++) as RevisionId,
+            tree: parsed.tree,
+            protocolVersion: config.protocolVersion,
+            opsCatalogVersion: config.opsCatalogVersion,
+          };
+          yield snapshot;
+        }
+      }
+      continue;
+    }
+
+    yield ev;
+  }
+}

--- a/middleware/src/channels/orchestratorDispatcher.ts
+++ b/middleware/src/channels/orchestratorDispatcher.ts
@@ -87,10 +87,19 @@ export function createOrchestratorDispatcher(
         yield { type: 'error', message: 'orchestrator unavailable' };
         return;
       }
+      // Omadia UI: thread the canvas session id (set by the canvas channel in
+      // the turn metadata) into ChatTurnInput so a canvas-aware orchestrator can
+      // stamp it onto the surface_* events it synthesises. Classic channels set
+      // no such metadata — the field stays undefined and nothing changes.
+      const canvasSessionId =
+        typeof input.metadata?.['canvasSessionId'] === 'string'
+          ? (input.metadata['canvasSessionId'] as string)
+          : undefined;
       yield* agent.chatStream({
         userMessage: input.text,
         sessionScope: input.scope,
         userId: input.userRef.id,
+        ...(canvasSessionId ? { canvasSessionId } : {}),
       });
     },
   };

--- a/middleware/test/uiOrchestratorSurface.test.ts
+++ b/middleware/test/uiOrchestratorSurface.test.ts
@@ -1,0 +1,149 @@
+/**
+ * PR-9b-1 — Tier-2 surface synthesis in the canvasChatAgent.
+ *
+ * Drives `synthesizeSurfaceEvents` with a fake base `ChatStreamEvent` stream
+ * (no kernel, no real orchestrator): an AUTHORISED tool's `_pendingCanvasTree`
+ * sentinel becomes an injected `surface_snapshot`; the gate is deny-by-default;
+ * non-tool events pass through unchanged; surfaceSeq/revision are monotonic.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { ChatStreamEvent } from '../packages/harness-channel-sdk/src/index.js';
+import {
+  synthesizeSurfaceEvents,
+  type SurfaceSynthesisConfig,
+} from '../packages/omadia-ui-orchestrator/src/surfaceSynthesis.js';
+
+function streamOf(events: ChatStreamEvent[]): AsyncIterable<ChatStreamEvent> {
+  return (async function* () {
+    for (const e of events) {
+      await Promise.resolve();
+      yield e;
+    }
+  })();
+}
+
+async function collect(
+  it: AsyncIterable<ChatStreamEvent>,
+): Promise<ChatStreamEvent[]> {
+  const out: ChatStreamEvent[] = [];
+  for await (const e of it) out.push(e);
+  return out;
+}
+
+function field(e: ChatStreamEvent, k: string): unknown {
+  return (e as unknown as Record<string, unknown>)[k];
+}
+
+function cfg(authorized: string[]): SurfaceSynthesisConfig {
+  return {
+    canvasSessionId: 'cs1',
+    authorizedToolNames: new Set(authorized),
+    protocolVersion: '1.0',
+    opsCatalogVersion: '1.0',
+  };
+}
+
+const toolUse = (id: string, name: string): ChatStreamEvent =>
+  ({ type: 'tool_use', id, name, input: {} }) as unknown as ChatStreamEvent;
+const toolResult = (id: string, output: string): ChatStreamEvent =>
+  ({ type: 'tool_result', id, output, durationMs: 1 }) as unknown as ChatStreamEvent;
+
+const CANVAS_TREE_OUTPUT = JSON.stringify({
+  prose: 'here is the table',
+  _pendingCanvasTree: { tree: { type: 'p_text', id: 'x' } },
+});
+
+describe('canvasChatAgent surface synthesis', () => {
+  it('synthesises a surface_snapshot from an authorised tool canvas sentinel', async () => {
+    const out = await collect(
+      synthesizeSurfaceEvents(
+        streamOf([
+          toolUse('t1', 'canvas_tool'),
+          toolResult('t1', CANVAS_TREE_OUTPUT),
+          { type: 'done', answer: 'x' } as unknown as ChatStreamEvent,
+        ]),
+        cfg(['canvas_tool']),
+      ),
+    );
+    const snap = out.find((e) => e.type === 'surface_snapshot');
+    assert.ok(snap, 'surface_snapshot emitted');
+    assert.equal(field(snap, 'canvasSessionId'), 'cs1');
+    assert.equal(field(snap, 'surfaceSeq'), 0);
+    assert.equal(field(snap, 'producesRevision'), '0');
+    assert.deepEqual(field(snap, 'tree'), { type: 'p_text', id: 'x' });
+    assert.equal(field(snap, 'protocolVersion'), '1.0');
+    // original events survive
+    assert.ok(out.some((e) => e.type === 'tool_result'));
+    assert.ok(out.some((e) => e.type === 'done'));
+  });
+
+  it('does not synthesise when the tool is not authorised (deny-by-default)', async () => {
+    const out = await collect(
+      synthesizeSurfaceEvents(
+        streamOf([
+          toolUse('t1', 'canvas_tool'),
+          toolResult('t1', CANVAS_TREE_OUTPUT),
+        ]),
+        cfg([]), // empty allow-set
+      ),
+    );
+    assert.ok(
+      !out.some((e) => e.type === 'surface_snapshot'),
+      'gate denies an unauthorised tool',
+    );
+    assert.ok(out.some((e) => e.type === 'tool_result'), 'tool_result still passes through');
+  });
+
+  it('passes through a tool result that carries no canvas sentinel', async () => {
+    const out = await collect(
+      synthesizeSurfaceEvents(
+        streamOf([
+          toolUse('t1', 'canvas_tool'),
+          toolResult('t1', 'just plain text'),
+        ]),
+        cfg(['canvas_tool']),
+      ),
+    );
+    assert.ok(!out.some((e) => e.type === 'surface_snapshot'));
+  });
+
+  it('passes non-tool events through unchanged and in order', async () => {
+    const out = await collect(
+      synthesizeSurfaceEvents(
+        streamOf([
+          { type: 'text_delta', text: 'a' } as ChatStreamEvent,
+          { type: 'text_delta', text: 'b' } as ChatStreamEvent,
+          { type: 'done', answer: 'ab' } as unknown as ChatStreamEvent,
+        ]),
+        cfg(['x']),
+      ),
+    );
+    assert.deepEqual(
+      out.map((e) => e.type),
+      ['text_delta', 'text_delta', 'done'],
+    );
+  });
+
+  it('assigns monotonic surfaceSeq + revision across multiple snapshots', async () => {
+    const out = await collect(
+      synthesizeSurfaceEvents(
+        streamOf([
+          toolUse('t1', 'canvas_tool'),
+          toolResult('t1', CANVAS_TREE_OUTPUT),
+          toolUse('t2', 'canvas_tool'),
+          toolResult('t2', CANVAS_TREE_OUTPUT),
+        ]),
+        cfg(['canvas_tool']),
+      ),
+    );
+    const snaps = out.filter((e) => e.type === 'surface_snapshot');
+    assert.equal(snaps.length, 2);
+    assert.equal(field(snaps[0] as ChatStreamEvent, 'surfaceSeq'), 0);
+    assert.equal(field(snaps[1] as ChatStreamEvent, 'surfaceSeq'), 1);
+    assert.equal(field(snaps[0] as ChatStreamEvent, 'producesRevision'), '0');
+    assert.equal(field(snaps[1] as ChatStreamEvent, 'producesRevision'), '1');
+  });
+});


### PR DESCRIPTION
## What

First slice of the real Tier-2 canvas composition. Makes `canvasChatAgent` a real **stream transformer** — **without touching the shared base orchestrator tool loop**. For a canvas turn (one carrying `input.canvasSessionId`), it wraps `base.chatStream` in `synthesizeSurfaceEvents`: each `tool_result` from an **authorised** tool is scanned with `parseToolEmittedCanvasTree` (#169), and a `_pendingCanvasTree` sentinel becomes a synthesised `surface_snapshot` injected into the stream. Everything else passes through; non-canvas turns and the `chat()` path pass straight through.

## Architecture

Surface synthesis lives entirely in the `canvasChatAgent` wrapper (a pure event-stream transformer). The base orchestrator tool loop, `NativeToolRegistry`, and `pluginContext` are **untouched**. Only two shared files get additive touches:
- `ChatTurnInput` gains an optional `canvasSessionId`;
- `orchestratorDispatcher` reads it from the turn metadata (set by the canvas channel, PR-10b) and threads it into `chatStream`. Classic channels never set it → unchanged.

`@omadia/orchestrator` added as a `ui-orchestrator` peerDep for the #169 parsers.

## Gate (deny-by-default)

Only tools in `authorizedToolNames` are scanned. The set is **empty today** — the boot-computed canvas-output allow-set is wired alongside the first producer tool (PR-9b-2). No tool emits `_pendingCanvasTree` yet, so the synthesiser is **correctly inert in production** (secure-by-construction). The gate mechanism itself is live + tested.

## Verification

- `build` ✓ · `lint` ✓ · `typecheck` ✓ · full `test` suite ✓ (2914 pass, 0 fail).
- `test/uiOrchestratorSurface.test.ts`: authorised sentinel → `surface_snapshot`; empty allow-set → nothing (deny-by-default); no sentinel → nothing; non-tool events unchanged + in order; monotonic `surfaceSeq`/revision.
- **Codex-reviewed: 0 blockers, 0 should-fix, 0 nits** — architecture, gate, threading, ordering, and additivity all confirmed clean.

## Scope / decomposition

PR-9b is deliberately multi-slice. **This is 9b-1** (the synthesis plumbing). Still to land:
- **9b-2** — the producer (a canvas-output tool / UI Skill that actually emits `_pendingCanvasTree`) + the boot-computed allow-set wiring. *(Product/architecture fork — to be decided before building.)*
- **9b-3** — `_pendingStructuredPayload` → `surface_data_ref_created` (DataRef HMAC), the per-`canvasSession` write mutex, cross-turn `surfaceSeq` continuity + cache.

Additive throughout; inert for every non-canvas turn and existing channel. Per AGENTS.md, `docs/middleware-agent-handoff.md` updated in the same PR; no `Co-Authored-By` trailer.