### PR TITLE
feat(builder): codegen/build/runtime observability tools for the Builder agent (#227)

### DIFF
--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -2290,6 +2290,18 @@ async function main(): Promise<void> {
     );
   }
 
+  // Issue #227 — platform-version banner for the Builder system prompt. The
+  // boot timestamp is captured once here (server start); a redeploy bumps it,
+  // letting the Builder notice the platform changed between turns and re-verify
+  // earlier bug hypotheses (inspect_generated_artifact / get_build_status /
+  // runtime_smoke_status) instead of asking the operator to drive a preview.
+  const builderPlatformPkg = await import('../package.json', {
+    with: { type: 'json' },
+  }).then((m) => m.default as { name?: string; version?: string });
+  const builderPlatformBanner =
+    `omadia platform: ${builderPlatformPkg.name ?? 'omadia-middleware'} ` +
+    `${builderPlatformPkg.version ?? '0.0.0'} (process booted ${new Date().toISOString()})`;
+
   const builderAgent = new BuilderAgent({
     anthropic: client,
     draftStore,
@@ -2325,6 +2337,13 @@ async function main(): Promise<void> {
     githubIssueCache: builderGithubIssueCache,
     upstreamIssueConfig,
     directIssueCreateAvailable: builderIssueCreator !== undefined,
+    // Issue #227 — codegen / build / runtime observability accessors for the
+    // get_build_status + runtime_smoke_status tools, plus the version banner.
+    lastBuildStatus: (draftId: string) =>
+      builderBuildPipeline.getLastBuildStatus(draftId),
+    lastSmokeStatus: (draftId: string) =>
+      builderRuntimeSmokeOrchestrator.getLastSmokeStatus(draftId),
+    platformBanner: builderPlatformBanner,
     logger: (...args: unknown[]) => {
       console.log('[builder]', ...args);
     },

--- a/middleware/src/plugins/builder/buildPipeline.ts
+++ b/middleware/src/plugins/builder/buildPipeline.ts
@@ -86,6 +86,34 @@ export interface PipelineRunResult {
   buildN: number;
 }
 
+/**
+ * Issue #227 — last-known build outcome for a draft, retained in-memory so
+ * the Builder agent's `get_build_status` tool can pull it without an SSE
+ * round-trip. BuildPipeline is the single chokepoint every preview / install
+ * build flows through (both the rebuild-scheduler and the chat-preview route
+ * call `run()`), so retaining the outcome here captures all builds from one
+ * place instead of the ~6 scattered `build_status` emit sites.
+ */
+export interface BuildStatusSnapshot {
+  status: 'ok' | 'failed';
+  /**
+   * `complete` on success; the failure stage otherwise. For build-produced
+   * failures this is the `BuildFailureReason` (`tsc` | `timeout` | …); for
+   * pre-build throws it is the `BuildPipelineError` code (`codegen_failed` |
+   * `staging_failed` | `spec_invalid` | `draft_not_found`) or `unknown`.
+   */
+  phase: string;
+  /** Monotonic build counter for the build this snapshot describes; absent
+   *  when the build failed before a counter was assigned (spec / codegen). */
+  buildN?: number;
+  /** Number of tsc errors on a `tsc`-phase failure. */
+  errorCount?: number;
+  /** Short failure reason / message. Absent on success. */
+  reason?: string;
+  /** ISO-8601 timestamp of when this outcome was recorded. */
+  builtAt: string;
+}
+
 export class BuildPipelineError extends Error {
   readonly code:
     | 'draft_not_found'
@@ -116,6 +144,9 @@ export class BuildPipeline {
   private readonly templateReady: Promise<void> | undefined;
   private readonly log: (...args: unknown[]) => void;
 
+  /** Issue #227 — last recorded build outcome per draft (in-memory). */
+  private readonly lastStatus = new Map<string, BuildStatusSnapshot>();
+
   constructor(deps: BuildPipelineDeps) {
     this.draftStore = deps.draftStore;
     this.buildQueue = deps.buildQueue;
@@ -127,7 +158,55 @@ export class BuildPipeline {
     this.log = deps.logger ?? (() => {});
   }
 
+  /**
+   * Public entry point. Delegates to `executeRun` and records the outcome
+   * (Issue #227) so the `get_build_status` tool can surface it. Recording
+   * covers the success path — including build-produced `tsc` failures, which
+   * `executeRun` returns rather than throws — and the typed
+   * `BuildPipelineError` throw paths.
+   */
   async run(opts: PipelineRunOptions): Promise<PipelineRunResult> {
+    try {
+      const result = await this.executeRun(opts);
+      this.lastStatus.set(
+        opts.draftId,
+        result.buildResult.ok
+          ? {
+              status: 'ok',
+              phase: 'complete',
+              buildN: result.buildN,
+              builtAt: new Date().toISOString(),
+            }
+          : {
+              status: 'failed',
+              phase: result.buildResult.reason,
+              buildN: result.buildN,
+              errorCount: result.buildResult.errors.length,
+              reason: result.buildResult.reason,
+              builtAt: new Date().toISOString(),
+            },
+      );
+      return result;
+    } catch (err) {
+      this.lastStatus.set(opts.draftId, {
+        status: 'failed',
+        phase: err instanceof BuildPipelineError ? err.code : 'unknown',
+        reason: err instanceof Error ? err.message : String(err),
+        builtAt: new Date().toISOString(),
+      });
+      throw err;
+    }
+  }
+
+  /**
+   * Issue #227 — last recorded build outcome for a draft, or `undefined` when
+   * no build has run for it in the current process.
+   */
+  getLastBuildStatus(draftId: string): BuildStatusSnapshot | undefined {
+    return this.lastStatus.get(draftId);
+  }
+
+  private async executeRun(opts: PipelineRunOptions): Promise<PipelineRunResult> {
     const draft = await this.draftStore.load(opts.userEmail, opts.draftId);
     if (!draft) {
       throw new BuildPipelineError(

--- a/middleware/src/plugins/builder/builderAgent.ts
+++ b/middleware/src/plugins/builder/builderAgent.ts
@@ -17,6 +17,8 @@ import { zodToJsonSchema } from '../zodToJsonSchema.js';
 import { type AuditLogger, createAuditLogger } from './audit.js';
 import { loadBoilerplate, type SlotDef } from './boilerplateSource.js';
 import type { DraftStore } from './draftStore.js';
+import type { BuildStatusSnapshot } from './buildPipeline.js';
+import type { SmokeStatusSnapshot } from './runtimeSmokeOrchestrator.js';
 import type { SlotTypecheckService } from './slotTypecheckPipeline.js';
 import type { SpecEventBus } from './specEventBus.js';
 import type { UserChoiceCoordinator } from './userChoiceCoordinator.js';
@@ -288,6 +290,29 @@ export interface BuilderAgentDeps {
    * observe calls without touching SQLite.
    */
   audit?: AuditLogger;
+  /**
+   * Issue #227 — pull-accessor for the last codegen→tsc build outcome of a
+   * draft, threaded into `BuilderToolContext.lastBuildStatus` so the
+   * `get_build_status` tool can surface it. Wired by `index.ts` to
+   * `BuildPipeline.getLastBuildStatus`. Omitted in tests → tool reports the
+   * surface unavailable.
+   */
+  lastBuildStatus?: (draftId: string) => BuildStatusSnapshot | undefined;
+  /**
+   * Issue #227 — pull-accessor for the last runtime-smoke result of a draft,
+   * threaded into `BuilderToolContext.lastSmokeStatus` for the
+   * `runtime_smoke_status` tool. Wired to
+   * `RuntimeSmokeOrchestrator.getLastSmokeStatus`.
+   */
+  lastSmokeStatus?: (draftId: string) => SmokeStatusSnapshot | undefined;
+  /**
+   * Issue #227 — one-line platform-version banner prepended to the system
+   * prompt (e.g. `omadia platform: omadia-middleware 0.2.0 (process booted
+   * 2026-06-05T…Z)`). Lets the Builder notice the platform changed between
+   * turns (a redeploy bumps the boot timestamp) and proactively re-verify
+   * earlier bug hypotheses. Wired by `index.ts`; omitted in tests → no banner.
+   */
+  platformBanner?: string;
   logger?: (...args: unknown[]) => void;
 }
 
@@ -332,6 +357,13 @@ export class BuilderAgent {
     repo: string;
     labels: readonly string[];
   };
+  private readonly lastBuildStatus?: (
+    draftId: string,
+  ) => BuildStatusSnapshot | undefined;
+  private readonly lastSmokeStatus?: (
+    draftId: string,
+  ) => SmokeStatusSnapshot | undefined;
+  private readonly platformBanner?: string;
   private readonly log: (...args: unknown[]) => void;
 
   private cachedSystemPromptSeed: string | null = null;
@@ -362,6 +394,9 @@ export class BuilderAgent {
     this.githubIssueCache = deps.githubIssueCache;
     this.directIssueCreateAvailable = deps.directIssueCreateAvailable ?? false;
     this.upstreamIssueConfig = deps.upstreamIssueConfig;
+    this.lastBuildStatus = deps.lastBuildStatus;
+    this.lastSmokeStatus = deps.lastSmokeStatus;
+    this.platformBanner = deps.platformBanner;
     this.log = deps.logger ?? (() => {});
   }
 
@@ -466,6 +501,8 @@ export class BuilderAgent {
         : {}),
       directIssueCreateAvailable: this.directIssueCreateAvailable,
       audit: this.audit,
+      ...(this.lastBuildStatus ? { lastBuildStatus: this.lastBuildStatus } : {}),
+      ...(this.lastSmokeStatus ? { lastSmokeStatus: this.lastSmokeStatus } : {}),
     };
 
     const subAgentTools = this.tools.map((tool) => bridgeBuilderTool(tool, toolCtx));
@@ -740,7 +777,15 @@ export class BuilderAgent {
       }
     }
     const header = buildSpecHeader(spec, slotManifest, draftSlots);
-    return `${header}\n\n---\n\n${this.cachedSystemPromptSeed}`;
+    // Issue #227 — lead with the platform-version banner (when wired) so the
+    // Builder can spot a platform change between turns and re-verify earlier
+    // bug hypotheses (via inspect_generated_artifact / get_build_status /
+    // runtime_smoke_status) instead of asking the operator to drive a preview.
+    const banner =
+      this.platformBanner && this.platformBanner.trim().length > 0
+        ? `${this.platformBanner.trim()}\n\n`
+        : '';
+    return `${banner}${header}\n\n---\n\n${this.cachedSystemPromptSeed}`;
   }
 }
 

--- a/middleware/src/plugins/builder/runtimeSmokeOrchestrator.ts
+++ b/middleware/src/plugins/builder/runtimeSmokeOrchestrator.ts
@@ -1,8 +1,23 @@
 import type { DraftStore } from './draftStore.js';
 import type { PreviewHandle } from './previewRuntime.js';
 import { invokeToolsOnHandle, type RuntimeSmokeResult } from './runtimeSmoke.js';
-import type { SpecEventBus } from './specEventBus.js';
+import type { SpecBusEvent, SpecEventBus } from './specEventBus.js';
 import { parseAgentSpec } from './agentSpec.js';
+
+/** The `runtime_smoke_status` variant of the spec-bus event union. */
+type RuntimeSmokeEvent = Extract<SpecBusEvent, { type: 'runtime_smoke_status' }>;
+
+/**
+ * Issue #227 — last runtime-smoke outcome for a draft, retained in-memory so
+ * the Builder agent's `runtime_smoke_status` tool can pull it (ctx.memory /
+ * ctx.http availability, per-tool + route smoke) without an operator-driven
+ * preview round-trip. Mirrors the emitted bus event minus its `type` tag,
+ * plus a record timestamp.
+ */
+export interface SmokeStatusSnapshot extends Omit<RuntimeSmokeEvent, 'type'> {
+  /** ISO-8601 timestamp of when this snapshot was recorded. */
+  smokedAt: string;
+}
 
 /**
  * RuntimeSmokeOrchestrator (B.9-3) — kicks off the runtime-smoke pass
@@ -38,6 +53,10 @@ export class RuntimeSmokeOrchestrator {
    *  rev hasn't advanced since the previous attempt. */
   private readonly lastSmokedRev = new Map<string, number>();
 
+  /** Issue #227 — per-draft last smoke outcome (in-memory), surfaced to the
+   *  Builder via the `runtime_smoke_status` tool. */
+  private readonly lastStatus = new Map<string, SmokeStatusSnapshot>();
+
   constructor(deps: RuntimeSmokeOrchestratorDeps) {
     this.draftStore = deps.draftStore;
     this.bus = deps.bus;
@@ -66,13 +85,32 @@ export class RuntimeSmokeOrchestrator {
     // returns don't race-fire two smoke runs for the same build.
     this.lastSmokedRev.set(draftId, handle.rev);
 
-    this.bus.emit(draftId, {
+    this.emitSmoke(draftId, {
       type: 'runtime_smoke_status',
       phase: 'running',
       buildN: handle.rev,
     });
 
     void this.runDetached({ handle, userEmail, draftId });
+  }
+
+  /**
+   * Issue #227 — last recorded smoke outcome for a draft, or `undefined` when
+   * no smoke has run for it in the current process.
+   */
+  getLastSmokeStatus(draftId: string): SmokeStatusSnapshot | undefined {
+    return this.lastStatus.get(draftId);
+  }
+
+  /**
+   * Emit a `runtime_smoke_status` event on the bus AND retain it as the
+   * draft's last-known snapshot (Issue #227). All smoke emits funnel through
+   * here so the pull-tool and the SSE stream never drift.
+   */
+  private emitSmoke(draftId: string, event: RuntimeSmokeEvent): void {
+    this.bus.emit(draftId, event);
+    const { type: _type, ...rest } = event;
+    this.lastStatus.set(draftId, { ...rest, smokedAt: new Date().toISOString() });
   }
 
   private async runDetached(opts: {
@@ -85,7 +123,7 @@ export class RuntimeSmokeOrchestrator {
     try {
       const draft = await this.draftStore.load(userEmail, draftId);
       if (!draft) {
-        this.bus.emit(draftId, {
+        this.emitSmoke(draftId, {
           type: 'runtime_smoke_status',
           phase: 'failed',
           buildN: handle.rev,
@@ -98,7 +136,7 @@ export class RuntimeSmokeOrchestrator {
       try {
         spec = parseAgentSpec(draft.spec);
       } catch (err) {
-        this.bus.emit(draftId, {
+        this.emitSmoke(draftId, {
           type: 'runtime_smoke_status',
           phase: 'failed',
           buildN: handle.rev,
@@ -116,7 +154,7 @@ export class RuntimeSmokeOrchestrator {
       // invokeToolsOnHandle itself shouldn't throw — but if the
       // handle.toolkit access blows up (cached handle was closed by
       // a concurrent invalidate), surface as activate_failed for UI.
-      this.bus.emit(draftId, {
+      this.emitSmoke(draftId, {
         type: 'runtime_smoke_status',
         phase: 'failed',
         buildN: handle.rev,
@@ -130,7 +168,7 @@ export class RuntimeSmokeOrchestrator {
       `[smoke] draft=${draftId} rev=${String(handle.rev)} ok=${String(result.ok)} reason=${result.reason} tools=${String(result.results.length)} duration_ms=${String(result.durationMs)}`,
     );
 
-    this.bus.emit(draftId, {
+    this.emitSmoke(draftId, {
       type: 'runtime_smoke_status',
       phase: result.ok ? 'ok' : 'failed',
       buildN: handle.rev,

--- a/middleware/src/plugins/builder/tools/getBuildStatus.ts
+++ b/middleware/src/plugins/builder/tools/getBuildStatus.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod';
+
+import type { BuildStatusSnapshot } from '../buildPipeline.js';
+import type { BuilderTool } from './types.js';
+
+/**
+ * Issue #227 — `get_build_status`.
+ *
+ * Pull the last codegen→staging→tsc→zip build outcome for the current draft.
+ * Lets the Builder agent verify a manifest-synthesis / tsc fix landed after a
+ * platform update without asking the operator to drive a preview round-trip
+ * and report back verbally. The status is retained by `BuildPipeline` — the
+ * single chokepoint every preview / install build flows through — so it
+ * stays in lock-step with the `build_status` SSE events the UI sees.
+ */
+
+const InputSchema = z.object({}).strict();
+
+type Input = z.infer<typeof InputSchema>;
+
+interface KnownResult extends BuildStatusSnapshot {
+  ok: true;
+}
+interface UnknownResult {
+  ok: true;
+  status: 'unknown';
+  note: string;
+}
+interface UnavailableResult {
+  ok: false;
+  error: string;
+}
+type Result = KnownResult | UnknownResult | UnavailableResult;
+
+export const getBuildStatusTool: BuilderTool<Input, Result> = {
+  id: 'get_build_status',
+  description:
+    'Return the last build outcome for the current draft: status (ok | ' +
+    'failed), the failure phase when failed (codegen | staging | tsc | …), ' +
+    'tsc error count, and a timestamp. Use it to confirm a codegen / tsc fix ' +
+    'took effect after a platform update — no operator preview round-trip ' +
+    'needed. Reports "unknown" when no build has run yet this process. ' +
+    'Read-only.',
+  input: InputSchema,
+  async run(_input, ctx) {
+    if (!ctx.lastBuildStatus) {
+      return {
+        ok: false,
+        error:
+          'build-status surface is not wired in this environment — no build ' +
+          'pipeline available to query',
+      };
+    }
+    const snapshot = ctx.lastBuildStatus(ctx.draftId);
+    if (!snapshot) {
+      return {
+        ok: true,
+        status: 'unknown',
+        note:
+          'No build has run for this draft in the current platform process. ' +
+          'Patch the spec or trigger a preview build, then check again.',
+      };
+    }
+    return { ok: true, ...snapshot };
+  },
+};

--- a/middleware/src/plugins/builder/tools/index.ts
+++ b/middleware/src/plugins/builder/tools/index.ts
@@ -1,5 +1,7 @@
 import { askUserChoiceTool } from './askUserChoice.js';
 import { fillSlotTool } from './fillSlot.js';
+import { getBuildStatusTool } from './getBuildStatus.js';
+import { inspectGeneratedArtifactTool } from './inspectGeneratedArtifact.js';
 import { lintSpecTool } from './lintSpec.js';
 import { listCatalogToolsTool } from './listCatalogTools.js';
 import { listPackageTypesTool } from './listPackageTypes.js';
@@ -9,6 +11,7 @@ import { readPackageTypesTool } from './readPackageTypes.js';
 import { readReferenceTool } from './readReference.js';
 import { readSlotTool } from './readSlot.js';
 import { reportPlatformIssueTool } from './reportPlatformIssue.js';
+import { runtimeSmokeStatusTool } from './runtimeSmokeStatus.js';
 import { setPersonaConfigTool } from './setPersonaConfig.js';
 import { setQualityConfigTool } from './setQualityConfig.js';
 import { suggestDependsOnTool } from './suggestDependsOn.js';
@@ -28,6 +31,8 @@ export type { LintIssue, LintSeverity } from './lintSpec.js';
 export {
   askUserChoiceTool,
   fillSlotTool,
+  getBuildStatusTool,
+  inspectGeneratedArtifactTool,
   lintSpecTool,
   listCatalogToolsTool,
   listPackageTypesTool,
@@ -37,6 +42,7 @@ export {
   readReferenceTool,
   readSlotTool,
   reportPlatformIssueTool,
+  runtimeSmokeStatusTool,
   setPersonaConfigTool,
   setQualityConfigTool,
   suggestDependsOnTool,
@@ -57,6 +63,10 @@ export function builderTools(): ReadonlyArray<BuilderTool<unknown, unknown>> {
     readReferenceTool as unknown as BuilderTool<unknown, unknown>,
     listPackageTypesTool as unknown as BuilderTool<unknown, unknown>,
     readPackageTypesTool as unknown as BuilderTool<unknown, unknown>,
+    // Issue #227 — codegen / build / runtime observability (read-only).
+    inspectGeneratedArtifactTool as unknown as BuilderTool<unknown, unknown>,
+    getBuildStatusTool as unknown as BuilderTool<unknown, unknown>,
+    runtimeSmokeStatusTool as unknown as BuilderTool<unknown, unknown>,
     setQualityConfigTool as unknown as BuilderTool<unknown, unknown>,
     setPersonaConfigTool as unknown as BuilderTool<unknown, unknown>,
     suggestDependsOnTool as unknown as BuilderTool<unknown, unknown>,

--- a/middleware/src/plugins/builder/tools/inspectGeneratedArtifact.ts
+++ b/middleware/src/plugins/builder/tools/inspectGeneratedArtifact.ts
@@ -1,0 +1,144 @@
+import { z } from 'zod';
+
+import { safeParseAgentSpec } from '../agentSpec.js';
+import { CodegenError, generate, type CodegenIssue } from '../codegen.js';
+import type { BuilderTool } from './types.js';
+
+/**
+ * Issue #227 — `inspect_generated_artifact`.
+ *
+ * Read-only window onto the Builder draft's *codegen output* — the rendered
+ * `manifest.yaml` / `package.json` / `tsconfig.json` (and every other
+ * generated file) that the spec + slots produce. Until this tool existed the
+ * codegen synthesis path was a blackbox to the Builder agent: it could lint
+ * the spec and gate slots through tsc, but it could not see what the manifest
+ * synthesiser actually emitted — so verifying a "the fix now lands
+ * `permissions.memory` in the manifest" claim required an operator-driven
+ * preview round-trip.
+ *
+ * Implementation note: `generate()` is a pure function of (spec, slots), so
+ * this tool re-runs it on-demand against the current draft rather than
+ * reading the build pipeline's staging directory (which is cleaned up after
+ * every build). A `CodegenError` is itself signal — it carries the exact
+ * placeholder-residue / missing-slot issues the agent needs to act on, so we
+ * surface those rather than swallowing them.
+ */
+
+const DEFAULT_FILE = 'manifest.yaml';
+
+/** Cap on returned content. The headline artefacts (manifest/package/tsconfig)
+ *  are tiny; a generous cap keeps a large slot-backed source file from blowing
+ *  the tool_result frame while still covering every real artefact. */
+const MAX_BYTES = 128 * 1024;
+
+const InputSchema = z
+  .object({
+    /**
+     * Generated file to read, relative to the plugin root (e.g.
+     * `manifest.yaml`, `package.json`, `tsconfig.json`, `src/plugin.ts`).
+     * Defaults to `manifest.yaml`. Call once with no args to discover the
+     * full file listing via the `availableFiles` field.
+     */
+    file: z.string().min(1).max(400).optional(),
+  })
+  .strict();
+
+type Input = z.infer<typeof InputSchema>;
+
+interface OkResult {
+  ok: true;
+  file: string;
+  content: string;
+  bytes: number;
+  /** Every generated file path, so the agent can pick another artefact. */
+  availableFiles: ReadonlyArray<string>;
+}
+interface ErrResult {
+  ok: false;
+  error: string;
+  hint?: string;
+  /** Populated on a codegen failure — the exact issues that blocked
+   *  synthesis (placeholder residue, missing required slot, …). This is the
+   *  whole point: the agent can now cite *why* the manifest is wrong. */
+  issues?: ReadonlyArray<CodegenIssue>;
+  /** Populated on a file-not-found miss so the agent can pick a real path. */
+  availableFiles?: ReadonlyArray<string>;
+}
+type Result = OkResult | ErrResult;
+
+export const inspectGeneratedArtifactTool: BuilderTool<Input, Result> = {
+  id: 'inspect_generated_artifact',
+  description:
+    'Read a generated artefact for the current draft — the codegen output, ' +
+    'not the spec. `file` defaults to "manifest.yaml" (also useful: ' +
+    '"package.json", "tsconfig.json", "src/plugin.ts"). Call with no args to ' +
+    'list every generated file. Re-runs codegen on demand; if synthesis ' +
+    'fails it returns the exact blocking issues (placeholder residue, missing ' +
+    'slot) so you can cite what the manifest is actually missing instead of ' +
+    'guessing. Read-only.',
+  input: InputSchema,
+  async run({ file }, ctx) {
+    const draft = await ctx.draftStore.load(ctx.userEmail, ctx.draftId);
+    if (!draft) {
+      return { ok: false, error: `draft '${ctx.draftId}' not found` };
+    }
+
+    const parsed = safeParseAgentSpec(draft.spec);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        error:
+          'spec does not validate — fix the spec (see lint_spec) before the ' +
+          'manifest can be generated',
+        hint: parsed.error.issues
+          .slice(0, 5)
+          .map((i) => `/${i.path.map(String).join('/')}: ${i.message}`)
+          .join('; '),
+      };
+    }
+
+    let files: Map<string, Buffer>;
+    try {
+      files = await generate({ spec: parsed.data, slots: draft.slots });
+    } catch (err) {
+      if (err instanceof CodegenError) {
+        return {
+          ok: false,
+          error: `codegen failed (${String(err.issues.length)} issue(s)) — the manifest could not be synthesised`,
+          issues: err.issues,
+        };
+      }
+      return {
+        ok: false,
+        error: `codegen threw: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    const availableFiles = [...files.keys()].sort();
+    const target = file ?? DEFAULT_FILE;
+    const buf = files.get(target);
+    if (!buf) {
+      return {
+        ok: false,
+        error: `generated file '${target}' does not exist`,
+        hint: `available: ${availableFiles.join(', ')}`,
+        availableFiles,
+      };
+    }
+    if (buf.byteLength > MAX_BYTES) {
+      return {
+        ok: false,
+        error: `generated file '${target}' exceeds ${String(MAX_BYTES)} bytes (size: ${String(buf.byteLength)})`,
+        availableFiles,
+      };
+    }
+
+    return {
+      ok: true,
+      file: target,
+      content: buf.toString('utf-8'),
+      bytes: buf.byteLength,
+      availableFiles,
+    };
+  },
+};

--- a/middleware/src/plugins/builder/tools/runtimeSmokeStatus.ts
+++ b/middleware/src/plugins/builder/tools/runtimeSmokeStatus.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+import type { SmokeStatusSnapshot } from '../runtimeSmokeOrchestrator.js';
+import type { BuilderTool } from './types.js';
+
+/**
+ * Issue #227 — `runtime_smoke_status`.
+ *
+ * Pull the last runtime-smoke outcome for the current draft: whether the
+ * plugin activated, which tools/admin-routes/ui-routes were exercised and how
+ * they fared. The smoke pass already runs after every preview build (it is
+ * how `ctx.memory unavailable`-class activation gaps are detected) but its
+ * result only flowed to the SSE stream — invisible to the Builder agent. This
+ * tool exposes the retained result so the agent can self-diagnose
+ * activate-time failures before the operator restarts the preview.
+ */
+
+const InputSchema = z.object({}).strict();
+
+type Input = z.infer<typeof InputSchema>;
+
+interface KnownResult extends SmokeStatusSnapshot {
+  ok: true;
+}
+interface UnknownResult {
+  ok: true;
+  status: 'unknown';
+  note: string;
+}
+interface UnavailableResult {
+  ok: false;
+  error: string;
+}
+type Result = KnownResult | UnknownResult | UnavailableResult;
+
+export const runtimeSmokeStatusTool: BuilderTool<Input, Result> = {
+  id: 'runtime_smoke_status',
+  description:
+    'Return the last runtime-smoke result for the current draft: did the ' +
+    'plugin activate, and how did its tools / admin-routes / ui-routes fare ' +
+    'when invoked with synthetic input. Use it to confirm activate-time ' +
+    'availability (e.g. ctx.memory / ctx.http) after a platform update ' +
+    'without an operator preview round-trip. Reports "unknown" when no smoke ' +
+    'has run yet this process; "running" while one is in flight. Read-only.',
+  input: InputSchema,
+  async run(_input, ctx) {
+    if (!ctx.lastSmokeStatus) {
+      return {
+        ok: false,
+        error:
+          'runtime-smoke surface is not wired in this environment — no smoke ' +
+          'orchestrator available to query',
+      };
+    }
+    const snapshot = ctx.lastSmokeStatus(ctx.draftId);
+    if (!snapshot) {
+      return {
+        ok: true,
+        status: 'unknown',
+        note:
+          'No runtime-smoke has run for this draft in the current platform ' +
+          'process. It fires automatically after the next successful preview ' +
+          'build — trigger one and check again.',
+      };
+    }
+    return { ok: true, ...snapshot };
+  },
+};

--- a/middleware/src/plugins/builder/tools/types.ts
+++ b/middleware/src/plugins/builder/tools/types.ts
@@ -1,7 +1,9 @@
 import type { z } from 'zod';
 
 import type { AuditLogger } from '../audit.js';
+import type { BuildStatusSnapshot } from '../buildPipeline.js';
 import type { DraftStore } from '../draftStore.js';
+import type { SmokeStatusSnapshot } from '../runtimeSmokeOrchestrator.js';
 import type { SlotTypecheckService } from '../slotTypecheckPipeline.js';
 import type { SpecEventBus } from '../specEventBus.js';
 import type { UserChoiceCoordinator } from '../userChoiceCoordinator.js';
@@ -179,6 +181,22 @@ export interface BuilderToolContext {
    * `read_reference`, …) leave it untouched.
    */
   readonly audit: AuditLogger;
+  /**
+   * Issue #227 — pull-accessor for the last codegen→tsc build outcome of this
+   * draft, surfaced by the `get_build_status` tool so the Builder can verify a
+   * build/tsc fix after a platform update without an operator preview
+   * round-trip. Backed by `BuildPipeline.getLastBuildStatus`. Optional: tests
+   * (and environments without a pipeline) omit it and the tool reports the
+   * surface as unavailable.
+   */
+  readonly lastBuildStatus?: (draftId: string) => BuildStatusSnapshot | undefined;
+  /**
+   * Issue #227 — pull-accessor for the last runtime-smoke result of this draft
+   * (activate success + ctx.memory/http availability + route smoke), surfaced
+   * by the `runtime_smoke_status` tool. Backed by
+   * `RuntimeSmokeOrchestrator.getLastSmokeStatus`. Optional.
+   */
+  readonly lastSmokeStatus?: (draftId: string) => SmokeStatusSnapshot | undefined;
 }
 
 /**

--- a/middleware/test/builder/buildPipelineService.test.ts
+++ b/middleware/test/builder/buildPipelineService.test.ts
@@ -135,6 +135,50 @@ describe('BuildPipeline', () => {
     assert.equal(existsSync(observedStaging), false, 'staging dir cleaned');
   });
 
+  it('retains the last build outcome for get_build_status pull (Issue #227)', async () => {
+    const { spec, slots } = loadFixtureSpec();
+    const draft = await store.create('alice@example.com', 'Weather');
+    await store.update('alice@example.com', draft.id, { spec, slots });
+
+    const queue = new BuildQueue({ concurrency: 1 });
+    let outcome: BuildResult = makeBuildSuccess();
+    const pipeline = new BuildPipeline({
+      draftStore: store,
+      buildQueue: queue,
+      templateRoot,
+      stagingBaseDir,
+      buildSandbox: async () => outcome,
+      logger: () => {},
+    });
+
+    // No build yet → no snapshot.
+    assert.equal(pipeline.getLastBuildStatus(draft.id), undefined);
+
+    // Success path → status ok / phase complete.
+    await pipeline.run({ userEmail: 'alice@example.com', draftId: draft.id });
+    const okSnap = pipeline.getLastBuildStatus(draft.id);
+    assert.equal(okSnap?.status, 'ok');
+    assert.equal(okSnap?.phase, 'complete');
+    assert.equal(okSnap?.buildN, 1);
+    assert.ok(okSnap?.builtAt);
+
+    // Build-produced tsc failure → status failed / phase tsc / errorCount.
+    outcome = makeBuildFailure();
+    await pipeline.run({ userEmail: 'alice@example.com', draftId: draft.id });
+    const failSnap = pipeline.getLastBuildStatus(draft.id);
+    assert.equal(failSnap?.status, 'failed');
+    assert.equal(failSnap?.phase, 'tsc');
+    assert.equal(failSnap?.errorCount, 1);
+
+    // Pre-build throw (missing draft) → status failed / phase draft_not_found.
+    await assert.rejects(
+      pipeline.run({ userEmail: 'alice@example.com', draftId: 'ghost' }),
+    );
+    const throwSnap = pipeline.getLastBuildStatus('ghost');
+    assert.equal(throwSnap?.status, 'failed');
+    assert.equal(throwSnap?.phase, 'draft_not_found');
+  });
+
   it('writes AGENT.md (with persona/quality frontmatter) into the staging dir (Phase 3 / OB-67)', async () => {
     const { spec, slots } = loadFixtureSpec();
     const draft = await store.create('alice@example.com', 'Weather');

--- a/middleware/test/builder/runtimeSmokeOrchestrator.test.ts
+++ b/middleware/test/builder/runtimeSmokeOrchestrator.test.ts
@@ -105,6 +105,28 @@ describe('RuntimeSmokeOrchestrator.attemptSmoke', () => {
     }
   });
 
+  it('retains the last smoke outcome for get_build_status pull (Issue #227)', async () => {
+    const orchestrator = new RuntimeSmokeOrchestrator({ draftStore: store, bus });
+    // No smoke yet → no snapshot.
+    assert.equal(orchestrator.getLastSmokeStatus(draftId), undefined);
+
+    const handle = makeHandle(3, [makeTool('noop', async () => 'done')]);
+    orchestrator.attemptSmoke({ handle, userEmail, draftId });
+
+    // `running` is retained synchronously (mirrors the sync emit).
+    const running = orchestrator.getLastSmokeStatus(draftId);
+    assert.equal(running?.phase, 'running');
+    assert.equal(running?.buildN, 3);
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    const terminal = orchestrator.getLastSmokeStatus(draftId);
+    assert.equal(terminal?.phase, 'ok');
+    assert.equal(terminal?.reason, 'ok');
+    assert.equal(terminal?.results?.length, 1);
+    assert.ok(terminal?.smokedAt);
+  });
+
   it('dedups by (draftId, rev) — second attempt at same rev is a no-op', async () => {
     const orchestrator = new RuntimeSmokeOrchestrator({ draftStore: store, bus });
     const handle = makeHandle(7, [makeTool('noop', async () => 'done')]);

--- a/middleware/test/builder/tools/observabilityTools.test.ts
+++ b/middleware/test/builder/tools/observabilityTools.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { inspectGeneratedArtifactTool } from '../../../src/plugins/builder/tools/inspectGeneratedArtifact.js';
+import { getBuildStatusTool } from '../../../src/plugins/builder/tools/getBuildStatus.js';
+import { runtimeSmokeStatusTool } from '../../../src/plugins/builder/tools/runtimeSmokeStatus.js';
+import { _resetCacheForTests } from '../../../src/plugins/builder/boilerplateSource.js';
+import { _resetServiceTypeRegistryForTests } from '../../../src/plugins/builder/serviceTypeRegistry.js';
+import type { BuildStatusSnapshot } from '../../../src/plugins/builder/buildPipeline.js';
+import type { SmokeStatusSnapshot } from '../../../src/plugins/builder/runtimeSmokeOrchestrator.js';
+import type { AgentSpecSkeleton } from '../../../src/plugins/builder/types.js';
+import {
+  createBuilderToolHarness,
+  type BuilderToolHarness,
+} from '../fixtures/builderToolHarness.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = path.join(HERE, '..', 'fixtures', 'minimal-spec.json');
+
+/** Seed the harness draft with the canonical minimal weather spec + slots so
+ *  codegen produces a full file map. */
+async function seedGeneratableDraft(harness: BuilderToolHarness): Promise<void> {
+  const raw = JSON.parse(readFileSync(FIXTURE_PATH, 'utf-8')) as Record<string, unknown>;
+  const slots = raw['slots'] as Record<string, string>;
+  const { slots: _ignored, ...specInput } = raw;
+  void _ignored;
+  await harness.draftStore.update(harness.userEmail, harness.draftId, {
+    spec: specInput as unknown as AgentSpecSkeleton,
+    slots,
+  });
+}
+
+describe('inspect_generated_artifact (Issue #227)', () => {
+  let harness: BuilderToolHarness;
+
+  beforeEach(async () => {
+    _resetCacheForTests();
+    _resetServiceTypeRegistryForTests();
+    harness = await createBuilderToolHarness();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  it('returns a spec-invalid error on an empty draft skeleton', async () => {
+    const result = await inspectGeneratedArtifactTool.run({}, harness.context());
+    assert.equal(result.ok, false);
+    assert.ok(/spec/i.test(result.error));
+  });
+
+  it('renders manifest.yaml by default and lists every generated file', async () => {
+    await seedGeneratableDraft(harness);
+    const result = await inspectGeneratedArtifactTool.run({}, harness.context());
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.file, 'manifest.yaml');
+      // The rendered manifest carries the resolved agent id, not a placeholder.
+      assert.ok(result.content.includes('de.byte5.agent.weather'));
+      assert.ok(!result.content.includes('{{AGENT_ID}}'));
+      assert.ok(result.availableFiles.includes('package.json'));
+      assert.ok(result.availableFiles.includes('tsconfig.json'));
+      assert.equal(result.bytes, Buffer.byteLength(result.content, 'utf-8'));
+    }
+  });
+
+  it('reads an explicitly requested artefact (package.json)', async () => {
+    await seedGeneratableDraft(harness);
+    const result = await inspectGeneratedArtifactTool.run(
+      { file: 'package.json' },
+      harness.context(),
+    );
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.equal(result.file, 'package.json');
+      const parsed = JSON.parse(result.content) as { name?: string };
+      assert.equal(typeof parsed.name, 'string');
+    }
+  });
+
+  it('errors with an availableFiles hint on an unknown artefact', async () => {
+    await seedGeneratableDraft(harness);
+    const result = await inspectGeneratedArtifactTool.run(
+      { file: 'does-not-exist.yaml' },
+      harness.context(),
+    );
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.ok(result.availableFiles && result.availableFiles.length > 0);
+      assert.ok(result.availableFiles.includes('manifest.yaml'));
+    }
+  });
+});
+
+describe('get_build_status (Issue #227)', () => {
+  let harness: BuilderToolHarness;
+
+  beforeEach(async () => {
+    harness = await createBuilderToolHarness();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  it('reports the surface unavailable when no accessor is wired', async () => {
+    const result = await getBuildStatusTool.run({}, harness.context());
+    assert.equal(result.ok, false);
+  });
+
+  it('returns status "unknown" when the accessor has no snapshot yet', async () => {
+    const ctx = { ...harness.context(), lastBuildStatus: () => undefined };
+    const result = await getBuildStatusTool.run({}, ctx);
+    assert.equal(result.ok, true);
+    if (result.ok && 'status' in result) {
+      assert.equal(result.status, 'unknown');
+    }
+  });
+
+  it('passes through a recorded build snapshot', async () => {
+    const snap: BuildStatusSnapshot = {
+      status: 'failed',
+      phase: 'tsc',
+      buildN: 7,
+      errorCount: 3,
+      reason: 'tsc',
+      builtAt: '2026-06-05T10:32:00.000Z',
+    };
+    const ctx = { ...harness.context(), lastBuildStatus: () => snap };
+    const result = await getBuildStatusTool.run({}, ctx);
+    assert.equal(result.ok, true);
+    if (result.ok && 'phase' in result) {
+      assert.equal(result.status, 'failed');
+      assert.equal(result.phase, 'tsc');
+      assert.equal(result.errorCount, 3);
+      assert.equal(result.builtAt, '2026-06-05T10:32:00.000Z');
+    }
+  });
+});
+
+describe('runtime_smoke_status (Issue #227)', () => {
+  let harness: BuilderToolHarness;
+
+  beforeEach(async () => {
+    harness = await createBuilderToolHarness();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  it('reports the surface unavailable when no accessor is wired', async () => {
+    const result = await runtimeSmokeStatusTool.run({}, harness.context());
+    assert.equal(result.ok, false);
+  });
+
+  it('returns status "unknown" when the accessor has no snapshot yet', async () => {
+    const ctx = { ...harness.context(), lastSmokeStatus: () => undefined };
+    const result = await runtimeSmokeStatusTool.run({}, ctx);
+    assert.equal(result.ok, true);
+    if (result.ok && 'status' in result) {
+      assert.equal(result.status, 'unknown');
+    }
+  });
+
+  it('passes through a recorded smoke snapshot', async () => {
+    const snap: SmokeStatusSnapshot = {
+      phase: 'failed',
+      buildN: 4,
+      reason: 'activate_failed',
+      activateError: 'ctx.memory is required but unavailable',
+      smokedAt: '2026-06-05T10:33:00.000Z',
+    };
+    const ctx = { ...harness.context(), lastSmokeStatus: () => snap };
+    const result = await runtimeSmokeStatusTool.run({}, ctx);
+    assert.equal(result.ok, true);
+    if (result.ok && 'phase' in result) {
+      assert.equal(result.phase, 'failed');
+      assert.equal(result.reason, 'activate_failed');
+      assert.equal(result.activateError, 'ctx.memory is required but unavailable');
+      assert.equal(result.smokedAt, '2026-06-05T10:33:00.000Z');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #227. The Builder tool-surface exposed spec/slot/catalog content but **not** codegen output, build status, runtime smoke, or the platform version — so after a platform update the agent could not verify whether a previously-reported bug was fixed without an operator-driven preview round-trip.

This adds all four fixes proposed in the issue. Design principle throughout: **retain status at its single source of truth and expose read-only pull-accessors** — no new persistence layer, no touching the ~6 scattered `build_status` emit sites, no bus-lifecycle coupling.

## Fixes

- **`inspect_generated_artifact`** (new tool) — re-runs the pure `generate()` on the current draft and returns the rendered `manifest.yaml` (default), `package.json`, `tsconfig.json`, plus a file listing. A `CodegenError` is surfaced as structured `issues`, so the Builder can cite *"`permissions.memory` is missing from the rendered manifest"* instead of guessing.
- **`get_build_status`** (new tool) — `BuildPipeline.run()` (the single chokepoint every preview/install build flows through) now records the last outcome (`ok`/`failed`, failure phase, tsc error count, timestamp) via a thin wrapper around the renamed `executeRun()`. Exposed through `getLastBuildStatus()`.
- **`runtime_smoke_status`** (new tool) — `RuntimeSmokeOrchestrator` already computed full smoke results but only emitted them to SSE. All emits now funnel through `emitSmoke()`, which also retains the last snapshot (`getLastSmokeStatus()`), so the pull-tool and SSE stream cannot drift.
- **Platform-version banner** — `index.ts` prepends `omadia platform: <pkg> <version> (process booted <ts>)` to the Builder system prompt. A redeploy bumps the timestamp, so the agent notices the platform changed between turns.

All three tools are optional in `BuilderToolContext` (tests omit the accessors → tools report the surface unavailable), keeping the change additive and risk-free for existing build/runtime paths.

## Files

- **New:** `tools/inspectGeneratedArtifact.ts`, `tools/getBuildStatus.ts`, `tools/runtimeSmokeStatus.ts`, `test/builder/tools/observabilityTools.test.ts`
- **Modified:** `tools/index.ts`, `tools/types.ts`, `buildPipeline.ts`, `runtimeSmokeOrchestrator.ts`, `builderAgent.ts`, `src/index.ts`, plus retention-getter tests in `runtimeSmokeOrchestrator.test.ts` & `buildPipelineService.test.ts`

## Verification

- Full builder suite: **1069 pass / 0 fail** (2 pre-existing skips)
- `tsc --noEmit`: **0 errors**
- ESLint: clean
- Verified after merging latest `main`