### PR TITLE
fix(orchestrator): raise tool-loop cap 12→25 with floor on stale configs

### DIFF
--- a/middleware/packages/harness-orchestrator/manifest.yaml
+++ b/middleware/packages/harness-orchestrator/manifest.yaml
@@ -88,7 +88,7 @@ setup:
       label: "Max Tool-Loop Iterations"
       type: "string"
       required: false
-      help: "Hard cap auf den agentic tool-loop pro Turn. Aborts den Turn wenn überschritten. Default: 12. Migriert aus MAX_TOOL_ITERATIONS."
+      help: "Hard cap auf den agentic tool-loop pro Turn. Aborts den Turn wenn überschritten. Default: 25 (auch Floor — niedrigere installierte Werte werden hochgesetzt). Migriert aus MAX_TOOL_ITERATIONS."
     - key: "assistant_identity"
       label: "Assistant-Persona"
       type: "string"

--- a/middleware/packages/harness-orchestrator/src/plugin.ts
+++ b/middleware/packages/harness-orchestrator/src/plugin.ts
@@ -141,7 +141,7 @@ const DEFAULT_MODEL = 'claude-opus-4-7';
 // mid-tool-call, so the file is never built. Also enforced as a floor below so
 // an already-installed registry config of 4096 gets bumped without reinstall.
 const DEFAULT_MAX_TOKENS = 8192;
-const DEFAULT_MAX_ITERATIONS = 12;
+const DEFAULT_MAX_ITERATIONS = 25;
 
 /**
  * Public shape of the `chatAgent@1` capability. Channel-plugins (Teams,
@@ -336,8 +336,14 @@ export async function activate(
     ),
     DEFAULT_MAX_TOKENS,
   );
-  const maxIterations = parseNumberOrDefault(
-    ctx.config.get<unknown>('max_tool_iterations'),
+  // Floor at DEFAULT_MAX_ITERATIONS: a stale installed config (older
+  // deployments persisted 12) would otherwise abort multi-step tasks early
+  // with "exceeded maxToolIterations" before reaching a final answer.
+  const maxIterations = Math.max(
+    parseNumberOrDefault(
+      ctx.config.get<unknown>('max_tool_iterations'),
+      DEFAULT_MAX_ITERATIONS,
+    ),
     DEFAULT_MAX_ITERATIONS,
   );
 


### PR DESCRIPTION
## Problem
Multi-step chat turns abort with `Orchestrator exceeded maxToolIterations (12) without reaching a final answer.` before they can finish — e.g. comparing several price lists across multiple lookups.

## Fix
- `plugin.ts`: `DEFAULT_MAX_ITERATIONS` 12 → **25**
- Apply it as a **floor** via `Math.max(...)` so an already-installed registry config persisting 12 gets bumped without a reinstall (mirrors the existing `maxTokens` floor pattern)
- `manifest.yaml`: setup-field help text updated to reflect new default/floor

Operators can still override higher via the `max_tool_iterations` setup field; they just can't go below 25.

## Verification
ESLint clean · `tsc --noEmit` clean · orchestrator turn-hook + buildOrchestrator tests pass (7/7)
