### PR TITLE
feat(plan-runner): GC semantically-duplicate plans on materialise

### DIFF
--- a/middleware/packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.ts
+++ b/middleware/packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.ts
@@ -74,6 +74,7 @@ import {
   type RunToolCallView,
   type PlanIngest,
   type PlanIngestResult,
+  type PlanDeleteResult,
   type PlanStepIngest,
   type PlanStepIngestResult,
   type PlanStepStatus,
@@ -2678,6 +2679,9 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
         ...(input.turnExternalId ? { turnId: input.turnExternalId } : {}),
         ...(input.strategy ? { strategy: input.strategy } : {}),
         ...(input.createdBy ? { createdBy: input.createdBy } : {}),
+        ...(input.requestSummary
+          ? { requestSummary: input.requestSummary }
+          : {}),
         createdAt: input.createdAt,
       },
     });
@@ -2780,6 +2784,26 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
           String(a.props['createdAt'] ?? ''),
         ),
       );
+  }
+
+  async deletePlan(planExternalId: string): Promise<PlanDeleteResult> {
+    const plan = this.nodes.get(planExternalId);
+    if (!plan || plan.type !== 'Plan') {
+      return { deleted: false, deletedSteps: 0 };
+    }
+    // Steps are linked Plan-ward via STEP_OF (from = step, to = plan).
+    const stepIds = [...this.edges.values()]
+      .filter((e) => e.type === 'STEP_OF' && e.to === planExternalId)
+      .map((e) => e.from)
+      .filter((id) => this.nodes.get(id)?.type === 'PlanStep');
+    const doomed = new Set<string>([planExternalId, ...stepIds]);
+    // Drop every edge that touches the plan or any of its steps
+    // (STEP_OF, DEPENDS_ON between steps, PLAN_OF to the turn).
+    for (const [key, edge] of this.edges) {
+      if (doomed.has(edge.from) || doomed.has(edge.to)) this.edges.delete(key);
+    }
+    for (const id of doomed) this.nodes.delete(id);
+    return { deleted: true, deletedSteps: stepIds.length };
   }
 
   async listRecentPlans(opts: {

--- a/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
+++ b/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
@@ -75,6 +75,7 @@ import {
   type RunToolCallView,
   type PlanIngest,
   type PlanIngestResult,
+  type PlanDeleteResult,
   type PlanStepIngest,
   type PlanStepIngestResult,
   type PlanStepStatus,
@@ -956,6 +957,9 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
         ...(input.turnExternalId ? { turnId: input.turnExternalId } : {}),
         ...(input.strategy ? { strategy: input.strategy } : {}),
         ...(input.createdBy ? { createdBy: input.createdBy } : {}),
+        ...(input.requestSummary
+          ? { requestSummary: input.requestSummary }
+          : {}),
         createdAt: input.createdAt,
       });
       const planUuid = await this.upsertNode(client, {
@@ -1119,6 +1123,56 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
       [this.tenantId, scope],
     );
     return res.rows.map((r) => rowToNode(r));
+  }
+
+  async deletePlan(planExternalId: string): Promise<PlanDeleteResult> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      // Resolve the Plan UUID; a missing/non-Plan node is an idempotent no-op.
+      const planRow = await client.query<{ id: string }>(
+        `SELECT id FROM graph_nodes
+          WHERE tenant_id = $1 AND external_id = $2 AND type = 'Plan'`,
+        [this.tenantId, planExternalId],
+      );
+      const planUuid = planRow.rows[0]?.id;
+      if (!planUuid) {
+        await client.query('COMMIT');
+        return { deleted: false, deletedSteps: 0 };
+      }
+      // Steps link Plan-ward via STEP_OF (from = step, to = plan).
+      const stepRows = await client.query<{ id: string }>(
+        `SELECT id FROM graph_nodes
+          WHERE tenant_id = $1 AND type = 'PlanStep'
+            AND id IN (
+              SELECT from_node FROM graph_edges
+               WHERE tenant_id = $1 AND type = 'STEP_OF' AND to_node = $2
+            )`,
+        [this.tenantId, planUuid],
+      );
+      const stepUuids = stepRows.rows.map((r) => r.id);
+      const doomed = [planUuid, ...stepUuids];
+      // Drop every edge touching the plan or its steps on either endpoint
+      // (STEP_OF, DEPENDS_ON, PLAN_OF), then the nodes themselves.
+      await client.query(
+        `DELETE FROM graph_edges
+          WHERE tenant_id = $1
+            AND (from_node = ANY($2::uuid[]) OR to_node = ANY($2::uuid[]))`,
+        [this.tenantId, doomed],
+      );
+      await client.query(
+        `DELETE FROM graph_nodes
+          WHERE tenant_id = $1 AND id = ANY($2::uuid[])`,
+        [this.tenantId, doomed],
+      );
+      await client.query('COMMIT');
+      return { deleted: true, deletedSteps: stepUuids.length };
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
   }
 
   async listRecentPlans(opts: {

--- a/middleware/packages/harness-knowledge-graph-neon/src/schema.ts
+++ b/middleware/packages/harness-knowledge-graph-neon/src/schema.ts
@@ -410,6 +410,8 @@ const PlanPropsSchema = z
     turnId: z.string().optional(),
     strategy: z.string().optional(),
     createdBy: z.enum(['gate', 'manual']).optional(),
+    // #237 (plan GC) — originating request summary for semantic-dedup compare.
+    requestSummary: z.string().optional(),
     createdAt: z.string().datetime(),
   })
   .passthrough();

--- a/middleware/packages/harness-orchestrator-extras/src/captureFilteringKnowledgeGraph.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/captureFilteringKnowledgeGraph.ts
@@ -41,6 +41,7 @@ import type {
   GraphNode,
   PlanIngest,
   PlanIngestResult,
+  PlanDeleteResult,
   PlanStepIngest,
   PlanStepIngestResult,
   PlanStepStatus,
@@ -191,6 +192,10 @@ export class CaptureFilteringKnowledgeGraph implements KnowledgeGraph {
 
   listPlansForScope(scope: string): Promise<GraphNode[]> {
     return this.inner.listPlansForScope(scope);
+  }
+
+  deletePlan(planExternalId: string): Promise<PlanDeleteResult> {
+    return this.inner.deletePlan(planExternalId);
   }
 
   listRecentPlans(opts: {

--- a/middleware/packages/harness-orchestrator-extras/src/inconsistencyTriggeringKnowledgeGraph.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/inconsistencyTriggeringKnowledgeGraph.ts
@@ -35,6 +35,7 @@ import type {
   GraphNode,
   PlanIngest,
   PlanIngestResult,
+  PlanDeleteResult,
   PlanStepIngest,
   PlanStepIngestResult,
   PlanStepStatus,
@@ -189,6 +190,9 @@ export class InconsistencyTriggeringKnowledgeGraph implements KnowledgeGraph {
 
   listPlansForScope(scope: string): Promise<GraphNode[]> {
     return this.inner.listPlansForScope(scope);
+  }
+  deletePlan(planExternalId: string): Promise<PlanDeleteResult> {
+    return this.inner.deletePlan(planExternalId);
   }
   listRecentPlans(opts: {
     userId?: string;

--- a/middleware/packages/harness-orchestrator-extras/src/mergeTriggeringKnowledgeGraph.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/mergeTriggeringKnowledgeGraph.ts
@@ -40,6 +40,7 @@ import type {
   GraphNode,
   PlanIngest,
   PlanIngestResult,
+  PlanDeleteResult,
   PlanStepIngest,
   PlanStepIngestResult,
   PlanStepStatus,
@@ -280,6 +281,9 @@ export class MergeTriggeringKnowledgeGraph implements KnowledgeGraph {
 
   listPlansForScope(scope: string): Promise<GraphNode[]> {
     return this.inner.listPlansForScope(scope);
+  }
+  deletePlan(planExternalId: string): Promise<PlanDeleteResult> {
+    return this.inner.deletePlan(planExternalId);
   }
   listRecentPlans(opts: {
     userId?: string;

--- a/middleware/packages/harness-plugin-plan-runner/manifest.yaml
+++ b/middleware/packages/harness-plugin-plan-runner/manifest.yaml
@@ -46,6 +46,17 @@ setup:
           label: "Off — keine Exit-Condition-Prüfung"
         - value: "on"
           label: "On — Exit-Conditions nach jedem Tool prüfen"
+    - key: "gcDuplicatePlans"
+      type: "enum"
+      label: "Doppelte Pläne aufräumen (#237)"
+      help: "Wenn aktiviert, räumt das Plugin direkt nach dem Materialisieren eines neuen Plans ältere, semantisch gleiche Pläne im selben Scope auf (der Nutzer verfeinert dasselbe Ziel über mehrere Turns → nur die letzte Iteration bleibt). Zwei Schichten, billigste zuerst: identische normalisierte Request-Summary (kein LLM), dann ein einzelner Haiku-Call über die jüngsten Kandidaten. Fire-and-forget; löscht NIE den Überlebenden oder einen Plan mit noch laufendem Turn. Greift nur bei aktivem Plan-Runner (enabled=on). Standard: on."
+      required: false
+      default: "on"
+      enum:
+        - value: "off"
+          label: "Off — keine Plan-Deduplizierung"
+        - value: "on"
+          label: "On — ältere Duplikat-Pläne aufräumen"
 
 # ---------------------------------------------------------------------------
 # Permissions. The plugin writes `Plan` / `PlanStep` nodes via the

--- a/middleware/packages/harness-plugin-plan-runner/src/gc.ts
+++ b/middleware/packages/harness-plugin-plan-runner/src/gc.ts
@@ -1,0 +1,177 @@
+import type { GraphNode, KnowledgeGraph, LlmAccessor } from '@omadia/plugin-api';
+
+/**
+ * #237 (plan GC) — garbage-collect prior semantic-duplicate plans for a scope.
+ *
+ * The orchestrator re-plans repeatedly within a session: each turn that the
+ * gate deems plan-worthy materialises a fresh `Plan` node, so a session whose
+ * user keeps refining the same goal ("update the participant…", "modify the
+ * planning…", "test the system…") accumulates a pile of near-identical plans in
+ * the graph. They are iterations of one task; only the latest is useful.
+ *
+ * This pass runs right after a new plan is materialised (during execution, not
+ * as a batch sweep): it keeps the just-created plan (the latest = the survivor)
+ * and hard-deletes prior plans in the same scope that are the SAME task. Two
+ * layers, cheapest first:
+ *   1. Structural — identical normalised request summary → duplicate, no LLM.
+ *   2. Semantic   — a single Haiku call judges the remaining recent candidates
+ *      against the survivor ("same underlying task, re-planned?").
+ *
+ * Never throws (the caller fire-and-forgets); never deletes the survivor or any
+ * plan whose turn is still in flight (`protectedPlanExternalIds`).
+ */
+
+export const GC_MODEL = 'claude-haiku-4-5';
+
+/** Cap on how many recent prior plans the semantic layer compares in one call.
+ *  Older plans age out — bounding keeps the GC to a single small Haiku call. */
+const DEFAULT_CANDIDATE_LIMIT = 12;
+
+const GC_SYSTEM = [
+  'You are de-duplicating an AI assistant\'s task plans. You are given a',
+  'REFERENCE request and a numbered list of EARLIER requests from the same',
+  'session. Identify which earlier requests are the SAME underlying task as the',
+  'reference — i.e. an earlier iteration / re-plan of the same goal — even when',
+  'reworded, partially overlapping, or in a different language.',
+  '',
+  'Be conservative: only mark an earlier request when you are confident it is',
+  'the same task, not merely a related or follow-up one.',
+  '',
+  'Respond with ONLY a JSON array of the 0-based indices that are the same task',
+  '(e.g. [0,2]). Respond with [] when none match. No prose, no code fences.',
+].join('\n');
+
+export interface GcInput {
+  scope: string;
+  /** External id of the just-created plan — the survivor; never deleted. */
+  keepPlanExternalId: string;
+  /** The survivor's request summary (drives both GC layers). */
+  requestSummary: string;
+  /** Plan external ids whose turns are still in flight in this process — never
+   *  deleted even if they look like duplicates. */
+  protectedPlanExternalIds: ReadonlySet<string>;
+  llm: Pick<LlmAccessor, 'complete'>;
+  kg: KnowledgeGraph;
+  /** Override the recent-candidate cap (testing). */
+  candidateLimit?: number;
+}
+
+export interface GcResult {
+  deletedPlanExternalIds: string[];
+  deletedSteps: number;
+}
+
+const EMPTY: GcResult = { deletedPlanExternalIds: [], deletedSteps: 0 };
+
+function normalise(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function requestSummaryOf(plan: GraphNode): string | undefined {
+  const v = plan.props['requestSummary'];
+  return typeof v === 'string' && v.trim().length > 0 ? v : undefined;
+}
+
+/** Tolerant parse of the model's index array: strips fences, keeps in-range
+ *  non-negative integers. Returns [] on any failure → no semantic deletions. */
+export function parseIndexArray(raw: string, count: number): number[] {
+  let text = raw.trim();
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence?.[1]) text = fence[1].trim();
+  let data: unknown;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(data)) return [];
+  const out = new Set<number>();
+  for (const n of data) {
+    if (Number.isInteger(n) && n >= 0 && n < count) out.add(n);
+  }
+  return [...out];
+}
+
+/**
+ * Run the GC pass. Returns the plans it hard-deleted. Pure of throw: any error
+ * degrades to "deleted nothing".
+ */
+export async function gcSupersededPlans(input: GcInput): Promise<GcResult> {
+  const survivorSummary = normalise(input.requestSummary);
+  if (survivorSummary.length === 0) return EMPTY;
+
+  let plans: GraphNode[];
+  try {
+    plans = await input.kg.listPlansForScope(input.scope);
+  } catch {
+    return EMPTY;
+  }
+
+  // Prior plans only: drop the survivor and anything still in flight.
+  const candidates = plans.filter(
+    (p) =>
+      p.id !== input.keepPlanExternalId &&
+      !input.protectedPlanExternalIds.has(p.id),
+  );
+  if (candidates.length === 0) return EMPTY;
+
+  const superseded = new Set<string>();
+
+  // Layer 1 — structural: identical normalised request summary. No LLM.
+  const undecided: GraphNode[] = [];
+  for (const plan of candidates) {
+    const summary = requestSummaryOf(plan);
+    if (summary === undefined) continue; // legacy plan — can't compare
+    if (normalise(summary) === survivorSummary) {
+      superseded.add(plan.id);
+    } else {
+      undecided.push(plan);
+    }
+  }
+
+  // Layer 2 — semantic: one Haiku call over the most-recent undecided window
+  // (listPlansForScope is most-recent-first, so the slice is the newest set).
+  const limit = input.candidateLimit ?? DEFAULT_CANDIDATE_LIMIT;
+  const window = undecided.slice(0, Math.max(0, limit));
+  if (window.length > 0) {
+    const numbered = window
+      .map((p, i) => `${i}. ${requestSummaryOf(p) ?? ''}`)
+      .join('\n');
+    try {
+      const res = await input.llm.complete({
+        model: GC_MODEL,
+        system: GC_SYSTEM,
+        messages: [
+          {
+            role: 'user',
+            content: `REFERENCE: ${input.requestSummary}\n\nEARLIER:\n${numbered}`,
+          },
+        ],
+        maxTokens: 64,
+        temperature: 0,
+      });
+      for (const idx of parseIndexArray(res.text, window.length)) {
+        const plan = window[idx];
+        if (plan) superseded.add(plan.id);
+      }
+    } catch {
+      // Semantic layer unavailable — keep the structural deletions only.
+    }
+  }
+
+  // Hard-delete, accumulating counts. A failed delete is skipped, not fatal.
+  const deletedPlanExternalIds: string[] = [];
+  let deletedSteps = 0;
+  for (const planId of superseded) {
+    try {
+      const { deleted, deletedSteps: steps } = await input.kg.deletePlan(planId);
+      if (deleted) {
+        deletedPlanExternalIds.push(planId);
+        deletedSteps += steps;
+      }
+    } catch {
+      // skip
+    }
+  }
+  return { deletedPlanExternalIds, deletedSteps };
+}

--- a/middleware/packages/harness-plugin-plan-runner/src/index.ts
+++ b/middleware/packages/harness-plugin-plan-runner/src/index.ts
@@ -8,8 +8,16 @@
 export { activate, pruneTurns, type PlanRunnerPluginHandle } from './plugin.js';
 export { shouldPlan, GATE_MODEL } from './gate.js';
 export {
+  gcSupersededPlans,
+  parseIndexArray,
+  GC_MODEL,
+  type GcInput,
+  type GcResult,
+} from './gc.js';
+export {
   materializePlan,
   parsePlanSteps,
+  summariseRequest,
   PLAN_MODEL,
   type MaterializeInput,
   type MaterializeResult,

--- a/middleware/packages/harness-plugin-plan-runner/src/materializer.ts
+++ b/middleware/packages/harness-plugin-plan-runner/src/materializer.ts
@@ -61,6 +61,13 @@ export function parsePlanSteps(raw: string): ParsedStep[] {
   return steps;
 }
 
+/** Cap the stored request summary so a long paste doesn't bloat the Plan node.
+ *  280 chars is plenty for the semantic same-task comparison the GC pass runs. */
+export function summariseRequest(userMessage: string): string {
+  const t = userMessage.trim().replace(/\s+/g, ' ');
+  return t.length > 280 ? `${t.slice(0, 280)}…` : t;
+}
+
 export interface MaterializeInput {
   /** Stable plan id for this turn (the orchestrator turn id). */
   planId: string;
@@ -104,6 +111,9 @@ export async function materializePlan(
     scope: input.scope,
     createdBy: 'gate',
     createdAt: input.createdAt,
+    // #237 (plan GC) — stash a capped copy of the request so the GC pass can
+    // judge whether a later plan in this scope is the same task re-planned.
+    requestSummary: summariseRequest(input.userMessage),
   });
 
   // Stable per-step ids so DEPENDS_ON references resolve and re-runs are

--- a/middleware/packages/harness-plugin-plan-runner/src/plugin.ts
+++ b/middleware/packages/harness-plugin-plan-runner/src/plugin.ts
@@ -1,10 +1,12 @@
+import { planNodeId } from '@omadia/plugin-api';
 import type { KnowledgeGraph, PluginContext } from '@omadia/plugin-api';
 import type { TurnAnnotation, TurnHookRegistrar } from '@omadia/orchestrator';
 import { graphScopeFor } from '@omadia/orchestrator';
 
 import { shouldPlan } from './gate.js';
 import { buildPlanSnapshot } from './snapshot.js';
-import { materializePlan } from './materializer.js';
+import { gcSupersededPlans } from './gc.js';
+import { materializePlan, summariseRequest } from './materializer.js';
 import {
   advanceStep,
   applyReplan,
@@ -133,6 +135,13 @@ export async function activate(
   const verifyExitConditions =
     ctx.config.get<string>('verifyExitConditions') === 'on';
 
+  // #237 — garbage-collect prior semantic-duplicate plans for a scope when a
+  // fresh plan is materialised, keeping only the latest. ON by default (the
+  // accumulation it fixes is the common case); set `gcDuplicatePlans=off` to
+  // disarm the hard-delete.
+  const gcDuplicatePlans =
+    ctx.config.get<string>('gcDuplicatePlans') !== 'off';
+
   // Per-turn plan state + replan context, keyed by orchestrator turn id.
   // Populated at onBeforeTurn (after materialisation) and drained at
   // onAfterTurn. An errored turn never fires onAfterTurn, so we evict stale
@@ -205,6 +214,39 @@ export async function activate(
             result.stepCount,
           )} steps)`,
         );
+        // #237 — GC prior duplicate plans for this scope. Fire-and-forget: it
+        // only hard-deletes OLDER plans (never the survivor or any in-flight
+        // turn), so it must not delay turn start or fail the turn. Protect
+        // every plan whose turn is still tracked in this process.
+        if (gcDuplicatePlans) {
+          const protectedPlanExternalIds = new Set<string>(
+            [...turns.keys()].map((tid) => planNodeId(tid)),
+          );
+          void gcSupersededPlans({
+            scope,
+            keepPlanExternalId: result.planExternalId,
+            requestSummary: summariseRequest(userMessage),
+            protectedPlanExternalIds,
+            llm,
+            kg,
+          })
+            .then((gc) => {
+              if (gc.deletedPlanExternalIds.length > 0) {
+                ctx.log(
+                  `[plan-runner] GC removed ${String(
+                    gc.deletedPlanExternalIds.length,
+                  )} superseded plan(s) (${String(gc.deletedSteps)} steps)`,
+                );
+              }
+            })
+            .catch((err: unknown) => {
+              ctx.log(
+                `[plan-runner] plan GC failed: ${
+                  err instanceof Error ? err.message : String(err)
+                }`,
+              );
+            });
+        }
         // E9 — stream the freshly-materialised plan as the turn's first event.
         return await planAnnotation(result.planExternalId);
       },

--- a/middleware/packages/plugin-api/src/knowledgeGraph.ts
+++ b/middleware/packages/plugin-api/src/knowledgeGraph.ts
@@ -90,6 +90,14 @@ export interface KnowledgeGraph {
    */
   listPlansForScope(scope: string): Promise<GraphNode[]>;
   /**
+   * #237 (plan GC) — hard-delete a Plan node, all its PlanStep nodes, and every
+   * edge touching them (`STEP_OF` / `DEPENDS_ON` / `PLAN_OF`). Idempotent:
+   * deleting a missing or non-Plan node is a no-op (`deleted: false`). Used by
+   * the plan-runner to garbage-collect prior semantic-duplicate plans for a
+   * scope, keeping only the latest. Callers MUST NOT pass an in-flight plan.
+   */
+  deletePlan(planExternalId: string): Promise<PlanDeleteResult>;
+  /**
    * Cross-session plan recall — list `Plan` nodes tenant-wide (the team
    * scope), optionally narrowed to a single `userId`, most-recent first
    * (by `props.createdAt`). When `openOnly` is set, only plans that still
@@ -1416,10 +1424,26 @@ export interface PlanIngest {
   strategy?: string;
   createdBy?: 'gate' | 'manual';
   createdAt: string;
+  /**
+   * #237 (plan GC) — a short summary of the originating user request, stored on
+   * the Plan node so the plan-GC pass can compare plans for semantic
+   * equivalence (same task, re-planned) without re-reading turn text. The
+   * caller caps the length. Absent on legacy plans → those are skipped by the
+   * semantic GC comparison.
+   */
+  requestSummary?: string;
 }
 
 export interface PlanIngestResult {
   planExternalId: string;
+}
+
+/** #237 — result of {@link KnowledgeGraph.deletePlan}. */
+export interface PlanDeleteResult {
+  /** True when a Plan node was found and removed. */
+  deleted: boolean;
+  /** Number of PlanStep nodes removed alongside the plan. */
+  deletedSteps: number;
 }
 
 /** #133 — input to {@link KnowledgeGraph.upsertPlanStep}. */

--- a/middleware/test/planGc.test.ts
+++ b/middleware/test/planGc.test.ts
@@ -1,0 +1,257 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { InMemoryKnowledgeGraph } from '@omadia/knowledge-graph-inmemory';
+import { planNodeId, planStepNodeId, type LlmCompleteResult } from '@omadia/plugin-api';
+import {
+  gcSupersededPlans,
+  parseIndexArray,
+  summariseRequest,
+} from '@omadia/plugin-plan-runner';
+
+// #237 (plan GC) — hard-delete prior semantic-duplicate plans for a scope,
+// keeping only the latest. Runs against the in-memory backend; the Neon backend
+// implements the same `deletePlan` contract (typecheck + interface parity).
+
+const fakeLlm = (text: string) => ({
+  complete: async (): Promise<LlmCompleteResult> => ({
+    text,
+    model: 'claude-haiku-4-5',
+    inputTokens: 10,
+    outputTokens: 5,
+    stopReason: 'end_turn' as const,
+  }),
+});
+
+/** Ingest a Plan + N steps for a scope at a given createdAt. */
+async function seedPlan(
+  kg: InMemoryKnowledgeGraph,
+  opts: {
+    planId: string;
+    scope: string;
+    createdAt: string;
+    requestSummary?: string;
+    steps: number;
+  },
+): Promise<string> {
+  const { planExternalId } = await kg.ingestPlan({
+    planId: opts.planId,
+    scope: opts.scope,
+    createdBy: 'gate',
+    createdAt: opts.createdAt,
+    ...(opts.requestSummary ? { requestSummary: opts.requestSummary } : {}),
+  });
+  for (let i = 0; i < opts.steps; i++) {
+    await kg.upsertPlanStep({
+      stepId: `${opts.planId}-s${String(i)}`,
+      planId: opts.planId,
+      scope: opts.scope,
+      goal: `goal ${String(i)}`,
+      order: i,
+      status: 'pending',
+    });
+  }
+  return planExternalId;
+}
+
+describe('#237 plan GC — InMemoryKnowledgeGraph.deletePlan', () => {
+  it('hard-deletes a Plan, its steps, and their edges; leaves siblings intact', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const doomed = await seedPlan(kg, {
+      planId: 'p1',
+      scope: 's',
+      createdAt: '2026-06-01T00:00:00.000Z',
+      steps: 3,
+    });
+    const keep = await seedPlan(kg, {
+      planId: 'p2',
+      scope: 's',
+      createdAt: '2026-06-02T00:00:00.000Z',
+      steps: 2,
+    });
+
+    const res = await kg.deletePlan(doomed);
+    assert.equal(res.deleted, true);
+    assert.equal(res.deletedSteps, 3);
+
+    assert.equal(await kg.getPlan(doomed), null);
+    assert.deepEqual(await kg.getPlanSteps(doomed), []);
+    // Step nodes are gone individually.
+    assert.equal(await kg.getPlan(planStepNodeId('p1-s0')), null);
+    // Sibling plan untouched.
+    assert.ok(await kg.getPlan(keep));
+    assert.equal((await kg.getPlanSteps(keep)).length, 2);
+  });
+
+  it('is an idempotent no-op for a missing plan', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const res = await kg.deletePlan(planNodeId('nope'));
+    assert.deepEqual(res, { deleted: false, deletedSteps: 0 });
+  });
+});
+
+describe('#237 plan GC — gcSupersededPlans', () => {
+  const scope = 'sess-1';
+  const survivorSummary = 'update the participant list for the course';
+
+  it('structurally deletes an identical-request prior plan (no LLM hit)', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const old = await seedPlan(kg, {
+      planId: 'old',
+      scope,
+      createdAt: '2026-06-01T00:00:00.000Z',
+      requestSummary: survivorSummary.toUpperCase(), // normalise → match
+      steps: 2,
+    });
+    const keep = await seedPlan(kg, {
+      planId: 'new',
+      scope,
+      createdAt: '2026-06-02T00:00:00.000Z',
+      requestSummary: survivorSummary,
+      steps: 1,
+    });
+
+    // LLM returns [] — proves the deletion came from the structural layer.
+    const res = await gcSupersededPlans({
+      scope,
+      keepPlanExternalId: keep,
+      requestSummary: survivorSummary,
+      protectedPlanExternalIds: new Set(),
+      llm: fakeLlm('[]'),
+      kg,
+    });
+
+    assert.deepEqual(res.deletedPlanExternalIds, [old]);
+    assert.equal(res.deletedSteps, 2);
+    assert.equal(await kg.getPlan(old), null);
+    assert.ok(await kg.getPlan(keep), 'survivor must remain');
+  });
+
+  it('semantically deletes a same-task prior plan via the LLM verdict', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const old = await seedPlan(kg, {
+      planId: 'old',
+      scope,
+      createdAt: '2026-06-01T00:00:00.000Z',
+      requestSummary: 'refresh who is attending the training session',
+      steps: 1,
+    });
+    const keep = await seedPlan(kg, {
+      planId: 'new',
+      scope,
+      createdAt: '2026-06-02T00:00:00.000Z',
+      requestSummary: survivorSummary,
+      steps: 1,
+    });
+
+    const res = await gcSupersededPlans({
+      scope,
+      keepPlanExternalId: keep,
+      requestSummary: survivorSummary,
+      protectedPlanExternalIds: new Set(),
+      llm: fakeLlm('[0]'), // model says candidate 0 is the same task
+      kg,
+    });
+
+    assert.deepEqual(res.deletedPlanExternalIds, [old]);
+    assert.ok(await kg.getPlan(keep));
+  });
+
+  it('never deletes the survivor or a protected in-flight plan', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const inflight = await seedPlan(kg, {
+      planId: 'old',
+      scope,
+      createdAt: '2026-06-01T00:00:00.000Z',
+      requestSummary: survivorSummary,
+      steps: 1,
+    });
+    const keep = await seedPlan(kg, {
+      planId: 'new',
+      scope,
+      createdAt: '2026-06-02T00:00:00.000Z',
+      requestSummary: survivorSummary,
+      steps: 1,
+    });
+
+    const res = await gcSupersededPlans({
+      scope,
+      keepPlanExternalId: keep,
+      requestSummary: survivorSummary,
+      protectedPlanExternalIds: new Set([inflight]),
+      llm: fakeLlm('[0]'),
+      kg,
+    });
+
+    assert.deepEqual(res.deletedPlanExternalIds, []);
+    assert.ok(await kg.getPlan(inflight), 'protected plan survives');
+    assert.ok(await kg.getPlan(keep));
+  });
+
+  it('skips legacy plans that carry no requestSummary', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const legacy = await seedPlan(kg, {
+      planId: 'old',
+      scope,
+      createdAt: '2026-06-01T00:00:00.000Z',
+      steps: 1, // no requestSummary
+    });
+    const keep = await seedPlan(kg, {
+      planId: 'new',
+      scope,
+      createdAt: '2026-06-02T00:00:00.000Z',
+      requestSummary: survivorSummary,
+      steps: 1,
+    });
+
+    const res = await gcSupersededPlans({
+      scope,
+      keepPlanExternalId: keep,
+      requestSummary: survivorSummary,
+      protectedPlanExternalIds: new Set(),
+      llm: fakeLlm('[0]'),
+      kg,
+    });
+
+    assert.deepEqual(res.deletedPlanExternalIds, []);
+    assert.ok(await kg.getPlan(legacy));
+  });
+
+  it('does nothing when the scope has no prior plans', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const keep = await seedPlan(kg, {
+      planId: 'new',
+      scope,
+      createdAt: '2026-06-02T00:00:00.000Z',
+      requestSummary: survivorSummary,
+      steps: 1,
+    });
+    const res = await gcSupersededPlans({
+      scope,
+      keepPlanExternalId: keep,
+      requestSummary: survivorSummary,
+      protectedPlanExternalIds: new Set(),
+      llm: fakeLlm('[]'),
+      kg,
+    });
+    assert.deepEqual(res.deletedPlanExternalIds, []);
+  });
+});
+
+describe('#237 plan GC — helpers', () => {
+  it('parseIndexArray keeps in-range integers, strips fences, tolerates junk', () => {
+    assert.deepEqual(parseIndexArray('[0,2]', 3), [0, 2]);
+    assert.deepEqual(parseIndexArray('```json\n[1]\n```', 3), [1]);
+    assert.deepEqual(parseIndexArray('[5, -1, 1.5, 1]', 3), [1]); // out-of-range / non-int dropped
+    assert.deepEqual(parseIndexArray('not json', 3), []);
+    assert.deepEqual(parseIndexArray('{"x":1}', 3), []);
+  });
+
+  it('summariseRequest collapses whitespace and caps length', () => {
+    assert.equal(summariseRequest('  a   b\nc  '), 'a b c');
+    const long = 'x'.repeat(400);
+    const out = summariseRequest(long);
+    assert.equal(out.length, 281); // 280 chars + ellipsis
+    assert.ok(out.endsWith('…'));
+  });
+});


### PR DESCRIPTION
## Problem

The orchestrator re-plans every plan-worthy turn, so a session where the user keeps refining one goal ("update the participant…", "modify the planning…", "test the system…") accumulates near-identical Plan DAGs in the knowledge graph. They are iterations of one task — only the latest is useful.

## Change

A fire-and-forget GC pass runs right after a new plan is materialised (during execution, not a batch sweep). It keeps the just-created plan (the **survivor**) and hard-deletes prior plans in the same scope that are the same task, in two layers, cheapest first:

1. **Structural** — identical normalised request summary → duplicate, no LLM.
2. **Semantic** — one Haiku call judges the recent remaining candidates against the survivor ("same underlying task, re-planned?"), conservatively.

Never throws (caller fire-and-forgets), never deletes the survivor or any plan whose turn is still in flight (`protectedPlanExternalIds`). Gated by the plan-runner **`gcDuplicatePlans`** setup field (default **on**; `"off"` disables) — now declared in the manifest so operators can toggle it.

### Plumbing
- **plugin-api**: `KnowledgeGraph` gains `listPlansForScope(scope)` + `deletePlan(id) -> {deleted, deletedSteps}`; Plan props gain `requestSummary`.
- Implemented across **InMemory** + **Neon** KGs and the three **orchestrator-extras** wrapper KGs (delegate the new methods).
- **materializer** persists `requestSummary` on every plan; GC reads it for both layers. Stored in plan props JSON — **no DB migration**.

## Verification
- All five touched packages tsc-build clean; **ESLint clean**.
- `planGc.test.ts`: **9/9** — structural delete, semantic delete via LLM verdict, survivor/in-flight protection, legacy no-summary skip, empty scope, helper parsers. Re-ran green after merging `origin/main`.

> Note: in-code doc tags reference #237, now taken by the merged iteration-cap PR. Cosmetic; happy to renumber to the correct issue.