### PR TITLE
fix(dynamic-runtime): late-resolve vault-armed Anthropic client for sub-agents

### DIFF
--- a/middleware/src/plugins/dynamicAgentRuntime.ts
+++ b/middleware/src/plugins/dynamicAgentRuntime.ts
@@ -369,9 +369,26 @@ export class DynamicAgentRuntime {
       effectiveModel,
     );
 
+    // OB-61 follow-up: the host arms the shared Anthropic client from the
+    // operator's vault key AFTER boot (see index.ts
+    // `refreshSharedAnthropicClientFromVault` →
+    // `serviceRegistry.replace('anthropicClient', …)`). The constructor-
+    // injected `this.deps.anthropic` is the *boot-time* client, built from
+    // `config.ANTHROPIC_API_KEY ?? ''`. On deployments where the key lives
+    // only in the vault (operator completed /setup, no ANTHROPIC_API_KEY in
+    // ENV — e.g. the Docker demo), that injected client has an empty apiKey
+    // and every sub-agent inner call throws "Could not resolve authentication
+    // method" at construction time (0 ms, before any tool runs). Late-resolve
+    // the live, vault-armed client from the registry — matching the documented
+    // late-resolve contract (index.ts ~295) — and fall back to the injected
+    // client only when no provider override is registered (env-key path).
+    const liveAnthropic =
+      this.deps.serviceRegistry.get<Anthropic>('anthropicClient') ??
+      this.deps.anthropic;
+
     const subAgent = new LocalSubAgent({
       name: shortName,
-      client: this.deps.anthropic,
+      client: liveAnthropic,
       model: effectiveModel,
       maxTokens: this.deps.subAgentMaxTokens,
       maxIterations: this.deps.subAgentMaxIterations,


### PR DESCRIPTION
## Problem

Dynamic agent sub-agents (e.g. `query_odoo_accounting`, `query_odoo_hr`) fail at runtime with **Could not resolve authentication method. Expected one of apiKey, authToken, credentials, config, or profile to be set** — but only on deployments where the Anthropic API key lives solely in the operator vault (operator completed `/setup`, no `ANTHROPIC_API_KEY` in env, e.g. the Docker Compose demo). It works on Fly because `ANTHROPIC_API_KEY` is set there.

## Root cause

`@anthropic-ai/sdk@0.101` throws at **client construction** when `apiKey` is empty (instant — `ERROR (0.0s)`, before any network call). The host builds a boot-time client from `config.ANTHROPIC_API_KEY ?? ''` (`index.ts:520`) and injects it into `DynamicAgentRuntime` by value. Post-boot the host arms the shared client from the vault via `serviceRegistry.replace('anthropicClient', …)` (`index.ts:961`), so only late-resolving consumers pick up the real key. `dynamicAgentRuntime.ts:374` kept using the stale injected `this.deps.anthropic`, so every dynamic sub-agent inner LLM call ran an empty-apiKey client and threw. Orchestrator/verifier work because they build their own per-plugin client from the vault.

## Fix

Late-resolve the live, vault-armed client from the `ServiceRegistry` (already in deps) at sub-agent build time, falling back to the injected client for the env-key path. Matches the documented late-resolve contract (`index.ts ~295`). Boot order guarantees the registry is armed (~961) before dynamic agents activate (~1099).

## Validation

- `tsc --noEmit` full workspace build — clean
- `eslint` changed file — clean
- Works on Fly (ENV key) and Docker/vault-only alike.