### PR TITLE
fix(middleware): propagate runtime plugin (de)activation to per-Agent orchestrators

### DIFF
--- a/middleware/src/agents/runtimeToolPropagation.ts
+++ b/middleware/src/agents/runtimeToolPropagation.ts
@@ -1,0 +1,89 @@
+/**
+ * Runtime domain-tool propagation.
+ *
+ * When an agent-plugin is (de)activated AFTER boot (operator install,
+ * Hub/registry install, package re-upload, self-extension), its DomainTool
+ * lives only in `dynamicAgentRuntime` and on the single legacy orchestrator.
+ * The per-Agent registry orchestrators — which the chat router resolves for
+ * every turn, falling back to the fallback Agent for un-slugged turns — are a
+ * boot snapshot that the install path historically never reconciled, so the
+ * new capability silently never went live without a restart.
+ *
+ * These two pure helpers carry the reconciliation so the host (index.ts) keeps
+ * only the plumbing (resolve the registry/config-store, persist the fallback
+ * enablement) and the testable decision logic lives here.
+ */
+
+import type { DomainTool } from '@omadia/orchestrator';
+
+/** The slice of `Orchestrator` the reconciler mutates. */
+export interface DomainToolHost {
+  hasDomainTool(name: string): boolean;
+  registerDomainTool(tool: DomainTool): void;
+  unregisterDomainTool(name: string): boolean;
+}
+
+/** One per-Agent orchestrator + whether the plugin under reconciliation is
+ *  enabled on that Agent (drives register-vs-withhold). */
+export interface ReconcileTarget {
+  readonly slug: string;
+  readonly enabled: boolean;
+  readonly orchestrator: DomainToolHost;
+}
+
+export interface ReconcileOptions {
+  /** The freshly-activated plugin's DomainTool, or `undefined` when the plugin
+   *  exposes none (tool/extension/integration) or was just deactivated. */
+  readonly tool?: DomainTool;
+  /** On uninstall the runtime no longer knows the tool — drop it by name. */
+  readonly removedToolName?: string;
+  /** Per-target failure sink; a throw on one Agent never aborts the rest. */
+  readonly onError?: (slug: string, err: unknown) => void;
+}
+
+/**
+ * Reconcile a single agent-plugin's DomainTool across every per-Agent
+ * orchestrator:
+ *
+ *  - `tool` present + enabled on the Agent → (re-)register a fresh handle,
+ *    replacing any stale one (safe for version re-uploads).
+ *  - `tool` present + NOT enabled → ensure it is absent (plugin withheld).
+ *  - `tool` absent + `removedToolName` → drop the named tool (uninstall).
+ *
+ * Idempotent and isolated: a throw on one target is routed to `onError` and
+ * the loop continues.
+ */
+export function reconcileDomainToolAcrossAgents(
+  targets: readonly ReconcileTarget[],
+  options: ReconcileOptions,
+): void {
+  const { tool, removedToolName, onError } = options;
+  for (const target of targets) {
+    const orch = target.orchestrator;
+    try {
+      if (tool) {
+        if (orch.hasDomainTool(tool.name)) orch.unregisterDomainTool(tool.name);
+        if (target.enabled) orch.registerDomainTool(tool);
+      } else if (removedToolName && orch.hasDomainTool(removedToolName)) {
+        orch.unregisterDomainTool(removedToolName);
+      }
+    } catch (err) {
+      onError?.(target.slug, err);
+    }
+  }
+}
+
+/**
+ * Merge the frozen boot-time DomainTool set with the runtime's currently-active
+ * set, de-duped by tool name. Boot built-ins are already present in `boot` and
+ * win on a name clash. Used to keep per-Agent orchestrator (re)hydration honest
+ * after a post-boot install: the boot array alone never sees a hot-installed
+ * agent's tool.
+ */
+export function mergeDomainTools(
+  boot: readonly DomainTool[],
+  runtime: readonly DomainTool[],
+): DomainTool[] {
+  const bootNames = new Set(boot.map((t) => t.name));
+  return [...boot, ...runtime.filter((t) => !bootNames.has(t.name))];
+}

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -22,6 +22,10 @@ import { createDuplicatesRouter } from './routes/duplicates.js';
 import { createTopicsRouter } from './routes/topics.js';
 import { createAgentResolver } from './agents/resolveAgentForTool.js';
 import { scopeDomainToolsToPlugins } from './agents/scopeDomainTools.js';
+import {
+  mergeDomainTools,
+  reconcileDomainToolAcrossAgents,
+} from './agents/runtimeToolPropagation.js';
 // `/attachments/<signed-key>` is now mounted by the de.byte5.channel.teams
 // plugin via ctx.routes.register (see packages/harness-channel-teams/src/plugin.ts,
 // phase-3.1-4). No kernel-side attachment router import needed anymore.
@@ -618,6 +622,24 @@ async function main(): Promise<void> {
   // eslint-disable-next-line prefer-const
   let channelRegistryRef: ChannelRegistry | undefined;
 
+  // Forward refs — runtime propagation of a POST-BOOT agent-plugin
+  // (de)activation into the per-Agent registry orchestrators + the fallback
+  // Agent's enabled-plugin set. Assigned in the orchestrator-wiring block far
+  // below (they need `registryForHydrate` + `currentDomainTools`). The install
+  // hooks only fire at runtime, after assignment; when chat is disabled (no
+  // orchestrator) they stay undefined and the `?.` calls no-op. Without this,
+  // a plugin installed at runtime (operator install, Hub/registry install,
+  // package re-upload, or self-extension) only reaches the single legacy
+  // orchestrator — un-slugged chat routes to the fallback Agent, whose
+  // per-Agent orchestrator never learned the new tool, so it behaves as if the
+  // plugin were never activated.
+   
+  let propagatePluginInstall: ((pluginId: string) => Promise<void>) | undefined;
+   
+  let propagatePluginUninstall:
+    | ((pluginId: string, removedToolName?: string) => Promise<void>)
+    | undefined;
+
   const installService = new InstallService({
     catalog: pluginCatalog,
     registry: installedRegistry,
@@ -647,6 +669,9 @@ async function main(): Promise<void> {
         case 'agent':
         default:
           await dynamicAgentRuntime.activate(agentId);
+          // Make the freshly-activated agent's tool reachable on the per-Agent
+          // orchestrators (incl. the fallback Agent) without a restart.
+          await propagatePluginInstall?.(agentId);
       }
     },
     onUninstall: async (agentId) => {
@@ -663,8 +688,14 @@ async function main(): Promise<void> {
           await toolPluginRuntime.deactivate(agentId);
           return;
         case 'agent':
-        default:
+        default: {
+          // Capture the tool name BEFORE deactivate drops it from the runtime —
+          // the per-Agent orchestrators must be told which tool to unregister.
+          const removedToolName =
+            dynamicAgentRuntime.domainToolFor(agentId)?.name;
           await dynamicAgentRuntime.deactivate(agentId);
+          await propagatePluginUninstall?.(agentId, removedToolName);
+        }
       }
     },
   });
@@ -1176,9 +1207,22 @@ async function main(): Promise<void> {
       // Agent (e.g. "marketing", which only enables the X plugin) no longer
       // inherits `query_odoo_accounting` et al. it was never granted.
       // See `scopeDomainToolsToPlugins` for the rule.
+      //
+      // LIVE tool source. The boot-time `domainTools[]` is frozen at process
+      // start, so an agent-plugin installed/activated AFTER boot (its tool
+      // lives only in `dynamicAgentRuntime`) would never reach a per-Agent
+      // orchestrator on a later rebuild. Merge the boot set with the runtime's
+      // currently-active domain tools, de-duped by name (boot built-ins are
+      // already in `domainTools` and win on clash).
+      const currentDomainTools = (): DomainTool[] =>
+        mergeDomainTools(domainTools, dynamicAgentRuntime.activeDomainTools());
+
       let attached = 0;
       for (const entry of registryForHydrate.list()) {
-        for (const t of scopeDomainToolsToPlugins(domainTools, entry.plugins)) {
+        for (const t of scopeDomainToolsToPlugins(
+          currentDomainTools(),
+          entry.plugins,
+        )) {
           if (!entry.built.orchestrator.hasDomainTool(t.name)) {
             entry.built.orchestrator.registerDomainTool(t);
             attached += 1;
@@ -1189,16 +1233,19 @@ async function main(): Promise<void> {
         `[middleware] registry orchestrators: hydrated with ${String(attached)} domain-tool registrations across ${String(registryForHydrate.list().length)} agent(s) (per-Agent plugin-scoped)`,
       );
       // Persist the wiring so a later `registry.reload()` that REBUILDS an
-      // Agent (privacy_profile flip, plugin enable/disable, etc.) re-hydrates
-      // the new orchestrator — still scoped to the Agent's enabled plugins.
-      // The entry is in the registry map before `onAgentBuilt` fires (both the
+      // Agent (privacy_profile flip, etc.) re-hydrates the new orchestrator —
+      // still scoped to the Agent's enabled plugins, and now from the LIVE tool
+      // source so a runtime-installed agent's tool survives the rebuild. The
+      // entry is in the registry map before `onAgentBuilt` fires (both the
       // `add` and `rebuild` actions set it first), so the plugin lookup is
       // available here. Without this, the rebuilt Agent goes back to
       // `domainTools: []` and the operator's next chat turn cannot reach its
       // sub-agents.
       registryForHydrate.setOnAgentBuilt((slug, built) => {
         const entry = registryForHydrate.get(slug);
-        const tools = entry ? scopeDomainToolsToPlugins(domainTools, entry.plugins) : [];
+        const tools = entry
+          ? scopeDomainToolsToPlugins(currentDomainTools(), entry.plugins)
+          : [];
         for (const t of tools) {
           if (!built.orchestrator.hasDomainTool(t.name)) {
             built.orchestrator.registerDomainTool(t);
@@ -1208,6 +1255,113 @@ async function main(): Promise<void> {
           `[middleware] registry: orchestrator for "${slug}" hydrated with ${String(tools.length)} domain-tool(s) (per-Agent plugin-scoped)`,
         );
       });
+
+      // --- Runtime plugin (de)activation propagation ----------------------
+      // A plugin (de)activated AFTER boot (operator install, Hub/registry
+      // install, package re-upload, self-extension) mutates only the standalone
+      // `dynamicAgentRuntime` + the single legacy orchestrator. The per-Agent
+      // registry orchestrators — which the chat router resolves for every turn,
+      // falling back to the fallback Agent for un-slugged turns — are a boot
+      // snapshot that the install path never reconciled. These two closures
+      // close that gap; the `let` forward-refs near the install hooks are
+      // assigned here (the hooks only fire at runtime, after this block ran).
+      const ORCHESTRATOR_PLUGIN_ID = '@omadia/orchestrator';
+
+      // Reconcile a single agent-plugin's DomainTool across every per-Agent
+      // orchestrator: (re-)register a fresh handle where the plugin is enabled,
+      // drop it where it is not. Idempotent and safe for re-uploads (the stale
+      // handle is replaced). No-ops for non-agent plugins (no DomainTool); on
+      // uninstall the runtime no longer knows the tool, so drop it by name.
+      const reconcileRuntimeDomainTool = (
+        pluginId: string,
+        removedToolName?: string,
+      ): void => {
+        const reg =
+          serviceRegistry.get<MultiOrchestratorRegistry>('orchestratorRegistry');
+        if (!reg) return;
+        const tool = dynamicAgentRuntime.domainToolFor(pluginId);
+        reconcileDomainToolAcrossAgents(
+          reg.list().map((entry) => ({
+            slug: entry.agent.slug,
+            enabled: entry.plugins.some(
+              (p) => p.enabled && p.pluginId === pluginId,
+            ),
+            orchestrator: entry.built.orchestrator,
+          })),
+          {
+            ...(tool ? { tool } : {}),
+            ...(removedToolName ? { removedToolName } : {}),
+            onError: (slug, err) =>
+              console.error(
+                `[middleware] reconcileRuntimeDomainTool(${pluginId}) on "${slug}" FAILED:`,
+                err instanceof Error ? err.message : String(err),
+              ),
+          },
+        );
+      };
+
+      propagatePluginInstall = async (pluginId: string): Promise<void> => {
+        if (pluginId === ORCHESTRATOR_PLUGIN_ID) return;
+        const store =
+          serviceRegistry.get<MultiOrchestratorConfigStore>('configStore');
+        const reg =
+          serviceRegistry.get<MultiOrchestratorRegistry>('orchestratorRegistry');
+        if (!store || !reg) return; // no-DB / chat-disabled boot — nothing to wire
+        try {
+          const { fallbackAgentId } = await store.getPlatformSettings();
+          if (fallbackAgentId) {
+            // Keep the "fallback Agent has every installed plugin enabled"
+            // invariant alive at runtime. Un-slugged chat routes to the
+            // fallback Agent (getDefaultSlug → slugForFallback); without an
+            // enabled `agent_plugins` row, `scopeDomainToolsToPlugins` would
+            // withhold the new tool even after it is hydrated. First-boot does
+            // this via `attachAllPlugins`; runtime installs never did.
+            await store.upsertAgentPlugin(fallbackAgentId, {
+              pluginId,
+              enabled: true,
+            });
+            // Refresh `entry.plugins` from the DB so the scoping check below
+            // sees the freshly-enabled row. Idempotent no-op when unchanged;
+            // a plugin-only change is an `update` (no rebuild → sessions kept).
+            await reg.reload();
+          }
+        } catch (err) {
+          console.error(
+            `[middleware] propagatePluginInstall(${pluginId}) enable/reload FAILED:`,
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+        reconcileRuntimeDomainTool(pluginId);
+        console.log(`[middleware] runtime plugin install propagated: ${pluginId}`);
+      };
+
+      propagatePluginUninstall = async (
+        pluginId: string,
+        removedToolName?: string,
+      ): Promise<void> => {
+        if (pluginId === ORCHESTRATOR_PLUGIN_ID) return;
+        const store =
+          serviceRegistry.get<MultiOrchestratorConfigStore>('configStore');
+        const reg =
+          serviceRegistry.get<MultiOrchestratorRegistry>('orchestratorRegistry');
+        if (!store || !reg) return;
+        try {
+          const { fallbackAgentId } = await store.getPlatformSettings();
+          if (fallbackAgentId) {
+            await store.removeAgentPlugin(fallbackAgentId, pluginId);
+            await reg.reload();
+          }
+        } catch (err) {
+          console.error(
+            `[middleware] propagatePluginUninstall(${pluginId}) disable/reload FAILED:`,
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+        reconcileRuntimeDomainTool(pluginId, removedToolName);
+        console.log(
+          `[middleware] runtime plugin uninstall propagated: ${pluginId}`,
+        );
+      };
     }
   }
 
@@ -1861,6 +2015,10 @@ async function main(): Promise<void> {
               await dynamicAgentRuntime.deactivate(agentId);
             }
             await dynamicAgentRuntime.activate(agentId);
+            // Hub/registry install + package re-upload land here. Propagate the
+            // (fresh) tool onto the per-Agent orchestrators so the new/updated
+            // capability is live for the next chat turn without a restart.
+            await propagatePluginInstall?.(agentId);
           }
         }
       },

--- a/middleware/src/plugins/dynamicAgentRuntime.ts
+++ b/middleware/src/plugins/dynamicAgentRuntime.ts
@@ -483,6 +483,22 @@ export class DynamicAgentRuntime {
   activeIds(): string[] {
     return Array.from(this.active.keys());
   }
+
+  /** DomainTools for every currently-active dynamic/uploaded agent. Lets the
+   *  host re-hydrate the per-Agent registry orchestrators after a POST-BOOT
+   *  activation — the boot-time `domainTools[]` snapshot in index.ts is frozen
+   *  and would otherwise never include a hot-installed agent's tool. */
+  activeDomainTools(): DomainTool[] {
+    return Array.from(this.active.values()).map((a) => a.domainTool);
+  }
+
+  /** The DomainTool a single active agent-plugin exposes, or `undefined` when
+   *  the agent is not active. The install/uninstall hooks use this to (re-)
+   *  register the fresh tool on — or drop a stale one from — the per-Agent
+   *  registry orchestrators without a restart. */
+  domainToolFor(agentId: string): DomainTool | undefined {
+    return this.active.get(agentId)?.domainTool;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/middleware/test/runtimeToolPropagation.test.ts
+++ b/middleware/test/runtimeToolPropagation.test.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type { DomainTool } from '@omadia/orchestrator';
+
+import {
+  mergeDomainTools,
+  reconcileDomainToolAcrossAgents,
+  type ReconcileTarget,
+} from '../src/agents/runtimeToolPropagation.js';
+
+/** Minimal fake of the orchestrator's domain-tool surface. */
+function fakeHost(initial: string[] = []) {
+  const tools = new Set(initial);
+  return {
+    tools,
+    hasDomainTool: (name: string) => tools.has(name),
+    registerDomainTool: (tool: DomainTool) => {
+      if (tools.has(tool.name)) {
+        throw new Error(`duplicate domain-tool name '${tool.name}'`);
+      }
+      tools.add(tool.name);
+    },
+    unregisterDomainTool: (name: string) => tools.delete(name),
+  };
+}
+
+function tool(name: string, agentId: string): DomainTool {
+  // The reconciler only touches `.name`; cast keeps the test free of the full
+  // DomainTool shape (handle/spec/domain).
+  return { name, agentId } as unknown as DomainTool;
+}
+
+const T = tool('query_acme', 'de.byte5.agent.acme');
+
+test('install: registers the tool only on Agents where the plugin is enabled', () => {
+  const fallback = fakeHost();
+  const scoped = fakeHost();
+  const targets: ReconcileTarget[] = [
+    { slug: 'fallback', enabled: true, orchestrator: fallback },
+    { slug: 'marketing', enabled: false, orchestrator: scoped },
+  ];
+
+  reconcileDomainToolAcrossAgents(targets, { tool: T });
+
+  assert.ok(fallback.tools.has('query_acme'), 'enabled Agent gets the tool');
+  assert.ok(!scoped.tools.has('query_acme'), 'scoped Agent withholds the tool');
+});
+
+test('re-upload: replaces a stale handle instead of throwing on duplicate', () => {
+  const host = fakeHost(['query_acme']); // v1 already registered
+  const targets: ReconcileTarget[] = [
+    { slug: 'fallback', enabled: true, orchestrator: host },
+  ];
+
+  // Would throw "duplicate domain-tool name" without the unregister-first step.
+  assert.doesNotThrow(() =>
+    reconcileDomainToolAcrossAgents(targets, { tool: T }),
+  );
+  assert.ok(host.tools.has('query_acme'));
+});
+
+test('disable: drops the tool from an Agent that no longer enables the plugin', () => {
+  const host = fakeHost(['query_acme']);
+  const targets: ReconcileTarget[] = [
+    { slug: 'fallback', enabled: false, orchestrator: host },
+  ];
+
+  reconcileDomainToolAcrossAgents(targets, { tool: T });
+
+  assert.ok(!host.tools.has('query_acme'), 'withheld tool is removed');
+});
+
+test('uninstall: drops the tool by name when the runtime no longer knows it', () => {
+  const a = fakeHost(['query_acme']);
+  const b = fakeHost(['query_acme', 'query_other']);
+  const targets: ReconcileTarget[] = [
+    { slug: 'fallback', enabled: false, orchestrator: a },
+    { slug: 'support', enabled: false, orchestrator: b },
+  ];
+
+  // No `tool` (deactivated) — removal is driven by `removedToolName`.
+  reconcileDomainToolAcrossAgents(targets, { removedToolName: 'query_acme' });
+
+  assert.ok(!a.tools.has('query_acme'));
+  assert.ok(!b.tools.has('query_acme'));
+  assert.ok(b.tools.has('query_other'), 'unrelated tools are untouched');
+});
+
+test('isolation: a throw on one Agent does not abort the rest', () => {
+  const boom = {
+    hasDomainTool: () => false,
+    registerDomainTool: () => {
+      throw new Error('kaboom');
+    },
+    unregisterDomainTool: () => false,
+  };
+  const ok = fakeHost();
+  const errors: string[] = [];
+  const targets: ReconcileTarget[] = [
+    { slug: 'broken', enabled: true, orchestrator: boom },
+    { slug: 'fine', enabled: true, orchestrator: ok },
+  ];
+
+  reconcileDomainToolAcrossAgents(targets, {
+    tool: T,
+    onError: (slug) => errors.push(slug),
+  });
+
+  assert.deepEqual(errors, ['broken']);
+  assert.ok(ok.tools.has('query_acme'), 'the healthy Agent still got the tool');
+});
+
+test('mergeDomainTools: boot built-ins win on a name clash, runtime tools append', () => {
+  const boot = [tool('query_acme', 'agent.acme'), tool('memory', 'core')];
+  const runtime = [
+    tool('query_acme', 'agent.acme'), // duplicate by name → boot wins
+    tool('query_new', 'agent.new'), // hot-installed → appended
+  ];
+
+  const merged = mergeDomainTools(boot, runtime);
+
+  assert.deepEqual(
+    merged.map((t) => t.name),
+    ['query_acme', 'memory', 'query_new'],
+  );
+});


### PR DESCRIPTION
## Problem

Plugins (de)activated **at runtime** — operator install, **Hub/registry install**, package re-upload, or self-extension — never went live without a restart, and un-slugged chat behaved like the generic **fallback Agent** as if the plugin were never activated.

## Root cause (verified against the code)

Two separate worlds drift apart on a post-boot install:

- **Standalone runtimes** (`dynamicAgentRuntime` / `toolPluginRuntime` / `channelRegistry`) activate the plugin and register its `DomainTool` only on the **single legacy orchestrator** (`attachOrchestrator` holds one reference).
- The **multi-Agent `OrchestratorRegistry`** — which the chat router resolves for every turn (`getDefaultSlug → slugForFallback` for un-slugged turns) — is a **boot snapshot the install path never reconciled**. No `registry.reload()` is triggered from the install hooks.

Two compounding defects:
1. Per-Agent hydration sourced a `domainTools[]` array **frozen at boot**, so a hot-installed agent's tool never reached the per-Agent orchestrators, even on a later rebuild.
2. `scopeDomainToolsToPlugins` withholds a tool unless the plugin is **enabled** on the Agent. The *"fallback Agent has every plugin enabled"* invariant was only established on **first boot** (`attachAllPlugins`) and never maintained at runtime — and a plugin-only change produces an `update` diff (no `onAgentBuilt`), so the tool was never registered on the existing orchestrator anyway.

## Fix

- `dynamicAgentRuntime`: expose `activeDomainTools()` / `domainToolFor()`.
- `index.ts`: hydrate per-Agent orchestrators from a **live** tool source (`mergeDomainTools(boot, runtime)`) at boot and on rebuild.
- `index.ts`: on install (**both** `onInstalled` *and* `onPackageReady` → covers operator, Hub, registry, re-upload, self-extension) auto-enable the plugin on the **fallback Agent** (keeps the first-boot invariant alive at runtime), `reload()` the registry to refresh `entry.plugins`, then reconcile the tool across all per-Agent orchestrators. Symmetric teardown on uninstall.
- Extract the reconcile/merge decision logic into a pure, **tested** module (`agents/runtimeToolPropagation.ts`).

## Decision

Per maintainer choice: newly installed/self-extended plugins are **auto-enabled on the fallback Agent only** (scoped Agents are left untouched — no silent capability grants).

## Verification

- `tsc --noEmit` clean, `eslint` clean.
- 7 new unit tests (install / re-upload / disable / uninstall / error-isolation / merge) + existing `scopeDomainTools`, `orchestratorRegistry`, `hot-reload`, `channelResolver`, `installService` suites — all green.
- Merged latest `origin/main` first; re-validated.

## Known boundary

Channel-kind plugins route via `channel_bindings`; binding a runtime-installed **channel** remains an explicit operator step (`operatorChannels` already calls `reload()`). Not changed here.
