### PR TITLE
feat(admin): .env-based settings overview with live auto-apply + model-routing env wiring

### DIFF
--- a/middleware/.env.example
+++ b/middleware/.env.example
@@ -20,6 +20,17 @@
 ORCHESTRATOR_MODEL=claude-opus-4-8
 ORCHESTRATOR_MAX_TOKENS=4096
 
+# --- Per-turn model routing (Haiku triage) ----------------------------------
+# When ON, a cheap Haiku classifier picks the model per turn: simple turns run
+# on the simple model (default sonnet-4-6), complex turns on the complex model
+# (default = ORCHESTRATOR_MODEL). Seeded into the orchestrator plugin config on
+# first boot; afterwards toggle it live via Admin → Konfiguration. The *_MODEL
+# overrides are optional — leave unset to use the defaults.
+ORCHESTRATOR_MODEL_ROUTING=true
+# MODEL_ROUTING_CLASSIFIER_MODEL=claude-haiku-4-5
+# MODEL_ROUTING_SIMPLE_MODEL=claude-sonnet-4-6
+# MODEL_ROUTING_COMPLEX_MODEL=claude-opus-4-8
+
 # --- Sub-agent runtime ------------------------------------------------------
 # Sub-agents run as local tool-loops in this process. Set SUB_AGENT_MODEL to
 # a cheaper model (e.g. claude-sonnet-4-6 or claude-haiku-4-5) to keep costs

--- a/middleware/src/config.ts
+++ b/middleware/src/config.ts
@@ -40,6 +40,21 @@ const ConfigSchema = z.object({
   ORCHESTRATOR_MODEL: z.string().min(1).default('claude-opus-4-8'),
   ORCHESTRATOR_MAX_TOKENS: z.coerce.number().int().positive().default(8192),
 
+  // Per-turn Sonnet/Opus routing (opt-in). When ON, a cheap Haiku classifier
+  // picks the model per turn: simple → ROUTING_SIMPLE_MODEL, complex →
+  // ROUTING_COMPLEX_MODEL. Seeded into the orchestrator plugin config so it is
+  // also editable at runtime via /api/v1/admin/settings. The *_MODEL overrides
+  // are optional — the orchestrator falls back to sensible defaults (classifier
+  // → TOPIC_CLASSIFIER_MODEL/haiku, simple → SUB_AGENT_MODEL/sonnet, complex →
+  // ORCHESTRATOR_MODEL) when they're unset.
+  ORCHESTRATOR_MODEL_ROUTING: z
+    .enum(['true', 'false'])
+    .transform((v) => v === 'true')
+    .default(false),
+  MODEL_ROUTING_CLASSIFIER_MODEL: z.string().min(1).optional(),
+  MODEL_ROUTING_SIMPLE_MODEL: z.string().min(1).optional(),
+  MODEL_ROUTING_COMPLEX_MODEL: z.string().min(1).optional(),
+
   // Sub-agent runtime (Odoo Accounting, Odoo HR, Confluence Playbook). These
   // sub-agents run locally inside the middleware; skill markdown lives under
   // SKILLS_DIR. Model default matches the orchestrator; override to run

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -61,6 +61,7 @@ import { createProfilesRouter } from './routes/profiles.js';
 import { createPackagesRouter } from './routes/packages.js';
 import { createRegistryInstallRouter } from './routes/registryInstall.js';
 import { createRuntimeRouter } from './routes/runtime.js';
+import { createAdminSettingsRouter } from './routes/adminSettings.js';
 import { createVaultStatusRouter } from './routes/vaultStatus.js';
 import { createBuilderRouter } from './routes/builder.js';
 import {
@@ -2139,6 +2140,20 @@ async function main(): Promise<void> {
     }),
   );
   console.log('[middleware] runtime introspection endpoint ready at /api/v1/admin/runtime (auth: required)');
+
+  // Operator settings overview — every .env-based value bootstrap writes into
+  // the config-store / vault, editable with live re-activation. Reuses the
+  // same installedRegistry + vault + reactivate plumbing as the runtime route.
+  app.use(
+    '/api/v1/admin/settings',
+    requireAuth,
+    createAdminSettingsRouter({
+      installedRegistry,
+      vault: secretVault,
+      reactivate: reactivateAgent,
+    }),
+  );
+  console.log('[middleware] settings overview endpoint ready at /api/v1/admin/settings (auth: required)');
 
   // ── Agent-Builder drafts (B.0) ────────────────────────────────────────────
   // SQLite-backed draft store; persists alongside the vault so redeploys

--- a/middleware/src/platform/settingsCatalog.ts
+++ b/middleware/src/platform/settingsCatalog.ts
@@ -1,0 +1,360 @@
+/**
+ * Operator-facing catalog of the `.env`-based settings that get written into
+ * the runtime config-store / secret vault on first boot (see
+ * `plugins/bootstrap.ts`). This is the single source of truth behind the
+ * `/api/v1/admin/settings` admin overview: each entry knows its human label,
+ * category, value type, and — crucially — WHERE the value lives at runtime
+ * (which installed plugin's config key, or which vault scope+key for secrets).
+ *
+ * Why a curated catalog rather than deriving from each plugin's setup_schema:
+ * the `.env` → config mappings in bootstrap are broader than the install
+ * wizard's setup_schema (e.g. model-routing flags, max-tokens) and we want a
+ * grouped, operator-readable overview of exactly those env-seeded values —
+ * not every internal config key. Keeping it as plain data also makes it
+ * trivially testable and lets the admin page render generic typed inputs.
+ *
+ * The admin PATCH handler writes config values via
+ * `installedRegistry.updateConfig` and secrets via `vault.setMany` /
+ * `deleteKey`, then `reactivate`s each affected plugin — the same plumbing the
+ * post-install editor (`routes/runtime.ts`) already uses, so changes take
+ * effect live ("auto change nach Änderung") without a restart.
+ */
+
+/** Plugin ids (installed-registry ids / vault scopes) the settings target. */
+const ORCHESTRATOR = '@omadia/orchestrator';
+const ORCHESTRATOR_EXTRAS = '@omadia/orchestrator-extras';
+const VERIFIER = '@omadia/verifier';
+const EMBEDDINGS = '@omadia/embeddings';
+const KNOWLEDGE_GRAPH = '@omadia/knowledge-graph-neon';
+const DIAGRAMS = '@omadia/diagrams';
+const MICROSOFT365 = 'de.byte5.integration.microsoft365';
+const TEAMS = 'de.byte5.channel.teams';
+const TELEGRAM = 'de.byte5.channel.telegram';
+
+export type SettingValueType =
+  | 'string'
+  | 'url'
+  | 'number'
+  | 'boolean'
+  | 'enum'
+  | 'secret';
+
+export interface SettingDef {
+  /** Stable identifier — the `.env` variable name. Also the GET/PATCH key. */
+  readonly key: string;
+  /** German UI label. */
+  readonly label: string;
+  /** Optional help text shown under the field. */
+  readonly help?: string;
+  /** Grouping shown as a section in the admin overview. */
+  readonly category: string;
+  readonly type: SettingValueType;
+  /** Options for `type === 'enum'`. */
+  readonly options?: ReadonlyArray<{ value: string; label: string }>;
+  /** Input placeholder / shown default hint. */
+  readonly placeholder?: string;
+  /**
+   * Target for NON-secret settings: the installed plugin whose `config[<key>]`
+   * holds the value. Exactly one of `config` / `secret` is set.
+   */
+  readonly config?: { readonly pluginId: string; readonly configKey: string };
+  /**
+   * Target for SECRET settings: the vault key, written into every listed
+   * scope (a secret like the Anthropic key is read by several plugins, each
+   * under its own vault namespace). Values are never read back — the overview
+   * only shows set / unset.
+   */
+  readonly secret?: { readonly vaultKey: string; readonly scopes: readonly string[] };
+}
+
+// Category labels (German — the admin section is hardcoded-German, matching
+// the sibling admin pages which don't use the i18n catalog).
+const C_MODELS = 'Modelle & Routing';
+const C_VERIFIER = 'Verifier';
+const C_KNOWLEDGE = 'Wissen & Embeddings';
+const C_DIAGRAMS = 'Diagramme & Speicher';
+const C_INTEGRATIONS = 'Integrationen';
+
+export const SETTINGS_CATALOG: readonly SettingDef[] = [
+  // ── Modelle & Routing (@omadia/orchestrator) ────────────────────────────
+  {
+    key: 'ANTHROPIC_API_KEY',
+    label: 'Anthropic API-Key',
+    help: 'Wird für Orchestrator, Verifier und die Background-Tasks benötigt. Beginnt mit "sk-ant-". Bestehender Wert wird nie angezeigt.',
+    category: C_MODELS,
+    type: 'secret',
+    placeholder: 'sk-ant-…',
+    secret: {
+      vaultKey: 'anthropic_api_key',
+      scopes: [ORCHESTRATOR, VERIFIER, ORCHESTRATOR_EXTRAS],
+    },
+  },
+  {
+    key: 'ORCHESTRATOR_MODEL',
+    label: 'Orchestrator-Modell',
+    help: 'Standard-Modell für jeden Chat-Turn (z. B. claude-opus-4-8). Bei aktivem Routing der "complex"-Fallback.',
+    category: C_MODELS,
+    type: 'string',
+    placeholder: 'claude-opus-4-8',
+    config: { pluginId: ORCHESTRATOR, configKey: 'orchestrator_model' },
+  },
+  {
+    key: 'ORCHESTRATOR_MAX_TOKENS',
+    label: 'Orchestrator max. Tokens',
+    category: C_MODELS,
+    type: 'number',
+    placeholder: '8192',
+    config: { pluginId: ORCHESTRATOR, configKey: 'orchestrator_max_tokens' },
+  },
+  {
+    key: 'MAX_TOOL_ITERATIONS',
+    label: 'Max. Tool-Iterationen pro Turn',
+    category: C_MODELS,
+    type: 'number',
+    placeholder: '12',
+    config: { pluginId: ORCHESTRATOR, configKey: 'max_tool_iterations' },
+  },
+  {
+    key: 'ORCHESTRATOR_MODEL_ROUTING',
+    label: 'Per-Turn Model-Routing (Haiku-Triage)',
+    help: 'Wenn an, klassifiziert ein günstiger Haiku-Call jeden Turn: einfach → Simple-Modell, komplex → Complex-Modell.',
+    category: C_MODELS,
+    type: 'boolean',
+    config: { pluginId: ORCHESTRATOR, configKey: 'orchestrator_model_routing' },
+  },
+  {
+    key: 'MODEL_ROUTING_CLASSIFIER_MODEL',
+    label: 'Routing: Klassifizierer-Modell',
+    help: 'Haiku-Modell für die Triage. Leer = Default (haiku-4-5).',
+    category: C_MODELS,
+    type: 'string',
+    placeholder: 'claude-haiku-4-5',
+    config: { pluginId: ORCHESTRATOR, configKey: 'model_routing_classifier_model' },
+  },
+  {
+    key: 'MODEL_ROUTING_SIMPLE_MODEL',
+    label: 'Routing: Modell für einfache Turns',
+    help: 'Leer = Default (sonnet-4-6).',
+    category: C_MODELS,
+    type: 'string',
+    placeholder: 'claude-sonnet-4-6',
+    config: { pluginId: ORCHESTRATOR, configKey: 'model_routing_simple_model' },
+  },
+  {
+    key: 'MODEL_ROUTING_COMPLEX_MODEL',
+    label: 'Routing: Modell für komplexe Turns',
+    help: 'Leer = Orchestrator-Modell.',
+    category: C_MODELS,
+    type: 'string',
+    placeholder: 'claude-opus-4-8',
+    config: { pluginId: ORCHESTRATOR, configKey: 'model_routing_complex_model' },
+  },
+  {
+    key: 'TOPIC_CLASSIFIER_MODEL',
+    label: 'Topic-/Fact-Klassifizierer-Modell',
+    help: 'Haiku-Tier-Modell für Topic-Clustering und Fakt-Extraktion.',
+    category: C_MODELS,
+    type: 'string',
+    placeholder: 'claude-haiku-4-5-20251001',
+    config: { pluginId: ORCHESTRATOR_EXTRAS, configKey: 'topic_classifier_model' },
+  },
+
+  // ── Verifier (@omadia/verifier) ─────────────────────────────────────────
+  {
+    key: 'VERIFIER_ENABLED',
+    label: 'Verifier aktiv',
+    help: 'Prüft jede Orchestrator-Antwort gegen Quellen.',
+    category: C_VERIFIER,
+    type: 'boolean',
+    config: { pluginId: VERIFIER, configKey: 'verifier_enabled' },
+  },
+  {
+    key: 'VERIFIER_MODE',
+    label: 'Verifier-Modus',
+    category: C_VERIFIER,
+    type: 'enum',
+    options: [
+      { value: 'shadow', label: 'shadow (nur protokollieren)' },
+      { value: 'enforce', label: 'enforce (blockieren)' },
+    ],
+    config: { pluginId: VERIFIER, configKey: 'verifier_mode' },
+  },
+  {
+    key: 'VERIFIER_MODEL',
+    label: 'Verifier-Modell',
+    category: C_VERIFIER,
+    type: 'string',
+    placeholder: 'claude-haiku-4-5-20251001',
+    config: { pluginId: VERIFIER, configKey: 'verifier_model' },
+  },
+  {
+    key: 'VERIFIER_MAX_CLAIMS',
+    label: 'Verifier max. Claims',
+    category: C_VERIFIER,
+    type: 'number',
+    placeholder: '20',
+    config: { pluginId: VERIFIER, configKey: 'verifier_max_claims' },
+  },
+  {
+    key: 'VERIFIER_MAX_RETRIES',
+    label: 'Verifier max. Retries',
+    category: C_VERIFIER,
+    type: 'number',
+    placeholder: '1',
+    config: { pluginId: VERIFIER, configKey: 'verifier_max_retries' },
+  },
+
+  // ── Wissen & Embeddings ─────────────────────────────────────────────────
+  {
+    key: 'OLLAMA_BASE_URL',
+    label: 'Ollama Base-URL',
+    category: C_KNOWLEDGE,
+    type: 'url',
+    placeholder: 'http://ollama:11434',
+    config: { pluginId: EMBEDDINGS, configKey: 'ollama_base_url' },
+  },
+  {
+    key: 'OLLAMA_EMBEDDING_MODEL',
+    label: 'Embedding-Modell',
+    category: C_KNOWLEDGE,
+    type: 'string',
+    placeholder: 'nomic-embed-text',
+    config: { pluginId: EMBEDDINGS, configKey: 'ollama_model' },
+  },
+  {
+    key: 'GRAPH_TENANT_ID',
+    label: 'Knowledge-Graph Tenant-ID',
+    category: C_KNOWLEDGE,
+    type: 'string',
+    placeholder: 'default',
+    config: { pluginId: KNOWLEDGE_GRAPH, configKey: 'graph_tenant_id' },
+  },
+  {
+    key: 'GRAPH_EMBEDDING_BACKFILL_ENABLED',
+    label: 'Embedding-Backfill aktiv',
+    category: C_KNOWLEDGE,
+    type: 'boolean',
+    config: {
+      pluginId: KNOWLEDGE_GRAPH,
+      configKey: 'graph_embedding_backfill_enabled',
+    },
+  },
+
+  // ── Diagramme & Speicher (@omadia/diagrams) ─────────────────────────────
+  {
+    key: 'KROKI_BASE_URL',
+    label: 'Kroki Base-URL',
+    category: C_DIAGRAMS,
+    type: 'url',
+    placeholder: 'http://kroki:8000',
+    config: { pluginId: DIAGRAMS, configKey: 'kroki_base_url' },
+  },
+  {
+    key: 'DIAGRAM_PUBLIC_BASE_URL',
+    label: 'Öffentliche Diagramm-Base-URL',
+    category: C_DIAGRAMS,
+    type: 'url',
+    config: { pluginId: DIAGRAMS, configKey: 'public_base_url' },
+  },
+  {
+    key: 'AWS_ENDPOINT_URL_S3',
+    label: 'S3/Tigris Endpoint',
+    category: C_DIAGRAMS,
+    type: 'url',
+    config: { pluginId: DIAGRAMS, configKey: 'tigris_endpoint' },
+  },
+  {
+    key: 'BUCKET_NAME',
+    label: 'S3/Tigris Bucket',
+    category: C_DIAGRAMS,
+    type: 'string',
+    config: { pluginId: DIAGRAMS, configKey: 'tigris_bucket' },
+  },
+  {
+    key: 'AWS_ACCESS_KEY_ID',
+    label: 'S3 Access-Key-ID',
+    category: C_DIAGRAMS,
+    type: 'secret',
+    secret: { vaultKey: 'aws_access_key_id', scopes: [DIAGRAMS] },
+  },
+  {
+    key: 'AWS_SECRET_ACCESS_KEY',
+    label: 'S3 Secret-Access-Key',
+    category: C_DIAGRAMS,
+    type: 'secret',
+    secret: { vaultKey: 'aws_secret_access_key', scopes: [DIAGRAMS] },
+  },
+
+  // ── Integrationen (private byte5-Plugins — werden als "nicht installiert"
+  //    angezeigt, wenn das jeweilige Plugin in diesem Deployment fehlt) ─────
+  {
+    key: 'MICROSOFT_APP_ID',
+    label: 'Microsoft App-ID',
+    category: C_INTEGRATIONS,
+    type: 'string',
+    config: { pluginId: MICROSOFT365, configKey: 'microsoft_app_id' },
+  },
+  {
+    key: 'MICROSOFT_APP_TENANT_ID',
+    label: 'Microsoft Tenant-ID',
+    category: C_INTEGRATIONS,
+    type: 'string',
+    config: { pluginId: MICROSOFT365, configKey: 'microsoft_tenant_id' },
+  },
+  {
+    key: 'MICROSOFT_APP_PASSWORD',
+    label: 'Microsoft App-Passwort',
+    category: C_INTEGRATIONS,
+    type: 'secret',
+    secret: { vaultKey: 'microsoft_app_password', scopes: [MICROSOFT365] },
+  },
+  {
+    key: 'TEAMS_SSO_CONNECTION_NAME',
+    label: 'Teams SSO Connection-Name',
+    category: C_INTEGRATIONS,
+    type: 'string',
+    config: { pluginId: TEAMS, configKey: 'teams_sso_connection_name' },
+  },
+  {
+    key: 'TELEGRAM_PUBLIC_BASE_URL',
+    label: 'Telegram Public-Base-URL',
+    category: C_INTEGRATIONS,
+    type: 'url',
+    config: { pluginId: TELEGRAM, configKey: 'telegram_public_base_url' },
+  },
+  {
+    key: 'TELEGRAM_BOT_TOKEN',
+    label: 'Telegram Bot-Token',
+    category: C_INTEGRATIONS,
+    type: 'secret',
+    secret: { vaultKey: 'telegram_bot_token', scopes: [TELEGRAM] },
+  },
+  {
+    key: 'TELEGRAM_WEBHOOK_SECRET',
+    label: 'Telegram Webhook-Secret',
+    category: C_INTEGRATIONS,
+    type: 'secret',
+    secret: { vaultKey: 'telegram_webhook_secret', scopes: [TELEGRAM] },
+  },
+];
+
+/** Lookup by `.env` key. */
+export function findSetting(key: string): SettingDef | undefined {
+  return SETTINGS_CATALOG.find((s) => s.key === key);
+}
+
+/** Distinct plugin ids a setting touches (config plugin + all secret scopes). */
+export function settingPluginIds(def: SettingDef): string[] {
+  if (def.config) return [def.config.pluginId];
+  if (def.secret) return [...def.secret.scopes];
+  return [];
+}
+
+/** Category order for stable rendering in the admin overview. */
+export const SETTINGS_CATEGORY_ORDER: readonly string[] = [
+  C_MODELS,
+  C_VERIFIER,
+  C_KNOWLEDGE,
+  C_DIAGRAMS,
+  C_INTEGRATIONS,
+];

--- a/middleware/src/plugins/bootstrap.ts
+++ b/middleware/src/plugins/bootstrap.ts
@@ -772,6 +772,25 @@ async function bootstrapOrchestratorFromEnv(
     deps.config.ORCHESTRATOR_MAX_TOKENS,
   );
   config['max_tool_iterations'] = String(deps.config.MAX_TOOL_ITERATIONS);
+  // Per-turn model routing (see plugin.ts — reads these keys). The flag is
+  // always seeded so the runtime read has a definite value; the per-bucket
+  // model overrides are seeded only when explicitly set, leaving the
+  // plugin's built-in fallbacks in charge otherwise.
+  config['orchestrator_model_routing'] = deps.config.ORCHESTRATOR_MODEL_ROUTING
+    ? 'true'
+    : 'false';
+  if (deps.config.MODEL_ROUTING_CLASSIFIER_MODEL) {
+    config['model_routing_classifier_model'] =
+      deps.config.MODEL_ROUTING_CLASSIFIER_MODEL;
+  }
+  if (deps.config.MODEL_ROUTING_SIMPLE_MODEL) {
+    config['model_routing_simple_model'] =
+      deps.config.MODEL_ROUTING_SIMPLE_MODEL;
+  }
+  if (deps.config.MODEL_ROUTING_COMPLEX_MODEL) {
+    config['model_routing_complex_model'] =
+      deps.config.MODEL_ROUTING_COMPLEX_MODEL;
+  }
 
   await deps.registry.register({
     id: ORCHESTRATOR_TOOL_ID,

--- a/middleware/src/routes/adminSettings.ts
+++ b/middleware/src/routes/adminSettings.ts
@@ -1,0 +1,285 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+
+import type { InstalledRegistry } from '../plugins/installedRegistry.js';
+import type { SecretVault } from '../secrets/vault.js';
+import {
+  SETTINGS_CATALOG,
+  SETTINGS_CATEGORY_ORDER,
+  findSetting,
+  settingPluginIds,
+  type SettingDef,
+} from '../platform/settingsCatalog.js';
+
+/**
+ * Operator settings overview — a single editable view of every `.env`-based
+ * value that bootstrap writes into the runtime config-store / secret vault
+ * (see `platform/settingsCatalog.ts`). Mounted at `/api/v1/admin/settings`.
+ *
+ *   GET  /            grouped catalog + current values (secrets: set/unset only)
+ *   PATCH /           apply a batch of changes, then reactivate affected plugins
+ *
+ * Writes go through the same plumbing the post-install editor uses
+ * (`installedRegistry.updateConfig` for config, `vault` for secrets), and each
+ * touched plugin is `reactivate`d so the change takes effect live — no restart.
+ */
+
+interface AdminSettingsDeps {
+  installedRegistry: InstalledRegistry;
+  vault?: SecretVault;
+  /** Tears down + re-activates a plugin so it re-reads fresh config/secrets. */
+  reactivate?: (agentId: string) => Promise<void>;
+}
+
+interface ResolvedSetting {
+  key: string;
+  label: string;
+  help?: string;
+  category: string;
+  type: SettingDef['type'];
+  options?: SettingDef['options'];
+  placeholder?: string;
+  /** All target plugins installed? Drives editability in the UI. */
+  installed: boolean;
+  /** Current non-secret value (stringified), or null when unset. */
+  value?: string | null;
+  /** Secret only: whether a value is stored (never the value itself). */
+  isSet?: boolean;
+}
+
+function stringifyConfigValue(v: unknown): string | null {
+  if (v === undefined || v === null) return null;
+  if (typeof v === 'string') return v;
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  return null;
+}
+
+export function createAdminSettingsRouter(deps: AdminSettingsDeps): Router {
+  const router = Router();
+
+  const allInstalled = (def: SettingDef): boolean =>
+    settingPluginIds(def).every((id) => deps.installedRegistry.has(id));
+
+  // Resolve one setting's current state. Secret reads need a per-scope vault
+  // lookup; the caller passes a cache so a GET doesn't re-list the same scope.
+  const resolve = async (
+    def: SettingDef,
+    keyCache: Map<string, Set<string>>,
+  ): Promise<ResolvedSetting> => {
+    const base: ResolvedSetting = {
+      key: def.key,
+      label: def.label,
+      ...(def.help ? { help: def.help } : {}),
+      category: def.category,
+      type: def.type,
+      ...(def.options ? { options: def.options } : {}),
+      ...(def.placeholder ? { placeholder: def.placeholder } : {}),
+      installed: allInstalled(def),
+    };
+    if (def.secret) {
+      const scope = def.secret.scopes[0];
+      let isSet = false;
+      if (deps.vault && scope) {
+        let keys = keyCache.get(scope);
+        if (!keys) {
+          keys = new Set(await deps.vault.listKeys(scope));
+          keyCache.set(scope, keys);
+        }
+        isSet = keys.has(def.secret.vaultKey);
+      }
+      return { ...base, isSet };
+    }
+    if (def.config) {
+      const entry = deps.installedRegistry.get(def.config.pluginId);
+      return {
+        ...base,
+        value: stringifyConfigValue(entry?.config?.[def.config.configKey]),
+      };
+    }
+    return base;
+  };
+
+  // ── GET / — grouped catalog + current values ────────────────────────────
+  router.get('/', async (_req: Request, res: Response) => {
+    try {
+      const keyCache = new Map<string, Set<string>>();
+      const resolved = await Promise.all(
+        SETTINGS_CATALOG.map((def) => resolve(def, keyCache)),
+      );
+      const byCategory = new Map<string, ResolvedSetting[]>();
+      for (const r of resolved) {
+        const list = byCategory.get(r.category) ?? [];
+        list.push(r);
+        byCategory.set(r.category, list);
+      }
+      const categories = SETTINGS_CATEGORY_ORDER.filter((c) =>
+        byCategory.has(c),
+      ).map((category) => ({
+        category,
+        settings: byCategory.get(category) ?? [],
+      }));
+      res.json({ categories, vault_available: Boolean(deps.vault) });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ code: 'settings.read_failed', message });
+    }
+  });
+
+  // ── PATCH / — apply a batch of changes ──────────────────────────────────
+  router.patch('/', async (req: Request, res: Response) => {
+    const body = req.body as { changes?: unknown } | null;
+    const rawChanges = body?.changes;
+    if (!Array.isArray(rawChanges) || rawChanges.length === 0) {
+      res.status(400).json({
+        code: 'settings.invalid_request',
+        message: 'body must be { changes: [{ key, value }] }',
+      });
+      return;
+    }
+
+    const errors: Array<{ key: string; message: string }> = [];
+    // Per-plugin config patches and per-scope secret patches, batched so each
+    // plugin is written + reactivated at most once.
+    const configPatch = new Map<string, Record<string, unknown>>();
+    const secretSet = new Map<string, Record<string, string>>();
+    const secretDelete = new Map<string, string[]>();
+    const affected = new Set<string>();
+
+    for (const raw of rawChanges) {
+      if (typeof raw !== 'object' || raw === null) {
+        errors.push({ key: '<unknown>', message: 'change must be an object' });
+        continue;
+      }
+      const key = (raw as { key?: unknown }).key;
+      const rawValue = (raw as { value?: unknown }).value;
+      if (typeof key !== 'string') {
+        errors.push({ key: '<unknown>', message: 'missing key' });
+        continue;
+      }
+      const def = findSetting(key);
+      if (!def) {
+        errors.push({ key, message: 'unknown setting' });
+        continue;
+      }
+      if (!allInstalled(def)) {
+        errors.push({ key, message: 'target plugin not installed' });
+        continue;
+      }
+      // null / empty → clear.
+      const cleared =
+        rawValue === null || rawValue === undefined || rawValue === '';
+      const value = cleared ? '' : String(rawValue);
+
+      // Type validation.
+      if (!cleared) {
+        if (def.type === 'number' && !Number.isFinite(Number(value))) {
+          errors.push({ key, message: 'must be a number' });
+          continue;
+        }
+        if (def.type === 'boolean' && value !== 'true' && value !== 'false') {
+          errors.push({ key, message: "must be 'true' or 'false'" });
+          continue;
+        }
+        if (
+          def.type === 'enum' &&
+          !(def.options ?? []).some((o) => o.value === value)
+        ) {
+          errors.push({ key, message: 'not an allowed option' });
+          continue;
+        }
+        if (
+          def.key === 'ANTHROPIC_API_KEY' &&
+          !value.startsWith('sk-ant-')
+        ) {
+          errors.push({ key, message: 'Anthropic-Keys beginnen mit "sk-ant-"' });
+          continue;
+        }
+      }
+
+      if (def.secret) {
+        for (const scope of def.secret.scopes) {
+          if (cleared) {
+            const list = secretDelete.get(scope) ?? [];
+            list.push(def.secret.vaultKey);
+            secretDelete.set(scope, list);
+          } else {
+            const map = secretSet.get(scope) ?? {};
+            map[def.secret.vaultKey] = value;
+            secretSet.set(scope, map);
+          }
+          affected.add(scope);
+        }
+      } else if (def.config) {
+        const patch = configPatch.get(def.config.pluginId) ?? {};
+        // `null` marks a clear; applied against the live config below.
+        patch[def.config.configKey] = cleared ? null : value;
+        configPatch.set(def.config.pluginId, patch);
+        affected.add(def.config.pluginId);
+      }
+    }
+
+    if (affected.size === 0) {
+      res.status(400).json({ code: 'settings.no_valid_changes', errors });
+      return;
+    }
+    if (!deps.vault && (secretSet.size > 0 || secretDelete.size > 0)) {
+      res.status(503).json({
+        code: 'settings.vault_unavailable',
+        message: 'vault not wired — secrets cannot be edited',
+      });
+      return;
+    }
+
+    try {
+      // Config: read live config, shallow-merge the patch (null clears a key).
+      for (const [pluginId, patch] of configPatch) {
+        const installed = deps.installedRegistry.get(pluginId);
+        if (!installed) continue;
+        const next: Record<string, unknown> = { ...installed.config };
+        for (const [k, v] of Object.entries(patch)) {
+          if (v === null) delete next[k];
+          else next[k] = v;
+        }
+        await deps.installedRegistry.updateConfig(pluginId, next);
+      }
+      // Secrets.
+      if (deps.vault) {
+        for (const [scope, map] of secretSet) {
+          if (Object.keys(map).length > 0) await deps.vault.setMany(scope, map);
+        }
+        for (const [scope, keys] of secretDelete) {
+          for (const k of keys) await deps.vault.deleteKey(scope, k);
+        }
+      }
+      // Live apply: reactivate every touched plugin so it re-reads config.
+      if (deps.reactivate) {
+        for (const pluginId of affected) {
+          await deps.reactivate(pluginId);
+        }
+      }
+
+      // Echo back the post-change state of the touched settings.
+      const keyCache = new Map<string, Set<string>>();
+      const touchedKeys = new Set(
+        rawChanges
+          .map((c) =>
+            typeof c === 'object' && c !== null
+              ? (c as { key?: unknown }).key
+              : undefined,
+          )
+          .filter((k): k is string => typeof k === 'string'),
+      );
+      const updated = await Promise.all(
+        SETTINGS_CATALOG.filter((d) => touchedKeys.has(d.key)).map((d) =>
+          resolve(d, keyCache),
+        ),
+      );
+      res.json({ updated, errors });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ code: 'settings.write_failed', message, errors });
+    }
+  });
+
+  return router;
+}

--- a/middleware/test/adminSettingsRoute.test.ts
+++ b/middleware/test/adminSettingsRoute.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import express from 'express';
+import type { Express } from 'express';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { createAdminSettingsRouter } from '../src/routes/adminSettings.js';
+import { InMemoryInstalledRegistry } from '../src/plugins/installedRegistry.js';
+import { InMemorySecretVault } from '../src/secrets/vault.js';
+
+/**
+ * /api/v1/admin/settings — the .env-based config/vault overview. Verifies the
+ * catalog → current-value resolution, the typed PATCH validation, and that a
+ * change writes to the right target (config-store vs vault) and reactivates
+ * exactly the touched plugins.
+ */
+
+const ORCH = '@omadia/orchestrator';
+const VERIFIER = '@omadia/verifier';
+const EXTRAS = '@omadia/orchestrator-extras';
+const DIAGRAMS = '@omadia/diagrams';
+
+interface Harness {
+  server: Server;
+  baseUrl: string;
+  vault: InMemorySecretVault;
+  registry: InMemoryInstalledRegistry;
+  reactivated: string[];
+  close(): Promise<void>;
+}
+
+async function makeHarness(
+  installed: Array<{ id: string; config?: Record<string, unknown> }>,
+): Promise<Harness> {
+  const vault = new InMemorySecretVault();
+  const registry = new InMemoryInstalledRegistry();
+  for (const p of installed) {
+    await registry.register({
+      id: p.id,
+      installed_version: '0.1.0',
+      installed_at: new Date().toISOString(),
+      status: 'active',
+      config: p.config ?? {},
+    });
+  }
+  const reactivated: string[] = [];
+  const app: Express = express();
+  app.use(express.json());
+  app.use(
+    '/api/v1/admin/settings',
+    createAdminSettingsRouter({
+      installedRegistry: registry,
+      vault,
+      reactivate: async (id: string) => {
+        reactivated.push(id);
+      },
+    }),
+  );
+  const server: Server = await new Promise((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const port = (server.address() as AddressInfo).port;
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${String(port)}`,
+    vault,
+    registry,
+    reactivated,
+    async close() {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+async function getSettings(h: Harness): Promise<{
+  categories: Array<{
+    category: string;
+    settings: Array<{
+      key: string;
+      installed: boolean;
+      value?: string | null;
+      isSet?: boolean;
+      type: string;
+    }>;
+  }>;
+  vault_available: boolean;
+}> {
+  const res = await fetch(`${h.baseUrl}/api/v1/admin/settings`);
+  assert.equal(res.status, 200);
+  return res.json() as never;
+}
+
+function findSetting(
+  body: Awaited<ReturnType<typeof getSettings>>,
+  key: string,
+): { installed: boolean; value?: string | null; isSet?: boolean } | undefined {
+  for (const c of body.categories) {
+    const s = c.settings.find((x) => x.key === key);
+    if (s) return s;
+  }
+  return undefined;
+}
+
+async function patch(
+  h: Harness,
+  changes: Array<{ key: string; value: string | null }>,
+): Promise<{ status: number; body: { updated?: unknown[]; errors?: Array<{ key: string; message: string }>; code?: string } }> {
+  const res = await fetch(`${h.baseUrl}/api/v1/admin/settings`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ changes }),
+  });
+  return { status: res.status, body: (await res.json()) as never };
+}
+
+describe('admin settings route — GET /', () => {
+  let h: Harness;
+  afterEach(async () => {
+    if (h) await h.close();
+  });
+
+  it('groups the catalog and resolves current config values', async () => {
+    h = await makeHarness([
+      { id: ORCH, config: { orchestrator_model: 'claude-opus-4-7' } },
+    ]);
+    const body = await getSettings(h);
+    assert.ok(body.vault_available);
+    const model = findSetting(body, 'ORCHESTRATOR_MODEL');
+    assert.equal(model?.installed, true);
+    assert.equal(model?.value, 'claude-opus-4-7');
+    // A setting whose plugin isn't installed is flagged not-installed.
+    const telegram = findSetting(body, 'TELEGRAM_BOT_TOKEN');
+    assert.equal(telegram?.installed, false);
+  });
+
+  it('reports secret set/unset without leaking the value', async () => {
+    h = await makeHarness([{ id: DIAGRAMS }]);
+    await h.vault.setMany(DIAGRAMS, { aws_access_key_id: 'AKIA-secret' });
+    const body = await getSettings(h);
+    const aws = findSetting(body, 'AWS_ACCESS_KEY_ID');
+    assert.equal(aws?.isSet, true);
+    assert.ok(!JSON.stringify(body).includes('AKIA-secret'));
+  });
+});
+
+describe('admin settings route — PATCH /', () => {
+  let h: Harness;
+  afterEach(async () => {
+    if (h) await h.close();
+  });
+
+  it('writes a config value and reactivates the target plugin', async () => {
+    h = await makeHarness([
+      { id: ORCH, config: { orchestrator_model: 'claude-opus-4-7' } },
+    ]);
+    const { status } = await patch(h, [
+      { key: 'ORCHESTRATOR_MODEL', value: 'claude-opus-4-8' },
+    ]);
+    assert.equal(status, 200);
+    assert.equal(
+      h.registry.get(ORCH)?.config['orchestrator_model'],
+      'claude-opus-4-8',
+    );
+    assert.deepEqual(h.reactivated, [ORCH]);
+  });
+
+  it('stores a boolean toggle as a string and reactivates once', async () => {
+    h = await makeHarness([{ id: ORCH }]);
+    const { status } = await patch(h, [
+      { key: 'ORCHESTRATOR_MODEL_ROUTING', value: 'true' },
+    ]);
+    assert.equal(status, 200);
+    assert.equal(
+      h.registry.get(ORCH)?.config['orchestrator_model_routing'],
+      'true',
+    );
+    assert.deepEqual(h.reactivated, [ORCH]);
+  });
+
+  it('clears a config key when value is empty/null', async () => {
+    h = await makeHarness([
+      { id: ORCH, config: { model_routing_simple_model: 'claude-sonnet-4-6' } },
+    ]);
+    const { status } = await patch(h, [
+      { key: 'MODEL_ROUTING_SIMPLE_MODEL', value: null },
+    ]);
+    assert.equal(status, 200);
+    assert.equal(
+      h.registry.get(ORCH)?.config['model_routing_simple_model'],
+      undefined,
+    );
+  });
+
+  it('rejects a non-numeric value for a number setting', async () => {
+    h = await makeHarness([{ id: ORCH }]);
+    const { status, body } = await patch(h, [
+      { key: 'ORCHESTRATOR_MAX_TOKENS', value: 'lots' },
+    ]);
+    // Only change is invalid → no valid changes.
+    assert.equal(status, 400);
+    assert.equal(body.code, 'settings.no_valid_changes');
+    assert.ok(body.errors?.some((e) => e.key === 'ORCHESTRATOR_MAX_TOKENS'));
+    assert.deepEqual(h.reactivated, []);
+  });
+
+  it('writes a secret to every configured vault scope', async () => {
+    h = await makeHarness([{ id: ORCH }, { id: VERIFIER }, { id: EXTRAS }]);
+    const { status } = await patch(h, [
+      { key: 'ANTHROPIC_API_KEY', value: 'sk-ant-test123' },
+    ]);
+    assert.equal(status, 200);
+    for (const scope of [ORCH, VERIFIER, EXTRAS]) {
+      const keys = await h.vault.listKeys(scope);
+      assert.ok(keys.includes('anthropic_api_key'), `missing in ${scope}`);
+    }
+    assert.deepEqual(h.reactivated.sort(), [ORCH, EXTRAS, VERIFIER].sort());
+  });
+
+  it('rejects an Anthropic key without the sk-ant- prefix', async () => {
+    h = await makeHarness([{ id: ORCH }, { id: VERIFIER }, { id: EXTRAS }]);
+    const { status, body } = await patch(h, [
+      { key: 'ANTHROPIC_API_KEY', value: 'nope' },
+    ]);
+    assert.equal(status, 400);
+    assert.ok(body.errors?.some((e) => e.key === 'ANTHROPIC_API_KEY'));
+  });
+
+  it('errors a change whose target plugin is not installed', async () => {
+    h = await makeHarness([{ id: ORCH }]);
+    const { status, body } = await patch(h, [
+      { key: 'TELEGRAM_PUBLIC_BASE_URL', value: 'https://x.example' },
+    ]);
+    assert.equal(status, 400);
+    assert.equal(body.code, 'settings.no_valid_changes');
+    assert.ok(
+      body.errors?.some(
+        (e) =>
+          e.key === 'TELEGRAM_PUBLIC_BASE_URL' &&
+          e.message.includes('not installed'),
+      ),
+    );
+  });
+
+  it('applies the valid changes in a mixed batch and skips the invalid one', async () => {
+    h = await makeHarness([{ id: ORCH }]);
+    const { status, body } = await patch(h, [
+      { key: 'ORCHESTRATOR_MODEL', value: 'claude-opus-4-8' },
+      { key: 'ORCHESTRATOR_MODEL_ROUTING', value: 'maybe' },
+    ]);
+    assert.equal(status, 200);
+    assert.equal(
+      h.registry.get(ORCH)?.config['orchestrator_model'],
+      'claude-opus-4-8',
+    );
+    assert.ok(body.errors?.some((e) => e.key === 'ORCHESTRATOR_MODEL_ROUTING'));
+  });
+});

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -178,6 +178,82 @@ export class ApiError extends Error {
 }
 
 // -----------------------------------------------------------------------------
+// Admin settings — the .env-based config/vault overview (/api/v1/admin/settings)
+// -----------------------------------------------------------------------------
+
+export type SettingValueType =
+  | 'string'
+  | 'url'
+  | 'number'
+  | 'boolean'
+  | 'enum'
+  | 'secret';
+
+export interface ResolvedSetting {
+  key: string;
+  label: string;
+  help?: string;
+  category: string;
+  type: SettingValueType;
+  options?: Array<{ value: string; label: string }>;
+  placeholder?: string;
+  /** All target plugins installed? Drives whether the field is editable. */
+  installed: boolean;
+  /** Current non-secret value (stringified), or null when unset. */
+  value?: string | null;
+  /** Secret only: whether a value is stored (never the value itself). */
+  isSet?: boolean;
+}
+
+export interface SettingsCategory {
+  category: string;
+  settings: ResolvedSetting[];
+}
+
+export interface SettingsResponse {
+  categories: SettingsCategory[];
+  vault_available: boolean;
+}
+
+export interface SettingChange {
+  key: string;
+  /** New value, or null to clear/delete. */
+  value: string | null;
+}
+
+export interface SettingsPatchResponse {
+  updated: ResolvedSetting[];
+  errors: Array<{ key: string; message: string }>;
+}
+
+export async function getSettings(): Promise<SettingsResponse> {
+  return getJson<SettingsResponse>('/v1/admin/settings');
+}
+
+export async function patchSettings(
+  changes: SettingChange[],
+): Promise<SettingsPatchResponse> {
+  const forwarded = await forwardCookieHeader();
+  const res = await fetch(botApi('/v1/admin/settings'), {
+    method: 'PATCH',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      ...forwarded,
+    },
+    body: JSON.stringify({ changes }),
+    cache: 'no-store',
+    credentials: 'include',
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    maybeNavigateToLogin(res.status);
+    throw new ApiError(res.status, `PATCH settings failed: ${res.status}`, text);
+  }
+  return JSON.parse(text) as SettingsPatchResponse;
+}
+
+// -----------------------------------------------------------------------------
 // NDJSON helper — yields parsed JSON objects from a `application/x-ndjson`
 // stream. Tolerates LF and CRLF line endings, ignores blank lines, and
 // surfaces JSON parse errors with line context so the caller can decide to

--- a/web-ui/app/admin/page.tsx
+++ b/web-ui/app/admin/page.tsx
@@ -20,6 +20,11 @@ export default function AdminIndexPage(): React.ReactElement {
 
       <ul className="grid gap-4 lg:grid-cols-2">
         <AdminCard
+          href="/admin/settings"
+          title="Konfiguration"
+          description="Alle .env-basierten Werte (Modelle & Routing, Verifier, Embeddings, Integrationen), die in Config-Store/Vault landen — direkt editierbar. Auto-Save, wirkt sofort ohne Neustart."
+        />
+        <AdminCard
           href="/admin/auth"
           title="Authentifizierungs-Provider"
           description="Lokale Anmeldung und Entra-ID aktivieren oder deaktivieren. Änderungen wirken ohne Neustart."

--- a/web-ui/app/admin/settings/page.tsx
+++ b/web-ui/app/admin/settings/page.tsx
@@ -1,0 +1,324 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  getSettings,
+  patchSettings,
+  type ResolvedSetting,
+  type SettingsCategory,
+} from '../../_lib/api';
+
+/**
+ * Operator settings overview — every .env-based value that bootstrap writes
+ * into the runtime config-store / secret vault, grouped and editable. Backend:
+ * GET/PATCH /api/v1/admin/settings (via the /bot-api proxy). Changes auto-save
+ * after a short debounce and the affected plugin is re-activated server-side,
+ * so they take effect live — no restart. Secrets show set/unset only; their
+ * stored value is never returned. Hardcoded-German labels follow the sibling
+ * admin pages (this section does not use the i18n message catalog).
+ */
+
+type FieldStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ready'; categories: SettingsCategory[]; vaultAvailable: boolean }
+  | { kind: 'error'; message: string };
+
+export default function AdminSettingsPage(): React.ReactElement {
+  const [state, setState] = useState<State>({ kind: 'loading' });
+  // Local draft values for non-secret + secret inputs, keyed by setting key.
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [status, setStatus] = useState<Record<string, FieldStatus>>({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+
+  const load = useCallback(async (): Promise<void> => {
+    try {
+      const res = await getSettings();
+      const seed: Record<string, string> = {};
+      for (const c of res.categories) {
+        for (const s of c.settings) {
+          if (s.type !== 'secret') seed[s.key] = s.value ?? '';
+        }
+      }
+      setValues(seed);
+      setState({
+        kind: 'ready',
+        categories: res.categories,
+        vaultAvailable: res.vault_available,
+      });
+    } catch (err) {
+      setState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const applyUpdated = useCallback((updated: ResolvedSetting): void => {
+    setState((prev) =>
+      prev.kind === 'ready'
+        ? {
+            ...prev,
+            categories: prev.categories.map((c) => ({
+              ...c,
+              settings: c.settings.map((s) =>
+                s.key === updated.key ? updated : s,
+              ),
+            })),
+          }
+        : prev,
+    );
+  }, []);
+
+  const save = useCallback(
+    async (key: string, value: string | null): Promise<void> => {
+      setStatus((s) => ({ ...s, [key]: 'saving' }));
+      setErrors((e) => {
+        const n = { ...e };
+        delete n[key];
+        return n;
+      });
+      try {
+        const res = await patchSettings([{ key, value }]);
+        const fieldErr = res.errors.find((er) => er.key === key);
+        if (fieldErr) {
+          setStatus((s) => ({ ...s, [key]: 'error' }));
+          setErrors((e) => ({ ...e, [key]: fieldErr.message }));
+          return;
+        }
+        const upd = res.updated.find((u) => u.key === key);
+        if (upd) applyUpdated(upd);
+        // Secret drafts are one-shot — clear the input after a successful save.
+        if (upd?.type === 'secret') {
+          setValues((v) => ({ ...v, [key]: '' }));
+        }
+        setStatus((s) => ({ ...s, [key]: 'saved' }));
+      } catch (err) {
+        setStatus((s) => ({ ...s, [key]: 'error' }));
+        setErrors((e) => ({
+          ...e,
+          [key]: err instanceof Error ? err.message : String(err),
+        }));
+      }
+    },
+    [applyUpdated],
+  );
+
+  const debouncedSave = useCallback(
+    (key: string, value: string | null): void => {
+      const existing = timers.current[key];
+      if (existing) clearTimeout(existing);
+      timers.current[key] = setTimeout(() => {
+        void save(key, value);
+      }, 700);
+    },
+    [save],
+  );
+
+  const onText = useCallback(
+    (s: ResolvedSetting, raw: string): void => {
+      setValues((v) => ({ ...v, [s.key]: raw }));
+      setStatus((st) => ({ ...st, [s.key]: 'idle' }));
+      if (s.type === 'secret') {
+        // Only auto-save a non-empty secret draft; empty means "leave as is".
+        if (raw.trim().length > 0) debouncedSave(s.key, raw);
+        return;
+      }
+      debouncedSave(s.key, raw.length === 0 ? null : raw);
+    },
+    [debouncedSave],
+  );
+
+  const onImmediate = useCallback(
+    (key: string, value: string | null): void => {
+      setValues((v) => ({ ...v, [key]: value ?? '' }));
+      void save(key, value);
+    },
+    [save],
+  );
+
+  return (
+    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-10 lg:py-16">
+      <header className="mb-8">
+        <h1 className="font-display text-[clamp(1.75rem,3.5vw,2.5rem)] leading-[1.1] text-[color:var(--fg-strong)]">
+          Konfiguration
+        </h1>
+        <p className="mt-3 max-w-2xl text-[15px] leading-[1.55] text-[color:var(--fg-muted)]">
+          Alle <code className="rounded bg-[color:var(--card)] px-1 py-0.5 text-[12px]">.env</code>-Werte,
+          die beim Start in den Config-Store bzw. den Secret-Vault geschrieben
+          werden. Änderungen werden automatisch gespeichert und das betroffene
+          Plugin neu aktiviert — sie wirken sofort, ohne Neustart. Secrets zeigen
+          nur, ob ein Wert hinterlegt ist; der Wert selbst wird nie angezeigt.
+        </p>
+      </header>
+
+      {state.kind === 'loading' ? (
+        <p className="text-sm opacity-70">Lädt …</p>
+      ) : state.kind === 'error' ? (
+        <p className="text-sm text-red-500">Fehler beim Laden: {state.message}</p>
+      ) : (
+        <div className="flex flex-col gap-8">
+          {!state.vaultAvailable && (
+            <p className="rounded-[12px] border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-600 dark:text-amber-300">
+              Vault nicht verfügbar — Secrets können nicht bearbeitet werden.
+            </p>
+          )}
+          {state.categories.map((cat) => (
+            <section key={cat.category}>
+              <h2 className="mb-3 text-[13px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
+                {cat.category}
+              </h2>
+              <ul className="flex flex-col gap-3">
+                {cat.settings.map((s) => (
+                  <li
+                    key={s.key}
+                    className="rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5"
+                  >
+                    <SettingRow
+                      setting={s}
+                      value={values[s.key] ?? ''}
+                      status={status[s.key] ?? 'idle'}
+                      error={errors[s.key]}
+                      onText={onText}
+                      onImmediate={onImmediate}
+                    />
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}
+
+const inputCls =
+  'w-full rounded-md border border-[color:var(--border)] bg-transparent px-3 py-2 text-sm outline-none focus:border-[color:var(--accent)] disabled:opacity-50';
+
+function SettingRow({
+  setting: s,
+  value,
+  status,
+  error,
+  onText,
+  onImmediate,
+}: {
+  setting: ResolvedSetting;
+  value: string;
+  status: FieldStatus;
+  error?: string;
+  onText: (s: ResolvedSetting, raw: string) => void;
+  onImmediate: (key: string, value: string | null) => void;
+}): React.ReactElement {
+  const disabled = !s.installed;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className="text-[14px] font-semibold text-[color:var(--fg-strong)]">
+            {s.label}
+          </span>
+          <code className="text-[11px] text-[color:var(--fg-muted)]">{s.key}</code>
+          {!s.installed && (
+            <span className="rounded-full bg-[color:var(--border)]/40 px-2 py-0.5 text-[10px] uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
+              nicht installiert
+            </span>
+          )}
+        </div>
+        <StatusChip status={status} />
+      </div>
+
+      {s.type === 'boolean' ? (
+        <select
+          value={value || 'false'}
+          disabled={disabled}
+          onChange={(e) => onImmediate(s.key, e.target.value)}
+          className={`${inputCls} sm:max-w-[200px]`}
+        >
+          <option value="true">an</option>
+          <option value="false">aus</option>
+        </select>
+      ) : s.type === 'enum' ? (
+        <select
+          value={value}
+          disabled={disabled}
+          onChange={(e) => onImmediate(s.key, e.target.value)}
+          className={`${inputCls} sm:max-w-[320px]`}
+        >
+          {(s.options ?? []).map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      ) : s.type === 'secret' ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className={[
+              'inline-flex items-center rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em]',
+              s.isSet
+                ? 'bg-emerald-500/10 text-emerald-500'
+                : 'bg-[color:var(--border)]/40 text-[color:var(--fg-muted)]',
+            ].join(' ')}
+          >
+            {s.isSet ? 'gesetzt' : 'nicht gesetzt'}
+          </span>
+          <input
+            type="password"
+            value={value}
+            disabled={disabled}
+            placeholder={s.isSet ? '•••••• (ersetzen)' : (s.placeholder ?? 'Wert eingeben')}
+            onChange={(e) => onText(s, e.target.value)}
+            className={`${inputCls} flex-1 sm:min-w-[260px]`}
+          />
+          {s.isSet && (
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => onImmediate(s.key, null)}
+              className="rounded-md border border-[color:var(--border)] px-3 py-2 text-sm font-medium text-[color:var(--fg-muted)] hover:bg-[color:var(--card)] disabled:opacity-50"
+            >
+              Entfernen
+            </button>
+          )}
+        </div>
+      ) : (
+        <input
+          type={s.type === 'number' ? 'number' : 'text'}
+          value={value}
+          disabled={disabled}
+          placeholder={s.placeholder ?? ''}
+          onChange={(e) => onText(s, e.target.value)}
+          className={`${inputCls} sm:max-w-[420px]`}
+        />
+      )}
+
+      {s.help && (
+        <p className="text-[12px] leading-[1.5] text-[color:var(--fg-muted)]">
+          {s.help}
+        </p>
+      )}
+      {error && <p className="text-[12px] text-red-500">{error}</p>}
+    </div>
+  );
+}
+
+function StatusChip({ status }: { status: FieldStatus }): React.ReactElement | null {
+  if (status === 'idle') return null;
+  const map: Record<Exclude<FieldStatus, 'idle'>, { label: string; cls: string }> = {
+    saving: { label: 'speichert …', cls: 'text-[color:var(--fg-muted)]' },
+    saved: { label: '✓ gespeichert', cls: 'text-emerald-500' },
+    error: { label: '✗ Fehler', cls: 'text-red-500' },
+  };
+  const { label, cls } = map[status];
+  return <span className={`text-[11px] ${cls}`}>{label}</span>;
+}


### PR DESCRIPTION
## What

Adds an **Admin → Konfiguration** page that surfaces every `.env`-based value bootstrap writes into the runtime **config-store / secret vault** — grouped, typed, and editable, analogous to the existing Plugins/Registries admin views. Changes **auto-save** (debounced) and the affected plugin is **re-activated server-side**, so they take effect live without a restart.

Also closes a gap: the per-turn **Haiku-triage model routing** (added with the cost-telemetry work) was implemented but only toggleable by hand-editing the config-store. It's now env-driven and exposed in the settings page.

## Why
Operators needed a single screen to manage model selection, toggle model-routing, rotate API keys, and tune integrations without redeploying or hand-editing the config-store / vault.

## Changes

**Backend**
- `platform/settingsCatalog.ts` — curated, typed catalog mapping each `.env` key → its target plugin **config-key** or **vault key(s)**, with label/category/value-type. Single source of truth for the overview.
- `routes/adminSettings.ts` — `GET /api/v1/admin/settings` (grouped catalog + current values; secrets shown **set/unset only**, never the value) and `PATCH` (typed validation, batched writes to config-store + vault, then `reactivate` of each touched plugin). Reuses the exact `installedRegistry.updateConfig` + `vault` + `reactivate` plumbing the post-install editor already uses.
- `index.ts` — mount behind `requireAuth`.
- `config.ts` + `bootstrap.ts` — add `ORCHESTRATOR_MODEL_ROUTING` (+ optional `MODEL_ROUTING_{CLASSIFIER,SIMPLE,COMPLEX}_MODEL`) and seed them into the orchestrator plugin config on first boot.
- `.env.example` — model-routing ON by default; orchestrator stays on `claude-opus-4-8` (the code default).

**Frontend**
- `app/admin/settings/page.tsx` — grouped panels, typed inputs (text/number/enum/boolean/secret), **debounced auto-save** (booleans/enums save immediately). Not-installed targets are flagged and disabled; secrets show set/unset with a "Entfernen".
- AdminCard added to the admin index; `getSettings`/`patchSettings` helpers in `_lib/api.ts`.

> Admin pages here are hardcoded-German by precedent (`usage`, `registries`, `domains` do the same and don't use the i18n catalog).

**Test**
- `test/adminSettingsRoute.test.ts` — 10 cases: value resolution, typed validation, config-vs-vault routing, multi-scope secrets, Anthropic-prefix check, not-installed handling, per-plugin reactivation.

## Verification
- middleware: `typecheck` + `lint` clean (exit 0); full test suite green; **10/10** new tests pass.
- web-ui: `typecheck` + `lint` clean (0 errors); `i18n:check` OK.

> Note: bootstrap only seeds config on first boot — existing deployments pick up new env values via this settings page (or a fresh data volume). The page is the intended way to change these at runtime.