### PR TITLE
fix(web-ui): dismiss stream toasts visually + explicit abort with confirm

### DIFF
--- a/web-ui/app/_components/StreamToasts.tsx
+++ b/web-ui/app/_components/StreamToasts.tsx
@@ -2,9 +2,10 @@
 
 import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslations } from 'next-intl';
 import { AnimatePresence, motion } from 'framer-motion';
-import { Loader2, X } from 'lucide-react';
+import { Ban, Loader2, X } from 'lucide-react';
 
 import { useChatSessionsCtx } from '../_lib/chatSessionsContext';
 import {
@@ -76,6 +77,13 @@ export function StreamToasts(): React.ReactElement {
                 openChat(rec.sessionId);
               }}
               onDismiss={() => {
+                // Visual-only: hide the toast but let the stream finish in
+                // the background. The message still lands in ChatSessions.
+                store.dismiss(rec.sessionId);
+              }}
+              onAbort={() => {
+                // Real stop: aborts the underlying fetch via the store's
+                // AbortController. Gated behind the confirm modal.
                 store.abort(rec.sessionId);
               }}
             />
@@ -91,6 +99,7 @@ interface StreamToastProps {
   t: ReturnType<typeof useTranslations>;
   onOpen: () => void;
   onDismiss: () => void;
+  onAbort: () => void;
 }
 
 function StreamToast({
@@ -98,11 +107,14 @@ function StreamToast({
   t,
   onOpen,
   onDismiss,
+  onAbort,
 }: StreamToastProps): React.ReactElement {
   const isTerminal =
     record.phase === 'done' ||
     record.phase === 'error' ||
     record.phase === 'aborted';
+  // Whether the abort-confirmation modal is currently open for this toast.
+  const [confirming, setConfirming] = useState(false);
   const phaseLabel = phaseLabelFor(record.phase, t);
   // Tick once a second while active so the elapsed-seconds line stays
   // honest. Terminal toasts freeze at their last event time — no point
@@ -198,7 +210,135 @@ function StreamToast({
           </div>
         </div>
       </div>
+      {/* Real-stop affordance — only while the stream is still running.
+          Clicking opens a confirm modal; confirming calls onAbort(), which
+          aborts the underlying fetch. Separate from the top-right X, which
+          only hides the toast. */}
+      {!isTerminal ? (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            setConfirming(true);
+          }}
+          className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-md border border-red-200 bg-red-50/60 px-2 py-1 text-[11px] font-medium text-red-700 transition hover:bg-red-100 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300 dark:hover:bg-red-950/70"
+        >
+          <Ban size={12} aria-hidden />
+          {t('abortButton')}
+        </button>
+      ) : null}
+      <AnimatePresence>
+        {confirming ? (
+          <AbortConfirmModal
+            t={t}
+            onConfirm={() => {
+              setConfirming(false);
+              onAbort();
+            }}
+            onCancel={() => {
+              setConfirming(false);
+            }}
+          />
+        ) : null}
+      </AnimatePresence>
     </div>
+  );
+}
+
+interface AbortConfirmModalProps {
+  t: ReturnType<typeof useTranslations>;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Lightweight custom confirmation dialog (no native window.confirm). Rendered
+ * through a portal to <body> so its fixed positioning is immune to the
+ * transformed motion ancestors of the toast stack. Closes on Escape or
+ * backdrop click; the safe "keep running" action is auto-focused.
+ */
+function AbortConfirmModal({
+  t,
+  onConfirm,
+  onCancel,
+}: AbortConfirmModalProps): React.ReactPortal | null {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [onCancel]);
+
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
+    <motion.div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.12 }}
+      onClick={(e) => {
+        e.stopPropagation();
+        onCancel();
+      }}
+      role="presentation"
+    >
+      <motion.div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="stream-abort-title"
+        aria-describedby="stream-abort-body"
+        className="w-full max-w-xs rounded-lg border border-neutral-200 bg-white p-4 shadow-xl dark:border-neutral-700 dark:bg-neutral-900"
+        initial={{ opacity: 0, scale: 0.95, y: 8 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 8 }}
+        transition={{ duration: 0.14 }}
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        <h2
+          id="stream-abort-title"
+          className="text-sm font-semibold text-neutral-900 dark:text-neutral-100"
+        >
+          {t('abortConfirmTitle')}
+        </h2>
+        <p
+          id="stream-abort-body"
+          className="mt-1 text-xs leading-snug text-neutral-600 dark:text-neutral-400"
+        >
+          {t('abortConfirmBody')}
+        </p>
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            type="button"
+            autoFocus
+            onClick={(e) => {
+              e.stopPropagation();
+              onCancel();
+            }}
+            className="rounded-md border border-neutral-200 px-3 py-1.5 text-xs font-medium text-neutral-700 transition hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
+          >
+            {t('abortConfirmKeep')}
+          </button>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onConfirm();
+            }}
+            className="rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-red-700"
+          >
+            {t('abortConfirmStop')}
+          </button>
+        </div>
+      </motion.div>
+    </motion.div>,
+    document.body,
   );
 }
 

--- a/web-ui/app/_lib/streamStore.tsx
+++ b/web-ui/app/_lib/streamStore.tsx
@@ -101,6 +101,11 @@ interface StreamStoreContextValue {
   ): void;
   /** User-initiated abort. Synchronous — flips phase immediately. */
   abort(sessionId: string): void;
+  /** Visual-only dismiss — drops the record from the store (hiding its
+   *  toast / tab badge) WITHOUT aborting the underlying stream. The runner
+   *  keeps writing tokens to ChatSessions; patch()/finish() simply no-op
+   *  once the record is gone. */
+  dismiss(sessionId: string): void;
   /** Inspect the record for a session. */
   get(sessionId: string): StreamRecord | undefined;
   /** True while the session has a non-terminal stream. */
@@ -262,6 +267,19 @@ export function StreamStoreProvider({
     [bumpQueue, publishSnapshot],
   );
 
+  const dismiss = useCallback(
+    (sessionId: string): void => {
+      // Visual-only: forget the record so its toast/badge disappears. We do
+      // NOT touch the AbortController — the runner owns its own signal
+      // reference, so the network stream keeps going and the assistant
+      // message still lands in ChatSessions. Any later patch()/finish()
+      // calls for this session early-return harmlessly.
+      if (!internalRef.current.delete(sessionId)) return;
+      publishSnapshot();
+    },
+    [publishSnapshot],
+  );
+
   const get = useCallback(
     (sessionId: string): StreamRecord | undefined => records.get(sessionId),
     [records],
@@ -302,6 +320,7 @@ export function StreamStoreProvider({
       patch,
       finish,
       abort,
+      dismiss,
       get,
       isActive,
     }),
@@ -313,6 +332,7 @@ export function StreamStoreProvider({
       patch,
       finish,
       abort,
+      dismiss,
       get,
       isActive,
     ],

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -481,8 +481,13 @@
     "tokensInTitle": "{n} Input-Tokens (kumuliert über Iterationen)",
     "tokensOutTitle": "{n} Output-Tokens (kumuliert über Iterationen)",
     "cacheHitTitle": "{n} Cache-Read-Tokens",
-    "dismissAriaLabel": "Stream abbrechen",
-    "dismissTitle": "Abbrechen"
+    "dismissAriaLabel": "Benachrichtigung schließen (Stream läuft weiter)",
+    "dismissTitle": "Schließen",
+    "abortButton": "Stream stoppen",
+    "abortConfirmTitle": "Stream wirklich stoppen?",
+    "abortConfirmBody": "Die laufende Antwort wird sofort abgebrochen und kann nicht fortgesetzt werden.",
+    "abortConfirmKeep": "Weiter laufen lassen",
+    "abortConfirmStop": "Ja, stoppen"
   },
   "builder": {
     "issueReport": {

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -481,8 +481,13 @@
     "tokensInTitle": "{n} input tokens (cumulative across iterations)",
     "tokensOutTitle": "{n} output tokens (cumulative across iterations)",
     "cacheHitTitle": "{n} cache-read tokens",
-    "dismissAriaLabel": "Cancel stream",
-    "dismissTitle": "Cancel"
+    "dismissAriaLabel": "Dismiss notification (stream keeps running)",
+    "dismissTitle": "Dismiss",
+    "abortButton": "Stop stream",
+    "abortConfirmTitle": "Stop this stream?",
+    "abortConfirmBody": "The running response will be aborted immediately and can't be resumed.",
+    "abortConfirmKeep": "Keep running",
+    "abortConfirmStop": "Yes, stop"
   },
   "builder": {
     "issueReport": {


### PR DESCRIPTION
## Problem

The stream-toast ✕ (top-right) went through `store.abort()`, which **early-returns on terminal records** (`done`/`error`/`aborted`) via `if (isTerminal(existing.phase)) return;`. The toasts that appear *after navigating away* from a chat are exactly the terminal ones — so they could not be closed at all and only disappeared via the 5-minute GC. For a still-running stream the same ✕ also **killed the underlying fetch**, which is not what a "dismiss" should do.

## Change

- **`streamStore.tsx`** — new `dismiss(sessionId)` that drops the record from the store **without** touching the `AbortController`. The `StreamRunner` owns its own signal reference and keeps writing tokens to `ChatSessions`, so the stream finishes in the background and the assistant message still lands. Later `patch()`/`finish()` calls early-return harmlessly.
- **`StreamToasts.tsx`** —
  - Top-right ✕ now calls `dismiss()` → **visual-only** close, stream keeps running.
  - New **"Stop stream"** button (running streams only) for a *real* abort, gated behind a **custom confirm modal** (no `window.confirm`). framer-motion dialog **portaled to `<body>`** so `fixed` positioning survives the transformed motion stack. Escape / backdrop cancel; safe "keep running" is `autoFocus`ed. Confirm calls `store.abort()`.
- **i18n** — relabel dismiss + add `abortButton` / `abortConfirm*` keys (en + de, parity-checked).

## Verification (node 22.22.3)

- `npm run i18n:check` → OK (1087 keys, en/de parity)
- `npx eslint` on changed files → 0 errors
- `npm run typecheck` → clean
- Re-verified after merging latest `origin/main`.