### PR TITLE
feat(chat): show the Haiku-triage decision inline in the turn card

### DIFF
--- a/middleware/packages/harness-channel-sdk/src/chatAgent.ts
+++ b/middleware/packages/harness-channel-sdk/src/chatAgent.ts
@@ -442,6 +442,19 @@ export interface AgentMeta {
  */
 export type ChatStreamEvent =
   | { type: 'iteration_start'; iteration: number }
+  /**
+   * Per-turn model-routing verdict. Emitted ONCE at turn start, right after the
+   * Haiku classifier resolves and before the first model call — only when
+   * routing is configured. Lets the UI show the triage decision inline at the
+   * top of the turn card. `bucket: 'fallback'` means the classifier call failed
+   * and the configured fallback model was used.
+   */
+  | {
+      type: 'turn_routing';
+      bucket: 'simple' | 'complex' | 'fallback';
+      classifierModel: string;
+      model: string;
+    }
   | { type: 'text_delta'; text: string }
   | {
       type: 'tool_use';

--- a/middleware/packages/harness-orchestrator/src/index.ts
+++ b/middleware/packages/harness-orchestrator/src/index.ts
@@ -25,7 +25,11 @@ export type {
 
 // Per-turn Sonnet/Opus routing config (attached to AgentRuntimeConfig).
 export { routeTurnModel } from './modelRouter.js';
-export type { ModelRoutingConfig } from './modelRouter.js';
+export type {
+  ModelRoutingConfig,
+  RouteResult,
+  RoutingBucket,
+} from './modelRouter.js';
 
 // Multi-orchestrator registry (US4) — read by US7 channel routing and US9 UI.
 export {

--- a/middleware/packages/harness-orchestrator/src/modelRouter.ts
+++ b/middleware/packages/harness-orchestrator/src/modelRouter.ts
@@ -47,18 +47,39 @@ function firstText(message: any): string {
   return '';
 }
 
+/** The bucket the classifier (or the fallback) landed on. `fallback` means the
+ *  classifier call failed and the caller's fallback model was used. */
+export type RoutingBucket = 'simple' | 'complex' | 'fallback';
+
+export interface RouteResult {
+  /** Model id the turn should run on. */
+  readonly model: string;
+  /** Which bucket the turn was routed into. */
+  readonly bucket: RoutingBucket;
+  /** The Haiku-tier model that made (or attempted) the classification. */
+  readonly classifierModel: string;
+}
+
 /**
- * Classifies `userMessage` and returns the model id the turn should run on.
- * Best-effort: returns `fallbackModel` on any failure.
+ * Classifies `userMessage` and returns the model id the turn should run on,
+ * together with the routing decision so callers can surface it in the UI.
+ * Best-effort: returns `fallbackModel` (bucket `fallback`) on any failure.
  */
 export async function routeTurnModel(
   client: Anthropic,
   cfg: ModelRoutingConfig,
   userMessage: string,
   fallbackModel: string,
-): Promise<string> {
+): Promise<RouteResult> {
   const text = userMessage.trim().slice(0, 4000);
-  if (!text) return cfg.complexModel;
+  // Empty message → nothing to classify; default to the stronger model.
+  if (!text) {
+    return {
+      model: cfg.complexModel,
+      bucket: 'complex',
+      classifierModel: cfg.classifierModel,
+    };
+  }
   try {
     const res = await client.messages.create({
       model: cfg.classifierModel,
@@ -76,14 +97,28 @@ export async function routeTurnModel(
       });
     }
     const verdict = firstText(res).toUpperCase();
-    if (verdict.includes('SIMPLE')) return cfg.simpleModel;
+    if (verdict.includes('SIMPLE')) {
+      return {
+        model: cfg.simpleModel,
+        bucket: 'simple',
+        classifierModel: cfg.classifierModel,
+      };
+    }
     // 'COMPLEX' or anything ambiguous → stronger model.
-    return cfg.complexModel;
+    return {
+      model: cfg.complexModel,
+      bucket: 'complex',
+      classifierModel: cfg.classifierModel,
+    };
   } catch (err) {
     console.warn(
       '[model-router] classification failed — using fallback model:',
       err instanceof Error ? err.message : err,
     );
-    return fallbackModel;
+    return {
+      model: fallbackModel,
+      bucket: 'fallback',
+      classifierModel: cfg.classifierModel,
+    };
   }
 }

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -93,7 +93,11 @@ import {
 import { RunTraceCollector, type InvocationHandle } from './runTraceCollector.js';
 import type { NativeToolRegistry } from './nativeToolRegistry.js';
 import { graphScopeFor, type SessionLogger } from './sessionLogger.js';
-import { type ModelRoutingConfig, routeTurnModel } from './modelRouter.js';
+import {
+  type ModelRoutingConfig,
+  type RoutingBucket,
+  routeTurnModel,
+} from './modelRouter.js';
 import { streamMessageEvents } from './streaming.js';
 import { steeringBus } from './steeringBus.js';
 import { buildDateHeader, today, turnContext } from './turnContext.js';
@@ -1680,16 +1684,29 @@ export class Orchestrator {
   /**
    * Resolves the model for a single turn. With routing configured, a Haiku
    * classifier picks Sonnet (simple) or Opus (complex); otherwise the static
-   * `this.model` is used. Never throws — falls back to `this.model`.
+   * `this.model` is used. Never throws — falls back to `this.model`. Returns
+   * the routing decision (when routing ran) so the streaming path can surface
+   * it inline in the UI as soon as the classifier resolves.
    */
-  private async resolveTurnModel(userMessage: string): Promise<string> {
-    if (!this.modelRouting) return this.model;
-    return routeTurnModel(
+  private async resolveTurnModel(userMessage: string): Promise<{
+    model: string;
+    routing?: { bucket: RoutingBucket; classifierModel: string; model: string };
+  }> {
+    if (!this.modelRouting) return { model: this.model };
+    const r = await routeTurnModel(
       this.client,
       this.modelRouting,
       userMessage,
       this.model,
     );
+    return {
+      model: r.model,
+      routing: {
+        bucket: r.bucket,
+        classifierModel: r.classifierModel,
+        model: r.model,
+      },
+    };
   }
 
   private async chatInContextInner(
@@ -1778,8 +1795,10 @@ export class Orchestrator {
     let forceFinalize = false;
 
     // Per-turn model routing (no-op unless configured). Resolved once so the
-    // whole turn — every tool-loop iteration — runs on one model.
-    const turnModel = await this.resolveTurnModel(input.userMessage);
+    // whole turn — every tool-loop iteration — runs on one model. The
+    // non-streaming path has no event channel, so the routing decision is
+    // simply applied (channels that want to surface it use chatStream).
+    const turnModel = (await this.resolveTurnModel(input.userMessage)).model;
 
     try {
       for (let iteration = 0; iteration < this.maxIterations; iteration++) {
@@ -2305,7 +2324,19 @@ export class Orchestrator {
     const steerKey = input.sessionScope ?? turnId;
     // Per-turn model routing (no-op unless configured). Resolved once so the
     // whole streamed turn runs on one model.
-    const turnModel = await this.resolveTurnModel(input.userMessage);
+    const resolved = await this.resolveTurnModel(input.userMessage);
+    const turnModel = resolved.model;
+    // Surface the Haiku-triage decision inline, before the first model call —
+    // the UI renders it at the top of the turn card so the operator sees the
+    // classifier's verdict (simple/complex → model) as soon as it lands.
+    if (resolved.routing) {
+      yield {
+        type: 'turn_routing',
+        bucket: resolved.routing.bucket,
+        classifierModel: resolved.routing.classifierModel,
+        model: resolved.routing.model,
+      };
+    }
     try {
       for (let iteration = 0; iteration < this.maxIterations; iteration++) {
         yield { type: 'iteration_start', iteration };

--- a/middleware/test/modelRouter.test.ts
+++ b/middleware/test/modelRouter.test.ts
@@ -1,0 +1,86 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { routeTurnModel } from '../packages/harness-orchestrator/src/modelRouter.js';
+
+/**
+ * Per-turn Haiku-triage router. Verifies the decision → model mapping and the
+ * routing metadata the streaming path surfaces inline in the UI.
+ */
+
+const cfg = {
+  classifierModel: 'claude-haiku-4-5',
+  simpleModel: 'claude-sonnet-4-6',
+  complexModel: 'claude-opus-4-8',
+};
+
+// Minimal structural stub for the Anthropic client — only `.messages.create`
+// is exercised. No `usage` field → the recorder is never touched.
+function clientReturning(text: string) {
+  return {
+    messages: {
+      create: () => Promise.resolve({ content: [{ type: 'text', text }] }),
+    },
+  };
+}
+function clientThrowing() {
+  return {
+    messages: {
+      create: () => Promise.reject(new Error('boom')),
+    },
+  };
+}
+
+describe('routeTurnModel', () => {
+  it('SIMPLE verdict → simple bucket + simpleModel', async () => {
+    const r = await routeTurnModel(clientReturning('SIMPLE') as never, cfg, 'hi', 'fb');
+    assert.equal(r.bucket, 'simple');
+    assert.equal(r.model, cfg.simpleModel);
+    assert.equal(r.classifierModel, cfg.classifierModel);
+  });
+
+  it('COMPLEX verdict → complex bucket + complexModel', async () => {
+    const r = await routeTurnModel(
+      clientReturning('COMPLEX') as never,
+      cfg,
+      'plan a migration',
+      'fb',
+    );
+    assert.equal(r.bucket, 'complex');
+    assert.equal(r.model, cfg.complexModel);
+  });
+
+  it('ambiguous verdict defaults to complex', async () => {
+    const r = await routeTurnModel(clientReturning('huh?') as never, cfg, 'x', 'fb');
+    assert.equal(r.bucket, 'complex');
+    assert.equal(r.model, cfg.complexModel);
+  });
+
+  it('empty message → complex without calling the classifier', async () => {
+    let called = false;
+    const client = {
+      messages: {
+        create: () => {
+          called = true;
+          return Promise.resolve({ content: [] });
+        },
+      },
+    };
+    const r = await routeTurnModel(client as never, cfg, '   ', 'fb');
+    assert.equal(r.bucket, 'complex');
+    assert.equal(r.model, cfg.complexModel);
+    assert.equal(called, false);
+  });
+
+  it('classifier error → fallback bucket + fallbackModel', async () => {
+    const r = await routeTurnModel(
+      clientThrowing() as never,
+      cfg,
+      'x',
+      'claude-fallback',
+    );
+    assert.equal(r.bucket, 'fallback');
+    assert.equal(r.model, 'claude-fallback');
+    assert.equal(r.classifierModel, cfg.classifierModel);
+  });
+});

--- a/web-ui/app/_lib/chatSessions.ts
+++ b/web-ui/app/_lib/chatSessions.ts
@@ -378,6 +378,16 @@ export interface Message {
    * routing is off. Rendered as a small badge next to the token counts.
    */
   model?: string;
+  /**
+   * Per-turn Haiku-triage verdict, from the `turn_routing` event emitted at
+   * turn start. Present only when model-routing is enabled. Rendered inline at
+   * the top of the assistant card as soon as the classifier resolves.
+   */
+  routing?: {
+    bucket: 'simple' | 'complex' | 'fallback';
+    classifierModel: string;
+    model: string;
+  };
 }
 
 /**

--- a/web-ui/app/_lib/chatStreamEvents.ts
+++ b/web-ui/app/_lib/chatStreamEvents.ts
@@ -25,6 +25,13 @@ import type {
  */
 export type ChatStreamEvent =
   | { type: 'iteration_start'; iteration: number }
+  /** Per-turn Haiku-triage verdict, emitted once at turn start. */
+  | {
+      type: 'turn_routing';
+      bucket: 'simple' | 'complex' | 'fallback';
+      classifierModel: string;
+      model: string;
+    }
   | { type: 'text_delta'; text: string }
   | {
       type: 'tool_use';
@@ -157,6 +164,15 @@ function foldIntoMessage(m: Message, event: ChatStreamEvent): Message {
   switch (event.type) {
     case 'text_delta':
       return { ...m, content: m.content + event.text };
+    case 'turn_routing':
+      return {
+        ...m,
+        routing: {
+          bucket: event.bucket,
+          classifierModel: event.classifierModel,
+          model: event.model,
+        },
+      };
     case 'turn_annotation':
       // #133 (E9) — the live plan snapshot. Re-emitted on every step change;
       // we just replace, so the card reflects the latest state.

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -560,6 +560,7 @@ function MessageRow({
           <div className="whitespace-pre-wrap text-sm">{message.content}</div>
         ) : (
           <>
+            {message.routing && <TriageBadge routing={message.routing} />}
             {message.recalledContext && (
               <RecalledContextCard recalled={message.recalledContext} />
             )}
@@ -805,6 +806,57 @@ function compactTokens(n: number): string {
     notation: 'compact',
     maximumFractionDigits: 1,
   }).format(n);
+}
+
+/**
+ * Inline triage chip — rendered at the top of an assistant turn as soon as the
+ * Haiku classifier resolves (the `turn_routing` event). Shows the verdict
+ * (einfach/komplex/Fallback) and which model the turn was routed to.
+ */
+function TriageBadge({
+  routing,
+}: {
+  routing: {
+    bucket: 'simple' | 'complex' | 'fallback';
+    classifierModel: string;
+    model: string;
+  };
+}): React.ReactElement {
+  const verdict: Record<typeof routing.bucket, { label: string; cls: string }> = {
+    simple: {
+      label: 'einfach',
+      cls: 'bg-emerald-500/10 text-emerald-600 ring-emerald-500/30 dark:text-emerald-400',
+    },
+    complex: {
+      label: 'komplex',
+      cls: 'bg-violet-500/10 text-violet-600 ring-violet-500/30 dark:text-violet-400',
+    },
+    fallback: {
+      label: 'Fallback',
+      cls: 'bg-amber-500/10 text-amber-600 ring-amber-500/30 dark:text-amber-400',
+    },
+  };
+  const v = verdict[routing.bucket];
+  return (
+    <div
+      className="mb-2 inline-flex flex-wrap items-center gap-1.5 text-[11px] text-neutral-500 dark:text-neutral-400"
+      title={`Triage-Klassifizierer: ${routing.classifierModel} → ${routing.bucket} → ${routing.model}`}
+    >
+      <span className="font-medium uppercase tracking-[0.12em]">Triage</span>
+      <span className="text-neutral-400 dark:text-neutral-500">
+        {shortModelName(routing.classifierModel)} →
+      </span>
+      <span
+        className={`inline-flex items-center rounded-full px-1.5 py-0.5 font-medium uppercase tracking-[0.08em] ring-1 ${v.cls}`}
+      >
+        {v.label}
+      </span>
+      <span className="text-neutral-400 dark:text-neutral-500">→</span>
+      <span className="rounded bg-current/10 px-1.5 py-0.5 font-medium">
+        {shortModelName(routing.model)}
+      </span>
+    </div>
+  );
 }
 
 function ToolOutputWithNudge({ output }: { output: string }): React.ReactElement {


### PR DESCRIPTION
## What
Shows the **Haiku-triage decision inline** at the top of each assistant turn card — the moment the classifier resolves, before the answer streams — so you see *einfach/komplex → which model* live, not just the final model badge in the footer.

## Why
Per-turn model routing was added recently, but the UI only revealed the chosen model at the end (the `done`-event footer badge). This surfaces the router's verdict the instant it lands.

## How
- **`modelRouter.ts`** — `routeTurnModel` now returns `{ model, bucket, classifierModel }` (`bucket: simple | complex | fallback`) instead of a bare model id.
- **`orchestrator.ts`** — `resolveTurnModel` returns the decision; the **streaming** path yields a new `turn_routing` event right after the classifier resolves and before the first model call. The non-streaming path just applies the model (no event channel).
- **`channel-sdk`** — adds `turn_routing` to `ChatStreamEvent`; the chat route forwards it verbatim.
- **web-ui** — folds `turn_routing` into `message.routing` (persisted, not stripped) and renders a `TriageBadge` at the top of the assistant card: `Triage · haiku-4-5 → komplex → opus-4-8` with a colour-coded verdict chip (emerald/violet/amber).

No behaviour change when routing is off — no event, no badge.

## Verification
- middleware: `typecheck` + `lint` clean; full suite **3050 pass / 0 fail**, incl. 5 new `modelRouter` tests (simple/complex/ambiguous/empty/error → bucket+model).
- web-ui: `typecheck` + `lint` clean (0 errors); `i18n:check` OK.