### PR TITLE
chore(compose): drop dead llama3.2:3b NER pull from ollama-init

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@
 #   - postgres         (Postgres + pgvector — KG / routines / verifier store)
 #   - kroki + companion (Mermaid/PlantUML/Graphviz/Vega/Excalidraw rendering)
 #   - minio + init     (S3-compatible storage for diagram + attachment payloads)
-#   - ollama + init    (in-tenant embeddings + small NER model)
+#   - ollama + init    (in-tenant embeddings)
 #
 # Usage:
 #   cp middleware/.env.example middleware/.env   # set ANTHROPIC_API_KEY
@@ -284,10 +284,7 @@ services:
           sleep 3
         done
         OLLAMA_HOST=http://ollama:11434 ollama pull nomic-embed-text
-        # Pull the NER model used by @omadia/plugin-privacy-detector-ollama
-        # so the Privacy-Proxy can run without an external API key.
-        OLLAMA_HOST=http://ollama:11434 ollama pull llama3.2:3b
-        echo "[ollama-init] nomic-embed-text + llama3.2:3b ready."
+        echo "[ollama-init] nomic-embed-text ready."
     restart: 'no'
 
 volumes:


### PR DESCRIPTION
## What

`ollama-init` no longer pulls `llama3.2:3b`. That model fed the `@omadia/plugin-privacy-detector-ollama` NER detector, whose source was removed in the Privacy Shield v4 migration (#119) — only a gitignored `dist/` leftover remains on disk (zero git-tracked files).

## Why

Every fresh `docker compose up` was downloading ~2 GB for a plugin that no longer exists in the repo. Privacy Shield v4 (`harness-plugin-privacy-guard`) is shape-based; a PII detector is an optional one-way booster that isn't wired in the OSS tree.

## Changes

- Remove the `llama3.2:3b` pull + its comment from `ollama-init`.
- `ollama-init` now pulls only the live `nomic-embed-text` (consumed by `@omadia/embeddings` → TopicDetector + Neon knowledge-graph).
- Trim the stale "small NER model" note from the compose header service list.

`docker compose config -q` validates clean.