### PR TITLE
fix(orchestrator): forward modelRouting to per-Agent orchestrators

### DIFF
--- a/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
@@ -153,6 +153,12 @@ export function buildForAgent(
       model: runtime.model,
       maxTokens: runtime.maxTokens,
       maxToolIterations: runtime.maxToolIterations,
+      // Per-turn model routing is a runtime knob like the others — forward it
+      // so registry-managed per-Agent orchestrators emit `turn_routing` (and
+      // the UI renders the Haiku-triage badge), not just the default boot-path
+      // orchestrator. Without this the badge only ever shows for the default
+      // agent. See harness-orchestrator/plugin.ts (defaultRuntimeConfig).
+      ...(runtime.modelRouting ? { modelRouting: runtime.modelRouting } : {}),
       ...(runtime.loopRepeatSoft !== undefined
         ? { loopRepeatSoft: runtime.loopRepeatSoft }
         : {}),

--- a/middleware/test/buildForAgentRouting.test.ts
+++ b/middleware/test/buildForAgentRouting.test.ts
@@ -1,0 +1,100 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import Anthropic from '@anthropic-ai/sdk';
+import { InMemoryNudgeRegistry } from '@omadia/plugin-api';
+import type { EntityRefBus, KnowledgeGraph, MemoryStore } from '@omadia/plugin-api';
+
+import type { OrchestratorDeps } from '../packages/harness-orchestrator/src/buildOrchestrator.js';
+import type { NativeToolRegistry } from '../packages/harness-orchestrator/src/nativeToolRegistry.js';
+import type { ModelRoutingConfig } from '../packages/harness-orchestrator/src/modelRouter.js';
+import type { AgentRow } from '../packages/harness-orchestrator/src/registry/configStore.js';
+import { buildForAgent } from '../packages/harness-orchestrator/src/registry/applyDiff.js';
+
+/**
+ * Regression guard: `buildForAgent` must forward `modelRouting` from the
+ * registry's `defaultRuntimeConfig` into each per-Agent orchestrator. It was
+ * dropped once — the factory hand-lists runtime knobs and the field was
+ * forgotten — so per-Agent chats never emitted `turn_routing` and the UI's
+ * Haiku-triage badge only ever showed for the default boot-path orchestrator.
+ *
+ * The decision wiring is verified directly off the built orchestrator (the
+ * field is private; read via a structural cast, matching the convention in
+ * uiOrchestratorSurface.test.ts).
+ */
+
+function fakeNativeToolRegistry(): NativeToolRegistry {
+  const names = new Set<string>();
+  return {
+    has: (name: string) => names.has(name),
+    register: (name: string) => {
+      names.add(name);
+      return () => names.delete(name);
+    },
+  } as unknown as NativeToolRegistry;
+}
+
+function deps(): OrchestratorDeps {
+  return {
+    client: new Anthropic({ apiKey: 'test-key' }),
+    knowledgeGraph: {} as KnowledgeGraph,
+    memoryStore: {} as MemoryStore,
+    entityRefBus: {} as EntityRefBus,
+    nativeToolRegistry: fakeNativeToolRegistry(),
+    nudgeRegistry: new InMemoryNudgeRegistry(),
+    responseGuard: () => undefined,
+    privacyGuard: () => undefined,
+  };
+}
+
+function agentRow(slug: string): AgentRow {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    slug,
+    name: slug,
+    description: null,
+    privacyProfile: 'default',
+    status: 'enabled',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  };
+}
+
+const modelRouting: ModelRoutingConfig = {
+  classifierModel: 'claude-haiku-4-5',
+  simpleModel: 'claude-sonnet-4-6',
+  complexModel: 'claude-opus-4-8',
+};
+
+function routingOf(built: ReturnType<typeof buildForAgent>): unknown {
+  return (built.orchestrator as unknown as { modelRouting?: unknown }).modelRouting;
+}
+
+test('buildForAgent forwards modelRouting into the per-Agent orchestrator', () => {
+  const built = buildForAgent(agentRow('accounting'), deps(), {
+    model: 'm',
+    maxTokens: 100,
+    maxToolIterations: 4,
+    modelRouting,
+  });
+
+  assert.deepEqual(
+    routingOf(built),
+    modelRouting,
+    'per-Agent orchestrator must carry the routing config so it emits turn_routing',
+  );
+});
+
+test('buildForAgent leaves routing unset when the runtime config has none', () => {
+  const built = buildForAgent(agentRow('plain'), deps(), {
+    model: 'm',
+    maxTokens: 100,
+    maxToolIterations: 4,
+  });
+
+  assert.equal(
+    routingOf(built),
+    undefined,
+    'no routing config in → no routing on the orchestrator (no event, no badge)',
+  );
+});


### PR DESCRIPTION
## Problem

The inline Haiku-triage badge (#261) and per-turn model routing (#253/#259) only ever showed up for the **default** orchestrator. In the multi-agent UI, chatting with a specialized Agent (e.g. the accounting agent) never rendered the `TriageBadge` — even with `ORCHESTRATOR_MODEL_ROUTING=true` and the boot log reporting `per-turn model routing ON`.

## Root cause

`registry/applyDiff.ts → buildForAgent()` builds each registry-managed per-Agent orchestrator by hand-listing runtime knobs from the runtime config:

```ts
buildOrchestratorForAgent({
  agentId, model, maxTokens, maxToolIterations,
  ...loopRepeatSoft / loopRepeatHard / maxTurnSeconds
}, deps)
```

It **never forwarded `modelRouting`**, even though `OrchestratorRegistry.defaultRuntimeConfig` carries it and `buildOrchestratorForAgent` already accepts + applies it. Result: every per-Agent orchestrator was constructed with `this.modelRouting === undefined` → `resolveTurnModel` returns a bare model → no `turn_routing` event → no badge. The default `chatAgent@1` boot path *does* set it, which masked the gap.

This is purely the config-plumbing layer — the backend emit, channel-sdk event, and web-ui `foldIntoMessage`/`TriageBadge` are all correct.

## Fix

Forward `runtime.modelRouting` through `buildForAgent`, mirroring the existing conditional-spread knobs.

## Test

`middleware/test/buildForAgentRouting.test.ts` — asserts a per-Agent orchestrator carries the routing config when configured, and leaves it unset otherwise. Verified the "forwards" assertion fails on the pre-fix code and passes after.

## Verification

- `node --test test/buildForAgentRouting.test.ts` → 2/2 pass
- `test/modelRouter.test.ts` + `test/orchestratorRegistry.test.ts` → 14/14 pass (no regressions)
- `tsc --noEmit` (orchestrator) clean · eslint clean

After deploy, agent chats emit `turn_routing` and render `Triage · haiku-4-5 → … → …`. Note: only **new** turns get the badge; turns already persisted without a `routing` field won't backfill.