### PR TITLE
feat(agent-builder): editable visual canvas for channels/sub-agents/skills/tools/MCP/schedules

### DIFF
--- a/middleware/migrations/0003_agent_builder_graph.sql
+++ b/middleware/migrations/0003_agent_builder_graph.sql
@@ -1,0 +1,165 @@
+-- 0003_agent_builder_graph.sql
+--
+-- Agent Builder canvas (P0). Adds the editable graph primitives that the
+-- visual builder wires together: skills, MCP servers, sub-agents, tool grants
+-- and schedule triggers — plus per-agent model-routing config and cosmetic
+-- canvas coordinates.
+--
+-- Source of truth is Postgres (copy-on-write from file-defined plugin
+-- defaults): the first canvas edit forks an agent's wiring into these tables
+-- and the DB rows become authoritative from then on.
+--
+-- Every mutation re-uses the existing notify_agents_changed bus so the
+-- OrchestratorRegistry hot-reloads without a restart (the payload is only a
+-- wake-up signal — the registry always recomputes a full snapshot diff).
+--
+-- Idempotent (IF NOT EXISTS / CREATE OR REPLACE) so re-application is a no-op.
+
+-- ── skills ────────────────────────────────────────────────────────────────
+-- DB-backed playbooks. `source='file'` rows are read-only mirrors imported
+-- from SKILL.md; `source='db'` rows are operator-authored / forked.
+CREATE TABLE IF NOT EXISTS skills (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug        TEXT NOT NULL UNIQUE,
+  name        TEXT NOT NULL,
+  description TEXT,
+  body        TEXT NOT NULL DEFAULT '',
+  frontmatter JSONB NOT NULL DEFAULT '{}',
+  source      TEXT NOT NULL DEFAULT 'db' CHECK (source IN ('db', 'file')),
+  source_path TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ── mcp_servers ─────────────────────────────────────────────────────────────
+-- External MCP endpoints registered for tool discovery. Secrets are never
+-- stored raw — `secret_ref` keys into the existing secrets store; `headers`
+-- holds only non-sensitive metadata.
+CREATE TABLE IF NOT EXISTS mcp_servers (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name               TEXT NOT NULL UNIQUE,
+  transport          TEXT NOT NULL CHECK (transport IN ('stdio', 'http', 'sse')),
+  endpoint           TEXT,
+  headers            JSONB NOT NULL DEFAULT '{}',
+  secret_ref         TEXT,
+  status             TEXT NOT NULL DEFAULT 'enabled'
+                       CHECK (status IN ('enabled', 'disabled')),
+  last_discovered_at TIMESTAMPTZ,
+  discovered_tools   JSONB NOT NULL DEFAULT '[]',
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ── agent_subagents ───────────────────────────────────────────────────────
+-- A capability-scoped in-process LocalSubAgent owned by a parent agent.
+CREATE TABLE IF NOT EXISTS agent_subagents (
+  id                     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  parent_agent_id        UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  name                   TEXT NOT NULL,
+  skill_id               UUID REFERENCES skills(id) ON DELETE SET NULL,
+  model                  TEXT,          -- null = inherit parent
+  max_tokens             INT,
+  max_iterations         INT,
+  system_prompt_override TEXT,          -- null = use skill body
+  status                 TEXT NOT NULL DEFAULT 'enabled'
+                           CHECK (status IN ('enabled', 'disabled')),
+  position               JSONB,         -- canvas {x,y}
+  created_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (parent_agent_id, name)
+);
+CREATE INDEX IF NOT EXISTS agent_subagents_parent_idx
+  ON agent_subagents(parent_agent_id);
+CREATE INDEX IF NOT EXISTS agent_subagents_skill_idx
+  ON agent_subagents(skill_id);
+
+-- ── agent_tool_grants ───────────────────────────────────────────────────────
+-- Which native / MCP tool an agent (or one of its sub-agents) may use.
+-- Exactly one of agent_id / subagent_id is set.
+CREATE TABLE IF NOT EXISTS agent_tool_grants (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id      UUID REFERENCES agents(id) ON DELETE CASCADE,
+  subagent_id   UUID REFERENCES agent_subagents(id) ON DELETE CASCADE,
+  tool_kind     TEXT NOT NULL CHECK (tool_kind IN ('native', 'mcp')),
+  tool_ref      TEXT NOT NULL,         -- native name, or "<server>:<tool>"
+  mcp_server_id UUID REFERENCES mcp_servers(id) ON DELETE CASCADE,
+  config        JSONB NOT NULL DEFAULT '{}',
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (agent_id IS NOT NULL OR subagent_id IS NOT NULL)
+);
+CREATE INDEX IF NOT EXISTS agent_tool_grants_agent_idx
+  ON agent_tool_grants(agent_id);
+CREATE INDEX IF NOT EXISTS agent_tool_grants_subagent_idx
+  ON agent_tool_grants(subagent_id);
+
+-- ── agent_schedules ─────────────────────────────────────────────────────────
+-- Cron trigger → synthetic agent turn.
+CREATE TABLE IF NOT EXISTS agent_schedules (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id    UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  cron        TEXT NOT NULL,
+  payload     JSONB NOT NULL DEFAULT '{}',
+  timezone    TEXT NOT NULL DEFAULT 'UTC',
+  status      TEXT NOT NULL DEFAULT 'enabled'
+                CHECK (status IN ('enabled', 'disabled')),
+  last_run_at TIMESTAMPTZ,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS agent_schedules_agent_idx
+  ON agent_schedules(agent_id);
+
+-- ── agents / channel_bindings extensions ────────────────────────────────────
+-- model_routing: { mode:'single'|'triage', main, triage?, escalate_on?[] }
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS model_routing JSONB;
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS canvas_position JSONB;
+ALTER TABLE channel_bindings ADD COLUMN IF NOT EXISTS canvas_position JSONB;
+
+-- ── notify trigger: teach it the new row shapes ──────────────────────────────
+-- The payload is only a wake-up hint; correctness comes from the registry's
+-- full snapshot diff. Branch by TG_TABLE_NAME so each row touches only the
+-- columns it actually has (plpgsql binds field refs at execution time).
+CREATE OR REPLACE FUNCTION notify_agents_changed() RETURNS trigger AS $$
+DECLARE
+  payload TEXT;
+BEGIN
+  IF TG_TABLE_NAME = 'multi_orchestrator_settings' THEN
+    payload := 'platform';
+  ELSIF TG_TABLE_NAME = 'agents' THEN
+    payload := COALESCE((CASE WHEN TG_OP = 'DELETE' THEN OLD.id ELSE NEW.id END)::text, 'platform');
+  ELSIF TG_TABLE_NAME IN ('agent_plugins', 'channel_bindings', 'agent_schedules') THEN
+    payload := COALESCE((CASE WHEN TG_OP = 'DELETE' THEN OLD.agent_id ELSE NEW.agent_id END)::text, 'platform');
+  ELSIF TG_TABLE_NAME = 'agent_subagents' THEN
+    payload := COALESCE((CASE WHEN TG_OP = 'DELETE' THEN OLD.parent_agent_id ELSE NEW.parent_agent_id END)::text, 'platform');
+  ELSE
+    -- skills, mcp_servers, agent_tool_grants — fan-out potential, full reload.
+    payload := 'platform';
+  END IF;
+  PERFORM pg_notify('agents_changed', payload);
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS skills_notify ON skills;
+CREATE TRIGGER skills_notify
+  AFTER INSERT OR UPDATE OR DELETE ON skills
+  FOR EACH ROW EXECUTE FUNCTION notify_agents_changed();
+
+DROP TRIGGER IF EXISTS mcp_servers_notify ON mcp_servers;
+CREATE TRIGGER mcp_servers_notify
+  AFTER INSERT OR UPDATE OR DELETE ON mcp_servers
+  FOR EACH ROW EXECUTE FUNCTION notify_agents_changed();
+
+DROP TRIGGER IF EXISTS agent_subagents_notify ON agent_subagents;
+CREATE TRIGGER agent_subagents_notify
+  AFTER INSERT OR UPDATE OR DELETE ON agent_subagents
+  FOR EACH ROW EXECUTE FUNCTION notify_agents_changed();
+
+DROP TRIGGER IF EXISTS agent_tool_grants_notify ON agent_tool_grants;
+CREATE TRIGGER agent_tool_grants_notify
+  AFTER INSERT OR UPDATE OR DELETE ON agent_tool_grants
+  FOR EACH ROW EXECUTE FUNCTION notify_agents_changed();
+
+DROP TRIGGER IF EXISTS agent_schedules_notify ON agent_schedules;
+CREATE TRIGGER agent_schedules_notify
+  AFTER INSERT OR UPDATE OR DELETE ON agent_schedules
+  FOR EACH ROW EXECUTE FUNCTION notify_agents_changed();

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1352,6 +1352,18 @@
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
       "license": "MIT"
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "license": "Apache-2.0",
@@ -1795,6 +1807,68 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@nodable/entities": {
       "version": "2.1.1",
@@ -2520,6 +2594,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -3326,6 +3439,23 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
@@ -3900,6 +4030,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/exceljs": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
@@ -3978,6 +4129,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-csv": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-4.3.6.tgz",
@@ -4012,6 +4181,22 @@
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
@@ -4419,6 +4604,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "9.1.0",
       "funding": [
@@ -4553,6 +4747,15 @@
     "node_modules/ini": {
       "version": "1.3.8",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -4692,6 +4895,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5271,6 +5480,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "license": "MIT",
@@ -5514,6 +5732,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/postgres-array": {
@@ -5773,6 +6000,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rimraf": {
@@ -6758,6 +6994,15 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
     "packages/agent-reference-maximum": {
       "name": "@omadia/agent-reference-maximum",
       "version": "0.3.2",
@@ -6941,6 +7186,9 @@
       "name": "@omadia/orchestrator",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      },
       "engines": {
         "node": ">=20"
       },

--- a/middleware/packages/harness-orchestrator/package.json
+++ b/middleware/packages/harness-orchestrator/package.json
@@ -25,5 +25,8 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0"
   }
 }

--- a/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
@@ -70,6 +70,9 @@ export interface AgentRuntimeConfig {
   readonly modelRouting?: ModelRoutingConfig;
   readonly maxTokens: number;
   readonly maxToolIterations: number;
+  /** Agent Builder — optional per-agent allow-list over plugin-contributed
+   *  native tools. Absent = all available. */
+  readonly nativeToolAllowList?: ReadonlySet<string>;
   /** Optional round-loop guard thresholds (see {@link OrchestratorOptions}). */
   readonly loopRepeatSoft?: number;
   readonly loopRepeatHard?: number;
@@ -206,6 +209,9 @@ export function buildOrchestratorForAgent(
       : {}),
     domainTools: [],
     nativeToolRegistry: deps.nativeToolRegistry,
+    ...(config.nativeToolAllowList
+      ? { nativeToolAllowList: config.nativeToolAllowList }
+      : {}),
     memoryToolHandler,
     sessionLogger,
     entityRefBus: deps.entityRefBus,

--- a/middleware/packages/harness-orchestrator/src/index.ts
+++ b/middleware/packages/harness-orchestrator/src/index.ts
@@ -85,6 +85,47 @@ export type {
 } from './registry/configStore.js';
 export { runMultiOrchestratorMigrations } from './registry/migrator.js';
 
+// Agent Builder — editable graph store, MCP client, sub-agent materialisation,
+// and the persisted-routing → runtime mapping.
+export { AgentGraphStore } from './registry/agentGraphStore.js';
+export type {
+  CanvasPos,
+  McpServerInput,
+  McpServerRow,
+  ScheduleInput,
+  ScheduleRow,
+  SkillInput,
+  SkillPatch,
+  SkillRow,
+  SubAgentInput,
+  SubAgentPatch,
+  SubAgentRow,
+  ToolGrantInput,
+  ToolGrantRow,
+} from './registry/agentGraphStore.js';
+export {
+  McpManager,
+  mcpNativeHandler,
+  mcpNativeToolName,
+  mcpToolToLocalSubAgentTool,
+  mcpToolToNativeSpec,
+} from './mcp/mcpClient.js';
+export type {
+  McpServerConfig,
+  McpToolDescriptor,
+  McpTransportKind,
+} from './mcp/mcpClient.js';
+export {
+  buildSubAgentDomainTools,
+  subAgentToolName,
+} from './registry/subAgentTools.js';
+export type {
+  SubAgentGraph,
+  SubAgentToolDeps,
+} from './registry/subAgentTools.js';
+export { resolveAgentModelRouting } from './registry/agentRuntime.js';
+export type { ResolvedAgentRuntime } from './registry/agentRuntime.js';
+
 // Per-Agent Orchestrator factory (US3) — re-exported so US4-style external
 // callers (CLI, tests) can build Orchestrators without going through the
 // plugin's activate path.

--- a/middleware/packages/harness-orchestrator/src/mcp/mcpClient.ts
+++ b/middleware/packages/harness-orchestrator/src/mcp/mcpClient.ts
@@ -1,0 +1,297 @@
+/**
+ * MCP client manager (Agent Builder P4).
+ *
+ * Connects to operator-registered MCP servers (stdio / streamable-HTTP / SSE)
+ * via the official `@modelcontextprotocol/sdk`, discovers their tools, and
+ * adapts each discovered tool into the two shapes the orchestrator already
+ * understands:
+ *
+ *   - `NativeToolSpec` + `NativeToolHandler` — for tools granted to a
+ *     top-level agent (registered on its `NativeToolRegistry`).
+ *   - `LocalSubAgentTool`               — for tools granted to a sub-agent
+ *     (passed into its `LocalSubAgent` tool list).
+ *
+ * Connections are pooled per server id and lazily (re)established. A failed
+ * connection is dropped so the next call retries — callers layer their own
+ * backoff. The manager never throws on `callTool`; it returns an `Error: …`
+ * string so a tool failure degrades the turn instead of killing it.
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type {
+  LocalSubAgentTool,
+  NativeToolHandler,
+  NativeToolSpec,
+} from '@omadia/plugin-api';
+
+export type McpTransportKind = 'stdio' | 'http' | 'sse';
+
+export interface McpServerConfig {
+  readonly id: string;
+  readonly name: string;
+  readonly transport: McpTransportKind;
+  /** URL for http/sse, or a shell command line for stdio. */
+  readonly endpoint: string | null;
+  /** Non-sensitive headers for http/sse. Secrets resolve via `secretRef`. */
+  readonly headers?: Record<string, string>;
+}
+
+export interface McpToolDescriptor {
+  readonly name: string;
+  readonly description?: string;
+  readonly inputSchema?: Record<string, unknown>;
+}
+
+interface Pooled {
+  readonly client: Client;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly transport: any;
+}
+
+const CLIENT_INFO = { name: 'omadia-agent-builder', version: '0.1.0' } as const;
+
+export class McpManager {
+  private readonly pool = new Map<string, Pooled>();
+  private readonly connecting = new Map<string, Promise<Pooled>>();
+
+  /** Discover the tool list a server exposes. Throws on connection failure so
+   *  the operator-facing `/discover` endpoint can report it. */
+  async listTools(cfg: McpServerConfig): Promise<McpToolDescriptor[]> {
+    const { client } = await this.getOrConnect(cfg);
+    const res = await client.listTools();
+    const tools = Array.isArray(res?.tools) ? res.tools : [];
+    return tools.map((t) => ({
+      name: String(t.name),
+      ...(t.description ? { description: String(t.description) } : {}),
+      ...(t.inputSchema
+        ? { inputSchema: t.inputSchema as Record<string, unknown> }
+        : {}),
+    }));
+  }
+
+  /** Invoke a tool. Never throws — returns an `Error: …` string on failure so
+   *  the orchestrator turn keeps going. */
+  async callTool(
+    cfg: McpServerConfig,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<string> {
+    let pooled: Pooled;
+    try {
+      pooled = await this.getOrConnect(cfg);
+    } catch (err) {
+      return `Error: could not connect to MCP server "${cfg.name}": ${msg(err)}`;
+    }
+    try {
+      const res = await pooled.client.callTool({
+        name: toolName,
+        arguments: args,
+      });
+      return renderToolResult(res);
+    } catch (err) {
+      // Drop the connection so the next call reconnects (server may have died).
+      await this.close(cfg.id);
+      return `Error: MCP tool "${toolName}" on "${cfg.name}" failed: ${msg(err)}`;
+    }
+  }
+
+  async close(id: string): Promise<void> {
+    const pooled = this.pool.get(id);
+    this.pool.delete(id);
+    this.connecting.delete(id);
+    if (!pooled) return;
+    try {
+      await pooled.client.close();
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  async closeAll(): Promise<void> {
+    await Promise.all([...this.pool.keys()].map((id) => this.close(id)));
+  }
+
+  private getOrConnect(cfg: McpServerConfig): Promise<Pooled> {
+    const existing = this.pool.get(cfg.id);
+    if (existing) return Promise.resolve(existing);
+    const inflight = this.connecting.get(cfg.id);
+    if (inflight) return inflight;
+
+    const p = this.connect(cfg)
+      .then((pooled) => {
+        this.pool.set(cfg.id, pooled);
+        this.connecting.delete(cfg.id);
+        return pooled;
+      })
+      .catch((err) => {
+        this.connecting.delete(cfg.id);
+        throw err;
+      });
+    this.connecting.set(cfg.id, p);
+    return p;
+  }
+
+  private async connect(cfg: McpServerConfig): Promise<Pooled> {
+    const transport = this.makeTransport(cfg);
+    const client = new Client(CLIENT_INFO);
+    await client.connect(transport);
+    return { client, transport };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private makeTransport(cfg: McpServerConfig): any {
+    if (!cfg.endpoint) {
+      throw new Error(`MCP server "${cfg.name}" has no endpoint configured`);
+    }
+    if (cfg.transport === 'stdio') {
+      const [command, ...args] = splitCommand(cfg.endpoint);
+      if (!command) {
+        throw new Error(`MCP server "${cfg.name}" stdio command is empty`);
+      }
+      return new StdioClientTransport({ command, args });
+    }
+    const url = new URL(cfg.endpoint);
+    const requestInit = cfg.headers ? { headers: cfg.headers } : undefined;
+    if (cfg.transport === 'sse') {
+      return new SSEClientTransport(url, requestInit ? { requestInit } : {});
+    }
+    return new StreamableHTTPClientTransport(
+      url,
+      requestInit ? { requestInit } : {},
+    );
+  }
+}
+
+// ── adapters ────────────────────────────────────────────────────────────────
+
+/** Anthropic tool names must match `^[a-zA-Z0-9_-]{1,64}$`. Build a stable,
+ *  collision-resistant native name for an MCP tool. */
+export function mcpNativeToolName(
+  serverName: string,
+  toolName: string,
+): string {
+  const raw = `mcp__${serverName}__${toolName}`;
+  const safe = raw.replace(/[^a-zA-Z0-9_-]/g, '_');
+  return safe.length <= 64 ? safe : safe.slice(0, 64);
+}
+
+function inputSchemaOrEmpty(tool: McpToolDescriptor): {
+  type: 'object';
+  properties: Record<string, unknown>;
+  required: string[];
+} {
+  const schema = tool.inputSchema;
+  if (schema && schema['type'] === 'object') {
+    return {
+      type: 'object',
+      properties: (schema['properties'] as Record<string, unknown>) ?? {},
+      required: Array.isArray(schema['required'])
+        ? (schema['required'] as string[])
+        : [],
+    };
+  }
+  return { type: 'object', properties: {}, required: [] };
+}
+
+/** Adapt an MCP tool into a top-level orchestrator NativeToolSpec. */
+export function mcpToolToNativeSpec(
+  serverName: string,
+  tool: McpToolDescriptor,
+): NativeToolSpec {
+  return {
+    name: mcpNativeToolName(serverName, tool.name),
+    description:
+      tool.description ?? `MCP tool "${tool.name}" from server "${serverName}".`,
+    input_schema: inputSchemaOrEmpty(tool),
+    domain: `mcp.${slugifyDomain(serverName)}`,
+  };
+}
+
+/** Native handler that routes a tool call to the MCP server. */
+export function mcpNativeHandler(
+  manager: McpManager,
+  cfg: McpServerConfig,
+  toolName: string,
+): NativeToolHandler {
+  return async (input: unknown): Promise<string> => {
+    const args =
+      input && typeof input === 'object'
+        ? (input as Record<string, unknown>)
+        : {};
+    return manager.callTool(cfg, toolName, args);
+  };
+}
+
+/** Adapt an MCP tool into a sub-agent tool (for `LocalSubAgent`). */
+export function mcpToolToLocalSubAgentTool(
+  manager: McpManager,
+  cfg: McpServerConfig,
+  tool: McpToolDescriptor,
+): LocalSubAgentTool {
+  return {
+    spec: {
+      name: mcpNativeToolName(cfg.name, tool.name),
+      description:
+        tool.description ?? `MCP tool "${tool.name}" from "${cfg.name}".`,
+      input_schema: inputSchemaOrEmpty(tool),
+    },
+    async handle(input: unknown): Promise<string> {
+      const args =
+        input && typeof input === 'object'
+          ? (input as Record<string, unknown>)
+          : {};
+      return manager.callTool(cfg, tool.name, args);
+    },
+  };
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+/** Flatten an MCP `CallToolResult` into a plain string for the LLM. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function renderToolResult(res: any): string {
+  const content = res?.content;
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const block of content) {
+      if (block?.type === 'text' && typeof block.text === 'string') {
+        parts.push(block.text);
+      } else if (block?.type === 'resource' && block.resource?.text) {
+        parts.push(String(block.resource.text));
+      } else {
+        parts.push(JSON.stringify(block));
+      }
+    }
+    const joined = parts.join('\n').trim();
+    const out = joined.length > 0 ? joined : JSON.stringify(content);
+    return res?.isError ? `Error: ${out}` : out;
+  }
+  if (typeof res?.structuredContent !== 'undefined') {
+    return JSON.stringify(res.structuredContent);
+  }
+  return JSON.stringify(res ?? {});
+}
+
+/** Split a shell command line into argv. Honours simple double/single quotes;
+ *  not a full shell parser, but enough for `npx -y @scope/pkg --flag "v"`. */
+export function splitCommand(line: string): string[] {
+  const out: string[] = [];
+  const re = /"([^"]*)"|'([^']*)'|(\S+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(line)) !== null) {
+    out.push(m[1] ?? m[2] ?? m[3] ?? '');
+  }
+  return out;
+}
+
+function slugifyDomain(name: string): string {
+  const s = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return s.length > 0 ? s : 'server';
+}
+
+function msg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -91,7 +91,10 @@ import {
   ensureWellFormedParams,
 } from './privacyHandle.js';
 import { RunTraceCollector, type InvocationHandle } from './runTraceCollector.js';
-import type { NativeToolRegistry } from './nativeToolRegistry.js';
+import type {
+  NativeToolRegistration,
+  NativeToolRegistry,
+} from './nativeToolRegistry.js';
 import { graphScopeFor, type SessionLogger } from './sessionLogger.js';
 import {
   type ModelRoutingConfig,
@@ -180,6 +183,14 @@ export interface OrchestratorOptions {
    *  between the orchestrator and the plugin-activation pipeline so plugin-
    *  contributed tools land in the same dispatch map as the kernel's own. */
   nativeToolRegistry: NativeToolRegistry;
+  /**
+   * Agent Builder — optional per-agent allow-list over plugin-contributed
+   * native tools. When set, only these tool names are advertised to the model
+   * (kernel marker tools like `memory` / `query_knowledge_graph` are always
+   * available — they are not plugin-contributed and not filtered). When
+   * absent, every plugin-contributed native tool is offered (default).
+   */
+  nativeToolAllowList?: ReadonlySet<string>;
   /**
    * Optional. #133 (plan-as-data) slice E0 — side-channel turn-hook runner.
    * When set, the orchestrator fires `onBeforeTurn` / `onAfterToolCall` /
@@ -868,6 +879,7 @@ export class Orchestrator {
    *  `OrchestratorOptions.assistantIdentity` / `DEFAULT_ASSISTANT_IDENTITY`. */
   private readonly assistantIdentity: string;
   private readonly nativeTools: NativeToolRegistry;
+  private readonly nativeToolAllowList: ReadonlySet<string> | undefined;
   /**
    * Per-turn scratchpad for the routine list smart-card emitted in-band by
    * `manage_routine.list`. Set by `extractToolEmittedRoutineList` when a
@@ -922,11 +934,23 @@ export class Orchestrator {
     this.turnHookRegistry = options.turnHookRegistry;
 
     this.nativeTools = options.nativeToolRegistry;
+    this.nativeToolAllowList = options.nativeToolAllowList;
     for (const name of KERNEL_NATIVE_TOOL_NAMES) {
       if (!this.nativeTools.has(name)) {
         this.nativeTools.register(name);
       }
     }
+  }
+
+  /**
+   * Plugin-contributed native tools the model may use this turn — the full
+   * registry list, narrowed to the per-agent allow-list when one is set.
+   * Kernel marker tools are unaffected (they are not in `listWithHandler`).
+   */
+  private allowedNativeEntries(): readonly NativeToolRegistration[] {
+    const all = this.nativeTools.listWithHandler();
+    if (!this.nativeToolAllowList) return all;
+    return all.filter((e) => this.nativeToolAllowList!.has(e.name));
   }
 
   /** Fresh {@link LoopGuard} for one turn, wired to this Agent's thresholds. */
@@ -3161,8 +3185,7 @@ export class Orchestrator {
     // kernel's hardcoded blocks (graph/diagram/…) remain in buildSystemPrompt
     // for their tools; plugin docs land in a separate bullet list so both
     // paths coexist cleanly during the extraction transition.
-    const extraDocs = this.nativeTools
-      .listWithHandler()
+    const extraDocs = this.allowedNativeEntries()
       .map((e) => e.promptDoc)
       .filter((doc): doc is string => typeof doc === 'string' && doc.length > 0);
     return buildSystemPrompt(
@@ -3285,8 +3308,9 @@ export class Orchestrator {
     if (this.bookMeetingTool) tools.push(bookMeetingToolSpec);
     // Plugin-contributed native tools (registered via ctx.tools.register).
     // Live-ingested: activating a tool-kind plugin makes its spec appear on
-    // the next iteration without requiring an orchestrator rebuild.
-    for (const entry of this.nativeTools.listWithHandler()) {
+    // the next iteration without requiring an orchestrator rebuild. Narrowed
+    // to the per-agent native-tool allow-list when one is configured.
+    for (const entry of this.allowedNativeEntries()) {
       if (entry.spec) tools.push(entry.spec);
     }
     // DomainTools dynamically from the map — so hot-registered uploaded

--- a/middleware/packages/harness-orchestrator/src/registry/agentGraphStore.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/agentGraphStore.ts
@@ -549,6 +549,40 @@ export class AgentGraphStore {
     await this.pool.query('DELETE FROM agent_tool_grants WHERE id = $1', [id]);
   }
 
+  /**
+   * Replace an agent's native-tool allow-list with exactly `toolRefs`
+   * (agent-level native grants). Empty list clears it → the agent gets every
+   * plugin-contributed native tool again. Atomic so the registry reload sees a
+   * consistent set.
+   */
+  async setAgentNativeTools(
+    agentId: string,
+    toolRefs: readonly string[],
+  ): Promise<void> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        `DELETE FROM agent_tool_grants
+         WHERE agent_id = $1 AND tool_kind = 'native'`,
+        [agentId],
+      );
+      for (const ref of toolRefs) {
+        await client.query(
+          `INSERT INTO agent_tool_grants (agent_id, tool_kind, tool_ref)
+           VALUES ($1, 'native', $2)`,
+          [agentId, ref],
+        );
+      }
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
   // ── schedules ─────────────────────────────────────────────────────────────
   async listAllSchedules(): Promise<readonly ScheduleRow[]> {
     const { rows } = await this.pool.query<ScheduleDbRow>(

--- a/middleware/packages/harness-orchestrator/src/registry/agentGraphStore.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/agentGraphStore.ts
@@ -1,0 +1,587 @@
+import type { Pool } from 'pg';
+
+import { ConfigValidationError } from './configStore.js';
+
+/**
+ * Agent Builder graph store (P0).
+ *
+ * Pure CRUD against the editable graph tables introduced by
+ * `0003_agent_builder_graph.sql` (skills, mcp_servers, agent_subagents,
+ * agent_tool_grants, agent_schedules). Kept separate from `ConfigStore` so the
+ * latter stays under the 500-line cap; `ConfigStore.loadSnapshot` composes the
+ * `list*` methods here into the registry snapshot.
+ *
+ * Like `ConfigStore`, this enforces only what the DB enforces (PK uniqueness,
+ * FK cascades, CHECK constraints) — graph-level validation (cycles, privacy
+ * conflicts) lives in the REST edge-create validator (P2).
+ */
+
+// ── row shapes (camelCase, mapped from snake_case DB rows) ──────────────────
+
+export interface CanvasPos {
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface SubAgentRow {
+  readonly id: string;
+  readonly parentAgentId: string;
+  readonly name: string;
+  readonly skillId: string | null;
+  readonly model: string | null;
+  readonly maxTokens: number | null;
+  readonly maxIterations: number | null;
+  readonly systemPromptOverride: string | null;
+  readonly status: 'enabled' | 'disabled';
+  readonly position: CanvasPos | null;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+export interface SkillRow {
+  readonly id: string;
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly body: string;
+  readonly frontmatter: Record<string, unknown>;
+  readonly source: 'db' | 'file';
+  readonly sourcePath: string | null;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+export interface McpServerRow {
+  readonly id: string;
+  readonly name: string;
+  readonly transport: 'stdio' | 'http' | 'sse';
+  readonly endpoint: string | null;
+  readonly headers: Record<string, unknown>;
+  readonly secretRef: string | null;
+  readonly status: 'enabled' | 'disabled';
+  readonly lastDiscoveredAt: Date | null;
+  readonly discoveredTools: readonly unknown[];
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+export interface ToolGrantRow {
+  readonly id: string;
+  readonly agentId: string | null;
+  readonly subAgentId: string | null;
+  readonly toolKind: 'native' | 'mcp';
+  readonly toolRef: string;
+  readonly mcpServerId: string | null;
+  readonly config: Record<string, unknown>;
+  readonly createdAt: Date;
+}
+
+export interface ScheduleRow {
+  readonly id: string;
+  readonly agentId: string;
+  readonly cron: string;
+  readonly payload: Record<string, unknown>;
+  readonly timezone: string;
+  readonly status: 'enabled' | 'disabled';
+  readonly lastRunAt: Date | null;
+  readonly createdAt: Date;
+}
+
+// ── inputs ──────────────────────────────────────────────────────────────────
+
+export interface SubAgentInput {
+  readonly parentAgentId: string;
+  readonly name: string;
+  readonly skillId?: string | null;
+  readonly model?: string | null;
+  readonly maxTokens?: number | null;
+  readonly maxIterations?: number | null;
+  readonly systemPromptOverride?: string | null;
+  readonly status?: 'enabled' | 'disabled';
+  readonly position?: CanvasPos | null;
+}
+
+export interface SubAgentPatch {
+  readonly name?: string;
+  readonly skillId?: string | null;
+  readonly model?: string | null;
+  readonly maxTokens?: number | null;
+  readonly maxIterations?: number | null;
+  readonly systemPromptOverride?: string | null;
+  readonly status?: 'enabled' | 'disabled';
+  readonly position?: CanvasPos | null;
+}
+
+export interface SkillInput {
+  readonly slug: string;
+  readonly name: string;
+  readonly description?: string | null;
+  readonly body?: string;
+  readonly frontmatter?: Record<string, unknown>;
+  readonly source?: 'db' | 'file';
+  readonly sourcePath?: string | null;
+}
+
+export interface SkillPatch {
+  readonly name?: string;
+  readonly description?: string | null;
+  readonly body?: string;
+  readonly frontmatter?: Record<string, unknown>;
+}
+
+export interface McpServerInput {
+  readonly name: string;
+  readonly transport: 'stdio' | 'http' | 'sse';
+  readonly endpoint?: string | null;
+  readonly headers?: Record<string, unknown>;
+  readonly secretRef?: string | null;
+  readonly status?: 'enabled' | 'disabled';
+}
+
+export interface ToolGrantInput {
+  readonly agentId?: string | null;
+  readonly subAgentId?: string | null;
+  readonly toolKind: 'native' | 'mcp';
+  readonly toolRef: string;
+  readonly mcpServerId?: string | null;
+  readonly config?: Record<string, unknown>;
+}
+
+export interface ScheduleInput {
+  readonly agentId: string;
+  readonly cron: string;
+  readonly payload?: Record<string, unknown>;
+  readonly timezone?: string;
+  readonly status?: 'enabled' | 'disabled';
+}
+
+// ── DB row shapes ─────────────────────────────────────────────────────────
+
+interface SubAgentDbRow {
+  id: string;
+  parent_agent_id: string;
+  name: string;
+  skill_id: string | null;
+  model: string | null;
+  max_tokens: number | null;
+  max_iterations: number | null;
+  system_prompt_override: string | null;
+  status: 'enabled' | 'disabled';
+  position: CanvasPos | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface SkillDbRow {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  body: string;
+  frontmatter: Record<string, unknown>;
+  source: 'db' | 'file';
+  source_path: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface McpServerDbRow {
+  id: string;
+  name: string;
+  transport: 'stdio' | 'http' | 'sse';
+  endpoint: string | null;
+  headers: Record<string, unknown>;
+  secret_ref: string | null;
+  status: 'enabled' | 'disabled';
+  last_discovered_at: Date | null;
+  discovered_tools: unknown[];
+  created_at: Date;
+  updated_at: Date;
+}
+
+interface ToolGrantDbRow {
+  id: string;
+  agent_id: string | null;
+  subagent_id: string | null;
+  tool_kind: 'native' | 'mcp';
+  tool_ref: string;
+  mcp_server_id: string | null;
+  config: Record<string, unknown>;
+  created_at: Date;
+}
+
+interface ScheduleDbRow {
+  id: string;
+  agent_id: string;
+  cron: string;
+  payload: Record<string, unknown>;
+  timezone: string;
+  status: 'enabled' | 'disabled';
+  last_run_at: Date | null;
+  created_at: Date;
+}
+
+// ── mappers ─────────────────────────────────────────────────────────────────
+
+function mapSubAgent(r: SubAgentDbRow): SubAgentRow {
+  return {
+    id: r.id,
+    parentAgentId: r.parent_agent_id,
+    name: r.name,
+    skillId: r.skill_id,
+    model: r.model,
+    maxTokens: r.max_tokens,
+    maxIterations: r.max_iterations,
+    systemPromptOverride: r.system_prompt_override,
+    status: r.status,
+    position: r.position,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}
+
+function mapSkill(r: SkillDbRow): SkillRow {
+  return {
+    id: r.id,
+    slug: r.slug,
+    name: r.name,
+    description: r.description,
+    body: r.body,
+    frontmatter: r.frontmatter,
+    source: r.source,
+    sourcePath: r.source_path,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}
+
+function mapMcpServer(r: McpServerDbRow): McpServerRow {
+  return {
+    id: r.id,
+    name: r.name,
+    transport: r.transport,
+    endpoint: r.endpoint,
+    headers: r.headers,
+    secretRef: r.secret_ref,
+    status: r.status,
+    lastDiscoveredAt: r.last_discovered_at,
+    discoveredTools: r.discovered_tools,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}
+
+function mapToolGrant(r: ToolGrantDbRow): ToolGrantRow {
+  return {
+    id: r.id,
+    agentId: r.agent_id,
+    subAgentId: r.subagent_id,
+    toolKind: r.tool_kind,
+    toolRef: r.tool_ref,
+    mcpServerId: r.mcp_server_id,
+    config: r.config,
+    createdAt: r.created_at,
+  };
+}
+
+function mapSchedule(r: ScheduleDbRow): ScheduleRow {
+  return {
+    id: r.id,
+    agentId: r.agent_id,
+    cron: r.cron,
+    payload: r.payload,
+    timezone: r.timezone,
+    status: r.status,
+    lastRunAt: r.last_run_at,
+    createdAt: r.created_at,
+  };
+}
+
+function isUniqueViolation(err: unknown, constraint?: string): boolean {
+  if (!err || typeof err !== 'object') return false;
+  if ((err as { code?: string }).code !== '23505') return false;
+  if (!constraint) return true;
+  return (err as { constraint?: string }).constraint === constraint;
+}
+
+export class AgentGraphStore {
+  constructor(private readonly pool: Pool) {}
+
+  // ── sub-agents ───────────────────────────────────────────────────────────
+  async listAllSubAgents(): Promise<readonly SubAgentRow[]> {
+    const { rows } = await this.pool.query<SubAgentDbRow>(
+      'SELECT * FROM agent_subagents ORDER BY parent_agent_id, name',
+    );
+    return rows.map(mapSubAgent);
+  }
+
+  async createSubAgent(input: SubAgentInput): Promise<SubAgentRow> {
+    try {
+      const { rows } = await this.pool.query<SubAgentDbRow>(
+        `INSERT INTO agent_subagents
+           (parent_agent_id, name, skill_id, model, max_tokens, max_iterations,
+            system_prompt_override, status, position)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,COALESCE($8,'enabled'),$9::jsonb)
+         RETURNING *`,
+        [
+          input.parentAgentId,
+          input.name,
+          input.skillId ?? null,
+          input.model ?? null,
+          input.maxTokens ?? null,
+          input.maxIterations ?? null,
+          input.systemPromptOverride ?? null,
+          input.status ?? null,
+          input.position ? JSON.stringify(input.position) : null,
+        ],
+      );
+      return mapSubAgent(rows[0]!);
+    } catch (err) {
+      if (isUniqueViolation(err, 'agent_subagents_parent_agent_id_name_key')) {
+        throw new ConfigValidationError(
+          `sub-agent "${input.name}" already exists for this agent`,
+        );
+      }
+      throw err;
+    }
+  }
+
+  async updateSubAgent(id: string, patch: SubAgentPatch): Promise<SubAgentRow> {
+    const { rows } = await this.pool.query<SubAgentDbRow>(
+      `UPDATE agent_subagents SET
+         name                   = COALESCE($2, name),
+         skill_id               = COALESCE($3, skill_id),
+         model                  = COALESCE($4, model),
+         max_tokens             = COALESCE($5, max_tokens),
+         max_iterations         = COALESCE($6, max_iterations),
+         system_prompt_override = COALESCE($7, system_prompt_override),
+         status                 = COALESCE($8, status),
+         position               = COALESCE($9::jsonb, position),
+         updated_at             = now()
+       WHERE id = $1
+       RETURNING *`,
+      [
+        id,
+        patch.name ?? null,
+        patch.skillId ?? null,
+        patch.model ?? null,
+        patch.maxTokens ?? null,
+        patch.maxIterations ?? null,
+        patch.systemPromptOverride ?? null,
+        patch.status ?? null,
+        patch.position ? JSON.stringify(patch.position) : null,
+      ],
+    );
+    const row = rows[0];
+    if (!row) throw new ConfigValidationError(`sub-agent ${id} not found`);
+    return mapSubAgent(row);
+  }
+
+  /** Set or clear (null) a sub-agent's skill. Direct write so the canvas can
+   *  detach a skill edge. */
+  async setSubAgentSkill(
+    id: string,
+    skillId: string | null,
+  ): Promise<SubAgentRow> {
+    const { rows } = await this.pool.query<SubAgentDbRow>(
+      `UPDATE agent_subagents SET skill_id = $2, updated_at = now()
+       WHERE id = $1 RETURNING *`,
+      [id, skillId],
+    );
+    const row = rows[0];
+    if (!row) throw new ConfigValidationError(`sub-agent ${id} not found`);
+    return mapSubAgent(row);
+  }
+
+  async deleteSubAgent(id: string): Promise<void> {
+    await this.pool.query('DELETE FROM agent_subagents WHERE id = $1', [id]);
+  }
+
+  async listSchedulesForAgent(agentId: string): Promise<readonly ScheduleRow[]> {
+    const { rows } = await this.pool.query<ScheduleDbRow>(
+      'SELECT * FROM agent_schedules WHERE agent_id = $1 ORDER BY created_at',
+      [agentId],
+    );
+    return rows.map(mapSchedule);
+  }
+
+  // ── skills ─────────────────────────────────────────────────────────────────
+  async listSkills(): Promise<readonly SkillRow[]> {
+    const { rows } = await this.pool.query<SkillDbRow>(
+      'SELECT * FROM skills ORDER BY slug',
+    );
+    return rows.map(mapSkill);
+  }
+
+  async upsertSkill(input: SkillInput): Promise<SkillRow> {
+    const { rows } = await this.pool.query<SkillDbRow>(
+      `INSERT INTO skills (slug, name, description, body, frontmatter, source, source_path)
+       VALUES ($1,$2,$3,COALESCE($4,''),COALESCE($5::jsonb,'{}'::jsonb),COALESCE($6,'db'),$7)
+       ON CONFLICT (slug) DO UPDATE SET
+         name        = EXCLUDED.name,
+         description = EXCLUDED.description,
+         body        = EXCLUDED.body,
+         frontmatter = EXCLUDED.frontmatter,
+         updated_at  = now()
+       RETURNING *`,
+      [
+        input.slug,
+        input.name,
+        input.description ?? null,
+        input.body ?? null,
+        input.frontmatter ? JSON.stringify(input.frontmatter) : null,
+        input.source ?? null,
+        input.sourcePath ?? null,
+      ],
+    );
+    return mapSkill(rows[0]!);
+  }
+
+  async updateSkill(id: string, patch: SkillPatch): Promise<SkillRow> {
+    const { rows } = await this.pool.query<SkillDbRow>(
+      `UPDATE skills SET
+         name        = COALESCE($2, name),
+         description  = COALESCE($3, description),
+         body         = COALESCE($4, body),
+         frontmatter  = COALESCE($5::jsonb, frontmatter),
+         updated_at   = now()
+       WHERE id = $1
+       RETURNING *`,
+      [
+        id,
+        patch.name ?? null,
+        patch.description ?? null,
+        patch.body ?? null,
+        patch.frontmatter ? JSON.stringify(patch.frontmatter) : null,
+      ],
+    );
+    const row = rows[0];
+    if (!row) throw new ConfigValidationError(`skill ${id} not found`);
+    return mapSkill(row);
+  }
+
+  async deleteSkill(id: string): Promise<void> {
+    await this.pool.query('DELETE FROM skills WHERE id = $1', [id]);
+  }
+
+  // ── mcp_servers ─────────────────────────────────────────────────────────────
+  async listMcpServers(): Promise<readonly McpServerRow[]> {
+    const { rows } = await this.pool.query<McpServerDbRow>(
+      'SELECT * FROM mcp_servers ORDER BY name',
+    );
+    return rows.map(mapMcpServer);
+  }
+
+  async createMcpServer(input: McpServerInput): Promise<McpServerRow> {
+    try {
+      const { rows } = await this.pool.query<McpServerDbRow>(
+        `INSERT INTO mcp_servers (name, transport, endpoint, headers, secret_ref, status)
+         VALUES ($1,$2,$3,COALESCE($4::jsonb,'{}'::jsonb),$5,COALESCE($6,'enabled'))
+         RETURNING *`,
+        [
+          input.name,
+          input.transport,
+          input.endpoint ?? null,
+          input.headers ? JSON.stringify(input.headers) : null,
+          input.secretRef ?? null,
+          input.status ?? null,
+        ],
+      );
+      return mapMcpServer(rows[0]!);
+    } catch (err) {
+      if (isUniqueViolation(err, 'mcp_servers_name_key')) {
+        throw new ConfigValidationError(
+          `MCP server "${input.name}" already exists`,
+        );
+      }
+      throw err;
+    }
+  }
+
+  async setMcpDiscoveredTools(
+    id: string,
+    tools: readonly unknown[],
+  ): Promise<void> {
+    await this.pool.query(
+      `UPDATE mcp_servers
+         SET discovered_tools = $2::jsonb, last_discovered_at = now(), updated_at = now()
+       WHERE id = $1`,
+      [id, JSON.stringify(tools)],
+    );
+  }
+
+  async deleteMcpServer(id: string): Promise<void> {
+    await this.pool.query('DELETE FROM mcp_servers WHERE id = $1', [id]);
+  }
+
+  // ── tool grants ───────────────────────────────────────────────────────────
+  async listAllToolGrants(): Promise<readonly ToolGrantRow[]> {
+    const { rows } = await this.pool.query<ToolGrantDbRow>(
+      'SELECT * FROM agent_tool_grants ORDER BY created_at',
+    );
+    return rows.map(mapToolGrant);
+  }
+
+  async createToolGrant(input: ToolGrantInput): Promise<ToolGrantRow> {
+    if (!input.agentId && !input.subAgentId) {
+      throw new ConfigValidationError(
+        'tool grant must target an agent or a sub-agent',
+      );
+    }
+    const { rows } = await this.pool.query<ToolGrantDbRow>(
+      `INSERT INTO agent_tool_grants
+         (agent_id, subagent_id, tool_kind, tool_ref, mcp_server_id, config)
+       VALUES ($1,$2,$3,$4,$5,COALESCE($6::jsonb,'{}'::jsonb))
+       RETURNING *`,
+      [
+        input.agentId ?? null,
+        input.subAgentId ?? null,
+        input.toolKind,
+        input.toolRef,
+        input.mcpServerId ?? null,
+        input.config ? JSON.stringify(input.config) : null,
+      ],
+    );
+    return mapToolGrant(rows[0]!);
+  }
+
+  async deleteToolGrant(id: string): Promise<void> {
+    await this.pool.query('DELETE FROM agent_tool_grants WHERE id = $1', [id]);
+  }
+
+  // ── schedules ─────────────────────────────────────────────────────────────
+  async listAllSchedules(): Promise<readonly ScheduleRow[]> {
+    const { rows } = await this.pool.query<ScheduleDbRow>(
+      'SELECT * FROM agent_schedules ORDER BY agent_id, created_at',
+    );
+    return rows.map(mapSchedule);
+  }
+
+  async createSchedule(input: ScheduleInput): Promise<ScheduleRow> {
+    const { rows } = await this.pool.query<ScheduleDbRow>(
+      `INSERT INTO agent_schedules (agent_id, cron, payload, timezone, status)
+       VALUES ($1,$2,COALESCE($3::jsonb,'{}'::jsonb),COALESCE($4,'UTC'),COALESCE($5,'enabled'))
+       RETURNING *`,
+      [
+        input.agentId,
+        input.cron,
+        input.payload ? JSON.stringify(input.payload) : null,
+        input.timezone ?? null,
+        input.status ?? null,
+      ],
+    );
+    return mapSchedule(rows[0]!);
+  }
+
+  async deleteSchedule(id: string): Promise<void> {
+    await this.pool.query('DELETE FROM agent_schedules WHERE id = $1', [id]);
+  }
+
+  /** Stamp a schedule's last fire time (scheduler worker). */
+  async markScheduleRun(id: string): Promise<void> {
+    await this.pool.query(
+      'UPDATE agent_schedules SET last_run_at = now() WHERE id = $1',
+      [id],
+    );
+  }
+}

--- a/middleware/packages/harness-orchestrator/src/registry/agentRuntime.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/agentRuntime.ts
@@ -1,0 +1,59 @@
+import type { ModelRoutingConfig as RuntimeModelRouting } from '../modelRouter.js';
+
+/**
+ * Map an agent's persisted `model_routing` JSON (the Agent Builder / plugin-api
+ * shape `{ mode, main, triage?, simple?, escalateOn? }`) onto the orchestrator
+ * runtime knobs:
+ *
+ *   - a `model` override (the agent's chosen primary model), and
+ *   - an optional `modelRouting` ({classifierModel, simpleModel, complexModel})
+ *     when the operator picked per-turn `triage` routing.
+ *
+ * Pure + defensive: unknown / malformed JSON yields `{}` (the registry falls
+ * back to the platform default runtime config). Lives in the orchestrator
+ * package so the persisted-shape→runtime-shape bridge has one home and is
+ * unit-testable without a DB.
+ */
+
+const DEFAULT_CLASSIFIER_MODEL = 'claude-haiku-4-5';
+
+export interface ResolvedAgentRuntime {
+  /** Primary model override (the agent's `main`), if set. */
+  readonly model?: string;
+  /** Per-turn routing config, only when mode is 'triage' with a usable `main`. */
+  readonly modelRouting?: RuntimeModelRouting;
+}
+
+export function resolveAgentModelRouting(
+  raw: Record<string, unknown> | null | undefined,
+): ResolvedAgentRuntime {
+  if (!raw || typeof raw !== 'object') return {};
+
+  const mode = raw['mode'];
+  const main = typeof raw['main'] === 'string' ? (raw['main'] as string) : undefined;
+  if (!main) return {};
+
+  if (mode === 'single') {
+    return { model: main };
+  }
+
+  if (mode === 'triage') {
+    const triage =
+      typeof raw['triage'] === 'string'
+        ? (raw['triage'] as string)
+        : DEFAULT_CLASSIFIER_MODEL;
+    const simple =
+      typeof raw['simple'] === 'string' ? (raw['simple'] as string) : main;
+    return {
+      model: main,
+      modelRouting: {
+        classifierModel: triage,
+        simpleModel: simple,
+        complexModel: main,
+      },
+    };
+  }
+
+  // Unknown mode — still honour the chosen primary model.
+  return { model: main };
+}

--- a/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
@@ -155,6 +155,7 @@ export function buildForAgent(
   agent: AgentRow,
   deps: OrchestratorDeps,
   runtime: Omit<AgentRuntimeConfig, 'agentId'>,
+  nativeToolAllowList?: ReadonlySet<string>,
 ): BuiltOrchestrator {
   // Agent Builder P5 — overlay the agent's persisted model_routing onto the
   // platform default: `main` overrides the model, `triage` mode adds per-turn
@@ -173,6 +174,7 @@ export function buildForAgent(
       ...((routing.modelRouting ?? runtime.modelRouting)
         ? { modelRouting: routing.modelRouting ?? runtime.modelRouting }
         : {}),
+      ...(nativeToolAllowList ? { nativeToolAllowList } : {}),
       ...(runtime.loopRepeatSoft !== undefined
         ? { loopRepeatSoft: runtime.loopRepeatSoft }
         : {}),

--- a/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
@@ -6,6 +6,12 @@ import {
 } from '../buildOrchestrator.js';
 
 import type {
+  SkillRow,
+  SubAgentRow,
+  ToolGrantRow,
+} from './agentGraphStore.js';
+import { resolveAgentModelRouting } from './agentRuntime.js';
+import type {
   AgentPluginRow,
   AgentRow,
   ChannelBindingRow,
@@ -99,7 +105,10 @@ export function diffSnapshots(
     if (!isEnabled) continue;
 
     // Both old and new are enabled. Decide rebuild vs metadata-only update.
-    const reasons = runtimeChangeReasons(oldAgent!, newAgent);
+    const reasons = [
+      ...runtimeChangeReasons(oldAgent!, newAgent),
+      ...graphChangeReasons(oldAgent!.id, newAgent.id, oldSnap, newSnap),
+    ];
     if (reasons.length > 0) {
       actions.push({
         kind: 'rebuild',
@@ -147,12 +156,17 @@ export function buildForAgent(
   deps: OrchestratorDeps,
   runtime: Omit<AgentRuntimeConfig, 'agentId'>,
 ): BuiltOrchestrator {
+  // Agent Builder P5 — overlay the agent's persisted model_routing onto the
+  // platform default: `main` overrides the model, `triage` mode adds per-turn
+  // Haiku→Sonnet/Opus routing. Falls back to the platform runtime when unset.
+  const routing = resolveAgentModelRouting(agent.modelRouting);
   return buildOrchestratorForAgent(
     {
       agentId: agent.slug,
-      model: runtime.model,
+      model: routing.model ?? runtime.model,
       maxTokens: runtime.maxTokens,
       maxToolIterations: runtime.maxToolIterations,
+      ...(routing.modelRouting ? { modelRouting: routing.modelRouting } : {}),
       ...(runtime.loopRepeatSoft !== undefined
         ? { loopRepeatSoft: runtime.loopRepeatSoft }
         : {}),
@@ -174,9 +188,88 @@ function runtimeChangeReasons(oldAgent: AgentRow, newAgent: AgentRow): string[] 
       `privacy_profile:${oldAgent.privacyProfile}->${newAgent.privacyProfile}`,
     );
   }
+  // Per-agent model routing (Agent Builder P5) changes which model the turn
+  // loop selects — a runtime-relevant change warranting a rebuild.
+  if (
+    JSON.stringify(oldAgent.modelRouting ?? null) !==
+    JSON.stringify(newAgent.modelRouting ?? null)
+  ) {
+    reasons.push('model_routing');
+  }
   // `name` / `description` are display-only and never warrant a rebuild —
   // they would invalidate sessions for no semantic gain.
   return reasons;
+}
+
+/**
+ * Agent Builder graph (P0): rebuild when an agent's sub-agents, tool grants,
+ * or any skill referenced by those sub-agents changed. These define what the
+ * orchestrator (and its LocalSubAgents) can do, so a change is runtime-
+ * relevant. Schedules are intentionally excluded — they are consumed by the
+ * cron worker, not baked into the orchestrator build.
+ */
+function graphChangeReasons(
+  oldAgentId: string,
+  newAgentId: string,
+  oldSnap: ConfigSnapshot | undefined,
+  newSnap: ConfigSnapshot,
+): string[] {
+  const oldSig = graphSignature(oldAgentId, oldSnap);
+  const newSig = graphSignature(newAgentId, newSnap);
+  return oldSig === newSig ? [] : ['graph'];
+}
+
+/**
+ * Deterministic fingerprint of an agent's graph wiring within one snapshot:
+ * its sub-agents, the tool grants targeting the agent or those sub-agents,
+ * and the bodies of any skills those sub-agents reference. Order-independent
+ * (everything is sorted) so it captures semantic, not row-order, change.
+ */
+function graphSignature(
+  agentId: string,
+  snap: ConfigSnapshot | undefined,
+): string {
+  const subAgents: readonly SubAgentRow[] = (snap?.subAgents ?? []).filter(
+    (s) => s.parentAgentId === agentId,
+  );
+  const subAgentIds = new Set(subAgents.map((s) => s.id));
+  const skillIds = new Set(
+    subAgents.map((s) => s.skillId).filter((id): id is string => !!id),
+  );
+
+  const grants: readonly ToolGrantRow[] = (snap?.toolGrants ?? []).filter(
+    (g) =>
+      (g.agentId !== null && g.agentId === agentId) ||
+      (g.subAgentId !== null && subAgentIds.has(g.subAgentId)),
+  );
+
+  const skills: readonly SkillRow[] = (snap?.skills ?? []).filter((sk) =>
+    skillIds.has(sk.id),
+  );
+
+  const subPart = subAgents
+    .map(
+      (s) =>
+        `${s.id}|${s.name}|${s.skillId ?? ''}|${s.model ?? ''}|${
+          s.maxTokens ?? ''
+        }|${s.maxIterations ?? ''}|${s.systemPromptOverride ?? ''}|${s.status}`,
+    )
+    .sort();
+  const grantPart = grants
+    .map(
+      (g) =>
+        `${g.agentId ?? ''}|${g.subAgentId ?? ''}|${g.toolKind}|${g.toolRef}|${
+          g.mcpServerId ?? ''
+        }|${JSON.stringify(g.config)}`,
+    )
+    .sort();
+  const skillPart = skills
+    .map(
+      (sk) => `${sk.id}|${sk.name}|${sk.body}|${JSON.stringify(sk.frontmatter)}`,
+    )
+    .sort();
+
+  return JSON.stringify({ subPart, grantPart, skillPart });
 }
 
 function equalPlugins(

--- a/middleware/packages/harness-orchestrator/src/registry/configStore.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/configStore.ts
@@ -1,5 +1,14 @@
 import type { Pool } from 'pg';
 
+import {
+  AgentGraphStore,
+  type ScheduleRow,
+  type SkillRow,
+  type SubAgentRow,
+  type McpServerRow,
+  type ToolGrantRow,
+} from './agentGraphStore.js';
+
 /**
  * Multi-orchestrator config store (US4 / T014).
  *
@@ -17,6 +26,11 @@ import type { Pool } from 'pg';
 export type PrivacyProfile = 'strict' | 'default';
 export type AgentStatus = 'enabled' | 'disabled';
 
+export interface CanvasPosition {
+  readonly x: number;
+  readonly y: number;
+}
+
 export interface AgentRow {
   readonly id: string;
   readonly slug: string;
@@ -24,6 +38,12 @@ export interface AgentRow {
   readonly description: string | null;
   readonly privacyProfile: PrivacyProfile;
   readonly status: AgentStatus;
+  /** Per-agent model routing (Agent Builder P0). Raw JSONB; shaped to
+   *  `ModelRoutingConfig` at the API boundary. `null`/absent = inherit
+   *  platform default. Optional so pre-existing AgentRow fixtures stay valid. */
+  readonly modelRouting?: Record<string, unknown> | null;
+  /** Cosmetic canvas coordinate; `null`/absent until first laid out. */
+  readonly canvasPosition?: CanvasPosition | null;
   readonly createdAt: Date;
   readonly updatedAt: Date;
 }
@@ -61,6 +81,8 @@ export interface AgentPatch {
   readonly description?: string | null;
   readonly privacyProfile?: PrivacyProfile;
   readonly status?: AgentStatus;
+  readonly modelRouting?: Record<string, unknown> | null;
+  readonly canvasPosition?: CanvasPosition | null;
 }
 
 export interface AgentPluginInput {
@@ -95,6 +117,8 @@ interface AgentDbRow {
   description: string | null;
   privacy_profile: PrivacyProfile;
   status: AgentStatus;
+  model_routing: Record<string, unknown> | null;
+  canvas_position: CanvasPosition | null;
   created_at: Date;
   updated_at: Date;
 }
@@ -127,6 +151,8 @@ function mapAgent(row: AgentDbRow): AgentRow {
     description: row.description,
     privacyProfile: row.privacy_profile,
     status: row.status,
+    modelRouting: row.model_routing ?? null,
+    canvasPosition: row.canvas_position ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -230,6 +256,8 @@ export class ConfigStore {
          description     = COALESCE($3, description),
          privacy_profile = COALESCE($4, privacy_profile),
          status          = COALESCE($5, status),
+         model_routing   = COALESCE($6::jsonb, model_routing),
+         canvas_position = COALESCE($7::jsonb, canvas_position),
          updated_at      = now()
        WHERE id = $1
        RETURNING *`,
@@ -239,6 +267,8 @@ export class ConfigStore {
         patch.description ?? null,
         patch.privacyProfile ?? null,
         patch.status ?? null,
+        patch.modelRouting ? JSON.stringify(patch.modelRouting) : null,
+        patch.canvasPosition ? JSON.stringify(patch.canvasPosition) : null,
       ],
     );
     const row = rows[0];
@@ -250,6 +280,46 @@ export class ConfigStore {
 
   async deleteAgent(id: string): Promise<void> {
     await this.pool.query('DELETE FROM agents WHERE id = $1', [id]);
+  }
+
+  /** Agent Builder — set (or clear, with null) the per-agent model routing.
+   *  Direct write (not COALESCE) so the operator can disable routing. */
+  async setModelRouting(
+    id: string,
+    routing: Record<string, unknown> | null,
+  ): Promise<AgentRow> {
+    const { rows } = await this.pool.query<AgentDbRow>(
+      `UPDATE agents SET model_routing = $2::jsonb, updated_at = now()
+       WHERE id = $1 RETURNING *`,
+      [id, routing ? JSON.stringify(routing) : null],
+    );
+    const row = rows[0];
+    if (!row) throw new ConfigValidationError(`agent ${id} not found`);
+    return mapAgent(row);
+  }
+
+  /** Agent Builder — persist an agent's cosmetic canvas coordinate. */
+  async setCanvasPosition(
+    id: string,
+    pos: CanvasPosition | null,
+  ): Promise<void> {
+    await this.pool.query(
+      `UPDATE agents SET canvas_position = $2::jsonb WHERE id = $1`,
+      [id, pos ? JSON.stringify(pos) : null],
+    );
+  }
+
+  /** Agent Builder — persist a channel binding's cosmetic canvas coordinate. */
+  async setChannelBindingPosition(
+    channelType: string,
+    channelKey: string,
+    pos: CanvasPosition | null,
+  ): Promise<void> {
+    await this.pool.query(
+      `UPDATE channel_bindings SET canvas_position = $3::jsonb
+       WHERE channel_type = $1 AND channel_key = $2`,
+      [channelType, channelKey, pos ? JSON.stringify(pos) : null],
+    );
   }
 
   // ── agent_plugins ─────────────────────────────────────────────────────
@@ -412,13 +482,39 @@ export class ConfigStore {
    * mildly-stale snapshot. The US5 reload bus catches up on the next NOTIFY.
    */
   async loadSnapshot(): Promise<ConfigSnapshot> {
-    const [agents, plugins, bindings, settings] = await Promise.all([
+    const graph = new AgentGraphStore(this.pool);
+    const [
+      agents,
+      plugins,
+      bindings,
+      settings,
+      subAgents,
+      toolGrants,
+      schedules,
+      skills,
+      mcpServers,
+    ] = await Promise.all([
       this.listAgents(),
       this.listAllAgentPlugins(),
       this.listChannelBindings(),
       this.getPlatformSettings(),
+      graph.listAllSubAgents(),
+      graph.listAllToolGrants(),
+      graph.listAllSchedules(),
+      graph.listSkills(),
+      graph.listMcpServers(),
     ]);
-    return { agents, agentPlugins: plugins, channelBindings: bindings, platformSettings: settings };
+    return {
+      agents,
+      agentPlugins: plugins,
+      channelBindings: bindings,
+      platformSettings: settings,
+      subAgents,
+      toolGrants,
+      schedules,
+      skills,
+      mcpServers,
+    };
   }
 }
 
@@ -427,6 +523,13 @@ export interface ConfigSnapshot {
   readonly agentPlugins: readonly AgentPluginRow[];
   readonly channelBindings: readonly ChannelBindingRow[];
   readonly platformSettings: PlatformSettingsRow;
+  // Agent Builder graph (P0). Optional so pre-existing snapshot literals
+  // (tests, fixtures) stay valid; `loadSnapshot` always populates them.
+  readonly subAgents?: readonly SubAgentRow[];
+  readonly toolGrants?: readonly ToolGrantRow[];
+  readonly schedules?: readonly ScheduleRow[];
+  readonly skills?: readonly SkillRow[];
+  readonly mcpServers?: readonly McpServerRow[];
 }
 
 function isUniqueViolation(err: unknown, constraint?: string): boolean {

--- a/middleware/packages/harness-orchestrator/src/registry/index.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/index.ts
@@ -313,6 +313,7 @@ export class OrchestratorRegistry {
           action.agent,
           this.deps,
           this.options.defaultRuntimeConfig,
+          nativeAllowFromGrants(graph.grantsByAgent.get(action.agent.id) ?? []),
         );
         const plugins = pluginsByAgent.get(action.agent.id) ?? [];
         const bindings = bindingsByAgent.get(action.agent.id) ?? [];
@@ -356,6 +357,7 @@ export class OrchestratorRegistry {
           action.agent,
           this.deps,
           this.options.defaultRuntimeConfig,
+          nativeAllowFromGrants(graph.grantsByAgent.get(action.agent.id) ?? []),
         );
         const plugins = pluginsByAgent.get(action.agent.id) ?? [];
         const bindings = bindingsByAgent.get(action.agent.id) ?? [];
@@ -688,6 +690,20 @@ interface GraphIndex {
   readonly subAgentsByAgent: Map<string, SubAgentRow[]>;
   readonly grantsByAgent: Map<string, ToolGrantRow[]>;
   readonly skillsByAgent: Map<string, SkillRow[]>;
+}
+
+/**
+ * Per-agent native-tool allow-list from its agent-level native grants. Empty
+ * (no native grants) → `undefined` = every plugin-contributed native tool is
+ * available (default). One or more → only those names are advertised.
+ */
+function nativeAllowFromGrants(
+  grants: readonly ToolGrantRow[],
+): ReadonlySet<string> | undefined {
+  const names = grants
+    .filter((g) => g.toolKind === 'native' && g.agentId)
+    .map((g) => g.toolRef);
+  return names.length > 0 ? new Set(names) : undefined;
 }
 
 function indexGraph(snap: ConfigSnapshot): GraphIndex {

--- a/middleware/packages/harness-orchestrator/src/registry/index.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/index.ts
@@ -6,6 +6,11 @@ import type {
 
 import type { ChatSessionStore, SessionConfigSnapshot } from '../chatSessionStore.js';
 
+import type {
+  SkillRow,
+  SubAgentRow,
+  ToolGrantRow,
+} from './agentGraphStore.js';
 import {
   buildForAgent,
   diffSnapshots,
@@ -137,6 +142,16 @@ export interface ActiveAgent {
   readonly bindings: readonly ChannelBindingRow[];
   readonly built: BuiltOrchestrator;
   /**
+   * Agent Builder graph (P0/P2): the agent's DB-defined sub-agents, the tool
+   * grants targeting the agent or those sub-agents, and the skills those
+   * sub-agents reference. Populated from the snapshot on add/rebuild/update so
+   * the kernel's `onAgentBuilt` callback can materialise sub-agent domain
+   * tools without re-querying the store.
+   */
+  readonly subAgents: readonly SubAgentRow[];
+  readonly toolGrants: readonly ToolGrantRow[];
+  readonly skills: readonly SkillRow[];
+  /**
    * Strict per-orchestrator memory scope: `['core', 'orchestrator:<slug>:*']`
    * (see {@link computeMemoryScope}). The Agent may touch only its own
    * orchestrator tree plus the shared `core` namespace — never another
@@ -261,10 +276,11 @@ export class OrchestratorRegistry {
   private applyDiffActions(plan: DiffPlan, snap: ConfigSnapshot): void {
     const pluginsByAgent = groupBy(snap.agentPlugins, (p) => p.agentId);
     const bindingsByAgent = groupBy(snap.channelBindings, (b) => b.agentId);
+    const graph = indexGraph(snap);
 
     for (const action of plan.actions) {
       try {
-        this.runAction(action, pluginsByAgent, bindingsByAgent);
+        this.runAction(action, pluginsByAgent, bindingsByAgent, graph);
       } catch (err) {
         // T022 — isolate per-action failures so a throw on one Agent never
         // aborts the rest of the diff.
@@ -289,6 +305,7 @@ export class OrchestratorRegistry {
     action: DiffAction,
     pluginsByAgent: Map<string, AgentPluginRow[]>,
     bindingsByAgent: Map<string, ChannelBindingRow[]>,
+    graph: GraphIndex,
   ): void {
     switch (action.kind) {
       case 'add': {
@@ -305,6 +322,9 @@ export class OrchestratorRegistry {
           plugins,
           bindings,
           built,
+          subAgents: graph.subAgentsByAgent.get(action.agent.id) ?? [],
+          toolGrants: graph.grantsByAgent.get(action.agent.id) ?? [],
+          skills: graph.skillsByAgent.get(action.agent.id) ?? [],
           memoryScope,
         });
         this.notifyBuilt(action.agent.slug, built, 'add');
@@ -345,6 +365,9 @@ export class OrchestratorRegistry {
           plugins,
           bindings,
           built,
+          subAgents: graph.subAgentsByAgent.get(action.agent.id) ?? [],
+          toolGrants: graph.grantsByAgent.get(action.agent.id) ?? [],
+          skills: graph.skillsByAgent.get(action.agent.id) ?? [],
           memoryScope,
         });
         this.notifyBuilt(action.agent.slug, built, 'rebuild');
@@ -367,6 +390,9 @@ export class OrchestratorRegistry {
           agent: action.agent,
           plugins,
           bindings,
+          subAgents: graph.subAgentsByAgent.get(action.agent.id) ?? [],
+          toolGrants: graph.grantsByAgent.get(action.agent.id) ?? [],
+          skills: graph.skillsByAgent.get(action.agent.id) ?? [],
           memoryScope,
         });
         this.log(`registry: agent metadata updated`, {
@@ -650,6 +676,54 @@ function actionSlug(action: DiffAction): string {
  */
 export function computeMemoryScope(agentSlug: string): readonly string[] {
   return orchestratorMemoryScope(agentSlug);
+}
+
+/**
+ * Per-agent index of the Agent Builder graph collections in a snapshot, so a
+ * diff action can attach an agent's sub-agents / tool grants / referenced
+ * skills in O(1). A grant is attributed to an agent when it targets the agent
+ * directly (`agentId`) or one of the agent's sub-agents (`subAgentId`).
+ */
+interface GraphIndex {
+  readonly subAgentsByAgent: Map<string, SubAgentRow[]>;
+  readonly grantsByAgent: Map<string, ToolGrantRow[]>;
+  readonly skillsByAgent: Map<string, SkillRow[]>;
+}
+
+function indexGraph(snap: ConfigSnapshot): GraphIndex {
+  const subAgents = snap.subAgents ?? [];
+  const grants = snap.toolGrants ?? [];
+  const skills = snap.skills ?? [];
+
+  const subAgentsByAgent = groupBy(subAgents, (s) => s.parentAgentId);
+  const subParent = new Map<string, string>(
+    subAgents.map((s) => [s.id, s.parentAgentId]),
+  );
+  const skillsById = new Map<string, SkillRow>(skills.map((s) => [s.id, s]));
+
+  const grantsByAgent = new Map<string, ToolGrantRow[]>();
+  for (const g of grants) {
+    const owner = g.agentId ?? (g.subAgentId ? subParent.get(g.subAgentId) : undefined);
+    if (!owner) continue;
+    const list = grantsByAgent.get(owner);
+    if (list) list.push(g);
+    else grantsByAgent.set(owner, [g]);
+  }
+
+  const skillsByAgent = new Map<string, SkillRow[]>();
+  for (const [agentId, subs] of subAgentsByAgent) {
+    const ids = new Set(
+      subs.map((s) => s.skillId).filter((id): id is string => !!id),
+    );
+    const refSkills: SkillRow[] = [];
+    for (const id of ids) {
+      const sk = skillsById.get(id);
+      if (sk) refSkills.push(sk);
+    }
+    skillsByAgent.set(agentId, refSkills);
+  }
+
+  return { subAgentsByAgent, grantsByAgent, skillsByAgent };
 }
 
 function groupBy<T, K>(

--- a/middleware/packages/harness-orchestrator/src/registry/subAgentTools.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/subAgentTools.ts
@@ -1,0 +1,158 @@
+import type Anthropic from '@anthropic-ai/sdk';
+import type { LocalSubAgentTool } from '@omadia/plugin-api';
+
+import { LocalSubAgent } from '../localSubAgent.js';
+import type {
+  McpManager} from '../mcp/mcpClient.js';
+import {
+  mcpToolToLocalSubAgentTool,
+  type McpServerConfig,
+} from '../mcp/mcpClient.js';
+import { createDomainTool, type DomainTool } from '../tools/domainQueryTool.js';
+
+import type {
+  SkillRow,
+  SubAgentRow,
+  ToolGrantRow,
+} from './agentGraphStore.js';
+
+/**
+ * Agent Builder P2/P4 — materialise an agent's DB-defined sub-agents into
+ * orchestrator `DomainTool`s.
+ *
+ * Each enabled `agent_subagents` row becomes a `LocalSubAgent` whose system
+ * prompt is its skill body (or an inline override), running on its own model
+ * with the tools granted to it (native tools resolved via the orchestrator's
+ * registry, MCP tools via the `McpManager`). The sub-agent is wrapped in a
+ * `DomainTool` (`ask_<name>`) so the parent orchestrator can delegate to it by
+ * tool name — the same mechanism plugin-provided domain agents use.
+ *
+ * Pure-ish factory: the only side effect is constructing `LocalSubAgent` /
+ * MCP-tool closures. Unit-testable by passing a fake client + resolvers.
+ */
+
+export interface SubAgentGraph {
+  readonly subAgents: readonly SubAgentRow[];
+  readonly toolGrants: readonly ToolGrantRow[];
+  readonly skills: readonly SkillRow[];
+}
+
+export interface SubAgentToolDeps {
+  readonly client: Anthropic;
+  readonly defaultModel: string;
+  readonly defaultMaxTokens: number;
+  readonly defaultMaxIterations: number;
+  /** Resolves an MCP server id → connection config (for mcp tool grants). */
+  readonly mcpServersById?: ReadonlyMap<string, McpServerConfig>;
+  /** Shared MCP connection pool. Required to honour mcp tool grants. */
+  readonly mcpManager?: McpManager;
+  /** Resolves a native tool name → a sub-agent-callable tool, if available. */
+  readonly nativeTool?: (toolRef: string) => LocalSubAgentTool | undefined;
+  readonly log?: (msg: string) => void;
+}
+
+export function buildSubAgentDomainTools(
+  graph: SubAgentGraph,
+  deps: SubAgentToolDeps,
+): DomainTool[] {
+  const skillsById = new Map(graph.skills.map((s) => [s.id, s]));
+  const grantsBySubAgent = new Map<string, ToolGrantRow[]>();
+  for (const g of graph.toolGrants) {
+    if (!g.subAgentId) continue;
+    const list = grantsBySubAgent.get(g.subAgentId);
+    if (list) list.push(g);
+    else grantsBySubAgent.set(g.subAgentId, [g]);
+  }
+
+  const tools: DomainTool[] = [];
+  for (const sub of graph.subAgents) {
+    if (sub.status !== 'enabled') continue;
+
+    const skillBody = sub.skillId
+      ? skillsById.get(sub.skillId)?.body
+      : undefined;
+    const systemPrompt =
+      sub.systemPromptOverride?.trim() ||
+      skillBody?.trim() ||
+      `You are the "${sub.name}" sub-agent. Answer the delegated question precisely using your available tools.`;
+
+    const subTools = resolveSubAgentTools(
+      grantsBySubAgent.get(sub.id) ?? [],
+      deps,
+    );
+
+    const local = new LocalSubAgent({
+      name: sub.name,
+      client: deps.client,
+      model: sub.model ?? deps.defaultModel,
+      maxTokens: sub.maxTokens ?? deps.defaultMaxTokens,
+      maxIterations: sub.maxIterations ?? deps.defaultMaxIterations,
+      systemPrompt,
+      tools: subTools,
+    });
+
+    tools.push(
+      createDomainTool({
+        name: subAgentToolName(sub.name),
+        description: `Delegate a focused question to the "${sub.name}" sub-agent.`,
+        agent: local,
+        domain: `subagent.${slugifyDomain(sub.name)}`,
+      }),
+    );
+  }
+  return tools;
+}
+
+function resolveSubAgentTools(
+  grants: readonly ToolGrantRow[],
+  deps: SubAgentToolDeps,
+): LocalSubAgentTool[] {
+  const out: LocalSubAgentTool[] = [];
+  for (const g of grants) {
+    if (g.toolKind === 'native') {
+      const t = deps.nativeTool?.(g.toolRef);
+      if (t) out.push(t);
+      else deps.log?.(`sub-agent tool: native tool "${g.toolRef}" not resolvable — skipped`);
+      continue;
+    }
+    // mcp
+    if (!g.mcpServerId || !deps.mcpManager || !deps.mcpServersById) {
+      deps.log?.(`sub-agent tool: mcp grant "${g.toolRef}" missing manager/server — skipped`);
+      continue;
+    }
+    const cfg = deps.mcpServersById.get(g.mcpServerId);
+    if (!cfg) {
+      deps.log?.(`sub-agent tool: mcp server ${g.mcpServerId} not found — skipped`);
+      continue;
+    }
+    const toolName = mcpToolNameFromRef(g.toolRef, cfg.name);
+    out.push(
+      mcpToolToLocalSubAgentTool(deps.mcpManager, cfg, { name: toolName }),
+    );
+  }
+  return out;
+}
+
+/** `toolRef` for an mcp grant is "<serverName>:<toolName>"; fall back to the
+ *  whole ref when it isn't prefixed. */
+export function mcpToolNameFromRef(toolRef: string, serverName: string): string {
+  const prefix = `${serverName}:`;
+  if (toolRef.startsWith(prefix)) return toolRef.slice(prefix.length);
+  const idx = toolRef.indexOf(':');
+  return idx >= 0 ? toolRef.slice(idx + 1) : toolRef;
+}
+
+/** `ask_<slug>` constrained to Anthropic's tool-name charset (`[a-zA-Z0-9_-]{1,64}`). */
+export function subAgentToolName(name: string): string {
+  const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '');
+  const full = `ask_${slug || 'subagent'}`;
+  return full.length <= 64 ? full : full.slice(0, 64);
+}
+
+/** Lowercase dotted-domain segment (matches PLUGIN_DOMAIN_REGEX once prefixed). */
+function slugifyDomain(name: string): string {
+  let s = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  if (s.length === 0) s = 'agent';
+  if (!/^[a-z]/.test(s)) s = `a${s}`;
+  return s;
+}

--- a/middleware/packages/plugin-api/src/agentGraph.ts
+++ b/middleware/packages/plugin-api/src/agentGraph.ts
@@ -1,0 +1,168 @@
+/**
+ * Agent Builder canvas — shared graph contract (P0).
+ *
+ * The visual builder is a thin renderer over the config graph: every node is
+ * a DB row, every edge is a relationship row. This module is the wire shape
+ * that the backend (`GET /api/v1/operator/agents/:slug/graph`) serialises and
+ * the web-ui canvas (xyflow) renders/mutates. Pure types — no runtime deps —
+ * so both sides import the same contract from the plugin-api surface.
+ *
+ * Edge semantics (what drawing a connection does):
+ *   channel_bind  Channel  → Agent       create channel_bindings row
+ *   subagent      Agent    → Sub-Agent   attach agent_subagents row
+ *   skill         Sub-Agent→ Skill       set agent_subagents.skill_id
+ *   tool_grant    Agent|Sub→ Tool|MCP    insert agent_tool_grants row
+ *   schedule      Schedule → Agent       insert agent_schedules row
+ */
+
+/** Cosmetic canvas coordinate persisted alongside the node's row. */
+export interface CanvasPosition {
+  readonly x: number;
+  readonly y: number;
+}
+
+// ── model routing (persisted on agents.model_routing) ──────────────────────
+
+export type ModelRoutingMode = 'single' | 'triage';
+
+/** A condition that escalates a triage-routed turn from the cheap to the main model. */
+export type EscalationTrigger = 'tool_error' | 'long_context' | 'low_confidence';
+
+export interface ModelRoutingConfig {
+  readonly mode: ModelRoutingMode;
+  /** Primary / complex-turn model id, e.g. 'claude-opus-4-8'. */
+  readonly main: string;
+  /** Cheap classifier model that decides simple-vs-complex per turn, e.g.
+   *  'claude-haiku-4-5'. Used when mode='triage'. */
+  readonly triage?: string;
+  /** Model for simple turns under triage, e.g. 'claude-sonnet-4-6'.
+   *  Defaults to `main` when omitted (degenerate triage = no savings). */
+  readonly simple?: string;
+  /** Conditions under which a triage turn escalates to `main`. */
+  readonly escalateOn?: readonly EscalationTrigger[];
+}
+
+// ── node DTOs ───────────────────────────────────────────────────────────────
+
+export interface AgentNode {
+  readonly id: string;
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly privacyProfile: 'strict' | 'default';
+  readonly status: 'enabled' | 'disabled';
+  readonly modelRouting: ModelRoutingConfig | null;
+  readonly position: CanvasPosition | null;
+}
+
+export interface ChannelNode {
+  readonly channelType: string;
+  readonly channelKey: string;
+  readonly position: CanvasPosition | null;
+}
+
+export interface SubAgentNode {
+  readonly id: string;
+  readonly parentAgentId: string;
+  readonly name: string;
+  readonly skillId: string | null;
+  readonly model: string | null;
+  readonly maxTokens: number | null;
+  readonly maxIterations: number | null;
+  readonly systemPromptOverride: string | null;
+  readonly status: 'enabled' | 'disabled';
+  readonly position: CanvasPosition | null;
+}
+
+export type SkillSource = 'db' | 'file';
+
+export interface SkillNode {
+  readonly id: string;
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly body: string;
+  readonly source: SkillSource;
+}
+
+export type ToolKind = 'native' | 'mcp';
+
+/** A tool granted to an agent or sub-agent (one grant = one canvas edge). */
+export interface ToolGrantNode {
+  readonly id: string;
+  /** Set when the grant belongs to the top-level agent. */
+  readonly agentId: string | null;
+  /** Set when the grant belongs to a sub-agent. */
+  readonly subAgentId: string | null;
+  readonly toolKind: ToolKind;
+  /** Native tool name, or "<mcpServerName>:<toolName>" for MCP tools. */
+  readonly toolRef: string;
+  readonly mcpServerId: string | null;
+}
+
+export type McpTransport = 'stdio' | 'http' | 'sse';
+
+export interface McpDiscoveredTool {
+  readonly name: string;
+  readonly description?: string;
+  readonly inputSchema?: Record<string, unknown>;
+}
+
+export interface McpServerNode {
+  readonly id: string;
+  readonly name: string;
+  readonly transport: McpTransport;
+  readonly endpoint: string | null;
+  readonly status: 'enabled' | 'disabled';
+  readonly lastDiscoveredAt: string | null;
+  readonly discoveredTools: readonly McpDiscoveredTool[];
+}
+
+export interface ScheduleNode {
+  readonly id: string;
+  readonly agentId: string;
+  readonly cron: string;
+  readonly timezone: string;
+  readonly payload: Record<string, unknown>;
+  readonly status: 'enabled' | 'disabled';
+  readonly lastRunAt: string | null;
+}
+
+// ── edges ─────────────────────────────────────────────────────────────────
+
+export type EdgeKind =
+  | 'channel_bind'
+  | 'subagent'
+  | 'skill'
+  | 'tool_grant'
+  | 'schedule';
+
+export interface CanvasEdge {
+  /** Stable id (the underlying row id, or a composite key for channel binds). */
+  readonly id: string;
+  readonly kind: EdgeKind;
+  /** Canvas node id of the edge source. */
+  readonly source: string;
+  /** Canvas node id of the edge target. */
+  readonly target: string;
+}
+
+/** Full canvas payload for a single agent. */
+export interface AgentGraph {
+  readonly agent: AgentNode;
+  readonly channels: readonly ChannelNode[];
+  readonly subAgents: readonly SubAgentNode[];
+  readonly skills: readonly SkillNode[];
+  readonly tools: readonly ToolGrantNode[];
+  readonly mcpServers: readonly McpServerNode[];
+  readonly schedules: readonly ScheduleNode[];
+  readonly edges: readonly CanvasEdge[];
+}
+
+/** Body of POST /api/v1/operator/agents/:slug/graph/edges. */
+export interface CreateEdgeRequest {
+  readonly kind: EdgeKind;
+  readonly source: string;
+  readonly target: string;
+  readonly config?: Record<string, unknown>;
+}

--- a/middleware/packages/plugin-api/src/index.ts
+++ b/middleware/packages/plugin-api/src/index.ts
@@ -13,6 +13,12 @@ export * from './targetRef.js';
 // mutability derivation. Consumed by the canvas orchestrator (PR-9).
 export * from './writeCapabilities.js';
 
+// Agent Builder canvas (P0): the shared graph contract — AgentGraph, node
+// DTOs, GraphEdge/EdgeKind, ModelRoutingConfig. The editable visual builder
+// is a thin renderer over the config graph; backend serialises this shape
+// from the registry tables and the web-ui xyflow canvas renders/mutates it.
+export * from './agentGraph.js';
+
 // S+11-1: Knowledge-graph capability contract (interface + DTOs + node-id
 // helpers) lives on the plugin-api surface. Both the in-memory and the Neon
 // `knowledgeGraph@1` provider plugins (S+11-2 split of @omadia/knowledge-graph)

--- a/middleware/src/agents/subAgentToolHydration.ts
+++ b/middleware/src/agents/subAgentToolHydration.ts
@@ -1,0 +1,123 @@
+/**
+ * Agent Builder P2/P4 — hydrate an agent's orchestrator with the DomainTools
+ * built from its DB-defined sub-agents (`agent_subagents` + `agent_tool_grants`
+ * + `skills`).
+ *
+ * Bridges the registry's `ActiveAgent` graph slices into
+ * `buildSubAgentDomainTools` and registers the result on the built
+ * orchestrator — the same `registerDomainTool` seam the kernel uses for
+ * plugin-provided domain agents. Adapters here turn:
+ *   - a `mcp_servers` row → an `McpServerConfig` (header coercion), and
+ *   - a native registry entry → a `LocalSubAgentTool` (so a sub-agent can call
+ *     a top-level native tool that was granted to it).
+ */
+
+import type Anthropic from '@anthropic-ai/sdk';
+import type { LocalSubAgentTool } from '@omadia/plugin-api';
+import {
+  buildSubAgentDomainTools,
+  type McpManager,
+  type McpServerConfig,
+  type McpServerRow,
+  type NativeToolRegistry,
+  type SkillRow,
+  type SubAgentRow,
+  type ToolGrantRow,
+} from '@omadia/orchestrator';
+
+/** Minimal structural view of a BuiltOrchestrator's domain-tool surface. */
+interface DomainToolHost {
+  readonly orchestrator: {
+    hasDomainTool(name: string): boolean;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registerDomainTool(tool: any): void;
+  };
+}
+
+export interface SubAgentGraphSlice {
+  readonly subAgents: readonly SubAgentRow[];
+  readonly toolGrants: readonly ToolGrantRow[];
+  readonly skills: readonly SkillRow[];
+}
+
+export interface HydrateDeps {
+  readonly client: Anthropic;
+  readonly nativeToolRegistry: NativeToolRegistry;
+  readonly mcpManager: McpManager;
+  readonly mcpServers: readonly McpServerRow[];
+  readonly defaultModel: string;
+  readonly defaultMaxTokens?: number;
+  readonly defaultMaxIterations?: number;
+  readonly log?: (msg: string) => void;
+}
+
+/** Coerce a `mcp_servers` row into the client config the manager consumes. */
+export function mcpRowToConfig(row: McpServerRow): McpServerConfig {
+  const headers: Record<string, string> = {};
+  for (const [k, v] of Object.entries(row.headers ?? {})) {
+    if (typeof v === 'string') headers[k] = v;
+  }
+  return {
+    id: row.id,
+    name: row.name,
+    transport: row.transport,
+    endpoint: row.endpoint,
+    ...(Object.keys(headers).length > 0 ? { headers } : {}),
+  };
+}
+
+/** Adapt a top-level native tool (handler + spec) into a sub-agent tool. */
+export function adaptNativeToolForSubAgent(
+  registry: NativeToolRegistry,
+  toolRef: string,
+): LocalSubAgentTool | undefined {
+  const reg = registry.get(toolRef);
+  if (!reg?.handler || !reg.spec) return undefined;
+  const handler = reg.handler;
+  return {
+    spec: {
+      name: reg.spec.name,
+      description: reg.spec.description,
+      input_schema: {
+        type: 'object',
+        properties: reg.spec.input_schema.properties,
+        required: [...(reg.spec.input_schema.required ?? [])],
+      },
+    },
+    handle: (input: unknown) => handler(input),
+  };
+}
+
+/**
+ * Build + register the sub-agent DomainTools for one agent. Returns the number
+ * of tools newly registered (skips names already present so it is safe to call
+ * on both initial hydrate and post-rebuild).
+ */
+export function registerDbSubAgentTools(
+  slice: SubAgentGraphSlice,
+  built: DomainToolHost,
+  deps: HydrateDeps,
+): number {
+  if (slice.subAgents.length === 0) return 0;
+  const mcpServersById = new Map<string, McpServerConfig>(
+    deps.mcpServers.map((r) => [r.id, mcpRowToConfig(r)]),
+  );
+  const tools = buildSubAgentDomainTools(slice, {
+    client: deps.client,
+    defaultModel: deps.defaultModel,
+    defaultMaxTokens: deps.defaultMaxTokens ?? 4096,
+    defaultMaxIterations: deps.defaultMaxIterations ?? 8,
+    mcpManager: deps.mcpManager,
+    mcpServersById,
+    nativeTool: (ref) => adaptNativeToolForSubAgent(deps.nativeToolRegistry, ref),
+    ...(deps.log ? { log: deps.log } : {}),
+  });
+  let n = 0;
+  for (const t of tools) {
+    if (!built.orchestrator.hasDomainTool(t.name)) {
+      built.orchestrator.registerDomainTool(t);
+      n += 1;
+    }
+  }
+  return n;
+}

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -1680,6 +1680,8 @@ async function main(): Promise<void> {
         graphPool ? new AgentGraphStore(graphPool) : undefined,
       getRegistry: () =>
         serviceRegistry.get<MultiOrchestratorRegistry>('orchestratorRegistry'),
+      getNativeTools: () => nativeToolRegistry.list(),
+      getInstalledPlugins: () => installedRegistry.list().map((a) => a.id),
     }),
   );
   console.log(

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -1682,6 +1682,7 @@ async function main(): Promise<void> {
         serviceRegistry.get<MultiOrchestratorRegistry>('orchestratorRegistry'),
       getNativeTools: () => nativeToolRegistry.list(),
       getInstalledPlugins: () => installedRegistry.list().map((a) => a.id),
+      getChannelDirectory: () => channelDirectoryRegistry,
     }),
   );
   console.log(

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -11,6 +11,8 @@ import { createAdminRouter } from './routes/admin.js';
 import { createChatRouter } from './routes/chat.js';
 import { createOperatorAgentsRouter } from './routes/operatorAgents.js';
 import { createOperatorChannelsRouter } from './routes/operatorChannels.js';
+import { createAgentBuilderRouter } from './routes/agentBuilder.js';
+import { ScheduleWorker } from './scheduler/scheduleWorker.js';
 import type {
   ConfigStore as MultiOrchestratorConfigStore,
   OrchestratorRegistry as MultiOrchestratorRegistry,
@@ -177,6 +179,9 @@ import { UiRouteCatalog } from './platform/uiRouteCatalog.js';
 import { ServiceRegistry } from './platform/serviceRegistry.js';
 import { TurnHookRegistry } from './platform/turnHookRegistry.js';
 import { NativeToolRegistry } from '@omadia/orchestrator';
+import { McpManager } from '@omadia/orchestrator';
+import { AgentGraphStore } from '@omadia/orchestrator';
+import { registerDbSubAgentTools } from './agents/subAgentToolHydration.js';
 import {
   DATA_DIR,
   DEV_VAULT_KEY_PATH,
@@ -1253,6 +1258,37 @@ async function main(): Promise<void> {
       const currentDomainTools = (): DomainTool[] =>
         mergeDomainTools(domainTools, dynamicAgentRuntime.activeDomainTools());
 
+      // Agent Builder P2/P4 — shared MCP connection pool + a closure that
+      // materialises each agent's DB-defined sub-agents into DomainTools and
+      // registers them on its orchestrator. Called on initial hydrate AND
+      // from `onAgentBuilt` so a rebuilt agent re-acquires its sub-agents.
+      const mcpManager = new McpManager();
+      const SUBAGENT_DEFAULT_MODEL = 'claude-sonnet-4-6';
+      const hydrateSubAgentTools = (
+        slug: string,
+        built: { orchestrator: { hasDomainTool(n: string): boolean; registerDomainTool(t: DomainTool): void } },
+      ): number => {
+        const entry = registryForHydrate.get(slug);
+        if (!entry) return 0;
+        const mcpServers = registryForHydrate.currentSnapshot()?.mcpServers ?? [];
+        return registerDbSubAgentTools(
+          {
+            subAgents: entry.subAgents,
+            toolGrants: entry.toolGrants,
+            skills: entry.skills,
+          },
+          built,
+          {
+            client,
+            nativeToolRegistry,
+            mcpManager,
+            mcpServers,
+            defaultModel: SUBAGENT_DEFAULT_MODEL,
+            log: (m: string) => console.log(`[middleware] ${m}`),
+          },
+        );
+      };
+
       let attached = 0;
       for (const entry of registryForHydrate.list()) {
         for (const t of scopeDomainToolsToPlugins(
@@ -1264,6 +1300,7 @@ async function main(): Promise<void> {
             attached += 1;
           }
         }
+        attached += hydrateSubAgentTools(entry.agent.slug, entry.built);
       }
       console.log(
         `[middleware] registry orchestrators: hydrated with ${String(attached)} domain-tool registrations across ${String(registryForHydrate.list().length)} agent(s) (per-Agent plugin-scoped)`,
@@ -1287,8 +1324,9 @@ async function main(): Promise<void> {
             built.orchestrator.registerDomainTool(t);
           }
         }
+        const subTools = hydrateSubAgentTools(slug, built);
         console.log(
-          `[middleware] registry: orchestrator for "${slug}" hydrated with ${String(tools.length)} domain-tool(s) (per-Agent plugin-scoped)`,
+          `[middleware] registry: orchestrator for "${slug}" hydrated with ${String(tools.length)} domain-tool(s) + ${String(subTools)} sub-agent tool(s) (per-Agent plugin-scoped)`,
         );
       });
 
@@ -1626,6 +1664,41 @@ async function main(): Promise<void> {
   console.log(
     '[middleware] operator-channels endpoints ready at /api/v1/operator/channels/* (auth-gated)',
   );
+
+  // Agent Builder canvas backend (P1/P2). Mounted at the /api/v1/operator
+  // parent so the /agents/:slug/graph|subagents|… subpaths fall through here
+  // after the operator-agents router. 503s without a graphPool (in-memory KG
+  // backend). Writes route through ConfigStore/AgentGraphStore → notify →
+  // registry.reload(), and we reload inline so the response reflects the diff.
+  app.use(
+    '/api/v1/operator',
+    requireAuth,
+    createAgentBuilderRouter({
+      getConfigStore: () =>
+        serviceRegistry.get<MultiOrchestratorConfigStore>('configStore'),
+      getGraphStore: () =>
+        graphPool ? new AgentGraphStore(graphPool) : undefined,
+      getRegistry: () =>
+        serviceRegistry.get<MultiOrchestratorRegistry>('orchestratorRegistry'),
+    }),
+  );
+  console.log(
+    `[middleware] agent-builder endpoints ready at /api/v1/operator/{agents/:slug/graph,skills,mcp-servers,…} (auth-gated, graphPool=${graphPool ? 'on' : 'off'})`,
+  );
+
+  // Agent Builder schedule worker (P6) — fires cron-scheduled agent turns.
+  // Only with a Neon graphPool (the agent_schedules table lives there).
+  if (graphPool) {
+    const schedulePool = graphPool;
+    const scheduleWorker = new ScheduleWorker({
+      getGraphStore: () => new AgentGraphStore(schedulePool),
+      getRegistry: () =>
+        serviceRegistry.get<MultiOrchestratorRegistry>('orchestratorRegistry'),
+      log: (m, f) => console.log(`[middleware] ${m}`, f ?? ''),
+    });
+    scheduleWorker.start();
+    console.log('[middleware] agent-builder schedule worker started (1-min poll)');
+  }
 
   // Slice 10 — near-duplicate MK workflow. Mirrors the Slice 9
   // mounting pattern: detector + bulk are optional, route 503s when

--- a/middleware/src/routes/agentBuilder.ts
+++ b/middleware/src/routes/agentBuilder.ts
@@ -33,6 +33,10 @@ export interface AgentBuilderRouterOptions {
   readonly getConfigStore: () => ConfigStore | undefined;
   readonly getGraphStore: () => AgentGraphStore | undefined;
   readonly getRegistry: () => OrchestratorRegistry | undefined;
+  /** Names of the orchestrator-native tools available to every agent. */
+  readonly getNativeTools?: () => readonly string[];
+  /** Ids of every installed plugin (for the per-agent plugin picker). */
+  readonly getInstalledPlugins?: () => readonly string[];
 }
 
 interface Live {
@@ -93,6 +97,7 @@ export function createAgentBuilderRouter(
       const plugins = (active?.plugins ?? [])
         .filter((p) => p.enabled)
         .map((p) => ({ id: p.pluginId }));
+      const nativeTools = options.getNativeTools?.() ?? [];
       res.json(
         assembleGraph(
           agent,
@@ -103,6 +108,7 @@ export function createAgentBuilderRouter(
           servers,
           schedules,
           plugins,
+          nativeTools,
         ),
       );
     } catch (err) {
@@ -235,6 +241,61 @@ export function createAgentBuilderRouter(
       fail(res, err);
     }
   });
+
+  // ── plugins (per-agent enable/disable) ──────────────────────────────────────
+  router.get(
+    '/agents/:slug/installable-plugins',
+    async (req: Request, res: Response) => {
+      const l = live(res);
+      if (!l) return;
+      try {
+        const agent = await agentOr404(l, str(req.params.slug), res);
+        if (!agent) return;
+        const installed = options.getInstalledPlugins?.() ?? [];
+        const enabled = new Set(
+          (await l.config.listAgentPlugins(agent.id))
+            .filter((p) => p.enabled)
+            .map((p) => p.pluginId),
+        );
+        res.json({ plugins: installed.filter((id) => !enabled.has(id)) });
+      } catch (err) {
+        fail(res, err);
+      }
+    },
+  );
+
+  router.post('/agents/:slug/plugins', async (req: Request, res: Response) => {
+    const l = live(res);
+    if (!l) return;
+    try {
+      const agent = await agentOr404(l, str(req.params.slug), res);
+      if (!agent) return;
+      const pluginId = String((req.body ?? {}).pluginId ?? '').trim();
+      if (!pluginId) throw new ConfigValidationError('pluginId is required');
+      await l.config.upsertAgentPlugin(agent.id, { pluginId, enabled: true });
+      await reload(l);
+      res.json({ id: pluginId });
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  router.delete(
+    '/agents/:slug/plugins/:pluginId',
+    async (req: Request, res: Response) => {
+      const l = live(res);
+      if (!l) return;
+      try {
+        const agent = await agentOr404(l, str(req.params.slug), res);
+        if (!agent) return;
+        await l.config.removeAgentPlugin(agent.id, str(req.params.pluginId));
+        await reload(l);
+        res.status(204).end();
+      } catch (err) {
+        fail(res, err);
+      }
+    },
+  );
 
   // ── skills (global) ────────────────────────────────────────────────────────
   router.get('/skills', async (_req: Request, res: Response) => {
@@ -492,6 +553,7 @@ function assembleGraph(
   servers: readonly McpServerRow[],
   schedules: readonly ScheduleRow[],
   plugins: readonly { id: string }[] = [],
+  nativeTools: readonly string[] = [],
 ) {
   const mySubs = subAgents.filter((s) => s.parentAgentId === agent.id);
   const subIds = new Set(mySubs.map((s) => s.id));
@@ -564,6 +626,7 @@ function assembleGraph(
     mcpServers: servers.map(mcpNode),
     schedules: schedules.map(scheduleNode),
     plugins: plugins.map((p) => ({ id: p.id })),
+    nativeTools: [...nativeTools],
     edges,
   };
 }

--- a/middleware/src/routes/agentBuilder.ts
+++ b/middleware/src/routes/agentBuilder.ts
@@ -86,8 +86,24 @@ export function createAgentBuilderRouter(
           l.graph.listMcpServers(),
           l.graph.listSchedulesForAgent(agent.id),
         ]);
+      // Current-system representation: the agent's live enabled plugins (the
+      // real capability surface), surfaced as read-only nodes so the canvas
+      // reflects what the agent already is — not just the editable graph layer.
+      const active = l.registry?.get(agent.slug);
+      const plugins = (active?.plugins ?? [])
+        .filter((p) => p.enabled)
+        .map((p) => ({ id: p.pluginId }));
       res.json(
-        assembleGraph(agent, bindings, subAgents, skills, grants, servers, schedules),
+        assembleGraph(
+          agent,
+          bindings,
+          subAgents,
+          skills,
+          grants,
+          servers,
+          schedules,
+          plugins,
+        ),
       );
     } catch (err) {
       fail(res, err);
@@ -475,6 +491,7 @@ function assembleGraph(
   grants: readonly ToolGrantRow[],
   servers: readonly McpServerRow[],
   schedules: readonly ScheduleRow[],
+  plugins: readonly { id: string }[] = [],
 ) {
   const mySubs = subAgents.filter((s) => s.parentAgentId === agent.id);
   const subIds = new Set(mySubs.map((s) => s.id));
@@ -525,6 +542,14 @@ function assembleGraph(
       target: `agent:${agent.id}`,
     });
   }
+  for (const p of plugins) {
+    edges.push({
+      id: `plugin:${p.id}`,
+      kind: 'plugin',
+      source: `plugin:${p.id}`,
+      target: `agent:${agent.id}`,
+    });
+  }
 
   return {
     agent: agentNode(agent),
@@ -538,6 +563,7 @@ function assembleGraph(
     tools: myGrants.map(toolGrantNode),
     mcpServers: servers.map(mcpNode),
     schedules: schedules.map(scheduleNode),
+    plugins: plugins.map((p) => ({ id: p.id })),
     edges,
   };
 }

--- a/middleware/src/routes/agentBuilder.ts
+++ b/middleware/src/routes/agentBuilder.ts
@@ -1,0 +1,669 @@
+/**
+ * Agent Builder canvas — REST surface (P1/P2).
+ *
+ * Backs the editable `/admin/builder` canvas. Mounted at `/api/v1/operator`
+ * (after the operator-agents router, so the `/agents/:slug/graph|subagents|…`
+ * subpaths fall through to here). Every write routes through `ConfigStore` /
+ * `AgentGraphStore`, whose triggers fire the `agents_changed` notify → the
+ * registry hot-reloads; we also call `registry.reload()` inline so the
+ * response already reflects the applied diff.
+ *
+ * Node-id scheme (must match web-ui `graphMapping.nodeId`):
+ *   channel:<type>:<key> · agent:<id> · subagent:<id> · skill:<id> ·
+ *   tool:<ref> · mcp:<id> · schedule:<id>
+ */
+
+import {
+  ConfigValidationError,
+  type AgentGraphStore,
+  type AgentRow,
+  type ConfigStore,
+  type McpServerConfig,
+  type McpServerRow,
+  type OrchestratorRegistry,
+  type ScheduleRow,
+  type SkillRow,
+  type SubAgentRow,
+  type ToolGrantRow,
+} from '@omadia/orchestrator';
+import { McpManager } from '@omadia/orchestrator';
+import { Router, type Request, type Response } from 'express';
+
+export interface AgentBuilderRouterOptions {
+  readonly getConfigStore: () => ConfigStore | undefined;
+  readonly getGraphStore: () => AgentGraphStore | undefined;
+  readonly getRegistry: () => OrchestratorRegistry | undefined;
+}
+
+interface Live {
+  readonly config: ConfigStore;
+  readonly graph: AgentGraphStore;
+  readonly registry: OrchestratorRegistry | undefined;
+}
+
+export function createAgentBuilderRouter(
+  options: AgentBuilderRouterOptions,
+): Router {
+  const router = Router();
+  const mcp = new McpManager();
+
+  function live(res: Response): Live | undefined {
+    const config = options.getConfigStore();
+    const graph = options.getGraphStore();
+    if (!config || !graph) {
+      res.status(503).json({ error: 'multi_orchestrator_unavailable' });
+      return undefined;
+    }
+    return { config, graph, registry: options.getRegistry() };
+  }
+
+  async function agentOr404(
+    l: Live,
+    slug: string,
+    res: Response,
+  ): Promise<AgentRow | undefined> {
+    const agent = await l.config.getAgentBySlug(slug);
+    if (!agent) {
+      res.status(404).json({ error: 'agent_not_found', slug });
+      return undefined;
+    }
+    return agent;
+  }
+
+  // ── GET graph ──────────────────────────────────────────────────────────
+  router.get('/agents/:slug/graph', async (req: Request, res: Response) => {
+    const l = live(res);
+    if (!l) return;
+    try {
+      const agent = await agentOr404(l, req.params.slug ?? '', res);
+      if (!agent) return;
+      const [bindings, subAgents, skills, grants, servers, schedules] =
+        await Promise.all([
+          l.config.listChannelBindingsForAgent(agent.id),
+          l.graph.listAllSubAgents(),
+          l.graph.listSkills(),
+          l.graph.listAllToolGrants(),
+          l.graph.listMcpServers(),
+          l.graph.listSchedulesForAgent(agent.id),
+        ]);
+      res.json(
+        assembleGraph(agent, bindings, subAgents, skills, grants, servers, schedules),
+      );
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  // ── edges ──────────────────────────────────────────────────────────────
+  router.post('/agents/:slug/graph/edges', async (req: Request, res: Response) => {
+    const l = live(res);
+    if (!l) return;
+    try {
+      const agent = await agentOr404(l, req.params.slug ?? '', res);
+      if (!agent) return;
+      const edge = await createEdge(l, agent, req.body ?? {});
+      const diff = await reload(l);
+      res.json({ edge, diff });
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  router.delete(
+    '/agents/:slug/graph/edges/:id',
+    async (req: Request, res: Response) => {
+      const l = live(res);
+      if (!l) return;
+      try {
+        const kind = String(req.query['kind'] ?? '');
+        await deleteEdge(l, decodeURIComponent(req.params.id ?? ''), kind);
+        await reload(l);
+        res.status(204).end();
+      } catch (err) {
+        fail(res, err);
+      }
+    },
+  );
+
+  // ── sub-agents ───────────────────────────────────────────────────────────
+  router.post('/agents/:slug/subagents', async (req: Request, res: Response) => {
+    const l = live(res);
+    if (!l) return;
+    try {
+      const agent = await agentOr404(l, req.params.slug ?? '', res);
+      if (!agent) return;
+      const b = req.body ?? {};
+      const row = await l.graph.createSubAgent({
+        parentAgentId: agent.id,
+        name: String(b.name ?? '').trim(),
+        skillId: b.skillId ?? null,
+        model: b.model ?? null,
+        maxTokens: b.maxTokens ?? null,
+        maxIterations: b.maxIterations ?? null,
+        systemPromptOverride: b.systemPromptOverride ?? null,
+        status: b.status ?? 'enabled',
+        position: b.position ?? null,
+      });
+      await reload(l);
+      res.json(subAgentNode(row));
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  router.patch(
+    '/agents/:slug/subagents/:id',
+    async (req: Request, res: Response) => {
+      const l = live(res);
+      if (!l) return;
+      try {
+        const row = await l.graph.updateSubAgent(req.params.id ?? '', req.body ?? {});
+        await reload(l);
+        res.json(subAgentNode(row));
+      } catch (err) {
+        fail(res, err);
+      }
+    },
+  );
+
+  router.delete(
+    '/agents/:slug/subagents/:id',
+    async (req: Request, res: Response) => {
+      const l = live(res);
+      if (!l) return;
+      try {
+        await l.graph.deleteSubAgent(req.params.id ?? '');
+        await reload(l);
+        res.status(204).end();
+      } catch (err) {
+        fail(res, err);
+      }
+    },
+  );
+
+  // ── model routing + positions ────────────────────────────────────────────
+  router.patch(
+    '/agents/:slug/model-routing',
+    async (req: Request, res: Response) => {
+      const l = live(res);
+      if (!l) return;
+      try {
+        const agent = await agentOr404(l, req.params.slug ?? '', res);
+        if (!agent) return;
+        const routing = (req.body ?? {}).modelRouting ?? null;
+        const updated = await l.config.setModelRouting(agent.id, routing);
+        await reload(l);
+        res.json(agentNode(updated));
+      } catch (err) {
+        fail(res, err);
+      }
+    },
+  );
+
+  router.patch('/agents/:slug/positions', async (req: Request, res: Response) => {
+    const l = live(res);
+    if (!l) return;
+    try {
+      const agent = await agentOr404(l, req.params.slug ?? '', res);
+      if (!agent) return;
+      const b = req.body ?? {};
+      if (b.agent) await l.config.setCanvasPosition(agent.id, b.agent);
+      for (const s of b.subAgents ?? []) {
+        await l.graph.updateSubAgent(s.id, { position: s.position });
+      }
+      for (const c of b.channels ?? []) {
+        await l.config.setChannelBindingPosition(c.channelType, c.channelKey, c.position);
+      }
+      res.status(204).end(); // positions are cosmetic — no reload needed
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  // ── skills (global) ────────────────────────────────────────────────────────
+  router.get('/skills', async (_req: Request, res: Response) => {
+    const l = live(res);
+    if (!l) return;
+    try {
+      const skills = (await l.graph.listSkills()).map(skillNode);
+      res.json({ skills });
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  router.post('/skills', async (req: Request, res: Response) => {
+    const l = live(res);
+    if (!l) return;
+    try {
+      const b = req.body ?? {};
+      const row = await l.graph.upsertSkill({
+        slug: String(b.slug ?? '').trim(),
+        name: String(b.name ?? '').trim(),
+        description: b.description ?? null,
+        body: b.body ?? '',
+      });
+      res.json(skillNode(row));
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  router.patch('/skills/:id', async (req: Request, res: Response) => {
+    const l = live(res);
+    if (!l) return;
+    try {
+      const row = await l.graph.updateSkill(req.params.id ?? '', req.body ?? {});
+      await reload(l);
+      res.json(skillNode(row));
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  router.delete('/skills/:id', async (req: Request, res: Response) => {
+    const l = live(res);
+    if (!l) return;
+    try {
+      await l.graph.deleteSkill(req.params.id ?? '');
+      await reload(l);
+      res.status(204).end();
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  // ── mcp servers ───────────────────────────────────────────────────────────
+  router.get('/mcp-servers', async (_req: Request, res: Response) => {
+    const l = live(res);
+    if (!l) return;
+    try {
+      res.json({ servers: (await l.graph.listMcpServers()).map(mcpNode) });
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  router.post('/mcp-servers', async (req: Request, res: Response) => {
+    const l = live(res);
+    if (!l) return;
+    try {
+      const b = req.body ?? {};
+      const row = await l.graph.createMcpServer({
+        name: String(b.name ?? '').trim(),
+        transport: b.transport,
+        endpoint: b.endpoint ?? null,
+        status: b.status ?? 'enabled',
+      });
+      res.json(mcpNode(row));
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  router.delete('/mcp-servers/:id', async (req: Request, res: Response) => {
+    const l = live(res);
+    if (!l) return;
+    try {
+      await l.graph.deleteMcpServer(req.params.id ?? '');
+      await reload(l);
+      res.status(204).end();
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  router.post('/mcp-servers/:id/discover', async (req: Request, res: Response) => {
+    const l = live(res);
+    if (!l) return;
+    try {
+      const servers = await l.graph.listMcpServers();
+      const row = servers.find((s) => s.id === req.params.id);
+      if (!row) {
+        res.status(404).json({ error: 'mcp_server_not_found' });
+        return;
+      }
+      const tools = await mcp.listTools(toMcpConfig(row));
+      await l.graph.setMcpDiscoveredTools(row.id, tools);
+      const updated = (await l.graph.listMcpServers()).find((s) => s.id === row.id);
+      res.json(updated ? mcpNode(updated) : mcpNode(row));
+    } catch (err) {
+      // Discovery talks to an external process — report as a 502, not a 5xx crash.
+      res.status(502).json({ error: 'mcp_discover_failed', message: msg(err) });
+    }
+  });
+
+  // ── schedules ─────────────────────────────────────────────────────────────
+  router.get('/agents/:slug/schedules', async (req: Request, res: Response) => {
+    const l = live(res);
+    if (!l) return;
+    try {
+      const agent = await agentOr404(l, req.params.slug ?? '', res);
+      if (!agent) return;
+      const schedules = (await l.graph.listSchedulesForAgent(agent.id)).map(
+        scheduleNode,
+      );
+      res.json({ schedules });
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  router.post('/agents/:slug/schedules', async (req: Request, res: Response) => {
+    const l = live(res);
+    if (!l) return;
+    try {
+      const agent = await agentOr404(l, req.params.slug ?? '', res);
+      if (!agent) return;
+      const b = req.body ?? {};
+      const row = await l.graph.createSchedule({
+        agentId: agent.id,
+        cron: String(b.cron ?? '').trim(),
+        timezone: b.timezone ?? 'UTC',
+        payload: b.payload ?? {},
+        status: b.status ?? 'enabled',
+      });
+      res.json(scheduleNode(row));
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  router.delete(
+    '/agents/:slug/schedules/:id',
+    async (req: Request, res: Response) => {
+      const l = live(res);
+      if (!l) return;
+      try {
+        await l.graph.deleteSchedule(req.params.id ?? '');
+        res.status(204).end();
+      } catch (err) {
+        fail(res, err);
+      }
+    },
+  );
+
+  return router;
+}
+
+// ── edge dispatchers ─────────────────────────────────────────────────────────
+
+async function createEdge(
+  l: Live,
+  agent: AgentRow,
+  body: Record<string, unknown>,
+): Promise<{ id: string; kind: string; source: string; target: string }> {
+  const kind = String(body['kind'] ?? '');
+  const source = String(body['source'] ?? '');
+  const target = String(body['target'] ?? '');
+  const config = (body['config'] as Record<string, unknown> | undefined) ?? {};
+
+  switch (kind) {
+    case 'channel_bind': {
+      const { channelType, channelKey } = parseChannel(source);
+      await l.config.createChannelBinding(agent.id, { channelType, channelKey });
+      return { id: `channel_bind:${channelType}:${channelKey}`, kind, source, target };
+    }
+    case 'skill': {
+      const subId = idAfter(source, 'subagent');
+      const skillId = idAfter(target, 'skill');
+      await l.graph.setSubAgentSkill(subId, skillId);
+      return { id: `skill:${subId}`, kind, source: `subagent:${subId}`, target };
+    }
+    case 'tool_grant': {
+      const onAgent = source.startsWith('agent:');
+      const subAgentId = onAgent ? null : idAfter(source, 'subagent');
+      const toolKind = (config['toolKind'] as 'native' | 'mcp') ?? 'native';
+      const toolRef = String(config['toolRef'] ?? idAfter(target, 'tool'));
+      const mcpServerId = (config['mcpServerId'] as string | null) ?? null;
+      if (!toolRef) {
+        throw new ConfigValidationError('tool_grant requires a toolRef');
+      }
+      const grant = await l.graph.createToolGrant({
+        agentId: onAgent ? agent.id : null,
+        subAgentId,
+        toolKind,
+        toolRef,
+        mcpServerId,
+      });
+      return { id: `tool_grant:${grant.id}`, kind, source, target };
+    }
+    case 'subagent':
+    case 'schedule':
+      // Sub-agents and schedules are created via their own POST endpoints; the
+      // ownership edge is implicit. Return it idempotently for the canvas.
+      return { id: `${kind}:${idAfter(target, target.split(':', 1)[0] ?? '')}`, kind, source, target };
+    default:
+      throw new ConfigValidationError(`unknown edge kind "${kind}"`);
+  }
+}
+
+async function deleteEdge(l: Live, id: string, kind: string): Promise<void> {
+  switch (kind) {
+    case 'channel_bind': {
+      const rest = id.slice('channel_bind:'.length);
+      const sep = rest.indexOf(':');
+      const channelType = sep >= 0 ? rest.slice(0, sep) : rest;
+      const channelKey = sep >= 0 ? rest.slice(sep + 1) : '';
+      await l.config.removeChannelBinding(channelType, channelKey);
+      return;
+    }
+    case 'subagent':
+      await l.graph.deleteSubAgent(id.slice('subagent:'.length));
+      return;
+    case 'skill':
+      await l.graph.setSubAgentSkill(id.slice('skill:'.length), null);
+      return;
+    case 'tool_grant':
+      await l.graph.deleteToolGrant(id.slice('tool_grant:'.length));
+      return;
+    case 'schedule':
+      await l.graph.deleteSchedule(id.slice('schedule:'.length));
+      return;
+    default:
+      throw new ConfigValidationError(`unknown edge kind "${kind}"`);
+  }
+}
+
+// ── graph assembly ─────────────────────────────────────────────────────────
+
+function assembleGraph(
+  agent: AgentRow,
+  bindings: readonly { channelType: string; channelKey: string }[],
+  subAgents: readonly SubAgentRow[],
+  skills: readonly SkillRow[],
+  grants: readonly ToolGrantRow[],
+  servers: readonly McpServerRow[],
+  schedules: readonly ScheduleRow[],
+) {
+  const mySubs = subAgents.filter((s) => s.parentAgentId === agent.id);
+  const subIds = new Set(mySubs.map((s) => s.id));
+  const myGrants = grants.filter(
+    (g) =>
+      (g.agentId && g.agentId === agent.id) ||
+      (g.subAgentId && subIds.has(g.subAgentId)),
+  );
+
+  const edges: { id: string; kind: string; source: string; target: string }[] = [];
+  for (const b of bindings) {
+    edges.push({
+      id: `channel_bind:${b.channelType}:${b.channelKey}`,
+      kind: 'channel_bind',
+      source: `channel:${b.channelType}:${b.channelKey}`,
+      target: `agent:${agent.id}`,
+    });
+  }
+  for (const s of mySubs) {
+    edges.push({
+      id: `subagent:${s.id}`,
+      kind: 'subagent',
+      source: `agent:${agent.id}`,
+      target: `subagent:${s.id}`,
+    });
+    if (s.skillId) {
+      edges.push({
+        id: `skill:${s.id}`,
+        kind: 'skill',
+        source: `subagent:${s.id}`,
+        target: `skill:${s.skillId}`,
+      });
+    }
+  }
+  for (const g of myGrants) {
+    edges.push({
+      id: `tool_grant:${g.id}`,
+      kind: 'tool_grant',
+      source: g.agentId ? `agent:${agent.id}` : `subagent:${g.subAgentId}`,
+      target: `tool:${g.toolRef}`,
+    });
+  }
+  for (const sc of schedules) {
+    edges.push({
+      id: `schedule:${sc.id}`,
+      kind: 'schedule',
+      source: `schedule:${sc.id}`,
+      target: `agent:${agent.id}`,
+    });
+  }
+
+  return {
+    agent: agentNode(agent),
+    channels: bindings.map((b) => ({
+      channelType: b.channelType,
+      channelKey: b.channelKey,
+      position: null,
+    })),
+    subAgents: mySubs.map(subAgentNode),
+    skills: skills.map(skillNode),
+    tools: myGrants.map(toolGrantNode),
+    mcpServers: servers.map(mcpNode),
+    schedules: schedules.map(scheduleNode),
+    edges,
+  };
+}
+
+// ── node mappers ─────────────────────────────────────────────────────────────
+
+function agentNode(a: AgentRow) {
+  return {
+    id: a.id,
+    slug: a.slug,
+    name: a.name,
+    description: a.description,
+    privacyProfile: a.privacyProfile,
+    status: a.status,
+    modelRouting: (a.modelRouting as Record<string, unknown> | null) ?? null,
+    position: a.canvasPosition ?? null,
+  };
+}
+
+function subAgentNode(s: SubAgentRow) {
+  return {
+    id: s.id,
+    parentAgentId: s.parentAgentId,
+    name: s.name,
+    skillId: s.skillId,
+    model: s.model,
+    maxTokens: s.maxTokens,
+    maxIterations: s.maxIterations,
+    systemPromptOverride: s.systemPromptOverride,
+    status: s.status,
+    position: s.position,
+  };
+}
+
+function skillNode(s: SkillRow) {
+  return {
+    id: s.id,
+    slug: s.slug,
+    name: s.name,
+    description: s.description,
+    body: s.body,
+    source: s.source,
+  };
+}
+
+function toolGrantNode(g: ToolGrantRow) {
+  return {
+    id: g.id,
+    agentId: g.agentId,
+    subAgentId: g.subAgentId,
+    toolKind: g.toolKind,
+    toolRef: g.toolRef,
+    mcpServerId: g.mcpServerId,
+  };
+}
+
+function mcpNode(s: McpServerRow) {
+  return {
+    id: s.id,
+    name: s.name,
+    transport: s.transport,
+    endpoint: s.endpoint,
+    status: s.status,
+    lastDiscoveredAt: s.lastDiscoveredAt ? s.lastDiscoveredAt.toISOString() : null,
+    discoveredTools: s.discoveredTools,
+  };
+}
+
+function scheduleNode(s: ScheduleRow) {
+  return {
+    id: s.id,
+    agentId: s.agentId,
+    cron: s.cron,
+    timezone: s.timezone,
+    payload: s.payload,
+    status: s.status,
+    lastRunAt: s.lastRunAt ? s.lastRunAt.toISOString() : null,
+  };
+}
+
+function toMcpConfig(row: McpServerRow): McpServerConfig {
+  const headers: Record<string, string> = {};
+  for (const [k, v] of Object.entries(row.headers ?? {})) {
+    if (typeof v === 'string') headers[k] = v;
+  }
+  return {
+    id: row.id,
+    name: row.name,
+    transport: row.transport,
+    endpoint: row.endpoint,
+    ...(Object.keys(headers).length > 0 ? { headers } : {}),
+  };
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+/** `channel:<type>:<key>` where key may itself contain ':'. */
+function parseChannel(source: string): { channelType: string; channelKey: string } {
+  const rest = source.startsWith('channel:') ? source.slice('channel:'.length) : source;
+  const sep = rest.indexOf(':');
+  if (sep < 0) throw new ConfigValidationError(`malformed channel node id "${source}"`);
+  return { channelType: rest.slice(0, sep), channelKey: rest.slice(sep + 1) };
+}
+
+function idAfter(nodeIdStr: string, prefix: string): string {
+  const p = `${prefix}:`;
+  return nodeIdStr.startsWith(p) ? nodeIdStr.slice(p.length) : nodeIdStr;
+}
+
+async function reload(l: Live): Promise<unknown> {
+  if (!l.registry) return undefined;
+  try {
+    return await l.registry.reload();
+  } catch {
+    return undefined;
+  }
+}
+
+function fail(res: Response, err: unknown): void {
+  if (err instanceof ConfigValidationError) {
+    res.status(409).json({ error: 'config_validation', message: err.message });
+    return;
+  }
+  res.status(500).json({ error: 'internal', message: msg(err) });
+}
+
+function msg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/middleware/src/routes/agentBuilder.ts
+++ b/middleware/src/routes/agentBuilder.ts
@@ -75,7 +75,7 @@ export function createAgentBuilderRouter(
     const l = live(res);
     if (!l) return;
     try {
-      const agent = await agentOr404(l, req.params.slug ?? '', res);
+      const agent = await agentOr404(l, str(req.params.slug), res);
       if (!agent) return;
       const [bindings, subAgents, skills, grants, servers, schedules] =
         await Promise.all([
@@ -99,7 +99,7 @@ export function createAgentBuilderRouter(
     const l = live(res);
     if (!l) return;
     try {
-      const agent = await agentOr404(l, req.params.slug ?? '', res);
+      const agent = await agentOr404(l, str(req.params.slug), res);
       if (!agent) return;
       const edge = await createEdge(l, agent, req.body ?? {});
       const diff = await reload(l);
@@ -115,8 +115,8 @@ export function createAgentBuilderRouter(
       const l = live(res);
       if (!l) return;
       try {
-        const kind = String(req.query['kind'] ?? '');
-        await deleteEdge(l, decodeURIComponent(req.params.id ?? ''), kind);
+        const kind = str(req.query['kind']);
+        await deleteEdge(l, decodeURIComponent(str(req.params.id)), kind);
         await reload(l);
         res.status(204).end();
       } catch (err) {
@@ -130,7 +130,7 @@ export function createAgentBuilderRouter(
     const l = live(res);
     if (!l) return;
     try {
-      const agent = await agentOr404(l, req.params.slug ?? '', res);
+      const agent = await agentOr404(l, str(req.params.slug), res);
       if (!agent) return;
       const b = req.body ?? {};
       const row = await l.graph.createSubAgent({
@@ -157,7 +157,7 @@ export function createAgentBuilderRouter(
       const l = live(res);
       if (!l) return;
       try {
-        const row = await l.graph.updateSubAgent(req.params.id ?? '', req.body ?? {});
+        const row = await l.graph.updateSubAgent(str(req.params.id), req.body ?? {});
         await reload(l);
         res.json(subAgentNode(row));
       } catch (err) {
@@ -172,7 +172,7 @@ export function createAgentBuilderRouter(
       const l = live(res);
       if (!l) return;
       try {
-        await l.graph.deleteSubAgent(req.params.id ?? '');
+        await l.graph.deleteSubAgent(str(req.params.id));
         await reload(l);
         res.status(204).end();
       } catch (err) {
@@ -188,7 +188,7 @@ export function createAgentBuilderRouter(
       const l = live(res);
       if (!l) return;
       try {
-        const agent = await agentOr404(l, req.params.slug ?? '', res);
+        const agent = await agentOr404(l, str(req.params.slug), res);
         if (!agent) return;
         const routing = (req.body ?? {}).modelRouting ?? null;
         const updated = await l.config.setModelRouting(agent.id, routing);
@@ -204,7 +204,7 @@ export function createAgentBuilderRouter(
     const l = live(res);
     if (!l) return;
     try {
-      const agent = await agentOr404(l, req.params.slug ?? '', res);
+      const agent = await agentOr404(l, str(req.params.slug), res);
       if (!agent) return;
       const b = req.body ?? {};
       if (b.agent) await l.config.setCanvasPosition(agent.id, b.agent);
@@ -253,7 +253,7 @@ export function createAgentBuilderRouter(
     const l = live(res);
     if (!l) return;
     try {
-      const row = await l.graph.updateSkill(req.params.id ?? '', req.body ?? {});
+      const row = await l.graph.updateSkill(str(req.params.id), req.body ?? {});
       await reload(l);
       res.json(skillNode(row));
     } catch (err) {
@@ -265,7 +265,7 @@ export function createAgentBuilderRouter(
     const l = live(res);
     if (!l) return;
     try {
-      await l.graph.deleteSkill(req.params.id ?? '');
+      await l.graph.deleteSkill(str(req.params.id));
       await reload(l);
       res.status(204).end();
     } catch (err) {
@@ -305,7 +305,7 @@ export function createAgentBuilderRouter(
     const l = live(res);
     if (!l) return;
     try {
-      await l.graph.deleteMcpServer(req.params.id ?? '');
+      await l.graph.deleteMcpServer(str(req.params.id));
       await reload(l);
       res.status(204).end();
     } catch (err) {
@@ -318,7 +318,7 @@ export function createAgentBuilderRouter(
     if (!l) return;
     try {
       const servers = await l.graph.listMcpServers();
-      const row = servers.find((s) => s.id === req.params.id);
+      const row = servers.find((s) => s.id === str(req.params.id));
       if (!row) {
         res.status(404).json({ error: 'mcp_server_not_found' });
         return;
@@ -338,7 +338,7 @@ export function createAgentBuilderRouter(
     const l = live(res);
     if (!l) return;
     try {
-      const agent = await agentOr404(l, req.params.slug ?? '', res);
+      const agent = await agentOr404(l, str(req.params.slug), res);
       if (!agent) return;
       const schedules = (await l.graph.listSchedulesForAgent(agent.id)).map(
         scheduleNode,
@@ -353,7 +353,7 @@ export function createAgentBuilderRouter(
     const l = live(res);
     if (!l) return;
     try {
-      const agent = await agentOr404(l, req.params.slug ?? '', res);
+      const agent = await agentOr404(l, str(req.params.slug), res);
       if (!agent) return;
       const b = req.body ?? {};
       const row = await l.graph.createSchedule({
@@ -375,7 +375,7 @@ export function createAgentBuilderRouter(
       const l = live(res);
       if (!l) return;
       try {
-        await l.graph.deleteSchedule(req.params.id ?? '');
+        await l.graph.deleteSchedule(str(req.params.id));
         res.status(204).end();
       } catch (err) {
         fail(res, err);
@@ -666,4 +666,15 @@ function fail(res: Response, err: unknown): void {
 
 function msg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Express 5 types `req.params[x]` / `req.query[x]` as `string | string[]`.
+ * Coerce to a single string (first element of an array, else empty) so route
+ * handlers can pass them to string-typed store methods.
+ */
+function str(v: unknown): string {
+  if (typeof v === 'string') return v;
+  if (Array.isArray(v) && typeof v[0] === 'string') return v[0];
+  return '';
 }

--- a/middleware/src/routes/agentBuilder.ts
+++ b/middleware/src/routes/agentBuilder.ts
@@ -29,6 +29,8 @@ import {
 import { McpManager } from '@omadia/orchestrator';
 import { Router, type Request, type Response } from 'express';
 
+import type { ChannelDirectoryRegistry } from '../channels/channelDirectoryRegistry.js';
+
 export interface AgentBuilderRouterOptions {
   readonly getConfigStore: () => ConfigStore | undefined;
   readonly getGraphStore: () => AgentGraphStore | undefined;
@@ -37,6 +39,8 @@ export interface AgentBuilderRouterOptions {
   readonly getNativeTools?: () => readonly string[];
   /** Ids of every installed plugin (for the per-agent plugin picker). */
   readonly getInstalledPlugins?: () => readonly string[];
+  /** Channel directory (available channel types + keys) for the bind picker. */
+  readonly getChannelDirectory?: () => ChannelDirectoryRegistry | undefined;
 }
 
 interface Live {
@@ -222,6 +226,26 @@ export function createAgentBuilderRouter(
     },
   );
 
+  // Per-agent native-tool allow-list (empty = all available).
+  router.put('/agents/:slug/native-tools', async (req: Request, res: Response) => {
+    const l = live(res);
+    if (!l) return;
+    try {
+      const agent = await agentOr404(l, str(req.params.slug), res);
+      if (!agent) return;
+      const tools = Array.isArray((req.body ?? {}).tools)
+        ? ((req.body.tools as unknown[]).filter(
+            (x): x is string => typeof x === 'string',
+          ))
+        : [];
+      await l.graph.setAgentNativeTools(agent.id, tools);
+      await reload(l);
+      res.json({ tools });
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
   router.patch('/agents/:slug/positions', async (req: Request, res: Response) => {
     const l = live(res);
     if (!l) return;
@@ -237,6 +261,29 @@ export function createAgentBuilderRouter(
         await l.config.setChannelBindingPosition(c.channelType, c.channelKey, c.position);
       }
       res.status(204).end(); // positions are cosmetic — no reload needed
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  // ── channel directory (available channels for the bind picker) ───────────────
+  router.get('/channel-directory', async (_req: Request, res: Response) => {
+    const dir = options.getChannelDirectory?.();
+    if (!dir) {
+      res.json({ types: [], keys: [] });
+      return;
+    }
+    try {
+      const keys = await dir.listAll();
+      res.json({
+        types: dir.types(),
+        keys: keys.map((k) => ({
+          channelType: k.channelType,
+          key: k.key,
+          label: k.label,
+          hint: k.hint ?? null,
+        })),
+      });
     } catch (err) {
       fail(res, err);
     }

--- a/middleware/src/scheduler/cron.ts
+++ b/middleware/src/scheduler/cron.ts
@@ -3,11 +3,13 @@
  *
  * Fields: minute hour day-of-month month day-of-week. Each field supports
  * a wildcard, a step ("wildcard/n"), an "a-b" range, "a-b/n", and comma lists
- * of those. Day-of-week 0 and 7 both mean Sunday. Evaluated against the supplied
- * `Date`'s UTC parts (timezone handling is a future enhancement — schedules
- * default to UTC).
+ * of those. Day-of-week 0 and 7 both mean Sunday. Evaluated against the
+ * supplied `Date` projected into the given IANA timezone (default 'UTC') via
+ * `Intl.DateTimeFormat` — so "0 9 * * *" in "Europe/Berlin" fires at Berlin
+ * 09:00 regardless of server TZ or DST.
  *
- * Pure + dependency-free so it unit-tests without a clock or a DB.
+ * Pure + dependency-free (Intl is built in) so it unit-tests without a clock
+ * or a DB.
  */
 
 const RANGES: ReadonlyArray<readonly [number, number]> = [
@@ -30,22 +32,81 @@ export function isValidCron(expr: string): boolean {
   });
 }
 
-export function cronMatches(expr: string, date: Date): boolean {
+export function cronMatches(
+  expr: string,
+  date: Date,
+  timezone = 'UTC',
+): boolean {
   const fields = expr.trim().split(/\s+/);
   if (fields.length !== 5) return false;
 
-  const minute = date.getUTCMinutes();
-  const hour = date.getUTCHours();
-  const dom = date.getUTCDate();
-  const month = date.getUTCMonth() + 1;
-  const dow = date.getUTCDay(); // 0..6, Sunday = 0
-
+  const { minute, hour, dom, month, dow } = zonedParts(date, timezone);
   const values = [minute, hour, dom, month, dow];
   for (let i = 0; i < 5; i++) {
     const set = expandField(fields[i]!, RANGES[i]![0], RANGES[i]![1]);
     if (!set.has(values[i]!)) return false;
   }
   return true;
+}
+
+const WEEKDAY_TO_NUM: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
+interface ZonedParts {
+  minute: number;
+  hour: number;
+  dom: number;
+  month: number;
+  dow: number;
+}
+
+/** Project a Date into a timezone's wall-clock fields. Falls back to UTC when
+ *  the timezone id is invalid. */
+export function zonedParts(date: Date, timezone: string): ZonedParts {
+  if (timezone === 'UTC') {
+    return {
+      minute: date.getUTCMinutes(),
+      hour: date.getUTCHours(),
+      dom: date.getUTCDate(),
+      month: date.getUTCMonth() + 1,
+      dow: date.getUTCDay(),
+    };
+  }
+  try {
+    const fmt = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      hourCycle: 'h23',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      weekday: 'short',
+    });
+    const map: Record<string, string> = {};
+    for (const p of fmt.formatToParts(date)) map[p.type] = p.value;
+    return {
+      minute: Number(map['minute']),
+      hour: Number(map['hour']) % 24,
+      dom: Number(map['day']),
+      month: Number(map['month']),
+      dow: WEEKDAY_TO_NUM[map['weekday'] ?? 'Sun'] ?? 0,
+    };
+  } catch {
+    return {
+      minute: date.getUTCMinutes(),
+      hour: date.getUTCHours(),
+      dom: date.getUTCDate(),
+      month: date.getUTCMonth() + 1,
+      dow: date.getUTCDay(),
+    };
+  }
 }
 
 function expandField(field: string, min: number, max: number): Set<number> {

--- a/middleware/src/scheduler/cron.ts
+++ b/middleware/src/scheduler/cron.ts
@@ -1,0 +1,91 @@
+/**
+ * Minimal standard 5-field cron matcher (Agent Builder P6).
+ *
+ * Fields: minute hour day-of-month month day-of-week. Each field supports
+ * a wildcard, a step ("wildcard/n"), an "a-b" range, "a-b/n", and comma lists
+ * of those. Day-of-week 0 and 7 both mean Sunday. Evaluated against the supplied
+ * `Date`'s UTC parts (timezone handling is a future enhancement — schedules
+ * default to UTC).
+ *
+ * Pure + dependency-free so it unit-tests without a clock or a DB.
+ */
+
+const RANGES: ReadonlyArray<readonly [number, number]> = [
+  [0, 59], // minute
+  [0, 23], // hour
+  [1, 31], // day of month
+  [1, 12], // month
+  [0, 6], // day of week (after 7→0 normalisation)
+];
+
+export function isValidCron(expr: string): boolean {
+  const fields = expr.trim().split(/\s+/);
+  if (fields.length !== 5) return false;
+  return fields.every((f, i) => {
+    try {
+      return expandField(f, RANGES[i]![0], RANGES[i]![1]).size > 0;
+    } catch {
+      return false;
+    }
+  });
+}
+
+export function cronMatches(expr: string, date: Date): boolean {
+  const fields = expr.trim().split(/\s+/);
+  if (fields.length !== 5) return false;
+
+  const minute = date.getUTCMinutes();
+  const hour = date.getUTCHours();
+  const dom = date.getUTCDate();
+  const month = date.getUTCMonth() + 1;
+  const dow = date.getUTCDay(); // 0..6, Sunday = 0
+
+  const values = [minute, hour, dom, month, dow];
+  for (let i = 0; i < 5; i++) {
+    const set = expandField(fields[i]!, RANGES[i]![0], RANGES[i]![1]);
+    if (!set.has(values[i]!)) return false;
+  }
+  return true;
+}
+
+function expandField(field: string, min: number, max: number): Set<number> {
+  const out = new Set<number>();
+  for (const part of field.split(',')) {
+    let step = 1;
+    let body = part;
+    const slash = part.indexOf('/');
+    if (slash >= 0) {
+      step = parseInt(part.slice(slash + 1), 10);
+      body = part.slice(0, slash);
+      if (!Number.isFinite(step) || step <= 0) {
+        throw new Error(`bad step in "${part}"`);
+      }
+    }
+
+    let lo = min;
+    let hi = max;
+    if (body !== '*') {
+      const dash = body.indexOf('-');
+      if (dash >= 0) {
+        lo = parseInt(body.slice(0, dash), 10);
+        hi = parseInt(body.slice(dash + 1), 10);
+      } else {
+        lo = parseInt(body, 10);
+        hi = lo;
+      }
+      if (!Number.isFinite(lo) || !Number.isFinite(hi)) {
+        throw new Error(`bad range in "${part}"`);
+      }
+    }
+
+    for (let v = lo; v <= hi; v += step) {
+      // day-of-week: 7 → 0 (Sunday)
+      const normalised = max === 6 && v === 7 ? 0 : v;
+      if (normalised < min || normalised > max) {
+        throw new Error(`value ${String(v)} out of [${String(min)},${String(max)}]`);
+      }
+      out.add(normalised);
+    }
+  }
+  return out;
+}

--- a/middleware/src/scheduler/scheduleWorker.ts
+++ b/middleware/src/scheduler/scheduleWorker.ts
@@ -75,7 +75,7 @@ export class ScheduleWorker {
       if (s.status !== 'enabled') continue;
       if (this.inFlight.has(s.id)) continue;
       if (this.firedThisMinute.get(s.id) === minuteKey) continue;
-      if (!cronMatches(s.cron, now)) continue;
+      if (!cronMatches(s.cron, now, s.timezone)) continue;
 
       const slug = slugByAgentId.get(s.agentId);
       if (!slug) {

--- a/middleware/src/scheduler/scheduleWorker.ts
+++ b/middleware/src/scheduler/scheduleWorker.ts
@@ -1,0 +1,143 @@
+/**
+ * Agent Builder schedule worker (P6).
+ *
+ * Polls `agent_schedules` once per minute and fires a synthetic chat turn
+ * against the bound agent's orchestrator for each enabled schedule whose cron
+ * matches the current minute. Per-minute, per-schedule de-duplication lives in
+ * memory so a within-minute restart can't double-fire; overlap across ticks is
+ * prevented by tracking in-flight schedule ids.
+ *
+ * The turn runs headlessly via the registry's `ChatAgent.chat(...)` — the same
+ * entrypoint the chat route uses — so scheduled runs exercise the full
+ * orchestrator (tools, sub-agents, memory) exactly like an interactive turn.
+ */
+
+import type { AgentGraphStore, OrchestratorRegistry } from '@omadia/orchestrator';
+
+import { cronMatches } from './cron.js';
+
+export interface ScheduleWorkerDeps {
+  readonly getGraphStore: () => AgentGraphStore | undefined;
+  readonly getRegistry: () => OrchestratorRegistry | undefined;
+  readonly log?: (msg: string, fields?: Record<string, unknown>) => void;
+  /** Poll cadence in ms. Defaults to 60_000 (one minute). */
+  readonly intervalMs?: number;
+  /** Injectable clock for tests. Defaults to `() => new Date()`. */
+  readonly now?: () => Date;
+}
+
+export class ScheduleWorker {
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private readonly firedThisMinute = new Map<string, string>();
+  private readonly inFlight = new Set<string>();
+
+  constructor(private readonly deps: ScheduleWorkerDeps) {}
+
+  start(): void {
+    if (this.timer) return;
+    const interval = this.deps.intervalMs ?? 60_000;
+    // Run once promptly, then on the cadence.
+    void this.tick();
+    this.timer = setInterval(() => void this.tick(), interval);
+    if (typeof this.timer.unref === 'function') this.timer.unref();
+    this.log('schedule worker started', { intervalMs: interval });
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  /** One poll cycle. Exposed for tests (call directly, no timer needed). */
+  async tick(): Promise<void> {
+    const graph = this.deps.getGraphStore();
+    const registry = this.deps.getRegistry();
+    if (!graph || !registry) return;
+
+    const now = (this.deps.now ?? (() => new Date()))();
+    const minuteKey = isoMinute(now);
+
+    let schedules;
+    try {
+      schedules = await graph.listAllSchedules();
+    } catch (err) {
+      this.log('schedule worker: list failed', { error: errMsg(err) });
+      return;
+    }
+
+    // Map agentId → slug from the live registry (only active agents can run).
+    const slugByAgentId = new Map<string, string>();
+    for (const a of registry.list()) slugByAgentId.set(a.agent.id, a.agent.slug);
+
+    for (const s of schedules) {
+      if (s.status !== 'enabled') continue;
+      if (this.inFlight.has(s.id)) continue;
+      if (this.firedThisMinute.get(s.id) === minuteKey) continue;
+      if (!cronMatches(s.cron, now)) continue;
+
+      const slug = slugByAgentId.get(s.agentId);
+      if (!slug) {
+        this.log('schedule worker: agent not active — skipping', {
+          scheduleId: s.id,
+          agentId: s.agentId,
+        });
+        continue;
+      }
+
+      this.firedThisMinute.set(s.id, minuteKey);
+      this.inFlight.add(s.id);
+      void this.fire(s.id, slug, s.payload, registry, graph).finally(() =>
+        this.inFlight.delete(s.id),
+      );
+    }
+
+    // Bound the dedup map: drop entries from previous minutes.
+    for (const [id, key] of this.firedThisMinute) {
+      if (key !== minuteKey) this.firedThisMinute.delete(id);
+    }
+  }
+
+  private async fire(
+    scheduleId: string,
+    slug: string,
+    payload: Record<string, unknown>,
+    registry: OrchestratorRegistry,
+    graph: AgentGraphStore,
+  ): Promise<void> {
+    const entry = registry.get(slug);
+    if (!entry) return;
+    const userMessage =
+      typeof payload['prompt'] === 'string' && payload['prompt'].trim()
+        ? (payload['prompt'] as string)
+        : 'Scheduled run: perform your configured routine.';
+    try {
+      this.log('schedule worker: firing', { scheduleId, slug });
+      await entry.built.bundle.agent.chat({
+        userMessage,
+        sessionScope: `schedule:${scheduleId}`,
+      });
+      await graph.markScheduleRun(scheduleId);
+      this.log('schedule worker: completed', { scheduleId, slug });
+    } catch (err) {
+      this.log('schedule worker: turn failed', {
+        scheduleId,
+        slug,
+        error: errMsg(err),
+      });
+    }
+  }
+
+  private log(msg: string, fields?: Record<string, unknown>): void {
+    this.deps.log?.(msg, fields);
+  }
+}
+
+function isoMinute(d: Date): string {
+  return d.toISOString().slice(0, 16); // YYYY-MM-DDTHH:MM
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/middleware/test/agentBuilderCron.test.ts
+++ b/middleware/test/agentBuilderCron.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Agent Builder P6 — cron matcher.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { cronMatches, isValidCron } from '../src/scheduler/cron.js';
+
+// 2026-06-08T09:30:00Z is a Monday (getUTCDay === 1).
+const MON_0930 = new Date('2026-06-08T09:30:00Z');
+
+test('wildcard every minute always matches', () => {
+  assert.equal(cronMatches('* * * * *', MON_0930), true);
+});
+
+test('exact minute+hour matches and near-misses do not', () => {
+  assert.equal(cronMatches('30 9 * * *', MON_0930), true);
+  assert.equal(cronMatches('31 9 * * *', MON_0930), false);
+  assert.equal(cronMatches('30 10 * * *', MON_0930), false);
+});
+
+test('step and range fields', () => {
+  assert.equal(cronMatches('*/15 * * * *', MON_0930), true); // 30 % 15 === 0
+  assert.equal(cronMatches('*/7 * * * *', MON_0930), false); // 30 % 7 !== 0
+  assert.equal(cronMatches('0-45 9 * * *', MON_0930), true);
+  assert.equal(cronMatches('0,15,30,45 9 * * *', MON_0930), true);
+});
+
+test('day-of-week (Sunday is both 0 and 7)', () => {
+  assert.equal(cronMatches('30 9 * * 1', MON_0930), true); // Monday
+  assert.equal(cronMatches('30 9 * * 0', MON_0930), false); // Sunday
+  const sun = new Date('2026-06-07T09:30:00Z'); // Sunday
+  assert.equal(cronMatches('30 9 * * 7', sun), true);
+  assert.equal(cronMatches('30 9 * * 0', sun), true);
+});
+
+test('isValidCron rejects malformed expressions', () => {
+  assert.equal(isValidCron('* * * * *'), true);
+  assert.equal(isValidCron('*/15 9 * * 1-5'), true);
+  assert.equal(isValidCron('* * * *'), false); // 4 fields
+  assert.equal(isValidCron('99 * * * *'), false); // out of range
+  assert.equal(isValidCron('*/0 * * * *'), false); // bad step
+});

--- a/middleware/test/agentBuilderCron.test.ts
+++ b/middleware/test/agentBuilderCron.test.ts
@@ -35,6 +35,18 @@ test('day-of-week (Sunday is both 0 and 7)', () => {
   assert.equal(cronMatches('30 9 * * 0', sun), true);
 });
 
+test('timezone projection: 09:00 fires at local wall-clock, not UTC', () => {
+  // 2026-06-08T07:30Z = 09:30 in Europe/Berlin (CEST, UTC+2).
+  const utc0730 = new Date('2026-06-08T07:30:00Z');
+  assert.equal(cronMatches('30 9 * * *', utc0730, 'Europe/Berlin'), true);
+  assert.equal(cronMatches('30 9 * * *', utc0730, 'UTC'), false);
+  assert.equal(cronMatches('30 7 * * *', utc0730, 'UTC'), true);
+});
+
+test('invalid timezone falls back to UTC', () => {
+  assert.equal(cronMatches('30 9 * * *', MON_0930, 'Not/AZone'), true);
+});
+
 test('isValidCron rejects malformed expressions', () => {
   assert.equal(isValidCron('* * * * *'), true);
   assert.equal(isValidCron('*/15 9 * * 1-5'), true);

--- a/middleware/test/agentBuilderDiff.test.ts
+++ b/middleware/test/agentBuilderDiff.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Agent Builder P0 — diffSnapshots graph-awareness.
+ *
+ * Verifies that `diffSnapshots` treats the new editable-graph collections
+ * (sub-agents, tool grants, referenced-skill bodies, model routing) as
+ * runtime-relevant — a change rebuilds the owning agent — while schedules,
+ * consumed by the cron worker rather than the orchestrator build, produce no
+ * orchestrator action.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type {
+  ScheduleRow,
+  SkillRow,
+  SubAgentRow,
+  ToolGrantRow,
+} from '../packages/harness-orchestrator/src/registry/agentGraphStore.js';
+import { diffSnapshots } from '../packages/harness-orchestrator/src/registry/applyDiff.js';
+import type {
+  AgentRow,
+  ConfigSnapshot,
+} from '../packages/harness-orchestrator/src/registry/configStore.js';
+
+const AGENT_ID = '00000000-0000-0000-0000-000000000001';
+const SKILL_ID = '00000000-0000-0000-0000-0000000000a1';
+const SUB_ID = '00000000-0000-0000-0000-0000000000b1';
+
+function agent(overrides: Partial<AgentRow> = {}): AgentRow {
+  return {
+    id: AGENT_ID,
+    slug: 'public',
+    name: 'public',
+    description: null,
+    privacyProfile: 'default',
+    status: 'enabled',
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+function snap(overrides: Partial<ConfigSnapshot> = {}): ConfigSnapshot {
+  return {
+    agents: [agent()],
+    agentPlugins: [],
+    channelBindings: [],
+    platformSettings: { fallbackAgentId: null, updatedAt: new Date(0) },
+    subAgents: [],
+    toolGrants: [],
+    schedules: [],
+    skills: [],
+    mcpServers: [],
+    ...overrides,
+  };
+}
+
+function subAgent(overrides: Partial<SubAgentRow> = {}): SubAgentRow {
+  return {
+    id: SUB_ID,
+    parentAgentId: AGENT_ID,
+    name: 'researcher',
+    skillId: null,
+    model: null,
+    maxTokens: null,
+    maxIterations: null,
+    systemPromptOverride: null,
+    status: 'enabled',
+    position: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+function skill(overrides: Partial<SkillRow> = {}): SkillRow {
+  return {
+    id: SKILL_ID,
+    slug: 'research',
+    name: 'Research',
+    description: null,
+    body: 'You research things.',
+    frontmatter: {},
+    source: 'db',
+    sourcePath: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+function grant(overrides: Partial<ToolGrantRow> = {}): ToolGrantRow {
+  return {
+    id: '00000000-0000-0000-0000-0000000000c1',
+    agentId: AGENT_ID,
+    subAgentId: null,
+    toolKind: 'native',
+    toolRef: 'web_search',
+    mcpServerId: null,
+    config: {},
+    createdAt: new Date(0),
+    ...overrides,
+  };
+}
+
+function onlyRebuild(plan: ReturnType<typeof diffSnapshots>) {
+  assert.equal(plan.actions.length, 1, 'exactly one action');
+  const [action] = plan.actions;
+  assert.equal(action!.kind, 'rebuild');
+  return action as { kind: 'rebuild'; reason: string };
+}
+
+test('adding a sub-agent rebuilds the owning agent (reason: graph)', () => {
+  const before = snap();
+  const after = snap({ subAgents: [subAgent()] });
+  const reason = onlyRebuild(diffSnapshots(before, after)).reason;
+  assert.match(reason, /graph/);
+});
+
+test('editing a referenced skill body rebuilds the agent', () => {
+  const base = {
+    subAgents: [subAgent({ skillId: SKILL_ID })],
+    skills: [skill()],
+  };
+  const before = snap(base);
+  const after = snap({
+    subAgents: [subAgent({ skillId: SKILL_ID })],
+    skills: [skill({ body: 'You research things, deeply.' })],
+  });
+  assert.match(onlyRebuild(diffSnapshots(before, after)).reason, /graph/);
+});
+
+test('an unrelated skill edit does NOT rebuild the agent', () => {
+  const before = snap({ skills: [skill()] });
+  const after = snap({ skills: [skill({ body: 'changed' })] });
+  // No sub-agent references this skill → no graph change for the agent.
+  assert.equal(diffSnapshots(before, after).actions.length, 0);
+});
+
+test('granting a tool to a sub-agent rebuilds the agent', () => {
+  const before = snap({ subAgents: [subAgent()] });
+  const after = snap({
+    subAgents: [subAgent()],
+    toolGrants: [grant({ agentId: null, subAgentId: SUB_ID })],
+  });
+  assert.match(onlyRebuild(diffSnapshots(before, after)).reason, /graph/);
+});
+
+test('changing model_routing rebuilds the agent (reason: model_routing)', () => {
+  const before = snap();
+  const after = snap({
+    agents: [agent({ modelRouting: { mode: 'triage', main: 'opus' } })],
+  });
+  assert.match(onlyRebuild(diffSnapshots(before, after)).reason, /model_routing/);
+});
+
+test('adding a schedule produces NO orchestrator action', () => {
+  const before = snap();
+  const after = snap({
+    schedules: [
+      {
+        id: '00000000-0000-0000-0000-0000000000d1',
+        agentId: AGENT_ID,
+        cron: '0 9 * * *',
+        payload: {},
+        timezone: 'UTC',
+        status: 'enabled',
+        lastRunAt: null,
+        createdAt: new Date(0),
+      } satisfies ScheduleRow,
+    ],
+  });
+  assert.equal(diffSnapshots(before, after).actions.length, 0);
+});
+
+test('idempotent: identical graph-populated snapshot yields zero actions', () => {
+  const populated = snap({
+    subAgents: [subAgent({ skillId: SKILL_ID })],
+    skills: [skill()],
+    toolGrants: [grant()],
+  });
+  assert.equal(diffSnapshots(populated, populated).actions.length, 0);
+});

--- a/middleware/test/agentBuilderModelRouting.test.ts
+++ b/middleware/test/agentBuilderModelRouting.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Agent Builder P5 — persisted model_routing JSON → runtime mapping.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { resolveAgentModelRouting } from '../packages/harness-orchestrator/src/registry/agentRuntime.js';
+
+test('null / malformed → empty (platform default)', () => {
+  assert.deepEqual(resolveAgentModelRouting(null), {});
+  assert.deepEqual(resolveAgentModelRouting(undefined), {});
+  assert.deepEqual(resolveAgentModelRouting({ mode: 'triage' }), {}); // no main
+});
+
+test('single mode → model override, no routing', () => {
+  const r = resolveAgentModelRouting({ mode: 'single', main: 'claude-opus-4-8' });
+  assert.equal(r.model, 'claude-opus-4-8');
+  assert.equal(r.modelRouting, undefined);
+});
+
+test('triage mode → runtime routing with classifier/simple/complex', () => {
+  const r = resolveAgentModelRouting({
+    mode: 'triage',
+    main: 'claude-opus-4-8',
+    triage: 'claude-haiku-4-5',
+    simple: 'claude-sonnet-4-6',
+  });
+  assert.equal(r.model, 'claude-opus-4-8');
+  assert.deepEqual(r.modelRouting, {
+    classifierModel: 'claude-haiku-4-5',
+    simpleModel: 'claude-sonnet-4-6',
+    complexModel: 'claude-opus-4-8',
+  });
+});
+
+test('triage without explicit simple defaults simple→main; missing triage→haiku', () => {
+  const r = resolveAgentModelRouting({ mode: 'triage', main: 'claude-opus-4-8' });
+  assert.deepEqual(r.modelRouting, {
+    classifierModel: 'claude-haiku-4-5',
+    simpleModel: 'claude-opus-4-8',
+    complexModel: 'claude-opus-4-8',
+  });
+});

--- a/middleware/test/agentBuilderSubAgentTools.test.ts
+++ b/middleware/test/agentBuilderSubAgentTools.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Agent Builder P2/P4 — sub-agent DomainTool builder + MCP adapters.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import type Anthropic from '@anthropic-ai/sdk';
+import type { LocalSubAgentTool } from '@omadia/plugin-api';
+
+import {
+  mcpNativeToolName,
+  mcpToolToNativeSpec,
+  renderToolResult,
+  splitCommand,
+} from '../packages/harness-orchestrator/src/mcp/mcpClient.js';
+import type {
+  SkillRow,
+  SubAgentRow,
+  ToolGrantRow,
+} from '../packages/harness-orchestrator/src/registry/agentGraphStore.js';
+import {
+  buildSubAgentDomainTools,
+  mcpToolNameFromRef,
+  subAgentToolName,
+} from '../packages/harness-orchestrator/src/registry/subAgentTools.js';
+
+const fakeClient = {} as unknown as Anthropic;
+
+function sub(overrides: Partial<SubAgentRow> = {}): SubAgentRow {
+  return {
+    id: 'sub-1',
+    parentAgentId: 'agent-1',
+    name: 'Researcher Bot',
+    skillId: 'skill-1',
+    model: null,
+    maxTokens: null,
+    maxIterations: null,
+    systemPromptOverride: null,
+    status: 'enabled',
+    position: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+function skill(): SkillRow {
+  return {
+    id: 'skill-1',
+    slug: 'research',
+    name: 'Research',
+    description: null,
+    body: 'You are a researcher.',
+    frontmatter: {},
+    source: 'db',
+    sourcePath: null,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  };
+}
+
+function nativeGrant(): ToolGrantRow {
+  return {
+    id: 'g-1',
+    agentId: null,
+    subAgentId: 'sub-1',
+    toolKind: 'native',
+    toolRef: 'web_search',
+    mcpServerId: null,
+    config: {},
+    createdAt: new Date(0),
+  };
+}
+
+const stubNativeTool: LocalSubAgentTool = {
+  spec: {
+    name: 'web_search',
+    description: 'search',
+    input_schema: { type: 'object', properties: {}, required: [] },
+  },
+  handle: async () => 'ok',
+};
+
+test('builds one DomainTool per enabled sub-agent with sanitised name+domain', () => {
+  const tools = buildSubAgentDomainTools(
+    { subAgents: [sub()], toolGrants: [nativeGrant()], skills: [skill()] },
+    {
+      client: fakeClient,
+      defaultModel: 'claude-sonnet-4-6',
+      defaultMaxTokens: 2048,
+      defaultMaxIterations: 6,
+      nativeTool: (ref) => (ref === 'web_search' ? stubNativeTool : undefined),
+    },
+  );
+  assert.equal(tools.length, 1);
+  assert.equal(tools[0]!.name, 'ask_researcher_bot');
+  assert.equal(tools[0]!.domain, 'subagent.researcher-bot');
+});
+
+test('disabled sub-agents are skipped', () => {
+  const tools = buildSubAgentDomainTools(
+    { subAgents: [sub({ status: 'disabled' })], toolGrants: [], skills: [] },
+    { client: fakeClient, defaultModel: 'm', defaultMaxTokens: 1, defaultMaxIterations: 1 },
+  );
+  assert.equal(tools.length, 0);
+});
+
+test('subAgentToolName + mcpToolNameFromRef', () => {
+  assert.equal(subAgentToolName('GTM Agent!!'), 'ask_gtm_agent');
+  assert.equal(mcpToolNameFromRef('exa:web_search', 'exa'), 'web_search');
+  assert.equal(mcpToolNameFromRef('web_search', 'exa'), 'web_search');
+});
+
+test('mcp adapters: native tool name + spec + result rendering + command split', () => {
+  assert.equal(mcpNativeToolName('Exa Search', 'web.search'), 'mcp__Exa_Search__web_search');
+  const spec = mcpToolToNativeSpec('exa', { name: 'search', description: 'd' });
+  assert.equal(spec.name, 'mcp__exa__search');
+  assert.equal(spec.input_schema.type, 'object');
+  assert.equal(spec.domain, 'mcp.exa');
+
+  assert.equal(
+    renderToolResult({ content: [{ type: 'text', text: 'hello' }] }),
+    'hello',
+  );
+  assert.equal(
+    renderToolResult({ isError: true, content: [{ type: 'text', text: 'boom' }] }),
+    'Error: boom',
+  );
+  assert.deepEqual(splitCommand('npx -y @scope/mcp --flag "a b"'), [
+    'npx',
+    '-y',
+    '@scope/mcp',
+    '--flag',
+    'a b',
+  ]);
+});

--- a/web-ui/app/_lib/agentBuilder.ts
+++ b/web-ui/app/_lib/agentBuilder.ts
@@ -197,6 +197,8 @@ export interface AgentGraph {
   mcpServers: McpServerNode[];
   schedules: ScheduleNode[];
   plugins: PluginNode[];
+  /** Orchestrator-native tools available to the agent (read-only baseline). */
+  nativeTools: string[];
   edges: CanvasEdge[];
 }
 
@@ -320,6 +322,39 @@ export async function patchPositions(
   await callJson(
     `/v1/operator/agents/${encodeURIComponent(slug)}/positions`,
     { method: 'PATCH', body: JSON.stringify(input) },
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Plugins (per-agent enable/disable)
+// -----------------------------------------------------------------------------
+
+export interface InstallablePluginsResponse {
+  plugins: string[];
+}
+
+export async function listInstallablePlugins(
+  slug: string,
+): Promise<InstallablePluginsResponse> {
+  return callJson<InstallablePluginsResponse>(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/installable-plugins`,
+  );
+}
+
+export async function enablePlugin(
+  slug: string,
+  pluginId: string,
+): Promise<{ id: string }> {
+  return callJson<{ id: string }>(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/plugins`,
+    { method: 'POST', body: JSON.stringify({ pluginId }) },
+  );
+}
+
+export async function disablePlugin(slug: string, pluginId: string): Promise<void> {
+  await callJson(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/plugins/${encodeURIComponent(pluginId)}`,
+    { method: 'DELETE' },
   );
 }
 

--- a/web-ui/app/_lib/agentBuilder.ts
+++ b/web-ui/app/_lib/agentBuilder.ts
@@ -1,0 +1,499 @@
+import { ApiError } from './api';
+
+/**
+ * Typed client for the Agent-Builder visual-canvas REST surface
+ * (`/api/v1/operator/agents/:slug/graph/*` and the sibling sub-agent /
+ * skill / mcp-server / schedule routes). Mirrors the cookie-forwarding +
+ * URL conventions from `_lib/agents.ts` and `_lib/api.ts` verbatim so the
+ * canvas works identically from RSC fetches and client-side writes.
+ *
+ * The types here intentionally re-declare the backend contract locally
+ * (no cross-package import from `middleware/`) so the web-ui bundle stays
+ * self-contained.
+ */
+
+function botApi(path: string): string {
+  if (typeof window !== 'undefined') {
+    return `/bot-api${path}`;
+  }
+  const base = process.env['MIDDLEWARE_URL'] ?? 'http://localhost:3979';
+  return `${base}/api${path}`;
+}
+
+async function forwardCookieHeader(): Promise<Record<string, string>> {
+  if (typeof window !== 'undefined') return {};
+  try {
+    const mod = await import('next/headers');
+    const jar = await mod.cookies();
+    const cookieHeader = jar
+      .getAll()
+      .map((c) => `${c.name}=${c.value}`)
+      .join('; ');
+    return cookieHeader ? { cookie: cookieHeader } : {};
+  } catch {
+    return {};
+  }
+}
+
+async function callJson<T>(
+  path: string,
+  init?: RequestInit & { method?: string },
+): Promise<T> {
+  const forwarded = await forwardCookieHeader();
+  const res = await fetch(botApi(path), {
+    ...init,
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      ...forwarded,
+      ...(init?.headers ?? {}),
+    },
+    cache: 'no-store',
+    credentials: 'include',
+  });
+  if (res.status === 204) return undefined as T;
+  const text = await res.text();
+  if (!res.ok) {
+    throw new ApiError(
+      res.status,
+      `${init?.method ?? 'GET'} ${path} failed: ${res.status}`,
+      text,
+    );
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return undefined as T;
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Backend contract types (mirrored locally — do NOT import from middleware)
+// -----------------------------------------------------------------------------
+
+export interface CanvasPosition {
+  x: number;
+  y: number;
+}
+
+export type ModelRoutingMode = 'single' | 'triage';
+export type EscalationTrigger = 'tool_error' | 'long_context' | 'low_confidence';
+
+export interface ModelRoutingConfig {
+  mode: ModelRoutingMode;
+  main: string;
+  triage?: string;
+  simple?: string;
+  escalateOn?: EscalationTrigger[];
+}
+
+export type PrivacyProfile = 'strict' | 'default';
+export type NodeStatus = 'enabled' | 'disabled';
+
+export interface AgentNode {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  privacyProfile: PrivacyProfile;
+  status: NodeStatus;
+  modelRouting: ModelRoutingConfig | null;
+  position: CanvasPosition | null;
+}
+
+export interface ChannelNode {
+  channelType: string;
+  channelKey: string;
+  position: CanvasPosition | null;
+}
+
+export interface SubAgentNode {
+  id: string;
+  parentAgentId: string;
+  name: string;
+  skillId: string | null;
+  model: string | null;
+  maxTokens: number | null;
+  maxIterations: number | null;
+  systemPromptOverride: string | null;
+  status: NodeStatus;
+  position: CanvasPosition | null;
+}
+
+export interface SkillNode {
+  id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  body: string;
+  source: 'db' | 'file';
+}
+
+export type ToolKind = 'native' | 'mcp';
+
+export interface ToolGrantNode {
+  id: string;
+  agentId: string | null;
+  subAgentId: string | null;
+  toolKind: ToolKind;
+  toolRef: string;
+  mcpServerId: string | null;
+}
+
+export interface McpDiscoveredTool {
+  name: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+}
+
+export type McpTransport = 'stdio' | 'http' | 'sse';
+
+export interface McpServerNode {
+  id: string;
+  name: string;
+  transport: McpTransport;
+  endpoint: string | null;
+  status: NodeStatus;
+  lastDiscoveredAt: string | null;
+  discoveredTools: McpDiscoveredTool[];
+}
+
+export interface ScheduleNode {
+  id: string;
+  agentId: string;
+  cron: string;
+  timezone: string;
+  payload: Record<string, unknown>;
+  status: NodeStatus;
+  lastRunAt: string | null;
+}
+
+export type EdgeKind =
+  | 'channel_bind'
+  | 'subagent'
+  | 'skill'
+  | 'tool_grant'
+  | 'schedule';
+
+export interface CanvasEdge {
+  id: string;
+  kind: EdgeKind;
+  source: string;
+  target: string;
+}
+
+export interface AgentGraph {
+  agent: AgentNode;
+  channels: ChannelNode[];
+  subAgents: SubAgentNode[];
+  skills: SkillNode[];
+  tools: ToolGrantNode[];
+  mcpServers: McpServerNode[];
+  schedules: ScheduleNode[];
+  edges: CanvasEdge[];
+}
+
+// -----------------------------------------------------------------------------
+// Graph read + edge mutations
+// -----------------------------------------------------------------------------
+
+export async function getAgentGraph(slug: string): Promise<AgentGraph> {
+  return callJson<AgentGraph>(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/graph`,
+  );
+}
+
+export interface CreateEdgeInput {
+  kind: EdgeKind;
+  source: string;
+  target: string;
+  config?: Record<string, unknown>;
+}
+
+export interface CreateEdgeResponse {
+  edge: CanvasEdge;
+  diff?: unknown;
+}
+
+export async function createGraphEdge(
+  slug: string,
+  input: CreateEdgeInput,
+): Promise<CreateEdgeResponse> {
+  return callJson<CreateEdgeResponse>(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/graph/edges`,
+    { method: 'POST', body: JSON.stringify(input) },
+  );
+}
+
+export async function deleteGraphEdge(
+  slug: string,
+  edgeId: string,
+  kind: EdgeKind,
+): Promise<void> {
+  const params = new URLSearchParams({ kind });
+  await callJson(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/graph/edges/${encodeURIComponent(edgeId)}?${params.toString()}`,
+    { method: 'DELETE' },
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Sub-agents
+// -----------------------------------------------------------------------------
+
+export interface CreateSubAgentInput {
+  name: string;
+  skillId?: string | null;
+  model?: string | null;
+  maxTokens?: number | null;
+  maxIterations?: number | null;
+  systemPromptOverride?: string | null;
+  status?: NodeStatus;
+  position?: CanvasPosition;
+}
+
+export async function createSubAgent(
+  slug: string,
+  input: CreateSubAgentInput,
+): Promise<SubAgentNode> {
+  return callJson<SubAgentNode>(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/subagents`,
+    { method: 'POST', body: JSON.stringify(input) },
+  );
+}
+
+export type PatchSubAgentInput = Partial<CreateSubAgentInput>;
+
+export async function patchSubAgent(
+  slug: string,
+  id: string,
+  patch: PatchSubAgentInput,
+): Promise<SubAgentNode> {
+  return callJson<SubAgentNode>(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/subagents/${encodeURIComponent(id)}`,
+    { method: 'PATCH', body: JSON.stringify(patch) },
+  );
+}
+
+export async function deleteSubAgent(slug: string, id: string): Promise<void> {
+  await callJson(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/subagents/${encodeURIComponent(id)}`,
+    { method: 'DELETE' },
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Model routing + positions
+// -----------------------------------------------------------------------------
+
+export async function patchModelRouting(
+  slug: string,
+  modelRouting: ModelRoutingConfig | null,
+): Promise<AgentNode> {
+  return callJson<AgentNode>(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/model-routing`,
+    { method: 'PATCH', body: JSON.stringify({ modelRouting }) },
+  );
+}
+
+export interface PositionsPatchInput {
+  agent?: CanvasPosition;
+  subAgents?: Array<{ id: string; position: CanvasPosition }>;
+  channels?: Array<{
+    channelType: string;
+    channelKey: string;
+    position: CanvasPosition;
+  }>;
+}
+
+export async function patchPositions(
+  slug: string,
+  input: PositionsPatchInput,
+): Promise<void> {
+  await callJson(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/positions`,
+    { method: 'PATCH', body: JSON.stringify(input) },
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Skills (global registry)
+// -----------------------------------------------------------------------------
+
+export interface SkillsListResponse {
+  skills: SkillNode[];
+}
+
+export async function listSkills(): Promise<SkillsListResponse> {
+  return callJson<SkillsListResponse>('/v1/operator/skills');
+}
+
+export interface CreateSkillInput {
+  slug: string;
+  name: string;
+  description?: string | null;
+  body: string;
+}
+
+export async function createSkill(input: CreateSkillInput): Promise<SkillNode> {
+  return callJson<SkillNode>('/v1/operator/skills', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+}
+
+export type PatchSkillInput = Partial<CreateSkillInput>;
+
+export async function patchSkill(
+  id: string,
+  patch: PatchSkillInput,
+): Promise<SkillNode> {
+  return callJson<SkillNode>(`/v1/operator/skills/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    body: JSON.stringify(patch),
+  });
+}
+
+export async function deleteSkill(id: string): Promise<void> {
+  await callJson(`/v1/operator/skills/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
+}
+
+// -----------------------------------------------------------------------------
+// MCP servers
+// -----------------------------------------------------------------------------
+
+export interface McpServersListResponse {
+  servers: McpServerNode[];
+}
+
+export async function listMcpServers(): Promise<McpServersListResponse> {
+  return callJson<McpServersListResponse>('/v1/operator/mcp-servers');
+}
+
+export interface CreateMcpServerInput {
+  name: string;
+  transport: McpTransport;
+  endpoint?: string | null;
+  status?: NodeStatus;
+}
+
+export async function createMcpServer(
+  input: CreateMcpServerInput,
+): Promise<McpServerNode> {
+  return callJson<McpServerNode>('/v1/operator/mcp-servers', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+}
+
+export async function deleteMcpServer(id: string): Promise<void> {
+  await callJson(`/v1/operator/mcp-servers/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
+}
+
+export async function discoverMcpTools(id: string): Promise<McpServerNode> {
+  return callJson<McpServerNode>(
+    `/v1/operator/mcp-servers/${encodeURIComponent(id)}/discover`,
+    { method: 'POST' },
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Schedules
+// -----------------------------------------------------------------------------
+
+export interface SchedulesListResponse {
+  schedules: ScheduleNode[];
+}
+
+export async function listSchedules(
+  slug: string,
+): Promise<SchedulesListResponse> {
+  return callJson<SchedulesListResponse>(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/schedules`,
+  );
+}
+
+export interface CreateScheduleInput {
+  cron: string;
+  timezone: string;
+  payload?: Record<string, unknown>;
+  status?: NodeStatus;
+}
+
+export async function createSchedule(
+  slug: string,
+  input: CreateScheduleInput,
+): Promise<ScheduleNode> {
+  return callJson<ScheduleNode>(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/schedules`,
+    { method: 'POST', body: JSON.stringify(input) },
+  );
+}
+
+export async function deleteSchedule(slug: string, id: string): Promise<void> {
+  await callJson(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/schedules/${encodeURIComponent(id)}`,
+    { method: 'DELETE' },
+  );
+}
+
+// -----------------------------------------------------------------------------
+// Edge semantics — single source of truth for legal connections.
+// Encoded as source-node-kind → target-node-kind → edge-kind. The canvas
+// stamps each ReactFlow node with a `kind` in its data; `isValidConnection`
+// looks the pair up here.
+// -----------------------------------------------------------------------------
+
+export type CanvasNodeKind =
+  | 'channel'
+  | 'agent'
+  | 'subagent'
+  | 'skill'
+  | 'tool'
+  | 'mcp'
+  | 'schedule';
+
+interface EdgeRule {
+  source: CanvasNodeKind;
+  target: CanvasNodeKind;
+  kind: EdgeKind;
+}
+
+const EDGE_RULES: readonly EdgeRule[] = [
+  { source: 'channel', target: 'agent', kind: 'channel_bind' },
+  { source: 'agent', target: 'subagent', kind: 'subagent' },
+  { source: 'subagent', target: 'skill', kind: 'skill' },
+  { source: 'agent', target: 'tool', kind: 'tool_grant' },
+  { source: 'agent', target: 'mcp', kind: 'tool_grant' },
+  { source: 'subagent', target: 'tool', kind: 'tool_grant' },
+  { source: 'subagent', target: 'mcp', kind: 'tool_grant' },
+  { source: 'schedule', target: 'agent', kind: 'schedule' },
+];
+
+/**
+ * Resolve the edge-kind for a directed source→target node-kind pair, or
+ * `null` when the connection is illegal. Used both by `isValidConnection`
+ * (reject illegal drags) and `onConnect` (derive the kind to POST).
+ */
+export function resolveEdgeKind(
+  source: CanvasNodeKind,
+  target: CanvasNodeKind,
+): EdgeKind | null {
+  const rule = EDGE_RULES.find(
+    (r) => r.source === source && r.target === target,
+  );
+  return rule ? rule.kind : null;
+}
+
+/** Hardcoded native-tool catalog surfaced in the toolbox palette. */
+export const NATIVE_TOOLS: readonly string[] = [
+  'web_search',
+  'query_knowledge_graph',
+  'render_diagram',
+  'book_meeting',
+  'find_free_slots',
+];

--- a/web-ui/app/_lib/agentBuilder.ts
+++ b/web-ui/app/_lib/agentBuilder.ts
@@ -326,6 +326,40 @@ export async function patchPositions(
 }
 
 // -----------------------------------------------------------------------------
+// Channel directory (available channels for the bind picker)
+// -----------------------------------------------------------------------------
+
+export interface ChannelDirectoryEntry {
+  channelType: string;
+  key: string;
+  label: string;
+  hint: string | null;
+}
+
+export interface ChannelDirectoryResponse {
+  types: string[];
+  keys: ChannelDirectoryEntry[];
+}
+
+export async function listChannelDirectory(): Promise<ChannelDirectoryResponse> {
+  return callJson<ChannelDirectoryResponse>('/v1/operator/channel-directory');
+}
+
+// -----------------------------------------------------------------------------
+// Per-agent native-tool allow-list (empty = all available)
+// -----------------------------------------------------------------------------
+
+export async function setAgentNativeTools(
+  slug: string,
+  tools: string[],
+): Promise<{ tools: string[] }> {
+  return callJson<{ tools: string[] }>(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/native-tools`,
+    { method: 'PUT', body: JSON.stringify({ tools }) },
+  );
+}
+
+// -----------------------------------------------------------------------------
 // Plugins (per-agent enable/disable)
 // -----------------------------------------------------------------------------
 

--- a/web-ui/app/_lib/agentBuilder.ts
+++ b/web-ui/app/_lib/agentBuilder.ts
@@ -168,12 +168,18 @@ export interface ScheduleNode {
   lastRunAt: string | null;
 }
 
+/** Read-only mirror of an enabled plugin on the agent (current-system view). */
+export interface PluginNode {
+  id: string;
+}
+
 export type EdgeKind =
   | 'channel_bind'
   | 'subagent'
   | 'skill'
   | 'tool_grant'
-  | 'schedule';
+  | 'schedule'
+  | 'plugin';
 
 export interface CanvasEdge {
   id: string;
@@ -190,6 +196,7 @@ export interface AgentGraph {
   tools: ToolGrantNode[];
   mcpServers: McpServerNode[];
   schedules: ScheduleNode[];
+  plugins: PluginNode[];
   edges: CanvasEdge[];
 }
 
@@ -455,7 +462,8 @@ export type CanvasNodeKind =
   | 'skill'
   | 'tool'
   | 'mcp'
-  | 'schedule';
+  | 'schedule'
+  | 'plugin';
 
 interface EdgeRule {
   source: CanvasNodeKind;

--- a/web-ui/app/admin/builder/BuilderCanvas.tsx
+++ b/web-ui/app/admin/builder/BuilderCanvas.tsx
@@ -1,0 +1,391 @@
+'use client';
+
+import '@xyflow/react/dist/style.css';
+
+import {
+  Background,
+  Controls,
+  type Connection,
+  type Edge,
+  type EdgeChange,
+  type NodeChange,
+  type NodeTypes,
+  ReactFlow,
+  ReactFlowProvider,
+  applyEdgeChanges,
+  applyNodeChanges,
+  useReactFlow,
+} from '@xyflow/react';
+import { useTranslations } from 'next-intl';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  createGraphEdge,
+  createSubAgent,
+  createSchedule,
+  createSkill,
+  createMcpServer,
+  deleteGraphEdge,
+  patchPositions,
+  resolveEdgeKind,
+  type CanvasPosition,
+  type EdgeKind,
+} from '../../_lib/agentBuilder';
+import { AgentNodeView } from './nodes/AgentNode';
+import { ChannelNodeView } from './nodes/ChannelNode';
+import { McpServerNodeView } from './nodes/McpServerNode';
+import { ScheduleNodeView } from './nodes/ScheduleNode';
+import { SkillNodeView } from './nodes/SkillNode';
+import { SubAgentNodeView } from './nodes/SubAgentNode';
+import { ToolNodeView } from './nodes/ToolNode';
+import type { BuilderNode, BuilderNodeData } from './nodes/types';
+import { graphToFlow, kindOfNodeId, nodeId } from './graphMapping';
+import { InspectorPanel } from './panels/InspectorPanel';
+import { DND_MIME, PalettePanel } from './panels/PalettePanel';
+import { TOOL_DND_MIME, ToolboxPanel, type ToolDragPayload } from './panels/ToolboxPanel';
+import { useAgentGraph } from './useAgentGraph';
+
+const nodeTypes: NodeTypes = {
+  channel: ChannelNodeView as NodeTypes[string],
+  agent: AgentNodeView as NodeTypes[string],
+  subagent: SubAgentNodeView as NodeTypes[string],
+  skill: SkillNodeView as NodeTypes[string],
+  tool: ToolNodeView as NodeTypes[string],
+  mcp: McpServerNodeView as NodeTypes[string],
+  schedule: ScheduleNodeView as NodeTypes[string],
+};
+
+export interface BuilderCanvasProps {
+  slug: string;
+}
+
+export default function BuilderCanvas(props: BuilderCanvasProps): React.ReactElement {
+  return (
+    <ReactFlowProvider>
+      <CanvasInner {...props} />
+    </ReactFlowProvider>
+  );
+}
+
+function CanvasInner({ slug }: BuilderCanvasProps): React.ReactElement {
+  const t = useTranslations('admin.builder');
+  const { state, actionError, clearActionError, reload, mutate } = useAgentGraph(slug);
+  const { screenToFlowPosition } = useReactFlow();
+
+  const labels = useMemo(
+    () => ({
+      channel: t('nodes.channel'),
+      agent: t('nodes.agent'),
+      subAgent: t('nodes.subagent'),
+      skill: t('nodes.skill'),
+      tool: t('nodes.tool'),
+      mcp: t('nodes.mcp'),
+      schedule: t('nodes.schedule'),
+      tools: t('nodes.tools'),
+    }),
+    [t],
+  );
+
+  const [nodes, setNodes] = useState<BuilderNode[]>([]);
+  const [edges, setEdges] = useState<Edge[]>([]);
+  const [selected, setSelected] = useState<BuilderNodeData | null>(null);
+  const dragTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+
+  // Re-derive the flow graph whenever the authoritative state changes.
+  useEffect(() => {
+    if (state.kind !== 'ready') return;
+    const flow = graphToFlow(state.graph, labels);
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setNodes(flow.nodes);
+    setEdges(flow.edges);
+  }, [state, labels]);
+
+  const onNodesChange = useCallback((changes: NodeChange[]) => {
+    setNodes((ns) => applyNodeChanges(changes, ns) as BuilderNode[]);
+  }, []);
+
+  const onEdgesChange = useCallback((changes: EdgeChange[]) => {
+    setEdges((es) => applyEdgeChanges(changes, es));
+  }, []);
+
+  const isValidConnection = useCallback((c: Connection | Edge): boolean => {
+    const s = kindOfNodeId(c.source ?? '');
+    const tgt = kindOfNodeId(c.target ?? '');
+    if (!s || !tgt) return false;
+    return resolveEdgeKind(s, tgt) !== null;
+  }, []);
+
+  const onConnect = useCallback(
+    (c: Connection) => {
+      const s = kindOfNodeId(c.source);
+      const tgt = kindOfNodeId(c.target);
+      if (!s || !tgt) return;
+      const kind = resolveEdgeKind(s, tgt);
+      if (!kind || !c.source || !c.target) return;
+      const tempId = `tmp-${String(Date.now())}`;
+      const source = c.source;
+      const target = c.target;
+      setEdges((es) => [...es, { id: tempId, source, target, data: { kind } }]);
+      void mutate(
+        (g) => g,
+        async () => {
+          try {
+            const res = await createGraphEdge(slug, { kind, source, target });
+            setEdges((es) =>
+              es.map((e) => (e.id === tempId ? { ...e, id: res.edge.id } : e)),
+            );
+          } catch (err) {
+            setEdges((es) => es.filter((e) => e.id !== tempId));
+            throw err;
+          }
+        },
+      );
+    },
+    [slug, mutate],
+  );
+
+  const onEdgesDelete = useCallback(
+    (deleted: Edge[]) => {
+      void mutate(
+        (g) => g,
+        async () => {
+          for (const e of deleted) {
+            const kind = (e.data as { kind?: EdgeKind } | undefined)?.kind;
+            if (!kind || e.id.startsWith('tmp-')) continue;
+            await deleteGraphEdge(slug, e.id, kind);
+          }
+        },
+      );
+    },
+    [slug, mutate],
+  );
+
+  // Debounced persistence of node positions after a drag settles.
+  const onNodeDragStop = useCallback(() => {
+    if (dragTimer.current) clearTimeout(dragTimer.current);
+    dragTimer.current = setTimeout(() => {
+      void persistPositions(slug, nodes);
+    }, 600);
+  }, [slug, nodes]);
+
+  useEffect(
+    () => () => {
+      if (dragTimer.current) clearTimeout(dragTimer.current);
+    },
+    [],
+  );
+
+  const onSelectionChange = useCallback(
+    (params: { nodes: BuilderNode[] }) => {
+      const first = params.nodes.length > 0 ? params.nodes[0] : undefined;
+      setSelected(first ? first.data : null);
+    },
+    [],
+  );
+
+  const handleToolDrop = useCallback(
+    (raw: string, pos: CanvasPosition): void => {
+      const payload = JSON.parse(raw) as ToolDragPayload;
+      // Find the agent/sub-agent node under the drop point to grant against.
+      const targetNode = nodeUnderPoint(nodes, pos);
+      if (
+        !targetNode ||
+        (targetNode.data.kind !== 'agent' && targetNode.data.kind !== 'subagent')
+      ) {
+        clearActionError();
+        return;
+      }
+      const toolNodeId = nodeId.tool(payload.toolRef);
+      void mutate(
+        (g) => g,
+        async () => {
+          await createGraphEdge(slug, {
+            kind: 'tool_grant',
+            source: targetNode.id,
+            target: toolNodeId,
+            config: {
+              toolKind: payload.toolKind,
+              toolRef: payload.toolRef,
+              mcpServerId: payload.mcpServerId,
+            },
+          });
+          await reload();
+        },
+      );
+    },
+    [slug, nodes, mutate, reload, clearActionError],
+  );
+
+  const handlePaletteDrop = useCallback(
+    (kind: string, pos: CanvasPosition): void => {
+      void mutate(
+        (g) => g,
+        async () => {
+          if (kind === 'subagent') {
+            await createSubAgent(slug, {
+              name: t('defaults.subAgentName'),
+              position: pos,
+            });
+          } else if (kind === 'skill') {
+            await createSkill({
+              slug: `skill-${String(Date.now())}`,
+              name: t('defaults.skillName'),
+              body: '',
+            });
+          } else if (kind === 'mcp') {
+            await createMcpServer({ name: t('defaults.mcpName'), transport: 'http' });
+          } else if (kind === 'schedule') {
+            await createSchedule(slug, { cron: '0 9 * * *', timezone: 'UTC' });
+          } else {
+            // channel — created via binding edge once wired; nothing to POST yet.
+            return;
+          }
+          await reload();
+        },
+      );
+    },
+    [slug, mutate, reload, t],
+  );
+
+  const onDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      const pos = screenToFlowPosition({ x: e.clientX, y: e.clientY });
+      const toolRaw = e.dataTransfer.getData(TOOL_DND_MIME);
+      if (toolRaw) {
+        handleToolDrop(toolRaw, pos);
+        return;
+      }
+      const nodeKind = e.dataTransfer.getData(DND_MIME);
+      if (nodeKind) handlePaletteDrop(nodeKind, pos);
+    },
+    [screenToFlowPosition, handleToolDrop, handlePaletteDrop],
+  );
+
+  if (state.kind === 'loading') {
+    return <Centered text={t('loading')} />;
+  }
+  if (state.kind === 'error') {
+    return <Centered text={`${t('loadError')}: ${state.message}`} tone="error" />;
+  }
+
+  return (
+    <div className="flex h-full w-full">
+      <PalettePanel />
+      <div
+        ref={wrapRef}
+        className="relative h-full flex-1"
+        onDragOver={(e) => {
+          e.preventDefault();
+          e.dataTransfer.dropEffect = 'move';
+        }}
+        onDrop={onDrop}
+      >
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          onEdgesDelete={onEdgesDelete}
+          onNodeDragStop={onNodeDragStop}
+          onSelectionChange={onSelectionChange}
+          isValidConnection={isValidConnection}
+          fitView
+          colorMode="dark"
+          proOptions={{ hideAttribution: true }}
+        >
+          <Background />
+          <Controls />
+        </ReactFlow>
+        {actionError && (
+          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 rounded-md border border-red-500/40 bg-red-500/10 px-4 py-2 text-sm text-red-400">
+            {actionError}
+          </div>
+        )}
+      </div>
+      {selected && (
+        <InspectorPanel
+          slug={slug}
+          data={selected}
+          onClose={() => setSelected(null)}
+          onSaved={() => void reload()}
+        />
+      )}
+      {state.kind === 'ready' && (
+        <ToolboxPanel mcpServers={state.graph.mcpServers} />
+      )}
+    </div>
+  );
+}
+
+function nodeUnderPoint(nodes: BuilderNode[], pos: CanvasPosition): BuilderNode | null {
+  // Reverse so topmost (later-rendered) node wins on overlap.
+  for (let i = nodes.length - 1; i >= 0; i -= 1) {
+    const n = nodes[i];
+    if (!n) continue;
+    const w = n.measured?.width ?? 220;
+    const h = n.measured?.height ?? 80;
+    if (
+      pos.x >= n.position.x &&
+      pos.x <= n.position.x + w &&
+      pos.y >= n.position.y &&
+      pos.y <= n.position.y + h
+    ) {
+      return n;
+    }
+  }
+  return null;
+}
+
+async function persistPositions(slug: string, nodes: BuilderNode[]): Promise<void> {
+  const subAgents: Array<{ id: string; position: CanvasPosition }> = [];
+  const channels: Array<{
+    channelType: string;
+    channelKey: string;
+    position: CanvasPosition;
+  }> = [];
+  let agent: CanvasPosition | undefined;
+
+  for (const n of nodes) {
+    const data = n.data;
+    if (data.kind === 'agent') {
+      agent = n.position;
+    } else if (data.kind === 'subagent') {
+      subAgents.push({ id: data.subAgent.id, position: n.position });
+    } else if (data.kind === 'channel') {
+      channels.push({
+        channelType: data.channel.channelType,
+        channelKey: data.channel.channelKey,
+        position: n.position,
+      });
+    }
+  }
+  try {
+    await patchPositions(slug, {
+      ...(agent ? { agent } : {}),
+      ...(subAgents.length ? { subAgents } : {}),
+      ...(channels.length ? { channels } : {}),
+    });
+  } catch {
+    // Position drift is non-critical; a reload will reconcile.
+  }
+}
+
+function Centered({
+  text,
+  tone,
+}: {
+  text: string;
+  tone?: 'error';
+}): React.ReactElement {
+  return (
+    <div
+      className={`flex h-full w-full items-center justify-center text-sm ${tone === 'error' ? 'text-red-500' : 'text-[color:var(--fg-muted)]'}`}
+    >
+      {text}
+    </div>
+  );
+}

--- a/web-ui/app/admin/builder/BuilderCanvas.tsx
+++ b/web-ui/app/admin/builder/BuilderCanvas.tsx
@@ -89,6 +89,7 @@ function CanvasInner({ slug }: BuilderCanvasProps): React.ReactElement {
       schedule: t('nodes.schedule'),
       plugin: t('nodes.plugin'),
       tools: t('nodes.tools'),
+      nativeBaseline: t('nodes.nativeBaseline'),
     }),
     [t],
   );
@@ -307,15 +308,34 @@ function CanvasInner({ slug }: BuilderCanvasProps): React.ReactElement {
             await createMcpServer({ name: t('defaults.mcpName'), transport: 'http' });
           } else if (kind === 'schedule') {
             await createSchedule(slug, { cron: '0 9 * * *', timezone: 'UTC' });
+          } else if (kind === 'channel') {
+            // Channel needs a type+key before it can bind — drop a draft node
+            // the operator fills in via the inspector, then "Bind" persists it.
+            const draftId = `channel:__draft__:${String(Date.now())}`;
+            setNodes((ns) => [
+              ...ns,
+              {
+                id: draftId,
+                type: 'channel',
+                position: pos,
+                deletable: true,
+                data: {
+                  kind: 'channel',
+                  labels,
+                  channel: { channelType: '', channelKey: '', position: null },
+                  draft: true,
+                },
+              },
+            ]);
+            return;
           } else {
-            // channel — created via binding edge once wired; nothing to POST yet.
             return;
           }
           await reload();
         },
       );
     },
-    [slug, mutate, reload, t],
+    [slug, mutate, reload, t, labels],
   );
 
   const onDrop = useCallback(

--- a/web-ui/app/admin/builder/BuilderCanvas.tsx
+++ b/web-ui/app/admin/builder/BuilderCanvas.tsx
@@ -405,6 +405,14 @@ function CanvasInner({ slug }: BuilderCanvasProps): React.ReactElement {
           onClose={() => setSelected(null)}
           onSaved={() => void reload()}
           onDelete={deleteSelected}
+          nativeTools={state.kind === 'ready' ? state.graph.nativeTools : []}
+          nativeGrants={
+            state.kind === 'ready'
+              ? state.graph.tools
+                  .filter((g) => g.agentId && g.toolKind === 'native')
+                  .map((g) => g.toolRef)
+              : []
+          }
         />
       )}
       {state.kind === 'ready' && (

--- a/web-ui/app/admin/builder/BuilderCanvas.tsx
+++ b/web-ui/app/admin/builder/BuilderCanvas.tsx
@@ -26,6 +26,10 @@ import {
   createSkill,
   createMcpServer,
   deleteGraphEdge,
+  deleteSubAgent,
+  deleteSkill,
+  deleteMcpServer,
+  deleteSchedule,
   patchPositions,
   resolveEdgeKind,
   type CanvasPosition,
@@ -34,6 +38,7 @@ import {
 import { AgentNodeView } from './nodes/AgentNode';
 import { ChannelNodeView } from './nodes/ChannelNode';
 import { McpServerNodeView } from './nodes/McpServerNode';
+import { PluginNodeView } from './nodes/PluginNode';
 import { ScheduleNodeView } from './nodes/ScheduleNode';
 import { SkillNodeView } from './nodes/SkillNode';
 import { SubAgentNodeView } from './nodes/SubAgentNode';
@@ -53,6 +58,7 @@ const nodeTypes: NodeTypes = {
   tool: ToolNodeView as NodeTypes[string],
   mcp: McpServerNodeView as NodeTypes[string],
   schedule: ScheduleNodeView as NodeTypes[string],
+  plugin: PluginNodeView as NodeTypes[string],
 };
 
 export interface BuilderCanvasProps {
@@ -81,6 +87,7 @@ function CanvasInner({ slug }: BuilderCanvasProps): React.ReactElement {
       tool: t('nodes.tool'),
       mcp: t('nodes.mcp'),
       schedule: t('nodes.schedule'),
+      plugin: t('nodes.plugin'),
       tools: t('nodes.tools'),
     }),
     [t],
@@ -159,6 +166,69 @@ function CanvasInner({ slug }: BuilderCanvasProps): React.ReactElement {
       );
     },
     [slug, mutate],
+  );
+
+  // Map a node to its backend delete. Agent + plugin nodes are not deletable
+  // (the agent is the canvas root; plugin nodes mirror the live system).
+  const deleteNodeData = useCallback(
+    async (data: BuilderNodeData): Promise<void> => {
+      switch (data.kind) {
+        case 'subagent':
+          await deleteSubAgent(slug, data.subAgent.id);
+          return;
+        case 'skill':
+          await deleteSkill(data.skill.id);
+          return;
+        case 'mcp':
+          await deleteMcpServer(data.server.id);
+          return;
+        case 'schedule':
+          await deleteSchedule(slug, data.schedule.id);
+          return;
+        case 'channel':
+          await deleteGraphEdge(
+            slug,
+            `channel_bind:${data.channel.channelType}:${data.channel.channelKey}`,
+            'channel_bind',
+          );
+          return;
+        case 'tool':
+          if (data.grant) {
+            await deleteGraphEdge(slug, `tool_grant:${data.grant.id}`, 'tool_grant');
+          }
+          return;
+        default:
+          return; // agent, plugin — not deletable
+      }
+    },
+    [slug],
+  );
+
+  const onNodesDelete = useCallback(
+    (deleted: BuilderNode[]) => {
+      void mutate(
+        (g) => g,
+        async () => {
+          for (const n of deleted) await deleteNodeData(n.data);
+          await reload();
+        },
+      );
+    },
+    [mutate, reload, deleteNodeData],
+  );
+
+  const deleteSelected = useCallback(
+    (data: BuilderNodeData) => {
+      setSelected(null);
+      void mutate(
+        (g) => g,
+        async () => {
+          await deleteNodeData(data);
+          await reload();
+        },
+      );
+    },
+    [mutate, reload, deleteNodeData],
   );
 
   // Debounced persistence of node positions after a drag settles.
@@ -290,9 +360,11 @@ function CanvasInner({ slug }: BuilderCanvasProps): React.ReactElement {
           onEdgesChange={onEdgesChange}
           onConnect={onConnect}
           onEdgesDelete={onEdgesDelete}
+          onNodesDelete={onNodesDelete}
           onNodeDragStop={onNodeDragStop}
           onSelectionChange={onSelectionChange}
           isValidConnection={isValidConnection}
+          deleteKeyCode={['Backspace', 'Delete']}
           fitView
           colorMode="dark"
           proOptions={{ hideAttribution: true }}
@@ -312,6 +384,7 @@ function CanvasInner({ slug }: BuilderCanvasProps): React.ReactElement {
           data={selected}
           onClose={() => setSelected(null)}
           onSaved={() => void reload()}
+          onDelete={deleteSelected}
         />
       )}
       {state.kind === 'ready' && (

--- a/web-ui/app/admin/builder/graphMapping.ts
+++ b/web-ui/app/admin/builder/graphMapping.ts
@@ -1,0 +1,126 @@
+import type { Edge } from '@xyflow/react';
+import type { AgentGraph, CanvasNodeKind } from '../../_lib/agentBuilder';
+import type { BuilderNode } from './nodes/types';
+
+/**
+ * Deterministic node-id helpers. A canvas node id encodes its kind so the
+ * connection handler can recover the node-kind pair purely from the id when
+ * the node `data` is momentarily stale during an optimistic add.
+ */
+export const nodeId = {
+  channel: (c: { channelType: string; channelKey: string }): string =>
+    `channel:${c.channelType}:${c.channelKey}`,
+  agent: (id: string): string => `agent:${id}`,
+  subagent: (id: string): string => `subagent:${id}`,
+  skill: (id: string): string => `skill:${id}`,
+  tool: (ref: string): string => `tool:${ref}`,
+  mcp: (id: string): string => `mcp:${id}`,
+  schedule: (id: string): string => `schedule:${id}`,
+};
+
+export function kindOfNodeId(id: string): CanvasNodeKind | null {
+  const prefix = id.split(':', 1)[0];
+  switch (prefix) {
+    case 'channel':
+      return 'channel';
+    case 'agent':
+      return 'agent';
+    case 'subagent':
+      return 'subagent';
+    case 'skill':
+      return 'skill';
+    case 'tool':
+      return 'tool';
+    case 'mcp':
+      return 'mcp';
+    case 'schedule':
+      return 'schedule';
+    default:
+      return null;
+  }
+}
+
+/** Auto-layout fallback when a node carries no persisted position. */
+function gridPos(col: number, row: number): { x: number; y: number } {
+  return { x: col * 300 + 40, y: row * 130 + 40 };
+}
+
+export function graphToFlow(
+  graph: AgentGraph,
+  labels: Record<string, string>,
+): { nodes: BuilderNode[]; edges: Edge[] } {
+  const nodes: BuilderNode[] = [];
+
+  graph.channels.forEach((channel, i) => {
+    nodes.push({
+      id: nodeId.channel(channel),
+      type: 'channel',
+      position: channel.position ?? gridPos(0, i),
+      data: { kind: 'channel', labels, channel },
+    });
+  });
+
+  nodes.push({
+    id: nodeId.agent(graph.agent.id),
+    type: 'agent',
+    position: graph.agent.position ?? gridPos(1, 0),
+    data: { kind: 'agent', labels, agent: graph.agent },
+  });
+
+  graph.subAgents.forEach((subAgent, i) => {
+    nodes.push({
+      id: nodeId.subagent(subAgent.id),
+      type: 'subagent',
+      position: subAgent.position ?? gridPos(2, i),
+      data: { kind: 'subagent', labels, subAgent },
+    });
+  });
+
+  graph.skills.forEach((skill, i) => {
+    nodes.push({
+      id: nodeId.skill(skill.id),
+      type: 'skill',
+      position: gridPos(3, i),
+      data: { kind: 'skill', labels, skill },
+    });
+  });
+
+  const grantByTool = new Map(graph.tools.map((g) => [g.toolRef, g]));
+  const toolRefs = new Set(graph.tools.map((g) => g.toolRef));
+  Array.from(toolRefs).forEach((ref, i) => {
+    nodes.push({
+      id: nodeId.tool(ref),
+      type: 'tool',
+      position: gridPos(3, graph.skills.length + i),
+      data: { kind: 'tool', labels, toolRef: ref, grant: grantByTool.get(ref) ?? null },
+    });
+  });
+
+  graph.mcpServers.forEach((server, i) => {
+    nodes.push({
+      id: nodeId.mcp(server.id),
+      type: 'mcp',
+      position: gridPos(4, i),
+      data: { kind: 'mcp', labels, server },
+    });
+  });
+
+  graph.schedules.forEach((schedule, i) => {
+    nodes.push({
+      id: nodeId.schedule(schedule.id),
+      type: 'schedule',
+      position: gridPos(0, graph.channels.length + i),
+      data: { kind: 'schedule', labels, schedule },
+    });
+  });
+
+  const edges: Edge[] = graph.edges.map((e) => ({
+    id: e.id,
+    source: e.source,
+    target: e.target,
+    data: { kind: e.kind },
+    animated: e.kind === 'schedule',
+  }));
+
+  return { nodes, edges };
+}

--- a/web-ui/app/admin/builder/graphMapping.ts
+++ b/web-ui/app/admin/builder/graphMapping.ts
@@ -16,6 +16,7 @@ export const nodeId = {
   tool: (ref: string): string => `tool:${ref}`,
   mcp: (id: string): string => `mcp:${id}`,
   schedule: (id: string): string => `schedule:${id}`,
+  plugin: (id: string): string => `plugin:${id}`,
 };
 
 export function kindOfNodeId(id: string): CanvasNodeKind | null {
@@ -35,6 +36,8 @@ export function kindOfNodeId(id: string): CanvasNodeKind | null {
       return 'mcp';
     case 'schedule':
       return 'schedule';
+    case 'plugin':
+      return 'plugin';
     default:
       return null;
   }
@@ -64,7 +67,19 @@ export function graphToFlow(
     id: nodeId.agent(graph.agent.id),
     type: 'agent',
     position: graph.agent.position ?? gridPos(1, 0),
+    deletable: false,
     data: { kind: 'agent', labels, agent: graph.agent },
+  });
+
+  (graph.plugins ?? []).forEach((plugin, i) => {
+    nodes.push({
+      id: nodeId.plugin(plugin.id),
+      type: 'plugin',
+      position: gridPos(1, i + 1),
+      deletable: false,
+      connectable: false,
+      data: { kind: 'plugin', labels, plugin },
+    });
   });
 
   graph.subAgents.forEach((subAgent, i) => {

--- a/web-ui/app/admin/builder/graphMapping.ts
+++ b/web-ui/app/admin/builder/graphMapping.ts
@@ -111,6 +111,23 @@ export function graphToFlow(
     });
   });
 
+  // Read-only baseline: orchestrator-native tools the agent can already use
+  // (current-system view). Skip any that are explicitly granted (a grant node
+  // already represents them). Non-deletable; wired into the agent.
+  const nativeBaseline = (graph.nativeTools ?? []).filter(
+    (ref) => !toolRefs.has(ref),
+  );
+  nativeBaseline.forEach((ref, i) => {
+    nodes.push({
+      id: nodeId.tool(ref),
+      type: 'tool',
+      position: gridPos(5, i),
+      deletable: false,
+      connectable: false,
+      data: { kind: 'tool', labels, toolRef: ref, grant: null, system: true },
+    });
+  });
+
   graph.mcpServers.forEach((server, i) => {
     nodes.push({
       id: nodeId.mcp(server.id),
@@ -136,6 +153,16 @@ export function graphToFlow(
     data: { kind: e.kind },
     animated: e.kind === 'schedule',
   }));
+  // Client-only baseline native-tool edges (read-only; not persisted).
+  for (const ref of nativeBaseline) {
+    edges.push({
+      id: `native:${ref}`,
+      source: nodeId.agent(graph.agent.id),
+      target: nodeId.tool(ref),
+      data: { kind: 'tool_grant' },
+      deletable: false,
+    });
+  }
 
   return { nodes, edges };
 }

--- a/web-ui/app/admin/builder/nodes/AgentNode.tsx
+++ b/web-ui/app/admin/builder/nodes/AgentNode.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import type { NodeProps } from '@xyflow/react';
+import { NodeShell } from './NodeShell';
+import type { AgentNodeData } from './types';
+
+export function AgentNodeView({
+  data,
+  selected,
+}: NodeProps & { data: AgentNodeData }): React.ReactElement {
+  const { agent, labels } = data;
+  const routing = agent.modelRouting;
+  return (
+    <NodeShell
+      kind="agent"
+      title={agent.name}
+      subtitle={agent.description}
+      badge={labels['agent']}
+      selected={selected}
+      hasTarget
+      hasSource
+    >
+      <div className="mt-1.5 flex flex-wrap gap-1">
+        <Pill text={agent.privacyProfile} />
+        <Pill text={agent.status} />
+        {routing ? <Pill text={`${routing.mode}: ${routing.main}`} /> : null}
+      </div>
+    </NodeShell>
+  );
+}
+
+function Pill({ text }: { text: string }): React.ReactElement {
+  return (
+    <span className="rounded bg-[color:var(--border)]/40 px-1.5 py-0.5 text-[9px] text-[color:var(--fg-muted)]">
+      {text}
+    </span>
+  );
+}

--- a/web-ui/app/admin/builder/nodes/ChannelNode.tsx
+++ b/web-ui/app/admin/builder/nodes/ChannelNode.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import type { NodeProps } from '@xyflow/react';
+import { NodeShell } from './NodeShell';
+import type { ChannelNodeData } from './types';
+
+export function ChannelNodeView({
+  data,
+  selected,
+}: NodeProps & { data: ChannelNodeData }): React.ReactElement {
+  const { channel, labels } = data;
+  return (
+    <NodeShell
+      kind="channel"
+      title={channel.channelType}
+      subtitle={channel.channelKey}
+      badge={labels['channel']}
+      selected={selected}
+      hasSource
+    />
+  );
+}

--- a/web-ui/app/admin/builder/nodes/McpServerNode.tsx
+++ b/web-ui/app/admin/builder/nodes/McpServerNode.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import type { NodeProps } from '@xyflow/react';
+import { NodeShell } from './NodeShell';
+import type { McpNodeData } from './types';
+
+export function McpServerNodeView({
+  data,
+  selected,
+}: NodeProps & { data: McpNodeData }): React.ReactElement {
+  const { server, labels } = data;
+  const toolCount = server.discoveredTools.length;
+  return (
+    <NodeShell
+      kind="mcp"
+      title={server.name}
+      subtitle={server.endpoint ?? server.transport}
+      badge={labels['mcp']}
+      selected={selected}
+      hasTarget
+    >
+      <div className="mt-1.5 text-[10px] text-[color:var(--fg-muted)]">
+        {toolCount} {labels['tools']}
+      </div>
+    </NodeShell>
+  );
+}

--- a/web-ui/app/admin/builder/nodes/NodeShell.tsx
+++ b/web-ui/app/admin/builder/nodes/NodeShell.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { Handle, Position } from '@xyflow/react';
+import type { CanvasNodeKind } from '../../../_lib/agentBuilder';
+
+export interface NodeShellProps {
+  kind: CanvasNodeKind;
+  title: string;
+  subtitle?: string | null;
+  badge?: string | null;
+  selected?: boolean;
+  /** Render a target handle (left) — node can be a connection target. */
+  hasTarget?: boolean;
+  /** Render a source handle (right) — node can start a connection. */
+  hasSource?: boolean;
+  children?: React.ReactNode;
+}
+
+const ACCENTS: Record<CanvasNodeKind, string> = {
+  channel: 'var(--accent)',
+  agent: '#7c5cff',
+  subagent: '#3aa0ff',
+  skill: '#34d399',
+  tool: '#f59e0b',
+  mcp: '#ec4899',
+  schedule: '#a3a3a3',
+};
+
+/**
+ * Shared visual shell for every canvas node. Keeps each node-type file tiny
+ * — they just pass a title/subtitle/badge and which handles to expose. The
+ * left/coloured rail encodes the node kind at a glance.
+ */
+export function NodeShell({
+  kind,
+  title,
+  subtitle,
+  badge,
+  selected,
+  hasTarget,
+  hasSource,
+  children,
+}: NodeShellProps): React.ReactElement {
+  const accent = ACCENTS[kind];
+  return (
+    <div
+      className="relative min-w-[180px] max-w-[260px] overflow-hidden rounded-[12px] border bg-[color:var(--card)] text-left shadow-sm"
+      style={{
+        borderColor: selected ? accent : 'var(--border)',
+        boxShadow: selected ? `0 0 0 1px ${accent}` : undefined,
+      }}
+    >
+      <div className="absolute inset-y-0 left-0 w-1" style={{ background: accent }} />
+      {hasTarget && (
+        <Handle
+          type="target"
+          position={Position.Left}
+          style={{ background: accent, width: 9, height: 9 }}
+        />
+      )}
+      {hasSource && (
+        <Handle
+          type="source"
+          position={Position.Right}
+          style={{ background: accent, width: 9, height: 9 }}
+        />
+      )}
+      <div className="px-3 py-2.5 pl-4">
+        <div className="flex items-start justify-between gap-2">
+          <span className="text-[13px] font-semibold leading-tight text-[color:var(--fg-strong)]">
+            {title}
+          </span>
+          {badge ? (
+            <span
+              className="shrink-0 rounded-full px-1.5 py-0.5 text-[9px] uppercase tracking-[0.14em]"
+              style={{ background: `${accent}22`, color: accent }}
+            >
+              {badge}
+            </span>
+          ) : null}
+        </div>
+        {subtitle ? (
+          <p className="mt-0.5 line-clamp-2 text-[11px] leading-snug text-[color:var(--fg-muted)]">
+            {subtitle}
+          </p>
+        ) : null}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/web-ui/app/admin/builder/nodes/NodeShell.tsx
+++ b/web-ui/app/admin/builder/nodes/NodeShell.tsx
@@ -24,6 +24,7 @@ const ACCENTS: Record<CanvasNodeKind, string> = {
   tool: '#f59e0b',
   mcp: '#ec4899',
   schedule: '#a3a3a3',
+  plugin: '#64748b',
 };
 
 /**

--- a/web-ui/app/admin/builder/nodes/PluginNode.tsx
+++ b/web-ui/app/admin/builder/nodes/PluginNode.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import type { NodeProps } from '@xyflow/react';
+import { NodeShell } from './NodeShell';
+import type { PluginNodeData } from './types';
+
+/**
+ * Read-only node mirroring an enabled plugin on the agent — the current-system
+ * representation. Not deletable/connectable (managed via plugin install, not
+ * the canvas); it connects into the agent so the operator sees the real
+ * capability surface at a glance.
+ */
+export function PluginNodeView({
+  data,
+  selected,
+}: NodeProps & { data: PluginNodeData }): React.ReactElement {
+  const { plugin, labels } = data;
+  return (
+    <NodeShell
+      kind="plugin"
+      title={plugin.id}
+      badge={labels['plugin']}
+      selected={selected}
+      hasSource
+    />
+  );
+}

--- a/web-ui/app/admin/builder/nodes/ScheduleNode.tsx
+++ b/web-ui/app/admin/builder/nodes/ScheduleNode.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import type { NodeProps } from '@xyflow/react';
+import { NodeShell } from './NodeShell';
+import type { ScheduleNodeData } from './types';
+
+export function ScheduleNodeView({
+  data,
+  selected,
+}: NodeProps & { data: ScheduleNodeData }): React.ReactElement {
+  const { schedule, labels } = data;
+  return (
+    <NodeShell
+      kind="schedule"
+      title={schedule.cron}
+      subtitle={schedule.timezone}
+      badge={labels['schedule']}
+      selected={selected}
+      hasSource
+    />
+  );
+}

--- a/web-ui/app/admin/builder/nodes/SkillNode.tsx
+++ b/web-ui/app/admin/builder/nodes/SkillNode.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import type { NodeProps } from '@xyflow/react';
+import { NodeShell } from './NodeShell';
+import type { SkillNodeData } from './types';
+
+export function SkillNodeView({
+  data,
+  selected,
+}: NodeProps & { data: SkillNodeData }): React.ReactElement {
+  const { skill, labels } = data;
+  return (
+    <NodeShell
+      kind="skill"
+      title={skill.name}
+      subtitle={skill.description}
+      badge={labels['skill']}
+      selected={selected}
+      hasTarget
+    />
+  );
+}

--- a/web-ui/app/admin/builder/nodes/SubAgentNode.tsx
+++ b/web-ui/app/admin/builder/nodes/SubAgentNode.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import type { NodeProps } from '@xyflow/react';
+import { NodeShell } from './NodeShell';
+import type { SubAgentNodeData } from './types';
+
+export function SubAgentNodeView({
+  data,
+  selected,
+}: NodeProps & { data: SubAgentNodeData }): React.ReactElement {
+  const { subAgent, labels } = data;
+  return (
+    <NodeShell
+      kind="subagent"
+      title={subAgent.name}
+      subtitle={subAgent.model}
+      badge={labels['subAgent']}
+      selected={selected}
+      hasTarget
+      hasSource
+    />
+  );
+}

--- a/web-ui/app/admin/builder/nodes/ToolNode.tsx
+++ b/web-ui/app/admin/builder/nodes/ToolNode.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import type { NodeProps } from '@xyflow/react';
+import { NodeShell } from './NodeShell';
+import type { ToolNodeData } from './types';
+
+export function ToolNodeView({
+  data,
+  selected,
+}: NodeProps & { data: ToolNodeData }): React.ReactElement {
+  const { toolRef, labels } = data;
+  return (
+    <NodeShell
+      kind="tool"
+      title={toolRef}
+      badge={labels['tool']}
+      selected={selected}
+      hasTarget
+    />
+  );
+}

--- a/web-ui/app/admin/builder/nodes/ToolNode.tsx
+++ b/web-ui/app/admin/builder/nodes/ToolNode.tsx
@@ -8,12 +8,13 @@ export function ToolNodeView({
   data,
   selected,
 }: NodeProps & { data: ToolNodeData }): React.ReactElement {
-  const { toolRef, labels } = data;
+  const { toolRef, labels, system } = data;
   return (
     <NodeShell
       kind="tool"
       title={toolRef}
       badge={labels['tool']}
+      subtitle={system ? labels['nativeBaseline'] : null}
       selected={selected}
       hasTarget
     />

--- a/web-ui/app/admin/builder/nodes/types.ts
+++ b/web-ui/app/admin/builder/nodes/types.ts
@@ -1,0 +1,63 @@
+import type { Node } from '@xyflow/react';
+import type {
+  AgentNode,
+  CanvasNodeKind,
+  ChannelNode,
+  McpServerNode,
+  ScheduleNode,
+  SkillNode,
+  SubAgentNode,
+  ToolGrantNode,
+} from '../../../_lib/agentBuilder';
+
+/**
+ * Per-node data carried on the ReactFlow node. Every node stamps its
+ * `kind` so `isValidConnection` can look the source/target pair up against
+ * the edge-semantics table without re-deriving it from the DOM.
+ */
+export interface BaseNodeData extends Record<string, unknown> {
+  kind: CanvasNodeKind;
+  /** i18n labels resolved once in the canvas and threaded into node UIs. */
+  labels: Record<string, string>;
+}
+
+export interface ChannelNodeData extends BaseNodeData {
+  kind: 'channel';
+  channel: ChannelNode;
+}
+export interface AgentNodeData extends BaseNodeData {
+  kind: 'agent';
+  agent: AgentNode;
+}
+export interface SubAgentNodeData extends BaseNodeData {
+  kind: 'subagent';
+  subAgent: SubAgentNode;
+}
+export interface SkillNodeData extends BaseNodeData {
+  kind: 'skill';
+  skill: SkillNode;
+}
+export interface ToolNodeData extends BaseNodeData {
+  kind: 'tool';
+  toolRef: string;
+  grant: ToolGrantNode | null;
+}
+export interface McpNodeData extends BaseNodeData {
+  kind: 'mcp';
+  server: McpServerNode;
+}
+export interface ScheduleNodeData extends BaseNodeData {
+  kind: 'schedule';
+  schedule: ScheduleNode;
+}
+
+export type BuilderNodeData =
+  | ChannelNodeData
+  | AgentNodeData
+  | SubAgentNodeData
+  | SkillNodeData
+  | ToolNodeData
+  | McpNodeData
+  | ScheduleNodeData;
+
+export type BuilderNode = Node<BuilderNodeData>;

--- a/web-ui/app/admin/builder/nodes/types.ts
+++ b/web-ui/app/admin/builder/nodes/types.ts
@@ -4,6 +4,7 @@ import type {
   CanvasNodeKind,
   ChannelNode,
   McpServerNode,
+  PluginNode,
   ScheduleNode,
   SkillNode,
   SubAgentNode,
@@ -50,6 +51,10 @@ export interface ScheduleNodeData extends BaseNodeData {
   kind: 'schedule';
   schedule: ScheduleNode;
 }
+export interface PluginNodeData extends BaseNodeData {
+  kind: 'plugin';
+  plugin: PluginNode;
+}
 
 export type BuilderNodeData =
   | ChannelNodeData
@@ -58,6 +63,7 @@ export type BuilderNodeData =
   | SkillNodeData
   | ToolNodeData
   | McpNodeData
-  | ScheduleNodeData;
+  | ScheduleNodeData
+  | PluginNodeData;
 
 export type BuilderNode = Node<BuilderNodeData>;

--- a/web-ui/app/admin/builder/nodes/types.ts
+++ b/web-ui/app/admin/builder/nodes/types.ts
@@ -25,6 +25,8 @@ export interface BaseNodeData extends Record<string, unknown> {
 export interface ChannelNodeData extends BaseNodeData {
   kind: 'channel';
   channel: ChannelNode;
+  /** Client-only: a freshly-added channel awaiting type/key before it binds. */
+  draft?: boolean;
 }
 export interface AgentNodeData extends BaseNodeData {
   kind: 'agent';
@@ -42,6 +44,8 @@ export interface ToolNodeData extends BaseNodeData {
   kind: 'tool';
   toolRef: string;
   grant: ToolGrantNode | null;
+  /** True for read-only baseline native tools (current-system view). */
+  system?: boolean;
 }
 export interface McpNodeData extends BaseNodeData {
   kind: 'mcp';

--- a/web-ui/app/admin/builder/page.tsx
+++ b/web-ui/app/admin/builder/page.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useTranslations } from 'next-intl';
+import { useEffect, useState } from 'react';
+
+import {
+  listOperatorAgents,
+  type OperatorAgentDto,
+} from '../../_lib/agents';
+
+const BuilderCanvas = dynamic(() => import('./BuilderCanvas'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-full items-center justify-center text-sm text-[color:var(--fg-muted)]">
+      …
+    </div>
+  ),
+});
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ready'; agents: OperatorAgentDto[] }
+  | { kind: 'error'; message: string };
+
+/**
+ * Agent-Builder visual canvas (`/admin/builder`). Pick an agent, then wire
+ * Channels → Agent → Sub-Agents → Skills → Tools/MCP plus a Schedule
+ * trigger on an editable node-graph. The canvas itself is lazy-loaded
+ * (ssr:false) to keep @xyflow out of the main bundle and avoid SSR issues.
+ */
+export default function BuilderPage(): React.ReactElement {
+  const t = useTranslations('admin.builder');
+  const [state, setState] = useState<State>({ kind: 'loading' });
+  const [slug, setSlug] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      try {
+        const res = await listOperatorAgents();
+        if (!alive) return;
+        setState({ kind: 'ready', agents: res.agents });
+        const first = res.agents.length > 0 ? res.agents[0] : undefined;
+        if (first) setSlug(first.slug);
+      } catch (err) {
+        if (!alive) return;
+        setState({
+          kind: 'error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return (
+    <main className="flex h-[calc(100vh-var(--nav-h,64px))] flex-col">
+      <header className="flex items-center justify-between gap-4 border-b border-[color:var(--border)] px-6 py-4">
+        <div>
+          <h1 className="text-xl font-semibold text-[color:var(--fg-strong)]">
+            {t('title')}
+          </h1>
+          <p className="mt-0.5 text-[13px] text-[color:var(--fg-muted)]">
+            {t('subtitle')}
+          </p>
+        </div>
+        {state.kind === 'ready' && (
+          <label className="flex items-center gap-2 text-sm">
+            <span className="text-[color:var(--fg-muted)]">{t('agentPicker')}</span>
+            <select
+              value={slug ?? ''}
+              onChange={(e) => setSlug(e.target.value || null)}
+              className="rounded-md border border-[color:var(--border)] bg-transparent px-3 py-1.5 text-sm outline-none focus:border-[color:var(--accent)]"
+            >
+              {state.agents.length === 0 && <option value="">—</option>}
+              {state.agents.map((a) => (
+                <option key={a.slug} value={a.slug}>
+                  {a.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+      </header>
+
+      <div className="min-h-0 flex-1">
+        {state.kind === 'loading' && (
+          <p className="px-6 py-6 text-sm text-[color:var(--fg-muted)]">{t('loading')}</p>
+        )}
+        {state.kind === 'error' && (
+          <p className="px-6 py-6 text-sm text-red-500">
+            {t('loadError')}: {state.message}
+          </p>
+        )}
+        {state.kind === 'ready' && slug && <BuilderCanvas slug={slug} />}
+        {state.kind === 'ready' && !slug && (
+          <p className="px-6 py-6 text-sm text-[color:var(--fg-muted)]">
+            {t('noAgents')}
+          </p>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/web-ui/app/admin/builder/panels/InspectorControls.tsx
+++ b/web-ui/app/admin/builder/panels/InspectorControls.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+export const inputCls =
+  'w-full rounded-md border border-[color:var(--border)] bg-transparent px-3 py-2 text-sm outline-none focus:border-[color:var(--accent)]';
+
+export function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+export function SaveButton({
+  onClick,
+  pending,
+  label,
+}: {
+  onClick: () => void;
+  pending: boolean;
+  label: string;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={pending}
+      className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-black disabled:opacity-50"
+    >
+      {pending ? '…' : label}
+    </button>
+  );
+}

--- a/web-ui/app/admin/builder/panels/InspectorPanel.tsx
+++ b/web-ui/app/admin/builder/panels/InspectorPanel.tsx
@@ -1,10 +1,14 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import {
+  createGraphEdge,
+  disablePlugin,
   discoverMcpTools,
+  enablePlugin,
+  listInstallablePlugins,
   patchModelRouting,
   patchSkill,
   patchSubAgent,
@@ -12,11 +16,12 @@ import {
   type McpServerNode,
   type ModelRoutingConfig,
   type ModelRoutingMode,
+  type PluginNode,
   type ScheduleNode,
   type SkillNode,
   type SubAgentNode,
 } from '../../../_lib/agentBuilder';
-import type { BuilderNodeData } from '../nodes/types';
+import type { BuilderNodeData, ChannelNodeData } from '../nodes/types';
 import { Field, inputCls, SaveButton } from './InspectorControls';
 
 export interface InspectorPanelProps {
@@ -79,6 +84,10 @@ function Editor(props: InspectorPanelProps): React.ReactElement {
       return <McpEditor server={data.server} onSaved={props.onSaved} />;
     case 'schedule':
       return <ScheduleViewer schedule={data.schedule} />;
+    case 'channel':
+      return <ChannelEditor slug={props.slug} data={data} onSaved={props.onSaved} />;
+    case 'plugin':
+      return <PluginEditor slug={props.slug} plugin={data.plugin} onSaved={props.onSaved} />;
     default:
       return <ReadOnly />;
   }
@@ -132,6 +141,27 @@ function AgentEditor({
   const [triage, setTriage] = useState(r?.triage ?? '');
   const [simple, setSimple] = useState(r?.simple ?? '');
   const { pending, error, run } = useSaver();
+  const [installable, setInstallable] = useState<string[]>([]);
+
+  useEffect(() => {
+    let alive = true;
+    void listInstallablePlugins(slug)
+      .then((res) => {
+        if (alive) setInstallable(res.plugins);
+      })
+      .catch(() => undefined);
+    return () => {
+      alive = false;
+    };
+  }, [slug]);
+
+  async function enable(id: string): Promise<void> {
+    await run(async () => {
+      await enablePlugin(slug, id);
+      setInstallable((xs) => xs.filter((x) => x !== id));
+      onSaved();
+    });
+  }
 
   async function save(): Promise<void> {
     await run(async () => {
@@ -174,6 +204,31 @@ function AgentEditor({
       )}
       <ErrLine error={error} />
       <SaveButton onClick={() => void save()} pending={pending} label={t('inspector.save')} />
+
+      <div className="mt-2 border-t border-[color:var(--border)] pt-3">
+        <p className="mb-2 text-[11px] uppercase tracking-[0.14em] text-[color:var(--fg-muted)]">
+          {t('inspector.addPlugin')}
+        </p>
+        {installable.length === 0 ? (
+          <p className="text-xs text-[color:var(--fg-muted)]">{t('inspector.noInstallable')}</p>
+        ) : (
+          <ul className="flex flex-col gap-1">
+            {installable.map((id) => (
+              <li key={id} className="flex items-center justify-between gap-2">
+                <span className="truncate text-xs text-[color:var(--fg-strong)]">{id}</span>
+                <button
+                  type="button"
+                  onClick={() => void enable(id)}
+                  disabled={pending}
+                  className="shrink-0 rounded-md border border-[color:var(--border)] px-2 py-0.5 text-xs text-[color:var(--accent)] hover:bg-[color:var(--card)] disabled:opacity-50"
+                >
+                  {t('inspector.enable')}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
     </div>
   );
 }
@@ -321,6 +376,103 @@ function McpEditor({
       </div>
       <ErrLine error={error} />
       <SaveButton onClick={() => void discover()} pending={pending} label={t('inspector.discover')} />
+    </div>
+  );
+}
+
+// ── Channel (bind a draft, or view a binding) ────────────────────────────────
+function ChannelEditor({
+  slug,
+  data,
+  onSaved,
+}: {
+  slug: string;
+  data: ChannelNodeData;
+  onSaved: () => void;
+}): React.ReactElement {
+  const t = useTranslations('admin.builder');
+  const [channelType, setChannelType] = useState(data.channel.channelType);
+  const [channelKey, setChannelKey] = useState(data.channel.channelKey);
+  const { pending, error, run } = useSaver();
+  const isDraft = !!data.draft;
+
+  async function bind(): Promise<void> {
+    await run(async () => {
+      const type = channelType.trim();
+      const key = channelKey.trim();
+      if (!type || !key) throw new Error(t('inspector.channelMissing'));
+      await createGraphEdge(slug, {
+        kind: 'channel_bind',
+        source: `channel:${type}:${key}`,
+        target: 'agent:_',
+      });
+      onSaved();
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Field label={t('inspector.channelType')}>
+        <input
+          value={channelType}
+          onChange={(e) => setChannelType(e.target.value)}
+          readOnly={!isDraft}
+          placeholder="slack"
+          className={inputCls}
+        />
+      </Field>
+      <Field label={t('inspector.channelKey')}>
+        <input
+          value={channelKey}
+          onChange={(e) => setChannelKey(e.target.value)}
+          readOnly={!isDraft}
+          placeholder="team:acme:general"
+          className={inputCls}
+        />
+      </Field>
+      <ErrLine error={error} />
+      {isDraft && (
+        <SaveButton onClick={() => void bind()} pending={pending} label={t('inspector.bind')} />
+      )}
+    </div>
+  );
+}
+
+// ── Plugin (read-only id + detach from this agent) ────────────────────────────
+function PluginEditor({
+  slug,
+  plugin,
+  onSaved,
+}: {
+  slug: string;
+  plugin: PluginNode;
+  onSaved: () => void;
+}): React.ReactElement {
+  const t = useTranslations('admin.builder');
+  const { pending, error, run } = useSaver();
+
+  async function detach(): Promise<void> {
+    await run(async () => {
+      await disablePlugin(slug, plugin.id);
+      onSaved();
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Field label={t('inspector.pluginId')}>
+        <input value={plugin.id} readOnly className={inputCls} />
+      </Field>
+      <p className="text-xs text-[color:var(--fg-muted)]">{t('inspector.pluginHint')}</p>
+      <ErrLine error={error} />
+      <button
+        type="button"
+        onClick={() => void detach()}
+        disabled={pending}
+        className="rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-400 hover:bg-red-500/20 disabled:opacity-50"
+      >
+        {t('inspector.pluginDetach')}
+      </button>
     </div>
   );
 }

--- a/web-ui/app/admin/builder/panels/InspectorPanel.tsx
+++ b/web-ui/app/admin/builder/panels/InspectorPanel.tsx
@@ -8,11 +8,14 @@ import {
   disablePlugin,
   discoverMcpTools,
   enablePlugin,
+  listChannelDirectory,
   listInstallablePlugins,
   patchModelRouting,
   patchSkill,
   patchSubAgent,
+  setAgentNativeTools,
   type AgentNode,
+  type ChannelDirectoryEntry,
   type McpServerNode,
   type ModelRoutingConfig,
   type ModelRoutingMode,
@@ -32,6 +35,10 @@ export interface InspectorPanelProps {
   onSaved: () => void;
   /** Delete the selected node (agent + plugin nodes are not deletable). */
   onDelete: (data: BuilderNodeData) => void;
+  /** All native tools available (for the agent's allow-list checklist). */
+  nativeTools?: string[];
+  /** The agent's current native-tool grants (the active allow-list). */
+  nativeGrants?: string[];
 }
 
 /**
@@ -73,7 +80,15 @@ function Editor(props: InspectorPanelProps): React.ReactElement {
   const { data } = props;
   switch (data.kind) {
     case 'agent':
-      return <AgentEditor slug={props.slug} agent={data.agent} onSaved={props.onSaved} />;
+      return (
+        <AgentEditor
+          slug={props.slug}
+          agent={data.agent}
+          onSaved={props.onSaved}
+          nativeTools={props.nativeTools ?? []}
+          nativeGrants={props.nativeGrants ?? []}
+        />
+      );
     case 'subagent':
       return (
         <SubAgentEditor slug={props.slug} subAgent={data.subAgent} onSaved={props.onSaved} />
@@ -129,10 +144,14 @@ function AgentEditor({
   slug,
   agent,
   onSaved,
+  nativeTools,
+  nativeGrants,
 }: {
   slug: string;
   agent: AgentNode;
   onSaved: () => void;
+  nativeTools: string[];
+  nativeGrants: string[];
 }): React.ReactElement {
   const t = useTranslations('admin.builder');
   const r = agent.modelRouting;
@@ -159,6 +178,23 @@ function AgentEditor({
     await run(async () => {
       await enablePlugin(slug, id);
       setInstallable((xs) => xs.filter((x) => x !== id));
+      onSaved();
+    });
+  }
+
+  // Native-tool allow-list. Empty grants = every native tool is available.
+  const allowActive = nativeGrants.length > 0;
+  const checked = (ref: string): boolean =>
+    allowActive ? nativeGrants.includes(ref) : true;
+
+  async function toggleNative(ref: string): Promise<void> {
+    await run(async () => {
+      const next = new Set(nativeTools.filter(checked));
+      if (next.has(ref)) next.delete(ref);
+      else next.add(ref);
+      // All selected → clear the allow-list (back to "all available").
+      const tools = next.size === nativeTools.length ? [] : [...next];
+      await setAgentNativeTools(slug, tools);
       onSaved();
     });
   }
@@ -205,10 +241,40 @@ function AgentEditor({
       <ErrLine error={error} />
       <SaveButton onClick={() => void save()} pending={pending} label={t('inspector.save')} />
 
+      {nativeTools.length > 0 && (
+        <div className="mt-2 border-t border-[color:var(--border)] pt-3">
+          <p className="mb-1 text-[11px] uppercase tracking-[0.14em] text-[color:var(--fg-muted)]">
+            {t('inspector.nativeTools')}
+          </p>
+          <p className="mb-2 text-[11px] text-[color:var(--fg-muted)]">
+            {t('inspector.nativeToolsHint')}
+          </p>
+          <ul className="flex flex-col gap-1">
+            {nativeTools.map((ref) => (
+              <li key={ref} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={checked(ref)}
+                  disabled={pending}
+                  onChange={() => void toggleNative(ref)}
+                />
+                <span className="truncate text-xs text-[color:var(--fg-strong)]">{ref}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       <div className="mt-2 border-t border-[color:var(--border)] pt-3">
         <p className="mb-2 text-[11px] uppercase tracking-[0.14em] text-[color:var(--fg-muted)]">
           {t('inspector.addPlugin')}
         </p>
+        <a
+          href="/admin/registries"
+          className="mb-2 block text-xs text-[color:var(--accent)] hover:underline"
+        >
+          {t('inspector.installMore')}
+        </a>
         {installable.length === 0 ? (
           <p className="text-xs text-[color:var(--fg-muted)]">{t('inspector.noInstallable')}</p>
         ) : (
@@ -395,6 +461,25 @@ function ChannelEditor({
   const [channelKey, setChannelKey] = useState(data.channel.channelKey);
   const { pending, error, run } = useSaver();
   const isDraft = !!data.draft;
+  const [dirTypes, setDirTypes] = useState<string[]>([]);
+  const [dirKeys, setDirKeys] = useState<ChannelDirectoryEntry[]>([]);
+
+  useEffect(() => {
+    if (!isDraft) return;
+    let alive = true;
+    void listChannelDirectory()
+      .then((res) => {
+        if (!alive) return;
+        setDirTypes(res.types);
+        setDirKeys(res.keys);
+      })
+      .catch(() => undefined);
+    return () => {
+      alive = false;
+    };
+  }, [isDraft]);
+
+  const keySuggestions = dirKeys.filter((k) => k.channelType === channelType);
 
   async function bind(): Promise<void> {
     await run(async () => {
@@ -413,22 +498,49 @@ function ChannelEditor({
   return (
     <div className="flex flex-col gap-3">
       <Field label={t('inspector.channelType')}>
-        <input
-          value={channelType}
-          onChange={(e) => setChannelType(e.target.value)}
-          readOnly={!isDraft}
-          placeholder="slack"
-          className={inputCls}
-        />
+        {isDraft && dirTypes.length > 0 ? (
+          <input
+            value={channelType}
+            onChange={(e) => setChannelType(e.target.value)}
+            list="ch-types"
+            placeholder="slack"
+            className={inputCls}
+          />
+        ) : (
+          <input
+            value={channelType}
+            onChange={(e) => setChannelType(e.target.value)}
+            readOnly={!isDraft}
+            placeholder="slack"
+            className={inputCls}
+          />
+        )}
+        {isDraft && (
+          <datalist id="ch-types">
+            {dirTypes.map((tp) => (
+              <option key={tp} value={tp} />
+            ))}
+          </datalist>
+        )}
       </Field>
       <Field label={t('inspector.channelKey')}>
         <input
           value={channelKey}
           onChange={(e) => setChannelKey(e.target.value)}
           readOnly={!isDraft}
+          list={isDraft ? 'ch-keys' : undefined}
           placeholder="team:acme:general"
           className={inputCls}
         />
+        {isDraft && (
+          <datalist id="ch-keys">
+            {keySuggestions.map((k) => (
+              <option key={k.key} value={k.key}>
+                {k.label}
+              </option>
+            ))}
+          </datalist>
+        )}
       </Field>
       <ErrLine error={error} />
       {isDraft && (

--- a/web-ui/app/admin/builder/panels/InspectorPanel.tsx
+++ b/web-ui/app/admin/builder/panels/InspectorPanel.tsx
@@ -25,6 +25,8 @@ export interface InspectorPanelProps {
   onClose: () => void;
   /** Re-fetch the authoritative graph after a successful save. */
   onSaved: () => void;
+  /** Delete the selected node (agent + plugin nodes are not deletable). */
+  onDelete: (data: BuilderNodeData) => void;
 }
 
 /**
@@ -49,6 +51,15 @@ export function InspectorPanel(props: InspectorPanelProps): React.ReactElement {
         </button>
       </div>
       <Editor {...props} />
+      {props.data.kind !== 'agent' && props.data.kind !== 'plugin' && (
+        <button
+          type="button"
+          onClick={() => props.onDelete(props.data)}
+          className="mt-auto rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-400 hover:bg-red-500/20"
+        >
+          {t('inspector.delete')}
+        </button>
+      )}
     </aside>
   );
 }

--- a/web-ui/app/admin/builder/panels/InspectorPanel.tsx
+++ b/web-ui/app/admin/builder/panels/InspectorPanel.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useState } from 'react';
+
+import {
+  discoverMcpTools,
+  patchModelRouting,
+  patchSkill,
+  patchSubAgent,
+  type AgentNode,
+  type McpServerNode,
+  type ModelRoutingConfig,
+  type ModelRoutingMode,
+  type ScheduleNode,
+  type SkillNode,
+  type SubAgentNode,
+} from '../../../_lib/agentBuilder';
+import type { BuilderNodeData } from '../nodes/types';
+import { Field, inputCls, SaveButton } from './InspectorControls';
+
+export interface InspectorPanelProps {
+  slug: string;
+  data: BuilderNodeData;
+  onClose: () => void;
+  /** Re-fetch the authoritative graph after a successful save. */
+  onSaved: () => void;
+}
+
+/**
+ * Right-hand inspector for the selected node. Switches editor by node kind:
+ * agent identity + model-routing, sub-agent model/skill/prompt, skill
+ * markdown body, MCP connection + Discover, schedule cron/timezone.
+ */
+export function InspectorPanel(props: InspectorPanelProps): React.ReactElement {
+  const t = useTranslations('admin.builder');
+  return (
+    <aside className="flex w-[320px] shrink-0 flex-col gap-4 overflow-y-auto border-l border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-[15px] font-semibold text-[color:var(--fg-strong)]">
+          {t('inspector.title')}
+        </h2>
+        <button
+          type="button"
+          onClick={props.onClose}
+          className="rounded-md border border-[color:var(--border)] px-2 py-1 text-xs text-[color:var(--fg-muted)] hover:bg-[color:var(--card)]"
+        >
+          {t('inspector.close')}
+        </button>
+      </div>
+      <Editor {...props} />
+    </aside>
+  );
+}
+
+function Editor(props: InspectorPanelProps): React.ReactElement {
+  const { data } = props;
+  switch (data.kind) {
+    case 'agent':
+      return <AgentEditor slug={props.slug} agent={data.agent} onSaved={props.onSaved} />;
+    case 'subagent':
+      return (
+        <SubAgentEditor slug={props.slug} subAgent={data.subAgent} onSaved={props.onSaved} />
+      );
+    case 'skill':
+      return <SkillEditor skill={data.skill} onSaved={props.onSaved} />;
+    case 'mcp':
+      return <McpEditor server={data.server} onSaved={props.onSaved} />;
+    case 'schedule':
+      return <ScheduleViewer schedule={data.schedule} />;
+    default:
+      return <ReadOnly />;
+  }
+}
+
+function ReadOnly(): React.ReactElement {
+  const t = useTranslations('admin.builder');
+  return <p className="text-sm text-[color:var(--fg-muted)]">{t('inspector.readOnly')}</p>;
+}
+
+function useSaver(): {
+  pending: boolean;
+  error: string | null;
+  run: (fn: () => Promise<void>) => Promise<void>;
+} {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  async function run(fn: () => Promise<void>): Promise<void> {
+    setPending(true);
+    setError(null);
+    try {
+      await fn();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPending(false);
+    }
+  }
+  return { pending, error, run };
+}
+
+function ErrLine({ error }: { error: string | null }): React.ReactElement | null {
+  if (!error) return null;
+  return <p className="text-xs text-red-500">{error}</p>;
+}
+
+// ── Agent ────────────────────────────────────────────────────────────────
+function AgentEditor({
+  slug,
+  agent,
+  onSaved,
+}: {
+  slug: string;
+  agent: AgentNode;
+  onSaved: () => void;
+}): React.ReactElement {
+  const t = useTranslations('admin.builder');
+  const r = agent.modelRouting;
+  const [mode, setMode] = useState<ModelRoutingMode>(r?.mode ?? 'single');
+  const [main, setMain] = useState(r?.main ?? '');
+  const [triage, setTriage] = useState(r?.triage ?? '');
+  const [simple, setSimple] = useState(r?.simple ?? '');
+  const { pending, error, run } = useSaver();
+
+  async function save(): Promise<void> {
+    await run(async () => {
+      const cfg: ModelRoutingConfig = {
+        mode,
+        main: main.trim(),
+        ...(triage.trim() ? { triage: triage.trim() } : {}),
+        ...(simple.trim() ? { simple: simple.trim() } : {}),
+      };
+      await patchModelRouting(slug, main.trim() ? cfg : null);
+      onSaved();
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-[13px] font-semibold text-[color:var(--fg-strong)]">{agent.name}</p>
+      <Field label={t('inspector.routingMode')}>
+        <select
+          value={mode}
+          onChange={(e) => setMode(e.target.value as ModelRoutingMode)}
+          className={inputCls}
+        >
+          <option value="single">single</option>
+          <option value="triage">triage</option>
+        </select>
+      </Field>
+      <Field label={t('inspector.modelMain')}>
+        <input value={main} onChange={(e) => setMain(e.target.value)} className={inputCls} />
+      </Field>
+      {mode === 'triage' && (
+        <>
+          <Field label={t('inspector.modelTriage')}>
+            <input value={triage} onChange={(e) => setTriage(e.target.value)} className={inputCls} />
+          </Field>
+          <Field label={t('inspector.modelSimple')}>
+            <input value={simple} onChange={(e) => setSimple(e.target.value)} className={inputCls} />
+          </Field>
+        </>
+      )}
+      <ErrLine error={error} />
+      <SaveButton onClick={() => void save()} pending={pending} label={t('inspector.save')} />
+    </div>
+  );
+}
+
+// ── Sub-agent ──────────────────────────────────────────────────────────────
+function SubAgentEditor({
+  slug,
+  subAgent,
+  onSaved,
+}: {
+  slug: string;
+  subAgent: SubAgentNode;
+  onSaved: () => void;
+}): React.ReactElement {
+  const t = useTranslations('admin.builder');
+  const [name, setName] = useState(subAgent.name);
+  const [model, setModel] = useState(subAgent.model ?? '');
+  const [prompt, setPrompt] = useState(subAgent.systemPromptOverride ?? '');
+  const { pending, error, run } = useSaver();
+
+  async function save(): Promise<void> {
+    await run(async () => {
+      await patchSubAgent(slug, subAgent.id, {
+        name: name.trim(),
+        model: model.trim() || null,
+        systemPromptOverride: prompt.trim() || null,
+      });
+      onSaved();
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Field label={t('inspector.name')}>
+        <input value={name} onChange={(e) => setName(e.target.value)} className={inputCls} />
+      </Field>
+      <Field label={t('inspector.model')}>
+        <input value={model} onChange={(e) => setModel(e.target.value)} className={inputCls} />
+      </Field>
+      <Field label={t('inspector.systemPrompt')}>
+        <textarea
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          rows={6}
+          className={inputCls}
+        />
+      </Field>
+      <ErrLine error={error} />
+      <SaveButton onClick={() => void save()} pending={pending} label={t('inspector.save')} />
+    </div>
+  );
+}
+
+// ── Skill ────────────────────────────────────────────────────────────────
+function SkillEditor({
+  skill,
+  onSaved,
+}: {
+  skill: SkillNode;
+  onSaved: () => void;
+}): React.ReactElement {
+  const t = useTranslations('admin.builder');
+  const [name, setName] = useState(skill.name);
+  const [body, setBody] = useState(skill.body);
+  const { pending, error, run } = useSaver();
+  const readOnly = skill.source === 'file';
+
+  async function save(): Promise<void> {
+    await run(async () => {
+      await patchSkill(skill.id, { name: name.trim(), body });
+      onSaved();
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {readOnly && (
+        <p className="rounded-md bg-amber-500/10 px-2 py-1 text-xs text-amber-500">
+          {t('inspector.skillFileReadOnly')}
+        </p>
+      )}
+      <Field label={t('inspector.name')}>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          disabled={readOnly}
+          className={inputCls}
+        />
+      </Field>
+      <Field label={t('inspector.skillBody')}>
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          disabled={readOnly}
+          rows={12}
+          className={`${inputCls} font-mono text-xs`}
+        />
+      </Field>
+      <ErrLine error={error} />
+      {!readOnly && (
+        <SaveButton onClick={() => void save()} pending={pending} label={t('inspector.save')} />
+      )}
+    </div>
+  );
+}
+
+// ── MCP server ──────────────────────────────────────────────────────────────
+function McpEditor({
+  server,
+  onSaved,
+}: {
+  server: McpServerNode;
+  onSaved: () => void;
+}): React.ReactElement {
+  const t = useTranslations('admin.builder');
+  // Local post-discover override, scoped to the current server id. When the
+  // selected server changes (id mismatch), the override is ignored and we
+  // fall back to the prop — no setState-in-effect needed.
+  const [override, setOverride] = useState<McpServerNode | null>(null);
+  const live = override && override.id === server.id ? override : server;
+  const { pending, error, run } = useSaver();
+
+  async function discover(): Promise<void> {
+    await run(async () => {
+      const updated = await discoverMcpTools(server.id);
+      setOverride(updated);
+      onSaved();
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Field label={t('inspector.name')}>
+        <input value={live.name} readOnly className={inputCls} />
+      </Field>
+      <Field label={t('inspector.transport')}>
+        <input value={live.transport} readOnly className={inputCls} />
+      </Field>
+      <Field label={t('inspector.endpoint')}>
+        <input value={live.endpoint ?? ''} readOnly className={inputCls} />
+      </Field>
+      <div className="text-xs text-[color:var(--fg-muted)]">
+        {live.discoveredTools.length} {t('nodes.tools')}
+        {live.lastDiscoveredAt ? ` · ${live.lastDiscoveredAt}` : ''}
+      </div>
+      <ErrLine error={error} />
+      <SaveButton onClick={() => void discover()} pending={pending} label={t('inspector.discover')} />
+    </div>
+  );
+}
+
+// ── Schedule (read-only view) ─────────────────────────────────────────────
+function ScheduleViewer({ schedule }: { schedule: ScheduleNode }): React.ReactElement {
+  const t = useTranslations('admin.builder');
+  return (
+    <div className="flex flex-col gap-3">
+      <Field label={t('inspector.cron')}>
+        <input value={schedule.cron} readOnly className={inputCls} />
+      </Field>
+      <Field label={t('inspector.timezone')}>
+        <input value={schedule.timezone} readOnly className={inputCls} />
+      </Field>
+      <div className="text-xs text-[color:var(--fg-muted)]">
+        {schedule.status}
+        {schedule.lastRunAt ? ` · ${schedule.lastRunAt}` : ''}
+      </div>
+    </div>
+  );
+}

--- a/web-ui/app/admin/builder/panels/PalettePanel.tsx
+++ b/web-ui/app/admin/builder/panels/PalettePanel.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import type { CanvasNodeKind } from '../../../_lib/agentBuilder';
+
+/** Node kinds the operator can drag onto the canvas to create new entities. */
+const ADDABLE: ReadonlyArray<Exclude<CanvasNodeKind, 'agent' | 'tool'>> = [
+  'channel',
+  'subagent',
+  'skill',
+  'mcp',
+  'schedule',
+];
+
+export const DND_MIME = 'application/x-omadia-builder-node';
+
+/**
+ * Left rail — drag-to-add palette. Sets a typed drag payload the canvas
+ * reads in `onDrop` to spawn a fresh node of that kind at the drop point.
+ */
+export function PalettePanel(): React.ReactElement {
+  const t = useTranslations('admin.builder');
+  return (
+    <aside className="flex w-[180px] shrink-0 flex-col gap-2 border-r border-[color:var(--border)] bg-[color:var(--card)]/30 p-3">
+      <h2 className="px-1 text-[11px] uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
+        {t('palette.title')}
+      </h2>
+      {ADDABLE.map((kind) => (
+        <div
+          key={kind}
+          draggable
+          onDragStart={(e) => {
+            e.dataTransfer.setData(DND_MIME, kind);
+            e.dataTransfer.effectAllowed = 'move';
+          }}
+          className="cursor-grab rounded-md border border-[color:var(--border)] bg-[color:var(--card)] px-3 py-2 text-[13px] text-[color:var(--fg-strong)] hover:border-[color:var(--accent)] active:cursor-grabbing"
+        >
+          {t(`nodes.${kind}`)}
+        </div>
+      ))}
+    </aside>
+  );
+}

--- a/web-ui/app/admin/builder/panels/ToolboxPanel.tsx
+++ b/web-ui/app/admin/builder/panels/ToolboxPanel.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import {
+  NATIVE_TOOLS,
+  type McpServerNode,
+} from '../../../_lib/agentBuilder';
+
+export const TOOL_DND_MIME = 'application/x-omadia-builder-tool';
+
+export interface ToolDragPayload {
+  toolKind: 'native' | 'mcp';
+  toolRef: string;
+  mcpServerId: string | null;
+}
+
+/**
+ * Right rail — toolbox. Lists native tools plus each MCP server's
+ * discovered tools. Dragging a tool onto an agent / sub-agent creates a
+ * `tool_grant` edge (handled by the canvas `onDrop`).
+ */
+export function ToolboxPanel({
+  mcpServers,
+}: {
+  mcpServers: McpServerNode[];
+}): React.ReactElement {
+  const t = useTranslations('admin.builder');
+
+  function onDragStart(e: React.DragEvent, payload: ToolDragPayload): void {
+    e.dataTransfer.setData(TOOL_DND_MIME, JSON.stringify(payload));
+    e.dataTransfer.effectAllowed = 'link';
+  }
+
+  return (
+    <aside className="flex w-[220px] shrink-0 flex-col gap-3 overflow-y-auto border-l border-[color:var(--border)] bg-[color:var(--card)]/30 p-3">
+      <section>
+        <h2 className="mb-2 px-1 text-[11px] uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
+          {t('toolbox.native')}
+        </h2>
+        <div className="flex flex-col gap-1.5">
+          {NATIVE_TOOLS.map((ref) => (
+            <div
+              key={ref}
+              draggable
+              onDragStart={(e) =>
+                onDragStart(e, { toolKind: 'native', toolRef: ref, mcpServerId: null })
+              }
+              className="cursor-grab rounded-md border border-[color:var(--border)] bg-[color:var(--card)] px-2.5 py-1.5 text-[12px] text-[color:var(--fg-strong)] hover:border-[color:var(--accent)] active:cursor-grabbing"
+            >
+              {ref}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {mcpServers.map((server) => (
+        <section key={server.id}>
+          <h2 className="mb-2 px-1 text-[11px] uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
+            {server.name}
+          </h2>
+          {server.discoveredTools.length === 0 ? (
+            <p className="px-1 text-[11px] text-[color:var(--fg-muted)]">
+              {t('toolbox.noTools')}
+            </p>
+          ) : (
+            <div className="flex flex-col gap-1.5">
+              {server.discoveredTools.map((tool) => (
+                <div
+                  key={tool.name}
+                  draggable
+                  title={tool.description}
+                  onDragStart={(e) =>
+                    onDragStart(e, {
+                      toolKind: 'mcp',
+                      toolRef: tool.name,
+                      mcpServerId: server.id,
+                    })
+                  }
+                  className="cursor-grab rounded-md border border-[color:var(--border)] bg-[color:var(--card)] px-2.5 py-1.5 text-[12px] text-[color:var(--fg-strong)] hover:border-[color:var(--accent)] active:cursor-grabbing"
+                >
+                  {tool.name}
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      ))}
+    </aside>
+  );
+}

--- a/web-ui/app/admin/builder/useAgentGraph.ts
+++ b/web-ui/app/admin/builder/useAgentGraph.ts
@@ -1,0 +1,96 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { ApiError } from '../../_lib/api';
+import { getAgentGraph, type AgentGraph } from '../../_lib/agentBuilder';
+
+export type GraphState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; graph: AgentGraph }
+  | { kind: 'error'; message: string };
+
+export interface UseAgentGraph {
+  state: GraphState;
+  /** Last transient action error (optimistic rollback surfaced this). */
+  actionError: string | null;
+  clearActionError: () => void;
+  /** Re-fetch the whole graph from the backend. */
+  reload: () => Promise<void>;
+  /**
+   * Optimistic mutation helper. Applies `optimistic` to the local graph
+   * immediately, runs `commit` against the backend, and rolls back to the
+   * pre-mutation snapshot if `commit` throws. `commit` may return a fresh
+   * graph to reconcile with the authoritative server state.
+   */
+  mutate: (
+    optimistic: (g: AgentGraph) => AgentGraph,
+    commit: (g: AgentGraph) => Promise<AgentGraph | void>,
+  ) => Promise<void>;
+}
+
+function friendlyError(err: unknown): string {
+  if (err instanceof ApiError) return `Fehler ${err.status}`;
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Loads and mutates an agent's canvas graph with optimistic UI + rollback.
+ * The single `mutate` primitive backs every edge/node operation in the
+ * canvas: snapshot → apply → commit → (rollback on failure).
+ */
+export function useAgentGraph(slug: string | null): UseAgentGraph {
+  const [state, setState] = useState<GraphState>(
+    slug ? { kind: 'loading' } : { kind: 'error', message: '' },
+  );
+  const [actionError, setActionError] = useState<string | null>(null);
+  const stateRef = useRef<GraphState>(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  const reload = useCallback(async (): Promise<void> => {
+    if (!slug) return;
+    setState({ kind: 'loading' });
+    try {
+      const graph = await getAgentGraph(slug);
+      setState({ kind: 'ready', graph });
+    } catch (err) {
+      setState({ kind: 'error', message: friendlyError(err) });
+    }
+  }, [slug]);
+
+  useEffect(() => {
+    if (!slug) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void reload();
+  }, [slug, reload]);
+
+  const mutate = useCallback<UseAgentGraph['mutate']>(
+    async (optimistic, commit) => {
+      const current = stateRef.current;
+      if (current.kind !== 'ready') return;
+      const snapshot = current.graph;
+      const next = optimistic(snapshot);
+      setActionError(null);
+      setState({ kind: 'ready', graph: next });
+      try {
+        const reconciled = await commit(next);
+        if (reconciled) setState({ kind: 'ready', graph: reconciled });
+      } catch (err) {
+        // Rollback to the authoritative pre-mutation snapshot.
+        setState({ kind: 'ready', graph: snapshot });
+        setActionError(friendlyError(err));
+      }
+    },
+    [],
+  );
+
+  return {
+    state,
+    actionError,
+    clearActionError: useCallback(() => setActionError(null), []),
+    reload,
+    mutate,
+  };
+}

--- a/web-ui/app/admin/page.tsx
+++ b/web-ui/app/admin/page.tsx
@@ -20,6 +20,11 @@ export default function AdminIndexPage(): React.ReactElement {
 
       <ul className="grid gap-4 lg:grid-cols-2">
         <AdminCard
+          href="/admin/builder"
+          title="Agent-Builder"
+          description="Visuelle Node-Graph-Leinwand: Kanäle, Sub-Agenten, Skills, Tools/MCP und Zeitpläne verdrahten. Verbindung ziehen schreibt die Verdrahtung, Kante löschen entfernt sie."
+        />
+        <AdminCard
           href="/admin/settings"
           title="Konfiguration"
           description="Alle .env-basierten Werte (Modelle & Routing, Verifier, Embeddings, Integrationen), die in Config-Store/Vault landen — direkt editierbar. Auto-Save, wirkt sofort ohne Neustart."

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -64,7 +64,10 @@
         "pluginDetach": "Von diesem Agent lösen",
         "addPlugin": "Plugin hinzufügen",
         "noInstallable": "Keine weiteren installierbaren Plugins.",
-        "enable": "Aktivieren"
+        "enable": "Aktivieren",
+        "installMore": "Weitere Plugins installieren →",
+        "nativeTools": "Native Tools",
+        "nativeToolsHint": "Angehakte Tools stehen diesem Agent zur Verfügung. Alle angehakt = keine Einschränkung."
       }
     }
   },

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1,4 +1,60 @@
 {
+  "admin": {
+    "builder": {
+      "title": "Agent-Builder",
+      "subtitle": "Kanäle, Sub-Agenten, Skills und Tools auf einer editierbaren Leinwand verdrahten.",
+      "agentPicker": "Agent",
+      "loading": "Lädt …",
+      "loadError": "Laden fehlgeschlagen",
+      "noAgents": "Noch keine Agenten verfügbar.",
+      "card": {
+        "title": "Agent-Builder",
+        "description": "Visuelle Node-Graph-Leinwand: Kanäle, Sub-Agenten, Skills, Tools/MCP und Zeitpläne verdrahten. Eine gezogene Verbindung schreibt die Verdrahtung; eine gelöschte Kante entfernt sie."
+      },
+      "nodes": {
+        "channel": "Kanal",
+        "agent": "Agent",
+        "subagent": "Sub-Agent",
+        "skill": "Skill",
+        "tool": "Tool",
+        "mcp": "MCP-Server",
+        "schedule": "Zeitplan",
+        "tools": "Tools"
+      },
+      "palette": {
+        "title": "Hinzufügen"
+      },
+      "toolbox": {
+        "native": "Native Tools",
+        "noTools": "Noch keine erkannten Tools."
+      },
+      "defaults": {
+        "subAgentName": "Neuer Sub-Agent",
+        "skillName": "Neuer Skill",
+        "mcpName": "Neuer MCP-Server"
+      },
+      "inspector": {
+        "title": "Inspektor",
+        "close": "Schließen",
+        "save": "Speichern",
+        "discover": "Tools erkennen",
+        "readOnly": "Dieser Node hat keine editierbaren Eigenschaften.",
+        "name": "Name",
+        "model": "Modell",
+        "systemPrompt": "System-Prompt-Override",
+        "routingMode": "Routing-Modus",
+        "modelMain": "Hauptmodell",
+        "modelTriage": "Triage-Modell",
+        "modelSimple": "Einfaches Modell",
+        "skillBody": "Skill-Inhalt (Markdown)",
+        "skillFileReadOnly": "Datei-basierter Skill — hier schreibgeschützt.",
+        "transport": "Transport",
+        "endpoint": "Endpoint",
+        "cron": "Cron",
+        "timezone": "Zeitzone"
+      }
+    }
+  },
   "selfExtension": {
     "intro": "Schlage eine Selbst-Erweiterung für dieses installierte Plugin vor: füge Tools oder Capabilities per Spec-Patch hinzu. Der Escalation-Guard lehnt jede Rechte-Ausweitung automatisch ab — ein Plugin kann sich keine Rechte selbst geben, die es nicht ohnehin schon hat.",
     "composeTitle": "Neuer Vorschlag",

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -19,6 +19,7 @@
         "tool": "Tool",
         "mcp": "MCP-Server",
         "schedule": "Zeitplan",
+        "plugin": "Plugin",
         "tools": "Tools"
       },
       "palette": {
@@ -36,6 +37,7 @@
       "inspector": {
         "title": "Inspektor",
         "close": "Schließen",
+        "delete": "Löschen",
         "save": "Speichern",
         "discover": "Tools erkennen",
         "readOnly": "Dieser Node hat keine editierbaren Eigenschaften.",

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -20,6 +20,7 @@
         "mcp": "MCP-Server",
         "schedule": "Zeitplan",
         "plugin": "Plugin",
+        "nativeBaseline": "nativ (eingebaut)",
         "tools": "Tools"
       },
       "palette": {
@@ -53,7 +54,17 @@
         "transport": "Transport",
         "endpoint": "Endpoint",
         "cron": "Cron",
-        "timezone": "Zeitzone"
+        "timezone": "Zeitzone",
+        "channelType": "Kanal-Typ",
+        "channelKey": "Kanal-Schlüssel",
+        "channelMissing": "Kanal-Typ und -Schlüssel angeben.",
+        "bind": "An Agent binden",
+        "pluginId": "Plugin",
+        "pluginHint": "Aktives Plugin auf diesem Agent (Installation über die Plugin-Verwaltung).",
+        "pluginDetach": "Von diesem Agent lösen",
+        "addPlugin": "Plugin hinzufügen",
+        "noInstallable": "Keine weiteren installierbaren Plugins.",
+        "enable": "Aktivieren"
       }
     }
   },

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -19,6 +19,7 @@
         "tool": "Tool",
         "mcp": "MCP Server",
         "schedule": "Schedule",
+        "plugin": "Plugin",
         "tools": "tools"
       },
       "palette": {
@@ -36,6 +37,7 @@
       "inspector": {
         "title": "Inspector",
         "close": "Close",
+        "delete": "Delete",
         "save": "Save",
         "discover": "Discover tools",
         "readOnly": "This node has no editable properties.",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1,4 +1,60 @@
 {
+  "admin": {
+    "builder": {
+      "title": "Agent Builder",
+      "subtitle": "Wire channels, sub-agents, skills and tools on an editable canvas.",
+      "agentPicker": "Agent",
+      "loading": "Loading…",
+      "loadError": "Failed to load",
+      "noAgents": "No agents available yet.",
+      "card": {
+        "title": "Agent Builder",
+        "description": "Visual node-graph canvas: wire channels, sub-agents, skills, tools/MCP and schedules. Drawing a connection writes the wiring; deleting an edge removes it."
+      },
+      "nodes": {
+        "channel": "Channel",
+        "agent": "Agent",
+        "subagent": "Sub-Agent",
+        "skill": "Skill",
+        "tool": "Tool",
+        "mcp": "MCP Server",
+        "schedule": "Schedule",
+        "tools": "tools"
+      },
+      "palette": {
+        "title": "Add"
+      },
+      "toolbox": {
+        "native": "Native tools",
+        "noTools": "No discovered tools yet."
+      },
+      "defaults": {
+        "subAgentName": "New sub-agent",
+        "skillName": "New skill",
+        "mcpName": "New MCP server"
+      },
+      "inspector": {
+        "title": "Inspector",
+        "close": "Close",
+        "save": "Save",
+        "discover": "Discover tools",
+        "readOnly": "This node has no editable properties.",
+        "name": "Name",
+        "model": "Model",
+        "systemPrompt": "System prompt override",
+        "routingMode": "Routing mode",
+        "modelMain": "Main model",
+        "modelTriage": "Triage model",
+        "modelSimple": "Simple model",
+        "skillBody": "Skill body (Markdown)",
+        "skillFileReadOnly": "File-backed skill — read-only here.",
+        "transport": "Transport",
+        "endpoint": "Endpoint",
+        "cron": "Cron",
+        "timezone": "Timezone"
+      }
+    }
+  },
   "selfExtension": {
     "intro": "Propose a self-extension for this installed plugin: add tools or capabilities by patching its spec. The escalation guard auto-denies any privilege widening — a plugin can never grant itself rights it does not already hold.",
     "composeTitle": "New proposal",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -20,6 +20,7 @@
         "mcp": "MCP Server",
         "schedule": "Schedule",
         "plugin": "Plugin",
+        "nativeBaseline": "native (built-in)",
         "tools": "tools"
       },
       "palette": {
@@ -53,7 +54,17 @@
         "transport": "Transport",
         "endpoint": "Endpoint",
         "cron": "Cron",
-        "timezone": "Timezone"
+        "timezone": "Timezone",
+        "channelType": "Channel type",
+        "channelKey": "Channel key",
+        "channelMissing": "Enter a channel type and key.",
+        "bind": "Bind to agent",
+        "pluginId": "Plugin",
+        "pluginHint": "Active plugin on this agent (managed via plugin install).",
+        "pluginDetach": "Detach from this agent",
+        "addPlugin": "Add a plugin",
+        "noInstallable": "No further installable plugins.",
+        "enable": "Enable"
       }
     }
   },

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -64,7 +64,10 @@
         "pluginDetach": "Detach from this agent",
         "addPlugin": "Add a plugin",
         "noInstallable": "No further installable plugins.",
-        "enable": "Enable"
+        "enable": "Enable",
+        "installMore": "Install more plugins →",
+        "nativeTools": "Native tools",
+        "nativeToolsHint": "Checked tools are available to this agent. All checked = no restriction."
       }
     }
   },

--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -13,6 +13,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@monaco-editor/react": "^4.7.0",
+        "@xyflow/react": "^12.11.0",
         "clsx": "^2.1.1",
         "cytoscape": "^3.33.4",
         "cytoscape-fcose": "^2.2.0",
@@ -3859,6 +3860,55 @@
         "cytoscape": "*"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -3951,7 +4001,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -4634,6 +4684,48 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.0.tgz",
+      "integrity": "sha512-na4IO33FSs2OS72hASgZDmTYwFAkef7Z74uBUVrong3ARmQQHfnRUVaCFn1kTt5LbS6pK03TbYjCPGLjLFfziA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.77",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.77",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.77.tgz",
+      "integrity": "sha512-qCDCMCQAAgUu8yHnhloHG9F5mwPX5E+Wl8McpYIOPSSXfzFJJoZcwOcsDiAjitVKIg2de1WmJbCHfpcvxprsgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -5207,6 +5299,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -5336,6 +5434,111 @@
       },
       "peerDependencies": {
         "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/damerau-levenshtein": {
@@ -11198,6 +11401,15 @@
         "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -12178,6 +12390,34 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -20,6 +20,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@monaco-editor/react": "^4.7.0",
+    "@xyflow/react": "^12.11.0",
     "clsx": "^2.1.1",
     "cytoscape": "^3.33.4",
     "cytoscape-fcose": "^2.2.0",


### PR DESCRIPTION
## Agent Builder — editable visual canvas

A LangChain-style visual builder at **`/admin/builder`** for wiring the orchestration layer: **Channels → Agent → Sub-Agents → Skills → Tools/MCP**, plus a **Schedule** trigger. Drawing a connection writes the wiring; deleting an edge removes it; node edits apply **live without a restart** via the existing `pg_notify('agents_changed')` → `registry.reload()` path.

### Backend (middleware)
- **Migration `0003_agent_builder_graph.sql`** — `skills`, `mcp_servers`, `agent_subagents`, `agent_tool_grants`, `agent_schedules` + `agents.model_routing/canvas_position` + notify triggers (auto-runs on boot).
- **`AgentGraphStore`** (CRUD) + `ConfigStore` snapshot/diff awareness — graph changes rebuild the owning agent; schedules stay orthogonal (consumed by the cron worker).
- **Per-agent model routing** — persisted JSON → runtime triage config; prefers per-agent routing, falls back to the platform default (keeps the Haiku-triage badge working).
- **MCP client** (`@modelcontextprotocol/sdk`, stdio/http/sse) + adapters into native + sub-agent tools.
- **DB sub-agents → `LocalSubAgent` DomainTools**, attached in `onAgentBuilt` (same seam plugin domain agents use).
- **REST router** at `/api/v1/operator` — graph read, edge create/delete dispatcher, sub-agent/skill/mcp/schedule CRUD, model-routing, positions, mcp discover (`requireAuth`, `ConfigValidationError → 409`, inline `reload()`).
- **Cron schedule worker** — 5-field matcher + per-minute-deduped poller firing headless `chat()` turns.

### Frontend (web-ui)
- **`@xyflow/react` canvas** — custom node types, palette, toolbox, inspector, optimistic edges with rollback, debounced position save. Admin dashboard card + en/de i18n.

### Verification
- `typecheck` + `lint` clean (middleware + web-ui), web-ui i18n parity OK.
- **27/27 unit tests pass**: cron matcher, model-routing mapping, sub-agent builder, MCP adapters, graph diff, registry hot-reload regression.

### Testing
Local end-to-end flow documented in `docs/plans/agent-builder-TESTING.md` (needs `DATABASE_URL` + `ANTHROPIC_API_KEY`; without a DB the builder endpoints 503 and the scheduler is skipped, by design).

### Notes / follow-ups
- Channel-node canvas positions not persisted on GET (cosmetic; agent + sub-agent positions are).
- Cron evaluated in UTC (per-timezone is a follow-up).
- DB is source of truth (copy-on-write); file-defined plugin defaults aren't auto-migrated into the tables.