### PR TITLE
feat(admin): de-duplicate per-plugin settings out of the .env admin page

### DIFF
--- a/middleware/packages/harness-orchestrator/manifest.yaml
+++ b/middleware/packages/harness-orchestrator/manifest.yaml
@@ -91,6 +91,26 @@ setup:
       type: "string"
       required: false
       help: "Hard cap auf den agentic tool-loop pro Turn. Bei Erschöpfung wird KEIN roher Fehler mehr geworfen — der Orchestrator erzwingt eine letzte tool-freie Iteration und gibt eine Best-Effort-Antwort. Default: 100 (auch Floor — niedrigere installierte Werte werden hochgesetzt). Round-Loops werden separat vom Loop-Guard abgefangen. Migriert aus MAX_TOOL_ITERATIONS."
+    - key: "orchestrator_model_routing"
+      label: "Per-Turn Model-Routing (Haiku-Triage)"
+      type: "boolean"
+      required: false
+      help: "Wenn an, klassifiziert ein günstiger Haiku-Call jeden Turn: einfach → Simple-Modell, komplex → Complex-Modell. Migriert aus ORCHESTRATOR_MODEL_ROUTING."
+    - key: "model_routing_classifier_model"
+      label: "Routing: Klassifizierer-Modell"
+      type: "string"
+      required: false
+      help: "Haiku-Modell für die Triage. Leer = Default (haiku-4-5). Migriert aus MODEL_ROUTING_CLASSIFIER_MODEL."
+    - key: "model_routing_simple_model"
+      label: "Routing: Modell für einfache Turns"
+      type: "string"
+      required: false
+      help: "Leer = Default (sonnet-4-6). Migriert aus MODEL_ROUTING_SIMPLE_MODEL."
+    - key: "model_routing_complex_model"
+      label: "Routing: Modell für komplexe Turns"
+      type: "string"
+      required: false
+      help: "Leer = Orchestrator-Modell. Migriert aus MODEL_ROUTING_COMPLEX_MODEL."
     - key: "max_turn_seconds"
       label: "Max Turn-Dauer (Sekunden)"
       type: "string"

--- a/middleware/src/platform/settingsCatalog.ts
+++ b/middleware/src/platform/settingsCatalog.ts
@@ -1,35 +1,29 @@
 /**
- * Operator-facing catalog of the `.env`-based settings that get written into
- * the runtime config-store / secret vault on first boot (see
- * `plugins/bootstrap.ts`). This is the single source of truth behind the
- * `/api/v1/admin/settings` admin overview: each entry knows its human label,
- * category, value type, and — crucially — WHERE the value lives at runtime
- * (which installed plugin's config key, or which vault scope+key for secrets).
+ * Operator-facing catalog of the *cross-plugin* `.env`-based settings exposed in
+ * the `/api/v1/admin/settings` admin overview.
  *
- * Why a curated catalog rather than deriving from each plugin's setup_schema:
- * the `.env` → config mappings in bootstrap are broader than the install
- * wizard's setup_schema (e.g. model-routing flags, max-tokens) and we want a
- * grouped, operator-readable overview of exactly those env-seeded values —
- * not every internal config key. Keeping it as plain data also makes it
- * trivially testable and lets the admin page render generic typed inputs.
+ * Historically this catalog mirrored ~every `.env` → plugin-config mapping from
+ * `plugins/bootstrap.ts`. That made it a hand-maintained duplicate of each
+ * plugin's own `manifest.yaml → setup.fields`, which are already editable
+ * through the per-plugin runtime editor (`routes/runtime.ts`). The duplication
+ * has been removed: per-plugin settings now live exclusively in that editor.
  *
- * The admin PATCH handler writes config values via
+ * What remains here are only the settings that genuinely DON'T map 1:1 to a
+ * single plugin's setup field — currently just the Anthropic API key, whose
+ * secret fans out across THREE vault scopes (orchestrator, verifier,
+ * orchestrator-extras). Setting it once centrally writes all three; the
+ * per-plugin editor would require editing each scope separately.
+ *
+ * The admin PATCH handler still writes config values via
  * `installedRegistry.updateConfig` and secrets via `vault.setMany` /
  * `deleteKey`, then `reactivate`s each affected plugin — the same plumbing the
- * post-install editor (`routes/runtime.ts`) already uses, so changes take
- * effect live ("auto change nach Änderung") without a restart.
+ * post-install editor uses, so changes take effect live without a restart.
  */
 
 /** Plugin ids (installed-registry ids / vault scopes) the settings target. */
 const ORCHESTRATOR = '@omadia/orchestrator';
 const ORCHESTRATOR_EXTRAS = '@omadia/orchestrator-extras';
 const VERIFIER = '@omadia/verifier';
-const EMBEDDINGS = '@omadia/embeddings';
-const KNOWLEDGE_GRAPH = '@omadia/knowledge-graph-neon';
-const DIAGRAMS = '@omadia/diagrams';
-const MICROSOFT365 = 'de.byte5.integration.microsoft365';
-const TEAMS = 'de.byte5.channel.teams';
-const TELEGRAM = 'de.byte5.channel.telegram';
 
 export type SettingValueType =
   | 'string'
@@ -70,17 +64,16 @@ export interface SettingDef {
 // Category labels (German — the admin section is hardcoded-German, matching
 // the sibling admin pages which don't use the i18n catalog).
 const C_MODELS = 'Modelle & Routing';
-const C_VERIFIER = 'Verifier';
-const C_KNOWLEDGE = 'Wissen & Embeddings';
-const C_DIAGRAMS = 'Diagramme & Speicher';
-const C_INTEGRATIONS = 'Integrationen';
 
 export const SETTINGS_CATALOG: readonly SettingDef[] = [
-  // ── Modelle & Routing (@omadia/orchestrator) ────────────────────────────
+  // ── Modelle & Routing — cross-plugin secret only ────────────────────────
+  // Everything else that used to live here (orchestrator/verifier/embeddings/
+  // knowledge-graph/diagrams/integration settings) is now edited per-plugin via
+  // the runtime editor, driven by each plugin's manifest setup.fields.
   {
     key: 'ANTHROPIC_API_KEY',
     label: 'Anthropic API-Key',
-    help: 'Wird für Orchestrator, Verifier und die Background-Tasks benötigt. Beginnt mit "sk-ant-". Bestehender Wert wird nie angezeigt.',
+    help: 'Wird für Orchestrator, Verifier und die Background-Tasks benötigt. Beginnt mit "sk-ant-". Bestehender Wert wird nie angezeigt. Wird zentral in alle drei Plugin-Vaults geschrieben.',
     category: C_MODELS,
     type: 'secret',
     placeholder: 'sk-ant-…',
@@ -88,253 +81,6 @@ export const SETTINGS_CATALOG: readonly SettingDef[] = [
       vaultKey: 'anthropic_api_key',
       scopes: [ORCHESTRATOR, VERIFIER, ORCHESTRATOR_EXTRAS],
     },
-  },
-  {
-    key: 'ORCHESTRATOR_MODEL',
-    label: 'Orchestrator-Modell',
-    help: 'Standard-Modell für jeden Chat-Turn (z. B. claude-opus-4-8). Bei aktivem Routing der "complex"-Fallback.',
-    category: C_MODELS,
-    type: 'string',
-    placeholder: 'claude-opus-4-8',
-    config: { pluginId: ORCHESTRATOR, configKey: 'orchestrator_model' },
-  },
-  {
-    key: 'ORCHESTRATOR_MAX_TOKENS',
-    label: 'Orchestrator max. Tokens',
-    category: C_MODELS,
-    type: 'number',
-    placeholder: '8192',
-    config: { pluginId: ORCHESTRATOR, configKey: 'orchestrator_max_tokens' },
-  },
-  {
-    key: 'MAX_TOOL_ITERATIONS',
-    label: 'Max. Tool-Iterationen pro Turn',
-    category: C_MODELS,
-    type: 'number',
-    placeholder: '12',
-    config: { pluginId: ORCHESTRATOR, configKey: 'max_tool_iterations' },
-  },
-  {
-    key: 'ORCHESTRATOR_MODEL_ROUTING',
-    label: 'Per-Turn Model-Routing (Haiku-Triage)',
-    help: 'Wenn an, klassifiziert ein günstiger Haiku-Call jeden Turn: einfach → Simple-Modell, komplex → Complex-Modell.',
-    category: C_MODELS,
-    type: 'boolean',
-    config: { pluginId: ORCHESTRATOR, configKey: 'orchestrator_model_routing' },
-  },
-  {
-    key: 'MODEL_ROUTING_CLASSIFIER_MODEL',
-    label: 'Routing: Klassifizierer-Modell',
-    help: 'Haiku-Modell für die Triage. Leer = Default (haiku-4-5).',
-    category: C_MODELS,
-    type: 'string',
-    placeholder: 'claude-haiku-4-5',
-    config: { pluginId: ORCHESTRATOR, configKey: 'model_routing_classifier_model' },
-  },
-  {
-    key: 'MODEL_ROUTING_SIMPLE_MODEL',
-    label: 'Routing: Modell für einfache Turns',
-    help: 'Leer = Default (sonnet-4-6).',
-    category: C_MODELS,
-    type: 'string',
-    placeholder: 'claude-sonnet-4-6',
-    config: { pluginId: ORCHESTRATOR, configKey: 'model_routing_simple_model' },
-  },
-  {
-    key: 'MODEL_ROUTING_COMPLEX_MODEL',
-    label: 'Routing: Modell für komplexe Turns',
-    help: 'Leer = Orchestrator-Modell.',
-    category: C_MODELS,
-    type: 'string',
-    placeholder: 'claude-opus-4-8',
-    config: { pluginId: ORCHESTRATOR, configKey: 'model_routing_complex_model' },
-  },
-  {
-    key: 'TOPIC_CLASSIFIER_MODEL',
-    label: 'Topic-/Fact-Klassifizierer-Modell',
-    help: 'Haiku-Tier-Modell für Topic-Clustering und Fakt-Extraktion.',
-    category: C_MODELS,
-    type: 'string',
-    placeholder: 'claude-haiku-4-5-20251001',
-    config: { pluginId: ORCHESTRATOR_EXTRAS, configKey: 'topic_classifier_model' },
-  },
-
-  // ── Verifier (@omadia/verifier) ─────────────────────────────────────────
-  {
-    key: 'VERIFIER_ENABLED',
-    label: 'Verifier aktiv',
-    help: 'Prüft jede Orchestrator-Antwort gegen Quellen.',
-    category: C_VERIFIER,
-    type: 'boolean',
-    config: { pluginId: VERIFIER, configKey: 'verifier_enabled' },
-  },
-  {
-    key: 'VERIFIER_MODE',
-    label: 'Verifier-Modus',
-    category: C_VERIFIER,
-    type: 'enum',
-    options: [
-      { value: 'shadow', label: 'shadow (nur protokollieren)' },
-      { value: 'enforce', label: 'enforce (blockieren)' },
-    ],
-    config: { pluginId: VERIFIER, configKey: 'verifier_mode' },
-  },
-  {
-    key: 'VERIFIER_MODEL',
-    label: 'Verifier-Modell',
-    category: C_VERIFIER,
-    type: 'string',
-    placeholder: 'claude-haiku-4-5-20251001',
-    config: { pluginId: VERIFIER, configKey: 'verifier_model' },
-  },
-  {
-    key: 'VERIFIER_MAX_CLAIMS',
-    label: 'Verifier max. Claims',
-    category: C_VERIFIER,
-    type: 'number',
-    placeholder: '20',
-    config: { pluginId: VERIFIER, configKey: 'verifier_max_claims' },
-  },
-  {
-    key: 'VERIFIER_MAX_RETRIES',
-    label: 'Verifier max. Retries',
-    category: C_VERIFIER,
-    type: 'number',
-    placeholder: '1',
-    config: { pluginId: VERIFIER, configKey: 'verifier_max_retries' },
-  },
-
-  // ── Wissen & Embeddings ─────────────────────────────────────────────────
-  {
-    key: 'OLLAMA_BASE_URL',
-    label: 'Ollama Base-URL',
-    category: C_KNOWLEDGE,
-    type: 'url',
-    placeholder: 'http://ollama:11434',
-    config: { pluginId: EMBEDDINGS, configKey: 'ollama_base_url' },
-  },
-  {
-    key: 'OLLAMA_EMBEDDING_MODEL',
-    label: 'Embedding-Modell',
-    category: C_KNOWLEDGE,
-    type: 'string',
-    placeholder: 'nomic-embed-text',
-    config: { pluginId: EMBEDDINGS, configKey: 'ollama_model' },
-  },
-  {
-    key: 'GRAPH_TENANT_ID',
-    label: 'Knowledge-Graph Tenant-ID',
-    category: C_KNOWLEDGE,
-    type: 'string',
-    placeholder: 'default',
-    config: { pluginId: KNOWLEDGE_GRAPH, configKey: 'graph_tenant_id' },
-  },
-  {
-    key: 'GRAPH_EMBEDDING_BACKFILL_ENABLED',
-    label: 'Embedding-Backfill aktiv',
-    category: C_KNOWLEDGE,
-    type: 'boolean',
-    config: {
-      pluginId: KNOWLEDGE_GRAPH,
-      configKey: 'graph_embedding_backfill_enabled',
-    },
-  },
-
-  // ── Diagramme & Speicher (@omadia/diagrams) ─────────────────────────────
-  {
-    key: 'KROKI_BASE_URL',
-    label: 'Kroki Base-URL',
-    category: C_DIAGRAMS,
-    type: 'url',
-    placeholder: 'http://kroki:8000',
-    config: { pluginId: DIAGRAMS, configKey: 'kroki_base_url' },
-  },
-  {
-    key: 'DIAGRAM_PUBLIC_BASE_URL',
-    label: 'Öffentliche Diagramm-Base-URL',
-    category: C_DIAGRAMS,
-    type: 'url',
-    config: { pluginId: DIAGRAMS, configKey: 'public_base_url' },
-  },
-  {
-    key: 'AWS_ENDPOINT_URL_S3',
-    label: 'S3/Tigris Endpoint',
-    category: C_DIAGRAMS,
-    type: 'url',
-    config: { pluginId: DIAGRAMS, configKey: 'tigris_endpoint' },
-  },
-  {
-    key: 'BUCKET_NAME',
-    label: 'S3/Tigris Bucket',
-    category: C_DIAGRAMS,
-    type: 'string',
-    config: { pluginId: DIAGRAMS, configKey: 'tigris_bucket' },
-  },
-  {
-    key: 'AWS_ACCESS_KEY_ID',
-    label: 'S3 Access-Key-ID',
-    category: C_DIAGRAMS,
-    type: 'secret',
-    secret: { vaultKey: 'aws_access_key_id', scopes: [DIAGRAMS] },
-  },
-  {
-    key: 'AWS_SECRET_ACCESS_KEY',
-    label: 'S3 Secret-Access-Key',
-    category: C_DIAGRAMS,
-    type: 'secret',
-    secret: { vaultKey: 'aws_secret_access_key', scopes: [DIAGRAMS] },
-  },
-
-  // ── Integrationen (private byte5-Plugins — werden als "nicht installiert"
-  //    angezeigt, wenn das jeweilige Plugin in diesem Deployment fehlt) ─────
-  {
-    key: 'MICROSOFT_APP_ID',
-    label: 'Microsoft App-ID',
-    category: C_INTEGRATIONS,
-    type: 'string',
-    config: { pluginId: MICROSOFT365, configKey: 'microsoft_app_id' },
-  },
-  {
-    key: 'MICROSOFT_APP_TENANT_ID',
-    label: 'Microsoft Tenant-ID',
-    category: C_INTEGRATIONS,
-    type: 'string',
-    config: { pluginId: MICROSOFT365, configKey: 'microsoft_tenant_id' },
-  },
-  {
-    key: 'MICROSOFT_APP_PASSWORD',
-    label: 'Microsoft App-Passwort',
-    category: C_INTEGRATIONS,
-    type: 'secret',
-    secret: { vaultKey: 'microsoft_app_password', scopes: [MICROSOFT365] },
-  },
-  {
-    key: 'TEAMS_SSO_CONNECTION_NAME',
-    label: 'Teams SSO Connection-Name',
-    category: C_INTEGRATIONS,
-    type: 'string',
-    config: { pluginId: TEAMS, configKey: 'teams_sso_connection_name' },
-  },
-  {
-    key: 'TELEGRAM_PUBLIC_BASE_URL',
-    label: 'Telegram Public-Base-URL',
-    category: C_INTEGRATIONS,
-    type: 'url',
-    config: { pluginId: TELEGRAM, configKey: 'telegram_public_base_url' },
-  },
-  {
-    key: 'TELEGRAM_BOT_TOKEN',
-    label: 'Telegram Bot-Token',
-    category: C_INTEGRATIONS,
-    type: 'secret',
-    secret: { vaultKey: 'telegram_bot_token', scopes: [TELEGRAM] },
-  },
-  {
-    key: 'TELEGRAM_WEBHOOK_SECRET',
-    label: 'Telegram Webhook-Secret',
-    category: C_INTEGRATIONS,
-    type: 'secret',
-    secret: { vaultKey: 'telegram_webhook_secret', scopes: [TELEGRAM] },
   },
 ];
 
@@ -351,10 +97,4 @@ export function settingPluginIds(def: SettingDef): string[] {
 }
 
 /** Category order for stable rendering in the admin overview. */
-export const SETTINGS_CATEGORY_ORDER: readonly string[] = [
-  C_MODELS,
-  C_VERIFIER,
-  C_KNOWLEDGE,
-  C_DIAGRAMS,
-  C_INTEGRATIONS,
-];
+export const SETTINGS_CATEGORY_ORDER: readonly string[] = [C_MODELS];

--- a/middleware/test/adminSettingsRoute.test.ts
+++ b/middleware/test/adminSettingsRoute.test.ts
@@ -10,16 +10,17 @@ import { InMemoryInstalledRegistry } from '../src/plugins/installedRegistry.js';
 import { InMemorySecretVault } from '../src/secrets/vault.js';
 
 /**
- * /api/v1/admin/settings — the .env-based config/vault overview. Verifies the
- * catalog → current-value resolution, the typed PATCH validation, and that a
- * change writes to the right target (config-store vs vault) and reactivates
- * exactly the touched plugins.
+ * /api/v1/admin/settings — the *cross-plugin* config/vault overview. After the
+ * per-plugin settings were de-duplicated out of this page (each plugin's own
+ * setup.fields editor is now the source of truth), the catalog holds only the
+ * shared Anthropic API key, whose secret fans out to three vault scopes. These
+ * tests cover that one entry end-to-end: secret set/unset resolution, the
+ * fan-out write, the sk-ant- prefix validation, and unknown/not-installed paths.
  */
 
 const ORCH = '@omadia/orchestrator';
 const VERIFIER = '@omadia/verifier';
 const EXTRAS = '@omadia/orchestrator-extras';
-const DIAGRAMS = '@omadia/diagrams';
 
 interface Harness {
   server: Server;
@@ -94,7 +95,7 @@ async function getSettings(h: Harness): Promise<{
 function findSetting(
   body: Awaited<ReturnType<typeof getSettings>>,
   key: string,
-): { installed: boolean; value?: string | null; isSet?: boolean } | undefined {
+): { installed: boolean; value?: string | null; isSet?: boolean; type?: string } | undefined {
   for (const c of body.categories) {
     const s = c.settings.find((x) => x.key === key);
     if (s) return s;
@@ -120,27 +121,31 @@ describe('admin settings route — GET /', () => {
     if (h) await h.close();
   });
 
-  it('groups the catalog and resolves current config values', async () => {
-    h = await makeHarness([
-      { id: ORCH, config: { orchestrator_model: 'claude-opus-4-7' } },
-    ]);
+  it('exposes the shared Anthropic key as an installed secret when all scopes are present', async () => {
+    h = await makeHarness([{ id: ORCH }, { id: VERIFIER }, { id: EXTRAS }]);
     const body = await getSettings(h);
     assert.ok(body.vault_available);
-    const model = findSetting(body, 'ORCHESTRATOR_MODEL');
-    assert.equal(model?.installed, true);
-    assert.equal(model?.value, 'claude-opus-4-7');
-    // A setting whose plugin isn't installed is flagged not-installed.
-    const telegram = findSetting(body, 'TELEGRAM_BOT_TOKEN');
-    assert.equal(telegram?.installed, false);
+    const key = findSetting(body, 'ANTHROPIC_API_KEY');
+    assert.equal(key?.installed, true);
+    assert.equal(key?.type, 'secret');
+    assert.equal(key?.isSet, false);
+  });
+
+  it('flags the key not-installed when one scope plugin is missing', async () => {
+    // Verifier + extras missing → the cross-plugin secret can't be fully written.
+    h = await makeHarness([{ id: ORCH }]);
+    const body = await getSettings(h);
+    const key = findSetting(body, 'ANTHROPIC_API_KEY');
+    assert.equal(key?.installed, false);
   });
 
   it('reports secret set/unset without leaking the value', async () => {
-    h = await makeHarness([{ id: DIAGRAMS }]);
-    await h.vault.setMany(DIAGRAMS, { aws_access_key_id: 'AKIA-secret' });
+    h = await makeHarness([{ id: ORCH }, { id: VERIFIER }, { id: EXTRAS }]);
+    await h.vault.setMany(ORCH, { anthropic_api_key: 'sk-ant-supersecret' });
     const body = await getSettings(h);
-    const aws = findSetting(body, 'AWS_ACCESS_KEY_ID');
-    assert.equal(aws?.isSet, true);
-    assert.ok(!JSON.stringify(body).includes('AKIA-secret'));
+    const key = findSetting(body, 'ANTHROPIC_API_KEY');
+    assert.equal(key?.isSet, true);
+    assert.ok(!JSON.stringify(body).includes('sk-ant-supersecret'));
   });
 });
 
@@ -150,61 +155,7 @@ describe('admin settings route — PATCH /', () => {
     if (h) await h.close();
   });
 
-  it('writes a config value and reactivates the target plugin', async () => {
-    h = await makeHarness([
-      { id: ORCH, config: { orchestrator_model: 'claude-opus-4-7' } },
-    ]);
-    const { status } = await patch(h, [
-      { key: 'ORCHESTRATOR_MODEL', value: 'claude-opus-4-8' },
-    ]);
-    assert.equal(status, 200);
-    assert.equal(
-      h.registry.get(ORCH)?.config['orchestrator_model'],
-      'claude-opus-4-8',
-    );
-    assert.deepEqual(h.reactivated, [ORCH]);
-  });
-
-  it('stores a boolean toggle as a string and reactivates once', async () => {
-    h = await makeHarness([{ id: ORCH }]);
-    const { status } = await patch(h, [
-      { key: 'ORCHESTRATOR_MODEL_ROUTING', value: 'true' },
-    ]);
-    assert.equal(status, 200);
-    assert.equal(
-      h.registry.get(ORCH)?.config['orchestrator_model_routing'],
-      'true',
-    );
-    assert.deepEqual(h.reactivated, [ORCH]);
-  });
-
-  it('clears a config key when value is empty/null', async () => {
-    h = await makeHarness([
-      { id: ORCH, config: { model_routing_simple_model: 'claude-sonnet-4-6' } },
-    ]);
-    const { status } = await patch(h, [
-      { key: 'MODEL_ROUTING_SIMPLE_MODEL', value: null },
-    ]);
-    assert.equal(status, 200);
-    assert.equal(
-      h.registry.get(ORCH)?.config['model_routing_simple_model'],
-      undefined,
-    );
-  });
-
-  it('rejects a non-numeric value for a number setting', async () => {
-    h = await makeHarness([{ id: ORCH }]);
-    const { status, body } = await patch(h, [
-      { key: 'ORCHESTRATOR_MAX_TOKENS', value: 'lots' },
-    ]);
-    // Only change is invalid → no valid changes.
-    assert.equal(status, 400);
-    assert.equal(body.code, 'settings.no_valid_changes');
-    assert.ok(body.errors?.some((e) => e.key === 'ORCHESTRATOR_MAX_TOKENS'));
-    assert.deepEqual(h.reactivated, []);
-  });
-
-  it('writes a secret to every configured vault scope', async () => {
+  it('writes the Anthropic secret to every configured vault scope and reactivates each', async () => {
     h = await makeHarness([{ id: ORCH }, { id: VERIFIER }, { id: EXTRAS }]);
     const { status } = await patch(h, [
       { key: 'ANTHROPIC_API_KEY', value: 'sk-ant-test123' },
@@ -217,6 +168,19 @@ describe('admin settings route — PATCH /', () => {
     assert.deepEqual(h.reactivated.sort(), [ORCH, EXTRAS, VERIFIER].sort());
   });
 
+  it('clears the Anthropic secret from every scope on an empty value', async () => {
+    h = await makeHarness([{ id: ORCH }, { id: VERIFIER }, { id: EXTRAS }]);
+    for (const scope of [ORCH, VERIFIER, EXTRAS]) {
+      await h.vault.setMany(scope, { anthropic_api_key: 'sk-ant-old' });
+    }
+    const { status } = await patch(h, [{ key: 'ANTHROPIC_API_KEY', value: null }]);
+    assert.equal(status, 200);
+    for (const scope of [ORCH, VERIFIER, EXTRAS]) {
+      const keys = await h.vault.listKeys(scope);
+      assert.ok(!keys.includes('anthropic_api_key'), `still set in ${scope}`);
+    }
+  });
+
   it('rejects an Anthropic key without the sk-ant- prefix', async () => {
     h = await makeHarness([{ id: ORCH }, { id: VERIFIER }, { id: EXTRAS }]);
     const { status, body } = await patch(h, [
@@ -224,35 +188,36 @@ describe('admin settings route — PATCH /', () => {
     ]);
     assert.equal(status, 400);
     assert.ok(body.errors?.some((e) => e.key === 'ANTHROPIC_API_KEY'));
+    assert.deepEqual(h.reactivated, []);
   });
 
-  it('errors a change whose target plugin is not installed', async () => {
-    h = await makeHarness([{ id: ORCH }]);
+  it('errors on an unknown setting key', async () => {
+    h = await makeHarness([{ id: ORCH }, { id: VERIFIER }, { id: EXTRAS }]);
     const { status, body } = await patch(h, [
-      { key: 'TELEGRAM_PUBLIC_BASE_URL', value: 'https://x.example' },
+      { key: 'ORCHESTRATOR_MODEL', value: 'claude-opus-4-8' },
+    ]);
+    // No longer in the catalog — orchestrator settings moved to the per-plugin editor.
+    assert.equal(status, 400);
+    assert.equal(body.code, 'settings.no_valid_changes');
+    assert.ok(
+      body.errors?.some(
+        (e) => e.key === 'ORCHESTRATOR_MODEL' && e.message.includes('unknown'),
+      ),
+    );
+  });
+
+  it('errors when a target scope plugin is not installed', async () => {
+    h = await makeHarness([{ id: ORCH }]); // verifier + extras missing
+    const { status, body } = await patch(h, [
+      { key: 'ANTHROPIC_API_KEY', value: 'sk-ant-test123' },
     ]);
     assert.equal(status, 400);
     assert.equal(body.code, 'settings.no_valid_changes');
     assert.ok(
       body.errors?.some(
         (e) =>
-          e.key === 'TELEGRAM_PUBLIC_BASE_URL' &&
-          e.message.includes('not installed'),
+          e.key === 'ANTHROPIC_API_KEY' && e.message.includes('not installed'),
       ),
     );
-  });
-
-  it('applies the valid changes in a mixed batch and skips the invalid one', async () => {
-    h = await makeHarness([{ id: ORCH }]);
-    const { status, body } = await patch(h, [
-      { key: 'ORCHESTRATOR_MODEL', value: 'claude-opus-4-8' },
-      { key: 'ORCHESTRATOR_MODEL_ROUTING', value: 'maybe' },
-    ]);
-    assert.equal(status, 200);
-    assert.equal(
-      h.registry.get(ORCH)?.config['orchestrator_model'],
-      'claude-opus-4-8',
-    );
-    assert.ok(body.errors?.some((e) => e.key === 'ORCHESTRATOR_MODEL_ROUTING'));
   });
 });

--- a/middleware/test/orchestratorManifestRoutingFields.test.ts
+++ b/middleware/test/orchestratorManifestRoutingFields.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { fileURLToPath } from 'node:url';
+
+import { loadManifestFromPath } from '../src/plugins/manifestLoader.js';
+
+/**
+ * Regression guard for the .env-admin cleanup: the orchestrator model-routing
+ * knobs used to be editable ONLY via the admin `/settings` catalog. They now
+ * live in the orchestrator's own manifest `setup.fields`, so they show up in
+ * the per-plugin settings editor like every other orchestrator setting. These
+ * keys must stay in the manifest and keep their bootstrap config-key names.
+ */
+
+const MANIFEST = fileURLToPath(
+  new URL(
+    '../packages/harness-orchestrator/manifest.yaml',
+    import.meta.url,
+  ),
+);
+
+const ROUTING_FIELDS: ReadonlyArray<{ key: string; type: string }> = [
+  { key: 'orchestrator_model_routing', type: 'boolean' },
+  { key: 'model_routing_classifier_model', type: 'string' },
+  { key: 'model_routing_simple_model', type: 'string' },
+  { key: 'model_routing_complex_model', type: 'string' },
+];
+
+describe('orchestrator manifest — model-routing setup fields', () => {
+  it('exposes all four routing knobs with the right types', async () => {
+    const entry = await loadManifestFromPath(MANIFEST);
+    assert.ok(entry, 'orchestrator manifest.yaml failed to load');
+    const fields = entry.plugin.setup_fields ?? [];
+    for (const expected of ROUTING_FIELDS) {
+      const field = fields.find((f) => f.key === expected.key);
+      assert.ok(field, `missing routing setup field: ${expected.key}`);
+      assert.equal(
+        field.type,
+        expected.type,
+        `${expected.key} should be type ${expected.type}`,
+      );
+    }
+  });
+});

--- a/web-ui/app/admin/settings/page.tsx
+++ b/web-ui/app/admin/settings/page.tsx
@@ -2,12 +2,29 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+
 import {
   getSettings,
   patchSettings,
   type ResolvedSetting,
   type SettingsCategory,
 } from '../../_lib/api';
+
+/**
+ * The plugins whose settings used to live on this page and now live with each
+ * plugin (edited via its own panel at `/store/<id>`, driven by the plugin's
+ * manifest setup.fields). Shown as a directory so operators can jump straight
+ * to the right editor. `labelKey` resolves under `adminSettings.pluginDirectory.plugins`.
+ */
+const PLUGIN_DIRECTORY: ReadonlyArray<{ id: string; labelKey: string }> = [
+  { id: '@omadia/orchestrator', labelKey: 'orchestrator' },
+  { id: '@omadia/verifier', labelKey: 'verifier' },
+  { id: '@omadia/embeddings', labelKey: 'embeddings' },
+  { id: '@omadia/knowledge-graph-neon', labelKey: 'knowledgeGraph' },
+  { id: '@omadia/diagrams', labelKey: 'diagrams' },
+];
 
 /**
  * Operator settings overview — every .env-based value that bootstrap writes
@@ -33,6 +50,7 @@ export default function AdminSettingsPage(): React.ReactElement {
   const [status, setStatus] = useState<Record<string, FieldStatus>>({});
   const [errors, setErrors] = useState<Record<string, string>>({});
   const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const tDir = useTranslations('adminSettings.pluginDirectory');
 
   const load = useCallback(async (): Promise<void> => {
     try {
@@ -196,6 +214,37 @@ export default function AdminSettingsPage(): React.ReactElement {
           ))}
         </div>
       )}
+
+      <section className="mt-12 border-t border-[color:var(--border)] pt-8">
+        <h2 className="mb-2 text-[13px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
+          {tDir('heading')}
+        </h2>
+        <p className="mb-4 max-w-2xl text-[13px] leading-[1.55] text-[color:var(--fg-muted)]">
+          {tDir('intro')}
+        </p>
+        <ul className="flex flex-col gap-2">
+          {PLUGIN_DIRECTORY.map((p) => (
+            <li key={p.id}>
+              <Link
+                href={`/store/${encodeURIComponent(p.id)}`}
+                className="flex items-center justify-between gap-3 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 px-5 py-4 transition-colors hover:bg-[color:var(--card)]"
+              >
+                <span className="flex items-center gap-2">
+                  <span className="text-[14px] font-semibold text-[color:var(--fg-strong)]">
+                    {tDir(`plugins.${p.labelKey}`)}
+                  </span>
+                  <code className="text-[11px] text-[color:var(--fg-muted)]">
+                    {p.id}
+                  </code>
+                </span>
+                <span className="text-[13px] font-medium text-[color:var(--accent)]">
+                  {tDir('open')} →
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
     </main>
   );
 }

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1357,5 +1357,20 @@
         "tooltip": "{used} von {cap} aktiven Drafts, Warnung ab {warnAt}"
       }
     }
+  },
+  "adminSettings": {
+    "pluginDirectory": {
+      "heading": "Plugin-Einstellungen",
+      "intro": "Die meisten Einstellungen liegen jetzt direkt beim jeweiligen Plugin und werden in dessen eigenem Einstellungs-Panel bearbeitet. Auf dieser Seite verbleiben nur echte Plugin-übergreifende Werte (wie der gemeinsame Anthropic-Key oben).",
+      "open": "Einstellungen öffnen",
+      "plugins": {
+        "orchestrator": "Orchestrator & Model-Routing",
+        "verifier": "Verifier",
+        "embeddings": "Embeddings",
+        "knowledgeGraph": "Knowledge-Graph",
+        "diagrams": "Diagramme & Speicher",
+        "integrations": "Integrationen (Microsoft, Teams, Telegram)"
+      }
+    }
   }
 }

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1357,5 +1357,20 @@
         "tooltip": "{used} of {cap} active drafts, warning from {warnAt}"
       }
     }
+  },
+  "adminSettings": {
+    "pluginDirectory": {
+      "heading": "Per-plugin settings",
+      "intro": "Most configuration now lives with each plugin and is edited in its own settings panel. Only genuinely cross-plugin values (like the shared Anthropic key above) remain on this page.",
+      "open": "Open settings",
+      "plugins": {
+        "orchestrator": "Orchestrator & model routing",
+        "verifier": "Verifier",
+        "embeddings": "Embeddings",
+        "knowledgeGraph": "Knowledge graph",
+        "diagrams": "Diagrams & storage",
+        "integrations": "Integrations (Microsoft, Teams, Telegram)"
+      }
+    }
   }
 }


### PR DESCRIPTION
## What

The admin `/settings` page was backed by a hand-maintained catalog (`settingsCatalog.ts`, 31 entries) that just mirrored each plugin's own `manifest.yaml → setup.fields` and wrote through the **exact same** `installedRegistry.updateConfig` / `vault` plumbing as the per-plugin runtime editor. ~27 of 31 entries were pure duplicates of settings already editable per-plugin.

The only keys the admin page uniquely owned were 4 orchestrator model-routing knobs that were missing from the orchestrator manifest.

## Changes

- **Move the 4 routing knobs into the orchestrator manifest** (`orchestrator_model_routing` + the 3 `model_routing_*_model` fields) in `harness-orchestrator/manifest.yaml` `setup.fields` → now editable in the per-plugin settings editor like every other orchestrator setting.
- **Slim `settingsCatalog.ts`** from 31 → **1 entry**: `ANTHROPIC_API_KEY`, the one genuinely cross-plugin value (its secret fans out to 3 vault scopes — orchestrator, verifier, orchestrator-extras — so setting it once centrally is a real convenience the per-plugin editor can't match). Every other setting now lives with its plugin.
- **Add a bilingual (next-intl, en/de) "plugin settings directory"** to `/admin/settings` that links each plugin to its own editor at `/store/<id>`.
- **Tests**: rewrite `adminSettingsRoute.test.ts` for the slim catalog (Anthropic fan-out, set/unset, sk-ant- validation, unknown/not-installed paths); add `orchestratorManifestRoutingFields.test.ts` as a regression guard that the 4 routing fields stay in the manifest with correct types.

## Why it's safe

`bootstrap.ts` `.env`→config seeding and the write plumbing are untouched. The catalog only ever drove the admin overview UI, so removing entries cannot change any runtime value — those settings remain fully editable through each plugin's own editor.

## Verification

- middleware: lint clean, `tsc --noEmit` clean, affected tests 11/11 pass (incl. the new main `buildForAgentRouting` test)
- web-ui: eslint clean, `tsc --noEmit` clean, `i18n:check` OK (1096 keys, en/de parity)
