### PR TITLE
fix(agent-builder): propagate runtime agent installs to fallback even when boot was chat-disabled

### DIFF
--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -670,11 +670,126 @@ async function main(): Promise<void> {
   // per-Agent orchestrator never learned the new tool, so it behaves as if the
   // plugin were never activated.
    
-  let propagatePluginInstall: ((pluginId: string) => Promise<void>) | undefined;
-   
-  let propagatePluginUninstall:
-    | ((pluginId: string, removedToolName?: string) => Promise<void>)
-    | undefined;
+  // --- Runtime plugin (de)activation propagation ------------------------
+  // A plugin (de)activated AFTER boot (operator install, Hub/registry
+  // install, package re-upload, self-extension) mutates only the standalone
+  // `dynamicAgentRuntime` + the single legacy orchestrator. The per-Agent
+  // registry orchestrators — which the chat router resolves for every turn,
+  // falling back to the fallback Agent for un-slugged turns — are a boot
+  // snapshot that the install path must reconcile.
+  //
+  // These closures are defined UNCONDITIONALLY here (not gated on the
+  // boot-time `orchestrator` being present) and resolve `configStore` /
+  // `orchestratorRegistry` LIVE from the serviceRegistry on every call.
+  // Previously they were assigned inside the `if (orchestrator) { … }`
+  // boot block, so on a chat-DISABLED boot (no ANTHROPIC_API_KEY at start —
+  // the Setup-Wizard / Docker path) they stayed `undefined`. The
+  // `onInstalled` hook's `propagatePluginInstall?.(agentId)` then silently
+  // no-op'd: the agent activated in `dynamicAgentRuntime` but the fallback
+  // Agent's `agent_plugins` enablement row was never written, so
+  // `scopeDomainToolsToPlugins` withheld its `query_*` tool — at install
+  // time AND on every later restart, because the missing DB row persists.
+  // (Channels are unaffected: the channel install hook activates them
+  // directly, with no plugin-scoping — which is why connectors appear on a
+  // new session but specialist agents never did.) Resolving live here makes
+  // the propagation take effect the moment chat goes live via the wizard.
+  const ORCHESTRATOR_PLUGIN_ID = '@omadia/orchestrator';
+
+  // Reconcile a single agent-plugin's DomainTool across every per-Agent
+  // orchestrator: (re-)register a fresh handle where the plugin is enabled,
+  // drop it where it is not. Idempotent and safe for re-uploads (the stale
+  // handle is replaced). No-ops for non-agent plugins (no DomainTool); on
+  // uninstall the runtime no longer knows the tool, so drop it by name.
+  const reconcileRuntimeDomainTool = (
+    pluginId: string,
+    removedToolName?: string,
+  ): void => {
+    const reg =
+      serviceRegistry.get<MultiOrchestratorRegistry>('orchestratorRegistry');
+    if (!reg) return;
+    const tool = dynamicAgentRuntime.domainToolFor(pluginId);
+    reconcileDomainToolAcrossAgents(
+      reg.list().map((entry) => ({
+        slug: entry.agent.slug,
+        enabled: entry.plugins.some(
+          (p) => p.enabled && p.pluginId === pluginId,
+        ),
+        orchestrator: entry.built.orchestrator,
+      })),
+      {
+        ...(tool ? { tool } : {}),
+        ...(removedToolName ? { removedToolName } : {}),
+        onError: (slug, err) =>
+          console.error(
+            `[middleware] reconcileRuntimeDomainTool(${pluginId}) on "${slug}" FAILED:`,
+            err instanceof Error ? err.message : String(err),
+          ),
+      },
+    );
+  };
+
+  const propagatePluginInstall = async (pluginId: string): Promise<void> => {
+    if (pluginId === ORCHESTRATOR_PLUGIN_ID) return;
+    const store =
+      serviceRegistry.get<MultiOrchestratorConfigStore>('configStore');
+    const reg =
+      serviceRegistry.get<MultiOrchestratorRegistry>('orchestratorRegistry');
+    if (!store || !reg) return; // no-DB / chat-disabled boot — nothing to wire
+    try {
+      const { fallbackAgentId } = await store.getPlatformSettings();
+      if (fallbackAgentId) {
+        // Keep the "fallback Agent has every installed plugin enabled"
+        // invariant alive at runtime. Un-slugged chat routes to the
+        // fallback Agent (getDefaultSlug → slugForFallback); without an
+        // enabled `agent_plugins` row, `scopeDomainToolsToPlugins` would
+        // withhold the new tool even after it is hydrated. First-boot does
+        // this via `attachAllPlugins`; runtime installs never did.
+        await store.upsertAgentPlugin(fallbackAgentId, {
+          pluginId,
+          enabled: true,
+        });
+        // Refresh `entry.plugins` from the DB so the scoping check below
+        // sees the freshly-enabled row. Idempotent no-op when unchanged;
+        // a plugin-only change is an `update` (no rebuild → sessions kept).
+        await reg.reload();
+      }
+    } catch (err) {
+      console.error(
+        `[middleware] propagatePluginInstall(${pluginId}) enable/reload FAILED:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    reconcileRuntimeDomainTool(pluginId);
+    console.log(`[middleware] runtime plugin install propagated: ${pluginId}`);
+  };
+
+  const propagatePluginUninstall = async (
+    pluginId: string,
+    removedToolName?: string,
+  ): Promise<void> => {
+    if (pluginId === ORCHESTRATOR_PLUGIN_ID) return;
+    const store =
+      serviceRegistry.get<MultiOrchestratorConfigStore>('configStore');
+    const reg =
+      serviceRegistry.get<MultiOrchestratorRegistry>('orchestratorRegistry');
+    if (!store || !reg) return;
+    try {
+      const { fallbackAgentId } = await store.getPlatformSettings();
+      if (fallbackAgentId) {
+        await store.removeAgentPlugin(fallbackAgentId, pluginId);
+        await reg.reload();
+      }
+    } catch (err) {
+      console.error(
+        `[middleware] propagatePluginUninstall(${pluginId}) disable/reload FAILED:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    reconcileRuntimeDomainTool(pluginId, removedToolName);
+    console.log(
+      `[middleware] runtime plugin uninstall propagated: ${pluginId}`,
+    );
+  };
 
   const installService = new InstallService({
     catalog: pluginCatalog,
@@ -707,7 +822,7 @@ async function main(): Promise<void> {
           await dynamicAgentRuntime.activate(agentId);
           // Make the freshly-activated agent's tool reachable on the per-Agent
           // orchestrators (incl. the fallback Agent) without a restart.
-          await propagatePluginInstall?.(agentId);
+          await propagatePluginInstall(agentId);
       }
     },
     onUninstall: async (agentId) => {
@@ -730,7 +845,7 @@ async function main(): Promise<void> {
           const removedToolName =
             dynamicAgentRuntime.domainToolFor(agentId)?.name;
           await dynamicAgentRuntime.deactivate(agentId);
-          await propagatePluginUninstall?.(agentId, removedToolName);
+          await propagatePluginUninstall(agentId, removedToolName);
         }
       }
     },
@@ -1292,112 +1407,6 @@ async function main(): Promise<void> {
         );
       });
 
-      // --- Runtime plugin (de)activation propagation ----------------------
-      // A plugin (de)activated AFTER boot (operator install, Hub/registry
-      // install, package re-upload, self-extension) mutates only the standalone
-      // `dynamicAgentRuntime` + the single legacy orchestrator. The per-Agent
-      // registry orchestrators — which the chat router resolves for every turn,
-      // falling back to the fallback Agent for un-slugged turns — are a boot
-      // snapshot that the install path never reconciled. These two closures
-      // close that gap; the `let` forward-refs near the install hooks are
-      // assigned here (the hooks only fire at runtime, after this block ran).
-      const ORCHESTRATOR_PLUGIN_ID = '@omadia/orchestrator';
-
-      // Reconcile a single agent-plugin's DomainTool across every per-Agent
-      // orchestrator: (re-)register a fresh handle where the plugin is enabled,
-      // drop it where it is not. Idempotent and safe for re-uploads (the stale
-      // handle is replaced). No-ops for non-agent plugins (no DomainTool); on
-      // uninstall the runtime no longer knows the tool, so drop it by name.
-      const reconcileRuntimeDomainTool = (
-        pluginId: string,
-        removedToolName?: string,
-      ): void => {
-        const reg =
-          serviceRegistry.get<MultiOrchestratorRegistry>('orchestratorRegistry');
-        if (!reg) return;
-        const tool = dynamicAgentRuntime.domainToolFor(pluginId);
-        reconcileDomainToolAcrossAgents(
-          reg.list().map((entry) => ({
-            slug: entry.agent.slug,
-            enabled: entry.plugins.some(
-              (p) => p.enabled && p.pluginId === pluginId,
-            ),
-            orchestrator: entry.built.orchestrator,
-          })),
-          {
-            ...(tool ? { tool } : {}),
-            ...(removedToolName ? { removedToolName } : {}),
-            onError: (slug, err) =>
-              console.error(
-                `[middleware] reconcileRuntimeDomainTool(${pluginId}) on "${slug}" FAILED:`,
-                err instanceof Error ? err.message : String(err),
-              ),
-          },
-        );
-      };
-
-      propagatePluginInstall = async (pluginId: string): Promise<void> => {
-        if (pluginId === ORCHESTRATOR_PLUGIN_ID) return;
-        const store =
-          serviceRegistry.get<MultiOrchestratorConfigStore>('configStore');
-        const reg =
-          serviceRegistry.get<MultiOrchestratorRegistry>('orchestratorRegistry');
-        if (!store || !reg) return; // no-DB / chat-disabled boot — nothing to wire
-        try {
-          const { fallbackAgentId } = await store.getPlatformSettings();
-          if (fallbackAgentId) {
-            // Keep the "fallback Agent has every installed plugin enabled"
-            // invariant alive at runtime. Un-slugged chat routes to the
-            // fallback Agent (getDefaultSlug → slugForFallback); without an
-            // enabled `agent_plugins` row, `scopeDomainToolsToPlugins` would
-            // withhold the new tool even after it is hydrated. First-boot does
-            // this via `attachAllPlugins`; runtime installs never did.
-            await store.upsertAgentPlugin(fallbackAgentId, {
-              pluginId,
-              enabled: true,
-            });
-            // Refresh `entry.plugins` from the DB so the scoping check below
-            // sees the freshly-enabled row. Idempotent no-op when unchanged;
-            // a plugin-only change is an `update` (no rebuild → sessions kept).
-            await reg.reload();
-          }
-        } catch (err) {
-          console.error(
-            `[middleware] propagatePluginInstall(${pluginId}) enable/reload FAILED:`,
-            err instanceof Error ? err.message : String(err),
-          );
-        }
-        reconcileRuntimeDomainTool(pluginId);
-        console.log(`[middleware] runtime plugin install propagated: ${pluginId}`);
-      };
-
-      propagatePluginUninstall = async (
-        pluginId: string,
-        removedToolName?: string,
-      ): Promise<void> => {
-        if (pluginId === ORCHESTRATOR_PLUGIN_ID) return;
-        const store =
-          serviceRegistry.get<MultiOrchestratorConfigStore>('configStore');
-        const reg =
-          serviceRegistry.get<MultiOrchestratorRegistry>('orchestratorRegistry');
-        if (!store || !reg) return;
-        try {
-          const { fallbackAgentId } = await store.getPlatformSettings();
-          if (fallbackAgentId) {
-            await store.removeAgentPlugin(fallbackAgentId, pluginId);
-            await reg.reload();
-          }
-        } catch (err) {
-          console.error(
-            `[middleware] propagatePluginUninstall(${pluginId}) disable/reload FAILED:`,
-            err instanceof Error ? err.message : String(err),
-          );
-        }
-        reconcileRuntimeDomainTool(pluginId, removedToolName);
-        console.log(
-          `[middleware] runtime plugin uninstall propagated: ${pluginId}`,
-        );
-      };
     }
   }
 
@@ -2065,7 +2074,7 @@ async function main(): Promise<void> {
             // Hub/registry install + package re-upload land here. Propagate the
             // (fresh) tool onto the per-Agent orchestrators so the new/updated
             // capability is live for the next chat turn without a restart.
-            await propagatePluginInstall?.(agentId);
+            await propagatePluginInstall(agentId);
           }
         }
       },


### PR DESCRIPTION
## Problem

After installing an **agent** plugin at runtime, its specialist sub-agent (`query_*` domain tool) was **not pulled into the fallback Agent** — neither on a fresh chat session nor after a restart. **Channel/connector** installs, by contrast, showed up on a new session. That asymmetry was the reported bug.

## Root cause

The `onInstalled` hook for `kind: 'agent'` activates the agent in `dynamicAgentRuntime`, then calls `propagatePluginInstall?.(agentId)` to wire the new domain tool into the per-Agent orchestrators (including the fallback Agent).

But `propagatePluginInstall` / `propagatePluginUninstall` (and `reconcileRuntimeDomainTool`) were **assigned only inside the boot-time `if (orchestrator) { … }` guard**. On a **chat-disabled boot** — no `ANTHROPIC_API_KEY` at process start, i.e. the Setup-Wizard / Docker path — `orchestrator` is falsy at boot, so those closures stayed `undefined`. The optional-chained call then silently no-op'd:

- The agent activated in `dynamicAgentRuntime`, **but** the fallback Agent's `agent_plugins` enablement row was never written.
- `scopeDomainToolsToPlugins` gates each domain tool on that row → the tool was **withheld** from the fallback Agent.
- The missing DB row **persists**, so it is still gone after a restart.

**Channels are unaffected** because the channel install hook activates them directly (`channelRegistryRef.activate`) with no plugin-scoping / DB enablement — which is exactly why connectors appeared on a fresh session but specialist agents never did.

## Fix

Define the three closures **unconditionally** (hoisted out of the `if (orchestrator)` boot guard). They already resolve `configStore` / `orchestratorRegistry` **live** from the `serviceRegistry` on every call, so they take effect the moment chat goes live via the Setup Wizard — and the enablement row they write now survives restarts. Forward-ref `let`s become `const`, and the now-redundant optional chaining at the call sites is dropped.

Pure code-motion + scope change; no behavioural change on the env-key (chat-enabled-at-boot) path.

## Verification

- `npm run build` ✅ (full workspace, ends by compiling `src/index.ts`)
- `eslint src/index.ts` ✅ (0 problems)
- `tsc --noEmit` ✅ (0 errors)
- `test/runtimeToolPropagation.test.ts` + `test/scopeDomainTools.test.ts` ✅ (10/10 pass)

## Remaining nuance (out of scope)

Installing an agent *before* the key is set (while `orchestratorRegistry` doesn't exist yet) still early-returns, but now self-heals on the next restart because the boot hydration reads enablement from the DB. The normal flow (set key → install agents) is fully fixed.
