### PR TITLE
chore(compose): drop fixed container_name from postgres service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -143,10 +143,11 @@ services:
   postgres:
     image: pgvector/pgvector:pg17
     restart: unless-stopped
-    # Explicit container_name + network alias so the middleware always
-    # resolves the `postgres` DNS name regardless of the compose project
-    # prefix (default name would be `<dir>-postgres-1`).
-    container_name: omadia-postgres
+    # Network alias + hostname so the middleware always resolves the
+    # `postgres` DNS name regardless of the compose project prefix. No explicit
+    # container_name: it's redundant for in-network DNS (the service name +
+    # `networks.omadia.aliases` below already resolve `postgres`) and a fixed
+    # name collides when a second compose project runs side by side.
     hostname: postgres
     environment:
       POSTGRES_USER: omadia


### PR DESCRIPTION
## What

Removes the explicit `container_name: omadia-postgres` from the `postgres` service in `docker-compose.yaml` (and corrects the now-stale comment).

## Why

The fixed `container_name` was not needed for the middleware to reach Postgres:

- Within the compose network, services are resolvable by their **service name** (`postgres`), and the service already declares `networks.omadia.aliases: [postgres]` plus `hostname: postgres` — so the `postgres` DNS name resolves regardless of the compose project prefix.
- A hard-coded `container_name` also **collides** when a second compose project (or a parallel stack) runs on the same host, since Docker container names must be globally unique.

Net: less surprising, no behavioural change to service discovery.

## Verification

- `docker compose -f docker-compose.yaml config -q` ✅ (validates clean)
