### PR TITLE
perf(plan-runner): reuse stored processes + batch plan-step reads, cache overlay

### DIFF
--- a/middleware/packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.ts
+++ b/middleware/packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.ts
@@ -2906,6 +2906,16 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
     });
   }
 
+  async getPlanStepsForPlans(
+    planExternalIds: string[],
+  ): Promise<Map<string, GraphNode[]>> {
+    const out = new Map<string, GraphNode[]>();
+    for (const id of planExternalIds) {
+      out.set(id, await this.getPlanSteps(id));
+    }
+    return out;
+  }
+
   async setPlanStepStatus(
     stepExternalId: string,
     status: PlanStepStatus,

--- a/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
+++ b/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
@@ -1083,21 +1083,60 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
   }
 
   async getPlanSteps(planExternalId: string): Promise<GraphNode[]> {
-    const planRow = await this.findNodeByExternalId(planExternalId);
-    if (!planRow || planRow.type !== 'Plan') return [];
+    // Single round-trip: join Plan→STEP_OF→PlanStep by the plan's external id
+    // so we no longer re-resolve the plan node we were handed (the old
+    // findNodeByExternalId + step query was two round-trips per call, and this
+    // runs once per tool-call on the live plan-snapshot path). A missing or
+    // non-Plan node simply yields no rows → [].
+    const stepCols = NODE_COLUMNS.split(', ')
+      .map((c) => `s.${c}`)
+      .join(', ');
     const res = await this.pool.query<NodeRow>(
-      `SELECT ${NODE_COLUMNS}
-         FROM graph_nodes
-        WHERE tenant_id = $1
-          AND type = 'PlanStep'
-          AND id IN (
-            SELECT from_node FROM graph_edges
-             WHERE tenant_id = $1 AND type = 'STEP_OF' AND to_node = $2
-          )
-        ORDER BY (properties->>'order')::int ASC`,
-      [this.tenantId, planRow.id],
+      `SELECT ${stepCols}
+         FROM graph_nodes p
+         JOIN graph_edges e
+           ON e.tenant_id = p.tenant_id AND e.type = 'STEP_OF' AND e.to_node = p.id
+         JOIN graph_nodes s
+           ON s.tenant_id = p.tenant_id AND s.id = e.from_node AND s.type = 'PlanStep'
+        WHERE p.tenant_id = $1 AND p.external_id = $2 AND p.type = 'Plan'
+        ORDER BY (s.properties->>'order')::int ASC`,
+      [this.tenantId, planExternalId],
     );
     return res.rows.map((r) => rowToNode(r));
+  }
+
+  async getPlanStepsForPlans(
+    planExternalIds: string[],
+  ): Promise<Map<string, GraphNode[]>> {
+    // Pre-seed every requested id so callers get a stable `[]` for plans with
+    // no steps (or unknown ids) without an `undefined` check.
+    const out = new Map<string, GraphNode[]>();
+    for (const id of planExternalIds) out.set(id, []);
+    if (planExternalIds.length === 0) return out;
+    // One round-trip for ALL plans: the same join as getPlanSteps, tagged with
+    // the owning plan's external id and filtered by `= ANY($2)`. Replaces the
+    // per-plan N+1 on the recall + overlay paths (up to 1+2N → 1 query).
+    const stepCols = NODE_COLUMNS.split(', ')
+      .map((c) => `s.${c}`)
+      .join(', ');
+    const res = await this.pool.query<NodeRow & { plan_ext: string }>(
+      `SELECT p.external_id AS plan_ext, ${stepCols}
+         FROM graph_nodes p
+         JOIN graph_edges e
+           ON e.tenant_id = p.tenant_id AND e.type = 'STEP_OF' AND e.to_node = p.id
+         JOIN graph_nodes s
+           ON s.tenant_id = p.tenant_id AND s.id = e.from_node AND s.type = 'PlanStep'
+        WHERE p.tenant_id = $1
+          AND p.external_id = ANY($2::text[])
+          AND p.type = 'Plan'
+        ORDER BY (s.properties->>'order')::int ASC`,
+      [this.tenantId, planExternalIds],
+    );
+    for (const r of res.rows) {
+      // Every plan_ext is one of the pre-seeded ids (WHERE = ANY($2)).
+      out.get(r.plan_ext)!.push(rowToNode(r));
+    }
+    return out;
   }
 
   async setPlanStepStatus(

--- a/middleware/packages/harness-knowledge-graph-neon/src/schema.ts
+++ b/middleware/packages/harness-knowledge-graph-neon/src/schema.ts
@@ -409,7 +409,7 @@ const PlanPropsSchema = z
     scope: z.string().min(1),
     turnId: z.string().optional(),
     strategy: z.string().optional(),
-    createdBy: z.enum(['gate', 'manual']).optional(),
+    createdBy: z.enum(['gate', 'manual', 'process']).optional(),
     // #237 (plan GC) — originating request summary for semantic-dedup compare.
     requestSummary: z.string().optional(),
     createdAt: z.string().datetime(),

--- a/middleware/packages/harness-orchestrator-extras/src/captureFilteringKnowledgeGraph.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/captureFilteringKnowledgeGraph.ts
@@ -185,6 +185,12 @@ export class CaptureFilteringKnowledgeGraph implements KnowledgeGraph {
     return this.inner.getPlanSteps(planExternalId);
   }
 
+  getPlanStepsForPlans(
+    planExternalIds: string[],
+  ): Promise<Map<string, GraphNode[]>> {
+    return this.inner.getPlanStepsForPlans(planExternalIds);
+  }
+
   setPlanStepStatus(
     stepExternalId: string,
     status: PlanStepStatus,

--- a/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
@@ -820,10 +820,20 @@ export class ContextRetriever {
           ? { agentScopePrefix: input.agentScopePrefix }
           : {}),
       });
+      // Cross-session only — drop same-session plans before fetching steps so
+      // the batched read does no wasted work.
+      const candidates = plans.filter(
+        (p) => p.props['scope'] !== input.sessionScope,
+      );
+      // One round-trip for every candidate's steps instead of a serial
+      // getPlanSteps per plan (the old loop was up to ~24 sequential Neon
+      // round-trips on the turn's context-build hot path).
+      const stepsByPlan = await this.graph.getPlanStepsForPlans(
+        candidates.map((p) => p.id),
+      );
       const scored: Array<{ hit: RecalledPlan; score: number }> = [];
-      for (const p of plans) {
-        if (p.props['scope'] === input.sessionScope) continue; // cross-session only
-        const steps = await this.graph.getPlanSteps(p.id);
+      for (const p of candidates) {
+        const steps = stepsByPlan.get(p.id) ?? [];
         const openStepGoals: string[] = [];
         const goalTexts: string[] = [];
         let doneCount = 0;

--- a/middleware/packages/harness-orchestrator-extras/src/inconsistencyTriggeringKnowledgeGraph.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/inconsistencyTriggeringKnowledgeGraph.ts
@@ -183,6 +183,12 @@ export class InconsistencyTriggeringKnowledgeGraph implements KnowledgeGraph {
     return this.inner.getPlanSteps(planExternalId);
   }
 
+  getPlanStepsForPlans(
+    planExternalIds: string[],
+  ): Promise<Map<string, GraphNode[]>> {
+    return this.inner.getPlanStepsForPlans(planExternalIds);
+  }
+
   setPlanStepStatus(
     stepExternalId: string,
     status: PlanStepStatus,

--- a/middleware/packages/harness-orchestrator-extras/src/mergeTriggeringKnowledgeGraph.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/mergeTriggeringKnowledgeGraph.ts
@@ -274,6 +274,12 @@ export class MergeTriggeringKnowledgeGraph implements KnowledgeGraph {
     return this.inner.getPlanSteps(planExternalId);
   }
 
+  getPlanStepsForPlans(
+    planExternalIds: string[],
+  ): Promise<Map<string, GraphNode[]>> {
+    return this.inner.getPlanStepsForPlans(planExternalIds);
+  }
+
   setPlanStepStatus(
     stepExternalId: string,
     status: PlanStepStatus,

--- a/middleware/packages/harness-plugin-plan-runner/src/index.ts
+++ b/middleware/packages/harness-plugin-plan-runner/src/index.ts
@@ -5,7 +5,14 @@
  * `activate`). Re-exports here are for tests + programmatic consumers.
  */
 
-export { activate, pruneTurns, type PlanRunnerPluginHandle } from './plugin.js';
+export {
+  activate,
+  pruneTurns,
+  pickReusableProcess,
+  DEFAULT_PROCESS_REUSE_THRESHOLD,
+  type PlanRunnerPluginHandle,
+  type ReusableProcess,
+} from './plugin.js';
 export { shouldPlan, GATE_MODEL } from './gate.js';
 export {
   gcSupersededPlans,
@@ -16,10 +23,12 @@ export {
 } from './gc.js';
 export {
   materializePlan,
+  materializePlanFromSteps,
   parsePlanSteps,
   summariseRequest,
   PLAN_MODEL,
   type MaterializeInput,
+  type MaterializeFromStepsInput,
   type MaterializeResult,
   type ParsedStep,
 } from './materializer.js';

--- a/middleware/packages/harness-plugin-plan-runner/src/materializer.ts
+++ b/middleware/packages/harness-plugin-plan-runner/src/materializer.ts
@@ -91,25 +91,25 @@ export interface MaterializeResult {
   exitConditions: Array<string | undefined>;
 }
 
-/** Materialise + persist a plan. Returns null when the model produced no
- *  usable steps (the gate said "plan" but decomposition yielded nothing). */
-export async function materializePlan(
-  input: MaterializeInput,
+/** Persist a parsed step list as a Plan + PlanStep DAG. Shared by the LLM
+ *  materialiser ({@link materializePlan}) and the process-reuse materialiser
+ *  ({@link materializePlanFromSteps}) so both write identical graph shapes;
+ *  only `createdBy`/`strategy` provenance differs. */
+async function persistPlan(
+  input: Pick<
+    MaterializeInput,
+    'planId' | 'scope' | 'userMessage' | 'createdAt' | 'kg'
+  >,
+  steps: ParsedStep[],
+  provenance: { createdBy: 'gate' | 'process'; strategy?: string },
 ): Promise<MaterializeResult | null> {
-  const res = await input.llm.complete({
-    model: PLAN_MODEL,
-    system: PLAN_SYSTEM,
-    messages: [{ role: 'user', content: input.userMessage.trim() }],
-    maxTokens: 1024,
-    temperature: 0,
-  });
-  const steps = parsePlanSteps(res.text);
   if (steps.length === 0) return null;
 
   const { planExternalId } = await input.kg.ingestPlan({
     planId: input.planId,
     scope: input.scope,
-    createdBy: 'gate',
+    createdBy: provenance.createdBy,
+    ...(provenance.strategy ? { strategy: provenance.strategy } : {}),
     createdAt: input.createdAt,
     // #237 (plan GC) — stash a capped copy of the request so the GC pass can
     // judge whether a later plan in this scope is the same task re-planned.
@@ -141,4 +141,49 @@ export async function materializePlan(
   }
 
   return { planExternalId, stepCount: steps.length, stepExternalIds, exitConditions };
+}
+
+/** Materialise + persist a plan. Returns null when the model produced no
+ *  usable steps (the gate said "plan" but decomposition yielded nothing). */
+export async function materializePlan(
+  input: MaterializeInput,
+): Promise<MaterializeResult | null> {
+  const res = await input.llm.complete({
+    model: PLAN_MODEL,
+    system: PLAN_SYSTEM,
+    messages: [{ role: 'user', content: input.userMessage.trim() }],
+    maxTokens: 1024,
+    temperature: 0,
+  });
+  return persistPlan(input, parsePlanSteps(res.text), { createdBy: 'gate' });
+}
+
+export interface MaterializeFromStepsInput
+  extends Omit<MaterializeInput, 'llm'> {
+  /** Ordered workflow steps from a reused {@link ProcessRecord}. Flat strings
+   *  (Phase-7 process shape) → sequential plan steps, no DAG dependencies. */
+  steps: readonly string[];
+  /** Title of the source process — stored on the plan as `strategy` so the UI
+   *  and GC can see the plan was reused, not freshly thought. */
+  processTitle: string;
+}
+
+/**
+ * Materialise a plan from a reused stored process — NO LLM call. The agent
+ * learned this workflow once (`write_process`); reusing its steps here is what
+ * stops every plan-worthy turn from re-deriving the same DAG via Haiku. Data
+ * is still fetched fresh at execution time — the plan only fixes the *steps*,
+ * never their results. Returns null on an empty/blank step list.
+ */
+export async function materializePlanFromSteps(
+  input: MaterializeFromStepsInput,
+): Promise<MaterializeResult | null> {
+  const steps: ParsedStep[] = input.steps
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map((goal) => ({ goal, dependsOn: [] }));
+  return persistPlan(input, steps, {
+    createdBy: 'process',
+    strategy: `Reused stored process: ${input.processTitle}`,
+  });
 }

--- a/middleware/packages/harness-plugin-plan-runner/src/plugin.ts
+++ b/middleware/packages/harness-plugin-plan-runner/src/plugin.ts
@@ -1,12 +1,20 @@
-import { planNodeId } from '@omadia/plugin-api';
-import type { KnowledgeGraph, PluginContext } from '@omadia/plugin-api';
+import { planNodeId, PROCESS_MEMORY_SERVICE_NAME } from '@omadia/plugin-api';
+import type {
+  KnowledgeGraph,
+  PluginContext,
+  ProcessMemoryService,
+} from '@omadia/plugin-api';
 import type { TurnAnnotation, TurnHookRegistrar } from '@omadia/orchestrator';
 import { graphScopeFor } from '@omadia/orchestrator';
 
 import { shouldPlan } from './gate.js';
 import { buildPlanSnapshot } from './snapshot.js';
 import { gcSupersededPlans } from './gc.js';
-import { materializePlan, summariseRequest } from './materializer.js';
+import {
+  materializePlan,
+  materializePlanFromSteps,
+  summariseRequest,
+} from './materializer.js';
 import {
   advanceStep,
   applyReplan,
@@ -59,6 +67,10 @@ interface TurnRecord {
   /** Step external id → its exit condition, for the opt-in E4 trigger (b)
    *  check. Only initial-plan steps are tracked (replan steps aren't). */
   readonly exitConditionByStep: ReadonlyMap<string, string>;
+  /** Title of the stored process this plan was reused from (no LLM
+   *  re-planning), threaded into every plan snapshot so the UI badges it.
+   *  Undefined for freshly-materialised plans. */
+  readonly reusedProcessTitle?: string;
   /** Replan counter — namespaces recovery step ids. */
   generation: number;
 }
@@ -94,6 +106,40 @@ export function pruneTurns<T extends { startedAtMs: number }>(
       dropped += 1;
     }
   }
+}
+
+/** Default hybrid-retrieval score above which a stored process is reused
+ *  instead of re-planned. Tunable via the `processReuseThreshold` setup field. */
+export const DEFAULT_PROCESS_REUSE_THRESHOLD = 0.6;
+
+export interface ReusableProcess {
+  readonly steps: readonly string[];
+  readonly title: string;
+  readonly id: string;
+}
+
+/**
+ * Find a learned process worth reusing for `query`. Returns the top hit when
+ * its hybrid score clears `threshold` and it has steps, else null. Never
+ * throws — a degraded process-recall must fall through to LLM planning, not
+ * kill the turn. Exported for unit testing.
+ */
+export async function pickReusableProcess(
+  processMemory: Pick<ProcessMemoryService, 'query'>,
+  query: string,
+  threshold: number,
+): Promise<ReusableProcess | null> {
+  let hits: Awaited<ReturnType<ProcessMemoryService['query']>>;
+  try {
+    hits = await processMemory.query({ query, limit: 1 });
+  } catch {
+    return null;
+  }
+  const top = hits[0];
+  if (!top || top.score < threshold || top.record.steps.length === 0) {
+    return null;
+  }
+  return { steps: top.record.steps, title: top.record.title, id: top.record.id };
 }
 
 export interface PlanRunnerPluginHandle {
@@ -142,6 +188,26 @@ export async function activate(
   const gcDuplicatePlans =
     ctx.config.get<string>('gcDuplicatePlans') !== 'off';
 
+  // Reuse a learned process (ProcessMemory) instead of re-planning a matching
+  // turn via Haiku — the core "stop re-thinking every turn" fix. ON by default
+  // (set `reuseProcesses=off` to disarm). Inert when no processMemory@1
+  // provider is published (e.g. the in-memory KG) → falls through to the gate.
+  const reuseProcesses = ctx.config.get<string>('reuseProcesses') !== 'off';
+  const processMemory = reuseProcesses
+    ? ctx.services.get<ProcessMemoryService>(PROCESS_MEMORY_SERVICE_NAME)
+    : undefined;
+  const reuseThresholdRaw = Number.parseFloat(
+    ctx.config.get<string>('processReuseThreshold') ?? '',
+  );
+  const reuseThreshold = Number.isFinite(reuseThresholdRaw)
+    ? reuseThresholdRaw
+    : DEFAULT_PROCESS_REUSE_THRESHOLD;
+  if (processMemory) {
+    ctx.log(
+      `[plan-runner] process reuse ON (threshold=${reuseThreshold.toFixed(2)})`,
+    );
+  }
+
   // Per-turn plan state + replan context, keyed by orchestrator turn id.
   // Populated at onBeforeTurn (after materialisation) and drained at
   // onAfterTurn. An errored turn never fires onAfterTurn, so we evict stale
@@ -154,9 +220,19 @@ export async function activate(
   // status. Never throws (a failed snapshot just means no UI update this tick).
   const planAnnotation = async (
     planExternalId: string,
+    reusedProcessTitle?: string,
   ): Promise<TurnAnnotation[]> => {
     try {
-      return [{ channel: 'plan', payload: await buildPlanSnapshot(planExternalId, kg) }];
+      return [
+        {
+          channel: 'plan',
+          payload: await buildPlanSnapshot(
+            planExternalId,
+            kg,
+            reusedProcessTitle ? { reusedProcessTitle } : undefined,
+          ),
+        },
+      ];
     } catch {
       return [];
     }
@@ -169,7 +245,6 @@ export async function activate(
       hook: async (hookCtx, payload): Promise<void | TurnAnnotation[]> => {
         const userMessage = payload.userMessage?.trim();
         if (!userMessage) return;
-        if (!(await shouldPlan(userMessage, llm))) return;
         // Per-orchestrator isolation: qualify the plan scope with the Agent
         // slug (same `graphScopeFor` formula SessionLogger uses for Turns) so
         // `listRecentPlans` recall stays per-Agent. `agentSlug` is undefined
@@ -180,14 +255,50 @@ export async function activate(
         );
         const nowMs = Date.now();
         const createdAt = new Date(nowMs).toISOString();
-        const result = await materializePlan({
-          planId: hookCtx.turnId,
-          scope,
-          userMessage,
-          createdAt,
-          llm,
-          kg,
-        });
+
+        // Process reuse first: a learned workflow that matches this request is
+        // materialised straight from its stored steps — no gate, no Haiku
+        // re-planning. A matched process is multi-step by construction, so the
+        // gate would only confirm what we already know. Data is still fetched
+        // fresh by the tool loop; the plan fixes the steps, not their results.
+        let result = null as Awaited<ReturnType<typeof materializePlan>>;
+        let reusedProcessId: string | undefined;
+        let reusedProcessTitle: string | undefined;
+        if (processMemory) {
+          const reuse = await pickReusableProcess(
+            processMemory,
+            userMessage,
+            reuseThreshold,
+          );
+          if (reuse) {
+            result = await materializePlanFromSteps({
+              planId: hookCtx.turnId,
+              scope,
+              userMessage,
+              createdAt,
+              kg,
+              steps: reuse.steps,
+              processTitle: reuse.title,
+            });
+            if (result) {
+              reusedProcessId = reuse.id;
+              reusedProcessTitle = reuse.title;
+            }
+          }
+        }
+
+        // No reusable process → the original gate → LLM-materialise path.
+        if (!result) {
+          if (!(await shouldPlan(userMessage, llm))) return;
+          result = await materializePlan({
+            planId: hookCtx.turnId,
+            scope,
+            userMessage,
+            createdAt,
+            llm,
+            kg,
+          });
+        }
         if (!result) return;
         // Evict any leaked records before adding this turn's.
         pruneTurns(turns, nowMs);
@@ -205,14 +316,17 @@ export async function activate(
           createdAt,
           startedAtMs: nowMs,
           exitConditionByStep,
+          ...(reusedProcessTitle ? { reusedProcessTitle } : {}),
           generation: 0,
         };
         turns.set(hookCtx.turnId, record);
         await startFirstStep(record.plan, kg);
         ctx.log(
-          `[plan-runner] materialised ${result.planExternalId} (${String(
-            result.stepCount,
-          )} steps)`,
+          `[plan-runner] ${
+            reusedProcessId
+              ? `reused process ${reusedProcessId} →`
+              : 'materialised'
+          } ${result.planExternalId} (${String(result.stepCount)} steps)`,
         );
         // #237 — GC prior duplicate plans for this scope. Fire-and-forget: it
         // only hard-deletes OLDER plans (never the survivor or any in-flight
@@ -248,7 +362,7 @@ export async function activate(
             });
         }
         // E9 — stream the freshly-materialised plan as the turn's first event.
-        return await planAnnotation(result.planExternalId);
+        return await planAnnotation(result.planExternalId, reusedProcessTitle);
       },
     }),
   );
@@ -288,7 +402,7 @@ export async function activate(
             // No recovery path — abandon the plan but don't loop.
             record.plan.cursor += 1;
           }
-          return await planAnnotation(record.planExternalId);
+          return await planAnnotation(record.planExternalId, record.reusedProcessTitle);
         }
 
         // Trigger (b) — exit condition unmet → replan the remainder. Opt-in
@@ -324,7 +438,7 @@ export async function activate(
           } else {
             record.plan.cursor += 1;
           }
-          return await planAnnotation(record.planExternalId);
+          return await planAnnotation(record.planExternalId, record.reusedProcessTitle);
         }
 
         await advanceStep(
@@ -335,7 +449,7 @@ export async function activate(
             : undefined,
         );
         // E9 — emit the refreshed plan snapshot so the UI advances the step live.
-        return await planAnnotation(record.planExternalId);
+        return await planAnnotation(record.planExternalId, record.reusedProcessTitle);
       },
     }),
   );
@@ -372,7 +486,7 @@ export async function activate(
         await finishPlan(record.plan, kg);
         // E9 — emit the final plan snapshot (all reached steps done) before the
         // turn's `done` event, then drop the per-turn state.
-        const annotation = await planAnnotation(record.planExternalId);
+        const annotation = await planAnnotation(record.planExternalId, record.reusedProcessTitle);
         turns.delete(hookCtx.turnId);
         return annotation;
       },

--- a/middleware/packages/harness-plugin-plan-runner/src/snapshot.ts
+++ b/middleware/packages/harness-plugin-plan-runner/src/snapshot.ts
@@ -19,17 +19,27 @@ export interface PlanStepSnapshot {
 export interface PlanSnapshot {
   planExternalId: string;
   steps: PlanStepSnapshot[];
+  /** Title of the stored process this plan was reused from (no LLM
+   *  re-planning). Absent for freshly-materialised plans. Surfaced so the chat
+   *  UI can badge the plan as reused. */
+  reusedProcessTitle?: string;
 }
 
 /** Read the plan's steps from the graph and project them into a PlanSnapshot,
- *  ordered by step order ascending. */
+ *  ordered by step order ascending. `opts.reusedProcessTitle` is threaded
+ *  through from the plugin (which knows it at materialisation time) so the
+ *  snapshot carries reuse provenance without an extra plan-node read. */
 export async function buildPlanSnapshot(
   planExternalId: string,
   kg: KnowledgeGraph,
+  opts?: { reusedProcessTitle?: string },
 ): Promise<PlanSnapshot> {
   const steps = await kg.getPlanSteps(planExternalId);
   return {
     planExternalId,
+    ...(opts?.reusedProcessTitle
+      ? { reusedProcessTitle: opts.reusedProcessTitle }
+      : {}),
     steps: steps
       .map((s) => ({
         stepExternalId: s.id,

--- a/middleware/packages/plugin-api/src/knowledgeGraph.ts
+++ b/middleware/packages/plugin-api/src/knowledgeGraph.ts
@@ -75,6 +75,16 @@ export interface KnowledgeGraph {
   /** #133 — read a Plan's steps, ordered by `props.order` ascending. */
   getPlanSteps(planExternalId: string): Promise<GraphNode[]>;
   /**
+   * #133 — batched {@link getPlanSteps}: load the steps for many plans in a
+   * single round-trip. Returns a Map keyed by plan external id; an unknown id
+   * or a step-less plan maps to `[]`. Each list is ordered by `props.order`
+   * ascending, identically to {@link getPlanSteps}. Collapses the per-plan N+1
+   * on the plan-recall (context build) and graph-overlay hot paths.
+   */
+  getPlanStepsForPlans(
+    planExternalIds: string[],
+  ): Promise<Map<string, GraphNode[]>>;
+  /**
    * #133 (E3) — patch a PlanStep's status (and optional resultSummary) in
    * place, leaving its other props intact. No-op when the step id is unknown.
    */
@@ -1538,9 +1548,13 @@ export interface PlanIngest {
   /** Turn external id to link via `PLAN_OF`. Skipped silently if absent. */
   turnExternalId?: string;
   userId?: string;
-  /** Free-form planning strategy label (e.g. the gate's rationale). */
+  /** Free-form planning strategy label (e.g. the gate's rationale, or the
+   *  title of the stored process a reused plan was materialised from). */
   strategy?: string;
-  createdBy?: 'gate' | 'manual';
+  /** Provenance of the plan: `gate` (Haiku materialiser), `manual`, or
+   *  `process` (materialised from a reused {@link ProcessMemoryService}
+   *  record — no LLM re-planning). */
+  createdBy?: 'gate' | 'manual' | 'process';
   createdAt: string;
   /**
    * #237 (plan GC) — a short summary of the originating user request, stored on

--- a/middleware/src/routes/devGraph.ts
+++ b/middleware/src/routes/devGraph.ts
@@ -1,9 +1,17 @@
 import { Router } from 'express';
 import type { Request, Response } from 'express';
-import type { KnowledgeGraph } from '@omadia/plugin-api';
+import type { GraphNode, KnowledgeGraph } from '@omadia/plugin-api';
+
+import { PlanScopeCache } from './planScopeCache.js';
+
+/** Cached `/plans` payload shape: a scope's plans, each with its steps. */
+export type PlanWithSteps = { plan: GraphNode; steps: GraphNode[] };
 
 interface DevGraphDeps {
   graph: KnowledgeGraph;
+  /** Optional injected cache (tests pass a clock-controlled instance). When
+   *  omitted, a default short-TTL cache is created per router. */
+  planCache?: PlanScopeCache<PlanWithSteps[]>;
 }
 
 /**
@@ -14,6 +22,7 @@ interface DevGraphDeps {
  */
 export function createDevGraphRouter(deps: DevGraphDeps): Router {
   const router = Router();
+  const planCache = deps.planCache ?? new PlanScopeCache<PlanWithSteps[]>();
 
   router.get('/stats', async (_req: Request, res: Response) => {
     try {
@@ -198,13 +207,22 @@ export function createDevGraphRouter(deps: DevGraphDeps): Router {
       return;
     }
     try {
+      const cached = planCache.get(scopeParam);
+      if (cached) {
+        res.json({ scope: scopeParam, plans: cached });
+        return;
+      }
       const planNodes = await deps.graph.listPlansForScope(scopeParam);
-      const plans = await Promise.all(
-        planNodes.map(async (plan) => ({
-          plan,
-          steps: await deps.graph.getPlanSteps(plan.id),
-        })),
+      // One batched read for all steps instead of a getPlanSteps per plan
+      // (the old Promise.all fanned out 1+2N Neon round-trips per request).
+      const stepsByPlan = await deps.graph.getPlanStepsForPlans(
+        planNodes.map((p) => p.id),
       );
+      const plans: PlanWithSteps[] = planNodes.map((plan) => ({
+        plan,
+        steps: stepsByPlan.get(plan.id) ?? [],
+      }));
+      planCache.set(scopeParam, plans);
       res.json({ scope: scopeParam, plans });
     } catch (err) {
       res

--- a/middleware/src/routes/planScopeCache.ts
+++ b/middleware/src/routes/planScopeCache.ts
@@ -1,0 +1,59 @@
+/**
+ * #133 — a tiny per-scope TTL cache for the dev graph `/plans` overlay.
+ *
+ * The plan overlay is an inspection view (the live chat UI gets plan progress
+ * from the turn stream, not this REST endpoint), so a short TTL is the right
+ * trade-off: it collapses repeated `/plans?scope=` reads — the WebUI refetches
+ * on every Pläne-toggle and session switch — to one knowledge-graph round-trip
+ * per window, while a few-second TTL keeps a freshly-advanced step visible.
+ *
+ * Pure and clock-injectable (`now`) so the TTL/invalidation behaviour is
+ * unit-testable without real time. `invalidate()` is exposed for callers that
+ * can observe a plan write and want zero staleness.
+ */
+
+export interface PlanScopeCacheOptions {
+  /** Entry lifetime in ms. Default 2000 — short, because the overlay is live. */
+  ttlMs?: number;
+  /** Clock source; injected in tests. Default `Date.now`. */
+  now?: () => number;
+}
+
+export class PlanScopeCache<T> {
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+  private readonly entries = new Map<string, { value: T; expiresAt: number }>();
+
+  constructor(opts: PlanScopeCacheOptions = {}) {
+    this.ttlMs = opts.ttlMs ?? 2000;
+    this.now = opts.now ?? ((): number => Date.now());
+  }
+
+  /** Return the cached value for `scope`, or undefined when absent/expired.
+   *  An expired entry is evicted on read so the map can't grow unboundedly. */
+  get(scope: string): T | undefined {
+    const hit = this.entries.get(scope);
+    if (!hit) return undefined;
+    if (this.now() >= hit.expiresAt) {
+      this.entries.delete(scope);
+      return undefined;
+    }
+    return hit.value;
+  }
+
+  /** Cache `value` for `scope`, expiring `ttlMs` from now. */
+  set(scope: string, value: T): void {
+    this.entries.set(scope, { value, expiresAt: this.now() + this.ttlMs });
+  }
+
+  /** Drop one scope's entry, or the whole cache when `scope` is omitted. */
+  invalidate(scope?: string): void {
+    if (scope === undefined) this.entries.clear();
+    else this.entries.delete(scope);
+  }
+
+  /** Live entry count (after no eviction) — for tests/diagnostics. */
+  get size(): number {
+    return this.entries.size;
+  }
+}

--- a/middleware/test/devGraphPlansCache.test.ts
+++ b/middleware/test/devGraphPlansCache.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, before, after } from 'node:test';
+import { strict as assert } from 'node:assert';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import express from 'express';
+import { InMemoryKnowledgeGraph } from '@omadia/knowledge-graph-inmemory';
+import {
+  createDevGraphRouter,
+  type PlanWithSteps,
+} from '../src/routes/devGraph.js';
+import { PlanScopeCache } from '../src/routes/planScopeCache.js';
+
+// #133 — the dev `/plans` overlay endpoint: batched step fetch + a short-TTL
+// per-scope cache. We count listPlansForScope calls to prove a second request
+// inside the TTL window is served from cache (no knowledge-graph round-trip),
+// and that the entry refetches once the injected clock passes the TTL.
+
+class CountingGraph extends InMemoryKnowledgeGraph {
+  listCalls = 0;
+  override async listPlansForScope(
+    scope: string,
+  ): ReturnType<InMemoryKnowledgeGraph['listPlansForScope']> {
+    this.listCalls += 1;
+    return super.listPlansForScope(scope);
+  }
+}
+
+interface PlansBody {
+  scope: string;
+  plans: Array<{
+    plan: { id: string };
+    steps: Array<{ id: string; props: Record<string, unknown> }>;
+  }>;
+}
+
+describe('/api/dev/graph/plans — batched + cached', () => {
+  let server: Server;
+  let baseUrl: string;
+  const graph = new CountingGraph();
+  let clock = 10_000;
+
+  before(async () => {
+    await graph.ingestPlan({
+      planId: 'p1',
+      scope: 'sess-A',
+      createdAt: '2026-06-01T10:00:00.000Z',
+    });
+    await graph.upsertPlanStep({
+      stepId: 'p1-s0',
+      planId: 'p1',
+      scope: 'sess-A',
+      goal: 'first goal',
+      order: 0,
+      status: 'pending',
+    });
+
+    const planCache = new PlanScopeCache<PlanWithSteps[]>({
+      ttlMs: 1000,
+      now: () => clock,
+    });
+    const app = express();
+    app.use('/api/dev/graph', createDevGraphRouter({ graph, planCache }));
+    server = app.listen(0);
+    const addr = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${String(addr.port)}/api/dev/graph`;
+  });
+
+  after(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('returns plans with their steps (batched read is correct)', async () => {
+    const res = await fetch(`${baseUrl}/plans?scope=sess-A`);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as PlansBody;
+    assert.equal(body.plans.length, 1);
+    assert.equal(body.plans[0]!.steps.length, 1);
+    assert.equal(body.plans[0]!.steps[0]!.props['goal'], 'first goal');
+    assert.equal(graph.listCalls, 1);
+  });
+
+  it('serves a second request within the TTL from cache (no KG hit)', async () => {
+    clock = 10_500; // < 10_000 + 1000
+    const res = await fetch(`${baseUrl}/plans?scope=sess-A`);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as PlansBody;
+    assert.equal(body.plans.length, 1);
+    assert.equal(graph.listCalls, 1, 'cache hit — listPlansForScope not re-called');
+  });
+
+  it('refetches once the TTL has elapsed', async () => {
+    clock = 11_100; // > 10_000 + 1000 → expired
+    const res = await fetch(`${baseUrl}/plans?scope=sess-A`);
+    assert.equal(res.status, 200);
+    assert.equal(graph.listCalls, 2, 'expired — listPlansForScope re-called');
+  });
+});

--- a/middleware/test/planProcessReuse.test.ts
+++ b/middleware/test/planProcessReuse.test.ts
@@ -1,0 +1,126 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { InMemoryKnowledgeGraph } from '@omadia/knowledge-graph-inmemory';
+import { planNodeId } from '@omadia/plugin-api';
+import type {
+  ProcessMemoryService,
+  ProcessQueryHit,
+  ProcessRecord,
+} from '@omadia/plugin-api';
+import {
+  materializePlanFromSteps,
+  pickReusableProcess,
+} from '@omadia/plugin-plan-runner';
+
+// Process reuse: a matching learned process is materialised straight from its
+// stored steps (no LLM), and the picker only reuses on a confident hit.
+
+const NOW = '2026-06-09T12:00:00.000Z';
+
+function record(over: Partial<ProcessRecord> = {}): ProcessRecord {
+  return {
+    id: 'process:sess-A:backend-deploy',
+    scope: 'sess-A',
+    title: 'Backend: Deploy to staging',
+    steps: ['Build the image', 'Push to registry', 'Roll the deployment'],
+    visibility: 'team',
+    version: 1,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...over,
+  };
+}
+
+/** Minimal ProcessMemoryService stub — only `query` is exercised. */
+function stubProcessMemory(
+  hits: readonly ProcessQueryHit[] | (() => Promise<never>),
+): Pick<ProcessMemoryService, 'query'> {
+  return {
+    query: typeof hits === 'function' ? hits : async () => hits,
+  };
+}
+
+describe('materializePlanFromSteps', () => {
+  it('persists a Plan + ordered steps from process steps, no LLM', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const result = await materializePlanFromSteps({
+      planId: 't1',
+      scope: 'sess-A',
+      userMessage: 'deploy the backend',
+      createdAt: NOW,
+      kg,
+      steps: ['Build the image', 'Push to registry', 'Roll the deployment'],
+      processTitle: 'Backend: Deploy to staging',
+    });
+    assert.ok(result);
+    assert.equal(result.stepCount, 3);
+
+    const plan = await kg.getPlan(planNodeId('t1'));
+    assert.equal(plan?.props['createdBy'], 'process');
+    assert.equal(
+      plan?.props['strategy'],
+      'Reused stored process: Backend: Deploy to staging',
+    );
+
+    const steps = await kg.getPlanSteps(planNodeId('t1'));
+    assert.deepEqual(
+      steps.map((s) => s.props['goal']),
+      ['Build the image', 'Push to registry', 'Roll the deployment'],
+    );
+    assert.ok(steps.every((s) => s.props['status'] === 'pending'));
+  });
+
+  it('skips blank steps and returns null when nothing remains', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const trimmed = await materializePlanFromSteps({
+      planId: 't2',
+      scope: 'sess-A',
+      userMessage: 'x',
+      createdAt: NOW,
+      kg,
+      steps: ['  ', 'Real step', ''],
+      processTitle: 'X: Y',
+    });
+    assert.equal(trimmed?.stepCount, 1);
+
+    const empty = await materializePlanFromSteps({
+      planId: 't3',
+      scope: 'sess-A',
+      userMessage: 'x',
+      createdAt: NOW,
+      kg,
+      steps: ['', '   '],
+      processTitle: 'X: Y',
+    });
+    assert.equal(empty, null);
+  });
+});
+
+describe('pickReusableProcess', () => {
+  it('reuses the top hit when it clears the threshold', async () => {
+    const svc = stubProcessMemory([{ record: record(), score: 0.82 }]);
+    const reuse = await pickReusableProcess(svc, 'deploy backend', 0.6);
+    assert.equal(reuse?.id, 'process:sess-A:backend-deploy');
+    assert.equal(reuse?.title, 'Backend: Deploy to staging');
+    assert.equal(reuse?.steps.length, 3);
+  });
+
+  it('does not reuse a hit below the threshold', async () => {
+    const svc = stubProcessMemory([{ record: record(), score: 0.4 }]);
+    assert.equal(await pickReusableProcess(svc, 'something else', 0.6), null);
+  });
+
+  it('does not reuse a step-less process', async () => {
+    const svc = stubProcessMemory([{ record: record({ steps: [] }), score: 0.95 }]);
+    assert.equal(await pickReusableProcess(svc, 'deploy', 0.6), null);
+  });
+
+  it('returns null on no hits and on a query error (fall through to LLM)', async () => {
+    assert.equal(await pickReusableProcess(stubProcessMemory([]), 'q', 0.6), null);
+    const throwing = stubProcessMemory(async () => {
+      throw new Error('process store down');
+    });
+    assert.equal(await pickReusableProcess(throwing, 'q', 0.6), null);
+  });
+});

--- a/middleware/test/planScopeCache.test.ts
+++ b/middleware/test/planScopeCache.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { PlanScopeCache } from '../src/routes/planScopeCache.js';
+
+// #133 — TTL cache backing the dev graph `/plans` overlay. Clock is injected
+// so expiry is deterministic (no real timers).
+
+describe('PlanScopeCache', () => {
+  it('returns a cached value within the TTL window', () => {
+    let now = 1000;
+    const cache = new PlanScopeCache<number[]>({ ttlMs: 500, now: () => now });
+    cache.set('sess-A', [1, 2, 3]);
+    now = 1400; // < 1000 + 500
+    assert.deepEqual(cache.get('sess-A'), [1, 2, 3]);
+  });
+
+  it('expires (and evicts) an entry once the TTL elapses', () => {
+    let now = 1000;
+    const cache = new PlanScopeCache<number[]>({ ttlMs: 500, now: () => now });
+    cache.set('sess-A', [1]);
+    assert.equal(cache.size, 1);
+    now = 1500; // == expiresAt → expired (>= boundary)
+    assert.equal(cache.get('sess-A'), undefined);
+    assert.equal(cache.size, 0, 'expired entry is evicted on read');
+  });
+
+  it('isolates scopes and misses unknown ones', () => {
+    const cache = new PlanScopeCache<string>({ ttlMs: 1000, now: () => 0 });
+    cache.set('a', 'A');
+    cache.set('b', 'B');
+    assert.equal(cache.get('a'), 'A');
+    assert.equal(cache.get('b'), 'B');
+    assert.equal(cache.get('c'), undefined);
+  });
+
+  it('invalidate(scope) drops one entry; invalidate() clears all', () => {
+    const cache = new PlanScopeCache<string>({ ttlMs: 1000, now: () => 0 });
+    cache.set('a', 'A');
+    cache.set('b', 'B');
+    cache.invalidate('a');
+    assert.equal(cache.get('a'), undefined);
+    assert.equal(cache.get('b'), 'B');
+    cache.invalidate();
+    assert.equal(cache.size, 0);
+    assert.equal(cache.get('b'), undefined);
+  });
+});

--- a/middleware/test/planStepsBatch.test.ts
+++ b/middleware/test/planStepsBatch.test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { InMemoryKnowledgeGraph } from '@omadia/knowledge-graph-inmemory';
+import { planNodeId, planStepNodeId } from '@omadia/plugin-api';
+
+// #133 — getPlanStepsForPlans: batched variant of getPlanSteps that collapses
+// the per-plan N+1 on the plan-recall and graph-overlay hot paths.
+
+async function seedPlan(
+  kg: InMemoryKnowledgeGraph,
+  planId: string,
+  scope: string,
+  goals: string[],
+): Promise<void> {
+  await kg.ingestPlan({ planId, scope, createdAt: '2026-06-01T10:00:00.000Z' });
+  for (let i = 0; i < goals.length; i++) {
+    await kg.upsertPlanStep({
+      stepId: `${planId}-s${String(i)}`,
+      planId,
+      scope,
+      goal: goals[i]!,
+      order: i,
+      status: 'pending',
+    });
+  }
+}
+
+describe('#133 — getPlanStepsForPlans', () => {
+  it('groups steps by plan, ordered, with [] for step-less/unknown ids', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    await seedPlan(kg, 'p1', 'sess-A', ['a0', 'a1']);
+    await seedPlan(kg, 'p2', 'sess-A', ['b0']);
+    await kg.ingestPlan({
+      planId: 'p3-empty',
+      scope: 'sess-A',
+      createdAt: '2026-06-01T10:00:00.000Z',
+    });
+
+    const map = await kg.getPlanStepsForPlans([
+      planNodeId('p1'),
+      planNodeId('p2'),
+      planNodeId('p3-empty'),
+      planNodeId('p-unknown'),
+    ]);
+
+    // Every requested id is present, even with no steps.
+    assert.equal(map.size, 4);
+    assert.deepEqual(
+      (map.get(planNodeId('p1')) ?? []).map((s) => s.id),
+      [planStepNodeId('p1-s0'), planStepNodeId('p1-s1')],
+    );
+    assert.deepEqual(
+      (map.get(planNodeId('p2')) ?? []).map((s) => s.props['goal']),
+      ['b0'],
+    );
+    assert.deepEqual(map.get(planNodeId('p3-empty')), []);
+    assert.deepEqual(map.get(planNodeId('p-unknown')), []);
+  });
+
+  it('matches getPlanSteps for each plan (parity with the single-plan read)', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    await seedPlan(kg, 'p1', 'sess-A', ['x', 'y', 'z']);
+
+    const single = await kg.getPlanSteps(planNodeId('p1'));
+    const batched = await kg.getPlanStepsForPlans([planNodeId('p1')]);
+    assert.deepEqual(
+      (batched.get(planNodeId('p1')) ?? []).map((s) => s.id),
+      single.map((s) => s.id),
+    );
+  });
+
+  it('returns an empty map for an empty id list (no work)', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const map = await kg.getPlanStepsForPlans([]);
+    assert.equal(map.size, 0);
+  });
+});

--- a/web-ui/app/_components/chat/PlanProgressCard.tsx
+++ b/web-ui/app/_components/chat/PlanProgressCard.tsx
@@ -66,6 +66,15 @@ export function PlanProgressCard({
             aria-hidden
           />
         )}
+        {plan.reusedProcessTitle && (
+          <span
+            className="ml-auto inline-flex items-center gap-1 rounded-full bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
+            title={t('reusedFrom', { title: plan.reusedProcessTitle })}
+          >
+            <span aria-hidden>♻</span>
+            {t('reusedBadge')}
+          </span>
+        )}
       </summary>
       <ol className="flex flex-col gap-1 px-2.5 pb-2 pt-0.5">
         {steps.map((s, i) => {

--- a/web-ui/app/_lib/chatSessions.ts
+++ b/web-ui/app/_lib/chatSessions.ts
@@ -220,6 +220,9 @@ export interface PlanStepSnapshot {
 export interface PlanSnapshot {
   planExternalId: string;
   steps: PlanStepSnapshot[];
+  /** Title of the stored process this plan was reused from (no LLM
+   *  re-planning). Absent for freshly-materialised plans. */
+  reusedProcessTitle?: string;
 }
 
 /** Cross-session recall probe — payload of the `kg_recall` turn_annotation.

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -97,7 +97,9 @@
     "statusInProgress": "läuft",
     "statusDone": "fertig",
     "statusFailed": "fehlgeschlagen",
-    "statusSkipped": "übersprungen"
+    "statusSkipped": "übersprungen",
+    "reusedBadge": "wiederverwendet",
+    "reusedFrom": "Wiederverwendet aus gespeichertem Prozess: {title}"
   },
   "recalledContext": {
     "heading": "Aus früheren Sessions",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -97,7 +97,9 @@
     "statusInProgress": "in progress",
     "statusDone": "done",
     "statusFailed": "failed",
-    "statusSkipped": "skipped"
+    "statusSkipped": "skipped",
+    "reusedBadge": "reused",
+    "reusedFrom": "Reused from stored process: {title}"
   },
   "recalledContext": {
     "heading": "From earlier sessions",


### PR DESCRIPTION
## Why

Found/materialised plans loaded slowly from the WebUI, and plan **execution**
felt sluggish — "as if everything is re-thought every turn." Two distinct root
causes.

## What

### 1. N+1 Neon round-trips on every plan read
- New `KnowledgeGraph.getPlanStepsForPlans()` — one query for all plans — plus
  `getPlanSteps` collapsed from 2 queries to 1 (join instead of re-resolving the
  plan node the caller already holds).
- Wired into `contextRetriever.loadPlanHits` (the turn context-build hot path,
  previously up to ~24 serial round-trips **before every turn**) and the dev
  `/plans` graph-overlay route.
- Short-TTL, clock-injectable `PlanScopeCache` on `/plans` (the overlay is a
  live inspection view → short TTL; the chat UI gets plan progress from the turn
  stream, not this endpoint).

### 2. Per-turn LLM re-planning → process reuse (default ON)
- `onBeforeTurn` now queries **ProcessMemory** first. A hit ≥
  `processReuseThreshold` (default `0.6`) materialises the plan straight from the
  stored process steps (`materializePlanFromSteps`) with **no gate and no Haiku
  call**. Data is still fetched fresh by the tool loop — the plan fixes the
  steps, not their results.
- Miss / no `processMemory@1` provider (e.g. in-memory KG) → falls through to the
  existing gate→materialize path. No regression.
- Disable via `reuseProcesses=off`; tune via `processReuseThreshold`.

### 3. Reuse visible in the WebUI
- Reuse provenance (`createdBy='process'`, `strategy=<title>`) flows to the graph
  overlay; the chat **PlanProgressCard** shows a ♻ "reused" badge via
  `PlanSnapshot.reusedProcessTitle` (threaded through `buildPlanSnapshot` /
  `planAnnotation` — no extra DB read). i18n added in `en` + `de`.

## Tests
- 4 new suites: `planProcessReuse`, `planStepsBatch`, `planScopeCache`,
  `devGraphPlansCache` (cache hit/expiry with a KG call-counter).
- 81 plan/devGraph/context tests green; no regression.
- middleware build/typecheck/lint clean; web-ui `tsc`/eslint clean; `i18n:check`
  OK (en/de parity).

## Follow-ups (deliberately out of scope)
- The no-process path still fires the gate Haiku per turn (could merge
  gate+materialize into one call).
- Process reuse adds one embedding (`query`) per turn even on a miss — acceptable.