### PR TITLE
fix(memory): stop logging expected memory-tool errors as crashes

### DIFF
--- a/middleware/packages/harness-memory/src/memoryTool.ts
+++ b/middleware/packages/harness-memory/src/memoryTool.ts
@@ -246,6 +246,24 @@ function findLineNumbers(haystack: string, needle: string): number[] {
   return hits;
 }
 
+/**
+ * The four domain error classes are part of the memory tool's normal return
+ * contract: they are caught in `handle`, formatted, and handed back to the model
+ * as a recoverable tool result (e.g. "create on an existing path" → the model
+ * switches to `str_replace`). They are control-flow signals, NOT failures, so
+ * they must never be logged as `console.error` with a stack trace — doing so
+ * makes routine model behaviour look like an unhandled crash in production logs
+ * and trips false-positive monitoring alerts.
+ */
+function isExpectedMemoryError(err: unknown): boolean {
+  return (
+    err instanceof MemoryAlreadyExistsError ||
+    err instanceof MemoryPathNotFoundError ||
+    err instanceof MemoryIsDirectoryError ||
+    err instanceof MemoryInvalidPathError
+  );
+}
+
 function logMemoryCall(cmd: MemoryCommand | undefined, result: string, err: unknown): void {
   const cmdLabel = cmd
     ? `${cmd.command} ${'path' in cmd ? cmd.path : `${cmd.old_path} → ${cmd.new_path}`}`
@@ -253,7 +271,10 @@ function logMemoryCall(cmd: MemoryCommand | undefined, result: string, err: unkn
   const outcome = err ? `ERROR (${err instanceof Error ? err.name : typeof err})` : 'ok';
   const snippet = result.replace(/\n/g, ' ⏎ ').slice(0, 240);
   console.log(`[memory] ${cmdLabel} → ${outcome}: ${snippet}`);
-  if (err) {
+  // Only surface a full stack trace for UNEXPECTED errors (DB outage, bugs).
+  // Expected domain errors are already conveyed by the one-line log above and
+  // are returned to the model as a recoverable result.
+  if (err && !isExpectedMemoryError(err)) {
     console.error('[memory] full error:', err);
   }
 }


### PR DESCRIPTION
## Problem

A test instance reported what looked like a crash:

```
[memory] full error: MemoryAlreadyExistsError: Path already exists: /memories/_rules/dynamics-courses.md
    at PostgresMemoryStore.createFile (...)
    at MemoryToolHandler.create (...)
    at MemoryToolHandler.handle (...)
    at Orchestrator.dispatchTool (...)
```

It is **not** a crash. `MemoryAlreadyExistsError` (and the other three `Memory*` domain errors) is part of the memory tool's normal return contract: it is caught in `MemoryToolHandler.handle`, formatted, and handed back to the model as a recoverable tool result (`Error: File … already exists`) — the documented Anthropic memory-tool recovery path. The model then switches to `str_replace`/`view`. The turn continues normally.

What actually happened: in a UI/canvas turn the model called `create` on `/memories/_rules/dynamics-courses.md`, which already existed (seeded or written by an earlier turn). The `MemorySeeder` is well-behaved (`fileExists` check in `missing` mode, upsert `writeFile` in `overwrite` mode), so the call came from the model, not the seeder.

The only real defect: `logMemoryCall` dumped a full stack trace via `console.error` for this expected, handled, model-recoverable condition — making routine behaviour look like an unhandled crash in production logs and tripping false-positive monitoring alerts.

## Fix

`middleware/packages/harness-memory/src/memoryTool.ts` only. New `isExpectedMemoryError` helper gates the `console.error` stack dump: the four `Memory*Error` classes keep the existing concise one-line log; only genuinely unexpected failures (DB outage, bugs) surface a stack trace.

**Store semantics unchanged** — `createFile` still throws `MemoryAlreadyExistsError` on an existing path, per the `MemoryStore` conformance contract.

## Verification

- `eslint --fix`: clean
- `typecheck -w @omadia/memory`: clean
- MemoryStore conformance (in-memory): 23/23 pass