### PR TITLE
feat(builder): one-click agent export from dashboard cards (#270)

### DIFF
--- a/web-ui/app/store/builder/_components/DraftRow.tsx
+++ b/web-ui/app/store/builder/_components/DraftRow.tsx
@@ -17,6 +17,7 @@ import type {
   DraftSummary,
 } from '../../../_lib/builderTypes';
 import { cn } from '../../../_lib/cn';
+import { ExportDraftButton } from './ExportDraftButton';
 
 interface DraftRowProps {
   draft: DraftSummary;
@@ -206,6 +207,9 @@ export function DraftRow({ draft, deleted = false }: DraftRowProps): React.React
           </button>
         ) : (
           <>
+            {draft.status === 'published' ? (
+              <ExportDraftButton draftId={draft.id} />
+            ) : null}
             <Link
               href={`/store/builder/${encodeURIComponent(draft.id)}`}
               className="inline-flex items-center gap-1.5 rounded-md bg-[color:var(--accent)]/10 px-2.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--accent)] transition-colors hover:bg-[color:var(--accent)] hover:text-white"

--- a/web-ui/app/store/builder/_components/ExportDraftButton.tsx
+++ b/web-ui/app/store/builder/_components/ExportDraftButton.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { ChevronDown, Download, Loader2 } from 'lucide-react';
+
+import { ApiError, captureSnapshot, snapshotDownloadUrl } from '../../../_lib/api';
+import { cn } from '../../../_lib/cn';
+
+type ExportFormat = 'plugin' | 'bundle';
+
+export interface ExportDraftButtonProps {
+  /** Draft id — equal to the backing `profile_id` (draft_id == profile_id). */
+  draftId: string;
+  /** Optional override for tests — defaults to the real api fn. */
+  capture?: typeof captureSnapshot;
+  /**
+   * Optional override for tests — performs the actual browser navigation
+   * that streams the ZIP. Defaults to `window.location.assign`.
+   */
+  onDownload?: (url: string) => void;
+}
+
+/**
+ * One-click export of a published builder draft from the dashboard card
+ * (#270). Opening the menu and picking a format is at most two clicks and
+ * never opens the builder editor.
+ *
+ * The download endpoint is keyed on a snapshot, so we `captureSnapshot`
+ * first. That call is content-addressed in the middleware
+ * (`createSnapshot` dedupes by `bundle_hash`): when the draft is unchanged
+ * it returns the existing snapshot with `was_existing: true` and creates
+ * **no** phantom snapshot row — satisfying the "no phantom snapshot"
+ * acceptance criterion. When the draft has diverged since the last
+ * snapshot, a fresh one capturing the current state is created silently.
+ */
+export function ExportDraftButton({
+  draftId,
+  capture,
+  onDownload,
+}: ExportDraftButtonProps): React.ReactElement {
+  const t = useTranslations('builder.drafts.row.export');
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onExport = useCallback(
+    async (format: ExportFormat): Promise<void> => {
+      setOpen(false);
+      setError(null);
+      setBusy(true);
+      try {
+        const captureFn = capture ?? captureSnapshot;
+        const snapshot = await captureFn(draftId);
+        const base = snapshotDownloadUrl(draftId, snapshot.snapshot_id);
+        const url = format === 'bundle' ? `${base}?format=bundle` : base;
+        const navigate =
+          onDownload ?? ((target: string): void => window.location.assign(target));
+        navigate(url);
+      } catch (err) {
+        setError(humanizeError(err));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [capture, draftId, onDownload],
+  );
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        disabled={busy}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={t('label')}
+        className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--fg-muted)] transition-colors hover:bg-[color:var(--bg-soft)] hover:text-[color:var(--fg-strong)] disabled:opacity-50"
+      >
+        {busy ? (
+          <Loader2 className="size-3.5 animate-spin" aria-hidden />
+        ) : (
+          <Download className="size-3.5" aria-hidden />
+        )}
+        {busy ? t('preparing') : t('label')}
+        {!busy && <ChevronDown className="size-3" aria-hidden />}
+      </button>
+
+      {open && !busy ? (
+        <>
+          {/* Click-outside backdrop. */}
+          <div
+            className="fixed inset-0 z-10"
+            aria-hidden
+            onClick={() => setOpen(false)}
+          />
+          <div
+            role="menu"
+            aria-label={t('menuLabel')}
+            className="absolute right-0 z-20 mt-1 w-56 overflow-hidden rounded-lg border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] py-1 shadow-[0_6px_20px_rgba(0,75,115,0.12)]"
+          >
+            <ExportMenuItem
+              label={t('plugin')}
+              hint={t('pluginHint')}
+              onClick={() => void onExport('plugin')}
+            />
+            <ExportMenuItem
+              label={t('bundle')}
+              hint={t('bundleHint')}
+              onClick={() => void onExport('bundle')}
+            />
+          </div>
+        </>
+      ) : null}
+
+      {error ? (
+        <p className="absolute right-0 mt-1 whitespace-nowrap text-[11px] text-[color:var(--danger)]">
+          {t('failed', { message: error })}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function ExportMenuItem({
+  label,
+  hint,
+  onClick,
+}: {
+  label: string;
+  hint: string;
+  onClick: () => void;
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onClick}
+      className={cn(
+        'flex w-full flex-col items-start gap-0.5 px-3 py-2 text-left',
+        'hover:bg-[color:var(--bg-soft)]',
+      )}
+    >
+      <span className="text-[12px] font-semibold text-[color:var(--fg-strong)]">
+        {label}
+      </span>
+      <span className="text-[10px] text-[color:var(--fg-muted)]">{hint}</span>
+    </button>
+  );
+}
+
+function humanizeError(err: unknown): string {
+  if (err instanceof ApiError) {
+    try {
+      const body = JSON.parse(err.body) as { message?: string };
+      return body.message ?? err.message;
+    } catch {
+      return err.message;
+    }
+  }
+  return err instanceof Error ? err.message : String(err);
+}

--- a/web-ui/app/store/builder/_components/__tests__/ExportDraftButton.test.tsx
+++ b/web-ui/app/store/builder/_components/__tests__/ExportDraftButton.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { renderWithIntl } from '../../../../_lib/test-utils';
+import { ExportDraftButton } from '../ExportDraftButton';
+
+function snapshot(id = 'snap-1') {
+  return {
+    snapshot_id: id,
+    bundle_hash: 'deadbeef',
+    bundle_size_bytes: 1234,
+    created_at: '2026-06-10T00:00:00.000Z',
+    was_existing: true,
+  };
+}
+
+describe('<ExportDraftButton />', () => {
+  it('opens a two-option menu (Plugin + Bundle) on click', () => {
+    renderWithIntl(<ExportDraftButton draftId="my-agent" capture={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /Export/i }));
+    expect(screen.getByRole('menuitem', { name: /Plugin ZIP/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Bundle ZIP/i })).toBeInTheDocument();
+  });
+
+  it('captures a snapshot and downloads the plugin ZIP (no ?format)', async () => {
+    const capture = vi.fn().mockResolvedValue(snapshot('snap-xyz'));
+    const onDownload = vi.fn();
+    renderWithIntl(
+      <ExportDraftButton draftId="my-agent" capture={capture} onDownload={onDownload} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Export/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Plugin ZIP/i }));
+
+    await waitFor(() => expect(capture).toHaveBeenCalledWith('my-agent'));
+    expect(onDownload).toHaveBeenCalledWith(
+      '/bot-api/v1/profiles/my-agent/snapshots/snap-xyz/download',
+    );
+  });
+
+  it('appends ?format=bundle for the bundle export', async () => {
+    const capture = vi.fn().mockResolvedValue(snapshot('snap-b'));
+    const onDownload = vi.fn();
+    renderWithIntl(
+      <ExportDraftButton draftId="my-agent" capture={capture} onDownload={onDownload} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Export/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Bundle ZIP/i }));
+
+    await waitFor(() =>
+      expect(onDownload).toHaveBeenCalledWith(
+        '/bot-api/v1/profiles/my-agent/snapshots/snap-b/download?format=bundle',
+      ),
+    );
+  });
+
+  it('surfaces a failure message when capture rejects', async () => {
+    const capture = vi.fn().mockRejectedValue(new Error('boom'));
+    const onDownload = vi.fn();
+    renderWithIntl(
+      <ExportDraftButton draftId="my-agent" capture={capture} onDownload={onDownload} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Export/i }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Plugin ZIP/i }));
+
+    expect(await screen.findByText(/Export failed: boom/i)).toBeInTheDocument();
+    expect(onDownload).not.toHaveBeenCalled();
+  });
+});

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1408,6 +1408,16 @@
         "delete": "Löschen",
         "workspace": "Workspace",
         "restore": "Wiederherstellen",
+        "export": {
+          "label": "Export",
+          "menuLabel": "Exportformat wählen",
+          "plugin": "Plugin-ZIP",
+          "pluginHint": "Direkt installierbar über /install/packages/upload",
+          "bundle": "Bundle-ZIP",
+          "bundleHint": "Profil-Bundle für instanzübergreifende Migration",
+          "preparing": "Wird vorbereitet…",
+          "failed": "Export fehlgeschlagen: {message}"
+        },
         "confirmDelete": "Draft \"{name}\" löschen?",
         "lastUpdated": "Zuletzt {relative}",
         "relative": {

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1408,6 +1408,16 @@
         "delete": "Delete",
         "workspace": "Workspace",
         "restore": "Restore",
+        "export": {
+          "label": "Export",
+          "menuLabel": "Choose export format",
+          "plugin": "Plugin ZIP",
+          "pluginHint": "Directly installable via /install/packages/upload",
+          "bundle": "Bundle ZIP",
+          "bundleHint": "Profile bundle for cross-instance migration",
+          "preparing": "Preparing…",
+          "failed": "Export failed: {message}"
+        },
         "confirmDelete": "Delete draft \"{name}\"?",
         "lastUpdated": "Last {relative}",
         "relative": {


### PR DESCRIPTION
## Summary

Implements **Option A** of #270 — one-click agent export from the builder dashboard. A published draft can now be downloaded (Plugin ZIP or Bundle ZIP) in at most two clicks, without opening the builder editor and drilling into the Versions tab.

## How it works

The download endpoint (`GET /:id/snapshots/:sid/download[?format=bundle]`) is snapshot-keyed, so the new action `captureSnapshot`s first. `createSnapshot` is **content-addressed** in the middleware (dedup by `bundle_hash`): an unchanged draft returns the existing snapshot with `was_existing=true` and creates **no phantom snapshot row**; a draft that diverged since its last snapshot silently captures the current state. This satisfies the "no phantom snapshot" acceptance criterion without any backend change.

## Changes

- **`ExportDraftButton.tsx`** (new) — `'use client'` dropdown with two options: Plugin ZIP (primary) and Bundle ZIP (secondary). Busy/error states, click-outside backdrop, ARIA menu roles. Test seams (`capture`, `onDownload`) injected.
- **`DraftRow.tsx`** — renders Export only for `published`, non-deleted drafts, next to Workspace.
- **i18n** — `builder.drafts.row.export.*` keys in `en.json` + `de.json`.
- **Tests** — vitest coverage for menu open, Plugin download URL, `?format=bundle` URL, and the capture-failure path.

## Acceptance criteria

- [x] Published draft downloadable (Plugin ZIP) in ≤2 clicks without the editor
- [x] No phantom snapshot created solely for a download (content-addressed dedup)
- [x] Both formats accessible — Plugin primary, Bundle secondary
- [x] Versions-tab download untouched (separate component, no regression)

## Out of scope (per issue)

Option B (store detail page), catalog-only agents without a backing draft, bulk export.

## Verification

`lint:fix` (0 errors), `typecheck` clean, `i18n:check` OK (1174 keys), 4/4 new vitest pass.

Closes #270