### PR TITLE
fix(builder): resolve Anthropic client per turn so vault-seeded keys reach the Builder

### DIFF
--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -314,6 +314,16 @@ async function main(): Promise<void> {
   // stays under 'llm' for plugins that go through the budget/model gate.
   serviceRegistry.provide('anthropicClient', client);
 
+  // Customer bug (builder.ask_failed / "Could not resolve authentication
+  // method"): on installs where the key arrives via the Setup Wizard (vault)
+  // and not via ENV, the boot-time `client` above is unauthenticated forever —
+  // `refreshSharedAnthropicClientFromVault` only swaps the REGISTRY providers,
+  // never this const. Host-side consumers (BuilderAgent, PreviewChatService)
+  // therefore take this accessor and re-resolve the current client per turn
+  // instead of capturing the boot instance.
+  const currentAnthropicClient = (): Anthropic =>
+    serviceRegistry.get<Anthropic>('anthropicClient') ?? client;
+
   // OB-29-3 — wrap the Anthropic client as an `llm` ServiceRegistry
   // provider so plugins that declare `permissions.llm.models_allowed`
   // can reach it via `ctx.llm.complete()`. The accessor wrapper applies
@@ -2494,7 +2504,7 @@ async function main(): Promise<void> {
   );
 
   const previewChatService = new PreviewChatService({
-    anthropic: client,
+    anthropic: currentAnthropicClient,
     draftStore,
     logger: () => {},
   });
@@ -2712,7 +2722,7 @@ async function main(): Promise<void> {
     `${builderPlatformPkg.version ?? '0.0.0'} (process booted ${new Date().toISOString()})`;
 
   const builderAgent = new BuilderAgent({
-    anthropic: client,
+    anthropic: currentAnthropicClient,
     draftStore,
     bus: builderSpecBus,
     rebuildScheduler: {

--- a/middleware/src/plugins/builder/builderAgent.ts
+++ b/middleware/src/plugins/builder/builderAgent.ts
@@ -204,7 +204,12 @@ export type BuilderReferenceCatalog = Readonly<
 >;
 
 export interface BuilderAgentDeps {
-  anthropic: Anthropic;
+  /** Accessor (not a captured instance): the shared Anthropic client is
+   *  hot-swapped when the API key arrives via the Setup Wizard / admin
+   *  secrets (OB-61), so it must be re-resolved per turn. A captured
+   *  boot-time client stays unauthenticated forever on vault-only installs
+   *  and every ask fails with builder.ask_failed. */
+  anthropic: () => Anthropic;
   draftStore: DraftStore;
   bus: SpecEventBus;
   rebuildScheduler: RebuildScheduler;
@@ -332,7 +337,7 @@ export interface RunBuilderTurnOptions {
 }
 
 export class BuilderAgent {
-  private readonly anthropic: Anthropic;
+  private readonly anthropic: () => Anthropic;
   private readonly draftStore: DraftStore;
   private readonly bus: SpecEventBus;
   private readonly rebuildScheduler: RebuildScheduler;
@@ -510,7 +515,7 @@ export class BuilderAgent {
 
     const subAgent = this.buildSubAgent({
       name: `builder-${opts.draftId}`,
-      client: this.anthropic,
+      client: this.anthropic(),
       model: opts.modelChoice,
       maxTokens: this.maxTokens,
       maxIterations: this.maxIterations,

--- a/middleware/src/plugins/builder/previewChatService.ts
+++ b/middleware/src/plugins/builder/previewChatService.ts
@@ -77,7 +77,10 @@ export interface SubAgentBuildOptions {
 }
 
 export interface PreviewChatServiceDeps {
-  anthropic: Anthropic;
+  /** Accessor (not a captured instance) — same rationale as
+   *  BuilderAgentDeps.anthropic: the shared client is hot-swapped on
+   *  Setup-Wizard key entry (OB-61), so resolve it per turn. */
+  anthropic: () => Anthropic;
   draftStore: DraftStore;
   /**
    * Custom system-prompt-loader. Default: read `<previewDir>/skills/*.md`,
@@ -121,7 +124,7 @@ export interface DirectToolResult {
 }
 
 export class PreviewChatService {
-  private readonly anthropic: Anthropic;
+  private readonly anthropic: () => Anthropic;
   private readonly draftStore: DraftStore;
   private readonly systemPromptFor: NonNullable<
     PreviewChatServiceDeps['systemPromptFor']
@@ -175,7 +178,7 @@ export class PreviewChatService {
 
     const subAgent = this.buildSubAgent({
       name: `preview-${opts.handle.agentId}`,
-      client: this.anthropic,
+      client: this.anthropic(),
       model: opts.modelChoice,
       maxTokens: this.maxTokens,
       maxIterations: this.maxIterations,

--- a/middleware/test/builder/builderAgent.test.ts
+++ b/middleware/test/builder/builderAgent.test.ts
@@ -93,6 +93,10 @@ interface Harness {
     script?: FakeAskScript;
     tools?: BuilderTool<unknown, unknown>[];
     slotTypechecker?: SlotTypecheckService;
+    anthropic?: () => Anthropic;
+    buildSubAgent?: (
+      opts: BuilderSubAgentBuildOptions,
+    ) => { ask: (q: string, observer?: AskObserver) => Promise<string> };
   }) => BuilderAgent;
   dispose: () => Promise<void>;
 }
@@ -126,7 +130,7 @@ async function createHarness(): Promise<Harness> {
     tmpRoot,
     agentFor(overrides) {
       return new BuilderAgent({
-        anthropic: fakeAnthropic,
+        anthropic: overrides?.anthropic ?? (() => fakeAnthropic),
         draftStore,
         bus,
         rebuildScheduler: {
@@ -139,9 +143,9 @@ async function createHarness(): Promise<Harness> {
         slotTypechecker: overrides?.slotTypechecker ?? noopSlotTypechecker,
         referenceCatalog,
         systemPromptSeed: async () => 'TEST-SEED',
-        buildSubAgent: makeFakeBuildSubAgent(
-          overrides?.script ?? { finalText: 'ok' },
-        ),
+        buildSubAgent:
+          overrides?.buildSubAgent ??
+          makeFakeBuildSubAgent(overrides?.script ?? { finalText: 'ok' }),
         tools: (overrides?.tools as ReadonlyArray<BuilderTool<unknown, unknown>>) ?? [
           patchSpecTool as unknown as BuilderTool<unknown, unknown>,
           fillSlotTool as unknown as BuilderTool<unknown, unknown>,
@@ -209,6 +213,49 @@ describe('BuilderAgent.runTurn', () => {
       assert.equal(assistantEv.role, 'assistant');
       assert.equal(assistantEv.text, 'Got it.');
     }
+  });
+
+  // Regression: customer-reported builder.ask_failed ("Could not resolve
+  // authentication method"). On vault-only installs the shared Anthropic
+  // client is hot-swapped AFTER boot (Setup Wizard key entry, OB-61); the
+  // BuilderAgent used to capture the unauthenticated boot client at
+  // construction and never see the swap. The accessor must be re-resolved
+  // on every turn.
+  it('resolves the anthropic client per turn, picking up a post-construction hot-swap', async () => {
+    const bootClient = { kind: 'boot' } as unknown as Anthropic;
+    const vaultClient = { kind: 'vault' } as unknown as Anthropic;
+    let current = bootClient;
+    const seenClients: Anthropic[] = [];
+    const inner = makeFakeBuildSubAgent({ finalText: 'ok' });
+    const agent = harness.agentFor({
+      anthropic: () => current,
+      buildSubAgent: (opts) => {
+        seenClients.push(opts.client);
+        return inner(opts);
+      },
+    });
+
+    await collect(
+      agent.runTurn({
+        draftId: harness.draftId,
+        userEmail: harness.userEmail,
+        userMessage: 'first turn',
+        modelChoice: 'claude-haiku-4-5-20251001',
+      }),
+    );
+    current = vaultClient; // Setup-Wizard key entry swaps the shared client
+    await collect(
+      agent.runTurn({
+        draftId: harness.draftId,
+        userEmail: harness.userEmail,
+        userMessage: 'second turn',
+        modelChoice: 'claude-haiku-4-5-20251001',
+      }),
+    );
+
+    assert.equal(seenClients.length, 2);
+    assert.equal(seenClients[0], bootClient);
+    assert.equal(seenClients[1], vaultClient);
   });
 
   it('reuses an explicit turnId in turn_started + turn_done when caller passes opts.turnId', async () => {
@@ -284,7 +331,7 @@ describe('BuilderAgent.runTurn', () => {
     });
 
     const agent = new BuilderAgent({
-      anthropic: {} as Anthropic,
+      anthropic: () => ({}) as Anthropic,
       draftStore: harness.draftStore,
       bus: harness.bus,
       rebuildScheduler: { schedule: () => {} },
@@ -321,7 +368,7 @@ describe('BuilderAgent.runTurn', () => {
   it('passes the bare user message through when the transcript is empty', async () => {
     let captured: string | null = null;
     const agent = new BuilderAgent({
-      anthropic: {} as Anthropic,
+      anthropic: () => ({}) as Anthropic,
       draftStore: harness.draftStore,
       bus: harness.bus,
       rebuildScheduler: { schedule: () => {} },
@@ -700,7 +747,7 @@ describe('BuilderAgent — B.8 manifest-linter E2E', () => {
 
     const knownIds = ['de.byte5.integration.openweather'];
     const agent = new BuilderAgent({
-      anthropic: {} as Anthropic,
+      anthropic: () => ({}) as Anthropic,
       draftStore: harness.draftStore,
       bus: harness.bus,
       rebuildScheduler: { schedule: () => {} },
@@ -778,7 +825,7 @@ describe('BuilderAgent — B.8 manifest-linter E2E', () => {
     });
 
     const agent = new BuilderAgent({
-      anthropic: {} as Anthropic,
+      anthropic: () => ({}) as Anthropic,
       draftStore: harness.draftStore,
       bus: harness.bus,
       rebuildScheduler: { schedule: () => {} },
@@ -865,7 +912,7 @@ describe('BuilderAgent.runTurn — OB-31 askOptions wiring', () => {
       },
     });
     const agent = new BuilderAgent({
-      anthropic: {} as Anthropic,
+      anthropic: () => ({}) as Anthropic,
       draftStore: harness.draftStore,
       bus: harness.bus,
       rebuildScheduler: {

--- a/middleware/test/builder/builderAgentHeartbeat.test.ts
+++ b/middleware/test/builder/builderAgentHeartbeat.test.ts
@@ -66,7 +66,7 @@ async function createHarness(): Promise<Harness> {
     tmpRoot,
     agentFor(subAgentBuilder) {
       return new BuilderAgent({
-        anthropic: fakeAnthropic,
+        anthropic: () => fakeAnthropic,
         draftStore,
         bus,
         rebuildScheduler: { schedule() {} },

--- a/middleware/test/builder/builderAgentPauseOnIssue.test.ts
+++ b/middleware/test/builder/builderAgentPauseOnIssue.test.ts
@@ -68,7 +68,7 @@ describe('BuilderAgent — pause-on-issue guard', () => {
 
     let subAgentBuilt = 0;
     const agent = new BuilderAgent({
-      anthropic: {} as Anthropic,
+      anthropic: () => ({}) as Anthropic,
       draftStore: store,
       bus,
       rebuildScheduler: { schedule: () => undefined },
@@ -129,7 +129,7 @@ describe('BuilderAgent — pause-on-issue guard', () => {
   it('runs normally when paused_on_issue is unset', async () => {
     let subAgentBuilt = 0;
     const agent = new BuilderAgent({
-      anthropic: {} as Anthropic,
+      anthropic: () => ({}) as Anthropic,
       draftStore: store,
       bus,
       rebuildScheduler: { schedule: () => undefined },

--- a/middleware/test/builder/builderAgentStream.test.ts
+++ b/middleware/test/builder/builderAgentStream.test.ts
@@ -70,7 +70,7 @@ async function createHarness(): Promise<Harness> {
     tmpRoot,
     agentFor(subAgentBuilder) {
       return new BuilderAgent({
-        anthropic: fakeAnthropic,
+        anthropic: () => fakeAnthropic,
         draftStore,
         bus,
         rebuildScheduler: { schedule() {} },

--- a/middleware/test/builder/builderChatRoutes.test.ts
+++ b/middleware/test/builder/builderChatRoutes.test.ts
@@ -90,7 +90,7 @@ async function createTestApp(opts: {
 
   const fakeAnthropic = {} as Anthropic;
   const builderAgent = new BuilderAgent({
-    anthropic: fakeAnthropic,
+    anthropic: () => fakeAnthropic,
     draftStore,
     bus,
     rebuildScheduler: {

--- a/middleware/test/builder/builderPreviewRoutes.test.ts
+++ b/middleware/test/builder/builderPreviewRoutes.test.ts
@@ -190,7 +190,7 @@ async function startHarness(opts: {
   });
 
   const chatService = new PreviewChatService({
-    anthropic: {} as never,
+    anthropic: (() => ({})) as never,
     draftStore: store,
     systemPromptFor: async () => 'sp',
     buildSubAgent: () => ({

--- a/middleware/test/builder/previewChatService.test.ts
+++ b/middleware/test/builder/previewChatService.test.ts
@@ -176,7 +176,7 @@ describe('PreviewChatService', () => {
         finalText: 'I called the echo tool.',
       });
       const svc = new PreviewChatService({
-        anthropic: fakeAnthropic,
+        anthropic: () => fakeAnthropic,
         draftStore: store,
         systemPromptFor: async () => 'system-prompt-stub',
         buildSubAgent: fake.build,
@@ -224,7 +224,7 @@ describe('PreviewChatService', () => {
       const handle = makeHandle({ draftId: draft.id });
       const fake = fakeSubAgentBuilder({ finalText: 'OK' });
       const svc = new PreviewChatService({
-        anthropic: fakeAnthropic,
+        anthropic: () => fakeAnthropic,
         draftStore: store,
         systemPromptFor: async () => 'sp',
         buildSubAgent: fake.build,
@@ -267,7 +267,7 @@ describe('PreviewChatService', () => {
       const handle = makeHandle({ draftId: draft.id });
       const fake = fakeSubAgentBuilder({ finalText: 'noted' });
       const svc = new PreviewChatService({
-        anthropic: fakeAnthropic,
+        anthropic: () => fakeAnthropic,
         draftStore: store,
         systemPromptFor: async () => 'sp',
         buildSubAgent: fake.build,
@@ -296,7 +296,7 @@ describe('PreviewChatService', () => {
       const handle = makeHandle({ draftId: draft.id });
       const fake = fakeSubAgentBuilder({ finalText: 'ack' });
       const svc = new PreviewChatService({
-        anthropic: fakeAnthropic,
+        anthropic: () => fakeAnthropic,
         draftStore: store,
         systemPromptFor: async () => 'sp',
         buildSubAgent: fake.build,
@@ -320,7 +320,7 @@ describe('PreviewChatService', () => {
       const handle = makeHandle({ draftId: draft.id, tools: [tool] });
       const fake = fakeSubAgentBuilder({ finalText: 'OK' });
       const svc = new PreviewChatService({
-        anthropic: fakeAnthropic,
+        anthropic: () => fakeAnthropic,
         draftStore: store,
         systemPromptFor: async () => 'CUSTOM-PROMPT',
         buildSubAgent: fake.build,
@@ -368,7 +368,7 @@ describe('PreviewChatService', () => {
       const handle = makeHandle({ draftId: draft.id, tools: [tool] });
       const fake = fakeSubAgentBuilder({ finalText: 'OK' });
       const svc = new PreviewChatService({
-        anthropic: fakeAnthropic,
+        anthropic: () => fakeAnthropic,
         draftStore: store,
         systemPromptFor: async () => 'sp',
         buildSubAgent: fake.build,
@@ -415,7 +415,7 @@ describe('PreviewChatService', () => {
         throws: new Error('anthropic-rate-limit'),
       });
       const svc = new PreviewChatService({
-        anthropic: fakeAnthropic,
+        anthropic: () => fakeAnthropic,
         draftStore: store,
         systemPromptFor: async () => 'sp',
         buildSubAgent: fake.build,
@@ -441,7 +441,7 @@ describe('PreviewChatService', () => {
       const handle = makeHandle({ draftId: draft.id });
       const fake = fakeSubAgentBuilder({ finalText: 'unused' });
       const svc = new PreviewChatService({
-        anthropic: fakeAnthropic,
+        anthropic: () => fakeAnthropic,
         draftStore: store,
         systemPromptFor: async () => 'sp',
         buildSubAgent: fake.build,
@@ -474,7 +474,7 @@ describe('PreviewChatService', () => {
       const handle = makeHandle({ draftId: draft.id });
       const fake = fakeSubAgentBuilder({ finalText: 'new reply' });
       const svc = new PreviewChatService({
-        anthropic: fakeAnthropic,
+        anthropic: () => fakeAnthropic,
         draftStore: store,
         systemPromptFor: async () => 'sp',
         buildSubAgent: fake.build,
@@ -512,7 +512,7 @@ describe('PreviewChatService', () => {
         finalText: 'done',
       });
       const svc = new PreviewChatService({
-        anthropic: fakeAnthropic,
+        anthropic: () => fakeAnthropic,
         draftStore: store,
         systemPromptFor: async () => 'sp',
         buildSubAgent: fake.build,
@@ -552,7 +552,7 @@ describe('PreviewChatService', () => {
       });
       const handle = makeHandle({ draftId: 'd1', tools: [tool] });
       const svc = new PreviewChatService({
-        anthropic: fakeAnthropic,
+        anthropic: () => fakeAnthropic,
         draftStore: store,
         systemPromptFor: async () => 'sp',
         logger: () => {},
@@ -570,7 +570,7 @@ describe('PreviewChatService', () => {
     it('returns isError=true on unknown toolId', async () => {
       const handle = makeHandle({ draftId: 'd1' });
       const svc = new PreviewChatService({
-        anthropic: fakeAnthropic,
+        anthropic: () => fakeAnthropic,
         draftStore: store,
         systemPromptFor: async () => 'sp',
         logger: () => {},
@@ -593,7 +593,7 @@ describe('PreviewChatService', () => {
       });
       const handle = makeHandle({ draftId: 'd1', tools: [tool] });
       const svc = new PreviewChatService({
-        anthropic: fakeAnthropic,
+        anthropic: () => fakeAnthropic,
         draftStore: store,
         systemPromptFor: async () => 'sp',
         logger: () => {},
@@ -614,7 +614,7 @@ describe('PreviewChatService', () => {
       });
       const handle = makeHandle({ draftId: 'd1', tools: [tool] });
       const svc = new PreviewChatService({
-        anthropic: fakeAnthropic,
+        anthropic: () => fakeAnthropic,
         draftStore: store,
         systemPromptFor: async () => 'sp',
         logger: () => {},


### PR DESCRIPTION
## Problem

Customer report: every Agent Builder ask fails with

```
builder.ask_failed: Could not resolve authentication method. Expected one of apiKey, authToken, credentials, config, or profile to be set. ...
```

**Affected setups:** the Anthropic API key was entered via the Setup Wizard / admin secrets (vault) and `ANTHROPIC_API_KEY` is **not** set as an env var on the middleware process. Chat works there (the orchestrator plugin builds its own client from its vault), but the Builder never does — including after a restart.

## Root cause

- `index.ts` builds the shared boot client solely from env: `new Anthropic({ apiKey: config.ANTHROPIC_API_KEY ?? '' })` → unauthenticated when the key lives only in the vault.
- The OB-61 fix (`refreshSharedAnthropicClientFromVault`) hot-swaps only the **ServiceRegistry providers** (`anthropicClient`, `llm`).
- `BuilderAgent` and `PreviewChatService` were constructed with the stale `client` **const** and held it forever. With an empty `apiKey` the SDK sends no `x-api-key` header and `validateHeaders` throws exactly the error above.

## Fix

- `BuilderAgentDeps.anthropic` and `PreviewChatServiceDeps.anthropic` are now **accessors** (`() => Anthropic`) resolved per turn instead of captured instances.
- `index.ts` passes `currentAnthropicClient`, a thunk reading the live `anthropicClient` registry provider (falls back to the boot client before first registration).
- Regression test: a client hot-swap after `BuilderAgent` construction must reach the next ask turn.

## Not in scope (same pattern, separate follow-up)

`DynamicAgentRuntime` (`index.ts` ~line 539) and `registerDbSubAgentTools` (~line 1399) also capture the boot client directly. Their failure paths are mitigated by per-plugin vault clients / ctx.llm, but they'd benefit from the same accessor treatment.

## Verification

- `tsc --noEmit` clean, full workspace build clean (node 22.22.3)
- all builder suites: **951 tests, 949 pass, 0 fail, 2 skipped** (includes the new hot-swap regression test)

## Customer workaround until deployed

Set `ANTHROPIC_API_KEY` as an env var on the middleware process and restart.