### PR TITLE
First Lume integration in the operator UI (#282)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,25 @@ ownership, auditability, and dropping into a real enterprise stack, not just
 - **Routines** — user-authored cron-triggered agent runs with full per-run
   trace + call-stack viewer
 
+## Design
+
+The operator UI speaks Lume, omadia's own visual language. The idea is that
+light is the material: surfaces read as condensed out of light, and the
+agent's attention shows up as accent-tinted illumination, not as flat color.
+Four recipes carry it. Surfaces are gradient pairs, borders catch the light on
+their top edge, one accent slot glows to mark focus and selection, and corners
+stay soft.
+
+Three accent palettes ship, Petrol, Atelier, and Lagoon as the default. The
+operator picks one and switches between light and dark from the header. The
+whole theme lives in a single token file (`web-ui/app/_lib/theme.css`), so
+restyling stays a change at the token tier rather than a sweep through
+components.
+
+Lume is specified in [byte5ai/omadia-ui](https://github.com/byte5ai/omadia-ui)
+under `docs/visual-spec.md`, the same language omadia's canvas app is built on.
+The operator UI and the canvas app share one identity.
+
 ## Architecture
 
 ```

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -779,9 +779,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -796,9 +796,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -813,9 +813,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -830,9 +830,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -847,9 +847,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -864,9 +864,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -881,9 +881,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -898,9 +898,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -915,9 +915,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -932,9 +932,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -949,9 +949,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -966,9 +966,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -983,9 +983,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -1000,9 +1000,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1017,9 +1017,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1034,9 +1034,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -1051,9 +1051,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -1068,9 +1068,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -1085,9 +1085,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -1102,9 +1102,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1119,9 +1119,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -1136,9 +1136,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -1153,9 +1153,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -1170,9 +1170,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -1187,9 +1187,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -1204,9 +1204,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -4380,9 +4380,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -4393,32 +4393,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escape-html": {

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -77,5 +77,8 @@
     "ts-node": "^10.9.2",
     "tsx": "^4.22.4",
     "typescript": "^6.0.2"
+  },
+  "overrides": {
+    "esbuild": "^0.28.1"
   }
 }

--- a/web-ui/app/_components/AgentPicker.tsx
+++ b/web-ui/app/_components/AgentPicker.tsx
@@ -91,7 +91,7 @@ export function AgentPicker(props: AgentPickerProps): React.ReactElement {
   if (props.pinnedSlug) {
     return (
       <span
-        className="inline-flex items-center gap-1.5 rounded border border-[color:var(--border)] bg-[color:var(--bg-soft)] px-2 py-1 font-mono text-xs text-[color:var(--fg)]"
+        className="inline-flex items-center gap-2 rounded border border-[color:var(--border)] bg-[color:var(--bg-soft)] px-2 py-1 font-mono text-xs text-[color:var(--fg)]"
         title={t('pinnedTooltip')}
       >
         <span className="text-[color:var(--fg-muted)]">{t('label')}</span>
@@ -121,7 +121,7 @@ export function AgentPicker(props: AgentPickerProps): React.ReactElement {
     return (
       <a
         href="/operator/agents"
-        className="inline-flex items-center gap-1.5 rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 px-2 py-1 text-xs text-[color:var(--warning)] hover:bg-[color:var(--warning)]/10"
+        className="inline-flex items-center gap-2 rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 px-2 py-1 text-xs text-[color:var(--warning)] hover:bg-[color:var(--warning)]/10"
       >
         {t('emptyCta')}
       </a>

--- a/web-ui/app/_components/AgentPicker.tsx
+++ b/web-ui/app/_components/AgentPicker.tsx
@@ -91,10 +91,10 @@ export function AgentPicker(props: AgentPickerProps): React.ReactElement {
   if (props.pinnedSlug) {
     return (
       <span
-        className="inline-flex items-center gap-1.5 rounded border border-neutral-300 bg-neutral-50 px-2 py-1 font-mono text-xs text-neutral-700"
+        className="inline-flex items-center gap-1.5 rounded border border-[color:var(--border)] bg-[color:var(--bg-soft)] px-2 py-1 font-mono text-xs text-[color:var(--fg)]"
         title={t('pinnedTooltip')}
       >
-        <span className="text-neutral-500">{t('label')}</span>
+        <span className="text-[color:var(--fg-muted)]">{t('label')}</span>
         <span className="font-semibold">{props.pinnedSlug}</span>
       </span>
     );
@@ -102,7 +102,7 @@ export function AgentPicker(props: AgentPickerProps): React.ReactElement {
 
   if (state.loading) {
     return (
-      <span className="inline-flex text-xs text-neutral-500">
+      <span className="inline-flex text-xs text-[color:var(--fg-muted)]">
         {t('loading')}
       </span>
     );
@@ -110,7 +110,7 @@ export function AgentPicker(props: AgentPickerProps): React.ReactElement {
 
   if (state.error) {
     return (
-      <span className="inline-flex text-xs text-red-700" title={state.error}>
+      <span className="inline-flex text-xs text-[color:var(--danger)]" title={state.error}>
         {t('error')}
       </span>
     );
@@ -121,7 +121,7 @@ export function AgentPicker(props: AgentPickerProps): React.ReactElement {
     return (
       <a
         href="/operator/agents"
-        className="inline-flex items-center gap-1.5 rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs text-amber-800 hover:bg-amber-100"
+        className="inline-flex items-center gap-1.5 rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 px-2 py-1 text-xs text-[color:var(--warning)] hover:bg-[color:var(--warning)]/10"
       >
         {t('emptyCta')}
       </a>
@@ -130,9 +130,9 @@ export function AgentPicker(props: AgentPickerProps): React.ReactElement {
 
   return (
     <label className="inline-flex items-center gap-2 text-xs">
-      <span className="text-neutral-500">{t('label')}</span>
+      <span className="text-[color:var(--fg-muted)]">{t('label')}</span>
       <select
-        className="rounded border border-neutral-300 bg-white px-2 py-1 font-mono text-xs"
+        className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-2 py-1 font-mono text-xs"
         value={props.selectedSlug ?? state.fallbackSlug ?? ''}
         onChange={(e) =>
           props.onSelect(e.target.value === '' ? undefined : e.target.value)

--- a/web-ui/app/_components/AgentUnavailableBanner.tsx
+++ b/web-ui/app/_components/AgentUnavailableBanner.tsx
@@ -69,18 +69,18 @@ export function AgentUnavailableBanner(
   }
 
   return (
-    <div className="mx-auto mt-4 max-w-4xl rounded border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900">
+    <div className="mx-auto mt-4 max-w-4xl rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 p-4 text-sm text-[color:var(--warning)]">
       <p className="font-medium">{t('unavailableTitle')}</p>
-      <p className="mt-1 text-amber-800">
+      <p className="mt-1 text-[color:var(--warning)]">
         {t('unavailableBody', { slug: props.unavailableSlug })}
       </p>
       {error && (
-        <p className="mt-2 text-red-800">{error}</p>
+        <p className="mt-2 text-[color:var(--danger)]">{error}</p>
       )}
       <div className="mt-3 flex gap-2">
         <button
           type="button"
-          className="rounded border border-amber-400 bg-white px-3 py-1 text-xs font-medium text-amber-900 hover:bg-amber-100 disabled:opacity-50"
+          className="rounded border border-[color:var(--warning)] bg-[color:var(--bg-elevated)] px-3 py-1 text-xs font-medium text-[color:var(--warning)] hover:bg-[color:var(--warning)]/10 disabled:opacity-50"
           disabled={!!busy}
           onClick={() => void reSnapshot()}
         >
@@ -88,7 +88,7 @@ export function AgentUnavailableBanner(
         </button>
         <button
           type="button"
-          className="rounded border border-red-400 bg-white px-3 py-1 text-xs font-medium text-red-800 hover:bg-red-50 disabled:opacity-50"
+          className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--bg-elevated)] px-3 py-1 text-xs font-medium text-[color:var(--danger)] hover:bg-[color:var(--danger)]/8 disabled:opacity-50"
           disabled={!!busy}
           onClick={() => void deleteSession()}
         >

--- a/web-ui/app/_components/AuthBadge.tsx
+++ b/web-ui/app/_components/AuthBadge.tsx
@@ -172,7 +172,7 @@ export function AuthBadge(): React.ReactElement | null {
               <div className="font-mono text-[11px] text-[color:var(--fg-muted)]">
                 {user.email}
               </div>
-              <div className="mt-2 flex items-center gap-1.5 text-[10px] uppercase tracking-[0.14em] text-[color:var(--fg-subtle)]">
+              <div className="mt-2 flex items-center gap-2 text-[10px] uppercase tracking-[0.14em] text-[color:var(--fg-subtle)]">
                 {tSession('expiresAtLabel')}
                 <span className="font-mono normal-case tracking-normal text-[color:var(--fg-muted)]">
                   {expiryLabel}

--- a/web-ui/app/_components/AuthBadge.tsx
+++ b/web-ui/app/_components/AuthBadge.tsx
@@ -108,7 +108,7 @@ export function AuthBadge(): React.ReactElement | null {
   if (state.kind === 'error') {
     return (
       <span
-        className="text-[11px] uppercase tracking-[0.18em] text-rose-600"
+        className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--danger)]"
         title={state.message}
       >
         {t('authError')}
@@ -160,7 +160,7 @@ export function AuthBadge(): React.ReactElement | null {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -6 }}
             transition={{ duration: 0.15, ease: 'easeOut' }}
-            className="absolute right-0 top-full z-50 mt-2 w-64 rounded-2xl border border-[color:var(--divider)] bg-[color:var(--surface)] p-3 shadow-xl"
+            className="absolute right-0 top-full z-50 mt-2 w-64 rounded-lg border border-[color:var(--divider)] bg-[color:var(--surface)] p-3 shadow-xl"
           >
             <div className="px-2 pb-3">
               <div className="text-[10px] uppercase tracking-[0.22em] text-[color:var(--fg-subtle)]">

--- a/web-ui/app/_components/ChatTabs.tsx
+++ b/web-ui/app/_components/ChatTabs.tsx
@@ -38,7 +38,7 @@ export function ChatTabs({
   const t = useTranslations('chatTabs');
   return (
     <div
-      className="flex items-center gap-1 overflow-x-auto border-b border-neutral-200 bg-neutral-50 px-2 py-1 text-xs dark:border-neutral-800 dark:bg-neutral-950"
+      className="flex items-center gap-1 overflow-x-auto border-b border-[color:var(--border)] bg-[color:var(--bg-soft)] px-2 py-1 text-xs"
       role="tablist"
     >
       {sessions.map((session) => (
@@ -62,7 +62,7 @@ export function ChatTabs({
       <button
         type="button"
         onClick={onCreate}
-        className="ml-1 shrink-0 rounded border border-neutral-300 px-2 py-1 font-medium text-neutral-700 transition hover:border-neutral-500 hover:bg-white dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
+        className="ml-1 shrink-0 rounded border border-[color:var(--border)] px-2 py-1 font-medium text-[color:var(--fg)] transition hover:border-[color:var(--border-strong)] hover:bg-[color:var(--bg-elevated)]"
         title={t('newChatTitle')}
       >
         + {t('newChat')}
@@ -142,8 +142,8 @@ function Tab({
       className={[
         'group flex shrink-0 cursor-pointer items-center gap-1 rounded px-2 py-1 transition',
         active
-          ? 'bg-white font-semibold text-neutral-900 ring-1 ring-neutral-300 dark:bg-neutral-800 dark:text-neutral-100 dark:ring-neutral-700'
-          : 'text-neutral-600 hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-neutral-900',
+          ? 'bg-[color:var(--bg-elevated)] font-semibold text-[color:var(--fg-strong)] ring-1 ring-[color:var(--border-strong)]'
+          : 'text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)]',
       ].join(' ')}
       title={`${session.title}\n${t('tabTitleSuffix', { id: session.id })}`}
     >
@@ -159,7 +159,7 @@ function Tab({
           onClick={(e) => {
             e.stopPropagation();
           }}
-          className="w-40 rounded border border-neutral-300 bg-white px-1 text-xs dark:border-neutral-600 dark:bg-neutral-900"
+          className="w-40 rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-1 text-xs"
           maxLength={120}
         />
       ) : (
@@ -170,7 +170,7 @@ function Tab({
           type="button"
           onClick={onClickClose}
           disabled={disabled}
-          className="ml-1 rounded px-1 text-neutral-400 opacity-0 transition group-hover:opacity-100 hover:bg-neutral-200 hover:text-neutral-800 disabled:cursor-not-allowed disabled:opacity-30 dark:hover:bg-neutral-700 dark:hover:text-neutral-100"
+          className="ml-1 rounded px-1 text-[color:var(--fg-subtle)] opacity-0 transition group-hover:opacity-100 hover:bg-[color:var(--state-loading)] hover:text-[color:var(--fg)] disabled:cursor-not-allowed disabled:opacity-30"
           aria-label={t('closeAriaLabel', { title: session.title })}
           title={disabled ? t('closeWhileBusyTitle') : t('closeTitle')}
         >

--- a/web-ui/app/_components/ChatTabs.tsx
+++ b/web-ui/app/_components/ChatTabs.tsx
@@ -141,8 +141,9 @@ function Tab({
       }}
       className={[
         'group flex shrink-0 cursor-pointer items-center gap-1 rounded px-2 py-1 transition',
+        // §4.2 tabs: the active tab carries the lit accent underline.
         active
-          ? 'bg-[color:var(--bg-elevated)] font-semibold text-[color:var(--fg-strong)] ring-1 ring-[color:var(--border-strong)]'
+          ? 'lume-tab-active bg-[color:var(--bg-elevated)] font-semibold'
           : 'text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)]',
       ].join(' ')}
       title={`${session.title}\n${t('tabTitleSuffix', { id: session.id })}`}

--- a/web-ui/app/_components/ChoiceCard.tsx
+++ b/web-ui/app/_components/ChoiceCard.tsx
@@ -28,15 +28,15 @@ export function ChoiceCard({
 }): React.ReactElement {
   const t = useTranslations('chat');
   return (
-    <div className="mt-3 rounded border border-indigo-200 bg-indigo-50/60 p-3 dark:border-indigo-800 dark:bg-indigo-950/40">
-      <div className="mb-1 text-xs font-semibold text-indigo-700 dark:text-indigo-300">
+    <div className="mt-3 rounded border border-[color:var(--accent)] bg-[color:var(--accent)]/10 p-3">
+      <div className="mb-1 text-xs font-semibold text-[color:var(--accent)]">
         {t('clarifyKicker')}
       </div>
-      <div className="mb-2 text-sm text-neutral-900 dark:text-neutral-100">
+      <div className="mb-2 text-sm text-[color:var(--fg-strong)]">
         {choice.question}
       </div>
       {choice.rationale && (
-        <div className="mb-2 text-xs text-neutral-500 italic dark:text-neutral-400">
+        <div className="mb-2 text-xs text-[color:var(--fg-muted)] italic">
           {choice.rationale}
         </div>
       )}
@@ -52,8 +52,8 @@ export function ChoiceCard({
             className={[
               'rounded border px-3 py-1.5 text-xs font-medium transition',
               idx === 0
-                ? 'border-indigo-600 bg-indigo-600 text-white hover:bg-indigo-700 dark:border-indigo-500 dark:bg-indigo-500 dark:hover:bg-indigo-600'
-                : 'border-neutral-300 bg-white text-neutral-700 hover:border-neutral-500 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200',
+                ? 'border-[color:var(--accent)] bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] hover:bg-[color:var(--accent)]'
+                : 'border-[color:var(--border)] bg-[color:var(--bg-elevated)] text-[color:var(--fg)] hover:border-[color:var(--border-strong)]',
               'disabled:cursor-not-allowed disabled:opacity-40',
             ].join(' ')}
           >

--- a/web-ui/app/_components/ChoiceCard.tsx
+++ b/web-ui/app/_components/ChoiceCard.tsx
@@ -50,7 +50,7 @@ export function ChoiceCard({
             }}
             disabled={disabled}
             className={[
-              'rounded border px-3 py-1.5 text-xs font-medium transition',
+              'rounded border px-3 py-2 text-xs font-medium transition',
               idx === 0
                 ? 'border-[color:var(--accent)] bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] hover:bg-[color:var(--accent)]'
                 : 'border-[color:var(--border)] bg-[color:var(--bg-elevated)] text-[color:var(--fg)] hover:border-[color:var(--border-strong)]',

--- a/web-ui/app/_components/ConfirmDialog.tsx
+++ b/web-ui/app/_components/ConfirmDialog.tsx
@@ -30,12 +30,14 @@ export function ConfirmDialog({
   onConfirm,
   onCancel,
 }: ConfirmDialogProps): React.ReactElement | null {
-  const confirmRef = useRef<HTMLButtonElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (!open) return;
-    // Auto-focus the confirm button so Enter commits.
-    confirmRef.current?.focus();
+    // §7.5: focus opens on Cancel — deliberate friction before an
+    // external-effect action. Enter therefore cancels by default; confirming
+    // requires an explicit Tab or click.
+    cancelRef.current?.focus();
   }, [open]);
 
   useEffect(() => {
@@ -54,10 +56,13 @@ export function ConfirmDialog({
 
   if (!open) return null;
 
+  // §4.2 button variants: danger is transparent + error edge + error text
+  // (the error is the signal — no fill, no glow); neutral confirm is the
+  // Lume primary (accent fill → gradient + glow via the material layer).
   const confirmCls =
     tone === 'danger'
-      ? 'bg-[color:var(--danger)] hover:bg-[color:var(--danger)] text-[color:var(--fg-on-dark)] border-[color:var(--danger-edge)]'
-      : 'bg-[color:var(--bg-inverse)] hover:bg-[color:var(--fg-muted)] text-[color:var(--fg-on-dark)] border-[color:var(--border-strong)]';
+      ? 'border-[color:var(--danger-edge)] bg-transparent text-[color:var(--danger)] hover:bg-[color:var(--danger)]/8'
+      : 'border-transparent bg-[color:var(--accent)]';
 
   return (
     <div
@@ -69,7 +74,7 @@ export function ConfirmDialog({
         if (e.target === e.currentTarget) onCancel();
       }}
     >
-      <div className="w-full max-w-md rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-5 shadow-xl">
+      <div className="w-full max-w-md rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-5 shadow-lg">
         <h2
           id="confirm-dialog-title"
           className="text-base font-semibold text-[color:var(--fg-strong)]"
@@ -83,6 +88,7 @@ export function ConfirmDialog({
         )}
         <div className="mt-5 flex justify-end gap-2">
           <button
+            ref={cancelRef}
             type="button"
             onClick={onCancel}
             className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-4 py-1.5 text-sm font-medium text-[color:var(--fg)] transition hover:border-[color:var(--border-strong)]"
@@ -90,7 +96,6 @@ export function ConfirmDialog({
             {cancelLabel}
           </button>
           <button
-            ref={confirmRef}
             type="button"
             onClick={onConfirm}
             className={`rounded border px-4 py-1.5 text-sm font-medium transition ${confirmCls}`}

--- a/web-ui/app/_components/ConfirmDialog.tsx
+++ b/web-ui/app/_components/ConfirmDialog.tsx
@@ -56,28 +56,28 @@ export function ConfirmDialog({
 
   const confirmCls =
     tone === 'danger'
-      ? 'bg-red-600 hover:bg-red-700 text-white border-red-600'
-      : 'bg-neutral-900 hover:bg-neutral-700 text-white border-neutral-900 dark:bg-neutral-100 dark:text-neutral-900 dark:border-neutral-100';
+      ? 'bg-[color:var(--danger)] hover:bg-[color:var(--danger)] text-[color:var(--fg-on-dark)] border-[color:var(--danger-edge)]'
+      : 'bg-[color:var(--bg-inverse)] hover:bg-[color:var(--fg-muted)] text-[color:var(--fg-on-dark)] border-[color:var(--border-strong)]';
 
   return (
     <div
       role="dialog"
       aria-modal="true"
       aria-labelledby="confirm-dialog-title"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--bg-modal-overlay)] p-4"
       onClick={(e) => {
         if (e.target === e.currentTarget) onCancel();
       }}
     >
-      <div className="w-full max-w-md rounded-lg border border-neutral-200 bg-white p-5 shadow-xl dark:border-neutral-700 dark:bg-neutral-900">
+      <div className="w-full max-w-md rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-5 shadow-xl">
         <h2
           id="confirm-dialog-title"
-          className="text-base font-semibold text-neutral-900 dark:text-neutral-100"
+          className="text-base font-semibold text-[color:var(--fg-strong)]"
         >
           {title}
         </h2>
         {body && (
-          <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
+          <p className="mt-2 text-sm text-[color:var(--fg-muted)]">
             {body}
           </p>
         )}
@@ -85,7 +85,7 @@ export function ConfirmDialog({
           <button
             type="button"
             onClick={onCancel}
-            className="rounded border border-neutral-300 bg-white px-4 py-1.5 text-sm font-medium text-neutral-700 transition hover:border-neutral-400 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200"
+            className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-4 py-1.5 text-sm font-medium text-[color:var(--fg)] transition hover:border-[color:var(--border-strong)]"
           >
             {cancelLabel}
           </button>

--- a/web-ui/app/_components/ConfirmDialog.tsx
+++ b/web-ui/app/_components/ConfirmDialog.tsx
@@ -74,7 +74,7 @@ export function ConfirmDialog({
         if (e.target === e.currentTarget) onCancel();
       }}
     >
-      <div className="w-full max-w-md rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-5 shadow-lg">
+      <div className="w-full max-w-md rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-4 shadow-lg">
         <h2
           id="confirm-dialog-title"
           className="text-base font-semibold text-[color:var(--fg-strong)]"
@@ -86,19 +86,19 @@ export function ConfirmDialog({
             {body}
           </p>
         )}
-        <div className="mt-5 flex justify-end gap-2">
+        <div className="mt-4 flex justify-end gap-2">
           <button
             ref={cancelRef}
             type="button"
             onClick={onCancel}
-            className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-4 py-1.5 text-sm font-medium text-[color:var(--fg)] transition hover:border-[color:var(--border-strong)]"
+            className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-4 py-2 text-sm font-medium text-[color:var(--fg)] transition hover:border-[color:var(--border-strong)]"
           >
             {cancelLabel}
           </button>
           <button
             type="button"
             onClick={onConfirm}
-            className={`rounded border px-4 py-1.5 text-sm font-medium transition ${confirmCls}`}
+            className={`rounded border px-4 py-2 text-sm font-medium transition ${confirmCls}`}
           >
             {confirmLabel}
           </button>

--- a/web-ui/app/_components/IssueReportCard.tsx
+++ b/web-ui/app/_components/IssueReportCard.tsx
@@ -127,7 +127,7 @@ export function IssueReportCard({
       </div>
 
       {phase === 'done' && filed ? (
-        <div className="text-sm text-neutral-900 dark:text-neutral-100">
+        <div className="text-sm text-[color:var(--fg-strong)]">
           {t.rich('filed', {
             number: filed.number,
             issueLink: (chunks) => (
@@ -144,15 +144,15 @@ export function IssueReportCard({
         </div>
       ) : (
         <>
-          <div className="mb-2 text-sm font-medium text-neutral-900 dark:text-neutral-100">
+          <div className="mb-2 text-sm font-medium text-[color:var(--fg-strong)]">
             {report.title}
           </div>
-          <p className="mb-2 text-xs text-neutral-500 dark:text-neutral-400">
+          <p className="mb-2 text-xs text-[color:var(--fg-muted)]">
             {t.rich('publicWarning', {
               strong: (chunks) => <strong>{chunks}</strong>,
             })}
           </p>
-          <pre className="mb-3 max-h-48 overflow-auto rounded bg-neutral-100 p-2 text-[11px] leading-snug whitespace-pre-wrap text-neutral-800 dark:bg-neutral-900 dark:text-neutral-200">
+          <pre className="mb-3 max-h-48 overflow-auto rounded bg-[color:var(--bg-soft)] p-2 text-[11px] leading-snug whitespace-pre-wrap text-[color:var(--fg)]">
             {report.sanitizedBody}
           </pre>
 
@@ -197,7 +197,7 @@ export function IssueReportCard({
                   setIssueNumberInput(e.target.value);
                 }}
                 placeholder={t('issueNumberPlaceholder')}
-                className="w-28 rounded border border-neutral-300 bg-white px-2 py-1.5 text-xs text-neutral-800 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-100"
+                className="w-28 rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-2 py-1.5 text-xs text-[color:var(--fg)]"
               />
               <PrimaryButton
                 disabled={busy}
@@ -230,7 +230,7 @@ function PrimaryButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="rounded border border-[color:var(--warning)] bg-[color:var(--warning)] px-3 py-1.5 text-xs font-medium text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+      className="rounded border border-[color:var(--warning)] bg-[color:var(--warning)] px-3 py-1.5 text-xs font-medium text-[color:var(--fg-on-dark)] transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
     >
       {children}
     </button>
@@ -251,7 +251,7 @@ function SecondaryButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="rounded border border-neutral-300 bg-white px-3 py-1.5 text-xs font-medium text-neutral-700 transition hover:border-neutral-500 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200"
+      className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-3 py-1.5 text-xs font-medium text-[color:var(--fg)] transition hover:border-[color:var(--border-strong)] disabled:cursor-not-allowed disabled:opacity-40"
     >
       {children}
     </button>

--- a/web-ui/app/_components/IssueReportCard.tsx
+++ b/web-ui/app/_components/IssueReportCard.tsx
@@ -122,7 +122,7 @@ export function IssueReportCard({
 
   return (
     <div className="mt-3 rounded border border-[color:var(--warning)]/50 bg-[color:var(--warning)]/10 p-3">
-      <div className="mb-1 flex items-center gap-1.5 text-xs font-semibold text-[color:var(--warning)]">
+      <div className="mb-1 flex items-center gap-2 text-xs font-semibold text-[color:var(--warning)]">
         <span aria-hidden>⚠</span> {t('kicker')}
       </div>
 
@@ -197,7 +197,7 @@ export function IssueReportCard({
                   setIssueNumberInput(e.target.value);
                 }}
                 placeholder={t('issueNumberPlaceholder')}
-                className="w-28 rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-2 py-1.5 text-xs text-[color:var(--fg)]"
+                className="w-28 rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-2 py-2 text-xs text-[color:var(--fg)]"
               />
               <PrimaryButton
                 disabled={busy}
@@ -230,7 +230,7 @@ function PrimaryButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="rounded border border-[color:var(--warning)] bg-[color:var(--warning)] px-3 py-1.5 text-xs font-medium text-[color:var(--fg-on-dark)] transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+      className="rounded border border-[color:var(--warning)] bg-[color:var(--warning)] px-3 py-2 text-xs font-medium text-[color:var(--fg-on-dark)] transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
     >
       {children}
     </button>
@@ -251,7 +251,7 @@ function SecondaryButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-3 py-1.5 text-xs font-medium text-[color:var(--fg)] transition hover:border-[color:var(--border-strong)] disabled:cursor-not-allowed disabled:opacity-40"
+      className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-3 py-2 text-xs font-medium text-[color:var(--fg)] transition hover:border-[color:var(--border-strong)] disabled:cursor-not-allowed disabled:opacity-40"
     >
       {children}
     </button>

--- a/web-ui/app/_components/KgWalkPane.tsx
+++ b/web-ui/app/_components/KgWalkPane.tsx
@@ -272,7 +272,7 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
       <button
         type="button"
         onClick={win.openWindow}
-        className="fixed bottom-6 right-6 z-40 flex items-center gap-2 rounded-full border border-[color:var(--accent)] bg-white/90 px-4 py-2 text-sm font-medium text-[color:var(--accent)] shadow-lg backdrop-blur transition hover:bg-[color:var(--bg-elevated)]"
+        className="fixed bottom-6 right-6 z-40 flex items-center gap-2 rounded-full border border-[color:var(--accent)] bg-[color:var(--bg-elevated)]/90 px-4 py-2 text-sm font-medium text-[color:var(--accent)] shadow-lg backdrop-blur transition hover:bg-[color:var(--bg-elevated)]"
         aria-label={t('openLabel')}
         title={t('openLabel')}
       >

--- a/web-ui/app/_components/KgWalkPane.tsx
+++ b/web-ui/app/_components/KgWalkPane.tsx
@@ -321,7 +321,7 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
               {t('badgeHops', { count: maxHop })}
             </span>
             {insertedCount > 0 && (
-              <span className="rounded bg-[color:var(--success)]/100/20 px-1.5 py-0.5 text-[color:var(--success)]">
+              <span className="rounded bg-[color:var(--success)]/20 px-1.5 py-0.5 text-[color:var(--success)]">
                 {t('badgeInserted', { count: insertedCount })}
               </span>
             )}
@@ -528,7 +528,7 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
                       {n.kind}
                     </span>
                     {n.inserted && (
-                      <span className="shrink-0 rounded bg-[color:var(--success)]/100/25 px-1 py-0.5 font-mono text-[9px] font-semibold text-[color:var(--success)]">
+                      <span className="shrink-0 rounded bg-[color:var(--success)]/25 px-1 py-0.5 font-mono text-[9px] font-semibold text-[color:var(--success)]">
                         {t('insertedTag')}
                       </span>
                     )}

--- a/web-ui/app/_components/KgWalkPane.tsx
+++ b/web-ui/app/_components/KgWalkPane.tsx
@@ -278,7 +278,7 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
       >
         <Network size={16} aria-hidden />
         {t('openLabel')}
-        <span className="rounded bg-[color:var(--accent)]/10 px-1.5 py-0.5 font-mono text-[10px] text-[color:var(--accent)]">
+        <span className="rounded bg-[color:var(--accent)]/10 px-2 py-0.5 font-mono text-[10px] text-[color:var(--accent)]">
           {totalNodes}
         </span>
       </button>
@@ -304,7 +304,7 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
         ].join(' ')}
       >
         <div className="flex min-w-0 flex-col gap-0.5">
-          <span className="flex items-center gap-1.5 text-xs font-semibold tracking-wide text-[color:var(--fg-on-dark)]">
+          <span className="flex items-center gap-2 text-xs font-semibold tracking-wide text-[color:var(--fg-on-dark)]">
             <Network size={13} aria-hidden className="text-[color:var(--accent)]" />
             {t('title')}
           </span>
@@ -312,16 +312,16 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
             {t('subtitle')}
           </span>
         </div>
-        <div className="flex shrink-0 items-center gap-1.5">
+        <div className="flex shrink-0 items-center gap-2">
           <span className="flex gap-1 font-mono text-[10px] text-[color:var(--fg-subtle)]">
-            <span className="rounded bg-white/10 px-1.5 py-0.5">
+            <span className="rounded bg-white/10 px-2 py-0.5">
               {t('badgeNodes', { count: totalNodes })}
             </span>
-            <span className="rounded bg-white/10 px-1.5 py-0.5">
+            <span className="rounded bg-white/10 px-2 py-0.5">
               {t('badgeHops', { count: maxHop })}
             </span>
             {insertedCount > 0 && (
-              <span className="rounded bg-[color:var(--success)]/20 px-1.5 py-0.5 text-[color:var(--success)]">
+              <span className="rounded bg-[color:var(--success)]/20 px-2 py-0.5 text-[color:var(--success)]">
                 {t('badgeInserted', { count: insertedCount })}
               </span>
             )}
@@ -491,11 +491,11 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
 
       {/* Hop-details list — scrollable, grouped by hop. */}
       <div className="min-h-0 flex-[2] overflow-y-auto border-t border-white/10 bg-[color:var(--bg-inverse)]/60">
-        <div className="px-3 py-1.5 text-[10px] font-medium uppercase tracking-wide text-[color:var(--fg-muted)]">
+        <div className="px-3 py-2 text-[10px] font-medium uppercase tracking-wide text-[color:var(--fg-muted)]">
           {t('hopListHeader', { nodes: totalNodes, hops: maxHop })}
         </div>
         {hopGroups.map((group) => (
-          <div key={group.hop} className="border-t border-white/5 px-3 py-1.5">
+          <div key={group.hop} className="border-t border-white/5 px-3 py-2">
             <div className="mb-1 text-[11px] font-semibold text-[color:var(--accent)]">
               {group.hop === 0
                 ? t('hopHeaderRoots')
@@ -515,7 +515,7 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
                       setActiveNodeId(null);
                     }}
                     className={[
-                      'flex items-center gap-1.5 rounded px-1.5 py-1 text-[11px]',
+                      'flex items-center gap-2 rounded px-2 py-1 text-[11px]',
                       isActive ? 'bg-white/10' : 'hover:bg-white/5',
                     ].join(' ')}
                   >

--- a/web-ui/app/_components/KgWalkPane.tsx
+++ b/web-ui/app/_components/KgWalkPane.tsx
@@ -272,13 +272,13 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
       <button
         type="button"
         onClick={win.openWindow}
-        className="fixed bottom-6 right-6 z-40 flex items-center gap-2 rounded-full border border-indigo-300 bg-white/90 px-4 py-2 text-sm font-medium text-indigo-700 shadow-lg backdrop-blur transition hover:bg-white dark:border-indigo-700 dark:bg-neutral-900/90 dark:text-indigo-300 dark:hover:bg-neutral-900"
+        className="fixed bottom-6 right-6 z-40 flex items-center gap-2 rounded-full border border-[color:var(--accent)] bg-white/90 px-4 py-2 text-sm font-medium text-[color:var(--accent)] shadow-lg backdrop-blur transition hover:bg-[color:var(--bg-elevated)]"
         aria-label={t('openLabel')}
         title={t('openLabel')}
       >
         <Network size={16} aria-hidden />
         {t('openLabel')}
-        <span className="rounded bg-indigo-100 px-1.5 py-0.5 font-mono text-[10px] text-indigo-700 dark:bg-indigo-900/60 dark:text-indigo-300">
+        <span className="rounded bg-[color:var(--accent)]/10 px-1.5 py-0.5 font-mono text-[10px] text-[color:var(--accent)]">
           {totalNodes}
         </span>
       </button>
@@ -290,7 +290,7 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
 
   return (
     <section
-      className="fixed z-50 flex flex-col overflow-hidden rounded-xl border border-neutral-300 bg-neutral-950 text-neutral-200 shadow-2xl dark:border-neutral-700"
+      className="fixed z-50 flex flex-col overflow-hidden rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-inverse)] text-[color:var(--fg-on-dark)] shadow-2xl"
       style={win.style}
       aria-label={t('title')}
     >
@@ -299,21 +299,21 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
         onPointerMove={win.headerHandlers.onPointerMove}
         onPointerUp={win.headerHandlers.onPointerUp}
         className={[
-          'flex items-center justify-between gap-2 border-b border-white/10 bg-neutral-900 px-3 py-2 select-none',
+          'flex items-center justify-between gap-2 border-b border-white/10 bg-[color:var(--bg-inverse)] px-3 py-2 select-none',
           win.maximized ? '' : 'cursor-move',
         ].join(' ')}
       >
         <div className="flex min-w-0 flex-col gap-0.5">
-          <span className="flex items-center gap-1.5 text-xs font-semibold tracking-wide text-neutral-100">
-            <Network size={13} aria-hidden className="text-indigo-400" />
+          <span className="flex items-center gap-1.5 text-xs font-semibold tracking-wide text-[color:var(--fg-on-dark)]">
+            <Network size={13} aria-hidden className="text-[color:var(--accent)]" />
             {t('title')}
           </span>
-          <span className="truncate text-[10px] text-neutral-500">
+          <span className="truncate text-[10px] text-[color:var(--fg-muted)]">
             {t('subtitle')}
           </span>
         </div>
         <div className="flex shrink-0 items-center gap-1.5">
-          <span className="flex gap-1 font-mono text-[10px] text-neutral-400">
+          <span className="flex gap-1 font-mono text-[10px] text-[color:var(--fg-subtle)]">
             <span className="rounded bg-white/10 px-1.5 py-0.5">
               {t('badgeNodes', { count: totalNodes })}
             </span>
@@ -321,7 +321,7 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
               {t('badgeHops', { count: maxHop })}
             </span>
             {insertedCount > 0 && (
-              <span className="rounded bg-emerald-500/20 px-1.5 py-0.5 text-emerald-300">
+              <span className="rounded bg-[color:var(--success)]/100/20 px-1.5 py-0.5 text-[color:var(--success)]">
                 {t('badgeInserted', { count: insertedCount })}
               </span>
             )}
@@ -329,7 +329,7 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
           <button
             type="button"
             onClick={win.toggleMaximized}
-            className="rounded p-1 text-neutral-400 transition hover:bg-white/10 hover:text-neutral-100"
+            className="rounded p-1 text-[color:var(--fg-subtle)] transition hover:bg-white/10 hover:text-[color:var(--fg-on-dark)]"
             aria-label={win.maximized ? t('restore') : t('maximize')}
             title={win.maximized ? t('restore') : t('maximize')}
           >
@@ -342,7 +342,7 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
           <button
             type="button"
             onClick={win.close}
-            className="rounded p-1 text-neutral-400 transition hover:bg-white/10 hover:text-neutral-100"
+            className="rounded p-1 text-[color:var(--fg-subtle)] transition hover:bg-white/10 hover:text-[color:var(--fg-on-dark)]"
             aria-label={t('close')}
             title={t('close')}
           >
@@ -459,7 +459,7 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
         )}
 
         {/* Minimal legend, bottom-left of the canvas. */}
-        <div className="pointer-events-none absolute bottom-2 left-2 flex gap-3 rounded-md bg-black/40 px-2 py-1 text-[10px] text-neutral-300 backdrop-blur-sm">
+        <div className="pointer-events-none absolute bottom-2 left-2 flex gap-3 rounded-md bg-[color:var(--bg-modal-overlay)] px-2 py-1 text-[10px] text-[color:var(--fg-subtle)] backdrop-blur-sm">
           <span className="flex items-center gap-1">
             <span
               aria-hidden
@@ -490,13 +490,13 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
       </div>
 
       {/* Hop-details list — scrollable, grouped by hop. */}
-      <div className="min-h-0 flex-[2] overflow-y-auto border-t border-white/10 bg-neutral-900/60">
-        <div className="px-3 py-1.5 text-[10px] font-medium uppercase tracking-wide text-neutral-500">
+      <div className="min-h-0 flex-[2] overflow-y-auto border-t border-white/10 bg-[color:var(--bg-inverse)]/60">
+        <div className="px-3 py-1.5 text-[10px] font-medium uppercase tracking-wide text-[color:var(--fg-muted)]">
           {t('hopListHeader', { nodes: totalNodes, hops: maxHop })}
         </div>
         {hopGroups.map((group) => (
           <div key={group.hop} className="border-t border-white/5 px-3 py-1.5">
-            <div className="mb-1 text-[11px] font-semibold text-indigo-300">
+            <div className="mb-1 text-[11px] font-semibold text-[color:var(--accent)]">
               {group.hop === 0
                 ? t('hopHeaderRoots')
                 : t('hopHeader', { hop: group.hop })}
@@ -524,31 +524,31 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
                       className="inline-block h-2 w-2 shrink-0 rounded-full"
                       style={{ backgroundColor: kindColor(n.kind) }}
                     />
-                    <span className="shrink-0 rounded bg-white/10 px-1 py-0.5 font-mono text-[9px] text-neutral-400">
+                    <span className="shrink-0 rounded bg-white/10 px-1 py-0.5 font-mono text-[9px] text-[color:var(--fg-subtle)]">
                       {n.kind}
                     </span>
                     {n.inserted && (
-                      <span className="shrink-0 rounded bg-emerald-500/25 px-1 py-0.5 font-mono text-[9px] font-semibold text-emerald-300">
+                      <span className="shrink-0 rounded bg-[color:var(--success)]/100/25 px-1 py-0.5 font-mono text-[9px] font-semibold text-[color:var(--success)]">
                         {t('insertedTag')}
                       </span>
                     )}
                     <span
                       className={[
                         'truncate',
-                        n.inserted ? 'text-emerald-200' : 'text-neutral-200',
+                        n.inserted ? 'text-[color:var(--success)]' : 'text-[color:var(--fg-on-dark)]',
                       ].join(' ')}
                       title={n.name}
                     >
                       {truncateLabel(n.name, 40)}
                     </span>
                     {n.isRoot && n.score !== undefined && (
-                      <span className="ml-auto shrink-0 font-mono text-[9px] text-emerald-400">
+                      <span className="ml-auto shrink-0 font-mono text-[9px] text-[color:var(--success)]">
                         {n.score.toFixed(2)}
                       </span>
                     )}
                     {!n.isRoot && incoming && (
                       <span
-                        className="ml-auto shrink-0 truncate font-mono text-[9px] text-neutral-500"
+                        className="ml-auto shrink-0 truncate font-mono text-[9px] text-[color:var(--fg-muted)]"
                         title={`${incoming.fromLabel} → ${incoming.type}`}
                       >
                         ← {incoming.type}
@@ -573,7 +573,7 @@ export function KgWalkPane({ walk }: Props): React.ReactElement | null {
         >
           <svg
             viewBox="0 0 10 10"
-            className="h-full w-full text-neutral-500"
+            className="h-full w-full text-[color:var(--fg-muted)]"
             fill="none"
             stroke="currentColor"
             strokeWidth="1"

--- a/web-ui/app/_components/Markdown.tsx
+++ b/web-ui/app/_components/Markdown.tsx
@@ -34,12 +34,12 @@ interface HastNode {
  * literal array so the Tailwind JIT picks the classes up from this file.
  */
 const PII_REVEALED_CLASS: readonly string[] = [
-  'rounded-[3px]',
-  'bg-violet-100',
+  'rounded-sm',
+  'bg-[color:var(--accent)]/10',
   'px-1',
-  'text-violet-950',
-  'dark:bg-violet-400/25',
-  'dark:text-violet-50',
+  'text-[color:var(--accent)]',
+  '',
+  '',
 ];
 
 /**

--- a/web-ui/app/_components/Nav.tsx
+++ b/web-ui/app/_components/Nav.tsx
@@ -84,7 +84,7 @@ export function Nav(): React.ReactElement {
   const t = useTranslations('nav');
   const activeHref = bestPrefixMatch(pathname);
   return (
-    <nav className="flex items-center gap-5 text-[13px] uppercase tracking-[0.18em]">
+    <nav className="flex items-center gap-4 text-[13px] uppercase tracking-[0.18em]">
       {NAV.map((item) =>
         item.kind === 'link' ? (
           <LeafLink
@@ -217,7 +217,7 @@ function ClusterDropdown({
                   role="menuitem"
                   onClick={() => setOpen(false)}
                   className={[
-                    'block px-3 py-1.5 text-[12px] uppercase tracking-[0.16em] transition-colors',
+                    'block px-3 py-2 text-[12px] uppercase tracking-[0.16em] transition-colors',
                     active
                       ? 'bg-[color:var(--bg-soft)] text-[color:var(--ink)]'
                       : 'text-[color:var(--muted-ink)] hover:bg-[color:var(--bg-soft)] hover:text-[color:var(--ink)]',

--- a/web-ui/app/_components/Nav.tsx
+++ b/web-ui/app/_components/Nav.tsx
@@ -207,7 +207,7 @@ function ClusterDropdown({
           role="menu"
           className="absolute left-0 top-full z-50 min-w-[180px] pt-1"
         >
-          <div className="rounded border border-neutral-200 bg-white py-1 shadow-lg dark:border-neutral-800 dark:bg-neutral-900">
+          <div className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] py-1 shadow-lg">
             {cluster.children.map((child) => {
               const active = child.href === activeHref;
               return (
@@ -219,8 +219,8 @@ function ClusterDropdown({
                   className={[
                     'block px-3 py-1.5 text-[12px] uppercase tracking-[0.16em] transition-colors',
                     active
-                      ? 'bg-neutral-100 text-[color:var(--ink)] dark:bg-neutral-800'
-                      : 'text-[color:var(--muted-ink)] hover:bg-neutral-100 hover:text-[color:var(--ink)] dark:hover:bg-neutral-800',
+                      ? 'bg-[color:var(--bg-soft)] text-[color:var(--ink)]'
+                      : 'text-[color:var(--muted-ink)] hover:bg-[color:var(--bg-soft)] hover:text-[color:var(--ink)]',
                   ].join(' ')}
                 >
                   {renderChildLabel(child)}

--- a/web-ui/app/_components/PlanDagPane.tsx
+++ b/web-ui/app/_components/PlanDagPane.tsx
@@ -91,7 +91,7 @@ export function PlanDagPane({ plan }: Props): React.ReactElement | null {
       >
         <GitBranch size={16} aria-hidden />
         {t('openLabel')}
-        <span className="rounded bg-[color:var(--accent)]/10 px-1.5 py-0.5 font-mono text-[10px] text-[color:var(--accent)]">
+        <span className="rounded bg-[color:var(--accent)]/10 px-2 py-0.5 font-mono text-[10px] text-[color:var(--accent)]">
           {doneCount}/{totalSteps}
         </span>
       </button>
@@ -116,7 +116,7 @@ export function PlanDagPane({ plan }: Props): React.ReactElement | null {
         ].join(' ')}
       >
         <div className="flex min-w-0 flex-col gap-0.5">
-          <span className="flex items-center gap-1.5 text-xs font-semibold tracking-wide text-[color:var(--fg-on-dark)]">
+          <span className="flex items-center gap-2 text-xs font-semibold tracking-wide text-[color:var(--fg-on-dark)]">
             <GitBranch size={13} aria-hidden className="text-[color:var(--accent)]" />
             {t('title')}
           </span>
@@ -124,9 +124,9 @@ export function PlanDagPane({ plan }: Props): React.ReactElement | null {
             {t('subtitle')}
           </span>
         </div>
-        <div className="flex shrink-0 items-center gap-1.5">
+        <div className="flex shrink-0 items-center gap-2">
           <span className="flex gap-1 font-mono text-[10px] text-[color:var(--fg-subtle)]">
-            <span className="rounded bg-white/10 px-1.5 py-0.5">
+            <span className="rounded bg-white/10 px-2 py-0.5">
               {t('badgeProgress', { done: doneCount, total: totalSteps })}
             </span>
           </span>
@@ -157,7 +157,7 @@ export function PlanDagPane({ plan }: Props): React.ReactElement | null {
 
       {/* Step list — the whole body. Ordered, scrollable, shows each goal. */}
       <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="sticky top-0 z-10 bg-[color:var(--bg-inverse)]/95 px-3 py-1.5 text-[10px] font-medium uppercase tracking-wide text-[color:var(--fg-muted)] backdrop-blur">
+        <div className="sticky top-0 z-10 bg-[color:var(--bg-inverse)]/95 px-3 py-2 text-[10px] font-medium uppercase tracking-wide text-[color:var(--fg-muted)] backdrop-blur">
           {t('listHeader', { done: doneCount, total: totalSteps })}
         </div>
         <ul className="flex flex-col">
@@ -165,7 +165,7 @@ export function PlanDagPane({ plan }: Props): React.ReactElement | null {
             <li
               key={s.stepExternalId}
               className={[
-                'flex items-center gap-2.5 border-t border-white/5 px-3 py-2 text-[12px] transition hover:bg-white/5',
+                'flex items-center gap-3 border-t border-white/5 px-3 py-2 text-[12px] transition hover:bg-white/5',
                 s.status === 'in_progress' ? 'bg-[color:var(--warning)]/10' : '',
               ].join(' ')}
             >
@@ -189,7 +189,7 @@ export function PlanDagPane({ plan }: Props): React.ReactElement | null {
                 {s.goal}
               </span>
               <span
-                className="shrink-0 rounded px-1.5 py-0.5 font-mono text-[9px]"
+                className="shrink-0 rounded px-2 py-0.5 font-mono text-[9px]"
                 style={{
                   backgroundColor: `${statusColor(s.status)}26`,
                   color: statusColor(s.status),

--- a/web-ui/app/_components/PlanDagPane.tsx
+++ b/web-ui/app/_components/PlanDagPane.tsx
@@ -166,7 +166,7 @@ export function PlanDagPane({ plan }: Props): React.ReactElement | null {
               key={s.stepExternalId}
               className={[
                 'flex items-center gap-2.5 border-t border-white/5 px-3 py-2 text-[12px] transition hover:bg-white/5',
-                s.status === 'in_progress' ? 'bg-[color:var(--warning)]/100/10' : '',
+                s.status === 'in_progress' ? 'bg-[color:var(--warning)]/10' : '',
               ].join(' ')}
             >
               <span

--- a/web-ui/app/_components/PlanDagPane.tsx
+++ b/web-ui/app/_components/PlanDagPane.tsx
@@ -85,13 +85,13 @@ export function PlanDagPane({ plan }: Props): React.ReactElement | null {
       <button
         type="button"
         onClick={openWindow}
-        className="fixed bottom-6 left-6 z-40 flex items-center gap-2 rounded-full border border-sky-300 bg-white/90 px-4 py-2 text-sm font-medium text-sky-700 shadow-lg backdrop-blur transition hover:bg-white dark:border-sky-700 dark:bg-neutral-900/90 dark:text-sky-300 dark:hover:bg-neutral-900"
+        className="fixed bottom-6 left-6 z-40 flex items-center gap-2 rounded-full border border-[color:var(--accent)] bg-white/90 px-4 py-2 text-sm font-medium text-[color:var(--accent)] shadow-lg backdrop-blur transition hover:bg-[color:var(--bg-elevated)]"
         aria-label={t('openLabel')}
         title={t('openLabel')}
       >
         <GitBranch size={16} aria-hidden />
         {t('openLabel')}
-        <span className="rounded bg-sky-100 px-1.5 py-0.5 font-mono text-[10px] text-sky-700 dark:bg-sky-900/60 dark:text-sky-300">
+        <span className="rounded bg-[color:var(--accent)]/10 px-1.5 py-0.5 font-mono text-[10px] text-[color:var(--accent)]">
           {doneCount}/{totalSteps}
         </span>
       </button>
@@ -102,7 +102,7 @@ export function PlanDagPane({ plan }: Props): React.ReactElement | null {
 
   return (
     <section
-      className="fixed z-50 flex flex-col overflow-hidden rounded-xl border border-neutral-300 bg-neutral-950 text-neutral-200 shadow-2xl dark:border-neutral-700"
+      className="fixed z-50 flex flex-col overflow-hidden rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-inverse)] text-[color:var(--fg-on-dark)] shadow-2xl"
       style={style}
       aria-label={t('title')}
     >
@@ -111,21 +111,21 @@ export function PlanDagPane({ plan }: Props): React.ReactElement | null {
         onPointerMove={headerHandlers.onPointerMove}
         onPointerUp={headerHandlers.onPointerUp}
         className={[
-          'flex items-center justify-between gap-2 border-b border-white/10 bg-neutral-900 px-3 py-2 select-none',
+          'flex items-center justify-between gap-2 border-b border-white/10 bg-[color:var(--bg-inverse)] px-3 py-2 select-none',
           maximized ? '' : 'cursor-move',
         ].join(' ')}
       >
         <div className="flex min-w-0 flex-col gap-0.5">
-          <span className="flex items-center gap-1.5 text-xs font-semibold tracking-wide text-neutral-100">
-            <GitBranch size={13} aria-hidden className="text-sky-400" />
+          <span className="flex items-center gap-1.5 text-xs font-semibold tracking-wide text-[color:var(--fg-on-dark)]">
+            <GitBranch size={13} aria-hidden className="text-[color:var(--accent)]" />
             {t('title')}
           </span>
-          <span className="truncate text-[10px] text-neutral-500">
+          <span className="truncate text-[10px] text-[color:var(--fg-muted)]">
             {t('subtitle')}
           </span>
         </div>
         <div className="flex shrink-0 items-center gap-1.5">
-          <span className="flex gap-1 font-mono text-[10px] text-neutral-400">
+          <span className="flex gap-1 font-mono text-[10px] text-[color:var(--fg-subtle)]">
             <span className="rounded bg-white/10 px-1.5 py-0.5">
               {t('badgeProgress', { done: doneCount, total: totalSteps })}
             </span>
@@ -133,7 +133,7 @@ export function PlanDagPane({ plan }: Props): React.ReactElement | null {
           <button
             type="button"
             onClick={toggleMaximized}
-            className="rounded p-1 text-neutral-400 transition hover:bg-white/10 hover:text-neutral-100"
+            className="rounded p-1 text-[color:var(--fg-subtle)] transition hover:bg-white/10 hover:text-[color:var(--fg-on-dark)]"
             aria-label={maximized ? t('restore') : t('maximize')}
             title={maximized ? t('restore') : t('maximize')}
           >
@@ -146,7 +146,7 @@ export function PlanDagPane({ plan }: Props): React.ReactElement | null {
           <button
             type="button"
             onClick={close}
-            className="rounded p-1 text-neutral-400 transition hover:bg-white/10 hover:text-neutral-100"
+            className="rounded p-1 text-[color:var(--fg-subtle)] transition hover:bg-white/10 hover:text-[color:var(--fg-on-dark)]"
             aria-label={t('close')}
             title={t('close')}
           >
@@ -157,7 +157,7 @@ export function PlanDagPane({ plan }: Props): React.ReactElement | null {
 
       {/* Step list — the whole body. Ordered, scrollable, shows each goal. */}
       <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="sticky top-0 z-10 bg-neutral-950/95 px-3 py-1.5 text-[10px] font-medium uppercase tracking-wide text-neutral-500 backdrop-blur">
+        <div className="sticky top-0 z-10 bg-[color:var(--bg-inverse)]/95 px-3 py-1.5 text-[10px] font-medium uppercase tracking-wide text-[color:var(--fg-muted)] backdrop-blur">
           {t('listHeader', { done: doneCount, total: totalSteps })}
         </div>
         <ul className="flex flex-col">
@@ -166,11 +166,11 @@ export function PlanDagPane({ plan }: Props): React.ReactElement | null {
               key={s.stepExternalId}
               className={[
                 'flex items-center gap-2.5 border-t border-white/5 px-3 py-2 text-[12px] transition hover:bg-white/5',
-                s.status === 'in_progress' ? 'bg-amber-500/10' : '',
+                s.status === 'in_progress' ? 'bg-[color:var(--warning)]/100/10' : '',
               ].join(' ')}
             >
               <span
-                className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full font-mono text-[10px] font-semibold text-neutral-950"
+                className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full font-mono text-[10px] font-semibold text-[color:var(--fg-strong)]"
                 style={{ backgroundColor: statusColor(s.status) }}
               >
                 {s.order + 1}
@@ -179,10 +179,10 @@ export function PlanDagPane({ plan }: Props): React.ReactElement | null {
                 className={[
                   'min-w-0 flex-1 truncate',
                   s.status === 'done'
-                    ? 'text-neutral-400 line-through'
+                    ? 'text-[color:var(--fg-subtle)] line-through'
                     : s.status === 'skipped'
-                      ? 'text-neutral-500'
-                      : 'text-neutral-200',
+                      ? 'text-[color:var(--fg-muted)]'
+                      : 'text-[color:var(--fg-on-dark)]',
                 ].join(' ')}
                 title={s.goal}
               >
@@ -213,7 +213,7 @@ export function PlanDagPane({ plan }: Props): React.ReactElement | null {
         >
           <svg
             viewBox="0 0 10 10"
-            className="h-full w-full text-neutral-500"
+            className="h-full w-full text-[color:var(--fg-muted)]"
             fill="none"
             stroke="currentColor"
             strokeWidth="1"

--- a/web-ui/app/_components/PlanDagPane.tsx
+++ b/web-ui/app/_components/PlanDagPane.tsx
@@ -85,7 +85,7 @@ export function PlanDagPane({ plan }: Props): React.ReactElement | null {
       <button
         type="button"
         onClick={openWindow}
-        className="fixed bottom-6 left-6 z-40 flex items-center gap-2 rounded-full border border-[color:var(--accent)] bg-white/90 px-4 py-2 text-sm font-medium text-[color:var(--accent)] shadow-lg backdrop-blur transition hover:bg-[color:var(--bg-elevated)]"
+        className="fixed bottom-6 left-6 z-40 flex items-center gap-2 rounded-full border border-[color:var(--accent)] bg-[color:var(--bg-elevated)]/90 px-4 py-2 text-sm font-medium text-[color:var(--accent)] shadow-lg backdrop-blur transition hover:bg-[color:var(--bg-elevated)]"
         aria-label={t('openLabel')}
         title={t('openLabel')}
       >

--- a/web-ui/app/_components/SessionWatcher.tsx
+++ b/web-ui/app/_components/SessionWatcher.tsx
@@ -193,7 +193,7 @@ function SessionWarningCard({
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 24 }}
       transition={{ duration: 0.2, ease: 'easeOut' }}
-      className="fixed bottom-5 right-5 z-[90] w-[min(92vw,22rem)] border border-[color:var(--rule-strong)] bg-[color:var(--paper)] p-5 shadow-[0_24px_60px_-20px_rgba(0,0,0,0.45)]"
+      className="fixed bottom-5 right-5 z-[90] w-[min(92vw,22rem)] border border-[color:var(--rule-strong)] bg-[color:var(--paper)] p-4 shadow-[0_24px_60px_-20px_rgba(0,0,0,0.45)]"
     >
       <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.2em] text-[color:var(--accent)]">
         <Clock className="size-3.5" aria-hidden />
@@ -247,7 +247,7 @@ function SessionExpiredOverlay(): React.ReactElement {
         initial={{ opacity: 0, scale: 0.96, y: 8 }}
         animate={{ opacity: 1, scale: 1, y: 0 }}
         transition={{ duration: 0.2, ease: 'easeOut' }}
-        className="relative z-10 w-full max-w-md border border-[color:var(--rule-strong)] bg-[color:var(--paper)] p-7 shadow-[0_30px_80px_-20px_rgba(0,0,0,0.5)]"
+        className="relative z-10 w-full max-w-md border border-[color:var(--rule-strong)] bg-[color:var(--paper)] p-6 shadow-[0_30px_80px_-20px_rgba(0,0,0,0.5)]"
       >
         <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.2em] text-[color:var(--accent)]">
           <Clock className="size-3.5" aria-hidden />
@@ -263,7 +263,7 @@ function SessionExpiredOverlay(): React.ReactElement {
           ref={ctaRef}
           type="button"
           onClick={relogin}
-          className="mt-5 flex w-full items-center justify-center gap-2 border border-[color:var(--ink)] bg-[color:var(--ink)] px-4 py-2.5 text-[12px] uppercase tracking-[0.16em] text-[color:var(--paper)] transition hover:border-[color:var(--accent)] hover:bg-[color:var(--accent)]"
+          className="mt-4 flex w-full items-center justify-center gap-2 border border-[color:var(--ink)] bg-[color:var(--ink)] px-4 py-3 text-[12px] uppercase tracking-[0.16em] text-[color:var(--paper)] transition hover:border-[color:var(--accent)] hover:bg-[color:var(--accent)]"
         >
           <LogIn className="size-3.5" aria-hidden />
           {t('expiredCta')}

--- a/web-ui/app/_components/StreamToasts.tsx
+++ b/web-ui/app/_components/StreamToasts.tsx
@@ -221,7 +221,7 @@ function StreamToast({
             e.stopPropagation();
             setConfirming(true);
           }}
-          className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 px-2 py-1 text-[11px] font-medium text-[color:var(--danger)] transition hover:bg-[color:var(--danger)]/8"
+          className="mt-2 flex w-full items-center justify-center gap-2 rounded-md border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 px-2 py-1 text-[11px] font-medium text-[color:var(--danger)] transition hover:bg-[color:var(--danger)]/8"
         >
           <Ban size={12} aria-hidden />
           {t('abortButton')}
@@ -321,7 +321,7 @@ function AbortConfirmModal({
               e.stopPropagation();
               onCancel();
             }}
-            className="rounded-md border border-[color:var(--border)] px-3 py-1.5 text-xs font-medium text-[color:var(--fg)] transition hover:bg-[color:var(--bg-soft)]"
+            className="rounded-md border border-[color:var(--border)] px-3 py-2 text-xs font-medium text-[color:var(--fg)] transition hover:bg-[color:var(--bg-soft)]"
           >
             {t('abortConfirmKeep')}
           </button>
@@ -331,7 +331,7 @@ function AbortConfirmModal({
               e.stopPropagation();
               onConfirm();
             }}
-            className="rounded-md border border-[color:var(--danger-edge)] bg-transparent px-3 py-1.5 text-xs font-medium text-[color:var(--danger)] transition hover:bg-[color:var(--danger)]/8"
+            className="rounded-md border border-[color:var(--danger-edge)] bg-transparent px-3 py-2 text-xs font-medium text-[color:var(--danger)] transition hover:bg-[color:var(--danger)]/8"
           >
             {t('abortConfirmStop')}
           </button>

--- a/web-ui/app/_components/StreamToasts.tsx
+++ b/web-ui/app/_components/StreamToasts.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslations } from 'next-intl';
 import { AnimatePresence, motion } from 'framer-motion';
-import { Ban, Loader2, X } from 'lucide-react';
+import { Ban, X } from 'lucide-react';
 
 import { useChatSessionsCtx } from '../_lib/chatSessionsContext';
 import {
@@ -145,7 +145,7 @@ function StreamToast({
           {isTerminal ? (
             <span className="text-base leading-none">{palette.symbol}</span>
           ) : (
-            <Loader2 size={14} className="animate-spin" />
+            <span className="lume-busy-dots" aria-hidden />
           )}
         </div>
         <div className="min-w-0 flex-1">
@@ -331,7 +331,7 @@ function AbortConfirmModal({
               e.stopPropagation();
               onConfirm();
             }}
-            className="rounded-md bg-[color:var(--danger)] px-3 py-1.5 text-xs font-medium text-[color:var(--fg-on-dark)] transition hover:bg-[color:var(--danger)]"
+            className="rounded-md border border-[color:var(--danger-edge)] bg-transparent px-3 py-1.5 text-xs font-medium text-[color:var(--danger)] transition hover:bg-[color:var(--danger)]/8"
           >
             {t('abortConfirmStop')}
           </button>

--- a/web-ui/app/_components/StreamToasts.tsx
+++ b/web-ui/app/_components/StreamToasts.tsx
@@ -150,10 +150,10 @@ function StreamToast({
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex items-center justify-between gap-2">
-            <div className="truncate text-xs font-semibold text-neutral-900 dark:text-neutral-100">
+            <div className="truncate text-xs font-semibold text-[color:var(--fg-strong)]">
               {phaseLabel}
               {record.toolName ? (
-                <span className="ml-1 font-mono text-[10px] font-normal text-neutral-500">
+                <span className="ml-1 font-mono text-[10px] font-normal text-[color:var(--fg-muted)]">
                   · {record.toolName}
                 </span>
               ) : null}
@@ -164,7 +164,7 @@ function StreamToast({
                 e.stopPropagation();
                 onDismiss();
               }}
-              className="rounded p-0.5 text-neutral-400 opacity-60 transition hover:bg-neutral-200 hover:text-neutral-700 group-hover:opacity-100 dark:hover:bg-neutral-700 dark:hover:text-neutral-200"
+              className="rounded p-0.5 text-[color:var(--fg-subtle)] opacity-60 transition hover:bg-[color:var(--state-loading)] hover:text-[color:var(--fg)] group-hover:opacity-100"
               aria-label={t('dismissAriaLabel')}
               title={t('dismissTitle')}
             >
@@ -172,11 +172,11 @@ function StreamToast({
             </button>
           </div>
           {record.previewTail && (
-            <div className="mt-1 line-clamp-3 text-[11px] leading-snug text-neutral-600 dark:text-neutral-400">
+            <div className="mt-1 line-clamp-3 text-[11px] leading-snug text-[color:var(--fg-muted)]">
               {record.previewTail}
             </div>
           )}
-          <div className="mt-1 flex items-center gap-2 text-[10px] text-neutral-500 dark:text-neutral-500">
+          <div className="mt-1 flex items-center gap-2 text-[10px] text-[color:var(--fg-muted)]">
             <span>{t('elapsedSec', { sec: elapsedSec })}</span>
             {typeof record.tokensIn === 'number' && record.tokensIn > 0 ? (
               <span
@@ -196,14 +196,14 @@ function StreamToast({
             ) : null}
             {typeof record.cacheTokens === 'number' && record.cacheTokens > 0 ? (
               <span
-                className="font-mono text-emerald-600 dark:text-emerald-400"
+                className="font-mono text-[color:var(--success)]"
                 title={t('cacheHitTitle', { n: record.cacheTokens })}
               >
                 · 🟢 {formatTokenCount(record.cacheTokens)}
               </span>
             ) : null}
             {record.error ? (
-              <span className="truncate text-red-600 dark:text-red-400">
+              <span className="truncate text-[color:var(--danger)]">
                 · {record.error}
               </span>
             ) : null}
@@ -221,7 +221,7 @@ function StreamToast({
             e.stopPropagation();
             setConfirming(true);
           }}
-          className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-md border border-red-200 bg-red-50/60 px-2 py-1 text-[11px] font-medium text-red-700 transition hover:bg-red-100 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300 dark:hover:bg-red-950/70"
+          className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-md border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 px-2 py-1 text-[11px] font-medium text-[color:var(--danger)] transition hover:bg-[color:var(--danger)]/8"
         >
           <Ban size={12} aria-hidden />
           {t('abortButton')}
@@ -276,7 +276,7 @@ function AbortConfirmModal({
 
   return createPortal(
     <motion.div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--bg-modal-overlay)] p-4"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
@@ -292,7 +292,7 @@ function AbortConfirmModal({
         aria-modal="true"
         aria-labelledby="stream-abort-title"
         aria-describedby="stream-abort-body"
-        className="w-full max-w-xs rounded-lg border border-neutral-200 bg-white p-4 shadow-xl dark:border-neutral-700 dark:bg-neutral-900"
+        className="w-full max-w-xs rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-4 shadow-xl"
         initial={{ opacity: 0, scale: 0.95, y: 8 }}
         animate={{ opacity: 1, scale: 1, y: 0 }}
         exit={{ opacity: 0, scale: 0.95, y: 8 }}
@@ -303,13 +303,13 @@ function AbortConfirmModal({
       >
         <h2
           id="stream-abort-title"
-          className="text-sm font-semibold text-neutral-900 dark:text-neutral-100"
+          className="text-sm font-semibold text-[color:var(--fg-strong)]"
         >
           {t('abortConfirmTitle')}
         </h2>
         <p
           id="stream-abort-body"
-          className="mt-1 text-xs leading-snug text-neutral-600 dark:text-neutral-400"
+          className="mt-1 text-xs leading-snug text-[color:var(--fg-muted)]"
         >
           {t('abortConfirmBody')}
         </p>
@@ -321,7 +321,7 @@ function AbortConfirmModal({
               e.stopPropagation();
               onCancel();
             }}
-            className="rounded-md border border-neutral-200 px-3 py-1.5 text-xs font-medium text-neutral-700 transition hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-200 dark:hover:bg-neutral-800"
+            className="rounded-md border border-[color:var(--border)] px-3 py-1.5 text-xs font-medium text-[color:var(--fg)] transition hover:bg-[color:var(--bg-soft)]"
           >
             {t('abortConfirmKeep')}
           </button>
@@ -331,7 +331,7 @@ function AbortConfirmModal({
               e.stopPropagation();
               onConfirm();
             }}
-            className="rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-red-700"
+            className="rounded-md bg-[color:var(--danger)] px-3 py-1.5 text-xs font-medium text-[color:var(--fg-on-dark)] transition hover:bg-[color:var(--danger)]"
           >
             {t('abortConfirmStop')}
           </button>
@@ -396,30 +396,30 @@ function paletteFor(phase: StreamPhase): {
   switch (phase) {
     case 'done':
       return {
-        border: 'border-emerald-300 dark:border-emerald-800',
-        bg: 'bg-emerald-50 dark:bg-emerald-950/60',
-        icon: 'text-emerald-700 dark:text-emerald-400',
+        border: 'border-[color:var(--success)]',
+        bg: 'bg-[color:var(--success)]/10',
+        icon: 'text-[color:var(--success)]',
         symbol: '✓',
       };
     case 'error':
       return {
-        border: 'border-red-300 dark:border-red-800',
-        bg: 'bg-red-50 dark:bg-red-950/60',
-        icon: 'text-red-700 dark:text-red-400',
+        border: 'border-[color:var(--danger-edge)]',
+        bg: 'bg-[color:var(--danger)]/8',
+        icon: 'text-[color:var(--danger)]',
         symbol: '✗',
       };
     case 'aborted':
       return {
-        border: 'border-neutral-300 dark:border-neutral-700',
-        bg: 'bg-neutral-50 dark:bg-neutral-900',
-        icon: 'text-neutral-500',
+        border: 'border-[color:var(--border)]',
+        bg: 'bg-[color:var(--bg-soft)]',
+        icon: 'text-[color:var(--fg-muted)]',
         symbol: '⏹',
       };
     default:
       return {
-        border: 'border-indigo-200 dark:border-indigo-800',
-        bg: 'bg-white dark:bg-neutral-900',
-        icon: 'text-indigo-600 dark:text-indigo-400',
+        border: 'border-[color:var(--accent)]',
+        bg: 'bg-[color:var(--bg-elevated)]',
+        icon: 'text-[color:var(--accent)]',
         symbol: '…',
       };
   }

--- a/web-ui/app/_components/ThemeControls.tsx
+++ b/web-ui/app/_components/ThemeControls.tsx
@@ -65,7 +65,12 @@ export function ThemeControls(): React.ReactElement {
   const theme = useSyncExternalStore(subscribeToRootAttrs, readTheme, () => 'system' as const);
 
   function applyPalette(next: PaletteName): void {
-    document.documentElement.setAttribute('data-palette', next);
+    const root = document.documentElement;
+    // §6.6: palette changes crossfade over motion.smooth. The transient class
+    // gates the typed-property transition so theme switches stay instant.
+    root.classList.add('lume-xfade');
+    root.setAttribute('data-palette', next);
+    window.setTimeout(() => root.classList.remove('lume-xfade'), 280);
     try {
       localStorage.setItem(PALETTE_KEY, next);
     } catch {

--- a/web-ui/app/_components/ThemeControls.tsx
+++ b/web-ui/app/_components/ThemeControls.tsx
@@ -2,7 +2,7 @@
 
 import { Moon, Palette, Sun } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useState } from 'react';
+import { useSyncExternalStore } from 'react';
 
 /**
  * Lume palette + appearance controls (issue #282).
@@ -12,12 +12,15 @@ import { useState } from 'react';
  * Appearance pins light/dark (or follows the OS) via `data-theme`, which flips
  * the `color-scheme` that the token layer's `light-dark()` resolves against.
  *
- * Both persist to localStorage; the pre-paint bootstrap script in layout.tsx
- * replays them before first paint so there is no flash.
+ * The <html> attributes are the single source of truth: the pre-paint
+ * bootstrap script in layout.tsx seeds them from localStorage before first
+ * paint (no FOUC), and the selects read them via useSyncExternalStore — so
+ * SSR renders the defaults and React reconciles to the real value right
+ * after hydration (no suppressed-mismatch staleness).
  */
 
 const PALETTES = ['lagoon', 'petrol', 'atelier'] as const;
-type Palette = (typeof PALETTES)[number];
+type PaletteName = (typeof PALETTES)[number];
 
 const THEMES = ['system', 'light', 'dark'] as const;
 type Theme = (typeof THEMES)[number];
@@ -25,11 +28,30 @@ type Theme = (typeof THEMES)[number];
 const PALETTE_KEY = 'omadia-palette';
 const THEME_KEY = 'omadia-theme';
 
-function isPalette(v: string | null): v is Palette {
+function isPalette(v: string | null): v is PaletteName {
   return v === 'lagoon' || v === 'petrol' || v === 'atelier';
 }
 function isTheme(v: string | null): v is Theme {
   return v === 'system' || v === 'light' || v === 'dark';
+}
+
+/** Re-render whenever the <html> theme attributes change. */
+function subscribeToRootAttrs(onChange: () => void): () => void {
+  const observer = new MutationObserver(onChange);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-palette', 'data-theme'],
+  });
+  return () => observer.disconnect();
+}
+
+function readPalette(): PaletteName {
+  const v = document.documentElement.getAttribute('data-palette');
+  return isPalette(v) ? v : 'lagoon';
+}
+function readTheme(): Theme {
+  const v = document.documentElement.getAttribute('data-theme');
+  return isTheme(v) ? v : 'system';
 }
 
 const selectClass =
@@ -39,24 +61,10 @@ const selectClass =
 
 export function ThemeControls(): React.ReactElement {
   const t = useTranslations('themeControls');
-  // Initialise from the attributes the pre-paint bootstrap script set on
-  // <html> (client), or fall back to the defaults during SSR. The <select>s
-  // carry suppressHydrationWarning so a client value differing from the SSR
-  // default doesn't warn.
-  const [palette, setPalette] = useState<Palette>(() => {
-    if (typeof document === 'undefined') return 'lagoon';
-    const p = document.documentElement.getAttribute('data-palette');
-    return isPalette(p) ? p : 'lagoon';
-  });
-  const [theme, setTheme] = useState<Theme>(() => {
-    if (typeof document === 'undefined') return 'system';
-    // bootstrap sets data-theme only for an explicit light/dark pin; absent => system.
-    const attr = document.documentElement.getAttribute('data-theme');
-    return isTheme(attr) ? attr : 'system';
-  });
+  const palette = useSyncExternalStore(subscribeToRootAttrs, readPalette, () => 'lagoon' as const);
+  const theme = useSyncExternalStore(subscribeToRootAttrs, readTheme, () => 'system' as const);
 
-  function applyPalette(next: Palette): void {
-    setPalette(next);
+  function applyPalette(next: PaletteName): void {
     document.documentElement.setAttribute('data-palette', next);
     try {
       localStorage.setItem(PALETTE_KEY, next);
@@ -66,7 +74,6 @@ export function ThemeControls(): React.ReactElement {
   }
 
   function applyTheme(next: Theme): void {
-    setTheme(next);
     const root = document.documentElement;
     if (next === 'system') {
       root.removeAttribute('data-theme');
@@ -89,9 +96,8 @@ export function ThemeControls(): React.ReactElement {
         />
         <select
           value={palette}
-          onChange={(e) => applyPalette(e.target.value as Palette)}
+          onChange={(e) => applyPalette(e.target.value as PaletteName)}
           className={selectClass}
-          suppressHydrationWarning
         >
           {PALETTES.map((p) => (
             <option
@@ -121,7 +127,6 @@ export function ThemeControls(): React.ReactElement {
           value={theme}
           onChange={(e) => applyTheme(e.target.value as Theme)}
           className={selectClass}
-          suppressHydrationWarning
         >
           {THEMES.map((m) => (
             <option

--- a/web-ui/app/_components/ThemeControls.tsx
+++ b/web-ui/app/_components/ThemeControls.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { Moon, Palette, Sun } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useState } from 'react';
+
+/**
+ * Lume palette + appearance controls (issue #282).
+ *
+ * Palette binds one of the three Lume accent palettes (Petrol, Atelier,
+ * Lagoon — spec §2.5) to the single accent slot via `data-palette` on <html>.
+ * Appearance pins light/dark (or follows the OS) via `data-theme`, which flips
+ * the `color-scheme` that the token layer's `light-dark()` resolves against.
+ *
+ * Both persist to localStorage; the pre-paint bootstrap script in layout.tsx
+ * replays them before first paint so there is no flash.
+ */
+
+const PALETTES = ['lagoon', 'petrol', 'atelier'] as const;
+type Palette = (typeof PALETTES)[number];
+
+const THEMES = ['system', 'light', 'dark'] as const;
+type Theme = (typeof THEMES)[number];
+
+const PALETTE_KEY = 'omadia-palette';
+const THEME_KEY = 'omadia-theme';
+
+function isPalette(v: string | null): v is Palette {
+  return v === 'lagoon' || v === 'petrol' || v === 'atelier';
+}
+function isTheme(v: string | null): v is Theme {
+  return v === 'system' || v === 'light' || v === 'dark';
+}
+
+const selectClass =
+  'appearance-none rounded-md border border-[color:var(--border)] bg-transparent py-1 pl-6 pr-2 text-xs ' +
+  'text-[color:var(--fg-muted)] outline-none transition-colors hover:text-[color:var(--fg-strong)] ' +
+  'focus:border-[color:var(--accent)] focus-visible:border-[color:var(--accent)]';
+
+export function ThemeControls(): React.ReactElement {
+  const t = useTranslations('themeControls');
+  // Initialise from the attributes the pre-paint bootstrap script set on
+  // <html> (client), or fall back to the defaults during SSR. The <select>s
+  // carry suppressHydrationWarning so a client value differing from the SSR
+  // default doesn't warn.
+  const [palette, setPalette] = useState<Palette>(() => {
+    if (typeof document === 'undefined') return 'lagoon';
+    const p = document.documentElement.getAttribute('data-palette');
+    return isPalette(p) ? p : 'lagoon';
+  });
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof document === 'undefined') return 'system';
+    // bootstrap sets data-theme only for an explicit light/dark pin; absent => system.
+    const attr = document.documentElement.getAttribute('data-theme');
+    return isTheme(attr) ? attr : 'system';
+  });
+
+  function applyPalette(next: Palette): void {
+    setPalette(next);
+    document.documentElement.setAttribute('data-palette', next);
+    try {
+      localStorage.setItem(PALETTE_KEY, next);
+    } catch {
+      /* storage unavailable — selection still applies for this session */
+    }
+  }
+
+  function applyTheme(next: Theme): void {
+    setTheme(next);
+    const root = document.documentElement;
+    if (next === 'system') {
+      root.removeAttribute('data-theme');
+    } else {
+      root.setAttribute('data-theme', next);
+    }
+    try {
+      localStorage.setItem(THEME_KEY, next);
+    } catch {
+      /* storage unavailable */
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <label className="relative inline-flex items-center" aria-label={t('paletteAriaLabel')}>
+        <Palette
+          className="pointer-events-none absolute left-1.5 h-3.5 w-3.5 text-[color:var(--fg-subtle)]"
+          aria-hidden
+        />
+        <select
+          value={palette}
+          onChange={(e) => applyPalette(e.target.value as Palette)}
+          className={selectClass}
+          suppressHydrationWarning
+        >
+          {PALETTES.map((p) => (
+            <option
+              key={p}
+              value={p}
+              className="bg-[color:var(--bg-elevated)] text-[color:var(--fg)]"
+            >
+              {t(`palette.${p}`)}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="relative inline-flex items-center" aria-label={t('appearanceAriaLabel')}>
+        {theme === 'dark' ? (
+          <Moon
+            className="pointer-events-none absolute left-1.5 h-3.5 w-3.5 text-[color:var(--fg-subtle)]"
+            aria-hidden
+          />
+        ) : (
+          <Sun
+            className="pointer-events-none absolute left-1.5 h-3.5 w-3.5 text-[color:var(--fg-subtle)]"
+            aria-hidden
+          />
+        )}
+        <select
+          value={theme}
+          onChange={(e) => applyTheme(e.target.value as Theme)}
+          className={selectClass}
+          suppressHydrationWarning
+        >
+          {THEMES.map((m) => (
+            <option
+              key={m}
+              value={m}
+              className="bg-[color:var(--bg-elevated)] text-[color:var(--fg)]"
+            >
+              {t(`appearance.${m}`)}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/web-ui/app/_components/__tests__/Markdown.test.tsx
+++ b/web-ui/app/_components/__tests__/Markdown.test.tsx
@@ -16,7 +16,7 @@ describe('<Markdown /> — Privacy Shield v4 highlight', () => {
         highlightTerms={['Marvin Vomberg']}
       />,
     );
-    const hit = container.querySelector('span.bg-violet-100');
+    const hit = container.querySelector('span[class*="bg-[color:var(--accent)]/10"]');
     expect(hit).not.toBeNull();
     expect(hit?.textContent).toBe('Marvin Vomberg');
   });
@@ -25,7 +25,7 @@ describe('<Markdown /> — Privacy Shield v4 highlight', () => {
     const { container } = render(
       <Markdown source={'Marvin Vomberg steht hier.'} />,
     );
-    expect(container.querySelector('span.bg-violet-100')).toBeNull();
+    expect(container.querySelector('span[class*="bg-[color:var(--accent)]/10"]')).toBeNull();
     expect(container.textContent).toContain('Marvin Vomberg steht hier.');
   });
 
@@ -36,7 +36,7 @@ describe('<Markdown /> — Privacy Shield v4 highlight', () => {
         highlightTerms={['Anna Rüsche']}
       />,
     );
-    expect(container.querySelectorAll('span.bg-violet-100').length).toBe(2);
+    expect(container.querySelectorAll('span[class*="bg-[color:var(--accent)]/10"]').length).toBe(2);
     expect(container.textContent).toContain('aber nicht Bob.');
   });
 
@@ -44,6 +44,6 @@ describe('<Markdown /> — Privacy Shield v4 highlight', () => {
     const { container } = render(
       <Markdown source={'Some answer text.'} highlightTerms={['', '  ']} />,
     );
-    expect(container.querySelector('span.bg-violet-100')).toBeNull();
+    expect(container.querySelector('span[class*="bg-[color:var(--accent)]/10"]')).toBeNull();
   });
 });

--- a/web-ui/app/_components/chat/AgentDetailsModal.tsx
+++ b/web-ui/app/_components/chat/AgentDetailsModal.tsx
@@ -64,7 +64,7 @@ export function AgentDetailsModal({
             type="button"
             onClick={onClose}
             aria-label={t('ariaCloseBackdrop')}
-            className="absolute inset-0 bg-black/45 backdrop-blur-[2px]"
+            className="absolute inset-0 bg-[color:var(--bg-modal-overlay)] backdrop-blur-[2px]"
             variants={BACKDROP_VARIANTS}
             transition={TRANSITION_FAST}
           />
@@ -74,20 +74,20 @@ export function AgentDetailsModal({
             transition={TRANSITION_BASE}
             className={cn(
               'relative z-10 flex max-h-[85vh] w-full max-w-2xl flex-col',
-              'rounded-t-[22px] sm:rounded-[22px]',
-              'bg-white text-[#004B73]',
-              'shadow-[0_18px_40px_rgba(0,75,115,0.20)]',
+              'rounded-t-lg sm:rounded-lg',
+              'bg-[color:var(--bg-elevated)] text-[color:var(--fg)]',
+              'shadow-[var(--shadow-lg)]',
             )}
           >
-            <header className="flex items-start justify-between gap-4 border-b border-[#D3DDE5] px-6 py-5">
+            <header className="flex items-start justify-between gap-4 border-b border-[color:var(--border)] px-6 py-5">
               <div>
-                <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-[#8A99A6]">
+                <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-[color:var(--fg-subtle)]">
                   {t('agentLabel')}
                 </div>
-                <h3 className="font-display mt-1 text-[26px] leading-[1.1] text-[#004B73]">
+                <h3 className="font-display mt-1 text-[26px] leading-[1.1] text-[color:var(--fg-strong)]">
                   {agent.label}
                 </h3>
-                <p className="font-mono-num mt-1 text-[11px] text-[#5F6E7B]">
+                <p className="font-mono-num mt-1 text-[11px] text-[color:var(--fg-muted)]">
                   {agent.id} · {t('callCount', { count: calls.length })}
                 </p>
               </div>
@@ -95,7 +95,7 @@ export function AgentDetailsModal({
                 type="button"
                 onClick={onClose}
                 aria-label={t('ariaClose')}
-                className="rounded-full p-2 text-[#5F6E7B] transition-colors duration-[140ms] ease-[cubic-bezier(0.22,0.61,0.36,1)] hover:bg-[#F4F7FA] hover:text-[#004B73]"
+                className="rounded-full p-2 text-[color:var(--fg-muted)] transition-colors duration-[100ms] ease-[var(--easing-standard)] hover:bg-[color:var(--bg-soft)] hover:text-[color:var(--fg-strong)]"
               >
                 <X className="size-4" aria-hidden />
               </button>
@@ -103,7 +103,7 @@ export function AgentDetailsModal({
 
             <div className="flex-1 overflow-y-auto px-6 py-5">
               {calls.length === 0 ? (
-                <p className="text-sm italic text-[#5F6E7B]">
+                <p className="text-sm italic text-[color:var(--fg-muted)]">
                   {t('noCallsInSession')}
                 </p>
               ) : (
@@ -119,15 +119,15 @@ export function AgentDetailsModal({
               )}
             </div>
 
-            <footer className="flex items-center justify-between gap-3 border-t border-[#D3DDE5] bg-[#F4F7FA] px-6 py-3">
-              <p className="text-[11px] leading-relaxed text-[#5F6E7B]">
+            <footer className="flex items-center justify-between gap-3 border-t border-[color:var(--border)] bg-[color:var(--bg-soft)] px-6 py-3">
+              <p className="text-[11px] leading-relaxed text-[color:var(--fg-muted)]">
                 <span className="b5-colon">:</span>
                 {t('footerNote')}
               </p>
               <button
                 type="button"
                 onClick={onClose}
-                className="rounded-full px-4 py-1.5 text-[12px] font-semibold text-[#004B73] transition-colors duration-[140ms] ease-[cubic-bezier(0.22,0.61,0.36,1)] hover:bg-white"
+                className="rounded-full px-4 py-1.5 text-[12px] font-semibold text-[color:var(--fg-strong)] transition-colors duration-[100ms] ease-[var(--easing-standard)] hover:bg-[color:var(--bg-elevated)]"
               >
                 {t('closeButton')}
               </button>
@@ -203,29 +203,29 @@ function ToolCallRow({
   const outputPreview = formatOutputPreview(event.output);
 
   return (
-    <li className="rounded-[14px] border border-[#E8EEF3] bg-[#F4F7FA] p-4">
+    <li className="rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-soft)] p-4">
       <header className="flex items-center gap-3">
-        <span className="font-mono-num inline-flex size-6 items-center justify-center rounded-full bg-white text-[10px] font-semibold text-[#004B73]">
+        <span className="font-mono-num inline-flex size-6 items-center justify-center rounded-full bg-[color:var(--bg-elevated)] text-[10px] font-semibold text-[color:var(--fg-strong)]">
           {index}
         </span>
-        <span className="font-mono-num text-[12px] text-[#004B73]">
+        <span className="font-mono-num text-[12px] text-[color:var(--fg-strong)]">
           {event.name}
         </span>
-        <span className="font-mono-num text-[10px] text-[#8A99A6]">
+        <span className="font-mono-num text-[10px] text-[color:var(--fg-subtle)]">
           {relativeLabel}
         </span>
         <span className="ml-auto flex items-center gap-2">
           {event.isError ? (
-            <span className="rounded-full bg-[#D9354C]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-[#D9354C]">
+            <span className="rounded-full bg-[color:var(--danger)]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--danger)]">
               {t('statusError')}
             </span>
           ) : (
-            <span className="rounded-full bg-[#15A06B]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-[#15A06B]">
+            <span className="rounded-full bg-[color:var(--success)]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--success)]">
               {t('statusOk')}
             </span>
           )}
           {typeof event.durationMs === 'number' ? (
-            <span className="font-mono-num text-[10px] text-[#5F6E7B]">
+            <span className="font-mono-num text-[10px] text-[color:var(--fg-muted)]">
               {formatMs(event.durationMs)}
             </span>
           ) : null}
@@ -234,10 +234,10 @@ function ToolCallRow({
 
       {inputPreview ? (
         <div className="mt-3">
-          <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#8A99A6]">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--fg-subtle)]">
             {t('inputLabel')}
           </div>
-          <pre className="font-mono-num mt-1 max-h-32 overflow-auto whitespace-pre-wrap break-words rounded-[8px] bg-white p-2 text-[11px] leading-relaxed text-[#283540]">
+          <pre className="font-mono-num mt-1 max-h-32 overflow-auto whitespace-pre-wrap break-words rounded-md bg-[color:var(--bg-elevated)] p-2 text-[11px] leading-relaxed text-[color:var(--fg)]">
             {inputPreview}
           </pre>
         </div>
@@ -245,17 +245,17 @@ function ToolCallRow({
 
       {outputPreview ? (
         <div className="mt-3">
-          <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[#8A99A6]">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--fg-subtle)]">
             {t('outputLabel')}
           </div>
-          <pre className="font-mono-num mt-1 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-[8px] bg-white p-2 text-[11px] leading-relaxed text-[#283540]">
+          <pre className="font-mono-num mt-1 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md bg-[color:var(--bg-elevated)] p-2 text-[11px] leading-relaxed text-[color:var(--fg)]">
             {outputPreview}
           </pre>
         </div>
       ) : null}
 
       {event.subEvents && event.subEvents.length > 0 ? (
-        <div className="mt-3 text-[11px] text-[#5F6E7B]">
+        <div className="mt-3 text-[11px] text-[color:var(--fg-muted)]">
           <span className="b5-colon">:</span>
           {t('subIterations', { count: event.subEvents.length })}
         </div>

--- a/web-ui/app/_components/chat/AgentDetailsModal.tsx
+++ b/web-ui/app/_components/chat/AgentDetailsModal.tsx
@@ -79,7 +79,7 @@ export function AgentDetailsModal({
               'shadow-[var(--shadow-lg)]',
             )}
           >
-            <header className="flex items-start justify-between gap-4 border-b border-[color:var(--border)] px-6 py-5">
+            <header className="flex items-start justify-between gap-4 border-b border-[color:var(--border)] px-6 py-4">
               <div>
                 <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-[color:var(--fg-subtle)]">
                   {t('agentLabel')}
@@ -101,7 +101,7 @@ export function AgentDetailsModal({
               </button>
             </header>
 
-            <div className="flex-1 overflow-y-auto px-6 py-5">
+            <div className="flex-1 overflow-y-auto px-6 py-4">
               {calls.length === 0 ? (
                 <p className="text-sm italic text-[color:var(--fg-muted)]">
                   {t('noCallsInSession')}
@@ -126,7 +126,7 @@ export function AgentDetailsModal({
               <button
                 type="button"
                 onClick={onClose}
-                className="rounded-full px-4 py-1.5 text-[12px] font-semibold text-[color:var(--fg-strong)] transition-colors duration-[100ms] ease-[var(--easing-standard)] hover:bg-[color:var(--bg-elevated)]"
+                className="rounded-full px-4 py-2 text-[12px] font-semibold text-[color:var(--fg-strong)] transition-colors duration-[100ms] ease-[var(--easing-standard)] hover:bg-[color:var(--bg-elevated)]"
               >
                 {t('closeButton')}
               </button>

--- a/web-ui/app/_components/chat/AgentDetailsModal.tsx
+++ b/web-ui/app/_components/chat/AgentDetailsModal.tsx
@@ -215,11 +215,11 @@ function ToolCallRow({
         </span>
         <span className="ml-auto flex items-center gap-2">
           {event.isError ? (
-            <span className="rounded-full bg-[color:var(--danger)]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--danger)]">
+            <span className="px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--danger)]">
               {t('statusError')}
             </span>
           ) : (
-            <span className="rounded-full bg-[color:var(--success)]/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--success)]">
+            <span className="px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--success)]">
               {t('statusOk')}
             </span>
           )}

--- a/web-ui/app/_components/chat/AgentDetailsModal.tsx
+++ b/web-ui/app/_components/chat/AgentDetailsModal.tsx
@@ -121,8 +121,7 @@ export function AgentDetailsModal({
 
             <footer className="flex items-center justify-between gap-3 border-t border-[color:var(--border)] bg-[color:var(--bg-soft)] px-6 py-3">
               <p className="text-[11px] leading-relaxed text-[color:var(--fg-muted)]">
-                <span className="b5-colon">:</span>
-                {t('footerNote')}
+                                {t('footerNote')}
               </p>
               <button
                 type="button"
@@ -256,8 +255,7 @@ function ToolCallRow({
 
       {event.subEvents && event.subEvents.length > 0 ? (
         <div className="mt-3 text-[11px] text-[color:var(--fg-muted)]">
-          <span className="b5-colon">:</span>
-          {t('subIterations', { count: event.subEvents.length })}
+                    {t('subIterations', { count: event.subEvents.length })}
         </div>
       ) : null}
     </li>

--- a/web-ui/app/_components/chat/AgentUsagePills.tsx
+++ b/web-ui/app/_components/chat/AgentUsagePills.tsx
@@ -46,7 +46,7 @@ export function AgentUsagePills({
     <>
       <motion.div
         className={cn(
-          'flex flex-wrap items-center gap-1.5',
+          'flex flex-wrap items-center gap-2',
           className,
         )}
         aria-label={t('ariaLabel')}
@@ -73,7 +73,7 @@ export function AgentUsagePills({
               onClick={() => setSelectedAgentId(agent.id)}
               title={t('pillTitle', { id: agent.id })}
               className={cn(
-                'inline-flex items-center gap-1.5 rounded-full px-3 py-1',
+                'inline-flex items-center gap-2 rounded-full px-3 py-1',
                 'text-[11px] font-semibold',
                 'focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--bg)]',
                 TONE_CLASS[agent.tone],
@@ -82,7 +82,7 @@ export function AgentUsagePills({
               <span>{agent.label}</span>
               <span
                 className={cn(
-                  'font-mono-num tabular-nums inline-flex min-w-[1.25rem] justify-center rounded-full px-1.5',
+                  'font-mono-num tabular-nums inline-flex min-w-[1.25rem] justify-center rounded-full px-2',
                   'bg-[color:var(--accent)] text-[color:var(--accent-fg)] text-[10px] leading-[1.1rem]',
                 )}
               >

--- a/web-ui/app/_components/chat/AgentUsagePills.tsx
+++ b/web-ui/app/_components/chat/AgentUsagePills.tsx
@@ -74,8 +74,8 @@ export function AgentUsagePills({
               title={t('pillTitle', { id: agent.id })}
               className={cn(
                 'inline-flex items-center gap-1.5 rounded-full px-3 py-1',
-                'text-[11px] font-semibold text-white',
-                'focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--bg)]',
+                'text-[11px] font-semibold',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--bg)]',
                 TONE_CLASS[agent.tone],
               )}
             >
@@ -83,7 +83,7 @@ export function AgentUsagePills({
               <span
                 className={cn(
                   'font-mono-num tabular-nums inline-flex min-w-[1.25rem] justify-center rounded-full px-1.5',
-                  'bg-white/25 text-white text-[10px] leading-[1.1rem]',
+                  'bg-[color:var(--accent)] text-[color:var(--accent-fg)] text-[10px] leading-[1.1rem]',
                 )}
               >
                 {count}
@@ -147,14 +147,21 @@ function collectToolNames(rows: AggregateRow[], agentId: string): string[] {
 }
 
 // ---------------------------------------------------------------------------
-// byte5 brand solid fills — fixed hex so contrast stays correct in dark mode
+// Lume pill fill — single accent material (spec §2.5). Lume has one accent
+// slot, so agents differentiate by label, not by hue. Every tone resolves to
+// the same accent-subtle chip with an accent-tinted glow on hover; the chip
+// follows the active palette + light/dark mode through the token layer.
 // ---------------------------------------------------------------------------
 
+const LUME_PILL =
+  'bg-[color:var(--accent-subtle)] text-[color:var(--accent)] ' +
+  'hover:shadow-[0_0_4px_var(--accent-glow-core),0_4px_12px_var(--accent-glow)]';
+
 const TONE_CLASS: Record<AgentMeta['tone'], string> = {
-  cyan:    'bg-[#009FE3] hover:bg-[#0086C0] shadow-[0_6px_16px_rgba(0,159,227,0.25)]',
-  navy:    'bg-[#004B73] hover:bg-[#003957] shadow-[0_6px_16px_rgba(0,75,115,0.22)]',
-  magenta: 'bg-[#EA5172] hover:bg-[#D43A5C] shadow-[0_6px_16px_rgba(234,81,114,0.25)]',
-  warning: 'bg-[#E0A82E] hover:bg-[#C6921F] shadow-[0_6px_16px_rgba(224,168,46,0.25)]',
+  cyan: LUME_PILL,
+  navy: LUME_PILL,
+  magenta: LUME_PILL,
+  warning: LUME_PILL,
 };
 
 // ---------------------------------------------------------------------------

--- a/web-ui/app/_components/chat/AutoPromotedBanner.tsx
+++ b/web-ui/app/_components/chat/AutoPromotedBanner.tsx
@@ -67,7 +67,7 @@ export function AutoPromotedBanner({
   }, [mkId, t, onDiscarded]);
 
   return (
-    <span className="ml-3 inline-flex items-center gap-2 rounded border border-green-300 bg-green-50 px-2 py-0.5 text-[11px] text-green-800 dark:border-green-800 dark:bg-green-900/30 dark:text-green-200">
+    <span className="ml-3 inline-flex items-center gap-2 rounded border border-[color:var(--success)] bg-[color:var(--success)]/10 px-2 py-0.5 text-[11px] text-[color:var(--success)]">
       <span aria-hidden>✓</span>
       <span>{t('label', { kind: t(`kind.${kind}`) })}</span>
       <span className="font-mono text-[10px] opacity-60" title={mkId}>
@@ -75,7 +75,7 @@ export function AutoPromotedBanner({
       </span>
       <a
         href={`/memories/${encodeURIComponent(mkId)}`}
-        className="rounded border border-green-300 px-1 py-0.5 text-[10px] hover:bg-green-100 dark:border-green-700 dark:hover:bg-green-900/40"
+        className="rounded border border-[color:var(--success)] px-1 py-0.5 text-[10px] hover:bg-[color:var(--success)]/10"
         title={t('viewTitle')}
       >
         {t('view')}
@@ -84,13 +84,13 @@ export function AutoPromotedBanner({
         type="button"
         onClick={() => void discard()}
         disabled={busy}
-        className="rounded border border-red-300 px-1 py-0.5 text-[10px] text-red-700 hover:bg-red-50 disabled:opacity-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
+        className="rounded border border-[color:var(--danger-edge)] px-1 py-0.5 text-[10px] text-[color:var(--danger)] hover:bg-[color:var(--danger)]/8 disabled:opacity-50"
         title={t('discardTitle')}
       >
         {busy ? t('discarding') : t('discard')}
       </button>
       {error !== null && (
-        <span className="text-red-600 dark:text-red-400">⚠ {error}</span>
+        <span className="text-[color:var(--danger)]">⚠ {error}</span>
       )}
     </span>
   );

--- a/web-ui/app/_components/chat/CaptureDisclosure.tsx
+++ b/web-ui/app/_components/chat/CaptureDisclosure.tsx
@@ -30,19 +30,19 @@ export function CaptureDisclosure({
   return (
     <details
       className={[
-        'mt-2 rounded bg-emerald-50/60 text-xs ring-1 ring-emerald-100',
-        'dark:bg-emerald-950/30 dark:ring-emerald-900/60',
+        'mt-2 rounded bg-[color:var(--success)]/10 text-xs ring-1 ring-[color:var(--success)]',
+        '',
         className ?? '',
       ].join(' ')}
     >
-      <summary className="cursor-pointer select-none px-2 py-1 font-medium text-emerald-800 dark:text-emerald-200">
+      <summary className="cursor-pointer select-none px-2 py-1 font-medium text-[color:var(--success)]">
         🧠 Memory-Auswirkung · {summary}
       </summary>
-      <div className="space-y-2 px-2 pb-2 pt-1 text-emerald-900 dark:text-emerald-100">
+      <div className="space-y-2 px-2 pb-2 pt-1 text-[color:var(--success)]">
         <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1">
           {facts.map((fact) => (
             <div key={fact.title} className="contents">
-              <dt className="text-[10px] font-semibold uppercase tracking-wider text-emerald-700/80 dark:text-emerald-300/80">
+              <dt className="text-[10px] font-semibold uppercase tracking-wider text-[color:var(--success)]/80">
                 {fact.title}
               </dt>
               <dd className="font-mono-num tabular-nums">{fact.value}</dd>
@@ -51,14 +51,14 @@ export function CaptureDisclosure({
         </dl>
         {disclosure.reasons.length > 0 && (
           <div>
-            <div className="text-[10px] font-semibold uppercase tracking-wider text-emerald-700/80 dark:text-emerald-300/80">
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-[color:var(--success)]/80">
               Begründung
             </div>
             <ul className="mt-1 space-y-0.5">
               {disclosure.reasons.map((reason, i) => (
                 <li
                   key={`${reason}-${String(i)}`}
-                  className="font-mono text-[11px] text-emerald-900/80 dark:text-emerald-200/90"
+                  className="font-mono text-[11px] text-[color:var(--success)]/80"
                 >
                   • {reason}
                 </li>
@@ -68,14 +68,14 @@ export function CaptureDisclosure({
         )}
         {disclosure.graphRefs && disclosure.graphRefs.entityNodeIds.length > 0 && (
           <div>
-            <div className="text-[10px] font-semibold uppercase tracking-wider text-emerald-700/80 dark:text-emerald-300/80">
+            <div className="text-[10px] font-semibold uppercase tracking-wider text-[color:var(--success)]/80">
               Verknüpfte Entitäten ({disclosure.graphRefs.entityNodeIds.length})
             </div>
             <ul className="mt-1 max-h-32 space-y-0.5 overflow-y-auto">
               {disclosure.graphRefs.entityNodeIds.map((id) => (
                 <li
                   key={id}
-                  className="font-mono text-[11px] text-emerald-900/80 dark:text-emerald-200/90"
+                  className="font-mono text-[11px] text-[color:var(--success)]/80"
                 >
                   • {id}
                 </li>

--- a/web-ui/app/_components/chat/NudgeCard.tsx
+++ b/web-ui/app/_components/chat/NudgeCard.tsx
@@ -110,19 +110,19 @@ export function NudgeCard({
   return (
     <div
       className={[
-        'mt-2 rounded-md border bg-amber-50/70 px-3 py-2 text-[12px]',
-        'border-amber-200 ring-1 ring-amber-100',
-        'dark:border-amber-900/60 dark:bg-amber-950/30 dark:ring-amber-900/40',
+        'mt-2 rounded-md border bg-[color:var(--warning)]/10 px-3 py-2 text-[12px]',
+        'border-[color:var(--warning)] ring-1 ring-[color:var(--warning)]',
+        '',
       ].join(' ')}
     >
-      <div className="mb-1 flex items-center gap-1 text-[11px] font-semibold tracking-wide text-amber-700 uppercase dark:text-amber-300">
+      <div className="mb-1 flex items-center gap-1 text-[11px] font-semibold tracking-wide text-[color:var(--warning)] uppercase">
         <span>💡</span>
         <span>{t('kicker')}</span>
-        <span className="ml-auto font-mono text-[10px] font-normal text-amber-600/80 dark:text-amber-400/80">
+        <span className="ml-auto font-mono text-[10px] font-normal text-[color:var(--warning)]/80">
           {nudge.id}
         </span>
       </div>
-      <p className="whitespace-pre-wrap text-amber-900 dark:text-amber-100">
+      <p className="whitespace-pre-wrap text-[color:var(--warning)]">
         {nudge.text}
       </p>
       <div className="mt-2 flex items-center gap-2">
@@ -136,9 +136,9 @@ export function NudgeCard({
               onCtaClick?.(nudge.cta);
             }}
             className={[
-              'rounded bg-amber-600 px-2 py-1 text-[11px] font-medium text-white',
-              'transition-colors hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60',
-              'dark:bg-amber-500 dark:hover:bg-amber-400',
+              'rounded bg-[color:var(--warning)] px-2 py-1 text-[11px] font-medium text-[color:var(--fg-on-dark)]',
+              'transition-colors hover:bg-[color:var(--warning)] disabled:cursor-not-allowed disabled:opacity-60',
+              '',
             ].join(' ')}
           >
             {acknowledged ? t('ackTriggered') : nudge.cta.label}
@@ -147,13 +147,13 @@ export function NudgeCard({
         <button
           type="button"
           onClick={() => onSuppressClick?.(nudge.id)}
-          className="text-[11px] text-amber-700 underline-offset-2 hover:underline dark:text-amber-300"
+          className="text-[11px] text-[color:var(--warning)] underline-offset-2 hover:underline"
         >
           {t('suppress')}
         </button>
         {nudge.cta ? (
           <span
-            className="ml-auto truncate font-mono text-[10px] text-amber-600/80 dark:text-amber-400/80"
+            className="ml-auto truncate font-mono text-[10px] text-[color:var(--warning)]/80"
             title={`${nudge.cta.toolName}(${JSON.stringify(nudge.cta.args)})`}
           >
             → {nudge.cta.toolName}

--- a/web-ui/app/_components/chat/PlanProgressCard.tsx
+++ b/web-ui/app/_components/chat/PlanProgressCard.tsx
@@ -68,7 +68,7 @@ export function PlanProgressCard({
         )}
         {plan.reusedProcessTitle && (
           <span
-            className="ml-auto inline-flex items-center gap-1 rounded-full bg-[color:var(--success)]/10 px-1.5 py-0.5 text-[10px] font-medium text-[color:var(--success)]"
+            className="ml-auto inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium text-[color:var(--success)]"
             title={t('reusedFrom', { title: plan.reusedProcessTitle })}
           >
             <span aria-hidden>♻</span>

--- a/web-ui/app/_components/chat/PlanProgressCard.tsx
+++ b/web-ui/app/_components/chat/PlanProgressCard.tsx
@@ -53,7 +53,7 @@ export function PlanProgressCard({
       open
       className="mb-2 rounded-md border border-[color:var(--accent)] bg-[color:var(--accent)]/10 text-xs"
     >
-      <summary className="flex cursor-pointer items-center gap-2 px-2.5 py-1.5 font-medium text-[color:var(--accent)]">
+      <summary className="flex cursor-pointer items-center gap-2 px-3 py-2 font-medium text-[color:var(--accent)]">
         <span aria-hidden>🗺</span>
         <span>{t('heading')}</span>
         <span className="font-normal text-[color:var(--accent)]">
@@ -68,7 +68,7 @@ export function PlanProgressCard({
         )}
         {plan.reusedProcessTitle && (
           <span
-            className="ml-auto inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium text-[color:var(--success)]"
+            className="ml-auto inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium text-[color:var(--success)]"
             title={t('reusedFrom', { title: plan.reusedProcessTitle })}
           >
             <span aria-hidden>♻</span>
@@ -76,7 +76,7 @@ export function PlanProgressCard({
           </span>
         )}
       </summary>
-      <ol className="flex flex-col gap-1 px-2.5 pb-2 pt-0.5">
+      <ol className="flex flex-col gap-1 px-3 pb-2 pt-0.5">
         {steps.map((s, i) => {
           const active = s.status === 'in_progress';
           return (
@@ -100,7 +100,7 @@ export function PlanProgressCard({
                   {i + 1}.
                 </span>{' '}
                 {s.goal}
-                <span className="ml-1.5 text-[10px] uppercase tracking-wide text-[color:var(--fg-subtle)]">
+                <span className="ml-2 text-[10px] uppercase tracking-wide text-[color:var(--fg-subtle)]">
                   {statusLabel(s.status)}
                 </span>
               </span>

--- a/web-ui/app/_components/chat/PlanProgressCard.tsx
+++ b/web-ui/app/_components/chat/PlanProgressCard.tsx
@@ -51,24 +51,24 @@ export function PlanProgressCard({
   return (
     <details
       open
-      className="mb-2 rounded-md border border-violet-200 bg-violet-50/50 text-xs dark:border-violet-900/50 dark:bg-violet-950/20"
+      className="mb-2 rounded-md border border-[color:var(--accent)] bg-[color:var(--accent)]/10 text-xs"
     >
-      <summary className="flex cursor-pointer items-center gap-2 px-2.5 py-1.5 font-medium text-violet-700 dark:text-violet-300">
+      <summary className="flex cursor-pointer items-center gap-2 px-2.5 py-1.5 font-medium text-[color:var(--accent)]">
         <span aria-hidden>🗺</span>
         <span>{t('heading')}</span>
-        <span className="font-normal text-violet-500 dark:text-violet-400">
+        <span className="font-normal text-[color:var(--accent)]">
           {t('summary', { done: doneCount, total: steps.length })}
         </span>
         {streaming && (
           <span
-            className="ml-1 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-violet-500"
+            className="ml-1 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--accent)]/100"
             title={t('statusInProgress')}
             aria-hidden
           />
         )}
         {plan.reusedProcessTitle && (
           <span
-            className="ml-auto inline-flex items-center gap-1 rounded-full bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
+            className="ml-auto inline-flex items-center gap-1 rounded-full bg-[color:var(--success)]/10 px-1.5 py-0.5 text-[10px] font-medium text-[color:var(--success)]"
             title={t('reusedFrom', { title: plan.reusedProcessTitle })}
           >
             <span aria-hidden>♻</span>
@@ -92,15 +92,15 @@ export function PlanProgressCard({
               <span
                 className={
                   s.status === 'skipped'
-                    ? 'text-neutral-400 line-through dark:text-neutral-500'
-                    : 'text-neutral-700 dark:text-neutral-300'
+                    ? 'text-[color:var(--fg-subtle)] line-through'
+                    : 'text-[color:var(--fg)]'
                 }
               >
-                <span className="text-neutral-400 dark:text-neutral-500">
+                <span className="text-[color:var(--fg-subtle)]">
                   {i + 1}.
                 </span>{' '}
                 {s.goal}
-                <span className="ml-1.5 text-[10px] uppercase tracking-wide text-neutral-400 dark:text-neutral-500">
+                <span className="ml-1.5 text-[10px] uppercase tracking-wide text-[color:var(--fg-subtle)]">
                   {statusLabel(s.status)}
                 </span>
               </span>

--- a/web-ui/app/_components/chat/PrivacyReceiptCard.tsx
+++ b/web-ui/app/_components/chat/PrivacyReceiptCard.tsx
@@ -157,20 +157,20 @@ export function PrivacyReceiptCard({
 
 const PALETTE_OK = {
   container:
-    'bg-emerald-50/60 ring-emerald-100 dark:bg-emerald-950/30 dark:ring-emerald-900/60',
-  summary: 'text-emerald-800 dark:text-emerald-200',
-  body: 'text-emerald-900 dark:text-emerald-100',
-  label: 'text-emerald-700/80 dark:text-emerald-300/80',
-  muted: 'text-emerald-900/80 dark:text-emerald-200/90',
+    'bg-[color:var(--success)]/10 ring-[color:var(--success)]',
+  summary: 'text-[color:var(--success)]',
+  body: 'text-[color:var(--success)]',
+  label: 'text-[color:var(--success)]/80',
+  muted: 'text-[color:var(--success)]/80',
 } as const;
 
 const PALETTE_BREACH = {
   container:
-    'bg-red-50/80 ring-red-300 dark:bg-red-950/40 dark:ring-red-800/70',
-  summary: 'font-semibold text-red-800 dark:text-red-200',
-  body: 'text-red-900 dark:text-red-100',
-  label: 'text-red-700/80 dark:text-red-300/80',
-  muted: 'text-red-900/80 dark:text-red-200/90',
+    'bg-[color:var(--danger)]/8 ring-[color:var(--danger-edge)]',
+  summary: 'font-semibold text-[color:var(--danger)]',
+  body: 'text-[color:var(--danger)]',
+  label: 'text-[color:var(--danger)]/80',
+  muted: 'text-[color:var(--danger)]/80',
 } as const;
 
 // Slice 2.5 — operator opted into bypass on at least one plugin this turn.
@@ -179,11 +179,11 @@ const PALETTE_BREACH = {
 // should still see it loud enough to notice.
 const PALETTE_BYPASS = {
   container:
-    'bg-amber-50/70 ring-amber-200 dark:bg-amber-950/30 dark:ring-amber-800/60',
-  summary: 'font-medium text-amber-800 dark:text-amber-200',
-  body: 'text-amber-900 dark:text-amber-100',
-  label: 'text-amber-700/80 dark:text-amber-300/80',
-  muted: 'text-amber-900/80 dark:text-amber-200/90',
+    'bg-[color:var(--warning)]/10 ring-[color:var(--warning)]',
+  summary: 'font-medium text-[color:var(--warning)]',
+  body: 'text-[color:var(--warning)]',
+  label: 'text-[color:var(--warning)]/80',
+  muted: 'text-[color:var(--warning)]/80',
 } as const;
 
 /**

--- a/web-ui/app/_components/chat/RecalledContextCard.tsx
+++ b/web-ui/app/_components/chat/RecalledContextCard.tsx
@@ -32,7 +32,7 @@ export function RecalledContextCard({
 
   return (
     <details className="mb-2 rounded-md border border-[color:var(--accent)] bg-[color:var(--accent)]/10 text-xs">
-      <summary className="flex cursor-pointer items-center gap-2 px-2.5 py-1.5 font-medium text-[color:var(--accent)]">
+      <summary className="flex cursor-pointer items-center gap-2 px-3 py-2 font-medium text-[color:var(--accent)]">
         <span aria-hidden>🧠</span>
         <span>{t('heading')}</span>
         <span className="font-normal text-[color:var(--accent)]">
@@ -43,7 +43,7 @@ export function RecalledContextCard({
           })}
         </span>
       </summary>
-      <div className="flex flex-col gap-2 px-2.5 pb-2 pt-0.5">
+      <div className="flex flex-col gap-2 px-3 pb-2 pt-0.5">
         {plans.length > 0 && (
           <section>
             <h4 className="text-[10px] uppercase tracking-wide text-[color:var(--accent)]">

--- a/web-ui/app/_components/chat/RecalledContextCard.tsx
+++ b/web-ui/app/_components/chat/RecalledContextCard.tsx
@@ -31,11 +31,11 @@ export function RecalledContextCard({
   }
 
   return (
-    <details className="mb-2 rounded-md border border-sky-200 bg-sky-50/50 text-xs dark:border-sky-900/50 dark:bg-sky-950/20">
-      <summary className="flex cursor-pointer items-center gap-2 px-2.5 py-1.5 font-medium text-sky-700 dark:text-sky-300">
+    <details className="mb-2 rounded-md border border-[color:var(--accent)] bg-[color:var(--accent)]/10 text-xs">
+      <summary className="flex cursor-pointer items-center gap-2 px-2.5 py-1.5 font-medium text-[color:var(--accent)]">
         <span aria-hidden>🧠</span>
         <span>{t('heading')}</span>
-        <span className="font-normal text-sky-500 dark:text-sky-400">
+        <span className="font-normal text-[color:var(--accent)]">
           {t('summary', {
             plans: plans.length,
             processes: processes.length,
@@ -46,17 +46,17 @@ export function RecalledContextCard({
       <div className="flex flex-col gap-2 px-2.5 pb-2 pt-0.5">
         {plans.length > 0 && (
           <section>
-            <h4 className="text-[10px] uppercase tracking-wide text-sky-600 dark:text-sky-400">
+            <h4 className="text-[10px] uppercase tracking-wide text-[color:var(--accent)]">
               {t('plansHeading')}
             </h4>
             <ul className="flex flex-col gap-0.5">
               {plans.map((p) => (
                 <li
                   key={p.planId}
-                  className="text-neutral-700 dark:text-neutral-300"
+                  className="text-[color:var(--fg)]"
                 >
                   {p.strategy ? `${p.strategy} — ` : ''}
-                  <span className="text-neutral-400 dark:text-neutral-500">
+                  <span className="text-[color:var(--fg-subtle)]">
                     {t('stepsProgress', {
                       done: p.doneCount,
                       total: p.totalCount,
@@ -75,17 +75,17 @@ export function RecalledContextCard({
         )}
         {processes.length > 0 && (
           <section>
-            <h4 className="text-[10px] uppercase tracking-wide text-sky-600 dark:text-sky-400">
+            <h4 className="text-[10px] uppercase tracking-wide text-[color:var(--accent)]">
               {t('processesHeading')}
             </h4>
             <ul className="flex flex-col gap-0.5">
               {processes.map((pr) => (
                 <li
                   key={pr.id}
-                  className="text-neutral-700 dark:text-neutral-300"
+                  className="text-[color:var(--fg)]"
                 >
                   {pr.title}{' '}
-                  <span className="text-neutral-400 dark:text-neutral-500">
+                  <span className="text-[color:var(--fg-subtle)]">
                     ({t('stepCount', { count: pr.stepCount })})
                   </span>
                 </li>
@@ -95,16 +95,16 @@ export function RecalledContextCard({
         )}
         {insights.length > 0 && (
           <section>
-            <h4 className="text-[10px] uppercase tracking-wide text-sky-600 dark:text-sky-400">
+            <h4 className="text-[10px] uppercase tracking-wide text-[color:var(--accent)]">
               {t('insightsHeading')}
             </h4>
             <ul className="flex flex-col gap-0.5">
               {insights.map((ins) => (
                 <li
                   key={ins.mkId}
-                  className="text-neutral-700 dark:text-neutral-300"
+                  className="text-[color:var(--fg)]"
                 >
-                  <span className="text-neutral-400 dark:text-neutral-500">
+                  <span className="text-[color:var(--fg-subtle)]">
                     {ins.kind}:
                   </span>{' '}
                   {ins.summary}

--- a/web-ui/app/_components/chat/SaveMemoryButton.tsx
+++ b/web-ui/app/_components/chat/SaveMemoryButton.tsx
@@ -174,7 +174,7 @@ export function SaveMemoryButton({
           if (saved !== null) reset();
           setOpen(true);
         }}
-        className="ml-3 rounded border border-[color:var(--border)] px-1.5 py-0.5 text-[11px] text-[color:var(--fg-muted)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--fg-strong)]"
+        className="ml-3 rounded border border-[color:var(--border)] px-2 py-0.5 text-[11px] text-[color:var(--fg-muted)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--fg-strong)]"
         title={t('buttonTitle')}
       >
         {saved !== null ? `✓ ${t('savedShort')}` : t('buttonLabel')}
@@ -190,7 +190,7 @@ export function SaveMemoryButton({
             if (e.target === e.currentTarget && !busy) close();
           }}
         >
-          <div className="w-full max-w-lg rounded-lg bg-[color:var(--bg-elevated)] p-5 shadow-xl">
+          <div className="w-full max-w-lg rounded-lg bg-[color:var(--bg-elevated)] p-4 shadow-xl">
             <div className="mb-3 flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <h2
@@ -202,7 +202,7 @@ export function SaveMemoryButton({
                 {palaiaExcerpt && (
                   <span
                     className={[
-                      'rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider',
+                      'rounded px-2 py-0.5 text-[10px] uppercase tracking-wider',
                       palaiaExcerpt.source === 'hint'
                         ? 'bg-[color:var(--warning)]/10 text-[color:var(--warning)]'
                         : 'bg-[color:var(--accent)]/10 text-[color:var(--accent)]',
@@ -230,7 +230,7 @@ export function SaveMemoryButton({
                   <legend className="mb-1 text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
                     {t('kindLabel')}
                   </legend>
-                  <div className="flex flex-wrap gap-1.5">
+                  <div className="flex flex-wrap gap-2">
                     {KINDS.map((k) => (
                       <label
                         key={k}
@@ -267,7 +267,7 @@ export function SaveMemoryButton({
                     disabled={busy}
                     maxLength={2000}
                     rows={3}
-                    className="w-full resize-y rounded border border-[color:var(--border)] px-2 py-1.5 text-sm text-[color:var(--fg-strong)] focus:border-[color:var(--border-strong)] focus:outline-none"
+                    className="w-full resize-y rounded border border-[color:var(--border)] px-2 py-2 text-sm text-[color:var(--fg-strong)] focus:border-[color:var(--border-strong)] focus:outline-none"
                     placeholder={t('summaryPlaceholder')}
                   />
                   <span className="mt-0.5 block text-right text-[10px] text-[color:var(--fg-muted)]">
@@ -314,7 +314,7 @@ export function SaveMemoryButton({
                     disabled={busy}
                     maxLength={10000}
                     rows={2}
-                    className="w-full resize-y rounded border border-[color:var(--border)] px-2 py-1.5 text-sm text-[color:var(--fg-strong)] focus:border-[color:var(--border-strong)] focus:outline-none"
+                    className="w-full resize-y rounded border border-[color:var(--border)] px-2 py-2 text-sm text-[color:var(--fg-strong)] focus:border-[color:var(--border-strong)] focus:outline-none"
                     placeholder={t('rationalePlaceholder')}
                   />
                 </label>
@@ -350,7 +350,7 @@ export function SaveMemoryButton({
               </>
             ) : (
               <>
-                <div className="mb-3 border-l-2 border-[color:var(--success)] px-2 py-1.5 text-xs text-[color:var(--fg)]">
+                <div className="mb-3 border-l-2 border-[color:var(--success)] px-2 py-2 text-xs text-[color:var(--fg)]">
                   {t('successHeadline')}
                 </div>
                 <dl className="mb-4 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 font-mono text-[11px]">

--- a/web-ui/app/_components/chat/SaveMemoryButton.tsx
+++ b/web-ui/app/_components/chat/SaveMemoryButton.tsx
@@ -174,7 +174,7 @@ export function SaveMemoryButton({
           if (saved !== null) reset();
           setOpen(true);
         }}
-        className="ml-3 rounded border border-neutral-300 px-1.5 py-0.5 text-[11px] text-neutral-600 transition hover:border-neutral-400 hover:text-neutral-900 dark:border-neutral-700 dark:text-neutral-400 dark:hover:border-neutral-500 dark:hover:text-neutral-100"
+        className="ml-3 rounded border border-[color:var(--border)] px-1.5 py-0.5 text-[11px] text-[color:var(--fg-muted)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--fg-strong)]"
         title={t('buttonTitle')}
       >
         {saved !== null ? `✓ ${t('savedShort')}` : t('buttonLabel')}
@@ -185,17 +185,17 @@ export function SaveMemoryButton({
           role="dialog"
           aria-modal="true"
           aria-labelledby="save-memory-title"
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--bg-modal-overlay)] p-4"
           onClick={(e) => {
             if (e.target === e.currentTarget && !busy) close();
           }}
         >
-          <div className="w-full max-w-lg rounded-lg bg-white p-5 shadow-xl dark:bg-neutral-900">
+          <div className="w-full max-w-lg rounded-lg bg-[color:var(--bg-elevated)] p-5 shadow-xl">
             <div className="mb-3 flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <h2
                   id="save-memory-title"
-                  className="text-sm font-medium text-neutral-900 dark:text-neutral-100"
+                  className="text-sm font-medium text-[color:var(--fg-strong)]"
                 >
                   {t('dialogTitle')}
                 </h2>
@@ -204,8 +204,8 @@ export function SaveMemoryButton({
                     className={[
                       'rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wider',
                       palaiaExcerpt.source === 'hint'
-                        ? 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200'
-                        : 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/40 dark:text-indigo-300',
+                        ? 'bg-[color:var(--warning)]/10 text-[color:var(--warning)]'
+                        : 'bg-[color:var(--accent)]/10 text-[color:var(--accent)]',
                     ].join(' ')}
                     title={t(`source.${palaiaExcerpt.source}Title`)}
                   >
@@ -217,7 +217,7 @@ export function SaveMemoryButton({
                 type="button"
                 onClick={close}
                 disabled={busy}
-                className="text-neutral-500 hover:text-neutral-900 disabled:opacity-50 dark:text-neutral-400 dark:hover:text-neutral-100"
+                className="text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)] disabled:opacity-50"
                 aria-label={t('closeAriaLabel')}
               >
                 ✕
@@ -227,7 +227,7 @@ export function SaveMemoryButton({
             {saved === null ? (
               <>
                 <fieldset className="mb-3">
-                  <legend className="mb-1 text-[11px] uppercase tracking-wider text-neutral-500">
+                  <legend className="mb-1 text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
                     {t('kindLabel')}
                   </legend>
                   <div className="flex flex-wrap gap-1.5">
@@ -237,8 +237,8 @@ export function SaveMemoryButton({
                         className={[
                           'cursor-pointer rounded border px-2 py-1 text-xs transition',
                           kind === k
-                            ? 'border-neutral-900 bg-neutral-900 text-white dark:border-neutral-200 dark:bg-neutral-200 dark:text-neutral-900'
-                            : 'border-neutral-300 text-neutral-700 hover:border-neutral-400 dark:border-neutral-700 dark:text-neutral-300 dark:hover:border-neutral-500',
+                            ? 'border-[color:var(--border-strong)] bg-[color:var(--bg-inverse)] text-[color:var(--fg-on-dark)]'
+                            : 'border-[color:var(--border)] text-[color:var(--fg)] hover:border-[color:var(--border-strong)]',
                         ].join(' ')}
                       >
                         <input
@@ -257,7 +257,7 @@ export function SaveMemoryButton({
                 </fieldset>
 
                 <label className="mb-3 block">
-                  <span className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-500">
+                  <span className="mb-1 block text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
                     {t('summaryLabel')}
                   </span>
                   <textarea
@@ -267,19 +267,19 @@ export function SaveMemoryButton({
                     disabled={busy}
                     maxLength={2000}
                     rows={3}
-                    className="w-full resize-y rounded border border-neutral-300 px-2 py-1.5 text-sm text-neutral-900 focus:border-neutral-500 focus:outline-none dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-100"
+                    className="w-full resize-y rounded border border-[color:var(--border)] px-2 py-1.5 text-sm text-[color:var(--fg-strong)] focus:border-[color:var(--border-strong)] focus:outline-none"
                     placeholder={t('summaryPlaceholder')}
                   />
-                  <span className="mt-0.5 block text-right text-[10px] text-neutral-500">
+                  <span className="mt-0.5 block text-right text-[10px] text-[color:var(--fg-muted)]">
                     {summary.length} / 2000
                   </span>
                 </label>
 
                 {palaiaExcerpt && palaiaExcerpt.excerpts.length > 0 && (
                   <div className="mb-3">
-                    <div className="mb-1 flex items-center justify-between text-[11px] uppercase tracking-wider text-neutral-500">
+                    <div className="mb-1 flex items-center justify-between text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
                       <span>{t('excerptsLabel')}</span>
-                      <span className="text-[10px] normal-case tracking-normal text-neutral-400">
+                      <span className="text-[10px] normal-case tracking-normal text-[color:var(--fg-subtle)]">
                         {t('excerptsHint')}
                       </span>
                     </div>
@@ -290,10 +290,10 @@ export function SaveMemoryButton({
                             type="button"
                             onClick={() => insertExcerpt(excerpt)}
                             disabled={busy}
-                            className="group w-full rounded border border-neutral-200 bg-neutral-50 px-2 py-1 text-left text-xs text-neutral-700 transition hover:border-indigo-300 hover:bg-indigo-50 disabled:opacity-50 dark:border-neutral-700 dark:bg-neutral-800/60 dark:text-neutral-300 dark:hover:border-indigo-700 dark:hover:bg-indigo-900/20"
+                            className="group w-full rounded border border-[color:var(--border)] bg-[color:var(--bg-soft)] px-2 py-1 text-left text-xs text-[color:var(--fg)] transition hover:border-[color:var(--accent)] hover:bg-[color:var(--accent)]/10 disabled:opacity-50"
                             title={t('excerptInsertTitle')}
                           >
-                            <span className="mr-1 text-neutral-400 group-hover:text-indigo-400">
+                            <span className="mr-1 text-[color:var(--fg-subtle)] group-hover:text-[color:var(--accent)]">
                               +
                             </span>
                             {excerpt}
@@ -305,7 +305,7 @@ export function SaveMemoryButton({
                 )}
 
                 <label className="mb-3 block">
-                  <span className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-500">
+                  <span className="mb-1 block text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
                     {t('rationaleLabel')}
                   </span>
                   <textarea
@@ -314,17 +314,17 @@ export function SaveMemoryButton({
                     disabled={busy}
                     maxLength={10000}
                     rows={2}
-                    className="w-full resize-y rounded border border-neutral-300 px-2 py-1.5 text-sm text-neutral-900 focus:border-neutral-500 focus:outline-none dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-100"
+                    className="w-full resize-y rounded border border-[color:var(--border)] px-2 py-1.5 text-sm text-[color:var(--fg-strong)] focus:border-[color:var(--border-strong)] focus:outline-none"
                     placeholder={t('rationalePlaceholder')}
                   />
                 </label>
 
-                <div className="mb-3 font-mono text-[10px] text-neutral-500">
+                <div className="mb-3 font-mono text-[10px] text-[color:var(--fg-muted)]">
                   {t('linkedToTurn', { turnId })}
                 </div>
 
                 {error !== null && (
-                  <div className="mb-3 border-l-2 border-red-400 px-2 py-1 text-xs text-red-700 dark:text-red-300">
+                  <div className="mb-3 border-l-2 border-[color:var(--danger-edge)] px-2 py-1 text-xs text-[color:var(--danger)]">
                     {t('errorPrefix')} {error}
                   </div>
                 )}
@@ -334,7 +334,7 @@ export function SaveMemoryButton({
                     type="button"
                     onClick={close}
                     disabled={busy}
-                    className="rounded border border-neutral-300 px-3 py-1 text-xs hover:border-neutral-400 disabled:opacity-50 dark:border-neutral-700 dark:hover:border-neutral-500"
+                    className="rounded border border-[color:var(--border)] px-3 py-1 text-xs hover:border-[color:var(--border-strong)] disabled:opacity-50"
                   >
                     {t('cancel')}
                   </button>
@@ -342,7 +342,7 @@ export function SaveMemoryButton({
                     type="button"
                     onClick={() => void submit()}
                     disabled={busy || summary.trim().length === 0}
-                    className="rounded bg-neutral-900 px-3 py-1 text-xs text-white hover:bg-neutral-700 disabled:opacity-50 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-300"
+                    className="rounded bg-[color:var(--bg-inverse)] px-3 py-1 text-xs text-[color:var(--fg-on-dark)] hover:bg-[color:var(--fg-muted)] disabled:opacity-50"
                   >
                     {busy ? t('saving') : t('save')}
                   </button>
@@ -350,32 +350,32 @@ export function SaveMemoryButton({
               </>
             ) : (
               <>
-                <div className="mb-3 border-l-2 border-green-400 px-2 py-1.5 text-xs text-neutral-700 dark:text-neutral-300">
+                <div className="mb-3 border-l-2 border-[color:var(--success)] px-2 py-1.5 text-xs text-[color:var(--fg)]">
                   {t('successHeadline')}
                 </div>
                 <dl className="mb-4 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 font-mono text-[11px]">
-                  <dt className="text-neutral-500">id</dt>
-                  <dd className="text-neutral-900 dark:text-neutral-100">
+                  <dt className="text-[color:var(--fg-muted)]">id</dt>
+                  <dd className="text-[color:var(--fg-strong)]">
                     {saved.memorableKnowledgeNodeId}
                   </dd>
-                  <dt className="text-neutral-500">{t('skippedInvolved')}</dt>
+                  <dt className="text-[color:var(--fg-muted)]">{t('skippedInvolved')}</dt>
                   <dd>{saved.skippedInvolved}</dd>
-                  <dt className="text-neutral-500">{t('skippedRequired')}</dt>
+                  <dt className="text-[color:var(--fg-muted)]">{t('skippedRequired')}</dt>
                   <dd>{saved.skippedRequired}</dd>
-                  <dt className="text-neutral-500">{t('skippedDerivedFrom')}</dt>
+                  <dt className="text-[color:var(--fg-muted)]">{t('skippedDerivedFrom')}</dt>
                   <dd>{saved.skippedDerivedFrom}</dd>
                 </dl>
                 <div className="flex justify-end gap-2">
                   <a
                     href={`/memories/${encodeURIComponent(saved.memorableKnowledgeNodeId)}`}
-                    className="rounded border border-neutral-300 px-3 py-1 text-xs hover:border-neutral-400 dark:border-neutral-700 dark:hover:border-neutral-500"
+                    className="rounded border border-[color:var(--border)] px-3 py-1 text-xs hover:border-[color:var(--border-strong)]"
                   >
                     {t('openDetail')}
                   </a>
                   <button
                     type="button"
                     onClick={close}
-                    className="rounded bg-neutral-900 px-3 py-1 text-xs text-white hover:bg-neutral-700 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-300"
+                    className="rounded bg-[color:var(--bg-inverse)] px-3 py-1 text-xs text-[color:var(--fg-on-dark)] hover:bg-[color:var(--fg-muted)]"
                   >
                     {t('close')}
                   </button>

--- a/web-ui/app/_components/chat/__tests__/PrivacyReceiptCard.test.tsx
+++ b/web-ui/app/_components/chat/__tests__/PrivacyReceiptCard.test.tsx
@@ -99,8 +99,8 @@ describe('<PrivacyReceiptCard />', () => {
       { locale: 'de' },
     );
     const root = container.querySelector('details');
-    expect(root?.className).toMatch(/red/);
-    expect(root?.className).not.toMatch(/emerald/);
+    expect(root?.className).toMatch(/danger/);
+    expect(root?.className).not.toMatch(/success/);
   });
 
   it('stays emerald when the user named nobody', () => {
@@ -109,8 +109,8 @@ describe('<PrivacyReceiptCard />', () => {
       { locale: 'de' },
     );
     const root = container.querySelector('details');
-    expect(root?.className).toMatch(/emerald/);
-    expect(root?.className).not.toMatch(/red/);
+    expect(root?.className).toMatch(/success/);
+    expect(root?.className).not.toMatch(/danger/);
   });
 
   it('never leaks a PII-shaped value — the receipt carries only counts', () => {

--- a/web-ui/app/_components/onboarding/OnboardingModal.tsx
+++ b/web-ui/app/_components/onboarding/OnboardingModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Check, Loader2, Sparkles, X } from 'lucide-react';
+import { Check, Sparkles, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 import { applyProfile, ApiError, profileExportUrl } from '../../_lib/api';
@@ -229,7 +229,7 @@ function ProfileGrid({
             >
               {isActive ? (
                 <>
-                  <Loader2 className="size-3.5 animate-spin" aria-hidden />
+                  <span className="lume-busy-dots" aria-hidden />
                   {t('applying')}
                 </>
               ) : (

--- a/web-ui/app/_components/onboarding/OnboardingModal.tsx
+++ b/web-ui/app/_components/onboarding/OnboardingModal.tsx
@@ -105,7 +105,7 @@ export function OnboardingModal({
           'max-h-[90vh] overflow-hidden',
         )}
       >
-        <header className="flex items-start justify-between gap-6 border-b border-[color:var(--rule)] px-7 py-5">
+        <header className="flex items-start justify-between gap-6 border-b border-[color:var(--rule)] px-6 py-4">
           <div className="min-w-0">
             <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.22em] text-[color:var(--accent)]">
               <Sparkles className="size-3.5" aria-hidden />
@@ -129,7 +129,7 @@ export function OnboardingModal({
           </button>
         </header>
 
-        <div className="flex-1 overflow-y-auto px-7 py-6">
+        <div className="flex-1 overflow-y-auto px-6 py-6">
           {phase.kind === 'done' ? (
             <OutcomeBody outcome={phase.outcome} />
           ) : phase.kind === 'errored' ? (
@@ -150,7 +150,7 @@ export function OnboardingModal({
           )}
         </div>
 
-        <footer className="flex items-center justify-between gap-4 border-t border-[color:var(--rule)] px-7 py-4 text-[11px] text-[color:var(--muted-ink)]">
+        <footer className="flex items-center justify-between gap-4 border-t border-[color:var(--rule)] px-6 py-4 text-[11px] text-[color:var(--muted-ink)]">
           <div>
             {t('exportPrefix')}{' '}
             <a
@@ -165,7 +165,7 @@ export function OnboardingModal({
             <button
               type="button"
               onClick={() => setDismissed(true)}
-              className="border border-[color:var(--rule-strong)] bg-[color:var(--paper)] px-4 py-1.5 text-[11px] uppercase tracking-[0.16em] text-[color:var(--ink)] transition hover:bg-[color:var(--ink)] hover:text-[color:var(--paper)]"
+              className="border border-[color:var(--rule-strong)] bg-[color:var(--paper)] px-4 py-2 text-[11px] uppercase tracking-[0.16em] text-[color:var(--ink)] transition hover:bg-[color:var(--ink)] hover:text-[color:var(--paper)]"
             >
               {t('done')}
             </button>
@@ -198,7 +198,7 @@ function ProfileGrid({
           <article
             key={profile.id}
             className={cn(
-              'flex flex-col border border-[color:var(--rule)] bg-[color:var(--paper)] p-5 transition',
+              'flex flex-col border border-[color:var(--rule)] bg-[color:var(--paper)] p-4 transition',
               !busy && 'hover:border-[color:var(--accent)]',
               isActive && 'border-[color:var(--accent)]',
             )}
@@ -251,7 +251,7 @@ function OutcomeBody({
   const t = useTranslations('onboarding');
   const hasErrors = outcome.errored.length > 0;
   return (
-    <div className="space-y-5">
+    <div className="space-y-4">
       <div
         className={cn(
           'flex items-center gap-3 border px-4 py-3',
@@ -364,7 +364,7 @@ function ErrorBody({
       <button
         type="button"
         onClick={onRetry}
-        className="border border-[color:var(--rule-strong)] bg-[color:var(--paper)] px-4 py-1.5 text-[12px] uppercase tracking-[0.16em] text-[color:var(--ink)] transition hover:bg-[color:var(--ink)] hover:text-[color:var(--paper)]"
+        className="border border-[color:var(--rule-strong)] bg-[color:var(--paper)] px-4 py-2 text-[12px] uppercase tracking-[0.16em] text-[color:var(--ink)] transition hover:bg-[color:var(--ink)] hover:text-[color:var(--paper)]"
       >
         {t('tryAnother')}
       </button>

--- a/web-ui/app/_components/onboarding/OnboardingModal.tsx
+++ b/web-ui/app/_components/onboarding/OnboardingModal.tsx
@@ -256,8 +256,8 @@ function OutcomeBody({
         className={cn(
           'flex items-center gap-3 border px-4 py-3',
           hasErrors
-            ? 'border-amber-500/50 bg-amber-50/40 text-amber-900'
-            : 'border-emerald-500/50 bg-emerald-50/40 text-emerald-900',
+            ? 'border-[color:var(--warning)]/50 bg-[color:var(--warning)]/10 text-[color:var(--warning)]'
+            : 'border-[color:var(--success)]/50 bg-[color:var(--success)]/10 text-[color:var(--success)]',
         )}
       >
         {hasErrors ? (
@@ -313,7 +313,7 @@ function OutcomeBody({
             {outcome.errored.map((p) => (
               <li
                 key={p.id}
-                className="border border-amber-500/40 bg-amber-50/30 px-3 py-2 text-amber-900"
+                className="border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/10 px-3 py-2 text-[color:var(--warning)]"
               >
                 <div className="font-mono text-[11px]">{p.id}</div>
                 <div className="mt-0.5 text-[10px] uppercase tracking-[0.16em]">
@@ -350,7 +350,7 @@ function ErrorBody({
   const t = useTranslations('onboarding');
   return (
     <div className="space-y-4">
-      <div className="flex items-start gap-3 border border-rose-500/50 bg-rose-50/40 px-4 py-3 text-rose-900">
+      <div className="flex items-start gap-3 border border-[color:var(--danger-edge)]/50 bg-[color:var(--danger)]/8 px-4 py-3 text-[color:var(--danger)]">
         <span aria-hidden>✗</span>
         <div className="text-[12px]">
           <div className="font-medium">

--- a/web-ui/app/_components/store/AdminUiPanel.tsx
+++ b/web-ui/app/_components/store/AdminUiPanel.tsx
@@ -54,7 +54,7 @@ export function AdminUiToggle(): React.ReactElement {
         'text-[12px] font-semibold uppercase tracking-[0.18em]',
         'border transition-colors',
         open
-          ? 'border-[color:var(--accent)] bg-[color:var(--accent)] text-white hover:bg-[color:var(--accent)]/90'
+          ? 'border-[color:var(--accent)] bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] hover:bg-[color:var(--accent)]/90'
           : 'border-[color:var(--rule-strong)] bg-[color:var(--paper)] text-[color:var(--ink)] hover:bg-[color:var(--bg-soft)]',
       )}
     >

--- a/web-ui/app/_components/store/AuditModeSwitch.tsx
+++ b/web-ui/app/_components/store/AuditModeSwitch.tsx
@@ -155,12 +155,12 @@ export function AuditModeSwitch({
       </div>
       <div className="min-h-[20px] text-[12px]">
         {status.kind === 'loading' && (
-          <span className="inline-flex items-center gap-1.5 text-[color:var(--fg-muted)]">
+          <span className="inline-flex items-center gap-2 text-[color:var(--fg-muted)]">
             <span className="lume-busy-dots" aria-hidden /> lädt …
           </span>
         )}
         {status.kind === 'saving' && (
-          <span className="inline-flex items-center gap-1.5 text-[color:var(--fg-muted)]">
+          <span className="inline-flex items-center gap-2 text-[color:var(--fg-muted)]">
             <span className="lume-busy-dots" aria-hidden /> speichert …
           </span>
         )}

--- a/web-ui/app/_components/store/AuditModeSwitch.tsx
+++ b/web-ui/app/_components/store/AuditModeSwitch.tsx
@@ -127,7 +127,7 @@ export function AuditModeSwitch({
           <label
             key={m.value}
             className={[
-              'flex cursor-pointer items-start gap-3 rounded-[10px] border p-3',
+              'flex cursor-pointer items-start gap-3 rounded-md border p-3',
               mode === m.value
                 ? 'border-[color:var(--accent)]'
                 : 'border-[color:var(--rule)]',

--- a/web-ui/app/_components/store/AuditModeSwitch.tsx
+++ b/web-ui/app/_components/store/AuditModeSwitch.tsx
@@ -16,7 +16,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { Loader2, ShieldAlert } from 'lucide-react';
+import { ShieldAlert } from 'lucide-react';
 
 import { ApiError, listInstalledSecretKeys, setAuditMode } from '../../_lib/api';
 import type { AuditMode } from '../../_lib/storeTypes';
@@ -156,12 +156,12 @@ export function AuditModeSwitch({
       <div className="min-h-[20px] text-[12px]">
         {status.kind === 'loading' && (
           <span className="inline-flex items-center gap-1.5 text-[color:var(--fg-muted)]">
-            <Loader2 className="size-3 animate-spin" aria-hidden /> lädt …
+            <span className="lume-busy-dots" aria-hidden /> lädt …
           </span>
         )}
         {status.kind === 'saving' && (
           <span className="inline-flex items-center gap-1.5 text-[color:var(--fg-muted)]">
-            <Loader2 className="size-3 animate-spin" aria-hidden /> speichert …
+            <span className="lume-busy-dots" aria-hidden /> speichert …
           </span>
         )}
         {status.kind === 'saved' && (

--- a/web-ui/app/_components/store/Chip.tsx
+++ b/web-ui/app/_components/store/Chip.tsx
@@ -25,7 +25,7 @@ export function Chip({
   return (
     <span
       className={cn(
-        'inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] leading-5',
+        'inline-flex items-center rounded-full border px-3 py-0.5 text-[11px] leading-5',
         tone !== 'mono' && 'uppercase tracking-[0.14em]',
         toneClass,
         className,

--- a/web-ui/app/_components/store/CredentialsEditor.tsx
+++ b/web-ui/app/_components/store/CredentialsEditor.tsx
@@ -213,7 +213,7 @@ export function CredentialsEditor({
                       "credentials". Secrets/OAuth land in the encrypted vault;
                       everything else is instance config. */}
                   <span
-                    className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${
+                    className={`rounded px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${
                       isSecret
                         ? 'bg-[color:var(--accent)]/12 text-[color:var(--accent)]'
                         : 'bg-[color:var(--rule)]/50 text-[color:var(--muted-ink)]'
@@ -269,7 +269,7 @@ export function CredentialsEditor({
                             },
                           }))
                         }
-                        className="min-w-0 flex-1 rounded-md border border-[color:var(--rule)] bg-[color:var(--bg)] px-2.5 py-1.5 text-[12px] text-[color:var(--ink)] focus:border-[color:var(--accent)] focus:outline-none disabled:opacity-50"
+                        className="min-w-0 flex-1 rounded-md border border-[color:var(--rule)] bg-[color:var(--bg)] px-3 py-2 text-[12px] text-[color:var(--ink)] focus:border-[color:var(--accent)] focus:outline-none disabled:opacity-50"
                       >
                         <option value="">{placeholder}</option>
                         {enumOptions.map((opt) => (
@@ -312,7 +312,7 @@ export function CredentialsEditor({
                           }))
                         }
                         placeholder={placeholder}
-                        className="min-w-0 flex-1 rounded-md border border-[color:var(--rule)] bg-[color:var(--bg)] px-2.5 py-1.5 text-[12px] text-[color:var(--ink)] placeholder:text-[color:var(--faint-ink)] focus:border-[color:var(--accent)] focus:outline-none disabled:opacity-50"
+                        className="min-w-0 flex-1 rounded-md border border-[color:var(--rule)] bg-[color:var(--bg)] px-3 py-2 text-[12px] text-[color:var(--ink)] placeholder:text-[color:var(--faint-ink)] focus:border-[color:var(--accent)] focus:outline-none disabled:opacity-50"
                       />
                     );
                   })()
@@ -358,7 +358,7 @@ export function CredentialsEditor({
           type="button"
           onClick={() => void onSave()}
           disabled={saving || dirtyCount === 0}
-          className="inline-flex items-center gap-2 rounded-md bg-[color:var(--accent)] px-3 py-1.5 text-[12px] font-semibold text-[color:var(--fg-on-dark)] shadow-sm transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+          className="inline-flex items-center gap-2 rounded-md bg-[color:var(--accent)] px-3 py-2 text-[12px] font-semibold text-[color:var(--fg-on-dark)] shadow-sm transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
         >
           {saving ? (
             <span className="lume-busy-dots" aria-hidden />

--- a/web-ui/app/_components/store/CredentialsEditor.tsx
+++ b/web-ui/app/_components/store/CredentialsEditor.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { CheckCircle2, KeyRound, Loader2, Trash2 } from 'lucide-react';
+import { CheckCircle2, KeyRound, Trash2 } from 'lucide-react';
 
 import {
   ApiError,
@@ -361,7 +361,7 @@ export function CredentialsEditor({
           className="inline-flex items-center gap-2 rounded-md bg-[color:var(--accent)] px-3 py-1.5 text-[12px] font-semibold text-[color:var(--fg-on-dark)] shadow-sm transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
         >
           {saving ? (
-            <Loader2 className="size-3.5 animate-spin" aria-hidden />
+            <span className="lume-busy-dots" aria-hidden />
           ) : (
             <CheckCircle2 className="size-3.5" aria-hidden />
           )}

--- a/web-ui/app/_components/store/CredentialsEditor.tsx
+++ b/web-ui/app/_components/store/CredentialsEditor.tsx
@@ -358,7 +358,7 @@ export function CredentialsEditor({
           type="button"
           onClick={() => void onSave()}
           disabled={saving || dirtyCount === 0}
-          className="inline-flex items-center gap-2 rounded-md bg-[color:var(--accent)] px-3 py-1.5 text-[12px] font-semibold text-white shadow-sm transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+          className="inline-flex items-center gap-2 rounded-md bg-[color:var(--accent)] px-3 py-1.5 text-[12px] font-semibold text-[color:var(--fg-on-dark)] shadow-sm transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
         >
           {saving ? (
             <Loader2 className="size-3.5 animate-spin" aria-hidden />

--- a/web-ui/app/_components/store/EditFromStoreButton.tsx
+++ b/web-ui/app/_components/store/EditFromStoreButton.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { AlertTriangle, Loader2, Pencil } from 'lucide-react';
+import { AlertTriangle, Pencil } from 'lucide-react';
 
 import { cloneBuilderDraftFromInstalled } from '../../_lib/api';
 import { cn } from '../../_lib/cn';
@@ -85,7 +85,7 @@ export function EditFromStoreButton({
       >
         {busy ? (
           <>
-            <Loader2 className="size-3.5 animate-spin" aria-hidden />
+            <span className="lume-busy-dots" aria-hidden />
             Klone Draft …
           </>
         ) : (

--- a/web-ui/app/_components/store/InstallButton.tsx
+++ b/web-ui/app/_components/store/InstallButton.tsx
@@ -6,8 +6,7 @@ import { useLocale } from 'next-intl';
 import {
   ArrowRight,
   Check,
-  Loader2,
-  Lock,
+    Lock,
   RefreshCw,
   Shield,
   Trash2,
@@ -167,7 +166,7 @@ export function InstallButton({
           {phase.kind === 'success' ? 'Installation erfolgreich' : 'Jetzt installieren'}
         </span>
         {phase.kind === 'creating' ? (
-          <Loader2 className="size-5 animate-spin" aria-hidden />
+          <span className="lume-busy-dots" aria-hidden />
         ) : (
           <ArrowRight
             className="size-5 transition-transform group-hover:translate-x-0.5"
@@ -433,7 +432,7 @@ function InstalledPanel({
               disabled={updating}
               className="inline-flex items-center gap-1.5 rounded-full bg-[color:var(--accent)] px-4 py-1.5 text-[12px] font-semibold text-[color:var(--accent-fg)] disabled:opacity-60"
             >
-              {updating ? <Loader2 className="size-3.5 animate-spin" aria-hidden /> : null}
+              {updating ? <span className="lume-busy-dots" aria-hidden /> : null}
               {updating ? 'Aktualisiere …' : 'Aktualisieren'}
             </button>
           </div>
@@ -530,7 +529,7 @@ function InstalledPanel({
 
       {working && (
         <div className="inline-flex items-center gap-2 text-[12px] text-[color:var(--fg-muted)]">
-          <Loader2 className="size-3.5 animate-spin" aria-hidden />
+          <span className="lume-busy-dots" aria-hidden />
           Wird deinstalliert …
         </div>
       )}
@@ -636,7 +635,7 @@ function InstallDrawer({
 
         {phase.kind === 'creating' ? (
           <div className="flex flex-1 flex-col items-center justify-center gap-3 p-10 text-[color:var(--muted-ink)]">
-            <Loader2 className="size-8 animate-spin" aria-hidden />
+            <span className="lume-busy-dots" aria-hidden />
             <span className="text-sm">Job wird erstellt …</span>
           </div>
         ) : phase.kind === 'error' && !jobFromPhase ? (
@@ -706,7 +705,7 @@ function InstallDrawer({
                 )}
               >
                 {submitting ? (
-                  <Loader2 className="size-4 animate-spin" aria-hidden />
+                  <span className="lume-busy-dots" aria-hidden />
                 ) : null}
                 <span className="text-[15px] font-semibold">
                   {submitting ? 'Wird installiert …' : 'Installation bestätigen'}
@@ -849,7 +848,7 @@ function PrivacyModePicker({
     return (
       <div className="rounded-md border border-[color:var(--border)] bg-[color:var(--bg-soft)] px-3 py-2.5">
         <div className="flex items-center gap-2 text-[11px] text-[color:var(--fg-subtle)]">
-          <Loader2 className="size-3.5 animate-spin" aria-hidden />
+          <span className="lume-busy-dots" aria-hidden />
           Privacy-Mode wird geladen …
         </div>
       </div>
@@ -908,7 +907,7 @@ function PrivacyModePicker({
       </p>
       {saving && (
         <div className="mt-1.5 flex items-center gap-1.5 text-[11px] text-[color:var(--fg-subtle)]">
-          <Loader2 className="size-3 animate-spin" aria-hidden />
+          <span className="lume-busy-dots" aria-hidden />
           Speichere …
         </div>
       )}

--- a/web-ui/app/_components/store/InstallButton.tsx
+++ b/web-ui/app/_components/store/InstallButton.tsx
@@ -112,7 +112,7 @@ export function InstallButton({
           type="button"
           disabled
           className={cn(
-            'group flex w-full items-center justify-between gap-3 rounded-full px-6 py-3.5',
+            'group flex w-full items-center justify-between gap-3 rounded-full px-6 py-3',
             'bg-[color:var(--bg-soft)] ring-1 ring-inset ring-[color:var(--border)]',
             'cursor-not-allowed text-[color:var(--fg-subtle)]',
           )}
@@ -153,7 +153,7 @@ export function InstallButton({
         onClick={handleOpen}
         aria-label={`${pluginName} installieren`}
         className={cn(
-          'group flex w-full items-center justify-between gap-3 rounded-full px-6 py-3.5',
+          'group flex w-full items-center justify-between gap-3 rounded-full px-6 py-3',
           'bg-[color:var(--accent)] text-[color:var(--accent-fg)] shadow-[var(--shadow-cta)]',
           'transition-[background,transform] duration-[var(--dur-fast)] ease-[var(--ease-out)]',
           'hover:bg-[color:var(--accent-hover)] active:translate-y-px active:bg-[color:var(--accent-press)]',
@@ -430,7 +430,7 @@ function InstalledPanel({
               type="button"
               onClick={() => void doUpdate()}
               disabled={updating}
-              className="inline-flex items-center gap-1.5 rounded-full bg-[color:var(--accent)] px-4 py-1.5 text-[12px] font-semibold text-[color:var(--accent-fg)] disabled:opacity-60"
+              className="inline-flex items-center gap-2 rounded-full bg-[color:var(--accent)] px-4 py-2 text-[12px] font-semibold text-[color:var(--accent-fg)] disabled:opacity-60"
             >
               {updating ? <span className="lume-busy-dots" aria-hidden /> : null}
               {updating ? 'Aktualisiere …' : 'Aktualisieren'}
@@ -445,7 +445,7 @@ function InstalledPanel({
       ) : null}
       <div
         className={cn(
-          'flex w-full items-center gap-3 rounded-full px-6 py-3.5',
+          'flex w-full items-center gap-3 rounded-full px-6 py-3',
           'bg-[color:var(--success)]/10 ring-1 ring-inset ring-[color:var(--success)]/40',
           'text-[color:var(--success)]',
         )}
@@ -510,7 +510,7 @@ function InstalledPanel({
             <button
               type="button"
               onClick={doUninstall}
-              className="rounded-full bg-[color:var(--danger,#b03030)] px-4 py-1.5 text-[12px] font-semibold text-[color:var(--fg-on-dark)]"
+              className="rounded-full bg-[color:var(--danger,#b03030)] px-4 py-2 text-[12px] font-semibold text-[color:var(--fg-on-dark)]"
             >
               {alsoDeletePackage
                 ? 'Ja, deinstallieren + löschen'
@@ -519,7 +519,7 @@ function InstalledPanel({
             <button
               type="button"
               onClick={() => setState({ kind: 'idle' })}
-              className="rounded-full bg-[color:var(--bg)] px-4 py-1.5 text-[12px] font-semibold text-[color:var(--fg-muted)] ring-1 ring-inset ring-[color:var(--border)]"
+              className="rounded-full bg-[color:var(--bg)] px-4 py-2 text-[12px] font-semibold text-[color:var(--fg-muted)] ring-1 ring-inset ring-[color:var(--border)]"
             >
               Abbrechen
             </button>
@@ -634,12 +634,12 @@ function InstallDrawer({
         </header>
 
         {phase.kind === 'creating' ? (
-          <div className="flex flex-1 flex-col items-center justify-center gap-3 p-10 text-[color:var(--muted-ink)]">
+          <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-[color:var(--muted-ink)]">
             <span className="lume-busy-dots" aria-hidden />
             <span className="text-sm">Job wird erstellt …</span>
           </div>
         ) : phase.kind === 'error' && !jobFromPhase ? (
-          <div className="min-h-0 flex-1 overflow-y-auto p-10">
+          <div className="min-h-0 flex-1 overflow-y-auto p-8">
             <InstallErrorBlock message={phase.message} />
           </div>
         ) : (
@@ -669,7 +669,7 @@ function InstallDrawer({
                   Installation rechts unten.
                 </p>
               ) : (
-                <div className="space-y-5">
+                <div className="space-y-4">
                   {fields.map((field) => (
                     <FieldRow
                       key={field.key}
@@ -687,7 +687,7 @@ function InstallDrawer({
               ) : null}
             </div>
 
-            <footer className="flex items-center justify-between gap-3 border-t border-[color:var(--rule)] bg-[color:var(--paper-soft)] px-8 py-5">
+            <footer className="flex items-center justify-between gap-3 border-t border-[color:var(--rule)] bg-[color:var(--paper-soft)] px-8 py-4">
               <p className="text-[11px] leading-relaxed text-[color:var(--muted-ink)]">
                 Secrets werden ausschließlich im per-Agent-Vault abgelegt.
                 <br />
@@ -846,7 +846,7 @@ function PrivacyModePicker({
 
   if (!loaded) {
     return (
-      <div className="rounded-md border border-[color:var(--border)] bg-[color:var(--bg-soft)] px-3 py-2.5">
+      <div className="rounded-md border border-[color:var(--border)] bg-[color:var(--bg-soft)] px-3 py-3">
         <div className="flex items-center gap-2 text-[11px] text-[color:var(--fg-subtle)]">
           <span className="lume-busy-dots" aria-hidden />
           Privacy-Mode wird geladen …
@@ -870,7 +870,7 @@ function PrivacyModePicker({
       : 'border-[color:var(--border)] bg-[color:var(--bg-soft)]';
 
   return (
-    <div className={cn('rounded-md border px-3 py-2.5', tone)}>
+    <div className={cn('rounded-md border px-3 py-3', tone)}>
       <label
         htmlFor={`privacy-mode-${pluginId}`}
         className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)]"
@@ -884,7 +884,7 @@ function PrivacyModePicker({
         disabled={saving}
         onChange={(e) => void handleChange(e.target.value as PrivacyMode)}
         className={cn(
-          'mt-1.5 w-full rounded border px-2 py-1.5 text-[13px]',
+          'mt-2 w-full rounded border px-2 py-2 text-[13px]',
           'border-[color:var(--border)] bg-[color:var(--bg)]',
           'focus:outline-none focus:ring-1 focus:ring-[color:var(--accent)]',
           saving ? 'opacity-60' : '',
@@ -898,7 +898,7 @@ function PrivacyModePicker({
           ),
         )}
       </select>
-      <p className="mt-1.5 text-[11px] leading-relaxed text-[color:var(--fg-subtle)]">
+      <p className="mt-2 text-[11px] leading-relaxed text-[color:var(--fg-subtle)]">
         {mode === 'guarded'
           ? 'Tool-Ergebnisse werden serverseitig hinter dem Privacy Shield v4 maskiert; der LLM sieht nur identitätsfreie Digests.'
           : mode === 'bypass'
@@ -906,13 +906,13 @@ function PrivacyModePicker({
             : 'Per-Tool-Whitelist: nur explizit gelistete Tools werden bypassed. Liste über das Feld `_privacy_bypass_scopes` setzen (Komma-getrennt).'}
       </p>
       {saving && (
-        <div className="mt-1.5 flex items-center gap-1.5 text-[11px] text-[color:var(--fg-subtle)]">
+        <div className="mt-2 flex items-center gap-2 text-[11px] text-[color:var(--fg-subtle)]">
           <span className="lume-busy-dots" aria-hidden />
           Speichere …
         </div>
       )}
       {error && (
-        <p className="font-mono-num mt-1.5 text-[11px] text-[color:var(--danger,#b03030)]">
+        <p className="font-mono-num mt-2 text-[11px] text-[color:var(--danger,#b03030)]">
           {error}
         </p>
       )}

--- a/web-ui/app/_components/store/InstallButton.tsx
+++ b/web-ui/app/_components/store/InstallButton.tsx
@@ -418,7 +418,7 @@ function InstalledPanel({
   return (
     <div className="space-y-3">
       {update ? (
-        <div className="rounded-[10px] border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/5 px-4 py-3">
+        <div className="rounded-md border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/5 px-4 py-3">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <span className="flex items-center gap-2 text-[13px] text-[color:var(--fg)]">
               <RefreshCw className="size-4 text-[color:var(--accent)]" aria-hidden />
@@ -483,7 +483,7 @@ function InstalledPanel({
       )}
 
       {state.kind === 'confirming' && (
-        <div className="rounded-[10px] border border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-3">
+        <div className="rounded-md border border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-3">
           <p className="text-[12px] leading-relaxed text-[color:var(--fg)]">
             <strong>{pluginName}</strong> entfernen? Tool wird sofort aus dem
             Orchestrator abgebaut, der Vault-Namespace wird geleert, Registry-
@@ -511,7 +511,7 @@ function InstalledPanel({
             <button
               type="button"
               onClick={doUninstall}
-              className="rounded-full bg-[color:var(--danger,#b03030)] px-4 py-1.5 text-[12px] font-semibold text-white"
+              className="rounded-full bg-[color:var(--danger,#b03030)] px-4 py-1.5 text-[12px] font-semibold text-[color:var(--fg-on-dark)]"
             >
               {alsoDeletePackage
                 ? 'Ja, deinstallieren + löschen'
@@ -536,7 +536,7 @@ function InstalledPanel({
       )}
 
       {state.kind === 'error' && (
-        <div className="rounded-[10px] border border-[color:var(--danger,#b03030)]/40 bg-[color:var(--danger,#b03030)]/6 px-3 py-2">
+        <div className="rounded-md border border-[color:var(--danger,#b03030)]/40 bg-[color:var(--danger,#b03030)]/6 px-3 py-2">
           <p className="text-[12px] text-[color:var(--danger,#b03030)]">
             Deinstallation fehlgeschlagen: {state.message}
           </p>
@@ -847,7 +847,7 @@ function PrivacyModePicker({
 
   if (!loaded) {
     return (
-      <div className="rounded-[10px] border border-[color:var(--border)] bg-[color:var(--bg-soft)] px-3 py-2.5">
+      <div className="rounded-md border border-[color:var(--border)] bg-[color:var(--bg-soft)] px-3 py-2.5">
         <div className="flex items-center gap-2 text-[11px] text-[color:var(--fg-subtle)]">
           <Loader2 className="size-3.5 animate-spin" aria-hidden />
           Privacy-Mode wird geladen …
@@ -857,7 +857,7 @@ function PrivacyModePicker({
   }
   if (mode === null) {
     return (
-      <div className="rounded-[10px] border border-[color:var(--danger,#b03030)]/40 bg-[color:var(--danger,#b03030)]/5 px-3 py-2">
+      <div className="rounded-md border border-[color:var(--danger,#b03030)]/40 bg-[color:var(--danger,#b03030)]/5 px-3 py-2">
         <p className="text-[12px] text-[color:var(--danger,#b03030)]">
           Privacy-Mode konnte nicht geladen werden{error ? `: ${error}` : '.'}
         </p>
@@ -867,11 +867,11 @@ function PrivacyModePicker({
 
   const tone =
     mode === 'bypass'
-      ? 'border-amber-300 bg-amber-50/50 dark:border-amber-800/60 dark:bg-amber-950/20'
+      ? 'border-[color:var(--warning)] bg-[color:var(--warning)]/10'
       : 'border-[color:var(--border)] bg-[color:var(--bg-soft)]';
 
   return (
-    <div className={cn('rounded-[10px] border px-3 py-2.5', tone)}>
+    <div className={cn('rounded-md border px-3 py-2.5', tone)}>
       <label
         htmlFor={`privacy-mode-${pluginId}`}
         className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)]"

--- a/web-ui/app/_components/store/PluginCard.tsx
+++ b/web-ui/app/_components/store/PluginCard.tsx
@@ -64,13 +64,13 @@ export function PluginCard({ plugin }: PluginCardProps): React.ReactElement {
         </div>
       </div>
 
-      <p className="mt-5 line-clamp-3 text-[14px] leading-relaxed text-[color:var(--fg-muted)]">
+      <p className="mt-4 line-clamp-3 text-[14px] leading-relaxed text-[color:var(--fg-muted)]">
         {plugin.description || <em>Keine Beschreibung hinterlegt.</em>}
       </p>
 
       {/* Metadata row. An update-available plugin IS installed — show that
           inline; the update itself is the top-right Störer. */}
-      <div className="mt-5 flex flex-wrap items-center gap-1.5">
+      <div className="mt-4 flex flex-wrap items-center gap-2">
         <StateBadge
           state={hasUpdate ? 'installed' : plugin.install_state}
           isLegacy={isLegacy}
@@ -93,7 +93,7 @@ export function PluginCard({ plugin }: PluginCardProps): React.ReactElement {
 
       {/* Integrations pinned at bottom */}
       {visibleIntegrations.length > 0 ? (
-        <div className="mt-5 border-t border-[color:var(--divider)] pt-3">
+        <div className="mt-4 border-t border-[color:var(--divider)] pt-3">
           <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-[11px]">
             <span className="uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
               Integration

--- a/web-ui/app/_components/store/PluginCard.tsx
+++ b/web-ui/app/_components/store/PluginCard.tsx
@@ -21,7 +21,7 @@ export function PluginCard({ plugin }: PluginCardProps): React.ReactElement {
   return (
     <Link
       href={`/store/${encodeURIComponent(plugin.id)}`}
-      className="group relative flex flex-col rounded-[14px] bg-[color:var(--bg-elevated)] p-6 shadow-[0_2px_6px_rgba(0,75,115,0.08)] transition-[transform,box-shadow] duration-[var(--dur-base)] ease-[var(--ease-out)] hover:-translate-y-0.5 hover:shadow-[0_8px_24px_rgba(0,75,115,0.10)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent)]"
+      className="group relative flex flex-col rounded-lg bg-[color:var(--bg-elevated)] p-6 shadow-[0_2px_6px_rgba(0,75,115,0.08)] transition-[transform,box-shadow] duration-[var(--dur-base)] ease-[var(--ease-out)] hover:-translate-y-0.5 hover:shadow-[0_8px_24px_rgba(0,75,115,0.10)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent)]"
     >
       {/* Update "Störer" — prominent top-right sticker. Only on plugins where a
           configured registry advertises a newer version than the installed one

--- a/web-ui/app/_components/store/RequiresWizard.tsx
+++ b/web-ui/app/_components/store/RequiresWizard.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Check, Loader2, X } from 'lucide-react';
+import { Check, X } from 'lucide-react';
 
 import { cn } from '../../_lib/cn';
 import {
@@ -480,7 +480,7 @@ function InstallingBody({
   return (
     <div className="space-y-5">
       <div className="flex items-center gap-3">
-        <Loader2 className="size-5 animate-spin text-[color:var(--accent)]" aria-hidden />
+        <span className="lume-busy-dots" aria-hidden />
         <div>
           <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--faint-ink)]">
             Schritt {phase.stepIndex + 1} / {phase.stepCount}
@@ -541,7 +541,7 @@ function SuccessBody({
 }): React.ReactElement {
   return (
     <div className="flex flex-col items-center gap-3 py-6 text-center">
-      <div className="flex size-12 items-center justify-center rounded-full bg-[color:var(--success)]/10 text-[color:var(--success)]">
+      <div className="flex size-12 items-center justify-center text-[color:var(--success)]">
         <Check className="size-6" aria-hidden />
       </div>
       <div className="font-display text-xl text-[color:var(--ink)]">

--- a/web-ui/app/_components/store/RequiresWizard.tsx
+++ b/web-ui/app/_components/store/RequiresWizard.tsx
@@ -126,7 +126,7 @@ export function RequiresWizard({
           'max-h-[90vh] overflow-hidden',
         )}
       >
-        <header className="flex items-start justify-between gap-6 border-b border-[color:var(--rule)] px-7 py-5">
+        <header className="flex items-start justify-between gap-6 border-b border-[color:var(--rule)] px-6 py-4">
           <div className="min-w-0">
             <div className="text-[11px] uppercase tracking-[0.22em] text-[color:var(--faint-ink)]">
               Voraussetzungen
@@ -151,7 +151,7 @@ export function RequiresWizard({
           </button>
         </header>
 
-        <div className="flex-1 overflow-y-auto px-7 py-6">
+        <div className="flex-1 overflow-y-auto px-6 py-6">
           {phase.kind === 'review' ? (
             <ReviewBody
               selections={selections}
@@ -182,7 +182,7 @@ export function RequiresWizard({
           )}
         </div>
 
-        <footer className="flex items-center justify-between gap-3 border-t border-[color:var(--rule)] bg-[color:var(--paper-soft)] px-7 py-4">
+        <footer className="flex items-center justify-between gap-3 border-t border-[color:var(--rule)] bg-[color:var(--paper-soft)] px-6 py-4">
           <p className="text-[11px] leading-relaxed text-[color:var(--faint-ink)]">
             {phase.kind === 'review'
               ? `${selections.length} Voraussetzung${selections.length === 1 ? '' : 'en'} → ${targetPluginName}`
@@ -207,7 +207,7 @@ export function RequiresWizard({
                   onClick={runInstallChain}
                   disabled={!allResolved}
                   className={cn(
-                    'inline-flex items-center gap-2 rounded-full px-5 py-2',
+                    'inline-flex items-center gap-2 rounded-full px-4 py-2',
                     'bg-[color:var(--accent)] text-[color:var(--accent-fg)] shadow-[var(--shadow-cta)]',
                     'transition-[background,transform] duration-[var(--dur-fast)] ease-[var(--ease-out)]',
                     'hover:bg-[color:var(--accent-hover)] active:translate-y-px',
@@ -224,7 +224,7 @@ export function RequiresWizard({
                 type="button"
                 onClick={() => formRef.current?.requestSubmit()}
                 className={cn(
-                  'inline-flex items-center gap-2 rounded-full px-5 py-2',
+                  'inline-flex items-center gap-2 rounded-full px-4 py-2',
                   'bg-[color:var(--accent)] text-[color:var(--accent-fg)] shadow-[var(--shadow-cta)]',
                 )}
               >
@@ -239,7 +239,7 @@ export function RequiresWizard({
                   onClose();
                   router.refresh();
                 }}
-                className="rounded-full bg-[color:var(--accent)] px-5 py-2 text-[13px] font-semibold text-[color:var(--accent-fg)]"
+                className="rounded-full bg-[color:var(--accent)] px-4 py-2 text-[13px] font-semibold text-[color:var(--accent-fg)]"
               >
                 Schließen
               </button>
@@ -355,7 +355,7 @@ function ReviewBody({
   onChange: (idx: number, providerId: string | null) => void;
 }): React.ReactElement {
   return (
-    <div className="space-y-5">
+    <div className="space-y-4">
       {selections.map((sel, idx) => (
         <ProviderPickRow
           key={sel.capability}
@@ -478,7 +478,7 @@ function InstallingBody({
   const fields: InstallSetupField[] = phase.currentJob?.setup_schema?.fields ?? [];
 
   return (
-    <div className="space-y-5">
+    <div className="space-y-4">
       <div className="flex items-center gap-3">
         <span className="lume-busy-dots" aria-hidden />
         <div>

--- a/web-ui/app/_components/store/SelfExtensionPanel.tsx
+++ b/web-ui/app/_components/store/SelfExtensionPanel.tsx
@@ -202,23 +202,23 @@ export function SelfExtensionPanel({ agentId }: { agentId: string }): React.Reac
           value={rationale}
           onChange={(e) => setRationale(e.target.value)}
           placeholder={t('rationalePlaceholder')}
-          className="mt-2 w-full rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-1.5 text-[13px] focus:outline-none focus:ring-1 focus:ring-[color:var(--accent)]"
+          className="mt-2 w-full rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-2 text-[13px] focus:outline-none focus:ring-1 focus:ring-[color:var(--accent)]"
         />
         <textarea
           value={patchesText}
           onChange={(e) => setPatchesText(e.target.value)}
           placeholder={t('patchesPlaceholder')}
           rows={4}
-          className="font-mono-num mt-2 w-full rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-1.5 text-[12px] focus:outline-none focus:ring-1 focus:ring-[color:var(--accent)]"
+          className="font-mono-num mt-2 w-full rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-2 text-[12px] focus:outline-none focus:ring-1 focus:ring-[color:var(--accent)]"
         />
         {composeError ? (
-          <p className="font-mono-num mt-1.5 text-[11px] text-[color:var(--danger,#b03030)]">{composeError}</p>
+          <p className="font-mono-num mt-2 text-[11px] text-[color:var(--danger,#b03030)]">{composeError}</p>
         ) : null}
         <button
           type="button"
           onClick={() => void handlePropose()}
           disabled={composeBusy || rationale.trim().length === 0 || patchesText.trim().length === 0}
-          className="mt-2 inline-flex items-center gap-1.5 rounded-full bg-[color:var(--accent)] px-4 py-1.5 text-[12px] font-semibold text-[color:var(--accent-fg)] disabled:opacity-60"
+          className="mt-2 inline-flex items-center gap-2 rounded-full bg-[color:var(--accent)] px-4 py-2 text-[12px] font-semibold text-[color:var(--accent-fg)] disabled:opacity-60"
         >
           {composeBusy ? <span className="lume-busy-dots" aria-hidden /> : null}
           {composeBusy ? t('proposing') : t('propose')}
@@ -235,7 +235,7 @@ export function SelfExtensionPanel({ agentId }: { agentId: string }): React.Reac
           <select
             value={tplId}
             onChange={(e) => setTplId(e.target.value)}
-            className="mt-2 w-full rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-1.5 text-[13px] focus:outline-none focus:ring-1 focus:ring-[color:var(--accent)]"
+            className="mt-2 w-full rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-2 text-[13px] focus:outline-none focus:ring-1 focus:ring-[color:var(--accent)]"
           >
             {templates.map((tpl) => (
               <option key={tpl.id} value={tpl.id}>
@@ -244,7 +244,7 @@ export function SelfExtensionPanel({ agentId }: { agentId: string }): React.Reac
             ))}
           </select>
           {templates.find((x) => x.id === tplId)?.description ? (
-            <p className="mt-1.5 text-[11px] leading-relaxed text-[color:var(--fg-subtle)]">
+            <p className="mt-2 text-[11px] leading-relaxed text-[color:var(--fg-subtle)]">
               {templates.find((x) => x.id === tplId)?.description}
             </p>
           ) : null}
@@ -253,23 +253,23 @@ export function SelfExtensionPanel({ agentId }: { agentId: string }): React.Reac
             value={tplRationale}
             onChange={(e) => setTplRationale(e.target.value)}
             placeholder={t('rationalePlaceholder')}
-            className="mt-2 w-full rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-1.5 text-[13px] focus:outline-none focus:ring-1 focus:ring-[color:var(--accent)]"
+            className="mt-2 w-full rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-2 text-[13px] focus:outline-none focus:ring-1 focus:ring-[color:var(--accent)]"
           />
           <textarea
             value={tplParamsText}
             onChange={(e) => setTplParamsText(e.target.value)}
             placeholder={t('templateParamsPlaceholder')}
             rows={3}
-            className="font-mono-num mt-2 w-full rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-1.5 text-[12px] focus:outline-none focus:ring-1 focus:ring-[color:var(--accent)]"
+            className="font-mono-num mt-2 w-full rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-2 text-[12px] focus:outline-none focus:ring-1 focus:ring-[color:var(--accent)]"
           />
           {tplError ? (
-            <p className="font-mono-num mt-1.5 text-[11px] text-[color:var(--danger,#b03030)]">{tplError}</p>
+            <p className="font-mono-num mt-2 text-[11px] text-[color:var(--danger,#b03030)]">{tplError}</p>
           ) : null}
           <button
             type="button"
             onClick={() => void handleProposeTemplate()}
             disabled={tplBusy || tplRationale.trim().length === 0 || tplId.length === 0}
-            className="mt-2 inline-flex items-center gap-1.5 rounded-full bg-[color:var(--accent)] px-4 py-1.5 text-[12px] font-semibold text-[color:var(--accent-fg)] disabled:opacity-60"
+            className="mt-2 inline-flex items-center gap-2 rounded-full bg-[color:var(--accent)] px-4 py-2 text-[12px] font-semibold text-[color:var(--accent-fg)] disabled:opacity-60"
           >
             {tplBusy ? <span className="lume-busy-dots" aria-hidden /> : null}
             {tplBusy ? t('proposing') : t('proposeTemplate')}
@@ -301,7 +301,7 @@ export function SelfExtensionPanel({ agentId }: { agentId: string }): React.Reac
 
               {p.escalations.length > 0 ? (
                 <div className="mt-2 rounded border border-[color:var(--danger,#b03030)]/40 bg-[color:var(--danger,#b03030)]/6 p-2">
-                  <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--danger,#b03030)]">
+                  <div className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--danger,#b03030)]">
                     <AlertTriangle className="size-3.5" aria-hidden />
                     {t('escalationsTitle')}
                   </div>
@@ -367,7 +367,7 @@ export function SelfExtensionPanel({ agentId }: { agentId: string }): React.Reac
                       type="button"
                       disabled={actionBusyId === p.id}
                       onClick={() => void runAction(p.id, () => approveSelfExtensionProposal(p.id))}
-                      className="inline-flex items-center gap-1.5 rounded-full bg-[color:var(--accent)] px-3 py-1 text-[12px] font-semibold text-[color:var(--accent-fg)] disabled:opacity-60"
+                      className="inline-flex items-center gap-2 rounded-full bg-[color:var(--accent)] px-3 py-1 text-[12px] font-semibold text-[color:var(--accent-fg)] disabled:opacity-60"
                     >
                       {actionBusyId === p.id ? <span className="lume-busy-dots" aria-hidden /> : <Check className="size-3.5" aria-hidden />}
                       {t('approve')}
@@ -376,7 +376,7 @@ export function SelfExtensionPanel({ agentId }: { agentId: string }): React.Reac
                       type="button"
                       disabled={actionBusyId === p.id}
                       onClick={() => setDenyFor(p.id)}
-                      className="inline-flex items-center gap-1.5 rounded-full bg-[color:var(--bg-soft)] px-3 py-1 text-[12px] font-semibold text-[color:var(--fg-muted)] ring-1 ring-inset ring-[color:var(--border)]"
+                      className="inline-flex items-center gap-2 rounded-full bg-[color:var(--bg-soft)] px-3 py-1 text-[12px] font-semibold text-[color:var(--fg-muted)] ring-1 ring-inset ring-[color:var(--border)]"
                     >
                       <X className="size-3.5" aria-hidden />
                       {t('deny')}
@@ -395,7 +395,7 @@ export function SelfExtensionPanel({ agentId }: { agentId: string }): React.Reac
                       router.refresh();
                     })
                   }
-                  className="mt-3 inline-flex items-center gap-1.5 rounded-full bg-[color:var(--accent)] px-3 py-1 text-[12px] font-semibold text-[color:var(--accent-fg)] disabled:opacity-60"
+                  className="mt-3 inline-flex items-center gap-2 rounded-full bg-[color:var(--accent)] px-3 py-1 text-[12px] font-semibold text-[color:var(--accent-fg)] disabled:opacity-60"
                 >
                   {actionBusyId === p.id ? <span className="lume-busy-dots" aria-hidden /> : null}
                   {actionBusyId === p.id ? t('installing') : t('install')}
@@ -427,7 +427,7 @@ function DecisionBadge({
           ? 'text-[color:var(--danger,#b03030)] border-[color:var(--danger,#b03030)]/40 bg-[color:var(--danger,#b03030)]/6'
           : 'text-[color:var(--fg-muted)] border-[color:var(--border)] bg-[color:var(--bg-soft)]';
   return (
-    <span className={cn('inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-[11px] font-semibold', tone)}>
+    <span className={cn('inline-flex items-center gap-2 rounded-full border px-3 py-0.5 text-[11px] font-semibold', tone)}>
       <ShieldQuestion className="size-3.5" aria-hidden />
       {t(`status_${status}`)} · {t(`decision_${decision}`)}
     </span>

--- a/web-ui/app/_components/store/SelfExtensionPanel.tsx
+++ b/web-ui/app/_components/store/SelfExtensionPanel.tsx
@@ -192,7 +192,7 @@ export function SelfExtensionPanel({ agentId }: { agentId: string }): React.Reac
       <p className="text-[12px] leading-relaxed text-[color:var(--fg-muted)]">{t('intro')}</p>
 
       {/* compose */}
-      <div className="rounded-[10px] border border-[color:var(--border)] bg-[color:var(--bg-soft)] p-3">
+      <div className="rounded-md border border-[color:var(--border)] bg-[color:var(--bg-soft)] p-3">
         <label className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
           <Sparkles className="size-3.5" aria-hidden />
           {t('composeTitle')}
@@ -227,7 +227,7 @@ export function SelfExtensionPanel({ agentId }: { agentId: string }): React.Reac
 
       {/* template compose (standalone plugins that expose selfExtend templates) */}
       {templates.length > 0 ? (
-        <div className="rounded-[10px] border border-[color:var(--border)] bg-[color:var(--bg-soft)] p-3">
+        <div className="rounded-md border border-[color:var(--border)] bg-[color:var(--bg-soft)] p-3">
           <label className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
             <Sparkles className="size-3.5" aria-hidden />
             {t('templateComposeTitle')}
@@ -290,7 +290,7 @@ export function SelfExtensionPanel({ agentId }: { agentId: string }): React.Reac
       ) : (
         <ul className="space-y-3">
           {proposals.map((p) => (
-            <li key={p.id} className="rounded-[10px] border border-[color:var(--border)] bg-[color:var(--bg)] p-3">
+            <li key={p.id} className="rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] p-3">
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <DecisionBadge decision={p.decision} status={p.status} t={t} />
                 <span className="font-mono-num text-[10px] text-[color:var(--fg-subtle)]">
@@ -346,7 +346,7 @@ export function SelfExtensionPanel({ agentId }: { agentId: string }): React.Reac
                       type="button"
                       disabled={actionBusyId === p.id || denyReason.trim().length === 0}
                       onClick={() => void runAction(p.id, () => denySelfExtensionProposal(p.id, denyReason))}
-                      className="rounded-full bg-[color:var(--danger,#b03030)] px-3 py-1 text-[12px] font-semibold text-white disabled:opacity-60"
+                      className="rounded-full bg-[color:var(--danger,#b03030)] px-3 py-1 text-[12px] font-semibold text-[color:var(--fg-on-dark)] disabled:opacity-60"
                     >
                       {t('confirmDeny')}
                     </button>

--- a/web-ui/app/_components/store/SelfExtensionPanel.tsx
+++ b/web-ui/app/_components/store/SelfExtensionPanel.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { AlertTriangle, Check, Loader2, ShieldQuestion, Sparkles, X } from 'lucide-react';
+import { AlertTriangle, Check, ShieldQuestion, Sparkles, X } from 'lucide-react';
 
 import { cn } from '../../_lib/cn';
 import {
@@ -220,7 +220,7 @@ export function SelfExtensionPanel({ agentId }: { agentId: string }): React.Reac
           disabled={composeBusy || rationale.trim().length === 0 || patchesText.trim().length === 0}
           className="mt-2 inline-flex items-center gap-1.5 rounded-full bg-[color:var(--accent)] px-4 py-1.5 text-[12px] font-semibold text-[color:var(--accent-fg)] disabled:opacity-60"
         >
-          {composeBusy ? <Loader2 className="size-3.5 animate-spin" aria-hidden /> : null}
+          {composeBusy ? <span className="lume-busy-dots" aria-hidden /> : null}
           {composeBusy ? t('proposing') : t('propose')}
         </button>
       </div>
@@ -271,7 +271,7 @@ export function SelfExtensionPanel({ agentId }: { agentId: string }): React.Reac
             disabled={tplBusy || tplRationale.trim().length === 0 || tplId.length === 0}
             className="mt-2 inline-flex items-center gap-1.5 rounded-full bg-[color:var(--accent)] px-4 py-1.5 text-[12px] font-semibold text-[color:var(--accent-fg)] disabled:opacity-60"
           >
-            {tplBusy ? <Loader2 className="size-3.5 animate-spin" aria-hidden /> : null}
+            {tplBusy ? <span className="lume-busy-dots" aria-hidden /> : null}
             {tplBusy ? t('proposing') : t('proposeTemplate')}
           </button>
         </div>
@@ -280,7 +280,7 @@ export function SelfExtensionPanel({ agentId }: { agentId: string }): React.Reac
       {/* list */}
       {proposals === null ? (
         <div className="inline-flex items-center gap-2 text-[12px] text-[color:var(--fg-subtle)]">
-          <Loader2 className="size-3.5 animate-spin" aria-hidden />
+          <span className="lume-busy-dots" aria-hidden />
           {t('loading')}
         </div>
       ) : loadError ? (
@@ -369,7 +369,7 @@ export function SelfExtensionPanel({ agentId }: { agentId: string }): React.Reac
                       onClick={() => void runAction(p.id, () => approveSelfExtensionProposal(p.id))}
                       className="inline-flex items-center gap-1.5 rounded-full bg-[color:var(--accent)] px-3 py-1 text-[12px] font-semibold text-[color:var(--accent-fg)] disabled:opacity-60"
                     >
-                      {actionBusyId === p.id ? <Loader2 className="size-3.5 animate-spin" aria-hidden /> : <Check className="size-3.5" aria-hidden />}
+                      {actionBusyId === p.id ? <span className="lume-busy-dots" aria-hidden /> : <Check className="size-3.5" aria-hidden />}
                       {t('approve')}
                     </button>
                     <button
@@ -397,7 +397,7 @@ export function SelfExtensionPanel({ agentId }: { agentId: string }): React.Reac
                   }
                   className="mt-3 inline-flex items-center gap-1.5 rounded-full bg-[color:var(--accent)] px-3 py-1 text-[12px] font-semibold text-[color:var(--accent-fg)] disabled:opacity-60"
                 >
-                  {actionBusyId === p.id ? <Loader2 className="size-3.5 animate-spin" aria-hidden /> : null}
+                  {actionBusyId === p.id ? <span className="lume-busy-dots" aria-hidden /> : null}
                   {actionBusyId === p.id ? t('installing') : t('install')}
                 </button>
               ) : null}

--- a/web-ui/app/_components/store/StateBadge.tsx
+++ b/web-ui/app/_components/store/StateBadge.tsx
@@ -34,7 +34,7 @@ export function StateBadge({
     return (
       <span
         className={cn(
-          'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5',
+          'inline-flex items-center gap-2 rounded-full border px-3 py-0.5',
           'text-[11px] font-medium uppercase tracking-[0.12em]',
           'text-[color:var(--warning)] border-[color:var(--warning)]/50 bg-[color:var(--warning)]/12',
           className,
@@ -51,7 +51,7 @@ export function StateBadge({
   return (
     <span
       className={cn(
-        'inline-flex items-center rounded-full border px-2.5 py-0.5',
+        'inline-flex items-center rounded-full border px-3 py-0.5',
         'text-[11px] font-medium uppercase tracking-[0.12em]',
         STYLE[state],
         className,

--- a/web-ui/app/_components/store/UploadDropzone.tsx
+++ b/web-ui/app/_components/store/UploadDropzone.tsx
@@ -99,7 +99,7 @@ export function UploadDropzone(): React.ReactElement {
   return (
     <section
       className={cn(
-        'rounded-[14px] border border-dashed transition-colors',
+        'rounded-lg border border-dashed transition-colors',
         'bg-[color:var(--bg-soft)]',
         dragging
           ? 'border-[color:var(--accent)] bg-[color:var(--accent)]/6'
@@ -165,7 +165,7 @@ export function UploadDropzone(): React.ReactElement {
                 className={cn(
                   'inline-flex items-center gap-2 rounded-full px-4 py-1.5',
                   'text-[13px] font-semibold',
-                  'bg-[color:var(--accent)] text-white shadow-[var(--shadow-cta)]',
+                  'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]',
                   'hover:brightness-110',
                 )}
               >
@@ -260,7 +260,7 @@ function SuccessRow({
   onDismiss: () => void;
 }): React.ReactElement {
   return (
-    <div className="mt-4 rounded-[10px] border border-[color:var(--success,#2a8a5f)]/40 bg-[color:var(--success,#2a8a5f)]/6 px-4 py-3">
+    <div className="mt-4 rounded-md border border-[color:var(--success,#2a8a5f)]/40 bg-[color:var(--success,#2a8a5f)]/6 px-4 py-3">
       <div className="flex items-baseline gap-2 text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--success,#2a8a5f)]">
         <span>✓ Hochgeladen</span>
         <span className="h-px flex-1 bg-[color:var(--success,#2a8a5f)]/30" />
@@ -307,7 +307,7 @@ function ErrorRow({
   onDismiss: () => void;
 }): React.ReactElement {
   return (
-    <div className="mt-4 rounded-[10px] border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/6 px-4 py-3">
+    <div className="mt-4 rounded-md border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/6 px-4 py-3">
       <div className="flex items-baseline gap-2 text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--danger)]">
         <span>Upload fehlgeschlagen</span>
         <span className="h-px flex-1 bg-[color:var(--danger)]/30" />

--- a/web-ui/app/_components/store/UploadDropzone.tsx
+++ b/web-ui/app/_components/store/UploadDropzone.tsx
@@ -112,7 +112,7 @@ export function UploadDropzone(): React.ReactElement {
       onDragLeave={() => setDragging(false)}
       onDrop={onDrop}
     >
-      <div className="flex items-start gap-5 px-6 py-5">
+      <div className="flex items-start gap-4 px-6 py-4">
         <div
           className={cn(
             'flex h-12 w-12 flex-none items-center justify-center rounded-full',
@@ -163,7 +163,7 @@ export function UploadDropzone(): React.ReactElement {
                 type="button"
                 onClick={() => fileInputRef.current?.click()}
                 className={cn(
-                  'inline-flex items-center gap-2 rounded-full px-4 py-1.5',
+                  'inline-flex items-center gap-2 rounded-full px-4 py-2',
                   'text-[13px] font-semibold',
                   'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]',
                   'hover:brightness-110',

--- a/web-ui/app/_components/store/WorkaroundBadge.tsx
+++ b/web-ui/app/_components/store/WorkaroundBadge.tsx
@@ -48,7 +48,7 @@ export function WorkaroundBadge({
   const content = (
     <span
       className={cn(
-        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5',
+        'inline-flex items-center gap-2 rounded-full border px-3 py-0.5',
         'text-[11px] font-medium uppercase tracking-[0.12em]',
         STYLE[status],
         className,

--- a/web-ui/app/_lib/design-tokens.ts
+++ b/web-ui/app/_lib/design-tokens.ts
@@ -1,95 +1,97 @@
 /**
- * Harness Platform — Design Tokens (TypeScript mirror of byte5 brand)
+ * omadia operator UI — Design Tokens (TypeScript mirror of the Lume tokens)
  * ---------------------------------------------------------------------------
- * The authoritative source is `theme.css`. This mirror exists for cases
- * where CSS var() isn't an option (Cytoscape canvas styles, chart libs,
- * canvas-drawn components). KEEP IN SYNC with theme.css.
+ * The authoritative source is `theme.css` (Lume, omadia visual spec v0.4).
+ * This mirror exists for the few cases where CSS `var()` isn't reachable —
+ * Cytoscape canvas styles, chart libs, canvas-drawn components. KEEP IN SYNC
+ * with theme.css.
  *
- * Brand summary (per byte5 README):
- *   - Core palette: only 5 colours (Blau, Blau dunkel, Weiss, Schwarz, Magenta).
- *   - Magenta is reserved for the signature ":" device — no state / UI chrome.
- *   - Typography: Days One for display/logo only; Nunito Sans for body.
- *   - Radii: pill (9999px) for CTAs + small (8–14px) for cards. No mid radii.
+ * Note on palette + mode: theme.css resolves three accent palettes (Petrol,
+ * Atelier, Lagoon) across light/dark via `light-dark()` + `[data-palette]`.
+ * This static mirror can only hold one snapshot, so it carries the **Lagoon
+ * light** defaults (the spec's default palette, §2.5.3). Canvas/chart surfaces
+ * that must follow the live palette/mode should read the CSS custom properties
+ * off `getComputedStyle(document.documentElement)` instead of these constants.
  */
 
 export const tokens = {
-  /** CORE — the five brand-official colours. */
-  brand: {
-    blau:        '#009FE3',
-    blauDunkel:  '#004B73',
-    weiss:       '#FFFFFF',
-    schwarz:     '#000000',
-    magenta:     '#EA5172',
+  /** Accent — the three Lume palettes' base fills (light mode, spec §2.5). */
+  accentPalette: {
+    lagoon:  '#1F8FA3',
+    petrol:  '#0F7AB8',
+    atelier: '#B36B2E',
   },
 
-  /** SYSTEM — grayscale + semantic roles derived to harmonise with core. */
+  /** SYSTEM — semantic roles (Lagoon light snapshot). */
   color: {
     // bg / fg semantic roles (light mode)
-    bg:            '#FFFFFF',
-    bgSoft:        '#F4F7FA',
+    bg:            '#F7F8FB',
+    bgSoft:        '#F2F3F7',
     bgElevated:    '#FFFFFF',
-    bgInverse:     '#004B73',
+    bgInverse:     '#1B1D24',
 
-    fg:            '#004B73',
-    fgStrong:      '#004B73',
-    fgMuted:       '#5F6E7B',
-    fgSubtle:      '#8A99A6',
-    fgOnDark:      '#FFFFFF',
-    fgOnAccent:    '#FFFFFF',
+    fg:            '#1B1D24',
+    fgStrong:      '#1B1D24',
+    fgMuted:       '#5B5F6B',
+    fgSubtle:      '#8D9099',
+    fgOnDark:      '#FCFCFD',
+    fgOnAccent:    '#FCFCFD',
 
-    accent:        '#009FE3',
-    accentHover:   '#0086C0',
-    accentPress:   '#006C9C',
+    accent:        '#1F8FA3',
+    accentHover:   '#197D90',
+    accentPress:   '#146B7C',
 
-    highlight:     '#EA5172',
+    highlight:     '#1F8FA3',
 
-    border:        '#D3DDE5',
-    borderStrong:  '#B4C2CD',
+    border:        '#E3E4E8',
+    borderStrong:  '#CDCED4',
 
-    success:       '#15A06B',
-    warning:       '#E0A82E',
-    danger:        '#D9354C',
-    info:          '#009FE3',
+    success:       '#3F7A55',
+    warning:       '#8C6A1F',
+    danger:        '#A8443B',
+    info:          '#1F8FA3',
   },
 
-  /** Grayscale ramp (50…900). */
+  /** Neutral ramp (50…900), hue ~250 to match the Lume surface family. */
   gray: {
-    50:  '#F4F7FA',
-    100: '#E8EEF3',
-    200: '#D3DDE5',
-    300: '#B4C2CD',
-    400: '#8A99A6',
-    500: '#5F6E7B',
-    600: '#3F4D59',
-    700: '#283540',
-    800: '#15212B',
-    900: '#0A1420',
+    50:  '#F7F8FB',
+    100: '#ECEDF2',
+    200: '#DCDEE3',
+    300: '#BFC1C6',
+    400: '#8D9099',
+    500: '#5B5F6B',
+    600: '#3E414C',
+    700: '#2A2D38',
+    800: '#1F2127',
+    900: '#16181E',
   },
 
   typography: {
-    displayFamily:
-      "'Days One', 'Nunito Sans', system-ui, sans-serif",
-    textFamily:
-      "'Nunito Sans', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif",
+    sansFamily:
+      "'Geist', system-ui, -apple-system, 'Segoe UI', sans-serif",
+    serifFamily:
+      "'Source Serif 4', Charter, 'Iowan Old Style', Georgia, serif",
     monoFamily:
-      "'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace",
+      "'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace",
   },
 
+  /** Lume radius scale (spec §2.9). */
   radii: {
-    xs:     '4px',
-    sm:     '8px',
-    md:     '14px',
-    lg:     '22px',
-    pill:   '9999px',
+    none:   '0',
+    sm:     '6px',
+    md:     '8px',
+    lg:     '12px',
+    pill:   '999px',
     circle: '50%',
   },
 
+  /** Lume motion tokens (spec §2.11). */
   motion: {
-    easeOut:   'cubic-bezier(0.22, 0.61, 0.36, 1)',
-    easeInOut: 'cubic-bezier(0.65, 0, 0.35, 1)',
-    durFast:   '140ms',
-    durBase:   '220ms',
-    durSlow:   '360ms',
+    standard: 'cubic-bezier(0.22, 0.61, 0.36, 1)',
+    emphasis: 'cubic-bezier(0.4, 0, 0.2, 1)',
+    quick:    '100ms',
+    smooth:   '200ms',
+    deliberate: '320ms',
   },
 } as const;
 

--- a/web-ui/app/_lib/theme.css
+++ b/web-ui/app/_lib/theme.css
@@ -231,6 +231,9 @@
       0 24px 48px light-dark(rgba(20, 24, 36, 0.12), rgba(0, 0, 0, 0.65)),
       0 0 32px var(--accent-glow-core),
       0 0 96px var(--accent-glow);
+  /* elev.drag (§2.10) — drag-in-flight ghost. No accent glow: drag is an
+     operation, not an active state (§6.7). */
+  --shadow-drag: 0 8px 24px light-dark(rgba(20, 24, 36, 0.16), rgba(0, 0, 0, 0.55));
   /* Accent emphasis on CTAs uses the two-stop Lume glow (spec §3.2), not a
      drop shadow. */
   --shadow-cta:     0 0 4px var(--accent-glow-core), 0 4px 12px var(--accent-glow);

--- a/web-ui/app/_lib/theme.css
+++ b/web-ui/app/_lib/theme.css
@@ -219,13 +219,17 @@
                           0 1px 2px rgba(0, 0, 0, 0.30));
   --shadow-sm: light-dark(0 1px 2px rgba(20, 24, 36, 0.04),
                           0 1px 2px rgba(0, 0, 0, 0.30));
-  --shadow-md: light-dark(0 1px 2px rgba(20, 24, 36, 0.04), 0 8px 24px rgba(20, 24, 36, 0.06),
-                          0 1px 2px rgba(0, 0, 0, 0.30), 0 8px 24px rgba(0, 0, 0, 0.45));
-  --shadow-lg: light-dark(
-      0 4px 16px rgba(20, 24, 36, 0.06), 0 24px 48px rgba(20, 24, 36, 0.12),
-      0 0 32px var(--accent-glow-core), 0 0 96px var(--accent-glow),
-      0 4px 16px rgba(0, 0, 0, 0.55), 0 24px 48px rgba(0, 0, 0, 0.65),
-      0 0 32px var(--accent-glow-core), 0 0 96px var(--accent-glow));
+  /* Multi-layer shadows wrap EACH layer in its own light-dark() — the
+     layer-separating commas must stay at the box-shadow top level, not inside
+     light-dark() (which takes exactly two args). */
+  --shadow-md:
+      light-dark(0 1px 2px rgba(20, 24, 36, 0.04), 0 1px 2px rgba(0, 0, 0, 0.30)),
+      light-dark(0 8px 24px rgba(20, 24, 36, 0.06), 0 8px 24px rgba(0, 0, 0, 0.45));
+  --shadow-lg:
+      light-dark(0 4px 16px rgba(20, 24, 36, 0.06), 0 4px 16px rgba(0, 0, 0, 0.55)),
+      light-dark(0 24px 48px rgba(20, 24, 36, 0.12), 0 24px 48px rgba(0, 0, 0, 0.65)),
+      0 0 32px var(--accent-glow-core),
+      0 0 96px var(--accent-glow);
   /* Accent emphasis on CTAs uses the two-stop Lume glow (spec §3.2), not a
      drop shadow. */
   --shadow-cta:     0 0 4px var(--accent-glow-core), 0 4px 12px var(--accent-glow);

--- a/web-ui/app/_lib/theme.css
+++ b/web-ui/app/_lib/theme.css
@@ -270,6 +270,33 @@
    [data-palette] on <html>. Each carries light + dark via light-dark().
    `lagoon` is also the :root default above.
    ============================================================ */
+/* ============================================================
+   §6.6 Palette-switch crossfade. Registering the accent sub-tokens as
+   typed <color> properties lets the browser interpolate them — which
+   animates every gradient, glow and fill that consumes them. The
+   transition is gated on a transient .lume-xfade class (set by
+   ThemeControls for ~250ms around a palette change) so that the
+   light/dark THEME switch stays motion.instant per §2.11.
+   ============================================================ */
+@property --accent            { syntax: '<color>'; inherits: true; initial-value: #1F8FA3; }
+@property --accent-hover      { syntax: '<color>'; inherits: true; initial-value: #197D90; }
+@property --accent-active     { syntax: '<color>'; inherits: true; initial-value: #146B7C; }
+@property --accent-subtle     { syntax: '<color>'; inherits: true; initial-value: rgba(31, 143, 163, 0.12); }
+@property --accent-glow       { syntax: '<color>'; inherits: true; initial-value: rgba(60, 175, 195, 0.32); }
+@property --accent-glow-strong{ syntax: '<color>'; inherits: true; initial-value: rgba(60, 175, 195, 0.48); }
+@property --accent-glow-core  { syntax: '<color>'; inherits: true; initial-value: rgba(180, 238, 248, 0.60); }
+
+html.lume-xfade {
+  transition:
+    --accent 200ms cubic-bezier(0.22, 0.61, 0.36, 1),
+    --accent-hover 200ms cubic-bezier(0.22, 0.61, 0.36, 1),
+    --accent-active 200ms cubic-bezier(0.22, 0.61, 0.36, 1),
+    --accent-subtle 200ms cubic-bezier(0.22, 0.61, 0.36, 1),
+    --accent-glow 200ms cubic-bezier(0.22, 0.61, 0.36, 1),
+    --accent-glow-strong 200ms cubic-bezier(0.22, 0.61, 0.36, 1),
+    --accent-glow-core 200ms cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
 :root[data-palette='lagoon'] {
   --accent:            light-dark(#1F8FA3, #6FC8D6);
   --accent-hover:      light-dark(#197D90, #88D2DE);

--- a/web-ui/app/_lib/theme.css
+++ b/web-ui/app/_lib/theme.css
@@ -215,19 +215,17 @@
      differentiated by border + radius + surface luminosity.
      Modals carry an accent-glow component (the lit object).
      ============================================================ */
-  --shadow-xs: light-dark(0 1px 2px rgba(20, 24, 36, 0.04),
-                          0 1px 2px rgba(0, 0, 0, 0.30));
-  --shadow-sm: light-dark(0 1px 2px rgba(20, 24, 36, 0.04),
-                          0 1px 2px rgba(0, 0, 0, 0.30));
-  /* Multi-layer shadows wrap EACH layer in its own light-dark() — the
-     layer-separating commas must stay at the box-shadow top level, not inside
-     light-dark() (which takes exactly two args). */
+  /* light-dark() is a <color> function — it may only sit in the COLOR
+     position of a shadow layer, never wrap the whole layer (that parses as
+     invalid and drops the declaration). */
+  --shadow-xs: 0 1px 2px light-dark(rgba(20, 24, 36, 0.04), rgba(0, 0, 0, 0.30));
+  --shadow-sm: 0 1px 2px light-dark(rgba(20, 24, 36, 0.04), rgba(0, 0, 0, 0.30));
   --shadow-md:
-      light-dark(0 1px 2px rgba(20, 24, 36, 0.04), 0 1px 2px rgba(0, 0, 0, 0.30)),
-      light-dark(0 8px 24px rgba(20, 24, 36, 0.06), 0 8px 24px rgba(0, 0, 0, 0.45));
+      0 1px 2px light-dark(rgba(20, 24, 36, 0.04), rgba(0, 0, 0, 0.30)),
+      0 8px 24px light-dark(rgba(20, 24, 36, 0.06), rgba(0, 0, 0, 0.45));
   --shadow-lg:
-      light-dark(0 4px 16px rgba(20, 24, 36, 0.06), 0 4px 16px rgba(0, 0, 0, 0.55)),
-      light-dark(0 24px 48px rgba(20, 24, 36, 0.12), 0 24px 48px rgba(0, 0, 0, 0.65)),
+      0 4px 16px light-dark(rgba(20, 24, 36, 0.06), rgba(0, 0, 0, 0.55)),
+      0 24px 48px light-dark(rgba(20, 24, 36, 0.12), rgba(0, 0, 0, 0.65)),
       0 0 32px var(--accent-glow-core),
       0 0 96px var(--accent-glow);
   /* Accent emphasis on CTAs uses the two-stop Lume glow (spec §3.2), not a

--- a/web-ui/app/_lib/theme.css
+++ b/web-ui/app/_lib/theme.css
@@ -106,7 +106,10 @@
   --fg-muted:     var(--text-secondary);
   --fg-subtle:    var(--text-tertiary);
   --fg-disabled:  var(--text-disabled);
-  --fg-on-dark:   #FCFCFD;
+  /* Text on an inverse-colored surface (--bg-inverse). The inverse surface
+     flips per mode (dark chip in light mode, light chip in dark mode), so its
+     text must flip with it — pinning this to white breaks dark mode. */
+  --fg-on-dark:   var(--text-inverse);
   --fg-on-accent: var(--text-inverse);
 
   --accent-fg:    var(--text-inverse);

--- a/web-ui/app/_lib/theme.css
+++ b/web-ui/app/_lib/theme.css
@@ -1,167 +1,296 @@
 /* ==========================================================================
-   Harness Platform — Design Tokens (CSS source of truth)
+   omadia operator UI — Design Tokens (CSS source of truth)
    --------------------------------------------------------------------------
-   byte5 Design System applied. Tokens are split into three tiers:
+   Design language: **Lume** (omadia visual spec v0.4).
+   Spec: byte5ai/omadia-ui · docs/visual-spec.md
 
-     1. CORE — the five official byte5 brand colours + typography/motion.
-        Source: ~/Downloads/byte5 Design System/colors_and_type.css.
-        Do not add non-brand values here.
-     2. SYSTEM — grayscale, semantic roles, surface gradients. Harmonic
-        with core; not part of the brand palette.
-     3. COMPAT — aliases matching the older "editorial" names used by the
-        first UI slice (`--paper`, `--ink`, `--oxblood`, etc). These remap
-        onto byte5 tokens so every existing `var(--paper)` etc. in
-        component code keeps working. Prefer the CORE / SYSTEM names in
-        new code.
+   Lume treats light as the material: UI reads as condensed out of light, with
+   the agent's attention visible as accent-tinted illumination. Four recipes
+   sit on top of a semantic token set:
 
-   Brand reference: README.md in the design system export. Key rules:
-   - Magenta `:` is a typographic device, not a state/UI colour.
-   - Pill radius (9999px) for CTAs; small radius (8–14px) for cards.
-   - Shadows are soft and blue-tinted, never neutral gray.
+     1. Surface luminosity — every surface is a 180° gradient between a
+        `.top` and `.btm` token (~1.5% lightness delta).
+     2. Accent as illumination — one accent slot with a fill plus three glow
+        sub-tokens (glow / glow-strong / glow-core) for focus, selection,
+        active states.
+     3. Directional borders — the border's top edge is lighter than the rest,
+        so edges read as catching light from above.
+     4. Soft corners — radius scale 6/8/12, hard radius-0 for editor surfaces.
+
+   Token tiers in this file:
+
+     1. PRIMITIVE — Lume raw tokens (spec §2): surface pairs, text, directional
+        border pairs, accent + glow (per active palette), semantic states.
+        Light/dark resolved with the CSS `light-dark()` function, driven by the
+        `color-scheme` property (system default, or forced via `[data-theme]`).
+     2. SEMANTIC — role names consumed by components (`--bg`, `--fg`,
+        `--accent`, `--border`, ...). These map onto the primitives.
+     3. COMPAT — editorial aliases the first UI slice used (`--paper`, `--ink`,
+        `--oxblood`, `--card`, ...). Remapped onto Lume so existing component
+        code keeps working without a per-component edit. Prefer SEMANTIC names
+        in new code.
+
+   Palette: three curated accents (Petrol, Atelier, Lagoon) bind to the single
+   accent slot via `[data-palette]` on <html>. Default: Lagoon (spec §2.5.3).
    ========================================================================== */
 
 :root {
   color-scheme: light dark;
 
   /* ============================================================
-     1. CORE — byte5 brand (official, five colours only)
+     1. PRIMITIVE — Lume surface tokens (spec §2.2)
+        Each surface is a top/btm pair, consumed as a 180° gradient.
+        light-dark(<light>, <dark>).
      ============================================================ */
-  --b5-blau:        #009FE3;   /* byte5-Blau — primary, Pantone Cyan C */
-  --b5-blau-dunkel: #004B73;   /* Blau dunkel — secondary, Pantone 3025 C */
-  --b5-weiss:       #FFFFFF;
-  --b5-schwarz:     #000000;
-  --b5-magenta:     #EA5172;   /* accent — SPARING use, signature ":" mark */
+  --bg-canvas-top:         light-dark(#FDFDFE, #232631);
+  --bg-canvas-btm:         light-dark(#F7F8FB, #1B1D24);
+  --bg-surface-top:        light-dark(#FFFFFF, #2A2D38);
+  --bg-surface-btm:        light-dark(#FAFAFD, #23262F);
+  --bg-surface-raised-top: light-dark(#FFFFFF, #303440);
+  --bg-surface-raised-btm: light-dark(#FCFCFE, #292C37);
+  --bg-surface-sunken-top: light-dark(#F2F3F7, #1D1F26);
+  --bg-surface-sunken-btm: light-dark(#ECEDF2, #16181E);
+  --bg-modal-surface-top:  light-dark(#FFFFFF, #303440);
+  --bg-modal-surface-btm:  light-dark(#FBFBFE, #292C37);
+  --bg-modal-overlay:      light-dark(rgba(20, 30, 50, 0.40), rgba(0, 0, 0, 0.60));
+
+  /* ---- Text tokens (spec §2.3) ---- */
+  --text-primary:   light-dark(#1B1D24, #EEEFF3);
+  --text-secondary: light-dark(#5B5F6B, #B6B9C3);
+  --text-tertiary:  light-dark(#8D9099, #888B95);
+  --text-disabled:  light-dark(#BFC1C6, #525561);
+  --text-inverse:   light-dark(#FCFCFD, #1F2127);
+
+  /* ---- Directional border pairs (spec §2.4) ----
+     Rendered as `1px solid <btm>` + `border-top-color: <top>` via the
+     `.lume-border*` recipes. Light from above in both modes. */
+  --border-subtle-top:  light-dark(rgba(20, 24, 36, 0.05), rgba(255, 255, 255, 0.06));
+  --border-subtle-btm:  light-dark(rgba(20, 24, 36, 0.09), rgba(0, 0, 0, 0.40));
+  --border-default-top: light-dark(rgba(20, 24, 36, 0.08), rgba(255, 255, 255, 0.10));
+  --border-default-btm: light-dark(rgba(20, 24, 36, 0.14), rgba(0, 0, 0, 0.50));
+  --border-strong-top:  light-dark(rgba(20, 24, 36, 0.16), rgba(255, 255, 255, 0.18));
+  --border-strong-btm:  light-dark(rgba(20, 24, 36, 0.26), rgba(0, 0, 0, 0.60));
+
+  /* ---- Semantic state tokens (spec §2.6) — text-only, never filled pills ---- */
+  --state-loading:     light-dark(#DCDEE3, #3E414C);
+  --state-loading-hi:  light-dark(#EFEFF2, #525561);
+  --state-error-fg:    light-dark(#A8443B, #E08577);
+  --state-error-edge:  light-dark(#C45A50, #C5685A);
+  --state-success-fg:  light-dark(#3F7A55, #88C499);
+  --state-warning-fg:  light-dark(#8C6A1F, #D6B468);
 
   /* ============================================================
-     2. SYSTEM — extended tokens (grays, semantics, surfaces)
+     Accent — active palette. Default = Lagoon (spec §2.5.3).
+     Overridden by [data-palette="petrol"|"atelier"|"lagoon"] below.
+     Seven sub-tokens per spec §2.5; light/dark via light-dark().
      ============================================================ */
-  --gray-50:  #F4F7FA;
-  --gray-100: #E8EEF3;
-  --gray-200: #D3DDE5;
-  --gray-300: #B4C2CD;
-  --gray-400: #8A99A6;
-  --gray-500: #5F6E7B;
-  --gray-600: #3F4D59;
-  --gray-700: #283540;
-  --gray-800: #15212B;
-  --gray-900: #0A1420;
-
-  --surface-gradient:      linear-gradient(180deg, #F1F5F9 0%, #E3ECF3 100%);
-  --surface-gradient-cyan: radial-gradient(120% 80% at 0% 0%, #B7E5F8 0%, #E8F2F8 60%, #F4F7FA 100%);
-
-  /* Semantic roles */
-  --bg:            var(--b5-weiss);
-  --bg-soft:       var(--gray-50);
-  --bg-elevated:   var(--b5-weiss);
-  --bg-inverse:    var(--b5-blau-dunkel);
-  --bg-tinted:     var(--surface-gradient);
-
-  --fg:            var(--b5-blau-dunkel);
-  --fg-strong:     var(--b5-blau-dunkel);
-  --fg-muted:      var(--gray-500);
-  --fg-subtle:     var(--gray-400);
-  --fg-on-dark:    var(--b5-weiss);
-  --fg-on-accent:  var(--b5-weiss);
-
-  --accent:        var(--b5-blau);      /* interactive accent / primary CTA */
-  --accent-fg:     var(--b5-weiss);
-  --accent-hover:  #0086C0;
-  --accent-press:  #006C9C;
-
-  --highlight:     var(--b5-magenta);   /* the ":" pop colour */
-  --highlight-fg:  var(--b5-weiss);
-
-  --border:        var(--gray-200);
-  --border-strong: var(--gray-300);
-  --divider:       rgba(0, 75, 115, 0.12);
-
-  --success:       #15A06B;
-  --warning:       #E0A82E;
-  --danger:        #D9354C;
-  --info:          var(--b5-blau);
+  --accent:            light-dark(#1F8FA3, #6FC8D6);
+  --accent-hover:      light-dark(#197D90, #88D2DE);
+  --accent-active:     light-dark(#146B7C, #A1DCE6);
+  --accent-subtle:     light-dark(rgba(31, 143, 163, 0.12), rgba(111, 200, 214, 0.20));
+  --accent-glow:       light-dark(rgba(60, 175, 195, 0.32), rgba(111, 200, 214, 0.32));
+  --accent-glow-strong:light-dark(rgba(60, 175, 195, 0.48), rgba(111, 200, 214, 0.48));
+  --accent-glow-core:  light-dark(rgba(180, 238, 248, 0.60), rgba(210, 245, 250, 0.50));
 
   /* ============================================================
-     3. COMPAT — aliases for the first-slice editorial names
-        so pre-existing component code reads the byte5 palette
-        without touching every file.
+     2. SEMANTIC — role names consumed across components.
+     ============================================================ */
+  --bg:           var(--bg-canvas-btm);
+  --bg-soft:      var(--bg-surface-sunken-top);
+  --bg-elevated:  var(--bg-surface-raised-top);
+  --bg-inverse:   light-dark(#1B1D24, #EEEFF3);
+  --bg-tinted:    var(--surface-gradient);
+
+  --fg:           var(--text-primary);
+  --fg-strong:    var(--text-primary);
+  --fg-muted:     var(--text-secondary);
+  --fg-subtle:    var(--text-tertiary);
+  --fg-disabled:  var(--text-disabled);
+  --fg-on-dark:   #FCFCFD;
+  --fg-on-accent: var(--text-inverse);
+
+  --accent-fg:    var(--text-inverse);
+  --accent-press: var(--accent-active);
+
+  --highlight:    var(--accent);          /* byte5 magenta retired → accent */
+  --highlight-fg: var(--accent-fg);
+
+  /* Single-color border fallback for components that paint one border color
+     on all four sides. A faint light-from-above hairline, visible in both
+     modes. The directional pair tokens above drive the `.lume-border` recipe
+     where the full top/btm treatment is wanted. */
+  --border:        light-dark(rgba(20, 24, 36, 0.10), rgba(255, 255, 255, 0.10));
+  --border-strong: light-dark(rgba(20, 24, 36, 0.18), rgba(255, 255, 255, 0.16));
+  --divider:       light-dark(rgba(20, 24, 36, 0.07), rgba(255, 255, 255, 0.07));
+
+  --success:      var(--state-success-fg);
+  --warning:      var(--state-warning-fg);
+  --danger:       var(--state-error-fg);
+  --danger-edge:  var(--state-error-edge);
+  --info:         var(--accent);
+
+  /* Surface gradients (spec §3.1) for token-driven backgrounds. */
+  --surface-gradient:
+      linear-gradient(180deg, var(--bg-canvas-top) 0%, var(--bg-canvas-btm) 100%);
+  --surface-gradient-accent:
+      radial-gradient(120% 80% at 0% 0%,
+        var(--accent-subtle) 0%, var(--bg-soft) 55%, var(--bg) 100%);
+  --surface-gradient-cyan: var(--surface-gradient-accent); /* compat alias */
+
+  /* ============================================================
+     3. COMPAT — editorial aliases used by the first UI slice so
+        pre-existing `var(--paper)` etc. keep resolving on Lume.
      ============================================================ */
   --paper:       var(--bg);
-  --paper-soft:  var(--gray-50);
-  --paper-sink:  var(--gray-100);
+  --paper-soft:  var(--bg-soft);
+  --paper-sink:  light-dark(#ECEDF2, #16181E);
 
   --ink:         var(--fg);
   --muted-ink:   var(--fg-muted);
   --faint-ink:   var(--fg-subtle);
+  --fg-default:  var(--fg);
 
   --rule:        var(--border);
   --rule-strong: var(--border-strong);
 
-  --oxblood:     var(--accent);         /* primary CTA → byte5-Blau */
+  --oxblood:     var(--accent);
   --oxblood-ink: var(--accent-hover);
   --forest:      var(--success);
   --amber:       var(--warning);
-  --sky:         var(--b5-blau-dunkel);
+  --sky:         var(--accent);
+  --ok:          var(--success);
+  --warn:        var(--warning);
+
+  --card:           var(--bg-elevated);
+  --surface:        var(--bg-elevated);
+  --surface-muted:  var(--bg-soft);
+  --bg-subtle:      var(--bg-soft);
+  --bg-hover:       light-dark(#F2F3F7, #1D1F26);
+  --accent-bg:      var(--accent-subtle);
+
+  --nav-h: 56px;
 
   /* ============================================================
-     Typography — families
-     (Next/font loads Days One, Nunito Sans and JetBrains Mono via
-     layout.tsx and assigns the matching --font-* CSS variables at
-     :root. The fallbacks below keep the stack valid even when the
-     next/font variables haven't hydrated yet.)
+     Typography — families (spec §2.7)
+     next/font (layout.tsx) self-hosts Geist, Geist Mono and
+     Source Serif 4, assigning --font-geist / --font-geist-mono /
+     --font-source-serif. The stacks below add the platform-strongest
+     fallbacks and stay valid before next/font hydrates.
      ============================================================ */
-  --font-display:  'Days One', 'Nunito Sans', system-ui, sans-serif;
-  --font-text:     'Nunito Sans', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
-  --font-serif:    var(--font-display);  /* compat with old name */
-  --font-sans:     var(--font-text);     /* compat with old name */
-  --font-mono:     'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+  --font-sans:  var(--font-geist), system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --font-mono:  var(--font-geist-mono), ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  --font-serif: var(--font-source-serif), Charter, 'Iowan Old Style', Georgia, serif;
+  /* Compat names from the first slice. Structural register is Geist; the old
+     display face (Days One) is retired — headings are Geist 600. */
+  --font-text:    var(--font-sans);
+  --font-display: var(--font-sans);
 
   /* ============================================================
-     Radii, shadows, motion (from byte5 kit)
+     Spacing — 4pt grid, closed set (spec §2.8)
      ============================================================ */
-  --radius-xs:     4px;
-  --radius-sm:     8px;
-  --radius-md:     14px;
-  --radius-lg:     22px;
-  --radius-pill:   9999px;
+  --space-0: 0;
+  --space-1: 2px;
+  --space-2: 4px;
+  --space-3: 8px;
+  --space-4: 12px;
+  --space-5: 16px;
+  --space-6: 24px;
+  --space-7: 32px;
+  --space-8: 48px;
+  --space-9: 64px;
+
+  /* ============================================================
+     Radii — Lume scale (spec §2.9). radius-0 for editor surfaces.
+     ============================================================ */
+  --radius-0:      0;
+  --radius-xs:     6px;   /* legacy name → sm */
+  --radius-sm:     6px;
+  --radius-md:     8px;
+  --radius-lg:     12px;
+  --radius-pill:   999px;
   --radius-circle: 50%;
 
-  --shadow-xs:      0 1px 2px   rgba(0, 75, 115, 0.06);
-  --shadow-sm:      0 2px 6px   rgba(0, 75, 115, 0.08);
-  --shadow-md:      0 8px 24px  rgba(0, 75, 115, 0.10);
-  --shadow-lg:      0 18px 40px rgba(0, 75, 115, 0.14);
-  --shadow-cta:     0 12px 28px rgba(0, 159, 227, 0.30);
-  --shadow-magenta: 0 12px 28px rgba(234, 81, 114, 0.28);
+  /* ============================================================
+     Elevation (spec §2.10). Cards get NO shadow — they are
+     differentiated by border + radius + surface luminosity.
+     Modals carry an accent-glow component (the lit object).
+     ============================================================ */
+  --shadow-xs: light-dark(0 1px 2px rgba(20, 24, 36, 0.04),
+                          0 1px 2px rgba(0, 0, 0, 0.30));
+  --shadow-sm: light-dark(0 1px 2px rgba(20, 24, 36, 0.04),
+                          0 1px 2px rgba(0, 0, 0, 0.30));
+  --shadow-md: light-dark(0 1px 2px rgba(20, 24, 36, 0.04), 0 8px 24px rgba(20, 24, 36, 0.06),
+                          0 1px 2px rgba(0, 0, 0, 0.30), 0 8px 24px rgba(0, 0, 0, 0.45));
+  --shadow-lg: light-dark(
+      0 4px 16px rgba(20, 24, 36, 0.06), 0 24px 48px rgba(20, 24, 36, 0.12),
+      0 0 32px var(--accent-glow-core), 0 0 96px var(--accent-glow),
+      0 4px 16px rgba(0, 0, 0, 0.55), 0 24px 48px rgba(0, 0, 0, 0.65),
+      0 0 32px var(--accent-glow-core), 0 0 96px var(--accent-glow));
+  /* Accent emphasis on CTAs uses the two-stop Lume glow (spec §3.2), not a
+     drop shadow. */
+  --shadow-cta:     0 0 4px var(--accent-glow-core), 0 4px 12px var(--accent-glow);
+  --shadow-magenta: var(--shadow-cta); /* compat alias */
 
-  --ease-out:    cubic-bezier(0.22, 0.61, 0.36, 1);
+  /* ============================================================
+     Motion (spec §2.11)
+     ============================================================ */
+  --motion-instant:    0ms;
+  --motion-quick:      100ms;
+  --motion-smooth:     200ms;
+  --motion-deliberate: 320ms;
+  --motion-condense:   800ms;
+  /* compat duration names */
+  --dur-fast: var(--motion-quick);
+  --dur-base: var(--motion-smooth);
+  --dur-slow: var(--motion-deliberate);
+
+  --easing-standard: cubic-bezier(0.22, 0.61, 0.36, 1.00);
+  --easing-emphasis: cubic-bezier(0.40, 0.00, 0.20, 1.00);
+  --easing-linear:   linear;
+  /* compat easing names */
+  --ease-out:    var(--easing-standard);
   --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
-  --dur-fast:    140ms;
-  --dur-base:    220ms;
-  --dur-slow:    360ms;
 }
 
 /* ============================================================
-   Dark mode — inverse surfaces use Blau dunkel per brand guide.
+   Explicit light/dark override. By default `color-scheme: light dark`
+   follows the OS (`prefers-color-scheme`). A `[data-theme]` on <html>
+   pins the scheme so light-dark() resolves to the chosen mode.
    ============================================================ */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg:            #0B1A24;             /* deeper than Blau dunkel for admin comfort */
-    --bg-soft:       #102533;
-    --bg-elevated:   #15303F;
+:root[data-theme='light'] { color-scheme: light; }
+:root[data-theme='dark']  { color-scheme: dark; }
 
-    --fg:            #E8F2F8;
-    --fg-strong:     #FFFFFF;
-    --fg-muted:      #A4B4C2;
-    --fg-subtle:     #768796;
+/* ============================================================
+   Accent palettes (spec §2.5). Bind one to the accent slot via
+   [data-palette] on <html>. Each carries light + dark via light-dark().
+   `lagoon` is also the :root default above.
+   ============================================================ */
+:root[data-palette='lagoon'] {
+  --accent:            light-dark(#1F8FA3, #6FC8D6);
+  --accent-hover:      light-dark(#197D90, #88D2DE);
+  --accent-active:     light-dark(#146B7C, #A1DCE6);
+  --accent-subtle:     light-dark(rgba(31, 143, 163, 0.12), rgba(111, 200, 214, 0.20));
+  --accent-glow:       light-dark(rgba(60, 175, 195, 0.32), rgba(111, 200, 214, 0.32));
+  --accent-glow-strong:light-dark(rgba(60, 175, 195, 0.48), rgba(111, 200, 214, 0.48));
+  --accent-glow-core:  light-dark(rgba(180, 238, 248, 0.60), rgba(210, 245, 250, 0.50));
+}
 
-    --border:        rgba(255, 255, 255, 0.10);
-    --border-strong: rgba(255, 255, 255, 0.18);
-    --divider:       rgba(255, 255, 255, 0.10);
+:root[data-palette='petrol'] {
+  --accent:            light-dark(#0F7AB8, #52B0E2);
+  --accent-hover:      light-dark(#0C6CA8, #74C0E8);
+  --accent-active:     light-dark(#0A5E94, #90CFEE);
+  --accent-subtle:     light-dark(rgba(15, 122, 184, 0.10), rgba(82, 176, 226, 0.16));
+  --accent-glow:       light-dark(rgba(15, 122, 184, 0.22), rgba(82, 176, 226, 0.28));
+  --accent-glow-strong:light-dark(rgba(15, 122, 184, 0.36), rgba(82, 176, 226, 0.44));
+  --accent-glow-core:  light-dark(rgba(165, 215, 240, 0.55), rgba(197, 229, 245, 0.45));
+}
 
-    --surface-gradient:
-        linear-gradient(180deg, #0E1F2A 0%, #162C3B 100%);
-
-    /* byte5 core colours keep their hex; hover adapts so it stays visible. */
-    --accent-hover:  #33B0E8;
-    --accent-press:  #66C1ED;
-  }
+:root[data-palette='atelier'] {
+  --accent:            light-dark(#B36B2E, #E0A26B);
+  --accent-hover:      light-dark(#9F5C26, #E5B080);
+  --accent-active:     light-dark(#8A4E1F, #EBBE93);
+  --accent-subtle:     light-dark(rgba(179, 107, 46, 0.10), rgba(224, 162, 107, 0.18));
+  --accent-glow:       light-dark(rgba(179, 107, 46, 0.24), rgba(224, 162, 107, 0.30));
+  --accent-glow-strong:light-dark(rgba(179, 107, 46, 0.38), rgba(224, 162, 107, 0.46));
+  --accent-glow-core:  light-dark(rgba(245, 215, 175, 0.55), rgba(250, 228, 200, 0.45));
 }

--- a/web-ui/app/admin/auth/page.tsx
+++ b/web-ui/app/admin/auth/page.tsx
@@ -69,7 +69,7 @@ export default function AdminAuthPage(): React.ReactElement {
   }
 
   return (
-    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-8">
         <h1 className="font-display text-[clamp(1.75rem,3.5vw,2.5rem)] leading-[1.1] text-[color:var(--fg-strong)]">
           Authentifizierungs-Provider
@@ -95,23 +95,23 @@ export default function AdminAuthPage(): React.ReactElement {
           {state.providers.map((p) => (
             <li
               key={p.id}
-              className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5"
+              className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4"
             >
               <div className="flex flex-1 flex-col">
                 <div className="flex items-center gap-2">
                   <span className="text-[15px] font-semibold text-[color:var(--fg-strong)]">
                     {p.display_name}
                   </span>
-                  <code className="rounded bg-[color:var(--card)] px-1.5 py-0.5 text-[11px] text-[color:var(--fg-muted)]">
+                  <code className="rounded bg-[color:var(--card)] px-2 py-0.5 text-[11px] text-[color:var(--fg-muted)]">
                     {p.id}
                   </code>
-                  <code className="rounded bg-[color:var(--card)] px-1.5 py-0.5 text-[11px] text-[color:var(--fg-muted)]">
+                  <code className="rounded bg-[color:var(--card)] px-2 py-0.5 text-[11px] text-[color:var(--fg-muted)]">
                     {p.kind}
                   </code>
                 </div>
                 <span
                   className={[
-                    'mt-1 inline-flex w-fit items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em]',
+                    'mt-1 inline-flex w-fit items-center gap-2 rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em]',
                     p.active
                       ? 'bg-[color:var(--success)]/10 text-[color:var(--success)]'
                       : 'bg-[color:var(--border)]/40 text-[color:var(--fg-muted)]',

--- a/web-ui/app/admin/auth/page.tsx
+++ b/web-ui/app/admin/auth/page.tsx
@@ -87,7 +87,7 @@ export default function AdminAuthPage(): React.ReactElement {
       {state.kind === 'loading' ? (
         <p className="text-sm opacity-70">Lädt …</p>
       ) : state.kind === 'error' ? (
-        <p className="text-sm text-red-500">
+        <p className="text-sm text-[color:var(--danger)]">
           Fehler beim Laden: {state.message}
         </p>
       ) : (
@@ -95,7 +95,7 @@ export default function AdminAuthPage(): React.ReactElement {
           {state.providers.map((p) => (
             <li
               key={p.id}
-              className="flex flex-wrap items-center justify-between gap-4 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5"
+              className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5"
             >
               <div className="flex flex-1 flex-col">
                 <div className="flex items-center gap-2">
@@ -113,14 +113,14 @@ export default function AdminAuthPage(): React.ReactElement {
                   className={[
                     'mt-1 inline-flex w-fit items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em]',
                     p.active
-                      ? 'bg-emerald-500/10 text-emerald-500'
+                      ? 'bg-[color:var(--success)]/100/10 text-[color:var(--success)]'
                       : 'bg-[color:var(--border)]/40 text-[color:var(--fg-muted)]',
                   ].join(' ')}
                 >
                   <span
                     className={[
                       'h-1.5 w-1.5 rounded-full',
-                      p.active ? 'bg-emerald-500' : 'bg-[color:var(--fg-muted)]',
+                      p.active ? 'bg-[color:var(--success)]/100' : 'bg-[color:var(--fg-muted)]',
                     ].join(' ')}
                   />
                   {p.active ? 'aktiv' : 'inaktiv'}
@@ -134,7 +134,7 @@ export default function AdminAuthPage(): React.ReactElement {
                   'rounded-md px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50',
                   p.active
                     ? 'border border-[color:var(--border)] text-[color:var(--fg-strong)] hover:bg-[color:var(--card)]'
-                    : 'bg-[color:var(--accent)] text-black',
+                    : 'bg-[color:var(--accent)] text-[color:var(--text-inverse)]',
                 ].join(' ')}
               >
                 {pendingId === p.id
@@ -149,7 +149,7 @@ export default function AdminAuthPage(): React.ReactElement {
       )}
 
       {actionError && (
-        <p className="mt-4 text-sm text-red-500">{actionError}</p>
+        <p className="mt-4 text-sm text-[color:var(--danger)]">{actionError}</p>
       )}
     </main>
   );

--- a/web-ui/app/admin/auth/page.tsx
+++ b/web-ui/app/admin/auth/page.tsx
@@ -113,7 +113,7 @@ export default function AdminAuthPage(): React.ReactElement {
                   className={[
                     'mt-1 inline-flex w-fit items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em]',
                     p.active
-                      ? 'bg-[color:var(--success)]/100/10 text-[color:var(--success)]'
+                      ? 'bg-[color:var(--success)]/10 text-[color:var(--success)]'
                       : 'bg-[color:var(--border)]/40 text-[color:var(--fg-muted)]',
                   ].join(' ')}
                 >

--- a/web-ui/app/admin/builder/BuilderCanvas.tsx
+++ b/web-ui/app/admin/builder/BuilderCanvas.tsx
@@ -301,7 +301,7 @@ function CanvasInner({ slug }: BuilderCanvasProps): React.ReactElement {
           <Controls />
         </ReactFlow>
         {actionError && (
-          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 rounded-md border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/80/10 px-4 py-2 text-sm text-[color:var(--danger)]">
+          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 rounded-md border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/10 px-4 py-2 text-sm text-[color:var(--danger)]">
             {actionError}
           </div>
         )}

--- a/web-ui/app/admin/builder/BuilderCanvas.tsx
+++ b/web-ui/app/admin/builder/BuilderCanvas.tsx
@@ -301,7 +301,7 @@ function CanvasInner({ slug }: BuilderCanvasProps): React.ReactElement {
           <Controls />
         </ReactFlow>
         {actionError && (
-          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 rounded-md border border-red-500/40 bg-red-500/10 px-4 py-2 text-sm text-red-400">
+          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 rounded-md border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/80/10 px-4 py-2 text-sm text-[color:var(--danger)]">
             {actionError}
           </div>
         )}
@@ -383,7 +383,7 @@ function Centered({
 }): React.ReactElement {
   return (
     <div
-      className={`flex h-full w-full items-center justify-center text-sm ${tone === 'error' ? 'text-red-500' : 'text-[color:var(--fg-muted)]'}`}
+      className={`flex h-full w-full items-center justify-center text-sm ${tone === 'error' ? 'text-[color:var(--danger)]' : 'text-[color:var(--fg-muted)]'}`}
     >
       {text}
     </div>

--- a/web-ui/app/admin/builder/nodes/AgentNode.tsx
+++ b/web-ui/app/admin/builder/nodes/AgentNode.tsx
@@ -20,7 +20,7 @@ export function AgentNodeView({
       hasTarget
       hasSource
     >
-      <div className="mt-1.5 flex flex-wrap gap-1">
+      <div className="mt-2 flex flex-wrap gap-1">
         <Pill text={agent.privacyProfile} />
         <Pill text={agent.status} />
         {routing ? <Pill text={`${routing.mode}: ${routing.main}`} /> : null}
@@ -31,7 +31,7 @@ export function AgentNodeView({
 
 function Pill({ text }: { text: string }): React.ReactElement {
   return (
-    <span className="rounded bg-[color:var(--border)]/40 px-1.5 py-0.5 text-[9px] text-[color:var(--fg-muted)]">
+    <span className="rounded bg-[color:var(--border)]/40 px-2 py-0.5 text-[9px] text-[color:var(--fg-muted)]">
       {text}
     </span>
   );

--- a/web-ui/app/admin/builder/nodes/McpServerNode.tsx
+++ b/web-ui/app/admin/builder/nodes/McpServerNode.tsx
@@ -19,7 +19,7 @@ export function McpServerNodeView({
       selected={selected}
       hasTarget
     >
-      <div className="mt-1.5 text-[10px] text-[color:var(--fg-muted)]">
+      <div className="mt-2 text-[10px] text-[color:var(--fg-muted)]">
         {toolCount} {labels['tools']}
       </div>
     </NodeShell>

--- a/web-ui/app/admin/builder/nodes/NodeShell.tsx
+++ b/web-ui/app/admin/builder/nodes/NodeShell.tsx
@@ -65,14 +65,14 @@ export function NodeShell({
           style={{ background: accent, width: 9, height: 9 }}
         />
       )}
-      <div className="px-3 py-2.5 pl-4">
+      <div className="px-3 py-3 pl-4">
         <div className="flex items-start justify-between gap-2">
           <span className="text-[13px] font-semibold leading-tight text-[color:var(--fg-strong)]">
             {title}
           </span>
           {badge ? (
             <span
-              className="shrink-0 rounded-full px-1.5 py-0.5 text-[9px] uppercase tracking-[0.14em]"
+              className="shrink-0 rounded-full px-2 py-0.5 text-[9px] uppercase tracking-[0.14em]"
               style={{ background: `${accent}22`, color: accent }}
             >
               {badge}

--- a/web-ui/app/admin/builder/nodes/NodeShell.tsx
+++ b/web-ui/app/admin/builder/nodes/NodeShell.tsx
@@ -44,7 +44,7 @@ export function NodeShell({
   const accent = ACCENTS[kind];
   return (
     <div
-      className="relative min-w-[180px] max-w-[260px] overflow-hidden rounded-[12px] border bg-[color:var(--card)] text-left shadow-sm"
+      className="relative min-w-[180px] max-w-[260px] overflow-hidden rounded-lg border bg-[color:var(--card)] text-left shadow-sm"
       style={{
         borderColor: selected ? accent : 'var(--border)',
         boxShadow: selected ? `0 0 0 1px ${accent}` : undefined,

--- a/web-ui/app/admin/builder/page.tsx
+++ b/web-ui/app/admin/builder/page.tsx
@@ -73,7 +73,7 @@ export default function BuilderPage(): React.ReactElement {
             <select
               value={slug ?? ''}
               onChange={(e) => setSlug(e.target.value || null)}
-              className="rounded-md border border-[color:var(--border)] bg-transparent px-3 py-1.5 text-sm outline-none focus:border-[color:var(--accent)]"
+              className="rounded-md border border-[color:var(--border)] bg-transparent px-3 py-2 text-sm outline-none focus:border-[color:var(--accent)]"
             >
               {state.agents.length === 0 && <option value="">—</option>}
               {state.agents.map((a) => (

--- a/web-ui/app/admin/builder/page.tsx
+++ b/web-ui/app/admin/builder/page.tsx
@@ -91,7 +91,7 @@ export default function BuilderPage(): React.ReactElement {
           <p className="px-6 py-6 text-sm text-[color:var(--fg-muted)]">{t('loading')}</p>
         )}
         {state.kind === 'error' && (
-          <p className="px-6 py-6 text-sm text-red-500">
+          <p className="px-6 py-6 text-sm text-[color:var(--danger)]">
             {t('loadError')}: {state.message}
           </p>
         )}

--- a/web-ui/app/admin/builder/panels/InspectorControls.tsx
+++ b/web-ui/app/admin/builder/panels/InspectorControls.tsx
@@ -11,7 +11,7 @@ export function Field({
   children: React.ReactNode;
 }): React.ReactElement {
   return (
-    <label className="flex flex-col gap-1.5">
+    <label className="flex flex-col gap-2">
       <span className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
         {label}
       </span>

--- a/web-ui/app/admin/builder/panels/InspectorControls.tsx
+++ b/web-ui/app/admin/builder/panels/InspectorControls.tsx
@@ -34,7 +34,7 @@ export function SaveButton({
       type="button"
       onClick={onClick}
       disabled={pending}
-      className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-black disabled:opacity-50"
+      className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-[color:var(--text-inverse)] disabled:opacity-50"
     >
       {pending ? '…' : label}
     </button>

--- a/web-ui/app/admin/builder/panels/InspectorPanel.tsx
+++ b/web-ui/app/admin/builder/panels/InspectorPanel.tsx
@@ -240,7 +240,7 @@ function SkillEditor({
   return (
     <div className="flex flex-col gap-3">
       {readOnly && (
-        <p className="rounded-md bg-[color:var(--warning)]/100/10 px-2 py-1 text-xs text-[color:var(--warning)]">
+        <p className="rounded-md bg-[color:var(--warning)]/10 px-2 py-1 text-xs text-[color:var(--warning)]">
           {t('inspector.skillFileReadOnly')}
         </p>
       )}

--- a/web-ui/app/admin/builder/panels/InspectorPanel.tsx
+++ b/web-ui/app/admin/builder/panels/InspectorPanel.tsx
@@ -101,7 +101,7 @@ function useSaver(): {
 
 function ErrLine({ error }: { error: string | null }): React.ReactElement | null {
   if (!error) return null;
-  return <p className="text-xs text-red-500">{error}</p>;
+  return <p className="text-xs text-[color:var(--danger)]">{error}</p>;
 }
 
 // ── Agent ────────────────────────────────────────────────────────────────
@@ -240,7 +240,7 @@ function SkillEditor({
   return (
     <div className="flex flex-col gap-3">
       {readOnly && (
-        <p className="rounded-md bg-amber-500/10 px-2 py-1 text-xs text-amber-500">
+        <p className="rounded-md bg-[color:var(--warning)]/100/10 px-2 py-1 text-xs text-[color:var(--warning)]">
           {t('inspector.skillFileReadOnly')}
         </p>
       )}

--- a/web-ui/app/admin/builder/panels/ToolboxPanel.tsx
+++ b/web-ui/app/admin/builder/panels/ToolboxPanel.tsx
@@ -37,7 +37,7 @@ export function ToolboxPanel({
         <h2 className="mb-2 px-1 text-[11px] uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
           {t('toolbox.native')}
         </h2>
-        <div className="flex flex-col gap-1.5">
+        <div className="flex flex-col gap-2">
           {NATIVE_TOOLS.map((ref) => (
             <div
               key={ref}
@@ -45,7 +45,7 @@ export function ToolboxPanel({
               onDragStart={(e) =>
                 onDragStart(e, { toolKind: 'native', toolRef: ref, mcpServerId: null })
               }
-              className="cursor-grab rounded-md border border-[color:var(--border)] bg-[color:var(--card)] px-2.5 py-1.5 text-[12px] text-[color:var(--fg-strong)] hover:border-[color:var(--accent)] active:cursor-grabbing"
+              className="cursor-grab rounded-md border border-[color:var(--border)] bg-[color:var(--card)] px-3 py-2 text-[12px] text-[color:var(--fg-strong)] hover:border-[color:var(--accent)] active:cursor-grabbing"
             >
               {ref}
             </div>
@@ -63,7 +63,7 @@ export function ToolboxPanel({
               {t('toolbox.noTools')}
             </p>
           ) : (
-            <div className="flex flex-col gap-1.5">
+            <div className="flex flex-col gap-2">
               {server.discoveredTools.map((tool) => (
                 <div
                   key={tool.name}
@@ -76,7 +76,7 @@ export function ToolboxPanel({
                       mcpServerId: server.id,
                     })
                   }
-                  className="cursor-grab rounded-md border border-[color:var(--border)] bg-[color:var(--card)] px-2.5 py-1.5 text-[12px] text-[color:var(--fg-strong)] hover:border-[color:var(--accent)] active:cursor-grabbing"
+                  className="cursor-grab rounded-md border border-[color:var(--border)] bg-[color:var(--card)] px-3 py-2 text-[12px] text-[color:var(--fg-strong)] hover:border-[color:var(--accent)] active:cursor-grabbing"
                 >
                   {tool.name}
                 </div>

--- a/web-ui/app/admin/bulk-promote/page.tsx
+++ b/web-ui/app/admin/bulk-promote/page.tsx
@@ -85,7 +85,7 @@ export default function BulkPromotePage(): React.ReactElement {
       <header className="mb-8">
         <Link
           href="/admin"
-          className="text-xs text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+          className="text-xs text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]"
         >
           ← /admin
         </Link>
@@ -99,34 +99,34 @@ export default function BulkPromotePage(): React.ReactElement {
         </p>
       </header>
 
-      <section className="mb-6 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
-        <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+      <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+        <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
           Vorschau
         </h2>
         {previewLoading && (
-          <p className="text-xs text-neutral-500">lädt…</p>
+          <p className="text-xs text-[color:var(--fg-muted)]">lädt…</p>
         )}
         {previewError !== null && (
-          <p className="border-l-2 border-red-400 px-2 py-1 text-xs text-red-700 dark:text-red-300">
+          <p className="border-l-2 border-[color:var(--danger-edge)] px-2 py-1 text-xs text-[color:var(--danger)]">
             Fehler: {previewError}
           </p>
         )}
         {preview !== null && previewError === null && (
           <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-sm">
-            <dt className="text-neutral-500">Turns ohne Significance</dt>
+            <dt className="text-[color:var(--fg-muted)]">Turns ohne Significance</dt>
             <dd className="font-mono">{preview.nullSignificanceCount}</dd>
-            <dt className="text-neutral-500">
+            <dt className="text-[color:var(--fg-muted)]">
               Eligible für Promotion (≥ {preview.threshold.toFixed(2)})
             </dt>
             <dd className="font-mono">{preview.eligibleForPromoteCount}</dd>
-            <dt className="text-neutral-500">Bereits promoted</dt>
+            <dt className="text-[color:var(--fg-muted)]">Bereits promoted</dt>
             <dd className="font-mono">{preview.alreadyPromotedCount}</dd>
-            <dt className="text-neutral-500">Scorer verfügbar</dt>
+            <dt className="text-[color:var(--fg-muted)]">Scorer verfügbar</dt>
             <dd>
               {preview.scorerAvailable ? (
-                <span className="text-green-600 dark:text-green-400">✓</span>
+                <span className="text-[color:var(--success)]">✓</span>
               ) : (
-                <span className="text-amber-600 dark:text-amber-400">
+                <span className="text-[color:var(--warning)]">
                   ✗ — ANTHROPIC_API_KEY nicht gesetzt
                 </span>
               )}
@@ -135,13 +135,13 @@ export default function BulkPromotePage(): React.ReactElement {
         )}
       </section>
 
-      <section className="mb-6 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
-        <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+      <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+        <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
           Parameter
         </h2>
         <div className="grid gap-3 sm:grid-cols-3">
           <label className="flex flex-col gap-1">
-            <span className="text-[11px] uppercase tracking-wider text-neutral-500">
+            <span className="text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
               Threshold
             </span>
             <input
@@ -152,11 +152,11 @@ export default function BulkPromotePage(): React.ReactElement {
               value={threshold}
               onChange={(e) => setThreshold(Number(e.target.value))}
               disabled={running}
-              className="rounded border border-neutral-300 px-2 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+              className="rounded border border-[color:var(--border)] px-2 py-1 text-sm"
             />
           </label>
           <label className="flex flex-col gap-1">
-            <span className="text-[11px] uppercase tracking-wider text-neutral-500">
+            <span className="text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
               Score-Limit
             </span>
             <input
@@ -166,11 +166,11 @@ export default function BulkPromotePage(): React.ReactElement {
               value={scoreLimit}
               onChange={(e) => setScoreLimit(Number(e.target.value))}
               disabled={running}
-              className="rounded border border-neutral-300 px-2 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+              className="rounded border border-[color:var(--border)] px-2 py-1 text-sm"
             />
           </label>
           <label className="flex flex-col gap-1">
-            <span className="text-[11px] uppercase tracking-wider text-neutral-500">
+            <span className="text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
               Promote-Limit
             </span>
             <input
@@ -180,7 +180,7 @@ export default function BulkPromotePage(): React.ReactElement {
               value={promoteLimit}
               onChange={(e) => setPromoteLimit(Number(e.target.value))}
               disabled={running}
-              className="rounded border border-neutral-300 px-2 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+              className="rounded border border-[color:var(--border)] px-2 py-1 text-sm"
             />
           </label>
         </div>
@@ -189,7 +189,7 @@ export default function BulkPromotePage(): React.ReactElement {
             type="button"
             onClick={() => void loadPreview()}
             disabled={running || previewLoading}
-            className="rounded border border-neutral-300 px-3 py-1 text-xs hover:border-neutral-400 disabled:opacity-50 dark:border-neutral-700"
+            className="rounded border border-[color:var(--border)] px-3 py-1 text-xs hover:border-[color:var(--border-strong)] disabled:opacity-50"
           >
             Vorschau aktualisieren
           </button>
@@ -201,7 +201,7 @@ export default function BulkPromotePage(): React.ReactElement {
               preview === null ||
               !preview.scorerAvailable
             }
-            className="rounded bg-neutral-900 px-3 py-1 text-xs text-white hover:bg-neutral-700 disabled:opacity-50 dark:bg-neutral-100 dark:text-neutral-900"
+            className="rounded bg-[color:var(--bg-inverse)] px-3 py-1 text-xs text-[color:var(--fg-on-dark)] hover:bg-[color:var(--fg-muted)] disabled:opacity-50"
           >
             {running ? 'läuft…' : 'Bulk-Job starten'}
           </button>
@@ -209,51 +209,51 @@ export default function BulkPromotePage(): React.ReactElement {
       </section>
 
       {runError !== null && (
-        <section className="mb-6 rounded-[14px] border border-red-400 bg-red-50 p-5 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-300">
+        <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-5 text-sm text-[color:var(--danger)]">
           {runError}
         </section>
       )}
 
       {result !== null && (
-        <section className="rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
-          <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+        <section className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+          <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
             Ergebnis ({result.durationMs} ms)
           </h2>
           <div className="grid gap-4 sm:grid-cols-2">
             <div>
-              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-neutral-600 dark:text-neutral-400">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
                 Phase 1 · SCORE
               </h3>
               <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-sm">
-                <dt className="text-neutral-500">scanned</dt>
+                <dt className="text-[color:var(--fg-muted)]">scanned</dt>
                 <dd className="font-mono">{result.scorePhase.scanned}</dd>
-                <dt className="text-neutral-500">scored</dt>
-                <dd className="font-mono text-green-600 dark:text-green-400">
+                <dt className="text-[color:var(--fg-muted)]">scored</dt>
+                <dd className="font-mono text-[color:var(--success)]">
                   {result.scorePhase.scored}
                 </dd>
-                <dt className="text-neutral-500">failed</dt>
-                <dd className="font-mono text-amber-600 dark:text-amber-400">
+                <dt className="text-[color:var(--fg-muted)]">failed</dt>
+                <dd className="font-mono text-[color:var(--warning)]">
                   {result.scorePhase.failed}
                 </dd>
               </dl>
             </div>
             <div>
-              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-neutral-600 dark:text-neutral-400">
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
                 Phase 2 · PROMOTE
               </h3>
               <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-sm">
-                <dt className="text-neutral-500">scanned</dt>
+                <dt className="text-[color:var(--fg-muted)]">scanned</dt>
                 <dd className="font-mono">{result.promotePhase.scanned}</dd>
-                <dt className="text-neutral-500">promoted</dt>
-                <dd className="font-mono text-green-600 dark:text-green-400">
+                <dt className="text-[color:var(--fg-muted)]">promoted</dt>
+                <dd className="font-mono text-[color:var(--success)]">
                   {result.promotePhase.promoted}
                 </dd>
-                <dt className="text-neutral-500">already</dt>
+                <dt className="text-[color:var(--fg-muted)]">already</dt>
                 <dd className="font-mono">{result.promotePhase.alreadyPromoted}</dd>
-                <dt className="text-neutral-500">below</dt>
+                <dt className="text-[color:var(--fg-muted)]">below</dt>
                 <dd className="font-mono">{result.promotePhase.belowThreshold}</dd>
-                <dt className="text-neutral-500">failed</dt>
-                <dd className="font-mono text-amber-600 dark:text-amber-400">
+                <dt className="text-[color:var(--fg-muted)]">failed</dt>
+                <dd className="font-mono text-[color:var(--warning)]">
                   {result.promotePhase.failed}
                 </dd>
               </dl>

--- a/web-ui/app/admin/bulk-promote/page.tsx
+++ b/web-ui/app/admin/bulk-promote/page.tsx
@@ -81,7 +81,7 @@ export default function BulkPromotePage(): React.ReactElement {
   }, [scoreLimit, promoteLimit, threshold, loadPreview]);
 
   return (
-    <main className="mx-auto max-w-[800px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[800px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-8">
         <Link
           href="/admin"
@@ -99,7 +99,7 @@ export default function BulkPromotePage(): React.ReactElement {
         </p>
       </header>
 
-      <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+      <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
         <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
           Vorschau
         </h2>
@@ -135,7 +135,7 @@ export default function BulkPromotePage(): React.ReactElement {
         )}
       </section>
 
-      <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+      <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
         <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
           Parameter
         </h2>
@@ -209,13 +209,13 @@ export default function BulkPromotePage(): React.ReactElement {
       </section>
 
       {runError !== null && (
-        <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-5 text-sm text-[color:var(--danger)]">
+        <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-4 text-sm text-[color:var(--danger)]">
           {runError}
         </section>
       )}
 
       {result !== null && (
-        <section className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+        <section className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
           <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
             Ergebnis ({result.durationMs} ms)
           </h2>

--- a/web-ui/app/admin/danger-zone/page.tsx
+++ b/web-ui/app/admin/danger-zone/page.tsx
@@ -166,11 +166,11 @@ export default function DangerZonePage(): React.ReactElement {
       <header className="mb-8">
         <Link
           href="/admin"
-          className="text-xs text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+          className="text-xs text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]"
         >
           ← /admin
         </Link>
-        <h1 className="mt-2 font-display text-[clamp(2rem,4vw,3rem)] leading-[1.1] text-red-500">
+        <h1 className="mt-2 font-display text-[clamp(2rem,4vw,3rem)] leading-[1.1] text-[color:var(--danger)]">
           Danger Zone · Memory-Purge
         </h1>
         <p className="mt-3 max-w-2xl text-[16px] leading-[1.55] text-[color:var(--fg-muted)]">
@@ -181,32 +181,32 @@ export default function DangerZonePage(): React.ReactElement {
         </p>
       </header>
 
-      <section className="mb-6 rounded-[14px] border border-red-500/40 bg-red-500/5 p-4 text-sm text-red-600 dark:text-red-300">
+      <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/80/5 p-4 text-sm text-[color:var(--danger)]">
         <p>
           <strong>Hinweis:</strong> Pro User / Team / Channel löschen wirkt nur
           im Knowledge-Graph — der Agent-Scratch ist agent-scoped.
         </p>
         {warning !== null && (
-          <p className="mt-2 border-t border-red-500/30 pt-2 font-medium">
+          <p className="mt-2 border-t border-[color:var(--danger-edge)]/30 pt-2 font-medium">
             ⚠ {warning}
           </p>
         )}
       </section>
 
-      <section className="mb-6 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
-        <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+      <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+        <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
           Ziel
         </h2>
         <div className="grid gap-3 sm:grid-cols-2">
           <label className="flex flex-col gap-1">
-            <span className="text-[11px] uppercase tracking-wider text-neutral-500">
+            <span className="text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
               Achse
             </span>
             <select
               value={axis}
               onChange={(e) => { onAxisChange(e.target.value as MemoryPurgeAxis); }}
               disabled={deleting}
-              className="rounded border border-neutral-300 px-2 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+              className="rounded border border-[color:var(--border)] px-2 py-1 text-sm"
             >
               {AXES.map((a) => (
                 <option key={a.value} value={a.value}>
@@ -218,7 +218,7 @@ export default function DangerZonePage(): React.ReactElement {
 
           {requiresSelector && (
             <label className="flex flex-col gap-1">
-              <span className="text-[11px] uppercase tracking-wider text-neutral-500">
+              <span className="text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
                 Selector
               </span>
               <input
@@ -229,7 +229,7 @@ export default function DangerZonePage(): React.ReactElement {
                   SELECTOR_PLACEHOLDER[axis as Exclude<MemoryPurgeAxis, 'all'>]
                 }
                 disabled={deleting}
-                className="rounded border border-neutral-300 px-2 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                className="rounded border border-[color:var(--border)] px-2 py-1 text-sm"
               />
             </label>
           )}
@@ -256,7 +256,7 @@ export default function DangerZonePage(): React.ReactElement {
               deleting ||
               (requiresSelector && trimmedSelector.length === 0)
             }
-            className="rounded border border-neutral-300 px-3 py-1 text-xs hover:border-neutral-400 disabled:opacity-50 dark:border-neutral-700"
+            className="rounded border border-[color:var(--border)] px-3 py-1 text-xs hover:border-[color:var(--border-strong)] disabled:opacity-50"
           >
             {previewLoading ? 'lädt…' : 'Vorschau'}
           </button>
@@ -264,31 +264,31 @@ export default function DangerZonePage(): React.ReactElement {
       </section>
 
       {previewError !== null && (
-        <section className="mb-6 rounded-[14px] border border-red-400 bg-red-50 p-5 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-300">
+        <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-5 text-sm text-[color:var(--danger)]">
           Vorschau-Fehler: {previewError}
         </section>
       )}
 
       {preview !== null && previewError === null && (
-        <section className="mb-6 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
-          <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+        <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+          <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
             Vorschau — wird gelöscht
           </h2>
           <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-sm">
-            <dt className="text-neutral-500">Agent-Scratch</dt>
-            <dd className="font-mono text-red-600 dark:text-red-400">
+            <dt className="text-[color:var(--fg-muted)]">Agent-Scratch</dt>
+            <dd className="font-mono text-[color:var(--danger)]">
               {preview.scratchCount}
             </dd>
-            <dt className="text-neutral-500">Knowledge-Graph</dt>
-            <dd className="font-mono text-red-600 dark:text-red-400">
+            <dt className="text-[color:var(--fg-muted)]">Knowledge-Graph</dt>
+            <dd className="font-mono text-[color:var(--danger)]">
               {preview.kgCount}
             </dd>
           </dl>
         </section>
       )}
 
-      <section className="mb-6 rounded-[14px] border border-red-500/50 bg-red-500/5 p-5">
-        <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-red-500">
+      <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)]/50 bg-[color:var(--danger)]/80/5 p-5">
+        <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--danger)]">
           Löschen bestätigen
         </h2>
         {preview === null ? (
@@ -303,7 +303,7 @@ export default function DangerZonePage(): React.ReactElement {
           <>
             <p className="mb-2 text-sm text-[color:var(--fg-muted)]">
               Zum Bestätigen exakt eingeben:{' '}
-              <code className="rounded bg-red-500/15 px-1.5 py-0.5 font-mono text-red-600 dark:text-red-300">
+              <code className="rounded bg-[color:var(--danger)]/80/15 px-1.5 py-0.5 font-mono text-[color:var(--danger)]">
                 {requiredPhrase}
               </code>
             </p>
@@ -313,14 +313,14 @@ export default function DangerZonePage(): React.ReactElement {
               onChange={(e) => { setConfirmInput(e.target.value); }}
               placeholder={requiredPhrase}
               disabled={deleting}
-              className="w-full rounded border border-red-400 px-2 py-1.5 text-sm font-mono dark:border-red-700 dark:bg-neutral-900"
+              className="w-full rounded border border-[color:var(--danger-edge)] px-2 py-1.5 text-sm font-mono"
             />
             <div className="mt-4 flex items-center justify-end">
               <button
                 type="button"
                 onClick={() => void runDelete()}
                 disabled={!canDelete}
-                className="rounded bg-red-600 px-4 py-1.5 text-xs font-semibold text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-40"
+                className="rounded bg-[color:var(--danger)] px-4 py-1.5 text-xs font-semibold text-[color:var(--fg-on-dark)] hover:bg-[color:var(--danger)] disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {deleting ? 'löscht…' : 'Unwiderruflich löschen'}
               </button>
@@ -330,20 +330,20 @@ export default function DangerZonePage(): React.ReactElement {
       </section>
 
       {deleteError !== null && (
-        <section className="mb-6 rounded-[14px] border border-red-400 bg-red-50 p-5 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-300">
+        <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-5 text-sm text-[color:var(--danger)]">
           Lösch-Fehler: {deleteError}
         </section>
       )}
 
       {result !== null && (
-        <section className="rounded-[14px] border border-emerald-500/40 bg-emerald-500/5 p-5">
-          <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-emerald-600 dark:text-emerald-400">
+        <section className="rounded-lg border border-[color:var(--success)]/40 bg-[color:var(--success)]/100/5 p-5">
+          <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--success)]">
             Gelöscht
           </h2>
           <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-sm">
-            <dt className="text-neutral-500">Agent-Scratch</dt>
+            <dt className="text-[color:var(--fg-muted)]">Agent-Scratch</dt>
             <dd className="font-mono">{result.scratchDeleted}</dd>
-            <dt className="text-neutral-500">Knowledge-Graph</dt>
+            <dt className="text-[color:var(--fg-muted)]">Knowledge-Graph</dt>
             <dd className="font-mono">{result.kgDeleted}</dd>
           </dl>
         </section>

--- a/web-ui/app/admin/danger-zone/page.tsx
+++ b/web-ui/app/admin/danger-zone/page.tsx
@@ -162,7 +162,7 @@ export default function DangerZonePage(): React.ReactElement {
   const warning = result?.warning ?? preview?.warning ?? null;
 
   return (
-    <main className="mx-auto max-w-[800px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[800px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-8">
         <Link
           href="/admin"
@@ -193,7 +193,7 @@ export default function DangerZonePage(): React.ReactElement {
         )}
       </section>
 
-      <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+      <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
         <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
           Ziel
         </h2>
@@ -264,13 +264,13 @@ export default function DangerZonePage(): React.ReactElement {
       </section>
 
       {previewError !== null && (
-        <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-5 text-sm text-[color:var(--danger)]">
+        <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-4 text-sm text-[color:var(--danger)]">
           Vorschau-Fehler: {previewError}
         </section>
       )}
 
       {preview !== null && previewError === null && (
-        <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+        <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
           <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
             Vorschau — wird gelöscht
           </h2>
@@ -287,7 +287,7 @@ export default function DangerZonePage(): React.ReactElement {
         </section>
       )}
 
-      <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)]/50 bg-[color:var(--danger)]/5 p-5">
+      <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)]/50 bg-[color:var(--danger)]/5 p-4">
         <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--danger)]">
           Löschen bestätigen
         </h2>
@@ -303,7 +303,7 @@ export default function DangerZonePage(): React.ReactElement {
           <>
             <p className="mb-2 text-sm text-[color:var(--fg-muted)]">
               Zum Bestätigen exakt eingeben:{' '}
-              <code className="rounded bg-[color:var(--danger)]/15 px-1.5 py-0.5 font-mono text-[color:var(--danger)]">
+              <code className="rounded bg-[color:var(--danger)]/15 px-2 py-0.5 font-mono text-[color:var(--danger)]">
                 {requiredPhrase}
               </code>
             </p>
@@ -313,14 +313,14 @@ export default function DangerZonePage(): React.ReactElement {
               onChange={(e) => { setConfirmInput(e.target.value); }}
               placeholder={requiredPhrase}
               disabled={deleting}
-              className="w-full rounded border border-[color:var(--danger-edge)] px-2 py-1.5 text-sm font-mono"
+              className="w-full rounded border border-[color:var(--danger-edge)] px-2 py-2 text-sm font-mono"
             />
             <div className="mt-4 flex items-center justify-end">
               <button
                 type="button"
                 onClick={() => void runDelete()}
                 disabled={!canDelete}
-                className="rounded-md border border-[color:var(--danger-edge)] bg-transparent px-4 py-1.5 text-xs font-semibold text-[color:var(--danger)] transition hover:bg-[color:var(--danger)]/8 disabled:cursor-not-allowed disabled:opacity-40"
+                className="rounded-md border border-[color:var(--danger-edge)] bg-transparent px-4 py-2 text-xs font-semibold text-[color:var(--danger)] transition hover:bg-[color:var(--danger)]/8 disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {deleting ? 'löscht…' : 'Unwiderruflich löschen'}
               </button>
@@ -330,13 +330,13 @@ export default function DangerZonePage(): React.ReactElement {
       </section>
 
       {deleteError !== null && (
-        <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-5 text-sm text-[color:var(--danger)]">
+        <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-4 text-sm text-[color:var(--danger)]">
           Lösch-Fehler: {deleteError}
         </section>
       )}
 
       {result !== null && (
-        <section className="rounded-lg border border-[color:var(--success)]/40 bg-[color:var(--success)]/5 p-5">
+        <section className="rounded-lg border border-[color:var(--success)]/40 bg-[color:var(--success)]/5 p-4">
           <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--success)]">
             Gelöscht
           </h2>

--- a/web-ui/app/admin/danger-zone/page.tsx
+++ b/web-ui/app/admin/danger-zone/page.tsx
@@ -181,7 +181,7 @@ export default function DangerZonePage(): React.ReactElement {
         </p>
       </header>
 
-      <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/80/5 p-4 text-sm text-[color:var(--danger)]">
+      <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/5 p-4 text-sm text-[color:var(--danger)]">
         <p>
           <strong>Hinweis:</strong> Pro User / Team / Channel löschen wirkt nur
           im Knowledge-Graph — der Agent-Scratch ist agent-scoped.
@@ -287,7 +287,7 @@ export default function DangerZonePage(): React.ReactElement {
         </section>
       )}
 
-      <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)]/50 bg-[color:var(--danger)]/80/5 p-5">
+      <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)]/50 bg-[color:var(--danger)]/5 p-5">
         <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--danger)]">
           Löschen bestätigen
         </h2>
@@ -303,7 +303,7 @@ export default function DangerZonePage(): React.ReactElement {
           <>
             <p className="mb-2 text-sm text-[color:var(--fg-muted)]">
               Zum Bestätigen exakt eingeben:{' '}
-              <code className="rounded bg-[color:var(--danger)]/80/15 px-1.5 py-0.5 font-mono text-[color:var(--danger)]">
+              <code className="rounded bg-[color:var(--danger)]/15 px-1.5 py-0.5 font-mono text-[color:var(--danger)]">
                 {requiredPhrase}
               </code>
             </p>
@@ -320,7 +320,7 @@ export default function DangerZonePage(): React.ReactElement {
                 type="button"
                 onClick={() => void runDelete()}
                 disabled={!canDelete}
-                className="rounded bg-[color:var(--danger)] px-4 py-1.5 text-xs font-semibold text-[color:var(--fg-on-dark)] hover:bg-[color:var(--danger)] disabled:cursor-not-allowed disabled:opacity-40"
+                className="rounded-md border border-[color:var(--danger-edge)] bg-transparent px-4 py-1.5 text-xs font-semibold text-[color:var(--danger)] transition hover:bg-[color:var(--danger)]/8 disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {deleting ? 'löscht…' : 'Unwiderruflich löschen'}
               </button>
@@ -336,7 +336,7 @@ export default function DangerZonePage(): React.ReactElement {
       )}
 
       {result !== null && (
-        <section className="rounded-lg border border-[color:var(--success)]/40 bg-[color:var(--success)]/100/5 p-5">
+        <section className="rounded-lg border border-[color:var(--success)]/40 bg-[color:var(--success)]/5 p-5">
           <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--success)]">
             Gelöscht
           </h2>

--- a/web-ui/app/admin/domains/page.tsx
+++ b/web-ui/app/admin/domains/page.tsx
@@ -93,7 +93,7 @@ export default function AdminDomainsPage(): React.ReactElement {
       {loading ? (
         <p className="text-[color:var(--fg-muted)]">Lade …</p>
       ) : error ? (
-        <p className="rounded-md border border-red-500/40 bg-red-500/10 p-4 text-sm text-red-300">
+        <p className="rounded-md border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/80/10 p-4 text-sm text-[color:var(--danger)]">
           Fehler beim Laden: {error}
         </p>
       ) : data ? (
@@ -131,11 +131,11 @@ function Content({ data }: { data: DomainsResponse }): React.ReactElement {
       )}
 
       {data.totals.fallbackDomains > 0 ? (
-        <p className="mt-8 rounded-md border border-amber-500/40 bg-amber-500/10 p-4 text-sm text-amber-200">
+        <p className="mt-8 rounded-md border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/100/10 p-4 text-sm text-[color:var(--warning)]">
           {data.totals.fallbackDomains} Plugin
           {data.totals.fallbackDomains === 1 ? '' : 's'} ohne deklarierte
           Domain — auto-fallback auf{' '}
-          <code className="text-amber-100">unknown.&lt;id&gt;</code>. Füge
+          <code className="text-[color:var(--warning)]">unknown.&lt;id&gt;</code>. Füge
           dem Manifest eine <code>identity.domain</code>-Zeile hinzu (z.B.
           <code> &quot;confluence&quot;</code>,{' '}
           <code>&quot;odoo.hr&quot;</code>) oder lade den Agent über den
@@ -155,15 +155,15 @@ function DomainSection({
     <li
       className={
         bucket.isFallback
-          ? 'rounded-[14px] border border-amber-500/40 bg-amber-500/5 p-5'
-          : 'rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5'
+          ? 'rounded-lg border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/100/5 p-5'
+          : 'rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5'
       }
     >
       <header className="mb-4 flex items-baseline justify-between gap-3">
         <h2
           className={
             bucket.isFallback
-              ? 'font-mono text-[15px] text-amber-200'
+              ? 'font-mono text-[15px] text-[color:var(--warning)]'
               : 'font-mono text-[15px] text-[color:var(--fg-strong)]'
           }
         >
@@ -211,8 +211,8 @@ function Stat({
     <div
       className={
         warn
-          ? 'rounded-[12px] border border-amber-500/40 bg-amber-500/5 p-4'
-          : 'rounded-[12px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4'
+          ? 'rounded-lg border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/100/5 p-4'
+          : 'rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4'
       }
     >
       <div className="text-[12px] uppercase tracking-wider text-[color:var(--fg-muted)]">
@@ -221,7 +221,7 @@ function Stat({
       <div
         className={
           warn
-            ? 'mt-1 font-display text-[28px] text-amber-200'
+            ? 'mt-1 font-display text-[28px] text-[color:var(--warning)]'
             : 'mt-1 font-display text-[28px] text-[color:var(--fg-strong)]'
         }
       >

--- a/web-ui/app/admin/domains/page.tsx
+++ b/web-ui/app/admin/domains/page.tsx
@@ -93,7 +93,7 @@ export default function AdminDomainsPage(): React.ReactElement {
       {loading ? (
         <p className="text-[color:var(--fg-muted)]">Lade …</p>
       ) : error ? (
-        <p className="rounded-md border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/80/10 p-4 text-sm text-[color:var(--danger)]">
+        <p className="rounded-md border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/10 p-4 text-sm text-[color:var(--danger)]">
           Fehler beim Laden: {error}
         </p>
       ) : data ? (
@@ -131,7 +131,7 @@ function Content({ data }: { data: DomainsResponse }): React.ReactElement {
       )}
 
       {data.totals.fallbackDomains > 0 ? (
-        <p className="mt-8 rounded-md border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/100/10 p-4 text-sm text-[color:var(--warning)]">
+        <p className="mt-8 rounded-md border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/10 p-4 text-sm text-[color:var(--warning)]">
           {data.totals.fallbackDomains} Plugin
           {data.totals.fallbackDomains === 1 ? '' : 's'} ohne deklarierte
           Domain — auto-fallback auf{' '}
@@ -155,7 +155,7 @@ function DomainSection({
     <li
       className={
         bucket.isFallback
-          ? 'rounded-lg border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/100/5 p-5'
+          ? 'rounded-lg border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/5 p-5'
           : 'rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5'
       }
     >
@@ -211,7 +211,7 @@ function Stat({
     <div
       className={
         warn
-          ? 'rounded-lg border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/100/5 p-4'
+          ? 'rounded-lg border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/5 p-4'
           : 'rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4'
       }
     >

--- a/web-ui/app/admin/domains/page.tsx
+++ b/web-ui/app/admin/domains/page.tsx
@@ -75,8 +75,8 @@ export default function AdminDomainsPage(): React.ReactElement {
   }, []);
 
   return (
-    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-10 lg:py-16">
-      <header className="mb-10">
+    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-8 lg:py-16">
+      <header className="mb-8">
         <h1 className="font-display text-[clamp(2rem,4vw,3rem)] leading-[1.1] text-[color:var(--fg-strong)]">
           Plugin-Domains
         </h1>
@@ -155,8 +155,8 @@ function DomainSection({
     <li
       className={
         bucket.isFallback
-          ? 'rounded-lg border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/5 p-5'
-          : 'rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5'
+          ? 'rounded-lg border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/5 p-4'
+          : 'rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4'
       }
     >
       <header className="mb-4 flex items-baseline justify-between gap-3">

--- a/web-ui/app/admin/duplicates/[id]/page.tsx
+++ b/web-ui/app/admin/duplicates/[id]/page.tsx
@@ -90,7 +90,7 @@ export default function DuplicateDetailPage(): React.ReactElement {
   );
 
   return (
-    <main className="mx-auto max-w-[1100px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[1100px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-8">
         <Link
           href="/admin/duplicates"
@@ -112,7 +112,7 @@ export default function DuplicateDetailPage(): React.ReactElement {
 
       {detail !== null && (
         <>
-          <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+          <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
             <h2 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
               Detector-Befund
             </h2>
@@ -139,7 +139,7 @@ export default function DuplicateDetailPage(): React.ReactElement {
           </div>
 
           {detail.props.status === 'open' && (
-            <section className="mt-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+            <section className="mt-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
               <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
                 Auflösung
               </h2>
@@ -198,7 +198,7 @@ function MemoryCard({
   mk: MemorableKnowledgeNode | null;
 }): React.ReactElement {
   return (
-    <article className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+    <article className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
       <header className="mb-3 flex items-center justify-between">
         <span className="text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
           {label}

--- a/web-ui/app/admin/duplicates/[id]/page.tsx
+++ b/web-ui/app/admin/duplicates/[id]/page.tsx
@@ -94,7 +94,7 @@ export default function DuplicateDetailPage(): React.ReactElement {
       <header className="mb-8">
         <Link
           href="/admin/duplicates"
-          className="text-xs text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+          className="text-xs text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]"
         >
           ← /admin/duplicates
         </Link>
@@ -103,17 +103,17 @@ export default function DuplicateDetailPage(): React.ReactElement {
         </h1>
       </header>
 
-      {loading && <p className="text-xs text-neutral-500">lädt…</p>}
+      {loading && <p className="text-xs text-[color:var(--fg-muted)]">lädt…</p>}
       {loadError !== null && (
-        <div className="border-l-2 border-red-400 px-3 py-2 text-xs text-red-700 dark:text-red-300">
+        <div className="border-l-2 border-[color:var(--danger-edge)] px-3 py-2 text-xs text-[color:var(--danger)]">
           Fehler: {loadError}
         </div>
       )}
 
       {detail !== null && (
         <>
-          <section className="mb-6 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
-            <h2 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+          <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+            <h2 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
               Detector-Befund
             </h2>
             <p className="text-sm">
@@ -122,11 +122,11 @@ export default function DuplicateDetailPage(): React.ReactElement {
               — Memories sind fast identisch.
             </p>
             <dl className="mt-3 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-[11px]">
-              <dt className="text-neutral-500">Status</dt>
+              <dt className="text-[color:var(--fg-muted)]">Status</dt>
               <dd className="font-mono">{detail.props.status}</dd>
               {detail.props.resolution && (
                 <>
-                  <dt className="text-neutral-500">Resolution</dt>
+                  <dt className="text-[color:var(--fg-muted)]">Resolution</dt>
                   <dd className="font-mono">{detail.props.resolution}</dd>
                 </>
               )}
@@ -139,12 +139,12 @@ export default function DuplicateDetailPage(): React.ReactElement {
           </div>
 
           {detail.props.status === 'open' && (
-            <section className="mt-6 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
-              <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+            <section className="mt-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+              <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
                 Auflösung
               </h2>
               <label className="mb-3 block">
-                <span className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-500">
+                <span className="mb-1 block text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
                   Begründung (optional, im Audit-Log)
                 </span>
                 <input
@@ -153,11 +153,11 @@ export default function DuplicateDetailPage(): React.ReactElement {
                   onChange={(e) => setReason(e.target.value)}
                   disabled={busy}
                   maxLength={1000}
-                  className="w-full rounded border border-neutral-300 px-2 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                  className="w-full rounded border border-[color:var(--border)] px-2 py-1 text-sm"
                 />
               </label>
               {mutationError !== null && (
-                <p className="mb-3 border-l-2 border-red-400 px-2 py-1 text-xs text-red-700 dark:text-red-300">
+                <p className="mb-3 border-l-2 border-[color:var(--danger-edge)] px-2 py-1 text-xs text-[color:var(--danger)]">
                   Fehler: {mutationError}
                 </p>
               )}
@@ -171,12 +171,12 @@ export default function DuplicateDetailPage(): React.ReactElement {
                     className={[
                       'rounded border px-3 py-2 text-left text-xs disabled:opacity-50',
                       r === 'keep_a' || r === 'keep_b'
-                        ? 'border-red-400 hover:bg-red-50 dark:border-red-800 dark:hover:bg-red-900/30'
-                        : 'border-neutral-300 hover:border-neutral-400 dark:border-neutral-700',
+                        ? 'border-[color:var(--danger-edge)] hover:bg-[color:var(--danger)]/8'
+                        : 'border-[color:var(--border)] hover:border-[color:var(--border-strong)]',
                     ].join(' ')}
                   >
                     <div className="font-semibold">{RESOLUTION_LABEL[r]}</div>
-                    <div className="mt-1 text-[10px] text-neutral-500">
+                    <div className="mt-1 text-[10px] text-[color:var(--fg-muted)]">
                       {RESOLUTION_DESCRIPTION[r]}
                     </div>
                   </button>
@@ -198,35 +198,35 @@ function MemoryCard({
   mk: MemorableKnowledgeNode | null;
 }): React.ReactElement {
   return (
-    <article className="rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+    <article className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
       <header className="mb-3 flex items-center justify-between">
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
           {label}
         </span>
         {mk && (
           <Link
             href={`/memories/${encodeURIComponent(mk.id)}`}
-            className="text-[10px] text-neutral-500 underline-offset-2 hover:underline"
+            className="text-[10px] text-[color:var(--fg-muted)] underline-offset-2 hover:underline"
           >
             zur Memory →
           </Link>
         )}
       </header>
       {!mk && (
-        <p className="text-xs italic text-neutral-500">
+        <p className="text-xs italic text-[color:var(--fg-muted)]">
           Memory nicht zugänglich (gelöscht oder kein Owner).
         </p>
       )}
       {mk && (
         <>
-          <div className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
+          <div className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
             {String(mk.props.kind)}
           </div>
-          <p className="text-sm text-neutral-900 dark:text-neutral-100">
+          <p className="text-sm text-[color:var(--fg-strong)]">
             {mk.props.summary}
           </p>
           {typeof mk.props.rationale === 'string' && (
-            <p className="mt-2 text-xs text-neutral-700 dark:text-neutral-300">
+            <p className="mt-2 text-xs text-[color:var(--fg)]">
               {mk.props.rationale}
             </p>
           )}

--- a/web-ui/app/admin/duplicates/excerpt/[id]/page.tsx
+++ b/web-ui/app/admin/duplicates/excerpt/[id]/page.tsx
@@ -92,7 +92,7 @@ export default function ExcerptDuplicateDetailPage(): React.ReactElement {
       <header className="mb-8">
         <Link
           href="/admin/duplicates"
-          className="text-xs text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+          className="text-xs text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]"
         >
           ← /admin/duplicates
         </Link>
@@ -101,17 +101,17 @@ export default function ExcerptDuplicateDetailPage(): React.ReactElement {
         </h1>
       </header>
 
-      {loading && <p className="text-xs text-neutral-500">lädt…</p>}
+      {loading && <p className="text-xs text-[color:var(--fg-muted)]">lädt…</p>}
       {loadError !== null && (
-        <div className="border-l-2 border-red-400 px-3 py-2 text-xs text-red-700 dark:text-red-300">
+        <div className="border-l-2 border-[color:var(--danger-edge)] px-3 py-2 text-xs text-[color:var(--danger)]">
           Fehler: {loadError}
         </div>
       )}
 
       {detail !== null && (
         <>
-          <section className="mb-6 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
-            <h2 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+          <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+            <h2 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
               Detector-Befund
             </h2>
             <p className="text-sm">
@@ -120,11 +120,11 @@ export default function ExcerptDuplicateDetailPage(): React.ReactElement {
               — Excerpts sind fast wörtlich identisch.
             </p>
             <dl className="mt-3 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-[11px]">
-              <dt className="text-neutral-500">Status</dt>
+              <dt className="text-[color:var(--fg-muted)]">Status</dt>
               <dd className="font-mono">{detail.props.status}</dd>
               {detail.props.resolution && (
                 <>
-                  <dt className="text-neutral-500">Resolution</dt>
+                  <dt className="text-[color:var(--fg-muted)]">Resolution</dt>
                   <dd className="font-mono">{detail.props.resolution}</dd>
                 </>
               )}
@@ -145,12 +145,12 @@ export default function ExcerptDuplicateDetailPage(): React.ReactElement {
           </div>
 
           {detail.props.status === 'open' && (
-            <section className="mt-6 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
-              <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+            <section className="mt-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+              <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
                 Auflösung
               </h2>
               <label className="mb-3 block">
-                <span className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-500">
+                <span className="mb-1 block text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
                   Begründung (optional, im Audit-Log)
                 </span>
                 <input
@@ -159,11 +159,11 @@ export default function ExcerptDuplicateDetailPage(): React.ReactElement {
                   onChange={(e) => setReason(e.target.value)}
                   disabled={busy}
                   maxLength={1000}
-                  className="w-full rounded border border-neutral-300 px-2 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                  className="w-full rounded border border-[color:var(--border)] px-2 py-1 text-sm"
                 />
               </label>
               {mutationError !== null && (
-                <p className="mb-3 border-l-2 border-red-400 px-2 py-1 text-xs text-red-700 dark:text-red-300">
+                <p className="mb-3 border-l-2 border-[color:var(--danger-edge)] px-2 py-1 text-xs text-[color:var(--danger)]">
                   Fehler: {mutationError}
                 </p>
               )}
@@ -177,12 +177,12 @@ export default function ExcerptDuplicateDetailPage(): React.ReactElement {
                     className={[
                       'rounded border px-3 py-2 text-left text-xs disabled:opacity-50',
                       r === 'keep_a' || r === 'keep_b'
-                        ? 'border-red-400 hover:bg-red-50 dark:border-red-800 dark:hover:bg-red-900/30'
-                        : 'border-neutral-300 hover:border-neutral-400 dark:border-neutral-700',
+                        ? 'border-[color:var(--danger-edge)] hover:bg-[color:var(--danger)]/8'
+                        : 'border-[color:var(--border)] hover:border-[color:var(--border-strong)]',
                     ].join(' ')}
                   >
                     <div className="font-semibold">{RESOLUTION_LABEL[r]}</div>
-                    <div className="mt-1 text-[10px] text-neutral-500">
+                    <div className="mt-1 text-[10px] text-[color:var(--fg-muted)]">
                       {RESOLUTION_DESCRIPTION[r]}
                     </div>
                   </button>
@@ -206,35 +206,35 @@ function ExcerptCard({
   parentMk: ExcerptMergeDetailDto['mkA'];
 }): React.ReactElement {
   return (
-    <article className="rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+    <article className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
       <header className="mb-3 flex items-center justify-between">
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
           {label}
         </span>
         {parentMk && (
           <Link
             href={`/memories/${encodeURIComponent(parentMk.id)}`}
-            className="text-[10px] text-neutral-500 underline-offset-2 hover:underline"
+            className="text-[10px] text-[color:var(--fg-muted)] underline-offset-2 hover:underline"
           >
             zur Parent-Memory →
           </Link>
         )}
       </header>
       {!excerpt && (
-        <p className="text-xs italic text-neutral-500">
+        <p className="text-xs italic text-[color:var(--fg-muted)]">
           Excerpt nicht zugänglich (gelöscht oder kein Owner).
         </p>
       )}
       {excerpt && (
         <>
-          <div className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
+          <div className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
             Position {excerpt.props.position} · {excerpt.props.source}
           </div>
-          <p className="text-sm text-neutral-900 dark:text-neutral-100">
+          <p className="text-sm text-[color:var(--fg-strong)]">
             „{excerpt.props.text}&ldquo;
           </p>
           {parentMk && (
-            <p className="mt-3 text-[11px] text-neutral-500">
+            <p className="mt-3 text-[11px] text-[color:var(--fg-muted)]">
               Parent-Memory: {String(parentMk.props.summary)}
             </p>
           )}

--- a/web-ui/app/admin/duplicates/excerpt/[id]/page.tsx
+++ b/web-ui/app/admin/duplicates/excerpt/[id]/page.tsx
@@ -88,7 +88,7 @@ export default function ExcerptDuplicateDetailPage(): React.ReactElement {
   );
 
   return (
-    <main className="mx-auto max-w-[1100px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[1100px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-8">
         <Link
           href="/admin/duplicates"
@@ -110,7 +110,7 @@ export default function ExcerptDuplicateDetailPage(): React.ReactElement {
 
       {detail !== null && (
         <>
-          <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+          <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
             <h2 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
               Detector-Befund
             </h2>
@@ -145,7 +145,7 @@ export default function ExcerptDuplicateDetailPage(): React.ReactElement {
           </div>
 
           {detail.props.status === 'open' && (
-            <section className="mt-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+            <section className="mt-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
               <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
                 Auflösung
               </h2>
@@ -206,7 +206,7 @@ function ExcerptCard({
   parentMk: ExcerptMergeDetailDto['mkA'];
 }): React.ReactElement {
   return (
-    <article className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+    <article className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
       <header className="mb-3 flex items-center justify-between">
         <span className="text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
           {label}

--- a/web-ui/app/admin/duplicates/page.tsx
+++ b/web-ui/app/admin/duplicates/page.tsx
@@ -200,7 +200,7 @@ export default function DuplicatesListPage(): React.ReactElement {
   }, [items]);
 
   return (
-    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-6">
         <Link
           href="/admin"
@@ -405,13 +405,13 @@ export default function DuplicatesListPage(): React.ReactElement {
                 <div className="mb-2 flex flex-wrap items-center gap-2 text-[10px]">
                   <span
                     className={[
-                      'rounded px-1.5 py-0.5 uppercase tracking-wider',
+                      'rounded px-2 py-0.5 uppercase tracking-wider',
                       STATUS_BADGE[mc.props.status],
                     ].join(' ')}
                   >
                     {mc.props.status}
                   </span>
-                  <span className="rounded bg-[color:var(--accent)]/10 px-1.5 py-0.5 font-mono uppercase tracking-wider text-[color:var(--accent)]">
+                  <span className="rounded bg-[color:var(--accent)]/10 px-2 py-0.5 font-mono uppercase tracking-wider text-[color:var(--accent)]">
                     cosine {mc.props.cosine_sim.toFixed(3)}
                   </span>
                   <time
@@ -603,13 +603,13 @@ export default function DuplicatesListPage(): React.ReactElement {
                     <div className="mb-2 flex flex-wrap items-center gap-2 text-[10px]">
                       <span
                         className={[
-                          'rounded px-1.5 py-0.5 uppercase tracking-wider',
+                          'rounded px-2 py-0.5 uppercase tracking-wider',
                           STATUS_BADGE[mc.props.status],
                         ].join(' ')}
                       >
                         {mc.props.status}
                       </span>
-                      <span className="rounded bg-[color:var(--warning)]/10 px-1.5 py-0.5 font-mono uppercase tracking-wider text-[color:var(--warning)]">
+                      <span className="rounded bg-[color:var(--warning)]/10 px-2 py-0.5 font-mono uppercase tracking-wider text-[color:var(--warning)]">
                         cosine {mc.props.cosine_sim.toFixed(3)}
                       </span>
                       <time

--- a/web-ui/app/admin/duplicates/page.tsx
+++ b/web-ui/app/admin/duplicates/page.tsx
@@ -23,11 +23,11 @@ import {
 type TabKey = 'memories' | 'excerpts';
 
 const STATUS_BADGE: Record<MergeCandidateStatus, string> = {
-  open: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+  open: 'bg-[color:var(--accent)]/10 text-[color:var(--accent)]',
   resolved:
-    'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
+    'bg-[color:var(--success)]/10 text-[color:var(--success)]',
   dismissed:
-    'bg-neutral-100 text-neutral-800 dark:bg-neutral-800 dark:text-neutral-300',
+    'bg-[color:var(--bg-soft)] text-[color:var(--fg)]',
 };
 
 const BULK_CONFIRM_THRESHOLD = 100;
@@ -204,7 +204,7 @@ export default function DuplicatesListPage(): React.ReactElement {
       <header className="mb-6">
         <Link
           href="/admin"
-          className="text-xs text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+          className="text-xs text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]"
         >
           ← /admin
         </Link>
@@ -231,7 +231,7 @@ export default function DuplicatesListPage(): React.ReactElement {
               '-mb-px rounded-t border-b-2 px-3 py-2 text-sm font-medium transition',
               tab === t
                 ? 'border-[color:var(--accent)] text-[color:var(--fg-strong)]'
-                : 'border-transparent text-neutral-500 hover:text-neutral-800 dark:hover:text-neutral-200',
+                : 'border-transparent text-[color:var(--fg-muted)] hover:text-[color:var(--fg)]',
             ].join(' ')}
           >
             {t === 'memories' ? 'Memories' : 'Excerpts (Palaia)'}
@@ -243,7 +243,7 @@ export default function DuplicatesListPage(): React.ReactElement {
       <>
       <section
         aria-label="Bulk merge detect"
-        className="mb-6 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4"
+        className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4"
       >
         <div className="mb-3 flex flex-wrap items-baseline gap-3">
           <h2 className="text-sm font-semibold text-[color:var(--fg-strong)]">
@@ -256,7 +256,7 @@ export default function DuplicatesListPage(): React.ReactElement {
         </div>
 
         {bulkPreviewError !== null && (
-          <p className="mb-2 text-xs text-red-600 dark:text-red-300">
+          <p className="mb-2 text-xs text-[color:var(--danger)]">
             Preview fehlgeschlagen: {bulkPreviewError}
           </p>
         )}
@@ -264,17 +264,17 @@ export default function DuplicatesListPage(): React.ReactElement {
         {bulkPreview !== null && (
           <dl className="mb-3 grid grid-cols-2 gap-2 text-xs sm:grid-cols-3">
             <div>
-              <dt className="text-neutral-500">ungeprüft</dt>
+              <dt className="text-[color:var(--fg-muted)]">ungeprüft</dt>
               <dd className="font-mono text-base">{bulkPreview.unchecked}</dd>
             </div>
             <div>
-              <dt className="text-neutral-500">schon geprüft</dt>
+              <dt className="text-[color:var(--fg-muted)]">schon geprüft</dt>
               <dd className="font-mono text-base">
                 {bulkPreview.alreadyChecked}
               </dd>
             </div>
             <div>
-              <dt className="text-neutral-500">ohne Embedding</dt>
+              <dt className="text-[color:var(--fg-muted)]">ohne Embedding</dt>
               <dd className="font-mono text-base">
                 {bulkPreview.withoutEmbedding}
               </dd>
@@ -306,49 +306,49 @@ export default function DuplicatesListPage(): React.ReactElement {
             disabled={
               bulkRunning || (bulkPreview !== null && bulkPreview.unchecked === 0)
             }
-            className="rounded border border-neutral-900 bg-neutral-900 px-3 py-1 text-xs text-white disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-200 dark:bg-neutral-200 dark:text-neutral-900"
+            className="rounded border border-[color:var(--border-strong)] bg-[color:var(--bg-inverse)] px-3 py-1 text-xs text-[color:var(--fg-on-dark)] disabled:cursor-not-allowed disabled:opacity-50"
           >
             {bulkRunning ? 'läuft…' : 'Bulk-Detect starten'}
           </button>
           {bulkLimit > BULK_CONFIRM_THRESHOLD && (
-            <span className="text-[11px] text-amber-700 dark:text-amber-300">
+            <span className="text-[11px] text-[color:var(--warning)]">
               ⚠️ Confirm bei Limit &gt; {BULK_CONFIRM_THRESHOLD}
             </span>
           )}
         </div>
 
         {bulkError !== null && (
-          <p className="mt-3 text-xs text-red-600 dark:text-red-300">
+          <p className="mt-3 text-xs text-[color:var(--danger)]">
             Run fehlgeschlagen: {bulkError}
           </p>
         )}
 
         {bulkResult !== null && (
-          <div className="mt-3 rounded border border-[color:var(--border)] bg-black/5 p-3 text-xs dark:bg-white/5">
+          <div className="mt-3 rounded border border-[color:var(--border)] bg-black/5 p-3 text-xs">
             <p className="mb-2 font-medium">
               Ergebnis · {bulkResult.durationMs} ms
             </p>
             <dl className="grid grid-cols-2 gap-2 sm:grid-cols-5">
               <div>
-                <dt className="text-neutral-500">scanned</dt>
+                <dt className="text-[color:var(--fg-muted)]">scanned</dt>
                 <dd className="font-mono">{bulkResult.scanned}</dd>
               </div>
               <div>
-                <dt className="text-neutral-500">checked</dt>
+                <dt className="text-[color:var(--fg-muted)]">checked</dt>
                 <dd className="font-mono">{bulkResult.checked}</dd>
               </div>
               <div>
-                <dt className="text-neutral-500">neue Duplikate</dt>
+                <dt className="text-[color:var(--fg-muted)]">neue Duplikate</dt>
                 <dd className="font-mono">
                   {bulkResult.mergeCandidatesCreated}
                 </dd>
               </div>
               <div>
-                <dt className="text-neutral-500">ohne Embedding</dt>
+                <dt className="text-[color:var(--fg-muted)]">ohne Embedding</dt>
                 <dd className="font-mono">{bulkResult.skippedNoEmbedding}</dd>
               </div>
               <div>
-                <dt className="text-neutral-500">Fehler</dt>
+                <dt className="text-[color:var(--fg-muted)]">Fehler</dt>
                 <dd className="font-mono">{bulkResult.failed}</dd>
               </div>
             </dl>
@@ -365,8 +365,8 @@ export default function DuplicatesListPage(): React.ReactElement {
             className={[
               'rounded border px-3 py-1 text-xs',
               statusFilter === s
-                ? 'border-neutral-900 bg-neutral-900 text-white dark:border-neutral-200 dark:bg-neutral-200 dark:text-neutral-900'
-                : 'border-neutral-300 hover:border-neutral-400 dark:border-neutral-700',
+                ? 'border-[color:var(--border-strong)] bg-[color:var(--bg-inverse)] text-[color:var(--fg-on-dark)]'
+                : 'border-[color:var(--border)] hover:border-[color:var(--border-strong)]',
             ].join(' ')}
           >
             {s === 'all' ? 'alle' : s}
@@ -376,20 +376,20 @@ export default function DuplicatesListPage(): React.ReactElement {
           type="button"
           onClick={() => void load()}
           disabled={loading}
-          className="ml-auto rounded border border-neutral-300 px-3 py-1 text-xs hover:border-neutral-400 disabled:opacity-50 dark:border-neutral-700"
+          className="ml-auto rounded border border-[color:var(--border)] px-3 py-1 text-xs hover:border-[color:var(--border-strong)] disabled:opacity-50"
         >
           {loading ? 'lädt…' : 'aktualisieren'}
         </button>
       </div>
 
       {error !== null && (
-        <div className="mb-4 border-l-2 border-red-400 px-3 py-2 text-xs text-red-700 dark:text-red-300">
+        <div className="mb-4 border-l-2 border-[color:var(--danger-edge)] px-3 py-2 text-xs text-[color:var(--danger)]">
           Fehler: {error}
         </div>
       )}
 
       {sorted !== null && sorted.length === 0 && error === null && (
-        <p className="text-sm italic text-neutral-500">
+        <p className="text-sm italic text-[color:var(--fg-muted)]">
           Keine Duplikat-Kandidaten in dieser Auswahl.
         </p>
       )}
@@ -400,7 +400,7 @@ export default function DuplicatesListPage(): React.ReactElement {
             <li key={mc.id}>
               <Link
                 href={`/admin/duplicates/${encodeURIComponent(mc.id)}`}
-                className="block rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4 transition-colors hover:border-[color:var(--accent)]"
+                className="block rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4 transition-colors hover:border-[color:var(--accent)]"
               >
                 <div className="mb-2 flex flex-wrap items-center gap-2 text-[10px]">
                   <span
@@ -411,20 +411,20 @@ export default function DuplicatesListPage(): React.ReactElement {
                   >
                     {mc.props.status}
                   </span>
-                  <span className="rounded bg-violet-100 px-1.5 py-0.5 font-mono uppercase tracking-wider text-violet-800 dark:bg-violet-900/40 dark:text-violet-200">
+                  <span className="rounded bg-[color:var(--accent)]/10 px-1.5 py-0.5 font-mono uppercase tracking-wider text-[color:var(--accent)]">
                     cosine {mc.props.cosine_sim.toFixed(3)}
                   </span>
                   <time
-                    className="font-mono text-neutral-500"
+                    className="font-mono text-[color:var(--fg-muted)]"
                     dateTime={mc.props.created_at}
                   >
                     {new Date(mc.props.created_at).toLocaleString('de-DE')}
                   </time>
                 </div>
-                <p className="text-sm text-neutral-900 dark:text-neutral-100">
+                <p className="text-sm text-[color:var(--fg-strong)]">
                   {mc.mkA?.props.summary?.slice(0, 90) ?? '(MK A)'}
                 </p>
-                <p className="mt-1 text-xs text-neutral-700 dark:text-neutral-300">
+                <p className="mt-1 text-xs text-[color:var(--fg)]">
                   ↔ {mc.mkB?.props.summary?.slice(0, 90) ?? '(MK B)'}
                 </p>
               </Link>
@@ -440,7 +440,7 @@ export default function DuplicatesListPage(): React.ReactElement {
         {/* Slice 12 — Excerpt Bulk Detect panel */}
         <section
           aria-label="Bulk excerpt-merge detect"
-          className="mb-6 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4"
+          className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4"
         >
           <div className="mb-3 flex flex-wrap items-baseline gap-3">
             <h2 className="text-sm font-semibold text-[color:var(--fg-strong)]">
@@ -452,7 +452,7 @@ export default function DuplicatesListPage(): React.ReactElement {
           </div>
 
           {excerptBulkPreviewError !== null && (
-            <p className="mb-2 text-xs text-red-600 dark:text-red-300">
+            <p className="mb-2 text-xs text-[color:var(--danger)]">
               Preview fehlgeschlagen: {excerptBulkPreviewError}
             </p>
           )}
@@ -460,19 +460,19 @@ export default function DuplicatesListPage(): React.ReactElement {
           {excerptBulkPreview !== null && (
             <dl className="mb-3 grid grid-cols-2 gap-2 text-xs sm:grid-cols-3">
               <div>
-                <dt className="text-neutral-500">ungeprüft</dt>
+                <dt className="text-[color:var(--fg-muted)]">ungeprüft</dt>
                 <dd className="font-mono text-base">
                   {excerptBulkPreview.unchecked}
                 </dd>
               </div>
               <div>
-                <dt className="text-neutral-500">schon geprüft</dt>
+                <dt className="text-[color:var(--fg-muted)]">schon geprüft</dt>
                 <dd className="font-mono text-base">
                   {excerptBulkPreview.alreadyChecked}
                 </dd>
               </div>
               <div>
-                <dt className="text-neutral-500">ohne Embedding</dt>
+                <dt className="text-[color:var(--fg-muted)]">ohne Embedding</dt>
                 <dd className="font-mono text-base">
                   {excerptBulkPreview.withoutEmbedding}
                 </dd>
@@ -505,45 +505,45 @@ export default function DuplicatesListPage(): React.ReactElement {
                 excerptBulkRunning ||
                 (excerptBulkPreview !== null && excerptBulkPreview.unchecked === 0)
               }
-              className="rounded border border-neutral-900 bg-neutral-900 px-3 py-1 text-xs text-white disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-200 dark:bg-neutral-200 dark:text-neutral-900"
+              className="rounded border border-[color:var(--border-strong)] bg-[color:var(--bg-inverse)] px-3 py-1 text-xs text-[color:var(--fg-on-dark)] disabled:cursor-not-allowed disabled:opacity-50"
             >
               {excerptBulkRunning ? 'läuft…' : 'Bulk-Detect starten'}
             </button>
             {excerptBulkLimit > BULK_CONFIRM_THRESHOLD && (
-              <span className="text-[11px] text-amber-700 dark:text-amber-300">
+              <span className="text-[11px] text-[color:var(--warning)]">
                 ⚠️ Confirm bei Limit &gt; {BULK_CONFIRM_THRESHOLD}
               </span>
             )}
           </div>
 
           {excerptBulkError !== null && (
-            <p className="mt-3 text-xs text-red-600 dark:text-red-300">
+            <p className="mt-3 text-xs text-[color:var(--danger)]">
               Run fehlgeschlagen: {excerptBulkError}
             </p>
           )}
 
           {excerptBulkResult !== null && (
-            <div className="mt-3 rounded border border-[color:var(--border)] bg-black/5 p-3 text-xs dark:bg-white/5">
+            <div className="mt-3 rounded border border-[color:var(--border)] bg-black/5 p-3 text-xs">
               <p className="mb-2 font-medium">
                 Ergebnis · {excerptBulkResult.durationMs} ms
               </p>
               <dl className="grid grid-cols-2 gap-2 sm:grid-cols-4">
                 <div>
-                  <dt className="text-neutral-500">scanned</dt>
+                  <dt className="text-[color:var(--fg-muted)]">scanned</dt>
                   <dd className="font-mono">{excerptBulkResult.scanned}</dd>
                 </div>
                 <div>
-                  <dt className="text-neutral-500">checked</dt>
+                  <dt className="text-[color:var(--fg-muted)]">checked</dt>
                   <dd className="font-mono">{excerptBulkResult.checked}</dd>
                 </div>
                 <div>
-                  <dt className="text-neutral-500">neue Duplikate</dt>
+                  <dt className="text-[color:var(--fg-muted)]">neue Duplikate</dt>
                   <dd className="font-mono">
                     {excerptBulkResult.excerptMergeCandidatesCreated}
                   </dd>
                 </div>
                 <div>
-                  <dt className="text-neutral-500">Fehler</dt>
+                  <dt className="text-[color:var(--fg-muted)]">Fehler</dt>
                   <dd className="font-mono">{excerptBulkResult.failed}</dd>
                 </div>
               </dl>
@@ -561,8 +561,8 @@ export default function DuplicatesListPage(): React.ReactElement {
               className={[
                 'rounded border px-3 py-1 text-xs',
                 excerptStatusFilter === s
-                  ? 'border-neutral-900 bg-neutral-900 text-white dark:border-neutral-200 dark:bg-neutral-200 dark:text-neutral-900'
-                  : 'border-neutral-300 hover:border-neutral-400 dark:border-neutral-700',
+                  ? 'border-[color:var(--border-strong)] bg-[color:var(--bg-inverse)] text-[color:var(--fg-on-dark)]'
+                  : 'border-[color:var(--border)] hover:border-[color:var(--border-strong)]',
               ].join(' ')}
             >
               {s === 'all' ? 'alle' : s}
@@ -572,20 +572,20 @@ export default function DuplicatesListPage(): React.ReactElement {
             type="button"
             onClick={() => void loadExcerpts()}
             disabled={excerptLoading}
-            className="ml-auto rounded border border-neutral-300 px-3 py-1 text-xs hover:border-neutral-400 disabled:opacity-50 dark:border-neutral-700"
+            className="ml-auto rounded border border-[color:var(--border)] px-3 py-1 text-xs hover:border-[color:var(--border-strong)] disabled:opacity-50"
           >
             {excerptLoading ? 'lädt…' : 'aktualisieren'}
           </button>
         </div>
 
         {excerptError !== null && (
-          <div className="mb-4 border-l-2 border-red-400 px-3 py-2 text-xs text-red-700 dark:text-red-300">
+          <div className="mb-4 border-l-2 border-[color:var(--danger-edge)] px-3 py-2 text-xs text-[color:var(--danger)]">
             Fehler: {excerptError}
           </div>
         )}
 
         {excerptItems !== null && excerptItems.length === 0 && excerptError === null && (
-          <p className="text-sm italic text-neutral-500">
+          <p className="text-sm italic text-[color:var(--fg-muted)]">
             Keine Excerpt-Duplikate in dieser Auswahl.
           </p>
         )}
@@ -598,7 +598,7 @@ export default function DuplicatesListPage(): React.ReactElement {
                 <li key={mc.id}>
                   <Link
                     href={`/admin/duplicates/excerpt/${encodeURIComponent(mc.id)}`}
-                    className="block rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4 transition-colors hover:border-[color:var(--accent)]"
+                    className="block rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4 transition-colors hover:border-[color:var(--accent)]"
                   >
                     <div className="mb-2 flex flex-wrap items-center gap-2 text-[10px]">
                       <span
@@ -609,20 +609,20 @@ export default function DuplicatesListPage(): React.ReactElement {
                       >
                         {mc.props.status}
                       </span>
-                      <span className="rounded bg-orange-100 px-1.5 py-0.5 font-mono uppercase tracking-wider text-orange-800 dark:bg-orange-900/40 dark:text-orange-200">
+                      <span className="rounded bg-[color:var(--warning)]/10 px-1.5 py-0.5 font-mono uppercase tracking-wider text-[color:var(--warning)]">
                         cosine {mc.props.cosine_sim.toFixed(3)}
                       </span>
                       <time
-                        className="font-mono text-neutral-500"
+                        className="font-mono text-[color:var(--fg-muted)]"
                         dateTime={mc.props.created_at}
                       >
                         {new Date(mc.props.created_at).toLocaleString('de-DE')}
                       </time>
                     </div>
-                    <p className="text-sm text-neutral-900 dark:text-neutral-100">
+                    <p className="text-sm text-[color:var(--fg-strong)]">
                       {mc.excerptA?.props.text?.slice(0, 90) ?? '(Excerpt A)'}
                     </p>
-                    <p className="mt-1 text-xs text-neutral-700 dark:text-neutral-300">
+                    <p className="mt-1 text-xs text-[color:var(--fg)]">
                       ↔ {mc.excerptB?.props.text?.slice(0, 90) ?? '(Excerpt B)'}
                     </p>
                   </Link>

--- a/web-ui/app/admin/inconsistencies/[id]/page.tsx
+++ b/web-ui/app/admin/inconsistencies/[id]/page.tsx
@@ -93,7 +93,7 @@ export default function InconsistencyDetailPage(): React.ReactElement {
   );
 
   return (
-    <main className="mx-auto max-w-[1100px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[1100px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-8">
         <Link
           href="/admin/inconsistencies"
@@ -115,7 +115,7 @@ export default function InconsistencyDetailPage(): React.ReactElement {
 
       {detail !== null && (
         <>
-          <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+          <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
             <h2 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
               Detector-Befund
             </h2>
@@ -140,7 +140,7 @@ export default function InconsistencyDetailPage(): React.ReactElement {
           </div>
 
           {detail.props.status === 'open' && (
-            <section className="mt-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+            <section className="mt-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
               <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
                 Auflösung
               </h2>
@@ -199,7 +199,7 @@ function MemoryCard({
   mk: MemorableKnowledgeNode | null;
 }): React.ReactElement {
   return (
-    <article className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+    <article className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
       <header className="mb-3 flex items-center justify-between">
         <span className="text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
           {label}

--- a/web-ui/app/admin/inconsistencies/[id]/page.tsx
+++ b/web-ui/app/admin/inconsistencies/[id]/page.tsx
@@ -97,7 +97,7 @@ export default function InconsistencyDetailPage(): React.ReactElement {
       <header className="mb-8">
         <Link
           href="/admin/inconsistencies"
-          className="text-xs text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+          className="text-xs text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]"
         >
           ← /admin/inconsistencies
         </Link>
@@ -106,28 +106,28 @@ export default function InconsistencyDetailPage(): React.ReactElement {
         </h1>
       </header>
 
-      {loading && <p className="text-xs text-neutral-500">lädt…</p>}
+      {loading && <p className="text-xs text-[color:var(--fg-muted)]">lädt…</p>}
       {loadError !== null && (
-        <div className="border-l-2 border-red-400 px-3 py-2 text-xs text-red-700 dark:text-red-300">
+        <div className="border-l-2 border-[color:var(--danger-edge)] px-3 py-2 text-xs text-[color:var(--danger)]">
           Fehler: {loadError}
         </div>
       )}
 
       {detail !== null && (
         <>
-          <section className="mb-6 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
-            <h2 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+          <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+            <h2 className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
               Detector-Befund
             </h2>
             <p className="text-sm">{detail.props.summary}</p>
             <dl className="mt-3 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-[11px]">
-              <dt className="text-neutral-500">Severity</dt>
+              <dt className="text-[color:var(--fg-muted)]">Severity</dt>
               <dd className="font-mono">{detail.props.severity}</dd>
-              <dt className="text-neutral-500">Status</dt>
+              <dt className="text-[color:var(--fg-muted)]">Status</dt>
               <dd className="font-mono">{detail.props.status}</dd>
               {detail.props.resolution && (
                 <>
-                  <dt className="text-neutral-500">Resolution</dt>
+                  <dt className="text-[color:var(--fg-muted)]">Resolution</dt>
                   <dd className="font-mono">{detail.props.resolution}</dd>
                 </>
               )}
@@ -140,12 +140,12 @@ export default function InconsistencyDetailPage(): React.ReactElement {
           </div>
 
           {detail.props.status === 'open' && (
-            <section className="mt-6 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
-              <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+            <section className="mt-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+              <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
                 Auflösung
               </h2>
               <label className="mb-3 block">
-                <span className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-500">
+                <span className="mb-1 block text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
                   Begründung (optional, im Audit-Log)
                 </span>
                 <input
@@ -154,11 +154,11 @@ export default function InconsistencyDetailPage(): React.ReactElement {
                   onChange={(e) => setReason(e.target.value)}
                   disabled={busy}
                   maxLength={1000}
-                  className="w-full rounded border border-neutral-300 px-2 py-1 text-sm dark:border-neutral-700 dark:bg-neutral-800"
+                  className="w-full rounded border border-[color:var(--border)] px-2 py-1 text-sm"
                 />
               </label>
               {mutationError !== null && (
-                <p className="mb-3 border-l-2 border-red-400 px-2 py-1 text-xs text-red-700 dark:text-red-300">
+                <p className="mb-3 border-l-2 border-[color:var(--danger-edge)] px-2 py-1 text-xs text-[color:var(--danger)]">
                   Fehler: {mutationError}
                 </p>
               )}
@@ -172,12 +172,12 @@ export default function InconsistencyDetailPage(): React.ReactElement {
                     className={[
                       'rounded border px-3 py-2 text-left text-xs disabled:opacity-50',
                       r === 'a_wins' || r === 'b_wins'
-                        ? 'border-red-400 hover:bg-red-50 dark:border-red-800 dark:hover:bg-red-900/30'
-                        : 'border-neutral-300 hover:border-neutral-400 dark:border-neutral-700',
+                        ? 'border-[color:var(--danger-edge)] hover:bg-[color:var(--danger)]/8'
+                        : 'border-[color:var(--border)] hover:border-[color:var(--border-strong)]',
                     ].join(' ')}
                   >
                     <div className="font-semibold">{RESOLUTION_LABEL[r]}</div>
-                    <div className="mt-1 text-[10px] text-neutral-500">
+                    <div className="mt-1 text-[10px] text-[color:var(--fg-muted)]">
                       {RESOLUTION_DESCRIPTION[r]}
                     </div>
                   </button>
@@ -199,35 +199,35 @@ function MemoryCard({
   mk: MemorableKnowledgeNode | null;
 }): React.ReactElement {
   return (
-    <article className="rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+    <article className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
       <header className="mb-3 flex items-center justify-between">
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
           {label}
         </span>
         {mk && (
           <Link
             href={`/memories/${encodeURIComponent(mk.id)}`}
-            className="text-[10px] text-neutral-500 underline-offset-2 hover:underline"
+            className="text-[10px] text-[color:var(--fg-muted)] underline-offset-2 hover:underline"
           >
             zur Memory →
           </Link>
         )}
       </header>
       {!mk && (
-        <p className="text-xs italic text-neutral-500">
+        <p className="text-xs italic text-[color:var(--fg-muted)]">
           Memory nicht zugänglich (gelöscht oder kein Owner).
         </p>
       )}
       {mk && (
         <>
-          <div className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
+          <div className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
             {String(mk.props.kind)}
           </div>
-          <p className="text-sm text-neutral-900 dark:text-neutral-100">
+          <p className="text-sm text-[color:var(--fg-strong)]">
             {mk.props.summary}
           </p>
           {typeof mk.props.rationale === 'string' && (
-            <p className="mt-2 text-xs text-neutral-700 dark:text-neutral-300">
+            <p className="mt-2 text-xs text-[color:var(--fg)]">
               {mk.props.rationale}
             </p>
           )}

--- a/web-ui/app/admin/inconsistencies/page.tsx
+++ b/web-ui/app/admin/inconsistencies/page.tsx
@@ -19,17 +19,17 @@ const BULK_DEFAULT_LIMIT = 25;
 const BULK_HARD_CAP = 200;
 
 const SEVERITY_BADGE: Record<InconsistencySeverity, string> = {
-  low: 'bg-neutral-200 text-neutral-700 dark:bg-neutral-700 dark:text-neutral-200',
-  medium: 'bg-amber-200 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
-  high: 'bg-red-200 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+  low: 'bg-[color:var(--state-loading)] text-[color:var(--fg)]',
+  medium: 'bg-[color:var(--warning)] text-[color:var(--warning)]',
+  high: 'bg-[color:var(--danger)]/15 text-[color:var(--danger)]',
 };
 
 const STATUS_BADGE: Record<InconsistencyStatus, string> = {
-  open: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+  open: 'bg-[color:var(--accent)]/10 text-[color:var(--accent)]',
   resolved:
-    'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
+    'bg-[color:var(--success)]/10 text-[color:var(--success)]',
   dismissed:
-    'bg-neutral-100 text-neutral-800 dark:bg-neutral-800 dark:text-neutral-300',
+    'bg-[color:var(--bg-soft)] text-[color:var(--fg)]',
 };
 
 const SEVERITY_RANK: Record<InconsistencySeverity, number> = {
@@ -138,7 +138,7 @@ export default function InconsistenciesListPage(): React.ReactElement {
       <header className="mb-8">
         <Link
           href="/admin"
-          className="text-xs text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+          className="text-xs text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]"
         >
           ← /admin
         </Link>
@@ -155,7 +155,7 @@ export default function InconsistenciesListPage(): React.ReactElement {
           the operator sees the marker-progress at a glance. */}
       <section
         aria-label="Bulk inconsistency detect"
-        className="mb-6 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4"
+        className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4"
       >
         <div className="mb-3 flex flex-wrap items-baseline gap-3">
           <h2 className="text-sm font-semibold text-[color:var(--fg-strong)]">
@@ -168,7 +168,7 @@ export default function InconsistenciesListPage(): React.ReactElement {
         </div>
 
         {bulkPreviewError !== null && (
-          <p className="mb-2 text-xs text-red-600 dark:text-red-300">
+          <p className="mb-2 text-xs text-[color:var(--danger)]">
             Preview fehlgeschlagen: {bulkPreviewError}
           </p>
         )}
@@ -176,29 +176,29 @@ export default function InconsistenciesListPage(): React.ReactElement {
         {bulkPreview !== null && (
           <dl className="mb-3 grid grid-cols-2 gap-2 text-xs sm:grid-cols-4">
             <div>
-              <dt className="text-neutral-500">ungeprüft</dt>
+              <dt className="text-[color:var(--fg-muted)]">ungeprüft</dt>
               <dd className="font-mono text-base">{bulkPreview.unchecked}</dd>
             </div>
             <div>
-              <dt className="text-neutral-500">schon geprüft</dt>
+              <dt className="text-[color:var(--fg-muted)]">schon geprüft</dt>
               <dd className="font-mono text-base">
                 {bulkPreview.alreadyChecked}
               </dd>
             </div>
             <div>
-              <dt className="text-neutral-500">ohne Embedding</dt>
+              <dt className="text-[color:var(--fg-muted)]">ohne Embedding</dt>
               <dd className="font-mono text-base">
                 {bulkPreview.withoutEmbedding}
               </dd>
             </div>
             <div>
-              <dt className="text-neutral-500">Detector</dt>
+              <dt className="text-[color:var(--fg-muted)]">Detector</dt>
               <dd
                 className={[
                   'font-mono text-base',
                   bulkPreview.detectorAvailable
-                    ? 'text-green-700 dark:text-green-300'
-                    : 'text-amber-700 dark:text-amber-300',
+                    ? 'text-[color:var(--success)]'
+                    : 'text-[color:var(--warning)]',
                 ].join(' ')}
               >
                 {bulkPreview.detectorAvailable ? 'ready' : 'kein Key'}
@@ -236,49 +236,49 @@ export default function InconsistenciesListPage(): React.ReactElement {
               bulkPreview?.detectorAvailable === false ||
               (bulkPreview !== null && bulkPreview.unchecked === 0)
             }
-            className="rounded border border-neutral-900 bg-neutral-900 px-3 py-1 text-xs text-white disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-200 dark:bg-neutral-200 dark:text-neutral-900"
+            className="rounded border border-[color:var(--border-strong)] bg-[color:var(--bg-inverse)] px-3 py-1 text-xs text-[color:var(--fg-on-dark)] disabled:cursor-not-allowed disabled:opacity-50"
           >
             {bulkRunning ? 'läuft…' : 'Bulk-Detect starten'}
           </button>
           {bulkLimit > BULK_CONFIRM_THRESHOLD && (
-            <span className="text-[11px] text-amber-700 dark:text-amber-300">
+            <span className="text-[11px] text-[color:var(--warning)]">
               ⚠️ Cost-Confirm bei Limit &gt; {BULK_CONFIRM_THRESHOLD}
             </span>
           )}
         </div>
 
         {bulkError !== null && (
-          <p className="mt-3 text-xs text-red-600 dark:text-red-300">
+          <p className="mt-3 text-xs text-[color:var(--danger)]">
             Run fehlgeschlagen: {bulkError}
           </p>
         )}
 
         {bulkResult !== null && (
-          <div className="mt-3 rounded border border-[color:var(--border)] bg-black/5 p-3 text-xs dark:bg-white/5">
+          <div className="mt-3 rounded border border-[color:var(--border)] bg-black/5 p-3 text-xs">
             <p className="mb-2 font-medium">
               Ergebnis · {bulkResult.durationMs} ms
             </p>
             <dl className="grid grid-cols-2 gap-2 sm:grid-cols-5">
               <div>
-                <dt className="text-neutral-500">scanned</dt>
+                <dt className="text-[color:var(--fg-muted)]">scanned</dt>
                 <dd className="font-mono">{bulkResult.scanned}</dd>
               </div>
               <div>
-                <dt className="text-neutral-500">checked</dt>
+                <dt className="text-[color:var(--fg-muted)]">checked</dt>
                 <dd className="font-mono">{bulkResult.checked}</dd>
               </div>
               <div>
-                <dt className="text-neutral-500">neue Konflikte</dt>
+                <dt className="text-[color:var(--fg-muted)]">neue Konflikte</dt>
                 <dd className="font-mono">
                   {bulkResult.inconsistenciesCreated}
                 </dd>
               </div>
               <div>
-                <dt className="text-neutral-500">ohne Embedding</dt>
+                <dt className="text-[color:var(--fg-muted)]">ohne Embedding</dt>
                 <dd className="font-mono">{bulkResult.skippedNoEmbedding}</dd>
               </div>
               <div>
-                <dt className="text-neutral-500">Fehler</dt>
+                <dt className="text-[color:var(--fg-muted)]">Fehler</dt>
                 <dd className="font-mono">{bulkResult.failed}</dd>
               </div>
             </dl>
@@ -295,8 +295,8 @@ export default function InconsistenciesListPage(): React.ReactElement {
             className={[
               'rounded border px-3 py-1 text-xs',
               statusFilter === s
-                ? 'border-neutral-900 bg-neutral-900 text-white dark:border-neutral-200 dark:bg-neutral-200 dark:text-neutral-900'
-                : 'border-neutral-300 hover:border-neutral-400 dark:border-neutral-700',
+                ? 'border-[color:var(--border-strong)] bg-[color:var(--bg-inverse)] text-[color:var(--fg-on-dark)]'
+                : 'border-[color:var(--border)] hover:border-[color:var(--border-strong)]',
             ].join(' ')}
           >
             {s === 'all' ? 'alle' : s}
@@ -306,20 +306,20 @@ export default function InconsistenciesListPage(): React.ReactElement {
           type="button"
           onClick={() => void load()}
           disabled={loading}
-          className="ml-auto rounded border border-neutral-300 px-3 py-1 text-xs hover:border-neutral-400 disabled:opacity-50 dark:border-neutral-700"
+          className="ml-auto rounded border border-[color:var(--border)] px-3 py-1 text-xs hover:border-[color:var(--border-strong)] disabled:opacity-50"
         >
           {loading ? 'lädt…' : 'aktualisieren'}
         </button>
       </div>
 
       {error !== null && (
-        <div className="mb-4 border-l-2 border-red-400 px-3 py-2 text-xs text-red-700 dark:text-red-300">
+        <div className="mb-4 border-l-2 border-[color:var(--danger-edge)] px-3 py-2 text-xs text-[color:var(--danger)]">
           Fehler: {error}
         </div>
       )}
 
       {sorted !== null && sorted.length === 0 && error === null && (
-        <p className="text-sm italic text-neutral-500">
+        <p className="text-sm italic text-[color:var(--fg-muted)]">
           Keine Widersprüche in dieser Auswahl.
         </p>
       )}
@@ -330,7 +330,7 @@ export default function InconsistenciesListPage(): React.ReactElement {
             <li key={inc.id}>
               <Link
                 href={`/admin/inconsistencies/${encodeURIComponent(inc.id)}`}
-                className="block rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4 transition-colors hover:border-[color:var(--accent)]"
+                className="block rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4 transition-colors hover:border-[color:var(--accent)]"
               >
                 <div className="mb-2 flex flex-wrap items-center gap-2 text-[10px]">
                   <span
@@ -350,16 +350,16 @@ export default function InconsistenciesListPage(): React.ReactElement {
                     {inc.props.status}
                   </span>
                   <time
-                    className="font-mono text-neutral-500"
+                    className="font-mono text-[color:var(--fg-muted)]"
                     dateTime={inc.props.created_at}
                   >
                     {new Date(inc.props.created_at).toLocaleString('de-DE')}
                   </time>
                 </div>
-                <p className="text-sm text-neutral-900 dark:text-neutral-100">
+                <p className="text-sm text-[color:var(--fg-strong)]">
                   {inc.props.summary}
                 </p>
-                <p className="mt-2 font-mono text-[10px] text-neutral-500">
+                <p className="mt-2 font-mono text-[10px] text-[color:var(--fg-muted)]">
                   {inc.mkA?.props.summary?.slice(0, 60) ?? '(MK A)'} ↔{' '}
                   {inc.mkB?.props.summary?.slice(0, 60) ?? '(MK B)'}
                 </p>

--- a/web-ui/app/admin/inconsistencies/page.tsx
+++ b/web-ui/app/admin/inconsistencies/page.tsx
@@ -134,7 +134,7 @@ export default function InconsistenciesListPage(): React.ReactElement {
   }, [items]);
 
   return (
-    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-8">
         <Link
           href="/admin"
@@ -335,7 +335,7 @@ export default function InconsistenciesListPage(): React.ReactElement {
                 <div className="mb-2 flex flex-wrap items-center gap-2 text-[10px]">
                   <span
                     className={[
-                      'rounded px-1.5 py-0.5 uppercase tracking-wider',
+                      'rounded px-2 py-0.5 uppercase tracking-wider',
                       SEVERITY_BADGE[inc.props.severity],
                     ].join(' ')}
                   >
@@ -343,7 +343,7 @@ export default function InconsistenciesListPage(): React.ReactElement {
                   </span>
                   <span
                     className={[
-                      'rounded px-1.5 py-0.5 uppercase tracking-wider',
+                      'rounded px-2 py-0.5 uppercase tracking-wider',
                       STATUS_BADGE[inc.props.status],
                     ].join(' ')}
                   >

--- a/web-ui/app/admin/kg-lifecycle/page.tsx
+++ b/web-ui/app/admin/kg-lifecycle/page.tsx
@@ -151,7 +151,7 @@ export default function KgLifecyclePage(): JSX.Element {
       </header>
 
       {error ? (
-        <div className="mb-6 rounded-md border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/80/10 px-4 py-3 text-sm text-[color:var(--danger)]">
+        <div className="mb-6 rounded-md border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/10 px-4 py-3 text-sm text-[color:var(--danger)]">
           {error}
         </div>
       ) : null}
@@ -475,10 +475,10 @@ function QuotaPill({
   const ratio = value / limit;
   const tone =
     ratio > 1.0
-      ? 'bg-[color:var(--danger)]/80/20 text-[color:var(--danger)]'
+      ? 'bg-[color:var(--danger)]/20 text-[color:var(--danger)]'
       : ratio > 0.8
-        ? 'bg-[color:var(--warning)]/100/20 text-[color:var(--warning)]'
-        : 'bg-[color:var(--success)]/100/20 text-[color:var(--success)]';
+        ? 'bg-[color:var(--warning)]/20 text-[color:var(--warning)]'
+        : 'bg-[color:var(--success)]/20 text-[color:var(--success)]';
   const formatted = `${value.toLocaleString()}/${limit.toLocaleString()}`;
   const tooltip =
     ratio > 1.0

--- a/web-ui/app/admin/kg-lifecycle/page.tsx
+++ b/web-ui/app/admin/kg-lifecycle/page.tsx
@@ -143,7 +143,7 @@ export default function KgLifecyclePage(): JSX.Element {
         </div>
         <button
           type="button"
-          className="rounded-md border border-[color:var(--border)] px-3 py-1.5 text-sm transition-colors hover:bg-[color:var(--border)]/30"
+          className="rounded-md border border-[color:var(--border)] px-3 py-2 text-sm transition-colors hover:bg-[color:var(--border)]/30"
           onClick={() => void reload()}
         >
           Refresh
@@ -180,7 +180,7 @@ export default function KgLifecyclePage(): JSX.Element {
       <section className="mb-8 grid gap-6 md:grid-cols-3">
         <Card title="Tier breakdown">
           {stats ? (
-            <ul className="space-y-1.5 text-sm">
+            <ul className="space-y-2 text-sm">
               <li>
                 <span className="text-[color:var(--fg-muted)]">HOT</span>:{' '}
                 <strong>{stats.byTier.HOT}</strong>
@@ -193,7 +193,7 @@ export default function KgLifecyclePage(): JSX.Element {
                 <span className="text-[color:var(--fg-muted)]">COLD</span>:{' '}
                 <strong>{stats.byTier.COLD}</strong>
               </li>
-              <li className="border-t border-[color:var(--border)] pt-1.5">
+              <li className="border-t border-[color:var(--border)] pt-2">
                 <span className="text-[color:var(--fg-muted)]">Total Turns</span>:{' '}
                 <strong>{stats.totalTurns}</strong>
               </li>
@@ -205,7 +205,7 @@ export default function KgLifecyclePage(): JSX.Element {
 
         <Card title="Entry-type breakdown">
           {stats ? (
-            <ul className="space-y-1.5 text-sm">
+            <ul className="space-y-2 text-sm">
               <li>
                 <span className="text-[color:var(--fg-muted)]">memory</span>:{' '}
                 <strong>{stats.byEntryType.memory}</strong>
@@ -226,7 +226,7 @@ export default function KgLifecyclePage(): JSX.Element {
 
         <Card title="Decay-score distribution">
           {stats ? (
-            <ul className="space-y-1.5 text-sm">
+            <ul className="space-y-2 text-sm">
               <li>
                 <span className="text-[color:var(--fg-muted)]">≥ 0.8</span>:{' '}
                 <strong>{stats.decayDistribution.high}</strong>
@@ -277,18 +277,18 @@ export default function KgLifecyclePage(): JSX.Element {
                       key={row.scope}
                       className="border-t border-[color:var(--border)]/50"
                     >
-                      <td className="py-1.5 font-mono text-xs">{row.scope}</td>
-                      <td className="py-1.5 text-right">{row.count}</td>
-                      <td className="py-1.5 text-right">
+                      <td className="py-2 font-mono text-xs">{row.scope}</td>
+                      <td className="py-2 text-right">{row.count}</td>
+                      <td className="py-2 text-right">
                         <QuotaPill
                           value={row.count}
                           limit={stats.quotas?.hotMaxEntries}
                         />
                       </td>
-                      <td className="py-1.5 text-right">
+                      <td className="py-2 text-right">
                         {row.chars.toLocaleString()}
                       </td>
-                      <td className="py-1.5 text-right">
+                      <td className="py-2 text-right">
                         <QuotaPill
                           value={row.chars}
                           limit={stats.quotas?.maxTotalChars}
@@ -383,7 +383,7 @@ function ActionCard({
       <button
         type="button"
         disabled={busy}
-        className="self-start rounded-md border border-[color:var(--highlight)] bg-[color:var(--highlight)]/10 px-3 py-1.5 text-sm text-[color:var(--highlight)] transition-colors hover:bg-[color:var(--highlight)]/20 disabled:opacity-50"
+        className="self-start rounded-md border border-[color:var(--highlight)] bg-[color:var(--highlight)]/10 px-3 py-2 text-sm text-[color:var(--highlight)] transition-colors hover:bg-[color:var(--highlight)]/20 disabled:opacity-50"
         onClick={onClick}
       >
         {busy ? 'Running…' : 'Run now'}

--- a/web-ui/app/admin/kg-lifecycle/page.tsx
+++ b/web-ui/app/admin/kg-lifecycle/page.tsx
@@ -151,7 +151,7 @@ export default function KgLifecyclePage(): JSX.Element {
       </header>
 
       {error ? (
-        <div className="mb-6 rounded-md border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+        <div className="mb-6 rounded-md border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/80/10 px-4 py-3 text-sm text-[color:var(--danger)]">
           {error}
         </div>
       ) : null}
@@ -475,10 +475,10 @@ function QuotaPill({
   const ratio = value / limit;
   const tone =
     ratio > 1.0
-      ? 'bg-red-500/20 text-red-400'
+      ? 'bg-[color:var(--danger)]/80/20 text-[color:var(--danger)]'
       : ratio > 0.8
-        ? 'bg-amber-500/20 text-amber-400'
-        : 'bg-emerald-500/20 text-emerald-400';
+        ? 'bg-[color:var(--warning)]/100/20 text-[color:var(--warning)]'
+        : 'bg-[color:var(--success)]/100/20 text-[color:var(--success)]';
   const formatted = `${value.toLocaleString()}/${limit.toLocaleString()}`;
   const tooltip =
     ratio > 1.0

--- a/web-ui/app/admin/kg-lifecycle/page.tsx
+++ b/web-ui/app/admin/kg-lifecycle/page.tsx
@@ -445,9 +445,9 @@ function LastRunCard({
 function SkeletonRows(): JSX.Element {
   return (
     <div className="space-y-2">
-      <div className="h-3 w-3/4 animate-pulse rounded bg-[color:var(--border)]" />
-      <div className="h-3 w-2/3 animate-pulse rounded bg-[color:var(--border)]" />
-      <div className="h-3 w-1/2 animate-pulse rounded bg-[color:var(--border)]" />
+      <div className="h-3 w-3/4 rounded lume-skeleton" />
+      <div className="h-3 w-2/3 rounded lume-skeleton" />
+      <div className="h-3 w-1/2 rounded lume-skeleton" />
     </div>
   );
 }

--- a/web-ui/app/admin/kg-priorities/page.tsx
+++ b/web-ui/app/admin/kg-priorities/page.tsx
@@ -136,7 +136,7 @@ export default function KgPrioritiesPage(): React.ReactElement {
   );
 
   return (
-    <main className="mx-auto max-w-[1200px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[1200px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-8">
         <h1 className="font-display text-[clamp(2rem,4vw,3rem)] leading-[1.1] text-[color:var(--fg-strong)]">
           Knowledge-Graph Priorities
@@ -149,7 +149,7 @@ export default function KgPrioritiesPage(): React.ReactElement {
         </p>
       </header>
 
-      <section className="mb-8 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+      <section className="mb-8 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
         <label className="block text-sm font-semibold text-[color:var(--fg-strong)]">
           Agent-ID
         </label>
@@ -177,7 +177,7 @@ export default function KgPrioritiesPage(): React.ReactElement {
         </div>
       ) : null}
 
-      <section className="mb-8 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+      <section className="mb-8 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
         <h2 className="text-lg font-semibold text-[color:var(--fg-strong)]">
           Neuer Eintrag
         </h2>

--- a/web-ui/app/admin/kg-priorities/page.tsx
+++ b/web-ui/app/admin/kg-priorities/page.tsx
@@ -172,7 +172,7 @@ export default function KgPrioritiesPage(): React.ReactElement {
       </section>
 
       {error !== null ? (
-        <div className="mb-6 rounded-md border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/80/10 p-3 text-sm text-[color:var(--danger)]">
+        <div className="mb-6 rounded-md border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/10 p-3 text-sm text-[color:var(--danger)]">
           {error}
         </div>
       ) : null}
@@ -268,8 +268,8 @@ export default function KgPrioritiesPage(): React.ReactElement {
                     <span
                       className={
                         r.action === 'block'
-                          ? 'rounded-full bg-[color:var(--danger)]/80/20 px-2 py-0.5 text-xs font-medium text-[color:var(--danger)]'
-                          : 'rounded-full bg-[color:var(--success)]/100/20 px-2 py-0.5 text-xs font-medium text-[color:var(--success)]'
+                          ? 'px-2 py-0.5 text-xs font-medium text-[color:var(--danger)]'
+                          : 'px-2 py-0.5 text-xs font-medium text-[color:var(--success)]'
                       }
                     >
                       {r.action}
@@ -289,7 +289,7 @@ export default function KgPrioritiesPage(): React.ReactElement {
                       type="button"
                       onClick={() => { void handleRemove(r.entryExternalId); }}
                       disabled={busy === `remove:${r.entryExternalId}`}
-                      className="rounded-md border border-[color:var(--border)] px-3 py-1 text-xs text-[color:var(--fg-strong)] hover:bg-[color:var(--danger)]/80/20 disabled:opacity-40"
+                      className="rounded-md border border-[color:var(--border)] px-3 py-1 text-xs text-[color:var(--fg-strong)] hover:bg-[color:var(--danger)]/20 disabled:opacity-40"
                     >
                       {busy === `remove:${r.entryExternalId}` ? '…' : 'Remove'}
                     </button>

--- a/web-ui/app/admin/kg-priorities/page.tsx
+++ b/web-ui/app/admin/kg-priorities/page.tsx
@@ -149,7 +149,7 @@ export default function KgPrioritiesPage(): React.ReactElement {
         </p>
       </header>
 
-      <section className="mb-8 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+      <section className="mb-8 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
         <label className="block text-sm font-semibold text-[color:var(--fg-strong)]">
           Agent-ID
         </label>
@@ -172,12 +172,12 @@ export default function KgPrioritiesPage(): React.ReactElement {
       </section>
 
       {error !== null ? (
-        <div className="mb-6 rounded-md border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-400">
+        <div className="mb-6 rounded-md border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/80/10 p-3 text-sm text-[color:var(--danger)]">
           {error}
         </div>
       ) : null}
 
-      <section className="mb-8 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+      <section className="mb-8 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
         <h2 className="text-lg font-semibold text-[color:var(--fg-strong)]">
           Neuer Eintrag
         </h2>
@@ -233,7 +233,7 @@ export default function KgPrioritiesPage(): React.ReactElement {
         </div>
       </section>
 
-      <section className="rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 overflow-x-auto">
+      <section className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 overflow-x-auto">
         <table className="w-full text-sm">
           <thead className="border-b border-[color:var(--border)] text-left text-[color:var(--fg-muted)]">
             <tr>
@@ -268,8 +268,8 @@ export default function KgPrioritiesPage(): React.ReactElement {
                     <span
                       className={
                         r.action === 'block'
-                          ? 'rounded-full bg-red-500/20 px-2 py-0.5 text-xs font-medium text-red-400'
-                          : 'rounded-full bg-emerald-500/20 px-2 py-0.5 text-xs font-medium text-emerald-400'
+                          ? 'rounded-full bg-[color:var(--danger)]/80/20 px-2 py-0.5 text-xs font-medium text-[color:var(--danger)]'
+                          : 'rounded-full bg-[color:var(--success)]/100/20 px-2 py-0.5 text-xs font-medium text-[color:var(--success)]'
                       }
                     >
                       {r.action}
@@ -289,7 +289,7 @@ export default function KgPrioritiesPage(): React.ReactElement {
                       type="button"
                       onClick={() => { void handleRemove(r.entryExternalId); }}
                       disabled={busy === `remove:${r.entryExternalId}`}
-                      className="rounded-md border border-[color:var(--border)] px-3 py-1 text-xs text-[color:var(--fg-strong)] hover:bg-red-500/20 disabled:opacity-40"
+                      className="rounded-md border border-[color:var(--border)] px-3 py-1 text-xs text-[color:var(--fg-strong)] hover:bg-[color:var(--danger)]/80/20 disabled:opacity-40"
                     >
                       {busy === `remove:${r.entryExternalId}` ? '…' : 'Remove'}
                     </button>

--- a/web-ui/app/admin/memory-backend/page.tsx
+++ b/web-ui/app/admin/memory-backend/page.tsx
@@ -116,7 +116,7 @@ export default function MemoryBackendPage(): React.ReactElement {
   }, [choice, load]);
 
   return (
-    <main className="mx-auto max-w-[800px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[800px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-8">
         <Link
           href="/admin"
@@ -138,20 +138,20 @@ export default function MemoryBackendPage(): React.ReactElement {
       </header>
 
       {loading && (
-        <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5 text-sm text-[color:var(--fg-muted)]">
+        <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4 text-sm text-[color:var(--fg-muted)]">
           lädt…
         </section>
       )}
 
       {loadError !== null && (
-        <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-5 text-sm text-[color:var(--danger)]">
+        <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-4 text-sm text-[color:var(--danger)]">
           Laden fehlgeschlagen: {loadError}
         </section>
       )}
 
       {state !== null && !loading && (
         <>
-          <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+          <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
             <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
               Aktueller Stand
             </h2>
@@ -176,7 +176,7 @@ export default function MemoryBackendPage(): React.ReactElement {
             </section>
           )}
 
-          <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+          <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
             <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
               Backend wählen
             </h2>
@@ -220,7 +220,7 @@ export default function MemoryBackendPage(): React.ReactElement {
                 type="button"
                 onClick={() => void onSave()}
                 disabled={!canSave}
-                className="rounded bg-[color:var(--accent)] px-4 py-1.5 text-xs font-semibold text-[color:var(--fg-on-dark)] hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+                className="rounded bg-[color:var(--accent)] px-4 py-2 text-xs font-semibold text-[color:var(--fg-on-dark)] hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {saving ? 'speichert…' : 'Auswahl speichern'}
               </button>
@@ -228,13 +228,13 @@ export default function MemoryBackendPage(): React.ReactElement {
           </section>
 
           {saveError !== null && (
-            <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-5 text-sm text-[color:var(--danger)]">
+            <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-4 text-sm text-[color:var(--danger)]">
               {saveError}
             </section>
           )}
 
           {saved !== null && saveError === null && (
-            <section className="rounded-lg border border-[color:var(--warning)]/50 bg-[color:var(--warning)]/10 p-5 text-sm text-[color:var(--warning)]">
+            <section className="rounded-lg border border-[color:var(--warning)]/50 bg-[color:var(--warning)]/10 p-4 text-sm text-[color:var(--warning)]">
               <p className="font-semibold">
                 Backend <code className="font-mono">{saved}</code> gespeichert.
               </p>

--- a/web-ui/app/admin/memory-backend/page.tsx
+++ b/web-ui/app/admin/memory-backend/page.tsx
@@ -120,7 +120,7 @@ export default function MemoryBackendPage(): React.ReactElement {
       <header className="mb-8">
         <Link
           href="/admin"
-          className="text-xs text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+          className="text-xs text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]"
         >
           ← /admin
         </Link>
@@ -138,31 +138,31 @@ export default function MemoryBackendPage(): React.ReactElement {
       </header>
 
       {loading && (
-        <section className="mb-6 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5 text-sm text-[color:var(--fg-muted)]">
+        <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5 text-sm text-[color:var(--fg-muted)]">
           lädt…
         </section>
       )}
 
       {loadError !== null && (
-        <section className="mb-6 rounded-[14px] border border-red-400 bg-red-50 p-5 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-300">
+        <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-5 text-sm text-[color:var(--danger)]">
           Laden fehlgeschlagen: {loadError}
         </section>
       )}
 
       {state !== null && !loading && (
         <>
-          <section className="mb-6 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
-            <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+          <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+            <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
               Aktueller Stand
             </h2>
             <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-sm">
-              <dt className="text-neutral-500">Aktives Backend</dt>
+              <dt className="text-[color:var(--fg-muted)]">Aktives Backend</dt>
               <dd className="font-mono">{state.current}</dd>
-              <dt className="text-neutral-500">Env-Default</dt>
+              <dt className="text-[color:var(--fg-muted)]">Env-Default</dt>
               <dd className="font-mono">{state.envDefault}</dd>
-              <dt className="text-neutral-500">Aktiver Provider</dt>
+              <dt className="text-[color:var(--fg-muted)]">Aktiver Provider</dt>
               <dd className="font-mono">{state.activeProviderId ?? '—'}</dd>
-              <dt className="text-neutral-500">DATABASE_URL</dt>
+              <dt className="text-[color:var(--fg-muted)]">DATABASE_URL</dt>
               <dd className="font-mono">
                 {state.databaseUrlPresent ? 'gesetzt' : 'nicht gesetzt'}
               </dd>
@@ -170,14 +170,14 @@ export default function MemoryBackendPage(): React.ReactElement {
           </section>
 
           {state.restartRequiredToApply && (
-            <section className="mb-6 rounded-[14px] border border-amber-500/50 bg-amber-500/10 p-4 text-sm font-medium text-amber-700 dark:text-amber-300">
+            <section className="mb-6 rounded-lg border border-[color:var(--warning)]/50 bg-[color:var(--warning)]/100/10 p-4 text-sm font-medium text-[color:var(--warning)]">
               ⚠ Ein Wechsel ist gespeichert, aber noch nicht aktiv — Neustart
               erforderlich, damit der Wechsel greift.
             </section>
           )}
 
-          <section className="mb-6 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
-            <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+          <section className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+            <h2 className="mb-3 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
               Backend wählen
             </h2>
             <div className="flex flex-col gap-2">
@@ -188,7 +188,7 @@ export default function MemoryBackendPage(): React.ReactElement {
                     key={b.value}
                     className={
                       disabled
-                        ? 'flex items-center gap-2 text-sm text-neutral-400 dark:text-neutral-600'
+                        ? 'flex items-center gap-2 text-sm text-[color:var(--fg-subtle)]'
                         : 'flex items-center gap-2 text-sm text-[color:var(--fg-strong)]'
                     }
                   >
@@ -206,7 +206,7 @@ export default function MemoryBackendPage(): React.ReactElement {
                     />
                     <span>{b.label}</span>
                     {disabled && (
-                      <span className="text-xs text-neutral-500">
+                      <span className="text-xs text-[color:var(--fg-muted)]">
                         — benötigt DATABASE_URL (Neon-KG/graphPool)
                       </span>
                     )}
@@ -220,7 +220,7 @@ export default function MemoryBackendPage(): React.ReactElement {
                 type="button"
                 onClick={() => void onSave()}
                 disabled={!canSave}
-                className="rounded bg-[color:var(--accent)] px-4 py-1.5 text-xs font-semibold text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+                className="rounded bg-[color:var(--accent)] px-4 py-1.5 text-xs font-semibold text-[color:var(--fg-on-dark)] hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {saving ? 'speichert…' : 'Auswahl speichern'}
               </button>
@@ -228,13 +228,13 @@ export default function MemoryBackendPage(): React.ReactElement {
           </section>
 
           {saveError !== null && (
-            <section className="mb-6 rounded-[14px] border border-red-400 bg-red-50 p-5 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-300">
+            <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-5 text-sm text-[color:var(--danger)]">
               {saveError}
             </section>
           )}
 
           {saved !== null && saveError === null && (
-            <section className="rounded-[14px] border border-amber-500/50 bg-amber-500/10 p-5 text-sm text-amber-700 dark:text-amber-300">
+            <section className="rounded-lg border border-[color:var(--warning)]/50 bg-[color:var(--warning)]/100/10 p-5 text-sm text-[color:var(--warning)]">
               <p className="font-semibold">
                 Backend <code className="font-mono">{saved}</code> gespeichert.
               </p>

--- a/web-ui/app/admin/memory-backend/page.tsx
+++ b/web-ui/app/admin/memory-backend/page.tsx
@@ -170,7 +170,7 @@ export default function MemoryBackendPage(): React.ReactElement {
           </section>
 
           {state.restartRequiredToApply && (
-            <section className="mb-6 rounded-lg border border-[color:var(--warning)]/50 bg-[color:var(--warning)]/100/10 p-4 text-sm font-medium text-[color:var(--warning)]">
+            <section className="mb-6 rounded-lg border border-[color:var(--warning)]/50 bg-[color:var(--warning)]/10 p-4 text-sm font-medium text-[color:var(--warning)]">
               ⚠ Ein Wechsel ist gespeichert, aber noch nicht aktiv — Neustart
               erforderlich, damit der Wechsel greift.
             </section>
@@ -234,7 +234,7 @@ export default function MemoryBackendPage(): React.ReactElement {
           )}
 
           {saved !== null && saveError === null && (
-            <section className="rounded-lg border border-[color:var(--warning)]/50 bg-[color:var(--warning)]/100/10 p-5 text-sm text-[color:var(--warning)]">
+            <section className="rounded-lg border border-[color:var(--warning)]/50 bg-[color:var(--warning)]/10 p-5 text-sm text-[color:var(--warning)]">
               <p className="font-semibold">
                 Backend <code className="font-mono">{saved}</code> gespeichert.
               </p>

--- a/web-ui/app/admin/page.tsx
+++ b/web-ui/app/admin/page.tsx
@@ -7,8 +7,8 @@ export const metadata: Metadata = {
 
 export default function AdminIndexPage(): React.ReactElement {
   return (
-    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-10 lg:py-16">
-      <header className="mb-10">
+    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-8 lg:py-16">
+      <header className="mb-8">
         <h1 className="font-display text-[clamp(2rem,4vw,3rem)] leading-[1.1] text-[color:var(--fg-strong)]">
           Admin
         </h1>
@@ -107,8 +107,8 @@ function AdminCard({
         href={href}
         className={
           danger
-            ? 'block rounded-lg border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/5 p-5 transition-colors hover:border-[color:var(--danger-edge)]'
-            : 'block rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5 transition-colors hover:border-[color:var(--accent)]'
+            ? 'block rounded-lg border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/5 p-4 transition-colors hover:border-[color:var(--danger-edge)]'
+            : 'block rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4 transition-colors hover:border-[color:var(--accent)]'
         }
       >
         <div
@@ -120,7 +120,7 @@ function AdminCard({
         >
           {title}
         </div>
-        <p className="mt-1.5 text-sm text-[color:var(--fg-muted)]">
+        <p className="mt-2 text-sm text-[color:var(--fg-muted)]">
           {description}
         </p>
       </Link>

--- a/web-ui/app/admin/page.tsx
+++ b/web-ui/app/admin/page.tsx
@@ -107,7 +107,7 @@ function AdminCard({
         href={href}
         className={
           danger
-            ? 'block rounded-lg border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/80/5 p-5 transition-colors hover:border-[color:var(--danger-edge)]'
+            ? 'block rounded-lg border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/5 p-5 transition-colors hover:border-[color:var(--danger-edge)]'
             : 'block rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5 transition-colors hover:border-[color:var(--accent)]'
         }
       >

--- a/web-ui/app/admin/page.tsx
+++ b/web-ui/app/admin/page.tsx
@@ -107,14 +107,14 @@ function AdminCard({
         href={href}
         className={
           danger
-            ? 'block rounded-[14px] border border-red-500/40 bg-red-500/5 p-5 transition-colors hover:border-red-500'
-            : 'block rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5 transition-colors hover:border-[color:var(--accent)]'
+            ? 'block rounded-lg border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/80/5 p-5 transition-colors hover:border-[color:var(--danger-edge)]'
+            : 'block rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5 transition-colors hover:border-[color:var(--accent)]'
         }
       >
         <div
           className={
             danger
-              ? 'text-[15px] font-semibold text-red-500'
+              ? 'text-[15px] font-semibold text-[color:var(--danger)]'
               : 'text-[15px] font-semibold text-[color:var(--fg-strong)]'
           }
         >

--- a/web-ui/app/admin/registries/page.tsx
+++ b/web-ui/app/admin/registries/page.tsx
@@ -148,7 +148,7 @@ export default function AdminRegistriesPage(): React.ReactElement {
       </header>
 
       {/* Add form */}
-      <section className="mb-8 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+      <section className="mb-8 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
         <h2 className="mb-4 text-[15px] font-semibold text-[color:var(--fg-strong)]">
           Registry hinzufügen
         </h2>
@@ -182,7 +182,7 @@ export default function AdminRegistriesPage(): React.ReactElement {
             type="button"
             onClick={() => void onAdd()}
             disabled={!canAdd}
-            className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-black disabled:opacity-50"
+            className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-[color:var(--text-inverse)] disabled:opacity-50"
           >
             {adding ? '…' : 'Hinzufügen'}
           </button>
@@ -192,7 +192,7 @@ export default function AdminRegistriesPage(): React.ReactElement {
       {state.kind === 'loading' ? (
         <p className="text-sm opacity-70">Lädt …</p>
       ) : state.kind === 'error' ? (
-        <p className="text-sm text-red-500">Fehler beim Laden: {state.message}</p>
+        <p className="text-sm text-[color:var(--danger)]">Fehler beim Laden: {state.message}</p>
       ) : state.registries.length === 0 ? (
         <p className="text-sm text-[color:var(--fg-muted)]">
           Keine Registries konfiguriert.
@@ -202,7 +202,7 @@ export default function AdminRegistriesPage(): React.ReactElement {
           {state.registries.map((r) => (
             <li
               key={r.name}
-              className="rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5"
+              className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5"
             >
               <div className="flex flex-wrap items-center justify-between gap-4">
                 <div className="flex flex-1 flex-col gap-1">
@@ -231,7 +231,7 @@ export default function AdminRegistriesPage(): React.ReactElement {
                     type="button"
                     onClick={() => void onDelete(r)}
                     disabled={pending === r.name}
-                    className="rounded-md border border-[color:var(--border)] px-3 py-2 text-sm font-medium text-red-500 hover:bg-red-500/10 disabled:opacity-50"
+                    className="rounded-md border border-[color:var(--border)] px-3 py-2 text-sm font-medium text-[color:var(--danger)] hover:bg-[color:var(--danger)]/80/10 disabled:opacity-50"
                   >
                     {pending === r.name ? '…' : 'Entfernen'}
                   </button>
@@ -261,7 +261,7 @@ export default function AdminRegistriesPage(): React.ReactElement {
                       type="button"
                       onClick={() => void onSaveEdit(r)}
                       disabled={pending === r.name}
-                      className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-black disabled:opacity-50"
+                      className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-[color:var(--text-inverse)] disabled:opacity-50"
                     >
                       Speichern
                     </button>
@@ -283,7 +283,7 @@ export default function AdminRegistriesPage(): React.ReactElement {
         </ul>
       )}
 
-      {actionError && <p className="mt-4 text-sm text-red-500">{actionError}</p>}
+      {actionError && <p className="mt-4 text-sm text-[color:var(--danger)]">{actionError}</p>}
     </main>
   );
 }
@@ -314,7 +314,7 @@ function TokenBadge({ hasToken }: { hasToken: boolean }): React.ReactElement {
       className={[
         'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em]',
         hasToken
-          ? 'bg-emerald-500/10 text-emerald-500'
+          ? 'bg-[color:var(--success)]/100/10 text-[color:var(--success)]'
           : 'bg-[color:var(--border)]/40 text-[color:var(--fg-muted)]',
       ].join(' ')}
     >

--- a/web-ui/app/admin/registries/page.tsx
+++ b/web-ui/app/admin/registries/page.tsx
@@ -231,7 +231,7 @@ export default function AdminRegistriesPage(): React.ReactElement {
                     type="button"
                     onClick={() => void onDelete(r)}
                     disabled={pending === r.name}
-                    className="rounded-md border border-[color:var(--border)] px-3 py-2 text-sm font-medium text-[color:var(--danger)] hover:bg-[color:var(--danger)]/80/10 disabled:opacity-50"
+                    className="rounded-md border border-[color:var(--border)] px-3 py-2 text-sm font-medium text-[color:var(--danger)] hover:bg-[color:var(--danger)]/10 disabled:opacity-50"
                   >
                     {pending === r.name ? '…' : 'Entfernen'}
                   </button>
@@ -314,7 +314,7 @@ function TokenBadge({ hasToken }: { hasToken: boolean }): React.ReactElement {
       className={[
         'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em]',
         hasToken
-          ? 'bg-[color:var(--success)]/100/10 text-[color:var(--success)]'
+          ? 'bg-[color:var(--success)]/10 text-[color:var(--success)]'
           : 'bg-[color:var(--border)]/40 text-[color:var(--fg-muted)]',
       ].join(' ')}
     >

--- a/web-ui/app/admin/registries/page.tsx
+++ b/web-ui/app/admin/registries/page.tsx
@@ -131,7 +131,7 @@ export default function AdminRegistriesPage(): React.ReactElement {
   const canAdd = name.trim().length > 0 && url.trim().length > 0 && !adding;
 
   return (
-    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-8">
         <h1 className="font-display text-[clamp(1.75rem,3.5vw,2.5rem)] leading-[1.1] text-[color:var(--fg-strong)]">
           Plugin-Registries
@@ -148,7 +148,7 @@ export default function AdminRegistriesPage(): React.ReactElement {
       </header>
 
       {/* Add form */}
-      <section className="mb-8 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+      <section className="mb-8 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
         <h2 className="mb-4 text-[15px] font-semibold text-[color:var(--fg-strong)]">
           Registry hinzufügen
         </h2>
@@ -202,7 +202,7 @@ export default function AdminRegistriesPage(): React.ReactElement {
           {state.registries.map((r) => (
             <li
               key={r.name}
-              className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5"
+              className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4"
             >
               <div className="flex flex-wrap items-center justify-between gap-4">
                 <div className="flex flex-1 flex-col gap-1">
@@ -299,7 +299,7 @@ function Field({
   children: React.ReactNode;
 }): React.ReactElement {
   return (
-    <label className="flex flex-col gap-1.5">
+    <label className="flex flex-col gap-2">
       <span className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
         {label}
       </span>
@@ -312,7 +312,7 @@ function TokenBadge({ hasToken }: { hasToken: boolean }): React.ReactElement {
   return (
     <span
       className={[
-        'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em]',
+        'inline-flex items-center gap-2 rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em]',
         hasToken
           ? 'bg-[color:var(--success)]/10 text-[color:var(--success)]'
           : 'bg-[color:var(--border)]/40 text-[color:var(--fg-muted)]',

--- a/web-ui/app/admin/settings/page.tsx
+++ b/web-ui/app/admin/settings/page.tsx
@@ -180,11 +180,11 @@ export default function AdminSettingsPage(): React.ReactElement {
       {state.kind === 'loading' ? (
         <p className="text-sm opacity-70">Lädt …</p>
       ) : state.kind === 'error' ? (
-        <p className="text-sm text-red-500">Fehler beim Laden: {state.message}</p>
+        <p className="text-sm text-[color:var(--danger)]">Fehler beim Laden: {state.message}</p>
       ) : (
         <div className="flex flex-col gap-8">
           {!state.vaultAvailable && (
-            <p className="rounded-[12px] border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-600 dark:text-amber-300">
+            <p className="rounded-lg border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/100/10 px-4 py-3 text-sm text-[color:var(--warning)]">
               Vault nicht verfügbar — Secrets können nicht bearbeitet werden.
             </p>
           )}
@@ -197,7 +197,7 @@ export default function AdminSettingsPage(): React.ReactElement {
                 {cat.settings.map((s) => (
                   <li
                     key={s.key}
-                    className="rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5"
+                    className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5"
                   >
                     <SettingRow
                       setting={s}
@@ -227,7 +227,7 @@ export default function AdminSettingsPage(): React.ReactElement {
             <li key={p.id}>
               <Link
                 href={`/store/${encodeURIComponent(p.id)}`}
-                className="flex items-center justify-between gap-3 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 px-5 py-4 transition-colors hover:bg-[color:var(--card)]"
+                className="flex items-center justify-between gap-3 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 px-5 py-4 transition-colors hover:bg-[color:var(--card)]"
               >
                 <span className="flex items-center gap-2">
                   <span className="text-[14px] font-semibold text-[color:var(--fg-strong)]">
@@ -315,7 +315,7 @@ function SettingRow({
             className={[
               'inline-flex items-center rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em]',
               s.isSet
-                ? 'bg-emerald-500/10 text-emerald-500'
+                ? 'bg-[color:var(--success)]/100/10 text-[color:var(--success)]'
                 : 'bg-[color:var(--border)]/40 text-[color:var(--fg-muted)]',
             ].join(' ')}
           >
@@ -356,7 +356,7 @@ function SettingRow({
           {s.help}
         </p>
       )}
-      {error && <p className="text-[12px] text-red-500">{error}</p>}
+      {error && <p className="text-[12px] text-[color:var(--danger)]">{error}</p>}
     </div>
   );
 }
@@ -365,8 +365,8 @@ function StatusChip({ status }: { status: FieldStatus }): React.ReactElement | n
   if (status === 'idle') return null;
   const map: Record<Exclude<FieldStatus, 'idle'>, { label: string; cls: string }> = {
     saving: { label: 'speichert …', cls: 'text-[color:var(--fg-muted)]' },
-    saved: { label: '✓ gespeichert', cls: 'text-emerald-500' },
-    error: { label: '✗ Fehler', cls: 'text-red-500' },
+    saved: { label: '✓ gespeichert', cls: 'text-[color:var(--success)]' },
+    error: { label: '✗ Fehler', cls: 'text-[color:var(--danger)]' },
   };
   const { label, cls } = map[status];
   return <span className={`text-[11px] ${cls}`}>{label}</span>;

--- a/web-ui/app/admin/settings/page.tsx
+++ b/web-ui/app/admin/settings/page.tsx
@@ -184,7 +184,7 @@ export default function AdminSettingsPage(): React.ReactElement {
       ) : (
         <div className="flex flex-col gap-8">
           {!state.vaultAvailable && (
-            <p className="rounded-lg border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/100/10 px-4 py-3 text-sm text-[color:var(--warning)]">
+            <p className="rounded-lg border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/10 px-4 py-3 text-sm text-[color:var(--warning)]">
               Vault nicht verfügbar — Secrets können nicht bearbeitet werden.
             </p>
           )}
@@ -315,7 +315,7 @@ function SettingRow({
             className={[
               'inline-flex items-center rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em]',
               s.isSet
-                ? 'bg-[color:var(--success)]/100/10 text-[color:var(--success)]'
+                ? 'bg-[color:var(--success)]/10 text-[color:var(--success)]'
                 : 'bg-[color:var(--border)]/40 text-[color:var(--fg-muted)]',
             ].join(' ')}
           >

--- a/web-ui/app/admin/settings/page.tsx
+++ b/web-ui/app/admin/settings/page.tsx
@@ -163,7 +163,7 @@ export default function AdminSettingsPage(): React.ReactElement {
   );
 
   return (
-    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-8">
         <h1 className="font-display text-[clamp(1.75rem,3.5vw,2.5rem)] leading-[1.1] text-[color:var(--fg-strong)]">
           Konfiguration
@@ -197,7 +197,7 @@ export default function AdminSettingsPage(): React.ReactElement {
                 {cat.settings.map((s) => (
                   <li
                     key={s.key}
-                    className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5"
+                    className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4"
                   >
                     <SettingRow
                       setting={s}
@@ -227,7 +227,7 @@ export default function AdminSettingsPage(): React.ReactElement {
             <li key={p.id}>
               <Link
                 href={`/store/${encodeURIComponent(p.id)}`}
-                className="flex items-center justify-between gap-3 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 px-5 py-4 transition-colors hover:bg-[color:var(--card)]"
+                className="flex items-center justify-between gap-3 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 px-4 py-4 transition-colors hover:bg-[color:var(--card)]"
               >
                 <span className="flex items-center gap-2">
                   <span className="text-[14px] font-semibold text-[color:var(--fg-strong)]">

--- a/web-ui/app/admin/topics/[id]/page.tsx
+++ b/web-ui/app/admin/topics/[id]/page.tsx
@@ -36,7 +36,7 @@ export default function TopicDetailPage(): React.ReactElement {
   }, [id, load]);
 
   return (
-    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-8">
         <Link
           href="/admin/topics"
@@ -62,10 +62,10 @@ export default function TopicDetailPage(): React.ReactElement {
             {detail.props.description}
           </p>
           <div className="mb-6 flex flex-wrap gap-2 text-[10px]">
-            <span className="rounded bg-[color:var(--accent)]/10 px-1.5 py-0.5 font-mono uppercase tracking-wider text-[color:var(--accent)]">
+            <span className="rounded bg-[color:var(--accent)]/10 px-2 py-0.5 font-mono uppercase tracking-wider text-[color:var(--accent)]">
               {detail.props.member_count} Memories
             </span>
-            <span className="rounded bg-[color:var(--bg-soft)] px-1.5 py-0.5 font-mono uppercase tracking-wider text-[color:var(--fg)]">
+            <span className="rounded bg-[color:var(--bg-soft)] px-2 py-0.5 font-mono uppercase tracking-wider text-[color:var(--fg)]">
               {detail.props.naming_source}
             </span>
           </div>

--- a/web-ui/app/admin/topics/[id]/page.tsx
+++ b/web-ui/app/admin/topics/[id]/page.tsx
@@ -40,15 +40,15 @@ export default function TopicDetailPage(): React.ReactElement {
       <header className="mb-8">
         <Link
           href="/admin/topics"
-          className="text-xs text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+          className="text-xs text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]"
         >
           ← /admin/topics
         </Link>
       </header>
 
-      {loading && <p className="text-xs text-neutral-500">lädt…</p>}
+      {loading && <p className="text-xs text-[color:var(--fg-muted)]">lädt…</p>}
       {error !== null && (
-        <div className="border-l-2 border-red-400 px-3 py-2 text-xs text-red-700 dark:text-red-300">
+        <div className="border-l-2 border-[color:var(--danger-edge)] px-3 py-2 text-xs text-[color:var(--danger)]">
           Fehler: {error}
         </div>
       )}
@@ -62,19 +62,19 @@ export default function TopicDetailPage(): React.ReactElement {
             {detail.props.description}
           </p>
           <div className="mb-6 flex flex-wrap gap-2 text-[10px]">
-            <span className="rounded bg-violet-100 px-1.5 py-0.5 font-mono uppercase tracking-wider text-violet-800 dark:bg-violet-900/40 dark:text-violet-200">
+            <span className="rounded bg-[color:var(--accent)]/10 px-1.5 py-0.5 font-mono uppercase tracking-wider text-[color:var(--accent)]">
               {detail.props.member_count} Memories
             </span>
-            <span className="rounded bg-neutral-100 px-1.5 py-0.5 font-mono uppercase tracking-wider text-neutral-700 dark:bg-neutral-800 dark:text-neutral-200">
+            <span className="rounded bg-[color:var(--bg-soft)] px-1.5 py-0.5 font-mono uppercase tracking-wider text-[color:var(--fg)]">
               {detail.props.naming_source}
             </span>
           </div>
 
-          <h2 className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-neutral-500">
+          <h2 className="mb-3 text-[11px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
             Mitglieder
           </h2>
           {detail.members.length === 0 && (
-            <p className="text-sm italic text-neutral-500">
+            <p className="text-sm italic text-[color:var(--fg-muted)]">
               Keine sichtbaren Mitglieder (oder ACL verbirgt sie).
             </p>
           )}
@@ -83,12 +83,12 @@ export default function TopicDetailPage(): React.ReactElement {
               <li key={mk.id}>
                 <Link
                   href={`/memories/${encodeURIComponent(mk.id)}`}
-                  className="block rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-3 transition-colors hover:border-[color:var(--accent)]"
+                  className="block rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-3 transition-colors hover:border-[color:var(--accent)]"
                 >
-                  <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-neutral-500">
+                  <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
                     {String(mk.props['kind'])}
                   </div>
-                  <p className="text-sm text-neutral-900 dark:text-neutral-100">
+                  <p className="text-sm text-[color:var(--fg-strong)]">
                     {String(mk.props['summary'])}
                   </p>
                 </Link>

--- a/web-ui/app/admin/topics/page.tsx
+++ b/web-ui/app/admin/topics/page.tsx
@@ -75,7 +75,7 @@ export default function TopicsListPage(): React.ReactElement {
       <header className="mb-8">
         <Link
           href="/admin"
-          className="text-xs text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+          className="text-xs text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]"
         >
           ← /admin
         </Link>
@@ -90,14 +90,14 @@ export default function TopicsListPage(): React.ReactElement {
 
       <section
         aria-label="Re-Cluster"
-        className="mb-6 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4"
+        className="mb-6 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4"
       >
         <h2 className="mb-3 text-sm font-semibold text-[color:var(--fg-strong)]">
           Re-Cluster
         </h2>
         <div className="grid gap-3 sm:grid-cols-2">
           <label className="block">
-            <span className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-500">
+            <span className="mb-1 block text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
               Cosine-Threshold (0.3-0.95)
             </span>
             <input
@@ -114,7 +114,7 @@ export default function TopicsListPage(): React.ReactElement {
             />
           </label>
           <label className="block">
-            <span className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-500">
+            <span className="mb-1 block text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
               Min Cluster-Größe (2-20)
             </span>
             <input
@@ -134,39 +134,39 @@ export default function TopicsListPage(): React.ReactElement {
           type="button"
           onClick={() => void triggerRecluster()}
           disabled={running}
-          className="mt-3 rounded border border-neutral-900 bg-neutral-900 px-3 py-1 text-xs text-white disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-200 dark:bg-neutral-200 dark:text-neutral-900"
+          className="mt-3 rounded border border-[color:var(--border-strong)] bg-[color:var(--bg-inverse)] px-3 py-1 text-xs text-[color:var(--fg-on-dark)] disabled:cursor-not-allowed disabled:opacity-50"
         >
           {running ? 'läuft…' : 'Re-Cluster starten'}
         </button>
         {runError !== null && (
-          <p className="mt-3 text-xs text-red-600 dark:text-red-300">
+          <p className="mt-3 text-xs text-[color:var(--danger)]">
             Fehler: {runError}
           </p>
         )}
         {runResult !== null && (
-          <div className="mt-3 rounded border border-[color:var(--border)] bg-black/5 p-3 text-xs dark:bg-white/5">
+          <div className="mt-3 rounded border border-[color:var(--border)] bg-black/5 p-3 text-xs">
             <p className="mb-2 font-medium">
               Ergebnis · {runResult.durationMs} ms
             </p>
             <dl className="grid grid-cols-2 gap-2 sm:grid-cols-4">
               <div>
-                <dt className="text-neutral-500">scanned</dt>
+                <dt className="text-[color:var(--fg-muted)]">scanned</dt>
                 <dd className="font-mono">{runResult.totalMemoriesScanned}</dd>
               </div>
               <div>
-                <dt className="text-neutral-500">topics neu</dt>
+                <dt className="text-[color:var(--fg-muted)]">topics neu</dt>
                 <dd className="font-mono">{runResult.topicsCreated}</dd>
               </div>
               <div>
-                <dt className="text-neutral-500">topics weg</dt>
+                <dt className="text-[color:var(--fg-muted)]">topics weg</dt>
                 <dd className="font-mono">{runResult.topicsDeleted}</dd>
               </div>
               <div>
-                <dt className="text-neutral-500">ungeclustert</dt>
+                <dt className="text-[color:var(--fg-muted)]">ungeclustert</dt>
                 <dd className="font-mono">{runResult.unclusteredMemories}</dd>
               </div>
               <div>
-                <dt className="text-neutral-500">Haiku-Calls</dt>
+                <dt className="text-[color:var(--fg-muted)]">Haiku-Calls</dt>
                 <dd className="font-mono">{runResult.haikuCalls}</dd>
               </div>
             </dl>
@@ -175,15 +175,15 @@ export default function TopicsListPage(): React.ReactElement {
       </section>
 
       {error !== null && (
-        <div className="mb-4 border-l-2 border-red-400 px-3 py-2 text-xs text-red-700 dark:text-red-300">
+        <div className="mb-4 border-l-2 border-[color:var(--danger-edge)] px-3 py-2 text-xs text-[color:var(--danger)]">
           Fehler: {error}
         </div>
       )}
 
-      {loading && <p className="text-xs text-neutral-500">lädt…</p>}
+      {loading && <p className="text-xs text-[color:var(--fg-muted)]">lädt…</p>}
 
       {items !== null && items.length === 0 && error === null && (
-        <p className="text-sm italic text-neutral-500">
+        <p className="text-sm italic text-[color:var(--fg-muted)]">
           Keine Topics. Starte einen Re-Cluster oben.
         </p>
       )}
@@ -194,28 +194,28 @@ export default function TopicsListPage(): React.ReactElement {
             <li key={t.id}>
               <Link
                 href={`/admin/topics/${encodeURIComponent(t.id)}`}
-                className="block rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4 transition-colors hover:border-[color:var(--accent)]"
+                className="block rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4 transition-colors hover:border-[color:var(--accent)]"
               >
                 <div className="mb-2 flex flex-wrap items-center gap-2 text-[10px]">
-                  <span className="rounded bg-violet-100 px-1.5 py-0.5 font-mono uppercase tracking-wider text-violet-800 dark:bg-violet-900/40 dark:text-violet-200">
+                  <span className="rounded bg-[color:var(--accent)]/10 px-1.5 py-0.5 font-mono uppercase tracking-wider text-[color:var(--accent)]">
                     {t.props.member_count} Memories
                   </span>
                   {t.props.naming_source === 'fallback' && (
-                    <span className="rounded bg-amber-100 px-1.5 py-0.5 font-mono uppercase tracking-wider text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+                    <span className="rounded bg-[color:var(--warning)]/10 px-1.5 py-0.5 font-mono uppercase tracking-wider text-[color:var(--warning)]">
                       fallback-name
                     </span>
                   )}
                   <time
-                    className="font-mono text-neutral-500"
+                    className="font-mono text-[color:var(--fg-muted)]"
                     dateTime={t.props.created_at}
                   >
                     {new Date(t.props.created_at).toLocaleString('de-DE')}
                   </time>
                 </div>
-                <h3 className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+                <h3 className="text-sm font-semibold text-[color:var(--fg-strong)]">
                   {t.props.name}
                 </h3>
-                <p className="mt-1 text-xs text-neutral-700 dark:text-neutral-300">
+                <p className="mt-1 text-xs text-[color:var(--fg)]">
                   {t.props.description}
                 </p>
               </Link>

--- a/web-ui/app/admin/topics/page.tsx
+++ b/web-ui/app/admin/topics/page.tsx
@@ -71,7 +71,7 @@ export default function TopicsListPage(): React.ReactElement {
   }, [load]);
 
   return (
-    <main className="mx-auto max-w-[1000px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[1000px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-8">
         <Link
           href="/admin"
@@ -197,11 +197,11 @@ export default function TopicsListPage(): React.ReactElement {
                 className="block rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4 transition-colors hover:border-[color:var(--accent)]"
               >
                 <div className="mb-2 flex flex-wrap items-center gap-2 text-[10px]">
-                  <span className="rounded bg-[color:var(--accent)]/10 px-1.5 py-0.5 font-mono uppercase tracking-wider text-[color:var(--accent)]">
+                  <span className="rounded bg-[color:var(--accent)]/10 px-2 py-0.5 font-mono uppercase tracking-wider text-[color:var(--accent)]">
                     {t.props.member_count} Memories
                   </span>
                   {t.props.naming_source === 'fallback' && (
-                    <span className="rounded bg-[color:var(--warning)]/10 px-1.5 py-0.5 font-mono uppercase tracking-wider text-[color:var(--warning)]">
+                    <span className="rounded bg-[color:var(--warning)]/10 px-2 py-0.5 font-mono uppercase tracking-wider text-[color:var(--warning)]">
                       fallback-name
                     </span>
                   )}

--- a/web-ui/app/admin/usage/page.tsx
+++ b/web-ui/app/admin/usage/page.tsx
@@ -114,7 +114,7 @@ export default function UsageDashboardPage(): React.ReactElement {
   );
 
   return (
-    <main className="mx-auto max-w-[1080px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[1080px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-8 flex flex-wrap items-end justify-between gap-4">
         <div>
           <h1 className="font-display text-[clamp(2rem,4vw,3rem)] leading-[1.1] text-[color:var(--fg-strong)]">
@@ -131,7 +131,7 @@ export default function UsageDashboardPage(): React.ReactElement {
               key={r.key}
               type="button"
               onClick={() => selectRange(r.key)}
-              className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
+              className={`rounded-md px-3 py-2 text-sm transition-colors ${
                 range === r.key
                   ? 'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)]'
                   : 'text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]'
@@ -204,17 +204,17 @@ export default function UsageDashboardPage(): React.ReactElement {
 
 function Kpi({ label, value, hint }: { label: string; value: string; hint?: string }): React.ReactElement {
   return (
-    <div className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+    <div className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
       <div className="text-xs uppercase tracking-wide text-[color:var(--fg-muted)]">{label}</div>
       <div className="mt-2 font-display text-[28px] leading-none text-[color:var(--fg-strong)]">{value}</div>
-      {hint && <div className="mt-1.5 text-xs text-[color:var(--fg-muted)]">{hint}</div>}
+      {hint && <div className="mt-2 text-xs text-[color:var(--fg-muted)]">{hint}</div>}
     </div>
   );
 }
 
 function Panel({ title, children }: { title: string; children: React.ReactNode }): React.ReactElement {
   return (
-    <section className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+    <section className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
       <h2 className="mb-4 text-[15px] font-semibold text-[color:var(--fg-strong)]">{title}</h2>
       {children}
     </section>

--- a/web-ui/app/admin/usage/page.tsx
+++ b/web-ui/app/admin/usage/page.tsx
@@ -125,15 +125,15 @@ export default function UsageDashboardPage(): React.ReactElement {
             Anthropic-Call — Orchestrator, Sub-Agents und die Haiku-Background-Tasks.
           </p>
         </div>
-        <div className="flex gap-1 rounded-[12px] border border-[color:var(--border)] p-1">
+        <div className="flex gap-1 rounded-lg border border-[color:var(--border)] p-1">
           {RANGES.map((r) => (
             <button
               key={r.key}
               type="button"
               onClick={() => selectRange(r.key)}
-              className={`rounded-[8px] px-3 py-1.5 text-sm transition-colors ${
+              className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
                 range === r.key
-                  ? 'bg-[color:var(--accent)] text-white'
+                  ? 'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)]'
                   : 'text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]'
               }`}
             >
@@ -144,7 +144,7 @@ export default function UsageDashboardPage(): React.ReactElement {
       </header>
 
       {error && (
-        <div className="mb-6 rounded-[12px] border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+        <div className="mb-6 rounded-lg border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/80/10 px-4 py-3 text-sm text-[color:var(--danger)]">
           Fehler beim Laden: {error}
         </div>
       )}
@@ -204,7 +204,7 @@ export default function UsageDashboardPage(): React.ReactElement {
 
 function Kpi({ label, value, hint }: { label: string; value: string; hint?: string }): React.ReactElement {
   return (
-    <div className="rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+    <div className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
       <div className="text-xs uppercase tracking-wide text-[color:var(--fg-muted)]">{label}</div>
       <div className="mt-2 font-display text-[28px] leading-none text-[color:var(--fg-strong)]">{value}</div>
       {hint && <div className="mt-1.5 text-xs text-[color:var(--fg-muted)]">{hint}</div>}
@@ -214,7 +214,7 @@ function Kpi({ label, value, hint }: { label: string; value: string; hint?: stri
 
 function Panel({ title, children }: { title: string; children: React.ReactNode }): React.ReactElement {
   return (
-    <section className="rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+    <section className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
       <h2 className="mb-4 text-[15px] font-semibold text-[color:var(--fg-strong)]">{title}</h2>
       {children}
     </section>

--- a/web-ui/app/admin/usage/page.tsx
+++ b/web-ui/app/admin/usage/page.tsx
@@ -144,7 +144,7 @@ export default function UsageDashboardPage(): React.ReactElement {
       </header>
 
       {error && (
-        <div className="mb-6 rounded-lg border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/80/10 px-4 py-3 text-sm text-[color:var(--danger)]">
+        <div className="mb-6 rounded-lg border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/10 px-4 py-3 text-sm text-[color:var(--danger)]">
           Fehler beim Laden: {error}
         </div>
       )}

--- a/web-ui/app/admin/users/[id]/page.tsx
+++ b/web-ui/app/admin/users/[id]/page.tsx
@@ -179,7 +179,7 @@ export default function AdminUserEditPage(): React.ReactElement {
         </p>
       </header>
 
-      <section className="mb-8 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+      <section className="mb-8 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
         <h2 className="mb-3 text-[15px] font-semibold text-[color:var(--fg-strong)]">
           Profil
         </h2>
@@ -221,7 +221,7 @@ export default function AdminUserEditPage(): React.ReactElement {
       </section>
 
       {isLocal && (
-        <section className="mb-8 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+        <section className="mb-8 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
           <h2 className="mb-3 text-[15px] font-semibold text-[color:var(--fg-strong)]">
             Passwort zurücksetzen
           </h2>
@@ -258,7 +258,7 @@ export default function AdminUserEditPage(): React.ReactElement {
         </section>
       )}
 
-      <section className="rounded-lg border border-[color:var(--danger-edge)]/30 bg-[color:var(--danger)]/5 p-5">
+      <section className="rounded-lg border border-[color:var(--danger-edge)]/30 bg-[color:var(--danger)]/5 p-4">
         <h2 className="mb-2 text-[15px] font-semibold text-[color:var(--danger)]">
           Gefahrenzone
         </h2>

--- a/web-ui/app/admin/users/[id]/page.tsx
+++ b/web-ui/app/admin/users/[id]/page.tsx
@@ -146,7 +146,7 @@ export default function AdminUserEditPage(): React.ReactElement {
   if (state.kind === 'error') {
     return (
       <main className="mx-auto max-w-[720px] px-6 py-12">
-        <p className="text-sm text-red-500">
+        <p className="text-sm text-[color:var(--danger)]">
           Fehler beim Laden: {state.message}
         </p>
         <Link
@@ -179,7 +179,7 @@ export default function AdminUserEditPage(): React.ReactElement {
         </p>
       </header>
 
-      <section className="mb-8 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+      <section className="mb-8 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
         <h2 className="mb-3 text-[15px] font-semibold text-[color:var(--fg-strong)]">
           Profil
         </h2>
@@ -207,13 +207,13 @@ export default function AdminUserEditPage(): React.ReactElement {
             </select>
           </label>
           {patchMessage && (
-            <p className="text-sm text-emerald-500">{patchMessage}</p>
+            <p className="text-sm text-[color:var(--success)]">{patchMessage}</p>
           )}
-          {patchError && <p className="text-sm text-red-500">{patchError}</p>}
+          {patchError && <p className="text-sm text-[color:var(--danger)]">{patchError}</p>}
           <button
             type="submit"
             disabled={savingPatch}
-            className="self-start rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-black disabled:opacity-50"
+            className="self-start rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-[color:var(--text-inverse)] disabled:opacity-50"
           >
             {savingPatch ? 'Speichere …' : 'Speichern'}
           </button>
@@ -221,7 +221,7 @@ export default function AdminUserEditPage(): React.ReactElement {
       </section>
 
       {isLocal && (
-        <section className="mb-8 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
+        <section className="mb-8 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5">
           <h2 className="mb-3 text-[15px] font-semibold text-[color:var(--fg-strong)]">
             Passwort zurücksetzen
           </h2>
@@ -250,16 +250,16 @@ export default function AdminUserEditPage(): React.ReactElement {
             </button>
           </div>
           {resetMessage && (
-            <p className="mt-3 text-sm text-emerald-500">{resetMessage}</p>
+            <p className="mt-3 text-sm text-[color:var(--success)]">{resetMessage}</p>
           )}
           {resetError && (
-            <p className="mt-3 text-sm text-red-500">{resetError}</p>
+            <p className="mt-3 text-sm text-[color:var(--danger)]">{resetError}</p>
           )}
         </section>
       )}
 
-      <section className="rounded-[14px] border border-red-500/30 bg-red-500/5 p-5">
-        <h2 className="mb-2 text-[15px] font-semibold text-red-500">
+      <section className="rounded-lg border border-[color:var(--danger-edge)]/30 bg-[color:var(--danger)]/80/5 p-5">
+        <h2 className="mb-2 text-[15px] font-semibold text-[color:var(--danger)]">
           Gefahrenzone
         </h2>
         <p className="mb-3 text-sm text-[color:var(--fg-muted)]">
@@ -269,12 +269,12 @@ export default function AdminUserEditPage(): React.ReactElement {
           type="button"
           onClick={() => void handleDelete()}
           disabled={deleting}
-          className="rounded-md border border-red-500/40 px-4 py-2 text-sm font-medium text-red-500 hover:bg-red-500/10 disabled:opacity-50"
+          className="rounded-md border border-[color:var(--danger-edge)]/40 px-4 py-2 text-sm font-medium text-[color:var(--danger)] hover:bg-[color:var(--danger)]/80/10 disabled:opacity-50"
         >
           {deleting ? 'Lösche …' : 'Nutzer löschen'}
         </button>
         {deleteError && (
-          <p className="mt-3 text-sm text-red-500">{deleteError}</p>
+          <p className="mt-3 text-sm text-[color:var(--danger)]">{deleteError}</p>
         )}
       </section>
     </main>

--- a/web-ui/app/admin/users/[id]/page.tsx
+++ b/web-ui/app/admin/users/[id]/page.tsx
@@ -258,7 +258,7 @@ export default function AdminUserEditPage(): React.ReactElement {
         </section>
       )}
 
-      <section className="rounded-lg border border-[color:var(--danger-edge)]/30 bg-[color:var(--danger)]/80/5 p-5">
+      <section className="rounded-lg border border-[color:var(--danger-edge)]/30 bg-[color:var(--danger)]/5 p-5">
         <h2 className="mb-2 text-[15px] font-semibold text-[color:var(--danger)]">
           Gefahrenzone
         </h2>
@@ -269,7 +269,7 @@ export default function AdminUserEditPage(): React.ReactElement {
           type="button"
           onClick={() => void handleDelete()}
           disabled={deleting}
-          className="rounded-md border border-[color:var(--danger-edge)]/40 px-4 py-2 text-sm font-medium text-[color:var(--danger)] hover:bg-[color:var(--danger)]/80/10 disabled:opacity-50"
+          className="rounded-md border border-[color:var(--danger-edge)]/40 px-4 py-2 text-sm font-medium text-[color:var(--danger)] hover:bg-[color:var(--danger)]/10 disabled:opacity-50"
         >
           {deleting ? 'Lösche …' : 'Nutzer löschen'}
         </button>

--- a/web-ui/app/admin/users/page.tsx
+++ b/web-ui/app/admin/users/page.tsx
@@ -103,7 +103,7 @@ export default function AdminUsersPage(): React.ReactElement {
         <button
           type="button"
           onClick={() => setShowCreate((s) => !s)}
-          className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-black"
+          className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-[color:var(--text-inverse)]"
         >
           {showCreate ? 'Abbrechen' : 'Neuen Nutzer anlegen'}
         </button>
@@ -112,7 +112,7 @@ export default function AdminUsersPage(): React.ReactElement {
       {showCreate && (
         <form
           onSubmit={handleCreate}
-          className="mb-8 grid gap-4 rounded-[14px] border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5 sm:grid-cols-2"
+          className="mb-8 grid gap-4 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5 sm:grid-cols-2"
         >
           <label className="flex flex-col gap-1 text-sm">
             <span className="font-medium">Email</span>
@@ -145,12 +145,12 @@ export default function AdminUsersPage(): React.ReactElement {
             />
           </label>
           {createError && (
-            <p className="text-sm text-red-500 sm:col-span-2">{createError}</p>
+            <p className="text-sm text-[color:var(--danger)] sm:col-span-2">{createError}</p>
           )}
           <button
             type="submit"
             disabled={submitting}
-            className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-black disabled:opacity-50 sm:col-span-2"
+            className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-[color:var(--text-inverse)] disabled:opacity-50 sm:col-span-2"
           >
             {submitting ? 'Lege an …' : 'Anlegen'}
           </button>
@@ -160,11 +160,11 @@ export default function AdminUsersPage(): React.ReactElement {
       {state.kind === 'loading' ? (
         <p className="text-sm opacity-70">Lädt …</p>
       ) : state.kind === 'error' ? (
-        <p className="text-sm text-red-500">
+        <p className="text-sm text-[color:var(--danger)]">
           Fehler beim Laden: {state.message}
         </p>
       ) : (
-        <div className="overflow-x-auto rounded-[14px] border border-[color:var(--border)]">
+        <div className="overflow-x-auto rounded-lg border border-[color:var(--border)]">
           <table className="w-full text-left text-sm">
             <thead className="bg-[color:var(--card)]/40 text-[12px] uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
               <tr>
@@ -199,8 +199,8 @@ export default function AdminUsersPage(): React.ReactElement {
                       className={[
                         'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em]',
                         u.status === 'active'
-                          ? 'bg-emerald-500/10 text-emerald-500'
-                          : 'bg-amber-500/10 text-amber-500',
+                          ? 'bg-[color:var(--success)]/100/10 text-[color:var(--success)]'
+                          : 'bg-[color:var(--warning)]/100/10 text-[color:var(--warning)]',
                       ].join(' ')}
                     >
                       {u.status}

--- a/web-ui/app/admin/users/page.tsx
+++ b/web-ui/app/admin/users/page.tsx
@@ -88,7 +88,7 @@ export default function AdminUsersPage(): React.ReactElement {
   }
 
   return (
-    <main className="mx-auto max-w-[1080px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[1080px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-8 flex flex-wrap items-end justify-between gap-4">
         <div>
           <h1 className="font-display text-[clamp(1.75rem,3.5vw,2.5rem)] leading-[1.1] text-[color:var(--fg-strong)]">
@@ -112,7 +112,7 @@ export default function AdminUsersPage(): React.ReactElement {
       {showCreate && (
         <form
           onSubmit={handleCreate}
-          className="mb-8 grid gap-4 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-5 sm:grid-cols-2"
+          className="mb-8 grid gap-4 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4 sm:grid-cols-2"
         >
           <label className="flex flex-col gap-1 text-sm">
             <span className="font-medium">Email</span>
@@ -197,7 +197,7 @@ export default function AdminUsersPage(): React.ReactElement {
                   <td className="px-4 py-3">
                     <span
                       className={[
-                        'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em]',
+                        'inline-flex items-center gap-2 rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em]',
                         u.status === 'active'
                           ? 'bg-[color:var(--success)]/10 text-[color:var(--success)]'
                           : 'bg-[color:var(--warning)]/10 text-[color:var(--warning)]',

--- a/web-ui/app/admin/users/page.tsx
+++ b/web-ui/app/admin/users/page.tsx
@@ -199,8 +199,8 @@ export default function AdminUsersPage(): React.ReactElement {
                       className={[
                         'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em]',
                         u.status === 'active'
-                          ? 'bg-[color:var(--success)]/100/10 text-[color:var(--success)]'
-                          : 'bg-[color:var(--warning)]/100/10 text-[color:var(--warning)]',
+                          ? 'bg-[color:var(--success)]/10 text-[color:var(--success)]'
+                          : 'bg-[color:var(--warning)]/10 text-[color:var(--warning)]',
                       ].join(' ')}
                     >
                       {u.status}

--- a/web-ui/app/error.tsx
+++ b/web-ui/app/error.tsx
@@ -58,14 +58,14 @@ export default function Error({
             onClick={() => {
               reset();
             }}
-            className="rounded bg-neutral-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-neutral-700 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-300"
+            className="rounded bg-[color:var(--bg-inverse)] px-4 py-2 text-sm font-medium text-[color:var(--fg-on-dark)] transition hover:bg-[color:var(--fg-muted)]"
           >
             {t('reload')}
           </button>
           <button
             type="button"
             onClick={resetLocalData}
-            className="rounded border border-neutral-300 bg-white px-4 py-2 text-sm font-medium text-neutral-700 transition hover:border-neutral-400 hover:bg-neutral-50 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200 dark:hover:bg-neutral-800"
+            className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-4 py-2 text-sm font-medium text-[color:var(--fg)] transition hover:border-[color:var(--border-strong)] hover:bg-[color:var(--bg-soft)]"
           >
             {t('resetData')}
           </button>

--- a/web-ui/app/globals.css
+++ b/web-ui/app/globals.css
@@ -82,15 +82,6 @@ body {
   line-height: 1.65;
 }
 
-/* The byte5 signature magenta colon is retired (Lume has no magenta device).
-   The class is kept so existing markup stays valid, but it no longer paints a
-   brand color — it inherits text color at a structural weight. */
-.b5-colon {
-  color: inherit;
-  font-weight: 600;
-  margin-right: 0.35em;
-}
-
 /* ------------------------------------------------------------------------ */
 /* Lume implementation primitives (spec §3) as composable utility classes.  */
 /* ------------------------------------------------------------------------ */

--- a/web-ui/app/globals.css
+++ b/web-ui/app/globals.css
@@ -194,11 +194,13 @@ body {
 .md-view code {
   @apply rounded px-1 py-0.5 text-[0.85em];
   font-family: var(--font-mono);
-  background: var(--bg-soft);
+  background: linear-gradient(180deg, var(--bg-surface-sunken-top) 0%, var(--bg-surface-sunken-btm) 100%);
 }
 .md-view pre {
-  @apply my-3 overflow-x-auto rounded p-3 text-xs;
-  background: var(--bg-soft);
+  @apply my-3 overflow-x-auto rounded-md p-3 text-xs;
+  background: linear-gradient(180deg, var(--bg-surface-sunken-top) 0%, var(--bg-surface-sunken-btm) 100%);
+  border: 1px solid var(--border-subtle-btm);
+  border-top-color: var(--border-subtle-top);
 }
 .md-view pre code {
   @apply bg-transparent p-0 text-xs;
@@ -235,6 +237,177 @@ body {
 .md-view hr {
   @apply my-3;
   border-color: var(--divider);
+}
+
+/* ========================================================================== */
+/* Lume material layer — auto-applied (spec §4.1).                            */
+/*                                                                            */
+/* The component code paints flat token fills (`bg-[color:var(--card)]`,      */
+/* `bg-[color:var(--accent)]`, ...). Lume's material is not flat: surfaces    */
+/* are gradient pairs, borders are directional, accent fills emit light.      */
+/* Rather than editing 300+ call sites, this layer matches the existing       */
+/* utility class *strings* and upgrades them to the §3 recipes. These rules   */
+/* are intentionally UN-layered: in Tailwind v4 utilities live in             */
+/* `@layer utilities`, and un-layered author CSS wins the cascade — so the    */
+/* material applies on top of every existing component without touching it.  */
+/*                                                                            */
+/* Pattern notes:                                                             */
+/*   [class^='X'], [class*=' X']  → matches X as a *base* utility only        */
+/*     (not `hover:X`, which would otherwise substring-match).                */
+/*   :not([class*='X/'])          → skips translucent variants (`X/40`),      */
+/*     which components use deliberately for washes and scrims.               */
+/* ========================================================================== */
+
+/* ---- Pane surfaces (ladder depth 1): bg / paper → bg.surface gradient ---- */
+[class^='bg-[color:var(--bg)]']:not([class*='bg-[color:var(--bg)]/']),
+[class*=' bg-[color:var(--bg)]']:not([class*='bg-[color:var(--bg)]/']),
+[class^='bg-[color:var(--paper)]']:not([class*='bg-[color:var(--paper)]/']),
+[class*=' bg-[color:var(--paper)]']:not([class*='bg-[color:var(--paper)]/']) {
+  background: linear-gradient(180deg, var(--bg-surface-top) 0%, var(--bg-surface-btm) 100%);
+}
+
+/* ---- Raised surfaces (depth 3): card / surface / bg-elevated ------------- */
+[class^='bg-[color:var(--card)]']:not([class*='bg-[color:var(--card)]/']),
+[class*=' bg-[color:var(--card)]']:not([class*='bg-[color:var(--card)]/']),
+[class^='bg-[color:var(--surface)]']:not([class*='bg-[color:var(--surface)]/']),
+[class*=' bg-[color:var(--surface)]']:not([class*='bg-[color:var(--surface)]/']),
+[class^='bg-[color:var(--bg-elevated)]']:not([class*='bg-[color:var(--bg-elevated)]/']),
+[class*=' bg-[color:var(--bg-elevated)]']:not([class*='bg-[color:var(--bg-elevated)]/']) {
+  background: linear-gradient(180deg, var(--bg-surface-raised-top) 0%, var(--bg-surface-raised-btm) 100%);
+  border-color: var(--border-subtle-btm);
+  border-top-color: var(--border-subtle-top);
+}
+/* Inset top-edge highlight (§3.4) — only when the element doesn't manage its
+   own shadow stack (modals carry elev tokens that already include it). */
+[class^='bg-[color:var(--card)]']:not([class*='bg-[color:var(--card)]/']):not([class*='shadow-']),
+[class*=' bg-[color:var(--card)]']:not([class*='bg-[color:var(--card)]/']):not([class*='shadow-']),
+[class^='bg-[color:var(--surface)]']:not([class*='bg-[color:var(--surface)]/']):not([class*='shadow-']),
+[class*=' bg-[color:var(--surface)]']:not([class*='bg-[color:var(--surface)]/']):not([class*='shadow-']),
+[class^='bg-[color:var(--bg-elevated)]']:not([class*='bg-[color:var(--bg-elevated)]/']):not([class*='shadow-']),
+[class*=' bg-[color:var(--bg-elevated)]']:not([class*='bg-[color:var(--bg-elevated)]/']):not([class*='shadow-']) {
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.06) inset;
+}
+
+/* ---- Sunken surfaces (depth 4+): bg-soft / surface-muted / bg-subtle ----- */
+[class^='bg-[color:var(--bg-soft)]']:not([class*='bg-[color:var(--bg-soft)]/']),
+[class*=' bg-[color:var(--bg-soft)]']:not([class*='bg-[color:var(--bg-soft)]/']),
+[class^='bg-[color:var(--surface-muted)]']:not([class*='bg-[color:var(--surface-muted)]/']),
+[class*=' bg-[color:var(--surface-muted)]']:not([class*='bg-[color:var(--surface-muted)]/']),
+[class^='bg-[color:var(--bg-subtle)]']:not([class*='bg-[color:var(--bg-subtle)]/']),
+[class*=' bg-[color:var(--bg-subtle)]']:not([class*='bg-[color:var(--bg-subtle)]/']) {
+  background: linear-gradient(180deg, var(--bg-surface-sunken-top) 0%, var(--bg-surface-sunken-btm) 100%);
+}
+
+/* ---- Hover wash for interactive surfaces ---------------------------------
+   The base rules above out-cascade `hover:bg-*` utilities, so interactive
+   elements would lose hover feedback. Restore it the Lume way: the agent's
+   attention as an accent-subtle tint over the gradient (inset-spread trick
+   tints without replacing the background). */
+a:hover[class*='bg-[color:var(--'],
+button:hover[class*='bg-[color:var(--']:not([class*='bg-[color:var(--accent)]']):not(:disabled),
+[role='button']:hover[class*='bg-[color:var(--']:not([class*='bg-[color:var(--accent)]']) {
+  box-shadow: inset 0 0 0 999px var(--accent-subtle);
+}
+
+/* ---- Accent fills: the lit elements (§4.2 button-primary) ---------------- */
+[class^='bg-[color:var(--accent)]']:not([class*='bg-[color:var(--accent)]/']),
+[class*=' bg-[color:var(--accent)]']:not([class*='bg-[color:var(--accent)]/']) {
+  background: linear-gradient(180deg, var(--accent) 0%, var(--accent-hover) 100%);
+  border-color: var(--accent-hover);
+  border-top-color: rgba(255, 255, 255, 0.18);
+  color: var(--accent-fg);
+  box-shadow: 0 0 4px var(--accent-glow-core), 0 4px 12px var(--accent-glow);
+  transition:
+    box-shadow var(--motion-quick) var(--easing-standard),
+    filter var(--motion-quick) var(--easing-standard);
+}
+a[class^='bg-[color:var(--accent)]']:hover,
+a[class*=' bg-[color:var(--accent)]']:hover,
+button[class^='bg-[color:var(--accent)]']:hover:not(:disabled),
+button[class*=' bg-[color:var(--accent)]']:hover:not(:disabled) {
+  box-shadow: 0 0 6px var(--accent-glow-core), 0 6px 18px var(--accent-glow-strong);
+  filter: brightness(1.04);
+}
+button[class^='bg-[color:var(--accent)]']:active:not(:disabled),
+button[class*=' bg-[color:var(--accent)]']:active:not(:disabled) {
+  background: var(--accent-active);
+  filter: none;
+}
+/* Focus on accent fills: §4.2 layered ring on top of the two-stop glow. */
+[class^='bg-[color:var(--accent)]']:focus-visible,
+[class*=' bg-[color:var(--accent)]']:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--bg),
+    0 0 0 4px var(--accent),
+    0 0 4px var(--accent-glow-core),
+    0 4px 12px var(--accent-glow);
+}
+
+/* ---- Inputs (§4.2 input): raised gradient, directional border, lit focus - */
+input:not([type='checkbox']):not([type='radio']):not([type='range']):not([type='file']):not([type='color']):not([type='hidden']),
+select,
+textarea {
+  background: linear-gradient(180deg, var(--bg-surface-raised-top) 0%, var(--bg-surface-raised-btm) 100%);
+  border-color: var(--border-default-btm);
+  border-top-color: var(--border-default-top);
+  transition:
+    border-color var(--motion-quick) var(--easing-standard),
+    box-shadow var(--motion-quick) var(--easing-standard);
+}
+input:not([type='checkbox']):not([type='radio']):not([type='range']):not([type='file']):not([type='color']):not([type='hidden']):focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  border-top-color: var(--accent);
+  box-shadow:
+    0 0 0 1px var(--accent),
+    0 0 0 4px var(--accent-glow),
+    0 0 12px var(--accent-glow-core);
+}
+/* Checked choice controls emit a small glow (§4.2 choice/toggle). */
+input[type='checkbox']:checked,
+input[type='radio']:checked {
+  accent-color: var(--accent);
+  box-shadow: 0 0 3px var(--accent-glow-core), 0 0 6px var(--accent-glow);
+}
+input[type='checkbox'],
+input[type='radio'] {
+  accent-color: var(--accent);
+}
+
+/* ---- Focus emits light, everywhere (§4.1) -------------------------------- */
+button:focus-visible,
+a:focus-visible,
+summary:focus-visible,
+[role='button']:focus-visible,
+[tabindex]:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent), 0 0 0 6px var(--accent-glow);
+}
+
+/* ---- Text selection: a lit pocket ----------------------------------------- */
+::selection {
+  background: var(--accent-glow);
+  color: var(--fg-strong);
+}
+
+/* ---- Scrollbars follow the material --------------------------------------- */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-strong) transparent;
+}
+
+/* ---- App header: pane-class chrome with directional bottom edge ----------- */
+.app-header {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--bg-surface-top) 90%, transparent) 0%,
+    color-mix(in srgb, var(--bg-surface-btm) 90%, transparent) 100%
+  );
+  border-bottom: 1px solid var(--border-subtle-btm);
+  box-shadow: 0 1px 0 var(--border-subtle-top) inset;
 }
 
 /* ------------------------------------------------------------------------ */

--- a/web-ui/app/globals.css
+++ b/web-ui/app/globals.css
@@ -7,8 +7,42 @@
 }
 
 /* -------------------------------------------------------------------------- */
-/* Global, token-driven baseline styles. The palette + typography live in     */
-/* _lib/theme.css so the byte5 Claude Design Kit swap is a single-file change.*/
+/* Tailwind token bridge (Lume). `inline` keeps these referencing the runtime  */
+/* CSS vars in _lib/theme.css, so utilities like `bg-accent` / `text-fg-muted` */
+/* follow the active palette + light/dark mode instead of freezing a value.    */
+/* This is the §2 / item-4 mapping: the design-system swap stays a single-file */
+/* change at the token tier.                                                    */
+/* -------------------------------------------------------------------------- */
+@theme inline {
+  --color-bg: var(--bg);
+  --color-bg-soft: var(--bg-soft);
+  --color-bg-elevated: var(--bg-elevated);
+  --color-surface: var(--surface);
+  --color-fg: var(--fg);
+  --color-fg-strong: var(--fg-strong);
+  --color-fg-muted: var(--fg-muted);
+  --color-fg-subtle: var(--fg-subtle);
+  --color-accent: var(--accent);
+  --color-accent-hover: var(--accent-hover);
+  --color-accent-subtle: var(--accent-subtle);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-danger: var(--danger);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
+  --font-serif: var(--font-serif);
+
+  --radius-sm: var(--radius-sm);
+  --radius-md: var(--radius-md);
+  --radius-lg: var(--radius-lg);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Global, token-driven baseline. Palette + typography live in _lib/theme.css  */
+/* so the design-system swap is a single-file change at the token tier.        */
 /* -------------------------------------------------------------------------- */
 
 html,
@@ -17,66 +51,110 @@ body {
 }
 
 body {
-  background: var(--bg);
+  /* Lume surface luminosity (§3.1): the workspace reads as condensed light. */
+  background: var(--surface-gradient);
+  background-attachment: fixed;
   color: var(--fg);
-  font-family: var(--font-text);
+  font-family: var(--font-sans);
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* Utility: numeric monospace for versions, IDs, timestamps. */
+/* Utility: tabular monospace for versions, IDs, timestamps (Geist Mono). */
 .font-mono-num {
   font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
 }
 
-/* Utility: Days One display face for headlines (byte5 brand). */
+/* Utility: structural display heading (Geist 600). Replaces the byte5
+   Days One display face — Lume headings stay structural (§2.7). */
 .font-display {
-  font-family: var(--font-display);
-  font-weight: 400;
+  font-family: var(--font-sans);
+  font-weight: 600;
   letter-spacing: -0.01em;
 }
 
-/* byte5 signature colon — magenta heavy, used inline before short phrases. */
+/* Long-form agent prose register — Source Serif 4 (§2.7). */
+.font-prose {
+  font-family: var(--font-serif);
+  font-optical-sizing: auto;
+  line-height: 1.65;
+}
+
+/* The byte5 signature magenta colon is retired (Lume has no magenta device).
+   The class is kept so existing markup stays valid, but it no longer paints a
+   brand color — it inherits text color at a structural weight. */
 .b5-colon {
-  color: var(--highlight);
-  font-weight: 900;
+  color: inherit;
+  font-weight: 600;
   margin-right: 0.35em;
 }
 
-/* Soft cyan-biased hero wash — replaces the earlier editorial grain overlay.
-   Per byte5 brand, hero panels are ALWAYS the light cyan gradient with navy
-   text, regardless of the user's system color-scheme preference. We therefore
-   lock the token values within this scope so nested elements get the correct
-   contrast even when `@media (prefers-color-scheme: dark)` has flipped the
-   :root tokens to white-on-dark values.
-   Scoped via CSS custom-property overrides — no component edits required. */
+/* ------------------------------------------------------------------------ */
+/* Lume implementation primitives (spec §3) as composable utility classes.  */
+/* ------------------------------------------------------------------------ */
+@layer components {
+  /* §3.1 Surface gradient */
+  .lume-surface {
+    background: linear-gradient(180deg, var(--bg-surface-top) 0%, var(--bg-surface-btm) 100%);
+  }
+  .lume-surface-raised {
+    background: linear-gradient(180deg, var(--bg-surface-raised-top) 0%, var(--bg-surface-raised-btm) 100%);
+    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.06) inset; /* top-edge highlight */
+  }
+  .lume-surface-sunken {
+    background: linear-gradient(180deg, var(--bg-surface-sunken-top) 0%, var(--bg-surface-sunken-btm) 100%);
+  }
+
+  /* §3.4 Directional border — top edge catches light from above */
+  .lume-border {
+    border: 1px solid var(--border-subtle-btm);
+    border-top-color: var(--border-subtle-top);
+  }
+  .lume-border-default {
+    border: 1px solid var(--border-default-btm);
+    border-top-color: var(--border-default-top);
+  }
+  .lume-border-strong {
+    border: 1px solid var(--border-strong-btm);
+    border-top-color: var(--border-strong-top);
+  }
+
+  /* §3.2 Two-stop glow — bright white-shifted core + accent-tinted corona */
+  .lume-glow {
+    box-shadow: 0 0 4px var(--accent-glow-core), 0 4px 12px var(--accent-glow);
+  }
+  .lume-glow-emphasis {
+    box-shadow: 0 0 6px var(--accent-glow-core), 0 6px 18px var(--accent-glow-strong);
+  }
+  /* Focus / selection — the two-stop glow on the focus ring */
+  .lume-focus:focus-visible {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow:
+      0 0 0 1px var(--accent),
+      0 0 6px var(--accent-glow-core),
+      0 6px 18px var(--accent-glow-strong);
+  }
+  /* Selected row / item — accent-subtle wash + soft corona (§2.5, §4) */
+  .lume-selected {
+    background: var(--accent-subtle);
+    box-shadow: 0 0 4px var(--accent-glow-core), 0 4px 12px var(--accent-glow);
+  }
+}
+
+/* Accent-washed hero / login surface. Lume keeps the agent's attention as
+   accent-tinted illumination; the byte5 cyan/navy hard-coded values are gone,
+   this now follows the active palette + mode through tokens. */
 .b5-hero-bg {
-  background: var(--surface-gradient-cyan);
-  color: #004B73;
-
-  --bg:            #FFFFFF;
-  --bg-soft:       #F4F7FA;
-  --bg-elevated:   #FFFFFF;
-
-  --fg:            #004B73;
-  --fg-strong:     #004B73;
-  --fg-muted:      #5F6E7B;
-  --fg-subtle:     #8A99A6;
-
-  --border:        #D3DDE5;
-  --border-strong: #B4C2CD;
-  --divider:       rgba(0, 75, 115, 0.12);
-
-  --accent:        #009FE3;
-  --accent-hover:  #0086C0;
-  --highlight:     #EA5172;
+  background: var(--surface-gradient-accent);
+  color: var(--fg);
 }
 
 /* ------------------------------------------------------------------------ */
 /* Markdown renderer — styles for content produced by react-markdown.       */
-/* Intentionally compact: this is a dev tool, not a blog.                    */
+/* Token-driven so it follows the Lume palette + light/dark mode.           */
 /* ------------------------------------------------------------------------ */
 .md-view {
   @apply text-sm leading-relaxed;
@@ -97,7 +175,8 @@ body {
   @apply my-3 text-base font-semibold;
 }
 .md-view h3 {
-  @apply my-2 text-sm font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400;
+  @apply my-2 text-sm font-semibold uppercase tracking-wide;
+  color: var(--fg-muted);
 }
 .md-view ul {
   @apply my-2 ml-5 list-disc space-y-1;
@@ -106,19 +185,28 @@ body {
   @apply my-2 ml-5 list-decimal space-y-1;
 }
 .md-view a {
-  @apply text-blue-600 underline underline-offset-2 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-200;
+  color: var(--accent);
+  @apply underline underline-offset-2;
+}
+.md-view a:hover {
+  color: var(--accent-hover);
 }
 .md-view code {
-  @apply rounded bg-neutral-100 px-1 py-0.5 font-mono text-[0.85em] dark:bg-neutral-800;
+  @apply rounded px-1 py-0.5 text-[0.85em];
+  font-family: var(--font-mono);
+  background: var(--bg-soft);
 }
 .md-view pre {
-  @apply my-3 overflow-x-auto rounded bg-neutral-100 p-3 text-xs dark:bg-neutral-800;
+  @apply my-3 overflow-x-auto rounded p-3 text-xs;
+  background: var(--bg-soft);
 }
 .md-view pre code {
   @apply bg-transparent p-0 text-xs;
 }
 .md-view blockquote {
-  @apply my-2 border-l-2 border-neutral-300 pl-3 text-neutral-600 dark:border-neutral-600 dark:text-neutral-400;
+  @apply my-2 pl-3;
+  border-left: 2px solid var(--border-strong);
+  color: var(--fg-muted);
 }
 /* Card-mode list (BuilderMarkdown ol-override) drops the ml-5/list-decimal
    reset so the strong leader prints flush inside the card. */
@@ -137,11 +225,29 @@ body {
 }
 .md-view th,
 .md-view td {
-  @apply border border-neutral-300 px-2 py-1 text-left align-top dark:border-neutral-700;
+  @apply px-2 py-1 text-left align-top;
+  border: 1px solid var(--border);
 }
 .md-view th {
-  @apply bg-neutral-100 font-semibold dark:bg-neutral-800;
+  @apply font-semibold;
+  background: var(--bg-soft);
 }
 .md-view hr {
-  @apply my-3 border-neutral-200 dark:border-neutral-800;
+  @apply my-3;
+  border-color: var(--divider);
+}
+
+/* ------------------------------------------------------------------------ */
+/* Reduced motion (spec §2.11). Collapse animation/transition for users who   */
+/* request it — any new Lume motion degrades to a plain fade or nothing.      */
+/* ------------------------------------------------------------------------ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/web-ui/app/globals.css
+++ b/web-ui/app/globals.css
@@ -190,6 +190,46 @@ body {
     animation: lume-condense var(--motion-condense) var(--easing-emphasis) both;
   }
 
+  /* §7.3 button-in-flight — the single spinner exception: verb + animated
+     dots. No spinner glyph, no spinning ring. Period. */
+  .lume-busy-dots::after {
+    content: '.';
+    display: inline-block;
+    width: 1.2em;
+    text-align: left;
+    animation: lume-dots 1.2s steps(1, end) infinite;
+  }
+
+  /* §4.2 list/tree — full selection recipe: the row is a lit pocket; the
+     accent left bar is the edge of the pocket, not a paint stroke. */
+  .lume-selected {
+    position: relative;
+    background:
+      radial-gradient(ellipse at 30% 50%, var(--accent-glow-core) 0%, var(--accent-glow) 20%, transparent 70%),
+      linear-gradient(180deg, var(--accent-subtle), transparent);
+    box-shadow:
+      0 0 12px -2px var(--accent-glow-core),
+      0 0 24px -6px var(--accent-glow-strong);
+  }
+  .lume-selected::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 4px;
+    bottom: 4px;
+    width: 2px;
+    background: var(--accent);
+    border-radius: 2px;
+    box-shadow: 0 0 6px var(--accent-glow-strong);
+  }
+
+  /* §6.7 drop target — 2px dashed accent, fades in over motion.quick. */
+  .lume-drop-target {
+    outline: 2px dashed var(--accent);
+    outline-offset: 2px;
+    transition: outline-color var(--motion-quick) var(--easing-standard);
+  }
+
   /* §4.2 tabs — the active tab's underline is lit, not just colored. */
   .lume-tab-active {
     position: relative;
@@ -234,6 +274,18 @@ body {
       0 0 0 4px var(--accent-glow),
       0 0 16px var(--accent-glow-core),
       0 12px 40px var(--accent-glow-strong);
+  }
+}
+
+@keyframes lume-dots {
+  0% {
+    content: '.';
+  }
+  33% {
+    content: '..';
+  }
+  66% {
+    content: '...';
   }
 }
 
@@ -532,6 +584,18 @@ summary:focus-visible,
 [tabindex]:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--accent), 0 0 0 6px var(--accent-glow);
+}
+
+/* ---- Tables (§4.2): sunken header, accent-washed row hover, aria-sort ---- */
+table:not(.md-view table) thead th {
+  background: linear-gradient(180deg, var(--bg-surface-sunken-top) 0%, var(--bg-surface-sunken-btm) 100%);
+}
+table:not(.md-view table) tbody tr:hover {
+  background: var(--accent-subtle);
+}
+th[aria-sort='ascending'],
+th[aria-sort='descending'] {
+  color: var(--accent); /* sort-active header: accent text, no glow (§4.2) */
 }
 
 /* ---- Text selection: a lit pocket ----------------------------------------- */

--- a/web-ui/app/globals.css
+++ b/web-ui/app/globals.css
@@ -182,13 +182,73 @@ body {
     animation: lume-shimmer 1.6s var(--easing-linear) infinite;
   }
 
-  /* §3.5 / §6.1 — content materialisation (condensation, single-component
-     web variant): opacity + scale(1.03) + blur(2px) → settled, 800ms,
-     front-loaded (≈90% visible at 40%). Applied to newly-arrived agent
-     content (chat messages, materialised cards). */
+  /* §3.5 / §6.1 — patch condensation, all three components:
+     1. content materialisation (opacity/scale/blur, front-loaded),
+     2. bloom collapse (radial accent pulse converging onto the content),
+     3. sweep bar (1px accent stroke laying down the content's bottom edge).
+     Reduced-motion drops 2+3 and collapses 1 to a plain fade (global rule).
+     Rapid-stream throttling (>5 patches/s, §3.5) is N/A at chat cadence —
+     each message node mounts exactly once. */
   .lume-condense {
+    position: relative;
     animation: lume-condense var(--motion-condense) var(--easing-emphasis) both;
   }
+  .lume-condense::before {
+    /* bloom collapse — light converging onto the new content */
+    content: '';
+    position: absolute;
+    inset: -10%;
+    pointer-events: none;
+    border-radius: inherit;
+    background: radial-gradient(ellipse at center, var(--accent-glow-strong) 0%, transparent 70%);
+    animation: lume-bloom var(--motion-condense) var(--easing-emphasis) both;
+  }
+  .lume-condense::after {
+    /* sweep bar — the agent's stroke along the bottom edge */
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 1px;
+    pointer-events: none;
+    background: var(--accent);
+    box-shadow: 0 0 4px var(--accent-glow);
+    transform-origin: left;
+    animation: lume-sweep 500ms var(--easing-emphasis) both;
+  }
+
+  /* §3.3 donut glow — for surfaces with a centered glyph: the glyph sits in
+     a clean accent-subtle pocket, the bright ring radiates outward (a lit
+     lampshade, not a bulb). Used by wizard current-step dots (§5.2),
+     center-glyph chips, active tool buttons. */
+  .lume-donut {
+    background: radial-gradient(
+      circle at center,
+      var(--accent-subtle) 0%,
+      var(--accent-subtle) 35%,
+      var(--accent-glow-core) 75%,
+      transparent 100%
+    );
+    box-shadow:
+      0 0 12px var(--accent-glow-core),
+      0 0 22px -4px var(--accent-glow-strong);
+  }
+
+  /* §2.7 type scale — the structural/prose/mono registers as composable
+     classes. Components adopt them in place of ad-hoc text-* stacks. */
+  .type-display       { font-size: 1.75rem;   line-height: 1.2;  font-weight: 600; letter-spacing: -0.01em; }
+  .type-heading-1     { font-size: 1.375rem;  line-height: 1.25; font-weight: 600; letter-spacing: -0.005em; }
+  .type-heading-2     { font-size: 1.125rem;  line-height: 1.3;  font-weight: 600; }
+  .type-heading-3     { font-size: 0.9375rem; line-height: 1.35; font-weight: 600; }
+  .type-body          { font-size: 0.875rem;  line-height: 1.5;  font-weight: 400; }
+  .type-body-strong   { font-size: 0.875rem;  line-height: 1.5;  font-weight: 600; }
+  .type-body-compact  { font-size: 0.8125rem; line-height: 1.45; font-weight: 400; }
+  .type-caption       { font-size: 0.75rem;   line-height: 1.4;  font-weight: 400; letter-spacing: 0.005em; }
+  .type-caption-strong{ font-size: 0.75rem;   line-height: 1.4;  font-weight: 600; letter-spacing: 0.02em; }
+  .type-prose         { font-family: var(--font-serif); font-optical-sizing: auto; font-size: 1rem; line-height: 1.65; font-weight: 400; }
+  .type-mono-data     { font-family: var(--font-mono); font-size: 0.8125rem; line-height: 1.45; font-weight: 450; font-feature-settings: 'tnum'; }
+  .type-mono-code     { font-family: var(--font-mono); font-size: 0.8125rem; line-height: 1.55; font-weight: 400; }
 
   /* §7.3 button-in-flight — the single spinner exception: verb + animated
      dots. No spinner glyph, no spinning ring. Period. */
@@ -316,6 +376,32 @@ body {
   }
 }
 
+@keyframes lume-bloom {
+  0% {
+    opacity: 1;
+    transform: scale(1.2);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+}
+
+@keyframes lume-sweep {
+  0% {
+    opacity: 1;
+    transform: scaleX(0);
+  }
+  70% {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+  100% {
+    opacity: 0;
+    transform: scaleX(1);
+  }
+}
+
 /* Accent-washed hero / login surface. Lume keeps the agent's attention as
    accent-tinted illumination; the byte5 cyan/navy hard-coded values are gone,
    this now follows the active palette + mode through tokens. */
@@ -351,10 +437,10 @@ body {
   color: var(--fg-muted);
 }
 .md-view ul {
-  @apply my-2 ml-5 list-disc space-y-1;
+  @apply my-2 ml-4 list-disc space-y-1;
 }
 .md-view ol {
-  @apply my-2 ml-5 list-decimal space-y-1;
+  @apply my-2 ml-4 list-decimal space-y-1;
 }
 .md-view a {
   color: var(--accent);
@@ -382,7 +468,7 @@ body {
   border-left: 2px solid var(--border-strong);
   color: var(--fg-muted);
 }
-/* Card-mode list (BuilderMarkdown ol-override) drops the ml-5/list-decimal
+/* Card-mode list (BuilderMarkdown ol-override) drops the ml-4/list-decimal
    reset so the strong leader prints flush inside the card. */
 .md-view-card > p:first-child {
   margin-top: 0;

--- a/web-ui/app/globals.css
+++ b/web-ui/app/globals.css
@@ -288,6 +288,33 @@ body {
   box-shadow: 0 1px 0 rgba(255, 255, 255, 0.06) inset;
 }
 
+/* ---- Translucent cards: the `/40` wash keeps its transparency but gains
+   the gradient (color-mix folds the alpha into each stop). This is the most
+   frequent card pattern in the app. ---------------------------------------- */
+[class^='bg-[color:var(--card)]/'],
+[class*=' bg-[color:var(--card)]/'] {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--bg-surface-raised-top) 55%, transparent) 0%,
+    color-mix(in srgb, var(--bg-surface-raised-btm) 55%, transparent) 100%
+  );
+  border-color: var(--border-subtle-btm);
+  border-top-color: var(--border-subtle-top);
+}
+
+/* ---- Directional borders everywhere (§2.4): upgrade the flat token border
+   to the top-lit pair wherever components draw a full border. -------------- */
+[class^='border-[color:var(--border)]'],
+[class*=' border-[color:var(--border)]'] {
+  border-color: var(--border-subtle-btm);
+  border-top-color: var(--border-subtle-top);
+}
+[class^='border-[color:var(--border-strong)]'],
+[class*=' border-[color:var(--border-strong)]'] {
+  border-color: var(--border-default-btm);
+  border-top-color: var(--border-default-top);
+}
+
 /* ---- Sunken surfaces (depth 4+): bg-soft / surface-muted / bg-subtle ----- */
 [class^='bg-[color:var(--bg-soft)]']:not([class*='bg-[color:var(--bg-soft)]/']),
 [class*=' bg-[color:var(--bg-soft)]']:not([class*='bg-[color:var(--bg-soft)]/']),

--- a/web-ui/app/globals.css
+++ b/web-ui/app/globals.css
@@ -90,6 +90,28 @@ body {
   line-height: 1.65;
 }
 
+/* §2.7 prose-vs-structure protocol applied to rendered agent markdown:
+   narration reads in the prose register (type.prose — 1rem/1.65, serif with
+   optical sizing); headings, tables and code stay structural/mono — they are
+   structural elements even inside a prose pane. */
+.lume-prose .md-view {
+  font-family: var(--font-serif);
+  font-optical-sizing: auto;
+  font-size: 1rem;
+  line-height: 1.65;
+}
+.lume-prose .md-view h1,
+.lume-prose .md-view h2,
+.lume-prose .md-view h3,
+.lume-prose .md-view table,
+.lume-prose .md-view th,
+.lume-prose .md-view td {
+  font-family: var(--font-sans);
+}
+.lume-prose .md-view table {
+  font-size: 0.75rem; /* type.caption — data stays compact */
+}
+
 /* ------------------------------------------------------------------------ */
 /* Lume implementation primitives (spec §3) as composable utility classes.  */
 /* ------------------------------------------------------------------------ */

--- a/web-ui/app/globals.css
+++ b/web-ui/app/globals.css
@@ -38,6 +38,14 @@
   --radius-sm: var(--radius-sm);
   --radius-md: var(--radius-md);
   --radius-lg: var(--radius-lg);
+
+  /* Elevation (§2.10): route the stock shadow-sm/md/lg utilities through the
+     Lume elevation tokens, so every existing `shadow-md` popover and
+     `shadow-lg` modal in the codebase gets elev.popover / elev.modal
+     (including the accent-glow components) without per-component edits. */
+  --shadow-sm: var(--shadow-sm);
+  --shadow-md: var(--shadow-md);
+  --shadow-lg: var(--shadow-lg);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -132,6 +140,105 @@ body {
   .lume-selected {
     background: var(--accent-subtle);
     box-shadow: 0 0 4px var(--accent-glow-core), 0 4px 12px var(--accent-glow);
+  }
+}
+
+/* ------------------------------------------------------------------------ */
+/* Lume per-primitive recipes (§3.5, §4.2, §5.3, §7.2)                       */
+/* ------------------------------------------------------------------------ */
+@layer components {
+  /* §7.2 / §3.5 — skeleton: state.loading gradient with a linear shimmer.
+     Replaces opacity-pulse skeletons; reduced-motion freezes to static fill. */
+  .lume-skeleton {
+    background: linear-gradient(
+      100deg,
+      var(--state-loading) 35%,
+      var(--state-loading-hi) 50%,
+      var(--state-loading) 65%
+    );
+    background-size: 220% 100%;
+    animation: lume-shimmer 1.6s var(--easing-linear) infinite;
+  }
+
+  /* §3.5 / §6.1 — content materialisation (condensation, single-component
+     web variant): opacity + scale(1.03) + blur(2px) → settled, 800ms,
+     front-loaded (≈90% visible at 40%). Applied to newly-arrived agent
+     content (chat messages, materialised cards). */
+  .lume-condense {
+    animation: lume-condense var(--motion-condense) var(--easing-emphasis) both;
+  }
+
+  /* §4.2 tabs — the active tab's underline is lit, not just colored. */
+  .lume-tab-active {
+    position: relative;
+    color: var(--fg-strong);
+  }
+  .lume-tab-active::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -1px;
+    height: 2px;
+    border-radius: 2px;
+    background: var(--accent);
+    box-shadow:
+      0 1px 6px var(--accent-glow),
+      0 0 4px var(--accent-glow-core);
+  }
+
+  /* §5.3 Spotlight — the composer stage: a radial accent-glow behind the
+     input leads the eye before the user reads it. The input itself gets the
+     three-stop showcase glow on focus. */
+  .lume-spotlight-stage {
+    position: relative;
+  }
+  .lume-spotlight-stage::before {
+    content: '';
+    position: absolute;
+    inset: -24px -12px -16px;
+    pointer-events: none;
+    background: radial-gradient(ellipse at 50% 60%, var(--accent-glow) 0%, transparent 65%);
+    opacity: 0.5;
+    transition: opacity var(--motion-smooth) var(--easing-standard);
+  }
+  .lume-spotlight-stage:focus-within::before {
+    opacity: 1;
+  }
+  .lume-spotlight-stage textarea:focus,
+  .lume-spotlight-stage input:focus {
+    border-color: var(--accent);
+    box-shadow:
+      0 0 0 4px var(--accent-glow),
+      0 0 16px var(--accent-glow-core),
+      0 12px 40px var(--accent-glow-strong);
+  }
+}
+
+@keyframes lume-shimmer {
+  from {
+    background-position: 120% 0;
+  }
+  to {
+    background-position: -120% 0;
+  }
+}
+
+@keyframes lume-condense {
+  0% {
+    opacity: 0;
+    transform: scale(1.03);
+    filter: blur(2px);
+  }
+  40% {
+    opacity: 0.92;
+    transform: scale(1.004);
+    filter: blur(0.3px);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+    filter: blur(0);
   }
 }
 

--- a/web-ui/app/graph/_components/DetailPanel.tsx
+++ b/web-ui/app/graph/_components/DetailPanel.tsx
@@ -40,8 +40,8 @@ export default function DetailPanel({
     ([, v]) => v !== null && v !== undefined && v !== '',
   );
   return (
-    <aside className="flex w-96 shrink-0 flex-col border-l border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900">
-      <div className="flex items-center gap-2 border-b border-neutral-200 px-3 py-2 text-xs dark:border-neutral-800">
+    <aside className="flex w-96 shrink-0 flex-col border-l border-[color:var(--border)] bg-[color:var(--bg-elevated)]">
+      <div className="flex items-center gap-2 border-b border-[color:var(--border)] px-3 py-2 text-xs">
         <span
           className="h-2.5 w-2.5 rounded-full"
           style={{ backgroundColor: nodeColor(node.type) }}
@@ -59,7 +59,7 @@ export default function DetailPanel({
         ) : null}
         {node.type === 'Turn' && node.manuallyAuthored ? (
           <span
-            className="rounded-full bg-amber-500/20 px-2 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400"
+            className="rounded-full bg-[color:var(--warning)]/100/20 px-2 py-0.5 text-[10px] font-medium text-[color:var(--warning)]"
             title="manuell erfasst — Score-Boost ×1.3 im Token-Budget-Assembler"
           >
             ✎ manual
@@ -68,25 +68,25 @@ export default function DetailPanel({
         <button
           type="button"
           onClick={onClose}
-          className="ml-auto rounded border border-neutral-300 px-2 py-0.5 hover:border-neutral-400 dark:border-neutral-700"
+          className="ml-auto rounded border border-[color:var(--border)] px-2 py-0.5 hover:border-[color:var(--border-strong)]"
         >
           ×
         </button>
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto p-3 text-xs">
-        <div className="mb-3 break-all font-mono text-[10px] text-neutral-500">
+        <div className="mb-3 break-all font-mono text-[10px] text-[color:var(--fg-muted)]">
           {node.id}
         </div>
         <div className="mb-3 flex flex-col gap-1">
           {propEntries.map(([k, v]) => (
             <div
               key={k}
-              className="flex items-start gap-2 border-b border-neutral-100 pb-1 last:border-0 dark:border-neutral-800"
+              className="flex items-start gap-2 border-b border-[color:var(--border)] pb-1 last:border-0"
             >
-              <span className="w-24 shrink-0 font-mono text-[10px] uppercase tracking-wide text-neutral-400">
+              <span className="w-24 shrink-0 font-mono text-[10px] uppercase tracking-wide text-[color:var(--fg-subtle)]">
                 {k}
               </span>
-              <span className="min-w-0 break-words text-neutral-700 dark:text-neutral-300">
+              <span className="min-w-0 break-words text-[color:var(--fg)]">
                 {formatValue(v)}
               </span>
             </div>
@@ -96,7 +96,7 @@ export default function DetailPanel({
           type="button"
           onClick={() => onExpand(node.id)}
           disabled={loadingNeighbors}
-          className="w-full rounded border border-neutral-300 px-2 py-1 text-[11px] font-semibold hover:border-neutral-400 disabled:opacity-50 dark:border-neutral-700"
+          className="w-full rounded border border-[color:var(--border)] px-2 py-1 text-[11px] font-semibold hover:border-[color:var(--border-strong)] disabled:opacity-50"
         >
           {loadingNeighbors ? 'lade Nachbarn…' : '↔ Nachbarn expandieren'}
         </button>
@@ -114,7 +114,7 @@ export default function DetailPanel({
 
         {neighbors && neighbors.length > 0 && (
           <div className="mt-3">
-            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-neutral-400">
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-[color:var(--fg-subtle)]">
               {neighbors.length} Nachbar{neighbors.length === 1 ? '' : 'n'}
             </div>
             <div className="flex flex-col gap-1">
@@ -123,14 +123,14 @@ export default function DetailPanel({
                   key={n.id}
                   type="button"
                   onClick={() => onSelect(n)}
-                  className="flex items-start gap-2 rounded border border-neutral-200 px-2 py-1 text-left hover:border-neutral-400 dark:border-neutral-700 dark:hover:border-neutral-500"
+                  className="flex items-start gap-2 rounded border border-[color:var(--border)] px-2 py-1 text-left hover:border-[color:var(--border-strong)]"
                 >
                   <span
                     className="mt-1 h-2 w-2 shrink-0 rounded-full"
                     style={{ backgroundColor: nodeColor(n.type) }}
                   />
                   <span className="min-w-0">
-                    <span className="block font-mono text-[10px] text-neutral-500">
+                    <span className="block font-mono text-[10px] text-[color:var(--fg-muted)]">
                       {nodeIcon(n.type)} {n.type}
                     </span>
                     <span className="block truncate">
@@ -177,9 +177,9 @@ function TierBadge({
   accessCount?: number;
 }): React.ReactElement {
   const palette: Record<Tier, string> = {
-    HOT: 'bg-cyan-500/20 text-cyan-600 dark:text-cyan-400',
-    WARM: 'bg-amber-500/20 text-amber-600 dark:text-amber-400',
-    COLD: 'bg-neutral-500/20 text-neutral-600 dark:text-neutral-400',
+    HOT: 'bg-[color:var(--accent)]/100/20 text-[color:var(--accent)]',
+    WARM: 'bg-[color:var(--warning)]/100/20 text-[color:var(--warning)]',
+    COLD: 'bg-[color:var(--fg-subtle)]/20 text-[color:var(--fg-muted)]',
   };
   const tooltipParts: string[] = [`tier=${tier}`];
   if (typeof decayScore === 'number') {
@@ -222,8 +222,8 @@ function ProvenanceSection({
       ? 'Lvl 2 · Session'
       : 'Lvl 2 · Turn / User / Entitäten';
   return (
-    <div className="mt-3 rounded border border-fuchsia-200 bg-fuchsia-50/50 p-2 dark:border-fuchsia-800/60 dark:bg-fuchsia-900/10">
-      <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-fuchsia-700 dark:text-fuchsia-300">
+    <div className="mt-3 rounded border border-[color:var(--accent)] bg-[color:var(--accent)]/10 p-2">
+      <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-[color:var(--accent)]">
         Provenance (2 Hops)
       </div>
       <ProvenanceList label={lvl1Label} nodes={provenance.level1} onSelect={onSelect} />
@@ -244,16 +244,16 @@ function ProvenanceList({
   if (nodes.length === 0) {
     return (
       <div className="mt-1">
-        <div className="text-[10px] uppercase tracking-wide text-neutral-400">
+        <div className="text-[10px] uppercase tracking-wide text-[color:var(--fg-subtle)]">
           {label}
         </div>
-        <div className="text-[11px] italic text-neutral-400">keine</div>
+        <div className="text-[11px] italic text-[color:var(--fg-subtle)]">keine</div>
       </div>
     );
   }
   return (
     <div className="mt-1">
-      <div className="text-[10px] uppercase tracking-wide text-neutral-400">
+      <div className="text-[10px] uppercase tracking-wide text-[color:var(--fg-subtle)]">
         {label}
       </div>
       <div className="mt-1 flex flex-col gap-1">
@@ -262,14 +262,14 @@ function ProvenanceList({
             key={n.id}
             type="button"
             onClick={() => onSelect(n)}
-            className="flex items-start gap-2 rounded border border-neutral-200 bg-white px-2 py-1 text-left hover:border-fuchsia-400 dark:border-neutral-700 dark:bg-neutral-900 dark:hover:border-fuchsia-500"
+            className="flex items-start gap-2 rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-2 py-1 text-left hover:border-[color:var(--accent)]"
           >
             <span
               className="mt-1 h-2 w-2 shrink-0 rounded-full"
               style={{ backgroundColor: nodeColor(n.type) }}
             />
             <span className="min-w-0">
-              <span className="block font-mono text-[10px] text-neutral-500">
+              <span className="block font-mono text-[10px] text-[color:var(--fg-muted)]">
                 {nodeIcon(n.type)} {n.type}
               </span>
               <span className="block truncate">

--- a/web-ui/app/graph/_components/DetailPanel.tsx
+++ b/web-ui/app/graph/_components/DetailPanel.tsx
@@ -59,7 +59,7 @@ export default function DetailPanel({
         ) : null}
         {node.type === 'Turn' && node.manuallyAuthored ? (
           <span
-            className="rounded-full bg-[color:var(--warning)]/100/20 px-2 py-0.5 text-[10px] font-medium text-[color:var(--warning)]"
+            className="px-2 py-0.5 text-[10px] font-medium text-[color:var(--warning)]"
             title="manuell erfasst — Score-Boost ×1.3 im Token-Budget-Assembler"
           >
             ✎ manual
@@ -177,8 +177,8 @@ function TierBadge({
   accessCount?: number;
 }): React.ReactElement {
   const palette: Record<Tier, string> = {
-    HOT: 'bg-[color:var(--accent)]/100/20 text-[color:var(--accent)]',
-    WARM: 'bg-[color:var(--warning)]/100/20 text-[color:var(--warning)]',
+    HOT: 'bg-[color:var(--accent)]/20 text-[color:var(--accent)]',
+    WARM: 'bg-[color:var(--warning)]/20 text-[color:var(--warning)]',
     COLD: 'bg-[color:var(--fg-subtle)]/20 text-[color:var(--fg-muted)]',
   };
   const tooltipParts: string[] = [`tier=${tier}`];

--- a/web-ui/app/graph/_components/GraphCanvas.tsx
+++ b/web-ui/app/graph/_components/GraphCanvas.tsx
@@ -912,7 +912,7 @@ export default function GraphCanvas({
       />
       <div className="pointer-events-none absolute inset-0 flex items-start justify-between p-3">
         <Legend dark={dark} filter={filter} />
-        <div className="pointer-events-auto flex flex-col gap-1.5 rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-elevated)]/90 p-1.5 shadow-sm backdrop-blur">
+        <div className="pointer-events-auto flex flex-col gap-2 rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-elevated)]/90 p-2 shadow-sm backdrop-blur">
           <IconBtn title="Zoom in" onClick={zoomIn}>＋</IconBtn>
           <IconBtn title="Zoom out" onClick={zoomOut}>−</IconBtn>
           <IconBtn title="Fit" onClick={fit}>⤢</IconBtn>
@@ -1013,7 +1013,7 @@ function Legend({
   return (
     <div
       className={[
-        'pointer-events-auto flex flex-col gap-1 rounded-lg border px-2 py-1.5 text-[10px] shadow-sm backdrop-blur',
+        'pointer-events-auto flex flex-col gap-1 rounded-lg border px-2 py-2 text-[10px] shadow-sm backdrop-blur',
         dark
           ? 'border-[color:var(--border-strong)] bg-[color:var(--bg-inverse)]/80 text-[color:var(--fg-subtle)]'
           : 'border-[color:var(--border)] bg-[color:var(--bg-elevated)]/90 text-[color:var(--fg-muted)]',

--- a/web-ui/app/graph/_components/GraphCanvas.tsx
+++ b/web-ui/app/graph/_components/GraphCanvas.tsx
@@ -912,7 +912,7 @@ export default function GraphCanvas({
       />
       <div className="pointer-events-none absolute inset-0 flex items-start justify-between p-3">
         <Legend dark={dark} filter={filter} />
-        <div className="pointer-events-auto flex flex-col gap-1.5 rounded-lg border border-[color:var(--border)] bg-white/90 p-1.5 shadow-sm backdrop-blur">
+        <div className="pointer-events-auto flex flex-col gap-1.5 rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-elevated)]/90 p-1.5 shadow-sm backdrop-blur">
           <IconBtn title="Zoom in" onClick={zoomIn}>＋</IconBtn>
           <IconBtn title="Zoom out" onClick={zoomOut}>−</IconBtn>
           <IconBtn title="Fit" onClick={fit}>⤢</IconBtn>
@@ -1016,7 +1016,7 @@ function Legend({
         'pointer-events-auto flex flex-col gap-1 rounded-lg border px-2 py-1.5 text-[10px] shadow-sm backdrop-blur',
         dark
           ? 'border-[color:var(--border-strong)] bg-[color:var(--bg-inverse)]/80 text-[color:var(--fg-subtle)]'
-          : 'border-[color:var(--border)] bg-white/90 text-[color:var(--fg-muted)]',
+          : 'border-[color:var(--border)] bg-[color:var(--bg-elevated)]/90 text-[color:var(--fg-muted)]',
       ].join(' ')}
     >
       {items.map(([t, label]) => (

--- a/web-ui/app/graph/_components/GraphCanvas.tsx
+++ b/web-ui/app/graph/_components/GraphCanvas.tsx
@@ -912,7 +912,7 @@ export default function GraphCanvas({
       />
       <div className="pointer-events-none absolute inset-0 flex items-start justify-between p-3">
         <Legend dark={dark} filter={filter} />
-        <div className="pointer-events-auto flex flex-col gap-1.5 rounded-lg border border-neutral-200 bg-white/90 p-1.5 shadow-sm backdrop-blur dark:border-neutral-700 dark:bg-neutral-900/80">
+        <div className="pointer-events-auto flex flex-col gap-1.5 rounded-lg border border-[color:var(--border)] bg-white/90 p-1.5 shadow-sm backdrop-blur">
           <IconBtn title="Zoom in" onClick={zoomIn}>＋</IconBtn>
           <IconBtn title="Zoom out" onClick={zoomOut}>−</IconBtn>
           <IconBtn title="Fit" onClick={fit}>⤢</IconBtn>
@@ -920,11 +920,11 @@ export default function GraphCanvas({
         </div>
       </div>
       {elements.length === 0 && (
-        <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-sm text-neutral-500">
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-sm text-[color:var(--fg-muted)]">
           keine Knoten — Session links wählen oder Filter anpassen
         </div>
       )}
-      <div className="pointer-events-none absolute bottom-2 left-3 text-[10px] text-neutral-500">
+      <div className="pointer-events-none absolute bottom-2 left-3 text-[10px] text-[color:var(--fg-muted)]">
         Klick = Auswählen · Doppelklick = Nachbarn laden · Rad = Zoom · Ziehen = Pan
       </div>
     </div>
@@ -945,7 +945,7 @@ function IconBtn({
       type="button"
       title={title}
       onClick={onClick}
-      className="flex h-7 w-7 items-center justify-center rounded font-mono text-sm text-neutral-600 hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-neutral-800"
+      className="flex h-7 w-7 items-center justify-center rounded font-mono text-sm text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)]"
     >
       {children}
     </button>
@@ -1015,8 +1015,8 @@ function Legend({
       className={[
         'pointer-events-auto flex flex-col gap-1 rounded-lg border px-2 py-1.5 text-[10px] shadow-sm backdrop-blur',
         dark
-          ? 'border-neutral-700 bg-neutral-900/80 text-neutral-300'
-          : 'border-neutral-200 bg-white/90 text-neutral-600',
+          ? 'border-[color:var(--border-strong)] bg-[color:var(--bg-inverse)]/80 text-[color:var(--fg-subtle)]'
+          : 'border-[color:var(--border)] bg-white/90 text-[color:var(--fg-muted)]',
       ].join(' ')}
     >
       {items.map(([t, label]) => (
@@ -1028,7 +1028,7 @@ function Legend({
           <span>{label}</span>
         </div>
       ))}
-      <div className="my-1 h-px bg-neutral-300/50 dark:bg-neutral-700/60" />
+      <div className="my-1 h-px bg-[color:var(--state-loading)]/50" />
       {edgeRows.map(([color, label]) => (
         <div key={label} className="flex items-center gap-2">
           <span

--- a/web-ui/app/graph/_components/ListView.tsx
+++ b/web-ui/app/graph/_components/ListView.tsx
@@ -68,19 +68,19 @@ function TurnCard({
   };
 
   return (
-    <div className="rounded-lg border border-neutral-200 bg-white p-4 text-sm shadow-sm dark:border-neutral-700 dark:bg-neutral-800">
-      <div className="mb-2 flex items-center gap-3 text-[11px] text-neutral-500">
+    <div className="rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-4 text-sm shadow-sm">
+      <div className="mb-2 flex items-center gap-3 text-[11px] text-[color:var(--fg-muted)]">
         <span className="font-mono">{time}</span>
         {tools !== undefined && <span>tools={String(tools)}</span>}
         <button
           type="button"
           onClick={toggle}
-          className="ml-auto rounded border border-neutral-300 px-2 py-0.5 font-mono hover:border-neutral-400 dark:border-neutral-700"
+          className="ml-auto rounded border border-[color:var(--border)] px-2 py-0.5 font-mono hover:border-[color:var(--border-strong)]"
         >
           {open ? '▾' : '▸'} Run-Trace
         </button>
       </div>
-      <div className="mb-2 whitespace-pre-wrap text-neutral-800 dark:text-neutral-200">
+      <div className="mb-2 whitespace-pre-wrap text-[color:var(--fg)]">
         {user}
       </div>
       {entities.length > 0 ? (
@@ -93,8 +93,8 @@ function TurnCard({
               className={[
                 'rounded-full px-2 py-0.5 font-mono text-[11px] transition',
                 e.type === 'ConfluencePage'
-                  ? 'bg-blue-50 text-blue-900 ring-1 ring-blue-200 hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-100 dark:ring-blue-800'
-                  : 'bg-emerald-50 text-emerald-900 ring-1 ring-emerald-200 hover:bg-emerald-100 dark:bg-emerald-900/30 dark:text-emerald-100 dark:ring-emerald-800',
+                  ? 'bg-[color:var(--accent)]/10 text-[color:var(--accent)] ring-1 ring-[color:var(--accent)] hover:bg-[color:var(--accent)]/10'
+                  : 'bg-[color:var(--success)]/10 text-[color:var(--success)] ring-1 ring-[color:var(--success)] hover:bg-[color:var(--success)]/10',
               ].join(' ')}
               title={e.id}
             >
@@ -103,17 +103,17 @@ function TurnCard({
           ))}
         </div>
       ) : (
-        <div className="text-[11px] text-neutral-400">
+        <div className="text-[11px] text-[color:var(--fg-subtle)]">
           keine Entities in diesem Turn
         </div>
       )}
       {open && (
-        <div className="mt-3 border-t border-neutral-200 pt-3 dark:border-neutral-700">
+        <div className="mt-3 border-t border-[color:var(--border)] pt-3">
           {runState === 'loading' && (
-            <div className="text-[11px] text-neutral-500">lade Run…</div>
+            <div className="text-[11px] text-[color:var(--fg-muted)]">lade Run…</div>
           )}
           {runState === 'missing' && (
-            <div className="text-[11px] text-neutral-500">
+            <div className="text-[11px] text-[color:var(--fg-muted)]">
               keine Run-Trace erfasst
             </div>
           )}
@@ -140,7 +140,7 @@ function RunTracePanel({
 
   return (
     <div className="flex flex-col gap-2 text-xs">
-      <div className="flex items-center gap-2 font-mono text-[11px] text-neutral-500">
+      <div className="flex items-center gap-2 font-mono text-[11px] text-[color:var(--fg-muted)]">
         <StatusPill status={status} />
         <span>{formatMs(duration)}</span>
         <span>·</span>
@@ -154,8 +154,8 @@ function RunTracePanel({
       </div>
 
       {run.orchestratorToolCalls.length > 0 && (
-        <div className="flex flex-col gap-1 rounded border border-neutral-200 bg-neutral-50 p-2 dark:border-neutral-700 dark:bg-neutral-900/40">
-          <div className="text-[10px] font-semibold uppercase tracking-wide text-neutral-400">
+        <div className="flex flex-col gap-1 rounded border border-[color:var(--border)] bg-[color:var(--bg-soft)] p-2">
+          <div className="text-[10px] font-semibold uppercase tracking-wide text-[color:var(--fg-subtle)]">
             Orchestrator-Tools
           </div>
           {run.orchestratorToolCalls.map((tc) => (
@@ -179,18 +179,18 @@ function RunTracePanel({
             className={[
               'flex flex-col gap-1 rounded border p-2',
               invStatus === 'error'
-                ? 'border-red-200 bg-red-50 dark:border-red-900/60 dark:bg-red-900/20'
-                : 'border-emerald-200 bg-emerald-50 dark:border-emerald-900/60 dark:bg-emerald-900/20',
+                ? 'border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8'
+                : 'border-[color:var(--success)] bg-[color:var(--success)]/10',
             ].join(' ')}
           >
             <div className="flex items-center gap-2 font-mono text-[11px]">
               <StatusPill status={invStatus} />
               <span className="font-semibold">🤖 {agentName}</span>
-              <span className="text-neutral-500">{formatMs(invDur)}</span>
-              <span className="text-neutral-500">·</span>
-              <span className="text-neutral-500">{subIter} iter</span>
-              <span className="text-neutral-500">·</span>
-              <span className="text-neutral-500">
+              <span className="text-[color:var(--fg-muted)]">{formatMs(invDur)}</span>
+              <span className="text-[color:var(--fg-muted)]">·</span>
+              <span className="text-[color:var(--fg-muted)]">{subIter} iter</span>
+              <span className="text-[color:var(--fg-muted)]">·</span>
+              <span className="text-[color:var(--fg-muted)]">
                 {inv.toolCalls.length} tool-call
                 {inv.toolCalls.length === 1 ? '' : 's'}
               </span>
@@ -212,7 +212,7 @@ function RunTracePanel({
 
       {run.orchestratorToolCalls.length === 0 &&
         run.agentInvocations.length === 0 && (
-          <div className="text-[11px] italic text-neutral-400">
+          <div className="text-[11px] italic text-[color:var(--fg-subtle)]">
             Run ohne Tool-Calls (reine Textantwort)
           </div>
         )}
@@ -234,21 +234,21 @@ function ToolCallRow({
     <div className="flex flex-wrap items-center gap-2 font-mono text-[11px]">
       <span
         className={
-          isError ? 'text-red-600' : 'text-neutral-700 dark:text-neutral-300'
+          isError ? 'text-[color:var(--danger)]' : 'text-[color:var(--fg)]'
         }
       >
         {isError ? '⚠' : '🔧'} {toolName}
       </span>
-      <span className="text-neutral-500">{formatMs(durationMs)}</span>
+      <span className="text-[color:var(--fg-muted)]">{formatMs(durationMs)}</span>
       {tc.producedEntities.length > 0 && (
         <span className="flex flex-wrap items-center gap-1">
-          <span className="text-neutral-400">↳</span>
+          <span className="text-[color:var(--fg-subtle)]">↳</span>
           {tc.producedEntities.map((e) => (
             <button
               key={e.id}
               type="button"
               onClick={() => onEntityClick(e.id)}
-              className="rounded bg-emerald-50 px-1.5 py-0.5 text-emerald-900 ring-1 ring-emerald-200 hover:bg-emerald-100 dark:bg-emerald-900/30 dark:text-emerald-100 dark:ring-emerald-800"
+              className="rounded bg-[color:var(--success)]/10 px-1.5 py-0.5 text-[color:var(--success)] ring-1 ring-[color:var(--success)] hover:bg-[color:var(--success)]/10"
               title={e.id}
             >
               {String(e.props['displayName'] ?? e.id)}
@@ -263,20 +263,20 @@ function ToolCallRow({
 function StatusPill({ status }: { status: string }): React.ReactElement {
   if (status === 'success') {
     return (
-      <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-semibold text-emerald-900 dark:bg-emerald-900/50 dark:text-emerald-100">
+      <span className="rounded bg-[color:var(--success)]/10 px-1.5 py-0.5 text-[10px] font-semibold text-[color:var(--success)]">
         OK
       </span>
     );
   }
   if (status === 'error') {
     return (
-      <span className="rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-semibold text-red-900 dark:bg-red-900/50 dark:text-red-100">
+      <span className="rounded bg-[color:var(--danger)]/8 px-1.5 py-0.5 text-[10px] font-semibold text-[color:var(--danger)]">
         FAIL
       </span>
     );
   }
   return (
-    <span className="rounded bg-neutral-200 px-1.5 py-0.5 text-[10px] font-semibold text-neutral-700 dark:bg-neutral-700 dark:text-neutral-200">
+    <span className="rounded bg-[color:var(--state-loading)] px-1.5 py-0.5 text-[10px] font-semibold text-[color:var(--fg)]">
       {status}
     </span>
   );

--- a/web-ui/app/graph/_components/ListView.tsx
+++ b/web-ui/app/graph/_components/ListView.tsx
@@ -248,7 +248,7 @@ function ToolCallRow({
               key={e.id}
               type="button"
               onClick={() => onEntityClick(e.id)}
-              className="rounded bg-[color:var(--success)]/10 px-1.5 py-0.5 text-[color:var(--success)] ring-1 ring-[color:var(--success)] hover:bg-[color:var(--success)]/10"
+              className="rounded bg-[color:var(--success)]/10 px-2 py-0.5 text-[color:var(--success)] ring-1 ring-[color:var(--success)] hover:bg-[color:var(--success)]/10"
               title={e.id}
             >
               {String(e.props['displayName'] ?? e.id)}
@@ -263,20 +263,20 @@ function ToolCallRow({
 function StatusPill({ status }: { status: string }): React.ReactElement {
   if (status === 'success') {
     return (
-      <span className="rounded bg-[color:var(--success)]/10 px-1.5 py-0.5 text-[10px] font-semibold text-[color:var(--success)]">
+      <span className="rounded bg-[color:var(--success)]/10 px-2 py-0.5 text-[10px] font-semibold text-[color:var(--success)]">
         OK
       </span>
     );
   }
   if (status === 'error') {
     return (
-      <span className="rounded bg-[color:var(--danger)]/8 px-1.5 py-0.5 text-[10px] font-semibold text-[color:var(--danger)]">
+      <span className="rounded bg-[color:var(--danger)]/8 px-2 py-0.5 text-[10px] font-semibold text-[color:var(--danger)]">
         FAIL
       </span>
     );
   }
   return (
-    <span className="rounded bg-[color:var(--state-loading)] px-1.5 py-0.5 text-[10px] font-semibold text-[color:var(--fg)]">
+    <span className="rounded bg-[color:var(--state-loading)] px-2 py-0.5 text-[10px] font-semibold text-[color:var(--fg)]">
       {status}
     </span>
   );

--- a/web-ui/app/graph/_components/MemoryAclSection.tsx
+++ b/web-ui/app/graph/_components/MemoryAclSection.tsx
@@ -194,15 +194,15 @@ export default function MemoryAclSection({
   }, [memoryId, onDeleted, reason]);
 
   return (
-    <div className="mt-3 border-t border-neutral-200 pt-3 dark:border-neutral-800">
+    <div className="mt-3 border-t border-[color:var(--border)] pt-3">
       <div className="mb-2 flex gap-1 text-[10px] font-semibold uppercase tracking-wide">
         <button
           type="button"
           onClick={() => setTab('owners')}
           className={`rounded px-2 py-0.5 ${
             tab === 'owners'
-              ? 'bg-neutral-200 text-neutral-900 dark:bg-neutral-700 dark:text-neutral-100'
-              : 'text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300'
+              ? 'bg-[color:var(--state-loading)] text-[color:var(--fg-strong)]'
+              : 'text-[color:var(--fg-muted)] hover:text-[color:var(--fg)]'
           }`}
         >
           Owners ({owners.length})
@@ -212,8 +212,8 @@ export default function MemoryAclSection({
           onClick={() => setTab('audit')}
           className={`rounded px-2 py-0.5 ${
             tab === 'audit'
-              ? 'bg-neutral-200 text-neutral-900 dark:bg-neutral-700 dark:text-neutral-100'
-              : 'text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300'
+              ? 'bg-[color:var(--state-loading)] text-[color:var(--fg-strong)]'
+              : 'text-[color:var(--fg-muted)] hover:text-[color:var(--fg)]'
           }`}
         >
           Audit
@@ -223,7 +223,7 @@ export default function MemoryAclSection({
       {tab === 'owners' && (
         <div className="flex flex-col gap-2">
           {owners.length === 0 ? (
-            <div className="text-[11px] italic text-neutral-500">
+            <div className="text-[11px] italic text-[color:var(--fg-muted)]">
               Keine Owner — Memory ist Admin-only invisible.
             </div>
           ) : (
@@ -231,7 +231,7 @@ export default function MemoryAclSection({
               {owners.map((id) => (
                 <li
                   key={id}
-                  className="flex items-center gap-1 rounded border border-neutral-200 px-2 py-1 dark:border-neutral-700"
+                  className="flex items-center gap-1 rounded border border-[color:var(--border)] px-2 py-1"
                 >
                   <span className="grow truncate font-mono text-[10px]">
                     {id}
@@ -240,7 +240,7 @@ export default function MemoryAclSection({
                     type="button"
                     disabled={busy}
                     onClick={() => void removeOwner(id)}
-                    className="rounded border border-neutral-300 px-1 text-[10px] hover:border-red-400 hover:text-red-500 disabled:opacity-50 dark:border-neutral-700"
+                    className="rounded border border-[color:var(--border)] px-1 text-[10px] hover:border-[color:var(--danger-edge)] hover:text-[color:var(--danger)] disabled:opacity-50"
                     title="Owner entfernen"
                   >
                     ×
@@ -256,7 +256,7 @@ export default function MemoryAclSection({
               placeholder="omadiaUserId (uuid) hinzufügen"
               value={addInput}
               onChange={(e) => setAddInput(e.target.value)}
-              className="rounded border border-neutral-300 px-2 py-1 font-mono text-[10px] dark:border-neutral-700 dark:bg-neutral-800"
+              className="rounded border border-[color:var(--border)] px-2 py-1 font-mono text-[10px]"
               disabled={busy}
             />
             <input
@@ -264,7 +264,7 @@ export default function MemoryAclSection({
               placeholder="Grund (optional, im Audit-Log)"
               value={reason}
               onChange={(e) => setReason(e.target.value)}
-              className="rounded border border-neutral-300 px-2 py-1 text-[10px] dark:border-neutral-700 dark:bg-neutral-800"
+              className="rounded border border-[color:var(--border)] px-2 py-1 text-[10px]"
               disabled={busy}
             />
             <div className="flex gap-1">
@@ -272,7 +272,7 @@ export default function MemoryAclSection({
                 type="button"
                 onClick={() => void addOwner()}
                 disabled={busy || addInput.trim().length === 0}
-                className="grow rounded border border-neutral-300 px-2 py-1 text-[11px] hover:border-neutral-400 disabled:opacity-50 dark:border-neutral-700"
+                className="grow rounded border border-[color:var(--border)] px-2 py-1 text-[11px] hover:border-[color:var(--border-strong)] disabled:opacity-50"
               >
                 + Owner hinzufügen
               </button>
@@ -280,7 +280,7 @@ export default function MemoryAclSection({
                 type="button"
                 onClick={() => void deleteMemory()}
                 disabled={busy}
-                className="rounded border border-red-400 px-2 py-1 text-[11px] text-red-500 hover:bg-red-500/10 disabled:opacity-50"
+                className="rounded border border-[color:var(--danger-edge)] px-2 py-1 text-[11px] text-[color:var(--danger)] hover:bg-[color:var(--danger)]/80/10 disabled:opacity-50"
                 title="Memory hart löschen (Audit-Trail bleibt)"
               >
                 Delete
@@ -289,7 +289,7 @@ export default function MemoryAclSection({
           </div>
 
           {error && (
-            <div className="text-[11px] text-red-500">Fehler: {error}</div>
+            <div className="text-[11px] text-[color:var(--danger)]">Fehler: {error}</div>
           )}
         </div>
       )}
@@ -297,17 +297,17 @@ export default function MemoryAclSection({
       {tab === 'audit' && (
         <div className="flex flex-col gap-2">
           {auditError && (
-            <div className="text-[11px] text-red-500">
+            <div className="text-[11px] text-[color:var(--danger)]">
               Audit nicht lesbar: {auditError}
             </div>
           )}
           {audit === null && !auditError && (
-            <div className="text-[11px] italic text-neutral-500">
+            <div className="text-[11px] italic text-[color:var(--fg-muted)]">
               lädt Audit-Trail…
             </div>
           )}
           {audit?.length === 0 && !auditError && (
-            <div className="text-[11px] italic text-neutral-500">
+            <div className="text-[11px] italic text-[color:var(--fg-muted)]">
               Keine Audit-Einträge.
             </div>
           )}
@@ -316,44 +316,44 @@ export default function MemoryAclSection({
               {audit.map((e) => (
                 <li
                   key={e.id}
-                  className="rounded border border-neutral-200 p-2 dark:border-neutral-700"
+                  className="rounded border border-[color:var(--border)] p-2"
                 >
                   <div className="flex items-center gap-2 text-[10px]">
                     <span
                       className={
                         e.action === 'create'
-                          ? 'rounded bg-green-500/20 px-1 text-green-500'
+                          ? 'rounded bg-[color:var(--success)]/100/20 px-1 text-[color:var(--success)]'
                           : e.action === 'expand'
-                            ? 'rounded bg-cyan-500/20 px-1 text-cyan-500'
+                            ? 'rounded bg-[color:var(--accent)]/100/20 px-1 text-[color:var(--accent)]'
                             : e.action === 'shrink'
-                              ? 'rounded bg-amber-500/20 px-1 text-amber-500'
+                              ? 'rounded bg-[color:var(--warning)]/100/20 px-1 text-[color:var(--warning)]'
                               : e.action === 'edit'
-                                ? 'rounded bg-blue-500/20 px-1 text-blue-500'
+                                ? 'rounded bg-[color:var(--accent)]/100/20 px-1 text-[color:var(--accent)]'
                                 : e.action === 'edit_excerpt'
-                                  ? 'rounded bg-violet-500/20 px-1 text-violet-500'
-                                  : 'rounded bg-red-500/20 px-1 text-red-500'
+                                  ? 'rounded bg-[color:var(--accent)]/100/20 px-1 text-[color:var(--accent)]'
+                                  : 'rounded bg-[color:var(--danger)]/80/20 px-1 text-[color:var(--danger)]'
                       }
                     >
                       {e.action}
                     </span>
-                    <span className="text-neutral-400">
+                    <span className="text-[color:var(--fg-subtle)]">
                       {new Date(e.createdAt).toLocaleString()}
                     </span>
                   </div>
-                  <div className="mt-1 font-mono text-[10px] text-neutral-500">
+                  <div className="mt-1 font-mono text-[10px] text-[color:var(--fg-muted)]">
                     actor: {e.actorOmadiaUserId}
                   </div>
-                  <div className="font-mono text-[10px] text-neutral-500">
+                  <div className="font-mono text-[10px] text-[color:var(--fg-muted)]">
                     before: [{e.beforeOwners.join(', ') || '—'}]
                   </div>
-                  <div className="font-mono text-[10px] text-neutral-500">
+                  <div className="font-mono text-[10px] text-[color:var(--fg-muted)]">
                     after:{' '}
                     {e.afterOwners === null
                       ? '(deleted)'
                       : `[${e.afterOwners.join(', ') || '—'}]`}
                   </div>
                   {e.reason && (
-                    <div className="mt-1 text-[10px] italic text-neutral-600 dark:text-neutral-400">
+                    <div className="mt-1 text-[10px] italic text-[color:var(--fg-muted)]">
                       „{e.reason}“
                     </div>
                   )}

--- a/web-ui/app/graph/_components/MemoryAclSection.tsx
+++ b/web-ui/app/graph/_components/MemoryAclSection.tsx
@@ -280,7 +280,7 @@ export default function MemoryAclSection({
                 type="button"
                 onClick={() => void deleteMemory()}
                 disabled={busy}
-                className="rounded border border-[color:var(--danger-edge)] px-2 py-1 text-[11px] text-[color:var(--danger)] hover:bg-[color:var(--danger)]/80/10 disabled:opacity-50"
+                className="rounded border border-[color:var(--danger-edge)] px-2 py-1 text-[11px] text-[color:var(--danger)] hover:bg-[color:var(--danger)]/10 disabled:opacity-50"
                 title="Memory hart löschen (Audit-Trail bleibt)"
               >
                 Delete
@@ -322,16 +322,16 @@ export default function MemoryAclSection({
                     <span
                       className={
                         e.action === 'create'
-                          ? 'rounded bg-[color:var(--success)]/100/20 px-1 text-[color:var(--success)]'
+                          ? 'rounded bg-[color:var(--success)]/20 px-1 text-[color:var(--success)]'
                           : e.action === 'expand'
-                            ? 'rounded bg-[color:var(--accent)]/100/20 px-1 text-[color:var(--accent)]'
+                            ? 'rounded bg-[color:var(--accent)]/20 px-1 text-[color:var(--accent)]'
                             : e.action === 'shrink'
-                              ? 'rounded bg-[color:var(--warning)]/100/20 px-1 text-[color:var(--warning)]'
+                              ? 'rounded bg-[color:var(--warning)]/20 px-1 text-[color:var(--warning)]'
                               : e.action === 'edit'
-                                ? 'rounded bg-[color:var(--accent)]/100/20 px-1 text-[color:var(--accent)]'
+                                ? 'rounded bg-[color:var(--accent)]/20 px-1 text-[color:var(--accent)]'
                                 : e.action === 'edit_excerpt'
-                                  ? 'rounded bg-[color:var(--accent)]/100/20 px-1 text-[color:var(--accent)]'
-                                  : 'rounded bg-[color:var(--danger)]/80/20 px-1 text-[color:var(--danger)]'
+                                  ? 'rounded bg-[color:var(--accent)]/20 px-1 text-[color:var(--accent)]'
+                                  : 'rounded bg-[color:var(--danger)]/20 px-1 text-[color:var(--danger)]'
                       }
                     >
                       {e.action}

--- a/web-ui/app/graph/page.tsx
+++ b/web-ui/app/graph/page.tsx
@@ -571,7 +571,7 @@ export default function GraphPage(): React.ReactElement {
         </div>
 
         <div className="min-h-0 flex-1 overflow-y-auto">
-          <div className="flex items-center justify-between px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wide text-[color:var(--fg-subtle)]">
+          <div className="flex items-center justify-between px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-[color:var(--fg-subtle)]">
             <span>
               Sessions ({filteredSessions.length}
               {filter ? `/${sessions.length}` : ''})
@@ -892,7 +892,7 @@ function SessionCard({
           [...agents].slice(0, 3).map((a) => (
             <span
               key={a}
-              className="rounded-full bg-[color:var(--accent)]/10 px-1.5 py-0.5 font-mono text-[color:var(--accent)] ring-1 ring-[color:var(--accent)]"
+              className="rounded-full bg-[color:var(--accent)]/10 px-2 py-0.5 font-mono text-[color:var(--accent)] ring-1 ring-[color:var(--accent)]"
             >
               🤖 {a}
             </span>
@@ -918,7 +918,7 @@ function Badge({
       : 'bg-[color:var(--bg-soft)] text-[color:var(--fg)] ring-[color:var(--border-strong)]';
   return (
     <span
-      className={`rounded-full px-1.5 py-0.5 font-mono text-[10px] ring-1 ${cls}`}
+      className={`rounded-full px-2 py-0.5 font-mono text-[10px] ring-1 ${cls}`}
     >
       {children}
     </span>
@@ -988,7 +988,7 @@ function FilterChip({
       onClick={onClick}
       title={hint}
       className={[
-        'rounded-full border px-2.5 py-0.5 text-[11px] font-medium transition',
+        'rounded-full border px-3 py-0.5 text-[11px] font-medium transition',
         active
           ? activeTone[tone]
           : 'border-[color:var(--border)] bg-[color:var(--bg-elevated)] text-[color:var(--fg-muted)] hover:border-[color:var(--border-strong)]',

--- a/web-ui/app/graph/page.tsx
+++ b/web-ui/app/graph/page.tsx
@@ -26,7 +26,7 @@ const sessionFetchLimit = createLimiter(4);
 const GraphCanvas = dynamic(() => import('./_components/GraphCanvas'), {
   ssr: false,
   loading: () => (
-    <div className="flex h-full items-center justify-center text-sm text-neutral-500">
+    <div className="flex h-full items-center justify-center text-sm text-[color:var(--fg-muted)]">
       lade Graph-Canvas…
     </div>
   ),
@@ -482,11 +482,11 @@ export default function GraphPage(): React.ReactElement {
 
   return (
     <main className="flex h-full">
-      <aside className="flex w-80 min-w-0 flex-col border-r border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900">
-        <div className="border-b border-neutral-200 px-3 py-3 text-xs dark:border-neutral-800">
+      <aside className="flex w-80 min-w-0 flex-col border-r border-[color:var(--border)] bg-[color:var(--bg-elevated)]">
+        <div className="border-b border-[color:var(--border)] px-3 py-3 text-xs">
           <div className="mb-1 font-semibold">Graph</div>
           {stats && (
-            <div className="space-y-0.5 font-mono text-[11px] text-neutral-500">
+            <div className="space-y-0.5 font-mono text-[11px] text-[color:var(--fg-muted)]">
               <div>
                 nodes={stats.nodes} · edges={stats.edges}
               </div>
@@ -508,7 +508,7 @@ export default function GraphPage(): React.ReactElement {
           <button
             type="button"
             onClick={() => void refresh()}
-            className="mt-2 text-[11px] text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-100"
+            className="mt-2 text-[11px] text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]"
           >
             ↻ neu laden
           </button>
@@ -524,14 +524,14 @@ export default function GraphPage(): React.ReactElement {
           className={[
             'mx-2 mb-1 mt-2 flex items-center gap-2 rounded-md border px-3 py-2 text-left text-xs transition',
             selected === ALL
-              ? 'border-purple-400 bg-purple-50 text-purple-900 dark:border-purple-700 dark:bg-purple-900/30 dark:text-purple-100'
-              : 'border-neutral-200 hover:border-neutral-400 dark:border-neutral-700 dark:hover:border-neutral-500',
+              ? 'border-[color:var(--accent)] bg-[color:var(--accent)]/10 text-[color:var(--accent)]'
+              : 'border-[color:var(--border)] hover:border-[color:var(--border-strong)]',
           ].join(' ')}
         >
           <span className="text-base">🌐</span>
           <span className="flex flex-col">
             <span className="font-semibold">Alle Sessions</span>
-            <span className="text-[10px] text-neutral-500">
+            <span className="text-[10px] text-[color:var(--fg-muted)]">
               Gesamte Wolke · {allTotal} Sessions
             </span>
           </span>
@@ -547,14 +547,14 @@ export default function GraphPage(): React.ReactElement {
           className={[
             'mx-2 mb-2 flex items-center gap-2 rounded-md border px-3 py-2 text-left text-xs transition',
             selected === MEMORIES
-              ? 'border-fuchsia-400 bg-fuchsia-50 text-fuchsia-900 dark:border-fuchsia-700 dark:bg-fuchsia-900/30 dark:text-fuchsia-100'
-              : 'border-neutral-200 hover:border-neutral-400 dark:border-neutral-700 dark:hover:border-neutral-500',
+              ? 'border-[color:var(--accent)] bg-[color:var(--accent)]/10 text-[color:var(--accent)]'
+              : 'border-[color:var(--border)] hover:border-[color:var(--border-strong)]',
           ].join(' ')}
         >
           <span className="text-base">🧠</span>
           <span className="flex flex-col">
             <span className="font-semibold">Alle Memories</span>
-            <span className="text-[10px] text-neutral-500">
+            <span className="text-[10px] text-[color:var(--fg-muted)]">
               Palaia-Provenance · 2-Hops
             </span>
           </span>
@@ -566,24 +566,24 @@ export default function GraphPage(): React.ReactElement {
             placeholder="Sessions filtern…"
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
-            className="w-full rounded border border-neutral-200 bg-white px-2 py-1 text-xs outline-none placeholder:text-neutral-400 focus:border-neutral-400 dark:border-neutral-700 dark:bg-neutral-800 dark:focus:border-neutral-500"
+            className="w-full rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-2 py-1 text-xs outline-none placeholder:text-[color:var(--fg-subtle)] focus:border-[color:var(--border-strong)]"
           />
         </div>
 
         <div className="min-h-0 flex-1 overflow-y-auto">
-          <div className="flex items-center justify-between px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wide text-neutral-400">
+          <div className="flex items-center justify-between px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wide text-[color:var(--fg-subtle)]">
             <span>
               Sessions ({filteredSessions.length}
               {filter ? `/${sessions.length}` : ''})
             </span>
           </div>
           {error && (
-            <div className="border-l-2 border-red-400 px-3 py-2 text-xs text-red-700 dark:text-red-300">
+            <div className="border-l-2 border-[color:var(--danger-edge)] px-3 py-2 text-xs text-[color:var(--danger)]">
               {error}
             </div>
           )}
           {sessions.length === 0 && !error && (
-            <div className="px-3 py-2 text-xs text-neutral-500">
+            <div className="px-3 py-2 text-xs text-[color:var(--fg-muted)]">
               keine — stell eine Frage im Chat
             </div>
           )}
@@ -602,12 +602,12 @@ export default function GraphPage(): React.ReactElement {
         </div>
       </aside>
 
-      <section className="flex min-w-0 flex-1 flex-col bg-neutral-50 dark:bg-neutral-950">
-        <div className="flex items-center gap-3 border-b border-neutral-200 bg-white px-4 py-2 text-xs dark:border-neutral-800 dark:bg-neutral-900">
-          <span className="truncate font-mono text-neutral-600 dark:text-neutral-400">
+      <section className="flex min-w-0 flex-1 flex-col bg-[color:var(--bg-soft)]">
+        <div className="flex items-center gap-3 border-b border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-4 py-2 text-xs">
+          <span className="truncate font-mono text-[color:var(--fg-muted)]">
             {headerTitle}
           </span>
-          <span className="text-[11px] text-neutral-500">
+          <span className="text-[11px] text-[color:var(--fg-muted)]">
             {selected === MEMORIES
               ? `${turnSum} Memor${turnSum === 1 ? 'y' : 'ies'}`
               : `${turnSum} Turn${turnSum === 1 ? '' : 's'}`}
@@ -682,7 +682,7 @@ export default function GraphPage(): React.ReactElement {
           )}
           <div
             className={[
-              'inline-flex overflow-hidden rounded border border-neutral-300 dark:border-neutral-700',
+              'inline-flex overflow-hidden rounded border border-[color:var(--border)]',
               mode === 'graph' ? '' : 'ml-auto',
             ].join(' ')}
           >
@@ -725,7 +725,7 @@ export default function GraphPage(): React.ReactElement {
                 dark={dark}
               />
             ) : (
-              <div className="flex h-full items-center justify-center text-sm text-neutral-500">
+              <div className="flex h-full items-center justify-center text-sm text-[color:var(--fg-muted)]">
                 lade Memories…
               </div>
             )}
@@ -750,7 +750,7 @@ export default function GraphPage(): React.ReactElement {
             />
           </div>
         ) : !activeView ? (
-          <div className="flex h-full items-center justify-center text-sm text-neutral-500">
+          <div className="flex h-full items-center justify-center text-sm text-[color:var(--fg-muted)]">
             lade Session…
           </div>
         ) : mode === 'memory' ? (
@@ -771,7 +771,7 @@ export default function GraphPage(): React.ReactElement {
                 dark={dark}
               />
             ) : (
-              <div className="flex h-full items-center justify-center text-sm text-neutral-500">
+              <div className="flex h-full items-center justify-center text-sm text-[color:var(--fg-muted)]">
                 lade Memories…
               </div>
             )}
@@ -865,11 +865,11 @@ function SessionCard({
       className={[
         'flex w-full flex-col gap-1 border-l-2 px-3 py-2 text-left transition',
         active
-          ? 'border-purple-500 bg-neutral-100 dark:bg-neutral-800'
-          : 'border-transparent hover:border-neutral-300 hover:bg-neutral-50 dark:hover:border-neutral-600 dark:hover:bg-neutral-800/50',
+          ? 'border-[color:var(--accent)] bg-[color:var(--bg-soft)]'
+          : 'border-transparent hover:border-[color:var(--border)] hover:bg-[color:var(--bg-soft)]',
       ].join(' ')}
     >
-      <div className="flex items-center gap-2 text-[10px] text-neutral-500">
+      <div className="flex items-center gap-2 text-[10px] text-[color:var(--fg-muted)]">
         <span className="font-mono">{relativeTime(summary.lastAt)}</span>
         <span className="ml-auto flex items-center gap-1">
           <Badge color="slate">💬 {summary.turnCount}</Badge>
@@ -879,11 +879,11 @@ function SessionCard({
         </span>
       </div>
       {firstUserMsg ? (
-        <div className="line-clamp-2 text-xs text-neutral-700 dark:text-neutral-300">
+        <div className="line-clamp-2 text-xs text-[color:var(--fg)]">
           {firstUserMsg}
         </div>
       ) : (
-        <div className="truncate font-mono text-[10px] text-neutral-400">
+        <div className="truncate font-mono text-[10px] text-[color:var(--fg-subtle)]">
           {summary.scope}
         </div>
       )}
@@ -892,13 +892,13 @@ function SessionCard({
           [...agents].slice(0, 3).map((a) => (
             <span
               key={a}
-              className="rounded-full bg-cyan-50 px-1.5 py-0.5 font-mono text-cyan-900 ring-1 ring-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-100 dark:ring-cyan-800"
+              className="rounded-full bg-[color:var(--accent)]/10 px-1.5 py-0.5 font-mono text-[color:var(--accent)] ring-1 ring-[color:var(--accent)]"
             >
               🤖 {a}
             </span>
           ))}
         {view === 'loading' && (
-          <span className="text-[10px] text-neutral-400">lädt…</span>
+          <span className="text-[10px] text-[color:var(--fg-subtle)]">lädt…</span>
         )}
       </div>
     </button>
@@ -914,8 +914,8 @@ function Badge({
 }): React.ReactElement {
   const cls =
     color === 'emerald'
-      ? 'bg-emerald-50 text-emerald-900 ring-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-100 dark:ring-emerald-800'
-      : 'bg-neutral-100 text-neutral-700 ring-neutral-200 dark:bg-neutral-800 dark:text-neutral-200 dark:ring-neutral-700';
+      ? 'bg-[color:var(--success)]/10 text-[color:var(--success)] ring-[color:var(--success)]'
+      : 'bg-[color:var(--bg-soft)] text-[color:var(--fg)] ring-[color:var(--border-strong)]';
   return (
     <span
       className={`rounded-full px-1.5 py-0.5 font-mono text-[10px] ring-1 ${cls}`}
@@ -944,8 +944,8 @@ function ModeBtn({
       className={[
         'px-3 py-1 font-semibold disabled:cursor-not-allowed disabled:opacity-40',
         active
-          ? 'bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900'
-          : 'bg-white text-neutral-600 hover:bg-neutral-100 dark:bg-neutral-900 dark:text-neutral-300 dark:hover:bg-neutral-800',
+          ? 'bg-[color:var(--bg-inverse)] text-[color:var(--fg-on-dark)]'
+          : 'bg-[color:var(--bg-elevated)] text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)]',
       ].join(' ')}
     >
       {label}
@@ -968,19 +968,19 @@ function FilterChip({
 }): React.ReactElement {
   const activeTone: Record<typeof tone, string> = {
     emerald:
-      'border-emerald-400 bg-emerald-50 text-emerald-900 dark:border-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-100',
+      'border-[color:var(--success)] bg-[color:var(--success)]/10 text-[color:var(--success)]',
     purple:
-      'border-purple-400 bg-purple-50 text-purple-900 dark:border-purple-700 dark:bg-purple-900/30 dark:text-purple-100',
+      'border-[color:var(--accent)] bg-[color:var(--accent)]/10 text-[color:var(--accent)]',
     slate:
-      'border-slate-400 bg-slate-100 text-slate-900 dark:border-slate-600 dark:bg-slate-800/60 dark:text-slate-100',
+      'border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] text-[color:var(--fg-strong)]',
     amber:
-      'border-amber-400 bg-amber-50 text-amber-900 dark:border-amber-700 dark:bg-amber-900/30 dark:text-amber-100',
+      'border-[color:var(--warning)] bg-[color:var(--warning)]/10 text-[color:var(--warning)]',
     fuchsia:
-      'border-fuchsia-400 bg-fuchsia-50 text-fuchsia-900 dark:border-fuchsia-700 dark:bg-fuchsia-900/30 dark:text-fuchsia-100',
+      'border-[color:var(--accent)] bg-[color:var(--accent)]/10 text-[color:var(--accent)]',
     teal:
-      'border-teal-400 bg-teal-50 text-teal-900 dark:border-teal-700 dark:bg-teal-900/30 dark:text-teal-100',
+      'border-[color:var(--accent)] bg-[color:var(--accent)]/10 text-[color:var(--accent)]',
     red:
-      'border-red-400 bg-red-50 text-red-900 dark:border-red-700 dark:bg-red-900/30 dark:text-red-100',
+      'border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 text-[color:var(--danger)]',
   };
   return (
     <button
@@ -991,7 +991,7 @@ function FilterChip({
         'rounded-full border px-2.5 py-0.5 text-[11px] font-medium transition',
         active
           ? activeTone[tone]
-          : 'border-neutral-200 bg-white text-neutral-500 hover:border-neutral-400 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-400 dark:hover:border-neutral-500',
+          : 'border-[color:var(--border)] bg-[color:var(--bg-elevated)] text-[color:var(--fg-muted)] hover:border-[color:var(--border-strong)]',
       ].join(' ')}
     >
       {active ? '●' : '○'} {label}

--- a/web-ui/app/layout.tsx
+++ b/web-ui/app/layout.tsx
@@ -1,16 +1,13 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import {
-  Days_One,
-  JetBrains_Mono,
-  Nunito_Sans,
-} from 'next/font/google';
+import { Geist, Geist_Mono, Source_Serif_4 } from 'next/font/google';
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages, getTranslations } from 'next-intl/server';
 
 import { AuthBadge } from './_components/AuthBadge';
 import { LocaleSwitcher } from './_components/LocaleSwitcher';
 import { Nav } from './_components/Nav';
+import { ThemeControls } from './_components/ThemeControls';
 import { SessionWatcher } from './_components/SessionWatcher';
 import { StreamRunner } from './_components/StreamRunner';
 import { StreamToasts } from './_components/StreamToasts';
@@ -19,37 +16,41 @@ import { StreamStoreProvider } from './_lib/streamStore';
 import './globals.css';
 
 /**
- * Typography per byte5 Design System:
- *   - Days One (single weight) for display + logo only.
- *   - Nunito Sans as the web fallback for Avenir Next — body + UI.
- *   - JetBrains Mono for IDs / versions / entity URIs.
+ * Typography per the Lume spec (§2.7) — three registers, three variable
+ * families, all self-hosted by next/font (no runtime font-CDN requests):
+ *   - Geist          — structural register: UI, labels, headings, buttons.
+ *   - Source Serif 4 — prose register: long-form agent narration.
+ *   - Geist Mono     — data/code register: IDs, numbers, code, paths.
  *
- * The CSS variable names (--font-serif, --font-sans, --font-mono) are kept
- * for continuity with the first UI slice, even though the actual faces are
- * now Days One / Nunito Sans / JetBrains Mono. The compat aliases in
- * theme.css map the byte5-native names (--font-display, --font-text) onto
- * the same stacks.
+ * next/font assigns dedicated CSS variables (--font-geist, --font-source-serif,
+ * --font-geist-mono); _lib/theme.css composes them into --font-sans / --font-serif
+ * / --font-mono with platform-strongest fallbacks. Geist is preloaded for FCP;
+ * the prose + mono faces are deferred (§2.7 "Font loading").
  */
-const display = Days_One({
+const sans = Geist({
   subsets: ['latin'],
-  variable: '--font-serif',
+  variable: '--font-geist',
   display: 'swap',
-  weight: '400',
 });
 
-const text = Nunito_Sans({
+const serif = Source_Serif_4({
   subsets: ['latin'],
-  variable: '--font-sans',
+  variable: '--font-source-serif',
   display: 'swap',
-  weight: ['400', '600', '700', '900'],
+  preload: false,
 });
 
-const mono = JetBrains_Mono({
+const mono = Geist_Mono({
   subsets: ['latin'],
-  variable: '--font-mono',
+  variable: '--font-geist-mono',
   display: 'swap',
-  weight: ['400', '500', '600'],
+  preload: false,
 });
+
+/* Pre-hydration palette/theme application — sets data-palette + data-theme on
+   <html> from localStorage before first paint so there is no flash of the
+   default palette/mode. Mirrors the keys ThemeControls writes. */
+const THEME_BOOTSTRAP = `(function(){try{var d=document.documentElement;var p=localStorage.getItem('omadia-palette');d.setAttribute('data-palette',(p==='petrol'||p==='atelier'||p==='lagoon')?p:'lagoon');var t=localStorage.getItem('omadia-theme');if(t==='light'||t==='dark')d.setAttribute('data-theme',t);}catch(e){document.documentElement.setAttribute('data-palette','lagoon');}})();`;
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('layout');
@@ -70,9 +71,14 @@ export default async function RootLayout({
   return (
     <html
       lang={locale}
-      className={`${display.variable} ${text.variable} ${mono.variable}`}
+      className={`${sans.variable} ${serif.variable} ${mono.variable}`}
+      suppressHydrationWarning
     >
       <body className="flex h-full flex-col">
+        <script
+          // Runs before paint; sets palette/mode from localStorage (no FOUC).
+          dangerouslySetInnerHTML={{ __html: THEME_BOOTSTRAP }}
+        />
         <NextIntlClientProvider locale={locale} messages={messages}>
           <ChatSessionsProvider>
             <StreamStoreProvider>
@@ -93,9 +99,6 @@ export default async function RootLayout({
                     </span>
                   </Link>
                   <span className="text-xs text-[color:var(--fg-muted)]">
-                    <span className="text-[color:var(--highlight)] font-[900]">
-                      :
-                    </span>{' '}
                     {t('subtitle')}
                   </span>
                   <div className="ml-auto flex items-center gap-5">
@@ -104,6 +107,7 @@ export default async function RootLayout({
                       className="hidden h-5 w-px bg-[color:var(--border)] sm:block"
                       aria-hidden
                     />
+                    <ThemeControls />
                     <LocaleSwitcher />
                     <AuthBadge />
                   </div>

--- a/web-ui/app/layout.tsx
+++ b/web-ui/app/layout.tsx
@@ -82,7 +82,7 @@ export default async function RootLayout({
         <NextIntlClientProvider locale={locale} messages={messages}>
           <ChatSessionsProvider>
             <StreamStoreProvider>
-              <header className="relative z-40 border-b border-[color:var(--border)] bg-[color:var(--bg)]/90 px-6 py-3 backdrop-blur">
+              <header className="app-header relative z-40 px-6 py-3 backdrop-blur">
                 <div className="mx-auto flex max-w-[1280px] items-center gap-4">
                   <Link
                     href="/"

--- a/web-ui/app/layout.tsx
+++ b/web-ui/app/layout.tsx
@@ -101,7 +101,7 @@ export default async function RootLayout({
                   <span className="text-xs text-[color:var(--fg-muted)]">
                     {t('subtitle')}
                   </span>
-                  <div className="ml-auto flex items-center gap-5">
+                  <div className="ml-auto flex items-center gap-4">
                     <Nav />
                     <span
                       className="hidden h-5 w-px bg-[color:var(--border)] sm:block"

--- a/web-ui/app/login/page.tsx
+++ b/web-ui/app/login/page.tsx
@@ -242,7 +242,7 @@ function PageShell({ children }: { children: React.ReactNode }): React.ReactElem
           <h1 className="font-display text-3xl text-[color:var(--fg-strong)]">
             Omadia
           </h1>
-          <span className="mt-1.5 text-[11px] uppercase tracking-[0.18em] text-[color:var(--fg-muted)]">
+          <span className="mt-2 text-[11px] uppercase tracking-[0.18em] text-[color:var(--fg-muted)]">
             an Agentic OS
           </span>
         </header>

--- a/web-ui/app/login/page.tsx
+++ b/web-ui/app/login/page.tsx
@@ -139,7 +139,7 @@ function LoginPageInner(): React.ReactElement {
   if (state.kind === 'error') {
     return (
       <PageShell>
-        <p className="text-sm text-red-500">
+        <p className="text-sm text-[color:var(--danger)]">
           {t('errorPrefix')} {state.message}
         </p>
       </PageShell>
@@ -149,7 +149,7 @@ function LoginPageInner(): React.ReactElement {
   if (state.kind === 'no-providers') {
     return (
       <PageShell>
-        <p className="text-sm text-amber-500">
+        <p className="text-sm text-[color:var(--warning)]">
           {t.rich('noProviders', {
             envVar: () => <code>AUTH_PROVIDERS</code>,
           })}
@@ -190,12 +190,12 @@ function LoginPageInner(): React.ReactElement {
             />
           </label>
           {submitError && (
-            <p className="text-sm text-red-500">{submitError}</p>
+            <p className="text-sm text-[color:var(--danger)]">{submitError}</p>
           )}
           <button
             type="submit"
             disabled={submitting}
-            className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-black disabled:opacity-50"
+            className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-[color:var(--text-inverse)] disabled:opacity-50"
           >
             {submitting ? t('submitting') : t('submit')}
           </button>

--- a/web-ui/app/login/page.tsx
+++ b/web-ui/app/login/page.tsx
@@ -235,7 +235,9 @@ function LoginPageInner(): React.ReactElement {
 function PageShell({ children }: { children: React.ReactNode }): React.ReactElement {
   return (
     <main className="flex min-h-screen items-center justify-center px-4">
-      <div className="w-full max-w-sm rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-6 shadow-sm">
+      {/* Lume modal-class surface: the login card is the lit object (§2.10
+          elev.modal carries the accent-glow components). */}
+      <div className="lume-surface-raised lume-border w-full max-w-sm rounded-lg p-6 shadow-[var(--shadow-lg)]">
         <header className="mb-6 flex flex-col leading-none">
           <h1 className="font-display text-3xl text-[color:var(--fg-strong)]">
             Omadia

--- a/web-ui/app/memories/[id]/page.tsx
+++ b/web-ui/app/memories/[id]/page.tsx
@@ -35,22 +35,22 @@ const KIND_LABELS: Record<MemorableKind, string> = {
 
 const KIND_BADGE: Record<MemorableKind, string> = {
   decision:
-    'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+    'bg-[color:var(--accent)]/10 text-[color:var(--accent)]',
   insight:
-    'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+    'bg-[color:var(--warning)]/10 text-[color:var(--warning)]',
   preference:
-    'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
+    'bg-[color:var(--success)]/10 text-[color:var(--success)]',
   reference:
-    'bg-neutral-100 text-neutral-800 dark:bg-neutral-800 dark:text-neutral-300',
+    'bg-[color:var(--bg-soft)] text-[color:var(--fg)]',
 };
 
 const ACTION_BADGE: Record<MemorableAclAction, string> = {
-  create: 'bg-green-500/20 text-green-700 dark:text-green-300',
-  expand: 'bg-cyan-500/20 text-cyan-700 dark:text-cyan-300',
-  shrink: 'bg-amber-500/20 text-amber-700 dark:text-amber-300',
-  delete: 'bg-red-500/20 text-red-700 dark:text-red-300',
-  edit: 'bg-blue-500/20 text-blue-700 dark:text-blue-300',
-  edit_excerpt: 'bg-violet-500/20 text-violet-700 dark:text-violet-300',
+  create: 'bg-[color:var(--success)]/100/20 text-[color:var(--success)]',
+  expand: 'bg-[color:var(--accent)]/100/20 text-[color:var(--accent)]',
+  shrink: 'bg-[color:var(--warning)]/100/20 text-[color:var(--warning)]',
+  delete: 'bg-[color:var(--danger)]/80/20 text-[color:var(--danger)]',
+  edit: 'bg-[color:var(--accent)]/100/20 text-[color:var(--accent)]',
+  edit_excerpt: 'bg-[color:var(--accent)]/100/20 text-[color:var(--accent)]',
 };
 
 const ACTION_LABELS: Record<MemorableAclAction, string> = {
@@ -69,10 +69,10 @@ const SOURCE_LABELS: Record<ExcerptSource, string> = {
 };
 
 const SOURCE_BADGE: Record<ExcerptSource, string> = {
-  llm: 'bg-neutral-200 text-neutral-700 dark:bg-neutral-700 dark:text-neutral-200',
-  hint: 'bg-amber-200 text-amber-800 dark:bg-amber-800/40 dark:text-amber-200',
+  llm: 'bg-[color:var(--state-loading)] text-[color:var(--fg)]',
+  hint: 'bg-[color:var(--warning)] text-[color:var(--warning)]',
   fallback:
-    'bg-orange-200 text-orange-800 dark:bg-orange-900/40 dark:text-orange-200',
+    'bg-[color:var(--warning)] text-[color:var(--warning)]',
 };
 
 /**
@@ -300,25 +300,25 @@ export default function MemoryDetailPage(): React.ReactElement {
 
   return (
     <main className="flex h-full flex-col">
-      <header className="border-b border-neutral-200 bg-white px-6 py-4 dark:border-neutral-800 dark:bg-neutral-900">
+      <header className="border-b border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-6 py-4">
         <div className="flex items-center gap-3">
           <Link
             href="/memories"
-            className="text-xs text-neutral-500 hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"
+            className="text-xs text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]"
           >
             ← /memories
           </Link>
           <h1 className="text-lg font-medium">Memory</h1>
-          <span className="font-mono text-[10px] text-neutral-500">{id}</span>
+          <span className="font-mono text-[10px] text-[color:var(--fg-muted)]">{id}</span>
         </div>
       </header>
 
-      <section className="min-h-0 flex-1 overflow-y-auto bg-neutral-50 px-6 py-4 dark:bg-neutral-950">
+      <section className="min-h-0 flex-1 overflow-y-auto bg-[color:var(--bg-soft)] px-6 py-4">
         {loading && (
-          <div className="text-xs text-neutral-500">lädt…</div>
+          <div className="text-xs text-[color:var(--fg-muted)]">lädt…</div>
         )}
         {loadError !== null && (
-          <div className="border-l-2 border-red-400 px-3 py-2 text-xs text-red-700 dark:text-red-300">
+          <div className="border-l-2 border-[color:var(--danger-edge)] px-3 py-2 text-xs text-[color:var(--danger)]">
             {loadError === 'memory.not_found'
               ? 'Memory nicht gefunden oder du bist kein Owner.'
               : `Fehler: ${loadError}`}
@@ -326,7 +326,7 @@ export default function MemoryDetailPage(): React.ReactElement {
         )}
 
         {!loading && node !== null && (
-          <article className="mx-auto max-w-2xl rounded border border-neutral-200 bg-white p-5 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+          <article className="mx-auto max-w-2xl rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-5 shadow-sm">
             <div className="mb-3 flex items-center justify-between gap-3">
               {editing ? (
                 <div className="flex flex-wrap gap-1.5">
@@ -336,8 +336,8 @@ export default function MemoryDetailPage(): React.ReactElement {
                       className={[
                         'cursor-pointer rounded border px-2 py-1 text-xs transition',
                         kind === k
-                          ? 'border-neutral-900 bg-neutral-900 text-white dark:border-neutral-200 dark:bg-neutral-200 dark:text-neutral-900'
-                          : 'border-neutral-300 text-neutral-700 hover:border-neutral-400 dark:border-neutral-700 dark:text-neutral-300',
+                          ? 'border-[color:var(--border-strong)] bg-[color:var(--bg-inverse)] text-[color:var(--fg-on-dark)]'
+                          : 'border-[color:var(--border)] text-[color:var(--fg)] hover:border-[color:var(--border-strong)]',
                       ].join(' ')}
                     >
                       <input
@@ -364,7 +364,7 @@ export default function MemoryDetailPage(): React.ReactElement {
                 </span>
               )}
               <time
-                className="font-mono text-[10px] text-neutral-500"
+                className="font-mono text-[10px] text-[color:var(--fg-muted)]"
                 dateTime={node.props.created_at}
               >
                 {new Date(node.props.created_at).toLocaleString('de-DE')}
@@ -372,7 +372,7 @@ export default function MemoryDetailPage(): React.ReactElement {
             </div>
 
             <div className="mb-4">
-              <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-500">
+              <label className="mb-1 block text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
                 Zusammenfassung
               </label>
               {editing ? (
@@ -382,17 +382,17 @@ export default function MemoryDetailPage(): React.ReactElement {
                   disabled={busy}
                   maxLength={2000}
                   rows={3}
-                  className="w-full resize-y rounded border border-neutral-300 px-2 py-1.5 text-sm focus:border-neutral-500 focus:outline-none dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-100"
+                  className="w-full resize-y rounded border border-[color:var(--border)] px-2 py-1.5 text-sm focus:border-[color:var(--border-strong)] focus:outline-none"
                 />
               ) : (
-                <p className="text-sm text-neutral-900 dark:text-neutral-100">
+                <p className="text-sm text-[color:var(--fg-strong)]">
                   {node.props.summary}
                 </p>
               )}
             </div>
 
             <div className="mb-4">
-              <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-500">
+              <label className="mb-1 block text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
                 Begründung
               </label>
               {editing ? (
@@ -402,21 +402,21 @@ export default function MemoryDetailPage(): React.ReactElement {
                   disabled={busy}
                   maxLength={10000}
                   rows={3}
-                  className="w-full resize-y rounded border border-neutral-300 px-2 py-1.5 text-sm focus:border-neutral-500 focus:outline-none dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-100"
+                  className="w-full resize-y rounded border border-[color:var(--border)] px-2 py-1.5 text-sm focus:border-[color:var(--border-strong)] focus:outline-none"
                   placeholder="(optional)"
                 />
               ) : node.props.rationale !== undefined ? (
-                <p className="text-xs text-neutral-700 dark:text-neutral-300">
+                <p className="text-xs text-[color:var(--fg)]">
                   {node.props.rationale}
                 </p>
               ) : (
-                <p className="text-xs text-neutral-400">— keine —</p>
+                <p className="text-xs text-[color:var(--fg-subtle)]">— keine —</p>
               )}
             </div>
 
             {editing && (
               <div className="mb-4">
-                <label className="mb-1 block text-[11px] uppercase tracking-wider text-neutral-500">
+                <label className="mb-1 block text-[11px] uppercase tracking-wider text-[color:var(--fg-muted)]">
                   Grund für die Änderung (optional, im Audit-Log)
                 </label>
                 <input
@@ -425,18 +425,18 @@ export default function MemoryDetailPage(): React.ReactElement {
                   onChange={(e) => setReason(e.target.value)}
                   disabled={busy}
                   maxLength={1000}
-                  className="w-full rounded border border-neutral-300 px-2 py-1 text-xs focus:border-neutral-500 focus:outline-none dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-100"
+                  className="w-full rounded border border-[color:var(--border)] px-2 py-1 text-xs focus:border-[color:var(--border-strong)] focus:outline-none"
                 />
               </div>
             )}
 
-            <dl className="mb-4 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 font-mono text-[10px] text-neutral-500">
+            <dl className="mb-4 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 font-mono text-[10px] text-[color:var(--fg-muted)]">
               <dt>created_by</dt>
-              <dd className="text-neutral-700 dark:text-neutral-300">
+              <dd className="text-[color:var(--fg)]">
                 {node.props.created_by}
               </dd>
               <dt>owners</dt>
-              <dd className="text-neutral-700 dark:text-neutral-300">
+              <dd className="text-[color:var(--fg)]">
                 {node.props.acl_owners.length}
               </dd>
               {typeof node.props.significance === 'number' && (
@@ -448,7 +448,7 @@ export default function MemoryDetailPage(): React.ReactElement {
             </dl>
 
             {mutationError !== null && (
-              <div className="mb-3 border-l-2 border-red-400 px-2 py-1 text-xs text-red-700 dark:text-red-300">
+              <div className="mb-3 border-l-2 border-[color:var(--danger-edge)] px-2 py-1 text-xs text-[color:var(--danger)]">
                 Fehler: {mutationError}
               </div>
             )}
@@ -460,7 +460,7 @@ export default function MemoryDetailPage(): React.ReactElement {
                     type="button"
                     onClick={cancelEdit}
                     disabled={busy}
-                    className="rounded border border-neutral-300 px-3 py-1 text-xs hover:border-neutral-400 disabled:opacity-50 dark:border-neutral-700"
+                    className="rounded border border-[color:var(--border)] px-3 py-1 text-xs hover:border-[color:var(--border-strong)] disabled:opacity-50"
                   >
                     Abbrechen
                   </button>
@@ -468,7 +468,7 @@ export default function MemoryDetailPage(): React.ReactElement {
                     type="button"
                     onClick={() => void save()}
                     disabled={busy || summary.trim().length === 0}
-                    className="rounded bg-neutral-900 px-3 py-1 text-xs text-white hover:bg-neutral-700 disabled:opacity-50 dark:bg-neutral-100 dark:text-neutral-900"
+                    className="rounded bg-[color:var(--bg-inverse)] px-3 py-1 text-xs text-[color:var(--fg-on-dark)] hover:bg-[color:var(--fg-muted)] disabled:opacity-50"
                   >
                     {busy ? 'speichert…' : 'Speichern'}
                   </button>
@@ -479,7 +479,7 @@ export default function MemoryDetailPage(): React.ReactElement {
                     type="button"
                     onClick={() => void discard()}
                     disabled={busy}
-                    className="rounded border border-red-400 px-3 py-1 text-xs text-red-600 hover:bg-red-50 disabled:opacity-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
+                    className="rounded border border-[color:var(--danger-edge)] px-3 py-1 text-xs text-[color:var(--danger)] hover:bg-[color:var(--danger)]/8 disabled:opacity-50"
                   >
                     Löschen
                   </button>
@@ -487,7 +487,7 @@ export default function MemoryDetailPage(): React.ReactElement {
                     type="button"
                     onClick={startEdit}
                     disabled={busy}
-                    className="rounded bg-neutral-900 px-3 py-1 text-xs text-white hover:bg-neutral-700 dark:bg-neutral-100 dark:text-neutral-900"
+                    className="rounded bg-[color:var(--bg-inverse)] px-3 py-1 text-xs text-[color:var(--fg-on-dark)] hover:bg-[color:var(--fg-muted)]"
                   >
                     Bearbeiten
                   </button>
@@ -500,26 +500,26 @@ export default function MemoryDetailPage(): React.ReactElement {
         {!loading && node !== null && (
           <section
             aria-label="Quellen-Snippets"
-            className="mx-auto mt-4 max-w-2xl rounded border border-neutral-200 bg-white p-5 shadow-sm dark:border-neutral-800 dark:bg-neutral-900"
+            className="mx-auto mt-4 max-w-2xl rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-5 shadow-sm"
           >
             <header className="mb-3 flex items-center justify-between">
               <div>
-                <h2 className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+                <h2 className="text-xs font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
                   Quellen-Snippets
                 </h2>
-                <p className="mt-0.5 text-[10px] text-neutral-500">
+                <p className="mt-0.5 text-[10px] text-[color:var(--fg-muted)]">
                   Verbatim aus dem ursprünglichen Turn — Provenance-Anker für die Memory.
                 </p>
               </div>
             </header>
 
             {excerptsError !== null && (
-              <div className="mb-2 border-l-2 border-red-400 px-2 py-1 text-xs text-red-700 dark:text-red-300">
+              <div className="mb-2 border-l-2 border-[color:var(--danger-edge)] px-2 py-1 text-xs text-[color:var(--danger)]">
                 Snippets nicht lesbar: {excerptsError}
               </div>
             )}
             {excerpts !== null && excerpts.length === 0 && excerptsError === null && (
-              <p className="text-xs italic text-neutral-500">
+              <p className="text-xs italic text-[color:var(--fg-muted)]">
                 Keine Quellen-Snippets — Memory wurde vor Slice 6.5 gespeichert oder
                 der Extractor lieferte keine Excerpts.
               </p>
@@ -532,11 +532,11 @@ export default function MemoryDetailPage(): React.ReactElement {
                   return (
                     <li
                       key={ex.id}
-                      className="rounded border border-neutral-200 px-3 py-2 dark:border-neutral-800"
+                      className="rounded border border-[color:var(--border)] px-3 py-2"
                     >
                       <div className="mb-1 flex items-center justify-between gap-2">
                         <div className="flex items-center gap-2 text-[10px]">
-                          <span className="font-mono text-neutral-500">
+                          <span className="font-mono text-[color:var(--fg-muted)]">
                             #{ex.props.position + 1}
                           </span>
                           <span
@@ -553,7 +553,7 @@ export default function MemoryDetailPage(): React.ReactElement {
                             <button
                               type="button"
                               onClick={() => void copyExcerpt(ex)}
-                              className="rounded border border-neutral-200 px-2 py-0.5 text-[10px] text-neutral-600 hover:border-neutral-400 hover:text-neutral-900 dark:border-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-100"
+                              className="rounded border border-[color:var(--border)] px-2 py-0.5 text-[10px] text-[color:var(--fg-muted)] hover:border-[color:var(--border-strong)] hover:text-[color:var(--fg-strong)]"
                               title="Snippet in die Zwischenablage kopieren"
                             >
                               {justCopied ? '✓ kopiert' : 'kopieren'}
@@ -561,7 +561,7 @@ export default function MemoryDetailPage(): React.ReactElement {
                             <button
                               type="button"
                               onClick={() => startExcerptEdit(ex)}
-                              className="rounded border border-neutral-200 px-2 py-0.5 text-[10px] text-neutral-600 hover:border-neutral-400 hover:text-neutral-900 dark:border-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-100"
+                              className="rounded border border-[color:var(--border)] px-2 py-0.5 text-[10px] text-[color:var(--fg-muted)] hover:border-[color:var(--border-strong)] hover:text-[color:var(--fg-strong)]"
                             >
                               bearbeiten
                             </button>
@@ -577,10 +577,10 @@ export default function MemoryDetailPage(): React.ReactElement {
                             disabled={excerptBusy}
                             maxLength={300}
                             rows={3}
-                            className="w-full resize-y rounded border border-neutral-300 px-2 py-1 text-sm focus:border-neutral-500 focus:outline-none dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-100"
+                            className="w-full resize-y rounded border border-[color:var(--border)] px-2 py-1 text-sm focus:border-[color:var(--border-strong)] focus:outline-none"
                           />
                           <div className="flex flex-wrap items-center gap-2">
-                            <label className="text-[10px] uppercase tracking-wider text-neutral-500">
+                            <label className="text-[10px] uppercase tracking-wider text-[color:var(--fg-muted)]">
                               Quelle:
                             </label>
                             {(['llm', 'hint', 'fallback'] as const).map((s) => (
@@ -589,8 +589,8 @@ export default function MemoryDetailPage(): React.ReactElement {
                                 className={[
                                   'cursor-pointer rounded border px-2 py-0.5 text-[10px]',
                                   excerptDraftSource === s
-                                    ? 'border-neutral-900 bg-neutral-900 text-white dark:border-neutral-200 dark:bg-neutral-200 dark:text-neutral-900'
-                                    : 'border-neutral-300 text-neutral-700 dark:border-neutral-700 dark:text-neutral-300',
+                                    ? 'border-[color:var(--border-strong)] bg-[color:var(--bg-inverse)] text-[color:var(--fg-on-dark)]'
+                                    : 'border-[color:var(--border)] text-[color:var(--fg)]',
                                 ].join(' ')}
                               >
                                 <input
@@ -610,7 +610,7 @@ export default function MemoryDetailPage(): React.ReactElement {
                                 type="button"
                                 onClick={cancelExcerptEdit}
                                 disabled={excerptBusy}
-                                className="rounded border border-neutral-300 px-2 py-0.5 text-[10px] hover:border-neutral-400 disabled:opacity-50 dark:border-neutral-700"
+                                className="rounded border border-[color:var(--border)] px-2 py-0.5 text-[10px] hover:border-[color:var(--border-strong)] disabled:opacity-50"
                               >
                                 Abbrechen
                               </button>
@@ -620,7 +620,7 @@ export default function MemoryDetailPage(): React.ReactElement {
                                 disabled={
                                   excerptBusy || excerptDraft.trim().length === 0
                                 }
-                                className="rounded bg-neutral-900 px-2 py-0.5 text-[10px] text-white hover:bg-neutral-700 disabled:opacity-50 dark:bg-neutral-100 dark:text-neutral-900"
+                                className="rounded bg-[color:var(--bg-inverse)] px-2 py-0.5 text-[10px] text-[color:var(--fg-on-dark)] hover:bg-[color:var(--fg-muted)] disabled:opacity-50"
                               >
                                 {excerptBusy ? 'speichert…' : 'Speichern'}
                               </button>
@@ -628,7 +628,7 @@ export default function MemoryDetailPage(): React.ReactElement {
                           </div>
                         </div>
                       ) : (
-                        <p className="whitespace-pre-wrap text-sm text-neutral-800 dark:text-neutral-200">
+                        <p className="whitespace-pre-wrap text-sm text-[color:var(--fg)]">
                           {ex.props.text}
                         </p>
                       )}
@@ -638,7 +638,7 @@ export default function MemoryDetailPage(): React.ReactElement {
               </ol>
             )}
             {copiedPos === -1 && (
-              <p className="mt-2 text-[10px] italic text-amber-700 dark:text-amber-300">
+              <p className="mt-2 text-[10px] italic text-[color:var(--warning)]">
                 Kopieren fehlgeschlagen (Browser blockiert Clipboard).
               </p>
             )}
@@ -648,29 +648,29 @@ export default function MemoryDetailPage(): React.ReactElement {
         {!loading && node !== null && (
           <section
             aria-label="Audit-Verlauf"
-            className="mx-auto mt-4 max-w-2xl rounded border border-neutral-200 bg-white p-5 shadow-sm dark:border-neutral-800 dark:bg-neutral-900"
+            className="mx-auto mt-4 max-w-2xl rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-5 shadow-sm"
           >
             <header className="mb-3 flex items-center justify-between">
-              <h2 className="text-xs font-semibold uppercase tracking-wider text-neutral-500">
+              <h2 className="text-xs font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
                 Verlauf
               </h2>
               <button
                 type="button"
                 onClick={() => void loadAudit()}
                 disabled={auditLoading}
-                className="text-[10px] text-neutral-500 underline-offset-2 hover:text-neutral-900 hover:underline disabled:opacity-50 dark:hover:text-neutral-100"
+                className="text-[10px] text-[color:var(--fg-muted)] underline-offset-2 hover:text-[color:var(--fg-strong)] hover:underline disabled:opacity-50"
               >
                 {auditLoading ? 'lädt…' : 'aktualisieren'}
               </button>
             </header>
 
             {auditError !== null && (
-              <div className="mb-2 border-l-2 border-red-400 px-2 py-1 text-xs text-red-700 dark:text-red-300">
+              <div className="mb-2 border-l-2 border-[color:var(--danger-edge)] px-2 py-1 text-xs text-[color:var(--danger)]">
                 Verlauf nicht lesbar: {auditError}
               </div>
             )}
             {audit !== null && audit.length === 0 && auditError === null && (
-              <p className="text-xs italic text-neutral-500">
+              <p className="text-xs italic text-[color:var(--fg-muted)]">
                 Keine Audit-Einträge.
               </p>
             )}
@@ -684,7 +684,7 @@ export default function MemoryDetailPage(): React.ReactElement {
                   return (
                     <li
                       key={e.id}
-                      className="rounded border border-neutral-200 px-3 py-2 dark:border-neutral-800"
+                      className="rounded border border-[color:var(--border)] px-3 py-2"
                     >
                       <div className="flex flex-wrap items-center gap-2 text-[10px]">
                         <span
@@ -697,7 +697,7 @@ export default function MemoryDetailPage(): React.ReactElement {
                         </span>
                         <time
                           dateTime={e.createdAt}
-                          className="font-mono text-neutral-500"
+                          className="font-mono text-[color:var(--fg-muted)]"
                         >
                           {new Date(e.createdAt).toLocaleString('de-DE')}
                         </time>
@@ -705,8 +705,8 @@ export default function MemoryDetailPage(): React.ReactElement {
                           <span
                             className={
                               ownersDelta > 0
-                                ? 'font-mono text-green-600 dark:text-green-400'
-                                : 'font-mono text-amber-600 dark:text-amber-400'
+                                ? 'font-mono text-[color:var(--success)]'
+                                : 'font-mono text-[color:var(--warning)]'
                             }
                           >
                             owners {ownersDelta > 0 ? '+' : ''}
@@ -714,19 +714,19 @@ export default function MemoryDetailPage(): React.ReactElement {
                           </span>
                         )}
                       </div>
-                      <div className="mt-1 font-mono text-[10px] text-neutral-500">
+                      <div className="mt-1 font-mono text-[10px] text-[color:var(--fg-muted)]">
                         actor: {e.actorOmadiaUserId}
                       </div>
                       {(e.action === 'expand' ||
                         e.action === 'shrink' ||
                         e.action === 'delete') && (
-                        <div className="mt-1 grid grid-cols-[max-content_1fr] gap-x-2 font-mono text-[10px] text-neutral-500">
+                        <div className="mt-1 grid grid-cols-[max-content_1fr] gap-x-2 font-mono text-[10px] text-[color:var(--fg-muted)]">
                           <span>before:</span>
-                          <span className="text-neutral-700 dark:text-neutral-300">
+                          <span className="text-[color:var(--fg)]">
                             [{e.beforeOwners.join(', ') || '—'}]
                           </span>
                           <span>after:</span>
-                          <span className="text-neutral-700 dark:text-neutral-300">
+                          <span className="text-[color:var(--fg)]">
                             {e.afterOwners === null
                               ? '(deleted)'
                               : `[${e.afterOwners.join(', ') || '—'}]`}
@@ -734,7 +734,7 @@ export default function MemoryDetailPage(): React.ReactElement {
                         </div>
                       )}
                       {e.reason !== undefined && e.reason.length > 0 && (
-                        <p className="mt-1 text-xs italic text-neutral-600 dark:text-neutral-400">
+                        <p className="mt-1 text-xs italic text-[color:var(--fg-muted)]">
                           „{e.reason}“
                         </p>
                       )}

--- a/web-ui/app/memories/[id]/page.tsx
+++ b/web-ui/app/memories/[id]/page.tsx
@@ -326,10 +326,10 @@ export default function MemoryDetailPage(): React.ReactElement {
         )}
 
         {!loading && node !== null && (
-          <article className="mx-auto max-w-2xl rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-5 shadow-sm">
+          <article className="mx-auto max-w-2xl rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-4 shadow-sm">
             <div className="mb-3 flex items-center justify-between gap-3">
               {editing ? (
-                <div className="flex flex-wrap gap-1.5">
+                <div className="flex flex-wrap gap-2">
                   {KINDS.map((k) => (
                     <label
                       key={k}
@@ -382,7 +382,7 @@ export default function MemoryDetailPage(): React.ReactElement {
                   disabled={busy}
                   maxLength={2000}
                   rows={3}
-                  className="w-full resize-y rounded border border-[color:var(--border)] px-2 py-1.5 text-sm focus:border-[color:var(--border-strong)] focus:outline-none"
+                  className="w-full resize-y rounded border border-[color:var(--border)] px-2 py-2 text-sm focus:border-[color:var(--border-strong)] focus:outline-none"
                 />
               ) : (
                 <p className="text-sm text-[color:var(--fg-strong)]">
@@ -402,7 +402,7 @@ export default function MemoryDetailPage(): React.ReactElement {
                   disabled={busy}
                   maxLength={10000}
                   rows={3}
-                  className="w-full resize-y rounded border border-[color:var(--border)] px-2 py-1.5 text-sm focus:border-[color:var(--border-strong)] focus:outline-none"
+                  className="w-full resize-y rounded border border-[color:var(--border)] px-2 py-2 text-sm focus:border-[color:var(--border-strong)] focus:outline-none"
                   placeholder="(optional)"
                 />
               ) : node.props.rationale !== undefined ? (
@@ -500,7 +500,7 @@ export default function MemoryDetailPage(): React.ReactElement {
         {!loading && node !== null && (
           <section
             aria-label="Quellen-Snippets"
-            className="mx-auto mt-4 max-w-2xl rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-5 shadow-sm"
+            className="mx-auto mt-4 max-w-2xl rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-4 shadow-sm"
           >
             <header className="mb-3 flex items-center justify-between">
               <div>
@@ -541,7 +541,7 @@ export default function MemoryDetailPage(): React.ReactElement {
                           </span>
                           <span
                             className={[
-                              'rounded px-1.5 py-0.5 uppercase tracking-wider',
+                              'rounded px-2 py-0.5 uppercase tracking-wider',
                               SOURCE_BADGE[ex.props.source],
                             ].join(' ')}
                           >
@@ -648,7 +648,7 @@ export default function MemoryDetailPage(): React.ReactElement {
         {!loading && node !== null && (
           <section
             aria-label="Audit-Verlauf"
-            className="mx-auto mt-4 max-w-2xl rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-5 shadow-sm"
+            className="mx-auto mt-4 max-w-2xl rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-4 shadow-sm"
           >
             <header className="mb-3 flex items-center justify-between">
               <h2 className="text-xs font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
@@ -689,7 +689,7 @@ export default function MemoryDetailPage(): React.ReactElement {
                       <div className="flex flex-wrap items-center gap-2 text-[10px]">
                         <span
                           className={[
-                            'rounded px-1.5 py-0.5 uppercase tracking-wider',
+                            'rounded px-2 py-0.5 uppercase tracking-wider',
                             ACTION_BADGE[e.action],
                           ].join(' ')}
                         >

--- a/web-ui/app/memories/[id]/page.tsx
+++ b/web-ui/app/memories/[id]/page.tsx
@@ -45,12 +45,12 @@ const KIND_BADGE: Record<MemorableKind, string> = {
 };
 
 const ACTION_BADGE: Record<MemorableAclAction, string> = {
-  create: 'bg-[color:var(--success)]/100/20 text-[color:var(--success)]',
-  expand: 'bg-[color:var(--accent)]/100/20 text-[color:var(--accent)]',
-  shrink: 'bg-[color:var(--warning)]/100/20 text-[color:var(--warning)]',
-  delete: 'bg-[color:var(--danger)]/80/20 text-[color:var(--danger)]',
-  edit: 'bg-[color:var(--accent)]/100/20 text-[color:var(--accent)]',
-  edit_excerpt: 'bg-[color:var(--accent)]/100/20 text-[color:var(--accent)]',
+  create: 'bg-[color:var(--success)]/20 text-[color:var(--success)]',
+  expand: 'bg-[color:var(--accent)]/20 text-[color:var(--accent)]',
+  shrink: 'bg-[color:var(--warning)]/20 text-[color:var(--warning)]',
+  delete: 'bg-[color:var(--danger)]/20 text-[color:var(--danger)]',
+  edit: 'bg-[color:var(--accent)]/20 text-[color:var(--accent)]',
+  edit_excerpt: 'bg-[color:var(--accent)]/20 text-[color:var(--accent)]',
 };
 
 const ACTION_LABELS: Record<MemorableAclAction, string> = {

--- a/web-ui/app/memories/page.tsx
+++ b/web-ui/app/memories/page.tsx
@@ -88,7 +88,7 @@ export default function MemoriesPage(): React.ReactElement {
             ↻ neu laden
           </button>
         </div>
-        <div className="mt-3 flex flex-wrap gap-1.5">
+        <div className="mt-3 flex flex-wrap gap-2">
           {KIND_FILTERS.map((k) => {
             const active = filter === k;
             const label = k === 'all' ? 'alle' : KIND_LABELS[k];

--- a/web-ui/app/memories/page.tsx
+++ b/web-ui/app/memories/page.tsx
@@ -27,13 +27,13 @@ const KIND_LABELS: Record<MemorableKind, string> = {
 
 const KIND_BADGE: Record<MemorableKind, string> = {
   decision:
-    'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+    'bg-[color:var(--accent)]/10 text-[color:var(--accent)]',
   insight:
-    'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+    'bg-[color:var(--warning)]/10 text-[color:var(--warning)]',
   preference:
-    'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
+    'bg-[color:var(--success)]/10 text-[color:var(--success)]',
   reference:
-    'bg-neutral-100 text-neutral-800 dark:bg-neutral-800 dark:text-neutral-300',
+    'bg-[color:var(--bg-soft)] text-[color:var(--fg)]',
 };
 
 /**
@@ -72,18 +72,18 @@ export default function MemoriesPage(): React.ReactElement {
 
   return (
     <main className="flex h-full flex-col">
-      <header className="border-b border-neutral-200 bg-white px-6 py-4 dark:border-neutral-800 dark:bg-neutral-900">
+      <header className="border-b border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-6 py-4">
         <div className="flex items-center justify-between gap-4">
           <div>
             <h1 className="text-lg font-medium">Memories</h1>
-            <p className="text-xs text-neutral-500">
+            <p className="text-xs text-[color:var(--fg-muted)]">
               Kuratiertes Wissen — ACL-gefiltert auf dich als Owner.
             </p>
           </div>
           <button
             type="button"
             onClick={() => void load()}
-            className="rounded border border-neutral-300 px-2 py-1 text-xs hover:border-neutral-400 dark:border-neutral-700 dark:hover:border-neutral-500"
+            className="rounded border border-[color:var(--border)] px-2 py-1 text-xs hover:border-[color:var(--border-strong)]"
           >
             ↻ neu laden
           </button>
@@ -100,8 +100,8 @@ export default function MemoriesPage(): React.ReactElement {
                 className={[
                   'rounded border px-2 py-1 text-xs transition',
                   active
-                    ? 'border-neutral-900 bg-neutral-900 text-white dark:border-neutral-200 dark:bg-neutral-200 dark:text-neutral-900'
-                    : 'border-neutral-300 text-neutral-700 hover:border-neutral-400 dark:border-neutral-700 dark:text-neutral-300 dark:hover:border-neutral-500',
+                    ? 'border-[color:var(--border-strong)] bg-[color:var(--bg-inverse)] text-[color:var(--fg-on-dark)]'
+                    : 'border-[color:var(--border)] text-[color:var(--fg)] hover:border-[color:var(--border-strong)]',
                 ].join(' ')}
               >
                 {label}
@@ -111,17 +111,17 @@ export default function MemoriesPage(): React.ReactElement {
         </div>
       </header>
 
-      <section className="min-h-0 flex-1 overflow-y-auto bg-neutral-50 px-6 py-4 dark:bg-neutral-950">
+      <section className="min-h-0 flex-1 overflow-y-auto bg-[color:var(--bg-soft)] px-6 py-4">
         {loading && (
-          <div className="text-xs text-neutral-500">lädt…</div>
+          <div className="text-xs text-[color:var(--fg-muted)]">lädt…</div>
         )}
         {error !== null && (
-          <div className="border-l-2 border-red-400 px-3 py-2 text-xs text-red-700 dark:text-red-300">
+          <div className="border-l-2 border-[color:var(--danger-edge)] px-3 py-2 text-xs text-[color:var(--danger)]">
             Fehler: {error}
           </div>
         )}
         {!loading && error === null && items.length === 0 && (
-          <div className="text-xs text-neutral-500">
+          <div className="text-xs text-[color:var(--fg-muted)]">
             {filter === 'all'
               ? 'Noch keine Memories. Erstelle eine via Chat oder POST /api/v1/memory.'
               : `Keine Memories vom Typ „${KIND_LABELS[filter]}". Filter zurücksetzen oder andere Art wählen.`}
@@ -133,7 +133,7 @@ export default function MemoriesPage(): React.ReactElement {
               <li key={mk.id}>
                 <Link
                   href={`/memories/${encodeURIComponent(mk.id)}`}
-                  className="block rounded border border-neutral-200 bg-white px-4 py-3 shadow-sm transition hover:border-neutral-400 hover:shadow dark:border-neutral-800 dark:bg-neutral-900 dark:hover:border-neutral-500"
+                  className="block rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-4 py-3 shadow-sm transition hover:border-[color:var(--border-strong)] hover:shadow"
                 >
                   <div className="flex items-start justify-between gap-3">
                     <span
@@ -145,21 +145,21 @@ export default function MemoriesPage(): React.ReactElement {
                       {KIND_LABELS[mk.props.kind]}
                     </span>
                     <time
-                      className="font-mono text-[10px] text-neutral-500"
+                      className="font-mono text-[10px] text-[color:var(--fg-muted)]"
                       dateTime={mk.props.created_at}
                     >
                       {new Date(mk.props.created_at).toLocaleString('de-DE')}
                     </time>
                   </div>
-                  <p className="mt-2 text-sm text-neutral-900 dark:text-neutral-100">
+                  <p className="mt-2 text-sm text-[color:var(--fg-strong)]">
                     {mk.props.summary}
                   </p>
                   {mk.props.rationale !== undefined && (
-                    <p className="mt-1 text-xs text-neutral-600 dark:text-neutral-400">
+                    <p className="mt-1 text-xs text-[color:var(--fg-muted)]">
                       {mk.props.rationale}
                     </p>
                   )}
-                  <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-neutral-500">
+                  <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-[color:var(--fg-muted)]">
                     <span className="font-mono">{mk.id}</span>
                     <span aria-hidden>·</span>
                     <span>{mk.props.acl_owners.length} Owner</span>

--- a/web-ui/app/memory/page.tsx
+++ b/web-ui/app/memory/page.tsx
@@ -135,7 +135,7 @@ export default function MemoryPage(): React.ReactElement {
             {backend !== null && (
               <span
                 className={[
-                  'rounded px-1.5 py-0.5 text-[10px] font-medium',
+                  'rounded px-2 py-0.5 text-[10px] font-medium',
                   backend === 'postgres'
                     ? 'bg-[color:var(--success)]/10 text-[color:var(--success)]'
                     : 'bg-[color:var(--warning)]/10 text-[color:var(--warning)]',
@@ -183,7 +183,7 @@ export default function MemoryPage(): React.ReactElement {
             <button
               type="button"
               onClick={() => setCwd(parent)}
-              className="flex w-full items-center gap-2 px-3 py-1.5 text-left font-mono text-xs text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)]"
+              className="flex w-full items-center gap-2 px-3 py-2 text-left font-mono text-xs text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)]"
             >
               ← ..
             </button>
@@ -215,7 +215,7 @@ export default function MemoryPage(): React.ReactElement {
                   }
                 }}
                 className={[
-                  'flex w-full items-center gap-2 px-3 py-1.5 text-left font-mono text-xs transition',
+                  'flex w-full items-center gap-2 px-3 py-2 text-left font-mono text-xs transition',
                   activeFile
                     ? 'bg-[color:var(--bg-soft)]'
                     : 'hover:bg-[color:var(--bg-soft)]',

--- a/web-ui/app/memory/page.tsx
+++ b/web-ui/app/memory/page.tsx
@@ -126,10 +126,10 @@ export default function MemoryPage(): React.ReactElement {
 
   return (
     <main className="flex h-full">
-      <aside className="flex w-80 min-w-0 flex-col border-r border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900">
-        <div className="border-b border-neutral-200 px-3 py-2 dark:border-neutral-800">
+      <aside className="flex w-80 min-w-0 flex-col border-r border-[color:var(--border)] bg-[color:var(--bg-elevated)]">
+        <div className="border-b border-[color:var(--border)] px-3 py-2">
           <div className="flex items-center gap-2">
-            <span className="text-sm font-semibold text-neutral-800 dark:text-neutral-100">
+            <span className="text-sm font-semibold text-[color:var(--fg)]">
               Memory
             </span>
             {backend !== null && (
@@ -137,15 +137,15 @@ export default function MemoryPage(): React.ReactElement {
                 className={[
                   'rounded px-1.5 py-0.5 text-[10px] font-medium',
                   backend === 'postgres'
-                    ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300'
-                    : 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+                    ? 'bg-[color:var(--success)]/10 text-[color:var(--success)]'
+                    : 'bg-[color:var(--warning)]/10 text-[color:var(--warning)]',
                 ].join(' ')}
               >
                 {backend === 'postgres' ? 'Postgres' : 'In-Memory · flüchtig'}
               </span>
             )}
           </div>
-          <p className="mt-0.5 text-[11px] text-neutral-500">
+          <p className="mt-0.5 text-[11px] text-[color:var(--fg-muted)]">
             Live-Browser des aktiven Memory-Stores
             {backend === 'inmemory'
               ? ' (RAM, beim Neustart leer).'
@@ -154,16 +154,16 @@ export default function MemoryPage(): React.ReactElement {
                 : '.'}
           </p>
         </div>
-        <div className="border-b border-neutral-200 px-3 py-2 text-xs dark:border-neutral-800">
-          <div className="mb-1 text-neutral-500">Pfad</div>
+        <div className="border-b border-[color:var(--border)] px-3 py-2 text-xs">
+          <div className="mb-1 text-[color:var(--fg-muted)]">Pfad</div>
           <div className="flex flex-wrap items-center gap-1 font-mono text-[11px]">
             {crumbs.map((c, i) => (
               <span key={c.path} className="flex items-center gap-1">
-                {i > 0 && <span className="text-neutral-400">/</span>}
+                {i > 0 && <span className="text-[color:var(--fg-subtle)]">/</span>}
                 <button
                   type="button"
                   onClick={() => setCwd(c.path)}
-                  className="rounded px-1 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+                  className="rounded px-1 hover:bg-[color:var(--bg-soft)]"
                 >
                   {c.label}
                 </button>
@@ -173,7 +173,7 @@ export default function MemoryPage(): React.ReactElement {
           <button
             type="button"
             onClick={() => void loadDir(cwd)}
-            className="mt-2 text-[11px] text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-100"
+            className="mt-2 text-[11px] text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]"
           >
             ↻ neu laden
           </button>
@@ -183,21 +183,21 @@ export default function MemoryPage(): React.ReactElement {
             <button
               type="button"
               onClick={() => setCwd(parent)}
-              className="flex w-full items-center gap-2 px-3 py-1.5 text-left font-mono text-xs text-neutral-500 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left font-mono text-xs text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)]"
             >
               ← ..
             </button>
           )}
           {loadingList && (
-            <div className="px-3 py-2 text-xs text-neutral-500">lädt…</div>
+            <div className="px-3 py-2 text-xs text-[color:var(--fg-muted)]">lädt…</div>
           )}
           {listError && (
-            <div className="border-l-2 border-red-400 px-3 py-2 text-xs text-red-700 dark:text-red-300">
+            <div className="border-l-2 border-[color:var(--danger-edge)] px-3 py-2 text-xs text-[color:var(--danger)]">
               {listError}
             </div>
           )}
           {!loadingList && !listError && entries.length === 0 && (
-            <div className="px-3 py-2 text-xs text-neutral-500">leer</div>
+            <div className="px-3 py-2 text-xs text-[color:var(--fg-muted)]">leer</div>
           )}
           {entries.map((e) => {
             const name = basename(e.virtualPath);
@@ -217,14 +217,14 @@ export default function MemoryPage(): React.ReactElement {
                 className={[
                   'flex w-full items-center gap-2 px-3 py-1.5 text-left font-mono text-xs transition',
                   activeFile
-                    ? 'bg-neutral-100 dark:bg-neutral-800'
-                    : 'hover:bg-neutral-100 dark:hover:bg-neutral-800',
+                    ? 'bg-[color:var(--bg-soft)]'
+                    : 'hover:bg-[color:var(--bg-soft)]',
                 ].join(' ')}
               >
                 <span>{e.isDirectory ? '📁' : '📄'}</span>
                 <span className="truncate">{name}</span>
                 {!e.isDirectory && (
-                  <span className="ml-auto text-[10px] text-neutral-400">
+                  <span className="ml-auto text-[10px] text-[color:var(--fg-subtle)]">
                     {formatSize(e.sizeBytes)}
                   </span>
                 )}
@@ -234,22 +234,22 @@ export default function MemoryPage(): React.ReactElement {
         </div>
       </aside>
 
-      <section className="flex min-w-0 flex-1 flex-col bg-neutral-50 dark:bg-neutral-950">
+      <section className="flex min-w-0 flex-1 flex-col bg-[color:var(--bg-soft)]">
         {selected === null ? (
-          <div className="flex h-full items-center justify-center text-sm text-neutral-500">
+          <div className="flex h-full items-center justify-center text-sm text-[color:var(--fg-muted)]">
             Eintrag links wählen…
           </div>
         ) : (
           <>
-            <div className="flex items-center gap-3 border-b border-neutral-200 bg-white px-4 py-2 text-xs dark:border-neutral-800 dark:bg-neutral-900">
-              <span className="font-mono text-neutral-600 dark:text-neutral-400">
+            <div className="flex items-center gap-3 border-b border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-4 py-2 text-xs">
+              <span className="font-mono text-[color:var(--fg-muted)]">
                 {selected}
               </span>
               <div className="ml-auto flex items-center gap-2">
                 <button
                   type="button"
                   onClick={() => void loadFile(selected)}
-                  className="rounded border border-neutral-300 px-2 py-0.5 hover:border-neutral-400 dark:border-neutral-700"
+                  className="rounded border border-[color:var(--border)] px-2 py-0.5 hover:border-[color:var(--border-strong)]"
                 >
                   ↻
                 </button>
@@ -257,10 +257,10 @@ export default function MemoryPage(): React.ReactElement {
             </div>
             <div className="min-h-0 flex-1 overflow-auto px-6 py-4">
               {loadingFile && (
-                <div className="text-xs text-neutral-500">lädt…</div>
+                <div className="text-xs text-[color:var(--fg-muted)]">lädt…</div>
               )}
               {fileError && (
-                <div className="border-l-2 border-red-400 px-3 py-2 text-xs text-red-700 dark:text-red-300">
+                <div className="border-l-2 border-[color:var(--danger-edge)] px-3 py-2 text-xs text-[color:var(--danger)]">
                   {fileError}
                 </div>
               )}
@@ -268,7 +268,7 @@ export default function MemoryPage(): React.ReactElement {
                 <Markdown source={content} />
               )}
               {!loadingFile && !fileError && !isMarkdown && (
-                <pre className="whitespace-pre-wrap font-mono text-xs text-neutral-800 dark:text-neutral-200">
+                <pre className="whitespace-pre-wrap font-mono text-xs text-[color:var(--fg)]">
                   {content}
                 </pre>
               )}

--- a/web-ui/app/operator/agents/_components/AgentsDashboard.tsx
+++ b/web-ui/app/operator/agents/_components/AgentsDashboard.tsx
@@ -105,7 +105,7 @@ export function AgentsDashboard({
   }
 
   return (
-    <div className="space-y-10">
+    <div className="space-y-8">
       {error && (
         <div className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-3 text-sm text-[color:var(--danger)]">
           {error}
@@ -117,7 +117,7 @@ export function AgentsDashboard({
         </div>
       )}
 
-      <section className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-5">
+      <section className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-4">
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-lg font-medium">{t('platformHeading')}</h2>
           <div className="flex gap-2">
@@ -292,7 +292,7 @@ function RoutingTester(props: {
   }
 
   return (
-    <section className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-5">
+    <section className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-4">
       <h2 className="mb-1 text-lg font-medium">{t('routingTesterHeading')}</h2>
       <p className="mb-3 text-xs text-[color:var(--fg-muted)]">
         {t('routingTesterHelp')}
@@ -346,7 +346,7 @@ function RoutingTester(props: {
         <button
           type="submit"
           disabled={props.disabled || running || !type || !key}
-          className="rounded bg-[color:var(--bg-inverse)] px-4 py-1.5 text-sm text-[color:var(--fg-on-dark)] hover:bg-[color:var(--bg-inverse)] disabled:opacity-40"
+          className="rounded bg-[color:var(--bg-inverse)] px-4 py-2 text-sm text-[color:var(--fg-on-dark)] hover:bg-[color:var(--bg-inverse)] disabled:opacity-40"
         >
           {running ? t('routingTesterRunning') : t('routingTesterSubmit')}
         </button>
@@ -390,7 +390,7 @@ function CreateAgentForm(props: {
   const [privacy, setPrivacy] = useState<PrivacyProfile>('default');
 
   return (
-    <section className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-5">
+    <section className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-4">
       <h2 className="mb-4 text-lg font-medium">{t('createHeading')}</h2>
       <form
         className="grid gap-4 lg:grid-cols-4"
@@ -451,7 +451,7 @@ function CreateAgentForm(props: {
           <button
             type="submit"
             disabled={props.disabled || !slug || !name}
-            className="rounded bg-[color:var(--bg-inverse)] px-4 py-1.5 text-sm text-[color:var(--fg-on-dark)] hover:bg-[color:var(--bg-inverse)] disabled:opacity-40"
+            className="rounded bg-[color:var(--bg-inverse)] px-4 py-2 text-sm text-[color:var(--fg-on-dark)] hover:bg-[color:var(--bg-inverse)] disabled:opacity-40"
           >
             {t('createSubmit')}
           </button>
@@ -499,7 +499,7 @@ function AgentCard(props: {
 
   return (
     <article className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)]">
-      <header className="flex items-start justify-between gap-4 px-5 py-3">
+      <header className="flex items-start justify-between gap-4 px-4 py-3">
         <button
           type="button"
           className="flex flex-1 items-start gap-2 text-left"
@@ -577,7 +577,7 @@ function AgentCard(props: {
       </header>
 
       {expanded && (
-        <div className="border-t border-[color:var(--border)] px-5 py-4">
+        <div className="border-t border-[color:var(--border)] px-4 py-4">
           {agent.description && (
             <p className="mb-4 text-sm text-[color:var(--fg)]">{agent.description}</p>
           )}
@@ -732,7 +732,7 @@ function BindingsEditor(props: {
       {rows.length === 0 ? (
         <p className="text-xs text-[color:var(--fg-muted)]">{t('bindingsEmpty')}</p>
       ) : (
-        <ul className="space-y-1.5">
+        <ul className="space-y-2">
           {rows.map((row, idx) => (
             <li key={idx} className="flex items-center gap-2">
               {props.channelTypes.length > 0 ? (

--- a/web-ui/app/operator/agents/_components/AgentsDashboard.tsx
+++ b/web-ui/app/operator/agents/_components/AgentsDashboard.tsx
@@ -107,23 +107,23 @@ export function AgentsDashboard({
   return (
     <div className="space-y-10">
       {error && (
-        <div className="rounded border border-red-400 bg-red-50 p-3 text-sm text-red-800">
+        <div className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-3 text-sm text-[color:var(--danger)]">
           {error}
         </div>
       )}
       {catalogError && (
-        <div className="rounded border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800">
+        <div className="rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 p-3 text-sm text-[color:var(--warning)]">
           {t('catalogError', { message: catalogError })}
         </div>
       )}
 
-      <section className="rounded border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-5">
+      <section className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-5">
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-lg font-medium">{t('platformHeading')}</h2>
           <div className="flex gap-2">
             <button
               type="button"
-              className="rounded border border-neutral-300 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800 px-3 py-1 text-xs hover:bg-neutral-100 dark:hover:bg-neutral-700"
+              className="rounded border border-[color:var(--border)] bg-[color:var(--bg-soft)] px-3 py-1 text-xs hover:bg-[color:var(--bg-soft)]"
               disabled={pending || !!busy || !fallbackSlug}
               onClick={() => {
                 if (!confirm(t('rehydrateConfirm'))) return;
@@ -143,7 +143,7 @@ export function AgentsDashboard({
             </button>
             <button
               type="button"
-              className="rounded border border-neutral-300 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800 px-3 py-1 text-xs hover:bg-neutral-100 dark:hover:bg-neutral-700"
+              className="rounded border border-[color:var(--border)] bg-[color:var(--bg-soft)] px-3 py-1 text-xs hover:bg-[color:var(--bg-soft)]"
               disabled={pending || !!busy}
               onClick={() => run('reload', () => triggerAgentReload())}
             >
@@ -172,12 +172,12 @@ export function AgentsDashboard({
       <section className="space-y-4">
         <h2 className="text-lg font-medium">
           {t('agentsHeading')}{' '}
-          <span className="text-sm font-normal text-neutral-500 dark:text-neutral-400">
+          <span className="text-sm font-normal text-[color:var(--fg-muted)]">
             ({initial.agents.length})
           </span>
         </h2>
         {initial.agents.length === 0 ? (
-          <p className="text-sm text-neutral-500 dark:text-neutral-400">{t('agentsEmpty')}</p>
+          <p className="text-sm text-[color:var(--fg-muted)]">{t('agentsEmpty')}</p>
         ) : (
           initial.agents.map((agent) => (
             <AgentCard
@@ -246,9 +246,9 @@ function FallbackPicker(props: {
   const t = useTranslations('operatorAgents');
   return (
     <label className="flex items-center gap-3 text-sm">
-      <span className="text-neutral-600 dark:text-neutral-300">{t('fallbackLabel')}</span>
+      <span className="text-[color:var(--fg-muted)]">{t('fallbackLabel')}</span>
       <select
-        className="rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-2 py-1"
+        className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-2 py-1"
         value={props.currentSlug ?? ''}
         disabled={props.disabled}
         onChange={(e) =>
@@ -292,9 +292,9 @@ function RoutingTester(props: {
   }
 
   return (
-    <section className="rounded border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-5">
+    <section className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-5">
       <h2 className="mb-1 text-lg font-medium">{t('routingTesterHeading')}</h2>
-      <p className="mb-3 text-xs text-neutral-500 dark:text-neutral-400">
+      <p className="mb-3 text-xs text-[color:var(--fg-muted)]">
         {t('routingTesterHelp')}
       </p>
       <form
@@ -305,14 +305,14 @@ function RoutingTester(props: {
         }}
       >
         <label className="flex flex-col gap-1">
-          <span className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+          <span className="text-xs uppercase tracking-wide text-[color:var(--fg-muted)]">
             {t('fieldChannelType')}
           </span>
           {props.channelTypes.length > 0 ? (
             <select
               value={type}
               onChange={(e) => setType(e.target.value)}
-              className="rounded border border-neutral-300 dark:border-neutral-700 px-2 py-1 text-sm"
+              className="rounded border border-[color:var(--border)] px-2 py-1 text-sm"
             >
               <option value="">—</option>
               {props.channelTypes.map((ct) => (
@@ -327,12 +327,12 @@ function RoutingTester(props: {
               value={type}
               onChange={(e) => setType(e.target.value)}
               placeholder="teams"
-              className="rounded border border-neutral-300 dark:border-neutral-700 px-2 py-1 text-sm"
+              className="rounded border border-[color:var(--border)] px-2 py-1 text-sm"
             />
           )}
         </label>
         <label className="flex flex-1 flex-col gap-1">
-          <span className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+          <span className="text-xs uppercase tracking-wide text-[color:var(--fg-muted)]">
             {t('fieldChannelKey')}
           </span>
           <input
@@ -340,22 +340,22 @@ function RoutingTester(props: {
             value={key}
             onChange={(e) => setKey(e.target.value)}
             placeholder="28:bot-id-or-@username"
-            className="rounded border border-neutral-300 dark:border-neutral-700 px-2 py-1 text-sm"
+            className="rounded border border-[color:var(--border)] px-2 py-1 text-sm"
           />
         </label>
         <button
           type="submit"
           disabled={props.disabled || running || !type || !key}
-          className="rounded bg-neutral-900 px-4 py-1.5 text-sm text-white hover:bg-neutral-800 disabled:opacity-40"
+          className="rounded bg-[color:var(--bg-inverse)] px-4 py-1.5 text-sm text-[color:var(--fg-on-dark)] hover:bg-[color:var(--bg-inverse)] disabled:opacity-40"
         >
           {running ? t('routingTesterRunning') : t('routingTesterSubmit')}
         </button>
       </form>
       {error && (
-        <p className="mt-3 text-sm text-red-700">{error}</p>
+        <p className="mt-3 text-sm text-[color:var(--danger)]">{error}</p>
       )}
       {result && (
-        <div className="mt-3 rounded border border-neutral-200 bg-neutral-50 dark:bg-neutral-800 p-3 text-sm">
+        <div className="mt-3 rounded border border-[color:var(--border)] bg-[color:var(--bg-soft)] p-3 text-sm">
           {result.matched ? (
             <p>
               {t('routingTesterMatched', {
@@ -364,7 +364,7 @@ function RoutingTester(props: {
               })}
             </p>
           ) : (
-            <p className="text-neutral-600 dark:text-neutral-300">
+            <p className="text-[color:var(--fg-muted)]">
               {result.message ?? t('routingTesterNoMatch')}
             </p>
           )}
@@ -390,7 +390,7 @@ function CreateAgentForm(props: {
   const [privacy, setPrivacy] = useState<PrivacyProfile>('default');
 
   return (
-    <section className="rounded border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-5">
+    <section className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-5">
       <h2 className="mb-4 text-lg font-medium">{t('createHeading')}</h2>
       <form
         className="grid gap-4 lg:grid-cols-4"
@@ -416,7 +416,7 @@ function CreateAgentForm(props: {
             onChange={(e) => setSlug(e.target.value)}
             pattern="^[a-z0-9][a-z0-9-]*$"
             required
-            className="w-full rounded border border-neutral-300 dark:border-neutral-700 px-2 py-1 text-sm"
+            className="w-full rounded border border-[color:var(--border)] px-2 py-1 text-sm"
             placeholder="public"
           />
         </Field>
@@ -426,7 +426,7 @@ function CreateAgentForm(props: {
             value={name}
             onChange={(e) => setName(e.target.value)}
             required
-            className="w-full rounded border border-neutral-300 dark:border-neutral-700 px-2 py-1 text-sm"
+            className="w-full rounded border border-[color:var(--border)] px-2 py-1 text-sm"
           />
         </Field>
         <Field label={t('fieldDescription')}>
@@ -434,14 +434,14 @@ function CreateAgentForm(props: {
             type="text"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
-            className="w-full rounded border border-neutral-300 dark:border-neutral-700 px-2 py-1 text-sm"
+            className="w-full rounded border border-[color:var(--border)] px-2 py-1 text-sm"
           />
         </Field>
         <Field label={t('fieldPrivacy')}>
           <select
             value={privacy}
             onChange={(e) => setPrivacy(e.target.value as PrivacyProfile)}
-            className="w-full rounded border border-neutral-300 dark:border-neutral-700 px-2 py-1 text-sm"
+            className="w-full rounded border border-[color:var(--border)] px-2 py-1 text-sm"
           >
             <option value="default">default</option>
             <option value="strict">strict</option>
@@ -451,7 +451,7 @@ function CreateAgentForm(props: {
           <button
             type="submit"
             disabled={props.disabled || !slug || !name}
-            className="rounded bg-neutral-900 px-4 py-1.5 text-sm text-white hover:bg-neutral-800 disabled:opacity-40"
+            className="rounded bg-[color:var(--bg-inverse)] px-4 py-1.5 text-sm text-[color:var(--fg-on-dark)] hover:bg-[color:var(--bg-inverse)] disabled:opacity-40"
           >
             {t('createSubmit')}
           </button>
@@ -498,7 +498,7 @@ function AgentCard(props: {
   const enabledPluginCount = agent.plugins.filter((p) => p.enabled).length;
 
   return (
-    <article className="rounded border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900">
+    <article className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)]">
       <header className="flex items-start justify-between gap-4 px-5 py-3">
         <button
           type="button"
@@ -506,17 +506,17 @@ function AgentCard(props: {
           onClick={() => setExpanded((v) => !v)}
           aria-expanded={expanded}
         >
-          <span className="mt-0.5 text-neutral-500 dark:text-neutral-400">
+          <span className="mt-0.5 text-[color:var(--fg-muted)]">
             {expanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
           </span>
           <span className="flex-1">
             <span className="block text-base font-semibold">
               {agent.name}{' '}
-              <span className="font-mono text-sm text-neutral-500 dark:text-neutral-400">
+              <span className="font-mono text-sm text-[color:var(--fg-muted)]">
                 ({agent.slug})
               </span>
             </span>
-            <span className="block text-xs text-neutral-500 dark:text-neutral-400">
+            <span className="block text-xs text-[color:var(--fg-muted)]">
               {t('agentCardSummary', {
                 privacy: agent.privacy_profile,
                 status:
@@ -536,7 +536,7 @@ function AgentCard(props: {
           <div className="flex gap-2">
             <button
               type="button"
-              className="rounded border border-neutral-300 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800 px-2 py-1 text-xs hover:bg-neutral-100 dark:hover:bg-neutral-700"
+              className="rounded border border-[color:var(--border)] bg-[color:var(--bg-soft)] px-2 py-1 text-xs hover:bg-[color:var(--bg-soft)]"
               disabled={props.disabled}
               onClick={() =>
                 props.onPatch({
@@ -550,7 +550,7 @@ function AgentCard(props: {
             </button>
             <button
               type="button"
-              className="rounded border border-neutral-300 dark:border-neutral-700 bg-neutral-50 dark:bg-neutral-800 px-2 py-1 text-xs hover:bg-neutral-100 dark:hover:bg-neutral-700"
+              className="rounded border border-[color:var(--border)] bg-[color:var(--bg-soft)] px-2 py-1 text-xs hover:bg-[color:var(--bg-soft)]"
               disabled={props.disabled}
               onClick={() =>
                 props.onPatch({
@@ -563,7 +563,7 @@ function AgentCard(props: {
             </button>
             <button
               type="button"
-              className="rounded border border-red-300 bg-red-50 px-2 py-1 text-xs text-red-800 hover:bg-red-100"
+              className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 px-2 py-1 text-xs text-[color:var(--danger)] hover:bg-[color:var(--danger)]/8"
               disabled={props.disabled}
               onClick={() => {
                 if (confirm(t('deleteConfirm', { slug: agent.slug })))
@@ -577,16 +577,16 @@ function AgentCard(props: {
       </header>
 
       {expanded && (
-        <div className="border-t border-neutral-200 px-5 py-4">
+        <div className="border-t border-[color:var(--border)] px-5 py-4">
           {agent.description && (
-            <p className="mb-4 text-sm text-neutral-700 dark:text-neutral-200">{agent.description}</p>
+            <p className="mb-4 text-sm text-[color:var(--fg)]">{agent.description}</p>
           )}
 
           <div className="mb-4 flex flex-wrap items-center gap-2">
-            <span className="text-xs text-neutral-500 dark:text-neutral-400">{t('sessionsLabel')}</span>
+            <span className="text-xs text-[color:var(--fg-muted)]">{t('sessionsLabel')}</span>
             <button
               type="button"
-              className="rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs text-amber-800 hover:bg-amber-100"
+              className="rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 px-2 py-1 text-xs text-[color:var(--warning)] hover:bg-[color:var(--warning)]/10"
               disabled={props.disabled}
               onClick={() => props.onDrain()}
               title={t('drainTooltip')}
@@ -595,7 +595,7 @@ function AgentCard(props: {
             </button>
             <button
               type="button"
-              className="rounded border border-red-300 bg-red-50 px-2 py-1 text-xs text-red-800 hover:bg-red-100"
+              className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 px-2 py-1 text-xs text-[color:var(--danger)] hover:bg-[color:var(--danger)]/8"
               disabled={props.disabled}
               onClick={() => {
                 if (confirm(t('killConfirm', { slug: agent.slug })))
@@ -611,7 +611,7 @@ function AgentCard(props: {
               {t('memoryScopeHeading')}
             </h4>
             {agent.memory_scope.length === 0 ? (
-              <p className="text-xs text-neutral-500 dark:text-neutral-400">
+              <p className="text-xs text-[color:var(--fg-muted)]">
                 {t('memoryScopeEmpty')}
               </p>
             ) : (
@@ -619,7 +619,7 @@ function AgentCard(props: {
                 {agent.memory_scope.map((s) => (
                   <li
                     key={s}
-                    className="rounded bg-neutral-100 dark:bg-neutral-800 px-2 py-0.5 text-neutral-700 dark:text-neutral-200"
+                    className="rounded bg-[color:var(--bg-soft)] px-2 py-0.5 text-[color:var(--fg)]"
                   >
                     {s}
                   </li>
@@ -629,7 +629,7 @@ function AgentCard(props: {
           </div>
 
           {props.isFallback && (
-            <div className="mb-3 rounded border border-sky-200 bg-sky-50 px-3 py-2 text-xs text-sky-900">
+            <div className="mb-3 rounded border border-[color:var(--accent)] bg-[color:var(--accent)]/10 px-3 py-2 text-xs text-[color:var(--accent)]">
               {t('fallbackStoreOnlyNotice')}
             </div>
           )}
@@ -643,7 +643,7 @@ function AgentCard(props: {
               onReplace={props.onReplacePlugins}
             />
           ) : (
-            <p className="text-xs text-neutral-500 dark:text-neutral-400">{t('catalogLoading')}</p>
+            <p className="text-xs text-[color:var(--fg-muted)]">{t('catalogLoading')}</p>
           )}
 
           <BindingsEditor
@@ -713,7 +713,7 @@ function BindingsEditor(props: {
         <span className="flex gap-2">
           <button
             type="button"
-            className="rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-2 py-0.5 text-xs hover:bg-neutral-50 dark:hover:bg-neutral-700"
+            className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-2 py-0.5 text-xs hover:bg-[color:var(--bg-soft)]"
             disabled={props.disabled}
             onClick={add}
           >
@@ -721,7 +721,7 @@ function BindingsEditor(props: {
           </button>
           <button
             type="button"
-            className="rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-2 py-0.5 text-xs hover:bg-neutral-50 dark:hover:bg-neutral-700"
+            className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-2 py-0.5 text-xs hover:bg-[color:var(--bg-soft)]"
             disabled={props.disabled}
             onClick={submit}
           >
@@ -730,7 +730,7 @@ function BindingsEditor(props: {
         </span>
       </h4>
       {rows.length === 0 ? (
-        <p className="text-xs text-neutral-500 dark:text-neutral-400">{t('bindingsEmpty')}</p>
+        <p className="text-xs text-[color:var(--fg-muted)]">{t('bindingsEmpty')}</p>
       ) : (
         <ul className="space-y-1.5">
           {rows.map((row, idx) => (
@@ -742,7 +742,7 @@ function BindingsEditor(props: {
                   onChange={(e) =>
                     update(idx, { channel_type: e.target.value })
                   }
-                  className="rounded border border-neutral-300 dark:border-neutral-700 px-2 py-1 text-xs"
+                  className="rounded border border-[color:var(--border)] px-2 py-1 text-xs"
                 >
                   {!props.channelTypes.includes(row.channel_type) && (
                     <option value={row.channel_type}>{row.channel_type}</option>
@@ -761,7 +761,7 @@ function BindingsEditor(props: {
                   onChange={(e) =>
                     update(idx, { channel_type: e.target.value })
                   }
-                  className="w-28 rounded border border-neutral-300 dark:border-neutral-700 px-2 py-1 text-xs"
+                  className="w-28 rounded border border-[color:var(--border)] px-2 py-1 text-xs"
                   placeholder="teams"
                 />
               )}
@@ -772,12 +772,12 @@ function BindingsEditor(props: {
                 onChange={(e) =>
                   update(idx, { channel_key: e.target.value })
                 }
-                className="flex-1 rounded border border-neutral-300 dark:border-neutral-700 px-2 py-1 font-mono text-xs"
+                className="flex-1 rounded border border-[color:var(--border)] px-2 py-1 font-mono text-xs"
                 placeholder="28:bot-id-or-@username"
               />
               <button
                 type="button"
-                className="rounded border border-red-300 bg-red-50 px-2 py-1 text-xs text-red-800 hover:bg-red-100"
+                className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 px-2 py-1 text-xs text-[color:var(--danger)] hover:bg-[color:var(--danger)]/8"
                 disabled={props.disabled}
                 onClick={() => remove(idx)}
               >
@@ -797,7 +797,7 @@ function Field(props: {
 }): React.ReactElement {
   return (
     <label className="flex flex-col gap-1">
-      <span className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+      <span className="text-xs uppercase tracking-wide text-[color:var(--fg-muted)]">
         {props.label}
       </span>
       {props.children}

--- a/web-ui/app/operator/agents/_components/PluginsDnd.tsx
+++ b/web-ui/app/operator/agents/_components/PluginsDnd.tsx
@@ -504,7 +504,7 @@ function Column(props: {
       className={[
         'rounded border bg-[color:var(--bg-soft)]/40 p-2 transition-colors',
         isOver
-          ? 'border-[color:var(--accent)] bg-[color:var(--accent)]/10'
+          ? 'border-dashed border-[color:var(--accent)] bg-[color:var(--accent)]/10'
           : 'border-[color:var(--border)]',
       ].join(' ')}
     >
@@ -566,7 +566,8 @@ function DraggablePluginTile(props: {
     transform: CSS.Transform.toString(transform),
     transition,
     marginLeft: props.depth > 0 ? `${props.depth * 16}px` : undefined,
-    opacity: isDragging ? 0.4 : 1,
+    opacity: isDragging ? 0.5 : 1,
+    boxShadow: isDragging ? 'var(--shadow-drag)' : undefined,
   };
 
   const attached = props.selection !== null;

--- a/web-ui/app/operator/agents/_components/PluginsDnd.tsx
+++ b/web-ui/app/operator/agents/_components/PluginsDnd.tsx
@@ -290,7 +290,7 @@ export function PluginsDnd(props: PluginsDndProps): React.ReactElement {
         {t('pluginsHeading')}
         <button
           type="button"
-          className="rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-2 py-0.5 text-xs hover:bg-neutral-50 dark:hover:bg-neutral-700"
+          className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-2 py-0.5 text-xs hover:bg-[color:var(--bg-soft)]"
           disabled={props.disabled}
           onClick={submit}
         >
@@ -363,14 +363,14 @@ export function PluginsDnd(props: PluginsDndProps): React.ReactElement {
               );
             })}
             {orphans.length > 0 && (
-              <div className="mt-3 border-t border-amber-200 pt-2">
+              <div className="mt-3 border-t border-[color:var(--warning)] pt-2">
                 <div className="mb-1 flex items-center justify-between">
-                  <p className="text-[10px] uppercase tracking-wide text-amber-700">
+                  <p className="text-[10px] uppercase tracking-wide text-[color:var(--warning)]">
                     {t('orphanPluginsHeading')} ({orphans.length})
                   </p>
                   <button
                     type="button"
-                    className="rounded border border-amber-300 bg-white dark:bg-neutral-900 px-1.5 py-0 text-[10px] text-amber-900 hover:bg-amber-100"
+                    className="rounded border border-[color:var(--warning)] bg-[color:var(--bg-elevated)] px-1.5 py-0 text-[10px] text-[color:var(--warning)] hover:bg-[color:var(--warning)]/10"
                     disabled={props.disabled}
                     onClick={clearAllOrphans}
                     title={t('orphanDetachAllTooltip')}
@@ -378,15 +378,15 @@ export function PluginsDnd(props: PluginsDndProps): React.ReactElement {
                     {t('orphanDetachAll')}
                   </button>
                 </div>
-                <p className="mb-2 text-[10px] text-amber-800">
+                <p className="mb-2 text-[10px] text-[color:var(--warning)]">
                   {t('orphanExplain')}
                 </p>
                 {orphans.map((id) => (
                   <div
                     key={id}
-                    className="mb-1 flex items-center gap-2 rounded border border-amber-200 bg-amber-50 px-2 py-1 text-xs"
+                    className="mb-1 flex items-center gap-2 rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 px-2 py-1 text-xs"
                   >
-                    <label className="flex items-center gap-1 text-[10px] text-amber-900">
+                    <label className="flex items-center gap-1 text-[10px] text-[color:var(--warning)]">
                       <input
                         type="checkbox"
                         checked={keptOrphans.has(id)}
@@ -395,13 +395,13 @@ export function PluginsDnd(props: PluginsDndProps): React.ReactElement {
                       />
                       {t('orphanKeep')}
                     </label>
-                    <span className="font-mono text-amber-900">{id}</span>
-                    <span className="text-[10px] uppercase text-amber-800">
+                    <span className="font-mono text-[color:var(--warning)]">{id}</span>
+                    <span className="text-[10px] uppercase text-[color:var(--warning)]">
                       {t('orphanPluginBadge')}
                     </span>
                     <button
                       type="button"
-                      className="ml-auto rounded border border-amber-300 bg-white dark:bg-neutral-900 px-1.5 py-0 text-[10px] hover:bg-amber-100"
+                      className="ml-auto rounded border border-[color:var(--warning)] bg-[color:var(--bg-elevated)] px-1.5 py-0 text-[10px] hover:bg-[color:var(--warning)]/10"
                       disabled={props.disabled}
                       onClick={() => detach(id)}
                     >
@@ -415,9 +415,9 @@ export function PluginsDnd(props: PluginsDndProps): React.ReactElement {
         </div>
         <DragOverlay>
           {activeEntry ? (
-            <div className="rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-2 py-1.5 text-xs shadow-lg">
+            <div className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-2 py-1.5 text-xs shadow-lg">
               <span className="font-medium">{activeEntry.name}</span>
-              <code className="ml-1 font-mono text-[10px] text-neutral-500 dark:text-neutral-400">
+              <code className="ml-1 font-mono text-[10px] text-[color:var(--fg-muted)]">
                 {activeEntry.id}
               </code>
             </div>
@@ -502,17 +502,17 @@ function Column(props: {
     <div
       ref={setNodeRef}
       className={[
-        'rounded border bg-neutral-50/40 dark:bg-neutral-900/40 p-2 transition-colors',
+        'rounded border bg-[color:var(--bg-soft)]/40 p-2 transition-colors',
         isOver
-          ? 'border-sky-400 bg-sky-50/60'
-          : 'border-neutral-200 dark:border-neutral-800',
+          ? 'border-[color:var(--accent)] bg-[color:var(--accent)]/10'
+          : 'border-[color:var(--border)]',
       ].join(' ')}
     >
       <div className="mb-2 flex items-center justify-between px-1">
-        <span className="text-xs font-medium uppercase tracking-wide text-neutral-600">
+        <span className="text-xs font-medium uppercase tracking-wide text-[color:var(--fg-muted)]">
           {props.title}
         </span>
-        <span className="text-[10px] text-neutral-500 dark:text-neutral-400">{props.count}</span>
+        <span className="text-[10px] text-[color:var(--fg-muted)]">{props.count}</span>
       </div>
       <SortableContext
         items={itemIds}
@@ -520,7 +520,7 @@ function Column(props: {
       >
         <div className="space-y-1.5">
           {props.count === 0 ? (
-            <p className="px-1 py-3 text-center text-xs text-neutral-400 dark:text-neutral-500 dark:text-neutral-400">
+            <p className="px-1 py-3 text-center text-xs text-[color:var(--fg-subtle)]">
               {props.emptyLabel}
             </p>
           ) : (
@@ -575,13 +575,13 @@ function DraggablePluginTile(props: {
 
   return (
     <div ref={setNodeRef} style={style} className="select-none">
-      <div className="rounded border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900">
+      <div className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)]">
         <div className="flex items-start gap-1.5 px-2 py-1.5">
           <button
             type="button"
             {...attributes}
             {...listeners}
-            className="mt-0.5 cursor-grab text-neutral-400 dark:text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:text-neutral-200 active:cursor-grabbing"
+            className="mt-0.5 cursor-grab text-[color:var(--fg-subtle)] hover:text-[color:var(--fg)] active:cursor-grabbing"
             title={t('dragHandle')}
             disabled={props.disabled}
           >
@@ -589,10 +589,10 @@ function DraggablePluginTile(props: {
           </button>
           <div className="flex-1 text-xs">
             <div className="flex flex-wrap items-center gap-1.5">
-              <span className="font-medium text-neutral-800 dark:text-neutral-100">
+              <span className="font-medium text-[color:var(--fg)]">
                 {entry.name}
               </span>
-              <code className="font-mono text-[10px] text-neutral-500 dark:text-neutral-400">
+              <code className="font-mono text-[10px] text-[color:var(--fg-muted)]">
                 {entry.id}
               </code>
               <KindBadge kind={entry.kind} />
@@ -602,13 +602,13 @@ function DraggablePluginTile(props: {
                     entry.multi_instance_justification ??
                     t('multiInstanceFalseBadge')
                   }
-                  className="rounded bg-amber-100 px-1.5 py-0 text-[10px] uppercase tracking-wide text-amber-800"
+                  className="rounded bg-[color:var(--warning)]/10 px-1.5 py-0 text-[10px] uppercase tracking-wide text-[color:var(--warning)]"
                 >
                   {t('multiInstanceFalseShort')}
                 </span>
               )}
               {isStrict && (
-                <span className="rounded bg-violet-100 px-1.5 py-0 text-[10px] uppercase tracking-wide text-violet-800">
+                <span className="rounded bg-[color:var(--accent)]/10 px-1.5 py-0 text-[10px] uppercase tracking-wide text-[color:var(--accent)]">
                   {t('privacyStrictBadge')}
                 </span>
               )}
@@ -617,13 +617,13 @@ function DraggablePluginTile(props: {
                   title={t('dependencyMissingTooltip', {
                     parent: entry.depends_on[0] ?? '',
                   })}
-                  className="rounded bg-rose-100 px-1.5 py-0 text-[10px] uppercase tracking-wide text-rose-800"
+                  className="rounded bg-[color:var(--danger)]/8 px-1.5 py-0 text-[10px] uppercase tracking-wide text-[color:var(--danger)]"
                 >
                   {t('dependencyMissingBadge')}
                 </span>
               )}
               {attached && (
-                <label className="ml-auto flex items-center gap-1 text-[10px] text-neutral-600">
+                <label className="ml-auto flex items-center gap-1 text-[10px] text-[color:var(--fg-muted)]">
                   <input
                     type="checkbox"
                     checked={props.selection?.enabled ?? false}
@@ -641,7 +641,7 @@ function DraggablePluginTile(props: {
                   <span
                     key={`r-${s}`}
                     title={t('memoryReadTooltip')}
-                    className="rounded bg-blue-50 px-1.5 py-0 text-[10px] text-blue-800"
+                    className="rounded bg-[color:var(--accent)]/10 px-1.5 py-0 text-[10px] text-[color:var(--accent)]"
                   >
                     r:{s}
                   </span>
@@ -650,7 +650,7 @@ function DraggablePluginTile(props: {
                   <span
                     key={`w-${s}`}
                     title={t('memoryWriteTooltip')}
-                    className="rounded bg-emerald-50 px-1.5 py-0 text-[10px] text-emerald-800"
+                    className="rounded bg-[color:var(--success)]/10 px-1.5 py-0 text-[10px] text-[color:var(--success)]"
                   >
                     w:{s}
                   </span>
@@ -658,7 +658,7 @@ function DraggablePluginTile(props: {
               </div>
             )}
             {entry.network_outbound.length > 0 && (
-              <p className="mt-1 truncate text-[10px] text-neutral-500 dark:text-neutral-400">
+              <p className="mt-1 truncate text-[10px] text-[color:var(--fg-muted)]">
                 {t('networkLabel')} {entry.network_outbound.join(', ')}
               </p>
             )}
@@ -667,7 +667,7 @@ function DraggablePluginTile(props: {
             {!attached ? (
               <button
                 type="button"
-                className="rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-1.5 py-0.5 text-[10px] hover:bg-neutral-100 dark:hover:bg-neutral-700"
+                className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-1.5 py-0.5 text-[10px] hover:bg-[color:var(--bg-soft)]"
                 disabled={props.disabled}
                 onClick={props.onAttach}
               >
@@ -679,14 +679,14 @@ function DraggablePluginTile(props: {
                   <button
                     type="button"
                     onClick={props.onToggleExpanded}
-                    className="rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-1.5 py-0.5 text-[10px] hover:bg-neutral-100 dark:hover:bg-neutral-700"
+                    className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-1.5 py-0.5 text-[10px] hover:bg-[color:var(--bg-soft)]"
                   >
                     {props.expanded ? t('configHide') : t('configShow')}
                   </button>
                 )}
                 <button
                   type="button"
-                  className="rounded border border-red-200 bg-red-50 px-1.5 py-0.5 text-[10px] text-red-800 hover:bg-red-100"
+                  className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 px-1.5 py-0.5 text-[10px] text-[color:var(--danger)] hover:bg-[color:var(--danger)]/8"
                   disabled={props.disabled}
                   onClick={props.onDetach}
                 >
@@ -711,12 +711,12 @@ function DraggablePluginTile(props: {
 
 function KindBadge({ kind }: { kind: string }): React.ReactElement {
   const cls = {
-    agent: 'bg-sky-100 text-sky-800',
-    integration: 'bg-emerald-100 text-emerald-800',
-    channel: 'bg-fuchsia-100 text-fuchsia-800',
-    tool: 'bg-neutral-200 text-neutral-700 dark:text-neutral-200',
-    extension: 'bg-orange-100 text-orange-800',
-  }[kind] ?? 'bg-neutral-200 text-neutral-700 dark:text-neutral-200';
+    agent: 'bg-[color:var(--accent)]/10 text-[color:var(--accent)]',
+    integration: 'bg-[color:var(--success)]/10 text-[color:var(--success)]',
+    channel: 'bg-[color:var(--accent)]/10 text-[color:var(--accent)]',
+    tool: 'bg-[color:var(--state-loading)] text-[color:var(--fg)]',
+    extension: 'bg-[color:var(--warning)]/10 text-[color:var(--warning)]',
+  }[kind] ?? 'bg-[color:var(--state-loading)] text-[color:var(--fg)]';
   return (
     <span
       className={`rounded px-1.5 py-0 text-[10px] uppercase tracking-wide ${cls}`}
@@ -736,7 +736,7 @@ function PluginConfigForm(props: {
   ) => void;
 }): React.ReactElement {
   return (
-    <div className="border-t border-neutral-200 dark:border-neutral-800 bg-neutral-50/50 dark:bg-neutral-900/40 px-3 py-2">
+    <div className="border-t border-[color:var(--border)] bg-[color:var(--bg-soft)]/50 px-3 py-2">
       <div className="grid gap-2 sm:grid-cols-2">
         {props.fields.map((f) => (
           <PluginConfigField
@@ -767,10 +767,10 @@ function PluginConfigField(props: {
 
   return (
     <label className="flex flex-col gap-0.5">
-      <span className="text-[10px] uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+      <span className="text-[10px] uppercase tracking-wide text-[color:var(--fg-muted)]">
         {field.label}
         {field.help && (
-          <span className="ml-1 text-neutral-400 dark:text-neutral-500 dark:text-neutral-400">— {field.help}</span>
+          <span className="ml-1 text-[color:var(--fg-subtle)]">— {field.help}</span>
         )}
       </span>
       {isSecret ? (
@@ -780,7 +780,7 @@ function PluginConfigField(props: {
           disabled={disabled}
           onChange={(e) => onChange(e.target.value)}
           autoComplete="off"
-          className="rounded border border-neutral-300 dark:border-neutral-700 px-2 py-1 text-xs"
+          className="rounded border border-[color:var(--border)] px-2 py-1 text-xs"
           placeholder={typeof field.default === 'string' ? field.default : ''}
         />
       ) : isEnum ? (
@@ -788,7 +788,7 @@ function PluginConfigField(props: {
           value={typeof value === 'string' ? value : ''}
           disabled={disabled}
           onChange={(e) => onChange(e.target.value)}
-          className="rounded border border-neutral-300 dark:border-neutral-700 px-2 py-1 text-xs"
+          className="rounded border border-[color:var(--border)] px-2 py-1 text-xs"
         >
           <option value="">—</option>
           {field.enum?.map((opt) => (
@@ -819,7 +819,7 @@ function PluginConfigField(props: {
           onChange={(e) =>
             onChange(e.target.value === '' ? 0 : Number(e.target.value))
           }
-          className="rounded border border-neutral-300 dark:border-neutral-700 px-2 py-1 text-xs"
+          className="rounded border border-[color:var(--border)] px-2 py-1 text-xs"
         />
       ) : isHostList ? (
         <textarea
@@ -841,7 +841,7 @@ function PluginConfigField(props: {
           }
           rows={3}
           placeholder="hostname.example.com"
-          className="rounded border border-neutral-300 dark:border-neutral-700 px-2 py-1 font-mono text-xs"
+          className="rounded border border-[color:var(--border)] px-2 py-1 font-mono text-xs"
         />
       ) : (
         <input
@@ -850,7 +850,7 @@ function PluginConfigField(props: {
           disabled={disabled}
           onChange={(e) => onChange(e.target.value)}
           placeholder={typeof field.default === 'string' ? field.default : ''}
-          className="rounded border border-neutral-300 dark:border-neutral-700 px-2 py-1 text-xs"
+          className="rounded border border-[color:var(--border)] px-2 py-1 text-xs"
         />
       )}
     </label>

--- a/web-ui/app/operator/agents/_components/PluginsDnd.tsx
+++ b/web-ui/app/operator/agents/_components/PluginsDnd.tsx
@@ -370,7 +370,7 @@ export function PluginsDnd(props: PluginsDndProps): React.ReactElement {
                   </p>
                   <button
                     type="button"
-                    className="rounded border border-[color:var(--warning)] bg-[color:var(--bg-elevated)] px-1.5 py-0 text-[10px] text-[color:var(--warning)] hover:bg-[color:var(--warning)]/10"
+                    className="rounded border border-[color:var(--warning)] bg-[color:var(--bg-elevated)] px-2 py-0 text-[10px] text-[color:var(--warning)] hover:bg-[color:var(--warning)]/10"
                     disabled={props.disabled}
                     onClick={clearAllOrphans}
                     title={t('orphanDetachAllTooltip')}
@@ -401,7 +401,7 @@ export function PluginsDnd(props: PluginsDndProps): React.ReactElement {
                     </span>
                     <button
                       type="button"
-                      className="ml-auto rounded border border-[color:var(--warning)] bg-[color:var(--bg-elevated)] px-1.5 py-0 text-[10px] hover:bg-[color:var(--warning)]/10"
+                      className="ml-auto rounded border border-[color:var(--warning)] bg-[color:var(--bg-elevated)] px-2 py-0 text-[10px] hover:bg-[color:var(--warning)]/10"
                       disabled={props.disabled}
                       onClick={() => detach(id)}
                     >
@@ -415,7 +415,7 @@ export function PluginsDnd(props: PluginsDndProps): React.ReactElement {
         </div>
         <DragOverlay>
           {activeEntry ? (
-            <div className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-2 py-1.5 text-xs shadow-lg">
+            <div className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-2 py-2 text-xs shadow-lg">
               <span className="font-medium">{activeEntry.name}</span>
               <code className="ml-1 font-mono text-[10px] text-[color:var(--fg-muted)]">
                 {activeEntry.id}
@@ -518,7 +518,7 @@ function Column(props: {
         items={itemIds}
         strategy={verticalListSortingStrategy}
       >
-        <div className="space-y-1.5">
+        <div className="space-y-2">
           {props.count === 0 ? (
             <p className="px-1 py-3 text-center text-xs text-[color:var(--fg-subtle)]">
               {props.emptyLabel}
@@ -577,7 +577,7 @@ function DraggablePluginTile(props: {
   return (
     <div ref={setNodeRef} style={style} className="select-none">
       <div className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)]">
-        <div className="flex items-start gap-1.5 px-2 py-1.5">
+        <div className="flex items-start gap-2 px-2 py-2">
           <button
             type="button"
             {...attributes}
@@ -589,7 +589,7 @@ function DraggablePluginTile(props: {
             <GripVertical size={14} />
           </button>
           <div className="flex-1 text-xs">
-            <div className="flex flex-wrap items-center gap-1.5">
+            <div className="flex flex-wrap items-center gap-2">
               <span className="font-medium text-[color:var(--fg)]">
                 {entry.name}
               </span>
@@ -603,13 +603,13 @@ function DraggablePluginTile(props: {
                     entry.multi_instance_justification ??
                     t('multiInstanceFalseBadge')
                   }
-                  className="rounded bg-[color:var(--warning)]/10 px-1.5 py-0 text-[10px] uppercase tracking-wide text-[color:var(--warning)]"
+                  className="rounded bg-[color:var(--warning)]/10 px-2 py-0 text-[10px] uppercase tracking-wide text-[color:var(--warning)]"
                 >
                   {t('multiInstanceFalseShort')}
                 </span>
               )}
               {isStrict && (
-                <span className="rounded bg-[color:var(--accent)]/10 px-1.5 py-0 text-[10px] uppercase tracking-wide text-[color:var(--accent)]">
+                <span className="rounded bg-[color:var(--accent)]/10 px-2 py-0 text-[10px] uppercase tracking-wide text-[color:var(--accent)]">
                   {t('privacyStrictBadge')}
                 </span>
               )}
@@ -618,7 +618,7 @@ function DraggablePluginTile(props: {
                   title={t('dependencyMissingTooltip', {
                     parent: entry.depends_on[0] ?? '',
                   })}
-                  className="rounded bg-[color:var(--danger)]/8 px-1.5 py-0 text-[10px] uppercase tracking-wide text-[color:var(--danger)]"
+                  className="rounded bg-[color:var(--danger)]/8 px-2 py-0 text-[10px] uppercase tracking-wide text-[color:var(--danger)]"
                 >
                   {t('dependencyMissingBadge')}
                 </span>
@@ -642,7 +642,7 @@ function DraggablePluginTile(props: {
                   <span
                     key={`r-${s}`}
                     title={t('memoryReadTooltip')}
-                    className="rounded bg-[color:var(--accent)]/10 px-1.5 py-0 text-[10px] text-[color:var(--accent)]"
+                    className="rounded bg-[color:var(--accent)]/10 px-2 py-0 text-[10px] text-[color:var(--accent)]"
                   >
                     r:{s}
                   </span>
@@ -651,7 +651,7 @@ function DraggablePluginTile(props: {
                   <span
                     key={`w-${s}`}
                     title={t('memoryWriteTooltip')}
-                    className="rounded bg-[color:var(--success)]/10 px-1.5 py-0 text-[10px] text-[color:var(--success)]"
+                    className="rounded bg-[color:var(--success)]/10 px-2 py-0 text-[10px] text-[color:var(--success)]"
                   >
                     w:{s}
                   </span>
@@ -668,7 +668,7 @@ function DraggablePluginTile(props: {
             {!attached ? (
               <button
                 type="button"
-                className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-1.5 py-0.5 text-[10px] hover:bg-[color:var(--bg-soft)]"
+                className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-2 py-0.5 text-[10px] hover:bg-[color:var(--bg-soft)]"
                 disabled={props.disabled}
                 onClick={props.onAttach}
               >
@@ -680,14 +680,14 @@ function DraggablePluginTile(props: {
                   <button
                     type="button"
                     onClick={props.onToggleExpanded}
-                    className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-1.5 py-0.5 text-[10px] hover:bg-[color:var(--bg-soft)]"
+                    className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-2 py-0.5 text-[10px] hover:bg-[color:var(--bg-soft)]"
                   >
                     {props.expanded ? t('configHide') : t('configShow')}
                   </button>
                 )}
                 <button
                   type="button"
-                  className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 px-1.5 py-0.5 text-[10px] text-[color:var(--danger)] hover:bg-[color:var(--danger)]/8"
+                  className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 px-2 py-0.5 text-[10px] text-[color:var(--danger)] hover:bg-[color:var(--danger)]/8"
                   disabled={props.disabled}
                   onClick={props.onDetach}
                 >
@@ -720,7 +720,7 @@ function KindBadge({ kind }: { kind: string }): React.ReactElement {
   }[kind] ?? 'bg-[color:var(--state-loading)] text-[color:var(--fg)]';
   return (
     <span
-      className={`rounded px-1.5 py-0 text-[10px] uppercase tracking-wide ${cls}`}
+      className={`rounded px-2 py-0 text-[10px] uppercase tracking-wide ${cls}`}
     >
       {kind}
     </span>

--- a/web-ui/app/operator/agents/page.tsx
+++ b/web-ui/app/operator/agents/page.tsx
@@ -33,12 +33,12 @@ export default async function OperatorAgentsPage(): Promise<React.ReactElement> 
     <main className="mx-auto w-full max-w-[1400px] px-6 py-12 lg:px-10 lg:py-16">
       <header className="mb-10">
         <h1 className="text-3xl font-semibold tracking-tight">{t('title')}</h1>
-        <p className="mt-2 max-w-2xl text-sm text-neutral-600">
+        <p className="mt-2 max-w-2xl text-sm text-[color:var(--fg-muted)]">
           {t('subtitle')}
         </p>
       </header>
       {loadError ? (
-        <div className="rounded border border-red-400 bg-red-50 p-4 text-sm text-red-800">
+        <div className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-4 text-sm text-[color:var(--danger)]">
           {loadError}
         </div>
       ) : (

--- a/web-ui/app/operator/agents/page.tsx
+++ b/web-ui/app/operator/agents/page.tsx
@@ -30,8 +30,8 @@ export default async function OperatorAgentsPage(): Promise<React.ReactElement> 
   }
 
   return (
-    <main className="mx-auto w-full max-w-[1400px] px-6 py-12 lg:px-10 lg:py-16">
-      <header className="mb-10">
+    <main className="mx-auto w-full max-w-[1400px] px-6 py-12 lg:px-8 lg:py-16">
+      <header className="mb-8">
         <h1 className="text-3xl font-semibold tracking-tight">{t('title')}</h1>
         <p className="mt-2 max-w-2xl text-sm text-[color:var(--fg-muted)]">
           {t('subtitle')}

--- a/web-ui/app/operator/channels/_components/ChannelsDashboard.tsx
+++ b/web-ui/app/operator/channels/_components/ChannelsDashboard.tsx
@@ -89,7 +89,7 @@ export function ChannelsDashboard({ initial }: Props): React.ReactElement {
           key={group.type}
           className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)]"
         >
-          <header className="border-b border-[color:var(--border)] px-5 py-3">
+          <header className="border-b border-[color:var(--border)] px-4 py-3">
             <h2 className="text-base font-semibold uppercase tracking-wide text-[color:var(--fg)]">
               {group.type}{' '}
               <span className="ml-1 text-xs font-normal text-[color:var(--fg-muted)]">
@@ -101,7 +101,7 @@ export function ChannelsDashboard({ initial }: Props): React.ReactElement {
             {group.channels.map((c) => (
               <li
                 key={`${c.channel_type}:${c.channel_key}`}
-                className="flex flex-wrap items-center gap-3 px-5 py-3"
+                className="flex flex-wrap items-center gap-3 px-4 py-3"
               >
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
@@ -109,12 +109,12 @@ export function ChannelsDashboard({ initial }: Props): React.ReactElement {
                       {c.label}
                     </span>
                     {c.hint && (
-                      <span className="rounded bg-[color:var(--bg-soft)] px-1.5 py-0 text-[11px] text-[color:var(--fg-muted)]">
+                      <span className="rounded bg-[color:var(--bg-soft)] px-2 py-0 text-[11px] text-[color:var(--fg-muted)]">
                         {c.hint}
                       </span>
                     )}
                     {c.stale && (
-                      <span className="rounded bg-[color:var(--warning)]/10 px-1.5 py-0 text-[10px] uppercase tracking-wide text-[color:var(--warning)]">
+                      <span className="rounded bg-[color:var(--warning)]/10 px-2 py-0 text-[10px] uppercase tracking-wide text-[color:var(--warning)]">
                         {t('staleBadge')}
                       </span>
                     )}

--- a/web-ui/app/operator/channels/_components/ChannelsDashboard.tsx
+++ b/web-ui/app/operator/channels/_components/ChannelsDashboard.tsx
@@ -53,15 +53,15 @@ export function ChannelsDashboard({ initial }: Props): React.ReactElement {
     return (
       <div className="space-y-4">
         {error && (
-          <div className="rounded border border-red-400 bg-red-50 p-3 text-sm text-red-800">
+          <div className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-3 text-sm text-[color:var(--danger)]">
             {error}
           </div>
         )}
-        <div className="rounded border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 p-8 text-sm text-neutral-600 dark:text-neutral-300">
+        <div className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-8 text-sm text-[color:var(--fg-muted)]">
           <p className="mb-2 font-medium">{t('emptyHeading')}</p>
           <p>{t('emptyExplain')}</p>
           {initial.directory_types.length > 0 && (
-            <p className="mt-3 text-xs text-neutral-500 dark:text-neutral-400">
+            <p className="mt-3 text-xs text-[color:var(--fg-muted)]">
               {t('emptyDirectoriesKnown', {
                 types: initial.directory_types.join(', '),
               })}
@@ -75,11 +75,11 @@ export function ChannelsDashboard({ initial }: Props): React.ReactElement {
   return (
     <div className="space-y-6">
       {error && (
-        <div className="rounded border border-red-400 bg-red-50 p-3 text-sm text-red-800">
+        <div className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-3 text-sm text-[color:var(--danger)]">
           {error}
         </div>
       )}
-      <p className="text-xs text-neutral-500 dark:text-neutral-400">
+      <p className="text-xs text-[color:var(--fg-muted)]">
         {t('fallbackHint', {
           fallback: initial.fallback_slug ?? t('fallbackHintNone'),
         })}
@@ -87,17 +87,17 @@ export function ChannelsDashboard({ initial }: Props): React.ReactElement {
       {groups.map((group) => (
         <section
           key={group.type}
-          className="rounded border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900"
+          className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)]"
         >
-          <header className="border-b border-neutral-200 dark:border-neutral-800 px-5 py-3">
-            <h2 className="text-base font-semibold uppercase tracking-wide text-neutral-800 dark:text-neutral-100">
+          <header className="border-b border-[color:var(--border)] px-5 py-3">
+            <h2 className="text-base font-semibold uppercase tracking-wide text-[color:var(--fg)]">
               {group.type}{' '}
-              <span className="ml-1 text-xs font-normal text-neutral-500 dark:text-neutral-400">
+              <span className="ml-1 text-xs font-normal text-[color:var(--fg-muted)]">
                 ({group.channels.length})
               </span>
             </h2>
           </header>
-          <ul className="divide-y divide-neutral-200 dark:divide-neutral-800">
+          <ul className="divide-y divide-[color:var(--divider)]">
             {group.channels.map((c) => (
               <li
                 key={`${c.channel_type}:${c.channel_key}`}
@@ -105,21 +105,21 @@ export function ChannelsDashboard({ initial }: Props): React.ReactElement {
               >
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
-                    <span className="font-medium text-neutral-800 dark:text-neutral-100">
+                    <span className="font-medium text-[color:var(--fg)]">
                       {c.label}
                     </span>
                     {c.hint && (
-                      <span className="rounded bg-neutral-100 dark:bg-neutral-800 px-1.5 py-0 text-[11px] text-neutral-600 dark:text-neutral-300">
+                      <span className="rounded bg-[color:var(--bg-soft)] px-1.5 py-0 text-[11px] text-[color:var(--fg-muted)]">
                         {c.hint}
                       </span>
                     )}
                     {c.stale && (
-                      <span className="rounded bg-amber-100 px-1.5 py-0 text-[10px] uppercase tracking-wide text-amber-800">
+                      <span className="rounded bg-[color:var(--warning)]/10 px-1.5 py-0 text-[10px] uppercase tracking-wide text-[color:var(--warning)]">
                         {t('staleBadge')}
                       </span>
                     )}
                   </div>
-                  <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-neutral-500 dark:text-neutral-400">
+                  <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-[color:var(--fg-muted)]">
                     <code className="font-mono">{c.channel_key}</code>
                     {c.origin_plugin_id && (
                       <span>
@@ -129,7 +129,7 @@ export function ChannelsDashboard({ initial }: Props): React.ReactElement {
                     )}
                   </div>
                 </div>
-                <label className="flex items-center gap-2 text-xs text-neutral-600 dark:text-neutral-300">
+                <label className="flex items-center gap-2 text-xs text-[color:var(--fg-muted)]">
                   <span>{t('routesTo')}</span>
                   <select
                     value={c.bound_agent_slug ?? ''}
@@ -143,7 +143,7 @@ export function ChannelsDashboard({ initial }: Props): React.ReactElement {
                           : setChannelBinding(c.channel_type, c.channel_key, v),
                       );
                     }}
-                    className="rounded border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-2 py-1 text-xs"
+                    className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-2 py-1 text-xs"
                   >
                     <option value="">
                       {t('routesToFallback', {
@@ -160,7 +160,7 @@ export function ChannelsDashboard({ initial }: Props): React.ReactElement {
                 {c.stale && (
                   <button
                     type="button"
-                    className="rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs text-amber-800 hover:bg-amber-100"
+                    className="rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 px-2 py-1 text-xs text-[color:var(--warning)] hover:bg-[color:var(--warning)]/10"
                     disabled={pending || !!busy}
                     onClick={() => {
                       const key = `${c.channel_type}:${c.channel_key}`;

--- a/web-ui/app/operator/channels/page.tsx
+++ b/web-ui/app/operator/channels/page.tsx
@@ -38,12 +38,12 @@ export default async function OperatorChannelsPage(): Promise<React.ReactElement
     <main className="mx-auto w-full max-w-[1400px] px-6 py-12 lg:px-10 lg:py-16">
       <header className="mb-10">
         <h1 className="text-3xl font-semibold tracking-tight">{t('title')}</h1>
-        <p className="mt-2 max-w-2xl text-sm text-neutral-600 dark:text-neutral-300">
+        <p className="mt-2 max-w-2xl text-sm text-[color:var(--fg-muted)]">
           {t('subtitle')}
         </p>
       </header>
       {loadError ? (
-        <div className="rounded border border-red-400 bg-red-50 p-4 text-sm text-red-800">
+        <div className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-4 text-sm text-[color:var(--danger)]">
           {loadError}
         </div>
       ) : (

--- a/web-ui/app/operator/channels/page.tsx
+++ b/web-ui/app/operator/channels/page.tsx
@@ -35,8 +35,8 @@ export default async function OperatorChannelsPage(): Promise<React.ReactElement
   }
 
   return (
-    <main className="mx-auto w-full max-w-[1400px] px-6 py-12 lg:px-10 lg:py-16">
-      <header className="mb-10">
+    <main className="mx-auto w-full max-w-[1400px] px-6 py-12 lg:px-8 lg:py-16">
+      <header className="mb-8">
         <h1 className="text-3xl font-semibold tracking-tight">{t('title')}</h1>
         <p className="mt-2 max-w-2xl text-sm text-[color:var(--fg-muted)]">
           {t('subtitle')}

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -788,10 +788,14 @@ function MessageRow({
               <SteerList steers={message.steers ?? []} />
             )}
             {message.content.length > 0 ? (
-              <Markdown
-                source={message.content}
-                highlightTerms={message.maskedValues}
-              />
+              /* §2.7: agent narration renders in the prose register
+                 (Source Serif 4); headings/tables/code stay structural. */
+              <div className="lume-prose">
+                <Markdown
+                  source={message.content}
+                  highlightTerms={message.maskedValues}
+                />
+              </div>
             ) : message.streaming ? (
               <StreamingDots />
             ) : null}

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -441,7 +441,7 @@ export default function ChatPage(): React.ReactElement {
         disabled={sending}
       />
 
-      <div className="border-b border-[color:var(--border)] bg-white/60 px-6 py-2 text-xs">
+      <div className="border-b border-[color:var(--border)] bg-[color:var(--bg-elevated)]/75 px-6 py-2 text-xs">
         <div className="mx-auto flex max-w-4xl flex-col gap-2">
           {/* Row 1 — stream info. Verlauf-Leeren wanderte 2026-05-26 als
               Eraser-Icon in den Composer (links neben Senden). */}
@@ -588,7 +588,7 @@ export default function ChatPage(): React.ReactElement {
           recent turn. Gated by its own header toggle. */}
       <PlanDagPane plan={planDagEnabled ? activePlan : null} />
 
-      <footer className="border-t border-[color:var(--border)] bg-white/80 px-6 py-4 backdrop-blur">
+      <footer className="border-t border-[color:var(--border)] bg-[color:var(--bg-elevated)]/85 px-6 py-4 backdrop-blur">
         <div className="mx-auto flex max-w-4xl flex-col gap-1.5">
           {/* Mid-turn steering hint / feedback — only while a turn streams. */}
           {sending && (
@@ -663,7 +663,7 @@ export default function ChatPage(): React.ReactElement {
                   send();
                 }}
                 disabled={input.trim().length === 0 || hydrating}
-                className="rounded bg-[color:var(--bg-inverse)] px-4 py-2 text-sm font-medium text-[color:var(--fg-on-dark)] transition hover:bg-[color:var(--fg-muted)] disabled:cursor-not-allowed disabled:opacity-40"
+                className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {t('sendButton')}
               </button>
@@ -1229,7 +1229,7 @@ function SubTrace({
                 ? 'border-[color:var(--border)]'
                 : row.result?.isError
                   ? 'border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8'
-                  : 'border-[color:var(--border)] bg-white/60',
+                  : 'border-[color:var(--border)] bg-[color:var(--bg-elevated)]/75',
             ].join(' ')}
           >
             <summary className="flex cursor-pointer items-center gap-2 px-2 py-0.5 font-mono select-none">

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -1037,15 +1037,15 @@ function TriageBadge({
   const verdict: Record<typeof routing.bucket, { label: string; cls: string }> = {
     simple: {
       label: 'einfach',
-      cls: 'bg-[color:var(--success)]/100/10 text-[color:var(--success)] ring-[color:var(--success)]',
+      cls: 'bg-[color:var(--success)]/10 text-[color:var(--success)] ring-[color:var(--success)]',
     },
     complex: {
       label: 'komplex',
-      cls: 'bg-[color:var(--accent)]/100/10 text-[color:var(--accent)] ring-[color:var(--accent)]',
+      cls: 'bg-[color:var(--accent)]/10 text-[color:var(--accent)] ring-[color:var(--accent)]',
     },
     fallback: {
       label: 'Fallback',
-      cls: 'bg-[color:var(--warning)]/100/10 text-[color:var(--warning)] ring-[color:var(--warning)]',
+      cls: 'bg-[color:var(--warning)]/10 text-[color:var(--warning)] ring-[color:var(--warning)]',
     },
   };
   const v = verdict[routing.bucket];
@@ -1592,9 +1592,9 @@ function phasePillClass(
     'inline-flex items-center rounded px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.16em]';
   switch (phase) {
     case 'streaming':
-      return `${base} bg-[color:var(--accent)]/100/15 text-[color:var(--accent)]`;
+      return `${base} bg-[color:var(--accent)]/15 text-[color:var(--accent)]`;
     case 'tool_running':
-      return `${base} bg-[color:var(--warning)]/100/15 text-[color:var(--warning)]`;
+      return `${base} bg-[color:var(--warning)]/15 text-[color:var(--warning)]`;
     case 'thinking':
     case 'idle':
     default:

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -476,7 +476,7 @@ export default function ChatPage(): React.ReactElement {
               onClick={() => setKgWalkEnabled(!kgWalkEnabled)}
               title={t('kgWalk.toggleLabel')}
               className={[
-                'inline-flex select-none items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition',
+                'inline-flex select-none items-center gap-2 rounded-full border px-3 py-1 text-[11px] font-medium transition',
                 kgWalkEnabled
                   ? 'border-[color:var(--accent)] bg-[color:var(--accent)]/10 text-[color:var(--accent)]'
                   : 'border-[color:var(--border)] bg-transparent text-[color:var(--fg-subtle)] hover:text-[color:var(--fg-muted)]',
@@ -501,7 +501,7 @@ export default function ChatPage(): React.ReactElement {
               onClick={() => setPlanDagEnabled(!planDagEnabled)}
               title={t('planDag.toggleLabel')}
               className={[
-                'inline-flex select-none items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition',
+                'inline-flex select-none items-center gap-2 rounded-full border px-3 py-1 text-[11px] font-medium transition',
                 planDagEnabled
                   ? 'border-[color:var(--accent)] bg-[color:var(--accent)]/10 text-[color:var(--accent)]'
                   : 'border-[color:var(--border)] bg-transparent text-[color:var(--fg-subtle)] hover:text-[color:var(--fg-muted)]',
@@ -589,10 +589,10 @@ export default function ChatPage(): React.ReactElement {
       <PlanDagPane plan={planDagEnabled ? activePlan : null} />
 
       <footer className="border-t border-[color:var(--border)] bg-[color:var(--bg-elevated)]/85 px-6 py-4 backdrop-blur">
-        <div className="mx-auto flex max-w-4xl flex-col gap-1.5">
+        <div className="mx-auto flex max-w-4xl flex-col gap-2">
           {/* Mid-turn steering hint / feedback — only while a turn streams. */}
           {sending && (
-            <div className="flex items-center gap-1.5 text-[11px]">
+            <div className="flex items-center gap-2 text-[11px]">
               <Navigation size={11} aria-hidden className="text-[color:var(--warning)]" />
               {steerNotice === 'sent' ? (
                 <span className="text-[color:var(--warning)]">
@@ -643,7 +643,7 @@ export default function ChatPage(): React.ReactElement {
                   }}
                   disabled={input.trim().length === 0 || steerBusy || hydrating}
                   title={t('steerButtonTitle')}
-                  className="flex items-center gap-1.5 rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 px-4 py-2 text-sm font-medium text-[color:var(--warning)] transition hover:bg-[color:var(--warning)]/10 disabled:cursor-not-allowed disabled:opacity-40"
+                  className="flex items-center gap-2 rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 px-4 py-2 text-sm font-medium text-[color:var(--warning)] transition hover:bg-[color:var(--warning)]/10 disabled:cursor-not-allowed disabled:opacity-40"
                 >
                   <Navigation size={14} aria-hidden />
                   {t('steerButton')}
@@ -847,7 +847,7 @@ function MessageRow({
               )}
               {message.model && (
                 <span
-                  className="ml-3 rounded bg-current/10 px-1.5 py-0.5 font-medium"
+                  className="ml-3 rounded bg-current/10 px-2 py-0.5 font-medium"
                   title={message.model}
                 >
                   {shortModelName(message.model)}
@@ -1051,7 +1051,7 @@ function TriageBadge({
   const v = verdict[routing.bucket];
   return (
     <div
-      className="mb-2 inline-flex flex-wrap items-center gap-1.5 text-[11px] text-[color:var(--fg-muted)]"
+      className="mb-2 inline-flex flex-wrap items-center gap-2 text-[11px] text-[color:var(--fg-muted)]"
       title={`Triage-Klassifizierer: ${routing.classifierModel} → ${routing.bucket} → ${routing.model}`}
     >
       <span className="font-medium uppercase tracking-[0.12em]">Triage</span>
@@ -1059,12 +1059,12 @@ function TriageBadge({
         {shortModelName(routing.classifierModel)} →
       </span>
       <span
-        className={`inline-flex items-center rounded-full px-1.5 py-0.5 font-medium uppercase tracking-[0.08em] ring-1 ${v.cls}`}
+        className={`inline-flex items-center rounded-full px-2 py-0.5 font-medium uppercase tracking-[0.08em] ring-1 ${v.cls}`}
       >
         {v.label}
       </span>
       <span className="text-[color:var(--fg-subtle)]">→</span>
-      <span className="rounded bg-current/10 px-1.5 py-0.5 font-medium">
+      <span className="rounded bg-current/10 px-2 py-0.5 font-medium">
         {shortModelName(routing.model)}
       </span>
     </div>
@@ -1135,7 +1135,7 @@ function SteerList({ steers }: { steers: string[] }): React.ReactElement {
       {steers.map((text, i) => (
         <div
           key={`${String(i)}:${text.slice(0, 24)}`}
-          className="flex items-start gap-1.5 rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 px-2 py-1 text-[11px] text-[color:var(--warning)]"
+          className="flex items-start gap-2 rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 px-2 py-1 text-[11px] text-[color:var(--warning)]"
         >
           <Navigation size={11} aria-hidden className="mt-0.5 shrink-0" />
           <span>
@@ -1480,10 +1480,10 @@ function FollowUpButtons({
   const t = useTranslations('chat');
   return (
     <div className="mt-3 border-t border-[color:var(--border)] pt-2">
-      <div className="mb-1.5 text-[10px] font-medium tracking-wide text-[color:var(--fg-muted)] uppercase">
+      <div className="mb-2 text-[10px] font-medium tracking-wide text-[color:var(--fg-muted)] uppercase">
         {t('followUpsLabel')}
       </div>
-      <div className="flex flex-wrap gap-1.5">
+      <div className="flex flex-wrap gap-2">
         {options.map((opt, idx) => (
           <button
             key={`${opt.label}-${String(idx)}`}
@@ -1542,7 +1542,7 @@ function LivenessRow({
   return (
     <div
       className={[
-        'mt-2 inline-flex flex-wrap items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.18em]',
+        'mt-2 inline-flex flex-wrap items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em]',
         stuck
           ? 'text-[color:var(--danger)]'
           : 'text-[color:var(--fg-muted)]',
@@ -1589,7 +1589,7 @@ function phasePillClass(
   phase: 'thinking' | 'streaming' | 'tool_running' | 'idle',
 ): string {
   const base =
-    'inline-flex items-center rounded px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.16em]';
+    'inline-flex items-center rounded px-2 py-0.5 text-[9px] font-bold uppercase tracking-[0.16em]';
   switch (phase) {
     case 'streaming':
       return `${base} bg-[color:var(--accent)]/15 text-[color:var(--accent)]`;

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -441,15 +441,15 @@ export default function ChatPage(): React.ReactElement {
         disabled={sending}
       />
 
-      <div className="border-b border-neutral-200 bg-white/60 px-6 py-2 text-xs dark:border-neutral-800 dark:bg-neutral-900/60">
+      <div className="border-b border-[color:var(--border)] bg-white/60 px-6 py-2 text-xs">
         <div className="mx-auto flex max-w-4xl flex-col gap-2">
           {/* Row 1 — stream info. Verlauf-Leeren wanderte 2026-05-26 als
               Eraser-Icon in den Composer (links neben Senden). */}
-          <div className="flex flex-wrap items-center gap-3 text-neutral-500">
+          <div className="flex flex-wrap items-center gap-3 text-[color:var(--fg-muted)]">
             <span>
               {t('streamLabel')} <code className="font-mono">/bot-api/chat/stream</code>
             </span>
-            <span className="truncate font-mono text-[11px] text-neutral-400">
+            <span className="truncate font-mono text-[11px] text-[color:var(--fg-subtle)]">
               {/* `activeId` is a client-only minted UUID — rendering it during
                   SSR produces a hydration mismatch (#95). Hold a placeholder
                   until `useChatSessions` finishes hydrating. */}
@@ -478,8 +478,8 @@ export default function ChatPage(): React.ReactElement {
               className={[
                 'inline-flex select-none items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition',
                 kgWalkEnabled
-                  ? 'border-indigo-300 bg-indigo-50 text-indigo-700 dark:border-indigo-600/60 dark:bg-indigo-500/15 dark:text-indigo-300'
-                  : 'border-neutral-300 bg-transparent text-neutral-400 hover:text-neutral-600 dark:border-neutral-700 dark:hover:text-neutral-300',
+                  ? 'border-[color:var(--accent)] bg-[color:var(--accent)]/10 text-[color:var(--accent)]'
+                  : 'border-[color:var(--border)] bg-transparent text-[color:var(--fg-subtle)] hover:text-[color:var(--fg-muted)]',
               ].join(' ')}
             >
               <Network size={12} aria-hidden />
@@ -489,8 +489,8 @@ export default function ChatPage(): React.ReactElement {
                 className={[
                   'inline-block h-1.5 w-1.5 rounded-full',
                   kgWalkEnabled
-                    ? 'bg-indigo-500'
-                    : 'bg-neutral-400 dark:bg-neutral-600',
+                    ? 'bg-[color:var(--accent)]/100'
+                    : 'bg-[color:var(--fg-subtle)]',
                 ].join(' ')}
               />
             </button>
@@ -503,8 +503,8 @@ export default function ChatPage(): React.ReactElement {
               className={[
                 'inline-flex select-none items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition',
                 planDagEnabled
-                  ? 'border-sky-300 bg-sky-50 text-sky-700 dark:border-sky-600/60 dark:bg-sky-500/15 dark:text-sky-300'
-                  : 'border-neutral-300 bg-transparent text-neutral-400 hover:text-neutral-600 dark:border-neutral-700 dark:hover:text-neutral-300',
+                  ? 'border-[color:var(--accent)] bg-[color:var(--accent)]/10 text-[color:var(--accent)]'
+                  : 'border-[color:var(--border)] bg-transparent text-[color:var(--fg-subtle)] hover:text-[color:var(--fg-muted)]',
               ].join(' ')}
             >
               <GitBranch size={12} aria-hidden />
@@ -514,8 +514,8 @@ export default function ChatPage(): React.ReactElement {
                 className={[
                   'inline-block h-1.5 w-1.5 rounded-full',
                   planDagEnabled
-                    ? 'bg-sky-500'
-                    : 'bg-neutral-400 dark:bg-neutral-600',
+                    ? 'bg-[color:var(--accent)]/100'
+                    : 'bg-[color:var(--fg-subtle)]',
                 ].join(' ')}
               />
             </button>
@@ -588,22 +588,22 @@ export default function ChatPage(): React.ReactElement {
           recent turn. Gated by its own header toggle. */}
       <PlanDagPane plan={planDagEnabled ? activePlan : null} />
 
-      <footer className="border-t border-neutral-200 bg-white/80 px-6 py-4 backdrop-blur dark:border-neutral-800 dark:bg-neutral-900/80">
+      <footer className="border-t border-[color:var(--border)] bg-white/80 px-6 py-4 backdrop-blur">
         <div className="mx-auto flex max-w-4xl flex-col gap-1.5">
           {/* Mid-turn steering hint / feedback — only while a turn streams. */}
           {sending && (
             <div className="flex items-center gap-1.5 text-[11px]">
-              <Navigation size={11} aria-hidden className="text-amber-600 dark:text-amber-400" />
+              <Navigation size={11} aria-hidden className="text-[color:var(--warning)]" />
               {steerNotice === 'sent' ? (
-                <span className="text-amber-700 dark:text-amber-400">
+                <span className="text-[color:var(--warning)]">
                   {t('steerNoticeSent')}
                 </span>
               ) : steerNotice === 'ended' ? (
-                <span className="text-neutral-500 dark:text-neutral-400">
+                <span className="text-[color:var(--fg-muted)]">
                   {t('steerNoticeEnded')}
                 </span>
               ) : (
-                <span className="text-neutral-500 dark:text-neutral-400">
+                <span className="text-[color:var(--fg-muted)]">
                   {t('steerHint')}
                 </span>
               )}
@@ -614,7 +614,7 @@ export default function ChatPage(): React.ReactElement {
               type="button"
               onClick={requestReset}
               disabled={!canReset}
-              className="rounded border border-neutral-300 bg-white p-2 text-neutral-500 transition hover:border-neutral-400 hover:text-neutral-700 disabled:cursor-not-allowed disabled:opacity-30 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-200"
+              className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-2 text-[color:var(--fg-muted)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--fg)] disabled:cursor-not-allowed disabled:opacity-30"
               title={t('composerResetTitle')}
               aria-label={t('composerResetAriaLabel')}
             >
@@ -629,7 +629,7 @@ export default function ChatPage(): React.ReactElement {
               onKeyDown={onKeyDown}
               rows={2}
               placeholder={sending ? t('steerPlaceholder') : t('placeholder')}
-              className="flex-1 resize-none rounded border border-neutral-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-neutral-500 focus:outline-none dark:border-neutral-700 dark:bg-neutral-800"
+              className="flex-1 resize-none rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-3 py-2 text-sm shadow-sm focus:border-[color:var(--border-strong)] focus:outline-none"
               disabled={hydrating}
             />
             {sending ? (
@@ -641,7 +641,7 @@ export default function ChatPage(): React.ReactElement {
                   }}
                   disabled={input.trim().length === 0 || steerBusy || hydrating}
                   title={t('steerButtonTitle')}
-                  className="flex items-center gap-1.5 rounded border border-amber-300 bg-amber-50 px-4 py-2 text-sm font-medium text-amber-800 transition hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-40 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300 dark:hover:bg-amber-900"
+                  className="flex items-center gap-1.5 rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 px-4 py-2 text-sm font-medium text-[color:var(--warning)] transition hover:bg-[color:var(--warning)]/10 disabled:cursor-not-allowed disabled:opacity-40"
                 >
                   <Navigation size={14} aria-hidden />
                   {t('steerButton')}
@@ -649,7 +649,7 @@ export default function ChatPage(): React.ReactElement {
                 <button
                   type="button"
                   onClick={abort}
-                  className="rounded border border-red-300 bg-red-50 px-4 py-2 text-sm font-medium text-red-700 transition hover:bg-red-100 dark:border-red-900 dark:bg-red-950 dark:text-red-300"
+                  className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 px-4 py-2 text-sm font-medium text-[color:var(--danger)] transition hover:bg-[color:var(--danger)]/8"
                 >
                   {t('stopButton')}
                 </button>
@@ -661,7 +661,7 @@ export default function ChatPage(): React.ReactElement {
                   send();
                 }}
                 disabled={input.trim().length === 0 || hydrating}
-                className="rounded bg-neutral-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-neutral-700 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-neutral-300"
+                className="rounded bg-[color:var(--bg-inverse)] px-4 py-2 text-sm font-medium text-[color:var(--fg-on-dark)] transition hover:bg-[color:var(--fg-muted)] disabled:cursor-not-allowed disabled:opacity-40"
               >
                 {t('sendButton')}
               </button>
@@ -698,16 +698,16 @@ function EmptyState({
   const t = useTranslations('chat');
   if (hydrating) {
     return (
-      <div className="rounded-lg border border-dashed border-neutral-300 p-8 text-center text-sm text-neutral-400 dark:border-neutral-700">
+      <div className="rounded-lg border border-dashed border-[color:var(--border)] p-8 text-center text-sm text-[color:var(--fg-subtle)]">
         {t('sessionsLoading')}
       </div>
     );
   }
   return (
-    <div className="rounded-lg border border-dashed border-neutral-300 p-8 text-center text-sm text-neutral-500 dark:border-neutral-700">
+    <div className="rounded-lg border border-dashed border-[color:var(--border)] p-8 text-center text-sm text-[color:var(--fg-muted)]">
       <div className="font-medium">{session.title}</div>
       <div className="mt-1">{t('emptyStatePrompt')}</div>
-      <div className="mt-2 text-xs text-neutral-400">
+      <div className="mt-2 text-xs text-[color:var(--fg-subtle)]">
         {t('emptyStateShortcut')}
       </div>
     </div>
@@ -753,10 +753,10 @@ function MessageRow({
         className={[
           'max-w-[85%] rounded-lg px-4 py-3 shadow-sm',
           isUser
-            ? 'bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900'
+            ? 'bg-[color:var(--bg-inverse)] text-[color:var(--fg-on-dark)]'
             : message.error
-              ? 'bg-red-50 text-red-900 ring-1 ring-red-200 dark:bg-red-900/30 dark:text-red-100 dark:ring-red-800'
-              : 'bg-white text-neutral-900 ring-1 ring-neutral-200 dark:bg-neutral-800 dark:text-neutral-100 dark:ring-neutral-700',
+              ? 'bg-[color:var(--danger)]/8 text-[color:var(--danger)] ring-1 ring-[color:var(--danger-edge)]'
+              : 'bg-[color:var(--bg-elevated)] text-[color:var(--fg-strong)] ring-1 ring-[color:var(--border-strong)]',
         ].join(' ')}
       >
         {isUser ? (
@@ -829,7 +829,7 @@ function MessageRow({
         )}
         {!isUser &&
           (message.telemetry || elapsed || message.turnId !== undefined) && (
-            <div className="mt-2 flex flex-wrap items-center border-t border-current/10 pt-2 text-[11px] text-neutral-500 dark:text-neutral-400">
+            <div className="mt-2 flex flex-wrap items-center border-t border-current/10 pt-2 text-[11px] text-[color:var(--fg-muted)]">
               {message.telemetry && (
                 <span>
                   tools={message.telemetry.tool_calls} · iterations=
@@ -887,8 +887,8 @@ function MessageRow({
 function ToolTrace({ tools }: { tools: ToolEvent[] }): React.ReactElement {
   const t = useTranslations('chat');
   return (
-    <details className="mb-2 rounded bg-neutral-50 text-xs dark:bg-neutral-900/60" open>
-      <summary className="cursor-pointer px-2 py-1 font-medium text-neutral-600 select-none dark:text-neutral-400">
+    <details className="mb-2 rounded bg-[color:var(--bg-soft)] text-xs" open>
+      <summary className="cursor-pointer px-2 py-1 font-medium text-[color:var(--fg-muted)] select-none">
         {t('toolTraceHeading', { count: tools.length })}
       </summary>
       <div className="flex flex-col gap-1 px-2 pb-2">
@@ -923,11 +923,11 @@ function ToolRow({ tool }: { tool: ToolEvent }): React.ReactElement {
     (tool.startedAt !== undefined ? now - tool.startedAt : tool.liveElapsedMs ?? 0);
   const elapsedColor = pending
     ? elapsedMs > 60_000
-      ? 'text-orange-600 dark:text-orange-400'
+      ? 'text-[color:var(--warning)]'
       : elapsedMs > 30_000
-        ? 'text-amber-600 dark:text-amber-400'
-        : 'text-neutral-500'
-    : 'text-neutral-500';
+        ? 'text-[color:var(--warning)]'
+        : 'text-[color:var(--fg-muted)]'
+    : 'text-[color:var(--fg-muted)]';
 
   const subEvents = tool.subEvents ?? [];
 
@@ -936,12 +936,12 @@ function ToolRow({ tool }: { tool: ToolEvent }): React.ReactElement {
       className={[
         'rounded border text-[11px]',
         pending
-          ? 'border-neutral-300 dark:border-neutral-700'
+          ? 'border-[color:var(--border)]'
           : tool.isError
-            ? 'border-red-300 bg-red-50 dark:border-red-800 dark:bg-red-950/40'
+            ? 'border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8'
             : isKG
-              ? 'border-indigo-200 bg-indigo-50 dark:border-indigo-800 dark:bg-indigo-950/40'
-              : 'border-neutral-200 bg-white dark:border-neutral-700 dark:bg-neutral-800',
+              ? 'border-[color:var(--accent)] bg-[color:var(--accent)]/10'
+              : 'border-[color:var(--border)] bg-[color:var(--bg-elevated)]',
       ].join(' ')}
       open={pending}
     >
@@ -951,14 +951,14 @@ function ToolRow({ tool }: { tool: ToolEvent }): React.ReactElement {
         <span className="font-semibold">{tool.name}</span>
         {inputPreview && (
           <span
-            className="max-w-[40ch] truncate font-normal text-neutral-500 dark:text-neutral-400"
+            className="max-w-[40ch] truncate font-normal text-[color:var(--fg-muted)]"
             title={inputPreview}
           >
             · {inputPreview}
           </span>
         )}
         {subEvents.length > 0 && (
-          <span className="rounded bg-neutral-200 px-1 font-normal text-neutral-600 dark:bg-neutral-700 dark:text-neutral-300">
+          <span className="rounded bg-[color:var(--state-loading)] px-1 font-normal text-[color:var(--fg-muted)]">
             {t('subCallCount', {
               count: subEvents.filter((e) => e.kind === 'tool_use').length,
             })}
@@ -970,8 +970,8 @@ function ToolRow({ tool }: { tool: ToolEvent }): React.ReactElement {
           </span>
         )}
       </summary>
-      <div className="border-t border-neutral-200 px-2 py-1 dark:border-neutral-700">
-        <div className="text-neutral-500">{t('inputLabel')}</div>
+      <div className="border-t border-[color:var(--border)] px-2 py-1">
+        <div className="text-[color:var(--fg-muted)]">{t('inputLabel')}</div>
         <pre className="overflow-x-auto font-mono">
           {JSON.stringify(tool.input, null, 2)}
         </pre>
@@ -1028,25 +1028,25 @@ function TriageBadge({
   const verdict: Record<typeof routing.bucket, { label: string; cls: string }> = {
     simple: {
       label: 'einfach',
-      cls: 'bg-emerald-500/10 text-emerald-600 ring-emerald-500/30 dark:text-emerald-400',
+      cls: 'bg-[color:var(--success)]/100/10 text-[color:var(--success)] ring-[color:var(--success)]',
     },
     complex: {
       label: 'komplex',
-      cls: 'bg-violet-500/10 text-violet-600 ring-violet-500/30 dark:text-violet-400',
+      cls: 'bg-[color:var(--accent)]/100/10 text-[color:var(--accent)] ring-[color:var(--accent)]',
     },
     fallback: {
       label: 'Fallback',
-      cls: 'bg-amber-500/10 text-amber-600 ring-amber-500/30 dark:text-amber-400',
+      cls: 'bg-[color:var(--warning)]/100/10 text-[color:var(--warning)] ring-[color:var(--warning)]',
     },
   };
   const v = verdict[routing.bucket];
   return (
     <div
-      className="mb-2 inline-flex flex-wrap items-center gap-1.5 text-[11px] text-neutral-500 dark:text-neutral-400"
+      className="mb-2 inline-flex flex-wrap items-center gap-1.5 text-[11px] text-[color:var(--fg-muted)]"
       title={`Triage-Klassifizierer: ${routing.classifierModel} → ${routing.bucket} → ${routing.model}`}
     >
       <span className="font-medium uppercase tracking-[0.12em]">Triage</span>
-      <span className="text-neutral-400 dark:text-neutral-500">
+      <span className="text-[color:var(--fg-subtle)]">
         {shortModelName(routing.classifierModel)} →
       </span>
       <span
@@ -1054,7 +1054,7 @@ function TriageBadge({
       >
         {v.label}
       </span>
-      <span className="text-neutral-400 dark:text-neutral-500">→</span>
+      <span className="text-[color:var(--fg-subtle)]">→</span>
       <span className="rounded bg-current/10 px-1.5 py-0.5 font-medium">
         {shortModelName(routing.model)}
       </span>
@@ -1067,7 +1067,7 @@ function ToolOutputWithNudge({ output }: { output: string }): React.ReactElement
   const { cleaned } = parseNudgeBlock(output);
   return (
     <>
-      <div className="mt-2 text-neutral-500">{t('outputLabel')}</div>
+      <div className="mt-2 text-[color:var(--fg-muted)]">{t('outputLabel')}</div>
       <pre className="max-h-64 overflow-auto whitespace-pre-wrap font-mono">
         {cleaned}
       </pre>
@@ -1126,7 +1126,7 @@ function SteerList({ steers }: { steers: string[] }): React.ReactElement {
       {steers.map((text, i) => (
         <div
           key={`${String(i)}:${text.slice(0, 24)}`}
-          className="flex items-start gap-1.5 rounded border border-amber-200 bg-amber-50 px-2 py-1 text-[11px] text-amber-800 dark:border-amber-900 dark:bg-amber-950/50 dark:text-amber-300"
+          className="flex items-start gap-1.5 rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 px-2 py-1 text-[11px] text-[color:var(--warning)]"
         >
           <Navigation size={11} aria-hidden className="mt-0.5 shrink-0" />
           <span>
@@ -1198,14 +1198,14 @@ function SubTrace({
   }
 
   return (
-    <div className="mt-2 space-y-1 border-l-2 border-neutral-300 pl-2 dark:border-neutral-600">
-      <div className="text-neutral-500">{t('subAgentTrace')}</div>
+    <div className="mt-2 space-y-1 border-l-2 border-[color:var(--border)] pl-2">
+      <div className="text-[color:var(--fg-muted)]">{t('subAgentTrace')}</div>
       {rows.map((row, idx) => {
         if (row.kind === 'iteration') {
           return (
             <div
               key={`iter-${String(idx)}`}
-              className="text-[10px] text-neutral-500"
+              className="text-[10px] text-[color:var(--fg-muted)]"
             >
               {t('iterationLabel', { n: row.iteration })}
             </div>
@@ -1221,10 +1221,10 @@ function SubTrace({
             className={[
               'rounded border text-[10px]',
               pending
-                ? 'border-neutral-300 dark:border-neutral-600'
+                ? 'border-[color:var(--border)]'
                 : row.result?.isError
-                  ? 'border-red-300 bg-red-50/60 dark:border-red-800 dark:bg-red-950/40'
-                  : 'border-neutral-200 bg-white/60 dark:border-neutral-700 dark:bg-neutral-900/40',
+                  ? 'border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8'
+                  : 'border-[color:var(--border)] bg-white/60',
             ].join(' ')}
           >
             <summary className="flex cursor-pointer items-center gap-2 px-2 py-0.5 font-mono select-none">
@@ -1234,17 +1234,17 @@ function SubTrace({
               <span className="font-semibold">{row.name ?? '?'}</span>
               {previewInput(row.input) && (
                 <span
-                  className="max-w-[36ch] truncate font-normal text-neutral-500"
+                  className="max-w-[36ch] truncate font-normal text-[color:var(--fg-muted)]"
                   title={previewInput(row.input) ?? ''}
                 >
                   · {previewInput(row.input)}
                 </span>
               )}
-              <span className="ml-auto text-neutral-500">
+              <span className="ml-auto text-[color:var(--fg-muted)]">
                 {formatMs(elapsedMs)}
               </span>
             </summary>
-            <div className="border-t border-neutral-200 px-2 py-1 dark:border-neutral-700">
+            <div className="border-t border-[color:var(--border)] px-2 py-1">
               <pre className="overflow-x-auto font-mono">
                 {JSON.stringify(row.input, null, 2)}
               </pre>
@@ -1365,7 +1365,7 @@ function AttachmentGrid({
           href={att.url}
           target="_blank"
           rel="noreferrer"
-          className="block overflow-hidden rounded border border-neutral-200 bg-white p-2 transition hover:border-neutral-400 dark:border-neutral-700 dark:bg-neutral-900"
+          className="block overflow-hidden rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-2 transition hover:border-[color:var(--border-strong)]"
           title={t('attachmentTitle', {
             kind: att.diagramKind,
             cachedSuffix: att.cacheHit ? t('attachmentCachedSuffix') : '',
@@ -1379,7 +1379,7 @@ function AttachmentGrid({
             alt={att.altText}
             className="mx-auto max-h-[500px] w-auto"
           />
-          <div className="mt-1 text-[10px] text-neutral-500">
+          <div className="mt-1 text-[10px] text-[color:var(--fg-muted)]">
             {att.diagramKind}
             {att.cacheHit && ' · cached'}
             {' · '}
@@ -1411,19 +1411,19 @@ function FileAttachmentList({
           download={file.altText}
           target="_blank"
           rel="noreferrer"
-          className="flex items-center gap-3 rounded border border-neutral-200 bg-white p-3 transition hover:border-neutral-400 dark:border-neutral-700 dark:bg-neutral-900"
+          className="flex items-center gap-3 rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-3 transition hover:border-[color:var(--border-strong)]"
         >
           <span aria-hidden className="text-xl">
             {fileGlyph(file)}
           </span>
           <span className="flex min-w-0 flex-col">
             <span className="truncate text-sm font-medium">{file.altText}</span>
-            <span className="text-[10px] uppercase text-neutral-500">
+            <span className="text-[10px] uppercase text-[color:var(--fg-muted)]">
               {fileExt(file.altText)}
               {file.sizeBytes ? ` · ${formatFileSize(file.sizeBytes)}` : ''}
             </span>
           </span>
-          <span className="ml-auto text-sm text-neutral-400" aria-hidden>
+          <span className="ml-auto text-sm text-[color:var(--fg-subtle)]" aria-hidden>
             ↓
           </span>
         </a>
@@ -1470,8 +1470,8 @@ function FollowUpButtons({
 }): React.ReactElement {
   const t = useTranslations('chat');
   return (
-    <div className="mt-3 border-t border-neutral-200 pt-2 dark:border-neutral-700">
-      <div className="mb-1.5 text-[10px] font-medium tracking-wide text-neutral-500 uppercase dark:text-neutral-400">
+    <div className="mt-3 border-t border-[color:var(--border)] pt-2">
+      <div className="mb-1.5 text-[10px] font-medium tracking-wide text-[color:var(--fg-muted)] uppercase">
         {t('followUpsLabel')}
       </div>
       <div className="flex flex-wrap gap-1.5">
@@ -1484,7 +1484,7 @@ function FollowUpButtons({
             }}
             disabled={disabled}
             title={opt.prompt}
-            className="rounded-full border border-neutral-300 bg-white px-3 py-1 text-[11px] font-medium text-neutral-700 transition hover:border-neutral-500 hover:bg-neutral-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+            className="rounded-full border border-[color:var(--border)] bg-[color:var(--bg-elevated)] px-3 py-1 text-[11px] font-medium text-[color:var(--fg)] transition hover:border-[color:var(--border-strong)] hover:bg-[color:var(--bg-soft)] disabled:cursor-not-allowed disabled:opacity-40"
           >
             {opt.label}
           </button>
@@ -1496,7 +1496,7 @@ function FollowUpButtons({
 
 function StreamingDots(): React.ReactElement {
   return (
-    <span className="inline-flex items-center gap-1 text-neutral-500">
+    <span className="inline-flex items-center gap-1 text-[color:var(--fg-muted)]">
       {[0, 150, 300].map((delay) => (
         <span
           key={delay}
@@ -1535,8 +1535,8 @@ function LivenessRow({
       className={[
         'mt-2 inline-flex flex-wrap items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.18em]',
         stuck
-          ? 'text-red-600 dark:text-red-400'
-          : 'text-neutral-500 dark:text-neutral-400',
+          ? 'text-[color:var(--danger)]'
+          : 'text-[color:var(--fg-muted)]',
       ].join(' ')}
     >
       {showInlineDots && <StreamingDots />}
@@ -1556,7 +1556,7 @@ function LivenessRow({
         </span>
       ) : null}
       {lastUsage && lastUsage.cacheReadInputTokens > 0 ? (
-        <span className="text-emerald-600 dark:text-emerald-400">
+        <span className="text-[color:var(--success)]">
           {t('cacheBadge', { tokens: lastUsage.cacheReadInputTokens })}
         </span>
       ) : null}
@@ -1583,13 +1583,13 @@ function phasePillClass(
     'inline-flex items-center rounded px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.16em]';
   switch (phase) {
     case 'streaming':
-      return `${base} bg-indigo-500/15 text-indigo-600 dark:text-indigo-400`;
+      return `${base} bg-[color:var(--accent)]/100/15 text-[color:var(--accent)]`;
     case 'tool_running':
-      return `${base} bg-amber-500/15 text-amber-600 dark:text-amber-400`;
+      return `${base} bg-[color:var(--warning)]/100/15 text-[color:var(--warning)]`;
     case 'thinking':
     case 'idle':
     default:
-      return `${base} bg-neutral-200 text-neutral-600 dark:bg-neutral-700 dark:text-neutral-300`;
+      return `${base} bg-[color:var(--state-loading)] text-[color:var(--fg-muted)]`;
   }
 }
 

--- a/web-ui/app/page.tsx
+++ b/web-ui/app/page.tsx
@@ -609,7 +609,9 @@ export default function ChatPage(): React.ReactElement {
               )}
             </div>
           )}
-          <div className="flex items-end gap-2">
+          {/* §5.3 Spotlight: the composer is the stage — radial accent glow
+              behind it, three-stop showcase glow on the focused input. */}
+          <div className="lume-spotlight-stage flex items-end gap-2">
             <button
               type="button"
               onClick={requestReset}
@@ -751,12 +753,15 @@ function MessageRow({
     <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
       <div
         className={[
-          'max-w-[85%] rounded-lg px-4 py-3 shadow-sm',
+          'max-w-[85%] rounded-lg px-4 py-3',
+          // §6.1: agent content condenses into existence; user bubbles are
+          // the user's own action and appear instantly.
+          isUser ? '' : 'lume-condense',
           isUser
             ? 'bg-[color:var(--bg-inverse)] text-[color:var(--fg-on-dark)]'
             : message.error
               ? 'bg-[color:var(--danger)]/8 text-[color:var(--danger)] ring-1 ring-[color:var(--danger-edge)]'
-              : 'bg-[color:var(--bg-elevated)] text-[color:var(--fg-strong)] ring-1 ring-[color:var(--border-strong)]',
+              : 'bg-[color:var(--bg-elevated)] text-[color:var(--fg-strong)] ring-1 ring-[color:var(--border)]',
         ].join(' ')}
       >
         {isUser ? (

--- a/web-ui/app/routines/[id]/runs/[runId]/page.tsx
+++ b/web-ui/app/routines/[id]/runs/[runId]/page.tsx
@@ -60,7 +60,7 @@ export default async function RoutineRunDetailPage({
       </nav>
 
       {loadError ? (
-        <div className="mt-8 rounded-[18px] border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/5 p-6 text-sm text-[color:var(--danger)]">
+        <div className="mt-8 rounded-lg border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/5 p-6 text-sm text-[color:var(--danger)]">
           <div className="font-semibold">Run nicht erreichbar</div>
           <div className="mt-2 font-mono text-xs">{loadError}</div>
         </div>
@@ -74,7 +74,7 @@ export default async function RoutineRunDetailPage({
 function RunDetail({ run }: { run: RoutineRunDetailDto }): React.ReactElement {
   return (
     <>
-      <header className="mt-6 rounded-[22px] border border-[color:var(--divider)] bg-[color:var(--surface)] p-6 lg:p-8">
+      <header className="mt-6 rounded-lg border border-[color:var(--divider)] bg-[color:var(--surface)] p-6 lg:p-8">
         <h1 className="font-display text-[clamp(1.75rem,3vw,2.5rem)] leading-[1.1] text-[color:var(--fg-strong)]">
           Run · {formatDate(run.startedAt)}
         </h1>
@@ -118,13 +118,13 @@ function RunDetail({ run }: { run: RoutineRunDetailDto }): React.ReactElement {
       </header>
 
       <section className="mt-8 grid gap-6 lg:grid-cols-2">
-        <div className="rounded-[22px] border border-[color:var(--divider)] bg-[color:var(--surface)] p-6">
+        <div className="rounded-lg border border-[color:var(--divider)] bg-[color:var(--surface)] p-6">
           <SectionTitle>Prompt</SectionTitle>
           <pre className="mt-3 overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-[color:var(--surface-muted)] p-3 font-mono text-[12px] text-[color:var(--fg-muted)]">
             {run.prompt}
           </pre>
         </div>
-        <div className="rounded-[22px] border border-[color:var(--divider)] bg-[color:var(--surface)] p-6">
+        <div className="rounded-lg border border-[color:var(--divider)] bg-[color:var(--surface)] p-6">
           <SectionTitle>Antwort</SectionTitle>
           {run.answer ? (
             <div className="mt-3">
@@ -139,7 +139,7 @@ function RunDetail({ run }: { run: RoutineRunDetailDto }): React.ReactElement {
         </div>
       </section>
 
-      <section className="mt-8 rounded-[22px] border border-[color:var(--divider)] bg-[color:var(--surface)] p-6">
+      <section className="mt-8 rounded-lg border border-[color:var(--divider)] bg-[color:var(--surface)] p-6">
         <SectionTitle>Call-Stack · Run-Trace</SectionTitle>
         <p className="mt-2 text-[12px] text-[color:var(--fg-subtle)]">
           Vollständiger agentischer Trace dieses Runs — Iterationen,

--- a/web-ui/app/routines/[id]/runs/[runId]/page.tsx
+++ b/web-ui/app/routines/[id]/runs/[runId]/page.tsx
@@ -41,7 +41,7 @@ export default async function RoutineRunDetailPage({
   }
 
   return (
-    <main className="mx-auto w-full max-w-[1280px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto w-full max-w-[1280px] px-6 py-12 lg:px-8 lg:py-16">
       <nav className="text-[12px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
         <Link href="/routines" className="hover:text-[color:var(--accent)]">
           Routinen

--- a/web-ui/app/routines/_components/RoutineActions.tsx
+++ b/web-ui/app/routines/_components/RoutineActions.tsx
@@ -87,13 +87,13 @@ export function RoutineActions({ routine }: Props): React.ReactElement {
 
   return (
     <div className="flex flex-col items-end gap-1">
-      <div className="flex flex-wrap justify-end gap-1.5">
+      <div className="flex flex-wrap justify-end gap-2">
         <button
           type="button"
           onClick={handleTriggerNow}
           disabled={pending}
           title="Routine jetzt manuell auslösen — feuert einen Agent-Run und liefert das Ergebnis ins Channel."
-          className="rounded-full border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/5 px-2.5 py-1 text-[11px] font-semibold text-[color:var(--accent)] transition hover:border-[color:var(--accent)] disabled:opacity-50"
+          className="rounded-full border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/5 px-3 py-1 text-[11px] font-semibold text-[color:var(--accent)] transition hover:border-[color:var(--accent)] disabled:opacity-50"
         >
           Jetzt
         </button>
@@ -101,7 +101,7 @@ export function RoutineActions({ routine }: Props): React.ReactElement {
           type="button"
           onClick={handleToggle}
           disabled={pending}
-          className="rounded-full border border-[color:var(--border)] bg-[color:var(--surface)] px-2.5 py-1 text-[11px] font-semibold text-[color:var(--fg-muted)] transition hover:border-[color:var(--accent)] hover:text-[color:var(--fg-strong)] disabled:opacity-50"
+          className="rounded-full border border-[color:var(--border)] bg-[color:var(--surface)] px-3 py-1 text-[11px] font-semibold text-[color:var(--fg-muted)] transition hover:border-[color:var(--accent)] hover:text-[color:var(--fg-strong)] disabled:opacity-50"
         >
           {isPaused ? 'Resume' : 'Pause'}
         </button>
@@ -109,7 +109,7 @@ export function RoutineActions({ routine }: Props): React.ReactElement {
           type="button"
           onClick={handleDelete}
           disabled={pending}
-          className="rounded-full border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/5 px-2.5 py-1 text-[11px] font-semibold text-[color:var(--danger)] transition hover:border-[color:var(--danger)] disabled:opacity-50"
+          className="rounded-full border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/5 px-3 py-1 text-[11px] font-semibold text-[color:var(--danger)] transition hover:border-[color:var(--danger)] disabled:opacity-50"
         >
           Delete
         </button>

--- a/web-ui/app/routines/_components/RoutineRow.tsx
+++ b/web-ui/app/routines/_components/RoutineRow.tsx
@@ -299,7 +299,7 @@ function RunHistoryPanel({
           type="button"
           onClick={onRefresh}
           disabled={loading}
-          className="rounded-full border border-[color:var(--border)] bg-[color:var(--surface)] px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)] transition hover:border-[color:var(--accent)] hover:text-[color:var(--fg-strong)] disabled:opacity-50"
+          className="rounded-full border border-[color:var(--border)] bg-[color:var(--surface)] px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)] transition hover:border-[color:var(--accent)] hover:text-[color:var(--fg-strong)] disabled:opacity-50"
         >
           {loading ? 'Lädt…' : 'Refresh'}
         </button>
@@ -366,7 +366,7 @@ function RunHistoryPanel({
                   <td className="whitespace-nowrap px-3 py-2 text-right">
                     <Link
                       href={`/routines/${routineId}/runs/${run.id}`}
-                      className="rounded-full border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/5 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--accent)] transition hover:border-[color:var(--accent)]"
+                      className="rounded-full border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/5 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--accent)] transition hover:border-[color:var(--accent)]"
                     >
                       Trace →
                     </Link>
@@ -390,7 +390,7 @@ function StatusBadge({
   const colorVar = tone === 'ok' ? '--ok' : '--warn';
   return (
     <span
-      className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em]"
+      className="inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em]"
       style={{
         color: `var(${colorVar})`,
         backgroundColor: `color-mix(in oklab, var(${colorVar}) 12%, transparent)`,
@@ -440,7 +440,7 @@ function RunStatusPill({
     status === 'ok' ? '--ok' : status === 'error' ? '--danger' : '--warn';
   return (
     <span
-      className="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em]"
+      className="inline-flex items-center gap-2 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em]"
       style={{
         color: `var(${colorVar})`,
         backgroundColor: `color-mix(in oklab, var(${colorVar}) 12%, transparent)`,

--- a/web-ui/app/routines/page.tsx
+++ b/web-ui/app/routines/page.tsx
@@ -30,8 +30,8 @@ export default async function RoutinesPage(): Promise<React.ReactElement> {
   const pausedCount = routines.filter((r) => r.status === 'paused').length;
 
   return (
-    <main className="mx-auto w-full max-w-[1600px] px-6 py-12 lg:px-10 lg:py-16">
-      <header className="b5-hero-bg relative -mx-6 rounded-lg border border-[color:var(--divider)] px-6 py-10 lg:-mx-10 lg:px-10 lg:py-14">
+    <main className="mx-auto w-full max-w-[1600px] px-6 py-12 lg:px-8 lg:py-16">
+      <header className="b5-hero-bg relative -mx-6 rounded-lg border border-[color:var(--divider)] px-6 py-8 lg:-mx-8 lg:px-8 lg:py-12">
         <div className="flex items-baseline gap-3 text-[12px] font-semibold uppercase tracking-[0.24em] text-[color:var(--accent)]">
           <span className="font-mono-num text-[color:var(--fg-subtle)]">
             04
@@ -58,7 +58,7 @@ export default async function RoutinesPage(): Promise<React.ReactElement> {
         </div>
       </header>
 
-      <section className="mt-10">
+      <section className="mt-8">
         {loadError ? (
           <div className="rounded-lg border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/5 p-6 text-sm text-[color:var(--danger)]">
             <div className="font-semibold">Routinen nicht erreichbar</div>
@@ -147,7 +147,7 @@ function EmptyState(): React.ReactElement {
         Routinen entstehen, wenn ein User im Chat etwas wie &bdquo;erinnere
         mich jeden Montag um 9 Uhr an X&ldquo; sagt &mdash; der Agent ruft
         das{' '}
-        <code className="rounded bg-[color:var(--surface-muted)] px-1.5 py-0.5 font-mono text-xs">
+        <code className="rounded bg-[color:var(--surface-muted)] px-2 py-0.5 font-mono text-xs">
           manage_routine
         </code>{' '}
         Tool und legt sie an.

--- a/web-ui/app/routines/page.tsx
+++ b/web-ui/app/routines/page.tsx
@@ -31,7 +31,7 @@ export default async function RoutinesPage(): Promise<React.ReactElement> {
 
   return (
     <main className="mx-auto w-full max-w-[1600px] px-6 py-12 lg:px-10 lg:py-16">
-      <header className="b5-hero-bg relative -mx-6 rounded-[22px] border border-[color:var(--divider)] px-6 py-10 lg:-mx-10 lg:px-10 lg:py-14">
+      <header className="b5-hero-bg relative -mx-6 rounded-lg border border-[color:var(--divider)] px-6 py-10 lg:-mx-10 lg:px-10 lg:py-14">
         <div className="flex items-baseline gap-3 text-[12px] font-semibold uppercase tracking-[0.24em] text-[color:var(--accent)]">
           <span className="font-mono-num text-[color:var(--fg-subtle)]">
             04
@@ -60,7 +60,7 @@ export default async function RoutinesPage(): Promise<React.ReactElement> {
 
       <section className="mt-10">
         {loadError ? (
-          <div className="rounded-[18px] border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/5 p-6 text-sm text-[color:var(--danger)]">
+          <div className="rounded-lg border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/5 p-6 text-sm text-[color:var(--danger)]">
             <div className="font-semibold">Routinen nicht erreichbar</div>
             <div className="mt-2 font-mono text-xs">{loadError}</div>
           </div>
@@ -80,7 +80,7 @@ function RoutinesTable({
   routines: RoutineDto[];
 }): React.ReactElement {
   return (
-    <div className="overflow-x-auto rounded-[22px] border border-[color:var(--divider)] bg-[color:var(--surface)] shadow-sm">
+    <div className="overflow-x-auto rounded-lg border border-[color:var(--divider)] bg-[color:var(--surface)] shadow-sm">
       <table className="w-full table-fixed text-sm">
         <colgroup>
           <col className="w-[28%]" />
@@ -139,7 +139,7 @@ function SummaryPill({
 
 function EmptyState(): React.ReactElement {
   return (
-    <div className="rounded-[22px] border border-dashed border-[color:var(--border)] bg-[color:var(--surface)] p-12 text-center">
+    <div className="rounded-lg border border-dashed border-[color:var(--border)] bg-[color:var(--surface)] p-12 text-center">
       <div className="text-base font-semibold text-[color:var(--fg-strong)]">
         Noch keine Routinen.
       </div>

--- a/web-ui/app/setup/page.tsx
+++ b/web-ui/app/setup/page.tsx
@@ -161,7 +161,7 @@ function SetupPageInner(): React.ReactElement {
   if (state.kind === 'error') {
     return (
       <PageShell>
-        <p className="text-sm text-red-500">
+        <p className="text-sm text-[color:var(--danger)]">
           {t('errorPrefix')} {state.message}
         </p>
       </PageShell>
@@ -245,12 +245,12 @@ function SetupPageInner(): React.ReactElement {
           <span className="text-xs opacity-60">{t('anthropicKeyHelp')}</span>
         </label>
         {submitError && (
-          <p className="text-sm text-red-500">{submitError}</p>
+          <p className="text-sm text-[color:var(--danger)]">{submitError}</p>
         )}
         <button
           type="submit"
           disabled={submitting}
-          className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-black disabled:opacity-50"
+          className="rounded-md bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-[color:var(--text-inverse)] disabled:opacity-50"
         >
           {submitting ? t('submitting') : t('submit')}
         </button>

--- a/web-ui/app/store/[id]/page.tsx
+++ b/web-ui/app/store/[id]/page.tsx
@@ -103,7 +103,7 @@ export default async function PluginDetailPage({
       </Link>
 
       {/* Hero */}
-      <header className="b5-hero-bg relative mt-6 -mx-6 rounded-[22px] border border-[color:var(--divider)] px-6 py-10 lg:-mx-10 lg:px-10 lg:py-12">
+      <header className="b5-hero-bg relative mt-6 -mx-6 rounded-lg border border-[color:var(--divider)] px-6 py-10 lg:-mx-10 lg:px-10 lg:py-12">
         <div className="flex flex-col items-start gap-8 lg:flex-row lg:items-end lg:justify-between">
           <div className="flex items-start gap-6">
             <PluginIcon
@@ -152,8 +152,7 @@ export default async function PluginDetailPage({
             <p className="text-[18px] font-semibold leading-[1.6] text-[color:var(--fg)]">
               {plugin.description ? (
                 <>
-                  <span className="b5-colon">:</span>
-                  {plugin.description}
+                                    {plugin.description}
                 </>
               ) : (
                 <span className="text-[color:var(--fg-muted)]">

--- a/web-ui/app/store/[id]/page.tsx
+++ b/web-ui/app/store/[id]/page.tsx
@@ -93,7 +93,7 @@ export default async function PluginDetailPage({
     : null;
 
   return (
-    <main className="mx-auto max-w-[1280px] px-6 py-10 lg:px-10 lg:py-14">
+    <main className="mx-auto max-w-[1280px] px-6 py-8 lg:px-8 lg:py-12">
       <Link
         href="/store"
         className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--fg-muted)] transition hover:text-[color:var(--accent)]"
@@ -103,7 +103,7 @@ export default async function PluginDetailPage({
       </Link>
 
       {/* Hero */}
-      <header className="b5-hero-bg relative mt-6 -mx-6 rounded-lg border border-[color:var(--divider)] px-6 py-10 lg:-mx-10 lg:px-10 lg:py-12">
+      <header className="b5-hero-bg relative mt-6 -mx-6 rounded-lg border border-[color:var(--divider)] px-6 py-8 lg:-mx-8 lg:px-8 lg:py-12">
         <div className="flex flex-col items-start gap-8 lg:flex-row lg:items-end lg:justify-between">
           <div className="flex items-start gap-6">
             <PluginIcon
@@ -332,7 +332,7 @@ export default async function PluginDetailPage({
           {visibleCategories.length > 0 ? (
             <div>
               <SideLabel>Kategorien</SideLabel>
-              <div className="mt-2 flex flex-wrap gap-1.5">
+              <div className="mt-2 flex flex-wrap gap-2">
                 {visibleCategories.map((cat) => (
                   <Chip key={cat} tone="muted">
                     {cat}
@@ -342,7 +342,7 @@ export default async function PluginDetailPage({
             </div>
           ) : null}
 
-          <dl className="space-y-4 border-y border-[color:var(--rule)] py-5">
+          <dl className="space-y-4 border-y border-[color:var(--rule)] py-4">
             <MetaRow label="Lizenz" value={plugin.license} />
             <MetaRow label="Core-Kompatibilität" value={plugin.compat_core} mono />
             <MetaRow label="Aktuelle Version" value={`v${plugin.version}`} mono />
@@ -358,7 +358,7 @@ export default async function PluginDetailPage({
           {plugin.authors.length > 0 ? (
             <div>
               <SideLabel>Autor:innen</SideLabel>
-              <ul className="mt-2 space-y-1.5 text-sm">
+              <ul className="mt-2 space-y-2 text-sm">
                 {plugin.authors.map((a, idx) => (
                   <li key={idx} className="text-[color:var(--ink)]">
                     {a.url ? (
@@ -388,7 +388,7 @@ export default async function PluginDetailPage({
       </AdminUiProvider>
 
       {/* Footer crumb */}
-      <footer className="mt-20 flex items-center justify-between border-t border-[color:var(--rule)] pt-5 text-[11px] uppercase tracking-[0.18em] text-[color:var(--faint-ink)]">
+      <footer className="mt-20 flex items-center justify-between border-t border-[color:var(--rule)] pt-4 text-[11px] uppercase tracking-[0.18em] text-[color:var(--faint-ink)]">
         <span className="flex items-center gap-2">
           <BookCheck className="size-3.5" aria-hidden />
           Manifest: {isLegacy ? 'Legacy' : 'Schema v1'}
@@ -511,14 +511,14 @@ function PermissionsBlock({
   }
 
   return (
-    <div className="space-y-5">
+    <div className="space-y-4">
       {active.map((group) => (
         <div key={group.label}>
           <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.18em] text-[color:var(--muted-ink)]">
             {group.icon}
             {group.label}
           </div>
-          <ul className="mt-2 flex flex-wrap gap-1.5">
+          <ul className="mt-2 flex flex-wrap gap-2">
             {group.items.map((item) => (
               <Chip
                 key={item}
@@ -601,7 +601,7 @@ function CapabilitiesBlock({
             Keine Capabilities deklariert.
           </p>
         ) : (
-          <ul className="mt-2 flex flex-wrap gap-1.5">
+          <ul className="mt-2 flex flex-wrap gap-2">
             {provides.map((cap) => (
               <li key={cap}>
                 <Chip tone="accent" className="font-mono-num normal-case tracking-normal">
@@ -622,7 +622,7 @@ function CapabilitiesBlock({
           </p>
         ) : (
           <>
-            <ul className="mt-2 flex flex-wrap gap-1.5">
+            <ul className="mt-2 flex flex-wrap gap-2">
               {requires.map((cap) => (
                 <li key={cap}>
                   <Chip tone="muted" className="font-mono-num normal-case tracking-normal">

--- a/web-ui/app/store/builder/[id]/_components/AuditTimelinePane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/AuditTimelinePane.tsx
@@ -128,7 +128,7 @@ export function AuditTimelinePane({ draftId }: AuditTimelinePaneProps): React.Re
       </header>
 
       {error && (
-        <div role="alert" className="text-xs text-red-600" data-testid="audit-error">
+        <div role="alert" className="text-xs text-[color:var(--danger)]" data-testid="audit-error">
           {error}
         </div>
       )}

--- a/web-ui/app/store/builder/[id]/_components/BoundariesSection.tsx
+++ b/web-ui/app/store/builder/[id]/_components/BoundariesSection.tsx
@@ -119,7 +119,7 @@ export function BoundariesSection({
         <div
           data-testid="boundaries-unknown-warning"
           role="alert"
-          className="rounded border border-amber-400 bg-amber-50 px-2 py-1 text-xs text-amber-900"
+          className="rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 px-2 py-1 text-xs text-[color:var(--warning)]"
         >
           {t('unknownPresets', { ids: unknownIds.join(', ') })}
         </div>
@@ -172,7 +172,7 @@ export function BoundariesSection({
       </div>
 
       {error && (
-        <div role="alert" className="text-xs text-red-600">
+        <div role="alert" className="text-xs text-[color:var(--danger)]">
           {error}
         </div>
       )}
@@ -182,7 +182,7 @@ export function BoundariesSection({
           type="button"
           onClick={handleSave}
           disabled={disabled || pending}
-          className="rounded bg-[color:var(--accent)] px-3 py-1 text-sm font-medium text-white disabled:opacity-50"
+          className="rounded bg-[color:var(--accent)] px-3 py-1 text-sm font-medium text-[color:var(--fg-on-dark)] disabled:opacity-50"
           data-testid="boundaries-save"
         >
           {pending ? t('saving') : t('save')}

--- a/web-ui/app/store/builder/[id]/_components/BuilderChatPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/BuilderChatPane.tsx
@@ -607,7 +607,7 @@ export function BuilderChatPane({
               type="button"
               onClick={() => void onSend()}
               disabled={input.trim().length === 0}
-              className="inline-flex h-[44px] shrink-0 items-center gap-1.5 rounded-md bg-[color:var(--accent)] px-3 py-2 text-[12px] font-semibold text-white shadow-[var(--shadow-cta)] transition-opacity hover:opacity-90 disabled:opacity-40"
+              className="inline-flex h-[44px] shrink-0 items-center gap-1.5 rounded-md bg-[color:var(--accent)] px-3 py-2 text-[12px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] transition-opacity hover:opacity-90 disabled:opacity-40"
             >
               <Send className="size-4" aria-hidden />
               {t('button.send')}
@@ -639,7 +639,7 @@ export function BuilderChatPane({
               </span>
             ) : null}
             {lastUsage && lastUsage.cacheReadInputTokens > 0 ? (
-              <span className="text-emerald-600">
+              <span className="text-[color:var(--success)]">
                 · 🟢 cache ({String(lastUsage.cacheReadInputTokens)}t)
               </span>
             ) : null}
@@ -731,9 +731,9 @@ function ChatItemView({ item }: { item: ChatItem }): React.ReactElement | null {
       <div className={cn('flex', isUser ? 'justify-end' : 'justify-start')}>
         <div
           className={cn(
-            'max-w-[88%] rounded-[12px] px-3 py-2 text-[13px] leading-snug',
+            'max-w-[88%] rounded-lg px-3 py-2 text-[13px] leading-snug',
             isUser
-              ? 'bg-[color:var(--accent)] text-white'
+              ? 'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)]'
               : 'bg-[color:var(--bg-soft)] text-[color:var(--fg-strong)]',
           )}
         >
@@ -796,7 +796,7 @@ function ToolCard({
   const [expanded, setExpanded] = useState(false);
   const pending = item.output === null;
   return (
-    <div className="rounded-[10px] border border-[color:var(--divider)] bg-[color:var(--bg-soft)]/60 text-[12px]">
+    <div className="rounded-md border border-[color:var(--divider)] bg-[color:var(--bg-soft)]/60 text-[12px]">
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
@@ -917,7 +917,7 @@ function phasePillClass(
     case 'streaming':
       return `${base} bg-[color:var(--accent)]/15 text-[color:var(--accent)]`;
     case 'tool_running':
-      return `${base} bg-amber-500/15 text-amber-600`;
+      return `${base} bg-[color:var(--warning)]/100/15 text-[color:var(--warning)]`;
     case 'thinking':
     case 'idle':
     default:

--- a/web-ui/app/store/builder/[id]/_components/BuilderChatPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/BuilderChatPane.tsx
@@ -12,8 +12,7 @@ import {
   AlertCircle,
   ChevronDown,
   ChevronRight,
-  Loader2,
-  MessageSquare,
+    MessageSquare,
   Send,
   StopCircle,
   Wrench,
@@ -622,7 +621,7 @@ export function BuilderChatPane({
                 : 'font-mono-num mt-2 inline-flex flex-wrap items-center gap-1.5 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]'
             }
           >
-            <Loader2 className="size-3 animate-spin" aria-hidden />
+            <span className="lume-busy-dots" aria-hidden />
             Stream live · {formatElapsed(turnStartedAt, elapsedNow)} · model {model}
             {liveness?.phase ? (
               <span className={phasePillClass(liveness.phase)}>
@@ -813,10 +812,7 @@ function ToolCard({
           {item.toolId}
         </span>
         {pending ? (
-          <Loader2
-            className="ml-auto size-3 animate-spin text-[color:var(--accent)]"
-            aria-hidden
-          />
+          <span className="lume-busy-dots ml-auto text-[color:var(--accent)]" aria-hidden />
         ) : item.isError ? (
           <span className="ml-auto inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.16em] text-[color:var(--danger)]">
             error
@@ -917,7 +913,7 @@ function phasePillClass(
     case 'streaming':
       return `${base} bg-[color:var(--accent)]/15 text-[color:var(--accent)]`;
     case 'tool_running':
-      return `${base} bg-[color:var(--warning)]/100/15 text-[color:var(--warning)]`;
+      return `${base} bg-[color:var(--warning)]/15 text-[color:var(--warning)]`;
     case 'thinking':
     case 'idle':
     default:

--- a/web-ui/app/store/builder/[id]/_components/BuilderChatPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/BuilderChatPane.tsx
@@ -540,7 +540,7 @@ export function BuilderChatPane({
     <div className="flex h-full min-h-0 flex-col">
       <div
         ref={scrollRef}
-        className="flex-1 space-y-3 overflow-y-auto px-5 py-4"
+        className="flex-1 space-y-3 overflow-y-auto px-4 py-4"
       >
         {empty ? (
           <EmptyHint />
@@ -565,7 +565,7 @@ export function BuilderChatPane({
       </div>
 
       {error ? (
-        <div className="mx-5 mb-2 flex items-start gap-2 rounded-md border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/8 px-3 py-2 text-[12px] text-[color:var(--danger)]">
+        <div className="mx-4 mb-2 flex items-start gap-2 rounded-md border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/8 px-3 py-2 text-[12px] text-[color:var(--danger)]">
           <AlertCircle className="mt-0.5 size-3.5 shrink-0" aria-hidden />
           <span className="break-words">{error}</span>
         </div>
@@ -573,7 +573,7 @@ export function BuilderChatPane({
 
       {turnStats ? <TurnStatsLine stats={turnStats} /> : null}
 
-      <div className="border-t border-[color:var(--divider)] px-5 py-3">
+      <div className="border-t border-[color:var(--divider)] px-4 py-3">
         <label className="sr-only" htmlFor={inputId}>
           {t('inputLabel')}
         </label>
@@ -596,7 +596,7 @@ export function BuilderChatPane({
             <button
               type="button"
               onClick={onStop}
-              className="inline-flex h-[44px] shrink-0 items-center gap-1.5 rounded-md border border-[color:var(--danger)]/40 px-3 py-2 text-[12px] font-semibold text-[color:var(--danger)] transition-colors hover:bg-[color:var(--danger)]/10"
+              className="inline-flex h-[44px] shrink-0 items-center gap-2 rounded-md border border-[color:var(--danger)]/40 px-3 py-2 text-[12px] font-semibold text-[color:var(--danger)] transition-colors hover:bg-[color:var(--danger)]/10"
             >
               <StopCircle className="size-4" aria-hidden />
               {t('button.stop')}
@@ -606,7 +606,7 @@ export function BuilderChatPane({
               type="button"
               onClick={() => void onSend()}
               disabled={input.trim().length === 0}
-              className="inline-flex h-[44px] shrink-0 items-center gap-1.5 rounded-md bg-[color:var(--accent)] px-3 py-2 text-[12px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] transition-opacity hover:opacity-90 disabled:opacity-40"
+              className="inline-flex h-[44px] shrink-0 items-center gap-2 rounded-md bg-[color:var(--accent)] px-3 py-2 text-[12px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] transition-opacity hover:opacity-90 disabled:opacity-40"
             >
               <Send className="size-4" aria-hidden />
               {t('button.send')}
@@ -617,8 +617,8 @@ export function BuilderChatPane({
           <p
             className={
               liveness && liveness.sinceLastActivityMs > 30000
-                ? 'font-mono-num mt-2 inline-flex flex-wrap items-center gap-1.5 text-[10px] uppercase tracking-[0.18em] text-[color:var(--danger)]'
-                : 'font-mono-num mt-2 inline-flex flex-wrap items-center gap-1.5 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]'
+                ? 'font-mono-num mt-2 inline-flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-[color:var(--danger)]'
+                : 'font-mono-num mt-2 inline-flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]'
             }
           >
             <span className="lume-busy-dots" aria-hidden />
@@ -692,7 +692,7 @@ function TurnStatsLine({ stats }: { stats: TurnStats }): React.ReactElement {
   if (others > 0) tools.push(`${String(others)} other`);
   const toolsLabel = tools.length > 0 ? tools.join(' · ') : '0 tools';
   return (
-    <div className="font-mono-num mx-5 mb-2 inline-flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
+    <div className="font-mono-num mx-4 mb-2 inline-flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
       <span>
         {stats.isLive ? t('turnStats.live') : t('turnStats.last')}: {toolsLabel}
       </span>
@@ -800,7 +800,7 @@ function ToolCard({
         type="button"
         onClick={() => setExpanded((v) => !v)}
         aria-expanded={expanded}
-        className="flex w-full items-center gap-1.5 px-3 py-2 text-left text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)] focus:outline-none"
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)] focus:outline-none"
       >
         {expanded ? (
           <ChevronDown className="size-3" aria-hidden />
@@ -824,7 +824,7 @@ function ToolCard({
         )}
       </button>
       {expanded ? (
-        <div className="space-y-1.5 border-t border-[color:var(--divider)] px-3 py-2">
+        <div className="space-y-2 border-t border-[color:var(--divider)] px-3 py-2">
           <pre className="font-mono-num overflow-x-auto whitespace-pre-wrap break-words rounded bg-[color:var(--bg)] px-2 py-1 text-[11px] text-[color:var(--fg-muted)]">
             {jsonPreview(item.input)}
           </pre>
@@ -858,7 +858,7 @@ function EventChip({
   return (
     <div className="font-mono-num inline-flex items-center gap-2 rounded-md bg-[color:var(--bg-soft)] px-2 py-1 text-[10px] uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
       <span className="text-[color:var(--accent)]">{label}</span>
-      <span className="rounded bg-[color:var(--bg)] px-1.5 py-0.5 normal-case tracking-normal text-[color:var(--fg-strong)]">
+      <span className="rounded bg-[color:var(--bg)] px-2 py-0.5 normal-case tracking-normal text-[color:var(--fg-strong)]">
         {detail}
       </span>
       <span className="text-[color:var(--fg-subtle)]">{cause}</span>
@@ -908,7 +908,7 @@ function phasePillClass(
   phase: 'thinking' | 'streaming' | 'tool_running' | 'idle',
 ): string {
   const base =
-    'inline-flex items-center rounded px-1.5 py-0.5 text-[9px] font-bold uppercase tracking-[0.16em]';
+    'inline-flex items-center rounded px-2 py-0.5 text-[9px] font-bold uppercase tracking-[0.16em]';
   switch (phase) {
     case 'streaming':
       return `${base} bg-[color:var(--accent)]/15 text-[color:var(--accent)]`;

--- a/web-ui/app/store/builder/[id]/_components/BuilderMarkdown.tsx
+++ b/web-ui/app/store/builder/[id]/_components/BuilderMarkdown.tsx
@@ -64,7 +64,7 @@ function tryRenderChoiceCards(items: ReactElement[]): React.ReactElement | null 
         return (
           <div
             key={i}
-            className="rounded-md border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] px-3 py-2.5 text-[12px] leading-snug text-[color:var(--fg-strong)] transition-colors hover:border-[color:var(--accent)]"
+            className="rounded-md border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] px-3 py-3 text-[12px] leading-snug text-[color:var(--fg-strong)] transition-colors hover:border-[color:var(--accent)]"
           >
             <div className="flex items-baseline gap-2">
               <span className="font-mono-num shrink-0 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-subtle)]">

--- a/web-ui/app/store/builder/[id]/_components/BuilderMarkdown.tsx
+++ b/web-ui/app/store/builder/[id]/_components/BuilderMarkdown.tsx
@@ -64,7 +64,7 @@ function tryRenderChoiceCards(items: ReactElement[]): React.ReactElement | null 
         return (
           <div
             key={i}
-            className="rounded-[10px] border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] px-3 py-2.5 text-[12px] leading-snug text-[color:var(--fg-strong)] transition-colors hover:border-[color:var(--accent)]"
+            className="rounded-md border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] px-3 py-2.5 text-[12px] leading-snug text-[color:var(--fg-strong)] transition-colors hover:border-[color:var(--accent)]"
           >
             <div className="flex items-baseline gap-2">
               <span className="font-mono-num shrink-0 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-subtle)]">

--- a/web-ui/app/store/builder/[id]/_components/CulturePresetDropdown.tsx
+++ b/web-ui/app/store/builder/[id]/_components/CulturePresetDropdown.tsx
@@ -100,12 +100,12 @@ export function CulturePresetDropdown({
           data-testid="culture-confirm-modal"
           role="dialog"
           aria-label={t('modalLabel')}
-          className="space-y-2 rounded border border-amber-400 bg-amber-50 p-3"
+          className="space-y-2 rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/10 p-3"
         >
-          <div className="text-sm font-medium text-amber-900">
+          <div className="text-sm font-medium text-[color:var(--warning)]">
             {t('overwriteNotice')}
           </div>
-          <ul className="space-y-0.5 text-xs text-amber-900" data-testid="culture-diff-list">
+          <ul className="space-y-0.5 text-xs text-[color:var(--warning)]" data-testid="culture-diff-list">
             {diff.map((d) => (
               <li key={d.axis} data-testid={`culture-diff-${d.axis}`}>
                 <code>{d.axis}</code>: {d.before ?? t('unset')} → {d.after}
@@ -116,7 +116,7 @@ export function CulturePresetDropdown({
             )}
           </ul>
           {error && (
-            <div role="alert" className="text-xs text-red-600">
+            <div role="alert" className="text-xs text-[color:var(--danger)]">
               {error}
             </div>
           )}
@@ -126,7 +126,7 @@ export function CulturePresetDropdown({
               data-testid="culture-confirm-apply"
               onClick={handleConfirm}
               disabled={disabled || pending || diff.length === 0}
-              className="rounded bg-[color:var(--accent)] px-3 py-1 text-sm font-medium text-white disabled:opacity-50"
+              className="rounded bg-[color:var(--accent)] px-3 py-1 text-sm font-medium text-[color:var(--fg-on-dark)] disabled:opacity-50"
             >
               {pending ? t('applying') : t('apply')}
             </button>

--- a/web-ui/app/store/builder/[id]/_components/DimensionSlider.tsx
+++ b/web-ui/app/store/builder/[id]/_components/DimensionSlider.tsx
@@ -75,12 +75,12 @@ export function DimensionSlider({
           {labelRight}
         </span>
       </div>
-      <div className="relative pt-5">
+      <div className="relative pt-4">
         <span
           className={cn(
             'pointer-events-none absolute top-0 z-10 -translate-x-1/2',
             'rounded-md border border-[color:var(--border)] bg-[color:var(--bg-elevated)]',
-            'px-1.5 py-0.5 font-mono-num tabular-nums text-[10px] text-[color:var(--fg-strong)]',
+            'px-2 py-0.5 font-mono-num tabular-nums text-[10px] text-[color:var(--fg-strong)]',
             'shadow-[var(--shadow-sm)]',
           )}
           style={{ left: `${bubbleLeftPct}%` }}
@@ -118,7 +118,7 @@ export function DimensionSlider({
       {warning ? (
         <div
           className={cn(
-            'flex items-center gap-1.5 text-[11px]',
+            'flex items-center gap-2 text-[11px]',
             warning === 'hard'
               ? 'text-[color:var(--danger)]'
               : 'text-[color:var(--warning)]',

--- a/web-ui/app/store/builder/[id]/_components/InlineSlotEditor.tsx
+++ b/web-ui/app/store/builder/[id]/_components/InlineSlotEditor.tsx
@@ -107,10 +107,10 @@ export function InlineSlotEditor({
 
   return (
     <div className="rounded-md border border-[color:var(--border)] bg-[color:var(--bg)]">
-      <div className="flex items-center gap-2 border-b border-[color:var(--border)] bg-[color:var(--bg-subtle)] px-3 py-1.5 text-[11px]">
+      <div className="flex items-center gap-2 border-b border-[color:var(--border)] bg-[color:var(--bg-subtle)] px-3 py-2 text-[11px]">
         <span className="font-medium text-[color:var(--fg-strong)]">{label}</span>
         {hint ? <span className="text-[color:var(--fg-muted)]">{hint}</span> : null}
-        <code className="ml-2 rounded bg-[color:var(--bg)] px-1.5 py-0.5 text-[10px] text-[color:var(--fg-muted)]">
+        <code className="ml-2 rounded bg-[color:var(--bg)] px-2 py-0.5 text-[10px] text-[color:var(--fg-muted)]">
           {slotKey}
         </code>
         <span className="ml-auto">

--- a/web-ui/app/store/builder/[id]/_components/InlineSlotEditor.tsx
+++ b/web-ui/app/store/builder/[id]/_components/InlineSlotEditor.tsx
@@ -145,7 +145,7 @@ function StatusBadge({ status }: { status: SaveStatus }): React.ReactElement | n
     case 'idle':
       return null;
     case 'dirty':
-      return <span className="text-amber-700">{t('inline.status.dirty')}</span>;
+      return <span className="text-[color:var(--warning)]">{t('inline.status.dirty')}</span>;
     case 'saving':
       return (
         <span className="text-[color:var(--fg-muted)]">
@@ -153,10 +153,10 @@ function StatusBadge({ status }: { status: SaveStatus }): React.ReactElement | n
         </span>
       );
     case 'saved':
-      return <span className="text-emerald-700">{t('inline.status.saved')}</span>;
+      return <span className="text-[color:var(--success)]">{t('inline.status.saved')}</span>;
     case 'error':
       return (
-        <span className="text-rose-700" title={status.message}>
+        <span className="text-[color:var(--danger)]" title={status.message}>
           {t('inline.status.error')}
         </span>
       );

--- a/web-ui/app/store/builder/[id]/_components/InstallDiffModal.tsx
+++ b/web-ui/app/store/builder/[id]/_components/InstallDiffModal.tsx
@@ -266,7 +266,7 @@ export function InstallDiffModal({
             disabled={busy || phase.kind === 'succeeded'}
             className={cn(
               'inline-flex items-center gap-2 rounded-md px-5 py-2 text-[12px] font-semibold uppercase tracking-[0.18em]',
-              'bg-[color:var(--accent)] text-white shadow-[var(--shadow-cta)]',
+              'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]',
               'transition-opacity',
               'disabled:opacity-50 disabled:cursor-not-allowed',
             )}
@@ -556,7 +556,7 @@ function FailureBanner({
               <button
                 type="button"
                 onClick={() => void onBumpAndRetry()}
-                className="inline-flex items-center gap-2 rounded-md bg-[color:var(--accent)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-white shadow-sm transition-opacity hover:opacity-90"
+                className="inline-flex items-center gap-2 rounded-md bg-[color:var(--accent)] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-on-dark)] shadow-sm transition-opacity hover:opacity-90"
               >
                 {t('bumpAndPublish', { current: currentVersion, next: bumped ?? '' })}
               </button>

--- a/web-ui/app/store/builder/[id]/_components/InstallDiffModal.tsx
+++ b/web-ui/app/store/builder/[id]/_components/InstallDiffModal.tsx
@@ -159,7 +159,7 @@ export function InstallDiffModal({
           'max-h-[90vh] overflow-hidden',
         )}
       >
-        <header className="flex items-start justify-between gap-6 border-b border-[color:var(--rule)] px-7 py-5">
+        <header className="flex items-start justify-between gap-6 border-b border-[color:var(--rule)] px-6 py-4">
           <div className="min-w-0">
             <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.22em] text-[color:var(--accent)]">
               <ShieldCheck className="size-3.5" aria-hidden />
@@ -185,7 +185,7 @@ export function InstallDiffModal({
           </button>
         </header>
 
-        <div className="flex-1 overflow-y-auto px-7 py-6">
+        <div className="flex-1 overflow-y-auto px-6 py-6">
           {phase.kind === 'failed' ? (
             <FailureBanner
               t={t}
@@ -246,7 +246,7 @@ export function InstallDiffModal({
           <DiffBody draft={draft} t={t} />
         </div>
 
-        <footer className="flex items-center justify-end gap-3 border-t border-[color:var(--rule)] px-7 py-4">
+        <footer className="flex items-center justify-end gap-3 border-t border-[color:var(--rule)] px-6 py-4">
           <button
             type="button"
             onClick={handleClose}
@@ -265,7 +265,7 @@ export function InstallDiffModal({
             onClick={() => void handleInstall()}
             disabled={busy || phase.kind === 'succeeded'}
             className={cn(
-              'inline-flex items-center gap-2 rounded-md px-5 py-2 text-[12px] font-semibold uppercase tracking-[0.18em]',
+              'inline-flex items-center gap-2 rounded-md px-4 py-2 text-[12px] font-semibold uppercase tracking-[0.18em]',
               'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]',
               'transition-opacity',
               'disabled:opacity-50 disabled:cursor-not-allowed',
@@ -368,7 +368,7 @@ function DiffBody({ draft, t }: { draft: Draft; t: InstallT }): React.ReactEleme
                     <summary className="cursor-pointer text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-subtle)]">
                       input schema
                     </summary>
-                    <pre className="mt-1 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded border border-[color:var(--divider)] bg-[color:var(--paper)] px-2 py-1.5 text-[10px] font-mono leading-relaxed text-[color:var(--fg-strong)]">
+                    <pre className="mt-1 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded border border-[color:var(--divider)] bg-[color:var(--paper)] px-2 py-2 text-[10px] font-mono leading-relaxed text-[color:var(--fg-strong)]">
                       {JSON.stringify(t.input, null, 2)}
                     </pre>
                   </details>
@@ -406,11 +406,11 @@ function DiffBody({ draft, t }: { draft: Draft; t: InstallT }): React.ReactEleme
         {outbound.length === 0 ? (
           <EmptyHint>{t('noOutboundHosts')}</EmptyHint>
         ) : (
-          <ul className="flex flex-wrap gap-1.5">
+          <ul className="flex flex-wrap gap-2">
             {outbound.map((h) => (
               <li
                 key={h}
-                className="font-mono-num rounded-full border border-[color:var(--divider)] bg-[color:var(--bg-soft)] px-2.5 py-0.5 text-[11px] text-[color:var(--fg-strong)]"
+                className="font-mono-num rounded-full border border-[color:var(--divider)] bg-[color:var(--bg-soft)] px-3 py-0.5 text-[11px] text-[color:var(--fg-strong)]"
               >
                 {h}
               </li>
@@ -430,7 +430,7 @@ function DiffBody({ draft, t }: { draft: Draft; t: InstallT }): React.ReactEleme
             {setupFields.map((f) => (
               <li
                 key={f.key}
-                className="flex items-baseline justify-between gap-3 rounded-md border border-[color:var(--divider)] px-3 py-1.5"
+                className="flex items-baseline justify-between gap-3 rounded-md border border-[color:var(--divider)] px-3 py-2"
               >
                 <span className="font-mono-num text-[12px] text-[color:var(--fg-strong)]">
                   {f.key}
@@ -467,7 +467,7 @@ function Section({
           <span className="text-[11px] text-[color:var(--fg-subtle)]">{subtitle}</span>
         ) : null}
       </div>
-      <div className="space-y-1.5 text-[12px]">{children}</div>
+      <div className="space-y-2 text-[12px]">{children}</div>
     </section>
   );
 }
@@ -594,7 +594,7 @@ function FailureDetails({
           <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
             {t('typescriptErrors', { count: errors.length })}
           </summary>
-          <ul className="mt-1.5 space-y-1">
+          <ul className="mt-2 space-y-1">
             {errors.slice(0, 10).map((e, i) => {
               const row = e as {
                 path?: string;
@@ -606,7 +606,7 @@ function FailureDetails({
               return (
                 <li
                   key={i}
-                  className="rounded border border-[color:var(--divider)] bg-[color:var(--paper)] px-2 py-1.5 text-[10px] font-mono leading-relaxed"
+                  className="rounded border border-[color:var(--divider)] bg-[color:var(--paper)] px-2 py-2 text-[10px] font-mono leading-relaxed"
                 >
                   <span className="text-[color:var(--fg-subtle)]">
                     {row.path ?? '?'}:{row.line ?? '?'}:{row.col ?? '?'}
@@ -635,13 +635,13 @@ function FailureDetails({
           <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
             {t('codegenIssues', { count: issues.length })}
           </summary>
-          <ul className="mt-1.5 space-y-1">
+          <ul className="mt-2 space-y-1">
             {issues.map((i, idx) => {
               const row = i as { code?: string; detail?: string };
               return (
                 <li
                   key={idx}
-                  className="rounded border border-[color:var(--divider)] bg-[color:var(--paper)] px-2 py-1.5 text-[11px]"
+                  className="rounded border border-[color:var(--divider)] bg-[color:var(--paper)] px-2 py-2 text-[11px]"
                 >
                   <span className="font-mono-num text-[10px] uppercase tracking-[0.14em] text-[color:var(--fg-subtle)]">
                     {row.code ?? '?'}

--- a/web-ui/app/store/builder/[id]/_components/InstallDiffModal.tsx
+++ b/web-ui/app/store/builder/[id]/_components/InstallDiffModal.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
-import { AlertTriangle, CheckCircle2, Loader2, ShieldCheck, X } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, ShieldCheck, X } from 'lucide-react';
 
 import { installBuilderDraft, patchBuilderSpec } from '../../../../_lib/api';
 import { cn } from '../../../../_lib/cn';
@@ -273,7 +273,7 @@ export function InstallDiffModal({
           >
             {busy ? (
               <>
-                <Loader2 className="size-3.5 animate-spin" aria-hidden />
+                <span className="lume-busy-dots" aria-hidden />
                 {t('publishing')}
               </>
             ) : phase.kind === 'succeeded' ? (

--- a/web-ui/app/store/builder/[id]/_components/ManifestDiffSidebar.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ManifestDiffSidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChevronLeft, ChevronRight, Loader2, RefreshCcw } from 'lucide-react';
+import { ChevronLeft, ChevronRight, RefreshCcw } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -88,7 +88,7 @@ export function ManifestDiffSidebar({
             manifest.yaml
           </span>
           {pending ? (
-            <Loader2 className="size-3 animate-spin text-[color:var(--fg-muted)]" aria-hidden />
+            <span className="lume-busy-dots" aria-hidden />
           ) : null}
         </div>
         <div className="flex items-center gap-1">

--- a/web-ui/app/store/builder/[id]/_components/PageForm.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PageForm.tsx
@@ -186,16 +186,16 @@ export function PageForm({
 
       {/* Library-mode fields */}
       {route.render_mode === 'library' ? (
-        <div className="space-y-3 rounded-md border border-emerald-200 bg-emerald-50/40 p-3">
+        <div className="space-y-3 rounded-md border border-[color:var(--success)] bg-[color:var(--success)]/10 p-3">
           <div>
-            <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-emerald-800">
+            <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-[color:var(--success)]">
               {t('uiTemplate.heading')}
             </div>
             <div className="space-y-1">
               {(['list-card', 'kpi-tiles'] as const).map((ut) => (
                 <label
                   key={ut}
-                  className="flex cursor-pointer items-start gap-2 rounded-md border border-emerald-200/60 bg-white px-2.5 py-1.5 hover:border-emerald-400"
+                  className="flex cursor-pointer items-start gap-2 rounded-md border border-[color:var(--success)]/60 bg-[color:var(--bg-elevated)] px-2.5 py-1.5 hover:border-[color:var(--success)]"
                 >
                   <input
                     type="radio"
@@ -283,7 +283,7 @@ export function PageForm({
           for react-ssr mode; lint rejects interactive=true for library/
           free-form-html (no React component to hydrate). */}
       {route.render_mode === 'react-ssr' ? (
-        <label className="flex items-start gap-2 rounded-md border border-sky-200 bg-sky-50/40 px-2.5 py-2 hover:border-sky-400">
+        <label className="flex items-start gap-2 rounded-md border border-[color:var(--accent)] bg-[color:var(--accent)]/10 px-2.5 py-2 hover:border-[color:var(--accent)]">
           <input
             type="checkbox"
             checked={route.interactive === true}
@@ -291,7 +291,7 @@ export function PageForm({
             className="mt-0.5"
           />
           <span className="flex-1 text-[12px]">
-            <span className="font-medium text-sky-900">
+            <span className="font-medium text-[color:var(--accent)]">
               {t('interactive.label')}
             </span>
             <span className="ml-2 text-[color:var(--fg-muted)]">
@@ -395,7 +395,7 @@ export default function ${componentName}Page({ data, fetchError }: PageProps) {
   if (fetchError) {
     return (
       <main data-omadia-page="${routeId}" className="max-w-3xl mx-auto p-6">
-        <div className="rounded-md border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800">
+        <div className="rounded-md border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-4 text-sm text-[color:var(--danger)]">
           Daten konnten nicht gelesen werden: {fetchError}
         </div>
       </main>
@@ -404,7 +404,7 @@ export default function ${componentName}Page({ data, fetchError }: PageProps) {
   const items = Array.isArray(data) ? data : [];
   if (items.length === 0) {
     return (
-      <main data-omadia-page="${routeId}" className="max-w-3xl mx-auto p-6 text-center text-slate-500">
+      <main data-omadia-page="${routeId}" className="max-w-3xl mx-auto p-6 text-center text-[color:var(--fg-muted)]">
         Keine Daten.
       </main>
     );
@@ -412,7 +412,7 @@ export default function ${componentName}Page({ data, fetchError }: PageProps) {
   return (
     <main data-omadia-page="${routeId}" className="max-w-3xl mx-auto p-6 space-y-2">
       <h1 className="text-2xl font-semibold mb-3">${componentName}</h1>
-      <pre className="text-xs bg-slate-100 p-3 rounded">{JSON.stringify(items, null, 2)}</pre>
+      <pre className="text-xs bg-[color:var(--bg-soft)] p-3 rounded">{JSON.stringify(items, null, 2)}</pre>
     </main>
   );
 }
@@ -426,7 +426,7 @@ function defaultFreeFormStub(pageTitle: string): string {
   body: html\`
     <main class="max-w-3xl mx-auto p-6">
       <h1 class="text-2xl font-semibold mb-4">${pageTitle}</h1>
-      <p class="text-sm text-slate-500">Replace this with your own rendering.</p>
+      <p class="text-sm text-[color:var(--fg-muted)]">Replace this with your own rendering.</p>
     </main>
   \`,
 });
@@ -461,7 +461,7 @@ function ItemTemplateEditor({
 
   return (
     <div className="space-y-2">
-      <div className="text-[11px] font-medium uppercase tracking-wide text-emerald-800">
+      <div className="text-[11px] font-medium uppercase tracking-wide text-[color:var(--success)]">
         {t.rich('itemTemplate.heading', {
           code: (chunks) => <code>{chunks}</code>,
         })}

--- a/web-ui/app/store/builder/[id]/_components/PageForm.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PageForm.tsx
@@ -158,7 +158,7 @@ export function PageForm({
           {(['library', 'react-ssr', 'free-form-html'] as const).map((mode) => (
             <label
               key={mode}
-              className="flex cursor-pointer items-start gap-2 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-2.5 py-2 hover:border-[color:var(--accent)]"
+              className="flex cursor-pointer items-start gap-2 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-3 py-2 hover:border-[color:var(--accent)]"
             >
               <input
                 type="radio"
@@ -195,7 +195,7 @@ export function PageForm({
               {(['list-card', 'kpi-tiles'] as const).map((ut) => (
                 <label
                   key={ut}
-                  className="flex cursor-pointer items-start gap-2 rounded-md border border-[color:var(--success)]/60 bg-[color:var(--bg-elevated)] px-2.5 py-1.5 hover:border-[color:var(--success)]"
+                  className="flex cursor-pointer items-start gap-2 rounded-md border border-[color:var(--success)]/60 bg-[color:var(--bg-elevated)] px-3 py-2 hover:border-[color:var(--success)]"
                 >
                   <input
                     type="radio"
@@ -264,7 +264,7 @@ export function PageForm({
                 patchField('/data_binding/tool_id', id);
               }
             }}
-            className="flex-1 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-1.5 text-[12px]"
+            className="flex-1 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-2 text-[12px]"
           >
             <option value="">{t('dataBinding.noToolOption')}</option>
             {tools.map((t) => (
@@ -283,7 +283,7 @@ export function PageForm({
           for react-ssr mode; lint rejects interactive=true for library/
           free-form-html (no React component to hydrate). */}
       {route.render_mode === 'react-ssr' ? (
-        <label className="flex items-start gap-2 rounded-md border border-[color:var(--accent)] bg-[color:var(--accent)]/10 px-2.5 py-2 hover:border-[color:var(--accent)]">
+        <label className="flex items-start gap-2 rounded-md border border-[color:var(--accent)] bg-[color:var(--accent)]/10 px-3 py-2 hover:border-[color:var(--accent)]">
           <input
             type="checkbox"
             checked={route.interactive === true}
@@ -365,7 +365,7 @@ function Field({
         value={value}
         maxLength={maxLength}
         onChange={(e) => onChange(e.target.value)}
-        className="w-full rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-1.5 text-[12px]"
+        className="w-full rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-2 text-[12px]"
       />
       {help ? (
         <p className="mt-1 text-[11px] text-[color:var(--fg-muted)]">{help}</p>

--- a/web-ui/app/store/builder/[id]/_components/PagePreviewFrame.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PagePreviewFrame.tsx
@@ -128,7 +128,7 @@ export function PagePreviewFrame({
           key={iframeKey}
           src={previewUrl}
           title={t('iframeTitle', { label: label ?? routeId })}
-          className="h-[480px] w-full border-0 bg-white"
+          className="h-[480px] w-full border-0 bg-[color:var(--bg-elevated)]"
           sandbox="allow-scripts allow-same-origin"
         />
       )}
@@ -147,13 +147,13 @@ function PreviewErrorBanner({
   const hintKey = HINT_KEYS[code];
   const hint = hintKey ? t(hintKey) : undefined;
   return (
-    <div className="bg-amber-50 px-4 py-6 text-[12px] text-amber-900">
+    <div className="bg-[color:var(--warning)]/10 px-4 py-6 text-[12px] text-[color:var(--warning)]">
       <div className="mb-1 font-semibold">{t('unavailableTitle')}</div>
-      <code className="block break-words text-[11px] text-amber-900/80">
+      <code className="block break-words text-[11px] text-[color:var(--warning)]/80">
         {code}: {message}
       </code>
       {hint ? (
-        <p className="mt-2 text-[11px] text-amber-800/90">
+        <p className="mt-2 text-[11px] text-[color:var(--warning)]/90">
           {t.rich('hintLine', {
             strong: (chunks) => <strong>{chunks}</strong>,
             hint,

--- a/web-ui/app/store/builder/[id]/_components/PagesList.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PagesList.tsx
@@ -232,7 +232,8 @@ function SortableRow({
   const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
-    opacity: isDragging ? 0.6 : 1,
+    opacity: isDragging ? 0.5 : 1,
+    boxShadow: isDragging ? 'var(--shadow-drag)' : undefined,
   };
   void index;
 

--- a/web-ui/app/store/builder/[id]/_components/PagesList.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PagesList.tsx
@@ -141,7 +141,7 @@ export function PagesList({
         <button
           type="button"
           onClick={onAdd}
-          className="mt-3 inline-flex items-center gap-1 rounded-md bg-[color:var(--accent)] px-2.5 py-1.5 text-[11px] font-semibold text-white shadow-[var(--shadow-cta)]"
+          className="mt-3 inline-flex items-center gap-1 rounded-md bg-[color:var(--accent)] px-2.5 py-1.5 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]"
         >
           <Plus className="size-3" aria-hidden />
           {t('addFirstPage')}
@@ -271,7 +271,7 @@ function SortableRow({
         <button
           type="button"
           onClick={onRemove}
-          className="rounded p-1 text-[color:var(--fg-muted)] hover:bg-rose-50 hover:text-rose-700"
+          className="rounded p-1 text-[color:var(--fg-muted)] hover:bg-[color:var(--danger)]/8 hover:text-[color:var(--danger)]"
           aria-label={t('deleteAriaLabel')}
         >
           <Trash2 className="size-3" />
@@ -295,10 +295,10 @@ function SortableRow({
 function ModeBadge({ mode }: { mode: UiRoute['render_mode'] }): React.ReactElement {
   const color =
     mode === 'library'
-      ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
+      ? 'bg-[color:var(--success)]/10 text-[color:var(--success)] border-[color:var(--success)]'
       : mode === 'react-ssr'
-        ? 'bg-sky-50 text-sky-700 border-sky-200'
-        : 'bg-amber-50 text-amber-700 border-amber-200';
+        ? 'bg-[color:var(--accent)]/10 text-[color:var(--accent)] border-[color:var(--accent)]'
+        : 'bg-[color:var(--warning)]/10 text-[color:var(--warning)] border-[color:var(--warning)]';
   const label =
     mode === 'library' ? 'Library' : mode === 'react-ssr' ? 'React SSR' : 'Free-form HTML';
   return (

--- a/web-ui/app/store/builder/[id]/_components/PagesList.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PagesList.tsx
@@ -141,7 +141,7 @@ export function PagesList({
         <button
           type="button"
           onClick={onAdd}
-          className="mt-3 inline-flex items-center gap-1 rounded-md bg-[color:var(--accent)] px-2.5 py-1.5 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]"
+          className="mt-3 inline-flex items-center gap-1 rounded-md bg-[color:var(--accent)] px-3 py-2 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]"
         >
           <Plus className="size-3" aria-hidden />
           {t('addFirstPage')}
@@ -158,7 +158,7 @@ export function PagesList({
         onDragEnd={onDragEnd}
       >
         <SortableContext items={ids} strategy={verticalListSortingStrategy}>
-          <ul className="space-y-1.5">
+          <ul className="space-y-2">
             {uiRoutes.map((route, index) => {
               const isExpanded = expandedId === route.id;
               return (
@@ -194,7 +194,7 @@ export function PagesList({
       <button
         type="button"
         onClick={onAdd}
-        className="inline-flex items-center gap-1 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-2.5 py-1.5 text-[11px] font-semibold text-[color:var(--fg-strong)] hover:border-[color:var(--accent)]"
+        className="inline-flex items-center gap-1 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-3 py-2 text-[11px] font-semibold text-[color:var(--fg-strong)] hover:border-[color:var(--accent)]"
       >
         <Plus className="size-3" aria-hidden />
         {t('addPage')}
@@ -304,7 +304,7 @@ function ModeBadge({ mode }: { mode: UiRoute['render_mode'] }): React.ReactEleme
     mode === 'library' ? 'Library' : mode === 'react-ssr' ? 'React SSR' : 'Free-form HTML';
   return (
     <span
-      className={`rounded-md border px-1.5 py-0.5 text-[10px] font-medium ${color}`}
+      className={`rounded-md border px-2 py-0.5 text-[10px] font-medium ${color}`}
     >
       {label}
     </span>

--- a/web-ui/app/store/builder/[id]/_components/PaneCard.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PaneCard.tsx
@@ -171,7 +171,7 @@ export function PaneCard({
             transition={{ duration: 0.18 }}
             className="flex min-h-0 flex-1 flex-col"
           >
-            <header className="flex items-baseline gap-3 border-b border-[color:var(--divider)] px-5 py-4">
+            <header className="flex items-baseline gap-3 border-b border-[color:var(--divider)] px-4 py-4">
               <span className="font-mono-num text-[10px] font-semibold uppercase tracking-[0.24em] text-[color:var(--fg-subtle)]">
                 {index}
               </span>

--- a/web-ui/app/store/builder/[id]/_components/PaneCard.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PaneCard.tsx
@@ -131,7 +131,7 @@ export function PaneCard({
             />
             {hasWarning ? (
               <span
-                className="font-mono-num inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-[color:var(--danger)] px-1 text-[10px] font-semibold text-[color:var(--fg-on-dark)]"
+                className="font-mono-num inline-flex h-4 min-w-[1rem] items-center justify-center px-1 text-[10px] font-semibold text-[color:var(--danger)]"
                 aria-label={t('missingCountAria', { count: warningCount })}
                 title={t('missingRequiredFields', { count: warningCount })}
               >
@@ -180,7 +180,7 @@ export function PaneCard({
               </h2>
               {hasWarning ? (
                 <span
-                  className="font-mono-num inline-flex items-center gap-1 rounded-full bg-[color:var(--danger)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-on-dark)]"
+                  className="font-mono-num inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--danger)]"
                   title={t('missingRequiredFields', { count: warningCount })}
                 >
                   <AlertTriangle className="size-2.5" aria-hidden />

--- a/web-ui/app/store/builder/[id]/_components/PaneCard.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PaneCard.tsx
@@ -89,7 +89,7 @@ export function PaneCard({
       layout
       transition={COLLAPSE_TRANSITION}
       className={cn(
-        'flex flex-col rounded-[14px] border bg-[color:var(--bg-elevated)]',
+        'flex flex-col rounded-lg border bg-[color:var(--bg-elevated)]',
         'overflow-hidden',
         hasWarning
           ? 'border-[color:var(--danger)]/50'
@@ -131,7 +131,7 @@ export function PaneCard({
             />
             {hasWarning ? (
               <span
-                className="font-mono-num inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-[color:var(--danger)] px-1 text-[10px] font-semibold text-white"
+                className="font-mono-num inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-[color:var(--danger)] px-1 text-[10px] font-semibold text-[color:var(--fg-on-dark)]"
                 aria-label={t('missingCountAria', { count: warningCount })}
                 title={t('missingRequiredFields', { count: warningCount })}
               >
@@ -180,7 +180,7 @@ export function PaneCard({
               </h2>
               {hasWarning ? (
                 <span
-                  className="font-mono-num inline-flex items-center gap-1 rounded-full bg-[color:var(--danger)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-white"
+                  className="font-mono-num inline-flex items-center gap-1 rounded-full bg-[color:var(--danger)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-on-dark)]"
                   title={t('missingRequiredFields', { count: warningCount })}
                 >
                   <AlertTriangle className="size-2.5" aria-hidden />

--- a/web-ui/app/store/builder/[id]/_components/PersonaPillar.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PersonaPillar.tsx
@@ -420,7 +420,7 @@ export function PersonaPillar({
             onClick={handleSave}
             disabled={!dirty || pending || disabled}
             className={cn(
-              'rounded-md bg-[color:var(--accent)] px-3 py-1.5 text-sm font-medium text-white',
+              'rounded-md bg-[color:var(--accent)] px-3 py-1.5 text-sm font-medium text-[color:var(--fg-on-dark)]',
               'shadow-[var(--shadow-cta)] disabled:opacity-50',
             )}
           >

--- a/web-ui/app/store/builder/[id]/_components/PersonaPillar.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PersonaPillar.tsx
@@ -159,7 +159,7 @@ export function PersonaPillar({
 
   return (
     <section
-      className="space-y-5 p-5"
+      className="space-y-4 p-4"
       data-testid="persona-pillar"
       aria-labelledby="persona-pillar-heading"
     >
@@ -261,7 +261,7 @@ export function PersonaPillar({
       />
 
       {/* Template (Phase-4-aware placeholder) */}
-      <div className="space-y-1.5">
+      <div className="space-y-2">
         <label
           className="block text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)]"
           htmlFor="persona-template"
@@ -349,7 +349,7 @@ export function PersonaPillar({
       </div>
 
       {/* Custom notes */}
-      <div className="space-y-1.5">
+      <div className="space-y-2">
         <label
           htmlFor="persona-custom-notes"
           className="block text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)]"
@@ -409,7 +409,7 @@ export function PersonaPillar({
             onClick={handleReset}
             disabled={!dirty || pending || disabled}
             className={cn(
-              'rounded-md border border-[color:var(--border)] px-3 py-1.5 text-sm',
+              'rounded-md border border-[color:var(--border)] px-3 py-2 text-sm',
               'text-[color:var(--fg)] disabled:opacity-50',
             )}
           >
@@ -420,7 +420,7 @@ export function PersonaPillar({
             onClick={handleSave}
             disabled={!dirty || pending || disabled}
             className={cn(
-              'rounded-md bg-[color:var(--accent)] px-3 py-1.5 text-sm font-medium text-[color:var(--fg-on-dark)]',
+              'rounded-md bg-[color:var(--accent)] px-3 py-2 text-sm font-medium text-[color:var(--fg-on-dark)]',
               'shadow-[var(--shadow-cta)] disabled:opacity-50',
             )}
           >

--- a/web-ui/app/store/builder/[id]/_components/PersonaTemplateGallery.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PersonaTemplateGallery.tsx
@@ -92,7 +92,7 @@ export function PersonaTemplateGallery({
       role="dialog"
       aria-modal="true"
       aria-label={t('title')}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--bg-modal-overlay)] p-4"
     >
       <div className="max-h-full w-full max-w-3xl overflow-y-auto rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-elevated,var(--bg))] p-4 text-[color:var(--fg)] shadow-xl">
         <header className="mb-3 flex items-baseline justify-between">
@@ -177,7 +177,7 @@ export function PersonaTemplateGallery({
         )}
 
         {error && (
-          <div role="alert" className="mt-3 text-sm text-red-600" data-testid="gallery-error">
+          <div role="alert" className="mt-3 text-sm text-[color:var(--danger)]" data-testid="gallery-error">
             {error}
           </div>
         )}
@@ -197,7 +197,7 @@ export function PersonaTemplateGallery({
             data-testid="gallery-apply"
             onClick={handleApply}
             disabled={disabled || pending || !selected}
-            className="rounded bg-[color:var(--accent)] px-3 py-1 text-sm font-medium text-white disabled:opacity-50"
+            className="rounded bg-[color:var(--accent)] px-3 py-1 text-sm font-medium text-[color:var(--fg-on-dark)] disabled:opacity-50"
           >
             {pending ? t('applying') : t('apply')}
           </button>

--- a/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
@@ -407,7 +407,7 @@ export function PreviewChatPane({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="flex items-center gap-2 border-b border-[color:var(--divider)] px-5 py-2 text-[11px] text-[color:var(--fg-muted)]">
+      <div className="flex items-center gap-2 border-b border-[color:var(--divider)] px-4 py-2 text-[11px] text-[color:var(--fg-muted)]">
         <Eye
           className="size-3 text-[color:var(--fg-subtle)]"
           aria-hidden
@@ -454,7 +454,7 @@ export function PreviewChatPane({
       />
 
       {rebuildSuccess ? (
-        <div className="mx-5 mt-3 flex items-center gap-2 rounded-md border border-[color:var(--success)]/30 bg-[color:var(--success)]/8 px-3 py-2 text-[12px] text-[color:var(--success)]">
+        <div className="mx-4 mt-3 flex items-center gap-2 rounded-md border border-[color:var(--success)]/30 bg-[color:var(--success)]/8 px-3 py-2 text-[12px] text-[color:var(--success)]">
           <CheckCircle2 className="size-3.5 shrink-0" aria-hidden />
           <span className="font-mono-num text-[11px]">
             {t('rebuildSuccess', { buildN: rebuildSuccess.buildN })}
@@ -470,7 +470,7 @@ export function PreviewChatPane({
       ) : null}
 
       {agentStuck ? (
-        <div className="mx-5 mt-3 flex items-start gap-2 rounded-md border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/8 px-3 py-2 text-[12px] text-[color:var(--warning)]">
+        <div className="mx-4 mt-3 flex items-start gap-2 rounded-md border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/8 px-3 py-2 text-[12px] text-[color:var(--warning)]">
           <AlertCircle className="mt-0.5 size-3.5 shrink-0" aria-hidden />
           <div className="min-w-0 flex-1 break-words">
             <div className="font-semibold">
@@ -502,7 +502,7 @@ export function PreviewChatPane({
 
       <div
         ref={scrollRef}
-        className="flex-1 space-y-3 overflow-y-auto px-5 py-4"
+        className="flex-1 space-y-3 overflow-y-auto px-4 py-4"
       >
         {items.length === 0 ? (
           <EmptyHint />
@@ -541,7 +541,7 @@ export function PreviewChatPane({
         // real lookups; everything else stays a hard error (red).
         // Source: HANDOFF-2026-05-04-preview-services-undefined.md.
         /is not registered/.test(error) ? (
-          <div className="mx-5 mb-2 flex items-start gap-2 rounded-md border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/8 px-3 py-2 text-[12px] text-[color:var(--warning)]">
+          <div className="mx-4 mb-2 flex items-start gap-2 rounded-md border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/8 px-3 py-2 text-[12px] text-[color:var(--warning)]">
             <AlertCircle className="mt-0.5 size-3.5 shrink-0" aria-hidden />
             <div className="min-w-0 flex-1 break-words">
               <div>{error}</div>
@@ -553,14 +553,14 @@ export function PreviewChatPane({
             </div>
           </div>
         ) : (
-          <div className="mx-5 mb-2 flex items-start gap-2 rounded-md border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/8 px-3 py-2 text-[12px] text-[color:var(--danger)]">
+          <div className="mx-4 mb-2 flex items-start gap-2 rounded-md border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/8 px-3 py-2 text-[12px] text-[color:var(--danger)]">
             <AlertCircle className="mt-0.5 size-3.5 shrink-0" aria-hidden />
             <span className="break-words">{error}</span>
           </div>
         )
       ) : null}
 
-      <div className="border-t border-[color:var(--divider)] px-5 py-3">
+      <div className="border-t border-[color:var(--divider)] px-4 py-3">
         <label className="sr-only" htmlFor={inputId}>
           {t('inputLabel')}
         </label>
@@ -581,7 +581,7 @@ export function PreviewChatPane({
             <button
               type="button"
               onClick={onStop}
-              className="inline-flex h-[44px] shrink-0 items-center gap-1.5 rounded-md border border-[color:var(--danger)]/40 px-3 py-2 text-[12px] font-semibold text-[color:var(--danger)] transition-colors hover:bg-[color:var(--danger)]/10"
+              className="inline-flex h-[44px] shrink-0 items-center gap-2 rounded-md border border-[color:var(--danger)]/40 px-3 py-2 text-[12px] font-semibold text-[color:var(--danger)] transition-colors hover:bg-[color:var(--danger)]/10"
             >
               <StopCircle className="size-4" aria-hidden />
               {t('stop')}
@@ -591,7 +591,7 @@ export function PreviewChatPane({
               type="button"
               onClick={() => void onSend()}
               disabled={input.trim().length === 0}
-              className="inline-flex h-[44px] shrink-0 items-center gap-1.5 rounded-md bg-[color:var(--accent)] px-3 py-2 text-[12px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-40"
+              className="inline-flex h-[44px] shrink-0 items-center gap-2 rounded-md bg-[color:var(--accent)] px-3 py-2 text-[12px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-40"
             >
               <Send className="size-4" aria-hidden />
               {t('send')}
@@ -599,7 +599,7 @@ export function PreviewChatPane({
           )}
         </div>
         {inflight ? (
-          <p className="font-mono-num mt-2 inline-flex items-center gap-1.5 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
+          <p className="font-mono-num mt-2 inline-flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
             <span className="lume-busy-dots" aria-hidden />
             {t('streamLive')} · {formatElapsed(turnStartedAt, elapsedNow)}
           </p>
@@ -663,7 +663,7 @@ function RuntimeSmokeStrip({
   return (
     <div
       className={cn(
-        'mx-5 mt-3 flex items-start gap-2 rounded-md border px-3 py-2 text-[12px]',
+        'mx-4 mt-3 flex items-start gap-2 rounded-md border px-3 py-2 text-[12px]',
         toneClass,
       )}
     >
@@ -687,7 +687,7 @@ function RuntimeSmokeStrip({
           <button
             type="button"
             onClick={onFixWithBuilder}
-            className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/10 px-2 py-1 text-[11px] font-mono-num uppercase tracking-[0.18em] text-[color:var(--danger)] transition-colors hover:bg-[color:var(--danger)]/15"
+            className="mt-2 inline-flex items-center gap-2 rounded-md border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/10 px-2 py-1 text-[11px] font-mono-num uppercase tracking-[0.18em] text-[color:var(--danger)] transition-colors hover:bg-[color:var(--danger)]/15"
           >
             <Wrench className="size-3" aria-hidden />
             {t('fixWithBuilder')}
@@ -816,7 +816,7 @@ function ToolCard({
         type="button"
         onClick={() => setExpanded((v) => !v)}
         aria-expanded={expanded}
-        className="flex w-full items-center gap-1.5 px-3 py-2 text-left text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)] focus:outline-none"
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)] focus:outline-none"
       >
         {expanded ? (
           <ChevronDown className="size-3" aria-hidden />
@@ -840,7 +840,7 @@ function ToolCard({
         )}
       </button>
       {expanded ? (
-        <div className="space-y-1.5 border-t border-[color:var(--divider)] px-3 py-2">
+        <div className="space-y-2 border-t border-[color:var(--divider)] px-3 py-2">
           <pre className="font-mono-num overflow-x-auto whitespace-pre-wrap break-words rounded bg-[color:var(--bg)] px-2 py-1 text-[11px] text-[color:var(--fg-muted)]">
             {jsonPreview(item.input)}
           </pre>

--- a/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
@@ -592,7 +592,7 @@ export function PreviewChatPane({
               type="button"
               onClick={() => void onSend()}
               disabled={input.trim().length === 0}
-              className="inline-flex h-[44px] shrink-0 items-center gap-1.5 rounded-md bg-[color:var(--accent)] px-3 py-2 text-[12px] font-semibold text-white shadow-[var(--shadow-cta)] disabled:opacity-40"
+              className="inline-flex h-[44px] shrink-0 items-center gap-1.5 rounded-md bg-[color:var(--accent)] px-3 py-2 text-[12px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-40"
             >
               <Send className="size-4" aria-hidden />
               {t('send')}
@@ -721,9 +721,9 @@ function ChatItemView({ item }: { item: ChatItem }): React.ReactElement | null {
       <div className={cn('flex', isUser ? 'justify-end' : 'justify-start')}>
         <div
           className={cn(
-            'max-w-[88%] rounded-[12px] px-3 py-2 text-[13px] leading-snug',
+            'max-w-[88%] rounded-lg px-3 py-2 text-[13px] leading-snug',
             isUser
-              ? 'bg-[color:var(--accent)] text-white'
+              ? 'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)]'
               : 'bg-[color:var(--bg-soft)] text-[color:var(--fg-strong)]',
           )}
         >
@@ -755,7 +755,7 @@ function ChatItemView({ item }: { item: ChatItem }): React.ReactElement | null {
           ? XCircle
           : Hammer;
     return (
-      <div className={cn('rounded-[10px] border px-3 py-2 text-[12px]', palette)}>
+      <div className={cn('rounded-md border px-3 py-2 text-[12px]', palette)}>
         <div className="flex items-center gap-2">
           <Icon className="size-3.5" aria-hidden />
           <span className="font-mono-num text-[10px] uppercase tracking-[0.16em]">
@@ -812,7 +812,7 @@ function ToolCard({
   const [expanded, setExpanded] = useState(false);
   const pending = item.output === null;
   return (
-    <div className="rounded-[10px] border border-[color:var(--divider)] bg-[color:var(--bg-soft)]/60 text-[12px]">
+    <div className="rounded-md border border-[color:var(--divider)] bg-[color:var(--bg-soft)]/60 text-[12px]">
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}

--- a/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
@@ -778,7 +778,7 @@ function ChatItemView({ item }: { item: ChatItem }): React.ReactElement | null {
             {item.codegenIssues.map((iss, i) => (
               <li
                 key={`codegen-${String(i)}`}
-                className="rounded border border-current/20 bg-white/40 px-2 py-1"
+                className="rounded border border-current/20 bg-[color:var(--bg-elevated)]/40 px-2 py-1"
               >
                 <span className="font-mono-num text-[10px] uppercase tracking-[0.16em] opacity-80">
                   {iss.code}

--- a/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
@@ -16,8 +16,7 @@ import {
   Eye,
   Hammer,
   KeyRound,
-  Loader2,
-  RefreshCw,
+    RefreshCw,
   Send,
   StopCircle,
   Wrench,
@@ -438,7 +437,7 @@ export function PreviewChatPane({
           className="inline-flex items-center gap-1 rounded-md bg-[color:var(--bg-soft)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)] hover:bg-[color:var(--gray-100)] hover:text-[color:var(--fg-strong)] disabled:opacity-50"
         >
           {rebuildPending ? (
-            <Loader2 className="size-3 animate-spin" aria-hidden />
+            <span className="lume-busy-dots" aria-hidden />
           ) : (
             <RefreshCw className="size-3" aria-hidden />
           )}
@@ -601,7 +600,7 @@ export function PreviewChatPane({
         </div>
         {inflight ? (
           <p className="font-mono-num mt-2 inline-flex items-center gap-1.5 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
-            <Loader2 className="size-3 animate-spin" aria-hidden />
+            <span className="lume-busy-dots" aria-hidden />
             {t('streamLive')} · {formatElapsed(turnStartedAt, elapsedNow)}
           </p>
         ) : null}
@@ -630,7 +629,7 @@ function RuntimeSmokeStrip({
   let label: string;
 
   if (snap.phase === 'running') {
-    icon = <Loader2 className="size-3 animate-spin" aria-hidden />;
+    icon = <span className="lume-busy-dots" aria-hidden />;
     toneClass =
       'border-[color:var(--divider)] bg-[color:var(--bg-soft)] text-[color:var(--fg-muted)]';
     label = t('running', { buildN: snap.buildN });
@@ -767,7 +766,7 @@ function ChatItemView({ item }: { item: ChatItem }): React.ReactElement | null {
             </span>
           ) : null}
           {item.phase === 'building' ? (
-            <Loader2 className="ml-auto size-3 animate-spin" aria-hidden />
+            <span className="lume-busy-dots" aria-hidden />
           ) : null}
         </div>
         {item.reason ? (
@@ -829,10 +828,7 @@ function ToolCard({
           {item.toolId}
         </span>
         {pending ? (
-          <Loader2
-            className="ml-auto size-3 animate-spin text-[color:var(--accent)]"
-            aria-hidden
-          />
+          <span className="lume-busy-dots ml-auto text-[color:var(--accent)]" aria-hidden />
         ) : item.isError ? (
           <span className="ml-auto inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.16em] text-[color:var(--danger)]">
             error

--- a/web-ui/app/store/builder/[id]/_components/PreviewPromptPanel.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PreviewPromptPanel.tsx
@@ -22,12 +22,12 @@ import {
 // so they stay readable on a dark theme (without it, the page's light
 // foreground inherits and the text disappears against the light pastel).
 const KIND_BG: Record<PreviewPromptSection['kind'], string> = {
-  header: 'bg-slate-50 text-slate-900',
-  persona: 'bg-amber-50 text-amber-950',
-  custom_notes: 'bg-amber-50/70 text-amber-950',
-  boundaries: 'bg-rose-50 text-rose-950',
-  sycophancy: 'bg-violet-50 text-violet-950',
-  skill: 'bg-emerald-50 text-emerald-950',
+  header: 'bg-[color:var(--bg-soft)] text-[color:var(--fg-strong)]',
+  persona: 'bg-[color:var(--warning)]/10 text-[color:var(--warning)]',
+  custom_notes: 'bg-[color:var(--warning)]/10 text-[color:var(--warning)]',
+  boundaries: 'bg-[color:var(--danger)]/8 text-[color:var(--danger)]',
+  sycophancy: 'bg-[color:var(--accent)]/10 text-[color:var(--accent)]',
+  skill: 'bg-[color:var(--success)]/10 text-[color:var(--success)]',
 };
 
 const KIND_LABEL: Record<PreviewPromptSection['kind'], string> = {
@@ -42,10 +42,10 @@ const KIND_LABEL: Record<PreviewPromptSection['kind'], string> = {
 type TokenHealthLevel = 'good' | 'medium' | 'high' | 'critical';
 
 function tokenHealth(tokens: number): { color: string; level: TokenHealthLevel } {
-  if (tokens < 2000) return { color: 'text-emerald-600', level: 'good' };
-  if (tokens < 3500) return { color: 'text-amber-600', level: 'medium' };
-  if (tokens < 5000) return { color: 'text-orange-600', level: 'high' };
-  return { color: 'text-red-600', level: 'critical' };
+  if (tokens < 2000) return { color: 'text-[color:var(--success)]', level: 'good' };
+  if (tokens < 3500) return { color: 'text-[color:var(--warning)]', level: 'medium' };
+  if (tokens < 5000) return { color: 'text-[color:var(--warning)]', level: 'high' };
+  return { color: 'text-[color:var(--danger)]', level: 'critical' };
 }
 
 export interface PreviewPromptPanelProps {
@@ -157,7 +157,7 @@ export function PreviewPromptPanel({
       </header>
 
       {error && (
-        <div role="alert" className="text-xs text-red-600" data-testid="preview-prompt-error">
+        <div role="alert" className="text-xs text-[color:var(--danger)]" data-testid="preview-prompt-error">
           {error}
         </div>
       )}

--- a/web-ui/app/store/builder/[id]/_components/QualityPanel.tsx
+++ b/web-ui/app/store/builder/[id]/_components/QualityPanel.tsx
@@ -18,9 +18,9 @@ import {
  */
 
 function scoreColor(score: number): string {
-  if (score >= 70) return 'bg-emerald-500';
-  if (score >= 40) return 'bg-amber-500';
-  return 'bg-red-500';
+  if (score >= 70) return 'bg-[color:var(--success)]/100';
+  if (score >= 40) return 'bg-[color:var(--warning)]/100';
+  return 'bg-[color:var(--danger)]/80';
 }
 
 export interface QualityPanelProps {
@@ -110,7 +110,7 @@ export function QualityPanel({ draftId, refetchKey }: QualityPanelProps): React.
       </header>
 
       {error && (
-        <div role="alert" className="text-xs text-red-600" data-testid="quality-error">
+        <div role="alert" className="text-xs text-[color:var(--danger)]" data-testid="quality-error">
           {error}
         </div>
       )}

--- a/web-ui/app/store/builder/[id]/_components/SecretsDrawer.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SecretsDrawer.tsx
@@ -147,7 +147,7 @@ export function SecretsDrawer({
             role="dialog"
             aria-label={t('title')}
           >
-            <header className="flex items-baseline gap-3 border-b border-[color:var(--divider)] px-5 py-4">
+            <header className="flex items-baseline gap-3 border-b border-[color:var(--divider)] px-4 py-4">
               <KeyRound
                 className="size-3.5 shrink-0 text-[color:var(--accent)]"
                 aria-hidden
@@ -165,7 +165,7 @@ export function SecretsDrawer({
               </button>
             </header>
 
-            <div className="space-y-4 overflow-y-auto px-5 py-4 text-[13px]">
+            <div className="space-y-4 overflow-y-auto px-4 py-4 text-[13px]">
               <p className="text-[12px] text-[color:var(--fg-muted)]">
                 {persistent === true
                   ? t('persistence.persistent')
@@ -205,12 +205,12 @@ export function SecretsDrawer({
               ) : null}
             </div>
 
-            <footer className="flex items-center gap-2 border-t border-[color:var(--divider)] px-5 py-3">
+            <footer className="flex items-center gap-2 border-t border-[color:var(--divider)] px-4 py-3">
               <button
                 type="button"
                 onClick={() => void onClearAll()}
                 disabled={pending || bufferedKeys.length === 0}
-                className="inline-flex items-center gap-1.5 rounded-md border border-[color:var(--danger)]/40 px-2.5 py-1.5 text-[11px] font-semibold text-[color:var(--danger)] transition-colors hover:bg-[color:var(--danger)]/10 disabled:opacity-40"
+                className="inline-flex items-center gap-2 rounded-md border border-[color:var(--danger)]/40 px-3 py-2 text-[11px] font-semibold text-[color:var(--danger)] transition-colors hover:bg-[color:var(--danger)]/10 disabled:opacity-40"
               >
                 <Trash2 className="size-3" aria-hidden />
                 {t('clearAll')}
@@ -219,7 +219,7 @@ export function SecretsDrawer({
                 type="button"
                 onClick={() => void onSave()}
                 disabled={pending || fields.length === 0}
-                className="ml-auto inline-flex items-center gap-1.5 rounded-md bg-[color:var(--accent)] px-3 py-1.5 text-[12px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-50"
+                className="ml-auto inline-flex items-center gap-2 rounded-md bg-[color:var(--accent)] px-3 py-2 text-[12px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-50"
               >
                 {pending ? (
                   <span className="lume-busy-dots" aria-hidden />
@@ -273,7 +273,7 @@ function SecretFieldRow({
         >
           {field.type ?? 'string'}
           {buffered ? (
-            <span className="ml-1 inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[color:var(--success)]">
+            <span className="ml-1 inline-flex items-center gap-0.5 px-2 py-0.5 text-[color:var(--success)]">
               <CheckCircle2 className="size-2.5" aria-hidden />
               {t('set')}
             </span>
@@ -289,7 +289,7 @@ function SecretFieldRow({
         </p>
       ) : null}
       {field.type === 'boolean' ? (
-        <label className="mt-1 inline-flex items-center gap-1.5 text-[12px] text-[color:var(--fg-strong)]">
+        <label className="mt-1 inline-flex items-center gap-2 text-[12px] text-[color:var(--fg-strong)]">
           <input
             type="checkbox"
             checked={value === 'true'}
@@ -308,7 +308,7 @@ function SecretFieldRow({
             buffered ? t('placeholder.buffered') : t('placeholder.empty')
           }
           autoComplete="off"
-          className="mt-1 w-full rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-1.5 text-[12px] text-[color:var(--fg-strong)] placeholder:text-[color:var(--fg-subtle)] focus:border-[color:var(--accent)] focus:outline-none"
+          className="mt-1 w-full rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-2 text-[12px] text-[color:var(--fg-strong)] placeholder:text-[color:var(--fg-subtle)] focus:border-[color:var(--accent)] focus:outline-none"
         />
       )}
     </li>

--- a/web-ui/app/store/builder/[id]/_components/SecretsDrawer.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SecretsDrawer.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { AnimatePresence, motion } from 'framer-motion';
-import { CheckCircle2, KeyRound, Loader2, Trash2, X } from 'lucide-react';
+import { CheckCircle2, KeyRound, Trash2, X } from 'lucide-react';
 
 import {
   ApiError,
@@ -222,7 +222,7 @@ export function SecretsDrawer({
                 className="ml-auto inline-flex items-center gap-1.5 rounded-md bg-[color:var(--accent)] px-3 py-1.5 text-[12px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-50"
               >
                 {pending ? (
-                  <Loader2 className="size-3.5 animate-spin" aria-hidden />
+                  <span className="lume-busy-dots" aria-hidden />
                 ) : (
                   <CheckCircle2 className="size-3.5" aria-hidden />
                 )}
@@ -273,7 +273,7 @@ function SecretFieldRow({
         >
           {field.type ?? 'string'}
           {buffered ? (
-            <span className="ml-1 inline-flex items-center gap-0.5 rounded-full bg-[color:var(--success)]/15 px-1.5 py-0.5 text-[color:var(--success)]">
+            <span className="ml-1 inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[color:var(--success)]">
               <CheckCircle2 className="size-2.5" aria-hidden />
               {t('set')}
             </span>

--- a/web-ui/app/store/builder/[id]/_components/SecretsDrawer.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SecretsDrawer.tsx
@@ -177,7 +177,7 @@ export function SecretsDrawer({
               </p>
 
               {fields.length === 0 ? (
-                <div className="rounded-[10px] border border-dashed border-[color:var(--divider)] p-4 text-center text-[12px] text-[color:var(--fg-muted)]">
+                <div className="rounded-md border border-dashed border-[color:var(--divider)] p-4 text-center text-[12px] text-[color:var(--fg-muted)]">
                   {t.rich('noFields', {
                     code: () => (
                       <span className="font-mono-num">setup_fields</span>
@@ -219,7 +219,7 @@ export function SecretsDrawer({
                 type="button"
                 onClick={() => void onSave()}
                 disabled={pending || fields.length === 0}
-                className="ml-auto inline-flex items-center gap-1.5 rounded-md bg-[color:var(--accent)] px-3 py-1.5 text-[12px] font-semibold text-white shadow-[var(--shadow-cta)] disabled:opacity-50"
+                className="ml-auto inline-flex items-center gap-1.5 rounded-md bg-[color:var(--accent)] px-3 py-1.5 text-[12px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-50"
               >
                 {pending ? (
                   <Loader2 className="size-3.5 animate-spin" aria-hidden />

--- a/web-ui/app/store/builder/[id]/_components/SetupFieldsEditor.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SetupFieldsEditor.tsx
@@ -138,7 +138,7 @@ function SetupFieldRow({
   const keyId = useId();
   const labelId = useId();
   return (
-    <li className="rounded-[10px] border border-[color:var(--divider)] bg-[color:var(--bg-soft)]/40 p-3">
+    <li className="rounded-md border border-[color:var(--divider)] bg-[color:var(--bg-soft)]/40 p-3">
       <div className="grid grid-cols-1 gap-2 md:grid-cols-[1.2fr_1fr_0.8fr_0.6fr_auto]">
         <div>
           <label
@@ -259,7 +259,7 @@ function NewFieldForm({
     !existingKeys.includes(trimmed);
 
   return (
-    <div className="rounded-[10px] border border-dashed border-[color:var(--divider)] bg-[color:var(--bg-soft)]/30 p-3">
+    <div className="rounded-md border border-dashed border-[color:var(--divider)] bg-[color:var(--bg-soft)]/30 p-3">
       <div className="flex flex-wrap items-end gap-2">
         <div className="min-w-[180px] flex-1">
           <label className="block text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-subtle)]">
@@ -323,7 +323,7 @@ function NewFieldForm({
             setRequired(false);
           }}
           disabled={!valid}
-          className="ml-auto inline-flex items-center gap-1 rounded-md bg-[color:var(--accent)] px-2.5 py-1.5 text-[11px] font-semibold text-white shadow-[var(--shadow-cta)] disabled:opacity-40"
+          className="ml-auto inline-flex items-center gap-1 rounded-md bg-[color:var(--accent)] px-2.5 py-1.5 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-40"
         >
           <Plus className="size-3" aria-hidden />
           {t('add')}

--- a/web-ui/app/store/builder/[id]/_components/SetupFieldsEditor.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SetupFieldsEditor.tsx
@@ -201,7 +201,7 @@ function SetupFieldRow({
           <label className="block text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-subtle)]">
             required
           </label>
-          <label className="mt-1 inline-flex items-center gap-1.5 text-[12px] text-[color:var(--fg-strong)]">
+          <label className="mt-1 inline-flex items-center gap-2 text-[12px] text-[color:var(--fg-strong)]">
             <input
               type="checkbox"
               checked={Boolean(field.required)}
@@ -218,7 +218,7 @@ function SetupFieldRow({
             type="button"
             onClick={onRemove}
             aria-label={t('removeAria', { key: field.key })}
-            className="rounded-md p-1.5 text-[color:var(--fg-muted)] hover:bg-[color:var(--danger)]/10 hover:text-[color:var(--danger)]"
+            className="rounded-md p-2 text-[color:var(--fg-muted)] hover:bg-[color:var(--danger)]/10 hover:text-[color:var(--danger)]"
           >
             <Trash2 className="size-3.5" aria-hidden />
           </button>
@@ -303,7 +303,7 @@ function NewFieldForm({
             ))}
           </select>
         </div>
-        <label className="mt-5 inline-flex items-center gap-1.5 text-[11px] text-[color:var(--fg-strong)]">
+        <label className="mt-4 inline-flex items-center gap-2 text-[11px] text-[color:var(--fg-strong)]">
           <input
             type="checkbox"
             checked={required}
@@ -323,7 +323,7 @@ function NewFieldForm({
             setRequired(false);
           }}
           disabled={!valid}
-          className="ml-auto inline-flex items-center gap-1 rounded-md bg-[color:var(--accent)] px-2.5 py-1.5 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-40"
+          className="ml-auto inline-flex items-center gap-1 rounded-md bg-[color:var(--accent)] px-3 py-2 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-40"
         >
           <Plus className="size-3" aria-hidden />
           {t('add')}

--- a/web-ui/app/store/builder/[id]/_components/SimpleIntakePane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SimpleIntakePane.tsx
@@ -236,7 +236,7 @@ export function SimpleIntakePane({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div ref={scrollRef} className="flex-1 space-y-3 overflow-y-auto px-6 py-5">
+      <div ref={scrollRef} className="flex-1 space-y-3 overflow-y-auto px-6 py-4">
         {empty && !inflight ? (
           <IntakeHero onPick={(text) => void onSend(text)} />
         ) : (
@@ -250,7 +250,7 @@ export function SimpleIntakePane({
             >
               <div
                 className={cn(
-                  'max-w-[86%] px-4 py-2.5 text-[14.5px] leading-relaxed',
+                  'max-w-[86%] px-4 py-3 text-[14.5px] leading-relaxed',
                   m.role === 'user'
                     ? 'rounded-lg rounded-br-sm bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-sm)]'
                     : 'rounded-lg rounded-bl-sm bg-[color:var(--bg-soft)] text-[color:var(--fg-strong)]',
@@ -286,7 +286,7 @@ export function SimpleIntakePane({
       </div>
 
       {error ? (
-        <div className="mx-6 mb-2 flex items-start gap-2 rounded-lg border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/8 px-3.5 py-2.5 text-[13px] text-[color:var(--danger)]">
+        <div className="mx-6 mb-2 flex items-start gap-2 rounded-lg border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/8 px-3 py-3 text-[13px] text-[color:var(--danger)]">
           <span className="break-words">{error}</span>
         </div>
       ) : null}
@@ -295,7 +295,7 @@ export function SimpleIntakePane({
         <label className="sr-only" htmlFor={inputId}>
           {t('inputLabel')}
         </label>
-        <div className="flex items-end gap-2.5">
+        <div className="flex items-end gap-3">
           <textarea
             id={inputId}
             value={input}
@@ -310,7 +310,7 @@ export function SimpleIntakePane({
             <button
               type="button"
               onClick={onStop}
-              className="inline-flex h-[50px] shrink-0 items-center gap-1.5 rounded-full border border-[color:var(--danger)]/40 px-4 text-[13px] font-semibold text-[color:var(--danger)] transition-colors hover:bg-[color:var(--danger)]/10"
+              className="inline-flex h-[50px] shrink-0 items-center gap-2 rounded-full border border-[color:var(--danger)]/40 px-4 text-[13px] font-semibold text-[color:var(--danger)] transition-colors hover:bg-[color:var(--danger)]/10"
             >
               <StopCircle className="size-4" aria-hidden />
               {t('stop')}
@@ -320,7 +320,7 @@ export function SimpleIntakePane({
               type="button"
               onClick={() => void onSend()}
               disabled={input.trim().length === 0}
-              className="inline-flex h-[50px] shrink-0 items-center gap-2 rounded-full bg-[color:var(--accent)] px-5 text-[14px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] transition-all hover:opacity-90 disabled:opacity-40 disabled:shadow-none"
+              className="inline-flex h-[50px] shrink-0 items-center gap-2 rounded-full bg-[color:var(--accent)] px-4 text-[14px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] transition-all hover:opacity-90 disabled:opacity-40 disabled:shadow-none"
             >
               <Send className="size-4" aria-hidden />
               {t('send')}
@@ -378,7 +378,7 @@ function friendlyStatusKey(ev: BuilderTurnEvent): StatusKey | null {
 
 function LoadingLine({ status }: { status: string }): React.ReactElement {
   return (
-    <div className="flex items-center gap-3 rounded-lg bg-[color:var(--bg-soft)] px-4 py-3.5">
+    <div className="flex items-center gap-3 rounded-lg bg-[color:var(--bg-soft)] px-4 py-3">
       <BreathingDots />
       <span className="text-[13.5px] text-[color:var(--fg-muted)]" aria-live="polite">
         {status}

--- a/web-ui/app/store/builder/[id]/_components/SimpleIntakePane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SimpleIntakePane.tsx
@@ -252,8 +252,8 @@ export function SimpleIntakePane({
                 className={cn(
                   'max-w-[86%] px-4 py-2.5 text-[14.5px] leading-relaxed',
                   m.role === 'user'
-                    ? 'rounded-[18px] rounded-br-[6px] bg-[color:var(--accent)] text-white shadow-[var(--shadow-sm)]'
-                    : 'rounded-[18px] rounded-bl-[6px] bg-[color:var(--bg-soft)] text-[color:var(--fg-strong)]',
+                    ? 'rounded-lg rounded-br-sm bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-sm)]'
+                    : 'rounded-lg rounded-bl-sm bg-[color:var(--bg-soft)] text-[color:var(--fg-strong)]',
                 )}
               >
                 {m.role === 'user' ? (
@@ -286,7 +286,7 @@ export function SimpleIntakePane({
       </div>
 
       {error ? (
-        <div className="mx-6 mb-2 flex items-start gap-2 rounded-[12px] border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/8 px-3.5 py-2.5 text-[13px] text-[color:var(--danger)]">
+        <div className="mx-6 mb-2 flex items-start gap-2 rounded-lg border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/8 px-3.5 py-2.5 text-[13px] text-[color:var(--danger)]">
           <span className="break-words">{error}</span>
         </div>
       ) : null}
@@ -304,7 +304,7 @@ export function SimpleIntakePane({
             onKeyDown={onKeyDown}
             rows={2}
             placeholder={inflight ? t('placeholderBusy') : t('placeholderIdle')}
-            className="min-h-[50px] flex-1 resize-none rounded-[16px] border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-3 text-[14.5px] leading-snug text-[color:var(--fg-strong)] placeholder:text-[color:var(--fg-subtle)] transition-colors focus:border-[color:var(--accent)] focus:outline-none focus:ring-4 focus:ring-[color:var(--accent)]/10 disabled:opacity-60"
+            className="min-h-[50px] flex-1 resize-none rounded-lg border border-[color:var(--border)] bg-[color:var(--bg)] px-4 py-3 text-[14.5px] leading-snug text-[color:var(--fg-strong)] placeholder:text-[color:var(--fg-subtle)] transition-colors focus:border-[color:var(--accent)] focus:outline-none focus:ring-4 focus:ring-[color:var(--accent)]/10 disabled:opacity-60"
           />
           {inflight ? (
             <button
@@ -320,7 +320,7 @@ export function SimpleIntakePane({
               type="button"
               onClick={() => void onSend()}
               disabled={input.trim().length === 0}
-              className="inline-flex h-[50px] shrink-0 items-center gap-2 rounded-full bg-[color:var(--accent)] px-5 text-[14px] font-semibold text-white shadow-[var(--shadow-cta)] transition-all hover:opacity-90 disabled:opacity-40 disabled:shadow-none"
+              className="inline-flex h-[50px] shrink-0 items-center gap-2 rounded-full bg-[color:var(--accent)] px-5 text-[14px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] transition-all hover:opacity-90 disabled:opacity-40 disabled:shadow-none"
             >
               <Send className="size-4" aria-hidden />
               {t('send')}
@@ -378,7 +378,7 @@ function friendlyStatusKey(ev: BuilderTurnEvent): StatusKey | null {
 
 function LoadingLine({ status }: { status: string }): React.ReactElement {
   return (
-    <div className="flex items-center gap-3 rounded-[16px] bg-[color:var(--bg-soft)] px-4 py-3.5">
+    <div className="flex items-center gap-3 rounded-lg bg-[color:var(--bg-soft)] px-4 py-3.5">
       <BreathingDots />
       <span className="text-[13.5px] text-[color:var(--fg-muted)]" aria-live="polite">
         {status}

--- a/web-ui/app/store/builder/[id]/_components/SimpleWorkspace.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SimpleWorkspace.tsx
@@ -96,7 +96,7 @@ export function SimpleWorkspace({
           aria-hidden
           className="pointer-events-none absolute -right-8 -top-10 size-40 rounded-full bg-white/40 blur-2xl"
         />
-        <span className="inline-flex items-center gap-1.5 rounded-full bg-white/55 px-3 py-1 text-[12px] font-semibold text-[#004B73]">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-[color:var(--accent-subtle)] px-3 py-1 text-[12px] font-semibold text-[color:var(--accent)]">
           <Wand2 className="size-3.5" aria-hidden />
           {t('intro.badge')}
         </span>

--- a/web-ui/app/store/builder/[id]/_components/SimpleWorkspace.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SimpleWorkspace.tsx
@@ -186,7 +186,7 @@ export function SimpleWorkspace({
 
           {hasBeenBuilt ? (
             <div className="flex items-center gap-2.5 rounded-lg bg-[color:var(--bg-soft)] px-4 py-3 text-[14px] text-[color:var(--fg-muted)]">
-              <span className="inline-flex size-7 items-center justify-center rounded-full bg-[color:var(--success)]/12 text-[color:var(--success)]">
+              <span className="inline-flex size-7 items-center justify-center text-[color:var(--success)]">
                 <Sparkles className="size-3.5" aria-hidden />
               </span>
               {toolCount > 0

--- a/web-ui/app/store/builder/[id]/_components/SimpleWorkspace.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SimpleWorkspace.tsx
@@ -90,7 +90,7 @@ export function SimpleWorkspace({
         initial={{ opacity: 0, y: 12 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5, ease: EASE_OUT }}
-        className="b5-hero-bg relative overflow-hidden rounded-[22px] px-7 py-7 shadow-[var(--shadow-sm)]"
+        className="b5-hero-bg relative overflow-hidden rounded-lg px-7 py-7 shadow-[var(--shadow-sm)]"
       >
         <div
           aria-hidden
@@ -102,8 +102,7 @@ export function SimpleWorkspace({
         </span>
         <h2 className="font-display mt-3 text-[26px] leading-tight">
           {t('intro.title')}
-          <span className="b5-colon">:</span>
-        </h2>
+                  </h2>
         <p className="mt-1.5 max-w-[480px] text-[15px] leading-relaxed">
           {t('intro.subtitle')}
         </p>
@@ -186,7 +185,7 @@ export function SimpleWorkspace({
           </OverviewField>
 
           {hasBeenBuilt ? (
-            <div className="flex items-center gap-2.5 rounded-[14px] bg-[color:var(--bg-soft)] px-4 py-3 text-[14px] text-[color:var(--fg-muted)]">
+            <div className="flex items-center gap-2.5 rounded-lg bg-[color:var(--bg-soft)] px-4 py-3 text-[14px] text-[color:var(--fg-muted)]">
               <span className="inline-flex size-7 items-center justify-center rounded-full bg-[color:var(--success)]/12 text-[color:var(--success)]">
                 <Sparkles className="size-3.5" aria-hidden />
               </span>
@@ -197,7 +196,7 @@ export function SimpleWorkspace({
           ) : null}
 
           {/* Persona — opt-in, collapsed by default to keep things calm. */}
-          <div className="overflow-hidden rounded-[16px] border border-[color:var(--divider)]">
+          <div className="overflow-hidden rounded-lg border border-[color:var(--divider)]">
             <button
               type="button"
               onClick={() => setPersonaOpen((v) => !v)}
@@ -278,10 +277,10 @@ function SimpleStepCard({
       initial={{ opacity: 0, y: 16 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5, ease: EASE_OUT, delay }}
-      className="overflow-hidden rounded-[22px] border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] shadow-[var(--shadow-md)]"
+      className="overflow-hidden rounded-lg border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] shadow-[var(--shadow-md)]"
     >
       <header className="flex items-center gap-4 border-b border-[color:var(--divider)] px-7 py-5">
-        <span className="relative inline-flex size-10 shrink-0 items-center justify-center rounded-full bg-[color:var(--accent)] text-white shadow-[var(--shadow-cta)]">
+        <span className="relative inline-flex size-10 shrink-0 items-center justify-center rounded-full bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]">
           <span className="font-display text-[16px] leading-none">{step}</span>
         </span>
         <div className="min-w-0 flex-1">

--- a/web-ui/app/store/builder/[id]/_components/SimpleWorkspace.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SimpleWorkspace.tsx
@@ -90,20 +90,20 @@ export function SimpleWorkspace({
         initial={{ opacity: 0, y: 12 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5, ease: EASE_OUT }}
-        className="b5-hero-bg relative overflow-hidden rounded-lg px-7 py-7 shadow-[var(--shadow-sm)]"
+        className="b5-hero-bg relative overflow-hidden rounded-lg px-6 py-6 shadow-[var(--shadow-sm)]"
       >
         <div
           aria-hidden
           className="pointer-events-none absolute -right-8 -top-10 size-40 rounded-full bg-white/40 blur-2xl"
         />
-        <span className="inline-flex items-center gap-1.5 rounded-full bg-[color:var(--accent-subtle)] px-3 py-1 text-[12px] font-semibold text-[color:var(--accent)]">
+        <span className="inline-flex items-center gap-2 rounded-full bg-[color:var(--accent-subtle)] px-3 py-1 text-[12px] font-semibold text-[color:var(--accent)]">
           <Wand2 className="size-3.5" aria-hidden />
           {t('intro.badge')}
         </span>
         <h2 className="font-display mt-3 text-[26px] leading-tight">
           {t('intro.title')}
                   </h2>
-        <p className="mt-1.5 max-w-[480px] text-[15px] leading-relaxed">
+        <p className="mt-2 max-w-[480px] text-[15px] leading-relaxed">
           {t('intro.subtitle')}
         </p>
       </motion.div>
@@ -164,7 +164,7 @@ export function SimpleWorkspace({
         subtitle={t('step2.subtitle')}
         delay={0.24}
       >
-        <div className="flex flex-col gap-5 px-7 py-6">
+        <div className="flex flex-col gap-4 px-6 py-6">
           <OverviewField label={t('overview.nameLabel')}>
             <span className="font-display text-[18px] text-[color:var(--fg-strong)]">
               {spec.name || t('overview.namePlaceholder')}
@@ -185,7 +185,7 @@ export function SimpleWorkspace({
           </OverviewField>
 
           {hasBeenBuilt ? (
-            <div className="flex items-center gap-2.5 rounded-lg bg-[color:var(--bg-soft)] px-4 py-3 text-[14px] text-[color:var(--fg-muted)]">
+            <div className="flex items-center gap-3 rounded-lg bg-[color:var(--bg-soft)] px-4 py-3 text-[14px] text-[color:var(--fg-muted)]">
               <span className="inline-flex size-7 items-center justify-center text-[color:var(--success)]">
                 <Sparkles className="size-3.5" aria-hidden />
               </span>
@@ -201,7 +201,7 @@ export function SimpleWorkspace({
               type="button"
               onClick={() => setPersonaOpen((v) => !v)}
               aria-expanded={personaOpen}
-              className="flex w-full items-center gap-3 px-4 py-3.5 text-left transition-colors hover:bg-[color:var(--bg-soft)]"
+              className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-[color:var(--bg-soft)]"
             >
               <span className="inline-flex size-8 shrink-0 items-center justify-center rounded-full bg-[color:var(--highlight)]/12 text-[color:var(--highlight)]">
                 <MessageCircleHeart className="size-4" aria-hidden />
@@ -214,7 +214,7 @@ export function SimpleWorkspace({
                   {t('persona.subtitle')}
                 </span>
               </span>
-              <span className="rounded-full bg-[color:var(--bg-soft)] px-2.5 py-0.5 text-[11px] font-medium text-[color:var(--fg-subtle)]">
+              <span className="rounded-full bg-[color:var(--bg-soft)] px-3 py-0.5 text-[11px] font-medium text-[color:var(--fg-subtle)]">
                 {t('persona.optional')}
               </span>
               <ChevronDown
@@ -252,7 +252,7 @@ function OverviewField({
   return (
     <div>
       <p className="text-[12px] font-semibold text-[color:var(--fg-subtle)]">{label}</p>
-      <div className="mt-1.5 break-words">{children}</div>
+      <div className="mt-2 break-words">{children}</div>
     </div>
   );
 }
@@ -279,8 +279,8 @@ function SimpleStepCard({
       transition={{ duration: 0.5, ease: EASE_OUT, delay }}
       className="overflow-hidden rounded-lg border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] shadow-[var(--shadow-md)]"
     >
-      <header className="flex items-center gap-4 border-b border-[color:var(--divider)] px-7 py-5">
-        <span className="relative inline-flex size-10 shrink-0 items-center justify-center rounded-full bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]">
+      <header className="flex items-center gap-4 border-b border-[color:var(--divider)] px-6 py-4">
+        <span className="lume-donut relative inline-flex size-10 shrink-0 items-center justify-center rounded-full border border-[color:var(--accent)] text-[color:var(--accent)]">
           <span className="font-display text-[16px] leading-none">{step}</span>
         </span>
         <div className="min-w-0 flex-1">

--- a/web-ui/app/store/builder/[id]/_components/SlotEditor.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SlotEditor.tsx
@@ -406,7 +406,7 @@ export function SlotEditor({
           type="button"
           onClick={() => void flush()}
           disabled={status.kind === 'pending'}
-          className="ml-auto inline-flex items-center gap-1.5 rounded-md bg-[color:var(--accent)] px-2.5 py-1 text-[11px] font-semibold text-white shadow-[var(--shadow-cta)] disabled:opacity-50"
+          className="ml-auto inline-flex items-center gap-1.5 rounded-md bg-[color:var(--accent)] px-2.5 py-1 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-50"
         >
           <Save className="size-3" aria-hidden />
           {t('save')}
@@ -481,7 +481,7 @@ function TemplateSlotsPanel({
           className={cn(
             'font-mono-num rounded-full px-1.5 text-[10px] font-semibold',
             missingRequired.length > 0
-              ? 'bg-[color:var(--danger)] text-white'
+              ? 'bg-[color:var(--danger)] text-[color:var(--fg-on-dark)]'
               : 'bg-[color:var(--success)]/15 text-[color:var(--success)]',
           )}
         >

--- a/web-ui/app/store/builder/[id]/_components/SlotEditor.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SlotEditor.tsx
@@ -17,8 +17,7 @@ import {
   CircleDashed,
   CircleDot,
   FileCode2,
-  Loader2,
-  Save,
+    Save,
   Sparkles,
 } from 'lucide-react';
 
@@ -435,7 +434,7 @@ export function SlotEditor({
           }}
           loading={
             <div className="flex h-full items-center justify-center text-[color:var(--fg-muted)]">
-              <Loader2 className="size-4 animate-spin" aria-hidden />
+              <span className="lume-busy-dots" aria-hidden />
             </div>
           }
         />
@@ -481,7 +480,7 @@ function TemplateSlotsPanel({
           className={cn(
             'font-mono-num rounded-full px-1.5 text-[10px] font-semibold',
             missingRequired.length > 0
-              ? 'bg-[color:var(--danger)] text-[color:var(--fg-on-dark)]'
+              ? 'text-[color:var(--danger)]'
               : 'bg-[color:var(--success)]/15 text-[color:var(--success)]',
           )}
         >
@@ -583,7 +582,7 @@ function SaveBadge({ status }: { status: SaveStatus }): React.ReactElement | nul
         status.kind === 'dirty' && 'text-[color:var(--warning)]',
       )}
     >
-      {status.kind === 'pending' && <Loader2 className="size-3 animate-spin" aria-hidden />}
+      {status.kind === 'pending' && <span className="lume-busy-dots" aria-hidden />}
       {status.kind === 'saved' && <Check className="size-3" aria-hidden />}
       {status.kind === 'dirty' && <span className="size-1.5 rounded-full bg-current" />}
       {status.kind === 'error' && <AlertCircle className="size-3" aria-hidden />}

--- a/web-ui/app/store/builder/[id]/_components/SlotEditor.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SlotEditor.tsx
@@ -381,7 +381,7 @@ export function SlotEditor({
         activeSlot={active}
       />
 
-      <div className="flex items-center gap-3 border-b border-[color:var(--divider)] px-5 py-3">
+      <div className="flex items-center gap-3 border-b border-[color:var(--divider)] px-4 py-3">
         <label
           htmlFor={selectId}
           className="font-mono-num text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]"
@@ -405,7 +405,7 @@ export function SlotEditor({
           type="button"
           onClick={() => void flush()}
           disabled={status.kind === 'pending'}
-          className="ml-auto inline-flex items-center gap-1.5 rounded-md bg-[color:var(--accent)] px-2.5 py-1 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-50"
+          className="ml-auto inline-flex items-center gap-2 rounded-md bg-[color:var(--accent)] px-3 py-1 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-50"
         >
           <Save className="size-3" aria-hidden />
           {t('save')}
@@ -472,13 +472,13 @@ function TemplateSlotsPanel({
       open={missingRequired.length > 0}
       className="group border-b border-[color:var(--divider)] bg-[color:var(--bg-soft)]/30"
     >
-      <summary className="flex cursor-pointer items-center gap-2 px-5 py-2 text-[11px] text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)]">
+      <summary className="flex cursor-pointer items-center gap-2 px-4 py-2 text-[11px] text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)]">
         <span className="font-mono-num text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
           {t('templateRequired.heading')}
         </span>
         <span
           className={cn(
-            'font-mono-num rounded-full px-1.5 text-[10px] font-semibold',
+            'font-mono-num rounded-full px-2 text-[10px] font-semibold',
             missingRequired.length > 0
               ? 'text-[color:var(--danger)]'
               : 'bg-[color:var(--success)]/15 text-[color:var(--success)]',
@@ -489,7 +489,7 @@ function TemplateSlotsPanel({
             : t('templateRequired.missing', { count: missingRequired.length })}
         </span>
       </summary>
-      <ul className="space-y-1 px-5 pb-3 pt-1">
+      <ul className="space-y-1 px-4 pb-3 pt-1">
         {templateSlots.map((slot) => {
           const filled = filledSet.has(slot.key);
           const isActive = slot.key === activeSlot;
@@ -497,7 +497,7 @@ function TemplateSlotsPanel({
             <li
               key={slot.key}
               className={cn(
-                'flex items-start gap-2 rounded-md px-2 py-1.5 transition-colors',
+                'flex items-start gap-2 rounded-md px-2 py-2 transition-colors',
                 filled && onSelectSlot && 'cursor-pointer hover:bg-[color:var(--bg-soft)]',
                 isActive && 'bg-[color:var(--bg-soft)]',
               )}

--- a/web-ui/app/store/builder/[id]/_components/SpecEditor.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SpecEditor.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { AlertCircle, Check, Loader2, Plus, X } from 'lucide-react';
+import { AlertCircle, Check, Plus, X } from 'lucide-react';
 
 import { ApiError, patchBuilderSpec } from '../../../../_lib/api';
 import type {
@@ -560,7 +560,7 @@ function SaveBadge({ status }: { status: SaveStatus }): React.ReactElement {
     if (status.kind === 'pending') {
       return (
         <>
-          <Loader2 className="size-3 animate-spin" aria-hidden />
+          <span className="lume-busy-dots" aria-hidden />
           <span>{t('save.saving')}</span>
         </>
       );

--- a/web-ui/app/store/builder/[id]/_components/SpecEditor.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SpecEditor.tsx
@@ -544,7 +544,7 @@ function ArrayField({
           type="button"
           onClick={submit}
           disabled={draft.trim().length === 0}
-          className="inline-flex items-center gap-1 rounded-md bg-[color:var(--accent)] px-2.5 py-1.5 text-[11px] font-semibold text-white shadow-[var(--shadow-cta)] disabled:opacity-40"
+          className="inline-flex items-center gap-1 rounded-md bg-[color:var(--accent)] px-2.5 py-1.5 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-40"
         >
           <Plus className="size-3" aria-hidden />
           {t('array.add')}

--- a/web-ui/app/store/builder/[id]/_components/SpecEditor.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SpecEditor.tsx
@@ -194,7 +194,7 @@ export function SpecEditor({ draftId, spec, agentStuck }: SpecEditorProps): Reac
   return (
     <div className="flex h-full min-h-0">
       <div className="flex h-full min-h-0 flex-1 flex-col">
-      <div className="flex-1 space-y-6 overflow-y-auto px-5 py-5">
+      <div className="flex-1 space-y-6 overflow-y-auto px-4 py-4">
         <FieldGroup title={t('groups.identity')}>
           <ScalarField
             label={t('fields.agentId')}
@@ -492,7 +492,7 @@ function ArrayField({
         {label}
       </label>
       {items.length > 0 ? (
-        <ul className="mb-2 flex flex-wrap gap-1.5">
+        <ul className="mb-2 flex flex-wrap gap-2">
           {items.map((item, i) => {
             const labelText = coerceArrayLabel(item);
             const malformed = typeof item !== 'string';
@@ -521,7 +521,7 @@ function ArrayField({
           })}
         </ul>
       ) : null}
-      <div className="flex gap-1.5">
+      <div className="flex gap-2">
         <input
           id={inputId}
           type="text"
@@ -535,7 +535,7 @@ function ArrayField({
             }
           }}
           className={cn(
-            'flex-1 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-3 py-1.5 text-[12px] text-[color:var(--fg-strong)] placeholder:text-[color:var(--fg-subtle)]',
+            'flex-1 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-3 py-2 text-[12px] text-[color:var(--fg-strong)] placeholder:text-[color:var(--fg-subtle)]',
             'focus:border-[color:var(--accent)] focus:outline-none',
             mono && 'font-mono-num',
           )}
@@ -544,7 +544,7 @@ function ArrayField({
           type="button"
           onClick={submit}
           disabled={draft.trim().length === 0}
-          className="inline-flex items-center gap-1 rounded-md bg-[color:var(--accent)] px-2.5 py-1.5 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-40"
+          className="inline-flex items-center gap-1 rounded-md bg-[color:var(--accent)] px-3 py-2 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-40"
         >
           <Plus className="size-3" aria-hidden />
           {t('array.add')}
@@ -587,8 +587,8 @@ function SaveBadge({ status }: { status: SaveStatus }): React.ReactElement {
   }, [status, t]);
   if (status.kind === 'idle') return <></>;
   return (
-    <div className="border-t border-[color:var(--divider)] px-5 py-2">
-      <div className="font-mono-num inline-flex items-center gap-1.5 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-muted)]">
+    <div className="border-t border-[color:var(--divider)] px-4 py-2">
+      <div className="font-mono-num inline-flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-muted)]">
         {content}
       </div>
     </div>

--- a/web-ui/app/store/builder/[id]/_components/SpecOverview.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SpecOverview.tsx
@@ -25,7 +25,7 @@ export function SpecOverview({ spec, slots }: SpecOverviewProps): React.ReactEle
   const networkCount = spec.network?.outbound?.length ?? 0;
 
   return (
-    <div className="grid grid-cols-1 gap-4 p-5 md:grid-cols-2">
+    <div className="grid grid-cols-1 gap-4 p-4 md:grid-cols-2">
       <Field label={t('fields.agentId')} value={spec.id || '—'} mono />
       <Field label={t('fields.name')} value={spec.name || '—'} />
       <Field label={t('fields.author')} value={spec.author || '—'} />
@@ -78,7 +78,7 @@ export function SpecOverview({ spec, slots }: SpecOverviewProps): React.ReactEle
           <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-[color:var(--fg-subtle)]">
             {t('slotKeys')}
           </p>
-          <ul className="mt-2 flex flex-wrap gap-1.5">
+          <ul className="mt-2 flex flex-wrap gap-2">
             {slotKeys.map((key) => (
               <li
                 key={key}

--- a/web-ui/app/store/builder/[id]/_components/ToolBulkImportModal.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolBulkImportModal.tsx
@@ -88,7 +88,7 @@ export function ToolBulkImportModal({
       role="dialog"
       aria-modal="true"
       aria-label={t('dialogLabel')}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--bg-modal-overlay)] px-4 py-10"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--bg-modal-overlay)] px-4 py-8"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
@@ -196,7 +196,7 @@ function TabBtn({
       type="button"
       onClick={onClick}
       className={cn(
-        'rounded-t border-x border-t px-3 py-1.5 text-[11px] font-semibold',
+        'rounded-t border-x border-t px-3 py-2 text-[11px] font-semibold',
         active
           ? 'border-[color:var(--border)] bg-[color:var(--bg)] text-[color:var(--fg-strong)]'
           : 'border-transparent text-[color:var(--fg-subtle)] hover:text-[color:var(--fg-strong)]',

--- a/web-ui/app/store/builder/[id]/_components/ToolBulkImportModal.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolBulkImportModal.tsx
@@ -88,7 +88,7 @@ export function ToolBulkImportModal({
       role="dialog"
       aria-modal="true"
       aria-label={t('dialogLabel')}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-10"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--bg-modal-overlay)] px-4 py-10"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
@@ -167,7 +167,7 @@ export function ToolBulkImportModal({
               result.tools.length === 0 ||
               result.tools.length === collisions.length
             }
-            className="inline-flex items-center gap-1 rounded bg-[color:var(--accent)] px-3 py-1 text-[11px] font-semibold text-white shadow-[var(--shadow-cta)] disabled:opacity-50"
+            className="inline-flex items-center gap-1 rounded bg-[color:var(--accent)] px-3 py-1 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-50"
           >
             {pending ? (
               <Loader2 className="size-3 animate-spin" aria-hidden />

--- a/web-ui/app/store/builder/[id]/_components/ToolBulkImportModal.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolBulkImportModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { AlertTriangle, Check, Loader2, Upload, X } from 'lucide-react';
+import { AlertTriangle, Check, Upload, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useMemo, useState } from 'react';
 
@@ -170,7 +170,7 @@ export function ToolBulkImportModal({
             className="inline-flex items-center gap-1 rounded bg-[color:var(--accent)] px-3 py-1 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-50"
           >
             {pending ? (
-              <Loader2 className="size-3 animate-spin" aria-hidden />
+              <span className="lume-busy-dots" aria-hidden />
             ) : (
               <Check className="size-3" aria-hidden />
             )}

--- a/web-ui/app/store/builder/[id]/_components/ToolForm.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolForm.tsx
@@ -309,7 +309,7 @@ function InputSchemaSection({
             className={cn(
               'px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em]',
               tab === 'form'
-                ? 'bg-[color:var(--accent)] text-white'
+                ? 'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)]'
                 : 'bg-[color:var(--bg)] text-[color:var(--fg-subtle)] hover:text-[color:var(--fg-strong)]',
             )}
           >
@@ -323,7 +323,7 @@ function InputSchemaSection({
             className={cn(
               'px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em]',
               tab === 'json'
-                ? 'bg-[color:var(--accent)] text-white'
+                ? 'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)]'
                 : 'bg-[color:var(--bg)] text-[color:var(--fg-subtle)] hover:text-[color:var(--fg-strong)]',
             )}
           >

--- a/web-ui/app/store/builder/[id]/_components/ToolInputSchemaBuilder.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolInputSchemaBuilder.tsx
@@ -109,7 +109,7 @@ export function ToolInputSchemaBuilder({
   }, [keys.length, properties, setProperty]);
 
   return (
-    <div className="space-y-1.5">
+    <div className="space-y-2">
       {keys.length === 0 ? (
         <p className="rounded border border-dashed border-[color:var(--border)] bg-[color:var(--bg)] px-3 py-2 text-[11px] italic text-[color:var(--fg-muted)]">
           {t('noProperties')}

--- a/web-ui/app/store/builder/[id]/_components/ToolInputSchemaJsonTab.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolInputSchemaJsonTab.tsx
@@ -82,7 +82,7 @@ export function ToolInputSchemaJsonTab({
   );
 
   return (
-    <div className="space-y-1.5">
+    <div className="space-y-2">
       <div className="overflow-hidden rounded-md border border-[color:var(--border)]">
         <MonacoEditor
           height="240px"

--- a/web-ui/app/store/builder/[id]/_components/ToolInputSchemaRow.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolInputSchemaRow.tsx
@@ -77,7 +77,7 @@ export function ToolInputSchemaRow({
         depth > 0 && 'ml-3',
       )}
     >
-      <div className="flex flex-wrap items-center gap-1.5 px-2 py-1.5">
+      <div className="flex flex-wrap items-center gap-2 px-2 py-2">
         <button
           type="button"
           onClick={() => setExpanded((p) => !p)}
@@ -110,7 +110,7 @@ export function ToolInputSchemaRow({
           aria-label={t('propertyType')}
           value={nodeType}
           onChange={(e) => changeType(e.target.value as SupportedType)}
-          className="rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-1.5 py-1 text-[11px] font-mono-num text-[color:var(--fg-strong)] focus:border-[color:var(--accent)] focus:outline-none"
+          className="rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-1 text-[11px] font-mono-num text-[color:var(--fg-strong)] focus:border-[color:var(--accent)] focus:outline-none"
         >
           <option value="string">string</option>
           <option value="number">number</option>
@@ -226,7 +226,7 @@ function DescriptionInput({
                   onChange(`${head}\`${m.$id}\``);
                 }}
                 title={m.summary ?? t('entityTitle', { name: m.name, version: m.version })}
-                className="inline-flex items-center gap-1 rounded border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/8 px-1.5 py-0.5 font-mono-num text-[10px] text-[color:var(--accent)] hover:bg-[color:var(--accent)]/15"
+                className="inline-flex items-center gap-1 rounded border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/8 px-2 py-0.5 font-mono-num text-[10px] text-[color:var(--accent)] hover:bg-[color:var(--accent)]/15"
               >
                 {m.$id}
               </button>
@@ -484,7 +484,7 @@ function ArrayItemsEditor({
   const items = (node.items as JsonSchemaNode | undefined) ?? { type: 'string' };
   const itemType = detectType(items);
   return (
-    <div className="space-y-1.5">
+    <div className="space-y-2">
       <div className="flex items-center gap-2">
         <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
           {t('itemType')}
@@ -495,7 +495,7 @@ function ArrayItemsEditor({
             const next = blankNodeForType(e.target.value as SupportedType);
             onChange({ ...node, items: next });
           }}
-          className="rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-1.5 py-1 text-[11px] font-mono-num text-[color:var(--fg-strong)] focus:border-[color:var(--accent)] focus:outline-none"
+          className="rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-1 text-[11px] font-mono-num text-[color:var(--fg-strong)] focus:border-[color:var(--accent)] focus:outline-none"
         >
           <option value="string">string</option>
           <option value="number">number</option>

--- a/web-ui/app/store/builder/[id]/_components/ToolInputSchemaRow.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolInputSchemaRow.tsx
@@ -462,7 +462,7 @@ function EnumValuesEditor({
             setDraft('');
           }}
           disabled={!draft.trim()}
-          className="rounded bg-[color:var(--accent)] px-2 py-1 text-[11px] font-semibold text-white disabled:opacity-40"
+          className="rounded bg-[color:var(--accent)] px-2 py-1 text-[11px] font-semibold text-[color:var(--fg-on-dark)] disabled:opacity-40"
         >
           +
         </button>

--- a/web-ui/app/store/builder/[id]/_components/ToolList.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolList.tsx
@@ -152,7 +152,7 @@ export function ToolList({
             <button
               type="button"
               onClick={onAdd}
-              className="inline-flex items-center gap-1 rounded-md bg-[color:var(--accent)] px-2.5 py-1.5 text-[11px] font-semibold text-white shadow-[var(--shadow-cta)]"
+              className="inline-flex items-center gap-1 rounded-md bg-[color:var(--accent)] px-2.5 py-1.5 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]"
             >
               <Plus className="size-3" aria-hidden />
               {t('addFirstTool')}

--- a/web-ui/app/store/builder/[id]/_components/ToolList.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolList.tsx
@@ -289,7 +289,7 @@ function SortableRow({
       style={style}
       className={cn(
         'rounded-md border border-[color:var(--border)] bg-[color:var(--bg)]',
-        isDragging && 'opacity-60 shadow-[var(--shadow-cta)]',
+        isDragging && 'opacity-50 shadow-[var(--shadow-drag)]',
       )}
     >
       <div className="flex items-center gap-1.5 px-2 py-1.5">
@@ -369,7 +369,7 @@ function AgentStuckMarker(): React.ReactElement {
   return (
     <span
       title={t('stuckTitle')}
-      className="ml-1 inline-flex shrink-0 items-center gap-1 rounded-full border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/10 px-1.5 py-0.5 text-[10px] font-semibold text-[color:var(--warning)]"
+      className="ml-1 inline-flex shrink-0 items-center gap-1 text-[10px] font-semibold text-[color:var(--warning)]"
     >
       <AlertTriangle className="size-2.5" aria-hidden />
       {t('stuckBadge')}

--- a/web-ui/app/store/builder/[id]/_components/ToolList.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolList.tsx
@@ -152,7 +152,7 @@ export function ToolList({
             <button
               type="button"
               onClick={onAdd}
-              className="inline-flex items-center gap-1 rounded-md bg-[color:var(--accent)] px-2.5 py-1.5 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]"
+              className="inline-flex items-center gap-1 rounded-md bg-[color:var(--accent)] px-3 py-2 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]"
             >
               <Plus className="size-3" aria-hidden />
               {t('addFirstTool')}
@@ -160,7 +160,7 @@ export function ToolList({
             <button
               type="button"
               onClick={() => setTemplatesOpen(true)}
-              className="inline-flex items-center gap-1 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-2.5 py-1.5 text-[11px] font-semibold text-[color:var(--fg-strong)] hover:border-[color:var(--accent)]"
+              className="inline-flex items-center gap-1 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-3 py-2 text-[11px] font-semibold text-[color:var(--fg-strong)] hover:border-[color:var(--accent)]"
             >
               <Layers className="size-3" aria-hidden />
               {t('fromTemplate')}
@@ -186,7 +186,7 @@ export function ToolList({
         onDragEnd={onDragEnd}
       >
         <SortableContext items={ids} strategy={verticalListSortingStrategy}>
-          <ul className="space-y-1.5">
+          <ul className="space-y-2">
             {tools.map((tool, index) => {
               const isExpanded = expandedId === tool.id;
               const stuck = isStuckForTool(agentStuck, tool.id);
@@ -214,7 +214,7 @@ export function ToolList({
         <button
           type="button"
           onClick={onAdd}
-          className="inline-flex items-center gap-1 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-2.5 py-1.5 text-[11px] font-semibold text-[color:var(--fg-strong)] hover:border-[color:var(--accent)]"
+          className="inline-flex items-center gap-1 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-3 py-2 text-[11px] font-semibold text-[color:var(--fg-strong)] hover:border-[color:var(--accent)]"
         >
           <Plus className="size-3" aria-hidden />
           {t('addTool')}
@@ -222,7 +222,7 @@ export function ToolList({
         <button
           type="button"
           onClick={() => setTemplatesOpen(true)}
-          className="inline-flex items-center gap-1 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-2.5 py-1.5 text-[11px] font-semibold text-[color:var(--fg-strong)] hover:border-[color:var(--accent)]"
+          className="inline-flex items-center gap-1 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-3 py-2 text-[11px] font-semibold text-[color:var(--fg-strong)] hover:border-[color:var(--accent)]"
         >
           <Layers className="size-3" aria-hidden />
           {t('fromTemplate')}
@@ -230,7 +230,7 @@ export function ToolList({
         <button
           type="button"
           onClick={() => setImportOpen(true)}
-          className="inline-flex items-center gap-1 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-2.5 py-1.5 text-[11px] font-semibold text-[color:var(--fg-strong)] hover:border-[color:var(--accent)]"
+          className="inline-flex items-center gap-1 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-3 py-2 text-[11px] font-semibold text-[color:var(--fg-strong)] hover:border-[color:var(--accent)]"
         >
           <Upload className="size-3" aria-hidden />
           {t('import')}
@@ -292,7 +292,7 @@ function SortableRow({
         isDragging && 'opacity-50 shadow-[var(--shadow-drag)]',
       )}
     >
-      <div className="flex items-center gap-1.5 px-2 py-1.5">
+      <div className="flex items-center gap-2 px-2 py-2">
         <button
           type="button"
           aria-label={t('reorderHandle')}

--- a/web-ui/app/store/builder/[id]/_components/ToolTemplatesModal.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolTemplatesModal.tsx
@@ -66,7 +66,7 @@ export function ToolTemplatesModal({
       role="dialog"
       aria-modal="true"
       aria-label={t('dialogLabel')}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--bg-modal-overlay)] px-4 py-10"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--bg-modal-overlay)] px-4 py-8"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
@@ -89,7 +89,7 @@ export function ToolTemplatesModal({
           </button>
         </header>
 
-        <div className="flex-1 space-y-1.5 overflow-y-auto px-4 py-3">
+        <div className="flex-1 space-y-2 overflow-y-auto px-4 py-3">
           {all.length === 0 ? (
             <p className="rounded border border-dashed border-[color:var(--border)] bg-[color:var(--bg)] px-3 py-4 text-center text-[12px] text-[color:var(--fg-muted)]">
               {t('empty')}
@@ -113,7 +113,7 @@ export function ToolTemplatesModal({
                     {tpl.label}
                   </span>
                   {tpl.source === 'personal' ? (
-                    <span className="rounded bg-[color:var(--accent)]/10 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.18em] text-[color:var(--accent)]">
+                    <span className="rounded bg-[color:var(--accent)]/10 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.18em] text-[color:var(--accent)]">
                       {t('personalBadge')}
                     </span>
                   ) : null}

--- a/web-ui/app/store/builder/[id]/_components/ToolTemplatesModal.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolTemplatesModal.tsx
@@ -66,7 +66,7 @@ export function ToolTemplatesModal({
       role="dialog"
       aria-modal="true"
       aria-label={t('dialogLabel')}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-10"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--bg-modal-overlay)] px-4 py-10"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}

--- a/web-ui/app/store/builder/[id]/_components/ToolTestModal.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolTestModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Loader2, Play, Save, X } from 'lucide-react';
+import { Play, Save, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useId, useMemo, useState } from 'react';
 
@@ -176,7 +176,7 @@ export function ToolTestModal({
                 className="inline-flex items-center gap-1 rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2.5 py-1 text-[11px] font-semibold text-[color:var(--fg-strong)] hover:border-[color:var(--accent)] disabled:opacity-50"
               >
                 {savingTestCase ? (
-                  <Loader2 className="size-3 animate-spin" aria-hidden />
+                  <span className="lume-busy-dots" aria-hidden />
                 ) : (
                   <Save className="size-3" aria-hidden />
                 )}
@@ -190,7 +190,7 @@ export function ToolTestModal({
               className="inline-flex items-center gap-1 rounded bg-[color:var(--accent)] px-3 py-1 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-50"
             >
               {pending ? (
-                <Loader2 className="size-3 animate-spin" aria-hidden />
+                <span className="lume-busy-dots" aria-hidden />
               ) : (
                 <Play className="size-3" aria-hidden />
               )}

--- a/web-ui/app/store/builder/[id]/_components/ToolTestModal.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolTestModal.tsx
@@ -106,7 +106,7 @@ export function ToolTestModal({
       role="dialog"
       aria-modal="true"
       aria-label={t('dialogLabel', { id: tool.id })}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--bg-modal-overlay)] px-4 py-10"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--bg-modal-overlay)] px-4 py-8"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
@@ -173,7 +173,7 @@ export function ToolTestModal({
                 type="button"
                 onClick={() => void onSave()}
                 disabled={savingTestCase}
-                className="inline-flex items-center gap-1 rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-2.5 py-1 text-[11px] font-semibold text-[color:var(--fg-strong)] hover:border-[color:var(--accent)] disabled:opacity-50"
+                className="inline-flex items-center gap-1 rounded border border-[color:var(--border)] bg-[color:var(--bg)] px-3 py-1 text-[11px] font-semibold text-[color:var(--fg-strong)] hover:border-[color:var(--accent)] disabled:opacity-50"
               >
                 {savingTestCase ? (
                   <span className="lume-busy-dots" aria-hidden />

--- a/web-ui/app/store/builder/[id]/_components/ToolTestModal.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolTestModal.tsx
@@ -106,7 +106,7 @@ export function ToolTestModal({
       role="dialog"
       aria-modal="true"
       aria-label={t('dialogLabel', { id: tool.id })}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-10"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--bg-modal-overlay)] px-4 py-10"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
@@ -187,7 +187,7 @@ export function ToolTestModal({
               type="button"
               onClick={() => void onRun()}
               disabled={pending}
-              className="inline-flex items-center gap-1 rounded bg-[color:var(--accent)] px-3 py-1 text-[11px] font-semibold text-white shadow-[var(--shadow-cta)] disabled:opacity-50"
+              className="inline-flex items-center gap-1 rounded bg-[color:var(--accent)] px-3 py-1 text-[11px] font-semibold text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] disabled:opacity-50"
             >
               {pending ? (
                 <Loader2 className="size-3 animate-spin" aria-hidden />

--- a/web-ui/app/store/builder/[id]/_components/ToolTestResultPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/ToolTestResultPane.tsx
@@ -31,7 +31,7 @@ export function ToolTestResultPane({
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-1.5">
+        <div className="flex items-center gap-2">
           {isError ? (
             <>
               <AlertCircle className="size-3.5 text-[color:var(--danger)]" aria-hidden />

--- a/web-ui/app/store/builder/[id]/_components/UiSurfacesEditor.tsx
+++ b/web-ui/app/store/builder/[id]/_components/UiSurfacesEditor.tsx
@@ -124,7 +124,7 @@ export function UiSurfacesEditor({
                 value={adminUiPath ?? ''}
                 onChange={(e) => updateAdminUiPath(e.target.value)}
                 placeholder="/api/<slug>/admin/index.html"
-                className="w-full rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-1.5 font-mono text-[12px]"
+                className="w-full rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-2 py-2 font-mono text-[12px]"
               />
             </label>
 

--- a/web-ui/app/store/builder/[id]/_components/UiSurfacesEditor.tsx
+++ b/web-ui/app/store/builder/[id]/_components/UiSurfacesEditor.tsx
@@ -88,7 +88,7 @@ export function UiSurfacesEditor({
     <div className="space-y-4">
       {/* ─── Admin UI Sub-Card ─── */}
       <SurfaceCard
-        icon={<ShieldCheck className="size-4 text-slate-500" />}
+        icon={<ShieldCheck className="size-4 text-[color:var(--fg-muted)]" />}
         title={t('adminUi.title')}
         subtitle={t('adminUi.subtitle')}
       >
@@ -137,7 +137,7 @@ export function UiSurfacesEditor({
               heightPx={280}
             />
 
-            <p className="rounded-md border border-amber-200 bg-amber-50/40 px-3 py-2 text-[11px] text-amber-900">
+            <p className="rounded-md border border-[color:var(--warning)] bg-[color:var(--warning)]/10 px-3 py-2 text-[11px] text-[color:var(--warning)]">
               {t.rich('adminUi.operatorContract', {
                 strong: (chunks) => <strong>{chunks}</strong>,
                 code: (chunks) => <code>{chunks}</code>,
@@ -155,7 +155,7 @@ export function UiSurfacesEditor({
 
       {/* ─── Dashboard Pages Sub-Card ─── */}
       <SurfaceCard
-        icon={<LayoutDashboard className="size-4 text-slate-500" />}
+        icon={<LayoutDashboard className="size-4 text-[color:var(--fg-muted)]" />}
         title={t('dashboardPages.title')}
         subtitle={t('dashboardPages.subtitle')}
       >

--- a/web-ui/app/store/builder/[id]/_components/UiSurfacesTabPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/UiSurfacesTabPane.tsx
@@ -80,7 +80,7 @@ export function UiSurfacesTabPane({
 
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col">
-      <div className="flex-1 space-y-6 overflow-y-auto px-5 py-5">
+      <div className="flex-1 space-y-6 overflow-y-auto px-4 py-4">
         <header className="space-y-1">
           <h2 className="text-[14px] font-semibold text-[color:var(--fg-strong)]">
             {t('heading')}
@@ -121,7 +121,7 @@ function SaveBadge({ status }: { status: SaveStatus }): React.ReactElement | nul
         : t('error', { message: status.message });
   return (
     <div
-      className={`mx-5 mb-3 rounded-md border px-3 py-1.5 text-[11px] ${cls}`}
+      className={`mx-4 mb-3 rounded-md border px-3 py-2 text-[11px] ${cls}`}
     >
       {label}
     </div>

--- a/web-ui/app/store/builder/[id]/_components/UiSurfacesTabPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/UiSurfacesTabPane.tsx
@@ -109,10 +109,10 @@ function SaveBadge({ status }: { status: SaveStatus }): React.ReactElement | nul
   if (status.kind === 'idle') return null;
   const cls =
     status.kind === 'error'
-      ? 'bg-rose-50 text-rose-900 border-rose-200'
+      ? 'bg-[color:var(--danger)]/8 text-[color:var(--danger)] border-[color:var(--danger-edge)]'
       : status.kind === 'saved'
-        ? 'bg-emerald-50 text-emerald-900 border-emerald-200'
-        : 'bg-slate-50 text-slate-700 border-slate-200';
+        ? 'bg-[color:var(--success)]/10 text-[color:var(--success)] border-[color:var(--success)]'
+        : 'bg-[color:var(--bg-soft)] text-[color:var(--fg)] border-[color:var(--border)]';
   const label =
     status.kind === 'pending'
       ? t('saving')

--- a/web-ui/app/store/builder/[id]/_components/VersionsTab.tsx
+++ b/web-ui/app/store/builder/[id]/_components/VersionsTab.tsx
@@ -289,7 +289,7 @@ function StatusPills({ snapshot }: { snapshot: SnapshotSummary }): React.ReactEl
   return (
     <div className="flex flex-wrap gap-1">
       {snapshot.is_deploy_ready ? (
-        <span className="rounded-full border border-[var(--success)] bg-[color-mix(in_srgb,var(--success)_12%,transparent)] px-2 py-0.5 text-xs font-medium text-[var(--success)]">
+        <span className="text-xs font-medium text-[var(--success)]">
           deploy-ready
         </span>
       ) : null}

--- a/web-ui/app/store/builder/[id]/_components/VersionsTab.tsx
+++ b/web-ui/app/store/builder/[id]/_components/VersionsTab.tsx
@@ -94,19 +94,19 @@ export function VersionsTab({ draftId }: VersionsTabProps): React.ReactElement {
   );
 
   return (
-    <div className="flex h-full flex-col p-5 text-[var(--fg)]">
+    <div className="flex h-full flex-col p-4 text-[var(--fg)]">
       <div className="mb-4 flex items-center gap-2">
         <button
           type="button"
           onClick={() => setCaptureOpen(true)}
-          className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-sm font-medium text-[color:var(--fg-on-dark)] hover:opacity-90"
+          className="rounded-md bg-[var(--accent)] px-3 py-2 text-sm font-medium text-[color:var(--fg-on-dark)] hover:opacity-90"
         >
           {t('createSnapshot')}
         </button>
         <button
           type="button"
           onClick={() => void refresh()}
-          className="rounded-md border border-[var(--border)] px-3 py-1.5 text-sm hover:border-current"
+          className="rounded-md border border-[var(--border)] px-3 py-2 text-sm hover:border-current"
         >
           {t('refresh')}
         </button>
@@ -245,7 +245,7 @@ function SnapshotTable({
               </tr>
               <tr>
                 <td colSpan={5} className="px-3 pb-3 pt-1">
-                  <div className="flex flex-wrap items-center gap-1.5">
+                  <div className="flex flex-wrap items-center gap-2">
                     <SmallButton onClick={() => onDiff(s)}>
                       {t('diffVsLive')}
                     </SmallButton>
@@ -384,7 +384,7 @@ function CaptureModal({
         <button
           type="button"
           onClick={onClose}
-          className="rounded-md border border-[var(--border)] px-3 py-1.5 text-sm"
+          className="rounded-md border border-[var(--border)] px-3 py-2 text-sm"
         >
           {t('cancel')}
         </button>
@@ -392,7 +392,7 @@ function CaptureModal({
           type="button"
           onClick={() => void submit()}
           disabled={busy}
-          className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-sm font-medium text-[color:var(--fg-on-dark)] disabled:opacity-50"
+          className="rounded-md bg-[var(--accent)] px-3 py-2 text-sm font-medium text-[color:var(--fg-on-dark)] disabled:opacity-50"
         >
           {t('create')}
         </button>
@@ -574,7 +574,7 @@ function RollbackModal({
         <button
           type="button"
           onClick={onClose}
-          className="rounded-md border border-[var(--border)] px-3 py-1.5 text-sm"
+          className="rounded-md border border-[var(--border)] px-3 py-2 text-sm"
         >
           {t('cancel')}
         </button>
@@ -582,7 +582,7 @@ function RollbackModal({
           type="button"
           onClick={() => void submit()}
           disabled={!matches || busy}
-          className="rounded-md bg-[var(--danger)] px-3 py-1.5 text-sm font-medium text-[color:var(--fg-on-dark)] disabled:opacity-50"
+          className="rounded-md bg-[var(--danger)] px-3 py-2 text-sm font-medium text-[color:var(--fg-on-dark)] disabled:opacity-50"
         >
           {t('rollbackExecute')}
         </button>
@@ -615,7 +615,7 @@ function ModalShell({
       }}
     >
       <div
-        className={`max-h-[80vh] overflow-auto rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] p-5 text-[var(--fg)] shadow-xl ${
+        className={`max-h-[80vh] overflow-auto rounded-lg border border-[var(--border)] bg-[var(--bg-elevated)] p-4 text-[var(--fg)] shadow-xl ${
           wide ? 'w-full max-w-3xl' : 'w-full max-w-md'
         }`}
       >

--- a/web-ui/app/store/builder/[id]/_components/VersionsTab.tsx
+++ b/web-ui/app/store/builder/[id]/_components/VersionsTab.tsx
@@ -99,7 +99,7 @@ export function VersionsTab({ draftId }: VersionsTabProps): React.ReactElement {
         <button
           type="button"
           onClick={() => setCaptureOpen(true)}
-          className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
+          className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-sm font-medium text-[color:var(--fg-on-dark)] hover:opacity-90"
         >
           {t('createSnapshot')}
         </button>
@@ -175,7 +175,7 @@ export function VersionsTab({ draftId }: VersionsTabProps): React.ReactElement {
           role="status"
           className={`pointer-events-none fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-md px-4 py-2 text-sm ${
             toast.kind === 'error'
-              ? 'bg-[var(--danger)] text-white'
+              ? 'bg-[var(--danger)] text-[color:var(--fg-on-dark)]'
               : 'bg-[var(--fg)] text-[var(--bg)]'
           }`}
         >
@@ -392,7 +392,7 @@ function CaptureModal({
           type="button"
           onClick={() => void submit()}
           disabled={busy}
-          className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+          className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-sm font-medium text-[color:var(--fg-on-dark)] disabled:opacity-50"
         >
           {t('create')}
         </button>
@@ -582,7 +582,7 @@ function RollbackModal({
           type="button"
           onClick={() => void submit()}
           disabled={!matches || busy}
-          className="rounded-md bg-[var(--danger)] px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+          className="rounded-md bg-[var(--danger)] px-3 py-1.5 text-sm font-medium text-[color:var(--fg-on-dark)] disabled:opacity-50"
         >
           {t('rollbackExecute')}
         </button>
@@ -607,7 +607,7 @@ function ModalShell({
   const t = useTranslations('builder.versions');
   return (
     <div
-      className="fixed inset-0 z-40 flex items-center justify-center bg-black/55 p-6"
+      className="fixed inset-0 z-40 flex items-center justify-center bg-[color:var(--bg-modal-overlay)] p-6"
       role="dialog"
       aria-modal="true"
       onClick={(e) => {

--- a/web-ui/app/store/builder/[id]/_components/Workspace.tsx
+++ b/web-ui/app/store/builder/[id]/_components/Workspace.tsx
@@ -1245,7 +1245,7 @@ function MobilePaneTabs({
     <nav
       role="tablist"
       aria-label={tw('mobilePaneAriaLabel')}
-      className="mb-3 flex items-center gap-1.5 overflow-x-auto rounded-[12px] border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] p-1.5"
+      className="mb-3 flex items-center gap-1.5 overflow-x-auto rounded-lg border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] p-1.5"
     >
       {items.map((it) => {
         const isActive = it.id === active;
@@ -1261,7 +1261,7 @@ function MobilePaneTabs({
               'inline-flex flex-1 items-center justify-center gap-2 rounded-md px-3 py-2',
               'text-[12px] font-semibold uppercase tracking-[0.18em] transition-colors',
               isActive
-                ? 'bg-[color:var(--accent)] text-white shadow-[var(--shadow-cta)]'
+                ? 'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]'
                 : 'text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)] hover:text-[color:var(--fg-strong)]',
               w > 0 && !isActive && 'text-[color:var(--danger)]',
             )}
@@ -1273,8 +1273,8 @@ function MobilePaneTabs({
                 className={cn(
                   'font-mono-num inline-flex min-w-[1rem] items-center justify-center rounded-full px-1 text-[10px] font-semibold',
                   isActive
-                    ? 'bg-white/25 text-white'
-                    : 'bg-[color:var(--danger)] text-white',
+                    ? 'bg-white/25 text-[color:var(--fg-on-dark)]'
+                    : 'bg-[color:var(--danger)] text-[color:var(--fg-on-dark)]',
                 )}
                 aria-label={tw('mobilePaneMissingAria', { count: w })}
               >
@@ -1356,7 +1356,7 @@ function WorkspaceHeader({
   const modelEditingEnabled = draft.status !== 'archived';
   const tw = useTranslations('builder.workspace');
   return (
-    <header className="flex flex-col gap-4 rounded-[14px] border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] px-5 py-4 lg:flex-row lg:items-center">
+    <header className="flex flex-col gap-4 rounded-lg border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] px-5 py-4 lg:flex-row lg:items-center">
       <Link
         href="/store/builder"
         className="inline-flex items-center gap-2 self-start rounded-md px-2 py-1 text-[12px] font-semibold uppercase tracking-[0.18em] text-[color:var(--fg-muted)] transition-colors hover:bg-[color:var(--bg-soft)] hover:text-[color:var(--fg-strong)]"
@@ -1415,7 +1415,7 @@ function WorkspaceHeader({
         className={cn(
           'inline-flex items-center gap-2 rounded-md px-4 py-2 text-[12px] font-semibold uppercase tracking-[0.18em] transition-opacity',
           installEnabled
-            ? 'bg-[color:var(--accent)] text-white shadow-[var(--shadow-cta)] hover:opacity-90'
+            ? 'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] hover:opacity-90'
             : 'cursor-not-allowed bg-[color:var(--bg-soft)] text-[color:var(--fg-subtle)]',
         )}
       >
@@ -1487,7 +1487,7 @@ function ViewModeToggle({
             className={cn(
               'rounded-full px-3 py-1 text-[12px] font-semibold transition-colors',
               active
-                ? 'bg-[color:var(--accent)] text-white shadow-[var(--shadow-cta)]'
+                ? 'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]'
                 : 'text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]',
               disabled && !active && 'cursor-not-allowed',
             )}
@@ -1792,7 +1792,7 @@ function EditorTabs({
             className={cn(
               'inline-flex items-center gap-1 rounded-md px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] transition-colors',
               active
-                ? 'bg-[color:var(--accent)] text-white'
+                ? 'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)]'
                 : 'text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)] hover:text-[color:var(--fg-strong)]',
               warningCount > 0 &&
                 !active &&
@@ -1805,8 +1805,8 @@ function EditorTabs({
                 className={cn(
                   'font-mono-num inline-flex min-w-[1rem] items-center justify-center rounded-full px-1 text-[10px] font-semibold',
                   active
-                    ? 'bg-white/25 text-white'
-                    : 'bg-[color:var(--danger)] text-white',
+                    ? 'bg-white/25 text-[color:var(--fg-on-dark)]'
+                    : 'bg-[color:var(--danger)] text-[color:var(--fg-on-dark)]',
                 )}
                 aria-label={tw('editorTabMissingAria', { count: warningCount })}
               >
@@ -1916,7 +1916,7 @@ function BuildStatusStrip({
       {showErrorList ? (
         <div
           id="builder-tsc-error-list"
-          className="rounded-[14px] border border-[color:var(--danger)]/30 bg-[color:var(--bg-elevated)] px-5 py-3"
+          className="rounded-lg border border-[color:var(--danger)]/30 bg-[color:var(--bg-elevated)] px-5 py-3"
         >
           <div className="font-mono-num mb-2 flex items-center justify-between text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
             <span>
@@ -1952,7 +1952,7 @@ function BuildStatusStrip({
           </ul>
         </div>
       ) : null}
-      <footer className="flex items-center gap-3 rounded-[14px] border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] px-5 py-3 text-[11px]">
+      <footer className="flex items-center gap-3 rounded-lg border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] px-5 py-3 text-[11px]">
         <span className="font-mono-num inline-flex items-center gap-1.5 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
           <Activity className="size-3" aria-hidden />
           {tw('buildStatusLabel')}

--- a/web-ui/app/store/builder/[id]/_components/Workspace.tsx
+++ b/web-ui/app/store/builder/[id]/_components/Workspace.tsx
@@ -11,8 +11,7 @@ import {
   Activity,
   Rocket,
   Wrench,
-  Loader2,
-  AlertTriangle,
+    AlertTriangle,
   X,
   ChevronDown,
   ChevronUp,
@@ -1273,8 +1272,8 @@ function MobilePaneTabs({
                 className={cn(
                   'font-mono-num inline-flex min-w-[1rem] items-center justify-center rounded-full px-1 text-[10px] font-semibold',
                   isActive
-                    ? 'bg-white/25 text-[color:var(--fg-on-dark)]'
-                    : 'bg-[color:var(--danger)] text-[color:var(--fg-on-dark)]',
+                    ? 'text-[color:var(--accent-fg)]'
+                    : 'text-[color:var(--danger)]',
                 )}
                 aria-label={tw('mobilePaneMissingAria', { count: w })}
               >
@@ -1675,7 +1674,7 @@ function AutoFixIndicator({
   if (snap.phase === 'triggered') {
     return (
       <div className="inline-flex w-fit items-center gap-2 rounded-full border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/10 px-3 py-1.5 text-[12px] text-[color:var(--accent)]">
-        <Loader2 className="size-3.5 animate-spin" aria-hidden />
+        <span className="lume-busy-dots" aria-hidden />
         <span className="font-mono-num text-[11px]">
           {tw('autoFixRunning', { buildN: snap.buildN, kind: kindLabel })}
         </span>
@@ -1805,8 +1804,8 @@ function EditorTabs({
                 className={cn(
                   'font-mono-num inline-flex min-w-[1rem] items-center justify-center rounded-full px-1 text-[10px] font-semibold',
                   active
-                    ? 'bg-white/25 text-[color:var(--fg-on-dark)]'
-                    : 'bg-[color:var(--danger)] text-[color:var(--fg-on-dark)]',
+                    ? 'text-[color:var(--accent-fg)]'
+                    : 'text-[color:var(--danger)]',
                 )}
                 aria-label={tw('editorTabMissingAria', { count: warningCount })}
               >

--- a/web-ui/app/store/builder/[id]/_components/Workspace.tsx
+++ b/web-ui/app/store/builder/[id]/_components/Workspace.tsx
@@ -1244,7 +1244,7 @@ function MobilePaneTabs({
     <nav
       role="tablist"
       aria-label={tw('mobilePaneAriaLabel')}
-      className="mb-3 flex items-center gap-1.5 overflow-x-auto rounded-lg border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] p-1.5"
+      className="mb-3 flex items-center gap-2 overflow-x-auto rounded-lg border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] p-2"
     >
       {items.map((it) => {
         const isActive = it.id === active;
@@ -1355,7 +1355,7 @@ function WorkspaceHeader({
   const modelEditingEnabled = draft.status !== 'archived';
   const tw = useTranslations('builder.workspace');
   return (
-    <header className="flex flex-col gap-4 rounded-lg border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] px-5 py-4 lg:flex-row lg:items-center">
+    <header className="flex flex-col gap-4 rounded-lg border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] px-4 py-4 lg:flex-row lg:items-center">
       <Link
         href="/store/builder"
         className="inline-flex items-center gap-2 self-start rounded-md px-2 py-1 text-[12px] font-semibold uppercase tracking-[0.18em] text-[color:var(--fg-muted)] transition-colors hover:bg-[color:var(--bg-soft)] hover:text-[color:var(--fg-strong)]"
@@ -1374,7 +1374,7 @@ function WorkspaceHeader({
       {/* Technical controls — only in the Extended view. The Simplified
           view keeps the header calm: just the mode toggle and Publish. */}
       {viewMode === 'extended' ? (
-        <dl className="flex flex-wrap items-center gap-x-5 gap-y-1 text-[11px]">
+        <dl className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px]">
           <TemplateSwitcher
             templates={templates}
             current={currentTemplate}
@@ -1509,7 +1509,7 @@ function StatusBadge({ status }: { status: Draft['status'] }): React.ReactElemen
   return (
     <span
       className={cn(
-        'inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-[0.16em]',
+        'inline-flex items-center rounded-full px-3 py-0.5 text-[11px] font-semibold uppercase tracking-[0.16em]',
         palette[status],
       )}
     >
@@ -1544,7 +1544,7 @@ function ModelSelector({
   const tw = useTranslations('builder.workspace');
   if (!enabled) {
     return (
-      <div className="flex items-baseline gap-1.5">
+      <div className="flex items-baseline gap-2">
         <dt className="text-[10px] font-semibold uppercase tracking-[0.2em] text-[color:var(--fg-subtle)]">
           {label}
         </dt>
@@ -1555,7 +1555,7 @@ function ModelSelector({
     );
   }
   return (
-    <label className="flex items-baseline gap-1.5">
+    <label className="flex items-baseline gap-2">
       <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-[color:var(--fg-subtle)]">
         {label}
       </span>
@@ -1617,7 +1617,7 @@ function AutoFixToggle({
       onClick={() => {
         void onChange(!enabled);
       }}
-      className="flex items-center gap-1.5"
+      className="flex items-center gap-2"
     >
       <dt className="text-[10px] font-semibold uppercase tracking-[0.2em] text-[color:var(--fg-subtle)]">
         {tw('autoFixLabel')}
@@ -1673,7 +1673,7 @@ function AutoFixIndicator({
 
   if (snap.phase === 'triggered') {
     return (
-      <div className="inline-flex w-fit items-center gap-2 rounded-full border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/10 px-3 py-1.5 text-[12px] text-[color:var(--accent)]">
+      <div className="inline-flex w-fit items-center gap-2 rounded-full border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/10 px-3 py-2 text-[12px] text-[color:var(--accent)]">
         <span className="lume-busy-dots" aria-hidden />
         <span className="font-mono-num text-[11px]">
           {tw('autoFixRunning', { buildN: snap.buildN, kind: kindLabel })}
@@ -1734,7 +1734,7 @@ function TemplateSwitcher({
     ? tw('templateTooltipEnabled')
     : tw('templateTooltipDisabled');
   return (
-    <div className="flex items-baseline gap-1.5">
+    <div className="flex items-baseline gap-2">
       <dt className="text-[10px] font-semibold uppercase tracking-[0.2em] text-[color:var(--fg-subtle)]">
         {tw('templateLabel')}
       </dt>
@@ -1789,7 +1789,7 @@ function EditorTabs({
             aria-selected={active}
             onClick={() => onChange(t)}
             className={cn(
-              'inline-flex items-center gap-1 rounded-md px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] transition-colors',
+              'inline-flex items-center gap-1 rounded-md px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] transition-colors',
               active
                 ? 'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)]'
                 : 'text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)] hover:text-[color:var(--fg-strong)]',
@@ -1825,7 +1825,7 @@ function EditorTabs({
 
 function ChatMeta(): React.ReactElement {
   return (
-    <span className="font-mono-num inline-flex items-center gap-1.5 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
+    <span className="font-mono-num inline-flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
       <MessageSquare className="size-3" aria-hidden />
       NDJSON
     </span>
@@ -1838,7 +1838,7 @@ function PreviewMeta({
   model: BuilderModelId;
 }): React.ReactElement {
   return (
-    <span className="font-mono-num inline-flex items-center gap-1.5 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
+    <span className="font-mono-num inline-flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
       <Eye className="size-3" aria-hidden />
       {MODEL_LABEL[model]}
     </span>
@@ -1899,7 +1899,7 @@ function BuildStatusStrip({
   const showErrorList = canExpand && errorsExpanded;
 
   const buildPillClasses = cn(
-    'font-mono-num inline-flex items-center gap-1.5 text-[10px] uppercase tracking-[0.18em]',
+    'font-mono-num inline-flex items-center gap-2 text-[10px] uppercase tracking-[0.18em]',
     buildPalette[buildStatus.phase],
   );
 
@@ -1915,7 +1915,7 @@ function BuildStatusStrip({
       {showErrorList ? (
         <div
           id="builder-tsc-error-list"
-          className="rounded-lg border border-[color:var(--danger)]/30 bg-[color:var(--bg-elevated)] px-5 py-3"
+          className="rounded-lg border border-[color:var(--danger)]/30 bg-[color:var(--bg-elevated)] px-4 py-3"
         >
           <div className="font-mono-num mb-2 flex items-center justify-between text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
             <span>
@@ -1935,7 +1935,7 @@ function BuildStatusStrip({
               <X className="size-3" aria-hidden />
             </button>
           </div>
-          <ul className="font-mono-num max-h-[40vh] space-y-1.5 overflow-y-auto text-[11px] leading-relaxed text-[color:var(--fg-default)]">
+          <ul className="font-mono-num max-h-[40vh] space-y-2 overflow-y-auto text-[11px] leading-relaxed text-[color:var(--fg-default)]">
             {errors.map((e, i) => (
               <li
                 key={`${e.file}:${String(e.line)}:${String(e.column)}:${e.code}:${String(i)}`}
@@ -1951,8 +1951,8 @@ function BuildStatusStrip({
           </ul>
         </div>
       ) : null}
-      <footer className="flex items-center gap-3 rounded-lg border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] px-5 py-3 text-[11px]">
-        <span className="font-mono-num inline-flex items-center gap-1.5 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
+      <footer className="flex items-center gap-3 rounded-lg border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] px-4 py-3 text-[11px]">
+        <span className="font-mono-num inline-flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
           <Activity className="size-3" aria-hidden />
           {tw('buildStatusLabel')}
         </span>
@@ -1995,13 +1995,13 @@ function BuildStatusStrip({
           <button
             type="button"
             onClick={onFixWithBuilder}
-            className="inline-flex items-center gap-1.5 rounded-md border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/10 px-2 py-1 font-mono-num text-[10px] uppercase tracking-[0.18em] text-[color:var(--danger)] transition-colors hover:bg-[color:var(--danger)]/15"
+            className="inline-flex items-center gap-2 rounded-md border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/10 px-2 py-1 font-mono-num text-[10px] uppercase tracking-[0.18em] text-[color:var(--danger)] transition-colors hover:bg-[color:var(--danger)]/15"
           >
             <Wrench className="size-3" aria-hidden />
             {tw('fixWithBuilder')}
           </button>
         ) : null}
-        <span className="font-mono-num inline-flex items-center gap-1.5 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
+        <span className="font-mono-num inline-flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
           <span className={`inline-block size-1.5 rounded-full ${busColor}`} />
           {tw('buildSse', { status: busLabel })}
         </span>

--- a/web-ui/app/store/builder/[id]/page.tsx
+++ b/web-ui/app/store/builder/[id]/page.tsx
@@ -47,7 +47,7 @@ async function LoadErrorState({
   const t = await getTranslations('builder.drafts.detail');
   const message = error instanceof Error ? error.message : t('error.unknown');
   return (
-    <main className="mx-auto max-w-[1280px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[1280px] px-6 py-12 lg:px-8 lg:py-16">
       <div className="rounded-lg border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/6 p-8">
         <div className="flex items-baseline gap-3 text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--danger)]">
           <span>{t('error.label')}</span>
@@ -61,7 +61,7 @@ async function LoadErrorState({
         </p>
         <Link
           href="/store/builder"
-          className="mt-6 inline-flex items-center gap-2 rounded-full bg-[color:var(--accent)] px-5 py-2 text-[12px] font-semibold uppercase tracking-[0.18em] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]"
+          className="mt-6 inline-flex items-center gap-2 rounded-full bg-[color:var(--accent)] px-4 py-2 text-[12px] font-semibold uppercase tracking-[0.18em] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]"
         >
           ← {t('error.backToList')}
         </Link>

--- a/web-ui/app/store/builder/[id]/page.tsx
+++ b/web-ui/app/store/builder/[id]/page.tsx
@@ -48,7 +48,7 @@ async function LoadErrorState({
   const message = error instanceof Error ? error.message : t('error.unknown');
   return (
     <main className="mx-auto max-w-[1280px] px-6 py-12 lg:px-10 lg:py-16">
-      <div className="rounded-[14px] border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/6 p-8">
+      <div className="rounded-lg border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/6 p-8">
         <div className="flex items-baseline gap-3 text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--danger)]">
           <span>{t('error.label')}</span>
           <span className="h-px flex-1 bg-[color:var(--danger)]/30" />
@@ -61,7 +61,7 @@ async function LoadErrorState({
         </p>
         <Link
           href="/store/builder"
-          className="mt-6 inline-flex items-center gap-2 rounded-full bg-[color:var(--accent)] px-5 py-2 text-[12px] font-semibold uppercase tracking-[0.18em] text-white shadow-[var(--shadow-cta)]"
+          className="mt-6 inline-flex items-center gap-2 rounded-full bg-[color:var(--accent)] px-5 py-2 text-[12px] font-semibold uppercase tracking-[0.18em] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]"
         >
           ← {t('error.backToList')}
         </Link>

--- a/web-ui/app/store/builder/_components/CreateDraftButton.tsx
+++ b/web-ui/app/store/builder/_components/CreateDraftButton.tsx
@@ -57,7 +57,7 @@ export function CreateDraftButton({
         className={cn(
           'inline-flex items-center gap-2 rounded-full px-5 py-2 text-[13px] font-semibold',
           'shadow-[var(--shadow-cta)] transition-transform duration-[var(--dur-base)]',
-          'bg-[color:var(--accent)] text-white hover:-translate-y-0.5',
+          'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] hover:-translate-y-0.5',
           'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent)]',
           'disabled:translate-y-0 disabled:opacity-50 disabled:hover:translate-y-0',
         )}

--- a/web-ui/app/store/builder/_components/CreateDraftButton.tsx
+++ b/web-ui/app/store/builder/_components/CreateDraftButton.tsx
@@ -55,7 +55,7 @@ export function CreateDraftButton({
         onClick={onClick}
         disabled={disabled}
         className={cn(
-          'inline-flex items-center gap-2 rounded-full px-5 py-2 text-[13px] font-semibold',
+          'inline-flex items-center gap-2 rounded-full px-4 py-2 text-[13px] font-semibold',
           'shadow-[var(--shadow-cta)] transition-transform duration-[var(--dur-base)]',
           'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] hover:-translate-y-0.5',
           'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent)]',

--- a/web-ui/app/store/builder/_components/DraftRow.tsx
+++ b/web-ui/app/store/builder/_components/DraftRow.tsx
@@ -93,7 +93,7 @@ export function DraftRow({ draft, deleted = false }: DraftRowProps): React.React
   return (
     <div
       className={cn(
-        'group relative flex items-start gap-4 rounded-[14px] border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] p-5 transition-[box-shadow] duration-[var(--dur-base)]',
+        'group relative flex items-start gap-4 rounded-lg border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] p-5 transition-[box-shadow] duration-[var(--dur-base)]',
         'hover:shadow-[0_4px_14px_rgba(0,75,115,0.08)]',
         pending && 'opacity-60',
       )}
@@ -212,7 +212,7 @@ export function DraftRow({ draft, deleted = false }: DraftRowProps): React.React
             ) : null}
             <Link
               href={`/store/builder/${encodeURIComponent(draft.id)}`}
-              className="inline-flex items-center gap-1.5 rounded-md bg-[color:var(--accent)]/10 px-2.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--accent)] transition-colors hover:bg-[color:var(--accent)] hover:text-white"
+              className="inline-flex items-center gap-1.5 rounded-md bg-[color:var(--accent)]/10 px-2.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--accent)] transition-colors hover:bg-[color:var(--accent)] hover:text-[color:var(--fg-on-dark)]"
             >
               {t('workspace')}
               <ArrowRight className="size-3.5" aria-hidden />

--- a/web-ui/app/store/builder/_components/DraftRow.tsx
+++ b/web-ui/app/store/builder/_components/DraftRow.tsx
@@ -93,7 +93,7 @@ export function DraftRow({ draft, deleted = false }: DraftRowProps): React.React
   return (
     <div
       className={cn(
-        'group relative flex items-start gap-4 rounded-lg border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] p-5 transition-[box-shadow] duration-[var(--dur-base)]',
+        'group relative flex items-start gap-4 rounded-lg border border-[color:var(--divider)] bg-[color:var(--bg-elevated)] p-4 transition-[box-shadow] duration-[var(--dur-base)]',
         'hover:shadow-[0_4px_14px_rgba(0,75,115,0.08)]',
         pending && 'opacity-60',
       )}
@@ -124,7 +124,7 @@ export function DraftRow({ draft, deleted = false }: DraftRowProps): React.React
             <button
               type="submit"
               aria-label={t('save')}
-              className="rounded-md p-1.5 text-[color:var(--accent)] hover:bg-[color:var(--bg-soft)]"
+              className="rounded-md p-2 text-[color:var(--accent)] hover:bg-[color:var(--bg-soft)]"
               disabled={pending}
             >
               <Check className="size-4" aria-hidden />
@@ -136,7 +136,7 @@ export function DraftRow({ draft, deleted = false }: DraftRowProps): React.React
                 setEditing(false);
                 setName(draft.name);
               }}
-              className="rounded-md p-1.5 text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)]"
+              className="rounded-md p-2 text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)]"
               disabled={pending}
             >
               <X className="size-4" aria-hidden />
@@ -200,7 +200,7 @@ export function DraftRow({ draft, deleted = false }: DraftRowProps): React.React
             type="button"
             onClick={onRestore}
             disabled={pending}
-            className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-semibold text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)] hover:text-[color:var(--fg-strong)] disabled:opacity-50"
+            className="inline-flex items-center gap-2 rounded-md px-3 py-2 text-[11px] font-semibold text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-soft)] hover:text-[color:var(--fg-strong)] disabled:opacity-50"
           >
             <Undo2 className="size-3.5" aria-hidden />
             {t('restore')}
@@ -212,7 +212,7 @@ export function DraftRow({ draft, deleted = false }: DraftRowProps): React.React
             ) : null}
             <Link
               href={`/store/builder/${encodeURIComponent(draft.id)}`}
-              className="inline-flex items-center gap-1.5 rounded-md bg-[color:var(--accent)]/10 px-2.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--accent)] transition-colors hover:bg-[color:var(--accent)] hover:text-[color:var(--fg-on-dark)]"
+              className="inline-flex items-center gap-2 rounded-md bg-[color:var(--accent)]/10 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--accent)] transition-colors hover:bg-[color:var(--accent)] hover:text-[color:var(--fg-on-dark)]"
             >
               {t('workspace')}
               <ArrowRight className="size-3.5" aria-hidden />
@@ -222,7 +222,7 @@ export function DraftRow({ draft, deleted = false }: DraftRowProps): React.React
               onClick={onDelete}
               disabled={pending}
               aria-label={t('delete')}
-              className="rounded-md p-1.5 text-[color:var(--fg-muted)] hover:bg-[color:var(--danger)]/10 hover:text-[color:var(--danger)] disabled:opacity-50"
+              className="rounded-md p-2 text-[color:var(--fg-muted)] hover:bg-[color:var(--danger)]/10 hover:text-[color:var(--danger)] disabled:opacity-50"
             >
               <Trash2 className="size-4" aria-hidden />
             </button>

--- a/web-ui/app/store/builder/_components/ExportDraftButton.tsx
+++ b/web-ui/app/store/builder/_components/ExportDraftButton.tsx
@@ -75,7 +75,7 @@ export function ExportDraftButton({
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={t('label')}
-        className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--fg-muted)] transition-colors hover:bg-[color:var(--bg-soft)] hover:text-[color:var(--fg-strong)] disabled:opacity-50"
+        className="inline-flex items-center gap-2 rounded-md px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--fg-muted)] transition-colors hover:bg-[color:var(--bg-soft)] hover:text-[color:var(--fg-strong)] disabled:opacity-50"
       >
         {busy ? (
           <span className="lume-busy-dots" aria-hidden />

--- a/web-ui/app/store/builder/_components/ExportDraftButton.tsx
+++ b/web-ui/app/store/builder/_components/ExportDraftButton.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { ChevronDown, Download, Loader2 } from 'lucide-react';
+import { ChevronDown, Download } from 'lucide-react';
 
 import { ApiError, captureSnapshot, snapshotDownloadUrl } from '../../../_lib/api';
 import { cn } from '../../../_lib/cn';
@@ -78,7 +78,7 @@ export function ExportDraftButton({
         className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--fg-muted)] transition-colors hover:bg-[color:var(--bg-soft)] hover:text-[color:var(--fg-strong)] disabled:opacity-50"
       >
         {busy ? (
-          <Loader2 className="size-3.5 animate-spin" aria-hidden />
+          <span className="lume-busy-dots" aria-hidden />
         ) : (
           <Download className="size-3.5" aria-hidden />
         )}

--- a/web-ui/app/store/builder/_components/ImportBundleButton.tsx
+++ b/web-ui/app/store/builder/_components/ImportBundleButton.tsx
@@ -129,7 +129,7 @@ function ImportBundleModal({
 
   return (
     <div
-      className="fixed inset-0 z-40 flex items-center justify-center bg-black/55 p-6"
+      className="fixed inset-0 z-40 flex items-center justify-center bg-[color:var(--bg-modal-overlay)] p-6"
       role="dialog"
       aria-modal="true"
       onClick={(e) => {
@@ -246,7 +246,7 @@ function ImportBundleModal({
             onClick={() => void onSubmit()}
             disabled={!file || busy}
             className={cn(
-              'rounded-md bg-[color:var(--accent)] px-3 py-1.5 text-sm font-medium text-white',
+              'rounded-md bg-[color:var(--accent)] px-3 py-1.5 text-sm font-medium text-[color:var(--fg-on-dark)]',
               'shadow-[var(--shadow-cta)] disabled:opacity-50',
             )}
           >

--- a/web-ui/app/store/builder/_components/ImportBundleButton.tsx
+++ b/web-ui/app/store/builder/_components/ImportBundleButton.tsx
@@ -136,7 +136,7 @@ function ImportBundleModal({
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="w-full max-w-md rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-5 text-[color:var(--fg)] shadow-xl">
+      <div className="w-full max-w-md rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-4 text-[color:var(--fg)] shadow-xl">
         <div className="mb-3 flex items-center justify-between">
           <h2 className="text-base font-semibold text-[color:var(--fg-strong)]">
             {t('modal.title')}
@@ -237,7 +237,7 @@ function ImportBundleModal({
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md border border-[color:var(--border)] px-3 py-1.5 text-sm text-[color:var(--fg)]"
+            className="rounded-md border border-[color:var(--border)] px-3 py-2 text-sm text-[color:var(--fg)]"
           >
             {t('modal.cancel')}
           </button>
@@ -246,7 +246,7 @@ function ImportBundleModal({
             onClick={() => void onSubmit()}
             disabled={!file || busy}
             className={cn(
-              'rounded-md bg-[color:var(--accent)] px-3 py-1.5 text-sm font-medium text-[color:var(--fg-on-dark)]',
+              'rounded-md bg-[color:var(--accent)] px-3 py-2 text-sm font-medium text-[color:var(--fg-on-dark)]',
               'shadow-[var(--shadow-cta)] disabled:opacity-50',
             )}
           >

--- a/web-ui/app/store/builder/page.tsx
+++ b/web-ui/app/store/builder/page.tsx
@@ -83,8 +83,8 @@ export default async function BuilderDashboardPage({
   const counts = countByScope(activeItems, deletedItems);
 
   return (
-    <main className="mx-auto max-w-[1280px] px-6 py-12 lg:px-10 lg:py-16">
-      <header className="b5-hero-bg relative -mx-6 rounded-lg border border-[color:var(--divider)] px-6 py-10 lg:-mx-10 lg:px-10 lg:py-14">
+    <main className="mx-auto max-w-[1280px] px-6 py-12 lg:px-8 lg:py-16">
+      <header className="b5-hero-bg relative -mx-6 rounded-lg border border-[color:var(--divider)] px-6 py-8 lg:-mx-8 lg:px-8 lg:py-12">
         <div className="flex items-baseline gap-3 text-[12px] font-semibold uppercase tracking-[0.24em] text-[color:var(--accent)]">
           <span className="font-mono-num text-[color:var(--fg-subtle)]">02</span>
           <span className="h-px flex-1 bg-[color:var(--border)]" />
@@ -110,7 +110,7 @@ export default async function BuilderDashboardPage({
           </div>
         </div>
 
-        <dl className="mt-10 grid max-w-2xl grid-cols-4 gap-6 border-t border-[color:var(--divider)] pt-5 text-sm">
+        <dl className="mt-8 grid max-w-2xl grid-cols-4 gap-6 border-t border-[color:var(--divider)] pt-4 text-sm">
           <Stat label={t('stats.drafts')} value={counts.draft} />
           <Stat label={t('stats.published')} value={counts.published} />
           <Stat label={t('stats.deleted')} value={counts.deleted} />
@@ -119,7 +119,7 @@ export default async function BuilderDashboardPage({
       </header>
 
       <nav
-        className="mt-10 flex flex-wrap items-center gap-2"
+        className="mt-8 flex flex-wrap items-center gap-2"
         aria-label={t('scopeFilterLabel')}
       >
         {(['draft', 'published', 'deleted'] as ScopeFilter[]).map((s) => {
@@ -130,7 +130,7 @@ export default async function BuilderDashboardPage({
               key={s}
               href={s === 'draft' ? '/store/builder' : `/store/builder?scope=${s}`}
               className={cn(
-                'inline-flex items-center gap-2 rounded-full px-4 py-1.5',
+                'inline-flex items-center gap-2 rounded-full px-4 py-2',
                 'text-[12px] font-semibold transition-colors duration-[140ms]',
                 'ease-[cubic-bezier(0.22,0.61,0.36,1)]',
                 active
@@ -142,7 +142,7 @@ export default async function BuilderDashboardPage({
               <span>{scopeLabel[s]}</span>
               <span
                 className={cn(
-                  'font-mono-num tabular-nums rounded-full px-1.5 text-[10px]',
+                  'font-mono-num tabular-nums rounded-full px-2 text-[10px]',
                   active
                     ? 'text-[color:var(--accent-fg)]'
                     : 'bg-[color:var(--bg)] text-[color:var(--fg-subtle)]',
@@ -173,7 +173,7 @@ export default async function BuilderDashboardPage({
         )}
       </section>
 
-      <footer className="mt-20 flex items-center justify-between border-t border-[color:var(--divider)] pt-5 text-[11px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
+      <footer className="mt-20 flex items-center justify-between border-t border-[color:var(--divider)] pt-4 text-[11px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
         <span>
           {t('footer.phaseLabel')}{' '}
           <span className="font-mono-num normal-case tracking-normal text-[color:var(--fg-muted)]">

--- a/web-ui/app/store/builder/page.tsx
+++ b/web-ui/app/store/builder/page.tsx
@@ -144,7 +144,7 @@ export default async function BuilderDashboardPage({
                 className={cn(
                   'font-mono-num tabular-nums rounded-full px-1.5 text-[10px]',
                   active
-                    ? 'bg-white/25 text-[color:var(--fg-on-dark)]'
+                    ? 'text-[color:var(--accent-fg)]'
                     : 'bg-[color:var(--bg)] text-[color:var(--fg-subtle)]',
                 )}
               >

--- a/web-ui/app/store/builder/page.tsx
+++ b/web-ui/app/store/builder/page.tsx
@@ -84,7 +84,7 @@ export default async function BuilderDashboardPage({
 
   return (
     <main className="mx-auto max-w-[1280px] px-6 py-12 lg:px-10 lg:py-16">
-      <header className="b5-hero-bg relative -mx-6 rounded-[22px] border border-[color:var(--divider)] px-6 py-10 lg:-mx-10 lg:px-10 lg:py-14">
+      <header className="b5-hero-bg relative -mx-6 rounded-lg border border-[color:var(--divider)] px-6 py-10 lg:-mx-10 lg:px-10 lg:py-14">
         <div className="flex items-baseline gap-3 text-[12px] font-semibold uppercase tracking-[0.24em] text-[color:var(--accent)]">
           <span className="font-mono-num text-[color:var(--fg-subtle)]">02</span>
           <span className="h-px flex-1 bg-[color:var(--border)]" />
@@ -97,8 +97,7 @@ export default async function BuilderDashboardPage({
               {t('headline')}
             </h1>
             <p className="mt-6 text-[18px] font-semibold leading-[1.55] text-[color:var(--fg)]">
-              <span className="b5-colon">:</span>
-              {t('lede')}
+                            {t('lede')}
             </p>
           </div>
 
@@ -135,7 +134,7 @@ export default async function BuilderDashboardPage({
                 'text-[12px] font-semibold transition-colors duration-[140ms]',
                 'ease-[cubic-bezier(0.22,0.61,0.36,1)]',
                 active
-                  ? 'bg-[color:var(--accent)] text-white shadow-[var(--shadow-cta)]'
+                  ? 'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]'
                   : 'bg-[color:var(--bg-soft)] text-[color:var(--fg-muted)] hover:bg-[color:var(--gray-100)] hover:text-[color:var(--fg-strong)]',
               )}
               aria-current={active ? 'page' : undefined}
@@ -145,7 +144,7 @@ export default async function BuilderDashboardPage({
                 className={cn(
                   'font-mono-num tabular-nums rounded-full px-1.5 text-[10px]',
                   active
-                    ? 'bg-white/25 text-white'
+                    ? 'bg-white/25 text-[color:var(--fg-on-dark)]'
                     : 'bg-[color:var(--bg)] text-[color:var(--fg-subtle)]',
                 )}
               >
@@ -223,7 +222,7 @@ async function EmptyState({ scope }: { scope: ScopeFilter }): Promise<React.Reac
         ? t('empty.published.hint')
         : t('empty.deleted.hint');
   return (
-    <div className="rounded-[14px] border border-dashed border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-12 text-center">
+    <div className="rounded-lg border border-dashed border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-12 text-center">
       <p className="font-display text-[22px] text-[color:var(--fg-strong)]">{headline}</p>
       <p className="mt-3 text-sm leading-relaxed text-[color:var(--fg-muted)]">{hint}</p>
     </div>
@@ -233,7 +232,7 @@ async function EmptyState({ scope }: { scope: ScopeFilter }): Promise<React.Reac
 async function LoadErrorState({ message }: { message: string }): Promise<React.ReactElement> {
   const t = await getTranslations('builder.drafts.list');
   return (
-    <div className="rounded-[14px] border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/6 p-8">
+    <div className="rounded-lg border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/6 p-8">
       <div className="flex items-baseline gap-3 text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--danger)]">
         <span>{t('error.label')}</span>
         <span className="h-px flex-1 bg-[color:var(--danger)]/30" />

--- a/web-ui/app/store/page.tsx
+++ b/web-ui/app/store/page.tsx
@@ -97,11 +97,11 @@ export default async function StorePage({
     filter === 'all' ? scoped : scoped.filter((p) => p.kind === filter);
 
   return (
-    <main className="mx-auto max-w-[1280px] px-6 py-12 lg:px-10 lg:py-16">
+    <main className="mx-auto max-w-[1280px] px-6 py-12 lg:px-8 lg:py-16">
       <OnboardingModal installedCount={installedCount} profiles={profiles} />
 
       {/* Hero — Omadia brand cadence (Days One headline + magenta colon lead) */}
-      <header className="b5-hero-bg relative -mx-6 rounded-lg border border-[color:var(--divider)] px-6 py-10 lg:-mx-10 lg:px-10 lg:py-14">
+      <header className="b5-hero-bg relative -mx-6 rounded-lg border border-[color:var(--divider)] px-6 py-8 lg:-mx-8 lg:px-8 lg:py-12">
         <div className="flex items-baseline gap-3 text-[12px] font-semibold uppercase tracking-[0.24em] text-[color:var(--accent)]">
           <span className="font-mono-num text-[color:var(--fg-subtle)]">
             01
@@ -122,7 +122,7 @@ export default async function StorePage({
         </p>
 
         {/* Stats strip — installed vs. hub split + total */}
-        <dl className="mt-10 grid max-w-2xl grid-cols-4 gap-6 border-t border-[color:var(--divider)] pt-5 text-sm">
+        <dl className="mt-8 grid max-w-2xl grid-cols-4 gap-6 border-t border-[color:var(--divider)] pt-4 text-sm">
           <Stat label="Plugins" value={plugins.length} />
           <Stat label="Hub" value={hubCount} accent />
           <Stat label="Lokal" value={localCount} />
@@ -161,7 +161,7 @@ export default async function StorePage({
                 key={f}
                 href={buildHref(source, f)}
                 className={cn(
-                  'inline-flex items-center gap-2 rounded-full px-4 py-1.5',
+                  'inline-flex items-center gap-2 rounded-full px-4 py-2',
                   'text-[12px] font-semibold transition-colors duration-[140ms]',
                   'ease-[cubic-bezier(0.22,0.61,0.36,1)]',
                   active
@@ -173,7 +173,7 @@ export default async function StorePage({
                 <span>{FILTER_LABEL[f]}</span>
                 <span
                   className={cn(
-                    'font-mono-num tabular-nums rounded-full px-1.5 text-[10px]',
+                    'font-mono-num tabular-nums rounded-full px-2 text-[10px]',
                     active
                       ? 'text-[color:var(--accent-fg)]'
                       : 'bg-[color:var(--bg)] text-[color:var(--fg-subtle)]',
@@ -194,7 +194,7 @@ export default async function StorePage({
         ) : visible.length === 0 ? (
           <EmptyState source={source} filter={filter} />
         ) : (
-          <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
             {visible.map((plugin) => (
               <PluginCard key={plugin.id} plugin={plugin} />
             ))}
@@ -203,7 +203,7 @@ export default async function StorePage({
       </section>
 
       {/* Footer note */}
-      <footer className="mt-20 flex items-center justify-between border-t border-[color:var(--divider)] pt-5 text-[11px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
+      <footer className="mt-20 flex items-center justify-between border-t border-[color:var(--divider)] pt-4 text-[11px] uppercase tracking-[0.18em] text-[color:var(--fg-subtle)]">
         <span>
           Quelle:{' '}
           <span className="font-mono-num normal-case tracking-normal text-[color:var(--fg-muted)]">
@@ -300,7 +300,7 @@ function SourceTabs({
             href={buildHref(tab.key, 'all')}
             aria-current={active ? 'page' : undefined}
             className={cn(
-              'inline-flex items-center gap-2 rounded-full px-5 py-2',
+              'inline-flex items-center gap-2 rounded-full px-4 py-2',
               'text-[13px] font-semibold transition-colors duration-[140ms]',
               'ease-[cubic-bezier(0.22,0.61,0.36,1)]',
               active
@@ -312,7 +312,7 @@ function SourceTabs({
             <span>{tab.label}</span>
             <span
               className={cn(
-                'font-mono-num tabular-nums rounded-full px-1.5 text-[10px]',
+                'font-mono-num tabular-nums rounded-full px-2 text-[10px]',
                 active
                   ? 'text-[color:var(--accent-fg)]'
                   : 'bg-[color:var(--bg)] text-[color:var(--fg-subtle)]',

--- a/web-ui/app/store/page.tsx
+++ b/web-ui/app/store/page.tsx
@@ -101,7 +101,7 @@ export default async function StorePage({
       <OnboardingModal installedCount={installedCount} profiles={profiles} />
 
       {/* Hero — Omadia brand cadence (Days One headline + magenta colon lead) */}
-      <header className="b5-hero-bg relative -mx-6 rounded-[22px] border border-[color:var(--divider)] px-6 py-10 lg:-mx-10 lg:px-10 lg:py-14">
+      <header className="b5-hero-bg relative -mx-6 rounded-lg border border-[color:var(--divider)] px-6 py-10 lg:-mx-10 lg:px-10 lg:py-14">
         <div className="flex items-baseline gap-3 text-[12px] font-semibold uppercase tracking-[0.24em] text-[color:var(--accent)]">
           <span className="font-mono-num text-[color:var(--fg-subtle)]">
             01
@@ -115,8 +115,7 @@ export default async function StorePage({
         </h1>
 
         <p className="mt-6 max-w-2xl text-[18px] font-semibold leading-[1.55] text-[color:var(--fg)]">
-          <span className="b5-colon">:</span>
-          Der Katalog bündelt Integrations (Credential-Container), Agents
+                    Der Katalog bündelt Integrations (Credential-Container), Agents
           (Domain-Capabilities) und Channels (User-Kanäle wie Teams,
           Telegram). Ein Klick auf eine Kachel zeigt Berechtigungen, Secrets
           und Abhängigkeiten vor der Installation.
@@ -166,7 +165,7 @@ export default async function StorePage({
                   'text-[12px] font-semibold transition-colors duration-[140ms]',
                   'ease-[cubic-bezier(0.22,0.61,0.36,1)]',
                   active
-                    ? 'bg-[color:var(--accent)] text-white shadow-[var(--shadow-cta)]'
+                    ? 'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]'
                     : 'bg-[color:var(--bg-soft)] text-[color:var(--fg-muted)] hover:bg-[color:var(--gray-100)] hover:text-[color:var(--fg-strong)]',
                 )}
                 aria-current={active ? 'page' : undefined}
@@ -176,7 +175,7 @@ export default async function StorePage({
                   className={cn(
                     'font-mono-num tabular-nums rounded-full px-1.5 text-[10px]',
                     active
-                      ? 'bg-white/25 text-white'
+                      ? 'bg-white/25 text-[color:var(--fg-on-dark)]'
                       : 'bg-[color:var(--bg)] text-[color:var(--fg-subtle)]',
                   )}
                 >
@@ -305,7 +304,7 @@ function SourceTabs({
               'text-[13px] font-semibold transition-colors duration-[140ms]',
               'ease-[cubic-bezier(0.22,0.61,0.36,1)]',
               active
-                ? 'bg-[color:var(--accent)] text-white shadow-[var(--shadow-cta)]'
+                ? 'bg-[color:var(--accent)] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)]'
                 : 'text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]',
             )}
           >
@@ -315,7 +314,7 @@ function SourceTabs({
               className={cn(
                 'font-mono-num tabular-nums rounded-full px-1.5 text-[10px]',
                 active
-                  ? 'bg-white/25 text-white'
+                  ? 'bg-white/25 text-[color:var(--fg-on-dark)]'
                   : 'bg-[color:var(--bg)] text-[color:var(--fg-subtle)]',
               )}
             >
@@ -338,7 +337,7 @@ function EmptyState({
   // Kind-filtered-into-emptiness inside a non-empty source: keep it short.
   if (filter !== 'all') {
     return (
-      <div className="rounded-[14px] border border-dashed border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-12 text-center">
+      <div className="rounded-lg border border-dashed border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-12 text-center">
         <p className="font-display text-[22px] text-[color:var(--fg-strong)]">
           Keine {FILTER_LABEL[filter]} in dieser Ansicht.
         </p>
@@ -351,7 +350,7 @@ function EmptyState({
 
   if (source === 'installed') {
     return (
-      <div className="rounded-[14px] border border-dashed border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-12 text-center">
+      <div className="rounded-lg border border-dashed border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-12 text-center">
         <p className="font-display text-[22px] text-[color:var(--fg-strong)]">
           Noch keine Plugins installiert.
         </p>
@@ -378,7 +377,7 @@ function EmptyState({
 
   if (source === 'local') {
     return (
-      <div className="rounded-[14px] border border-dashed border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-12 text-center">
+      <div className="rounded-lg border border-dashed border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-12 text-center">
         <p className="font-display text-[22px] text-[color:var(--fg-strong)]">
           Keine lokalen Pakete.
         </p>
@@ -394,7 +393,7 @@ function EmptyState({
   // (not-yet-local) plugin. Either no registry is reachable, or every hub
   // entry is already installed locally (the merge drops those).
   return (
-    <div className="rounded-[14px] border border-dashed border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-12 text-center">
+    <div className="rounded-lg border border-dashed border-[color:var(--border-strong)] bg-[color:var(--bg-soft)] p-12 text-center">
       <p className="font-display text-[22px] text-[color:var(--fg-strong)]">
         Keine Plugins im Hub verfügbar.
       </p>
@@ -421,7 +420,7 @@ function EmptyState({
 
 function LoadErrorState({ message }: { message: string }): React.ReactElement {
   return (
-    <div className="rounded-[14px] border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/6 p-8">
+    <div className="rounded-lg border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/6 p-8">
       <div className="flex items-baseline gap-3 text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--danger)]">
         <span>Fehler</span>
         <span className="h-px flex-1 bg-[color:var(--danger)]/30" />

--- a/web-ui/app/store/page.tsx
+++ b/web-ui/app/store/page.tsx
@@ -175,7 +175,7 @@ export default async function StorePage({
                   className={cn(
                     'font-mono-num tabular-nums rounded-full px-1.5 text-[10px]',
                     active
-                      ? 'bg-white/25 text-[color:var(--fg-on-dark)]'
+                      ? 'text-[color:var(--accent-fg)]'
                       : 'bg-[color:var(--bg)] text-[color:var(--fg-subtle)]',
                   )}
                 >
@@ -314,7 +314,7 @@ function SourceTabs({
               className={cn(
                 'font-mono-num tabular-nums rounded-full px-1.5 text-[10px]',
                 active
-                  ? 'bg-white/25 text-[color:var(--fg-on-dark)]'
+                  ? 'text-[color:var(--accent-fg)]'
                   : 'bg-[color:var(--bg)] text-[color:var(--fg-subtle)]',
               )}
             >

--- a/web-ui/app/system/_components/VaultStatusCard.tsx
+++ b/web-ui/app/system/_components/VaultStatusCard.tsx
@@ -17,7 +17,7 @@ export function VaultStatusCard({ status }: Props): React.ReactElement {
     : 'muted';
 
   return (
-    <article className="rounded-[22px] border border-[color:var(--divider)] bg-[color:var(--surface)] p-6 shadow-sm">
+    <article className="rounded-lg border border-[color:var(--divider)] bg-[color:var(--surface)] p-6 shadow-sm">
       <header className="flex items-baseline justify-between gap-3">
         <div>
           <div className="text-[11px] uppercase tracking-[0.22em] text-[color:var(--fg-subtle)]">
@@ -143,12 +143,12 @@ function Row({ label, value, mono, tone = 'muted' }: RowProps): React.ReactEleme
 function StatusDot({ tone }: { tone: Tone }): React.ReactElement {
   const color =
     tone === 'ok'
-      ? 'bg-emerald-500'
+      ? 'bg-[color:var(--success)]/100'
       : tone === 'warn'
-        ? 'bg-amber-500'
+        ? 'bg-[color:var(--warning)]/100'
         : tone === 'danger'
-          ? 'bg-rose-500'
-          : 'bg-slate-400';
+          ? 'bg-[color:var(--danger)]/80'
+          : 'bg-[color:var(--fg-subtle)]';
   return (
     <span className="inline-flex items-center gap-2 text-[11px] uppercase tracking-[0.22em] text-[color:var(--fg-subtle)]">
       <span className={`h-2 w-2 rounded-full ${color}`} />
@@ -168,9 +168,9 @@ function toneClass(tone: Tone): string {
     case 'ok':
       return 'text-[color:var(--fg-strong)]';
     case 'warn':
-      return 'text-amber-600';
+      return 'text-[color:var(--warning)]';
     case 'danger':
-      return 'text-rose-600';
+      return 'text-[color:var(--danger)]';
     default:
       return 'text-[color:var(--fg-strong)]';
   }

--- a/web-ui/app/system/page.tsx
+++ b/web-ui/app/system/page.tsx
@@ -24,8 +24,8 @@ export default async function SystemPage(): Promise<React.ReactElement> {
   }
 
   return (
-    <main className="mx-auto max-w-[1280px] px-6 py-12 lg:px-10 lg:py-16">
-      <header className="b5-hero-bg relative -mx-6 rounded-lg border border-[color:var(--divider)] px-6 py-10 lg:-mx-10 lg:px-10 lg:py-14">
+    <main className="mx-auto max-w-[1280px] px-6 py-12 lg:px-8 lg:py-16">
+      <header className="b5-hero-bg relative -mx-6 rounded-lg border border-[color:var(--divider)] px-6 py-8 lg:-mx-8 lg:px-8 lg:py-12">
         <div className="flex items-baseline gap-3 text-[12px] font-semibold uppercase tracking-[0.24em] text-[color:var(--accent)]">
           <span className="font-mono-num text-[color:var(--fg-subtle)]">
             03
@@ -44,7 +44,7 @@ export default async function SystemPage(): Promise<React.ReactElement> {
         </p>
       </header>
 
-      <section className="mt-10 grid gap-6 lg:grid-cols-2">
+      <section className="mt-8 grid gap-6 lg:grid-cols-2">
         {loadError ? (
           <div className="rounded-lg border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/5 p-6 text-sm text-[color:var(--danger)]">
             <div className="font-semibold">Vault-Status nicht erreichbar</div>

--- a/web-ui/app/system/page.tsx
+++ b/web-ui/app/system/page.tsx
@@ -25,7 +25,7 @@ export default async function SystemPage(): Promise<React.ReactElement> {
 
   return (
     <main className="mx-auto max-w-[1280px] px-6 py-12 lg:px-10 lg:py-16">
-      <header className="b5-hero-bg relative -mx-6 rounded-[22px] border border-[color:var(--divider)] px-6 py-10 lg:-mx-10 lg:px-10 lg:py-14">
+      <header className="b5-hero-bg relative -mx-6 rounded-lg border border-[color:var(--divider)] px-6 py-10 lg:-mx-10 lg:px-10 lg:py-14">
         <div className="flex items-baseline gap-3 text-[12px] font-semibold uppercase tracking-[0.24em] text-[color:var(--accent)]">
           <span className="font-mono-num text-[color:var(--fg-subtle)]">
             03
@@ -46,7 +46,7 @@ export default async function SystemPage(): Promise<React.ReactElement> {
 
       <section className="mt-10 grid gap-6 lg:grid-cols-2">
         {loadError ? (
-          <div className="rounded-[18px] border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/5 p-6 text-sm text-[color:var(--danger)]">
+          <div className="rounded-lg border border-[color:var(--danger)]/40 bg-[color:var(--danger)]/5 p-6 text-sm text-[color:var(--danger)]">
             <div className="font-semibold">Vault-Status nicht erreichbar</div>
             <div className="mt-2 font-mono text-xs">{loadError}</div>
           </div>

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -151,6 +151,20 @@
   "localeSwitcher": {
     "ariaLabel": "Sprache wechseln"
   },
+  "themeControls": {
+    "paletteAriaLabel": "Akzent-Palette",
+    "appearanceAriaLabel": "Darstellung",
+    "palette": {
+      "lagoon": "Lagoon",
+      "petrol": "Petrol",
+      "atelier": "Atelier"
+    },
+    "appearance": {
+      "system": "System",
+      "light": "Hell",
+      "dark": "Dunkel"
+    }
+  },
   "login": {
     "title": "Bei Omadia anmelden",
     "shellLoading": "Lade Login…",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -151,6 +151,20 @@
   "localeSwitcher": {
     "ariaLabel": "Switch language"
   },
+  "themeControls": {
+    "paletteAriaLabel": "Accent palette",
+    "appearanceAriaLabel": "Appearance",
+    "palette": {
+      "lagoon": "Lagoon",
+      "petrol": "Petrol",
+      "atelier": "Atelier"
+    },
+    "appearance": {
+      "system": "System",
+      "light": "Light",
+      "dark": "Dark"
+    }
+  },
   "login": {
     "title": "Sign in to Omadia",
     "shellLoading": "Loading login…",

--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -682,9 +682,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -696,13 +696,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -714,13 +714,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -732,13 +732,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -750,13 +750,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -768,13 +768,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -786,13 +786,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -804,13 +804,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -822,13 +822,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -840,13 +840,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -858,13 +858,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -876,13 +876,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -894,13 +894,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -912,13 +912,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -930,13 +930,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -948,13 +948,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -966,13 +966,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -984,13 +984,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -1006,9 +1006,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -1020,13 +1020,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1042,9 +1042,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -1056,13 +1056,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -1078,9 +1078,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -1092,13 +1092,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -1110,13 +1110,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -1128,13 +1128,13 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -1146,7 +1146,7 @@
       ],
       "peer": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -6146,9 +6146,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -6157,32 +6157,35 @@
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -11866,420 +11869,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
@@ -12305,50 +11894,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/vitest/node_modules/vite": {

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -56,6 +56,7 @@
     "vitest": "^4.1.8"
   },
   "overrides": {
-    "@swc/helpers": "0.5.21"
+    "@swc/helpers": "0.5.21",
+    "esbuild": "^0.28.1"
   }
 }


### PR DESCRIPTION
First integration of **Lume**, omadia's own visual language, into the operator web UI (`web-ui/`). It replaces the byte5 agency design system the UI shipped with, so operators configuring agents, plugins and memory see omadia's identity instead of the company's.

Lume is specified in [byte5ai/omadia-ui](https://github.com/byte5ai/omadia-ui) (`docs/visual-spec.md`, v0.4), the same language the omadia canvas app is built on. Adopting it here gives both surfaces one identity.

Scope is the operator UI only. The canvas wire protocol, the primitive vocabulary and the Electron host app stay in omadia-ui and out of this PR.

## What Lume is

Light is the material. Surfaces read as condensed out of light, and the agent's attention shows up as accent-tinted illumination instead of flat color. In CSS that is a small set of recipes on one semantic token layer: gradient surface pairs, directional borders that catch light on their top edge, an accent slot with a glow for focus and selection, and soft corners.

## What shipped

- **Token tier.** `web-ui/app/_lib/theme.css` is now the full Lume token set (surface pairs, directional borders, text, semantic states, per-palette accent + glow). Light and dark resolve through CSS `light-dark()`, so all three palettes cover both modes without an `@media` cross-product. The existing semantic and editorial token names remap onto Lume, so components keep working without per-component edits.
- **Three palettes, selectable.** Petrol, Atelier and Lagoon (default), bound through `[data-palette]` on `<html>`. A header control switches palette and appearance (system / light / dark), persisted in localStorage with a pre-paint bootstrap so there is no flash. Palette changes cross-fade the accent tokens (visual-spec §6.6).
- **Typography.** Self-hosted Geist, Geist Mono and Source Serif 4 via `next/font`, no runtime font-CDN. Agent prose renders in the serif register; structure and code stay in Geist. Days One and the magenta-colon device are gone.
- **Material everywhere.** A token-matched CSS layer upgrades the existing utility classes in place: surface gradients, directional borders, lit accent fills, lit inputs, glow on focus and selection, a Spotlight composer, and content condensation on newly arrived agent messages.
- **The sweep.** ~1,700 raw Tailwind palette classes and 545 `dark:` color variants mapped onto the Lume token ladders. Spacing snapped to the 4pt set, radii to the closed set, motion to the Lume tokens.
- **Per-primitive recipes.** Spinner ban (§7.3, verb + animated dots, no spinning glyph), danger buttons as outline, status states text-only, drag ghost + dashed drop target, table header and row-hover, focus-on-cancel confirm dialog, donut glow, full patch condensation.

## Verification

`typecheck`, `lint` (0 errors), production `build`, `i18n:check` parity and the test suite all pass. Built the web-ui image on the target Node and verified in a real browser across all six palette × mode combinations.

A WCAG pass over the token set surfaced two findings in the spec itself (light-mode Lagoon and Atelier miss the 4.5:1 floor for text-on-accent), filed upstream as byte5ai/omadia-ui#22 per the visual-spec implementation contract.

## Follow-ups

- #286 — stream toasts vs the no-toasts rule (§7.6)
- #287 — palette preference persisted server-side per user (§2.5.4)
- byte5ai/omadia-ui#22 — spec contrast finding