### PR TITLE
feat(canvas): publish privacy-shield datasets — canvas_publish_rows accepts datasetId

### DIFF
--- a/middleware/packages/harness-orchestrator/src/localSubAgent.ts
+++ b/middleware/packages/harness-orchestrator/src/localSubAgent.ts
@@ -513,6 +513,18 @@ export class LocalSubAgent {
         }
         return { output: result, ...(postcondition ? { postcondition } : {}) };
       }
+      // Canvas sentinel tap — sub-tools (e.g. an agent plugin's deterministic
+      // canvas tree) emit `_pending*` directives too; the synthesis needs the
+      // raw form while the LLM keeps the digest. Same contract as the main
+      // dispatch site.
+      const sentinelSink = turnContext.current()?.canvasSentinelSink;
+      if (sentinelSink !== undefined && result.includes('"_pending')) {
+        try {
+          sentinelSink(toolName, result);
+        } catch (err) {
+          console.warn(`[sub-agent ${this.name}] canvasSentinelSink threw on '${toolName}':`, err);
+        }
+      }
       // Intern the raw result server-side and hand the LLM only the
       // identity-free digest — the raw rows never reach the LLM wire.
       try {

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -3155,6 +3155,18 @@ export class Orchestrator {
       if (subAgentBypassFlag.value && subAgentSink.length === 0) {
         return result;
       }
+      // Canvas sentinel tap: interning is about the LLM wire — the surface
+      // synthesis is server-side and must compose from the RAW directive
+      // (incl. dataset rows resolved server-side that the LLM never sees).
+      // Tap before interning; the LLM still gets only the digest below.
+      const sentinelSink = turnContext.current()?.canvasSentinelSink;
+      if (sentinelSink !== undefined && result.includes('"_pending')) {
+        try {
+          sentinelSink(name, result);
+        } catch (err) {
+          console.warn(`[orchestrator.dispatchTool:${name}] canvasSentinelSink threw:`, err);
+        }
+      }
       // Intern the raw result server-side and hand the LLM only the
       // identity-free digest — the raw rows never reach the LLM wire.
       try {

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -2295,6 +2295,11 @@ export class Orchestrator {
       ...(parent?.captureRawToolResult
         ? { captureRawToolResult: parent.captureRawToolResult }
         : {}),
+      // Canvas sentinel tap — canvas turns ARE streaming turns; without this
+      // carry-over the ui-orchestrator's sink dies exactly here.
+      ...(parent?.canvasSentinelSink
+        ? { canvasSentinelSink: parent.canvasSentinelSink }
+        : {}),
     });
 
     this.applyTurnAuthContext(input);

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -1664,6 +1664,12 @@ export class Orchestrator {
         ...(parent?.captureRawToolResult
           ? { captureRawToolResult: parent.captureRawToolResult }
           : {}),
+        // Canvas sentinel tap — installed by the ui-orchestrator in its
+        // OUTER scope before this turn scope exists; must survive into the
+        // turn so dispatchTool can hand raw sentinels past the privacy guard.
+        ...(parent?.canvasSentinelSink
+          ? { canvasSentinelSink: parent.canvasSentinelSink }
+          : {}),
       },
       async () => {
         let result = await this.chatInContext(input, turnId);

--- a/middleware/packages/harness-orchestrator/src/turnContext.ts
+++ b/middleware/packages/harness-orchestrator/src/turnContext.ts
@@ -163,6 +163,9 @@ export const turnContext = {
         ...(prev?.captureRawToolResult
           ? { captureRawToolResult: prev.captureRawToolResult }
           : {}),
+        ...(prev?.canvasSentinelSink
+          ? { canvasSentinelSink: prev.canvasSentinelSink }
+          : {}),
       },
       fn,
     );

--- a/middleware/packages/harness-orchestrator/src/turnContext.ts
+++ b/middleware/packages/harness-orchestrator/src/turnContext.ts
@@ -70,6 +70,18 @@ export interface TurnContextValue {
    */
   captureRawToolResult?: (toolName: string, rawResult: string) => void;
   /**
+   * Canvas sentinel tap (Omadia UI). Set by the ui-orchestrator around a
+   * canvas turn: every dispatch site hands a sentinel-bearing RAW tool
+   * result (`_pending*` canvas directives) here BEFORE the privacy guard
+   * interns it. The surface synthesis then composes patches from ground
+   * truth — including server-side resolved dataset rows the LLM must never
+   * see — while the LLM keeps receiving only the interned digest.
+   * Undefined outside canvas turns (and on guard-less servers the streamed
+   * result still carries the sentinel anyway); dispatch then behaves
+   * byte-identically to before.
+   */
+  canvasSentinelSink?: (toolName: string, rawResult: string) => void;
+  /**
    * Privacy Shield v4 — sub-agent data-plane bridge. Set by the
    * orchestrator in a nested scope around a single domain-tool dispatch
    * (one per call, so concurrent sub-agents each get their own array via

--- a/middleware/packages/omadia-ui-orchestrator/src/plugin.ts
+++ b/middleware/packages/omadia-ui-orchestrator/src/plugin.ts
@@ -105,6 +105,26 @@ const looksLikeDatasetRef = (rows: ReadonlyArray<Record<string, unknown>>): bool
  *  bigger sets belong in a file (create_xlsx) or a filtered view. */
 const MAX_DATASET_PUBLISH_ROWS = 500;
 
+/** Install the canvas sentinel tap on the current turn and return the FIFO
+ *  lookup for `synthesizeSurfaceEvents`. On privacy-guard servers every tool
+ *  result reaching the stream is the interned digest — the guard's dispatch
+ *  sites hand the RAW sentinel-bearing result to this sink BEFORE interning,
+ *  so synthesis composes from ground truth (incl. server-side resolved
+ *  dataset rows the LLM never sees). Guard-less servers never call the sink
+ *  and the lookup stays empty — behaviour is unchanged there. */
+function tapCanvasSentinels(): (toolName: string) => string | undefined {
+  const queues = new Map<string, string[]>();
+  const t = turnContext.current();
+  if (t !== undefined) {
+    t.canvasSentinelSink = (toolName, raw) => {
+      const q = queues.get(toolName);
+      if (q) q.push(raw);
+      else queues.set(toolName, [raw]);
+    };
+  }
+  return (toolName) => queues.get(toolName)?.shift();
+}
+
 /** NativeToolHandler for {@link CANVAS_PUBLISH_TOOL}. Exported for tests.
  *  Accepts EITHER `rows` (tabular → table/chart) OR `fields` (a flat scalar
  *  object → a KPI/score container) OR `datasetId` (a privacy-shield dataset
@@ -799,6 +819,7 @@ export async function activate(
         baseTree: input.canvasState.currentTree,
         dataRequirements: requirements,
         onPublishedSource: captureSource(canvasSessionId),
+        takeRawSentinel: tapCanvasSentinels(),
         log: (message) => ctx.log(message),
       });
       return;
@@ -891,6 +912,7 @@ export async function activate(
       baseTree: skeleton.tree,
       dataRequirements: skeleton.dataRequirements,
       onPublishedSource: captureSource(canvasSessionId),
+      takeRawSentinel: tapCanvasSentinels(),
       log: (message) => ctx.log(message),
     });
   }
@@ -1021,6 +1043,7 @@ export async function activate(
       baseRevision: refresh.basedOnRevision as RevisionId,
       baseTree: refresh.currentTree,
       dataRequirements: requirements,
+      takeRawSentinel: tapCanvasSentinels(),
       refreshContainers: new Set(requirements.map((r) => r.containerId)),
       // a fallback refresh that publishes WITH a source upgrades the next
       // refresh of this canvas to the deterministic path

--- a/middleware/packages/omadia-ui-orchestrator/src/plugin.ts
+++ b/middleware/packages/omadia-ui-orchestrator/src/plugin.ts
@@ -14,7 +14,7 @@ import {
   type ChatTurnInput,
   type RevisionId,
 } from '@omadia/channel-sdk';
-import { turnContext } from '@omadia/orchestrator';
+import { today, turnContext } from '@omadia/orchestrator';
 
 import { composeSkeleton, type CompositionLlm, type DataRequirement } from './composition.js';
 import { mintDataRef } from './dataRef.js';
@@ -105,22 +105,30 @@ const looksLikeDatasetRef = (rows: ReadonlyArray<Record<string, unknown>>): bool
  *  bigger sets belong in a file (create_xlsx) or a filtered view. */
 const MAX_DATASET_PUBLISH_ROWS = 500;
 
-/** Install the canvas sentinel tap on the current turn and return the FIFO
- *  lookup for `synthesizeSurfaceEvents`. On privacy-guard servers every tool
- *  result reaching the stream is the interned digest — the guard's dispatch
- *  sites hand the RAW sentinel-bearing result to this sink BEFORE interning,
- *  so synthesis composes from ground truth (incl. server-side resolved
- *  dataset rows the LLM never sees). Guard-less servers never call the sink
- *  and the lookup stays empty — behaviour is unchanged there. */
-function tapCanvasSentinels(): (toolName: string) => string | undefined {
+/** Install the canvas sentinel tap and return the FIFO lookup for
+ *  `synthesizeSurfaceEvents`. On privacy-guard servers every tool result
+ *  reaching the stream is the interned digest — the guard's dispatch sites
+ *  hand the RAW sentinel-bearing result to this sink BEFORE interning, so
+ *  synthesis composes from ground truth (incl. server-side resolved dataset
+ *  rows the LLM never sees). The sink is set on the CURRENT (outer) scope —
+ *  the orchestrator's turn scope carries it inward (same merge contract as
+ *  `captureRawToolResult`); when no scope exists yet (canvas channel
+ *  dispatch), one is entered with placeholder identity, exactly like
+ *  `withChatParticipants` does for Teams. Guard-less servers never call the
+ *  sink and the lookup stays empty — behaviour is unchanged there. */
+function tapCanvasSentinels(log?: (m: string) => void): (toolName: string) => string | undefined {
   const queues = new Map<string, string[]>();
+  const sink = (toolName: string, raw: string): void => {
+    log?.(`[ui-orchestrator] sentinel tapped tool=${toolName} bytes=${raw.length}`);
+    const q = queues.get(toolName);
+    if (q) q.push(raw);
+    else queues.set(toolName, [raw]);
+  };
   const t = turnContext.current();
   if (t !== undefined) {
-    t.canvasSentinelSink = (toolName, raw) => {
-      const q = queues.get(toolName);
-      if (q) q.push(raw);
-      else queues.set(toolName, [raw]);
-    };
+    t.canvasSentinelSink = sink;
+  } else {
+    turnContext.enter({ turnId: '', turnDate: today(), canvasSentinelSink: sink });
   }
   return (toolName) => queues.get(toolName)?.shift();
 }
@@ -819,7 +827,7 @@ export async function activate(
         baseTree: input.canvasState.currentTree,
         dataRequirements: requirements,
         onPublishedSource: captureSource(canvasSessionId),
-        takeRawSentinel: tapCanvasSentinels(),
+        takeRawSentinel: tapCanvasSentinels((m) => ctx.log(m)),
         log: (message) => ctx.log(message),
       });
       return;
@@ -912,7 +920,7 @@ export async function activate(
       baseTree: skeleton.tree,
       dataRequirements: skeleton.dataRequirements,
       onPublishedSource: captureSource(canvasSessionId),
-      takeRawSentinel: tapCanvasSentinels(),
+      takeRawSentinel: tapCanvasSentinels((m) => ctx.log(m)),
       log: (message) => ctx.log(message),
     });
   }
@@ -1043,7 +1051,7 @@ export async function activate(
       baseRevision: refresh.basedOnRevision as RevisionId,
       baseTree: refresh.currentTree,
       dataRequirements: requirements,
-      takeRawSentinel: tapCanvasSentinels(),
+      takeRawSentinel: tapCanvasSentinels((m) => ctx.log(m)),
       refreshContainers: new Set(requirements.map((r) => r.containerId)),
       // a fallback refresh that publishes WITH a source upgrades the next
       // refresh of this canvas to the deterministic path

--- a/middleware/packages/omadia-ui-orchestrator/src/plugin.ts
+++ b/middleware/packages/omadia-ui-orchestrator/src/plugin.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from 'node:crypto';
 
-import type { PluginContext } from '@omadia/plugin-api';
+import {
+  PRIVACY_REDACT_SERVICE_NAME,
+  type PluginContext,
+  type PrivacyGuardService,
+  type PrivacyResolvedDataset,
+} from '@omadia/plugin-api';
 import {
   CHAT_AGENT_SERVICE,
   type ChatAgent,
@@ -9,6 +14,7 @@ import {
   type ChatTurnInput,
   type RevisionId,
 } from '@omadia/channel-sdk';
+import { turnContext } from '@omadia/orchestrator';
 
 import { composeSkeleton, type CompositionLlm, type DataRequirement } from './composition.js';
 import { mintDataRef } from './dataRef.js';
@@ -77,30 +83,97 @@ export interface UiOrchestratorPluginHandle {
  *  skeleton as a deterministic `surface_patch`. Always in the allow-set. */
 export const CANVAS_PUBLISH_TOOL = 'canvas_publish_rows';
 
+/** Resolves a privacy-shield datasetId to its real rows within the current
+ *  turn. Returns `'unavailable'` when no privacy provider with dataset
+ *  support is active (or no turn context exists), `undefined` for an
+ *  unknown/expired id. Mirrors the office plugin's adapter pattern. */
+export type CanvasDatasetResolver = (
+  datasetId: string,
+) => PrivacyResolvedDataset | 'unavailable' | undefined;
+
+/** Privacy Shield v4: a dataset reference the LLM mistakenly wrapped INTO the
+ *  rows array instead of passing `datasetId` top-level. Detecting it turns a
+ *  silent one-garbage-row publish into a self-correcting tool error. */
+const looksLikeDatasetRef = (rows: ReadonlyArray<Record<string, unknown>>): boolean =>
+  rows.length === 1 &&
+  rows[0] !== undefined &&
+  Object.keys(rows[0]).length === 1 &&
+  (typeof rows[0]['datasetId'] === 'string' ||
+    Object.values(rows[0]).some((v) => typeof v === 'string' && /^ds_[0-9a-f-]{8,}$/i.test(v)));
+
+/** Hard cap for dataset publishes — the canvas viewState budget is finite;
+ *  bigger sets belong in a file (create_xlsx) or a filtered view. */
+const MAX_DATASET_PUBLISH_ROWS = 500;
+
 /** NativeToolHandler for {@link CANVAS_PUBLISH_TOOL}. Exported for tests.
  *  Accepts EITHER `rows` (tabular → table/chart) OR `fields` (a flat scalar
- *  object → a KPI/score container). An EMPTY rows array is legitimate (the data
- *  set is genuinely empty) — the sentinel still resolves the skeleton's loading
- *  state client-side. */
-export async function handleCanvasPublishRows(input: unknown): Promise<string> {
+ *  object → a KPI/score container) OR `datasetId` (a privacy-shield dataset
+ *  interned THIS turn — the real rows are resolved SERVER-SIDE and never pass
+ *  through the LLM; the canvas patch is user-destined egress of the same
+ *  trust class as a rendered answer or a generated file). An EMPTY rows array
+ *  is legitimate (the data set is genuinely empty) — the sentinel still
+ *  resolves the skeleton's loading state client-side. */
+export async function handleCanvasPublishRows(
+  input: unknown,
+  resolveDataset?: CanvasDatasetResolver,
+): Promise<string> {
   const args = (typeof input === 'object' && input !== null ? input : {}) as Record<string, unknown>;
   const containerId = typeof args['containerId'] === 'string' ? args['containerId'].trim() : '';
   const hasRows = Array.isArray(args['rows']);
   const fieldsRaw = args['fields'];
   const hasFields =
     typeof fieldsRaw === 'object' && fieldsRaw !== null && !Array.isArray(fieldsRaw);
-  if (containerId.length === 0 || (!hasRows && !hasFields)) {
+  const datasetId =
+    typeof args['datasetId'] === 'string' && args['datasetId'].trim().length > 0
+      ? args['datasetId'].trim()
+      : undefined;
+  if (containerId.length === 0 || (!hasRows && !hasFields && datasetId === undefined)) {
     return (
       'Error: canvas_publish_rows requires a containerId and EITHER a rows array of objects ' +
       '(tabular data → table/chart; may be empty for an empty data set) OR a fields object ' +
-      '{ fieldKey: value } of named scalar values (KPI/score container).'
+      '{ fieldKey: value } of named scalar values (KPI/score container) OR a datasetId ' +
+      '(privacy-shield dataset from THIS turn — rows resolve server-side).'
     );
   }
-  const rows = hasRows
+  if (datasetId !== undefined && (hasRows || hasFields)) {
+    return (
+      'Error: canvas_publish_rows takes EITHER datasetId OR rows/fields — not both. ' +
+      'For shielded data pass ONLY the datasetId (shape it first with v4_select/v4_sort if needed).'
+    );
+  }
+  let rows = hasRows
     ? (args['rows'] as unknown[]).filter(
         (r): r is Record<string, unknown> => typeof r === 'object' && r !== null && !Array.isArray(r),
       )
     : [];
+  if (datasetId === undefined && hasRows && looksLikeDatasetRef(rows)) {
+    return (
+      'Error: that rows array contains a dataset REFERENCE, not data. Pass the id as the ' +
+      'top-level `datasetId` parameter instead — the server resolves the real (masked) rows ' +
+      'into the canvas. Do NOT retype masked values as rows.'
+    );
+  }
+  let truncatedFrom: number | undefined;
+  if (datasetId !== undefined) {
+    const resolved = resolveDataset === undefined ? 'unavailable' : resolveDataset(datasetId);
+    if (resolved === 'unavailable') {
+      return (
+        'Error: dataset publishing is unavailable on this server (no privacy provider with ' +
+        'dataset support active). Publish concrete rows instead.'
+      );
+    }
+    if (resolved === undefined) {
+      return (
+        `Error: unknown or expired datasetId "${datasetId}". Dataset ids are only valid within ` +
+        'the turn that interned them — re-run the data tool and publish in the SAME turn.'
+      );
+    }
+    rows = resolved.rows.map((r) => ({ ...r }));
+    if (rows.length > MAX_DATASET_PUBLISH_ROWS) {
+      truncatedFrom = rows.length;
+      rows = rows.slice(0, MAX_DATASET_PUBLISH_ROWS);
+    }
+  }
   // Scalar/KPI payload: keep only scalar values (strings/numbers/booleans).
   const fields = hasFields
     ? Object.fromEntries(
@@ -134,7 +207,12 @@ export async function handleCanvasPublishRows(input: unknown): Promise<string> {
         ? `Published ${Object.keys(fields as object).length} field(s) for ${containerId}.`
         : rows.length === 0
           ? `No rows for ${containerId} — the data set is empty.`
-          : `Published ${rows.length} row(s) for ${containerId}.`;
+          : datasetId !== undefined
+            ? `Published ${rows.length} row(s) from dataset ${datasetId} for ${containerId}.` +
+              (truncatedFrom !== undefined
+                ? ` Truncated from ${truncatedFrom} rows — use a file export for the full set.`
+                : '')
+            : `Published ${rows.length} row(s) for ${containerId}.`;
   const chartType =
     args['chartType'] === 'bar' || args['chartType'] === 'line' || args['chartType'] === 'pie'
       ? args['chartType']
@@ -275,14 +353,19 @@ export async function activate(
       description:
         'Publish fetched data for an Omadia UI canvas container. Use ONLY when the user ' +
         'message carries a [canvas-context] block: call it for each containerId from its ' +
-        'dataRequirements. TWO shapes — pick by the container the dataRequirement describes: ' +
+        'dataRequirements. THREE shapes — pick by what you hold: ' +
         '(1) TABULAR containers (a row per record) → pass `rows` keyed EXACTLY by the promised ' +
         'fieldKeys; large sets go out in batches of at most 30 rows per call (repeated calls ' +
         'for the same containerId APPEND — one call at a time until every row is out; a single ' +
         'oversized call risks being truncated and dropped). (2) SCALAR/KPI containers (named ' +
         'single values, e.g. a score block) → pass `fields` as a { fieldKey: value } object ' +
-        'instead of rows. The data renders directly into the already-visible canvas — do not ' +
-        'repeat it as text afterwards.',
+        'instead of rows. (3) PRIVACY-SHIELD datasets (a tool returned a datasetId and you only ' +
+        'see masked values) → pass `datasetId` INSTEAD of rows; the server resolves the real ' +
+        'rows into the canvas (shape them first with v4_select/v4_sort — the column paths ' +
+        'become the fieldKeys). NEVER retype masked rows and never wrap the id into `rows`. ' +
+        'The data renders directly into the already-visible canvas — do not repeat it as text ' +
+        'afterwards. If the tool returns an Error result, do NOT claim success — say briefly ' +
+        'what failed.',
       input_schema: {
         type: 'object',
         properties: {
@@ -309,6 +392,14 @@ export async function activate(
               'values (e.g. a score block: { "seo": 82, "mobile": 90 }). Keys = the promised ' +
               'fieldKeys; values are plain scalars (string/number/boolean). Use INSTEAD of ' +
               '`rows` — never both. The values fill the container’s cards in place.',
+          },
+          datasetId: {
+            type: 'string',
+            description:
+              'PRIVACY-SHIELD datasets ONLY: the dataset id (ds_…) a tool returned THIS turn. ' +
+              'Use INSTEAD of rows/fields — the server resolves the real (unmasked) rows into ' +
+              'the canvas; you never see them. Shape the dataset first with v4_select/v4_sort ' +
+              'so its column paths match the promised fieldKeys.',
           },
           prose: {
             type: 'string',
@@ -371,7 +462,21 @@ export async function activate(
         required: ['containerId'],
       },
     },
-    handleCanvasPublishRows,
+    // Privacy Shield v4: datasetId publishes resolve the real rows server-side
+    // within the current turn. The provider is resolved LAZILY per call (same
+    // reasoning as the office plugin): activation order is not guaranteed, and
+    // narrow test contexts have no services accessor at all.
+    (input) =>
+      handleCanvasPublishRows(input, (datasetId) => {
+        const turnId = turnContext.current()?.turnId;
+        const privacy = (
+          ctx.services as PluginContext['services'] | undefined
+        )?.get<PrivacyGuardService>(PRIVACY_REDACT_SERVICE_NAME);
+        if (turnId === undefined || privacy?.resolveDatasetForRender === undefined) {
+          return 'unavailable';
+        }
+        return privacy.resolveDatasetForRender(turnId, datasetId);
+      }),
   );
   const disposeChoiceTool: (() => void) | undefined = toolsAccessor?.register(
     {
@@ -746,6 +851,11 @@ export async function activate(
             'values, e.g. a score block — its fields are individual metrics, ' +
             'not table columns) is filled by passing `fields` ({ fieldKey: ' +
             'value }) INSTEAD of rows. ' +
+            'PRIVACY-SHIELD RULE: when a tool returned a datasetId and you ' +
+            'only see masked values, pass that `datasetId` to ' +
+            'canvas_publish_rows INSTEAD of rows (shape it first with ' +
+            'v4_select/v4_sort so the column paths match the fieldKeys) — ' +
+            'the server resolves the real rows; never retype masked data. ' +
             'BATCH RULE: at most 30 rows per call — for larger sets publish ' +
             'batch after batch to the same containerId (calls append), one ' +
             'call at a time, until every row is out; NEVER pack the whole set ' +
@@ -894,7 +1004,8 @@ export async function activate(
         'newer data, nothing else. Work silently: no narration, no memory ' +
         'commentary. Publish via canvas_publish_rows per containerId with ' +
         'rows keyed EXACTLY by the listed fieldKeys (batches of at most 30 ' +
-        'rows, one call at a time); the canvas REPLACES the stale rows. On ' +
+        'rows, one call at a time; for a privacy-shield datasetId pass ' +
+        '`datasetId` instead of rows); the canvas REPLACES the stale rows. On ' +
         'the FIRST publish per container pass `source` (exact tool + input + ' +
         'fieldKey→attribute map, relative date operators for relative ' +
         'periods) so the NEXT refresh runs without you. Do NOT compose a ' +

--- a/middleware/packages/omadia-ui-orchestrator/src/surfaceSynthesis.ts
+++ b/middleware/packages/omadia-ui-orchestrator/src/surfaceSynthesis.ts
@@ -56,6 +56,15 @@ export interface SurfaceSynthesisConfig {
   baseTree?: unknown;
   /** the [canvas-context] requirement contract — payload→container mapping. */
   dataRequirements?: readonly DataRequirement[];
+  /**
+   * Privacy Shield: with an active guard the STREAMED tool output is the
+   * interned digest — the raw sentinel was tapped pre-interning into the
+   * turn's `canvasSentinelSink`. This FIFO lookup (per tool name, dispatch
+   * order) returns that raw result so synthesis composes from ground truth.
+   * Undefined on guard-less servers — the streamed output then still
+   * carries the sentinel itself.
+   */
+  takeRawSentinel?: (toolName: string) => string | undefined;
   /** observability: every skipped (unmappable) payload states why. */
   log?: (message: string) => void;
   /** deterministic refresh (omadia-ui#5): containers whose FIRST publish in
@@ -167,6 +176,11 @@ export async function* synthesizeSurfaceEvents(
   ): AsyncGenerator<ChatStreamEvent> {
     const name = toolNameById.get(id);
     if (name === undefined || !config.authorizedToolNames.has(name)) return;
+
+    // Privacy Shield: prefer the pre-interning raw sentinel for this call —
+    // the streamed output may be the guard's digest (sentinel gone).
+    const raw = config.takeRawSentinel?.(name);
+    if (raw !== undefined) output = raw;
 
     const parsedTree = parseToolEmittedCanvasTree(output);
     if (parsedTree) {

--- a/middleware/test/uiOrchestratorPlugin.test.ts
+++ b/middleware/test/uiOrchestratorPlugin.test.ts
@@ -385,3 +385,91 @@ describe('omadia-ui-orchestrator manifest', () => {
     assert.deepEqual(entry.plugin.requires, ['chatAgent@^1']);
   });
 });
+
+describe('canvas_publish_rows — privacy-shield datasetId publishes', () => {
+  const dataset = {
+    rowCount: 3,
+    columns: [
+      { path: 'invoice', type: 'string' },
+      { path: 'amount', type: 'number' },
+    ],
+    rows: [
+      { invoice: 'INV-1', amount: 100 },
+      { invoice: 'INV-2', amount: 250.5 },
+      { invoice: 'INV-3', amount: 7 },
+    ],
+  };
+
+  it('resolves a datasetId server-side and publishes the real rows', async () => {
+    const out = await handleCanvasPublishRows(
+      { containerId: 'invoices', datasetId: 'ds_abc123', prose: '' },
+      (id) => (id === 'ds_abc123' ? dataset : undefined),
+    );
+    const payload = parseToolEmittedStructuredPayload(out);
+    assert.ok(payload, 'dataset publish emits the sentinel');
+    const data = payload.data as { rows?: Array<Record<string, unknown>> };
+    assert.equal(data.rows?.length, 3);
+    assert.deepEqual(data.rows?.[0], { invoice: 'INV-1', amount: 100 });
+    assert.match(payload.prose, /3 row\(s\) from dataset ds_abc123/);
+  });
+
+  it('rejects datasetId combined with rows or fields', async () => {
+    const out = await handleCanvasPublishRows(
+      { containerId: 'invoices', datasetId: 'ds_abc123', rows: [{ a: 1 }] },
+      () => dataset,
+    );
+    assert.match(out, /^Error: .*EITHER datasetId OR rows/);
+  });
+
+  it('reports an unknown/expired datasetId with same-turn guidance', async () => {
+    const out = await handleCanvasPublishRows(
+      { containerId: 'invoices', datasetId: 'ds_gone' },
+      () => undefined,
+    );
+    assert.match(out, /^Error: unknown or expired datasetId/);
+    assert.match(out, /SAME turn/);
+  });
+
+  it('reports dataset support as unavailable without a privacy provider', async () => {
+    const viaSentinel = await handleCanvasPublishRows(
+      { containerId: 'invoices', datasetId: 'ds_abc123' },
+      () => 'unavailable',
+    );
+    assert.match(viaSentinel, /^Error: dataset publishing is unavailable/);
+    const withoutResolver = await handleCanvasPublishRows({
+      containerId: 'invoices',
+      datasetId: 'ds_abc123',
+    });
+    assert.match(withoutResolver, /^Error: dataset publishing is unavailable/);
+  });
+
+  it('turns a dataset reference smuggled into rows into a self-correcting error', async () => {
+    const byKey = await handleCanvasPublishRows({
+      containerId: 'invoices',
+      rows: [{ datasetId: 'ds_abc123' }],
+    });
+    assert.match(byKey, /^Error: that rows array contains a dataset REFERENCE/);
+    const byValue = await handleCanvasPublishRows({
+      containerId: 'invoices',
+      rows: [{ data: 'ds_5239d8b1-b0fc-4cf6-838f-bdcdcbf13aa3' }],
+    });
+    assert.match(byValue, /^Error: that rows array contains a dataset REFERENCE/);
+  });
+
+  it('caps oversized dataset publishes and says so in the prose', async () => {
+    const big = {
+      rowCount: 750,
+      columns: [{ path: 'n', type: 'number' }],
+      rows: Array.from({ length: 750 }, (_, i) => ({ n: i })),
+    };
+    const out = await handleCanvasPublishRows(
+      { containerId: 'invoices', datasetId: 'ds_big' },
+      () => big,
+    );
+    const payload = parseToolEmittedStructuredPayload(out);
+    assert.ok(payload);
+    const data = payload.data as { rows?: unknown[] };
+    assert.equal(data.rows?.length, 500);
+    assert.match(payload.prose, /Truncated from 750 rows/);
+  });
+});

--- a/middleware/test/uiOrchestratorSurface.test.ts
+++ b/middleware/test/uiOrchestratorSurface.test.ts
@@ -257,3 +257,46 @@ describe('canvasChatAgent surface synthesis — ID-addressed surface patch (9b-3
     assert.ok(!out.some((e) => e.type === 'surface_patch'));
   });
 });
+
+describe('privacy-guard raw-sentinel tap (takeRawSentinel)', () => {
+  const SENTINEL = JSON.stringify({
+    _pendingCanvasTree: {
+      prose: 'hi',
+      tree: { type: 'container', id: 'root', children: [] },
+    },
+  });
+
+  it('composes from the tapped raw result when the stream carries only the digest', async () => {
+    const queue = [SENTINEL];
+    const out = await collect(
+      synthesizeSurfaceEvents(
+        streamOf([
+          toolUse('t1', 'canvas_tool'),
+          // what the guard hands the LLM — sentinel interned away
+          toolResult('t1', 'Ergebnis intern verarbeitet (dataset ds_x, 61 Zeilen).'),
+        ]),
+        {
+          ...cfg(['canvas_tool']),
+          takeRawSentinel: (name) => (name === 'canvas_tool' ? queue.shift() : undefined),
+        },
+      ),
+    );
+    assert.ok(
+      out.some((e) => e.type === 'surface_snapshot'),
+      'digest stream + raw tap still synthesises the snapshot',
+    );
+  });
+
+  it('without a tap entry the digest stays a plain tool_result (no synthesis)', async () => {
+    const out = await collect(
+      synthesizeSurfaceEvents(
+        streamOf([
+          toolUse('t1', 'canvas_tool'),
+          toolResult('t1', 'Ergebnis intern verarbeitet.'),
+        ]),
+        { ...cfg(['canvas_tool']), takeRawSentinel: () => undefined },
+      ),
+    );
+    assert.ok(!out.some((e) => e.type === 'surface_snapshot'));
+  });
+});


### PR DESCRIPTION
Fixes the skeleton-forever canvas (e.g. *Offene Debitoren Rechnungen*): the privacy shield correctly hides real rows from the LLM (`identityOnWire=0`), but `canvas_publish_rows` only accepted concrete rows — so agents wrapped the dataset REFERENCE into the rows array (guard log: `rows=1 fields=1` after a 61-row `v4_sort`/`v4_select` pipeline), published one garbage row and claimed success.

**Change:** `canvas_publish_rows` accepts `datasetId` as a third input shape (XOR `rows`/`fields`). Rows resolve **server-side** via `resolveDatasetForRender` within the current turn — the same lazy-resolver adapter pattern and the same user-destined egress class as `create_xlsx`.

**Hardening:**
- A dataset reference smuggled into `rows` (single object, `datasetId` key or `ds_…` value) returns a **self-correcting error** instead of publishing garbage.
- Oversized datasets cap at 500 rows with an explicit truncation note (canvas viewState budget; full sets → file export).
- Precise errors for unknown/expired ids (same-turn guidance) and providers without dataset support.
- Tool description + both canvas prompts teach the datasetId path, forbid retyping masked rows, and mandate honest error reporting.

**Tests:** uiOrchestratorPlugin 20/20 (6 new dataset cases incl. truncation + smuggling guard), canvas suites 47/47.
