### PR TITLE
feat(ui-orchestrator): skeleton composition always uses cheapest class:fast model

### DIFF
--- a/middleware/packages/omadia-ui-orchestrator/manifest.yaml
+++ b/middleware/packages/omadia-ui-orchestrator/manifest.yaml
@@ -41,9 +41,9 @@ setup:
     - key: "ui_orchestrator_model"
       type: "string"
       label: "Composition model"
-      help: "Fast-tier model for the skeleton composition call. Pin to a Sonnet id if the spike tree-validity gate (<95% first-attempt schema-valid) fails — implementation-plan §8 risk #1."
+      help: "Skeleton composition model. Default 'class:fast' = always the cheapest tier on whatever LLM provider is active (anthropic→haiku, openai→gpt-mini, mistral→small). Pin a concrete id or 'class:balanced' only if the tree-validity gate (<95% first-attempt schema-valid) fails — implementation-plan §8 risk #1."
       required: false
-      default: "claude-haiku-4-5"
+      default: "class:fast"
     - key: "canvas_output_tools"
       type: "string"
       label: "Canvas-output tool allow-set"
@@ -54,14 +54,18 @@ setup:
 permissions:
   filesystem:
     scratch: false
-  # The skeleton composition call (composeSkeleton): fast tier by default,
-  # Sonnet allowed as the documented fallback when the validity gate fails.
+  # The skeleton composition call (composeSkeleton): cheapest tier by default.
+  # Provider-agnostic class refs — resolved against the ACTIVE provider in
+  # createLlmAccessor, so this gate is byte-identical to the old anthropic lock
+  # (class:fast→claude-haiku, class:balanced→claude-sonnet) AND works on
+  # openai/mistral without edits. class:balanced stays allowed as the documented
+  # fallback when the validity gate fails.
   # Per turn: 1 composition call + at most 1 repair retry; the cap of 8 leaves
   # headroom for later 9b slices (patch recomposition, suggestedActions).
   llm:
     models_allowed:
-      - "claude-haiku-4-5*"
-      - "claude-sonnet-4-*"
+      - "class:fast"
+      - "class:balanced"
     # NOTE: the LlmAccessor's calls counter is scoped to the plugin CONTEXT,
     # which for an extension plugin is created once per activation — so this
     # cap is effectively a LIFETIME budget, not per-invocation. With the old

--- a/middleware/packages/omadia-ui-orchestrator/src/plugin.ts
+++ b/middleware/packages/omadia-ui-orchestrator/src/plugin.ts
@@ -32,10 +32,11 @@ import { synthesizeSurfaceEvents } from './surfaceSynthesis.js';
  * the bundle a canvas channel reaches via `channel.dispatch_service` (PR-6).
  *
  * For a **canvas turn** (one that carries `input.canvasSessionId`) the agent now
- * runs the Haiku composition step before delegating:
+ * runs the cheapest-class composition step before delegating:
  *
- *   1. **Skeleton-first** — `composeSkeleton` (fast model from
- *      `ui_orchestrator_model`, validator-gated with one repair retry,
+ *   1. **Skeleton-first** — `composeSkeleton` (cheapest fast-class model —
+ *      `class:fast` by default, overridable via `ui_orchestrator_model`;
+ *      validator-gated with one repair retry,
  *      deterministic fallback) yields a `surface_snapshot` (revision "0")
  *      BEFORE the slow main turn starts.
  *   2. **Requirement handoff** — the delegated main turn's user message carries
@@ -70,7 +71,13 @@ export const CANVAS_CHAT_AGENT_SERVICE = 'canvasChatAgent';
 
 const CANVAS_PROTOCOL_VERSION = '1.0';
 const OPS_CATALOG_VERSION = '1.0';
-const DEFAULT_COMPOSITION_MODEL = 'claude-haiku-4-5';
+// Skeleton composition is a low-stakes structural placeholder, so it ALWAYS
+// runs on the cheapest tier — the `class:fast` ref resolves (in createLlmAccessor)
+// to the active provider's fast/cheapest model: anthropic→claude-haiku, openai→
+// gpt-5.4-mini, mistral→mistral-small. Provider-agnostic: pin a concrete id or a
+// bigger class via the `ui_orchestrator_model` config only if the tree-validity
+// gate (<95% first-attempt schema-valid) demands it.
+const DEFAULT_COMPOSITION_MODEL = 'class:fast';
 
 export interface UiOrchestratorPluginHandle {
   close(): Promise<void>;


### PR DESCRIPTION
## Problem

The canvas Tier-2 **skeleton composition** model was hardwired to `claude-haiku-4-5`. On a non-Anthropic stack (e.g. Mistral) the composition LLM call fails (`has ctx.llm but no 'llm' provider is registered`) and every canvas renders the empty fallback skeleton — the board shows empty, "can't interact with" frames.

## Fix

Use the registry's provider-agnostic `class:fast` ref instead of a vendor-pinned id:
- `DEFAULT_COMPOSITION_MODEL` → `class:fast`
- manifest `ui_orchestrator_model` default → `class:fast`
- manifest `models_allowed` → `class:fast` + `class:balanced`

`createLlmAccessor` resolves `class:fast` to the **active** provider's cheapest/fast model (anthropic→haiku, openai→gpt-5.4-mini, mistral→mistral-small-latest) and coerces the call. Skeleton = low-stakes placeholder → cheapest tier is the right default. Byte-identical on the Anthropic default; `class:balanced` kept as the validity-gate fallback.

## Verification
- `tsc --noEmit` clean on `@omadia/ui-orchestrator`.
- `test/llmClassRefGate.test.ts` 17/17 pass (class:fast gate match + cross-provider coercion + back-compat).

## Notes
Selecting *which* provider serves the canvas stays the operator's `llm_provider` config — unchanged here.
