### PR TITLE
feat(admin): data-driven provider compliance flags (requiresAvvDisclosure/euHosted)

### DIFF
--- a/middleware/packages/llm-provider/src/index.ts
+++ b/middleware/packages/llm-provider/src/index.ts
@@ -61,6 +61,7 @@ export {
 export {
   LlmProviderCatalog,
   type LlmProviderDescriptor,
+  type ProviderPolicy,
   type ProviderQuirks,
 } from './providerCatalog.js';
 

--- a/middleware/packages/llm-provider/src/providerCatalog.ts
+++ b/middleware/packages/llm-provider/src/providerCatalog.ts
@@ -40,7 +40,22 @@ export interface LlmProviderDescriptor {
   /** Optional config key an operator can set to override `baseURL` per scope. */
   readonly baseUrlConfigKey?: string;
   readonly quirks?: ProviderQuirks;
+  /** Operator-UI compliance hints (not LLM behaviour) surfaced on the admin
+   *  providers page so the view stays data-driven instead of hard-coding ids. */
+  readonly policy?: ProviderPolicy;
   readonly models: ReadonlyArray<ModelInfo>;
+}
+
+/** Provider data-protection hints for the operator UI. Defaults are the safe
+ *  conservative choice: a provider with no policy is treated as a third-party,
+ *  non-EU processor (disclosure shown, no EU-hosting note). */
+export interface ProviderPolicy {
+  /** Show the AVV / Art. 28 DSGVO third-party-processing disclosure before
+   *  routing an agent to this provider. Default (omitted) = true. */
+  readonly requiresAvvDisclosure?: boolean;
+  /** Provider is hosted in the EU (no third-country transfer) — surfaces a note.
+   *  Default (omitted) = false. */
+  readonly euHosted?: boolean;
 }
 
 export class LlmProviderCatalog {

--- a/middleware/src/platform/builtinLlmProviders.ts
+++ b/middleware/src/platform/builtinLlmProviders.ts
@@ -25,6 +25,9 @@ export const BUILTIN_LLM_PROVIDERS: ReadonlyArray<LlmProviderDescriptor> = [
     label: 'Anthropic',
     wireFormat: 'anthropic',
     baseURL: 'https://api.anthropic.com',
+    // Preserves the previous hard-coded behaviour (`provider !== 'anthropic'`):
+    // the AVV third-party disclosure is suppressed for Anthropic.
+    policy: { requiresAvvDisclosure: false },
     models: [
       {
         id: 'anthropic:claude-opus-4-8',
@@ -118,6 +121,8 @@ export const BUILTIN_LLM_PROVIDERS: ReadonlyArray<LlmProviderDescriptor> = [
     label: 'Mistral',
     wireFormat: 'openai-compatible',
     baseURL: 'https://api.mistral.ai/v1',
+    // EU-hosted (France) — surfaces the no-third-country-transfer note.
+    policy: { euHosted: true },
     // No quirk: Mistral's OpenAI-compatible layer uses the legacy `max_tokens`,
     // which is exactly what the adapter emits for a non-openai id by default.
     models: [

--- a/middleware/src/routes/adminProviders.ts
+++ b/middleware/src/routes/adminProviders.ts
@@ -32,10 +32,18 @@ export interface AdminProvidersDeps {
   readonly vault?: SecretVault;
   /** Tear down + re-activate a plugin so it re-reads its config. */
   readonly reactivate?: (agentId: string) => Promise<void>;
-  /** Plugin-contributed providers — supplies display labels for ids that are
-   *  not built in (structural to avoid a hard dep on the catalog class). */
+  /** Provider catalog — supplies display labels + data-protection policy hints
+   *  for the admin UI (structural, to avoid a hard dep on the catalog class). */
   readonly llmProviderCatalog?: {
-    get(id: string): { readonly label: string } | undefined;
+    get(id: string):
+      | {
+          readonly label: string;
+          readonly policy?: {
+            readonly requiresAvvDisclosure?: boolean;
+            readonly euHosted?: boolean;
+          };
+        }
+      | undefined;
   };
 }
 
@@ -136,10 +144,16 @@ export function createAdminProvidersRouter(deps: AdminProvidersDeps): Router {
     try {
       const providerIds = [...new Set(listModels().map((m) => m.provider))];
       const providers = await Promise.all(
-        providerIds.map(async (id) => ({
+        providerIds.map(async (id) => {
+          const descriptor = deps.llmProviderCatalog?.get(id);
+          return {
           id,
-          label: deps.llmProviderCatalog?.get(id)?.label ?? providerLabel(id),
+          label: descriptor?.label ?? providerLabel(id),
           connected: await isConnected(deps.vault, id),
+          // Data-protection hints for the operator UI (data-driven, no id checks).
+          // Safe defaults for an unknown provider: third-party, non-EU.
+          requiresAvvDisclosure: descriptor?.policy?.requiresAvvDisclosure ?? true,
+          euHosted: descriptor?.policy?.euHosted ?? false,
           models: listModelsByProvider(id).map((m) => ({
             id: m.id,
             modelId: m.modelId,
@@ -149,7 +163,8 @@ export function createAdminProvidersRouter(deps: AdminProvidersDeps): Router {
             maxTokens: m.maxTokens,
             vision: m.vision,
           })),
-        })),
+          };
+        }),
       );
 
       const assignments = LLM_PLUGINS.map((p) => {

--- a/middleware/test/adminProvidersRoute.test.ts
+++ b/middleware/test/adminProvidersRoute.test.ts
@@ -3,18 +3,22 @@ import { strict as assert } from 'node:assert';
 import type { Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
-import { providerApiKeyVaultKey } from '@omadia/llm-provider';
+import {
+  LlmProviderCatalog,
+  clearExternalModels,
+  providerApiKeyVaultKey,
+} from '@omadia/llm-provider';
 import express from 'express';
 import type { Express } from 'express';
 
 import { createAdminProvidersRouter } from '../src/routes/adminProviders.js';
 import { InMemoryInstalledRegistry } from '../src/plugins/installedRegistry.js';
 import { InMemorySecretVault } from '../src/secrets/vault.js';
-import { useBuiltinProviders } from './_helpers/builtinProviders.js';
+import { registerBuiltinLlmProviders } from '../src/platform/builtinLlmProviders.js';
 
-// The registry ships no static models now; register the bundled built-ins
-// (anthropic/openai/mistral) so the route lists them as before.
-useBuiltinProviders();
+// The registry ships no static models now; makeHarness registers the bundled
+// built-ins (anthropic/openai/mistral) into a catalog passed to the route, so it
+// lists them + their data-protection policy exactly as production wires it.
 
 /**
  * /api/v1/admin/providers (S6) — the dedicated models/providers admin backend.
@@ -51,6 +55,11 @@ async function makeHarness(
       config: p.config ?? {},
     });
   }
+  // Register the bundled built-ins into a fresh catalog (also populates the
+  // global model overlay) so the route lists providers/models + their policy.
+  clearExternalModels();
+  const llmProviderCatalog = new LlmProviderCatalog();
+  registerBuiltinLlmProviders(llmProviderCatalog);
   const reactivated: string[] = [];
   const app: Express = express();
   app.use(express.json());
@@ -62,6 +71,7 @@ async function makeHarness(
       reactivate: async (id: string) => {
         reactivated.push(id);
       },
+      llmProviderCatalog,
     }),
   );
   const server: Server = await new Promise((resolve) => {
@@ -85,6 +95,8 @@ interface ProvidersResponse {
     id: string;
     label: string;
     connected: boolean;
+    requiresAvvDisclosure?: boolean;
+    euHosted?: boolean;
     models: Array<{ id: string; modelId: string; class: string }>;
   }>;
   assignments: Array<{
@@ -119,6 +131,9 @@ describe('admin providers route — GET /', () => {
   let h: Harness;
   afterEach(async () => {
     if (h) await h.close();
+    // Clear the global model overlay so concurrent test files don't see our
+    // built-ins (and we don't see theirs) — keeps the full-suite run clean.
+    clearExternalModels();
   });
 
   it('lists providers + registry models and per-plugin assignments', async () => {
@@ -134,6 +149,13 @@ describe('admin providers route — GET /', () => {
     assert.equal(mistral.label, 'Mistral');
     assert.ok(mistral.models.some((m) => m.modelId === 'mistral-large-latest'));
     assert.equal(mistral.connected, false);
+    // Data-protection policy flags are data-driven from the provider descriptor
+    // (replaces the old hard-coded `provider !== 'anthropic'` / `=== 'mistral'`).
+    assert.equal(anthropic.requiresAvvDisclosure, false);
+    assert.equal(openai.requiresAvvDisclosure, true);
+    assert.equal(mistral.requiresAvvDisclosure, true);
+    assert.equal(mistral.euHosted, true);
+    assert.equal(anthropic.euHosted, false);
     // nothing connected yet
     assert.equal(anthropic.connected, false);
     assert.equal(openai.connected, false);
@@ -173,6 +195,9 @@ describe('admin providers route — POST /assignment', () => {
   let h: Harness;
   afterEach(async () => {
     if (h) await h.close();
+    // Clear the global model overlay so concurrent test files don't see our
+    // built-ins (and we don't see theirs) — keeps the full-suite run clean.
+    clearExternalModels();
   });
 
   it('sets provider + model, disables routing for the orchestrator, reactivates', async () => {

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -276,6 +276,11 @@ export interface AdminProvider {
   label: string;
   /** True when an API key for this provider is present in the vault. */
   connected: boolean;
+  /** Data-protection hints for the UI (data-driven; defaulted server-side).
+   *  `requiresAvvDisclosure`: show the Art. 28 DSGVO third-party disclosure.
+   *  `euHosted`: provider is hosted in the EU (no third-country transfer). */
+  requiresAvvDisclosure?: boolean;
+  euHosted?: boolean;
   models: AdminProviderModel[];
 }
 

--- a/web-ui/app/admin/providers/page.tsx
+++ b/web-ui/app/admin/providers/page.tsx
@@ -225,9 +225,10 @@ function AssignmentRow({
     providers.find((p) => p.id === a.provider) ?? providers[0];
   const models = selectedProvider?.models ?? [];
   const disabled = !a.installed;
-  // The disclosure is relevant whenever the plugin is (or would be) on a
-  // non-Anthropic provider — i.e. data leaves the default in-house path.
-  const showDisclosure = a.provider !== 'anthropic';
+  // Data-driven: surface the AVV / Art. 28 third-party disclosure unless the
+  // provider opts out via its policy (the server defaults unknown providers to
+  // requiring it). Replaces the previous hard-coded `!== 'anthropic'` check.
+  const showDisclosure = selectedProvider?.requiresAvvDisclosure ?? true;
 
   const onProvider = (providerId: string): void => {
     const next = providers.find((p) => p.id === providerId);
@@ -298,9 +299,11 @@ function AssignmentRow({
           {t('assignments.avvDisclosure', { provider: selectedProvider?.label ?? a.provider })}
         </p>
       )}
-      {a.provider === 'mistral' && (
+      {selectedProvider?.euHosted && (
         <p className="rounded-md border border-[color:var(--border)] bg-[color:var(--border)]/10 px-3 py-2 text-[12px] leading-[1.5] text-[color:var(--fg-muted)]">
-          {t('assignments.euHostedNote')}
+          {t('assignments.euHostedNote', {
+            provider: selectedProvider?.label ?? a.provider,
+          })}
         </p>
       )}
       {error && <p className="text-[12px] text-[color:var(--danger)]">{error}</p>}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1509,7 +1509,7 @@
       "modelLabel": "Modell",
       "pickModel": "Modell wählen …",
       "avvDisclosure": "Wird dieser Agent auf {provider} umgestellt, werden seine Prompt-Daten an einen Drittanbieter (Auftragsverarbeiter) übermittelt. Stelle sicher, dass ein Auftragsverarbeitungsvertrag (DSGVO Art. 28) vorliegt, bevor du ihn für personenbezogene Daten nutzt.",
-      "euHostedNote": "Mistral wird in der EU (Frankreich) gehostet. Ein Auftragsverarbeitungsvertrag nach DSGVO Art. 28 ist weiterhin erforderlich, aber es findet keine Drittlandübermittlung statt — anders als bei US-Anbietern."
+      "euHostedNote": "{provider} wird in der EU gehostet. Ein Auftragsverarbeitungsvertrag nach DSGVO Art. 28 ist weiterhin erforderlich, aber es findet keine Drittlandübermittlung statt — anders als bei US-Anbietern."
     },
     "status": {
       "saving": "speichert …",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1509,7 +1509,7 @@
       "modelLabel": "Model",
       "pickModel": "Select a model …",
       "avvDisclosure": "Routing this agent to {provider} sends its prompt data to a third-party processor. Ensure a data-processing agreement (DSGVO Art. 28) is in place before using it for personal data.",
-      "euHostedNote": "Mistral is hosted in the EU (France). An Art. 28 DSGVO processing agreement is still required, but there is no third-country transfer — unlike US-based providers."
+      "euHostedNote": "{provider} is hosted in the EU. An Art. 28 DSGVO processing agreement is still required, but there is no third-country transfer — unlike US-based providers."
     },
     "status": {
       "saving": "saving …",


### PR DESCRIPTION
## What

Follow-up to #300 (which merged before this landed): makes the **last two hard-coded provider checks** in the operator providers view data-driven, so newly-installed provider plugins get correct data-protection treatment automatically.

## How

- `@omadia/llm-provider`: `LlmProviderDescriptor.policy { requiresAvvDisclosure?, euHosted? }` (`ProviderPolicy`).
- Bundled built-ins: `anthropic` → `requiresAvvDisclosure: false` (preserves the previous `provider !== 'anthropic'` AVV-suppression); `mistral` → `euHosted: true`.
- `adminProviders` GET surfaces both flags with safe defaults for unknown providers (disclosure **on**, non-EU).
- web-ui: `AdminProvider` gains the fields; `providers/page.tsx` drives the AVV/Art.28 disclosure off `requiresAvvDisclosure` and the EU-hosting note off `euHosted` (no more `=== 'mistral'`); `euHostedNote` is generic via `{provider}` (de+en parity).

Behaviour is unchanged for anthropic/openai/mistral; only now it's data-driven.

## Tests

Full middleware suite **3385 pass / 0 fail / 4 skipped** (DB-env skips); `npm run typecheck` + `npm run build` green; web-ui `tsc --noEmit` + `i18n:check` green. Provider-policy assertions added to `adminProvidersRoute.test`.
