### PR TITLE
fix(llm): preserve server tools through the provider seam (live 400 hotfix)

### DIFF
--- a/middleware/packages/harness-orchestrator/src/llmProviderSeam.ts
+++ b/middleware/packages/harness-orchestrator/src/llmProviderSeam.ts
@@ -131,10 +131,26 @@ function toToolSpecs(tools: AnthropicBlock[]): {
   let cacheTools = false;
   const specs = tools.map((tool) => {
     if (tool['cache_control'] !== undefined) cacheTools = true;
+    const inputSchema = tool['input_schema'] as
+      | Record<string, unknown>
+      | undefined;
+    // Provider-native server tools (Anthropic memory `memory_20250818`,
+    // web_search, …) carry a `type` discriminator and NO `input_schema` —
+    // the vendor owns the schema. Preserve `type` so the adapter re-emits
+    // the server-tool shape; dropping it produced a custom tool with a
+    // missing input_schema → 400 `tools.0.custom.input_schema: Field required`.
+    if (inputSchema === undefined && typeof tool['type'] === 'string') {
+      return {
+        name: tool['name'] as string,
+        description: (tool['description'] ?? '') as string,
+        inputSchema: {} as Record<string, unknown>,
+        serverType: tool['type'] as string,
+      };
+    }
     return {
       name: tool['name'] as string,
       description: (tool['description'] ?? '') as string,
-      inputSchema: tool['input_schema'] as Record<string, unknown>,
+      inputSchema: inputSchema as Record<string, unknown>,
     };
   });
   return { tools: specs, cacheTools };

--- a/middleware/packages/llm-provider/src/anthropicProvider.ts
+++ b/middleware/packages/llm-provider/src/anthropicProvider.ts
@@ -96,16 +96,26 @@ function toAnthropicTools(
   tools: ReadonlyArray<ToolSpec>,
   cacheHints: CacheHints | undefined,
 ): AnthropicContentBlockParam[] {
-  return tools.map((tool, i) => ({
-    name: tool.name,
-    description: tool.description,
-    input_schema: tool.inputSchema,
+  return tools.map((tool, i) => {
     // Caching the LAST tool caches everything up to that point — the
     // stable prefix across tool-loop iterations (localSubAgent convention).
-    ...(cacheHints?.tools === true && i === tools.length - 1
-      ? { cache_control: CACHE_EPHEMERAL }
-      : {}),
-  }));
+    const cache =
+      cacheHints?.tools === true && i === tools.length - 1
+        ? { cache_control: CACHE_EPHEMERAL }
+        : {};
+    // Provider-native server tool (memory, web_search, …): typed, schema
+    // owned server side. Emit the `{ type, name }` shape — a custom-tool
+    // `input_schema` would be rejected by the API for these.
+    if (tool.serverType !== undefined) {
+      return { type: tool.serverType, name: tool.name, ...cache };
+    }
+    return {
+      name: tool.name,
+      description: tool.description,
+      input_schema: tool.inputSchema,
+      ...cache,
+    };
+  });
 }
 
 function toAnthropicToolChoice(

--- a/middleware/packages/llm-provider/src/openaiProvider.ts
+++ b/middleware/packages/llm-provider/src/openaiProvider.ts
@@ -230,15 +230,20 @@ function toOpenAiTools(
   tools: ReadonlyArray<ToolSpec>,
   strict: boolean,
 ): OpenAiMessageParam[] {
-  return tools.map((t) => ({
-    type: 'function',
-    function: {
-      name: t.name,
-      description: t.description,
-      parameters: t.inputSchema ?? EMPTY_TOOL_PARAMETERS,
-      ...(strict ? { strict: true } : {}),
-    },
-  }));
+  return tools
+    // Provider-native server tools (e.g. Anthropic's memory tool) have no
+    // OpenAI equivalent — skip them rather than emit a bogus empty-param
+    // function the model would never be able to call correctly.
+    .filter((t) => t.serverType === undefined)
+    .map((t) => ({
+      type: 'function',
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.inputSchema ?? EMPTY_TOOL_PARAMETERS,
+        ...(strict ? { strict: true } : {}),
+      },
+    }));
 }
 
 function toOpenAiToolChoice(choice: ToolChoice): unknown {

--- a/middleware/packages/llm-provider/src/types.ts
+++ b/middleware/packages/llm-provider/src/types.ts
@@ -67,6 +67,14 @@ export interface ToolSpec {
   /** JSON Schema for the tool input. Adapters validate vendor-specific
    *  restrictions (e.g. OpenAI strict mode) and throw early. */
   readonly inputSchema: Record<string, unknown>;
+  /** Provider-native server/built-in tool discriminator (e.g. Anthropic's
+   *  memory tool `memory_20250818`, web_search, …). When set, the tool has
+   *  NO author-supplied `inputSchema` — the vendor owns the schema server
+   *  side — and the owning adapter must emit the `{ type, name }` server-tool
+   *  shape instead of a custom tool. Adapters that cannot honor the server
+   *  tool (OpenAI, Mistral) MUST skip it rather than send a malformed custom
+   *  function. */
+  readonly serverType?: string;
 }
 
 export type ToolChoice =

--- a/middleware/test/llmProviderAnthropicAdapter.test.ts
+++ b/middleware/test/llmProviderAnthropicAdapter.test.ts
@@ -195,6 +195,39 @@ test('request mapping: image, tool_result, cacheHints, toolChoice', async () => 
   });
 });
 
+test('request mapping: server tool (memory) emits {type,name}, no input_schema', async () => {
+  // Regression for the live 400 `tools.0.custom.input_schema: Field required`:
+  // a ToolSpec carrying `serverType` is a provider-native server tool whose
+  // schema lives server side. It must be sent as `{ type, name }`, never as a
+  // custom tool with an `input_schema`.
+  const captured: Captured = {};
+  const provider = createAnthropicProvider({
+    client: mockClient(captured, textResponse()),
+  });
+
+  await provider.complete({
+    model: 'claude-sonnet-4-6',
+    maxTokens: 256,
+    tools: [
+      {
+        name: 'memory',
+        description: '',
+        inputSchema: {},
+        serverType: 'memory_20250818',
+      },
+      { name: 'a', description: 'A', inputSchema: { type: 'object' } },
+    ],
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+  });
+
+  const p = captured.params as Record<string, unknown>;
+  const tools = p['tools'] as Array<Record<string, unknown>>;
+  assert.deepEqual(tools[0], { type: 'memory_20250818', name: 'memory' });
+  assert.equal('input_schema' in (tools[0] ?? {}), false);
+  // the custom tool still carries its schema
+  assert.deepEqual(tools[1]?.['input_schema'], { type: 'object' });
+});
+
 test('stream() yields text deltas then a final response', async () => {
   const events = [
     { type: 'message_start' },

--- a/middleware/test/orchestratorLlmProviderSeam.test.ts
+++ b/middleware/test/orchestratorLlmProviderSeam.test.ts
@@ -64,6 +64,32 @@ test('toLlmRequest maps tools (cache on last → cacheHints.tools) + tool_choice
   assert.deepEqual(req.toolChoice, { type: 'required', disableParallel: true });
 });
 
+test('toLlmRequest preserves server tools (memory) via serverType, not custom', () => {
+  // Regression: the orchestrator's first tool is the Anthropic memory tool
+  // `{ type: 'memory_20250818', name: 'memory' }` — a server tool with NO
+  // input_schema. Dropping `type` rebuilt it as a custom tool with a missing
+  // input_schema → 400 `tools.0.custom.input_schema: Field required`.
+  const params: AnthropicParams = {
+    model: 'claude-sonnet-4-6',
+    max_tokens: 1024,
+    messages: [{ role: 'user', content: 'go' }],
+    tools: [
+      { type: 'memory_20250818', name: 'memory' },
+      { name: 'a', description: 'A', input_schema: { type: 'object' } },
+    ],
+  };
+  const req = toLlmRequest(params);
+  assert.deepEqual(req.tools, [
+    {
+      name: 'memory',
+      description: '',
+      inputSchema: {},
+      serverType: 'memory_20250818',
+    },
+    { name: 'a', description: 'A', inputSchema: { type: 'object' } },
+  ]);
+});
+
 test('toLlmRequest maps tool_use echo + tool_result + image blocks', () => {
   const params: AnthropicParams = {
     model: 'claude-opus-4-8',


### PR DESCRIPTION
## 🔴 Production hotfix — every tool-bearing agent turn fails on Live

**Symptom (odoo-bot-middleware v285, `main` @ `2fa7997`):** every orchestrator / sub-agent turn that offers tools fails with:

```
[orchestrator] turn failed: Error: 400 invalid_request_error
tools.0.custom.input_schema: Field required
```

### Root cause
The orchestrator's **first tool** is the Anthropic memory tool `{ type: 'memory_20250818', name: 'memory' }` — a provider-native **server** tool with **no `input_schema`** (the vendor owns the schema).

The empty-core provider seam (#300) round-trips every tool through the neutral `ToolSpec`, which modelled **only custom tools** `{name, description, inputSchema}`. The seam **dropped the server-tool `type`**, and the Anthropic adapter rebuilt it as a custom tool with `input_schema: undefined` → the API rejects it as a malformed custom tool (`tools.0` = the memory tool).

Pre-#300 this worked because `buildToolsList()` output went straight to the Anthropic SDK, which accepts `{type, name}` server tools.

### Fix (surgical, contract-level)
- **`ToolSpec`** gains optional `serverType` — provider-native server tools carry no author-supplied schema.
- **Seam** (`llmProviderSeam.ts`) preserves `type` as `serverType` when a tool has a `type` and no `input_schema`.
- **Anthropic adapter** emits the `{ type, name }` server-tool shape for `serverType` tools (no `input_schema`); cache_control handling unchanged.
- **OpenAI/Mistral adapter** skips `serverType` tools — no equivalent, must not emit a bogus empty-param function.

### Tests
- ✅ seam regression: memory server tool preserved via `serverType`
- ✅ Anthropic adapter regression: emits `{type,name}` with no `input_schema`
- ✅ llm-provider + orchestrator suites green (seam 23, openai/minimax 33; builds clean)

### Deploy
After merge → full deploy (middleware **and** web-ui harness).