### PR TITLE
feat(install): multiline setup fields for string/secret values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,14 @@ middleware/packages/harness-integration-confluence/
 middleware/packages/harness-integration-microsoft365/
 middleware/packages/harness-integration-odoo/
 
+# ─── Hub-distributed plugins ──────────────────────────────────────────────
+# GitHub integration + agent. Distributed via the Omadia Hub
+# (hub.omadia.ai), not committed here — the published .zip is the source of
+# truth. Kept on disk as a working-dev copy for local build/test/publish.
+middleware/packages/integration-github/
+middleware/packages/agent-github/
+middleware/test/integration-github/
+
 # Local-only screencast pipeline (Playwright recorder + GIF conversion).
 # Tooling for the README demo GIF; not part of the repo.
 /screencast/

--- a/docs/creating-plugins.md
+++ b/docs/creating-plugins.md
@@ -150,6 +150,9 @@ permissions:
   hat (sonst silent override).
 - `setup.fields[].type`: `string | url | secret | oauth | enum | boolean | integer | host_list`.
   `enum` braucht `enum: [{value,label}]`, `oauth` braucht `provider` + `scopes`.
+- `string`/`secret`-Felder können `multiline: true` setzen → Install-Drawer rendert
+  eine Textarea (z.B. für PEM-Keys). Ältere Cores ignorieren das Flag (Fallback:
+  Wert base64-encoden und im Plugin dekodieren).
 
 ---
 

--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -391,6 +391,10 @@ export interface InstallSetupField {
   provider?: string;
   scopes?: string[];
   pattern?: string;
+  /** Render as multi-row textarea (string/secret only) — for values that
+   *  contain newlines, e.g. PEM private keys. Older UIs ignore the flag
+   *  and fall back to a single-line input. */
+  multiline?: boolean;
 }
 
 export interface InstallSetupSchema {

--- a/middleware/src/plugins/installService.ts
+++ b/middleware/src/plugins/installService.ts
@@ -455,6 +455,9 @@ export function extractSetupSchema(
     if (f['default'] !== undefined) field.default = f['default'];
     const pattern = asString(f['pattern']);
     if (pattern) field.pattern = pattern;
+    if ((type === 'string' || type === 'secret') && f['multiline'] === true) {
+      field.multiline = true;
+    }
     if (type === 'enum') {
       const enumRaw = f['enum'];
       if (Array.isArray(enumRaw)) {

--- a/middleware/test/installService.test.ts
+++ b/middleware/test/installService.test.ts
@@ -7,10 +7,14 @@ import type {
   InstalledRegistry,
 } from '../src/plugins/installedRegistry.js';
 import {
+  extractSetupSchema,
   InstallError,
   InstallService,
 } from '../src/plugins/installService.js';
-import type { PluginCatalog } from '../src/plugins/manifestLoader.js';
+import type {
+  PluginCatalog,
+  PluginCatalogEntry,
+} from '../src/plugins/manifestLoader.js';
 import type { SecretVault } from '../src/secrets/vault.js';
 
 /**
@@ -431,5 +435,66 @@ describe('InstallError.details', () => {
   it('leaves details undefined when not provided (backward compat)', () => {
     const err = new InstallError('x', 'msg', 409);
     assert.equal(err.details, undefined);
+  });
+});
+
+describe('extractSetupSchema — multiline flag', () => {
+  function makeEntry(fields: unknown[]): PluginCatalogEntry {
+    return {
+      plugin: makePlugin({
+        id: 'multiline-test',
+        provides: [],
+        requires: [],
+        depends_on: [],
+      }),
+      manifest: { setup: { fields } },
+      source_path: '<test>/multiline-test.manifest.yaml',
+      source_kind: 'manifest-v1',
+    } as unknown as PluginCatalogEntry;
+  }
+
+  function fieldByKey(
+    schema: ReturnType<typeof extractSetupSchema>,
+    key: string,
+  ) {
+    return schema?.fields.find((f) => f.key === key);
+  }
+
+  it('passes multiline: true through for secret and string fields', () => {
+    const schema = extractSetupSchema(
+      makeEntry([
+        { key: 'private_key', type: 'secret', label: 'Key', multiline: true },
+        { key: 'notes', type: 'string', label: 'Notes', multiline: true },
+      ]),
+    );
+    assert.equal(fieldByKey(schema, 'private_key')?.multiline, true);
+    assert.equal(fieldByKey(schema, 'notes')?.multiline, true);
+  });
+
+  it('leaves multiline undefined when the manifest does not set it', () => {
+    const schema = extractSetupSchema(
+      makeEntry([{ key: 'token', type: 'secret', label: 'Token' }]),
+    );
+    assert.equal(fieldByKey(schema, 'token')?.multiline, undefined);
+  });
+
+  it('ignores multiline on non-text field types', () => {
+    const schema = extractSetupSchema(
+      makeEntry([
+        { key: 'count', type: 'integer', label: 'Count', multiline: true },
+        { key: 'endpoint', type: 'url', label: 'URL', multiline: true },
+      ]),
+    );
+    assert.equal(fieldByKey(schema, 'count')?.multiline, undefined);
+    assert.equal(fieldByKey(schema, 'endpoint')?.multiline, undefined);
+  });
+
+  it('ignores non-boolean multiline values', () => {
+    const schema = extractSetupSchema(
+      makeEntry([
+        { key: 'pem', type: 'secret', label: 'PEM', multiline: 'yes' },
+      ]),
+    );
+    assert.equal(fieldByKey(schema, 'pem')?.multiline, undefined);
   });
 });

--- a/web-ui/app/_components/store/setupForm.tsx
+++ b/web-ui/app/_components/store/setupForm.tsx
@@ -89,6 +89,21 @@ export function FieldRow({
             }
             className={common}
           />
+        ) : field.multiline &&
+          (field.type === 'string' || field.type === 'secret') ? (
+          <textarea
+            id={id}
+            name={field.key}
+            rows={6}
+            required={field.required}
+            placeholder={field.type === 'secret' ? '••••••••' : undefined}
+            defaultValue={
+              typeof field.default === 'string' ? field.default : ''
+            }
+            className={cn(common, 'resize-y font-mono text-xs leading-relaxed')}
+            autoComplete="off"
+            spellCheck={false}
+          />
         ) : (
           <input
             id={id}

--- a/web-ui/app/_lib/storeTypes.ts
+++ b/web-ui/app/_lib/storeTypes.ts
@@ -199,6 +199,7 @@ export interface InstallSetupField {
   provider?: string;
   scopes?: string[];
   pattern?: string;
+  multiline?: boolean;
 }
 
 export interface InstallSetupSchema {


### PR DESCRIPTION
## What
Add an optional `multiline: true` flag to `setup.fields` of type `string` or `secret`. When set, the install drawer renders a `<textarea>` instead of a single-line input, so values containing newlines (PEM private keys, certificates) survive intact to the configure endpoint.

## Why
Single-line `<input>` fields silently strip/mangle newlines, so a plugin can't accept a multi-line secret (e.g. an RSA private key) at install time. This is a small, reusable core primitive — any plugin needing a multi-line secret/string can opt in. Older cores ignore the flag and fall back to a single-line input.

## Test plan
- [x] `node --test test/installService.test.ts` in middleware — 16 pass (4 new `extractSetupSchema` multiline cases: passthrough for string/secret, undefined when unset, ignored on non-text types, ignored for non-boolean values)
- [x] `tsc --noEmit` green in both `middleware` and `web-ui`
- [x] manual: install drawer renders the field as a textarea; a 3-line value round-trips to the vault intact; non-multiline fields render unchanged

## Risk / blast radius
- Additive only: new optional manifest field + an extra render branch. No schema/migration changes.
- `PluginSetupField`/`InstallSetupField` gain an optional `multiline?: boolean` — backward compatible (absent → false → today's behavior).