### PR TITLE
fix(llm): register provider plugins on hot-install, not just at boot

### DIFF
--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -188,7 +188,10 @@ import { LocalDevPackageStore } from './plugins/localDevPackageStore.js';
 import { FileSecretVault, resolveMasterKey } from './secrets/fileVault.js';
 import { VaultBackupService } from './secrets/vaultBackup.js';
 import { createAnthropicLlmProvider } from './platform/anthropicLlmProvider.js';
-import { parseLlmProviderManifestBlock } from './platform/llmProviderManifest.js';
+import {
+  registerPluginLlmProvider,
+  unregisterPluginLlmProvider,
+} from './platform/llmProviderManifest.js';
 import { registerBuiltinLlmProviders } from './platform/builtinLlmProviders.js';
 import { BackgroundJobRegistry } from './platform/backgroundJobRegistry.js';
 import { ChatAgentWrapRegistry } from './platform/chatAgentWrapRegistry.js';
@@ -524,42 +527,54 @@ async function main(): Promise<void> {
   );
   await installedRegistry.load();
 
-  // Populate the LLM provider catalog from INSTALLED plugins that declare an
-  // `llm_provider` manifest block (provider-plugin seam). Done BEFORE
-  // `toolPluginRuntime.activateAllInstalled()` so the orchestrator resolves a
-  // plugin-contributed provider at its own activate(). A malformed block is
-  // logged and skipped — never fatal at boot.
-  for (const entry of pluginCatalog.list()) {
-    if (!installedRegistry.has(entry.plugin.id)) continue;
-    const block = (entry.manifest as { llm_provider?: unknown } | null)
-      ?.llm_provider;
-    if (block === undefined || block === null) continue;
+  // Register/unregister a plugin's `llm_provider` block into the catalog (which
+  // also overlays its models into the model-registry the admin Providers page
+  // reads). Thin wrappers over the shared platform helpers — they add the
+  // config-scope lookup, logging, and never-fatal error handling. Used by BOTH
+  // the boot loop AND the hot-install path (InstallService.onInstalled/
+  // onUninstall) so a provider plugin installed at runtime appears WITHOUT a
+  // restart.
+  const registerProviderFromPlugin = (pluginId: string): void => {
     try {
-      const descriptor = parseLlmProviderManifestBlock(block);
-      // Resolve a per-install baseURL override (e.g. MiniMax China endpoint).
-      // The override config key lives in the PROVIDER plugin's own config scope,
-      // so it is resolved here (where we have that scope) and baked into the
-      // descriptor — the orchestrator then just uses descriptor.baseURL.
-      let baseURL = descriptor.baseURL;
-      if (descriptor.baseUrlConfigKey !== undefined) {
-        const cfg = installedRegistry.get(entry.plugin.id)?.config ?? {};
-        const override = (cfg as Record<string, unknown>)[
-          descriptor.baseUrlConfigKey
-        ];
-        if (typeof override === 'string' && override.trim().length > 0) {
-          baseURL = override.trim();
-        }
-      }
-      llmProviderCatalog.register({ ...descriptor, baseURL });
-      console.log(
-        `[middleware] llm provider '${descriptor.id}' registered from ${entry.plugin.id} (${String(descriptor.models.length)} model(s), baseURL ${baseURL})`,
+      const descriptor = registerPluginLlmProvider(
+        pluginCatalog.get(pluginId)?.manifest,
+        installedRegistry.get(pluginId)?.config,
+        llmProviderCatalog,
       );
+      if (descriptor !== undefined) {
+        console.log(
+          `[middleware] llm provider '${descriptor.id}' registered from ${pluginId} (${String(descriptor.models.length)} model(s), baseURL ${descriptor.baseURL})`,
+        );
+      }
     } catch (err) {
       console.warn(
-        `[middleware] skipped llm_provider block in ${entry.plugin.id}:`,
+        `[middleware] skipped llm_provider block in ${pluginId}:`,
         err instanceof Error ? err.message : err,
       );
     }
+  };
+  const unregisterProviderFromPlugin = (pluginId: string): void => {
+    try {
+      const id = unregisterPluginLlmProvider(
+        pluginCatalog.get(pluginId)?.manifest,
+        llmProviderCatalog,
+      );
+      if (id !== undefined) {
+        console.log(
+          `[middleware] llm provider '${id}' unregistered (plugin ${pluginId} uninstalled)`,
+        );
+      }
+    } catch {
+      // malformed block never registered — nothing to clean up
+    }
+  };
+
+  // Populate the LLM provider catalog from INSTALLED plugins at boot. Done
+  // BEFORE `toolPluginRuntime.activateAllInstalled()` so the orchestrator
+  // resolves a plugin-contributed provider at its own activate().
+  for (const entry of pluginCatalog.list()) {
+    if (!installedRegistry.has(entry.plugin.id)) continue;
+    registerProviderFromPlugin(entry.plugin.id);
   }
 
   // Phase B (B1) — publish `pluginCapabilities@1` so the orchestrator's
@@ -933,6 +948,12 @@ async function main(): Promise<void> {
     registry: installedRegistry,
     vault: secretVault,
     onInstalled: async (agentId) => {
+      // A plugin may contribute an `llm_provider` block regardless of its kind
+      // (provider plugins ship as `extension`). Register it FIRST — mirroring
+      // the boot-time loop — so a runtime-installed provider lands in the
+      // catalog + model registry and appears on the admin Providers page
+      // without a restart. No-ops when the manifest declares no provider.
+      registerProviderFromPlugin(agentId);
       // Dispatch by manifest.identity.kind. Without this, every uploaded
       // package — channels, integrations, tools — is fed to the agent
       // runtime, which crashes (channel: wrong handle shape; integration:
@@ -963,6 +984,10 @@ async function main(): Promise<void> {
       }
     },
     onUninstall: async (agentId) => {
+      // Symmetric to onInstalled: drop a contributed provider + its models so
+      // an uninstalled provider plugin disappears from the admin Providers page
+      // without a restart. Runs BEFORE runtime deactivation/registry removal.
+      unregisterProviderFromPlugin(agentId);
       const kind = pluginCatalog.get(agentId)?.plugin.kind ?? 'agent';
       switch (kind) {
         case 'channel':

--- a/middleware/src/platform/llmProviderManifest.ts
+++ b/middleware/src/platform/llmProviderManifest.ts
@@ -11,6 +11,7 @@
  * `registerExternalModels`; this layer only enforces shape + required fields.
  */
 import type {
+  LlmProviderCatalog,
   LlmProviderDescriptor,
   ModelInfo,
   ProviderQuirks,
@@ -138,4 +139,55 @@ export function parseLlmProviderManifestBlock(
     ...(quirks !== undefined ? { quirks } : {}),
     models: modelsRaw.map(parseModel),
   };
+}
+
+/** Read a plugin manifest's `llm_provider` block and register the resulting
+ *  provider (and its models) into `catalog`. Resolves a per-install `baseURL`
+ *  override from the plugin's own config scope when the descriptor declares a
+ *  `base_url_config_key`. Returns the registered descriptor (with the resolved
+ *  baseURL) so the caller can log it, or `undefined` when the manifest declares
+ *  no provider. Throws on a MALFORMED block — the caller logs + skips.
+ *
+ *  Shared by the boot-time registration loop and the hot-install path
+ *  (InstallService.onInstalled) so a provider plugin installed at runtime lands
+ *  in the catalog + model registry — and thus the admin Providers page —
+ *  WITHOUT a middleware restart. Idempotent: `catalog.register` replaces an
+ *  existing same-id entry (disposing the old models). */
+export function registerPluginLlmProvider(
+  manifest: unknown,
+  config: Record<string, unknown> | undefined,
+  catalog: LlmProviderCatalog,
+): LlmProviderDescriptor | undefined {
+  const block = (manifest as { llm_provider?: unknown } | null | undefined)
+    ?.llm_provider;
+  if (block === undefined || block === null) return undefined;
+  const descriptor = parseLlmProviderManifestBlock(block);
+  let baseURL = descriptor.baseURL;
+  if (descriptor.baseUrlConfigKey !== undefined) {
+    const override = (config ?? {})[descriptor.baseUrlConfigKey];
+    if (typeof override === 'string' && override.trim().length > 0) {
+      baseURL = override.trim();
+    }
+  }
+  const resolved = { ...descriptor, baseURL };
+  catalog.register(resolved);
+  return resolved;
+}
+
+/** Counterpart to {@link registerPluginLlmProvider}: drop a plugin's contributed
+ *  provider (and its models) from `catalog`. Returns the unregistered provider
+ *  id, or `undefined` when the manifest declares no provider OR the provider was
+ *  not registered. Throws only on a malformed block (which never registered) —
+ *  the caller ignores. */
+export function unregisterPluginLlmProvider(
+  manifest: unknown,
+  catalog: LlmProviderCatalog,
+): string | undefined {
+  const block = (manifest as { llm_provider?: unknown } | null | undefined)
+    ?.llm_provider;
+  if (block === undefined || block === null) return undefined;
+  const { id } = parseLlmProviderManifestBlock(block);
+  if (!catalog.has(id)) return undefined;
+  catalog.unregister(id);
+  return id;
 }

--- a/middleware/test/llmProviderPluginRegistration.test.ts
+++ b/middleware/test/llmProviderPluginRegistration.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression for the runtime provider-plugin registration gap: a provider
+ * plugin installed AFTER boot must land in the catalog AND the global model
+ * registry — the data the admin Providers page derives its list from
+ * (`adminProviders` builds providers from `listModels()`) — without a restart,
+ * and must disappear again on uninstall.
+ *
+ * Before the fix, `llm_provider` blocks were only registered by a boot-time
+ * loop; a plugin installed at runtime (e.g. MiniMax) activated as a tool
+ * extension but never contributed its provider, so it was missing from the
+ * admin page until the next middleware restart.
+ */
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+
+import { LlmProviderCatalog, listModelsByProvider } from '@omadia/llm-provider';
+
+import {
+  registerPluginLlmProvider,
+  unregisterPluginLlmProvider,
+} from '../src/platform/llmProviderManifest.js';
+
+// A minimal MiniMax-shaped manifest with an `llm_provider` block in the exact
+// snake_case shape a plugin ships — and `kind: extension`, mirroring how the
+// real MiniMax plugin is published. A unique provider id keeps the global model
+// overlay clean across the suite.
+const MINIMAX_MANIFEST = {
+  kind: 'extension',
+  llm_provider: {
+    id: 'minimax-test',
+    label: 'MiniMax (test)',
+    wire_format: 'openai-compatible',
+    default_base_url: 'https://api.minimax.io/v1',
+    base_url_config_key: 'minimax_base_url',
+    quirks: {
+      max_tokens_field: 'max_completion_tokens',
+      drop_tool_choice: true,
+    },
+    models: [
+      {
+        id: 'minimax-test:MiniMax-Text-01',
+        model_id: 'MiniMax-Text-01',
+        label: 'MiniMax Text 01',
+        class: 'frontier',
+        class_default: true,
+        max_tokens: 8192,
+        context_window: 1_000_000,
+        vision: false,
+      },
+    ],
+  },
+};
+
+const catalog = new LlmProviderCatalog();
+afterEach(() => catalog.clear());
+
+test('registers a runtime-installed provider + its models (admin-page path)', () => {
+  const desc = registerPluginLlmProvider(MINIMAX_MANIFEST, undefined, catalog);
+  assert.equal(desc?.id, 'minimax-test');
+  assert.equal(desc?.baseURL, 'https://api.minimax.io/v1');
+  assert.equal(catalog.has('minimax-test'), true);
+  // The regression: these stayed empty for a post-boot install, so the admin
+  // Providers page (built from listModels) never showed the provider.
+  const models = listModelsByProvider('minimax-test');
+  assert.equal(models.length, 1);
+  assert.equal(models[0]?.modelId, 'MiniMax-Text-01');
+});
+
+test('applies a per-install baseURL override from plugin config', () => {
+  const desc = registerPluginLlmProvider(
+    MINIMAX_MANIFEST,
+    { minimax_base_url: 'https://api.minimaxi.chat/v1' },
+    catalog,
+  );
+  assert.equal(desc?.baseURL, 'https://api.minimaxi.chat/v1');
+  assert.equal(
+    catalog.get('minimax-test')?.baseURL,
+    'https://api.minimaxi.chat/v1',
+  );
+});
+
+test('unregister drops the provider + its models (uninstall path)', () => {
+  registerPluginLlmProvider(MINIMAX_MANIFEST, undefined, catalog);
+  assert.equal(listModelsByProvider('minimax-test').length, 1);
+
+  const id = unregisterPluginLlmProvider(MINIMAX_MANIFEST, catalog);
+  assert.equal(id, 'minimax-test');
+  assert.equal(catalog.has('minimax-test'), false);
+  assert.equal(listModelsByProvider('minimax-test').length, 0);
+});
+
+test('a manifest with no llm_provider block is a safe no-op', () => {
+  assert.equal(
+    registerPluginLlmProvider({ kind: 'tool' }, undefined, catalog),
+    undefined,
+  );
+  assert.equal(unregisterPluginLlmProvider({ kind: 'tool' }, catalog), undefined);
+  assert.equal(registerPluginLlmProvider(undefined, undefined, catalog), undefined);
+  assert.equal(unregisterPluginLlmProvider(null, catalog), undefined);
+});


### PR DESCRIPTION
## Problem — installed provider plugin doesn't appear in admin Providers

Installing the MiniMax provider plugin (Store → install) leaves it **absent from the admin Providers page** until the middleware is restarted.

### Root cause
The admin Providers list is derived from the global model registry (`adminProviders.ts`: `[...new Set(listModels().map(m => m.provider))]`). A plugin's `llm_provider` manifest block is registered into the `LlmProviderCatalog` (which overlays its models into that registry) **only by a one-shot loop at middleware boot** (`index.ts`).

A plugin installed at **runtime** goes through `InstallService.onInstalled`, which dispatches by `kind` and activates it as a tool **extension** (provider plugins ship `kind: extension`) — but **never registers its `llm_provider` block**. So no models → provider missing from the page until the next boot (when the loop re-runs and picks it up).

Confirmed in production logs: plugin installed 08:21, `ACTIVATED … (extension)`, no `llm provider … registered` line; boot loop had already run at 08:00.

### Fix
Run the same registration on the hot-install path, symmetric on uninstall.

- Extract the boot loop's logic into pure, testable helpers `registerPluginLlmProvider` / `unregisterPluginLlmProvider` (`platform/llmProviderManifest.ts`) — resolve the per-install `baseURL` override, register/unregister into the catalog (which overlays + disposes models).
- `index.ts`: boot loop now calls the shared helper; `InstallService.onInstalled` registers the provider (regardless of `kind`), `onUninstall` unregisters it so it disappears without a restart. Idempotent, never fatal.

### Tests
- ✅ new `llmProviderPluginRegistration.test.ts`: register → provider + models visible via `listModelsByProvider` (the admin-page path); baseURL override applies; unregister removes provider + models; no-provider manifest no-ops.
- ✅ adjacent suites green (installService, installServicePrivacyMode, adminProvidersRoute, model registry — 43 tests); `tsc --noEmit` + eslint clean.

### Follow-up (noted, out of scope)
A `baseURL` override entered AFTER install (via reactivate) isn't yet re-registered — install-time config is captured. Default baseURL works for all current providers.

### Deploy
After merge → full deploy (middleware + web-ui). Existing installs (incl. the already-installed MiniMax) get picked up on the deploy's restart; future runtime installs no longer need one.