### PR TITLE
fix(ui-orchestrator): canvas composition uses model classes + mirror provider keys (fixes stuck "Working on it…")

### DIFF
--- a/middleware/packages/omadia-ui-orchestrator/manifest.yaml
+++ b/middleware/packages/omadia-ui-orchestrator/manifest.yaml
@@ -41,9 +41,9 @@ setup:
     - key: "ui_orchestrator_model"
       type: "string"
       label: "Composition model"
-      help: "Fast-tier model for the skeleton composition call. Pin to a Sonnet id if the spike tree-validity gate (<95% first-attempt schema-valid) fails — implementation-plan §8 risk #1."
+      help: "Skeleton composition model. Default 'class:fast' = always the cheapest tier on whatever LLM provider is active (anthropic→haiku, openai→gpt-mini, mistral→small). Pin a concrete id or 'class:balanced' only if the tree-validity gate (<95% first-attempt schema-valid) fails — implementation-plan §8 risk #1."
       required: false
-      default: "claude-haiku-4-5"
+      default: "class:fast"
     - key: "canvas_output_tools"
       type: "string"
       label: "Canvas-output tool allow-set"
@@ -54,14 +54,18 @@ setup:
 permissions:
   filesystem:
     scratch: false
-  # The skeleton composition call (composeSkeleton): fast tier by default,
-  # Sonnet allowed as the documented fallback when the validity gate fails.
+  # The skeleton composition call (composeSkeleton): cheapest tier by default.
+  # Provider-agnostic class refs — resolved against the ACTIVE provider in
+  # createLlmAccessor, so this gate is byte-identical to the old anthropic lock
+  # (class:fast→claude-haiku, class:balanced→claude-sonnet) AND works on
+  # openai/mistral without edits. class:balanced stays allowed as the documented
+  # fallback when the validity gate fails.
   # Per turn: 1 composition call + at most 1 repair retry; the cap of 8 leaves
   # headroom for later 9b slices (patch recomposition, suggestedActions).
   llm:
     models_allowed:
-      - "claude-haiku-4-5*"
-      - "claude-sonnet-4-*"
+      - "class:fast"
+      - "class:balanced"
     # NOTE: the LlmAccessor's calls counter is scoped to the plugin CONTEXT,
     # which for an extension plugin is created once per activation — so this
     # cap is effectively a LIFETIME budget, not per-invocation. With the old

--- a/middleware/packages/omadia-ui-orchestrator/src/plugin.ts
+++ b/middleware/packages/omadia-ui-orchestrator/src/plugin.ts
@@ -32,10 +32,11 @@ import { synthesizeSurfaceEvents } from './surfaceSynthesis.js';
  * the bundle a canvas channel reaches via `channel.dispatch_service` (PR-6).
  *
  * For a **canvas turn** (one that carries `input.canvasSessionId`) the agent now
- * runs the Haiku composition step before delegating:
+ * runs the cheapest-class composition step before delegating:
  *
- *   1. **Skeleton-first** — `composeSkeleton` (fast model from
- *      `ui_orchestrator_model`, validator-gated with one repair retry,
+ *   1. **Skeleton-first** — `composeSkeleton` (cheapest fast-class model —
+ *      `class:fast` by default, overridable via `ui_orchestrator_model`;
+ *      validator-gated with one repair retry,
  *      deterministic fallback) yields a `surface_snapshot` (revision "0")
  *      BEFORE the slow main turn starts.
  *   2. **Requirement handoff** — the delegated main turn's user message carries
@@ -70,7 +71,13 @@ export const CANVAS_CHAT_AGENT_SERVICE = 'canvasChatAgent';
 
 const CANVAS_PROTOCOL_VERSION = '1.0';
 const OPS_CATALOG_VERSION = '1.0';
-const DEFAULT_COMPOSITION_MODEL = 'claude-haiku-4-5';
+// Skeleton composition is a low-stakes structural placeholder, so it ALWAYS
+// runs on the cheapest tier — the `class:fast` ref resolves (in createLlmAccessor)
+// to the active provider's fast/cheapest model: anthropic→claude-haiku, openai→
+// gpt-5.4-mini, mistral→mistral-small. Provider-agnostic: pin a concrete id or a
+// bigger class via the `ui_orchestrator_model` config only if the tree-validity
+// gate (<95% first-attempt schema-valid) demands it.
+const DEFAULT_COMPOSITION_MODEL = 'class:fast';
 
 export interface UiOrchestratorPluginHandle {
   close(): Promise<void>;

--- a/middleware/src/plugins/bootstrap.ts
+++ b/middleware/src/plugins/bootstrap.ts
@@ -2,7 +2,10 @@ import { createHash, randomBytes } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-import { providerApiKeyVaultKey } from '@omadia/llm-provider';
+import {
+  legacyProviderApiKeyVaultKey,
+  providerApiKeyVaultKey,
+} from '@omadia/llm-provider';
 import { parseCapabilityRef } from '@omadia/plugin-api';
 
 import type { Config } from '../config.js';
@@ -21,6 +24,9 @@ const MEMORY_POSTGRES_ID = '@omadia/memory-postgres';
 const ORCHESTRATOR_TOOL_ID = '@omadia/orchestrator';
 const ORCHESTRATOR_EXTRAS_TOOL_ID = '@omadia/orchestrator-extras';
 const VERIFIER_TOOL_ID = '@omadia/verifier';
+const UI_ORCHESTRATOR_TOOL_ID = '@omadia/ui-orchestrator';
+/** Providers whose API keys are mirrored into the canvas plugin's scope. */
+const MIRRORED_PROVIDERS = ['anthropic', 'openai', 'mistral'] as const;
 
 // S+11-2b: KG providers are operator-managed (RequiresWizard / install UI).
 // Both sibling plugins declare `provides: knowledgeGraph@1` —
@@ -256,6 +262,10 @@ export async function runLegacyBootstrap(deps: BootstrapDeps): Promise<void> {
   await bootstrapOrchestratorExtrasFromEnv(deps);
   await bootstrapVerifierFromEnv(deps);
   await bootstrapOrchestratorFromEnv(deps);
+  // Canvas plugin makes its own ctx.llm call but has no provider key of its own
+  // — mirror the orchestrator's keys into its scope (must run AFTER the
+  // orchestrator bootstrap so the source keys exist).
+  await mirrorProviderKeysToUiOrchestrator(deps);
   if (deps.builtInStore) {
     await bootstrapBuiltInPackages(deps);
   }
@@ -845,6 +855,49 @@ async function bootstrapVerifierFromEnv(
  * Idempotent: once the registry entry exists we never overwrite the
  * operator's settings.
  */
+/**
+ * The canvas Tier-2 composer (@omadia/ui-orchestrator) makes its OWN per-agent
+ * `ctx.llm` skeleton call. But provider API keys are entered per-plugin (they
+ * land in the orchestrator's vault scope) and vaults have NO shared fallback
+ * (see secrets/vault.ts) — and the canvas plugin has no provider-key setup
+ * field and was absent from every key-distribution list. Net effect: the canvas
+ * never had ANY provider key in its scope, so every canvas turn failed with
+ * "no 'llm' provider is registered" → empty fallback skeleton, even with the
+ * provider showing CONNECTED in the admin UI.
+ *
+ * Mirror the orchestrator's connected provider keys into the canvas plugin's
+ * scope. Non-destructive (skips a key the canvas already holds); no plaintext
+ * ever leaves the kernel (vault → vault copy). Runs each boot so a provider
+ * connected later propagates on the next restart.
+ */
+async function mirrorProviderKeysToUiOrchestrator(
+  deps: BootstrapDeps,
+): Promise<void> {
+  const log = deps.log ?? ((m) => console.log(m));
+  const vaultKeys: string[] = [];
+  for (const provider of MIRRORED_PROVIDERS) {
+    vaultKeys.push(providerApiKeyVaultKey(provider));
+    const legacy = legacyProviderApiKeyVaultKey(provider);
+    if (legacy !== undefined) vaultKeys.push(legacy);
+  }
+  const updates: Record<string, string> = {};
+  for (const key of vaultKeys) {
+    const existing = await deps.vault.get(UI_ORCHESTRATOR_TOOL_ID, key);
+    if (typeof existing === 'string' && existing.trim().length > 0) continue;
+    const source = await deps.vault.get(ORCHESTRATOR_TOOL_ID, key);
+    if (typeof source === 'string' && source.trim().length > 0) {
+      updates[key] = source;
+    }
+  }
+  const count = Object.keys(updates).length;
+  if (count > 0) {
+    await deps.vault.setMany(UI_ORCHESTRATOR_TOOL_ID, updates);
+    log(
+      `[bootstrap] mirrored ${String(count)} provider key(s) → ${UI_ORCHESTRATOR_TOOL_ID} (canvas LLM enablement)`,
+    );
+  }
+}
+
 async function bootstrapOrchestratorFromEnv(
   deps: BootstrapDeps,
 ): Promise<void> {


### PR DESCRIPTION
## Problem

On `main`, the canvas (ui-orchestrator) is stuck on the static fallback skeleton — the UI shows **"Working on it…"** and never fills in. Middleware log:

```
[@omadia/ui-orchestrator] [composition] llm call failed → fallback skeleton:
  plugin '@omadia/ui-orchestrator' tried to call model 'class:balanced'
  — not in manifest's permissions.llm.models_allowed whitelist
```

Two independent gaps, both surfaced by the "everything is a plugin" / model-class migration that landed on `main`:

1. **Manifest whitelist not migrated to classes.** The skeleton composition call resolves its model via the new provider-agnostic class refs (`class:fast` / `class:balanced`), but the ui-orchestrator manifest's `permissions.llm.models_allowed` still listed only concrete `claude-haiku-4-5*` / `claude-sonnet-4-*` globs → every composition call is rejected → static fallback skeleton.
2. **Canvas has no provider key.** The ui-orchestrator makes its own `ctx.llm` composition call but, unlike the main orchestrator, never had a provider key mirrored into its scope — so even with the whitelist fixed the call would fail with no credentials.

## Fix

- `manifest.yaml`: `models_allowed` → `class:fast` / `class:balanced`; default composition model → `class:fast` (cheapest tier on whatever provider is active — anthropic→haiku, openai→gpt-mini, mistral→small). Provider-agnostic, byte-identical gating to the old anthropic lock.
- `plugin.ts`: skeleton composition uses the `class:fast` default.
- `bootstrap.ts`: `mirrorProviderKeysToUiOrchestrator()` — mirror the orchestrator's provider keys (anthropic/openai/mistral, canonical + legacy vault keys) into the ui-orchestrator scope at boot. Idempotent; runs after the orchestrator bootstrap so the source keys exist.

## Scope / provenance

This is the **minimal, isolated** canvas fix cherry-picked from the larger `feat/ui-orchestrator-cheapest-skeleton-model` branch. The rest of that branch (a second Mistral-provider implementation) is **obsolete** — `main` already ships Mistral via the plugin-based `builtinLlmProviders.ts`, so only the ui-orchestrator bits are kept here. Touches only the ui-orchestrator package + `bootstrap.ts`; `main` does not modify either, so it applies conflict-free.

## Verification

- `tsc --noEmit` clean: ui-orchestrator package + `bootstrap.ts`.
- Middleware Docker image rebuilds clean; container boots healthy.
- Final UI check: run a canvas turn in the desktop app — composition now renders instead of "Working on it…".
