### PR TITLE
feat(llm-provider): support keyless local providers (e.g. Ollama)

### DIFF
--- a/middleware/packages/llm-provider/src/openaiClient.ts
+++ b/middleware/packages/llm-provider/src/openaiClient.ts
@@ -17,9 +17,11 @@ import OpenAI from 'openai';
 export type OpenAiClient = OpenAI;
 
 export interface OpenAiClientOptions {
-  /** May be empty on cold boots before a provider is connected — the SDK
-   *  constructor tolerates it; the first real call fails with an auth error
-   *  (classified non-retryable). */
+  /** Must be non-empty: the OpenAI SDK constructor REJECTS a falsy apiKey
+   *  ("Missing credentials… set OPENAI_API_KEY"). Keyless providers (local
+   *  self-hosted, e.g. Ollama) pass a placeholder via resolveLlmProvider; the
+   *  server ignores the Authorization header. A wrong key fails at first call
+   *  with an auth error (classified non-retryable). */
   readonly apiKey: string;
   /** Override the API base URL for OpenAI-compatible servers (Mistral, Ollama,
    *  vLLM, Azure OpenAI). Omit for api.openai.com. */

--- a/middleware/packages/llm-provider/src/providerCatalog.ts
+++ b/middleware/packages/llm-provider/src/providerCatalog.ts
@@ -56,6 +56,11 @@ export interface ProviderPolicy {
   /** Provider is hosted in the EU (no third-country transfer) — surfaces a note.
    *  Default (omitted) = false. */
   readonly euHosted?: boolean;
+  /** Whether this provider needs an API key to be usable. Local / self-hosted
+   *  providers (e.g. Ollama) run without credentials — set `false` so the
+   *  factory builds the provider with an empty key instead of treating the
+   *  missing key as "not connected". Default (omitted) = true. */
+  readonly requiresApiKey?: boolean;
 }
 
 export class LlmProviderCatalog {

--- a/middleware/packages/llm-provider/src/providerFactory.ts
+++ b/middleware/packages/llm-provider/src/providerFactory.ts
@@ -66,15 +66,27 @@ export interface ResolveLlmProviderOptions {
 export async function resolveLlmProvider(
   opts: ResolveLlmProviderOptions,
 ): Promise<LlmProvider | undefined> {
-  const apiKey = await readProviderApiKey(opts.getSecret, opts.providerId);
-  if (apiKey === undefined) return undefined;
+  // Resolve the catalog descriptor first — it tells us whether this provider
+  // even needs a key. A plugin-contributed provider (the catalog) declares its
+  // wireFormat; the built-in `anthropic` default keeps the Anthropic wire format
+  // with no descriptor.
+  const descriptor = opts.catalog?.get(opts.providerId);
 
-  // Resolve the wire format + baseURL once. A plugin-contributed provider (the
-  // catalog) declares its wireFormat; the built-in `anthropic` default keeps the
-  // Anthropic wire format with no descriptor. baseURL precedence: explicit
+  const apiKey = await readProviderApiKey(opts.getSecret, opts.providerId);
+  // Local / self-hosted providers (e.g. Ollama) declare `policy.requiresApiKey:
+  // false` and run without credentials — build them with an empty key. For every
+  // other provider, a missing key means "not connected" → no provider.
+  const keyless = descriptor?.policy?.requiresApiKey === false;
+  if (apiKey === undefined && !keyless) return undefined;
+  // The OpenAI/Anthropic SDK constructors reject a falsy apiKey, so a keyless
+  // provider (no credential by design — Ollama ignores the Authorization header)
+  // gets a non-empty placeholder instead of ''. Only reached when apiKey is
+  // genuinely absent AND the provider declared requiresApiKey:false.
+  const resolvedKey = apiKey ?? 'no-key-required';
+
+  // Resolve the wire format + baseURL once. baseURL precedence: explicit
   // opts.baseURL (self-hosted gateway / Azure) > catalog descriptor > a well-known
   // default (knownProviderBaseUrl, e.g. mistral) so the operator never types it.
-  const descriptor = opts.catalog?.get(opts.providerId);
   const wireFormat =
     descriptor?.wireFormat ??
     (opts.providerId === 'anthropic' ? 'anthropic' : 'openai-compatible');
@@ -87,7 +99,7 @@ export async function resolveLlmProvider(
     // anthropic default). Quirks are openai-only and do not apply here.
     return createAnthropicProvider({
       client: createAnthropicClient({
-        apiKey,
+        apiKey: resolvedKey,
         ...(opts.maxRetries !== undefined ? { maxRetries: opts.maxRetries } : {}),
         ...(baseURL !== undefined ? { baseURL } : {}),
       }),
@@ -110,7 +122,7 @@ export async function resolveLlmProvider(
     );
   }
   return createOpenAiProvider({
-    apiKey,
+    apiKey: resolvedKey,
     ...(baseURL !== undefined ? { baseURL } : {}),
     ...(opts.maxRetries !== undefined ? { maxRetries: opts.maxRetries } : {}),
     ...(opts.providerId !== 'openai' ? { id: opts.providerId } : {}),

--- a/middleware/src/platform/llmProviderManifest.ts
+++ b/middleware/src/platform/llmProviderManifest.ts
@@ -14,6 +14,7 @@ import type {
   LlmProviderCatalog,
   LlmProviderDescriptor,
   ModelInfo,
+  ProviderPolicy,
   ProviderQuirks,
 } from '@omadia/llm-provider';
 
@@ -110,6 +111,24 @@ function parseQuirks(raw: unknown): ProviderQuirks | undefined {
   };
 }
 
+/** Parse the optional `policy` block (operator-UI compliance hints). All
+ *  fields optional; non-booleans are ignored so a typo can't flip a default. */
+function parsePolicy(raw: unknown): ProviderPolicy | undefined {
+  if (raw === undefined) return undefined;
+  const rec = asRecord(raw);
+  return {
+    ...(typeof rec['requires_avv_disclosure'] === 'boolean'
+      ? { requiresAvvDisclosure: rec['requires_avv_disclosure'] }
+      : {}),
+    ...(typeof rec['eu_hosted'] === 'boolean'
+      ? { euHosted: rec['eu_hosted'] }
+      : {}),
+    ...(typeof rec['requires_api_key'] === 'boolean'
+      ? { requiresApiKey: rec['requires_api_key'] }
+      : {}),
+  };
+}
+
 /** Map a raw `llm_provider` manifest block to a typed descriptor, or throw. */
 export function parseLlmProviderManifestBlock(
   raw: unknown,
@@ -128,6 +147,7 @@ export function parseLlmProviderManifestBlock(
   // Quirks are openai-only; ignore any declared on an anthropic-wire provider.
   const quirks =
     wireFormat === 'openai-compatible' ? parseQuirks(rec['quirks']) : undefined;
+  const policy = parsePolicy(rec['policy']);
   return {
     id: reqString(rec, 'id'),
     label: reqString(rec, 'label'),
@@ -137,6 +157,7 @@ export function parseLlmProviderManifestBlock(
       ? { baseUrlConfigKey: optString(rec, 'base_url_config_key') }
       : {}),
     ...(quirks !== undefined ? { quirks } : {}),
+    ...(policy !== undefined ? { policy } : {}),
     models: modelsRaw.map(parseModel),
   };
 }


### PR DESCRIPTION
## What

Lets a manifest-contributed LLM provider declare that it needs **no API key**, so a **local / self-hosted provider like [Ollama](https://ollama.com)** works end-to-end as an admin-selectable provider.

## Why

The provider seam assumed every provider needs a key. A keyless provider broke in two ways:

1. **Orchestrator 503** — `resolveLlmProvider()` returned `undefined` when no vault key was present, so `@omadia/orchestrator` never published `chatAgent@1` → `GET /v1/operator/agents` returned **503** (log: `no API key for provider 'ollama' — chatAgent@1 capability NOT published`).
2. **Wrong AVV disclosure** — the admin Providers page showed the *AVV / Art. 28 DSGVO third-party-processing* disclosure for a local provider, where there is no third-party processor at all.

Both stem from the same root, and a manifest provider had **no way** to say otherwise: `parseLlmProviderManifestBlock` silently dropped the `policy` block.

## Changes

- `ProviderPolicy.requiresApiKey?: boolean` (default `true`).
- `parseLlmProviderManifestBlock` now parses the manifest `policy` block (`requires_api_key` / `requires_avv_disclosure` / `eu_hosted`) — previously ignored.
- `resolveLlmProvider` resolves the catalog descriptor **before** the key check; when `policy.requiresApiKey === false` it builds the provider with a non-empty placeholder key (the OpenAI/Anthropic SDK constructors reject a falsy `apiKey`; the local server ignores the `Authorization` header).
- Corrects the stale `openaiClient` comment that claimed the SDK tolerates an empty `apiKey` (it does not).

A provider can now declare:

```yaml
llm_provider:
  policy:
    requires_api_key: false
    requires_avv_disclosure: false
```

to run keyless and suppress the disclosure. Existing providers are unaffected (defaults unchanged). The admin Providers page already reads `descriptor.policy.requiresAvvDisclosure`, so the AVV note disappears once the manifest carries the policy.

## Testing

Verified on a live local stack (omadia-test): with an Ollama provider declaring `requires_api_key: false`, the middleware boots with `chatAgent@1 published (model=llama3.2:3b …)`, `/v1/operator/agents` is no longer 503, and the AVV disclosure is gone. Embeddings/cloud providers unchanged.