### PR TITLE
feat(orchestrator-extras): relevance-gate + LLM-agnostic judge for cross-session recall

### DIFF
--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -3637,7 +3637,9 @@
       }
     },
     "node_modules/botframework-streaming/node_modules/ws": {
-      "version": "7.5.10",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
@@ -4954,14 +4956,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -5199,7 +5203,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6911,7 +6917,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
@@ -58,9 +58,10 @@ export interface ContextRetrieverOptions {
   memoryLimit?: number;
   /** Max excerpt-quotes rendered per surfaced MK. Default 2. */
   excerptsPerMemory?: number;
-  /** Min cosine similarity for both MK and excerpt search. Default 0.5
-   *  — higher than Turn-search (0.3) because curated memory should
-   *  surface only on a strong match. */
+  /** Min cosine similarity for both MK and excerpt search. Default 0.6
+   *  — raised from 0.5 so curated memory surfaces only on a strong match
+   *  (loosely-related insights were leaking into the "earlier sessions"
+   *  panel). Higher than Turn-search (0.3). */
   memoryMinSimilarity?: number;
   /** Score multiplier for memory-origin hits in the assembler. Default
    *  1.2 — curated memory ranks above raw FTS hits at similar cosine. */
@@ -85,8 +86,21 @@ export interface ContextRetrieverOptions {
   processRecallDisabled?: boolean;
   /** Max stored processes surfaced per turn. Default 3. */
   processLimit?: number;
-  /** Min hybrid score for a process to be surfaced. Default 0.3. */
+  /** Min hybrid score for a process to be surfaced. Default 0.45 —
+   *  raised from 0.3 so weakly-related processes no longer surface in the
+   *  "earlier sessions" panel. */
   processMinScore?: number;
+  /**
+   * Turn-level recall gate. When true (default), the three CROSS-SESSION
+   * recall legs (plans / processes / insights) only run when the user
+   * message yields at least one candidate term (`extractCandidateTerms`).
+   * Greetings, acknowledgements and bare continuations ("ok", "weiter",
+   * "danke") carry no term → the legs are skipped entirely and the panel
+   * stays empty, instead of dumping the most-recent-N regardless of topic.
+   * In-session tail / entity / FTS recall is unaffected. Disable with
+   * `kg_recall_require_terms=false` to restore the always-on behaviour.
+   */
+  recallRequiresTerms?: boolean;
 }
 
 export interface ContextBuildInput {
@@ -271,7 +285,7 @@ const DEFAULTS: Required<
   memoryRecallDisabled: false,
   memoryLimit: 3,
   excerptsPerMemory: 2,
-  memoryMinSimilarity: 0.5,
+  memoryMinSimilarity: 0.6,
   memoryBoostFactor: 1.2,
   // Cross-session recall probe defaults.
   teamVisibility: false,
@@ -280,7 +294,8 @@ const DEFAULTS: Required<
   planOpenOnly: true,
   processRecallDisabled: false,
   processLimit: 3,
-  processMinScore: 0.3,
+  processMinScore: 0.45,
+  recallRequiresTerms: true,
 };
 
 // Tiny, language-agnostic stopword list. We keep it short because the real
@@ -465,6 +480,17 @@ export class ContextRetriever {
         : {}),
     };
 
+    // Turn-level recall gate. The three CROSS-SESSION legs only fire when the
+    // message carries a topical anchor; a term-less turn (greeting / ack / bare
+    // continuation) would otherwise surface the most-recent-N plans/processes/
+    // insights regardless of relevance — the "earlier sessions" panel showing
+    // unrelated content. In-session recall (tail / entity / FTS) is unaffected.
+    const runCrossSessionRecall =
+      !this.opts.recallRequiresTerms || extractedTerms.length > 0;
+    const emptyPlans: Promise<RecalledPlan[]> = Promise.resolve([]);
+    const emptyProcesses: Promise<RecalledProcess[]> = Promise.resolve([]);
+    const emptyMemory: Promise<MemoryRecallHit[]> = Promise.resolve([]);
+
     const [
       tail,
       entityHits,
@@ -478,9 +504,9 @@ export class ContextRetriever {
       this.loadEntityHits(buildInput, extractedTerms),
       this.loadFtsHits(buildInput),
       this.loadAgentPriorities(input.agentId),
-      this.loadPlanHits(buildInput),
-      this.loadProcessHits(buildInput),
-      this.loadMemoryHits(buildInput),
+      runCrossSessionRecall ? this.loadPlanHits(buildInput) : emptyPlans,
+      runCrossSessionRecall ? this.loadProcessHits(buildInput) : emptyProcesses,
+      runCrossSessionRecall ? this.loadMemoryHits(buildInput) : emptyMemory,
     ]);
 
     // Build candidate pool. Tail first (chronological → fills first).
@@ -670,6 +696,25 @@ export class ContextRetriever {
     console.error(
       `[context:assembled] scope=${scope} agent=${input.agentId} pool=${String(filtered.length)} included=${String(included.length)} excluded=${String(excluded.length)} compact=${String(compactMode)} plans=${String(recalled.plans.length)} processes=${String(recalled.processes.length)} insights=${String(recalled.insights.length)} tokens=${String(tokensUsed)}/${String(budgetTokens)}`,
     );
+    // Per-item recall trace — lets us see WHY something surfaced (and tune the
+    // floors empirically) instead of guessing from aggregate counts. Only
+    // emitted when the probe actually surfaced something.
+    if (
+      recalled.plans.length > 0 ||
+      recalled.processes.length > 0 ||
+      recalled.insights.length > 0
+    ) {
+      const plansTrace = recalled.plans.map((p) => p.planId).join(',');
+      const procTrace = recalled.processes
+        .map((p) => `${p.id}:${p.score.toFixed(2)}`)
+        .join(',');
+      const insTrace = recalled.insights
+        .map((i) => `${i.kind}:${i.score.toFixed(2)}`)
+        .join(',');
+      console.error(
+        `[context:recall] scope=${scope} gate=${runCrossSessionRecall ? 'open' : 'closed'} terms=[${extractedTerms.join(',')}] plans=[${plansTrace}] processes=[${procTrace}] insights=[${insTrace}]`,
+      );
+    }
 
     return {
       text,
@@ -810,6 +855,12 @@ export class ContextRetriever {
     const terms = extractCandidateTerms(input.userMessage).map((t) =>
       t.toLowerCase(),
     );
+    // Term-less turns (greeting / ack / bare continuation) get NO plan recall:
+    // without a topical anchor the only ranking signal is recency, which dumps
+    // the latest open plans regardless of topic — the reported "earlier
+    // sessions" bug. The turn-level gate in `assembleForBudget` normally
+    // prevents this path being reached; this is the defensive floor.
+    if (terms.length === 0) return [];
     try {
       // Over-fetch a wider candidate window so the relevance filter has
       // something to choose from (recency-only would pick the latest N).
@@ -849,13 +900,10 @@ export class ContextRetriever {
         // Relevance = how many query terms appear in strategy + step goals.
         const haystack =
           `${String(p.props['strategy'] ?? '')} ${goalTexts.join(' ')}`.toLowerCase();
-        const score =
-          terms.length === 0
-            ? 0
-            : terms.filter((t) => haystack.includes(t)).length;
-        // Drop topically-unrelated plans. With no query terms (bare
-        // continuation) every plan scores 0 → keep the recency fallback.
-        if (terms.length > 0 && score === 0) continue;
+        const score = terms.filter((t) => haystack.includes(t)).length;
+        // Drop topically-unrelated plans (no shared term). `terms` is
+        // guaranteed non-empty here (early return above).
+        if (score === 0) continue;
         scored.push({
           hit: {
             planId: p.id,

--- a/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
@@ -18,6 +18,11 @@ import {
   type TurnSearchHit,
 } from '@omadia/plugin-api';
 
+import type {
+  RecallCandidate,
+  RecallRelevanceJudge,
+} from './recallRelevanceJudge.js';
+
 export interface ContextRetrieverOptions {
   /** Verbatim tail depth (most recent turns of the active chat). */
   tailSize?: number;
@@ -101,6 +106,14 @@ export interface ContextRetrieverOptions {
    * `kg_recall_require_terms=false` to restore the always-on behaviour.
    */
   recallRequiresTerms?: boolean;
+  /**
+   * Disable the LLM relevance re-rank even when a judge is wired. Default
+   * false (= judge runs whenever one is provided). The judge adds ONE cheap
+   * fast-model call per turn that has cross-session candidates; set
+   * `kg_recall_relevance_judge_enabled=false` to fall back to the cosine /
+   * lexical floors only.
+   */
+  recallRelevanceJudgeDisabled?: boolean;
 }
 
 export interface ContextBuildInput {
@@ -296,6 +309,7 @@ const DEFAULTS: Required<
   processLimit: 3,
   processMinScore: 0.45,
   recallRequiresTerms: true,
+  recallRelevanceJudgeDisabled: false,
 };
 
 // Tiny, language-agnostic stopword list. We keep it short because the real
@@ -376,6 +390,12 @@ export class ContextRetriever {
      *  a stored-process recall leg (semantic query over the `processes`
      *  store). Absent → the leg is skipped, plan + memory legs still run. */
     private readonly processMemory?: ProcessMemoryService,
+    /** Relevance re-rank — optional. When wired (and not disabled via
+     *  `recallRelevanceJudgeDisabled`), the cross-session candidates
+     *  (plans / processes / insights) are filtered by an LLM relevance pass
+     *  against the current message before they surface. Absent → cosine /
+     *  lexical floors are the only gate (prior behaviour). */
+    private readonly relevanceJudge?: RecallRelevanceJudge,
   ) {
     this.opts = { ...DEFAULTS, ...opts };
   }
@@ -624,15 +644,56 @@ export class ContextRetriever {
     // tail reservation is capped so a pathological giant turn can't starve
     // recall entirely. When every recall leg is empty the blocks render to ''
     // and the turn budget is untouched (byte-identical to pre-probe behaviour).
-    const insights: RecalledInsight[] = memoryHits.map((h) => ({
+    // Relevance re-rank — precision stage on top of the cheap recall legs.
+    // Cosine / lexical overlap can let a generic note out-score a specific
+    // on-topic fact, so a score threshold alone can't separate signal from
+    // noise. The judge drops candidates that aren't actually useful for THIS
+    // message. It FAILS OPEN (keeps everything on any error), so a degraded
+    // judge never silently hides recall the cheaper legs already surfaced.
+    let judgedPlans = planHits;
+    let judgedProcesses = processHits;
+    let judgedMemory = memoryHits;
+    if (
+      runCrossSessionRecall &&
+      this.relevanceJudge &&
+      !this.opts.recallRelevanceJudgeDisabled &&
+      (planHits.length > 0 || processHits.length > 0 || memoryHits.length > 0)
+    ) {
+      const candidates: RecallCandidate[] = [
+        ...planHits.map((p) => ({
+          id: p.planId,
+          kind: 'plan' as const,
+          text: `${p.strategy ?? ''} ${p.openStepGoals.join('; ')}`,
+        })),
+        ...processHits.map((p) => ({
+          id: p.id,
+          kind: 'process' as const,
+          text: p.title,
+        })),
+        ...memoryHits.map((h) => ({
+          id: h.mk.id,
+          kind: 'insight' as const,
+          text: String(h.mk.props['summary'] ?? ''),
+        })),
+      ];
+      const keep = await this.relevanceJudge.filterRelevant(
+        input.userMessage,
+        candidates,
+      );
+      judgedPlans = planHits.filter((p) => keep.has(p.planId));
+      judgedProcesses = processHits.filter((p) => keep.has(p.id));
+      judgedMemory = memoryHits.filter((h) => keep.has(h.mk.id));
+    }
+
+    const insights: RecalledInsight[] = judgedMemory.map((h) => ({
       mkId: h.mk.id,
       kind: String(h.mk.props['kind'] ?? 'memory'),
       summary: truncate(String(h.mk.props['summary'] ?? ''), 300),
       score: h.score,
     }));
     const recalled: RecalledContext = {
-      plans: planHits,
-      processes: processHits,
+      plans: judgedPlans,
+      processes: judgedProcesses,
       insights,
     };
     const tailReserveCapChars = Math.floor(budgetChars * 0.6);
@@ -697,13 +758,13 @@ export class ContextRetriever {
       `[context:assembled] scope=${scope} agent=${input.agentId} pool=${String(filtered.length)} included=${String(included.length)} excluded=${String(excluded.length)} compact=${String(compactMode)} plans=${String(recalled.plans.length)} processes=${String(recalled.processes.length)} insights=${String(recalled.insights.length)} tokens=${String(tokensUsed)}/${String(budgetTokens)}`,
     );
     // Per-item recall trace — lets us see WHY something surfaced (and tune the
-    // floors empirically) instead of guessing from aggregate counts. Only
-    // emitted when the probe actually surfaced something.
-    if (
-      recalled.plans.length > 0 ||
-      recalled.processes.length > 0 ||
-      recalled.insights.length > 0
-    ) {
+    // floors / judge empirically) instead of guessing from aggregate counts.
+    // Emitted whenever the cheap legs fetched any candidate, so a judge that
+    // dropped everything is still visible (pre→post counts).
+    const preCount = planHits.length + processHits.length + memoryHits.length;
+    if (preCount > 0) {
+      const judgeOn =
+        !!this.relevanceJudge && !this.opts.recallRelevanceJudgeDisabled;
       const plansTrace = recalled.plans.map((p) => p.planId).join(',');
       const procTrace = recalled.processes
         .map((p) => `${p.id}:${p.score.toFixed(2)}`)
@@ -711,8 +772,10 @@ export class ContextRetriever {
       const insTrace = recalled.insights
         .map((i) => `${i.kind}:${i.score.toFixed(2)}`)
         .join(',');
+      const pre = `${planHits.length}/${processHits.length}/${memoryHits.length}`;
+      const post = `${recalled.plans.length}/${recalled.processes.length}/${recalled.insights.length}`;
       console.error(
-        `[context:recall] scope=${scope} gate=${runCrossSessionRecall ? 'open' : 'closed'} terms=[${extractedTerms.join(',')}] plans=[${plansTrace}] processes=[${procTrace}] insights=[${insTrace}]`,
+        `[context:recall] scope=${scope} gate=${runCrossSessionRecall ? 'open' : 'closed'} judge=${judgeOn ? 'on' : 'off'} pre(p/pr/i)=${pre} post=${post} terms=[${extractedTerms.join(',')}] plans=[${plansTrace}] processes=[${procTrace}] insights=[${insTrace}]`,
       );
     }
 

--- a/middleware/packages/harness-orchestrator-extras/src/index.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/index.ts
@@ -88,6 +88,13 @@ export type {
 } from './captureFilter.js';
 export { createHaikuSignificanceScorer } from './significanceScorer.js';
 export type { HaikuSignificanceScorerOptions } from './significanceScorer.js';
+export { createRecallRelevanceJudge } from './recallRelevanceJudge.js';
+export type {
+  RecallRelevanceJudge,
+  RecallRelevanceJudgeOptions,
+  RecallCandidate,
+  RecallCandidateKind,
+} from './recallRelevanceJudge.js';
 export { CaptureFilteringKnowledgeGraph } from './captureFilteringKnowledgeGraph.js';
 export type { CaptureFilteringKnowledgeGraphOptions } from './captureFilteringKnowledgeGraph.js';
 

--- a/middleware/packages/harness-orchestrator-extras/src/plugin.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/plugin.ts
@@ -221,7 +221,7 @@ export async function activate(
   );
   const memoryMinSimilarity = parseNumberOrDefault(
     ctx.config.get<unknown>('kg_acl_memory_recall_min_similarity'),
-    0.5,
+    0.6,
   );
   const memoryBoostFactor = parseNumberOrDefault(
     ctx.config.get<unknown>('kg_acl_memory_recall_boost_factor'),
@@ -264,6 +264,25 @@ export async function activate(
     ctx.config.get<unknown>('kg_recall_process_limit'),
     3,
   );
+  // Min hybrid score for a stored process to surface. Raised from the old
+  // hardcoded 0.3 → 0.45 so weakly-related processes stop appearing in the
+  // "earlier sessions" panel. Tune via kg_recall_process_min_score.
+  const processMinScore = parseNumberOrDefault(
+    ctx.config.get<unknown>('kg_recall_process_min_score'),
+    0.45,
+  );
+  // Turn-level recall gate (default ON): cross-session plan/process/insight
+  // recall only fires when the message carries a candidate term, so greetings
+  // and bare continuations no longer surface unrelated prior-session context.
+  // Set kg_recall_require_terms=false (or KG_RECALL_REQUIRE_TERMS=false) to
+  // restore the always-on behaviour.
+  const recallRequiresTermsRaw =
+    ctx.config.get<unknown>('kg_recall_require_terms') ??
+    process.env['KG_RECALL_REQUIRE_TERMS'];
+  const recallRequiresTerms =
+    typeof recallRequiresTermsRaw === 'string'
+      ? recallRequiresTermsRaw.toLowerCase() !== 'false'
+      : recallRequiresTermsRaw !== false;
 
   // Cost telemetry: wire the recorder to the shared graph pool and wrap the
   // client so the background Haiku scorers/extractors record their usage.
@@ -415,13 +434,15 @@ export async function activate(
       planLimit,
       processRecallDisabled,
       processLimit,
+      processMinScore,
+      recallRequiresTerms,
     },
     embeddingClient,
     agentPriorities,
     processMemory,
   );
   ctx.log(
-    `[harness-orchestrator-extras] context-assembler ready (budget=${String(contextDefaultBudgetTokens)}tk, chars/tk=${String(contextCharsPerToken)}, manual-boost=${contextManualBoostFactor.toFixed(2)}, compact>${String(contextCompactModeThreshold)}, agentPriorities=${agentPriorities ? 'on' : 'off'}, memoryRecall=${embeddingClient && !memoryRecallDisabled ? `on(limit=${String(memoryLimit)},excerpts=${String(memoryExcerptsPerMemory)},minSim=${memoryMinSimilarity.toFixed(2)})` : 'off'}, teamVisibility=${teamVisibility ? 'on' : 'off'}, planRecall=${planRecallDisabled ? 'off' : `on(limit=${String(planLimit)})`}, processRecall=${processMemory && !processRecallDisabled ? `on(limit=${String(processLimit)})` : 'off'})`,
+    `[harness-orchestrator-extras] context-assembler ready (budget=${String(contextDefaultBudgetTokens)}tk, chars/tk=${String(contextCharsPerToken)}, manual-boost=${contextManualBoostFactor.toFixed(2)}, compact>${String(contextCompactModeThreshold)}, agentPriorities=${agentPriorities ? 'on' : 'off'}, memoryRecall=${embeddingClient && !memoryRecallDisabled ? `on(limit=${String(memoryLimit)},excerpts=${String(memoryExcerptsPerMemory)},minSim=${memoryMinSimilarity.toFixed(2)})` : 'off'}, teamVisibility=${teamVisibility ? 'on' : 'off'}, planRecall=${planRecallDisabled ? 'off' : `on(limit=${String(planLimit)})`}, processRecall=${processMemory && !processRecallDisabled ? `on(limit=${String(processLimit)},minScore=${processMinScore.toFixed(2)})` : 'off'}, recallGate=${recallRequiresTerms ? 'require-terms' : 'off'})`,
   );
   const disposeContext = ctx.services.provide(
     CONTEXT_RETRIEVER_SERVICE,

--- a/middleware/packages/harness-orchestrator-extras/src/plugin.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/plugin.ts
@@ -1,5 +1,5 @@
-import type { LlmProvider } from '@omadia/llm-provider';
-import { resolveLlmProvider } from '@omadia/llm-provider';
+import type { LlmProvider, ProviderId } from '@omadia/llm-provider';
+import { resolveLlmProvider, resolveModelRef } from '@omadia/llm-provider';
 import type { PluginContext } from '@omadia/plugin-api';
 import type { EmbeddingClient } from '@omadia/embeddings';
 import type {
@@ -29,6 +29,7 @@ import {
 } from './captureFilter.js';
 import { CaptureFilteringKnowledgeGraph } from './captureFilteringKnowledgeGraph.js';
 import { ContextRetriever } from './contextRetriever.js';
+import { createRecallRelevanceJudge } from './recallRelevanceJudge.js';
 import type { Pool } from 'pg';
 import {
   initUsageRecorder,
@@ -294,6 +295,34 @@ export async function activate(
     llm = withProviderUsageTracking(baseProvider, { source: 'extras' });
   }
 
+  // Recall relevance judge (LLM-agnostic). Re-ranks the cross-session recall
+  // candidates with the provider's FAST model class: a cosine / lexical score
+  // can't separate a specific on-topic fact from a generic note that happens
+  // to score higher, so this is the precision stage. Default ON when an LLM is
+  // available — one cheap fast-model call per turn that actually has
+  // candidates. Disable with kg_recall_relevance_judge_enabled=false; falls
+  // back to the cosine/lexical floors when no LLM or no fast model resolves.
+  const recallJudgeEnabledRaw =
+    ctx.config.get<unknown>('kg_recall_relevance_judge_enabled') ??
+    process.env['KG_RECALL_RELEVANCE_JUDGE_ENABLED'];
+  const recallRelevanceJudgeDisabled =
+    typeof recallJudgeEnabledRaw === 'string'
+      ? recallJudgeEnabledRaw.toLowerCase() === 'false'
+      : recallJudgeEnabledRaw === false;
+  const recallJudgeModel =
+    (ctx.config.get<string>('kg_recall_relevance_judge_model') ?? '').trim() ||
+    resolveModelRef('class:fast', {
+      defaultProvider: providerId as ProviderId,
+    })?.modelId;
+  const relevanceJudge =
+    llm && !recallRelevanceJudgeDisabled && recallJudgeModel
+      ? createRecallRelevanceJudge({
+          llm,
+          model: recallJudgeModel,
+          log: ctx.log,
+        })
+      : undefined;
+
   // ---------------------------------------------------------------------
   // OB-71 — palaia capture-filter wiring.
   //
@@ -436,13 +465,15 @@ export async function activate(
       processLimit,
       processMinScore,
       recallRequiresTerms,
+      recallRelevanceJudgeDisabled,
     },
     embeddingClient,
     agentPriorities,
     processMemory,
+    relevanceJudge,
   );
   ctx.log(
-    `[harness-orchestrator-extras] context-assembler ready (budget=${String(contextDefaultBudgetTokens)}tk, chars/tk=${String(contextCharsPerToken)}, manual-boost=${contextManualBoostFactor.toFixed(2)}, compact>${String(contextCompactModeThreshold)}, agentPriorities=${agentPriorities ? 'on' : 'off'}, memoryRecall=${embeddingClient && !memoryRecallDisabled ? `on(limit=${String(memoryLimit)},excerpts=${String(memoryExcerptsPerMemory)},minSim=${memoryMinSimilarity.toFixed(2)})` : 'off'}, teamVisibility=${teamVisibility ? 'on' : 'off'}, planRecall=${planRecallDisabled ? 'off' : `on(limit=${String(planLimit)})`}, processRecall=${processMemory && !processRecallDisabled ? `on(limit=${String(processLimit)},minScore=${processMinScore.toFixed(2)})` : 'off'}, recallGate=${recallRequiresTerms ? 'require-terms' : 'off'})`,
+    `[harness-orchestrator-extras] context-assembler ready (budget=${String(contextDefaultBudgetTokens)}tk, chars/tk=${String(contextCharsPerToken)}, manual-boost=${contextManualBoostFactor.toFixed(2)}, compact>${String(contextCompactModeThreshold)}, agentPriorities=${agentPriorities ? 'on' : 'off'}, memoryRecall=${embeddingClient && !memoryRecallDisabled ? `on(limit=${String(memoryLimit)},excerpts=${String(memoryExcerptsPerMemory)},minSim=${memoryMinSimilarity.toFixed(2)})` : 'off'}, teamVisibility=${teamVisibility ? 'on' : 'off'}, planRecall=${planRecallDisabled ? 'off' : `on(limit=${String(planLimit)})`}, processRecall=${processMemory && !processRecallDisabled ? `on(limit=${String(processLimit)},minScore=${processMinScore.toFixed(2)})` : 'off'}, recallGate=${recallRequiresTerms ? 'require-terms' : 'off'}, recallJudge=${relevanceJudge ? `on(${recallJudgeModel ?? '?'})` : 'off'})`,
   );
   const disposeContext = ctx.services.provide(
     CONTEXT_RETRIEVER_SERVICE,

--- a/middleware/packages/harness-orchestrator-extras/src/recallRelevanceJudge.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/recallRelevanceJudge.ts
@@ -1,0 +1,164 @@
+/**
+ * @omadia/orchestrator-extras — RecallRelevanceJudge.
+ *
+ * The cross-session recall legs (plans / processes / insights) over-fetch by
+ * lexical overlap and embedding cosine. Both are coarse: a long, business-noun-
+ * packed *generic* note can out-score a specific on-topic fact (observed live —
+ * a generic "AI has no Odoo access, use Dynamics…" reference scored a higher
+ * cosine than the specific weekly course list for the query "Kurse diese
+ * Woche"). No score threshold can separate signal from noise when the noise
+ * scores higher.
+ *
+ * This judge does a single, cheap, LLM-agnostic relevance pass over the
+ * already-fetched candidates: it asks the configured FAST model class (resolved
+ * to a concrete model id by the caller — never hardcoded to one vendor) which
+ * items are actually useful for answering the CURRENT message, and returns the
+ * surviving ids. It is the precision stage on top of the cheap recall legs.
+ *
+ * Failure semantics: FAIL-OPEN. Any error (empty/non-JSON response, provider
+ * throw) returns ALL candidate ids — a degraded judge must never silently hide
+ * recall that the cheaper legs already deemed plausible.
+ */
+
+import type { LlmProvider } from '@omadia/llm-provider';
+import { collectText, textMessage } from '@omadia/llm-provider';
+
+export type RecallCandidateKind = 'plan' | 'process' | 'insight';
+
+export interface RecallCandidate {
+  /** Stable id used to map the verdict back onto the source hit. */
+  id: string;
+  kind: RecallCandidateKind;
+  /** Short human-readable text the judge reasons over (caller truncates). */
+  text: string;
+}
+
+export interface RecallRelevanceJudge {
+  /**
+   * Returns the subset of candidate ids judged relevant to `userMessage`.
+   * FAIL-OPEN: on any error returns every candidate id unchanged.
+   */
+  filterRelevant(
+    userMessage: string,
+    candidates: readonly RecallCandidate[],
+  ): Promise<Set<string>>;
+}
+
+export interface RecallRelevanceJudgeOptions {
+  /** Provider-agnostic LLM. */
+  llm: LlmProvider;
+  /**
+   * Concrete model id the provider understands. The caller resolves the FAST
+   * model class (`class:fast`) to this id so the judge stays vendor-neutral.
+   */
+  model: string;
+  /** Max tokens for the verdict (ids only → tiny). Default 512. */
+  maxTokens?: number;
+  /** Per-candidate text cap fed to the model. Default 280 chars. */
+  maxCandidateChars?: number;
+  log?: (msg: string) => void;
+}
+
+const DEFAULT_MAX_TOKENS = 512;
+const DEFAULT_MAX_CANDIDATE_CHARS = 280;
+
+const SYSTEM_PROMPT = `You filter "recalled context" for relevance.
+
+You are given the user's CURRENT message and a list of items recalled from
+earlier sessions (each with an id, a kind, and its text). Decide which items are
+DIRECTLY useful for answering THIS specific message right now.
+
+KEEP an item only if it is on-topic and specifically helpful for the current
+message. DROP:
+  - generic background / operational notes that apply to almost any request
+    (e.g. "the agent has no access to X, use Y instead", tool/integration
+    inventories, SEO notes) unless the message is specifically about that;
+  - items about a different subject than the current message;
+  - anything only loosely or incidentally related.
+
+Be strict: when in doubt, DROP. Keeping nothing is a valid answer.
+
+Output STRICT JSON with exactly one field, the ids to KEEP:
+  { "relevant": ["<id>", "<id>"] }
+No markdown fence, no commentary.`;
+
+/** Build a relevance judge backed by the provider's FAST model class. */
+export function createRecallRelevanceJudge(
+  opts: RecallRelevanceJudgeOptions,
+): RecallRelevanceJudge {
+  const model = opts.model.trim();
+  const maxTokens = opts.maxTokens ?? DEFAULT_MAX_TOKENS;
+  const maxChars = opts.maxCandidateChars ?? DEFAULT_MAX_CANDIDATE_CHARS;
+  const log = opts.log ?? ((msg): void => console.error(msg));
+
+  return {
+    async filterRelevant(
+      userMessage: string,
+      candidates: readonly RecallCandidate[],
+    ): Promise<Set<string>> {
+      const allIds = new Set(candidates.map((c) => c.id));
+      // Nothing to judge, or no usable message → keep everything (cheap legs win).
+      if (candidates.length === 0 || userMessage.trim().length === 0) {
+        return allIds;
+      }
+
+      const lines = candidates.map((c) => {
+        const text = c.text.replace(/\s+/g, ' ').trim().slice(0, maxChars);
+        return `[id=${c.id} kind=${c.kind}] ${text}`;
+      });
+      const userBlock =
+        `Current message:\n${userMessage.trim()}\n\n` +
+        `Recalled items:\n${lines.join('\n')}`;
+
+      try {
+        const response = await opts.llm.complete({
+          model,
+          maxTokens,
+          system: SYSTEM_PROMPT,
+          messages: [textMessage('user', userBlock)],
+        });
+        const replyText = collectText(response.content);
+        if (!replyText) {
+          log('[recall-judge] empty response — keeping all candidates');
+          return allIds;
+        }
+        const parsed = parseJsonStrict(replyText);
+        const rawRelevant = (parsed as { relevant?: unknown } | null)?.relevant;
+        if (!Array.isArray(rawRelevant)) {
+          log(
+            `[recall-judge] non-JSON / missing "relevant": ${replyText.slice(0, 120)}… — keeping all`,
+          );
+          return allIds;
+        }
+        // Intersect with known ids so a hallucinated id can't resurrect or
+        // invent a candidate.
+        const kept = new Set<string>();
+        for (const id of rawRelevant) {
+          if (typeof id === 'string' && allIds.has(id)) kept.add(id);
+        }
+        return kept;
+      } catch (err) {
+        log(
+          `[recall-judge] judge call failed — keeping all candidates: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+        return allIds;
+      }
+    },
+  };
+}
+
+/** Parse strict JSON, tolerating a stray ```fence the model might add. */
+function parseJsonStrict(raw: string): unknown {
+  const trimmed = raw
+    .trim()
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/```$/i, '')
+    .trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -112,6 +112,11 @@ import {
   routeTurnModel,
 } from './modelRouter.js';
 import { fromLlmResponse, toLlmRequest } from './llmProviderSeam.js';
+import type {
+  AnthropicBlock,
+  AnthropicParams,
+  SeamMessage,
+} from './llmProviderSeam.js';
 import { streamMessageEvents } from './streaming.js';
 import { steeringBus } from './steeringBus.js';
 import { buildDateHeader, today, turnContext } from './turnContext.js';
@@ -1349,6 +1354,87 @@ export class Orchestrator {
   }
 
   /**
+   * Card-router pass for providers that don't interleave text + tool calls
+   * (`capabilities.interleavedToolUse === false`, e.g. Mistral / any
+   * OpenAI-compatible server). Those models emit the CONTENT of a choice card
+   * or follow-up buttons as PROSE in their answer instead of calling
+   * `ask_user_choice` / `suggest_follow_ups` — the Chat Completions API returns
+   * `content` OR `tool_calls`, never both. This runs ONE extra forced-tool call
+   * over {question, answer} so the intent is routed through the existing tool
+   * handlers; the normal `drainPendingChoice` / `drainFollowUps` sites then pick
+   * up whatever was scheduled.
+   *
+   * No-op (and zero extra cost) when: neither card tool is installed, the
+   * provider already interleaves, the model ALREADY scheduled a card this turn,
+   * or the answer is too short to warrant one. Best-effort — any failure is
+   * swallowed so a router hiccup never blocks the user's answer.
+   */
+  private async maybeRouteCardsFromText(
+    userMessage: string,
+    answer: string,
+    model: string,
+  ): Promise<void> {
+    if (this.provider.capabilities.interleavedToolUse !== false) return;
+    const wantsChoice = this.askUserChoiceTool !== undefined;
+    const wantsFollowUps = this.suggestFollowUpsTool !== undefined;
+    if (!wantsChoice && !wantsFollowUps) return;
+    // The model routed correctly on its own this turn — don't double-fire.
+    if (this.askUserChoiceTool?.hasPending() === true) return;
+    if (this.suggestFollowUpsTool?.hasPending() === true) return;
+    const trimmed = answer.trim();
+    // Trivial replies (confirmations, one-line facts) never warrant a card;
+    // skip them to avoid a needless extra LLM call on every short turn.
+    if (trimmed.length < 40) return;
+
+    const tools: AnthropicBlock[] = [];
+    if (wantsChoice) tools.push(askUserChoiceToolSpec);
+    if (wantsFollowUps) tools.push(suggestFollowUpsToolSpec);
+    tools.push(noCardToolSpec);
+
+    const params: AnthropicParams = {
+      model,
+      max_tokens: 1024,
+      system: CARD_ROUTER_SYSTEM,
+      tools,
+      // Force exactly one tool so the model can't slip back into prose.
+      tool_choice: { type: 'any' },
+      messages: [
+        { role: 'user', content: `Ursprüngliche User-Frage:\n${userMessage}` },
+        { role: 'assistant', content: trimmed },
+        { role: 'user', content: CARD_ROUTER_INSTRUCTION },
+      ],
+    };
+
+    let routed: SeamMessage;
+    try {
+      routed = fromLlmResponse(await this.provider.complete(toLlmRequest(params)));
+    } catch (err) {
+      console.error(
+        '[orchestrator] card-router pass failed (continuing without card):',
+        err instanceof Error ? err.message : err,
+      );
+      return;
+    }
+
+    const call = routed.content.find((b) => b['type'] === 'tool_use');
+    if (!call || call['name'] === NO_CARD_TOOL_NAME) return;
+    const name = call['name'] as string;
+    const inputArg = call['input'];
+    try {
+      if (name === ASK_USER_CHOICE_TOOL_NAME) {
+        await this.askUserChoiceTool?.handle(inputArg);
+      } else if (name === SUGGEST_FOLLOW_UPS_TOOL_NAME) {
+        await this.suggestFollowUpsTool?.handle(inputArg);
+      }
+    } catch (err) {
+      console.error(
+        '[orchestrator] card-router handler failed (continuing without card):',
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  /**
    * Collect a pending slot-picker card scheduled by `find_free_slots` during
    * the current turn and clear the tool's buffer. Sidecar pattern — does
    * NOT terminate the turn. Mirrors `drainFollowUps`.
@@ -2062,6 +2148,15 @@ export class Orchestrator {
               });
             }
           }
+          // Non-interleaving providers (Mistral/OpenAI-compatible) emit card
+          // intent as prose; route it through the existing handlers before the
+          // drains below pick it up. No-op on Anthropic and on trivial answers.
+          await this.maybeRouteCardsFromText(
+            input.userMessage,
+            answer,
+            turnModel,
+          );
+          const pendingUserChoice = this.drainPendingChoice();
           const followUpOptions = this.drainFollowUps();
           const pendingSlotCard = this.drainPendingSlotCard();
           const pendingRoutineList = this.drainPendingRoutineList();
@@ -2074,6 +2169,7 @@ export class Orchestrator {
             ...(runTrace ? { runTrace } : {}),
             ...(attachments ? { attachments } : {}),
             ...(fileAttachments ? { fileAttachments } : {}),
+            ...(pendingUserChoice ? { pendingUserChoice } : {}),
             ...(followUpOptions ? { followUpOptions } : {}),
             ...(pendingSlotCard ? { pendingSlotCard } : {}),
             ...(pendingRoutineList ? { pendingRoutineList } : {}),
@@ -2646,6 +2742,15 @@ export class Orchestrator {
               );
             }
           }
+          // Non-interleaving providers (Mistral/OpenAI-compatible) emit card
+          // intent as prose; route it through the existing handlers before the
+          // drains below pick it up. No-op on Anthropic and on trivial answers.
+          await this.maybeRouteCardsFromText(
+            input.userMessage,
+            answer,
+            turnModel,
+          );
+          const pendingUserChoice = this.drainPendingChoice();
           const followUpOptions = this.drainFollowUps();
           const pendingSlotCard = this.drainPendingSlotCard();
           const pendingRoutineList = this.drainPendingRoutineList();
@@ -2686,6 +2791,7 @@ export class Orchestrator {
             ...(attachments ? { attachments } : {}),
             ...(fileAttachments ? { fileAttachments } : {}),
             ...(runTrace ? { runTrace } : {}),
+            ...(pendingUserChoice ? { pendingUserChoice } : {}),
             ...(followUpOptions ? { followUpOptions } : {}),
             ...(pendingSlotCard ? { pendingSlotCard } : {}),
             ...(pendingRoutineList ? { pendingRoutineList } : {}),
@@ -3641,6 +3747,38 @@ const FILE_RETRY_NUDGE =
  */
 const FINALIZE_DIRECTIVE =
   'Du hast das Tool-Budget für diesen Turn aufgebraucht und kannst KEINE weiteren Tools aufrufen. Fasse zusammen, was du bereits herausgefunden hast, und gib JETZT die bestmögliche Antwort mit den vorhandenen Informationen. Wenn etwas unklar oder unvollständig bleibt, sag dem User in einem Satz klar, was noch offen ist. Beschreibe keine weiteren geplanten Tool-Aufrufe.';
+
+// ---------------------------------------------------------------------------
+// Card-router pass (non-interleaving providers, e.g. Mistral / OpenAI-compatible)
+// ---------------------------------------------------------------------------
+//
+// Such models can't emit assistant text AND a tool call in one completion, so
+// the model expresses a choice card or follow-up buttons as PROSE in its answer
+// instead of calling `ask_user_choice` / `suggest_follow_ups`. This second pass
+// re-reads {question, answer} and, with one forced-tool call, routes that intent
+// through the EXISTING tool handlers so the normal drain sites pick it up.
+// `no_card` is the escape hatch so the forced choice can decline.
+
+const NO_CARD_TOOL_NAME = 'no_card';
+
+const noCardToolSpec = {
+  name: NO_CARD_TOOL_NAME,
+  description:
+    'Wähle dies, wenn die Antwort KEINE interaktive Karte braucht — also weder eine echte Rückfrage mit kleiner Optionsmenge noch naheliegende 1-Klick-Varianten desselben Reports.',
+  input_schema: { type: 'object' as const, properties: {} },
+};
+
+const CARD_ROUTER_SYSTEM =
+  'Du bist ein Klassifizierer, der NACH einer fertigen Assistenten-Antwort entscheidet, ob unter die Antwort eine interaktive Karte gehört. Du beantwortest NICHTS neu und schreibst KEINEN Fließtext — du rufst genau EIN Tool auf.\n' +
+  '\n' +
+  '- `ask_user_choice`: NUR wenn die Antwort selbst eine **Rückfrage** ist, weil die ursprüngliche Eingabe genuin mehrdeutig war UND es eine **kleine, endliche Menge** klarer Optionen gibt (die in der Antwort meist schon als Liste genannt sind). Extrahiere die Frage und 2–4 kurze, einzigartige Labels.\n' +
+  '- `suggest_follow_ups`: NUR wenn die Antwort eine **vollständige, inhaltliche Antwort** ist (z. B. Top-N / Ranking / Trend / Aggregat), zu der es naheliegende Varianten desselben Reports gibt. Jedes `prompt` ist eine vollständige, eigenständige Folgefrage.\n' +
+  '- `no_card`: in ALLEN anderen Fällen (Trivial-Antworten, reine Fakten, kein klarer Varianten- oder Optionsraum).\n' +
+  '\n' +
+  'Im Zweifel `no_card`. Erfinde keine Optionen, die nicht zur Antwort passen.';
+
+const CARD_ROUTER_INSTRUCTION =
+  'Entscheide jetzt für die obige Assistenten-Antwort: Rufe genau eines von `ask_user_choice`, `suggest_follow_ups` oder `no_card` auf.';
 
 /** Compose the per-iteration system hint, appending the finalize directive on
  *  the final tools-disabled pass. Kept as a free function so both tool loops

--- a/middleware/packages/harness-orchestrator/src/tools/suggestFollowUpsTool.ts
+++ b/middleware/packages/harness-orchestrator/src/tools/suggestFollowUpsTool.ts
@@ -133,4 +133,8 @@ export class SuggestFollowUpsTool {
     this.pending = undefined;
     return p;
   }
+
+  hasPending(): boolean {
+    return this.pending !== undefined;
+  }
 }

--- a/middleware/packages/llm-provider/src/anthropicProvider.ts
+++ b/middleware/packages/llm-provider/src/anthropicProvider.ts
@@ -340,6 +340,10 @@ export function createAnthropicProvider(
       promptCaching: true,
       forcedToolChoice: true,
       parallelToolCalls: true,
+      // Claude emits natural-language text alongside tool_use in one assistant
+      // message, so sidecar tools (suggest_follow_ups) fire inline — no
+      // post-turn card-router pass needed.
+      interleavedToolUse: true,
     },
 
     async complete(req: LlmRequest): Promise<LlmResponse> {

--- a/middleware/packages/llm-provider/src/openaiProvider.ts
+++ b/middleware/packages/llm-provider/src/openaiProvider.ts
@@ -108,6 +108,11 @@ const DEFAULT_CAPABILITIES: ProviderCapabilities = {
   promptCaching: false,
   forcedToolChoice: true,
   parallelToolCalls: true,
+  // Chat Completions returns assistant `content` OR `tool_calls` per
+  // completion, never both — so a sidecar tool the model is asked to call
+  // alongside its answer (suggest_follow_ups) won't fire here. The orchestrator
+  // reads this to run a post-turn card-router pass instead.
+  interleavedToolUse: false,
 };
 
 // ---------------------------------------------------------------------------

--- a/middleware/packages/llm-provider/src/types.ts
+++ b/middleware/packages/llm-provider/src/types.ts
@@ -214,6 +214,17 @@ export interface ProviderCapabilities {
   /** Supports `toolChoice: { type: 'required' | 'tool' }`. */
   readonly forcedToolChoice: boolean;
   readonly parallelToolCalls: boolean;
+  /** Whether the model emits assistant text AND tool calls in the SAME
+   *  message (Anthropic) versus one-or-the-other per completion (the OpenAI
+   *  Chat Completions family — Mistral/Ollama/vLLM/Azure — where a turn returns
+   *  either `content` or `tool_calls`, never both). Callers that rely on a
+   *  non-blocking "sidecar" tool the model is asked to call *alongside* its
+   *  prose answer (e.g. `suggest_follow_ups`) only get it on interleaving
+   *  providers; on non-interleaving ones the model tends to express the same
+   *  intent as PROSE instead, so the orchestrator compensates with a post-turn
+   *  pass. Optional; treated as `true` (interleaves) when unset, preserving
+   *  pre-existing behaviour for every provider that doesn't set it. */
+  readonly interleavedToolUse?: boolean;
 }
 
 export interface LlmProvider {

--- a/middleware/test/recallProbe.test.ts
+++ b/middleware/test/recallProbe.test.ts
@@ -5,7 +5,12 @@ import { toSemanticAnswer } from '@omadia/channel-sdk';
 import type { ChatTurnResult } from '@omadia/channel-sdk';
 import type { EmbeddingClient } from '@omadia/embeddings';
 import { InMemoryKnowledgeGraph } from '@omadia/knowledge-graph-inmemory';
-import { ContextRetriever } from '@omadia/orchestrator-extras';
+import {
+  ContextRetriever,
+  createRecallRelevanceJudge,
+} from '@omadia/orchestrator-extras';
+import type { RecallRelevanceJudge } from '@omadia/orchestrator-extras';
+import type { LlmProvider } from '@omadia/llm-provider';
 import type {
   ProcessMemoryService,
   ProcessQueryHit,
@@ -655,5 +660,147 @@ describe('T1 · toSemanticAnswer forwards recalled (non-stream / Teams path)', (
   it('omits recalled when absent', () => {
     const result: ChatTurnResult = { answer: 'hi', toolCalls: 0, iterations: 1 };
     assert.equal(toSemanticAnswer(result).recalled, undefined);
+  });
+});
+
+/** Minimal LlmProvider stub: `complete` returns a fixed text body (or throws). */
+function stubLlm(reply: string | (() => never)): LlmProvider {
+  return {
+    async complete(): Promise<unknown> {
+      if (typeof reply === 'function') return reply();
+      return { content: [{ type: 'text', text: reply }] };
+    },
+  } as unknown as LlmProvider;
+}
+
+describe('R8 · recall relevance judge (LLM-agnostic)', () => {
+  const cands = [
+    { id: 'plan:a', kind: 'plan' as const, text: 'about billing migration' },
+    { id: 'process:b', kind: 'process' as const, text: 'deploy to staging' },
+    { id: 'mk:c', kind: 'insight' as const, text: 'generic odoo access note' },
+  ];
+
+  it('keeps only the ids the model returns', async () => {
+    const judge = createRecallRelevanceJudge({
+      llm: stubLlm(JSON.stringify({ relevant: ['plan:a', 'process:b'] })),
+      model: 'fast-test',
+    });
+    const keep = await judge.filterRelevant('how do I deploy billing?', cands);
+    assert.deepEqual([...keep].sort(), ['plan:a', 'process:b']);
+  });
+
+  it('ignores hallucinated ids not among the candidates', async () => {
+    const judge = createRecallRelevanceJudge({
+      llm: stubLlm(JSON.stringify({ relevant: ['plan:a', 'mk:GHOST'] })),
+      model: 'fast-test',
+    });
+    const keep = await judge.filterRelevant('deploy', cands);
+    assert.deepEqual([...keep], ['plan:a']);
+  });
+
+  it('FAILS OPEN (keeps all) on a non-JSON reply', async () => {
+    const judge = createRecallRelevanceJudge({
+      llm: stubLlm('sorry, I cannot do that'),
+      model: 'fast-test',
+    });
+    const keep = await judge.filterRelevant('deploy', cands);
+    assert.equal(keep.size, 3);
+  });
+
+  it('FAILS OPEN (keeps all) when the provider throws', async () => {
+    const judge = createRecallRelevanceJudge({
+      llm: stubLlm(() => {
+        throw new Error('provider down');
+      }),
+      model: 'fast-test',
+    });
+    const keep = await judge.filterRelevant('deploy', cands);
+    assert.equal(keep.size, 3);
+  });
+
+  it('keeps everything when there are no candidates', async () => {
+    const judge = createRecallRelevanceJudge({
+      llm: stubLlm('{"relevant":[]}'),
+      model: 'fast-test',
+    });
+    const keep = await judge.filterRelevant('deploy', []);
+    assert.equal(keep.size, 0);
+  });
+});
+
+describe('R9 · ContextRetriever applies the relevance judge to recalled', () => {
+  async function seedPlanAndInsight(kg: InMemoryKnowledgeGraph): Promise<void> {
+    await kg.ingestPlan({
+      planId: 'prior',
+      scope: 'sess-prior',
+      strategy: 'Migrate the billing module',
+      createdAt: '2026-06-01T10:00:00.000Z',
+    });
+    await kg.upsertPlanStep({
+      stepId: 'prior-s1',
+      planId: 'prior',
+      scope: 'sess-prior',
+      goal: 'run billing migration in staging',
+      order: 0,
+      status: 'pending',
+    });
+    const mk = await kg.createMemorableKnowledge({
+      kind: 'reference',
+      summary: 'generic note about billing access',
+      createdBy: 'web:bob',
+      involvedOmadiaUserIds: [],
+      aclOwners: ['bob'],
+    });
+    kg.setEmbedding(mk.memorableKnowledgeNodeId, ALIGNED);
+  }
+
+  // A judge that drops every INSIGHT (mk:*) but keeps plans/processes.
+  const dropInsights: RecallRelevanceJudge = {
+    async filterRelevant(_msg, candidates): Promise<Set<string>> {
+      return new Set(
+        candidates.filter((c) => c.kind !== 'insight').map((c) => c.id),
+      );
+    },
+  };
+
+  it('drops the candidates the judge rejects (insight filtered, plan kept)', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    await seedPlanAndInsight(kg);
+    const retriever = new ContextRetriever(
+      kg,
+      { teamVisibility: true },
+      stubEmbedder,
+      undefined,
+      undefined,
+      dropInsights,
+    );
+    const result = await retriever.assembleForBudget({
+      userMessage: 'how do I run the billing migration in staging?',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    assert.equal(result.recalled.plans.length, 1, 'relevant plan kept');
+    assert.equal(result.recalled.insights.length, 0, 'insight judged out');
+  });
+
+  it('recallRelevanceJudgeDisabled=true bypasses the judge', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    await seedPlanAndInsight(kg);
+    const retriever = new ContextRetriever(
+      kg,
+      { teamVisibility: true, recallRelevanceJudgeDisabled: true },
+      stubEmbedder,
+      undefined,
+      undefined,
+      dropInsights,
+    );
+    const result = await retriever.assembleForBudget({
+      userMessage: 'how do I run the billing migration in staging?',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    assert.equal(result.recalled.insights.length, 1, 'judge bypassed → insight stays');
   });
 });

--- a/middleware/test/recallProbe.test.ts
+++ b/middleware/test/recallProbe.test.ts
@@ -472,18 +472,147 @@ describe('R6 · relevance-filtered plan recall', () => {
     assert.equal(result.recalled.plans[0]!.planId, 'plan:two'); // 3 terms > 1
   });
 
-  it('falls back to recency when the message has no candidate terms', async () => {
+  it('does NOT surface plans when the message has no candidate terms', async () => {
     const kg = new InMemoryKnowledgeGraph();
     await seedVacationPlan(kg);
     const retriever = new ContextRetriever(kg, { teamVisibility: true });
-    // "ok" / punctuation only → no extractable terms → recency fallback.
+    // "ok?" → no extractable terms. The old recency fallback dumped the latest
+    // open plan regardless of topic (the reported bug); the turn-level gate now
+    // suppresses cross-session recall entirely on term-less turns.
     const result = await retriever.assembleForBudget({
       userMessage: 'ok?',
       agentId: 'test-agent',
       sessionScope: 'sess-now',
       userId: 'alice',
     });
-    assert.equal(result.recalled.plans.length, 1);
+    assert.equal(result.recalled.plans.length, 0);
+  });
+});
+
+describe('R7 · turn-level recall gate (plans + processes + insights)', () => {
+  it('a term-less turn surfaces NO processes or insights', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    // A team insight + a strongly-matching process would both surface if the
+    // gate were open — they must NOT on a term-less greeting.
+    const mk = await kg.createMemorableKnowledge({
+      kind: 'reference',
+      summary: 'unrelated prior-session insight',
+      createdBy: 'web:bob',
+      involvedOmadiaUserIds: [],
+      aclOwners: ['bob'],
+    });
+    kg.setEmbedding(mk.memorableKnowledgeNodeId, ALIGNED);
+    const processMemory = stubProcessMemory([
+      {
+        record: {
+          id: 'process:sess-x:deploy',
+          scope: 'sess-x',
+          title: 'Deploy',
+          steps: ['build'],
+          visibility: 'team',
+          version: 1,
+          createdAt: '2026-06-01T09:00:00.000Z',
+          updatedAt: '2026-06-01T09:00:00.000Z',
+        },
+        score: 0.99,
+      },
+    ]);
+    const retriever = new ContextRetriever(
+      kg,
+      { teamVisibility: true },
+      stubEmbedder,
+      undefined,
+      processMemory,
+    );
+    const result = await retriever.assembleForBudget({
+      userMessage: 'danke!',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    assert.deepEqual(result.recalled, {
+      plans: [],
+      processes: [],
+      insights: [],
+    });
+  });
+
+  it('drops a process scoring below the raised default floor (0.45)', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const processMemory = stubProcessMemory([
+      {
+        record: {
+          id: 'process:sess-x:weak',
+          scope: 'sess-x',
+          title: 'Weakly related',
+          steps: ['x'],
+          visibility: 'team',
+          version: 1,
+          createdAt: '2026-06-01T09:00:00.000Z',
+          updatedAt: '2026-06-01T09:00:00.000Z',
+        },
+        score: 0.4, // ≥ old 0.3 default, < new 0.45 default
+      },
+    ]);
+    const retriever = new ContextRetriever(
+      kg,
+      { teamVisibility: true },
+      stubEmbedder,
+      undefined,
+      processMemory,
+    );
+    const result = await retriever.assembleForBudget({
+      userMessage: 'how do I run the deployment process?',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    assert.equal(result.recalled.processes.length, 0);
+  });
+
+  it('recallRequiresTerms=false re-opens the gate for the semantic legs on a term-less turn', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const mk = await kg.createMemorableKnowledge({
+      kind: 'reference',
+      summary: 'aligned prior-session insight',
+      createdBy: 'web:bob',
+      involvedOmadiaUserIds: [],
+      aclOwners: ['bob'],
+    });
+    kg.setEmbedding(mk.memorableKnowledgeNodeId, ALIGNED);
+    // …also seed an open plan: even with the gate open, plans must NOT return
+    // on a term-less turn — that recency dump is the bug, never restored.
+    await kg.ingestPlan({
+      planId: 'open-plan',
+      scope: 'sess-prior',
+      strategy: 'Urlaubsregeln zusammenfassen',
+      createdAt: '2026-06-01T10:00:00.000Z',
+    });
+    await kg.upsertPlanStep({
+      stepId: 'op-s1',
+      planId: 'open-plan',
+      scope: 'sess-prior',
+      goal: 'Punkte herausarbeiten',
+      order: 0,
+      status: 'pending',
+    });
+    const retriever = new ContextRetriever(
+      kg,
+      { teamVisibility: true, recallRequiresTerms: false },
+      stubEmbedder,
+    );
+    const result = await retriever.assembleForBudget({
+      userMessage: 'ok?',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    assert.equal(
+      result.recalled.insights.length,
+      1,
+      'gate open → insight surfaces',
+    );
+    assert.equal(result.recalled.plans.length, 0, 'plans never recency-dump');
   });
 });
 

--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -121,13 +121,13 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -146,21 +146,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -187,14 +187,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -204,14 +204,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -241,9 +241,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -251,29 +251,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -293,9 +293,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -313,9 +313,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -323,27 +323,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -395,33 +395,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -429,14 +429,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1960,9 +1960,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
-      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
+      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1976,9 +1976,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
-      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
+      "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
       "cpu": [
         "arm64"
       ],
@@ -1992,9 +1992,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
-      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
+      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
       "cpu": [
         "x64"
       ],
@@ -2008,9 +2008,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
-      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
+      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
       "cpu": [
         "arm64"
       ],
@@ -2024,9 +2024,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
-      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
+      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
       "cpu": [
         "arm64"
       ],
@@ -2040,9 +2040,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
-      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
+      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
       "cpu": [
         "x64"
       ],
@@ -2056,9 +2056,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
-      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
+      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
       "cpu": [
         "x64"
       ],
@@ -2072,9 +2072,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
-      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
+      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
       "cpu": [
         "arm64"
       ],
@@ -2088,9 +2088,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
-      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
+      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
       "cpu": [
         "x64"
       ],
@@ -2738,381 +2738,6 @@
       "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -5921,9 +5546,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.349",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
-      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
+      "version": "1.5.372",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
+      "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
       "dev": true,
       "license": "ISC"
     },
@@ -6152,6 +5777,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -7942,10 +7568,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9495,12 +9131,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
-      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
+      "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.6",
+        "@next/env": "16.2.9",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -9514,14 +9150,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.6",
-        "@next/swc-darwin-x64": "16.2.6",
-        "@next/swc-linux-arm64-gnu": "16.2.6",
-        "@next/swc-linux-arm64-musl": "16.2.6",
-        "@next/swc-linux-x64-gnu": "16.2.6",
-        "@next/swc-linux-x64-musl": "16.2.6",
-        "@next/swc-win32-arm64-msvc": "16.2.6",
-        "@next/swc-win32-x64-msvc": "16.2.6",
+        "@next/swc-darwin-arm64": "16.2.9",
+        "@next/swc-darwin-x64": "16.2.9",
+        "@next/swc-linux-arm64-gnu": "16.2.9",
+        "@next/swc-linux-arm64-musl": "16.2.9",
+        "@next/swc-linux-x64-gnu": "16.2.9",
+        "@next/swc-linux-x64-musl": "16.2.9",
+        "@next/swc-win32-arm64-msvc": "16.2.9",
+        "@next/swc-win32-x64-msvc": "16.2.9",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -9688,11 +9324,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -10472,52 +10111,6 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/rollup": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "1.0.8"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.2",
-        "@rollup/rollup-android-arm64": "4.60.2",
-        "@rollup/rollup-darwin-arm64": "4.60.2",
-        "@rollup/rollup-darwin-x64": "4.60.2",
-        "@rollup/rollup-freebsd-arm64": "4.60.2",
-        "@rollup/rollup-freebsd-x64": "4.60.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
-        "@rollup/rollup-linux-arm64-musl": "4.60.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
-        "@rollup/rollup-linux-loong64-musl": "4.60.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-musl": "4.60.2",
-        "@rollup/rollup-openbsd-x64": "4.60.2",
-        "@rollup/rollup-openharmony-arm64": "4.60.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
-        "@rollup/rollup-win32-x64-gnu": "4.60.2",
-        "@rollup/rollup-win32-x64-msvc": "4.60.2",
-        "fsevents": "~2.3.2"
-      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -11719,22 +11312,23 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.21",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "esbuild": "^0.21.3",
-        "postcss": "^8.4.43",
-        "rollup": "^4.20.0"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -11743,23 +11337,33 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.4.0"
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "@types/node": {
           "optional": true
         },
-        "less": {
+        "@vitejs/devtools": {
           "optional": true
         },
-        "lightningcss": {
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
           "optional": true
         },
         "sass": {
@@ -11775,6 +11379,12 @@
           "optional": true
         },
         "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
           "optional": true
         }
       }
@@ -11892,84 +11502,6 @@
           "optional": true
         },
         "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vitest/node_modules/vite": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "1.0.3",
-        "tinyglobby": "^0.2.17"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
-        "esbuild": "^0.27.0 || ^0.28.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
           "optional": true
         }
       }


### PR DESCRIPTION
## Problem

The **"Aus früheren Sessions"** panel (open plans / saved processes / related insights) surfaced content unrelated to the current request. `ContextRetriever.assembleForBudget()` built the payload from three independent recall legs, each emitting above a weak, inconsistent bar with **no turn-level gate** and **no relevance re-rank**.

## Fix — in two commits

### 1. `fix:` relevance-gate the recall probe (`0dcd296`)
- **Turn-level gate** (`recallRequiresTerms`, default on; env `kg_recall_require_terms`): the three cross-session legs only run when the message yields ≥1 candidate term. Term-less turns (greetings/acks/continuations) no longer dump the most-recent-N. In-session tail/entity/FTS recall unaffected.
- `loadPlanHits` **never recency-dumps** on a term-less turn.
- Process floor **0.3 → 0.45** (env `kg_recall_process_min_score`); insight cosine floor **0.5 → 0.6**.
- Per-item `[context:recall]` trace.

### 2. `feat:` LLM-agnostic relevance judge (`c5d2891`)
A realistic query exposed that floors aren't enough: for *"Kurse diese Woche"* a generic note (*"AI has no Odoo access, use Dynamics 365… courses"*) scored cosine **0.79 — higher** than the specific weekly course list. A score threshold provably can't separate signal from noise when noise scores higher.

- `recallRelevanceJudge.ts`: a precision re-rank over the over-fetched candidates — the configured **FAST model class** decides which are useful for *this* message. **LLM-agnostic**: the caller resolves `class:fast` via `resolveModelRef` to a concrete model id, so it works across any provider/plugin (no hardcoded vendor). **Fails open** (any error keeps all candidates).
- `ContextRetriever` takes an optional judge (6th ctor arg) and filters recalled plans/processes/insights through it; gated by `recallRelevanceJudgeDisabled` (env `kg_recall_relevance_judge_enabled`, default on when an LLM is available — one cheap fast-model call per turn that has candidates). Optional `kg_recall_relevance_judge_model`.
- Subsumes the plan-embedding follow-up: the judge drops an off-topic plan (e.g. a revenue plan matched only on the filler word "Woche") in the same pass.

## Tests
27/27 recall (`recallProbe.test.ts`: gate suite, judge unit incl. fail-open & hallucinated-id guard, ContextRetriever integration) + 26 adjacent context suites green. Full middleware build + ESLint clean.

## Verified live (omadia-test docker, :3333)
Boot log: `recallGate=require-terms, recallJudge=on(mistral-small-latest)` (env runs Mistral → fast class resolved automatically). Functional:
- term-less *"Danke!"* → `plans=0 processes=0 insights=0` (gate closed);
- *"Kurse diese Woche"* → `judge=on pre(p/pr/i)=2/0/3 post=1/0/0` — kept only the relevant courses plan, dropped the revenue plan **and** the 3 Dynamics/Odoo/SEO meta-ref insights. UI panel: *"1 plan · 0 processes · 0 insights"*.

Tuning note: the judge is intentionally strict ("when in doubt, drop"); soften the prompt in `recallRelevanceJudge.ts` if marginally-relevant insights should be retained.
