### PR TITLE
fix(web-ui): widen markdown table cell spacing to Lume density

### DIFF
--- a/web-ui/app/globals.css
+++ b/web-ui/app/globals.css
@@ -485,7 +485,7 @@ body {
 }
 .md-view th,
 .md-view td {
-  @apply px-2 py-1 text-left align-top;
+  @apply px-3 py-2 text-left align-top tabular-nums;
   border: 1px solid var(--border);
 }
 .md-view th {


### PR DESCRIPTION
## Was

Die in der Chat-Konsole gerenderten Markdown-Tabellen ("Turnliste") wirkten zu eng (`zu knapp`) und schlecht aligned.

## Ursache

`.md-view th, .md-view td` nutzte `px-2 py-1` (8×4px) — eine Stufe enger auf **beiden** Achsen als jede andere Lume-Tabelle der App (z.B. `RoutineRow` mit `px-3 py-2`).

## Fix (`web-ui/app/globals.css`)

- `px-2 py-1` → `px-3 py-2` — bringt die Zell-Dichte auf die kanonische Lume-Tabellen-Dichte.
- `tabular-nums` ergänzt — Datums-/Zahlen-Spalten (z.B. `15.06.2026`) richten sich sauber aus.

Einzeiler-CSS-Change, kein Verhalten betroffen.
