### PR TITLE
feat: durable long-term knowledge tier + auto-promotion (KG recall)

### DIFF
--- a/middleware/packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.ts
+++ b/middleware/packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.ts
@@ -140,6 +140,18 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
     this.embeddings.set(externalId, [...vector]);
   }
 
+  /** Test/seed helper to flip the top-level `manuallyAuthored` marker on an
+   *  existing node. Mirrors the production DB column `manually_authored`,
+   *  which the in-memory backend otherwise only defaults (false on Turn
+   *  ingest). The durable-recall tier keys off this flag, so durable-tier
+   *  fixtures seed it here after `createMemorableKnowledge`. No-op if the
+   *  node does not exist; callers are tests in control of the substrate. */
+  setManuallyAuthored(externalId: string, value: boolean): void {
+    const node = this.nodes.get(externalId);
+    if (!node) return;
+    this.nodes.set(externalId, { ...node, manuallyAuthored: value });
+  }
+
   async ingestTurn(turn: TurnIngest): Promise<TurnIngestResult> {
     const sessionId = sessionNodeId(turn.scope);
     const turnId = turnNodeId(turn.scope, turn.time);
@@ -858,6 +870,11 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
       ...(input.visibility !== undefined
         ? { visibility: input.visibility }
         : {}),
+      // Durable-curation marker — mirrors the Neon `manually_authored` column.
+      // Top-level GraphNode field (not props); keys the durable recall tier.
+      ...(input.manuallyAuthored !== undefined
+        ? { manuallyAuthored: input.manuallyAuthored }
+        : {}),
       props: {
         kind: input.kind,
         summary: input.summary,
@@ -1414,6 +1431,9 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
     const hits: MemorableKnowledgeHit[] = [];
     for (const node of this.nodes.values()) {
       if (node.type !== 'MemorableKnowledge') continue;
+      // Durable-tier filter — mirror neon: rank only manually-authored MK.
+      if (opts.manuallyAuthoredOnly === true && node.manuallyAuthored !== true)
+        continue;
       const owners = Array.isArray(node.props['acl_owners'])
         ? (node.props['acl_owners'] as string[])
         : [];

--- a/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
+++ b/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
@@ -1904,6 +1904,11 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
         ...(input.visibility !== undefined
           ? { visibility: input.visibility }
           : {}),
+        // Durable-curation marker → top-level `manually_authored` column.
+        // Set by the durable-promotion pipeline; defaults to false otherwise.
+        ...(input.manuallyAuthored !== undefined
+          ? { manuallyAuthored: input.manuallyAuthored }
+          : {}),
       });
 
       // INVOLVED edges — resolve omadiaUserId → user-cluster external_id
@@ -2703,6 +2708,9 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
       WHERE tenant_id = $2
         AND type = 'MemorableKnowledge'
         AND embedding IS NOT NULL
+        -- Durable-tier filter: when set, rank only manually-authored MK among
+        -- itself (so the always-surface leg isn't crowded out by session noise).
+        AND ($7::boolean IS NOT TRUE OR manually_authored = true)
         AND (
           -- team/public-promoted MK stays shareable across Agents.
           ($5::boolean AND COALESCE(visibility, 'team') IN ('team', 'public'))
@@ -2728,6 +2736,7 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
       limit,
       opts.teamVisibility === true,
       opts.viewerAgentSlug ?? null,
+      opts.manuallyAuthoredOnly === true,
     ]);
     return rows.rows
       .filter((r) => Number(r.cosine_sim) >= minSimilarity)
@@ -4729,23 +4738,30 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
       entryType?: string;
       visibility?: string;
       significance?: number | null;
+      // Durable-curation marker → top-level `manually_authored` column. When
+      // undefined, the schema default (false) takes over on insert and the row
+      // is left unchanged on conflict. When provided, it overwrites the column
+      // so the durable-promotion pipeline can flip an existing MK to durable.
+      manuallyAuthored?: boolean;
     },
   ): Promise<string> {
     const palaiaSet = [
       params.entryType !== undefined ? `entry_type = $8` : null,
       params.visibility !== undefined ? `visibility = $9` : null,
       params.significance !== undefined ? `significance = $10` : null,
+      params.manuallyAuthored !== undefined ? `manually_authored = $11` : null,
     ]
       .filter((s): s is string => s !== null)
       .join(', ');
     const updateClause = palaiaSet ? `, ${palaiaSet}` : '';
     const result = await client.query<{ id: string }>(
       `
-      INSERT INTO graph_nodes (external_id, type, tenant_id, scope, user_id, properties, entry_type, visibility, significance)
+      INSERT INTO graph_nodes (external_id, type, tenant_id, scope, user_id, properties, entry_type, visibility, significance, manually_authored)
       VALUES ($1, $2, $3, $4, $5, $6::jsonb,
               COALESCE($8::text, 'memory'),
               COALESCE($9::text, 'team'),
-              $10::real)
+              $10::real,
+              COALESCE($11::boolean, false))
       ON CONFLICT (tenant_id, external_id) DO UPDATE
         SET properties = graph_nodes.properties || EXCLUDED.properties || $7::jsonb,
             scope = COALESCE(EXCLUDED.scope, graph_nodes.scope),
@@ -4763,6 +4779,7 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
         params.entryType ?? null,
         params.visibility ?? null,
         params.significance ?? null,
+        params.manuallyAuthored ?? null,
       ],
     );
     const id = result.rows[0]?.id;

--- a/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
@@ -71,6 +71,22 @@ export interface ContextRetrieverOptions {
   /** Score multiplier for memory-origin hits in the assembler. Default
    *  1.2 — curated memory ranks above raw FTS hits at similar cosine. */
   memoryBoostFactor?: number;
+  /** Additive durable-curation tier. When enabled (default), manual-authored
+   *  MemorableKnowledge of the configured `durableKinds` ALWAYS surfaces in
+   *  recall: independent of the turn-term gate, with its own low/no cosine
+   *  floor, outside the fuzzy `memoryLimit`, and never sent to the judge.
+   *  Set `kg_durable_tier_enabled=false` to restore the exact pre-tier
+   *  behaviour. */
+  durableTierDisabled?: boolean;
+  /** Reserved slots for durable curated MK, additive to `memoryLimit`.
+   *  Default 2. */
+  durableReservedSlots?: number;
+  /** MemorableKnowledge kinds admitted to the durable tier. Default
+   *  `reference,decision`. */
+  durableKinds?: string[];
+  /** Min cosine for the durable tier. Default 0.0 on purpose: curated,
+   *  manual-authored long-term knowledge must survive paraphrase. */
+  durableMinSimilarity?: number;
 
   // Cross-session recall probe — Plan + Process + team-scoped insights.
   /**
@@ -300,6 +316,10 @@ const DEFAULTS: Required<
   excerptsPerMemory: 2,
   memoryMinSimilarity: 0.6,
   memoryBoostFactor: 1.2,
+  durableTierDisabled: false,
+  durableReservedSlots: 2,
+  durableKinds: ['reference', 'decision'],
+  durableMinSimilarity: 0,
   // Cross-session recall probe defaults.
   teamVisibility: false,
   planRecallDisabled: false,
@@ -519,6 +539,7 @@ export class ContextRetriever {
       planHits,
       processHits,
       memoryHits,
+      durableHits,
     ] = await Promise.all([
       this.loadTail(buildInput),
       this.loadEntityHits(buildInput, extractedTerms),
@@ -527,6 +548,7 @@ export class ContextRetriever {
       runCrossSessionRecall ? this.loadPlanHits(buildInput) : emptyPlans,
       runCrossSessionRecall ? this.loadProcessHits(buildInput) : emptyProcesses,
       runCrossSessionRecall ? this.loadMemoryHits(buildInput) : emptyMemory,
+      this.loadDurableHits(buildInput),
     ]);
 
     // Build candidate pool. Tail first (chronological → fills first).
@@ -685,12 +707,20 @@ export class ContextRetriever {
       judgedMemory = memoryHits.filter((h) => keep.has(h.mk.id));
     }
 
-    const insights: RecalledInsight[] = judgedMemory.map((h) => ({
-      mkId: h.mk.id,
-      kind: String(h.mk.props['kind'] ?? 'memory'),
-      summary: truncate(String(h.mk.props['summary'] ?? ''), 300),
-      score: h.score,
-    }));
+    const seenInsightIds = new Set<string>();
+    const insights: RecalledInsight[] = [];
+    for (const hit of durableHits) {
+      const insight = toRecalledInsight(hit);
+      if (seenInsightIds.has(insight.mkId)) continue;
+      seenInsightIds.add(insight.mkId);
+      insights.push(insight);
+    }
+    for (const hit of judgedMemory) {
+      const insight = toRecalledInsight(hit);
+      if (seenInsightIds.has(insight.mkId)) continue;
+      seenInsightIds.add(insight.mkId);
+      insights.push(insight);
+    }
     const recalled: RecalledContext = {
       plans: judgedPlans,
       processes: judgedProcesses,
@@ -761,7 +791,11 @@ export class ContextRetriever {
     // floors / judge empirically) instead of guessing from aggregate counts.
     // Emitted whenever the cheap legs fetched any candidate, so a judge that
     // dropped everything is still visible (pre→post counts).
-    const preCount = planHits.length + processHits.length + memoryHits.length;
+    const preCount =
+      planHits.length +
+      processHits.length +
+      memoryHits.length +
+      durableHits.length;
     if (preCount > 0) {
       const judgeOn =
         !!this.relevanceJudge && !this.opts.recallRelevanceJudgeDisabled;
@@ -775,7 +809,7 @@ export class ContextRetriever {
       const pre = `${planHits.length}/${processHits.length}/${memoryHits.length}`;
       const post = `${recalled.plans.length}/${recalled.processes.length}/${recalled.insights.length}`;
       console.error(
-        `[context:recall] scope=${scope} gate=${runCrossSessionRecall ? 'open' : 'closed'} judge=${judgeOn ? 'on' : 'off'} pre(p/pr/i)=${pre} post=${post} terms=[${extractedTerms.join(',')}] plans=[${plansTrace}] processes=[${procTrace}] insights=[${insTrace}]`,
+        `[context:recall] scope=${scope} gate=${runCrossSessionRecall ? 'open' : 'closed'} judge=${judgeOn ? 'on' : 'off'} durable=${String(durableHits.length)} pre(p/pr/i)=${pre} post=${post} terms=[${extractedTerms.join(',')}] plans=[${plansTrace}] processes=[${procTrace}] insights=[${insTrace}]`,
       );
     }
 
@@ -1158,6 +1192,78 @@ export class ContextRetriever {
     return merged.slice(0, this.opts.memoryLimit);
   }
 
+  /**
+   * Additive durable tier for manual-authored long-term knowledge.
+   *
+   * Deliberately separate from the fuzzy memory leg: it ignores the turn-term
+   * gate, uses its own low/no cosine floor so paraphrases still hit, bypasses
+   * the fuzzy `memoryLimit`, and NEVER enters the relevance judge's candidate
+   * set. Failures degrade to [] — same discipline as `loadMemoryHits`.
+   */
+  private async loadDurableHits(
+    input: ContextBuildInput,
+  ): Promise<MemoryRecallHit[]> {
+    if (this.opts.durableTierDisabled) return [];
+    if (!this.embeddingClient || !input.userId) return [];
+
+    const reservedSlots = Math.max(0, this.opts.durableReservedSlots);
+    if (reservedSlots === 0) return [];
+
+    let queryVector: number[];
+    try {
+      queryVector = await this.embeddingClient.embed(input.userMessage);
+    } catch (err) {
+      console.error(
+        '[context:durable] query embed failed — skipping durable recall:',
+        err instanceof Error ? err.message : err,
+      );
+      return [];
+    }
+    if (queryVector.length === 0) return [];
+
+    const durableKinds = new Set(
+      this.opts.durableKinds.map((kind) => kind.toLowerCase()),
+    );
+    const overshoot = Math.max(reservedSlots * 4, 8);
+
+    let mkHits: MemorableKnowledgeHit[];
+    try {
+      mkHits = await this.graph.searchMemorableKnowledgeByEmbedding({
+        queryEmbedding: queryVector,
+        viewerOmadiaUserId: input.userId,
+        limit: overshoot,
+        minSimilarity: this.opts.durableMinSimilarity,
+        teamVisibility: this.opts.teamVisibility,
+        // Rank durable MK among itself at the SQL level — otherwise higher-cosine
+        // session noise crowds durable knowledge out of the over-fetch window.
+        manuallyAuthoredOnly: true,
+        ...(input.agentSlug ? { viewerAgentSlug: input.agentSlug } : {}),
+      });
+    } catch (err) {
+      console.error(
+        '[context:durable] backend search failed — skipping durable recall:',
+        err instanceof Error ? err.message : err,
+      );
+      return [];
+    }
+
+    const durableHits: MemoryRecallHit[] = [];
+    for (const hit of mkHits) {
+      const kind = String(hit.mk.props['kind'] ?? '').toLowerCase();
+      // Durable marker lives on the GraphNode (column `manually_authored`),
+      // hydrated by rowToNode — NOT in the `props` JSONB blob.
+      if (hit.mk.manuallyAuthored !== true) continue;
+      if (!durableKinds.has(kind)) continue;
+      durableHits.push({
+        mk: hit.mk,
+        excerpts: [],
+        score: hit.cosineSim,
+      });
+    }
+    durableHits.sort((a, b) => b.score - a.score);
+    return durableHits.slice(0, reservedSlots);
+  }
+
   private async loadFtsHits(input: ContextBuildInput): Promise<TurnSearchHit[]> {
     // Vector search first when we have an embedding client + the backend
     // supports it. Semantic recall catches paraphrases ("kredite" ↔ "darlehen")
@@ -1379,6 +1485,15 @@ function renderRecallBlocks(
   }
 
   return parts.join('\n');
+}
+
+function toRecalledInsight(hit: MemoryRecallHit): RecalledInsight {
+  return {
+    mkId: hit.mk.id,
+    kind: String(hit.mk.props['kind'] ?? 'memory'),
+    summary: truncate(String(hit.mk.props['summary'] ?? ''), 300),
+    score: hit.score,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/middleware/packages/harness-orchestrator-extras/src/index.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/index.ts
@@ -115,6 +115,15 @@ export type { HaikuPalaiaExcerptExtractorOptions } from './excerptExtractor.js';
 // declines all promotions with reason='no-significance'.
 export { promoteTurnIfSignificant } from './promotion.js';
 export type { PromoteTurnInput, PromoteTurnResult } from './promotion.js';
+export {
+  promoteRuleFileToDurable,
+  isDurableRulePath,
+  DURABLE_RULES_PREFIX,
+} from './promoteDurableRule.js';
+export type {
+  PromoteRuleInput,
+  PromoteRuleResult,
+} from './promoteDurableRule.js';
 
 // KG-ACL Slice 8 — operator-triggered retrospective bulk score +
 // promotion. Two-phase pass over historical Turns: (1) Haiku-score

--- a/middleware/packages/harness-orchestrator-extras/src/plugin.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/plugin.ts
@@ -285,6 +285,38 @@ export async function activate(
       ? recallRequiresTermsRaw.toLowerCase() !== 'false'
       : recallRequiresTermsRaw !== false;
 
+  // Durable-curation tier. Manual-authored MemorableKnowledge of the
+  // configured kinds ALWAYS surfaces — independent of the turn-term gate,
+  // with its own low/no cosine floor, outside the fuzzy memoryLimit, and never
+  // sent to the relevance judge. Default ON. Set kg_durable_tier_enabled=false
+  // (or env KG_DURABLE_TIER_ENABLED=false) to restore the pre-tier behaviour.
+  const durableTierEnabledRaw =
+    ctx.config.get<unknown>('kg_durable_tier_enabled') ??
+    process.env['KG_DURABLE_TIER_ENABLED'];
+  const durableTierDisabled =
+    typeof durableTierEnabledRaw === 'string'
+      ? durableTierEnabledRaw.toLowerCase() === 'false'
+      : durableTierEnabledRaw === false;
+  const durableReservedSlots = parseNumberOrDefault(
+    ctx.config.get<unknown>('kg_durable_reserved_slots'),
+    2,
+  );
+  // Comma-separated MK kinds admitted to the durable tier. Empty/blank → fall
+  // back to the ContextRetriever default (reference,decision).
+  const durableKindsRaw = (
+    ctx.config.get<string>('kg_durable_kinds') ?? ''
+  ).trim();
+  const durableKinds = durableKindsRaw
+    ? durableKindsRaw
+        .split(',')
+        .map((kind) => kind.trim().toLowerCase())
+        .filter((kind) => kind.length > 0)
+    : undefined;
+  const durableMinSimilarity = parseNumberOrDefault(
+    ctx.config.get<unknown>('kg_durable_min_similarity'),
+    0,
+  );
+
   // Cost telemetry: wire the recorder to the shared graph pool and wrap the
   // client so the background Haiku scorers/extractors record their usage.
   const usagePool = ctx.services.get<Pool>('graphPool');
@@ -466,6 +498,11 @@ export async function activate(
       processMinScore,
       recallRequiresTerms,
       recallRelevanceJudgeDisabled,
+      // Durable-curation tier.
+      durableTierDisabled,
+      durableReservedSlots,
+      durableMinSimilarity,
+      ...(durableKinds ? { durableKinds } : {}),
     },
     embeddingClient,
     agentPriorities,
@@ -473,7 +510,7 @@ export async function activate(
     relevanceJudge,
   );
   ctx.log(
-    `[harness-orchestrator-extras] context-assembler ready (budget=${String(contextDefaultBudgetTokens)}tk, chars/tk=${String(contextCharsPerToken)}, manual-boost=${contextManualBoostFactor.toFixed(2)}, compact>${String(contextCompactModeThreshold)}, agentPriorities=${agentPriorities ? 'on' : 'off'}, memoryRecall=${embeddingClient && !memoryRecallDisabled ? `on(limit=${String(memoryLimit)},excerpts=${String(memoryExcerptsPerMemory)},minSim=${memoryMinSimilarity.toFixed(2)})` : 'off'}, teamVisibility=${teamVisibility ? 'on' : 'off'}, planRecall=${planRecallDisabled ? 'off' : `on(limit=${String(planLimit)})`}, processRecall=${processMemory && !processRecallDisabled ? `on(limit=${String(processLimit)},minScore=${processMinScore.toFixed(2)})` : 'off'}, recallGate=${recallRequiresTerms ? 'require-terms' : 'off'}, recallJudge=${relevanceJudge ? `on(${recallJudgeModel ?? '?'})` : 'off'})`,
+    `[harness-orchestrator-extras] context-assembler ready (budget=${String(contextDefaultBudgetTokens)}tk, chars/tk=${String(contextCharsPerToken)}, manual-boost=${contextManualBoostFactor.toFixed(2)}, compact>${String(contextCompactModeThreshold)}, agentPriorities=${agentPriorities ? 'on' : 'off'}, memoryRecall=${embeddingClient && !memoryRecallDisabled ? `on(limit=${String(memoryLimit)},excerpts=${String(memoryExcerptsPerMemory)},minSim=${memoryMinSimilarity.toFixed(2)})` : 'off'}, teamVisibility=${teamVisibility ? 'on' : 'off'}, planRecall=${planRecallDisabled ? 'off' : `on(limit=${String(planLimit)})`}, processRecall=${processMemory && !processRecallDisabled ? `on(limit=${String(processLimit)},minScore=${processMinScore.toFixed(2)})` : 'off'}, recallGate=${recallRequiresTerms ? 'require-terms' : 'off'}, recallJudge=${relevanceJudge ? `on(${recallJudgeModel ?? '?'})` : 'off'}, durableTier=${durableTierDisabled ? 'off' : `on(slots=${String(durableReservedSlots)},kinds=${(durableKinds ?? ['reference', 'decision']).join('+')},minSim=${durableMinSimilarity.toFixed(2)})`})`,
   );
   const disposeContext = ctx.services.provide(
     CONTEXT_RETRIEVER_SERVICE,

--- a/middleware/packages/harness-orchestrator-extras/src/promoteDurableRule.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/promoteDurableRule.ts
@@ -1,0 +1,116 @@
+/**
+ * Trigger T1 — promote a durable `_rules/` memory-file into the Knowledge-Graph
+ * as a curated `manuallyAuthored=true` MemorableKnowledge so the always-surface
+ * durable recall tier (B1) can surface it. Shared by BOTH the one-shot backfill
+ * script and the live memory-write hook so the two paths stay identical.
+ *
+ * Idempotent (create-only): if a durable MK already carries this file's
+ * `source-memory-path:` marker, it is left untouched. `createMemorableKnowledge`
+ * does not embed inline, so we write the `summary + rationale` joint embedding
+ * explicitly — matching the Slice-7 contract — when an embedding client is given.
+ *
+ * Never throws: failures are logged and returned as `{ action: 'error' }` so a
+ * fire-and-forget caller (the write hook) can ignore the result.
+ */
+import type { Pool } from 'pg';
+import type { KnowledgeGraph } from '@omadia/plugin-api';
+import type { EmbeddingClient } from '@omadia/embeddings';
+
+/** Model-facing prefix for the shared, repo-curated rules namespace. */
+export const DURABLE_RULES_PREFIX = '/memories/_rules/';
+const SOURCE_MARKER = 'source-memory-path: ';
+const MAX_SUMMARY = 1900; // MemorableKnowledge.summary hard cap is 2000.
+
+/** True for paths that should become durable MK (skips the README index). */
+export function isDurableRulePath(virtualPath: string): boolean {
+  return (
+    virtualPath.startsWith(DURABLE_RULES_PREFIX) &&
+    !/\/README\.md$/i.test(virtualPath)
+  );
+}
+
+export interface PromoteRuleInput {
+  pool: Pool;
+  kg: KnowledgeGraph;
+  tenantId: string;
+  virtualPath: string;
+  content: string;
+  /** When given, the summary+rationale joint embedding is written so the MK is
+   *  immediately reachable by searchMemorableKnowledgeByEmbedding. */
+  embeddingClient?: EmbeddingClient;
+  log?: (msg: string) => void;
+}
+
+export interface PromoteRuleResult {
+  action: 'created' | 'skipped' | 'error';
+  mkId?: string;
+}
+
+export async function promoteRuleFileToDurable(
+  input: PromoteRuleInput,
+): Promise<PromoteRuleResult> {
+  const log = input.log ?? ((): void => {});
+  try {
+    if (!isDurableRulePath(input.virtualPath)) return { action: 'skipped' };
+    const trimmed = input.content.trim();
+    if (trimmed.length === 0) return { action: 'skipped' };
+
+    // Idempotency (create-only): already promoted? matched on the source marker.
+    const existing = await input.pool.query<{ external_id: string }>(
+      `SELECT external_id FROM graph_nodes
+        WHERE tenant_id = $1
+          AND type = 'MemorableKnowledge'
+          AND manually_authored = true
+          AND properties->>'rationale' LIKE $2 || '%'
+        LIMIT 1`,
+      [input.tenantId, SOURCE_MARKER + input.virtualPath],
+    );
+    if (existing.rows.length > 0) {
+      return { action: 'skipped', mkId: existing.rows[0]!.external_id };
+    }
+
+    const summary =
+      trimmed.length > MAX_SUMMARY ? trimmed.slice(0, MAX_SUMMARY) : trimmed;
+    const rationale = `${SOURCE_MARKER}${input.virtualPath}\n\n${trimmed}`.slice(
+      0,
+      9900,
+    );
+
+    const result = await input.kg.createMemorableKnowledge({
+      kind: 'reference',
+      summary,
+      rationale,
+      manuallyAuthored: true,
+      significance: 1,
+      createdBy: 'system:rules-hook',
+      involvedOmadiaUserIds: [],
+      aclOwners: [], // team-visible curated rule (no per-user ownership)
+      visibility: 'team',
+    });
+    const mkId = result.memorableKnowledgeNodeId;
+
+    if (input.embeddingClient) {
+      const vector = await input.embeddingClient.embed(
+        `${summary}\n\n${rationale}`,
+      );
+      if (vector.length > 0) {
+        await input.pool.query(
+          `UPDATE graph_nodes
+              SET embedding = $1::vector,
+                  embedding_attempts = 0,
+                  embedding_last_error_at = NULL,
+                  embedding_last_error = NULL
+            WHERE external_id = $2 AND tenant_id = $3`,
+          [`[${vector.join(',')}]`, mkId, input.tenantId],
+        );
+      }
+    }
+    log(`[durable-rules] created mk=${mkId} from ${input.virtualPath}`);
+    return { action: 'created', mkId };
+  } catch (err) {
+    log(
+      `[durable-rules] FAILED ${input.virtualPath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { action: 'error' };
+  }
+}

--- a/middleware/packages/harness-orchestrator-extras/src/promotion.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/promotion.ts
@@ -66,6 +66,16 @@ export interface PromoteTurnInput {
    * cross-agent). Omit on legacy / single-agent boots.
    */
   originAgent?: string;
+  /**
+   * Trigger T3 — durable auto-promotion. When set, an auto-promoted MK is
+   * additionally marked `manuallyAuthored=true` (→ always-surface durable
+   * recall tier) iff `significance >= durableMinSignificance`, its `kind` is in
+   * `durableKinds`, and it passes the narration/snapshot hygiene check. Undefined
+   * → never auto-mark durable (pre-T3 behaviour). Re-pollution guard.
+   */
+  durableMinSignificance?: number;
+  /** Kinds eligible for durable auto-promotion. Default `['reference']`. */
+  durableKinds?: MemorableKind[];
   /** Optional log sink. Defaults to `console.error`. */
   log?: (msg: string) => void;
 }
@@ -166,11 +176,23 @@ export async function promoteTurnIfSignificant(
       input.fallbackAssistantAnswer,
     );
 
+    // Trigger T3 — durable auto-promotion gate. Conservative by design: only
+    // high-significance reference knowledge that survives the hygiene check is
+    // marked durable, so conversational narration + time-bound snapshots never
+    // re-pollute the always-surface tier.
+    const durableKinds = input.durableKinds ?? ['reference'];
+    const durable =
+      input.durableMinSignificance !== undefined &&
+      significance >= input.durableMinSignificance &&
+      durableKinds.includes(kind) &&
+      passesDurableHygiene(summary, rationale);
+
     const result = await input.kg.createMemorableKnowledge({
       kind,
       summary,
       ...(rationale !== undefined ? { rationale } : {}),
       significance,
+      ...(durable ? { manuallyAuthored: true } : {}),
       createdBy: `auto:${input.userId}`,
       involvedOmadiaUserIds: [input.userId],
       aclOwners: [input.userId],
@@ -192,7 +214,7 @@ export async function promoteTurnIfSignificant(
     });
 
     log(
-      `[promotion] PROMOTED turn=${input.turnId} mk=${result.memorableKnowledgeNodeId} significance=${significance.toFixed(2)} kind=${kind}`,
+      `[promotion] PROMOTED turn=${input.turnId} mk=${result.memorableKnowledgeNodeId} significance=${significance.toFixed(2)} kind=${kind} durable=${durable ? 'yes' : 'no'}`,
     );
     return {
       promoted: true,
@@ -206,6 +228,24 @@ export async function promoteTurnIfSignificant(
     );
     return { promoted: false, reason: 'error', significance: null };
   }
+}
+
+/**
+ * Hygiene gate for durable auto-promotion (Trigger T3). Rejects the two
+ * pollution classes observed in the live KG — first-person agent narration
+ * ("Ich schaue zuerst in den Memory…") and trivially short fragments — so they
+ * stay in the fuzzy tier instead of re-polluting the always-surface durable
+ * tier. Conservative: returns false when unsure.
+ */
+function passesDurableHygiene(summary: string, rationale?: string): boolean {
+  const head = summary.trim();
+  const full = `${summary} ${rationale ?? ''}`.trim();
+  if (full.length < 40) return false;
+  // First-person agent narration / meta-process preambles.
+  const NARRATION =
+    /^(ich\s+(schaue|schau|prüfe|pruefe|sehe|gucke|lese|checke|werde|muss)|lass\s+mich|du\s+hast\s+recht|moment\b|kurz\b|let me\b|i\s+will\b|i'?ll\b|looking\b|checking\b)/i;
+  if (NARRATION.test(head)) return false;
+  return true;
 }
 
 function buildPayload(

--- a/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
@@ -44,6 +44,7 @@ import type { NativeToolRegistry } from './nativeToolRegistry.js';
 import type { ModelRoutingConfig } from './modelRouter.js';
 import { Orchestrator } from './orchestrator.js';
 import { OrchestratorMemoryNamespacer } from './orchestratorMemoryNamespacer.js';
+import { DurableRulesMemoryStore } from './durableRulesMemoryStore.js';
 import {
   ScopedMemoryStore,
   orchestratorMemoryScope,
@@ -170,9 +171,31 @@ export function buildOrchestratorForAgent(
     chatSessionStore,
     config.agentId,
   );
-  const memoryToolHandler = new MemoryToolHandler(
-    new OrchestratorMemoryNamespacer(config.agentId, scopedStore),
+  // Trigger T1 — durable-rules live hook. Wrap the (shared-passthrough)
+  // namespacer so writes to `/memories/_rules/` auto-promote into curated
+  // durable MemorableKnowledge. Needs the graph pool; gated off when absent or
+  // via KG_DURABLE_RULES_HOOK=false. Decorator sits OUTSIDE the namespacer so
+  // it sees the model-facing `_rules/` path (namespacer passes `_` through).
+  const namespacedStore: MemoryStore = new OrchestratorMemoryNamespacer(
+    config.agentId,
+    scopedStore,
   );
+  const durableRulesHookEnabled =
+    process.env['KG_DURABLE_RULES_HOOK'] !== 'false' && !!deps.graphPool;
+  const memoryToolStore: MemoryStore = durableRulesHookEnabled
+    ? new DurableRulesMemoryStore(namespacedStore, {
+        pool: deps.graphPool!,
+        kg: deps.knowledgeGraph,
+        tenantId: deps.graphTenantId ?? 'default',
+        ...(deps.embeddingClient
+          ? { embeddingClient: deps.embeddingClient }
+          : {}),
+        log: (msg): void => {
+          console.error(msg);
+        },
+      })
+    : namespacedStore;
+  const memoryToolHandler = new MemoryToolHandler(memoryToolStore);
 
   // Native-tool instances (channel-coupled UI cards + calendar). The calendar
   // tools are present only when the Microsoft 365 accessor is available.

--- a/middleware/packages/harness-orchestrator/src/durableRulesMemoryStore.ts
+++ b/middleware/packages/harness-orchestrator/src/durableRulesMemoryStore.ts
@@ -1,0 +1,86 @@
+/**
+ * Trigger T1 (live hook) — a MemoryStore decorator that promotes every write to
+ * the shared `/memories/_rules/` namespace into a curated `manuallyAuthored`
+ * MemorableKnowledge, so durable rules the agent authors at runtime reach the
+ * always-surface durable recall tier without a manual backfill.
+ *
+ * Placed OUTSIDE the OrchestratorMemoryNamespacer so it sees the model-facing
+ * `/memories/_rules/...` path (the namespacer passes `_` segments through
+ * unchanged). The promotion is fire-and-forget: it runs after the inner write
+ * resolves and never blocks or fails the write. Idempotent (create-only) via the
+ * shared `promoteRuleFileToDurable`.
+ */
+import type { Pool } from 'pg';
+import type {
+  KnowledgeGraph,
+  MemoryEntry,
+  MemoryStore,
+} from '@omadia/plugin-api';
+import type { EmbeddingClient } from '@omadia/embeddings';
+import {
+  isDurableRulePath,
+  promoteRuleFileToDurable,
+} from '@omadia/orchestrator-extras';
+
+export interface DurableRulesHookDeps {
+  pool: Pool;
+  kg: KnowledgeGraph;
+  tenantId: string;
+  embeddingClient?: EmbeddingClient;
+  log?: (msg: string) => void;
+}
+
+export class DurableRulesMemoryStore implements MemoryStore {
+  constructor(
+    private readonly inner: MemoryStore,
+    private readonly deps: DurableRulesHookDeps,
+  ) {}
+
+  private maybePromote(virtualPath: string, content: string): void {
+    if (!isDurableRulePath(virtualPath)) return;
+    // Fire-and-forget — never block or fail the originating write.
+    void promoteRuleFileToDurable({
+      pool: this.deps.pool,
+      kg: this.deps.kg,
+      tenantId: this.deps.tenantId,
+      virtualPath,
+      content,
+      ...(this.deps.embeddingClient
+        ? { embeddingClient: this.deps.embeddingClient }
+        : {}),
+      ...(this.deps.log ? { log: this.deps.log } : {}),
+    }).catch(() => {
+      /* promoteRuleFileToDurable already swallows + logs its own errors */
+    });
+  }
+
+  async createFile(virtualPath: string, content: string): Promise<void> {
+    await this.inner.createFile(virtualPath, content);
+    this.maybePromote(virtualPath, content);
+  }
+
+  async writeFile(virtualPath: string, content: string): Promise<void> {
+    await this.inner.writeFile(virtualPath, content);
+    this.maybePromote(virtualPath, content);
+  }
+
+  // ── Pure pass-throughs ────────────────────────────────────────────────
+  list(virtualPath: string): Promise<MemoryEntry[]> {
+    return this.inner.list(virtualPath);
+  }
+  fileExists(virtualPath: string): Promise<boolean> {
+    return this.inner.fileExists(virtualPath);
+  }
+  directoryExists(virtualPath: string): Promise<boolean> {
+    return this.inner.directoryExists(virtualPath);
+  }
+  readFile(virtualPath: string): Promise<string> {
+    return this.inner.readFile(virtualPath);
+  }
+  delete(virtualPath: string): Promise<void> {
+    return this.inner.delete(virtualPath);
+  }
+  rename(fromVirtualPath: string, toVirtualPath: string): Promise<void> {
+    return this.inner.rename(fromVirtualPath, toVirtualPath);
+  }
+}

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -77,6 +77,7 @@ import { extractAttachmentText } from './attachmentExtract.js';
 import type {
   EntityRefBus,
   KnowledgeGraph,
+  MemorableKind,
   NudgeRegistry,
   NudgeStateStore,
   PalaiaExcerpt,
@@ -381,6 +382,11 @@ export interface OrchestratorOptions {
    */
   autoPromote?: boolean;
   autoPromoteThreshold?: number;
+  /** Trigger T3 — when set, auto-promoted MK at/above this significance whose
+   *  kind is in `autoPromoteDurableKinds` (and passing hygiene) is marked
+   *  `manuallyAuthored=true` (durable always-surface tier). Undefined → off. */
+  autoPromoteDurableMinSignificance?: number;
+  autoPromoteDurableKinds?: MemorableKind[];
   graphPool?: Pool;
   graphTenantId?: string;
   /**
@@ -909,6 +915,8 @@ export class Orchestrator {
   private readonly knowledgeGraph: KnowledgeGraph | undefined;
   private readonly autoPromote: boolean;
   private readonly autoPromoteThreshold: number;
+  private readonly autoPromoteDurableMinSignificance: number | undefined;
+  private readonly autoPromoteDurableKinds: MemorableKind[] | undefined;
   private readonly graphPool: Pool | undefined;
   private readonly graphTenantId: string | undefined;
   /** Operator persona — first line(s) of the system prompt. See
@@ -962,6 +970,9 @@ export class Orchestrator {
     this.excerptExtractor = options.excerptExtractor;
     this.autoPromote = options.autoPromote ?? false;
     this.autoPromoteThreshold = options.autoPromoteThreshold ?? 0.7;
+    this.autoPromoteDurableMinSignificance =
+      options.autoPromoteDurableMinSignificance;
+    this.autoPromoteDurableKinds = options.autoPromoteDurableKinds;
     this.graphPool = options.graphPool;
     this.graphTenantId = options.graphTenantId;
     this.assistantIdentity =
@@ -1038,6 +1049,15 @@ export class Orchestrator {
       // Per-orchestrator isolation: stamp the producing Agent so auto-promoted
       // MK default-isolates to it (team/public promotion stays cross-agent).
       originAgent: this.agentId,
+      // Trigger T3 — durable auto-promotion gate (undefined → off).
+      ...(this.autoPromoteDurableMinSignificance !== undefined
+        ? {
+            durableMinSignificance: this.autoPromoteDurableMinSignificance,
+          }
+        : {}),
+      ...(this.autoPromoteDurableKinds !== undefined
+        ? { durableKinds: this.autoPromoteDurableKinds }
+        : {}),
       ...(opts.palaiaExcerpt ? { palaiaExcerpt: opts.palaiaExcerpt } : {}),
     };
     try {

--- a/middleware/packages/harness-orchestrator/src/plugin.ts
+++ b/middleware/packages/harness-orchestrator/src/plugin.ts
@@ -425,6 +425,20 @@ export async function activate(
     process.env['KG_ACL_AUTO_PROMOTE_THRESHOLD'],
     0.7,
   );
+  // Trigger T3 — durable auto-promotion: high-significance reference MK is
+  // marked manuallyAuthored (always-surface durable tier). Default ON at 0.85;
+  // set KG_DURABLE_AUTOPROMOTE=false to disable. Kinds default to ['reference']
+  // inside promoteTurnIfSignificant.
+  const durableAutoPromoteEnabled =
+    process.env['KG_DURABLE_AUTOPROMOTE'] === undefined
+      ? true
+      : parseBooleanEnv(process.env['KG_DURABLE_AUTOPROMOTE']);
+  const autoPromoteDurableMinSignificance = durableAutoPromoteEnabled
+    ? parseNumberOrDefault(
+        process.env['KG_DURABLE_AUTOPROMOTE_MIN_SIGNIFICANCE'],
+        0.85,
+      )
+    : undefined;
   const graphPool = ctx.services.get<Pool>(GRAPH_POOL_SERVICE);
   const graphTenantId =
     process.env['GRAPH_TENANT_ID'] ??
@@ -545,6 +559,9 @@ export async function activate(
     ...(processMemory ? { processMemory } : {}),
     autoPromote,
     autoPromoteThreshold,
+    ...(autoPromoteDurableMinSignificance !== undefined
+      ? { autoPromoteDurableMinSignificance }
+      : {}),
     ...(graphPool ? { graphPool } : {}),
     graphTenantId,
     ...(assistantIdentity ? { assistantIdentity } : {}),
@@ -714,7 +731,7 @@ export async function activate(
   }
 
   ctx.log(
-    `[harness-orchestrator] chatAgent@1 published (model=${model}, maxTokens=${String(maxTokens)}, maxIter=${String(maxIterations)}, verifier=${verifierBundle ? 'on' : 'off'}, calendar=${microsoft365 ? 'on' : 'off'}, contextRetriever=${contextRetriever ? 'on' : 'off'}, factExtractor=${factExtractor ? 'on' : 'off'}, palaiaExcerpt=${excerptExtractor ? 'on' : 'off'}, autoPromote=${autoPromote ? `on@${autoPromoteThreshold.toFixed(2)}` : 'off'}, embeddingClient=${embeddingClient ? 'on' : 'off'}, responseGuard=late-bound)`,
+    `[harness-orchestrator] chatAgent@1 published (model=${model}, maxTokens=${String(maxTokens)}, maxIter=${String(maxIterations)}, verifier=${verifierBundle ? 'on' : 'off'}, calendar=${microsoft365 ? 'on' : 'off'}, contextRetriever=${contextRetriever ? 'on' : 'off'}, factExtractor=${factExtractor ? 'on' : 'off'}, palaiaExcerpt=${excerptExtractor ? 'on' : 'off'}, autoPromote=${autoPromote ? `on@${autoPromoteThreshold.toFixed(2)}` : 'off'}, durableAutoPromote=${autoPromoteDurableMinSignificance !== undefined ? `on@${autoPromoteDurableMinSignificance.toFixed(2)}` : 'off'}, embeddingClient=${embeddingClient ? 'on' : 'off'}, responseGuard=late-bound)`,
   );
 
   return {

--- a/middleware/packages/plugin-api/src/knowledgeGraph.ts
+++ b/middleware/packages/plugin-api/src/knowledgeGraph.ts
@@ -806,6 +806,14 @@ export interface MemorableKnowledgeSearchOptions {
    * callers → no agent constraint.
    */
   viewerAgentSlug?: string;
+  /**
+   * Durable-tier filter. When true, only `manually_authored = true` MK are
+   * returned — applied at the SQL level so the always-surface durable recall
+   * leg ranks durable knowledge among itself, instead of over-fetching from
+   * the general pool (where higher-cosine session noise would crowd it out).
+   * Default false.
+   */
+  manuallyAuthoredOnly?: boolean;
 }
 
 /** Slice 7 — single MK hit from semantic search. */
@@ -1217,6 +1225,15 @@ export interface MemorableKnowledgeIngest {
    * and editable via {@link KnowledgeGraph.updateExcerpt}.
    */
   palaiaExcerpts?: PalaiaExcerptInput;
+  /**
+   * Durable-curation marker. When `true`, the new MK is written with the
+   * top-level `manually_authored` column set, which makes it eligible for the
+   * always-surface durable recall tier (see ContextRetriever durable leg).
+   * Default `false` → ordinary fuzzy/session MK. Set by the durable-promotion
+   * pipeline (the `_rules/`-write hook and high-significance auto-promotion),
+   * never by raw auto-harvesting.
+   */
+  manuallyAuthored?: boolean;
 }
 
 /**

--- a/middleware/scripts/backfill-durable-rules.ts
+++ b/middleware/scripts/backfill-durable-rules.ts
@@ -1,0 +1,116 @@
+/**
+ * Trigger T1 (backfill) — one-shot promotion of existing durable `_rules/`
+ * memory-files into the Knowledge-Graph as curated `manuallyAuthored` MK, so the
+ * always-surface durable recall tier (B1) can surface them. Shares the exact
+ * promotion logic with the live write-hook via `promoteRuleFileToDurable`.
+ *
+ * Usage (DRY-RUN by default — lists candidates, writes nothing):
+ *   npx tsx scripts/backfill-durable-rules.ts
+ *   npx tsx scripts/backfill-durable-rules.ts --apply
+ *
+ * Env: DATABASE_URL (required), GRAPH_TENANT_ID (default 'default'),
+ *      OLLAMA_BASE_URL / ollama_base_url (default http://localhost:11434),
+ *      OLLAMA_MODEL (default nomic-embed-text).
+ */
+import 'dotenv/config';
+import { Pool } from 'pg';
+import { NeonKnowledgeGraph } from '@omadia/knowledge-graph-neon';
+import { createEmbeddingClient } from '@omadia/embeddings';
+import {
+  promoteRuleFileToDurable,
+  isDurableRulePath,
+  DURABLE_RULES_PREFIX,
+} from '@omadia/orchestrator-extras';
+
+const APPLY = process.argv.includes('--apply');
+const TENANT = process.env['GRAPH_TENANT_ID'] ?? 'default';
+
+function log(msg: string): void {
+  console.log(msg);
+}
+
+async function main(): Promise<void> {
+  const dbUrl = process.env['DATABASE_URL'];
+  if (!dbUrl) throw new Error('DATABASE_URL required');
+
+  const ollamaBase =
+    process.env['OLLAMA_BASE_URL'] ??
+    process.env['ollama_base_url'] ??
+    'http://localhost:11434';
+  const ollamaModel = process.env['OLLAMA_MODEL'] ?? 'nomic-embed-text';
+
+  log(
+    `[durable-backfill] mode=${APPLY ? 'APPLY' : 'DRY-RUN'} tenant=${TENANT} ollama=${ollamaBase} model=${ollamaModel}`,
+  );
+
+  const pool = new Pool({ connectionString: dbUrl, max: 2 });
+  const embeddingClient = createEmbeddingClient({
+    baseUrl: ollamaBase,
+    model: ollamaModel,
+  });
+  const graph = new NeonKnowledgeGraph({
+    pool,
+    tenantId: TENANT,
+    embeddingClient,
+  });
+
+  // Pre-flight the embedder — a durable MK without an embedding is invisible to
+  // the recall tier, so fail loudly rather than create unsearchable nodes.
+  try {
+    const probe = await embeddingClient.embed('probe');
+    log(`[durable-backfill] embedder OK (dims=${String(probe.length)})`);
+  } catch (err) {
+    throw new Error(
+      `embedder unreachable at ${ollamaBase} (${err instanceof Error ? err.message : String(err)}). ` +
+        `Run inside the middleware container or set OLLAMA_BASE_URL.`,
+    );
+  }
+
+  const files = await pool.query<{ virtual_path: string; content: string }>(
+    `SELECT virtual_path, content FROM memory_files
+      WHERE virtual_path LIKE $1 || '%'
+      ORDER BY virtual_path`,
+    [DURABLE_RULES_PREFIX],
+  );
+  log(`[durable-backfill] found ${String(files.rows.length)} _rules/ file(s)`);
+
+  let created = 0;
+  let skipped = 0;
+  for (const { virtual_path, content } of files.rows) {
+    if (!isDurableRulePath(virtual_path)) {
+      log(`  - SKIP ${virtual_path} (not a durable rule path)`);
+      skipped++;
+      continue;
+    }
+    if (!APPLY) {
+      log(`  - WOULD PROMOTE ${virtual_path}`);
+      created++;
+      continue;
+    }
+    const res = await promoteRuleFileToDurable({
+      pool,
+      kg: graph,
+      tenantId: TENANT,
+      virtualPath: virtual_path,
+      content,
+      embeddingClient,
+      log,
+    });
+    log(`  - ${res.action.toUpperCase()} ${virtual_path}${res.mkId ? ` (mk=${res.mkId})` : ''}`);
+    if (res.action === 'created') created++;
+    else skipped++;
+  }
+
+  log(
+    `[durable-backfill] done: ${APPLY ? 'created' : 'would-create'}=${String(created)} skipped=${String(skipped)}`,
+  );
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error(
+    '[durable-backfill] FAILED:',
+    err instanceof Error ? err.message : err,
+  );
+  process.exit(1);
+});

--- a/middleware/test/durableRecall.test.ts
+++ b/middleware/test/durableRecall.test.ts
@@ -1,0 +1,260 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { EmbeddingClient } from '@omadia/embeddings';
+import { InMemoryKnowledgeGraph } from '@omadia/knowledge-graph-inmemory';
+import { ContextRetriever } from '@omadia/orchestrator-extras';
+import type { RecallRelevanceJudge } from '@omadia/orchestrator-extras';
+
+// B1 · durable-curation tier.
+//
+// Manual-authored MemorableKnowledge of the configured kinds must surface in
+// recall UNCONDITIONALLY: independent of the turn-term gate (so it survives a
+// term-less follow-up), with a low/no cosine floor (so a paraphrase still
+// hits), and — critically — it must NEVER be handed to the relevance judge.
+// A fuzzy insight (manuallyAuthored=false) must keep going through the gate +
+// floor + judge exactly as before.
+
+// A query vector and a DELIBERATELY low-overlap durable vector. cosine is low
+// (well under the fuzzy 0.6 floor) but > 0, so the durable tier (min-sim 0)
+// admits it while the fuzzy leg would not.
+const QUERY_VEC: number[] = [1, 0, 0, 0];
+const LOW_VEC: number[] = [0.2, 0.98, 0, 0]; // cosine(QUERY,LOW) ≈ 0.2
+
+/** Every text embeds to the query vector — the MK side is seeded directly via
+ *  `setEmbedding`, so query↔MK cosine is governed by the seeded MK vector. */
+const queryEmbedder: EmbeddingClient = {
+  async embed(): Promise<number[]> {
+    return [...QUERY_VEC];
+  },
+};
+
+/** Seed a durable (manual-authored) MK of the given kind with a LOW-cosine
+ *  embedding versus the query. Returns its node id. */
+async function seedDurableMk(
+  kg: InMemoryKnowledgeGraph,
+  kind: string,
+  summary: string,
+): Promise<string> {
+  // Exercise the real B2 ingest path: `manuallyAuthored: true` flows through
+  // createMemorableKnowledge → the top-level marker — no test-only setter.
+  const created = await kg.createMemorableKnowledge({
+    kind,
+    summary,
+    createdBy: 'web:bob',
+    involvedOmadiaUserIds: [],
+    aclOwners: ['bob'], // non-owner viewer ⇒ needs teamVisibility
+    manuallyAuthored: true,
+  });
+  const id = created.memorableKnowledgeNodeId;
+  kg.setEmbedding(id, LOW_VEC);
+  return id;
+}
+
+/** Seed a fuzzy (auto-captured, manuallyAuthored=false) MK aligned to the
+ *  query so it would clear the fuzzy floor and reach the judge. */
+async function seedFuzzyMk(
+  kg: InMemoryKnowledgeGraph,
+  summary: string,
+): Promise<string> {
+  const created = await kg.createMemorableKnowledge({
+    kind: 'reference',
+    summary,
+    createdBy: 'web:bob',
+    involvedOmadiaUserIds: [],
+    aclOwners: ['bob'],
+  });
+  kg.setEmbedding(created.memorableKnowledgeNodeId, [...QUERY_VEC]);
+  return created.memorableKnowledgeNodeId;
+}
+
+/** A judge that records every candidate id it ever sees and drops all
+ *  `insight` candidates. Durable hits must NOT appear in `seen`. */
+function recordingJudge(): {
+  judge: RecallRelevanceJudge;
+  seen: Set<string>;
+} {
+  const seen = new Set<string>();
+  const judge: RecallRelevanceJudge = {
+    async filterRelevant(_msg, candidates): Promise<Set<string>> {
+      for (const c of candidates) seen.add(c.id);
+      // Reject every insight; keep plans/processes.
+      return new Set(
+        candidates.filter((c) => c.kind !== 'insight').map((c) => c.id),
+      );
+    },
+  };
+  return { judge, seen };
+}
+
+describe('B1 · durable-curation tier surfaces manual MK', () => {
+  it('(a) WITH terms: low-cosine durable reference surfaces despite the fuzzy floor', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const mkId = await seedDurableMk(
+      kg,
+      'reference',
+      'Die Reisekosten-DSN liegt im Vault unter billing/staging',
+    );
+    const retriever = new ContextRetriever(
+      kg,
+      { teamVisibility: true },
+      queryEmbedder,
+    );
+    const result = await retriever.assembleForBudget({
+      userMessage: 'Wie lauten die Urlaubsregeln für Teilzeitkräfte?',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    assert.equal(result.recalled.insights.length, 1, 'durable insight present');
+    assert.equal(result.recalled.insights[0]!.mkId, mkId);
+  });
+
+  it('(b) TERM-LESS follow-up: durable still surfaces (bypasses the turn gate)', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    // Also seed a fuzzy MK; on a term-less turn the fuzzy leg must stay closed
+    // while the durable leg still fires.
+    await seedFuzzyMk(kg, 'auto-captured note that must NOT surface term-less');
+    const mkId = await seedDurableMk(kg, 'decision', 'Wir nutzen Odoo 17 CE');
+    const retriever = new ContextRetriever(
+      kg,
+      { teamVisibility: true },
+      queryEmbedder,
+    );
+    const result = await retriever.assembleForBudget({
+      userMessage: 'ok?', // no extractable terms → fuzzy gate closes
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    assert.equal(
+      result.recalled.insights.length,
+      1,
+      'only the durable insight survives the term-less turn',
+    );
+    assert.equal(result.recalled.insights[0]!.mkId, mkId);
+  });
+
+  it('(c) paraphrased query: low-cosine durable still surfaces', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const mkId = await seedDurableMk(
+      kg,
+      'reference',
+      'Stammdaten-Konvention: Kundennummern sind 6-stellig',
+    );
+    const retriever = new ContextRetriever(
+      kg,
+      { teamVisibility: true },
+      queryEmbedder,
+    );
+    // A topically-distant paraphrase — embeds to QUERY_VEC, cosine ≈ 0.2 to the
+    // MK. The fuzzy leg (floor 0.6) would drop it; the durable leg keeps it.
+    const result = await retriever.assembleForBudget({
+      userMessage: 'Erzähl mir etwas völlig anderes über das Wetter',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    assert.equal(result.recalled.insights.length, 1);
+    assert.equal(result.recalled.insights[0]!.mkId, mkId);
+  });
+
+  it('durable hits are NEVER submitted to the relevance judge', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const durableId = await seedDurableMk(
+      kg,
+      'reference',
+      'Durable curated fact that must bypass the judge',
+    );
+    const { judge, seen } = recordingJudge();
+    const retriever = new ContextRetriever(
+      kg,
+      { teamVisibility: true },
+      queryEmbedder,
+      undefined,
+      undefined,
+      judge,
+    );
+    const result = await retriever.assembleForBudget({
+      userMessage: 'Was waren die wichtigsten Buchungsregeln?',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    // The judge would have dropped any insight it saw → durable survives only
+    // because it never reached the judge.
+    assert.equal(result.recalled.insights.length, 1, 'durable insight kept');
+    assert.equal(result.recalled.insights[0]!.mkId, durableId);
+    assert.equal(
+      seen.has(durableId),
+      false,
+      'durable id must NOT appear in the judge candidate set',
+    );
+  });
+
+  it('a fuzzy insight still goes through gate + floor + judge unchanged', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    const fuzzyId = await seedFuzzyMk(kg, 'generic auto-captured billing note');
+    const { judge, seen } = recordingJudge();
+    const retriever = new ContextRetriever(
+      kg,
+      { teamVisibility: true },
+      queryEmbedder,
+      undefined,
+      undefined,
+      judge,
+    );
+    const result = await retriever.assembleForBudget({
+      userMessage: 'how do I run the billing migration in staging?',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    // The fuzzy MK reached the judge (recorded) and was dropped (kind=insight).
+    assert.equal(seen.has(fuzzyId), true, 'fuzzy insight reached the judge');
+    assert.equal(
+      result.recalled.insights.length,
+      0,
+      'fuzzy insight judged out — pre-B1 behaviour preserved',
+    );
+  });
+
+  it('durableTierDisabled=true restores pre-tier behaviour (no durable insertion)', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    await seedDurableMk(kg, 'reference', 'Durable fact that must stay hidden');
+    const retriever = new ContextRetriever(
+      kg,
+      { teamVisibility: true, durableTierDisabled: true },
+      queryEmbedder,
+    );
+    const result = await retriever.assembleForBudget({
+      userMessage: 'Wie lauten die Urlaubsregeln?',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    assert.equal(
+      result.recalled.insights.length,
+      0,
+      'durable tier off → low-cosine manual MK does not surface',
+    );
+  });
+
+  it('only the configured durableKinds are admitted (a non-durable kind is ignored)', async () => {
+    const kg = new InMemoryKnowledgeGraph();
+    // kind 'scratch' is NOT in the default reference,decision set.
+    await seedDurableMk(kg, 'scratch', 'manual but wrong kind');
+    const retriever = new ContextRetriever(
+      kg,
+      { teamVisibility: true },
+      queryEmbedder,
+    );
+    const result = await retriever.assembleForBudget({
+      userMessage: 'Wie lauten die Urlaubsregeln?',
+      agentId: 'test-agent',
+      sessionScope: 'sess-now',
+      userId: 'alice',
+    });
+    assert.equal(result.recalled.insights.length, 0, 'wrong kind not admitted');
+  });
+});


### PR DESCRIPTION
## Problem

Since PR #310 (recall-relevance-gate + LLM judge) the agent stopped surfacing learned **durable** long-term knowledge — concretely a customer's course-DB schema. Root cause (verified live against omadia-test): the real schema lived only in `_rules/` memory-files with no deterministic auto-inject, while the KG's auto-recall panel held mostly session-harvested echoes that the cosine cap + judge dropped. There was **no always-available durable tier** in the KG and **no escalation** of durable knowledge into one.

## What this does

Makes the Knowledge Graph the canonical home for durable long-term knowledge, with a deterministic always-surface tier plus automatic escalation into it. The fuzzy/PR-#310 recall path is unchanged when the new flags are off.

**B1 — durable always-surface recall tier** (`contextRetriever`)
- `loadDurableHits` leg for `manuallyAuthored` reference/decision MK: gate-independent, no cosine floor, reserved slots before the memory cap, bypasses the relevance judge.
- `searchMemorableKnowledgeByEmbedding` gains SQL-level `manuallyAuthoredOnly` so durable MK rank among themselves instead of being crowded out of the over-fetch window by higher-cosine session noise.
- Config: `kg_durable_tier_enabled`, `kg_durable_reserved_slots`, `kg_durable_kinds`, `kg_durable_min_similarity`.

**B2 — ingest API** `MemorableKnowledgeIngest.manuallyAuthored` (plugin-api + neon `manually_authored` column in `upsertNode` + neon/inmemory create).

**B3 — automatic escalation into the durable tier**
- **T1 live hook** — `DurableRulesMemoryStore` decorator promotes every write to `/memories/_rules/` into a curated `manuallyAuthored` MK via the shared, idempotent `promoteRuleFileToDurable` (embeds inline). Gated by `KG_DURABLE_RULES_HOOK`.
- **T1 backfill** — `scripts/backfill-durable-rules.ts` (one-shot, dry-run by default).
- **T3** — `promoteTurnIfSignificant` marks high-significance reference turns durable (`>= KG_DURABLE_AUTOPROMOTE_MIN_SIGNIFICANCE`, default 0.85) behind a narration/snapshot hygiene filter.

## Verification

- `node:test` recall + promotion suites green (76/76), incl. 7 new durable-tier cases.
- Deployed to omadia-test; backfill promoted the live `_rules/dynamics-courses.md` / `dynamics-kurse.md` / `smart-cards.md`. Durable-leg query returns the course schema as top-2 for "Welche Kurse haben wir diese Woche?", "Wie ist unsere Kurs-Datenbank aufgebaut?" and the term-less follow-up "und nächste Woche?".
- T1 hook verified live: a `_rules/` write creates a curated, embedded `manuallyAuthored` MK; re-write is idempotent.

## Notes / follow-ups

- Default-on knobs: `durableTier`, `durableAutoPromote@0.85`, `KG_DURABLE_RULES_HOOK`.
- The durable insight is rendered truncated to 300 chars (existing `toRecalledInsight`) — raising that for schema knowledge is a possible follow-up.
- Cleanup of the ~74 legacy auto-harvested MK (narration/snapshots) is out of scope here.
