### PR TITLE
feat(platform): runtime credentials + flow toolkit + plugin status (spec 004)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,6 +49,13 @@ middleware/fly-memory-pull
 middleware/packages/*/dist
 middleware/packages/*/tsconfig.tsbuildinfo
 middleware/packages/*/node_modules
+# Hub-distributed plugins (gitignored): these ship via the Hub / zip-upload,
+# never baked into the core image. Without this their source is copied and the
+# catalog registers them as BUILT-IN entries — but the middleware build chain
+# never compiles their dist/, so activation fails ("entry file not readable")
+# and the operator upload path 409s on a built-in id conflict. Keep them out.
+middleware/packages/integration-github
+middleware/packages/agent-github
 middleware/scripts
 # Re-include the build-asset copier — it runs as part of `npm run build`
 # inside the Docker builder stage.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,10 @@ jobs:
           load: true
           tags: omadia-middleware:ci-${{ github.sha }}
           cache-from: type=gha,scope=middleware
-          cache-to: type=gha,scope=middleware,mode=max
+          # ignore-error: a GitHub Actions cache-export hiccup ("error writing
+          # layer blob: not_found") must not fail an otherwise-successful image
+          # build. The cache is an optimization, not a build gate.
+          cache-to: type=gha,scope=middleware,mode=max,ignore-error=true
 
       - name: Image size + layer summary
         run: |
@@ -86,7 +89,8 @@ jobs:
           build-args: |
             MIDDLEWARE_URL=http://middleware:8080
           cache-from: type=gha,scope=web-ui
-          cache-to: type=gha,scope=web-ui,mode=max
+          # See the middleware job: a cache-export error is non-fatal.
+          cache-to: type=gha,scope=web-ui,mode=max,ignore-error=true
 
       - name: Image size + layer summary
         run: |

--- a/middleware/.env.example
+++ b/middleware/.env.example
@@ -98,6 +98,12 @@ DIAGRAM_URL_SECRET=
 # the middleware on :8080.
 DIAGRAM_PUBLIC_BASE_URL=http://localhost:8080
 
+# --- Plugin credential flows (spec 004) -------------------------------------
+# Browser-facing origin that plugin OAuth/credential flow callbacks resolve
+# against (ctx.flows.publicUrl). Defaults to PUBLIC_BASE_URL — set this only
+# when flow callbacks must land on a different origin than the admin UI (rare).
+# FLOW_PUBLIC_BASE_URL=https://omadia.example.com
+
 # Object-storage credentials. Locally filled by docker-compose.yaml's MinIO.
 BUCKET_NAME=diagrams
 AWS_ENDPOINT_URL_S3=http://localhost:9000

--- a/middleware/assets/boilerplate/agent-integration/types.ts
+++ b/middleware/assets/boilerplate/agent-integration/types.ts
@@ -14,10 +14,17 @@ export interface PluginContext {
     get(key: string): Promise<string | undefined>;
     require(key: string): Promise<string>;
     keys(): Promise<string[]>;
+    /** Spec 004 — present only with `permissions.secrets.runtime_write`.
+     *  Writes to THIS plugin's namespace; guard with `if (ctx.secrets.set)`. */
+    set?(key: string, value: string): Promise<void>;
+    delete?(key: string): Promise<void>;
   };
   readonly config: {
     get<T = unknown>(key: string): T | undefined;
     require<T = unknown>(key: string): T;
+    /** Spec 004 — persist a non-secret declared setup field. Present only
+     *  with `permissions.secrets.runtime_write`. */
+    set?(key: string, value: unknown): Promise<void>;
   };
   /** Cross-plugin service registry. Used by `spec.external_reads` (Theme A)
    *  to consume typed surfaces from depends_on plugins (e.g.

--- a/middleware/assets/boilerplate/agent-integration/types.ts
+++ b/middleware/assets/boilerplate/agent-integration/types.ts
@@ -96,6 +96,14 @@ export interface PluginContext {
    *  per-call max-tokens-clamp are enforced by the manifest. */
   readonly llm?: LlmAccessor;
 
+  /** Spec 004 — redirect/callback flow toolkit. Present iff the manifest
+   *  declares `permissions.flows: true`. `publicUrl(rel)` resolves this
+   *  plugin's own browser-facing callback URL; `signState`/`verifyState`
+   *  mint and check a CSRF-safe, plugin-audience-bound state token (the
+   *  signing key stays kernel-side). Guard with `if (ctx.flows)` — an older
+   *  core may not provide it. */
+  readonly flows?: FlowsAccessor;
+
   /** Per-plugin memory store, scoped to `/memories/agents/<agentId>/`.
    *  All paths are RELATIVE — `notes.md` resolves to
    *  `/memories/agents/<agentId>/notes.md` under the hood. Plugins cannot
@@ -146,6 +154,30 @@ export interface MemoryEntryInfo {
   readonly relPath: string;
   readonly isDirectory: boolean;
   readonly sizeBytes: number;
+}
+
+/**
+ * Spec 004 — flow toolkit (mirror of `FlowsAccessor` from
+ * `@omadia/plugin-api`). For plugins that run a redirect/callback flow on
+ * their own route. The kernel owns the public-URL topology and the HS512
+ * state-signing key; the plugin owns its route handler. The state token's
+ * audience is auto-bound to this plugin id, so it cannot be replayed against
+ * another plugin's callback.
+ */
+export interface FlowsAccessor {
+  /** Resolve this plugin's browser-facing callback URL (for an IdP
+   *  `redirect_url`). A route registered at `/api/<…>` is reached via the
+   *  `/bot-api/* → /api/*` proxy, so the leading `/api` is dropped. Pass
+   *  `opts.prefix` only when the plugin registered several routes. */
+  publicUrl(relPath: string, opts?: { prefix?: string }): string;
+  /** Sign arbitrary claims into a short-lived (10-min default) state token. */
+  signState(
+    claims: Record<string, unknown>,
+    opts?: { ttl?: string },
+  ): Promise<string>;
+  /** Verify a returned state token; throws on bad signature, wrong audience,
+   *  or expiry. Returns the decoded claims. */
+  verifyState(token: string): Promise<Record<string, unknown>>;
 }
 
 /**

--- a/middleware/assets/boilerplate/agent-integration/types.ts
+++ b/middleware/assets/boilerplate/agent-integration/types.ts
@@ -104,6 +104,12 @@ export interface PluginContext {
    *  core may not provide it. */
   readonly flows?: FlowsAccessor;
 
+  /** Spec 004 — report an operator-facing action status (e.g. "not connected
+   *  yet"). The admin UI renders it as a badge on the plugin card + a banner
+   *  on the detail page, clearing when the plugin reports `ok`. Always present,
+   *  ungated; re-report on `activate()` (in-memory, self-heals on restart). */
+  readonly status: StatusAccessor;
+
   /** Per-plugin memory store, scoped to `/memories/agents/<agentId>/`.
    *  All paths are RELATIVE — `notes.md` resolves to
    *  `/memories/agents/<agentId>/notes.md` under the hood. Plugins cannot
@@ -178,6 +184,20 @@ export interface FlowsAccessor {
   /** Verify a returned state token; throws on bad signature, wrong audience,
    *  or expiry. Returns the decoded claims. */
   verifyState(token: string): Promise<Record<string, unknown>>;
+}
+
+/** Operator-facing plugin health (mirror of `@omadia/plugin-api`). */
+export type PluginActionState = 'ok' | 'needs_action' | 'error';
+
+export interface PluginActionStatus {
+  readonly state: PluginActionState;
+  readonly title?: string;
+  readonly detail?: string;
+}
+
+export interface StatusAccessor {
+  report(status: PluginActionStatus): void;
+  clear(): void;
 }
 
 /**

--- a/middleware/packages/plugin-api/src/index.ts
+++ b/middleware/packages/plugin-api/src/index.ts
@@ -1,4 +1,7 @@
 export * from './pluginContext.js';
+// Spec 004 FR-B4 — PKCE (RFC 7636) helpers as pure SDK functions, for plugins
+// running their own redirect/OAuth flows alongside `ctx.flows`.
+export * from './pkce.js';
 export * from './conversation.js';
 export * from './limitSignal.js';
 export * from './selfExtend.js';

--- a/middleware/packages/plugin-api/src/pkce.ts
+++ b/middleware/packages/plugin-api/src/pkce.ts
@@ -1,0 +1,42 @@
+/**
+ * RFC 7636 — PKCE helpers, exported as pure SDK functions (spec 004 FR-B4).
+ *
+ * Lifted from the kernel's `src/plugins/oauth/pkce.ts` so any plugin running
+ * its own redirect flow (the GitHub App-Manifest dance, a device flow, a
+ * bespoke OAuth client) can mint a verifier/challenge pair without reaching
+ * back into the middleware. The kernel re-exports these same functions, so
+ * there is a single implementation.
+ *
+ * Verifier is a high-entropy (32-byte) URL-safe base64 string; challenge is
+ * the S256 hash of the verifier in URL-safe base64. Both are fully stateless —
+ * the caller stores the verifier and sends the challenge through the IdP
+ * round-trip.
+ */
+
+import crypto from 'node:crypto';
+
+/** RFC 7636 §4.1 verifier length is 43-128 chars; 32 random bytes ≈ 43
+ *  base64url chars, the minimum spec-allowed. 32B already gives 256 bits of
+ *  entropy. */
+const VERIFIER_BYTES = 32;
+
+/** Base64url encode without padding — what RFC 7636 requires. */
+function base64url(buf: Buffer): string {
+  return buf
+    .toString('base64')
+    .replace(/=+$/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+/** Generate a fresh PKCE code-verifier. The caller MUST store this securely
+ *  until the callback redeems the auth-code. */
+export function generateCodeVerifier(): string {
+  return base64url(crypto.randomBytes(VERIFIER_BYTES));
+}
+
+/** Compute the S256 code-challenge for a verifier. The challenge is the value
+ *  that goes into the authorize-URL; the verifier stays on the server. */
+export function computeCodeChallenge(verifier: string): string {
+  return base64url(crypto.createHash('sha256').update(verifier).digest());
+}

--- a/middleware/packages/plugin-api/src/pluginContext.ts
+++ b/middleware/packages/plugin-api/src/pluginContext.ts
@@ -154,6 +154,14 @@ export interface PluginContext {
    *  a Hub plugin may land on an older core that lacks it. */
   readonly flows?: FlowsAccessor;
 
+  /** Report an operator-facing action status (e.g. "not connected yet"). The
+   *  kernel holds the latest value per plugin and the admin UI renders it as a
+   *  badge on the plugin card + a banner on the detail page that clears when
+   *  the plugin reports `ok`. Always present, ungated — a plugin reports only
+   *  its OWN status. In-memory: re-report on `activate()` so it self-heals
+   *  after a restart. */
+  readonly status: StatusAccessor;
+
   log(...args: unknown[]): void;
 }
 
@@ -545,6 +553,36 @@ export interface FlowsAccessor {
    * `aud`, `iat`, `exp`) on success.
    */
   verifyState(token: string): Promise<Record<string, unknown>>;
+}
+
+/**
+ * Normalized, operator-facing health of a plugin. `ok` = nothing to do;
+ * `needs_action` = a required setup/connection step is pending (rendered as an
+ * amber badge + banner with a call-to-action toward the plugin's admin UI);
+ * `error` = misconfigured/failing (red). The kernel maps these to the UI;
+ * `title`/`detail` let the plugin phrase the specifics ("Nicht verbunden" /
+ * "Erstelle die GitHub App in der Admin-UI").
+ */
+export type PluginActionState = 'ok' | 'needs_action' | 'error';
+
+export interface PluginActionStatus {
+  readonly state: PluginActionState;
+  /** Short label for the badge/banner (e.g. "Nicht verbunden"). */
+  readonly title?: string;
+  /** One-line detail / next step (e.g. "Verbindung in der Admin-UI herstellen"). */
+  readonly detail?: string;
+}
+
+/**
+ * Push-based status reporter. A plugin calls `report(...)` whenever its
+ * operator-facing state changes (typically from its discovery/health check),
+ * and `clear()` once everything is fine. The kernel keeps only the latest
+ * value per plugin; there is no history. Reporting another plugin's status is
+ * impossible — the accessor is bound to the calling plugin's id.
+ */
+export interface StatusAccessor {
+  report(status: PluginActionStatus): void;
+  clear(): void;
 }
 
 /**

--- a/middleware/packages/plugin-api/src/pluginContext.ts
+++ b/middleware/packages/plugin-api/src/pluginContext.ts
@@ -761,6 +761,15 @@ export interface SecretsAccessor {
   require(key: string): Promise<string>;
   /** Keys present in the vault for this plugin. Never returns values. */
   keys(): Promise<string[]>;
+  /** Spec 004 — create or overwrite a secret in THIS plugin's namespace.
+   *  Present only when the manifest declares `permissions.secrets.runtime_write`
+   *  (otherwise `undefined`). Used by runtime credential-acquisition flows to
+   *  persist an acquired secret (e.g. a GitHub App private key). Cannot reach
+   *  another plugin's namespace. Guard with `if (ctx.secrets.set)`. */
+  set?(key: string, value: string): Promise<void>;
+  /** Spec 004 — remove a secret from this plugin's namespace. No-op if absent.
+   *  Present only with `permissions.secrets.runtime_write`. */
+  delete?(key: string): Promise<void>;
 }
 
 /**
@@ -781,6 +790,12 @@ export interface ConfigAccessor {
   get<T = unknown>(key: string): T | undefined;
   /** Returns the config value, or throws a MissingConfigError. */
   require<T = unknown>(key: string): T;
+  /** Spec 004 — persist a NON-secret config value to this plugin's own
+   *  installed-registry config. The key MUST be a declared, non-secret setup
+   *  field (secrets go through `secrets.set`). Present only when the manifest
+   *  declares `permissions.secrets.runtime_write`. Guard with
+   *  `if (ctx.config.set)`. */
+  set?(key: string, value: unknown): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------

--- a/middleware/packages/plugin-api/src/pluginContext.ts
+++ b/middleware/packages/plugin-api/src/pluginContext.ts
@@ -143,6 +143,17 @@ export interface PluginContext {
    *  rephrasing) without managing API keys themselves — the host pays. */
   readonly llm?: LlmAccessor;
 
+  /** Spec 004 — redirect/callback flow toolkit. Present iff the manifest
+   *  declares `permissions.flows: true`. Supplies the three things a plugin
+   *  needs to run a credential-acquisition round-trip on its OWN route:
+   *  the public callback URL (`publicUrl`), and a CSRF-safe, plugin-audience-
+   *  bound state token (`signState`/`verifyState`). The signing key is held by
+   *  the kernel and never reaches plugin code — a token signed for plugin A
+   *  fails `verifyState` in plugin B. Used by the GitHub App-Manifest flow;
+   *  re-usable by any future device/OAuth dance. Guard with `if (ctx.flows)` —
+   *  a Hub plugin may land on an older core that lacks it. */
+  readonly flows?: FlowsAccessor;
+
   log(...args: unknown[]): void;
 }
 
@@ -486,6 +497,54 @@ export interface ToolRegistrationOptions {
  */
 export interface RoutesAccessor {
   register(prefix: string, router: unknown): () => void;
+}
+
+/**
+ * Spec 004 — toolkit for plugins that run a redirect/callback flow on their
+ * own route (`permissions.flows: true`). The kernel owns the public-URL
+ * topology and the state-signing key; the plugin owns its route handler and
+ * the provider-specific logic (what to POST, how to parse the response).
+ *
+ * Threat model: the state token is the CSRF guard for the whole round-trip.
+ * The kernel auto-binds its audience to the calling plugin id, so a token
+ * minted by (or for) one plugin cannot be replayed against another's
+ * callback. The HS512 signing key is kernel-held; `signState`/`verifyState`
+ * close over it without ever exposing it.
+ */
+export interface FlowsAccessor {
+  /**
+   * Resolve the browser-facing absolute URL for one of this plugin's own
+   * routes — the value to hand an external IdP as a `redirect_url`.
+   *
+   * Mirrors how the store-detail page reaches a plugin's admin UI: the
+   * plugin's route is mounted on the middleware under `/api/<…>`, and the
+   * browser reaches it through the `/bot-api/*` → `/api/*` proxy. So a route
+   * registered at prefix `/api/github` with `relPath = 'flow/callback'`
+   * resolves to `{FLOW_PUBLIC_BASE_URL}/bot-api/github/flow/callback`.
+   *
+   * The prefix is the plugin's sole registered route prefix; when the plugin
+   * registered several, pass `opts.prefix` to disambiguate. `relPath` is
+   * relative (a leading slash is tolerated). Throws if no route is registered
+   * yet (register the route before calling) or if the prefix is ambiguous.
+   */
+  publicUrl(relPath: string, opts?: { prefix?: string }): string;
+  /**
+   * Sign arbitrary claims into a short-lived (10-min default) HS512 state
+   * token. The kernel sets `iss=omadia`, `aud=plugin:<thisPluginId>`, and the
+   * issued-at/expiry — the plugin only supplies its own claims (e.g. a nonce,
+   * a return path). Use the result as the `state` query-param of the flow.
+   */
+  signState(
+    claims: Record<string, unknown>,
+    opts?: { ttl?: string },
+  ): Promise<string>;
+  /**
+   * Verify a state token returned on the callback. Rejects (throws) a token
+   * whose signature is invalid, whose `aud` is not this plugin, or whose TTL
+   * has expired. Returns the decoded claims (including the standard `iss`,
+   * `aud`, `iat`, `exp`) on success.
+   */
+  verifyState(token: string): Promise<Record<string, unknown>>;
 }
 
 /**

--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -110,6 +110,15 @@ export interface PluginPermissionsSummary {
   /** OB-29-3: hard-cap on `LlmCompleteRequest.maxTokens`. Plugin-side
    *  larger values are silently clamped, not rejected. Default 4096. */
   llm_max_tokens_per_call?: number;
+  /** Spec 004: plugin may write its OWN vault secrets + config at runtime
+   *  (`ctx.secrets.set`/`delete`, `ctx.config.set`). Namespace-locked — a
+   *  plugin can never reach another's secrets. Surfaced as a store-detail
+   *  chip. Loader defaults to `false`. */
+  secrets_runtime_write?: boolean;
+  /** Spec 004: plugin runs credential-acquisition flows on its own routes —
+   *  the `ctx.flows` accessor (public-callback-URL resolution + kernel-held
+   *  state signing) is provisioned. Loader defaults to `false`. */
+  flows?: boolean;
 }
 
 export type PluginInstallState =

--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -206,6 +206,19 @@ export interface ChannelManifestBlock {
  */
 export type LocalizedMarkdown = Record<string, string>;
 
+/**
+ * Spec 004 — operator-facing plugin health, pushed by the plugin via
+ * `ctx.status` (mirror of `@omadia/plugin-api`'s `PluginActionStatus`, kept
+ * inline so this type contract stays dependency-free).
+ */
+export type PluginActionState = 'ok' | 'needs_action' | 'error';
+
+export interface PluginActionStatus {
+  state: PluginActionState;
+  title?: string;
+  detail?: string;
+}
+
 export interface Plugin {
   id: AgentId;
   kind: PluginKind;
@@ -294,6 +307,14 @@ export interface Plugin {
    * Path includes a leading slash, e.g. `/api/telegram/admin/ui/`.
    */
   admin_ui_path?: string;
+  /**
+   * Spec 004 — operator-facing action status the (active) plugin pushed via
+   * `ctx.status`. Present only while it reports `needs_action` / `error`;
+   * absent for `ok` or an inactive plugin. The web-ui renders it as a badge on
+   * the plugin card + a banner on the detail page, both clearing when the
+   * plugin reports `ok`.
+   */
+  action_status?: PluginActionStatus;
   /**
    * OB-29-0 marker. When `true`, this plugin is a Builder-Reference
    * (Pattern-Quelle für den BuilderAgent) and MUST NOT appear in the
@@ -404,6 +425,12 @@ export interface InstallSetupField {
    *  contain newlines, e.g. PEM private keys. Older UIs ignore the flag
    *  and fall back to a single-line input. */
   multiline?: boolean;
+  /** Omit this field from the initial install flyout to keep first-time setup
+   *  minimal. The field stays declared (so a runtime flow may write it via
+   *  `ctx.config.set`) and editable later via the store-detail setup editor —
+   *  it just isn't shown at install time. For flow-populated credentials.
+   *  Older UIs ignore the flag and render the field as usual. */
+  install_hidden?: boolean;
 }
 
 export interface InstallSetupSchema {

--- a/middleware/src/channels/channelRegistry.ts
+++ b/middleware/src/channels/channelRegistry.ts
@@ -1,6 +1,7 @@
 import { createPluginContext } from '../platform/pluginContext.js';
 import type { PluginRouteRegistry } from '../platform/pluginRouteRegistry.js';
 import type { NotificationRouter } from '../platform/notificationRouter.js';
+import type { PluginStatusRegistry } from '../platform/pluginStatusRegistry.js';
 import type { UiRouteCatalog } from '../platform/uiRouteCatalog.js';
 import type { ServiceRegistry } from '../platform/serviceRegistry.js';
 import type { InstalledRegistry } from '../plugins/installedRegistry.js';
@@ -42,6 +43,8 @@ export interface ChannelRegistryDeps {
   /** Spec 004 — key + origin for the `ctx.flows` toolkit (optional in tests). */
   flowSigningKey?: Uint8Array;
   flowPublicBaseUrl?: string;
+  /** Spec 004 — backing store for `ctx.status`; cleared on deactivate. */
+  pluginStatusRegistry?: PluginStatusRegistry;
   resolver: ChannelPluginResolver;
   coreApi: CoreApi;
   routes: ExpressRouteRegistry;
@@ -106,6 +109,7 @@ export class DefaultChannelRegistry implements ChannelRegistry {
       jobScheduler: this.deps.jobScheduler,
       flowSigningKey: this.deps.flowSigningKey,
       flowPublicBaseUrl: this.deps.flowPublicBaseUrl,
+      pluginStatusRegistry: this.deps.pluginStatusRegistry,
     });
 
     const handle = await impl.activate(ctx, this.deps.coreApi);
@@ -130,6 +134,7 @@ export class DefaultChannelRegistry implements ChannelRegistry {
     // would otherwise outlive its plugin in the catalogue and surface
     // a stale entry in channel-teams' Hub + Tab-Config dropdown.
     this.deps.uiRouteCatalog.disposeBySource(agentId);
+    this.deps.pluginStatusRegistry?.clear(agentId);
     if (!handle) return;
     this.handles.delete(agentId);
     try {

--- a/middleware/src/channels/channelRegistry.ts
+++ b/middleware/src/channels/channelRegistry.ts
@@ -39,6 +39,9 @@ export interface ChannelRegistryDeps {
   notificationRouter: NotificationRouter;
   uiRouteCatalog: UiRouteCatalog;
   jobScheduler: JobScheduler;
+  /** Spec 004 — key + origin for the `ctx.flows` toolkit (optional in tests). */
+  flowSigningKey?: Uint8Array;
+  flowPublicBaseUrl?: string;
   resolver: ChannelPluginResolver;
   coreApi: CoreApi;
   routes: ExpressRouteRegistry;
@@ -101,6 +104,8 @@ export class DefaultChannelRegistry implements ChannelRegistry {
       notificationRouter: this.deps.notificationRouter,
       uiRouteCatalog: this.deps.uiRouteCatalog,
       jobScheduler: this.deps.jobScheduler,
+      flowSigningKey: this.deps.flowSigningKey,
+      flowPublicBaseUrl: this.deps.flowPublicBaseUrl,
     });
 
     const handle = await impl.activate(ctx, this.deps.coreApi);

--- a/middleware/src/config.ts
+++ b/middleware/src/config.ts
@@ -122,6 +122,11 @@ const ConfigSchema = z.object({
     .string()
     .url()
     .default('http://localhost:3979'),
+  // Spec 004 (FR-B5) — browser-facing origin that plugin flow-callback URLs
+  // (`ctx.flows.publicUrl`) resolve against. Defaults to PUBLIC_BASE_URL; set
+  // it only when flow callbacks must land on a different origin than the rest
+  // of the admin UI (rare). Mirrors the AUTH_REDIRECT_URI precedent.
+  FLOW_PUBLIC_BASE_URL: z.string().url().optional(),
   // Absolute URL Azure AD redirects to after login. MUST be registered
   // verbatim in the MS365 App Registration. In prod: middleware's own
   // /api/v1/auth/callback. In dev: http://localhost:3000/bot-api/v1/auth/callback

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -199,6 +199,7 @@ import { PromptContributionRegistry } from './platform/promptContributionRegistr
 import { installProcessGuards } from './platform/processGuards.js';
 import { PluginRouteRegistry } from './platform/pluginRouteRegistry.js';
 import { NotificationRouter } from './platform/notificationRouter.js';
+import { PluginStatusRegistry } from './platform/pluginStatusRegistry.js';
 import { UiRouteCatalog } from './platform/uiRouteCatalog.js';
 import { CanvasOutputRegistry } from './platform/canvasOutputRegistry.js';
 import { DeterministicActionRegistry } from './platform/deterministicActionRegistry.js';
@@ -341,6 +342,10 @@ async function main(): Promise<void> {
   // 'uiRouteCatalog')`. Published BEFORE any plugin activates so the
   // service is available the moment a consumer asks for it.
   serviceRegistry.provide('uiRouteCatalog', uiRouteCatalog);
+
+  // Spec 004 — kernel store of plugin action statuses (ctx.status). Read by the
+  // admin API to surface "Aktion erforderlich" badges/banners in the store UI.
+  const pluginStatusRegistry = new PluginStatusRegistry();
 
   // Shared Anthropic client used by sub-agents (LocalSubAgent inner Claude
   // calls) and the Teams channel (anthropicClient dep). The orchestrator-
@@ -687,6 +692,7 @@ async function main(): Promise<void> {
     jobScheduler,
     flowSigningKey: sessionSigningKey,
     flowPublicBaseUrl,
+    pluginStatusRegistry,
     canvasOutputRegistry,
     deterministicActionRegistry,
     log: (...a) => console.log(...a),
@@ -757,6 +763,7 @@ async function main(): Promise<void> {
     jobScheduler,
     flowSigningKey: sessionSigningKey,
     flowPublicBaseUrl,
+    pluginStatusRegistry,
     selfExtendRegistry,
     extensionStore,
     // When an integration plugin activates — at boot OR via a live hot-
@@ -2226,6 +2233,7 @@ async function main(): Promise<void> {
       catalog: pluginCatalog,
       registry: installedRegistry,
       client: registryClient,
+      pluginStatusRegistry,
     }),
   );
   console.log('[middleware] plugin store endpoints ready at /api/v1/store/plugins (auth: required)');
@@ -3277,6 +3285,7 @@ async function main(): Promise<void> {
     jobScheduler,
     flowSigningKey: sessionSigningKey,
     flowPublicBaseUrl,
+    pluginStatusRegistry,
     resolver: channelPluginResolver,
     coreApi: channelCoreApi,
     routes: routeRegistry,

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -522,6 +522,17 @@ async function main(): Promise<void> {
 
   const secretVault = new FileSecretVault(VAULT_PATH, masterKey.key);
   await secretVault.load();
+
+  // Session signing key lives in the vault (`core:auth` scope). First boot
+  // generates; every subsequent boot reuses the same key so outstanding
+  // cookies stay valid across deploys. Resolved here (before the plugin
+  // runtimes are constructed) because it doubles as the key the `ctx.flows`
+  // toolkit signs plugin-flow state with (spec 004 FR-B3).
+  const sessionSigningKey = await resolveSessionSigningKey(secretVault);
+  // Spec 004 (FR-B5) — origin plugin flow callbacks resolve against.
+  const flowPublicBaseUrl =
+    config.FLOW_PUBLIC_BASE_URL ?? config.PUBLIC_BASE_URL;
+
   const installedRegistry = new FileInstalledRegistry(
     INSTALLED_REGISTRY_PATH,
   );
@@ -674,6 +685,8 @@ async function main(): Promise<void> {
     notificationRouter,
     uiRouteCatalog,
     jobScheduler,
+    flowSigningKey: sessionSigningKey,
+    flowPublicBaseUrl,
     canvasOutputRegistry,
     deterministicActionRegistry,
     log: (...a) => console.log(...a),
@@ -742,6 +755,8 @@ async function main(): Promise<void> {
     notificationRouter,
     uiRouteCatalog,
     jobScheduler,
+    flowSigningKey: sessionSigningKey,
+    flowPublicBaseUrl,
     selfExtendRegistry,
     extensionStore,
     // When an integration plugin activates — at boot OR via a live hot-
@@ -1150,10 +1165,8 @@ async function main(): Promise<void> {
   });
 
   // ── Admin auth (A.1) ──────────────────────────────────────────────────────
-  // Session signing key lives in the vault (`core:auth` scope). First boot
-  // generates; every subsequent boot reuses the same key so outstanding
-  // cookies stay valid across deploys.
-  const sessionSigningKey = await resolveSessionSigningKey(secretVault);
+  // `sessionSigningKey` is resolved earlier (right after the vault loads) so
+  // the plugin runtimes can also use it for `ctx.flows` state signing.
   const emailWhitelist = new EmailWhitelist(config.ADMIN_ALLOWED_EMAILS);
   if (emailWhitelist.isEmpty()) {
     console.warn(
@@ -3262,6 +3275,8 @@ async function main(): Promise<void> {
     notificationRouter,
     uiRouteCatalog,
     jobScheduler,
+    flowSigningKey: sessionSigningKey,
+    flowPublicBaseUrl,
     resolver: channelPluginResolver,
     coreApi: channelCoreApi,
     routes: routeRegistry,

--- a/middleware/src/platform/flowState.ts
+++ b/middleware/src/platform/flowState.ts
@@ -1,0 +1,72 @@
+/**
+ * Spec 004 (FR-B3) — generic, plugin-audience-bound state token for the
+ * `ctx.flows` toolkit.
+ *
+ * A plugin running its own redirect flow (the GitHub App-Manifest dance, a
+ * device flow, a bespoke OAuth client) needs a CSRF-safe `state` value it can
+ * round-trip through an external IdP and verify on the callback. We mint a
+ * short-lived (10-min) HS512 JWT over the SAME symmetric key as session
+ * cookies (`auth/sessionSigningKey.ts`) — machine-stable, vault-persisted, no
+ * separate rotation.
+ *
+ * The audience is auto-bound to `plugin:<pluginId>` by the kernel. A token
+ * minted for plugin A therefore fails `jwtVerify` in plugin B (audience
+ * mismatch) — one compromised plugin cannot forge state for another. The
+ * signing key is held by the kernel and never reaches plugin code; plugins
+ * only ever see the opaque token string.
+ *
+ * This is deliberately distinct from `oauth/state.ts`, which carries the fixed
+ * broker claim-set (flowId/jobId/providerId/fieldKey) under the shared
+ * `plugin-oauth` audience. Here the claims are arbitrary and the audience is
+ * per-plugin.
+ */
+
+import { SignJWT, jwtVerify } from 'jose';
+
+const ALG = 'HS512';
+const ISSUER = 'omadia';
+const DEFAULT_TTL = '10m';
+
+/** Audience claim for a plugin-flow state token. Kept in one place so signing
+ *  and verifying can never drift. */
+export function flowAudience(pluginId: string): string {
+  return `plugin:${pluginId}`;
+}
+
+/**
+ * Sign arbitrary claims into a flow-state token bound to `pluginId`. Standard
+ * claims (`iss`, `aud`, `iat`, `exp`) are set by the kernel; caller-supplied
+ * keys colliding with those are ignored (the protected/registered claims win).
+ */
+export async function signFlowState(
+  pluginId: string,
+  claims: Record<string, unknown>,
+  key: Uint8Array,
+  expiresIn: string = DEFAULT_TTL,
+): Promise<string> {
+  return await new SignJWT(claims)
+    .setProtectedHeader({ alg: ALG })
+    .setIssuer(ISSUER)
+    .setAudience(flowAudience(pluginId))
+    .setIssuedAt()
+    .setExpirationTime(expiresIn)
+    .sign(key);
+}
+
+/**
+ * Verify a flow-state token. Throws when the signature is invalid, the
+ * audience is not `plugin:<pluginId>`, the issuer is wrong, or the TTL has
+ * expired. Returns the full decoded payload (custom claims + standard claims).
+ */
+export async function verifyFlowState(
+  pluginId: string,
+  token: string,
+  key: Uint8Array,
+): Promise<Record<string, unknown>> {
+  const { payload } = await jwtVerify(token, key, {
+    issuer: ISSUER,
+    audience: flowAudience(pluginId),
+    algorithms: [ALG],
+  });
+  return payload as Record<string, unknown>;
+}

--- a/middleware/src/platform/pluginContext.ts
+++ b/middleware/src/platform/pluginContext.ts
@@ -18,6 +18,7 @@ import {
   type EntityIngestResult,
   type FactIngest,
   type FactIngestResult,
+  type FlowsAccessor,
   type HttpAccessor,
   type JobsAccessor,
   type KnowledgeGraph,
@@ -62,6 +63,7 @@ import type { PluginRouteRegistry } from './pluginRouteRegistry.js';
 import type { NotificationRouter } from './notificationRouter.js';
 import type { UiRouteCatalog } from './uiRouteCatalog.js';
 import { createHttpAccessor, isAuditMode, type AuditMode } from './httpAccessor.js';
+import { signFlowState, verifyFlowState } from './flowState.js';
 import { createMemoryAccessor } from './memoryAccessor.js';
 import { SCRATCH_DIR } from './paths.js';
 import type { ServiceRegistry } from './serviceRegistry.js';
@@ -125,6 +127,16 @@ export interface CreatePluginContextOptions {
    *  delegates here; consumers (channel-teams Hub + Tab-Config) query
    *  it at request time via the `uiRouteCatalog` service. */
   uiRouteCatalog: UiRouteCatalog;
+  /** Spec 004 (FR-B3) — symmetric key used to sign/verify `ctx.flows` state
+   *  tokens (the same `auth/sessionSigningKey`). Held by the kernel; the
+   *  `flows` accessor closes over it and never exposes it. Optional: when
+   *  absent, `ctx.flows` is not built even if the manifest declares
+   *  `permissions.flows` (migration/test contexts don't run flows). */
+  flowSigningKey?: Uint8Array;
+  /** Spec 004 (FR-B5) — browser-facing origin the flow callback URLs resolve
+   *  against (`FLOW_PUBLIC_BASE_URL`, defaulting to `PUBLIC_BASE_URL`). No
+   *  trailing slash. Required alongside `flowSigningKey` for `ctx.flows`. */
+  flowPublicBaseUrl?: string;
   logger?: (...args: unknown[]) => void;
 }
 
@@ -404,6 +416,73 @@ export function createPluginContext(
     },
   };
 
+  // Spec 004 (FR-B2..B5) — flow toolkit. Present iff the manifest declares
+  // `permissions.flows` AND the kernel threaded both the signing key and the
+  // public base URL (production always does; migration/test contexts may not,
+  // so we degrade to `undefined` rather than throw). The plugin uses this to
+  // run a redirect/callback round-trip on its OWN route.
+  const flowsDeclared =
+    catalog.get(agentId)?.plugin.permissions_summary.flows === true;
+  const flowSigningKey = opts.flowSigningKey;
+  const flowPublicBaseUrl = opts.flowPublicBaseUrl;
+  const flows: FlowsAccessor | undefined =
+    flowsDeclared && flowSigningKey && flowPublicBaseUrl
+      ? {
+          publicUrl(relPath: string, urlOpts?: { prefix?: string }): string {
+            // Resolve which of the plugin's registered route prefixes to mount
+            // against. Explicit `opts.prefix` wins; otherwise the plugin's sole
+            // live registration is used. Ambiguity / absence is a loud error —
+            // a wrong redirect_url silently breaks the whole flow.
+            let prefix = urlOpts?.prefix;
+            if (!prefix) {
+              const own = opts.routeRegistry
+                .list()
+                .filter((e) => e.source === agentId && !e.disposed)
+                .map((e) => e.prefix);
+              const unique = Array.from(new Set(own));
+              if (unique.length === 0) {
+                throw new Error(
+                  `flows.publicUrl: ${agentId} has no registered route — call ctx.routes.register(...) first or pass opts.prefix`,
+                );
+              }
+              if (unique.length > 1) {
+                throw new Error(
+                  `flows.publicUrl: ${agentId} registered multiple routes (${unique.join(', ')}) — pass opts.prefix to disambiguate`,
+                );
+              }
+              prefix = unique[0]!;
+            }
+            if (!prefix.startsWith('/')) {
+              throw new Error(
+                `flows.publicUrl: prefix must start with '/' (got '${prefix}')`,
+              );
+            }
+            // The plugin route is mounted under `/api/<…>`; the browser reaches
+            // it through the `/bot-api/* → /api/*` proxy. Strip a leading `/api`
+            // segment exactly as the store-detail iframe does
+            // (web-ui store/[id]/page.tsx) so the two stay in lockstep.
+            const mountPath = prefix.replace(/^\/api(?=\/|$)/, '');
+            const base = flowPublicBaseUrl.replace(/\/+$/, '');
+            const rel = relPath.replace(/^\/+/, '');
+            return `${base}/bot-api${mountPath}/${rel}`;
+          },
+          async signState(
+            claims: Record<string, unknown>,
+            stateOpts?: { ttl?: string },
+          ): Promise<string> {
+            return await signFlowState(
+              agentId,
+              claims,
+              flowSigningKey,
+              stateOpts?.ttl,
+            );
+          },
+          async verifyState(token: string): Promise<Record<string, unknown>> {
+            return await verifyFlowState(agentId, token, flowSigningKey);
+          },
+        }
+      : undefined;
+
   // Jobs accessor: hands programmatic registrations to the kernel scheduler,
   // which keys them by (agentId, name). The runtime owns bulk teardown via
   // scheduler.stopForPlugin(agentId) on deactivate, so a leaked dispose from
@@ -483,6 +562,7 @@ export function createPluginContext(
     ...(subAgent ? { subAgent } : {}),
     ...(knowledgeGraph ? { knowledgeGraph } : {}),
     ...(llm ? { llm } : {}),
+    ...(flows ? { flows } : {}),
     log,
   };
 }

--- a/middleware/src/platform/pluginContext.ts
+++ b/middleware/src/platform/pluginContext.ts
@@ -248,6 +248,16 @@ export function createPluginContext(
         })
       : undefined;
 
+  // Spec 004 — runtime credential write. When the manifest declares
+  // `permissions.secrets.runtime_write`, the plugin gets write methods on its
+  // OWN vault namespace + config (never the depends_on chain). Used by
+  // credential-acquisition flows (e.g. the GitHub App-Manifest conversion) to
+  // persist what they obtain. Absent otherwise, mirroring how ctx.http /
+  // ctx.memory are gated.
+  const runtimeWrite =
+    catalog.get(agentId)?.plugin.permissions_summary.secrets_runtime_write ===
+    true;
+
   const secrets: SecretsAccessor = {
     async get(key) {
       for (const id of chain) {
@@ -277,6 +287,18 @@ export function createPluginContext(
       }
       return out;
     },
+    ...(runtimeWrite
+      ? {
+          async set(key: string, value: string): Promise<void> {
+            log(`[secrets:write] ${agentId} set ${key}`);
+            await vault.set(agentId, key, value);
+          },
+          async delete(key: string): Promise<void> {
+            log(`[secrets:write] ${agentId} delete ${key}`);
+            await vault.deleteKey(agentId, key);
+          },
+        }
+      : {}),
   };
 
   const config: ConfigAccessor = {
@@ -298,6 +320,31 @@ export function createPluginContext(
       }
       return v;
     },
+    ...(runtimeWrite
+      ? {
+          async set(key: string, value: unknown): Promise<void> {
+            // Only declared, non-secret setup fields may be written as config —
+            // secrets must go through secrets.set so they land in the vault.
+            const field = catalog
+              .get(agentId)
+              ?.plugin.setup_fields?.find((f) => f.key === key);
+            if (!field) {
+              throw new Error(
+                `config.set: "${key}" is not a declared setup field of ${agentId}`,
+              );
+            }
+            if (field.type === 'secret' || field.type === 'oauth') {
+              throw new Error(
+                `config.set: "${key}" is a ${field.type} field — use ctx.secrets.set`,
+              );
+            }
+            // Write to the plugin's OWN config (not the inherited chain).
+            const current = registry.get(agentId)?.config ?? {};
+            log(`[config:write] ${agentId} set ${key}`);
+            await registry.updateConfig(agentId, { ...current, [key]: value });
+          },
+        }
+      : {}),
   };
 
   // Tools accessor: funnel plugin-contributed tool registrations into the

--- a/middleware/src/platform/pluginContext.ts
+++ b/middleware/src/platform/pluginContext.ts
@@ -33,10 +33,12 @@ import {
   type NotificationsAccessor,
   type PluginContext,
   type RoutesAccessor,
+  type PluginActionStatus,
   type ScratchDirAccessor,
   type SecretsAccessor,
   type SecretsReadWriteAccessor,
   type ServicesAccessor,
+  type StatusAccessor,
   type SubAgentAccessor,
   type UiRoutesAccessor,
   type ToolsAccessor,
@@ -64,6 +66,7 @@ import type { NotificationRouter } from './notificationRouter.js';
 import type { UiRouteCatalog } from './uiRouteCatalog.js';
 import { createHttpAccessor, isAuditMode, type AuditMode } from './httpAccessor.js';
 import { signFlowState, verifyFlowState } from './flowState.js';
+import type { PluginStatusRegistry } from './pluginStatusRegistry.js';
 import { createMemoryAccessor } from './memoryAccessor.js';
 import { SCRATCH_DIR } from './paths.js';
 import type { ServiceRegistry } from './serviceRegistry.js';
@@ -137,6 +140,9 @@ export interface CreatePluginContextOptions {
    *  against (`FLOW_PUBLIC_BASE_URL`, defaulting to `PUBLIC_BASE_URL`). No
    *  trailing slash. Required alongside `flowSigningKey` for `ctx.flows`. */
   flowPublicBaseUrl?: string;
+  /** Spec 004 — kernel store backing `ctx.status`. Optional: when absent the
+   *  accessor is a no-op (test/migration contexts don't surface status). */
+  pluginStatusRegistry?: PluginStatusRegistry;
   logger?: (...args: unknown[]) => void;
 }
 
@@ -483,6 +489,35 @@ export function createPluginContext(
         }
       : undefined;
 
+  // Status accessor (spec 004): the plugin pushes its operator-facing action
+  // status to the kernel registry. Self-scoped to this plugin id — a plugin
+  // cannot report another's status. No-op when no registry was threaded
+  // (migration/test contexts). `clear()` and `report({state:'ok'})` both leave
+  // no badge; the value is normalized to guard against malformed input.
+  const statusRegistry = opts.pluginStatusRegistry;
+  const status: StatusAccessor = {
+    report(next) {
+      if (!statusRegistry) return;
+      const state =
+        next?.state === 'ok' || next?.state === 'needs_action' || next?.state === 'error'
+          ? next.state
+          : 'needs_action';
+      const normalized: PluginActionStatus = {
+        state,
+        ...(typeof next?.title === 'string' ? { title: next.title } : {}),
+        ...(typeof next?.detail === 'string' ? { detail: next.detail } : {}),
+      };
+      if (state === 'ok') {
+        statusRegistry.clear(agentId);
+        return;
+      }
+      statusRegistry.set(agentId, normalized);
+    },
+    clear() {
+      statusRegistry?.clear(agentId);
+    },
+  };
+
   // Jobs accessor: hands programmatic registrations to the kernel scheduler,
   // which keys them by (agentId, name). The runtime owns bulk teardown via
   // scheduler.stopForPlugin(agentId) on deactivate, so a leaked dispose from
@@ -563,6 +598,7 @@ export function createPluginContext(
     ...(knowledgeGraph ? { knowledgeGraph } : {}),
     ...(llm ? { llm } : {}),
     ...(flows ? { flows } : {}),
+    status,
     log,
   };
 }

--- a/middleware/src/platform/pluginStatusRegistry.ts
+++ b/middleware/src/platform/pluginStatusRegistry.ts
@@ -1,0 +1,30 @@
+import type { PluginActionStatus } from '@omadia/plugin-api';
+
+/**
+ * Kernel-held, in-memory store of each plugin's operator-facing action status
+ * (spec 004). Plugins push via `ctx.status.report(...)`; the admin API reads
+ * it to surface a badge on the plugin card + a banner on the detail page.
+ *
+ * In-memory by design (like `pendingFlows`): a status is ephemeral runtime
+ * health, not durable state. It is re-reported on each `activate()`, so a
+ * restart self-heals once the plugin's discovery runs again. Cleared when a
+ * plugin deactivates so an uninstalled plugin leaves no stale signal.
+ */
+export class PluginStatusRegistry {
+  private readonly statuses = new Map<string, PluginActionStatus>();
+
+  /** Replace the plugin's status. `state: 'ok'` is stored but renders nothing
+   *  (the UI only badges `needs_action` / `error`). */
+  set(pluginId: string, status: PluginActionStatus): void {
+    this.statuses.set(pluginId, status);
+  }
+
+  /** Drop the plugin's status entirely (equivalent to `ok` for the UI). */
+  clear(pluginId: string): void {
+    this.statuses.delete(pluginId);
+  }
+
+  get(pluginId: string): PluginActionStatus | undefined {
+    return this.statuses.get(pluginId);
+  }
+}

--- a/middleware/src/plugins/dynamicAgentRuntime.ts
+++ b/middleware/src/plugins/dynamicAgentRuntime.ts
@@ -16,6 +16,7 @@ import { deterministicActionToolIds } from '../platform/deterministicActionRegis
 import { createPluginContext } from '../platform/pluginContext.js';
 import type { PluginRouteRegistry } from '../platform/pluginRouteRegistry.js';
 import type { NotificationRouter } from '../platform/notificationRouter.js';
+import type { PluginStatusRegistry } from '../platform/pluginStatusRegistry.js';
 import type { UiRouteCatalog } from '../platform/uiRouteCatalog.js';
 import type { ServiceRegistry } from '../platform/serviceRegistry.js';
 import type { SecretVault } from '../secrets/vault.js';
@@ -160,6 +161,8 @@ export interface DynamicAgentRuntimeDeps {
   /** Spec 004 — key + origin for the `ctx.flows` toolkit (optional in tests). */
   flowSigningKey?: Uint8Array;
   flowPublicBaseUrl?: string;
+  /** Spec 004 — backing store for `ctx.status`; cleared on deactivate. */
+  pluginStatusRegistry?: PluginStatusRegistry;
   /** Canvas-output autodiscovery: manifest capability entries declaring
    *  `canvas_output: true` are resolved into this registry on (de)activation
    *  so the ui-orchestrator can derive its sentinel allow-set without
@@ -344,6 +347,7 @@ export class DynamicAgentRuntime {
       jobScheduler: this.deps.jobScheduler,
       flowSigningKey: this.deps.flowSigningKey,
       flowPublicBaseUrl: this.deps.flowPublicBaseUrl,
+      pluginStatusRegistry: this.deps.pluginStatusRegistry,
       logger: (...args) => console.log(`[${agentId}]`, ...args),
     });
 
@@ -593,6 +597,7 @@ export class DynamicAgentRuntime {
     // teardown comment.
     this.deps.jobScheduler.stopForPlugin(agentId);
     this.deps.uiRouteCatalog.disposeBySource(agentId);
+    this.deps.pluginStatusRegistry?.clear(agentId);
     this.active.delete(agentId);
     log(`[dynamic-runtime] DEACTIVATED ${agentId}`);
     return true;

--- a/middleware/src/plugins/dynamicAgentRuntime.ts
+++ b/middleware/src/plugins/dynamicAgentRuntime.ts
@@ -157,6 +157,9 @@ export interface DynamicAgentRuntimeDeps {
   /** Kernel-wide background-job scheduler. Plugin-contributed jobs register
    *  here via `ctx.jobs.register(spec, handler)`. */
   jobScheduler: JobScheduler;
+  /** Spec 004 — key + origin for the `ctx.flows` toolkit (optional in tests). */
+  flowSigningKey?: Uint8Array;
+  flowPublicBaseUrl?: string;
   /** Canvas-output autodiscovery: manifest capability entries declaring
    *  `canvas_output: true` are resolved into this registry on (de)activation
    *  so the ui-orchestrator can derive its sentinel allow-set without
@@ -339,6 +342,8 @@ export class DynamicAgentRuntime {
       notificationRouter: this.deps.notificationRouter,
       uiRouteCatalog: this.deps.uiRouteCatalog,
       jobScheduler: this.deps.jobScheduler,
+      flowSigningKey: this.deps.flowSigningKey,
+      flowPublicBaseUrl: this.deps.flowPublicBaseUrl,
       logger: (...args) => console.log(`[${agentId}]`, ...args),
     });
 

--- a/middleware/src/plugins/installService.ts
+++ b/middleware/src/plugins/installService.ts
@@ -458,6 +458,9 @@ export function extractSetupSchema(
     if ((type === 'string' || type === 'secret') && f['multiline'] === true) {
       field.multiline = true;
     }
+    if (f['install_hidden'] === true) {
+      field.install_hidden = true;
+    }
     if (type === 'enum') {
       const enumRaw = f['enum'];
       if (Array.isArray(enumRaw)) {

--- a/middleware/src/plugins/manifestLoader.ts
+++ b/middleware/src/plugins/manifestLoader.ts
@@ -599,6 +599,8 @@ function extractPermissions(
     typeof llmTokensRaw === 'number' && Number.isFinite(llmTokensRaw)
       ? Math.max(1, Math.floor(llmTokensRaw))
       : 4096;
+  // Spec 004 — runtime credential write + flow toolkit gates.
+  const secretsBlock = asRecord(permissions?.['secrets']);
   return {
     memory_reads: extractStringArray(memory?.['reads']),
     memory_writes: extractStringArray(memory?.['writes']),
@@ -618,6 +620,8 @@ function extractPermissions(
     llm_models_allowed: llmModelsAllowed,
     llm_calls_per_invocation: llmCallsPerInvocation,
     llm_max_tokens_per_call: llmMaxTokensPerCall,
+    secrets_runtime_write: secretsBlock?.['runtime_write'] === true,
+    flows: permissions?.['flows'] === true,
   };
 }
 

--- a/middleware/src/plugins/oauth/pkce.ts
+++ b/middleware/src/plugins/oauth/pkce.ts
@@ -1,38 +1,10 @@
 /**
  * RFC 7636 — PKCE helpers for the plugin-OAuth flow.
  *
- * Verifier is a high-entropy (32-byte) URL-safe base64 string; challenge is
- * the S256 hash of the verifier in URL-safe base64. Both are fully
- * stateless — the install-route stores the verifier in pendingFlows and
- * sends the challenge through the IdP roundtrip.
+ * The implementation now lives in `@omadia/plugin-api` (spec 004 FR-B4) so
+ * plugins running their own redirect flows and the kernel broker share one
+ * source of truth. This module re-exports it to keep existing kernel imports
+ * (`oauth/index.ts`) stable.
  */
 
-import crypto from 'node:crypto';
-
-/** RFC 7636 §4.1 verifier length is 43-128 chars; 32 random bytes ≈ 43
- *  base64url chars which is the minimum spec-allowed. We could go higher
- *  but 32B already gives 256 bits of entropy. */
-const VERIFIER_BYTES = 32;
-
-/** Base64url encode without padding — what RFC 7636 requires. */
-function base64url(buf: Buffer): string {
-  return buf
-    .toString('base64')
-    .replace(/=+$/g, '')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_');
-}
-
-/** Generate a fresh PKCE code-verifier. Caller MUST store this securely
- *  (we use the in-memory pendingFlows store) until the callback redeems
- *  the auth-code. */
-export function generateCodeVerifier(): string {
-  return base64url(crypto.randomBytes(VERIFIER_BYTES));
-}
-
-/** Compute the S256 code-challenge for a verifier. The challenge is the
- *  value that goes into the authorize-URL; the verifier stays on the
- *  server. */
-export function computeCodeChallenge(verifier: string): string {
-  return base64url(crypto.createHash('sha256').update(verifier).digest());
-}
+export { generateCodeVerifier, computeCodeChallenge } from '@omadia/plugin-api';

--- a/middleware/src/plugins/toolPluginRuntime.ts
+++ b/middleware/src/plugins/toolPluginRuntime.ts
@@ -5,6 +5,7 @@ import { promises as fs } from 'node:fs';
 import { createPluginContext } from '../platform/pluginContext.js';
 import type { PluginRouteRegistry } from '../platform/pluginRouteRegistry.js';
 import type { NotificationRouter } from '../platform/notificationRouter.js';
+import type { PluginStatusRegistry } from '../platform/pluginStatusRegistry.js';
 import type { UiRouteCatalog } from '../platform/uiRouteCatalog.js';
 import type { ServiceRegistry } from '../platform/serviceRegistry.js';
 import type { SecretVault } from '../secrets/vault.js';
@@ -83,6 +84,8 @@ export interface ToolPluginRuntimeDeps {
    *  them (flows simply stays unavailable). */
   flowSigningKey?: Uint8Array;
   flowPublicBaseUrl?: string;
+  /** Spec 004 — backing store for `ctx.status`; cleared on deactivate. */
+  pluginStatusRegistry?: PluginStatusRegistry;
   /**
    * Fired after a plugin's activate() succeeds and it is recorded active.
    * Used to register the plugin's manifest-declared `service_types` into the
@@ -247,6 +250,7 @@ export class ToolPluginRuntime {
       jobScheduler: this.deps.jobScheduler,
       flowSigningKey: this.deps.flowSigningKey,
       flowPublicBaseUrl: this.deps.flowPublicBaseUrl,
+      pluginStatusRegistry: this.deps.pluginStatusRegistry,
       logger: (...args) => console.log(`[${agentId}]`, ...args),
     });
 
@@ -342,6 +346,7 @@ export class ToolPluginRuntime {
     // its plugin's lifecycle.
     this.deps.jobScheduler.stopForPlugin(agentId);
     this.deps.uiRouteCatalog.disposeBySource(agentId);
+    this.deps.pluginStatusRegistry?.clear(agentId);
     this.active.delete(agentId);
 
     if (this.deps.onDeactivated) {

--- a/middleware/src/plugins/toolPluginRuntime.ts
+++ b/middleware/src/plugins/toolPluginRuntime.ts
@@ -78,6 +78,11 @@ export interface ToolPluginRuntimeDeps {
   notificationRouter: NotificationRouter;
   uiRouteCatalog: UiRouteCatalog;
   jobScheduler: JobScheduler;
+  /** Spec 004 — key + origin for the `ctx.flows` toolkit, threaded straight
+   *  into every `createPluginContext`. Optional so test harnesses can omit
+   *  them (flows simply stays unavailable). */
+  flowSigningKey?: Uint8Array;
+  flowPublicBaseUrl?: string;
   /**
    * Fired after a plugin's activate() succeeds and it is recorded active.
    * Used to register the plugin's manifest-declared `service_types` into the
@@ -240,6 +245,8 @@ export class ToolPluginRuntime {
       notificationRouter: this.deps.notificationRouter,
       uiRouteCatalog: this.deps.uiRouteCatalog,
       jobScheduler: this.deps.jobScheduler,
+      flowSigningKey: this.deps.flowSigningKey,
+      flowPublicBaseUrl: this.deps.flowPublicBaseUrl,
       logger: (...args) => console.log(`[${agentId}]`, ...args),
     });
 

--- a/middleware/src/routes/store.ts
+++ b/middleware/src/routes/store.ts
@@ -10,6 +10,7 @@ import type {
 } from '../api/admin-v1.js';
 import type { InstalledRegistry } from '../plugins/installedRegistry.js';
 import type { PluginCatalog } from '../plugins/manifestLoader.js';
+import type { PluginStatusRegistry } from '../platform/pluginStatusRegistry.js';
 import type {
   RegistryClient,
   ResolvedRegistryPlugin,
@@ -23,6 +24,19 @@ interface StoreDeps {
    *  operator can install from the hub. A local plugin of the same id wins;
    *  a registry fetch failure never breaks the local listing. */
   client?: RegistryClient;
+  /** Spec 004 — read-only access to plugins' pushed `ctx.status` so the list
+   *  and detail responses can carry `action_status` for the badge/banner. */
+  pluginStatusRegistry?: PluginStatusRegistry;
+}
+
+/** Overlay the live `ctx.status` value (if any) onto a plugin record. Returns
+ *  the input unchanged when no status is reported (the common case). */
+function withActionStatus(
+  plugin: Plugin,
+  statusRegistry: PluginStatusRegistry | undefined,
+): Plugin {
+  const status = statusRegistry?.get(plugin.id);
+  return status ? { ...plugin, action_status: status } : plugin;
 }
 
 /**
@@ -105,7 +119,7 @@ export function createStoreRouter(deps: StoreDeps): Router {
       }
 
       const body: StoreListResponse = {
-        items,
+        items: items.map((p) => withActionStatus(p, deps.pluginStatusRegistry)),
         next_cursor: null,
         total: items.length,
       };
@@ -179,6 +193,7 @@ export function createStoreRouter(deps: StoreDeps): Router {
         }
       }
       const installAvailable = plugin.install_state === 'available';
+      plugin = withActionStatus(plugin, deps.pluginStatusRegistry);
       const body: StoreGetResponse = {
         plugin,
         manifest: entry.manifest,

--- a/middleware/test/flowState.test.ts
+++ b/middleware/test/flowState.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Spec 004 Phase B (FR-B3 / SC3) — plugin-audience-bound flow-state tokens.
+ *
+ * The state token is the CSRF guard for a plugin's redirect round-trip. These
+ * tests pin the two security-critical properties: a token minted for one
+ * plugin must NOT verify for another (audience binding), and an expired token
+ * must be rejected.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import crypto from 'node:crypto';
+
+import { SignJWT } from 'jose';
+
+import {
+  flowAudience,
+  signFlowState,
+  verifyFlowState,
+} from '../src/platform/flowState.js';
+
+const KEY = new Uint8Array(crypto.randomBytes(64));
+const OTHER_KEY = new Uint8Array(crypto.randomBytes(64));
+
+describe('Spec 004 — flow-state round-trip', () => {
+  it('verifies a token signed for the same plugin and returns the claims', async () => {
+    const token = await signFlowState('@omadia/integration-github', { nonce: 'abc', n: 1 }, KEY);
+    const claims = await verifyFlowState('@omadia/integration-github', token, KEY);
+    assert.equal(claims['nonce'], 'abc');
+    assert.equal(claims['n'], 1);
+    assert.equal(claims['aud'], 'plugin:@omadia/integration-github');
+    assert.equal(claims['iss'], 'omadia');
+  });
+});
+
+describe('Spec 004 — flow-state audience binding (SC3b)', () => {
+  it('rejects a token signed for a DIFFERENT plugin id', async () => {
+    const token = await signFlowState('plugin-a', { nonce: 'x' }, KEY);
+    await assert.rejects(
+      () => verifyFlowState('plugin-b', token, KEY),
+      /audience|aud/i,
+    );
+  });
+
+  it('rejects a token signed with a different key', async () => {
+    const token = await signFlowState('plugin-a', { nonce: 'x' }, KEY);
+    await assert.rejects(() => verifyFlowState('plugin-a', token, OTHER_KEY));
+  });
+
+  it('binds the audience as plugin:<id>', () => {
+    assert.equal(flowAudience('plugin-a'), 'plugin:plugin-a');
+  });
+});
+
+describe('Spec 004 — flow-state expiry (SC3a)', () => {
+  it('rejects an expired token', async () => {
+    // Mint a token whose exp is already in the past — same iss/aud the verifier
+    // expects, so only the TTL check can reject it.
+    const past = Math.floor(Date.now() / 1000) - 120;
+    const expired = await new SignJWT({ nonce: 'x' })
+      .setProtectedHeader({ alg: 'HS512' })
+      .setIssuer('omadia')
+      .setAudience(flowAudience('plugin-a'))
+      .setIssuedAt(past - 60)
+      .setExpirationTime(past)
+      .sign(KEY);
+    await assert.rejects(
+      () => verifyFlowState('plugin-a', expired, KEY),
+      /exp|expired/i,
+    );
+  });
+
+  it('honours a custom TTL', async () => {
+    const token = await signFlowState('plugin-a', { nonce: 'x' }, KEY, '30m');
+    const claims = await verifyFlowState('plugin-a', token, KEY);
+    const ttl = (claims['exp'] as number) - (claims['iat'] as number);
+    assert.equal(ttl, 30 * 60);
+  });
+});

--- a/middleware/test/installService.test.ts
+++ b/middleware/test/installService.test.ts
@@ -498,3 +498,46 @@ describe('extractSetupSchema — multiline flag', () => {
     assert.equal(fieldByKey(schema, 'pem')?.multiline, undefined);
   });
 });
+
+describe('extractSetupSchema — install_hidden flag', () => {
+  function makeEntry(fields: unknown[]): PluginCatalogEntry {
+    return {
+      plugin: makePlugin({
+        id: 'install-hidden-test',
+        provides: [],
+        requires: [],
+        depends_on: [],
+      }),
+      manifest: { setup: { fields } },
+      source_path: '<test>/install-hidden-test.manifest.yaml',
+      source_kind: 'manifest-v1',
+    } as unknown as PluginCatalogEntry;
+  }
+
+  function fieldByKey(
+    schema: ReturnType<typeof extractSetupSchema>,
+    key: string,
+  ) {
+    return schema?.fields.find((f) => f.key === key);
+  }
+
+  it('passes install_hidden: true through (any field type)', () => {
+    const schema = extractSetupSchema(
+      makeEntry([
+        { key: 'app_id', type: 'string', label: 'App ID', install_hidden: true },
+        { key: 'org', type: 'string', label: 'Org' },
+      ]),
+    );
+    assert.equal(fieldByKey(schema, 'app_id')?.install_hidden, true);
+    assert.equal(fieldByKey(schema, 'org')?.install_hidden, undefined);
+  });
+
+  it('ignores non-boolean install_hidden values', () => {
+    const schema = extractSetupSchema(
+      makeEntry([
+        { key: 'app_id', type: 'string', label: 'App ID', install_hidden: 'yes' },
+      ]),
+    );
+    assert.equal(fieldByKey(schema, 'app_id')?.install_hidden, undefined);
+  });
+});

--- a/middleware/test/manifestRuntimeCredentials.test.ts
+++ b/middleware/test/manifestRuntimeCredentials.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Spec 004 Phase A/B — verifies `adaptManifestV1` maps the runtime-credential
+ * permission gates (`permissions.secrets.runtime_write`, `permissions.flows`)
+ * onto `permissions_summary`, defaulting both to `false` when absent.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { adaptManifestV1 } from '../src/plugins/manifestLoader.js';
+
+function manifest(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schema_version: '1',
+    identity: {
+      id: 'de.byte5.agent.test',
+      kind: 'agent',
+      domain: 'test',
+      name: 'Test Plugin',
+      version: '1.0.0',
+    },
+    ...extra,
+  };
+}
+
+test('defaults secrets_runtime_write and flows to false when permissions omit them', () => {
+  const plugin = adaptManifestV1(manifest());
+  assert.ok(plugin);
+  assert.equal(plugin.permissions_summary.secrets_runtime_write, false);
+  assert.equal(plugin.permissions_summary.flows, false);
+});
+
+test('maps permissions.secrets.runtime_write: true', () => {
+  const plugin = adaptManifestV1(
+    manifest({ permissions: { secrets: { runtime_write: true } } }),
+  );
+  assert.ok(plugin);
+  assert.equal(plugin.permissions_summary.secrets_runtime_write, true);
+});
+
+test('maps permissions.flows: true', () => {
+  const plugin = adaptManifestV1(manifest({ permissions: { flows: true } }));
+  assert.ok(plugin);
+  assert.equal(plugin.permissions_summary.flows, true);
+});
+
+test('treats non-boolean runtime_write / flows as false', () => {
+  const plugin = adaptManifestV1(
+    manifest({
+      permissions: { secrets: { runtime_write: 'yes' }, flows: 1 },
+    }),
+  );
+  assert.ok(plugin);
+  assert.equal(plugin.permissions_summary.secrets_runtime_write, false);
+  assert.equal(plugin.permissions_summary.flows, false);
+});

--- a/middleware/test/pkceSdk.test.ts
+++ b/middleware/test/pkceSdk.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Spec 004 Phase B (FR-B4) — PKCE helpers are exported as pure SDK functions
+ * from `@omadia/plugin-api`, so plugins running their own redirect flows mint
+ * a verifier/challenge pair without reaching into the kernel.
+ */
+
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import { generateCodeVerifier, computeCodeChallenge } from '@omadia/plugin-api';
+
+test('SDK PKCE matches RFC 7636 Appendix B sample vector', () => {
+  const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+  const expected = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+  assert.equal(computeCodeChallenge(verifier), expected);
+});
+
+test('SDK generateCodeVerifier is URL-safe and >=43 chars', () => {
+  const v = generateCodeVerifier();
+  assert.match(v, /^[A-Za-z0-9_-]+$/);
+  assert.ok(v.length >= 43);
+});

--- a/middleware/test/pluginContextFlows.test.ts
+++ b/middleware/test/pluginContextFlows.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Spec 004 Phase B (FR-B2..B5) — the `ctx.flows` accessor.
+ *
+ * Verifies gating (present only with `permissions.flows` AND a threaded
+ * signing key + base URL), the `publicUrl` resolution (mirroring the
+ * `/bot-api` → `/api` proxy by stripping a leading `/api`), and that
+ * `signState`/`verifyState` round-trip while staying plugin-audience-bound
+ * (a token minted by plugin A is rejected by plugin B).
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import crypto from 'node:crypto';
+
+import type { Plugin } from '../src/api/admin-v1.js';
+import type {
+  PluginCatalog,
+  PluginCatalogEntry,
+} from '../src/plugins/manifestLoader.js';
+import { ServiceRegistry } from '../src/platform/serviceRegistry.js';
+import { createPluginContext } from '../src/platform/pluginContext.js';
+
+const KEY = new Uint8Array(crypto.randomBytes(64));
+const BASE = 'https://omadia.example.com';
+
+function makeRouteRegistry() {
+  const entries: { prefix: string; source: string; disposed: boolean }[] = [];
+  return {
+    register(prefix: string, _router: unknown, source: string) {
+      const e = { prefix, source, disposed: false };
+      entries.push(e);
+      return () => {
+        e.disposed = true;
+      };
+    },
+    list: () => entries.map((e) => ({ ...e })),
+    disposeBySource: () => 0,
+  } as unknown as Parameters<typeof createPluginContext>[0]['routeRegistry'];
+}
+
+function makeStubs() {
+  const vault = {
+    get: async () => undefined,
+    listKeys: async () => [],
+  } as unknown as Parameters<typeof createPluginContext>[0]['vault'];
+  const registry = {
+    has: () => true,
+    list: () => [],
+    get: () => undefined,
+  } as unknown as Parameters<typeof createPluginContext>[0]['registry'];
+  const stubNativeToolRegistry = {
+    register: () => () => {},
+    registerHandler: () => () => {},
+  } as unknown as Parameters<typeof createPluginContext>[0]['nativeToolRegistry'];
+  const stubJobScheduler = {
+    register: () => () => {},
+    stopForPlugin: () => {},
+  } as unknown as Parameters<typeof createPluginContext>[0]['jobScheduler'];
+  return { vault, registry, stubNativeToolRegistry, stubJobScheduler };
+}
+
+function makeCatalog(id: string, flows: boolean): PluginCatalog {
+  const plugin = {
+    id,
+    kind: 'integration',
+    name: id,
+    version: '0.1.0',
+    domain: 'test',
+    setup_fields: [],
+    permissions_summary: {
+      memory_reads: [],
+      memory_writes: [],
+      graph_reads: [],
+      graph_writes: [],
+      network_outbound: [],
+      flows,
+    },
+    depends_on: [],
+    provides: [],
+    requires: [],
+  } as unknown as Plugin;
+  const entry = {
+    plugin,
+    manifest: {},
+    source_path: `/abs/${id}/manifest.yaml`,
+    source_kind: 'manifest-v1',
+  } as unknown as PluginCatalogEntry;
+  return {
+    list: () => [entry],
+    get: (q: string) => (q === id ? entry : undefined),
+  } as unknown as PluginCatalog;
+}
+
+interface CtxOpts {
+  flows?: boolean;
+  key?: Uint8Array;
+  base?: string;
+  id?: string;
+}
+
+function makeCtx(o: CtxOpts = {}) {
+  const id = o.id ?? 'caller';
+  const s = makeStubs();
+  const routeRegistry = makeRouteRegistry();
+  const ctx = createPluginContext({
+    agentId: id,
+    vault: s.vault,
+    registry: s.registry,
+    catalog: makeCatalog(id, o.flows ?? true),
+    serviceRegistry: new ServiceRegistry(),
+    nativeToolRegistry: s.stubNativeToolRegistry,
+    routeRegistry,
+    jobScheduler: s.stubJobScheduler,
+    flowSigningKey: o.key,
+    flowPublicBaseUrl: o.base,
+    logger: () => {},
+  });
+  return { ctx, routeRegistry };
+}
+
+describe('Spec 004 — ctx.flows gating', () => {
+  it('is undefined when permissions.flows is false', () => {
+    const { ctx } = makeCtx({ flows: false, key: KEY, base: BASE });
+    assert.equal(ctx.flows, undefined);
+  });
+
+  it('is undefined when no signing key is threaded', () => {
+    const { ctx } = makeCtx({ flows: true, base: BASE });
+    assert.equal(ctx.flows, undefined);
+  });
+
+  it('is undefined when no public base URL is threaded', () => {
+    const { ctx } = makeCtx({ flows: true, key: KEY });
+    assert.equal(ctx.flows, undefined);
+  });
+
+  it('is present when declared AND fully wired', () => {
+    const { ctx } = makeCtx({ flows: true, key: KEY, base: BASE });
+    assert.equal(typeof ctx.flows?.publicUrl, 'function');
+    assert.equal(typeof ctx.flows?.signState, 'function');
+    assert.equal(typeof ctx.flows?.verifyState, 'function');
+  });
+});
+
+describe('Spec 004 — ctx.flows.publicUrl', () => {
+  it('strips a leading /api and routes through /bot-api', () => {
+    const { ctx } = makeCtx({ flows: true, key: KEY, base: BASE });
+    ctx.routes.register('/api/github', {} as unknown);
+    assert.equal(
+      ctx.flows!.publicUrl('flow/callback'),
+      'https://omadia.example.com/bot-api/github/flow/callback',
+    );
+  });
+
+  it('tolerates a leading slash on relPath', () => {
+    const { ctx } = makeCtx({ flows: true, key: KEY, base: BASE });
+    ctx.routes.register('/api/github', {} as unknown);
+    assert.equal(
+      ctx.flows!.publicUrl('/flow/callback'),
+      'https://omadia.example.com/bot-api/github/flow/callback',
+    );
+  });
+
+  it('trims a trailing slash on the base URL', () => {
+    const { ctx } = makeCtx({ flows: true, key: KEY, base: `${BASE}/` });
+    ctx.routes.register('/api/github', {} as unknown);
+    assert.equal(
+      ctx.flows!.publicUrl('flow/callback'),
+      'https://omadia.example.com/bot-api/github/flow/callback',
+    );
+  });
+
+  it('throws when no route is registered yet', () => {
+    const { ctx } = makeCtx({ flows: true, key: KEY, base: BASE });
+    assert.throws(() => ctx.flows!.publicUrl('flow/callback'), /no registered route/);
+  });
+
+  it('throws on ambiguity, resolves with opts.prefix', () => {
+    const { ctx } = makeCtx({ flows: true, key: KEY, base: BASE });
+    ctx.routes.register('/api/github/admin', {} as unknown);
+    ctx.routes.register('/api/github/flow', {} as unknown);
+    assert.throws(() => ctx.flows!.publicUrl('callback'), /multiple routes/);
+    assert.equal(
+      ctx.flows!.publicUrl('callback', { prefix: '/api/github/flow' }),
+      'https://omadia.example.com/bot-api/github/flow/callback',
+    );
+  });
+});
+
+describe('Spec 004 — ctx.flows.signState/verifyState', () => {
+  it('round-trips claims bound to the plugin', async () => {
+    const { ctx } = makeCtx({ flows: true, key: KEY, base: BASE });
+    const token = await ctx.flows!.signState({ org: 'acme' });
+    const claims = await ctx.flows!.verifyState(token);
+    assert.equal(claims['org'], 'acme');
+    assert.equal(claims['aud'], 'plugin:caller');
+  });
+
+  it('rejects a token minted by another plugin (same key)', async () => {
+    const a = makeCtx({ flows: true, key: KEY, base: BASE, id: 'plugin-a' });
+    const b = makeCtx({ flows: true, key: KEY, base: BASE, id: 'plugin-b' });
+    const token = await a.ctx.flows!.signState({ org: 'acme' });
+    await assert.rejects(() => b.ctx.flows!.verifyState(token), /audience|aud/i);
+  });
+});

--- a/middleware/test/pluginContextRuntimeWrite.test.ts
+++ b/middleware/test/pluginContextRuntimeWrite.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Spec 004 Phase A (FR-A2..A3) — runtime credential write accessors.
+ *
+ * Verifies that `ctx.secrets.set/delete` and `ctx.config.set` are present
+ * ONLY when the manifest declares `permissions.secrets.runtime_write`, write
+ * to the plugin's OWN namespace, and that config.set refuses keys that aren't
+ * declared non-secret setup fields.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it, beforeEach } from 'node:test';
+
+import type { Plugin, PluginSetupField } from '../src/api/admin-v1.js';
+import type {
+  PluginCatalog,
+  PluginCatalogEntry,
+} from '../src/plugins/manifestLoader.js';
+import { ServiceRegistry } from '../src/platform/serviceRegistry.js';
+import { createPluginContext } from '../src/platform/pluginContext.js';
+
+interface VaultCall {
+  agentId: string;
+  key: string;
+  value?: string;
+}
+
+function makeStubs() {
+  const setCalls: VaultCall[] = [];
+  const deleteCalls: VaultCall[] = [];
+  const configWrites: Array<{ id: string; config: Record<string, unknown> }> = [];
+  const store: Record<string, Record<string, unknown>> = {
+    caller: { app_id: 'old' },
+  };
+
+  const vault = {
+    get: async () => undefined,
+    listKeys: async () => [],
+    async set(agentId: string, key: string, value: string) {
+      setCalls.push({ agentId, key, value });
+    },
+    async deleteKey(agentId: string, key: string) {
+      deleteCalls.push({ agentId, key });
+    },
+  } as unknown as Parameters<typeof createPluginContext>[0]['vault'];
+
+  const registry = {
+    has: () => true,
+    list: () => [],
+    get: (id: string) =>
+      store[id] ? { config: store[id] } : undefined,
+    async updateConfig(id: string, config: Record<string, unknown>) {
+      configWrites.push({ id, config });
+      store[id] = config;
+    },
+  } as unknown as Parameters<typeof createPluginContext>[0]['registry'];
+
+  const stubNativeToolRegistry = {
+    register: () => () => {},
+    registerHandler: () => () => {},
+  } as unknown as Parameters<
+    typeof createPluginContext
+  >[0]['nativeToolRegistry'];
+  const stubRouteRegistry = {
+    register: () => () => {},
+    disposeBySource: () => 0,
+  } as unknown as Parameters<typeof createPluginContext>[0]['routeRegistry'];
+  const stubJobScheduler = {
+    register: () => () => {},
+    stopForPlugin: () => {},
+  } as unknown as Parameters<typeof createPluginContext>[0]['jobScheduler'];
+
+  return {
+    setCalls,
+    deleteCalls,
+    configWrites,
+    vault,
+    registry,
+    stubNativeToolRegistry,
+    stubRouteRegistry,
+    stubJobScheduler,
+  };
+}
+
+const SETUP_FIELDS: PluginSetupField[] = [
+  { key: 'app_id', label: 'App ID', type: 'string' },
+  { key: 'private_key', label: 'Key', type: 'secret' },
+];
+
+function makeCatalog(runtimeWrite: boolean): PluginCatalog {
+  const plugin = {
+    id: 'caller',
+    kind: 'integration',
+    name: 'caller',
+    version: '0.1.0',
+    domain: 'test',
+    setup_fields: SETUP_FIELDS,
+    permissions_summary: {
+      memory_reads: [],
+      memory_writes: [],
+      graph_reads: [],
+      graph_writes: [],
+      network_outbound: [],
+      secrets_runtime_write: runtimeWrite,
+    },
+    depends_on: [],
+    provides: [],
+    requires: [],
+  } as unknown as Plugin;
+  const entry = {
+    plugin,
+    manifest: {},
+    source_path: '/abs/caller/manifest.yaml',
+    source_kind: 'manifest-v1',
+  } as unknown as PluginCatalogEntry;
+  return {
+    list: () => [entry],
+    get: (id: string) => (id === 'caller' ? entry : undefined),
+  } as unknown as PluginCatalog;
+}
+
+function makeCtx(runtimeWrite: boolean) {
+  const s = makeStubs();
+  const ctx = createPluginContext({
+    agentId: 'caller',
+    vault: s.vault,
+    registry: s.registry,
+    catalog: makeCatalog(runtimeWrite),
+    serviceRegistry: new ServiceRegistry(),
+    nativeToolRegistry: s.stubNativeToolRegistry,
+    routeRegistry: s.stubRouteRegistry,
+    jobScheduler: s.stubJobScheduler,
+    logger: () => {},
+  });
+  return { ctx, ...s };
+}
+
+describe('Spec 004 — runtime write accessors are gated', () => {
+  it('omits set/delete when permissions.secrets.runtime_write is false', () => {
+    const { ctx } = makeCtx(false);
+    assert.equal(ctx.secrets.set, undefined);
+    assert.equal(ctx.secrets.delete, undefined);
+    assert.equal(ctx.config.set, undefined);
+  });
+
+  it('exposes set/delete when runtime_write is true', () => {
+    const { ctx } = makeCtx(true);
+    assert.equal(typeof ctx.secrets.set, 'function');
+    assert.equal(typeof ctx.secrets.delete, 'function');
+    assert.equal(typeof ctx.config.set, 'function');
+  });
+});
+
+describe('Spec 004 — secrets.set/delete write the OWN namespace', () => {
+  let h: ReturnType<typeof makeCtx>;
+  beforeEach(() => {
+    h = makeCtx(true);
+  });
+
+  it('secrets.set writes to vault under the plugin id', async () => {
+    await h.ctx.secrets.set!('private_key', 'PEM');
+    assert.deepEqual(h.setCalls, [
+      { agentId: 'caller', key: 'private_key', value: 'PEM' },
+    ]);
+  });
+
+  it('secrets.delete removes from the plugin namespace', async () => {
+    await h.ctx.secrets.delete!('private_key');
+    assert.deepEqual(h.deleteCalls, [{ agentId: 'caller', key: 'private_key' }]);
+  });
+});
+
+describe('Spec 004 — config.set validates the key', () => {
+  let h: ReturnType<typeof makeCtx>;
+  beforeEach(() => {
+    h = makeCtx(true);
+  });
+
+  it('persists a declared non-secret field, merged with existing config', async () => {
+    await h.ctx.config.set!('app_id', '123456');
+    assert.equal(h.configWrites.length, 1);
+    assert.deepEqual(h.configWrites[0], {
+      id: 'caller',
+      config: { app_id: '123456' },
+    });
+  });
+
+  it('rejects an undeclared key', async () => {
+    await assert.rejects(
+      () => h.ctx.config.set!('not_a_field', 'x'),
+      /not a declared setup field/,
+    );
+    assert.equal(h.configWrites.length, 0);
+  });
+
+  it('rejects a secret-typed field (must go through secrets.set)', async () => {
+    await assert.rejects(
+      () => h.ctx.config.set!('private_key', 'x'),
+      /use ctx\.secrets\.set/,
+    );
+    assert.equal(h.configWrites.length, 0);
+  });
+});

--- a/middleware/test/pluginContextStatus.test.ts
+++ b/middleware/test/pluginContextStatus.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Spec 004 — `ctx.status` accessor + PluginStatusRegistry.
+ *
+ * The accessor is always present, ungated, self-scoped to the plugin id, and
+ * normalizes malformed input. `report({state:'ok'})` and `clear()` both leave
+ * no entry (the UI badges only needs_action / error).
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { Plugin } from '../src/api/admin-v1.js';
+import type {
+  PluginCatalog,
+  PluginCatalogEntry,
+} from '../src/plugins/manifestLoader.js';
+import { ServiceRegistry } from '../src/platform/serviceRegistry.js';
+import { PluginStatusRegistry } from '../src/platform/pluginStatusRegistry.js';
+import { createPluginContext } from '../src/platform/pluginContext.js';
+
+function makeCatalog(id: string): PluginCatalog {
+  const plugin = {
+    id,
+    kind: 'integration',
+    name: id,
+    version: '0.1.0',
+    domain: 'test',
+    setup_fields: [],
+    permissions_summary: {
+      memory_reads: [],
+      memory_writes: [],
+      graph_reads: [],
+      graph_writes: [],
+      network_outbound: [],
+    },
+    depends_on: [],
+    provides: [],
+    requires: [],
+  } as unknown as Plugin;
+  const entry = {
+    plugin,
+    manifest: {},
+    source_path: `/abs/${id}/manifest.yaml`,
+    source_kind: 'manifest-v1',
+  } as unknown as PluginCatalogEntry;
+  return {
+    list: () => [entry],
+    get: (q: string) => (q === id ? entry : undefined),
+  } as unknown as PluginCatalog;
+}
+
+function makeCtx(id: string, statusRegistry?: PluginStatusRegistry) {
+  const stub = () => () => {};
+  return createPluginContext({
+    agentId: id,
+    vault: {
+      get: async () => undefined,
+      listKeys: async () => [],
+    } as unknown as Parameters<typeof createPluginContext>[0]['vault'],
+    registry: {
+      has: () => true,
+      list: () => [],
+      get: () => undefined,
+    } as unknown as Parameters<typeof createPluginContext>[0]['registry'],
+    catalog: makeCatalog(id),
+    serviceRegistry: new ServiceRegistry(),
+    nativeToolRegistry: {
+      register: stub,
+      registerHandler: stub,
+    } as unknown as Parameters<typeof createPluginContext>[0]['nativeToolRegistry'],
+    routeRegistry: {
+      register: stub,
+      disposeBySource: () => 0,
+    } as unknown as Parameters<typeof createPluginContext>[0]['routeRegistry'],
+    jobScheduler: {
+      register: stub,
+      stopForPlugin: () => {},
+    } as unknown as Parameters<typeof createPluginContext>[0]['jobScheduler'],
+    ...(statusRegistry ? { pluginStatusRegistry: statusRegistry } : {}),
+    logger: () => {},
+  });
+}
+
+describe('Spec 004 — ctx.status', () => {
+  it('is always present even without a registry, and is a no-op then', () => {
+    const ctx = makeCtx('caller');
+    assert.equal(typeof ctx.status.report, 'function');
+    assert.equal(typeof ctx.status.clear, 'function');
+    assert.doesNotThrow(() => ctx.status.report({ state: 'needs_action' }));
+    assert.doesNotThrow(() => ctx.status.clear());
+  });
+
+  it('report writes to the registry under the plugin id', () => {
+    const reg = new PluginStatusRegistry();
+    const ctx = makeCtx('caller', reg);
+    ctx.status.report({ state: 'needs_action', title: 'Nicht verbunden', detail: 'd' });
+    assert.deepEqual(reg.get('caller'), {
+      state: 'needs_action',
+      title: 'Nicht verbunden',
+      detail: 'd',
+    });
+  });
+
+  it('report({state:ok}) and clear() both leave no entry', () => {
+    const reg = new PluginStatusRegistry();
+    const ctx = makeCtx('caller', reg);
+    ctx.status.report({ state: 'needs_action', title: 'x' });
+    ctx.status.report({ state: 'ok' });
+    assert.equal(reg.get('caller'), undefined);
+    ctx.status.report({ state: 'error', title: 'y' });
+    ctx.status.clear();
+    assert.equal(reg.get('caller'), undefined);
+  });
+
+  it('normalizes a malformed state to needs_action', () => {
+    const reg = new PluginStatusRegistry();
+    const ctx = makeCtx('caller', reg);
+    // @ts-expect-error — deliberately invalid runtime input
+    ctx.status.report({ state: 'bogus', title: 't' });
+    assert.equal(reg.get('caller')?.state, 'needs_action');
+  });
+
+  it('writes only the calling plugin id (self-scoped)', () => {
+    const reg = new PluginStatusRegistry();
+    makeCtx('plugin-a', reg).status.report({ state: 'error' });
+    makeCtx('plugin-b', reg).status.report({ state: 'needs_action' });
+    assert.equal(reg.get('plugin-a')?.state, 'error');
+    assert.equal(reg.get('plugin-b')?.state, 'needs_action');
+  });
+});

--- a/web-ui/app/_components/store/ActionStatusBanner.tsx
+++ b/web-ui/app/_components/store/ActionStatusBanner.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AlertTriangle } from 'lucide-react';
+
+import type { PluginActionStatus } from '../../_lib/storeTypes';
+
+/**
+ * Spec 004 — operator-action banner on the plugin detail page. Seeded with the
+ * server-rendered status, then polls the store detail endpoint so it
+ * auto-clears the moment the plugin reports `ok` (e.g. after the operator
+ * connects via the admin UI embedded right below). Renders nothing when there
+ * is no pending action — so a healthy plugin shows no banner.
+ */
+export function ActionStatusBanner({
+  pluginId,
+  initial,
+}: {
+  pluginId: string;
+  initial?: PluginActionStatus;
+}): React.ReactElement | null {
+  const [status, setStatus] = useState<PluginActionStatus | undefined>(initial);
+
+  useEffect(() => {
+    let alive = true;
+    const url = `/bot-api/v1/store/plugins/${encodeURIComponent(pluginId)}`;
+    const poll = async (): Promise<void> => {
+      try {
+        const res = await fetch(url, { cache: 'no-store' });
+        if (!res.ok) return;
+        const data = (await res.json()) as {
+          plugin?: { action_status?: PluginActionStatus };
+        };
+        if (alive) setStatus(data.plugin?.action_status);
+      } catch {
+        // transient — keep the last known status, try again next tick
+      }
+    };
+    const timer = setInterval(poll, 15_000);
+    void poll();
+    return () => {
+      alive = false;
+      clearInterval(timer);
+    };
+  }, [pluginId]);
+
+  if (!status || status.state === 'ok') return null;
+
+  const isError = status.state === 'error';
+  return (
+    <div
+      role="status"
+      className={
+        isError
+          ? 'mb-6 flex items-start gap-3 rounded-lg border border-[color:var(--danger)]/30 bg-[color:var(--danger)]/8 p-4'
+          : 'mb-6 flex items-start gap-3 rounded-lg border border-[color:var(--warning)]/30 bg-[color:var(--warning)]/8 p-4'
+      }
+    >
+      <AlertTriangle
+        className={
+          isError
+            ? 'mt-0.5 size-5 shrink-0 text-[color:var(--danger)]'
+            : 'mt-0.5 size-5 shrink-0 text-[color:var(--warning)]'
+        }
+        aria-hidden
+      />
+      <div className="min-w-0">
+        <p className="text-[14px] font-semibold text-[color:var(--fg-strong)]">
+          {status.title ?? (isError ? 'Fehler' : 'Aktion erforderlich')}
+        </p>
+        {status.detail ? (
+          <p className="mt-1 text-[13px] leading-relaxed text-[color:var(--fg-muted)]">
+            {status.detail}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/web-ui/app/_components/store/InstallButton.tsx
+++ b/web-ui/app/_components/store/InstallButton.tsx
@@ -576,7 +576,13 @@ function InstallDrawer({
           ? phase.job
           : null;
 
-  const fields = jobFromPhase?.setup_schema?.fields ?? [];
+  // `install_hidden` fields (flow-managed credentials, e.g. a key populated by
+  // a one-click OAuth/App flow) are omitted from the install flyout to keep
+  // first-time setup minimal. They stay editable later via the store-detail
+  // setup editor.
+  const fields = (jobFromPhase?.setup_schema?.fields ?? []).filter(
+    (f) => !f.install_hidden,
+  );
   const submitting = phase.kind === 'submitting';
 
   return (

--- a/web-ui/app/_components/store/PluginCard.tsx
+++ b/web-ui/app/_components/store/PluginCard.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { ArrowUpRight, RefreshCw, Store } from 'lucide-react';
+import { AlertTriangle, ArrowUpRight, RefreshCw, Store } from 'lucide-react';
 
 import type { Plugin } from '../../_lib/storeTypes';
 import { Chip } from './Chip';
@@ -75,6 +75,23 @@ export function PluginCard({ plugin }: PluginCardProps): React.ReactElement {
           state={hasUpdate ? 'installed' : plugin.install_state}
           isLegacy={isLegacy}
         />
+        {/* Spec 004 — operator-action signal pushed by the active plugin via
+            ctx.status. Persists across visits and clears once the plugin
+            reports `ok`. Amber = needs_action, red = error. */}
+        {plugin.action_status &&
+        plugin.action_status.state !== 'ok' ? (
+          <span
+            className={
+              plugin.action_status.state === 'error'
+                ? 'inline-flex items-center gap-1 rounded-full bg-[color:var(--danger)]/12 px-2.5 py-0.5 text-[11px] font-semibold text-[color:var(--danger)]'
+                : 'inline-flex items-center gap-1 rounded-full bg-[color:var(--warning)]/12 px-2.5 py-0.5 text-[11px] font-semibold text-[color:var(--warning)]'
+            }
+            title={plugin.action_status.detail ?? undefined}
+          >
+            <AlertTriangle className="size-3" aria-hidden />
+            {plugin.action_status.title ?? 'Aktion erforderlich'}
+          </span>
+        ) : null}
         {/* Origin marker — present only on remote-registry (Hub) entries that
             are not yet ingested locally. Lets the Hub view distinguish a
             hub-sourced plugin from a local catalog package at a glance. */}

--- a/web-ui/app/_components/store/RequiresWizard.tsx
+++ b/web-ui/app/_components/store/RequiresWizard.tsx
@@ -471,7 +471,11 @@ function InstallingBody({
   formRef: React.MutableRefObject<HTMLFormElement | null>;
   onFormSubmit: (values: Record<string, unknown>) => void;
 }): React.ReactElement {
-  const fields: InstallSetupField[] = phase.currentJob?.setup_schema?.fields ?? [];
+  // Mirror the install drawer: flow-managed `install_hidden` fields are kept
+  // out of the setup form (editable later via the store-detail editor).
+  const fields: InstallSetupField[] = (
+    phase.currentJob?.setup_schema?.fields ?? []
+  ).filter((f) => !f.install_hidden);
 
   return (
     <div className="space-y-4">

--- a/web-ui/app/_lib/storeTypes.ts
+++ b/web-ui/app/_lib/storeTypes.ts
@@ -43,6 +43,11 @@ export interface PluginPermissionsSummary {
    *  reach arbitrary public hosts (gated by the operator-selected
    *  `audit_mode`). Optional: absent on pre-#91 store payloads. */
   network_web_scanner?: boolean;
+  /** Spec 004 — plugin may write its own vault secrets + config at runtime.
+   *  Surfaced as a store-detail permission chip. */
+  secrets_runtime_write?: boolean;
+  /** Spec 004 — plugin runs credential-acquisition flows on its own routes. */
+  flows?: boolean;
 }
 
 export type PluginInstallState =

--- a/web-ui/app/_lib/storeTypes.ts
+++ b/web-ui/app/_lib/storeTypes.ts
@@ -104,6 +104,15 @@ export interface PluginJobSpec {
   overlap?: 'skip' | 'queue';
 }
 
+/** Spec 004 — operator-facing plugin health (mirror of middleware admin-v1). */
+export type PluginActionState = 'ok' | 'needs_action' | 'error';
+
+export interface PluginActionStatus {
+  state: PluginActionState;
+  title?: string;
+  detail?: string;
+}
+
 export interface Plugin {
   id: string;
   kind: PluginKind;
@@ -145,6 +154,10 @@ export interface Plugin {
    * channel-SDK's `core.registerRouter`.
    */
   admin_ui_path?: string;
+  /** Spec 004 — operator-facing action status the active plugin pushed via
+   *  `ctx.status`. Present only while `needs_action` / `error`; absent for
+   *  `ok` or inactive. Drives the card badge + detail-page banner. */
+  action_status?: PluginActionStatus;
   /** Present only for entries sourced from a remote registry that are not yet
    *  ingested locally. Drives the remote-install flow (fetch-then-ingest
    *  before the normal install job). Mirrors middleware admin-v1. */
@@ -205,6 +218,8 @@ export interface InstallSetupField {
   scopes?: string[];
   pattern?: string;
   multiline?: boolean;
+  /** Omitted from the install flyout (flow-managed / editable later). */
+  install_hidden?: boolean;
 }
 
 export interface InstallSetupSchema {

--- a/web-ui/app/store/[id]/page.tsx
+++ b/web-ui/app/store/[id]/page.tsx
@@ -28,6 +28,7 @@ import {
   AdminUiProvider,
   AdminUiToggle,
 } from '../../_components/store/AdminUiPanel';
+import { ActionStatusBanner } from '../../_components/store/ActionStatusBanner';
 import { Chip } from '../../_components/store/Chip';
 import { AuditModeSwitch } from '../../_components/store/AuditModeSwitch';
 import { CredentialsEditor } from '../../_components/store/CredentialsEditor';
@@ -138,6 +139,12 @@ export default async function PluginDetailPage({
           </div>
         </div>
       </header>
+
+      {/* Spec 004 — operator-action banner (auto-clears once the plugin reports
+          ok, e.g. after connecting via the admin UI below). */}
+      <div className="mt-8">
+        <ActionStatusBanner pluginId={plugin.id} initial={plugin.action_status} />
+      </div>
 
       {/* Two-column body */}
       <AdminUiProvider>

--- a/web-ui/app/store/[id]/page.tsx
+++ b/web-ui/app/store/[id]/page.tsx
@@ -502,7 +502,24 @@ function PermissionsBlock({
   ];
 
   const active = groups.filter((g) => g.items.length > 0);
-  if (active.length === 0) {
+
+  // Spec 004 — boolean capability flags (no string list). Surfaced so an
+  // operator reviewing a Hub plugin sees its runtime-credential powers.
+  const flags: Array<{ label: string; icon: React.ReactNode }> = [];
+  if (perms.secrets_runtime_write) {
+    flags.push({
+      label: 'Schreibt eigene Credentials zur Laufzeit',
+      icon: <KeyRound className="size-3.5" aria-hidden />,
+    });
+  }
+  if (perms.flows) {
+    flags.push({
+      label: 'Führt Credential-Flows auf eigenen Routes aus',
+      icon: <ShieldAlert className="size-3.5" aria-hidden />,
+    });
+  }
+
+  if (active.length === 0 && flags.length === 0) {
     return (
       <p className="text-sm italic text-[color:var(--faint-ink)]">
         Keine Berechtigungen deklariert.
@@ -512,6 +529,25 @@ function PermissionsBlock({
 
   return (
     <div className="space-y-4">
+      {flags.length > 0 ? (
+        <div>
+          <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.18em] text-[color:var(--muted-ink)]">
+            <KeyRound className="size-3.5" aria-hidden />
+            Laufzeit-Credentials
+          </div>
+          <ul className="mt-2 flex flex-wrap gap-2">
+            {flags.map((flag) => (
+              <Chip
+                key={flag.label}
+                tone="accent"
+                className="normal-case tracking-normal"
+              >
+                {flag.label}
+              </Chip>
+            ))}
+          </ul>
+        </div>
+      ) : null}
       {active.map((group) => (
         <div key={group.label}>
           <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.18em] text-[color:var(--muted-ink)]">


### PR DESCRIPTION
Reusable platform layer so any plugin can acquire credentials at runtime and run its own redirect/callback flow — without a bespoke core PR. Validated end-to-end by the (Hub-distributed) GitHub integration's one-click GitHub-App-Manifest flow, smoke-tested live on the docker-compose stack.

The GitHub plugin packages themselves are Hub-distributed (git-ignored) and are **not** part of this PR — only the reusable core primitives are.

## What's in here (3 commits)

**Phase A — runtime credential write** (`61dfdd1`)
- Gated `ctx.secrets.set/delete` + `ctx.config.set`, built only when the manifest declares `permissions.secrets.runtime_write`. Writes are namespace-locked to the calling plugin; `config.set` only accepts declared, non-secret setup fields. Surfaced as a store-detail permission chip.

**Phase B — `ctx.flows` toolkit + PKCE SDK** (`52c45df`)
- `ctx.flows.publicUrl()` resolves a plugin's browser-facing callback URL (mirrors the `/bot-api → /api` proxy mapping). `signState`/`verifyState` mint/verify a CSRF-safe state token (HS512, 10-min TTL) whose audience is **auto-bound to the plugin id** — a token minted for plugin A is rejected for plugin B. The signing key is kernel-held and never reaches plugin code. Present only with `permissions.flows`.
- PKCE (`generateCodeVerifier`/`computeCodeChallenge`) lifted into `@omadia/plugin-api` as the single source; the kernel's `oauth/pkce.ts` re-exports it. New `FLOW_PUBLIC_BASE_URL` (defaults to `PUBLIC_BASE_URL`).

**install_hidden + `ctx.status` + .dockerignore** (`d6cd0f9`)
- `install_hidden` setup-field flag (like `multiline`): flow-managed fields are omitted from the install flyout to keep first-time setup minimal, but stay declared (writable via `ctx.config.set`) and editable later on the store-detail page.
- `ctx.status.report()/clear()` — a state-aware, operator-facing plugin health signal (always present, ungated, self-scoped). Backed by an in-memory `PluginStatusRegistry` threaded through the tool/agent/channel runtimes (cleared on deactivate, re-reported on activate). The store list/detail API carries `action_status`; the web-ui renders a card badge + a detail banner that auto-clears once the plugin reports `ok`.
- `.dockerignore`: keep Hub-distributed plugin packages out of the core image (their source was being registered as broken built-in catalog entries with uncompiled `dist/`, blocking the operator zip-upload path).

## Notes
- All new manifest keys / accessors are additive and parsed leniently; older cores ignore them and plugins degrade to a manual path.
- Types mirrored into `@omadia/plugin-api` + the boilerplate `types.ts` duplicate.

## Testing
- Full middleware suite green (3481 pass / 0 fail); web-ui typecheck + i18n parity green.
- New unit tests: state audience-binding + expiry, `ctx.flows` gating + URL resolution, PKCE SDK vector, runtime write gating + namespace lock, `install_hidden` parsing, `ctx.status` presence/normalization/self-scoping.
- Live smoke on docker-compose: one-click connect, minimal install flyout, and the action-status badge appearing → auto-clearing on connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)