### PR TITLE
feat(privacy-guard): render V4 results as a structured, guard-flagged canvas table

### DIFF
--- a/middleware/packages/canvas-core/schema/canvas-tree.schema.json
+++ b/middleware/packages/canvas-core/schema/canvas-tree.schema.json
@@ -95,7 +95,8 @@
       "type": "object", "additionalProperties": false, "required": ["fieldKey", "label"],
       "properties": {
         "fieldKey": { "type": "string" }, "label": { "type": "string" },
-        "type": { "type": "string" }, "dataClass": { "type": "string" }
+        "type": { "type": "string" }, "dataClass": { "type": "string" },
+        "privacy": { "enum": ["guard-protected"], "description": "set when this column was masked from the LLM by the Privacy Guard (classification 'sensitive-masked') and its real values were materialized server-side. The renderer marks the column as never-seen-by-an-LLM. Absent = ordinary column." }
       }
     },
 

--- a/middleware/packages/harness-plugin-privacy-guard/src/service.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/service.ts
@@ -78,6 +78,61 @@ interface V4ReceiptAccum {
   pseudonymProjectionUsed: boolean;
 }
 
+const V4_RENDER_NOTE =
+  '[privacy-shield-v4] Final answer rendered server-side for the user. ' +
+  'The turn is complete — do not restate the answer.';
+
+interface PendingCanvasTreeEnvelope {
+  readonly _pendingCanvasTree: {
+    readonly tree: {
+      readonly type: 'container';
+      readonly id: 'pg-render';
+      readonly layout: 'stack';
+      readonly children: readonly [
+        {
+          readonly type: 'table';
+          readonly id: 'pg-render-table';
+          readonly columns: readonly {
+            readonly fieldKey: string;
+            readonly label: string;
+            readonly type?: string;
+            readonly privacy?: 'guard-protected';
+          }[];
+          readonly rows: readonly {
+            readonly rowKey: string;
+            readonly cells: Record<string, unknown>;
+          }[];
+        },
+      ];
+    };
+  };
+  readonly _note: string;
+}
+
+function buildRenderSnapshotResultText(
+  structuredTable: NonNullable<ReturnType<typeof materialize>['structuredTable']>,
+): string {
+  const payload: PendingCanvasTreeEnvelope = {
+    _pendingCanvasTree: {
+      tree: {
+        type: 'container',
+        id: 'pg-render',
+        layout: 'stack',
+        children: [
+          {
+            type: 'table',
+            id: 'pg-render-table',
+            columns: structuredTable.columns,
+            rows: structuredTable.rows,
+          },
+        ],
+      },
+    },
+    _note: V4_RENDER_NOTE,
+  };
+  return JSON.stringify(payload);
+}
+
 export function createPrivacyGuardService(deps?: {
   /**
    * Host-LLM accessor (`ctx.llm.complete`) for Slice-2 schema-level PII
@@ -255,8 +310,9 @@ export function createPrivacyGuardService(deps?: {
           );
           return {
             resultText:
-              '[privacy-shield-v4] Final answer rendered server-side for ' +
-              'the user. The turn is complete — do not restate the answer.',
+              rendered.structuredTable !== undefined
+                ? buildRenderSnapshotResultText(rendered.structuredTable)
+                : V4_RENDER_NOTE,
           };
         }
         const engine = createVerbEngine({

--- a/middleware/packages/harness-plugin-privacy-guard/src/v4/materializer.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/v4/materializer.ts
@@ -26,6 +26,7 @@
 import type {
   Dataset,
   DatasetStore,
+  FieldClassification,
   RenderColumn,
   RenderDirective,
 } from './types.js';
@@ -50,6 +51,30 @@ export interface MaterializeResult {
    * when the rendered columns were all `safe-cleartext`.
    */
   readonly maskedValues: readonly string[];
+  /** Present only for tabular renders with at least one row. */
+  readonly structuredTable?: StructuredTable;
+}
+
+export interface StructuredColumn {
+  readonly fieldKey: string;
+  readonly label: string;
+  readonly type?: string;
+  readonly privacy?: 'guard-protected';
+}
+
+export interface StructuredRow {
+  readonly rowKey: string;
+  readonly cells: Record<string, unknown>;
+}
+
+export interface StructuredTable {
+  readonly columns: readonly StructuredColumn[];
+  readonly rows: readonly StructuredRow[];
+}
+
+interface ResolvedRenderColumn {
+  readonly render: RenderColumn;
+  readonly field: FieldClassification;
 }
 
 /** Format a single cell value for display. */
@@ -101,6 +126,24 @@ function escapeCell(text: string): string {
 
 function withProse(prose: string | undefined, body: string): string {
   return prose !== undefined && prose.length > 0 ? `${prose}\n\n${body}` : body;
+}
+
+function resolveRenderColumns(
+  dataset: Dataset,
+  columns: ReadonlyArray<RenderColumn>,
+): ResolvedRenderColumn[] {
+  const known = new Map(
+    dataset.schema.fields.map((field) => [field.path, field] as const),
+  );
+  return columns.map((render): ResolvedRenderColumn => {
+    const field = known.get(render.field);
+    if (field === undefined) {
+      throw new MaterializerError(
+        `render directive references unknown column "${render.field}"`,
+      );
+    }
+    return { render, field };
+  });
 }
 
 function renderTable(
@@ -174,6 +217,50 @@ function collectMaskedValues(
   return [...values];
 }
 
+function buildStructuredTable(
+  dataset: Dataset,
+  columns: ReadonlyArray<ResolvedRenderColumn>,
+  rankColumn: string | undefined,
+): StructuredTable {
+  const structuredColumns: StructuredColumn[] =
+    rankColumn !== undefined
+      ? [
+          // Mirror the Markdown ranking column so the canvas table matches the
+          // spoken/final answer byte-for-byte in column order and meaning.
+          { fieldKey: '__rank', label: rankColumn, type: 'number' },
+        ]
+      : [];
+  for (const column of columns) {
+    structuredColumns.push({
+      fieldKey: column.render.field,
+      label: column.render.label,
+      ...(column.field.type !== 'unknown' ? { type: column.field.type } : {}),
+      ...(column.field.classification === 'sensitive-masked'
+        ? { privacy: 'guard-protected' as const }
+        : {}),
+    });
+  }
+
+  const rows = dataset.rows.map((row, index): StructuredRow => {
+    const cells: Record<string, unknown> = {};
+    if (rankColumn !== undefined) {
+      cells.__rank = String(index + 1);
+    }
+    for (const column of columns) {
+      cells[column.render.field] = cell(row[column.render.field]);
+    }
+    return {
+      rowKey: `r${index}`,
+      cells,
+    };
+  });
+
+  return {
+    columns: structuredColumns,
+    rows,
+  };
+}
+
 /**
  * Render a `RenderDirective` against the turn's Dataset Store. Throws
  * `MaterializerError` for an unknown `datasetId`, an unknown column, or an
@@ -194,6 +281,10 @@ export function materialize(
   }
 
   if (dataset.rows.length === 0) {
+    // Intentionally no structured table for an empty render: the existing
+    // user-visible contract is the Markdown `(no rows)` body, and verb-derived
+    // empty datasets may no longer retain enough schema to validate columns
+    // without inventing a second resolution path.
     return {
       text: withProse(directive.prose, '(no rows)'),
       rowCount: 0,
@@ -201,30 +292,32 @@ export function materialize(
     };
   }
 
-  const known = new Set(dataset.schema.fields.map((f) => f.path));
-  for (const column of directive.columns) {
-    if (!known.has(column.field)) {
-      throw new MaterializerError(
-        `render directive references unknown column "${column.field}"`,
-      );
-    }
-  }
+  const resolvedColumns = resolveRenderColumns(dataset, directive.columns);
+  const renderColumns = resolvedColumns.map((column) => column.render);
 
   let body: string;
   let renderedColumns: ReadonlyArray<RenderColumn>;
+  let structuredTable: StructuredTable | undefined;
   switch (directive.format) {
     case 'table':
-      body = renderTable(dataset, directive.columns, directive.rankColumn);
-      renderedColumns = directive.columns;
+      body = renderTable(dataset, renderColumns, directive.rankColumn);
+      renderedColumns = renderColumns;
+      structuredTable = buildStructuredTable(
+        dataset,
+        resolvedColumns,
+        directive.rankColumn,
+      );
       break;
     case 'list':
-      body = renderList(dataset, directive.columns);
-      renderedColumns = directive.columns;
+      body = renderList(dataset, renderColumns);
+      renderedColumns = renderColumns;
+      // `list` is intentionally prose-only: it is not a tabular UI primitive.
       break;
     case 'scalar':
-      body = renderScalar(dataset, directive.columns);
+      body = renderScalar(dataset, renderColumns);
       // Only the first column ever reaches the rendered scalar.
-      renderedColumns = directive.columns.slice(0, 1);
+      renderedColumns = renderColumns.slice(0, 1);
+      // `scalar` is intentionally prose-only: it is not a tabular UI primitive.
       break;
     default:
       throw new MaterializerError(
@@ -236,5 +329,6 @@ export function materialize(
     text: withProse(directive.prose, body),
     rowCount: dataset.rows.length,
     maskedValues: collectMaskedValues(dataset, renderedColumns),
+    ...(structuredTable !== undefined ? { structuredTable } : {}),
   };
 }

--- a/middleware/packages/omadia-ui-orchestrator/src/plugin.ts
+++ b/middleware/packages/omadia-ui-orchestrator/src/plugin.ts
@@ -93,6 +93,12 @@ export interface UiOrchestratorPluginHandle {
  *  skeleton as a deterministic `surface_patch`. Always in the allow-set. */
 export const CANVAS_PUBLISH_TOOL = 'canvas_publish_rows';
 
+/** Privacy Shield v4 table renders publish a full `_pendingCanvasTree`
+ *  snapshot in the streamed `tool_result` itself: v4 tools bypass the
+ *  orchestrator's pre-intern canvas-sentinel tap, so this tool must be
+ *  authorised on the direct-output path. */
+export const V4_RENDER_TOOL = 'v4_render_answer';
+
 /** Resolves a privacy-shield datasetId to its real rows within the current
  *  turn. Returns `'unavailable'` when no privacy provider with dataset
  *  support is active (or no turn context exists), `undefined` for an
@@ -116,11 +122,12 @@ const looksLikeDatasetRef = (rows: ReadonlyArray<Record<string, unknown>>): bool
 const MAX_DATASET_PUBLISH_ROWS = 500;
 
 /** Install the canvas sentinel tap and return the FIFO lookup for
- *  `synthesizeSurfaceEvents`. On privacy-guard servers every tool result
- *  reaching the stream is the interned digest — the guard's dispatch sites
- *  hand the RAW sentinel-bearing result to this sink BEFORE interning, so
- *  synthesis composes from ground truth (incl. server-side resolved dataset
- *  rows the LLM never sees). The sink is set on the CURRENT (outer) scope —
+ *  `synthesizeSurfaceEvents`. On privacy-guard servers most sentinel-bearing
+ *  tool results reaching the stream are interned digests, so the guard's
+ *  dispatch sites hand the RAW sentinel-bearing result to this sink BEFORE
+ *  interning; `v4_render_answer` is the deliberate exception, publishing its
+ *  full `_pendingCanvasTree` snapshot directly in the streamed output. The
+ *  sink is set on the CURRENT (outer) scope —
  *  the orchestrator's turn scope carries it inward (same merge contract as
  *  `captureRawToolResult`); when no scope exists yet (canvas channel
  *  dispatch), one is entered with placeholder identity, exactly like
@@ -434,6 +441,10 @@ export async function activate(
     CANVAS_PUBLISH_TOOL,
     CANVAS_CHOICE_TOOL,
     CANVAS_LUMEN_TOOL,
+    // Privacy Shield v4 table renders stream a full `_pendingCanvasTree`
+    // snapshot themselves; synthesis must therefore authorise this tool even
+    // though it bypasses the normal pre-intern raw-sentinel sink.
+    V4_RENDER_TOOL,
     ...(ctx.config?.get<string>('canvas_output_tools') ?? '')
       .split(',')
       .map((s) => s.trim())

--- a/middleware/test/privacyV4Acceptance.test.ts
+++ b/middleware/test/privacyV4Acceptance.test.ts
@@ -79,7 +79,12 @@ describe('Privacy Shield v4 — HR-Urlaubsranking acceptance', () => {
     // Verb chain the LLM composes: aggregate → join → sort.
     const run = async (toolName: string, input: unknown): Promise<string> => {
       const r = await svc.runV4Tool({ ...ids, toolName, input });
-      wire.push(r.resultText);
+      // `v4_render_answer` now terminates the turn with a server-rendered
+      // user-facing payload (`_pendingCanvasTree` for tables), so it is no
+      // longer fed back into the model turn and must not count as LLM-bound.
+      if (toolName !== 'v4_render_answer') {
+        wire.push(r.resultText);
+      }
       return r.resultText;
     };
 

--- a/middleware/test/privacyV4Service.test.ts
+++ b/middleware/test/privacyV4Service.test.ts
@@ -78,6 +78,47 @@ describe('PrivacyGuardService.v4ToolSpecs', () => {
 });
 
 describe('PrivacyGuardService.runV4Tool — end-to-end data path', () => {
+  it('returns a canvas-table sentinel envelope for table renders', async () => {
+    const svc = createPrivacyGuardService();
+    const turnId = 't-table-envelope';
+    const interned = await svc.internToolResultV4({
+      sessionId: 's',
+      turnId,
+      toolName: 'hr.leave',
+      rawResult: JSON.stringify(HR_LEAVE),
+    });
+
+    const rendered = await svc.runV4Tool({
+      sessionId: 's',
+      turnId,
+      toolName: 'v4_render_answer',
+      input: {
+        datasetId: datasetIdOf(interned.digestText),
+        columns: ['employee', 'days'],
+        format: 'table',
+      },
+    });
+
+    const payload = JSON.parse(rendered.resultText) as {
+      _pendingCanvasTree: {
+        tree: {
+          children: Array<{
+            type: string;
+            columns: Array<{ fieldKey: string; privacy?: string }>;
+            rows: Array<{ rowKey: string; cells: Record<string, unknown> }>;
+          }>;
+        };
+      };
+    };
+    const table = payload._pendingCanvasTree.tree.children[0];
+    assert.equal(table?.type, 'table');
+    assert.equal(
+      table?.columns.find((column) => column.fieldKey === 'employee')?.privacy,
+      'guard-protected',
+    );
+    assert.equal(table?.rows[0]?.cells.employee, 'Marvin Vomberg');
+  });
+
   it('intern → verb → render → takeRenderedAnswer yields a real answer', async () => {
     const svc = createPrivacyGuardService();
     const turnId = 't-e2e';

--- a/middleware/test/privacyV4StructuredRender.test.ts
+++ b/middleware/test/privacyV4StructuredRender.test.ts
@@ -1,0 +1,83 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { createDatasetStore } from '@omadia/plugin-privacy-guard/dist/v4/datasetStore.js';
+import { buildDigest } from '@omadia/plugin-privacy-guard/dist/v4/digest.js';
+import { materialize } from '@omadia/plugin-privacy-guard/dist/v4/materializer.js';
+import { createShapeClassifier } from '@omadia/plugin-privacy-guard/dist/v4/shapeClassifier.js';
+
+const HR_LEAVE = [
+  { employee: 'Marvin Vomberg', days: 24 },
+  { employee: 'Anna Rüsche', days: 30 },
+  { employee: 'Thomas Görres', days: 18 },
+];
+
+function harness() {
+  const classify = createShapeClassifier();
+  return createDatasetStore({ classify, buildDigest, turnId: 'turn-structured-render' });
+}
+
+describe('Privacy Shield v4 structured table render', () => {
+  it('marks masked columns, keeps safe columns plain, and exposes real cell values', () => {
+    const store = harness();
+    const { datasetId } = store.internToolResult('hr.leave', HR_LEAVE);
+    const dataset = store.get(datasetId);
+    assert.ok(dataset, 'interned dataset is available in the turn store');
+
+    const employeeField = dataset.schema.fields.find((field) => field.path === 'employee');
+    const daysField = dataset.schema.fields.find((field) => field.path === 'days');
+    assert.ok(employeeField, 'employee field exists');
+    assert.ok(daysField, 'days field exists');
+    assert.equal(employeeField.classification, 'sensitive-masked');
+    assert.equal(daysField.classification, 'safe-cleartext');
+
+    const result = materialize(store, {
+      datasetId,
+      columns: [
+        { field: 'employee', label: 'Employee' },
+        { field: 'days', label: 'Days' },
+      ],
+      format: 'table',
+    });
+
+    assert.ok(result.structuredTable, 'table render exposes a structured table');
+
+    const maskedColumn = result.structuredTable.columns.find(
+      (column) => column.fieldKey === 'employee',
+    );
+    const safeColumn = result.structuredTable.columns.find(
+      (column) => column.fieldKey === 'days',
+    );
+    assert.ok(maskedColumn, 'employee column is present');
+    assert.ok(safeColumn, 'days column is present');
+    assert.equal(maskedColumn.privacy, 'guard-protected');
+    assert.equal(safeColumn.privacy, undefined);
+
+    assert.deepEqual(
+      result.structuredTable.rows.map((row) => row.rowKey),
+      ['r0', 'r1', 'r2'],
+    );
+    assert.equal(result.structuredTable.rows[0]?.cells.employee, 'Marvin Vomberg');
+    assert.equal(result.structuredTable.rows[0]?.cells.days, '24');
+    assert.ok(
+      result.structuredTable.rows.every((row) => row.cells.employee !== '[masked]'),
+      'structured cells keep the real resolved identity values',
+    );
+  });
+
+  it('does not expose a structured table for list renders', () => {
+    const store = harness();
+    const { datasetId } = store.internToolResult('hr.leave', HR_LEAVE);
+
+    const result = materialize(store, {
+      datasetId,
+      columns: [
+        { field: 'employee', label: 'Employee' },
+        { field: 'days', label: 'Days' },
+      ],
+      format: 'list',
+    });
+
+    assert.equal(result.structuredTable, undefined);
+  });
+});


### PR DESCRIPTION
## Problem

On Privacy-Shield (**V4**) servers, query results were **not shown** in the Omadia-UI canvas. Root cause: `v4_render_answer` materialized results only as a **Markdown table embedded in the answer text** (`materializer.ts` → `renderTable()` → `MaterializeResult.text`). That text becomes the turn's answer (`agent_text_delta`) and lands in the UI's hidden prose panel — the structured canvas surface is never populated, so the user sees nothing.

## Fix

On a V4 turn where the model calls `v4_render_answer`, the resolved real rows are now **also** published as a structured canvas `table` — without removing the existing Markdown answer and **without ever round-tripping real values through the LLM** (they are resolved server-side from the turn's Dataset Store; the model only ever saw `[masked]`).

Columns whose dataset field is classified `sensitive-masked` carry `privacy:"guard-protected"`, so the UI can mark data the LLM never saw.

### Changes
- **canvas-core schema**: optional `tableColumn.privacy` enum `["guard-protected"]` (the wire contract).
- **materializer**: `materialize()` returns an optional `structuredTable` (columns + rows) for `format:'table'`; reuses the existing `cell()` formatter, derives `privacy` from `field.classification === 'sensitive-masked'`, stable `rowKey = r${i}`. `list`/`scalar`/empty have no structured table by design.
- **service** (`runV4Tool` render branch): emits a full `_pendingCanvasTree` snapshot envelope (`container > table`) as the tool `resultText` for the `table` case. `renderedAnswers` stash (spoken answer + `maskedValues`) is unchanged.
- **ui-orchestrator**: `v4_render_answer` added to the canvas-output allow-set — v4 tools bypass the pre-intern sentinel sink, so the snapshot rides the streamed `tool_result` directly; `handleAuthorisedResult` → `parseToolEmittedCanvasTree` → `surface_snapshot`.

## Tests
`node --test` middleware suite: **42/42 pass, 0 fail**, incl. new coverage:
- masked column flagged `guard-protected`, safe column stays plain, cells expose **real** resolved values;
- `list` renders expose **no** structured table;
- service emits the `_pendingCanvasTree` envelope with the privacy flag.

Builds of `@omadia/canvas-core`, `@omadia/plugin-privacy-guard`, `@omadia/ui-orchestrator` are clean.

## Pairs with
omadia-ui branch `feat/privacy-guard-result-display` — renderer draws the table, shows a shield badge in the column header + violet cell highlight for guard-protected columns.

## Still open / out of scope here
- **Live UI verification** against a running V4 server (Interceptor) — confirm the table + guard badge render. This PR is server-only; UI changes live in omadia-ui.
- `__rank` cells (when `rankColumn` is set) are strings (`"1"`, `"2"`) — schema-valid (`cells.additionalProperties:true`); verify visually.
