### PR TITLE
fix(builder): provide ctx.jobs + ctx.status stubs in preview harness

### DIFF
--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -6227,7 +6227,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.1.1",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",

--- a/middleware/src/plugins/builder/previewRuntime.ts
+++ b/middleware/src/plugins/builder/previewRuntime.ts
@@ -87,6 +87,32 @@ export interface PreviewUiRouteDescriptorInput {
   readonly order?: number;
 }
 
+/** Mirror of `JobSchedule` from the boilerplate contract
+ *  (`agent-integration/types.ts`). Inline-copied to keep previewRuntime
+ *  self-contained. */
+export type PreviewJobSchedule =
+  | { readonly cron: string }
+  | { readonly intervalMs: number };
+
+/** Mirror of `JobSpec` — only the fields the preview needs to capture +
+ *  surface. The kernel validates the full shape at register-time; the
+ *  preview accepts and records it without scheduling anything. */
+export interface PreviewJobSpecInput {
+  readonly name: string;
+  readonly schedule: PreviewJobSchedule;
+  readonly timeoutMs?: number;
+  readonly overlap?: 'skip' | 'queue';
+}
+
+export type PreviewJobHandler = (signal: AbortSignal) => Promise<void>;
+
+/** Mirror of `PluginActionStatus` from the boilerplate contract. */
+export interface PreviewStatusInput {
+  readonly state: 'ok' | 'needs_action' | 'error';
+  readonly title?: string;
+  readonly detail?: string;
+}
+
 export interface PreviewPluginContext {
   readonly agentId: string;
   readonly secrets: {
@@ -106,6 +132,29 @@ export interface PreviewPluginContext {
    *  kernel after install. */
   readonly uiRoutes: {
     register(descriptor: PreviewUiRouteDescriptorInput): () => void;
+  };
+  /** Background-job registry. Non-optional in the kernel contract
+   *  (`pluginContext.ts` always wires `jobs`), so a plugin with a scheduled
+   *  job calls `ctx.jobs.register(...)` in activate() unconditionally. Before
+   *  this stub existed the call threw `Cannot read properties of undefined
+   *  (reading 'register')` ONLY in preview — the agent compiled and ran fine
+   *  after install. The preview CAPTURES the registration (so the operator can
+   *  see "this agent schedules N jobs") and returns a working disposer, but
+   *  deliberately does NOT fire the cron/interval: preview activations are
+   *  ephemeral and must not trigger real side effects. Contract-parity without
+   *  runtime side effects — the same call shape and disposer the kernel hands
+   *  the plugin post-install. */
+  readonly jobs: {
+    register(spec: PreviewJobSpecInput, handler: PreviewJobHandler): () => void;
+  };
+  /** Operator-facing action-status reporter. Non-optional in the kernel
+   *  contract (`pluginContext.ts` always wires `status`). Preview has no admin
+   *  badge to render into, so `report`/`clear` record the call locally (for
+   *  introspection + smoke) without surfacing a banner. Same crash class as
+   *  `jobs` before this stub — `reading 'report'`. */
+  readonly status: {
+    report(status: PreviewStatusInput): void;
+    clear(): void;
   };
   /** ServicesAccessor (solution B). When the runtime is wired with the live
    *  kernel ServiceRegistry (`PreviewRuntimeDeps.serviceRegistry`), `get`/`has`
@@ -161,6 +210,21 @@ export interface PreviewRouteCapture {
   disposed: boolean;
 }
 
+/**
+ * Job registration captured at activate-time by the preview's
+ * `jobs.register`. The preview does NOT schedule the job (no cron fires in
+ * an ephemeral preview); it records the spec + handler so the operator/smoke
+ * can see what the agent would schedule post-install. `disposed` flips when
+ * the plugin's close() calls the returned dispose handle.
+ */
+export interface PreviewJobCapture {
+  readonly name: string;
+  readonly schedule: PreviewJobSchedule;
+  readonly spec: PreviewJobSpecInput;
+  readonly handler: PreviewJobHandler;
+  disposed: boolean;
+}
+
 export interface PreviewActivateOptions {
   zipBuffer: Buffer;
   draftId: string;
@@ -186,6 +250,16 @@ export interface PreviewHandle {
    *  during `activate()` and may be flagged `disposed` when the plugin's
    *  close-handle is invoked. */
   readonly routeCaptures: ReadonlyArray<PreviewRouteCapture>;
+  /** Background jobs the plugin's `activate()` registered via
+   *  `ctx.jobs.register(...)`. Captured but never scheduled in preview.
+   *  Lets the operator/smoke confirm the agent wires its job the same way
+   *  the kernel would post-install. Empty for plugins with no jobs. */
+  readonly jobCaptures: ReadonlyArray<PreviewJobCapture>;
+  /** Action-status values the plugin reported via `ctx.status.report(...)`
+   *  during `activate()`, newest last. `ctx.status.clear()` appends a
+   *  synthetic `{ state: 'ok' }` marker (the kernel treats `ok`/clear the
+   *  same — both remove the badge). Empty when the plugin reports nothing. */
+  readonly statusReports: ReadonlyArray<PreviewStatusInput>;
   close(): Promise<void>;
 }
 
@@ -387,12 +461,16 @@ export class PreviewRuntime {
         : undefined;
 
     const routeCaptures: PreviewRouteCapture[] = [];
+    const jobCaptures: PreviewJobCapture[] = [];
+    const statusReports: PreviewStatusInput[] = [];
     const ctx = createStubContext({
       agentId,
       configValues: opts.configValues,
       secretValues: opts.secretValues,
       smokeMode: opts.smokeMode === true,
       routeCaptures,
+      jobCaptures,
+      statusReports,
       hostServices: this.hostServices,
       provideMemory,
       ...(http ? { http } : {}),
@@ -418,6 +496,8 @@ export class PreviewRuntime {
       toolkit: handle.toolkit,
       previewDir,
       routeCaptures,
+      jobCaptures,
+      statusReports,
       close: async () => {
         try {
           await withTimeout(
@@ -514,6 +594,8 @@ function createStubContext(opts: {
   secretValues: Readonly<Record<string, string>>;
   smokeMode: boolean;
   routeCaptures: PreviewRouteCapture[];
+  jobCaptures: PreviewJobCapture[];
+  statusReports: PreviewStatusInput[];
   hostServices?: PreviewHostServices;
   provideMemory: boolean;
   http?: HttpAccessor;
@@ -582,6 +664,53 @@ function createStubContext(opts: {
     // catalogue gets populated only after a real Install.
     uiRoutes: {
       register: (_descriptor) => () => {},
+    },
+    // Jobs accessor — non-optional in the kernel contract, so a plugin with a
+    // scheduled job calls `ctx.jobs.register(...)` unconditionally in
+    // activate(). Before this stub the call threw `Cannot read properties of
+    // undefined (reading 'register')` ONLY in preview (the plugin compiled and
+    // ran fine after install — the kernel always wires `jobs`). We CAPTURE the
+    // registration so the operator/smoke can see what the agent would schedule,
+    // and return a real disposer matching the kernel shape — but we never fire
+    // the cron/interval: preview activations are ephemeral and must not trigger
+    // real side effects. Same intent as the routes/uiRoutes stubs.
+    jobs: {
+      register: (spec, handler) => {
+        const entry: PreviewJobCapture = {
+          name: spec.name,
+          schedule: spec.schedule,
+          spec,
+          handler,
+          disposed: false,
+        };
+        opts.jobCaptures.push(entry);
+        return () => {
+          entry.disposed = true;
+        };
+      },
+    },
+    // Status accessor — also non-optional in the kernel contract. Preview has
+    // no admin badge to render into, so we just record the reported values
+    // (newest last) for introspection. `clear()` records a synthetic `ok`
+    // marker since the kernel treats `ok` and clear identically (both drop the
+    // badge). Same crash class as `jobs` before this stub (`reading 'report'`).
+    status: {
+      report: (next) => {
+        const state =
+          next.state === 'ok' ||
+          next.state === 'needs_action' ||
+          next.state === 'error'
+            ? next.state
+            : 'needs_action';
+        opts.statusReports.push({
+          state,
+          ...(typeof next.title === 'string' ? { title: next.title } : {}),
+          ...(typeof next.detail === 'string' ? { detail: next.detail } : {}),
+        });
+      },
+      clear: () => {
+        opts.statusReports.push({ state: 'ok' });
+      },
     },
     // ServicesAccessor (solution B): read through to the live kernel
     // ServiceRegistry when one is wired, so an integration-backed agent under

--- a/middleware/test/builder/previewCtxJobsRegisterRepro.test.ts
+++ b/middleware/test/builder/previewCtxJobsRegisterRepro.test.ts
@@ -1,0 +1,175 @@
+/**
+ * REGRESSION — `builder.preview_chat_failed: Cannot read properties of
+ * undefined (reading 'register')`.
+ *
+ * Customer hit this in the Agent-Builder preview. The builder agent guessed
+ * the crash came from the codegen-emitted `ctx.uiRoutes.register(...)` and the
+ * preview harness "not mocking ctx.uiRoutes". That diagnosis was WRONG:
+ *
+ *   - `ctx.uiRoutes` IS stubbed in preview (always was). Not the culprit.
+ *   - The real gap: the boilerplate PluginContext contract
+ *     (assets/boilerplate/agent-integration/types.ts) declares `jobs:
+ *     JobsAccessor` and `status: StatusAccessor` as NON-optional, the kernel's
+ *     createPluginContext provides both, but the preview's createStubContext
+ *     omitted BOTH. Any plugin that registers a scheduled job compiled cleanly,
+ *     worked after install, and crashed ONLY in preview when activate() ran
+ *     `ctx.jobs.register(...)`.
+ *
+ * Fix: createStubContext now stubs `ctx.jobs` + `ctx.status`, mirroring the
+ * kernel wiring (capture + real disposer) WITHOUT firing cron in the ephemeral
+ * preview. These tests pin the fixed behaviour and prove a builder-generated
+ * agent wires a job + a status report the same way the core does post-install.
+ */
+import { describe, it, before, after } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import {
+  PreviewRuntime,
+  type PreviewHandle,
+  type PreviewPluginContext,
+} from '../../src/plugins/builder/previewRuntime.js';
+
+describe('REGRESSION: preview ctx provides jobs/status accessors', () => {
+  let tmp: string;
+
+  before(() => {
+    tmp = mkdtempSync(path.join(tmpdir(), 'preview-jobs-reg-'));
+  });
+  after(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  /** Runtime whose activateModule hands the REAL preview ctx to `onActivate`,
+   *  exactly as the kernel hands it to a plugin's activate(). */
+  function runtimeWith(
+    root: string,
+    onActivate: (ctx: PreviewPluginContext) => void | Promise<void>,
+  ): PreviewRuntime {
+    return new PreviewRuntime({
+      previewsRoot: root,
+      logger: () => {},
+      extractZip: async (_zip, destDir) => {
+        mkdirSync(path.join(destDir, 'dist'), { recursive: true });
+        writeFileSync(
+          path.join(destDir, 'package.json'),
+          JSON.stringify({
+            name: '@omadia/agent-repro',
+            version: '0.1.0',
+            main: 'dist/index.js',
+          }),
+        );
+        writeFileSync(path.join(destDir, 'dist', 'index.js'), '// stub\n');
+      },
+      activateModule: async (_entry, ctx) => {
+        await onActivate(ctx);
+        return { toolkit: { tools: [] }, close: async () => {} };
+      },
+    });
+  }
+
+  function freshRoot(name: string): string {
+    const root = path.join(tmp, name);
+    mkdirSync(root, { recursive: true });
+    return root;
+  }
+
+  function activate(runtime: PreviewRuntime, draftId: string): Promise<PreviewHandle> {
+    return runtime.activate({
+      zipBuffer: Buffer.from('PK'),
+      draftId,
+      rev: 1,
+      configValues: {},
+      secretValues: {},
+    });
+  }
+
+  it('ctx.uiRoutes is stubbed (control — never was the culprit)', async () => {
+    let ok = false;
+    const runtime = runtimeWith(freshRoot('ui'), (ctx) => {
+      const dispose = ctx.uiRoutes.register({
+        routeId: 'dashboard',
+        path: '/dashboard',
+        title: 'Dashboard',
+      });
+      dispose();
+      ok = true;
+    });
+    await activate(runtime, 'd-ui');
+    assert.equal(ok, true);
+  });
+
+  it('ctx.jobs.register no longer throws and the registration is captured', async () => {
+    let dispose: (() => void) | undefined;
+    const runtime = runtimeWith(freshRoot('jobs'), (ctx) => {
+      assert.ok(ctx.jobs, 'ctx.jobs must be present');
+      dispose = ctx.jobs.register(
+        { name: 'nightly-sync', schedule: { cron: '0 3 * * *' } },
+        async () => {},
+      );
+      assert.equal(typeof dispose, 'function', 'register returns a disposer');
+    });
+
+    const handle = await activate(runtime, 'd-jobs');
+
+    assert.equal(handle.jobCaptures.length, 1, 'one job captured');
+    assert.equal(handle.jobCaptures[0]?.name, 'nightly-sync');
+    assert.deepEqual(handle.jobCaptures[0]?.schedule, { cron: '0 3 * * *' });
+    assert.equal(handle.jobCaptures[0]?.disposed, false);
+
+    // Disposer mirrors the kernel contract — flips the capture to disposed.
+    dispose?.();
+    assert.equal(handle.jobCaptures[0]?.disposed, true);
+  });
+
+  it('ctx.status.report/clear no longer throws and reports are captured', async () => {
+    const runtime = runtimeWith(freshRoot('status'), (ctx) => {
+      assert.ok(ctx.status, 'ctx.status must be present');
+      ctx.status.report({ state: 'needs_action', title: 'Connect your account' });
+      ctx.status.clear();
+    });
+
+    const handle = await activate(runtime, 'd-status');
+
+    assert.equal(handle.statusReports.length, 2);
+    assert.deepEqual(handle.statusReports[0], {
+      state: 'needs_action',
+      title: 'Connect your account',
+    });
+    // clear() records a synthetic `ok` (kernel treats ok/clear identically).
+    assert.deepEqual(handle.statusReports[1], { state: 'ok' });
+  });
+
+  it('a builder-generated agent wires a job AND a report like core does', async () => {
+    // Simulates the activate-body of a generated plugin that schedules a
+    // background sync and reports its connection status — the exact shape the
+    // kernel wires post-install, now faithfully captured in preview.
+    const runtime = runtimeWith(freshRoot('agent'), (ctx) => {
+      ctx.status.report({ state: 'ok', title: 'Connected' });
+      ctx.jobs.register(
+        { name: 'poll-inbox', schedule: { intervalMs: 300_000 }, overlap: 'skip' },
+        async (signal) => {
+          // handler body would do the real poll post-install; never fires in preview
+          void signal;
+        },
+      );
+    });
+
+    const handle = await activate(runtime, 'd-agent');
+
+    // Job built the way core wires it:
+    assert.equal(handle.jobCaptures.length, 1);
+    assert.equal(handle.jobCaptures[0]?.name, 'poll-inbox');
+    assert.deepEqual(handle.jobCaptures[0]?.schedule, { intervalMs: 300_000 });
+    assert.equal(handle.jobCaptures[0]?.spec.overlap, 'skip');
+    assert.equal(typeof handle.jobCaptures[0]?.handler, 'function');
+
+    // Report built the way core wires it:
+    assert.equal(handle.statusReports.length, 1);
+    assert.deepEqual(handle.statusReports[0], { state: 'ok', title: 'Connected' });
+
+    await handle.close();
+  });
+});


### PR DESCRIPTION
Closes #327

## Problem

The Agent-Builder preview crashes with `builder.preview_chat_failed: Cannot read properties of undefined (reading 'register')` for any plugin that registers a scheduled job. The error occurs **only in preview**; after install the same plugin runs fine.

## Root Cause

The plugin contract (`agent-integration/types.ts`) declares `jobs: JobsAccessor` and `status: StatusAccessor` as **non-optional**, and the kernel's `createPluginContext` provides both. The preview harness `createStubContext` (`previewRuntime.ts`), however, provided neither `jobs` nor `status`. A `ctx.jobs.register(...)` in `activate()` compiles cleanly, runs after install, but crashes in preview because `ctx.jobs` is `undefined` there. (`ctx.uiRoutes` was never the cause — it is already stubbed.)

## Fix

`createStubContext` now wires `jobs` + `status`, faithful to the kernel wiring:

- `jobs.register` **captures** the registration + returns a real disposer, but **never fires the cron** (preview is ephemeral, no side effects).
- `status.report/clear` records reports (`clear` = synthetic `ok`).
- Both exposed on `PreviewHandle` (`jobCaptures`, `statusReports`) for operator/smoke introspection.

This way a builder-generated agent wires a job and a status report in preview the same shape the core wires post-install — contract parity without runtime side effects.

## Tests

- New regression test `middleware/test/builder/previewCtxJobsRegisterRepro.test.ts` (4 tests): uiRoutes control, jobs.register capture+disposer, status.report/clear capture, and "builder-generated agent wires a job + report like the core".
- Full middleware suite: **3476 pass / 0 fail / 4 skipped**. Build + typecheck + lint clean.