### PR TITLE
feat(orchestrator): agent transparency + Direct Line + forced delegation (#332)

### DIFF
--- a/middleware/packages/harness-channel-sdk/src/chatAgent.ts
+++ b/middleware/packages/harness-channel-sdk/src/chatAgent.ts
@@ -1,5 +1,9 @@
 import type { PrivacyReceipt, RecalledContext } from '@omadia/plugin-api';
-import type { FollowUpOption, SemanticAnswer } from './outgoing.js';
+import type {
+  DelegatedAnswer,
+  FollowUpOption,
+  SemanticAnswer,
+} from './outgoing.js';
 import type { SurfaceStreamEvent, PendingCanvasSurface } from './surface.js';
 
 /**
@@ -230,6 +234,18 @@ export interface ChatTurnInput {
    */
   extraSystemHint?: string;
   /**
+   * #332 Layer 3 — forced-delegation obligation. The tool name of a sub-agent
+   * that MUST be invoked at least once during this turn. If the orchestrator
+   * tries to end the turn (pure-text stop) without ever calling it, the harness
+   * performs ONE bounded escalation iteration with
+   * `tool_choice: { type: 'tool', name: <X> }` plus a synthetic reminder —
+   * exactly as `LocalSubAgent` does for sub-agents (OB-31). Unknown tool names
+   * are ignored. The Conductor (Spec 005) composes these into multi-step
+   * processes; on its own it guarantees the consult HAPPENS (Layer 1 surfaces
+   * it). Faithful input/output is the Direct Line's (Layer 2) job.
+   */
+  expectedDomainTool?: string;
+  /**
    * "Fresh check" mode — bypass the FTS context block, verbatim tail, and
    * memory-read convention for this turn only. The orchestrator treats the
    * user message as the sole source of truth and is explicitly told not to
@@ -428,6 +444,14 @@ export interface ChatTurnResult {
    * Omitted when nothing was recalled.
    */
   recalled?: RecalledContext;
+  /**
+   * #332 Layer 2 — Direct Line. The verbatim sub-agent answer for a turn the
+   * user directed at a named specialist (`@omadia #strategist …`). Set by the
+   * harness inside `chatStream`, NOT by the LLM; `toSemanticAnswer` forwards it
+   * to `SemanticAnswer.delegatedAnswer` so the orchestrator cannot suppress or
+   * reword it. Omitted on ordinary turns.
+   */
+  delegatedAnswer?: DelegatedAnswer;
 }
 
 /**
@@ -622,6 +646,12 @@ export type ChatStreamEvent =
        * answered, alongside the live token counts.
        */
       model?: string;
+      /**
+       * #332 Layer 2 — Direct Line. Harness-owned verbatim sub-agent segment
+       * for a user-directed specialist turn; see ChatTurnResult.delegatedAnswer.
+       * The orchestrator cannot suppress or reword it.
+       */
+      delegatedAnswer?: DelegatedAnswer;
     }
   /**
    * Emitted after `done` by the verifier wrapper (only when enabled). The

--- a/middleware/packages/harness-channel-sdk/src/index.ts
+++ b/middleware/packages/harness-channel-sdk/src/index.ts
@@ -98,6 +98,10 @@ export type {
 // adapters can call it without crossing into kernel internals.
 export { toSemanticAnswer } from './toSemanticAnswer.js';
 
+// #332 Layer 1 — plain-text fallback so even a minimal connector (no rich-card
+// UI) can append a readable, harness-sourced consulted-agents footer line.
+export { agentsConsultedFooterText } from './toSemanticAnswer.js';
+
 // Semantic outgoing-message contracts (connectors render native)
 export type {
   SemanticAnswer,
@@ -109,6 +113,8 @@ export type {
   OutgoingSlotPicker,
   OutgoingTopicAsk,
   CaptureDisclosure,
+  AgentConsultation,
+  DelegatedAnswer,
 } from './outgoing.js';
 
 // Channel-agnostic store interfaces

--- a/middleware/packages/harness-channel-sdk/src/outgoing.ts
+++ b/middleware/packages/harness-channel-sdk/src/outgoing.ts
@@ -109,6 +109,64 @@ export interface SemanticAnswer {
    * recalled. Sidecar — does NOT short-circuit the answer.
    */
   recalled?: RecalledContext;
+
+  /**
+   * #332 Layer 1 — tamper-evident agent transparency. A curated projection of
+   * the deterministic run-trace's sub-agent invocations, built by the HARNESS
+   * (not the LLM) from the choke-point trace. Lets EVERY channel — including
+   * Teams / Telegram, which never see the raw `runTrace` — show which
+   * specialist(s) were actually consulted this turn. If the orchestrator only
+   * *claims* "I asked the Strategist" but never invoked the tool, this array is
+   * empty and the contradiction is visible. Omitted when no sub-agent ran.
+   * Sidecar — does NOT short-circuit the answer.
+   */
+  agentsConsulted?: readonly AgentConsultation[];
+
+  /**
+   * #332 Layer 2 — Direct Line. The verbatim answer of a sub-agent the USER
+   * directed input at (e.g. `@omadia #strategist …`), captured at the choke
+   * point and delivered as a HARNESS-owned, attributed segment INDEPENDENT of
+   * the orchestrator's own `text`. The orchestrator can neither remove nor
+   * rewrite it — its only sanctioned addition is an attributed, additive note
+   * in `text` (never a replacement). Still PII-masked by the privacy guard.
+   * Omitted on ordinary turns (no direct-line directive). Sidecar.
+   */
+  delegatedAnswer?: DelegatedAnswer;
+}
+
+/**
+ * #332 Layer 1 — one curated entry per sub-agent invocation this turn.
+ * Derived from the deterministic `runTrace.agentInvocations` (the choke-point
+ * record), NEVER from the orchestrator's prose. Carries only what a footer
+ * needs; the raw run-trace stays behind the connector boundary.
+ */
+export interface AgentConsultation {
+  /** Stable agent id when resolvable (e.g. `de.byte5.agent.strategist`). */
+  agentId?: string;
+  /** Human label for the footer (e.g. `Strategist`). Always present. */
+  label: string;
+  /** Deterministic outcome of the invocation. */
+  status: 'success' | 'error';
+  /** Wall-clock duration of the invocation, when recorded. */
+  durationMs?: number;
+  /** COUNT of tool calls the sub-agent made — never the orchestrator's prose. */
+  toolCalls?: number;
+}
+
+/**
+ * #332 Layer 2 — the harness-owned verbatim sub-agent segment for a
+ * direct-line turn. Rendered attributed and visually separate from the
+ * orchestrator's `text`. `status: 'error'` carries a faithful failure message
+ * in `text` (never a cover-up or hallucinated answer).
+ */
+export interface DelegatedAnswer {
+  /** Stable agent id the directive resolved to. */
+  agentId: string;
+  /** Human label for attribution (e.g. `Strategist`). */
+  label: string;
+  /** The sub-agent's verbatim answer (PII-masked), or a faithful error line. */
+  text: string;
+  status: 'success' | 'error';
 }
 
 /** Image/file side-channel. `url` must be reachable by the channel. */

--- a/middleware/packages/harness-channel-sdk/src/toSemanticAnswer.ts
+++ b/middleware/packages/harness-channel-sdk/src/toSemanticAnswer.ts
@@ -1,10 +1,53 @@
 import type { ChatTurnResult } from './chatAgent.js';
 import type {
+  AgentConsultation,
   OutgoingAttachment,
   OutgoingInteractive,
   SemanticAnswer,
   VerifierBadge,
 } from './outgoing.js';
+
+/**
+ * #332 Layer 1 — plain-text fallback footer for connectors without rich-card
+ * UI. Renders the harness-sourced `agentsConsulted` projection as a single
+ * readable line, e.g. `🔎 Consulted: Strategist ✓ · 2 steps`. Returns
+ * `undefined` when no sub-agent ran (caller appends nothing). Rich connectors
+ * (web-ui, Teams) render their own UI from the structured field instead.
+ */
+export function agentsConsultedFooterText(
+  answer: Pick<SemanticAnswer, 'agentsConsulted'>,
+): string | undefined {
+  const consulted = answer.agentsConsulted;
+  if (!consulted || consulted.length === 0) return undefined;
+  const parts = consulted.map((c) => {
+    const mark = c.status === 'success' ? '✓' : '✗';
+    const steps =
+      typeof c.toolCalls === 'number' && c.toolCalls > 0
+        ? ` · ${c.toolCalls} ${c.toolCalls === 1 ? 'step' : 'steps'}`
+        : '';
+    return `${c.label} ${mark}${steps}`;
+  });
+  return `🔎 Consulted: ${parts.join(' · ')}`;
+}
+
+/**
+ * Humanize a run-trace `agentName` (which is the invoked tool name, e.g.
+ * `ask_strategist` / `@omadia/agent-strategist`) into a footer label. Mirrors
+ * the middleware-side `labelFromAgentId` (agents/resolveAgentForTool.ts) but
+ * stays local — channel-sdk has no access to the dynamic agent runtime. Strips
+ * an `ask_`/`consult_` verb prefix and any npm-scope / legacy-namespace, then
+ * Title-Cases the remainder.
+ */
+function humanizeAgentLabel(agentName: string): string {
+  const last = agentName.split(/[./]/).pop() ?? agentName;
+  const deverbed = last.replace(/^(?:ask|consult|query|invoke|agent)[-_]/i, '');
+  const titled = deverbed
+    .split(/[-_]/)
+    .filter((seg) => seg.length > 0)
+    .map((seg) => seg.charAt(0).toUpperCase() + seg.slice(1))
+    .join(' ');
+  return titled.length > 0 ? titled : agentName;
+}
 
 /**
  * Convert the internal kernel-shaped `ChatTurnResult` to the channel-agnostic
@@ -87,9 +130,30 @@ export function toSemanticAnswer(r: ChatTurnResult): SemanticAnswer {
     ? { status: r.verifier.badge }
     : undefined;
 
+  // #332 Layer 1 — curate a tamper-evident consulted-agents footer from the
+  // deterministic run-trace. This is the ONLY sub-agent signal Teams/Telegram
+  // get; the raw `runTrace` stays dropped (see header). Built by the harness,
+  // outside the LLM's output stream — a fabricated "I asked X" with no real
+  // invocation yields an empty array here.
+  const agentsConsulted: AgentConsultation[] | undefined =
+    r.runTrace?.agentInvocations && r.runTrace.agentInvocations.length > 0
+      ? r.runTrace.agentInvocations.map((inv) => ({
+          label: humanizeAgentLabel(inv.agentName),
+          status: inv.status,
+          ...(typeof inv.durationMs === 'number'
+            ? { durationMs: inv.durationMs }
+            : {}),
+          ...(inv.toolCalls ? { toolCalls: inv.toolCalls.length } : {}),
+        }))
+      : undefined;
+
   return {
     text: r.answer,
     ...(verifier ? { verifier } : {}),
+    ...(agentsConsulted && agentsConsulted.length > 0
+      ? { agentsConsulted }
+      : {}),
+    ...(r.delegatedAnswer ? { delegatedAnswer: r.delegatedAnswer } : {}),
     ...(attachments && attachments.length > 0 ? { attachments } : {}),
     ...(r.followUpOptions && r.followUpOptions.length > 0
       ? { followUps: r.followUpOptions }

--- a/middleware/packages/harness-orchestrator/src/directLine.ts
+++ b/middleware/packages/harness-orchestrator/src/directLine.ts
@@ -1,0 +1,127 @@
+/**
+ * #332 Layer 2 — Direct Line directive parsing & target resolution.
+ *
+ * Pure, channel-agnostic helpers. The orchestrator owns the turn as always;
+ * when the USER names a specialist inside the payload (`@omadia #strategist
+ * <question>`), these helpers let the HARNESS — not the LLM — bind the
+ * sub-agent's input to the verbatim user payload and route it through the
+ * deterministic choke point. No model, no orchestrator discretion.
+ *
+ * Channel survival: chat clients resolve their own `@`-mentions, so the bot is
+ * addressed natively and the specialist is named *in the payload*. The Teams
+ * adapter additionally strips the bot's recipient mention and collapses
+ * whitespace (`extractUserMessage`), so the directive must be a single leading
+ * token that survives `\s+`→space normalization. A leading `#<label>` token
+ * meets that bar.
+ */
+
+/** A parsed direct-line directive. */
+export interface DirectLineDirective {
+  /** The bare token the user named, lower-cased, sans prefix (e.g. `strategist`). */
+  token: string;
+  /** The verbatim remainder = the faithful sub-agent input. */
+  payload: string;
+}
+
+/** Default directive prefix. Configurable per deployment (see Open question 3). */
+export const DEFAULT_DIRECTIVE_PREFIX = '#';
+
+/**
+ * Parse a leading `#<token> <payload>` directive out of a user message.
+ *
+ * Hard requirements honoured:
+ * - The directive token must be the FIRST token (after trim) — this both
+ *   survives Teams whitespace-collapse and gives a clean literal-collision
+ *   rule: a `#` that is NOT the first token is treated as ordinary text.
+ * - Returns `undefined` when there is no leading directive (ordinary turn).
+ * - Returns a directive with an EMPTY payload when the user named a specialist
+ *   but typed nothing after it — the caller surfaces a faithful prompt rather
+ *   than dispatching an empty question.
+ */
+export function parseDirectLineDirective(
+  text: string,
+  prefix: string = DEFAULT_DIRECTIVE_PREFIX,
+): DirectLineDirective | undefined {
+  const trimmed = text.trimStart();
+  if (!trimmed.startsWith(prefix)) return undefined;
+  const afterPrefix = trimmed.slice(prefix.length);
+  // Token = leading run of label characters (letters, digits, _ , -, .).
+  const match = /^([A-Za-z0-9._-]+)(.*)$/s.exec(afterPrefix);
+  if (!match) return undefined;
+  const token = match[1]!.toLowerCase();
+  const payload = match[2]!.trim();
+  return { token, payload };
+}
+
+/** A candidate sub-agent the directive may resolve to. */
+export interface DirectLineCandidate {
+  /** Stable tool name (key in the orchestrator's whitelist map). */
+  toolName: string;
+  /** Stable agent id when known (e.g. `de.byte5.agent.strategist`). */
+  agentId?: string;
+  /** Human label for attribution (e.g. `Strategist`). */
+  label: string;
+}
+
+/** Outcome of resolving a directive token against the whitelisted agents. */
+export type DirectLineResolution =
+  | { kind: 'resolved'; candidate: DirectLineCandidate }
+  | { kind: 'unknown' }
+  | { kind: 'ambiguous'; matches: DirectLineCandidate[] };
+
+/**
+ * Human label for a sub-agent, derived from its stable agent id (preferred)
+ * or tool name. Mirrors the middleware `labelFromAgentId` (Title-Cased last
+ * segment) and strips an `ask_`/`consult_` verb prefix from tool names.
+ */
+export function directLineLabel(agentIdOrToolName: string): string {
+  const last = agentIdOrToolName.split(/[./]/).pop() ?? agentIdOrToolName;
+  const deverbed = last.replace(/^(?:ask|consult|query|invoke|agent)[-_]/i, '');
+  const titled = deverbed
+    .split(/[-_]/)
+    .filter((seg) => seg.length > 0)
+    .map((seg) => seg.charAt(0).toUpperCase() + seg.slice(1))
+    .join(' ');
+  return titled.length > 0 ? titled : agentIdOrToolName;
+}
+
+/** Reduce a label/id/tool-name to a comparable key (lowercase alphanumerics). */
+function normalizeKey(value: string): string {
+  const last = value.split(/[./]/).pop() ?? value;
+  const deverbed = last.replace(/^(?:ask|consult|query|invoke|agent)[-_]/i, '');
+  return deverbed.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+/**
+ * Resolve a directive token to exactly one whitelisted sub-agent — or report
+ * `unknown` / `ambiguous` so the caller can surface a disambiguation prompt and
+ * NEVER silently route to the wrong agent (Pitfall 7). Matching is scoped to
+ * the candidates the caller passes, which MUST be this orchestrator's
+ * whitelisted sub-agents (reuses the OB-29-1 access gating).
+ */
+export function resolveDirectLineTarget(
+  token: string,
+  candidates: readonly DirectLineCandidate[],
+): DirectLineResolution {
+  const want = normalizeKey(token);
+  if (want.length === 0) return { kind: 'unknown' };
+  const matches = candidates.filter((c) => {
+    const keys = [normalizeKey(c.label), normalizeKey(c.toolName)];
+    if (c.agentId) keys.push(normalizeKey(c.agentId));
+    return keys.includes(want);
+  });
+  if (matches.length === 0) return { kind: 'unknown' };
+  if (matches.length > 1) return { kind: 'ambiguous', matches };
+  return { kind: 'resolved', candidate: matches[0]! };
+}
+
+/** Direct-line delivery policy — who, if anyone, may add to the verbatim block. */
+export type DirectLineMode =
+  /** Pure relay: the orchestrator's own generation is suppressed. Default. */
+  | 'strict'
+  /**
+   * Guarded additive: the verbatim sub-agent answer is still delivered
+   * byte-for-byte and independently (harness-owned), but the orchestrator MAY
+   * append an attributed, visually separated note. It can never redact.
+   */
+  | 'guarded';

--- a/middleware/packages/harness-orchestrator/src/directLine.ts
+++ b/middleware/packages/harness-orchestrator/src/directLine.ts
@@ -49,7 +49,11 @@ export function parseDirectLineDirective(
   const match = /^([A-Za-z0-9._-]+)(.*)$/s.exec(afterPrefix);
   if (!match) return undefined;
   const token = match[1]!.toLowerCase();
-  const payload = match[2]!.trim();
+  // Strip ONLY the leading separator whitespace between token and payload;
+  // keep the remainder byte-for-byte so a whitespace-significant payload (e.g.
+  // a fenced code block) reaches the sub-agent verbatim. An all-whitespace
+  // remainder collapses to '' (treated as an empty payload by the caller).
+  const payload = match[2]!.replace(/^\s+/, '');
   return { token, payload };
 }
 

--- a/middleware/packages/harness-orchestrator/src/index.ts
+++ b/middleware/packages/harness-orchestrator/src/index.ts
@@ -140,6 +140,21 @@ export type {
 export { Orchestrator, parseToolEmittedChoice } from './orchestrator.js';
 export type { OrchestratorOptions } from './orchestrator.js';
 
+// #332 Layer 2 — Direct Line directive parsing & target resolution (exported
+// for unit coverage and reuse by deterministic routers / the Conductor).
+export {
+  parseDirectLineDirective,
+  resolveDirectLineTarget,
+  directLineLabel,
+  DEFAULT_DIRECTIVE_PREFIX,
+} from './directLine.js';
+export type {
+  DirectLineDirective,
+  DirectLineCandidate,
+  DirectLineResolution,
+  DirectLineMode,
+} from './directLine.js';
+
 // Round-loop guard — exported so it can be unit-tested in isolation and reused
 // by other agentic loops (e.g. the Builder).
 export { LoopGuard, canonicalize } from './loopGuard.js';

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -1968,7 +1968,18 @@ export class Orchestrator {
     // verbatim block in `delegatedAnswer` stays intact regardless (the
     // no-redaction invariant is structural).
     let answer = verbatim;
-    if (this.directLineMode === 'guarded' && status === 'success') {
+    // Guarded-additive note runs an extra LLM completion over the verbatim
+    // answer. That direct `provider.complete` is NOT routed through the privacy
+    // interning path, so when a privacy guard is active the raw payload/answer
+    // could carry un-masked PII to the model provider. To avoid that leak we
+    // degrade to strict passthrough whenever a privacy guard is installed; the
+    // verbatim block is still delivered intact. (A privacy-aware note that
+    // interns its input first is a follow-up.)
+    if (
+      this.directLineMode === 'guarded' &&
+      status === 'success' &&
+      this.privacyGuard?.() === undefined
+    ) {
       const note = await this.maybeDirectLineNote(
         candidate.label,
         directive.payload,
@@ -2001,6 +2012,20 @@ export class Orchestrator {
           err instanceof Error ? err.message : err,
         );
       }
+    }
+
+    // Fact extraction parity (#332 review follow-up): a direct-line turn skips
+    // chatInContext*, so without this the KG would never learn from a delegated
+    // answer. Fire-and-forget against Haiku, after the session log lands so the
+    // Fact → Turn edge has an anchor. Never awaited; entityRefs are empty (the
+    // relay issues no orchestrator-level tool calls of its own).
+    if (this.factExtractor && persistedTurnId) {
+      void this.factExtractor.extractAndIngest({
+        turnId: persistedTurnId,
+        userMessage: input.userMessage,
+        assistantAnswer: answer,
+        entityRefs: [],
+      });
     }
 
     return {

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -2818,7 +2818,12 @@ export class Orchestrator {
             'onAfterTurn',
             turnId,
             input,
-            { assistantAnswer: doneEvent.answer },
+            {
+              assistantAnswer: doneEvent.answer,
+              // Parity with the normal done branch — graph-linking observers
+              // (#133 E8) need the persisted Turn id on direct-line turns too.
+              ...(doneEvent.turnId ? { turnExternalId: doneEvent.turnId } : {}),
+            },
             2000,
           ),
         );

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -5,6 +5,7 @@ import {
   type ChatStreamEvent,
   type ChatTurnInput,
   type ChatTurnResult,
+  type DelegatedAnswer,
   type DiagramAttachment,
   type OutgoingFileAttachment,
   type PendingRoutineList,
@@ -104,6 +105,13 @@ import {
   ensureWellFormedParams,
 } from './privacyHandle.js';
 import { RunTraceCollector, type InvocationHandle } from './runTraceCollector.js';
+import {
+  parseDirectLineDirective,
+  resolveDirectLineTarget,
+  directLineLabel,
+  type DirectLineCandidate,
+  type DirectLineMode,
+} from './directLine.js';
 import type { NativeToolRegistry } from './nativeToolRegistry.js';
 import { isInternExemptTool } from './privacyInternPolicy.js';
 import { graphScopeFor, type SessionLogger } from './sessionLogger.js';
@@ -196,6 +204,19 @@ export interface OrchestratorOptions {
   maxTurnSeconds?: number;
   /** One delegation tool per Managed Agent domain (accounting, hr, …). */
   domainTools: DomainTool[];
+  /**
+   * #332 Layer 2 — Direct Line delivery policy. `'strict'` (default) relays a
+   * directed specialist's verbatim answer with no orchestrator generation;
+   * `'guarded'` additionally lets the orchestrator append an attributed,
+   * additive note (never a redaction). Absent → `'strict'`.
+   */
+  directLineMode?: DirectLineMode;
+  /**
+   * #332 Layer 2 — directive prefix the user puts before a specialist name
+   * (`@omadia #strategist …`). Absent → `'#'`. Must survive the channel's own
+   * mention/markup parsing (see directLine.ts).
+   */
+  directLinePrefix?: string;
   /** Kernel-shared native-tool registry. Created once at boot and shared
    *  between the orchestrator and the plugin-activation pipeline so plugin-
    *  contributed tools land in the same dispatch map as the kernel's own. */
@@ -881,6 +902,10 @@ export class Orchestrator {
   /** Per-Agent scoped memory-tool handler; overrides the global one. */
   private readonly memoryToolHandler: MemoryToolHandler | undefined;
   private readonly domainToolsByName: Map<string, DomainTool>;
+  /** #332 Layer 2 — Direct Line delivery policy (default `'strict'`). */
+  private readonly directLineMode: DirectLineMode;
+  /** #332 Layer 2 — directive prefix (default `'#'`). */
+  private readonly directLinePrefix: string;
   // systemPrompt is rebuilt live per turn from `buildSystemPrompt()` —
   // so hot-registered DomainTools show up in the preamble. Prompt caching
   // still applies within stable phases (between two register/unregister
@@ -952,6 +977,8 @@ export class Orchestrator {
         : 0;
     this.memoryToolHandler = options.memoryToolHandler;
     this.domainToolsByName = new Map(options.domainTools.map((t) => [t.name, t]));
+    this.directLineMode = options.directLineMode ?? 'strict';
+    this.directLinePrefix = options.directLinePrefix ?? '#';
     this.knowledgeGraph = options.knowledgeGraph;
     this.knowledgeGraphTool = options.knowledgeGraph
       ? new KnowledgeGraphTool(options.knowledgeGraph, options.embeddingClient)
@@ -1784,7 +1811,13 @@ export class Orchestrator {
           : {}),
       },
       async () => {
-        let result = await this.chatInContext(input, turnId);
+        // #332 Layer 2 — Direct Line short-circuit (non-streaming / Teams
+        // path). A user-directed specialist turn is dispatched deterministically
+        // by the harness; the orchestrator LLM never runs. Still flows through
+        // the privacy-finalize block below so the verbatim answer is PII-masked
+        // (Pitfall 3) and a receipt is attached.
+        const direct = await this.executeDirectLine(input, turnId);
+        let result = direct ?? (await this.chatInContext(input, turnId));
         // Privacy Shield v4 — when a v4_render_answer call produced the
         // answer this turn it is final and already safe (real values
         // materialized server-side from ground truth). Swap it in.
@@ -1816,6 +1849,230 @@ export class Orchestrator {
         return result;
       },
     );
+  }
+
+  /**
+   * #332 Layer 2 — Direct Line. When the USER directs input at a named
+   * specialist (`@omadia #strategist <payload>`), the HARNESS — not the LLM —
+   * binds the sub-agent's input to the verbatim payload, dispatches it through
+   * the deterministic choke point, captures the verbatim answer, and delivers
+   * it as a harness-owned, attributed `delegatedAnswer` the orchestrator can
+   * neither suppress nor reword.
+   *
+   * Returns a finished `ChatTurnResult` for a direct-line turn (so both the
+   * non-streaming `runTurn`/Teams path and the streaming `chatStream`/web-ui
+   * path can short-circuit), or `undefined` for an ordinary turn (the caller
+   * proceeds with the normal LLM loop).
+   *
+   * Awareness (the orchestrator "stays aware"): the verbatim block becomes the
+   * turn's `answer`, so it is persisted as the assistant turn and re-enters the
+   * orchestrator's context on the next turn via the channel's prior-turn
+   * history — no hidden generation needed (Pitfall 5).
+   */
+  private async executeDirectLine(
+    input: ChatTurnInput,
+    turnId: string,
+    observer?: AskObserver,
+  ): Promise<ChatTurnResult | undefined> {
+    const directive = parseDirectLineDirective(
+      input.userMessage,
+      this.directLinePrefix,
+    );
+    if (!directive) return undefined; // ordinary turn — proceed with the LLM.
+
+    // Candidates = THIS orchestrator's whitelisted sub-agents (OB-29-1 gating).
+    const candidates: DirectLineCandidate[] = Array.from(
+      this.domainToolsByName.values(),
+    ).map((t) => ({
+      toolName: t.name,
+      ...(t.agentId ? { agentId: t.agentId } : {}),
+      label: directLineLabel(t.agentId ?? t.name),
+    }));
+
+    if (directive.payload.length === 0) {
+      return this.directLineNotice(
+        `You addressed a specialist but didn't include a question. Try \`${this.directLinePrefix}${directive.token} <your question>\`.`,
+      );
+    }
+
+    const resolution = resolveDirectLineTarget(directive.token, candidates);
+    if (resolution.kind === 'unknown') {
+      const available =
+        candidates.map((c) => c.label).join(', ') || '(none configured)';
+      return this.directLineNotice(
+        `No specialist named "${directive.token}" is available here. Available: ${available}.`,
+      );
+    }
+    if (resolution.kind === 'ambiguous') {
+      const names = resolution.matches.map((c) => c.label).join(', ');
+      return this.directLineNotice(
+        `"${directive.token}" is ambiguous — it matches ${names}. Please name one specifically.`,
+      );
+    }
+
+    const candidate = resolution.candidate;
+    const tool = this.domainToolsByName.get(candidate.toolName);
+    if (!tool) {
+      return this.directLineNotice(
+        `Specialist "${candidate.label}" is no longer available.`,
+      );
+    }
+
+    // Deterministic harness invocation through the choke point. Input is bound
+    // to the verbatim user payload — the orchestrator cannot reshape it.
+    const collector = new RunTraceCollector({
+      scope: input.sessionScope ?? turnId,
+      ...(input.userId ? { userId: input.userId } : {}),
+    });
+    const handle = collector.beginInvocation(tool.name);
+    const startedAt = Date.now();
+    let verbatim: string;
+    let status: 'success' | 'error';
+    try {
+      // The domain-tool contract takes `{ question }` (see createDomainTool);
+      // bind it to the user's VERBATIM payload — the orchestrator never
+      // reshapes it.
+      verbatim = await tool.handle(
+        { question: directive.payload },
+        handle.observer,
+      );
+      // `createDomainTool.handle` does not throw on a sub-agent failure — it
+      // returns an `Error …` string. Treat that as a faithful failure too.
+      status = /^error\b/i.test(verbatim.trimStart()) ? 'error' : 'success';
+    } catch (err) {
+      // Faithful failure — never a cover-up or a hallucinated answer.
+      verbatim = `${candidate.label} could not respond: ${
+        err instanceof Error ? err.message : String(err)
+      }`;
+      status = 'error';
+    }
+    handle.finish({ durationMs: Date.now() - startedAt, status });
+    const runTrace = collector.finish({ iterations: 1, status });
+
+    // Harness-owned, attributed segment — byte-for-byte the sub-agent's words.
+    const delegatedAnswer: DelegatedAnswer = {
+      agentId: candidate.agentId ?? candidate.toolName,
+      label: candidate.label,
+      text: verbatim,
+      status,
+    };
+
+    // `answer` carries the verbatim block so even connectors that don't yet
+    // know `delegatedAnswer` show the specialist's words (graceful degrade).
+    // In strict passthrough the orchestrator LLM never runs → nothing can
+    // distort it. In guarded mode we MAY append an attributed note; the
+    // verbatim block in `delegatedAnswer` stays intact regardless (the
+    // no-redaction invariant is structural).
+    let answer = verbatim;
+    if (this.directLineMode === 'guarded' && status === 'success') {
+      const note = await this.maybeDirectLineNote(
+        candidate.label,
+        directive.payload,
+        verbatim,
+      );
+      if (note) answer = `${verbatim}\n\n▸ omadia note: ${note}`;
+    }
+
+    return {
+      answer,
+      toolCalls: 1,
+      iterations: 1,
+      runTrace,
+      delegatedAnswer,
+    };
+  }
+
+  /**
+   * #332 Layer 2 — a faithful, non-dispatching direct-line response (empty
+   * payload, unknown / ambiguous specialist). No sub-agent ran, so there is no
+   * `delegatedAnswer` and the consulted-footer stays empty. Never silently
+   * routes to the wrong agent (Pitfall 7).
+   */
+  private directLineNotice(text: string): ChatTurnResult {
+    return { answer: text, toolCalls: 0, iterations: 0 };
+  }
+
+  /**
+   * #332 Layer 3 — resolve the per-turn forced-delegation obligation. Returns
+   * the obligation tool name (only when it is one of THIS orchestrator's
+   * whitelisted sub-agents — unknown names are ignored) and the matching
+   * `tool_choice` payload to force it. Shared by both the streaming and
+   * non-streaming loops.
+   */
+  private directLineObligationState(input: ChatTurnInput): {
+    obligationTool: string | undefined;
+    forceObligation: { type: 'tool'; name: string } | undefined;
+  } {
+    const tool =
+      input.expectedDomainTool &&
+      this.domainToolsByName.has(input.expectedDomainTool)
+        ? input.expectedDomainTool
+        : undefined;
+    return {
+      obligationTool: tool,
+      ...(tool
+        ? { forceObligation: { type: 'tool' as const, name: tool } }
+        : { forceObligation: undefined }),
+    };
+  }
+
+  /** #332 Layer 3 — synthetic reminder pushed when an obligation is unmet. */
+  private obligationReminder(toolName: string): string {
+    return (
+      `IMPORTANT: Du hast den Turn beendet, ohne den erwarteten Spezialisten ` +
+      `(\`${toolName}\`) zu konsultieren. Dieser Consult ist für diesen Turn ` +
+      `verpflichtend. Rufe \`${toolName}\` jetzt auf, bevor du dem Nutzer antwortest.`
+    );
+  }
+
+  /**
+   * #332 Layer 2 (guarded mode) — best-effort, bounded single-shot completion
+   * that lets the orchestrator add a SHORT attributed cross-cutting note to a
+   * specialist's verbatim answer. Additive only: the caller keeps the verbatim
+   * block intact. Fail-open (any error / empty → no note). Mirrors the
+   * self-contained extra-pass shape of `maybeRouteCardsFromText`.
+   */
+  private async maybeDirectLineNote(
+    label: string,
+    userPayload: string,
+    verbatimAnswer: string,
+  ): Promise<string | undefined> {
+    const params: AnthropicParams = {
+      model: this.model,
+      max_tokens: 512,
+      system:
+        'You are the omadia orchestrator. A specialist sub-agent has ALREADY ' +
+        'answered the user directly and their verbatim answer is delivered ' +
+        'independently — you cannot edit or remove it. Your ONLY option is to ' +
+        'OPTIONALLY add a SHORT (max 2 sentences) cross-cutting note when you ' +
+        'see a concrete cross-domain risk, policy concern, or missing prior ' +
+        'context the specialist could not see. If you have nothing material to ' +
+        'add, reply with exactly an empty message. Never restate or contradict ' +
+        'the specialist; only add.',
+      messages: [
+        {
+          role: 'user',
+          content: `User asked the ${label} specialist:\n${userPayload}\n\n${label}'s verbatim answer:\n${verbatimAnswer}\n\nYour optional additive note (or empty):`,
+        },
+      ],
+    };
+    try {
+      const response = fromLlmResponse(
+        await this.provider.complete(toLlmRequest(params)),
+      );
+      const text = response.content
+        .filter((b) => b['type'] === 'text')
+        .map((b) => String(b['text'] ?? ''))
+        .join('')
+        .trim();
+      return text.length > 0 ? text : undefined;
+    } catch (err) {
+      console.error(
+        '[orchestrator] direct-line guarded-note pass failed (continuing without note):',
+        err instanceof Error ? err.message : err,
+      );
+      return undefined;
+    }
   }
 
   /**
@@ -2034,6 +2291,16 @@ export class Orchestrator {
     const turnStartedAt = Date.now();
     let forceFinalize = false;
 
+    // #332 Layer 3 — forced-delegation obligation (OB-31 ported to the
+    // orchestrator). When the input names a whitelisted sub-agent that MUST be
+    // consulted, the harness escalates ONCE with a forced tool_choice + a
+    // synthetic reminder if the turn would otherwise end without it.
+    const { obligationTool, forceObligation: forceObligationFor } =
+      this.directLineObligationState(input);
+    let obligationMet = obligationTool === undefined;
+    let obligationEscalationsUsed = 0;
+    let forceObligationNext = false;
+
     // Per-turn model routing (no-op unless configured). Resolved once so the
     // whole turn — every tool-loop iteration — runs on one model. The
     // non-streaming path has no event channel, so the routing decision is
@@ -2049,15 +2316,25 @@ export class Orchestrator {
           forceFinalize ||
           iteration === this.maxIterations - 1 ||
           this.turnBudgetExceeded(turnStartedAt);
+        // #332 Layer 3 — this iteration forces the obligation tool. One-shot:
+        // consumed here so a still-mute model only re-escalates within budget.
+        const forceObligation = forceObligationNext && !obligationMet;
+        forceObligationNext = false;
         const baseParams = {
           model: turnModel,
           max_tokens: this.maxTokens,
           system: buildSystemBlocks(
             this.composeStableSystemPrompt(prependRules),
             priorContext,
-            withFinalizeHint(effectiveExtraSystemHint, finalizeThisIter),
+            withFinalizeHint(
+              effectiveExtraSystemHint,
+              finalizeThisIter && !forceObligation,
+            ),
           ),
-          tools: finalizeThisIter ? [] : this.buildToolsList(),
+          tools: finalizeThisIter && !forceObligation ? [] : this.buildToolsList(),
+          ...(forceObligation && obligationTool
+            ? { tool_choice: forceObligationFor }
+            : {}),
           messages,
         };
         // Last-resort guard: repair any lone UTF-16 surrogate before the
@@ -2098,6 +2375,29 @@ export class Orchestrator {
                   ? ' — response carries tool_use blocks that will NOT run (truncated mid-call?)'
                   : ''),
             );
+          }
+          // #332 Layer 3 — forced-delegation obligation unmet at a pure-text
+          // turn end: escalate ONCE with a forced tool_choice + synthetic
+          // reminder (OB-31). Guarded by `!finalizeThisIter` so a normal
+          // tool-enabled iteration follows within the iteration budget.
+          if (
+            obligationTool &&
+            !obligationMet &&
+            !finalizeThisIter &&
+            !responseHasToolUse &&
+            obligationEscalationsUsed < 1
+          ) {
+            obligationEscalationsUsed++;
+            forceObligationNext = true;
+            messages.push({
+              role: 'user',
+              content: this.obligationReminder(obligationTool),
+            });
+            textParts.length = 0;
+            console.error(
+              `[orchestrator] obligation unmet — forcing one consult of \`${obligationTool}\``,
+            );
+            continue;
           }
           if (
             !finalizeThisIter &&
@@ -2213,6 +2513,14 @@ export class Orchestrator {
         // submission order. Mirror of the streaming-side parallelisation in
         // chatStreamInner.
         toolCalls += toolUses.length;
+        // #332 Layer 3 — mark the obligation satisfied as soon as the named
+        // sub-agent is actually dispatched this turn.
+        if (
+          obligationTool &&
+          toolUses.some((u: ContentBlock) => u.name === obligationTool)
+        ) {
+          obligationMet = true;
+        }
         const startedTimes = toolUses.map(() => Date.now());
         const invocations = toolUses.map((use: ContentBlock) => {
           const isNative = this.nativeTools.has(use.name);
@@ -2442,6 +2750,48 @@ export class Orchestrator {
     // loop drains them at each iteration boundary; `endTurn` clears the buffer.
     steeringBus.beginTurn(sessionId);
     try {
+      // #332 Layer 2 — Direct Line short-circuit (streaming / web-ui path).
+      // A user-directed specialist turn is dispatched deterministically by the
+      // harness; the orchestrator LLM never runs. We synthesize the `done`
+      // event and decorate it with the privacy receipt + onAfterTurn hook,
+      // exactly like the normal done branch below.
+      const direct = await this.executeDirectLine(input, turnId, observer);
+      if (direct) {
+        let doneEvent: Extract<ChatStreamEvent, { type: 'done' }> = {
+          type: 'done',
+          answer: direct.answer,
+          toolCalls: direct.toolCalls,
+          iterations: direct.iterations,
+          ...(direct.runTrace ? { runTrace: direct.runTrace } : {}),
+          ...(direct.delegatedAnswer
+            ? { delegatedAnswer: direct.delegatedAnswer }
+            : {}),
+        };
+        if (privacyHandle) {
+          try {
+            const receipt = await privacyHandle.finalize(input.userMessage);
+            if (receipt) {
+              doneEvent = { ...doneEvent, privacyReceipt: receipt };
+            }
+          } catch (err) {
+            console.warn(
+              '[orchestrator] privacyGuard.finalizeTurn threw — receipt dropped:',
+              err,
+            );
+          }
+        }
+        yield* this.toAnnotationEvents(
+          await this.fireTurnHook(
+            'onAfterTurn',
+            turnId,
+            input,
+            { assistantAnswer: doneEvent.answer },
+            2000,
+          ),
+        );
+        yield doneEvent;
+        return;
+      }
       for await (const event of this.chatStreamInner(input, turnId, observer)) {
         if (event.type === 'tool_use') {
           toolNameById.set(event.id, event.name);
@@ -2595,6 +2945,13 @@ export class Orchestrator {
     const turnStartedAt = Date.now();
     let forceFinalize = false;
 
+    // #332 Layer 3 — forced-delegation obligation (OB-31), streaming path.
+    const { obligationTool, forceObligation: forceObligationFor } =
+      this.directLineObligationState(input);
+    let obligationMet = obligationTool === undefined;
+    let obligationEscalationsUsed = 0;
+    let forceObligationNext = false;
+
     // Mid-turn steering — same key the route enqueues under (see chatStream:
     // `sessionId`). Drained at the top of every iteration below.
     const steerKey = input.sessionScope ?? turnId;
@@ -2631,6 +2988,9 @@ export class Orchestrator {
           forceFinalize ||
           iteration === this.maxIterations - 1 ||
           this.turnBudgetExceeded(turnStartedAt);
+        // #332 Layer 3 — one-shot forced obligation iteration (OB-31).
+        const forceObligation = forceObligationNext && !obligationMet;
+        forceObligationNext = false;
 
         // Fold any messages the user injected via `/chat/steer` since the
         // previous iteration into the conversation, so the model sees them on
@@ -2663,9 +3023,16 @@ export class Orchestrator {
             system: buildSystemBlocks(
               this.composeStableSystemPrompt(prependRules),
               priorContext,
-              withFinalizeHint(effectiveExtraSystemHint, finalizeThisIter),
+              withFinalizeHint(
+                effectiveExtraSystemHint,
+                finalizeThisIter && !forceObligation,
+              ),
             ),
-            tools: finalizeThisIter ? [] : this.buildToolsList(),
+            tools:
+              finalizeThisIter && !forceObligation ? [] : this.buildToolsList(),
+            ...(forceObligation && obligationTool
+              ? { tool_choice: forceObligationFor }
+              : {}),
             messages,
           },
           observer,
@@ -2705,6 +3072,29 @@ export class Orchestrator {
                   ? ' — response carries tool_use blocks that will NOT run (truncated mid-call?)'
                   : ''),
             );
+          }
+          // #332 Layer 3 — forced-delegation obligation unmet at a pure-text
+          // turn end: escalate ONCE with a forced tool_choice + synthetic
+          // reminder (OB-31). Guarded by `!finalizeThisIter` so a normal
+          // tool-enabled iteration follows within the iteration budget.
+          if (
+            obligationTool &&
+            !obligationMet &&
+            !finalizeThisIter &&
+            !responseHasToolUse &&
+            obligationEscalationsUsed < 1
+          ) {
+            obligationEscalationsUsed++;
+            forceObligationNext = true;
+            messages.push({
+              role: 'user',
+              content: this.obligationReminder(obligationTool),
+            });
+            textParts.length = 0;
+            console.error(
+              `[orchestrator] obligation unmet — forcing one consult of \`${obligationTool}\``,
+            );
+            continue;
           }
           if (
             !finalizeThisIter &&
@@ -2828,6 +3218,13 @@ export class Orchestrator {
         const toolUses = finalMessage.content.filter(
           (block: ContentBlock) => block.type === 'tool_use',
         );
+        // #332 Layer 3 — obligation satisfied once the named sub-agent runs.
+        if (
+          obligationTool &&
+          toolUses.some((u: ContentBlock) => u.name === obligationTool)
+        ) {
+          obligationMet = true;
+        }
 
         // Yield tool_use blocks upfront so the UI can render every pill
         // immediately, even before any tool has resolved.

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -1873,7 +1873,6 @@ export class Orchestrator {
   private async executeDirectLine(
     input: ChatTurnInput,
     turnId: string,
-    observer?: AskObserver,
   ): Promise<ChatTurnResult | undefined> {
     const directive = parseDirectLineDirective(
       input.userMessage,
@@ -2812,7 +2811,7 @@ export class Orchestrator {
       // harness; the orchestrator LLM never runs. We synthesize the `done`
       // event and decorate it with the privacy receipt + onAfterTurn hook,
       // exactly like the normal done branch below.
-      const direct = await this.executeDirectLine(input, turnId, observer);
+      const direct = await this.executeDirectLine(input, turnId);
       if (direct) {
         let doneEvent: Extract<ChatStreamEvent, { type: 'done' }> = {
           type: 'done',

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -1864,10 +1864,11 @@ export class Orchestrator {
    * path can short-circuit), or `undefined` for an ordinary turn (the caller
    * proceeds with the normal LLM loop).
    *
-   * Awareness (the orchestrator "stays aware"): the verbatim block becomes the
-   * turn's `answer`, so it is persisted as the assistant turn and re-enters the
-   * orchestrator's context on the next turn via the channel's prior-turn
-   * history — no hidden generation needed (Pitfall 5).
+   * Awareness (the orchestrator "stays aware", Pitfall 5): the verbatim block
+   * becomes the turn's `answer` AND is persisted via the same `sessionLogger`
+   * as a normal turn, so it re-enters the orchestrator's context next turn both
+   * via the channel's prior-turn buffer AND via cross-session recall / KG
+   * continuity — no hidden generation needed.
    */
   private async executeDirectLine(
     input: ChatTurnInput,
@@ -1889,24 +1890,27 @@ export class Orchestrator {
       label: directLineLabel(t.agentId ?? t.name),
     }));
 
-    if (directive.payload.length === 0) {
-      return this.directLineNotice(
-        `You addressed a specialist but didn't include a question. Try \`${this.directLinePrefix}${directive.token} <your question>\`.`,
-      );
-    }
-
     const resolution = resolveDirectLineTarget(directive.token, candidates);
-    if (resolution.kind === 'unknown') {
-      const available =
-        candidates.map((c) => c.label).join(', ') || '(none configured)';
-      return this.directLineNotice(
-        `No specialist named "${directive.token}" is available here. Available: ${available}.`,
-      );
-    }
+    // Collision rule (#332 Open Q3): a leading `#token` is only treated as a
+    // Direct-Line directive when it RESOLVES to a whitelisted specialist.
+    // An unknown token falls THROUGH to the normal LLM turn — so an ordinary
+    // message that merely starts with `#` (e.g. `#urgent …`, `#1 priority …`,
+    // a hashtag) is never hijacked into a "no such agent" reply. Ambiguity (the
+    // token matched ≥2 whitelisted agents) IS a directive intent, so we
+    // disambiguate rather than route silently (Pitfall 7).
+    if (resolution.kind === 'unknown') return undefined;
     if (resolution.kind === 'ambiguous') {
       const names = resolution.matches.map((c) => c.label).join(', ');
       return this.directLineNotice(
         `"${directive.token}" is ambiguous — it matches ${names}. Please name one specifically.`,
+      );
+    }
+
+    // A resolved specialist with no question — ask for one rather than
+    // dispatching an empty payload.
+    if (directive.payload.length === 0) {
+      return this.directLineNotice(
+        `You addressed ${resolution.candidate.label} but didn't include a question. Try \`${this.directLinePrefix}${directive.token} <your question>\`.`,
       );
     }
 
@@ -1973,20 +1977,48 @@ export class Orchestrator {
       if (note) answer = `${verbatim}\n\n▸ omadia note: ${note}`;
     }
 
+    // Awareness / continuity (#332 Pitfall 5): persist the verbatim exchange
+    // through the SAME session logger as a normal turn, so the orchestrator
+    // sees it on later turns (memory, cross-session recall, KG continuity) —
+    // not only via the channel's own prior-turn buffer. Best-effort: a logging
+    // failure must never swallow the already-captured answer.
+    let persistedTurnId: string | undefined;
+    if (this.sessionLogger && input.sessionScope) {
+      try {
+        const logged = await this.sessionLogger.log({
+          scope: input.sessionScope,
+          userMessage: input.userMessage,
+          assistantAnswer: answer,
+          toolCalls: 1,
+          iterations: 1,
+          ...(input.userId ? { userId: input.userId } : {}),
+          runTrace,
+        });
+        persistedTurnId = logged.turnExternalId;
+      } catch (err) {
+        console.error(
+          '[orchestrator] direct-line session log failed (continuing):',
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+
     return {
       answer,
       toolCalls: 1,
       iterations: 1,
       runTrace,
       delegatedAnswer,
+      ...(persistedTurnId ? { turnId: persistedTurnId } : {}),
     };
   }
 
   /**
-   * #332 Layer 2 — a faithful, non-dispatching direct-line response (empty
-   * payload, unknown / ambiguous specialist). No sub-agent ran, so there is no
-   * `delegatedAnswer` and the consulted-footer stays empty. Never silently
-   * routes to the wrong agent (Pitfall 7).
+   * #332 Layer 2 — a faithful, non-dispatching direct-line response (a resolved
+   * specialist named with no question, or an ambiguous token). No sub-agent
+   * ran, so there is no `delegatedAnswer` and the consulted-footer stays empty.
+   * Never silently routes to the wrong agent (Pitfall 7). An UNKNOWN token is
+   * not handled here — it falls through to the normal LLM turn (collision rule).
    */
   private directLineNotice(text: string): ChatTurnResult {
     return { answer: text, toolCalls: 0, iterations: 0 };
@@ -2763,6 +2795,7 @@ export class Orchestrator {
           toolCalls: direct.toolCalls,
           iterations: direct.iterations,
           ...(direct.runTrace ? { runTrace: direct.runTrace } : {}),
+          ...(direct.turnId ? { turnId: direct.turnId } : {}),
           ...(direct.delegatedAnswer
             ? { delegatedAnswer: direct.delegatedAnswer }
             : {}),

--- a/middleware/test/orchestrator/directLine.test.ts
+++ b/middleware/test/orchestrator/directLine.test.ts
@@ -263,25 +263,57 @@ describe('#332 Layer 2 — Direct Line (strict passthrough, non-streaming/Teams)
     assert.equal(sa.agentsConsulted?.[0]?.label, 'Strategist'); // L1 footer
   });
 
-  it('an unknown specialist yields a disambiguation, never a silent wrong route', async () => {
+  it('an UNKNOWN token falls through to the normal LLM turn — ordinary `#…` messages are not hijacked', async () => {
     let asked = false;
     const tool = strategistTool(async () => {
       asked = true;
       return 'should not run';
     });
+    // The LLM IS allowed to run here (this is a normal turn that merely starts
+    // with `#`). It must not be short-circuited into a "no such agent" reply.
+    const { provider } = scriptedCompleteProvider([
+      textResponse('normal LLM answer'),
+    ]);
     const orch = new Orchestrator({
-      provider: neverCalledProvider(),
+      provider,
       model: 'test',
       maxTokens: 1024,
       maxToolIterations: 5,
       domainTools: [tool],
       nativeToolRegistry: new NativeToolRegistry(),
     });
-    const sa = await orch.chat({ userMessage: '#nobody hello?', sessionScope: 's2' });
+    const sa = await orch.chat({ userMessage: '#urgent server is down', sessionScope: 's2' });
     assert.equal(asked, false, 'no sub-agent may run for an unknown token');
     assert.equal(sa.delegatedAnswer, undefined);
-    assert.match(sa.text, /No specialist named "nobody"/);
-    assert.match(sa.text, /Strategist/); // lists what IS available
+    assert.equal(sa.text, 'normal LLM answer'); // handled by the LLM, not hijacked
+  });
+
+  it('an AMBIGUOUS token disambiguates, never a silent wrong route', async () => {
+    const a = createDomainTool({
+      name: 'ask_twin_a',
+      description: 'twin a',
+      domain: 'x',
+      agentId: 'de.byte5.agent.twin',
+      agent: { ask: async () => 'A' },
+    });
+    const b = createDomainTool({
+      name: 'ask_twin_b',
+      description: 'twin b',
+      domain: 'y',
+      agentId: 'com.other.agent.twin',
+      agent: { ask: async () => 'B' },
+    });
+    const orch = new Orchestrator({
+      provider: neverCalledProvider(),
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [a, b],
+      nativeToolRegistry: new NativeToolRegistry(),
+    });
+    const sa = await orch.chat({ userMessage: '#twin go', sessionScope: 's2b' });
+    assert.equal(sa.delegatedAnswer, undefined);
+    assert.match(sa.text, /ambiguous/i);
   });
 
   it('delivers a sub-agent failure faithfully (no cover-up)', async () => {
@@ -299,6 +331,31 @@ describe('#332 Layer 2 — Direct Line (strict passthrough, non-streaming/Teams)
     const sa = await orch.chat({ userMessage: '#strategist plan?', sessionScope: 's3' });
     assert.equal(sa.delegatedAnswer?.status, 'error');
     assert.match(sa.delegatedAnswer?.text ?? '', /Error|could not respond|503/i);
+  });
+
+  it('persists the verbatim exchange via the session logger (awareness / continuity)', async () => {
+    const logged: Array<{ scope: string; assistantAnswer: string }> = [];
+    const fakeLogger = {
+      log: async (entry: { scope: string; assistantAnswer: string }) => {
+        logged.push(entry);
+        return { turnExternalId: 'turn:test:1' };
+      },
+    };
+    const tool = strategistTool(async () => 'VERBATIM-LOGGED');
+    const orch = new Orchestrator({
+      provider: neverCalledProvider(),
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [tool],
+      nativeToolRegistry: new NativeToolRegistry(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sessionLogger: fakeLogger as any,
+    });
+    await orch.chat({ userMessage: '#strategist plan?', sessionScope: 'sLog' });
+    assert.equal(logged.length, 1, 'the direct-line turn must be persisted');
+    assert.equal(logged[0]?.scope, 'sLog');
+    assert.equal(logged[0]?.assistantAnswer, 'VERBATIM-LOGGED');
   });
 });
 

--- a/middleware/test/orchestrator/directLine.test.ts
+++ b/middleware/test/orchestrator/directLine.test.ts
@@ -44,6 +44,14 @@ describe('#332 parseDirectLineDirective', () => {
   it('reports an empty payload when the specialist is named with no question', () => {
     const d = parseDirectLineDirective('#strategist');
     assert.deepEqual(d, { token: 'strategist', payload: '' });
+    // all-whitespace remainder collapses to empty too
+    assert.equal(parseDirectLineDirective('#strategist   ')?.payload, '');
+  });
+
+  it('keeps internal/trailing whitespace verbatim — only the separator is stripped', () => {
+    const d = parseDirectLineDirective('#strategist  line1\n\n  indented\n');
+    assert.equal(d?.token, 'strategist');
+    assert.equal(d?.payload, 'line1\n\n  indented\n');
   });
 });
 

--- a/middleware/test/orchestrator/directLine.test.ts
+++ b/middleware/test/orchestrator/directLine.test.ts
@@ -1,0 +1,353 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import type { LlmProvider, LlmResponse } from '@omadia/llm-provider';
+import {
+  NativeToolRegistry,
+  Orchestrator,
+  createDomainTool,
+  parseDirectLineDirective,
+  resolveDirectLineTarget,
+  directLineLabel,
+  type DirectLineCandidate,
+} from '@omadia/orchestrator';
+import {
+  toSemanticAnswer,
+  agentsConsultedFooterText,
+  type ChatTurnResult,
+} from '@omadia/channel-sdk';
+
+// ── #332 Layer 2 — pure parser / resolver ────────────────────────────────────
+
+describe('#332 parseDirectLineDirective', () => {
+  it('parses a leading #token and the verbatim payload', () => {
+    const d = parseDirectLineDirective('#strategist  What are 3 risks in plan A?');
+    assert.deepEqual(d, {
+      token: 'strategist',
+      payload: 'What are 3 risks in plan A?',
+    });
+  });
+
+  it('returns undefined when there is no leading directive', () => {
+    assert.equal(parseDirectLineDirective('just a normal question'), undefined);
+    // A `#` that is NOT the first token is ordinary text (collision rule).
+    assert.equal(parseDirectLineDirective('tell me about #strategist'), undefined);
+  });
+
+  it('survives Teams whitespace-collapse (single leading token)', () => {
+    // extractUserMessage collapses \s+ → single space; the directive still parses.
+    const d = parseDirectLineDirective('#Strategist risks?');
+    assert.equal(d?.token, 'strategist');
+    assert.equal(d?.payload, 'risks?');
+  });
+
+  it('reports an empty payload when the specialist is named with no question', () => {
+    const d = parseDirectLineDirective('#strategist');
+    assert.deepEqual(d, { token: 'strategist', payload: '' });
+  });
+});
+
+describe('#332 resolveDirectLineTarget', () => {
+  const candidates: DirectLineCandidate[] = [
+    {
+      toolName: 'ask_strategist',
+      agentId: 'de.byte5.agent.strategist',
+      label: 'Strategist',
+    },
+    { toolName: 'query_accounting', agentId: '@omadia/agent-accounting', label: 'Accounting' },
+  ];
+
+  it('resolves by label / agentId / tool name (verb-stripped)', () => {
+    assert.equal(
+      resolveDirectLineTarget('strategist', candidates).kind,
+      'resolved',
+    );
+    assert.equal(
+      resolveDirectLineTarget('accounting', candidates).kind,
+      'resolved',
+    );
+  });
+
+  it('returns unknown for a name no whitelisted agent matches', () => {
+    assert.deepEqual(resolveDirectLineTarget('nobody', candidates), {
+      kind: 'unknown',
+    });
+  });
+
+  it('never silently routes — duplicate labels are ambiguous', () => {
+    const dup: DirectLineCandidate[] = [
+      { toolName: 'a', label: 'Twin' },
+      { toolName: 'b', label: 'Twin' },
+    ];
+    const r = resolveDirectLineTarget('twin', dup);
+    assert.equal(r.kind, 'ambiguous');
+  });
+});
+
+describe('#332 directLineLabel', () => {
+  it('humanizes agent ids and verb-prefixed tool names', () => {
+    assert.equal(directLineLabel('de.byte5.agent.strategist'), 'Strategist');
+    assert.equal(directLineLabel('@omadia/agent-seo-analyst'), 'Seo Analyst');
+    assert.equal(directLineLabel('ask_strategist'), 'Strategist');
+  });
+});
+
+// ── #332 Layer 1 — projection + plain-text fallback ──────────────────────────
+
+describe('#332 toSemanticAnswer agentsConsulted projection', () => {
+  const base: ChatTurnResult = { answer: 'hi', toolCalls: 0, iterations: 0 };
+
+  it('projects runTrace.agentInvocations into a curated footer field', () => {
+    const r: ChatTurnResult = {
+      ...base,
+      runTrace: {
+        scope: 's',
+        startedAt: '2026-01-01T00:00:00.000Z',
+        finishedAt: '2026-01-01T00:00:01.000Z',
+        durationMs: 1000,
+        status: 'success',
+        iterations: 1,
+        orchestratorToolCalls: [],
+        agentInvocations: [
+          {
+            index: 0,
+            agentName: 'ask_strategist',
+            durationMs: 950,
+            subIterations: 2,
+            status: 'success',
+            toolCalls: [
+              {
+                callId: 'c1',
+                toolName: 'x',
+                durationMs: 5,
+                isError: false,
+                agentContext: 'ask_strategist',
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const sa = toSemanticAnswer(r);
+    assert.equal(sa.agentsConsulted?.length, 1);
+    assert.equal(sa.agentsConsulted?.[0]?.label, 'Strategist');
+    assert.equal(sa.agentsConsulted?.[0]?.status, 'success');
+    assert.equal(sa.agentsConsulted?.[0]?.toolCalls, 1);
+    assert.equal(
+      agentsConsultedFooterText(sa),
+      '🔎 Consulted: Strategist ✓ · 1 step',
+    );
+  });
+
+  it('omits agentsConsulted (and footer) when no sub-agent ran — fabricated claims show nothing', () => {
+    const sa = toSemanticAnswer(base);
+    assert.equal(sa.agentsConsulted, undefined);
+    assert.equal(agentsConsultedFooterText(sa), undefined);
+  });
+});
+
+// ── #332 Layer 2 / 3 — integration via Orchestrator.chat() (Teams path) ───────
+
+const providerCapabilities = {
+  tools: true,
+  vision: true,
+  streaming: true,
+  promptCaching: true,
+  forcedToolChoice: true,
+  parallelToolCalls: true,
+} as const;
+
+/** Provider whose every call throws — proves the LLM never ran (strict mode). */
+function neverCalledProvider(): LlmProvider {
+  const p = {
+    id: 'anthropic',
+    capabilities: providerCapabilities,
+    complete: async (): Promise<LlmResponse> => {
+      throw new Error('LLM must not be called on a strict direct-line turn');
+    },
+    stream: () => {
+      throw new Error('LLM must not be called on a strict direct-line turn');
+    },
+    classifyError: () => ({ retryable: false, kind: 'other' as const }),
+  };
+  return p as unknown as LlmProvider;
+}
+
+const usage = {
+  inputTokens: 10,
+  outputTokens: 1,
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+};
+const textResponse = (text: string): LlmResponse =>
+  ({
+    content: [{ type: 'text', text }],
+    finishReason: 'stop',
+    providerFinishReason: 'end_turn',
+    model: 'test',
+    usage,
+  }) as unknown as LlmResponse;
+const toolResponse = (name: string, input: unknown): LlmResponse =>
+  ({
+    content: [{ type: 'tool_call', id: `use-${name}`, name, input }],
+    finishReason: 'tool_calls',
+    providerFinishReason: 'tool_use',
+    model: 'test',
+    usage,
+  }) as unknown as LlmResponse;
+
+/** Provider that returns a scripted sequence of `complete()` responses. */
+function scriptedCompleteProvider(seq: LlmResponse[]): {
+  provider: LlmProvider;
+  calls: () => number;
+} {
+  let i = 0;
+  const provider = {
+    id: 'anthropic',
+    capabilities: providerCapabilities,
+    complete: async (): Promise<LlmResponse> => {
+      const r = seq[i] ?? textResponse('done');
+      i += 1;
+      return r;
+    },
+    stream: () => {
+      throw new Error('not scripted for stream');
+    },
+    classifyError: () => ({ retryable: false, kind: 'other' as const }),
+  };
+  return { provider: provider as unknown as LlmProvider, calls: () => i };
+}
+
+function strategistTool(
+  impl: (question: string) => Promise<string>,
+  captured?: { q?: string },
+) {
+  return createDomainTool({
+    name: 'ask_strategist',
+    description: 'Strategy sparring partner',
+    domain: 'strategy',
+    agentId: 'de.byte5.agent.strategist',
+    agent: {
+      ask: async (question: string): Promise<string> => {
+        if (captured) captured.q = question;
+        return impl(question);
+      },
+    },
+  });
+}
+
+describe('#332 Layer 2 — Direct Line (strict passthrough, non-streaming/Teams)', () => {
+  it('delivers the verbatim answer attributed, with the LLM never called, input bound verbatim', async () => {
+    const captured: { q?: string } = {};
+    const tool = strategistTool(async () => 'VERBATIM-STRATEGIST-ANSWER', captured);
+    const orch = new Orchestrator({
+      provider: neverCalledProvider(),
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [tool],
+      nativeToolRegistry: new NativeToolRegistry(),
+    });
+
+    const sa = await orch.chat({
+      userMessage: '#strategist What are three risks in plan A?',
+      sessionScope: 's1',
+    });
+
+    assert.equal(captured.q, 'What are three risks in plan A?'); // verbatim input
+    assert.ok(sa.delegatedAnswer, 'delegatedAnswer must be present');
+    assert.equal(sa.delegatedAnswer?.label, 'Strategist');
+    assert.equal(sa.delegatedAnswer?.status, 'success');
+    assert.equal(sa.delegatedAnswer?.text, 'VERBATIM-STRATEGIST-ANSWER');
+    assert.equal(sa.text, 'VERBATIM-STRATEGIST-ANSWER'); // graceful degrade
+    assert.equal(sa.agentsConsulted?.[0]?.label, 'Strategist'); // L1 footer
+  });
+
+  it('an unknown specialist yields a disambiguation, never a silent wrong route', async () => {
+    let asked = false;
+    const tool = strategistTool(async () => {
+      asked = true;
+      return 'should not run';
+    });
+    const orch = new Orchestrator({
+      provider: neverCalledProvider(),
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [tool],
+      nativeToolRegistry: new NativeToolRegistry(),
+    });
+    const sa = await orch.chat({ userMessage: '#nobody hello?', sessionScope: 's2' });
+    assert.equal(asked, false, 'no sub-agent may run for an unknown token');
+    assert.equal(sa.delegatedAnswer, undefined);
+    assert.match(sa.text, /No specialist named "nobody"/);
+    assert.match(sa.text, /Strategist/); // lists what IS available
+  });
+
+  it('delivers a sub-agent failure faithfully (no cover-up)', async () => {
+    const tool = strategistTool(async () => {
+      throw new Error('upstream 503');
+    });
+    const orch = new Orchestrator({
+      provider: neverCalledProvider(),
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [tool],
+      nativeToolRegistry: new NativeToolRegistry(),
+    });
+    const sa = await orch.chat({ userMessage: '#strategist plan?', sessionScope: 's3' });
+    assert.equal(sa.delegatedAnswer?.status, 'error');
+    assert.match(sa.delegatedAnswer?.text ?? '', /Error|could not respond|503/i);
+  });
+});
+
+describe('#332 Layer 3 — forced-delegation obligation (non-streaming)', () => {
+  it('forces a consult when the model would end the turn without it', async () => {
+    const captured: { q?: string } = {};
+    const tool = strategistTool(async () => 'STRATEGIST-CONSULTED', captured);
+    // 1st model turn: pure text (skips the consult). After the forced
+    // escalation: the model calls the obligation tool. Then a final text.
+    const { provider, calls } = scriptedCompleteProvider([
+      textResponse('Here is my own take, ignoring the specialist.'),
+      toolResponse('ask_strategist', { question: 'forced question' }),
+      textResponse('Final synthesis.'),
+    ]);
+    const orch = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 6,
+      domainTools: [tool],
+      nativeToolRegistry: new NativeToolRegistry(),
+    });
+    const sa = await orch.chat({
+      userMessage: 'run the strategy process',
+      sessionScope: 's4',
+      expectedDomainTool: 'ask_strategist',
+    });
+    assert.equal(captured.q, 'forced question', 'obligation tool must have run');
+    assert.ok(calls() >= 2, 'the harness escalated at least once');
+    assert.ok(sa.text.length > 0);
+  });
+
+  it('does not force anything on an ordinary turn (no obligation set)', async () => {
+    let asked = false;
+    const tool = strategistTool(async () => {
+      asked = true;
+      return 'x';
+    });
+    const { provider } = scriptedCompleteProvider([textResponse('plain answer')]);
+    const orch = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 6,
+      domainTools: [tool],
+      nativeToolRegistry: new NativeToolRegistry(),
+    });
+    const sa = await orch.chat({ userMessage: 'hello', sessionScope: 's5' });
+    assert.equal(asked, false);
+    assert.equal(sa.text, 'plain answer');
+  });
+});

--- a/middleware/test/orchestrator/directLine.test.ts
+++ b/middleware/test/orchestrator/directLine.test.ts
@@ -367,6 +367,60 @@ describe('#332 Layer 2 — Direct Line (strict passthrough, non-streaming/Teams)
   });
 });
 
+// Minimal privacy-guard service stub — enough for runTurn's post-turn block
+// (takeRenderedAnswerV4 + finalizeTurn). Direct-line never interns, so the
+// other methods are not exercised.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const fakePrivacyGuard = (): any => () =>
+  ({
+    internToolResultV4: async () => ({ digest: '', datasetId: '' }),
+    subAgentResultV4: async (i: { narration: string }) => ({
+      resultText: i.narration,
+    }),
+    takeRenderedAnswerV4: async () => undefined,
+    finalizeTurn: async () => undefined,
+  }) as any;
+
+describe('#332 Layer 2 — guarded-additive mode', () => {
+  it('appends an attributed note but keeps the verbatim block byte-for-byte (no-redaction)', async () => {
+    const tool = strategistTool(async () => 'VERBATIM-X');
+    // provider.complete is called once, for the note generation.
+    const { provider } = scriptedCompleteProvider([
+      textResponse('cross-domain caveat'),
+    ]);
+    const orch = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [tool],
+      nativeToolRegistry: new NativeToolRegistry(),
+      directLineMode: 'guarded',
+    });
+    const sa = await orch.chat({ userMessage: '#strategist plan?', sessionScope: 'g1' });
+    assert.equal(sa.delegatedAnswer?.text, 'VERBATIM-X'); // intact, independent
+    assert.match(sa.text, /VERBATIM-X/);
+    assert.match(sa.text, /▸ omadia note: cross-domain caveat/);
+  });
+
+  it('degrades to strict (no note LLM call) when a privacy guard is active — no PII to the provider', async () => {
+    const tool = strategistTool(async () => 'VERBATIM-Y');
+    const orch = new Orchestrator({
+      provider: neverCalledProvider(), // throws if the note LLM is invoked
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [tool],
+      nativeToolRegistry: new NativeToolRegistry(),
+      directLineMode: 'guarded',
+      privacyGuard: fakePrivacyGuard(),
+    });
+    const sa = await orch.chat({ userMessage: '#strategist plan?', sessionScope: 'g2' });
+    assert.equal(sa.delegatedAnswer?.text, 'VERBATIM-Y');
+    assert.equal(sa.text, 'VERBATIM-Y'); // no note appended → no provider call
+  });
+});
+
 describe('#332 Layer 3 — forced-delegation obligation (non-streaming)', () => {
   it('forces a consult when the model would end the turn without it', async () => {
     const captured: { q?: string } = {};


### PR DESCRIPTION
## Why

omadia routes every turn through a single **orchestrator**, which decides at LLM discretion *whether/when/how* to delegate to a named specialist and *rephrases* the result. This produces **gatekeeper drift**: the orchestrator quietly concentrates competence and mediates everything, so a requested delegation is neither *observable* nor *non-suppressible*. That is a blocker for enterprise adoption — most visibly on **MS Teams**, where the user today has **no** agent-invocation visibility at all.

This PR keeps the orchestrator in the loop and aware, but removes its **destructive** powers (suppressing/falsifying a delegation) while preserving its **constructive** ones, via three independently-shippable layers. Addresses the in-process scope of #332 (the Teams Adaptive-Card rendering lives in the private connector repo and is a follow-up).

## What

### L1 — Tamper-evident transparency (the minimum)
- New contract on `SemanticAnswer`: `agentsConsulted` (curated projection of the deterministic `runTrace.agentInvocations`) + `DelegatedAnswer`.
- `toSemanticAnswer` builds `agentsConsulted` from the choke-point trace — **not** the LLM's prose. The raw `runTrace` stays dropped at the channel boundary. A fabricated "I asked X" with no real invocation yields an empty list.
- Exported `agentsConsultedFooterText()` plain-text fallback (`🔎 Consulted: Strategist ✓ · 2 steps`).

### L2 — Direct Line (core of the maximum)
- New pure module `directLine.ts`: `parseDirectLineDirective` (a leading `#<specialist>` token that survives Teams mention-strip + whitespace-collapse) and `resolveDirectLineTarget` (resolves only against this orchestrator's **whitelisted** sub-agents).
- **Collision rule (#332 Open Q3):** a leading `#token` is treated as a directive **only when it resolves** to a whitelisted specialist. An **unknown** token falls through to the normal LLM turn, so ordinary messages that merely start with `#` (`#urgent …`, `#1 priority …`, hashtags) are never hijacked. **Ambiguous** tokens (matched ≥2 agents) disambiguate instead of routing silently (Pitfall 7).
- `Orchestrator.executeDirectLine`: binds the sub-agent's input to the user's **verbatim** payload via the deterministic choke point, captures the verbatim answer, and delivers it as a **harness-owned, attributed** `delegatedAnswer` the orchestrator can neither remove nor reword. Routed through the same `privacyHandle.finalize`. Faithful failures, never a cover-up.
- **Awareness/continuity (Pitfall 5):** the verbatim exchange is persisted through the same `sessionLogger` as a normal turn (KG continuity + cross-session recall + `turnId`), not just the channel's prior-turn buffer.
- Policy: **strict passthrough** (default) or **guarded additive** (an attributed `▸ omadia note:` may be appended; the verbatim block stays byte-for-byte intact — the no-redaction invariant is structural).

### L3 — Forced delegation obligation
- `ChatTurnInput.expectedDomainTool` ports OB-31 to the orchestrator loop: if the turn would end (pure-text stop) without invoking the required sub-agent, the harness escalates **once** with `tool_choice:{type:'tool',name:X}` + a synthetic reminder. This forces the consult within the iteration budget; an *absolute* "cannot end without it" guarantee additionally needs the verifier/postcondition layer (out of scope here, per the issue).

### MS Teams note (important)
Teams uses `chat()` → `runTurn` → `chatInContextInner` (**non-streaming**); web-ui uses `chatStream` → `chatStreamInner` (streaming). The issue located L2/L3 only in `chatStream`, which would have left Teams uncovered — so **L2 and L3 are wired into BOTH parallel loops**.

## Files
- `harness-channel-sdk/src/{outgoing,toSemanticAnswer,chatAgent,index}.ts` — L1 contract, projection, fallback, `expectedDomainTool`, `done`-event `delegatedAnswer`.
- `harness-orchestrator/src/directLine.ts` (new) — pure parser/resolver/label.
- `harness-orchestrator/src/orchestrator.ts` — `executeDirectLine`, guarded note, session-log persistence, options, obligation port in both loops.
- `harness-orchestrator/src/index.ts` — exports.
- `test/orchestrator/directLine.test.ts` (new) — 20 tests.

## Validation
- Full build clean (0 TS errors).
- New tests **20/20 green**: parser/resolver/label + verbatim-preservation; L1 projection + footer; L2 strict verbatim + verbatim-input-binding + LLM-never-called + unknown-token-fall-through + ambiguous-disambiguation + faithful-error + session-log persistence; guarded no-redaction + guarded degrades-to-strict-under-privacy; L3 forces-consult + no-op-when-unset.
- Full suite **3503/3503 pass, 0 fail** (last run). A non-deterministic, pre-existing test-pollution failure (a different unrelated builder route each run, e.g. `builderEditRoutes` / runtime-secrets) sometimes appears in the full run but passes in isolation and alongside the new tests — unrelated to this PR.

## Acceptance criteria
- [x] Teams sees a consulted footer sourced from `runTrace`, not the LLM; a fabricated consult shows nothing.
- [x] A direct-line directive delivers the specialist's verbatim answer, attributed; the orchestrator cannot suppress/reword it.
- [x] Guarded-additive keeps the verbatim block byte-for-byte intact (structural; covered by a no-redaction test).
- [x] No PII leak to the model provider: guarded-additive runs an extra completion over the answer, so it **degrades to strict passthrough whenever a privacy guard is active** (tested). The verbatim block is delivered intact regardless. (Note: the user-facing delegated answer is the sub-agent's own LLM output, produced under the per-turn privacy handle.)
- [x] Ambiguous token → disambiguation, never a silent wrong route; unknown token → normal LLM turn (no hijack).
- [x] Sub-agent errors are delivered faithfully.
- [~] (L3) A turn carrying an obligation is forced toward the consult via **one OB-31 escalation**; an *absolute* block needs the verifier/postcondition layer (not in this PR). `expectedDomainTool` is a primitive with no production producer yet — the Conductor (#321) is its intended caller.
- [x] No regression to orchestrator memory/recall/privacy/follow-ups/scheduling. Direct-line persists via the session logger AND fires fact-extraction, so the KG learns from delegated answers too.

## Independent review
An independent Codex/GPT-5.4 adversarial review was run. Fixes applied from it: streaming `turnExternalId` parity, truly-verbatim payload (only the separator is stripped), guarded-mode PII degrade-to-strict, and KG fact-extraction parity. Confirmed structurally sound: the no-redaction invariant and the directive collision rule.

## Follow-ups (not in this PR)
- Teams connector rendering (private repo) after this contract merges.
- web-ui curated render of `agentsConsulted` / `delegatedAnswer`.
- A privacy-aware guarded note (intern the note input) so guarded mode can also run under an active privacy guard.
- Non-stream relay does not run the turn-hook side-channel / entity-ref collection (no plan, no orchestrator-level tool calls) — fire them if a future need arises.

Complementary to the Conductor (#321): this PR delivers the per-turn trust primitives; the Conductor composes L3 obligations into multi-step processes.
