### PR TITLE
fix(ci): publish versioned + latest images on auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 concurrency:
   group: auto-release
@@ -27,12 +28,15 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      new_tag: ${{ steps.rel.outputs.new_tag }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Compute bump, tag, and release
+        id: rel
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -77,3 +81,21 @@ jobs:
           git tag -a "$new" -m "omadia $new"
           git push origin "$new"
           gh release create "$new" --generate-notes --title "omadia $new" --latest
+          # Hand the new tag to the publish-images job below. A GITHUB_TOKEN
+          # release does not fire a `release` event, so the image build must run
+          # here in the same workflow rather than via an event trigger.
+          echo "new_tag=$new" >> "$GITHUB_OUTPUT"
+
+  # Build + push the versioned + :latest images for the Release just cut.
+  # Runs only when a release happened (new_tag set). In-run call, so it does
+  # not depend on the (suppressed) `release` event firing.
+  publish-images:
+    needs: release
+    if: ${{ needs.release.outputs.new_tag != '' }}
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/publish-images.yml
+    with:
+      ref: ${{ needs.release.outputs.new_tag }}
+      version: ${{ needs.release.outputs.new_tag }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,90 @@
+# Reusable image-publish workflow (called by release.yml and auto-release.yml).
+#
+# Builds + pushes the multi-arch (amd64+arm64) middleware + web-ui images to
+# GHCR. Two modes via the `version` input:
+#   - version == ''  -> edge build: ghcr.io/byte5ai/omadia-*:edge + :sha-<short>
+#   - version set     -> release build: :X.Y.Z + :vX.Y.Z + :X.Y + :vX.Y + :latest
+#
+# Lives as a reusable `workflow_call` so the edge path (release.yml, on push to
+# main) and the version path (auto-release.yml, right after it cuts a Release)
+# share ONE build definition. The version path is invoked as a direct job, not
+# via a `release: published` event — GitHub does not fire event-triggered
+# workflows from a GITHUB_TOKEN-created release, so the call must be in-run.
+
+name: publish-images
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to build (empty = the caller ref, e.g. main for edge).'
+        required: false
+        type: string
+        default: ''
+      version:
+        description: 'Release tag like v0.3.0 (empty = edge build).'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: middleware
+            image: ghcr.io/byte5ai/omadia-middleware
+            context: .
+            dockerfile: ./Dockerfile
+            build_args: ''
+          - name: web-ui
+            image: ghcr.io/byte5ai/omadia-web-ui
+            context: ./web-ui
+            dockerfile: ./web-ui/Dockerfile
+            build_args: |
+              MIDDLEWARE_URL=http://middleware:8080
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ matrix.image }}
+          # latest=auto tags :latest only when a (non-prerelease) semver tag is
+          # produced — i.e. the version path, never the edge path.
+          flavor: |
+            latest=auto
+          tags: |
+            type=edge,branch=main,enable=${{ inputs.version == '' }}
+            type=sha,prefix=sha-,enable=${{ inputs.version == '' }}
+            type=semver,pattern={{version}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
+            type=semver,pattern=v{{version}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
+            type=semver,pattern=v{{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ matrix.build_args }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,13 @@
-# Release workflow — container images ACTIVE; npm publish still gated.
+# Release workflow — edge images on every push to main; npm publish gated.
 #
-# Container images (middleware + web-ui) publish to GHCR:
-#   - push to `main`            -> ghcr.io/byte5ai/omadia-*:edge + :sha-<short>
-#   - GitHub Release published  -> :X.Y.Z + :vX.Y.Z + :X.Y + :vX.Y + :latest
-#     (auto-release.yml cuts the vX.Y.Z tag + Release on feat/fix merges to main;
-#      both v-prefixed and bare image tags are published so either pin resolves)
+# Image publishing is centralized in the reusable publish-images.yml:
+#   - this file (push to `main`)      -> :edge + :sha-<short>
+#   - auto-release.yml (after Release) -> :X.Y.Z / :vX.Y.Z / :X.Y / :vX.Y / :latest
+#
+# Why the version path lives in auto-release.yml and not a `release: published`
+# trigger here: auto-release cuts the Release with the default GITHUB_TOKEN, and
+# GitHub does not fire event-triggered workflows from GITHUB_TOKEN-created
+# releases. So auto-release calls publish-images directly, in the same run.
 # docker-compose.yaml pulls these by ${OMADIA_VERSION:-latest}.
 #
 # npm package publishing stays gated (`if: false`) until the npm-scope
@@ -15,112 +18,18 @@ name: Release
 on:
   push:
     branches: [main]
-  release:
-    types: [published]
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Dry-run only (build images, skip the GHCR push)'
-        required: false
-        type: boolean
-        default: true
-
-permissions:
-  contents: read
-  packages: write
-  id-token: write   # OIDC for npm provenance once wired
 
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  ghcr-middleware:
-    name: middleware → GHCR
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/metadata-action@v5
-        id: meta
-        with:
-          images: ghcr.io/byte5ai/omadia-middleware
-          # latest=auto tags :latest on a (non-prerelease) semver Release tag,
-          # never on a plain main push. It does not compare against
-          # already-published tags, so manually re-releasing an older line would
-          # re-point :latest — auto-release.yml only ever advances forward.
-          flavor: |
-            latest=auto
-          tags: |
-            type=edge,branch=main
-            type=sha,prefix=sha-,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          # Push for push/release events; for a manual run only when dry_run=false.
-          push: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: true
-          sbom: true
-
-  ghcr-web-ui:
-    name: web-ui → GHCR
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/metadata-action@v5
-        id: meta
-        with:
-          images: ghcr.io/byte5ai/omadia-web-ui
-          # latest=auto tags :latest on a (non-prerelease) semver Release tag,
-          # never on a plain main push. It does not compare against
-          # already-published tags, so manually re-releasing an older line would
-          # re-point :latest — auto-release.yml only ever advances forward.
-          flavor: |
-            latest=auto
-          tags: |
-            type=edge,branch=main
-            type=sha,prefix=sha-,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-      - uses: docker/build-push-action@v6
-        with:
-          context: ./web-ui
-          file: ./web-ui/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            MIDDLEWARE_URL=http://middleware:8080
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: true
-          sbom: true
+  edge-images:
+    permissions:
+      contents: read
+      packages: write
+    # No `version` input -> edge build (:edge + :sha-<short>) from this commit.
+    uses: ./.github/workflows/publish-images.yml
 
   # ──────────────────────────────────────────────────────────────────
   # npm package publishing — GATED OFF until the npm-scope decision
@@ -130,6 +39,9 @@ jobs:
     name: npm publish (gated off)
     runs-on: ubuntu-latest
     if: false
+    permissions:
+      contents: read
+      id-token: write   # OIDC for npm provenance once wired
     defaults:
       run:
         working-directory: middleware


### PR DESCRIPTION
## Problem
After #339 merged, only `:edge` + `:sha-<short>` images were published. The versioned + `:latest` images were **not**, so `docker compose up -d` (which pulls `${OMADIA_VERSION:-latest}`) has no image to pull.

Root cause: `release.yml` published versioned/`:latest` on a `release: published` trigger, but `auto-release.yml` cuts the Release with the default `GITHUB_TOKEN`. GitHub deliberately does **not** run event-triggered workflows from `GITHUB_TOKEN`-created tags/releases (recursion guard). So the trigger never fired — confirmed on v0.35.0: an `auto-release` run exists, a Release exists, but there is **no** `release`-event `release.yml` run.

## Fix
- **New reusable `publish-images.yml`** (`workflow_call`) holds the single multi-arch (amd64+arm64) GHCR build. Two modes via the `version` input: empty → edge build (`:edge` + `:sha`), set → release build (`:X.Y.Z` / `:vX.Y.Z` / `:X.Y` / `:vX.Y` / `:latest` via `latest=auto`).
- **`release.yml`** now just calls it on push to `main` for the edge images (dropped the duplicated jobs and the dead `release:` trigger; npm-publish stays gated).
- **`auto-release.yml`** outputs the new tag and, in the **same run**, calls `publish-images.yml` with that tag. No cross-workflow event and no PAT, so the `GITHUB_TOKEN` limitation no longer applies.

## Effect
Merging this is a `fix:` commit, so auto-release cuts the next patch release and exercises the new path end-to-end — publishing `:latest` (and the versioned tags) for the first time via the working pipeline.

Follow-up to #339 / #336.
