### PR TITLE
feat(desktop): native one-click installer — bundled PostgreSQL 17 + pgvector, macOS/Linux/Windows

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -99,3 +99,16 @@ jobs:
     with:
       ref: ${{ needs.release.outputs.new_tag }}
       version: ${{ needs.release.outputs.new_tag }}
+
+  # Build + attach the native desktop installers (macOS/Linux signed if secrets
+  # are set; Windows best-effort). Same in-run pattern as publish-images, because
+  # the GITHUB_TOKEN-created release does not fire a `release` event.
+  desktop-apps:
+    needs: release
+    if: ${{ needs.release.outputs.new_tag != '' }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/desktop-apps.yml
+    with:
+      tag: ${{ needs.release.outputs.new_tag }}
+    secrets: inherit

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -3,8 +3,8 @@
 # Release that triggered the run.
 #
 # This is the no-Docker, one-click installer in `desktop/`: an Electron shell
-# that bundles + supervises the existing middleware kernel and web-ui plus an
-# embedded Postgres (PGlite). See desktop/README.md and
+# that bundles + supervises the existing middleware kernel and web-ui plus a
+# bundled native PostgreSQL 17 + pgvector. See desktop/README.md and
 # docs/plans/native-installer-plan.md.
 #
 # Runs separately from release.yml (the GHCR image pipeline) so a desktop build
@@ -57,13 +57,12 @@ jobs:
           # Intel runners queue for hours). Intel x64 is a tracked follow-up.
           - os: macos-latest
             args: --mac --arm64
-          # Linux + Windows are temporarily off while the bundled-Postgres engine
-          # (replacing the crashing PGlite) is proven end-to-end on macOS. They
-          # return once their pgvector provisioning (apt / Windows build) is wired.
-          # - os: ubuntu-latest
-          #   args: --linux
-          # - os: windows-latest
-          #   args: --win
+          # Linux + Windows each provision a PG17 pgvector for their embedded
+          # engine below (apt pgdg / MSVC nmake build) before staging. x64 only.
+          - os: ubuntu-latest
+            args: --linux
+          - os: windows-latest
+            args: --win
     runs-on: ${{ matrix.os }}
     # Hard cap so a stuck native build can never run for hours.
     timeout-minutes: 30
@@ -174,7 +173,60 @@ jobs:
           cp "$PV/lib/postgresql@17/vector.dylib" "$NATIVE/lib/postgresql/vector.dylib"
           cp "$PV/share/postgresql@17/extension/vector.control" "$NATIVE/share/postgresql/extension/"
           cp "$PV"/share/postgresql@17/extension/vector--*.sql "$NATIVE/share/postgresql/extension/"
-          echo "✓ pgvector staged into the embedded PG17 engine"
+          echo "✓ pgvector staged into the embedded PG17 engine (darwin-arm64)"
+
+      # Linux: the PostgreSQL APT repo (pgdg) ships a prebuilt postgresql-17-pgvector.
+      # A PG17 vector.so loads in the embedded PG17 (extensions are ABI-stable within
+      # a major). Unix layout: module in lib/postgresql/, control+SQL in
+      # share/postgresql/extension/ (same as macOS).
+      - name: Provision pgvector into the embedded Postgres (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -fsSL -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+            https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+            | sudo tee /etc/apt/sources.list.d/pgdg.list
+          sudo apt-get update
+          sudo apt-get install -y postgresql-17-pgvector
+          NATIVE="desktop/node_modules/@embedded-postgres/linux-x64/native"
+          mkdir -p "$NATIVE/lib/postgresql" "$NATIVE/share/postgresql/extension"
+          cp /usr/lib/postgresql/17/lib/vector.so "$NATIVE/lib/postgresql/vector.so"
+          cp /usr/share/postgresql/17/extension/vector.control "$NATIVE/share/postgresql/extension/"
+          cp /usr/share/postgresql/17/extension/vector--*.sql "$NATIVE/share/postgresql/extension/"
+          echo "✓ pgvector staged into the embedded PG17 engine (linux-x64)"
+
+      # Windows: no prebuilt pgvector exists, so build vector.dll from source with
+      # MSVC against a full PG17 (Chocolatey ships headers + lib; the embedded
+      # engine is a minimal dist with neither). A PG17 build loads in the embedded
+      # PG17. Windows layout is FLAT: module in lib/, control+SQL in share/extension/.
+      - name: Set up MSVC (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Provision pgvector into the embedded Postgres (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          choco install postgresql17 --params "/Password:postgres" -y --no-progress
+          $pgroot = "C:\Program Files\PostgreSQL\17"
+          if (-not (Test-Path $pgroot)) {
+            $pgroot = (Get-ChildItem 'C:\Program Files\PostgreSQL' -Directory |
+              Sort-Object Name -Descending | Select-Object -First 1).FullName
+          }
+          $env:PGROOT = $pgroot
+          Write-Host "PGROOT=$pgroot"
+          git clone --depth 1 --branch v0.8.3 https://github.com/pgvector/pgvector.git "$env:RUNNER_TEMP\pgvector"
+          Push-Location "$env:RUNNER_TEMP\pgvector"
+          nmake /NOLOGO /F Makefile.win
+          if ($LASTEXITCODE -ne 0) { throw "pgvector nmake build failed ($LASTEXITCODE)" }
+          Pop-Location
+          $native = "desktop\node_modules\@embedded-postgres\windows-x64\native"
+          New-Item -ItemType Directory -Force -Path "$native\share\extension" | Out-Null
+          Copy-Item "$env:RUNNER_TEMP\pgvector\vector.dll" "$native\lib\vector.dll" -Force
+          Copy-Item "$env:RUNNER_TEMP\pgvector\vector.control" "$native\share\extension\" -Force
+          Copy-Item "$env:RUNNER_TEMP\pgvector\sql\vector--*.sql" "$native\share\extension\" -Force
+          Write-Host "✓ pgvector built + staged into the embedded PG17 engine (windows-x64)"
 
       - name: Stage runtime (middleware + web-ui + Postgres → desktop/runtime)
         working-directory: desktop

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -52,8 +52,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # macOS is built PER ARCH on a matching-arch runner, because the native
+          # modules ship as extraResources (copied verbatim, not arch-split): a
+          # single arm64 runner would otherwise put an arm64 better_sqlite3.node
+          # into the x64 DMG and crash on Intel Macs. macos-latest = Apple Silicon,
+          # macos-13 = Intel.
           - os: macos-latest
-            args: --mac
+            args: --mac --arm64
+          - os: macos-13
+            args: --mac --x64
           - os: windows-latest
             args: --win
           # Linux is best-effort for now: AppImage/deb are built + uploaded but
@@ -163,7 +170,7 @@ jobs:
 
       # --- macOS signing + notarization (proven for omadia-ui) --------------
       - name: Prepare Apple signing (optional — needs _HIGH5 secrets)
-        if: ${{ matrix.os == 'macos-latest' && env.APPLE_P12_BASE64 != '' }}
+        if: ${{ startsWith(matrix.os, 'macos') && env.APPLE_P12_BASE64 != '' }}
         run: |
           printf '%s' "$APPLE_P12_BASE64" | base64 -d > "$RUNNER_TEMP/developer-id.p12"
           printf '%s' "$APPLE_ASC_KEY_P8_BASE64" | base64 -d > "$RUNNER_TEMP/asc-key.p8"
@@ -224,28 +231,10 @@ jobs:
         working-directory: desktop
         run: npx electron-builder ${{ matrix.args }} ${EB_NOTARIZE:-} --publish never
 
-      # Make the built installers downloadable from the run itself, independent of
-      # whether they're also uploaded to a Release — so a green OS leg always
-      # yields artifacts even on a build-validation (no-release) dispatch.
-      - name: Upload installers as run artifacts
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: omadia-installers-${{ matrix.os }}
-          if-no-files-found: ignore
-          path: |
-            desktop/release/*.dmg
-            desktop/release/*.zip
-            desktop/release/*.exe
-            desktop/release/*.AppImage
-            desktop/release/*.deb
-            desktop/release/*.blockmap
-            desktop/release/latest*.yml
-
       # The .app is notarized + stapled by electron-builder above; the DMG needs
       # its own ticket so `stapler validate` passes on the disk image itself.
       - name: Notarize + staple the DMGs
-        if: ${{ matrix.os == 'macos-latest' && env.APPLE_P12_BASE64 != '' }}
+        if: ${{ startsWith(matrix.os, 'macos') && env.APPLE_P12_BASE64 != '' }}
         working-directory: desktop
         run: |
           for dmg in release/*.dmg; do
@@ -258,7 +247,7 @@ jobs:
           done
 
       - name: Verify macOS signatures (acceptance gate)
-        if: ${{ matrix.os == 'macos-latest' && env.APPLE_P12_BASE64 != '' }}
+        if: ${{ startsWith(matrix.os, 'macos') && env.APPLE_P12_BASE64 != '' }}
         working-directory: desktop
         run: |
           set -e
@@ -294,7 +283,31 @@ jobs:
 
       - name: Tear down signing material
         if: ${{ always() }}
-        run: rm -f "$RUNNER_TEMP/developer-id.p12" "$RUNNER_TEMP/asc-key.p8" "$RUNNER_TEMP/win-cert.p12" || true
+        run: |
+          rm -f "$RUNNER_TEMP/developer-id.p12" "$RUNNER_TEMP/asc-key.p8" "$RUNNER_TEMP/win-cert.p12" || true
+          # Also drop our temp signing keychain (and let macOS fall back to the
+          # default search list) so nothing signing-related lingers.
+          if [ -n "${MAC_SIGN_KEYCHAIN:-}" ]; then
+            security delete-keychain "$MAC_SIGN_KEYCHAIN" 2>/dev/null || true
+          fi
+
+      # Downloadable from the run itself (independent of the Release upload), and
+      # placed AFTER notarize/staple/verify so the artifacts are the final,
+      # stapled installers — not a pre-notarization copy.
+      - name: Upload installers as run artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: omadia-installers-${{ matrix.os }}
+          if-no-files-found: ignore
+          path: |
+            desktop/release/*.dmg
+            desktop/release/*.zip
+            desktop/release/*.exe
+            desktop/release/*.AppImage
+            desktop/release/*.deb
+            desktop/release/*.blockmap
+            desktop/release/latest*.yml
 
       - name: Upload installers to the release
         env:

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -30,6 +30,15 @@ on:
         description: 'Release tag to build + attach to (e.g. v0.3.0)'
         required: true
         type: string
+  # Called in-run from auto-release.yml: a GITHUB_TOKEN-created release does NOT
+  # fire the `release` event, so the apps must be built from within the same run
+  # that cut the release (same pattern as publish-images.yml).
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to build + attach to'
+        required: true
+        type: string
 
 concurrency:
   group: desktop-apps-${{ github.event.release.tag_name || inputs.tag }}
@@ -53,12 +62,19 @@ jobs:
           - os: ubuntu-latest
             args: --linux
     runs-on: ${{ matrix.os }}
+    # Windows native rebuild (better-sqlite3 via node-gyp/VS) is not yet working;
+    # don't let it block the macOS/Linux installers. Tracked as a follow-up.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
+    # Hard cap so a stuck native build can never run for hours.
+    timeout-minutes: 30
     env:
       TAG: ${{ github.event.release.tag_name || inputs.tag }}
       # Must match Supervisor.KERNEL_PORT in desktop/src/supervisor.ts — the
       # web-ui bakes this kernel URL into its routes-manifest at BUILD time, so
       # it cannot be a per-launch random port.
       KERNEL_URL: http://127.0.0.1:8769
+      # node-gyp's VS auto-detection is unreliable on windows-latest; pin VS2022.
+      GYP_MSVS_VERSION: '2022'
       # macOS signing (hoisted so they're addressable in step-level `if:`).
       APPLE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64_HIGH5 }}
       APPLE_P12_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD_HIGH5 }}
@@ -81,6 +97,21 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+
+      # node-gyp's bundled gyp imports Python's `distutils`, removed in Python
+      # 3.12. The macOS/Windows runners default to 3.12+ (Ubuntu still ships
+      # 3.11), so pin 3.11 everywhere to keep native rebuilds working.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # @electron/rebuild pulls @electron/node-gyp as a git+ssh GitHub dependency.
+      # Runners have no SSH key, so rewrite git+ssh GitHub URLs to https (public
+      # repo, no auth) before any npm install/ci, or those installs fail.
+      - name: Allow git-https for git dependencies
+        run: |
+          git config --global url."https://github.com/".insteadOf "ssh://git@github.com/"
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
 
       # --- build the omadia runtime the installer bundles -------------------
       - name: Build middleware kernel
@@ -150,8 +181,17 @@ jobs:
           security import "$RUNNER_TEMP/developer-id.p12" -k "$KEYCHAIN" \
             -P "$APPLE_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KCPASS" "$KEYCHAIN" >/dev/null
-          # Prepend our keychain to the user search list (keep the existing ones).
-          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | sed 's/[\"[:space:]]//g')
+          # Prepend our keychain to the user search list, KEEPING the existing ones.
+          # Build the list as an array (bash 3.2 on macOS runners — no mapfile) so
+          # multiple existing keychains aren't mashed into one path by whitespace
+          # stripping. Only quotes + leading/trailing space are trimmed per entry.
+          EXISTING=()
+          while IFS= read -r kc; do
+            kc="${kc//\"/}"
+            kc="$(printf '%s' "$kc" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+            [ -n "$kc" ] && EXISTING+=("$kc")
+          done < <(security list-keychains -d user)
+          security list-keychains -d user -s "$KEYCHAIN" "${EXISTING[@]}"
 
           # The exact Developer ID Application identity now present in the keychain.
           IDENT=$(security find-identity -v -p codesigning "$KEYCHAIN" \
@@ -183,6 +223,24 @@ jobs:
         working-directory: desktop
         run: npx electron-builder ${{ matrix.args }} ${EB_NOTARIZE:-} --publish never
 
+      # Make the built installers downloadable from the run itself, independent of
+      # whether they're also uploaded to a Release — so a green OS leg always
+      # yields artifacts even on a build-validation (no-release) dispatch.
+      - name: Upload installers as run artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: omadia-installers-${{ matrix.os }}
+          if-no-files-found: ignore
+          path: |
+            desktop/release/*.dmg
+            desktop/release/*.zip
+            desktop/release/*.exe
+            desktop/release/*.AppImage
+            desktop/release/*.deb
+            desktop/release/*.blockmap
+            desktop/release/latest*.yml
+
       # The .app is notarized + stapled by electron-builder above; the DMG needs
       # its own ticket so `stapler validate` passes on the disk image itself.
       - name: Notarize + staple the DMGs
@@ -203,7 +261,13 @@ jobs:
         working-directory: desktop
         run: |
           set -e
-          for app in release/mac*/*.app; do
+          shopt -s nullglob
+          apps=(release/mac*/*.app)
+          if [ ${#apps[@]} -eq 0 ]; then
+            echo "FAIL: no .app produced under release/mac*/ — nothing to verify" >&2
+            exit 1
+          fi
+          for app in "${apps[@]}"; do
             # `--deep` is deprecated for verification and does NOT descend into
             # extraResources — verify the app, then EACH nested native binary
             # explicitly, then the real Gatekeeper verdict.
@@ -237,15 +301,15 @@ jobs:
         working-directory: desktop
         run: |
           shopt -s nullglob
-          # On workflow_dispatch the tag may not correspond to an existing
-          # release — fail with a clear message rather than a cryptic gh error.
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
-            echo "no GitHub Release exists for tag '$TAG' — create the release first" >&2
-            exit 1
-          fi
           files=(release/*.dmg release/*.zip release/*.exe release/*.AppImage release/*.deb release/*.blockmap release/latest*.yml)
           if [ ${#files[@]} -eq 0 ]; then
             echo "no installer artifacts found in desktop/release/" >&2
             exit 1
+          fi
+          # If TAG has no matching release (e.g. a build-validation dispatch on a
+          # branch name), this is a build-only run — skip upload, don't fail.
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            echo "no GitHub Release for '$TAG' — build validated, skipping upload."
+            exit 0
           fi
           gh release upload "$TAG" "${files[@]}" --clobber

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -57,13 +57,13 @@ jobs:
           # Intel runners queue for hours). Intel x64 is a tracked follow-up.
           - os: macos-latest
             args: --mac --arm64
-          - os: windows-latest
-            args: --win
-          # Linux is best-effort for now: AppImage/deb are built + uploaded but
-          # unsigned, and the AppImage bundling of native modules + PGlite WASM
-          # is the least-exercised path (no smoke-boot gate yet).
-          - os: ubuntu-latest
-            args: --linux
+          # Linux + Windows are temporarily off while the bundled-Postgres engine
+          # (replacing the crashing PGlite) is proven end-to-end on macOS. They
+          # return once their pgvector provisioning (apt / Windows build) is wired.
+          # - os: ubuntu-latest
+          #   args: --linux
+          # - os: windows-latest
+          #   args: --win
     runs-on: ${{ matrix.os }}
     # Hard cap so a stuck native build can never run for hours.
     timeout-minutes: 30
@@ -160,7 +160,23 @@ jobs:
         working-directory: desktop
         run: npm run build
 
-      - name: Stage runtime (middleware + web-ui → desktop/runtime)
+      # The bundled embedded Postgres (@embedded-postgres) is a minimal server with
+      # no pgvector. Build/grab pgvector for PG17 and copy vector.* into the engine
+      # so stage-runtime bundles it. PG extensions are ABI-stable within a major
+      # version, so a PG17 vector.dylib from Homebrew loads in the embedded PG17.
+      - name: Provision pgvector into the embedded Postgres (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          brew install pgvector
+          PV="$(brew --prefix pgvector)"
+          NATIVE="desktop/node_modules/@embedded-postgres/darwin-arm64/native"
+          mkdir -p "$NATIVE/lib/postgresql" "$NATIVE/share/postgresql/extension"
+          cp "$PV/lib/postgresql@17/vector.dylib" "$NATIVE/lib/postgresql/vector.dylib"
+          cp "$PV/share/postgresql@17/extension/vector.control" "$NATIVE/share/postgresql/extension/"
+          cp "$PV"/share/postgresql@17/extension/vector--*.sql "$NATIVE/share/postgresql/extension/"
+          echo "✓ pgvector staged into the embedded PG17 engine"
+
+      - name: Stage runtime (middleware + web-ui + Postgres → desktop/runtime)
         working-directory: desktop
         run: npm run stage
 
@@ -262,14 +278,17 @@ jobs:
               echo "FAIL: $app is ad-hoc signed — the Developer ID did not apply" >&2
               exit 1
             fi
-            # Every staged .node/.dylib must be individually signed with the
-            # Developer ID (not ad-hoc) — afterPack.js does this.
+            # Every staged Mach-O (middleware native modules AND the bundled
+            # Postgres binaries/dylibs, which are extensionless) must be signed
+            # with the Developer ID (not ad-hoc) — afterPack.js does this. Detect
+            # Mach-O via `file` so extensionless executables are covered.
             while IFS= read -r bin; do
+              file "$bin" | grep -q 'Mach-O' || continue
               codesign --verify --strict "$bin" || { echo "FAIL: unsigned nested binary $bin" >&2; exit 1; }
               if codesign -dv "$bin" 2>&1 | grep -q 'Signature=adhoc'; then
                 echo "FAIL: nested binary is ad-hoc signed, not Developer ID: $bin" >&2; exit 1
               fi
-            done < <(find "$app/Contents/Resources/omadia" -type f \( -name '*.node' -o -name '*.dylib' \))
+            done < <(find "$app/Contents/Resources/omadia" "$app/Contents/Resources/omadia-pg" -type f)
             xcrun stapler validate "$app"
             spctl --assess --type execute -vvv "$app"
           done

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -62,9 +62,6 @@ jobs:
           - os: ubuntu-latest
             args: --linux
     runs-on: ${{ matrix.os }}
-    # Windows native rebuild (better-sqlite3 via node-gyp/VS) is not yet working;
-    # don't let it block the macOS/Linux installers. Tracked as a follow-up.
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     # Hard cap so a stuck native build can never run for hours.
     timeout-minutes: 30
     env:

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -52,15 +52,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # macOS is built PER ARCH on a matching-arch runner, because the native
-          # modules ship as extraResources (copied verbatim, not arch-split): a
-          # single arm64 runner would otherwise put an arm64 better_sqlite3.node
-          # into the x64 DMG and crash on Intel Macs. macos-latest = Apple Silicon,
-          # macos-13 = Intel.
+          # macOS is Apple Silicon (arm64) only for v1 — see the rationale in
+          # desktop/electron-builder.yml (extraResources can't be arch-split, and
+          # Intel runners queue for hours). Intel x64 is a tracked follow-up.
           - os: macos-latest
             args: --mac --arm64
-          - os: macos-13
-            args: --mac --x64
           - os: windows-latest
             args: --win
           # Linux is best-effort for now: AppImage/deb are built + uploaded but

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -132,25 +132,25 @@ jobs:
         working-directory: desktop
         run: npm ci
 
-      # better-sqlite3/argon2/sharp ship in middleware/node_modules built for the
-      # system Node ABI; the kernel runs under Electron's Node (ELECTRON_RUN_AS_NODE)
-      # so they must be rebuilt against Electron's ABI before staging. electron-builder
-      # rebuilds the APP's own deps but NOT extraResources, so we do it here.
-      - name: Rebuild middleware native modules for Electron
-        working-directory: desktop
-        # Pin the Electron version explicitly: electron-rebuild's auto-detection
-        # is unreliable across the --module-dir boundary (electron lives in
-        # desktop/, the modules in middleware/), and a wrong-ABI rebuild fails
-        # silently until the kernel won't boot.
+      # Make the middleware's native modules load under Electron's Node (the kernel
+      # runs via ELECTRON_RUN_AS_NODE). argon2 + sharp are N-API → ABI-stable across
+      # node/electron, so their shipped binaries already work, no rebuild needed.
+      # Only better-sqlite3 (non-N-API) needs an Electron-ABI build — and it
+      # publishes Electron PREBUILDS, so fetch one with prebuild-install (no
+      # node-gyp / Visual Studio). Fall back to a source rebuild if no prebuild
+      # exists for this Electron version on this platform.
+      - name: Provision better-sqlite3 for Electron
+        shell: bash
         run: |
-          EV="$(node -p "require('electron/package.json').version")"
-          echo "rebuilding middleware native modules for Electron $EV"
-          npx electron-rebuild --version "$EV" --module-dir ../middleware \
-            --only better-sqlite3,argon2,sharp --force
-          # Real ABI check: load a rebuilt native module under Electron's own Node
-          # runtime. If the rebuild targeted the wrong ABI this require() throws.
-          ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron -e \
-            "require('../middleware/node_modules/better-sqlite3'); console.log('native modules load under Electron ABI OK')"
+          EV="$(node -p "require('./desktop/node_modules/electron/package.json').version")"
+          echo "provisioning better-sqlite3 for Electron $EV"
+          ( cd middleware/node_modules/better-sqlite3 \
+            && npx --yes prebuild-install -r electron -t "$EV" --verbose ) \
+          || ( cd desktop \
+            && npx electron-rebuild --version "$EV" --module-dir ../middleware --only better-sqlite3 --force )
+          # Verify it loads under Electron's ABI.
+          ELECTRON_RUN_AS_NODE=1 ./desktop/node_modules/.bin/electron -e \
+            "require('./middleware/node_modules/better-sqlite3'); console.log('better-sqlite3 loads under Electron ABI OK')"
 
       - name: Build desktop (main + preload + renderer)
         working-directory: desktop

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -145,9 +145,13 @@ jobs:
             && npx --yes prebuild-install -r electron -t "$EV" --verbose ) \
           || ( cd desktop \
             && npx electron-rebuild --version "$EV" --module-dir ../middleware --only better-sqlite3 --force )
-          # Verify it loads under Electron's ABI.
+          # Verify ALL three native modules actually load under Electron's runtime
+          # — not just the rebuilt better-sqlite3, but also argon2 + sharp, whose
+          # (un-rebuilt) prebuilds we ASSUME are N-API/ABI-stable. If that
+          # assumption is wrong, this fails here instead of crashing the kernel at
+          # boot in the shipped app.
           ELECTRON_RUN_AS_NODE=1 ./desktop/node_modules/.bin/electron -e \
-            "require('./middleware/node_modules/better-sqlite3'); console.log('better-sqlite3 loads under Electron ABI OK')"
+            "require('./middleware/node_modules/better-sqlite3'); require('./middleware/node_modules/argon2'); require('./middleware/node_modules/sharp'); console.log('better-sqlite3 + argon2 + sharp load under Electron ABI OK')"
 
       - name: Build desktop (main + preload + renderer)
         working-directory: desktop

--- a/desktop/buildResources/afterPack.js
+++ b/desktop/buildResources/afterPack.js
@@ -1,0 +1,110 @@
+// electron-builder afterPack hook — sign the native Mach-O binaries that ship
+// as extraResources (the staged middleware's node_modules: better-sqlite3,
+// argon2, sharp, and any nested .dylib).
+//
+// WHY: electron-builder signs the app bundle + its OWN dependencies, but it does
+// NOT sign extraResources payloads. Under `hardenedRuntime: true` + notarization,
+// Apple's notary service rejects bundles that contain unsigned Mach-O binaries
+// (and hardened-runtime library validation refuses to load unsigned .node at
+// runtime). We must sign these BEFORE electron-builder seals the outer app, so
+// afterPack (post-pack, pre-sign) is the correct hook — the outer signature then
+// records the now-signed nested binaries.
+//
+// Fail-soft: if no Developer ID identity is available (unsigned/local build), it
+// logs and skips, so dev/ad-hoc builds still work.
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * Resolves the Developer ID Application identity to sign with.
+ *
+ * Prefers an explicit `MAC_SIGN_IDENTITY` env (set by CI) so we don't depend on
+ * electron-builder's temporary keychain already existing when afterPack runs;
+ * falls back to scanning the keychain via `security find-identity`.
+ */
+function findIdentity() {
+  const fromEnv = (process.env.MAC_SIGN_IDENTITY || '').trim();
+  if (fromEnv) return fromEnv;
+  try {
+    const out = execFileSync('security', ['find-identity', '-v', '-p', 'codesigning'], {
+      encoding: 'utf8',
+    });
+    const m = out.match(/"(Developer ID Application:[^"]+)"/);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+function collectMachO(dir, found) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir);
+  } catch {
+    return found;
+  }
+  for (const name of entries) {
+    const p = path.join(dir, name);
+    let st;
+    try {
+      // statSync FOLLOWS symlinks, so symlinked vendor dirs (e.g. sharp's libvips)
+      // get walked and symlinked .dylibs resolve to their real target — which we
+      // dedupe so we sign each Mach-O once. lstat-based walks miss these and ship
+      // them unsigned, which the verify gate (find follows them) would then fail.
+      st = fs.statSync(p);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      collectMachO(p, found);
+    } else if (st.isFile() && (name.endsWith('.node') || name.endsWith('.dylib'))) {
+      try {
+        found.add(fs.realpathSync(p));
+      } catch {
+        found.add(p);
+      }
+    }
+  }
+  return found;
+}
+
+exports.default = async function afterPack(context) {
+  if (context.electronPlatformName !== 'darwin') return;
+
+  const identity = findIdentity();
+  if (!identity) {
+    // With signing secrets present (MAC_SIGN_EXPECTED=1) a missing identity is a
+    // HARD error — silently shipping unsigned nested modules would only fail
+    // later at notarization. Without secrets, this is the legitimate unsigned
+    // (dev / ad-hoc) path, so we skip.
+    if (process.env.MAC_SIGN_EXPECTED === '1') {
+      throw new Error(
+        '[afterPack] signing was expected (MAC_SIGN_EXPECTED=1) but no Developer ID ' +
+          'Application identity is available — the signing keychain was not set up ' +
+          'before packaging. Refusing to ship unsigned native modules.',
+      );
+    }
+    console.log('[afterPack] no Developer ID identity — skipping nested signing (unsigned build).');
+    return;
+  }
+
+  const appName = `${context.packager.appInfo.productFilename}.app`;
+  const omadiaResources = path.join(context.appOutDir, appName, 'Contents', 'Resources', 'omadia');
+  const targets = [...collectMachO(omadiaResources, new Set())];
+  if (targets.length === 0) {
+    console.log('[afterPack] no nested Mach-O binaries found under extraResources.');
+    return;
+  }
+
+  const keychain = (process.env.MAC_SIGN_KEYCHAIN || '').trim();
+  const args = ['--force', '--options', 'runtime', '--timestamp'];
+  if (keychain) args.push('--keychain', keychain);
+  args.push('--sign', identity);
+
+  console.log(`[afterPack] signing ${targets.length} nested Mach-O binaries with "${identity}"`);
+  for (const target of targets) {
+    execFileSync('codesign', [...args, target], { stdio: 'inherit' });
+  }
+};

--- a/desktop/buildResources/afterPack.js
+++ b/desktop/buildResources/afterPack.js
@@ -38,6 +38,26 @@ function findIdentity() {
   }
 }
 
+// Mach-O magic numbers (first 4 bytes). Detecting by magic — not by extension —
+// is required because the bundled Postgres binaries (postgres, initdb, pg_ctl …)
+// are Mach-O EXECUTABLES with no extension, alongside the .node/.dylib modules.
+const MACHO_MAGIC = new Set([0xfeedface, 0xfeedfacf, 0xcafebabe, 0xcefaedfe, 0xcffaedfe, 0xbebafeca]);
+
+function isMachO(file) {
+  let fd;
+  try {
+    fd = fs.openSync(file, 'r');
+    const buf = Buffer.alloc(4);
+    const n = fs.readSync(fd, buf, 0, 4, 0);
+    if (n < 4) return false;
+    return MACHO_MAGIC.has(buf.readUInt32BE(0)) || MACHO_MAGIC.has(buf.readUInt32LE(0));
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
+}
+
 function collectMachO(dir, found) {
   let entries;
   try {
@@ -59,7 +79,7 @@ function collectMachO(dir, found) {
     }
     if (st.isDirectory()) {
       collectMachO(p, found);
-    } else if (st.isFile() && (name.endsWith('.node') || name.endsWith('.dylib'))) {
+    } else if (st.isFile() && isMachO(p)) {
       try {
         found.add(fs.realpathSync(p));
       } catch {
@@ -91,8 +111,13 @@ exports.default = async function afterPack(context) {
   }
 
   const appName = `${context.packager.appInfo.productFilename}.app`;
-  const omadiaResources = path.join(context.appOutDir, appName, 'Contents', 'Resources', 'omadia');
-  const targets = [...collectMachO(omadiaResources, new Set())];
+  const resources = path.join(context.appOutDir, appName, 'Contents', 'Resources');
+  // Sign Mach-O in BOTH staged extraResources trees: the middleware native
+  // modules (omadia/) and the bundled Postgres engine (omadia-pg/).
+  const found = new Set();
+  collectMachO(path.join(resources, 'omadia'), found);
+  collectMachO(path.join(resources, 'omadia-pg'), found);
+  const targets = [...found];
   if (targets.length === 0) {
     console.log('[afterPack] no nested Mach-O binaries found under extraResources.');
     return;

--- a/desktop/buildResources/entitlements.mac.plist
+++ b/desktop/buildResources/entitlements.mac.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Electron + a forked Node kernel need JIT/unsigned-executable-memory under
+       the hardened runtime. PGlite is WASM (no native JIT) but the bundled
+       V8/Node still requires these. -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <!-- Outbound network: BYO LLM key calls + optional model/asset downloads.
+       No inbound server entitlement needed (loopback only). -->
+  <key>com.apple.security.network.client</key>
+  <true/>
+</dict>
+</plist>

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -17,7 +17,7 @@ copyright: Copyright © 2026 byte5 GmbH
 
 directories:
   output: release
-  buildResources: build
+  buildResources: buildResources
 
 # Only the compiled desktop app + its own node_modules go into the app bundle.
 files:
@@ -42,20 +42,23 @@ asarUnpack:
 # Sign the native Mach-O binaries inside the staged middleware (extraResources)
 # BEFORE the outer app is signed — electron-builder does not sign extraResources,
 # and notarization rejects unsigned nested Mach-O. Fail-soft when unsigned.
-afterPack: build/afterPack.js
+afterPack: buildResources/afterPack.js
 
 mac:
   category: public.app-category.developer-tools
   hardenedRuntime: true
   gatekeeperAssess: false
-  entitlements: build/entitlements.mac.plist
-  entitlementsInherit: build/entitlements.mac.plist
+  entitlements: buildResources/entitlements.mac.plist
+  entitlementsInherit: buildResources/entitlements.mac.plist
   target:
     - target: dmg
       arch: [arm64, x64]
     - target: zip          # required by electron-updater on macOS
       arch: [arm64, x64]
-  notarize: false          # flip to true in CI once APPLE_* secrets are set
+  # Notarization is left unset here so it's driven entirely by CI: the workflow
+  # adds `--config.mac.notarize=true` only when the Apple secrets are present
+  # (and electron-builder skips it without notary credentials). A hard-coded
+  # `notarize: false` here would fight that CLI override.
 
 dmg:
   title: ${productName} ${version}

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -50,11 +50,16 @@ mac:
   gatekeeperAssess: false
   entitlements: buildResources/entitlements.mac.plist
   entitlementsInherit: buildResources/entitlements.mac.plist
+  # Apple Silicon only for v1. The native modules ship as extraResources (copied
+  # verbatim, not arch-split), and GitHub's Intel (macos-13) runners queue for
+  # hours — impractical for a release. An x64 DMG built on an arm64 runner would
+  # contain arm64 native modules and crash on Intel. Intel support is a follow-up
+  # (cross-compile x64 prebuilds on the arm64 runner into a second staged tree).
   target:
     - target: dmg
-      arch: [arm64, x64]
+      arch: [arm64]
     - target: zip          # required by electron-updater on macOS
-      arch: [arm64, x64]
+      arch: [arm64]
   # Notarization is left unset here so it's driven entirely by CI: the workflow
   # adds `--config.mac.notarize=true` only when the Apple secrets are present
   # (and electron-builder skips it without notary credentials). A hard-coded

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -20,24 +20,27 @@ directories:
   buildResources: buildResources
 
 # Only the compiled desktop app + its own node_modules go into the app bundle.
+# The ~130MB Postgres engine ships via extraResources (staged to runtime/omadia-pg),
+# so exclude its node_modules copy to avoid duplicating it inside the asar.
 files:
   - dist/**/*
   - package.json
   - "!**/*.map"
+  - "!**/node_modules/@embedded-postgres/**"
+  - "!**/node_modules/embedded-postgres/**"
 
-# The omadia stack lives outside the asar so child processes can execute it and
-# PGlite can memory-map its WASM. These paths are produced by `scripts/stage-runtime.mjs`
-# (run before electron-builder) which copies the built middleware + web-ui here.
+# The omadia stack lives outside the asar so child processes can execute it. These
+# paths are produced by `scripts/stage-runtime.mjs` (run before electron-builder),
+# which copies the built middleware + web-ui + the bundled Postgres engine here.
 extraResources:
   - from: runtime/middleware
     to: omadia/middleware
   - from: runtime/web-ui
     to: omadia/web-ui
+  - from: runtime/omadia-pg
+    to: omadia-pg
 
 asar: true
-# pglite ships a .wasm + .data that must stay on disk, not inside asar.
-asarUnpack:
-  - "**/node_modules/@electric-sql/**"
 
 # Sign the native Mach-O binaries inside the staged middleware (extraResources)
 # BEFORE the outer app is signed — electron-builder does not sign extraResources,

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -9,13 +9,14 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@electric-sql/pglite": "0.3.4",
-        "@electric-sql/pglite-socket": "^0.0.9",
-        "electron-updater": "^6.3.9"
+        "electron-updater": "^6.3.9",
+        "embedded-postgres": "^17.10.0-beta.17",
+        "pg": "^8.13.0"
       },
       "devDependencies": {
         "@electron/rebuild": "3.6.1",
         "@types/node": "^22.10.0",
+        "@types/pg": "^8.11.10",
         "electron": "^37.2.0",
         "electron-builder": "^25.1.8",
         "typescript": "^5.7.2"
@@ -37,24 +38,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/@electric-sql/pglite": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.4.tgz",
-      "integrity": "sha512-h5hoL2GuxcWN8Q3+jtesIRem14iIvAZVEsTeUF6eO9RiUb6ar73QVIEW9t+Ud58iXAcAE2dFMtWqw3W2Oo4LDw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@electric-sql/pglite-socket": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.0.9.tgz",
-      "integrity": "sha512-vB/FlCxkua6qzBIHMmZZY/uY8yZy89PlLiJ8YpbFr4+hxDCpe8wHL1uIP+Y2MWX87jQN5LcYqje6yNZ/8ZK3IA==",
-      "license": "Apache-2.0",
-      "bin": {
-        "pglite-server": "dist/scripts/server.js"
-      },
-      "peerDependencies": {
-        "@electric-sql/pglite": "0.3.4"
       }
     },
     "node_modules/@electron/asar": {
@@ -333,6 +316,142 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@embedded-postgres/darwin-arm64": {
+      "version": "17.10.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/darwin-arm64/-/darwin-arm64-17.10.0-beta.17.tgz",
+      "integrity": "sha512-E2dxhSllrcyAJBHuvgTrBTx2BaPlX2vvjXClPKHxfwBezk+nTZ01uAEraKiRJMpzHSCyN8J1dTjKh4q/uTsBLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/darwin-x64": {
+      "version": "17.10.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/darwin-x64/-/darwin-x64-17.10.0-beta.17.tgz",
+      "integrity": "sha512-gXk65MIyttD/PWo6NDSmu/n4vzPcqZQmxVWjEKuecwlyGmWO984AZ3Ljb7F0bwPvXhqcovH4FGN4ydr0fGeJxg==",
+      "cpu": [
+        "x64"
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-arm": {
+      "version": "17.10.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-arm/-/linux-arm-17.10.0-beta.17.tgz",
+      "integrity": "sha512-XQrRydqjgPrvvCKF1PrLvMljMbeXXT4GbB70+z7viqUWg3bgq31nGMkupa2TXHLqRnfmEhz1u3gn3xgQIphLZQ==",
+      "cpu": [
+        "arm"
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-arm64": {
+      "version": "17.10.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-arm64/-/linux-arm64-17.10.0-beta.17.tgz",
+      "integrity": "sha512-mC+bQvaBEf0WDD0nPWW3eGUXDUVzoyCzMtgl+Fw6Jy9DkQFK+jcPtzkzqhhrS/fGzn5telNpKInl8xPqDh71Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-ia32": {
+      "version": "17.10.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-ia32/-/linux-ia32-17.10.0-beta.17.tgz",
+      "integrity": "sha512-ck2QlYCPmmNRJotXp0cJnnB5Yn/bk89qT3cjVCxUfkS1b/56Odu9ID6zvAYFebvYeHU69UwOEbplikV4saRYWw==",
+      "cpu": [
+        "ia32"
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-ppc64": {
+      "version": "17.10.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-ppc64/-/linux-ppc64-17.10.0-beta.17.tgz",
+      "integrity": "sha512-+Mb0E41rvlwBhAV11eZf51rlxSHA8ancPHPFxhyljg+ZJ62QB1YryBf+rIkphpG2bnt4aJwxd1JOUk3PonlrLA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-x64": {
+      "version": "17.10.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-x64/-/linux-x64-17.10.0-beta.17.tgz",
+      "integrity": "sha512-hU4Sgna19ixDP/l3P/zkHhQ9B0JDV39qA97RNz55QcngeRjFC5/1G36LZjODVJ84kVJHUTQMmly7nzWO8js8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/windows-x64": {
+      "version": "17.10.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/windows-x64/-/windows-x64-17.10.0-beta.17.tgz",
+      "integrity": "sha512-q6xIETTkv67i1QlTWz1LAKb3Z+vG2V3qrp+BjLEWhCQ9jE4hbbsQ/J/3wiOPFLJbuwak7CfHC9EUJG7txAbGKw==",
+      "cpu": [
+        "x64"
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@gar/promisify": {
@@ -641,6 +760,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/plist": {
@@ -993,7 +1124,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
       "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -2097,6 +2227,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/embedded-postgres": {
+      "version": "17.10.0-beta.17",
+      "resolved": "https://registry.npmjs.org/embedded-postgres/-/embedded-postgres-17.10.0-beta.17.tgz",
+      "integrity": "sha512-s9ITJA41OTIQmn91RLqQ5X2MVP2BCZ8pb4tQX3MY8VOd8xNCzzlgfHGcXuitDzK800FhbG/3YufFk21KTTvpzA==",
+      "license": "MIT",
+      "dependencies": {
+        "async-exit-hook": "^2.0.1",
+        "pg": "^8.7.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@embedded-postgres/darwin-arm64": "^17.10.0-beta.17",
+        "@embedded-postgres/darwin-x64": "^17.10.0-beta.17",
+        "@embedded-postgres/linux-arm": "^17.10.0-beta.17",
+        "@embedded-postgres/linux-arm64": "^17.10.0-beta.17",
+        "@embedded-postgres/linux-ia32": "^17.10.0-beta.17",
+        "@embedded-postgres/linux-ppc64": "^17.10.0-beta.17",
+        "@embedded-postgres/linux-x64": "^17.10.0-beta.17",
+        "@embedded-postgres/windows-x64": "^17.10.0-beta.17"
       }
     },
     "node_modules/emoji-regex": {
@@ -3863,6 +4016,95 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3883,6 +4125,45 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -4364,6 +4645,15 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -4781,6 +5071,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -14,6 +14,7 @@
         "electron-updater": "^6.3.9"
       },
       "devDependencies": {
+        "@electron/rebuild": "3.6.1",
         "@types/node": "^22.10.0",
         "electron": "^37.2.0",
         "electron-builder": "^25.1.8",
@@ -127,6 +128,51 @@
         "global-agent": "^3.0.0"
       }
     },
+    "node_modules/@electron/get/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@electron/get/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@electron/get/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/@electron/notarize": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
@@ -158,29 +204,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@electron/notarize/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/notarize/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@electron/osx-sign": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.1.tgz",
@@ -203,21 +226,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@electron/osx-sign/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
@@ -229,29 +237,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/gjtorikian/"
-      }
-    },
-    "node_modules/@electron/osx-sign/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/osx-sign/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@electron/rebuild": {
@@ -281,57 +266,6 @@
       },
       "engines": {
         "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@electron/rebuild/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@electron/rebuild/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/rebuild/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@electron/rebuild/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@electron/universal": {
@@ -385,19 +319,6 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/@electron/universal/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/@electron/universal/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -412,16 +333,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@electron/universal/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -589,29 +500,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@malept/flatpak-bundler/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@malept/flatpak-bundler/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@npmcli/fs": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
@@ -624,19 +512,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@npmcli/fs/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@npmcli/move-file": {
@@ -978,57 +853,6 @@
         "electron-builder-squirrel-windows": "25.1.8"
       }
     },
-    "node_modules/app-builder-lib/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/aproba": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
@@ -1353,44 +1177,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/builder-util/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/builder-util/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/builder-util/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/cacache": {
@@ -2103,44 +1889,6 @@
         "dmg-license": "^1.0.11"
       }
     },
-    "node_modules/dmg-builder/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/dmg-builder/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/dmg-builder/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/dmg-license": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
@@ -2294,85 +2042,6 @@
         "fs-extra": "^10.1.0"
       }
     },
-    "node_modules/electron-builder-squirrel-windows/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/electron-builder-squirrel-windows/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/electron-builder-squirrel-windows/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/electron-builder/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/electron-builder/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/electron-builder/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/electron-publish": {
       "version": "25.1.7",
       "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-25.1.7.tgz",
@@ -2387,44 +2056,6 @@
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "mime": "^2.5.2"
-      }
-    },
-    "node_modules/electron-publish/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/electron-publish/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/electron-publish/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/electron-updater": {
@@ -2456,32 +2087,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/electron-updater/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/electron-updater/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/electron-updater/node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -2492,15 +2097,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/electron-updater/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -2788,18 +2384,17 @@
       "peer": true
     },
     "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
+        "node": ">=12"
       }
     },
     "node_modules/fs-minipass": {
@@ -2988,20 +2583,6 @@
       },
       "engines": {
         "node": ">=10.0"
-      }
-    },
-    "node_modules/global-agent/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/globalthis": {
@@ -3493,11 +3074,13 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3993,19 +3576,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/node-abi/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/node-addon-api": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
@@ -4022,19 +3592,6 @@
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
-      }
-    },
-    "node_modules/node-api-version/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/node-gyp": {
@@ -4061,19 +3618,6 @@
       },
       "engines": {
         "node": "^12.13 || ^14.13 || >=16"
-      }
-    },
-    "node_modules/node-gyp/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/nopt": {
@@ -4642,13 +4186,16 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver-compare": {
@@ -4721,19 +4268,6 @@
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/simple-update-notifier/node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
@@ -5013,44 +4547,6 @@
         "fs-extra": "^10.0.0"
       }
     },
-    "node_modules/temp-file/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/temp-file/node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/temp-file/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/tiny-typed-emitter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
@@ -5149,13 +4645,12 @@
       }
     },
     "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "license": "MIT",
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/uri-js": {

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -19,6 +19,7 @@
         "@types/pg": "^8.11.10",
         "electron": "^37.2.0",
         "electron-builder": "^25.1.8",
+        "esbuild": "^0.28.0",
         "typescript": "^5.7.2"
       }
     },
@@ -452,6 +453,448 @@
       ],
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@gar/promisify": {
@@ -2353,6 +2796,48 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -25,13 +25,14 @@
     "pack:all": "npm run build && npm run stage && electron-builder --mac --win --publish never"
   },
   "dependencies": {
-    "@electric-sql/pglite": "0.3.4",
-    "@electric-sql/pglite-socket": "^0.0.9",
-    "electron-updater": "^6.3.9"
+    "electron-updater": "^6.3.9",
+    "embedded-postgres": "^17.10.0-beta.17",
+    "pg": "^8.13.0"
   },
   "devDependencies": {
     "@electron/rebuild": "3.6.1",
     "@types/node": "^22.10.0",
+    "@types/pg": "^8.11.10",
     "electron": "^37.2.0",
     "electron-builder": "^25.1.8",
     "typescript": "^5.7.2"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -15,7 +15,7 @@
   },
   "main": "dist/main.js",
   "scripts": {
-    "build": "tsc -p tsconfig.json && node scripts/copy-renderer.mjs",
+    "build": "tsc -p tsconfig.json && node scripts/bundle-preload.mjs && node scripts/copy-renderer.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "stage": "node scripts/stage-runtime.mjs",
     "start": "npm run build && electron .",
@@ -35,6 +35,7 @@
     "@types/pg": "^8.11.10",
     "electron": "^37.2.0",
     "electron-builder": "^25.1.8",
+    "esbuild": "^0.28.0",
     "typescript": "^5.7.2"
   }
 }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -3,8 +3,16 @@
   "version": "0.1.0",
   "private": true,
   "description": "omadia native desktop installer — runs the full omadia stack locally with an embedded Postgres+pgvector engine, no Docker.",
-  "author": "byte5 GmbH",
+  "author": {
+    "name": "byte5 GmbH",
+    "email": "mwege@byte5.de"
+  },
   "license": "Apache-2.0",
+  "homepage": "https://github.com/byte5ai/omadia",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/byte5ai/omadia.git"
+  },
   "main": "dist/main.js",
   "scripts": {
     "build": "tsc -p tsconfig.json && node scripts/copy-renderer.mjs",
@@ -22,7 +30,7 @@
     "electron-updater": "^6.3.9"
   },
   "devDependencies": {
-    "@electron/rebuild": "^3.7.1",
+    "@electron/rebuild": "3.6.1",
     "@types/node": "^22.10.0",
     "electron": "^37.2.0",
     "electron-builder": "^25.1.8",

--- a/desktop/scripts/bundle-preload.mjs
+++ b/desktop/scripts/bundle-preload.mjs
@@ -1,0 +1,33 @@
+// Bundles the preload into a single self-contained dist/preload.js.
+//
+// WHY: the BrowserWindow runs with `sandbox: true` (main.ts). A sandboxed
+// preload only gets a limited `require` (electron + a small polyfill set) — it
+// CANNOT `require('./ipcTypes')` or any other local module. tsc emits a preload
+// that does exactly that, so the script fails to load with
+// "Error: module not found: ./ipcTypes", `window.omadia` is never exposed, and
+// every wizard/loading bridge call silently hangs (key test stuck on "Testing…",
+// folder picker never opens, completion stalls).
+//
+// esbuild inlines the local imports (ipcTypes constants + erased types) into one
+// file with `electron` left external (provided by the runtime), so the preload
+// loads cleanly under the sandbox while keeping a single source of truth for the
+// channel names. Runs AFTER tsc (overwriting tsc's broken dist/preload.js).
+import { build } from 'esbuild';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+await build({
+  entryPoints: [path.join(here, '..', 'src', 'preload.ts')],
+  outfile: path.join(here, '..', 'dist', 'preload.js'),
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  target: 'node22',
+  external: ['electron'],
+  sourcemap: false,
+  logLevel: 'warning',
+});
+
+console.log('[bundle-preload] dist/preload.js bundled (self-contained, sandbox-safe)');

--- a/desktop/scripts/stage-runtime.mjs
+++ b/desktop/scripts/stage-runtime.mjs
@@ -99,30 +99,30 @@ requireDir(
 const stagedPg = path.join(runtime, 'omadia-pg');
 fs.cpSync(pgNative, stagedPg, { recursive: true, dereference: true });
 
-// fs.cpSync({dereference:true}) does NOT preserve the engine's RELATIVE same-dir
-// symlinks (e.g. libicudata.68.dylib -> libicudata.68.2.dylib). It rewrites them
-// into ABSOLUTE links pointing at THIS build machine's node_modules. They resolve
-// on the build box (so a local build boots — masking the bug) but DANGLE anywhere
-// else: on CI the link targets `/Users/runner/work/...`, so dyld can't find
-// `@loader_path/../lib/libicudata.68.dylib` and initdb/postgres fail to launch.
-// Restore the engine's own relative symlinks verbatim from the source tree so the
-// dylib chain resolves wherever the installer lands. (All source links are
-// relative + in-tree — verified — so copying their readlink value is sufficient.)
+// The @embedded-postgres tarball ships ZERO real symlinks — it records the
+// engine's intra-lib links (e.g. libicudata.68.dylib -> libicudata.68.2.dylib) in
+// pg-symlinks.json and its postinstall materialises them. cpSync({dereference:true})
+// then turns whatever real symlinks exist into ABSOLUTE links pointing at THIS
+// build machine's node_modules: they resolve on the build box (so a local build
+// boots — masking the bug) but DANGLE anywhere else (CI: `/Users/runner/work/...`),
+// so dyld/ld.so can't find `@loader_path/../lib/libicudata.68.dylib` and
+// initdb/postgres fail to launch. Recreate the links RELATIVE + in-tree straight
+// from the manifest — independent of whether postinstall ran — so the dylib chain
+// resolves wherever the installer lands. (Windows manifest is empty: flat DLLs.)
 let relinked = 0;
-const restoreLinks = (srcDir) => {
-  for (const ent of fs.readdirSync(srcDir, { withFileTypes: true })) {
-    const src = path.join(srcDir, ent.name);
-    if (ent.isSymbolicLink()) {
-      const dest = path.join(stagedPg, path.relative(pgNative, src));
-      fs.rmSync(dest, { force: true, recursive: true });
-      fs.symlinkSync(fs.readlinkSync(src), dest);
-      relinked++;
-    } else if (ent.isDirectory()) {
-      restoreLinks(src);
-    }
+const manifest = path.join(pgNative, 'pg-symlinks.json');
+if (fs.existsSync(manifest)) {
+  const stripNative = (p) => p.replace(/^native[\\/]/, '');
+  for (const { source, target } of JSON.parse(fs.readFileSync(manifest, 'utf8'))) {
+    const realFile = path.join(stagedPg, stripNative(source));
+    const linkPath = path.join(stagedPg, stripNative(target));
+    if (!fs.existsSync(realFile)) continue; // nothing to point at — skip silently
+    fs.rmSync(linkPath, { force: true, recursive: true });
+    fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+    fs.symlinkSync(path.relative(path.dirname(linkPath), realFile), linkPath);
+    relinked++;
   }
-};
-restoreLinks(pgNative);
+}
 console.log(`[stage-runtime] restored ${relinked} relative symlink(s) in the Postgres engine`);
 
 // Sanity: pgvector must have been FULLY provisioned into the engine (CI step) —
@@ -130,12 +130,16 @@ console.log(`[stage-runtime] restored ${relinked} relative symlink(s) in the Pos
 // control descriptor, the loadable module, and at least one install SQL script.
 // Checking only vector.control would let a half-copied payload pass staging and
 // fail at runtime when the first migration runs `CREATE EXTENSION vector`.
-const extDir = path.join(runtime, 'omadia-pg', 'share', 'postgresql', 'extension');
-const libDir = path.join(runtime, 'omadia-pg', 'lib', 'postgresql');
+// Layout differs by platform: Windows keeps extension modules flat in lib/ and
+// control/SQL in share/extension/; macOS + Linux nest them under postgresql/.
+const isWin = process.platform === 'win32';
+const extDir = path.join(stagedPg, 'share', ...(isWin ? ['extension'] : ['postgresql', 'extension']));
+const libDir = path.join(stagedPg, 'lib', ...(isWin ? [] : ['postgresql']));
 const moduleName = { win32: 'vector.dll', darwin: 'vector.dylib' }[process.platform] ?? 'vector.so';
+const relLib = path.relative(stagedPg, path.join(libDir, moduleName));
 const missing = [];
 if (!fs.existsSync(path.join(extDir, 'vector.control'))) missing.push('share/.../vector.control');
-if (!fs.existsSync(path.join(libDir, moduleName))) missing.push(`lib/postgresql/${moduleName}`);
+if (!fs.existsSync(path.join(libDir, moduleName))) missing.push(relLib);
 const hasInstallSql =
   fs.existsSync(extDir) && fs.readdirSync(extDir).some((f) => /^vector--.*\.sql$/.test(f));
 if (!hasInstallSql) missing.push('share/.../vector--*.sql');

--- a/desktop/scripts/stage-runtime.mjs
+++ b/desktop/scripts/stage-runtime.mjs
@@ -43,6 +43,34 @@ for (const entry of ['dist', 'node_modules', 'packages', 'migrations', 'assets',
   const to = path.join(mwDest, entry);
   fs.cpSync(from, to, { recursive: true, dereference: true });
 }
+
+// fs.cpSync({dereference:true}) does NOT reliably materialise the npm-workspace
+// symlinks `node_modules/@omadia/* → packages/*` — on CI runners they're ABSOLUTE
+// (`/Users/runner/.../packages/x`), so the shipped bundle ends up with DANGLING
+// symlinks to the build machine and the kernel can't resolve any @omadia/* package
+// at runtime (ERR_MODULE_NOT_FOUND → kernel crash). Replace each @omadia symlink
+// with a real copy of the package it resolves to. (Each package's own nested
+// @omadia symlinks may stay dangling but are unused: Node resolves up to this
+// top-level real dir.)
+const scope = path.join(mwDest, 'node_modules', '@omadia');
+if (fs.existsSync(scope)) {
+  let materialised = 0;
+  for (const name of fs.readdirSync(scope)) {
+    const link = path.join(scope, name);
+    if (!fs.lstatSync(link).isSymbolicLink()) continue;
+    let target;
+    try {
+      target = fs.realpathSync(link);
+    } catch {
+      console.error(`[stage-runtime] FATAL: dangling @omadia/${name} symlink — build the middleware first`);
+      process.exit(1);
+    }
+    fs.rmSync(link, { force: true });
+    fs.cpSync(target, link, { recursive: true });
+    materialised++;
+  }
+  console.log(`[stage-runtime] materialised ${materialised} @omadia workspace package(s)`);
+}
 console.log('[stage-runtime] staged middleware');
 
 // --- web-ui: flatten the Next standalone output into runtime/web-ui ---

--- a/desktop/scripts/stage-runtime.mjs
+++ b/desktop/scripts/stage-runtime.mjs
@@ -96,7 +96,35 @@ requireDir(
   pgNative,
   `install embedded-postgres so the @embedded-postgres/${pgPlat} binary is present`,
 );
-fs.cpSync(pgNative, path.join(runtime, 'omadia-pg'), { recursive: true, dereference: true });
+const stagedPg = path.join(runtime, 'omadia-pg');
+fs.cpSync(pgNative, stagedPg, { recursive: true, dereference: true });
+
+// fs.cpSync({dereference:true}) does NOT preserve the engine's RELATIVE same-dir
+// symlinks (e.g. libicudata.68.dylib -> libicudata.68.2.dylib). It rewrites them
+// into ABSOLUTE links pointing at THIS build machine's node_modules. They resolve
+// on the build box (so a local build boots — masking the bug) but DANGLE anywhere
+// else: on CI the link targets `/Users/runner/work/...`, so dyld can't find
+// `@loader_path/../lib/libicudata.68.dylib` and initdb/postgres fail to launch.
+// Restore the engine's own relative symlinks verbatim from the source tree so the
+// dylib chain resolves wherever the installer lands. (All source links are
+// relative + in-tree — verified — so copying their readlink value is sufficient.)
+let relinked = 0;
+const restoreLinks = (srcDir) => {
+  for (const ent of fs.readdirSync(srcDir, { withFileTypes: true })) {
+    const src = path.join(srcDir, ent.name);
+    if (ent.isSymbolicLink()) {
+      const dest = path.join(stagedPg, path.relative(pgNative, src));
+      fs.rmSync(dest, { force: true, recursive: true });
+      fs.symlinkSync(fs.readlinkSync(src), dest);
+      relinked++;
+    } else if (ent.isDirectory()) {
+      restoreLinks(src);
+    }
+  }
+};
+restoreLinks(pgNative);
+console.log(`[stage-runtime] restored ${relinked} relative symlink(s) in the Postgres engine`);
+
 // Sanity: pgvector must have been FULLY provisioned into the engine (CI step) —
 // not just the control file. `CREATE EXTENSION vector` needs all three: the
 // control descriptor, the loadable module, and at least one install SQL script.

--- a/desktop/scripts/stage-runtime.mjs
+++ b/desktop/scripts/stage-runtime.mjs
@@ -84,4 +84,40 @@ if (fs.existsSync(uiPublic)) {
   fs.cpSync(uiPublic, path.join(uiDest, 'public'), { recursive: true });
 }
 console.log('[stage-runtime] staged web-ui');
+
+// --- embedded Postgres engine: stage the platform's PG binaries (+ pgvector,
+// which CI copies into native/ before staging) into runtime/omadia-pg. The kernel
+// connects to a real bundled PostgreSQL 17; embeddedDb.ts resolves this at
+// resourcesPath/omadia-pg in the packaged app. ---
+const pgOs = process.platform === 'win32' ? 'windows' : process.platform;
+const pgPlat = `${pgOs}-${process.arch}`;
+const pgNative = path.join(here, '..', 'node_modules', '@embedded-postgres', pgPlat, 'native');
+requireDir(
+  pgNative,
+  `install embedded-postgres so the @embedded-postgres/${pgPlat} binary is present`,
+);
+fs.cpSync(pgNative, path.join(runtime, 'omadia-pg'), { recursive: true, dereference: true });
+// Sanity: pgvector must have been FULLY provisioned into the engine (CI step) —
+// not just the control file. `CREATE EXTENSION vector` needs all three: the
+// control descriptor, the loadable module, and at least one install SQL script.
+// Checking only vector.control would let a half-copied payload pass staging and
+// fail at runtime when the first migration runs `CREATE EXTENSION vector`.
+const extDir = path.join(runtime, 'omadia-pg', 'share', 'postgresql', 'extension');
+const libDir = path.join(runtime, 'omadia-pg', 'lib', 'postgresql');
+const moduleName = { win32: 'vector.dll', darwin: 'vector.dylib' }[process.platform] ?? 'vector.so';
+const missing = [];
+if (!fs.existsSync(path.join(extDir, 'vector.control'))) missing.push('share/.../vector.control');
+if (!fs.existsSync(path.join(libDir, moduleName))) missing.push(`lib/postgresql/${moduleName}`);
+const hasInstallSql =
+  fs.existsSync(extDir) && fs.readdirSync(extDir).some((f) => /^vector--.*\.sql$/.test(f));
+if (!hasInstallSql) missing.push('share/.../vector--*.sql');
+if (missing.length) {
+  console.error(
+    `[stage-runtime] FATAL: pgvector not fully provisioned — missing: ${missing.join(', ')}. ` +
+      'CI must place the matching vector.control + module + vector--*.sql into the engine before staging.',
+  );
+  process.exit(1);
+}
+console.log(`[stage-runtime] staged Postgres engine (${pgPlat}) + pgvector (control + ${moduleName} + install SQL)`);
+
 console.log('[stage-runtime] done →', runtime);

--- a/desktop/src/embeddedDb.ts
+++ b/desktop/src/embeddedDb.ts
@@ -1,127 +1,216 @@
-import { PGlite } from '@electric-sql/pglite';
-import { vector } from '@electric-sql/pglite/vector';
-import { PGLiteSocketServer } from '@electric-sql/pglite-socket';
+import { spawn, ChildProcess, execFileSync } from 'node:child_process';
+import { Client } from 'pg';
 import fs from 'node:fs';
 import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { embeddedDbDir, dataRoot, runtimeIsDev } from './paths';
 import { findFreePort, isPortFree } from './ports';
-import { embeddedDbDir, dataRoot } from './paths';
 import { log } from './log';
 
 /**
- * The embedded Postgres engine.
+ * The embedded database engine: a REAL, bundled PostgreSQL 17 + pgvector.
  *
- * This is the piece that dissolves omadia's "postgres+pgvector is the blocker"
- * constraint for a no-Docker install. PGlite is a full Postgres compiled to WASM
- * that runs in-process and persists to disk; the `vector` extension gives us
- * pgvector. We then expose it over the Postgres *wire protocol* on a loopback
- * port via PGLiteSocketServer, so the kernel connects through its existing
- * node-postgres (`pg`) code path with a normal `DATABASE_URL` — zero kernel
- * changes, and all existing SQL migrations run unmodified.
+ * We previously embedded PGlite (Postgres compiled to WASM) over the wire
+ * protocol via pglite-socket. That worked for builds/boot but the WASM engine
+ * crashed (`RuntimeError: unreachable`) under the kernel's real query load, and
+ * pglite-socket is single-connection. A native Postgres removes both problems:
+ * full SQL compatibility (no WASM traps) and real connection pooling.
  *
- * Caveat (documented): PGlite is single-connection. The socket server serializes
- * client connections, so the kernel's pool effectively runs queries one at a
- * time. Acceptable for a single-tenant local install; the fallback if this ever
- * bottlenecks is a bundled native Postgres.
+ * The Postgres server binaries (initdb/postgres) + pgvector ship with the app
+ * (dev: the @embedded-postgres platform package in node_modules; packaged: staged
+ * to `resourcesPath/omadia-pg` as extraResources, so they're executable on disk
+ * — never trapped inside the asar archive). We drive initdb/postgres directly
+ * rather than via the embedded-postgres wrapper, which is asar-unaware.
+ *
+ * The kernel connects over loopback TCP with trust auth (loopback-only; no LAN
+ * exposure). No GRAPH_POOL_MAX=1 cap needed — real Postgres pools normally.
  */
 
-// NOT a credential: pglite-socket on loopback does not authenticate, so these
-// only populate the DATABASE_URL the kernel's pg client expects — any value is
-// accepted. Security rests entirely on the 127.0.0.1-only bind, not on this.
 const DB_NAME = 'omadia';
 const DB_USER = 'omadia';
-const DB_PASSWORD = 'omadia';
+const exe = (name: string): string => (process.platform === 'win32' ? `${name}.exe` : name);
 
 export interface EmbeddedDb {
   /** DATABASE_URL the kernel should use to reach this engine. */
   databaseUrl: string;
   /** The bound loopback port. */
   port: number;
-  /** Snapshot the on-disk data directory (used before applying an app update). */
+  /** Stop the Postgres server. */
   stop(): Promise<void>;
 }
 
-let current: { db: PGlite; server: PGLiteSocketServer; port: number } | null = null;
+let current: { proc: ChildProcess; port: number } | null = null;
+// Set while we are deliberately shutting the server down, so the `exit` handler
+// (registered at spawn) does not misreport an intentional stop as a crash.
+let stopping = false;
 
-export async function startEmbeddedDb(): Promise<EmbeddedDb> {
-  if (current) {
-    return toHandle(current);
-  }
-
-  const dir = embeddedDbDir();
-  log.info(`[db] opening embedded Postgres at ${dir}`);
-  // The kernel's KG migrations require `vector` (pgvector, embedding similarity)
-  // and `pg_trgm` (turn full-text search); both must be registered on the PGlite
-  // instance for the migrations' `CREATE EXTENSION` to succeed. Load + install
-  // them up front, and translate a bundling/staging miss into a clear error
-  // instead of a cryptic module-resolution or mid-migration failure.
-  const msg = (e: unknown): string => (e instanceof Error ? e.message : String(e));
-
-  // A failure to LOAD the extension module is unambiguously a bundling/staging
-  // problem (the package isn't fully shipped) — say so clearly.
-  // pg_trgm's contrib subpath is ESM-only, so load it dynamically (this file
-  // compiles to CommonJS). `vector` ships a CJS build and imports statically.
-  let pg_trgm: unknown;
-  try {
-    ({ pg_trgm } = await import('@electric-sql/pglite/contrib/pg_trgm'));
-  } catch (err) {
-    throw new Error(
-      'Embedded Postgres extension module (pg_trgm) failed to load — the installer ' +
-        `bundle is likely incomplete (@electric-sql/pglite not fully staged). Underlying: ${msg(err)}`,
-      { cause: err },
-    );
-  }
-
-  // Opening the DB can fail for bundling reasons OR storage reasons (unwritable /
-  // corrupt data dir, disk full) — don't pin the blame on the bundle here.
-  let db: PGlite;
-  try {
-    db = await PGlite.create({ dataDir: dir, extensions: { vector, pg_trgm: pg_trgm as never } });
-    await db.exec('CREATE EXTENSION IF NOT EXISTS vector;');
-    await db.exec('CREATE EXTENSION IF NOT EXISTS pg_trgm;');
-  } catch (err) {
-    throw new Error(
-      `Failed to open the embedded Postgres database at ${dir} — this is usually an ` +
-        `incomplete bundle or an unwritable/corrupt data directory. Underlying: ${msg(err)}`,
-      { cause: err },
-    );
-  }
-  // (pgcrypto is intentionally NOT required: the kernel migrations only used it
-  // for gen_random_uuid(), which is core since Postgres 13.)
-
-  // From here on, any failure must close `db` — otherwise the PGlite instance
-  // leaks and keeps the dataDir lock, so a retry can't reopen the same dir.
-  let server: PGLiteSocketServer;
-  let port: number;
-  try {
-    port = await stableDbPort();
-    server = new PGLiteSocketServer({ db, port, host: '127.0.0.1' });
-    await server.start();
-  } catch (err) {
-    await db.close().catch(() => {});
-    throw err;
-  }
-  log.info(`[db] embedded Postgres listening on 127.0.0.1:${port}`);
-
-  current = { db, server, port };
-  return toHandle(current);
+/** @embedded-postgres package name for this platform (win32 → windows). */
+function pgPlatform(): string {
+  const os = process.platform === 'win32' ? 'windows' : process.platform;
+  return `${os}-${process.arch}`;
 }
 
-function toHandle(c: { db: PGlite; server: PGLiteSocketServer; port: number }): EmbeddedDb {
-  const databaseUrl =
-    `postgresql://${DB_USER}:${DB_PASSWORD}@127.0.0.1:${c.port}/${DB_NAME}`;
+/** The staged Postgres "native" dir (contains bin/, lib/, share/). */
+function pgNativeDir(): string {
+  if (runtimeIsDev) {
+    return path.join(__dirname, '..', 'node_modules', '@embedded-postgres', pgPlatform(), 'native');
+  }
+  return path.join(process.resourcesPath, 'omadia-pg');
+}
+
+function pgBin(name: string): string {
+  return path.join(pgNativeDir(), 'bin', exe(name));
+}
+
+export async function startEmbeddedDb(): Promise<EmbeddedDb> {
+  if (current) return toHandle(current.port);
+
+  const dataDir = embeddedDbDir();
+  const nativeDir = pgNativeDir();
+  if (!fs.existsSync(pgBin('postgres'))) {
+    throw new Error(
+      `Embedded Postgres binary not found at ${pgBin('postgres')} — the installer ` +
+        'bundle is incomplete (Postgres engine not staged).',
+    );
+  }
+
+  // First run: initialise the data cluster. `-A trust` (loopback-only) + locale C
+  // (avoids the "no suitable text search config for UTF-8 locale" initdb warning).
+  if (!fs.existsSync(path.join(dataDir, 'PG_VERSION'))) {
+    log.info('[db] initialising embedded Postgres cluster…');
+    const pwFile = path.join(dataDir, '..', '.pg-init-noop');
+    fs.mkdirSync(path.dirname(pwFile), { recursive: true });
+    execFileSync(
+      pgBin('initdb'),
+      ['-D', dataDir, '-U', DB_USER, '-A', 'trust', '-E', 'UTF8', '--locale=C'],
+      { stdio: 'pipe' },
+    );
+  }
+
+  const port = await stableDbPort();
+
+  // Start the server bound to loopback TCP only (unix sockets disabled — avoids
+  // the ~107-char socket-path limit under long userData paths and is moot on
+  // Windows). PG locates its share/lib relative to the binary.
+  log.info(`[db] starting embedded Postgres on 127.0.0.1:${port}…`);
+  const proc = spawn(
+    pgBin('postgres'),
+    [
+      '-D', dataDir,
+      '-p', String(port),
+      '-c', 'listen_addresses=127.0.0.1',
+      '-c', 'unix_socket_directories=',
+      '-c', 'fsync=on',
+    ],
+    { cwd: nativeDir, stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+  proc.stdout?.on('data', (d: Buffer) => log.info(`[postgres] ${d.toString().trimEnd()}`));
+  proc.stderr?.on('data', (d: Buffer) => log.info(`[postgres] ${d.toString().trimEnd()}`));
+  proc.on('exit', (code, signal) => {
+    if (current && current.proc === proc) {
+      if (!stopping) {
+        log.warn(`[db] embedded Postgres exited unexpectedly code=${code} signal=${signal}`);
+      }
+      current = null;
+    }
+  });
+
+  current = { proc, port };
+
+  try {
+    await waitForReady(port);
+    await ensureDatabase(port);
+  } catch (err) {
+    // Deliberate cleanup of a server that failed to come ready — mark it so the
+    // exit handler reports the original failure, not a spurious "exited
+    // unexpectedly". (waitForReady already throws the actionable message.)
+    stopping = true;
+    await stopProc(proc);
+    current = null;
+    stopping = false;
+    throw err;
+  }
+
+  log.info(`[db] embedded Postgres ready on 127.0.0.1:${port}`);
+  return toHandle(port);
+}
+
+/** Poll until the server accepts a TCP connection and answers a query. */
+async function waitForReady(port: number, timeoutMs = 30_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr = '';
+  while (Date.now() < deadline) {
+    if (!current || current.proc.exitCode !== null) {
+      throw new Error('embedded Postgres exited before becoming ready');
+    }
+    const client = new Client({ host: '127.0.0.1', port, user: DB_USER, database: 'postgres', connectionTimeoutMillis: 3000 });
+    try {
+      await client.connect();
+      await client.query('SELECT 1');
+      await client.end();
+      return;
+    } catch (err) {
+      lastErr = err instanceof Error ? err.message : String(err);
+      await client.end().catch(() => {});
+    }
+    await delay(400);
+  }
+  throw new Error(`embedded Postgres did not become ready in ${timeoutMs}ms (${lastErr})`);
+}
+
+/** Ensure the `omadia` database exists (CREATE DATABASE has no IF NOT EXISTS). */
+async function ensureDatabase(port: number): Promise<void> {
+  const client = new Client({ host: '127.0.0.1', port, user: DB_USER, database: 'postgres' });
+  await client.connect();
+  try {
+    const { rowCount } = await client.query('SELECT 1 FROM pg_database WHERE datname = $1', [DB_NAME]);
+    if (!rowCount) {
+      await client.query(`CREATE DATABASE ${DB_NAME} OWNER ${DB_USER}`);
+      log.info(`[db] created database "${DB_NAME}"`);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+function toHandle(port: number): EmbeddedDb {
   return {
-    databaseUrl,
-    port: c.port,
+    databaseUrl: `postgresql://${DB_USER}@127.0.0.1:${port}/${DB_NAME}`,
+    port,
     async stop() {
-      log.info('[db] stopping embedded Postgres');
-      try {
-        await c.server.stop();
-      } finally {
-        await c.db.close();
+      if (current) {
+        stopping = true;
+        await stopProc(current.proc);
         current = null;
+        stopping = false;
       }
     },
   };
+}
+
+/** Fast, clean Postgres shutdown: SIGINT → wait → SIGQUIT → SIGKILL. */
+function stopProc(proc: ChildProcess): Promise<void> {
+  if (proc.exitCode !== null || proc.signalCode !== null) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(t1);
+      clearTimeout(t2);
+      resolve();
+    };
+    proc.once('exit', finish);
+    log.info('[db] stopping embedded Postgres (fast shutdown)');
+    proc.kill('SIGINT'); // fast shutdown
+    const t1 = setTimeout(() => {
+      if (proc.exitCode === null) proc.kill('SIGQUIT'); // immediate shutdown
+    }, 4_000);
+    const t2 = setTimeout(() => {
+      if (proc.exitCode === null) proc.kill('SIGKILL');
+      finish();
+    }, 8_000);
+  });
 }
 
 export function isEmbeddedDbRunning(): boolean {
@@ -129,13 +218,9 @@ export function isEmbeddedDbRunning(): boolean {
 }
 
 /**
- * Returns a STABLE loopback port for the embedded DB, persisted across restarts.
- *
- * The kernel records its `database_url` (port included) in its config store on
- * first boot, and that persisted value wins over the env var on later boots. If
- * the embedded DB picked a fresh random port each launch, the kernel would keep
- * dialing the first-ever port and fail with ECONNREFUSED. So we choose a port
- * once, store it, and reuse it — only re-picking if it's genuinely taken.
+ * STABLE loopback port, persisted across restarts. The kernel records its
+ * `database_url` (port included) in its config store on first boot and that
+ * persisted value wins on later boots — so the port must not drift.
  */
 async function stableDbPort(): Promise<number> {
   const file = path.join(dataRoot(), 'db-port.txt');
@@ -146,11 +231,9 @@ async function stableDbPort(): Promise<number> {
   } catch {
     /* no stored port yet */
   }
-  if (stored !== null && (await isPortFree(stored))) {
-    return stored;
-  }
+  if (stored !== null && (await isPortFree(stored))) return stored;
   if (stored !== null) {
-    log.warn(`[db] stored port ${stored} is busy; picking a new one (kernel db_url may need a reset)`);
+    log.warn(`[db] stored port ${stored} busy; picking a new one`);
   }
   const port = await findFreePort('127.0.0.1');
   fs.writeFileSync(file, String(port), 'utf8');

--- a/desktop/src/embeddedDb.ts
+++ b/desktop/src/embeddedDb.ts
@@ -24,6 +24,9 @@ import { log } from './log';
  * bottlenecks is a bundled native Postgres.
  */
 
+// NOT a credential: pglite-socket on loopback does not authenticate, so these
+// only populate the DATABASE_URL the kernel's pg client expects — any value is
+// accepted. Security rests entirely on the 127.0.0.1-only bind, not on this.
 const DB_NAME = 'omadia';
 const DB_USER = 'omadia';
 const DB_PASSWORD = 'omadia';
@@ -85,13 +88,18 @@ export async function startEmbeddedDb(): Promise<EmbeddedDb> {
   // (pgcrypto is intentionally NOT required: the kernel migrations only used it
   // for gen_random_uuid(), which is core since Postgres 13.)
 
-  const port = await stableDbPort();
-  const server = new PGLiteSocketServer({
-    db,
-    port,
-    host: '127.0.0.1',
-  });
-  await server.start();
+  // From here on, any failure must close `db` — otherwise the PGlite instance
+  // leaks and keeps the dataDir lock, so a retry can't reopen the same dir.
+  let server: PGLiteSocketServer;
+  let port: number;
+  try {
+    port = await stableDbPort();
+    server = new PGLiteSocketServer({ db, port, host: '127.0.0.1' });
+    await server.start();
+  } catch (err) {
+    await db.close().catch(() => {});
+    throw err;
+  }
   log.info(`[db] embedded Postgres listening on 127.0.0.1:${port}`);
 
   current = { db, server, port };

--- a/desktop/src/ipcTypes.ts
+++ b/desktop/src/ipcTypes.ts
@@ -7,7 +7,14 @@ export const CH = {
   complete: 'omadia:complete',
   exportRecoveryKey: 'omadia:exportRecoveryKey',
   bootProgress: 'omadia:bootProgress',
+  bootLog: 'omadia:bootLog',
 } as const;
+
+/** A single line streamed to the wizard/loading UI during boot. */
+export interface BootLogLine {
+  level: 'INFO' | 'WARN' | 'ERROR';
+  msg: string;
+}
 
 export interface AppState {
   setupComplete: boolean;

--- a/desktop/src/log.ts
+++ b/desktop/src/log.ts
@@ -10,6 +10,19 @@ import path from 'node:path';
 
 let stream: fs.WriteStream | null = null;
 
+// Optional taps so the main process can mirror log lines to the wizard/loading
+// UI during boot (install verbosity). Kept out of the file/console path so a
+// throwing listener can never break logging.
+export type LogLevel = 'INFO' | 'WARN' | 'ERROR';
+type LogListener = (level: LogLevel, msg: string) => void;
+const listeners = new Set<LogListener>();
+
+/** Subscribe to every log line. Returns an unsubscribe. */
+export function onLog(cb: LogListener): () => void {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}
+
 function logFilePath(): string {
   const dir = path.join(app.getPath('userData'), 'logs');
   fs.mkdirSync(dir, { recursive: true });
@@ -31,6 +44,13 @@ function write(level: string, msg: string): void {
     stream.write(line);
   } catch {
     /* never let logging crash the app */
+  }
+  for (const l of listeners) {
+    try {
+      l(level as LogLevel, msg);
+    } catch {
+      /* a bad tap must never break logging */
+    }
   }
 }
 

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -6,7 +6,7 @@ import { CH } from './ipcTypes';
 import { createTray, setTrayStatus, destroyTray, TrayActions } from './tray';
 import { initUpdater, isUpdateInstalling } from './updater';
 import { isSetupComplete } from './setupState';
-import { log } from './log';
+import { log, onLog } from './log';
 
 // Stable app identity so userData resolves to ".../omadia" in both dev and
 // packaged builds (in dev the Electron CLI would otherwise name it "Electron").
@@ -15,6 +15,11 @@ app.setName('omadia');
 let win: BrowserWindow | null = null;
 let supervisor: Supervisor | null = null;
 let quitting = false;
+// While true, every log line is mirrored to the wizard/loading UI so the user
+// sees what's happening during the (potentially ~90s) install/boot. Turned off
+// once the admin UI takes over so normal operation isn't streamed to a page that
+// no longer listens.
+let streamBootLogs = false;
 
 function rendererPath(file: string): string {
   return path.join(app.getAppPath(), 'dist', 'renderer', file);
@@ -60,14 +65,17 @@ function trayActions(): TrayActions {
       await win.loadFile(rendererPath('loading.html'));
       setTrayStatus(trayActions(), 'starting');
       supervisor.on('progress', forwardProgress);
+      streamBootLogs = true;
       try {
         const uiUrl = await supervisor.restart();
+        streamBootLogs = false;
         await win.loadURL(uiUrl);
         setTrayStatus(trayActions(), 'running');
       } catch (err) {
         log.error(`[main] restart failed: ${String(err)}`);
         setTrayStatus(trayActions(), 'error');
       } finally {
+        streamBootLogs = false;
         supervisor.off('progress', forwardProgress);
       }
     },
@@ -82,12 +90,22 @@ function forwardProgress(p: BootProgress): void {
   if (win && !win.isDestroyed()) win.webContents.send(CH.bootProgress, p);
 }
 
+// Mirror log lines (kernel/web-ui/DB output all funnel through `log`) to the
+// boot UI for install verbosity. Subscribed once; gated by `streamBootLogs`.
+onLog((level, msg) => {
+  if (streamBootLogs && win && !win.isDestroyed()) {
+    win.webContents.send(CH.bootLog, { level, msg });
+  }
+});
+
 async function bootExistingInstall(): Promise<void> {
   if (!win || !supervisor) return;
   await win.loadFile(rendererPath('loading.html'));
   supervisor.on('progress', forwardProgress);
+  streamBootLogs = true;
   try {
     const uiUrl = await supervisor.start();
+    streamBootLogs = false;
     await win.loadURL(uiUrl);
     setTrayStatus(trayActions(), 'running');
   } catch (err) {
@@ -109,6 +127,7 @@ async function bootExistingInstall(): Promise<void> {
       app.quit();
     }
   } finally {
+    streamBootLogs = false;
     supervisor.off('progress', forwardProgress);
   }
 }
@@ -127,9 +146,11 @@ async function onReady(): Promise<void> {
   registerIpc({
     boot: async (forward) => {
       supervisor!.on('progress', forward);
+      streamBootLogs = true;
       try {
         return await supervisor!.start();
       } finally {
+        streamBootLogs = false;
         supervisor!.off('progress', forward);
       }
     },

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -4,7 +4,7 @@ import { Supervisor, setActiveSupervisor, BootProgress } from './supervisor';
 import { registerIpc } from './ipc';
 import { CH } from './ipcTypes';
 import { createTray, setTrayStatus, destroyTray, TrayActions } from './tray';
-import { initUpdater } from './updater';
+import { initUpdater, isUpdateInstalling } from './updater';
 import { isSetupComplete } from './setupState';
 import { log } from './log';
 
@@ -184,6 +184,10 @@ if (!gotLock) {
   app.on('before-quit', (e) => {
     quitting = true;
     destroyTray();
+    // During an update install, electron-updater drives the quit and runs the
+    // installer on `will-quit`. It already stopped the supervisor, so we must
+    // NOT preventDefault + app.exit() here — that would bypass the install.
+    if (isUpdateInstalling()) return;
     if (quitHandled || !supervisor) return;
     // Block the quit just long enough to flush + close the embedded DB and
     // terminate the children cleanly, then exit for real.

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -6,6 +6,7 @@ import {
   TestLlmKeyResult,
   WizardConfig,
   CompleteResult,
+  BootLogLine,
 } from './ipcTypes';
 import type { BootProgress } from './supervisor';
 
@@ -25,6 +26,11 @@ const api = {
     const listener = (_e: unknown, p: BootProgress): void => cb(p);
     ipcRenderer.on(CH.bootProgress, listener);
     return () => ipcRenderer.removeListener(CH.bootProgress, listener);
+  },
+  onBootLog: (cb: (line: BootLogLine) => void): (() => void) => {
+    const listener = (_e: unknown, line: BootLogLine): void => cb(line);
+    ipcRenderer.on(CH.bootLog, listener);
+    return () => ipcRenderer.removeListener(CH.bootLog, listener);
   },
 };
 

--- a/desktop/src/renderer/loading.html
+++ b/desktop/src/renderer/loading.html
@@ -10,12 +10,13 @@
     <link rel="stylesheet" href="wizard.css" />
   </head>
   <body>
-    <div style="display:flex;align-items:center;justify-content:center;height:100vh;flex-direction:column;gap:24px;">
+    <div style="display:flex;align-items:center;justify-content:center;height:100vh;flex-direction:column;gap:20px;padding:32px;box-sizing:border-box;">
       <div class="brand" style="font-size:28px;">omadia</div>
-      <div class="progress" style="width:360px;">
+      <div class="progress" style="width:520px;max-width:100%;">
         <div class="bar"><div id="barFill" class="bar-fill"></div></div>
         <p id="progressMsg" class="progress-msg" style="text-align:center;">Starting local services…</p>
       </div>
+      <pre id="bootLog" class="boot-log" style="width:520px;max-width:100%;" aria-label="startup log"></pre>
     </div>
     <script src="loading.js"></script>
   </body>

--- a/desktop/src/renderer/loading.js
+++ b/desktop/src/renderer/loading.js
@@ -9,10 +9,31 @@ const PHASE_PCT = {
   error: 100,
 };
 
-window.omadia.onBootProgress((p) => {
-  const fill = document.getElementById('barFill');
-  const msg = document.getElementById('progressMsg');
-  fill.style.width = (PHASE_PCT[p.phase] ?? 10) + '%';
-  msg.textContent = p.message + (p.detail ? ' — ' + p.detail : '');
-  if (p.phase === 'error') fill.style.background = 'var(--err)';
-});
+const msgEl = document.getElementById('progressMsg');
+
+if (!window.omadia) {
+  // Preload bridge failed — show it instead of a frozen progress bar.
+  if (msgEl) msgEl.textContent = 'Internal error: the app bridge did not load (tray → Open Logs).';
+} else {
+  window.omadia.onBootProgress((p) => {
+    const fill = document.getElementById('barFill');
+    fill.style.width = (PHASE_PCT[p.phase] ?? 10) + '%';
+    if (msgEl) msgEl.textContent = p.message + (p.detail ? ' — ' + p.detail : '');
+    if (p.phase === 'error') fill.style.background = 'var(--err)';
+  });
+
+  // Live, granular startup log for verbosity.
+  if (window.omadia.onBootLog) {
+    const logEl = document.getElementById('bootLog');
+    window.omadia.onBootLog((line) => {
+      if (!logEl) return;
+      const row = document.createElement('div');
+      const cls = line.level === 'ERROR' ? 'l-err' : line.level === 'WARN' ? 'l-warn' : '';
+      if (cls) row.className = cls;
+      row.textContent = line.msg;
+      logEl.appendChild(row);
+      while (logEl.childElementCount > 400) logEl.removeChild(logEl.firstChild);
+      logEl.scrollTop = logEl.scrollHeight;
+    });
+  }
+}

--- a/desktop/src/renderer/wizard.css
+++ b/desktop/src/renderer/wizard.css
@@ -88,3 +88,25 @@ input:focus, select:focus { border-color: var(--accent); }
 .error { color: var(--err); font-size: 14px; }
 .error.hidden { display: none; }
 .provisioning { display: flex; flex-direction: column; }
+
+/* Live install/boot log — verbosity during provisioning + startup. */
+.boot-log {
+  margin: 16px 0 0;
+  max-height: 220px;
+  overflow-y: auto;
+  padding: 12px 14px;
+  background: #080a0e;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--muted);
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 11.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.boot-log:empty { display: none; }
+.boot-log .l-warn { color: #e3b341; }
+.boot-log .l-err { color: var(--err); }
+.boot-log .l-ok { color: var(--ok); }
+#elapsed { opacity: 0.8; }

--- a/desktop/src/renderer/wizard.html
+++ b/desktop/src/renderer/wizard.html
@@ -119,7 +119,9 @@
           <div class="progress">
             <div class="bar"><div id="barFill" class="bar-fill"></div></div>
             <p id="progressMsg" class="progress-msg">Starting…</p>
+            <p class="hint" id="progressHint">First start runs database migrations — this can take up to a minute. <span id="elapsed"></span></p>
           </div>
+          <pre id="bootLog" class="boot-log" aria-label="installation log"></pre>
           <p id="provisionError" class="error hidden"></p>
         </section>
 

--- a/desktop/src/renderer/wizard.js
+++ b/desktop/src/renderer/wizard.js
@@ -14,6 +14,31 @@ const state = {
 const $ = (sel) => document.querySelector(sel);
 const stepSections = () => Array.from(document.querySelectorAll('.step[data-step]'));
 
+/* If the preload bridge failed to load, `window.omadia` is undefined and every
+   action would silently do nothing. Surface it loudly instead of hanging. */
+function bridgeOk() {
+  if (omadia) return true;
+  const el = $('#testResult') || document.body;
+  el.textContent =
+    'Internal error: the app bridge did not load. Please reinstall or report this (tray → Open Logs).';
+  if (el.className !== undefined) el.className = 'test-result err';
+  return false;
+}
+
+/* Append a line to the live install log (verbosity during provisioning). */
+function appendBootLog(level, msg) {
+  const el = $('#bootLog');
+  if (!el) return;
+  const line = document.createElement('div');
+  const cls = level === 'ERROR' ? 'l-err' : level === 'WARN' ? 'l-warn' : '';
+  if (cls) line.className = cls;
+  line.textContent = msg;
+  el.appendChild(line);
+  // Cap to keep the DOM light on a chatty boot.
+  while (el.childElementCount > 400) el.removeChild(el.firstChild);
+  el.scrollTop = el.scrollHeight;
+}
+
 function show(stepKey) {
   stepSections().forEach((el) => {
     el.classList.toggle('hidden', el.dataset.step !== String(stepKey));
@@ -80,24 +105,47 @@ const PHASE_PCT = {
 };
 
 async function provision() {
+  if (!bridgeOk()) return;
   show('provision');
   document.querySelector('.nav').style.display = 'none';
   document.querySelectorAll('#steps li').forEach((li) => li.classList.add('done'));
+  $('#provisionError').classList.add('hidden');
+  $('#bootLog').textContent = '';
 
-  const unsub = omadia.onBootProgress((p) => {
+  // Elapsed timer so a long first-boot (migrations) clearly looks alive.
+  const started = Date.now();
+  const elapsedEl = $('#elapsed');
+  const ticker = setInterval(() => {
+    if (elapsedEl) elapsedEl.textContent = `(${Math.round((Date.now() - started) / 1000)}s)`;
+  }, 1000);
+
+  const unsubProgress = omadia.onBootProgress((p) => {
     const pct = PHASE_PCT[p.phase] ?? 10;
     $('#barFill').style.width = pct + '%';
     $('#progressMsg').textContent = p.message + (p.detail ? ' — ' + p.detail : '');
     if (p.phase === 'error') $('#barFill').style.background = 'var(--err)';
   });
+  // Live, granular log (kernel migrations, plugin activation, DB readiness …).
+  const unsubLog = omadia.onBootLog
+    ? omadia.onBootLog((line) => appendBootLog(line.level, line.msg))
+    : () => {};
 
-  const res = await omadia.complete(collectConfig());
-  unsub();
+  let res;
+  try {
+    res = await omadia.complete(collectConfig());
+  } catch (err) {
+    res = { ok: false, error: (err && err.message) || 'Setup crashed unexpectedly.' };
+  } finally {
+    clearInterval(ticker);
+    unsubProgress();
+    unsubLog();
+  }
 
   if (!res.ok) {
     const err = $('#provisionError');
     err.textContent = res.error || 'Setup failed. Check the logs (tray → Open Logs).';
     err.classList.remove('hidden');
+    appendBootLog('ERROR', res.error || 'Setup failed.');
     // Allow another attempt.
     document.querySelector('.nav').style.display = 'flex';
     $('#next').textContent = 'Retry';
@@ -121,35 +169,59 @@ $('#back').addEventListener('click', () => {
 });
 
 $('#testKey').addEventListener('click', async () => {
+  if (!bridgeOk()) return;
   const provider = $('#provider').value;
   const apiKey = $('#apiKey').value.trim();
   if (apiKey.length < 8) {
     flashTest('Key looks too short.', false);
     return;
   }
+  const btn = $('#testKey');
+  btn.disabled = true;
   flashTest('Testing…', true);
-  const res = await omadia.testLlmKey({ provider, apiKey });
-  state.keyVerified = res.ok;
-  flashTest(res.ok ? 'Key works.' : res.error || 'Key check failed.', res.ok);
+  try {
+    const res = await omadia.testLlmKey({ provider, apiKey });
+    state.keyVerified = res.ok;
+    flashTest(res.ok ? 'Key works.' : res.error || 'Key check failed.', res.ok);
+  } catch (err) {
+    // Never leave the user stuck on "Testing…" — surface the failure.
+    state.keyVerified = false;
+    flashTest((err && err.message) || 'Key check failed (internal error).', false);
+  } finally {
+    btn.disabled = false;
+  }
 });
 
 $('#chooseDir').addEventListener('click', async () => {
-  const dir = await omadia.chooseDataDir();
-  if (dir) {
-    state.dataDir = dir;
-    $('#dataDir').value = dir;
-    $('#dataDirHint').textContent = 'omadia will store everything in this folder.';
+  if (!bridgeOk()) return;
+  try {
+    const dir = await omadia.chooseDataDir();
+    if (dir) {
+      state.dataDir = dir;
+      $('#dataDir').value = dir;
+      $('#dataDirHint').textContent = 'omadia will store everything in this folder.';
+    }
+  } catch (err) {
+    $('#dataDirHint').textContent =
+      'Could not open the folder picker: ' + ((err && err.message) || 'internal error') + '. The default folder will be used.';
   }
 });
 
 $('#revealKey').addEventListener('click', async () => {
-  const key = await omadia.exportRecoveryKey();
-  $('#recoveryKey').textContent = key;
-  $('#revealKey').textContent = 'Copy';
-  $('#revealKey').onclick = async () => {
-    await navigator.clipboard.writeText(key);
-    $('#revealKey').textContent = 'Copied';
-  };
+  if (!bridgeOk()) return;
+  try {
+    const key = await omadia.exportRecoveryKey();
+    $('#recoveryKey').textContent = key;
+    $('#revealKey').textContent = 'Copy';
+    $('#revealKey').onclick = async () => {
+      await navigator.clipboard.writeText(key);
+      $('#revealKey').textContent = 'Copied';
+    };
+  } catch (err) {
+    $('#recoveryKey').textContent = 'unavailable — ' + ((err && err.message) || 'internal error');
+  }
 });
 
 goto(0);
+// Fail loud, not silent, if the preload bridge is missing.
+if (!omadia) bridgeOk();

--- a/desktop/src/secrets.ts
+++ b/desktop/src/secrets.ts
@@ -52,7 +52,16 @@ function load(): SecretsBlob {
     }
   }
   cache = { vaultKey: generateVaultKey(), providerKeys: {} };
-  persist();
+  try {
+    persist();
+  } catch (err) {
+    // Fail-closed: if we couldn't persist (e.g. OS encryption unavailable in a
+    // packaged build), do NOT leave the unpersisted key cached — a later call
+    // would otherwise return it past the `if (cache)` short-circuit and bypass
+    // the fail-closed guard, diverging from whatever gets persisted next launch.
+    cache = null;
+    throw err;
+  }
   return cache;
 }
 

--- a/desktop/src/supervisor.ts
+++ b/desktop/src/supervisor.ts
@@ -146,11 +146,13 @@ export class Supervisor extends EventEmitter {
       // interfaces), which would expose the local install on the LAN.
       HOST: '127.0.0.1',
       DATABASE_URL: this.db?.databaseUrl ?? '',
-      // The embedded PGlite engine is single-client over the wire protocol; a
-      // multi-connection pool terminates the extra connections. Capping the
-      // kernel's pool at 1 makes node-postgres multiplex every query over one
-      // reused connection — the seam that makes the no-Docker DB work.
-      GRAPH_POOL_MAX: '1',
+      // Signals the kernel that DATABASE_URL points at our embedded Postgres,
+      // whose loopback port can change between launches (collision → new port).
+      // The knowledge-graph plugin then treats the live env DSN as authoritative
+      // over the first-boot value frozen in the vault, so a port change can't
+      // crash-loop boot against a dead port. Cloud/server leave this unset and
+      // keep vault precedence.
+      OMADIA_EMBEDDED_DB: '1',
       VAULT_KEY: vaultKey(),
       PLATFORM_DATA_DIR: platformDataDir(),
       // The browser opens signed diagram URLs against this host base.

--- a/desktop/src/supervisor.ts
+++ b/desktop/src/supervisor.ts
@@ -11,7 +11,6 @@ import {
 import { findFreePorts, isPortFree } from './ports';
 import { startEmbeddedDb, EmbeddedDb } from './embeddedDb';
 import { vaultKey, allProviderKeys } from './secrets';
-import { readSetup } from './setupState';
 import { log } from './log';
 
 export type BootPhase =
@@ -126,16 +125,18 @@ export class Supervisor extends EventEmitter {
       this.progress('ready', 'omadia is ready.');
       return this.uiUrl;
     } catch (err) {
-      // Roll back any partially-started children so a retry starts from a clean
-      // slate (and so we don't leak processes or hold the PGlite lock).
-      await this.teardownChildren();
-      this.state = 'idle';
+      // If a concurrent stop()/restart() superseded this boot (it bumped the
+      // generation), it now owns teardown + the state — do NOT double-tear-down
+      // or stomp its state. Only clean up when we're still the live generation.
+      if (gen === this.generation) {
+        await this.teardownChildren();
+        this.state = 'idle';
+      }
       throw err;
     }
   }
 
   private kernelEnv(port: number): NodeJS.ProcessEnv {
-    const setup = readSetup();
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       ELECTRON_RUN_AS_NODE: '1',
@@ -159,7 +160,6 @@ export class Supervisor extends EventEmitter {
     // v1 wires only persistence + LLM. Embeddings (in-process), diagrams (hosted),
     // and the filesystem attachment store are later milestones; leaving their env
     // unset means the kernel degrades gracefully rather than failing.
-    void setup;
     return env;
   }
 

--- a/desktop/src/updater.ts
+++ b/desktop/src/updater.ts
@@ -3,7 +3,14 @@ import { autoUpdater } from 'electron-updater';
 import fs from 'node:fs';
 import path from 'node:path';
 import { embeddedDbDir, snapshotDir } from './paths';
+import { getActiveSupervisor } from './supervisor';
 import { log } from './log';
+
+let installing = false;
+/** True once the user accepted an update and we're handing off to the installer. */
+export function isUpdateInstalling(): boolean {
+  return installing;
+}
 
 /**
  * Auto-update via electron-updater against GitHub Releases.
@@ -28,12 +35,6 @@ export function initUpdater(): void {
   );
   autoUpdater.on('update-downloaded', async (info) => {
     log.info(`[updater] downloaded ${info.version}`);
-    try {
-      snapshotDbDir(info.version);
-    } catch (err) {
-      log.error(`[updater] snapshot failed, not auto-installing: ${String(err)}`);
-      return;
-    }
     const { response } = await dialog.showMessageBox({
       type: 'info',
       buttons: ['Restart now', 'Later'],
@@ -41,11 +42,24 @@ export function initUpdater(): void {
       cancelId: 1,
       title: 'Update ready',
       message: `omadia ${info.version} is ready to install.`,
-      detail: 'Your data has been snapshotted. omadia will restart to apply the update.',
+      detail: 'omadia will close, back up your local data, and restart to apply the update.',
     });
-    if (response === 0) {
-      autoUpdater.quitAndInstall();
+    if (response !== 0) return;
+
+    // Quiesce the stack FIRST so the embedded DB is flushed + closed before we
+    // copy its directory — a live cpSync could capture a torn, unrestorable
+    // snapshot. Then snapshot, then hand off to the installer.
+    installing = true;
+    try {
+      const sup = getActiveSupervisor();
+      if (sup) await sup.stop();
+      snapshotDbDir(info.version);
+    } catch (err) {
+      log.error(`[updater] pre-install stop/snapshot failed (installing anyway): ${String(err)}`);
     }
+    // quitAndInstall drives the app quit itself; main's before-quit checks
+    // isUpdateInstalling() and steps aside so the installer isn't bypassed.
+    autoUpdater.quitAndInstall();
   });
 
   autoUpdater.checkForUpdates().catch((err) => log.error(`[updater] check failed: ${String(err)}`));

--- a/middleware/packages/harness-knowledge-graph-neon/src/plugin.ts
+++ b/middleware/packages/harness-knowledge-graph-neon/src/plugin.ts
@@ -118,7 +118,17 @@ export async function activate(
   // setup-form (Vault) post-install. The legacy installed.json fallback was
   // dropped; bootstrapKnowledgeGraphFromEnv migrates pre-S+12.5-3 entries
   // automatically on first boot.
-  const databaseUrl = await ctx.secrets.get('database_url');
+  //
+  // Desktop installer exception: the embedded Postgres binds a loopback port
+  // that can change between launches (collision → a new free port is chosen),
+  // but the vault froze the FIRST-boot DSN and bootstrap never refreshes it. So
+  // when the supervisor signals an embedded DB (OMADIA_EMBEDDED_DB=1), the live
+  // DATABASE_URL env is authoritative — otherwise a drifted port would make this
+  // eager connect crash-loop boot against a dead port. Cloud/server (flag unset)
+  // keep vault precedence unchanged.
+  const embeddedDbUrl =
+    process.env['OMADIA_EMBEDDED_DB'] === '1' ? process.env['DATABASE_URL'] : undefined;
+  const databaseUrl = embeddedDbUrl || (await ctx.secrets.get('database_url'));
 
   if (!databaseUrl) {
     ctx.log(
@@ -139,13 +149,11 @@ export async function activate(
     process.env['GRAPH_TENANT_ID'] ??
     'default';
 
-  // Pool size is configurable so an embedded single-connection engine can cap it
-  // at 1. The omadia desktop installer runs Postgres via PGlite exposed over the
-  // wire protocol (pglite-socket), which is single-client: a multi-connection
-  // pool terminates the extra connections. With `GRAPH_POOL_MAX=1` node-postgres
-  // multiplexes every query over one reused connection (empirically: 20
-  // concurrent queries in <10ms), so this is the seam that makes the no-Docker
-  // embedded DB work without forking the kernel. Defaults to 5 for server/cloud.
+  // Pool size is configurable via graph_pool_max / GRAPH_POOL_MAX (defaults to
+  // 5). The desktop installer bundles a REAL native PostgreSQL 17, which pools
+  // normally — no single-connection cap needed. (The knob predates that: it let
+  // an earlier PGlite-over-pglite-socket engine, which was single-client, cap at
+  // 1. Kept configurable for constrained deployments.)
   const poolMaxRaw =
     ctx.config.get<string | number>('graph_pool_max') ?? process.env['GRAPH_POOL_MAX'];
   const poolMaxParsed = Number(poolMaxRaw);


### PR DESCRIPTION
Supersedes the earlier (closed) #355 — same branch, now also carrying the cross-platform matrix and the onboarding-wizard fix.

## What

Ships the **native one-click desktop installer** for omadia (macOS / Linux / Windows) — an Electron shell that bundles and supervises the existing middleware kernel + web-ui plus a **bundled native PostgreSQL 17 + pgvector**, with **no Docker** and no separate Node runtime. Once merged, `auto-release.yml` builds and attaches the installers to every release automatically (the `desktop-apps` reusable-workflow job).

## Why native Postgres (not PGlite)

The first iteration embedded PGlite (Postgres-in-WASM) over `pglite-socket`. It booted, but the WASM engine crashed (`RuntimeError: unreachable`) under the kernel's real query load and is single-connection. This replaces it with a real bundled PostgreSQL 17 driven directly via `initdb`/`postgres` child processes (loopback-TCP, trust auth), staged as `extraResources` so it is executable on disk (never trapped in the asar).

## Platforms — all three CI-green

| OS | pgvector source | Verification |
|----|-----------------|--------------|
| macOS arm64 | Homebrew `postgresql@17` | build + **boot-tested** end-to-end (auth/health 200, `CREATE EXTENSION vector` 0.8.3 loads, port-drift recovery) |
| Linux x64 | pgdg apt `postgresql-17-pgvector` | build + artifact structurally verified (vector.so, relative symlinks) |
| Windows x64 | MSVC `nmake` build from pgvector source (Chocolatey PG17 for headers) | build + artifact structurally verified (vector.dll PE32+ x64) |

## Notable fixes found by booting real artifacts (not just green CI)

- **Port/vault drift**: the kernel read `database_url` only from the vault (frozen at first boot); a changed embedded-DB port would crash-loop boot. Gated `OMADIA_EMBEDDED_DB=1` makes the live env DSN authoritative on desktop (cloud unchanged). Proven: forced the frozen port busy → app drifted to a new port → graph reconnected.
- **Dangling dylib/so symlinks**: `cpSync({dereference:true})` rewrote the engine's relative library symlinks to absolute build-machine paths (resolved locally, dangled on CI / end-user machines → `dyld: Library not loaded`). Fixed by restoring relative in-tree symlinks from the engine's `pg-symlinks.json` manifest.
- **Onboarding wizard broken on all platforms** (reported on Windows: key test stuck on "Testing…", folder picker dead, setup stalled): the `sandbox: true` preload could not `require('./ipcTypes')`, so `window.omadia` was never exposed and every bridge call silently hung. Fixed by bundling the preload self-contained with esbuild, plus renderer guards so a bridge failure surfaces instead of hanging. Verified on the packaged wizard via CDP (`window.omadia` present, `testLlmKey` round-trips and resolves).
- **Install verbosity**: kernel/web-ui/Postgres output (which all funnel through `log`) is now mirrored to the wizard + loading UI via a gated `bootLog` channel — live scrolling log + elapsed-time counter so a long first boot (migrations) visibly stays alive.

## Signing (fail-soft)

Unsigned/ad-hoc without secrets; the build still produces installers. macOS reuses the proven `_HIGH5` Apple secret names (Developer ID + notarization). Windows Authenticode is optional (`WINDOWS_CSC_*`).

## Known limitations / follow-ups

- **Runtime** boot of the Linux AppImage and Windows installer on those actual OSes is not yet done (only macOS can be booted on the dev box). The bundling is verified; the `vector.so`/`vector.dll` load and the wizard are the same PG17-ABI / sandbox-preload mechanisms proven on macOS.
- macOS is **arm64 only** for v1 (Intel runners queue for hours). Intel x64 is a tracked follow-up.
- Signed/notarized artifacts require the Apple/Windows signing secrets on the repo.
