### PR TITLE
fix(desktop): onboarding wizard preload + install verbosity

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -19,6 +19,7 @@
         "@types/pg": "^8.11.10",
         "electron": "^37.2.0",
         "electron-builder": "^25.1.8",
+        "esbuild": "^0.28.0",
         "typescript": "^5.7.2"
       }
     },
@@ -452,6 +453,448 @@
       ],
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@gar/promisify": {
@@ -2353,6 +2796,48 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -15,7 +15,7 @@
   },
   "main": "dist/main.js",
   "scripts": {
-    "build": "tsc -p tsconfig.json && node scripts/copy-renderer.mjs",
+    "build": "tsc -p tsconfig.json && node scripts/bundle-preload.mjs && node scripts/copy-renderer.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "stage": "node scripts/stage-runtime.mjs",
     "start": "npm run build && electron .",
@@ -35,6 +35,7 @@
     "@types/pg": "^8.11.10",
     "electron": "^37.2.0",
     "electron-builder": "^25.1.8",
+    "esbuild": "^0.28.0",
     "typescript": "^5.7.2"
   }
 }

--- a/desktop/scripts/bundle-preload.mjs
+++ b/desktop/scripts/bundle-preload.mjs
@@ -1,0 +1,33 @@
+// Bundles the preload into a single self-contained dist/preload.js.
+//
+// WHY: the BrowserWindow runs with `sandbox: true` (main.ts). A sandboxed
+// preload only gets a limited `require` (electron + a small polyfill set) — it
+// CANNOT `require('./ipcTypes')` or any other local module. tsc emits a preload
+// that does exactly that, so the script fails to load with
+// "Error: module not found: ./ipcTypes", `window.omadia` is never exposed, and
+// every wizard/loading bridge call silently hangs (key test stuck on "Testing…",
+// folder picker never opens, completion stalls).
+//
+// esbuild inlines the local imports (ipcTypes constants + erased types) into one
+// file with `electron` left external (provided by the runtime), so the preload
+// loads cleanly under the sandbox while keeping a single source of truth for the
+// channel names. Runs AFTER tsc (overwriting tsc's broken dist/preload.js).
+import { build } from 'esbuild';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+await build({
+  entryPoints: [path.join(here, '..', 'src', 'preload.ts')],
+  outfile: path.join(here, '..', 'dist', 'preload.js'),
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  target: 'node22',
+  external: ['electron'],
+  sourcemap: false,
+  logLevel: 'warning',
+});
+
+console.log('[bundle-preload] dist/preload.js bundled (self-contained, sandbox-safe)');

--- a/desktop/src/ipcTypes.ts
+++ b/desktop/src/ipcTypes.ts
@@ -7,7 +7,14 @@ export const CH = {
   complete: 'omadia:complete',
   exportRecoveryKey: 'omadia:exportRecoveryKey',
   bootProgress: 'omadia:bootProgress',
+  bootLog: 'omadia:bootLog',
 } as const;
+
+/** A single line streamed to the wizard/loading UI during boot. */
+export interface BootLogLine {
+  level: 'INFO' | 'WARN' | 'ERROR';
+  msg: string;
+}
 
 export interface AppState {
   setupComplete: boolean;

--- a/desktop/src/log.ts
+++ b/desktop/src/log.ts
@@ -10,6 +10,19 @@ import path from 'node:path';
 
 let stream: fs.WriteStream | null = null;
 
+// Optional taps so the main process can mirror log lines to the wizard/loading
+// UI during boot (install verbosity). Kept out of the file/console path so a
+// throwing listener can never break logging.
+export type LogLevel = 'INFO' | 'WARN' | 'ERROR';
+type LogListener = (level: LogLevel, msg: string) => void;
+const listeners = new Set<LogListener>();
+
+/** Subscribe to every log line. Returns an unsubscribe. */
+export function onLog(cb: LogListener): () => void {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}
+
 function logFilePath(): string {
   const dir = path.join(app.getPath('userData'), 'logs');
   fs.mkdirSync(dir, { recursive: true });
@@ -31,6 +44,13 @@ function write(level: string, msg: string): void {
     stream.write(line);
   } catch {
     /* never let logging crash the app */
+  }
+  for (const l of listeners) {
+    try {
+      l(level as LogLevel, msg);
+    } catch {
+      /* a bad tap must never break logging */
+    }
   }
 }
 

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -6,7 +6,7 @@ import { CH } from './ipcTypes';
 import { createTray, setTrayStatus, destroyTray, TrayActions } from './tray';
 import { initUpdater, isUpdateInstalling } from './updater';
 import { isSetupComplete } from './setupState';
-import { log } from './log';
+import { log, onLog } from './log';
 
 // Stable app identity so userData resolves to ".../omadia" in both dev and
 // packaged builds (in dev the Electron CLI would otherwise name it "Electron").
@@ -15,6 +15,11 @@ app.setName('omadia');
 let win: BrowserWindow | null = null;
 let supervisor: Supervisor | null = null;
 let quitting = false;
+// While true, every log line is mirrored to the wizard/loading UI so the user
+// sees what's happening during the (potentially ~90s) install/boot. Turned off
+// once the admin UI takes over so normal operation isn't streamed to a page that
+// no longer listens.
+let streamBootLogs = false;
 
 function rendererPath(file: string): string {
   return path.join(app.getAppPath(), 'dist', 'renderer', file);
@@ -60,14 +65,17 @@ function trayActions(): TrayActions {
       await win.loadFile(rendererPath('loading.html'));
       setTrayStatus(trayActions(), 'starting');
       supervisor.on('progress', forwardProgress);
+      streamBootLogs = true;
       try {
         const uiUrl = await supervisor.restart();
+        streamBootLogs = false;
         await win.loadURL(uiUrl);
         setTrayStatus(trayActions(), 'running');
       } catch (err) {
         log.error(`[main] restart failed: ${String(err)}`);
         setTrayStatus(trayActions(), 'error');
       } finally {
+        streamBootLogs = false;
         supervisor.off('progress', forwardProgress);
       }
     },
@@ -82,12 +90,22 @@ function forwardProgress(p: BootProgress): void {
   if (win && !win.isDestroyed()) win.webContents.send(CH.bootProgress, p);
 }
 
+// Mirror log lines (kernel/web-ui/DB output all funnel through `log`) to the
+// boot UI for install verbosity. Subscribed once; gated by `streamBootLogs`.
+onLog((level, msg) => {
+  if (streamBootLogs && win && !win.isDestroyed()) {
+    win.webContents.send(CH.bootLog, { level, msg });
+  }
+});
+
 async function bootExistingInstall(): Promise<void> {
   if (!win || !supervisor) return;
   await win.loadFile(rendererPath('loading.html'));
   supervisor.on('progress', forwardProgress);
+  streamBootLogs = true;
   try {
     const uiUrl = await supervisor.start();
+    streamBootLogs = false;
     await win.loadURL(uiUrl);
     setTrayStatus(trayActions(), 'running');
   } catch (err) {
@@ -109,6 +127,7 @@ async function bootExistingInstall(): Promise<void> {
       app.quit();
     }
   } finally {
+    streamBootLogs = false;
     supervisor.off('progress', forwardProgress);
   }
 }
@@ -127,9 +146,11 @@ async function onReady(): Promise<void> {
   registerIpc({
     boot: async (forward) => {
       supervisor!.on('progress', forward);
+      streamBootLogs = true;
       try {
         return await supervisor!.start();
       } finally {
+        streamBootLogs = false;
         supervisor!.off('progress', forward);
       }
     },

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -6,6 +6,7 @@ import {
   TestLlmKeyResult,
   WizardConfig,
   CompleteResult,
+  BootLogLine,
 } from './ipcTypes';
 import type { BootProgress } from './supervisor';
 
@@ -25,6 +26,11 @@ const api = {
     const listener = (_e: unknown, p: BootProgress): void => cb(p);
     ipcRenderer.on(CH.bootProgress, listener);
     return () => ipcRenderer.removeListener(CH.bootProgress, listener);
+  },
+  onBootLog: (cb: (line: BootLogLine) => void): (() => void) => {
+    const listener = (_e: unknown, line: BootLogLine): void => cb(line);
+    ipcRenderer.on(CH.bootLog, listener);
+    return () => ipcRenderer.removeListener(CH.bootLog, listener);
   },
 };
 

--- a/desktop/src/renderer/loading.html
+++ b/desktop/src/renderer/loading.html
@@ -10,12 +10,13 @@
     <link rel="stylesheet" href="wizard.css" />
   </head>
   <body>
-    <div style="display:flex;align-items:center;justify-content:center;height:100vh;flex-direction:column;gap:24px;">
+    <div style="display:flex;align-items:center;justify-content:center;height:100vh;flex-direction:column;gap:20px;padding:32px;box-sizing:border-box;">
       <div class="brand" style="font-size:28px;">omadia</div>
-      <div class="progress" style="width:360px;">
+      <div class="progress" style="width:520px;max-width:100%;">
         <div class="bar"><div id="barFill" class="bar-fill"></div></div>
         <p id="progressMsg" class="progress-msg" style="text-align:center;">Starting local services…</p>
       </div>
+      <pre id="bootLog" class="boot-log" style="width:520px;max-width:100%;" aria-label="startup log"></pre>
     </div>
     <script src="loading.js"></script>
   </body>

--- a/desktop/src/renderer/loading.js
+++ b/desktop/src/renderer/loading.js
@@ -9,10 +9,31 @@ const PHASE_PCT = {
   error: 100,
 };
 
-window.omadia.onBootProgress((p) => {
-  const fill = document.getElementById('barFill');
-  const msg = document.getElementById('progressMsg');
-  fill.style.width = (PHASE_PCT[p.phase] ?? 10) + '%';
-  msg.textContent = p.message + (p.detail ? ' — ' + p.detail : '');
-  if (p.phase === 'error') fill.style.background = 'var(--err)';
-});
+const msgEl = document.getElementById('progressMsg');
+
+if (!window.omadia) {
+  // Preload bridge failed — show it instead of a frozen progress bar.
+  if (msgEl) msgEl.textContent = 'Internal error: the app bridge did not load (tray → Open Logs).';
+} else {
+  window.omadia.onBootProgress((p) => {
+    const fill = document.getElementById('barFill');
+    fill.style.width = (PHASE_PCT[p.phase] ?? 10) + '%';
+    if (msgEl) msgEl.textContent = p.message + (p.detail ? ' — ' + p.detail : '');
+    if (p.phase === 'error') fill.style.background = 'var(--err)';
+  });
+
+  // Live, granular startup log for verbosity.
+  if (window.omadia.onBootLog) {
+    const logEl = document.getElementById('bootLog');
+    window.omadia.onBootLog((line) => {
+      if (!logEl) return;
+      const row = document.createElement('div');
+      const cls = line.level === 'ERROR' ? 'l-err' : line.level === 'WARN' ? 'l-warn' : '';
+      if (cls) row.className = cls;
+      row.textContent = line.msg;
+      logEl.appendChild(row);
+      while (logEl.childElementCount > 400) logEl.removeChild(logEl.firstChild);
+      logEl.scrollTop = logEl.scrollHeight;
+    });
+  }
+}

--- a/desktop/src/renderer/wizard.css
+++ b/desktop/src/renderer/wizard.css
@@ -88,3 +88,25 @@ input:focus, select:focus { border-color: var(--accent); }
 .error { color: var(--err); font-size: 14px; }
 .error.hidden { display: none; }
 .provisioning { display: flex; flex-direction: column; }
+
+/* Live install/boot log — verbosity during provisioning + startup. */
+.boot-log {
+  margin: 16px 0 0;
+  max-height: 220px;
+  overflow-y: auto;
+  padding: 12px 14px;
+  background: #080a0e;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--muted);
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 11.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.boot-log:empty { display: none; }
+.boot-log .l-warn { color: #e3b341; }
+.boot-log .l-err { color: var(--err); }
+.boot-log .l-ok { color: var(--ok); }
+#elapsed { opacity: 0.8; }

--- a/desktop/src/renderer/wizard.html
+++ b/desktop/src/renderer/wizard.html
@@ -119,7 +119,9 @@
           <div class="progress">
             <div class="bar"><div id="barFill" class="bar-fill"></div></div>
             <p id="progressMsg" class="progress-msg">Starting…</p>
+            <p class="hint" id="progressHint">First start runs database migrations — this can take up to a minute. <span id="elapsed"></span></p>
           </div>
+          <pre id="bootLog" class="boot-log" aria-label="installation log"></pre>
           <p id="provisionError" class="error hidden"></p>
         </section>
 

--- a/desktop/src/renderer/wizard.js
+++ b/desktop/src/renderer/wizard.js
@@ -14,6 +14,31 @@ const state = {
 const $ = (sel) => document.querySelector(sel);
 const stepSections = () => Array.from(document.querySelectorAll('.step[data-step]'));
 
+/* If the preload bridge failed to load, `window.omadia` is undefined and every
+   action would silently do nothing. Surface it loudly instead of hanging. */
+function bridgeOk() {
+  if (omadia) return true;
+  const el = $('#testResult') || document.body;
+  el.textContent =
+    'Internal error: the app bridge did not load. Please reinstall or report this (tray → Open Logs).';
+  if (el.className !== undefined) el.className = 'test-result err';
+  return false;
+}
+
+/* Append a line to the live install log (verbosity during provisioning). */
+function appendBootLog(level, msg) {
+  const el = $('#bootLog');
+  if (!el) return;
+  const line = document.createElement('div');
+  const cls = level === 'ERROR' ? 'l-err' : level === 'WARN' ? 'l-warn' : '';
+  if (cls) line.className = cls;
+  line.textContent = msg;
+  el.appendChild(line);
+  // Cap to keep the DOM light on a chatty boot.
+  while (el.childElementCount > 400) el.removeChild(el.firstChild);
+  el.scrollTop = el.scrollHeight;
+}
+
 function show(stepKey) {
   stepSections().forEach((el) => {
     el.classList.toggle('hidden', el.dataset.step !== String(stepKey));
@@ -80,24 +105,47 @@ const PHASE_PCT = {
 };
 
 async function provision() {
+  if (!bridgeOk()) return;
   show('provision');
   document.querySelector('.nav').style.display = 'none';
   document.querySelectorAll('#steps li').forEach((li) => li.classList.add('done'));
+  $('#provisionError').classList.add('hidden');
+  $('#bootLog').textContent = '';
 
-  const unsub = omadia.onBootProgress((p) => {
+  // Elapsed timer so a long first-boot (migrations) clearly looks alive.
+  const started = Date.now();
+  const elapsedEl = $('#elapsed');
+  const ticker = setInterval(() => {
+    if (elapsedEl) elapsedEl.textContent = `(${Math.round((Date.now() - started) / 1000)}s)`;
+  }, 1000);
+
+  const unsubProgress = omadia.onBootProgress((p) => {
     const pct = PHASE_PCT[p.phase] ?? 10;
     $('#barFill').style.width = pct + '%';
     $('#progressMsg').textContent = p.message + (p.detail ? ' — ' + p.detail : '');
     if (p.phase === 'error') $('#barFill').style.background = 'var(--err)';
   });
+  // Live, granular log (kernel migrations, plugin activation, DB readiness …).
+  const unsubLog = omadia.onBootLog
+    ? omadia.onBootLog((line) => appendBootLog(line.level, line.msg))
+    : () => {};
 
-  const res = await omadia.complete(collectConfig());
-  unsub();
+  let res;
+  try {
+    res = await omadia.complete(collectConfig());
+  } catch (err) {
+    res = { ok: false, error: (err && err.message) || 'Setup crashed unexpectedly.' };
+  } finally {
+    clearInterval(ticker);
+    unsubProgress();
+    unsubLog();
+  }
 
   if (!res.ok) {
     const err = $('#provisionError');
     err.textContent = res.error || 'Setup failed. Check the logs (tray → Open Logs).';
     err.classList.remove('hidden');
+    appendBootLog('ERROR', res.error || 'Setup failed.');
     // Allow another attempt.
     document.querySelector('.nav').style.display = 'flex';
     $('#next').textContent = 'Retry';
@@ -121,35 +169,59 @@ $('#back').addEventListener('click', () => {
 });
 
 $('#testKey').addEventListener('click', async () => {
+  if (!bridgeOk()) return;
   const provider = $('#provider').value;
   const apiKey = $('#apiKey').value.trim();
   if (apiKey.length < 8) {
     flashTest('Key looks too short.', false);
     return;
   }
+  const btn = $('#testKey');
+  btn.disabled = true;
   flashTest('Testing…', true);
-  const res = await omadia.testLlmKey({ provider, apiKey });
-  state.keyVerified = res.ok;
-  flashTest(res.ok ? 'Key works.' : res.error || 'Key check failed.', res.ok);
+  try {
+    const res = await omadia.testLlmKey({ provider, apiKey });
+    state.keyVerified = res.ok;
+    flashTest(res.ok ? 'Key works.' : res.error || 'Key check failed.', res.ok);
+  } catch (err) {
+    // Never leave the user stuck on "Testing…" — surface the failure.
+    state.keyVerified = false;
+    flashTest((err && err.message) || 'Key check failed (internal error).', false);
+  } finally {
+    btn.disabled = false;
+  }
 });
 
 $('#chooseDir').addEventListener('click', async () => {
-  const dir = await omadia.chooseDataDir();
-  if (dir) {
-    state.dataDir = dir;
-    $('#dataDir').value = dir;
-    $('#dataDirHint').textContent = 'omadia will store everything in this folder.';
+  if (!bridgeOk()) return;
+  try {
+    const dir = await omadia.chooseDataDir();
+    if (dir) {
+      state.dataDir = dir;
+      $('#dataDir').value = dir;
+      $('#dataDirHint').textContent = 'omadia will store everything in this folder.';
+    }
+  } catch (err) {
+    $('#dataDirHint').textContent =
+      'Could not open the folder picker: ' + ((err && err.message) || 'internal error') + '. The default folder will be used.';
   }
 });
 
 $('#revealKey').addEventListener('click', async () => {
-  const key = await omadia.exportRecoveryKey();
-  $('#recoveryKey').textContent = key;
-  $('#revealKey').textContent = 'Copy';
-  $('#revealKey').onclick = async () => {
-    await navigator.clipboard.writeText(key);
-    $('#revealKey').textContent = 'Copied';
-  };
+  if (!bridgeOk()) return;
+  try {
+    const key = await omadia.exportRecoveryKey();
+    $('#recoveryKey').textContent = key;
+    $('#revealKey').textContent = 'Copy';
+    $('#revealKey').onclick = async () => {
+      await navigator.clipboard.writeText(key);
+      $('#revealKey').textContent = 'Copied';
+    };
+  } catch (err) {
+    $('#recoveryKey').textContent = 'unavailable — ' + ((err && err.message) || 'internal error');
+  }
 });
 
 goto(0);
+// Fail loud, not silent, if the preload bridge is missing.
+if (!omadia) bridgeOk();


### PR DESCRIPTION
Follow-up to #355 (native installer + bundled PostgreSQL 17, already merged). Fixes the onboarding wizard, which was broken on all platforms but only surfaced when actually running the wizard on Windows.

## Symptoms (reported on Windows)

1. **Key Test** stuck on "Testing…" forever.
2. **Data-folder picker** never opens.
3. Setup does not continue after that.

## Root cause (one bug)

The BrowserWindow runs with `sandbox: true`, but `tsc` emitted a preload doing `require("./ipcTypes")`. A sandboxed preload only gets a limited `require` and cannot load local modules, so the preload failed (`module not found: ./ipcTypes`), `window.omadia` was never exposed, and every wizard/loading bridge call silently rejected with no catch → it hung. macOS never hit it because the boot tests pre-seeded `setup.json` and skipped the wizard entirely.

## Fix

- **Bundle the preload** into a self-contained `dist/preload.js` with esbuild (`electron` external), so it loads under the sandbox while keeping one source of truth for the channel names + types. (Adds an esbuild devDep + a build step.)
- **Renderer hardening**: every bridge call (`testLlmKey` / `chooseDataDir` / `exportRecoveryKey` / `complete`) is guarded and try/caught, so a bridge failure shows a clear error instead of hanging. The key test resets its button and surfaces results; the folder picker reports failure and falls back to the default location.
- **Install verbosity** (requested): kernel / web-ui / Postgres output all funnel through `log`, so an `onLog` tap mirrors lines to the wizard + loading UI via a new gated `bootLog` IPC channel. Both screens now show a live scrolling log plus an elapsed-time counter, so a long first boot (migrations) visibly stays alive.

## Verification

On the packaged macOS `.app`, driven against the actual wizard via CDP:

```
window.omadia  = object        (was undefined → the whole bug)
testLlmKey     = function
chooseDataDir  = function
onBootLog      = function
testLlmKey round-trip = RESOLVED {"ok":false,"error":"Key was rejected (unauthorized)."}
```

The key test now resolves through the full IPC→main→fetch cycle instead of hanging; `chooseDataDir` / `complete` use the same now-working bridge. The fix is platform-agnostic (sandbox preload behaves identically on Windows). All three desktop builds are green.

Note: I can't run the Windows installer on the macOS dev box, so the final click-through of onboarding on Windows is still worth a manual confirmation.
