### PR TITLE
fix(web-ui): lowercase the omadia brand name in user-facing text

### DIFF
--- a/web-ui/Dockerfile
+++ b/web-ui/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 #
-# Omadia Admin UI — Next.js standalone build for Docker / Fly.io.
+# omadia Admin UI — Next.js standalone build for Docker / Fly.io.
 # Multi-stage: install deps → build standalone → copy thin runtime image.
 # Final image ~150 MB (node 22 slim + standalone server + static assets).
 

--- a/web-ui/README.md
+++ b/web-ui/README.md
@@ -1,4 +1,4 @@
-# `web-ui/` — Local Next.js dev UI for the Omadia middleware
+# `web-ui/` — Local Next.js dev UI for the omadia middleware
 
 Lightweight Next.js 15 + React 19 app that renders the chat surface, the plugin store, the builder, and the admin panels on top of the middleware's `/api/v1/*` HTTP API. **Not for production exposure** — auth is cookie-based and assumes a trusted single-tenant deployment.
 

--- a/web-ui/app/admin/page.tsx
+++ b/web-ui/app/admin/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 
 export const metadata: Metadata = {
-  title: 'Admin · Omadia',
+  title: 'Admin · omadia',
 };
 
 export default function AdminIndexPage(): React.ReactElement {

--- a/web-ui/app/layout.tsx
+++ b/web-ui/app/layout.tsx
@@ -91,7 +91,7 @@ export default async function RootLayout({
                   >
                     <span className="flex flex-col leading-none">
                       <span className="font-display text-lg text-[color:var(--fg-strong)]">
-                        Omadia
+                        omadia
                       </span>
                       <span className="mt-1 text-[10px] uppercase tracking-[0.14em] text-[color:var(--fg-muted)]">
                         an Agentic OS

--- a/web-ui/app/login/page.tsx
+++ b/web-ui/app/login/page.tsx
@@ -238,7 +238,7 @@ function PageShell({ children }: { children: React.ReactNode }): React.ReactElem
       <div className="lume-surface-raised lume-border w-full max-w-sm rounded-lg p-6 shadow-[var(--shadow-lg)]">
         <header className="mb-6 flex flex-col leading-none">
           <h1 className="font-display text-3xl text-[color:var(--fg-strong)]">
-            Omadia
+            omadia
           </h1>
           <span className="mt-2 text-[11px] uppercase tracking-[0.18em] text-[color:var(--fg-muted)]">
             an Agentic OS

--- a/web-ui/app/operator/agents/page.tsx
+++ b/web-ui/app/operator/agents/page.tsx
@@ -13,7 +13,7 @@ import { AgentsDashboard } from './_components/AgentsDashboard';
  */
 
 export const metadata: Metadata = {
-  title: 'Agents · Omadia',
+  title: 'Agents · omadia',
 };
 
 export const dynamic = 'force-dynamic';

--- a/web-ui/app/operator/channels/page.tsx
+++ b/web-ui/app/operator/channels/page.tsx
@@ -18,7 +18,7 @@ import { ChannelsDashboard } from './_components/ChannelsDashboard';
  */
 
 export const metadata: Metadata = {
-  title: 'Channels · Omadia',
+  title: 'Channels · omadia',
 };
 
 export const dynamic = 'force-dynamic';

--- a/web-ui/app/routines/[id]/runs/[runId]/page.tsx
+++ b/web-ui/app/routines/[id]/runs/[runId]/page.tsx
@@ -18,7 +18,7 @@ interface RouteParams {
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  title: 'Routine Run · Omadia',
+  title: 'Routine Run · omadia',
 };
 
 export default async function RoutineRunDetailPage({

--- a/web-ui/app/routines/page.tsx
+++ b/web-ui/app/routines/page.tsx
@@ -5,7 +5,7 @@ import { redirectIfUnauthorized } from '../_lib/authRedirect';
 import { RoutineRow } from './_components/RoutineRow';
 
 export const metadata: Metadata = {
-  title: 'Routines · Omadia',
+  title: 'Routines · omadia',
 };
 
 export const dynamic = 'force-dynamic';

--- a/web-ui/app/store/[id]/page.tsx
+++ b/web-ui/app/store/[id]/page.tsx
@@ -400,7 +400,7 @@ export default async function PluginDetailPage({
           <BookCheck className="size-3.5" aria-hidden />
           Manifest: {isLegacy ? 'Legacy' : 'Schema v1'}
         </span>
-        <span className="font-mono-num">Omadia · v1 · Slice 1.1</span>
+        <span className="font-mono-num">omadia · v1 · Slice 1.1</span>
       </footer>
     </main>
   );

--- a/web-ui/app/store/builder/[id]/page.tsx
+++ b/web-ui/app/store/builder/[id]/page.tsx
@@ -9,7 +9,7 @@ import { redirectIfUnauthorized } from '../../../_lib/authRedirect';
 import { Workspace } from './_components/Workspace';
 
 export const metadata: Metadata = {
-  title: 'Workspace · Agent-Builder · Omadia',
+  title: 'Workspace · Agent-Builder · omadia',
 };
 
 export const dynamic = 'force-dynamic';

--- a/web-ui/app/store/builder/page.tsx
+++ b/web-ui/app/store/builder/page.tsx
@@ -15,7 +15,7 @@ import { ImportBundleButton } from './_components/ImportBundleButton';
 import { QuotaBadge } from './_components/QuotaBadge';
 
 export const metadata: Metadata = {
-  title: 'Agent-Builder · Omadia',
+  title: 'Agent-Builder · omadia',
 };
 
 export const dynamic = 'force-dynamic';
@@ -181,7 +181,7 @@ export default async function BuilderDashboardPage({
           </span>
         </span>
         <span className="font-mono-num text-[color:var(--fg-muted)]">
-          Omadia · Agent-Builder
+          omadia · Agent-Builder
         </span>
       </footer>
     </main>

--- a/web-ui/app/store/page.tsx
+++ b/web-ui/app/store/page.tsx
@@ -12,7 +12,7 @@ import { UploadDropzone } from '../_components/store/UploadDropzone';
 import { cn } from '../_lib/cn';
 
 export const metadata: Metadata = {
-  title: 'Plugin-Store · Omadia',
+  title: 'Plugin-Store · omadia',
 };
 
 export const dynamic = 'force-dynamic';
@@ -100,7 +100,7 @@ export default async function StorePage({
     <main className="mx-auto max-w-[1280px] px-6 py-12 lg:px-8 lg:py-16">
       <OnboardingModal installedCount={installedCount} profiles={profiles} />
 
-      {/* Hero — Omadia brand cadence (Days One headline + magenta colon lead) */}
+      {/* Hero — omadia brand cadence (Days One headline + magenta colon lead) */}
       <header className="b5-hero-bg relative -mx-6 rounded-lg border border-[color:var(--divider)] px-6 py-8 lg:-mx-8 lg:px-8 lg:py-12">
         <div className="flex items-baseline gap-3 text-[12px] font-semibold uppercase tracking-[0.24em] text-[color:var(--accent)]">
           <span className="font-mono-num text-[color:var(--fg-subtle)]">
@@ -111,7 +111,7 @@ export default async function StorePage({
         </div>
 
         <h1 className="font-display mt-6 text-[clamp(2.25rem,4.5vw,3.75rem)] leading-[1.05] text-[color:var(--fg-strong)]">
-          Agenten für die Omadia-Plattform.
+          Agenten für die omadia-Plattform.
         </h1>
 
         <p className="mt-6 max-w-2xl text-[18px] font-semibold leading-[1.55] text-[color:var(--fg)]">
@@ -211,7 +211,7 @@ export default async function StorePage({
           </span>
         </span>
         <span className="font-mono-num text-[color:var(--fg-muted)]">
-          Omadia · v1
+          omadia · v1
         </span>
       </footer>
     </main>

--- a/web-ui/app/system/page.tsx
+++ b/web-ui/app/system/page.tsx
@@ -5,7 +5,7 @@ import { redirectIfUnauthorized } from '../_lib/authRedirect';
 import { VaultStatusCard } from './_components/VaultStatusCard';
 
 export const metadata: Metadata = {
-  title: 'System · Omadia',
+  title: 'System · omadia',
 };
 
 export const dynamic = 'force-dynamic';

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -143,10 +143,10 @@
     "clearStale": "Binding entfernen"
   },
   "layout": {
-    "logoAriaLabel": "Omadia · Startseite",
+    "logoAriaLabel": "omadia · Startseite",
     "subtitle": "Management UI · local",
-    "metaTitle": "Omadia · Management UI",
-    "metaDescription": "Verwaltungsoberfläche für die Omadia Agent-Plattform (lokal)."
+    "metaTitle": "omadia · Management UI",
+    "metaDescription": "Verwaltungsoberfläche für die omadia Agent-Plattform (lokal)."
   },
   "localeSwitcher": {
     "ariaLabel": "Sprache wechseln"
@@ -166,7 +166,7 @@
     }
   },
   "login": {
-    "title": "Bei Omadia anmelden",
+    "title": "Bei omadia anmelden",
     "shellLoading": "Lade Login…",
     "loadingProviders": "Lade Login…",
     "errorPrefix": "Login-Provider konnten nicht geladen werden:",
@@ -180,7 +180,7 @@
     "continueWith": "Weiter mit {provider}"
   },
   "setup": {
-    "title": "Willkommen bei Omadia",
+    "title": "Willkommen bei omadia",
     "shellLoading": "Lade Setup…",
     "loading": "Lade Setup…",
     "errorPrefix": "Setup-Status konnte nicht geladen werden:",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -143,10 +143,10 @@
     "clearStale": "Clear binding"
   },
   "layout": {
-    "logoAriaLabel": "Omadia · Home",
+    "logoAriaLabel": "omadia · Home",
     "subtitle": "Management UI · local",
-    "metaTitle": "Omadia · Management UI",
-    "metaDescription": "Admin UI for the Omadia agent platform (local)."
+    "metaTitle": "omadia · Management UI",
+    "metaDescription": "Admin UI for the omadia agent platform (local)."
   },
   "localeSwitcher": {
     "ariaLabel": "Switch language"
@@ -166,7 +166,7 @@
     }
   },
   "login": {
-    "title": "Sign in to Omadia",
+    "title": "Sign in to omadia",
     "shellLoading": "Loading login…",
     "loadingProviders": "Loading login…",
     "errorPrefix": "Failed to load login providers:",
@@ -180,7 +180,7 @@
     "continueWith": "Continue with {provider}"
   },
   "setup": {
-    "title": "Welcome to Omadia",
+    "title": "Welcome to omadia",
     "shellLoading": "Loading setup…",
     "loading": "Loading setup…",
     "errorPrefix": "Failed to load setup state:",


### PR DESCRIPTION
## What

The brand name is always written **omadia** (all lowercase). Several
user-facing surfaces in the web-ui still rendered the capitalized
"Omadia". This PR lowercases every one of them.

### Changed (web-ui, 16 files)
- **Page `<title>` metadata** — admin, system, routines (+ run detail), agents, channels, store, builder (+ workspace).
- **Wordmarks** — the sidebar logo (`layout.tsx`) and the login header (`login/page.tsx`).
- **Footers / hero** — store footer, builder footer, store hero headline, plugin-detail footer.
- **i18n strings** — `messages/de.json` + `messages/en.json` (logo aria-label, meta title/description, login title, setup welcome).
- **Prose** — `README.md`, `Dockerfile` header comment, one source comment.

### Deliberately NOT changed
camelCase code identifiers are part of the API/data contract and must
stay as-is: `actorOmadiaUserId`, `involvedOmadiaUserIds`, and the
`OmadiaBridge` TypeScript type in the desktop app.

### Desktop app
Already lowercase everywhere user-facing (`productName: omadia`, tray,
window titles, onboarding wizard HTML, updater dialogs). The only
capitalized occurrence is the `OmadiaBridge` type name — code, left
untouched. So no functional desktop changes were needed.

## Verification
- `tsc --noEmit` clean (node 22.22.3).
- `de.json` / `en.json` parse as valid JSON.
- grep confirms the only remaining "Omadia" tokens are the camelCase identifiers above.
- No test asserts on the changed brand strings.
