### PR TITLE
docs: onboarding, contributor security, and package metadata (#344-#350)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,29 @@ for everyone.
   out. Auto-generated boilerplate (param descriptions that just restate
   the type) is noise; please skip it.
 
+## Security guidelines
+
+The middleware runs plugin code and custodies operator secrets, so a few rules
+are non-negotiable in any contribution:
+
+- Never interpolate untrusted input into a shell command. Use argument arrays
+  or `execFile`, never string concatenation into `exec`.
+- Unwrap symlinks before any path operation on an operator-supplied path, so a
+  crafted link cannot escape the directory it is meant to stay in.
+- No `eval` or `new Function()` on untrusted content in plugin code.
+- Validate cron strings before they reach the scheduler.
+
+The patterns behind these rules live in
+[`docs/security-architecture.md`](docs/security-architecture.md). Read it
+before you touch the vault, the plugin loader, or any ingress channel.
+
+### Dependency hardening
+
+- **npm**: pin to a caret range (`^x.y.z`). Patch-level auto-updates are
+  acceptable; open ranges (`*`, `latest`) and unpinned minors are not.
+- **GitHub Actions**: pin third-party actions to a full commit SHA, not a
+  moving tag. First-party `actions/*` may stay on a major tag.
+
 ## Plugin contributions
 
 Channel and integration plugins generally belong in their own repositories

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ sprawling feature nobody asked for.
 
 Prerequisites:
 
-- Node.js **22.12.x** (pinned via `middleware/.nvmrc` — `nvm use` picks
+- Node.js **22.22.x** (pinned via `middleware/.nvmrc` — `nvm use` picks
   it up automatically). Other Node versions break the `better-sqlite3`
   native ABI; the `preinstall` hook will refuse to proceed if you're on
   the wrong version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,22 @@ change can land quickly.
 - Security issues do **not** belong in the public issue tracker. See
   [SECURITY.md](SECURITY.md) for the private channel.
 
+## Contribution priority
+
+Not every contribution gets the same review turnaround. Roughly highest to
+lowest:
+
+1. **Bug fixes**, especially regressions against a released version
+2. **Security improvements** (coordinate sensitive ones privately first, see
+   [SECURITY.md](SECURITY.md))
+3. **Performance improvements** that ship with a before/after benchmark
+4. **New features** that match the roadmap in the
+   [README](README.md#status--roadmap)
+5. **Documentation and examples**
+
+This is a guide, not a gate. A well-scoped docs fix still lands faster than a
+sprawling feature nobody asked for.
+
 ## Local development setup
 
 Prerequisites:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ Your LLM key. Your data. Your compliance story.
   for each agent run, so you can audit, debug, and prove what happened — built in,
   not bolted on.
 
+## Prerequisites
+
+The quickstart runs entirely in containers, so the host stays light:
+
+- **Docker 24+** with the Docker Compose v2 plugin (the `docker compose`
+  subcommand, not the legacy `docker-compose` binary)
+- **Git**, to clone the repository
+
+That is the whole list for running omadia. A local Node toolchain is only
+needed when you build the services from source or develop plugins:
+
+- **Node 22.x** for the middleware and admin UI outside Docker. The pinned
+  version lives in `.nvmrc`, so `nvm use` picks it up. The middleware blocks
+  installation on a mismatched major version, because native modules are
+  built against a specific ABI.
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full from-source setup.
+
 ## ⚡ Quickstart
 
 ```bash
@@ -255,6 +273,30 @@ Third-party dependency licenses and notices are documented in
 free of GPL, AGPL, and SSPL packages; weak-copyleft components (LGPL via
 `sharp-libvips`, MPL-2.0 via `axe-core` / `lightningcss` / `dompurify`) are
 used as documented unmodified dependencies.
+
+## Troubleshooting
+
+**Port already in use.** The core binds `3333` for the admin UI plus the
+Postgres port. If another process holds one of them, the affected container
+exits on start. Free the port, or remap it in your own compose override, then
+re-run `docker compose up -d`.
+
+**`VAULT_KEY` missing at boot.** A production image (`NODE_ENV=production`)
+refuses to start without `VAULT_KEY`, on purpose. Generate one with `openssl
+rand -base64 32` and set it in your project-root `.env` before deploying. The
+bundled `docker-compose.yaml` pins `NODE_ENV=development`, so a local `docker
+compose up` keeps the dev fallback. Full context lives in
+[Deployment](#deployment).
+
+**Optional overlay not found.** Optional features are overlay files added with
+repeated `-f` flags, not Compose profiles. Pass the full filename, for example
+`-f docker-compose.yaml -f docker-compose.storage.yaml`. A bare `--profile
+storage` matches nothing here.
+
+**Node version mismatch from source.** The middleware pins its Node major
+version in `.nvmrc` and stops `npm install` on a different one, because
+`better-sqlite3` and other native modules are compiled against a specific ABI.
+Run `nvm use` in the repository root before installing.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -177,8 +177,9 @@ The operator UI and the canvas app share one identity.
   (Postgres + pgvector) (Ollama / API)              (AES-256-GCM file)
 ```
 
-A more detailed walk-through of the plugin loading sequence, capability
-registry, and the multi-provider authentication layer lives under
+Start with the [architecture overview](docs/architecture.md) for the component
+map and request flow. The deeper walk-through of the plugin loading sequence,
+capability registry, and multi-provider authentication layer lives under
 [`docs/`](docs/).
 
 ### Optional features

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,16 +6,20 @@ Dieser Ordner ist das kollektive Gedächtnis des Omadia-Projekts. Mehrere Agents
 
 1. [`/AGENTS.md`](../AGENTS.md) — Dokumentations-Policy, Kernregeln, Anti-Pattern
 2. **dieses README** — Landkarte
-3. [`middleware-agent-handoff.md`](middleware-agent-handoff.md) — Vollständige Tech-Übersicht
-4. [`CHANGELOG.md`](CHANGELOG.md) — Was ist zuletzt passiert
-5. [`security-architecture.md`](security-architecture.md) — Security-Design-Patterns
+3. [`architecture.md`](architecture.md) — System-Überblick (Component-Map, Request-Flow), Einstieg vor dem Deep-Dive
+4. [`middleware-agent-handoff.md`](middleware-agent-handoff.md) — Vollständige Tech-Übersicht
+5. [`CHANGELOG.md`](CHANGELOG.md) — Was ist zuletzt passiert
+6. [`security-architecture.md`](security-architecture.md) — Security-Design-Patterns
 
 ## Dokument-Verzeichnis
 
 | Doc | Scope | Update-Frequenz | Wer pflegt |
 |---|---|---|---|
 | [`/AGENTS.md`](../AGENTS.md) | **Policy** für Multi-Agent-Arbeit | Nur bei Regelwechsel | Jeder, der die Regeln ändert — MIT CHANGELOG-Eintrag |
+| [`architecture.md`](architecture.md) | System-Überblick: Component-Map, Request-Flow, Key-Decisions — die **Landkarte** vor den Deep-Dive-Docs | Bei strukturellen Architektur-Änderungen | Feature-Agents |
 | [`middleware-agent-handoff.md`](middleware-agent-handoff.md) | Architektur, Layout, Commands, Config, Roadmap — der **primäre** Tech-Einstieg | Bei jeder strukturellen Änderung | Feature-Agents |
+| [`upgrading.md`](upgrading.md) | Upgrade- und Migrations-Pfade pro Minor-Version (Env-Vars, Schema, Plugin-API) | Bei jedem Release mit Breaking Changes | Release-Thread |
+| [`rca/`](rca/) | Root-Cause-Analysen für operative Incidents (Template + Index) | Nach jedem Incident | Operator / betroffener Thread |
 | [`CHANGELOG.md`](CHANGELOG.md) | Rolling chronologische Chronik aller signifikanten Änderungen | Nach jeder Aufgabe | Der Agent, der die Änderung macht |
 | [`security-architecture.md`](security-architecture.md) | Security-Design-Patterns (Vault-Credentials, Proxy-Routes, Scope-Locked Sub-Agents, signed URLs) | Bei Security-Architektur-Änderungen | Security-Thread |
 | [`creating-plugins.md`](creating-plugins.md) | HowTo: Plugin bauen (Scaffold → Manifest → ZIP) + Publish auf den Hub | Bei Änderungen am Package-Contract / Publish-Flow | Plugin-/Registry-Thread |

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Dieser Ordner ist das kollektive Gedächtnis des Omadia-Projekts. Mehrere Agents
 
 1. [`/AGENTS.md`](../AGENTS.md) — Dokumentations-Policy, Kernregeln, Anti-Pattern
 2. **dieses README** — Landkarte
-3. [`architecture.md`](architecture.md) — System-Überblick (Component-Map, Request-Flow), Einstieg vor dem Deep-Dive
+3. [`architecture.md`](architecture.md): System-Überblick (Component-Map, Request-Flow), Einstieg vor dem Deep-Dive
 4. [`middleware-agent-handoff.md`](middleware-agent-handoff.md) — Vollständige Tech-Übersicht
 5. [`CHANGELOG.md`](CHANGELOG.md) — Was ist zuletzt passiert
 6. [`security-architecture.md`](security-architecture.md) — Security-Design-Patterns
@@ -16,7 +16,7 @@ Dieser Ordner ist das kollektive Gedächtnis des Omadia-Projekts. Mehrere Agents
 | Doc | Scope | Update-Frequenz | Wer pflegt |
 |---|---|---|---|
 | [`/AGENTS.md`](../AGENTS.md) | **Policy** für Multi-Agent-Arbeit | Nur bei Regelwechsel | Jeder, der die Regeln ändert — MIT CHANGELOG-Eintrag |
-| [`architecture.md`](architecture.md) | System-Überblick: Component-Map, Request-Flow, Key-Decisions — die **Landkarte** vor den Deep-Dive-Docs | Bei strukturellen Architektur-Änderungen | Feature-Agents |
+| [`architecture.md`](architecture.md) | System-Überblick: Component-Map, Request-Flow, Key-Decisions. Die **Landkarte** vor den Deep-Dive-Docs | Bei strukturellen Architektur-Änderungen | Feature-Agents |
 | [`middleware-agent-handoff.md`](middleware-agent-handoff.md) | Architektur, Layout, Commands, Config, Roadmap — der **primäre** Tech-Einstieg | Bei jeder strukturellen Änderung | Feature-Agents |
 | [`upgrading.md`](upgrading.md) | Upgrade- und Migrations-Pfade pro Minor-Version (Env-Vars, Schema, Plugin-API) | Bei jedem Release mit Breaking Changes | Release-Thread |
 | [`rca/`](rca/) | Root-Cause-Analysen für operative Incidents (Template + Index) | Nach jedem Incident | Operator / betroffener Thread |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,68 @@
+# omadia architecture overview
+
+A one-page map of the system and how a request flows through it. This is the
+orientation layer. For the full technical detail, read
+[`middleware-agent-handoff.md`](middleware-agent-handoff.md); for the security
+patterns, read [`security-architecture.md`](security-architecture.md).
+
+omadia is a self-hostable agentic operating system. You compose teams of agents
+from signed plugins, run them on one machine, and get an auditable trace for
+every action they take.
+
+## Component map
+
+| Component | What it does |
+|---|---|
+| **Middleware kernel** | The Node process that boots everything, loads plugins, and exposes the HTTP API. Runs on `:3333` in the default compose setup. |
+| **Orchestrator** | Routes each conversation turn to the right agent, dispatches tool calls, and streams the result back. Records a per-run trace. |
+| **Plugin runtime** | Loads agents, tools, capability providers, and integrations behind one stable contract, [`@omadia/plugin-api`](../middleware/packages/plugin-api). Plugins ship as signed ZIPs with their dependencies baked in. |
+| **Knowledge graph** | The agent memory substrate. pgvector on Postgres in production, with an in-memory alternative for tests. |
+| **Embeddings** | Turns content into vectors for retrieval. Local Ollama or an external API, opt-in via a compose overlay. |
+| **Vault** | Encrypted secret storage (AES-256-GCM file). Holds LLM keys and connector credentials; gated by `VAULT_KEY` in production. |
+| **Ingress channels** | Where conversations enter. Web-chat (the admin UI) is in-tree; Teams and Telegram ship as separate plugin ZIPs. |
+| **Web UI** | The Next.js admin UI: setup wizard, plugin builder, chat, and the call-stack trace viewer. Styled with Lume. |
+
+## Data flow
+
+A single turn travels one path:
+
+```
+channel  ->  orchestrator  ->  plugin (agent / tool)  ->  knowledge graph / vault
+            (routes turn)     (does the work)            (memory + secrets)
+   ^                                                            |
+   |____________________  response + trace  _____________________|
+```
+
+1. A message arrives on a **channel** and is handed to the kernel through the
+   ChannelSDK as a `SemanticAnswer` request.
+2. The **orchestrator** picks the agent for the turn and passes it a
+   `PluginContext` (`ctx`): memory access, tool dispatch, vault reads, and
+   logging.
+3. The **agent** runs, calling **tools** and **capability providers** as
+   needed. Reads and writes go through the **knowledge graph**; secrets come
+   from the **vault**, never from prompts or config.
+4. The result streams back to the channel, and the full **trace** (every step,
+   tool call, and decision) is stored as the run's audit receipt.
+
+## Key design decisions
+
+The reasoning behind the architecture is captured as ADRs under
+[`docs/adr/`](adr/). The load-bearing ones:
+
+- [ADR-0001: Plugin distribution via signed ZIP packages](adr/0001-plugin-distribution-via-signed-zip.md):
+  plugins are verifiable packages, not arbitrary npm pulled at runtime.
+- [ADR-0003: Capability-based, multi-provider middleware](adr/0003-capability-based-multi-provider-middleware.md):
+  agents depend on capabilities, not concrete providers, so LLMs and storage
+  stay swappable.
+- [ADR-0004: Knowledge graph as the agent memory substrate](adr/0004-knowledge-graph-as-memory-substrate.md):
+  memory is a graph, not a flat log.
+- [ADR-0005: Two-phase confirmation for write-capable connectors](adr/0005-two-phase-confirmation-for-writes.md):
+  write actions are proposed and confirmed, not fired blind.
+
+## Go deeper
+
+- [`middleware-agent-handoff.md`](middleware-agent-handoff.md): the plugin
+  loading sequence, capability registry, and multi-provider auth layer.
+- [`security-architecture.md`](security-architecture.md): vault credentials,
+  proxy routes, scope-locked sub-agents, and signed URLs.
+- [`adr/`](adr/): the full decision record.

--- a/docs/rca/0000-template.md
+++ b/docs/rca/0000-template.md
@@ -1,0 +1,41 @@
+# RCA-NNNN: <short incident title>
+
+## Summary
+
+<Two or three sentences: what broke, what was affected, and for how long.>
+
+- **Date:** YYYY-MM-DD
+- **Severity:** <low | medium | high>
+- **Status:** <investigating | resolved>
+- **Authors:** <roles / people>
+
+## Impact
+
+<The observable effect. Which users, environments, or services were hit, and
+in what way.>
+
+## Root cause
+
+<The single underlying reason, stated plainly. The cause, not the symptom.>
+
+## Timeline
+
+All times <timezone>.
+
+- `HH:MM`: <first event>
+- `HH:MM`: <detection>
+- `HH:MM`: <mitigation applied>
+- `HH:MM`: <resolution confirmed>
+
+## Fix
+
+<What was changed to resolve the incident. Link the PR or commit.>
+
+## Prevention
+
+<What keeps this class of incident from recurring: a test, a guard, an alert, a
+doc, or a process change. Each item concrete and actionable.>
+
+## More information
+
+<Links to related ADRs, PRs, logs, or discussion.>

--- a/docs/rca/README.md
+++ b/docs/rca/README.md
@@ -1,0 +1,29 @@
+# Root Cause Analyses
+
+This directory records root cause analyses (RCAs) for operational incidents in
+**omadia**: production outages, release quirks, and data issues worth learning
+from.
+
+An RCA captures what broke, why, and what stops it from happening again. It is
+the operational counterpart to an [ADR](../adr/). An ADR explains a design
+decision; an RCA explains an incident.
+
+## Why we keep RCAs
+
+- Turn a one-time firefight into durable knowledge.
+- Give new operators the "why" behind a guard or an alert.
+- Signal that incidents are handled in the open.
+
+## Writing a new RCA
+
+1. Copy [`0000-template.md`](0000-template.md) to the next free number:
+   `NNNN-short-kebab-title.md`.
+2. Fill in Summary, Impact, Root cause, Timeline, Fix, and Prevention.
+3. Keep it blameless: focus on systems and causes, not individuals.
+4. Add a row to the index below.
+
+## Index
+
+| #    | Title       | Date       |
+| ---- | ----------- | ---------- |
+| _none yet_ |       |            |

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,43 @@
+# Upgrade and migration guide
+
+How to move an omadia deployment from one version to the next.
+[`CHANGELOG.md`](CHANGELOG.md) records *what* changed; this guide covers *how
+to migrate*: renamed environment variables, schema changes, removed config
+keys, and shifts in the plugin API.
+
+> **Pre-1.0 caveat.** omadia is in public preview. Database schemas and
+> internal surfaces may break between minor versions until `1.0.0`, and the
+> upgrade path is hand-rolled today. An automated migration runner is on the
+> v1.0 roadmap. Until then, read the section for your target version before
+> pulling a new image.
+
+## General upgrade steps
+
+1. Read the section for your target version below, plus the
+   [`CHANGELOG.md`](CHANGELOG.md) entries since your current one.
+2. Back up your Postgres volume and your `VAULT_KEY`.
+3. Pull the new image. Pin a release with `OMADIA_VERSION`, see the
+   [README quickstart](../README.md#-quickstart).
+4. Restart with `docker compose up -d`.
+5. Verify the admin UI comes up and an existing agent run still works.
+
+## Upgrading to 0.3
+
+> Stub. Fill this in as part of the 0.3 release.
+
+### Breaking changes
+
+- _none recorded yet_
+
+### Steps
+
+1. Pull the new image.
+2. Run the database migration if the schema changed (called out in the
+   CHANGELOG).
+3. Update any plugins built against an older `@omadia/plugin-api`.
+
+## Keeping this guide current
+
+Add a section per minor version as part of the release process. Even a short
+stub beats a blank page: record renamed env vars, schema migrations, and
+removed config keys while they are fresh.

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -4,6 +4,17 @@
   "private": true,
   "type": "module",
   "main": "dist/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/byte5ai/omadia"
+  },
+  "homepage": "https://omadia.ai",
+  "keywords": [
+    "ai-agents",
+    "self-hosted",
+    "orchestrator",
+    "plugin"
+  ],
   "workspaces": [
     "packages/*"
   ],

--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "odoo-bot-web-ui",
+  "name": "@omadia/web-ui",
   "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "odoo-bot-web-ui",
+      "name": "@omadia/web-ui",
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -1,9 +1,20 @@
 {
-  "name": "odoo-bot-web-ui",
+  "name": "@omadia/web-ui",
   "private": true,
   "version": "0.2.0",
   "description": "Local-only Next.js dev UI for chatting with the middleware. Not for production.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/byte5ai/omadia"
+  },
+  "homepage": "https://omadia.ai",
+  "keywords": [
+    "ai-agents",
+    "self-hosted",
+    "orchestrator",
+    "plugin"
+  ],
   "scripts": {
     "dev": "next dev -p 3300",
     "build": "next build",


### PR DESCRIPTION
Bundles seven related documentation and metadata "good first issue" items into one PR. No runtime code changes.

## What's included

- **#344** `docs(readme)`: prerequisites section (Docker + Git, Node only for from-source/plugin dev) before the quickstart, and a troubleshooting FAQ (port conflicts, `VAULT_KEY` boot requirement, optional compose overlays, Node ABI mismatch).
- **#345** `docs(contributing)`: highest-to-lowest contribution priority list.
- **#346** `docs(contributing)`: contributor security guidelines + dependency hardening rules (npm caret pinning, SHA-pinned third-party Actions), linked to `docs/security-architecture.md`.
- **#347** `chore`: rename `web-ui` package `odoo-bot-web-ui` -> `@omadia/web-ui`, add `repository`/`homepage`/`keywords` to both `web-ui` and `middleware` manifests (lockfile name synced).
- **#348** `docs`: new `docs/architecture.md` one-page overview (component map, data flow, ADR-linked decisions), linked from the README and the docs index.
- **#349** `docs`: new `docs/rca/` pattern (blameless template + README index), modeled on the ADR template. Template only, no first entry yet.
- **#350** `docs`: new `docs/upgrading.md` migration guide (general steps + per-minor structure, 0.3 stub).

## Verification

- Both `package.json` files parse; `npm pkg get` confirms the new metadata. Lockfile diff is name-only (2 lines), no dependency churn.
- All added internal markdown links and README anchors resolve to existing files.
- New prose follows house style (no em-dashes, no AI-slop vocabulary, omadia lowercase).

Closes #344
Closes #345
Closes #346
Closes #347
Closes #348
Closes #349
Closes #350