### PR TITLE
feat(#309): run agents on LLM subscriptions via the official CLIs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,23 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends gosu zip \
  && rm -rf /var/lib/apt/lists/*
 
+# Subscription-CLI backends (#309): optionally bundle the official Claude CLI so
+# a single-operator self-host can run agents on a subscription (Claude Pro/Max)
+# instead of a metered API key. The CLI detector surfaces it in the admin UI.
+# Default OFF for public images — redistributing a proprietary vendor CLI needs
+# a legal review; the local/dev compose enables it via build arg. Login is still
+# per-host (`claude auth login`), never baked into the image.
+ARG INSTALL_SUBSCRIPTION_CLIS=false
+ARG CLAUDE_CODE_VERSION=2.1.187
+RUN if [ "${INSTALL_SUBSCRIPTION_CLIS}" = "true" ]; then \
+      npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+   && npm cache clean --force; \
+    fi
+# Subscription-CLI credentials live on the persisted data volume (not the
+# ephemeral image home), so a `claude auth login` survives container recreate.
+# The detector + login flow both honor CLAUDE_CONFIG_DIR.
+ENV CLAUDE_CONFIG_DIR=/data/claude-cli
+
 COPY middleware/package.json middleware/package-lock.json ./
 # S+11+ workspace packages: pull from the builder stage (with compiled dist/ per
 # package). Must be in place BEFORE `npm ci --omit=dev` so npm can

--- a/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
@@ -304,7 +304,7 @@ export function buildOrchestratorForAgent(
   // channels) routes to the CLI runtime, not just the default service. The raw
   // Orchestrator is still built + returned (sub-agents attach to it post-activate;
   // exposing those to the CLI dispatch is a follow-up — native tools work now).
-  if (deps.provider.id === 'claude-cli') {
+  if (deps.provider?.id === 'claude-cli') {
     // Security note (P2-2): the subscription CLI sees the FULL native tool
     // registry via the loopback MCP server, with no allowlist beyond MCP
     // server scoping; a per-agent tool allowlist is a follow-up.

--- a/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
@@ -44,6 +44,8 @@ import type { Microsoft365Accessor } from './microsoft365-shim.js';
 import type { NativeToolRegistry } from './nativeToolRegistry.js';
 import type { ModelRoutingConfig } from './modelRouter.js';
 import { Orchestrator } from './orchestrator.js';
+import { CliChatAgent } from './cliChatAgent.js';
+import { ToolDispatchService } from './toolDispatchService.js';
 import { OrchestratorMemoryNamespacer } from './orchestratorMemoryNamespacer.js';
 import { DurableRulesMemoryStore } from './durableRulesMemoryStore.js';
 import {
@@ -292,6 +294,45 @@ export function buildOrchestratorForAgent(
       ? { attachmentReader: deps.attachmentReader }
       : {}),
   });
+
+  // #309 Shape 3: a tool-less subscription-CLI provider (`claude-cli`) CANNOT
+  // drive the in-process tool loop (its `stream()`/`complete()` reject any
+  // request carrying tools). Swap the agent for the CLI agent-runtime, where the
+  // official `claude` CLI owns the loop and reaches omadia's tools via the
+  // loopback MCP server. Done HERE — the single factory the default chatAgent
+  // path AND the US4 registry both call — so every chat surface (web-ui canvas,
+  // channels) routes to the CLI runtime, not just the default service. The raw
+  // Orchestrator is still built + returned (sub-agents attach to it post-activate;
+  // exposing those to the CLI dispatch is a follow-up — native tools work now).
+  if (deps.provider.id === 'claude-cli') {
+    // Security note (P2-2): the subscription CLI sees the FULL native tool
+    // registry via the loopback MCP server, with no allowlist beyond MCP
+    // server scoping; a per-agent tool allowlist is a follow-up.
+    const dispatch = new ToolDispatchService({
+      nativeTools: deps.nativeToolRegistry,
+      // Live read: sub-agents (ask_<slug>) attach to `orchestrator` post-activate,
+      // so the CLI reaches them over the loopback bridge. A sub-agent's own loop
+      // still runs in-process on the tool-less claude-cli provider, so tool-using
+      // sub-agents fail GRACEFULLY (dispatch returns an error result) until they
+      // also run on the CLI (recursive Shape 3 — follow-up); tool-less ones work.
+      domainToolsProvider: () => orchestrator.listDomainTools(),
+    });
+    return {
+      orchestrator,
+      bundle: {
+        agent: new CliChatAgent({
+          dispatch,
+          model: config.model.replace(/-cli$/, '') || 'sonnet',
+          ...(deps.assistantIdentity
+            ? { systemPrompt: deps.assistantIdentity }
+            : {}),
+        }),
+        raw: orchestrator,
+        sessionLogger,
+        chatSessionStore,
+      },
+    };
+  }
 
   // Verifier wrapper — only when the `verifier@1` capability is published.
   // Without it the bare Orchestrator IS the chatAgent.

--- a/middleware/packages/harness-orchestrator/src/cliChatAgent.ts
+++ b/middleware/packages/harness-orchestrator/src/cliChatAgent.ts
@@ -1,0 +1,790 @@
+import { randomUUID } from 'node:crypto';
+import { spawn as nodeSpawn } from 'node:child_process';
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  ChatAgent,
+  ChatTurnInput,
+  ChatStreamEvent,
+  ChatStreamObserver,
+  SemanticAnswer,
+} from '@omadia/channel-sdk';
+import type {
+  DispatchableToolSpec,
+  ToolDispatchService,
+} from './toolDispatchService.js';
+import { LoopbackMcpServer } from './loopbackMcpServer.js';
+import type { LoopbackMcpServerHandle } from './loopbackMcpServer.js';
+
+const DEFAULT_CLI_BINARY = 'claude';
+const DEFAULT_MODEL = 'sonnet';
+const DEFAULT_SPAWN_TIMEOUT_MS = 120_000;
+const DEFAULT_IDLE_TIMEOUT_MS = 60_000;
+const FORCE_KILL_DELAY_MS = 2_000;
+const DEFAULT_MAX_CONCURRENT_TURNS = 3;
+
+const EMPTY_USAGE: CliUsage = {
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadInputTokens: 0,
+  cacheCreationInputTokens: 0,
+  costUsd: 0,
+  numTurns: 0,
+};
+
+export const CLI_ENV_SCRUB_KEYS: readonly string[] = [
+  // Direct API keys / tokens — would switch the CLI off the subscription.
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
+  'GOOGLE_API_KEY',
+  // Routing/header overrides — could redirect to a metered gateway/proxy.
+  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_CUSTOM_HEADERS',
+  // Alternate-backend switches — would bill Bedrock/Vertex, not the sub.
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_VERTEX',
+  'ANTHROPIC_VERTEX_PROJECT_ID',
+  'CLOUD_ML_REGION',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+  'AWS_PROFILE',
+  'AWS_REGION',
+  'AWS_DEFAULT_REGION',
+];
+
+type JsonRecord = Record<string, unknown>;
+
+export interface CliUsage {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadInputTokens: number;
+  readonly cacheCreationInputTokens: number;
+  readonly costUsd: number;
+  readonly numTurns: number;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function formatUnknown(value: unknown): string {
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function formatTerminalErrorMessage(subtype: string | undefined, result: string): string {
+  return `${subtype ?? 'error'}: ${result}`;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+  });
+}
+
+export class TurnSemaphore {
+  private readonly waiters: Array<() => void> = [];
+
+  private availablePermits: number;
+
+  public constructor(private readonly maxPermits: number) {
+    if (!Number.isInteger(maxPermits) || maxPermits < 1) {
+      throw new Error('TurnSemaphore: maxPermits must be an integer >= 1');
+    }
+    this.availablePermits = maxPermits;
+  }
+
+  public acquire(): Promise<void> {
+    if (this.availablePermits > 0) {
+      this.availablePermits -= 1;
+      return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  public release(): void {
+    const next = this.waiters.shift();
+    if (next !== undefined) {
+      next();
+      return;
+    }
+
+    if (this.availablePermits >= this.maxPermits) {
+      throw new Error('TurnSemaphore: release called without a matching acquire');
+    }
+    this.availablePermits += 1;
+  }
+}
+
+// The CLI emits NDJSON, not SSE. We intentionally map only the empirically stable shapes:
+// text deltas stream the answer, assistant snapshots are the only reliable full tool_use payloads,
+// user snapshots carry the canonical tool_result content, and the terminal result line is the
+// authoritative source for final text plus usage. Everything else is noise for this contract.
+export class StreamJsonParser {
+  private readonly now: () => number;
+
+  private readonly textDeltas: string[] = [];
+
+  private readonly seenToolUseIds = new Set<string>();
+
+  private readonly toolUseSeenAt = new Map<string, number>();
+
+  private usageSnapshot: CliUsage = EMPTY_USAGE;
+
+  private messageStartCount = 0;
+
+  private terminalAnswer = '';
+
+  private terminalResultSeen = false;
+
+  private terminalIterations = 0;
+
+  private terminalIsError = false;
+
+  private terminalError = '';
+
+  public constructor(now: () => number = () => Date.now()) {
+    this.now = now;
+  }
+
+  public push(line: string): ChatStreamEvent[] {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      return [];
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      return [];
+    }
+
+    if (!isRecord(parsed)) {
+      return [];
+    }
+
+    const topLevelType = asString(parsed.type);
+    if (topLevelType === 'stream_event') {
+      return this.handleStreamEvent(parsed);
+    }
+    if (topLevelType === 'assistant') {
+      return this.handleAssistantSnapshot(parsed);
+    }
+    if (topLevelType === 'user') {
+      return this.handleUserSnapshot(parsed);
+    }
+    if (topLevelType === 'result') {
+      return this.handleTerminalResult(parsed);
+    }
+
+    return [];
+  }
+
+  public finalAnswer(): string {
+    return this.terminalAnswer.length > 0 ? this.terminalAnswer : this.textDeltas.join('');
+  }
+
+  public toolCalls(): number {
+    return this.seenToolUseIds.size;
+  }
+
+  public iterations(): number {
+    return this.terminalIterations > 0 ? this.terminalIterations : this.messageStartCount;
+  }
+
+  public usage(): CliUsage {
+    return { ...this.usageSnapshot };
+  }
+
+  public sawTerminalResult(): boolean {
+    return this.terminalResultSeen;
+  }
+
+  public isError(): boolean {
+    return this.terminalIsError;
+  }
+
+  public errorMessage(): string {
+    return this.terminalError;
+  }
+
+  private handleStreamEvent(payload: JsonRecord): ChatStreamEvent[] {
+    const event = payload.event;
+    if (!isRecord(event)) {
+      return [];
+    }
+
+    const eventType = asString(event.type);
+    if (eventType === 'message_start') {
+      this.messageStartCount += 1;
+      return [];
+    }
+
+    if (eventType !== 'content_block_delta') {
+      return [];
+    }
+
+    const delta = event.delta;
+    if (!isRecord(delta) || asString(delta.type) !== 'text_delta') {
+      return [];
+    }
+
+    const text = asString(delta.text);
+    if (text === undefined) {
+      return [];
+    }
+
+    this.textDeltas.push(text);
+    return [{ type: 'text_delta', text }];
+  }
+
+  private handleAssistantSnapshot(payload: JsonRecord): ChatStreamEvent[] {
+    const message = payload.message;
+    if (!isRecord(message)) {
+      return [];
+    }
+
+    const content = message.content;
+    if (!Array.isArray(content)) {
+      return [];
+    }
+
+    const events: ChatStreamEvent[] = [];
+    for (const block of content) {
+      if (!isRecord(block) || asString(block.type) !== 'tool_use') {
+        continue;
+      }
+
+      const id = asString(block.id);
+      const name = asString(block.name);
+      if (id === undefined || name === undefined || this.seenToolUseIds.has(id)) {
+        continue;
+      }
+
+      this.seenToolUseIds.add(id);
+      this.toolUseSeenAt.set(id, this.now());
+      events.push({
+        type: 'tool_use',
+        id,
+        name,
+        input: block.input,
+      });
+    }
+
+    return events;
+  }
+
+  private handleUserSnapshot(payload: JsonRecord): ChatStreamEvent[] {
+    const message = payload.message;
+    if (!isRecord(message)) {
+      return [];
+    }
+
+    const content = message.content;
+    if (!Array.isArray(content)) {
+      return [];
+    }
+
+    const events: ChatStreamEvent[] = [];
+    for (const block of content) {
+      if (!isRecord(block) || asString(block.type) !== 'tool_result') {
+        continue;
+      }
+
+      const id = asString(block.tool_use_id);
+      if (id === undefined) {
+        continue;
+      }
+
+      const seenAt = this.toolUseSeenAt.get(id);
+      const durationMs = seenAt === undefined ? 0 : Math.max(0, this.now() - seenAt);
+      const output = this.flattenToolResultContent(block.content);
+      const isError = block.is_error === true ? true : undefined;
+
+      events.push({
+        type: 'tool_result',
+        id,
+        output,
+        durationMs,
+        ...(isError === true ? { isError } : {}),
+      });
+    }
+
+    return events;
+  }
+
+  private handleTerminalResult(payload: JsonRecord): ChatStreamEvent[] {
+    const subtype = asString(payload.subtype);
+    const terminalResult = asString(payload.result) ?? '';
+    const usagePayload = isRecord(payload.usage) ? payload.usage : undefined;
+    const numTurns = asNumber(payload.num_turns);
+
+    this.terminalResultSeen = true;
+    this.terminalAnswer = terminalResult.length > 0 ? terminalResult : this.textDeltas.join('');
+    this.terminalIterations = numTurns ?? this.messageStartCount;
+    this.terminalIsError = payload.is_error === true;
+    this.terminalError = this.terminalIsError
+      ? formatTerminalErrorMessage(subtype, terminalResult)
+      : '';
+    this.usageSnapshot = {
+      inputTokens: usagePayload === undefined ? 0 : asNumber(usagePayload.input_tokens) ?? 0,
+      outputTokens: usagePayload === undefined ? 0 : asNumber(usagePayload.output_tokens) ?? 0,
+      cacheReadInputTokens:
+        usagePayload === undefined ? 0 : asNumber(usagePayload.cache_read_input_tokens) ?? 0,
+      cacheCreationInputTokens:
+        usagePayload === undefined ? 0 : asNumber(usagePayload.cache_creation_input_tokens) ?? 0,
+      costUsd: asNumber(payload.total_cost_usd) ?? 0,
+      numTurns: numTurns ?? this.messageStartCount,
+    };
+
+    return [
+      {
+        type: 'done',
+        answer: this.finalAnswer(),
+        toolCalls: this.toolCalls(),
+        iterations: this.iterations(),
+      },
+    ];
+  }
+
+  private flattenToolResultContent(content: unknown): string {
+    if (!Array.isArray(content)) {
+      return content === undefined ? '' : formatUnknown(content);
+    }
+
+    return content
+      .map((block) => {
+        if (isRecord(block) && asString(block.type) === 'text') {
+          return asString(block.text) ?? '';
+        }
+        return formatUnknown(block);
+      })
+      .join('');
+  }
+}
+
+export interface CliChatAgentDeps {
+  readonly dispatch: ToolDispatchService;
+  readonly createLoopbackServer?: (deps: {
+    readonly dispatch: ToolDispatchService;
+    readonly bearer: string;
+    readonly tools: readonly DispatchableToolSpec[];
+  }) => LoopbackMcpServer;
+  readonly cliBinary?: string;
+  readonly model?: string;
+  readonly systemPrompt?: string;
+  readonly buildEnv?: () => NodeJS.ProcessEnv;
+  readonly spawnFn?: typeof nodeSpawn;
+  readonly spawnTimeoutMs?: number;
+  readonly idleTimeoutMs?: number;
+  readonly maxConcurrentTurns?: number;
+}
+
+// SEAM (M3): boot/resolveChatAgent/provider routing constructs + selects this agent.
+export class CliChatAgent implements ChatAgent {
+  private readonly turnSemaphore: TurnSemaphore;
+
+  public constructor(private readonly deps: CliChatAgentDeps) {
+    this.turnSemaphore = new TurnSemaphore(
+      deps.maxConcurrentTurns ?? DEFAULT_MAX_CONCURRENT_TURNS,
+    );
+  }
+
+  public async chat(input: ChatTurnInput): Promise<SemanticAnswer> {
+    const lifecycle = this.runLifecycle(input);
+
+    while (true) {
+      const step = await lifecycle.next();
+      if (step.done) {
+        // chat() always drains to natural completion, which returns a real
+        // parser; the `undefined` case only arises from chatStream's abort
+        // `.return()`, never here. Guard defensively for the widened type.
+        const parser = step.value;
+        if (!parser) {
+          throw new Error('claude-cli turn ended without a result');
+        }
+        if (parser.isError()) {
+          throw new Error(parser.errorMessage());
+        }
+        return { text: parser.finalAnswer() };
+      }
+    }
+  }
+
+  public async *chatStream(
+    input: ChatTurnInput,
+    _observer?: ChatStreamObserver,
+  ): AsyncGenerator<ChatStreamEvent> {
+    const lifecycle = this.runLifecycle(input);
+    let finished = false;
+
+    try {
+      while (true) {
+        const step = await lifecycle.next();
+        if (step.done) {
+          finished = true;
+          return;
+        }
+
+        yield step.value;
+      }
+    } catch (error) {
+      yield {
+        type: 'error',
+        message: error instanceof Error ? error.message : String(error),
+      };
+    } finally {
+      if (!finished) {
+        await lifecycle.return(undefined);
+      }
+    }
+  }
+
+  private composePrompt(input: ChatTurnInput): string {
+    const lines: string[] = [];
+
+    if (typeof input.extraSystemHint === 'string' && input.extraSystemHint.trim().length > 0) {
+      lines.push(`System Hint: ${input.extraSystemHint}`);
+    }
+
+    for (const turn of input.priorTurns ?? []) {
+      lines.push(`User: ${turn.userMessage}`);
+      lines.push(`Assistant: ${turn.assistantAnswer}`);
+    }
+
+    lines.push(`User: ${input.userMessage}`);
+    return lines.join('\n');
+  }
+
+  private buildMcpConfig(url: string, bearer: string): string {
+    return JSON.stringify({
+      mcpServers: {
+        omadia: {
+          type: 'http',
+          url,
+          headers: {
+            Authorization: `Bearer ${bearer}`,
+          },
+        },
+      },
+    });
+  }
+
+  private async *runLifecycle(
+    input: ChatTurnInput,
+  ): AsyncGenerator<ChatStreamEvent, StreamJsonParser | undefined> {
+    const parser = new StreamJsonParser();
+    const tools = this.deps.dispatch.listDispatchableToolSpecs();
+    const bearer = randomUUID();
+    const createLoopbackServer =
+      this.deps.createLoopbackServer ??
+      ((serverDeps: {
+        readonly dispatch: ToolDispatchService;
+        readonly bearer: string;
+        readonly tools: readonly DispatchableToolSpec[];
+      }) => new LoopbackMcpServer(serverDeps));
+
+    let server: LoopbackMcpServer | undefined;
+    let handle: LoopbackMcpServerHandle | undefined;
+    let tempDir: string | undefined;
+    let child: ChildProcessWithoutNullStreams | undefined;
+    let closePromise: Promise<{ readonly code: number | null; readonly signal: NodeJS.Signals | null }> | undefined;
+    let overallTimer: NodeJS.Timeout | undefined;
+    let idleTimer: NodeJS.Timeout | undefined;
+    let pendingFailure: Error | undefined;
+    let stderr = '';
+    let stdoutBuffer = '';
+    let stdoutDone = false;
+    let permitAcquired = false;
+    let closeInfo: { readonly code: number | null; readonly signal: NodeJS.Signals | null } | undefined;
+    const lineQueue: string[] = [];
+    let lineWaiter: (() => void) | undefined;
+
+    const wakeReader = (): void => {
+      if (lineWaiter === undefined) {
+        return;
+      }
+
+      const resolve = lineWaiter;
+      lineWaiter = undefined;
+      resolve();
+    };
+
+    const finishStdout = (): void => {
+      if (stdoutDone) {
+        return;
+      }
+
+      if (stdoutBuffer.length > 0) {
+        lineQueue.push(stdoutBuffer);
+        stdoutBuffer = '';
+      }
+
+      stdoutDone = true;
+      wakeReader();
+    };
+
+    const resetIdleTimer = (): void => {
+      if (idleTimer !== undefined) {
+        clearTimeout(idleTimer);
+      }
+
+      idleTimer = setTimeout(() => {
+        const timeoutError = new Error(
+          `CLI idle timeout after ${this.deps.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS}ms`,
+        );
+        if (pendingFailure === undefined) {
+          pendingFailure = timeoutError;
+        }
+        if (child !== undefined && child.exitCode === null && child.signalCode === null) {
+          child.kill('SIGTERM');
+        }
+        wakeReader();
+      }, this.deps.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS);
+    };
+
+    const failRuntime = (error: Error): void => {
+      if (pendingFailure !== undefined) {
+        return;
+      }
+
+      pendingFailure = error;
+      if (child !== undefined && child.exitCode === null && child.signalCode === null) {
+        child.kill('SIGTERM');
+      }
+      wakeReader();
+    };
+
+    try {
+      await this.turnSemaphore.acquire();
+      permitAcquired = true;
+
+      server = createLoopbackServer({
+        dispatch: this.deps.dispatch,
+        bearer,
+        tools,
+      });
+      handle = await server.start();
+
+      tempDir = await mkdtemp(join(tmpdir(), 'omadia-cli-'));
+      const configPath = join(tempDir, 'mcp-config.json');
+      await writeFile(configPath, this.buildMcpConfig(handle.url, bearer), { mode: 0o600 });
+
+      const argv = [
+        '-p',
+        '--output-format',
+        'stream-json',
+        '--include-partial-messages',
+        '--verbose',
+        '--strict-mcp-config',
+        '--mcp-config',
+        configPath,
+        '--allowedTools',
+        'mcp__omadia__*',
+        '--model',
+        this.deps.model ?? DEFAULT_MODEL,
+      ];
+
+      if (typeof this.deps.systemPrompt === 'string' && this.deps.systemPrompt.length > 0) {
+        argv.push('--append-system-prompt', this.deps.systemPrompt);
+      }
+
+      child = (this.deps.spawnFn ?? nodeSpawn)(
+        this.deps.cliBinary ?? DEFAULT_CLI_BINARY,
+        argv,
+        {
+          env: this.buildEnv(),
+          stdio: ['pipe', 'pipe', 'pipe'],
+        },
+      ) as ChildProcessWithoutNullStreams;
+
+      closePromise = new Promise((resolve) => {
+        child!.once('close', (code, signal) => {
+          closeInfo = { code, signal };
+          finishStdout();
+          resolve(closeInfo);
+        });
+      });
+
+      child.once('error', (error) => {
+        failRuntime(error instanceof Error ? error : new Error(String(error)));
+      });
+      child.stdin.on('error', (error) => {
+        failRuntime(error instanceof Error ? error : new Error(String(error)));
+      });
+      child.stdout.on('error', (error) => {
+        failRuntime(error instanceof Error ? error : new Error(String(error)));
+      });
+      child.stderr.on('error', (error) => {
+        failRuntime(error instanceof Error ? error : new Error(String(error)));
+      });
+
+      child.stdout.on('data', (chunk: Buffer | string) => {
+        resetIdleTimer();
+        stdoutBuffer += chunk.toString();
+        const lines = stdoutBuffer.split('\n');
+        stdoutBuffer = lines.pop() ?? '';
+        lineQueue.push(...lines);
+        wakeReader();
+      });
+
+      child.stdout.on('end', () => {
+        finishStdout();
+      });
+
+      child.stderr.on('data', (chunk: Buffer | string) => {
+        stderr += chunk.toString();
+      });
+
+      overallTimer = setTimeout(() => {
+        failRuntime(
+          new Error(`CLI timed out after ${this.deps.spawnTimeoutMs ?? DEFAULT_SPAWN_TIMEOUT_MS}ms`),
+        );
+      }, this.deps.spawnTimeoutMs ?? DEFAULT_SPAWN_TIMEOUT_MS);
+
+      resetIdleTimer();
+
+      // We send one fully composed plain-text prompt so the child process stays stateless and
+      // deterministic for tests; replaying prior turns here mirrors the CLI's single-shot mode.
+      child.stdin.end(this.composePrompt(input));
+
+      while (true) {
+        while (lineQueue.length > 0) {
+          const line = lineQueue.shift();
+          if (line === undefined) {
+            continue;
+          }
+
+          for (const event of parser.push(line)) {
+            yield event;
+          }
+        }
+
+        if (pendingFailure !== undefined) {
+          throw pendingFailure;
+        }
+
+        if (stdoutDone) {
+          break;
+        }
+
+        await new Promise<void>((resolve) => {
+          lineWaiter = resolve;
+        });
+      }
+
+      if (closePromise !== undefined && closeInfo === undefined) {
+        closeInfo = await closePromise;
+      }
+
+      if (pendingFailure !== undefined) {
+        throw pendingFailure;
+      }
+
+      if (closeInfo?.signal !== null && closeInfo?.signal !== undefined) {
+        throw new Error(`CLI exited with signal ${closeInfo.signal}`);
+      }
+
+      if ((closeInfo?.code ?? 0) !== 0) {
+        const stderrSuffix = stderr.trim().length > 0 ? `: ${stderr.trim()}` : '';
+        throw new Error(`CLI exited with code ${String(closeInfo?.code)}${stderrSuffix}`);
+      }
+
+      if (!parser.sawTerminalResult()) {
+        throw new Error('claude-cli exited without a terminal result line');
+      }
+
+      return parser;
+    } finally {
+      if (overallTimer !== undefined) {
+        clearTimeout(overallTimer);
+      }
+      if (idleTimer !== undefined) {
+        clearTimeout(idleTimer);
+      }
+      // `permitAcquired` flips true only after a successful acquire, and this
+      // finally runs exactly once per lifecycle, so the release happens once on
+      // every path (success / error / abort) and never without a prior acquire.
+      if (permitAcquired) {
+        this.turnSemaphore.release();
+      }
+
+      if (server !== undefined) {
+        try {
+          await server.stop();
+        } catch {
+          // Stop errors are best-effort cleanup only; preserving the primary failure is more useful.
+        }
+      }
+
+      if (child !== undefined) {
+        // Bind to a non-undefined local so the SIGKILL closure below keeps the
+        // narrowed type — TS cannot prove the outer `let child` is still defined
+        // across the setTimeout callback boundary.
+        const liveChild = child;
+        if (liveChild.exitCode === null && liveChild.signalCode === null) {
+          liveChild.kill('SIGTERM');
+        }
+
+        let forceKillTimer: NodeJS.Timeout | undefined;
+        if (liveChild.exitCode === null && liveChild.signalCode === null) {
+          forceKillTimer = setTimeout(() => {
+            if (liveChild.exitCode === null && liveChild.signalCode === null) {
+              liveChild.kill('SIGKILL');
+            }
+          }, FORCE_KILL_DELAY_MS);
+        }
+
+        try {
+          if (closePromise !== undefined) {
+            await Promise.race([closePromise, delay(FORCE_KILL_DELAY_MS + 500)]);
+          }
+        } finally {
+          if (forceKillTimer !== undefined) {
+            clearTimeout(forceKillTimer);
+          }
+        }
+      }
+
+      if (tempDir !== undefined) {
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    }
+  }
+
+  private buildEnv(): NodeJS.ProcessEnv {
+    const env = this.deps.buildEnv?.() ?? { ...process.env };
+
+    // Subscription-authenticated CLI runs must not inherit API-key or proxy overrides from the
+    // host process, otherwise tests become flaky and production can silently switch auth modes.
+    for (const key of CLI_ENV_SCRUB_KEYS) {
+      delete env[key];
+    }
+
+    return env;
+  }
+}

--- a/middleware/packages/harness-orchestrator/src/cliSubAgent.ts
+++ b/middleware/packages/harness-orchestrator/src/cliSubAgent.ts
@@ -1,0 +1,75 @@
+import type { LocalSubAgentTool } from '@omadia/plugin-api';
+
+import { CliChatAgent } from './cliChatAgent.js';
+import type { CliChatAgentDeps } from './cliChatAgent.js';
+import { NativeToolRegistry } from './nativeToolRegistry.js';
+import { ToolDispatchService } from './toolDispatchService.js';
+import type { DomainTool, DomainToolSpec } from './tools/domainQueryTool.js';
+import type { AskObserver, Askable } from './tools/domainQueryTool.js';
+
+export interface CliSubAgentOptions {
+  /** Sub-agent label for logs/domains, e.g. the short agent name. */
+  readonly name: string;
+  /** Sub-agent system prompt (skill body / composed prompt). */
+  readonly systemPrompt: string;
+  /** CLI model alias already stripped of any `-cli` suffix (`opus`/`sonnet`/`haiku`). */
+  readonly model: string;
+  /** The sub-agent's own tools, in kernel `LocalSubAgentTool` shape. */
+  readonly tools: readonly LocalSubAgentTool[];
+  /** Test seam: override CliChatAgent construction (inject fake spawn/loopback). */
+  readonly createCliAgent?: (deps: CliChatAgentDeps) => CliChatAgent;
+}
+
+/**
+ * Build an `Askable` whose `ask()` runs the sub-agent's loop through a dedicated
+ * `CliChatAgent`. The official `claude` CLI owns the loop; the sub-agent's own
+ * tools reach it over a fresh loopback MCP server scoped to THIS sub-agent — no
+ * native kernel tools are exposed (an empty `NativeToolRegistry`). Used for
+ * recursive Shape 3 (#309) so tool-using sub-agents work on the subscription
+ * provider, where the in-process `LocalSubAgent` would break (its provider
+ * rejects any request carrying tools).
+ */
+export function createCliSubAgent(options: CliSubAgentOptions): Askable {
+  const dispatch = new ToolDispatchService({
+    nativeTools: new NativeToolRegistry(),
+    domainTools: options.tools.map((tool) => adaptSubAgentTool(tool)),
+  });
+  const make =
+    options.createCliAgent ??
+    ((deps: CliChatAgentDeps) => new CliChatAgent(deps));
+  const agent = make({
+    dispatch,
+    model: options.model,
+    systemPrompt: options.systemPrompt,
+  });
+  return {
+    async ask(question: string, _observer?: AskObserver): Promise<string> {
+      const answer = await agent.chat({ userMessage: question });
+      return answer.text;
+    },
+  };
+}
+
+/**
+ * Adapt one kernel `LocalSubAgentTool` (`{ spec, handle }`, handle returns
+ * `string | LocalSubAgentToolResult`) into the `DomainTool` shape the loopback
+ * dispatch serves. The dispatch contract requires a `string` result, so the
+ * structured union is unwrapped to its `.output`. Each adapted tool gets a
+ * stable per-tool domain so trace labelling stays unique.
+ */
+function adaptSubAgentTool(tool: LocalSubAgentTool): DomainTool {
+  return {
+    name: tool.spec.name,
+    spec: {
+      name: tool.spec.name,
+      description: tool.spec.description,
+      // LocalSubAgentToolSpec allows broader property values than DomainToolSpec.
+      input_schema: tool.spec.input_schema as DomainToolSpec['input_schema'],
+    },
+    domain: `subagent.tool.${tool.spec.name}`,
+    async handle(input: unknown): Promise<string> {
+      const raw = await tool.handle(input);
+      return typeof raw === 'string' ? raw : raw.output;
+    },
+  };
+}

--- a/middleware/packages/harness-orchestrator/src/index.ts
+++ b/middleware/packages/harness-orchestrator/src/index.ts
@@ -196,6 +196,20 @@ export type {
   LocalSubAgentToolResult,
   AskOptions,
 } from './localSubAgent.js';
+export { ToolDispatchService } from './toolDispatchService.js';
+export type {
+  DispatchableToolSpec,
+  ToolDispatchResult,
+} from './toolDispatchService.js';
+export { LoopbackMcpServer } from './loopbackMcpServer.js';
+export type {
+  LoopbackMcpServerDeps,
+  LoopbackMcpServerHandle,
+} from './loopbackMcpServer.js';
+export { CLI_ENV_SCRUB_KEYS, CliChatAgent, StreamJsonParser } from './cliChatAgent.js';
+export type { CliChatAgentDeps, CliUsage } from './cliChatAgent.js';
+export { createCliSubAgent } from './cliSubAgent.js';
+export type { CliSubAgentOptions } from './cliSubAgent.js';
 
 // Knowledge-graph native tool (moved from harness-knowledge-graph in S+12.5-1)
 export {

--- a/middleware/packages/harness-orchestrator/src/loopbackMcpServer.ts
+++ b/middleware/packages/harness-orchestrator/src/loopbackMcpServer.ts
@@ -1,0 +1,247 @@
+/**
+ * M1 library code for #309 Shape-3 OpenClaw.
+ *
+ * This loopback Streamable-HTTP MCP server binds to 127.0.0.1 on an ephemeral
+ * port, enforces a bearer token, and relies entirely on injected dependencies
+ * with no global state. It lives in the orchestrator package because it uses
+ * the dispatch service and the MCP SDK this package already depends on.
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  createServer,
+  type IncomingMessage,
+  type Server as HttpServer,
+  type ServerResponse,
+} from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {
+  CallToolRequestSchema,
+  ErrorCode,
+  ListToolsRequestSchema,
+  McpError,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import type {
+  DispatchableToolSpec,
+  ToolDispatchService,
+} from './toolDispatchService.js';
+
+const MAX_REQUEST_BYTES = 8 * 1024 * 1024;
+
+class PayloadTooLargeError extends Error {}
+
+export interface LoopbackMcpServerDeps {
+  readonly dispatch: ToolDispatchService;
+  readonly bearer: string;
+  readonly tools: readonly DispatchableToolSpec[];
+  readonly serverName?: string;
+  readonly serverVersion?: string;
+}
+
+export interface LoopbackMcpServerHandle {
+  readonly url: string;
+  readonly port: number;
+  readonly bearer: string;
+}
+
+export class LoopbackMcpServer {
+  private http?: HttpServer;
+  private transport?: StreamableHTTPServerTransport;
+  private mcp?: McpServer;
+  private started = false;
+
+  constructor(private readonly deps: LoopbackMcpServerDeps) {
+    if (!deps.bearer) {
+      throw new Error(
+        'LoopbackMcpServer: bearer must be a non-empty string',
+      );
+    }
+  }
+
+  async start(): Promise<LoopbackMcpServerHandle> {
+    if (this.started) {
+      // Throwing makes double-start a visible lifecycle bug instead of silently
+      // reusing stale transport state.
+      throw new Error('LoopbackMcpServer: already started');
+    }
+
+    this.mcp = new McpServer(
+      {
+        name: this.deps.serverName ?? 'omadia-loopback',
+        version: this.deps.serverVersion ?? '0.0.0',
+      },
+      { capabilities: { tools: {} } },
+    );
+
+    this.mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: this.deps.tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.input_schema,
+      })),
+    }));
+
+    this.mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const { name, arguments: args } = request.params;
+      const result = await this.deps.dispatch.dispatch(name, args ?? {});
+      return {
+        content: [{ type: 'text' as const, text: result.content }],
+        ...(result.isError ? { isError: true } : {}),
+      };
+    });
+
+    // Stateless-ish loopback transport; JSON responses simplify the client and
+    // session IDs remain required by the protocol.
+    this.transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      enableJsonResponse: true,
+    });
+    await this.mcp.connect(this.transport);
+
+    this.http = createServer((req, res) => {
+      void this.handleHttp(req, res);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const http = this.http;
+      if (!http) {
+        reject(new Error('LoopbackMcpServer: HTTP server missing'));
+        return;
+      }
+      http.once('error', reject);
+      // The listen callback bounds readiness and gives us the ephemeral port.
+      // Security note (P2-4): this binds 127.0.0.1 on an ephemeral port and is
+      // bearer-gated, so any local process that can read the 0600 mcp-config
+      // bearer can call omadia's tools — a local-process trust boundary.
+      http.listen(0, '127.0.0.1', () => {
+        http.removeListener('error', reject);
+        resolve();
+      });
+    });
+
+    const address = this.http.address() as AddressInfo;
+    const port = address.port;
+    const url = `http://127.0.0.1:${port}/mcp`;
+    this.started = true;
+    return { url, port, bearer: this.deps.bearer };
+  }
+
+  async stop(): Promise<void> {
+    if (!this.started) {
+      return;
+    }
+
+    await this.mcp?.close().catch(() => {});
+    await this.transport?.close().catch(() => {});
+
+    if (this.http) {
+      await new Promise<void>((resolve) => {
+        this.http?.close(() => resolve());
+      });
+    }
+
+    this.http = undefined;
+    this.transport = undefined;
+    this.mcp = undefined;
+    this.started = false;
+  }
+
+  private async handleHttp(
+    req: IncomingMessage,
+    res: ServerResponse,
+  ): Promise<void> {
+    const authorization = req.headers.authorization;
+    const expected = `Bearer ${this.deps.bearer}`;
+
+    // Single enforcement point for loopback auth. If tokens ever become
+    // per-tool/per-call, request-level McpError handling is an M2 seam.
+    if (
+      typeof authorization !== 'string' ||
+      !this.constantTimeEquals(authorization, expected)
+    ) {
+      res.writeHead(401, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          error: { code: -32001, message: 'Unauthorized' },
+          id: null,
+        }),
+      );
+      return;
+    }
+
+    try {
+      const transport = this.transport;
+      if (!transport) {
+        throw new McpError(ErrorCode.InternalError, 'Transport not started');
+      }
+
+      if (req.method === 'POST') {
+        const rawBody = await this.readBody(req);
+        const parsedBody = rawBody.length > 0 ? JSON.parse(rawBody) : undefined;
+        await transport.handleRequest(req, res, parsedBody);
+        return;
+      }
+
+      await transport.handleRequest(req, res);
+    } catch (error) {
+      if (res.headersSent) {
+        res.end();
+        return;
+      }
+
+      if (error instanceof PayloadTooLargeError) {
+        res.writeHead(413, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            error: { code: 413, message: 'Payload Too Large' },
+            id: null,
+          }),
+        );
+        return;
+      }
+
+      const message =
+        error instanceof Error ? error.message : 'Internal server error';
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          error: { code: -32603, message },
+          id: null,
+        }),
+      );
+    }
+  }
+
+  private async readBody(req: IncomingMessage): Promise<string> {
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    for await (const chunk of req) {
+      const buffer =
+        typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk;
+      totalBytes += buffer.length;
+      if (totalBytes > MAX_REQUEST_BYTES) {
+        throw new PayloadTooLargeError('Payload Too Large');
+      }
+      chunks.push(buffer);
+    }
+    return Buffer.concat(chunks).toString('utf8');
+  }
+
+  private constantTimeEquals(left: string, right: string): boolean {
+    if (left.length !== right.length) {
+      return false;
+    }
+
+    let diff = 0;
+    for (let index = 0; index < left.length; index += 1) {
+      diff |= left.charCodeAt(index) ^ right.charCodeAt(index);
+    }
+    return diff === 0;
+  }
+}

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -4021,6 +4021,14 @@ export class Orchestrator {
    * next iteration onwards because `buildToolsList()` iterates the map
    * live. The Orchestrator simply does not mention them in the preamble.
    */
+  /** Live snapshot of the registered sub-agent (`ask_<slug>`) DomainTools.
+   *  Used by the #309 CLI agent-runtime to expose sub-agents to `claude -p`
+   *  over the loopback MCP bridge (they attach post-activate, so this must be
+   *  read live, not captured at build time). */
+  listDomainTools(): readonly DomainTool[] {
+    return [...this.domainToolsByName.values()];
+  }
+
   registerDomainTool(tool: DomainTool): void {
     // Hard collision check. Silent last-wins was the previous behavior and
     // it made two uploaded agents with the same shortName (last dot-segment

--- a/middleware/packages/harness-orchestrator/src/plugin.ts
+++ b/middleware/packages/harness-orchestrator/src/plugin.ts
@@ -667,6 +667,11 @@ export async function activate(
           : {}),
       });
 
+      // SEAM (M3-followup): the `claude-cli` -> CliChatAgent swap lives in
+      // buildOrchestratorForAgent (buildOrchestrator.ts), which both the
+      // default `chatAgent@1` path and the US4 registry call via buildForAgent.
+      // Registry-managed Agents are CLI-backed too; the remaining follow-up is
+      // exposing sub-agent/kernel tools to the CLI dispatch (`domainTools: []`).
       registry = new OrchestratorRegistry(store, orchestratorDeps, {
         defaultRuntimeConfig: {
           model,

--- a/middleware/packages/harness-orchestrator/src/registry/subAgentTools.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/subAgentTools.ts
@@ -1,6 +1,7 @@
 import type { LlmProvider } from '@omadia/llm-provider';
 import type { LocalSubAgentTool } from '@omadia/plugin-api';
 
+import { createCliSubAgent } from '../cliSubAgent.js';
 import { LocalSubAgent } from '../localSubAgent.js';
 import type {
   McpManager} from '../mcp/mcpClient.js';
@@ -8,7 +9,11 @@ import {
   mcpToolToLocalSubAgentTool,
   type McpServerConfig,
 } from '../mcp/mcpClient.js';
-import { createDomainTool, type DomainTool } from '../tools/domainQueryTool.js';
+import {
+  createDomainTool,
+  type Askable,
+  type DomainTool,
+} from '../tools/domainQueryTool.js';
 
 import type {
   SkillRow,
@@ -42,6 +47,13 @@ export interface SubAgentToolDeps {
   readonly defaultModel: string;
   readonly defaultMaxTokens: number;
   readonly defaultMaxIterations: number;
+  /** #309 recursive Shape 3 — when the host provider is the subscription CLI,
+   *  run each DB-defined sub-agent through its own CliChatAgent instead of the
+   *  in-process LocalSubAgent. Default false → byte-identical legacy path. */
+  readonly hostIsCliProvider?: boolean;
+  /** CLI model alias resolver (strip `-cli`). Required only when
+   *  hostIsCliProvider is true; defaults to identity otherwise. */
+  readonly cliModelAlias?: (model: string) => string;
   /** Resolves an MCP server id → connection config (for mcp tool grants). */
   readonly mcpServersById?: ReadonlyMap<string, McpServerConfig>;
   /** Shared MCP connection pool. Required to honour mcp tool grants. */
@@ -81,21 +93,30 @@ export function buildSubAgentDomainTools(
       deps,
     );
 
-    const local = new LocalSubAgent({
-      name: sub.name,
-      provider: deps.provider,
-      model: sub.model ?? deps.defaultModel,
-      maxTokens: sub.maxTokens ?? deps.defaultMaxTokens,
-      maxIterations: sub.maxIterations ?? deps.defaultMaxIterations,
-      systemPrompt,
-      tools: subTools,
-    });
+    const agent: Askable = deps.hostIsCliProvider
+      ? createCliSubAgent({
+          name: sub.name,
+          systemPrompt,
+          model: (deps.cliModelAlias ?? ((model) => model))(
+            sub.model ?? deps.defaultModel,
+          ),
+          tools: subTools,
+        })
+      : new LocalSubAgent({
+          name: sub.name,
+          provider: deps.provider,
+          model: sub.model ?? deps.defaultModel,
+          maxTokens: sub.maxTokens ?? deps.defaultMaxTokens,
+          maxIterations: sub.maxIterations ?? deps.defaultMaxIterations,
+          systemPrompt,
+          tools: subTools,
+        });
 
     tools.push(
       createDomainTool({
         name: subAgentToolName(sub.name),
         description: `Delegate a focused question to the "${sub.name}" sub-agent.`,
-        agent: local,
+        agent,
         domain: `subagent.${slugifyDomain(sub.name)}`,
       }),
     );

--- a/middleware/packages/harness-orchestrator/src/toolDispatchService.ts
+++ b/middleware/packages/harness-orchestrator/src/toolDispatchService.ts
@@ -1,0 +1,110 @@
+/**
+ * M1 library code for #309 Shape-3 OpenClaw.
+ *
+ * This standalone dispatcher executes tools outside the Orchestrator turn loop.
+ * It intentionally replicates only the native-handler and DomainTool branches
+ * of `Orchestrator.dispatchToolInner`; kernel-tool branches plus privacy/trace
+ * seams are deferred to M2.
+ */
+
+import type { DomainTool } from './tools/domainQueryTool.js';
+import type { NativeToolRegistry } from './nativeToolRegistry.js';
+
+export interface ToolDispatchResult {
+  readonly content: string;
+  readonly isError?: boolean;
+}
+
+export interface DispatchableToolSpec {
+  readonly name: string;
+  readonly description: string;
+  readonly input_schema: {
+    readonly type: 'object';
+    readonly properties: Record<string, unknown>;
+    readonly required?: readonly string[];
+  };
+}
+
+export class ToolDispatchService {
+  constructor(
+    private readonly deps: {
+      readonly nativeTools: NativeToolRegistry;
+      /** Static sub-agent tools (M1 tests / fixed sets). */
+      readonly domainTools?: readonly DomainTool[];
+      /** Live sub-agent tools — read on every dispatch/list so sub-agents that
+       *  attach to the orchestrator AFTER construction (the normal post-activate
+       *  flow via `registerDomainTool`) are reachable. Takes precedence over the
+       *  static list when present. */
+      readonly domainToolsProvider?: () => readonly DomainTool[];
+    },
+  ) {}
+
+  private domainTools(): readonly DomainTool[] {
+    return this.deps.domainToolsProvider?.() ?? this.deps.domainTools ?? [];
+  }
+
+  async dispatch(name: string, input: unknown): Promise<ToolDispatchResult> {
+    const nativeRegistration = this.deps.nativeTools.get(name);
+    // Mirrors Orchestrator ordering: plugin/native handlers win first.
+    if (nativeRegistration?.handler) {
+      try {
+        return { content: await nativeRegistration.handler(input) };
+      } catch (error) {
+        return { content: this.errMsg(error), isError: true };
+      }
+    }
+
+    const domainTool = this.domainTools().find((t) => t.name === name);
+    if (domainTool) {
+      try {
+        return { content: await domainTool.handle(input) };
+      } catch (error) {
+        return { content: this.errMsg(error), isError: true };
+      }
+    }
+
+    return { content: `Error: unknown tool \`${name}\`.`, isError: true };
+  }
+
+  listDispatchableToolSpecs(): readonly DispatchableToolSpec[] {
+    const advertised = new Map<string, DispatchableToolSpec>();
+
+    for (const registration of this.deps.nativeTools.listWithHandler()) {
+      if (!registration.spec) {
+        // Handler-only registrations remain dispatchable by name, but cannot be
+        // advertised without a stable tool spec.
+        continue;
+      }
+
+      advertised.set(registration.name, {
+        name: registration.spec.name,
+        description: registration.spec.description,
+        input_schema: registration.spec.input_schema,
+      });
+    }
+
+    for (const tool of this.domainTools()) {
+      // Native tools keep precedence on collisions to mirror dispatch order.
+      if (advertised.has(tool.name)) {
+        continue;
+      }
+      advertised.set(tool.name, {
+        name: tool.spec.name,
+        description: tool.spec.description,
+        input_schema: tool.spec.input_schema,
+      });
+    }
+
+    return Array.from(advertised.values());
+  }
+
+  private errMsg(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+// SEAM (M2): kernel-tool branches (knowledge_graph, chat_participants,
+// ask_user_choice, suggest_follow_ups, find_free_slots, book_meeting,
+// read_attachment) and scoped-memory shadowing, plus privacy interning /
+// trace capture, are intentionally NOT replicated here — see
+// Orchestrator.dispatchToolInner.

--- a/middleware/packages/llm-provider-api/src/descriptor.ts
+++ b/middleware/packages/llm-provider-api/src/descriptor.ts
@@ -8,11 +8,13 @@
  */
 import type { ModelInfo } from './models.js';
 
-/** The HTTP wire protocol an adapter speaks. A provider picks one; the matching
+/** The transport an adapter speaks. Most are HTTP wire protocols; the matching
  *  registered `LlmAdapter` (see ./adapter.ts) builds the concrete provider.
  *  `openai-compatible` = OpenAI Chat Completions (most providers); `anthropic` =
- *  Anthropic Messages (Claude, or an Anthropic-compatible gateway). */
-export type WireFormat = 'openai-compatible' | 'anthropic';
+ *  Anthropic Messages (Claude, or an Anthropic-compatible gateway); `claude-cli`
+ *  = not HTTP at all but the local official `claude` CLI driven as a tool-less
+ *  completion endpoint on a subscription (#309 Shape 2, keyless). */
+export type WireFormat = 'openai-compatible' | 'anthropic' | 'claude-cli';
 
 /** Vendor deviations from plain OpenAI that the OpenAI adapter handles when set. */
 export interface ProviderQuirks {

--- a/middleware/src/agents/subAgentToolHydration.ts
+++ b/middleware/src/agents/subAgentToolHydration.ts
@@ -51,6 +51,8 @@ export interface HydrateDeps {
   readonly defaultModel: string;
   readonly defaultMaxTokens?: number;
   readonly defaultMaxIterations?: number;
+  readonly hostIsCliProvider?: boolean;
+  readonly cliModelAlias?: (model: string) => string;
   readonly log?: (msg: string) => void;
 }
 
@@ -113,6 +115,12 @@ export function registerDbSubAgentTools(
     mcpManager: deps.mcpManager,
     mcpServersById,
     nativeTool: (ref) => adaptNativeToolForSubAgent(deps.nativeToolRegistry, ref),
+    ...(deps.hostIsCliProvider !== undefined
+      ? { hostIsCliProvider: deps.hostIsCliProvider }
+      : {}),
+    ...(deps.cliModelAlias !== undefined
+      ? { cliModelAlias: deps.cliModelAlias }
+      : {}),
     ...(deps.log ? { log: deps.log } : {}),
   });
   let n = 0;

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -79,6 +79,8 @@ import { createRegistryInstallRouter } from './routes/registryInstall.js';
 import { createRuntimeRouter } from './routes/runtime.js';
 import { createAdminSettingsRouter } from './routes/adminSettings.js';
 import { createAdminProvidersRouter } from './routes/adminProviders.js';
+import { createAdminCliBackendsRouter } from './routes/adminCliBackends.js';
+import { registerClaudeCliAdapter } from './platform/claudeCliAdapter.js';
 import { createVaultStatusRouter } from './routes/vaultStatus.js';
 import { createBuilderRouter } from './routes/builder.js';
 import {
@@ -321,6 +323,9 @@ async function main(): Promise<void> {
   // another register*Adapter call here (or a plugin registering at activate).
   registerAnthropicAdapter(defaultLlmAdapters);
   registerOpenAiAdapter(defaultLlmAdapters);
+  // #309 Shape 2 — the local `claude` CLI as a keyless, tool-less completion
+  // provider on the operator's subscription (not an HTTP wire format).
+  registerClaudeCliAdapter(defaultLlmAdapters);
   console.log(
     `[middleware] ${String(defaultLlmAdapters.list().length)} LLM wire-format adapter(s) registered: ${defaultLlmAdapters
       .list()
@@ -1595,6 +1600,17 @@ async function main(): Promise<void> {
       // from `onAgentBuilt` so a rebuilt agent re-acquires its sub-agents.
       const mcpManager = new McpManager();
       const SUBAGENT_DEFAULT_MODEL = 'claude-sonnet-4-6';
+      // Read the orchestrator provider from LIVE installed config on each
+      // hydrate so a runtime switch to/from the CLI provider is picked up on
+      // the next agent build without a process restart.
+      const orchestratorProviderId = (): string => {
+        const raw = installedRegistry.get('@omadia/orchestrator')?.config?.[
+          'llm_provider'
+        ];
+        return typeof raw === 'string' && raw.trim().length > 0
+          ? raw.trim()
+          : 'anthropic';
+      };
       const hydrateSubAgentTools = (
         slug: string,
         built: { orchestrator: { hasDomainTool(n: string): boolean; registerDomainTool(t: DomainTool): void } },
@@ -1602,6 +1618,7 @@ async function main(): Promise<void> {
         const entry = registryForHydrate.get(slug);
         if (!entry) return 0;
         const mcpServers = registryForHydrate.currentSnapshot()?.mcpServers ?? [];
+        const providerId = orchestratorProviderId();
         return registerDbSubAgentTools(
           {
             subAgents: entry.subAgents,
@@ -1615,6 +1632,9 @@ async function main(): Promise<void> {
             mcpManager,
             mcpServers,
             defaultModel: SUBAGENT_DEFAULT_MODEL,
+            hostIsCliProvider: providerId === 'claude-cli',
+            cliModelAlias: (model: string): string =>
+              model.replace(/-cli$/, '') || 'sonnet',
             log: (m: string) => console.log(`[middleware] ${m}`),
           },
         );
@@ -2572,6 +2592,12 @@ async function main(): Promise<void> {
     }),
   );
   console.log('[middleware] providers admin endpoint ready at /api/v1/admin/providers (auth: required)');
+
+  // Subscription-CLI backends (#309) — detect installed/logged-in vendor CLIs
+  // (Claude/Codex/Gemini) so the operator can run agents on a subscription.
+  // Read-only host-capability probe; never triggers a login or consumes quota.
+  app.use('/api/v1/admin/cli-backends', requireAuth, createAdminCliBackendsRouter());
+  console.log('[middleware] CLI backends endpoint ready at /api/v1/admin/cli-backends (auth: required)');
 
   // ── Agent-Builder drafts (B.0) ────────────────────────────────────────────
   // SQLite-backed draft store; persists alongside the vault so redeploys

--- a/middleware/src/platform/builtinLlmProviders.ts
+++ b/middleware/src/platform/builtinLlmProviders.ts
@@ -117,6 +117,55 @@ export const BUILTIN_LLM_PROVIDERS: ReadonlyArray<LlmProviderDescriptor> = [
     ],
   },
   {
+    // #309 Shape 2 — the local official `claude` CLI driven as a keyless,
+    // tool-less completion provider on the operator's Claude subscription. Not
+    // an HTTP endpoint: the `claude-cli` adapter spawns `claude -p`. Keyless
+    // (auth = host capability via `claude auth login`, surfaced on the
+    // Subscription CLIs admin page); `baseURL` is unused by this adapter.
+    id: 'claude-cli',
+    label: 'Claude (subscription CLI)',
+    wireFormat: 'claude-cli',
+    baseURL: '',
+    policy: { requiresApiKey: false, requiresAvvDisclosure: false },
+    models: [
+      // modelId is suffixed `-cli` so it never collides with another provider's
+      // alias (the registry requires globally-unique aliases and id ==
+      // `<provider>:<modelId>`); the claude-cli adapter strips the `-cli` suffix
+      // back to the CLI alias (`opus`/`sonnet`/`haiku`) for `claude -p --model`.
+      {
+        id: 'claude-cli:opus-cli',
+        provider: 'claude-cli',
+        modelId: 'opus-cli',
+        label: 'Claude Opus (CLI)',
+        class: 'frontier',
+        maxTokens: 32_000,
+        contextWindow: 200_000,
+        vision: false,
+      },
+      {
+        id: 'claude-cli:sonnet-cli',
+        provider: 'claude-cli',
+        modelId: 'sonnet-cli',
+        label: 'Claude Sonnet (CLI)',
+        class: 'balanced',
+        maxTokens: 64_000,
+        contextWindow: 200_000,
+        vision: false,
+        classDefault: true,
+      },
+      {
+        id: 'claude-cli:haiku-cli',
+        provider: 'claude-cli',
+        modelId: 'haiku-cli',
+        label: 'Claude Haiku (CLI)',
+        class: 'fast',
+        maxTokens: 8_192,
+        contextWindow: 200_000,
+        vision: false,
+      },
+    ],
+  },
+  {
     id: 'mistral',
     label: 'Mistral',
     wireFormat: 'openai-compatible',

--- a/middleware/src/platform/claudeCliAdapter.ts
+++ b/middleware/src/platform/claudeCliAdapter.ts
@@ -1,0 +1,298 @@
+/**
+ * `claude-cli` wire-format adapter (#309, Shape 2 — keyless, tool-less).
+ *
+ * Drives the local official `claude` CLI as a single-shot completion endpoint on
+ * the operator's subscription, so high-volume tool-less calls (session summary,
+ * fact extraction, classifier, verifier-judge) can run on a Claude Pro/Max plan
+ * instead of a metered API key. omadia keeps its own orchestration loop; this
+ * provider only answers one prompt at a time.
+ *
+ * It is NOT an HTTP adapter: `build()` returns an `LlmProvider` whose
+ * `complete()` spawns `claude -p --output-format json` with the API-key env
+ * scrubbed (subscription path, #309 §2) and the prompt on stdin (never argv).
+ * Tools are not supported — full-tool subscription agents are the separate
+ * CLI-owns-loop path (Shape 3). Streaming is emulated as a single delta.
+ *
+ * Auth is host capability: if the CLI is not logged in, `complete()` rejects and
+ * `classifyError` reports a non-retryable auth error.
+ */
+import { spawn } from 'node:child_process';
+
+import type {
+  LlmAdapter,
+  LlmAdapterBuildOptions,
+  LlmProvider,
+  LlmRequest,
+  LlmResponse,
+  LlmStreamEvent,
+  LlmErrorClassification,
+  ProviderCapabilities,
+  ChatMessage,
+  ContentPart,
+  SystemBlock,
+  ToolSpec,
+} from '@omadia/llm-provider';
+
+import { scrubbedEnv } from './cliBackendDetector.js';
+
+const CLI_BIN = 'claude';
+const COMPLETE_TIMEOUT_MS = 120_000;
+const MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
+
+const CAPABILITIES: ProviderCapabilities = {
+  // No general agent-loop tool use over this single-shot provider — that path
+  // is Shape 3 (CliChatAgent owns the loop). But the FORCED single-tool
+  // structured-output pattern (verifier claimExtractor / evidenceJudge:
+  // `toolChoice:{type:'tool'}`) IS supported via a JSON-schema prompt (below).
+  tools: false,
+  vision: false,
+  streaming: false,
+  promptCaching: false,
+  forcedToolChoice: true,
+  parallelToolCalls: false,
+};
+
+function textOfContent(content: ReadonlyArray<ContentPart>): string {
+  return content
+    .map((p) => (p.type === 'text' ? p.text : p.type === 'tool_result' ? stringifyToolResult(p) : ''))
+    .filter(Boolean)
+    .join('\n');
+}
+
+function stringifyToolResult(part: Extract<ContentPart, { type: 'tool_result' }>): string {
+  if (typeof part.content === 'string') return part.content;
+  return part.content.map((c) => (c.type === 'text' ? c.text : '')).join('\n');
+}
+
+function systemText(system: LlmRequest['system']): string {
+  if (!system) return '';
+  if (typeof system === 'string') return system;
+  return (system as ReadonlyArray<SystemBlock>).map((b) => b.text).join('\n\n');
+}
+
+function buildPrompt(messages: ReadonlyArray<ChatMessage>): string {
+  // Tool-less single-shot: render the turns as a plain transcript. Most callers
+  // send one user message (summary/classify/judge), so this stays compact.
+  return messages
+    .map((m) => {
+      const text = textOfContent(m.content).trim();
+      if (!text) return '';
+      const label = m.role === 'assistant' ? 'Assistant' : 'Human';
+      return `${label}: ${text}`;
+    })
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+interface CliResultJson {
+  result?: string;
+  is_error?: boolean;
+  usage?: { input_tokens?: number; output_tokens?: number; cache_read_input_tokens?: number };
+}
+
+/** Parse the first top-level JSON object in the CLI output (tolerates a stray
+ *  leading progress/warning line). Returns undefined if none parses. */
+function parseResultJson(out: string): CliResultJson | undefined {
+  const start = out.indexOf('{');
+  const end = out.lastIndexOf('}');
+  if (start === -1 || end <= start) return undefined;
+  try {
+    return JSON.parse(out.slice(start, end + 1)) as CliResultJson;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Registry modelIds are `<alias>-cli` to avoid alias collisions; the CLI wants
+ *  the bare alias (`opus`/`sonnet`/`haiku`) or a full model id. */
+function toCliModel(model: string): string {
+  return model.replace(/-cli$/, '');
+}
+
+/** The FORCED single-tool structured-output pattern: `toolChoice:{type:'tool'}`
+ *  naming a tool present in `tools` (the verifier's claimExtractor/evidenceJudge),
+ *  or `required` with exactly one tool. Returns that spec, else undefined.
+ *  General/auto multi-tool use is NOT this — it stays rejected (needs Shape 3). */
+function forcedTool(req: LlmRequest): ToolSpec | undefined {
+  const tc = req.toolChoice;
+  if (!req.tools || req.tools.length === 0 || !tc) return undefined;
+  if (tc.type === 'tool' && tc.name) return req.tools.find((t) => t.name === tc.name);
+  if (tc.type === 'required' && req.tools.length === 1) return req.tools[0];
+  return undefined;
+}
+
+/** Instruction appended to the prompt so `claude -p` emits ONLY the tool's
+ *  arguments as JSON — which we parse back into a synthetic tool_call. */
+function structuredSuffix(tool: ToolSpec): string {
+  return [
+    '',
+    `You MUST produce the arguments for the tool \`${tool.name}\`${tool.description ? ` (${tool.description})` : ''}.`,
+    'Respond with ONLY a single JSON object — no prose, no markdown fences — whose',
+    'shape matches this JSON schema exactly:',
+    JSON.stringify(tool.inputSchema),
+  ].join('\n');
+}
+
+/** Parse the first top-level JSON object out of arbitrary text. */
+function parseFirstJsonObject(text: string): Record<string, unknown> | undefined {
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end <= start) return undefined;
+  try {
+    const v = JSON.parse(text.slice(start, end + 1));
+    return v && typeof v === 'object' ? (v as Record<string, unknown>) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function runClaude(req: LlmRequest): Promise<LlmResponse> {
+  const forced = forcedTool(req);
+  // Fail CLOSED on GENERAL/auto tool use — only the forced single-tool
+  // structured-output pattern is served (via JSON-schema prompt). General
+  // tool loops need the CLI to own the loop (Shape 3 / CliChatAgent).
+  if (req.tools && req.tools.length > 0 && !forced) {
+    return Promise.reject(
+      new Error(
+        'claude-cli provider supports only forced single-tool structured output, not general tool use',
+      ),
+    );
+  }
+
+  const args = ['-p', '--output-format', 'json', '--model', toCliModel(req.model)];
+  const sys = systemText(req.system);
+  if (sys) args.push('--append-system-prompt', sys);
+  const prompt = forced
+    ? `${buildPrompt(req.messages)}\n${structuredSuffix(forced)}`
+    : buildPrompt(req.messages);
+
+  return new Promise<LlmResponse>((resolve, reject) => {
+    const child = spawn(CLI_BIN, args, { env: scrubbedEnv(), windowsHide: true });
+    let stdout = '';
+    let stderr = '';
+    let bytes = 0;
+    let tooBig = false;
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error('claude-cli completion timed out'));
+    }, COMPLETE_TIMEOUT_MS);
+
+    child.stdout.on('data', (d: Buffer) => {
+      bytes += d.length;
+      if (bytes > MAX_OUTPUT_BYTES) {
+        tooBig = true;
+        child.kill('SIGKILL');
+        return;
+      }
+      stdout += d.toString('utf8');
+    });
+    child.stderr.on('data', (d: Buffer) => {
+      stderr += d.toString('utf8');
+    });
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('exit', (code) => {
+      clearTimeout(timer);
+      if (tooBig) {
+        reject(new Error('claude-cli output exceeded the size limit'));
+        return;
+      }
+      if (code !== 0) {
+        reject(new Error(`claude-cli exited ${code}: ${(stderr || stdout).slice(0, 500).trim()}`));
+        return;
+      }
+      // Be tolerant of a stray progress/warning line on stdout: parse the first
+      // top-level JSON object rather than assuming the whole stream is clean JSON.
+      const parsed = parseResultJson(stdout);
+      if (!parsed) {
+        reject(new Error(`claude-cli returned non-JSON output: ${stdout.slice(0, 300)}`));
+        return;
+      }
+      if (parsed.is_error) {
+        reject(new Error(`claude-cli reported an error: ${(parsed.result ?? '').slice(0, 300)}`));
+        return;
+      }
+      const text = parsed.result ?? '';
+      const usage = {
+        inputTokens: parsed.usage?.input_tokens ?? 0,
+        outputTokens: parsed.usage?.output_tokens ?? 0,
+        ...(parsed.usage?.cache_read_input_tokens !== undefined
+          ? { cacheReadTokens: parsed.usage.cache_read_input_tokens }
+          : {}),
+      };
+      if (forced) {
+        const argsObj = parseFirstJsonObject(text);
+        if (!argsObj) {
+          reject(
+            new Error(
+              `claude-cli forced-tool '${forced.name}': model did not return parseable JSON args`,
+            ),
+          );
+          return;
+        }
+        resolve({
+          content: [
+            { type: 'tool_call', id: `call_${forced.name}`, name: forced.name, input: argsObj },
+          ],
+          finishReason: 'tool_calls',
+          providerFinishReason: 'tool_use',
+          model: req.model,
+          usage,
+        });
+        return;
+      }
+      resolve({
+        content: [{ type: 'text', text }],
+        finishReason: 'stop',
+        providerFinishReason: 'end_turn',
+        model: req.model,
+        usage,
+      });
+    });
+
+    if (prompt) child.stdin.write(prompt);
+    child.stdin.end();
+  });
+}
+
+function classifyError(err: unknown): LlmErrorClassification {
+  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  if (/not logged in|logged out|unauthorized|credential|please run.*login|\/login/.test(msg)) {
+    return { retryable: false, kind: 'auth' };
+  }
+  if (/rate.?limit|429|too many/.test(msg)) return { retryable: true, kind: 'rate_limit' };
+  if (/overload|529|capacity/.test(msg)) return { retryable: true, kind: 'overloaded' };
+  return { retryable: false, kind: 'other' };
+}
+
+function createClaudeCliProvider(opts: LlmAdapterBuildOptions): LlmProvider {
+  return {
+    id: opts.id ?? 'claude-cli',
+    capabilities: CAPABILITIES,
+    async complete(req: LlmRequest): Promise<LlmResponse> {
+      return runClaude(req);
+    },
+    async *stream(req: LlmRequest): AsyncIterable<LlmStreamEvent> {
+      // The CLI completes in one shot; surface it as a single delta + final.
+      const response = await runClaude(req);
+      const text = response.content.map((p) => (p.type === 'text' ? p.text : '')).join('');
+      if (text) yield { type: 'text_delta', text };
+      yield { type: 'final', response };
+    },
+    classifyError,
+  };
+}
+
+export const claudeCliAdapter: LlmAdapter = {
+  wireFormat: 'claude-cli',
+  build: createClaudeCliProvider,
+};
+
+/** Register the claude-cli adapter into a registry (call at boot). */
+export function registerClaudeCliAdapter(registry: {
+  register(a: LlmAdapter): void;
+}): void {
+  registry.register(claudeCliAdapter);
+}

--- a/middleware/src/platform/cliAuthService.ts
+++ b/middleware/src/platform/cliAuthService.ts
@@ -1,0 +1,284 @@
+/**
+ * In-app CLI login flow (#309, Phase B) — drives `claude auth login` from the
+ * Web UI so a self-hoster never needs a terminal.
+ *
+ * The flow is two-leg, matching how the official CLI authenticates inside a
+ * container (verified empirically against claude v2.1.187):
+ *
+ *   1. Spawn `claude auth login --claudeai`. The CLI prints an OAuth URL
+ *      ("… visit: https://claude.com/cai/oauth/authorize?…") and then waits at
+ *      a "Paste code here" prompt reading stdin. We capture the URL and hand it
+ *      to the browser (leg OUT).
+ *   2. The operator authenticates in their own browser and gets a login code.
+ *      The UI posts it back; we write it to the login process's stdin (leg IN).
+ *      A wrong code returns "Invalid code" and the process stays alive to retry;
+ *      a correct code writes credentials to CLAUDE_CONFIG_DIR (the persisted
+ *      volume) and the session becomes authorized.
+ *
+ * Hard rules:
+ *  - **Subscription path only.** `--claudeai` (never `--console`) and the env is
+ *    scrubbed of API-key vars (#309 §2 billing-precedence footgun).
+ *  - **Code via stdin, never argv** (no leak through `ps`).
+ *  - **Single active session.** Login is host-global state on a single sticky
+ *    runtime; a second start replaces the first.
+ *  - **No shell, bounded buffer, hard lifetime + idle timeouts.**
+ */
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+
+import { scrubbedEnv, detectCliBackends, __resetCliBackendCache } from './cliBackendDetector.js';
+
+export type CliLoginStatus = 'pending' | 'authorized' | 'invalid' | 'expired' | 'error';
+
+interface LoginSession {
+  readonly id: string;
+  readonly cliId: string;
+  child: ChildProcessWithoutNullStreams | undefined;
+  verificationUrl: string | undefined;
+  status: CliLoginStatus;
+  account?: string;
+  error?: string;
+  buffer: string;
+  readonly createdAt: number;
+  lifetimeTimer?: NodeJS.Timeout;
+}
+
+const MAX_BUFFER = 64 * 1024;
+const URL_WAIT_MS = 12_000;
+const SESSION_LIFETIME_MS = 5 * 60_000;
+const CODE_RESULT_WAIT_MS = 15_000;
+const STATUS_POLL_INTERVAL_MS = 1500;
+
+let counter = 0;
+let active: LoginSession | undefined;
+
+/** Only Claude is wired for v1 (the only confirmed subscription-billed CLI). */
+function assertSupported(cliId: string): void {
+  if (cliId !== 'claude') {
+    throw new Error(`Login is not supported for "${cliId}" yet.`);
+  }
+}
+
+function disposeActive(): void {
+  const s = active;
+  if (!s) return;
+  active = undefined; // clear first so re-entry + getActiveLogin are truthful
+  if (s.lifetimeTimer) clearTimeout(s.lifetimeTimer);
+  const child = s.child;
+  s.child = undefined;
+  if (child && child.exitCode === null) {
+    try {
+      child.kill('SIGTERM');
+    } catch {
+      /* already gone */
+    }
+    // Escalate to SIGKILL if it doesn't exit (a hung `claude auth login`).
+    const kill = setTimeout(() => {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        /* already gone */
+      }
+    }, 2000);
+    if (typeof kill.unref === 'function') kill.unref();
+  }
+}
+
+function append(session: LoginSession, chunk: string): void {
+  session.buffer = (session.buffer + chunk).slice(-MAX_BUFFER);
+}
+
+export interface StartLoginResult {
+  readonly sessionId: string;
+  readonly verificationUrl: string;
+}
+
+/**
+ * Spawn the login process and resolve once the OAuth URL is captured. Replaces
+ * any in-flight session (single-operator, single sticky runtime).
+ */
+export async function startCliLogin(cliId: string): Promise<StartLoginResult> {
+  assertSupported(cliId);
+
+  // A logged-in CLI does not need re-login; surface that to the caller.
+  const snap = await detectCliBackends({ force: true });
+  const backend = snap.backends.find((b) => b.id === cliId);
+  if (!backend?.installed) {
+    throw new Error(`${cliId} is not installed in this environment.`);
+  }
+
+  disposeActive();
+
+  const child = spawn(backend.bin, ['auth', 'login', '--claudeai'], {
+    env: scrubbedEnv(),
+    windowsHide: true,
+  });
+
+  const session: LoginSession = {
+    id: `login-${++counter}-${child.pid ?? 'x'}`,
+    cliId,
+    child,
+    verificationUrl: undefined,
+    status: 'pending',
+    buffer: '',
+    createdAt: Date.now(),
+  };
+  active = session;
+
+  session.lifetimeTimer = setTimeout(() => {
+    // Dispose any still-active session at lifetime — pending OR invalid (an
+    // "invalid code" leaves the child alive for a retry; if the operator walks
+    // away it must still be reaped). Authorized sessions already disposed.
+    if (active === session) {
+      if (session.status === 'pending') session.status = 'expired';
+      disposeActive();
+    }
+  }, SESSION_LIFETIME_MS);
+
+  child.stdout.setEncoding('utf8');
+  child.stderr.setEncoding('utf8');
+  child.stdout.on('data', (d: string) => append(session, d));
+  child.stderr.on('data', (d: string) => append(session, d));
+  child.on('error', (err) => {
+    session.status = 'error';
+    session.error = err.message;
+    if (active === session) disposeActive();
+  });
+  child.on('exit', () => {
+    // If the process exits before authorization, mark it terminal and drop the
+    // stale session so getActiveLogin reports the truth. A successful submit has
+    // already flipped status to 'authorized' and disposed before this fires.
+    if (session.status === 'pending') session.status = 'error';
+    if (active === session && session.status !== 'authorized') disposeActive();
+  });
+
+  const url = await waitFor(() => extractUrl(session.buffer), URL_WAIT_MS);
+  if (!url) {
+    const detail = session.buffer.trim().split('\n').slice(-2).join(' ') || 'no output';
+    disposeActive();
+    throw new Error(`Could not start the login flow (${detail}).`);
+  }
+  session.verificationUrl = url;
+  return { sessionId: session.id, verificationUrl: url };
+}
+
+/**
+ * Write the operator's login code to the waiting process and report the result.
+ * A wrong code keeps the session alive for another attempt.
+ */
+export async function submitCliCode(
+  sessionId: string,
+  code: string,
+): Promise<{ status: CliLoginStatus; account?: string; error?: string }> {
+  const session = active;
+  if (!session || session.id !== sessionId) {
+    return { status: 'expired', error: 'No active login session. Start again.' };
+  }
+  const child = session.child;
+  if (!child || child.exitCode !== null) {
+    return { status: 'expired', error: 'Login process is no longer running. Start again.' };
+  }
+  const trimmed = code.trim();
+  if (!trimmed) return { status: 'invalid', error: 'Empty code.' };
+
+  // Capture THIS attempt's output independently of the capped rolling buffer,
+  // so the invalid-code check can't be confused by truncation or a prior attempt.
+  let attemptOut = '';
+  const onData = (d: Buffer | string): void => {
+    attemptOut += d.toString();
+  };
+  child.stdout.on('data', onData);
+  child.stderr.on('data', onData);
+  try {
+    child.stdin.write(`${trimmed}\n`);
+    const deadline = Date.now() + CODE_RESULT_WAIT_MS;
+    while (Date.now() < deadline) {
+      await delay(STATUS_POLL_INTERVAL_MS);
+
+      // Authoritative success check FIRST — a confirmed login must win over any
+      // lagging "invalid code" text (e.g. from a previous attempt).
+      const snap = await detectCliBackends({ force: true });
+      const backend = snap.backends.find((b) => b.id === session.cliId);
+      if (backend?.loggedIn === 'yes') {
+        session.status = 'authorized';
+        if (backend.account) session.account = backend.account;
+        const account = session.account;
+        disposeActive();
+        __resetCliBackendCache();
+        return account ? { status: 'authorized', account } : { status: 'authorized' };
+      }
+      if (/invalid code/i.test(attemptOut)) {
+        session.status = 'invalid';
+        return { status: 'invalid', error: 'Invalid code. Copy the full code and try again.' };
+      }
+      if (child.exitCode !== null) {
+        session.status = 'error';
+        return { status: 'error', error: 'The login process ended before sign-in completed. Start again.' };
+      }
+    }
+    return { status: 'pending', error: 'Still waiting. If you authorized in the browser, re-check status.' };
+  } finally {
+    child.stdout.off('data', onData);
+    child.stderr.off('data', onData);
+  }
+}
+
+export function getActiveLogin(): { sessionId: string; status: CliLoginStatus; verificationUrl?: string } | undefined {
+  if (!active) return undefined;
+  return {
+    sessionId: active.id,
+    status: active.status,
+    ...(active.verificationUrl ? { verificationUrl: active.verificationUrl } : {}),
+  };
+}
+
+export function cancelCliLogin(): void {
+  disposeActive();
+}
+
+/** Run `claude auth logout`, then bust the detection cache. */
+export async function cliLogout(cliId: string): Promise<{ ok: boolean }> {
+  assertSupported(cliId);
+  disposeActive();
+  const snap = await detectCliBackends({ force: true });
+  const backend = snap.backends.find((b) => b.id === cliId);
+  if (!backend?.installed) return { ok: true };
+  await new Promise<void>((resolve) => {
+    const c = spawn(backend.bin, ['auth', 'logout'], { env: scrubbedEnv(), windowsHide: true });
+    c.on('error', () => resolve());
+    c.on('exit', () => resolve());
+    setTimeout(() => {
+      try {
+        c.kill();
+      } catch {
+        /* noop */
+      }
+      resolve();
+    }, 8000);
+  });
+  __resetCliBackendCache();
+  return { ok: true };
+}
+
+function extractUrl(buf: string): string | undefined {
+  return buf.match(/https:\/\/claude\.com\/\S+/)?.[0];
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function waitFor<T>(probe: () => T | undefined, timeoutMs: number): Promise<T | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const v = probe();
+    if (v) return v;
+    await delay(250);
+  }
+  return probe();
+}
+
+/** Test seam. */
+export function __resetCliAuthState(): void {
+  disposeActive();
+  counter = 0;
+}

--- a/middleware/src/platform/cliBackendDetector.ts
+++ b/middleware/src/platform/cliBackendDetector.ts
@@ -1,0 +1,263 @@
+/**
+ * CLI subscription-backend detection (#309, Phase B).
+ *
+ * Detects whether a vendor LLM CLI (Claude / Codex / Gemini) is installed on
+ * the host AND logged in, so omadia can offer subscription-backed agents and
+ * surface a clear "backend available?" status in the Web UI. This is the
+ * "auth = host capability, not a vault secret" model from the #309 plan: the
+ * relevant CLI must be installed and authenticated on the host, never an API
+ * key in the vault.
+ *
+ * Hard rules baked in here:
+ *  - **Zero-side-effect probes.** We only run `--version` and a read-only auth
+ *    status command. We NEVER trigger a login, never consume quota, never write.
+ *  - **No shell.** Every probe is `execFile` with a fixed argv (no string
+ *    interpolation), short timeout, output capped — so a stuck or chatty CLI
+ *    can't hang or flood the kernel.
+ *  - **Honest states.** `loggedIn` is a tri-state (`yes`/`no`/`unknown`):
+ *    install + not-logged-in are reliable; wrong-account / expired / lapsed
+ *    need a real server round-trip, so we report `unknown` rather than guess.
+ *
+ * Billing reality (surfaced to the UI, decided in #309 §2): only the Anthropic
+ * CLI is confirmed in-scope for v1 (subscription billing). Codex signs in via
+ * ChatGPT but auto-generates an API key (likely meters the API), and Gemini's
+ * free OAuth is preview-limited — both are detected + shown but flagged
+ * "needs verification" and not yet recommended.
+ */
+import { execFile } from 'node:child_process';
+import { CLI_ENV_SCRUB_KEYS } from '@omadia/orchestrator';
+
+/** Tri-state: we are honest about what a read-only probe can actually prove. */
+export type CliLoginState = 'yes' | 'no' | 'unknown';
+
+/** Per-vendor billing posture for the UI (decided in #309 §2). */
+export type CliBillingPosture = 'subscription' | 'needs-verification';
+
+export interface CliBackendStatus {
+  readonly id: string;
+  readonly label: string;
+  /** The binary we probe for, e.g. `claude`. */
+  readonly bin: string;
+  readonly installed: boolean;
+  /** Trimmed `--version` output when installed. */
+  readonly version?: string;
+  readonly loggedIn: CliLoginState;
+  /** Logged-in account identity when the probe surfaces it (for self-check). */
+  readonly account?: string;
+  /** Whether this vendor is confirmed to bill the subscription (v1 = Claude). */
+  readonly billing: CliBillingPosture;
+  /** Short human note explaining the current state / next step. */
+  readonly detail: string;
+}
+
+interface CliBackendSpec {
+  readonly id: string;
+  readonly label: string;
+  readonly bin: string;
+  /** Args that print a version (read-only). */
+  readonly versionArgs: readonly string[];
+  /** Read-only auth probe; omitted vendors report `unknown`. */
+  readonly authArgs?: readonly string[];
+  /** Map a successful auth-probe result → login state + optional account. */
+  readonly parseAuth?: (out: string) => { state: CliLoginState; account?: string };
+  readonly billing: CliBillingPosture;
+}
+
+/**
+ * Supported CLIs. Claude first (the only v1-recommended path). Codex/Gemini are
+ * detected so the UI can show them, but their billing is `needs-verification`.
+ */
+const CLI_BACKENDS: ReadonlyArray<CliBackendSpec> = [
+  {
+    id: 'claude',
+    label: 'Claude (Anthropic)',
+    bin: 'claude',
+    versionArgs: ['--version'],
+    // `claude auth status` is a read-only, no-quota probe. The current CLI
+    // prints JSON, e.g. {"loggedIn":false,"authMethod":"none","apiProvider":
+    // "firstParty"} (exit 1 when logged out). We parse JSON first, then fall
+    // back to a loose text heuristic for other/older CLI versions, and only
+    // report `unknown` when neither is conclusive (#309: honest tri-state).
+    authArgs: ['auth', 'status', '--json'],
+    parseAuth: (out) => {
+      const json = tryParseJsonObject(out);
+      if (json && typeof json['loggedIn'] === 'boolean') {
+        if (!json['loggedIn']) return { state: 'no' };
+        const account = pickString(json, ['email', 'account', 'organizationName', 'organization']);
+        return account ? { state: 'yes', account } : { state: 'yes' };
+      }
+      const lower = out.toLowerCase();
+      if (/not logged in|logged out|please run|no credentials/.test(lower)) {
+        return { state: 'no' };
+      }
+      if (/logged in|authenticated|subscription/.test(lower)) {
+        const email = out.match(/[\w.+-]+@[\w-]+\.[\w.-]+/)?.[0];
+        return email ? { state: 'yes', account: email } : { state: 'yes' };
+      }
+      return { state: 'unknown' };
+    },
+    billing: 'subscription',
+  },
+  {
+    id: 'codex',
+    label: 'Codex (OpenAI)',
+    bin: 'codex',
+    versionArgs: ['--version'],
+    billing: 'needs-verification',
+  },
+  {
+    id: 'gemini',
+    label: 'Gemini (Google)',
+    bin: 'gemini',
+    versionArgs: ['--version'],
+    billing: 'needs-verification',
+  },
+];
+
+const PROBE_TIMEOUT_MS = 4000;
+const MAX_OUTPUT_BYTES = 64 * 1024;
+
+/** Run a binary with a fixed argv, no shell, bounded time + output. */
+function runProbe(
+  bin: string,
+  args: readonly string[],
+): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    execFile(
+      bin,
+      [...args],
+      {
+        timeout: PROBE_TIMEOUT_MS,
+        maxBuffer: MAX_OUTPUT_BYTES,
+        // Never inherit a shell; never pass user input. Scrub credential env
+        // vars so a probe can't be tricked into an API-key path (#309 §2).
+        env: scrubbedEnv(),
+        windowsHide: true,
+      },
+      (err, stdout, stderr) => {
+        if (err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+          resolve({ ok: false, stdout: '', stderr: 'not found' });
+          return;
+        }
+        // A non-zero exit (e.g. "not logged in") is still a usable signal.
+        resolve({
+          ok: !err,
+          stdout: String(stdout ?? ''),
+          stderr: String(stderr ?? ''),
+        });
+      },
+    );
+  });
+}
+
+/**
+ * Copy of the process env with vendor credential vars removed. Keeps a probe
+ * (and later, the real CLI spawn) on the subscription path — see #309 §2
+ * "billing-precedence footgun".
+ */
+export function scrubbedEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of CLI_ENV_SCRUB_KEYS) {
+    delete env[key];
+  }
+  return env;
+}
+
+/** Parse the first top-level JSON object found in CLI output, or undefined. */
+function tryParseJsonObject(out: string): Record<string, unknown> | undefined {
+  const start = out.indexOf('{');
+  const end = out.lastIndexOf('}');
+  if (start === -1 || end <= start) return undefined;
+  try {
+    const parsed = JSON.parse(out.slice(start, end + 1));
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** First non-empty string value among the given keys. */
+function pickString(obj: Record<string, unknown>, keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    const v = obj[key];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return undefined;
+}
+
+async function detectOne(spec: CliBackendSpec): Promise<CliBackendStatus> {
+  const ver = await runProbe(spec.bin, spec.versionArgs);
+  if (!ver.ok && ver.stderr === 'not found') {
+    return {
+      id: spec.id,
+      label: spec.label,
+      bin: spec.bin,
+      installed: false,
+      loggedIn: 'no',
+      billing: spec.billing,
+      detail: `${spec.bin} is not installed in this environment.`,
+    };
+  }
+
+  const version = (ver.stdout || ver.stderr).trim().split('\n')[0]?.trim() || undefined;
+
+  let loggedIn: CliLoginState = 'unknown';
+  let account: string | undefined;
+  if (spec.authArgs && spec.parseAuth) {
+    const auth = await runProbe(spec.bin, spec.authArgs);
+    const parsed = spec.parseAuth(`${auth.stdout}\n${auth.stderr}`);
+    loggedIn = parsed.state;
+    account = parsed.account;
+  }
+
+  const detail =
+    loggedIn === 'yes'
+      ? account
+        ? `Logged in as ${account}.`
+        : 'Logged in.'
+      : loggedIn === 'no'
+        ? `Installed but not logged in. Run the in-app login to connect a subscription.`
+        : `Installed. Login status could not be confirmed — open the login panel to check.`;
+
+  return {
+    id: spec.id,
+    label: spec.label,
+    bin: spec.bin,
+    installed: true,
+    ...(version ? { version } : {}),
+    loggedIn,
+    ...(account ? { account } : {}),
+    billing: spec.billing,
+    detail,
+  };
+}
+
+export interface CliBackendsSnapshot {
+  readonly backends: ReadonlyArray<CliBackendStatus>;
+  /** Epoch ms when this snapshot was produced. */
+  readonly generatedAt: number;
+}
+
+let cache: CliBackendsSnapshot | undefined;
+const CACHE_TTL_MS = 30_000;
+
+/**
+ * Detect all supported CLI backends. Cached for {@link CACHE_TTL_MS} (logins
+ * change out of band); pass `{ force: true }` for the UI's "re-check" action.
+ */
+export async function detectCliBackends(
+  opts: { force?: boolean } = {},
+): Promise<CliBackendsSnapshot> {
+  const now = Date.now();
+  if (!opts.force && cache && now - cache.generatedAt < CACHE_TTL_MS) {
+    return cache;
+  }
+  const backends = await Promise.all(CLI_BACKENDS.map((s) => detectOne(s)));
+  cache = { backends, generatedAt: now };
+  return cache;
+}
+
+/** Test seam: clear the module-level cache. */
+export function __resetCliBackendCache(): void {
+  cache = undefined;
+}

--- a/middleware/src/plugins/dynamicAgentRuntime.ts
+++ b/middleware/src/plugins/dynamicAgentRuntime.ts
@@ -24,7 +24,9 @@ import type { ServiceRegistry } from '../platform/serviceRegistry.js';
 import type { SecretVault } from '../secrets/vault.js';
 import type { NativeToolRegistry } from '@omadia/orchestrator';
 import {
+  createCliSubAgent,
   LocalSubAgent,
+  type Askable,
   type LocalSubAgentTool,
   type LocalSubAgentToolResult,
 } from '@omadia/orchestrator';
@@ -469,15 +471,28 @@ export class DynamicAgentRuntime {
       }
     }
 
-    const subAgent = new LocalSubAgent({
-      name: shortName,
-      provider,
-      model: subAgentModel,
-      maxTokens: this.deps.subAgentMaxTokens,
-      maxIterations: this.deps.subAgentMaxIterations,
-      systemPrompt,
-      tools: subAgentTools,
-    });
+    // #309 recursive Shape 3: on the subscription CLI provider the in-process
+    // LocalSubAgent cannot run a tool loop (its provider rejects tool-carrying
+    // requests). Run the sub-agent through its own CliChatAgent instead — the
+    // `claude` CLI owns the loop, the sub-agent's tools reach it over a fresh
+    // loopback MCP server. Every other provider keeps the in-process path.
+    const subAgent: Askable =
+      hostProviderId === 'claude-cli'
+        ? createCliSubAgent({
+            name: shortName,
+            systemPrompt,
+            model: stripCliModelAlias(subAgentModel),
+            tools: subAgentTools,
+          })
+        : new LocalSubAgent({
+            name: shortName,
+            provider,
+            model: subAgentModel,
+            maxTokens: this.deps.subAgentMaxTokens,
+            maxIterations: this.deps.subAgentMaxIterations,
+            systemPrompt,
+            tools: subAgentTools,
+          });
 
     const description = buildDomainToolDescription(catalogEntry);
 
@@ -726,6 +741,13 @@ function isLocalSubAgentTool(t: unknown): t is LocalSubAgentTool {
     'handle' in t &&
     typeof (t as { handle: unknown }).handle === 'function'
   );
+}
+
+/** Strip the registry's `-cli` model-alias suffix back to the bare CLI alias
+ *  (`opus-cli` -> `opus`) for `claude -p --model`. Mirrors buildOrchestrator.ts.
+ *  Falls back to `sonnet` when stripping yields an empty string. */
+function stripCliModelAlias(model: string): string {
+  return model.replace(/-cli$/, '') || 'sonnet';
 }
 
 function isStreamingUploadedToolkitTool(

--- a/middleware/src/routes/adminCliBackends.ts
+++ b/middleware/src/routes/adminCliBackends.ts
@@ -1,0 +1,84 @@
+/**
+ * `/api/v1/admin/cli-backends` — backend for the "Subscription CLIs" admin page
+ * (#309, Phase B). Reports which vendor LLM CLIs (Claude / Codex / Gemini) are
+ * installed on the host and whether they are logged in, and drives the in-app
+ * login flow, so a self-hoster can run agents on a subscription they already pay
+ * for instead of a metered API key.
+ *
+ *  GET  /                       → { backends, generatedAt } (`?refresh=1` to bust cache)
+ *  POST /:id/login/start        → { sessionId, verificationUrl } (spawns `claude auth login`)
+ *  POST /:id/login/code         → { status, account? } (writes the pasted code to stdin)
+ *  POST /:id/login/cancel       → { ok }
+ *  POST /:id/logout             → { ok }
+ *
+ * Detection is read-only (never triggers a login or consumes quota). The login
+ * endpoints spawn the official CLI with the API-key env scrubbed (subscription
+ * path only). Auth is required — this exposes host capability, not a secret.
+ */
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+
+import { detectCliBackends } from '../platform/cliBackendDetector.js';
+import {
+  startCliLogin,
+  submitCliCode,
+  cancelCliLogin,
+  cliLogout,
+} from '../platform/cliAuthService.js';
+
+export function createAdminCliBackendsRouter(): Router {
+  const router = Router();
+
+  router.get('/', async (req: Request, res: Response) => {
+    const force = req.query['refresh'] === '1' || req.query['refresh'] === 'true';
+    try {
+      const snapshot = await detectCliBackends({ force });
+      res.json(snapshot);
+    } catch (err) {
+      res.status(500).json({ error: 'detection_failed', message: errMessage(err) });
+    }
+  });
+
+  router.post('/:id/login/start', async (req: Request, res: Response) => {
+    try {
+      const result = await startCliLogin(String(req.params['id']));
+      res.json(result);
+    } catch (err) {
+      res.status(400).json({ error: 'login_start_failed', message: errMessage(err) });
+    }
+  });
+
+  router.post('/:id/login/code', async (req: Request, res: Response) => {
+    const body = (req.body ?? {}) as { sessionId?: unknown; code?: unknown };
+    if (typeof body.sessionId !== 'string' || typeof body.code !== 'string') {
+      res.status(400).json({ error: 'bad_request', message: 'sessionId and code are required.' });
+      return;
+    }
+    try {
+      const result = await submitCliCode(body.sessionId, body.code);
+      res.json(result);
+    } catch (err) {
+      res.status(400).json({ error: 'login_code_failed', message: errMessage(err) });
+    }
+  });
+
+  router.post('/:id/login/cancel', (_req: Request, res: Response) => {
+    cancelCliLogin();
+    res.json({ ok: true });
+  });
+
+  router.post('/:id/logout', async (req: Request, res: Response) => {
+    try {
+      const result = await cliLogout(String(req.params['id']));
+      res.json(result);
+    } catch (err) {
+      res.status(400).json({ error: 'logout_failed', message: errMessage(err) });
+    }
+  });
+
+  return router;
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/middleware/src/routes/adminProviders.ts
+++ b/middleware/src/routes/adminProviders.ts
@@ -26,6 +26,7 @@ import type { Request, Response } from 'express';
 
 import type { InstalledRegistry } from '../plugins/installedRegistry.js';
 import type { SecretVault } from '../secrets/vault.js';
+import { detectCliBackends } from '../platform/cliBackendDetector.js';
 
 export interface AdminProvidersDeps {
   readonly installedRegistry: InstalledRegistry;
@@ -38,6 +39,7 @@ export interface AdminProvidersDeps {
     get(id: string):
       | {
           readonly label: string;
+          readonly wireFormat?: string;
           readonly policy?: {
             readonly requiresAvvDisclosure?: boolean;
             readonly euHosted?: boolean;
@@ -61,6 +63,11 @@ interface LlmPluginDesc {
   readonly modelKeys: readonly string[];
   /** Extra config to apply on a non-Anthropic assignment. */
   readonly extraOnNonAnthropic?: Readonly<Record<string, string>>;
+  /** This plugin drives a tool loop, so a tool-less provider (e.g. the
+   *  `claude-cli` Shape-2 backend) must NOT be assignable to it — that would
+   *  silently disable its tools. Tool-less plugins (extractors/classifiers)
+   *  omit this. */
+  readonly requiresTools?: boolean;
 }
 
 const LLM_PLUGINS: ReadonlyArray<LlmPluginDesc> = [
@@ -68,13 +75,17 @@ const LLM_PLUGINS: ReadonlyArray<LlmPluginDesc> = [
     id: '@omadia/orchestrator',
     label: 'Orchestrator',
     modelKeys: ['orchestrator_model'],
-    // Per-turn Sonnet/Opus routing only makes sense within Anthropic.
+    // Per-turn Sonnet/Opus routing only makes sense within Anthropic; the
+    // default chatAgent path now accepts the subscription CLI via Shape 3.
     extraOnNonAnthropic: { orchestrator_model_routing: 'false' },
   },
   {
     id: '@omadia/verifier',
     label: 'Verifier',
     modelKeys: ['verifier_model'],
+    // The verifier uses FORCED single-tool structured output (claimExtractor /
+    // evidenceJudge), which the claude-cli provider now supports via a
+    // JSON-schema prompt — so the subscription CLI is a valid choice here.
   },
   {
     id: '@omadia/orchestrator-extras',
@@ -143,13 +154,21 @@ export function createAdminProvidersRouter(deps: AdminProvidersDeps): Router {
     // an uncaught vault/read failure would hang the request. Catch → 500.
     try {
       const providerIds = [...new Set(listModels().map((m) => m.provider))];
+      // #309: a CLI-backed provider is keyless — "connected" means the local CLI
+      // is installed AND logged in (host capability), not a vault key. Detect once.
+      const cliSnap = await detectCliBackends().catch(() => undefined);
+      const cliConnected = (cliId: string): boolean =>
+        cliSnap?.backends.find((b) => b.id === cliId)?.loggedIn === 'yes';
       const providers = await Promise.all(
         providerIds.map(async (id) => {
           const descriptor = deps.llmProviderCatalog?.get(id);
           return {
           id,
           label: descriptor?.label ?? providerLabel(id),
-          connected: await isConnected(deps.vault, id),
+          connected: id === 'claude-cli' ? cliConnected('claude') : await isConnected(deps.vault, id),
+          // Tool-less (Shape-2 CLI) providers can't drive a tool loop — the UI
+          // uses this to disable them for tool-dependent plugins.
+          toolLess: descriptor?.wireFormat === 'claude-cli',
           // Data-protection hints for the operator UI (data-driven, no id checks).
           // Safe defaults for an unknown provider: third-party, non-EU.
           requiresAvvDisclosure: descriptor?.policy?.requiresAvvDisclosure ?? true,
@@ -178,6 +197,8 @@ export function createAdminProvidersRouter(deps: AdminProvidersDeps): Router {
           provider: readStringConfig(cfg, 'llm_provider') ?? DEFAULT_PROVIDER,
           model: readStringConfig(cfg, modelKey) ?? null,
           modelKey,
+          // This plugin drives a tool loop → the UI disables tool-less providers.
+          requiresTools: p.requiresTools === true,
           // surface the orchestrator's per-turn routing flag so the page can show
           // /edit it directly (it gets force-disabled on a non-Anthropic switch).
           ...(p.id === '@omadia/orchestrator'
@@ -222,6 +243,18 @@ export function createAdminProvidersRouter(deps: AdminProvidersDeps): Router {
       res.status(404).json({
         code: 'providers.not_installed',
         message: `${pluginId} is not installed`,
+      });
+      return;
+    }
+    // Fail closed: never assign a tool-less provider (the `claude-cli` Shape-2
+    // backend) to a plugin that drives a tool loop — it would silently disable
+    // tools/memory/sub-agents. Tool-less plugins (extractors/classifiers) are
+    // fine and are the intended target for the subscription CLI.
+    const providerWire = deps.llmProviderCatalog?.get(provider)?.wireFormat;
+    if (desc.requiresTools === true && providerWire === 'claude-cli') {
+      res.status(400).json({
+        code: 'providers.tool_incompatible',
+        message: `${desc.label} needs tool support; the subscription CLI provider is tool-less. Use it only for tool-less roles (e.g. extraction/classification).`,
       });
       return;
     }

--- a/middleware/test/agentBuilderSubAgentTools.test.ts
+++ b/middleware/test/agentBuilderSubAgentTools.test.ts
@@ -24,6 +24,7 @@ import {
   mcpToolNameFromRef,
   subAgentToolName,
 } from '../packages/harness-orchestrator/src/registry/subAgentTools.js';
+import { registerDbSubAgentTools } from '../src/agents/subAgentToolHydration.js';
 
 const fakeProvider = {} as unknown as LlmProvider;
 
@@ -104,6 +105,68 @@ test('disabled sub-agents are skipped', () => {
     { provider: fakeProvider, defaultModel: 'm', defaultMaxTokens: 1, defaultMaxIterations: 1 },
   );
   assert.equal(tools.length, 0);
+});
+
+test('registerDbSubAgentTools registers one domain tool on local and CLI host paths', () => {
+  const slice = {
+    subAgents: [sub()],
+    toolGrants: [nativeGrant()],
+    skills: [skill()],
+  };
+
+  const makeBuilt = () => {
+    const registered: Array<{ name: string }> = [];
+    return {
+      built: {
+        orchestrator: {
+          hasDomainTool: (name: string): boolean =>
+            registered.some((tool) => tool.name === name),
+          registerDomainTool: (tool: { name: string }): void => {
+            registered.push(tool);
+          },
+        },
+      },
+      registered,
+    };
+  };
+
+  const makeDeps = (
+    overrides: Partial<Parameters<typeof registerDbSubAgentTools>[2]> = {},
+  ): Parameters<typeof registerDbSubAgentTools>[2] => ({
+    client: {} as Parameters<typeof registerDbSubAgentTools>[2]['client'],
+    nativeToolRegistry: {
+      get: (toolRef: string) =>
+        toolRef === 'web_search'
+          ? { spec: stubNativeTool.spec, handler: stubNativeTool.handle }
+          : undefined,
+    } as Parameters<typeof registerDbSubAgentTools>[2]['nativeToolRegistry'],
+    mcpManager: {} as Parameters<typeof registerDbSubAgentTools>[2]['mcpManager'],
+    mcpServers: [],
+    defaultModel: 'claude-sonnet-4-6',
+    ...overrides,
+  });
+
+  const local = makeBuilt();
+  const cli = makeBuilt();
+
+  assert.equal(registerDbSubAgentTools(slice, local.built, makeDeps()), 1);
+  assert.equal(local.registered.length, 1);
+  assert.equal(local.registered[0]?.name, 'ask_researcher_bot');
+
+  assert.equal(
+    registerDbSubAgentTools(
+      slice,
+      cli.built,
+      makeDeps({
+        hostIsCliProvider: true,
+        cliModelAlias: (model: string): string =>
+          model.replace(/-cli$/, '') || 'sonnet',
+      }),
+    ),
+    1,
+  );
+  assert.equal(cli.registered.length, 1);
+  assert.equal(cli.registered[0]?.name, 'ask_researcher_bot');
 });
 
 test('subAgentToolName + mcpToolNameFromRef', () => {

--- a/middleware/test/cliBackendDetector.test.ts
+++ b/middleware/test/cliBackendDetector.test.ts
@@ -72,18 +72,24 @@ describe('cliBackendDetector', () => {
   });
 });
 
-describe('claudeCliAdapter (Shape-2, tool-less)', () => {
-  it('advertises tools:false and fails closed when a request carries tools', async () => {
+describe('claudeCliAdapter (Shape-2)', () => {
+  it('advertises tools:false but supports forced single-tool structured output', () => {
     const provider = claudeCliAdapter.build({ apiKey: 'no-key-required', id: 'claude-cli' });
     assert.equal(provider.capabilities.tools, false);
+    assert.equal(provider.capabilities.forcedToolChoice, true);
+  });
+
+  it('fails closed on GENERAL (auto, non-forced) tool use', async () => {
+    const provider = claudeCliAdapter.build({ apiKey: 'no-key-required', id: 'claude-cli' });
     await assert.rejects(
       provider.complete({
         model: 'sonnet-cli',
         messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
         maxTokens: 100,
         tools: [{ name: 'do_thing', description: 'x', inputSchema: {} }],
+        // no toolChoice → general tool use → rejected (forced single-tool only)
       }),
-      /tool-less/,
+      /forced single-tool|general tool use/,
     );
   });
 });

--- a/middleware/test/cliBackendDetector.test.ts
+++ b/middleware/test/cliBackendDetector.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import express from 'express';
+import { CLI_ENV_SCRUB_KEYS } from '../packages/harness-orchestrator/src/cliChatAgent.js';
+
+import {
+  detectCliBackends,
+  scrubbedEnv,
+  __resetCliBackendCache,
+} from '../src/platform/cliBackendDetector.js';
+import { createAdminCliBackendsRouter } from '../src/routes/adminCliBackends.js';
+import { claudeCliAdapter } from '../src/platform/claudeCliAdapter.js';
+
+describe('cliBackendDetector', () => {
+  afterEach(() => {
+    __resetCliBackendCache();
+  });
+
+  it('reports the three supported vendor CLIs with honest billing posture', async () => {
+    const snap = await detectCliBackends({ force: true });
+    const ids = snap.backends.map((b) => b.id).sort();
+    assert.deepEqual(ids, ['claude', 'codex', 'gemini']);
+
+    const claude = snap.backends.find((b) => b.id === 'claude');
+    assert.ok(claude);
+    // Claude is the only v1-recommended (subscription-billed) path.
+    assert.equal(claude.billing, 'subscription');
+
+    for (const id of ['codex', 'gemini']) {
+      const b = snap.backends.find((x) => x.id === id);
+      assert.ok(b);
+      assert.equal(b.billing, 'needs-verification');
+    }
+  });
+
+  it('every backend exposes a tri-state login and a human detail', async () => {
+    const snap = await detectCliBackends({ force: true });
+    for (const b of snap.backends) {
+      assert.ok(['yes', 'no', 'unknown'].includes(b.loggedIn));
+      assert.equal(typeof b.installed, 'boolean');
+      assert.ok(b.detail.length > 0);
+      // A CLI that is not installed must never claim a login.
+      if (!b.installed) assert.equal(b.loggedIn, 'no');
+    }
+  });
+
+  it('caches within the TTL and re-detects on force', async () => {
+    const first = await detectCliBackends({ force: true });
+    const cached = await detectCliBackends();
+    assert.equal(first, cached, 'a non-forced call within TTL returns the cached snapshot');
+
+    const forced = await detectCliBackends({ force: true });
+    assert.notEqual(forced, cached, 'force bypasses the cache');
+    assert.equal(forced.backends.length, 3);
+  });
+
+  it('scrubbedEnv strips the canonical credential and backend-switch key set', () => {
+    const vars = Object.fromEntries(
+      CLI_ENV_SCRUB_KEYS.map((key) => [key, `${key.toLowerCase()}-secret`]),
+    );
+    for (const [k, v] of Object.entries(vars)) process.env[k] = v;
+    try {
+      const env = scrubbedEnv();
+      for (const k of CLI_ENV_SCRUB_KEYS) assert.equal(env[k], undefined, `${k} must be scrubbed`);
+      assert.equal(env['PATH'], process.env['PATH']); // non-credential vars preserved
+    } finally {
+      for (const k of Object.keys(vars)) delete process.env[k];
+    }
+  });
+});
+
+describe('claudeCliAdapter (Shape-2, tool-less)', () => {
+  it('advertises tools:false and fails closed when a request carries tools', async () => {
+    const provider = claudeCliAdapter.build({ apiKey: 'no-key-required', id: 'claude-cli' });
+    assert.equal(provider.capabilities.tools, false);
+    await assert.rejects(
+      provider.complete({
+        model: 'sonnet-cli',
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+        maxTokens: 100,
+        tools: [{ name: 'do_thing', description: 'x', inputSchema: {} }],
+      }),
+      /tool-less/,
+    );
+  });
+});
+
+describe('adminCliBackends route', () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    __resetCliBackendCache();
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+      server = undefined;
+    }
+  });
+
+  it('GET / returns the detection snapshot as JSON', async () => {
+    const app = express();
+    app.use('/api/v1/admin/cli-backends', createAdminCliBackendsRouter());
+    server = app.listen(0);
+    const port = (server.address() as AddressInfo).port;
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/v1/admin/cli-backends`);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as {
+      backends: Array<{ id: string }>;
+      generatedAt: number;
+    };
+    assert.equal(body.backends.length, 3);
+    assert.equal(typeof body.generatedAt, 'number');
+  });
+
+  it('POST /:id/login/code rejects a missing sessionId/code with 400', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/v1/admin/cli-backends', createAdminCliBackendsRouter());
+    server = app.listen(0);
+    const port = (server.address() as AddressInfo).port;
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/v1/admin/cli-backends/claude/login/code`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ code: 'x' }),
+    });
+    assert.equal(res.status, 400);
+  });
+
+  it('POST /:id/login/cancel always returns ok', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/v1/admin/cli-backends', createAdminCliBackendsRouter());
+    server = app.listen(0);
+    const port = (server.address() as AddressInfo).port;
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/v1/admin/cli-backends/claude/login/cancel`, {
+      method: 'POST',
+    });
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { ok: true });
+  });
+});

--- a/middleware/test/cliBridge/cliChatAgent.test.ts
+++ b/middleware/test/cliBridge/cliChatAgent.test.ts
@@ -1,0 +1,117 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { PassThrough } from 'node:stream';
+
+import {
+  CliChatAgent,
+  StreamJsonParser,
+} from '../../packages/harness-orchestrator/src/cliChatAgent.js';
+import type { CliChatAgentDeps } from '../../packages/harness-orchestrator/src/cliChatAgent.js';
+
+// Unit tests for the M2 stream-json → omadia mapping. The `claude -p
+// --output-format stream-json` terminal `result` line is the authoritative
+// source for final text + usage; these lock that mapping + malformed-line
+// tolerance without spawning the CLI (the live end-to-end path is exercised
+// against the real logged-in CLI in the container, gated on login).
+describe('StreamJsonParser (M2 stream-json mapping)', () => {
+  it('maps a terminal success result to finalAnswer, a done event, and usage', () => {
+    const p = new StreamJsonParser(() => 0);
+    const events = p.push(
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        result: 'hello world',
+        num_turns: 3,
+        total_cost_usd: 0.01,
+        usage: {
+          input_tokens: 5,
+          output_tokens: 9,
+          cache_read_input_tokens: 100,
+          cache_creation_input_tokens: 2,
+        },
+      }),
+    );
+
+    assert.equal(p.isError(), false);
+    assert.equal(p.sawTerminalResult(), true);
+    assert.equal(p.finalAnswer(), 'hello world');
+    assert.equal(p.iterations(), 3);
+    const u = p.usage();
+    assert.equal(u.inputTokens, 5);
+    assert.equal(u.outputTokens, 9);
+    assert.equal(u.cacheReadInputTokens, 100);
+    assert.equal(u.cacheCreationInputTokens, 2);
+    assert.equal(u.costUsd, 0.01);
+    assert.equal(u.numTurns, 3);
+    assert.ok(events.some((e) => e.type === 'done'));
+  });
+
+  it('flags a terminal error result with a formatted message', () => {
+    const p = new StreamJsonParser(() => 0);
+    p.push(
+      JSON.stringify({
+        type: 'result',
+        subtype: 'error_max_turns',
+        is_error: true,
+        result: 'too many turns',
+      }),
+    );
+    assert.equal(p.isError(), true);
+    assert.match(p.errorMessage(), /error_max_turns/);
+    assert.match(p.errorMessage(), /too many turns/);
+  });
+
+  it('tolerates malformed, non-object, and blank lines without throwing', () => {
+    const p = new StreamJsonParser(() => 0);
+    assert.deepEqual(p.push('not json at all'), []);
+    assert.deepEqual(p.push(''), []);
+    assert.deepEqual(p.push('   '), []);
+    assert.deepEqual(p.push('123'), []);
+    assert.deepEqual(p.push(JSON.stringify({ type: 'unknown_event' })), []);
+    // After noise, a real terminal still parses cleanly.
+    p.push(JSON.stringify({ type: 'result', is_error: false, result: 'ok', num_turns: 1 }));
+    assert.equal(p.finalAnswer(), 'ok');
+  });
+
+  it('chat() rejects a clean CLI exit that never produced a terminal result line', async () => {
+    const agent = new CliChatAgent({
+      dispatch: {
+        listDispatchableToolSpecs: () => [],
+      } as CliChatAgentDeps['dispatch'],
+      createLoopbackServer: () =>
+        ({
+          start: async () => ({
+            url: 'http://127.0.0.1:1/mcp',
+            port: 1,
+            bearer: 'bearer',
+          }),
+          stop: async () => {},
+        }) as never,
+      spawnFn: (() => {
+        const stdout = new PassThrough();
+        const stderr = new PassThrough();
+        const stdin = new PassThrough();
+        const child = Object.assign(new PassThrough(), {
+          stdin,
+          stdout,
+          stderr,
+          exitCode: null as number | null,
+          signalCode: null as NodeJS.Signals | null,
+          kill: () => true,
+        });
+        stdin.on('finish', () => {
+          stdout.end();
+          child.exitCode = 0;
+          child.emit('close', 0, null);
+        });
+        return child;
+      }) as CliChatAgentDeps['spawnFn'],
+    });
+
+    await assert.rejects(
+      agent.chat({ userMessage: 'hello from test' }),
+      /terminal result line/,
+    );
+  });
+});

--- a/middleware/test/cliBridge/cliEnvScrub.test.ts
+++ b/middleware/test/cliBridge/cliEnvScrub.test.ts
@@ -1,0 +1,88 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  CLI_ENV_SCRUB_KEYS,
+  CliChatAgent,
+  TurnSemaphore,
+} from '../../packages/harness-orchestrator/src/cliChatAgent.js';
+import type { CliChatAgentDeps } from '../../packages/harness-orchestrator/src/cliChatAgent.js';
+
+const EXPECTED_SCRUB_KEYS = [
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
+  'GOOGLE_API_KEY',
+  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_CUSTOM_HEADERS',
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_VERTEX',
+  'ANTHROPIC_VERTEX_PROJECT_ID',
+  'CLOUD_ML_REGION',
+  'GOOGLE_APPLICATION_CREDENTIALS',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+  'AWS_PROFILE',
+  'AWS_REGION',
+  'AWS_DEFAULT_REGION',
+] as const;
+
+describe('CLI env scrubbing', () => {
+  it('exports the complete canonical scrub-key list', () => {
+    assert.deepEqual([...CLI_ENV_SCRUB_KEYS].sort(), [...EXPECTED_SCRUB_KEYS].sort());
+  });
+
+  it('CliChatAgent.buildEnv strips every scrubbed key and preserves unrelated env', () => {
+    const rawEnv = Object.fromEntries(
+      EXPECTED_SCRUB_KEYS.map((key) => [key, `${key.toLowerCase()}-secret`]),
+    ) as NodeJS.ProcessEnv;
+    rawEnv['MARKER'] = 'keep-me';
+
+    const agent = new CliChatAgent({
+      dispatch: {
+        listDispatchableToolSpecs: () => [],
+      } as CliChatAgentDeps['dispatch'],
+      buildEnv: () => ({ ...rawEnv }),
+    });
+
+    const env = (agent as unknown as { buildEnv(): NodeJS.ProcessEnv }).buildEnv();
+    for (const key of CLI_ENV_SCRUB_KEYS) {
+      assert.equal(env[key], undefined, `${key} must be scrubbed`);
+    }
+    assert.equal(env['MARKER'], 'keep-me');
+  });
+});
+
+describe('TurnSemaphore', () => {
+  it('queues waiters in FIFO order and throws on over-release', async () => {
+    const semaphore = new TurnSemaphore(2);
+    await semaphore.acquire();
+    await semaphore.acquire();
+
+    const order: string[] = [];
+    const thirdAcquire = semaphore.acquire().then(() => {
+      order.push('third');
+    });
+    const fourthAcquire = semaphore.acquire().then(() => {
+      order.push('fourth');
+    });
+
+    await Promise.resolve();
+    assert.deepEqual(order, []);
+
+    semaphore.release();
+    await thirdAcquire;
+    assert.deepEqual(order, ['third']);
+
+    semaphore.release();
+    await fourthAcquire;
+    assert.deepEqual(order, ['third', 'fourth']);
+
+    semaphore.release();
+    semaphore.release();
+    assert.throws(() => semaphore.release(), /matching acquire/);
+  });
+});

--- a/middleware/test/cliBridge/cliSubAgent.test.ts
+++ b/middleware/test/cliBridge/cliSubAgent.test.ts
@@ -1,0 +1,101 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { LocalSubAgentTool } from '@omadia/plugin-api';
+
+import { createCliSubAgent } from '../../packages/harness-orchestrator/src/cliSubAgent.js';
+import type { CliChatAgentDeps } from '../../packages/harness-orchestrator/src/cliChatAgent.js';
+
+describe('createCliSubAgent', () => {
+  it('routes ask() through CliChatAgent.chat and exposes sub-agent tools on dispatch', async () => {
+    let seenInput: { userMessage: string } | undefined;
+    let capturedDeps: CliChatAgentDeps | undefined;
+    const structuredTool: LocalSubAgentTool = {
+      spec: {
+        name: 'sub_lookup',
+        description: 'lookup',
+        input_schema: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+          },
+          required: ['id'],
+        },
+      },
+      async handle(input) {
+        assert.deepEqual(input, { id: '42' });
+        return { output: 'tool-out' };
+      },
+    };
+
+    const agent = createCliSubAgent({
+      name: 'finance',
+      systemPrompt: 'You are finance.',
+      model: 'sonnet',
+      tools: [structuredTool],
+      createCliAgent(deps) {
+        capturedDeps = deps;
+        return {
+          async chat(input) {
+            seenInput = input;
+            return { text: 'cli-answer' };
+          },
+        } as never;
+      },
+    });
+
+    const answer = await agent.ask('where is invoice 42?');
+
+    assert.equal(answer, 'cli-answer');
+    assert.deepEqual(seenInput, { userMessage: 'where is invoice 42?' });
+    assert.ok(capturedDeps);
+    assert.deepEqual(
+      capturedDeps.dispatch.listDispatchableToolSpecs().map((spec) => spec.name),
+      ['sub_lookup'],
+    );
+
+    const dispatched = await capturedDeps.dispatch.dispatch('sub_lookup', {
+      id: '42',
+    });
+    assert.equal(dispatched.content, 'tool-out');
+    assert.equal(dispatched.isError, undefined);
+  });
+
+  it('passes through string-returning sub-agent tools unchanged', async () => {
+    let capturedDeps: CliChatAgentDeps | undefined;
+    const stringTool: LocalSubAgentTool = {
+      spec: {
+        name: 'sub_ping',
+        description: 'ping',
+        input_schema: {
+          type: 'object',
+          properties: {},
+          required: [],
+        },
+      },
+      async handle() {
+        return 'pong';
+      },
+    };
+
+    createCliSubAgent({
+      name: 'ops',
+      systemPrompt: 'You are ops.',
+      model: 'haiku',
+      tools: [stringTool],
+      createCliAgent(deps) {
+        capturedDeps = deps;
+        return {
+          async chat() {
+            return { text: 'unused' };
+          },
+        } as never;
+      },
+    });
+
+    assert.ok(capturedDeps);
+    const dispatched = await capturedDeps.dispatch.dispatch('sub_ping', {});
+    assert.equal(dispatched.content, 'pong');
+    assert.equal(dispatched.isError, undefined);
+  });
+});

--- a/middleware/test/cliBridge/loopbackMcpServer.test.ts
+++ b/middleware/test/cliBridge/loopbackMcpServer.test.ts
@@ -1,0 +1,225 @@
+import { strict as assert } from 'node:assert';
+import { afterEach, describe, it } from 'node:test';
+
+import { LoopbackMcpServer } from '../../packages/harness-orchestrator/src/loopbackMcpServer.js';
+import type { ToolDispatchService } from '../../packages/harness-orchestrator/src/toolDispatchService.js';
+
+function parseMcpJson(text: string): unknown {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('event:') && !trimmed.startsWith('data:')) {
+    return JSON.parse(trimmed);
+  }
+
+  const dataLines = trimmed
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith('data:'))
+    .map((line) => line.slice('data:'.length).trim())
+    .filter(Boolean);
+
+  return JSON.parse(dataLines.join('\n'));
+}
+
+describe('LoopbackMcpServer', () => {
+  let server: LoopbackMcpServer | undefined;
+
+  afterEach(async () => {
+    await server?.stop();
+    server = undefined;
+  });
+
+  it('serves initialize, tools/list, and tools/call over loopback HTTP', async (t) => {
+    const seenCalls: Array<{ name: string; input: unknown }> = [];
+    const fakeDispatch = {
+      async dispatch(name: string, input: unknown) {
+        seenCalls.push({ name, input });
+        return { content: `dispatch:${name}:${JSON.stringify(input)}` };
+      },
+    } as unknown as ToolDispatchService;
+
+    server = new LoopbackMcpServer({
+      dispatch: fakeDispatch,
+      bearer: 'secret-token',
+      tools: [
+        {
+          name: 'ping',
+          description: 'p',
+          input_schema: { type: 'object', properties: {} },
+        },
+      ],
+    });
+
+    let handle: Awaited<ReturnType<typeof server.start>>;
+    try {
+      handle = await server.start();
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        error.code === 'EPERM'
+      ) {
+        t.skip('sandbox blocks loopback listeners on 127.0.0.1');
+        return;
+      }
+      throw error;
+    }
+
+    const initializeResponse = await fetch(handle.url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${handle.bearer}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '0' },
+        },
+        id: 1,
+      }),
+    });
+    assert.equal(initializeResponse.status, 200);
+    const sessionId = initializeResponse.headers.get('mcp-session-id');
+    assert.ok(sessionId);
+    const initializePayload = parseMcpJson(await initializeResponse.text()) as {
+      result?: { protocolVersion?: string };
+    };
+    assert.ok(initializePayload.result);
+
+    const initializedResponse = await fetch(handle.url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${handle.bearer}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        'mcp-session-id': sessionId,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'notifications/initialized',
+      }),
+    });
+    assert.equal(initializedResponse.status, 202);
+
+    const listResponse = await fetch(handle.url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${handle.bearer}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        'mcp-session-id': sessionId,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'tools/list',
+        params: {},
+        id: 2,
+      }),
+    });
+    assert.equal(listResponse.status, 200);
+    const listPayload = parseMcpJson(await listResponse.text()) as {
+      result?: { tools?: Array<{ name: string }> };
+    };
+    assert.ok(listPayload.result?.tools?.some((tool) => tool.name === 'ping'));
+
+    const callResponse = await fetch(handle.url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${handle.bearer}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+        'mcp-session-id': sessionId,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'tools/call',
+        params: { name: 'ping', arguments: {} },
+        id: 3,
+      }),
+    });
+    assert.equal(callResponse.status, 200);
+    const callPayload = parseMcpJson(await callResponse.text()) as {
+      result?: {
+        content?: Array<{ type: string; text: string }>;
+        isError?: boolean;
+      };
+    };
+    assert.equal(callPayload.result?.content?.[0]?.text, 'dispatch:ping:{}');
+    assert.equal(callPayload.result?.isError, undefined);
+    assert.deepEqual(seenCalls, [{ name: 'ping', input: {} }]);
+
+    const badBearerResponse = await fetch(handle.url, {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer wrong',
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'tools/list',
+        params: {},
+        id: 4,
+      }),
+    });
+    assert.equal(badBearerResponse.status, 401);
+    const badBearerPayload = parseMcpJson(await badBearerResponse.text()) as {
+      error?: { message?: string };
+      result?: unknown;
+    };
+    assert.equal(badBearerPayload.result, undefined);
+    assert.equal(badBearerPayload.error?.message, 'Unauthorized');
+  });
+
+  it('rejects oversized POST bodies with HTTP 413', async (t) => {
+    const fakeDispatch = {
+      async dispatch() {
+        return { content: 'ok' };
+      },
+    } as unknown as ToolDispatchService;
+
+    server = new LoopbackMcpServer({
+      dispatch: fakeDispatch,
+      bearer: 'secret-token',
+      tools: [],
+    });
+
+    let handle: Awaited<ReturnType<typeof server.start>>;
+    try {
+      handle = await server.start();
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        error.code === 'EPERM'
+      ) {
+        t.skip('sandbox blocks loopback listeners on 127.0.0.1');
+        return;
+      }
+      throw error;
+    }
+
+    const tooLargeBody = JSON.stringify({
+      payload: 'x'.repeat(8 * 1024 * 1024),
+    });
+
+    const response = await fetch(handle.url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${handle.bearer}`,
+        'Content-Type': 'application/json',
+      },
+      body: tooLargeBody,
+    });
+
+    assert.equal(response.status, 413);
+    const payload = parseMcpJson(await response.text()) as {
+      error?: { code?: number; message?: string };
+    };
+    assert.equal(payload.error?.code, 413);
+    assert.equal(payload.error?.message, 'Payload Too Large');
+  });
+});

--- a/middleware/test/cliBridge/toolDispatchService.test.ts
+++ b/middleware/test/cliBridge/toolDispatchService.test.ts
@@ -1,0 +1,205 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { DomainTool } from '../../packages/harness-orchestrator/src/tools/domainQueryTool.js';
+import { NativeToolRegistry } from '../../packages/harness-orchestrator/src/nativeToolRegistry.js';
+import { ToolDispatchService } from '../../packages/harness-orchestrator/src/toolDispatchService.js';
+
+describe('ToolDispatchService', () => {
+  it('routes to native handlers first', async () => {
+    const nativeTools = new NativeToolRegistry();
+    nativeTools.register('echo_native', {
+      handler: async (input) => `native:${JSON.stringify(input)}`,
+      spec: {
+        name: 'echo_native',
+        description: 'd',
+        input_schema: { type: 'object', properties: {} },
+      },
+      domain: 'test.x',
+    });
+
+    const service = new ToolDispatchService({ nativeTools, domainTools: [] });
+    const result = await service.dispatch('echo_native', { ok: true });
+
+    assert.equal(result.content, 'native:{"ok":true}');
+    assert.equal(result.isError, undefined);
+  });
+
+  it('routes to domain tools when native is absent', async () => {
+    const nativeTools = new NativeToolRegistry();
+    const seen: unknown[] = [];
+    const domainTool: DomainTool = {
+      name: 'domain_ping',
+      spec: {
+        name: 'domain_ping',
+        description: 'domain',
+        input_schema: {
+          type: 'object',
+          properties: {
+            msg: { type: 'string', description: 'message' },
+          },
+          required: ['msg'],
+        },
+      },
+      domain: 'domain.test',
+      async handle(input) {
+        seen.push(input);
+        return `domain:${JSON.stringify(input)}`;
+      },
+    };
+
+    const service = new ToolDispatchService({
+      nativeTools,
+      domainTools: [domainTool],
+    });
+    const result = await service.dispatch('domain_ping', { msg: 'hi' });
+
+    assert.equal(result.content, 'domain:{"msg":"hi"}');
+    assert.deepEqual(seen, [{ msg: 'hi' }]);
+  });
+
+  it('keeps native precedence on name collisions', async () => {
+    const nativeTools = new NativeToolRegistry();
+    nativeTools.register('shared_name', {
+      handler: async () => 'native wins',
+      spec: {
+        name: 'shared_name',
+        description: 'native',
+        input_schema: { type: 'object', properties: {} },
+      },
+      domain: 'test.x',
+    });
+
+    const domainTool: DomainTool = {
+      name: 'shared_name',
+      spec: {
+        name: 'shared_name',
+        description: 'domain',
+        input_schema: { type: 'object', properties: {}, required: [] },
+      },
+      domain: 'domain.test',
+      async handle() {
+        return 'domain loses';
+      },
+    };
+
+    const service = new ToolDispatchService({
+      nativeTools,
+      domainTools: [domainTool],
+    });
+
+    const result = await service.dispatch('shared_name', {});
+    assert.equal(result.content, 'native wins');
+  });
+
+  it('returns an error for unknown tools', async () => {
+    const service = new ToolDispatchService({
+      nativeTools: new NativeToolRegistry(),
+      domainTools: [],
+    });
+
+    const result = await service.dispatch('missing_tool', {});
+
+    assert.equal(result.isError, true);
+    assert.match(result.content, /missing_tool/);
+  });
+
+  it('returns handler errors as error content', async () => {
+    const nativeTools = new NativeToolRegistry();
+    nativeTools.register('boom', {
+      handler: async () => {
+        throw new Error('native broke');
+      },
+      spec: {
+        name: 'boom',
+        description: 'boom',
+        input_schema: { type: 'object', properties: {} },
+      },
+      domain: 'test.x',
+    });
+
+    const service = new ToolDispatchService({ nativeTools, domainTools: [] });
+    const result = await service.dispatch('boom', {});
+
+    assert.equal(result.isError, true);
+    assert.equal(result.content, 'native broke');
+  });
+
+  it('lists advertised native and domain specs with native precedence', async () => {
+    const nativeTools = new NativeToolRegistry();
+    nativeTools.register('echo_native', {
+      handler: async () => 'ok',
+      spec: {
+        name: 'echo_native',
+        description: 'native spec',
+        input_schema: { type: 'object', properties: { a: { type: 'string' } } },
+      },
+      domain: 'test.x',
+    });
+    nativeTools.register('shared_name', {
+      handler: async () => 'ok',
+      spec: {
+        name: 'shared_name',
+        description: 'native shared',
+        input_schema: { type: 'object', properties: {} },
+      },
+      domain: 'test.x',
+    });
+
+    const domainTool: DomainTool = {
+      name: 'domain_ping',
+      spec: {
+        name: 'domain_ping',
+        description: 'domain spec',
+        input_schema: {
+          type: 'object',
+          properties: { msg: { type: 'string' } },
+          required: ['msg'],
+        },
+      },
+      domain: 'domain.test',
+      async handle() {
+        return 'domain';
+      },
+    };
+    const collidingDomainTool: DomainTool = {
+      name: 'shared_name',
+      spec: {
+        name: 'shared_name',
+        description: 'domain shared',
+        input_schema: { type: 'object', properties: {}, required: [] },
+      },
+      domain: 'domain.test',
+      async handle() {
+        return 'domain';
+      },
+    };
+
+    const service = new ToolDispatchService({
+      nativeTools,
+      domainTools: [domainTool, collidingDomainTool],
+    });
+
+    const specs = service.listDispatchableToolSpecs();
+    assert.deepEqual(
+      specs.map((spec) => spec.name),
+      ['echo_native', 'shared_name', 'domain_ping'],
+    );
+    assert.equal(specs[0]?.input_schema.type, 'object');
+    assert.equal(specs[2]?.input_schema.type, 'object');
+    assert.equal(specs[1]?.description, 'native shared');
+  });
+
+  it('does not advertise handler-only native entries but still dispatches them', async () => {
+    const nativeTools = new NativeToolRegistry();
+    nativeTools.registerHandler('mem', {
+      handler: async () => 'handler-only',
+    });
+
+    const service = new ToolDispatchService({ nativeTools, domainTools: [] });
+    const result = await service.dispatch('mem', {});
+
+    assert.equal(result.content, 'handler-only');
+    assert.deepEqual(service.listDispatchableToolSpecs(), []);
+  });
+});

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -281,6 +281,9 @@ export interface AdminProvider {
    *  `euHosted`: provider is hosted in the EU (no third-country transfer). */
   requiresAvvDisclosure?: boolean;
   euHosted?: boolean;
+  /** Tool-less Shape-2 CLI provider — cannot drive a tool loop, so the UI
+   *  disables it for tool-dependent plugins. */
+  toolLess?: boolean;
   models: AdminProviderModel[];
 }
 
@@ -293,6 +296,8 @@ export interface ProviderAssignment {
   modelKey: string;
   /** Orchestrator only: per-turn model-routing flag ('true' | 'false'). */
   modelRouting?: string;
+  /** This plugin drives a tool loop → a tool-less provider is not assignable. */
+  requiresTools?: boolean;
 }
 
 export interface ProvidersResponse {
@@ -322,6 +327,79 @@ export async function assignProvider(
   body: AssignProviderRequest,
 ): Promise<AssignProviderResponse> {
   return postJson<AssignProviderResponse>('/v1/admin/providers/assignment', body);
+}
+
+// -----------------------------------------------------------------------------
+// Subscription-CLI backends (#309) — detect installed/logged-in vendor CLIs
+// (Claude/Codex/Gemini) so an operator can run agents on a subscription instead
+// of a metered API key. Read-only host-capability probe.
+// -----------------------------------------------------------------------------
+
+export type CliLoginState = 'yes' | 'no' | 'unknown';
+export type CliBillingPosture = 'subscription' | 'needs-verification';
+
+export interface CliBackendStatus {
+  id: string;
+  label: string;
+  bin: string;
+  installed: boolean;
+  version?: string;
+  loggedIn: CliLoginState;
+  account?: string;
+  billing: CliBillingPosture;
+  detail: string;
+}
+
+export interface CliBackendsResponse {
+  backends: CliBackendStatus[];
+  generatedAt: number;
+}
+
+/** Fetch CLI-backend detection. Pass `force` for the operator's "re-check". */
+export async function getCliBackends(force = false): Promise<CliBackendsResponse> {
+  return getJson<CliBackendsResponse>(
+    `/v1/admin/cli-backends${force ? '?refresh=1' : ''}`,
+  );
+}
+
+export interface CliLoginStart {
+  sessionId: string;
+  verificationUrl: string;
+}
+
+export type CliLoginStatus = 'pending' | 'authorized' | 'invalid' | 'expired' | 'error';
+
+export interface CliCodeResult {
+  status: CliLoginStatus;
+  account?: string;
+  error?: string;
+}
+
+/** Start the in-app CLI login flow (spawns `claude auth login`, returns the URL). */
+export async function startCliLogin(id: string): Promise<CliLoginStart> {
+  return postJson<CliLoginStart>(`/v1/admin/cli-backends/${encodeURIComponent(id)}/login/start`, {});
+}
+
+/** Submit the login code the operator's browser returned. */
+export async function submitCliLoginCode(
+  id: string,
+  sessionId: string,
+  code: string,
+): Promise<CliCodeResult> {
+  return postJson<CliCodeResult>(`/v1/admin/cli-backends/${encodeURIComponent(id)}/login/code`, {
+    sessionId,
+    code,
+  });
+}
+
+/** Cancel an in-flight CLI login. */
+export async function cancelCliLogin(id: string): Promise<{ ok: boolean }> {
+  return postJson<{ ok: boolean }>(`/v1/admin/cli-backends/${encodeURIComponent(id)}/login/cancel`, {});
+}
+
+/** Log the CLI out (clears the stored subscription session). */
+export async function cliLogout(id: string): Promise<{ ok: boolean }> {
+  return postJson<{ ok: boolean }>(`/v1/admin/cli-backends/${encodeURIComponent(id)}/logout`, {});
 }
 
 // -----------------------------------------------------------------------------

--- a/web-ui/app/admin/page.tsx
+++ b/web-ui/app/admin/page.tsx
@@ -35,6 +35,11 @@ export default function AdminIndexPage(): React.ReactElement {
           description="Provider verbinden (Anthropic, OpenAI, Mistral) und pro Agent Provider + Modell zuordnen. Schlüssel liegen verschlüsselt im Vault. AVV-Hinweis beim Wechsel auf einen Drittanbieter. Wirkt sofort."
         />
         <AdminCard
+          href="/admin/subscription-clis"
+          title="Abo-CLIs (Claude / Codex / Gemini)"
+          description="Agenten über ein bestehendes LLM-Abo (Claude Pro/Max) statt über einen API-Schlüssel betreiben — via offizieller CLI. Zeigt erkannte CLIs, Login-Status und wie eine Verbindung aussieht. Einrichtung für Einzelnutzer-Self-Hosting."
+        />
+        <AdminCard
           href="/admin/auth"
           title="Authentifizierungs-Provider"
           description="Lokale Anmeldung und Entra-ID aktivieren oder deaktivieren. Änderungen wirken ohne Neustart."

--- a/web-ui/app/admin/providers/page.tsx
+++ b/web-ui/app/admin/providers/page.tsx
@@ -8,10 +8,24 @@ import { useTranslations } from 'next-intl';
 import {
   assignProvider,
   getProviders,
+  ApiError,
   type AdminProvider,
   type ProviderAssignment,
   type ProvidersResponse,
 } from '../../_lib/api';
+
+/** Pull the backend's `message` out of an ApiError JSON body when present. */
+function friendlyError(err: unknown): string {
+  if (err instanceof ApiError && err.body) {
+    try {
+      const j = JSON.parse(err.body) as { message?: unknown };
+      if (typeof j.message === 'string' && j.message.trim()) return j.message;
+    } catch {
+      /* fall through to the generic message */
+    }
+  }
+  return err instanceof Error ? err.message : String(err);
+}
 
 /**
  * LLM provider admin (S4). Two concerns on one page:
@@ -57,6 +71,8 @@ export default function AdminProvidersPage(): React.ReactElement {
     void load();
   }, [load]);
 
+  // Prefer the backend's explanatory message (e.g. "…the subscription CLI is
+  // tool-less…") over the generic "POST … failed: 400".
   const apply = useCallback(
     async (pluginId: string, provider: string, model: string): Promise<void> => {
       setStatus((s) => ({ ...s, [pluginId]: 'saving' }));
@@ -85,7 +101,7 @@ export default function AdminProvidersPage(): React.ReactElement {
         setStatus((s) => ({ ...s, [pluginId]: 'error' }));
         setErrors((e) => ({
           ...e,
-          [pluginId]: err instanceof Error ? err.message : String(err),
+          [pluginId]: friendlyError(err),
         }));
       }
     },
@@ -190,13 +206,23 @@ function ProviderRow({
         >
           {p.connected ? t('providers.connected') : t('providers.notConnected')}
         </span>
-        {!p.connected && (
+        {p.toolLess ? (
+          // Subscription CLI: connect/manage via the in-app login, not a vault key.
           <Link
-            href="/admin/settings"
+            href="/admin/subscription-clis"
             className="text-[13px] font-medium text-[color:var(--accent)]"
           >
-            {t('providers.addKey')} →
+            {(p.connected ? t('providers.manageCli') : t('providers.logIn'))} →
           </Link>
+        ) : (
+          !p.connected && (
+            <Link
+              href="/admin/settings"
+              className="text-[13px] font-medium text-[color:var(--accent)]"
+            >
+              {t('providers.addKey')} →
+            </Link>
+          )
         )}
       </span>
     </li>
@@ -267,12 +293,20 @@ function AssignmentRow({
           onChange={(e) => onProvider(e.target.value)}
           className={`${selectCls} sm:max-w-[220px]`}
         >
-          {providers.map((p) => (
-            <option key={p.id} value={p.id}>
-              {p.label}
-              {p.connected ? '' : ` (${t('providers.notConnected')})`}
-            </option>
-          ))}
+          {providers.map((p) => {
+            // A tool-less provider can't drive a tool plugin → offer but disable.
+            const blocked = p.toolLess === true && a.requiresTools === true;
+            return (
+              <option key={p.id} value={p.id} disabled={blocked}>
+                {p.label}
+                {blocked
+                  ? ` (${t('assignments.toolLessBlocked')})`
+                  : p.connected
+                    ? ''
+                    : ` (${t('providers.notConnected')})`}
+              </option>
+            );
+          })}
         </select>
 
         <label className="sr-only" htmlFor={`model-${a.pluginId}`}>

--- a/web-ui/app/admin/subscription-clis/page.tsx
+++ b/web-ui/app/admin/subscription-clis/page.tsx
@@ -1,0 +1,400 @@
+'use client';
+
+/**
+ * `/admin/subscription-clis` — "Subscription CLIs" admin page (#309, Phase B).
+ *
+ * Lets a self-hoster see which vendor LLM CLIs (Claude / Codex / Gemini) are
+ * installed and logged in, and connect one via an in-app login flow (no
+ * terminal), so they can run agents on a subscription they already pay for
+ * instead of a metered API key. Aimed at a first-time self-hoster: clear status,
+ * one-click connect, honest caveats.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+
+import { Button } from '../../_components/ui/Button';
+import {
+  getCliBackends,
+  startCliLogin,
+  submitCliLoginCode,
+  cancelCliLogin,
+  cliLogout,
+  type CliBackendsResponse,
+  type CliBackendStatus,
+} from '../../_lib/api';
+
+type T = ReturnType<typeof useTranslations>;
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ready'; data: CliBackendsResponse }
+  | { kind: 'error'; message: string };
+
+export default function AdminSubscriptionClisPage(): React.ReactElement {
+  const t = useTranslations('adminSubscriptionClis');
+  const [state, setState] = useState<State>({ kind: 'loading' });
+  const [rechecking, setRechecking] = useState(false);
+
+  const load = useCallback(async (force: boolean) => {
+    if (force) setRechecking(true);
+    try {
+      const data = await getCliBackends(force);
+      setState({ kind: 'ready', data });
+    } catch (err) {
+      // Keep a prior good snapshot visible; only show the full error on first load.
+      setState((prev) =>
+        prev.kind === 'ready'
+          ? prev
+          : { kind: 'error', message: err instanceof Error ? err.message : String(err) },
+      );
+    } finally {
+      if (force) setRechecking(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const data = await getCliBackends(false);
+        if (!cancelled) setState({ kind: 'ready', data });
+      } catch (err) {
+        if (!cancelled) {
+          setState({ kind: 'error', message: err instanceof Error ? err.message : String(err) });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-8 lg:py-16">
+      <header className="mb-8">
+        <h1 className="font-display text-[clamp(1.75rem,3.5vw,2.5rem)] leading-[1.1] text-[color:var(--fg-strong)]">
+          {t('title')}
+        </h1>
+        <p className="mt-3 max-w-2xl text-[16px] leading-[1.55] text-[color:var(--fg-muted)]">
+          {t('intro')}
+        </p>
+      </header>
+
+      <div className="mb-8 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
+        <div className="text-[13px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
+          {t('explainer.heading')}
+        </div>
+        <p className="mt-2 text-sm leading-[1.55] text-[color:var(--fg-muted)]">{t('explainer.body')}</p>
+        <p className="mt-2 text-sm leading-[1.55] text-[color:var(--fg-muted)]">
+          {t('explainer.singleOperator')}
+        </p>
+        <p className="mt-3 text-sm">
+          <Link href="/admin/providers" className="font-medium text-[color:var(--accent)] underline">
+            {t('selectModelLink')} →
+          </Link>
+        </p>
+      </div>
+
+      {state.kind === 'loading' && (
+        <p className="text-sm text-[color:var(--fg-muted)]">{t('loading')}</p>
+      )}
+      {state.kind === 'error' && (
+        <p className="text-sm text-[color:var(--danger)]">{t('loadError', { message: state.message })}</p>
+      )}
+
+      {state.kind === 'ready' && (
+        <section>
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-[13px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
+              {t('detected.heading')}
+            </h2>
+            <Button
+              variant="secondary"
+              size="sm"
+              busy={rechecking}
+              busyLabel={t('rechecking')}
+              onClick={() => void load(true)}
+            >
+              {t('recheck')}
+            </Button>
+          </div>
+          <ul className="flex flex-col gap-3">
+            {state.data.backends.map((b) => (
+              <CliRow key={b.id} b={b} t={t} onChanged={() => void load(true)} />
+            ))}
+          </ul>
+        </section>
+      )}
+    </main>
+  );
+}
+
+type LoginPhase =
+  | { phase: 'idle' }
+  | { phase: 'starting' }
+  | { phase: 'awaiting'; sessionId: string; url: string }
+  | { phase: 'submitting'; sessionId: string; url: string }
+  | { phase: 'error'; message: string; sessionId?: string; url?: string };
+
+function CliRow({
+  b,
+  t,
+  onChanged,
+}: {
+  b: CliBackendStatus;
+  t: T;
+  onChanged: () => void;
+}): React.ReactElement {
+  const [login, setLogin] = useState<LoginPhase>({ phase: 'idle' });
+  const [code, setCode] = useState('');
+  const [busyLogout, setBusyLogout] = useState(false);
+
+  const statusLine = !b.installed
+    ? t('status.notInstalled')
+    : b.loggedIn === 'yes'
+      ? b.account
+        ? t('status.loggedInAs', { account: b.account })
+        : t('status.loggedIn')
+      : b.loggedIn === 'no'
+        ? t('status.installedNotLoggedIn')
+        : t('status.installedUnknown');
+
+  const onConnect = async (): Promise<void> => {
+    setLogin({ phase: 'starting' });
+    setCode('');
+    try {
+      const { sessionId, verificationUrl } = await startCliLogin(b.id);
+      setLogin({ phase: 'awaiting', sessionId, url: verificationUrl });
+    } catch (err) {
+      setLogin({ phase: 'error', message: err instanceof Error ? err.message : String(err) });
+    }
+  };
+
+  const onSubmitCode = async (sessionId: string, url: string): Promise<void> => {
+    if (!code.trim()) return;
+    setLogin({ phase: 'submitting', sessionId, url });
+    try {
+      const res = await submitCliLoginCode(b.id, sessionId, code.trim());
+      if (res.status === 'authorized') {
+        setLogin({ phase: 'idle' });
+        setCode('');
+        onChanged();
+      } else if (res.status === 'pending') {
+        // Code accepted but the CLI hadn't flipped to logged-in within the
+        // backend window. Keep polling detection before giving up, so a slower
+        // real sign-in still resolves to success without the user re-submitting.
+        for (let i = 0; i < 8; i++) {
+          await new Promise((r) => setTimeout(r, 3000));
+          const snap = await getCliBackends(true);
+          if (snap.backends.find((x) => x.id === b.id)?.loggedIn === 'yes') {
+            setLogin({ phase: 'idle' });
+            setCode('');
+            onChanged();
+            return;
+          }
+        }
+        setLogin({ phase: 'error', message: t('connect.stillPending'), sessionId, url });
+      } else {
+        setLogin({ phase: 'error', message: res.error ?? t('connect.failed'), sessionId, url });
+      }
+    } catch (err) {
+      setLogin({ phase: 'error', message: err instanceof Error ? err.message : String(err), sessionId, url });
+    }
+  };
+
+  const onCancel = (): void => {
+    void cancelCliLogin(b.id);
+    setLogin({ phase: 'idle' });
+    setCode('');
+  };
+
+  const onLogout = async (): Promise<void> => {
+    setBusyLogout(true);
+    try {
+      await cliLogout(b.id);
+      onChanged();
+    } finally {
+      setBusyLogout(false);
+    }
+  };
+
+  const canConnect = b.installed && b.billing === 'subscription' && b.loggedIn !== 'yes';
+
+  return (
+    <li className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 px-4 py-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className="text-[15px] font-semibold text-[color:var(--fg-strong)]">{b.label}</span>
+          <code className="text-[12px] text-[color:var(--fg-muted)]">{b.bin}</code>
+          {b.version ? (
+            <span className="text-[12px] text-[color:var(--fg-muted)]">{t('version', { version: b.version })}</span>
+          ) : null}
+        </div>
+        <div className="flex items-center gap-2">
+          <InstallBadge installed={b.installed} loggedIn={b.loggedIn} t={t} />
+          <BillingBadge billing={b.billing} t={t} />
+        </div>
+      </div>
+      <p className="mt-2 text-sm text-[color:var(--fg-muted)]">{statusLine}</p>
+
+      {/* Logged in → offer logout. */}
+      {b.loggedIn === 'yes' && (
+        <div className="mt-3">
+          <Button variant="ghost" size="sm" busy={busyLogout} busyLabel={t('logout.busy')} onClick={() => void onLogout()}>
+            {t('logout.button')}
+          </Button>
+        </div>
+      )}
+
+      {/* In-app login flow for a connectable (Claude) CLI. */}
+      {canConnect && (
+        <div className="mt-3 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)]/40 p-3">
+          {login.phase === 'idle' && (
+            <div>
+              <Button variant="primary" size="sm" onClick={() => void onConnect()}>
+                {t('connect.button')}
+              </Button>
+              <details className="mt-3">
+                <summary className="cursor-pointer text-[12px] text-[color:var(--fg-muted)]">
+                  {t('connect.manualSummary')}
+                </summary>
+                <ol className="mt-2 list-decimal space-y-1 pl-5 text-sm text-[color:var(--fg-muted)]">
+                  <li>
+                    {t('connect.step1')}{' '}
+                    <code className="select-all text-[color:var(--fg-strong)]">{t('connect.installCmd')}</code>
+                  </li>
+                  <li>
+                    {t('connect.step2')}{' '}
+                    <code className="select-all text-[color:var(--fg-strong)]">{b.bin} auth login</code>
+                  </li>
+                  <li>{t('connect.step3')}</li>
+                </ol>
+              </details>
+            </div>
+          )}
+
+          {login.phase === 'starting' && (
+            <p className="text-sm text-[color:var(--fg-muted)]">{t('connect.starting')}</p>
+          )}
+
+          {(login.phase === 'awaiting' || login.phase === 'submitting' || (login.phase === 'error' && login.url)) && (
+            <div>
+              <div className="text-[12px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
+                {t('connect.heading')}
+              </div>
+              <ol className="mt-2 list-decimal space-y-2 pl-5 text-sm text-[color:var(--fg-muted)]">
+                <li>
+                  {t('connect.openHint')}{' '}
+                  {'url' in login && login.url ? (
+                    <a
+                      href={login.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="break-all text-[color:var(--accent)] underline"
+                    >
+                      {t('connect.openLink')}
+                    </a>
+                  ) : null}
+                </li>
+                <li>
+                  {t('connect.pasteHint')}
+                  <div className="mt-2 flex flex-wrap items-center gap-2">
+                    <input
+                      type="text"
+                      value={code}
+                      onChange={(e) => setCode(e.target.value)}
+                      placeholder={t('connect.codePlaceholder')}
+                      className="min-w-[260px] flex-1 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-3 py-1.5 text-sm text-[color:var(--fg-strong)]"
+                    />
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      busy={login.phase === 'submitting'}
+                      busyLabel={t('connect.submitting')}
+                      onClick={() => {
+                        const sid = 'sessionId' in login ? login.sessionId : undefined;
+                        const url = 'url' in login ? login.url : undefined;
+                        if (sid && url) void onSubmitCode(sid, url);
+                      }}
+                    >
+                      {t('connect.submit')}
+                    </Button>
+                    <Button variant="ghost" size="sm" onClick={onCancel}>
+                      {t('connect.cancel')}
+                    </Button>
+                  </div>
+                </li>
+              </ol>
+              {login.phase === 'error' && (
+                <p className="mt-2 text-sm text-[color:var(--danger)]">{login.message}</p>
+              )}
+            </div>
+          )}
+
+          {login.phase === 'error' && !login.url && (
+            <div>
+              <p className="text-sm text-[color:var(--danger)]">{login.message}</p>
+              <div className="mt-2">
+                <Button variant="secondary" size="sm" onClick={() => void onConnect()}>
+                  {t('connect.retry')}
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {b.billing === 'needs-verification' && (
+        <p className="mt-2 rounded-md border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/10 px-3 py-2 text-[12px] text-[color:var(--warning)]">
+          {t('needsVerificationNote')}
+        </p>
+      )}
+    </li>
+  );
+}
+
+function InstallBadge({
+  installed,
+  loggedIn,
+  t,
+}: {
+  installed: boolean;
+  loggedIn: CliBackendStatus['loggedIn'];
+  t: T;
+}): React.ReactElement {
+  const [label, cls] = !installed
+    ? [t('badge.notInstalled'), 'bg-[color:var(--border)]/40 text-[color:var(--fg-muted)]']
+    : loggedIn === 'yes'
+      ? [t('badge.loggedIn'), 'bg-[color:var(--success)]/10 text-[color:var(--success)]']
+      : loggedIn === 'no'
+        ? [t('badge.needsLogin'), 'bg-[color:var(--warning)]/10 text-[color:var(--warning)]']
+        : [t('badge.installed'), 'bg-[color:var(--border)]/40 text-[color:var(--fg-muted)]'];
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em] ${cls}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+function BillingBadge({
+  billing,
+  t,
+}: {
+  billing: CliBackendStatus['billing'];
+  t: T;
+}): React.ReactElement {
+  const [label, cls] =
+    billing === 'subscription'
+      ? [t('badge.subscription'), 'bg-[color:var(--success)]/10 text-[color:var(--success)]']
+      : [t('badge.needsVerification'), 'bg-[color:var(--warning)]/10 text-[color:var(--warning)]'];
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] uppercase tracking-[0.16em] ${cls}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1499,12 +1499,15 @@
       "modelCount": "{count, plural, one {# Modell} other {# Modelle}}",
       "connected": "verbunden",
       "notConnected": "kein Schlüssel",
-      "addKey": "Schlüssel hinterlegen"
+      "addKey": "Schlüssel hinterlegen",
+      "logIn": "Anmelden",
+      "manageCli": "Verwalten"
     },
     "assignments": {
       "heading": "Zuordnung pro Agent",
       "intro": "Ordne jedem LLM-fähigen Plugin einen Provider und ein Modell zu. Beim Speichern wird das Plugin neu aktiviert, sodass die Änderung sofort greift.",
       "notInstalled": "nicht installiert",
+      "toolLessBlocked": "braucht Tools — nicht für diese Rolle",
       "providerLabel": "Provider",
       "modelLabel": "Modell",
       "pickModel": "Modell wählen …",
@@ -1515,6 +1518,64 @@
       "saving": "speichert …",
       "saved": "✓ gespeichert",
       "errorChip": "✗ Fehler"
+    }
+  },
+  "adminSubscriptionClis": {
+    "title": "Abo-CLIs",
+    "intro": "Betreibe Agenten über ein LLM-Abo, das du bereits bezahlst (etwa Claude Pro oder Max), indem du die offizielle CLI des Anbieters verbindest, statt pro Token mit einem API-Schlüssel zu zahlen. omadia erkennt, welche CLIs auf diesem Server installiert und angemeldet sind.",
+    "explainer": {
+      "heading": "Abo vs. API-Schlüssel",
+      "body": "Ein API-Schlüssel rechnet pro Token ab. Eine Abo-CLI läuft über deinen bestehenden Tarif: Du meldest dich einmal mit dem offiziellen Tool an, und omadia nutzt diese Sitzung weiter. Das ist derselbe erlaubte Weg, den die offizielle CLI selbst nutzt, kein Token-Auslesen.",
+      "singleOperator": "Abo-Guthaben gehört zu einem Konto und lässt sich nicht teilen, daher passt das zu einem Self-Host für eine einzelne Person. Für ein geteiltes oder produktives Gateway nutze einen API-Schlüssel auf der Seite LLM-Provider."
+    },
+    "loading": "Lädt …",
+    "loadError": "Laden fehlgeschlagen: {message}",
+    "selectModelLink": "Nach der Anmeldung ein CLI-Modell für einen Agenten unter LLM-Provider auswählen",
+    "detected": {
+      "heading": "Erkannte CLIs"
+    },
+    "recheck": "Erneut prüfen",
+    "rechecking": "Prüft …",
+    "version": "v{version}",
+    "status": {
+      "notInstalled": "In dieser Umgebung nicht installiert.",
+      "loggedIn": "Angemeldet und bereit.",
+      "loggedInAs": "Angemeldet als {account}.",
+      "installedNotLoggedIn": "Installiert, aber noch nicht angemeldet.",
+      "installedUnknown": "Installiert. Anmeldestatus konnte nicht bestätigt werden."
+    },
+    "connect": {
+      "button": "Abo verbinden",
+      "starting": "Anmeldung wird gestartet …",
+      "heading": "Bei deinem Abo anmelden",
+      "openHint": "Öffne die Anthropic-Anmeldeseite und bestätige den Zugriff:",
+      "openLink": "Anmeldeseite öffnen",
+      "pasteHint": "Kopiere den nach der Bestätigung angezeigten Code, füge ihn hier ein und sende ab:",
+      "codePlaceholder": "Login-Code einfügen",
+      "submit": "Code senden",
+      "submitting": "Anmeldung läuft …",
+      "cancel": "Abbrechen",
+      "retry": "Erneut versuchen",
+      "failed": "Anmeldung fehlgeschlagen. Bitte erneut versuchen.",
+      "stillPending": "Noch nicht angemeldet. Öffne den Link, bestätige den Zugriff und sende den Code erneut.",
+      "manualSummary": "Lieber das Terminal?",
+      "step1": "Stelle sicher, dass die CLI installiert ist (im omadia-Image enthalten oder selbst installieren):",
+      "installCmd": "npm install -g @anthropic-ai/claude-code",
+      "step2": "Melde dich mit deinem Abo-Konto an:",
+      "step3": "Komm hierher zurück und drücke Erneut prüfen. Eine angemeldete CLI zeigt ein grünes Badge."
+    },
+    "logout": {
+      "button": "Abmelden",
+      "busy": "Abmeldung läuft …"
+    },
+    "needsVerificationNote": "Die Abo-Abrechnung für diese CLI ist noch nicht bestätigt. Eine Anmeldung könnte statt des Abos die API abrechnen, daher ist sie für omadia bis zur Prüfung nicht empfohlen.",
+    "badge": {
+      "notInstalled": "nicht gefunden",
+      "installed": "installiert",
+      "needsLogin": "Anmeldung nötig",
+      "loggedIn": "angemeldet",
+      "subscription": "Abo",
+      "needsVerification": "Prüfung nötig"
     }
   },
   "createIssue": {

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1499,12 +1499,15 @@
       "modelCount": "{count, plural, one {# model} other {# models}}",
       "connected": "connected",
       "notConnected": "no key",
-      "addKey": "Add key"
+      "addKey": "Add key",
+      "logIn": "Log in",
+      "manageCli": "Manage"
     },
     "assignments": {
       "heading": "Per-agent assignment",
       "intro": "Pin each LLM-capable plugin to a provider and model. Saving re-activates the plugin so the change applies immediately.",
       "notInstalled": "not installed",
+      "toolLessBlocked": "needs tools — not for this role",
       "providerLabel": "Provider",
       "modelLabel": "Model",
       "pickModel": "Select a model …",
@@ -1515,6 +1518,64 @@
       "saving": "saving …",
       "saved": "✓ saved",
       "errorChip": "✗ error"
+    }
+  },
+  "adminSubscriptionClis": {
+    "title": "Subscription CLIs",
+    "intro": "Run agents on an LLM subscription you already pay for (such as Claude Pro or Max) by connecting the vendor's official CLI, instead of paying per token with an API key. omadia detects which CLIs are installed and logged in on this server.",
+    "explainer": {
+      "heading": "Subscription vs API key",
+      "body": "An API key bills you per token. A subscription CLI runs on your existing plan: you log in once with the official tool and omadia reuses that session. This is the same sanctioned path the official CLI uses, not token extraction.",
+      "singleOperator": "Subscription credits belong to one account and cannot be shared, so this fits a single-operator self-host. For a shared or production gateway, use an API key on the LLM providers page."
+    },
+    "loading": "Loading …",
+    "loadError": "Failed to load: {message}",
+    "selectModelLink": "Once logged in, select a CLI model for an agent in LLM providers",
+    "detected": {
+      "heading": "Detected CLIs"
+    },
+    "recheck": "Re-check",
+    "rechecking": "Checking …",
+    "version": "v{version}",
+    "status": {
+      "notInstalled": "Not installed in this environment.",
+      "loggedIn": "Logged in and ready.",
+      "loggedInAs": "Logged in as {account}.",
+      "installedNotLoggedIn": "Installed but not logged in yet.",
+      "installedUnknown": "Installed. Login status could not be confirmed."
+    },
+    "connect": {
+      "button": "Connect subscription",
+      "starting": "Starting the sign-in …",
+      "heading": "Sign in to your subscription",
+      "openHint": "Open the Anthropic sign-in page and approve access:",
+      "openLink": "Open the sign-in page",
+      "pasteHint": "Copy the code shown after you approve, paste it here, and submit:",
+      "codePlaceholder": "Paste the login code",
+      "submit": "Submit code",
+      "submitting": "Signing in …",
+      "cancel": "Cancel",
+      "retry": "Try again",
+      "failed": "Sign-in failed. Try again.",
+      "stillPending": "Not signed in yet. Open the link, approve access, then submit the code again.",
+      "manualSummary": "Prefer the terminal?",
+      "step1": "Make sure the CLI is installed (bundled in the omadia image, or install it):",
+      "installCmd": "npm install -g @anthropic-ai/claude-code",
+      "step2": "Log in with your subscription account:",
+      "step3": "Come back here and press Re-check. A logged-in CLI shows a green badge."
+    },
+    "logout": {
+      "button": "Log out",
+      "busy": "Logging out …"
+    },
+    "needsVerificationNote": "Subscription billing for this CLI is not confirmed yet. Signing in may meter the API instead of your subscription, so it is not recommended for omadia until verified.",
+    "badge": {
+      "notInstalled": "not found",
+      "installed": "installed",
+      "needsLogin": "needs login",
+      "loggedIn": "logged in",
+      "subscription": "subscription",
+      "needsVerification": "needs verification"
     }
   },
   "createIssue": {


### PR DESCRIPTION
Closes #309.

Lets a self-hoster run omadia agents on an LLM **subscription** they already pay for (Claude Pro/Max) via the vendor's official CLI — the sanctioned OpenClaw pattern — instead of a metered API key. Builds on the existing pluggable provider seam; no OAuth-token extraction (the forbidden path is explicitly avoided).

## What ships

- **Subscription CLIs admin page** (`/admin/subscription-clis`): detects installed/logged-in CLIs and runs an **in-app two-leg login** for `claude` (OAuth URL out → operator approves in browser → login code back into the CLI). The CLI is bundled into the image behind a build-arg; credentials persist on a `node`-owned volume (`CLAUDE_CONFIG_DIR`).
- **`claude-cli` LLM provider** (keyless, Shape 2): tool-less completions for high-volume calls, **plus forced-single-tool structured output** so the **Verifier** (claim extraction / evidence judging) runs on the subscription.
- **Full-tool agents** (Shape 3): a bearer-guarded **loopback MCP server** re-exposes omadia's tools to a `claude -p` process that owns the agent loop (`CliChatAgent`). The **orchestrator** and, recursively, **sub-agents** (dynamic + DB) run on the subscription, each over its own per-session loopback bridge.
- **LLM-section integration**: `claude-cli` is selectable per agent; connected-status reflects CLI login (not a vault key); fail-closed guards; Subscription-CLIs ↔ LLM-Providers cross-links.

## Safety / hardening

- Single source of truth for env-scrubbing — strips API-key vars **and** Bedrock/Vertex/AWS switches so a misconfigured host can't silently bill a metered backend.
- Per-turn concurrency cap, SIGTERM→SIGKILL lifecycle + 0600 bearer-file cleanup, loopback request-size cap, bearer never in argv/env.
- Two GPT-5.4 (codex) reviews; all P1 findings fixed.

## Scope / non-goals

- Single-operator self-host (subscription credits are per-account, non-poolable) — not a multi-tenant gateway.
- Codex/Gemini CLIs are detected but out of v1 (their CLIs likely bill the API, not the subscription) — gated behind the same interface.
- Public redistribution of the bundled proprietary CLI is build-arg-gated (default off) pending legal review.

## Verification

Built + deployed to a local stack and proven end-to-end on a real subscription login: orchestrator turn, verifier forced-tool structured output, and a recursive sub-agent tool call all succeed via the CLI. Middleware test suite green (incl. new `test/cliBridge/*`); `tsc`/lint/i18n-parity clean.

Default provider left as Anthropic; flip any agent to "Claude (subscription CLI)" to run it on the subscription.