### PR TITLE
chore: add issue templates and CITATION.cff

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,46 @@
+name: Bug report
+description: Something isn't working as documented
+labels: ["bug", "needs-triage"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. docker compose up -d
+        2. ...
+        3. See error
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: omadia version
+      description: From the admin UI footer, or the OMADIA_VERSION you pinned.
+      placeholder: v0.41.0
+    validations:
+      required: true
+  - type: dropdown
+    id: deploy
+    attributes:
+      label: How are you running it?
+      options:
+        - Docker Compose (prebuilt GHCR images)
+        - Docker Compose (built from source)
+        - From source (Node)
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste container or middleware logs. This is automatically formatted as code.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & ideas (Discussions)
+    url: https://github.com/byte5ai/omadia/discussions
+    about: Ask questions, share what you built, and discuss ideas.
+  - name: 📖 Documentation
+    url: https://omadia.ai/docs
+    about: Setup, configuration, and architecture guides.
+  - name: 🔒 Report a security issue
+    url: https://github.com/byte5ai/omadia/security/policy
+    about: Please report vulnerabilities privately, not as a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: Suggest an idea or improvement
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that omadia makes hard today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,11 @@
+cff-version: 1.2.0
+message: "If you use omadia in your work, please cite it using this metadata."
+title: omadia
+abstract: "Self-hostable agentic OS for building, running, and auditing multi-agent AI teams from signed plugins, with a privacy boundary, answer verification, and a receipt for every action."
+type: software
+url: "https://omadia.ai"
+repository-code: "https://github.com/byte5ai/omadia"
+license: MIT
+authors:
+  - name: "byte5 GmbH"
+    website: "https://byte5.de"


### PR DESCRIPTION
Repo-discovery groundwork (part of the GitHub reach pass).

- **Issue templates** (`.github/ISSUE_TEMPLATE/`): structured bug + feature forms; `config.yml` routes questions to Discussions, docs, and private security reporting.
- **CITATION.cff**: adds the *Cite this repository* button and machine-readable metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)