### PR TITLE
docs: add 'Multiplayer by design' to the Why omadia? table

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@
 
 </div>
 
-**omadia is a self-hostable agentic OS that makes AI dependable enough for real
-work.** A team of agents runs on infrastructure you own and turns your data,
-software, and people into results you can steer, audit, and prove. Sensitive data
-stays in the house and never leaves in clear text. Every answer is checked before
-it ships. Every action carries a receipt. Bring your own LLM key and switch
+**omadia is a self-hostable, multiplayer agentic OS that makes AI dependable
+enough for real work.** A team of agents runs on infrastructure you own and works
+inside your team's shared channels, so several people collaborate with the same
+agents in one context, not a private one-on-one chatbot. The agents turn your
+data, software, and people into results you can steer, audit, and prove. Sensitive
+data stays in the house and never leaves in clear text. Every answer is checked
+before it ships. Every action carries a receipt. Bring your own LLM key and switch
 providers by config, not code.
 
 #### 🎬 The 2-minute pitch

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ three rows are why teams choose it; the rest is the groundwork done properly.
 | ✅ **Answer verification** | A verifier checks each answer's claims against the run's own sources and records a verdict (`approved` / `approved_with_disclaimer`) before it reaches the channel. |
 | 🧮 **Computed, not guessed** | Office and Excel output comes from a real spreadsheet engine, server-side, over real rows (`datasetId`). The figures are calculated by that engine rather than produced by the model. |
 | 🧾 **A receipt for every action** | Every agent run carries a full per-run trace and call-stack viewer: every step, tool call, and decision, replayable. |
+| 👥 **Multiplayer by design** | Agents run in your team's shared channels (Slack, Teams, Telegram, Discord), so several people work with them in one context, not a private one-on-one chatbot. |
 | 🤖 **Agent teams, not one chatbot** | An orchestrator routes each turn to the right specialist plugin agent. Channels, integrations, tools, and capability providers sit behind one stable API. |
 | 🔒 **Self-hosted and yours** | One `docker compose up` on a single machine. Your Postgres, your LLM key, all of the data on your own infrastructure. GDPR-aware and made in the EU. |
 | 🧩 **Signed plugin distribution** | Plugins ship as verifiable signed packages. The platform never pulls arbitrary npm at runtime. |


### PR DESCRIPTION
Adds a *Multiplayer by design* row: agents run in shared team channels (Slack, Teams, Telegram, Discord) so several people use them in one context, rather than a private one-on-one chatbot. A core feature that was missing from the README, and an on-trend framing for agent collaboration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)