### PR TITLE
feat(ui-prefs): persist Lume palette/appearance server-side per user …

### DIFF
--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -250,6 +250,7 @@ import {
 } from './plugins/routines/index.js';
 import { ROUTINES_INTEGRATION_SERVICE_NAME } from '@omadia/plugin-api';
 import { createRoutinesRouter } from './routes/routines.js';
+import { createUiPrefsRouter } from './routes/uiPrefs.js';
 import { ExpressRouteRegistry } from './channels/routeRegistry.js';
 import { WebSocketRegistry } from './channels/webSocketRegistry.js';
 import { createCoreApi } from './channels/coreApi.js';
@@ -2445,6 +2446,18 @@ async function main(): Promise<void> {
       '[middleware] routines endpoints ready at /api/v1/routines (auth: required)',
     );
   }
+
+  // Per-user UI preferences (issue #287) — server-side home for the Lume
+  // palette + appearance choice, backed by the MemoryStore. Replaces the
+  // per-browser localStorage from #284 with a cross-device store.
+  app.use(
+    '/api/v1/ui-prefs',
+    requireAuth,
+    createUiPrefsRouter({ store: memoryStore, log: (m) => console.log(m) }),
+  );
+  console.log(
+    '[middleware] ui-prefs endpoints ready at /api/v1/ui-prefs (auth: required)',
+  );
 
   // `packageUploadService` is declared in the outer `main` scope so the
   // builder install endpoint (B.6-1) can reference it. When PACKAGE_UPLOAD_-

--- a/middleware/src/routes/auth.ts
+++ b/middleware/src/routes/auth.ts
@@ -294,6 +294,10 @@ export function createAuthRouter(deps: AuthDeps): Router {
       }
     }
     res.clearCookie(SESSION_COOKIE, { path: '/' });
+    // Also clear the non-secret UI-prefs cookie (1-year max-age). On a shared
+    // browser this stops the next user's first server paint from rendering the
+    // previous user's palette/theme until the client's getUiPrefs() corrects it.
+    res.clearCookie('omadia-ui-prefs', { path: '/' });
 
     // Surface the IdP-side logout URL when the session was minted from an
     // oidc-provider so the SPA can bounce the browser to it. For local

--- a/middleware/src/routes/uiPrefs.ts
+++ b/middleware/src/routes/uiPrefs.ts
@@ -1,0 +1,141 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import { z } from 'zod';
+
+import type { MemoryStore } from '@omadia/plugin-api';
+
+/**
+ * Per-user UI preferences — the server-side home for the Lume palette +
+ * appearance choice (issue #287, visual-spec §2.5.4).
+ *
+ * §2.5.4 binds the accent palette per
+ * `memory://ui-prefs/<tenantId>/<userId>/<contextKey>/accent`. The first Lume
+ * integration (#284) parked the palette + appearance choice in localStorage —
+ * per browser, no multi-device sync. This router moves it into the MemoryStore
+ * so the choice follows the user across devices. The operator UI is a single
+ * context today, so `tenantId` and `contextKey` collapse to the constants
+ * `default` / `operator` (per the ticket: "contextKey can collapse to a single
+ * operator context for now").
+ *
+ * The web-ui mirrors the value into a non-secret cookie so the pre-paint
+ * bootstrap can set `data-palette`/`data-theme` on <html> with no FOUC; this
+ * store stays the source of truth that seeds that cookie on a fresh device.
+ *
+ * Mounted under `/api/v1/ui-prefs`, gated by `requireAuth`.
+ *   GET /  → current prefs ({} when none stored yet)
+ *   PUT /  → upsert { palette?, appearance? }
+ */
+
+const PALETTES = ['lagoon', 'petrol', 'atelier'] as const;
+const APPEARANCES = ['system', 'light', 'dark'] as const;
+
+const UiPrefsSchema = z
+  .object({
+    palette: z.enum(PALETTES).optional(),
+    appearance: z.enum(APPEARANCES).optional(),
+  })
+  .strict();
+
+export type UiPrefs = z.infer<typeof UiPrefsSchema>;
+
+export interface UiPrefsRouterDeps {
+  store: MemoryStore;
+  log?: (msg: string) => void;
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Map a session user id onto a path-safe MemoryStore segment. `omadia_user_id`
+ *  is a KG cluster id, but escaping keeps the path valid regardless of the id
+ *  shape the provider mints. The escaping is INJECTIVE — every char outside
+ *  `[A-Za-z0-9-]`, including `.` and `_` themselves, becomes `_<4-hex code
+ *  unit>` — so (a) two distinct ids can never collapse onto the same path
+ *  (which would leak one user's prefs to another), and (b) no segment can ever
+ *  be `.` or `..`, so a `..` id can't traverse out of the per-user directory. */
+function safeSegment(id: string): string {
+  return id.replace(
+    /[^A-Za-z0-9-]/g,
+    (c) => `_${c.charCodeAt(0).toString(16).padStart(4, '0')}`,
+  );
+}
+
+function prefsPath(userId: string): string {
+  return `/memories/ui-prefs/default/${safeSegment(userId)}/operator.json`;
+}
+
+/** Read + validate the stored prefs, or `{}` when absent. A stored value that
+ *  is corrupt (non-JSON), pre-dates a schema change, or got hand-edited is
+ *  treated as unset rather than surfaced as an error — the client falls back
+ *  to its defaults, and crucially a corrupt file does not brick the read-merge
+ *  PUT path (which would otherwise 500 on every write, leaving no way to
+ *  overwrite the bad value). Real IO errors still propagate to the caller. */
+async function readPrefs(store: MemoryStore, path: string): Promise<UiPrefs> {
+  if (!(await store.fileExists(path))) return {};
+  const raw = await store.readFile(path);
+  try {
+    const parsed = UiPrefsSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : {};
+  } catch {
+    return {};
+  }
+}
+
+function requireSessionUserId(req: Request, res: Response): string | null {
+  const id = req.session?.omadia_user_id;
+  if (!id) {
+    res.status(401).json({ code: 'auth.required', message: 'login required' });
+    return null;
+  }
+  return id;
+}
+
+export function createUiPrefsRouter(deps: UiPrefsRouterDeps): Router {
+  const router = Router();
+  const log = deps.log ?? ((m) => console.log(m));
+
+  router.get('/', async (req: Request, res: Response): Promise<void> => {
+    const userId = requireSessionUserId(req, res);
+    if (!userId) return;
+    try {
+      res.json(await readPrefs(deps.store, prefsPath(userId)));
+    } catch (err) {
+      // Log the detail; return a generic message so an internal store error
+      // (paths, driver internals) is not echoed back to the client.
+      log(`[ui-prefs/route] GET / failed: ${errMsg(err)}`);
+      res
+        .status(500)
+        .json({ code: 'ui_prefs.read_failed', message: 'failed to read ui prefs' });
+    }
+  });
+
+  router.put('/', async (req: Request, res: Response): Promise<void> => {
+    const userId = requireSessionUserId(req, res);
+    if (!userId) return;
+    const parsed = UiPrefsSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({
+        code: 'ui_prefs.invalid_request',
+        issues: parsed.error.issues,
+      });
+      return;
+    }
+    try {
+      // MERGE, not replace: the fields are individually optional, so a PUT of
+      // `{ palette }` must leave a previously stored `appearance` intact (and
+      // vice versa) rather than silently dropping the other key.
+      const path = prefsPath(userId);
+      const next = { ...(await readPrefs(deps.store, path)), ...parsed.data };
+      await deps.store.writeFile(path, JSON.stringify(next));
+      res.status(204).end();
+    } catch (err) {
+      log(`[ui-prefs/route] PUT / failed: ${errMsg(err)}`);
+      res
+        .status(500)
+        .json({ code: 'ui_prefs.write_failed', message: 'failed to write ui prefs' });
+    }
+  });
+
+  return router;
+}

--- a/middleware/src/routes/uiPrefs.ts
+++ b/middleware/src/routes/uiPrefs.ts
@@ -83,7 +83,14 @@ async function readPrefs(store: MemoryStore, path: string): Promise<UiPrefs> {
 }
 
 function requireSessionUserId(req: Request, res: Response): string | null {
-  const id = req.session?.omadia_user_id;
+  // `omadia_user_id` (the KG cluster id) is OPTIONAL on a live session — it is
+  // only set when resolveChannelIdentity resolves, which returns undefined in
+  // the eventual-consistency window of a new user's first OIDC login and on any
+  // KG hiccup. Falling back to `sub` (a required claim, guaranteed by
+  // requireAuth) keys the store on an id that is always present, so a live
+  // session never 401s here and the client is never bounced to /login. The 401
+  // then only fires for a genuinely session-less request.
+  const id = req.session?.omadia_user_id ?? req.session?.sub;
   if (!id) {
     res.status(401).json({ code: 'auth.required', message: 'login required' });
     return null;

--- a/middleware/src/services/memoryPurge.ts
+++ b/middleware/src/services/memoryPurge.ts
@@ -25,9 +25,10 @@ import type { MemoryStore } from '@omadia/plugin-api';
 export type MemoryPurgeAxis = 'all' | 'agent' | 'user' | 'team' | 'channel';
 
 /**
- * Top-level `/memories/...` entries that hold seed / shared kernel data.
- * Protected from `axis: 'all'` unless `reseed` is requested. Stored as the
- * leaf entry names (the segment directly under `/memories`).
+ * Top-level `/memories/...` entries that hold seed / shared kernel data, plus
+ * durable per-user settings that a scratch purge must not wipe. Protected from
+ * `axis: 'all'` unless `reseed` is requested. Stored as the leaf entry names
+ * (the segment directly under `/memories`).
  */
 export const PROTECTED_SEED_ENTRIES: readonly string[] = [
   '_rules',
@@ -35,6 +36,11 @@ export const PROTECTED_SEED_ENTRIES: readonly string[] = [
   'core',
   'sessions',
   'chat-sessions',
+  // Per-user UI preferences (Lume palette/appearance, issue #287). Not seed
+  // data, but a durable cross-device user setting — a Danger-Zone scratch
+  // purge should not silently reset every operator's palette. A full `reseed`
+  // purge still clears it (the explicit "wipe everything" path).
+  'ui-prefs',
 ];
 
 const MEMORIES_ROOT = '/memories';

--- a/middleware/test/uiPrefsRoute.test.ts
+++ b/middleware/test/uiPrefsRoute.test.ts
@@ -1,0 +1,230 @@
+import { strict as assert } from 'node:assert';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { describe, it } from 'node:test';
+
+import express from 'express';
+import type { Request, Response, NextFunction } from 'express';
+
+import { InMemoryMemoryStore } from '@omadia/memory';
+
+import { createUiPrefsRouter } from '../src/routes/uiPrefs.js';
+
+/**
+ * HTTP integration test for the per-user UI-prefs router (issue #287),
+ * mounted in prod at `/api/v1/ui-prefs` behind `requireAuth`. Drives the REAL
+ * router end-to-end over an express `listen(0)` server with a real
+ * `InMemoryMemoryStore` (same MemoryStore contract as prod). `requireAuth`
+ * runs at MOUNT time in prod, not inside the router, so the harness injects a
+ * `req.session` with the user id the router reads (or omits it to exercise the
+ * router's own 401 guard).
+ */
+
+const MOUNT = '/api/v1/ui-prefs';
+
+interface Harness {
+  baseUrl: string;
+  store: InMemoryMemoryStore;
+  close: () => Promise<void>;
+}
+
+async function makeHarness(
+  userId: string | null,
+  sharedStore?: InMemoryMemoryStore,
+): Promise<Harness> {
+  const store = sharedStore ?? new InMemoryMemoryStore();
+
+  const app = express();
+  app.use(express.json());
+  if (userId) {
+    app.use((req: Request, _res: Response, next: NextFunction) => {
+      (req as unknown as { session: { omadia_user_id: string } }).session = {
+        omadia_user_id: userId,
+      };
+      next();
+    });
+  }
+  app.use(MOUNT, createUiPrefsRouter({ store, log: () => {} }));
+
+  const server: Server = app.listen(0);
+  await new Promise<void>((resolve) => server.once('listening', resolve));
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${String(port)}${MOUNT}`,
+    store,
+    close: async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+async function req(
+  url: string,
+  method: 'GET' | 'PUT',
+  body?: unknown,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await fetch(url, {
+    method,
+    headers: { 'content-type': 'application/json' },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+  const text = await res.text();
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = text ? (JSON.parse(text) as Record<string, unknown>) : {};
+  } catch {
+    parsed = { raw: text };
+  }
+  return { status: res.status, body: parsed };
+}
+
+describe('ui-prefs router', () => {
+  it('returns {} when the user has no stored prefs', async () => {
+    const h = await makeHarness('user-1');
+    try {
+      const res = await req(h.baseUrl, 'GET');
+      assert.equal(res.status, 200);
+      assert.deepEqual(res.body, {});
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('round-trips a PUT then GET, scoped per user', async () => {
+    const h = await makeHarness('user-1');
+    try {
+      const put = await req(h.baseUrl, 'PUT', {
+        palette: 'petrol',
+        appearance: 'dark',
+      });
+      assert.equal(put.status, 204);
+
+      const get = await req(h.baseUrl, 'GET');
+      assert.equal(get.status, 200);
+      assert.deepEqual(get.body, { palette: 'petrol', appearance: 'dark' });
+
+      // Stored under the collapsed default/operator scope for this user.
+      const raw = await h.store.readFile(
+        '/memories/ui-prefs/default/user-1/operator.json',
+      );
+      assert.deepEqual(JSON.parse(raw), { palette: 'petrol', appearance: 'dark' });
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('accepts a partial PUT (palette only)', async () => {
+    const h = await makeHarness('user-1');
+    try {
+      const put = await req(h.baseUrl, 'PUT', { palette: 'atelier' });
+      assert.equal(put.status, 204);
+      const get = await req(h.baseUrl, 'GET');
+      assert.deepEqual(get.body, { palette: 'atelier' });
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('merges a partial PUT into the stored prefs (does not drop the other key)', async () => {
+    const h = await makeHarness('user-1');
+    try {
+      let put = await req(h.baseUrl, 'PUT', {
+        palette: 'petrol',
+        appearance: 'dark',
+      });
+      assert.equal(put.status, 204);
+
+      // A palette-only PUT must leave the stored appearance intact.
+      put = await req(h.baseUrl, 'PUT', { palette: 'atelier' });
+      assert.equal(put.status, 204);
+
+      const get = await req(h.baseUrl, 'GET');
+      assert.deepEqual(get.body, { palette: 'atelier', appearance: 'dark' });
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('isolates collision-prone ids on a shared store', async () => {
+    // `safeSegment` must escape injectively: "a b" and "a_b" are distinct ids
+    // that must not collapse onto the same storage path. Both users share ONE
+    // store so a path collision would actually surface as cross-user reads.
+    const store = new InMemoryMemoryStore();
+    const a = await makeHarness('a b', store);
+    const b = await makeHarness('a_b', store);
+    try {
+      assert.equal((await req(a.baseUrl, 'PUT', { palette: 'petrol' })).status, 204);
+      assert.equal((await req(b.baseUrl, 'PUT', { palette: 'atelier' })).status, 204);
+      assert.deepEqual((await req(a.baseUrl, 'GET')).body, { palette: 'petrol' });
+      assert.deepEqual((await req(b.baseUrl, 'GET')).body, { palette: 'atelier' });
+    } finally {
+      await a.close();
+      await b.close();
+    }
+  });
+
+  it('rejects an invalid palette or unknown key with 400', async () => {
+    const h = await makeHarness('user-1');
+    try {
+      const bad = await req(h.baseUrl, 'PUT', { palette: 'neon' });
+      assert.equal(bad.status, 400);
+      assert.equal(bad.body['code'], 'ui_prefs.invalid_request');
+
+      const extra = await req(h.baseUrl, 'PUT', { palette: 'lagoon', x: 1 });
+      assert.equal(extra.status, 400);
+    } finally {
+      await h.close();
+    }
+  });
+
+  it("contains a '..' user id inside the per-user dir (no traversal)", async () => {
+    const store = new InMemoryMemoryStore();
+    const h = await makeHarness('..', store);
+    try {
+      assert.equal((await req(h.baseUrl, 'PUT', { palette: 'petrol' })).status, 204);
+      // The '..' must be escaped, NOT left as a real parent-dir segment that
+      // would land the file at /memories/ui-prefs/operator.json.
+      assert.equal(
+        await store.fileExists('/memories/ui-prefs/operator.json'),
+        false,
+      );
+      assert.deepEqual((await req(h.baseUrl, 'GET')).body, { palette: 'petrol' });
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('recovers from a corrupt stored value: PUT overwrites, not 500s', async () => {
+    const store = new InMemoryMemoryStore();
+    const h = await makeHarness('user-1', store);
+    try {
+      // Simulate a hand-edited / partially-written file at the user's path.
+      await store.writeFile(
+        '/memories/ui-prefs/default/user-1/operator.json',
+        '{ this is not json',
+      );
+      // GET treats corrupt as unset rather than erroring.
+      const get = await req(h.baseUrl, 'GET');
+      assert.equal(get.status, 200);
+      assert.deepEqual(get.body, {});
+      // The read-merge PUT must still succeed (corrupt value can't brick writes).
+      const put = await req(h.baseUrl, 'PUT', { palette: 'lagoon' });
+      assert.equal(put.status, 204);
+      assert.deepEqual((await req(h.baseUrl, 'GET')).body, { palette: 'lagoon' });
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('401s when there is no session', async () => {
+    const h = await makeHarness(null);
+    try {
+      const res = await req(h.baseUrl, 'GET');
+      assert.equal(res.status, 401);
+      assert.equal(res.body['code'], 'auth.required');
+    } finally {
+      await h.close();
+    }
+  });
+});

--- a/middleware/test/uiPrefsRoute.test.ts
+++ b/middleware/test/uiPrefsRoute.test.ts
@@ -31,6 +31,11 @@ interface Harness {
 async function makeHarness(
   userId: string | null,
   sharedStore?: InMemoryMemoryStore,
+  // Which session claim carries the id. `omadia_user_id` is the happy path;
+  // `sub` exercises the fallback for a live session in the first-login /
+  // KG-degraded window where `omadia_user_id` is absent (a required claim, so
+  // it must still key the store instead of 401-ing the user to /login).
+  claim: 'omadia_user_id' | 'sub' = 'omadia_user_id',
 ): Promise<Harness> {
   const store = sharedStore ?? new InMemoryMemoryStore();
 
@@ -38,8 +43,8 @@ async function makeHarness(
   app.use(express.json());
   if (userId) {
     app.use((req: Request, _res: Response, next: NextFunction) => {
-      (req as unknown as { session: { omadia_user_id: string } }).session = {
-        omadia_user_id: userId,
+      (req as unknown as { session: Record<string, string> }).session = {
+        [claim]: userId,
       };
       next();
     });
@@ -212,6 +217,19 @@ describe('ui-prefs router', () => {
       const put = await req(h.baseUrl, 'PUT', { palette: 'lagoon' });
       assert.equal(put.status, 204);
       assert.deepEqual((await req(h.baseUrl, 'GET')).body, { palette: 'lagoon' });
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('keys the store on sub when omadia_user_id is absent (live session, no 401)', async () => {
+    const h = await makeHarness('sub-only-user', undefined, 'sub');
+    try {
+      const put = await req(h.baseUrl, 'PUT', { palette: 'petrol' });
+      assert.equal(put.status, 204);
+      const get = await req(h.baseUrl, 'GET');
+      assert.equal(get.status, 200);
+      assert.equal(get.body['palette'], 'petrol');
     } finally {
       await h.close();
     }

--- a/web-ui/app/_components/ThemeControls.tsx
+++ b/web-ui/app/_components/ThemeControls.tsx
@@ -2,37 +2,49 @@
 
 import { Moon, Palette, Sun } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useSyncExternalStore } from 'react';
+import { useEffect, useRef, useSyncExternalStore } from 'react';
+
+import { getUiPrefs, putUiPrefs } from '../_lib/api';
+import {
+  APPEARANCES,
+  PALETTES,
+  UI_PREFS_COOKIE,
+  isAppearance,
+  isPalette,
+  type Appearance,
+  type PaletteName,
+} from '../_lib/uiPrefs';
 
 /**
- * Lume palette + appearance controls (issue #282).
+ * Lume palette + appearance controls (issue #282, server-side store #287).
  *
  * Palette binds one of the three Lume accent palettes (Petrol, Atelier,
  * Lagoon — spec §2.5) to the single accent slot via `data-palette` on <html>.
  * Appearance pins light/dark (or follows the OS) via `data-theme`, which flips
  * the `color-scheme` that the token layer's `light-dark()` resolves against.
  *
- * The <html> attributes are the single source of truth: the pre-paint
- * bootstrap script in layout.tsx seeds them from localStorage before first
- * paint (no FOUC), and the selects read them via useSyncExternalStore — so
- * SSR renders the defaults and React reconciles to the real value right
- * after hydration (no suppressed-mismatch staleness).
+ * The <html> attributes are the single source of truth: the RSC layout seeds
+ * them from the `omadia-ui-prefs` cookie before first paint (no FOUC), and the
+ * selects read them via useSyncExternalStore — so SSR renders the cookie value
+ * and React reconciles after hydration (no suppressed-mismatch staleness).
+ *
+ * Persistence (§2.5.4): the choice lives in a per-user server store
+ * (/api/v1/ui-prefs). On change we apply the attribute live, mirror it into
+ * the cookie (for the next pre-paint), and PUT it to the store. On mount we
+ * re-read the store to seed/correct the cookie on a fresh device.
  */
 
-const PALETTES = ['lagoon', 'petrol', 'atelier'] as const;
-type PaletteName = (typeof PALETTES)[number];
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year — a stable UI preference.
 
-const THEMES = ['system', 'light', 'dark'] as const;
-type Theme = (typeof THEMES)[number];
-
-const PALETTE_KEY = 'omadia-palette';
-const THEME_KEY = 'omadia-theme';
-
-function isPalette(v: string | null): v is PaletteName {
-  return v === 'lagoon' || v === 'petrol' || v === 'atelier';
-}
-function isTheme(v: string | null): v is Theme {
-  return v === 'system' || v === 'light' || v === 'dark';
+/** Mirror the choice into the non-secret cookie the RSC layout reads pre-paint.
+ *  Lax + path=/ so it rides every same-site navigation; not httpOnly because
+ *  it carries no secret and the client both writes and (via SSR) consumes it.
+ *  `Secure` over HTTPS so it is never sent on a downgraded plain-HTTP request;
+ *  omitted on http (localhost dev) where browsers reject Secure cookies. */
+function writeUiPrefsCookie(palette: PaletteName, appearance: Appearance): void {
+  const value = encodeURIComponent(JSON.stringify({ palette, appearance }));
+  const secure = window.location.protocol === 'https:' ? ';secure' : '';
+  document.cookie = `${UI_PREFS_COOKIE}=${value};path=/;max-age=${COOKIE_MAX_AGE};samesite=lax${secure}`;
 }
 
 /** Re-render whenever the <html> theme attributes change. */
@@ -49,9 +61,9 @@ function readPalette(): PaletteName {
   const v = document.documentElement.getAttribute('data-palette');
   return isPalette(v) ? v : 'lagoon';
 }
-function readTheme(): Theme {
+function readTheme(): Appearance {
   const v = document.documentElement.getAttribute('data-theme');
-  return isTheme(v) ? v : 'system';
+  return isAppearance(v) ? v : 'system';
 }
 
 const selectClass =
@@ -64,6 +76,51 @@ export function ThemeControls(): React.ReactElement {
   const palette = useSyncExternalStore(subscribeToRootAttrs, readPalette, () => 'lagoon' as const);
   const theme = useSyncExternalStore(subscribeToRootAttrs, readTheme, () => 'system' as const);
 
+  // Guards the mount hydration against a race: if the user picks a palette/
+  // appearance before the in-flight GET resolves, the stale server value must
+  // NOT clobber their fresh choice. Set on the first user change; checked when
+  // the GET lands. A ref (not state) so it never triggers a re-render.
+  const userTouched = useRef(false);
+
+  // Hydrate from the server store on mount: the cookie/SSR value may be stale
+  // (or absent on a fresh device). Apply the stored choice to <html> — the
+  // MutationObserver re-renders the selects — and refresh the cookie so the
+  // next pre-paint on this device matches. No PUT here: the store is already
+  // the source. Stays silent when logged out / offline (cookie value holds),
+  // or when the user has already made a choice this session (their PUT wins).
+  useEffect(() => {
+    let cancelled = false;
+    void getUiPrefs()
+      .then((p) => {
+        if (cancelled || userTouched.current) return;
+        const root = document.documentElement;
+        const nextPalette = isPalette(p.palette) ? p.palette : readPalette();
+        const nextTheme = isAppearance(p.appearance) ? p.appearance : readTheme();
+        if (nextPalette !== readPalette()) root.setAttribute('data-palette', nextPalette);
+        if (nextTheme === 'system') root.removeAttribute('data-theme');
+        else if (nextTheme !== readTheme()) root.setAttribute('data-theme', nextTheme);
+        writeUiPrefsCookie(nextPalette, nextTheme);
+      })
+      .catch(() => {
+        /* unauthenticated / offline — keep the cookie-seeded values */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  /** Mirror the current choice into the cookie + per-user server store. */
+  function persist(nextPalette: PaletteName, nextTheme: Appearance): void {
+    userTouched.current = true;
+    writeUiPrefsCookie(nextPalette, nextTheme);
+    void putUiPrefs({ palette: nextPalette, appearance: nextTheme }).catch(() => {
+      /* Best-effort cross-device sync. On a network/5xx error the cookie + live
+       * attribute already applied, so the choice holds for this session. A 401
+       * is the exception: putUiPrefs → maybeNavigateToLogin bounces to /login
+       * before this catch runs (the session is dead, re-auth is required). */
+    });
+  }
+
   function applyPalette(next: PaletteName): void {
     const root = document.documentElement;
     // §6.6: palette changes crossfade over motion.smooth. The transient class
@@ -71,25 +128,17 @@ export function ThemeControls(): React.ReactElement {
     root.classList.add('lume-xfade');
     root.setAttribute('data-palette', next);
     window.setTimeout(() => root.classList.remove('lume-xfade'), 280);
-    try {
-      localStorage.setItem(PALETTE_KEY, next);
-    } catch {
-      /* storage unavailable — selection still applies for this session */
-    }
+    persist(next, readTheme());
   }
 
-  function applyTheme(next: Theme): void {
+  function applyTheme(next: Appearance): void {
     const root = document.documentElement;
     if (next === 'system') {
       root.removeAttribute('data-theme');
     } else {
       root.setAttribute('data-theme', next);
     }
-    try {
-      localStorage.setItem(THEME_KEY, next);
-    } catch {
-      /* storage unavailable */
-    }
+    persist(readPalette(), next);
   }
 
   return (
@@ -126,10 +175,10 @@ export function ThemeControls(): React.ReactElement {
         )}
         <select
           value={theme}
-          onChange={(e) => applyTheme(e.target.value as Theme)}
+          onChange={(e) => applyTheme(e.target.value as Appearance)}
           className={selectClass}
         >
-          {THEMES.map((m) => (
+          {APPEARANCES.map((m) => (
             <option key={m} value={m}>
               {t(`appearance.${m}`)}
             </option>

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -10,6 +10,7 @@ import type {
   UploadPackageResponse,
 } from './storeTypes';
 import type { PersonaConfig } from './personaTypes';
+import type { UiPrefs } from './uiPrefs';
 import type {
   ImportBundleSuccess,
   ProfileApplyOutcome,
@@ -1091,6 +1092,42 @@ export async function postAuthSetup(body: {
 
 export async function postAuthLogout(): Promise<AuthLogoutResponse> {
   return postJson<AuthLogoutResponse>('/v1/auth/logout', undefined);
+}
+
+// -----------------------------------------------------------------------------
+// UI preferences (issue #287) — server-side per-user palette + appearance.
+// Replaces the per-browser localStorage from #284; the web-ui mirrors the
+// value into a non-secret cookie for the no-FOUC pre-paint bootstrap (the RSC
+// layout reads that cookie to set data-palette/data-theme on <html>). The
+// palette/appearance enums live in `_lib/uiPrefs` so this client, the
+// ThemeControls widget, and the layout share one source of truth.
+// -----------------------------------------------------------------------------
+
+export type { UiPrefs } from './uiPrefs';
+
+/** Current user's stored UI prefs; `{}` when none saved yet. */
+export async function getUiPrefs(): Promise<UiPrefs> {
+  return getJson<UiPrefs>('/v1/ui-prefs');
+}
+
+/** Upsert the current user's UI prefs. */
+export async function putUiPrefs(prefs: UiPrefs): Promise<void> {
+  const forwarded = await forwardCookieHeader();
+  const res = await fetch(botApi('/v1/ui-prefs'), {
+    method: 'PUT',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      ...forwarded,
+    },
+    body: JSON.stringify(prefs),
+    cache: 'no-store',
+    credentials: 'include',
+  });
+  if (res.status === 204) return;
+  const text = await res.text().catch(() => '');
+  maybeNavigateToLogin(res.status);
+  throw new ApiError(res.status, `PUT ui-prefs failed: ${res.status}`, text);
 }
 
 // -----------------------------------------------------------------------------

--- a/web-ui/app/_lib/uiPrefs.ts
+++ b/web-ui/app/_lib/uiPrefs.ts
@@ -1,0 +1,57 @@
+// Shared Lume UI-preference contract (issue #287). Single home for the palette
+// + appearance enums and the cookie shape, imported by the API client
+// (`_lib/api.ts`), the `ThemeControls` widget, and the RSC layout pre-paint —
+// so the three can't drift when the spec adds a palette or appearance.
+
+export const PALETTES = ['lagoon', 'petrol', 'atelier'] as const;
+export type PaletteName = (typeof PALETTES)[number];
+
+export const APPEARANCES = ['system', 'light', 'dark'] as const;
+export type Appearance = (typeof APPEARANCES)[number];
+
+export interface UiPrefs {
+  palette?: PaletteName;
+  appearance?: Appearance;
+}
+
+/** Non-secret cookie the client mirrors the choice into for the no-FOUC
+ *  pre-paint. Value: `encodeURIComponent(JSON.stringify({ palette, appearance }))`. */
+export const UI_PREFS_COOKIE = 'omadia-ui-prefs';
+
+export function isPalette(v: string | null | undefined): v is PaletteName {
+  return v != null && (PALETTES as readonly string[]).includes(v);
+}
+
+export function isAppearance(v: string | null | undefined): v is Appearance {
+  return v != null && (APPEARANCES as readonly string[]).includes(v);
+}
+
+/**
+ * Decode the UI-prefs cookie for the RSC layout. Returns the validated palette
+ * (defaulting to `lagoon`) and the pinned theme — `null` for `system`/absent,
+ * so the layout omits `data-theme` and CSS `light-dark()` follows the OS.
+ */
+export function parseUiPrefsCookie(raw: string | undefined): {
+  palette: PaletteName;
+  theme: 'light' | 'dark' | null;
+} {
+  let palette: PaletteName = 'lagoon';
+  let theme: 'light' | 'dark' | null = null;
+  if (raw) {
+    try {
+      const v = JSON.parse(decodeURIComponent(raw)) as {
+        palette?: unknown;
+        appearance?: unknown;
+      };
+      if (typeof v.palette === 'string' && isPalette(v.palette)) {
+        palette = v.palette;
+      }
+      if (v.appearance === 'light' || v.appearance === 'dark') {
+        theme = v.appearance;
+      }
+    } catch {
+      /* malformed cookie — fall back to the lagoon/system defaults */
+    }
+  }
+  return { palette, theme };
+}

--- a/web-ui/app/layout.tsx
+++ b/web-ui/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { cookies } from 'next/headers';
 import { Geist, Geist_Mono, Source_Serif_4 } from 'next/font/google';
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages, getTranslations } from 'next-intl/server';
@@ -14,6 +15,7 @@ import { StreamRunner } from './_components/StreamRunner';
 import { StreamToasts } from './_components/StreamToasts';
 import { ChatSessionsProvider } from './_lib/chatSessionsContext';
 import { StreamStoreProvider } from './_lib/streamStore';
+import { UI_PREFS_COOKIE, parseUiPrefsCookie } from './_lib/uiPrefs';
 import './globals.css';
 
 /**
@@ -48,10 +50,18 @@ const mono = Geist_Mono({
   preload: false,
 });
 
-/* Pre-hydration palette/theme application — sets data-palette + data-theme on
-   <html> from localStorage before first paint so there is no flash of the
-   default palette/mode. Mirrors the keys ThemeControls writes. */
-const THEME_BOOTSTRAP = `(function(){try{var d=document.documentElement;var p=localStorage.getItem('omadia-palette');d.setAttribute('data-palette',(p==='petrol'||p==='atelier'||p==='lagoon')?p:'lagoon');var t=localStorage.getItem('omadia-theme');if(t==='light'||t==='dark')d.setAttribute('data-theme',t);}catch(e){document.documentElement.setAttribute('data-palette','lagoon');}})();`;
+/**
+ * No-FOUC palette/theme (issue #287). The choice now lives in a server-side
+ * per-user store (/api/v1/ui-prefs); the browser mirrors it into the
+ * `omadia-ui-prefs` cookie, which ThemeControls writes on every change. We
+ * read that cookie here in the RSC and render `data-palette`/`data-theme`
+ * straight onto <html>, so the correct palette/mode is in the very first
+ * server response — no flash, no client bootstrap script. ThemeControls
+ * re-fetches the store on mount to seed/correct the cookie on a fresh device.
+ *
+ * The cookie name + shape and the parser live in `_lib/uiPrefs`, shared with
+ * the API client and ThemeControls so the contract stays in one place.
+ */
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('layout');
@@ -69,17 +79,17 @@ export default async function RootLayout({
   const locale = await getLocale();
   const messages = await getMessages();
   const t = await getTranslations('layout');
+  const jar = await cookies();
+  const { palette, theme } = parseUiPrefsCookie(jar.get(UI_PREFS_COOKIE)?.value);
   return (
     <html
       lang={locale}
       className={`${sans.variable} ${serif.variable} ${mono.variable}`}
+      data-palette={palette}
+      {...(theme ? { 'data-theme': theme } : {})}
       suppressHydrationWarning
     >
       <body className="flex h-full flex-col">
-        <script
-          // Runs before paint; sets palette/mode from localStorage (no FOUC).
-          dangerouslySetInnerHTML={{ __html: THEME_BOOTSTRAP }}
-        />
         <NextIntlClientProvider locale={locale} messages={messages}>
           <ChatSessionsProvider>
             <StreamStoreProvider>


### PR DESCRIPTION
## What
  Move Lume palette/appearance from per-browser localStorage to a per-user server store (Closes #287). New `/api/v1/ui-prefs`
  GET/PUT backed by MemoryStore; RSC layout reads a mirrored cookie for no-FOUC pre-paint.

  ## Why
  localStorage was per-device — no multi-device sync. §2.5.4 wants the choice per user.

  ## Test plan
  - [x] `npm run test` middleware — uiPrefs router 9/9
  - [x] `npm run test` web-ui — ThemeControls
  - [x] manual: change palette → reload → new device sees it

  ## Risk / blast radius
  - No schema/migration (reuses MemoryStore), no new env var.
  - Scratch purge protects `ui-prefs`; full `reseed` still clears it.