### PR TITLE
feat(store): dynamic post-install setup options for plugin fields

### DIFF
--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -70,6 +70,22 @@ export interface PluginSetupField {
   provider?: string;
   /** Spec 005 — OAuth scopes requested for a `type === 'oauth'` field. */
   scopes?: string[];
+  /** Dynamic post-install options: the toolkit-tool id (on the SAME plugin)
+   *  that returns selectable `SetupOption[]` for this field. The field `type`
+   *  stays a normal union member (typically `string`); the post-install editor
+   *  fetches options live and stores the picks. Additive + optional — fields
+   *  without it behave exactly as before. */
+  options_provider?: string;
+  /** When true, this field holds MULTIPLE selected values (stored as a
+   *  JSON-encoded `string[]`). Only meaningful alongside `options_provider`. */
+  multi?: boolean;
+}
+
+/** A single selectable choice returned by a field's `options_provider` tool. */
+export interface SetupOption {
+  value: string;
+  label: string;
+  group?: string;
 }
 
 /**

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -2614,6 +2614,7 @@ async function main(): Promise<void> {
       vault: secretVault,
       catalog: pluginCatalog,
       reactivate: reactivateAgent,
+      dynamicAgentRuntime,
     }),
   );
   console.log('[middleware] runtime introspection endpoint ready at /api/v1/admin/runtime (auth: required)');

--- a/middleware/src/plugins/dynamicAgentRuntime.ts
+++ b/middleware/src/plugins/dynamicAgentRuntime.ts
@@ -195,6 +195,20 @@ export interface DynamicAgentRuntimeDeps {
   log?: (...args: unknown[]) => void;
 }
 
+/** Thrown by {@link DynamicAgentRuntime.resolveSetupOptions} for conditions the
+ *  post-install setup-options endpoint maps to specific HTTP codes. A plain
+ *  throw from the provider's own run() is deliberately NOT this type — the route
+ *  maps that to 502 (provider failed). */
+export class SetupOptionsResolveError extends Error {
+  constructor(
+    public readonly code: 'agent_inactive' | 'tool_not_found',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SetupOptionsResolveError';
+  }
+}
+
 export class DynamicAgentRuntime {
   private readonly active = new Map<string, ActiveAgent>();
   private orchestrator: Orchestrator | null = null;
@@ -730,6 +744,40 @@ export class DynamicAgentRuntime {
     }
     return undefined;
   }
+
+  /** Resolve dynamic setup options from an ACTIVE plugin's toolkit tool, for the
+   *  post-install setup-options endpoint. Looks up ONLY the named agent (never a
+   *  cross-agent scan — that would be a confused-deputy leak), finds the raw
+   *  toolkit tool by id, and invokes it DIRECTLY (not via the bridged string
+   *  path) so a structured value or a real throw both surface to the caller.
+   *  Read-only by contract; the caller wraps this in a timeout. */
+  async resolveSetupOptions(
+    agentId: string,
+    toolId: string,
+    input: unknown,
+  ): Promise<unknown> {
+    const entry = this.active.get(agentId);
+    if (!entry) {
+      throw new SetupOptionsResolveError(
+        'agent_inactive',
+        `agent '${agentId}' is not active`,
+      );
+    }
+    const tool = entry.rawTools.find((c) => toolIdentifier(c) === toolId);
+    if (!tool) {
+      throw new SetupOptionsResolveError(
+        'tool_not_found',
+        `tool '${toolId}' is not exposed by agent '${agentId}'`,
+      );
+    }
+    // LocalSubAgentTool exposes handle() (string-ish); the Zod toolkit shape
+    // exposes run() (structured). Prefer run() for real data.
+    if (isLocalSubAgentTool(tool)) {
+      const res = await tool.handle(input);
+      return typeof res === 'string' ? res : res.output;
+    }
+    return tool.run(input);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1146,7 +1194,7 @@ async function ensureReadable(absPath: string): Promise<void> {
   }
 }
 
-async function withTimeout<T>(
+export async function withTimeout<T>(
   promise: Promise<T>,
   ms: number,
   message: string,

--- a/middleware/src/plugins/manifestLoader.ts
+++ b/middleware/src/plugins/manifestLoader.ts
@@ -233,6 +233,10 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
         if (scopes.length > 0) entry.scopes = scopes;
       }
     }
+    // Dynamic post-install options (additive, lenient — any field type).
+    const optionsProvider = asString(f['options_provider']);
+    if (optionsProvider) entry.options_provider = optionsProvider;
+    if (f['multi'] === true) entry.multi = true;
     setupFields.push(entry);
   }
 

--- a/middleware/src/routes/runtime.ts
+++ b/middleware/src/routes/runtime.ts
@@ -7,10 +7,20 @@ import type { PromptContributionRegistry } from '../platform/promptContributionR
 import type { ServiceRegistry } from '../platform/serviceRegistry.js';
 import type { TurnHookRegistry } from '../platform/turnHookRegistry.js';
 import { isAuditMode } from '../platform/httpAccessor.js';
+import type { SetupOption } from '../api/admin-v1.js';
+import {
+  SetupOptionsResolveError,
+  withTimeout,
+} from '../plugins/dynamicAgentRuntime.js';
 import { extractSetupSchema } from '../plugins/installService.js';
 import type { InstalledRegistry } from '../plugins/installedRegistry.js';
 import type { PluginCatalog } from '../plugins/manifestLoader.js';
 import type { SecretVault } from '../secrets/vault.js';
+
+/** Per-call budget for invoking a plugin's dynamic options provider. */
+const SETUP_OPTIONS_TIMEOUT_MS = 8_000;
+/** Hard cap on options returned to the editor. */
+const MAX_SETUP_OPTIONS = 500;
 
 /**
  * Runtime introspection endpoints — diagnostic view into what the harness
@@ -49,6 +59,17 @@ interface RuntimeDeps {
    *  current runtime instance and re-activates it so the plugin reads
    *  the fresh values — most plugins cache config at activate-time. */
   reactivate?: (agentId: string) => Promise<void>;
+  /** Live-plugin tool invoker for dynamic setup-field options (post-install).
+   *  Optional so existing test wiring keeps compiling — the setup-options
+   *  endpoint 503s when absent, and PATCH /config falls back to opaque-id
+   *  validation for multiselect fields. */
+  dynamicAgentRuntime?: {
+    resolveSetupOptions(
+      agentId: string,
+      toolId: string,
+      input: unknown,
+    ): Promise<unknown>;
+  };
 }
 
 export function createRuntimeRouter(deps: RuntimeDeps): Router {
@@ -146,9 +167,27 @@ export function createRuntimeRouter(deps: RuntimeDeps): Router {
       for (const [k, v] of Object.entries(patch)) {
         if (v === null) {
           delete nextConfig[k];
-        } else {
-          nextConfig[k] = v;
+          continue;
         }
+        // Fields declaring `options_provider` carry a multiselect array; they
+        // are validated against the live provider and stored JSON-encoded.
+        // Every other key keeps the legacy blind-merge behaviour.
+        const optField = findOptionsProviderField(deps.catalog, id, k);
+        if (optField) {
+          const checked = await validateMultiselectValue(
+            v,
+            id,
+            optField,
+            deps.dynamicAgentRuntime,
+          );
+          if ('error' in checked) {
+            res.status(400).json(checked.error);
+            return;
+          }
+          nextConfig[k] = checked.value;
+          continue;
+        }
+        nextConfig[k] = v;
       }
       try {
         await deps.installedRegistry.updateConfig(id, nextConfig);
@@ -170,6 +209,77 @@ export function createRuntimeRouter(deps: RuntimeDeps): Router {
         res
           .status(500)
           .json({ code: 'runtime.update_failed', message });
+      }
+    },
+  );
+
+  // GET /installed/:id/setup-options/:fieldKey — dynamic, post-install options
+  // for a field that declares `options_provider`. Resolves the named toolkit
+  // tool on the ACTIVE plugin and returns the choices for the editor. Advisory
+  // for the UI only; PATCH /config re-validates server-side (trust boundary).
+  // Concurrent identical requests share one provider invocation.
+  const optionsInFlight = new Map<string, Promise<SetupOption[] | null>>();
+  router.get(
+    '/installed/:id/setup-options/:fieldKey',
+    async (req: Request, res: Response) => {
+      const id = readId(req);
+      const rawField = req.params['fieldKey'];
+      const fieldKey = typeof rawField === 'string' ? rawField : '';
+      if (!id || !fieldKey) {
+        res.status(400).json({
+          code: 'runtime.invalid_id',
+          message: 'missing id or fieldKey',
+        });
+        return;
+      }
+      if (!deps.installedRegistry.get(id)) {
+        res.status(404).json({
+          code: 'runtime.not_installed',
+          message: `agent '${id}' is not installed`,
+        });
+        return;
+      }
+      const field = findOptionsProviderField(deps.catalog, id, fieldKey);
+      if (!field) {
+        res.status(400).json({
+          code: 'runtime.no_options_provider',
+          message: `field '${fieldKey}' declares no options_provider`,
+        });
+        return;
+      }
+      const resolver = deps.dynamicAgentRuntime;
+      if (!resolver) {
+        res.status(503).json({
+          code: 'runtime.options_unavailable',
+          message: 'dynamic setup-options are not available on this core',
+        });
+        return;
+      }
+      const cacheKey = `${id}::${fieldKey}`;
+      try {
+        let pending = optionsInFlight.get(cacheKey);
+        if (!pending) {
+          pending = withTimeout(
+            resolver.resolveSetupOptions(id, field.toolId, {}),
+            SETUP_OPTIONS_TIMEOUT_MS,
+            'setup-options provider timed out',
+          ).then((raw) => normalizeSetupOptions(raw));
+          optionsInFlight.set(cacheKey, pending);
+          void pending
+            .catch(() => undefined)
+            .finally(() => optionsInFlight.delete(cacheKey));
+        }
+        const options = await pending;
+        if (options === null) {
+          res.status(502).json({
+            code: 'runtime.options_provider_bad_shape',
+            message: 'provider did not return an options array',
+          });
+          return;
+        }
+        res.json({ options });
+      } catch (err) {
+        sendOptionsError(res, err);
       }
     },
   );
@@ -521,4 +631,149 @@ function resolveSecretFieldKeys(
     if (f.type === 'secret' || f.type === 'oauth') out.add(f.key);
   }
   return out;
+}
+
+interface OptionsProviderField {
+  toolId: string;
+  multi: boolean;
+}
+
+/**
+ * Reads a setup field's `options_provider` / `multi` straight from the raw
+ * manifest (mirrors `extractSetupSchema`'s raw read, so it stays decoupled from
+ * the InstallSetupField type). Returns null when the field does not declare a
+ * dynamic options provider — the caller then treats the key as an ordinary
+ * config value, preserving legacy behaviour.
+ */
+function findOptionsProviderField(
+  catalog: PluginCatalog | undefined,
+  pluginId: string,
+  fieldKey: string,
+): OptionsProviderField | null {
+  if (!catalog) return null;
+  const entry = catalog.get(pluginId);
+  if (!entry) return null;
+  const manifest = entry.manifest;
+  if (!manifest || typeof manifest !== 'object') return null;
+  const setup = (manifest as Record<string, unknown>)['setup'];
+  if (!setup || typeof setup !== 'object') return null;
+  const fieldsRaw = (setup as Record<string, unknown>)['fields'];
+  if (!Array.isArray(fieldsRaw)) return null;
+  for (const raw of fieldsRaw) {
+    if (!raw || typeof raw !== 'object') continue;
+    const f = raw as Record<string, unknown>;
+    if (f['key'] !== fieldKey) continue;
+    const toolId =
+      typeof f['options_provider'] === 'string' ? f['options_provider'] : '';
+    if (!toolId) return null;
+    return { toolId, multi: f['multi'] === true };
+  }
+  return null;
+}
+
+/**
+ * Coerce a provider's raw return into well-formed SetupOption rows. Returns
+ * null when the shape is wrong (not an array) so the caller can 502; an empty
+ * array is legitimate (e.g. nothing shared yet) and passes through. Caps the
+ * list and keeps only `{value,label}` string rows (rendered as text only).
+ */
+function normalizeSetupOptions(raw: unknown): SetupOption[] | null {
+  if (!Array.isArray(raw)) return null;
+  const out: SetupOption[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const o = item as Record<string, unknown>;
+    const value = typeof o['value'] === 'string' ? o['value'] : undefined;
+    const label = typeof o['label'] === 'string' ? o['label'] : undefined;
+    if (!value || !label) continue;
+    const opt: SetupOption = { value, label };
+    if (typeof o['group'] === 'string') opt.group = o['group'];
+    out.push(opt);
+    if (out.length >= MAX_SETUP_OPTIONS) break;
+  }
+  return out;
+}
+
+/** Map a provider-invocation failure to the typed HTTP response. */
+function sendOptionsError(res: Response, err: unknown): void {
+  if (err instanceof SetupOptionsResolveError) {
+    res
+      .status(409)
+      .json({ code: 'runtime.agent_inactive', message: err.message });
+    return;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  if (message.includes('timed out')) {
+    res
+      .status(504)
+      .json({ code: 'runtime.options_provider_timeout', message });
+    return;
+  }
+  res
+    .status(502)
+    .json({ code: 'runtime.options_provider_failed', message });
+}
+
+/**
+ * Server-side validation of a submitted multiselect value (do NOT trust the
+ * client). Requires a `string[]`; re-invokes the provider and rejects any value
+ * not in the live set. If the provider is inactive/throws/times out at save
+ * time, degrades to accepting only syntactically-safe opaque ids rather than
+ * bricking the save. Returns the value JSON-encoded for scalar config storage.
+ */
+async function validateMultiselectValue(
+  raw: unknown,
+  pluginId: string,
+  field: OptionsProviderField,
+  resolver: RuntimeDeps['dynamicAgentRuntime'],
+): Promise<{ value: string } | { error: { code: string; message: string } }> {
+  if (!Array.isArray(raw) || !raw.every((x) => typeof x === 'string')) {
+    return {
+      error: {
+        code: 'runtime.invalid_multiselect',
+        message: 'value must be an array of strings',
+      },
+    };
+  }
+  const values = raw as string[];
+
+  let allowed: Set<string> | null = null;
+  if (resolver) {
+    try {
+      const result = await withTimeout(
+        resolver.resolveSetupOptions(pluginId, field.toolId, {}),
+        SETUP_OPTIONS_TIMEOUT_MS,
+        'setup-options provider timed out',
+      );
+      const opts = normalizeSetupOptions(result);
+      if (opts) allowed = new Set(opts.map((o) => o.value));
+    } catch {
+      // provider down / inactive / threw → fall through to degraded check
+    }
+  }
+
+  if (allowed) {
+    const allowedSet = allowed;
+    const bad = values.find((x) => !allowedSet.has(x));
+    if (bad !== undefined) {
+      return {
+        error: {
+          code: 'runtime.value_not_offered',
+          message: `value '${bad}' is not an offered option`,
+        },
+      };
+    }
+  } else {
+    const SAFE_ID = /^[A-Za-z0-9_-]{1,128}$/;
+    const bad = values.find((x) => !SAFE_ID.test(x));
+    if (bad !== undefined) {
+      return {
+        error: {
+          code: 'runtime.invalid_multiselect',
+          message: `value '${bad}' is not a safe opaque id`,
+        },
+      };
+    }
+  }
+  return { value: JSON.stringify(values) };
 }

--- a/web-ui/app/_components/store/CredentialsEditor.tsx
+++ b/web-ui/app/_components/store/CredentialsEditor.tsx
@@ -16,13 +16,16 @@
  * secrets after registration, etc.). Same vault, different UX moment.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CheckCircle2, KeyRound, Plug, Trash2 } from 'lucide-react';
 
 import {
   ApiError,
+  fetchSetupFieldOptions,
   listInstalledSecretKeys,
+  patchInstalledConfig,
   patchInstalledSecrets,
+  type SetupOption,
 } from '../../_lib/api';
 import type { PluginSetupField } from '../../_lib/storeTypes';
 import { Button } from '@/app/_components/ui/Button';
@@ -118,6 +121,10 @@ export function CredentialsEditor({
       const set: Record<string, string> = {};
       const del: string[] = [];
       for (const f of setupFields) {
+        // Multiselect (options_provider) fields persist themselves through
+        // patchInstalledConfig in MultiselectField — never via this scalar
+        // secrets patch (which cannot carry arrays).
+        if (f.options_provider && f.multi) continue;
         const s = fieldStates[f.key];
         if (!s) continue;
         if (s.pendingDelete) {
@@ -185,6 +192,7 @@ export function CredentialsEditor({
             ({ draft: '', dirty: false, pendingDelete: false } as FieldState);
           const isStored = storedKeys?.has(field.key) ?? false;
           const isSecret = field.type === 'secret' || field.type === 'oauth';
+          const isMultiselect = Boolean(field.options_provider && field.multi);
           const enumOptions =
             field.type === 'enum' && field.enum && field.enum.length > 0
               ? field.enum
@@ -240,7 +248,13 @@ export function CredentialsEditor({
                 ) : null}
               </div>
               <div className="flex flex-1 items-center gap-2">
-                {field.type === 'oauth' ? (
+                {isMultiselect ? (
+                  <MultiselectField
+                    pluginId={pluginId}
+                    fieldKey={field.key}
+                    storedValue={storedValues[field.key]}
+                  />
+                ) : field.type === 'oauth' ? (
                   // Spec 005 — an OAuth field has no typeable value; the kernel
                   // broker holds the tokens. Render a Connect button that
                   // navigates (top-level, so the server can 302 to the IdP) to
@@ -329,7 +343,7 @@ export function CredentialsEditor({
                     );
                   })()
                 )}
-                {isStored ? (
+                {isStored && !isMultiselect ? (
                   <button
                     type="button"
                     onClick={() =>
@@ -429,6 +443,204 @@ function OAuthConnectField({
         <Plug className="size-3.5" aria-hidden />
         {connected ? 'Neu verbinden' : 'Verbinden'}
       </a>
+    </div>
+  );
+}
+
+/** Parse the stored config value (a JSON-encoded `string[]`, or a tolerated
+ *  legacy comma string) into the current selection. */
+function parseStoredArray(raw: string | undefined): string[] {
+  if (!raw) return [];
+  const t = raw.trim();
+  if (!t.startsWith('[')) {
+    return t
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+  try {
+    const parsed: unknown = JSON.parse(t);
+    return Array.isArray(parsed)
+      ? parsed.filter((x): x is string => typeof x === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Post-install multiselect for a field that declares `options_provider`.
+ * Fetches choices from the running plugin, renders grouped checkboxes, and
+ * saves the selection via patchInstalledConfig (the array-capable path). When
+ * the provider is inactive/failing (409/502/504), degrades to a comma-separated
+ * free-text input so the operator is never blocked.
+ */
+function MultiselectField({
+  pluginId,
+  fieldKey,
+  storedValue,
+}: {
+  pluginId: string;
+  fieldKey: string;
+  storedValue: string | undefined;
+}): React.ReactElement {
+  const [selected, setSelected] = useState<string[]>([]);
+  const [options, setOptions] = useState<SetupOption[] | null>(null);
+  const [status, setStatus] = useState<'loading' | 'loaded' | 'degraded'>(
+    'loading',
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [freeText, setFreeText] = useState<string>('');
+  const [saving, setSaving] = useState(false);
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  // Hydrate the current selection from the stored value ONCE it arrives. The
+  // parent fetches config values async, so `storedValue` is undefined on the
+  // first render — initialising state from it directly would miss the value
+  // (and the checkboxes would look empty after a reload). Guard with a ref so
+  // we never clobber an in-progress edit if the parent re-fetches.
+  const hydratedRef = useRef(false);
+  useEffect(() => {
+    if (hydratedRef.current || storedValue === undefined) return;
+    hydratedRef.current = true;
+    const arr = parseStoredArray(storedValue);
+    setSelected(arr);
+    setFreeText(arr.join(', '));
+  }, [storedValue]);
+
+  const load = useCallback(async () => {
+    setStatus('loading');
+    setError(null);
+    try {
+      const opts = await fetchSetupFieldOptions(pluginId, fieldKey);
+      setOptions(opts);
+      setStatus('loaded');
+    } catch (err) {
+      setError(humanizeError(err));
+      setStatus('degraded');
+    }
+  }, [pluginId, fieldKey]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void load();
+  }, [load]);
+
+  const toggle = (value: string): void =>
+    setSelected((prev) =>
+      prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value],
+    );
+
+  const onSave = useCallback(async () => {
+    setSaving(true);
+    setError(null);
+    setSavedAt(null);
+    try {
+      const values =
+        status === 'degraded'
+          ? freeText
+              .split(/[\s,]+/)
+              .map((s) => s.trim())
+              .filter(Boolean)
+          : selected;
+      await patchInstalledConfig(pluginId, { [fieldKey]: values });
+      setSavedAt(Date.now());
+    } catch (err) {
+      setError(humanizeError(err));
+    } finally {
+      setSaving(false);
+    }
+  }, [status, freeText, selected, pluginId, fieldKey]);
+
+  const groups = useMemo(() => {
+    const m = new Map<string, SetupOption[]>();
+    for (const o of options ?? []) {
+      const g = o.group ?? '';
+      const arr = m.get(g) ?? [];
+      arr.push(o);
+      m.set(g, arr);
+    }
+    return Array.from(m.entries());
+  }, [options]);
+
+  return (
+    <div className="flex min-w-0 flex-1 flex-col gap-2">
+      {status === 'loading' ? (
+        <span className="text-[12px] text-[color:var(--muted-ink)]">
+          Loading options…
+        </span>
+      ) : status === 'degraded' ? (
+        <div className="flex flex-col gap-1">
+          <span className="text-[11px] text-[color:var(--muted-ink)]">
+            Options unavailable ({error ?? 'plugin inactive'}). Enter
+            values/IDs comma-separated.
+          </span>
+          <input
+            type="text"
+            value={freeText}
+            onChange={(e) => setFreeText(e.target.value)}
+            placeholder="id-1, id-2, …"
+            className="min-w-0 rounded-md border border-[color:var(--rule)] bg-[color:var(--bg)] px-3 py-2 text-[12px] text-[color:var(--ink)] placeholder:text-[color:var(--faint-ink)] focus:border-[color:var(--accent)] focus:outline-none"
+          />
+        </div>
+      ) : options && options.length > 0 ? (
+        <div className="max-h-56 overflow-auto rounded-md border border-[color:var(--rule)] p-2">
+          {groups.map(([group, opts]) => (
+            <div key={group || '_'} className="mb-2 last:mb-0">
+              {group ? (
+                <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--faint-ink)]">
+                  {group}
+                </div>
+              ) : null}
+              {opts.map((o) => (
+                <label
+                  key={o.value}
+                  className="flex cursor-pointer items-center gap-2 py-0.5 text-[12px] text-[color:var(--ink)]"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.includes(o.value)}
+                    onChange={() => toggle(o.value)}
+                    className="size-4 accent-[color:var(--accent)]"
+                  />
+                  <span className="truncate">{o.label}</span>
+                </label>
+              ))}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <span className="text-[12px] text-[color:var(--muted-ink)]">
+          No selectable entries (nothing shared with the integration?).
+        </span>
+      )}
+      <div className="flex items-center gap-3">
+        <Button
+          variant="primary"
+          onClick={() => void onSave()}
+          disabled={saving}
+          busy={saving}
+          busyLabel="Saving"
+        >
+          <CheckCircle2 className="size-3.5" aria-hidden />
+          Save selection
+          {status !== 'degraded' ? ` (${String(selected.length)})` : ''}
+        </Button>
+        {savedAt !== null ? (
+          <span className="text-[11px] text-[color:var(--muted-ink)]">
+            ✓ Saved
+          </span>
+        ) : null}
+        {status === 'loaded' ? (
+          <button
+            type="button"
+            onClick={() => void load()}
+            className="text-[11px] text-[color:var(--muted-ink)] underline hover:text-[color:var(--accent)]"
+          >
+            Refresh list
+          </button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -2084,6 +2084,68 @@ export async function patchInstalledSecrets(
   return (await res.json()) as InstalledSecretsState;
 }
 
+/** A selectable choice for a setup field that declares `options_provider`. */
+export interface SetupOption {
+  value: string;
+  label: string;
+  group?: string;
+}
+
+/**
+ * Fetch live options for a post-install multiselect field from the running
+ * plugin's options-provider tool. Throws ApiError on failure — notably 409
+ * (plugin inactive), 502 (provider failed), 504 (timeout) — which the editor
+ * uses to degrade to a free-text input.
+ */
+export async function fetchSetupFieldOptions(
+  pluginId: string,
+  fieldKey: string,
+): Promise<SetupOption[]> {
+  const { options } = await getJson<{ options: SetupOption[] }>(
+    `/v1/admin/runtime/installed/${encodeURIComponent(
+      pluginId,
+    )}/setup-options/${encodeURIComponent(fieldKey)}`,
+  );
+  return options;
+}
+
+/**
+ * Patch non-secret config for an installed plugin (array-capable, unlike
+ * patchInstalledSecrets which only carries strings). Used to persist
+ * multiselect selections; the middleware re-validates each submitted value
+ * against the live provider before storing.
+ */
+export async function patchInstalledConfig(
+  pluginId: string,
+  patch: Record<string, unknown>,
+): Promise<void> {
+  const forwarded = await forwardCookieHeader();
+  const res = await fetch(
+    botApi(
+      `/v1/admin/runtime/installed/${encodeURIComponent(pluginId)}/config`,
+    ),
+    {
+      method: 'PATCH',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json',
+        ...forwarded,
+      },
+      body: JSON.stringify(patch),
+      credentials: 'include',
+      cache: 'no-store',
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new ApiError(
+      res.status,
+      `PATCH installed/${pluginId}/config failed: ${res.status}`,
+      text,
+    );
+  }
+}
+
 /**
  * #91 — set the audit egress mode for an installed web_scanner plugin.
  * The middleware validates the mode enum and rejects the call when the

--- a/web-ui/app/_lib/storeTypes.ts
+++ b/web-ui/app/_lib/storeTypes.ts
@@ -35,6 +35,14 @@ export interface PluginSetupField {
    *  field connects through, and the scopes requested. */
   provider?: string;
   scopes?: string[];
+  /** Dynamic post-install options: the plugin toolkit-tool id that returns the
+   *  selectable choices for this field. With `multi`, the post-install editor
+   *  renders a fetched multiselect instead of a text input. `type` stays a
+   *  normal union member (typically `string`). */
+  options_provider?: string;
+  /** Holds multiple selected values (stored as a JSON-encoded `string[]`).
+   *  Only meaningful with `options_provider`. */
+  multi?: boolean;
 }
 
 /** Spec 005 — how a declarative OAuth descriptor authenticates to the token


### PR DESCRIPTION
## What

Adds **dynamic, post-install setup options** for plugin configuration fields. A plugin's setup field can now declare:

- `options_provider` — the id of a toolkit-tool on the *same* plugin that returns the selectable choices (`SetupOption[]`) for that field, and
- `multi` — when set, the field holds multiple selected values (stored JSON-encoded as a `string[]`).

The post-install credentials editor then renders a **live multiselect** populated from the running plugin, instead of a blind free-text box.

Both attributes are **additive and optional** — fields that don't declare them behave exactly as before.

## Why

Some setup fields can only be filled in meaningfully *after* the plugin is installed and running, because the valid choices come from the plugin itself (e.g. channels/rooms/projects the connected account can actually see). Until now the operator had to paste opaque ids into a free-text field with no validation, which is error-prone and easy to get wrong. This lets the plugin surface the real, current set of choices and lets the operator pick from them.

## How

**Middleware**
- `admin-v1.ts` / `manifestLoader.ts` / `storeTypes.ts`: optional `options_provider` + `multi` on setup fields, plus the `SetupOption { value, label, group? }` shape.
- `dynamicAgentRuntime.ts`: `resolveSetupOptions()` invokes **only the named active plugin's** toolkit tool directly (no cross-agent scan — avoids a confused-deputy leak) and surfaces a structured value or a real throw. Typed `SetupOptionsResolveError` distinguishes *agent inactive* vs *tool not found*.
- `routes/runtime.ts`:
  - `GET /installed/:id/setup-options/:fieldKey` — resolves live choices for the editor. 8s per-call budget, 500-option cap, concurrent identical requests share one provider invocation. Typed error mapping (409 inactive / 502 bad shape or failure / 504 timeout / 503 unavailable).
  - `PATCH /installed/:id/config` — re-validates each submitted multiselect value **server-side** against the live provider (the GET endpoint is advisory only; this is the trust boundary), stores values JSON-encoded, and degrades to accepting only syntactically-safe opaque ids if the provider is unavailable at save time rather than bricking the save.

**Web UI**
- `_lib/api.ts`: `fetchSetupFieldOptions()` and an array-capable `patchInstalledConfig()`.
- `CredentialsEditor.tsx`: fetched multiselect that degrades to a free-text input on 409/502/504.

## Notes

- No new behavior for existing plugins — purely opt-in via the new manifest fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)