### PR TITLE
feat(conductor): guided designer UX — dropdowns + builders replace raw ISO/cron/JSON inputs

### DIFF
--- a/middleware/src/conductor/index.ts
+++ b/middleware/src/conductor/index.ts
@@ -73,6 +73,8 @@ export async function wireConductor(deps: {
   getRegistry: () => OrchestratorRegistry | undefined;
   /** invokes a deterministic-action / connector tool by id for action steps. */
   invokeAction?: (toolId: string, input: unknown) => Promise<string | undefined>;
+  /** lists registered deterministic-action / tool ids for the Designer's action-step picker. */
+  listActions?: () => string[];
   /** read model of the event-emit catalog (declared `event_emit` capabilities) for the Designer. */
   eventCatalog?: { list(): string[]; byPluginId(): Record<string, string[]> };
   /** resolves a proactive sender for a channel (US5 reminders) — from the routines senderRegistry. */
@@ -163,7 +165,20 @@ export async function wireConductor(deps: {
   deps.app.use(
     '/api/v1/operator/conductors',
     deps.requireAuth,
-    createConductorRouter({ workflowStore, runStore, awaitStore, roleStore, scheduleStore, executor, eventRouter, eventCatalog: deps.eventCatalog, builderAgent }),
+    createConductorRouter({
+      workflowStore,
+      runStore,
+      awaitStore,
+      roleStore,
+      scheduleStore,
+      executor,
+      eventRouter,
+      eventCatalog: deps.eventCatalog,
+      // Live agent/action catalogs for the Designer's step pickers (dropdowns).
+      agentCatalog: () => (deps.getRegistry()?.list() ?? []).map((a) => ({ slug: a.agent.slug, name: a.agent.name })),
+      ...(deps.listActions ? { actionCatalog: deps.listActions } : {}),
+      builderAgent,
+    }),
   );
 
   return { workflowStore, runStore, awaitStore, roleStore, scheduleStore, channelBindingStore, executor, awaitWorker, resumeWorker, scheduleWorker, eventRouter, builderAgent };

--- a/middleware/src/conductor/routes.ts
+++ b/middleware/src/conductor/routes.ts
@@ -46,6 +46,10 @@ export interface ConductorRouterDeps {
   eventRouter: ConductorEventRouter;
   /** Read model of declared emittable events (US4) — powers the Designer's event-trigger picker. */
   eventCatalog?: { list(): string[]; byPluginId(): Record<string, string[]> };
+  /** Live orchestrator slugs + names — powers the Designer's agent-step picker (dropdown). */
+  agentCatalog?: () => Array<{ slug: string; name: string }>;
+  /** Registered deterministic-action / tool ids — powers the Designer's action-step picker (dropdown). */
+  actionCatalog?: () => string[];
   /** Conversational builder agent (US7) — co-design a draft graph by chat. Optional: absent on hosts without a registry. */
   builderAgent?: ConductorBuilderAgent;
 }
@@ -136,6 +140,25 @@ export function createConductorRouter(deps: ConductorRouterDeps): Router {
       res.json({ events: deps.eventCatalog?.list() ?? [], byPlugin: deps.eventCatalog?.byPluginId() ?? {} });
     } catch (err) {
       res.status(500).json({ code: 'conductor.event_catalog_failed', message: errMsg(err) });
+    }
+  });
+
+  // Agent catalog — live orchestrator slugs + names for the Designer's agent-step dropdown.
+  // Before '/:slug' so the catch-all workflow route doesn't swallow it.
+  router.get('/agents', (_req: Request, res: Response): void => {
+    try {
+      res.json({ agents: deps.agentCatalog?.() ?? [] });
+    } catch (err) {
+      res.status(500).json({ code: 'conductor.agent_catalog_failed', message: errMsg(err) });
+    }
+  });
+
+  // Action catalog — registered deterministic-action / tool ids for the Designer's action-step dropdown.
+  router.get('/actions', (_req: Request, res: Response): void => {
+    try {
+      res.json({ actions: deps.actionCatalog?.() ?? [] });
+    } catch (err) {
+      res.status(500).json({ code: 'conductor.action_catalog_failed', message: errMsg(err) });
     }
   });
 

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -2141,6 +2141,7 @@ async function main(): Promise<void> {
       requireAuth,
       getRegistry,
       invokeAction: (toolId, input) => dynamicAgentRuntime.invokeAgentTool(toolId, input),
+      listActions: () => deterministicActionRegistry.list(),
       eventCatalog: eventCatalogRegistry,
       // US5 reminders: resolve a channel's proactive sender from the routines senderRegistry. Adapt
       // ProactiveSender → the worker's minimal shape ({ text } is a valid SemanticAnswer).

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -3657,6 +3657,16 @@ export async function getConductorRoles(): Promise<{ roles: Array<{ key: string;
   return getJson(`${CONDUCTOR_BASE}/roles`);
 }
 
+/** Live orchestrator agents, for the Designer's agent-step dropdown. */
+export async function getConductorAgents(): Promise<{ agents: Array<{ slug: string; name: string }> }> {
+  return getJson(`${CONDUCTOR_BASE}/agents`);
+}
+
+/** Registered deterministic-action / tool ids, for the Designer's action-step dropdown. */
+export async function getConductorActions(): Promise<{ actions: string[] }> {
+  return getJson(`${CONDUCTOR_BASE}/actions`);
+}
+
 export interface ConductorAwait {
   id: string;
   runId: string;

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -3652,6 +3652,11 @@ export async function getConductorEventCatalog(): Promise<{ events: string[]; by
   return getJson(`${CONDUCTOR_BASE}/events/catalog`);
 }
 
+/** Conductor roles (US6), for the Designer's human-step principal picker. */
+export async function getConductorRoles(): Promise<{ roles: Array<{ key: string; label?: string }> }> {
+  return getJson(`${CONDUCTOR_BASE}/roles`);
+}
+
 export interface ConductorAwait {
   id: string;
   runId: string;

--- a/web-ui/app/conductor/_components/ConditionBuilder.tsx
+++ b/web-ui/app/conductor/_components/ConditionBuilder.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+/**
+ * ConditionBuilder — edit a Conductor predicate (postcondition / transition guard)
+ * as field/operator/value ROWS instead of hand-written JSON AST. Rows combine via
+ * AND/OR. Anything the rows can't represent (nested and/or/not, const) falls back
+ * to an "advanced" raw-JSON editor, so no expressiveness is lost. The control
+ * round-trips the SAME JSON string the canvas stores (empty = no condition).
+ */
+import { useEffect, useId, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { gcInput, gcLbl } from './GuidedControls';
+import { Button } from '@/app/_components/ui/Button';
+
+type LeafOp = 'eq' | 'ne' | 'gt' | 'lt' | 'gte' | 'lte' | 'exists' | 'in' | 'matches';
+const LEAF_OPS: LeafOp[] = ['eq', 'ne', 'gt', 'lt', 'gte', 'lte', 'exists', 'in', 'matches'];
+
+// Stable per-row id so React keys survive a mid-list delete (avoids focus/IME glitches — review L2).
+let rowSeq = 0;
+const nextRowId = (): string => `row-${String((rowSeq += 1))}`;
+
+interface Row {
+  id: string;
+  path: string;
+  op: LeafOp;
+  value: string; // user-facing; coerced to JSON on build
+}
+
+interface BuilderState {
+  mode: 'rows' | 'advanced';
+  combiner: 'and' | 'or';
+  rows: Row[];
+  raw: string;
+}
+
+/** Try JSON, fall back to the raw string literal (so `true`/`42`/`"x"` and bare text both work). */
+function coerce(v: string): unknown {
+  const s = v.trim();
+  if (s === '') return '';
+  try {
+    return JSON.parse(s) as unknown;
+  } catch {
+    return v;
+  }
+}
+
+function rowToPredicate(r: Row): Record<string, unknown> {
+  if (r.op === 'exists') return { op: 'exists', path: r.path };
+  if (r.op === 'in') {
+    const value = r.value
+      .split(',')
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0)
+      .map(coerce);
+    return { op: 'in', path: r.path, value };
+  }
+  if (r.op === 'matches') return { op: 'matches', path: r.path, value: r.value };
+  return { op: r.op, path: r.path, value: coerce(r.value) };
+}
+
+function predicateToRow(p: Record<string, unknown>): Row | null {
+  const op = p['op'];
+  if (typeof op !== 'string' || !LEAF_OPS.includes(op as LeafOp)) return null;
+  const path = typeof p['path'] === 'string' ? p['path'] : '';
+  if (op === 'exists') return { id: nextRowId(), path, op: 'exists', value: '' };
+  if (op === 'in') {
+    const arr = Array.isArray(p['value']) ? p['value'] : [];
+    // A comma-joined text row can only safely represent comma-free scalars. Anything else (an element
+    // containing a comma, or a nested object/array) would corrupt on the next split → keep it in the
+    // advanced JSON editor instead (review M1).
+    const representable = arr.every((x) =>
+      typeof x === 'string' ? !x.includes(',') : typeof x === 'number' || typeof x === 'boolean',
+    );
+    if (!representable) return null;
+    return { id: nextRowId(), path, op: 'in', value: arr.map((x) => (typeof x === 'string' ? x : JSON.stringify(x))).join(', ') };
+  }
+  if (op === 'matches') return { id: nextRowId(), path, op: 'matches', value: typeof p['value'] === 'string' ? p['value'] : '' };
+  const raw = p['value'];
+  return { id: nextRowId(), path, op: op as LeafOp, value: typeof raw === 'string' ? JSON.stringify(raw) : JSON.stringify(raw ?? null) };
+}
+
+function parseValue(json: string): BuilderState {
+  const base: BuilderState = { mode: 'rows', combiner: 'and', rows: [], raw: '' };
+  const s = (json ?? '').trim();
+  if (!s) return base;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(s);
+  } catch {
+    return { ...base, mode: 'advanced', raw: json };
+  }
+  if (!parsed || typeof parsed !== 'object') return { ...base, mode: 'advanced', raw: s };
+  const obj = parsed as Record<string, unknown>;
+  if ((obj['op'] === 'and' || obj['op'] === 'or') && Array.isArray(obj['args'])) {
+    const rows = obj['args'].map((a) => (a && typeof a === 'object' ? predicateToRow(a as Record<string, unknown>) : null));
+    if (rows.every((r): r is Row => r !== null)) {
+      return { ...base, combiner: obj['op'] as 'and' | 'or', rows };
+    }
+    return { ...base, mode: 'advanced', raw: JSON.stringify(parsed, null, 2) };
+  }
+  const single = predicateToRow(obj);
+  if (single) return { ...base, rows: [single] };
+  return { ...base, mode: 'advanced', raw: JSON.stringify(parsed, null, 2) };
+}
+
+function build(state: BuilderState): string {
+  if (state.mode === 'advanced') return state.raw.trim();
+  const usable = state.rows.filter((r) => r.path.trim().length > 0);
+  const [first] = usable;
+  if (!first) return '';
+  if (usable.length === 1) return JSON.stringify(rowToPredicate(first));
+  return JSON.stringify({ op: state.combiner, args: usable.map(rowToPredicate) });
+}
+
+export function ConditionBuilder(props: {
+  label: string;
+  value: string;
+  onChange: (json: string) => void;
+  /** dot-path suggestions, e.g. stepResult.approved */
+  pathOptions?: readonly string[];
+}): React.JSX.Element {
+  const t = useTranslations('conductor');
+  const pathListId = useId();
+  const [state, setState] = useState<BuilderState>(() => parseValue(props.value));
+
+  useEffect(() => {
+    // Controlled-component resync: adopt an externally-changed predicate (e.g. a node loads).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (build(state) !== (props.value ?? '').trim()) setState(parseValue(props.value));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.value]);
+
+  const commit = (next: BuilderState): void => {
+    setState(next);
+    props.onChange(build(next));
+  };
+
+  const setRow = (i: number, patch: Partial<Row>): void =>
+    commit({ ...state, rows: state.rows.map((r, j) => (j === i ? { ...r, ...patch } : r)) });
+  const addRow = (): void => commit({ ...state, rows: [...state.rows, { id: nextRowId(), path: '', op: 'eq', value: '' }] });
+  const removeRow = (i: number): void => commit({ ...state, rows: state.rows.filter((_, j) => j !== i) });
+
+  return (
+    <div className="grid gap-2">
+      <div className="flex items-center justify-between">
+        <span className="text-[12px] text-[color:var(--fg-muted)]">{props.label}</span>
+        <button
+          type="button"
+          className="text-[11px] text-[color:var(--accent)] hover:underline"
+          onClick={() =>
+            commit(state.mode === 'rows' ? { ...state, mode: 'advanced', raw: build({ ...state, mode: 'rows' }) } : parseValue(state.raw))
+          }
+        >
+          {state.mode === 'rows' ? t('conditionAdvanced') : t('conditionSimple')}
+        </button>
+      </div>
+
+      {state.mode === 'advanced' ? (
+        <textarea
+          className={`${gcInput} min-h-[60px] font-mono`}
+          value={state.raw}
+          placeholder='{"op":"and","args":[{"op":"eq","path":"stepResult.approved","value":true}]}'
+          onChange={(e) => commit({ ...state, raw: e.target.value })}
+        />
+      ) : (
+        <>
+          {state.rows.length > 1 && (
+            <label className={gcLbl}>
+              {t('conditionCombiner')}
+              <select className={gcInput} value={state.combiner} onChange={(e) => commit({ ...state, combiner: e.target.value as 'and' | 'or' })}>
+                <option value="and">{t('conditionAnd')}</option>
+                <option value="or">{t('conditionOr')}</option>
+              </select>
+            </label>
+          )}
+          {state.rows.map((row, i) => (
+            <div key={row.id} className="grid grid-cols-[1fr_auto_1fr_auto] items-center gap-1">
+              <input
+                className={gcInput}
+                list={pathListId}
+                value={row.path}
+                placeholder="stepResult.approved"
+                onChange={(e) => setRow(i, { path: e.target.value })}
+              />
+              <select className={gcInput} value={row.op} onChange={(e) => setRow(i, { op: e.target.value as LeafOp })}>
+                {LEAF_OPS.map((o) => (
+                  <option key={o} value={o}>
+                    {t(`conditionOp_${o}`)}
+                  </option>
+                ))}
+              </select>
+              {row.op === 'exists' ? (
+                <span className="text-[11px] text-[color:var(--fg-muted)]">—</span>
+              ) : (
+                <input
+                  className={gcInput}
+                  value={row.value}
+                  placeholder={row.op === 'in' ? 'a, b, c' : row.op === 'matches' ? '^ok$' : 'true'}
+                  onChange={(e) => setRow(i, { value: e.target.value })}
+                />
+              )}
+              <button
+                type="button"
+                className="px-1 text-[13px] text-[color:var(--danger)] hover:opacity-80"
+                aria-label={t('conditionRemove')}
+                onClick={() => removeRow(i)}
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+          <datalist id={pathListId}>
+            {(props.pathOptions ?? ['stepResult.approved', 'stepResult.text', 'ctx']).map((p) => (
+              <option key={p} value={p} />
+            ))}
+          </datalist>
+          <div>
+            <Button variant="ghost" onClick={addRow}>
+              {t('conditionAddRow')}
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/web-ui/app/conductor/_components/ConductorCanvas.tsx
+++ b/web-ui/app/conductor/_components/ConductorCanvas.tsx
@@ -23,9 +23,13 @@ import {
 import '@xyflow/react/dist/style.css';
 
 import { Button } from '@/app/_components/ui/Button';
+import { ChannelSelect, DurationInput, QuorumSelect, RefPicker } from './GuidedControls';
+import { ScheduleBuilder } from './ScheduleBuilder';
+import { ConditionBuilder } from './ConditionBuilder';
 import {
   ApiError,
   getConductorEventCatalog,
+  getConductorRoles,
   getConductorRun,
   getConductorWorkflowGraph,
   previewConductorWorkflow,
@@ -170,6 +174,8 @@ function CanvasInner({
   // Declared emittable events (US4 / FR-028) — the Designer sources the event-trigger picker from the
   // live catalog. Best-effort: an empty catalog just falls back to free-text entry.
   const [eventCatalog, setEventCatalog] = useState<string[]>([]);
+  // Known role keys (US6) — source for the human-step principal picker. Best-effort like the events.
+  const [roleCatalog, setRoleCatalog] = useState<string[]>([]);
   const eventListId = useId(); // unique per canvas instance — no datalist id collision on double-mount
 
   useEffect(() => {
@@ -181,6 +187,11 @@ function CanvasInner({
       })
       // Errors degrade to the empty-catalog hint + free-text entry. (A 401 still triggers getJson's
       // standard login redirect — same as every other page fetch — which is the desired behaviour.)
+      .catch(() => undefined);
+    void getConductorRoles()
+      .then((r) => {
+        if (!cancelled) setRoleCatalog(Array.isArray(r?.roles) ? r.roles.map((x) => x.key).filter(Boolean) : []);
+      })
       .catch(() => undefined);
     return () => {
       cancelled = true;
@@ -515,10 +526,7 @@ function CanvasInner({
           </label>
         )}
         {triggerKind === 'cron' && (
-          <label className={lbl}>
-            cron
-            <input className={input} value={triggerCron} onChange={(e) => setTriggerCron(e.target.value)} placeholder="0 9 * * 1" />
-          </label>
+          <ScheduleBuilder label={t('scheduleLabel')} value={triggerCron} onChange={setTriggerCron} />
         )}
         <label className={lbl}>
           {t('loadLabel')}
@@ -618,10 +626,14 @@ function CanvasInner({
               </label>
               {sel.data.kind === 'agent' && (
                 <>
-                  <label className={lbl}>
-                    {t('agentSlugLabel')}
-                    <input className={input} value={sel.data.agentId} onChange={(e) => patchNode(sel.id, { agentId: e.target.value })} />
-                  </label>
+                  <RefPicker
+                    label={t('agentSlugLabel')}
+                    value={sel.data.agentId}
+                    onChange={(v) => patchNode(sel.id, { agentId: v })}
+                    options={[]}
+                    placeholder="fallback"
+                    hint={t('agentSlugHint')}
+                  />
                   <label className={lbl}>
                     {t('promptLabel')}
                     <textarea className={`${input} min-h-[80px]`} value={sel.data.prompt} onChange={(e) => patchNode(sel.id, { prompt: e.target.value })} />
@@ -630,10 +642,13 @@ function CanvasInner({
               )}
               {sel.data.kind === 'action' && (
                 <>
-                  <label className={lbl}>
-                    {t('actionIdLabel')}
-                    <input className={input} value={sel.data.actionId} onChange={(e) => patchNode(sel.id, { actionId: e.target.value })} />
-                  </label>
+                  <RefPicker
+                    label={t('actionIdLabel')}
+                    value={sel.data.actionId}
+                    onChange={(v) => patchNode(sel.id, { actionId: v })}
+                    options={[]}
+                    hint={t('actionIdHint')}
+                  />
                   <label className={lbl}>
                     {t('inputLabel')}
                     <textarea className={`${input} min-h-[60px] font-mono`} value={sel.data.input} onChange={(e) => patchNode(sel.id, { input: e.target.value })} placeholder="{}" />
@@ -642,49 +657,61 @@ function CanvasInner({
               )}
               {sel.data.kind === 'human' && (
                 <>
-                  <label className={lbl}>
+                  <div className={lbl}>
                     {t('principalLabel')}
                     <div className="flex gap-2">
                       <select
-                        className={input}
+                        className={`${input} w-24`}
                         value={sel.data.human.principalKind}
                         onChange={(e) => patchNode(sel.id, { human: { ...sel.data.human, principalKind: e.target.value as 'user' | 'role' } })}
                       >
                         <option value="role">role</option>
                         <option value="user">user</option>
                       </select>
-                      <input
-                        className={input}
-                        value={sel.data.human.principalRef}
-                        onChange={(e) => patchNode(sel.id, { human: { ...sel.data.human, principalRef: e.target.value } })}
-                        placeholder="approver.release"
-                      />
+                      <div className="flex-1">
+                        <RefPicker
+                          label=""
+                          value={sel.data.human.principalRef}
+                          onChange={(v) => patchNode(sel.id, { human: { ...sel.data.human, principalRef: v } })}
+                          options={sel.data.human.principalKind === 'role' ? roleCatalog : []}
+                          placeholder={sel.data.human.principalKind === 'role' ? 'approver.release' : 'name@firm.com'}
+                        />
+                      </div>
                     </div>
-                  </label>
-                  <label className={lbl}>
-                    {t('channelLabel')}
-                    <input className={input} value={sel.data.human.channel} onChange={(e) => patchNode(sel.id, { human: { ...sel.data.human, channel: e.target.value } })} />
-                  </label>
+                  </div>
+                  <ChannelSelect
+                    label={t('channelLabel')}
+                    value={sel.data.human.channel}
+                    onChange={(v) => patchNode(sel.id, { human: { ...sel.data.human, channel: v } })}
+                  />
                   <label className={lbl}>
                     {t('messageLabel')}
                     <textarea className={`${input} min-h-[50px]`} value={sel.data.human.message} onChange={(e) => patchNode(sel.id, { human: { ...sel.data.human, message: e.target.value } })} />
                   </label>
                   <div className="grid grid-cols-2 gap-2">
-                    <label className={lbl}>
-                      {t('reminderLabel')}
-                      <input className={input} value={sel.data.human.reminderInterval} onChange={(e) => patchNode(sel.id, { human: { ...sel.data.human, reminderInterval: e.target.value } })} placeholder="PT6H" />
-                    </label>
-                    <label className={lbl}>
-                      {t('deadlineLabel')}
-                      <input className={input} value={sel.data.human.deadline} onChange={(e) => patchNode(sel.id, { human: { ...sel.data.human, deadline: e.target.value } })} placeholder="PT24H" />
-                    </label>
+                    <DurationInput
+                      label={t('reminderLabel')}
+                      value={sel.data.human.reminderInterval}
+                      onChange={(v) => patchNode(sel.id, { human: { ...sel.data.human, reminderInterval: v } })}
+                    />
+                    <DurationInput
+                      label={t('deadlineLabel')}
+                      value={sel.data.human.deadline}
+                      onChange={(v) => patchNode(sel.id, { human: { ...sel.data.human, deadline: v } })}
+                    />
                   </div>
+                  <QuorumSelect
+                    label={t('quorumLabel')}
+                    value={sel.data.human.quorum}
+                    onChange={(q) => patchNode(sel.id, { human: { ...sel.data.human, quorum: q } })}
+                  />
                 </>
               )}
-              <label className={lbl}>
-                {t('postconditionLabel')}
-                <textarea className={`${input} min-h-[50px] font-mono`} value={sel.data.postcondition} onChange={(e) => patchNode(sel.id, { postcondition: e.target.value })} placeholder='{"op":"exists","path":"stepResult.text"}' />
-              </label>
+              <ConditionBuilder
+                label={t('postconditionLabel')}
+                value={sel.data.postcondition}
+                onChange={(v) => patchNode(sel.id, { postcondition: v })}
+              />
               <label className={lbl}>
                 {t('fallbackLabel')}
                 <select className={input} value={sel.data.fallbackTransitionId} onChange={(e) => patchNode(sel.id, { fallbackTransitionId: e.target.value })}>
@@ -707,15 +734,11 @@ function CanvasInner({
             <div className="grid gap-3">
               <div className="text-[12px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">{t('transitionLabel')}</div>
               <div className="font-mono text-[12px] text-[color:var(--fg-muted)]">{selEdge.id}</div>
-              <label className={lbl}>
-                {t('guardLabel')}
-                <textarea
-                  className={`${input} min-h-[60px] font-mono`}
-                  value={(selEdge.data?.guard as string) ?? ''}
-                  onChange={(e) => setEdges((es) => es.map((ed) => (ed.id === selEdge.id ? { ...ed, data: { ...ed.data, guard: e.target.value } } : ed)))}
-                  placeholder='{"op":"eq","path":"stepResult.approved","value":true}'
-                />
-              </label>
+              <ConditionBuilder
+                label={t('guardLabel')}
+                value={(selEdge.data?.guard as string) ?? ''}
+                onChange={(v) => setEdges((es) => es.map((ed) => (ed.id === selEdge.id ? { ...ed, data: { ...ed.data, guard: v } } : ed)))}
+              />
             </div>
           )}
         </div>

--- a/web-ui/app/conductor/_components/ConductorCanvas.tsx
+++ b/web-ui/app/conductor/_components/ConductorCanvas.tsx
@@ -23,11 +23,14 @@ import {
 import '@xyflow/react/dist/style.css';
 
 import { Button } from '@/app/_components/ui/Button';
-import { ChannelSelect, DurationInput, QuorumSelect, RefPicker } from './GuidedControls';
+import { ChannelSelect, DurationInput, QuorumSelect, RefPicker, SelectPicker } from './GuidedControls';
 import { ScheduleBuilder } from './ScheduleBuilder';
 import { ConditionBuilder } from './ConditionBuilder';
+import { KeyValueEditor } from './KeyValueEditor';
 import {
   ApiError,
+  getConductorActions,
+  getConductorAgents,
   getConductorEventCatalog,
   getConductorRoles,
   getConductorRun,
@@ -168,6 +171,8 @@ function CanvasInner({
 
   const [slug, setSlug] = useState('');
   const [name, setName] = useState('');
+  // Auto-derive the slug from the name until the user edits the slug directly (or a workflow loads).
+  const slugEdited = useRef(false);
   const [triggerKind, setTriggerKind] = useState<'manual' | 'event' | 'cron'>('manual');
   const [triggerEventId, setTriggerEventId] = useState('');
   const [triggerCron, setTriggerCron] = useState('');
@@ -176,6 +181,9 @@ function CanvasInner({
   const [eventCatalog, setEventCatalog] = useState<string[]>([]);
   // Known role keys (US6) — source for the human-step principal picker. Best-effort like the events.
   const [roleCatalog, setRoleCatalog] = useState<string[]>([]);
+  // Live agent + action catalogs — real dropdowns for the agent/action steps. Best-effort.
+  const [agentCatalog, setAgentCatalog] = useState<Array<{ slug: string; name: string }>>([]);
+  const [actionCatalog, setActionCatalog] = useState<string[]>([]);
   const eventListId = useId(); // unique per canvas instance — no datalist id collision on double-mount
 
   useEffect(() => {
@@ -191,6 +199,16 @@ function CanvasInner({
     void getConductorRoles()
       .then((r) => {
         if (!cancelled) setRoleCatalog(Array.isArray(r?.roles) ? r.roles.map((x) => x.key).filter(Boolean) : []);
+      })
+      .catch(() => undefined);
+    void getConductorAgents()
+      .then((r) => {
+        if (!cancelled) setAgentCatalog(Array.isArray(r?.agents) ? r.agents.filter((a) => a.slug) : []);
+      })
+      .catch(() => undefined);
+    void getConductorActions()
+      .then((r) => {
+        if (!cancelled) setActionCatalog(Array.isArray(r?.actions) ? r.actions.filter(Boolean) : []);
       })
       .catch(() => undefined);
     return () => {
@@ -376,7 +394,7 @@ function CanvasInner({
             agentId: String(step.agentId ?? ''),
             prompt: String(step.prompt ?? ''),
             actionId: String(step.actionId ?? ''),
-            input: step.input ? JSON.stringify(step.input, null, 2) : '',
+            input: step.input !== undefined ? JSON.stringify(step.input, null, 2) : '',
             human: {
               principalKind: (principal.kind as 'user' | 'role') ?? 'role',
               principalRef: String(principal.ref ?? ''),
@@ -386,7 +404,7 @@ function CanvasInner({
               deadline: String(human.deadline ?? ''),
               quorum: (human.quorum as 'any' | 'all') ?? 'any',
             },
-            postcondition: step.postcondition ? JSON.stringify(step.postcondition, null, 2) : '',
+            postcondition: step.postcondition !== undefined ? JSON.stringify(step.postcondition, null, 2) : '',
             fallbackTransitionId: String(step.fallbackTransitionId ?? ''),
             isEntry: step.id === g.entryStepId,
           },
@@ -396,7 +414,7 @@ function CanvasInner({
         id: String(tr.id),
         source: String(tr.source),
         target: String(tr.target),
-        data: { guard: tr.guard ? JSON.stringify(tr.guard) : '' },
+        data: { guard: tr.guard !== undefined ? JSON.stringify(tr.guard) : '' },
       }));
       setNodes(newNodes);
       setEdges(newEdges);
@@ -414,6 +432,7 @@ function CanvasInner({
     async (wfSlug: string) => {
       try {
         const { workflow, graph } = await getConductorWorkflowGraph(wfSlug);
+        slugEdited.current = true; // a loaded workflow keeps its slug; don't auto-rewrite from the name
         setSlug(workflow.slug);
         setName(workflow.name);
         hydrateFromGraph(graph);
@@ -489,12 +508,28 @@ function CanvasInner({
       {/* Toolbar */}
       <div className="flex flex-wrap items-end gap-3 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-3">
         <label className={lbl}>
-          {t('slugLabel')}
-          <input className={input} value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="release-signoff" />
+          {t('nameLabel')}
+          <input
+            className={input}
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+              if (!slugEdited.current) setSlug(slugify(e.target.value));
+            }}
+            placeholder="Release sign-off"
+          />
         </label>
         <label className={lbl}>
-          {t('nameLabel')}
-          <input className={input} value={name} onChange={(e) => setName(e.target.value)} placeholder="Release sign-off" />
+          {t('slugLabel')}
+          <input
+            className={`${input} font-mono`}
+            value={slug}
+            onChange={(e) => {
+              slugEdited.current = true;
+              setSlug(slugifyLive(e.target.value));
+            }}
+            placeholder="release-signoff"
+          />
         </label>
         <label className={lbl}>
           {t('triggerLabel')}
@@ -539,7 +574,7 @@ function CanvasInner({
             ))}
           </select>
         </label>
-        <Button variant="primary" busy={saving} disabled={saving} onClick={() => void handleSave()}>
+        <Button variant="primary" busy={saving} disabled={saving || !slug || !name} onClick={() => void handleSave()}>
           {saving ? t('publishing') : t('saveButton')}
         </Button>
         <Button variant="secondary" busy={busy} disabled={busy || !slug} onClick={() => void handleRun()}>
@@ -626,14 +661,25 @@ function CanvasInner({
               </label>
               {sel.data.kind === 'agent' && (
                 <>
-                  <RefPicker
-                    label={t('agentSlugLabel')}
-                    value={sel.data.agentId}
-                    onChange={(v) => patchNode(sel.id, { agentId: v })}
-                    options={[]}
-                    placeholder="fallback"
-                    hint={t('agentSlugHint')}
-                  />
+                  {agentCatalog.length > 0 ? (
+                    <SelectPicker
+                      label={t('agentSlugLabel')}
+                      value={sel.data.agentId}
+                      onChange={(v) => patchNode(sel.id, { agentId: v })}
+                      options={agentCatalog.map((a) => ({ value: a.slug, label: `${a.name} (${a.slug})` }))}
+                      emptyLabel={t('agentPick')}
+                      hint={t('agentSlugHint')}
+                    />
+                  ) : (
+                    <RefPicker
+                      label={t('agentSlugLabel')}
+                      value={sel.data.agentId}
+                      onChange={(v) => patchNode(sel.id, { agentId: v })}
+                      options={[]}
+                      placeholder="fallback"
+                      hint={t('agentSlugHint')}
+                    />
+                  )}
                   <label className={lbl}>
                     {t('promptLabel')}
                     <textarea className={`${input} min-h-[80px]`} value={sel.data.prompt} onChange={(e) => patchNode(sel.id, { prompt: e.target.value })} />
@@ -642,17 +688,25 @@ function CanvasInner({
               )}
               {sel.data.kind === 'action' && (
                 <>
-                  <RefPicker
-                    label={t('actionIdLabel')}
-                    value={sel.data.actionId}
-                    onChange={(v) => patchNode(sel.id, { actionId: v })}
-                    options={[]}
-                    hint={t('actionIdHint')}
-                  />
-                  <label className={lbl}>
-                    {t('inputLabel')}
-                    <textarea className={`${input} min-h-[60px] font-mono`} value={sel.data.input} onChange={(e) => patchNode(sel.id, { input: e.target.value })} placeholder="{}" />
-                  </label>
+                  {actionCatalog.length > 0 ? (
+                    <SelectPicker
+                      label={t('actionIdLabel')}
+                      value={sel.data.actionId}
+                      onChange={(v) => patchNode(sel.id, { actionId: v })}
+                      options={actionCatalog.map((a) => ({ value: a, label: a }))}
+                      emptyLabel={t('actionPick')}
+                      hint={t('actionIdHint')}
+                    />
+                  ) : (
+                    <RefPicker
+                      label={t('actionIdLabel')}
+                      value={sel.data.actionId}
+                      onChange={(v) => patchNode(sel.id, { actionId: v })}
+                      options={[]}
+                      hint={t('actionIdHint')}
+                    />
+                  )}
+                  <KeyValueEditor label={t('inputLabel')} value={sel.data.input} onChange={(v) => patchNode(sel.id, { input: v })} />
                 </>
               )}
               {sel.data.kind === 'human' && (
@@ -785,6 +839,29 @@ function CanvasInner({
       )}
     </div>
   );
+}
+
+/** Slugify a workflow name into the a-z0-9-dash form the backend expects. Folds accents/umlauts
+ *  (München → munchen) so non-ASCII names still produce a usable slug instead of a dash-mangled one. */
+function slugify(s: string): string {
+  return s
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Sanitize the slug field WHILE typing — keeps a hyphen the user is typing (only strips leading
+ *  dashes), so `my-flow` can be authored left-to-right. Full trim happens via slugify on name-derive. */
+function slugifyLive(s: string): string {
+  return s
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+/, '');
 }
 
 export function ConductorCanvas(props: {

--- a/web-ui/app/conductor/_components/GuidedControls.tsx
+++ b/web-ui/app/conductor/_components/GuidedControls.tsx
@@ -196,3 +196,34 @@ export function RefPicker(props: {
     </label>
   );
 }
+
+/**
+ * SelectPicker — a real <select> dropdown over a known catalog (agents, actions).
+ * Preserves a stored value that isn't in the catalog (e.g. a disabled agent) as its
+ * own option so loading never silently drops it, and offers an empty option.
+ */
+export function SelectPicker(props: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  options: ReadonlyArray<{ value: string; label: string }>;
+  emptyLabel?: string;
+  hint?: string;
+}): React.JSX.Element {
+  const present = props.value === '' || props.options.some((o) => o.value === props.value);
+  return (
+    <label className={gcLbl}>
+      {props.label}
+      <select className={gcInput} value={props.value} onChange={(e) => props.onChange(e.target.value)}>
+        <option value="">{props.emptyLabel ?? '—'}</option>
+        {!present ? <option value={props.value}>{props.value}</option> : null}
+        {props.options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      {props.hint ? <span className={gcHint}>{props.hint}</span> : null}
+    </label>
+  );
+}

--- a/web-ui/app/conductor/_components/GuidedControls.tsx
+++ b/web-ui/app/conductor/_components/GuidedControls.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+/**
+ * Guided form controls for the Conductor designer — replace the raw text inputs
+ * (ISO-8601 durations, free-text role/channel ids, hidden quorum) with self-
+ * explanatory pickers. All controls round-trip the SAME serialized shapes the
+ * canvas already stores (ISO-8601 strings, channel slug, 'any'|'all'), so the
+ * publish path is unchanged. i18n lives under the `conductor` namespace.
+ */
+import { useId } from 'react';
+import { useTranslations } from 'next-intl';
+
+export const gcInput =
+  'w-full rounded-md border border-[color:var(--border)] bg-transparent px-2 py-1 text-[13px] text-[color:var(--fg-strong)]';
+export const gcLbl = 'grid gap-1 text-[12px] text-[color:var(--fg-muted)]';
+const gcHint = 'text-[11px] text-[color:var(--fg-muted)]';
+
+// --- ISO-8601 duration <-> { amount, unit } -------------------------------
+// The designer only ever emits single-unit durations, so we parse/serialize the
+// common forms: PT{n}M (minutes), PT{n}H (hours), P{n}D (days), P{n}W (weeks).
+export type DurationUnit = 'minutes' | 'hours' | 'days' | 'weeks';
+
+export function parseDuration(iso: string): { amount: number; unit: DurationUnit } | null {
+  const s = (iso ?? '').trim();
+  if (!s) return null;
+  const m = /^P(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?)?$/.exec(s);
+  if (!m) return null;
+  const [, w, d, h, min] = m;
+  let result: { amount: number; unit: DurationUnit } | null = null;
+  if (w) result = { amount: Number(w), unit: 'weeks' };
+  else if (d) result = { amount: Number(d), unit: 'days' };
+  else if (h) result = { amount: Number(h), unit: 'hours' };
+  else if (min) result = { amount: Number(min), unit: 'minutes' };
+  // Strict: only a SINGLE-unit duration that re-serializes byte-identically is representable as
+  // value+unit. Multi-unit forms (PT1H30M, P1DT12H) and units we don't model (PT30S, P1Y) return
+  // null so the control can fall back to a raw editor and never silently truncate the stored value.
+  if (!result) return null;
+  return serializeDuration(result.amount, result.unit) === s ? result : null;
+}
+
+export function serializeDuration(amount: number, unit: DurationUnit): string {
+  const n = Math.floor(amount);
+  if (!Number.isFinite(n) || n <= 0) return '';
+  switch (unit) {
+    case 'minutes':
+      return `PT${String(n)}M`;
+    case 'hours':
+      return `PT${String(n)}H`;
+    case 'days':
+      return `P${String(n)}D`;
+    case 'weeks':
+      return `P${String(n)}W`;
+  }
+}
+
+/** Value (number) + unit picker that serializes to an ISO-8601 duration. Empty = "no value". */
+export function DurationInput(props: {
+  label: string;
+  value: string;
+  onChange: (iso: string) => void;
+  hint?: string;
+}): React.JSX.Element {
+  const t = useTranslations('conductor');
+  const parsed = parseDuration(props.value);
+  const amount = parsed?.amount ?? '';
+  const unit: DurationUnit = parsed?.unit ?? 'hours';
+  const units: DurationUnit[] = ['minutes', 'hours', 'days', 'weeks'];
+  // A non-empty value the picker can't represent as a single unit (e.g. PT1H30M, P1Y) must stay
+  // editable as raw ISO so we never truncate or wipe a value the engine accepts (review H1).
+  const isRaw = props.value.trim().length > 0 && !parsed;
+
+  const emit = (nextAmount: number | '', nextUnit: DurationUnit): void => {
+    if (nextAmount === '' || Number(nextAmount) <= 0) {
+      props.onChange('');
+      return;
+    }
+    props.onChange(serializeDuration(Number(nextAmount), nextUnit));
+  };
+
+  if (isRaw) {
+    return (
+      <label className={gcLbl}>
+        {props.label}
+        <input
+          className={`${gcInput} font-mono`}
+          value={props.value}
+          onChange={(e) => props.onChange(e.target.value)}
+        />
+        <span className={gcHint}>{t('durationRawHint')}</span>
+      </label>
+    );
+  }
+
+  return (
+    <label className={gcLbl}>
+      {props.label}
+      <div className="flex gap-2">
+        <input
+          type="number"
+          min={1}
+          step={1}
+          className={`${gcInput} w-20`}
+          value={amount}
+          placeholder="—"
+          onChange={(e) => emit(e.target.value === '' ? '' : Number(e.target.value), unit)}
+        />
+        <select
+          className={gcInput}
+          value={unit}
+          onChange={(e) => emit(amount === '' ? '' : Number(amount), e.target.value as DurationUnit)}
+        >
+          {units.map((u) => (
+            <option key={u} value={u}>
+              {t(`durationUnit_${u}`)}
+            </option>
+          ))}
+        </select>
+      </div>
+      {props.hint ? <span className={gcHint}>{props.hint}</span> : null}
+    </label>
+  );
+}
+
+/** Quorum: 'any' (first response wins) vs 'all' (every holder must respond). */
+export function QuorumSelect(props: {
+  label: string;
+  value: 'any' | 'all';
+  onChange: (q: 'any' | 'all') => void;
+}): React.JSX.Element {
+  const t = useTranslations('conductor');
+  const value = props.value || 'any'; // defensive: an older graph could carry undefined → controlled 'any'
+  return (
+    <label className={gcLbl}>
+      {props.label}
+      <select className={gcInput} value={value} onChange={(e) => props.onChange(e.target.value as 'any' | 'all')}>
+        <option value="any">{t('quorumAny')}</option>
+        <option value="all">{t('quorumAll')}</option>
+      </select>
+      <span className={gcHint}>{value === 'all' ? t('quorumAllHint') : t('quorumAnyHint')}</span>
+    </label>
+  );
+}
+
+/** Channel picker — a select over the known delivery channels (free value preserved if unknown). */
+export function ChannelSelect(props: {
+  label: string;
+  value: string;
+  onChange: (channel: string) => void;
+}): React.JSX.Element {
+  const known = ['teams', 'telegram', 'discord', 'whatsapp'];
+  const options = known.includes(props.value) || !props.value ? known : [props.value, ...known];
+  return (
+    <label className={gcLbl}>
+      {props.label}
+      <select className={gcInput} value={props.value || 'teams'} onChange={(e) => props.onChange(e.target.value)}>
+        {options.map((c) => (
+          <option key={c} value={c}>
+            {c}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+/**
+ * Combobox: a free-text input backed by a <datalist> of known ids (roles, agents,
+ * actions, events). Suggests existing refs while still allowing a not-yet-created
+ * one — the proven W5 event-catalog pattern, generalised.
+ */
+export function RefPicker(props: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  options: readonly string[];
+  placeholder?: string;
+  hint?: string;
+}): React.JSX.Element {
+  const listId = useId();
+  return (
+    <label className={gcLbl}>
+      {props.label}
+      <input
+        className={gcInput}
+        list={listId}
+        value={props.value}
+        placeholder={props.placeholder}
+        onChange={(e) => props.onChange(e.target.value)}
+      />
+      <datalist id={listId}>
+        {props.options.map((o) => (
+          <option key={o} value={o} />
+        ))}
+      </datalist>
+      {props.hint ? <span className={gcHint}>{props.hint}</span> : null}
+    </label>
+  );
+}

--- a/web-ui/app/conductor/_components/KeyValueEditor.tsx
+++ b/web-ui/app/conductor/_components/KeyValueEditor.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+/**
+ * KeyValueEditor — edit an action's input object as key/value ROWS instead of a
+ * hand-written JSON blob. Values are coerced (JSON-first, string fallback) so
+ * `true`/`42`/`"text"` all work. Anything the rows can't model (a nested object/
+ * array value, or a non-object top level) falls back to an "advanced" raw-JSON
+ * editor so no shape is lost. Round-trips the SAME JSON string the canvas stores
+ * (empty = no input).
+ */
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { gcInput } from './GuidedControls';
+import { Button } from '@/app/_components/ui/Button';
+
+let kvSeq = 0;
+const nextKvId = (): string => `kv-${String((kvSeq += 1))}`;
+
+interface KvRow {
+  id: string;
+  key: string;
+  value: string;
+}
+
+interface KvState {
+  mode: 'rows' | 'advanced';
+  rows: KvRow[];
+  raw: string;
+}
+
+function coerce(v: string): unknown {
+  const s = v.trim();
+  if (s === '') return '';
+  try {
+    return JSON.parse(s) as unknown;
+  } catch {
+    return v;
+  }
+}
+
+/** A value is row-representable only if it's a scalar (string/number/boolean/null). */
+function isScalar(x: unknown): boolean {
+  return x === null || ['string', 'number', 'boolean'].includes(typeof x);
+}
+
+function parseValue(json: string): KvState {
+  const base: KvState = { mode: 'rows', rows: [], raw: '' };
+  const s = (json ?? '').trim();
+  if (!s) return base;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(s);
+  } catch {
+    return { ...base, mode: 'advanced', raw: json };
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { ...base, mode: 'advanced', raw: JSON.stringify(parsed, null, 2) };
+  }
+  const obj = parsed as Record<string, unknown>;
+  const entries = Object.entries(obj);
+  if (!entries.every(([, val]) => isScalar(val))) {
+    return { ...base, mode: 'advanced', raw: JSON.stringify(parsed, null, 2) };
+  }
+  return {
+    ...base,
+    rows: entries.map(([key, val]) => ({
+      id: nextKvId(),
+      key,
+      value: JSON.stringify(val),
+    })),
+  };
+}
+
+function build(state: KvState): string {
+  if (state.mode === 'advanced') return state.raw.trim();
+  const usable = state.rows.filter((r) => r.key.trim().length > 0);
+  if (usable.length === 0) return '';
+  const obj: Record<string, unknown> = {};
+  for (const r of usable) obj[r.key.trim()] = coerce(r.value);
+  return JSON.stringify(obj);
+}
+
+export function KeyValueEditor(props: {
+  label: string;
+  value: string;
+  onChange: (json: string) => void;
+}): React.JSX.Element {
+  const t = useTranslations('conductor');
+  const [state, setState] = useState<KvState>(() => parseValue(props.value));
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (build(state) !== (props.value ?? '').trim()) setState(parseValue(props.value));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.value]);
+
+  const commit = (next: KvState): void => {
+    setState(next);
+    props.onChange(build(next));
+  };
+  const setRow = (i: number, patch: Partial<KvRow>): void =>
+    commit({ ...state, rows: state.rows.map((r, j) => (j === i ? { ...r, ...patch } : r)) });
+  const addRow = (): void => commit({ ...state, rows: [...state.rows, { id: nextKvId(), key: '', value: '' }] });
+  const removeRow = (i: number): void => commit({ ...state, rows: state.rows.filter((_, j) => j !== i) });
+
+  return (
+    <div className="grid gap-2">
+      <div className="flex items-center justify-between">
+        <span className="text-[12px] text-[color:var(--fg-muted)]">{props.label}</span>
+        <button
+          type="button"
+          className="text-[11px] text-[color:var(--accent)] hover:underline"
+          onClick={() =>
+            commit(state.mode === 'rows' ? { ...state, mode: 'advanced', raw: build({ ...state, mode: 'rows' }) || '{}' } : parseValue(state.raw))
+          }
+        >
+          {state.mode === 'rows' ? t('conditionAdvanced') : t('conditionSimple')}
+        </button>
+      </div>
+
+      {state.mode === 'advanced' ? (
+        <textarea
+          className={`${gcInput} min-h-[60px] font-mono`}
+          value={state.raw}
+          placeholder="{}"
+          onChange={(e) => commit({ ...state, raw: e.target.value })}
+        />
+      ) : (
+        <>
+          {state.rows.map((row, i) => (
+            <div key={row.id} className="grid grid-cols-[1fr_1fr_auto] items-center gap-1">
+              <input className={gcInput} value={row.key} placeholder={t('kvKey')} onChange={(e) => setRow(i, { key: e.target.value })} />
+              <input className={gcInput} value={row.value} placeholder={t('kvValue')} onChange={(e) => setRow(i, { value: e.target.value })} />
+              <button
+                type="button"
+                className="px-1 text-[13px] text-[color:var(--danger)] hover:opacity-80"
+                aria-label={t('conditionRemove')}
+                onClick={() => removeRow(i)}
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+          <div>
+            <Button variant="ghost" onClick={addRow}>
+              {t('kvAddRow')}
+            </Button>
+          </div>
+          {state.rows.length > 0 ? (
+            <span className="text-[11px] text-[color:var(--fg-muted)]">{t('kvHint')}</span>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}

--- a/web-ui/app/conductor/_components/ScheduleBuilder.tsx
+++ b/web-ui/app/conductor/_components/ScheduleBuilder.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+/**
+ * ScheduleBuilder — turn the raw 5-field cron string into a guided picker with a
+ * plain-language preview, so nobody has to remember `0 9 * * 1`. Presets cover the
+ * common cases (hourly / daily / weekly / monthly); an "advanced" mode keeps the
+ * raw cron field for power users. The control round-trips the SAME cron string the
+ * trigger already stores.
+ */
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { gcInput, gcLbl } from './GuidedControls';
+
+type Mode = 'hourly' | 'daily' | 'weekly' | 'monthly' | 'advanced';
+
+interface CronParts {
+  mode: Mode;
+  minute: number;
+  hour: number;
+  dom: number; // day of month 1-31
+  dow: number; // day of week 0-6 (Sun..Sat)
+  raw: string;
+}
+
+const DEFAULTS: CronParts = { mode: 'daily', minute: 0, hour: 9, dom: 1, dow: 1, raw: '0 9 * * *' };
+
+function clampInt(v: string, lo: number, hi: number, fallback: number): number {
+  const n = Number.parseInt(v, 10);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(hi, Math.max(lo, n));
+}
+
+/** Best-effort parse of a cron string into a known preset; unrecognised → advanced. */
+export function parseCron(cron: string): CronParts {
+  const s = (cron ?? '').trim();
+  if (!s) return { ...DEFAULTS };
+  const f = s.split(/\s+/);
+  if (f.length !== 5) return { ...DEFAULTS, mode: 'advanced', raw: s };
+  const [min = '', hr = '', dom = '', mon = '', dow = ''] = f;
+  const numeric = (x: string): number | null => (/^\d+$/.test(x) ? Number(x) : null);
+  const m = numeric(min);
+  const h = numeric(hr);
+  // hourly: `0 * * * *`
+  if (min === '0' && hr === '*' && dom === '*' && mon === '*' && dow === '*') {
+    return { ...DEFAULTS, mode: 'hourly', minute: 0, raw: s };
+  }
+  if (m !== null && h !== null && mon === '*') {
+    // daily: `M H * * *`
+    if (dom === '*' && dow === '*') return { ...DEFAULTS, mode: 'daily', minute: m, hour: h, raw: s };
+    // weekly: `M H * * D`
+    const d = numeric(dow);
+    if (dom === '*' && d !== null) return { ...DEFAULTS, mode: 'weekly', minute: m, hour: h, dow: d, raw: s };
+  }
+  // monthly: `M H D * *`
+  const dnum = numeric(dom);
+  if (m !== null && h !== null && dnum !== null && mon === '*' && dow === '*') {
+    return { ...DEFAULTS, mode: 'monthly', minute: m, hour: h, dom: dnum, raw: s };
+  }
+  return { ...DEFAULTS, mode: 'advanced', raw: s };
+}
+
+function buildCron(p: CronParts): string {
+  const hh = String(p.hour);
+  const mm = String(p.minute);
+  switch (p.mode) {
+    case 'hourly':
+      return '0 * * * *';
+    case 'daily':
+      return `${mm} ${hh} * * *`;
+    case 'weekly':
+      return `${mm} ${hh} * * ${String(p.dow)}`;
+    case 'monthly':
+      return `${mm} ${hh} ${String(p.dom)} * *`;
+    case 'advanced':
+      return p.raw;
+  }
+}
+
+const hhmm = (p: CronParts): string =>
+  `${String(p.hour).padStart(2, '0')}:${String(p.minute).padStart(2, '0')}`;
+
+export function ScheduleBuilder(props: {
+  label: string;
+  value: string;
+  onChange: (cron: string) => void;
+}): React.JSX.Element {
+  const t = useTranslations('conductor');
+  const [parts, setParts] = useState<CronParts>(() => parseCron(props.value));
+
+  // Re-seed when the cron changes from outside (e.g. a workflow loads) and no
+  // longer matches what we last emitted.
+  useEffect(() => {
+    // Controlled-component resync: adopt an externally-changed cron (e.g. a workflow loads). Compare
+    // TRIMMED so a self-emitted value with incidental whitespace (advanced raw box) doesn't yank the
+    // user back into a preset mode mid-edit (review M2).
+    if (buildCron(parts).trim() !== (props.value ?? '').trim()) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setParts(parseCron(props.value));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.value]);
+
+  const update = (next: CronParts): void => {
+    setParts(next);
+    props.onChange(buildCron(next));
+  };
+
+  // Mode switch must not lose structured edits: entering advanced seeds `raw` from the current preset
+  // (else buildCron would emit the stale loaded raw); leaving advanced re-derives the fields from the
+  // raw cron so a hand-edited expression carries its time/day into the preset (review H2).
+  const changeMode = (nextMode: Mode): void => {
+    if (nextMode === 'advanced') {
+      update({ ...parts, mode: 'advanced', raw: buildCron({ ...parts, mode: parts.mode }) });
+    } else if (parts.mode === 'advanced') {
+      update({ ...parseCron(parts.raw), mode: nextMode });
+    } else {
+      update({ ...parts, mode: nextMode });
+    }
+  };
+
+  const dows = [0, 1, 2, 3, 4, 5, 6];
+  const preview =
+    parts.mode === 'hourly'
+      ? t('cronPreviewHourly')
+      : parts.mode === 'daily'
+        ? t('cronPreviewDaily', { time: hhmm(parts) })
+        : parts.mode === 'weekly'
+          ? t('cronPreviewWeekly', { day: t(`weekday_${String(parts.dow)}`), time: hhmm(parts) })
+          : parts.mode === 'monthly'
+            ? t('cronPreviewMonthly', { dom: String(parts.dom), time: hhmm(parts) })
+            : t('cronPreviewAdvanced');
+
+  return (
+    <div className="grid gap-2">
+      <label className={gcLbl}>
+        {props.label}
+        <select className={gcInput} value={parts.mode} onChange={(e) => changeMode(e.target.value as Mode)}>
+          <option value="hourly">{t('cronModeHourly')}</option>
+          <option value="daily">{t('cronModeDaily')}</option>
+          <option value="weekly">{t('cronModeWeekly')}</option>
+          <option value="monthly">{t('cronModeMonthly')}</option>
+          <option value="advanced">{t('cronModeAdvanced')}</option>
+        </select>
+      </label>
+
+      {parts.mode === 'weekly' && (
+        <label className={gcLbl}>
+          {t('cronWeekday')}
+          <select className={gcInput} value={parts.dow} onChange={(e) => update({ ...parts, dow: Number(e.target.value) })}>
+            {dows.map((d) => (
+              <option key={d} value={d}>
+                {t(`weekday_${String(d)}`)}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      {parts.mode === 'monthly' && (
+        <label className={gcLbl}>
+          {t('cronDayOfMonth')}
+          <input
+            type="number"
+            min={1}
+            max={31}
+            className={gcInput}
+            value={parts.dom}
+            onChange={(e) => update({ ...parts, dom: clampInt(e.target.value, 1, 31, 1) })}
+          />
+        </label>
+      )}
+
+      {(parts.mode === 'daily' || parts.mode === 'weekly' || parts.mode === 'monthly') && (
+        <label className={gcLbl}>
+          {t('cronTime')}
+          <input
+            type="time"
+            className={gcInput}
+            value={hhmm(parts)}
+            onChange={(e) => {
+              const [h, m] = e.target.value.split(':');
+              update({ ...parts, hour: clampInt(h ?? '', 0, 23, parts.hour), minute: clampInt(m ?? '', 0, 59, parts.minute) });
+            }}
+          />
+        </label>
+      )}
+
+      {parts.mode === 'advanced' && (
+        <label className={gcLbl}>
+          {t('cronRaw')}
+          <input
+            className={`${gcInput} font-mono`}
+            value={parts.raw}
+            placeholder="0 9 * * 1"
+            onChange={(e) => update({ ...parts, raw: e.target.value })}
+          />
+        </label>
+      )}
+
+      <p className="text-[11px] text-[color:var(--accent)]">🕒 {preview}</p>
+    </div>
+  );
+}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -491,7 +491,13 @@
     "agentSlugHint": "Der Orchestrator-Slug, der für diesen Schritt läuft.",
     "actionIdHint": "Die Tool-/Connector-Action-ID, die aufgerufen wird.",
     "scheduleLabel": "Zeitplan",
-    "durationRawHint": "Eigene ISO-8601-Dauer (z. B. PT1H30M)"
+    "durationRawHint": "Eigene ISO-8601-Dauer (z. B. PT1H30M)",
+    "agentPick": "Agent wählen…",
+    "actionPick": "Aktion wählen…",
+    "kvKey": "Schlüssel",
+    "kvValue": "Wert",
+    "kvAddRow": "+ Feld hinzufügen",
+    "kvHint": "Tipp: Text in Anführungszeichen bleibt ein String, z. B. \"123\"."
   },
   "operatorChannels": {
     "title": "Channels",

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -132,11 +132,21 @@
       "h1": "Admin",
       "subtitle": "Agenten, Modelle, Wissen, Plugins, Zugänge und Kosten dieser omadia-Instanz verwalten und überwachen.",
       "groups": {
-        "llm": { "heading": "LLM-Zugang" },
-        "knowledge": { "heading": "Wissen & Memory" },
-        "plugins": { "heading": "Plugins" },
-        "access": { "heading": "Zugang" },
-        "danger": { "heading": "Gefahrenzone" }
+        "llm": {
+          "heading": "LLM-Zugang"
+        },
+        "knowledge": {
+          "heading": "Wissen & Memory"
+        },
+        "plugins": {
+          "heading": "Plugins"
+        },
+        "access": {
+          "heading": "Zugang"
+        },
+        "danger": {
+          "heading": "Gefahrenzone"
+        }
       },
       "cards": {
         "llmAccess": {
@@ -431,7 +441,57 @@
     "colActor": "Akteur",
     "runTriggerLabel": "Auslöser",
     "startedLabel": "Gestartet",
-    "endedLabel": "Beendet"
+    "endedLabel": "Beendet",
+    "quorumLabel": "Quorum",
+    "quorumAny": "Eine Antwort genügt",
+    "quorumAll": "Alle müssen zustimmen",
+    "quorumAnyHint": "Der Schritt geht weiter, sobald ein Freigeber antwortet.",
+    "quorumAllHint": "Jeder aktuelle Freigeber muss antworten, bevor es weitergeht.",
+    "durationUnit_minutes": "Minuten",
+    "durationUnit_hours": "Stunden",
+    "durationUnit_days": "Tage",
+    "durationUnit_weeks": "Wochen",
+    "cronModeHourly": "Stündlich",
+    "cronModeDaily": "Täglich",
+    "cronModeWeekly": "Wöchentlich",
+    "cronModeMonthly": "Monatlich",
+    "cronModeAdvanced": "Erweitert (Cron)",
+    "cronWeekday": "Wochentag",
+    "cronDayOfMonth": "Tag im Monat",
+    "cronTime": "Uhrzeit",
+    "cronRaw": "Cron-Ausdruck",
+    "cronPreviewHourly": "Stündlich",
+    "cronPreviewDaily": "Täglich um {time}",
+    "cronPreviewWeekly": "Jeden {day} um {time}",
+    "cronPreviewMonthly": "Am {dom}. jedes Monats um {time}",
+    "cronPreviewAdvanced": "Eigener Zeitplan (Cron)",
+    "weekday_0": "Sonntag",
+    "weekday_1": "Montag",
+    "weekday_2": "Dienstag",
+    "weekday_3": "Mittwoch",
+    "weekday_4": "Donnerstag",
+    "weekday_5": "Freitag",
+    "weekday_6": "Samstag",
+    "conditionAdvanced": "Erweitert (JSON)",
+    "conditionSimple": "Einfach",
+    "conditionCombiner": "Verknüpfen mit",
+    "conditionAnd": "Alle (UND)",
+    "conditionOr": "Eine (ODER)",
+    "conditionAddRow": "+ Bedingung hinzufügen",
+    "conditionRemove": "Bedingung entfernen",
+    "conditionOp_eq": "gleich",
+    "conditionOp_ne": "ungleich",
+    "conditionOp_gt": "größer als",
+    "conditionOp_lt": "kleiner als",
+    "conditionOp_gte": "größer/gleich",
+    "conditionOp_lte": "kleiner/gleich",
+    "conditionOp_exists": "existiert",
+    "conditionOp_in": "ist eine von",
+    "conditionOp_matches": "passt auf",
+    "agentSlugHint": "Der Orchestrator-Slug, der für diesen Schritt läuft.",
+    "actionIdHint": "Die Tool-/Connector-Action-ID, die aufgerufen wird.",
+    "scheduleLabel": "Zeitplan",
+    "durationRawHint": "Eigene ISO-8601-Dauer (z. B. PT1H30M)"
   },
   "operatorChannels": {
     "title": "Channels",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -491,7 +491,13 @@
     "agentSlugHint": "The orchestrator slug to run for this step.",
     "actionIdHint": "The tool / connector action id to invoke.",
     "scheduleLabel": "Schedule",
-    "durationRawHint": "Custom ISO-8601 duration (e.g. PT1H30M)"
+    "durationRawHint": "Custom ISO-8601 duration (e.g. PT1H30M)",
+    "agentPick": "Select an agent…",
+    "actionPick": "Select an action…",
+    "kvKey": "key",
+    "kvValue": "value",
+    "kvAddRow": "+ Add field",
+    "kvHint": "Tip: wrap text in quotes to keep it a string, e.g. \"123\"."
   },
   "operatorChannels": {
     "title": "Channels",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -132,11 +132,21 @@
       "h1": "Admin",
       "subtitle": "Configure and monitor agents, models, knowledge, plugins, access, and cost for this omadia instance.",
       "groups": {
-        "llm": { "heading": "LLM Access" },
-        "knowledge": { "heading": "Knowledge & Memory" },
-        "plugins": { "heading": "Plugins" },
-        "access": { "heading": "Access" },
-        "danger": { "heading": "Danger Zone" }
+        "llm": {
+          "heading": "LLM Access"
+        },
+        "knowledge": {
+          "heading": "Knowledge & Memory"
+        },
+        "plugins": {
+          "heading": "Plugins"
+        },
+        "access": {
+          "heading": "Access"
+        },
+        "danger": {
+          "heading": "Danger Zone"
+        }
       },
       "cards": {
         "llmAccess": {
@@ -431,7 +441,57 @@
     "colActor": "Actor",
     "runTriggerLabel": "Trigger",
     "startedLabel": "Started",
-    "endedLabel": "Ended"
+    "endedLabel": "Ended",
+    "quorumLabel": "Quorum",
+    "quorumAny": "First response is enough",
+    "quorumAll": "All approvers must respond",
+    "quorumAnyHint": "The step continues as soon as one holder responds.",
+    "quorumAllHint": "Every current holder must respond before the step continues.",
+    "durationUnit_minutes": "Minutes",
+    "durationUnit_hours": "Hours",
+    "durationUnit_days": "Days",
+    "durationUnit_weeks": "Weeks",
+    "cronModeHourly": "Hourly",
+    "cronModeDaily": "Daily",
+    "cronModeWeekly": "Weekly",
+    "cronModeMonthly": "Monthly",
+    "cronModeAdvanced": "Advanced (cron)",
+    "cronWeekday": "Weekday",
+    "cronDayOfMonth": "Day of month",
+    "cronTime": "Time",
+    "cronRaw": "Cron expression",
+    "cronPreviewHourly": "Every hour",
+    "cronPreviewDaily": "Every day at {time}",
+    "cronPreviewWeekly": "Every {day} at {time}",
+    "cronPreviewMonthly": "On day {dom} of every month at {time}",
+    "cronPreviewAdvanced": "Custom schedule (raw cron)",
+    "weekday_0": "Sunday",
+    "weekday_1": "Monday",
+    "weekday_2": "Tuesday",
+    "weekday_3": "Wednesday",
+    "weekday_4": "Thursday",
+    "weekday_5": "Friday",
+    "weekday_6": "Saturday",
+    "conditionAdvanced": "Advanced (JSON)",
+    "conditionSimple": "Simple",
+    "conditionCombiner": "Combine with",
+    "conditionAnd": "All (AND)",
+    "conditionOr": "Any (OR)",
+    "conditionAddRow": "+ Add condition",
+    "conditionRemove": "Remove condition",
+    "conditionOp_eq": "equals",
+    "conditionOp_ne": "not equals",
+    "conditionOp_gt": "greater than",
+    "conditionOp_lt": "less than",
+    "conditionOp_gte": "greater or equal",
+    "conditionOp_lte": "less or equal",
+    "conditionOp_exists": "exists",
+    "conditionOp_in": "is one of",
+    "conditionOp_matches": "matches",
+    "agentSlugHint": "The orchestrator slug to run for this step.",
+    "actionIdHint": "The tool / connector action id to invoke.",
+    "scheduleLabel": "Schedule",
+    "durationRawHint": "Custom ISO-8601 duration (e.g. PT1H30M)"
   },
   "operatorChannels": {
     "title": "Channels",


### PR DESCRIPTION
## Summary

Overhauls the Conductor **designer** so a workflow can be built without typing
ISO-8601 durations, cron strings, predicate/JSON blobs, or free-text agent/action
ids. Every raw input becomes a guided control (dropdown, picker, value+unit,
schedule/condition builder), with an advanced escape hatch wherever a shape can't
be modelled. Frontend-only except two small read-only catalog endpoints.

### Guided controls (`web-ui/app/conductor/_components/`)
- **DurationInput** — reminder/deadline as value + unit ⇄ ISO-8601; a non-single-unit
  or unsupported ISO stays editable as raw (never truncated).
- **ScheduleBuilder** — cron trigger via presets + day/time + a plain-language
  preview ("Every Monday at 09:00"); advanced-cron escape.
- **ConditionBuilder** — postcondition / transition guard as field/op/value rows ⇄
  predicate AST, AND/OR, with an advanced-JSON fallback for nested/not/const.
- **KeyValueEditor** — action input as key/value rows ⇄ JSON object (no hand-written
  JSON), advanced-JSON escape for nested values.
- **SelectPicker / RefPicker / ChannelSelect / QuorumSelect** — agent + action steps
  become real `<select>` dropdowns (free-text fallback when the catalog is empty),
  quorum is finally rendered (it was in the model but had no UI), channel + role/event
  are pickers.
- Workflow **slug auto-derived** from the name (NFKD-folded: München → munchen), Save
  guarded against empty slug/name.

### Backend
- `GET /conductors/agents` (orchestrator slug+name from the registry) and
  `GET /conductors/actions` (deterministic-action ids), registered before the
  catch-all `/:slug`; threaded via `wireConductor` (`listActions`) +
  `createConductorRouter` (`agentCatalog`/`actionCatalog`). New api clients
  `getConductorAgents` / `getConductorActions` / `getConductorRoles`.

### Reviews (Claude + Forge/Codex, both executed the round-trip transforms)
Folded every HIGH/MED across two review passes — all data-loss round-trips fixed:
- DurationInput raw-escape for non-representable ISO; ScheduleBuilder re-seeds raw
  on mode switch + trims the resync compare; ConditionBuilder routes comma/structured
  `in` lists to advanced; definedness-not-truthiness rehydration of falsy
  input/postcondition/guard; agent free-text fallback on empty catalog; live-hyphen
  slug + unicode fold + save guard; stable row keys / `useId` datalists; integer-only
  durations. Refuted (both, with evidence): infinite resync loops, falsy-eq
  round-trip, matches/const/not/nested round-trip, i18n parity.

## Tests / gates
- `tsc` clean, `eslint` 0 errors, `npm run i18n:check` OK (1585 keys, en+de ICU
  parity), `next build` compiled, middleware build clean.
- Verified live on the local `omadia-dev` stack (:3333); the new catalog endpoints
  return 401 (auth) not 404 (registered + reachable).

## Follow-ups
- Per-action input JSON-schemas would turn the action-input key/value editor into a
  typed form (the registry currently exposes only ids).
- a11y: associate the principal-block label with its control.
