### PR TITLE
fix(store): portal install drawer above global header

### DIFF
--- a/web-ui/app/_components/store/InstallButton.tsx
+++ b/web-ui/app/_components/store/InstallButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useRouter } from 'next/navigation';
 import { useLocale } from 'next-intl';
 import {
@@ -585,7 +586,11 @@ function InstallDrawer({
   );
   const submitting = phase.kind === 'submitting';
 
-  return (
+  // Portal to <body> so the drawer escapes the store sidebar's
+  // `position: sticky` stacking context (which always creates one, even at
+  // z-index auto). Without this, the drawer's z-50 is trapped inside that
+  // context and the global header (z-40) paints on top of it.
+  return createPortal(
     <div
       className="fixed inset-0 z-50 flex justify-end"
       role="dialog"
@@ -601,7 +606,7 @@ function InstallDrawer({
 
       <aside
         className={cn(
-          'relative z-10 flex h-full max-h-screen w-full max-w-xl flex-col',
+          'relative flex h-full max-h-screen w-full max-w-xl flex-col',
           'border-l border-[color:var(--rule-strong)] bg-[color:var(--paper)]',
           'shadow-[-20px_0_60px_-20px_rgba(0,0,0,0.3)]',
         )}
@@ -709,7 +714,8 @@ function InstallDrawer({
           </form>
         )}
       </aside>
-    </div>
+    </div>,
+    document.body,
   );
 }
 


### PR DESCRIPTION
 ## What

  Portal the plugin install/config drawer to document.body so it renders above the global navigation header. Closes #399 

  ## Why

  The drawer mounts inside the store sidebar's position: sticky element, which always creates a stacking context —
  trapping the drawer's z-50 below the header's z-40. At scroll-top the header covered the drawer's heading and Close
  button. Portaling escapes that context; matches existing createPortal usage (CreateIssueButton, StreamToasts).

  ## Test plan

  - [X] npm run typecheck — passed (drawer file clean)
  - [X] npm run lint — pending
  - [X] npm run test — pending
  - [X] manual: open plugin detail → start install → scroll to top → heading + Close visible and clickable above header

  ## Risk / blast radius

  Low. Single client component; no schema/API/env/CI changes. Drawer only mounts on interaction (phase.kind !== 'idle')
  → SSR-safe.