### PR TITLE
nav: move Orchestrators/Conductor into Admin, enlarge chevron

### DIFF
--- a/web-ui/app/_components/Nav.tsx
+++ b/web-ui/app/_components/Nav.tsx
@@ -26,11 +26,6 @@ type NavItem = NavLeaf | NavCluster;
 
 const NAV: readonly NavItem[] = [
   { kind: 'link', href: '/', key: 'dashboard' },
-  { kind: 'link', href: '/chat', key: 'chat' },
-  // Orchestrators is a direct link: the overview page now carries both the
-  // orchestrator and channel settings, so the old Overview/Channels dropdown
-  // collapsed into a single destination.
-  { kind: 'link', href: '/operator/agents', key: 'agentsCluster' },
   { kind: 'link', href: '/operator/skills', key: 'skills' },
   {
     kind: 'cluster',
@@ -41,13 +36,17 @@ const NAV: readonly NavItem[] = [
     ],
   },
   { kind: 'link', href: '/routines', key: 'routines' },
-  { kind: 'link', href: '/conductor', key: 'conductor' },
+  { kind: 'link', href: '/chat', key: 'chat' },
   {
     kind: 'cluster',
     key: 'adminCluster',
     children: [
       { kind: 'link', href: '/admin', key: 'admin' },
       { kind: 'link', href: '/system', key: 'system' },
+      // Orchestrators and Conductor moved here from the top level — they're
+      // operator-facing configuration surfaces, same audience as Admin/System.
+      { kind: 'link', href: '/operator/agents', key: 'agentsCluster' },
+      { kind: 'link', href: '/conductor', key: 'conductor' },
     ],
   },
 ] as const;
@@ -185,7 +184,7 @@ function ClusterDropdown({
         ].join(' ')}
       >
         {label}
-        <span aria-hidden="true" className="text-[10px]">
+        <span aria-hidden="true" className="text-[15px] leading-none">
           ▾
         </span>
         {containsActive ? (


### PR DESCRIPTION
## Summary
- Top nav reordered: Dashboard | Skills | Plugins | Routinen | Chat | Admin
- Orchestratoren (`/operator/agents`) and Conductor (`/conductor`) moved from top-level links into the Admin dropdown (alongside Admin/System)
- Enlarged the cluster-dropdown chevron (`▾`) from `text-[10px]` to `text-[15px]`

## Verification
- `npm run typecheck` — clean
- `npm run lint` (Nav.tsx) — clean
- `npm run i18n:check` — OK, 1661 keys (pre-existing unrelated warnings only)
- `npm run build` — succeeds, all routes still present
- No new translation keys needed (all reused existing `nav.*` keys)
- Not visually verified in a browser: the dev server redirects to `/login` without the middleware backend + auth session running, and there's no existing Nav component test to exercise instead. Structural/typecheck verification only.