### PR TITLE
web-ui: restore Days One face for the omadia wordmark

### DIFF
--- a/web-ui/app/globals.css
+++ b/web-ui/app/globals.css
@@ -83,6 +83,15 @@ body {
   letter-spacing: -0.01em;
 }
 
+/* Utility: the omadia wordmark only (header logo + login card). Keeps the
+   original Days One brand face without reopening the §2.7 decision that
+   moved every other heading onto Geist (.font-display above). */
+.font-logo {
+  font-family: var(--font-days-one), var(--font-sans);
+  font-weight: 400;
+  letter-spacing: -0.01em;
+}
+
 /* Long-form agent prose register — Source Serif 4 (§2.7). */
 .font-prose {
   font-family: var(--font-serif);

--- a/web-ui/app/layout.tsx
+++ b/web-ui/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { cookies } from 'next/headers';
-import { Geist, Geist_Mono, Source_Serif_4 } from 'next/font/google';
+import { Days_One, Geist, Geist_Mono, Source_Serif_4 } from 'next/font/google';
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages, getTranslations } from 'next-intl/server';
 
@@ -51,6 +51,20 @@ const mono = Geist_Mono({
 });
 
 /**
+ * Brand wordmark only — the omadia logo (header + login card) keeps the
+ * original Days One face. Lume headings elsewhere stay on Geist per §2.7
+ * (see globals.css .font-display); this is a separate `.font-logo` class
+ * so the wordmark can diverge without reopening that decision sitewide.
+ */
+const logo = Days_One({
+  subsets: ['latin'],
+  weight: '400',
+  variable: '--font-days-one',
+  display: 'swap',
+  preload: false,
+});
+
+/**
  * No-FOUC palette/theme (issue #287). The choice now lives in a server-side
  * per-user store (/api/v1/ui-prefs); the browser mirrors it into the
  * `omadia-ui-prefs` cookie, which ThemeControls writes on every change. We
@@ -84,7 +98,7 @@ export default async function RootLayout({
   return (
     <html
       lang={locale}
-      className={`${sans.variable} ${serif.variable} ${mono.variable}`}
+      className={`${sans.variable} ${serif.variable} ${mono.variable} ${logo.variable}`}
       data-palette={palette}
       {...(theme ? { 'data-theme': theme } : {})}
       suppressHydrationWarning
@@ -101,7 +115,7 @@ export default async function RootLayout({
                     aria-label={t('logoAriaLabel')}
                   >
                     <span className="flex flex-col leading-none">
-                      <span className="font-display text-lg text-[color:var(--fg-strong)]">
+                      <span className="font-logo text-lg text-[color:var(--fg-strong)]">
                         omadia
                       </span>
                       <span className="mt-1 text-[10px] uppercase tracking-[0.14em] text-[color:var(--fg-muted)]">

--- a/web-ui/app/login/page.tsx
+++ b/web-ui/app/login/page.tsx
@@ -250,7 +250,7 @@ function PageShell({ children }: { children: React.ReactNode }): React.ReactElem
           elev.modal carries the accent-glow components). */}
       <div className="lume-surface-raised lume-border w-full max-w-sm rounded-lg p-6 shadow-[var(--shadow-lg)]">
         <header className="mb-6 flex flex-col leading-none">
-          <h1 className="font-display text-3xl text-[color:var(--fg-strong)]">
+          <h1 className="font-logo text-3xl text-[color:var(--fg-strong)]">
             omadia
           </h1>
           <span className="mt-2 text-[11px] uppercase tracking-[0.18em] text-[color:var(--fg-muted)]">


### PR DESCRIPTION
## Summary
Restores the original "Days One" display font for the omadia brand wordmark ("omadia" text in the app header and login card), without reopening the sitewide Lume §2.7 decision that moved every other heading (`.font-display`) onto Geist.

## Changes
- `web-ui/app/layout.tsx` - self-hosts `Days One` via `next/font/google`, exposes `--font-days-one` CSS variable
- `web-ui/app/globals.css` - new `.font-logo` utility class (`font-family: var(--font-days-one), var(--font-sans)`), scoped separately from `.font-display`
- `web-ui/app/login/page.tsx` - applies `.font-logo` to the duplicate "omadia" wordmark on the login card

## Verification
- `npm run build` passes clean
- `npm run lint` - only pre-existing warnings, no new issues
- Confirmed in the compiled CSS output that the `@font-face` for Days One (self-hosted woff2, no runtime font-CDN request) and the `.font-logo` rule are correctly bundled and applied to both wordmark instances