### PR TITLE
feat(web-ui/chat): collapsible debug-chat intro banner

### DIFF
--- a/web-ui/app/chat/page.tsx
+++ b/web-ui/app/chat/page.tsx
@@ -451,6 +451,8 @@ export default function ChatPage(): React.ReactElement {
         disabled={sending}
       />
 
+      <ChatIntro />
+
       <div className="border-b border-[color:var(--border)] bg-[color:var(--bg-elevated)]/75 px-6 py-2 text-xs">
         <div className="mx-auto flex max-w-4xl flex-col gap-2">
           {/* Row 1 — orchestrator picker. The stream-path + session-scope
@@ -689,6 +691,26 @@ export default function ChatPage(): React.ReactElement {
         }}
       />
     </main>
+  );
+}
+
+/**
+ * What-is-this-page explainer. Native `<details>` — same collapsed-by-
+ * default disclosure pattern as `<ToolTrace>` below — so the explanation is
+ * one click away without permanently eating vertical space from the chat
+ * area on every load.
+ */
+function ChatIntro(): React.ReactElement {
+  const t = useTranslations('chat');
+  return (
+    <details className="border-b border-[color:var(--border)] bg-[color:var(--bg-elevated)]/50 px-6 text-xs">
+      <summary className="mx-auto max-w-4xl cursor-pointer select-none py-2 font-medium text-[color:var(--fg-muted)]">
+        {t('intro.summary')}
+      </summary>
+      <div className="mx-auto max-w-4xl pb-3 text-[color:var(--fg-subtle)]">
+        {t('intro.body')}
+      </div>
+    </details>
   );
 }
 

--- a/web-ui/app/chat/page.tsx
+++ b/web-ui/app/chat/page.tsx
@@ -10,7 +10,7 @@ import {
   type KeyboardEvent,
 } from 'react';
 import { useTranslations } from 'next-intl';
-import { Eraser, GitBranch, Navigation, Network, X } from 'lucide-react';
+import { ChevronDown, Eraser, GitBranch, Navigation, Network } from 'lucide-react';
 import { ChatTabs } from '../_components/ChatTabs';
 import { ScrollToBottomButton } from '../_components/ScrollToBottomButton';
 import { Button } from '../_components/ui/Button';
@@ -694,81 +694,87 @@ export default function ChatPage(): React.ReactElement {
   );
 }
 
-// Persisted "hidden" flag for the chat intro banner, keyed in localStorage —
+// Persisted collapse state for the chat intro header, keyed in localStorage —
 // same module-level-store + useSyncExternalStore shape as the dashboard
-// onboarding dismiss ([[DashboardOnboarding]]), so a close click sticks
-// across reloads without a setState-in-effect.
-const CHAT_INTRO_HIDDEN_KEY = 'omadia.chat.intro.hidden';
-let chatIntroHiddenCache: boolean | null = null;
-const chatIntroHiddenListeners = new Set<() => void>();
+// onboarding dismiss ([[DashboardOnboarding]]), so a toggle sticks across
+// reloads without a setState-in-effect. Server + initial-client snapshot are
+// both `false` (expanded) — an operator only ever collapses it explicitly.
+const CHAT_INTRO_COLLAPSED_KEY = 'omadia.chat.intro.collapsed';
+let chatIntroCollapsedCache: boolean | null = null;
+const chatIntroCollapsedListeners = new Set<() => void>();
 
-function readChatIntroHidden(): boolean {
+function readChatIntroCollapsed(): boolean {
   try {
-    return window.localStorage.getItem(CHAT_INTRO_HIDDEN_KEY) === '1';
+    return window.localStorage.getItem(CHAT_INTRO_COLLAPSED_KEY) === '1';
   } catch {
     return false;
   }
 }
 
-function subscribeChatIntroHidden(cb: () => void): () => void {
-  chatIntroHiddenListeners.add(cb);
-  return () => chatIntroHiddenListeners.delete(cb);
+function subscribeChatIntroCollapsed(cb: () => void): () => void {
+  chatIntroCollapsedListeners.add(cb);
+  return () => chatIntroCollapsedListeners.delete(cb);
 }
 
-function getChatIntroHiddenSnapshot(): boolean {
-  if (chatIntroHiddenCache === null) chatIntroHiddenCache = readChatIntroHidden();
-  return chatIntroHiddenCache;
+function getChatIntroCollapsedSnapshot(): boolean {
+  if (chatIntroCollapsedCache === null) {
+    chatIntroCollapsedCache = readChatIntroCollapsed();
+  }
+  return chatIntroCollapsedCache;
 }
 
-function getChatIntroHiddenServerSnapshot(): boolean {
+function getChatIntroCollapsedServerSnapshot(): boolean {
   return false;
 }
 
-function setChatIntroHiddenPersisted(value: boolean): void {
-  chatIntroHiddenCache = value;
+function setChatIntroCollapsedPersisted(value: boolean): void {
+  chatIntroCollapsedCache = value;
   try {
-    if (value) window.localStorage.setItem(CHAT_INTRO_HIDDEN_KEY, '1');
-    else window.localStorage.removeItem(CHAT_INTRO_HIDDEN_KEY);
+    if (value) window.localStorage.setItem(CHAT_INTRO_COLLAPSED_KEY, '1');
+    else window.localStorage.removeItem(CHAT_INTRO_COLLAPSED_KEY);
   } catch {
     /* private mode / no storage */
   }
-  for (const l of chatIntroHiddenListeners) l();
+  for (const l of chatIntroCollapsedListeners) l();
 }
 
 /**
- * What-is-this-page header — same kicker + body + close-button language as
- * the dashboard onboarding card, scaled down for a top-of-chat banner.
- * Dismissing persists in localStorage, so it stays gone across reloads
- * instead of coming back to eat chat space every session.
+ * What-is-this-page header — kicker + body in the same `b5-hero-bg` treatment
+ * as the Hub page hero, scaled down for a top-of-chat banner. Starts
+ * expanded; the chevron toggles collapse and the choice persists in
+ * localStorage, so a collapsed operator doesn't see it re-expand every
+ * reload.
  */
-function ChatIntro(): React.ReactElement | null {
+function ChatIntro(): React.ReactElement {
   const t = useTranslations('chat');
-  const hidden = useSyncExternalStore(
-    subscribeChatIntroHidden,
-    getChatIntroHiddenSnapshot,
-    getChatIntroHiddenServerSnapshot,
+  const collapsed = useSyncExternalStore(
+    subscribeChatIntroCollapsed,
+    getChatIntroCollapsedSnapshot,
+    getChatIntroCollapsedServerSnapshot,
   );
-  if (hidden) return null;
   return (
     <div className="b5-hero-bg border-b border-[color:var(--border)] px-6 py-4">
-      <div className="mx-auto flex max-w-4xl items-start justify-between gap-4">
-        <div className="min-w-0">
-          <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--accent)]">
-            {t('intro.kicker')}
-          </div>
+      <div className="mx-auto max-w-4xl">
+        <button
+          type="button"
+          onClick={() => setChatIntroCollapsedPersisted(!collapsed)}
+          aria-expanded={!collapsed}
+          className="flex w-full items-center gap-2 text-left text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--accent)]"
+        >
+          <ChevronDown
+            className={[
+              'size-3.5 shrink-0 transition-transform',
+              collapsed ? '-rotate-90' : '',
+            ].join(' ')}
+            aria-hidden
+          />
+          {t('intro.kicker')}
+        </button>
+        {!collapsed && (
           <p className="mt-1.5 max-w-2xl text-[13px] leading-relaxed text-[color:var(--fg)]">
             {t('intro.body')}
           </p>
-        </div>
-        <button
-          type="button"
-          onClick={() => setChatIntroHiddenPersisted(true)}
-          className="shrink-0 text-[color:var(--fg-subtle)] transition-colors hover:text-[color:var(--fg-strong)]"
-          aria-label={t('intro.dismiss')}
-          title={t('intro.dismiss')}
-        >
-          <X className="size-4" aria-hidden />
-        </button>
+        )}
       </div>
     </div>
   );

--- a/web-ui/app/chat/page.tsx
+++ b/web-ui/app/chat/page.tsx
@@ -10,7 +10,7 @@ import {
   type KeyboardEvent,
 } from 'react';
 import { useTranslations } from 'next-intl';
-import { Eraser, GitBranch, Navigation, Network } from 'lucide-react';
+import { Eraser, GitBranch, Navigation, Network, X } from 'lucide-react';
 import { ChatTabs } from '../_components/ChatTabs';
 import { ScrollToBottomButton } from '../_components/ScrollToBottomButton';
 import { Button } from '../_components/ui/Button';
@@ -694,23 +694,83 @@ export default function ChatPage(): React.ReactElement {
   );
 }
 
+// Persisted "hidden" flag for the chat intro banner, keyed in localStorage —
+// same module-level-store + useSyncExternalStore shape as the dashboard
+// onboarding dismiss ([[DashboardOnboarding]]), so a close click sticks
+// across reloads without a setState-in-effect.
+const CHAT_INTRO_HIDDEN_KEY = 'omadia.chat.intro.hidden';
+let chatIntroHiddenCache: boolean | null = null;
+const chatIntroHiddenListeners = new Set<() => void>();
+
+function readChatIntroHidden(): boolean {
+  try {
+    return window.localStorage.getItem(CHAT_INTRO_HIDDEN_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function subscribeChatIntroHidden(cb: () => void): () => void {
+  chatIntroHiddenListeners.add(cb);
+  return () => chatIntroHiddenListeners.delete(cb);
+}
+
+function getChatIntroHiddenSnapshot(): boolean {
+  if (chatIntroHiddenCache === null) chatIntroHiddenCache = readChatIntroHidden();
+  return chatIntroHiddenCache;
+}
+
+function getChatIntroHiddenServerSnapshot(): boolean {
+  return false;
+}
+
+function setChatIntroHiddenPersisted(value: boolean): void {
+  chatIntroHiddenCache = value;
+  try {
+    if (value) window.localStorage.setItem(CHAT_INTRO_HIDDEN_KEY, '1');
+    else window.localStorage.removeItem(CHAT_INTRO_HIDDEN_KEY);
+  } catch {
+    /* private mode / no storage */
+  }
+  for (const l of chatIntroHiddenListeners) l();
+}
+
 /**
- * What-is-this-page explainer. Native `<details>` — same collapsed-by-
- * default disclosure pattern as `<ToolTrace>` below — so the explanation is
- * one click away without permanently eating vertical space from the chat
- * area on every load.
+ * What-is-this-page header — same kicker + body + close-button language as
+ * the dashboard onboarding card, scaled down for a top-of-chat banner.
+ * Dismissing persists in localStorage, so it stays gone across reloads
+ * instead of coming back to eat chat space every session.
  */
-function ChatIntro(): React.ReactElement {
+function ChatIntro(): React.ReactElement | null {
   const t = useTranslations('chat');
+  const hidden = useSyncExternalStore(
+    subscribeChatIntroHidden,
+    getChatIntroHiddenSnapshot,
+    getChatIntroHiddenServerSnapshot,
+  );
+  if (hidden) return null;
   return (
-    <details className="border-b border-[color:var(--border)] bg-[color:var(--bg-elevated)]/50 px-6 text-xs">
-      <summary className="mx-auto max-w-4xl cursor-pointer select-none py-2 font-medium text-[color:var(--fg-muted)]">
-        {t('intro.summary')}
-      </summary>
-      <div className="mx-auto max-w-4xl pb-3 text-[color:var(--fg-subtle)]">
-        {t('intro.body')}
+    <div className="b5-hero-bg border-b border-[color:var(--border)] px-6 py-4">
+      <div className="mx-auto flex max-w-4xl items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--accent)]">
+            {t('intro.kicker')}
+          </div>
+          <p className="mt-1.5 max-w-2xl text-[13px] leading-relaxed text-[color:var(--fg)]">
+            {t('intro.body')}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setChatIntroHiddenPersisted(true)}
+          className="shrink-0 text-[color:var(--fg-subtle)] transition-colors hover:text-[color:var(--fg-strong)]"
+          aria-label={t('intro.dismiss')}
+          title={t('intro.dismiss')}
+        >
+          <X className="size-4" aria-hidden />
+        </button>
       </div>
-    </details>
+    </div>
   );
 }
 

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -712,6 +712,10 @@
     "errorMiddlewareUnreachable": "Middleware nicht erreichbar auf localhost:3979. Läuft `npm run dev` im middleware-Ordner?",
     "errorProxyFailure": "Proxy-Fehler (HTTP {status}). Prüf die Middleware-Logs.",
     "errorAborted": "Abgebrochen.",
+    "intro": {
+      "summary": "Wofür ist dieser Chat?",
+      "body": "Das ist der Debug-Chat für Operatoren — eine direkte Leitung zu deinen Orchestratoren zum Testen von Prompts und zum Beobachten von Tool-Aufrufen, Plänen und Knowledge-Graph-Walks in Echtzeit. Das ist nicht die Endnutzer-Erfahrung, sondern zum Debuggen gedacht."
+    },
     "streamLabel": "Stream:",
     "clearTabTitle": "Nur den aktiven Tab leeren",
     "clearTabButton": "Verlauf leeren",

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -713,8 +713,9 @@
     "errorProxyFailure": "Proxy-Fehler (HTTP {status}). Prüf die Middleware-Logs.",
     "errorAborted": "Abgebrochen.",
     "intro": {
-      "summary": "Wofür ist dieser Chat?",
-      "body": "Das ist der Debug-Chat für Operatoren — eine direkte Leitung zu deinen Orchestratoren zum Testen von Prompts und zum Beobachten von Tool-Aufrufen, Plänen und Knowledge-Graph-Walks in Echtzeit. Das ist nicht die Endnutzer-Erfahrung, sondern zum Debuggen gedacht."
+      "kicker": "Wofür ist dieser Chat?",
+      "body": "Das ist der Debug-Chat für Operatoren — eine direkte Leitung zu deinen Orchestratoren zum Testen von Prompts und zum Beobachten von Tool-Aufrufen, Plänen und Knowledge-Graph-Walks in Echtzeit. Das ist nicht die Endnutzer-Erfahrung, sondern zum Debuggen gedacht.",
+      "dismiss": "Hinweis ausblenden"
     },
     "streamLabel": "Stream:",
     "clearTabTitle": "Nur den aktiven Tab leeren",

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -714,8 +714,7 @@
     "errorAborted": "Abgebrochen.",
     "intro": {
       "kicker": "Wofür ist dieser Chat?",
-      "body": "Das ist der Debug-Chat für Operatoren — eine direkte Leitung zu deinen Orchestratoren zum Testen von Prompts und zum Beobachten von Tool-Aufrufen, Plänen und Knowledge-Graph-Walks in Echtzeit. Das ist nicht die Endnutzer-Erfahrung, sondern zum Debuggen gedacht.",
-      "dismiss": "Hinweis ausblenden"
+      "body": "Das ist der Debug-Chat für Operatoren — eine direkte Leitung zu deinen Orchestratoren zum Testen von Prompts und zum Beobachten von Tool-Aufrufen, Plänen und Knowledge-Graph-Walks in Echtzeit. Das ist nicht die Endnutzer-Erfahrung, sondern zum Debuggen gedacht."
     },
     "streamLabel": "Stream:",
     "clearTabTitle": "Nur den aktiven Tab leeren",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -712,6 +712,10 @@
     "errorMiddlewareUnreachable": "Middleware unreachable on localhost:3979. Is `npm run dev` running in the middleware folder?",
     "errorProxyFailure": "Proxy error (HTTP {status}). Check the middleware logs.",
     "errorAborted": "Aborted.",
+    "intro": {
+      "summary": "What is this chat?",
+      "body": "This is the operator debug chat — a direct line to your orchestrators for testing prompts and inspecting tool calls, plans, and knowledge-graph walks as they happen. It's not the end-user experience; it's built for debugging."
+    },
     "streamLabel": "Stream:",
     "clearTabTitle": "Clear only the active tab",
     "clearTabButton": "Clear history",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -714,8 +714,7 @@
     "errorAborted": "Aborted.",
     "intro": {
       "kicker": "What is this chat?",
-      "body": "This is the operator debug chat — a direct line to your orchestrators for testing prompts and inspecting tool calls, plans, and knowledge-graph walks as they happen. It's not the end-user experience; it's built for debugging.",
-      "dismiss": "Hide this note"
+      "body": "This is the operator debug chat — a direct line to your orchestrators for testing prompts and inspecting tool calls, plans, and knowledge-graph walks as they happen. It's not the end-user experience; it's built for debugging."
     },
     "streamLabel": "Stream:",
     "clearTabTitle": "Clear only the active tab",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -713,8 +713,9 @@
     "errorProxyFailure": "Proxy error (HTTP {status}). Check the middleware logs.",
     "errorAborted": "Aborted.",
     "intro": {
-      "summary": "What is this chat?",
-      "body": "This is the operator debug chat — a direct line to your orchestrators for testing prompts and inspecting tool calls, plans, and knowledge-graph walks as they happen. It's not the end-user experience; it's built for debugging."
+      "kicker": "What is this chat?",
+      "body": "This is the operator debug chat — a direct line to your orchestrators for testing prompts and inspecting tool calls, plans, and knowledge-graph walks as they happen. It's not the end-user experience; it's built for debugging.",
+      "dismiss": "Hide this note"
     },
     "streamLabel": "Stream:",
     "clearTabTitle": "Clear only the active tab",


### PR DESCRIPTION
## What
Adds a collapsible `<details>` intro banner to the top of `/chat`, right below the tab bar, explaining what the page is for: the operator debug chat for testing orchestrators (prompts, tool calls, plan graphs, KG walks) — not the end-user experience.

## Why
The page had no explainer for new operators, and any static explainer would eat into the vertical chat area. Native `<details>`/`<summary>`, collapsed by default — same disclosure pattern already used for `ToolTrace` and `CaptureDisclosure` in this file — so it's a click away without costing space by default.

## Changes
- `web-ui/app/chat/page.tsx`: new `ChatIntro` component, mounted between `ChatTabs` and the orchestrator-picker header row
- `web-ui/messages/en.json` / `de.json`: new `chat.intro.summary` / `chat.intro.body` keys

## Verification
- `tsc --noEmit`: clean
- `eslint app/chat/page.tsx`: 0 errors (4 pre-existing unrelated warnings)
- `npm run i18n:check`: OK, 1667 keys, en/de in sync
- `next build`: succeeds, `/chat` route compiles
- Not live-verified in a running browser session — the app requires an authenticated middleware session (:3979) not available in this worktree; the collapsible follows the exact same native `<details>` pattern already shipped and visually verified for `ToolTrace`/`CaptureDisclosure` in the same file.