### PR TITLE
fix: close #332 gaps — agentId, Direct Line privacy masking, standing L3 obligation, web-ui render

### DIFF
--- a/middleware/packages/harness-channel-sdk/src/chatAgent.ts
+++ b/middleware/packages/harness-channel-sdk/src/chatAgent.ts
@@ -1,5 +1,6 @@
 import type { PrivacyReceipt, RecalledContext } from '@omadia/plugin-api';
 import type {
+  AgentConsultation,
   DelegatedAnswer,
   FollowUpOption,
   SemanticAnswer,
@@ -159,6 +160,11 @@ export interface RunAgentInvocation {
   /** 0-based index across the Run — ties back the INVOKED_AGENT edge ordering. */
   index: number;
   agentName: string;
+  /** Stable agent id when resolvable (e.g. `de.byte5.agent.strategist`). Lets
+   *  consumers disambiguate invocations whose human-facing label collides
+   *  (#332 gap-closure). Absent when the invoked tool has no registered
+   *  agentId (native/kernel tools). */
+  agentId?: string;
   durationMs: number;
   subIterations: number;
   status: RunStatus;
@@ -667,6 +673,15 @@ export type ChatStreamEvent =
        * The orchestrator cannot suppress or reword it.
        */
       delegatedAnswer?: DelegatedAnswer;
+      /**
+       * #332 Layer 1 (gap-closure) — curated, tamper-evident projection of
+       * `runTrace.agentInvocations`, identical in shape and derivation to
+       * `SemanticAnswer.agentsConsulted` (see `deriveAgentsConsulted` in
+       * `toSemanticAnswer.ts`). Streaming clients (web-ui) previously had to
+       * either re-derive this from the raw `runTrace` or go without; this
+       * field gives every channel the SAME harness-built array.
+       */
+      agentsConsulted?: AgentConsultation[];
     }
   /**
    * Emitted after `done` by the verifier wrapper (only when enabled). The

--- a/middleware/packages/harness-channel-sdk/src/index.ts
+++ b/middleware/packages/harness-channel-sdk/src/index.ts
@@ -102,6 +102,11 @@ export { toSemanticAnswer } from './toSemanticAnswer.js';
 // UI) can append a readable, harness-sourced consulted-agents footer line.
 export { agentsConsultedFooterText } from './toSemanticAnswer.js';
 
+// #332 Layer 1 (gap-closure) — shared derivation so streaming clients
+// (web-ui) and non-streaming `toSemanticAnswer` callers (Teams et al.) build
+// the IDENTICAL curated agentsConsulted array from the same run-trace.
+export { deriveAgentsConsulted } from './toSemanticAnswer.js';
+
 // Semantic outgoing-message contracts (connectors render native)
 export type {
   SemanticAnswer,

--- a/middleware/packages/harness-channel-sdk/src/toSemanticAnswer.ts
+++ b/middleware/packages/harness-channel-sdk/src/toSemanticAnswer.ts
@@ -1,4 +1,4 @@
-import type { ChatTurnResult } from './chatAgent.js';
+import type { ChatTurnResult, RunTracePayload } from './chatAgent.js';
 import type {
   AgentConsultation,
   OutgoingAttachment,
@@ -47,6 +47,31 @@ function humanizeAgentLabel(agentName: string): string {
     .map((seg) => seg.charAt(0).toUpperCase() + seg.slice(1))
     .join(' ');
   return titled.length > 0 ? titled : agentName;
+}
+
+/**
+ * #332 Layer 1 — curate a tamper-evident consulted-agents projection from a
+ * run-trace's `agentInvocations`. Extracted (gap-closure) so BOTH the
+ * non-streaming `toSemanticAnswer` conversion (Teams et al.) AND the
+ * streaming `done` event construction (web-ui) build the identical
+ * harness-sourced array — one derivation, not a client-reimplemented one, so
+ * the tamper-evidence property (empty when no sub-agent really ran) holds on
+ * every channel.
+ */
+export function deriveAgentsConsulted(
+  runTrace: Pick<RunTracePayload, 'agentInvocations'> | undefined,
+): AgentConsultation[] | undefined {
+  return runTrace?.agentInvocations && runTrace.agentInvocations.length > 0
+    ? runTrace.agentInvocations.map((inv) => ({
+        ...(inv.agentId !== undefined ? { agentId: inv.agentId } : {}),
+        label: humanizeAgentLabel(inv.agentName),
+        status: inv.status,
+        ...(typeof inv.durationMs === 'number'
+          ? { durationMs: inv.durationMs }
+          : {}),
+        ...(inv.toolCalls ? { toolCalls: inv.toolCalls.length } : {}),
+      }))
+    : undefined;
 }
 
 /**
@@ -135,17 +160,7 @@ export function toSemanticAnswer(r: ChatTurnResult): SemanticAnswer {
   // get; the raw `runTrace` stays dropped (see header). Built by the harness,
   // outside the LLM's output stream — a fabricated "I asked X" with no real
   // invocation yields an empty array here.
-  const agentsConsulted: AgentConsultation[] | undefined =
-    r.runTrace?.agentInvocations && r.runTrace.agentInvocations.length > 0
-      ? r.runTrace.agentInvocations.map((inv) => ({
-          label: humanizeAgentLabel(inv.agentName),
-          status: inv.status,
-          ...(typeof inv.durationMs === 'number'
-            ? { durationMs: inv.durationMs }
-            : {}),
-          ...(inv.toolCalls ? { toolCalls: inv.toolCalls.length } : {}),
-        }))
-      : undefined;
+  const agentsConsulted = deriveAgentsConsulted(r.runTrace);
 
   return {
     text: r.answer,

--- a/middleware/packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.ts
+++ b/middleware/packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.ts
@@ -518,6 +518,7 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
         props: {
           runId,
           agentName: inv.agentName,
+          ...(inv.agentId !== undefined ? { agentId: inv.agentId } : {}),
           index: inv.index,
           durationMs: inv.durationMs,
           subIterations: inv.subIterations,

--- a/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
+++ b/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
@@ -905,6 +905,7 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
         const invProps = validateNodeProps('AgentInvocation', {
           runId: runExtId,
           agentName: inv.agentName,
+          ...(inv.agentId !== undefined ? { agentId: inv.agentId } : {}),
           index: inv.index,
           durationMs: inv.durationMs,
           subIterations: inv.subIterations,

--- a/middleware/packages/harness-knowledge-graph-neon/src/schema.ts
+++ b/middleware/packages/harness-knowledge-graph-neon/src/schema.ts
@@ -217,6 +217,8 @@ const AgentInvocationPropsSchema = z
   .object({
     runId: z.string().min(1),
     agentName: z.string().min(1),
+    /** Stable agent id when resolvable (#332 gap-closure). */
+    agentId: z.string().optional(),
     index: z.number().int().nonnegative(),
     durationMs: z.number().int().nonnegative(),
     subIterations: z.number().int().nonnegative(),

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import type { Pool } from 'pg';
 import {
+  deriveAgentsConsulted,
   toSemanticAnswer,
   type ChatStreamEvent,
   type ChatTurnInput,
@@ -222,6 +223,19 @@ export interface OrchestratorOptions {
    * mention/markup parsing (see directLine.ts).
    */
   directLinePrefix?: string;
+  /**
+   * #332 Layer 3 (gap-closure) — standing, per-orchestrator forced-delegation
+   * obligation. When set to one of this orchestrator's whitelisted domain
+   * tool names, EVERY ordinary (non-direct-line) turn carries that turn's
+   * obligation automatically — equivalent to the caller passing
+   * `expectedDomainTool` on every `ChatTurnInput`, without requiring the
+   * caller to wire it per turn. Opt-in; absent → no standing obligation (byte
+   * -identical pre-gap-closure behaviour). A per-turn `input.expectedDomainTool`
+   * still takes precedence when both are set. Gives OB-31 forced-tool-choice a
+   * real (minimal) production producer beyond the Conductor's own future,
+   * heavier per-step reuse.
+   */
+  requiredConsultToolName?: string;
   /** Kernel-shared native-tool registry. Created once at boot and shared
    *  between the orchestrator and the plugin-activation pipeline so plugin-
    *  contributed tools land in the same dispatch map as the kernel's own. */
@@ -929,6 +943,8 @@ export class Orchestrator {
   private readonly directLineMode: DirectLineMode;
   /** #332 Layer 2 — directive prefix (default `'#'`). */
   private readonly directLinePrefix: string;
+  /** #332 Layer 3 (gap-closure) — standing forced-consult tool name, if any. */
+  private readonly requiredConsultToolName: string | undefined;
   // systemPrompt is rebuilt live per turn from `buildSystemPrompt()` —
   // so hot-registered DomainTools show up in the preamble. Prompt caching
   // still applies within stable phases (between two register/unregister
@@ -1003,6 +1019,7 @@ export class Orchestrator {
     this.domainToolsByName = new Map(options.domainTools.map((t) => [t.name, t]));
     this.directLineMode = options.directLineMode ?? 'strict';
     this.directLinePrefix = options.directLinePrefix ?? '#';
+    this.requiredConsultToolName = options.requiredConsultToolName;
     this.knowledgeGraph = options.knowledgeGraph;
     this.knowledgeGraphTool = options.knowledgeGraph
       ? new KnowledgeGraphTool(options.knowledgeGraph, options.embeddingClient)
@@ -1951,15 +1968,21 @@ export class Orchestrator {
       scope: input.sessionScope ?? turnId,
       ...(input.userId ? { userId: input.userId } : {}),
     });
-    const handle = collector.beginInvocation(tool.name);
+    const handle = collector.beginInvocation(tool.name, candidate.agentId);
     const startedAt = Date.now();
     let verbatim: string;
     let status: 'success' | 'error';
     try {
       // The domain-tool contract takes `{ question }` (see createDomainTool);
       // bind it to the user's VERBATIM payload — the orchestrator never
-      // reshapes it.
-      verbatim = await tool.handle(
+      // reshapes it. Routed through the SAME `dispatchTool` choke point as
+      // every other domain-tool dispatch (not a raw `tool.handle` call) so
+      // the Privacy Shield v4 masking cascade applies here too — #332
+      // gap-closure: a raw `tool.handle` call bypassed `dispatchTool`
+      // entirely, so a verbatim delegated answer was never interned even
+      // when a privacy guard was active.
+      verbatim = await this.dispatchTool(
+        tool.name,
         { question: directive.payload },
         handle.observer,
       );
@@ -2083,10 +2106,14 @@ export class Orchestrator {
     obligationTool: string | undefined;
     forceObligation: { type: 'tool'; name: string } | undefined;
   } {
+    // #332 gap-closure — a per-turn `expectedDomainTool` still wins; absent,
+    // fall back to this orchestrator's standing `requiredConsultToolName`
+    // (if configured), so the forced-delegation primitive has a real,
+    // opt-in producer beyond a caller wiring it per turn.
+    const requested = input.expectedDomainTool ?? this.requiredConsultToolName;
     const tool =
-      input.expectedDomainTool &&
-      this.domainToolsByName.has(input.expectedDomainTool)
-        ? input.expectedDomainTool
+      requested && this.domainToolsByName.has(requested)
+        ? requested
         : undefined;
     return {
       obligationTool: tool,
@@ -2660,7 +2687,10 @@ export class Orchestrator {
         const invocations = toolUses.map((use: ContentBlock) => {
           const isNative = this.nativeTools.has(use.name);
           return !isNative && traceCollector
-            ? traceCollector.beginInvocation(use.name)
+            ? traceCollector.beginInvocation(
+                use.name,
+                this.domainToolsByName.get(use.name)?.agentId,
+              )
             : undefined;
         });
         const settled = await Promise.allSettled(
@@ -2892,6 +2922,7 @@ export class Orchestrator {
       // exactly like the normal done branch below.
       const direct = await this.executeDirectLine(input, turnId);
       if (direct) {
+        const directAgentsConsulted = deriveAgentsConsulted(direct.runTrace);
         let doneEvent: Extract<ChatStreamEvent, { type: 'done' }> = {
           type: 'done',
           answer: direct.answer,
@@ -2901,6 +2932,9 @@ export class Orchestrator {
           ...(direct.turnId ? { turnId: direct.turnId } : {}),
           ...(direct.delegatedAnswer
             ? { delegatedAnswer: direct.delegatedAnswer }
+            : {}),
+          ...(directAgentsConsulted && directAgentsConsulted.length > 0
+            ? { agentsConsulted: directAgentsConsulted }
             : {}),
         };
         if (privacyHandle) {
@@ -3353,6 +3387,7 @@ export class Orchestrator {
           // the freshly-inserted neighbourhood in the floating pane. Best-effort
           // & guarded; emitted before `done` so it lands with the final turn.
           yield* await this.toKgInsertAnnotationEvents(autoPromotedMkId);
+          const finalAgentsConsulted = deriveAgentsConsulted(runTrace);
           yield {
             type: 'done',
             answer,
@@ -3370,6 +3405,9 @@ export class Orchestrator {
             ...(pendingSlotCard ? { pendingSlotCard } : {}),
             ...(pendingRoutineList ? { pendingRoutineList } : {}),
             ...(pendingOAuthConsent ? { pendingOAuthConsent: true } : {}),
+            ...(finalAgentsConsulted && finalAgentsConsulted.length > 0
+              ? { agentsConsulted: finalAgentsConsulted }
+              : {}),
           };
           return;
         }
@@ -3579,6 +3617,7 @@ export class Orchestrator {
               );
             }
           }
+          const choiceAgentsConsulted = deriveAgentsConsulted(runTrace);
           yield {
             type: 'done',
             answer,
@@ -3588,6 +3627,9 @@ export class Orchestrator {
             pendingUserChoice,
             ...(persistedTurnId ? { turnId: persistedTurnId } : {}),
             ...(runTrace ? { runTrace } : {}),
+            ...(choiceAgentsConsulted && choiceAgentsConsulted.length > 0
+              ? { agentsConsulted: choiceAgentsConsulted }
+              : {}),
           };
           return;
         }
@@ -3631,7 +3673,10 @@ export class Orchestrator {
     const isNative = this.nativeTools.has(use.name);
     const invocation =
       !isNative && traceCollector
-        ? traceCollector.beginInvocation(use.name)
+        ? traceCollector.beginInvocation(
+            use.name,
+            this.domainToolsByName.get(use.name)?.agentId,
+          )
         : undefined;
     const observer = this.makeSlotObserver(use.id, subEvents, invocation);
     const started = Date.now();

--- a/middleware/packages/harness-orchestrator/src/runTraceCollector.ts
+++ b/middleware/packages/harness-orchestrator/src/runTraceCollector.ts
@@ -71,7 +71,7 @@ export class RunTraceCollector {
     });
   }
 
-  beginInvocation(agentName: string): InvocationHandle {
+  beginInvocation(agentName: string, agentId?: string): InvocationHandle {
     const index = this.invocationIndex++;
     const toolCallStarts = new Map<string, { name: string }>();
     const subToolCalls: RunToolCall[] = [];
@@ -112,6 +112,7 @@ export class RunTraceCollector {
         push({
           index,
           agentName,
+          ...(agentId !== undefined ? { agentId } : {}),
           durationMs,
           subIterations,
           status,

--- a/middleware/packages/plugin-api/src/knowledgeGraph.ts
+++ b/middleware/packages/plugin-api/src/knowledgeGraph.ts
@@ -1537,6 +1537,11 @@ export interface RunAgentInvocation {
   /** 0-based index across the Run — ties back the INVOKED_AGENT edge ordering. */
   index: number;
   agentName: string;
+  /** Stable agent id when resolvable (e.g. `de.byte5.agent.strategist`). Lets
+   *  consumers disambiguate invocations whose human-facing label collides
+   *  (#332 gap-closure). Absent when the invoked tool has no registered
+   *  agentId (native/kernel tools). */
+  agentId?: string;
   durationMs: number;
   subIterations: number;
   status: RunStatus;

--- a/middleware/test/orchestrator/directLine.test.ts
+++ b/middleware/test/orchestrator/directLine.test.ts
@@ -1,7 +1,12 @@
 import { describe, it } from 'node:test';
 import { strict as assert } from 'node:assert';
 
-import type { LlmProvider, LlmResponse } from '@omadia/llm-provider';
+import type {
+  LlmProvider,
+  LlmRequest,
+  LlmResponse,
+  LlmStreamEvent,
+} from '@omadia/llm-provider';
 import {
   NativeToolRegistry,
   Orchestrator,
@@ -9,6 +14,7 @@ import {
   parseDirectLineDirective,
   resolveDirectLineTarget,
   directLineLabel,
+  type ChatStreamEvent,
   type DirectLineCandidate,
 } from '@omadia/orchestrator';
 import {
@@ -151,6 +157,112 @@ describe('#332 toSemanticAnswer agentsConsulted projection', () => {
     const sa = toSemanticAnswer(base);
     assert.equal(sa.agentsConsulted, undefined);
     assert.equal(agentsConsultedFooterText(sa), undefined);
+  });
+
+  it('#332 gap-closure — carries agentId through the projection when the run-trace resolved one', () => {
+    const r: ChatTurnResult = {
+      ...base,
+      runTrace: {
+        scope: 's',
+        startedAt: '2026-01-01T00:00:00.000Z',
+        finishedAt: '2026-01-01T00:00:01.000Z',
+        durationMs: 100,
+        status: 'success',
+        iterations: 1,
+        orchestratorToolCalls: [],
+        agentInvocations: [
+          {
+            index: 0,
+            agentName: 'ask_strategist',
+            agentId: 'de.byte5.agent.strategist',
+            durationMs: 50,
+            subIterations: 1,
+            status: 'success',
+            toolCalls: [],
+          },
+        ],
+      },
+    };
+    const sa = toSemanticAnswer(r);
+    assert.equal(sa.agentsConsulted?.[0]?.agentId, 'de.byte5.agent.strategist');
+  });
+
+  it('#332 gap-closure — two agents sharing a display label still resolve to distinct agentIds', () => {
+    // Both tool names humanize to the SAME label ("Strategist") — the bug
+    // this closes: before agentId was threaded through, these were
+    // indistinguishable in the projection.
+    const r: ChatTurnResult = {
+      ...base,
+      runTrace: {
+        scope: 's',
+        startedAt: '2026-01-01T00:00:00.000Z',
+        finishedAt: '2026-01-01T00:00:01.000Z',
+        durationMs: 100,
+        status: 'success',
+        iterations: 1,
+        orchestratorToolCalls: [],
+        agentInvocations: [
+          {
+            index: 0,
+            agentName: 'ask_strategist',
+            agentId: 'de.byte5.agent.strategist',
+            durationMs: 50,
+            subIterations: 1,
+            status: 'success',
+            toolCalls: [],
+          },
+          {
+            index: 1,
+            agentName: 'consult_strategist',
+            agentId: 'com.other.agent.strategist',
+            durationMs: 40,
+            subIterations: 1,
+            status: 'success',
+            toolCalls: [],
+          },
+        ],
+      },
+    };
+    const sa = toSemanticAnswer(r);
+    assert.equal(sa.agentsConsulted?.length, 2);
+    assert.equal(sa.agentsConsulted?.[0]?.label, 'Strategist');
+    assert.equal(sa.agentsConsulted?.[1]?.label, 'Strategist');
+    assert.equal(sa.agentsConsulted?.[0]?.agentId, 'de.byte5.agent.strategist');
+    assert.equal(sa.agentsConsulted?.[1]?.agentId, 'com.other.agent.strategist');
+    assert.notEqual(
+      sa.agentsConsulted?.[0]?.agentId,
+      sa.agentsConsulted?.[1]?.agentId,
+    );
+  });
+
+  it('#332 gap-closure — agentId is absent from the plain-text footer fallback (internal id stays internal)', () => {
+    const r: ChatTurnResult = {
+      ...base,
+      runTrace: {
+        scope: 's',
+        startedAt: '2026-01-01T00:00:00.000Z',
+        finishedAt: '2026-01-01T00:00:01.000Z',
+        durationMs: 100,
+        status: 'success',
+        iterations: 1,
+        orchestratorToolCalls: [],
+        agentInvocations: [
+          {
+            index: 0,
+            agentName: 'ask_strategist',
+            agentId: 'de.byte5.agent.strategist',
+            durationMs: 50,
+            subIterations: 1,
+            status: 'success',
+            toolCalls: [],
+          },
+        ],
+      },
+    };
+    const sa = toSemanticAnswer(r);
+    const footer = agentsConsultedFooterText(sa);
+    assert.ok(footer);
+    assert.doesNotMatch(footer ?? '', /de\.byte5\.agent\.strategist/);
   });
 });
 
@@ -367,13 +479,22 @@ describe('#332 Layer 2 — Direct Line (strict passthrough, non-streaming/Teams)
   });
 });
 
-// Minimal privacy-guard service stub — enough for runTurn's post-turn block
-// (takeRenderedAnswerV4 + finalizeTurn). Direct-line never interns, so the
-// other methods are not exercised.
+// Minimal privacy-guard service stub. #332 gap-closure: direct-line now
+// routes through the same `dispatchTool` choke point as every other
+// domain-tool dispatch, so `internToolResultV4` IS exercised here — the
+// digest it returns is what a masked delegated answer looks like. The
+// digest text is deterministic-but-distinguishable from the raw input so
+// tests can assert masking actually happened (not just pass through).
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const fakePrivacyGuard = (): any => () =>
   ({
-    internToolResultV4: async () => ({ digest: '', datasetId: '' }),
+    internToolResultV4: async (input: {
+      toolName: string;
+      rawResult: string;
+    }) => ({
+      digestText: `[masked:${input.toolName}:${input.rawResult.length}]`,
+      datasetId: 'ds-test-1',
+    }),
     subAgentResultV4: async (i: { narration: string }) => ({
       resultText: i.narration,
     }),
@@ -416,8 +537,54 @@ describe('#332 Layer 2 — guarded-additive mode', () => {
       privacyGuard: fakePrivacyGuard(),
     });
     const sa = await orch.chat({ userMessage: '#strategist plan?', sessionScope: 'g2' });
-    assert.equal(sa.delegatedAnswer?.text, 'VERBATIM-Y');
-    assert.equal(sa.text, 'VERBATIM-Y'); // no note appended → no provider call
+    // #332 gap-closure: the verbatim answer is now routed through the same
+    // masking cascade as every other domain-tool dispatch — the raw
+    // 'VERBATIM-Y' must NOT reach the user when a privacy guard is active.
+    assert.equal(sa.delegatedAnswer?.text, '[masked:ask_strategist:10]');
+    assert.equal(sa.text, '[masked:ask_strategist:10]'); // no note appended → no provider call
+  });
+});
+
+describe('#332 gap-closure — Direct Line answers are actually PII-masked', () => {
+  it('a verbatim answer is interned (masked) when a privacy guard is active (strict mode)', async () => {
+    const tool = strategistTool(
+      async () => 'contact jane.doe@example.com for details',
+    );
+    const orch = new Orchestrator({
+      provider: neverCalledProvider(),
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [tool],
+      nativeToolRegistry: new NativeToolRegistry(),
+      privacyGuard: fakePrivacyGuard(), // strict is the default directLineMode
+    });
+    const sa = await orch.chat({ userMessage: '#strategist plan?', sessionScope: 'pii1' });
+    assert.ok(sa.delegatedAnswer);
+    assert.doesNotMatch(sa.delegatedAnswer?.text ?? '', /jane\.doe@example\.com/);
+    assert.match(sa.delegatedAnswer?.text ?? '', /^\[masked:ask_strategist:/);
+    assert.doesNotMatch(sa.text, /jane\.doe@example\.com/);
+  });
+
+  it('the raw verbatim text passes through unmasked when NO privacy guard is configured (documented contract)', async () => {
+    const tool = strategistTool(
+      async () => 'contact jane.doe@example.com for details',
+    );
+    const orch = new Orchestrator({
+      provider: neverCalledProvider(),
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [tool],
+      nativeToolRegistry: new NativeToolRegistry(),
+      // no privacyGuard configured — matches production hosts that never
+      // registered a `privacy.redact@1` provider.
+    });
+    const sa = await orch.chat({ userMessage: '#strategist plan?', sessionScope: 'pii2' });
+    assert.equal(
+      sa.delegatedAnswer?.text,
+      'contact jane.doe@example.com for details',
+    );
   });
 });
 
@@ -468,5 +635,198 @@ describe('#332 Layer 3 — forced-delegation obligation (non-streaming)', () => 
     const sa = await orch.chat({ userMessage: 'hello', sessionScope: 's5' });
     assert.equal(asked, false);
     assert.equal(sa.text, 'plain answer');
+  });
+});
+
+describe('#332 gap-closure — standing requiredConsultToolName (L3 real producer)', () => {
+  it('forces the consult from a standing orchestrator-level obligation, with no per-turn expectedDomainTool', async () => {
+    const captured: { q?: string } = {};
+    const tool = strategistTool(async () => 'STANDING-CONSULTED', captured);
+    const { provider, calls } = scriptedCompleteProvider([
+      textResponse('ignoring the specialist'),
+      toolResponse('ask_strategist', { question: 'standing-forced question' }),
+      textResponse('final synthesis'),
+    ]);
+    const orch = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 6,
+      domainTools: [tool],
+      nativeToolRegistry: new NativeToolRegistry(),
+      requiredConsultToolName: 'ask_strategist',
+    });
+    const sa = await orch.chat({
+      userMessage: 'run the strategy process',
+      sessionScope: 's6',
+      // no expectedDomainTool — the STANDING config must be what forces it
+    });
+    assert.equal(captured.q, 'standing-forced question');
+    assert.ok(calls() >= 2, 'the harness escalated at least once');
+    assert.ok(sa.text.length > 0);
+  });
+
+  it('a standing obligation for an unknown tool name is ignored (isolation — never forces a non-whitelisted tool)', async () => {
+    let asked = false;
+    const tool = strategistTool(async () => {
+      asked = true;
+      return 'x';
+    });
+    const { provider } = scriptedCompleteProvider([textResponse('plain answer')]);
+    const orch = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 6,
+      domainTools: [tool],
+      nativeToolRegistry: new NativeToolRegistry(),
+      requiredConsultToolName: 'ask_nonexistent',
+    });
+    const sa = await orch.chat({ userMessage: 'hello', sessionScope: 's7' });
+    assert.equal(asked, false);
+    assert.equal(sa.text, 'plain answer');
+  });
+
+  it('a per-turn expectedDomainTool overrides the standing requiredConsultToolName', async () => {
+    const captured: { strategist?: string; twin?: string } = {};
+    const strategist = strategistTool(async (q) => {
+      captured.strategist = q;
+      return 'S';
+    });
+    const twin = createDomainTool({
+      name: 'ask_twin',
+      description: 'twin',
+      domain: 'x',
+      agentId: 'com.other.agent.twin',
+      agent: {
+        ask: async (q: string) => {
+          captured.twin = q;
+          return 'T';
+        },
+      },
+    });
+    const { provider, calls } = scriptedCompleteProvider([
+      textResponse('ignoring both specialists'),
+      toolResponse('ask_twin', { question: 'per-turn wins' }),
+      textResponse('final synthesis'),
+    ]);
+    const orch = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 6,
+      domainTools: [strategist, twin],
+      nativeToolRegistry: new NativeToolRegistry(),
+      requiredConsultToolName: 'ask_strategist', // standing default
+    });
+    const sa = await orch.chat({
+      userMessage: 'run the process',
+      sessionScope: 's8',
+      expectedDomainTool: 'ask_twin', // per-turn override
+    });
+    assert.equal(captured.twin, 'per-turn wins', 'the per-turn obligation must win');
+    assert.equal(captured.strategist, undefined, 'the standing default must not also fire');
+    assert.ok(calls() >= 2);
+    assert.ok(sa.text.length > 0);
+  });
+});
+
+describe('#332 gap-closure — agentsConsulted on the STREAMING done event (web-ui path)', () => {
+  it('a Direct Line streamed turn carries agentsConsulted on its done event', async () => {
+    const tool = strategistTool(async () => 'STREAMED-VERBATIM');
+    const orch = new Orchestrator({
+      provider: neverCalledProvider(),
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [tool],
+      nativeToolRegistry: new NativeToolRegistry(),
+    });
+    let doneEvent: Extract<ChatStreamEvent, { type: 'done' }> | undefined;
+    for await (const event of orch.chatStream({
+      userMessage: '#strategist plan?',
+      sessionScope: 'stream1',
+    })) {
+      if (event.type === 'done') doneEvent = event;
+    }
+    assert.ok(doneEvent, 'a done event must be yielded');
+    assert.equal(doneEvent?.delegatedAnswer?.text, 'STREAMED-VERBATIM');
+    assert.equal(doneEvent?.agentsConsulted?.length, 1);
+    assert.equal(doneEvent?.agentsConsulted?.[0]?.label, 'Strategist');
+    assert.equal(
+      doneEvent?.agentsConsulted?.[0]?.agentId,
+      'de.byte5.agent.strategist',
+    );
+  });
+
+  it('an ordinary orchestrator-driven streamed turn carries agentsConsulted on its done event', async () => {
+    const tool = strategistTool(async () => 'ORDINARY-STREAMED');
+    // `chatStream` drives the LLM via `provider.stream()` (an SSE-shaped
+    // event protocol), NOT `provider.complete()` — mirrors the pattern in
+    // parallelTool.test.ts. Two scripted calls: 1st yields a tool_use, 2nd
+    // yields the final text.
+    let callIdx = 0;
+    const streams: LlmStreamEvent[][] = [
+      [
+        { type: 'tool_use_start' },
+        { type: 'tool_input_delta', text: JSON.stringify({ question: 'what now?' }) },
+        {
+          type: 'final',
+          response: {
+            content: [
+              { type: 'tool_call', id: 'u1', name: 'ask_strategist', input: { question: 'what now?' } },
+            ],
+            finishReason: 'tool_calls',
+            providerFinishReason: 'tool_use',
+            model: 'test',
+            usage,
+          } as unknown as LlmResponse,
+        },
+      ],
+      [
+        { type: 'text_delta', text: 'final synthesis' },
+        {
+          type: 'final',
+          response: textResponse('final synthesis'),
+        },
+      ],
+    ];
+    const provider = {
+      id: 'anthropic',
+      capabilities: providerCapabilities,
+      complete: async (): Promise<LlmResponse> => {
+        throw new Error('complete() not scripted for this streaming test');
+      },
+      stream: (_req: LlmRequest): AsyncIterable<LlmStreamEvent> => {
+        const events = streams[callIdx] ?? [];
+        callIdx += 1;
+        return {
+          async *[Symbol.asyncIterator]() {
+            for (const ev of events) yield ev;
+          },
+        };
+      },
+      classifyError: () => ({ retryable: false, kind: 'other' as const }),
+    } as unknown as LlmProvider;
+    const orch = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [tool],
+      nativeToolRegistry: new NativeToolRegistry(),
+    });
+    let sawAgentsConsulted = false;
+    for await (const event of orch.chatStream({
+      userMessage: 'consult the strategist',
+      sessionScope: 'stream2',
+    })) {
+      if (event.type === 'done') {
+        sawAgentsConsulted =
+          (event.agentsConsulted?.length ?? 0) === 1 &&
+          event.agentsConsulted?.[0]?.label === 'Strategist';
+      }
+    }
+    assert.ok(sawAgentsConsulted, 'the done event must carry agentsConsulted');
   });
 });

--- a/web-ui/app/_components/chat/AgentsConsultedFooter.tsx
+++ b/web-ui/app/_components/chat/AgentsConsultedFooter.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import type { AgentConsultation } from '../../_lib/chatSessions';
+
+interface AgentsConsultedFooterProps {
+  agents: AgentConsultation[];
+  className?: string;
+}
+
+/**
+ * #332 Layer 1 (gap-closure) — compact, tamper-evident footer showing which
+ * sub-agent(s) were actually consulted this turn. Harness-sourced from the
+ * deterministic run-trace (`Message.agentsConsulted`), never from the
+ * orchestrator's own prose — a fabricated "I asked X" with no real
+ * invocation never reaches this component (the parent renders nothing when
+ * `agentsConsulted` is empty/undefined).
+ *
+ * Mirrors the plain-text fallback (`🔎 Consulted: X ✓ · N steps`) that
+ * channel-sdk provides for connectors without rich UI, but as chips so it
+ * reads well inline with the rest of the message chrome.
+ */
+export function AgentsConsultedFooter({
+  agents,
+  className,
+}: AgentsConsultedFooterProps): React.ReactElement | null {
+  const t = useTranslations('directLine');
+  if (agents.length === 0) return null;
+
+  return (
+    <div
+      className={[
+        'mt-2 flex flex-wrap items-center gap-1.5 text-[11px]',
+        className ?? '',
+      ].join(' ')}
+    >
+      <span className="text-[color:var(--fg-subtle)]">
+        {t('consultedLabel')}
+      </span>
+      {agents.map((a, i) => (
+        <span
+          key={`${a.agentId ?? a.label}-${String(i)}`}
+          className={[
+            'inline-flex items-center gap-1 rounded-full px-2 py-0.5 ring-1',
+            a.status === 'success'
+              ? 'text-[color:var(--success)] ring-[color:var(--success)]/40'
+              : 'text-[color:var(--danger)] ring-[color:var(--danger-edge)]',
+          ].join(' ')}
+        >
+          <span className="font-medium">{a.label}</span>
+          <span aria-hidden="true">{a.status === 'success' ? '✓' : '✗'}</span>
+          {typeof a.toolCalls === 'number' && a.toolCalls > 0 && (
+            <span className="text-[color:var(--fg-subtle)]">
+              · {t('stepsCount', { count: a.toolCalls })}
+            </span>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/web-ui/app/_components/chat/DelegatedAnswerCard.tsx
+++ b/web-ui/app/_components/chat/DelegatedAnswerCard.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import type { DelegatedAnswer } from '../../_lib/chatSessions';
+
+interface DelegatedAnswerCardProps {
+  answer: DelegatedAnswer;
+  className?: string;
+}
+
+/**
+ * #332 Layer 2 (gap-closure) — the harness-owned, attributed verbatim answer
+ * for a Direct-Line turn (`#<agent> <question>`). Rendered as a visually
+ * distinct block, separate from the orchestrator's own `content`, so the
+ * user can see the specialist's exact words — the orchestrator could not
+ * have removed or reworded them.
+ *
+ * Deliberately rendered as plain text (`whitespace-pre-wrap`), NOT through
+ * the Markdown component: the point is byte-for-byte fidelity to what the
+ * specialist actually said, not richly-formatted prose. `status: 'error'`
+ * still renders here — a faithful failure message, never a cover-up.
+ */
+export function DelegatedAnswerCard({
+  answer,
+  className,
+}: DelegatedAnswerCardProps): React.ReactElement {
+  const t = useTranslations('directLine');
+  const isError = answer.status === 'error';
+
+  return (
+    <div
+      className={[
+        'mt-2 rounded-lg px-3 py-2 text-sm ring-1',
+        isError
+          ? 'bg-[color:var(--danger)]/8 ring-[color:var(--danger-edge)]'
+          : 'bg-[color:var(--accent)]/6 ring-[color:var(--accent)]/30',
+        className ?? '',
+      ].join(' ')}
+    >
+      <div
+        className={[
+          'flex items-center gap-1.5 text-[11px] font-medium',
+          isError
+            ? 'text-[color:var(--danger)]'
+            : 'text-[color:var(--accent)]',
+        ].join(' ')}
+      >
+        <span aria-hidden="true">💬</span>
+        <span>{t('delegatedAnswerFrom', { label: answer.label })}</span>
+      </div>
+      <div className="mt-1 whitespace-pre-wrap text-[color:var(--fg-strong)]">
+        {answer.text}
+      </div>
+      <div className="mt-1 text-[10px] italic text-[color:var(--fg-subtle)]">
+        {t('delegatedAnswerCaption')}
+      </div>
+    </div>
+  );
+}

--- a/web-ui/app/_lib/chatSessions.ts
+++ b/web-ui/app/_lib/chatSessions.ts
@@ -165,6 +165,40 @@ export interface PrivacyReceipt {
   bypassedTools?: readonly BypassedToolEntry[];
 }
 
+/**
+ * #332 Layer 1 (gap-closure) — one curated, tamper-evident entry per
+ * sub-agent invocation this turn. Harness-built from the deterministic
+ * run-trace, never from the orchestrator's own prose — a fabricated "I
+ * consulted X" with no real invocation yields an empty array, not a fake
+ * entry here. Mirrors `AgentConsultation` in
+ * `harness-channel-sdk/src/outgoing.ts`.
+ */
+export interface AgentConsultation {
+  /** Stable agent id when resolvable (e.g. `de.byte5.agent.strategist`). */
+  agentId?: string;
+  /** Human label for the footer (e.g. `Strategist`). Always present. */
+  label: string;
+  status: 'success' | 'error';
+  durationMs?: number;
+  /** Count of tool calls the sub-agent made — never the orchestrator's prose. */
+  toolCalls?: number;
+}
+
+/**
+ * #332 Layer 2 (gap-closure) — the harness-owned verbatim sub-agent segment
+ * for a Direct-Line turn (`#<agent> <question>`). Delivered independently of
+ * the orchestrator's own `content`; the orchestrator can neither remove nor
+ * reword it. Mirrors `DelegatedAnswer` in `harness-channel-sdk/src/outgoing.ts`.
+ */
+export interface DelegatedAnswer {
+  agentId: string;
+  label: string;
+  /** The sub-agent's verbatim answer (PII-masked when a privacy guard is
+   *  active), or a faithful failure line when `status === 'error'`. */
+  text: string;
+  status: 'success' | 'error';
+}
+
 /** Slice 2.5 — one entry in `PrivacyReceipt.bypassedTools`. */
 export interface BypassedToolEntry {
   toolName: string;
@@ -371,6 +405,18 @@ export interface Message {
    * answer or it exposed no masked field.
    */
   maskedValues?: readonly string[];
+  /**
+   * #332 Layer 1 (gap-closure) — which sub-agent(s) were actually consulted
+   * this turn, harness-sourced from the run-trace. Rendered as a compact
+   * footer. Absent when no sub-agent ran this turn.
+   */
+  agentsConsulted?: AgentConsultation[];
+  /**
+   * #332 Layer 2 (gap-closure) — the harness-owned, attributed verbatim
+   * answer for a Direct-Line turn. Rendered as a visually distinct block,
+   * separate from `content`. Absent on ordinary turns.
+   */
+  delegatedAnswer?: DelegatedAnswer;
   error?: boolean;
   startedAt: number;
   finishedAt?: number;

--- a/web-ui/app/_lib/chatStreamEvents.ts
+++ b/web-ui/app/_lib/chatStreamEvents.ts
@@ -1,7 +1,9 @@
 'use client';
 
 import type {
+  AgentConsultation,
   ChatSession,
+  DelegatedAnswer,
   DiagramAttachment,
   FollowUpOption,
   KgWalkEdge,
@@ -129,6 +131,10 @@ export type ChatStreamEvent =
       followUpOptions?: FollowUpOption[];
       privacyReceipt?: PrivacyReceipt;
       maskedValues?: readonly string[];
+      /** #332 Layer 1 (gap-closure) — see `Message.agentsConsulted`. */
+      agentsConsulted?: AgentConsultation[];
+      /** #332 Layer 2 (gap-closure) — see `Message.delegatedAnswer`. */
+      delegatedAnswer?: DelegatedAnswer;
     }
   /** #133 (E9) — opaque turn annotation the orchestrator forwarded from a
    *  turn-hook. `channel: 'plan'` carries a live PlanSnapshot. */
@@ -355,6 +361,12 @@ function foldIntoMessage(m: Message, event: ChatStreamEvent): Message {
         ...(event.privacyReceipt ? { privacyReceipt: event.privacyReceipt } : {}),
         ...(event.maskedValues && event.maskedValues.length > 0
           ? { maskedValues: event.maskedValues }
+          : {}),
+        ...(event.agentsConsulted && event.agentsConsulted.length > 0
+          ? { agentsConsulted: event.agentsConsulted }
+          : {}),
+        ...(event.delegatedAnswer
+          ? { delegatedAnswer: event.delegatedAnswer }
           : {}),
         finishedAt: Date.now(),
         streaming: false,

--- a/web-ui/app/chat/page.tsx
+++ b/web-ui/app/chat/page.tsx
@@ -18,9 +18,11 @@ import { useStickToBottom } from '../_lib/useStickToBottom';
 import { AgentPicker } from '../_components/AgentPicker';
 import { AgentUnavailableBanner } from '../_components/AgentUnavailableBanner';
 import { AgentUsagePills } from '../_components/chat/AgentUsagePills';
+import { AgentsConsultedFooter } from '../_components/chat/AgentsConsultedFooter';
 import { AutoPromotedBanner } from '../_components/chat/AutoPromotedBanner';
 import { CaptureDisclosure } from '../_components/chat/CaptureDisclosure';
 import { ConfirmDialog } from '../_components/ConfirmDialog';
+import { DelegatedAnswerCard } from '../_components/chat/DelegatedAnswerCard';
 import { NudgeCard, parseNudgeBlock } from '../_components/chat/NudgeCard';
 import { PlanProgressCard } from '../_components/chat/PlanProgressCard';
 import { RecalledContextCard } from '../_components/chat/RecalledContextCard';
@@ -838,6 +840,19 @@ function MessageRow({
   const liveElapsedSec = showLiveness
     ? Math.max(0, Math.round((liveNow - message.startedAt) / 1000))
     : null;
+  // #332 Layer 2 (gap-closure) — `content` already carries the delegated
+  // answer's verbatim text (backend graceful-degrade design: even a
+  // connector that ignores `delegatedAnswer` shows the specialist's words).
+  // `<DelegatedAnswerCard>` renders that verbatim block attributed; render
+  // the ordinary content block ONLY for whatever the orchestrator added
+  // beyond it (the guarded-mode `▸ omadia note: …` suffix), so the answer
+  // never appears twice. Falls back to the full content if it doesn't start
+  // with the expected prefix (defensive — never silently drops text).
+  const delegatedNote =
+    message.delegatedAnswer &&
+    message.content.startsWith(message.delegatedAnswer.text)
+      ? message.content.slice(message.delegatedAnswer.text.length).replace(/^\s+/, '')
+      : message.content;
 
   return (
     <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
@@ -878,18 +893,24 @@ function MessageRow({
             {(message.steers?.length ?? 0) > 0 && (
               <SteerList steers={message.steers ?? []} />
             )}
-            {message.content.length > 0 ? (
+            {message.delegatedAnswer && (
+              <DelegatedAnswerCard answer={message.delegatedAnswer} />
+            )}
+            {delegatedNote.length > 0 ? (
               /* §2.7: agent narration renders in the prose register
                  (Source Serif 4); headings/tables/code stay structural. */
               <div className="lume-prose">
                 <Markdown
-                  source={message.content}
+                  source={delegatedNote}
                   highlightTerms={message.maskedValues}
                 />
               </div>
             ) : message.streaming ? (
               <StreamingDots />
             ) : null}
+            {message.agentsConsulted && message.agentsConsulted.length > 0 && (
+              <AgentsConsultedFooter agents={message.agentsConsulted} />
+            )}
             {showLiveness && (
               <LivenessRow
                 liveness={message.liveness}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -876,6 +876,12 @@
     "bypassedBytes": "{kb} KB roh",
     "explainerBypassed": "Der Operator hat für mindestens ein Plugin den Privacy-Mode auf »Bypass« gestellt — dessen Tool-Ergebnisse erreichten das Modell unmaskiert. Eingesetzt für vertrauenswürdige interne Quellen, deren Inhalte der Privacy Shield strukturell nicht sinnvoll digestieren kann."
   },
+  "directLine": {
+    "consultedLabel": "🔎 Konsultiert:",
+    "stepsCount": "{count, plural, one {# Schritt} other {# Schritte}}",
+    "delegatedAnswerFrom": "Direkte Antwort von {label}",
+    "delegatedAnswerCaption": "Wortgetreu übermittelt — der Orchestrator kann diese Antwort nicht bearbeiten oder entfernen."
+  },
   "privacyOperator": {
     "eyebrow": "Privacy Operator",
     "heroTitle": "Privacy Shield.",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -876,6 +876,12 @@
     "bypassedBytes": "{kb} KB raw",
     "explainerBypassed": "The operator set Privacy Mode to »Bypass« for at least one plugin — its tool results reached the model unmasked. Used for trusted internal sources whose content the Privacy Shield cannot usefully digest structurally."
   },
+  "directLine": {
+    "consultedLabel": "🔎 Consulted:",
+    "stepsCount": "{count, plural, one {# step} other {# steps}}",
+    "delegatedAnswerFrom": "Direct answer from {label}",
+    "delegatedAnswerCaption": "Delivered verbatim — the orchestrator cannot edit or remove this answer."
+  },
   "privacyOperator": {
     "eyebrow": "Privacy Operator",
     "heroTitle": "Privacy Shield.",


### PR DESCRIPTION
## Summary

Follow-up to #332 (Trustworthy sub-agent delegation), whose L1/L2/L3 core merged in #335. A fresh audit against live code + GitHub state found the "implemented + shipped" status comment was accurate for code-complete but premature on "live-and-verified" — 7 gaps survived uncaught for 18 days. This PR closes the ones with a code fix; the rest are closed by process actions (see below).

## What this PR fixes

1. **agentId enrichment** — `RunAgentInvocation` now carries the resolved `agentId` (was `agentName` only), threaded through `RunTraceCollector.beginInvocation` and all 3 orchestrator call sites, surfaced in the `AgentConsultation` projection. Closes the label-collision gap: two distinctly-configured sub-agents sharing a display label were indistinguishable in `agentsConsulted`.

2. **Direct Line privacy-masking bypass** (a real gap, not just a missing test) — `executeDirectLine` called `tool.handle()` directly, bypassing the `dispatchTool` choke point entirely, so a directed specialist's verbatim answer was **never** routed through the Privacy Shield v4 masking cascade — contradicting the documented "still PII-masked" contract on `DelegatedAnswer`. Fixed by routing through `this.dispatchTool(...)` (the same masking cascade every other domain-tool dispatch already gets). New tests prove PII is masked when a privacy guard is active and pass-through when none is configured (documented contract).

3. **L3 forced-delegation had no production producer** — added an opt-in, standing `requiredConsultToolName` orchestrator option. A per-turn `expectedDomainTool` still wins; absent both → byte-identical prior behaviour.

4. **web-ui rendered neither `agentsConsulted` nor `delegatedAnswer`** — the biggest of the 7 gaps, since it meant no channel reliably showed the trust guarantees to users. Added `<AgentsConsultedFooter>` and `<DelegatedAnswerCard>`, wired through the streaming `done` event (which previously only carried raw `runTrace`; extracted a shared `deriveAgentsConsulted()` helper so streaming and non-streaming channels build the identical harness-sourced array).

## What's closed by process, not code (see linked issue/PR activity)

- **Teams connector "PR #19"** — turned out to be based on a stale premise: private plugins were split into individual repos as a hard rule; `byte5ai/omadia-channel-teams` is now standalone and already contains this work plus further fixes. Closed the old monorepo PR as superseded: byte5ai/omadia-byte5-plugins#19.
- **Sticky direct-line mode** (an explicitly-deferred v1 open question) — now has a real tracking issue instead of only living in chat history/memory: #445.
- **Live production deployment verification** — out of scope for this PR (needs operator/production access); tracked as a follow-up.

## Verification

- Full middleware suite: 3823/3823 passing (0 regressions), `npm run lint` clean.
- `directLine.test.ts`: 20 → 30 tests (agentId enrichment, PII-masking, standing-obligation, streaming-parity).
- web-ui: `tsc --noEmit` clean, `eslint` 0 errors, `npm run i18n:check` OK (1671 keys, en/de), `next build` succeeds.

Refs #332