### PR TITLE
fix(web-ui): make session-warning "Relogin now" actually re-login (#412)

### DIFF
--- a/web-ui/app/_components/SessionWatcher.tsx
+++ b/web-ui/app/_components/SessionWatcher.tsx
@@ -50,10 +50,20 @@ function formatClock(ms: number): string {
   return `${minutes.toString()}:${seconds.toString().padStart(2, '0')}`;
 }
 
-/** Bounce to the login page, preserving the current location as `return`. */
+/**
+ * Bounce to the login page to re-authenticate, preserving the current
+ * location as `return`.
+ *
+ * The `reauth=1` flag marks this as an *explicit* re-login. During the
+ * warning phase the current session is still (briefly) valid, so without
+ * this flag the login page would see a live session and immediately bounce
+ * back here — making the "Relogin now" button look like it does nothing.
+ * The flag tells /login to show the form regardless.
+ */
 function relogin(): void {
   const target = window.location.pathname + window.location.search;
-  window.location.assign(`/login?return=${encodeURIComponent(target)}`);
+  const query = new URLSearchParams({ return: target, reauth: '1' });
+  window.location.assign(`/login?${query.toString()}`);
 }
 
 export function SessionWatcher(): React.ReactElement | null {

--- a/web-ui/app/_components/__tests__/SessionWatcher.test.tsx
+++ b/web-ui/app/_components/__tests__/SessionWatcher.test.tsx
@@ -105,6 +105,42 @@ describe('<SessionWatcher />', () => {
     expect(screen.getByText(EXPIRED_TITLE)).toBeInTheDocument();
   });
 
+  it('"Relogin now" navigates to /login with a reauth flag and return path', async () => {
+    // The current session is still valid during the warning phase, so the
+    // reauth flag is what stops /login from bouncing straight back (#412).
+    // jsdom's location.assign is non-configurable, so swap the whole object.
+    const assign = vi.fn();
+    const realLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { pathname: '/chat', search: '?thread=42', assign },
+    });
+    try {
+      mockAuthedSession(2 * 60); // inside the warn window
+      renderWithIntl(<SessionWatcher />, { locale: 'de' });
+      await flush();
+
+      const cta = screen.getByRole('button', { name: 'Jetzt neu anmelden' });
+      await act(async () => {
+        cta.click();
+      });
+
+      expect(assign).toHaveBeenCalledTimes(1);
+      const url = new URL(
+        assign.mock.calls[0]?.[0] as string,
+        'http://localhost',
+      );
+      expect(url.pathname).toBe('/login');
+      expect(url.searchParams.get('reauth')).toBe('1');
+      expect(url.searchParams.get('return')).toBe('/chat?thread=42');
+    } finally {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: realLocation,
+      });
+    }
+  });
+
   it('renders nothing and never probes on the /login page', async () => {
     mockUsePathname.mockReturnValue('/login');
     mockAuthedSession(2 * 60);

--- a/web-ui/app/login/__tests__/page.test.tsx
+++ b/web-ui/app/login/__tests__/page.test.tsx
@@ -95,6 +95,20 @@ describe('<LoginPage /> redirect on mount', () => {
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith('/'));
   });
 
+  it('does not redirect on an explicit ?reauth=1 even when still authenticated', async () => {
+    // The "Relogin now" button lands here with a live session; the page
+    // must show the form instead of bouncing back (issue #412).
+    mockSearchParamsGet.mockImplementation((key) =>
+      key === 'reauth' ? '1' : key === 'return' ? '/chat' : null,
+    );
+    mockGetSessionStatus.mockImplementation(authedSession);
+
+    renderWithIntl(<LoginPage />);
+
+    await waitFor(() => expect(mockGetAuthProviders).toHaveBeenCalled());
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
   it('does not redirect an unauthenticated visitor', async () => {
     mockSearchParamsGet.mockReturnValue(null);
     mockGetSessionStatus.mockImplementation(unauthedSession);

--- a/web-ui/app/login/page.tsx
+++ b/web-ui/app/login/page.tsx
@@ -67,6 +67,13 @@ function LoginPageInner(): React.ReactElement {
     return raw;
   }, [searchParams]);
 
+  // Explicit re-login request (SessionWatcher's "Relogin now" button). The
+  // current session may still be valid, but the operator asked to mint a
+  // fresh token — so skip the already-authenticated short-circuit below and
+  // render the login form. Without this the page would bounce straight back
+  // and the button would appear to do nothing.
+  const forceReauth = searchParams.get('reauth') === '1';
+
   const [state, setState] = useState<State>({ kind: 'loading' });
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -85,7 +92,7 @@ function LoginPageInner(): React.ReactElement {
           getAuthProviders(),
         ]);
         if (cancelled) return;
-        if (session.authenticated) {
+        if (session.authenticated && !forceReauth) {
           // Guard against ?return=/login which would re-enter this page
           // and loop. Only reachable via hand-crafted URLs today.
           router.replace(returnPath === '/login' ? '/' : returnPath);
@@ -118,7 +125,7 @@ function LoginPageInner(): React.ReactElement {
     return () => {
       cancelled = true;
     };
-  }, [returnPath, router]);
+  }, [returnPath, router, forceReauth]);
 
   async function handlePasswordSubmit(
     e: React.FormEvent<HTMLFormElement>,


### PR DESCRIPTION
## Summary

Fixes #412 — clicking **"Relogin now"** ("Jetzt neu anmelden") in the session-expiry warning card did nothing.

The card appears ~5 min *before* expiry, while the `omadia_session` cookie is **still valid**. The button navigated to `/login?return=…`, but the login page probes the session on mount, saw a live session, and immediately `router.replace(returnPath)` — bouncing the operator straight back with no re-auth and no visible change.

## Fix

- **`SessionWatcher.tsx`** — `relogin()` now appends `reauth=1` to the login URL, marking it an *explicit* re-login.
- **`login/page.tsx`** — reads `forceReauth = searchParams.get('reauth') === '1'` and skips the already-authenticated short-circuit when set, so the login form renders and a fresh token can be minted.

The same `relogin()` is shared by the expired-overlay button, so this also hardens that path against the clock-skew race where the server cookie briefly outlives the client-side expiry clock. Normal proxy/401 redirects on genuine expiry are untouched (they don't set the flag).

## Testing

- Added a login-page test: no redirect on `?reauth=1` even when still authenticated.
- Added a SessionWatcher test: the button navigates to `/login` with `reauth=1` and the preserved `return` path.
- `vitest` on both files: 12 passed · `tsc --noEmit`: clean · `eslint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)