### PR TITLE
fix(mcp): store registry bearer tokens in the vault, not the DB row (#463)

### DIFF
--- a/middleware/migrations/0020_mcp_registry_token_vault.sql
+++ b/middleware/migrations/0020_mcp_registry_token_vault.sql
@@ -1,0 +1,20 @@
+-- Epic #459 / issue #463 item 5 — move MCP registry bearer tokens out of the DB.
+--
+-- `mcp_registries.token` (added in 0010) stored the optional bearer credential
+-- for a catalog source as PLAINTEXT. That is the wrong storage class for a
+-- secret-at-rest: registry tokens now live ONLY in the SecretVault (namespace
+-- `@omadia/mcp-registry`, key = registry id), exactly like schema-driven MCP
+-- server-config secrets (0019, namespace `@omadia/mcp-config`).
+--
+-- Expand/contract: this migration is the EXPAND step. The column is retained
+-- (nullable) as the source for the one-time, idempotent boot backfill
+-- (`backfillMcpRegistryTokens`), which moves any legacy plaintext token into
+-- the vault and NULLs the column. Application code no longer reads or writes
+-- this column. Dropping it is the CONTRACT step, deferred to a later release
+-- once every deployment has booted through the backfill at least once.
+COMMENT ON COLUMN mcp_registries.token IS
+  'DEPRECATED (issue #463 item 5). Registry bearer tokens live in the SecretVault '
+  '(@omadia/mcp-registry, key = registry id), never here. Retained only as the '
+  'backfill source; NULLed at boot and dropped in a later migration.';
+
+-- rollback: COMMENT ON COLUMN mcp_registries.token IS NULL;

--- a/middleware/packages/harness-orchestrator/src/registry/agentGraphStore.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/agentGraphStore.ts
@@ -285,7 +285,11 @@ export interface McpRegistryRow {
   readonly name: string;
   readonly url: string;
   readonly authKind: 'none' | 'bearer';
-  readonly token: string | null;
+  // NOTE: the bearer token is intentionally absent from the persisted row.
+  // It is a secret-at-rest and lives ONLY in the SecretVault (namespace
+  // `@omadia/mcp-registry`, key = id) — see McpRegistrySecretService and
+  // migration 0020 (issue #463 item 5). Resolve it at runtime when building
+  // the McpRegistryClient's McpRegistryConfig.
   /** Catalog-API dialect selecting the client normalizer (issue #455 W7). */
   readonly kind: 'official' | 'smithery' | 'generic';
   readonly createdAt: Date;
@@ -395,7 +399,8 @@ interface McpRegistryDbRow {
   name: string;
   url: string;
   auth_kind: 'none' | 'bearer';
-  token: string | null;
+  // token column still exists (migration 0020, expand phase) but is never
+  // mapped onto McpRegistryRow — the secret lives in the vault, not the row.
   kind?: 'official' | 'smithery' | 'generic';
   created_at: Date;
 }
@@ -406,7 +411,6 @@ function mapMcpRegistry(r: McpRegistryDbRow): McpRegistryRow {
     name: r.name,
     url: r.url,
     authKind: r.auth_kind,
-    token: r.token,
     kind: r.kind ?? 'generic',
     createdAt: r.created_at,
   };
@@ -1405,20 +1409,39 @@ export class AgentGraphStore {
     readonly name: string;
     readonly url: string;
     readonly authKind?: 'none' | 'bearer';
-    readonly token?: string | null;
     readonly kind?: 'official' | 'smithery' | 'generic';
   }): Promise<McpRegistryRow> {
+    // The bearer token is NOT written here — the caller persists it to the
+    // vault via McpRegistrySecretService.setToken(row.id, token) after create.
     const { rows } = await this.pool.query<McpRegistryDbRow>(
-      `INSERT INTO mcp_registries (name, url, auth_kind, token, kind)
-       VALUES ($1,$2,COALESCE($3,'none'),$4,COALESCE($5,'generic'))
+      `INSERT INTO mcp_registries (name, url, auth_kind, kind)
+       VALUES ($1,$2,COALESCE($3,'none'),COALESCE($4,'generic'))
        RETURNING *`,
-      [input.name, input.url, input.authKind ?? null, input.token ?? null, input.kind ?? null],
+      [input.name, input.url, input.authKind ?? null, input.kind ?? null],
     );
     return mapMcpRegistry(rows[0]!);
   }
 
   async deleteMcpRegistry(id: string): Promise<void> {
+    // The vault token (if any) is removed by the caller via
+    // McpRegistrySecretService.deleteToken(id) — the store has no vault handle.
     await this.pool.query('DELETE FROM mcp_registries WHERE id = $1', [id]);
+  }
+
+  // ── Legacy plaintext token backfill (issue #463 item 5) ────────────────────
+  // Source + clear helpers for the one-time boot migration of any pre-0020
+  // plaintext `mcp_registries.token` into the vault. Kept separate from
+  // mapMcpRegistry so the secret never rides on the ordinary row type.
+
+  async listLegacyMcpRegistryTokens(): Promise<readonly { id: string; token: string }[]> {
+    const { rows } = await this.pool.query<{ id: string; token: string }>(
+      `SELECT id, token FROM mcp_registries WHERE token IS NOT NULL`,
+    );
+    return rows;
+  }
+
+  async clearLegacyMcpRegistryToken(id: string): Promise<void> {
+    await this.pool.query('UPDATE mcp_registries SET token = NULL WHERE id = $1', [id]);
   }
 
   /** Bump the config epoch of every grant on a server (epic #459, codex

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -238,6 +238,10 @@ import { NativeToolRegistry } from '@omadia/orchestrator';
 import { McpManager, type McpCallLogEntry, type McpServerConfig } from '@omadia/orchestrator';
 import { McpOAuthService } from './services/mcpOAuthService.js';
 import { McpConfigService } from './services/mcpConfigService.js';
+import {
+  McpRegistrySecretService,
+  backfillMcpRegistryTokens,
+} from './services/mcpRegistrySecretService.js';
 import { AgentGraphStore } from '@omadia/orchestrator';
 import { registerDbSubAgentTools } from './agents/subAgentToolHydration.js';
 import {
@@ -1445,6 +1449,22 @@ async function main(): Promise<void> {
     ? new McpConfigService({ graph: new AgentGraphStore(graphPool), vault: secretVault })
     : undefined;
 
+  // MCP registry bearer tokens live in the vault, never on the DB row
+  // (issue #463 item 5). Move any legacy plaintext token (pre-0020) into the
+  // vault on boot — idempotent, a no-op once the column is NULL.
+  const mcpRegistrySecrets = graphPool
+    ? new McpRegistrySecretService({ vault: secretVault })
+    : undefined;
+  if (graphPool && mcpRegistrySecrets) {
+    await backfillMcpRegistryTokens({
+      store: new AgentGraphStore(graphPool),
+      secrets: mcpRegistrySecrets,
+      log: (m) => console.log(m),
+    }).catch((e: unknown) =>
+      console.error('[middleware] mcp registry token backfill failed:', e),
+    );
+  }
+
   // Phase 5B: publish so dynamic-imported channel plugins can late-resolve
   // the tenant id via ctx.services.get('graphTenantId') instead of being
   // threaded through constructor Deps.
@@ -2279,6 +2299,7 @@ async function main(): Promise<void> {
       // Generic MCP OAuth (epic #459 W9) — begin/callback/manual-client routes.
       ...(mcpOAuthService ? { mcpOAuth: mcpOAuthService, mcpOAuthUserKey } : {}),
       ...(mcpConfigService ? { mcpConfig: mcpConfigService } : {}),
+      ...(mcpRegistrySecrets ? { mcpRegistrySecrets } : {}),
     }),
   );
   console.log(

--- a/middleware/src/routes/agentBuilder.ts
+++ b/middleware/src/routes/agentBuilder.ts
@@ -19,6 +19,7 @@ import {
   type AgentRow,
   type ConfigStore,
   type McpConfigField,
+  type McpRegistryRow,
   type McpServerConfig,
   type McpServerRow,
   type OrchestratorRegistry,
@@ -42,7 +43,11 @@ import {
   MCP_SEVERITIES_NEEDING_ACK,
   refreshMcpGrantPolicy,
 } from '../services/mcpGrantPolicy.js';
-import { McpRegistryClient, McpRegistryError } from '../services/mcpRegistryClient.js';
+import {
+  McpRegistryClient,
+  McpRegistryError,
+  type McpRegistryConfig,
+} from '../services/mcpRegistryClient.js';
 import { scanDiscoveredTools } from '../services/mcpToolGuard.js';
 import { scanSkillForRisks } from '../services/skillGuard.js';
 import { importSkillMarkdown } from '../services/skillImport.js';
@@ -116,6 +121,15 @@ export interface AgentBuilderRouterOptions {
     secretsSet(server: McpServerRow): Promise<Record<string, boolean>>;
     getConfigHeaders(cfg: McpServerConfig): Promise<Record<string, string>>;
     getConfigEnv(cfg: McpServerConfig): Promise<Record<string, string>>;
+  };
+  /** Vault-backed MCP registry bearer tokens (issue #463 item 5). The token is
+   *  never persisted on the DB row — the create route stores it here, the
+   *  catalog/search proxy resolves it here, delete removes it. Absent → the
+   *  registry is treated as keyless. */
+  readonly mcpRegistrySecrets?: {
+    getToken(registryId: string): Promise<string | undefined>;
+    setToken(registryId: string, value: string): Promise<void>;
+    deleteToken(registryId: string): Promise<void>;
   };
 }
 
@@ -219,6 +233,23 @@ export function createAgentBuilderRouter(
   // with a 5-minute cache, so registry tokens never reach the browser.
   const mcpRegistryClient = new McpRegistryClient();
 
+  // Build the client's runtime config from the persisted row, resolving the
+  // bearer token from the Vault (issue #463 item 5) — it is never on the row.
+  async function toRegistryConfig(row: McpRegistryRow): Promise<McpRegistryConfig> {
+    const token =
+      row.authKind === 'bearer' && options.mcpRegistrySecrets
+        ? ((await options.mcpRegistrySecrets.getToken(row.id)) ?? null)
+        : null;
+    return {
+      id: row.id,
+      name: row.name,
+      url: row.url,
+      authKind: row.authKind,
+      token,
+      kind: row.kind,
+    };
+  }
+
   /**
    * Epic #459 — the config fields a server declares, self-healed on demand, plus
    * which REQUIRED fields still have no value. A marketplace server imported
@@ -240,7 +271,7 @@ export function createAgentBuilderRouter(
       try {
         const registry = (await graph.listMcpRegistries()).find((r) => r.id === row.registryId);
         if (registry) {
-          const entry = await mcpRegistryClient.resolve(registry, row.name);
+          const entry = await mcpRegistryClient.resolve(await toRegistryConfig(registry), row.name);
           if (entry.configSchema && entry.configSchema.length > 0) {
             schema = entry.configSchema;
             await graph.setMcpServerConfigSchema(row.id, schema as never);
@@ -1706,13 +1737,19 @@ export function createAgentBuilderRouter(
     try {
       const registries = await l.graph.listMcpRegistries();
       res.json({
-        registries: registries.map((r) => ({
-          id: r.id,
-          name: r.name,
-          url: r.url,
-          authKind: r.authKind,
-          hasToken: r.token !== null && r.token !== '',
-        })),
+        registries: await Promise.all(
+          registries.map(async (r) => ({
+            id: r.id,
+            name: r.name,
+            url: r.url,
+            authKind: r.authKind,
+            // presence only — the token value itself never leaves the vault
+            hasToken:
+              r.authKind === 'bearer' && options.mcpRegistrySecrets
+                ? (await options.mcpRegistrySecrets.getToken(r.id)) != null
+                : false,
+          })),
+        ),
       });
     } catch (err) {
       fail(res, err);
@@ -1730,13 +1767,21 @@ export function createAgentBuilderRouter(
         res.status(400).json({ error: 'invalid_registry' });
         return;
       }
-      const row = await l.graph.createMcpRegistry({
-        name,
-        url,
-        authKind: b.authKind === 'bearer' ? 'bearer' : 'none',
-        token: typeof b.token === 'string' && b.token !== '' ? b.token : null,
+      const authKind = b.authKind === 'bearer' ? 'bearer' : 'none';
+      const token =
+        authKind === 'bearer' && typeof b.token === 'string' && b.token !== '' ? b.token : null;
+      const row = await l.graph.createMcpRegistry({ name, url, authKind });
+      // Secret-at-rest: the bearer token goes to the Vault, never the DB row.
+      if (token && options.mcpRegistrySecrets) {
+        await options.mcpRegistrySecrets.setToken(row.id, token);
+      }
+      res.json({
+        id: row.id,
+        name: row.name,
+        url: row.url,
+        authKind: row.authKind,
+        hasToken: token !== null,
       });
-      res.json({ id: row.id, name: row.name, url: row.url, authKind: row.authKind, hasToken: row.token !== null });
     } catch (err) {
       fail(res, err);
     }
@@ -1746,8 +1791,10 @@ export function createAgentBuilderRouter(
     const l = live(res);
     if (!l) return;
     try {
-      await l.graph.deleteMcpRegistry(str(req.params.id));
-      mcpRegistryClient.invalidate(str(req.params.id));
+      const registryId = str(req.params.id);
+      await l.graph.deleteMcpRegistry(registryId);
+      await options.mcpRegistrySecrets?.deleteToken(registryId);
+      mcpRegistryClient.invalidate(registryId);
       res.status(204).end();
     } catch (err) {
       fail(res, err);
@@ -1767,7 +1814,7 @@ export function createAgentBuilderRouter(
         return;
       }
       const q = typeof req.query['q'] === 'string' ? req.query['q'] : '';
-      const entries = await mcpRegistryClient.search(registry, q);
+      const entries = await mcpRegistryClient.search(await toRegistryConfig(registry), q);
       res.json({ entries });
     } catch (err) {
       if (err instanceof McpRegistryError) {
@@ -1793,7 +1840,7 @@ export function createAgentBuilderRouter(
         res.status(404).json({ error: 'mcp_registry_not_found' });
         return;
       }
-      const entry = await mcpRegistryClient.resolve(registry, catalogEntryId);
+      const entry = await mcpRegistryClient.resolve(await toRegistryConfig(registry), catalogEntryId);
       if (!entry.transport || !entry.endpoint) {
         res.status(422).json({ error: 'mcp_catalog_entry_not_importable', id: entry.id });
         return;

--- a/middleware/src/services/mcpRegistrySecretService.ts
+++ b/middleware/src/services/mcpRegistrySecretService.ts
@@ -1,0 +1,78 @@
+/**
+ * Epic #459 / issue #463 item 5 — Vault-backed MCP registry bearer tokens.
+ *
+ * A catalog source (mcp_registries) may carry an optional bearer token. That
+ * token is a secret-at-rest and must NEVER live on the DB row. It is stored
+ * ONLY in the Vault (namespace `@omadia/mcp-registry`, key = registry id),
+ * mirroring `McpConfigService` (server-config secrets, `@omadia/mcp-config`).
+ *
+ * The runtime `McpRegistryConfig` consumed by `McpRegistryClient` still carries
+ * a `token` field — the caller resolves it from this service when assembling
+ * the config, instead of reading a plaintext column.
+ */
+
+interface Vault {
+  get(namespace: string, key: string): Promise<string | undefined>;
+  set(namespace: string, key: string, value: string): Promise<void>;
+  deleteKey?(namespace: string, key: string): Promise<void>;
+}
+
+const VAULT_NS = '@omadia/mcp-registry';
+
+export interface McpRegistrySecretServiceDeps {
+  readonly vault: Vault;
+}
+
+export class McpRegistrySecretService {
+  constructor(private readonly deps: McpRegistrySecretServiceDeps) {}
+
+  /** The bearer token for a registry, or undefined when none is stored. */
+  async getToken(registryId: string): Promise<string | undefined> {
+    return this.deps.vault.get(VAULT_NS, registryId);
+  }
+
+  async setToken(registryId: string, value: string): Promise<void> {
+    await this.deps.vault.set(VAULT_NS, registryId, value);
+  }
+
+  async deleteToken(registryId: string): Promise<void> {
+    await this.deps.vault.deleteKey?.(VAULT_NS, registryId);
+  }
+}
+
+/** Minimal store surface the backfill needs — satisfied by AgentGraphStore. */
+export interface McpRegistryTokenBackfillStore {
+  listLegacyMcpRegistryTokens(): Promise<readonly { id: string; token: string }[]>;
+  clearLegacyMcpRegistryToken(id: string): Promise<void>;
+}
+
+export interface BackfillMcpRegistryTokensDeps {
+  readonly store: McpRegistryTokenBackfillStore;
+  readonly secrets: McpRegistrySecretService;
+  readonly log?: (msg: string) => void;
+}
+
+/**
+ * One-time, idempotent migration of legacy plaintext `mcp_registries.token`
+ * values into the Vault. Safe to run on every boot: after the first pass the
+ * column is NULL, so subsequent passes find nothing and do nothing. Ordered
+ * write-then-clear so a crash mid-backfill leaves the token recoverable from
+ * the (still-populated) column on the next boot rather than lost.
+ */
+export async function backfillMcpRegistryTokens(
+  deps: BackfillMcpRegistryTokensDeps,
+): Promise<number> {
+  const log = deps.log ?? (() => undefined);
+  const legacy = await deps.store.listLegacyMcpRegistryTokens();
+  if (legacy.length === 0) return 0;
+  let moved = 0;
+  for (const { id, token } of legacy) {
+    await deps.secrets.setToken(id, token);
+    await deps.store.clearLegacyMcpRegistryToken(id);
+    moved += 1;
+  }
+  log(
+    `[mcp-registry] backfilled ${String(moved)} legacy plaintext registry token(s) into the vault`,
+  );
+  return moved;
+}

--- a/middleware/test/mcpRegistrySecretService.test.ts
+++ b/middleware/test/mcpRegistrySecretService.test.ts
@@ -1,0 +1,97 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  McpRegistrySecretService,
+  backfillMcpRegistryTokens,
+  type McpRegistryTokenBackfillStore,
+} from '../src/services/mcpRegistrySecretService.js';
+
+/** In-memory Vault double keyed by `${namespace}${key}`. */
+function fakeVault() {
+  const store = new Map<string, string>();
+  const k = (ns: string, key: string) => `${ns}${key}`;
+  return {
+    store,
+    get: async (ns: string, key: string) => store.get(k(ns, key)),
+    set: async (ns: string, key: string, value: string) => {
+      store.set(k(ns, key), value);
+    },
+    deleteKey: async (ns: string, key: string) => {
+      store.delete(k(ns, key));
+    },
+  };
+}
+
+const NS = '@omadia/mcp-registry';
+
+describe('McpRegistrySecretService', () => {
+  it('stores the token in the registry vault namespace keyed by registry id', async () => {
+    const vault = fakeVault();
+    const svc = new McpRegistrySecretService({ vault });
+    await svc.setToken('reg-1', 'sk-secret');
+    assert.equal(vault.store.get(`${NS}reg-1`), 'sk-secret');
+    assert.equal(await svc.getToken('reg-1'), 'sk-secret');
+  });
+
+  it('returns undefined when no token is stored', async () => {
+    const svc = new McpRegistrySecretService({ vault: fakeVault() });
+    assert.equal(await svc.getToken('missing'), undefined);
+  });
+
+  it('deletes the token', async () => {
+    const vault = fakeVault();
+    const svc = new McpRegistrySecretService({ vault });
+    await svc.setToken('reg-1', 'sk-secret');
+    await svc.deleteToken('reg-1');
+    assert.equal(await svc.getToken('reg-1'), undefined);
+    assert.equal(vault.store.size, 0);
+  });
+});
+
+/** Store double recording legacy-token reads and the columns it cleared. */
+function fakeBackfillStore(
+  initial: { id: string; token: string }[],
+): McpRegistryTokenBackfillStore & { cleared: string[]; remaining: () => { id: string; token: string }[] } {
+  let rows = [...initial];
+  const cleared: string[] = [];
+  return {
+    cleared,
+    remaining: () => rows,
+    listLegacyMcpRegistryTokens: async () => rows,
+    clearLegacyMcpRegistryToken: async (id: string) => {
+      cleared.push(id);
+      rows = rows.filter((r) => r.id !== id);
+    },
+  };
+}
+
+describe('backfillMcpRegistryTokens', () => {
+  it('moves every legacy plaintext token into the vault and clears the column', async () => {
+    const vault = fakeVault();
+    const secrets = new McpRegistrySecretService({ vault });
+    const store = fakeBackfillStore([
+      { id: 'reg-1', token: 'tok-1' },
+      { id: 'reg-2', token: 'tok-2' },
+    ]);
+
+    const moved = await backfillMcpRegistryTokens({ store, secrets });
+
+    assert.equal(moved, 2);
+    assert.equal(await secrets.getToken('reg-1'), 'tok-1');
+    assert.equal(await secrets.getToken('reg-2'), 'tok-2');
+    assert.deepEqual(store.cleared.sort(), ['reg-1', 'reg-2']);
+    assert.equal(store.remaining().length, 0);
+  });
+
+  it('is a no-op when there is nothing to migrate (idempotent second pass)', async () => {
+    const vault = fakeVault();
+    const secrets = new McpRegistrySecretService({ vault });
+    const store = fakeBackfillStore([{ id: 'reg-1', token: 'tok-1' }]);
+
+    assert.equal(await backfillMcpRegistryTokens({ store, secrets }), 1);
+    // second pass: column already cleared, nothing left to do
+    assert.equal(await backfillMcpRegistryTokens({ store, secrets }), 0);
+    assert.equal(store.cleared.length, 1);
+  });
+});


### PR DESCRIPTION
Closes #463 (item 5 — the last open bit of the MCP epic).

## The missing bit

The MCP marketplace registry layer (issue #455) stores an optional bearer token for a catalog source as **plaintext** in `mcp_registries.token` (migration `0010`) and reads it directly when proxying catalog/search. That is the wrong storage class for a secret-at-rest — and unlike a purely-latent gap, the registry CRUD + catalog/search routes in `agentBuilder.ts` are wired, so an operator adding a bearer registry writes a real plaintext credential today.

## Plan (implemented here)

Mirror the schema-driven MCP **server-config** secret pattern (`0019`, `McpConfigService`, namespace `@omadia/mcp-config`): the secret lives **only** in the SecretVault, never on the DB row.

| Step | Change |
|---|---|
| Vault service | `middleware/src/services/mcpRegistrySecretService.ts` — `McpRegistrySecretService.{getToken,setToken,deleteToken}` over namespace `@omadia/mcp-registry`, key = registry id. |
| Store | `agentGraphStore.ts` — drop `token` from `McpRegistryRow`, the `INSERT`, and `mapMcpRegistry`; add `listLegacyMcpRegistryTokens` / `clearLegacyMcpRegistryToken` for the backfill. |
| Routes | `agentBuilder.ts` — create route writes the token to the vault; list route derives `hasToken` from the vault; delete purges it; catalog/search resolve it via a new `toRegistryConfig(row)` helper when building `McpRegistryConfig`. |
| Backfill | `backfillMcpRegistryTokens` — idempotent boot migration of any pre-existing plaintext token into the vault, then NULLs the column (write-then-clear: a crash mid-backfill leaves the value recoverable). Wired at boot next to `McpConfigService`. |
| Migration | `0020_mcp_registry_token_vault.sql` — **expand** step: documents the column as deprecated (app no longer reads/writes it). The `DROP COLUMN` is the **contract** step, deferred to a later release once every deployment has booted through the backfill. |

## Why expand/contract instead of dropping the column now

Migrations are pure SQL applied before the app boots, so they cannot move a secret into the (app-level) vault. The safe sequence is: keep the column → boot backfill moves any legacy token to the vault and NULLs it → a later migration drops the empty column. After this PR the column is written-never and NULL in practice.

## Verification

- `middleware/test/mcpRegistrySecretService.test.ts` — set/get/delete roundtrip + backfill moves-and-clears + idempotent second pass (5 tests, green).
- `npx tsc --noEmit` clean across the middleware workspace; existing `mcpRegistryClient` tests unchanged (16, green).

## Follow-ups (not in this PR)

- Contract migration to `DROP COLUMN mcp_registries.token` in a later release.
- Deploy verification: add a bearer registry, confirm no plaintext token in `mcp_registries`, and that catalog/search still authenticates.
