### PR TITLE
feat(scripts): add checklist reconciliation to the issue-triage workflow

### DIFF
--- a/scripts/issue-triage.workflow.mjs
+++ b/scripts/issue-triage.workflow.mjs
@@ -1,35 +1,52 @@
 /**
- * Issue triage workflow (Claude Code "Workflow" tool script).
+ * Issue triage + checklist workflow (Claude Code "Workflow" tool script).
  *
- * Fans out one codebase-grounded investigator per open GitHub issue, then runs an
- * adversarial fact-checker over each draft comment before anything is posted. Each
- * investigator reads the issue + its comments (REST only) and verifies claims against
- * a read-only checkout of the target branch, so every file path / symbol / "already
- * shipped" statement in the resulting comment is checked before a human sees it.
+ * Two capabilities, selectable via `mode`:
+ *
+ *  - TRIAGE: fans out one codebase-grounded investigator per open issue, then an
+ *    adversarial fact-checker over each draft comment. Each investigator reads the
+ *    issue + comments (REST only) and verifies every path/symbol/"already shipped"
+ *    claim against a read-only checkout before a human sees it.
+ *  - CHECKLIST: for every unchecked `- [ ]` in an issue's body and comments, verify
+ *    against the code whether it is DONE on the current branch and, if so, tick it.
+ *    Each issue agent returns per-target edits (the full body/comment text, verbatim
+ *    except satisfied boxes flipped to `[x]`) + one-line evidence per tick, then an
+ *    adversarial verifier re-checks each tick. The CALLER applies each edit only if
+ *    the diff vs the live text is PURELY `[ ]`→`[x]` (a safety gate against content
+ *    rewrites) — see applyChecklistEdit contract below.
  *
  * This is NOT a standalone Node script — it runs inside the Claude Code Workflow tool
  * (agent()/parallel()/pipeline()/log() are provided by that runtime). Run it with:
  *
  *   Workflow({ scriptPath: "scripts/issue-triage.workflow.mjs", args: {
  *     repo:     "<owner>/<name>",              // any GitHub repo, e.g. "octo/hello"
- *     repoPath: "/abs/path/to/checkout",       // read-only checkout of the branch to triage against
- *     headSha:  "<short-sha>",                 // the commit the checkout is on (for comment footers)
+ *     repoPath: "/abs/path/to/checkout",       // read-only checkout of the branch to review against
+ *     headSha:  "<short-sha>",                 // the commit the checkout is on (for footers)
+ *     mode:     "full",                        // "full" (triage+checklist) | "triage" | "checklist"
  *     issues:   [ { number, title, labels: [], comments: <int>, updated: "YYYY-MM-DD" }, ... ]
  *   }})
  *
  * The caller gathers the issue list up front (e.g. `gh api repos/<repo>/issues?state=open`)
- * and passes it in. The workflow returns { headSha, triaged: [...] } where each entry
- * carries the triage verdict plus a verified `finalComment` ready to post via REST.
- * The workflow itself never writes to GitHub — posting/closing is done by the caller.
+ * and passes it in. The workflow returns { headSha, mode, triaged, checklist }:
+ *   - triaged[]:   { number, ...verdict, verified, finalComment }  — post finalComment via REST.
+ *   - checklist[]: { number, verified, summaryMarkdown, edits[] }  where each edit is
+ *       { target: "body" | "comment", commentId, updatedText, changed[], evidence[] }.
+ * The workflow itself NEVER writes to GitHub — posting/ticking/closing is done by the caller.
+ *
+ * Caller's diff-safety gate (applyChecklistEdit): fetch the live body/comment text; split
+ * both into lines; require equal line count; every line that differs MUST be an exact
+ * `[ ]`→`[x]` flip (same prefix/label). If anything else differs, DROP the edit and log it.
  */
 
 export const meta = {
   name: 'issue-triage',
-  description: 'Triage open GitHub issues and draft verified implementation-detail comments',
-  whenToUse: 'Backlog triage: assign priority/status/effort to every open issue and attach a code-grounded implementation plan, fact-checked against the current branch before posting.',
+  description: 'Triage open GitHub issues and verify/tick their acceptance-criteria checkboxes',
+  whenToUse: 'Backlog triage (priority/status/effort + code-grounded plan) and/or checklist reconciliation: verify every open checkbox against the current branch and tick the ones that are demonstrably done.',
   phases: [
     { title: 'Triage', detail: 'one codebase-grounded investigator per issue' },
     { title: 'Verify', detail: 'adversarial fact-check of every draft comment' },
+    { title: 'Checklist', detail: 'verify each checkbox against the code' },
+    { title: 'Checklist Verify', detail: 'adversarial re-check of every proposed tick' },
   ],
 }
 
@@ -37,6 +54,7 @@ const input = typeof args === 'string' ? JSON.parse(args) : args
 const REPO = input.repo
 const REPO_PATH = input.repoPath
 const HEAD = input.headSha
+const MODE = input.mode || 'full' // 'full' | 'triage' | 'checklist'
 const issues = input.issues
 
 const TRIAGE_SCHEMA = {
@@ -65,6 +83,43 @@ const VERIFY_SCHEMA = {
     verified: { type: 'boolean', description: 'true if the corrected comment is safe to post publicly' },
     issuesFound: { type: 'string', description: 'summary of factual errors you found and fixed; empty if none' },
     commentMarkdown: { type: 'string', description: 'the final, corrected comment body' },
+  },
+}
+
+const EDIT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['target', 'commentId', 'updatedText', 'changed', 'evidence'],
+  properties: {
+    target: { type: 'string', enum: ['body', 'comment'] },
+    commentId: { type: ['integer', 'null'], description: 'REST comment id when target=comment; null when target=body' },
+    updatedText: { type: 'string', description: 'the FULL body/comment markdown, verbatim except satisfied `- [ ]` flipped to `- [x]`. Change nothing else.' },
+    changed: { type: 'array', items: { type: 'string' }, description: 'the exact checkbox label text of each box you flipped' },
+    evidence: { type: 'array', items: { type: 'string' }, description: 'one line of code evidence (file:symbol or commit/PR) per flipped box, same order as changed' },
+  },
+}
+
+const CHECKLIST_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['number', 'nothingToTick', 'edits', 'summaryMarkdown'],
+  properties: {
+    number: { type: 'integer' },
+    nothingToTick: { type: 'boolean', description: 'true when no unchecked box is demonstrably satisfied' },
+    edits: { type: 'array', items: EDIT_SCHEMA },
+    summaryMarkdown: { type: 'string', description: 'a short comment summarizing ticked vs still-open with evidence; empty when nothingToTick' },
+  },
+}
+
+const CHECKLIST_VERIFY_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['number', 'verified', 'edits', 'summaryMarkdown'],
+  properties: {
+    number: { type: 'integer' },
+    verified: { type: 'boolean', description: 'true if the surviving ticks are all safe to apply' },
+    edits: { type: 'array', items: EDIT_SCHEMA, description: 'only the ticks you CONFIRMED are satisfied; drop the rest' },
+    summaryMarkdown: { type: 'string', description: 'the corrected summary comment reflecting only confirmed ticks; empty if none survive' },
   },
 }
 
@@ -140,21 +195,94 @@ ${t.commentMarkdown}
 Triage metadata for context: priority=${t.priority}, status=${t.status}, rationale: ${t.rationale}`
 }
 
-log(`Triaging ${issues.length} open issues against ${HEAD}`)
+function checklistPrompt(issue) {
+  return `You are reconciling the CHECKBOXES on GitHub issue #${issue.number} of ${REPO}: "${issue.title}". Your job: find every unchecked \`- [ ]\` box in the issue body AND every comment, decide which are DEMONSTRABLY done on the current branch, and produce edits that tick ONLY those.
 
-const results = await pipeline(
-  issues,
-  (issue) => agent(triagePrompt(issue), { label: `triage:#${issue.number}`, phase: 'Triage', schema: TRIAGE_SCHEMA }),
-  (t, issue) => {
-    if (!t) return null
-    if (t.skipComment || !t.commentMarkdown.trim()) return { ...t, title: issue.title, verified: false, issuesFound: '', finalComment: '' }
-    return agent(verifyPrompt(t, issue), { label: `verify:#${issue.number}`, phase: 'Verify', schema: VERIFY_SCHEMA })
-      .then(v => v
-        ? { ...t, title: issue.title, verified: v.verified, issuesFound: v.issuesFound, finalComment: v.commentMarkdown }
-        : { ...t, title: issue.title, verified: false, issuesFound: 'verify agent failed', finalComment: '' })
-  }
-)
+## Ground rules (hard constraints)
+- GitHub API: REST only via \`gh api repos/...\`. Fetch the body with \`gh api repos/${REPO}/issues/${issue.number} --jq .body\` and comments with \`gh api repos/${REPO}/issues/${issue.number}/comments --jq '.[] | {id, body}'\`. NEVER use \`gh issue\`/\`gh pr\`/\`gh search\`/GraphQL. Do NOT write anything — you only return data.
+- Read-only checkout at ${REPO_PATH} @ ${HEAD}. Verify with rg/fd/cat and \`git log\`. Do not modify files or switch branches.
 
-const ok = results.filter(Boolean)
-log(`Done: ${ok.length}/${issues.length} triaged, ${ok.filter(r => r.verified).length} comments verified for posting, ${ok.filter(r => r.skipComment).length} skipped`)
-return { headSha: HEAD, triaged: ok }
+## What counts as "done" (be strict — a wrong tick is worse than an unticked box)
+- Tick a box ONLY when the code on this branch demonstrably satisfies it, with concrete evidence: a real file:symbol, a route, a migration, a passing test in the repo, or a merged commit/PR you verified in \`git log\`.
+- A box that asserts runtime/deployment/manual verification ("verified on the deployed environment", "smoke test on main", "operator confirms …") may be ticked ONLY if a test in the repo covers it; otherwise leave it unchecked.
+- If you are not sure, LEAVE IT UNCHECKED. Do not tick aspirational, partial, or design-decision boxes.
+
+## Output — one edit per target you change
+For each body/comment that has at least one box you are ticking, return an edit:
+- target: "body" or "comment"; commentId: the REST comment id (null for body).
+- updatedText: the FULL original markdown of that body/comment, VERBATIM, except each satisfied \`- [ ]\` flipped to \`- [x]\`. Change NOTHING else — not one character of wording, whitespace, ordering, or already-checked boxes. (The caller rejects any edit whose diff is not purely \`[ ]\`→\`[x]\`.)
+- changed: the exact label text of each box you flipped (the text after the checkbox).
+- evidence: one line per flipped box (same order) — file:symbol / migration / test / commit that proves it.
+
+Set nothingToTick=true (and edits=[], summaryMarkdown="") when no box is demonstrably satisfied — that is the expected outcome for most not-yet-built issues.
+
+When you do tick boxes, also return summaryMarkdown — a short English comment:
+"## Checklist review\\nTicked N of M open checkboxes verified done on \`${HEAD}\`:\\n- <label> — <evidence>\\n...\\nStill open: <count> (unchanged).\\n\\n---\\n_Automated checklist reconciliation against \`${HEAD}\`; ticks applied after adversarial verification._"
+
+Return the structured result.`
+}
+
+function checklistVerifyPrompt(c, issue) {
+  return `You are an adversarial verifier for CHECKBOX ticks about to be applied to GitHub issue #${c.number} ("${issue.title}") of ${REPO}. Someone proposes flipping the boxes below from \`[ ]\` to \`[x]\`. REFUTE each: assume it is NOT done until the code proves it.
+
+Check against the read-only checkout at ${REPO_PATH} (@ ${HEAD}) with rg/fd/cat/\`git log\`, and cross-check the live text via REST (\`gh api repos/${REPO}/issues/${c.number}/comments\`).
+
+For EACH proposed tick:
+- Confirm the cited evidence actually exists and actually satisfies the box's wording. Drop the tick if the evidence is missing, unrelated, only partial, or merely a plan/intention.
+- Drop any tick whose box requires runtime/deployment/manual confirmation unless a repo test covers it.
+
+Then rebuild the edits keeping ONLY confirmed ticks:
+- Re-derive each updatedText from the CURRENT live text (fetch it), flipping only the confirmed boxes, changing nothing else. Keep commentId/target correct. If an edit ends up with no confirmed ticks, drop the whole edit.
+- Rewrite summaryMarkdown to list only confirmed ticks (empty string if none survive).
+- verified=true if the surviving edits are safe to apply; false to abort applying anything for this issue.
+
+PROPOSED TICKS:
+<<<
+${JSON.stringify({ edits: c.edits, summaryMarkdown: c.summaryMarkdown }, null, 2)}
+>>>`
+}
+
+async function runTriage() {
+  log(`Triaging ${issues.length} issues against ${HEAD}`)
+  const results = await pipeline(
+    issues,
+    (issue) => agent(triagePrompt(issue), { label: `triage:#${issue.number}`, phase: 'Triage', schema: TRIAGE_SCHEMA }),
+    (t, issue) => {
+      if (!t) return null
+      if (t.skipComment || !t.commentMarkdown.trim()) return { ...t, title: issue.title, verified: false, issuesFound: '', finalComment: '' }
+      return agent(verifyPrompt(t, issue), { label: `verify:#${issue.number}`, phase: 'Verify', schema: VERIFY_SCHEMA })
+        .then(v => v
+          ? { ...t, title: issue.title, verified: v.verified, issuesFound: v.issuesFound, finalComment: v.commentMarkdown }
+          : { ...t, title: issue.title, verified: false, issuesFound: 'verify agent failed', finalComment: '' })
+    }
+  )
+  const ok = results.filter(Boolean)
+  log(`Triage done: ${ok.length}/${issues.length}, ${ok.filter(r => r.verified).length} comments ready, ${ok.filter(r => r.skipComment).length} skipped`)
+  return ok
+}
+
+async function runChecklist() {
+  log(`Reconciling checkboxes on ${issues.length} issues against ${HEAD}`)
+  const results = await pipeline(
+    issues,
+    (issue) => agent(checklistPrompt(issue), { label: `checklist:#${issue.number}`, phase: 'Checklist', schema: CHECKLIST_SCHEMA }),
+    (c, issue) => {
+      if (!c) return null
+      if (c.nothingToTick || !c.edits || c.edits.length === 0) {
+        return { number: issue.number, title: issue.title, verified: false, edits: [], summaryMarkdown: '', nothingToTick: true }
+      }
+      return agent(checklistVerifyPrompt(c, issue), { label: `checklist-verify:#${issue.number}`, phase: 'Checklist Verify', schema: CHECKLIST_VERIFY_SCHEMA })
+        .then(v => v
+          ? { number: issue.number, title: issue.title, verified: v.verified, edits: v.edits || [], summaryMarkdown: v.summaryMarkdown || '', nothingToTick: (v.edits || []).length === 0 }
+          : { number: issue.number, title: issue.title, verified: false, edits: [], summaryMarkdown: '', nothingToTick: true })
+    }
+  )
+  const ok = results.filter(Boolean)
+  const ticks = ok.reduce((n, r) => n + r.edits.reduce((m, e) => m + (e.changed?.length || 0), 0), 0)
+  log(`Checklist done: ${ok.filter(r => r.verified && r.edits.length).length} issues with ticks, ${ticks} boxes to flip`)
+  return ok
+}
+
+const triaged = MODE === 'full' || MODE === 'triage' ? await runTriage() : []
+const checklist = MODE === 'full' || MODE === 'checklist' ? await runChecklist() : []
+return { headSha: HEAD, mode: MODE, triaged, checklist }


### PR DESCRIPTION
## What

Extends `scripts/issue-triage.workflow.mjs` (added in #465) with a generic **checklist reconciliation** capability, selectable via a new `mode` arg: `"full"` (triage + checklist), `"triage"`, or `"checklist"`.

## Why

Issue and comment checklists drift: acceptance-criteria and epic wave boxes stay `- [ ]` long after the work ships. This adds a verified, auditable pass that ticks the ones that are actually done — and, crucially, leaves the rest alone.

## How it works

Per issue, pipelined:
1. **Checklist** — an agent enumerates every unchecked `- [ ]` in the issue body and all comments, and for each decides whether it is *demonstrably* done on the current branch (real file:symbol / migration / passing test / merged commit). It returns per-target edits: the full body/comment text **verbatim except satisfied boxes flipped to `[x]`**, plus one line of evidence per tick. Aspirational, partial, or runtime/deploy-only boxes are left unchecked.
2. **Checklist Verify** — an adversarial verifier re-checks every proposed tick (assume-not-done), dropping any whose evidence is missing, unrelated, partial, or needs a running instance not covered by a repo test.

The workflow never writes to GitHub. The caller applies each edit only if the diff vs the **live** text is purely `[ ]`→`[x]` (a safety gate against content rewrites) and posts a per-issue "Checklist review" summary comment listing every tick with its evidence.

## Proven out on this repo

Ran in `checklist` mode against all 28 open issues @ `main`. Result: only the MCP epic (#459) had verified-done boxes — its W0–W6 master wave checklist and the "PR #464 merged" box were ticked (8 flips, evidence per wave), summary posted. Every other issue was correctly left untouched (their criteria are unbuilt future work). Zero edits tripped the safety gate.

## Notes

- Not a standalone Node script; runs inside the Claude Code Workflow tool.
- Return shape gains `checklist[]` alongside `triaged[]`; the caller's diff-safety + apply contract is documented in the file header.
