### PR TITLE
fix(web-ui): humanize provider errors across chat surfaces (#403)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -54,9 +54,13 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 - **web-ui/chat**: provider errors (quota, rate-limit, billing) are now surfaced
   as the provider's human-readable sentence across all chat surfaces — the main
-  chat bubble, the stream toast, the builder chat, the preview chat, and the
-  default simple builder intake — with a translated generic fallback, instead of
-  the raw HTTP status and JSON envelope (#403).
+  chat bubble, the builder chat, the preview chat, and the default simple
+  builder intake — with a translated generic fallback, instead of the raw HTTP
+  status and JSON envelope. On the primary path the orchestrator failure arrives
+  as an in-band error event on an already-streaming 200 response; the background
+  stream toast now finishes that turn as a failure showing the same humanized
+  sentence, instead of reporting it as 'done' (a successful turn) as it did
+  before (#403).
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,14 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   translates through `llmProviderSeam`, including streaming final-event usage
   telemetry and provider-based retry classification.
 
+### Fixed
+
+- **web-ui/chat**: provider errors (quota, rate-limit, billing) are now surfaced
+  as the provider's human-readable sentence across all chat surfaces — the main
+  chat bubble, the stream toast, the builder chat, the preview chat, and the
+  default simple builder intake — with a translated generic fallback, instead of
+  the raw HTTP status and JSON envelope (#403).
+
 ---
 
 ## [0.54.0] - 2026-07-06

--- a/web-ui/app/_components/StreamRunner.tsx
+++ b/web-ui/app/_components/StreamRunner.tsx
@@ -176,7 +176,7 @@ async function runOneTurn(claim: ClaimedRequest, depsRef: DepsRef): Promise<void
         msg = fallback || `HTTP ${String(res.status)}`;
       }
       applyEvent({ type: 'error', message: msg });
-      store.finish(sessionId, 'error', msg);
+      store.finish(sessionId, 'error', humanizeProviderError(msg, t('errorProviderGeneric')));
       finalizePending(depsRef.current.sessions, sessionId, pendingMessageId);
       return;
     }
@@ -216,9 +216,10 @@ async function runOneTurn(claim: ClaimedRequest, depsRef: DepsRef): Promise<void
       applyEvent({ type: 'error', message: t('errorAborted') });
       store.finish(sessionId, 'aborted');
     } else {
+      const { t } = depsRef.current;
       const msg = err instanceof Error ? err.message : String(err);
       applyEvent({ type: 'error', message: msg });
-      store.finish(sessionId, 'error', msg);
+      store.finish(sessionId, 'error', humanizeProviderError(msg, t('errorProviderGeneric')));
     }
   } finally {
     finalizePending(depsRef.current.sessions, sessionId, pendingMessageId);

--- a/web-ui/app/_components/StreamRunner.tsx
+++ b/web-ui/app/_components/StreamRunner.tsx
@@ -66,7 +66,7 @@ export function StreamRunner(): null {
   return null;
 }
 
-interface DepsRef {
+export interface DepsRef {
   current: {
     t: ReturnType<typeof useTranslations>;
     sessions: ReturnType<typeof useChatSessionsCtx>;
@@ -74,7 +74,12 @@ interface DepsRef {
   };
 }
 
-async function runOneTurn(claim: ClaimedRequest, depsRef: DepsRef): Promise<void> {
+// Exported for unit tests (#403): drives the fetch + NDJSON-drain loop and the
+// terminal store outcome. Not part of the component's public surface otherwise.
+export async function runOneTurn(
+  claim: ClaimedRequest,
+  depsRef: DepsRef,
+): Promise<void> {
   const { request, signal } = claim;
   const { sessionId, pendingMessageId, message, agentSlug } = request;
   const { store } = depsRef.current;
@@ -87,6 +92,11 @@ async function runOneTurn(claim: ClaimedRequest, depsRef: DepsRef): Promise<void
   let tokensIn = 0;
   let tokensOut = 0;
   let cacheTokens = 0;
+  // #403 — an in-band `error` event on a 200 stream still means the turn
+  // failed. Capture its humanized message here so the terminal record (and
+  // the background stream toast) can report the failure instead of a false
+  // 'done'. Stays null on a clean turn.
+  let inbandErrorMessage: string | null = null;
 
   const applyEvent = (event: ChatStreamEvent): void => {
     const { sessions: liveSessions, t } = depsRef.current;
@@ -96,6 +106,7 @@ async function runOneTurn(claim: ClaimedRequest, depsRef: DepsRef): Promise<void
     let outgoing = event;
     if (event.type === 'error') {
       const clean = humanizeProviderError(event.message, t('errorProviderGeneric'));
+      inbandErrorMessage = clean;
       if (clean !== event.message) {
         console.warn('[chat] provider error', event.message);
         outgoing = { ...event, message: clean };
@@ -209,7 +220,11 @@ async function runOneTurn(claim: ClaimedRequest, depsRef: DepsRef): Promise<void
         /* ignore */
       }
     }
-    store.finish(sessionId, 'done');
+    if (inbandErrorMessage !== null) {
+      store.finish(sessionId, 'error', inbandErrorMessage);
+    } else {
+      store.finish(sessionId, 'done');
+    }
   } catch (err) {
     if ((err as Error).name === 'AbortError') {
       const { t } = depsRef.current;

--- a/web-ui/app/_components/StreamRunner.tsx
+++ b/web-ui/app/_components/StreamRunner.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { applyStreamEvent, type ChatStreamEvent } from '../_lib/chatStreamEvents';
+import { humanizeProviderError } from '../_lib/providerErrorMessage';
 import { useChatSessionsCtx } from '../_lib/chatSessionsContext';
 import {
   type ClaimedRequest,
@@ -88,8 +89,19 @@ async function runOneTurn(claim: ClaimedRequest, depsRef: DepsRef): Promise<void
   let cacheTokens = 0;
 
   const applyEvent = (event: ChatStreamEvent): void => {
-    const { sessions: liveSessions } = depsRef.current;
-    applyStreamEvent(liveSessions, sessionId, pendingMessageId, event);
+    const { sessions: liveSessions, t } = depsRef.current;
+    // A provider error arrives as a raw wrapped string (status + JSON blob).
+    // Reduce it to the embedded human sentence before it reaches the bubble;
+    // keep the raw text in the console for debugging.
+    let outgoing = event;
+    if (event.type === 'error') {
+      const clean = humanizeProviderError(event.message, t('errorProviderGeneric'));
+      if (clean !== event.message) {
+        console.warn('[chat] provider error', event.message);
+        outgoing = { ...event, message: clean };
+      }
+    }
+    applyStreamEvent(liveSessions, sessionId, pendingMessageId, outgoing);
 
     // Accumulate per-turn signals BEFORE deriving the patch so the
     // patch has fresh numbers.

--- a/web-ui/app/_components/__tests__/StreamRunner.test.tsx
+++ b/web-ui/app/_components/__tests__/StreamRunner.test.tsx
@@ -1,0 +1,157 @@
+import { act, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { UseChatSessionsResult } from '../../_lib/chatSessions';
+import {
+  StreamStoreProvider,
+  useStreamStore,
+  type ClaimedRequest,
+} from '../../_lib/streamStore';
+import { runOneTurn, type DepsRef } from '../StreamRunner';
+
+/**
+ * The primary #403 path (verified end to end): the orchestrator fails while the
+ * server is ALREADY streaming a 200 response, so the failure arrives as an
+ * in-band NDJSON `error` event rather than a non-200 status or a thrown fetch.
+ * `runOneTurn` humanizes that message for the chat bubble, but must ALSO finish
+ * the stream record as 'error' carrying the humanized sentence — otherwise the
+ * background stream toast reports success for a turn that actually failed.
+ *
+ * These tests assert the terminal STORE outcome (phase + record.error), not the
+ * rendered bubble, because the bug was a state-transition bug: the bubble was
+ * already clean before the fix.
+ */
+
+type StoreValue = ReturnType<typeof useStreamStore>;
+
+/** Render a real <StreamStoreProvider> and expose its live context value. */
+function captureStore(): { latest: () => StoreValue } {
+  let value: StoreValue | null = null;
+  function Capture(): null {
+    value = useStreamStore();
+    return null;
+  }
+  render(
+    <StreamStoreProvider>
+      <Capture />
+    </StreamStoreProvider>,
+  );
+  return {
+    latest(): StoreValue {
+      if (!value) throw new Error('store value never captured');
+      return value;
+    },
+  };
+}
+
+/**
+ * Minimal chat-sessions stub. `runOneTurn` only ever touches `mutateActive`
+ * (via applyStreamEvent + finalizePending) and `persistActive`; everything else
+ * on the context is irrelevant to the store-outcome decision under test.
+ */
+function stubSessions(): UseChatSessionsResult {
+  return {
+    mutateActive: vi.fn(),
+    persistActive: vi.fn().mockResolvedValue(undefined),
+  } as unknown as UseChatSessionsResult;
+}
+
+const GENERIC_FALLBACK = 'Something went wrong talking to the provider.';
+
+/** Translation stub — only `errorProviderGeneric` matters here. */
+const tStub = ((key: string): string =>
+  key === 'errorProviderGeneric' ? GENERIC_FALLBACK : key) as unknown as DepsRef['current']['t'];
+
+/** A 200 response whose body is exactly `body`, then EOF. */
+function ndjson200(body: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'application/x-ndjson' },
+  });
+}
+
+/**
+ * Start a turn, claim it, and run it against the real store with a stub
+ * sessions/translations. Returns the sessionId so the caller can read the
+ * terminal record.
+ */
+async function drive(store: StoreValue, response: Response): Promise<string> {
+  const sessionId = 'session-403';
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue(response);
+
+  let claim: ClaimedRequest | undefined;
+  await act(async () => {
+    store.startTurn({ sessionId, pendingMessageId: 'pending-1', message: 'hi' });
+    claim = store.claimRequest();
+  });
+  if (!claim) throw new Error('claimRequest returned nothing');
+
+  const depsRef: DepsRef = {
+    current: { t: tStub, sessions: stubSessions(), store },
+  };
+  await act(async () => {
+    await runOneTurn(claim as ClaimedRequest, depsRef);
+  });
+  return sessionId;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('runOneTurn — in-band error on a 200 stream (#403)', () => {
+  it('finishes the stream record as error with the humanized sentence', async () => {
+    const { latest } = captureStore();
+    const store = latest();
+
+    // The exact failing input from the reviewer: an Anthropic billing error
+    // wrapped in a status prefix + JSON envelope, delivered as a single NDJSON
+    // `error` line with NO trailing newline (so it lands in the `tail` parse).
+    const rawProviderError =
+      '400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API."}}';
+    const body = JSON.stringify({ type: 'error', message: rawProviderError });
+
+    const sessionId = await drive(store, ndjson200(body));
+
+    const record = latest().get(sessionId);
+    expect(record?.phase).toBe('error');
+    expect(record?.error).toBe(
+      'Your credit balance is too low to access the Anthropic API.',
+    );
+  });
+
+  it('also captures an in-band error delivered on a newline-terminated line', async () => {
+    const { latest } = captureStore();
+    const store = latest();
+
+    const rawProviderError =
+      '429 You exceeded your current quota, please check your plan and billing details.';
+    const body = `${JSON.stringify({ type: 'error', message: rawProviderError })}\n`;
+
+    const sessionId = await drive(store, ndjson200(body));
+
+    const record = latest().get(sessionId);
+    expect(record?.phase).toBe('error');
+    expect(record?.error).toBe(
+      'You exceeded your current quota, please check your plan and billing details.',
+    );
+  });
+
+  it('still finishes as done when the stream carries no error event', async () => {
+    const { latest } = captureStore();
+    const store = latest();
+
+    const body = `${JSON.stringify({
+      type: 'done',
+      answer: 'all good',
+      toolCalls: 0,
+      iterations: 1,
+    })}\n`;
+
+    const sessionId = await drive(store, ndjson200(body));
+
+    const record = latest().get(sessionId);
+    expect(record?.phase).toBe('done');
+    expect(record?.error).toBeUndefined();
+  });
+});

--- a/web-ui/app/_lib/__tests__/providerErrorMessage.test.ts
+++ b/web-ui/app/_lib/__tests__/providerErrorMessage.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractProviderErrorMessage,
+  humanizeProviderError,
+} from '../providerErrorMessage';
+
+/**
+ * The chat surfaces used to render the raw provider error verbatim — HTTP
+ * status, JSON envelope and all (issue #403). `extractProviderErrorMessage`
+ * peels that wrapping off and returns the embedded human sentence, or null so
+ * the caller can fall back to a translated generic notice.
+ */
+describe('extractProviderErrorMessage', () => {
+  it('strips the status prefix from an OpenAI plain-text error', () => {
+    const raw =
+      '429 You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.';
+    expect(extractProviderErrorMessage(raw)).toBe(
+      'You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.',
+    );
+  });
+
+  it('extracts error.message from an Anthropic JSON envelope', () => {
+    const raw =
+      '400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."},"request_id":"req_011Ccf9tf8Q1EgNHAcSZF7zP"}';
+    expect(extractProviderErrorMessage(raw)).toBe(
+      'Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.',
+    );
+  });
+
+  it('returns a top-level message when there is no nested error', () => {
+    expect(
+      extractProviderErrorMessage('500 {"message":"internal error"}'),
+    ).toBe('internal error');
+  });
+
+  it('returns null for a JSON envelope carrying no message', () => {
+    expect(
+      extractProviderErrorMessage('503 {"error":{"type":"overloaded_error"}}'),
+    ).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(extractProviderErrorMessage('')).toBeNull();
+    expect(extractProviderErrorMessage('   ')).toBeNull();
+  });
+
+  it('leaves an already-clean human message untouched', () => {
+    const clean = 'This build is paused on issue #12 — resolve it to continue.';
+    expect(extractProviderErrorMessage(clean)).toBe(clean);
+  });
+});
+
+describe('humanizeProviderError', () => {
+  it('returns the extracted message when one is present', () => {
+    expect(humanizeProviderError('429 quota exceeded', 'fallback')).toBe(
+      'quota exceeded',
+    );
+  });
+
+  it('returns the fallback when nothing can be extracted', () => {
+    expect(
+      humanizeProviderError('503 {"error":{"type":"overloaded_error"}}', 'fallback'),
+    ).toBe('fallback');
+  });
+});

--- a/web-ui/app/_lib/__tests__/providerErrorMessage.test.ts
+++ b/web-ui/app/_lib/__tests__/providerErrorMessage.test.ts
@@ -20,12 +20,47 @@ describe('extractProviderErrorMessage', () => {
     );
   });
 
+  it('returns null for a status-less rate-limit envelope (no raw JSON leak)', () => {
+    // A real path: streamingRetry surfaces exactly this status-less envelope.
+    // The old brace-substring hunt leaked it verbatim to the chat surfaces.
+    expect(
+      extractProviderErrorMessage(
+        '{"type":"error","error":{"type":"rate_limit_error"}}',
+      ),
+    ).toBeNull();
+  });
+
+  it('leaves a status-less application message that embeds a JSON object untouched', () => {
+    const raw = 'Agent stopped: {"message":"waiting"}';
+    expect(extractProviderErrorMessage(raw)).toBe(raw);
+  });
+
+  it('mines error.message from a status-less JSON envelope', () => {
+    expect(
+      extractProviderErrorMessage('{"error":{"message":"Overloaded"}}'),
+    ).toBe('Overloaded');
+  });
+
   it('extracts error.message from an Anthropic JSON envelope', () => {
     const raw =
       '400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."},"request_id":"req_011Ccf9tf8Q1EgNHAcSZF7zP"}';
     expect(extractProviderErrorMessage(raw)).toBe(
       'Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.',
     );
+  });
+
+  it('extracts error.message from a status-prefixed credit-balance envelope', () => {
+    expect(
+      extractProviderErrorMessage(
+        '400 {"error":{"message":"Your credit balance is too low."}}',
+      ),
+    ).toBe('Your credit balance is too low.');
+  });
+
+  it('strips the status prefix from a short plain-text quota error', () => {
+    expect(
+      extractProviderErrorMessage('429 You exceeded your current quota.'),
+    ).toBe('You exceeded your current quota.');
   });
 
   it('returns a top-level message when there is no nested error', () => {
@@ -51,6 +86,11 @@ describe('extractProviderErrorMessage', () => {
 
   it('leaves a status-less application message with non-JSON braces untouched', () => {
     const raw = 'Validation failed for {field: name}';
+    expect(extractProviderErrorMessage(raw)).toBe(raw);
+  });
+
+  it('leaves a plain application message with no braces untouched', () => {
+    const raw = 'Connection to the middleware was lost.';
     expect(extractProviderErrorMessage(raw)).toBe(raw);
   });
 

--- a/web-ui/app/_lib/__tests__/providerErrorMessage.test.ts
+++ b/web-ui/app/_lib/__tests__/providerErrorMessage.test.ts
@@ -40,6 +40,20 @@ describe('extractProviderErrorMessage', () => {
     ).toBeNull();
   });
 
+  it('still returns null for a status-prefixed envelope with no surfaceable message', () => {
+    expect(extractProviderErrorMessage('400 {"type":"error"}')).toBeNull();
+  });
+
+  it('leaves a status-less application message that contains valid JSON braces untouched', () => {
+    const raw = 'Build failed with diagnostics {"code":"TS2304","file":"slot.ts"}';
+    expect(extractProviderErrorMessage(raw)).toBe(raw);
+  });
+
+  it('leaves a status-less application message with non-JSON braces untouched', () => {
+    const raw = 'Validation failed for {field: name}';
+    expect(extractProviderErrorMessage(raw)).toBe(raw);
+  });
+
   it('returns null for an empty string', () => {
     expect(extractProviderErrorMessage('')).toBeNull();
     expect(extractProviderErrorMessage('   ')).toBeNull();

--- a/web-ui/app/_lib/providerErrorMessage.ts
+++ b/web-ui/app/_lib/providerErrorMessage.ts
@@ -1,0 +1,69 @@
+/**
+ * Provider errors reach the chat surfaces as a raw string that wraps the one
+ * sentence a user can act on in transport noise: a leading HTTP status
+ * ("429 ..."), and — for JSON-bodied providers like Anthropic — the full
+ * response envelope. `extractProviderErrorMessage` peels both away and returns
+ * the embedded human-readable message, provider-agnostic (works for the OpenAI
+ * plain-text shape and the Anthropic JSON shape alike).
+ *
+ * It is deliberately a no-op on strings that are already clean: an input with
+ * no status prefix and no JSON envelope is returned unchanged, so the builder's
+ * own human-readable error events (e.g. `builder.paused_on_issue`) pass through
+ * untouched. It returns `null` only when the string looks like a wrapped
+ * provider error yet carries no message we can surface — that is the caller's
+ * cue to fall back to a translated generic notice.
+ */
+export function extractProviderErrorMessage(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  // Strip a leading HTTP status ("429 ...", "400 ...").
+  const withoutStatus = trimmed.replace(/^\d{3}\s+/, '');
+  const hadStatus = withoutStatus !== trimmed;
+
+  // Anthropic-style: a JSON envelope carries the sentence under `error.message`
+  // (or a top-level `message`).
+  const jsonStart = withoutStatus.indexOf('{');
+  const jsonEnd = withoutStatus.lastIndexOf('}');
+  if (jsonStart !== -1 && jsonEnd > jsonStart) {
+    const message = messageFromJson(withoutStatus.slice(jsonStart, jsonEnd + 1));
+    if (message) return message;
+    // A JSON envelope we can't pull a message from is unusable noise.
+    return null;
+  }
+
+  // OpenAI-style: plain-text sentence behind the status prefix.
+  if (hadStatus) {
+    return withoutStatus.length > 0 ? withoutStatus : null;
+  }
+
+  // No status, no JSON envelope: already a clean human string — pass through.
+  return trimmed;
+}
+
+/**
+ * Convenience wrapper for UI call sites: returns the extracted provider message
+ * when one is present, otherwise the caller's translated generic fallback.
+ */
+export function humanizeProviderError(raw: string, fallback: string): string {
+  return extractProviderErrorMessage(raw) ?? fallback;
+}
+
+function messageFromJson(candidate: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(candidate);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const obj = parsed as Record<string, unknown>;
+  const nested = obj.error;
+  if (nested && typeof nested === 'object') {
+    const message = (nested as Record<string, unknown>).message;
+    if (typeof message === 'string' && message.trim()) return message.trim();
+  }
+  const top = obj.message;
+  if (typeof top === 'string' && top.trim()) return top.trim();
+  return null;
+}

--- a/web-ui/app/_lib/providerErrorMessage.ts
+++ b/web-ui/app/_lib/providerErrorMessage.ts
@@ -6,12 +6,20 @@
  * the embedded human-readable message, provider-agnostic (works for the OpenAI
  * plain-text shape and the Anthropic JSON shape alike).
  *
- * It is deliberately a no-op on strings that are already clean: an input with
- * no status prefix and no JSON envelope is returned unchanged, so the builder's
- * own human-readable error events (e.g. `builder.paused_on_issue`) pass through
- * untouched. It returns `null` only when the string looks like a wrapped
- * provider error yet carries no message we can surface — that is the caller's
- * cue to fall back to a translated generic notice.
+ * A leading 3-digit HTTP status is the only reliable evidence that a string is a
+ * wrapped transport error rather than an application message. The function keys
+ * its "give up" behaviour on that fact:
+ *
+ *   - Empty / whitespace input returns `null`.
+ *   - A JSON envelope is mined for `error.message`, then a top-level `message`;
+ *     a match is returned whether or not a status prefix was present.
+ *   - When nothing surfaceable can be pulled out, a status-prefixed input
+ *     returns `null` (it IS a wrapped provider error carrying no message — the
+ *     caller shows the generic fallback), while an input with no status prefix
+ *     is returned unchanged. A string with no status prefix is treated as an
+ *     application message, braces or not, and is never destroyed — so the
+ *     builder's own human-readable events (e.g. `builder.paused_on_issue`) and
+ *     brace-bearing diagnostics pass through untouched.
  */
 export function extractProviderErrorMessage(raw: string): string | null {
   const trimmed = raw.trim();
@@ -28,8 +36,10 @@ export function extractProviderErrorMessage(raw: string): string | null {
   if (jsonStart !== -1 && jsonEnd > jsonStart) {
     const message = messageFromJson(withoutStatus.slice(jsonStart, jsonEnd + 1));
     if (message) return message;
-    // A JSON envelope we can't pull a message from is unusable noise.
-    return null;
+    // A JSON envelope we can't pull a message from is only noise when a status
+    // prefix marks it as a wrapped provider error; without one it is an
+    // application message that merely contains braces — hand it back untouched.
+    return hadStatus ? null : trimmed;
   }
 
   // OpenAI-style: plain-text sentence behind the status prefix.

--- a/web-ui/app/_lib/providerErrorMessage.ts
+++ b/web-ui/app/_lib/providerErrorMessage.ts
@@ -1,25 +1,28 @@
 /**
  * Provider errors reach the chat surfaces as a raw string that wraps the one
- * sentence a user can act on in transport noise: a leading HTTP status
+ * sentence a user can act on in transport noise: an optional leading HTTP status
  * ("429 ..."), and — for JSON-bodied providers like Anthropic — the full
  * response envelope. `extractProviderErrorMessage` peels both away and returns
  * the embedded human-readable message, provider-agnostic (works for the OpenAI
  * plain-text shape and the Anthropic JSON shape alike).
  *
- * A leading 3-digit HTTP status is the only reliable evidence that a string is a
- * wrapped transport error rather than an application message. The function keys
- * its "give up" behaviour on that fact:
+ * The discriminator is a single question: after stripping any leading HTTP
+ * status, does the *whole* remaining string parse as a JSON object? That, not
+ * the presence of braces and not a leading status, is what tells a wrapped
+ * provider envelope apart from an application message:
  *
  *   - Empty / whitespace input returns `null`.
- *   - A JSON envelope is mined for `error.message`, then a top-level `message`;
- *     a match is returned whether or not a status prefix was present.
- *   - When nothing surfaceable can be pulled out, a status-prefixed input
- *     returns `null` (it IS a wrapped provider error carrying no message — the
- *     caller shows the generic fallback), while an input with no status prefix
- *     is returned unchanged. A string with no status prefix is treated as an
- *     application message, braces or not, and is never destroyed — so the
- *     builder's own human-readable events (e.g. `builder.paused_on_issue`) and
- *     brace-bearing diagnostics pass through untouched.
+ *   - If the remainder is a JSON object, it is a provider envelope: mine
+ *     `error.message`, then a top-level `message`, and return the first
+ *     non-empty one. An envelope with nothing surfaceable returns `null` so the
+ *     caller shows the generic fallback — never the raw JSON. This covers the
+ *     status-less rate-limit envelope `{"type":"error","error":{...}}`, which a
+ *     brace-substring hunt used to leak verbatim to users.
+ *   - Otherwise it is an application message and is returned unchanged (minus
+ *     the stripped status prefix), braces or not. So the builder's own
+ *     human-readable events, brace-bearing diagnostics, and messages that merely
+ *     embed a JSON fragment (e.g. `Agent stopped: {"message":"waiting"}`) pass
+ *     through with their surrounding text intact.
  */
 export function extractProviderErrorMessage(raw: string): string | null {
   const trimmed = raw.trim();
@@ -27,28 +30,19 @@ export function extractProviderErrorMessage(raw: string): string | null {
 
   // Strip a leading HTTP status ("429 ...", "400 ...").
   const withoutStatus = trimmed.replace(/^\d{3}\s+/, '');
-  const hadStatus = withoutStatus !== trimmed;
 
-  // Anthropic-style: a JSON envelope carries the sentence under `error.message`
-  // (or a top-level `message`).
-  const jsonStart = withoutStatus.indexOf('{');
-  const jsonEnd = withoutStatus.lastIndexOf('}');
-  if (jsonStart !== -1 && jsonEnd > jsonStart) {
-    const message = messageFromJson(withoutStatus.slice(jsonStart, jsonEnd + 1));
-    if (message) return message;
-    // A JSON envelope we can't pull a message from is only noise when a status
-    // prefix marks it as a wrapped provider error; without one it is an
-    // application message that merely contains braces — hand it back untouched.
-    return hadStatus ? null : trimmed;
+  // Provider envelope iff the whole remaining string is a JSON object.
+  const envelope = parseJsonObject(withoutStatus);
+  if (envelope) {
+    // Anthropic-style: the sentence lives under `error.message`, else a
+    // top-level `message`. No message means the envelope carries nothing
+    // surfaceable — fall back rather than leak the raw JSON.
+    return messageFromEnvelope(envelope);
   }
 
-  // OpenAI-style: plain-text sentence behind the status prefix.
-  if (hadStatus) {
-    return withoutStatus.length > 0 ? withoutStatus : null;
-  }
-
-  // No status, no JSON envelope: already a clean human string — pass through.
-  return trimmed;
+  // Not a JSON object: an application message (with or without a stripped status
+  // prefix). Return it unchanged; never destroy it.
+  return withoutStatus.length > 0 ? withoutStatus : null;
 }
 
 /**
@@ -59,15 +53,30 @@ export function humanizeProviderError(raw: string, fallback: string): string {
   return extractProviderErrorMessage(raw) ?? fallback;
 }
 
-function messageFromJson(candidate: string): string | null {
+/**
+ * Parse `candidate` as a whole and return it only when it is a non-null JSON
+ * object. Anything else (parse failure, array, string, number, `null`) yields
+ * `null` — the string is then treated as an application message, not envelope.
+ */
+function parseJsonObject(candidate: string): Record<string, unknown> | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(candidate);
   } catch {
     return null;
   }
-  if (typeof parsed !== 'object' || parsed === null) return null;
-  const obj = parsed as Record<string, unknown>;
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * Mine the human-readable sentence from a parsed provider envelope: prefer
+ * `error.message`, then a top-level `message`. Returns `null` when neither
+ * exists so the caller shows the translated generic fallback.
+ */
+function messageFromEnvelope(obj: Record<string, unknown>): string | null {
   const nested = obj.error;
   if (nested && typeof nested === 'object') {
     const message = (nested as Record<string, unknown>).message;

--- a/web-ui/app/store/builder/[id]/_components/BuilderChatPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/BuilderChatPane.tsx
@@ -34,6 +34,7 @@ import type {
   TranscriptEntry,
 } from '../../../../_lib/builderTypes';
 import { cn } from '../../../../_lib/cn';
+import { humanizeProviderError } from '../../../../_lib/providerErrorMessage';
 import { ChoiceCard } from '../../../../_components/ChoiceCard';
 
 import { BuilderMarkdown } from './BuilderMarkdown';
@@ -252,7 +253,8 @@ export function BuilderChatPane({
         }
         if (ev.type === 'turn_done') break;
         if (ev.type === 'error') {
-          setError(`${ev.code}: ${ev.message}`);
+          console.warn(`[builder.chat] provider error (${ev.code})`, ev.message);
+          setError(humanizeProviderError(ev.message, t('error.providerGeneric')));
           break;
         }
       }

--- a/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/PreviewChatPane.tsx
@@ -40,6 +40,7 @@ import type {
   TranscriptEntry,
 } from '../../../../_lib/builderTypes';
 import { cn } from '../../../../_lib/cn';
+import { humanizeProviderError } from '../../../../_lib/providerErrorMessage';
 import {
   ChoiceCard,
   type PendingUserChoice,
@@ -259,7 +260,8 @@ export function PreviewChatPane({
         applyEvent(ev);
         if (ev.type === 'turn_done') break;
         if (ev.type === 'error') {
-          setError(`${ev.code}: ${ev.message}`);
+          console.warn(`[builder.preview.chat] provider error (${ev.code})`, ev.message);
+          setError(humanizeProviderError(ev.message, t('error.providerGeneric')));
           break;
         }
       }

--- a/web-ui/app/store/builder/[id]/_components/SimpleIntakePane.tsx
+++ b/web-ui/app/store/builder/[id]/_components/SimpleIntakePane.tsx
@@ -20,6 +20,7 @@ import type {
   TranscriptEntry,
 } from '../../../../_lib/builderTypes';
 import { cn } from '../../../../_lib/cn';
+import { humanizeProviderError } from '../../../../_lib/providerErrorMessage';
 import { ChoiceCard } from '../../../../_components/ChoiceCard';
 
 import { BuilderMarkdown } from './BuilderMarkdown';
@@ -154,7 +155,8 @@ export function SimpleIntakePane({
           applyEvent(ev);
           if (ev.type === 'turn_done') break;
           if (ev.type === 'error') {
-            setError(`${ev.code}: ${ev.message}`);
+            console.warn(`[builder.simple.intake] provider error (${ev.code})`, ev.message);
+            setError(humanizeProviderError(ev.message, t('errorProviderGeneric')));
             break;
           }
         }

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -734,6 +734,7 @@
     "errorMiddlewareUnreachable": "Middleware nicht erreichbar auf localhost:3979. Läuft `npm run dev` im middleware-Ordner?",
     "errorProxyFailure": "Proxy-Fehler (HTTP {status}). Prüf die Middleware-Logs.",
     "errorAborted": "Abgebrochen.",
+    "errorProviderGeneric": "Beim Zugriff auf den KI-Anbieter ist etwas schiefgelaufen. Bitte versuch es erneut.",
     "intro": {
       "kicker": "Wofür ist dieser Chat?",
       "body": "Das ist der Debug-Chat für Operatoren — eine direkte Leitung zu deinen Orchestratoren zum Testen von Prompts und zum Beobachten von Tool-Aufrufen, Plänen und Knowledge-Graph-Walks in Echtzeit. Das ist nicht die Endnutzer-Erfahrung, sondern zum Debuggen gedacht."
@@ -1407,6 +1408,7 @@
       "error": {
         "connectionLost": "Verbindung verloren: {message}",
         "unknownTurn": "Unbekannter Fehler beim Builder-Turn",
+        "providerGeneric": "Beim Zugriff auf den KI-Anbieter ist etwas schiefgelaufen. Bitte versuch es erneut.",
         "choiceSaveFailedDetail": "Auswahl konnte nicht gespeichert werden: {message}",
         "choiceSaveFailed": "Auswahl konnte nicht gespeichert werden."
       },
@@ -1464,7 +1466,8 @@
         "streamLive": "Stream live",
         "error": {
           "connectionLost": "Verbindung verloren: {message}",
-          "unknownTurn": "Unbekannter Fehler beim Preview-Turn"
+          "unknownTurn": "Unbekannter Fehler beim Preview-Turn",
+          "providerGeneric": "Beim Zugriff auf den KI-Anbieter ist etwas schiefgelaufen. Bitte versuch es erneut."
         },
         "externalReadsHint": "Preview führt Cross-Integration-Lookups (<code>spec.external_reads</code>) nicht aus — der Agent erkennt den fehlenden Service korrekt und wirft. Stelle den Agent in deiner Instanz bereit, um den echten Datenpfad zu testen.",
         "agentStuck": {

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1227,6 +1227,7 @@
         "statusBusy": "Arbeitet …",
         "errorLostConnection": "Verbindung verloren: {message}",
         "errorUnknown": "Unbekannter Fehler — bitte erneut versuchen.",
+        "errorProviderGeneric": "Dein Assistent konnte den KI-Dienst gerade nicht erreichen. Bitte versuch es gleich noch einmal.",
         "errorChoiceFailed": "Auswahl konnte nicht gespeichert werden.",
         "errorChoiceFailedMessage": "Auswahl konnte nicht gespeichert werden: {message}"
       }

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -734,6 +734,7 @@
     "errorMiddlewareUnreachable": "Middleware unreachable on localhost:3979. Is `npm run dev` running in the middleware folder?",
     "errorProxyFailure": "Proxy error (HTTP {status}). Check the middleware logs.",
     "errorAborted": "Aborted.",
+    "errorProviderGeneric": "Something went wrong while talking to the AI provider. Please try again.",
     "intro": {
       "kicker": "What is this chat?",
       "body": "This is the operator debug chat — a direct line to your orchestrators for testing prompts and inspecting tool calls, plans, and knowledge-graph walks as they happen. It's not the end-user experience; it's built for debugging."
@@ -1407,6 +1408,7 @@
       "error": {
         "connectionLost": "Connection lost: {message}",
         "unknownTurn": "Unknown error during builder turn",
+        "providerGeneric": "Something went wrong while talking to the AI provider. Please try again.",
         "choiceSaveFailedDetail": "Could not save selection: {message}",
         "choiceSaveFailed": "Could not save selection."
       },
@@ -1464,7 +1466,8 @@
         "streamLive": "Stream live",
         "error": {
           "connectionLost": "Connection lost: {message}",
-          "unknownTurn": "Unknown error during the preview turn"
+          "unknownTurn": "Unknown error during the preview turn",
+          "providerGeneric": "Something went wrong while talking to the AI provider. Please try again."
         },
         "externalReadsHint": "Preview does not run cross-integration lookups (<code>spec.external_reads</code>) — the agent correctly detects the missing service and throws. Publish the agent to the platform store to test the real data path.",
         "agentStuck": {

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1227,6 +1227,7 @@
         "statusBusy": "Working …",
         "errorLostConnection": "Connection lost: {message}",
         "errorUnknown": "Unknown error — please try again.",
+        "errorProviderGeneric": "Your assistant couldn't reach the AI service just now. Please try again in a moment.",
         "errorChoiceFailed": "Your choice could not be saved.",
         "errorChoiceFailedMessage": "Your choice could not be saved: {message}"
       }


### PR DESCRIPTION
## Problem

When a provider rejected a chat turn (quota exceeded, rate limit, billing), the chat surfaces rendered the raw error string verbatim — leading HTTP status and JSON response envelope included. Users saw transport noise like `400 {"type":"error","error":{"message":"Your credit balance is too low..."}}` instead of the one actionable sentence.

## Change

Introduces `web-ui/app/_lib/providerErrorMessage.ts` with `extractProviderErrorMessage(raw)` and the `humanizeProviderError(raw, fallback)` wrapper, wired into every surface that renders a provider failure: the main chat bubble, the builder chat pane, the preview chat pane, and the default simple builder intake. Each shows the provider's human-readable sentence, falling back to a translated generic notice (new `en.json` / `de.json` keys) when none can be surfaced.

On the primary path the orchestrator failure arrives as an in-band error event on an already-streaming 200 response, so `res.ok` is true and nothing throws. `StreamRunner` used to finish that turn as `done`, which meant the background stream toast reported **success for a failed turn**. It now finishes as a failure carrying the humanized sentence. Covered by `StreamRunner.test.tsx`.

## Extractor semantics

The discriminator is a single question: after stripping any leading HTTP status prefix, does the **whole** remaining string parse as a JSON object?

- Empty / whitespace input → `null`.
- If it is a JSON object, it is a provider envelope: mine `error.message`, then a top-level `message`; return the first non-empty one, else `null` so the caller shows the generic fallback — never raw JSON.
- Otherwise it is an application message and is returned unchanged (minus any stripped status), braces or not.

Earlier iterations hunted for a brace substring between the first `{` and the last `}`, and keyed the give-up on a leading HTTP status. Both were wrong. A status-less rate-limit envelope — `{"type":"error","error":{"type":"rate_limit_error"}}`, which `middleware/test/orchestrator/streamingRetry.test.ts` documents on a real path — leaked raw JSON to users, and an application message merely embedding a JSON fragment (`Agent stopped: {"message":"waiting"}`) could be reduced to just that field. Parsing the whole string closes both.

## Tests

`providerErrorMessage.test.ts` covers status-prefixed and status-less envelopes, plain-text quota errors, application messages with JSON and non-JSON braces, embedded-JSON application messages, brace-free messages, and empty input. `StreamRunner.test.tsx` drives the in-band error path and asserts the **store outcome**, not the rendered string; reverting only the conditional `store.finish()` makes exactly those two tests fail.

Gate green: `tsc --noEmit` clean, `vitest run` 206/206, `i18n:check` OK (2735 keys, en + de).

## How this branch was produced

Authored and reviewed by the interactive issue loop in `scripts/issue-{cluster,implement}.workflow.mjs` (#469), over six implement→review rounds. Every round ran an adversarial diff reviewer and, after it approved, an independent cross-vendor reviewer (`codex`, gpt-5.5). The first reviewer approved this branch in rounds 2, 3, 4 and 5; the cross-vendor reviewer rejected it each time, finding — in order — a missed default chat surface, a state bug where the toast reported success on failure, an extractor regression that destroyed clean messages containing braces, and a raw-JSON leak on the status-less rate-limit path. A human verified every finding against the branch before it was fed back. Both reviewers approve the final state.

Known non-blocking notes for the reviewer:

- On the OpenAI quota path the surfaced sentence is the provider's own, which still ends in a developer-docs URL. That is a real improvement over the HTTP status plus JSON envelope, but it is not bespoke non-technical copy. Whether that satisfies this issue is a maintainer call.
- The branch is named `feat/…` while the issue is labelled `bug`; the commits are all `fix(web-ui):` and squash-merge uses the PR title.
- `/^\d{3}\s+/` strips a leading three-digit token from any message, so a hypothetical `404 errors were found` would lose its prefix. No provider path produces that shape.

Closes #403
