### PR TITLE
Plugin security & quality cluster: SkillSpector package scanning, prompt PII masking, plugin v1.0 pass (#453, #431, #361)

### DIFF
--- a/docker-compose.skillspector.yaml
+++ b/docker-compose.skillspector.yaml
@@ -1,0 +1,30 @@
+# Optional overlay — SkillSpector plugin code scanning (issue #453).
+#
+# Adds the SkillSpector sidecar (built from middleware/sidecars/skillspector)
+# and points the middleware at it. Advisory-only: without this overlay the
+# default stack runs unchanged, installs never block, and plugin verdicts
+# record `scan_failed`.
+#
+#   docker compose -f docker-compose.yaml -f docker-compose.skillspector.yaml up -d
+
+services:
+  middleware:
+    environment:
+      SKILLSPECTOR_URL: http://skillspector:8811
+
+  skillspector:
+    build: middleware/sidecars/skillspector
+    restart: unless-stopped
+    # No ports: the scanner is only reachable from inside the compose
+    # network — it accepts arbitrary file trees and must never be public.
+    networks: [omadia]
+    healthcheck:
+      test:
+        - 'CMD'
+        - 'python'
+        - '-c'
+        - "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8811/health').status==200 else 1)"
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 30s

--- a/docker-compose.skillspector.yaml
+++ b/docker-compose.skillspector.yaml
@@ -2,8 +2,9 @@
 #
 # Adds the SkillSpector sidecar (built from middleware/sidecars/skillspector)
 # and points the middleware at it. Advisory-only: without this overlay the
-# default stack runs unchanged, installs never block, and plugin verdicts
-# record `scan_failed`.
+# default stack runs unchanged, installs never block, no scan is scheduled,
+# and no plugin verdict rows are written (`scan_failed` is reserved for real
+# sidecar failures).
 #
 #   docker compose -f docker-compose.yaml -f docker-compose.skillspector.yaml up -d
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,7 @@
 #   -f docker-compose.storage.yaml     object storage (MinIO) — chat attachments
 #   -f docker-compose.diagrams.yaml    Kroki diagram rendering (needs storage too)
 #   -f docker-compose.embeddings.yaml  in-tenant embeddings (Ollama)
+#   -f docker-compose.skillspector.yaml  advisory plugin code scanning (SkillSpector)
 #   -f docker-compose.build.yaml       build middleware + web-ui from source
 #
 # Example — full stack:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,16 +45,27 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   failure degrades to C0 with audit; a baseline failure or residual span
   blocks the turn — there is no pass-through-unmasked path. Flag-off is
   byte-identical to previous behavior.
-- Orchestrator: LLM-bound sites (message assembly, ingested attachment
-  tail, model/persona routing, KG-recall query, nudge pipeline, card
-  router, excerpt pass) consume the masked wire variant; memory persistence
-  and receipt attribution keep the original text. Streamed deltas may
-  transiently show a surrogate; the `done` answer is authoritative (same
-  contract as the v4 rendered-answer swap).
-- Committed runnable validation harness with pre-committed recall gates:
-  `harness-plugin-privacy-guard/src/validation/` (not a CI gate). The C1
-  transformer slot (Piiranha/GLiNER) ships inert until a locale passes its
-  gates.
+- Orchestrator: every LLM-bound site (message assembly, ingested attachment
+  tail, model/persona routing, KG-recall query, recalled-context injection,
+  fact-extraction prompt, nudge pipeline, card router, excerpt pass)
+  consumes the masked wire variant. Server-side persistence stores real
+  values only: the session log / KG persist the POST-restore answer,
+  extracted facts and the Palaia excerpt are restored surrogate→real before
+  ingest/promotion (fire-and-forget extraction uses a snapshot of the
+  turn's map, `snapshotPromptRestorer`), and receipt attribution keeps the
+  original text. Direct-line turns mask the fact-extraction inputs the same
+  way and skip extraction (audited) if masking is blocked. Streamed deltas
+  may transiently show a surrogate; the `done` answer is authoritative
+  (same contract as the v4 rendered-answer swap).
+- Committed runnable validation harness with pre-committed gates:
+  `harness-plugin-privacy-guard/src/validation/` (not a CI gate). Current
+  coverage: `de` + `en` fixture sets, **C0 regex tier only** — the C1
+  transformer slot (Piiranha/GLiNER) is an inert stub. Gates: recall ≥ 0.97
+  for structured identifiers, ≥ 0.90 for names/free-form entities (needs
+  C1 — C0 does not detect names), precision proxy ≥ 0.85 on PII-free
+  negatives, p95 added latency ≤ 400 ms. Enabling `mask_user_prompt` for a
+  locale requires posting a green harness run for that locale to issue
+  #361 first.
 
 ### Changed — v1.0 readiness pass across the earliest core plugins (#431)
 
@@ -65,8 +76,10 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 - `agent-seo-analyst`: operator-catalog `identity.description` translated to
   English; README gains the same PluginContext-surface audit section.
 - `harness-plugin-privacy-guard`: `package.json` version aligned to the
-  manifest (`0.2.0`); the v4 path (`src/service.ts` + `src/v4/`) is declared
-  the single canonical implementation — no legacy branch exists (see README).
+  manifest (`0.2.0` at the time of #431; both sit at `0.3.0` after the #361
+  bump in this branch); the v4 path (`src/service.ts` + `src/v4/`) is
+  declared the single canonical implementation — no legacy branch exists
+  (see README).
 - Recorded decisions: plugins stay independently versioned (no lockstep bump
   with core); package layout is per-kind (tool plugins `src/`→`dist/`, agent
   packages flat, per `agent-reference-maximum` + boilerplate templates).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,13 +24,24 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   is optionally scanned by an NVIDIA SkillSpector sidecar
   (`middleware/sidecars/skillspector/`, enabled via `SKILLSPECTOR_URL` /
   `docker-compose.skillspector.yaml`). Fire-and-forget after ingest success —
-  a scanner outage or unset URL records a `scan_failed` verdict and never
-  fails an install. Verdicts are cached by ZIP sha256 + scanner version
+  a scanner outage records a `scan_failed` verdict and never fails an
+  install; with `SKILLSPECTOR_URL` unset nothing is scheduled and NO verdict
+  row is written (store pages show no badge on unconfigured deployments).
+  The shim and the middleware parser are **fail-closed**: only the
+  positively-verified SkillSpector report schema (exit 0, `issues` list +
+  `risk_assessment` object — observed against the pinned commit, CLI
+  v2.3.11) counts as a scan; any unrecognized output surfaces as
+  `scan_failed`, never as a false `no_signals` all-clear. The sidecar
+  dependency is pinned to an exact upstream commit SHA (pin-bump procedure:
+  sidecar README). Verdicts are cached by ZIP sha256 + scanner version
   (**migration `0021_plugin_verdict.sql`**, table `plugin_verdicts` incl.
   inline operator ack columns), surface as a badge + `verdict` field on
   `GET /api/v1/store/plugins/:id`, and can be acknowledged via
-  `POST /api/v1/store/plugins/:id/verdict/ack`. Advisory-only in v1: nothing
-  blocks. New env vars: `SKILLSPECTOR_URL`, `SKILLSPECTOR_TIMEOUT_MS`.
+  `POST /api/v1/store/plugins/:id/verdict/ack`. An ack records the severity
+  the operator saw (`ack_severity`) and is cleared automatically when a
+  later re-scan WORSENS the verdict; it survives equal-or-better results.
+  Advisory-only in v1: nothing blocks. New env vars: `SKILLSPECTOR_URL`,
+  `SKILLSPECTOR_TIMEOUT_MS`.
 
 ### Added — free-text user-prompt PII masking, default off (#361)
 
@@ -45,18 +56,23 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   failure degrades to C0 with audit; a baseline failure or residual span
   blocks the turn — there is no pass-through-unmasked path. Flag-off is
   byte-identical to previous behavior.
-- Orchestrator: every LLM-bound site (message assembly, ingested attachment
-  tail, model/persona routing, KG-recall query, recalled-context injection,
+- Orchestrator: every LLM-bound site (message assembly, **live chat
+  history/`priorTurns` — which replays persisted REAL values from earlier
+  turns**, ingested attachment tail, model/persona routing, KG-recall
+  query, recalled-context injection, **direct-line relay payloads**,
   fact-extraction prompt, nudge pipeline, card router, excerpt pass)
   consumes the masked wire variant. Server-side persistence stores real
   values only: the session log / KG persist the POST-restore answer,
   extracted facts and the Palaia excerpt are restored surrogate→real before
   ingest/promotion (fire-and-forget extraction uses a snapshot of the
   turn's map, `snapshotPromptRestorer`), and receipt attribution keeps the
-  original text. Direct-line turns mask the fact-extraction inputs the same
-  way and skip extraction (audited) if masking is blocked. Streamed deltas
-  may transiently show a surrogate; the `done` answer is authoritative
-  (same contract as the v4 rendered-answer swap).
+  original text. User-facing card content (`ask_user_choice` question/
+  options, follow-up buttons) is restored surrogate→real before rendering.
+  Direct-line turns mask the relayed payload before dispatch, restore the
+  sub-agent's answer, fail closed (generic privacy error, audited) when
+  masking is blocked, and mask the fact-extraction inputs the same way.
+  Streamed deltas may transiently show a surrogate; the `done` answer is
+  authoritative (same contract as the v4 rendered-answer swap).
 - Committed runnable validation harness with pre-committed gates:
   `harness-plugin-privacy-guard/src/validation/` (not a CI gate). Current
   coverage: `de` + `en` fixture sets, **C0 regex tier only** — the C1

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,20 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — advisory SkillSpector code scanning for plugin packages (#453)
+
+- Every ingested plugin package (direct upload, hub install, Builder install)
+  is optionally scanned by an NVIDIA SkillSpector sidecar
+  (`middleware/sidecars/skillspector/`, enabled via `SKILLSPECTOR_URL` /
+  `docker-compose.skillspector.yaml`). Fire-and-forget after ingest success —
+  a scanner outage or unset URL records a `scan_failed` verdict and never
+  fails an install. Verdicts are cached by ZIP sha256 + scanner version
+  (**migration `0021_plugin_verdict.sql`**, table `plugin_verdicts` incl.
+  inline operator ack columns), surface as a badge + `verdict` field on
+  `GET /api/v1/store/plugins/:id`, and can be acknowledged via
+  `POST /api/v1/store/plugins/:id/verdict/ack`. Advisory-only in v1: nothing
+  blocks. New env vars: `SKILLSPECTOR_URL`, `SKILLSPECTOR_TIMEOUT_MS`.
+
 ### Added — pluggable LLM provider (OpenAI as an admin-selectable provider)
 
 - **`@omadia/llm-provider`**: a neutral LLM provider contract with Anthropic and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,30 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   `POST /api/v1/store/plugins/:id/verdict/ack`. Advisory-only in v1: nothing
   blocks. New env vars: `SKILLSPECTOR_URL`, `SKILLSPECTOR_TIMEOUT_MS`.
 
+### Added — free-text user-prompt PII masking, default off (#361)
+
+- `harness-plugin-privacy-guard` 0.3.0: new **default-off** setup field
+  `mask_user_prompt`. When on, PII spans detected in the user's own message
+  (C0 regex baseline: email, IBAN, phone, German street+postal address,
+  amounts, DOB dates) are replaced by realistic pseudonyms before the prompt
+  crosses the LLM wire (pseudonym projection via the shipped `v4/pseudonym`
+  mechanism — no on-wire token map); the real values are restored
+  server-side in the final answer, and the spans surface (PII-free) as
+  `maskedPromptSpans` on the `PrivacyReceipt`. Failure-closed: C1-detector
+  failure degrades to C0 with audit; a baseline failure or residual span
+  blocks the turn — there is no pass-through-unmasked path. Flag-off is
+  byte-identical to previous behavior.
+- Orchestrator: LLM-bound sites (message assembly, ingested attachment
+  tail, model/persona routing, KG-recall query, nudge pipeline, card
+  router, excerpt pass) consume the masked wire variant; memory persistence
+  and receipt attribution keep the original text. Streamed deltas may
+  transiently show a surrogate; the `done` answer is authoritative (same
+  contract as the v4 rendered-answer swap).
+- Committed runnable validation harness with pre-committed recall gates:
+  `harness-plugin-privacy-guard/src/validation/` (not a CI gate). The C1
+  transformer slot (Piiranha/GLiNER) ships inert until a locale passes its
+  gates.
+
 ### Changed — v1.0 readiness pass across the earliest core plugins (#431)
 
 - `harness-plugin-web-search`, `harness-plugin-privacy-guard`, and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,7 +31,12 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   positively-verified SkillSpector report schema (exit 0, `issues` list +
   `risk_assessment` object — observed against the pinned commit, CLI
   v2.3.11) counts as a scan; any unrecognized output surfaces as
-  `scan_failed`, never as a false `no_signals` all-clear. The sidecar
+  `scan_failed`, never as a false `no_signals` all-clear. Coverage of the
+  executed entry point is guaranteed the same way: upload validation
+  rejects a `lifecycle.entry` below `node_modules`/hidden directories
+  (`package.entry_unscannable`), and the scanner force-includes the entry
+  file when the directory walk skipped it — failing closed (`scan_failed`)
+  when it cannot. The sidecar
   dependency is pinned to an exact upstream commit SHA (pin-bump procedure:
   sidecar README). Verdicts are cached by ZIP sha256 + scanner version
   (**migration `0021_plugin_verdict.sql`**, table `plugin_verdicts` incl.
@@ -58,10 +63,12 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   byte-identical to previous behavior.
 - Orchestrator: every LLM-bound site (message assembly, **live chat
   history/`priorTurns` — which replays persisted REAL values from earlier
-  turns**, ingested attachment tail, model/persona routing, KG-recall
-  query, recalled-context injection, **direct-line relay payloads**,
-  fact-extraction prompt, nudge pipeline, card router, excerpt pass)
-  consumes the masked wire variant. Server-side persistence stores real
+  turns**, ingested attachment tail, **mid-turn steering messages injected
+  via `POST /chat/steer`** (masked through the same per-turn map before the
+  iteration loop folds them into the conversation), model/persona routing,
+  KG-recall query, recalled-context injection, **direct-line relay
+  payloads**, fact-extraction prompt, nudge pipeline, card router, excerpt
+  pass) consumes the masked wire variant. Server-side persistence stores real
   values only: the session log / KG persist the POST-restore answer,
   extracted facts and the Palaia excerpt are restored surrogate→real before
   ingest/promotion (fire-and-forget extraction uses a snapshot of the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,21 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   `POST /api/v1/store/plugins/:id/verdict/ack`. Advisory-only in v1: nothing
   blocks. New env vars: `SKILLSPECTOR_URL`, `SKILLSPECTOR_TIMEOUT_MS`.
 
+### Changed — v1.0 readiness pass across the earliest core plugins (#431)
+
+- `harness-plugin-web-search`, `harness-plugin-privacy-guard`, and
+  `harness-plugin-quality-guard` now ship READMEs (purpose, config keys,
+  published capabilities/tools, recorded `ctx.jobs`/`ctx.status`/`ctx.llm`/
+  `ctx.mcp` adopt-or-skip decisions).
+- `agent-seo-analyst`: operator-catalog `identity.description` translated to
+  English; README gains the same PluginContext-surface audit section.
+- `harness-plugin-privacy-guard`: `package.json` version aligned to the
+  manifest (`0.2.0`); the v4 path (`src/service.ts` + `src/v4/`) is declared
+  the single canonical implementation — no legacy branch exists (see README).
+- Recorded decisions: plugins stay independently versioned (no lockstep bump
+  with core); package layout is per-kind (tool plugins `src/`→`dist/`, agent
+  packages flat, per `agent-reference-maximum` + boilerplate templates).
+
 ### Added — pluggable LLM provider (OpenAI as an admin-selectable provider)
 
 - **`@omadia/llm-provider`**: a neutral LLM provider contract with Anthropic and

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -68,14 +68,21 @@ discovered from public registries. This keeps the supply chain explicit:
 - Optionally (issue #453), every ingested package — direct upload, hub
   install, Builder install — is statically scanned by an NVIDIA
   SkillSpector sidecar (`SKILLSPECTOR_URL`, deterministic `--no-llm` mode,
-  no outbound calls). The scan is **advisory-only in v1**: it runs
-  fire-and-forget after a successful ingest, its verdict (severity +
-  findings, cached by ZIP sha256 + scanner version in `plugin_verdicts`,
-  migration 0021) decorates the store detail page, and a scanner outage
-  degrades to a `scan_failed` verdict — never a failed install. Operator
-  acknowledgements persist `ack_by`/`ack_at` for audit; turning the
-  verdict into a hard install block is deferred until omadia has a role
-  model (same policy gap as skill-verdict suppression, see
+  no outbound calls; the scanner dependency is pinned to an exact upstream
+  commit SHA — pin-bump procedure in the sidecar README). The scan is
+  **advisory-only in v1**: it runs fire-and-forget after a successful
+  ingest, its verdict (severity + findings, cached by ZIP sha256 + scanner
+  version in `plugin_verdicts`, migration 0021) decorates the store detail
+  page, and a scanner outage degrades to a `scan_failed` verdict — never a
+  failed install. With `SKILLSPECTOR_URL` unset no scan is scheduled and no
+  verdict row is written. The result pipeline is **fail-closed**: only
+  SkillSpector's positively-verified report schema counts as a scan; an
+  unrecognized schema is recorded as `scan_failed`, never as a
+  `no_signals` all-clear. Operator acknowledgements persist
+  `ack_by`/`ack_at`/`ack_severity` for audit and are cleared automatically
+  when a later re-scan worsens the verdict beyond the acked severity;
+  turning the verdict into a hard install block is deferred until omadia
+  has a role model (same policy gap as skill-verdict suppression, see
   `agentBuilder.ts`).
 
 ## 5. Signed artefact URLs

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -78,7 +78,14 @@ discovered from public registries. This keeps the supply chain explicit:
   verdict row is written. The result pipeline is **fail-closed**: only
   SkillSpector's positively-verified report schema counts as a scan; an
   unrecognized schema is recorded as `scan_failed`, never as a
-  `no_signals` all-clear. Operator acknowledgements persist
+  `no_signals` all-clear. Entry-point coverage is fail-closed too: upload
+  validation rejects a `lifecycle.entry` that resolves below
+  `node_modules` or a hidden directory (`package.entry_unscannable` —
+  the scanner's directory walk skips those, so the runtime would execute
+  code the scan never saw), and as defense in depth the scanner
+  force-includes the manifest's entry file in the scan payload when the
+  walk skipped it, recording `scan_failed` when coverage cannot be
+  guaranteed. Operator acknowledgements persist
   `ack_by`/`ack_at`/`ack_severity` for audit and are cleared automatically
   when a later re-scan worsens the verdict beyond the acked severity;
   turning the verdict into a hard install block is deferred until omadia

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -65,6 +65,18 @@ discovered from public registries. This keeps the supply chain explicit:
   filesystem). The runtime enforces the declaration.
 - A plugin's `depends_on` is a soft contract, not an automatic install
   trigger.
+- Optionally (issue #453), every ingested package — direct upload, hub
+  install, Builder install — is statically scanned by an NVIDIA
+  SkillSpector sidecar (`SKILLSPECTOR_URL`, deterministic `--no-llm` mode,
+  no outbound calls). The scan is **advisory-only in v1**: it runs
+  fire-and-forget after a successful ingest, its verdict (severity +
+  findings, cached by ZIP sha256 + scanner version in `plugin_verdicts`,
+  migration 0021) decorates the store detail page, and a scanner outage
+  degrades to a `scan_failed` verdict — never a failed install. Operator
+  acknowledgements persist `ack_by`/`ack_at` for audit; turning the
+  verdict into a hard install block is deferred until omadia has a role
+  model (same policy gap as skill-verdict suppression, see
+  `agentBuilder.ts`).
 
 ## 5. Signed artefact URLs
 

--- a/middleware/.env.example
+++ b/middleware/.env.example
@@ -147,6 +147,17 @@ TOPIC_CLASSIFIER_MODEL=claude-haiku-4-5
 TOPIC_UPPER_THRESHOLD=0.55
 TOPIC_LOWER_THRESHOLD=0.15
 
+# --- Plugin code scanning (SkillSpector sidecar, issue #453) — OPTIONAL -----
+# Advisory static scan of every ingested plugin package (upload, hub install,
+# Builder install). OFF by default: without SKILLSPECTOR_URL nothing scans,
+# installs behave unchanged, and verdict rows record `scan_failed`. A verdict
+# NEVER blocks an install in v1 — it decorates the store detail page.
+#   With Docker: enable via docker-compose.skillspector.yaml (it builds
+#   middleware/sidecars/skillspector and sets the URL for you).
+#   Bare-metal dev: run the sidecar yourself and uncomment below.
+# SKILLSPECTOR_URL=http://localhost:8811
+# SKILLSPECTOR_TIMEOUT_MS=20000
+
 # --- Vault (encrypted secrets store) ----------------------------------------
 # Master key used to AES-256-GCM-encrypt plugin secrets at rest under
 # /data/vault. Generate once with `openssl rand -base64 32` and keep stable

--- a/middleware/.env.example
+++ b/middleware/.env.example
@@ -150,8 +150,9 @@ TOPIC_LOWER_THRESHOLD=0.15
 # --- Plugin code scanning (SkillSpector sidecar, issue #453) — OPTIONAL -----
 # Advisory static scan of every ingested plugin package (upload, hub install,
 # Builder install). OFF by default: without SKILLSPECTOR_URL nothing scans,
-# installs behave unchanged, and verdict rows record `scan_failed`. A verdict
-# NEVER blocks an install in v1 — it decorates the store detail page.
+# installs behave unchanged, and NO verdict rows are written (store pages
+# show no badge); `scan_failed` is reserved for real sidecar failures. A
+# verdict NEVER blocks an install in v1 — it decorates the store detail page.
 #   With Docker: enable via docker-compose.skillspector.yaml (it builds
 #   middleware/sidecars/skillspector and sets the URL for you).
 #   Bare-metal dev: run the sidecar yourself and uncomment below.

--- a/middleware/migrations/0021_plugin_verdict.sql
+++ b/middleware/migrations/0021_plugin_verdict.sql
@@ -6,10 +6,13 @@
 -- upgrade recomputes without losing history for the old version.
 --
 -- Unlike skill verdicts, the operator acknowledgement lives inline
--- (`ack_by` / `ack_at`): the upsert path only ever rewrites the scan columns
--- (severity, findings, rationale, computed_at), so an ack survives a
--- re-scan under the same verifier_version, and a verifier upgrade
--- (new verifier_version → new row) correctly invalidates the ack.
+-- (`ack_by` / `ack_at` / `ack_severity`). `ack_severity` records the
+-- severity the operator actually looked at, so a re-scan under the same
+-- verifier_version keeps the ack only while the new severity is equal or
+-- BETTER than the acked one — a worse re-scan result (e.g. an acked
+-- `scan_failed` upgrading to `high_risk`) clears the ack, because the
+-- operator never saw those findings. A verifier upgrade (new
+-- verifier_version → new row) correctly invalidates the ack either way.
 --
 -- Advisory-only in v1: nothing reads this table to block an install.
 CREATE TABLE IF NOT EXISTS plugin_verdicts (
@@ -24,8 +27,13 @@ CREATE TABLE IF NOT EXISTS plugin_verdicts (
   computed_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
   ack_by           TEXT,
   ack_at           TIMESTAMPTZ,
+  ack_severity     TEXT,
   PRIMARY KEY (content_hash, verifier_version)
 );
+
+-- Idempotent guard for environments that created the table from an earlier
+-- revision of this (unreleased) migration, before ack_severity existed.
+ALTER TABLE plugin_verdicts ADD COLUMN IF NOT EXISTS ack_severity TEXT;
 
 -- Store/detail pages look verdicts up by plugin id (latest install wins).
 CREATE INDEX IF NOT EXISTS plugin_verdicts_plugin_idx

--- a/middleware/migrations/0021_plugin_verdict.sql
+++ b/middleware/migrations/0021_plugin_verdict.sql
@@ -1,0 +1,34 @@
+-- ── plugin code-scan verdicts (issue #453) ─────────────────────────────────
+-- Verdicts produced by the SkillSpector code scanner over executable plugin
+-- packages. Keyed on the ingested ZIP's sha256 (`content_hash`) plus the
+-- scanner identity (`verifier_version`), mirroring `0007_skill_verdict.sql`,
+-- so re-installs of an identical package are a cache hit and a scanner
+-- upgrade recomputes without losing history for the old version.
+--
+-- Unlike skill verdicts, the operator acknowledgement lives inline
+-- (`ack_by` / `ack_at`): the upsert path only ever rewrites the scan columns
+-- (severity, findings, rationale, computed_at), so an ack survives a
+-- re-scan under the same verifier_version, and a verifier upgrade
+-- (new verifier_version → new row) correctly invalidates the ack.
+--
+-- Advisory-only in v1: nothing reads this table to block an install.
+CREATE TABLE IF NOT EXISTS plugin_verdicts (
+  content_hash     TEXT NOT NULL,
+  verifier_version TEXT NOT NULL,
+  plugin_id        TEXT NOT NULL,
+  severity         TEXT NOT NULL
+                   CHECK (severity IN ('no_signals', 'flagged', 'high_risk', 'scan_failed', 'pending', 'too_large_to_scan')),
+  findings         JSONB NOT NULL DEFAULT '[]',
+  scanner_version  TEXT NOT NULL DEFAULT '',
+  rationale        TEXT,
+  computed_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  ack_by           TEXT,
+  ack_at           TIMESTAMPTZ,
+  PRIMARY KEY (content_hash, verifier_version)
+);
+
+-- Store/detail pages look verdicts up by plugin id (latest install wins).
+CREATE INDEX IF NOT EXISTS plugin_verdicts_plugin_idx
+  ON plugin_verdicts(plugin_id, computed_at DESC);
+
+-- rollback: DROP TABLE plugin_verdicts;

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -8647,7 +8647,7 @@
     },
     "packages/harness-plugin-privacy-guard": {
       "name": "@omadia/plugin-privacy-guard",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/middleware/packages/agent-seo-analyst/README.md
+++ b/middleware/packages/agent-seo-analyst/README.md
@@ -88,3 +88,18 @@ Das Build-Script nutzt die package-lokale `tsconfig.json` (keine Querverweise in
 middleware-Tree — das Zip ist standalone). `PluginContext` ist in `types.ts`
 strukturell dupliziert, damit der Agent ohne Import aus `middleware/src/platform`
 auskommt.
+
+## PluginContext surface — v1.0 readiness audit (#431)
+
+| Surface | Decision | Rationale |
+|---|---|---|
+| `ctx.jobs` | deferred adopt | Long `audit_site` crawls are the natural fit (background job + progress). Deliberately **not** adopted in the #431 polish pass — moving the crawl into a job changes the tool's response contract; tracked as a follow-up, not a readiness blocker. Crawl budget stays hard-capped (100 pages / depth 5) meanwhile. |
+| `ctx.status` | skip | No credentials or external connection to report; the activate-time self-test already gates activation. |
+| `ctx.llm` | skip | The host LLM drives agent turns; the analyzers are deliberately deterministic (same HTML → same score). |
+| `ctx.mcp` | skip for 1.0 | Outbound fetches route through `ctx.http` with zero configuration — the plugin's design goal. Reaching external SEO tooling via a granted MCP server is a possible extension, not a readiness item. |
+
+Versioning: stays independently versioned (currently `0.1.0`); does not bump
+in lockstep with core. Package layout stays the flat agent-package shape —
+canonical per `agent-reference-maximum` (the declared pattern source) and the
+`middleware/assets/boilerplate/agent-*` starter templates; tool plugins use
+`src/` → `dist/`. Both shapes are the documented per-kind conventions.

--- a/middleware/packages/agent-seo-analyst/manifest.yaml
+++ b/middleware/packages/agent-seo-analyst/manifest.yaml
@@ -5,7 +5,7 @@ identity:
   domain: "seo"
   name: "SEO Analyst"
   version: "0.1.0"
-  description: "Analysiert byte5-Webseiten aus SEO-Perspektive: On-Page, Technical, Structured Data, Crawl-Audits."
+  description: "Analyzes websites from an SEO perspective: on-page, technical, structured data, and crawl audits."
   authors:
     - name: "byte5 GmbH"
       email: "info@omadia.ai"

--- a/middleware/packages/harness-orchestrator-extras/src/factExtractor.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/factExtractor.ts
@@ -40,9 +40,23 @@ export interface FactExtractorOptions {
 
 export interface ExtractInput {
   turnId: string;
+  /**
+   * #361 — when prompt masking is on, the caller passes the MASKED wire
+   * variants here: the extraction prompt goes to an LLM (Haiku), so it is
+   * wire content like the main call. Facts are restored via `restoreFacts`
+   * before persistence.
+   */
   userMessage: string;
   assistantAnswer: string;
   entityRefs: readonly EntityRef[];
+  /**
+   * #361 — surrogate→real inversion snapshot for this turn (see
+   * `PrivacyTurnHandle.snapshotPromptRestorer`). Applied to every extracted
+   * fact field before ingest, so the knowledge graph stores REAL values —
+   * never surrogates — while the Haiku call above only ever saw the masked
+   * text. Absent when the turn masked nothing.
+   */
+  restoreFacts?: (text: string) => string;
 }
 
 export interface ExtractedFact {
@@ -95,7 +109,21 @@ export class FactExtractor {
    */
   async extractAndIngest(input: ExtractInput): Promise<number> {
     try {
-      const facts = await this.extract(input);
+      const extracted = await this.extract(input);
+      // #361 — restore prompt surrogates → real values BEFORE persistence.
+      // The Haiku extraction above ran on masked wire text; the graph must
+      // store ground truth (a fabricated surrogate IBAN re-surfaced by
+      // recall as if real is memory poisoning). Identity when no restorer
+      // was passed (turn masked nothing / flag off).
+      const restore = input.restoreFacts;
+      const facts = restore
+        ? extracted.map((f) => ({
+            ...f,
+            subject: restore(f.subject),
+            predicate: restore(f.predicate),
+            object: restore(f.object),
+          }))
+        : extracted;
       if (facts.length === 0) {
         this.opts.log(`[fact-extractor] 0 facts turn=${shortTurn(input.turnId)}`);
         return 0;

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -104,6 +104,7 @@ import { LoopGuard } from './loopGuard.js';
 import {
   createPrivacyTurnHandle,
   ensureWellFormedParams,
+  type PrivacyTurnHandle,
 } from './privacyHandle.js';
 import { RunTraceCollector, type InvocationHandle } from './runTraceCollector.js';
 import {
@@ -490,7 +491,12 @@ type Message = any;
 function buildUserContent(
   input: ChatTurnInput,
   extraText?: string,
+  wireUserMessage?: string,
 ): ContentBlock[] | string {
+  // #361 — when prompt masking is on, the caller passes the pseudonym-
+  // substituted variant for the LLM wire; `input.userMessage` stays the
+  // original for memory persistence and receipt attribution.
+  const message = wireUserMessage ?? input.userMessage;
   // #268 — server-side auto-ingested attachment text, appended as a trailing
   // block so the model sees the document content without a tool call. Kept
   // additive to the existing image/bytesBase64 multimodal path.
@@ -500,10 +506,8 @@ function buildUserContent(
     (a) => a.kind === 'image' && typeof a.bytesBase64 === 'string',
   );
   if (imageAtts.length === 0) {
-    if (!ingested) return input.userMessage;
-    return input.userMessage.length > 0
-      ? `${input.userMessage}${ingested}`
-      : ingested;
+    if (!ingested) return message;
+    return message.length > 0 ? `${message}${ingested}` : ingested;
   }
   const blocks: ContentBlock[] = [];
   for (const att of imageAtts) {
@@ -516,11 +520,59 @@ function buildUserContent(
       },
     });
   }
-  const trailingText = `${input.userMessage}${ingested ?? ''}`;
+  const trailingText = `${message}${ingested ?? ''}`;
   if (trailingText.trim().length > 0) {
     blocks.push({ type: 'text', text: trailingText });
   }
   return blocks;
+}
+
+// ---------------------------------------------------------------------------
+// #361 — free-text user-prompt PII masking (wire side).
+// ---------------------------------------------------------------------------
+
+/** Thrown when prompt masking was requested but could not be guaranteed —
+ *  failure-closed: the turn is blocked instead of sending PII to the model. */
+export class PromptMaskBlockedError extends Error {
+  constructor(reason: string) {
+    super(`[privacy] user-prompt masking failed (${reason}) — turn blocked`);
+    this.name = 'PromptMaskBlockedError';
+  }
+}
+
+/** User-facing answer for a prompt-mask-blocked turn. Deliberately generic —
+ *  it must not echo any detected value. */
+const PROMPT_MASK_BLOCKED_ANSWER =
+  'This message could not be processed: privacy protection for your text ' +
+  'could not be guaranteed (prompt masking failed), so it was not sent to ' +
+  'the language model. Please try again or contact your operator.';
+
+/**
+ * Mask a wire-bound prompt text through the turn's privacy handle. Returns
+ * the text unchanged when no handle is present, the operator flag is off,
+ * or the text is empty — byte-identical legacy behavior. Throws
+ * `PromptMaskBlockedError` on the failure-closed `blocked` outcome.
+ */
+async function maskPromptForWire(
+  privacy: PrivacyTurnHandle | undefined,
+  text: string,
+): Promise<string> {
+  if (privacy === undefined || text.length === 0) return text;
+  const result = await privacy.maskUserPrompt(text);
+  if (result.outcome === 'blocked') {
+    throw new PromptMaskBlockedError(result.reason);
+  }
+  return result.outcome === 'masked' ? result.maskedText : text;
+}
+
+/** `maskPromptForWire` for the #268 ingested attachment tail — skips the
+ *  empty/whitespace case (`ingestAttachments` returns '' without docs). */
+async function maskIngestedForWire(
+  privacy: PrivacyTurnHandle | undefined,
+  ingestedText: string,
+): Promise<string> {
+  if (ingestedText.trim().length === 0) return ingestedText;
+  return maskPromptForWire(privacy, ingestedText);
 }
 
 const MEMORY_TOOL_NAME = 'memory';
@@ -1231,6 +1283,9 @@ export class Orchestrator {
         arguments: Record<string, unknown>;
       };
     }) => void,
+    // #361 — the wire-bound (possibly masked) message variant; nudge
+    // provider output can land back in LLM-bound tool_result content.
+    wireUserMessage?: string,
   ): Promise<void> {
     if (!this.nudgeRegistry) return;
     const registry = this.nudgeRegistry;
@@ -1280,7 +1335,7 @@ export class Orchestrator {
           turnContext: {
             turnId,
             agentId,
-            userMessage: input.userMessage,
+            userMessage: wireUserMessage ?? input.userMessage,
             toolTrace,
             sessionScope,
           },
@@ -1630,6 +1685,10 @@ export class Orchestrator {
    */
   private async retrievePriorContext(
     input: ChatTurnInput,
+    // #361 — the wire-bound (possibly masked) message variant. The recalled
+    // text this returns flows INTO the LLM prompt, so the recall query must
+    // not itself carry a raw PII span the mask pass just removed.
+    wireUserMessage?: string,
   ): Promise<{ text: string | undefined; recalled: RecalledContext | undefined }> {
     // Use console.error so the trace lands on stderr — Fly's log aggregator
     // has been observed to drop some stdout INFO lines under load, and this
@@ -1656,7 +1715,7 @@ export class Orchestrator {
       // directly should pass their manifest identity.id so per-agent
       // priorities apply.
       const result = await this.contextRetriever.assembleForBudget({
-        userMessage: input.userMessage,
+        userMessage: wireUserMessage ?? input.userMessage,
         // Per-orchestrator isolation: the real Agent identity drives the KG
         // scope-prefix filter (and agent_priorities). The retriever expects
         // the sessionScope already agent-qualified — `graphScopeFor` is the
@@ -1882,7 +1941,20 @@ export class Orchestrator {
         // the privacy-finalize block below so the verbatim answer is PII-masked
         // (Pitfall 3) and a receipt is attached.
         const direct = await this.executeDirectLine(input, turnId);
-        let result = direct ?? (await this.chatInContext(input, turnId));
+        let result: ChatTurnResult;
+        try {
+          result = direct ?? (await this.chatInContext(input, turnId));
+        } catch (err) {
+          // #361 — failure-closed prompt masking: the prompt never reached
+          // the model; answer with a generic privacy error instead of a raw
+          // 500. Audited above by the guard service itself.
+          if (err instanceof PromptMaskBlockedError) {
+            console.error(`[orchestrator] ${err.message}`);
+            result = { answer: PROMPT_MASK_BLOCKED_ANSWER, toolCalls: 0, iterations: 0 };
+          } else {
+            throw err;
+          }
+        }
         // Privacy Shield v4 — when a v4_render_answer call produced the
         // answer this turn it is final and already safe (real values
         // materialized server-side from ground truth). Swap it in.
@@ -1896,6 +1968,22 @@ export class Orchestrator {
                 ? { maskedValues: v4Rendered.maskedValues }
                 : {}),
             };
+          }
+        }
+        // #361 — restore prompt surrogates → real values over the final
+        // answer (identity when the turn masked nothing). Must run BEFORE
+        // finalize, which drops the turn's surrogate map.
+        if (privacyHandle) {
+          try {
+            result = {
+              ...result,
+              answer: await privacyHandle.restorePromptPseudonyms(result.answer),
+            };
+          } catch (err) {
+            console.warn(
+              '[orchestrator] restorePromptPseudonyms threw — answer left as-is:',
+              err,
+            );
           }
         }
         if (privacyHandle) {
@@ -2398,14 +2486,30 @@ export class Orchestrator {
     await this.fireTurnHook('onBeforeTurn', turnId, input, {
       userMessage: input.userMessage,
     });
+    // #361 — mask the wire-bound prompt BEFORE anything LLM-adjacent sees
+    // it. `wireUserMessage` is the LLM-facing variant (pseudonyms for
+    // detected PII spans when the operator flag is on; the original text
+    // otherwise). `input.userMessage` stays untouched for memory
+    // persistence (sessionLogger / factExtractor) and receipt attribution.
+    // Failure-closed: a `blocked` outcome throws and the turn fails.
+    const privacyForPrompt = turnContext.current()?.privacyHandle;
+    const wireUserMessage = await maskPromptForWire(
+      privacyForPrompt,
+      input.userMessage,
+    );
     // Non-streaming path: `priorContext` is injected into the prompt; the
     // structured `recalled` payload rides out on the ChatTurnResult so
     // non-streaming channels (Teams) can render a recall card (the streaming
     // path emits it as a `kg_recall` annotation instead).
     const { text: priorContext, recalled } =
-      await this.retrievePriorContext(input);
+      await this.retrievePriorContext(input, wireUserMessage);
     // #268 — pre-fetch + extract any uploaded document text for this turn.
-    const ingestedText = await this.ingestAttachments(input);
+    // #361 — the ingested verbatim tail crosses the wire alongside the
+    // message, so it is masked through the SAME turn map (stable surrogates).
+    const ingestedText = await maskIngestedForWire(
+      privacyForPrompt,
+      await this.ingestAttachments(input),
+    );
     const effectiveExtraSystemHint = composeExtraSystemHint(input);
     // Palaia Phase 8 (OB-77) — per-turn nudge counter (shared across all
     // tool-call iterations of this turn so NUDGE_MAX_PER_TURN is enforced).
@@ -2443,7 +2547,7 @@ export class Orchestrator {
         }
         return pair;
       }),
-      { role: 'user', content: buildUserContent(input, ingestedText) },
+      { role: 'user', content: buildUserContent(input, ingestedText, wireUserMessage) },
     ];
 
     // Open an EntityRef collection keyed to this turn. Tool handlers that
@@ -2496,8 +2600,8 @@ export class Orchestrator {
     // non-streaming path has no event channel, so both decisions are simply
     // applied (channels that want to surface them use chatStream).
     const [turnModelResolved, turnPersonaResolved] = await Promise.all([
-      this.resolveTurnModel(input.userMessage),
-      this.resolveTurnPersona(input.userMessage),
+      this.resolveTurnModel(wireUserMessage),
+      this.resolveTurnPersona(wireUserMessage),
     ]);
     const turnModel = turnModelResolved.model;
     const turnPersonaBody = turnPersonaResolved.skillBody;
@@ -2672,7 +2776,7 @@ export class Orchestrator {
           // intent as prose; route it through the existing handlers before the
           // drains below pick it up. No-op on Anthropic and on trivial answers.
           await this.maybeRouteCardsFromText(
-            input.userMessage,
+            wireUserMessage,
             answer,
             turnModel,
           );
@@ -2789,6 +2893,8 @@ export class Orchestrator {
           nudgeTrace,
           input,
           turnId,
+          undefined,
+          wireUserMessage,
         );
         // Round-loop guard. A `nudge` steer is appended to THIS iteration's
         // tool-result user message (keeping a single well-formed user turn);
@@ -3000,7 +3106,29 @@ export class Orchestrator {
         yield doneEvent;
         return;
       }
-      for await (const event of this.chatStreamInner(input, turnId, observer)) {
+      // #361 — failure-closed prompt masking (streaming path): the inner
+      // generator throws before any model call when masking cannot be
+      // guaranteed; convert that into a graceful privacy-error `done` event
+      // instead of tearing the stream down with a raw 500.
+      const inner = this.chatStreamInner(input, turnId, observer);
+      const guardedInner = (async function* () {
+        try {
+          yield* inner;
+        } catch (err) {
+          if (err instanceof PromptMaskBlockedError) {
+            console.error(`[orchestrator] ${err.message}`);
+            yield {
+              type: 'done',
+              answer: PROMPT_MASK_BLOCKED_ANSWER,
+              toolCalls: 0,
+              iterations: 0,
+            } as Extract<ChatStreamEvent, { type: 'done' }>;
+            return;
+          }
+          throw err;
+        }
+      })();
+      for await (const event of guardedInner) {
         if (event.type === 'tool_use') {
           toolNameById.set(event.id, event.name);
         } else if (event.type === 'tool_result') {
@@ -3034,6 +3162,22 @@ export class Orchestrator {
                     : {}),
                 }
               : event;
+          // #361 — restore prompt surrogates → real values on the final
+          // answer, before finalize drops the turn's surrogate map. Note:
+          // streamed text deltas may transiently show a surrogate; the
+          // `done` answer is authoritative (same contract as the v4
+          // rendered-answer swap above).
+          try {
+            doneEvent = {
+              ...doneEvent,
+              answer: await privacyHandle.restorePromptPseudonyms(doneEvent.answer),
+            };
+          } catch (err) {
+            console.warn(
+              '[orchestrator] restorePromptPseudonyms threw — answer left as-is:',
+              err,
+            );
+          }
           try {
             const receipt = await privacyHandle.finalize(input.userMessage);
             if (receipt) {
@@ -3088,8 +3232,15 @@ export class Orchestrator {
     turnId: string,
     observer: AskObserver | undefined,
   ): AsyncGenerator<ChatStreamEvent> {
+    // #361 — wire-bound prompt masking; see chatInContextInner for the full
+    // rationale. Same seam, streaming path.
+    const privacyForPrompt = turnContext.current()?.privacyHandle;
+    const wireUserMessage = await maskPromptForWire(
+      privacyForPrompt,
+      input.userMessage,
+    );
     const { text: priorContext, recalled } =
-      await this.retrievePriorContext(input);
+      await this.retrievePriorContext(input, wireUserMessage);
     // Cross-session recall probe — surface plans/processes/insights pulled
     // from prior sessions as a visible `kg_recall` card before the answer
     // streams in. No-op when every recall leg was empty.
@@ -3099,7 +3250,11 @@ export class Orchestrator {
     // can never break or delay the turn; additive/opaque to the model.
     yield* await this.toKgGraphAnnotationEvents(recalled);
     // #268 — pre-fetch + extract any uploaded document text for this turn.
-    const ingestedText = await this.ingestAttachments(input);
+    // #361 — masked through the same turn map as the message (see above).
+    const ingestedText = await maskIngestedForWire(
+      privacyForPrompt,
+      await this.ingestAttachments(input),
+    );
     const effectiveExtraSystemHint = composeExtraSystemHint(input);
     // Palaia Phase 8 (OB-77) — see chatInContextInner for rationale.
     const nudgeCounter = createNudgeTurnCounter();
@@ -3129,7 +3284,7 @@ export class Orchestrator {
         }
         return pair;
       }),
-      { role: 'user', content: buildUserContent(input, ingestedText) },
+      { role: 'user', content: buildUserContent(input, ingestedText, wireUserMessage) },
     ];
 
     const entityCollection = this.entityRefBus?.beginCollection(turnId);
@@ -3168,8 +3323,8 @@ export class Orchestrator {
     // classifier calls — run in parallel so persona routing adds no serial
     // latency. Resolved once so the whole streamed turn runs on one model.
     const [resolved, resolvedPersona] = await Promise.all([
-      this.resolveTurnModel(input.userMessage),
-      this.resolveTurnPersona(input.userMessage),
+      this.resolveTurnModel(wireUserMessage),
+      this.resolveTurnPersona(wireUserMessage),
     ]);
     const turnModel = resolved.model;
     const turnPersonaBody = resolvedPersona.skillBody;
@@ -3387,7 +3542,7 @@ export class Orchestrator {
           // intent as prose; route it through the existing handlers before the
           // drains below pick it up. No-op on Anthropic and on trivial answers.
           await this.maybeRouteCardsFromText(
-            input.userMessage,
+            wireUserMessage,
             answer,
             turnModel,
           );
@@ -3401,8 +3556,10 @@ export class Orchestrator {
           // carrier and the chat UI wants the suggestion immediately;
           // accept the 300-800ms latency cost. Failure → undefined,
           // modal falls back to its 240-char prefill.
+          // #361 — the excerpt pass is a Haiku (LLM) call, so it gets the
+          // wire variant; a masked span in the suggestion beats leaking it.
           const palaiaExcerpt = await this.maybeExtractExcerpt(
-            input.userMessage,
+            wireUserMessage,
             answer,
           );
           // Slice 4b/4c — auto-promotion. Awaited so the resulting
@@ -3570,6 +3727,7 @@ export class Orchestrator {
           (event) => {
             stagedNudgeEvents.push({ type: 'nudge', ...event });
           },
+          wireUserMessage,
         );
         for (const ev of stagedNudgeEvents) {
           yield ev;

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -3608,9 +3608,20 @@ export class Orchestrator {
         // present — at iteration ≥1 it's the tool_results turn) keeps roles
         // strictly alternating; otherwise we append a fresh user turn.
         for (const steerText of steeringBus.drain(steerKey)) {
+          // #361 (codex review fix) — steered text is LLM-bound wire content
+          // exactly like the original user message: mask it through the SAME
+          // per-turn map before it is appended, so answer-side restore covers
+          // steered spans too. Fails closed via PromptMaskBlockedError (the
+          // stream guard in chatStream converts it into a graceful privacy
+          // `done` event). The `steer_applied` event below stays RAW — it is
+          // user-facing echo, not wire content.
+          const wireSteerText = await maskPromptForWire(
+            privacyForPrompt,
+            steerText,
+          );
           const steerBlock = {
             type: 'text' as const,
-            text: `[Live user steering — added mid-turn]: ${steerText}`,
+            text: `[Live user steering — added mid-turn]: ${wireSteerText}`,
           };
           const last = messages[messages.length - 1];
           if (last && last.role === 'user') {

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -575,6 +575,74 @@ async function maskIngestedForWire(
   return maskPromptForWire(privacy, ingestedText);
 }
 
+/** `maskPromptForWire` for the recalled prior-context block. The recalled
+ *  TEXT is injected into the next prompt, so it is LLM-bound wire content:
+ *  a raw span recalled from turn N would undo the masking of turn N. Runs
+ *  through the SAME turn map, so answer-side restore covers these spans
+ *  too. Server-side stores stay raw — only the injected copy is masked. */
+async function maskRecalledForWire(
+  privacy: PrivacyTurnHandle | undefined,
+  recalledText: string | undefined,
+): Promise<string | undefined> {
+  if (recalledText === undefined || recalledText.trim().length === 0) {
+    return recalledText;
+  }
+  return maskPromptForWire(privacy, recalledText);
+}
+
+/**
+ * Restore prompt surrogates → real values in a text that is about to be
+ * PERSISTED (session log / KG / promoted memory) or returned as the final
+ * answer. Identity when no handle is present or nothing was masked.
+ * Best-effort: a restore failure must never lose the answer — the wire
+ * variant is logged and kept (surrogates, but no data loss and no leak).
+ */
+async function restorePromptForPersistence(
+  privacy: PrivacyTurnHandle | undefined,
+  text: string,
+): Promise<string> {
+  if (privacy === undefined || text.length === 0) return text;
+  try {
+    return await privacy.restorePromptPseudonyms(text);
+  } catch (err) {
+    console.warn(
+      '[orchestrator] restorePromptPseudonyms threw — text left as-is:',
+      err,
+    );
+    return text;
+  }
+}
+
+/**
+ * #361 — restore the string fields of a Palaia excerpt before it is
+ * persisted (auto-promotion) or shown in the save-as-memory modal. The
+ * excerpt came out of an LLM pass over masked wire text, so its copies may
+ * carry surrogates; stored memories must carry real values.
+ */
+async function restoreExcerptForPersistence(
+  privacy: PrivacyTurnHandle | undefined,
+  excerpt: PalaiaExcerpt | undefined,
+): Promise<PalaiaExcerpt | undefined> {
+  if (privacy === undefined || excerpt === undefined) return excerpt;
+  const restored = { ...excerpt };
+  restored.suggestedSummary = await restorePromptForPersistence(
+    privacy,
+    excerpt.suggestedSummary,
+  );
+  if (excerpt.suggestedRationale !== undefined) {
+    restored.suggestedRationale = await restorePromptForPersistence(
+      privacy,
+      excerpt.suggestedRationale,
+    );
+  }
+  const excerpts: string[] = [];
+  for (const span of excerpt.excerpts) {
+    excerpts.push(await restorePromptForPersistence(privacy, span));
+  }
+  restored.excerpts = excerpts;
+  return restored;
+}
+
 const MEMORY_TOOL_NAME = 'memory';
 const MEMORY_TOOL_TYPE = 'memory_20250818';
 const MEMORY_BETA_HEADER = 'context-management-2025-06-27';
@@ -2177,13 +2245,37 @@ export class Orchestrator {
     // answer. Fire-and-forget against Haiku, after the session log lands so the
     // Fact → Turn edge has an anchor. Never awaited; entityRefs are empty (the
     // relay issues no orchestrator-level tool calls of its own).
+    // #361 — the extraction prompt is LLM-bound, so a direct-line turn (which
+    // never masked anything up to here) masks both texts through the turn map
+    // first; the extracted facts are restored to real values before ingest.
+    // Fail closed on `blocked`: skip fact extraction (audited) rather than
+    // send an unmasked prompt — the user-visible answer is unaffected.
     if (this.factExtractor && persistedTurnId) {
-      void this.factExtractor.extractAndIngest({
-        turnId: persistedTurnId,
-        userMessage: input.userMessage,
-        assistantAnswer: answer,
-        entityRefs: [],
-      });
+      const privacyForPrompt = turnContext.current()?.privacyHandle;
+      try {
+        const maskedUserMessage = await maskPromptForWire(
+          privacyForPrompt,
+          input.userMessage,
+        );
+        const maskedAnswer = await maskPromptForWire(privacyForPrompt, answer);
+        const restoreFacts = privacyForPrompt?.snapshotPromptRestorer();
+        void this.factExtractor.extractAndIngest({
+          turnId: persistedTurnId,
+          userMessage: maskedUserMessage,
+          assistantAnswer: maskedAnswer,
+          entityRefs: [],
+          ...(restoreFacts ? { restoreFacts } : {}),
+        });
+      } catch (err) {
+        if (err instanceof PromptMaskBlockedError) {
+          console.error(
+            '[orchestrator] direct-line fact extraction skipped — ' +
+              `prompt masking blocked: ${err.message}`,
+          );
+        } else {
+          throw err;
+        }
+      }
     }
 
     return {
@@ -2501,8 +2593,17 @@ export class Orchestrator {
     // structured `recalled` payload rides out on the ChatTurnResult so
     // non-streaming channels (Teams) can render a recall card (the streaming
     // path emits it as a `kg_recall` annotation instead).
-    const { text: priorContext, recalled } =
+    const { text: rawPriorContext, recalled } =
       await this.retrievePriorContext(input, wireUserMessage);
+    // #361 — the recalled TEXT is LLM-bound wire content: it carries real
+    // values persisted from earlier turns, so it is masked through the SAME
+    // turn map before injection (answer-side restore covers these spans).
+    // The structured `recalled` payload stays raw — it goes to the UI, not
+    // the model.
+    const priorContext = await maskRecalledForWire(
+      privacyForPrompt,
+      rawPriorContext,
+    );
     // #268 — pre-fetch + extract any uploaded document text for this turn.
     // #361 — the ingested verbatim tail crosses the wire alongside the
     // message, so it is masked through the SAME turn map (stable surrogates).
@@ -2725,6 +2826,15 @@ export class Orchestrator {
             drainedAttachments.files.length > 0
               ? drainedAttachments.files
               : undefined;
+          // #361 — restore prompt surrogates → real values BEFORE anything
+          // is persisted: the session log / KG must store ground truth, or
+          // recall would re-surface fabricated surrogate IBANs/addresses as
+          // if real. `answer` (the wire variant) stays in scope for the
+          // LLM-bound extra passes below (card router, fact extraction).
+          const restoredAnswer = await restorePromptForPersistence(
+            privacyForPrompt,
+            answer,
+          );
           // Hoisted so the return payload can carry the KG turn id back to
           // the chat UI (powers the save-as-memory affordance). Stays
           // undefined when session-logging is disabled or threw.
@@ -2737,7 +2847,7 @@ export class Orchestrator {
             // the latency cost is worth the retrieval guarantee.
             const entityRefs = entityCollection?.drain() ?? [];
             const answerForGraph = appendToolDigest(
-              answer,
+              restoredAnswer,
               attachments,
               fileAttachments,
             );
@@ -2763,12 +2873,22 @@ export class Orchestrator {
             // session log lands in the graph (so the Fact → Turn
             // DERIVED_FROM edge finds its anchor). Never awaited — a slow
             // or failing extractor must not delay the user reply.
+            // #361 — the extraction prompt is LLM-bound, so it gets the
+            // MASKED wire variants; the extracted facts are restored to
+            // real values before ingest via the snapshot restorer (which
+            // stays valid after finalize drops the live map).
             if (this.factExtractor && persistedTurnId) {
+              const restoreFacts = privacyForPrompt?.snapshotPromptRestorer();
               void this.factExtractor.extractAndIngest({
                 turnId: persistedTurnId,
-                userMessage: input.userMessage,
-                assistantAnswer: answerForGraph,
+                userMessage: wireUserMessage,
+                assistantAnswer: appendToolDigest(
+                  answer,
+                  attachments,
+                  fileAttachments,
+                ),
                 entityRefs,
+                ...(restoreFacts ? { restoreFacts } : {}),
               });
             }
           }
@@ -2786,7 +2906,7 @@ export class Orchestrator {
           const pendingRoutineList = this.drainPendingRoutineList();
           const pendingOAuthConsent = this.drainConsentRequired();
           return {
-            answer,
+            answer: restoredAnswer,
             toolCalls,
             iterations,
             ...(persistedTurnId ? { turnId: persistedTurnId } : {}),
@@ -2936,6 +3056,11 @@ export class Orchestrator {
           // resolving the choice.
           this.drainPendingRoutineList();
           const answer = textParts.join('\n\n').trim();
+          // #361 — persisted + user-facing: restore surrogates → real values.
+          const restoredAnswer = await restorePromptForPersistence(
+            privacyForPrompt,
+            answer,
+          );
           const iterations = iteration + 1;
           const runTrace = traceCollector?.finish({
             iterations,
@@ -2944,8 +3069,8 @@ export class Orchestrator {
           let persistedTurnId: string | undefined;
           if (this.sessionLogger && input.sessionScope) {
             const entityRefs = entityCollection?.drain() ?? [];
-            const loggedAnswer = answer.length > 0
-              ? `${answer}\n\n[Rückfrage] ${pendingUserChoice.question}`
+            const loggedAnswer = restoredAnswer.length > 0
+              ? `${restoredAnswer}\n\n[Rückfrage] ${pendingUserChoice.question}`
               : `[Rückfrage] ${pendingUserChoice.question}`;
             try {
               const logged = await this.sessionLogger.log({
@@ -2967,7 +3092,7 @@ export class Orchestrator {
             }
           }
           return {
-            answer,
+            answer: restoredAnswer,
             toolCalls,
             iterations,
             pendingUserChoice,
@@ -3239,8 +3364,14 @@ export class Orchestrator {
       privacyForPrompt,
       input.userMessage,
     );
-    const { text: priorContext, recalled } =
+    const { text: rawPriorContext, recalled } =
       await this.retrievePriorContext(input, wireUserMessage);
+    // #361 — the recalled TEXT is LLM-bound wire content; mask through the
+    // same turn map before injection (see chatInContextInner).
+    const priorContext = await maskRecalledForWire(
+      privacyForPrompt,
+      rawPriorContext,
+    );
     // Cross-session recall probe — surface plans/processes/insights pulled
     // from prior sessions as a visible `kg_recall` card before the answer
     // streams in. No-op when every recall leg was empty.
@@ -3507,6 +3638,14 @@ export class Orchestrator {
             iterations,
             status: 'success',
           });
+          // #361 — restore prompt surrogates → real values BEFORE anything
+          // is persisted (session log, auto-promotion). `answer` (the wire
+          // variant) stays in scope for the LLM-bound extra passes below
+          // (card router, excerpt pass).
+          const restoredAnswer = await restorePromptForPersistence(
+            privacyForPrompt,
+            answer,
+          );
           let persistedTurnId: string | undefined;
           if (this.sessionLogger && input.sessionScope) {
             const entityRefs = entityCollection?.drain() ?? [];
@@ -3515,7 +3654,7 @@ export class Orchestrator {
             // are already committed to waiting for the final `done` event,
             // so the extra ~sub-second is paid by the client already.
             const answerForGraph = appendToolDigest(
-              answer,
+              restoredAnswer,
               attachments,
               fileAttachments,
             );
@@ -3557,10 +3696,12 @@ export class Orchestrator {
           // accept the 300-800ms latency cost. Failure → undefined,
           // modal falls back to its 240-char prefill.
           // #361 — the excerpt pass is a Haiku (LLM) call, so it gets the
-          // wire variant; a masked span in the suggestion beats leaking it.
-          const palaiaExcerpt = await this.maybeExtractExcerpt(
-            wireUserMessage,
-            answer,
+          // wire variants in; its OUTPUT is persisted (auto-promotion) and
+          // user-facing (modal prefill), so surrogates are restored to real
+          // values before either consumer sees it.
+          const palaiaExcerpt = await restoreExcerptForPersistence(
+            privacyForPrompt,
+            await this.maybeExtractExcerpt(wireUserMessage, answer),
           );
           // Slice 4b/4c — auto-promotion. Awaited so the resulting
           // mkId rides the same `done` event and the UI can render an
@@ -3571,7 +3712,7 @@ export class Orchestrator {
             turnId: persistedTurnId,
             userId: input.userId,
             palaiaExcerpt,
-            fallbackAssistantAnswer: answer,
+            fallbackAssistantAnswer: restoredAnswer,
           });
           // KG-insert chat visualization — when this turn wrote a node, pulse
           // the freshly-inserted neighbourhood in the floating pane. Best-effort
@@ -3580,7 +3721,7 @@ export class Orchestrator {
           const finalAgentsConsulted = deriveAgentsConsulted(runTrace);
           yield {
             type: 'done',
-            answer,
+            answer: restoredAnswer,
             toolCalls,
             iterations,
             model: turnModel,
@@ -3778,6 +3919,11 @@ export class Orchestrator {
           this.drainFollowUps();
           this.drainPendingSlotCard();
           const answer = textParts.join('\n\n').trim();
+          // #361 — persisted + user-facing: restore surrogates → real values.
+          const restoredAnswer = await restorePromptForPersistence(
+            privacyForPrompt,
+            answer,
+          );
           const iterations = iteration + 1;
           const runTrace = traceCollector?.finish({
             iterations,
@@ -3786,8 +3932,8 @@ export class Orchestrator {
           let persistedTurnId: string | undefined;
           if (this.sessionLogger && input.sessionScope) {
             const entityRefs = entityCollection?.drain() ?? [];
-            const loggedAnswer = answer.length > 0
-              ? `${answer}\n\n[Rückfrage] ${pendingUserChoice.question}`
+            const loggedAnswer = restoredAnswer.length > 0
+              ? `${restoredAnswer}\n\n[Rückfrage] ${pendingUserChoice.question}`
               : `[Rückfrage] ${pendingUserChoice.question}`;
             try {
               const logged = await this.sessionLogger.log({
@@ -3811,7 +3957,7 @@ export class Orchestrator {
           const choiceAgentsConsulted = deriveAgentsConsulted(runTrace);
           yield {
             type: 'done',
-            answer,
+            answer: restoredAnswer,
             toolCalls,
             iterations,
             model: turnModel,

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -590,6 +590,35 @@ async function maskRecalledForWire(
   return maskPromptForWire(privacy, recalledText);
 }
 
+/** #361 second-review fix — live chat history (`input.priorTurns`) is
+ *  LLM-bound wire content too: persisted turns store restored REAL values
+ *  by design, and channels replay them verbatim as priorTurns, so turn-N
+ *  PII would reach the model raw on turn N+1. Mask every prior userMessage
+ *  AND assistant answer through the SAME turn map before message assembly
+ *  (answer-side restore covers these spans as well). Empty pairs are
+ *  filtered so a failed prior turn can't poison context. */
+async function maskPriorTurnsForWire(
+  privacy: PrivacyTurnHandle | undefined,
+  priorTurns: ChatTurnInput['priorTurns'],
+): Promise<Array<{ role: 'user' | 'assistant'; content: string }>> {
+  const pairs: Array<{ role: 'user' | 'assistant'; content: string }> = [];
+  for (const t of priorTurns ?? []) {
+    if (t.userMessage.trim().length > 0) {
+      pairs.push({
+        role: 'user',
+        content: await maskPromptForWire(privacy, t.userMessage),
+      });
+    }
+    if (t.assistantAnswer.trim().length > 0) {
+      pairs.push({
+        role: 'assistant',
+        content: await maskPromptForWire(privacy, t.assistantAnswer),
+      });
+    }
+  }
+  return pairs;
+}
+
 /**
  * Restore prompt surrogates → real values in a text that is about to be
  * PERSISTED (session log / KG / promoted memory) or returned as the final
@@ -641,6 +670,55 @@ async function restoreExcerptForPersistence(
   }
   restored.excerpts = excerpts;
   return restored;
+}
+
+/** #361 — an `ask_user_choice` card (LLM tool call or card-router pass over
+ *  masked wire text) is user-facing: restore surrogates → real values in
+ *  question, rationale, and option labels/values before the channel renders
+ *  it (cosmetic surrogate exposure otherwise). Identity when no handle is
+ *  present or nothing was masked this turn. */
+async function restorePendingChoiceForUser(
+  privacy: PrivacyTurnHandle | undefined,
+  choice: PendingUserChoice | undefined,
+): Promise<PendingUserChoice | undefined> {
+  if (privacy === undefined || choice === undefined) return choice;
+  const options: PendingUserChoice['options'] = [];
+  for (const opt of choice.options) {
+    options.push({
+      label: await restorePromptForPersistence(privacy, opt.label),
+      value: await restorePromptForPersistence(privacy, opt.value),
+    });
+  }
+  const restored: PendingUserChoice = {
+    ...choice,
+    question: await restorePromptForPersistence(privacy, choice.question),
+    options,
+  };
+  if (choice.rationale !== undefined) {
+    restored.rationale = await restorePromptForPersistence(
+      privacy,
+      choice.rationale,
+    );
+  }
+  return restored;
+}
+
+/** #361 — same rationale as `restorePendingChoiceForUser`, for the
+ *  follow-up suggestion buttons (labels are shown to the user; the prompt
+ *  becomes the next turn's user message). */
+async function restoreFollowUpsForUser(
+  privacy: PrivacyTurnHandle | undefined,
+  followUps: FollowUpOption[] | undefined,
+): Promise<FollowUpOption[] | undefined> {
+  if (privacy === undefined || followUps === undefined) return followUps;
+  const out: FollowUpOption[] = [];
+  for (const f of followUps) {
+    out.push({
+      label: await restorePromptForPersistence(privacy, f.label),
+      prompt: await restorePromptForPersistence(privacy, f.prompt),
+    });
+  }
+  return out;
 }
 
 const MEMORY_TOOL_NAME = 'memory';
@@ -2142,8 +2220,28 @@ export class Orchestrator {
       );
     }
 
+    // #361 second-review fix — the relayed payload is LLM-bound wire
+    // content: `dispatchTool` hands it to an LLM-backed sub-agent verbatim.
+    // Mask it through the SAME turn map as a normal prompt; the sub-agent's
+    // answer is restored surrogate→real below, so the user still sees the
+    // real values (the no-redaction invariant holds on the restored text).
+    // Failure-closed: a `blocked` outcome answers with the generic privacy
+    // error (audited by the guard) instead of dispatching unmasked.
+    const privacyForPrompt = turnContext.current()?.privacyHandle;
+    let wirePayload: string;
+    try {
+      wirePayload = await maskPromptForWire(privacyForPrompt, directive.payload);
+    } catch (err) {
+      if (err instanceof PromptMaskBlockedError) {
+        console.error(`[orchestrator] direct-line dispatch blocked — ${err.message}`);
+        return { answer: PROMPT_MASK_BLOCKED_ANSWER, toolCalls: 0, iterations: 0 };
+      }
+      throw err;
+    }
+
     // Deterministic harness invocation through the choke point. Input is bound
-    // to the verbatim user payload — the orchestrator cannot reshape it.
+    // to the user payload — the orchestrator never reshapes it beyond the
+    // #361 privacy masking above (flag off ⇒ byte-identical verbatim relay).
     const collector = new RunTraceCollector({
       scope: input.sessionScope ?? turnId,
       ...(input.userId ? { userId: input.userId } : {}),
@@ -2154,16 +2252,16 @@ export class Orchestrator {
     let status: 'success' | 'error';
     try {
       // The domain-tool contract takes `{ question }` (see createDomainTool);
-      // bind it to the user's VERBATIM payload — the orchestrator never
-      // reshapes it. Routed through the SAME `dispatchTool` choke point as
-      // every other domain-tool dispatch (not a raw `tool.handle` call) so
-      // the Privacy Shield v4 masking cascade applies here too — #332
-      // gap-closure: a raw `tool.handle` call bypassed `dispatchTool`
-      // entirely, so a verbatim delegated answer was never interned even
-      // when a privacy guard was active.
+      // bind it to the user's payload (masked when the #361 flag is on,
+      // byte-identical otherwise). Routed through the SAME `dispatchTool`
+      // choke point as every other domain-tool dispatch (not a raw
+      // `tool.handle` call) so the Privacy Shield v4 masking cascade applies
+      // here too — #332 gap-closure: a raw `tool.handle` call bypassed
+      // `dispatchTool` entirely, so a verbatim delegated answer was never
+      // interned even when a privacy guard was active.
       verbatim = await this.dispatchTool(
         tool.name,
-        { question: directive.payload },
+        { question: wirePayload },
         handle.observer,
       );
       // `createDomainTool.handle` does not throw on a sub-agent failure — it
@@ -2179,7 +2277,13 @@ export class Orchestrator {
     handle.finish({ durationMs: Date.now() - startedAt, status });
     const runTrace = collector.finish({ iterations: 1, status });
 
-    // Harness-owned, attributed segment — byte-for-byte the sub-agent's words.
+    // #361 — the sub-agent may echo the masked payload's surrogates back;
+    // restore them to real values (identity when nothing was masked) before
+    // the text is rendered, persisted, or attributed.
+    verbatim = await restorePromptForPersistence(privacyForPrompt, verbatim);
+
+    // Harness-owned, attributed segment — byte-for-byte the sub-agent's words
+    // (post surrogate-restore, which only inverts the #361 pseudonym map).
     const delegatedAnswer: DelegatedAnswer = {
       agentId: candidate.agentId ?? candidate.toolName,
       label: candidate.label,
@@ -2251,7 +2355,6 @@ export class Orchestrator {
     // Fail closed on `blocked`: skip fact extraction (audited) rather than
     // send an unmasked prompt — the user-visible answer is unaffected.
     if (this.factExtractor && persistedTurnId) {
-      const privacyForPrompt = turnContext.current()?.privacyHandle;
       try {
         const maskedUserMessage = await maskPromptForWire(
           privacyForPrompt,
@@ -2628,26 +2731,18 @@ export class Orchestrator {
       domain?: string;
     }> = [];
 
+    // #361 — priorTurns replay persisted REAL values (turn N restored them
+    // before persistence), so they are masked through the same turn map
+    // before assembly. See maskPriorTurnsForWire.
+    const priorTurnMessages = await maskPriorTurnsForWire(
+      privacyForPrompt,
+      input.priorTurns,
+    );
     const messages: Array<{ role: 'user' | 'assistant'; content: ContentBlock[] | string }> = [
       // Live chat history first. Each turn becomes a (user, assistant) pair —
       // same shape the Anthropic API expects for a multi-turn conversation.
       // Empty pairs are filtered so a failed prior turn can't poison context.
-      ...(input.priorTurns ?? []).flatMap<{
-        role: 'user' | 'assistant';
-        content: ContentBlock[] | string;
-      }>((t) => {
-        const pair: Array<{
-          role: 'user' | 'assistant';
-          content: ContentBlock[] | string;
-        }> = [];
-        if (t.userMessage.trim().length > 0) {
-          pair.push({ role: 'user', content: t.userMessage });
-        }
-        if (t.assistantAnswer.trim().length > 0) {
-          pair.push({ role: 'assistant', content: t.assistantAnswer });
-        }
-        return pair;
-      }),
+      ...priorTurnMessages,
       { role: 'user', content: buildUserContent(input, ingestedText, wireUserMessage) },
     ];
 
@@ -2900,8 +2995,16 @@ export class Orchestrator {
             answer,
             turnModel,
           );
-          const pendingUserChoice = this.drainPendingChoice();
-          const followUpOptions = this.drainFollowUps();
+          // #361 — card contents came out of an LLM pass over masked wire
+          // text and are user-facing; restore surrogates → real values.
+          const pendingUserChoice = await restorePendingChoiceForUser(
+            privacyForPrompt,
+            this.drainPendingChoice(),
+          );
+          const followUpOptions = await restoreFollowUpsForUser(
+            privacyForPrompt,
+            this.drainFollowUps(),
+          );
           const pendingSlotCard = this.drainPendingSlotCard();
           const pendingRoutineList = this.drainPendingRoutineList();
           const pendingOAuthConsent = this.drainConsentRequired();
@@ -3039,9 +3142,13 @@ export class Orchestrator {
         // plugin-tool result this batch. Stored on the orchestrator until
         // the done block drains it. Doesn't affect short-circuit decisions.
         this.extractToolEmittedRoutineList(toolResults);
-        const pendingUserChoice =
+        // #361 — the choice card is user-facing AND its question is
+        // persisted in the session log; restore surrogates → real values.
+        const pendingUserChoice = await restorePendingChoiceForUser(
+          privacyForPrompt,
           this.drainPendingChoice() ??
-          this.extractToolEmittedChoice(toolResults);
+            this.extractToolEmittedChoice(toolResults),
+        );
         if (pendingUserChoice) {
           this.drainAttachments();
           // Follow-up suggestions are incompatible with a blocking choice
@@ -3397,24 +3504,15 @@ export class Orchestrator {
       domain?: string;
     }> = [];
 
+    // #361 — priorTurns are masked through the same turn map before
+    // assembly; see chatInContextInner / maskPriorTurnsForWire.
+    const priorTurnMessages = await maskPriorTurnsForWire(
+      privacyForPrompt,
+      input.priorTurns,
+    );
     const messages: Array<{ role: 'user' | 'assistant'; content: ContentBlock[] | string }> = [
       // Same in-memory history injection as chat() — see chatInContext().
-      ...(input.priorTurns ?? []).flatMap<{
-        role: 'user' | 'assistant';
-        content: ContentBlock[] | string;
-      }>((t) => {
-        const pair: Array<{
-          role: 'user' | 'assistant';
-          content: ContentBlock[] | string;
-        }> = [];
-        if (t.userMessage.trim().length > 0) {
-          pair.push({ role: 'user', content: t.userMessage });
-        }
-        if (t.assistantAnswer.trim().length > 0) {
-          pair.push({ role: 'assistant', content: t.assistantAnswer });
-        }
-        return pair;
-      }),
+      ...priorTurnMessages,
       { role: 'user', content: buildUserContent(input, ingestedText, wireUserMessage) },
     ];
 
@@ -3685,8 +3783,16 @@ export class Orchestrator {
             answer,
             turnModel,
           );
-          const pendingUserChoice = this.drainPendingChoice();
-          const followUpOptions = this.drainFollowUps();
+          // #361 — card contents came out of an LLM pass over masked wire
+          // text and are user-facing; restore surrogates → real values.
+          const pendingUserChoice = await restorePendingChoiceForUser(
+            privacyForPrompt,
+            this.drainPendingChoice(),
+          );
+          const followUpOptions = await restoreFollowUpsForUser(
+            privacyForPrompt,
+            this.drainFollowUps(),
+          );
           const pendingSlotCard = this.drainPendingSlotCard();
           const pendingRoutineList = this.drainPendingRoutineList();
           const pendingOAuthConsent = this.drainConsentRequired();
@@ -3908,9 +4014,13 @@ export class Orchestrator {
         // plugin-tool result this batch. Stored on the orchestrator until
         // the done block drains it. Doesn't affect short-circuit decisions.
         this.extractToolEmittedRoutineList(toolResults);
-        const pendingUserChoice =
+        // #361 — the choice card is user-facing AND its question is
+        // persisted in the session log; restore surrogates → real values.
+        const pendingUserChoice = await restorePendingChoiceForUser(
+          privacyForPrompt,
           this.drainPendingChoice() ??
-          this.extractToolEmittedChoice(toolResults);
+            this.extractToolEmittedChoice(toolResults),
+        );
         if (pendingUserChoice) {
           this.drainAttachments();
           // Follow-up suggestions are incompatible with a blocking choice

--- a/middleware/packages/harness-orchestrator/src/privacyHandle.ts
+++ b/middleware/packages/harness-orchestrator/src/privacyHandle.ts
@@ -95,6 +95,14 @@ export interface PrivacyTurnHandle {
    */
   restorePromptPseudonyms(text: string): Promise<string>;
   /**
+   * #361 — snapshot this turn's surrogate→real inversion as a synchronous
+   * closure that stays valid after `finalize` dropped the live map. For the
+   * fire-and-forget fact-extraction path, which must restore extracted
+   * facts to real values before persisting them. `undefined` when nothing
+   * was masked this turn (or the provider predates the contract).
+   */
+  snapshotPromptRestorer(): ((text: string) => string) | undefined;
+  /**
    * Drop the turn's Dataset Store and drain the user-facing receipt.
    * `turnInput` — the requester's own message text — lets the receipt
    * report identity values the user named themselves. Returns `undefined`
@@ -183,6 +191,10 @@ export function createPrivacyTurnHandle(deps: {
     async restorePromptPseudonyms(text) {
       if (deps.service.restorePromptPseudonyms === undefined) return text;
       return deps.service.restorePromptPseudonyms(deps.turnId, text);
+    },
+
+    snapshotPromptRestorer() {
+      return deps.service.snapshotPromptRestorer?.(deps.turnId);
     },
 
     async finalize(turnInput) {

--- a/middleware/packages/harness-orchestrator/src/privacyHandle.ts
+++ b/middleware/packages/harness-orchestrator/src/privacyHandle.ts
@@ -12,6 +12,7 @@
 
 import type {
   PrivacyGuardService,
+  PrivacyPromptMaskResult,
   PrivacyReceipt,
   PrivacyRenderedAnswer,
   PrivacyV4ToolSpec,
@@ -78,6 +79,21 @@ export interface PrivacyTurnHandle {
   takeRenderedAnswerV4(): Promise<PrivacyRenderedAnswer | undefined>;
   /** The verb + render tool specs to offer the LLM. */
   v4ToolSpecs(): ReadonlyArray<PrivacyV4ToolSpec>;
+  /**
+   * #361 — mask PII spans in a wire-bound prompt text (user message or
+   * ingested attachment tail). `disabled` when the operator flag is off or
+   * the provider predates the contract — the caller uses the original text
+   * (byte-identical legacy behavior). `blocked` = failure-closed: the turn
+   * MUST fail instead of sending the prompt. Repeated calls within the
+   * turn share one server-held surrogate map.
+   */
+  maskUserPrompt(text: string): Promise<PrivacyPromptMaskResult>;
+  /**
+   * #361 — invert this turn's prompt-surrogate map over the final answer.
+   * Identity when nothing was masked. Must run BEFORE `finalize` (which
+   * drops the map).
+   */
+  restorePromptPseudonyms(text: string): Promise<string>;
   /**
    * Drop the turn's Dataset Store and drain the user-facing receipt.
    * `turnInput` — the requester's own message text — lets the receipt
@@ -149,6 +165,24 @@ export function createPrivacyTurnHandle(deps: {
 
     v4ToolSpecs() {
       return deps.service.v4ToolSpecs();
+    },
+
+    async maskUserPrompt(text) {
+      // Optional on the service contract — providers (and test stubs) that
+      // predate #361 simply never mask.
+      if (deps.service.maskUserPrompt === undefined) {
+        return { outcome: 'disabled' };
+      }
+      return deps.service.maskUserPrompt({
+        sessionId: deps.sessionId,
+        turnId: deps.turnId,
+        text,
+      });
+    },
+
+    async restorePromptPseudonyms(text) {
+      if (deps.service.restorePromptPseudonyms === undefined) return text;
+      return deps.service.restorePromptPseudonyms(deps.turnId, text);
     },
 
     async finalize(turnInput) {

--- a/middleware/packages/harness-orchestrator/src/registry/agentGraphStore.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/agentGraphStore.ts
@@ -394,6 +394,8 @@ interface PluginVerdictDbRow {
   computed_at: Date;
   ack_by: string | null;
   ack_at: Date | null;
+  /** Severity at ack time — drives ack invalidation on a WORSE re-scan. */
+  ack_severity: string | null;
 }
 
 interface SkillResourceDbRow {
@@ -1097,12 +1099,31 @@ export class AgentGraphStore {
   }
 
   /**
-   * Upsert deliberately leaves `ack_by`/`ack_at` untouched: an operator ack
-   * survives a re-scan under the same verifier_version, while a verifier
-   * upgrade produces a fresh row (new PK) with no ack — see
-   * migration 0021_plugin_verdict.sql.
+   * Upsert keeps an operator ack only while the new severity is equal or
+   * BETTER than the severity the operator actually acknowledged
+   * (`ack_severity`, recorded at ack time): a re-scan that upgrades the row
+   * to something WORSE (e.g. acked `scan_failed` → `high_risk`) clears
+   * `ack_by`/`ack_at`/`ack_severity`, because the operator never saw those
+   * findings. Comparing against `ack_severity` (not the live severity)
+   * keeps the scheduler's interim `pending` write from destroying the
+   * comparison baseline. A verifier upgrade produces a fresh row (new PK)
+   * with no ack — see migration 0021_plugin_verdict.sql. Severity ranks
+   * mirror SEVERITY_RANK in middleware/src/services/skillVerdict.ts.
    */
   async upsertPluginVerdict(row: PluginVerdictRow): Promise<void> {
+    const rank = (expr: string): string =>
+      `CASE ${expr}
+         WHEN 'no_signals' THEN 0
+         WHEN 'pending' THEN 1
+         WHEN 'scan_failed' THEN 2
+         WHEN 'too_large_to_scan' THEN 3
+         WHEN 'flagged' THEN 4
+         WHEN 'high_risk' THEN 5
+         ELSE 6 END`;
+    const ackSurvives =
+      `plugin_verdicts.ack_by IS NOT NULL AND ` +
+      `${rank('EXCLUDED.severity')} <= ` +
+      `${rank('COALESCE(plugin_verdicts.ack_severity, plugin_verdicts.severity)')}`;
     await this.pool.query(
       `INSERT INTO plugin_verdicts
          (content_hash, verifier_version, plugin_id, severity, findings, scanner_version, rationale, computed_at)
@@ -1113,7 +1134,10 @@ export class AgentGraphStore {
          findings        = EXCLUDED.findings,
          scanner_version = EXCLUDED.scanner_version,
          rationale       = EXCLUDED.rationale,
-         computed_at     = EXCLUDED.computed_at`,
+         computed_at     = EXCLUDED.computed_at,
+         ack_by          = CASE WHEN ${ackSurvives} THEN plugin_verdicts.ack_by ELSE NULL END,
+         ack_at          = CASE WHEN ${ackSurvives} THEN plugin_verdicts.ack_at ELSE NULL END,
+         ack_severity    = CASE WHEN ${ackSurvives} THEN plugin_verdicts.ack_severity ELSE NULL END`,
       [
         row.contentHash,
         row.verifierVersion,
@@ -1140,8 +1164,10 @@ export class AgentGraphStore {
     return new Map(rows.map((row) => [row.content_hash, mapPluginVerdict(row)]));
   }
 
-  /** Ack the existing verdict row. Returns undefined when nothing has been
-   *  scanned yet — there is no verdict to acknowledge. */
+  /** Ack the existing verdict row. Records the acked severity alongside so
+   *  a later re-scan that WORSENS the verdict can invalidate the ack (see
+   *  upsertPluginVerdict). Returns undefined when nothing has been scanned
+   *  yet — there is no verdict to acknowledge. */
   async upsertPluginVerdictAck(
     contentHash: string,
     verifierVersion: string,
@@ -1149,7 +1175,7 @@ export class AgentGraphStore {
   ): Promise<{ ackBy: string; ackAt: Date } | undefined> {
     const { rows } = await this.pool.query<{ ack_by: string; ack_at: Date }>(
       `UPDATE plugin_verdicts
-       SET ack_by = $3, ack_at = now()
+       SET ack_by = $3, ack_at = now(), ack_severity = severity
        WHERE content_hash = $1 AND verifier_version = $2
        RETURNING ack_by, ack_at`,
       [contentHash, verifierVersion, ackedBy],

--- a/middleware/packages/harness-orchestrator/src/registry/agentGraphStore.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/agentGraphStore.ts
@@ -114,6 +114,34 @@ export interface SkillVerdictRow {
   readonly computedAt: Date;
 }
 
+/**
+ * Mirrored from `middleware/src/services/pluginScanner.ts`; keep in sync.
+ * The route layer wires these together via structural typing.
+ */
+export interface PluginScanFinding {
+  readonly code: string;
+  readonly severity: string;
+  readonly message: string;
+  readonly file: string | null;
+}
+
+/**
+ * Mirrored from `middleware/src/services/pluginVerdict.ts`; keep in sync.
+ * The route layer wires these together via structural typing.
+ */
+export interface PluginVerdictRow {
+  readonly contentHash: string;
+  readonly verifierVersion: string;
+  readonly pluginId: string;
+  readonly severity: Severity;
+  readonly findings: readonly PluginScanFinding[];
+  readonly scannerVersion: string;
+  readonly rationale: string | null;
+  readonly computedAt: Date;
+  readonly ackBy: string | null;
+  readonly ackAt: Date | null;
+}
+
 export interface SkillResourceRow {
   readonly id: string;
   readonly skillId: string;
@@ -353,6 +381,19 @@ interface SkillVerdictDbRow {
   risk_codes: unknown;
   rationale: string | null;
   computed_at: Date;
+}
+
+interface PluginVerdictDbRow {
+  content_hash: string;
+  verifier_version: string;
+  plugin_id: string;
+  severity: string;
+  findings: unknown;
+  scanner_version: string;
+  rationale: string | null;
+  computed_at: Date;
+  ack_by: string | null;
+  ack_at: Date | null;
 }
 
 interface SkillResourceDbRow {
@@ -609,6 +650,42 @@ function mapSkillVerdict(r: SkillVerdictDbRow): SkillVerdictRow {
     riskCodes: parseSkillVerdictRiskCodes(r.risk_codes),
     rationale: r.rationale,
     computedAt: r.computed_at,
+  };
+}
+
+function parsePluginScanFindings(value: unknown): readonly PluginScanFinding[] {
+  const raw = typeof value === 'string' ? JSON.parse(value) : value;
+  if (!Array.isArray(raw)) return [];
+  const parsed: PluginScanFinding[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const f = entry as Record<string, unknown>;
+    if (typeof f['code'] !== 'string' || typeof f['severity'] !== 'string') continue;
+    parsed.push({
+      code: f['code'],
+      severity: f['severity'],
+      message: typeof f['message'] === 'string' ? f['message'] : '',
+      file: typeof f['file'] === 'string' ? f['file'] : null,
+    });
+  }
+  return parsed;
+}
+
+function mapPluginVerdict(r: PluginVerdictDbRow): PluginVerdictRow {
+  if (!isSeverity(r.severity)) {
+    throw new Error(`unexpected plugin verdict severity in DB: ${String(r.severity)}`);
+  }
+  return {
+    contentHash: r.content_hash,
+    verifierVersion: r.verifier_version,
+    pluginId: r.plugin_id,
+    severity: r.severity,
+    findings: parsePluginScanFindings(r.findings),
+    scannerVersion: r.scanner_version,
+    rationale: r.rationale,
+    computedAt: r.computed_at,
+    ackBy: r.ack_by,
+    ackAt: r.ack_at,
   };
 }
 
@@ -986,6 +1063,99 @@ export class AgentGraphStore {
     );
     const row = rows[0]!;
     return { ackedBy: row.acked_by, ackedAt: row.acked_at };
+  }
+
+  // ── plugin code-scan verdicts (issue #453) ─────────────────────────────────
+
+  async getPluginVerdict(
+    contentHash: string,
+    verifierVersion: string,
+  ): Promise<PluginVerdictRow | undefined> {
+    const { rows } = await this.pool.query<PluginVerdictDbRow>(
+      `SELECT * FROM plugin_verdicts
+       WHERE content_hash = $1 AND verifier_version = $2`,
+      [contentHash, verifierVersion],
+    );
+    const row = rows[0];
+    return row ? mapPluginVerdict(row) : undefined;
+  }
+
+  /** Latest verdict for a plugin id — fallback lookup when the uploaded-
+   *  package record (and with it the sha256) is no longer around. */
+  async getLatestPluginVerdict(
+    pluginId: string,
+    verifierVersion: string,
+  ): Promise<PluginVerdictRow | undefined> {
+    const { rows } = await this.pool.query<PluginVerdictDbRow>(
+      `SELECT * FROM plugin_verdicts
+       WHERE plugin_id = $1 AND verifier_version = $2
+       ORDER BY computed_at DESC LIMIT 1`,
+      [pluginId, verifierVersion],
+    );
+    const row = rows[0];
+    return row ? mapPluginVerdict(row) : undefined;
+  }
+
+  /**
+   * Upsert deliberately leaves `ack_by`/`ack_at` untouched: an operator ack
+   * survives a re-scan under the same verifier_version, while a verifier
+   * upgrade produces a fresh row (new PK) with no ack — see
+   * migration 0021_plugin_verdict.sql.
+   */
+  async upsertPluginVerdict(row: PluginVerdictRow): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO plugin_verdicts
+         (content_hash, verifier_version, plugin_id, severity, findings, scanner_version, rationale, computed_at)
+       VALUES ($1,$2,$3,$4,$5::jsonb,$6,$7,$8)
+       ON CONFLICT (content_hash, verifier_version) DO UPDATE SET
+         plugin_id       = EXCLUDED.plugin_id,
+         severity        = EXCLUDED.severity,
+         findings        = EXCLUDED.findings,
+         scanner_version = EXCLUDED.scanner_version,
+         rationale       = EXCLUDED.rationale,
+         computed_at     = EXCLUDED.computed_at`,
+      [
+        row.contentHash,
+        row.verifierVersion,
+        row.pluginId,
+        row.severity,
+        JSON.stringify(row.findings),
+        row.scannerVersion,
+        row.rationale,
+        row.computedAt,
+      ],
+    );
+  }
+
+  async getPluginVerdictsByShas(
+    contentHashes: readonly string[],
+    verifierVersion: string,
+  ): Promise<Map<string, PluginVerdictRow>> {
+    if (contentHashes.length === 0) return new Map<string, PluginVerdictRow>();
+    const { rows } = await this.pool.query<PluginVerdictDbRow>(
+      `SELECT * FROM plugin_verdicts
+       WHERE content_hash = ANY($1) AND verifier_version = $2`,
+      [contentHashes, verifierVersion],
+    );
+    return new Map(rows.map((row) => [row.content_hash, mapPluginVerdict(row)]));
+  }
+
+  /** Ack the existing verdict row. Returns undefined when nothing has been
+   *  scanned yet — there is no verdict to acknowledge. */
+  async upsertPluginVerdictAck(
+    contentHash: string,
+    verifierVersion: string,
+    ackedBy: string,
+  ): Promise<{ ackBy: string; ackAt: Date } | undefined> {
+    const { rows } = await this.pool.query<{ ack_by: string; ack_at: Date }>(
+      `UPDATE plugin_verdicts
+       SET ack_by = $3, ack_at = now()
+       WHERE content_hash = $1 AND verifier_version = $2
+       RETURNING ack_by, ack_at`,
+      [contentHash, verifierVersion, ackedBy],
+    );
+    const row = rows[0];
+    return row ? { ackBy: row.ack_by, ackAt: row.ack_at } : undefined;
   }
 
   // ── MCP tool verdicts (epic #459 W1, issue #454) ───────────────────────────

--- a/middleware/packages/harness-plugin-privacy-guard/README.md
+++ b/middleware/packages/harness-plugin-privacy-guard/README.md
@@ -22,20 +22,28 @@ only permission is `llm` (see below).
 
 The one setup field is `mask_user_prompt` (enum `off`/`on`, **default
 `off`** — flag-off is byte-identical to pre-#361 behavior). When on, PII
-spans detected in the user's own message (and the ingested attachment tail)
-are substituted with realistic, type-shaped pseudonyms before the prompt
-crosses the LLM wire; the surrogate↔real map is held server-side per turn
-and inverted over the final answer. Wire-substitution with answer-side
-restore — NOT server-side interning (the prompt must cross the wire) and
-NOT an on-wire token map (deleted for cause by #119/#126/#153).
+spans detected in the user's own message are substituted with realistic,
+type-shaped pseudonyms in **every LLM-bound copy of the turn** — the main
+prompt, the ingested attachment tail, the recalled prior-context block,
+and auxiliary LLM passes (fact extraction, model/persona routing, card
+router, excerpt) — while the surrogate↔real map is held server-side per
+turn and inverted over the final answer **and over everything persisted**
+(session log, extracted KG facts, promoted memories store real values,
+never surrogates). Wire-substitution with answer-side restore — NOT
+server-side interning (the prompt must cross the wire) and NOT an on-wire
+token map (deleted for cause by #119/#126/#153).
 
-- **Detection:** pluggable `PromptPiiDetector` seam. Shipped: the
-  deterministic **C0 regex baseline** (email, IBAN, phone, German
+- **Detection:** pluggable `PromptPiiDetector` seam. Shipped today: the
+  deterministic **C0 regex baseline only** (email, IBAN, phone, German
   postal+street, currency/salary amounts, DOB dates). Names/free-form
   entities need the **C1 transformer** slot (Piiranha/GLiNER), which ships
-  as an inert stub until the committed validation harness
-  (`src/validation/`, runnable via `npx tsx …/promptDetectorEval.ts`)
-  passes its documented recall gates for a locale.
+  as an **inert stub** until the committed validation harness
+  (`src/validation/`, runnable via `npx tsx …/promptDetectorEval.ts`,
+  fixtures currently `de` + `en`) passes its documented gates for a locale
+  (structured-identifier recall ≥ 0.97, person recall ≥ 0.90 with C1,
+  precision proxy ≥ 0.85, p95 added latency ≤ 400 ms).
+- **Flag policy:** enabling `mask_user_prompt` for a locale requires
+  posting a green harness run for that locale to issue #361 first.
 - **Failure-closed:** the C1 detector throwing degrades to C0 with a
   `promptMaskDegraded` audit line; a baseline failure or a residual real
   span surviving substitution **blocks the turn** — there is no

--- a/middleware/packages/harness-plugin-privacy-guard/README.md
+++ b/middleware/packages/harness-plugin-privacy-guard/README.md
@@ -14,9 +14,34 @@ every tool result:
 5. Each turn emits a PII-free **PrivacyReceipt** that the channel renderers
    (Teams Adaptive Card, web inline disclosure) surface to the user.
 
-There are no setup fields: the boundary is generic over JSON shape and value
-statistics — no per-tenant policy, allowlist, or detector configuration.
-The only permission is `llm` (see below).
+The boundary itself has no configuration: it is generic over JSON shape and
+value statistics — no per-tenant policy, allowlist, or detector tuning. The
+only permission is `llm` (see below).
+
+## Free-text user-prompt masking (#361, default off)
+
+The one setup field is `mask_user_prompt` (enum `off`/`on`, **default
+`off`** — flag-off is byte-identical to pre-#361 behavior). When on, PII
+spans detected in the user's own message (and the ingested attachment tail)
+are substituted with realistic, type-shaped pseudonyms before the prompt
+crosses the LLM wire; the surrogate↔real map is held server-side per turn
+and inverted over the final answer. Wire-substitution with answer-side
+restore — NOT server-side interning (the prompt must cross the wire) and
+NOT an on-wire token map (deleted for cause by #119/#126/#153).
+
+- **Detection:** pluggable `PromptPiiDetector` seam. Shipped: the
+  deterministic **C0 regex baseline** (email, IBAN, phone, German
+  postal+street, currency/salary amounts, DOB dates). Names/free-form
+  entities need the **C1 transformer** slot (Piiranha/GLiNER), which ships
+  as an inert stub until the committed validation harness
+  (`src/validation/`, runnable via `npx tsx …/promptDetectorEval.ts`)
+  passes its documented recall gates for a locale.
+- **Failure-closed:** the C1 detector throwing degrades to C0 with a
+  `promptMaskDegraded` audit line; a baseline failure or a residual real
+  span surviving substitution **blocks the turn** — there is no
+  pass-through-unmasked path.
+- **Transparency:** masked spans surface (type + detector only, PII-free)
+  as `maskedPromptSpans` on the turn's `PrivacyReceipt`.
 
 ## Canonical implementation path (resolved in #431)
 
@@ -41,9 +66,10 @@ behavioral gain.
 | `ctx.status` | skip | No external connection or degraded mode to report. |
 | `ctx.mcp` | skip | MCP tool results reach the boundary via the orchestrator choke point (`internToolResultV4`) like every other tool result; the guard must not source data itself. |
 
-Versioning: manifest and `package.json` are aligned at `0.2.0` (the
-`package.json 0.1.0` mismatch was fixed in #431). Stays independently
-versioned; does not bump in lockstep with core.
+Versioning: manifest and `package.json` are aligned (the `package.json
+0.1.0` vs manifest `0.2.0` mismatch was fixed in #431; both bumped to
+`0.3.0` with #361). Stays independently versioned; does not bump in
+lockstep with core.
 
 ## Tests
 

--- a/middleware/packages/harness-plugin-privacy-guard/README.md
+++ b/middleware/packages/harness-plugin-privacy-guard/README.md
@@ -1,0 +1,54 @@
+# Privacy Guard (`@omadia/plugin-privacy-guard`)
+
+Privacy Shield **v4 — Data-Plane Boundary**. Publishes the
+`privacy.redact@1` capability the orchestrator's tool-dispatch hook calls on
+every tool result:
+
+1. Raw tool results are **interned server-side** into a per-turn Dataset
+   Store — real rows never reach the LLM wire.
+2. The LLM receives only a shape-classified, identity-free **Digest**.
+3. Identity-/order-critical work (filter, sort, join, aggregate) runs through
+   a server-side **Verb API** (`v4_*` tools) against the real rows.
+4. The final answer is **materialized from ground truth** via
+   `v4_render_answer`; real values are resolved behind the boundary.
+5. Each turn emits a PII-free **PrivacyReceipt** that the channel renderers
+   (Teams Adaptive Card, web inline disclosure) surface to the user.
+
+There are no setup fields: the boundary is generic over JSON shape and value
+statistics — no per-tenant policy, allowlist, or detector configuration.
+The only permission is `llm` (see below).
+
+## Canonical implementation path (resolved in #431)
+
+`src/service.ts` (**the** v4 service factory, `createPrivacyGuardService`)
+plus the `src/v4/` engine modules (datasetStore, shapeClassifier, digest,
+verbs, materializer, pseudonym, onTheWire, piiClassifier) are the **single
+canonical implementation**. There is no parallel legacy path: the pre-v4
+on-wire token map (`«TYPE_N»`), its response restore pass, and the Presidio
+NER sidecar were removed by #119/#126/#153/#242 — the documented failure
+modes live in `plugin-api/src/piiAnnotation.ts` as the historical record.
+The `v4/` directory name is kept deliberately: it is the engine namespace
+that tests (`middleware/test/privacyV4*.test.ts`) and the #361 prompt-mask
+design reference; flattening it would churn PII-handling paths for no
+behavioral gain.
+
+## PluginContext surface — v1.0 readiness audit (#431)
+
+| Surface | Decision | Rationale |
+|---|---|---|
+| `ctx.llm` | **adopted** (Slice 2) | Schema-level PII classification (field names + types only, never values); absent LLM ⇒ byte-identical no-classifier behavior. |
+| `ctx.jobs` | skip | All state is turn-scoped and dropped in `finalizeTurn`; nothing outlives a turn. |
+| `ctx.status` | skip | No external connection or degraded mode to report. |
+| `ctx.mcp` | skip | MCP tool results reach the boundary via the orchestrator choke point (`internToolResultV4`) like every other tool result; the guard must not source data itself. |
+
+Versioning: manifest and `package.json` are aligned at `0.2.0` (the
+`package.json 0.1.0` mismatch was fixed in #431). Stays independently
+versioned; does not bump in lockstep with core.
+
+## Tests
+
+Central suites: `middleware/test/privacyV4*.test.ts` (acceptance, dataset
+store, digest, materializer, on-the-wire leak scorer, pseudonym projection,
+PII classifier, shape classifier, tool defs, verbs, service) plus
+`privacyInternPolicy.test.ts` and `privacyV4Bypass.test.ts` (Slice 2.5
+per-plugin bypass).

--- a/middleware/packages/harness-plugin-privacy-guard/README.md
+++ b/middleware/packages/harness-plugin-privacy-guard/README.md
@@ -24,14 +24,18 @@ The one setup field is `mask_user_prompt` (enum `off`/`on`, **default
 `off`** — flag-off is byte-identical to pre-#361 behavior). When on, PII
 spans detected in the user's own message are substituted with realistic,
 type-shaped pseudonyms in **every LLM-bound copy of the turn** — the main
-prompt, the ingested attachment tail, the recalled prior-context block,
-and auxiliary LLM passes (fact extraction, model/persona routing, card
-router, excerpt) — while the surrogate↔real map is held server-side per
-turn and inverted over the final answer **and over everything persisted**
-(session log, extracted KG facts, promoted memories store real values,
-never surrogates). Wire-substitution with answer-side restore — NOT
-server-side interning (the prompt must cross the wire) and NOT an on-wire
-token map (deleted for cause by #119/#126/#153).
+prompt, the **live chat history** (`priorTurns`, which replays persisted
+REAL values from earlier turns), the ingested attachment tail, the
+recalled prior-context block, the **direct-line relay payload** (a
+`#specialist question` turn hands the question to an LLM-backed
+sub-agent), and auxiliary LLM passes (fact extraction, model/persona
+routing, card router, excerpt) — while the surrogate↔real map is held
+server-side per turn and inverted over the final answer, over user-facing
+card content (choice cards, follow-up buttons), **and over everything
+persisted** (session log, extracted KG facts, promoted memories store
+real values, never surrogates). Wire-substitution with answer-side
+restore — NOT server-side interning (the prompt must cross the wire) and
+NOT an on-wire token map (deleted for cause by #119/#126/#153).
 
 - **Detection:** pluggable `PromptPiiDetector` seam. Shipped today: the
   deterministic **C0 regex baseline only** (email, IBAN, phone, German

--- a/middleware/packages/harness-plugin-privacy-guard/manifest.yaml
+++ b/middleware/packages/harness-plugin-privacy-guard/manifest.yaml
@@ -3,7 +3,7 @@ schema_version: "1"
 identity:
   id: "@omadia/plugin-privacy-guard"
   name: "Privacy Guard"
-  version: "0.2.0"
+  version: "0.3.0"
   kind: "tool"
   domain: "privacy.redact"
   description: "Privacy Shield v4 core plugin. Publishes the `privacy.redact@1` capability — a Data-Plane Boundary that interns raw tool results server-side and hands the LLM only an identity-free Digest. Identity-/order-critical work runs through a server-side Verb API; the final answer is materialized from ground truth. Emits a PII-free PrivacyReceipt the channel renderers (Teams Adaptive-Card, Web inline disclosure) consume to surface what was protected on each turn."
@@ -25,12 +25,26 @@ lifecycle:
   entry: "dist/plugin.js"
 
 # ---------------------------------------------------------------------------
-# No setup fields. The v4 Data-Plane Boundary is generic over JSON shape and
-# value statistics — there is no per-tenant policy, allowlist, or detector
-# configuration to tune.
+# One setup field (#361). The v4 Data-Plane Boundary itself stays
+# configuration-free — generic over JSON shape and value statistics. The
+# only toggle is free-text user-prompt masking, DEFAULT OFF: flag-off is
+# byte-identical to pre-#361 behavior. Flipping it on for a locale requires
+# a green run of the committed validation harness (src/validation/) against
+# its documented recall gates.
 # ---------------------------------------------------------------------------
 setup:
-  fields: []
+  fields:
+    - key: "mask_user_prompt"
+      type: "enum"
+      label: "Free-text user-prompt PII masking"
+      help: "EXPERIMENTAL, default off. When on, PII spans detected in the user's own message (email, IBAN, phone, address, amounts, dates — C0 regex baseline) are replaced by realistic pseudonyms before the prompt reaches the LLM; the real values are restored server-side in the final answer. Failure-closed: if masking cannot be guaranteed, the turn is blocked rather than sent unmasked. Names/free-form entities require the C1 transformer detector, which is not wired by default — see the plugin README."
+      required: false
+      default: "off"
+      enum:
+        - value: "off"
+          label: "Off — prompts pass unchanged (default)"
+        - value: "on"
+          label: "On — mask detected PII spans (C0 baseline)"
 
 playbook:
   when_to_use: |

--- a/middleware/packages/harness-plugin-privacy-guard/manifest.yaml
+++ b/middleware/packages/harness-plugin-privacy-guard/manifest.yaml
@@ -37,7 +37,7 @@ setup:
     - key: "mask_user_prompt"
       type: "enum"
       label: "Free-text user-prompt PII masking"
-      help: "EXPERIMENTAL, default off. When on, PII spans detected in the user's own message (email, IBAN, phone, address, amounts, dates — C0 regex baseline) are replaced by realistic pseudonyms in every LLM-bound copy of the turn (main prompt, ingested attachment text, recalled prior context, fact-extraction/routing/excerpt passes); the real values are restored server-side in the final answer and in everything persisted (session log, knowledge graph, promoted memories). Failure-closed: if masking cannot be guaranteed, the turn is blocked rather than sent unmasked. Names/free-form entities require the C1 transformer detector, which is not wired by default — see the plugin README."
+      help: "EXPERIMENTAL, default off. When on, PII spans detected in the user's own message (email, IBAN, phone, address, amounts, dates — C0 regex baseline) are replaced by realistic pseudonyms in every LLM-bound copy of the turn (main prompt, live chat history/priorTurns, ingested attachment text, recalled prior context, direct-line relay payloads, fact-extraction/routing/excerpt passes); the real values are restored server-side in the final answer and in everything persisted (session log, knowledge graph, promoted memories). Failure-closed: if masking cannot be guaranteed, the turn is blocked rather than sent unmasked — this includes direct-line (#specialist) turns. Names/free-form entities require the C1 transformer detector, which is not wired by default — see the plugin README."
       required: false
       default: "off"
       enum:

--- a/middleware/packages/harness-plugin-privacy-guard/manifest.yaml
+++ b/middleware/packages/harness-plugin-privacy-guard/manifest.yaml
@@ -30,14 +30,14 @@ lifecycle:
 # only toggle is free-text user-prompt masking, DEFAULT OFF: flag-off is
 # byte-identical to pre-#361 behavior. Flipping it on for a locale requires
 # a green run of the committed validation harness (src/validation/) against
-# its documented recall gates.
+# its documented recall gates, posted to issue #361 first.
 # ---------------------------------------------------------------------------
 setup:
   fields:
     - key: "mask_user_prompt"
       type: "enum"
       label: "Free-text user-prompt PII masking"
-      help: "EXPERIMENTAL, default off. When on, PII spans detected in the user's own message (email, IBAN, phone, address, amounts, dates — C0 regex baseline) are replaced by realistic pseudonyms before the prompt reaches the LLM; the real values are restored server-side in the final answer. Failure-closed: if masking cannot be guaranteed, the turn is blocked rather than sent unmasked. Names/free-form entities require the C1 transformer detector, which is not wired by default — see the plugin README."
+      help: "EXPERIMENTAL, default off. When on, PII spans detected in the user's own message (email, IBAN, phone, address, amounts, dates — C0 regex baseline) are replaced by realistic pseudonyms in every LLM-bound copy of the turn (main prompt, ingested attachment text, recalled prior context, fact-extraction/routing/excerpt passes); the real values are restored server-side in the final answer and in everything persisted (session log, knowledge graph, promoted memories). Failure-closed: if masking cannot be guaranteed, the turn is blocked rather than sent unmasked. Names/free-form entities require the C1 transformer detector, which is not wired by default — see the plugin README."
       required: false
       default: "off"
       enum:

--- a/middleware/packages/harness-plugin-privacy-guard/package.json
+++ b/middleware/packages/harness-plugin-privacy-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omadia/plugin-privacy-guard",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/middleware/packages/harness-plugin-privacy-guard/package.json
+++ b/middleware/packages/harness-plugin-privacy-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omadia/plugin-privacy-guard",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/middleware/packages/harness-plugin-privacy-guard/src/plugin.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/plugin.ts
@@ -18,6 +18,10 @@ import { createPrivacyGuardService } from './service.js';
  * statistics — there is no per-tenant policy, allowlist, or detector
  * configuration to read. All per-turn state (Dataset Store, receipt
  * counters) lives inside the service and is dropped at `finalizeTurn`.
+ *
+ * #361 — the one operator toggle is `mask_user_prompt` (default off), read
+ * live via the plugin's ConfigAccessor: free-text user prompts get their
+ * detected PII spans replaced by pseudonyms before crossing the LLM wire.
  */
 
 export interface PrivacyGuardPluginHandle {
@@ -34,9 +38,13 @@ export async function activate(
   // an LLM provider (ANTHROPIC_API_KEY). Absent ⇒ the classifier simply does
   // not run; interning behaves byte-identically to before.
   const llm = ctx.llm;
-  const service = createPrivacyGuardService(
-    llm ? { llmComplete: llm.complete.bind(llm) } : undefined,
-  );
+  const service = createPrivacyGuardService({
+    ...(llm ? { llmComplete: llm.complete.bind(llm) } : {}),
+    // #361 — live flag reader for default-off user-prompt masking. Routed
+    // through the plugin's own ConfigAccessor so an operator toggle saved
+    // via the install UI applies on the very next turn (no restart).
+    readConfig: (key) => ctx.config.get(key),
+  });
   const disposeService = ctx.services.provide<PrivacyGuardService>(
     PRIVACY_REDACT_SERVICE_NAME,
     service,

--- a/middleware/packages/harness-plugin-privacy-guard/src/promptMask.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/promptMask.ts
@@ -1,0 +1,255 @@
+/**
+ * #361 — free-text user-prompt PII masking (detection + substitution).
+ *
+ * Detection is the pluggable `PromptPiiDetector` seam from `@omadia/plugin-api`.
+ * This module ships:
+ *   - `createBaselineDetector()` — the deterministic C0 regex baseline
+ *     (email, IBAN, phone, German postal+street address, currency/salary
+ *     amounts, DOB-style dates). C0 gates on STRUCTURED identifiers only —
+ *     names/free-form addresses need the C1 transformer.
+ *   - `createC1StubDetector()` — the wiring point for the C1 transformer
+ *     ensemble (Piiranha / GLiNER). Deliberately inert until the committed
+ *     validation harness (`src/validation/`) passes its documented recall
+ *     gates for a target locale.
+ *   - span dedup + word-boundary extension and `maskPrompt()` — the
+ *     substitution pass over the shipped pseudonym-projection mechanism
+ *     (`v4/pseudonym.ts`), longest-span-first.
+ *
+ * Substitution decision (#361, recorded): pseudonym projection with a
+ * server-held real↔surrogate map resolved over the final answer — NOT a
+ * reintroduced on-wire token map (deleted for cause by #119/#126/#153).
+ */
+
+import type { PromptPiiDetector, PromptPiiSpan } from '@omadia/plugin-api';
+
+import {
+  createPromptPseudonymMap,
+  type PromptSpanValue,
+} from './v4/pseudonym.js';
+import type { PseudonymMap } from './v4/types.js';
+
+// ---------------------------------------------------------------------------
+// C0 — deterministic regex baseline.
+// ---------------------------------------------------------------------------
+
+interface C0Pattern {
+  readonly type: string;
+  readonly re: RegExp;
+}
+
+// Order matters only for readability; overlaps are resolved by dedup below.
+const C0_PATTERNS: readonly C0Pattern[] = [
+  {
+    type: 'email',
+    re: /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
+  },
+  {
+    // IBAN — two letters, two check digits, 11–30 alphanumerics, optionally
+    // grouped in spaced blocks of 4 (the common human spelling).
+    type: 'iban',
+    re: /\b[A-Z]{2}\d{2}(?:\s?[A-Z0-9]{4}){2,7}(?:\s?[A-Z0-9]{1,4})?\b/g,
+  },
+  {
+    // Phone — international (+49 30 …) or local (030 / 0171 …) forms with
+    // ≥7 digits total, tolerant of space/dash/paren grouping.
+    type: 'phone',
+    re: /(?:\+\d{1,3}[\s-]?|\b0)\d{1,4}(?:[\s\-/]?\d{2,6}){1,4}\b/g,
+  },
+  {
+    // German street + number (+ optional postal code + city):
+    // "Bahnhofstr. 5", "Bahnhofstraße 5, 60311 Frankfurt".
+    type: 'address',
+    re: /\b[A-ZÄÖÜ][a-zäöüß.-]+(?:[Ss]tr\.|[Ss]traße|[Ww]eg|[Pp]latz|[Aa]llee|[Gg]asse|[Rr]ing)\s?\d{1,4}[a-z]?(?:\s*,\s*\d{5}\s+[A-ZÄÖÜ][A-Za-zäöüß-]+)?/g,
+  },
+  {
+    // Bare postal code + city ("60311 Frankfurt") not already caught above.
+    type: 'address',
+    re: /\b\d{5}\s+[A-ZÄÖÜ][A-Za-zäöüß-]{2,}\b/g,
+  },
+  {
+    // Currency / salary amounts: "€72,000", "72.000 €", "EUR 72000",
+    // "72,000.50 USD".
+    type: 'amount',
+    re: /(?:[€$£]|\b(?:EUR|USD|GBP|CHF)\b)\s?\d{1,3}(?:[.,]\d{3})*(?:[.,]\d{1,2})?|\b\d{1,3}(?:[.,]\d{3})+(?:[.,]\d{1,2})?\s?(?:[€$£]|(?:EUR|USD|GBP|CHF)\b)/g,
+  },
+  {
+    // DOB-style dates: 24.12.1987, 1987-12-24, 24/12/1987.
+    type: 'date',
+    re: /\b(?:\d{1,2}[./]\d{1,2}[./](?:19|20)\d{2}|(?:19|20)\d{2}-\d{2}-\d{2})\b/g,
+  },
+];
+
+/** The deterministic C0 regex baseline (#361). Confidence is always 1 —
+ *  every match is a hard pattern hit. Never throws. */
+export function createBaselineDetector(): PromptPiiDetector {
+  return {
+    id: 'c0-regex',
+    async detect(text: string): Promise<readonly PromptPiiSpan[]> {
+      const spans: PromptPiiSpan[] = [];
+      for (const { type, re } of C0_PATTERNS) {
+        // Fresh regex state per call (global flag carries lastIndex).
+        const pattern = new RegExp(re.source, re.flags);
+        for (const match of text.matchAll(pattern)) {
+          if (match.index === undefined || match[0].length === 0) continue;
+          spans.push({
+            start: match.index,
+            end: match.index + match[0].length,
+            type,
+            confidence: 1,
+          });
+        }
+      }
+      return spans;
+    },
+  };
+}
+
+/**
+ * C1 seam — transformer-ensemble slot (Piiranha / GLiNER). Ships INERT: it
+ * reports no spans, so C0 alone decides until an operator wires a real
+ * transformer detector AND the validation harness gates pass for the
+ * locale. Kept as a concrete detector (not just a type) so the service's
+ * degrade-to-C0 failure path has a stable seam to exercise in tests.
+ */
+export function createC1StubDetector(): PromptPiiDetector {
+  return {
+    id: 'c1-stub',
+    async detect(): Promise<readonly PromptPiiSpan[]> {
+      return [];
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Span dedup + word-boundary extension.
+// ---------------------------------------------------------------------------
+
+export interface ResolvedSpan {
+  readonly start: number;
+  readonly end: number;
+  readonly type: string;
+  readonly detector: string;
+  readonly value: string;
+}
+
+const WORD_CHAR = /[\p{L}\p{N}_@.-]/u;
+
+/** Extend a span outward while it splits a word-like run — a half-masked
+ *  identifier is a leak (the RFC's word-boundary-extension trick). */
+function extendToWordBoundaries(
+  text: string,
+  start: number,
+  end: number,
+): { start: number; end: number } {
+  let s = start;
+  let e = end;
+  while (s > 0 && WORD_CHAR.test(text[s - 1]!) && WORD_CHAR.test(text[s]!)) s--;
+  while (e < text.length && WORD_CHAR.test(text[e]!) && WORD_CHAR.test(text[e - 1]!)) e++;
+  return { start: s, end: e };
+}
+
+/**
+ * Merge detector outputs: extend to word boundaries, then resolve overlaps
+ * by keeping the higher-confidence span (ties → the longer span). Output is
+ * sorted by start offset and non-overlapping.
+ */
+export function dedupSpans(
+  text: string,
+  detected: ReadonlyArray<{ span: PromptPiiSpan; detector: string }>,
+): ResolvedSpan[] {
+  const extended = detected
+    .filter(({ span }) => span.end > span.start && span.start >= 0 && span.end <= text.length)
+    .map(({ span, detector }) => {
+      const { start, end } = extendToWordBoundaries(text, span.start, span.end);
+      return { start, end, type: span.type, detector, confidence: span.confidence };
+    })
+    .sort(
+      (a, b) =>
+        b.confidence - a.confidence || b.end - b.start - (a.end - a.start) || a.start - b.start,
+    );
+
+  const kept: typeof extended = [];
+  for (const candidate of extended) {
+    const overlapping = kept.some(
+      (k) => candidate.start < k.end && k.start < candidate.end,
+    );
+    if (!overlapping) kept.push(candidate);
+  }
+  return kept
+    .sort((a, b) => a.start - b.start)
+    .map(({ start, end, type, detector }) => ({
+      start,
+      end,
+      type,
+      detector,
+      value: text.slice(start, end),
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Substitution.
+// ---------------------------------------------------------------------------
+
+export interface MaskPromptResult {
+  readonly maskedText: string;
+  /** Server-held map (extended from `existingMap` when given). */
+  readonly map: PseudonymMap;
+  /** The resolved spans, WITH real values — server-side use only. */
+  readonly spans: readonly ResolvedSpan[];
+}
+
+/**
+ * Run the detectors over `text` and substitute every resolved span with its
+ * stable pseudonym. Replacement runs right-to-left over the original
+ * offsets (equivalent to longest-span-first: spans are non-overlapping
+ * after dedup, so offset order is the safe application order).
+ *
+ * `existingMap` threads the turn's server-held map through repeated calls
+ * (user message, then the ingested attachment tail) so the same real value
+ * always gets the same surrogate within a turn.
+ */
+export async function maskPrompt(
+  text: string,
+  detectors: readonly PromptPiiDetector[],
+  existingMap?: PseudonymMap,
+): Promise<MaskPromptResult> {
+  const detected: Array<{ span: PromptPiiSpan; detector: string }> = [];
+  for (const detector of detectors) {
+    const spans = await detector.detect(text);
+    for (const span of spans) detected.push({ span, detector: detector.id });
+  }
+  const spans = dedupSpans(text, detected);
+  if (spans.length === 0) {
+    return {
+      maskedText: text,
+      map: existingMap ?? { forward: new Map(), reverse: new Map() },
+      spans,
+    };
+  }
+
+  const spanValues: PromptSpanValue[] = spans.map((s) => ({
+    value: s.value,
+    type: s.type,
+  }));
+  const map = createPromptPseudonymMap(spanValues, text, existingMap);
+
+  let masked = text;
+  for (const span of [...spans].sort((a, b) => b.start - a.start)) {
+    const surrogate = map.forward.get(span.value);
+    // Defensive: the map covers every span value by construction.
+    if (surrogate === undefined) continue;
+    masked = masked.slice(0, span.start) + surrogate + masked.slice(span.end);
+  }
+  // Belt and braces: a detected value may occur AGAIN at a position no
+  // detector flagged (e.g. an email repeated mid-sentence in a shape the
+  // regex misses after boundary extension). Sweep every known real value —
+  // including ones from earlier calls this turn via `existingMap` — longest
+  // first, so the service's post-mask `findIdentityLeaks` assertion is a
+  // true invariant, not a coin flip.
+  for (const [real, surrogate] of [...map.forward.entries()].sort(
+    (a, b) => b[0].length - a[0].length,
+  )) {
+    if (masked.includes(real)) masked = masked.split(real).join(surrogate);
+  }
+  return { maskedText: masked, map, spans };
+}

--- a/middleware/packages/harness-plugin-privacy-guard/src/service.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/service.ts
@@ -19,6 +19,8 @@ import type {
   BypassedToolEntry,
   PrivacyBypassedToolRequest,
   PrivacyGuardService,
+  PrivacyPromptMaskRequest,
+  PrivacyPromptMaskResult,
   PrivacyReceipt,
   PrivacyRenderedAnswer,
   PrivacySubAgentResultV4Request,
@@ -26,6 +28,8 @@ import type {
   PrivacyToolResultV4Result,
   PrivacyV4ToolRequest,
   PrivacyV4ToolSpec,
+  PromptMaskedSpanInfo,
+  PromptPiiDetector,
 } from '@omadia/plugin-api';
 
 import { createDatasetStore } from './v4/datasetStore.js';
@@ -45,6 +49,10 @@ import {
   type LlmComplete,
   type PiiSchemaClassifier,
 } from './v4/piiClassifier.js';
+import { createBaselineDetector, maskPrompt } from './promptMask.js';
+import { findIdentityLeaks } from './v4/onTheWire.js';
+import { resolvePseudonyms } from './v4/pseudonym.js';
+import type { PseudonymMap } from './v4/types.js';
 
 /**
  * Collect the identity-bearing string(s) of a single field VALUE into `out`
@@ -76,6 +84,17 @@ interface V4ReceiptAccum {
   fieldsCleartext: number;
   readonly verbsExecuted: string[];
   pseudonymProjectionUsed: boolean;
+  /** #361 — PII-free records of prompt spans masked this turn. */
+  readonly maskedPromptSpans: PromptMaskedSpanInfo[];
+}
+
+/** #361 — config key on THIS plugin's install that turns prompt masking on.
+ *  Default off: absent/other values mean `maskUserPrompt` reports `disabled`
+ *  and the orchestrator proceeds byte-identically to legacy behavior. */
+export const MASK_USER_PROMPT_CONFIG_KEY = 'mask_user_prompt';
+
+function isPromptMaskEnabled(value: unknown): boolean {
+  return value === true || value === 'true' || value === 'on';
 }
 
 const V4_RENDER_NOTE =
@@ -141,6 +160,19 @@ export function createPrivacyGuardService(deps?: {
    * masking is wholly independent of this.
    */
   readonly llmComplete?: LlmComplete;
+  /**
+   * #361 — live config reader (`ctx.config.get`) for the default-off
+   * `mask_user_prompt` flag. Absent ⇒ prompt masking always reports
+   * `disabled` (byte-identical legacy behavior).
+   */
+  readonly readConfig?: (key: string) => unknown;
+  /**
+   * #361 — the C1 transformer detector slot (Piiranha / GLiNER). Absent ⇒
+   * only the C0 regex baseline runs. When present and it THROWS, masking
+   * degrades to C0 with a `promptMaskDegraded` audit log (failure-closed
+   * tier 1); it never silently passes an unmasked prompt.
+   */
+  readonly c1Detector?: PromptPiiDetector;
 }): PrivacyGuardService {
   // One turn-scoped Dataset Store per turn, minted lazily on the first
   // `internToolResultV4` and dropped by `finalizeTurn`.
@@ -160,6 +192,11 @@ export function createPrivacyGuardService(deps?: {
   // plugin). Drained into the receipt by `finalizeTurn`. Entries carry
   // only tool/plugin names + a byte count (no values).
   const bypassedTools = new Map<string, BypassedToolEntry[]>();
+  // #361 — per-turn prompt-surrogate map (real↔surrogate), server-side
+  // only. Extended across repeated mask calls within one turn (message +
+  // ingested attachment tail) so surrogates stay stable; inverted over the
+  // final answer by `restorePromptPseudonyms`; dropped by `finalizeTurn`.
+  const promptMaskMaps = new Map<string, PseudonymMap>();
   // Slice 2 — cached, Haiku-backed schema PII classifier. Process-scoped
   // (its cache spans turns — schema verdicts are tool-shape-stable). Absent
   // when no host LLM is wired.
@@ -195,6 +232,7 @@ export function createPrivacyGuardService(deps?: {
         fieldsCleartext: 0,
         verbsExecuted: [],
         pseudonymProjectionUsed: false,
+        maskedPromptSpans: [],
       };
       receipts.set(turnId, r);
     }
@@ -395,6 +433,94 @@ export function createPrivacyGuardService(deps?: {
       return answer;
     },
 
+    // #361 — free-text prompt masking. Failure-closed: there is no
+    // pass-through-unmasked outcome. Tier 1: the C1 transformer throwing
+    // degrades to C0 results with a `promptMaskDegraded` audit line.
+    // Tier 2: the C0 baseline itself failing, or a residual real span
+    // surviving substitution (asserted via `findIdentityLeaks`), BLOCKS
+    // the turn.
+    async maskUserPrompt(
+      request: PrivacyPromptMaskRequest,
+    ): Promise<PrivacyPromptMaskResult> {
+      if (!isPromptMaskEnabled(deps?.readConfig?.(MASK_USER_PROMPT_CONFIG_KEY))) {
+        return { outcome: 'disabled' };
+      }
+      const detectors = [createBaselineDetector()];
+      let degraded = false;
+      if (deps?.c1Detector) {
+        // Run the C1 detector up-front so its failure cannot take the C0
+        // baseline down with it (tier-1 degrade, audited); its spans are
+        // memoized into a pass-through detector for the mask pass.
+        const c1 = deps.c1Detector;
+        try {
+          const c1Spans = await c1.detect(request.text);
+          detectors.push({ id: c1.id, detect: async () => c1Spans });
+        } catch (err) {
+          degraded = true;
+          console.warn(
+            `[privacy-guard v4] promptMaskDegraded turn=${request.turnId} ` +
+              `detector=${c1.id}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+      try {
+        const result = await maskPrompt(
+          request.text,
+          detectors,
+          promptMaskMaps.get(request.turnId),
+        );
+        // Post-mask invariant: no detected real value may survive in the
+        // wire-bound text. A hit means substitution failed — block.
+        const residual = findIdentityLeaks(result.maskedText, [
+          ...result.map.forward.keys(),
+        ]);
+        if (residual.length > 0) {
+          console.error(
+            `[privacy-guard v4] promptMaskBlocked turn=${request.turnId} ` +
+              `residual=${String(residual.length)} span(s) survived substitution`,
+          );
+          return {
+            outcome: 'blocked',
+            reason: 'residual PII span survived substitution',
+          };
+        }
+        promptMaskMaps.set(request.turnId, result.map);
+        const spanInfos: PromptMaskedSpanInfo[] = result.spans.map((s) => ({
+          type: s.type,
+          detector: s.detector,
+        }));
+        if (spanInfos.length > 0) {
+          receiptFor(request.turnId).maskedPromptSpans.push(...spanInfos);
+        }
+        console.log(
+          `[privacy-guard v4] promptMask turn=${request.turnId} ` +
+            `spans=${String(spanInfos.length)}${degraded ? ' degraded=c0-only' : ''}`,
+        );
+        return {
+          outcome: 'masked',
+          maskedText: result.maskedText,
+          spans: spanInfos,
+          degraded,
+        };
+      } catch (err) {
+        // Tier 2 — the baseline path itself failed. Never pass unmasked.
+        console.error(
+          `[privacy-guard v4] promptMaskBlocked turn=${request.turnId}: ` +
+            `${err instanceof Error ? err.message : String(err)}`,
+        );
+        return {
+          outcome: 'blocked',
+          reason: 'prompt PII detection failed',
+        };
+      }
+    },
+
+    async restorePromptPseudonyms(turnId: string, text: string): Promise<string> {
+      const map = promptMaskMaps.get(turnId);
+      if (map === undefined || map.reverse.size === 0) return text;
+      return resolvePseudonyms(text, map);
+    },
+
     resolveDatasetForRender(turnId, datasetId) {
       const dataset = stores.get(turnId)?.get(datasetId);
       if (dataset === undefined) return undefined;
@@ -424,18 +550,23 @@ export function createPrivacyGuardService(deps?: {
       stores.get(turnId)?.finalizeTurn();
       stores.delete(turnId);
       renderedAnswers.delete(turnId);
+      // #361 — drop the prompt-surrogate map. `restorePromptPseudonyms`
+      // must have run over the final answer before this point.
+      promptMaskMaps.delete(turnId);
       const accum = receipts.get(turnId);
       receipts.delete(turnId);
       const piiValues = turnPiiValues.get(turnId);
       turnPiiValues.delete(turnId);
       const bypassed = bypassedTools.get(turnId);
       bypassedTools.delete(turnId);
-      // No receipt for a turn that touched neither the boundary nor a
-      // bypass — there is nothing to report and a zero receipt is just
-      // noise in the channel UI.
+      // No receipt for a turn that touched neither the boundary, a bypass,
+      // nor prompt masking — there is nothing to report and a zero receipt
+      // is just noise in the channel UI.
       const hasInterned = accum !== undefined && accum.datasetsInterned > 0;
       const hasBypassed = bypassed !== undefined && bypassed.length > 0;
-      if (!hasInterned && !hasBypassed) return undefined;
+      const hasMaskedPrompt =
+        accum !== undefined && accum.maskedPromptSpans.length > 0;
+      if (!hasInterned && !hasBypassed && !hasMaskedPrompt) return undefined;
       // identityValuesOnWire — personal-identity values the requester named
       // in their own message text. A transparency notice (the user put a
       // real identity on the wire), NOT a leak of tool data.
@@ -462,6 +593,9 @@ export function createPrivacyGuardService(deps?: {
         pseudonymProjectionUsed: accum?.pseudonymProjectionUsed ?? false,
         identityValuesOnWire,
         ...(hasBypassed ? { bypassedTools: [...bypassed] } : {}),
+        ...(hasMaskedPrompt
+          ? { maskedPromptSpans: [...accum.maskedPromptSpans] }
+          : {}),
       };
     },
   };

--- a/middleware/packages/harness-plugin-privacy-guard/src/service.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/service.ts
@@ -521,6 +521,22 @@ export function createPrivacyGuardService(deps?: {
       return resolvePseudonyms(text, map);
     },
 
+    snapshotPromptRestorer(
+      turnId: string,
+    ): ((text: string) => string) | undefined {
+      const map = promptMaskMaps.get(turnId);
+      if (map === undefined || map.reverse.size === 0) return undefined;
+      // Self-contained copy: the closure must keep working after
+      // `finalizeTurn` dropped the live map — fire-and-forget fact
+      // extraction restores extracted facts to real values long after the
+      // turn's answer went out.
+      const snapshot: PseudonymMap = {
+        forward: new Map(map.forward),
+        reverse: new Map(map.reverse),
+      };
+      return (text: string): string => resolvePseudonyms(text, snapshot);
+    },
+
     resolveDatasetForRender(turnId, datasetId) {
       const dataset = stores.get(turnId)?.get(datasetId);
       if (dataset === undefined) return undefined;

--- a/middleware/packages/harness-plugin-privacy-guard/src/v4/pseudonym.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/v4/pseudonym.ts
@@ -111,6 +111,159 @@ export function projectDataset(dataset: Dataset): {
   return { rows, map };
 }
 
+// ---------------------------------------------------------------------------
+// #361 — prompt-span pseudonyms (text-span variant of `createPseudonymMap`).
+//
+// Free-text prompt masking substitutes DETECTED spans, which are typed
+// (email, IBAN, phone, address, amount, date, person) — a "Lukas Becker"
+// name surrogate would be shape-wrong for an IBAN and would degrade the
+// LLM answer the masking is trying to preserve. Each type therefore draws
+// from its own realistic surrogate pool. Same invariants as
+// `createPseudonymMap`: deterministic per input set, bijective, and no
+// surrogate ever equals a real value or appears in the input text (C5).
+// ---------------------------------------------------------------------------
+
+/** A real value + its PII type, as detected in a prompt. */
+export interface PromptSpanValue {
+  readonly value: string;
+  readonly type: string;
+}
+
+/** Deterministic per-type surrogate candidate streams. Every generator is
+ *  unbounded via a numeric suffix/variation, so the pool cannot exhaust. */
+function* personCandidates(): Generator<string> {
+  yield* pseudonymCandidates();
+  // Overflow beyond the finite name pool: numbered variants.
+  for (let i = 2; ; i++) {
+    for (const last of LAST_NAMES) {
+      for (const first of FIRST_NAMES) yield `${first} ${last} ${String(i)}`;
+    }
+  }
+}
+
+function* emailCandidates(): Generator<string> {
+  for (let i = 0; ; i++) {
+    const first = FIRST_NAMES[i % FIRST_NAMES.length]!.toLowerCase();
+    const last =
+      LAST_NAMES[Math.floor(i / FIRST_NAMES.length) % LAST_NAMES.length]!.toLowerCase();
+    yield i < FIRST_NAMES.length * LAST_NAMES.length
+      ? `${first}.${last}@example.net`
+      : `${first}.${last}${String(i)}@example.net`;
+  }
+}
+
+/** Valid-looking DE IBAN shape with a varying account part. Deliberately
+ *  NOT checksum-valid — it must never collide with a real account, only
+ *  look shape-plausible to the model. */
+function* ibanCandidates(): Generator<string> {
+  for (let i = 0; ; i++) {
+    yield `DE00500105170${String(1000 + (i % 9000))}${String(2000 + i).padStart(4, '0')}`;
+  }
+}
+
+function* phoneCandidates(): Generator<string> {
+  for (let i = 0; ; i++) {
+    yield `+49 30 5559${String(i % 10000).padStart(4, '0')}`;
+  }
+}
+
+function* addressCandidates(): Generator<string> {
+  for (let i = 0; ; i++) {
+    yield `Musterstraße ${String(1 + (i % 199))}, ${String(10000 + ((i * 37) % 89999))} Musterstadt`;
+  }
+}
+
+function* amountCandidates(): Generator<string> {
+  for (let i = 0; ; i++) {
+    yield `€${String(10000 + ((i * 1111) % 90000))}`;
+  }
+}
+
+function* dateCandidates(): Generator<string> {
+  for (let i = 0; ; i++) {
+    yield `${String(1 + (i % 28)).padStart(2, '0')}.${String(1 + (i % 12)).padStart(2, '0')}.${String(1970 + (i % 40))}`;
+  }
+}
+
+/** Unknown category from a future detector — neutral placeholder, still
+ *  bijective and restorable. */
+function* genericCandidates(type: string): Generator<string> {
+  for (let i = 0; ; i++) {
+    yield `PLATZHALTER-${type.toUpperCase()}-${String(i + 1)}`;
+  }
+}
+
+function surrogateCandidates(type: string): Generator<string> {
+  switch (type) {
+    case 'person':
+      return personCandidates();
+    case 'email':
+      return emailCandidates();
+    case 'iban':
+      return ibanCandidates();
+    case 'phone':
+      return phoneCandidates();
+    case 'address':
+      return addressCandidates();
+    case 'amount':
+      return amountCandidates();
+    case 'date':
+      return dateCandidates();
+    default:
+      return genericCandidates(type);
+  }
+}
+
+/**
+ * Build (or extend) a pseudonym map for detected prompt spans. Guarantees:
+ *   - stable: a value already in `existing` keeps its surrogate;
+ *   - bijective: no two real values share a surrogate;
+ *   - collision-free: a surrogate never equals a real value in the set,
+ *     never appears as a substring of `avoidText` (the full prompt), and
+ *     never collides with an existing surrogate.
+ * Deterministic for the same inputs, so a person/value is stable within a
+ * turn across multiple mask calls (message + ingested attachment tail).
+ */
+export function createPromptPseudonymMap(
+  spanValues: Iterable<PromptSpanValue>,
+  avoidText: string,
+  existing?: PseudonymMap,
+): PseudonymMap {
+  const forward = new Map<string, string>(existing?.forward ?? []);
+  const reverse = new Map<string, string>(existing?.reverse ?? []);
+
+  // Deduplicate by value, deterministic order (sorted by value).
+  const pending = new Map<string, string>();
+  for (const { value, type } of spanValues) {
+    if (value.length === 0 || forward.has(value)) continue;
+    if (!pending.has(value)) pending.set(value, type);
+  }
+  const realSet = new Set(pending.keys());
+
+  for (const [value, type] of [...pending.entries()].sort((a, b) =>
+    a[0].localeCompare(b[0]),
+  )) {
+    let surrogate: string | undefined;
+    for (const candidate of surrogateCandidates(type)) {
+      if (
+        !reverse.has(candidate) &&
+        !realSet.has(candidate) &&
+        !avoidText.includes(candidate)
+      ) {
+        surrogate = candidate;
+        break;
+      }
+    }
+    // Unreachable: every stream is unbounded — but keep the invariant loud.
+    if (surrogate === undefined) {
+      throw new Error('[privacy-shield-v4] prompt surrogate pool exhausted');
+    }
+    forward.set(value, surrogate);
+    reverse.set(surrogate, value);
+  }
+  return { forward, reverse };
+}
+
 /**
  * Resolve pseudonyms back to real values in a block of text — the inverse of
  * `projectDataset`, applied at materialization. Longest pseudonyms first so a

--- a/middleware/packages/harness-plugin-privacy-guard/src/v4/pseudonym.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/v4/pseudonym.ts
@@ -218,9 +218,10 @@ function surrogateCandidates(type: string): Generator<string> {
  * Build (or extend) a pseudonym map for detected prompt spans. Guarantees:
  *   - stable: a value already in `existing` keeps its surrogate;
  *   - bijective: no two real values share a surrogate;
- *   - collision-free: a surrogate never equals a real value in the set,
- *     never appears as a substring of `avoidText` (the full prompt), and
- *     never collides with an existing surrogate.
+ *   - collision-free: a surrogate never equals a real value in the set OR
+ *     any real value from an earlier call this turn (`existing`), never
+ *     appears as a substring of `avoidText` (the full prompt), and never
+ *     collides with an existing surrogate.
  * Deterministic for the same inputs, so a person/value is stable within a
  * turn across multiple mask calls (message + ingested attachment tail).
  */
@@ -238,7 +239,13 @@ export function createPromptPseudonymMap(
     if (value.length === 0 || forward.has(value)) continue;
     if (!pending.has(value)) pending.set(value, type);
   }
+  // Collision domain = ALL real values seen so far this turn: the current
+  // call's pending values AND every real already in `existing` from earlier
+  // calls (message, ingested tail, recalled context). Without the latter, a
+  // later call could mint a surrogate equal to a real value masked earlier
+  // in the turn — answer-side restore would then corrupt that span.
   const realSet = new Set(pending.keys());
+  for (const real of forward.keys()) realSet.add(real);
 
   for (const [value, type] of [...pending.entries()].sort((a, b) =>
     a[0].localeCompare(b[0]),

--- a/middleware/packages/harness-plugin-privacy-guard/src/validation/README.md
+++ b/middleware/packages/harness-plugin-privacy-guard/src/validation/README.md
@@ -28,9 +28,11 @@ the masked output — any surviving identifying character is a leak.
 | Added latency, p95 per prompt | ≤ 400 ms |
 
 **Flag policy:** `mask_user_prompt` may be enabled only for locales whose
-fixture set passes ALL gates with the shipped detector set. C0 alone gates
-on structured identifiers only — a deployment that needs name masking must
-wire a C1 detector and re-run.
+fixture set passes ALL gates with the shipped detector set, and the harness
+results for that locale must be posted to issue #361 BEFORE the flag flips
+on. C0 alone gates on structured identifiers only — a deployment that needs
+name masking must wire a C1 detector (the shipped C1 slot is an inert stub)
+and re-run. Current coverage: `de` + `en` fixtures, C0 tier only.
 
 ## Fixtures
 

--- a/middleware/packages/harness-plugin-privacy-guard/src/validation/README.md
+++ b/middleware/packages/harness-plugin-privacy-guard/src/validation/README.md
@@ -1,0 +1,58 @@
+# Prompt-PII detector validation harness (#361)
+
+Standalone, runnable evaluation for the prompt-masking detector ensemble —
+**not a CI gate**. It exists so that flipping the `mask_user_prompt` flag on
+for a locale is a measured decision, not a vibe check: the pass/fail gates
+below were committed *before* any run.
+
+## Run
+
+```bash
+# from middleware/
+npx tsx packages/harness-plugin-privacy-guard/src/validation/promptDetectorEval.ts
+```
+
+Scores the configured detectors (`C0` regex baseline; add the C1 transformer
+detector to `DETECTOR_SETS` once wired) against the fixture sets, using
+exact-match leak scoring via `v4/onTheWire.ts#findIdentityLeaks`: a PII
+instance counts as masked only when the real value is entirely absent from
+the masked output — any surviving identifying character is a leak.
+
+## Pre-committed gates (per locale × detector set)
+
+| Metric | Gate |
+|---|---|
+| Recall, structured identifiers (email, IBAN, phone, amount, date, address) | ≥ 0.97 |
+| Recall, names / free-form entities (`person`) | ≥ 0.90 (requires C1 — C0 does not detect names) |
+| Precision proxy (spans flagged on PII-free negatives) | ≥ 0.85 |
+| Added latency, p95 per prompt | ≤ 400 ms |
+
+**Flag policy:** `mask_user_prompt` may be enabled only for locales whose
+fixture set passes ALL gates with the shipped detector set. C0 alone gates
+on structured identifiers only — a deployment that needs name masking must
+wire a C1 detector and re-run.
+
+## Fixtures
+
+`fixtures/<locale>.json` — array of items:
+
+```json
+{ "text": "…prompt…", "spans": [{ "value": "anna@firma.de", "type": "email", "tier": "high" }] }
+```
+
+- Items with `spans: []` are **negatives** (PII-free) and feed the
+  over-masking measurement.
+- `de` and `en` ship hand-built slices, including the documented NER-sidecar
+  failure modes from `plugin-api/src/piiAnnotation.ts` (partial German
+  names, "Krankheit"→ADDRESS-class false positives) — any C1 candidate must
+  clear exactly these before a go verdict.
+- `fr` / `es` / `it` / `nl` are **not yet populated** — per the RFC these
+  locales need an ai4privacy-derived backbone plus a native-speaker-checked
+  hand slice before their flag may flip on.
+
+## Honest-measurement caveat (from the RFC)
+
+Piiranha-class models are trained on ai4privacy-style data; evaluating them
+on ai4privacy items is partially in-distribution and inflates numbers. The
+go/no-go signal is the hand-built out-of-distribution slice in these
+fixtures, not a public-benchmark score.

--- a/middleware/packages/harness-plugin-privacy-guard/src/validation/fixtures/de.json
+++ b/middleware/packages/harness-plugin-privacy-guard/src/validation/fixtures/de.json
@@ -1,0 +1,44 @@
+[
+  {
+    "text": "Was sollten wir Anna Schmidt (32, wohnhaft Bahnhofstr. 5, 60311 Frankfurt) zahlen, ausgehend von ihrem aktuellen Gehalt von €72.000?",
+    "spans": [
+      { "value": "Anna Schmidt", "type": "person", "tier": "high" },
+      { "value": "Bahnhofstr. 5, 60311 Frankfurt", "type": "address", "tier": "high" },
+      { "value": "€72.000", "type": "amount", "tier": "critical" }
+    ]
+  },
+  {
+    "text": "Bitte überweise das Gehalt auf DE89 3704 0044 0532 0130 00 und bestätige an m.vomberg@firma-beispiel.de.",
+    "spans": [
+      { "value": "DE89 3704 0044 0532 0130 00", "type": "iban", "tier": "critical" },
+      { "value": "m.vomberg@firma-beispiel.de", "type": "email", "tier": "high" }
+    ]
+  },
+  {
+    "text": "Ruf Marvin Vomberg unter +49 171 5551234 an, er ist am 24.12.1987 geboren.",
+    "spans": [
+      { "value": "Marvin Vomberg", "type": "person", "tier": "high" },
+      { "value": "+49 171 5551234", "type": "phone", "tier": "high" },
+      { "value": "24.12.1987", "type": "date", "tier": "high" }
+    ]
+  },
+  {
+    "text": "Die Rechnung über 1.250,50 € ging an die Musterallee 12, 10115 Berlin.",
+    "spans": [
+      { "value": "1.250,50 €", "type": "amount", "tier": "critical" },
+      { "value": "Musterallee 12, 10115 Berlin", "type": "address", "tier": "high" }
+    ]
+  },
+  {
+    "text": "Der Abwesenheitstyp Krankheit wird im HR-Modul separat ausgewiesen — bitte fasse die Regelung zusammen.",
+    "spans": []
+  },
+  {
+    "text": "Wie viele Urlaubstage stehen einem Mitarbeiter nach drei Jahren Betriebszugehörigkeit zu?",
+    "spans": []
+  },
+  {
+    "text": "Erstelle einen Statusbericht für das Q3-Projekt, Budgetrahmen unverändert.",
+    "spans": []
+  }
+]

--- a/middleware/packages/harness-plugin-privacy-guard/src/validation/fixtures/en.json
+++ b/middleware/packages/harness-plugin-privacy-guard/src/validation/fixtures/en.json
@@ -1,0 +1,32 @@
+[
+  {
+    "text": "What should we pay Anna Schmidt (32, lives at Bahnhofstr. 5, 60311 Frankfurt) given her current salary of €72,000?",
+    "spans": [
+      { "value": "Anna Schmidt", "type": "person", "tier": "high" },
+      { "value": "Bahnhofstr. 5, 60311 Frankfurt", "type": "address", "tier": "high" },
+      { "value": "€72,000", "type": "amount", "tier": "critical" }
+    ]
+  },
+  {
+    "text": "Wire the bonus to GB29 NWBK 6016 1331 9268 19 and cc jane.doe@example-corp.com on the confirmation.",
+    "spans": [
+      { "value": "GB29 NWBK 6016 1331 9268 19", "type": "iban", "tier": "critical" },
+      { "value": "jane.doe@example-corp.com", "type": "email", "tier": "high" }
+    ]
+  },
+  {
+    "text": "Call the candidate at +44 20 7946 0958; her date of birth is 1990-06-15.",
+    "spans": [
+      { "value": "+44 20 7946 0958", "type": "phone", "tier": "high" },
+      { "value": "1990-06-15", "type": "date", "tier": "high" }
+    ]
+  },
+  {
+    "text": "Summarize our vacation carry-over policy for employees in their first year.",
+    "spans": []
+  },
+  {
+    "text": "Draft a follow-up on the roadmap review; keep the tone neutral.",
+    "spans": []
+  }
+]

--- a/middleware/packages/harness-plugin-privacy-guard/src/validation/promptDetectorEval.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/validation/promptDetectorEval.ts
@@ -1,0 +1,125 @@
+/**
+ * #361 — standalone prompt-PII detector evaluation (NOT a CI gate).
+ *
+ * Run from `middleware/`:
+ *   npx tsx packages/harness-plugin-privacy-guard/src/validation/promptDetectorEval.ts
+ *
+ * Scores each configured detector set against the fixture files using the
+ * exact-match leak criterion (`findIdentityLeaks`): a PII instance counts as
+ * masked only when its full real value is absent from the masked output.
+ * Gates are documented in ./README.md and were committed before any run.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { PromptPiiDetector } from '@omadia/plugin-api';
+
+import { createBaselineDetector, maskPrompt } from '../promptMask.js';
+import { findIdentityLeaks } from '../v4/onTheWire.js';
+
+interface FixtureSpan {
+  readonly value: string;
+  readonly type: string;
+  readonly tier: 'critical' | 'high' | 'medium';
+}
+
+interface FixtureItem {
+  readonly text: string;
+  readonly spans: readonly FixtureSpan[];
+}
+
+/** Detector sets under evaluation. Add `['c0+c1', [baseline, c1]]` here
+ *  once a real C1 transformer detector is wired. */
+const DETECTOR_SETS: ReadonlyArray<[string, readonly PromptPiiDetector[]]> = [
+  ['c0', [createBaselineDetector()]],
+];
+
+/** Types the C0 baseline is expected (and gated) to catch. `person` and
+ *  other free-form entities are C1 territory — reported separately. */
+const STRUCTURED_TYPES = new Set(['email', 'iban', 'phone', 'address', 'amount', 'date']);
+
+function p95(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1)]!;
+}
+
+async function evalLocale(
+  locale: string,
+  items: readonly FixtureItem[],
+  detectors: readonly PromptPiiDetector[],
+): Promise<void> {
+  const byType = new Map<string, { total: number; masked: number }>();
+  let negatives = 0;
+  let cleanNegatives = 0;
+  const latencies: number[] = [];
+
+  for (const item of items) {
+    const startedAt = performance.now();
+    const result = await maskPrompt(item.text, detectors);
+    latencies.push(performance.now() - startedAt);
+
+    if (item.spans.length === 0) {
+      negatives += 1;
+      if (result.spans.length === 0) cleanNegatives += 1;
+      continue;
+    }
+    for (const span of item.spans) {
+      const bucket = byType.get(span.type) ?? { total: 0, masked: 0 };
+      bucket.total += 1;
+      // Exact-match criterion: the full real value must be gone.
+      if (findIdentityLeaks(result.maskedText, [span.value]).length === 0) {
+        bucket.masked += 1;
+      }
+      byType.set(span.type, bucket);
+    }
+  }
+
+  console.log(`\n=== ${locale} ===`);
+  let structuredTotal = 0;
+  let structuredMasked = 0;
+  for (const [type, { total, masked }] of [...byType.entries()].sort()) {
+    const recall = total === 0 ? 1 : masked / total;
+    const scope = STRUCTURED_TYPES.has(type) ? 'structured' : 'c1-scope';
+    console.log(
+      `  recall ${type.padEnd(8)} ${masked}/${total}  ${(recall * 100).toFixed(1)}%  (${scope})`,
+    );
+    if (STRUCTURED_TYPES.has(type)) {
+      structuredTotal += total;
+      structuredMasked += masked;
+    }
+  }
+  const structuredRecall = structuredTotal === 0 ? 1 : structuredMasked / structuredTotal;
+  const precisionProxy = negatives === 0 ? 1 : cleanNegatives / negatives;
+  const latencyP95 = p95(latencies);
+  console.log(`  structured recall     ${(structuredRecall * 100).toFixed(1)}%  (gate ≥ 97%)`);
+  console.log(`  negatives clean       ${cleanNegatives}/${negatives}  (gate ≥ 85%)`);
+  console.log(`  p95 latency           ${latencyP95.toFixed(1)} ms  (gate ≤ 400 ms)`);
+  const pass =
+    structuredRecall >= 0.97 && precisionProxy >= 0.85 && latencyP95 <= 400;
+  console.log(`  verdict (structured-identifier gates only): ${pass ? 'PASS' : 'FAIL'}`);
+}
+
+async function main(): Promise<void> {
+  const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+  const locales = readdirSync(fixturesDir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => f.replace(/\.json$/, ''))
+    .sort();
+  for (const [setName, detectors] of DETECTOR_SETS) {
+    console.log(`\n########## detector set: ${setName} ##########`);
+    for (const locale of locales) {
+      const items = JSON.parse(
+        readFileSync(join(fixturesDir, `${locale}.json`), 'utf-8'),
+      ) as FixtureItem[];
+      await evalLocale(locale, items, detectors);
+    }
+  }
+  console.log(
+    '\nNote: name/free-form (`person`) recall requires a C1 transformer detector — C0 alone must not gate those types. See README.md.',
+  );
+}
+
+void main();

--- a/middleware/packages/harness-plugin-quality-guard/README.md
+++ b/middleware/packages/harness-plugin-quality-guard/README.md
@@ -1,0 +1,48 @@
+# Quality Guard (`@omadia/plugin-quality-guard`)
+
+Response-quality core plugin. Publishes the `responseGuard@1` capability:
+sycophancy levels (`off`/`low`/`medium`/`high`) plus a boundary-preset
+library. The orchestrator splices the returned `prependRules` block into the
+system prompt **ahead of** the body prose as its own cache element; profiles
+without quality frontmatter inherit the global defaults configured here.
+
+The plugin manipulates strings only — no network, graph, memory, or
+filesystem access (all permission allow-lists are explicit-empty).
+
+## Capability
+
+| Surface | What it does |
+|---|---|
+| `responseGuard@1` | `getRules(profileQuality?)` → guardrail block for the system prompt. Per-profile overrides come from AGENT.md frontmatter; the `agent_overrides` map below is the pre-frontmatter fallback. |
+
+## Config keys (`setup.fields`)
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `default_sycophancy` | enum | `medium` | Global default for profiles without `quality.sycophancy`. `high` = devil's advocate. |
+| `default_boundary_presets` | string | `""` | Comma-separated preset IDs (e.g. `no-financial-advice`, `no-medical-advice`, `privacy-first`, …). Unknown IDs are ignored. |
+| `default_boundary_custom` | string | `""` | Free-text boundaries, one per line, spliced verbatim as bullet points. |
+| `agent_overrides` | string | `""` | Optional JSON map `agentId → SycophancyLevel`; frontmatter wins once present. |
+
+## Layout
+
+Standard tool-plugin shape: `src/` → compiled `dist/` (`lifecycle.entry:
+dist/plugin.js`). `boundaryPresets.ts` holds the preset library,
+`sycophancyGuard.ts` the level → rules mapping, `configSchema.ts` the
+setup-field parsing.
+
+## PluginContext surface — v1.0 readiness audit (#431)
+
+| Surface | Decision | Rationale |
+|---|---|---|
+| `ctx.jobs` | skip | Pure synchronous string assembly — nothing to schedule. |
+| `ctx.status` | skip | No external connection or degraded mode to report. |
+| `ctx.llm` | skip | Deterministic rule splicing by design; an LLM step would make guardrails nondeterministic. |
+| `ctx.mcp` | skip | No external tooling involved. |
+
+Versioning: stays independently versioned (currently `0.1.0`); does not bump
+in lockstep with core.
+
+## Tests
+
+Central suite: `middleware/test/qualityGuardPlugin.test.ts`.

--- a/middleware/packages/harness-plugin-web-search/README.md
+++ b/middleware/packages/harness-plugin-web-search/README.md
@@ -1,0 +1,61 @@
+# Web Search (`@omadia/plugin-web-search`)
+
+Live web-search core plugin. Publishes the `webSearch@1` capability and a
+`web_search` native tool with structured citation objects, backed by one of
+two providers the operator picks at install time:
+
+- **Tavily** (default) — built for AI use, structured snippets, optional
+  extracted full text.
+- **Brave Search** — independent crawler, no full-text inlining.
+
+If the selected provider's API key is empty at activate time, the plugin
+degrades to "no capability published" instead of failing activation — see
+`src/plugin.ts`.
+
+## Tools & capability
+
+| Surface | What it does |
+|---|---|
+| `web_search` (native tool) | Query → ranked results with title, URL, snippet, and citation objects. Attached to the orchestrator's tool list automatically. |
+| `webSearch@1` (capability) | Programmatic search for consuming plugins — declare `requires: ["webSearch@^1"]`. |
+
+## Config keys (`setup.fields`)
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `provider` | enum | `tavily` | `tavily` or `brave`; only the matching key is needed. |
+| `tavily_api_key` | secret | — | Vault-stored. Only when `provider: tavily`. |
+| `brave_api_key` | secret | — | Vault-stored. Only when `provider: brave`. |
+| `default_top_k` | integer | `5` | Results per query when the caller omits `top_k` (1–20). |
+| `cache_ttl_search_sec` | integer | `600` | Identical queries are served from an in-memory cache to protect the provider quota. |
+| `cache_max_entries` | integer | `200` | LRU bound on the cache map. |
+
+## Permissions
+
+Outbound network is an exact-hostname allow-list (`api.tavily.com`,
+`api.search.brave.com`) enforced by the host's `HttpAccessor`; no memory,
+graph, or filesystem access. All outbound calls route through `ctx.http`,
+all secrets through `ctx.secrets`.
+
+## Layout
+
+Standard tool-plugin shape: `src/` → compiled `dist/` (`lifecycle.entry:
+dist/plugin.js`). `src/providers/` holds the per-provider adapters,
+`searchService.ts` the cache + dispatch, `searchTool.ts` the native-tool
+binding.
+
+## PluginContext surface — v1.0 readiness audit (#431)
+
+| Surface | Decision | Rationale |
+|---|---|---|
+| `ctx.jobs` | skip | Searches are synchronous, second-scale calls; nothing long-running to schedule. |
+| `ctx.status` | skip for 1.0 | Missing-key handling (degrade to "no capability") predates `ctx.status`; reporting it as an action status is a candidate follow-up, not a readiness blocker. |
+| `ctx.llm` | skip | Pure retrieval — no LLM step inside the plugin. |
+| `ctx.mcp` | skip | Direct provider REST APIs via `ctx.http` are the point of this plugin; an MCP indirection adds nothing. |
+
+Versioning: stays independently versioned (currently `0.1.0`); does not bump
+in lockstep with core (`compat.core: ">=1.0 <2.0"` states compatibility).
+
+## Tests
+
+Central suite: `middleware/test/webSearchPlugin.test.ts`.

--- a/middleware/packages/plugin-api/src/privacyReceipt.ts
+++ b/middleware/packages/plugin-api/src/privacyReceipt.ts
@@ -80,6 +80,13 @@ export interface PrivacyReceipt {
    * count, never a raw value.
    */
   readonly bypassedTools?: readonly BypassedToolEntry[];
+  /**
+   * #361 — PII spans detected in the user's own prompt and substituted with
+   * pseudonyms before the prompt crossed the LLM wire. Absent when prompt
+   * masking is off (the default) or nothing was detected. PII-free: entries
+   * carry the span TYPE + detector id only, never the value.
+   */
+  readonly maskedPromptSpans?: readonly PromptMaskedSpanInfo[];
 }
 
 // ---------------------------------------------------------------------------
@@ -199,6 +206,74 @@ export interface PrivacyResolvedDataset {
   readonly rows: ReadonlyArray<Record<string, unknown>>;
 }
 
+// ---------------------------------------------------------------------------
+// #361 — free-text user-prompt PII masking (wire-substitution with
+// answer-side restore).
+//
+// Unlike the dataset boundary (real rows never leave the server), the user's
+// prompt itself must cross the wire — so detected PII spans are substituted
+// with realistic pseudonyms (the shipped US7 mechanism, `v4/pseudonym.ts`),
+// the surrogate-bearing text goes to the LLM, and the surrogate↔real map is
+// held server-side per turn and inverted over the final answer.
+// ---------------------------------------------------------------------------
+
+/** One PII span a detector found in a prompt text. Offsets are UTF-16 code
+ *  unit indices into the analyzed text; `end` is exclusive. */
+export interface PromptPiiSpan {
+  readonly start: number;
+  readonly end: number;
+  /** PII category, e.g. 'email' | 'iban' | 'phone' | 'address' | 'amount'
+   *  | 'date' | 'person'. Open set — detectors may add categories. */
+  readonly type: string;
+  /** Detection confidence in [0,1]. The C0 regex baseline reports 1. */
+  readonly confidence: number;
+}
+
+/**
+ * Pluggable prompt-PII detector seam (#361). C0 is the deterministic regex
+ * baseline shipped with the privacy-guard plugin; C1 is the transformer
+ * ensemble slot (Piiranha / GLiNER) — wired only after the committed
+ * validation harness passes its documented recall gates for a locale.
+ */
+export interface PromptPiiDetector {
+  /** Stable id recorded (PII-free) in the receipt, e.g. 'c0-regex'. */
+  readonly id: string;
+  detect(text: string): Promise<readonly PromptPiiSpan[]>;
+}
+
+/** PII-free record of one masked prompt span for the receipt. */
+export interface PromptMaskedSpanInfo {
+  readonly type: string;
+  readonly detector: string;
+}
+
+export interface PrivacyPromptMaskRequest {
+  readonly sessionId: string;
+  readonly turnId: string;
+  /** The prompt text to mask (user message or ingested attachment tail). */
+  readonly text: string;
+}
+
+/**
+ * Failure-closed result contract (#361): there is NO pass-through-unmasked
+ * outcome. `disabled` = the operator flag is off (caller uses the original
+ * text — byte-identical legacy behavior); `masked` = surrogates substituted
+ * (`degraded` when the C1 detector failed and only C0 ran, audited);
+ * `blocked` = masking was requested but could not be guaranteed (baseline
+ * detector failure or a residual real span survived substitution) — the
+ * caller MUST fail the turn instead of sending the prompt.
+ */
+export type PrivacyPromptMaskResult =
+  | { readonly outcome: 'disabled' }
+  | {
+      readonly outcome: 'masked';
+      readonly maskedText: string;
+      /** PII-free span records, also aggregated into the turn receipt. */
+      readonly spans: readonly PromptMaskedSpanInfo[];
+      readonly degraded: boolean;
+    }
+  | { readonly outcome: 'blocked'; readonly reason: string };
+
 /**
  * Service surface published by the `privacy.redact@1` provider plugin.
  */
@@ -262,6 +337,27 @@ export interface PrivacyGuardService {
     turnId: string,
     datasetId: string,
   ): PrivacyResolvedDataset | undefined;
+  /**
+   * #361 — mask PII spans in a free-text prompt before it crosses the LLM
+   * wire. Gated on the plugin's default-off `mask_user_prompt` config; when
+   * the flag is off the result is `{outcome:'disabled'}` and the caller
+   * proceeds byte-identically to legacy behavior. Repeated calls within one
+   * turn share the same server-held surrogate map (stable surrogates).
+   *
+   * Optional on the interface so alternative privacy providers (and test
+   * stubs) need not implement it; consumers feature-detect and degrade to
+   * `disabled`.
+   */
+  maskUserPrompt?(
+    request: PrivacyPromptMaskRequest,
+  ): Promise<PrivacyPromptMaskResult>;
+  /**
+   * #361 — invert this turn's prompt-surrogate map over a block of text
+   * (the final answer), restoring real values the user originally wrote.
+   * Identity when the turn masked nothing. MUST be called before
+   * `finalizeTurn` — finalize drops the map.
+   */
+  restorePromptPseudonyms?(turnId: string, text: string): Promise<string>;
   /**
    * Privacy Shield v4 — the verb + render tool specs to offer the LLM.
    */

--- a/middleware/packages/plugin-api/src/privacyReceipt.ts
+++ b/middleware/packages/plugin-api/src/privacyReceipt.ts
@@ -359,6 +359,17 @@ export interface PrivacyGuardService {
    */
   restorePromptPseudonyms?(turnId: string, text: string): Promise<string>;
   /**
+   * #361 — capture this turn's prompt-surrogate inversion as a synchronous,
+   * self-contained closure (a snapshot copy of the map). For consumers that
+   * complete AFTER `finalizeTurn` dropped the live map — e.g. fire-and-forget
+   * fact extraction, which must restore surrogates in extracted facts to
+   * real values before persisting them to the knowledge graph. Returns
+   * `undefined` when the turn masked nothing (callers skip the restore pass).
+   */
+  snapshotPromptRestorer?(
+    turnId: string,
+  ): ((text: string) => string) | undefined;
+  /**
    * Privacy Shield v4 — the verb + render tool specs to offer the LLM.
    */
   v4ToolSpecs(): ReadonlyArray<PrivacyV4ToolSpec>;

--- a/middleware/sidecars/skillspector/Dockerfile
+++ b/middleware/sidecars/skillspector/Dockerfile
@@ -1,0 +1,29 @@
+# SkillSpector code-scan sidecar (issue #453).
+#
+# Wraps NVIDIA SkillSpector (Apache-2.0, github.com/NVIDIA/skillspector) in a
+# minimal HTTP shim so the Node middleware never needs a Python runtime:
+# `POST /scan` with the package file tree → `skillspector scan <tmpdir>
+# --no-llm --format json` → normalized findings JSON.
+#
+# Deterministic mode only (`--no-llm`): no API keys, no outbound calls.
+# Deployment config (fly.skillspector.toml etc.) stays deployment-local.
+FROM python:3.12-slim-bookworm
+
+# libyara for SkillSpector's YARA detectors (YR1–YR4); build tools for the
+# yara-python wheel when no prebuilt wheel matches.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends gcc libssl-dev libyara-dev git \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY server.py .
+
+# Run as non-root: the shim only needs /tmp and the port.
+RUN useradd --create-home scanner
+USER scanner
+
+EXPOSE 8811
+CMD ["python", "server.py"]

--- a/middleware/sidecars/skillspector/README.md
+++ b/middleware/sidecars/skillspector/README.md
@@ -1,0 +1,42 @@
+# SkillSpector code-scan sidecar (issue #453)
+
+HTTP shim around [NVIDIA SkillSpector](https://github.com/NVIDIA/skillspector)
+(Apache-2.0) so the Node middleware never needs a Python runtime. The
+middleware posts the extracted package's file tree to `POST /scan`; the shim
+materializes it into a temp dir, runs
+`skillspector scan <dir> --no-llm --format json`, and answers a normalized
+`{ok, scanner_version, findings: [{code, severity, message, file}]}`.
+
+Deterministic mode only (`--no-llm`): no API keys, no outbound calls.
+Enable in the middleware via `SKILLSPECTOR_URL` (see
+`docker-compose.skillspector.yaml`).
+
+## Fail-closed response contract
+
+The shim positively verifies SkillSpector's report schema (observed on the
+pinned commit, CLI v2.3.11): exit code `0` **and** parseable JSON **and** a
+top-level object with an `issues` list plus a `risk_assessment` object.
+"Ran clean" is exit 0 with `issues: []`. Everything else — non-zero exit,
+non-JSON stdout, or an unrecognized schema — answers `ok: false`, which the
+middleware records as a `scan_failed` verdict. An unrecognized schema must
+never read as a clean scan (`no_signals`).
+
+## Dependency pin & bump procedure
+
+`requirements.txt` pins SkillSpector to an **exact commit SHA** — never a
+moving branch (supply chain: the sidecar executes third-party scanner code
+against every uploaded package tree). To bump the pin:
+
+1. Pick the new upstream commit (`git ls-remote https://github.com/NVIDIA/skillspector.git HEAD`
+   or a reviewed release tag) and review the upstream diff since the current pin.
+2. Update the SHA in `requirements.txt`, rebuild the image
+   (`docker build middleware/sidecars/skillspector`), and re-run the schema
+   probe: one benign fixture (expect `ok:true, findings: []`) and one with an
+   obvious exfiltration pattern (expect an `E*` / YARA finding). If the report
+   schema changed, align `extract_findings` in `server.py` — it fails closed
+   on any mismatch, so a silent schema drift surfaces as `scan_failed`, not
+   as a false all-clear.
+3. Bump `PLUGIN_SCANNER_VERSION` in `middleware/src/services/pluginScanner.ts`
+   if the detector set changed in a way that should invalidate cached verdicts.
+4. Switch to a versioned `skillspector==X.Y.Z` pin as soon as a PyPI release
+   exists.

--- a/middleware/sidecars/skillspector/requirements.txt
+++ b/middleware/sidecars/skillspector/requirements.txt
@@ -1,4 +1,5 @@
 # NVIDIA SkillSpector — deterministic agent-skill/code scanner (Apache-2.0).
-# Pinned to the repo's main branch until a PyPI release exists; move to a
-# versioned `skillspector==X.Y.Z` pin as soon as one is published.
-skillspector @ git+https://github.com/NVIDIA/skillspector.git
+# Pinned to an exact commit SHA (supply-chain: never track a moving branch).
+# No PyPI release exists yet; move to a versioned `skillspector==X.Y.Z` pin
+# as soon as one is published. Pin-bump procedure: see README.md.
+skillspector @ git+https://github.com/NVIDIA/skillspector.git@c2d09df019e358d3dc12d980b82c798b87cb9f56

--- a/middleware/sidecars/skillspector/requirements.txt
+++ b/middleware/sidecars/skillspector/requirements.txt
@@ -1,0 +1,4 @@
+# NVIDIA SkillSpector — deterministic agent-skill/code scanner (Apache-2.0).
+# Pinned to the repo's main branch until a PyPI release exists; move to a
+# versioned `skillspector==X.Y.Z` pin as soon as one is published.
+skillspector @ git+https://github.com/NVIDIA/skillspector.git

--- a/middleware/sidecars/skillspector/server.py
+++ b/middleware/sidecars/skillspector/server.py
@@ -1,0 +1,149 @@
+"""HTTP shim around the SkillSpector CLI (issue #453).
+
+Endpoints:
+    GET  /health  -> {"ok": true}
+    POST /scan    -> body {"files": [{"path": "...", "content_b64": "..."}]}
+                     writes the tree to a temp dir, runs
+                     `skillspector scan <dir> --no-llm --format json`,
+                     responds {"ok": true, "scanner_version": "...",
+                               "findings": [{"code","severity","message","file"}]}
+
+Deliberately stdlib-only (the single dependency is SkillSpector itself) and
+stateless: every request gets a fresh temp dir that is removed afterwards.
+The middleware-side contract lives in
+middleware/src/services/pluginScanner.ts (`parseSidecarResponse`).
+"""
+
+import base64
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PORT = int(os.environ.get("PORT", "8811"))
+SCAN_TIMEOUT_S = int(os.environ.get("SCAN_TIMEOUT_S", "120"))
+MAX_BODY_BYTES = int(os.environ.get("MAX_BODY_BYTES", str(64 * 1024 * 1024)))
+
+
+def skillspector_version() -> str:
+    try:
+        out = subprocess.run(
+            ["skillspector", "--version"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return (out.stdout or out.stderr).strip()
+    except Exception:  # noqa: BLE001 — version string is cosmetic only
+        return "unknown"
+
+
+def materialize(files: list, root: str) -> None:
+    """Write the posted file tree below `root`, rejecting path escapes."""
+    for entry in files:
+        rel = entry.get("path")
+        content_b64 = entry.get("content_b64")
+        if not isinstance(rel, str) or not isinstance(content_b64, str):
+            raise ValueError("file entries need string 'path' and 'content_b64'")
+        target = os.path.realpath(os.path.join(root, rel))
+        if not target.startswith(os.path.realpath(root) + os.sep):
+            raise ValueError(f"path escapes scan root: {rel!r}")
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "wb") as fh:
+            fh.write(base64.b64decode(content_b64))
+
+
+def extract_findings(payload) -> list:
+    """Normalize SkillSpector's JSON output into flat finding dicts."""
+    if isinstance(payload, list):
+        raw = payload
+    elif isinstance(payload, dict):
+        raw = None
+        for key in ("findings", "results", "detections"):
+            if isinstance(payload.get(key), list):
+                raw = payload[key]
+                break
+        if raw is None:
+            raw = []
+    else:
+        raw = []
+    findings = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        findings.append({
+            "code": str(item.get("code") or item.get("id") or item.get("detector") or "unknown"),
+            "severity": str(item.get("severity") or item.get("level") or "LOW"),
+            "message": str(item.get("message") or item.get("description") or item.get("title") or ""),
+            "file": item.get("file") or item.get("path") or item.get("location"),
+        })
+    return findings
+
+
+def run_scan(files: list) -> dict:
+    root = tempfile.mkdtemp(prefix="skillspector-")
+    try:
+        materialize(files, root)
+        proc = subprocess.run(
+            ["skillspector", "scan", root, "--no-llm", "--format", "json"],
+            capture_output=True, text=True, timeout=SCAN_TIMEOUT_S,
+        )
+        # SkillSpector uses non-zero exit codes to signal findings; only a
+        # non-parseable stdout is treated as a scanner failure.
+        try:
+            payload = json.loads(proc.stdout)
+        except (json.JSONDecodeError, TypeError):
+            return {
+                "ok": False,
+                "error": f"skillspector produced no JSON (exit={proc.returncode}): {proc.stderr[:2000]}",
+            }
+        return {
+            "ok": True,
+            "scanner_version": skillspector_version(),
+            "findings": extract_findings(payload),
+        }
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _respond(self, status: int, body: dict) -> None:
+        raw = json.dumps(body).encode("utf-8")
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def do_GET(self):  # noqa: N802 — http.server API
+        if self.path == "/health":
+            self._respond(200, {"ok": True})
+        else:
+            self._respond(404, {"ok": False, "error": "not found"})
+
+    def do_POST(self):  # noqa: N802 — http.server API
+        if self.path != "/scan":
+            self._respond(404, {"ok": False, "error": "not found"})
+            return
+        length = int(self.headers.get("content-length", "0"))
+        if length <= 0 or length > MAX_BODY_BYTES:
+            self._respond(413, {"ok": False, "error": "body missing or too large"})
+            return
+        try:
+            body = json.loads(self.rfile.read(length))
+            files = body.get("files")
+            if not isinstance(files, list):
+                raise ValueError("body needs a 'files' array")
+            self._respond(200, run_scan(files))
+        except subprocess.TimeoutExpired:
+            self._respond(504, {"ok": False, "error": "scan timed out"})
+        except Exception as err:  # noqa: BLE001 — shim must answer, not die
+            self._respond(400, {"ok": False, "error": str(err)})
+
+    def log_message(self, fmt, *args):  # quiet default access log
+        pass
+
+
+if __name__ == "__main__":
+    print(f"[skillspector-sidecar] listening on :{PORT} (scan timeout {SCAN_TIMEOUT_S}s)")
+    ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()

--- a/middleware/sidecars/skillspector/server.py
+++ b/middleware/sidecars/skillspector/server.py
@@ -53,31 +53,53 @@ def materialize(files: list, root: str) -> None:
             fh.write(base64.b64decode(content_b64))
 
 
+class SchemaMismatch(ValueError):
+    """The scanner's output is not the positively-recognized report schema."""
+
+
 def extract_findings(payload) -> list:
-    """Normalize SkillSpector's JSON output into flat finding dicts."""
-    if isinstance(payload, list):
-        raw = payload
-    elif isinstance(payload, dict):
-        raw = None
-        for key in ("findings", "results", "detections"):
-            if isinstance(payload.get(key), list):
-                raw = payload[key]
-                break
-        if raw is None:
-            raw = []
-    else:
-        raw = []
+    """Normalize SkillSpector's JSON report into flat finding dicts.
+
+    FAIL-CLOSED (#453 second-review fix): only the positively-verified
+    SkillSpector report schema is accepted — observed on the pinned commit
+    (v2.3.11): a top-level object with `issues` (list) and `risk_assessment`
+    (dict); each issue carries `id`, `severity`, `explanation`, and
+    `location.file`. Anything else raises `SchemaMismatch`, so the caller
+    answers ok:false and the middleware records `scan_failed` — an
+    unrecognized schema must NEVER read as a clean scan.
+    """
+    if not isinstance(payload, dict):
+        raise SchemaMismatch(f"report is not an object (got {type(payload).__name__})")
+    issues = payload.get("issues")
+    if not isinstance(issues, list):
+        raise SchemaMismatch("report has no 'issues' list — unrecognized schema")
+    if not isinstance(payload.get("risk_assessment"), dict):
+        raise SchemaMismatch("report has no 'risk_assessment' object — unrecognized schema")
     findings = []
-    for item in raw:
+    for item in issues:
         if not isinstance(item, dict):
-            continue
+            raise SchemaMismatch("issue entry is not an object — unrecognized schema")
+        location = item.get("location")
+        file_ = location.get("file") if isinstance(location, dict) else None
         findings.append({
-            "code": str(item.get("code") or item.get("id") or item.get("detector") or "unknown"),
-            "severity": str(item.get("severity") or item.get("level") or "LOW"),
-            "message": str(item.get("message") or item.get("description") or item.get("title") or ""),
-            "file": item.get("file") or item.get("path") or item.get("location"),
+            "code": str(item.get("id") or "unknown"),
+            "severity": str(item.get("severity") or "LOW"),
+            "message": str(
+                item.get("explanation") or item.get("finding") or item.get("category") or ""
+            ),
+            "file": file_ if isinstance(file_, str) else None,
         })
     return findings
+
+
+def report_version(payload) -> str:
+    """Scanner version, preferring the report's own metadata over the CLI."""
+    metadata = payload.get("metadata") if isinstance(payload, dict) else None
+    if isinstance(metadata, dict):
+        v = metadata.get("skillspector_version")
+        if isinstance(v, str) and v:
+            return f"SkillSpector v{v}" if not v.startswith("SkillSpector") else v
+    return skillspector_version()
 
 
 def run_scan(files: list) -> dict:
@@ -88,8 +110,18 @@ def run_scan(files: list) -> dict:
             ["skillspector", "scan", root, "--no-llm", "--format", "json"],
             capture_output=True, text=True, timeout=SCAN_TIMEOUT_S,
         )
-        # SkillSpector uses non-zero exit codes to signal findings; only a
-        # non-parseable stdout is treated as a scanner failure.
+        # Observed on the pinned commit: a completed scan exits 0 whether or
+        # not it found issues (findings do NOT change the exit code); usage/
+        # input errors exit non-zero with a prose message on stdout/stderr.
+        # Positive verification, fail-closed: success requires exit 0 AND
+        # parseable JSON AND the recognized report schema. 'Ran clean' is
+        # exit 0 + `issues: []`; everything ambiguous is a failure.
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "")[:2000]
+            return {
+                "ok": False,
+                "error": f"skillspector exited {proc.returncode}: {detail}",
+            }
         try:
             payload = json.loads(proc.stdout)
         except (json.JSONDecodeError, TypeError):
@@ -97,10 +129,14 @@ def run_scan(files: list) -> dict:
                 "ok": False,
                 "error": f"skillspector produced no JSON (exit={proc.returncode}): {proc.stderr[:2000]}",
             }
+        try:
+            findings = extract_findings(payload)
+        except SchemaMismatch as err:
+            return {"ok": False, "error": f"unrecognized scanner output: {err}"}
         return {
             "ok": True,
-            "scanner_version": skillspector_version(),
-            "findings": extract_findings(payload),
+            "scanner_version": report_version(payload),
+            "findings": findings,
         }
     finally:
         shutil.rmtree(root, ignore_errors=True)

--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -477,11 +477,35 @@ export type PluginJobSchedule =
 
 export type StoreListResponse = Page<Plugin>;
 
+/** Advisory code-scan verdict for an ingested plugin package (issue #453).
+ *  Absent when the plugin was never scanned (built-ins, no scanner). */
+export interface PluginVerdict {
+  severity:
+    | 'no_signals'
+    | 'flagged'
+    | 'high_risk'
+    | 'scan_failed'
+    | 'pending'
+    | 'too_large_to_scan';
+  findings: readonly {
+    readonly code: string;
+    readonly severity: string;
+    readonly message: string;
+    readonly file: string | null;
+  }[];
+  scanner_version: string;
+  rationale: string | null;
+  computed_at: ISO8601;
+  ack: { by: string; at: ISO8601 } | null;
+}
+
 export interface StoreGetResponse {
   plugin: Plugin;
   manifest: unknown;
   install_available: boolean;
   blocking_reasons?: string[];
+  /** Advisory-only — never blocks install (issue #453). */
+  verdict?: PluginVerdict;
 }
 
 // ---------------------------------------------------------------------------

--- a/middleware/src/config.ts
+++ b/middleware/src/config.ts
@@ -400,6 +400,12 @@ const ConfigSchema = z.object({
   PACKAGE_UPLOAD_MAX_BYTES: z.coerce.number().int().positive().default(15 * 1024 * 1024),
   PACKAGE_UPLOAD_MAX_EXTRACTED_BYTES: z.coerce.number().int().positive().default(80 * 1024 * 1024),
   PACKAGE_UPLOAD_MAX_ENTRIES: z.coerce.number().int().positive().default(2000),
+  /** Base URL of the SkillSpector code-scan sidecar (issue #453), e.g.
+   *  http://skillspector:8811. Unset → no scanning: ingests succeed
+   *  unchanged and verdict rows record `scan_failed`. Advisory-only in
+   *  v1 — a verdict never blocks an install. */
+  SKILLSPECTOR_URL: z.string().url().optional(),
+  SKILLSPECTOR_TIMEOUT_MS: z.coerce.number().int().positive().default(20_000),
   /** Root of the built-in package tree (scanned for manifest.yaml files at
    *  boot). In dev this resolves to `<repo>/middleware/packages`; in the
    *  Docker image it's `/app/packages`. Each subdirectory with a valid

--- a/middleware/src/config.ts
+++ b/middleware/src/config.ts
@@ -402,8 +402,9 @@ const ConfigSchema = z.object({
   PACKAGE_UPLOAD_MAX_ENTRIES: z.coerce.number().int().positive().default(2000),
   /** Base URL of the SkillSpector code-scan sidecar (issue #453), e.g.
    *  http://skillspector:8811. Unset → no scanning: ingests succeed
-   *  unchanged and verdict rows record `scan_failed`. Advisory-only in
-   *  v1 — a verdict never blocks an install. */
+   *  unchanged and NO verdict rows are written (`scan_failed` is reserved
+   *  for real sidecar failures). Advisory-only in v1 — a verdict never
+   *  blocks an install. */
   SKILLSPECTOR_URL: z.string().url().optional(),
   SKILLSPECTOR_TIMEOUT_MS: z.coerce.number().int().positive().default(20_000),
   /** Root of the built-in package tree (scanned for manifest.yaml files at

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -35,6 +35,15 @@ import {
 } from './services/mcpGrantPolicy.js';
 import { rescanAllMcpServers } from './services/mcpRescan.js';
 import { createLlmVerifier, type LlmVerifier } from './services/skillVerdictLlmVerifier.js';
+import {
+  HttpSkillSpectorScanner,
+  NullPluginScanner,
+} from './services/pluginScanner.js';
+import {
+  createPluginScanScheduler,
+  createPluginVerdictLookup,
+  type PluginVerdictLookup,
+} from './services/pluginVerdict.js';
 import { ScheduleWorker } from './scheduler/scheduleWorker.js';
 import type {
   ConfigStore as MultiOrchestratorConfigStore,
@@ -1449,6 +1458,37 @@ async function main(): Promise<void> {
     ? new McpConfigService({ graph: new AgentGraphStore(graphPool), vault: secretVault })
     : undefined;
 
+  // Plugin code scanning (issue #453) — SkillSpector sidecar behind the
+  // PluginScanner seam. Requires the Postgres graph backend for the verdict
+  // table; without it (in-memory dev/tests) scanning is simply absent.
+  // Advisory-only v1: verdicts decorate the store/detail responses, nothing
+  // reads them to block an install.
+  const pluginVerdictStore = graphPool ? new AgentGraphStore(graphPool) : undefined;
+  const pluginScanScheduler = pluginVerdictStore
+    ? createPluginScanScheduler({
+        store: pluginVerdictStore,
+        scanner: config.SKILLSPECTOR_URL
+          ? new HttpSkillSpectorScanner({
+              baseUrl: config.SKILLSPECTOR_URL,
+              timeoutMs: config.SKILLSPECTOR_TIMEOUT_MS,
+              log: (m) => console.log(m),
+            })
+          : new NullPluginScanner(),
+        log: (m) => console.log(m),
+      })
+    : undefined;
+  const pluginVerdictLookup: PluginVerdictLookup | undefined = pluginVerdictStore
+    ? createPluginVerdictLookup({
+        store: pluginVerdictStore,
+        packages: uploadedPackageStore,
+      })
+    : undefined;
+  if (config.SKILLSPECTOR_URL && !graphPool) {
+    console.warn(
+      '[middleware] SKILLSPECTOR_URL is set but the graph backend is in-memory — plugin code scanning disabled (verdicts need Postgres)',
+    );
+  }
+
   // MCP registry bearer tokens live in the vault, never on the DB row
   // (issue #463 item 5). Move any legacy plaintext token (pre-0020) into the
   // vault on boot — idempotent, a no-op once the column is NULL.
@@ -2646,6 +2686,9 @@ async function main(): Promise<void> {
       registry: installedRegistry,
       client: registryClient,
       pluginStatusRegistry,
+      // Issue #453 — read-only code-scan verdict on the detail response
+      // plus the operator ack endpoint. Lookup only, never scans on GET.
+      verdicts: pluginVerdictLookup,
     }),
   );
   console.log('[middleware] plugin store endpoints ready at /api/v1/store/plugins (auth: required)');
@@ -2788,6 +2831,9 @@ async function main(): Promise<void> {
       hostDependencies,
       registry: installedRegistry,
       migrationRunner,
+      // Issue #453 — advisory SkillSpector scan, fire-and-forget after a
+      // successful ingest. Absent without a Postgres graph backend.
+      scanScheduler: pluginScanScheduler,
       // After a re-upload onto an already installed agent (registry entry
       // still alive, package was deleted + re-uploaded) we activate the
       // runtime directly — otherwise the tool stays unknown until the user

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -35,10 +35,7 @@ import {
 } from './services/mcpGrantPolicy.js';
 import { rescanAllMcpServers } from './services/mcpRescan.js';
 import { createLlmVerifier, type LlmVerifier } from './services/skillVerdictLlmVerifier.js';
-import {
-  HttpSkillSpectorScanner,
-  NullPluginScanner,
-} from './services/pluginScanner.js';
+import { HttpSkillSpectorScanner } from './services/pluginScanner.js';
 import {
   createPluginScanScheduler,
   createPluginVerdictLookup,
@@ -1461,22 +1458,24 @@ async function main(): Promise<void> {
   // Plugin code scanning (issue #453) — SkillSpector sidecar behind the
   // PluginScanner seam. Requires the Postgres graph backend for the verdict
   // table; without it (in-memory dev/tests) scanning is simply absent.
-  // Advisory-only v1: verdicts decorate the store/detail responses, nothing
-  // reads them to block an install.
+  // Second-review fix: with SKILLSPECTOR_URL unset no scheduler is wired at
+  // all — no verdict row is written on ingest, so store pages show no badge
+  // on unconfigured deployments. `scan_failed` is reserved for REAL sidecar
+  // failures. Advisory-only v1: verdicts decorate the store/detail
+  // responses, nothing reads them to block an install.
   const pluginVerdictStore = graphPool ? new AgentGraphStore(graphPool) : undefined;
-  const pluginScanScheduler = pluginVerdictStore
-    ? createPluginScanScheduler({
-        store: pluginVerdictStore,
-        scanner: config.SKILLSPECTOR_URL
-          ? new HttpSkillSpectorScanner({
-              baseUrl: config.SKILLSPECTOR_URL,
-              timeoutMs: config.SKILLSPECTOR_TIMEOUT_MS,
-              log: (m) => console.log(m),
-            })
-          : new NullPluginScanner(),
-        log: (m) => console.log(m),
-      })
-    : undefined;
+  const pluginScanScheduler =
+    pluginVerdictStore && config.SKILLSPECTOR_URL
+      ? createPluginScanScheduler({
+          store: pluginVerdictStore,
+          scanner: new HttpSkillSpectorScanner({
+            baseUrl: config.SKILLSPECTOR_URL,
+            timeoutMs: config.SKILLSPECTOR_TIMEOUT_MS,
+            log: (m) => console.log(m),
+          }),
+          log: (m) => console.log(m),
+        })
+      : undefined;
   const pluginVerdictLookup: PluginVerdictLookup | undefined = pluginVerdictStore
     ? createPluginVerdictLookup({
         store: pluginVerdictStore,

--- a/middleware/src/plugins/packageUploadService.ts
+++ b/middleware/src/plugins/packageUploadService.ts
@@ -8,6 +8,7 @@ import {
   MigrationTimeoutError,
 } from '@omadia/plugin-api';
 
+import { findUnscannableSegment } from '../services/pluginScanner.js';
 import type { InstalledRegistry } from './installedRegistry.js';
 import type { PluginCatalog } from './manifestLoader.js';
 import { loadManifestFromPath } from './manifestLoader.js';
@@ -220,6 +221,19 @@ export class PackageUploadService {
         return fail(
           'package.entry_missing',
           `lifecycle.entry '${entryRel}' ist im Zip nicht vorhanden.`,
+        );
+      }
+      // #453 (codex review fix) — the code scan skips node_modules/.git, so
+      // an entry point below such a path would EXECUTE code the scanner
+      // never saw while the store shows a clean badge. No legitimate omadia
+      // plugin does this (the boilerplate uses dist/plugin.js) → reject.
+      const unscannable = findUnscannableSegment(
+        path.relative(packageRoot, absEntry),
+      );
+      if (unscannable !== null) {
+        return fail(
+          'package.entry_unscannable',
+          `lifecycle.entry '${entryRel}' liegt unter '${unscannable}' — Entry Points unter node_modules oder versteckten Verzeichnissen sind nicht erlaubt (der Code-Scan würde sie nicht erfassen).`,
         );
       }
 

--- a/middleware/src/plugins/packageUploadService.ts
+++ b/middleware/src/plugins/packageUploadService.ts
@@ -87,6 +87,19 @@ export interface PackageUploadServiceDeps {
    * without an `onMigrate` export would get).
    */
   migrationRunner?: MigrationRunner;
+  /**
+   * Optional code-scan scheduler (issue #453). Invoked fire-and-forget on
+   * the ingest success path — a missing scheduler, a scheduler throw, or a
+   * scanner outage must never fail or delay an ingest (advisory-only v1).
+   * Structural slice of `PluginScanScheduler` in services/pluginVerdict.ts.
+   */
+  scanScheduler?: {
+    scheduleScan(input: {
+      sha256: string;
+      pluginId: string;
+      installedDir: string;
+    }): Promise<void>;
+  };
   log?: (msg: string) => void;
 }
 
@@ -326,6 +339,29 @@ export class PackageUploadService {
       log(
         `[upload] ingest OK id=${plugin.id} version=${plugin.version} sha256=${sha256.slice(0, 12)} peers_missing=${peersMissing.length}${migratedConfig !== null ? ' [migrated]' : ''}`,
       );
+
+      // Advisory code scan (issue #453) — fire-and-forget AFTER the package
+      // is fully ingested. Not awaited: ingest latency stays unaffected, and
+      // any scheduler error is contained here.
+      if (this.deps.scanScheduler) {
+        try {
+          void this.deps.scanScheduler
+            .scheduleScan({
+              sha256,
+              pluginId: plugin.id,
+              installedDir: finalDir,
+            })
+            .catch((err: unknown) => {
+              log(
+                `[upload] plugin scan for ${plugin.id} failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            });
+        } catch (err) {
+          log(
+            `[upload] plugin scan scheduling for ${plugin.id} failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
 
       // Re-upload onto an already installed agent (typical: package file
       // was deleted, registry entry still `active`). Without the hook the

--- a/middleware/src/routes/store.ts
+++ b/middleware/src/routes/store.ts
@@ -11,6 +11,7 @@ import type {
 import type { InstalledRegistry } from '../plugins/installedRegistry.js';
 import type { PluginCatalog } from '../plugins/manifestLoader.js';
 import type { PluginStatusRegistry } from '../platform/pluginStatusRegistry.js';
+import type { PluginVerdictLookup } from '../services/pluginVerdict.js';
 import type {
   RegistryClient,
   ResolvedRegistryPlugin,
@@ -27,6 +28,10 @@ interface StoreDeps {
   /** Spec 004 — read-only access to plugins' pushed `ctx.status` so the list
    *  and detail responses can carry `action_status` for the badge/banner. */
   pluginStatusRegistry?: PluginStatusRegistry;
+  /** Issue #453 — advisory code-scan verdicts for ingested packages. When
+   *  present, the detail response carries a read-only `verdict` and the
+   *  operator ack endpoint is mounted. Lookup only — GET never scans. */
+  verdicts?: PluginVerdictLookup;
 }
 
 /** Overlay the live `ctx.status` value (if any) onto a plugin record. Returns
@@ -194,6 +199,17 @@ export function createStoreRouter(deps: StoreDeps): Router {
       }
       const installAvailable = plugin.install_state === 'available';
       plugin = withActionStatus(plugin, deps.pluginStatusRegistry);
+      // Issue #453 — decorate with the advisory code-scan verdict. Pure
+      // lookup (never triggers a scan); a store hiccup degrades to "no
+      // verdict shown", never a 500.
+      let verdict;
+      if (deps.verdicts) {
+        try {
+          verdict = await deps.verdicts.getForPlugin(id);
+        } catch {
+          verdict = undefined;
+        }
+      }
       const body: StoreGetResponse = {
         plugin,
         manifest: entry.manifest,
@@ -201,11 +217,48 @@ export function createStoreRouter(deps: StoreDeps): Router {
         ...(plugin.incompatibility_reasons
           ? { blocking_reasons: plugin.incompatibility_reasons }
           : {}),
+        ...(verdict ? { verdict } : {}),
       };
       res.json(body);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       res.status(500).json({ code: 'store.get_failed', message });
+    }
+  });
+
+  // Issue #453 — operator acknowledgement of a code-scan verdict. Advisory
+  // model as in #452: any authenticated operator may ack (omadia has no role
+  // differentiation yet — see the acknowledged gap in agentBuilder.ts), but
+  // ack_by/ack_at are persisted for audit.
+  router.post('/:id/verdict/ack', async (req: Request, res: Response) => {
+    try {
+      const rawId = req.params['id'];
+      const id = typeof rawId === 'string' ? rawId : undefined;
+      if (!id) {
+        res.status(400).json({ code: 'store.invalid_id', message: 'missing id' });
+        return;
+      }
+      if (!deps.verdicts) {
+        res.status(404).json({
+          code: 'store.verdicts_unavailable',
+          message: 'code-scan verdicts are not enabled on this deployment',
+        });
+        return;
+      }
+      const session = (req as Request & { session?: { email: string } }).session;
+      const ackedBy = session?.email ?? 'unknown';
+      const ack = await deps.verdicts.ack(id, ackedBy);
+      if (!ack) {
+        res.status(404).json({
+          code: 'store.verdict_not_found',
+          message: `no code-scan verdict recorded for plugin '${id}'`,
+        });
+        return;
+      }
+      res.json({ ack });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ code: 'store.ack_failed', message });
     }
   });
 

--- a/middleware/src/services/pluginScanner.ts
+++ b/middleware/src/services/pluginScanner.ts
@@ -8,10 +8,12 @@ import type { Severity } from './skillVerdict.js';
  *
  * `PluginScanner` is the seam between the ingest pipeline and the NVIDIA
  * SkillSpector sidecar: one method, directory in, normalized `ScanResult`
- * out. Two implementations ship — `HttpSkillSpectorScanner` posts the
- * package's file tree to the sidecar's `POST /scan` shim (which runs
- * `skillspector scan <dir> --no-llm --format json`), and
- * `NullPluginScanner` covers deployments without a configured sidecar.
+ * out. `HttpSkillSpectorScanner` posts the package's file tree to the
+ * sidecar's `POST /scan` shim (which runs `skillspector scan <dir>
+ * --no-llm --format json`). Deployments without a configured sidecar
+ * (`SKILLSPECTOR_URL` unset) wire NO scanner and NO scheduler at all — no
+ * verdict rows are written, store pages show no badge; `scan_failed` is
+ * reserved for REAL scanner failures.
  *
  * Contract: `scan()` NEVER throws. Every failure mode (sidecar down,
  * timeout, malformed response, unreadable package dir) degrades to a
@@ -45,8 +47,8 @@ export interface ScanFinding {
 }
 
 export interface ScanResult {
-  /** 'skipped' = no scanner configured; 'failed' = scanner errored. */
-  readonly status: 'scanned' | 'skipped' | 'failed';
+  /** 'failed' = the scanner errored (sidecar down/timeout/bad schema). */
+  readonly status: 'scanned' | 'failed';
   readonly severity: Severity;
   readonly findings: readonly ScanFinding[];
   readonly scannerVersion: string;
@@ -81,24 +83,6 @@ function failed(rationale: string): ScanResult {
     scannerVersion: PLUGIN_SCANNER_VERSION,
     rationale,
   };
-}
-
-/**
- * No-op scanner for deployments without a SkillSpector sidecar
- * (`SKILLSPECTOR_URL` unset) and for tests. Reports `scan_failed` with a
- * `skipped` status so the verdict row is honest about why there is no
- * signal — installs proceed unaffected either way (advisory-only v1).
- */
-export class NullPluginScanner implements PluginScanner {
-  async scan(_dir: string): Promise<ScanResult> {
-    return {
-      status: 'skipped',
-      severity: 'scan_failed',
-      findings: [],
-      scannerVersion: PLUGIN_SCANNER_VERSION,
-      rationale: 'No code scanner configured (SKILLSPECTOR_URL is unset).',
-    };
-  }
 }
 
 export interface HttpSkillSpectorScannerOptions {
@@ -205,34 +189,40 @@ async function collectFiles(dir: string): Promise<CollectedFiles> {
 }
 
 /**
- * Tolerant mapping of the sidecar's JSON onto `ScanResult`. The shim
- * forwards SkillSpector's `--format json` output; we read the common field
- * spellings defensively so a minor upstream schema change degrades to
- * `scan_failed` (or a finding with an empty code) rather than a throw.
+ * FAIL-CLOSED mapping of the sidecar shim's JSON onto `ScanResult`
+ * (second-review fix). The shim's contract is exactly
+ * `{ok: true, scanner_version, findings: [{code, severity, message, file}]}`
+ * (the shim itself positively verifies SkillSpector's report schema and
+ * answers `ok: false` on any mismatch — see
+ * middleware/sidecars/skillspector/server.py). No alternate field spellings
+ * are guessed here: anything that is not the promised contract degrades to
+ * `scan_failed`, never to an implicit `no_signals` all-clear.
  */
 export function parseSidecarResponse(body: unknown): ScanResult {
   if (!body || typeof body !== 'object') {
     return failed('Scanner sidecar returned a non-object response.');
   }
   const record = body as Record<string, unknown>;
-  if (record['ok'] === false) {
+  if (record['ok'] !== true) {
     const message =
       typeof record['error'] === 'string' ? record['error'] : 'unknown scanner error';
     return failed(`Scanner reported failure: ${message}`);
   }
-  const rawFindings = firstArray(record, ['findings', 'results', 'detections']);
-  if (!rawFindings) {
+  const rawFindings = record['findings'];
+  if (!Array.isArray(rawFindings)) {
     return failed('Scanner sidecar response carries no findings array.');
   }
   const findings: ScanFinding[] = [];
   for (const raw of rawFindings) {
-    if (!raw || typeof raw !== 'object') continue;
+    if (!raw || typeof raw !== 'object') {
+      return failed('Scanner sidecar response carries a non-object finding.');
+    }
     const f = raw as Record<string, unknown>;
     findings.push({
-      code: firstString(f, ['code', 'id', 'detector']) ?? 'unknown',
-      severity: firstString(f, ['severity', 'level']) ?? 'LOW',
-      message: firstString(f, ['message', 'description', 'title']) ?? '',
-      file: firstString(f, ['file', 'path', 'location']),
+      code: firstString(f, ['code']) ?? 'unknown',
+      severity: firstString(f, ['severity']) ?? 'LOW',
+      message: firstString(f, ['message']) ?? '',
+      file: firstString(f, ['file']),
     });
   }
   const scannerVersion =
@@ -252,17 +242,6 @@ function firstString(record: Record<string, unknown>, keys: string[]): string | 
   for (const key of keys) {
     const value = record[key];
     if (typeof value === 'string' && value.length > 0) return value;
-  }
-  return null;
-}
-
-function firstArray(
-  record: Record<string, unknown>,
-  keys: string[],
-): unknown[] | null {
-  for (const key of keys) {
-    const value = record[key];
-    if (Array.isArray(value)) return value;
   }
   return null;
 }

--- a/middleware/src/services/pluginScanner.ts
+++ b/middleware/src/services/pluginScanner.ts
@@ -1,6 +1,8 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
+import { parse as parseYaml } from 'yaml';
+
 import type { Severity } from './skillVerdict.js';
 
 /**
@@ -36,6 +38,25 @@ const MAX_FILE_BYTES = 5 * 1024 * 1024;
 const MAX_TOTAL_BYTES = 30 * 1024 * 1024;
 /** Directories that carry no scannable plugin code. */
 const SKIPPED_DIRS = new Set(['node_modules', '.git']);
+
+/**
+ * #453 (codex review fix) — shared skip predicate for `lifecycle.entry`
+ * validation. Returns the first path segment that makes the path
+ * unscannable (a `SKIPPED_DIRS` member or any hidden `.`-prefixed
+ * segment), or `null` when every segment is scannable. Upload validation
+ * uses this to REJECT packages whose entry point the scanner would never
+ * see; no legitimate omadia plugin places its entry there (the boilerplate
+ * uses `dist/plugin.js`). Deliberately broader than `collectFiles`' own
+ * walk (which only skips `SKIPPED_DIRS`): hidden segments are rejected
+ * up-front too, so the accepted surface stays conservative.
+ */
+export function findUnscannableSegment(relPath: string): string | null {
+  for (const segment of relPath.split(/[\\/]+/)) {
+    if (segment === '' || segment === '.') continue;
+    if (SKIPPED_DIRS.has(segment) || segment.startsWith('.')) return segment;
+  }
+  return null;
+}
 
 export interface ScanFinding {
   /** SkillSpector detector id, e.g. 'E2', 'YR1', 'LP3', 'OH1'. */
@@ -104,9 +125,9 @@ export class HttpSkillSpectorScanner implements PluginScanner {
   async scan(dir: string): Promise<ScanResult> {
     const log = this.opts.log ?? (() => undefined);
 
-    let collected: CollectedFiles;
+    let collected: ScanPayload;
     try {
-      collected = await collectFiles(dir);
+      collected = await collectScanPayload(dir);
     } catch (err) {
       return failed(
         `Package directory unreadable: ${err instanceof Error ? err.message : String(err)}`,
@@ -120,6 +141,13 @@ export class HttpSkillSpectorScanner implements PluginScanner {
         scannerVersion: PLUGIN_SCANNER_VERSION,
         rationale: `Package exceeds the scan size cap (${MAX_TOTAL_BYTES} bytes total / ${MAX_FILE_BYTES} bytes per file).`,
       };
+    }
+    // #453 (codex review fix) — fail CLOSED when the executed entry point is
+    // not part of the payload: a package whose `lifecycle.entry` the scanner
+    // never saw must surface as `scan_failed`, never as a `no_signals`
+    // all-clear.
+    if (collected.coverageError !== null) {
+      return failed(collected.coverageError);
     }
 
     const controller = new AbortController();
@@ -156,6 +184,93 @@ export class HttpSkillSpectorScanner implements PluginScanner {
 interface CollectedFiles {
   files: { path: string; content_b64: string }[];
   tooLarge: boolean;
+}
+
+export interface ScanPayload extends CollectedFiles {
+  /** `null` when the manifest's `lifecycle.entry` file is guaranteed to be
+   *  part of `files`; otherwise the reason coverage cannot be guaranteed
+   *  (the caller degrades to `scan_failed`). Undefined semantics only when
+   *  `tooLarge` is set (the payload is discarded then anyway). */
+  coverageError: string | null;
+}
+
+/**
+ * #453 (codex review fix) — collect the file tree AND guarantee coverage of
+ * the executed entry point. `collectFiles` skips `SKIPPED_DIRS`
+ * (node_modules, .git) because they carry no scannable plugin code — but
+ * the manifest's `lifecycle.entry` may point exactly there, and the runtime
+ * would import it. Upload validation rejects such entries for NEW packages
+ * (`findUnscannableSegment`); this is the defense-in-depth layer behind it:
+ * when the walk dropped the entry file, it is force-included in the
+ * payload, and when it cannot be included (missing, symlink, oversize,
+ * escapes the root, undeterminable manifest) the scan fails CLOSED.
+ */
+export async function collectScanPayload(dir: string): Promise<ScanPayload> {
+  const collected = await collectFiles(dir);
+  if (collected.tooLarge) return { ...collected, coverageError: null };
+  const coverageError = await ensureEntryCovered(dir, collected.files);
+  return { ...collected, coverageError };
+}
+
+/** Read `lifecycle.entry` from the package manifest; defaults to
+ *  `dist/plugin.js` (mirroring `packageUploadService`). Returns `null` when
+ *  the manifest is missing or unparseable — the entry point cannot be
+ *  determined then, so coverage cannot be guaranteed. */
+async function readManifestEntry(dir: string): Promise<string | null> {
+  try {
+    const raw = await fs.readFile(path.join(dir, 'manifest.yaml'), 'utf-8');
+    const manifest: unknown = parseYaml(raw);
+    if (!manifest || typeof manifest !== 'object') return null;
+    const lifecycle = (manifest as Record<string, unknown>)['lifecycle'];
+    const entry =
+      lifecycle && typeof lifecycle === 'object'
+        ? (lifecycle as Record<string, unknown>)['entry']
+        : undefined;
+    return typeof entry === 'string' && entry.length > 0
+      ? entry
+      : 'dist/plugin.js';
+  } catch {
+    return null;
+  }
+}
+
+/** Returns `null` when the entry file is covered by `files` (force-including
+ *  it when the walk skipped it), or the fail-closed reason otherwise. */
+async function ensureEntryCovered(
+  dir: string,
+  files: { path: string; content_b64: string }[],
+): Promise<string | null> {
+  const entryRel = await readManifestEntry(dir);
+  if (entryRel === null) {
+    return (
+      'manifest.yaml is missing or unparseable — the executed entry point ' +
+      'cannot be determined, so scan coverage cannot be guaranteed.'
+    );
+  }
+  const root = path.resolve(dir);
+  const absEntry = path.resolve(root, entryRel);
+  if (!absEntry.startsWith(root + path.sep)) {
+    return `lifecycle.entry '${entryRel}' escapes the package root — scan coverage cannot be guaranteed.`;
+  }
+  const relPosix = path.relative(root, absEntry).split(path.sep).join('/');
+  if (files.some((f) => f.path === relPosix)) return null;
+  // The walk dropped it (skipped dir / symlink) or it is absent: force-
+  // include plain, in-cap regular files; anything else fails closed.
+  let stat;
+  try {
+    stat = await fs.lstat(absEntry);
+  } catch {
+    return `lifecycle.entry '${entryRel}' does not exist in the package — scan coverage cannot be guaranteed.`;
+  }
+  if (!stat.isFile()) {
+    return `lifecycle.entry '${entryRel}' is not a regular file — scan coverage cannot be guaranteed.`;
+  }
+  if (stat.size > MAX_FILE_BYTES) {
+    return `lifecycle.entry '${entryRel}' exceeds the per-file scan cap — scan coverage cannot be guaranteed.`;
+  }
+  const content = await fs.readFile(absEntry);
+  files.push({ path: relPosix, content_b64: content.toString('base64') });
+  return null;
 }
 
 async function collectFiles(dir: string): Promise<CollectedFiles> {

--- a/middleware/src/services/pluginScanner.ts
+++ b/middleware/src/services/pluginScanner.ts
@@ -1,0 +1,268 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import type { Severity } from './skillVerdict.js';
+
+/**
+ * Static code scanning for executable plugin packages (issue #453).
+ *
+ * `PluginScanner` is the seam between the ingest pipeline and the NVIDIA
+ * SkillSpector sidecar: one method, directory in, normalized `ScanResult`
+ * out. Two implementations ship — `HttpSkillSpectorScanner` posts the
+ * package's file tree to the sidecar's `POST /scan` shim (which runs
+ * `skillspector scan <dir> --no-llm --format json`), and
+ * `NullPluginScanner` covers deployments without a configured sidecar.
+ *
+ * Contract: `scan()` NEVER throws. Every failure mode (sidecar down,
+ * timeout, malformed response, unreadable package dir) degrades to a
+ * `scan_failed` result — the caller persists it as an advisory verdict and
+ * ingest is never affected. See docs/security-architecture.md.
+ */
+
+/**
+ * Scanner identity persisted with each verdict row. Bump when the sidecar
+ * image / detector set changes in a way that should invalidate cached
+ * verdicts (mirrors `CURRENT_VERIFIER_VERSION` in skillVerdict.ts).
+ */
+export const PLUGIN_SCANNER_VERSION = 'skillspector-v1';
+
+/** Caps for the file tree posted to the sidecar. Packages beyond these
+ *  bounds report `too_large_to_scan` instead of a partial (misleading)
+ *  scan. Extraction is already capped upstream (PACKAGE_UPLOAD_MAX_-
+ *  EXTRACTED_BYTES, default 80 MB), so these only bite on outliers. */
+const MAX_FILE_BYTES = 5 * 1024 * 1024;
+const MAX_TOTAL_BYTES = 30 * 1024 * 1024;
+/** Directories that carry no scannable plugin code. */
+const SKIPPED_DIRS = new Set(['node_modules', '.git']);
+
+export interface ScanFinding {
+  /** SkillSpector detector id, e.g. 'E2', 'YR1', 'LP3', 'OH1'. */
+  readonly code: string;
+  /** SkillSpector-native severity: CRITICAL | HIGH | MEDIUM | LOW. */
+  readonly severity: string;
+  readonly message: string;
+  readonly file: string | null;
+}
+
+export interface ScanResult {
+  /** 'skipped' = no scanner configured; 'failed' = scanner errored. */
+  readonly status: 'scanned' | 'skipped' | 'failed';
+  readonly severity: Severity;
+  readonly findings: readonly ScanFinding[];
+  readonly scannerVersion: string;
+  readonly rationale: string | null;
+}
+
+export interface PluginScanner {
+  /** Scan the extracted package at `dir`. Never throws. */
+  scan(dir: string): Promise<ScanResult>;
+}
+
+/**
+ * Map SkillSpector finding severities onto the shared verdict scale.
+ * CRITICAL/HIGH (YARA malware/webshell/miner, exfiltration) → `high_risk`;
+ * MEDIUM/LOW (permission mismatch, output hygiene) → `flagged`; an empty
+ * finding list → `no_signals`.
+ */
+export function mapSkillSpectorSeverity(findings: readonly ScanFinding[]): Severity {
+  if (findings.length === 0) return 'no_signals';
+  const hasHigh = findings.some((f) => {
+    const s = f.severity.toUpperCase();
+    return s === 'CRITICAL' || s === 'HIGH';
+  });
+  return hasHigh ? 'high_risk' : 'flagged';
+}
+
+function failed(rationale: string): ScanResult {
+  return {
+    status: 'failed',
+    severity: 'scan_failed',
+    findings: [],
+    scannerVersion: PLUGIN_SCANNER_VERSION,
+    rationale,
+  };
+}
+
+/**
+ * No-op scanner for deployments without a SkillSpector sidecar
+ * (`SKILLSPECTOR_URL` unset) and for tests. Reports `scan_failed` with a
+ * `skipped` status so the verdict row is honest about why there is no
+ * signal — installs proceed unaffected either way (advisory-only v1).
+ */
+export class NullPluginScanner implements PluginScanner {
+  async scan(_dir: string): Promise<ScanResult> {
+    return {
+      status: 'skipped',
+      severity: 'scan_failed',
+      findings: [],
+      scannerVersion: PLUGIN_SCANNER_VERSION,
+      rationale: 'No code scanner configured (SKILLSPECTOR_URL is unset).',
+    };
+  }
+}
+
+export interface HttpSkillSpectorScannerOptions {
+  /** Base URL of the sidecar, e.g. http://skillspector:8811 */
+  baseUrl: string;
+  timeoutMs: number;
+  log?: (msg: string) => void;
+}
+
+/**
+ * Posts the package file tree as JSON (`{ files: [{path, content_b64}] }`)
+ * to the sidecar shim. A file-tree POST instead of a shared volume keeps
+ * the middleware and the sidecar deployable as independent machines (the
+ * fly.io topology has no shared filesystem between processes).
+ */
+export class HttpSkillSpectorScanner implements PluginScanner {
+  constructor(private readonly opts: HttpSkillSpectorScannerOptions) {}
+
+  async scan(dir: string): Promise<ScanResult> {
+    const log = this.opts.log ?? (() => undefined);
+
+    let collected: CollectedFiles;
+    try {
+      collected = await collectFiles(dir);
+    } catch (err) {
+      return failed(
+        `Package directory unreadable: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    if (collected.tooLarge) {
+      return {
+        status: 'scanned',
+        severity: 'too_large_to_scan',
+        findings: [],
+        scannerVersion: PLUGIN_SCANNER_VERSION,
+        rationale: `Package exceeds the scan size cap (${MAX_TOTAL_BYTES} bytes total / ${MAX_FILE_BYTES} bytes per file).`,
+      };
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.opts.timeoutMs);
+    try {
+      const res = await fetch(`${this.opts.baseUrl.replace(/\/$/, '')}/scan`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ files: collected.files }),
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        return failed(`Scanner sidecar responded ${res.status}.`);
+      }
+      const body: unknown = await res.json();
+      return parseSidecarResponse(body);
+    } catch (err) {
+      const reason =
+        controller.signal.aborted
+          ? `Scanner sidecar timed out after ${this.opts.timeoutMs}ms.`
+          : `Scanner sidecar unreachable: ${err instanceof Error ? err.message : String(err)}`;
+      log(`[plugin-scan] ${reason}`);
+      return failed(reason);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+interface CollectedFiles {
+  files: { path: string; content_b64: string }[];
+  tooLarge: boolean;
+}
+
+async function collectFiles(dir: string): Promise<CollectedFiles> {
+  const out: { path: string; content_b64: string }[] = [];
+  let totalBytes = 0;
+
+  async function walk(current: string, relBase: string): Promise<boolean> {
+    const entries = await fs.readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) continue;
+      const abs = path.join(current, entry.name);
+      const rel = relBase ? `${relBase}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        if (SKIPPED_DIRS.has(entry.name)) continue;
+        if (!(await walk(abs, rel))) return false;
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const stat = await fs.stat(abs);
+      if (stat.size > MAX_FILE_BYTES) return false;
+      totalBytes += stat.size;
+      if (totalBytes > MAX_TOTAL_BYTES) return false;
+      const content = await fs.readFile(abs);
+      out.push({ path: rel, content_b64: content.toString('base64') });
+    }
+    return true;
+  }
+
+  const ok = await walk(dir, '');
+  return { files: out, tooLarge: !ok };
+}
+
+/**
+ * Tolerant mapping of the sidecar's JSON onto `ScanResult`. The shim
+ * forwards SkillSpector's `--format json` output; we read the common field
+ * spellings defensively so a minor upstream schema change degrades to
+ * `scan_failed` (or a finding with an empty code) rather than a throw.
+ */
+export function parseSidecarResponse(body: unknown): ScanResult {
+  if (!body || typeof body !== 'object') {
+    return failed('Scanner sidecar returned a non-object response.');
+  }
+  const record = body as Record<string, unknown>;
+  if (record['ok'] === false) {
+    const message =
+      typeof record['error'] === 'string' ? record['error'] : 'unknown scanner error';
+    return failed(`Scanner reported failure: ${message}`);
+  }
+  const rawFindings = firstArray(record, ['findings', 'results', 'detections']);
+  if (!rawFindings) {
+    return failed('Scanner sidecar response carries no findings array.');
+  }
+  const findings: ScanFinding[] = [];
+  for (const raw of rawFindings) {
+    if (!raw || typeof raw !== 'object') continue;
+    const f = raw as Record<string, unknown>;
+    findings.push({
+      code: firstString(f, ['code', 'id', 'detector']) ?? 'unknown',
+      severity: firstString(f, ['severity', 'level']) ?? 'LOW',
+      message: firstString(f, ['message', 'description', 'title']) ?? '',
+      file: firstString(f, ['file', 'path', 'location']),
+    });
+  }
+  const scannerVersion =
+    typeof record['scanner_version'] === 'string' && record['scanner_version']
+      ? `${PLUGIN_SCANNER_VERSION} (${record['scanner_version']})`
+      : PLUGIN_SCANNER_VERSION;
+  return {
+    status: 'scanned',
+    severity: mapSkillSpectorSeverity(findings),
+    findings,
+    scannerVersion,
+    rationale: null,
+  };
+}
+
+function firstString(record: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return null;
+}
+
+function firstArray(
+  record: Record<string, unknown>,
+  keys: string[],
+): unknown[] | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (Array.isArray(value)) return value;
+  }
+  return null;
+}

--- a/middleware/src/services/pluginVerdict.ts
+++ b/middleware/src/services/pluginVerdict.ts
@@ -1,0 +1,199 @@
+import {
+  PLUGIN_SCANNER_VERSION,
+  type PluginScanner,
+  type ScanFinding,
+} from './pluginScanner.js';
+import type { Severity } from './skillVerdict.js';
+
+/**
+ * Plugin code-scan verdicts (issue #453) — persistence port + fire-and-forget
+ * scheduler around the `PluginScanner` seam.
+ *
+ * Mirrors `skillVerdict.ts`: verdicts are derived artifacts keyed on
+ * content_hash (the ingested ZIP's sha256) + verifier_version, cached
+ * cache-aside so re-installing the same bytes never re-scans. The graph-
+ * backed implementation lives in
+ * `middleware/packages/harness-orchestrator/src/registry/agentGraphStore.ts`.
+ *
+ * Advisory-only v1: `scheduleScan` runs strictly AFTER a successful ingest,
+ * never inline, and never throws — a scanner outage degrades to a
+ * `scan_failed` verdict row, not a failed install.
+ */
+
+export interface PluginVerdictRow {
+  readonly contentHash: string;
+  readonly verifierVersion: string;
+  readonly pluginId: string;
+  readonly severity: Severity;
+  readonly findings: readonly ScanFinding[];
+  readonly scannerVersion: string;
+  readonly rationale: string | null;
+  readonly computedAt: Date;
+  readonly ackBy: string | null;
+  readonly ackAt: Date | null;
+}
+
+export interface PluginVerdictStore {
+  getPluginVerdict(
+    contentHash: string,
+    verifierVersion: string,
+  ): Promise<PluginVerdictRow | undefined>;
+  /** Latest verdict for a plugin id, regardless of content hash. */
+  getLatestPluginVerdict(
+    pluginId: string,
+    verifierVersion: string,
+  ): Promise<PluginVerdictRow | undefined>;
+  upsertPluginVerdict(row: PluginVerdictRow): Promise<void>;
+  getPluginVerdictsByShas(
+    contentHashes: readonly string[],
+    verifierVersion: string,
+  ): Promise<Map<string, PluginVerdictRow>>;
+  /** Returns undefined when no verdict row exists to acknowledge. */
+  upsertPluginVerdictAck(
+    contentHash: string,
+    verifierVersion: string,
+    ackedBy: string,
+  ): Promise<{ ackBy: string; ackAt: Date } | undefined>;
+}
+
+export interface ScheduleScanInput {
+  sha256: string;
+  pluginId: string;
+  /** Absolute path of the extracted package (post atomic move). */
+  installedDir: string;
+}
+
+export interface PluginScanScheduler {
+  /**
+   * Fire-and-forget: persists a `pending` row, runs the scanner, persists
+   * the resolved verdict. Resolves when the scan settles; callers are free
+   * to `void` the promise. Never rejects.
+   */
+  scheduleScan(input: ScheduleScanInput): Promise<void>;
+}
+
+export interface PluginScanSchedulerDeps {
+  store: PluginVerdictStore;
+  scanner: PluginScanner;
+  log?: (msg: string) => void;
+}
+
+export function createPluginScanScheduler(
+  deps: PluginScanSchedulerDeps,
+): PluginScanScheduler {
+  const log = deps.log ?? ((m) => console.log(m));
+  return {
+    async scheduleScan(input: ScheduleScanInput): Promise<void> {
+      try {
+        // Cache-aside on (sha256, scanner version). Operational states
+        // (`pending` from a crashed run, `scan_failed` from a sidecar
+        // outage) are retried on the next install; real scan outcomes are
+        // final for this scanner version.
+        const cached = await deps.store.getPluginVerdict(
+          input.sha256,
+          PLUGIN_SCANNER_VERSION,
+        );
+        if (cached && cached.severity !== 'pending' && cached.severity !== 'scan_failed') {
+          return;
+        }
+
+        await deps.store.upsertPluginVerdict({
+          contentHash: input.sha256,
+          verifierVersion: PLUGIN_SCANNER_VERSION,
+          pluginId: input.pluginId,
+          severity: 'pending',
+          findings: [],
+          scannerVersion: PLUGIN_SCANNER_VERSION,
+          rationale: null,
+          computedAt: new Date(),
+          ackBy: null,
+          ackAt: null,
+        });
+
+        const result = await deps.scanner.scan(input.installedDir);
+        await deps.store.upsertPluginVerdict({
+          contentHash: input.sha256,
+          verifierVersion: PLUGIN_SCANNER_VERSION,
+          pluginId: input.pluginId,
+          severity: result.severity,
+          findings: result.findings,
+          scannerVersion: result.scannerVersion,
+          rationale: result.rationale,
+          computedAt: new Date(),
+          ackBy: null,
+          ackAt: null,
+        });
+        log(
+          `[plugin-scan] verdict id=${input.pluginId} sha=${input.sha256.slice(0, 12)} severity=${result.severity} findings=${result.findings.length}`,
+        );
+      } catch (err) {
+        // Persistence failures must never surface into the ingest path.
+        log(
+          `[plugin-scan] scan for ${input.pluginId} failed to persist: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    },
+  };
+}
+
+/** Read-model for route serializers (store detail, packages list). */
+export interface PluginVerdictView {
+  readonly severity: Severity;
+  readonly findings: readonly ScanFinding[];
+  readonly scanner_version: string;
+  readonly rationale: string | null;
+  readonly computed_at: string;
+  readonly ack: { by: string; at: string } | null;
+}
+
+export function toPluginVerdictView(row: PluginVerdictRow): PluginVerdictView {
+  return {
+    severity: row.severity,
+    findings: row.findings,
+    scanner_version: row.scannerVersion,
+    rationale: row.rationale,
+    computed_at: row.computedAt.toISOString(),
+    ack: row.ackBy && row.ackAt ? { by: row.ackBy, at: row.ackAt.toISOString() } : null,
+  };
+}
+
+export interface PluginVerdictLookupDeps {
+  store: PluginVerdictStore;
+  /** Structural slice of UploadedPackageStore — resolves plugin id → sha256. */
+  packages: { get(id: string): { sha256: string } | undefined };
+}
+
+export interface PluginVerdictLookup {
+  /** Lookup only — never triggers a scan (safe on GET paths). */
+  getForPlugin(pluginId: string): Promise<PluginVerdictView | undefined>;
+  /** Acknowledge the current verdict; undefined when nothing is scanned. */
+  ack(pluginId: string, ackedBy: string): Promise<{ by: string; at: string } | undefined>;
+}
+
+export function createPluginVerdictLookup(
+  deps: PluginVerdictLookupDeps,
+): PluginVerdictLookup {
+  const resolveHash = (pluginId: string): string | undefined =>
+    deps.packages.get(pluginId)?.sha256;
+  return {
+    async getForPlugin(pluginId) {
+      const sha = resolveHash(pluginId);
+      const row = sha
+        ? await deps.store.getPluginVerdict(sha, PLUGIN_SCANNER_VERSION)
+        : // Package record gone (e.g. deleted after install) — fall back to
+          // the latest verdict recorded for this plugin id.
+          await deps.store.getLatestPluginVerdict(pluginId, PLUGIN_SCANNER_VERSION);
+      return row ? toPluginVerdictView(row) : undefined;
+    },
+    async ack(pluginId, ackedBy) {
+      const sha = resolveHash(pluginId);
+      if (!sha) return undefined;
+      const ack = await deps.store.upsertPluginVerdictAck(
+        sha,
+        PLUGIN_SCANNER_VERSION,
+        ackedBy,
+      );
+      return ack ? { by: ack.ackBy, at: ack.ackAt.toISOString() } : undefined;
+    },
+  };
+}

--- a/middleware/src/services/pluginVerdict.ts
+++ b/middleware/src/services/pluginVerdict.ts
@@ -43,6 +43,12 @@ export interface PluginVerdictStore {
     pluginId: string,
     verifierVersion: string,
   ): Promise<PluginVerdictRow | undefined>;
+  /**
+   * Rewrites the scan columns. An existing operator ack survives only while
+   * the new severity is equal or BETTER than the severity acked (recorded
+   * at ack time); a WORSE re-scan result clears the ack — the operator
+   * never saw those findings.
+   */
   upsertPluginVerdict(row: PluginVerdictRow): Promise<void>;
   getPluginVerdictsByShas(
     contentHashes: readonly string[],

--- a/middleware/test/orchestrator/promptMaskPipeline.test.ts
+++ b/middleware/test/orchestrator/promptMaskPipeline.test.ts
@@ -1,0 +1,277 @@
+/**
+ * #361 — orchestrator-level end-to-end assertions for free-text user-prompt
+ * PII masking. Complements `test/privacyPromptMask.test.ts` (engine/service
+ * units) by exercising the REAL turn pipeline with the REAL privacy-guard
+ * service and the REAL FactExtractor:
+ *
+ *   1. flag on → the outgoing LLM params of the MAIN call AND of the
+ *      fact-extraction call carry surrogates and ZERO raw detected spans;
+ *   2. persisted content (session log answer, ingested KG facts) carries
+ *      the REAL values — never surrogates;
+ *   3. turn-N+1 recalled prior context is masked before injection, so a
+ *      raw span persisted on turn N never re-crosses the wire.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type {
+  LlmProvider,
+  LlmRequest,
+  LlmResponse,
+  LlmStreamEvent,
+} from '@omadia/llm-provider';
+import { NativeToolRegistry, Orchestrator } from '@omadia/orchestrator';
+import { FactExtractor } from '@omadia/orchestrator-extras';
+import type { FactIngest, KnowledgeGraph } from '@omadia/plugin-api';
+import { createPrivacyGuardService } from '@omadia/plugin-privacy-guard/dist/index.js';
+
+const providerCapabilities = {
+  tools: true,
+  vision: true,
+  streaming: true,
+  promptCaching: true,
+  forcedToolChoice: true,
+  parallelToolCalls: true,
+} as const;
+
+const RAW_EMAIL = 'anna.schmidt@firma.de';
+const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/;
+
+/** The privacy-guard service with the #361 flag forced ON. */
+function maskingService(): ReturnType<typeof createPrivacyGuardService> {
+  return createPrivacyGuardService({
+    readConfig: (key: string) => (key === 'mask_user_prompt' ? 'on' : undefined),
+  });
+}
+
+function textResponse(text: string): LlmResponse {
+  return {
+    content: [{ type: 'text', text }],
+    finishReason: 'stop',
+    providerFinishReason: 'end_turn',
+    model: 'test',
+    usage: {
+      inputTokens: 10,
+      outputTokens: 1,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    },
+  };
+}
+
+/** Main-call fake: records every request and answers by echoing the first
+ *  email-shaped token it can find in its own request — i.e. the surrogate
+ *  the mask pass put on the wire. */
+function echoingMainProvider(requests: string[]): LlmProvider {
+  const provider = {
+    id: 'anthropic',
+    capabilities: providerCapabilities,
+    complete: async (req: LlmRequest): Promise<LlmResponse> => {
+      const serialized = JSON.stringify(req);
+      requests.push(serialized);
+      const email = EMAIL_RE.exec(serialized)?.[0] ?? 'no-email-in-request';
+      return textResponse(`Notiert. Ich schreibe an ${email}.`);
+    },
+    stream: (): AsyncIterable<LlmStreamEvent> => {
+      throw new Error('echoingMainProvider: stream() not scripted');
+    },
+    classifyError: () => ({ retryable: false, kind: 'other' as const }),
+  };
+  return provider as unknown as LlmProvider;
+}
+
+/** Haiku fake for the FactExtractor: records the request and returns one
+ *  fact whose object is the email token it saw — the surrogate, when the
+ *  orchestrator fed it masked wire text. */
+function factLlm(requests: string[]): LlmProvider {
+  const provider = {
+    id: 'anthropic',
+    capabilities: providerCapabilities,
+    complete: async (req: LlmRequest): Promise<LlmResponse> => {
+      const serialized = JSON.stringify(req);
+      requests.push(serialized);
+      const email = EMAIL_RE.exec(serialized)?.[0] ?? 'no-email-in-request';
+      return textResponse(
+        JSON.stringify([
+          {
+            subject: 'kunde:anna',
+            predicate: 'kontakt_email',
+            object: email,
+            confidence: 0.9,
+          },
+        ]),
+      );
+    },
+    stream: (): AsyncIterable<LlmStreamEvent> => {
+      throw new Error('factLlm: stream() not scripted');
+    },
+    classifyError: () => ({ retryable: false, kind: 'other' as const }),
+  };
+  return provider as unknown as LlmProvider;
+}
+
+type OrchestratorOptions = ConstructorParameters<typeof Orchestrator>[0];
+
+describe('#361 prompt masking — orchestrator pipeline', () => {
+  it('masks main + fact-extraction LLM params, persists real values', async () => {
+    const mainRequests: string[] = [];
+    const factRequests: string[] = [];
+    const loggedEntries: Array<{ userMessage: string; assistantAnswer: string }> =
+      [];
+    const ingestedFacts: FactIngest[] = [];
+    let resolveIngest: () => void = () => undefined;
+    const ingestDone = new Promise<void>((resolve) => {
+      resolveIngest = resolve;
+    });
+
+    const sessionLogger = {
+      log: async (entry: {
+        userMessage: string;
+        assistantAnswer: string;
+      }): Promise<{ turnExternalId: string }> => {
+        loggedEntries.push({
+          userMessage: entry.userMessage,
+          assistantAnswer: entry.assistantAnswer,
+        });
+        return { turnExternalId: 'turn:sess-1:t1' };
+      },
+    } as unknown as OrchestratorOptions['sessionLogger'];
+
+    const graph = {
+      ingestFacts: async (
+        ingests: FactIngest[],
+      ): Promise<{ inserted: number; updated: number; factIds: string[] }> => {
+        ingestedFacts.push(...ingests);
+        resolveIngest();
+        return {
+          inserted: ingests.length,
+          updated: 0,
+          factIds: ingests.map((i) => i.factId),
+        };
+      },
+    } as unknown as KnowledgeGraph;
+
+    const orch = new Orchestrator({
+      provider: echoingMainProvider(mainRequests),
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 3,
+      domainTools: [],
+      nativeToolRegistry: new NativeToolRegistry(),
+      sessionLogger,
+      factExtractor: new FactExtractor({ llm: factLlm(factRequests), graph }),
+      privacyGuard: () => maskingService(),
+    });
+
+    const result = await orch.runTurn({
+      userMessage: `Bitte schreibe an ${RAW_EMAIL} wegen des Vertrags.`,
+      sessionScope: 'sess-1',
+      userId: 'u1',
+    });
+
+    // Fire-and-forget extraction — wait for the graph write (bounded).
+    await Promise.race([
+      ingestDone,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => {
+          reject(new Error('fact ingest did not complete within 5s'));
+        }, 5_000),
+      ),
+    ]);
+
+    // (1) MAIN call: surrogate on the wire, zero raw spans.
+    assert.equal(mainRequests.length, 1);
+    assert.ok(
+      !mainRequests[0]!.includes(RAW_EMAIL),
+      'main LLM params must not contain the raw email',
+    );
+    const surrogate = EMAIL_RE.exec(mainRequests[0]!)?.[0];
+    assert.ok(surrogate, 'main LLM params must carry an email-shaped surrogate');
+    assert.notEqual(surrogate, RAW_EMAIL);
+
+    // (1) FACT-EXTRACTION call: same wire rule.
+    assert.equal(factRequests.length, 1);
+    assert.ok(
+      !factRequests[0]!.includes(RAW_EMAIL),
+      'fact-extraction LLM params must not contain the raw email',
+    );
+    assert.ok(
+      factRequests[0]!.includes(surrogate!),
+      'fact-extraction call must see the SAME turn-stable surrogate',
+    );
+
+    // (2) Persisted session log: raw user message, POST-restore answer.
+    assert.equal(loggedEntries.length, 1);
+    assert.ok(loggedEntries[0]!.userMessage.includes(RAW_EMAIL));
+    assert.ok(
+      loggedEntries[0]!.assistantAnswer.includes(RAW_EMAIL),
+      'persisted answer must carry the restored real value',
+    );
+    assert.ok(
+      !loggedEntries[0]!.assistantAnswer.includes(surrogate!),
+      'persisted answer must not carry the surrogate',
+    );
+
+    // (2) Persisted KG facts: restored to the real value.
+    assert.equal(ingestedFacts.length, 1);
+    assert.equal(ingestedFacts[0]!.object, RAW_EMAIL);
+
+    // User-facing answer: restored.
+    assert.ok(result.answer.includes(RAW_EMAIL));
+    assert.ok(!result.answer.includes(surrogate!));
+
+    // Transparency: the receipt records the masked prompt span (PII-free).
+    assert.ok(result.privacyReceipt, 'a privacy receipt must be attached');
+    const spans = result.privacyReceipt.maskedPromptSpans ?? [];
+    assert.ok(
+      spans.some((s) => s.type === 'email'),
+      'receipt must record the masked email span',
+    );
+  });
+
+  it('turn N+1: recalled prior context is masked before injection', async () => {
+    const mainRequests: string[] = [];
+    // Simulates the KG recall of turn N — real values, as persisted.
+    const contextRetriever = {
+      assembleForBudget: async (): Promise<unknown> => ({
+        text: `## Letzte Turns in diesem Chat\nUser bat um Mail an ${RAW_EMAIL}.`,
+        included: [],
+        excluded: [],
+        stats: { candidatePool: 1, compactMode: false, tokensUsed: 10 },
+        recalled: undefined,
+      }),
+    } as unknown as OrchestratorOptions['contextRetriever'];
+
+    const orch = new Orchestrator({
+      provider: echoingMainProvider(mainRequests),
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 3,
+      domainTools: [],
+      nativeToolRegistry: new NativeToolRegistry(),
+      contextRetriever,
+      privacyGuard: () => maskingService(),
+    });
+
+    const result = await orch.runTurn({
+      userMessage: 'An welche Adresse ging die Mail nochmal?',
+      sessionScope: 'sess-1',
+      userId: 'u1',
+    });
+
+    assert.equal(mainRequests.length, 1);
+    assert.ok(
+      !mainRequests[0]!.includes(RAW_EMAIL),
+      'turn-N+1 LLM params must not re-leak the raw span from turn N',
+    );
+    const surrogate = EMAIL_RE.exec(mainRequests[0]!)?.[0];
+    assert.ok(
+      surrogate,
+      'the recalled context must carry an email-shaped surrogate instead',
+    );
+    // Answer-side restore covers recall-injected spans too: the provider
+    // echoed the surrogate, the user sees the real value.
+    assert.ok(result.answer.includes(RAW_EMAIL));
+  });
+});

--- a/middleware/test/orchestrator/promptMaskPipeline.test.ts
+++ b/middleware/test/orchestrator/promptMaskPipeline.test.ts
@@ -21,7 +21,7 @@ import type {
   LlmResponse,
   LlmStreamEvent,
 } from '@omadia/llm-provider';
-import { NativeToolRegistry, Orchestrator } from '@omadia/orchestrator';
+import { NativeToolRegistry, Orchestrator, steeringBus } from '@omadia/orchestrator';
 import { FactExtractor } from '@omadia/orchestrator-extras';
 import type { FactIngest, KnowledgeGraph } from '@omadia/plugin-api';
 import { createPrivacyGuardService } from '@omadia/plugin-privacy-guard/dist/index.js';
@@ -345,5 +345,109 @@ describe('#361 prompt masking — orchestrator pipeline', () => {
     // echoed the surrogate, the user sees the real value.
     assert.ok(result.answer.includes(RAW_IBAN));
     assert.ok(!result.answer.includes(surrogate!));
+  });
+
+  it('mid-turn steering (/chat/steer) is masked before it crosses the wire', async () => {
+    // Codex review fix — the steering bus injects RAW user text into the
+    // running iteration loop (streaming path). That text is LLM-bound wire
+    // content like the original user message: with the flag on, a steered
+    // IBAN must reach the provider only as a surrogate, through the SAME
+    // turn map (so answer-side restore covers steered spans too).
+    const RAW_IBAN = 'DE89370400440532013000';
+    const IBAN_RE = /\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b/;
+    const streamRequests: string[] = [];
+    const provider = {
+      id: 'anthropic',
+      capabilities: providerCapabilities,
+      complete: async (): Promise<LlmResponse> => {
+        throw new Error('steering provider: complete() not scripted');
+      },
+      stream: (req: LlmRequest): AsyncIterable<LlmStreamEvent> => {
+        const serialized = JSON.stringify(req);
+        streamRequests.push(serialized);
+        const iban = IBAN_RE.exec(serialized)?.[0] ?? 'no-iban-in-request';
+        const text = `Verstanden, ich nutze ${iban}.`;
+        return {
+          async *[Symbol.asyncIterator]() {
+            yield { type: 'text_delta', text } as LlmStreamEvent;
+            yield {
+              type: 'final',
+              response: {
+                content: [{ type: 'text', text }],
+                finishReason: 'stop',
+                providerFinishReason: 'end_turn',
+                model: 'test',
+                usage: {
+                  inputTokens: 10,
+                  outputTokens: 1,
+                  cacheReadTokens: 0,
+                  cacheWriteTokens: 0,
+                },
+              },
+            } as LlmStreamEvent;
+          },
+        };
+      },
+      classifyError: () => ({ retryable: false, kind: 'other' as const }),
+    } as unknown as LlmProvider;
+
+    const orch = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 3,
+      domainTools: [],
+      nativeToolRegistry: new NativeToolRegistry(),
+      privacyGuard: () => maskingService(),
+    });
+
+    const events: Array<{ type: string } & Record<string, unknown>> = [];
+    let steered = false;
+    for await (const event of orch.chatStream({
+      userMessage: 'Bitte fasse den Stand kurz zusammen.',
+      sessionScope: 'sess-steer',
+      userId: 'u1',
+    })) {
+      events.push(event as { type: string } & Record<string, unknown>);
+      // The generator suspends at each yield: enqueueing on the first
+      // `iteration_start` lands in the bus BEFORE the loop's drain runs,
+      // exactly like a real /chat/steer request racing the model call.
+      if (event.type === 'iteration_start' && !steered) {
+        steered = true;
+        const enq = steeringBus.enqueue(
+          'sess-steer',
+          `Wichtig: nimm das Konto ${RAW_IBAN} dafür.`,
+        );
+        assert.equal(enq.live, true, 'the turn must be live for steering');
+      }
+    }
+
+    // The steer was applied — and echoed to the user RAW (user-facing).
+    const applied = events.find((e) => e.type === 'steer_applied');
+    assert.ok(applied, 'a steer_applied event must be emitted');
+    assert.ok(String(applied!['message']).includes(RAW_IBAN));
+
+    // ZERO raw detected spans in ANY outgoing streaming request body.
+    assert.ok(streamRequests.length >= 1);
+    for (const req of streamRequests) {
+      assert.ok(
+        !req.includes(RAW_IBAN),
+        'streamed LLM params must not contain the raw steered IBAN',
+      );
+    }
+    const withSurrogate = streamRequests.find((req) => IBAN_RE.test(req));
+    assert.ok(
+      withSurrogate,
+      'the steered text must reach the wire as an IBAN-shaped surrogate',
+    );
+    const surrogate = IBAN_RE.exec(withSurrogate!)?.[0];
+    assert.notEqual(surrogate, RAW_IBAN);
+
+    // Answer-side restore covers steered spans (same turn map): the
+    // provider echoed the surrogate, the final answer shows the real value.
+    const done = events.find((e) => e.type === 'done');
+    assert.ok(done, 'the stream must settle with a done event');
+    assert.ok(String(done!['answer']).includes(RAW_IBAN));
+    assert.ok(!String(done!['answer']).includes(surrogate!));
   });
 });

--- a/middleware/test/orchestrator/promptMaskPipeline.test.ts
+++ b/middleware/test/orchestrator/promptMaskPipeline.test.ts
@@ -274,4 +274,76 @@ describe('#361 prompt masking — orchestrator pipeline', () => {
     // echoed the surrogate, the user sees the real value.
     assert.ok(result.answer.includes(RAW_EMAIL));
   });
+
+  it('turn N+1: priorTurns (live chat history) are masked before assembly', async () => {
+    // Second-review fix — persisted turns store restored REAL values by
+    // design, and channels replay them verbatim as `priorTurns`. Turn 1
+    // named an IBAN; turn 2 sends priorTurns=[turn 1] → the turn-2 request
+    // body must contain ZERO raw detected spans.
+    const RAW_IBAN = 'DE89370400440532013000';
+    const IBAN_RE = /\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b/;
+    const mainRequests: string[] = [];
+    const provider = {
+      id: 'anthropic',
+      capabilities: providerCapabilities,
+      complete: async (req: LlmRequest): Promise<LlmResponse> => {
+        const serialized = JSON.stringify(req);
+        mainRequests.push(serialized);
+        const iban = IBAN_RE.exec(serialized)?.[0] ?? 'no-iban-in-request';
+        return textResponse(`Die Überweisung geht an ${iban}.`);
+      },
+      stream: (): AsyncIterable<LlmStreamEvent> => {
+        throw new Error('priorTurns provider: stream() not scripted');
+      },
+      classifyError: () => ({ retryable: false, kind: 'other' as const }),
+    } as unknown as LlmProvider;
+
+    const orch = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 3,
+      domainTools: [],
+      nativeToolRegistry: new NativeToolRegistry(),
+      privacyGuard: () => maskingService(),
+    });
+
+    const result = await orch.runTurn({
+      userMessage: 'An welches Konto ging die Überweisung nochmal?',
+      sessionScope: 'sess-1',
+      userId: 'u1',
+      // The IBAN is space-delimited in both copies: the detector's
+      // word-boundary extension folds adjacent punctuation into the span
+      // VALUE, and only byte-identical values share one map entry.
+      priorTurns: [
+        {
+          userMessage: `Bitte überweise das Gehalt auf ${RAW_IBAN} sofort`,
+          assistantAnswer: `Alles klar, ich habe ${RAW_IBAN} als Zielkonto notiert`,
+        },
+      ],
+    });
+
+    assert.equal(mainRequests.length, 1);
+    assert.ok(
+      !mainRequests[0]!.includes(RAW_IBAN),
+      'turn-2 request body must contain zero raw detected spans from turn 1',
+    );
+    const surrogate = IBAN_RE.exec(mainRequests[0]!)?.[0];
+    assert.ok(
+      surrogate,
+      'the prior turns must carry an IBAN-shaped surrogate instead',
+    );
+    assert.notEqual(surrogate, RAW_IBAN);
+    // Both copies (prior user message AND prior assistant answer) carry the
+    // SAME turn-stable surrogate — the shared per-turn map at work.
+    const occurrences = mainRequests[0]!.split(surrogate!).length - 1;
+    assert.ok(
+      occurrences >= 2,
+      'prior user message and prior assistant answer must share one surrogate',
+    );
+    // Answer-side restore covers priorTurn-derived spans too: the provider
+    // echoed the surrogate, the user sees the real value.
+    assert.ok(result.answer.includes(RAW_IBAN));
+    assert.ok(!result.answer.includes(surrogate!));
+  });
 });

--- a/middleware/test/packageUploadService.test.ts
+++ b/middleware/test/packageUploadService.test.ts
@@ -171,4 +171,49 @@ describe('PackageUploadService ingest × scan scheduler (issue #453)', () => {
     });
     assert.equal(result.ok, true);
   });
+
+  // #453 codex review fix — the scanner skips node_modules, so an entry
+  // point there would execute code the scan never saw while the store shows
+  // a clean badge. Such packages are rejected at upload time.
+  function manifestWithEntry(entry: string): string {
+    return MANIFEST_YAML.replace('entry: "dist/plugin.js"', `entry: "${entry}"`);
+  }
+
+  it('rejects a lifecycle.entry inside node_modules (scanner blind spot)', async () => {
+    const buffer = await buildZip({
+      'manifest.yaml': manifestWithEntry('node_modules/payload/plugin.js'),
+      'node_modules/payload/plugin.js': 'module.exports = { activate() {} };\n',
+      'dist/plugin.js': '// decoy at the boilerplate location\n',
+    });
+    const result = await service().ingest({
+      fileBuffer: buffer,
+      originalFilename: 'scan-target.zip',
+      uploadedBy: 'test@example.com',
+    });
+    assert.equal(result.ok, false);
+    assert.equal((result as { code: string }).code, 'package.entry_unscannable');
+  });
+
+  it('rejects a lifecycle.entry inside a hidden directory', async () => {
+    const buffer = await buildZip({
+      'manifest.yaml': manifestWithEntry('.hidden/plugin.js'),
+      '.hidden/plugin.js': 'module.exports = { activate() {} };\n',
+    });
+    const result = await service().ingest({
+      fileBuffer: buffer,
+      originalFilename: 'scan-target.zip',
+      uploadedBy: 'test@example.com',
+    });
+    assert.equal(result.ok, false);
+    assert.equal((result as { code: string }).code, 'package.entry_unscannable');
+  });
+
+  it('still accepts the boilerplate dist/plugin.js entry', async () => {
+    const result = await service().ingest({
+      fileBuffer: await fixtureZip(),
+      originalFilename: 'scan-target.zip',
+      uploadedBy: 'test@example.com',
+    });
+    assert.equal(result.ok, true);
+  });
 });

--- a/middleware/test/packageUploadService.test.ts
+++ b/middleware/test/packageUploadService.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import yazl from 'yazl';
+
+import { PackageUploadService } from '../src/plugins/packageUploadService.js';
+import type { PluginCatalog } from '../src/plugins/manifestLoader.js';
+import type {
+  UploadedPackage,
+  UploadedPackageStore,
+} from '../src/plugins/uploadedPackageStore.js';
+
+/**
+ * Ingest-path coverage for the scan-scheduler seam (issue #453): the
+ * advisory code scan is fire-and-forget and must never affect the ingest
+ * result — present, absent, throwing, or rejecting.
+ */
+
+const MANIFEST_YAML = `schema_version: "1"
+
+identity:
+  id: "@test/scan-target"
+  name: "Scan Target"
+  version: "1.0.0"
+  kind: "tool"
+  description: "Fixture plugin for ingest tests."
+
+compat:
+  core: ">=1.0 <2.0"
+
+lifecycle:
+  entry: "dist/plugin.js"
+`;
+
+function buildZip(files: Record<string, string>): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const zip = new yazl.ZipFile();
+    const chunks: Buffer[] = [];
+    zip.outputStream.on('data', (c: Buffer) => chunks.push(c));
+    zip.outputStream.on('end', () => resolve(Buffer.concat(chunks)));
+    zip.outputStream.on('error', reject);
+    for (const [name, content] of Object.entries(files)) {
+      zip.addBuffer(Buffer.from(content, 'utf-8'), name, { mtime: new Date(0) });
+    }
+    zip.end();
+  });
+}
+
+function fixtureZip(): Promise<Buffer> {
+  return buildZip({
+    'manifest.yaml': MANIFEST_YAML,
+    'dist/plugin.js': 'module.exports = { activate() {} };\n',
+  });
+}
+
+function fakeStore(): UploadedPackageStore {
+  const packages = new Map<string, UploadedPackage>();
+  return {
+    get: (id: string) => packages.get(id),
+    list: () => [...packages.values()],
+    register: async (pkg: UploadedPackage) => {
+      packages.set(pkg.id, pkg);
+    },
+  } as unknown as UploadedPackageStore;
+}
+
+function fakeCatalog(): PluginCatalog {
+  return {
+    get: () => undefined,
+    load: async () => undefined,
+    list: () => [],
+  } as unknown as PluginCatalog;
+}
+
+describe('PackageUploadService ingest × scan scheduler (issue #453)', () => {
+  let packagesDir: string;
+
+  beforeEach(async () => {
+    packagesDir = await fs.mkdtemp(path.join(os.tmpdir(), 'upload-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(packagesDir, { recursive: true, force: true });
+  });
+
+  function service(
+    scanScheduler?: ConstructorParameters<typeof PackageUploadService>[0]['scanScheduler'],
+  ): PackageUploadService {
+    return new PackageUploadService({
+      store: fakeStore(),
+      catalog: fakeCatalog(),
+      packagesDir,
+      limits: { maxBytes: 1024 * 1024, maxExtractedBytes: 4 * 1024 * 1024, maxEntries: 50 },
+      hostDependencies: {},
+      ...(scanScheduler ? { scanScheduler } : {}),
+      log: () => undefined,
+    });
+  }
+
+  it('invokes the scheduler with the ZIP sha256, plugin id, and final dir', async () => {
+    const calls: { sha256: string; pluginId: string; installedDir: string }[] = [];
+    let resolveScheduled: () => void;
+    const scheduled = new Promise<void>((r) => {
+      resolveScheduled = r;
+    });
+    const svc = service({
+      scheduleScan: async (input) => {
+        calls.push(input);
+        resolveScheduled();
+      },
+    });
+
+    const buffer = await fixtureZip();
+    const result = await svc.ingest({
+      fileBuffer: buffer,
+      originalFilename: 'scan-target.zip',
+      uploadedBy: 'test@example.com',
+    });
+
+    assert.equal(result.ok, true);
+    await scheduled;
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]!.pluginId, '@test/scan-target');
+    assert.equal(
+      calls[0]!.sha256,
+      createHash('sha256').update(buffer).digest('hex'),
+    );
+    assert.ok(calls[0]!.installedDir.startsWith(packagesDir));
+    // The scheduler receives the post-move location, and the package is
+    // actually there (scan runs against the final dir, not staging).
+    await fs.access(path.join(calls[0]!.installedDir, 'manifest.yaml'));
+  });
+
+  it('ingest succeeds without a scheduler (dep is optional)', async () => {
+    const result = await service().ingest({
+      fileBuffer: await fixtureZip(),
+      originalFilename: 'scan-target.zip',
+      uploadedBy: 'test@example.com',
+    });
+    assert.equal(result.ok, true);
+  });
+
+  it('ingest succeeds when the scheduler throws synchronously', async () => {
+    const svc = service({
+      scheduleScan: () => {
+        throw new Error('scheduler exploded');
+      },
+    });
+    const result = await svc.ingest({
+      fileBuffer: await fixtureZip(),
+      originalFilename: 'scan-target.zip',
+      uploadedBy: 'test@example.com',
+    });
+    assert.equal(result.ok, true);
+  });
+
+  it('ingest succeeds when the scheduler rejects asynchronously', async () => {
+    const svc = service({
+      scheduleScan: async () => {
+        throw new Error('async scheduler failure');
+      },
+    });
+    const result = await svc.ingest({
+      fileBuffer: await fixtureZip(),
+      originalFilename: 'scan-target.zip',
+      uploadedBy: 'test@example.com',
+    });
+    assert.equal(result.ok, true);
+  });
+});

--- a/middleware/test/pluginScanner.test.ts
+++ b/middleware/test/pluginScanner.test.ts
@@ -5,6 +5,8 @@ import os from 'node:os';
 import path from 'node:path';
 
 import {
+  collectScanPayload,
+  findUnscannableSegment,
   HttpSkillSpectorScanner,
   mapSkillSpectorSeverity,
   parseSidecarResponse,
@@ -100,5 +102,117 @@ describe('HttpSkillSpectorScanner', () => {
     const result = await scanner.scan(path.join(os.tmpdir(), 'scan-test-missing-dir'));
     assert.equal(result.status, 'failed');
     assert.equal(result.severity, 'scan_failed');
+  });
+});
+
+describe('findUnscannableSegment (#453 codex review fix)', () => {
+  it('flags node_modules, .git, and hidden segments', () => {
+    assert.equal(findUnscannableSegment('node_modules/payload/plugin.js'), 'node_modules');
+    assert.equal(findUnscannableSegment('dist/node_modules/x.js'), 'node_modules');
+    assert.equal(findUnscannableSegment('.git/hooks/plugin.js'), '.git');
+    assert.equal(findUnscannableSegment('.hidden/plugin.js'), '.hidden');
+  });
+
+  it('accepts the boilerplate layout', () => {
+    assert.equal(findUnscannableSegment('dist/plugin.js'), null);
+    assert.equal(findUnscannableSegment('dist/sub/plugin.js'), null);
+  });
+});
+
+describe('collectScanPayload — entry-point coverage guard (#453 codex review fix)', () => {
+  async function withTmpDir(
+    files: Record<string, string>,
+    fn: (dir: string) => Promise<void>,
+  ): Promise<void> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'scan-coverage-'));
+    try {
+      for (const [rel, content] of Object.entries(files)) {
+        const abs = path.join(dir, rel);
+        await fs.mkdir(path.dirname(abs), { recursive: true });
+        await fs.writeFile(abs, content);
+      }
+      await fn(dir);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  const manifestWithEntry = (entry: string): string =>
+    `schema_version: "1"\nlifecycle:\n  entry: "${entry}"\n`;
+
+  it('force-includes an entry the directory walk skipped (node_modules)', async () => {
+    await withTmpDir(
+      {
+        'manifest.yaml': manifestWithEntry('node_modules/payload/plugin.js'),
+        'node_modules/payload/plugin.js': 'module.exports = { activate() {} };\n',
+        'dist/other.js': '// decoy the walk does collect\n',
+      },
+      async (dir) => {
+        const payload = await collectScanPayload(dir);
+        assert.equal(payload.coverageError, null);
+        assert.ok(
+          payload.files.some((f) => f.path === 'node_modules/payload/plugin.js'),
+          'the executed entry point must be part of the scan payload',
+        );
+        // The rest of node_modules stays skipped — only the entry is pulled in.
+        assert.equal(
+          payload.files.filter((f) => f.path.startsWith('node_modules/')).length,
+          1,
+        );
+      },
+    );
+  });
+
+  it('fails closed when the declared entry file is absent', async () => {
+    await withTmpDir(
+      { 'manifest.yaml': manifestWithEntry('dist/plugin.js') },
+      async (dir) => {
+        const payload = await collectScanPayload(dir);
+        assert.ok(payload.coverageError, 'missing entry must be a coverage error');
+        // End-to-end: the scanner surfaces it as scan_failed WITHOUT any
+        // sidecar round-trip (never as a no_signals all-clear).
+        const scanner = new HttpSkillSpectorScanner({
+          baseUrl: 'http://192.0.2.1:1',
+          timeoutMs: 500,
+          log: () => undefined,
+        });
+        const result = await scanner.scan(dir);
+        assert.equal(result.status, 'failed');
+        assert.equal(result.severity, 'scan_failed');
+        assert.ok(result.rationale?.includes('coverage'));
+      },
+    );
+  });
+
+  it('fails closed when the entry is a symlink (never silently included)', async () => {
+    await withTmpDir(
+      {
+        'manifest.yaml': manifestWithEntry('node_modules/payload/plugin.js'),
+        'real.js': 'module.exports = {};\n',
+      },
+      async (dir) => {
+        await fs.mkdir(path.join(dir, 'node_modules/payload'), { recursive: true });
+        await fs.symlink(
+          path.join(dir, 'real.js'),
+          path.join(dir, 'node_modules/payload/plugin.js'),
+        );
+        const payload = await collectScanPayload(dir);
+        assert.ok(payload.coverageError, 'a symlinked entry must be a coverage error');
+      },
+    );
+  });
+
+  it('covers the normal boilerplate layout without a coverage error', async () => {
+    await withTmpDir(
+      {
+        'manifest.yaml': manifestWithEntry('dist/plugin.js'),
+        'dist/plugin.js': 'module.exports = { activate() {} };\n',
+      },
+      async (dir) => {
+        const payload = await collectScanPayload(dir);
+        assert.equal(payload.coverageError, null);
+        assert.ok(payload.files.some((f) => f.path === 'dist/plugin.js'));
+      },
+    );
   });
 });

--- a/middleware/test/pluginScanner.test.ts
+++ b/middleware/test/pluginScanner.test.ts
@@ -7,7 +7,6 @@ import path from 'node:path';
 import {
   HttpSkillSpectorScanner,
   mapSkillSpectorSeverity,
-  NullPluginScanner,
   parseSidecarResponse,
   PLUGIN_SCANNER_VERSION,
   type ScanFinding,
@@ -54,14 +53,14 @@ describe('parseSidecarResponse', () => {
     assert.equal(result.scannerVersion, `${PLUGIN_SCANNER_VERSION} (1.2.3)`);
   });
 
-  it('tolerates alternate field spellings', () => {
+  it('fails CLOSED on any schema the shim did not promise (no guessing)', () => {
+    // Second-review fix: an unrecognized schema must surface as
+    // `scan_failed`, never as an implicit all-clear.
     const result = parseSidecarResponse({
       results: [{ id: 'LP2', level: 'MEDIUM', description: 'permission mismatch' }],
     });
-    assert.equal(result.severity, 'flagged');
-    assert.equal(result.findings[0]!.code, 'LP2');
-    assert.equal(result.findings[0]!.severity, 'MEDIUM');
-    assert.equal(result.findings[0]!.message, 'permission mismatch');
+    assert.equal(result.status, 'failed');
+    assert.equal(result.severity, 'scan_failed');
   });
 
   it('degrades to scan_failed on ok:false, non-objects, and missing findings', () => {
@@ -69,15 +68,6 @@ describe('parseSidecarResponse', () => {
     assert.equal(parseSidecarResponse(null).severity, 'scan_failed');
     assert.equal(parseSidecarResponse('nope').severity, 'scan_failed');
     assert.equal(parseSidecarResponse({ ok: true }).severity, 'scan_failed');
-  });
-});
-
-describe('NullPluginScanner', () => {
-  it('reports skipped + scan_failed without touching the directory', async () => {
-    const result = await new NullPluginScanner().scan('/does/not/exist');
-    assert.equal(result.status, 'skipped');
-    assert.equal(result.severity, 'scan_failed');
-    assert.equal(result.findings.length, 0);
   });
 });
 

--- a/middleware/test/pluginScanner.test.ts
+++ b/middleware/test/pluginScanner.test.ts
@@ -1,0 +1,114 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  HttpSkillSpectorScanner,
+  mapSkillSpectorSeverity,
+  NullPluginScanner,
+  parseSidecarResponse,
+  PLUGIN_SCANNER_VERSION,
+  type ScanFinding,
+} from '../src/services/pluginScanner.js';
+
+function finding(severity: string, code = 'E2'): ScanFinding {
+  return { code, severity, message: 'test finding', file: null };
+}
+
+describe('mapSkillSpectorSeverity', () => {
+  it('maps an empty finding list to no_signals', () => {
+    assert.equal(mapSkillSpectorSeverity([]), 'no_signals');
+  });
+
+  it('maps CRITICAL/HIGH findings to high_risk (case-insensitive)', () => {
+    assert.equal(mapSkillSpectorSeverity([finding('CRITICAL')]), 'high_risk');
+    assert.equal(mapSkillSpectorSeverity([finding('high')]), 'high_risk');
+    assert.equal(
+      mapSkillSpectorSeverity([finding('LOW'), finding('HIGH')]),
+      'high_risk',
+    );
+  });
+
+  it('maps MEDIUM/LOW-only findings to flagged', () => {
+    assert.equal(mapSkillSpectorSeverity([finding('MEDIUM')]), 'flagged');
+    assert.equal(mapSkillSpectorSeverity([finding('LOW'), finding('MEDIUM')]), 'flagged');
+  });
+});
+
+describe('parseSidecarResponse', () => {
+  it('maps a well-formed sidecar response', () => {
+    const result = parseSidecarResponse({
+      ok: true,
+      scanner_version: '1.2.3',
+      findings: [
+        { code: 'YR1', severity: 'CRITICAL', message: 'webshell signature', file: 'dist/plugin.js' },
+      ],
+    });
+    assert.equal(result.status, 'scanned');
+    assert.equal(result.severity, 'high_risk');
+    assert.equal(result.findings.length, 1);
+    assert.equal(result.findings[0]!.code, 'YR1');
+    assert.equal(result.findings[0]!.file, 'dist/plugin.js');
+    assert.equal(result.scannerVersion, `${PLUGIN_SCANNER_VERSION} (1.2.3)`);
+  });
+
+  it('tolerates alternate field spellings', () => {
+    const result = parseSidecarResponse({
+      results: [{ id: 'LP2', level: 'MEDIUM', description: 'permission mismatch' }],
+    });
+    assert.equal(result.severity, 'flagged');
+    assert.equal(result.findings[0]!.code, 'LP2');
+    assert.equal(result.findings[0]!.severity, 'MEDIUM');
+    assert.equal(result.findings[0]!.message, 'permission mismatch');
+  });
+
+  it('degrades to scan_failed on ok:false, non-objects, and missing findings', () => {
+    assert.equal(parseSidecarResponse({ ok: false, error: 'boom' }).severity, 'scan_failed');
+    assert.equal(parseSidecarResponse(null).severity, 'scan_failed');
+    assert.equal(parseSidecarResponse('nope').severity, 'scan_failed');
+    assert.equal(parseSidecarResponse({ ok: true }).severity, 'scan_failed');
+  });
+});
+
+describe('NullPluginScanner', () => {
+  it('reports skipped + scan_failed without touching the directory', async () => {
+    const result = await new NullPluginScanner().scan('/does/not/exist');
+    assert.equal(result.status, 'skipped');
+    assert.equal(result.severity, 'scan_failed');
+    assert.equal(result.findings.length, 0);
+  });
+});
+
+describe('HttpSkillSpectorScanner', () => {
+  it('never throws on an unreachable sidecar — degrades to scan_failed', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'scan-test-'));
+    await fs.writeFile(path.join(dir, 'manifest.yaml'), 'schema_version: "1"\n');
+    try {
+      const scanner = new HttpSkillSpectorScanner({
+        // Reserved TEST-NET-1 address — guaranteed unreachable, and the
+        // 500ms timeout keeps the failure fast either way.
+        baseUrl: 'http://192.0.2.1:1',
+        timeoutMs: 500,
+        log: () => undefined,
+      });
+      const result = await scanner.scan(dir);
+      assert.equal(result.status, 'failed');
+      assert.equal(result.severity, 'scan_failed');
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports scan_failed for an unreadable package directory', async () => {
+    const scanner = new HttpSkillSpectorScanner({
+      baseUrl: 'http://192.0.2.1:1',
+      timeoutMs: 500,
+      log: () => undefined,
+    });
+    const result = await scanner.scan(path.join(os.tmpdir(), 'scan-test-missing-dir'));
+    assert.equal(result.status, 'failed');
+    assert.equal(result.severity, 'scan_failed');
+  });
+});

--- a/middleware/test/pluginVerdict.test.ts
+++ b/middleware/test/pluginVerdict.test.ts
@@ -13,8 +13,20 @@ import {
   type PluginVerdictStore,
 } from '../src/services/pluginVerdict.js';
 
+/** Mirrors the SQL severity rank in agentGraphStore.upsertPluginVerdict. */
+const SEVERITY_ORDER: Record<string, number> = {
+  no_signals: 0,
+  pending: 1,
+  scan_failed: 2,
+  too_large_to_scan: 3,
+  flagged: 4,
+  high_risk: 5,
+};
+
 class FakePluginVerdictStore implements PluginVerdictStore {
   readonly rows = new Map<string, PluginVerdictRow>();
+  /** Severity at ack time, keyed like `rows` — mirrors `ack_severity`. */
+  readonly ackSeverities = new Map<string, string>();
   upsertCalls = 0;
 
   async getPluginVerdict(
@@ -39,12 +51,21 @@ class FakePluginVerdictStore implements PluginVerdictStore {
   async upsertPluginVerdict(row: PluginVerdictRow): Promise<void> {
     this.upsertCalls += 1;
     const key = `${row.contentHash}:${row.verifierVersion}`;
-    // Mirror the SQL upsert: scan columns are rewritten, ack columns survive.
+    // Mirror the SQL upsert: scan columns are rewritten; the ack survives
+    // only while the new severity is equal or BETTER than the severity the
+    // operator acknowledged (a worse re-scan result clears the ack).
     const existing = this.rows.get(key);
+    const ackedSeverity =
+      this.ackSeverities.get(key) ?? (existing ? existing.severity : undefined);
+    const ackSurvives =
+      existing?.ackBy != null &&
+      ackedSeverity !== undefined &&
+      SEVERITY_ORDER[row.severity]! <= SEVERITY_ORDER[ackedSeverity]!;
+    if (!ackSurvives) this.ackSeverities.delete(key);
     this.rows.set(key, {
       ...row,
-      ackBy: existing?.ackBy ?? null,
-      ackAt: existing?.ackAt ?? null,
+      ackBy: ackSurvives ? existing.ackBy : null,
+      ackAt: ackSurvives ? existing.ackAt : null,
     });
   }
 
@@ -69,6 +90,7 @@ class FakePluginVerdictStore implements PluginVerdictStore {
     const existing = this.rows.get(key);
     if (!existing) return undefined;
     const ack = { ackBy: ackedBy, ackAt: new Date() };
+    this.ackSeverities.set(key, existing.severity);
     this.rows.set(key, { ...existing, ackBy: ack.ackBy, ackAt: ack.ackAt });
     return ack;
   }
@@ -162,7 +184,7 @@ describe('createPluginScanScheduler', () => {
     await assert.doesNotReject(() => scheduler.scheduleScan(scanInput()));
   });
 
-  it('preserves an existing ack across a re-scan under the same version', async () => {
+  it('clears an ack when a re-scan WORSENS the verdict (scan_failed → high_risk)', async () => {
     const store = new FakePluginVerdictStore();
     const failing = new FakeScanner({
       status: 'failed',
@@ -175,7 +197,8 @@ describe('createPluginScanScheduler', () => {
       .scheduleScan(scanInput());
     await store.upsertPluginVerdictAck('sha-1', PLUGIN_SCANNER_VERSION, 'op@example.com');
 
-    // scan_failed is retried; the ack must survive the rewrite.
+    // scan_failed is retried; the operator acked a FAILED scan, never these
+    // findings — a high_risk upgrade must invalidate the ack.
     await createPluginScanScheduler({
       store,
       scanner: new FakeScanner(HIGH_RISK_RESULT),
@@ -184,6 +207,39 @@ describe('createPluginScanScheduler', () => {
 
     const row = await store.getPluginVerdict('sha-1', PLUGIN_SCANNER_VERSION);
     assert.equal(row?.severity, 'high_risk');
+    assert.equal(row?.ackBy, null);
+    assert.equal(row?.ackAt, null);
+  });
+
+  it('keeps an ack when a re-scan is equal or BETTER (scan_failed → no_signals)', async () => {
+    const store = new FakePluginVerdictStore();
+    const failing = new FakeScanner({
+      status: 'failed',
+      severity: 'scan_failed',
+      findings: [],
+      scannerVersion: PLUGIN_SCANNER_VERSION,
+      rationale: null,
+    });
+    await createPluginScanScheduler({ store, scanner: failing, log: () => undefined })
+      .scheduleScan(scanInput());
+    await store.upsertPluginVerdictAck('sha-1', PLUGIN_SCANNER_VERSION, 'op@example.com');
+
+    // The interim `pending` write of the retry must not destroy the
+    // comparison baseline either — the clean result keeps the ack.
+    await createPluginScanScheduler({
+      store,
+      scanner: new FakeScanner({
+        status: 'scanned',
+        severity: 'no_signals',
+        findings: [],
+        scannerVersion: PLUGIN_SCANNER_VERSION,
+        rationale: null,
+      }),
+      log: () => undefined,
+    }).scheduleScan(scanInput());
+
+    const row = await store.getPluginVerdict('sha-1', PLUGIN_SCANNER_VERSION);
+    assert.equal(row?.severity, 'no_signals');
     assert.equal(row?.ackBy, 'op@example.com');
   });
 });

--- a/middleware/test/pluginVerdict.test.ts
+++ b/middleware/test/pluginVerdict.test.ts
@@ -1,0 +1,255 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  PLUGIN_SCANNER_VERSION,
+  type PluginScanner,
+  type ScanResult,
+} from '../src/services/pluginScanner.js';
+import {
+  createPluginScanScheduler,
+  createPluginVerdictLookup,
+  type PluginVerdictRow,
+  type PluginVerdictStore,
+} from '../src/services/pluginVerdict.js';
+
+class FakePluginVerdictStore implements PluginVerdictStore {
+  readonly rows = new Map<string, PluginVerdictRow>();
+  upsertCalls = 0;
+
+  async getPluginVerdict(
+    contentHash: string,
+    verifierVersion: string,
+  ): Promise<PluginVerdictRow | undefined> {
+    return this.rows.get(`${contentHash}:${verifierVersion}`);
+  }
+
+  async getLatestPluginVerdict(
+    pluginId: string,
+    verifierVersion: string,
+  ): Promise<PluginVerdictRow | undefined> {
+    let latest: PluginVerdictRow | undefined;
+    for (const row of this.rows.values()) {
+      if (row.pluginId !== pluginId || row.verifierVersion !== verifierVersion) continue;
+      if (!latest || row.computedAt > latest.computedAt) latest = row;
+    }
+    return latest;
+  }
+
+  async upsertPluginVerdict(row: PluginVerdictRow): Promise<void> {
+    this.upsertCalls += 1;
+    const key = `${row.contentHash}:${row.verifierVersion}`;
+    // Mirror the SQL upsert: scan columns are rewritten, ack columns survive.
+    const existing = this.rows.get(key);
+    this.rows.set(key, {
+      ...row,
+      ackBy: existing?.ackBy ?? null,
+      ackAt: existing?.ackAt ?? null,
+    });
+  }
+
+  async getPluginVerdictsByShas(
+    contentHashes: readonly string[],
+    verifierVersion: string,
+  ): Promise<Map<string, PluginVerdictRow>> {
+    const out = new Map<string, PluginVerdictRow>();
+    for (const hash of contentHashes) {
+      const row = this.rows.get(`${hash}:${verifierVersion}`);
+      if (row) out.set(hash, row);
+    }
+    return out;
+  }
+
+  async upsertPluginVerdictAck(
+    contentHash: string,
+    verifierVersion: string,
+    ackedBy: string,
+  ): Promise<{ ackBy: string; ackAt: Date } | undefined> {
+    const key = `${contentHash}:${verifierVersion}`;
+    const existing = this.rows.get(key);
+    if (!existing) return undefined;
+    const ack = { ackBy: ackedBy, ackAt: new Date() };
+    this.rows.set(key, { ...existing, ackBy: ack.ackBy, ackAt: ack.ackAt });
+    return ack;
+  }
+}
+
+class FakeScanner implements PluginScanner {
+  scans = 0;
+  constructor(private readonly result: ScanResult) {}
+  async scan(_dir: string): Promise<ScanResult> {
+    this.scans += 1;
+    return this.result;
+  }
+}
+
+const HIGH_RISK_RESULT: ScanResult = {
+  status: 'scanned',
+  severity: 'high_risk',
+  findings: [{ code: 'E2', severity: 'HIGH', message: 'exfil pattern', file: 'dist/plugin.js' }],
+  scannerVersion: PLUGIN_SCANNER_VERSION,
+  rationale: null,
+};
+
+function scanInput(sha = 'sha-1') {
+  return { sha256: sha, pluginId: '@test/plugin', installedDir: '/tmp/pkg' };
+}
+
+describe('createPluginScanScheduler', () => {
+  it('persists the resolved verdict keyed on sha + scanner version', async () => {
+    const store = new FakePluginVerdictStore();
+    const scanner = new FakeScanner(HIGH_RISK_RESULT);
+    const scheduler = createPluginScanScheduler({ store, scanner, log: () => undefined });
+
+    await scheduler.scheduleScan(scanInput());
+
+    const row = await store.getPluginVerdict('sha-1', PLUGIN_SCANNER_VERSION);
+    assert.ok(row);
+    assert.equal(row.severity, 'high_risk');
+    assert.equal(row.pluginId, '@test/plugin');
+    assert.equal(row.findings.length, 1);
+    // pending row + resolved row
+    assert.equal(store.upsertCalls, 2);
+  });
+
+  it('is a cache hit for an already-scanned sha (no rescan)', async () => {
+    const store = new FakePluginVerdictStore();
+    const scanner = new FakeScanner(HIGH_RISK_RESULT);
+    const scheduler = createPluginScanScheduler({ store, scanner, log: () => undefined });
+
+    await scheduler.scheduleScan(scanInput());
+    await scheduler.scheduleScan(scanInput());
+
+    assert.equal(scanner.scans, 1);
+  });
+
+  it('retries operational states (scan_failed) on the next install', async () => {
+    const store = new FakePluginVerdictStore();
+    const failing = new FakeScanner({
+      status: 'failed',
+      severity: 'scan_failed',
+      findings: [],
+      scannerVersion: PLUGIN_SCANNER_VERSION,
+      rationale: 'sidecar down',
+    });
+    const scheduler = createPluginScanScheduler({ store, scanner: failing, log: () => undefined });
+    await scheduler.scheduleScan(scanInput());
+    assert.equal(
+      (await store.getPluginVerdict('sha-1', PLUGIN_SCANNER_VERSION))?.severity,
+      'scan_failed',
+    );
+
+    const recovered = new FakeScanner(HIGH_RISK_RESULT);
+    const scheduler2 = createPluginScanScheduler({ store, scanner: recovered, log: () => undefined });
+    await scheduler2.scheduleScan(scanInput());
+    assert.equal(recovered.scans, 1);
+    assert.equal(
+      (await store.getPluginVerdict('sha-1', PLUGIN_SCANNER_VERSION))?.severity,
+      'high_risk',
+    );
+  });
+
+  it('never rejects when the store throws', async () => {
+    const store = new FakePluginVerdictStore();
+    store.getPluginVerdict = async () => {
+      throw new Error('db down');
+    };
+    const scheduler = createPluginScanScheduler({
+      store,
+      scanner: new FakeScanner(HIGH_RISK_RESULT),
+      log: () => undefined,
+    });
+    await assert.doesNotReject(() => scheduler.scheduleScan(scanInput()));
+  });
+
+  it('preserves an existing ack across a re-scan under the same version', async () => {
+    const store = new FakePluginVerdictStore();
+    const failing = new FakeScanner({
+      status: 'failed',
+      severity: 'scan_failed',
+      findings: [],
+      scannerVersion: PLUGIN_SCANNER_VERSION,
+      rationale: null,
+    });
+    await createPluginScanScheduler({ store, scanner: failing, log: () => undefined })
+      .scheduleScan(scanInput());
+    await store.upsertPluginVerdictAck('sha-1', PLUGIN_SCANNER_VERSION, 'op@example.com');
+
+    // scan_failed is retried; the ack must survive the rewrite.
+    await createPluginScanScheduler({
+      store,
+      scanner: new FakeScanner(HIGH_RISK_RESULT),
+      log: () => undefined,
+    }).scheduleScan(scanInput());
+
+    const row = await store.getPluginVerdict('sha-1', PLUGIN_SCANNER_VERSION);
+    assert.equal(row?.severity, 'high_risk');
+    assert.equal(row?.ackBy, 'op@example.com');
+  });
+});
+
+describe('createPluginVerdictLookup', () => {
+  function seededStore(): FakePluginVerdictStore {
+    const store = new FakePluginVerdictStore();
+    store.rows.set(`sha-1:${PLUGIN_SCANNER_VERSION}`, {
+      contentHash: 'sha-1',
+      verifierVersion: PLUGIN_SCANNER_VERSION,
+      pluginId: '@test/plugin',
+      severity: 'flagged',
+      findings: [],
+      scannerVersion: PLUGIN_SCANNER_VERSION,
+      rationale: null,
+      computedAt: new Date('2026-07-09T00:00:00Z'),
+      ackBy: null,
+      ackAt: null,
+    });
+    return store;
+  }
+
+  it('resolves plugin id → sha256 → verdict view', async () => {
+    const lookup = createPluginVerdictLookup({
+      store: seededStore(),
+      packages: { get: (id) => (id === '@test/plugin' ? { sha256: 'sha-1' } : undefined) },
+    });
+    const view = await lookup.getForPlugin('@test/plugin');
+    assert.equal(view?.severity, 'flagged');
+    assert.equal(view?.ack, null);
+  });
+
+  it('falls back to the latest verdict when the package record is gone', async () => {
+    const lookup = createPluginVerdictLookup({
+      store: seededStore(),
+      packages: { get: () => undefined },
+    });
+    const view = await lookup.getForPlugin('@test/plugin');
+    assert.equal(view?.severity, 'flagged');
+  });
+
+  it('returns undefined for a never-scanned plugin', async () => {
+    const lookup = createPluginVerdictLookup({
+      store: new FakePluginVerdictStore(),
+      packages: { get: () => ({ sha256: 'sha-unknown' }) },
+    });
+    assert.equal(await lookup.getForPlugin('@test/other'), undefined);
+  });
+
+  it('acks via the sha and reports the recorded ack', async () => {
+    const store = seededStore();
+    const lookup = createPluginVerdictLookup({
+      store,
+      packages: { get: () => ({ sha256: 'sha-1' }) },
+    });
+    const ack = await lookup.ack('@test/plugin', 'op@example.com');
+    assert.equal(ack?.by, 'op@example.com');
+    const view = await lookup.getForPlugin('@test/plugin');
+    assert.equal(view?.ack?.by, 'op@example.com');
+  });
+
+  it('ack returns undefined when nothing was scanned', async () => {
+    const lookup = createPluginVerdictLookup({
+      store: new FakePluginVerdictStore(),
+      packages: { get: () => ({ sha256: 'sha-unscanned' }) },
+    });
+    assert.equal(await lookup.ack('@test/plugin', 'op@example.com'), undefined);
+  });
+});

--- a/middleware/test/pluginVerdictStore.pg.test.ts
+++ b/middleware/test/pluginVerdictStore.pg.test.ts
@@ -1,0 +1,124 @@
+import { strict as assert } from 'node:assert';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { after, before, describe, it } from 'node:test';
+
+import { Pool } from 'pg';
+
+import { AgentGraphStore, runMultiOrchestratorMigrations } from '@omadia/orchestrator';
+
+/**
+ * PG-gated coverage for the plugin_verdicts store surface (issue #453,
+ * second-review fix): the SQL upsert must clear an operator ack whenever a
+ * re-scan under the same verifier_version WORSENS the severity relative to
+ * the severity that was acked, and keep it when the result is equal or
+ * better — including across the scheduler's interim `pending` write.
+ * Skips when no test Postgres is reachable, mirroring the other pg tests.
+ */
+const PG_URL =
+  process.env['GRAPH_PG_TEST_URL'] ??
+  process.env['MEMORY_PG_TEST_URL'] ??
+  process.env['WS5_PG_TEST_URL'] ??
+  'postgres://test:test@127.0.0.1:55438/test';
+
+const HASH_PREFIX = 'plugin-verdict-test-';
+const VERIFIER = 'skillspector-test';
+const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'migrations');
+
+const probePool = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 2000 });
+let pgAvailable = true;
+try {
+  await probePool.query('SELECT 1');
+} catch {
+  pgAvailable = false;
+  await probePool.end().catch(() => undefined);
+}
+
+type Severity =
+  | 'no_signals'
+  | 'flagged'
+  | 'high_risk'
+  | 'scan_failed'
+  | 'pending'
+  | 'too_large_to_scan';
+
+describe('AgentGraphStore plugin verdicts (pg)', { skip: !pgAvailable }, () => {
+  const pool = probePool;
+  let store: AgentGraphStore;
+
+  function row(contentHash: string, severity: Severity) {
+    return {
+      contentHash,
+      verifierVersion: VERIFIER,
+      pluginId: '@test/plugin',
+      severity,
+      findings: [],
+      scannerVersion: VERIFIER,
+      rationale: null,
+      computedAt: new Date(),
+      ackBy: null,
+      ackAt: null,
+    };
+  }
+
+  async function cleanup(): Promise<void> {
+    await pool.query('DELETE FROM plugin_verdicts WHERE content_hash LIKE $1', [
+      `${HASH_PREFIX}%`,
+    ]);
+  }
+
+  before(async () => {
+    await runMultiOrchestratorMigrations(pool, undefined, migrationsDir);
+    await cleanup();
+    store = new AgentGraphStore(pool);
+  });
+
+  after(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  it('clears the ack when a re-scan worsens the severity', async () => {
+    const hash = `${HASH_PREFIX}worse`;
+    await store.upsertPluginVerdict(row(hash, 'scan_failed'));
+    const ack = await store.upsertPluginVerdictAck(hash, VERIFIER, 'op@example.com');
+    assert.ok(ack);
+
+    // Scheduler retry: interim pending, then a WORSE final verdict.
+    await store.upsertPluginVerdict(row(hash, 'pending'));
+    await store.upsertPluginVerdict(row(hash, 'high_risk'));
+
+    const verdict = await store.getPluginVerdict(hash, VERIFIER);
+    assert.equal(verdict?.severity, 'high_risk');
+    assert.equal(verdict?.ackBy, null);
+    assert.equal(verdict?.ackAt, null);
+  });
+
+  it('keeps the ack when a re-scan is equal or better', async () => {
+    const hash = `${HASH_PREFIX}better`;
+    await store.upsertPluginVerdict(row(hash, 'scan_failed'));
+    assert.ok(await store.upsertPluginVerdictAck(hash, VERIFIER, 'op@example.com'));
+
+    // Interim pending must not destroy the comparison baseline: the acked
+    // severity (scan_failed) is the reference, not the live `pending`.
+    await store.upsertPluginVerdict(row(hash, 'pending'));
+    await store.upsertPluginVerdict(row(hash, 'no_signals'));
+
+    const verdict = await store.getPluginVerdict(hash, VERIFIER);
+    assert.equal(verdict?.severity, 'no_signals');
+    assert.equal(verdict?.ackBy, 'op@example.com');
+    assert.ok(verdict?.ackAt);
+  });
+
+  it('keeps the ack on an equal re-scan result', async () => {
+    const hash = `${HASH_PREFIX}equal`;
+    await store.upsertPluginVerdict(row(hash, 'scan_failed'));
+    assert.ok(await store.upsertPluginVerdictAck(hash, VERIFIER, 'op@example.com'));
+
+    await store.upsertPluginVerdict(row(hash, 'scan_failed'));
+
+    const verdict = await store.getPluginVerdict(hash, VERIFIER);
+    assert.equal(verdict?.severity, 'scan_failed');
+    assert.equal(verdict?.ackBy, 'op@example.com');
+  });
+});

--- a/middleware/test/privacyInternPolicy.test.ts
+++ b/middleware/test/privacyInternPolicy.test.ts
@@ -39,6 +39,12 @@ describe('privacyInternPolicy', () => {
     'odoo_search',
     'enrich_company',
     'web_search',
+    // #361 acceptance pin — MCP-sourced tools (adapted via
+    // `mcpNativeToolName` → `mcp__<server>__<tool>`, or exposed through a
+    // sub-agent toolkit) dispatch through the same choke points as
+    // first-party tools and MUST stay interned via `internToolResultV4`.
+    'mcp__strava__get_activities',
+    'mcp__confluence__search_pages',
   ];
 
   it('exempts exactly the agent self/infra tools', () => {

--- a/middleware/test/privacyPromptMask.test.ts
+++ b/middleware/test/privacyPromptMask.test.ts
@@ -1,0 +1,314 @@
+/**
+ * #361 — free-text user-prompt PII masking.
+ *
+ * Covers the detection/substitution engine (`promptMask.ts`), the typed
+ * prompt-surrogate map (`v4/pseudonym.ts#createPromptPseudonymMap`), the
+ * service policy surface (`maskUserPrompt` / `restorePromptPseudonyms` —
+ * default-off flag, degrade-to-C0, failure-closed), and the orchestrator's
+ * `PrivacyTurnHandle` delegation incl. feature-detection on providers that
+ * predate the contract.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { PrivacyGuardService, PromptPiiDetector } from '@omadia/plugin-api';
+import { createPrivacyTurnHandle } from '@omadia/orchestrator/dist/privacyHandle.js';
+import { createPrivacyGuardService } from '@omadia/plugin-privacy-guard/dist/index.js';
+import {
+  createBaselineDetector,
+  createC1StubDetector,
+  dedupSpans,
+  maskPrompt,
+} from '@omadia/plugin-privacy-guard/dist/promptMask.js';
+import { findIdentityLeaks } from '@omadia/plugin-privacy-guard/dist/v4/onTheWire.js';
+import {
+  createPromptPseudonymMap,
+  resolvePseudonyms,
+} from '@omadia/plugin-privacy-guard/dist/v4/pseudonym.js';
+
+const RFC_PROMPT =
+  'What should we pay Anna Schmidt (32, lives at Bahnhofstr. 5, 60311 Frankfurt) ' +
+  'given her current salary of €72,000? Reach her at anna.schmidt@firma.de or +49 171 5551234.';
+
+const RFC_STRUCTURED_VALUES = [
+  'Bahnhofstr. 5, 60311 Frankfurt',
+  '€72,000',
+  'anna.schmidt@firma.de',
+  '+49 171 5551234',
+];
+
+describe('createBaselineDetector (C0)', () => {
+  it('detects each structured identifier type', async () => {
+    const spans = await createBaselineDetector().detect(RFC_PROMPT);
+    const types = new Set(spans.map((s) => s.type));
+    for (const expected of ['email', 'phone', 'address', 'amount']) {
+      assert.ok(types.has(expected), `C0 must detect type '${expected}'`);
+    }
+  });
+
+  it('detects IBAN and DOB-style dates', async () => {
+    const spans = await createBaselineDetector().detect(
+      'Konto DE89 3704 0044 0532 0130 00, geboren am 24.12.1987.',
+    );
+    const types = new Set(spans.map((s) => s.type));
+    assert.ok(types.has('iban'));
+    assert.ok(types.has('date'));
+  });
+
+  it('reports nothing on a PII-free prompt (over-masking guard)', async () => {
+    const spans = await createBaselineDetector().detect(
+      'Summarize our vacation carry-over policy for first-year employees.',
+    );
+    assert.equal(spans.length, 0);
+  });
+});
+
+describe('dedupSpans', () => {
+  it('resolves overlaps to the higher-confidence span and extends to word boundaries', () => {
+    const text = 'mail me at anna.schmidt@firma.de today';
+    const resolved = dedupSpans(text, [
+      // Low-confidence span covering only part of the address…
+      { span: { start: 11, end: 23, type: 'person', confidence: 0.4 }, detector: 'c1' },
+      // …and the full email at confidence 1.
+      { span: { start: 11, end: 32, type: 'email', confidence: 1 }, detector: 'c0-regex' },
+    ]);
+    assert.equal(resolved.length, 1);
+    assert.equal(resolved[0]!.type, 'email');
+    assert.equal(resolved[0]!.value, 'anna.schmidt@firma.de');
+  });
+
+  it('extends a mid-word span so no identifying fragment survives', () => {
+    const text = 'contact anna.schmidt@firma.de';
+    const resolved = dedupSpans(text, [
+      // Detector only caught the local part.
+      { span: { start: 8, end: 20, type: 'email', confidence: 0.9 }, detector: 'c1' },
+    ]);
+    assert.equal(resolved[0]!.value, 'anna.schmidt@firma.de');
+  });
+});
+
+describe('createPromptPseudonymMap', () => {
+  it('is bijective, type-shaped, and never collides with the input text', () => {
+    const map = createPromptPseudonymMap(
+      [
+        { value: 'anna.schmidt@firma.de', type: 'email' },
+        { value: '+49 171 5551234', type: 'phone' },
+        { value: 'Anna Schmidt', type: 'person' },
+      ],
+      RFC_PROMPT,
+    );
+    assert.equal(map.forward.size, 3);
+    assert.equal(map.reverse.size, 3);
+    assert.ok(map.forward.get('anna.schmidt@firma.de')!.includes('@'));
+    for (const surrogate of map.reverse.keys()) {
+      assert.ok(!RFC_PROMPT.includes(surrogate), `surrogate '${surrogate}' collides with input`);
+    }
+  });
+
+  it('keeps existing surrogates stable when extended', () => {
+    const first = createPromptPseudonymMap(
+      [{ value: 'anna.schmidt@firma.de', type: 'email' }],
+      'a',
+    );
+    const second = createPromptPseudonymMap(
+      [
+        { value: 'anna.schmidt@firma.de', type: 'email' },
+        { value: 'DE89370400440532013000', type: 'iban' },
+      ],
+      'a',
+      first,
+    );
+    assert.equal(
+      second.forward.get('anna.schmidt@firma.de'),
+      first.forward.get('anna.schmidt@firma.de'),
+    );
+  });
+});
+
+describe('maskPrompt', () => {
+  it('produces wire text with zero identity leaks for detected values', async () => {
+    const result = await maskPrompt(RFC_PROMPT, [createBaselineDetector()]);
+    for (const value of RFC_STRUCTURED_VALUES) {
+      assert.equal(
+        findIdentityLeaks(result.maskedText, [value]).length,
+        0,
+        `real value '${value}' survived masking`,
+      );
+    }
+  });
+
+  it('round-trips exactly via resolvePseudonyms', async () => {
+    const result = await maskPrompt(RFC_PROMPT, [createBaselineDetector()]);
+    assert.equal(resolvePseudonyms(result.maskedText, result.map), RFC_PROMPT);
+  });
+
+  it('masks a repeated value everywhere, even when detected once', async () => {
+    const email = 'anna.schmidt@firma.de';
+    const text = `Mail ${email}. I repeat: ${email}`;
+    const result = await maskPrompt(text, [createBaselineDetector()]);
+    assert.equal(findIdentityLeaks(result.maskedText, [email]).length, 0);
+  });
+
+  it('is a no-op on PII-free text', async () => {
+    const text = 'Draft a neutral follow-up on the roadmap review.';
+    const result = await maskPrompt(text, [createBaselineDetector()]);
+    assert.equal(result.maskedText, text);
+    assert.equal(result.spans.length, 0);
+  });
+});
+
+describe('PrivacyGuardService.maskUserPrompt', () => {
+  const req = (turnId: string) => ({ sessionId: 's', turnId, text: RFC_PROMPT });
+
+  it('reports disabled without a readConfig (flag-off ⇒ byte-identical path)', async () => {
+    const svc = createPrivacyGuardService();
+    assert.deepEqual(await svc.maskUserPrompt!(req('t-off')), { outcome: 'disabled' });
+  });
+
+  it('reports disabled when the flag is off/unset', async () => {
+    const svc = createPrivacyGuardService({ readConfig: () => 'off' });
+    assert.deepEqual(await svc.maskUserPrompt!(req('t-off2')), { outcome: 'disabled' });
+  });
+
+  it('masks when the flag is on; wire text carries zero detected real values', async () => {
+    const svc = createPrivacyGuardService({ readConfig: () => 'on' });
+    const result = await svc.maskUserPrompt!(req('t-on'));
+    assert.equal(result.outcome, 'masked');
+    if (result.outcome !== 'masked') return;
+    assert.equal(result.degraded, false);
+    for (const value of RFC_STRUCTURED_VALUES) {
+      assert.equal(findIdentityLeaks(result.maskedText, [value]).length, 0);
+    }
+    // Span records are PII-free (type + detector only).
+    for (const span of result.spans) {
+      assert.deepEqual(Object.keys(span).sort(), ['detector', 'type']);
+    }
+  });
+
+  it('restores surrogates in the answer and surfaces spans in the receipt', async () => {
+    const svc = createPrivacyGuardService({ readConfig: () => 'on' });
+    const masked = await svc.maskUserPrompt!(req('t-restore'));
+    assert.equal(masked.outcome, 'masked');
+    if (masked.outcome !== 'masked') return;
+    // Simulate the LLM echoing a surrogate back in its answer.
+    const answer = `The details: ${masked.maskedText}`;
+    const restored = await svc.restorePromptPseudonyms!('t-restore', answer);
+    for (const value of RFC_STRUCTURED_VALUES) {
+      assert.ok(restored.includes(value), `answer must restore '${value}'`);
+    }
+    const receipt = await svc.finalizeTurn('t-restore');
+    assert.ok(receipt, 'a masked-prompt turn must emit a receipt');
+    assert.ok((receipt.maskedPromptSpans?.length ?? 0) > 0);
+    // finalize dropped the map — restore becomes identity.
+    assert.equal(await svc.restorePromptPseudonyms!('t-restore', answer), answer);
+  });
+
+  it('shares one surrogate map across repeated calls in a turn', async () => {
+    const svc = createPrivacyGuardService({ readConfig: () => 'on' });
+    const a = await svc.maskUserPrompt!({
+      sessionId: 's',
+      turnId: 't-shared',
+      text: 'Mail anna.schmidt@firma.de',
+    });
+    const b = await svc.maskUserPrompt!({
+      sessionId: 's',
+      turnId: 't-shared',
+      text: 'Attachment mentions anna.schmidt@firma.de again',
+    });
+    assert.equal(a.outcome, 'masked');
+    assert.equal(b.outcome, 'masked');
+    if (a.outcome !== 'masked' || b.outcome !== 'masked') return;
+    const surrogateA = a.maskedText.replace('Mail ', '');
+    assert.ok(
+      b.maskedText.includes(surrogateA),
+      'the same real value must map to the same surrogate within a turn',
+    );
+  });
+
+  it('degrades to C0 (audited, masked) when the C1 detector throws', async () => {
+    const throwingC1: PromptPiiDetector = {
+      id: 'c1-broken',
+      detect: async () => {
+        throw new Error('transformer down');
+      },
+    };
+    const svc = createPrivacyGuardService({
+      readConfig: () => 'on',
+      c1Detector: throwingC1,
+    });
+    const result = await svc.maskUserPrompt!(req('t-degraded'));
+    assert.equal(result.outcome, 'masked');
+    if (result.outcome !== 'masked') return;
+    assert.equal(result.degraded, true);
+    // C0 results still applied.
+    assert.equal(
+      findIdentityLeaks(result.maskedText, ['anna.schmidt@firma.de']).length,
+      0,
+    );
+  });
+
+  it('uses C1 spans when the detector works (stub seam contract)', async () => {
+    const svc = createPrivacyGuardService({
+      readConfig: () => 'on',
+      c1Detector: createC1StubDetector(),
+    });
+    const result = await svc.maskUserPrompt!(req('t-c1'));
+    assert.equal(result.outcome, 'masked');
+    if (result.outcome !== 'masked') return;
+    assert.equal(result.degraded, false);
+  });
+});
+
+describe('PrivacyTurnHandle prompt-mask delegation', () => {
+  function stubService(overrides: Partial<PrivacyGuardService>): PrivacyGuardService {
+    return {
+      internToolResultV4: async () => ({ digestText: '', datasetId: 'ds' }),
+      recordBypassedTool: async () => undefined,
+      runV4Tool: async () => ({ resultText: '' }),
+      subAgentResultV4: async () => ({ resultText: '' }),
+      takeRenderedAnswerV4: async () => undefined,
+      v4ToolSpecs: () => [],
+      finalizeTurn: async () => undefined,
+      ...overrides,
+    };
+  }
+
+  it('feature-detects providers without the optional methods (disabled / identity)', async () => {
+    const handle = createPrivacyTurnHandle({
+      service: stubService({}),
+      sessionId: 's',
+      turnId: 't',
+    });
+    assert.deepEqual(await handle.maskUserPrompt('text'), { outcome: 'disabled' });
+    assert.equal(await handle.restorePromptPseudonyms('answer'), 'answer');
+  });
+
+  it('propagates the failure-closed blocked outcome', async () => {
+    const handle = createPrivacyTurnHandle({
+      service: stubService({
+        maskUserPrompt: async () => ({ outcome: 'blocked', reason: 'test' }),
+      }),
+      sessionId: 's',
+      turnId: 't',
+    });
+    const result = await handle.maskUserPrompt('text');
+    assert.equal(result.outcome, 'blocked');
+  });
+
+  it('scopes the request to the handle turn/session pair', async () => {
+    let seen: { sessionId: string; turnId: string; text: string } | undefined;
+    const handle = createPrivacyTurnHandle({
+      service: stubService({
+        maskUserPrompt: async (request) => {
+          seen = request;
+          return { outcome: 'masked', maskedText: 'X', spans: [], degraded: false };
+        },
+      }),
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+    });
+    await handle.maskUserPrompt('hello');
+    assert.deepEqual(seen, { sessionId: 'session-1', turnId: 'turn-1', text: 'hello' });
+  });
+});

--- a/web-ui/app/_components/admin/PluginVerdictBadge.tsx
+++ b/web-ui/app/_components/admin/PluginVerdictBadge.tsx
@@ -1,0 +1,77 @@
+import { useTranslations } from 'next-intl';
+
+import type { PluginVerdict } from '../../_lib/storeTypes';
+import { cn } from '../../_lib/cn';
+
+export type PluginVerdictSeverity = PluginVerdict['severity'] | 'not_yet_scanned';
+
+interface PluginVerdictBadgeProps {
+  severity: PluginVerdictSeverity;
+  className?: string;
+}
+
+/**
+ * Advisory code-scan badge for executable plugin packages (issue #453) —
+ * the plugin-surface sibling of `SkillVerdictBadge` (#436/#452), sharing
+ * its severity scale, iconography, and the `skills.verdict` label strings.
+ * Like there: labels read as signal statements, never as proof of safety,
+ * and the verdict never blocks anything in v1.
+ */
+const LABEL_KEY: Record<PluginVerdictSeverity, string> = {
+  no_signals: 'noSignals',
+  flagged: 'flagged',
+  high_risk: 'highRisk',
+  scan_failed: 'scanFailed',
+  too_large_to_scan: 'tooLargeToScan',
+  pending: 'pending',
+  not_yet_scanned: 'notYetScanned',
+};
+
+const ICON: Record<PluginVerdictSeverity, string> = {
+  no_signals: '○',
+  flagged: '⚠',
+  high_risk: '⚠',
+  scan_failed: '✕',
+  too_large_to_scan: '✕',
+  pending: '…',
+  not_yet_scanned: '○',
+};
+
+const STYLE: Record<PluginVerdictSeverity, string> = {
+  no_signals:
+    'text-[color:var(--fg-muted)] border-[color:var(--border)] bg-[color:var(--bg-soft)]',
+  flagged:
+    'text-[color:var(--warning)] border-[color:var(--warning)]/50 bg-[color:var(--warning)]/10',
+  high_risk:
+    'text-[color:var(--danger)] border-[color:var(--danger)]/50 bg-[color:var(--danger)]/8',
+  scan_failed:
+    'text-[color:var(--fg-muted)] border-[color:var(--border-strong)] bg-[color:var(--bg-soft)]',
+  too_large_to_scan:
+    'text-[color:var(--fg-muted)] border-[color:var(--border-strong)] bg-[color:var(--bg-soft)]',
+  pending:
+    'text-[color:var(--accent)] border-[color:var(--accent)]/50 bg-[color:var(--accent)]/10',
+  not_yet_scanned:
+    'text-[color:var(--fg-muted)] border-[color:var(--border)] bg-[color:var(--bg-soft)]',
+};
+
+export function PluginVerdictBadge({
+  severity,
+  className,
+}: PluginVerdictBadgeProps): React.ReactElement {
+  const t = useTranslations('skills.verdict');
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5',
+        'text-[11px] font-medium uppercase tracking-[0.1em]',
+        STYLE[severity],
+        className,
+      )}
+    >
+      <span className="-mt-0.5" aria-hidden>
+        {ICON[severity]}
+      </span>
+      {t(LABEL_KEY[severity])}
+    </span>
+  );
+}

--- a/web-ui/app/_components/admin/__tests__/PluginVerdictBadge.test.tsx
+++ b/web-ui/app/_components/admin/__tests__/PluginVerdictBadge.test.tsx
@@ -1,0 +1,22 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { renderWithIntl } from '../../../_lib/test-utils';
+import { PluginVerdictBadge, type PluginVerdictSeverity } from '../PluginVerdictBadge';
+
+describe('<PluginVerdictBadge />', () => {
+  const cases: [PluginVerdictSeverity, RegExp][] = [
+    ['no_signals', /No known risk signals/i],
+    ['flagged', /Flagged — review recommended/i],
+    ['high_risk', /High risk — review required/i],
+    ['scan_failed', /Scan failed/i],
+    ['too_large_to_scan', /Too large to scan/i],
+    ['pending', /Scanning…/i],
+    ['not_yet_scanned', /Not yet scanned/i],
+  ];
+
+  it.each(cases)('renders the %s severity label', (severity, label) => {
+    renderWithIntl(<PluginVerdictBadge severity={severity} />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+});

--- a/web-ui/app/_lib/storeTypes.ts
+++ b/web-ui/app/_lib/storeTypes.ts
@@ -224,11 +224,36 @@ export interface StoreListResponse {
   total?: number;
 }
 
+/** Advisory code-scan verdict for an ingested plugin package (issue #453).
+ *  Mirrors `PluginVerdict` in middleware admin-v1. Absent when the plugin
+ *  was never scanned (built-ins, no scanner configured). */
+export interface PluginVerdict {
+  severity:
+    | 'no_signals'
+    | 'flagged'
+    | 'high_risk'
+    | 'scan_failed'
+    | 'pending'
+    | 'too_large_to_scan';
+  findings: readonly {
+    readonly code: string;
+    readonly severity: string;
+    readonly message: string;
+    readonly file: string | null;
+  }[];
+  scanner_version: string;
+  rationale: string | null;
+  computed_at: string;
+  ack: { by: string; at: string } | null;
+}
+
 export interface StoreGetResponse {
   plugin: Plugin;
   manifest: unknown;
   install_available: boolean;
   blocking_reasons?: string[];
+  /** Advisory-only — never blocks install (issue #453). */
+  verdict?: PluginVerdict;
 }
 
 // ---------------------------------------------------------------------------

--- a/web-ui/app/store/[id]/page.tsx
+++ b/web-ui/app/store/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
 import { getLocale, getTranslations } from 'next-intl/server';
 
 import { Markdown } from '../../_components/Markdown';
+import { PluginVerdictBadge } from '../../_components/admin/PluginVerdictBadge';
 import { pickLocalized } from '../../_lib/localized';
 
 import { ApiError, getStorePlugin } from '../../_lib/api';
@@ -147,6 +148,11 @@ export default async function PluginDetailPage({
                 ) : (
                   <Chip tone="muted">{t('unsigned')}</Chip>
                 )}
+                {/* Issue #453 — advisory code-scan verdict for ingested
+                    packages. Absent (no badge) when never scanned. */}
+                {detail.verdict ? (
+                  <PluginVerdictBadge severity={detail.verdict.severity} />
+                ) : null}
               </div>
             </div>
           </div>


### PR DESCRIPTION
This branch implements three related issues around plugin security and quality, hardened through four review rounds (three Claude adversarial reviews + cross-vendor codex review).

## #453 — Advisory SkillSpector code scanning for ingested packages

Every executable plugin package that passes `PackageUploadService.ingest` (direct upload, hub install, Builder install) is statically scanned by an NVIDIA SkillSpector sidecar (`middleware/sidecars/skillspector/`, enabled via `SKILLSPECTOR_URL`, deterministic `--no-llm` mode, dependency pinned to an exact upstream commit SHA). The scan is fire-and-forget after ingest success: a scanner outage or an unset `SKILLSPECTOR_URL` can never fail or delay an install. Verdicts are cached by ZIP sha256 + scanner version (migration `0021_plugin_verdict.sql`), surface as a badge + `verdict` field on the store detail page, and support an operator ack with a persisted audit trail (`ack_severity` recorded; ack cleared automatically when a re-scan worsens the verdict). Advisory-only in v1 — nothing blocks.

The result pipeline is fail-closed end to end:

- The sidecar shim positively verifies SkillSpector's real report schema (observed live via a Docker E2E run against the pinned commit: findings arrive under `issues`, not the initially guessed keys) and answers `ok: false` on exit != 0 / non-JSON / schema mismatch; the middleware parser accepts only the promised contract. Anything else is recorded as `scan_failed`, never as a false `no_signals` all-clear.
- Entry-point coverage is guaranteed (codex review fix): upload validation rejects a `lifecycle.entry` that resolves below `node_modules`, `.git`, or any hidden segment (`package.entry_unscannable`) — the scanner's directory walk skips those, so the runtime would otherwise execute code the scan never saw. As defense in depth, the scanner force-includes the manifest's entry file in the scan payload when the walk skipped it, and records `scan_failed` when coverage cannot be guaranteed (missing file, symlink, oversize, root escape, undeterminable manifest).

## #361 — Free-text user-prompt PII masking (default off)

`harness-plugin-privacy-guard` 0.3.0 adds a default-off `mask_user_prompt` setup field. When on, PII spans detected in the user's own message (C0 regex baseline: email, IBAN, phone, German street+postal address, amounts, DOB dates) are replaced with realistic pseudonyms before the prompt crosses the LLM wire, via the shipped v4 pseudonym-projection mechanism with a server-held per-turn map — no on-wire token map. Real values are restored server-side in the final answer and persisted content; masked spans surface (PII-free) as `maskedPromptSpans` on the `PrivacyReceipt`. Failure-closed: a baseline failure or residual span blocks the turn; there is no pass-through-unmasked path. Flag-off is byte-identical to previous behavior.

Every LLM-bound copy consumes the masked wire variant: message assembly, live chat history (`priorTurns`, which replays persisted real values), ingested attachment tail, mid-turn steering messages injected via `POST /chat/steer` (codex review fix — steered text now runs through the same per-turn map before the iteration loop folds it into the conversation, so answer-side restore covers steered spans and a blocked mask fails the turn closed), model/persona routing, KG-recall query, recalled-context injection, direct-line relay payloads, fact-extraction prompts, nudge pipeline, card router, and the excerpt pass. Server-side persistence stores real values only; user-facing card content is restored before rendering. A committed validation harness (`de` + `en` fixtures, C0 tier) documents the recall/precision/latency gates required before enabling the flag for a locale.

## #431 — v1.0 readiness pass across the earliest core plugins

Missing READMEs added (web-search, privacy-guard, quality-guard) with purpose, config keys, and published capabilities; `agent-seo-analyst` operator-catalog description translated to English; privacy-guard `package.json` aligned with its manifest; the v4 path declared the single canonical privacy-guard implementation; explicit adopt/skip decisions recorded for `ctx.jobs` / `ctx.status` / `ctx.llm` / `ctx.mcp` per plugin. No wire-behavior changes.

## Maintainer decisions & things to sign off in this review

- **One PR for three issues (waiver):** deliberate — the cluster is file-dependent (#431 cleans the privacy-guard state #361 builds on) and was approved as a one-branch cluster. Deviates from the AGENTS.md one-change-per-PR default. Note: squash-merge would collapse 7 well-separated commits into one changelog entry — consider a merge commit.
- **Implement-ahead-of-mandate (approved in-session):** #453 originally asked for an evaluation spike and #361 for validate-before-integrate. The maintainer approved plan-first implementation for both (implementation plans are posted on the issues). Mitigations: advisory-only verdicts; masking strictly default-off. **#361 stays open (`Refs`, not `Closes`)** — the C1 transformer (Piiranha/GLiNER) evaluation across 6 locales remains its deliverable; the shipped C0 baseline does **not** detect names ("Anna Schmidt" is not masked; disclosed in help text and CHANGELOG).
- **Deployment config touched:** new opt-in `docker-compose.skillspector.yaml` overlay + a comment line in `docker-compose.yaml` + a new Python sidecar image (stdlib-only shim). Default stack is behavior-unchanged; follows the existing overlay pattern (storage/diagrams/embeddings). Please sign off explicitly.
- **Migration number hazard:** this PR takes `0021`. The dev-platform epic #470 specs also reserve 0021–0024 — whichever lands second must renumber.

## Tests and verification

New/extended coverage: orchestrator-level prompt-mask pipeline tests (main call, fact extraction, recall injection, priorTurns, steering — zero raw spans in the request body, surrogate on the wire, restored answer), upload rejection for `node_modules`/hidden entry points, scan-payload coverage guard, verdict store/scheduler tests including a pg-gated run, and sidecar parser fail-closed tests.

- middleware: build + lint + test — 4000 tests, 0 failures.
- web-ui: typecheck + lint + test — green; re-verified after merging current `main` (incl. #472): typecheck clean, 213/213 tests.
- Sidecar E2E (Docker): benign fixture → `no_signals`; exfiltration fixture → `flagged` (E1); six malformed payload shapes → `scan_failed`.
- Cross-vendor codex review: 2 high findings raised and fixed (steering mask bypass, scanner entry-point blind spot); re-review verdict **approve, zero findings**.

Closes #453
Closes #431
Refs #361
