### PR TITLE
C1 transformer PII detection for prompt masking + 6-locale validation build-out (#361)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ build/
 out/
 .next/
 *.tsbuildinfo
+# Python bytecode from the sidecar unit tests (middleware/sidecars/*)
+__pycache__/
+*.pyc
 
 # ─── Local-only dev state ─────────────────────────────────────────────────
 # Data pulled from production Fly volumes (never commit — user-specific + sensitive)

--- a/docker-compose.pii-detector.yaml
+++ b/docker-compose.pii-detector.yaml
@@ -1,0 +1,34 @@
+# Optional overlay — GLiNER PII-detector sidecar for prompt masking (#361).
+#
+# Adds the C1 transformer PII-detection sidecar (built from
+# middleware/sidecars/pii-detector) and points the middleware at it via
+# PRIVACY_C1_DETECTOR_URL. Advisory overlay: without it the default stack
+# runs unchanged — the (default-off) `mask_user_prompt` feature then runs on
+# the C0 regex baseline only, and no C1 calls are attempted. Sidecar down at
+# runtime ⇒ audited degrade to C0 (`promptMaskDegraded`), never a silent
+# unmasked pass-through.
+#
+#   docker compose -f docker-compose.yaml -f docker-compose.pii-detector.yaml up -d
+
+services:
+  middleware:
+    environment:
+      PRIVACY_C1_DETECTOR_URL: http://pii-detector:8812
+
+  pii-detector:
+    build: middleware/sidecars/pii-detector
+    restart: unless-stopped
+    # No ports: the detector receives raw user-prompt PII and is only
+    # reachable from inside the compose network — it must never be public.
+    networks: [omadia]
+    healthcheck:
+      test:
+        - 'CMD'
+        - 'python'
+        - '-c'
+        - "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8812/health').status==200 else 1)"
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      # The model (~280M backbone) loads before /health starts serving.
+      start_period: 120s

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -150,6 +150,33 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   per-locale flag policy is unchanged: results posted to #361 before any
   locale flips `mask_user_prompt` on.
 
+### Fixed — prompt-mask overlap resolution kept only the winning span (#361)
+
+- `promptMask.ts#dedupSpans` resolved detector overlaps by dropping the
+  lower-confidence span wholesale. A long C1 span (e.g. a free-form address
+  GLiNER scored 0.8) that merely brushed a short confidence-1 C0 hit inside
+  it (the postal code) therefore lost its ENTIRE coverage — the rest of the
+  address reached the LLM wire unmasked, and the post-mask residual check
+  only asserts kept values, so it could not catch the drop (review finding
+  on the #361 branch). Overlap resolution now lets the winner own only the
+  contested characters: every uncovered remainder of a losing span is kept
+  as a masking span of its own (word-boundary re-extended, output still
+  non-overlapping). Regression tests cover the exact reviewer scenario at
+  both the `dedupSpans` and the `maskPrompt` level.
+
+### Added — recorded 6-locale validation run (#361)
+
+- `harness-plugin-privacy-guard/src/validation/RESULTS.md` commits the full
+  `c0` / `c0+c1` / `c1-solo` × 6-locale harness run (2026-07-10, pinned
+  GLiNER ONNX model, sidecar defaults, dedup fix included): **de/en/it pass
+  ALL gates on `c0+c1`** (person recall 100% incl. the hand-built OOD
+  slice); es/fr/nl fail on recorded C0 structured locale gaps (amounts /
+  dates / phone formats), not on C1 quality; the `c1-solo` ablation
+  confirms C0 stays load-bearing for structured identifiers. The flag
+  policy is unchanged — these tables must be posted to issue #361 before
+  any locale flips `mask_user_prompt` on; the validation README now links
+  the recorded run.
+
 ### Added — privacy receipt card shows masked prompt spans (#361)
 
 - The chat privacy-receipt card now surfaces the backend receipt field

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -107,8 +107,20 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   middleware env var `PRIVACY_C1_DETECTOR_URL`. Without the overlay the
   default stack is unchanged; sidecar down at runtime means the audited
   degrade-to-C0 path (`promptMaskDegraded`), never a silent unmasked
-  pass-through. The middleware-side detector client wiring follows in the
-  same branch.
+  pass-through.
+- `harness-plugin-privacy-guard` 0.4.0: the sidecar is wired into the
+  shipped `PromptPiiDetector` seam via a new fail-closed HTTP client
+  (`createC1HttpDetector`, detector id `c1-gliner`) injected through the
+  existing `createPrivacyGuardService({c1Detector})` slot — no service-,
+  mask- or orchestrator-logic changes. New non-secret setup field
+  `c1_detector_url` (live-read per call; `PRIVACY_C1_DETECTOR_URL` env
+  fallback; empty ⇒ C0-only, no C1 call attempted) and one deliberate
+  `permissions.network.outbound` entry for the sidecar (the plugin was
+  previously pure compute). The client positively validates the sidecar's
+  response schema and converts its Unicode code-point offsets to UTF-16
+  exactly, asserting per span that the converted slice reproduces the
+  sidecar's text — any mismatch, timeout (default 1500 ms), non-200 or
+  malformed body throws and rides the audited degrade-to-C0 path.
 
 ### Changed — v1.0 readiness pass across the earliest core plugins (#431)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -122,6 +122,34 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   sidecar's text — any mismatch, timeout (default 1500 ms), non-200 or
   malformed body throws and rides the audited degrade-to-C0 path.
 
+### Added — 6-locale prompt-PII validation build-out (#361)
+
+- The runnable validation harness
+  (`harness-plugin-privacy-guard/src/validation/`, still NOT a CI gate) now
+  covers all six target locales: fixtures for fr/es/it/nl plus scaled-up
+  de/en — 121 items per locale (89 positives incl. a 25-item hand-built
+  out-of-distribution slice, 32 PII-free negatives). All committed fixtures
+  are original (hand-built + LLM-generated synthetic); no ai4privacy rows or
+  derivatives are committed (restricted commercial terms — local uncommitted
+  use only). fr/es/it/nl carry a recorded "native-speaker spot-check
+  pending" caveat. Locale ID numbers (Steuer-ID, NINO, NIE/DNI, codice
+  fiscale, BSN) are typed `idnum` and measured informationally, never gated
+  in v1.
+- Harness extensions: with `PII_DETECTOR_URL` set, the eval adds a `c0+c1`
+  set (person recall ≥ 0.90 now enforceable, plus the shipped structured /
+  precision / latency gates) and a `c1-solo` ablation (reported, never
+  gated); one un-timed warm-up call per set keeps model warm-up out of p95;
+  `--markdown` emits GitHub-flavored tables for posting run results to
+  issue #361. Fixture files are linted at load (verbatim span values, known
+  types/tiers, duplicate rejection) and a malformed file fails the run
+  loudly. Without `PII_DETECTOR_URL` the harness runs c0-only exactly as
+  before: de/en still PASS their structured gates, while the fr/es/it/nl
+  runs now honestly document the C0 baseline's locale gaps (French
+  space-grouped amounts, Dutch address/date formats, Spanish local phones)
+  in the validation README instead of the fixtures being softened. The
+  per-locale flag policy is unchanged: results posted to #361 before any
+  locale flips `mask_user_prompt` on.
+
 ### Changed — v1.0 readiness pass across the earliest core plugins (#431)
 
 - `harness-plugin-web-search`, `harness-plugin-privacy-guard`, and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -150,6 +150,20 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   per-locale flag policy is unchanged: results posted to #361 before any
   locale flips `mask_user_prompt` on.
 
+### Added — privacy receipt card shows masked prompt spans (#361)
+
+- The chat privacy-receipt card now surfaces the backend receipt field
+  `maskedPromptSpans` (shipped with the prompt-masking runtime path, but
+  until now unknown to the frontend mirror): a collapsed summary chunk
+  ("prompt: N masked") plus an expanded fact row with a per-type breakdown
+  (e.g. "3 (2 × person, 1 × email)"). Span types are an open set rendered
+  verbatim; detector ids stay in the data and are not rendered. A dedicated
+  explainer line states that identifiers in the user's own message were
+  pseudonymised before the model call and restored in the answer. Absent or
+  empty field ⇒ the card renders byte-identically to before. New
+  `privacyReceipt.{summaryPromptMasked,factPromptMasked,explainerPromptMasked}`
+  i18n keys in en + de.
+
 ### Changed — v1.0 readiness pass across the earliest core plugins (#431)
 
 - `harness-plugin-web-search`, `harness-plugin-privacy-guard`, and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -90,6 +90,26 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   locale requires posting a green harness run for that locale to issue
   #361 first.
 
+### Added — GLiNER PII-detector sidecar for prompt masking (#361)
+
+- New optional inference sidecar `middleware/sidecars/pii-detector/`
+  (skillspector pattern: stdlib-only HTTP shim, stateless, fail-closed):
+  runs `urchade/gliner_multi_pii-v1` (Apache-2.0, quantized ONNX backend by
+  default, torch fallback) and answers `POST /detect` with scored
+  `person`/`address` spans as Unicode code-point offsets — the C1
+  transformer tier that detects the PII classes the C0 regex baseline
+  structurally cannot (names, free-form addresses). Model + deps are pinned
+  to exact versions and baked into the image at build time (pinned HF
+  revision, `HF_HUB_OFFLINE=1` — the running container performs no egress).
+  Enable via the `docker-compose.pii-detector.yaml` overlay, which keeps the
+  sidecar internal-network-only (no published ports — it receives raw prompt
+  PII; request text and span values are never logged) and sets the new
+  middleware env var `PRIVACY_C1_DETECTOR_URL`. Without the overlay the
+  default stack is unchanged; sidecar down at runtime means the audited
+  degrade-to-C0 path (`promptMaskDegraded`), never a silent unmasked
+  pass-through. The middleware-side detector client wiring follows in the
+  same branch.
+
 ### Changed — v1.0 readiness pass across the earliest core plugins (#431)
 
 - `harness-plugin-web-search`, `harness-plugin-privacy-guard`, and

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -868,7 +868,17 @@ Manuelles E2E (dev):
 5. `mask_user_prompt: off` ⇒ byte-identisches Legacy-Verhalten.
 
 Tests: `middleware/test/privacyPromptC1Detector.test.ts` (Client-Kontrakt +
-Service-Komposition), `privacyPromptMask.test.ts` (Seam/Degrade generisch).
+Service-Komposition), `privacyPromptMask.test.ts` (Seam/Degrade generisch,
+inkl. Regression: Overlap-Verlierer-Spans behalten ihre unbedeckten Reste —
+ein langer C1-Adress-Span wird nie mehr komplett verworfen, nur weil ein
+kurzer C0-Treffer in ihm liegt).
+
+Recorded Validation-Run (2026-07-10, alle drei Detector-Sets × 6 Locales):
+`middleware/packages/harness-plugin-privacy-guard/src/validation/RESULTS.md`
+— de/en/it bestehen ALLE Gates auf `c0+c1`; es/fr/nl scheitern an
+dokumentierten C0-Locale-Lücken (Beträge/Daten/Telefonformate). Flag-Policy
+unverändert: Tabellen müssen vor dem Flag-Flip pro Locale auf Issue #361
+gepostet sein.
 
 ---
 

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -794,6 +794,8 @@ DIAGRAM_MAX_PNG_BYTES=900000               # <1 MB Teams-Limit
 BUCKET_NAME, AWS_ENDPOINT_URL_S3, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
 # Tenant-Scope (auch für Diagramm-Cache-Keys genutzt)
 GRAPH_TENANT_ID=byte5
+# Prompt-PII C1-Detector (GLiNER-Sidecar, #361) — optional
+PRIVACY_C1_DETECTOR_URL=http://pii-detector:8812   # unset ⇒ nur C0-Regex-Baseline
 # Runtime
 PORT=3979
 ```
@@ -815,6 +817,58 @@ PORT=3979
    undici-Agent mit `rejectUnauthorized: false`. Global
    `NODE_TLS_REJECT_UNAUTHORIZED=0` **nicht** setzen — kompromittiert
    auch Anthropic-Verbindung.
+
+### Prompt-PII-Masking (#361): C1-Transformer-Detector (GLiNER-Sidecar)
+
+Das Privacy-Guard-Plugin (`middleware/packages/harness-plugin-privacy-guard`,
+Manifest 0.4.0) maskiert bei aktiviertem Setup-Field `mask_user_prompt`
+(default **off**) PII-Spans im freien User-Prompt durch Pseudonyme, bevor der
+Text die LLM-Wire kreuzt; die Realwerte werden server-seitig in der finalen
+Antwort restauriert. Zwei Detektor-Tiers:
+
+- **C0** — deterministische Regex-Baseline (E-Mail, IBAN, Telefon, Adresse,
+  Beträge, Daten), immer aktiv, wirft nie.
+- **C1** — Transformer-Tier für Personennamen + Freiform-Adressen:
+  `src/c1Detector.ts` (`createC1HttpDetector`, Detector-Id `c1-gliner`)
+  spricht den GLiNER-Inference-Sidecar `middleware/sidecars/pii-detector/`
+  über `POST /detect` an. Injection über den bestehenden
+  `createPrivacyGuardService({c1Detector})`-Slot — **keine** Änderungen an
+  `service.ts` / `promptMask.ts` / Orchestrator.
+
+Konfiguration (live pro Call aufgelöst, kein Restart nötig): Setup-Field
+`c1_detector_url` zuerst, Env-Fallback `PRIVACY_C1_DETECTOR_URL` (leer =
+unset). URL nicht gesetzt ⇒ C1 unkonfiguriert, es wird **kein** Call
+versucht (kein Degrade-Audit-Noise). Docker: Overlay
+`docker-compose.pii-detector.yaml` baut den Sidecar (keine published Ports —
+er sieht rohe Prompt-PII, niemals öffentlich exponieren) und setzt die URL.
+
+Fail-closed-Verhalten des Clients: Response-Schema wird **positiv**
+validiert (skillspector-Präzedenz); Non-200, `ok:false`, malformed Spans,
+Non-JSON oder Timeout (default 1500 ms) ⇒ throw ⇒ der Service degradiert
+auditiert auf C0 (`promptMaskDegraded`-Log-Zeile), niemals ein stiller
+unmaskierter Pass-Through. Offset-Kontrakt: der Sidecar liefert
+Unicode-**Code-Point**-Offsets (Python-Semantik), der Client konvertiert
+exakt nach UTF-16 und asserted pro Span `text.slice(...) === span.text` —
+Mismatch ⇒ throw (ein falsch verankerter Personen-Span wäre ein Leak).
+Fehlermeldungen tragen nie Prompt-Text oder Span-Werte (sie landen im
+Audit-Log).
+
+Manuelles E2E (dev):
+
+1. `docker compose -f docker-compose.yaml -f docker-compose.pii-detector.yaml up -d`,
+   warten bis `pii-detector` healthy (Modell-Load ~1-2 min).
+2. Im Plugin-Setup `c1_detector_url` (`http://pii-detector:8812`) und
+   `mask_user_prompt: on` setzen.
+3. Prompt senden: *"What should we pay Anna Schmidt (32, lives at
+   Bahnhofstr. 5, 60311 Frankfurt) given her salary of €72,000?"* —
+   Service-Log zeigt `promptMask ... spans=N` inkl. `person`-Span, der
+   Wire-Text trägt einen Surrogat-Namen, die finale Antwort den echten.
+4. Sidecar stoppen, erneut senden — Log zeigt `promptMaskDegraded`, der
+   Turn läuft auf C0 weiter (E-Mail/IBAN etc. weiterhin maskiert).
+5. `mask_user_prompt: off` ⇒ byte-identisches Legacy-Verhalten.
+
+Tests: `middleware/test/privacyPromptC1Detector.test.ts` (Client-Kontrakt +
+Service-Komposition), `privacyPromptMask.test.ts` (Seam/Degrade generisch).
 
 ---
 

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -833,7 +833,8 @@ Antwort restauriert. Zwei Detektor-Tiers:
   spricht den GLiNER-Inference-Sidecar `middleware/sidecars/pii-detector/`
   über `POST /detect` an. Injection über den bestehenden
   `createPrivacyGuardService({c1Detector})`-Slot — **keine** Änderungen an
-  `service.ts` / `promptMask.ts` / Orchestrator.
+  `service.ts` / Orchestrator; `promptMask.ts` wurde nur durch den
+  Overlap-Remainder-Fix (`6b42c6c`, siehe unten) angepasst.
 
 Konfiguration (live pro Call aufgelöst, kein Restart nötig): Setup-Field
 `c1_detector_url` zuerst, Env-Fallback `PRIVACY_C1_DETECTOR_URL` (leer =

--- a/middleware/.env.example
+++ b/middleware/.env.example
@@ -159,6 +159,19 @@ TOPIC_LOWER_THRESHOLD=0.15
 # SKILLSPECTOR_URL=http://localhost:8811
 # SKILLSPECTOR_TIMEOUT_MS=20000
 
+# --- Prompt-PII C1 detector (GLiNER sidecar, issue #361) — OPTIONAL ---------
+# Transformer-based multilingual PII detection (person names, free-form
+# addresses) for the privacy-guard `mask_user_prompt` feature — the C1 tier
+# on top of the C0 regex baseline. OFF by default: without this URL no C1
+# call is attempted and prompt masking (itself default-off) runs C0-only.
+# Sidecar unreachable at runtime => audited degrade to C0
+# (`promptMaskDegraded`) — never a silent unmasked pass-through. The sidecar
+# receives raw prompt PII: keep it internal-network-only, never public.
+#   With Docker: enable via docker-compose.pii-detector.yaml (it builds
+#   middleware/sidecars/pii-detector and sets the URL for you).
+#   Bare-metal dev: run the sidecar yourself and uncomment below.
+# PRIVACY_C1_DETECTOR_URL=http://localhost:8812
+
 # --- Vault (encrypted secrets store) ----------------------------------------
 # Master key used to AES-256-GCM-encrypt plugin secrets at rest under
 # /data/vault. Generate once with `openssl rand -base64 32` and keep stable

--- a/middleware/packages/harness-plugin-privacy-guard/manifest.yaml
+++ b/middleware/packages/harness-plugin-privacy-guard/manifest.yaml
@@ -3,7 +3,7 @@ schema_version: "1"
 identity:
   id: "@omadia/plugin-privacy-guard"
   name: "Privacy Guard"
-  version: "0.3.0"
+  version: "0.4.0"
   kind: "tool"
   domain: "privacy.redact"
   description: "Privacy Shield v4 core plugin. Publishes the `privacy.redact@1` capability — a Data-Plane Boundary that interns raw tool results server-side and hands the LLM only an identity-free Digest. Identity-/order-critical work runs through a server-side Verb API; the final answer is materialized from ground truth. Emits a PII-free PrivacyReceipt the channel renderers (Teams Adaptive-Card, Web inline disclosure) consume to surface what was protected on each turn."
@@ -25,19 +25,22 @@ lifecycle:
   entry: "dist/plugin.js"
 
 # ---------------------------------------------------------------------------
-# One setup field (#361). The v4 Data-Plane Boundary itself stays
+# Two setup fields (#361). The v4 Data-Plane Boundary itself stays
 # configuration-free — generic over JSON shape and value statistics. The
-# only toggle is free-text user-prompt masking, DEFAULT OFF: flag-off is
-# byte-identical to pre-#361 behavior. Flipping it on for a locale requires
-# a green run of the committed validation harness (src/validation/) against
-# its documented recall gates, posted to issue #361 first.
+# only toggles concern free-text user-prompt masking, DEFAULT OFF: flag-off
+# is byte-identical to pre-#361 behavior. Flipping it on for a locale
+# requires a green run of the committed validation harness (src/validation/)
+# against its documented recall gates, posted to issue #361 first.
+# `c1_detector_url` points at the optional GLiNER inference sidecar — a URL,
+# not a credential, hence a plain non-secret field (secrets-only-in-Vault
+# rule untouched).
 # ---------------------------------------------------------------------------
 setup:
   fields:
     - key: "mask_user_prompt"
       type: "enum"
       label: "Free-text user-prompt PII masking"
-      help: "EXPERIMENTAL, default off. When on, PII spans detected in the user's own message (email, IBAN, phone, address, amounts, dates — C0 regex baseline) are replaced by realistic pseudonyms in every LLM-bound copy of the turn (main prompt, live chat history/priorTurns, ingested attachment text, recalled prior context, direct-line relay payloads, fact-extraction/routing/excerpt passes); the real values are restored server-side in the final answer and in everything persisted (session log, knowledge graph, promoted memories). Failure-closed: if masking cannot be guaranteed, the turn is blocked rather than sent unmasked — this includes direct-line (#specialist) turns. Names/free-form entities require the C1 transformer detector, which is not wired by default — see the plugin README."
+      help: "EXPERIMENTAL, default off. When on, PII spans detected in the user's own message (email, IBAN, phone, address, amounts, dates — C0 regex baseline) are replaced by realistic pseudonyms in every LLM-bound copy of the turn (main prompt, live chat history/priorTurns, ingested attachment text, recalled prior context, direct-line relay payloads, fact-extraction/routing/excerpt passes); the real values are restored server-side in the final answer and in everything persisted (session log, knowledge graph, promoted memories). Failure-closed: if masking cannot be guaranteed, the turn is blocked rather than sent unmasked — this includes direct-line (#specialist) turns. Names/free-form entities require the C1 transformer detector — set `c1_detector_url` (or the `PRIVACY_C1_DETECTOR_URL` env var) to enable it; unset, only the C0 regex baseline runs."
       required: false
       default: "off"
       enum:
@@ -45,6 +48,12 @@ setup:
           label: "Off — prompts pass unchanged (default)"
         - value: "on"
           label: "On — mask detected PII spans (C0 baseline)"
+    - key: "c1_detector_url"
+      type: "string"
+      label: "C1 PII-detector sidecar URL"
+      help: "Base URL of the GLiNER PII-inference sidecar (middleware/sidecars/pii-detector) that detects person names and free-form addresses — the C1 tier on top of the C0 regex baseline. Under the docker-compose.pii-detector.yaml overlay: http://pii-detector:8812. Leave empty to run only the C0 regex baseline (no C1 call is attempted). The sidecar receives raw prompt PII — keep it internal-network-only, never public. Sidecar unreachable at runtime => audited degrade to C0 (promptMaskDegraded), never a silent unmasked pass-through. Falls back to the PRIVACY_C1_DETECTOR_URL env var when empty."
+      required: false
+      default: ""
 
 playbook:
   when_to_use: |
@@ -64,7 +73,9 @@ playbook:
     und kann dort als Collapsed-/Expanded-Card gerendert werden.
 
 # ---------------------------------------------------------------------------
-# Permissions. Pure server-side compute — no network, no graph, no memory.
+# Permissions. Server-side compute plus ONE deliberate network target
+# (#361): the operator-configured on-prem C1 PII-inference sidecar. No
+# graph, no memory.
 # ---------------------------------------------------------------------------
 permissions:
   memory:
@@ -74,7 +85,13 @@ permissions:
     reads: []
     writes: []
   network:
-    outbound: []
+    outbound:
+      # #361 — the GLiNER PII-detector sidecar (`c1_detector_url` setup
+      # field / PRIVACY_C1_DETECTOR_URL). Operator-configured, on-prem,
+      # internal-network-only — it receives raw prompt text, so this is a
+      # deliberate, security-reviewable exception to the plugin's
+      # previously pure-compute posture.
+      - "pii-detector-sidecar"
   filesystem:
     scratch: false
   # Slice 2 — schema-level PII classification. The plugin asks a cheap Haiku

--- a/middleware/packages/harness-plugin-privacy-guard/package.json
+++ b/middleware/packages/harness-plugin-privacy-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omadia/plugin-privacy-guard",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/middleware/packages/harness-plugin-privacy-guard/src/c1Detector.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/c1Detector.ts
@@ -1,0 +1,258 @@
+/**
+ * #361 — C1 transformer PII detector over the GLiNER inference sidecar
+ * (`middleware/sidecars/pii-detector/`).
+ *
+ * Implements the shipped `PromptPiiDetector` seam (`@omadia/plugin-api`)
+ * as a thin, FAIL-CLOSED HTTP client. Division of labor with the service:
+ *
+ *   - URL unresolved            ⇒ `detect()` returns `[]` — C1 is simply
+ *     not configured. Equivalent to the inert `createC1StubDetector()`;
+ *     deliberately NOT a degrade (no audit noise on unconfigured installs).
+ *   - Anything else unexpected  ⇒ `detect()` THROWS. The service's tier-1
+ *     path (`service.ts` maskUserPrompt) catches it, degrades to C0 and
+ *     writes the `promptMaskDegraded` audit line. This module never
+ *     swallows errors and never returns a half-result — lenient parsing of
+ *     a PII detector's output is itself a leak vector (skillspector
+ *     `parseSidecarResponse` precedent, `src/services/pluginScanner.ts`).
+ *
+ * Offset semantics: the sidecar (Python) reports Unicode CODE-POINT
+ * offsets; `PromptPiiSpan` requires UTF-16 code units (contract in
+ * `plugin-api/src/privacyReceipt.ts`). Conversion is exact (single pass
+ * over the analyzed text) and verified per span by asserting
+ * `text.slice(startU16, endU16) === span.text` — a mis-anchored person
+ * span would mask the wrong characters, i.e. leak the real ones.
+ *
+ * PRIVACY: error messages thrown here end up in the `promptMaskDegraded`
+ * audit log — they must never carry prompt text or span values. Only
+ * status codes, counts, and offsets.
+ */
+
+import type { PromptPiiDetector, PromptPiiSpan } from '@omadia/plugin-api';
+
+export interface C1HttpDetectorOptions {
+  /**
+   * Live URL resolver — read on every `detect()` call so an operator
+   * config change (install-UI setup field) applies without a plugin
+   * restart. `undefined`/empty ⇒ C1 not configured.
+   */
+  readonly resolveUrl: () => string | undefined;
+  /** Hard cap per detect() call, covering connect + body read. */
+  readonly timeoutMs?: number;
+  /** Test seam. Defaults to `globalThis.fetch`. */
+  readonly fetchFn?: typeof fetch;
+  /** Calibrated fixed label set — NOT operator-extendable open labels
+   *  (false-positive cascade class, see #242 / the plan on #361). */
+  readonly labels?: readonly string[];
+  readonly threshold?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 1500;
+const DEFAULT_LABELS: readonly string[] = ['person', 'address'];
+const DEFAULT_THRESHOLD = 0.5;
+
+/** Detector id recorded (PII-free) on the receipt per masked span. */
+export const C1_DETECTOR_ID = 'c1-gliner';
+
+/** Shape of one span in the sidecar's positively-validated response. */
+interface SidecarSpan {
+  readonly start: number;
+  readonly end: number;
+  readonly text: string;
+  readonly label: string;
+  readonly score: number;
+}
+
+export function createC1HttpDetector(
+  opts: C1HttpDetectorOptions,
+): PromptPiiDetector {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchFn = opts.fetchFn ?? globalThis.fetch;
+  const labels = opts.labels ?? DEFAULT_LABELS;
+  const threshold = opts.threshold ?? DEFAULT_THRESHOLD;
+
+  return {
+    id: C1_DETECTOR_ID,
+    async detect(text: string): Promise<readonly PromptPiiSpan[]> {
+      const rawUrl = opts.resolveUrl();
+      const url = typeof rawUrl === 'string' ? rawUrl.trim() : undefined;
+      if (url === undefined || url === '') {
+        // Unconfigured — C0-only operation, not a failure.
+        return [];
+      }
+
+      const body = await withTimeout(timeoutMs, async (signal) => {
+        const res = await fetchFn(`${url.replace(/\/+$/, '')}/detect`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ text, labels, threshold }),
+          signal,
+        });
+        // The sidecar contract answers exactly 200 on success and
+        // `{ok: false}` + non-200 on any failure — treat everything else
+        // as failure (positive validation, never lenient).
+        if (res.status !== 200) {
+          throw new Error(`C1 sidecar responded ${String(res.status)}`);
+        }
+        try {
+          return (await res.json()) as unknown;
+        } catch {
+          throw new Error('C1 sidecar returned a non-JSON body');
+        }
+      });
+
+      const sidecarSpans = parseDetectResponse(body);
+      return toPromptSpans(text, sidecarSpans);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Timeout — own ref'ed timer race, not only the fetch signal. A misbehaving
+// transport that ignores the AbortSignal must still not stall
+// `maskUserPrompt` (and `AbortSignal.timeout()`'s timer is unref'ed, so it
+// cannot be relied on to keep the loop alive). Skillspector-client
+// precedent: AbortController + setTimeout + clearTimeout.
+// ---------------------------------------------------------------------------
+
+async function withTimeout<T>(
+  timeoutMs: number,
+  fn: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await new Promise<T>((resolve, reject) => {
+      timer = setTimeout(() => {
+        controller.abort();
+        reject(new Error(`C1 sidecar timed out after ${String(timeoutMs)}ms`));
+      }, timeoutMs);
+      fn(controller.signal).then(resolve, reject);
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Positive response-schema validation (fail-closed).
+// ---------------------------------------------------------------------------
+
+function parseDetectResponse(body: unknown): SidecarSpan[] {
+  if (body === null || typeof body !== 'object') {
+    throw new Error('C1 sidecar returned a non-object response');
+  }
+  const record = body as Record<string, unknown>;
+  if (record['ok'] !== true) {
+    const error =
+      typeof record['error'] === 'string' ? record['error'] : 'unknown error';
+    throw new Error(`C1 sidecar reported failure: ${error}`);
+  }
+  const rawSpans = record['spans'];
+  if (!Array.isArray(rawSpans)) {
+    throw new Error('C1 sidecar response carries no spans array');
+  }
+  const spans: SidecarSpan[] = [];
+  for (const raw of rawSpans) {
+    if (raw === null || typeof raw !== 'object') {
+      throw new Error('C1 sidecar response carries a non-object span');
+    }
+    const s = raw as Record<string, unknown>;
+    const start = s['start'];
+    const end = s['end'];
+    const text = s['text'];
+    const label = s['label'];
+    const score = s['score'];
+    if (
+      typeof start !== 'number' ||
+      !Number.isInteger(start) ||
+      start < 0 ||
+      typeof end !== 'number' ||
+      !Number.isInteger(end) ||
+      end <= start ||
+      typeof text !== 'string' ||
+      text.length === 0 ||
+      typeof label !== 'string' ||
+      label.length === 0 ||
+      typeof score !== 'number' ||
+      !Number.isFinite(score)
+    ) {
+      throw new Error('C1 sidecar span failed schema validation');
+    }
+    spans.push({ start, end, text, label, score });
+  }
+  return spans;
+}
+
+// ---------------------------------------------------------------------------
+// Code-point → UTF-16 offset conversion + slice-equality assertion.
+// ---------------------------------------------------------------------------
+
+function toPromptSpans(
+  analyzedText: string,
+  sidecarSpans: readonly SidecarSpan[],
+): PromptPiiSpan[] {
+  if (sidecarSpans.length === 0) return [];
+
+  // Single pass: record the UTF-16 index at every code-point boundary a
+  // span references. `for..of` iterates code points; `ch.length` is the
+  // UTF-16 width (1 for BMP, 2 for astral — the emoji case).
+  const needed = new Set<number>();
+  for (const s of sidecarSpans) {
+    needed.add(s.start);
+    needed.add(s.end);
+  }
+  const cpToU16 = new Map<number, number>();
+  let cp = 0;
+  let u16 = 0;
+  for (const ch of analyzedText) {
+    if (needed.has(cp)) cpToU16.set(cp, u16);
+    cp += 1;
+    u16 += ch.length;
+  }
+  // End-of-text is a valid exclusive `end` boundary.
+  if (needed.has(cp)) cpToU16.set(cp, u16);
+
+  const result: PromptPiiSpan[] = [];
+  for (const s of sidecarSpans) {
+    const start = cpToU16.get(s.start);
+    const end = cpToU16.get(s.end);
+    if (start === undefined || end === undefined) {
+      throw new Error(
+        `C1 sidecar span offsets out of range (${String(s.start)}..${String(s.end)})`,
+      );
+    }
+    // The decisive fail-closed check: the sidecar's own `text` slice must
+    // reproduce exactly under the converted offsets. A mis-anchored
+    // person span is a leak — never "best-effort" it.
+    if (analyzedText.slice(start, end) !== s.text) {
+      throw new Error(
+        `C1 sidecar span text does not match its offsets (${String(s.start)}..${String(s.end)})`,
+      );
+    }
+    result.push({
+      start,
+      end,
+      type: toSpanType(s.label),
+      confidence: Math.min(1, Math.max(0, s.score)),
+    });
+  }
+  return result;
+}
+
+/**
+ * Label → span-type mapping. `person` and `address` hit the dedicated
+ * surrogate streams in `v4/pseudonym.ts`; any other label becomes a
+ * lowercased slug, which the pseudonym layer covers with its generic
+ * `PLATZHALTER-<TYPE>-n` fallback — unknown categories mask safely, they
+ * never pass through.
+ */
+function toSpanType(label: string): string {
+  const lower = label.toLowerCase();
+  if (lower === 'person') return 'person';
+  if (lower === 'address') return 'address';
+  const slug = lower.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  if (slug === '') {
+    throw new Error('C1 sidecar span label is not representable');
+  }
+  return slug;
+}

--- a/middleware/packages/harness-plugin-privacy-guard/src/index.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/index.ts
@@ -13,3 +13,8 @@ export { activate } from './plugin.js';
 export type { PrivacyGuardPluginHandle } from './plugin.js';
 
 export { createPrivacyGuardService } from './service.js';
+
+// #361 — C1 transformer detector (GLiNER sidecar client), re-exported for
+// tests and for hosts that wire the seam manually.
+export { createC1HttpDetector, C1_DETECTOR_ID } from './c1Detector.js';
+export type { C1HttpDetectorOptions } from './c1Detector.js';

--- a/middleware/packages/harness-plugin-privacy-guard/src/plugin.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/plugin.ts
@@ -4,6 +4,7 @@ import {
   type PrivacyGuardService,
 } from '@omadia/plugin-api';
 
+import { createC1HttpDetector } from './c1Detector.js';
 import { createPrivacyGuardService } from './service.js';
 
 /**
@@ -22,6 +23,13 @@ import { createPrivacyGuardService } from './service.js';
  * #361 — the one operator toggle is `mask_user_prompt` (default off), read
  * live via the plugin's ConfigAccessor: free-text user prompts get their
  * detected PII spans replaced by pseudonyms before crossing the LLM wire.
+ * The C1 transformer tier (GLiNER sidecar) is injected here as a
+ * `PromptPiiDetector` with a LIVE URL resolver — setup field
+ * `c1_detector_url` first, `PRIVACY_C1_DETECTOR_URL` env fallback — so an
+ * operator config change applies on the next turn without a restart. URL
+ * unset ⇒ the detector reports no spans (C0-only, byte-identical to the
+ * pre-C1 behavior); sidecar failure ⇒ the service's audited tier-1
+ * degrade-to-C0 path.
  */
 
 export interface PrivacyGuardPluginHandle {
@@ -38,12 +46,27 @@ export async function activate(
   // an LLM provider (ANTHROPIC_API_KEY). Absent ⇒ the classifier simply does
   // not run; interning behaves byte-identically to before.
   const llm = ctx.llm;
+  // #361 — C1 transformer detector (GLiNER sidecar HTTP client). The URL is
+  // resolved LIVE per detect() call: operator setup field first, env
+  // fallback second (empty strings count as unset — see the `??` vs `||`
+  // env gotcha in the handoff doc §10).
+  const resolveC1Url = (): string | undefined => {
+    const fromConfig = ctx.config.get('c1_detector_url');
+    const configUrl =
+      typeof fromConfig === 'string' && fromConfig.trim() !== ''
+        ? fromConfig.trim()
+        : undefined;
+    const envUrl = process.env['PRIVACY_C1_DETECTOR_URL']?.trim();
+    return configUrl ?? (envUrl !== undefined && envUrl !== '' ? envUrl : undefined);
+  };
+  const c1Detector = createC1HttpDetector({ resolveUrl: resolveC1Url });
   const service = createPrivacyGuardService({
     ...(llm ? { llmComplete: llm.complete.bind(llm) } : {}),
     // #361 — live flag reader for default-off user-prompt masking. Routed
     // through the plugin's own ConfigAccessor so an operator toggle saved
     // via the install UI applies on the very next turn (no restart).
     readConfig: (key) => ctx.config.get(key),
+    c1Detector,
   });
   const disposeService = ctx.services.provide<PrivacyGuardService>(
     PRIVACY_REDACT_SERVICE_NAME,
@@ -51,7 +74,9 @@ export async function activate(
   );
 
   ctx.log(
-    `[privacy-guard] ready (schema PII classifier: ${llm ? 'on' : 'off'})`,
+    `[privacy-guard] ready (schema PII classifier: ${llm ? 'on' : 'off'}, ` +
+      // Startup snapshot only — the URL is re-resolved on every call.
+      `C1 prompt detector: ${resolveC1Url() !== undefined ? 'configured' : 'unconfigured'})`,
   );
 
   return {

--- a/middleware/packages/harness-plugin-privacy-guard/src/promptMask.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/promptMask.ts
@@ -148,16 +148,57 @@ function extendToWordBoundaries(
   return { start: s, end: e };
 }
 
+interface ExtendedSpan {
+  start: number;
+  end: number;
+  readonly type: string;
+  readonly detector: string;
+  readonly confidence: number;
+}
+
+/** The parts of `[candidate.start, candidate.end)` not covered by any of
+ *  `covering` (all overlapping the candidate, non-overlapping each other). */
+function uncoveredParts(
+  candidate: ExtendedSpan,
+  covering: readonly ExtendedSpan[],
+): Array<{ start: number; end: number }> {
+  const parts: Array<{ start: number; end: number }> = [];
+  let cursor = candidate.start;
+  for (const k of [...covering].sort((a, b) => a.start - b.start)) {
+    if (k.start > cursor) parts.push({ start: cursor, end: Math.min(k.start, candidate.end) });
+    cursor = Math.max(cursor, k.end);
+    if (cursor >= candidate.end) break;
+  }
+  if (cursor < candidate.end) parts.push({ start: cursor, end: candidate.end });
+  return parts;
+}
+
+/** True when the slice holds at least one word-like character — a remainder
+ *  of pure whitespace/punctuation carries nothing identifying and masking it
+ *  would substitute separators. */
+function hasWordChar(text: string, start: number, end: number): boolean {
+  for (let i = start; i < end; i++) {
+    if (WORD_CHAR.test(text[i]!)) return true;
+  }
+  return false;
+}
+
 /**
  * Merge detector outputs: extend to word boundaries, then resolve overlaps
- * by keeping the higher-confidence span (ties → the longer span). Output is
- * sorted by start offset and non-overlapping.
+ * by letting the higher-confidence span (ties → the longer span) own the
+ * contested characters. A losing span is NOT discarded wholesale: the parts
+ * of it no winning span covers are kept as masking spans of their own —
+ * otherwise a long low-confidence C1 span (e.g. a free-form address at
+ * score 0.8) that merely brushes a short confidence-1 C0 hit (the postal
+ * code inside it) would silently drop the rest of the address onto the
+ * wire (#361 review finding). Output is sorted by start offset and
+ * non-overlapping.
  */
 export function dedupSpans(
   text: string,
   detected: ReadonlyArray<{ span: PromptPiiSpan; detector: string }>,
 ): ResolvedSpan[] {
-  const extended = detected
+  const extended: ExtendedSpan[] = detected
     .filter(({ span }) => span.end > span.start && span.start >= 0 && span.end <= text.length)
     .map(({ span, detector }) => {
       const { start, end } = extendToWordBoundaries(text, span.start, span.end);
@@ -168,12 +209,27 @@ export function dedupSpans(
         b.confidence - a.confidence || b.end - b.start - (a.end - a.start) || a.start - b.start,
     );
 
-  const kept: typeof extended = [];
+  const kept: ExtendedSpan[] = [];
   for (const candidate of extended) {
-    const overlapping = kept.some(
+    const overlapping = kept.filter(
       (k) => candidate.start < k.end && k.start < candidate.end,
     );
-    if (!overlapping) kept.push(candidate);
+    if (overlapping.length === 0) {
+      kept.push(candidate);
+      continue;
+    }
+    // The candidate loses the contested characters, never its own coverage:
+    // keep every uncovered remainder (re-extended to word boundaries —
+    // kept-span edges already sit on word boundaries, so extension cannot
+    // re-enter a kept span; if it ever would, fall back to the exact
+    // remainder, which is non-overlapping by construction).
+    for (const part of uncoveredParts(candidate, overlapping)) {
+      if (!hasWordChar(text, part.start, part.end)) continue;
+      const grown = extendToWordBoundaries(text, part.start, part.end);
+      const collides = kept.some((k) => grown.start < k.end && k.start < grown.end);
+      const bounds = collides ? part : grown;
+      kept.push({ ...candidate, start: bounds.start, end: bounds.end });
+    }
   }
   return kept
     .sort((a, b) => a.start - b.start)

--- a/middleware/packages/harness-plugin-privacy-guard/src/validation/README.md
+++ b/middleware/packages/harness-plugin-privacy-guard/src/validation/README.md
@@ -66,6 +66,11 @@ and the harness results for that locale must be posted to issue #361 BEFORE
 the flag flips on. A deployment that needs name masking must run the
 `c0+c1` set against the GLiNER sidecar and pass the person gate.
 
+**Recorded run:** the full `c0` / `c0+c1` / `c1-solo` × 6-locale run
+(2026-07-10, pinned model + sidecar defaults) is committed in
+[`RESULTS.md`](./RESULTS.md) — de/en/it pass ALL gates on `c0+c1`;
+es/fr/nl fail on C0 structured locale gaps (details below and there).
+
 ## Fixtures
 
 `fixtures/<locale>.json` — array of items:
@@ -124,19 +129,20 @@ ceiling), and locale ID numbers typed `idnum`.
   out-of-distribution for the candidate model by construction, which is the
   honest go/no-go signal the RFC's in-distribution caveat asks for.
 
-## Known C0 locale gaps (c0-only run, recorded findings)
+## Known C0 locale gaps (recorded run, see RESULTS.md)
 
-The C0 regexes are de/en-centric by design. The 6-locale c0-only run
-reports these honestly rather than the fixtures being softened around them:
+The C0 regexes are de/en-centric by design. The recorded 6-locale run
+([`RESULTS.md`](./RESULTS.md)) reports these honestly rather than the
+fixtures being softened around them:
 
-| Locale | Structured recall (c0) | Main gaps |
+| Locale | Structured recall (c0 / c0+c1) | Main gaps |
 |---|---|---|
-| de | 100% — PASS | — |
-| en | 100% — PASS | — |
-| it | ~99% — PASS | street-only addresses without a postal code (dot-grouped amounts and 5-digit postal codes coincide with the de patterns) |
-| es | ~94% — FAIL | amounts without thousands separator ("899 €"), local phone formats without leading 0/+ ("612 334 455"), street-only addresses |
-| nl | ~85% — FAIL | Dutch addresses (`straat`/`gracht`/`plein` suffixes and 4-digit `1016 AZ` postcodes match nothing), dashed dates ("24-12-1987") |
-| fr | ~75% — FAIL | space-grouped amounts ("2 400 €"), written-out dates ("17 septembre 1984"), street-only addresses |
+| de | 100% / 100% — PASS | — |
+| en | 100% / 100% — PASS | — |
+| it | 99.1% / 100% — PASS | street-only addresses without a postal code (closed by C1; dot-grouped amounts and 5-digit postal codes coincide with the de patterns) |
+| es | 94.4% / 95.4% — FAIL | amounts without thousands separator ("899 €"), local phone formats without leading 0/+ ("612 334 455"), street-only addresses |
+| nl | 85.3% / 96.3% — FAIL | dashed dates ("24-12-1987"); Dutch addresses (`straat`/`gracht`/`plein` suffixes, 4-digit `1016 AZ` postcodes) match no C0 pattern but are fully carried by C1 |
+| fr | 75.0% / 75.9% — FAIL | space-grouped amounts ("2 400 €"), written-out dates ("17 septembre 1984"), street-only addresses |
 
 Where fr/es/it/nl address rows *do* count as masked under c0, it is mostly
 the partial-masking effect described above (the 5-digit postal-code

--- a/middleware/packages/harness-plugin-privacy-guard/src/validation/README.md
+++ b/middleware/packages/harness-plugin-privacy-guard/src/validation/README.md
@@ -8,53 +8,146 @@ below were committed *before* any run.
 ## Run
 
 ```bash
-# from middleware/
+# from middleware/ — C0 regex baseline only:
 npx tsx packages/harness-plugin-privacy-guard/src/validation/promptDetectorEval.ts
+
+# with the GLiNER sidecar (docker-compose.pii-detector.yaml overlay, or a
+# local `python server.py` from middleware/sidecars/pii-detector/) —
+# adds the `c0+c1` and `c1-solo` sets:
+PII_DETECTOR_URL=http://localhost:8812 \
+  npx tsx packages/harness-plugin-privacy-guard/src/validation/promptDetectorEval.ts
+
+# GitHub-flavored markdown output, ready to paste into issue #361:
+PII_DETECTOR_URL=http://localhost:8812 \
+  npx tsx packages/harness-plugin-privacy-guard/src/validation/promptDetectorEval.ts --markdown
 ```
 
-Scores the configured detectors (`C0` regex baseline; add the C1 transformer
-detector to `DETECTOR_SETS` once wired) against the fixture sets, using
-exact-match leak scoring via `v4/onTheWire.ts#findIdentityLeaks`: a PII
-instance counts as masked only when the real value is entirely absent from
-the masked output — any surviving identifying character is a leak.
+Scoring uses exact-match leak scoring via `v4/onTheWire.ts#findIdentityLeaks`:
+a PII instance counts as masked only when the real value is entirely absent
+from the masked output — any surviving verbatim value is a leak. Honest
+caveat that cuts the other way: a long value that is only *partially* masked
+(e.g. the postal-code fragment of a free-form address) already counts as
+masked under this criterion, because the full verbatim string is gone.
+Surviving fragments are exactly what the C1 tier exists to catch — compare
+the `c0` vs `c0+c1` address/person rows.
+
+## Detector sets
+
+| Set | Detectors | Gated? |
+|---|---|---|
+| `c0` | regex baseline (`createBaselineDetector`) | structured gates only |
+| `c0+c1` | baseline + GLiNER sidecar (`createC1HttpDetector`, requires `PII_DETECTOR_URL`) | ALL gates incl. person recall |
+| `c1-solo` | GLiNER sidecar alone | never — ablation for marginal-contribution analysis |
+
+One un-timed warm-up call runs per set before measurement so sidecar/session
+warm-up never pollutes the p95 latency numbers. The harness uses a 10 s C1
+timeout (vs the runtime's 1500 ms) deliberately: it measures quality and
+*reports* latency against the gate instead of converting a slow sidecar into
+thrown timeouts.
 
 ## Pre-committed gates (per locale × detector set)
 
 | Metric | Gate |
 |---|---|
 | Recall, structured identifiers (email, IBAN, phone, amount, date, address) | ≥ 0.97 |
-| Recall, names / free-form entities (`person`) | ≥ 0.90 (requires C1 — C0 does not detect names) |
+| Recall, names / free-form entities (`person`) | ≥ 0.90 — enforced on the `c0+c1` set (C0 does not detect names) |
 | Precision proxy (spans flagged on PII-free negatives) | ≥ 0.85 |
 | Added latency, p95 per prompt | ≤ 400 ms |
 
-**Flag policy:** `mask_user_prompt` may be enabled only for locales whose
-fixture set passes ALL gates with the shipped detector set, and the harness
-results for that locale must be posted to issue #361 BEFORE the flag flips
-on. C0 alone gates on structured identifiers only — a deployment that needs
-name masking must wire a C1 detector (the shipped C1 slot is an inert stub)
-and re-run. Current coverage: `de` + `en` fixtures, C0 tier only.
+`idnum` spans (locale ID numbers: Steuer-ID, NINO, NIE/DNI, codice fiscale,
+BSN, n° de sécurité sociale) are measured **informationally only and never
+gated in v1**: C0 has no patterns for them and C1's calibrated label set is
+`person`/`address`. If a run shows Critical-tier `idnum` leaks in practice,
+locale ID regexes are the recorded fast-follow.
+
+**Flag policy (unchanged):** `mask_user_prompt` may be enabled only for
+locales whose fixture set passes ALL gates with the shipped detector set,
+and the harness results for that locale must be posted to issue #361 BEFORE
+the flag flips on. A deployment that needs name masking must run the
+`c0+c1` set against the GLiNER sidecar and pass the person gate.
 
 ## Fixtures
 
 `fixtures/<locale>.json` — array of items:
 
 ```json
-{ "text": "…prompt…", "spans": [{ "value": "anna@firma.de", "type": "email", "tier": "high" }] }
+{
+  "text": "…prompt…",
+  "spans": [{ "value": "anna@firma.de", "type": "email", "tier": "high" }],
+  "origin": "hand"
+}
 ```
 
 - Items with `spans: []` are **negatives** (PII-free) and feed the
   over-masking measurement.
-- `de` and `en` ship hand-built slices, including the documented NER-sidecar
-  failure modes from `plugin-api/src/piiAnnotation.ts` (partial German
-  names, "Krankheit"→ADDRESS-class false positives) — any C1 candidate must
-  clear exactly these before a go verdict.
-- `fr` / `es` / `it` / `nl` are **not yet populated** — per the RFC these
-  locales need an ai4privacy-derived backbone plus a native-speaker-checked
-  hand slice before their flag may flip on.
+- `origin` is optional: `"hand"` marks the hand-built out-of-distribution
+  slice; absent means `"synthetic"` (LLM-generated backbone). The
+  **hand-slice person recall is the go/no-go signal** (see caveat below);
+  the harness reports it separately from overall recall.
+- Every span `value` must occur verbatim in `text`; types and tiers must be
+  from the known sets; duplicate items are rejected. The harness lints all
+  fixture files at load time and fails the whole run loudly on any
+  violation.
+
+### Coverage (per locale)
+
+| Locale | Items | Positives | Negatives | Hand slice |
+|---|---|---|---|---|
+| de | 121 | 89 | 32 (26%) | 25 |
+| en | 121 | 89 | 32 (26%) | 25 |
+| fr | 121 | 89 | 32 (26%) | 25 |
+| es | 121 | 89 | 32 (26%) | 25 |
+| it | 121 | 89 | 32 (26%) | 25 |
+| nl | 121 | 89 | 32 (26%) | 25 |
+
+Hand slices include the documented NER-sidecar failure modes from
+`plugin-api/src/piiAnnotation.ts` (partial German names, "Krankheit"-class
+false positives), German capitalized common nouns as person-FP bait,
+multi-part Spanish surnames, French particle names (de/du/d'), Dutch
+tussenvoegsel names ("Jan van der Berg"), Italian names adjacent to
+codice-fiscale-shaped strings, adjacent distinct persons in one sentence,
+free-form addresses longer than 12 words (probes GLiNER's span-width
+ceiling), and locale ID numbers typed `idnum`.
+
+### Provenance & licensing (hard rule)
+
+- All committed fixtures are **original**: hand-built items plus
+  LLM-generated synthetic chat prompts in the ai4privacy *style*. **No
+  ai4privacy rows or derivatives are committed** — `pii-masking-300k`
+  carries restricted commercial terms, and committed derivatives would
+  contaminate the repo. ai4privacy may be used as a **local, uncommitted**
+  supplementary check only.
+- `fr` / `es` / `it` / `nl` fixtures are LLM-generated with a
+  **native-speaker spot-check pending** — a standing caveat on those
+  locales' go/no-go verdicts until cleared.
+- Side effect of the originality rule: the committed set is
+  out-of-distribution for the candidate model by construction, which is the
+  honest go/no-go signal the RFC's in-distribution caveat asks for.
+
+## Known C0 locale gaps (c0-only run, recorded findings)
+
+The C0 regexes are de/en-centric by design. The 6-locale c0-only run
+reports these honestly rather than the fixtures being softened around them:
+
+| Locale | Structured recall (c0) | Main gaps |
+|---|---|---|
+| de | 100% — PASS | — |
+| en | 100% — PASS | — |
+| it | ~99% — PASS | street-only addresses without a postal code (dot-grouped amounts and 5-digit postal codes coincide with the de patterns) |
+| es | ~94% — FAIL | amounts without thousands separator ("899 €"), local phone formats without leading 0/+ ("612 334 455"), street-only addresses |
+| nl | ~85% — FAIL | Dutch addresses (`straat`/`gracht`/`plein` suffixes and 4-digit `1016 AZ` postcodes match nothing), dashed dates ("24-12-1987") |
+| fr | ~75% — FAIL | space-grouped amounts ("2 400 €"), written-out dates ("17 septembre 1984"), street-only addresses |
+
+Where fr/es/it/nl address rows *do* count as masked under c0, it is mostly
+the partial-masking effect described above (the 5-digit postal-code
+fragment matches the de pattern and breaks the full value) — not genuine
+street-address detection. These gaps are part of what the per-locale flag
+policy protects against: a locale whose structured identifiers C0 cannot
+carry does not flip on, C1 or not.
 
 ## Honest-measurement caveat (from the RFC)
 
-Piiranha-class models are trained on ai4privacy-style data; evaluating them
-on ai4privacy items is partially in-distribution and inflates numbers. The
-go/no-go signal is the hand-built out-of-distribution slice in these
-fixtures, not a public-benchmark score.
+Transformer PII models are trained on ai4privacy-style data; evaluating
+them on in-distribution items inflates numbers. The go/no-go signal is the
+hand-built out-of-distribution slice in these fixtures (reported separately
+as "hand-slice" person recall), not a public-benchmark score.

--- a/middleware/packages/harness-plugin-privacy-guard/src/validation/RESULTS.md
+++ b/middleware/packages/harness-plugin-privacy-guard/src/validation/RESULTS.md
@@ -467,4 +467,3 @@ Detector sets: `c0`, `c0+c1`, `c1-solo`.
 | p95 added latency | 42.3 ms | ≤ 400 ms | not gated |
 
 **Verdict** (ablation — reported, never gated): n/a
-

--- a/middleware/packages/harness-plugin-privacy-guard/src/validation/RESULTS.md
+++ b/middleware/packages/harness-plugin-privacy-guard/src/validation/RESULTS.md
@@ -1,0 +1,470 @@
+# Recorded prompt-PII validation run (#361)
+
+Full `c0` / `c0+c1` / `c1-solo` × 6-locale run of the harness in this
+directory (`promptDetectorEval.ts --markdown`, verbatim output below).
+Gates were committed in `README.md` before this run; nothing was tuned
+afterwards. These are the tables to post to issue #361 — per the flag
+policy, a locale's results must be on the issue before `mask_user_prompt`
+flips on for it.
+
+## Run environment
+
+| | |
+|---|---|
+| Date | 2026-07-10 |
+| Model | `onnx-community/gliner_multi_pii-v1` @ `2e0397a7e8a250d76c37122232b3cbde42c8d629` (pinned) |
+| Backend | ONNX, `onnx/model_quantized.onnx` (sidecar default) |
+| Runtime | `gliner` 0.2.27, `onnxruntime` 1.27.0, Python 3.13 — the pins from `middleware/sidecars/pii-detector/requirements.txt` |
+| Labels / threshold | `person,address` / `0.5` (sidecar defaults) |
+| Sidecar | `server.py` local, loopback `http://localhost:8812` |
+| Host | Apple M4 Max, CPU inference |
+| Code state | includes the dedup remainder fix (losing overlap spans keep their uncovered parts) — this run measures the shipped masking path |
+
+**Latency caveat:** the p95 numbers below are loopback-to-a-local-sidecar on
+developer hardware. The ≤ 400 ms gate must be re-confirmed on the target
+deployment (compose network, production CPU) before a latency-sensitive
+install relies on it; detection *quality* numbers are hardware-independent.
+
+## Verdict summary
+
+| Locale | `c0` (structured gates) | `c0+c1` (ALL gates) | Blocking gap |
+|---|---|---|---|
+| de | PASS | **PASS** | — |
+| en | PASS | **PASS** | — |
+| it | PASS | **PASS** | — |
+| es | FAIL (structured 94.4%) | FAIL (structured 95.4%) | C0: separator-less amounts ("899 €"), local phone formats |
+| fr | FAIL (structured 75.0%) | FAIL (structured 75.9%) | C0: space-grouped amounts ("2 400 €"), written-out dates |
+| nl | FAIL (structured 85.3%) | FAIL (structured 96.3%) | C0: dashed dates ("24-12-1987"); addresses are carried by C1 |
+
+- **de / en / it pass ALL gates on `c0+c1`** — person recall 100% incl. the
+  hand-built OOD slice, precision proxy ≥ 87.5%, p95 ≤ 85.2 ms. These
+  locales are eligible for `mask_user_prompt` once these tables are posted
+  to #361.
+- **es / fr / nl stay off** — every failure is a *C0 structured-identifier*
+  locale gap (recorded per locale below), not a C1 quality problem. Closing
+  them means locale-aware C0 patterns (amounts, dates, phones), a recorded
+  fast-follow — C1 already carries `person` at 100% and lifts `address` to
+  100% in all six locales.
+- **nl person recall is 100%** even though the GLiNER fine-tune's language
+  card does not list Dutch — the gate policy absorbed the risk, and the
+  measurement (not the model card) decides. The structured `date` gap keeps
+  nl off regardless.
+- `c1-solo` confirms the division of labor: GLiNER alone collapses on
+  structured identifiers (20–25% structured recall) — C0 stays load-bearing;
+  C1 is additive, never a replacement.
+- fr/es/it/nl fixtures still carry the standing **native-speaker spot-check
+  pending** caveat from `README.md`.
+
+## Harness output (verbatim)
+
+Detector sets: `c0`, `c0+c1`, `c1-solo`.
+
+
+## de
+
+### Set `c0`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 20/20 | 100.0% | 4/4 (100.0%) | structured |
+| amount | 26/26 | 100.0% | 2/2 (100.0%) | structured |
+| date | 19/19 | 100.0% | 3/3 (100.0%) | structured |
+| email | 22/22 | 100.0% | 2/2 (100.0%) | structured |
+| iban | 14/14 | 100.0% | 2/2 (100.0%) | structured |
+| idnum | 0/1 | 0.0% | 0/1 (0.0%) | informational — ungated in v1 |
+| person | 0/64 | 0.0% | 0/16 (0.0%) | c1-scope |
+| phone | 14/14 | 100.0% | 2/2 (100.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 100.0% | ≥ 97% | PASS |
+| person recall | 0.0% | ≥ 90% | not gated |
+| precision proxy (negatives clean) | 32/32 (100.0%) | ≥ 85% | PASS |
+| p95 added latency | 0.0 ms | ≤ 400 ms | PASS |
+
+**Verdict** (structured-identifier gates only): **PASS**
+
+### Set `c0+c1`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 20/20 | 100.0% | 4/4 (100.0%) | structured |
+| amount | 26/26 | 100.0% | 2/2 (100.0%) | structured |
+| date | 19/19 | 100.0% | 3/3 (100.0%) | structured |
+| email | 22/22 | 100.0% | 2/2 (100.0%) | structured |
+| iban | 14/14 | 100.0% | 2/2 (100.0%) | structured |
+| idnum | 0/1 | 0.0% | 0/1 (0.0%) | informational — ungated in v1 |
+| person | 64/64 | 100.0% | 16/16 (100.0%) | c1-scope |
+| phone | 14/14 | 100.0% | 2/2 (100.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 100.0% | ≥ 97% | PASS |
+| person recall | 100.0% | ≥ 90% | PASS |
+| precision proxy (negatives clean) | 28/32 (87.5%) | ≥ 85% | PASS |
+| p95 added latency | 19.5 ms | ≤ 400 ms | PASS |
+
+**Verdict** (all gates incl. person recall): **PASS**
+
+### Set `c1-solo`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 20/20 | 100.0% | 4/4 (100.0%) | structured |
+| amount | 0/26 | 0.0% | 0/2 (0.0%) | structured |
+| date | 0/19 | 0.0% | 0/3 (0.0%) | structured |
+| email | 4/22 | 18.2% | 1/2 (50.0%) | structured |
+| iban | 5/14 | 35.7% | 0/2 (0.0%) | structured |
+| idnum | 0/1 | 0.0% | 0/1 (0.0%) | informational — ungated in v1 |
+| person | 64/64 | 100.0% | 16/16 (100.0%) | c1-scope |
+| phone | 0/14 | 0.0% | 0/2 (0.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 25.2% | ≥ 97% | not gated |
+| person recall | 100.0% | ≥ 90% | not gated |
+| precision proxy (negatives clean) | 28/32 (87.5%) | ≥ 85% | not gated |
+| p95 added latency | 59.9 ms | ≤ 400 ms | not gated |
+
+**Verdict** (ablation — reported, never gated): n/a
+
+## en
+
+### Set `c0`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 19/19 | 100.0% | 3/3 (100.0%) | structured |
+| amount | 26/26 | 100.0% | 2/2 (100.0%) | structured |
+| date | 18/18 | 100.0% | 2/2 (100.0%) | structured |
+| email | 22/22 | 100.0% | 2/2 (100.0%) | structured |
+| iban | 13/13 | 100.0% | 1/1 (100.0%) | structured |
+| idnum | 0/1 | 0.0% | 0/1 (0.0%) | informational — ungated in v1 |
+| person | 0/64 | 0.0% | 0/16 (0.0%) | c1-scope |
+| phone | 14/14 | 100.0% | 2/2 (100.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 100.0% | ≥ 97% | PASS |
+| person recall | 0.0% | ≥ 90% | not gated |
+| precision proxy (negatives clean) | 32/32 (100.0%) | ≥ 85% | PASS |
+| p95 added latency | 0.0 ms | ≤ 400 ms | PASS |
+
+**Verdict** (structured-identifier gates only): **PASS**
+
+### Set `c0+c1`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 19/19 | 100.0% | 3/3 (100.0%) | structured |
+| amount | 26/26 | 100.0% | 2/2 (100.0%) | structured |
+| date | 18/18 | 100.0% | 2/2 (100.0%) | structured |
+| email | 22/22 | 100.0% | 2/2 (100.0%) | structured |
+| iban | 13/13 | 100.0% | 1/1 (100.0%) | structured |
+| idnum | 0/1 | 0.0% | 0/1 (0.0%) | informational — ungated in v1 |
+| person | 64/64 | 100.0% | 16/16 (100.0%) | c1-scope |
+| phone | 14/14 | 100.0% | 2/2 (100.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 100.0% | ≥ 97% | PASS |
+| person recall | 100.0% | ≥ 90% | PASS |
+| precision proxy (negatives clean) | 30/32 (93.8%) | ≥ 85% | PASS |
+| p95 added latency | 18.6 ms | ≤ 400 ms | PASS |
+
+**Verdict** (all gates incl. person recall): **PASS**
+
+### Set `c1-solo`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 19/19 | 100.0% | 3/3 (100.0%) | structured |
+| amount | 0/26 | 0.0% | 0/2 (0.0%) | structured |
+| date | 0/18 | 0.0% | 0/2 (0.0%) | structured |
+| email | 6/22 | 27.3% | 1/2 (50.0%) | structured |
+| iban | 0/13 | 0.0% | 0/1 (0.0%) | structured |
+| idnum | 0/1 | 0.0% | 0/1 (0.0%) | informational — ungated in v1 |
+| person | 64/64 | 100.0% | 16/16 (100.0%) | c1-scope |
+| phone | 2/14 | 14.3% | 0/2 (0.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 24.1% | ≥ 97% | not gated |
+| person recall | 100.0% | ≥ 90% | not gated |
+| precision proxy (negatives clean) | 30/32 (93.8%) | ≥ 85% | not gated |
+| p95 added latency | 93.5 ms | ≤ 400 ms | not gated |
+
+**Verdict** (ablation — reported, never gated): n/a
+
+## es
+
+### Set `c0`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 17/18 | 94.4% | 1/2 (50.0%) | structured |
+| amount | 21/25 | 84.0% | 1/1 (100.0%) | structured |
+| date | 17/17 | 100.0% | 1/1 (100.0%) | structured |
+| email | 22/22 | 100.0% | 2/2 (100.0%) | structured |
+| iban | 13/13 | 100.0% | 1/1 (100.0%) | structured |
+| idnum | 0/2 | 0.0% | 0/2 (0.0%) | informational — ungated in v1 |
+| person | 0/66 | 0.0% | 0/18 (0.0%) | c1-scope |
+| phone | 12/13 | 92.3% | 0/1 (0.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 94.4% | ≥ 97% | FAIL |
+| person recall | 0.0% | ≥ 90% | not gated |
+| precision proxy (negatives clean) | 32/32 (100.0%) | ≥ 85% | PASS |
+| p95 added latency | 0.0 ms | ≤ 400 ms | PASS |
+
+**Verdict** (structured-identifier gates only): **FAIL**
+
+### Set `c0+c1`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 18/18 | 100.0% | 2/2 (100.0%) | structured |
+| amount | 21/25 | 84.0% | 1/1 (100.0%) | structured |
+| date | 17/17 | 100.0% | 1/1 (100.0%) | structured |
+| email | 22/22 | 100.0% | 2/2 (100.0%) | structured |
+| iban | 13/13 | 100.0% | 1/1 (100.0%) | structured |
+| idnum | 0/2 | 0.0% | 0/2 (0.0%) | informational — ungated in v1 |
+| person | 66/66 | 100.0% | 18/18 (100.0%) | c1-scope |
+| phone | 12/13 | 92.3% | 0/1 (0.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 95.4% | ≥ 97% | FAIL |
+| person recall | 100.0% | ≥ 90% | PASS |
+| precision proxy (negatives clean) | 31/32 (96.9%) | ≥ 85% | PASS |
+| p95 added latency | 49.9 ms | ≤ 400 ms | PASS |
+
+**Verdict** (all gates incl. person recall): **FAIL**
+
+### Set `c1-solo`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 17/18 | 94.4% | 1/2 (50.0%) | structured |
+| amount | 0/25 | 0.0% | 0/1 (0.0%) | structured |
+| date | 0/17 | 0.0% | 0/1 (0.0%) | structured |
+| email | 6/22 | 27.3% | 0/2 (0.0%) | structured |
+| iban | 0/13 | 0.0% | 0/1 (0.0%) | structured |
+| idnum | 0/2 | 0.0% | 0/2 (0.0%) | informational — ungated in v1 |
+| person | 66/66 | 100.0% | 18/18 (100.0%) | c1-scope |
+| phone | 0/13 | 0.0% | 0/1 (0.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 21.3% | ≥ 97% | not gated |
+| person recall | 100.0% | ≥ 90% | not gated |
+| precision proxy (negatives clean) | 31/32 (96.9%) | ≥ 85% | not gated |
+| p95 added latency | 61.0 ms | ≤ 400 ms | not gated |
+
+**Verdict** (ablation — reported, never gated): n/a
+
+## fr
+
+### Set `c0`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 17/18 | 94.4% | 1/2 (50.0%) | structured |
+| amount | 0/25 | 0.0% | 0/1 (0.0%) | structured |
+| date | 17/18 | 94.4% | 1/2 (50.0%) | structured |
+| email | 21/21 | 100.0% | 1/1 (100.0%) | structured |
+| iban | 13/13 | 100.0% | 1/1 (100.0%) | structured |
+| idnum | 0/1 | 0.0% | 0/1 (0.0%) | informational — ungated in v1 |
+| person | 0/66 | 0.0% | 0/18 (0.0%) | c1-scope |
+| phone | 13/13 | 100.0% | 1/1 (100.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 75.0% | ≥ 97% | FAIL |
+| person recall | 0.0% | ≥ 90% | not gated |
+| precision proxy (negatives clean) | 32/32 (100.0%) | ≥ 85% | PASS |
+| p95 added latency | 0.0 ms | ≤ 400 ms | PASS |
+
+**Verdict** (structured-identifier gates only): **FAIL**
+
+### Set `c0+c1`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 18/18 | 100.0% | 2/2 (100.0%) | structured |
+| amount | 0/25 | 0.0% | 0/1 (0.0%) | structured |
+| date | 17/18 | 94.4% | 1/2 (50.0%) | structured |
+| email | 21/21 | 100.0% | 1/1 (100.0%) | structured |
+| iban | 13/13 | 100.0% | 1/1 (100.0%) | structured |
+| idnum | 0/1 | 0.0% | 0/1 (0.0%) | informational — ungated in v1 |
+| person | 66/66 | 100.0% | 18/18 (100.0%) | c1-scope |
+| phone | 13/13 | 100.0% | 1/1 (100.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 75.9% | ≥ 97% | FAIL |
+| person recall | 100.0% | ≥ 90% | PASS |
+| precision proxy (negatives clean) | 30/32 (93.8%) | ≥ 85% | PASS |
+| p95 added latency | 115.6 ms | ≤ 400 ms | PASS |
+
+**Verdict** (all gates incl. person recall): **FAIL**
+
+### Set `c1-solo`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 18/18 | 100.0% | 2/2 (100.0%) | structured |
+| amount | 0/25 | 0.0% | 0/1 (0.0%) | structured |
+| date | 0/18 | 0.0% | 0/2 (0.0%) | structured |
+| email | 4/21 | 19.0% | 0/1 (0.0%) | structured |
+| iban | 0/13 | 0.0% | 0/1 (0.0%) | structured |
+| idnum | 0/1 | 0.0% | 0/1 (0.0%) | informational — ungated in v1 |
+| person | 66/66 | 100.0% | 18/18 (100.0%) | c1-scope |
+| phone | 0/13 | 0.0% | 0/1 (0.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 20.4% | ≥ 97% | not gated |
+| person recall | 100.0% | ≥ 90% | not gated |
+| precision proxy (negatives clean) | 30/32 (93.8%) | ≥ 85% | not gated |
+| p95 added latency | 38.0 ms | ≤ 400 ms | not gated |
+
+**Verdict** (ablation — reported, never gated): n/a
+
+## it
+
+### Set `c0`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 18/19 | 94.7% | 2/3 (66.7%) | structured |
+| amount | 25/25 | 100.0% | 1/1 (100.0%) | structured |
+| date | 17/17 | 100.0% | 1/1 (100.0%) | structured |
+| email | 21/21 | 100.0% | 1/1 (100.0%) | structured |
+| iban | 13/13 | 100.0% | 1/1 (100.0%) | structured |
+| idnum | 0/2 | 0.0% | 0/2 (0.0%) | informational — ungated in v1 |
+| person | 0/66 | 0.0% | 0/18 (0.0%) | c1-scope |
+| phone | 13/13 | 100.0% | 1/1 (100.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 99.1% | ≥ 97% | PASS |
+| person recall | 0.0% | ≥ 90% | not gated |
+| precision proxy (negatives clean) | 32/32 (100.0%) | ≥ 85% | PASS |
+| p95 added latency | 0.0 ms | ≤ 400 ms | PASS |
+
+**Verdict** (structured-identifier gates only): **PASS**
+
+### Set `c0+c1`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 19/19 | 100.0% | 3/3 (100.0%) | structured |
+| amount | 25/25 | 100.0% | 1/1 (100.0%) | structured |
+| date | 17/17 | 100.0% | 1/1 (100.0%) | structured |
+| email | 21/21 | 100.0% | 1/1 (100.0%) | structured |
+| iban | 13/13 | 100.0% | 1/1 (100.0%) | structured |
+| idnum | 0/2 | 0.0% | 0/2 (0.0%) | informational — ungated in v1 |
+| person | 66/66 | 100.0% | 18/18 (100.0%) | c1-scope |
+| phone | 13/13 | 100.0% | 1/1 (100.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 100.0% | ≥ 97% | PASS |
+| person recall | 100.0% | ≥ 90% | PASS |
+| precision proxy (negatives clean) | 30/32 (93.8%) | ≥ 85% | PASS |
+| p95 added latency | 85.2 ms | ≤ 400 ms | PASS |
+
+**Verdict** (all gates incl. person recall): **PASS**
+
+### Set `c1-solo`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 18/19 | 94.7% | 2/3 (66.7%) | structured |
+| amount | 0/25 | 0.0% | 0/1 (0.0%) | structured |
+| date | 0/17 | 0.0% | 0/1 (0.0%) | structured |
+| email | 4/21 | 19.0% | 0/1 (0.0%) | structured |
+| iban | 0/13 | 0.0% | 0/1 (0.0%) | structured |
+| idnum | 0/2 | 0.0% | 0/2 (0.0%) | informational — ungated in v1 |
+| person | 66/66 | 100.0% | 18/18 (100.0%) | c1-scope |
+| phone | 0/13 | 0.0% | 0/1 (0.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 20.4% | ≥ 97% | not gated |
+| person recall | 100.0% | ≥ 90% | not gated |
+| precision proxy (negatives clean) | 30/32 (93.8%) | ≥ 85% | not gated |
+| p95 added latency | 38.6 ms | ≤ 400 ms | not gated |
+
+**Verdict** (ablation — reported, never gated): n/a
+
+## nl
+
+### Set `c0`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 7/19 | 36.8% | 1/3 (33.3%) | structured |
+| amount | 25/25 | 100.0% | 1/1 (100.0%) | structured |
+| date | 14/18 | 77.8% | 2/2 (100.0%) | structured |
+| email | 21/21 | 100.0% | 1/1 (100.0%) | structured |
+| iban | 13/13 | 100.0% | 1/1 (100.0%) | structured |
+| idnum | 0/1 | 0.0% | 0/1 (0.0%) | informational — ungated in v1 |
+| person | 0/66 | 0.0% | 0/18 (0.0%) | c1-scope |
+| phone | 13/13 | 100.0% | 1/1 (100.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 85.3% | ≥ 97% | FAIL |
+| person recall | 0.0% | ≥ 90% | not gated |
+| precision proxy (negatives clean) | 32/32 (100.0%) | ≥ 85% | PASS |
+| p95 added latency | 0.0 ms | ≤ 400 ms | PASS |
+
+**Verdict** (structured-identifier gates only): **FAIL**
+
+### Set `c0+c1`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 19/19 | 100.0% | 3/3 (100.0%) | structured |
+| amount | 25/25 | 100.0% | 1/1 (100.0%) | structured |
+| date | 14/18 | 77.8% | 2/2 (100.0%) | structured |
+| email | 21/21 | 100.0% | 1/1 (100.0%) | structured |
+| iban | 13/13 | 100.0% | 1/1 (100.0%) | structured |
+| idnum | 0/1 | 0.0% | 0/1 (0.0%) | informational — ungated in v1 |
+| person | 66/66 | 100.0% | 18/18 (100.0%) | c1-scope |
+| phone | 13/13 | 100.0% | 1/1 (100.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 96.3% | ≥ 97% | FAIL |
+| person recall | 100.0% | ≥ 90% | PASS |
+| precision proxy (negatives clean) | 28/32 (87.5%) | ≥ 85% | PASS |
+| p95 added latency | 77.5 ms | ≤ 400 ms | PASS |
+
+**Verdict** (all gates incl. person recall): **FAIL**
+
+### Set `c1-solo`
+
+| Type | Masked/Total | Recall | Hand slice | Scope |
+|---|---|---|---|---|
+| address | 18/19 | 94.7% | 2/3 (66.7%) | structured |
+| amount | 0/25 | 0.0% | 0/1 (0.0%) | structured |
+| date | 0/18 | 0.0% | 0/2 (0.0%) | structured |
+| email | 5/21 | 23.8% | 0/1 (0.0%) | structured |
+| iban | 0/13 | 0.0% | 0/1 (0.0%) | structured |
+| idnum | 0/1 | 0.0% | 0/1 (0.0%) | informational — ungated in v1 |
+| person | 66/66 | 100.0% | 18/18 (100.0%) | c1-scope |
+| phone | 0/13 | 0.0% | 0/1 (0.0%) | structured |
+
+| Gate | Value | Threshold | Status |
+|---|---|---|---|
+| structured recall | 21.1% | ≥ 97% | not gated |
+| person recall | 100.0% | ≥ 90% | not gated |
+| precision proxy (negatives clean) | 28/32 (87.5%) | ≥ 85% | not gated |
+| p95 added latency | 42.3 ms | ≤ 400 ms | not gated |
+
+**Verdict** (ablation — reported, never gated): n/a
+

--- a/middleware/packages/harness-plugin-privacy-guard/src/validation/fixtures/de.json
+++ b/middleware/packages/harness-plugin-privacy-guard/src/validation/fixtures/de.json
@@ -2,36 +2,1404 @@
   {
     "text": "Was sollten wir Anna Schmidt (32, wohnhaft Bahnhofstr. 5, 60311 Frankfurt) zahlen, ausgehend von ihrem aktuellen Gehalt von €72.000?",
     "spans": [
-      { "value": "Anna Schmidt", "type": "person", "tier": "high" },
-      { "value": "Bahnhofstr. 5, 60311 Frankfurt", "type": "address", "tier": "high" },
-      { "value": "€72.000", "type": "amount", "tier": "critical" }
-    ]
+      {
+        "value": "Anna Schmidt",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Bahnhofstr. 5, 60311 Frankfurt",
+        "type": "address",
+        "tier": "high"
+      },
+      {
+        "value": "€72.000",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ],
+    "origin": "hand"
   },
   {
     "text": "Bitte überweise das Gehalt auf DE89 3704 0044 0532 0130 00 und bestätige an m.vomberg@firma-beispiel.de.",
     "spans": [
-      { "value": "DE89 3704 0044 0532 0130 00", "type": "iban", "tier": "critical" },
-      { "value": "m.vomberg@firma-beispiel.de", "type": "email", "tier": "high" }
-    ]
+      {
+        "value": "DE89 3704 0044 0532 0130 00",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "m.vomberg@firma-beispiel.de",
+        "type": "email",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
   },
   {
     "text": "Ruf Marvin Vomberg unter +49 171 5551234 an, er ist am 24.12.1987 geboren.",
     "spans": [
-      { "value": "Marvin Vomberg", "type": "person", "tier": "high" },
-      { "value": "+49 171 5551234", "type": "phone", "tier": "high" },
-      { "value": "24.12.1987", "type": "date", "tier": "high" }
-    ]
+      {
+        "value": "Marvin Vomberg",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+49 171 5551234",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "24.12.1987",
+        "type": "date",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
   },
   {
     "text": "Die Rechnung über 1.250,50 € ging an die Musterallee 12, 10115 Berlin.",
     "spans": [
-      { "value": "1.250,50 €", "type": "amount", "tier": "critical" },
-      { "value": "Musterallee 12, 10115 Berlin", "type": "address", "tier": "high" }
+      {
+        "value": "1.250,50 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Musterallee 12, 10115 Berlin",
+        "type": "address",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Anna Schmidt und Maria Weber teilen sich ab April die Teamleitung — bitte beide Verträge anpassen.",
+    "spans": [
+      {
+        "value": "Anna Schmidt",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Maria Weber",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Frau Schmidt hat die unterschriebenen Unterlagen noch nicht eingereicht — bitte freundlich erinnern.",
+    "spans": [
+      {
+        "value": "Frau Schmidt",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Herr M. Vomberg wartet seit zwei Wochen auf die Rückmeldung zur Gehaltsanpassung.",
+    "spans": [
+      {
+        "value": "M. Vomberg",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Das Paket bitte an das gelbe Hinterhaus im zweiten Hof der Lindenallee 5, dritter Aufgang links, 60311 Frankfurt am Main liefern.",
+    "spans": [
+      {
+        "value": "das gelbe Hinterhaus im zweiten Hof der Lindenallee 5, dritter Aufgang links, 60311 Frankfurt am Main",
+        "type": "address",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Die Steuer-ID von Jonas Weber lautet 86195742719 — bitte in der Personalakte hinterlegen.",
+    "spans": [
+      {
+        "value": "Jonas Weber",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "86195742719",
+        "type": "idnum",
+        "tier": "critical"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Anna Schmidt fällt wegen Krankheit bis 24.10.2026 aus — bitte eine Vertretung organisieren.",
+    "spans": [
+      {
+        "value": "Anna Schmidt",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "24.10.2026",
+        "type": "date",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Katharina von Aue übernimmt ab sofort das Mandat der Kanzlei.",
+    "spans": [
+      {
+        "value": "Katharina von Aue",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Zum Offsite kommen Erik Wagner, Petra Sonntag und Felix Brandt.",
+    "spans": [
+      {
+        "value": "Erik Wagner",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Petra Sonntag",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Felix Brandt",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Unsere Ansprechpartnerin heißt Gül Yilmaz, erreichbar unter +49 159 04412875.",
+    "spans": [
+      {
+        "value": "Gül Yilmaz",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+49 159 04412875",
+        "type": "phone",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Die Betriebsfeier findet im Vereinsheim hinter dem alten Wasserturm an der Feldgasse 2, Eingang über den Parkplatz an der Rückseite, 24103 Kiel statt.",
+    "spans": [
+      {
+        "value": "im Vereinsheim hinter dem alten Wasserturm an der Feldgasse 2, Eingang über den Parkplatz an der Rückseite, 24103 Kiel",
+        "type": "address",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Bitte überweise die offene Provision an Miriam Schulz, IBAN DE21 3012 0400 0000 0152 28.",
+    "spans": [
+      {
+        "value": "Miriam Schulz",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "DE21 3012 0400 0000 0152 28",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Der Mietvertrag der Werkswohnung von Herrn Kaminski läuft zum 31.03.2027 aus.",
+    "spans": [
+      {
+        "value": "Herrn Kaminski",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "31.03.2027",
+        "type": "date",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Bitte lade aylin.demir@beispiel-gmbh.de zum Kickoff ein — sie vertritt Herrn Öztürk.",
+    "spans": [
+      {
+        "value": "aylin.demir@beispiel-gmbh.de",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "Herrn Öztürk",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Was sollten wir Miriam Schulz zahlen, wenn sie aktuell 12.750,00 € verdient?",
+    "spans": [
+      {
+        "value": "Miriam Schulz",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "12.750,00 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Was sollten wir Daniel Roth zahlen, wenn sie aktuell €58.500 verdient?",
+    "spans": [
+      {
+        "value": "Daniel Roth",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "€58.500",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Was sollten wir Carola Wendt zahlen, wenn sie aktuell €899 verdient?",
+    "spans": [
+      {
+        "value": "Carola Wendt",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "€899",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Was sollten wir Daniel Roth zahlen, wenn sie aktuell 15.000 € verdient?",
+    "spans": [
+      {
+        "value": "Daniel Roth",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "15.000 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Bitte überweise die Abschlagszahlung auf DE89 3704 0044 0532 0130 00 und bestätige an personal@krause-logistik.de.",
+    "spans": [
+      {
+        "value": "DE89 3704 0044 0532 0130 00",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "personal@krause-logistik.de",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bitte überweise die Abschlagszahlung auf DE75 5121 0800 1245 1261 99 und bestätige an m.schulz@web-beispiel.de.",
+    "spans": [
+      {
+        "value": "DE75 5121 0800 1245 1261 99",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "m.schulz@web-beispiel.de",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bitte überweise die Abschlagszahlung auf DE27 1007 7777 0209 2997 00 und bestätige an k.hoffmann@beispiel-gmbh.de.",
+    "spans": [
+      {
+        "value": "DE27 1007 7777 0209 2997 00",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "k.hoffmann@beispiel-gmbh.de",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bitte überweise die Abschlagszahlung auf DE44 5001 0517 5407 3249 31 und bestätige an j.steinbach@rheintal-it.de.",
+    "spans": [
+      {
+        "value": "DE44 5001 0517 5407 3249 31",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "j.steinbach@rheintal-it.de",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Ruf Andreas Kellner unter 089 5540 2218 an — Geburtsdatum 05.03.2001.",
+    "spans": [
+      {
+        "value": "Andreas Kellner",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "089 5540 2218",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "05.03.2001",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Ruf Vanessa Kluge unter 0221 9987 4451 an — Geburtsdatum 05.03.2001.",
+    "spans": [
+      {
+        "value": "Vanessa Kluge",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "0221 9987 4451",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "05.03.2001",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Ruf Carola Wendt unter +49 30 4478120 an — Geburtsdatum 28.02.1995.",
+    "spans": [
+      {
+        "value": "Carola Wendt",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+49 30 4478120",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "28.02.1995",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Ruf Miriam Schulz unter +49 152 28871190 an — Geburtsdatum 05.03.2001.",
+    "spans": [
+      {
+        "value": "Miriam Schulz",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+49 152 28871190",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "05.03.2001",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Die Rechnung über €67.200 geht an die Adresse Mühlenring 4, 24103 Kiel.",
+    "spans": [
+      {
+        "value": "€67.200",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Mühlenring 4, 24103 Kiel",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Die Rechnung über 3.499,99 € geht an die Adresse Mühlenring 4, 24103 Kiel.",
+    "spans": [
+      {
+        "value": "3.499,99 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Mühlenring 4, 24103 Kiel",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Die Rechnung über 62.400 € geht an die Adresse Marktplatz 3, 80331 München.",
+    "spans": [
+      {
+        "value": "62.400 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Marktplatz 3, 80331 München",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Die Rechnung über 15.000 € geht an die Adresse Hauptstraße 118, 69117 Heidelberg.",
+    "spans": [
+      {
+        "value": "15.000 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Hauptstraße 118, 69117 Heidelberg",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Lege Vanessa Kluge als neuen Mitarbeiter an, Dienst-E-Mail c.neumann@hansa-consult.de.",
+    "spans": [
+      {
+        "value": "Vanessa Kluge",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "c.neumann@hansa-consult.de",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Lege Julia Steinbach als neuen Mitarbeiter an, Dienst-E-Mail rechnung@sonntag-bau.de.",
+    "spans": [
+      {
+        "value": "Julia Steinbach",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "rechnung@sonntag-bau.de",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Lege Miriam Schulz als neuen Mitarbeiter an, Dienst-E-Mail f.brandt@beispielwerk.de.",
+    "spans": [
+      {
+        "value": "Miriam Schulz",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "f.brandt@beispielwerk.de",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Lege Katrin Hoffmann als neuen Mitarbeiter an, Dienst-E-Mail k.hoffmann@beispiel-gmbh.de.",
+    "spans": [
+      {
+        "value": "Katrin Hoffmann",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "k.hoffmann@beispiel-gmbh.de",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Petra Sonntag ist zum 05.03.2001 aus dem Unternehmen ausgeschieden — bitte den Austrittsprozess starten.",
+    "spans": [
+      {
+        "value": "Petra Sonntag",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "05.03.2001",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Franziska Moll ist zum 12.11.1979 aus dem Unternehmen ausgeschieden — bitte den Austrittsprozess starten.",
+    "spans": [
+      {
+        "value": "Franziska Moll",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "12.11.1979",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Petra Sonntag ist zum 17.09.1984 aus dem Unternehmen ausgeschieden — bitte den Austrittsprozess starten.",
+    "spans": [
+      {
+        "value": "Petra Sonntag",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "17.09.1984",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Martin Vogel ist zum 05.03.2001 aus dem Unternehmen ausgeschieden — bitte den Austrittsprozess starten.",
+    "spans": [
+      {
+        "value": "Martin Vogel",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "05.03.2001",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Aktualisiere die Stammdaten: Claudia Neumann wohnt jetzt in der Schillerstr. 22, 60313 Frankfurt.",
+    "spans": [
+      {
+        "value": "Claudia Neumann",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Schillerstr. 22, 60313 Frankfurt",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Aktualisiere die Stammdaten: Vanessa Kluge wohnt jetzt in der Lindenallee 12, 04109 Leipzig.",
+    "spans": [
+      {
+        "value": "Vanessa Kluge",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Lindenallee 12, 04109 Leipzig",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Aktualisiere die Stammdaten: Erik Wagner wohnt jetzt in der Schillerstr. 22, 60313 Frankfurt.",
+    "spans": [
+      {
+        "value": "Erik Wagner",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Schillerstr. 22, 60313 Frankfurt",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Aktualisiere die Stammdaten: Franziska Moll wohnt jetzt in der Lindenallee 12, 04109 Leipzig.",
+    "spans": [
+      {
+        "value": "Franziska Moll",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Lindenallee 12, 04109 Leipzig",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Erstattung der Reisekosten von €899 bitte auf DE27 1007 7777 0209 2997 00.",
+    "spans": [
+      {
+        "value": "€899",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "DE27 1007 7777 0209 2997 00",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Erstattung der Reisekosten von 15.000 € bitte auf DE44 5001 0517 5407 3249 31.",
+    "spans": [
+      {
+        "value": "15.000 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "DE44 5001 0517 5407 3249 31",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Erstattung der Reisekosten von 1.250,50 € bitte auf DE89 3704 0044 0532 0130 00.",
+    "spans": [
+      {
+        "value": "1.250,50 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "DE89 3704 0044 0532 0130 00",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Erstattung der Reisekosten von 62.400 € bitte auf DE12 5001 0517 0648 4898 90.",
+    "spans": [
+      {
+        "value": "62.400 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "DE12 5001 0517 0648 4898 90",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Schick die Gehaltsabrechnung an j.steinbach@rheintal-it.de, das Bruttogehalt beträgt €58.500.",
+    "spans": [
+      {
+        "value": "j.steinbach@rheintal-it.de",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "€58.500",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Schick die Gehaltsabrechnung an j.steinbach@rheintal-it.de, das Bruttogehalt beträgt €72.000.",
+    "spans": [
+      {
+        "value": "j.steinbach@rheintal-it.de",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "€72.000",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Schick die Gehaltsabrechnung an rechnung@sonntag-bau.de, das Bruttogehalt beträgt 15.000 €.",
+    "spans": [
+      {
+        "value": "rechnung@sonntag-bau.de",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "15.000 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Schick die Gehaltsabrechnung an t.krueger@nordwind-ag.de, das Bruttogehalt beträgt €58.500.",
+    "spans": [
+      {
+        "value": "t.krueger@nordwind-ag.de",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "€58.500",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Für die Referenzprüfung erreichst du Matthias Grunow unter +49 30 4478120.",
+    "spans": [
+      {
+        "value": "Matthias Grunow",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+49 30 4478120",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Für die Referenzprüfung erreichst du Felix Brandt unter +49 30 4478120.",
+    "spans": [
+      {
+        "value": "Felix Brandt",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+49 30 4478120",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Für die Referenzprüfung erreichst du Tobias Krüger unter +49 152 28871190.",
+    "spans": [
+      {
+        "value": "Tobias Krüger",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+49 152 28871190",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Für die Referenzprüfung erreichst du Matthias Grunow unter +49 171 5559214.",
+    "spans": [
+      {
+        "value": "Matthias Grunow",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+49 171 5559214",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bitte bereite das Mitarbeitergespräch mit Franziska Moll vor.",
+    "spans": [
+      {
+        "value": "Franziska Moll",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bitte bereite das Mitarbeitergespräch mit Petra Sonntag vor.",
+    "spans": [
+      {
+        "value": "Petra Sonntag",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bitte bereite das Mitarbeitergespräch mit Tobias Krüger vor.",
+    "spans": [
+      {
+        "value": "Tobias Krüger",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bitte bereite das Mitarbeitergespräch mit Heike Sommerfeld vor.",
+    "spans": [
+      {
+        "value": "Heike Sommerfeld",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Petra Sonntag hat sich zum 03.05.1991 krankgemeldet — bitte im HR-Modul erfassen.",
+    "spans": [
+      {
+        "value": "Petra Sonntag",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "03.05.1991",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Matthias Grunow hat sich zum 01.02.2023 krankgemeldet — bitte im HR-Modul erfassen.",
+    "spans": [
+      {
+        "value": "Matthias Grunow",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "01.02.2023",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Sebastian Ehlers hat sich zum 05.03.2001 krankgemeldet — bitte im HR-Modul erfassen.",
+    "spans": [
+      {
+        "value": "Sebastian Ehlers",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "05.03.2001",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Franziska Moll hat sich zum 30.06.2026 krankgemeldet — bitte im HR-Modul erfassen.",
+    "spans": [
+      {
+        "value": "Franziska Moll",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "30.06.2026",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Der Lieferant möchte die Zahlung von €899 auf DE12 5001 0517 0648 4898 90 erhalten.",
+    "spans": [
+      {
+        "value": "€899",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "DE12 5001 0517 0648 4898 90",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Der Lieferant möchte die Zahlung von €67.200 auf DE89 3704 0044 0532 0130 00 erhalten.",
+    "spans": [
+      {
+        "value": "€67.200",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "DE89 3704 0044 0532 0130 00",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Der Lieferant möchte die Zahlung von €72.000 auf DE27 1007 7777 0209 2997 00 erhalten.",
+    "spans": [
+      {
+        "value": "€72.000",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "DE27 1007 7777 0209 2997 00",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Der Lieferant möchte die Zahlung von 15.000 € auf DE89 3704 0044 0532 0130 00 erhalten.",
+    "spans": [
+      {
+        "value": "15.000 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "DE89 3704 0044 0532 0130 00",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Neue Bewerbung: Jonas Weber, erreichbar unter 0341 22874415 oder t.krueger@nordwind-ag.de.",
+    "spans": [
+      {
+        "value": "Jonas Weber",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "0341 22874415",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "t.krueger@nordwind-ag.de",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Neue Bewerbung: Daniel Roth, erreichbar unter 0341 22874415 oder t.krueger@nordwind-ag.de.",
+    "spans": [
+      {
+        "value": "Daniel Roth",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "0341 22874415",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "t.krueger@nordwind-ag.de",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Neue Bewerbung: Katrin Hoffmann, erreichbar unter +49 40 3319 8752 oder m.schulz@web-beispiel.de.",
+    "spans": [
+      {
+        "value": "Katrin Hoffmann",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+49 40 3319 8752",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "m.schulz@web-beispiel.de",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Neue Bewerbung: Sabine Lorenz, erreichbar unter 0341 22874415 oder c.neumann@hansa-consult.de.",
+    "spans": [
+      {
+        "value": "Sabine Lorenz",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "0341 22874415",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "c.neumann@hansa-consult.de",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bitte versende das Angebot an Daniel Roth, Birkenweg 15, 33602 Bielefeld.",
+    "spans": [
+      {
+        "value": "Daniel Roth",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Birkenweg 15, 33602 Bielefeld",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bitte versende das Angebot an Vanessa Kluge, Rosengasse 9, 93047 Regensburg.",
+    "spans": [
+      {
+        "value": "Vanessa Kluge",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Rosengasse 9, 93047 Regensburg",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bitte versende das Angebot an Daniel Roth, Lindenallee 12, 04109 Leipzig.",
+    "spans": [
+      {
+        "value": "Daniel Roth",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Lindenallee 12, 04109 Leipzig",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bitte versende das Angebot an Miriam Schulz, Rosengasse 9, 93047 Regensburg.",
+    "spans": [
+      {
+        "value": "Miriam Schulz",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Rosengasse 9, 93047 Regensburg",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Der Arbeitsvertrag von Heike Sommerfeld beginnt am 12.11.1979 mit einem Jahresgehalt von €67.200.",
+    "spans": [
+      {
+        "value": "Heike Sommerfeld",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "12.11.1979",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "€67.200",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Der Arbeitsvertrag von Daniel Roth beginnt am 30.06.2026 mit einem Jahresgehalt von €58.500.",
+    "spans": [
+      {
+        "value": "Daniel Roth",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "30.06.2026",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "€58.500",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Der Arbeitsvertrag von Oliver Petersen beginnt am 03.05.1991 mit einem Jahresgehalt von 62.400 €.",
+    "spans": [
+      {
+        "value": "Oliver Petersen",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "03.05.1991",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "62.400 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Der Arbeitsvertrag von Daniel Roth beginnt am 28.02.1995 mit einem Jahresgehalt von 12.750,00 €.",
+    "spans": [
+      {
+        "value": "Daniel Roth",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "28.02.1995",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "12.750,00 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Trage Jonas Weber für die Schulung nächste Woche ein und informiere buchhaltung@vogel-partner.de.",
+    "spans": [
+      {
+        "value": "Jonas Weber",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "buchhaltung@vogel-partner.de",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Trage Heike Sommerfeld für die Schulung nächste Woche ein und informiere f.brandt@beispielwerk.de.",
+    "spans": [
+      {
+        "value": "Heike Sommerfeld",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "f.brandt@beispielwerk.de",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Trage Martin Vogel für die Schulung nächste Woche ein und informiere k.hoffmann@beispiel-gmbh.de.",
+    "spans": [
+      {
+        "value": "Martin Vogel",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "k.hoffmann@beispiel-gmbh.de",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Trage Sabine Lorenz für die Schulung nächste Woche ein und informiere jonas.weber@firma-muster.de.",
+    "spans": [
+      {
+        "value": "Sabine Lorenz",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "jonas.weber@firma-muster.de",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "An welche Adresse ging die letzte Mahnung — Gartenweg 7, 55116 Mainz, korrekt?",
+    "spans": [
+      {
+        "value": "Gartenweg 7, 55116 Mainz",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "An welche Adresse ging die letzte Mahnung — Hauptstraße 118, 69117 Heidelberg, korrekt?",
+    "spans": [
+      {
+        "value": "Hauptstraße 118, 69117 Heidelberg",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "An welche Adresse ging die letzte Mahnung — Marktplatz 3, 80331 München, korrekt?",
+    "spans": [
+      {
+        "value": "Marktplatz 3, 80331 München",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "An welche Adresse ging die letzte Mahnung — Birkenweg 15, 33602 Bielefeld, korrekt?",
+    "spans": [
+      {
+        "value": "Birkenweg 15, 33602 Bielefeld",
+        "type": "address",
+        "tier": "high"
+      }
     ]
   },
   {
     "text": "Der Abwesenheitstyp Krankheit wird im HR-Modul separat ausgewiesen — bitte fasse die Regelung zusammen.",
-    "spans": []
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Krankheit und Urlaub werden in der Monatsauswertung getrennt gezählt.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Die Verantwortung für die Einhaltung liegt bei der Geschäftsführung und dem Betriebsrat.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Erkläre den Unterschied zwischen Bruttogehalt und Nettogehalt.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Straße, Weg und Platz sind im Adressmodul getrennte Feldtypen.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Der Alexanderplatz dient in der Anleitung nur als Beispielwert.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Goethe und Schiller sind die Namen der beiden Besprechungsräume.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Die Begriffe Werkvertrag und Dienstvertrag werden im Handbuch oft verwechselt.",
+    "spans": [],
+    "origin": "hand"
   },
   {
     "text": "Wie viele Urlaubstage stehen einem Mitarbeiter nach drei Jahren Betriebszugehörigkeit zu?",
@@ -39,6 +1407,94 @@
   },
   {
     "text": "Erstelle einen Statusbericht für das Q3-Projekt, Budgetrahmen unverändert.",
+    "spans": []
+  },
+  {
+    "text": "Fasse die Reisekostenrichtlinie in fünf Stichpunkten zusammen.",
+    "spans": []
+  },
+  {
+    "text": "Welche Schritte umfasst der Onboarding-Prozess im ersten Monat?",
+    "spans": []
+  },
+  {
+    "text": "Formuliere eine freundliche Erinnerung an die wöchentliche Zeiterfassung.",
+    "spans": []
+  },
+  {
+    "text": "Wie beantrage ich einen neuen Laptop über das Ticketsystem?",
+    "spans": []
+  },
+  {
+    "text": "Erstelle eine Agenda für das nächste Teammeeting mit drei Schwerpunkten.",
+    "spans": []
+  },
+  {
+    "text": "Welche Fristen gelten für die Abgabe der Reisekostenabrechnung?",
+    "spans": []
+  },
+  {
+    "text": "Fasse die Änderungen der Homeoffice-Regelung zusammen.",
+    "spans": []
+  },
+  {
+    "text": "Wie funktioniert die Freigabe von Bestellungen im Einkaufsmodul?",
+    "spans": []
+  },
+  {
+    "text": "Erkläre den Genehmigungsworkflow für externe Fortbildungen.",
+    "spans": []
+  },
+  {
+    "text": "Welche Berichte kann das Buchhaltungsmodul monatlich erzeugen?",
+    "spans": []
+  },
+  {
+    "text": "Schreibe eine kurze Ankündigung für die Systemwartung am Wochenende.",
+    "spans": []
+  },
+  {
+    "text": "Wie lege ich eine neue Kostenstelle im System an?",
+    "spans": []
+  },
+  {
+    "text": "Was ist der Unterschied zwischen Angebot und Auftragsbestätigung?",
+    "spans": []
+  },
+  {
+    "text": "Erstelle eine Checkliste für den Monatsabschluss in der Buchhaltung.",
+    "spans": []
+  },
+  {
+    "text": "Wie exportiere ich die Urlaubsübersicht als Tabelle?",
+    "spans": []
+  },
+  {
+    "text": "Welche Rollen gibt es im Freigabeprozess für Eingangsrechnungen?",
+    "spans": []
+  },
+  {
+    "text": "Formuliere eine höfliche Absage für einen verschobenen Liefertermin.",
+    "spans": []
+  },
+  {
+    "text": "Fasse die wichtigsten Punkte der Gleitzeitvereinbarung zusammen.",
+    "spans": []
+  },
+  {
+    "text": "Wie richte ich eine Abwesenheitsnotiz für die Feiertage ein?",
+    "spans": []
+  },
+  {
+    "text": "Welche Felder sind beim Anlegen eines neuen Lieferanten Pflicht?",
+    "spans": []
+  },
+  {
+    "text": "Beschreibe den Ablauf der jährlichen Inventur im Lager.",
+    "spans": []
+  },
+  {
+    "text": "Wie kann ich wiederkehrende Rechnungen automatisch erstellen lassen?",
     "spans": []
   }
 ]

--- a/middleware/packages/harness-plugin-privacy-guard/src/validation/fixtures/en.json
+++ b/middleware/packages/harness-plugin-privacy-guard/src/validation/fixtures/en.json
@@ -2,31 +2,1484 @@
   {
     "text": "What should we pay Anna Schmidt (32, lives at Bahnhofstr. 5, 60311 Frankfurt) given her current salary of €72,000?",
     "spans": [
-      { "value": "Anna Schmidt", "type": "person", "tier": "high" },
-      { "value": "Bahnhofstr. 5, 60311 Frankfurt", "type": "address", "tier": "high" },
-      { "value": "€72,000", "type": "amount", "tier": "critical" }
-    ]
+      {
+        "value": "Anna Schmidt",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Bahnhofstr. 5, 60311 Frankfurt",
+        "type": "address",
+        "tier": "high"
+      },
+      {
+        "value": "€72,000",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ],
+    "origin": "hand"
   },
   {
     "text": "Wire the bonus to GB29 NWBK 6016 1331 9268 19 and cc jane.doe@example-corp.com on the confirmation.",
     "spans": [
-      { "value": "GB29 NWBK 6016 1331 9268 19", "type": "iban", "tier": "critical" },
-      { "value": "jane.doe@example-corp.com", "type": "email", "tier": "high" }
-    ]
+      {
+        "value": "GB29 NWBK 6016 1331 9268 19",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "jane.doe@example-corp.com",
+        "type": "email",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
   },
   {
     "text": "Call the candidate at +44 20 7946 0958; her date of birth is 1990-06-15.",
     "spans": [
-      { "value": "+44 20 7946 0958", "type": "phone", "tier": "high" },
-      { "value": "1990-06-15", "type": "date", "tier": "high" }
+      {
+        "value": "+44 20 7946 0958",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "1990-06-15",
+        "type": "date",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Charlotte Hayes and Emily Carter will share the team lead role from April — please amend both contracts.",
+    "spans": [
+      {
+        "value": "Charlotte Hayes",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Emily Carter",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Mr. O. Bennett is still waiting for feedback on the salary adjustment.",
+    "spans": [
+      {
+        "value": "O. Bennett",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Please have the courier deliver the parcel to the small workshop behind the bakery at Gartenweg 7, second entrance on the left, 55116 Mainz.",
+    "spans": [
+      {
+        "value": "the small workshop behind the bakery at Gartenweg 7, second entrance on the left, 55116 Mainz",
+        "type": "address",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "The national insurance number for Daniel Brooks is QQ 12 34 56 C.",
+    "spans": [
+      {
+        "value": "Daniel Brooks",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "QQ 12 34 56 C",
+        "type": "idnum",
+        "tier": "critical"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Dr. Fiona Marsh will cover the Leeds office next quarter.",
+    "spans": [
+      {
+        "value": "Fiona Marsh",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Three colleagues attend the offsite: Samuel Pritchard, Grace Middleton and Thomas Ashford.",
+    "spans": [
+      {
+        "value": "Samuel Pritchard",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Grace Middleton",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Thomas Ashford",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Our new contact is Aoife Ní Bhraonáin from the Dublin branch.",
+    "spans": [
+      {
+        "value": "Aoife Ní Bhraonáin",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Please onboard Nguyen Van Minh from procurement next Monday.",
+    "spans": [
+      {
+        "value": "Nguyen Van Minh",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "The tenancy for Mr Kaminski's flat ends on 24/12/2026.",
+    "spans": [
+      {
+        "value": "Mr Kaminski",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "24/12/2026",
+        "type": "date",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Candidate Leonie Baumgartner-Schmidt made it to the second interview round.",
+    "spans": [
+      {
+        "value": "Leonie Baumgartner-Schmidt",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "The equipment goes to the storage unit past the old water tower on Mühlenweg 11, gate C at the back of the yard, 28195 Bremen.",
+    "spans": [
+      {
+        "value": "the storage unit past the old water tower on Mühlenweg 11, gate C at the back of the yard, 28195 Bremen",
+        "type": "address",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Payroll flagged that James Whitfield has two open advances totalling £3,150.",
+    "spans": [
+      {
+        "value": "James Whitfield",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "£3,150",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Sophie Turner's emergency contact is her brother at +44 7700 900456.",
+    "spans": [
+      {
+        "value": "Sophie Turner",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+44 7700 900456",
+        "type": "phone",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Forward the signed contract to h.lawson@mail-sample.org and let Hannah Lawson know it arrived.",
+    "spans": [
+      {
+        "value": "h.lawson@mail-sample.org",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "Hannah Lawson",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "What should we pay Thomas Ashford given a current salary of £2,300?",
+    "spans": [
+      {
+        "value": "Thomas Ashford",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "£2,300",
+        "type": "amount",
+        "tier": "critical"
+      }
     ]
   },
   {
+    "text": "What should we pay Daniel Brooks given a current salary of EUR 64,000?",
+    "spans": [
+      {
+        "value": "Daniel Brooks",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "EUR 64,000",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "What should we pay Daniel Brooks given a current salary of €3,499?",
+    "spans": [
+      {
+        "value": "Daniel Brooks",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "€3,499",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "What should we pay Grace Middleton given a current salary of £45,000?",
+    "spans": [
+      {
+        "value": "Grace Middleton",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "£45,000",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Wire the bonus to DE89 3704 0044 0532 0130 00 and cc t.ashford@example-consult.com on the confirmation.",
+    "spans": [
+      {
+        "value": "DE89 3704 0044 0532 0130 00",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "t.ashford@example-consult.com",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Wire the bonus to GB98 MIDL 0700 9312 3456 78 and cc s.turner@example-consult.com on the confirmation.",
+    "spans": [
+      {
+        "value": "GB98 MIDL 0700 9312 3456 78",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "s.turner@example-consult.com",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Wire the bonus to GB82 WEST 1234 5698 7654 32 and cc j.whitfield@acme-example.com on the confirmation.",
+    "spans": [
+      {
+        "value": "GB82 WEST 1234 5698 7654 32",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "j.whitfield@acme-example.com",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Wire the bonus to GB94 BARC 1020 1530 0934 59 and cc charlotte.hayes@sample-industries.co.uk on the confirmation.",
+    "spans": [
+      {
+        "value": "GB94 BARC 1020 1530 0934 59",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "charlotte.hayes@sample-industries.co.uk",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Call the candidate Emily Carter at +44 113 496 0921; the date of birth on file is 03/05/1991.",
+    "spans": [
+      {
+        "value": "Emily Carter",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+44 113 496 0921",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "03/05/1991",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Call the candidate Fiona Marsh at +44 7911 123456; the date of birth on file is 12/11/1979.",
+    "spans": [
+      {
+        "value": "Fiona Marsh",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+44 7911 123456",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "12/11/1979",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Call the candidate Charlotte Hayes at +44 7700 900123; the date of birth on file is 1984-09-17.",
+    "spans": [
+      {
+        "value": "Charlotte Hayes",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+44 7700 900123",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "1984-09-17",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Call the candidate James Whitfield at +44 7700 900123; the date of birth on file is 24/12/1987.",
+    "spans": [
+      {
+        "value": "James Whitfield",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+44 7700 900123",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "24/12/1987",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "The invoice for EUR 64,000 should go to Lindenallee 3, 10115 Berlin.",
+    "spans": [
+      {
+        "value": "EUR 64,000",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Lindenallee 3, 10115 Berlin",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "The invoice for £58,900 should go to Lindenallee 3, 10115 Berlin.",
+    "spans": [
+      {
+        "value": "£58,900",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Lindenallee 3, 10115 Berlin",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "The invoice for £58,900 should go to Schlossallee 2, 70173 Stuttgart.",
+    "spans": [
+      {
+        "value": "£58,900",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Schlossallee 2, 70173 Stuttgart",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "The invoice for EUR 64,000 should go to Marktplatz 8, 50667 Köln.",
+    "spans": [
+      {
+        "value": "EUR 64,000",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Marktplatz 8, 50667 Köln",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Set up Samuel Pritchard as a new employee with the work email h.lawson@mail-sample.org.",
+    "spans": [
+      {
+        "value": "Samuel Pritchard",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "h.lawson@mail-sample.org",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Set up Fiona Marsh as a new employee with the work email invoices@acme-example.com.",
+    "spans": [
+      {
+        "value": "Fiona Marsh",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "invoices@acme-example.com",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Set up Samuel Pritchard as a new employee with the work email emily.carter@mail-sample.org.",
+    "spans": [
+      {
+        "value": "Samuel Pritchard",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "emily.carter@mail-sample.org",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Set up Daniel Brooks as a new employee with the work email emily.carter@mail-sample.org.",
+    "spans": [
+      {
+        "value": "Daniel Brooks",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "emily.carter@mail-sample.org",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Oliver Bennett left the company on 30/06/2026 — please start the offboarding checklist.",
+    "spans": [
+      {
+        "value": "Oliver Bennett",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "30/06/2026",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Nathan Ellery left the company on 1990-06-15 — please start the offboarding checklist.",
+    "spans": [
+      {
+        "value": "Nathan Ellery",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "1990-06-15",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Peter Colgan left the company on 03/05/1991 — please start the offboarding checklist.",
+    "spans": [
+      {
+        "value": "Peter Colgan",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "03/05/1991",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Grace Middleton left the company on 24/12/1987 — please start the offboarding checklist.",
+    "spans": [
+      {
+        "value": "Grace Middleton",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "24/12/1987",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Update the master data: Nathan Ellery now lives at Lindenallee 3, 10115 Berlin.",
+    "spans": [
+      {
+        "value": "Nathan Ellery",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Lindenallee 3, 10115 Berlin",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Update the master data: Daniel Brooks now lives at Gartenweg 21, 55116 Mainz.",
+    "spans": [
+      {
+        "value": "Daniel Brooks",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Gartenweg 21, 55116 Mainz",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Update the master data: Peter Colgan now lives at Lindenallee 3, 10115 Berlin.",
+    "spans": [
+      {
+        "value": "Peter Colgan",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Lindenallee 3, 10115 Berlin",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Update the master data: James Whitfield now lives at Hauptstraße 64, 79098 Freiburg.",
+    "spans": [
+      {
+        "value": "James Whitfield",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Hauptstraße 64, 79098 Freiburg",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Reimburse travel expenses of $68,500 to GB98 MIDL 0700 9312 3456 78.",
+    "spans": [
+      {
+        "value": "$68,500",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "GB98 MIDL 0700 9312 3456 78",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Reimburse travel expenses of 72,000.50 USD to GB29 NWBK 6016 1331 9268 19.",
+    "spans": [
+      {
+        "value": "72,000.50 USD",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "GB29 NWBK 6016 1331 9268 19",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Reimburse travel expenses of €3,499 to GB33 BUKB 2020 1555 5555 55.",
+    "spans": [
+      {
+        "value": "€3,499",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "GB33 BUKB 2020 1555 5555 55",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Reimburse travel expenses of £12,750 to GB29 NWBK 6016 1331 9268 19.",
+    "spans": [
+      {
+        "value": "£12,750",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "GB29 NWBK 6016 1331 9268 19",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Send the payslip to m.reeves@example-corp.com; gross pay is £58,900.",
+    "spans": [
+      {
+        "value": "m.reeves@example-corp.com",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "£58,900",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Send the payslip to t.ashford@example-consult.com; gross pay is $68,500.",
+    "spans": [
+      {
+        "value": "t.ashford@example-consult.com",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "$68,500",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Send the payslip to s.turner@example-consult.com; gross pay is €3,499.",
+    "spans": [
+      {
+        "value": "s.turner@example-consult.com",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "€3,499",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Send the payslip to h.lawson@mail-sample.org; gross pay is $1,250.75.",
+    "spans": [
+      {
+        "value": "h.lawson@mail-sample.org",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "$1,250.75",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "For the reference check you can reach Michael Reeves at 020 7946 0011.",
+    "spans": [
+      {
+        "value": "Michael Reeves",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "020 7946 0011",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "For the reference check you can reach Grace Middleton at +44 161 496 0142.",
+    "spans": [
+      {
+        "value": "Grace Middleton",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+44 161 496 0142",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "For the reference check you can reach Charlotte Hayes at +44 113 496 0921.",
+    "spans": [
+      {
+        "value": "Charlotte Hayes",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+44 113 496 0921",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "For the reference check you can reach Marcus Tilbury at 020 7946 0011.",
+    "spans": [
+      {
+        "value": "Marcus Tilbury",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "020 7946 0011",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Please prepare the appraisal meeting with Samuel Pritchard.",
+    "spans": [
+      {
+        "value": "Samuel Pritchard",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Please prepare the appraisal meeting with Charlotte Hayes.",
+    "spans": [
+      {
+        "value": "Charlotte Hayes",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Please prepare the appraisal meeting with Rebecca Osborne.",
+    "spans": [
+      {
+        "value": "Rebecca Osborne",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Please prepare the appraisal meeting with Sophie Turner.",
+    "spans": [
+      {
+        "value": "Sophie Turner",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Rachel Duffield called in sick on 1995-02-28 — log it in the HR module.",
+    "spans": [
+      {
+        "value": "Rachel Duffield",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "1995-02-28",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Samuel Pritchard called in sick on 2023-02-01 — log it in the HR module.",
+    "spans": [
+      {
+        "value": "Samuel Pritchard",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "2023-02-01",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Fiona Marsh called in sick on 24/12/1987 — log it in the HR module.",
+    "spans": [
+      {
+        "value": "Fiona Marsh",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "24/12/1987",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Nathan Ellery called in sick on 1995-02-28 — log it in the HR module.",
+    "spans": [
+      {
+        "value": "Nathan Ellery",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "1995-02-28",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "The supplier expects the payment of $1,250.75 to GB98 MIDL 0700 9312 3456 78.",
+    "spans": [
+      {
+        "value": "$1,250.75",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "GB98 MIDL 0700 9312 3456 78",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "The supplier expects the payment of $68,500 to GB29 NWBK 6016 1331 9268 19.",
+    "spans": [
+      {
+        "value": "$68,500",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "GB29 NWBK 6016 1331 9268 19",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "The supplier expects the payment of EUR 64,000 to GB29 NWBK 6016 1331 9268 19.",
+    "spans": [
+      {
+        "value": "EUR 64,000",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "GB29 NWBK 6016 1331 9268 19",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "The supplier expects the payment of £12,750 to GB94 BARC 1020 1530 0934 59.",
+    "spans": [
+      {
+        "value": "£12,750",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "GB94 BARC 1020 1530 0934 59",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "New application: Sophie Turner, reachable at +44 113 496 0921 or charlotte.hayes@sample-industries.co.uk.",
+    "spans": [
+      {
+        "value": "Sophie Turner",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+44 113 496 0921",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "charlotte.hayes@sample-industries.co.uk",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "New application: Charlotte Hayes, reachable at 0161 496 0735 or t.ashford@example-consult.com.",
+    "spans": [
+      {
+        "value": "Charlotte Hayes",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "0161 496 0735",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "t.ashford@example-consult.com",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "New application: Alice Redfern, reachable at +44 113 496 0921 or t.ashford@example-consult.com.",
+    "spans": [
+      {
+        "value": "Alice Redfern",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+44 113 496 0921",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "t.ashford@example-consult.com",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "New application: Rebecca Osborne, reachable at 020 7946 0011 or hr@sample-industries.co.uk.",
+    "spans": [
+      {
+        "value": "Rebecca Osborne",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "020 7946 0011",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "hr@sample-industries.co.uk",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Please send the offer letter to Marcus Tilbury, Schlossallee 2, 70173 Stuttgart.",
+    "spans": [
+      {
+        "value": "Marcus Tilbury",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Schlossallee 2, 70173 Stuttgart",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Please send the offer letter to Samuel Pritchard, Gartenweg 21, 55116 Mainz.",
+    "spans": [
+      {
+        "value": "Samuel Pritchard",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Gartenweg 21, 55116 Mainz",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Please send the offer letter to Peter Colgan, Mühlenweg 11, 28195 Bremen.",
+    "spans": [
+      {
+        "value": "Peter Colgan",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Mühlenweg 11, 28195 Bremen",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Please send the offer letter to Grace Middleton, Mühlenweg 11, 28195 Bremen.",
+    "spans": [
+      {
+        "value": "Grace Middleton",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Mühlenweg 11, 28195 Bremen",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "The employment contract for Grace Middleton starts on 1995-02-28 with an annual salary of €3,499.",
+    "spans": [
+      {
+        "value": "Grace Middleton",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "1995-02-28",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "€3,499",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "The employment contract for Jessica Holt starts on 1990-06-15 with an annual salary of £45,000.",
+    "spans": [
+      {
+        "value": "Jessica Holt",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "1990-06-15",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "£45,000",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "The employment contract for Emily Carter starts on 30/06/2026 with an annual salary of £58,900.",
+    "spans": [
+      {
+        "value": "Emily Carter",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "30/06/2026",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "£58,900",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "The employment contract for Emily Carter starts on 24/12/1987 with an annual salary of EUR 64,000.",
+    "spans": [
+      {
+        "value": "Emily Carter",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "24/12/1987",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "EUR 64,000",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Enroll Grace Middleton in next week's training and notify t.ashford@example-consult.com.",
+    "spans": [
+      {
+        "value": "Grace Middleton",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "t.ashford@example-consult.com",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Enroll Hannah Lawson in next week's training and notify h.lawson@mail-sample.org.",
+    "spans": [
+      {
+        "value": "Hannah Lawson",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "h.lawson@mail-sample.org",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Enroll Jessica Holt in next week's training and notify hr@sample-industries.co.uk.",
+    "spans": [
+      {
+        "value": "Jessica Holt",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "hr@sample-industries.co.uk",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Enroll Michael Reeves in next week's training and notify emily.carter@mail-sample.org.",
+    "spans": [
+      {
+        "value": "Michael Reeves",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "emily.carter@mail-sample.org",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Which address did the last reminder go to — Gartenweg 21, 55116 Mainz, correct?",
+    "spans": [
+      {
+        "value": "Gartenweg 21, 55116 Mainz",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Which address did the last reminder go to — Schlossallee 2, 70173 Stuttgart, correct?",
+    "spans": [
+      {
+        "value": "Schlossallee 2, 70173 Stuttgart",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Which address did the last reminder go to — Marktplatz 8, 50667 Köln, correct?",
+    "spans": [
+      {
+        "value": "Marktplatz 8, 50667 Köln",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Which address did the last reminder go to — Hauptstraße 64, 79098 Freiburg, correct?",
+    "spans": [
+      {
+        "value": "Hauptstraße 64, 79098 Freiburg",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Sickness and holiday absences are counted separately in the monthly report.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "The Works Council and the Management Board meet on the first Monday.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Explain the difference between gross pay and net pay.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Street, avenue and lane are separate field types in the address module.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Reading, Bath and Sale are on the shortlist of towns for the new depot.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Churchill is the name of the large meeting room on the second floor.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
     "text": "Summarize our vacation carry-over policy for employees in their first year.",
-    "spans": []
+    "spans": [],
+    "origin": "hand"
   },
   {
     "text": "Draft a follow-up on the roadmap review; keep the tone neutral.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "How many vacation days does an employee accrue after three years of service?",
+    "spans": []
+  },
+  {
+    "text": "Create a status report for the third-quarter project; the budget is unchanged.",
+    "spans": []
+  },
+  {
+    "text": "Summarize the travel expense policy in five bullet points.",
+    "spans": []
+  },
+  {
+    "text": "Which steps does the onboarding process cover in the first month?",
+    "spans": []
+  },
+  {
+    "text": "Draft a friendly reminder about weekly time tracking.",
+    "spans": []
+  },
+  {
+    "text": "How do I request a new laptop through the ticket system?",
+    "spans": []
+  },
+  {
+    "text": "Create an agenda for the next team meeting with three focus topics.",
+    "spans": []
+  },
+  {
+    "text": "Which deadlines apply to submitting travel expense reports?",
+    "spans": []
+  },
+  {
+    "text": "Summarize the recent changes to the remote work policy.",
+    "spans": []
+  },
+  {
+    "text": "How does purchase order approval work in the procurement module?",
+    "spans": []
+  },
+  {
+    "text": "Explain the approval workflow for external training courses.",
+    "spans": []
+  },
+  {
+    "text": "Which reports can the accounting module generate monthly?",
+    "spans": []
+  },
+  {
+    "text": "Write a short announcement for the weekend system maintenance.",
+    "spans": []
+  },
+  {
+    "text": "How do I create a new cost center in the system?",
+    "spans": []
+  },
+  {
+    "text": "What is the difference between a quotation and an order confirmation?",
+    "spans": []
+  },
+  {
+    "text": "Create a checklist for the month-end close in accounting.",
+    "spans": []
+  },
+  {
+    "text": "How do I export the leave overview as a spreadsheet?",
+    "spans": []
+  },
+  {
+    "text": "Which roles exist in the approval process for incoming invoices?",
+    "spans": []
+  },
+  {
+    "text": "Draft a polite decline for a postponed delivery date.",
+    "spans": []
+  },
+  {
+    "text": "Summarize the key points of the flextime agreement.",
+    "spans": []
+  },
+  {
+    "text": "How do I set up an out-of-office notice for the holidays?",
+    "spans": []
+  },
+  {
+    "text": "Which fields are mandatory when creating a new supplier?",
+    "spans": []
+  },
+  {
+    "text": "Describe the annual warehouse inventory procedure.",
+    "spans": []
+  },
+  {
+    "text": "How can recurring invoices be generated automatically?",
     "spans": []
   }
 ]

--- a/middleware/packages/harness-plugin-privacy-guard/src/validation/fixtures/es.json
+++ b/middleware/packages/harness-plugin-privacy-guard/src/validation/fixtures/es.json
@@ -1,0 +1,1480 @@
+[
+  {
+    "text": "María del Carmen García López se incorpora al equipo de nóminas en mayo.",
+    "spans": [
+      {
+        "value": "María del Carmen García López",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "José Manuel Ruiz de la Torre ha solicitado el traslado a la oficina de Valencia.",
+    "spans": [
+      {
+        "value": "José Manuel Ruiz de la Torre",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Ana Belén Torres y Lucía Fernández comparten la coordinación del turno de tarde.",
+    "spans": [
+      {
+        "value": "Ana Belén Torres",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Lucía Fernández",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "El señor García sigue esperando la respuesta sobre su excedencia.",
+    "spans": [
+      {
+        "value": "señor García",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "El NIE de Andrés Vidal es X-2482300-W.",
+    "spans": [
+      {
+        "value": "Andrés Vidal",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "X-2482300-W",
+        "type": "idnum",
+        "tier": "critical"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "El DNI que figura en el contrato de Marta Sánchez es 45678123L.",
+    "spans": [
+      {
+        "value": "Marta Sánchez",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "45678123L",
+        "type": "idnum",
+        "tier": "critical"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Entregad el pedido en el almacén detrás de la nave antigua en la Calle de los Olivos 14, segunda puerta junto al muelle de carga, 41020 Sevilla.",
+    "spans": [
+      {
+        "value": "el almacén detrás de la nave antigua en la Calle de los Olivos 14, segunda puerta junto al muelle de carga, 41020 Sevilla",
+        "type": "address",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Manda al mensajero a la Avenida de la Constitución 3 antes del mediodía.",
+    "spans": [
+      {
+        "value": "Avenida de la Constitución 3",
+        "type": "address",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Francisco Javier López-Alcalá impartirá la formación de seguridad.",
+    "spans": [
+      {
+        "value": "Francisco Javier López-Alcalá",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Llama a Diego Navarro al 612 334 455 para confirmar la revisión médica.",
+    "spans": [
+      {
+        "value": "Diego Navarro",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "612 334 455",
+        "type": "phone",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Al taller asisten Teresa Pascual, Rubén Ortega y Silvia Robles.",
+    "spans": [
+      {
+        "value": "Teresa Pascual",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Rubén Ortega",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Silvia Robles",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "La nómina de Pablo Herrera incluye un plus de 1.250,50 € este mes.",
+    "spans": [
+      {
+        "value": "Pablo Herrera",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "1.250,50 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Transfiere el anticipo a la cuenta ES91 2100 0418 4502 0005 1332 de Irene Castillo.",
+    "spans": [
+      {
+        "value": "ES91 2100 0418 4502 0005 1332",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "Irene Castillo",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Elena Cordero nació el 03/05/1991 según el expediente.",
+    "spans": [
+      {
+        "value": "Elena Cordero",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "03/05/1991",
+        "type": "date",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "La candidata Nuria Delgado-Ibáñez pasó a la última fase.",
+    "spans": [
+      {
+        "value": "Nuria Delgado-Ibáñez",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "El proveedor pregunta por Óscar Peña, su contacto es o.pena@ejemplo-sl.es.",
+    "spans": [
+      {
+        "value": "Óscar Peña",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "o.pena@ejemplo-sl.es",
+        "type": "email",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Reenvía el contrato firmado a m.sanchez@empresa-ejemplo.es y avisa a Marta Sánchez.",
+    "spans": [
+      {
+        "value": "m.sanchez@empresa-ejemplo.es",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "Marta Sánchez",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "¿Qué deberíamos pagar a Silvia Robles si su salario actual es de 12.750,00 €?",
+    "spans": [
+      {
+        "value": "Silvia Robles",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "12.750,00 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "¿Qué deberíamos pagar a Pablo Herrera si su salario actual es de 150 €?",
+    "spans": [
+      {
+        "value": "Pablo Herrera",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "150 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "¿Qué deberíamos pagar a Víctor Salinas si su salario actual es de 67.200 €?",
+    "spans": [
+      {
+        "value": "Víctor Salinas",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "67.200 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "¿Qué deberíamos pagar a Teresa Pascual si su salario actual es de 72.000 €?",
+    "spans": [
+      {
+        "value": "Teresa Pascual",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "72.000 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Transfiere el anticipo a ES66 2100 0418 4012 3456 7891 y pon en copia a m.sanchez@empresa-ejemplo.es.",
+    "spans": [
+      {
+        "value": "ES66 2100 0418 4012 3456 7891",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "m.sanchez@empresa-ejemplo.es",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Transfiere el anticipo a ES15 0049 1500 0512 3456 7892 y pon en copia a nominas@ejemplo-sl.es.",
+    "spans": [
+      {
+        "value": "ES15 0049 1500 0512 3456 7892",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "nominas@ejemplo-sl.es",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Transfiere el anticipo a ES66 2100 0418 4012 3456 7891 y pon en copia a p.herrera@correo-ejemplo.es.",
+    "spans": [
+      {
+        "value": "ES66 2100 0418 4012 3456 7891",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "p.herrera@correo-ejemplo.es",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Transfiere el anticipo a ES91 2100 0418 4502 0005 1332 y pon en copia a rrhh@ejemplo-consult.es.",
+    "spans": [
+      {
+        "value": "ES91 2100 0418 4502 0005 1332",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "rrhh@ejemplo-consult.es",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Llama a Marta Sánchez al +34 93 412 76 55; su fecha de nacimiento es 24/12/1987.",
+    "spans": [
+      {
+        "value": "Marta Sánchez",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+34 93 412 76 55",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "24/12/1987",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Llama a Silvia Robles al +34 93 412 76 55; su fecha de nacimiento es 01/02/2023.",
+    "spans": [
+      {
+        "value": "Silvia Robles",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+34 93 412 76 55",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "01/02/2023",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Llama a Irene Castillo al +34 96 351 28 47; su fecha de nacimiento es 05/03/2001.",
+    "spans": [
+      {
+        "value": "Irene Castillo",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+34 96 351 28 47",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "05/03/2001",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Llama a Ana Belén Torres al +34 685 21 47 90; su fecha de nacimiento es 28/02/1995.",
+    "spans": [
+      {
+        "value": "Ana Belén Torres",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+34 685 21 47 90",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "28/02/1995",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "La factura de 1.250,50 € debe enviarse a Avenida de la Constitución 3, 41001 Sevilla.",
+    "spans": [
+      {
+        "value": "1.250,50 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Avenida de la Constitución 3, 41001 Sevilla",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "La factura de 12.750,00 € debe enviarse a Carrer de Balmes 24, 08007 Barcelona.",
+    "spans": [
+      {
+        "value": "12.750,00 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Carrer de Balmes 24, 08007 Barcelona",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "La factura de 4.980 € debe enviarse a Plaza del Sol 7, 28004 Madrid.",
+    "spans": [
+      {
+        "value": "4.980 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Plaza del Sol 7, 28004 Madrid",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "La factura de 72.000 € debe enviarse a Calle de Alcalá 89, 28009 Madrid.",
+    "spans": [
+      {
+        "value": "72.000 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Calle de Alcalá 89, 28009 Madrid",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Da de alta a Andrés Vidal como nuevo empleado con el correo p.herrera@correo-ejemplo.es.",
+    "spans": [
+      {
+        "value": "Andrés Vidal",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "p.herrera@correo-ejemplo.es",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Da de alta a Ana Belén Torres como nuevo empleado con el correo a.martinez@empresa-ejemplo.es.",
+    "spans": [
+      {
+        "value": "Ana Belén Torres",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "a.martinez@empresa-ejemplo.es",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Da de alta a Pablo Herrera como nuevo empleado con el correo i.castillo@ejemplo-sl.es.",
+    "spans": [
+      {
+        "value": "Pablo Herrera",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "i.castillo@ejemplo-sl.es",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Da de alta a Lucía Fernández como nuevo empleado con el correo rrhh@ejemplo-consult.es.",
+    "spans": [
+      {
+        "value": "Lucía Fernández",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "rrhh@ejemplo-consult.es",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Marta Sánchez dejó la empresa el 24/12/1987 — inicia el proceso de baja.",
+    "spans": [
+      {
+        "value": "Marta Sánchez",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "24/12/1987",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Elena Cordero dejó la empresa el 28/02/1995 — inicia el proceso de baja.",
+    "spans": [
+      {
+        "value": "Elena Cordero",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "28/02/1995",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Diego Navarro dejó la empresa el 28/02/1995 — inicia el proceso de baja.",
+    "spans": [
+      {
+        "value": "Diego Navarro",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "28/02/1995",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Rubén Ortega dejó la empresa el 12/11/1979 — inicia el proceso de baja.",
+    "spans": [
+      {
+        "value": "Rubén Ortega",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "12/11/1979",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Actualiza los datos maestros: Javier Fuentes vive ahora en Paseo de Gracia 12, 08008 Barcelona.",
+    "spans": [
+      {
+        "value": "Javier Fuentes",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Paseo de Gracia 12, 08008 Barcelona",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Actualiza los datos maestros: Sergio Molina vive ahora en Gran Vía 44, 48011 Bilbao.",
+    "spans": [
+      {
+        "value": "Sergio Molina",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Gran Vía 44, 48011 Bilbao",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Actualiza los datos maestros: Álvaro Martínez vive ahora en Carrer de Balmes 24, 08007 Barcelona.",
+    "spans": [
+      {
+        "value": "Álvaro Martínez",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Carrer de Balmes 24, 08007 Barcelona",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Actualiza los datos maestros: Rocío Márquez vive ahora en Avenida de la Constitución 3, 41001 Sevilla.",
+    "spans": [
+      {
+        "value": "Rocío Márquez",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Avenida de la Constitución 3, 41001 Sevilla",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Reembolsa los gastos de viaje de 72.000 € a ES66 2100 0418 4012 3456 7891.",
+    "spans": [
+      {
+        "value": "72.000 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "ES66 2100 0418 4012 3456 7891",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Reembolsa los gastos de viaje de 62.400 € a ES91 2100 0418 4502 0005 1332.",
+    "spans": [
+      {
+        "value": "62.400 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "ES91 2100 0418 4502 0005 1332",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Reembolsa los gastos de viaje de 899 € a ES28 0075 0315 4506 0012 3456.",
+    "spans": [
+      {
+        "value": "899 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "ES28 0075 0315 4506 0012 3456",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Reembolsa los gastos de viaje de 4.980 € a ES66 2100 0418 4012 3456 7891.",
+    "spans": [
+      {
+        "value": "4.980 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "ES66 2100 0418 4012 3456 7891",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Envía la nómina a c.jimenez@correo-ejemplo.es; el salario bruto es de 4.980 €.",
+    "spans": [
+      {
+        "value": "c.jimenez@correo-ejemplo.es",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "4.980 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Envía la nómina a i.castillo@ejemplo-sl.es; el salario bruto es de 67.200 €.",
+    "spans": [
+      {
+        "value": "i.castillo@ejemplo-sl.es",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "67.200 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Envía la nómina a i.castillo@ejemplo-sl.es; el salario bruto es de 72.000 €.",
+    "spans": [
+      {
+        "value": "i.castillo@ejemplo-sl.es",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "72.000 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Envía la nómina a c.jimenez@correo-ejemplo.es; el salario bruto es de 1.250,50 €.",
+    "spans": [
+      {
+        "value": "c.jimenez@correo-ejemplo.es",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "1.250,50 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Para las referencias puedes localizar a Marta Sánchez en el +34 671 45 82 03.",
+    "spans": [
+      {
+        "value": "Marta Sánchez",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+34 671 45 82 03",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Para las referencias puedes localizar a Javier Fuentes en el +34 91 522 18 30.",
+    "spans": [
+      {
+        "value": "Javier Fuentes",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+34 91 522 18 30",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Para las referencias puedes localizar a Marcos Ibáñez en el +34 93 412 76 55.",
+    "spans": [
+      {
+        "value": "Marcos Ibáñez",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+34 93 412 76 55",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Para las referencias puedes localizar a Rubén Ortega en el +34 671 45 82 03.",
+    "spans": [
+      {
+        "value": "Rubén Ortega",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+34 671 45 82 03",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Prepara la evaluación anual con Sergio Molina.",
+    "spans": [
+      {
+        "value": "Sergio Molina",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Prepara la evaluación anual con Javier Fuentes.",
+    "spans": [
+      {
+        "value": "Javier Fuentes",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Prepara la evaluación anual con Marcos Ibáñez.",
+    "spans": [
+      {
+        "value": "Marcos Ibáñez",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Prepara la evaluación anual con Diego Navarro.",
+    "spans": [
+      {
+        "value": "Diego Navarro",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Elena Cordero se dio de baja por enfermedad el 12/11/1979 — regístralo en el módulo de RRHH.",
+    "spans": [
+      {
+        "value": "Elena Cordero",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "12/11/1979",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Sergio Molina se dio de baja por enfermedad el 24/12/1987 — regístralo en el módulo de RRHH.",
+    "spans": [
+      {
+        "value": "Sergio Molina",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "24/12/1987",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Teresa Pascual se dio de baja por enfermedad el 05/03/2001 — regístralo en el módulo de RRHH.",
+    "spans": [
+      {
+        "value": "Teresa Pascual",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "05/03/2001",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Silvia Robles se dio de baja por enfermedad el 30/06/2026 — regístralo en el módulo de RRHH.",
+    "spans": [
+      {
+        "value": "Silvia Robles",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "30/06/2026",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "El proveedor espera el pago de 62.400 € en ES91 2100 0418 4502 0005 1332.",
+    "spans": [
+      {
+        "value": "62.400 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "ES91 2100 0418 4502 0005 1332",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "El proveedor espera el pago de 62.400 € en ES28 0075 0315 4506 0012 3456.",
+    "spans": [
+      {
+        "value": "62.400 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "ES28 0075 0315 4506 0012 3456",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "El proveedor espera el pago de 67.200 € en ES28 0075 0315 4506 0012 3456.",
+    "spans": [
+      {
+        "value": "67.200 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "ES28 0075 0315 4506 0012 3456",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "El proveedor espera el pago de 150 € en ES44 2038 5778 9830 0076 0236.",
+    "spans": [
+      {
+        "value": "150 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "ES44 2038 5778 9830 0076 0236",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Nueva candidatura: Carmen Jiménez, localizable en el +34 622 90 11 34 o en rrhh@ejemplo-consult.es.",
+    "spans": [
+      {
+        "value": "Carmen Jiménez",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+34 622 90 11 34",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "rrhh@ejemplo-consult.es",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Nueva candidatura: Diego Navarro, localizable en el +34 96 351 28 47 o en facturas@ejemplo-consult.es.",
+    "spans": [
+      {
+        "value": "Diego Navarro",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+34 96 351 28 47",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "facturas@ejemplo-consult.es",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Nueva candidatura: Óscar Peña, localizable en el +34 910 23 45 67 o en contabilidad@ejemplo-sl.es.",
+    "spans": [
+      {
+        "value": "Óscar Peña",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+34 910 23 45 67",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "contabilidad@ejemplo-sl.es",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Nueva candidatura: Óscar Peña, localizable en el +34 685 21 47 90 o en nominas@ejemplo-sl.es.",
+    "spans": [
+      {
+        "value": "Óscar Peña",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+34 685 21 47 90",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "nominas@ejemplo-sl.es",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Envía la oferta a Javier Fuentes, Carrer de Balmes 24, 08007 Barcelona.",
+    "spans": [
+      {
+        "value": "Javier Fuentes",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Carrer de Balmes 24, 08007 Barcelona",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Envía la oferta a Lucía Fernández, Calle de Alcalá 89, 28009 Madrid.",
+    "spans": [
+      {
+        "value": "Lucía Fernández",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Calle de Alcalá 89, 28009 Madrid",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Envía la oferta a Pablo Herrera, Carrer de Balmes 24, 08007 Barcelona.",
+    "spans": [
+      {
+        "value": "Pablo Herrera",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Carrer de Balmes 24, 08007 Barcelona",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Envía la oferta a Marta Sánchez, Ronda de Toledo 5, 28005 Madrid.",
+    "spans": [
+      {
+        "value": "Marta Sánchez",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Ronda de Toledo 5, 28005 Madrid",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "El contrato de Pablo Herrera empieza el 24/12/1987 con un salario anual de 150 €.",
+    "spans": [
+      {
+        "value": "Pablo Herrera",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "24/12/1987",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "150 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "El contrato de Irene Castillo empieza el 30/06/2026 con un salario anual de 72.000 €.",
+    "spans": [
+      {
+        "value": "Irene Castillo",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "30/06/2026",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "72.000 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "El contrato de Álvaro Martínez empieza el 12/11/1979 con un salario anual de 3.499,99 €.",
+    "spans": [
+      {
+        "value": "Álvaro Martínez",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "12/11/1979",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "3.499,99 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "El contrato de Irene Castillo empieza el 05/03/2001 con un salario anual de 1.250,50 €.",
+    "spans": [
+      {
+        "value": "Irene Castillo",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "05/03/2001",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "1.250,50 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Apunta a Óscar Peña a la formación de la próxima semana y avisa a a.martinez@empresa-ejemplo.es.",
+    "spans": [
+      {
+        "value": "Óscar Peña",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "a.martinez@empresa-ejemplo.es",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Apunta a Óscar Peña a la formación de la próxima semana y avisa a nominas@ejemplo-sl.es.",
+    "spans": [
+      {
+        "value": "Óscar Peña",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "nominas@ejemplo-sl.es",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Apunta a Beatriz Salas a la formación de la próxima semana y avisa a c.jimenez@correo-ejemplo.es.",
+    "spans": [
+      {
+        "value": "Beatriz Salas",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "c.jimenez@correo-ejemplo.es",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Apunta a Sergio Molina a la formación de la próxima semana y avisa a p.herrera@correo-ejemplo.es.",
+    "spans": [
+      {
+        "value": "Sergio Molina",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "p.herrera@correo-ejemplo.es",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "¿A qué dirección se envió el último recordatorio — Gran Vía 44, 48011 Bilbao, correcto?",
+    "spans": [
+      {
+        "value": "Gran Vía 44, 48011 Bilbao",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "¿A qué dirección se envió el último recordatorio — Calle Mayor 15, 28013 Madrid, correcto?",
+    "spans": [
+      {
+        "value": "Calle Mayor 15, 28013 Madrid",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "¿A qué dirección se envió el último recordatorio — Avenida de la Constitución 3, 41001 Sevilla, correcto?",
+    "spans": [
+      {
+        "value": "Avenida de la Constitución 3, 41001 Sevilla",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "¿A qué dirección se envió el último recordatorio — Calle de Alcalá 89, 28009 Madrid, correcto?",
+    "spans": [
+      {
+        "value": "Calle de Alcalá 89, 28009 Madrid",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Enfermedad y vacaciones se contabilizan por separado en el informe.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "La Dirección General y el Comité de Empresa se reúnen el lunes.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Explica la diferencia entre salario bruto y salario neto.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Calle, avenida y paseo son tipos de vía distintos en el módulo de direcciones.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "El Camino de Santiago aparece como ejemplo en la guía de estilo.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Recursos Humanos publicará mañana la nueva tabla salarial.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "El Buen Retiro es el nombre en clave del proyecto de la nueva oficina.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Mercadona, Zara y Repsol aparecen como ejemplos en el informe sectorial.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "¿Cuántos días de vacaciones acumula un empleado tras tres años de antigüedad?",
+    "spans": []
+  },
+  {
+    "text": "Prepara un informe de estado del proyecto del tercer trimestre; el presupuesto no cambia.",
+    "spans": []
+  },
+  {
+    "text": "Resume la política de gastos de viaje en cinco puntos.",
+    "spans": []
+  },
+  {
+    "text": "¿Qué pasos cubre el proceso de incorporación durante el primer mes?",
+    "spans": []
+  },
+  {
+    "text": "Redacta un recordatorio amable sobre el registro semanal de horas.",
+    "spans": []
+  },
+  {
+    "text": "¿Cómo solicito un portátil nuevo a través del sistema de tickets?",
+    "spans": []
+  },
+  {
+    "text": "Prepara un orden del día para la próxima reunión de equipo con tres prioridades.",
+    "spans": []
+  },
+  {
+    "text": "¿Qué plazos aplican a la entrega de los informes de gastos?",
+    "spans": []
+  },
+  {
+    "text": "Resume los cambios recientes de la política de teletrabajo.",
+    "spans": []
+  },
+  {
+    "text": "¿Cómo funciona la aprobación de pedidos en el módulo de compras?",
+    "spans": []
+  },
+  {
+    "text": "Explica el flujo de aprobación de las formaciones externas.",
+    "spans": []
+  },
+  {
+    "text": "¿Qué informes puede generar mensualmente el módulo de contabilidad?",
+    "spans": []
+  },
+  {
+    "text": "Escribe un breve anuncio sobre el mantenimiento del sistema este fin de semana.",
+    "spans": []
+  },
+  {
+    "text": "¿Cómo creo un nuevo centro de coste en el sistema?",
+    "spans": []
+  },
+  {
+    "text": "¿Cuál es la diferencia entre un presupuesto y una confirmación de pedido?",
+    "spans": []
+  },
+  {
+    "text": "Prepara una lista de comprobación para el cierre mensual en contabilidad.",
+    "spans": []
+  },
+  {
+    "text": "¿Cómo exporto el resumen de vacaciones como hoja de cálculo?",
+    "spans": []
+  },
+  {
+    "text": "¿Qué roles participan en la aprobación de facturas recibidas?",
+    "spans": []
+  },
+  {
+    "text": "Redacta una negativa cortés para un plazo de entrega aplazado.",
+    "spans": []
+  },
+  {
+    "text": "Resume los puntos clave del acuerdo de horario flexible.",
+    "spans": []
+  },
+  {
+    "text": "¿Cómo configuro una respuesta de ausencia para las fiestas?",
+    "spans": []
+  },
+  {
+    "text": "¿Qué campos son obligatorios al crear un proveedor nuevo?",
+    "spans": []
+  },
+  {
+    "text": "Describe el procedimiento del inventario anual del almacén.",
+    "spans": []
+  },
+  {
+    "text": "¿Cómo se pueden generar facturas recurrentes automáticamente?",
+    "spans": []
+  }
+]

--- a/middleware/packages/harness-plugin-privacy-guard/src/validation/fixtures/fr.json
+++ b/middleware/packages/harness-plugin-privacy-guard/src/validation/fixtures/fr.json
@@ -1,0 +1,1475 @@
+[
+  {
+    "text": "Guillaume de Villeneuve rejoint l'équipe commerciale le mois prochain.",
+    "spans": [
+      {
+        "value": "Guillaume de Villeneuve",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Anne d'Harcourt présidera le comité de pilotage à partir de septembre.",
+    "spans": [
+      {
+        "value": "Anne d'Harcourt",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Marie de la Roche et Julien Lefèvre partagent la responsabilité du site de Lyon.",
+    "spans": [
+      {
+        "value": "Marie de la Roche",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Julien Lefèvre",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Henri du Plessis attend toujours la réponse concernant sa demande de mutation.",
+    "spans": [
+      {
+        "value": "Henri du Plessis",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Madame Moreau n'a pas encore signé l'avenant — merci de la relancer.",
+    "spans": [
+      {
+        "value": "Madame Moreau",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Livrez le matériel à l'entrepôt derrière l'ancienne gare au 27 rue des Lilas, deuxième portail à gauche après le passage à niveau, 44000 Nantes.",
+    "spans": [
+      {
+        "value": "l'entrepôt derrière l'ancienne gare au 27 rue des Lilas, deuxième portail à gauche après le passage à niveau, 44000 Nantes",
+        "type": "address",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Envoie le coursier au 8 avenue Victor Hugo avant midi.",
+    "spans": [
+      {
+        "value": "8 avenue Victor Hugo",
+        "type": "address",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Le numéro de sécurité sociale de Camille Moreau est 1 84 12 75 123 456 78.",
+    "spans": [
+      {
+        "value": "Camille Moreau",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "1 84 12 75 123 456 78",
+        "type": "idnum",
+        "tier": "critical"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Élodie Bernard est née le 17 septembre 1984 à Bordeaux.",
+    "spans": [
+      {
+        "value": "Élodie Bernard",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "17 septembre 1984",
+        "type": "date",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Contacte Thibault Marchand au 06 71 23 45 89 pour la visite médicale.",
+    "spans": [
+      {
+        "value": "Thibault Marchand",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "06 71 23 45 89",
+        "type": "phone",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Au séminaire participent Pauline Chevalier, Antoine Perrot et Margaux Lambert.",
+    "spans": [
+      {
+        "value": "Pauline Chevalier",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Antoine Perrot",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Margaux Lambert",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "La prime de Nicolas Girard, soit 2 400 €, sera versée avec la paie de mars.",
+    "spans": [
+      {
+        "value": "Nicolas Girard",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "2 400 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Merci de virer l'acompte sur le compte FR76 3000 6000 0112 3456 7890 189 de Claire Fontaine.",
+    "spans": [
+      {
+        "value": "FR76 3000 6000 0112 3456 7890 189",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "Claire Fontaine",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "La candidate Inès Blanchard-Torres a réussi le second entretien.",
+    "spans": [
+      {
+        "value": "Inès Blanchard-Torres",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "M. N'Diaye du service comptabilité demande un accès au module fournisseurs.",
+    "spans": [
+      {
+        "value": "M. N'Diaye",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Jean-Pierre Lemaire prend sa retraite le 30/06/2027.",
+    "spans": [
+      {
+        "value": "Jean-Pierre Lemaire",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "30/06/2027",
+        "type": "date",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Transmets le contrat signé à c.fontaine@societe-exemple.fr et préviens Claire Fontaine.",
+    "spans": [
+      {
+        "value": "c.fontaine@societe-exemple.fr",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "Claire Fontaine",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Que devrions-nous proposer à Damien Roche, dont le salaire actuel est de 899 € ?",
+    "spans": [
+      {
+        "value": "Damien Roche",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "899 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Que devrions-nous proposer à Romain Delacroix, dont le salaire actuel est de 3 499 € ?",
+    "spans": [
+      {
+        "value": "Romain Delacroix",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "3 499 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Que devrions-nous proposer à Amélie Dubois, dont le salaire actuel est de 12 750 € ?",
+    "spans": [
+      {
+        "value": "Amélie Dubois",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "12 750 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Que devrions-nous proposer à Amélie Dubois, dont le salaire actuel est de 4 980 € ?",
+    "spans": [
+      {
+        "value": "Amélie Dubois",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "4 980 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Merci de virer l'acompte sur FR58 3000 6000 0148 9226 7411 707 et de mettre a.dubois@exemple-sarl.fr en copie.",
+    "spans": [
+      {
+        "value": "FR58 3000 6000 0148 9226 7411 707",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "a.dubois@exemple-sarl.fr",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Merci de virer l'acompte sur FR33 3000 6000 0112 3456 7891 234 et de mettre n.girard@courriel-exemple.fr en copie.",
+    "spans": [
+      {
+        "value": "FR33 3000 6000 0112 3456 7891 234",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "n.girard@courriel-exemple.fr",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Merci de virer l'acompte sur FR21 2004 1010 0505 8834 3M02 411 et de mettre camille.moreau@exemple-sarl.fr en copie.",
+    "spans": [
+      {
+        "value": "FR21 2004 1010 0505 8834 3M02 411",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "camille.moreau@exemple-sarl.fr",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Merci de virer l'acompte sur FR47 2004 1010 0505 0001 3M02 585 et de mettre t.marchand@societe-exemple.fr en copie.",
+    "spans": [
+      {
+        "value": "FR47 2004 1010 0505 0001 3M02 585",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "t.marchand@societe-exemple.fr",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Appelle Louise Prévost au +33 4 91 55 11 20 — date de naissance : 01/02/2023.",
+    "spans": [
+      {
+        "value": "Louise Prévost",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+33 4 91 55 11 20",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "01/02/2023",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Appelle Mathieu Rousseau au 01 45 67 89 23 — date de naissance : 12/11/1979.",
+    "spans": [
+      {
+        "value": "Mathieu Rousseau",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "01 45 67 89 23",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "12/11/1979",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Appelle Hugo Charpentier au 06 32 18 90 47 — date de naissance : 12/11/1979.",
+    "spans": [
+      {
+        "value": "Hugo Charpentier",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "06 32 18 90 47",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "12/11/1979",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Appelle Damien Roche au +33 7 60 12 34 56 — date de naissance : 17/09/1984.",
+    "spans": [
+      {
+        "value": "Damien Roche",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+33 7 60 12 34 56",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "17/09/1984",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "La facture de 899 € doit être envoyée à l'adresse 3 boulevard Saint-Michel, 75005 Paris.",
+    "spans": [
+      {
+        "value": "899 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "3 boulevard Saint-Michel, 75005 Paris",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "La facture de 899 € doit être envoyée à l'adresse 9 impasse des Acacias, 31000 Toulouse.",
+    "spans": [
+      {
+        "value": "899 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "9 impasse des Acacias, 31000 Toulouse",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "La facture de 12 750 € doit être envoyée à l'adresse 8 avenue Victor Hugo, 69006 Lyon.",
+    "spans": [
+      {
+        "value": "12 750 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "8 avenue Victor Hugo, 69006 Lyon",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "La facture de 64 000 € doit être envoyée à l'adresse 14 rue du Château, 67000 Strasbourg.",
+    "spans": [
+      {
+        "value": "64 000 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "14 rue du Château, 67000 Strasbourg",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Crée la fiche de Bastien Leroy avec l'adresse e-mail professionnelle j.lefevre@societe-exemple.fr.",
+    "spans": [
+      {
+        "value": "Bastien Leroy",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "j.lefevre@societe-exemple.fr",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Crée la fiche de Romain Delacroix avec l'adresse e-mail professionnelle t.marchand@societe-exemple.fr.",
+    "spans": [
+      {
+        "value": "Romain Delacroix",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "t.marchand@societe-exemple.fr",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Crée la fiche de Damien Roche avec l'adresse e-mail professionnelle rh@exemple-conseil.fr.",
+    "spans": [
+      {
+        "value": "Damien Roche",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "rh@exemple-conseil.fr",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Crée la fiche de Chloé Vasseur avec l'adresse e-mail professionnelle j.lefevre@societe-exemple.fr.",
+    "spans": [
+      {
+        "value": "Chloé Vasseur",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "j.lefevre@societe-exemple.fr",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Étienne Caron a quitté l'entreprise le 12/11/1979 — merci de lancer le processus de départ.",
+    "spans": [
+      {
+        "value": "Étienne Caron",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "12/11/1979",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Margaux Lambert a quitté l'entreprise le 01/02/2023 — merci de lancer le processus de départ.",
+    "spans": [
+      {
+        "value": "Margaux Lambert",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "01/02/2023",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Amélie Dubois a quitté l'entreprise le 17/09/1984 — merci de lancer le processus de départ.",
+    "spans": [
+      {
+        "value": "Amélie Dubois",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "17/09/1984",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Damien Roche a quitté l'entreprise le 03/05/1991 — merci de lancer le processus de départ.",
+    "spans": [
+      {
+        "value": "Damien Roche",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "03/05/1991",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Mets à jour la fiche : Romain Delacroix habite désormais au 9 impasse des Acacias, 31000 Toulouse.",
+    "spans": [
+      {
+        "value": "Romain Delacroix",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "9 impasse des Acacias, 31000 Toulouse",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Mets à jour la fiche : Étienne Caron habite désormais au 8 avenue Victor Hugo, 69006 Lyon.",
+    "spans": [
+      {
+        "value": "Étienne Caron",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "8 avenue Victor Hugo, 69006 Lyon",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Mets à jour la fiche : Julien Lefèvre habite désormais au 5 place de la République, 34000 Montpellier.",
+    "spans": [
+      {
+        "value": "Julien Lefèvre",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "5 place de la République, 34000 Montpellier",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Mets à jour la fiche : Thibault Marchand habite désormais au 27 rue des Lilas, 44000 Nantes.",
+    "spans": [
+      {
+        "value": "Thibault Marchand",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "27 rue des Lilas, 44000 Nantes",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Rembourse les frais de déplacement de 4 980 € sur FR58 3000 6000 0148 9226 7411 707.",
+    "spans": [
+      {
+        "value": "4 980 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "FR58 3000 6000 0148 9226 7411 707",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Rembourse les frais de déplacement de 2 400 € sur FR21 2004 1010 0505 8834 3M02 411.",
+    "spans": [
+      {
+        "value": "2 400 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "FR21 2004 1010 0505 8834 3M02 411",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Rembourse les frais de déplacement de 58 900 € sur FR76 3000 6000 0112 3456 7890 189.",
+    "spans": [
+      {
+        "value": "58 900 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "FR76 3000 6000 0112 3456 7890 189",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Rembourse les frais de déplacement de 2 300 € sur FR33 3000 6000 0112 3456 7891 234.",
+    "spans": [
+      {
+        "value": "2 300 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "FR33 3000 6000 0112 3456 7891 234",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Envoie le bulletin de paie à t.marchand@societe-exemple.fr ; le brut s'élève à 4 980 €.",
+    "spans": [
+      {
+        "value": "t.marchand@societe-exemple.fr",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "4 980 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Envoie le bulletin de paie à c.fontaine@societe-exemple.fr ; le brut s'élève à 72 000 €.",
+    "spans": [
+      {
+        "value": "c.fontaine@societe-exemple.fr",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "72 000 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Envoie le bulletin de paie à paie@exemple-sarl.fr ; le brut s'élève à 72 000 €.",
+    "spans": [
+      {
+        "value": "paie@exemple-sarl.fr",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "72 000 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Envoie le bulletin de paie à facturation@exemple-conseil.fr ; le brut s'élève à 12 750 €.",
+    "spans": [
+      {
+        "value": "facturation@exemple-conseil.fr",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "12 750 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Pour la prise de références, tu peux joindre Margaux Lambert au +33 2 40 89 63 12.",
+    "spans": [
+      {
+        "value": "Margaux Lambert",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+33 2 40 89 63 12",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Pour la prise de références, tu peux joindre Camille Moreau au +33 4 91 55 11 20.",
+    "spans": [
+      {
+        "value": "Camille Moreau",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+33 4 91 55 11 20",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Pour la prise de références, tu peux joindre Pauline Chevalier au +33 1 42 68 53 00.",
+    "spans": [
+      {
+        "value": "Pauline Chevalier",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+33 1 42 68 53 00",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Pour la prise de références, tu peux joindre Manon Berger au +33 4 91 55 11 20.",
+    "spans": [
+      {
+        "value": "Manon Berger",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+33 4 91 55 11 20",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Prépare l'entretien annuel avec Damien Roche.",
+    "spans": [
+      {
+        "value": "Damien Roche",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Prépare l'entretien annuel avec Élodie Bernard.",
+    "spans": [
+      {
+        "value": "Élodie Bernard",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Prépare l'entretien annuel avec Pauline Chevalier.",
+    "spans": [
+      {
+        "value": "Pauline Chevalier",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Prépare l'entretien annuel avec Hugo Charpentier.",
+    "spans": [
+      {
+        "value": "Hugo Charpentier",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Margaux Lambert s'est déclaré malade le 01/02/2023 — enregistre-le dans le module RH.",
+    "spans": [
+      {
+        "value": "Margaux Lambert",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "01/02/2023",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Claire Fontaine s'est déclaré malade le 17/09/1984 — enregistre-le dans le module RH.",
+    "spans": [
+      {
+        "value": "Claire Fontaine",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "17/09/1984",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Florian Mercier s'est déclaré malade le 30/06/2026 — enregistre-le dans le module RH.",
+    "spans": [
+      {
+        "value": "Florian Mercier",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "30/06/2026",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Thibault Marchand s'est déclaré malade le 12/11/1979 — enregistre-le dans le module RH.",
+    "spans": [
+      {
+        "value": "Thibault Marchand",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "12/11/1979",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Le fournisseur attend le règlement de 3 499 € sur FR47 2004 1010 0505 0001 3M02 585.",
+    "spans": [
+      {
+        "value": "3 499 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "FR47 2004 1010 0505 0001 3M02 585",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Le fournisseur attend le règlement de 12 750 € sur FR58 3000 6000 0148 9226 7411 707.",
+    "spans": [
+      {
+        "value": "12 750 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "FR58 3000 6000 0148 9226 7411 707",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Le fournisseur attend le règlement de 3 499 € sur FR58 3000 6000 0148 9226 7411 707.",
+    "spans": [
+      {
+        "value": "3 499 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "FR58 3000 6000 0148 9226 7411 707",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Le fournisseur attend le règlement de 4 980 € sur FR76 3000 6000 0112 3456 7890 189.",
+    "spans": [
+      {
+        "value": "4 980 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "FR76 3000 6000 0112 3456 7890 189",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Nouvelle candidature : Louise Prévost, joignable au 06 32 18 90 47 ou via facturation@exemple-conseil.fr.",
+    "spans": [
+      {
+        "value": "Louise Prévost",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "06 32 18 90 47",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "facturation@exemple-conseil.fr",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Nouvelle candidature : Camille Moreau, joignable au +33 2 40 89 63 12 ou via t.marchand@societe-exemple.fr.",
+    "spans": [
+      {
+        "value": "Camille Moreau",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+33 2 40 89 63 12",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "t.marchand@societe-exemple.fr",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Nouvelle candidature : Antoine Perrot, joignable au 01 45 67 89 23 ou via comptabilite@exemple-sarl.fr.",
+    "spans": [
+      {
+        "value": "Antoine Perrot",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "01 45 67 89 23",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "comptabilite@exemple-sarl.fr",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Nouvelle candidature : Inès Blanchard, joignable au 01 45 67 89 23 ou via m.rousseau@exemple-conseil.fr.",
+    "spans": [
+      {
+        "value": "Inès Blanchard",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "01 45 67 89 23",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "m.rousseau@exemple-conseil.fr",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Envoie la proposition à Camille Moreau, 3 boulevard Saint-Michel, 75005 Paris.",
+    "spans": [
+      {
+        "value": "Camille Moreau",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "3 boulevard Saint-Michel, 75005 Paris",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Envoie la proposition à Nicolas Girard, 9 impasse des Acacias, 31000 Toulouse.",
+    "spans": [
+      {
+        "value": "Nicolas Girard",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "9 impasse des Acacias, 31000 Toulouse",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Envoie la proposition à Étienne Caron, 5 place de la République, 34000 Montpellier.",
+    "spans": [
+      {
+        "value": "Étienne Caron",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "5 place de la République, 34000 Montpellier",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Envoie la proposition à Solène Garnier, 22 quai des Belges, 13001 Marseille.",
+    "spans": [
+      {
+        "value": "Solène Garnier",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "22 quai des Belges, 13001 Marseille",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Le contrat de Élodie Bernard débute le 28/02/1995 avec un salaire annuel de 58 900 €.",
+    "spans": [
+      {
+        "value": "Élodie Bernard",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "28/02/1995",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "58 900 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Le contrat de Quentin Aubert débute le 01/02/2023 avec un salaire annuel de 12 750 €.",
+    "spans": [
+      {
+        "value": "Quentin Aubert",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "01/02/2023",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "12 750 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Le contrat de Julien Lefèvre débute le 28/02/1995 avec un salaire annuel de 2 400 €.",
+    "spans": [
+      {
+        "value": "Julien Lefèvre",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "28/02/1995",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "2 400 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Le contrat de Océane Faure débute le 12/11/1979 avec un salaire annuel de 64 000 €.",
+    "spans": [
+      {
+        "value": "Océane Faure",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "12/11/1979",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "64 000 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Inscris Camille Moreau à la formation de la semaine prochaine et informe m.rousseau@exemple-conseil.fr.",
+    "spans": [
+      {
+        "value": "Camille Moreau",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "m.rousseau@exemple-conseil.fr",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Inscris Étienne Caron à la formation de la semaine prochaine et informe t.marchand@societe-exemple.fr.",
+    "spans": [
+      {
+        "value": "Étienne Caron",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "t.marchand@societe-exemple.fr",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Inscris Solène Garnier à la formation de la semaine prochaine et informe j.lefevre@societe-exemple.fr.",
+    "spans": [
+      {
+        "value": "Solène Garnier",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "j.lefevre@societe-exemple.fr",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Inscris Océane Faure à la formation de la semaine prochaine et informe c.fontaine@societe-exemple.fr.",
+    "spans": [
+      {
+        "value": "Océane Faure",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "c.fontaine@societe-exemple.fr",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "À quelle adresse la dernière relance est-elle partie — 22 quai des Belges, 13001 Marseille, c'est bien ça ?",
+    "spans": [
+      {
+        "value": "22 quai des Belges, 13001 Marseille",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "À quelle adresse la dernière relance est-elle partie — 9 impasse des Acacias, 31000 Toulouse, c'est bien ça ?",
+    "spans": [
+      {
+        "value": "9 impasse des Acacias, 31000 Toulouse",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "À quelle adresse la dernière relance est-elle partie — 27 rue des Lilas, 44000 Nantes, c'est bien ça ?",
+    "spans": [
+      {
+        "value": "27 rue des Lilas, 44000 Nantes",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "À quelle adresse la dernière relance est-elle partie — 8 avenue Victor Hugo, 69006 Lyon, c'est bien ça ?",
+    "spans": [
+      {
+        "value": "8 avenue Victor Hugo, 69006 Lyon",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "La Direction et le Comité Social et Économique se réunissent lundi matin.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Maladie et congés payés sont comptés séparément dans le rapport mensuel.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Explique la différence entre salaire brut et salaire net.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Rue, avenue et boulevard sont des types de voies distincts dans le module d'adresses.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "La Sécurité Sociale exige un justificatif pour tout arrêt de plus de trois jours.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Les Ressources Humaines publient la nouvelle grille interne demain.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Victor Hugo est au programme du séminaire littéraire de l'équipe communication.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Le Salon de l'Agriculture ferme ses portes dimanche — aucun stand ne reste ouvert.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Combien de jours de congé un salarié cumule-t-il après trois ans d'ancienneté ?",
+    "spans": []
+  },
+  {
+    "text": "Prépare un rapport d'avancement pour le projet du troisième trimestre, budget inchangé.",
+    "spans": []
+  },
+  {
+    "text": "Résume la politique de notes de frais en cinq points.",
+    "spans": []
+  },
+  {
+    "text": "Quelles étapes couvre le parcours d'intégration le premier mois ?",
+    "spans": []
+  },
+  {
+    "text": "Rédige un rappel amical concernant la saisie hebdomadaire des temps.",
+    "spans": []
+  },
+  {
+    "text": "Comment demander un nouvel ordinateur portable via l'outil de tickets ?",
+    "spans": []
+  },
+  {
+    "text": "Prépare un ordre du jour pour la prochaine réunion d'équipe avec trois priorités.",
+    "spans": []
+  },
+  {
+    "text": "Quels délais s'appliquent à la remise des notes de frais ?",
+    "spans": []
+  },
+  {
+    "text": "Résume les changements récents de la politique de télétravail.",
+    "spans": []
+  },
+  {
+    "text": "Comment fonctionne la validation des bons de commande dans le module achats ?",
+    "spans": []
+  },
+  {
+    "text": "Explique le circuit d'approbation des formations externes.",
+    "spans": []
+  },
+  {
+    "text": "Quels rapports le module comptable peut-il générer chaque mois ?",
+    "spans": []
+  },
+  {
+    "text": "Rédige une courte annonce pour la maintenance du système ce week-end.",
+    "spans": []
+  },
+  {
+    "text": "Comment créer un nouveau centre de coûts dans le système ?",
+    "spans": []
+  },
+  {
+    "text": "Quelle est la différence entre un devis et une confirmation de commande ?",
+    "spans": []
+  },
+  {
+    "text": "Prépare une liste de contrôle pour la clôture mensuelle en comptabilité.",
+    "spans": []
+  },
+  {
+    "text": "Comment exporter le récapitulatif des congés sous forme de tableau ?",
+    "spans": []
+  },
+  {
+    "text": "Quels rôles interviennent dans la validation des factures fournisseurs ?",
+    "spans": []
+  },
+  {
+    "text": "Rédige un refus poli pour un délai de livraison reporté.",
+    "spans": []
+  },
+  {
+    "text": "Résume les points clés de l'accord sur les horaires flexibles.",
+    "spans": []
+  },
+  {
+    "text": "Comment configurer un message d'absence pour les fêtes ?",
+    "spans": []
+  },
+  {
+    "text": "Quels champs sont obligatoires à la création d'un fournisseur ?",
+    "spans": []
+  },
+  {
+    "text": "Décris le déroulement de l'inventaire annuel de l'entrepôt.",
+    "spans": []
+  },
+  {
+    "text": "Comment générer automatiquement des factures récurrentes ?",
+    "spans": []
+  }
+]

--- a/middleware/packages/harness-plugin-privacy-guard/src/validation/fixtures/it.json
+++ b/middleware/packages/harness-plugin-privacy-guard/src/validation/fixtures/it.json
@@ -1,0 +1,1480 @@
+[
+  {
+    "text": "Mario Rossi, codice fiscale RSSMRA85T10A562S, va inserito in anagrafica fornitori.",
+    "spans": [
+      {
+        "value": "Mario Rossi",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "RSSMRA85T10A562S",
+        "type": "idnum",
+        "tier": "critical"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Il codice fiscale di Giulia Ferrari è FRRGLI90A41L219X — aggiornare la scheda.",
+    "spans": [
+      {
+        "value": "Giulia Ferrari",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "FRRGLI90A41L219X",
+        "type": "idnum",
+        "tier": "critical"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Chiara Romano e Marco Esposito condividono il coordinamento del turno serale.",
+    "spans": [
+      {
+        "value": "Chiara Romano",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Marco Esposito",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Il signor Bianchi attende ancora una risposta sull'aspettativa.",
+    "spans": [
+      {
+        "value": "signor Bianchi",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Consegnate il materiale al magazzino dietro la vecchia stazione in Via dei Tigli 27, secondo cancello a sinistra dopo il passaggio a livello, 40121 Bologna.",
+    "spans": [
+      {
+        "value": "al magazzino dietro la vecchia stazione in Via dei Tigli 27, secondo cancello a sinistra dopo il passaggio a livello, 40121 Bologna",
+        "type": "address",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Manda il corriere in Piazza del Duomo 1 entro mezzogiorno.",
+    "spans": [
+      {
+        "value": "Piazza del Duomo 1",
+        "type": "address",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Matteo De Luca subentra come referente per la sede di Genova.",
+    "spans": [
+      {
+        "value": "Matteo De Luca",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Al workshop partecipano Valentina Conti, Davide Gallo e Silvia Costa.",
+    "spans": [
+      {
+        "value": "Valentina Conti",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Davide Gallo",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Silvia Costa",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "La tredicesima di Luca Marino, pari a 2.150,00 €, sarà accreditata a dicembre.",
+    "spans": [
+      {
+        "value": "Luca Marino",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "2.150,00 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Trasferisci l'acconto sul conto IT60 X054 2811 1010 0000 0123 456 di Elisa Fontana.",
+    "spans": [
+      {
+        "value": "IT60 X054 2811 1010 0000 0123 456",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "Elisa Fontana",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Chiama Andrea Serra al +39 347 112 8845 per la visita medica.",
+    "spans": [
+      {
+        "value": "Andrea Serra",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+39 347 112 8845",
+        "type": "phone",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Federica Villa è nata il 24/12/1987 secondo il fascicolo.",
+    "spans": [
+      {
+        "value": "Federica Villa",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "24/12/1987",
+        "type": "date",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Il candidato Riccardo Monti-Pellegrini ha superato il secondo colloquio.",
+    "spans": [
+      {
+        "value": "Riccardo Monti-Pellegrini",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "L'ospite si chiama Jean-Claude Njoya e arriva dalla sede di Lione.",
+    "spans": [
+      {
+        "value": "Jean-Claude Njoya",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "La dottoressa Alessia Barbieri coprirà l'ambulatorio aziendale a marzo.",
+    "spans": [
+      {
+        "value": "Alessia Barbieri",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Stefano Longo ha comunicato il nuovo indirizzo: Via San Marco 19, 35139 Padova.",
+    "spans": [
+      {
+        "value": "Stefano Longo",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Via San Marco 19, 35139 Padova",
+        "type": "address",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Inoltra il contratto firmato a f.greco@azienda-esempio.it e avvisa Francesca Greco.",
+    "spans": [
+      {
+        "value": "f.greco@azienda-esempio.it",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "Francesca Greco",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Quanto dovremmo offrire a Simone Ferraro, considerando lo stipendio attuale di 67.200 €?",
+    "spans": [
+      {
+        "value": "Simone Ferraro",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "67.200 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Quanto dovremmo offrire a Nicola Basile, considerando lo stipendio attuale di 1.250,50 €?",
+    "spans": [
+      {
+        "value": "Nicola Basile",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "1.250,50 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Quanto dovremmo offrire a Luca Marino, considerando lo stipendio attuale di 72.000 €?",
+    "spans": [
+      {
+        "value": "Luca Marino",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "72.000 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Quanto dovremmo offrire a Beatrice Colombo, considerando lo stipendio attuale di 2.150,00 €?",
+    "spans": [
+      {
+        "value": "Beatrice Colombo",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "2.150,00 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Bonifica l'acconto su IT09 X054 2811 1010 5544 3322 110 e metti in copia d.gallo@azienda-esempio.it.",
+    "spans": [
+      {
+        "value": "IT09 X054 2811 1010 5544 3322 110",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "d.gallo@azienda-esempio.it",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bonifica l'acconto su IT45 K054 2811 1010 0000 0987 654 e metti in copia hr@esempio-consult.it.",
+    "spans": [
+      {
+        "value": "IT45 K054 2811 1010 0000 0987 654",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "hr@esempio-consult.it",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bonifica l'acconto su IT77 B030 0203 2801 9911 2233 445 e metti in copia paghe@esempio-srl.it.",
+    "spans": [
+      {
+        "value": "IT77 B030 0203 2801 9911 2233 445",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "paghe@esempio-srl.it",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bonifica l'acconto su IT09 X054 2811 1010 5544 3322 110 e metti in copia fatture@esempio-consult.it.",
+    "spans": [
+      {
+        "value": "IT09 X054 2811 1010 5544 3322 110",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "fatture@esempio-consult.it",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Chiama Camilla Orlandi al +39 06 4890 0312; la data di nascita in archivio è 24/12/1987.",
+    "spans": [
+      {
+        "value": "Camilla Orlandi",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+39 06 4890 0312",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "24/12/1987",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Chiama Federica Villa al 011 562 4478; la data di nascita in archivio è 17/09/1984.",
+    "spans": [
+      {
+        "value": "Federica Villa",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "011 562 4478",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "17/09/1984",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Chiama Marco Esposito al +39 320 445 7789; la data di nascita in archivio è 24/12/1987.",
+    "spans": [
+      {
+        "value": "Marco Esposito",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+39 320 445 7789",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "24/12/1987",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Chiama Stefano Longo al +39 320 445 7789; la data di nascita in archivio è 28/02/1995.",
+    "spans": [
+      {
+        "value": "Stefano Longo",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+39 320 445 7789",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "28/02/1995",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "La fattura di 2.150,00 € va spedita a Largo Augusto 2, 20122 Milano.",
+    "spans": [
+      {
+        "value": "2.150,00 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Largo Augusto 2, 20122 Milano",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "La fattura di 58.500 € va spedita a Via Dante 5, 16121 Genova.",
+    "spans": [
+      {
+        "value": "58.500 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Via Dante 5, 16121 Genova",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "La fattura di 4.980 € va spedita a Via Dante 5, 16121 Genova.",
+    "spans": [
+      {
+        "value": "4.980 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Via Dante 5, 16121 Genova",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "La fattura di 72.000 € va spedita a Via Dante 5, 16121 Genova.",
+    "spans": [
+      {
+        "value": "72.000 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Via Dante 5, 16121 Genova",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Registra Federica Villa come nuovo dipendente con l'email aziendale f.greco@azienda-esempio.it.",
+    "spans": [
+      {
+        "value": "Federica Villa",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "f.greco@azienda-esempio.it",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Registra Nicola Basile come nuovo dipendente con l'email aziendale d.gallo@azienda-esempio.it.",
+    "spans": [
+      {
+        "value": "Nicola Basile",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "d.gallo@azienda-esempio.it",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Registra Riccardo Monti come nuovo dipendente con l'email aziendale l.marino@posta-esempio.it.",
+    "spans": [
+      {
+        "value": "Riccardo Monti",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "l.marino@posta-esempio.it",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Registra Andrea Serra come nuovo dipendente con l'email aziendale l.marino@posta-esempio.it.",
+    "spans": [
+      {
+        "value": "Andrea Serra",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "l.marino@posta-esempio.it",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Alessia Barbieri ha lasciato l'azienda il 28/02/1995 — avvia la procedura di uscita.",
+    "spans": [
+      {
+        "value": "Alessia Barbieri",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "28/02/1995",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Giulia Ferrari ha lasciato l'azienda il 17/09/1984 — avvia la procedura di uscita.",
+    "spans": [
+      {
+        "value": "Giulia Ferrari",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "17/09/1984",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Martina Rizzo ha lasciato l'azienda il 12/11/1979 — avvia la procedura di uscita.",
+    "spans": [
+      {
+        "value": "Martina Rizzo",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "12/11/1979",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Ilaria Pellegrini ha lasciato l'azienda il 03/05/1991 — avvia la procedura di uscita.",
+    "spans": [
+      {
+        "value": "Ilaria Pellegrini",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "03/05/1991",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Aggiorna l'anagrafica: Matteo De Luca abita ora in Via Roma 8, 50123 Firenze.",
+    "spans": [
+      {
+        "value": "Matteo De Luca",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Via Roma 8, 50123 Firenze",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Aggiorna l'anagrafica: Chiara Romano abita ora in Via Roma 8, 50123 Firenze.",
+    "spans": [
+      {
+        "value": "Chiara Romano",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Via Roma 8, 50123 Firenze",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Aggiorna l'anagrafica: Chiara Romano abita ora in Viale dei Mille 33, 40121 Bologna.",
+    "spans": [
+      {
+        "value": "Chiara Romano",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Viale dei Mille 33, 40121 Bologna",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Aggiorna l'anagrafica: Davide Gallo abita ora in Piazza del Duomo 1, 20121 Milano.",
+    "spans": [
+      {
+        "value": "Davide Gallo",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Piazza del Duomo 1, 20121 Milano",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Rimborsa le spese di trasferta di 62.400 € su IT60 X054 2811 1010 0000 0123 456.",
+    "spans": [
+      {
+        "value": "62.400 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "IT60 X054 2811 1010 0000 0123 456",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Rimborsa le spese di trasferta di 58.500 € su IT09 X054 2811 1010 5544 3322 110.",
+    "spans": [
+      {
+        "value": "58.500 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "IT09 X054 2811 1010 5544 3322 110",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Rimborsa le spese di trasferta di 4.980 € su IT28 W030 0203 2801 1257 3862 400.",
+    "spans": [
+      {
+        "value": "4.980 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "IT28 W030 0203 2801 1257 3862 400",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Rimborsa le spese di trasferta di 58.500 € su IT60 X054 2811 1010 0000 0123 456.",
+    "spans": [
+      {
+        "value": "58.500 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "IT60 X054 2811 1010 0000 0123 456",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Invia il cedolino a c.romano@posta-esempio.it; il lordo è di 58.500 €.",
+    "spans": [
+      {
+        "value": "c.romano@posta-esempio.it",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "58.500 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Invia il cedolino a giulia.ferrari@esempio-srl.it; il lordo è di 4.980 €.",
+    "spans": [
+      {
+        "value": "giulia.ferrari@esempio-srl.it",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "4.980 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Invia il cedolino a a.ricci@esempio-consult.it; il lordo è di 67.200 €.",
+    "spans": [
+      {
+        "value": "a.ricci@esempio-consult.it",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "67.200 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Invia il cedolino a v.conti@esempio-srl.it; il lordo è di 67.200 €.",
+    "spans": [
+      {
+        "value": "v.conti@esempio-srl.it",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "67.200 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Per le referenze puoi raggiungere Stefano Longo al +39 02 8846 1220.",
+    "spans": [
+      {
+        "value": "Stefano Longo",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+39 02 8846 1220",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Per le referenze puoi raggiungere Ilaria Pellegrini al 011 562 4478.",
+    "spans": [
+      {
+        "value": "Ilaria Pellegrini",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "011 562 4478",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Per le referenze puoi raggiungere Elisa Fontana al 06 8830 1245.",
+    "spans": [
+      {
+        "value": "Elisa Fontana",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "06 8830 1245",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Per le referenze puoi raggiungere Silvia Costa al 011 562 4478.",
+    "spans": [
+      {
+        "value": "Silvia Costa",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "011 562 4478",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Prepara il colloquio di valutazione con Stefano Longo.",
+    "spans": [
+      {
+        "value": "Stefano Longo",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Prepara il colloquio di valutazione con Valentina Conti.",
+    "spans": [
+      {
+        "value": "Valentina Conti",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Prepara il colloquio di valutazione con Francesca Greco.",
+    "spans": [
+      {
+        "value": "Francesca Greco",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Prepara il colloquio di valutazione con Beatrice Colombo.",
+    "spans": [
+      {
+        "value": "Beatrice Colombo",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Elisa Fontana si è messo in malattia il 03/05/1991 — registralo nel modulo HR.",
+    "spans": [
+      {
+        "value": "Elisa Fontana",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "03/05/1991",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Giulia Ferrari si è messo in malattia il 01/02/2023 — registralo nel modulo HR.",
+    "spans": [
+      {
+        "value": "Giulia Ferrari",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "01/02/2023",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Martina Rizzo si è messo in malattia il 05/03/2001 — registralo nel modulo HR.",
+    "spans": [
+      {
+        "value": "Martina Rizzo",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "05/03/2001",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Chiara Romano si è messo in malattia il 05/03/2001 — registralo nel modulo HR.",
+    "spans": [
+      {
+        "value": "Chiara Romano",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "05/03/2001",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Il fornitore attende il pagamento di 72.000 € su IT28 W030 0203 2801 1257 3862 400.",
+    "spans": [
+      {
+        "value": "72.000 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "IT28 W030 0203 2801 1257 3862 400",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Il fornitore attende il pagamento di 58.500 € su IT09 X054 2811 1010 5544 3322 110.",
+    "spans": [
+      {
+        "value": "58.500 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "IT09 X054 2811 1010 5544 3322 110",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Il fornitore attende il pagamento di 72.000 € su IT12 A030 0203 2801 4455 6677 889.",
+    "spans": [
+      {
+        "value": "72.000 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "IT12 A030 0203 2801 4455 6677 889",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Il fornitore attende il pagamento di 1.250,50 € su IT09 X054 2811 1010 5544 3322 110.",
+    "spans": [
+      {
+        "value": "1.250,50 €",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "IT09 X054 2811 1010 5544 3322 110",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Nuova candidatura: Federica Villa, raggiungibile al +39 06 4890 0312 o via fatture@esempio-consult.it.",
+    "spans": [
+      {
+        "value": "Federica Villa",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+39 06 4890 0312",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "fatture@esempio-consult.it",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Nuova candidatura: Elisa Fontana, raggiungibile al 06 8830 1245 o via d.gallo@azienda-esempio.it.",
+    "spans": [
+      {
+        "value": "Elisa Fontana",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "06 8830 1245",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "d.gallo@azienda-esempio.it",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Nuova candidatura: Luca Marino, raggiungibile al +39 333 482 1157 o via l.marino@posta-esempio.it.",
+    "spans": [
+      {
+        "value": "Luca Marino",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+39 333 482 1157",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "l.marino@posta-esempio.it",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Nuova candidatura: Riccardo Monti, raggiungibile al +39 347 112 8845 o via giulia.ferrari@esempio-srl.it.",
+    "spans": [
+      {
+        "value": "Riccardo Monti",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+39 347 112 8845",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "giulia.ferrari@esempio-srl.it",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Spedisci l'offerta a Camilla Orlandi, Via San Marco 19, 35139 Padova.",
+    "spans": [
+      {
+        "value": "Camilla Orlandi",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Via San Marco 19, 35139 Padova",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Spedisci l'offerta a Tommaso Ferri, Viale dei Mille 33, 40121 Bologna.",
+    "spans": [
+      {
+        "value": "Tommaso Ferri",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Viale dei Mille 33, 40121 Bologna",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Spedisci l'offerta a Alessia Barbieri, Corso Vittorio Emanuele 15, 00186 Roma.",
+    "spans": [
+      {
+        "value": "Alessia Barbieri",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Corso Vittorio Emanuele 15, 00186 Roma",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Spedisci l'offerta a Marco Esposito, Corso Vittorio Emanuele 15, 00186 Roma.",
+    "spans": [
+      {
+        "value": "Marco Esposito",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Corso Vittorio Emanuele 15, 00186 Roma",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Il contratto di Luca Marino inizia il 01/02/2023 con una retribuzione annua di 1.250,50 €.",
+    "spans": [
+      {
+        "value": "Luca Marino",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "01/02/2023",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "1.250,50 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Il contratto di Marco Esposito inizia il 24/12/1987 con una retribuzione annua di 58.500 €.",
+    "spans": [
+      {
+        "value": "Marco Esposito",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "24/12/1987",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "58.500 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Il contratto di Riccardo Monti inizia il 05/03/2001 con una retribuzione annua di 1.250,50 €.",
+    "spans": [
+      {
+        "value": "Riccardo Monti",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "05/03/2001",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "1.250,50 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Il contratto di Chiara Romano inizia il 05/03/2001 con una retribuzione annua di 2.150,00 €.",
+    "spans": [
+      {
+        "value": "Chiara Romano",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "05/03/2001",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "2.150,00 €",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Iscrivi Beatrice Colombo alla formazione della prossima settimana e informa f.greco@azienda-esempio.it.",
+    "spans": [
+      {
+        "value": "Beatrice Colombo",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "f.greco@azienda-esempio.it",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Iscrivi Luca Marino alla formazione della prossima settimana e informa d.gallo@azienda-esempio.it.",
+    "spans": [
+      {
+        "value": "Luca Marino",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "d.gallo@azienda-esempio.it",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Iscrivi Riccardo Monti alla formazione della prossima settimana e informa m.esposito@azienda-esempio.it.",
+    "spans": [
+      {
+        "value": "Riccardo Monti",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "m.esposito@azienda-esempio.it",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Iscrivi Alessia Barbieri alla formazione della prossima settimana e informa l.marino@posta-esempio.it.",
+    "spans": [
+      {
+        "value": "Alessia Barbieri",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "l.marino@posta-esempio.it",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "A quale indirizzo è partito l'ultimo sollecito — Via Dante 5, 16121 Genova, giusto?",
+    "spans": [
+      {
+        "value": "Via Dante 5, 16121 Genova",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "A quale indirizzo è partito l'ultimo sollecito — Largo Augusto 2, 20122 Milano, giusto?",
+    "spans": [
+      {
+        "value": "Largo Augusto 2, 20122 Milano",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "A quale indirizzo è partito l'ultimo sollecito — Viale dei Mille 33, 40121 Bologna, giusto?",
+    "spans": [
+      {
+        "value": "Viale dei Mille 33, 40121 Bologna",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "A quale indirizzo è partito l'ultimo sollecito — Via Roma 8, 50123 Firenze, giusto?",
+    "spans": [
+      {
+        "value": "Via Roma 8, 50123 Firenze",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Malattia e ferie vengono conteggiate separatamente nel report mensile.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "La Direzione e il Consiglio di Amministrazione si riuniscono lunedì.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Spiega la differenza tra retribuzione lorda e netta.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Via, viale e piazza sono tipi di indirizzo distinti nel modulo anagrafico.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Leonardo da Vinci è il nome della sala riunioni al secondo piano.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Le Risorse Umane pubblicano domani il nuovo tariffario interno.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Il Codice Fiscale come campo è obbligatorio solo per i fornitori italiani.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "San Marco è la fermata più vicina alla sede di Padova.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Quanti giorni di ferie matura un dipendente dopo tre anni di anzianità?",
+    "spans": []
+  },
+  {
+    "text": "Prepara un report di stato per il progetto del terzo trimestre; il budget resta invariato.",
+    "spans": []
+  },
+  {
+    "text": "Riassumi la policy delle note spese in cinque punti.",
+    "spans": []
+  },
+  {
+    "text": "Quali passaggi copre il processo di onboarding nel primo mese?",
+    "spans": []
+  },
+  {
+    "text": "Scrivi un promemoria gentile sulla rilevazione settimanale delle ore.",
+    "spans": []
+  },
+  {
+    "text": "Come richiedo un nuovo portatile tramite il sistema di ticket?",
+    "spans": []
+  },
+  {
+    "text": "Prepara l'ordine del giorno per la prossima riunione di team con tre priorità.",
+    "spans": []
+  },
+  {
+    "text": "Quali scadenze valgono per la consegna delle note spese?",
+    "spans": []
+  },
+  {
+    "text": "Riassumi le modifiche recenti alla policy sul lavoro da remoto.",
+    "spans": []
+  },
+  {
+    "text": "Come funziona l'approvazione degli ordini nel modulo acquisti?",
+    "spans": []
+  },
+  {
+    "text": "Spiega il flusso di approvazione per le formazioni esterne.",
+    "spans": []
+  },
+  {
+    "text": "Quali report può generare mensilmente il modulo contabilità?",
+    "spans": []
+  },
+  {
+    "text": "Scrivi un breve annuncio per la manutenzione di sistema nel fine settimana.",
+    "spans": []
+  },
+  {
+    "text": "Come creo un nuovo centro di costo nel sistema?",
+    "spans": []
+  },
+  {
+    "text": "Qual è la differenza tra un preventivo e una conferma d'ordine?",
+    "spans": []
+  },
+  {
+    "text": "Prepara una checklist per la chiusura mensile in contabilità.",
+    "spans": []
+  },
+  {
+    "text": "Come esporto il riepilogo ferie in un foglio di calcolo?",
+    "spans": []
+  },
+  {
+    "text": "Quali ruoli intervengono nell'approvazione delle fatture passive?",
+    "spans": []
+  },
+  {
+    "text": "Scrivi un rifiuto cortese per una consegna posticipata.",
+    "spans": []
+  },
+  {
+    "text": "Riassumi i punti chiave dell'accordo sull'orario flessibile.",
+    "spans": []
+  },
+  {
+    "text": "Come imposto una risposta di assenza per le festività?",
+    "spans": []
+  },
+  {
+    "text": "Quali campi sono obbligatori alla creazione di un nuovo fornitore?",
+    "spans": []
+  },
+  {
+    "text": "Descrivi la procedura dell'inventario annuale di magazzino.",
+    "spans": []
+  },
+  {
+    "text": "Come si possono generare automaticamente fatture ricorrenti?",
+    "spans": []
+  }
+]

--- a/middleware/packages/harness-plugin-privacy-guard/src/validation/fixtures/nl.json
+++ b/middleware/packages/harness-plugin-privacy-guard/src/validation/fixtures/nl.json
@@ -1,0 +1,1480 @@
+[
+  {
+    "text": "Jan van der Berg neemt vanaf mei de teamleiding over.",
+    "spans": [
+      {
+        "value": "Jan van der Berg",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Anouk de Vries en Pieter van den Heuvel delen de coördinatie van de avondploeg.",
+    "spans": [
+      {
+        "value": "Anouk de Vries",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Pieter van den Heuvel",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Sophie van Dijk wacht nog op een reactie over haar overplaatsing.",
+    "spans": [
+      {
+        "value": "Sophie van Dijk",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Willem ten Brink gaat op 30-06-2027 met pensioen.",
+    "spans": [
+      {
+        "value": "Willem ten Brink",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "30-06-2027",
+        "type": "date",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Mevrouw Bakker heeft het addendum nog niet ondertekend — graag herinneren.",
+    "spans": [
+      {
+        "value": "Mevrouw Bakker",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Bezorg de apparatuur bij de opslag achter de oude watertoren aan de Molenweg 3, tweede hek links na de spoorwegovergang, 6741 KM Lunteren.",
+    "spans": [
+      {
+        "value": "de opslag achter de oude watertoren aan de Molenweg 3, tweede hek links na de spoorwegovergang, 6741 KM Lunteren",
+        "type": "address",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Stuur de koerier vóór twaalven naar de Herengracht 341.",
+    "spans": [
+      {
+        "value": "Herengracht 341",
+        "type": "address",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Het BSN van Daan Visser is 123456782 — vastleggen in het dossier.",
+    "spans": [
+      {
+        "value": "Daan Visser",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "123456782",
+        "type": "idnum",
+        "tier": "critical"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Bel Femke Mulder op 06 1234 5678 voor de keuring.",
+    "spans": [
+      {
+        "value": "Femke Mulder",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "06 1234 5678",
+        "type": "phone",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Aan de workshop doen Lotte Meijer, Bram Dekker en Eva Scholten mee.",
+    "spans": [
+      {
+        "value": "Lotte Meijer",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Bram Dekker",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Eva Scholten",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "De bonus van Ruben Smit, € 1.850, wordt met het meisalaris uitbetaald.",
+    "spans": [
+      {
+        "value": "Ruben Smit",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "€ 1.850",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Maak het voorschot over naar NL91 ABNA 0417 1643 00 ten name van Marit Postma.",
+    "spans": [
+      {
+        "value": "NL91 ABNA 0417 1643 00",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "Marit Postma",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Kandidaat Nienke Vos-Hoekstra is door naar de laatste ronde.",
+    "spans": [
+      {
+        "value": "Nienke Vos-Hoekstra",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Onze nieuwe contactpersoon heet Fatima el Amrani van de vestiging Rotterdam.",
+    "spans": [
+      {
+        "value": "Fatima el Amrani",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Joris Hendriks is geboren op 1990-06-15 volgens het dossier.",
+    "spans": [
+      {
+        "value": "Joris Hendriks",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "1990-06-15",
+        "type": "date",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Thijs Kuipers verhuist naar de Kerkstraat 12, 3811 KE Amersfoort.",
+    "spans": [
+      {
+        "value": "Thijs Kuipers",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Kerkstraat 12, 3811 KE Amersfoort",
+        "type": "address",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Stuur het getekende contract door naar l.meijer@bedrijf-voorbeeld.nl en laat Lotte Meijer het weten.",
+    "spans": [
+      {
+        "value": "l.meijer@bedrijf-voorbeeld.nl",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "Lotte Meijer",
+        "type": "person",
+        "tier": "high"
+      }
+    ],
+    "origin": "hand"
+  },
+  {
+    "text": "Wat zouden we Anouk Willemsen moeten betalen bij een huidig salaris van € 12.750,00?",
+    "spans": [
+      {
+        "value": "Anouk Willemsen",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "€ 12.750,00",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Wat zouden we Stijn Bosman moeten betalen bij een huidig salaris van € 12.750,00?",
+    "spans": [
+      {
+        "value": "Stijn Bosman",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "€ 12.750,00",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Wat zouden we Roos Jacobs moeten betalen bij een huidig salaris van € 3.499,99?",
+    "spans": [
+      {
+        "value": "Roos Jacobs",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "€ 3.499,99",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Wat zouden we Stijn Bosman moeten betalen bij een huidig salaris van € 4.980?",
+    "spans": [
+      {
+        "value": "Stijn Bosman",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "€ 4.980",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Maak het voorschot over naar NL63 INGB 0004 5566 78 en zet facturen@voorbeeld-consult.nl in de cc.",
+    "spans": [
+      {
+        "value": "NL63 INGB 0004 5566 78",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "facturen@voorbeeld-consult.nl",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Maak het voorschot over naar NL86 INGB 0002 4455 88 en zet salaris@voorbeeld-bv.nl in de cc.",
+    "spans": [
+      {
+        "value": "NL86 INGB 0002 4455 88",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "salaris@voorbeeld-bv.nl",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Maak het voorschot over naar NL39 RABO 0300 0652 64 en zet salaris@voorbeeld-bv.nl in de cc.",
+    "spans": [
+      {
+        "value": "NL39 RABO 0300 0652 64",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "salaris@voorbeeld-bv.nl",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Maak het voorschot over naar NL39 RABO 0300 0652 64 en zet d.visser@bedrijf-voorbeeld.nl in de cc.",
+    "spans": [
+      {
+        "value": "NL39 RABO 0300 0652 64",
+        "type": "iban",
+        "tier": "critical"
+      },
+      {
+        "value": "d.visser@bedrijf-voorbeeld.nl",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bel Bram Dekker op +31 20 624 1187; de geboortedatum in het dossier is 1990-06-15.",
+    "spans": [
+      {
+        "value": "Bram Dekker",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+31 20 624 1187",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "1990-06-15",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bel Koen Peters op +31 6 5512 3498; de geboortedatum in het dossier is 28-02-1995.",
+    "spans": [
+      {
+        "value": "Koen Peters",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+31 6 5512 3498",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "28-02-1995",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bel Iris Groen op 06 1234 5678; de geboortedatum in het dossier is 1984-09-17.",
+    "spans": [
+      {
+        "value": "Iris Groen",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "06 1234 5678",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "1984-09-17",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bel Thijs Kuipers op 020 623 4455; de geboortedatum in het dossier is 28-02-1995.",
+    "spans": [
+      {
+        "value": "Thijs Kuipers",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "020 623 4455",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "28-02-1995",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "De factuur van € 67.200 moet naar Amstelveenseweg 88, 1075 XM Amsterdam.",
+    "spans": [
+      {
+        "value": "€ 67.200",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Amstelveenseweg 88, 1075 XM Amsterdam",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "De factuur van € 899 moet naar Wilhelminalaan 4, 2012 EM Haarlem.",
+    "spans": [
+      {
+        "value": "€ 899",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Wilhelminalaan 4, 2012 EM Haarlem",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "De factuur van € 72.000 moet naar Stationsplein 9, 3511 ED Utrecht.",
+    "spans": [
+      {
+        "value": "€ 72.000",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Stationsplein 9, 3511 ED Utrecht",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "De factuur van € 15.000 moet naar Stationsplein 9, 3511 ED Utrecht.",
+    "spans": [
+      {
+        "value": "€ 15.000",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "Stationsplein 9, 3511 ED Utrecht",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Voer Stijn Bosman op als nieuwe medewerker met het werkadres r.smit@voorbeeld-consult.nl.",
+    "spans": [
+      {
+        "value": "Stijn Bosman",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "r.smit@voorbeeld-consult.nl",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Voer Lars Veldkamp op als nieuwe medewerker met het werkadres sanne.bakker@voorbeeld-bv.nl.",
+    "spans": [
+      {
+        "value": "Lars Veldkamp",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "sanne.bakker@voorbeeld-bv.nl",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Voer Lotte Meijer op als nieuwe medewerker met het werkadres sanne.bakker@voorbeeld-bv.nl.",
+    "spans": [
+      {
+        "value": "Lotte Meijer",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "sanne.bakker@voorbeeld-bv.nl",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Voer Maud Prins op als nieuwe medewerker met het werkadres l.meijer@bedrijf-voorbeeld.nl.",
+    "spans": [
+      {
+        "value": "Maud Prins",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "l.meijer@bedrijf-voorbeeld.nl",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Daan Visser is per 12-11-1979 uit dienst — start de offboardingchecklist.",
+    "spans": [
+      {
+        "value": "Daan Visser",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "12-11-1979",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Sven Hoekstra is per 12-11-1979 uit dienst — start de offboardingchecklist.",
+    "spans": [
+      {
+        "value": "Sven Hoekstra",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "12-11-1979",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Sven Hoekstra is per 30-06-2026 uit dienst — start de offboardingchecklist.",
+    "spans": [
+      {
+        "value": "Sven Hoekstra",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "30-06-2026",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Ruben Smit is per 2023-02-01 uit dienst — start de offboardingchecklist.",
+    "spans": [
+      {
+        "value": "Ruben Smit",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "2023-02-01",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Werk de stamgegevens bij: Sanne Bakker woont nu op Molenweg 3, 6741 KM Lunteren.",
+    "spans": [
+      {
+        "value": "Sanne Bakker",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Molenweg 3, 6741 KM Lunteren",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Werk de stamgegevens bij: Marit Postma woont nu op Dorpsweg 17, 8325 BH Vollenhove.",
+    "spans": [
+      {
+        "value": "Marit Postma",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Dorpsweg 17, 8325 BH Vollenhove",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Werk de stamgegevens bij: Eva Scholten woont nu op Stationsplein 9, 3511 ED Utrecht.",
+    "spans": [
+      {
+        "value": "Eva Scholten",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Stationsplein 9, 3511 ED Utrecht",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Werk de stamgegevens bij: Femke Mulder woont nu op Prinsengracht 263, 1016 GV Amsterdam.",
+    "spans": [
+      {
+        "value": "Femke Mulder",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Prinsengracht 263, 1016 GV Amsterdam",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Vergoed de reiskosten van € 15.000 naar NL86 INGB 0002 4455 88.",
+    "spans": [
+      {
+        "value": "€ 15.000",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "NL86 INGB 0002 4455 88",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Vergoed de reiskosten van € 72.000 naar NL63 INGB 0004 5566 78.",
+    "spans": [
+      {
+        "value": "€ 72.000",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "NL63 INGB 0004 5566 78",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Vergoed de reiskosten van € 58.500 naar NL39 RABO 0300 0652 64.",
+    "spans": [
+      {
+        "value": "€ 58.500",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "NL39 RABO 0300 0652 64",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Vergoed de reiskosten van € 72.000 naar NL39 RABO 0300 0652 64.",
+    "spans": [
+      {
+        "value": "€ 72.000",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "NL39 RABO 0300 0652 64",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Stuur de loonstrook naar salaris@voorbeeld-bv.nl; het brutoloon is € 4.980.",
+    "spans": [
+      {
+        "value": "salaris@voorbeeld-bv.nl",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "€ 4.980",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Stuur de loonstrook naar sanne.bakker@voorbeeld-bv.nl; het brutoloon is € 72.000.",
+    "spans": [
+      {
+        "value": "sanne.bakker@voorbeeld-bv.nl",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "€ 72.000",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Stuur de loonstrook naar salaris@voorbeeld-bv.nl; het brutoloon is € 3.499,99.",
+    "spans": [
+      {
+        "value": "salaris@voorbeeld-bv.nl",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "€ 3.499,99",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Stuur de loonstrook naar boekhouding@voorbeeld-bv.nl; het brutoloon is € 899.",
+    "spans": [
+      {
+        "value": "boekhouding@voorbeeld-bv.nl",
+        "type": "email",
+        "tier": "high"
+      },
+      {
+        "value": "€ 899",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Voor de referentiecheck kun je Marit Postma bereiken op +31 20 624 1187.",
+    "spans": [
+      {
+        "value": "Marit Postma",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+31 20 624 1187",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Voor de referentiecheck kun je Jelle Timmermans bereiken op +31 20 624 1187.",
+    "spans": [
+      {
+        "value": "Jelle Timmermans",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+31 20 624 1187",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Voor de referentiecheck kun je Iris Groen bereiken op 06 1234 5678.",
+    "spans": [
+      {
+        "value": "Iris Groen",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "06 1234 5678",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Voor de referentiecheck kun je Marit Postma bereiken op +31 6 2445 8812.",
+    "spans": [
+      {
+        "value": "Marit Postma",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+31 6 2445 8812",
+        "type": "phone",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bereid het beoordelingsgesprek met Niels Verbeek voor.",
+    "spans": [
+      {
+        "value": "Niels Verbeek",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bereid het beoordelingsgesprek met Daan Visser voor.",
+    "spans": [
+      {
+        "value": "Daan Visser",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bereid het beoordelingsgesprek met Anouk Willemsen voor.",
+    "spans": [
+      {
+        "value": "Anouk Willemsen",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bereid het beoordelingsgesprek met Fleur Sanders voor.",
+    "spans": [
+      {
+        "value": "Fleur Sanders",
+        "type": "person",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Lotte Meijer heeft zich op 12-11-1979 ziek gemeld — registreer dit in de HR-module.",
+    "spans": [
+      {
+        "value": "Lotte Meijer",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "12-11-1979",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Marit Postma heeft zich op 30-06-2026 ziek gemeld — registreer dit in de HR-module.",
+    "spans": [
+      {
+        "value": "Marit Postma",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "30-06-2026",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Sanne Bakker heeft zich op 12-11-1979 ziek gemeld — registreer dit in de HR-module.",
+    "spans": [
+      {
+        "value": "Sanne Bakker",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "12-11-1979",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Bram Dekker heeft zich op 28-02-1995 ziek gemeld — registreer dit in de HR-module.",
+    "spans": [
+      {
+        "value": "Bram Dekker",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "28-02-1995",
+        "type": "date",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "De leverancier verwacht de betaling van € 1.250,50 op NL39 RABO 0300 0652 64.",
+    "spans": [
+      {
+        "value": "€ 1.250,50",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "NL39 RABO 0300 0652 64",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "De leverancier verwacht de betaling van € 12.750,00 op NL20 ABNA 0512 3344 55.",
+    "spans": [
+      {
+        "value": "€ 12.750,00",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "NL20 ABNA 0512 3344 55",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "De leverancier verwacht de betaling van € 4.980 op NL39 RABO 0300 0652 64.",
+    "spans": [
+      {
+        "value": "€ 4.980",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "NL39 RABO 0300 0652 64",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "De leverancier verwacht de betaling van € 899 op NL86 INGB 0002 4455 88.",
+    "spans": [
+      {
+        "value": "€ 899",
+        "type": "amount",
+        "tier": "critical"
+      },
+      {
+        "value": "NL86 INGB 0002 4455 88",
+        "type": "iban",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Nieuwe sollicitatie: Daan Visser, bereikbaar op +31 20 624 1187 of via f.mulder@post-voorbeeld.nl.",
+    "spans": [
+      {
+        "value": "Daan Visser",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+31 20 624 1187",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "f.mulder@post-voorbeeld.nl",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Nieuwe sollicitatie: Lotte Meijer, bereikbaar op +31 10 411 2230 of via r.smit@voorbeeld-consult.nl.",
+    "spans": [
+      {
+        "value": "Lotte Meijer",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+31 10 411 2230",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "r.smit@voorbeeld-consult.nl",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Nieuwe sollicitatie: Iris Groen, bereikbaar op +31 6 5512 3498 of via f.mulder@post-voorbeeld.nl.",
+    "spans": [
+      {
+        "value": "Iris Groen",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+31 6 5512 3498",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "f.mulder@post-voorbeeld.nl",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Nieuwe sollicitatie: Sven Hoekstra, bereikbaar op +31 6 5512 3498 of via hr@voorbeeld-consult.nl.",
+    "spans": [
+      {
+        "value": "Sven Hoekstra",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "+31 6 5512 3498",
+        "type": "phone",
+        "tier": "high"
+      },
+      {
+        "value": "hr@voorbeeld-consult.nl",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Stuur het aanbod naar Ilse Brouwer, Amstelveenseweg 88, 1075 XM Amsterdam.",
+    "spans": [
+      {
+        "value": "Ilse Brouwer",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Amstelveenseweg 88, 1075 XM Amsterdam",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Stuur het aanbod naar Femke Mulder, Herengracht 341, 1016 AZ Amsterdam.",
+    "spans": [
+      {
+        "value": "Femke Mulder",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Herengracht 341, 1016 AZ Amsterdam",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Stuur het aanbod naar Femke Mulder, Amstelveenseweg 88, 1075 XM Amsterdam.",
+    "spans": [
+      {
+        "value": "Femke Mulder",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Amstelveenseweg 88, 1075 XM Amsterdam",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Stuur het aanbod naar Stijn Bosman, Herengracht 341, 1016 AZ Amsterdam.",
+    "spans": [
+      {
+        "value": "Stijn Bosman",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "Herengracht 341, 1016 AZ Amsterdam",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Het contract van Lars Veldkamp start op 28-02-1995 met een jaarsalaris van € 12.750,00.",
+    "spans": [
+      {
+        "value": "Lars Veldkamp",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "28-02-1995",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "€ 12.750,00",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Het contract van Maud Prins start op 30-06-2026 met een jaarsalaris van € 58.500.",
+    "spans": [
+      {
+        "value": "Maud Prins",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "30-06-2026",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "€ 58.500",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Het contract van Wouter Blom start op 28-02-1995 met een jaarsalaris van € 62.400.",
+    "spans": [
+      {
+        "value": "Wouter Blom",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "28-02-1995",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "€ 62.400",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Het contract van Femke Mulder start op 1990-06-15 met een jaarsalaris van € 62.400.",
+    "spans": [
+      {
+        "value": "Femke Mulder",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "1990-06-15",
+        "type": "date",
+        "tier": "high"
+      },
+      {
+        "value": "€ 62.400",
+        "type": "amount",
+        "tier": "critical"
+      }
+    ]
+  },
+  {
+    "text": "Schrijf Thijs Kuipers in voor de training van volgende week en informeer salaris@voorbeeld-bv.nl.",
+    "spans": [
+      {
+        "value": "Thijs Kuipers",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "salaris@voorbeeld-bv.nl",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Schrijf Joris Hendriks in voor de training van volgende week en informeer salaris@voorbeeld-bv.nl.",
+    "spans": [
+      {
+        "value": "Joris Hendriks",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "salaris@voorbeeld-bv.nl",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Schrijf Maud Prins in voor de training van volgende week en informeer hr@voorbeeld-consult.nl.",
+    "spans": [
+      {
+        "value": "Maud Prins",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "hr@voorbeeld-consult.nl",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Schrijf Wouter Blom in voor de training van volgende week en informeer a.willemsen@voorbeeld-bv.nl.",
+    "spans": [
+      {
+        "value": "Wouter Blom",
+        "type": "person",
+        "tier": "high"
+      },
+      {
+        "value": "a.willemsen@voorbeeld-bv.nl",
+        "type": "email",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Naar welk adres ging de laatste aanmaning — Wilhelminalaan 4, 2012 EM Haarlem, klopt dat?",
+    "spans": [
+      {
+        "value": "Wilhelminalaan 4, 2012 EM Haarlem",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Naar welk adres ging de laatste aanmaning — Stationsplein 9, 3511 ED Utrecht, klopt dat?",
+    "spans": [
+      {
+        "value": "Stationsplein 9, 3511 ED Utrecht",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Naar welk adres ging de laatste aanmaning — Dorpsweg 17, 8325 BH Vollenhove, klopt dat?",
+    "spans": [
+      {
+        "value": "Dorpsweg 17, 8325 BH Vollenhove",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Naar welk adres ging de laatste aanmaning — Prinsengracht 263, 1016 GV Amsterdam, klopt dat?",
+    "spans": [
+      {
+        "value": "Prinsengracht 263, 1016 GV Amsterdam",
+        "type": "address",
+        "tier": "high"
+      }
+    ]
+  },
+  {
+    "text": "Ziekte en verlof worden in de rapportage apart geteld.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "De Directie en de Ondernemingsraad vergaderen maandagochtend.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Leg het verschil uit tussen brutoloon en nettoloon.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Straat, laan en gracht zijn aparte veldtypes in de adresmodule.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Van Gogh is de naam van de vergaderruimte op de derde verdieping.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Personeelszaken publiceert morgen de nieuwe salaristabel.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "De Zuidas is het voorbeeldgebied in de handleiding voor regiocodes.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Willem van Oranje komt voor in de quizvragen voor het teamuitje.",
+    "spans": [],
+    "origin": "hand"
+  },
+  {
+    "text": "Hoeveel vakantiedagen bouwt een medewerker op na drie jaar dienstverband?",
+    "spans": []
+  },
+  {
+    "text": "Maak een statusrapport voor het derdekwartaalproject; het budget blijft ongewijzigd.",
+    "spans": []
+  },
+  {
+    "text": "Vat het declaratiebeleid samen in vijf punten.",
+    "spans": []
+  },
+  {
+    "text": "Welke stappen omvat het onboardingproces in de eerste maand?",
+    "spans": []
+  },
+  {
+    "text": "Schrijf een vriendelijke herinnering over de wekelijkse urenregistratie.",
+    "spans": []
+  },
+  {
+    "text": "Hoe vraag ik een nieuwe laptop aan via het ticketsysteem?",
+    "spans": []
+  },
+  {
+    "text": "Maak een agenda voor het volgende teamoverleg met drie speerpunten.",
+    "spans": []
+  },
+  {
+    "text": "Welke deadlines gelden voor het indienen van declaraties?",
+    "spans": []
+  },
+  {
+    "text": "Vat de recente wijzigingen in het thuiswerkbeleid samen.",
+    "spans": []
+  },
+  {
+    "text": "Hoe werkt de goedkeuring van bestellingen in de inkoopmodule?",
+    "spans": []
+  },
+  {
+    "text": "Leg de goedkeuringsflow voor externe trainingen uit.",
+    "spans": []
+  },
+  {
+    "text": "Welke rapporten kan de boekhoudmodule maandelijks genereren?",
+    "spans": []
+  },
+  {
+    "text": "Schrijf een korte aankondiging voor het systeemonderhoud in het weekend.",
+    "spans": []
+  },
+  {
+    "text": "Hoe maak ik een nieuwe kostenplaats aan in het systeem?",
+    "spans": []
+  },
+  {
+    "text": "Wat is het verschil tussen een offerte en een orderbevestiging?",
+    "spans": []
+  },
+  {
+    "text": "Maak een checklist voor de maandafsluiting in de boekhouding.",
+    "spans": []
+  },
+  {
+    "text": "Hoe exporteer ik het verlofoverzicht als spreadsheet?",
+    "spans": []
+  },
+  {
+    "text": "Welke rollen zijn er in het goedkeuringsproces voor inkoopfacturen?",
+    "spans": []
+  },
+  {
+    "text": "Schrijf een beleefde afwijzing voor een uitgestelde leverdatum.",
+    "spans": []
+  },
+  {
+    "text": "Vat de belangrijkste punten van de flexwerkregeling samen.",
+    "spans": []
+  },
+  {
+    "text": "Hoe stel ik een afwezigheidsbericht in voor de feestdagen?",
+    "spans": []
+  },
+  {
+    "text": "Welke velden zijn verplicht bij het aanmaken van een nieuwe leverancier?",
+    "spans": []
+  },
+  {
+    "text": "Beschrijf de procedure van de jaarlijkse magazijninventarisatie.",
+    "spans": []
+  },
+  {
+    "text": "Hoe kunnen terugkerende facturen automatisch worden aangemaakt?",
+    "spans": []
+  }
+]

--- a/middleware/packages/harness-plugin-privacy-guard/src/validation/promptDetectorEval.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/validation/promptDetectorEval.ts
@@ -4,10 +4,22 @@
  * Run from `middleware/`:
  *   npx tsx packages/harness-plugin-privacy-guard/src/validation/promptDetectorEval.ts
  *
- * Scores each configured detector set against the fixture files using the
- * exact-match leak criterion (`findIdentityLeaks`): a PII instance counts as
- * masked only when its full real value is absent from the masked output.
- * Gates are documented in ./README.md and were committed before any run.
+ * Detector sets are built from the environment:
+ *   - always:                      `c0`      (regex baseline)
+ *   - with PII_DETECTOR_URL set:   `c0+c1`   (baseline + GLiNER sidecar)
+ *                                  `c1-solo` (ablation — reported, not gated)
+ *     e.g. PII_DETECTOR_URL=http://localhost:8812 when the
+ *     `docker-compose.pii-detector.yaml` sidecar is reachable locally.
+ *
+ * Flags:
+ *   --markdown   emit GitHub-flavored tables (for posting to issue #361)
+ *                instead of the default console format.
+ *
+ * Scoring uses the exact-match leak criterion (`findIdentityLeaks`): a PII
+ * instance counts as masked only when its full verbatim value is absent
+ * from the masked output. Gates are documented in ./README.md and were
+ * committed before any run; scoring/aggregation/rendering helpers live in
+ * ./report.ts.
  */
 
 import { readdirSync, readFileSync } from 'node:fs';
@@ -16,110 +28,105 @@ import { fileURLToPath } from 'node:url';
 
 import type { PromptPiiDetector } from '@omadia/plugin-api';
 
+import { createC1HttpDetector } from '../c1Detector.js';
 import { createBaselineDetector, maskPrompt } from '../promptMask.js';
-import { findIdentityLeaks } from '../v4/onTheWire.js';
+import {
+  aggregateLocale,
+  evaluateGates,
+  lintFixtures,
+  renderConsoleLocale,
+  renderMarkdown,
+  type FixtureItem,
+  type ItemOutcome,
+  type LocaleResult,
+  type SetResults,
+} from './report.js';
 
-interface FixtureSpan {
-  readonly value: string;
-  readonly type: string;
-  readonly tier: 'critical' | 'high' | 'medium';
+/** Detector sets under evaluation, built from the environment. Without
+ *  `PII_DETECTOR_URL` this is the shipped c0-only run. The C1 timeout is
+ *  deliberately generous (10 s vs the runtime's 1500 ms): the harness
+ *  measures detection quality and REPORTS latency against the 400 ms gate —
+ *  it must not silently convert a slow sidecar into thrown timeouts. */
+function buildDetectorSets(): Array<[string, readonly PromptPiiDetector[]]> {
+  const sets: Array<[string, readonly PromptPiiDetector[]]> = [
+    ['c0', [createBaselineDetector()]],
+  ];
+  const c1Url = process.env['PII_DETECTOR_URL']?.trim();
+  if (c1Url !== undefined && c1Url !== '') {
+    const c1 = createC1HttpDetector({ resolveUrl: () => c1Url, timeoutMs: 10_000 });
+    sets.push(['c0+c1', [createBaselineDetector(), c1]]);
+    sets.push(['c1-solo', [c1]]);
+  }
+  return sets;
 }
 
-interface FixtureItem {
-  readonly text: string;
-  readonly spans: readonly FixtureSpan[];
-}
-
-/** Detector sets under evaluation. Add `['c0+c1', [baseline, c1]]` here
- *  once a real C1 transformer detector is wired. */
-const DETECTOR_SETS: ReadonlyArray<[string, readonly PromptPiiDetector[]]> = [
-  ['c0', [createBaselineDetector()]],
-];
-
-/** Types the C0 baseline is expected (and gated) to catch. `person` and
- *  other free-form entities are C1 territory — reported separately. */
-const STRUCTURED_TYPES = new Set(['email', 'iban', 'phone', 'address', 'amount', 'date']);
-
-function p95(values: number[]): number {
-  if (values.length === 0) return 0;
-  const sorted = [...values].sort((a, b) => a - b);
-  return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1)]!;
-}
+/** PII-shaped warm-up text: primes regex JIT and, more importantly, the
+ *  sidecar's first-inference session so model warm-up never pollutes p95. */
+const WARMUP_TEXT =
+  'Warm-up only: contact Max Mustermann at Musterstraße 1, 12345 Berlin ' +
+  'or max.mustermann@example.com before 24.12.2026.';
 
 async function evalLocale(
-  locale: string,
   items: readonly FixtureItem[],
   detectors: readonly PromptPiiDetector[],
-): Promise<void> {
-  const byType = new Map<string, { total: number; masked: number }>();
-  let negatives = 0;
-  let cleanNegatives = 0;
-  const latencies: number[] = [];
-
+): Promise<ItemOutcome[]> {
+  const outcomes: ItemOutcome[] = [];
   for (const item of items) {
     const startedAt = performance.now();
     const result = await maskPrompt(item.text, detectors);
-    latencies.push(performance.now() - startedAt);
-
-    if (item.spans.length === 0) {
-      negatives += 1;
-      if (result.spans.length === 0) cleanNegatives += 1;
-      continue;
-    }
-    for (const span of item.spans) {
-      const bucket = byType.get(span.type) ?? { total: 0, masked: 0 };
-      bucket.total += 1;
-      // Exact-match criterion: the full real value must be gone.
-      if (findIdentityLeaks(result.maskedText, [span.value]).length === 0) {
-        bucket.masked += 1;
-      }
-      byType.set(span.type, bucket);
-    }
+    const latencyMs = performance.now() - startedAt;
+    outcomes.push({
+      maskedText: result.maskedText,
+      flaggedSpans: result.spans.length,
+      latencyMs,
+    });
   }
-
-  console.log(`\n=== ${locale} ===`);
-  let structuredTotal = 0;
-  let structuredMasked = 0;
-  for (const [type, { total, masked }] of [...byType.entries()].sort()) {
-    const recall = total === 0 ? 1 : masked / total;
-    const scope = STRUCTURED_TYPES.has(type) ? 'structured' : 'c1-scope';
-    console.log(
-      `  recall ${type.padEnd(8)} ${masked}/${total}  ${(recall * 100).toFixed(1)}%  (${scope})`,
-    );
-    if (STRUCTURED_TYPES.has(type)) {
-      structuredTotal += total;
-      structuredMasked += masked;
-    }
-  }
-  const structuredRecall = structuredTotal === 0 ? 1 : structuredMasked / structuredTotal;
-  const precisionProxy = negatives === 0 ? 1 : cleanNegatives / negatives;
-  const latencyP95 = p95(latencies);
-  console.log(`  structured recall     ${(structuredRecall * 100).toFixed(1)}%  (gate ≥ 97%)`);
-  console.log(`  negatives clean       ${cleanNegatives}/${negatives}  (gate ≥ 85%)`);
-  console.log(`  p95 latency           ${latencyP95.toFixed(1)} ms  (gate ≤ 400 ms)`);
-  const pass =
-    structuredRecall >= 0.97 && precisionProxy >= 0.85 && latencyP95 <= 400;
-  console.log(`  verdict (structured-identifier gates only): ${pass ? 'PASS' : 'FAIL'}`);
+  return outcomes;
 }
 
 async function main(): Promise<void> {
+  const markdown = process.argv.includes('--markdown');
   const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
   const locales = readdirSync(fixturesDir)
     .filter((f) => f.endsWith('.json'))
     .map((f) => f.replace(/\.json$/, ''))
     .sort();
-  for (const [setName, detectors] of DETECTOR_SETS) {
-    console.log(`\n########## detector set: ${setName} ##########`);
-    for (const locale of locales) {
-      const items = JSON.parse(
-        readFileSync(join(fixturesDir, `${locale}.json`), 'utf-8'),
-      ) as FixtureItem[];
-      await evalLocale(locale, items, detectors);
-    }
+
+  // Load + lint everything up-front: a malformed fixture file fails the
+  // whole run loudly before any numbers are printed.
+  const fixtures = new Map<string, FixtureItem[]>();
+  for (const locale of locales) {
+    const raw: unknown = JSON.parse(
+      readFileSync(join(fixturesDir, `${locale}.json`), 'utf-8'),
+    );
+    fixtures.set(locale, lintFixtures(locale, raw));
   }
-  console.log(
-    '\nNote: name/free-form (`person`) recall requires a C1 transformer detector — C0 alone must not gate those types. See README.md.',
-  );
+
+  const allResults: SetResults[] = [];
+  for (const [setName, detectors] of buildDetectorSets()) {
+    if (!markdown) console.log(`\n########## detector set: ${setName} ##########`);
+    // One un-timed warm-up call per set before measurement.
+    await maskPrompt(WARMUP_TEXT, detectors);
+    const perLocale: LocaleResult[] = [];
+    for (const [locale, items] of fixtures) {
+      const outcomes = await evalLocale(items, detectors);
+      const report = aggregateLocale(locale, items, outcomes);
+      const verdict = evaluateGates(setName, report);
+      perLocale.push({ report, verdict });
+      if (!markdown) console.log(renderConsoleLocale(report, verdict));
+    }
+    allResults.push({ set: setName, locales: perLocale });
+  }
+
+  if (markdown) {
+    console.log(renderMarkdown(allResults));
+  } else {
+    console.log(
+      '\nNote: `person` recall gates only on the c0+c1 set (C0 alone does not ' +
+        'detect names); run with PII_DETECTOR_URL pointing at the GLiNER ' +
+        'sidecar to evaluate it. See README.md.',
+    );
+  }
 }
 
 void main();

--- a/middleware/packages/harness-plugin-privacy-guard/src/validation/report.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/validation/report.ts
@@ -1,0 +1,396 @@
+/**
+ * #361 — pure helpers for the prompt-PII detector evaluation
+ * (`promptDetectorEval.ts`): fixture lint, per-locale aggregation, gate
+ * evaluation, and console/markdown rendering. No IO, no detector calls —
+ * everything here is a pure function so the runnable eval file stays small
+ * (500-line rule) and the scoring logic is unit-testable in isolation.
+ */
+
+import { findIdentityLeaks } from '../v4/onTheWire.js';
+
+// ---------------------------------------------------------------------------
+// Fixture schema + lint
+// ---------------------------------------------------------------------------
+
+export type FixtureTier = 'critical' | 'high' | 'medium';
+export type FixtureOrigin = 'hand' | 'synthetic';
+
+export interface FixtureSpan {
+  readonly value: string;
+  readonly type: string;
+  readonly tier: FixtureTier;
+}
+
+export interface FixtureItem {
+  readonly text: string;
+  readonly spans: readonly FixtureSpan[];
+  /** Provenance: `hand` = hand-built out-of-distribution slice (the
+   *  go/no-go signal per README); absent = `synthetic` (LLM-generated
+   *  backbone). */
+  readonly origin?: FixtureOrigin;
+}
+
+/** Types the C0 baseline is expected (and gated) to catch. */
+export const STRUCTURED_TYPES: ReadonlySet<string> = new Set([
+  'email',
+  'iban',
+  'phone',
+  'address',
+  'amount',
+  'date',
+]);
+
+/** Measured informationally only — no detector tier owns these in v1
+ *  (C0 has no locale-ID patterns; C1's calibrated label set is
+ *  person/address). Never gated. */
+export const INFORMATIONAL_TYPES: ReadonlySet<string> = new Set(['idnum']);
+
+export const KNOWN_TYPES: ReadonlySet<string> = new Set([
+  ...STRUCTURED_TYPES,
+  'person',
+  ...INFORMATIONAL_TYPES,
+]);
+
+const TIERS: ReadonlySet<string> = new Set(['critical', 'high', 'medium']);
+const ORIGINS: ReadonlySet<string> = new Set(['hand', 'synthetic']);
+
+/**
+ * Validate one parsed fixture file. Throws (loudly, with locale + item
+ * index) on any malformed entry — a silently-skipped fixture would make a
+ * PASS verdict meaningless.
+ */
+export function lintFixtures(locale: string, raw: unknown): FixtureItem[] {
+  const fail = (msg: string): never => {
+    throw new Error(`[fixtures/${locale}.json] ${msg}`);
+  };
+  if (!Array.isArray(raw) || raw.length === 0) {
+    return fail('must be a non-empty JSON array');
+  }
+  const seen = new Set<string>();
+  const items: FixtureItem[] = [];
+  raw.forEach((entry, index) => {
+    const at = `item ${String(index)}`;
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+      return fail(`${at}: not an object`);
+    }
+    const { text, spans, origin } = entry as Record<string, unknown>;
+    if (typeof text !== 'string' || text.length === 0) {
+      return fail(`${at}: "text" must be a non-empty string`);
+    }
+    if (seen.has(text)) return fail(`${at}: duplicate item text`);
+    seen.add(text);
+    if (origin !== undefined && (typeof origin !== 'string' || !ORIGINS.has(origin))) {
+      return fail(`${at}: "origin" must be "hand" | "synthetic"`);
+    }
+    if (!Array.isArray(spans)) return fail(`${at}: "spans" must be an array`);
+    const checked: FixtureSpan[] = spans.map((span, spanIndex) => {
+      const sAt = `${at} span ${String(spanIndex)}`;
+      if (typeof span !== 'object' || span === null) return fail(`${sAt}: not an object`);
+      const { value, type, tier } = span as Record<string, unknown>;
+      if (typeof value !== 'string' || value.length === 0) {
+        return fail(`${sAt}: "value" must be a non-empty string`);
+      }
+      if (!text.includes(value)) {
+        return fail(`${sAt}: value does not occur verbatim in text`);
+      }
+      if (typeof type !== 'string' || !KNOWN_TYPES.has(type)) {
+        return fail(`${sAt}: unknown type "${String(type)}"`);
+      }
+      if (typeof tier !== 'string' || !TIERS.has(tier)) {
+        return fail(`${sAt}: unknown tier "${String(tier)}"`);
+      }
+      return { value, type, tier: tier as FixtureTier };
+    });
+    items.push(
+      origin === undefined
+        ? { text, spans: checked }
+        : { text, spans: checked, origin: origin as FixtureOrigin },
+    );
+  });
+  return items;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+/** What the eval loop observed for one fixture item. */
+export interface ItemOutcome {
+  readonly maskedText: string;
+  /** Number of spans the detector set flagged (over-masking signal on
+   *  negatives). */
+  readonly flaggedSpans: number;
+  readonly latencyMs: number;
+}
+
+export interface TypeRecall {
+  readonly type: string;
+  readonly total: number;
+  readonly masked: number;
+  readonly handTotal: number;
+  readonly handMasked: number;
+}
+
+export interface LocaleReport {
+  readonly locale: string;
+  readonly byType: readonly TypeRecall[];
+  readonly structuredRecall: number;
+  readonly personRecall: number;
+  readonly personHandRecall: number;
+  readonly negatives: number;
+  readonly cleanNegatives: number;
+  readonly precisionProxy: number;
+  readonly latencyP95: number;
+}
+
+export function p95(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * 0.95) - 1)]!;
+}
+
+const recallOf = (masked: number, total: number): number =>
+  total === 0 ? 1 : masked / total;
+
+/**
+ * Score one locale for one detector set. Exact-match leak criterion (as
+ * shipped): a span counts as masked only when its full verbatim value is
+ * absent from the masked output (`findIdentityLeaks`). Note the honest
+ * caveat: a long value that is only PARTIALLY masked already counts as
+ * masked under this criterion — surviving fragments are a C1-tier
+ * measurement, visible in the c0 vs c0+c1 delta.
+ */
+export function aggregateLocale(
+  locale: string,
+  items: readonly FixtureItem[],
+  outcomes: readonly ItemOutcome[],
+): LocaleReport {
+  if (items.length !== outcomes.length) {
+    throw new Error(`[${locale}] items/outcomes length mismatch`);
+  }
+  const buckets = new Map<
+    string,
+    { total: number; masked: number; handTotal: number; handMasked: number }
+  >();
+  let negatives = 0;
+  let cleanNegatives = 0;
+  const latencies: number[] = [];
+
+  items.forEach((item, index) => {
+    const outcome = outcomes[index]!;
+    latencies.push(outcome.latencyMs);
+    if (item.spans.length === 0) {
+      negatives += 1;
+      if (outcome.flaggedSpans === 0) cleanNegatives += 1;
+      return;
+    }
+    const isHand = item.origin === 'hand';
+    for (const span of item.spans) {
+      const bucket =
+        buckets.get(span.type) ??
+        { total: 0, masked: 0, handTotal: 0, handMasked: 0 };
+      bucket.total += 1;
+      if (isHand) bucket.handTotal += 1;
+      if (findIdentityLeaks(outcome.maskedText, [span.value]).length === 0) {
+        bucket.masked += 1;
+        if (isHand) bucket.handMasked += 1;
+      }
+      buckets.set(span.type, bucket);
+    }
+  });
+
+  let structuredTotal = 0;
+  let structuredMasked = 0;
+  for (const [type, bucket] of buckets) {
+    if (STRUCTURED_TYPES.has(type)) {
+      structuredTotal += bucket.total;
+      structuredMasked += bucket.masked;
+    }
+  }
+  const person = buckets.get('person') ?? {
+    total: 0,
+    masked: 0,
+    handTotal: 0,
+    handMasked: 0,
+  };
+
+  return {
+    locale,
+    byType: [...buckets.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([type, b]) => ({ type, ...b })),
+    structuredRecall: recallOf(structuredMasked, structuredTotal),
+    personRecall: recallOf(person.masked, person.total),
+    personHandRecall: recallOf(person.handMasked, person.handTotal),
+    negatives,
+    cleanNegatives,
+    precisionProxy: recallOf(cleanNegatives, negatives),
+    latencyP95: p95(latencies),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Gates (pre-committed in README.md — do not tune after a run)
+// ---------------------------------------------------------------------------
+
+export interface GateRow {
+  readonly name: string;
+  readonly value: string;
+  readonly threshold: string;
+  /** Whether this gate counts toward the verdict for the given set. */
+  readonly enforced: boolean;
+  readonly pass: boolean;
+}
+
+export interface SetVerdict {
+  /** false = ablation set, reported but never gated (c1-solo). */
+  readonly gated: boolean;
+  readonly pass: boolean;
+  readonly rows: readonly GateRow[];
+  readonly note: string;
+}
+
+const pct = (v: number): string => `${(v * 100).toFixed(1)}%`;
+
+/**
+ * Gate policy per detector set:
+ *   - `c0`      — structured-identifier gates only (person is C1 territory).
+ *   - `c0+c1`   — structured AND person recall AND precision AND latency.
+ *   - `c1-solo` — ablation for marginal-contribution analysis: never gated.
+ * Unknown set names fall back to the c0 policy (conservative: never gate
+ * person recall on a set that was not declared to include C1).
+ */
+export function evaluateGates(setName: string, r: LocaleReport): SetVerdict {
+  const gated = setName !== 'c1-solo';
+  const personEnforced = setName === 'c0+c1';
+  const rows: GateRow[] = [
+    {
+      name: 'structured recall',
+      value: pct(r.structuredRecall),
+      threshold: '≥ 97%',
+      enforced: gated,
+      pass: r.structuredRecall >= 0.97,
+    },
+    {
+      name: 'person recall',
+      value: pct(r.personRecall),
+      threshold: '≥ 90%',
+      enforced: personEnforced,
+      pass: r.personRecall >= 0.9,
+    },
+    {
+      name: 'precision proxy (negatives clean)',
+      value: `${String(r.cleanNegatives)}/${String(r.negatives)} (${pct(r.precisionProxy)})`,
+      threshold: '≥ 85%',
+      enforced: gated,
+      pass: r.precisionProxy >= 0.85,
+    },
+    {
+      name: 'p95 added latency',
+      value: `${r.latencyP95.toFixed(1)} ms`,
+      threshold: '≤ 400 ms',
+      enforced: gated,
+      pass: r.latencyP95 <= 400,
+    },
+  ];
+  const note =
+    setName === 'c1-solo'
+      ? 'ablation — reported, never gated'
+      : setName === 'c0+c1'
+        ? 'all gates incl. person recall'
+        : 'structured-identifier gates only';
+  return {
+    gated,
+    pass: rows.filter((row) => row.enforced).every((row) => row.pass),
+    rows,
+    note,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+const typeScope = (type: string): string =>
+  STRUCTURED_TYPES.has(type)
+    ? 'structured'
+    : INFORMATIONAL_TYPES.has(type)
+      ? 'informational — ungated in v1'
+      : 'c1-scope';
+
+/** Default console output for one locale × set (matches the shipped
+ *  format, extended by person/hand-slice lines). */
+export function renderConsoleLocale(r: LocaleReport, verdict: SetVerdict): string {
+  const lines: string[] = [`\n=== ${r.locale} ===`];
+  for (const t of r.byType) {
+    lines.push(
+      `  recall ${t.type.padEnd(8)} ${String(t.masked)}/${String(t.total)}  ` +
+        `${pct(recallOf(t.masked, t.total))}  (${typeScope(t.type)})`,
+    );
+  }
+  lines.push(
+    `  person recall         overall ${pct(r.personRecall)}, ` +
+      `hand-slice ${pct(r.personHandRecall)} (go/no-go signal)`,
+  );
+  for (const row of verdict.rows) {
+    const gate = row.enforced ? `gate ${row.threshold}` : `${row.threshold}, not gated for this set`;
+    lines.push(`  ${row.name.padEnd(34)} ${row.value}  (${gate})`);
+  }
+  lines.push(
+    `  verdict (${verdict.note}): ${verdict.gated ? (verdict.pass ? 'PASS' : 'FAIL') : 'n/a'}`,
+  );
+  return lines.join('\n');
+}
+
+export interface LocaleResult {
+  readonly report: LocaleReport;
+  readonly verdict: SetVerdict;
+}
+
+export interface SetResults {
+  readonly set: string;
+  readonly locales: readonly LocaleResult[];
+}
+
+/** GitHub-flavored markdown for posting a full run to issue #361:
+ *  one section per locale, one block per detector set. */
+export function renderMarkdown(results: readonly SetResults[]): string {
+  const locales = results[0]?.locales.map((l) => l.report.locale) ?? [];
+  const out: string[] = ['# Prompt-PII detector validation run (#361)', ''];
+  out.push(`Detector sets: ${results.map((r) => `\`${r.set}\``).join(', ')}.`, '');
+  for (const locale of locales) {
+    out.push(`## ${locale}`, '');
+    for (const { set, locales: perLocale } of results) {
+      const entry = perLocale.find((l) => l.report.locale === locale);
+      if (!entry) continue;
+      const { report, verdict } = entry;
+      out.push(`### Set \`${set}\``, '');
+      out.push('| Type | Masked/Total | Recall | Hand slice | Scope |');
+      out.push('|---|---|---|---|---|');
+      for (const t of report.byType) {
+        const hand =
+          t.handTotal === 0
+            ? '—'
+            : `${String(t.handMasked)}/${String(t.handTotal)} (${pct(recallOf(t.handMasked, t.handTotal))})`;
+        out.push(
+          `| ${t.type} | ${String(t.masked)}/${String(t.total)} | ` +
+            `${pct(recallOf(t.masked, t.total))} | ${hand} | ${typeScope(t.type)} |`,
+        );
+      }
+      out.push('');
+      out.push('| Gate | Value | Threshold | Status |');
+      out.push('|---|---|---|---|');
+      for (const row of verdict.rows) {
+        const status = row.enforced ? (row.pass ? 'PASS' : 'FAIL') : 'not gated';
+        out.push(`| ${row.name} | ${row.value} | ${row.threshold} | ${status} |`);
+      }
+      out.push('');
+      out.push(
+        `**Verdict** (${verdict.note}): ` +
+          `${verdict.gated ? (verdict.pass ? '**PASS**' : '**FAIL**') : 'n/a'}`,
+      );
+      out.push('');
+    }
+  }
+  return out.join('\n');
+}

--- a/middleware/sidecars/pii-detector/Dockerfile
+++ b/middleware/sidecars/pii-detector/Dockerfile
@@ -1,0 +1,55 @@
+# GLiNER multilingual PII-detector sidecar (issue #361).
+#
+# Wraps urchade/GLiNER (Apache-2.0) with the `gliner_multi_pii-v1` fine-tune
+# in a minimal stdlib-only HTTP shim so the Node middleware never needs a
+# Python runtime: `POST /detect {text}` -> scored {start, end, text, label,
+# score} spans with Unicode code-point offsets.
+#
+# The model is baked into the image at BUILD time, pinned to an exact HF
+# revision — the running container performs no network egress (HF_HUB_OFFLINE
+# turns accidental download attempts into hard failures). On-prem friendly,
+# fail-fast. Deployment config stays deployment-local (skillspector precedent).
+FROM python:3.12-slim-bookworm
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Default: the ONNX export of urchade/gliner_multi_pii-v1 (quantized variant,
+# CPU-friendly). Torch fallback: build with
+#   --build-arg MODEL_ID=urchade/gliner_multi_pii-v1 \
+#   --build-arg MODEL_REVISION=1fcf13e85f4eef5394e1fcd406cf2ca9ea82351d \
+#   --build-arg DETECTOR_BACKEND=torch
+# (allow_patterns below covers both layouts; see README "Model pin & bump").
+ARG MODEL_ID=onnx-community/gliner_multi_pii-v1
+ARG MODEL_REVISION=2e0397a7e8a250d76c37122232b3cbde42c8d629
+ARG DETECTOR_BACKEND=onnx
+RUN python -c "\
+import os; \
+from huggingface_hub import snapshot_download; \
+snapshot_download(\
+    repo_id=os.environ['MODEL_ID'], \
+    revision=os.environ['MODEL_REVISION'], \
+    local_dir='/app/model', \
+    allow_patterns=[\
+        'gliner_config.json', 'config.json', \
+        'tokenizer.json', 'tokenizer_config.json', \
+        'special_tokens_map.json', 'added_tokens.json', 'spm.model', \
+        'onnx/model_quantized.onnx', \
+        'pytorch_model.bin', \
+    ])"
+
+ENV MODEL_ID=${MODEL_ID} \
+    MODEL_REVISION=${MODEL_REVISION} \
+    DETECTOR_BACKEND=${DETECTOR_BACKEND} \
+    MODEL_DIR=/app/model \
+    HF_HUB_OFFLINE=1
+
+COPY server.py .
+
+# Run as non-root: the shim only needs the model dir (read-only) and the port.
+RUN useradd --create-home detector
+USER detector
+
+EXPOSE 8812
+CMD ["python", "server.py"]

--- a/middleware/sidecars/pii-detector/README.md
+++ b/middleware/sidecars/pii-detector/README.md
@@ -1,0 +1,116 @@
+# GLiNER PII-detector sidecar (issue #361)
+
+HTTP shim around [urchade/GLiNER](https://github.com/urchade/GLiNER)
+(Apache-2.0) running the `gliner_multi_pii-v1` multilingual PII fine-tune
+(Apache-2.0). It is the C1 transformer tier of the privacy-guard
+`mask_user_prompt` feature: it finds the PII classes regex structurally
+cannot detect — `person` names and free-form `address`es — in en/de/fr/es/it
+(the fine-tune's card does not list nl; the per-locale validation gate
+absorbs that honestly).
+
+The middleware posts prompt text to `POST /detect`; the shim runs chunked
+GLiNER inference and answers scored spans. Enable in the middleware via
+`PRIVACY_C1_DETECTOR_URL` (see `docker-compose.pii-detector.yaml`). Sidecar
+unavailable ⇒ the middleware's audited degrade-to-C0 path fires
+(`promptMaskDegraded`) — never a silent unmasked pass-through.
+
+**This sidecar handles raw user-prompt PII.** It must only ever be reachable
+from the internal network (the compose overlay publishes no ports), it is
+stateless, and it never logs request text or span values — only lengths,
+counts, and durations.
+
+## HTTP contract (fail-closed, versioned)
+
+- `GET /health` →
+  `200 {"ok": true, "model": "...", "revision": "<pinned sha>", "backend": "onnx"}`.
+  The model loads before the server starts listening, so a 200 means
+  inference is ready (compose healthcheck uses `start_period: 120s` to cover
+  the load).
+- `POST /detect` with `{"text": str, "labels"?: [str], "threshold"?: float}` →
+  `200 {"ok": true, "model_version": str, "spans": [{"start": int, "end": int,
+  "text": str, "label": str, "score": float}]}`.
+  - Defaults when omitted: `labels = ["person", "address"]` (env
+    `DETECTOR_LABELS`, comma-separated), `threshold = 0.5` (env
+    `DETECTOR_THRESHOLD`).
+  - Any error (bad body, oversized body, model failure, overload) → non-200
+    with `{"ok": false, "error": str}`. Never a 200 with a half-result.
+
+### Span offset semantics
+
+`start`/`end` are **Unicode code-point offsets into the request text**
+(Python `str` indexing — an astral-plane emoji counts as one position), and
+`text` is the exact `text[start:end]` slice. JavaScript string indices are
+UTF-16 code units, so the middleware client converts code points → UTF-16
+offsets and then asserts its slice equals the returned `text` field; a
+mismatch is treated as a detector failure (a mis-anchored span is a leak).
+
+## Configuration (env)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `PORT` | `8812` | Listen port |
+| `MAX_BODY_BYTES` | `1048576` (1 MiB) | Request-body cap — prompts, not file trees |
+| `DETECT_TIMEOUT_S` | `30` | Max seconds a request waits for the serialized model (inference is single-flight behind a lock) before answering `503` |
+| `DETECTOR_LABELS` | `person,address` | Default label set — fixed and calibrated; open-label mode is deliberately not exposed (false-positive cascade class, see #242) |
+| `DETECTOR_THRESHOLD` | `0.5` | Default score threshold |
+| `DETECTOR_BACKEND` | `onnx` | `onnx` (quantized, CPU-friendly, avoids the documented AVX2 "Illegal instruction" hazard of default torch inference) or `torch` (fallback) |
+| `ONNX_MODEL_FILE` | `onnx/model_quantized.onnx` | ONNX file inside the model snapshot |
+| `CHUNK_MAX_WORDS` / `CHUNK_OVERLAP_WORDS` | `250` / `30` | Word-window chunking (GLiNER's encoder truncates at 384 tokens); overlapping windows are offset-remapped and deduped (higher score wins) |
+
+## Model pin & bump procedure
+
+The Dockerfile bakes the model at **build time**, pinned to an exact HF
+revision sha — the running container needs no egress (`HF_HUB_OFFLINE=1`
+makes accidental download attempts fail hard).
+
+- Default (ONNX): `onnx-community/gliner_multi_pii-v1` @
+  `2e0397a7e8a250d76c37122232b3cbde42c8d629`
+- Torch fallback: `urchade/gliner_multi_pii-v1` @
+  `1fcf13e85f4eef5394e1fcd406cf2ca9ea82351d` — build with
+  `--build-arg MODEL_ID=urchade/gliner_multi_pii-v1 --build-arg
+  MODEL_REVISION=1fcf13e… --build-arg DETECTOR_BACKEND=torch`
+
+To bump the pin (model revision or the `gliner`/`onnxruntime` pins in
+`requirements.txt`):
+
+1. Pick the new revision on Hugging Face (`GET
+   https://huggingface.co/api/models/<repo>` → `sha`) and review the upstream
+   diff / model-card changes since the current pin. License must stay
+   Apache-2.0 (Piiranha-v1 was rejected for CC-BY-NC-ND — do not "upgrade"
+   into a non-commercial license).
+2. Update the `ARG MODEL_REVISION` default in the Dockerfile (and
+   `MODEL_REVISION` default in `server.py`), rebuild
+   (`docker build middleware/sidecars/pii-detector`), and re-run the smoke
+   probe below.
+3. Re-run the 6-locale validation harness
+   (`harness-plugin-privacy-guard/src/validation/`) before any locale keeps
+   `mask_user_prompt` enabled on the new pin — detector quality is gated per
+   locale, not assumed.
+
+## Tests & smoke probe
+
+Pure-helper unit tests (chunking, span merge, request validation — no model
+needed):
+
+```bash
+cd middleware && python3 -m unittest sidecars/pii-detector/test_server.py
+```
+
+Manual smoke after a build:
+
+```bash
+docker compose -f docker-compose.yaml -f docker-compose.pii-detector.yaml up -d
+docker compose exec middleware node -e "fetch('http://pii-detector:8812/health').then(r => r.json()).then(j => console.log(j))"
+docker compose exec middleware node -e "
+fetch('http://pii-detector:8812/detect', {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ text: 'Anna Schmidt wohnt in der Bahnhofstr. 5, 60311 Frankfurt.' }),
+}).then(r => r.json()).then(j => console.log(JSON.stringify(j, null, 2)))"
+```
+
+Expected: a `person` span covering exactly `Anna Schmidt` and a plausible
+`address` span; for every span, `text` equals the code-point slice
+`[start, end)` of the request text. (The probe runs from inside the
+middleware container because the sidecar deliberately publishes no host
+port.)

--- a/middleware/sidecars/pii-detector/requirements.txt
+++ b/middleware/sidecars/pii-detector/requirements.txt
@@ -1,0 +1,11 @@
+# GLiNER — multilingual zero-shot NER used for PII span detection
+# (github.com/urchade/GLiNER, Apache-2.0). Exact pins, never ranges: the
+# sidecar sits on the raw-prompt path and its output gates what crosses the
+# LLM wire. Pin-bump procedure: see README.md.
+#
+# onnxruntime powers the default backend (quantized ONNX on CPU — avoids the
+# documented AVX2 "Illegal instruction" hazard of default torch inference).
+# gliner's own transitive deps (torch, transformers, huggingface_hub) come
+# with the gliner pin; the torch path stays available as a fallback backend.
+gliner==0.2.27
+onnxruntime==1.27.0

--- a/middleware/sidecars/pii-detector/server.py
+++ b/middleware/sidecars/pii-detector/server.py
@@ -1,0 +1,312 @@
+"""HTTP shim around GLiNER multilingual PII detection (issue #361).
+
+Endpoints:
+    GET  /health  -> 200 {"ok": true, "model": "...", "revision": "...",
+                          "backend": "onnx"|"torch"}
+                     The model is loaded BEFORE the server starts listening,
+                     so a 200 here means inference is ready.
+    POST /detect  -> body {"text": str, "labels"?: [str], "threshold"?: float}
+                     responds {"ok": true, "model_version": str,
+                               "spans": [{"start", "end", "text", "label",
+                                          "score"}]}
+
+Span offsets: `start`/`end` are Unicode CODE-POINT offsets into the request
+text (Python `str` indexing — an astral-plane emoji counts as ONE position),
+and `text` is the exact `text[start:end]` slice. The middleware client
+converts code points to the UTF-16 offsets JavaScript needs and uses the
+`text` field to verify its conversion (a mis-anchored span is a leak).
+
+Fail-closed: any error (bad body, oversized body, model failure, overload)
+answers non-200 with {"ok": false, "error": str} — never a 200 with a
+half-result. The middleware treats a non-200 as "C1 unavailable" and rides
+its audited degrade-to-C0 path.
+
+PRIVACY: this sidecar handles raw user-prompt PII. Request text and span
+values are NEVER logged — only lengths, counts, and durations.
+
+Deliberately stdlib-only apart from the model runtime itself (precedent:
+middleware/sidecars/skillspector/server.py). Stateless: nothing is persisted
+between requests. The middleware-side contract lands with the
+`createC1HttpDetector` client in harness-plugin-privacy-guard.
+"""
+
+import json
+import os
+import re
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PORT = int(os.environ.get("PORT", "8812"))
+# Prompts, not file trees — 1 MiB is generous for a chat message.
+MAX_BODY_BYTES = int(os.environ.get("MAX_BODY_BYTES", str(1024 * 1024)))
+# Max seconds a request waits for the serialized model before answering 503.
+# (In-process inference cannot be interrupted mid-run; this bounds queueing.)
+DETECT_TIMEOUT_S = float(os.environ.get("DETECT_TIMEOUT_S", "30"))
+
+# Model identity — baked into the image by the Dockerfile (exact HF revision,
+# downloaded at build time; the running container performs no egress).
+MODEL_ID = os.environ.get("MODEL_ID", "onnx-community/gliner_multi_pii-v1")
+MODEL_REVISION = os.environ.get(
+    "MODEL_REVISION", "2e0397a7e8a250d76c37122232b3cbde42c8d629"
+)
+MODEL_DIR = os.environ.get("MODEL_DIR", "/app/model")
+# "onnx" (default: quantized ONNX on CPU — avoids the documented AVX2
+# "Illegal instruction" hazard of default torch inference) or "torch"
+# (fallback; needs a torch-weights snapshot, see README).
+DETECTOR_BACKEND = os.environ.get("DETECTOR_BACKEND", "onnx")
+ONNX_MODEL_FILE = os.environ.get("ONNX_MODEL_FILE", "onnx/model_quantized.onnx")
+
+# Calibrated, fixed label set — C1 owns exactly the classes regex cannot
+# detect. Open-label flexibility is deliberately NOT exposed (false-positive
+# cascade class, see #242 / piiAnnotation.ts history).
+DEFAULT_LABELS = [
+    label.strip()
+    for label in os.environ.get("DETECTOR_LABELS", "person,address").split(",")
+    if label.strip()
+]
+DEFAULT_THRESHOLD = float(os.environ.get("DETECTOR_THRESHOLD", "0.5"))
+
+# GLiNER's encoder truncates at 384 tokens; ~250 words per window with a
+# 30-word overlap keeps every entity fully inside at least one window.
+CHUNK_MAX_WORDS = int(os.environ.get("CHUNK_MAX_WORDS", "250"))
+CHUNK_OVERLAP_WORDS = int(os.environ.get("CHUNK_OVERLAP_WORDS", "30"))
+
+_WORD_RE = re.compile(r"\S+")
+
+# Populated once by main() before the server starts serving.
+_STATE = {"model": None, "backend": None}
+_INFER_LOCK = threading.Lock()
+
+
+def chunk_text(text, max_words=None, overlap_words=None):
+    """Split `text` into overlapping word-window chunks.
+
+    Returns a list of `(offset, chunk)` pairs where `offset` is the
+    code-point offset of `chunk` inside `text`, i.e. the invariant
+    `text[offset:offset + len(chunk)] == chunk` always holds. Words are
+    maximal runs of non-whitespace; chunk boundaries sit on word boundaries,
+    so only inter-word whitespace can fall between chunks. Empty /
+    whitespace-only text yields no chunks.
+    """
+    max_words = CHUNK_MAX_WORDS if max_words is None else max_words
+    overlap_words = CHUNK_OVERLAP_WORDS if overlap_words is None else overlap_words
+    if max_words <= 0:
+        raise ValueError("max_words must be positive")
+    if not 0 <= overlap_words < max_words:
+        raise ValueError("overlap_words must be in [0, max_words)")
+    words = list(_WORD_RE.finditer(text))
+    if not words:
+        return []
+    if len(words) <= max_words:
+        return [(0, text)]
+    step = max_words - overlap_words
+    chunks = []
+    for i in range(0, len(words), step):
+        window = words[i : i + max_words]
+        start = window[0].start()
+        end = window[-1].end()
+        chunks.append((start, text[start:end]))
+        if i + max_words >= len(words):
+            break
+    return chunks
+
+
+def merge_spans(chunk_results):
+    """Map chunk-relative spans to absolute offsets and dedupe overlaps.
+
+    `chunk_results` is `[(chunk_offset, spans)]` with GLiNER-shaped span
+    dicts (`start`/`end`/`text`/`label`/`score`, offsets relative to the
+    chunk). Overlapping absolute spans — typically the same entity seen by
+    two overlapping windows — are deduped keeping the higher score;
+    deterministic tie-break prefers the longer span, then the earlier one.
+    Touching spans (`a.end == b.start`) do not overlap. Result is sorted by
+    `start`.
+    """
+    absolute = []
+    for offset, spans in chunk_results:
+        for span in spans:
+            absolute.append(
+                {
+                    "start": int(span["start"]) + offset,
+                    "end": int(span["end"]) + offset,
+                    "text": str(span["text"]),
+                    "label": str(span["label"]),
+                    "score": float(span["score"]),
+                }
+            )
+    absolute.sort(
+        key=lambda s: (
+            -s["score"],
+            -(s["end"] - s["start"]),
+            s["start"],
+            s["end"],
+            s["label"],
+        )
+    )
+    kept = []
+    for cand in absolute:
+        if any(
+            cand["start"] < k["end"] and k["start"] < cand["end"] for k in kept
+        ):
+            continue
+        kept.append(cand)
+    kept.sort(key=lambda s: (s["start"], s["end"], s["label"]))
+    return kept
+
+
+def validate_request(body, default_labels=None, default_threshold=None):
+    """Validate a /detect body; returns (text, labels, threshold).
+
+    Raises ValueError with a text-free message on any malformed input —
+    the error string must never echo prompt content.
+    """
+    default_labels = DEFAULT_LABELS if default_labels is None else default_labels
+    default_threshold = (
+        DEFAULT_THRESHOLD if default_threshold is None else default_threshold
+    )
+    if not isinstance(body, dict):
+        raise ValueError("body must be a JSON object")
+    unknown = set(body) - {"text", "labels", "threshold"}
+    if unknown:
+        raise ValueError(f"unknown body keys: {sorted(unknown)}")
+    text = body.get("text")
+    if not isinstance(text, str):
+        raise ValueError("body needs a string 'text'")
+    labels = body.get("labels", default_labels)
+    if (
+        not isinstance(labels, list)
+        or not labels
+        or not all(isinstance(l, str) and l.strip() for l in labels)
+    ):
+        raise ValueError("'labels' must be a non-empty array of non-empty strings")
+    threshold = body.get("threshold", default_threshold)
+    if isinstance(threshold, bool) or not isinstance(threshold, (int, float)):
+        raise ValueError("'threshold' must be a number")
+    threshold = float(threshold)
+    if not 0.0 < threshold <= 1.0:
+        raise ValueError("'threshold' must be in (0, 1]")
+    return text, [label.strip() for label in labels], threshold
+
+
+def load_model():
+    """Load GLiNER once at process start; returns (model, backend)."""
+    from gliner import GLiNER  # deferred: unit tests import this module without it
+
+    if DETECTOR_BACKEND == "onnx":
+        model = GLiNER.from_pretrained(
+            MODEL_DIR,
+            load_onnx_model=True,
+            load_tokenizer=True,
+            onnx_model_file=ONNX_MODEL_FILE,
+        )
+        return model, "onnx"
+    if DETECTOR_BACKEND == "torch":
+        model = GLiNER.from_pretrained(MODEL_DIR)
+        return model, "torch"
+    raise ValueError(f"unsupported DETECTOR_BACKEND: {DETECTOR_BACKEND!r}")
+
+
+def detect(text, labels, threshold):
+    """Chunked, offset-remapped inference over `text`. Caller holds the lock."""
+    model = _STATE["model"]
+    if model is None:
+        raise RuntimeError("model not loaded")
+    chunk_results = []
+    for offset, chunk in chunk_text(text):
+        entities = model.predict_entities(chunk, labels, threshold=threshold)
+        chunk_results.append((offset, entities))
+    return merge_spans(chunk_results)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _respond(self, status, body):
+        raw = json.dumps(body).encode("utf-8")
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def do_GET(self):  # noqa: N802 — http.server API
+        if self.path == "/health":
+            self._respond(
+                200,
+                {
+                    "ok": True,
+                    "model": MODEL_ID,
+                    "revision": MODEL_REVISION,
+                    "backend": _STATE["backend"],
+                },
+            )
+        else:
+            self._respond(404, {"ok": False, "error": "not found"})
+
+    def do_POST(self):  # noqa: N802 — http.server API
+        if self.path != "/detect":
+            self._respond(404, {"ok": False, "error": "not found"})
+            return
+        length = int(self.headers.get("content-length", "0"))
+        if length <= 0 or length > MAX_BODY_BYTES:
+            self._respond(413, {"ok": False, "error": "body missing or too large"})
+            return
+        try:
+            body = json.loads(self.rfile.read(length))
+        except Exception:  # malformed JSON/encoding — never echo the payload
+            self._respond(400, {"ok": False, "error": "invalid JSON body"})
+            return
+        try:
+            text, labels, threshold = validate_request(body)
+        except ValueError as err:  # validate_request messages are text-free
+            self._respond(400, {"ok": False, "error": str(err)})
+            return
+        if not _INFER_LOCK.acquire(timeout=DETECT_TIMEOUT_S):
+            self._respond(
+                503, {"ok": False, "error": "detector busy (queue wait exceeded)"}
+            )
+            return
+        started = time.monotonic()
+        try:
+            spans = detect(text, labels, threshold)
+        except Exception as err:  # noqa: BLE001 — shim must answer, not die
+            # Type name only: library errors could embed input fragments.
+            self._respond(
+                500, {"ok": False, "error": f"inference failed: {type(err).__name__}"}
+            )
+            return
+        finally:
+            _INFER_LOCK.release()
+        duration_ms = int((time.monotonic() - started) * 1000)
+        # Lengths/counts/durations only — never the text or span values.
+        print(
+            f"[pii-detector] /detect text_len={len(text)} labels={len(labels)} "
+            f"spans={len(spans)} ms={duration_ms}",
+            flush=True,
+        )
+        self._respond(
+            200,
+            {
+                "ok": True,
+                "model_version": f"{MODEL_ID}@{MODEL_REVISION[:12]}",
+                "spans": spans,
+            },
+        )
+
+    def log_message(self, fmt, *args):  # quiet default access log (paths only anyway)
+        pass
+
+
+if __name__ == "__main__":
+    print(
+        f"[pii-detector] loading {MODEL_ID}@{MODEL_REVISION[:12]} "
+        f"(backend={DETECTOR_BACKEND}) ...",
+        flush=True,
+    )
+    _load_started = time.monotonic()
+    _STATE["model"], _STATE["backend"] = load_model()
+    print(
+        f"[pii-detector] model ready in {time.monotonic() - _load_started:.1f}s; "
+        f"listening on :{PORT}",
+        flush=True,
+    )
+    ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()

--- a/middleware/sidecars/pii-detector/test_server.py
+++ b/middleware/sidecars/pii-detector/test_server.py
@@ -1,0 +1,194 @@
+"""Unit tests for the pure helpers in server.py (issue #361).
+
+Stdlib-only; `server` is importable without gliner/onnxruntime installed
+(the model import is deferred into load_model). Run from middleware/:
+
+    python3 -m unittest sidecars/pii-detector/test_server.py
+"""
+
+import os
+import sys
+import unittest
+
+# Make `import server` work regardless of the caller's cwd (e.g. running
+# `python3 -m unittest sidecars/pii-detector/test_server.py` from middleware/).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import server  # noqa: E402 — needs the sys.path entry above
+
+
+def span(start, end, text="x", label="person", score=0.9):
+    return {"start": start, "end": end, "text": text, "label": label, "score": score}
+
+
+class ChunkTextTests(unittest.TestCase):
+    def test_empty_text_yields_no_chunks(self):
+        self.assertEqual(server.chunk_text(""), [])
+
+    def test_whitespace_only_yields_no_chunks(self):
+        self.assertEqual(server.chunk_text("   \n\t  "), [])
+
+    def test_text_shorter_than_window_is_single_chunk_at_offset_zero(self):
+        text = "  Anna Schmidt wohnt in Frankfurt.  "
+        self.assertEqual(server.chunk_text(text, max_words=250), [(0, text)])
+
+    def test_exactly_max_words_is_single_chunk(self):
+        text = " ".join(f"w{i}" for i in range(10))
+        self.assertEqual(server.chunk_text(text, max_words=10, overlap_words=3), [(0, text)])
+
+    def test_chunk_offsets_slice_back_to_chunk(self):
+        text = "  " + "  ".join(f"word{i}" for i in range(120)) + "  "
+        for offset, chunk in server.chunk_text(text, max_words=25, overlap_words=5):
+            self.assertEqual(text[offset : offset + len(chunk)], chunk)
+
+    def test_every_word_is_covered_by_some_chunk(self):
+        words = [f"word{i}" for i in range(97)]  # not a multiple of the step
+        text = " ".join(words)
+        chunks = server.chunk_text(text, max_words=20, overlap_words=4)
+        for match in server._WORD_RE.finditer(text):
+            covered = any(
+                offset <= match.start() and match.end() <= offset + len(chunk)
+                for offset, chunk in chunks
+            )
+            self.assertTrue(covered, f"word at {match.start()} not covered")
+
+    def test_overlap_continuity_between_consecutive_chunks(self):
+        text = " ".join(f"word{i}" for i in range(100))
+        overlap = 4
+        chunks = server.chunk_text(text, max_words=20, overlap_words=overlap)
+        self.assertGreater(len(chunks), 1)
+        for (off_a, chunk_a), (off_b, chunk_b) in zip(chunks, chunks[1:]):
+            # The next chunk starts overlap words before the previous one ends.
+            tail_words = chunk_a.split()[-overlap:]
+            head_words = chunk_b.split()[:overlap]
+            self.assertEqual(tail_words, head_words)
+            self.assertLess(off_b, off_a + len(chunk_a))
+
+    def test_offsets_are_code_points_with_multibyte_and_astral_chars(self):
+        # "🜁" (astral) and "ä" each count as ONE code point in offsets.
+        text = "🜁🜁 Müller 😀foo " + " ".join(f"w{i}" for i in range(50))
+        chunks = server.chunk_text(text, max_words=10, overlap_words=2)
+        for offset, chunk in chunks:
+            self.assertEqual(text[offset : offset + len(chunk)], chunk)
+        # The word "Müller" sits fully inside the first chunk at its str index.
+        first_offset, first_chunk = chunks[0]
+        idx = text.index("Müller")
+        self.assertEqual(first_offset, 0)
+        self.assertEqual(first_chunk[idx : idx + len("Müller")], "Müller")
+
+    def test_invalid_parameters_raise(self):
+        with self.assertRaises(ValueError):
+            server.chunk_text("hello world", max_words=0)
+        with self.assertRaises(ValueError):
+            server.chunk_text("hello world", max_words=10, overlap_words=10)
+        with self.assertRaises(ValueError):
+            server.chunk_text("hello world", max_words=10, overlap_words=-1)
+
+
+class MergeSpansTests(unittest.TestCase):
+    def test_empty_input(self):
+        self.assertEqual(server.merge_spans([]), [])
+        self.assertEqual(server.merge_spans([(0, [])]), [])
+
+    def test_chunk_offsets_are_applied(self):
+        merged = server.merge_spans([(100, [span(5, 12, "Anna Sc")])])
+        self.assertEqual(merged, [span(105, 112, "Anna Sc")])
+
+    def test_overlapping_duplicate_keeps_higher_score(self):
+        # Same entity seen by two overlapping windows at the same absolute spot.
+        merged = server.merge_spans(
+            [
+                (0, [span(10, 22, "Anna Schmidt", score=0.71)]),
+                (8, [span(2, 14, "Anna Schmidt", score=0.93)]),
+            ]
+        )
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["score"], 0.93)
+        self.assertEqual((merged[0]["start"], merged[0]["end"]), (10, 22))
+
+    def test_partial_overlap_keeps_higher_score(self):
+        merged = server.merge_spans(
+            [(0, [span(0, 10, score=0.6), span(8, 20, score=0.8)])]
+        )
+        self.assertEqual(len(merged), 1)
+        self.assertEqual((merged[0]["start"], merged[0]["end"]), (8, 20))
+
+    def test_score_tie_prefers_longer_span(self):
+        merged = server.merge_spans(
+            [(0, [span(0, 5, score=0.7), span(0, 12, score=0.7)])]
+        )
+        self.assertEqual(len(merged), 1)
+        self.assertEqual((merged[0]["start"], merged[0]["end"]), (0, 12))
+
+    def test_touching_spans_do_not_overlap(self):
+        merged = server.merge_spans(
+            [(0, [span(0, 5, score=0.9), span(5, 10, score=0.5)])]
+        )
+        self.assertEqual(len(merged), 2)
+
+    def test_disjoint_spans_kept_and_sorted_by_start(self):
+        merged = server.merge_spans(
+            [
+                (50, [span(0, 4, label="address", score=0.5)]),
+                (0, [span(1, 5, score=0.99)]),
+            ]
+        )
+        self.assertEqual([(s["start"], s["end"]) for s in merged], [(1, 5), (50, 54)])
+
+    def test_coerces_numeric_types(self):
+        merged = server.merge_spans([(0, [span(1, 3, score=1)])])
+        self.assertIsInstance(merged[0]["score"], float)
+        self.assertIsInstance(merged[0]["start"], int)
+
+
+class ValidateRequestTests(unittest.TestCase):
+    def test_valid_minimal_body_applies_defaults(self):
+        text, labels, threshold = server.validate_request(
+            {"text": "hello"}, default_labels=["person"], default_threshold=0.5
+        )
+        self.assertEqual(text, "hello")
+        self.assertEqual(labels, ["person"])
+        self.assertEqual(threshold, 0.5)
+
+    def test_explicit_labels_and_threshold_pass_through(self):
+        text, labels, threshold = server.validate_request(
+            {"text": "t", "labels": [" person ", "address"], "threshold": 0.8}
+        )
+        self.assertEqual(labels, ["person", "address"])
+        self.assertEqual(threshold, 0.8)
+
+    def test_empty_text_is_valid(self):
+        text, _, _ = server.validate_request({"text": ""})
+        self.assertEqual(text, "")
+
+    def test_rejects_non_object_body(self):
+        for body in (None, [], "text", 42):
+            with self.assertRaises(ValueError):
+                server.validate_request(body)
+
+    def test_rejects_missing_or_non_string_text(self):
+        for body in ({}, {"text": 5}, {"text": None}, {"text": ["a"]}):
+            with self.assertRaises(ValueError):
+                server.validate_request(body)
+
+    def test_rejects_bad_labels(self):
+        for labels in ([], [""], ["  "], "person", [1], ["person", 2]):
+            with self.assertRaises(ValueError):
+                server.validate_request({"text": "t", "labels": labels})
+
+    def test_rejects_bad_threshold(self):
+        for threshold in (0, 0.0, 1.5, -0.1, "0.5", True, None):
+            with self.assertRaises(ValueError):
+                server.validate_request({"text": "t", "threshold": threshold})
+
+    def test_threshold_upper_bound_inclusive(self):
+        _, _, threshold = server.validate_request({"text": "t", "threshold": 1})
+        self.assertEqual(threshold, 1.0)
+
+    def test_rejects_unknown_keys(self):
+        with self.assertRaises(ValueError):
+            server.validate_request({"text": "t", "prompt": "smuggled"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/middleware/test/privacyPromptC1Detector.test.ts
+++ b/middleware/test/privacyPromptC1Detector.test.ts
@@ -1,0 +1,350 @@
+/**
+ * #361 — C1 HTTP detector (`createC1HttpDetector`) over the GLiNER
+ * PII-detector sidecar.
+ *
+ * Pins the fail-closed client contract:
+ *   - URL unresolved      ⇒ `[]`, no fetch (unconfigured ≠ degraded);
+ *   - valid response      ⇒ spans converted code-point → UTF-16 exactly
+ *                           (incl. astral-plane characters);
+ *   - anything unexpected ⇒ THROW (schema mismatch, non-200, non-JSON,
+ *                           offset/slice mismatch, timeout) — the service's
+ *                           tier-1 path turns the throw into an audited
+ *                           degrade-to-C0, which the composition tests at
+ *                           the bottom pin end-to-end.
+ *
+ * The generic throwing-detector degrade case lives in
+ * `privacyPromptMask.test.ts`; here the SAME semantics are asserted through
+ * the real HTTP client implementation.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { PromptPiiSpan } from '@omadia/plugin-api';
+import {
+  C1_DETECTOR_ID,
+  createC1HttpDetector,
+} from '@omadia/plugin-privacy-guard/dist/c1Detector.js';
+import { createPrivacyGuardService } from '@omadia/plugin-privacy-guard/dist/index.js';
+import { findIdentityLeaks } from '@omadia/plugin-privacy-guard/dist/v4/onTheWire.js';
+
+type SidecarSpan = {
+  start: number;
+  end: number;
+  text: string;
+  label: string;
+  score: number;
+};
+
+/** fetch fake answering a canned sidecar response; records calls. */
+function fakeFetch(
+  respond: (body: string) => Response | Promise<Response>,
+): { fn: typeof fetch; calls: { url: string; body: unknown }[] } {
+  const calls: { url: string; body: unknown }[] = [];
+  const fn = (async (input: unknown, init?: RequestInit) => {
+    const url = String(input);
+    const body: unknown = JSON.parse(String(init?.body ?? 'null'));
+    calls.push({ url, body });
+    return await respond(String(init?.body ?? ''));
+  }) as typeof fetch;
+  return { fn, calls };
+}
+
+function okResponse(spans: SidecarSpan[]): Response {
+  return new Response(
+    JSON.stringify({ ok: true, model_version: 'test', spans }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+describe('createC1HttpDetector', () => {
+  it('returns [] without fetching when no URL resolves (unconfigured, not degraded)', async () => {
+    const { fn, calls } = fakeFetch(() => okResponse([]));
+    for (const unresolved of [undefined, '', '   ']) {
+      const detector = createC1HttpDetector({
+        resolveUrl: () => unresolved,
+        fetchFn: fn,
+      });
+      assert.deepEqual(await detector.detect('Mail an Anna Schmidt'), []);
+    }
+    assert.equal(calls.length, 0, 'unconfigured detector must not fetch');
+  });
+
+  it('has the stable receipt id c1-gliner', () => {
+    const detector = createC1HttpDetector({ resolveUrl: () => undefined });
+    assert.equal(detector.id, 'c1-gliner');
+    assert.equal(detector.id, C1_DETECTOR_ID);
+  });
+
+  it('POSTs {text, labels, threshold} to <url>/detect (trailing slash normalized)', async () => {
+    const { fn, calls } = fakeFetch(() => okResponse([]));
+    const detector = createC1HttpDetector({
+      resolveUrl: () => 'http://pii-detector:8812/',
+      fetchFn: fn,
+    });
+    await detector.detect('kein PII hier');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]!.url, 'http://pii-detector:8812/detect');
+    assert.deepEqual(calls[0]!.body, {
+      text: 'kein PII hier',
+      labels: ['person', 'address'],
+      threshold: 0.5,
+    });
+  });
+
+  it('converts code-point offsets to UTF-16 exactly (astral-plane case)', async () => {
+    // '😀' is ONE code point but TWO UTF-16 units — the exact Python↔JS
+    // divergence the conversion exists for.
+    const text = '😀 Anna Schmidt wohnt in der Bahnhofstr. 5';
+    // Sidecar (Python) offsets: emoji=1 position, so 'Anna Schmidt' is
+    // code points 2..14 and 'Bahnhofstr. 5' is 28..41.
+    const { fn } = fakeFetch(() =>
+      okResponse([
+        { start: 2, end: 14, text: 'Anna Schmidt', label: 'person', score: 0.93 },
+        { start: 28, end: 41, text: 'Bahnhofstr. 5', label: 'address', score: 0.81 },
+      ]),
+    );
+    const detector = createC1HttpDetector({
+      resolveUrl: () => 'http://sidecar',
+      fetchFn: fn,
+    });
+    const spans = await detector.detect(text);
+    assert.equal(spans.length, 2);
+    const [person, address] = spans as [PromptPiiSpan, PromptPiiSpan];
+    // UTF-16: emoji occupies indices 0..2, so the name starts at 3.
+    assert.equal(person.start, 3);
+    assert.equal(person.end, 15);
+    assert.equal(text.slice(person.start, person.end), 'Anna Schmidt');
+    assert.equal(person.type, 'person');
+    assert.equal(person.confidence, 0.93);
+    assert.equal(text.slice(address.start, address.end), 'Bahnhofstr. 5');
+    assert.equal(address.type, 'address');
+  });
+
+  it('accepts a span ending exactly at end-of-text', async () => {
+    const text = '😀 Anna';
+    const { fn } = fakeFetch(() =>
+      okResponse([{ start: 2, end: 6, text: 'Anna', label: 'person', score: 0.9 }]),
+    );
+    const detector = createC1HttpDetector({
+      resolveUrl: () => 'http://sidecar',
+      fetchFn: fn,
+    });
+    const spans = await detector.detect(text);
+    assert.equal(spans.length, 1);
+    assert.equal(text.slice(spans[0]!.start, spans[0]!.end), 'Anna');
+  });
+
+  it('throws when the span text does not match its offsets (mis-anchored span = leak)', async () => {
+    const { fn } = fakeFetch(() =>
+      okResponse([
+        // Offsets point at 'Anna Schm', text claims something else.
+        { start: 0, end: 9, text: 'Bob Miller', label: 'person', score: 0.9 },
+      ]),
+    );
+    const detector = createC1HttpDetector({
+      resolveUrl: () => 'http://sidecar',
+      fetchFn: fn,
+    });
+    await assert.rejects(detector.detect('Anna Schmidt calls'), /does not match/);
+  });
+
+  it('throws when span offsets are out of range', async () => {
+    const { fn } = fakeFetch(() =>
+      okResponse([{ start: 90, end: 99, text: 'x', label: 'person', score: 0.9 }]),
+    );
+    const detector = createC1HttpDetector({
+      resolveUrl: () => 'http://sidecar',
+      fetchFn: fn,
+    });
+    await assert.rejects(detector.detect('kurz'), /out of range/);
+  });
+
+  it('throws on non-200, ok:false, malformed spans, and non-JSON bodies', async () => {
+    const cases: { name: string; respond: () => Response }[] = [
+      {
+        name: 'non-200',
+        respond: () =>
+          new Response(JSON.stringify({ ok: false, error: 'overloaded' }), {
+            status: 503,
+          }),
+      },
+      {
+        name: 'ok:false with 200',
+        respond: () =>
+          new Response(JSON.stringify({ ok: false, error: 'nope' }), { status: 200 }),
+      },
+      {
+        name: 'missing spans array',
+        respond: () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      },
+      {
+        name: 'span missing score',
+        respond: () =>
+          new Response(
+            JSON.stringify({
+              ok: true,
+              spans: [{ start: 0, end: 4, text: 'Anna', label: 'person' }],
+            }),
+            { status: 200 },
+          ),
+      },
+      {
+        name: 'span with non-integer offsets',
+        respond: () =>
+          new Response(
+            JSON.stringify({
+              ok: true,
+              spans: [{ start: 0.5, end: 4, text: 'Anna', label: 'person', score: 1 }],
+            }),
+            { status: 200 },
+          ),
+      },
+      {
+        name: 'span with end <= start',
+        respond: () =>
+          new Response(
+            JSON.stringify({
+              ok: true,
+              spans: [{ start: 4, end: 4, text: 'Anna', label: 'person', score: 1 }],
+            }),
+            { status: 200 },
+          ),
+      },
+      {
+        name: 'non-JSON body',
+        respond: () => new Response('<html>gateway error</html>', { status: 200 }),
+      },
+      {
+        name: 'non-object body',
+        respond: () => new Response('42', { status: 200 }),
+      },
+    ];
+    for (const { name, respond } of cases) {
+      const { fn } = fakeFetch(respond);
+      const detector = createC1HttpDetector({
+        resolveUrl: () => 'http://sidecar',
+        fetchFn: fn,
+      });
+      await assert.rejects(
+        detector.detect('Anna Schmidt'),
+        undefined,
+        `case '${name}' must throw (fail-closed)`,
+      );
+    }
+  });
+
+  it('throws on timeout even when the transport ignores the abort signal', async () => {
+    const never = (() => new Promise<Response>(() => undefined)) as typeof fetch;
+    const detector = createC1HttpDetector({
+      resolveUrl: () => 'http://sidecar',
+      fetchFn: never,
+      timeoutMs: 25,
+    });
+    await assert.rejects(detector.detect('Anna Schmidt'), /timed out after 25ms/);
+  });
+
+  it('maps unknown labels to a slug type and clamps the score into [0,1]', async () => {
+    const text = 'DE89 3704 0044 0532 0130 00 gehört Anna';
+    const { fn } = fakeFetch(() =>
+      okResponse([
+        { start: 0, end: 27, text: 'DE89 3704 0044 0532 0130 00', label: 'Credit Card', score: 1.7 },
+        { start: 35, end: 39, text: 'Anna', label: 'person', score: -0.2 },
+      ]),
+    );
+    const detector = createC1HttpDetector({
+      resolveUrl: () => 'http://sidecar',
+      fetchFn: fn,
+    });
+    const spans = await detector.detect(text);
+    assert.equal(spans[0]!.type, 'credit-card');
+    assert.equal(spans[0]!.confidence, 1);
+    assert.equal(spans[1]!.type, 'person');
+    assert.equal(spans[1]!.confidence, 0);
+  });
+
+  it('honors custom labels and threshold in the request body', async () => {
+    const { fn, calls } = fakeFetch(() => okResponse([]));
+    const detector = createC1HttpDetector({
+      resolveUrl: () => 'http://sidecar',
+      fetchFn: fn,
+      labels: ['person'],
+      threshold: 0.7,
+    });
+    await detector.detect('text');
+    assert.deepEqual(calls[0]!.body, { text: 'text', labels: ['person'], threshold: 0.7 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Composition with the shipped service — the HTTP detector's throw semantics
+// must ride the tier-1 degrade path, and its spans the normal mask pass.
+// (The generic stub/throwing-detector cases live in privacyPromptMask.test.ts;
+// these two pin the REAL client end-to-end.)
+// ---------------------------------------------------------------------------
+
+describe('createC1HttpDetector × createPrivacyGuardService', () => {
+  it('degrades to C0 (masked, degraded:true) when the sidecar is unreachable', async () => {
+    const failingFetch = (async () => {
+      throw new Error('connect ECONNREFUSED');
+    }) as typeof fetch;
+    const svc = createPrivacyGuardService({
+      readConfig: () => 'on',
+      c1Detector: createC1HttpDetector({
+        resolveUrl: () => 'http://sidecar',
+        fetchFn: failingFetch,
+      }),
+    });
+    const result = await svc.maskUserPrompt!({
+      sessionId: 's',
+      turnId: 't-http-degraded',
+      text: 'Mail an anna.schmidt@firma.de bitte',
+    });
+    assert.equal(result.outcome, 'masked');
+    if (result.outcome !== 'masked') return;
+    assert.equal(result.degraded, true);
+    // The C0 baseline still masked the structured identifier.
+    assert.equal(
+      findIdentityLeaks(result.maskedText, ['anna.schmidt@firma.de']).length,
+      0,
+    );
+  });
+
+  it('masks C1 person spans through the normal pass (degraded:false, detector attributed)', async () => {
+    const text = 'What should we pay Anna Schmidt next year?';
+    const { fn } = fakeFetch(() =>
+      okResponse([
+        { start: 19, end: 31, text: 'Anna Schmidt', label: 'person', score: 0.95 },
+      ]),
+    );
+    const svc = createPrivacyGuardService({
+      readConfig: () => 'on',
+      c1Detector: createC1HttpDetector({
+        resolveUrl: () => 'http://sidecar',
+        fetchFn: fn,
+      }),
+    });
+    const result = await svc.maskUserPrompt!({
+      sessionId: 's',
+      turnId: 't-http-person',
+      text,
+    });
+    assert.equal(result.outcome, 'masked');
+    if (result.outcome !== 'masked') return;
+    assert.equal(result.degraded, false);
+    assert.ok(
+      !result.maskedText.includes('Anna Schmidt'),
+      'the real name must not survive on the wire',
+    );
+    const personSpans = result.spans.filter((s) => s.type === 'person');
+    assert.ok(personSpans.length >= 1);
+    assert.equal(personSpans[0]!.detector, 'c1-gliner');
+    // Restore projects the surrogate back to the real name.
+    const surrogate = result.maskedText.slice(19).split(' next')[0]!;
+    const restored = await svc.restorePromptPseudonyms!(
+      't-http-person',
+      `We should pay ${surrogate} more.`,
+    );
+    assert.equal(restored, 'We should pay Anna Schmidt more.');
+  });
+});

--- a/middleware/test/privacyPromptMask.test.ts
+++ b/middleware/test/privacyPromptMask.test.ts
@@ -86,6 +86,42 @@ describe('dedupSpans', () => {
     ]);
     assert.equal(resolved[0]!.value, 'anna.schmidt@firma.de');
   });
+
+  it('keeps the uncovered remainder of a losing lower-confidence span (review finding)', () => {
+    // A long C1 free-form-address span (score < 1) brushing a short
+    // confidence-1 C0 hit inside it must NOT be dropped wholesale — the
+    // parts C0 does not cover would otherwise reach the wire unmasked.
+    const text =
+      'Das Paket bitte an das gelbe Hinterhaus im zweiten Hof der ' +
+      'Lindenallee 5, dritter Aufgang links, 60311 Frankfurt am Main liefern.';
+    const c1Value =
+      'das gelbe Hinterhaus im zweiten Hof der Lindenallee 5, ' +
+      'dritter Aufgang links, 60311 Frankfurt am Main';
+    const c1Start = text.indexOf(c1Value);
+    const c0Value = '60311 Frankfurt';
+    const c0Start = text.indexOf(c0Value);
+    const resolved = dedupSpans(text, [
+      {
+        span: { start: c1Start, end: c1Start + c1Value.length, type: 'address', confidence: 0.8 },
+        detector: 'c1-gliner',
+      },
+      {
+        span: { start: c0Start, end: c0Start + c0Value.length, type: 'address', confidence: 1 },
+        detector: 'c0-regex',
+      },
+    ]);
+    // Every character of the C1 span is covered by some kept span.
+    for (let i = c1Start; i < c1Start + c1Value.length; i++) {
+      assert.ok(
+        resolved.some((s) => s.start <= i && i < s.end),
+        `offset ${String(i)} ('${text[i]!}') of the C1 span lost coverage`,
+      );
+    }
+    // And the output stays non-overlapping, sorted by start.
+    for (let i = 1; i < resolved.length; i++) {
+      assert.ok(resolved[i - 1]!.end <= resolved[i]!.start);
+    }
+  });
 });
 
 describe('createPromptPseudonymMap', () => {
@@ -155,6 +191,31 @@ describe('maskPrompt', () => {
     const result = await maskPrompt(text, [createBaselineDetector()]);
     assert.equal(result.maskedText, text);
     assert.equal(result.spans.length, 0);
+  });
+
+  it('masks a C1 free-form address even where C0 hits inside it (review finding)', async () => {
+    const text =
+      'Das Paket bitte an das gelbe Hinterhaus im zweiten Hof der ' +
+      'Lindenallee 5, dritter Aufgang links, 60311 Frankfurt am Main liefern.';
+    const c1Value =
+      'das gelbe Hinterhaus im zweiten Hof der Lindenallee 5, ' +
+      'dritter Aufgang links, 60311 Frankfurt am Main';
+    const c1Start = text.indexOf(c1Value);
+    const fakeC1: PromptPiiDetector = {
+      id: 'c1-gliner',
+      detect: async () => [
+        { start: c1Start, end: c1Start + c1Value.length, type: 'address', confidence: 0.8 },
+      ],
+    };
+    const result = await maskPrompt(text, [createBaselineDetector(), fakeC1]);
+    for (const fragment of ['Hinterhaus', 'Lindenallee', 'Aufgang', 'Frankfurt']) {
+      assert.equal(
+        findIdentityLeaks(result.maskedText, [fragment]).length,
+        0,
+        `address fragment '${fragment}' survived masking`,
+      );
+    }
+    assert.equal(resolvePseudonyms(result.maskedText, result.map), text);
   });
 });
 

--- a/web-ui/app/_components/chat/PrivacyReceiptCard.tsx
+++ b/web-ui/app/_components/chat/PrivacyReceiptCard.tsx
@@ -2,7 +2,10 @@
 
 import { useTranslations } from 'next-intl';
 
-import type { PrivacyReceipt } from '../../_lib/chatSessions';
+import type {
+  PrivacyReceipt,
+  PromptMaskedSpanInfo,
+} from '../../_lib/chatSessions';
 
 interface PrivacyReceiptCardProps {
   receipt: PrivacyReceipt;
@@ -36,6 +39,7 @@ export function PrivacyReceiptCard({
   const t = useTranslations('privacyReceipt');
   const verbs = receipt.verbsExecuted;
   const bypassed = receipt.bypassedTools ?? [];
+  const promptSpans = receipt.maskedPromptSpans ?? [];
 
   // Palette precedence: identity-breach (red) wins over bypass-warning
   // (amber) wins over default (emerald). Breach is a transparency notice
@@ -101,6 +105,13 @@ export function PrivacyReceiptCard({
             }
             labelClass={palette.label}
           />
+          {promptSpans.length > 0 && (
+            <Fact
+              label={t('factPromptMasked')}
+              value={formatMaskedPromptSpans(promptSpans)}
+              labelClass={palette.label}
+            />
+          )}
           {breached && (
             <Fact
               label={t('factIdentityOnWire')}
@@ -140,6 +151,11 @@ export function PrivacyReceiptCard({
         <div className={['text-[11px] italic', palette.muted].join(' ')}>
           {t(explainerKey)}
         </div>
+        {promptSpans.length > 0 && (
+          <div className={['text-[11px] italic', palette.muted].join(' ')}>
+            {t('explainerPromptMasked')}
+          </div>
+        )}
         {hasBypass && (
           <div className={['text-[11px] italic', palette.muted].join(' ')}>
             {t('explainerBypassed')}
@@ -212,12 +228,38 @@ export function summarisePrivacyReceipt(r: PrivacyReceipt, t: TFn): string {
   if (bypassed.length > 0) {
     parts.push(t('summaryBypassed', { count: bypassed.length }));
   }
+  const promptSpans = r.maskedPromptSpans ?? [];
+  if (promptSpans.length > 0) {
+    parts.push(t('summaryPromptMasked', { count: promptSpans.length }));
+  }
   const onWire = r.identityValuesOnWire ?? 0;
   if (onWire > 0) {
     // Lead with the breach clause so it is the first thing read.
     parts.unshift(t('summaryIdentityOnWire', { count: onWire }));
   }
   return parts.join(' · ');
+}
+
+/**
+ * #361 — fact-row value for the masked-prompt-spans row: total count plus a
+ * per-type breakdown, e.g. `3 (2 × person, 1 × email)`. Pure and exported
+ * for unit tests. Types are an OPEN set — whatever string the backend
+ * detector emitted renders verbatim (like verb names), no type enum here.
+ * Detector ids stay in the data; the card does not surface them (parity
+ * with the existing fact-row density — no other row shows engine ids).
+ * Grouping preserves first-seen order so the value is deterministic.
+ */
+export function formatMaskedPromptSpans(
+  spans: readonly PromptMaskedSpanInfo[],
+): string {
+  const byType = new Map<string, number>();
+  for (const span of spans) {
+    byType.set(span.type, (byType.get(span.type) ?? 0) + 1);
+  }
+  const breakdown = [...byType.entries()]
+    .map(([type, count]) => `${String(count)} × ${type}`)
+    .join(', ');
+  return `${String(spans.length)} (${breakdown})`;
 }
 
 // ---------------------------------------------------------------------------

--- a/web-ui/app/_components/chat/__tests__/PrivacyReceiptCard.test.tsx
+++ b/web-ui/app/_components/chat/__tests__/PrivacyReceiptCard.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import type { PrivacyReceipt } from '../../../_lib/chatSessions';
 import { renderWithIntl } from '../../../_lib/test-utils';
 import {
+  formatMaskedPromptSpans,
   PrivacyReceiptCard,
   summarisePrivacyReceipt,
 } from '../PrivacyReceiptCard';
@@ -40,6 +41,16 @@ const NAMED: PrivacyReceipt = {
   verbsExecuted: ['filter'],
   pseudonymProjectionUsed: false,
   identityValuesOnWire: 1,
+};
+
+/** #361 — three prompt spans were pseudonymised before the LLM wire. */
+const PROMPT_MASKED: PrivacyReceipt = {
+  ...RANKED,
+  maskedPromptSpans: [
+    { type: 'person', detector: 'c1-gliner' },
+    { type: 'person', detector: 'c1-gliner' },
+    { type: 'email', detector: 'c0-regex' },
+  ],
 };
 
 describe('<PrivacyReceiptCard />', () => {
@@ -113,6 +124,58 @@ describe('<PrivacyReceiptCard />', () => {
     expect(root?.className).not.toMatch(/danger/);
   });
 
+  it('shows the masked-prompt summary chunk and fact row when spans exist', () => {
+    renderWithIntl(<PrivacyReceiptCard receipt={PROMPT_MASKED} />, {
+      locale: 'de',
+    });
+    expect(screen.getByText(/Privacy Shield/).textContent).toContain(
+      'Prompt: 3 maskiert',
+    );
+    expect(
+      screen.getByText('Maskierte PII in deiner Nachricht'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('3 (2 × person, 1 × email)')).toBeInTheDocument();
+  });
+
+  it('shows the masked-prompt explainer only when the row is present', () => {
+    renderWithIntl(<PrivacyReceiptCard receipt={PROMPT_MASKED} />, {
+      locale: 'de',
+    });
+    expect(screen.getByText(/durch Pseudonyme ersetzt/)).toBeInTheDocument();
+  });
+
+  it('renders an unknown open-set span type as plain text', () => {
+    const receipt: PrivacyReceipt = {
+      ...RANKED,
+      maskedPromptSpans: [{ type: 'idnum', detector: 'c1-gliner' }],
+    };
+    renderWithIntl(<PrivacyReceiptCard receipt={receipt} />, { locale: 'de' });
+    expect(screen.getByText('1 (1 × idnum)')).toBeInTheDocument();
+  });
+
+  it('renders byte-identically to today when maskedPromptSpans is absent', () => {
+    const { container } = renderWithIntl(
+      <PrivacyReceiptCard receipt={RANKED} />,
+      { locale: 'de' },
+    );
+    expect(
+      screen.queryByText('Maskierte PII in deiner Nachricht'),
+    ).not.toBeInTheDocument();
+    expect(container.textContent).not.toContain('Prompt:');
+    expect(container.textContent).not.toContain('Pseudonyme ersetzt');
+  });
+
+  it('treats an empty maskedPromptSpans array as absent', () => {
+    const receipt: PrivacyReceipt = { ...RANKED, maskedPromptSpans: [] };
+    renderWithIntl(<PrivacyReceiptCard receipt={receipt} />, { locale: 'de' });
+    expect(
+      screen.queryByText('Maskierte PII in deiner Nachricht'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/Privacy Shield/).textContent).not.toContain(
+      'Prompt:',
+    );
+  });
+
   it('never leaks a PII-shaped value — the receipt carries only counts', () => {
     // The v4 receipt is PII-free by construction: counts and verb names
     // only. This pins the contract — if the schema ever regains a value
@@ -155,5 +218,42 @@ describe('summarisePrivacyReceipt()', () => {
     expect(summarisePrivacyReceipt(RANKED, t)).not.toContain(
       'summaryIdentityOnWire',
     );
+  });
+
+  it('adds the masked-prompt clause when prompt spans exist', () => {
+    expect(summarisePrivacyReceipt(PROMPT_MASKED, t)).toContain(
+      'summaryPromptMasked:3',
+    );
+  });
+
+  it('omits the masked-prompt clause when the field is absent or empty', () => {
+    expect(summarisePrivacyReceipt(RANKED, t)).not.toContain(
+      'summaryPromptMasked',
+    );
+    expect(
+      summarisePrivacyReceipt({ ...RANKED, maskedPromptSpans: [] }, t),
+    ).not.toContain('summaryPromptMasked');
+  });
+});
+
+describe('formatMaskedPromptSpans()', () => {
+  it('groups spans by type in first-seen order', () => {
+    expect(formatMaskedPromptSpans(PROMPT_MASKED.maskedPromptSpans ?? [])).toBe(
+      '3 (2 × person, 1 × email)',
+    );
+  });
+
+  it('renders unknown open-set types verbatim', () => {
+    expect(
+      formatMaskedPromptSpans([{ type: 'idnum', detector: 'c1-gliner' }]),
+    ).toBe('1 (1 × idnum)');
+  });
+
+  it('never includes detector ids in the rendered value', () => {
+    const value = formatMaskedPromptSpans(
+      PROMPT_MASKED.maskedPromptSpans ?? [],
+    );
+    expect(value).not.toContain('c1-gliner');
+    expect(value).not.toContain('c0-regex');
   });
 });

--- a/web-ui/app/_lib/chatSessions.ts
+++ b/web-ui/app/_lib/chatSessions.ts
@@ -163,6 +163,22 @@ export interface PrivacyReceipt {
    * Absent / empty when no bypass fired. PII-free.
    */
   bypassedTools?: readonly BypassedToolEntry[];
+  /**
+   * #361 — PII spans detected in the user's own prompt and substituted with
+   * pseudonyms before the prompt crossed the LLM wire. Absent when prompt
+   * masking is off (the default) or nothing was detected. PII-free: entries
+   * carry the span TYPE + detector id only, never the value.
+   */
+  maskedPromptSpans?: readonly PromptMaskedSpanInfo[];
+}
+
+/** #361 — PII-free record of one prompt span masked before the LLM wire.
+ *  Mirrors `PromptMaskedSpanInfo` from `@omadia/plugin-api`. */
+export interface PromptMaskedSpanInfo {
+  /** Span type — open set, e.g. `person`, `email`, `address`, `iban`. */
+  type: string;
+  /** Detector that found the span, e.g. `c0-regex` or `c1-gliner`. */
+  detector: string;
 }
 
 /**

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -923,7 +923,10 @@
     "factBypassed": "Nicht maskiert (Operator-Entscheidung)",
     "bypassedReasonOperatorSetting": "Operator-Setting: Bypass",
     "bypassedBytes": "{kb} KB roh",
-    "explainerBypassed": "Der Operator hat für mindestens ein Plugin den Privacy-Mode auf »Bypass« gestellt — dessen Tool-Ergebnisse erreichten das Modell unmaskiert. Eingesetzt für vertrauenswürdige interne Quellen, deren Inhalte der Privacy Shield strukturell nicht sinnvoll digestieren kann."
+    "explainerBypassed": "Der Operator hat für mindestens ein Plugin den Privacy-Mode auf »Bypass« gestellt — dessen Tool-Ergebnisse erreichten das Modell unmaskiert. Eingesetzt für vertrauenswürdige interne Quellen, deren Inhalte der Privacy Shield strukturell nicht sinnvoll digestieren kann.",
+    "summaryPromptMasked": "Prompt: {count} maskiert",
+    "factPromptMasked": "Maskierte PII in deiner Nachricht",
+    "explainerPromptMasked": "In deiner eigenen Nachricht erkannte Identifikatoren wurden vor dem Modellaufruf durch Pseudonyme ersetzt und in der Antwort wiederhergestellt."
   },
   "directLine": {
     "consultedLabel": "🔎 Konsultiert",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -923,7 +923,10 @@
     "factBypassed": "Not masked (operator decision)",
     "bypassedReasonOperatorSetting": "Operator setting: bypass",
     "bypassedBytes": "{kb} KB raw",
-    "explainerBypassed": "The operator set Privacy Mode to »Bypass« for at least one plugin — its tool results reached the model unmasked. Used for trusted internal sources whose content the Privacy Shield cannot usefully digest structurally."
+    "explainerBypassed": "The operator set Privacy Mode to »Bypass« for at least one plugin — its tool results reached the model unmasked. Used for trusted internal sources whose content the Privacy Shield cannot usefully digest structurally.",
+    "summaryPromptMasked": "prompt: {count} masked",
+    "factPromptMasked": "PII masked in your prompt",
+    "explainerPromptMasked": "Identifiers detected in your own message were replaced with pseudonyms before the model call and restored in the answer."
   },
   "directLine": {
     "consultedLabel": "🔎 Consulted",


### PR DESCRIPTION
Implements the remaining scope of the prompt-PII-masking work per the plan of record on #361 (verified against `main @ 527fff3`). PR #477 shipped the entire orchestrator side — the `PromptPiiDetector` seam, the failure-closed `maskUserPrompt` path with a `c1Detector` injection slot, span dedup/pseudonym substitution, the runnable validation harness with pre-committed gates, and receipt plumbing. This branch delivers the four follow-up units:

## 1. GLiNER PII-detector sidecar (`d5bbc22`)

New optional inference sidecar `middleware/sidecars/pii-detector/` following the skillspector precedent: stdlib-only Python HTTP shim, stateless, fail-closed. Runs `urchade/gliner_multi_pii-v1` (Apache-2.0 — chosen over the RFC's Piiranha, whose CC-BY-NC-ND-4.0 license blocks commercial use), quantized ONNX backend by default with torch fallback. `POST /detect` returns scored `person`/`address` spans as Unicode code-point offsets; model and deps are exact-version-pinned and baked into the image at build time (`HF_HUB_OFFLINE=1`, no runtime egress). Enabled via the `docker-compose.pii-detector.yaml` overlay — internal-network-only, no published ports, request text and span values never logged. Without the overlay the default stack is unchanged.

## 2. C1 HTTP detector wired into the shipped seam (`46392a1`)

`harness-plugin-privacy-guard` 0.4.0 adds `createC1HttpDetector` (detector id `c1-gliner`), injected through the existing `createPrivacyGuardService({ c1Detector })` deps option — zero changes to `service.ts`, `promptMask.ts`, or the orchestrator. New non-secret setup field `c1_detector_url` (env fallback `PRIVACY_C1_DETECTOR_URL`; unset means C0-only, no call attempted) and one deliberate `permissions.network.outbound` entry. The client positively validates the sidecar response schema, converts code-point offsets to UTF-16 exactly, and asserts per span that the converted slice reproduces the sidecar's text — any mismatch, timeout, non-200, or malformed body throws and rides the shipped audited degrade-to-C0 path. Never a silent unmasked pass-through.

## 3. 6-locale validation build-out (`e7e6c02`)

Fixtures for fr/es/it/nl plus scaled-up de/en — 121 items per locale (89 positives including a 25-item hand-built out-of-distribution slice, 32 PII-free negatives). All committed fixtures are original (hand-built + LLM-generated synthetic); no ai4privacy-derived rows (restricted commercial terms). With `PII_DETECTOR_URL` set, the harness adds a `c0+c1` set (person recall >= 0.90 now enforceable alongside the shipped structured/precision/latency gates) and a `c1-solo` ablation; `--markdown` emits GFM tables for posting run results to #361. Locale ID numbers are typed `idnum` and measured informationally, never gated in v1. The harness stays runnable-not-CI; the per-locale flag policy is unchanged (green posted run before any locale flips `mask_user_prompt` on).

## 4. Receipt UI: masked prompt spans (`1c58c71`)

The chat privacy-receipt card now surfaces the backend receipt field `maskedPromptSpans` (shipped in PR #477 but unknown to the frontend mirror until now):

- `PromptMaskedSpanInfo` mirrored into `web-ui/app/_lib/chatSessions.ts`, `maskedPromptSpans?` added to the frontend `PrivacyReceipt`.
- `PrivacyReceiptCard`: collapsed summary chunk ("prompt: 3 masked"), expanded fact row with a per-type breakdown ("3 (2 x person, 1 x email)") following the existing `bypassedTools` pattern, plus a dedicated explainer line. Span types are an open set rendered verbatim; detector ids stay in the data and are not rendered (no other fact row exposes engine ids). Absent or empty field renders the card byte-identically to before.
- Lume constraints honored: existing neutral fact-row styling and semantic tokens only, no new buttons, no spinners, no hardcoded colors.
- i18n keys `privacyReceipt.{summaryPromptMasked,factPromptMasked,explainerPromptMasked}` in both en and de (parity check green).
- 11 new vitest cases: chunk/row/explainer presence, grouped breakdown, unknown open-set type rendering, absent and empty-array behavior, detector ids never rendered.

Deviations from the unit spec, noted for review: (a) the German `factPromptMasked` uses Du-form ("deiner Nachricht") instead of the spec's Sie-form, matching the tone of every existing string on this card; (b) `docs/CHANGELOG.md` entries accompany each unit per AGENTS.md, beyond the units' listed file scopes; (c) a pure `formatMaskedPromptSpans` helper is exported for unit testing, mirroring the existing `summarisePrivacyReceipt` pattern.

## Verification

Per unit: sidecar unittest suite and docker build; middleware detector/service tests; harness c0-only run green without the sidecar. Frontend unit: `npm run typecheck` (clean), `npm run test` (34 files, 223 tests passed), `npm run i18n:check` (OK, 2738 keys, en/de parity).

Closing deliverable after merge: run the harness (c0, c0+c1, c1-solo across all 6 locales) on representative CPU hardware and post the markdown tables to #361; only locales with a green posted run flip `mask_user_prompt` on.

Closes #361