### PR TITLE
fix(ci): grant id-token: write to release.yml's edge-images job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # Keyless cosign signing of the dev-runner release image (spec §10): the
+      # reusable workflow signs with the workflow's GitHub OIDC token, so the
+      # CALLER must grant id-token here — a reusable workflow cannot self-grant it.
+      id-token: write
     # No `version` input -> edge build (:edge + :sha-<short>) from this commit.
     uses: ./.github/workflows/publish-images.yml
 


### PR DESCRIPTION
## Summary

`release.yml`'s `edge-images` job (push-to-`main` → `:edge` + `:sha-<short>` Docker images) calls the reusable `publish-images.yml` workflow, which requires `id-token: write` for keyless cosign signing (spec §10, added at some point after this job was written). A reusable workflow cannot self-grant that permission — the caller must. `edge-images` was never updated when that requirement landed, while `auto-release.yml`'s equivalent `publish-images` job (for versioned releases) already grants it correctly.

Result: GitHub rejects the workflow file at parse time —

```
Error calling workflow '.../publish-images.yml@<sha>'. The workflow is
requesting 'id-token: write', but is only allowed 'id-token: none'.
```

Checked all Release-workflow runs on `main`: this has been `startup_failure` on **every push to main since 2026-07-12** (`c627c3c`) — 15 days, no `:edge` image has published.

## Fix

Add `id-token: write` to `edge-images`'s `permissions:` block — the exact same line + comment already used in `auto-release.yml`'s `publish-images` job (confirmed no other caller of `publish-images.yml` is missing it).

## Test plan

- [x] Diffed against `auto-release.yml`'s working `publish-images` job — identical permission set
- [x] Confirmed the only two callers of `publish-images.yml` in the repo, both now consistent
- [ ] CI green on this PR (only touches a workflow YAML file, no build-affecting checks expected to change)
- [ ] Merge and confirm the next push-to-main successfully runs `edge-images` end-to-end (can't be verified pre-merge since `release.yml` only triggers on push to `main`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787716836&installation_model_id=428086&pr_number=514&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F514&signature=2e5e6fc6205eba9438b2000df28e3b4777d15192444c307d5cb0609f6aebfe64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->