### PR TITLE
fix(builder): synthesize manifest capabilities per tool (#507)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,29 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — codegen: manifest capabilities[] now reflect per-tool spec flags (#507)
+
+- `reproduceManifestCapabilities` (builder codegen) used to clone the
+  boilerplate's `search` capability (`input_schema:{query}`,
+  `side_effects:'read'`, `idempotent:true`, `autonomous:true`,
+  `timeout_ms:20000`) onto every tool, substituting only id/description.
+  `toolkit.ts` was generated correctly per-tool from the real Zod schemas,
+  but `manifest.yaml`'s declared metadata was not: write tools shipped as
+  `side_effects:'read'` + `autonomous:true`, misrepresenting their real
+  behavior to anything that reads the manifest (marketplace listings,
+  human reviewers, or any orchestrator-side consumer of these flags).
+  `ToolSpecSchema` gained explicit `output`, `side_effects`, `idempotent`,
+  `autonomous`, and `timeout_ms` fields (previously stripped silently by
+  Zod's non-strict mode) so codegen can synthesise each `capabilities[]`
+  entry from the real per-tool spec, falling back to the boilerplate
+  defaults only for fields a tool omits. Applies uniformly to single- and
+  multi-tool specs. `side_effects` is declared and passed through as the
+  manifest's own `'read' | 'write' | 'none'` string enum (matching
+  `agent-integration/manifest.yaml` and `agent-reference-maximum/manifest.yaml`),
+  not a boolean — an earlier draft of this fix used a boolean field with a
+  boolean-to-string mapping in codegen, which rejected valid spec/patch
+  payloads shaped like the manifest's real contract.
+
 ### Fixed — templates v2 review round 3: owner-aware publish vs. auth timing (#478)
 
 - The save-as-template dialog no longer reads the viewer's own template id as

--- a/middleware/src/plugins/builder/agentSpec.ts
+++ b/middleware/src/plugins/builder/agentSpec.ts
@@ -84,13 +84,35 @@ export const ToolSpecSchema = z.object({
   // omits the field. The lint_spec pass (B.4) still flags missing
   // schemas as warnings for tools that look like they should have args.
   input: InputJsonSchemaShape.default({} as JsonSchema),
+  // Optional JSON-Schema for the tool's return value. Mirrors `input`
+  // shape-wise; codegen falls back to the boilerplate's default
+  // `output_schema` when a tool omits this (see codegen.ts
+  // reproduceManifestCapabilities).
+  output: InputJsonSchemaShape.optional(),
+  // #507 — these four used to be advisory-only: the Builder LLM emitted
+  // them from training memory, Zod's non-strict mode silently dropped
+  // them, and codegen cloned the boilerplate's static `search`-template
+  // values (side_effects:'read', idempotent:true, autonomous:true,
+  // timeout_ms:20000) onto every tool regardless of what the LLM wrote
+  // here. Declaring them explicitly lets codegen synthesise each
+  // capability entry per-tool instead. `side_effects` mirrors the
+  // manifest's own `'read' | 'write' | 'none'` string enum (see
+  // middleware/assets/boilerplate/agent-integration/manifest.yaml and
+  // middleware/packages/agent-reference-maximum/manifest.yaml) — it is
+  // passed straight through by codegen, not mapped from a boolean.
+  // Undefined fields fall back to the boilerplate default per-tool,
+  // same as `output` above.
+  side_effects: z.enum(['read', 'write', 'none']).optional(),
+  idempotent: z.boolean().optional(),
+  autonomous: z.boolean().optional(),
+  timeout_ms: z.number().int().positive().optional(),
 });
 // Note: NOT `.strict()` — the Builder LLM frequently adds advisory
-// metadata fields it learned from other tool schemas (`side_effects`,
-// `idempotent`, `autonomous`, `timeout_ms`, etc.). Zod's default
-// behaviour silently strips unrecognized keys, which is the right
-// trade-off: we'd rather move forward with a clean spec than block the
-// build on metadata that nothing downstream consumes.
+// metadata fields it learned from other tool schemas beyond the ones
+// declared above. Zod's default behaviour silently strips unrecognized
+// keys, which is the right trade-off: we'd rather move forward with a
+// clean spec than block the build on metadata that nothing downstream
+// consumes.
 
 export type ToolSpec = z.infer<typeof ToolSpecSchema>;
 

--- a/middleware/src/plugins/builder/codegen.ts
+++ b/middleware/src/plugins/builder/codegen.ts
@@ -1,6 +1,6 @@
 import yaml from 'yaml';
 
-import { type AgentSpec, validateSpecForCodegen } from './agentSpec.js';
+import { type AgentSpec, type ToolSpec, validateSpecForCodegen } from './agentSpec.js';
 import {
   loadBoilerplate,
   type BoilerplateBundle,
@@ -549,24 +549,29 @@ function reproduceManifestCapabilities(
     return doc.toString();
   }
 
-  if (spec.tools.length <= 1) {
-    // 0 tools: clear the array (placeholder cap is meaningless without a tool).
-    // 1 tool:  default boilerplate already shapes one cap; placeholder
-    //          substitution finishes the job.
-    if (spec.tools.length === 0) capsNode.items = [];
+  if (spec.tools.length === 0) {
+    // Placeholder cap is meaningless without a tool.
+    capsNode.items = [];
     return doc.toString();
   }
 
-  // Multi-tool: clone the first cap once per tool, baking each tool's id +
-  // description into the per-clone copy. Placeholder substitution still runs
-  // afterwards over the resulting YAML to handle anything else in the block.
+  // #507 — one capability entry per spec.tools[i], synthesised from the
+  // tool's own fields rather than cloning the boilerplate's `search`
+  // template verbatim. This used to only trigger for spec.tools.length > 1
+  // (the single-tool case relied on the boilerplate's static defaults +
+  // placeholder substitution), which meant a single write-tool agent
+  // shipped `side_effects: read` / `autonomous: true` in manifest.yaml
+  // regardless of the spec, even though toolkit.ts had the correct
+  // per-tool schema. Applying the same synthesis uniformly to 1-tool
+  // agents makes the manifest's declared metadata match the spec in
+  // every case. Mirrors the per-item synthesis pattern in
+  // buildExternalReadsArtifacts below: fields the tool spec doesn't
+  // declare fall back to the boilerplate template's static defaults.
   const templateNode = capsNode.items[0] as yaml.Node;
-  const templateJson = templateNode.toJSON() as unknown;
-  const newItems = spec.tools.map((tool) => {
-    const cloneJson = JSON.parse(JSON.stringify(templateJson)) as unknown;
-    const baked = bakePerToolPlaceholders(cloneJson, tool.id, tool.description);
-    return doc.createNode(baked);
-  });
+  const templateJson = templateNode.toJSON() as Record<string, unknown>;
+  const newItems = spec.tools.map((tool) =>
+    doc.createNode(synthesizeCapabilityEntry(templateJson, tool)),
+  );
   capsNode.items = newItems as typeof capsNode.items;
   return doc.toString();
 }
@@ -642,6 +647,49 @@ function bakePerToolPlaceholders(
     return out;
   }
   return node;
+}
+
+/**
+ * #507 — builds one `capabilities[]` entry from a boilerplate template
+ * clone + a single `spec.tools[i]`. `input_schema` is always taken from
+ * `tool.input` (ToolSpecSchema defaults it to `{}`, so it's never
+ * undefined — an explicit "no args" schema, not a missing one).
+ * `output_schema`/`side_effects`/`idempotent`/`autonomous`/`timeout_ms`
+ * are genuinely optional on ToolSpec, so a tool that omits one falls
+ * back to whatever the boilerplate template shipped for that field.
+ *
+ * `side_effects` is already the manifest's own `'read' | 'write' | 'none'`
+ * string enum on ToolSpec (see ToolSpecSchema in agentSpec.ts) and is
+ * passed straight through, never mapped from a boolean. Getting this
+ * right matters: anything that reads manifest.yaml's declared
+ * side_effects/autonomous flags to decide whether a tool call needs
+ * confirmation depends on these values actually matching the tool's
+ * real behavior, and a write tool falling through to the template
+ * default would misreport itself as read-only/autonomous instead.
+ */
+function synthesizeCapabilityEntry(
+  templateJson: Record<string, unknown>,
+  tool: ToolSpec,
+): Record<string, unknown> {
+  const cloneJson = JSON.parse(JSON.stringify(templateJson)) as Record<string, unknown>;
+  // Bake any stray {{CAPABILITY_ID}}/{{CAPABILITY_DESCRIPTION_DE}} usage
+  // elsewhere in the template clone (e.g. inside output_schema docs)
+  // before the explicit field overrides below take precedence.
+  const baked = bakePerToolPlaceholders(cloneJson, tool.id, tool.description) as Record<
+    string,
+    unknown
+  >;
+  return {
+    ...baked,
+    id: tool.id,
+    description: tool.description,
+    input_schema: tool.input,
+    output_schema: tool.output ?? baked['output_schema'],
+    side_effects: tool.side_effects ?? baked['side_effects'],
+    idempotent: tool.idempotent ?? baked['idempotent'],
+    autonomous: tool.autonomous ?? baked['autonomous'],
+    timeout_ms: tool.timeout_ms ?? baked['timeout_ms'],
+  };
 }
 
 const RESIDUE_RE = /\{\{[A-Z][A-Z0-9_]*\}\}/g;

--- a/middleware/test/builder/codegen.test.ts
+++ b/middleware/test/builder/codegen.test.ts
@@ -392,22 +392,111 @@ describe('codegen.generate', () => {
   });
 
   it('reproduces manifest capabilities for multi-tool specs', async () => {
+    // #507 regression test — the old codegen cloned the boilerplate's
+    // `search` capability (input_schema:{query}, side_effects:'read',
+    // idempotent:true, autonomous:true, timeout_ms:20000) onto every tool
+    // and only substituted id/description. This spec mixes a read tool, a
+    // write tool with fully-specified flags, and a third tool that omits
+    // the optional flags entirely (must fall back to the boilerplate
+    // template's defaults, not silently disappear).
     const { spec: base, slots } = loadFixture();
     const spec = parseAgentSpec({
       ...base,
       tools: [
-        { id: 'get_forecast', description: 'Wetter-Forecast', input: { type: 'object' } },
-        { id: 'get_alerts', description: 'Wetterwarnungen', input: { type: 'object' } },
+        {
+          id: 'list_teams',
+          description: 'Listet Teams',
+          input: { type: 'object', properties: {} },
+          side_effects: 'read',
+          idempotent: true,
+          autonomous: true,
+          timeout_ms: 15000,
+        },
+        {
+          id: 'create_issue',
+          description: 'Legt ein Issue an',
+          input: {
+            type: 'object',
+            required: ['team_id', 'title'],
+            properties: {
+              team_id: { type: 'string' },
+              title: { type: 'string' },
+            },
+          },
+          output: { type: 'object', properties: { id: { type: 'string' } } },
+          side_effects: 'write',
+          idempotent: false,
+          autonomous: false,
+          timeout_ms: 15000,
+        },
+        {
+          id: 'get_forecast',
+          description: 'Wetter-Forecast',
+          input: { type: 'object' },
+          // No side_effects/idempotent/autonomous/timeout_ms — must fall
+          // back to the boilerplate template's static defaults.
+        },
       ],
     });
     const out = await generate({ spec, slots });
 
     const manifestYaml = out.get('manifest.yaml')!.toString('utf-8');
-    const parsed = yaml.parse(manifestYaml) as { capabilities: Array<{ id: string }> };
-    assert.equal(parsed.capabilities.length, 2);
-    const ids = parsed.capabilities.map((c) => c.id);
-    assert.ok(ids.includes('get_forecast'));
-    assert.ok(ids.includes('get_alerts'));
+    const parsed = yaml.parse(manifestYaml) as {
+      capabilities: Array<{
+        id: string;
+        input_schema: unknown;
+        output_schema: unknown;
+        side_effects: string;
+        idempotent: boolean;
+        autonomous: boolean;
+        timeout_ms: number;
+      }>;
+    };
+    assert.equal(parsed.capabilities.length, 3);
+    const byId = new Map(parsed.capabilities.map((c) => [c.id, c]));
+
+    const listTeams = byId.get('list_teams')!;
+    assert.deepEqual(listTeams.input_schema, { type: 'object', properties: {} });
+    assert.equal(listTeams.side_effects, 'read');
+    assert.equal(listTeams.idempotent, true);
+    assert.equal(listTeams.autonomous, true);
+    assert.equal(listTeams.timeout_ms, 15000);
+
+    const createIssue = byId.get('create_issue')!;
+    assert.deepEqual(createIssue.input_schema, {
+      type: 'object',
+      required: ['team_id', 'title'],
+      properties: {
+        team_id: { type: 'string' },
+        title: { type: 'string' },
+      },
+    });
+    assert.deepEqual(createIssue.output_schema, {
+      type: 'object',
+      properties: { id: { type: 'string' } },
+    });
+    // Security-critical: a write tool must NEVER surface as side_effects:
+    // 'read' or autonomous:true — that's what let mutations skip the
+    // orchestrator's confirm-gate.
+    assert.equal(createIssue.side_effects, 'write');
+    assert.equal(createIssue.idempotent, false);
+    assert.equal(createIssue.autonomous, false);
+    assert.equal(createIssue.timeout_ms, 15000);
+
+    // Tool with no explicit flags falls back to the boilerplate template's
+    // defaults (the same values the `search` capability ships with).
+    const getForecast = byId.get('get_forecast')!;
+    assert.deepEqual(getForecast.input_schema, { type: 'object' });
+    assert.equal(getForecast.side_effects, 'read');
+    assert.equal(getForecast.idempotent, true);
+    assert.equal(getForecast.autonomous, true);
+    assert.equal(getForecast.timeout_ms, 20000);
+
+    // The three tools must not have converged on identical input_schema —
+    // this is the exact bug: every tool cloned {query} from the `search`
+    // template.
+    assert.notDeepEqual(listTeams.input_schema, createIssue.input_schema);
+    assert.notDeepEqual(listTeams.input_schema, getForecast.input_schema);
   });
 
   it('throws CodegenError when a required slot is missing', async () => {


### PR DESCRIPTION
## What

`reproduceManifestCapabilities` in the `agent-integration` codegen cloned the boilerplate's `search` capability entry (`input_schema:{query}`, `side_effects:'read'`, `idempotent:true`, `autonomous:true`, `timeout_ms:20000`) onto every tool, substituting only `{{CAPABILITY_ID}}`/`{{CAPABILITY_DESCRIPTION_DE}}`. Every tool in the generated `manifest.yaml` ended up with identical, static values regardless of its real spec — while `toolkit.ts` (the runtime tool bridge) was correct, since the LLM writes real per-tool Zod schemas there.

Concretely, for a multi-tool draft with mixed read/write tools:
- `input_schema` was `{query: string}` for every tool, including tools that take no args or different args.
- `side_effects`/`idempotent`/`autonomous` were pinned to the boilerplate's static values for every tool.
- Write tools (`side_effects: true` in the spec) were emitted into the manifest as `side_effects: 'read'` + `autonomous: true`, misrepresenting their real behavior to anything that reads the manifest (marketplace listing, human review, or an orchestrator-side consumer of these flags, if one exists downstream of this repo).

Root cause: `ToolSpecSchema` didn't declare `side_effects`/`idempotent`/`autonomous`/`timeout_ms`/`output`, so Zod's non-strict parsing silently dropped them from `spec.tools[i]` before codegen ever saw them.

## Changes

- `middleware/src/plugins/builder/agentSpec.ts`: `ToolSpecSchema` gains `output` (JSON-Schema, optional), `side_effects` (`'read'|'write'|'none'`, optional — the manifest's own enum, not a boolean), `idempotent` (boolean, optional), `autonomous` (boolean, optional), `timeout_ms` (positive int, optional).
- `middleware/src/plugins/builder/codegen.ts`: new `synthesizeCapabilityEntry` helper builds each `capabilities[]` entry from `spec.tools[i]` (mirroring the per-item synthesis pattern in `buildExternalReadsArtifacts`), falling back to the boilerplate template's static defaults only for fields a tool spec omits. Applies uniformly to the 1-tool and multi-tool paths — the old code special-cased and skipped synthesis entirely for the 1-tool case, which had the identical metadata-fidelity gap for any 1-tool write agent.
- `middleware/test/builder/codegen.test.ts`: strengthened `'reproduces manifest capabilities for multi-tool specs'` to assert per-tool `input_schema`/`output_schema`/`side_effects`/`idempotent`/`autonomous`/`timeout_ms` values across a read tool, a fully-specified write tool, and a tool that omits the optional flags (fallback-to-boilerplate-default case) — instead of only checking `id` equality, which is how the bug shipped undetected.
- `docs/CHANGELOG.md`: `[Unreleased]` entry per `AGENTS.md`'s mandatory-docs rule.

## Note on scope

I grepped this repo (`middleware/src`, `middleware/packages`) for a runtime consumer of `capabilities[].side_effects`/`.autonomous`/`.idempotent` and found none — `manifestLoader.ts` doesn't parse the tool-level `capabilities:` block into any runtime structure. So this PR is scoped to making the generated manifest's metadata honestly reflect the tool spec, which is correct on its own merits regardless of whether an enforcement gate reads it today. If an orchestrator-side confirm-gate that reads these fields exists elsewhere (e.g. a private plugin), a maintainer should confirm this closes that gap for it; I did not find or touch such a consumer in this repo.

## Verification

```
cd middleware
npm run build -w @omadia/plugin-api
node --import tsx --test --test-reporter=spec test/builder/codegen.test.ts test/builder/agentSpec.test.ts
```
91/91 tests pass (49 codegen + 42 agentSpec). `npx eslint` clean on all touched files. `tsc` build of `@omadia/plugin-api` succeeds with no errors.

Closes #507

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787723597&installation_model_id=428086&pr_number=523&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F523&signature=53184be28c90f7a35111ffa9b7f82742bd308114a11cd5801dcc229fc4e6b327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->