### PR TITLE
fix(orchestrator): embed image attachments as vision input

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,32 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   way. Latent today (no in-repo channel triggers it yet), but closes the gap
   before a future url-only channel (Slack, Discord, WhatsApp) ships broken
   vision silently (#505).
+- Review round 2: neither path checked whether the active provider/model
+  actually supports vision before building an image content-block, so a
+  turn routed through a non-vision provider could still get an image block
+  the API might reject or silently drop — reintroducing the same "agent
+  can't see the image, nothing indicates why" failure. Both call sites now
+  read `this.provider.capabilities.vision` and thread it through
+  `ingestAttachments`/`buildUserContent`: when unsupported, no image
+  content-block is built (avoids the provider rejecting the whole request),
+  and image candidates aren't even fetched — but the attachment is never
+  silently dropped either. A visible note (`[N image attachment(s) received
+  but the active model does not support image input]`) is folded into the
+  turn's text instead, so the model — and the user — knows an image existed
+  and why it wasn't seen. `claude-cli`-routed turns (`CliChatAgent`, swapped
+  in by `buildOrchestrator.ts` on `provider.id === 'claude-cli'`) take a
+  separate code path that never calls `buildUserContent`/`ingestAttachments`
+  at all; this change does not touch, fix, or regress that path.
+- Review round 4: a fetched image candidate that failed the
+  `checkVisionEmbeddable` guard (oversized >5MB, or an unsupported format
+  such as SVG/BMP/TIFF) under a VISION-CAPABLE provider was only logged via
+  `console.warn` and silently dropped otherwise — the same silent-drop
+  failure #504 exists to close, just triggered by size/format instead of
+  provider capability. `ingestAttachments` now also collects each
+  rejection's reason, and `buildUserContent` folds a visible
+  `[N image attachment(s) could not be shown: <reason(s)>]` note into the
+  turn's text alongside (never instead of) the existing non-vision-provider
+  note.
 
 ### Fixed — templates v2 review round 3: owner-aware publish vs. auth timing (#478)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,7 +26,7 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   images — so the fetched image was silently dropped and never reached the
   model, leaving the agent to falsely claim it couldn't see the image.
   `ingestAttachments` now routes image candidates through a new
-  `checkVisionEmbeddable` guard (supported type + 5MB size cap) and embeds them
+  `checkVisionEmbeddable` guard (supported type + size cap) and embeds them
   as Anthropic vision content-blocks via `buildUserContent`, the same path
   Telegram's inline `bytesBase64` attachments already use (#504).
 - Also implemented the `url`-fetch fallback that `chatAgent.ts` / `incoming.ts`
@@ -52,7 +52,7 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   separate code path that never calls `buildUserContent`/`ingestAttachments`
   at all; this change does not touch, fix, or regress that path.
 - Review round 4: a fetched image candidate that failed the
-  `checkVisionEmbeddable` guard (oversized >5MB, or an unsupported format
+  `checkVisionEmbeddable` guard (oversized, or an unsupported format
   such as SVG/BMP/TIFF) under a VISION-CAPABLE provider was only logged via
   `console.warn` and silently dropped otherwise — the same silent-drop
   failure #504 exists to close, just triggered by size/format instead of
@@ -80,6 +80,18 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   `this.visionSupported ?? this.provider.capabilities.vision` — an explicit
   per-model value wins; omitting it preserves the exact prior
   provider-level behavior for callers not yet updated to pass it.
+- Review round 7: `checkVisionEmbeddable` compared the fetched image's RAW
+  byte length against a 5MB cap, but that cap is Anthropic's documented
+  per-image *base64-encoded* payload limit — comparing raw bytes against a
+  base64-payload limit is the wrong unit, and rejected valid images (e.g. a
+  ~5.5MB raw screenshot, ~7.3MB once base64-encoded) that were well under the
+  real limit. The 5MB figure was also wrong for this deployment: the bundled
+  Anthropic provider (`builtinLlmProviders.ts`) uses
+  `https://api.anthropic.com` — the direct API, whose documented limit is
+  10MB base64-encoded (5MB base64 applies only to Bedrock/Vertex). The guard
+  now computes the base64-encoded size (`Math.ceil(rawBytes / 3) * 4`) and
+  compares it against a corrected `MAX_VISION_IMAGE_BASE64_BYTES = 10MB`
+  constant.
 
 ### Fixed — templates v2 review round 3: owner-aware publish vs. auth timing (#478)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -61,6 +61,25 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   `[N image attachment(s) could not be shown: <reason(s)>]` note into the
   turn's text alongside (never instead of) the existing non-vision-provider
   note.
+- Review round 6 (cross-vendor): the vision guard read
+  `this.provider.capabilities.vision` — a flag on the PROVIDER CONNECTION,
+  not the active MODEL. This is wrong whenever one connection serves
+  multiple models with different vision support, which is not hypothetical:
+  the bundled `mistral` openai-compatible connection serves
+  `mistral-large-latest` and `mistral-medium-latest` (vision) alongside
+  `mistral-small-latest` (no vision), yet `llm-adapter-openai`'s
+  `openaiProvider.ts` hardcodes `capabilities.vision = true` on the
+  connection regardless of the active model — so a turn on
+  `mistral-small-latest` would have passed the old check and still built an
+  image block for a model that can't use it. `OrchestratorOptions` gained a
+  new optional `visionSupported?: boolean` — the ACTIVE model's vision
+  capability, resolved by the caller the same way `maxTokens` is already
+  resolved per-model, since `harness-orchestrator` deliberately has no
+  dependency on `@omadia/llm-provider`/`@omadia/llm-provider-api` and does
+  not resolve the model registry itself. Both call sites now read
+  `this.visionSupported ?? this.provider.capabilities.vision` — an explicit
+  per-model value wins; omitting it preserves the exact prior
+  provider-level behavior for callers not yet updated to pass it.
 
 ### Fixed — templates v2 review round 3: owner-aware publish vs. auth timing (#478)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,24 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — Teams-uploaded images now reach the model as vision input (#504, #505)
+
+- Teams delivers inbound images via a Tigris `storage_key` + `[attachments-info]`
+  manifest, never inline `bytesBase64`. The attachment auto-ingest path fetched
+  those bytes but handed them to the text extractor, which correctly refuses
+  images — so the fetched image was silently dropped and never reached the
+  model, leaving the agent to falsely claim it couldn't see the image.
+  `ingestAttachments` now routes image candidates through a new
+  `checkVisionEmbeddable` guard (supported type + 5MB size cap) and embeds them
+  as Anthropic vision content-blocks via `buildUserContent`, the same path
+  Telegram's inline `bytesBase64` attachments already use (#504).
+- Also implemented the `url`-fetch fallback that `chatAgent.ts` / `incoming.ts`
+  document but the orchestrator never honored: an image attachment with a
+  `url` and no pre-fetched `bytesBase64` is now fetched and embedded the same
+  way. Latent today (no in-repo channel triggers it yet), but closes the gap
+  before a future url-only channel (Slack, Discord, WhatsApp) ships broken
+  vision silently (#505).
+
 ### Fixed — templates v2 review round 3: owner-aware publish vs. auth timing (#478)
 
 - The save-as-template dialog no longer reads the viewer's own template id as

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -70,16 +70,22 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   `mistral-small-latest` (no vision), yet `llm-adapter-openai`'s
   `openaiProvider.ts` hardcodes `capabilities.vision = true` on the
   connection regardless of the active model — so a turn on
-  `mistral-small-latest` would have passed the old check and still built an
-  image block for a model that can't use it. `OrchestratorOptions` gained a
-  new optional `visionSupported?: boolean` — the ACTIVE model's vision
-  capability, resolved by the caller the same way `maxTokens` is already
-  resolved per-model, since `harness-orchestrator` deliberately has no
-  dependency on `@omadia/llm-provider`/`@omadia/llm-provider-api` and does
-  not resolve the model registry itself. Both call sites now read
-  `this.visionSupported ?? this.provider.capabilities.vision` — an explicit
-  per-model value wins; omitting it preserves the exact prior
-  provider-level behavior for callers not yet updated to pass it.
+  `mistral-small-latest` would still build an image block for a model that
+  can't use it. `OrchestratorOptions` gained a new optional
+  `visionSupported?: boolean` — the ACTIVE model's vision capability, meant
+  to be resolved by the caller the same way `maxTokens` is already resolved
+  per-model, since `harness-orchestrator` deliberately has no dependency on
+  `@omadia/llm-provider`/`@omadia/llm-provider-api` and does not resolve the
+  model registry itself. Both call sites now read `this.visionSupported ??
+  this.provider.capabilities.vision` — an explicit per-model value would win
+  if one were passed; omitting it preserves the exact prior provider-level
+  behavior. **This is a mechanism, not an end-to-end fix**: as of this PR no
+  real caller (`buildOrchestrator.ts`, `plugin.ts`, or any bundled config)
+  sets `visionSupported` yet, so the concrete `mistral-small` scenario above
+  is made fixable, not actually resolved in production today — a future
+  change still needs to wire the active model's real vision capability
+  through to `OrchestratorOptions` for any given connection. Backward
+  compatible either way: no caller passing it is a no-op, not a regression.
 - Review round 7: `checkVisionEmbeddable` compared the fetched image's RAW
   byte length against a 5MB cap, but that cap is Anthropic's documented
   per-image *base64-encoded* payload limit — comparing raw bytes against a

--- a/middleware/packages/harness-orchestrator/src/attachmentExtract.ts
+++ b/middleware/packages/harness-orchestrator/src/attachmentExtract.ts
@@ -30,10 +30,21 @@ const SUPPORTED_VISION_IMAGE_TYPES = new Set([
   'image/webp',
 ]);
 
-/** Anthropic's documented per-image base64 payload cap. Oversized images are
- *  dropped before the API call rather than risking a 4xx that fails the
- *  whole turn. */
-const MAX_VISION_IMAGE_BYTES = 5 * 1024 * 1024;
+/** Anthropic's documented per-image cap for the *base64-encoded* payload
+ *  when calling the direct API (`https://api.anthropic.com`, which is what
+ *  `builtinLlmProviders.ts` uses): 10 MB base64-encoded. (Bedrock and Vertex
+ *  enforce a stricter 5 MB base64 cap — irrelevant today since this deployment
+ *  only talks to the direct API, but worth remembering if that ever changes.)
+ *  Oversized images are dropped before the API call rather than risking a
+ *  4xx that fails the whole turn. */
+const MAX_VISION_IMAGE_BASE64_BYTES = 10 * 1024 * 1024;
+
+/** Size of `rawBytes` once base64-encoded, without actually allocating the
+ *  base64 string: base64 emits 4 output chars per 3 input bytes, rounded up
+ *  to the next multiple of 4 (padding). */
+function base64EncodedLength(rawBytes: number): number {
+  return Math.ceil(rawBytes / 3) * 4;
+}
 
 export type VisionEmbedCheck =
   | { ok: true; mediaType: string }
@@ -109,10 +120,11 @@ export function checkVisionEmbeddable(
       reason: `unsupported image type for vision (contentType=${ct || 'unknown'})`,
     };
   }
-  if (byteLength > MAX_VISION_IMAGE_BYTES) {
+  const encodedLength = base64EncodedLength(byteLength);
+  if (encodedLength > MAX_VISION_IMAGE_BASE64_BYTES) {
     return {
       ok: false,
-      reason: `image too large for vision (${byteLength} bytes > ${MAX_VISION_IMAGE_BYTES} byte cap)`,
+      reason: `image too large for vision (${encodedLength} base64-encoded bytes > ${MAX_VISION_IMAGE_BASE64_BYTES} byte cap)`,
     };
   }
   return { ok: true, mediaType: ct };

--- a/middleware/packages/harness-orchestrator/src/attachmentExtract.ts
+++ b/middleware/packages/harness-orchestrator/src/attachmentExtract.ts
@@ -21,6 +21,24 @@ export type ExtractResult =
   | { ok: true; text: string }
   | { ok: false; reason: string };
 
+/** Anthropic's vision API only accepts these four raster formats via a
+ *  base64 image content-block. */
+const SUPPORTED_VISION_IMAGE_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+]);
+
+/** Anthropic's documented per-image base64 payload cap. Oversized images are
+ *  dropped before the API call rather than risking a 4xx that fails the
+ *  whole turn. */
+const MAX_VISION_IMAGE_BYTES = 5 * 1024 * 1024;
+
+export type VisionEmbedCheck =
+  | { ok: true; mediaType: string }
+  | { ok: false; reason: string };
+
 /** Lowercased file extension (without the dot), or '' when absent. */
 function extOf(fileName: string | undefined): string {
   if (!fileName) return '';
@@ -73,6 +91,32 @@ const PLAIN_TEXT_EXTS = new Set([
 const DOCX_TYPE =
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
 const PDF_TYPE = 'application/pdf';
+
+/**
+ * Guard for the attachment auto-ingest path's image branch (issues #504,
+ * #505): decides whether a fetched attachment (Tigris `storage_key` or
+ * `url`) can be embedded as an Anthropic vision content-block, as opposed to
+ * being silently dropped after fetch. Never throws.
+ */
+export function checkVisionEmbeddable(
+  contentType: string | undefined,
+  byteLength: number,
+): VisionEmbedCheck {
+  const ct = normalizeContentType(contentType);
+  if (!SUPPORTED_VISION_IMAGE_TYPES.has(ct)) {
+    return {
+      ok: false,
+      reason: `unsupported image type for vision (contentType=${ct || 'unknown'})`,
+    };
+  }
+  if (byteLength > MAX_VISION_IMAGE_BYTES) {
+    return {
+      ok: false,
+      reason: `image too large for vision (${byteLength} bytes > ${MAX_VISION_IMAGE_BYTES} byte cap)`,
+    };
+  }
+  return { ok: true, mediaType: ct };
+}
 
 /**
  * Extract plain text from an attachment's bytes. Never throws — any failure

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -75,7 +75,7 @@ import {
   readAttachmentToolSpec,
 } from './tools/readAttachmentTool.js';
 import { parseAttachmentsInfo } from './attachmentsInfo.js';
-import { extractAttachmentText } from './attachmentExtract.js';
+import { checkVisionEmbeddable, extractAttachmentText } from './attachmentExtract.js';
 import type {
   EntityRefBus,
   KnowledgeGraph,
@@ -478,20 +478,36 @@ type ContentBlock = any;
 type Message = any;
 
 /**
- * Build the user-message content for the Anthropic API. When the channel
- * supplied image attachments with `bytesBase64`, return a multimodal
- * content array (image source-blocks first, then text); otherwise just
- * pass the plain string for the simple text case (so existing callers
- * without attachments don't pay an array allocation).
+ * A base64-encoded image resolved by {@link ingestAttachments}'s async
+ * pre-fetch pass (issues #504, #505) — Teams `[attachments-info]`
+ * storage_key images and url-only image attachments from any channel that
+ * doesn't pre-fetch bytes. Same wire shape `buildUserContent` already
+ * builds for inline `bytesBase64` attachments below, just sourced from a
+ * fetch instead of the channel payload.
+ */
+interface IngestedImageBlock {
+  mediaType: string;
+  bytesBase64: string;
+}
+
+/**
+ * Build the user-message content for the Anthropic API. Returns a
+ * multimodal content array (image source-blocks first, then text) when
+ * there is at least one image to embed; otherwise just the plain string
+ * (so existing callers without attachments don't pay an array allocation).
  *
- * S+7.7+ — wired in for Telegram channel's photo/image-document path.
- * Teams calendar/diagram channels don't populate `attachments` today,
- * so this stays a no-op for them.
+ * Images come from two sources, both folded into the same block list:
+ *   - `input.attachments[]` entries with `bytesBase64` already set —
+ *     wired in for Telegram's photo/image-document path (S+7.7+).
+ *   - `ingestedImages`, resolved by `ingestAttachments`'s async pre-fetch —
+ *     Teams' Tigris `storage_key` images (#504) and url-only image
+ *     attachments from channels that don't pre-fetch bytes (#505).
  */
 function buildUserContent(
   input: ChatTurnInput,
   extraText?: string,
   wireUserMessage?: string,
+  ingestedImages?: IngestedImageBlock[],
 ): ContentBlock[] | string {
   // #361 — when prompt masking is on, the caller passes the pseudonym-
   // substituted variant for the LLM wire; `input.userMessage` stays the
@@ -505,7 +521,7 @@ function buildUserContent(
   const imageAtts = (input.attachments ?? []).filter(
     (a) => a.kind === 'image' && typeof a.bytesBase64 === 'string',
   );
-  if (imageAtts.length === 0) {
+  if (imageAtts.length === 0 && (ingestedImages?.length ?? 0) === 0) {
     if (!ingested) return message;
     return message.length > 0 ? `${message}${ingested}` : ingested;
   }
@@ -517,6 +533,16 @@ function buildUserContent(
         type: 'base64',
         media_type: att.mediaType,
         data: att.bytesBase64,
+      },
+    });
+  }
+  for (const img of ingestedImages ?? []) {
+    blocks.push({
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: img.mediaType,
+        data: img.bytesBase64,
       },
     });
   }
@@ -2708,11 +2734,17 @@ export class Orchestrator {
       rawPriorContext,
     );
     // #268 — pre-fetch + extract any uploaded document text for this turn.
+    // #504/#505 — the same pass also resolves image attachments (Teams
+    // Tigris storage_key, or a bare url for channels without a pre-fetch)
+    // into vision content-blocks; `ingestedImages` rides separately from the
+    // text since it never crosses the PII-masking wire.
     // #361 — the ingested verbatim tail crosses the wire alongside the
     // message, so it is masked through the SAME turn map (stable surrogates).
+    const { text: ingestedRawText, images: ingestedImages } =
+      await this.ingestAttachments(input);
     const ingestedText = await maskIngestedForWire(
       privacyForPrompt,
-      await this.ingestAttachments(input),
+      ingestedRawText,
     );
     const effectiveExtraSystemHint = composeExtraSystemHint(input);
     // Palaia Phase 8 (OB-77) — per-turn nudge counter (shared across all
@@ -2743,7 +2775,15 @@ export class Orchestrator {
       // same shape the Anthropic API expects for a multi-turn conversation.
       // Empty pairs are filtered so a failed prior turn can't poison context.
       ...priorTurnMessages,
-      { role: 'user', content: buildUserContent(input, ingestedText, wireUserMessage) },
+      {
+        role: 'user',
+        content: buildUserContent(
+          input,
+          ingestedText,
+          wireUserMessage,
+          ingestedImages,
+        ),
+      },
     ];
 
     // Open an EntityRef collection keyed to this turn. Tool handlers that
@@ -3488,10 +3528,14 @@ export class Orchestrator {
     // can never break or delay the turn; additive/opaque to the model.
     yield* await this.toKgGraphAnnotationEvents(recalled);
     // #268 — pre-fetch + extract any uploaded document text for this turn.
+    // #504/#505 — same pass also resolves image attachments into vision
+    // content-blocks; see chatInContextInner for the full rationale.
     // #361 — masked through the same turn map as the message (see above).
+    const { text: ingestedRawText, images: ingestedImages } =
+      await this.ingestAttachments(input);
     const ingestedText = await maskIngestedForWire(
       privacyForPrompt,
-      await this.ingestAttachments(input),
+      ingestedRawText,
     );
     const effectiveExtraSystemHint = composeExtraSystemHint(input);
     // Palaia Phase 8 (OB-77) — see chatInContextInner for rationale.
@@ -3513,7 +3557,15 @@ export class Orchestrator {
     const messages: Array<{ role: 'user' | 'assistant'; content: ContentBlock[] | string }> = [
       // Same in-memory history injection as chat() — see chatInContext().
       ...priorTurnMessages,
-      { role: 'user', content: buildUserContent(input, ingestedText, wireUserMessage) },
+      {
+        role: 'user',
+        content: buildUserContent(
+          input,
+          ingestedText,
+          wireUserMessage,
+          ingestedImages,
+        ),
+      },
     ];
 
     const entityCollection = this.entityRefBus?.beginCollection(turnId);
@@ -4723,24 +4775,37 @@ export class Orchestrator {
 
   /**
    * #268 sub-problem 2 — server-side attachment auto-ingest.
+   * #504/#505 — extended to also resolve image attachments into vision
+   * content-blocks instead of silently dropping them after fetch.
    *
-   * Pre-fetches and text-extracts the user's current-turn document uploads so
-   * the model can read them WITHOUT a tool call. Candidates come from BOTH
-   * sources:
+   * Pre-fetches the user's current-turn uploads so the model can read/see
+   * them WITHOUT a tool call. Candidates come from THREE sources:
    *   - the `[attachments-info]` block Teams appends to `input.userMessage`
-   *     (preferred: read by storage_key, since signed URLs expire);
+   *     (preferred: read by storage_key, since signed URLs expire) — files
+   *     AND images alike;
    *   - `input.attachments[]` non-image file entries from other channels
-   *     (read by url).
-   * De-duplicated by storageKey/url. Images and unsupported types are skipped
-   * silently (brand:// / vision handles images). Ingested regardless of
-   * `freshCheck` — these are the user's current message, not recalled context.
+   *     (read by url);
+   *   - `input.attachments[]` image entries that lack `bytesBase64` (read by
+   *     url) — the documented fallback for channels that don't pre-fetch
+   *     (`chatAgent.ts` / `incoming.ts`); images WITH `bytesBase64` are
+   *     already handled inline by `buildUserContent` and are skipped here.
+   * De-duplicated by storageKey/url. Text is extracted for non-image
+   * candidates; images are guarded by {@link checkVisionEmbeddable}
+   * (supported type + size cap) and turned into base64 image blocks —
+   * neither path throws, both just skip the candidate on failure. Ingested
+   * regardless of `freshCheck` — these are the user's current message, not
+   * recalled context.
    *
-   * Returns a concatenation of `[attachment-content: …]` blocks (leading
-   * with `\n\n`), or '' when there is nothing to ingest or no reader is
-   * configured. NEVER throws — any failure logs a warning and returns ''.
+   * Returns `text` (a concatenation of `[attachment-content: …]` blocks,
+   * leading with `\n\n`, or '' when there is no document text) and `images`
+   * (base64 blocks for `buildUserContent` to embed, or `[]`). NEVER throws —
+   * any failure logs a warning and returns the empty shape.
    */
-  private async ingestAttachments(input: ChatTurnInput): Promise<string> {
-    if (!this.attachmentReader) return '';
+  private async ingestAttachments(
+    input: ChatTurnInput,
+  ): Promise<{ text: string; images: IngestedImageBlock[] }> {
+    const empty = { text: '', images: [] as IngestedImageBlock[] };
+    if (!this.attachmentReader) return empty;
     try {
       type Candidate = {
         fileName: string | undefined;
@@ -4748,6 +4813,11 @@ export class Orchestrator {
         storageKey?: string;
         url?: string;
         dedupe: string;
+        /** #504/#505 — route to the vision branch below instead of
+         *  `extractAttachmentText`. Set from the manifest/attachment kind at
+         *  candidate time; re-checked against the fetched content-type since
+         *  a signed URL or Tigris object can disagree with the caller's claim. */
+        isImage: boolean;
       };
       const candidates: Candidate[] = [];
       const seen = new Set<string>();
@@ -4757,7 +4827,8 @@ export class Orchestrator {
         candidates.push(c);
       };
 
-      // 1. Teams `[attachments-info]` manifest (storage_key-bearing).
+      // 1. Teams `[attachments-info]` manifest (storage_key-bearing) — files
+      //    and images alike (#504).
       for (const info of parseAttachmentsInfo(input.userMessage)) {
         push({
           fileName: info.fileName,
@@ -4765,6 +4836,7 @@ export class Orchestrator {
           storageKey: info.storageKey,
           ...(info.signedUrl ? { url: info.signedUrl } : {}),
           dedupe: `key:${info.storageKey}`,
+          isImage: info.contentType.toLowerCase().startsWith('image/'),
         });
       }
       // 2. Non-image file attachments from other channels (url-bearing).
@@ -4776,11 +4848,29 @@ export class Orchestrator {
           contentType: att.mediaType,
           url: att.url,
           dedupe: `url:${att.url}`,
+          isImage: false,
         });
       }
-      if (candidates.length === 0) return '';
+      // 3. Image attachments without pre-fetched bytes (url-bearing) — the
+      //    documented url-fetch fallback for channels that don't pre-fetch
+      //    (#505). Images WITH `bytesBase64` are already handled inline by
+      //    `buildUserContent`, so they're excluded here to avoid double-embedding.
+      for (const att of input.attachments ?? []) {
+        if (att.kind !== 'image') continue;
+        if (typeof att.bytesBase64 === 'string') continue;
+        if (typeof att.url !== 'string' || att.url.length === 0) continue;
+        push({
+          fileName: att.name,
+          contentType: att.mediaType,
+          url: att.url,
+          dedupe: `url:${att.url}`,
+          isImage: true,
+        });
+      }
+      if (candidates.length === 0) return empty;
 
-      const blocks: string[] = [];
+      const textBlocks: string[] = [];
+      const images: IngestedImageBlock[] = [];
       for (const c of candidates) {
         try {
           // Prefer storage_key (durable) over url (Teams signed urls expire).
@@ -4790,18 +4880,36 @@ export class Orchestrator {
               ? await this.attachmentReader.readByUrl(c.url)
               : undefined;
           if (!fetched) continue;
+          const contentType = fetched.contentType ?? c.contentType;
+          if (c.isImage) {
+            const guard = checkVisionEmbeddable(
+              contentType,
+              fetched.bytes.length,
+            );
+            if (!guard.ok) {
+              console.warn(
+                `[harness-orchestrator] ingestAttachments: skipped image — ${guard.reason}`,
+              );
+              continue;
+            }
+            images.push({
+              mediaType: guard.mediaType,
+              bytesBase64: fetched.bytes.toString('base64'),
+            });
+            continue;
+          }
           const fetchedFileName =
             'fileName' in fetched
               ? (fetched as { fileName?: string }).fileName
               : undefined;
           const result = await extractAttachmentText(
             fetched.bytes,
-            fetched.contentType ?? c.contentType,
+            contentType,
             fetchedFileName ?? c.fileName,
           );
           if (!result.ok) continue;
           const label = c.fileName ?? c.storageKey ?? c.url ?? 'attachment';
-          blocks.push(
+          textBlocks.push(
             `\n\n[attachment-content: ${label}]\n${result.text}\n[/attachment-content]`,
           );
         } catch (err) {
@@ -4812,14 +4920,14 @@ export class Orchestrator {
           );
         }
       }
-      return blocks.join('');
+      return { text: textBlocks.join(''), images };
     } catch (err) {
       console.warn(
         `[harness-orchestrator] ingestAttachments failed (non-fatal) — ${
           err instanceof Error ? err.message : String(err)
         }`,
       );
-      return '';
+      return empty;
     }
   }
 

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -502,12 +502,39 @@ interface IngestedImageBlock {
  *   - `ingestedImages`, resolved by `ingestAttachments`'s async pre-fetch —
  *     Teams' Tigris `storage_key` images (#504) and url-only image
  *     attachments from channels that don't pre-fetch bytes (#505).
+ *
+ * `visionSupported` gates BOTH sources at once (#504/#505 review round 2):
+ * a provider/model without vision capability can reject the whole request
+ * or silently drop an unsupported content block, reintroducing the "agent
+ * cannot see the image, nothing indicates why" failure these issues exist
+ * to close. When `false`, no image content-blocks are built at all — but
+ * the fact that image(s) were received is never silently dropped either:
+ * a visible `[N image attachment(s) received but the active model does not
+ * support image input]` note is folded into the text instead, combining
+ * the caller-supplied `skippedVisionImageCount` (images `ingestAttachments`
+ * didn't even bother fetching, see there) with the inline `bytesBase64`
+ * attachments this function would otherwise have embedded itself.
+ *
+ * Separately, `rejectedImageReasons` (#504/#505 review round 4) covers image
+ * candidates that WERE fetched by `ingestAttachments` under a vision-capable
+ * provider but failed {@link checkVisionEmbeddable} (oversized, or an
+ * unsupported format such as SVG/BMP/TIFF). That guard rejection used to be
+ * a server-only `console.warn` with no trace in the turn's text — the exact
+ * silent-drop failure #504 exists to close, just triggered by size/format
+ * instead of provider capability. A visible `[N image attachment(s) could
+ * not be shown: <reason(s)>]` note now covers it. The two notes cannot
+ * describe the same image (a guard rejection only happens when vision IS
+ * supported, since `ingestAttachments` skips fetching entirely otherwise),
+ * so they are simply concatenated when both are non-empty.
  */
 function buildUserContent(
   input: ChatTurnInput,
   extraText?: string,
   wireUserMessage?: string,
   ingestedImages?: IngestedImageBlock[],
+  visionSupported = true,
+  skippedVisionImageCount = 0,
+  rejectedImageReasons: string[] = [],
 ): ContentBlock[] | string {
   // #361 — when prompt masking is on, the caller passes the pseudonym-
   // substituted variant for the LLM wire; `input.userMessage` stays the
@@ -518,12 +545,35 @@ function buildUserContent(
   // additive to the existing image/bytesBase64 multimodal path.
   const ingested =
     extraText && extraText.trim().length > 0 ? extraText : undefined;
-  const imageAtts = (input.attachments ?? []).filter(
+  const rawImageAtts = (input.attachments ?? []).filter(
     (a) => a.kind === 'image' && typeof a.bytesBase64 === 'string',
   );
-  if (imageAtts.length === 0 && (ingestedImages?.length ?? 0) === 0) {
-    if (!ingested) return message;
-    return message.length > 0 ? `${message}${ingested}` : ingested;
+
+  // #504/#505 vision-capability guard — see doc comment above. Zero out
+  // both image sources up front so nothing below ever builds an image
+  // content-block for a non-vision provider.
+  const imageAtts = visionSupported ? rawImageAtts : [];
+  const effectiveIngestedImages = visionSupported ? ingestedImages : undefined;
+  const visionNoteCount = visionSupported
+    ? 0
+    : rawImageAtts.length + skippedVisionImageCount;
+  const visionNote =
+    visionNoteCount > 0
+      ? `\n\n[${visionNoteCount} image attachment${visionNoteCount === 1 ? '' : 's'} received but the active model does not support image input]`
+      : '';
+  // #504/#505 review round 4 — a fetched image candidate that failed
+  // checkVisionEmbeddable (oversized / unsupported format) must still leave
+  // a visible trace, not just a server-side console.warn.
+  const guardRejectedCount = rejectedImageReasons.length;
+  const guardNote =
+    guardRejectedCount > 0
+      ? `\n\n[${guardRejectedCount} image attachment${guardRejectedCount === 1 ? '' : 's'} could not be shown: ${rejectedImageReasons.join('; ')}]`
+      : '';
+
+  if (imageAtts.length === 0 && (effectiveIngestedImages?.length ?? 0) === 0) {
+    const trailing = `${ingested ?? ''}${visionNote}${guardNote}`;
+    if (trailing.length === 0) return message;
+    return message.length > 0 ? `${message}${trailing}` : trailing;
   }
   const blocks: ContentBlock[] = [];
   for (const att of imageAtts) {
@@ -536,7 +586,7 @@ function buildUserContent(
       },
     });
   }
-  for (const img of ingestedImages ?? []) {
+  for (const img of effectiveIngestedImages ?? []) {
     blocks.push({
       type: 'image',
       source: {
@@ -546,7 +596,7 @@ function buildUserContent(
       },
     });
   }
-  const trailingText = `${message}${ingested ?? ''}`;
+  const trailingText = `${message}${ingested ?? ''}${visionNote}${guardNote}`;
   if (trailingText.trim().length > 0) {
     blocks.push({ type: 'text', text: trailingText });
   }
@@ -2737,11 +2787,19 @@ export class Orchestrator {
     // #504/#505 — the same pass also resolves image attachments (Teams
     // Tigris storage_key, or a bare url for channels without a pre-fetch)
     // into vision content-blocks; `ingestedImages` rides separately from the
-    // text since it never crosses the PII-masking wire.
+    // text since it never crosses the PII-masking wire. Gated on the active
+    // provider's vision capability (review round 2) — a non-vision model
+    // never gets an image content-block, and `buildUserContent` below
+    // surfaces a visible note instead of silently dropping the attachment.
     // #361 — the ingested verbatim tail crosses the wire alongside the
     // message, so it is masked through the SAME turn map (stable surrogates).
-    const { text: ingestedRawText, images: ingestedImages } =
-      await this.ingestAttachments(input);
+    const visionSupported = this.provider.capabilities.vision;
+    const {
+      text: ingestedRawText,
+      images: ingestedImages,
+      skippedVisionImageCount,
+      rejectedImageReasons,
+    } = await this.ingestAttachments(input, visionSupported);
     const ingestedText = await maskIngestedForWire(
       privacyForPrompt,
       ingestedRawText,
@@ -2782,6 +2840,9 @@ export class Orchestrator {
           ingestedText,
           wireUserMessage,
           ingestedImages,
+          visionSupported,
+          skippedVisionImageCount,
+          rejectedImageReasons,
         ),
       },
     ];
@@ -3529,10 +3590,16 @@ export class Orchestrator {
     yield* await this.toKgGraphAnnotationEvents(recalled);
     // #268 — pre-fetch + extract any uploaded document text for this turn.
     // #504/#505 — same pass also resolves image attachments into vision
-    // content-blocks; see chatInContextInner for the full rationale.
+    // content-blocks; see chatInContextInner for the full rationale,
+    // including the vision-capability gate (review round 2).
     // #361 — masked through the same turn map as the message (see above).
-    const { text: ingestedRawText, images: ingestedImages } =
-      await this.ingestAttachments(input);
+    const visionSupported = this.provider.capabilities.vision;
+    const {
+      text: ingestedRawText,
+      images: ingestedImages,
+      skippedVisionImageCount,
+      rejectedImageReasons,
+    } = await this.ingestAttachments(input, visionSupported);
     const ingestedText = await maskIngestedForWire(
       privacyForPrompt,
       ingestedRawText,
@@ -3564,6 +3631,9 @@ export class Orchestrator {
           ingestedText,
           wireUserMessage,
           ingestedImages,
+          visionSupported,
+          skippedVisionImageCount,
+          rejectedImageReasons,
         ),
       },
     ];
@@ -4796,15 +4866,45 @@ export class Orchestrator {
    * regardless of `freshCheck` — these are the user's current message, not
    * recalled context.
    *
+   * `visionSupported` (#504/#505 review round 2 — `this.provider.capabilities
+   * .vision` at both call sites): when `false`, image candidates are never
+   * fetched at all (fetching bytes the provider can't accept would just
+   * waste the round-trip) — they're counted into `skippedVisionImageCount`
+   * instead so `buildUserContent` can still surface a visible note that
+   * image(s) existed, rather than silently acting as if none did.
+   *
+   * `rejectedImageReasons` (#504/#505 review round 4): a candidate IS
+   * fetched (vision is supported) but fails {@link checkVisionEmbeddable}
+   * — oversized (>5MB) or an unsupported format (SVG/BMP/TIFF/…). That used
+   * to be a server-only `console.warn` with no trace in the turn's text,
+   * reproducing the exact silent-drop failure #504 exists to close via a
+   * different trigger (size/format instead of provider capability). Each
+   * rejection's `guard.reason` is collected here so `buildUserContent` can
+   * surface a visible note instead.
+   *
    * Returns `text` (a concatenation of `[attachment-content: …]` blocks,
-   * leading with `\n\n`, or '' when there is no document text) and `images`
-   * (base64 blocks for `buildUserContent` to embed, or `[]`). NEVER throws —
-   * any failure logs a warning and returns the empty shape.
+   * leading with `\n\n`, or '' when there is no document text), `images`
+   * (base64 blocks for `buildUserContent` to embed, or `[]`),
+   * `skippedVisionImageCount` (image candidates found but not fetched
+   * because vision is unsupported), and `rejectedImageReasons` (reasons for
+   * fetched image candidates the vision-embeddability guard rejected).
+   * NEVER throws — any failure logs a warning and returns the empty shape.
    */
   private async ingestAttachments(
     input: ChatTurnInput,
-  ): Promise<{ text: string; images: IngestedImageBlock[] }> {
-    const empty = { text: '', images: [] as IngestedImageBlock[] };
+    visionSupported: boolean,
+  ): Promise<{
+    text: string;
+    images: IngestedImageBlock[];
+    skippedVisionImageCount: number;
+    rejectedImageReasons: string[];
+  }> {
+    const empty = {
+      text: '',
+      images: [] as IngestedImageBlock[],
+      skippedVisionImageCount: 0,
+      rejectedImageReasons: [] as string[],
+    };
     if (!this.attachmentReader) return empty;
     try {
       type Candidate = {
@@ -4827,16 +4927,41 @@ export class Orchestrator {
         candidates.push(c);
       };
 
+      // De-dup guard for source 1 below: filenames already embedded inline
+      // by `buildUserContent` from `input.attachments[]` entries that carry
+      // `bytesBase64`. Today Teams (the manifest's only producer) never
+      // populates `attachments[].bytesBase64` and the channels that DO
+      // (Telegram) never emit an `[attachments-info]` manifest, so this set
+      // is empty in practice — but it's the one place this invariant is
+      // actually checked, not just documented, so a future channel that
+      // violates it can't silently double-send an image to the model.
+      const inlineImageFileNames = new Set(
+        (input.attachments ?? [])
+          .filter(
+            (a): a is typeof a & { name: string } =>
+              a.kind === 'image' &&
+              typeof a.bytesBase64 === 'string' &&
+              typeof a.name === 'string',
+          )
+          .map((a) => a.name.trim().toLowerCase()),
+      );
+
       // 1. Teams `[attachments-info]` manifest (storage_key-bearing) — files
       //    and images alike (#504).
       for (const info of parseAttachmentsInfo(input.userMessage)) {
+        const isImage = info.contentType.toLowerCase().startsWith('image/');
+        if (isImage && inlineImageFileNames.has(info.fileName.trim().toLowerCase())) {
+          // Already embedded inline via `bytesBase64` — skip to avoid
+          // sending the same image to the model twice in one turn.
+          continue;
+        }
         push({
           fileName: info.fileName,
           contentType: info.contentType,
           storageKey: info.storageKey,
           ...(info.signedUrl ? { url: info.signedUrl } : {}),
           dedupe: `key:${info.storageKey}`,
-          isImage: info.contentType.toLowerCase().startsWith('image/'),
+          isImage,
         });
       }
       // 2. Non-image file attachments from other channels (url-bearing).
@@ -4871,8 +4996,19 @@ export class Orchestrator {
 
       const textBlocks: string[] = [];
       const images: IngestedImageBlock[] = [];
+      const rejectedImageReasons: string[] = [];
+      let skippedVisionImageCount = 0;
       for (const c of candidates) {
         try {
+          // #504/#505 review round 2 — don't even fetch an image candidate
+          // when the active provider/model has no vision capability; the
+          // bytes would just be discarded. Count it instead so
+          // `buildUserContent` can surface a visible note rather than
+          // silently acting as if the image never existed.
+          if (c.isImage && !visionSupported) {
+            skippedVisionImageCount += 1;
+            continue;
+          }
           // Prefer storage_key (durable) over url (Teams signed urls expire).
           const fetched = c.storageKey
             ? await this.attachmentReader.readByStorageKey(c.storageKey)
@@ -4890,6 +5026,9 @@ export class Orchestrator {
               console.warn(
                 `[harness-orchestrator] ingestAttachments: skipped image — ${guard.reason}`,
               );
+              // #504/#505 review round 4 — a guard rejection must leave a
+              // visible trace in the turn's text, not just this server log.
+              rejectedImageReasons.push(guard.reason);
               continue;
             }
             images.push({
@@ -4920,7 +5059,12 @@ export class Orchestrator {
           );
         }
       }
-      return { text: textBlocks.join(''), images };
+      return {
+        text: textBlocks.join(''),
+        images,
+        skippedVisionImageCount,
+        rejectedImageReasons,
+      };
     } catch (err) {
       console.warn(
         `[harness-orchestrator] ingestAttachments failed (non-fatal) — ${

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -193,6 +193,30 @@ export interface OrchestratorOptions {
    */
   modelRouting?: ModelRoutingConfig;
   maxTokens: number;
+  /**
+   * #504/#505 (round-6 codex review) — the ACTIVE model's vision capability
+   * (the registry's per-model `ModelInfo.vision`, e.g. from
+   * `@omadia/llm-provider-api`), resolved by the caller the same way it
+   * already resolves `maxTokens` for the model. harness-orchestrator has no
+   * dependency on `@omadia/llm-provider` / `@omadia/llm-provider-api` (by
+   * design — it never imports the model registry itself, exactly like
+   * `maxTokens` above arrives pre-resolved instead of being looked up
+   * internally), so this cannot be derived in here; the caller must pass it.
+   *
+   * Deliberately NOT `this.provider.capabilities.vision` (a property of the
+   * PROVIDER CONNECTION, not the model): one provider connection can serve
+   * several models with different vision support — e.g. the bundled
+   * `mistral` openai-compatible connection serves `mistral-large-latest`
+   * and `mistral-medium-latest` (vision) alongside `mistral-small-latest`
+   * (no vision), yet the openai adapter hardcodes
+   * `capabilities.vision = true` on the connection regardless of which
+   * model is actually selected for the turn.
+   *
+   * Omitted → falls back to `this.provider.capabilities.vision` (today's
+   * behaviour), for backward compatibility with callers that haven't been
+   * updated to pass the more precise per-model value yet.
+   */
+  visionSupported?: boolean;
   maxToolIterations: number;
   /**
    * Round-loop guard thresholds (see {@link LoopGuard}). When the model
@@ -1225,6 +1249,10 @@ export class Orchestrator {
   /** Wave 8 — direct-answer persona candidates; empty when none attached. */
   private readonly personaSkills: readonly OrchestratorPersonaSkill[];
   private readonly maxTokens: number;
+  /** #504/#505 — active model's vision support, if the caller resolved it
+   *  (see OrchestratorOptions.visionSupported). Undefined → callers fall
+   *  back to `this.provider.capabilities.vision` at each read site. */
+  private readonly visionSupported: boolean | undefined;
   private readonly maxIterations: number;
   /** Round-loop guard thresholds (see {@link LoopGuard}). */
   private readonly loopRepeatSoft: number | undefined;
@@ -1303,6 +1331,7 @@ export class Orchestrator {
     this.modelRouting = options.modelRouting;
     this.personaSkills = options.personaSkills ?? [];
     this.maxTokens = options.maxTokens;
+    this.visionSupported = options.visionSupported;
     this.maxIterations = options.maxToolIterations;
     this.loopRepeatSoft = options.loopRepeatSoft;
     this.loopRepeatHard = options.loopRepeatHard;
@@ -2787,13 +2816,18 @@ export class Orchestrator {
     // #504/#505 — the same pass also resolves image attachments (Teams
     // Tigris storage_key, or a bare url for channels without a pre-fetch)
     // into vision content-blocks; `ingestedImages` rides separately from the
-    // text since it never crosses the PII-masking wire. Gated on the active
-    // provider's vision capability (review round 2) — a non-vision model
-    // never gets an image content-block, and `buildUserContent` below
-    // surfaces a visible note instead of silently dropping the attachment.
+    // text since it never crosses the PII-masking wire. Gated on the ACTIVE
+    // MODEL's vision capability (round-6 codex review) — `visionSupported`
+    // wins when the caller resolved it (see OrchestratorOptions), otherwise
+    // this falls back to the provider connection's own capability flag,
+    // which is imprecise whenever one connection serves several models with
+    // different vision support. Either way, a non-vision model never gets
+    // an image content-block, and `buildUserContent` below surfaces a
+    // visible note instead of silently dropping the attachment.
     // #361 — the ingested verbatim tail crosses the wire alongside the
     // message, so it is masked through the SAME turn map (stable surrogates).
-    const visionSupported = this.provider.capabilities.vision;
+    const visionSupported =
+      this.visionSupported ?? this.provider.capabilities.vision;
     const {
       text: ingestedRawText,
       images: ingestedImages,
@@ -3591,9 +3625,10 @@ export class Orchestrator {
     // #268 — pre-fetch + extract any uploaded document text for this turn.
     // #504/#505 — same pass also resolves image attachments into vision
     // content-blocks; see chatInContextInner for the full rationale,
-    // including the vision-capability gate (review round 2).
+    // including the per-model vision-capability gate (round-6 codex review).
     // #361 — masked through the same turn map as the message (see above).
-    const visionSupported = this.provider.capabilities.vision;
+    const visionSupported =
+      this.visionSupported ?? this.provider.capabilities.vision;
     const {
       text: ingestedRawText,
       images: ingestedImages,

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -4910,7 +4910,8 @@ export class Orchestrator {
    *
    * `rejectedImageReasons` (#504/#505 review round 4): a candidate IS
    * fetched (vision is supported) but fails {@link checkVisionEmbeddable}
-   * — oversized (>5MB) or an unsupported format (SVG/BMP/TIFF/…). That used
+   * — oversized (>10MB base64-encoded) or an unsupported format
+   * (SVG/BMP/TIFF/…). That used
    * to be a server-only `console.warn` with no trace in the turn's text,
    * reproducing the exact silent-drop failure #504 exists to close via a
    * different trigger (size/format instead of provider capability). Each

--- a/middleware/test/attachmentExtract.test.ts
+++ b/middleware/test/attachmentExtract.test.ts
@@ -1,7 +1,10 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { extractAttachmentText } from '../packages/harness-orchestrator/src/attachmentExtract.js';
+import {
+  checkVisionEmbeddable,
+  extractAttachmentText,
+} from '../packages/harness-orchestrator/src/attachmentExtract.js';
 
 describe('extractAttachmentText', () => {
   it('passes through markdown via contentType', async () => {
@@ -128,5 +131,50 @@ describe('extractAttachmentText', () => {
     );
     assert.equal(r.ok, false);
     assert.ok(!r.ok && r.reason.length > 0);
+  });
+});
+
+// #504/#505 — the vision-embed guard used by `Orchestrator.ingestAttachments`
+// to decide whether a fetched image can become a base64 vision content-block.
+describe('checkVisionEmbeddable', () => {
+  const ONE_KB = 1024;
+
+  for (const mediaType of ['image/jpeg', 'image/png', 'image/gif', 'image/webp']) {
+    it(`accepts ${mediaType} under the size cap`, () => {
+      const r = checkVisionEmbeddable(mediaType, ONE_KB);
+      assert.equal(r.ok, true);
+      assert.ok(r.ok && r.mediaType === mediaType);
+    });
+  }
+
+  it('normalizes contentType params (charset/case) before matching', () => {
+    const r = checkVisionEmbeddable('IMAGE/PNG; charset=binary', ONE_KB);
+    assert.equal(r.ok, true);
+    assert.ok(r.ok && r.mediaType === 'image/png');
+  });
+
+  it('rejects an unsupported image type (e.g. svg — not vision-safe)', () => {
+    const r = checkVisionEmbeddable('image/svg+xml', ONE_KB);
+    assert.equal(r.ok, false);
+    assert.ok(!r.ok && /unsupported/i.test(r.reason));
+  });
+
+  it('rejects a non-image contentType', () => {
+    const r = checkVisionEmbeddable('application/pdf', ONE_KB);
+    assert.equal(r.ok, false);
+    assert.ok(!r.ok && /unsupported/i.test(r.reason));
+  });
+
+  it('rejects an oversized image (>5MB) of an otherwise-supported type', () => {
+    const FIVE_MB = 5 * 1024 * 1024;
+    const r = checkVisionEmbeddable('image/png', FIVE_MB + 1);
+    assert.equal(r.ok, false);
+    assert.ok(!r.ok && /too large/i.test(r.reason));
+  });
+
+  it('accepts an image exactly at the size cap', () => {
+    const FIVE_MB = 5 * 1024 * 1024;
+    const r = checkVisionEmbeddable('image/png', FIVE_MB);
+    assert.equal(r.ok, true);
   });
 });

--- a/middleware/test/attachmentExtract.test.ts
+++ b/middleware/test/attachmentExtract.test.ts
@@ -165,16 +165,31 @@ describe('checkVisionEmbeddable', () => {
     assert.ok(!r.ok && /unsupported/i.test(r.reason));
   });
 
-  it('rejects an oversized image (>5MB) of an otherwise-supported type', () => {
-    const FIVE_MB = 5 * 1024 * 1024;
-    const r = checkVisionEmbeddable('image/png', FIVE_MB + 1);
+  // The cap applies to the *base64-encoded* size (Anthropic's documented
+  // direct-API limit: 10 MB base64), not raw bytes. base64 encoding inflates
+  // size by ceil(rawBytes / 3) * 4, so the raw-byte boundary sits at
+  // 7,864,320 bytes (7.5 MB) — exactly 10 MB once encoded.
+  const RAW_BYTES_AT_BASE64_CAP = 7_864_320; // encodes to exactly 10 MB base64
+  const TEN_MB = 10 * 1024 * 1024;
+
+  it('rejects an image whose base64-encoded size exceeds the 10MB direct-API cap', () => {
+    const r = checkVisionEmbeddable('image/png', RAW_BYTES_AT_BASE64_CAP + 1);
     assert.equal(r.ok, false);
     assert.ok(!r.ok && /too large/i.test(r.reason));
+    assert.ok(!r.ok && r.reason.includes(String(TEN_MB)));
   });
 
-  it('accepts an image exactly at the size cap', () => {
-    const FIVE_MB = 5 * 1024 * 1024;
-    const r = checkVisionEmbeddable('image/png', FIVE_MB);
+  it('accepts an image whose base64-encoded size is exactly at the 10MB cap', () => {
+    const r = checkVisionEmbeddable('image/png', RAW_BYTES_AT_BASE64_CAP);
+    assert.equal(r.ok, true);
+  });
+
+  it('accepts a ~5.5MB raw image (base64 ~7.3MB) that the old 5MB-raw-byte check wrongly rejected', () => {
+    // Regression for the round-7 finding: the old guard compared RAW bytes
+    // against a base64-payload cap, so a perfectly valid ~5.5MB screenshot
+    // (well under the real 10MB base64 limit) was wrongly rejected.
+    const FIVE_POINT_FIVE_MB = 5.5 * 1024 * 1024;
+    const r = checkVisionEmbeddable('image/png', FIVE_POINT_FIVE_MB);
     assert.equal(r.ok, true);
   });
 });

--- a/middleware/test/orchestratorVisionAttachmentIngest.test.ts
+++ b/middleware/test/orchestratorVisionAttachmentIngest.test.ts
@@ -1,0 +1,500 @@
+/**
+ * #504/#505 — orchestrator-level coverage for the attachment auto-ingest
+ * path's image handling: Teams `[attachments-info]` manifest images (#504)
+ * and the `input.attachments[]` url-fallback for images without
+ * `bytesBase64` (#505) must both end up as vision content-blocks on the
+ * outgoing LLM request — not silently dropped, and not double-embedded when
+ * an image is reachable through more than one candidate source.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type {
+  ContentPart,
+  LlmProvider,
+  LlmRequest,
+  LlmResponse,
+  LlmStreamEvent,
+} from '@omadia/llm-provider';
+import {
+  type AttachmentReader,
+  type ChatTurnAttachment,
+  NativeToolRegistry,
+  Orchestrator,
+} from '@omadia/orchestrator';
+
+const providerCapabilities = {
+  tools: true,
+  vision: true,
+  streaming: true,
+  promptCaching: true,
+  forcedToolChoice: true,
+  parallelToolCalls: true,
+} as const;
+
+/** #504/#505 review round 2 — a provider/model with NO vision capability, to
+ *  verify the guard: zero image content-blocks, but a visible note instead
+ *  of a silent drop. */
+const nonVisionProviderCapabilities = {
+  ...providerCapabilities,
+  vision: false,
+} as const;
+
+function textResponse(text: string): LlmResponse {
+  return {
+    content: [{ type: 'text', text }],
+    finishReason: 'stop',
+    providerFinishReason: 'end_turn',
+    model: 'test',
+    usage: {
+      inputTokens: 10,
+      outputTokens: 1,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    },
+  };
+}
+
+/** Records every request the orchestrator sends and answers with fixed text. */
+function recordingProvider(
+  requests: LlmRequest[],
+  capabilities: typeof providerCapabilities = providerCapabilities,
+): LlmProvider {
+  const provider = {
+    id: 'anthropic',
+    capabilities,
+    complete: async (req: LlmRequest): Promise<LlmResponse> => {
+      requests.push(req);
+      return textResponse('ok');
+    },
+    stream: (): AsyncIterable<LlmStreamEvent> => {
+      throw new Error('recordingProvider: stream() not scripted');
+    },
+    classifyError: () => ({ retryable: false, kind: 'other' as const }),
+  };
+  return provider as unknown as LlmProvider;
+}
+
+/** Image content-parts of the FIRST user message the provider saw. */
+function imagePartsOf(req: LlmRequest): ContentPart[] {
+  const first = req.messages[0];
+  if (!first || typeof first.content === 'string') return [];
+  return [...first.content].filter((p): p is ContentPart => p.type === 'image');
+}
+
+/** Plain text of the FIRST user message the provider saw — handles both the
+ *  plain-string shape (no images) and the multimodal content-block array. */
+function textOf(req: LlmRequest): string {
+  const first = req.messages[0];
+  if (!first) return '';
+  if (typeof first.content === 'string') return first.content;
+  return first.content
+    .filter((p): p is Extract<ContentPart, { type: 'text' }> => p.type === 'text')
+    .map((p) => p.text)
+    .join('');
+}
+
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+
+/** A fake `AttachmentReader` scripted with a fixed map of storageKey/url →
+ *  fetch result, and a call log so tests can assert what was (not) fetched. */
+function fakeAttachmentReader(opts: {
+  byStorageKey?: Record<
+    string,
+    { bytes: Buffer; contentType?: string; fileName?: string }
+  >;
+  byUrl?: Record<string, { bytes: Buffer; contentType?: string }>;
+}): AttachmentReader & { calls: { storageKeys: string[]; urls: string[] } } {
+  const calls = { storageKeys: [] as string[], urls: [] as string[] };
+  return {
+    calls,
+    readByStorageKey: async (storageKey: string) => {
+      calls.storageKeys.push(storageKey);
+      return opts.byStorageKey?.[storageKey];
+    },
+    readByUrl: async (url: string) => {
+      calls.urls.push(url);
+      return opts.byUrl?.[url];
+    },
+  };
+}
+
+type OrchestratorOptions = ConstructorParameters<typeof Orchestrator>[0];
+
+function baseOrchestratorOptions(
+  requests: LlmRequest[],
+  attachmentReader: AttachmentReader,
+  capabilities: typeof providerCapabilities = providerCapabilities,
+): OrchestratorOptions {
+  return {
+    provider: recordingProvider(requests, capabilities),
+    model: 'test',
+    maxTokens: 1024,
+    maxToolIterations: 3,
+    domainTools: [],
+    nativeToolRegistry: new NativeToolRegistry(),
+    attachmentReader,
+  };
+}
+
+describe('#504/#505 — vision attachment auto-ingest', () => {
+  it('#504: a Teams-manifest image candidate is embedded via images, not extractAttachmentText', async () => {
+    const requests: LlmRequest[] = [];
+    const reader = fakeAttachmentReader({
+      byStorageKey: {
+        'tigris:photo-1': {
+          bytes: PNG_BYTES,
+          contentType: 'image/png',
+          fileName: 'photo.png',
+        },
+      },
+    });
+    const orch = new Orchestrator(baseOrchestratorOptions(requests, reader));
+
+    const userMessage =
+      'Was ist auf dem Bild?\n\n' +
+      '[attachments-info] 1 Datei(en) in diesem Turn hochgeladen + persistiert:\n' +
+      '- photo.png (image/png, 4 KB) · storage_key=tigris:photo-1';
+
+    await orch.runTurn({ userMessage, sessionScope: 'sess-1', userId: 'u1' });
+
+    assert.equal(requests.length, 1);
+    const images = imagePartsOf(requests[0]!);
+    assert.equal(images.length, 1, 'the manifest image must reach the model as a vision block');
+    const img = images[0]! as Extract<ContentPart, { type: 'image' }>;
+    assert.equal(img.mediaType, 'image/png');
+    assert.equal(img.data, PNG_BYTES.toString('base64'));
+
+    // No `[attachment-content: …]` text block — it went through the vision
+    // branch, not `extractAttachmentText`.
+    const text = requests[0]!.messages[0]!.content
+      .filter((p): p is Extract<ContentPart, { type: 'text' }> => p.type === 'text')
+      .map((p) => p.text)
+      .join('');
+    assert.ok(!text.includes('[attachment-content:'));
+  });
+
+  it('#505: an attachments[] image with url + no bytesBase64 is fetched and embedded via images', async () => {
+    const requests: LlmRequest[] = [];
+    const reader = fakeAttachmentReader({
+      byUrl: {
+        'https://example.com/cat.png': { bytes: PNG_BYTES, contentType: 'image/png' },
+      },
+    });
+    const orch = new Orchestrator(baseOrchestratorOptions(requests, reader));
+
+    const attachments: ChatTurnAttachment[] = [
+      {
+        kind: 'image',
+        url: 'https://example.com/cat.png',
+        mediaType: 'image/png',
+        name: 'cat.png',
+      },
+    ];
+
+    await orch.runTurn({
+      userMessage: 'Was zeigt das Bild?',
+      sessionScope: 'sess-1',
+      userId: 'u1',
+      attachments,
+    });
+
+    assert.equal(requests.length, 1);
+    const images = imagePartsOf(requests[0]!);
+    assert.equal(images.length, 1, 'the url-only image attachment must be fetched and embedded');
+    const img = images[0]! as Extract<ContentPart, { type: 'image' }>;
+    assert.equal(img.data, PNG_BYTES.toString('base64'));
+    assert.deepEqual(reader.calls.urls, ['https://example.com/cat.png']);
+  });
+
+  it('#505: an attachments[] image that already has bytesBase64 is left alone (not fetched again)', async () => {
+    const requests: LlmRequest[] = [];
+    const reader = fakeAttachmentReader({});
+    const orch = new Orchestrator(baseOrchestratorOptions(requests, reader));
+
+    const inlineBase64 = PNG_BYTES.toString('base64');
+    const attachments: ChatTurnAttachment[] = [
+      {
+        kind: 'image',
+        url: 'https://example.com/dog.png',
+        mediaType: 'image/png',
+        name: 'dog.png',
+        bytesBase64: inlineBase64,
+      },
+    ];
+
+    await orch.runTurn({
+      userMessage: 'Was zeigt das Bild?',
+      sessionScope: 'sess-1',
+      userId: 'u1',
+      attachments,
+    });
+
+    assert.equal(requests.length, 1);
+    const images = imagePartsOf(requests[0]!);
+    assert.equal(images.length, 1, 'exactly one image block — the inline one');
+    const img = images[0]! as Extract<ContentPart, { type: 'image' }>;
+    assert.equal(img.data, inlineBase64);
+    // The pre-fetch pass must never have touched the network for this image.
+    assert.deepEqual(reader.calls.urls, []);
+    assert.deepEqual(reader.calls.storageKeys, []);
+  });
+
+  it('folds an ingested (manifest) image alongside an existing inline bytesBase64 image block', async () => {
+    const requests: LlmRequest[] = [];
+    const reader = fakeAttachmentReader({
+      byStorageKey: {
+        'tigris:chart-1': { bytes: PNG_BYTES, contentType: 'image/png', fileName: 'chart.png' },
+      },
+    });
+    const orch = new Orchestrator(baseOrchestratorOptions(requests, reader));
+
+    const inlineBytes = Buffer.from([0x47, 0x49, 0x46, 0x38]); // GIF magic
+    const attachments: ChatTurnAttachment[] = [
+      {
+        kind: 'image',
+        url: 'https://example.com/inline.gif',
+        mediaType: 'image/gif',
+        name: 'inline.gif',
+        bytesBase64: inlineBytes.toString('base64'),
+      },
+    ];
+    const userMessage =
+      'Vergleiche die beiden Bilder.\n\n' +
+      '[attachments-info] 1 Datei(en) in diesem Turn hochgeladen + persistiert:\n' +
+      '- chart.png (image/png, 4 KB) · storage_key=tigris:chart-1';
+
+    await orch.runTurn({ userMessage, sessionScope: 'sess-1', userId: 'u1', attachments });
+
+    assert.equal(requests.length, 1);
+    const images = imagePartsOf(requests[0]!) as Array<Extract<ContentPart, { type: 'image' }>>;
+    assert.equal(images.length, 2, 'both the inline and the ingested image must be present');
+    // Inline bytesBase64 blocks are built first, ingested ones appended after.
+    assert.equal(images[0]!.mediaType, 'image/gif');
+    assert.equal(images[0]!.data, inlineBytes.toString('base64'));
+    assert.equal(images[1]!.mediaType, 'image/png');
+    assert.equal(images[1]!.data, PNG_BYTES.toString('base64'));
+  });
+
+  it('de-dup guard: a manifest image candidate matching an already-inline-embedded filename is not double-sent', async () => {
+    const requests: LlmRequest[] = [];
+    const reader = fakeAttachmentReader({
+      // Scripted so that IF the guard failed and the manifest candidate were
+      // fetched anyway, the test would still see a second image block and fail
+      // loudly rather than silently passing on an empty-candidate skip.
+      byStorageKey: {
+        'tigris:dup-1': { bytes: PNG_BYTES, contentType: 'image/png', fileName: 'photo.png' },
+      },
+    });
+    const orch = new Orchestrator(baseOrchestratorOptions(requests, reader));
+
+    const inlineBytes = Buffer.from([0x47, 0x49, 0x46, 0x38]);
+    const attachments: ChatTurnAttachment[] = [
+      {
+        kind: 'image',
+        url: 'https://example.com/photo.png',
+        mediaType: 'image/png',
+        name: 'photo.png',
+        bytesBase64: inlineBytes.toString('base64'),
+      },
+    ];
+    // Same filename as the inline attachment above — the structural overlap
+    // the reviewer flagged as unguarded.
+    const userMessage =
+      'Bild anbei.\n\n' +
+      '[attachments-info] 1 Datei(en) in diesem Turn hochgeladen + persistiert:\n' +
+      '- photo.png (image/png, 4 KB) · storage_key=tigris:dup-1';
+
+    await orch.runTurn({ userMessage, sessionScope: 'sess-1', userId: 'u1', attachments });
+
+    assert.equal(requests.length, 1);
+    const images = imagePartsOf(requests[0]!) as Array<Extract<ContentPart, { type: 'image' }>>;
+    assert.equal(
+      images.length,
+      1,
+      'the manifest candidate must be skipped once its filename matches an inline image',
+    );
+    assert.equal(images[0]!.data, inlineBytes.toString('base64'));
+    assert.deepEqual(
+      reader.calls.storageKeys,
+      [],
+      'the guarded candidate must never even be fetched',
+    );
+  });
+
+  it('#504 review round 4: an oversized manifest image under a vision-capable provider is skipped, not embedded and not text-extracted, but leaves a visible note', async () => {
+    const requests: LlmRequest[] = [];
+    const reader = fakeAttachmentReader({
+      byStorageKey: {
+        'tigris:huge-1': {
+          bytes: Buffer.alloc(5 * 1024 * 1024 + 1),
+          contentType: 'image/png',
+          fileName: 'huge.png',
+        },
+      },
+    });
+    const orch = new Orchestrator(baseOrchestratorOptions(requests, reader));
+
+    const userMessage =
+      'Bild anbei.\n\n' +
+      '[attachments-info] 1 Datei(en) in diesem Turn hochgeladen + persistiert:\n' +
+      '- huge.png (image/png, 5121 KB) · storage_key=tigris:huge-1';
+
+    await orch.runTurn({ userMessage, sessionScope: 'sess-1', userId: 'u1' });
+
+    assert.equal(requests.length, 1);
+    assert.equal(imagePartsOf(requests[0]!).length, 0);
+    // Round-4 finding: a guard rejection under a VISION-CAPABLE provider used
+    // to be a silent console.warn with zero trace in the turn's text — the
+    // exact silent-drop failure #504 exists to close, just triggered by size
+    // instead of provider capability. Must now leave a visible note.
+    const text = textOf(requests[0]!);
+    assert.match(
+      text,
+      /1 image attachment.*could not be shown.*too large/,
+      'a guard-rejected image must leave a visible note, not just a console.warn',
+    );
+  });
+});
+
+describe('#504/#505 review round 2 — vision-capability guard', () => {
+  it('a Teams-manifest image is never embedded for a non-vision provider, and leaves a visible note', async () => {
+    const requests: LlmRequest[] = [];
+    const reader = fakeAttachmentReader({
+      byStorageKey: {
+        'tigris:photo-1': {
+          bytes: PNG_BYTES,
+          contentType: 'image/png',
+          fileName: 'photo.png',
+        },
+      },
+    });
+    const orch = new Orchestrator(
+      baseOrchestratorOptions(requests, reader, nonVisionProviderCapabilities),
+    );
+
+    const userMessage =
+      'Was ist auf dem Bild?\n\n' +
+      '[attachments-info] 1 Datei(en) in diesem Turn hochgeladen + persistiert:\n' +
+      '- photo.png (image/png, 4 KB) · storage_key=tigris:photo-1';
+
+    await orch.runTurn({ userMessage, sessionScope: 'sess-1', userId: 'u1' });
+
+    assert.equal(requests.length, 1);
+    assert.equal(
+      imagePartsOf(requests[0]!).length,
+      0,
+      'no image content-block may be built for a non-vision provider',
+    );
+    // The candidate must never even be fetched — vision-unsupported image
+    // candidates are skipped before the network round-trip.
+    assert.deepEqual(reader.calls.storageKeys, []);
+    const text = textOf(requests[0]!);
+    assert.match(
+      text,
+      /1 image attachment.*received but the active model does not support image input/,
+      'a visible note must replace the silently-dropped image, not a silent no-op',
+    );
+  });
+
+  it('an attachments[] bytesBase64 image is never embedded for a non-vision provider, and leaves a visible note', async () => {
+    const requests: LlmRequest[] = [];
+    const reader = fakeAttachmentReader({});
+    const orch = new Orchestrator(
+      baseOrchestratorOptions(requests, reader, nonVisionProviderCapabilities),
+    );
+
+    const attachments: ChatTurnAttachment[] = [
+      {
+        kind: 'image',
+        url: 'https://example.com/dog.png',
+        mediaType: 'image/png',
+        name: 'dog.png',
+        bytesBase64: PNG_BYTES.toString('base64'),
+      },
+    ];
+
+    await orch.runTurn({
+      userMessage: 'Was zeigt das Bild?',
+      sessionScope: 'sess-1',
+      userId: 'u1',
+      attachments,
+    });
+
+    assert.equal(requests.length, 1);
+    assert.equal(imagePartsOf(requests[0]!).length, 0);
+    const text = textOf(requests[0]!);
+    assert.match(
+      text,
+      /1 image attachment.*received but the active model does not support image input/,
+    );
+  });
+
+  it('an attachments[] url-only image is never fetched for a non-vision provider, and leaves a visible note', async () => {
+    const requests: LlmRequest[] = [];
+    const reader = fakeAttachmentReader({
+      byUrl: {
+        'https://example.com/cat.png': { bytes: PNG_BYTES, contentType: 'image/png' },
+      },
+    });
+    const orch = new Orchestrator(
+      baseOrchestratorOptions(requests, reader, nonVisionProviderCapabilities),
+    );
+
+    const attachments: ChatTurnAttachment[] = [
+      {
+        kind: 'image',
+        url: 'https://example.com/cat.png',
+        mediaType: 'image/png',
+        name: 'cat.png',
+      },
+    ];
+
+    await orch.runTurn({
+      userMessage: 'Was zeigt das Bild?',
+      sessionScope: 'sess-1',
+      userId: 'u1',
+      attachments,
+    });
+
+    assert.equal(requests.length, 1);
+    assert.equal(imagePartsOf(requests[0]!).length, 0);
+    // Never fetched — a non-vision provider can't use the bytes anyway.
+    assert.deepEqual(reader.calls.urls, []);
+    const text = textOf(requests[0]!);
+    assert.match(
+      text,
+      /1 image attachment.*received but the active model does not support image input/,
+    );
+  });
+
+  it('vision-capable providers are unaffected — no note, images embedded as before', async () => {
+    const requests: LlmRequest[] = [];
+    const reader = fakeAttachmentReader({
+      byStorageKey: {
+        'tigris:photo-1': {
+          bytes: PNG_BYTES,
+          contentType: 'image/png',
+          fileName: 'photo.png',
+        },
+      },
+    });
+    const orch = new Orchestrator(baseOrchestratorOptions(requests, reader));
+
+    const userMessage =
+      'Was ist auf dem Bild?\n\n' +
+      '[attachments-info] 1 Datei(en) in diesem Turn hochgeladen + persistiert:\n' +
+      '- photo.png (image/png, 4 KB) · storage_key=tigris:photo-1';
+
+    await orch.runTurn({ userMessage, sessionScope: 'sess-1', userId: 'u1' });
+
+    assert.equal(requests.length, 1);
+    assert.equal(imagePartsOf(requests[0]!).length, 1);
+    const text = textOf(requests[0]!);
+    assert.ok(
+      !text.includes('does not support image input'),
+      'a vision-capable provider must never see the guard note',
+    );
+  });
+});

--- a/middleware/test/orchestratorVisionAttachmentIngest.test.ts
+++ b/middleware/test/orchestratorVisionAttachmentIngest.test.ts
@@ -329,8 +329,13 @@ describe('#504/#505 — vision attachment auto-ingest', () => {
     const requests: LlmRequest[] = [];
     const reader = fakeAttachmentReader({
       byStorageKey: {
+        // The guard's cap is on the *base64-encoded* size (10MB, Anthropic's
+        // direct-API limit) — 8MB raw bytes encode to ~10.67MB base64, well
+        // over the cap. (A 5MB+1 raw buffer, as this test used before the
+        // round-7 fix, encodes to only ~6.67MB base64 and is now correctly
+        // ACCEPTED, not rejected.)
         'tigris:huge-1': {
-          bytes: Buffer.alloc(5 * 1024 * 1024 + 1),
+          bytes: Buffer.alloc(8 * 1024 * 1024),
           contentType: 'image/png',
           fileName: 'huge.png',
         },
@@ -341,7 +346,7 @@ describe('#504/#505 — vision attachment auto-ingest', () => {
     const userMessage =
       'Bild anbei.\n\n' +
       '[attachments-info] 1 Datei(en) in diesem Turn hochgeladen + persistiert:\n' +
-      '- huge.png (image/png, 5121 KB) · storage_key=tigris:huge-1';
+      '- huge.png (image/png, 8192 KB) · storage_key=tigris:huge-1';
 
     await orch.runTurn({ userMessage, sessionScope: 'sess-1', userId: 'u1' });
 

--- a/middleware/test/orchestratorVisionAttachmentIngest.test.ts
+++ b/middleware/test/orchestratorVisionAttachmentIngest.test.ts
@@ -10,6 +10,7 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
+import type { ChatStreamEvent } from '@omadia/channel-sdk';
 import type {
   ContentPart,
   LlmProvider,
@@ -76,6 +77,39 @@ function recordingProvider(
   return provider as unknown as LlmProvider;
 }
 
+/**
+ * Records every request the orchestrator sends through `provider.stream()`
+ * (the real production entry point for channel connectors — Teams, Telegram,
+ * HTTP — which all consume `agent.chatStream()`, not `agent.chat()`) and
+ * answers with a scripted single-chunk text stream. Follows the same
+ * fake-`LlmProvider.stream()` pattern as `middleware/test/orchestrator/
+ * parallelTool.test.ts`.
+ */
+function recordingStreamProvider(
+  requests: LlmRequest[],
+  capabilities: typeof providerCapabilities = providerCapabilities,
+): LlmProvider {
+  const provider = {
+    id: 'anthropic',
+    capabilities,
+    complete: async (): Promise<LlmResponse> => {
+      throw new Error('recordingStreamProvider: complete() not scripted');
+    },
+    stream: (req: LlmRequest): AsyncIterable<LlmStreamEvent> => {
+      requests.push(req);
+      const response = textResponse('ok');
+      return {
+        async *[Symbol.asyncIterator]() {
+          yield { type: 'text_delta', text: 'ok' } as LlmStreamEvent;
+          yield { type: 'final', response } as LlmStreamEvent;
+        },
+      };
+    },
+    classifyError: () => ({ retryable: false, kind: 'other' as const }),
+  };
+  return provider as unknown as LlmProvider;
+}
+
 /** Image content-parts of the FIRST user message the provider saw. */
 function imagePartsOf(req: LlmRequest): ContentPart[] {
   const first = req.messages[0];
@@ -130,6 +164,28 @@ function baseOrchestratorOptions(
 ): OrchestratorOptions {
   return {
     provider: recordingProvider(requests, capabilities),
+    model: 'test',
+    maxTokens: 1024,
+    maxToolIterations: 3,
+    domainTools: [],
+    nativeToolRegistry: new NativeToolRegistry(),
+    attachmentReader,
+    ...(visionSupported === undefined ? {} : { visionSupported }),
+  };
+}
+
+/** Same as {@link baseOrchestratorOptions} but wires the
+ *  `provider.stream()`-driven fake — for tests that exercise `chatStream()`
+ *  (the real Teams/Telegram/HTTP connector entry point) instead of
+ *  `runTurn()`. */
+function baseStreamingOrchestratorOptions(
+  requests: LlmRequest[],
+  attachmentReader: AttachmentReader,
+  capabilities: typeof providerCapabilities = providerCapabilities,
+  visionSupported?: boolean,
+): OrchestratorOptions {
+  return {
+    provider: recordingStreamProvider(requests, capabilities),
     model: 'test',
     maxTokens: 1024,
     maxToolIterations: 3,
@@ -616,5 +672,66 @@ describe('round-6 codex review — per-model visionSupported override', () => {
       textOf(requestsNonVision[0]!),
       /1 image attachment.*received but the active model does not support image input/,
     );
+  });
+});
+
+describe('#504 — chatStream() production entry point (Teams/Telegram/HTTP connectors)', () => {
+  // Round-8 review: every prior test in this file drives the orchestrator via
+  // `runTurn()`, which calls the private `chatInContextInner()`. But channel
+  // plugins (Teams, Telegram, HTTP — see
+  // `middleware/packages/harness-orchestrator/manifest.yaml`) consume
+  // `agent.chatStream()`, which calls the SEPARATE private `chatStreamInner()`
+  // — the actual path #504 was reported and reproduced on (Teams). Both inner
+  // methods thread `visionSupported` through the identical `ingestAttachments`
+  // / `buildUserContent` wiring, but nothing proved that on the streaming
+  // path until now. This mirrors the '#504: a Teams-manifest image candidate
+  // is embedded' `runTurn()` test above, driven through `chatStream()`
+  // instead.
+  it('a Teams-manifest image candidate is embedded via images when driven through chatStream(), not runTurn()', async () => {
+    const requests: LlmRequest[] = [];
+    const reader = fakeAttachmentReader({
+      byStorageKey: {
+        'tigris:photo-1': {
+          bytes: PNG_BYTES,
+          contentType: 'image/png',
+          fileName: 'photo.png',
+        },
+      },
+    });
+    const orch = new Orchestrator(baseStreamingOrchestratorOptions(requests, reader));
+
+    const userMessage =
+      'Was ist auf dem Bild?\n\n' +
+      '[attachments-info] 1 Datei(en) in diesem Turn hochgeladen + persistiert:\n' +
+      '- photo.png (image/png, 4 KB) · storage_key=tigris:photo-1';
+
+    const events: ChatStreamEvent[] = [];
+    for await (const ev of orch.chatStream({
+      userMessage,
+      sessionScope: 'sess-1',
+      userId: 'u1',
+    })) {
+      events.push(ev);
+    }
+
+    assert.ok(
+      events.some((e) => e.type === 'done'),
+      'the stream must terminate with a done event',
+    );
+    assert.equal(requests.length, 1);
+    const images = imagePartsOf(requests[0]!);
+    assert.equal(
+      images.length,
+      1,
+      'the manifest image must reach the model as a vision block via chatStream(), the real Teams connector path',
+    );
+    const img = images[0]! as Extract<ContentPart, { type: 'image' }>;
+    assert.equal(img.mediaType, 'image/png');
+    assert.equal(img.data, PNG_BYTES.toString('base64'));
+
+    // No `[attachment-content: …]` text block — same vision-branch check as
+    // the runTurn() counterpart.
+    const text = textOf(requests[0]!);
+    assert.ok(!text.includes('[attachment-content:'));
   });
 });

--- a/middleware/test/orchestratorVisionAttachmentIngest.test.ts
+++ b/middleware/test/orchestratorVisionAttachmentIngest.test.ts
@@ -126,6 +126,7 @@ function baseOrchestratorOptions(
   requests: LlmRequest[],
   attachmentReader: AttachmentReader,
   capabilities: typeof providerCapabilities = providerCapabilities,
+  visionSupported?: boolean,
 ): OrchestratorOptions {
   return {
     provider: recordingProvider(requests, capabilities),
@@ -135,6 +136,7 @@ function baseOrchestratorOptions(
     domainTools: [],
     nativeToolRegistry: new NativeToolRegistry(),
     attachmentReader,
+    ...(visionSupported === undefined ? {} : { visionSupported }),
   };
 }
 
@@ -495,6 +497,119 @@ describe('#504/#505 review round 2 — vision-capability guard', () => {
     assert.ok(
       !text.includes('does not support image input'),
       'a vision-capable provider must never see the guard note',
+    );
+  });
+});
+
+describe('round-6 codex review — per-model visionSupported override', () => {
+  it('OrchestratorOptions.visionSupported=false wins over a vision-capable provider connection (the real bundled mistral-small-on-openai-compatible-connection case)', async () => {
+    // Simulates exactly the case codex flagged: `mistral` is a single
+    // openai-compatible provider CONNECTION whose adapter hardcodes
+    // `capabilities.vision = true` regardless of which model is active
+    // (see llm-adapter-openai/src/openaiProvider.ts:104), even though the
+    // bundled `mistral-small-latest` MODEL does not support vision
+    // (builtinLlmProviders.ts). The caller resolves the active model's real
+    // vision support and passes it as `visionSupported: false`; that must
+    // win over `provider.capabilities.vision === true`.
+    const requests: LlmRequest[] = [];
+    const reader = fakeAttachmentReader({
+      byStorageKey: {
+        'tigris:photo-1': {
+          bytes: PNG_BYTES,
+          contentType: 'image/png',
+          fileName: 'photo.png',
+        },
+      },
+    });
+    const orch = new Orchestrator(
+      // provider.capabilities.vision = true (the connection-level flag),
+      // but visionSupported = false (the active model's real capability).
+      baseOrchestratorOptions(requests, reader, providerCapabilities, false),
+    );
+
+    const userMessage =
+      'Was ist auf dem Bild?\n\n' +
+      '[attachments-info] 1 Datei(en) in diesem Turn hochgeladen + persistiert:\n' +
+      '- photo.png (image/png, 4 KB) · storage_key=tigris:photo-1';
+
+    await orch.runTurn({ userMessage, sessionScope: 'sess-1', userId: 'u1' });
+
+    assert.equal(requests.length, 1);
+    assert.equal(
+      imagePartsOf(requests[0]!).length,
+      0,
+      'no image content-block may be built when the ACTIVE MODEL lacks vision, even if the provider connection claims it',
+    );
+    // Never even fetched — same short-circuit as the provider-level guard.
+    assert.deepEqual(reader.calls.storageKeys, []);
+    const text = textOf(requests[0]!);
+    assert.match(
+      text,
+      /1 image attachment.*received but the active model does not support image input/,
+      'must take the same visible-note path as the provider-level non-vision case',
+    );
+  });
+
+  it('omitting visionSupported preserves exact current behaviour (falls back to provider.capabilities.vision)', async () => {
+    // No existing caller has been updated to pass `visionSupported` yet, so
+    // this must be byte-identical to pre-fix behaviour: a vision-capable
+    // provider still embeds images with no note.
+    const requestsVisionCapable: LlmRequest[] = [];
+    const readerVisionCapable = fakeAttachmentReader({
+      byStorageKey: {
+        'tigris:photo-1': {
+          bytes: PNG_BYTES,
+          contentType: 'image/png',
+          fileName: 'photo.png',
+        },
+      },
+    });
+    const orchVisionCapable = new Orchestrator(
+      baseOrchestratorOptions(requestsVisionCapable, readerVisionCapable),
+    );
+    const userMessage =
+      'Was ist auf dem Bild?\n\n' +
+      '[attachments-info] 1 Datei(en) in diesem Turn hochgeladen + persistiert:\n' +
+      '- photo.png (image/png, 4 KB) · storage_key=tigris:photo-1';
+    await orchVisionCapable.runTurn({ userMessage, sessionScope: 'sess-1', userId: 'u1' });
+
+    assert.equal(requestsVisionCapable.length, 1);
+    assert.equal(imagePartsOf(requestsVisionCapable[0]!).length, 1);
+    assert.ok(!textOf(requestsVisionCapable[0]!).includes('does not support image input'));
+
+    // And a non-vision provider still shows the note — with `visionSupported`
+    // omitted (undefined), not merely falsy.
+    const requestsNonVision: LlmRequest[] = [];
+    const readerNonVision = fakeAttachmentReader({
+      byStorageKey: {
+        'tigris:photo-2': {
+          bytes: PNG_BYTES,
+          contentType: 'image/png',
+          fileName: 'photo.png',
+        },
+      },
+    });
+    const orchNonVision = new Orchestrator(
+      baseOrchestratorOptions(
+        requestsNonVision,
+        readerNonVision,
+        nonVisionProviderCapabilities,
+        // visionSupported intentionally omitted (undefined), not passed as
+        // false — this exercises the `??` fallback operator itself, not
+        // just an explicit false override.
+      ),
+    );
+    const userMessage2 =
+      'Was ist auf dem Bild?\n\n' +
+      '[attachments-info] 1 Datei(en) in diesem Turn hochgeladen + persistiert:\n' +
+      '- photo.png (image/png, 4 KB) · storage_key=tigris:photo-2';
+    await orchNonVision.runTurn({ userMessage: userMessage2, sessionScope: 'sess-1', userId: 'u1' });
+
+    assert.equal(requestsNonVision.length, 1);
+    assert.equal(imagePartsOf(requestsNonVision[0]!).length, 0);
+    assert.match(
+      textOf(requestsNonVision[0]!),
+      /1 image attachment.*received but the active model does not support image input/,
     );
   });
 });


### PR DESCRIPTION
## Summary

Teams delivers inbound images via a Tigris `storage_key` + `[attachments-info]` manifest, never inline `bytesBase64`. The attachment auto-ingest path fetched those bytes but handed them to the text extractor, which correctly refuses images — so the fetched image was silently dropped and never reached the model, leaving the agent to falsely claim it couldn't see the image (#504).

Separately, the documented `url`-fetch fallback for `input.attachments[]` images without pre-fetched `bytesBase64` was never implemented — latent today (no in-repo channel triggers it), but would silently break vision for any future url-only channel (#505).

## What changed

- `ingestAttachments` now routes image candidates — both Teams-manifest `storage_key` candidates and `attachments[]` items with a `url` and no `bytesBase64` — through a new `checkVisionEmbeddable` guard (supported type + size cap) and embeds them as vision content-blocks via `buildUserContent`, the same path Telegram's inline `bytesBase64` attachments already use.
- Neither the manifest path nor the url-fetch path silently drops an image anymore: an unsupported/oversized candidate, or one rejected because the active provider/model has no vision support, folds a visible note into the turn's text instead (`[N image attachment(s) received but the active model does not support image input]` / `[N image attachment(s) could not be shown: <reason(s)>]`).
- A de-dup guard prevents double-sending an image reachable through both an inline `bytesBase64` attachment and a manifest entry with the same filename.
- The size guard checks the base64-encoded size (not raw bytes) against Anthropic's documented 10MB direct-API per-image limit (verified against current docs; 5MB applies only to Bedrock/Vertex, not the bundled `https://api.anthropic.com` connection this repo uses).
- `OrchestratorOptions` gained an optional `visionSupported?: boolean` so a caller can override the provider-connection-level `capabilities.vision` flag with a specific model's real vision support (motivating case: the bundled `mistral` openai-compatible connection serves both vision and non-vision models through one connection). **This mechanism is prepared and tested, not yet wired to a real caller** — no `buildOrchestratorForAgent`/`plugin.ts`/bundled config currently sets it, so it falls back unchanged to the provider-level check today. Wiring it up for real, and making it aware of per-turn model routing (`resolveTurnModel` runs after the image-embed decision today), is tracked separately as #524 rather than folded into this PR.
- Test coverage spans both orchestrator entry points channel plugins actually use: `runTurn()` (non-streaming) and `chatStream()` (the path Teams/Telegram/HTTP connectors use in production, and the one #504 was originally reproduced on).

## Review history

This branch went through multiple rounds of adversarial review (same-family + cross-vendor via codex) before landing here — each round is reflected in a distinct commit: initial implementation, test coverage + de-dup guard, per-model capability gate (round 6, after codex caught the provider-vs-model gap), a corrected size-guard unit/constant (round 7, after independent verification against live Anthropic docs), and `chatStream()` test coverage + changelog accuracy fix (round 8/9, after review found the streaming path — the actual Teams production path — was untested).

## Test plan

```
cd middleware
npm run lint        # 0 errors (1 pre-existing warning, unrelated file)
npm run typecheck   # clean across all workspaces
npm test            # full suite green; one pre-existing unrelated flake reproduces
                     # identically on main and is untouched by this diff
```

Closes #504
Closes #505
