### PR TITLE
fix(harness-orchestrator): resolve vision per routed model, not just provider

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -72,20 +72,39 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   connection regardless of the active model — so a turn on
   `mistral-small-latest` would still build an image block for a model that
   can't use it. `OrchestratorOptions` gained a new optional
-  `visionSupported?: boolean` — the ACTIVE model's vision capability, meant
-  to be resolved by the caller the same way `maxTokens` is already resolved
-  per-model, since `harness-orchestrator` deliberately has no dependency on
-  `@omadia/llm-provider`/`@omadia/llm-provider-api` and does not resolve the
-  model registry itself. Both call sites now read `this.visionSupported ??
-  this.provider.capabilities.vision` — an explicit per-model value would win
-  if one were passed; omitting it preserves the exact prior provider-level
-  behavior. **This is a mechanism, not an end-to-end fix**: as of this PR no
-  real caller (`buildOrchestrator.ts`, `plugin.ts`, or any bundled config)
-  sets `visionSupported` yet, so the concrete `mistral-small` scenario above
-  is made fixable, not actually resolved in production today — a future
-  change still needs to wire the active model's real vision capability
-  through to `OrchestratorOptions` for any given connection. Backward
-  compatible either way: no caller passing it is a no-op, not a regression.
+  `visionSupported?: boolean` — an explicit per-model override, checked
+  before any other source. Both call sites at the time read
+  `this.visionSupported ?? this.provider.capabilities.vision`; omitting it
+  preserved the prior provider-level behavior. (Superseded by round 8/#524
+  below — this override alone could not reflect model routing, and no real
+  caller ever set it.)
+- Review round 8 (#524, cross-vendor codex review of round 6): the round-6
+  `visionSupported` mechanism had two gaps. First, nothing in production set
+  it — `buildOrchestratorForAgent` never passed it, so every turn still fell
+  back to `this.provider.capabilities.vision`, the exact `mistral-small`
+  case round 6 diagnosed but did not close. Second, even a correctly-wired
+  static `visionSupported` would be wrong under `modelRouting`: the
+  image-embed decision (`ingestAttachments`/`buildUserContent`, inside
+  `chatInContextInner`/`chatStreamInner`) ran BEFORE `resolveTurnModel`
+  resolved which model this specific turn actually routes to, so a turn
+  configured with `modelRouting.simpleModel`/`complexModel` of different
+  vision support could send the image to the wrong model regardless of any
+  static override. Both call sites now resolve `resolveTurnModel` FIRST,
+  then gate the vision decision on the ROUTED model via a new
+  `resolveTurnVisionSupported(turnModel)`: `resolveModelRef(turnModel, {
+  defaultProvider: this.provider.id })` (the model registry's per-model
+  `ModelInfo.vision`, resolved the same way `registry/agentRuntime.ts`'s
+  `resolveModelIdForProvider` already resolves model refs) falls back to
+  `this.provider.capabilities.vision` only when the routed model id isn't
+  registered — never throws, so an unknown model id can't crash a turn.
+  Correction to round 6's own claim: `harness-orchestrator` DOES depend on
+  `@omadia/llm-provider` (a `peerDependency`, already imported by
+  `registry/agentRuntime.ts` and `registry/configStore.ts`) — there was no
+  architectural boundary preventing this lookup from living in
+  `orchestrator.ts` itself. `visionSupported` remains as an explicit
+  caller-override escape hatch (still checked first) but is no longer the
+  only mechanism; the common case (omitted) now resolves correctly per turn
+  without any caller wiring.
 - Review round 7: `checkVisionEmbeddable` compared the fetched image's RAW
   byte length against a 5MB cap, but that cap is Anthropic's documented
   per-image *base64-encoded* payload limit — comparing raw bytes against a

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -105,6 +105,30 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   caller-override escape hatch (still checked first) but is no longer the
   only mechanism; the common case (omitted) now resolves correctly per turn
   without any caller wiring.
+- Review round 9 (#524, cross-vendor codex review of round 8): round 8's
+  `resolveTurnVisionSupported` let a registry HIT on the routed model
+  OVERRIDE `this.provider.capabilities.vision` outright — `info?.vision ??
+  this.provider.capabilities.vision`, evaluated as "registry wins whenever it
+  has an opinion". That regressed the pre-existing guard from round 2: a
+  non-vision-capable PROVIDER CONNECTION was supposed to be a hard stop
+  regardless of which model string was in play. Concrete failing case: an
+  `anthropic` connection with `capabilities.vision = false` (e.g. a
+  restricted/on-prem/vision-disabled connection) paired with
+  `claude-opus-4-8`, a model id the bundled registry lists as `vision:
+  true` — the registry hit resolved the turn as vision-capable and embedded
+  the image, silently omitting the non-vision note even though the active
+  CONNECTION explicitly cannot accept images. `resolveTurnVisionSupported`
+  now combines the two sources with a logical AND instead of an override:
+  the provider-connection flag is checked first and is a hard floor/veto —
+  `false` short-circuits to `false` before the registry is even consulted;
+  only when the connection reports `true` does the routed model's
+  registry-resolved `ModelInfo.vision` get a say, and only to NARROW
+  support (catching a model that is less capable than its connection, the
+  mistral small/large case round 8 introduced), never to WIDEN it. Registry
+  metadata about what a model generally supports must never manufacture
+  vision capability the actual connection lacks. The `visionSupported`
+  explicit caller-override and the registry-miss fallback (trust the
+  connection-level flag alone) are unchanged.
 - Review round 7: `checkVisionEmbeddable` compared the fetched image's RAW
   byte length against a 5MB cap, but that cap is Anthropic's documented
   per-image *base64-encoded* payload limit — comparing raw bytes against a

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -215,10 +215,14 @@ export interface OrchestratorOptions {
    * (no vision) while the openai adapter hardcodes
    * `capabilities.vision = true` on the connection regardless of model.
    *
-   * Omitted (the common case) → `resolveTurnVisionSupported` resolves the
-   * routed model against the registry per turn, falling back to
-   * `this.provider.capabilities.vision` only when the routed model id is
-   * not registered.
+   * Omitted (the common case) → `resolveTurnVisionSupported` combines
+   * `this.provider.capabilities.vision` and the routed model's
+   * registry-resolved `ModelInfo.vision` with a logical AND: the connection
+   * flag is a hard floor/veto (a connection that reports no vision support
+   * can never be granted it by the registry), and the per-model registry
+   * lookup can only narrow — never widen — vision support on top of that,
+   * falling back to trusting `this.provider.capabilities.vision` alone when
+   * the routed model id is not registered.
    */
   visionSupported?: boolean;
   maxToolIterations: number;
@@ -2738,18 +2742,34 @@ export class Orchestrator {
    * Precedence:
    *  1. `this.visionSupported` (explicit `OrchestratorOptions.visionSupported`
    *     override) — wins unconditionally when set.
-   *  2. the model registry's `ModelInfo.vision` for `turnModel`, resolved the
-   *     same way `registry/agentRuntime.ts`'s `resolveModelIdForProvider`
+   *  2. Otherwise, the PROVIDER CONNECTION's `capabilities.vision` flag is a
+   *     hard floor/veto: a connection that reports it cannot accept images
+   *     (e.g. a restricted/on-prem/vision-disabled Anthropic connection)
+   *     never gets vision for this turn, no matter what the model registry
+   *     says about the routed model in general. When the connection-level
+   *     flag is `false`, this returns `false` immediately — the registry is
+   *     never even consulted, because registry metadata about what a model
+   *     GENERALLY supports must never manufacture vision capability the
+   *     actual connection lacks.
+   *  3. Only when the connection reports `capabilities.vision === true` does
+   *     the model registry's `ModelInfo.vision` for `turnModel` get a say —
+   *     and only to NARROW, never widen: it can catch a routed model that is
+   *     LESS capable than its connection (e.g. the bundled `mistral`
+   *     openai-compatible connection hardcodes `capabilities.vision = true`
+   *     on the connection while `mistral-small-latest` itself has no vision,
+   *     unlike `mistral-large-latest` / `mistral-medium-latest`). Resolved
+   *     the same way `registry/agentRuntime.ts`'s `resolveModelIdForProvider`
    *     resolves model refs (`resolveModelRef` with `defaultProvider` bound
    *     to this provider, so a bare vendor id like `mistral-small-latest`
-   *     resolves against the right provider's models).
-   *  3. `this.provider.capabilities.vision` (the provider-connection-level
-   *     flag) — used when `turnModel` isn't in the registry (a fully custom
-   *     / unregistered model id). Never throws, so an unknown model id can
-   *     never crash a turn.
+   *     resolves against the right provider's models). A registry miss
+   *     (`turnModel` not registered) falls back to trusting the
+   *     connection-level flag alone, per the existing fallback-on-miss
+   *     behaviour. Never throws, so an unknown model id can never crash a
+   *     turn.
    */
   private resolveTurnVisionSupported(turnModel: string): boolean {
     if (this.visionSupported !== undefined) return this.visionSupported;
+    if (!this.provider.capabilities.vision) return false;
     const info = resolveModelRef(turnModel, { defaultProvider: this.provider.id });
     return info?.vision ?? this.provider.capabilities.vision;
   }

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -13,7 +13,7 @@ import {
   type SemanticAnswer,
 } from '@omadia/channel-sdk';
 import type { EmbeddingClient } from '@omadia/embeddings';
-import type { LlmProvider } from '@omadia/llm-provider';
+import { resolveModelRef, type LlmProvider } from '@omadia/llm-provider';
 import type {
   ContextRetriever,
   FactExtractor,
@@ -194,27 +194,31 @@ export interface OrchestratorOptions {
   modelRouting?: ModelRoutingConfig;
   maxTokens: number;
   /**
-   * #504/#505 (round-6 codex review) — the ACTIVE model's vision capability
-   * (the registry's per-model `ModelInfo.vision`, e.g. from
-   * `@omadia/llm-provider-api`), resolved by the caller the same way it
-   * already resolves `maxTokens` for the model. harness-orchestrator has no
-   * dependency on `@omadia/llm-provider` / `@omadia/llm-provider-api` (by
-   * design — it never imports the model registry itself, exactly like
-   * `maxTokens` above arrives pre-resolved instead of being looked up
-   * internally), so this cannot be derived in here; the caller must pass it.
+   * #504/#505 (round-6 codex review) — explicit caller override for the
+   * ACTIVE model's vision capability. Optional: since #524, every turn
+   * resolves the same thing itself (see `resolveTurnVisionSupported`) from
+   * the model registry's per-model `ModelInfo.vision`, keyed off whichever
+   * model {@link resolveTurnModel} actually routes THIS turn to — so this
+   * field is no longer required for correctness under `modelRouting`, it
+   * only remains as a way for a caller to force a value the registry
+   * wouldn't otherwise produce (e.g. a model id the registry doesn't know
+   * about yet). `harness-orchestrator` DOES depend on `@omadia/llm-provider`
+   * (see `registry/agentRuntime.ts`'s `resolveModelIdForProvider`, which
+   * uses the same `resolveModelRef` call) — there is no architectural
+   * boundary preventing the per-turn lookup from happening in here.
    *
-   * Deliberately NOT `this.provider.capabilities.vision` (a property of the
-   * PROVIDER CONNECTION, not the model): one provider connection can serve
-   * several models with different vision support — e.g. the bundled
-   * `mistral` openai-compatible connection serves `mistral-large-latest`
+   * Precedence when set: wins over BOTH the registry lookup and
+   * `this.provider.capabilities.vision` (the PROVIDER CONNECTION's coarser
+   * flag) — useful for the case that motivated this field, the bundled
+   * `mistral` openai-compatible connection serving `mistral-large-latest`
    * and `mistral-medium-latest` (vision) alongside `mistral-small-latest`
-   * (no vision), yet the openai adapter hardcodes
-   * `capabilities.vision = true` on the connection regardless of which
-   * model is actually selected for the turn.
+   * (no vision) while the openai adapter hardcodes
+   * `capabilities.vision = true` on the connection regardless of model.
    *
-   * Omitted → falls back to `this.provider.capabilities.vision` (today's
-   * behaviour), for backward compatibility with callers that haven't been
-   * updated to pass the more precise per-model value yet.
+   * Omitted (the common case) → `resolveTurnVisionSupported` resolves the
+   * routed model against the registry per turn, falling back to
+   * `this.provider.capabilities.vision` only when the routed model id is
+   * not registered.
    */
   visionSupported?: boolean;
   maxToolIterations: number;
@@ -1249,9 +1253,10 @@ export class Orchestrator {
   /** Wave 8 — direct-answer persona candidates; empty when none attached. */
   private readonly personaSkills: readonly OrchestratorPersonaSkill[];
   private readonly maxTokens: number;
-  /** #504/#505 — active model's vision support, if the caller resolved it
-   *  (see OrchestratorOptions.visionSupported). Undefined → callers fall
-   *  back to `this.provider.capabilities.vision` at each read site. */
+  /** #504/#505/#524 — explicit caller override for the active model's vision
+   *  support (see OrchestratorOptions.visionSupported). Undefined (the
+   *  common case) → each turn resolves it itself via
+   *  {@link resolveTurnVisionSupported}. */
   private readonly visionSupported: boolean | undefined;
   private readonly maxIterations: number;
   /** Round-loop guard thresholds (see {@link LoopGuard}). */
@@ -2724,6 +2729,32 @@ export class Orchestrator {
   }
 
   /**
+   * #524 — resolves whether the model ROUTED for this turn (`turnModel`,
+   * from {@link resolveTurnModel}) supports vision. Runs per turn so
+   * `modelRouting` (different `simpleModel`/`complexModel` vision support)
+   * is reflected correctly, instead of a value fixed at Orchestrator-
+   * construction time or the provider connection's coarser flag.
+   *
+   * Precedence:
+   *  1. `this.visionSupported` (explicit `OrchestratorOptions.visionSupported`
+   *     override) — wins unconditionally when set.
+   *  2. the model registry's `ModelInfo.vision` for `turnModel`, resolved the
+   *     same way `registry/agentRuntime.ts`'s `resolveModelIdForProvider`
+   *     resolves model refs (`resolveModelRef` with `defaultProvider` bound
+   *     to this provider, so a bare vendor id like `mistral-small-latest`
+   *     resolves against the right provider's models).
+   *  3. `this.provider.capabilities.vision` (the provider-connection-level
+   *     flag) — used when `turnModel` isn't in the registry (a fully custom
+   *     / unregistered model id). Never throws, so an unknown model id can
+   *     never crash a turn.
+   */
+  private resolveTurnVisionSupported(turnModel: string): boolean {
+    if (this.visionSupported !== undefined) return this.visionSupported;
+    const info = resolveModelRef(turnModel, { defaultProvider: this.provider.id });
+    return info?.vision ?? this.provider.capabilities.vision;
+  }
+
+  /**
    * Wave 8 — resolves the direct-answer persona for a single turn. With
    * persona skills attached, a Haiku classifier picks at most one candidate;
    * its `body` should replace `assistantIdentity` for this turn only. Empty
@@ -2812,22 +2843,43 @@ export class Orchestrator {
       privacyForPrompt,
       rawPriorContext,
     );
+    // #524 — resolve the model ROUTED for this turn BEFORE any
+    // attachment/vision-ingest work below: the image-embed decision must
+    // reflect the model this turn actually runs on. Per-turn model routing
+    // (no-op unless configured) + Wave 8 persona routing (no-op unless
+    // persona skills are attached) are resolved together — independent
+    // classifier calls, run in parallel so persona routing adds no serial
+    // latency on top of model routing. Both resolved once so the whole turn
+    // — every tool-loop iteration — is stable. The non-streaming path has no
+    // event channel, so both decisions are simply applied (channels that
+    // want to surface them use chatStream). Safe to run ahead of
+    // `resolvePrependRules(messages)` below: that helper only ever reads
+    // `messages[].content` as a string (`typeof m.content === 'string' ? …
+    // : ''`), discarding the `ContentBlock[]` array `buildUserContent`
+    // returns whenever attachments are present, so it has no dependency on
+    // the image blocks or on which model gets routed.
+    const [turnModelResolved, turnPersonaResolved] = await Promise.all([
+      this.resolveTurnModel(wireUserMessage),
+      this.resolveTurnPersona(wireUserMessage),
+    ]);
+    const turnModel = turnModelResolved.model;
+    const turnPersonaBody = turnPersonaResolved.skillBody;
+
     // #268 — pre-fetch + extract any uploaded document text for this turn.
     // #504/#505 — the same pass also resolves image attachments (Teams
     // Tigris storage_key, or a bare url for channels without a pre-fetch)
     // into vision content-blocks; `ingestedImages` rides separately from the
-    // text since it never crosses the PII-masking wire. Gated on the ACTIVE
-    // MODEL's vision capability (round-6 codex review) — `visionSupported`
-    // wins when the caller resolved it (see OrchestratorOptions), otherwise
-    // this falls back to the provider connection's own capability flag,
-    // which is imprecise whenever one connection serves several models with
-    // different vision support. Either way, a non-vision model never gets
-    // an image content-block, and `buildUserContent` below surfaces a
-    // visible note instead of silently dropping the attachment.
+    // text since it never crosses the PII-masking wire. #524 — gated on the
+    // ROUTED model's vision capability (`resolveTurnVisionSupported`,
+    // resolved from `turnModel` above via the model registry), not the
+    // provider connection's coarser flag, which is imprecise whenever one
+    // connection serves several models with different vision support.
+    // Either way, a non-vision model never gets an image content-block, and
+    // `buildUserContent` below surfaces a visible note instead of silently
+    // dropping the attachment.
     // #361 — the ingested verbatim tail crosses the wire alongside the
     // message, so it is masked through the SAME turn map (stable surrogates).
-    const visionSupported =
-      this.visionSupported ?? this.provider.capabilities.vision;
+    const visionSupported = this.resolveTurnVisionSupported(turnModel);
     const {
       text: ingestedRawText,
       images: ingestedImages,
@@ -2922,20 +2974,6 @@ export class Orchestrator {
     let obligationMet = obligationTool === undefined;
     let obligationEscalationsUsed = 0;
     let forceObligationNext = false;
-
-    // Per-turn model routing (no-op unless configured) + Wave 8 persona
-    // routing (no-op unless persona skills are attached), resolved together
-    // — independent classifier calls, run in parallel so persona routing
-    // adds no serial latency on top of model routing. Both resolved once so
-    // the whole turn — every tool-loop iteration — is stable. The
-    // non-streaming path has no event channel, so both decisions are simply
-    // applied (channels that want to surface them use chatStream).
-    const [turnModelResolved, turnPersonaResolved] = await Promise.all([
-      this.resolveTurnModel(wireUserMessage),
-      this.resolveTurnPersona(wireUserMessage),
-    ]);
-    const turnModel = turnModelResolved.model;
-    const turnPersonaBody = turnPersonaResolved.skillBody;
 
     try {
       for (let iteration = 0; iteration < this.maxIterations; iteration++) {
@@ -3622,13 +3660,28 @@ export class Orchestrator {
     // recalled KG neighbourhood. Best-effort & guarded inside the helper so it
     // can never break or delay the turn; additive/opaque to the model.
     yield* await this.toKgGraphAnnotationEvents(recalled);
+    // #524 — resolve the model ROUTED for this turn BEFORE any
+    // attachment/vision-ingest work below; see chatInContextInner for the
+    // full rationale (safe to run ahead of `resolvePrependRules(messages)`
+    // further down). Per-turn model routing (no-op unless configured) +
+    // Wave 8 persona routing (no-op unless persona skills are attached) are
+    // independent classifier calls, run in parallel so persona routing adds
+    // no serial latency. Resolved once so the whole streamed turn runs on
+    // one model. The `turn_routing`/`turn_persona` events stay below, right
+    // before the tool loop, unchanged — only the resolution moved earlier.
+    const [resolved, resolvedPersona] = await Promise.all([
+      this.resolveTurnModel(wireUserMessage),
+      this.resolveTurnPersona(wireUserMessage),
+    ]);
+    const turnModel = resolved.model;
+    const turnPersonaBody = resolvedPersona.skillBody;
     // #268 — pre-fetch + extract any uploaded document text for this turn.
     // #504/#505 — same pass also resolves image attachments into vision
-    // content-blocks; see chatInContextInner for the full rationale,
-    // including the per-model vision-capability gate (round-6 codex review).
+    // content-blocks; see chatInContextInner for the full rationale. #524 —
+    // gated on the ROUTED model's vision capability
+    // (`resolveTurnVisionSupported`, resolved from `turnModel` above).
     // #361 — masked through the same turn map as the message (see above).
-    const visionSupported =
-      this.visionSupported ?? this.provider.capabilities.vision;
+    const visionSupported = this.resolveTurnVisionSupported(turnModel);
     const {
       text: ingestedRawText,
       images: ingestedImages,
@@ -3704,16 +3757,10 @@ export class Orchestrator {
     // Mid-turn steering — same key the route enqueues under (see chatStream:
     // `sessionId`). Drained at the top of every iteration below.
     const steerKey = input.sessionScope ?? turnId;
-    // Per-turn model routing (no-op unless configured) + Wave 8 persona
-    // routing (no-op unless persona skills are attached). Independent
-    // classifier calls — run in parallel so persona routing adds no serial
-    // latency. Resolved once so the whole streamed turn runs on one model.
-    const [resolved, resolvedPersona] = await Promise.all([
-      this.resolveTurnModel(wireUserMessage),
-      this.resolveTurnPersona(wireUserMessage),
-    ]);
-    const turnModel = resolved.model;
-    const turnPersonaBody = resolvedPersona.skillBody;
+    // `resolved`/`resolvedPersona` (and the `turnModel`/`turnPersonaBody`
+    // derived from them) were already resolved above, ahead of the
+    // vision-ingest step (#524) — only the routing/persona EVENTS are
+    // surfaced here, at the same point in the turn as before.
     // Surface the Haiku-triage decision inline, before the first model call —
     // the UI renders it at the top of the turn card so the operator sees the
     // classifier's verdict (simple/complex → model) as soon as it lands.

--- a/middleware/test/orchestratorVisionAttachmentIngest.test.ts
+++ b/middleware/test/orchestratorVisionAttachmentIngest.test.ts
@@ -8,19 +8,23 @@
  */
 
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import type { ChatStreamEvent } from '@omadia/channel-sdk';
-import type {
-  ContentPart,
-  LlmProvider,
-  LlmRequest,
-  LlmResponse,
-  LlmStreamEvent,
+import {
+  clearExternalModels,
+  registerExternalModels,
+  type ContentPart,
+  type LlmProvider,
+  type LlmRequest,
+  type LlmResponse,
+  type LlmStreamEvent,
+  type ModelInfo,
 } from '@omadia/llm-provider';
 import {
   type AttachmentReader,
   type ChatTurnAttachment,
+  type ModelRoutingConfig,
   NativeToolRegistry,
   Orchestrator,
 } from '@omadia/orchestrator';
@@ -672,6 +676,163 @@ describe('round-6 codex review — per-model visionSupported override', () => {
       textOf(requestsNonVision[0]!),
       /1 image attachment.*received but the active model does not support image input/,
     );
+  });
+});
+
+describe('#524 — per-turn vision resolution under modelRouting (the real mistral small/large case)', () => {
+  // The bundled `mistral` openai-compatible connection reports
+  // `capabilities.vision = true` on the CONNECTION regardless of which
+  // model is active (llm-adapter-openai/src/openaiProvider.ts) — exactly the
+  // case #524 exists to fix. `simpleModel`/`complexModel` are two DIFFERENT
+  // registered models through that SAME connection with different `vision`
+  // flags, so only a per-turn, per-model registry lookup (not the provider-
+  // level flag) can tell them apart.
+  const MISTRAL_SMALL: ModelInfo = {
+    id: 'mistral:mistral-small-latest',
+    provider: 'mistral',
+    modelId: 'mistral-small-latest',
+    label: 'Mistral Small',
+    class: 'fast',
+    maxTokens: 8192,
+    contextWindow: 32000,
+    vision: false,
+  };
+  const MISTRAL_LARGE: ModelInfo = {
+    id: 'mistral:mistral-large-latest',
+    provider: 'mistral',
+    modelId: 'mistral-large-latest',
+    label: 'Mistral Large',
+    class: 'frontier',
+    maxTokens: 8192,
+    contextWindow: 128000,
+    vision: true,
+  };
+  const modelRouting: ModelRoutingConfig = {
+    classifierModel: 'mistral-classifier-latest',
+    simpleModel: 'mistral-small-latest',
+    complexModel: 'mistral-large-latest',
+  };
+
+  beforeEach(() => {
+    clearExternalModels();
+    registerExternalModels([MISTRAL_SMALL, MISTRAL_LARGE]);
+  });
+  afterEach(() => {
+    clearExternalModels();
+  });
+
+  /** Records every non-classifier request; answers the classifier call with
+   *  the scripted verdict so the routing decision is deterministic, and
+   *  every other call with a fixed text answer. Provider id `mistral`, with
+   *  `capabilities.vision = true` at the CONNECTION level — the coarse flag
+   *  that must NOT be what decides vision for these turns. */
+  function mistralRoutingProvider(
+    requests: LlmRequest[],
+    verdict: 'SIMPLE' | 'COMPLEX',
+  ): LlmProvider {
+    const provider = {
+      id: 'mistral',
+      capabilities: providerCapabilities,
+      complete: async (req: LlmRequest): Promise<LlmResponse> => {
+        if (req.model === modelRouting.classifierModel) {
+          return textResponse(verdict);
+        }
+        requests.push(req);
+        return textResponse('ok');
+      },
+      stream: (): AsyncIterable<LlmStreamEvent> => {
+        throw new Error('mistralRoutingProvider: stream() not scripted');
+      },
+      classifyError: () => ({ retryable: false, kind: 'other' as const }),
+    };
+    return provider as unknown as LlmProvider;
+  }
+
+  it('a turn routed to the SIMPLE (non-vision) model does not embed the image and surfaces the non-vision note, even though the provider connection reports capabilities.vision=true', async () => {
+    const requests: LlmRequest[] = [];
+    const reader = fakeAttachmentReader({
+      byStorageKey: {
+        'tigris:photo-1': {
+          bytes: PNG_BYTES,
+          contentType: 'image/png',
+          fileName: 'photo.png',
+        },
+      },
+    });
+    const orch = new Orchestrator({
+      provider: mistralRoutingProvider(requests, 'SIMPLE'),
+      model: 'mistral-large-latest',
+      modelRouting,
+      maxTokens: 1024,
+      maxToolIterations: 3,
+      domainTools: [],
+      nativeToolRegistry: new NativeToolRegistry(),
+      attachmentReader: reader,
+    });
+
+    const userMessage =
+      'Was ist auf dem Bild?\n\n' +
+      '[attachments-info] 1 Datei(en) in diesem Turn hochgeladen + persistiert:\n' +
+      '- photo.png (image/png, 4 KB) · storage_key=tigris:photo-1';
+
+    await orch.runTurn({ userMessage, sessionScope: 'sess-1', userId: 'u1' });
+
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0]!.model, 'mistral-small-latest');
+    assert.equal(
+      imagePartsOf(requests[0]!).length,
+      0,
+      'the SIMPLE-routed (non-vision) model must never receive an image content-block',
+    );
+    assert.deepEqual(reader.calls.storageKeys, []);
+    const text = textOf(requests[0]!);
+    assert.match(
+      text,
+      /1 image attachment.*received but the active model does not support image input/,
+    );
+  });
+
+  it('a turn routed to the COMPLEX (vision-capable) model embeds the image', async () => {
+    const requests: LlmRequest[] = [];
+    const reader = fakeAttachmentReader({
+      byStorageKey: {
+        'tigris:photo-1': {
+          bytes: PNG_BYTES,
+          contentType: 'image/png',
+          fileName: 'photo.png',
+        },
+      },
+    });
+    const orch = new Orchestrator({
+      provider: mistralRoutingProvider(requests, 'COMPLEX'),
+      model: 'mistral-large-latest',
+      modelRouting,
+      maxTokens: 1024,
+      maxToolIterations: 3,
+      domainTools: [],
+      nativeToolRegistry: new NativeToolRegistry(),
+      attachmentReader: reader,
+    });
+
+    const userMessage =
+      'Was ist auf dem Bild?\n\n' +
+      '[attachments-info] 1 Datei(en) in diesem Turn hochgeladen + persistiert:\n' +
+      '- photo.png (image/png, 4 KB) · storage_key=tigris:photo-1';
+
+    await orch.runTurn({ userMessage, sessionScope: 'sess-1', userId: 'u1' });
+
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0]!.model, 'mistral-large-latest');
+    const images = imagePartsOf(requests[0]!);
+    assert.equal(
+      images.length,
+      1,
+      'the COMPLEX-routed (vision-capable) model must receive the image content-block',
+    );
+    const img = images[0]! as Extract<ContentPart, { type: 'image' }>;
+    assert.equal(img.mediaType, 'image/png');
+    assert.equal(img.data, PNG_BYTES.toString('base64'));
+    assert.ok(!textOf(requests[0]!).includes('does not support image input'));
   });
 });
 

--- a/middleware/test/orchestratorVisionAttachmentIngest.test.ts
+++ b/middleware/test/orchestratorVisionAttachmentIngest.test.ts
@@ -836,6 +836,83 @@ describe('#524 — per-turn vision resolution under modelRouting (the real mistr
   });
 });
 
+describe('#524 (codex cross-vendor review) — provider capability is a floor, the model registry can only narrow, never widen', () => {
+  // Codex's exact failing example: an `anthropic` PROVIDER CONNECTION with
+  // `capabilities.vision = false` (e.g. a restricted/on-prem/vision-disabled
+  // Anthropic connection) paired with `claude-opus-4-8`, a model id the
+  // bundled registry lists as `vision: true`. The round-1 fix let a registry
+  // HIT override the connection-level flag whenever one was found — which
+  // let a non-vision CONNECTION embed an image just because the ROUTED MODEL
+  // is generally vision-capable. The connection-level flag must stay a hard
+  // veto: the registry may only narrow vision support (catch a model that is
+  // LESS capable than its connection — the mistral small/large case below),
+  // never widen it (grant vision to a connection that says it can't).
+  const CLAUDE_OPUS_VISION: ModelInfo = {
+    id: 'anthropic:claude-opus-4-8',
+    provider: 'anthropic',
+    modelId: 'claude-opus-4-8',
+    label: 'Claude Opus 4.8',
+    class: 'frontier',
+    maxTokens: 8192,
+    contextWindow: 200000,
+    vision: true,
+  };
+
+  beforeEach(() => {
+    clearExternalModels();
+    registerExternalModels([CLAUDE_OPUS_VISION]);
+  });
+  afterEach(() => {
+    clearExternalModels();
+  });
+
+  it('a non-vision anthropic CONNECTION never embeds an image for a registry-vision-capable model, and still shows the non-vision note', async () => {
+    const requests: LlmRequest[] = [];
+    const reader = fakeAttachmentReader({
+      byStorageKey: {
+        'tigris:photo-1': {
+          bytes: PNG_BYTES,
+          contentType: 'image/png',
+          fileName: 'photo.png',
+        },
+      },
+    });
+    const orch = new Orchestrator({
+      // provider.id === 'anthropic', capabilities.vision === false — the
+      // CONNECTION reports it cannot accept images at all.
+      provider: recordingProvider(requests, nonVisionProviderCapabilities),
+      // A model the bundled/external registry resolves to `vision: true`.
+      model: 'claude-opus-4-8',
+      maxTokens: 1024,
+      maxToolIterations: 3,
+      domainTools: [],
+      nativeToolRegistry: new NativeToolRegistry(),
+      attachmentReader: reader,
+    });
+
+    const userMessage =
+      'Was ist auf dem Bild?\n\n' +
+      '[attachments-info] 1 Datei(en) in diesem Turn hochgeladen + persistiert:\n' +
+      '- photo.png (image/png, 4 KB) · storage_key=tigris:photo-1';
+
+    await orch.runTurn({ userMessage, sessionScope: 'sess-1', userId: 'u1' });
+
+    assert.equal(requests.length, 1);
+    assert.equal(
+      imagePartsOf(requests[0]!).length,
+      0,
+      'the non-vision PROVIDER CONNECTION must veto vision even though the registry says the routed model supports it',
+    );
+    assert.deepEqual(reader.calls.storageKeys, []);
+    const text = textOf(requests[0]!);
+    assert.match(
+      text,
+      /1 image attachment.*received but the active model does not support image input/,
+      'the connection-level hard-stop must still produce the visible non-vision note',
+    );
+  });
+});
+
 describe('#504 — chatStream() production entry point (Teams/Telegram/HTTP connectors)', () => {
   // Round-8 review: every prior test in this file drives the orchestrator via
   // `runTurn()`, which calls the private `chatInContextInner()`. But channel


### PR DESCRIPTION
## Stacked on PR #525 — do not merge before it

This branch is cut from `feat/cluster-vision-attachment-fetch` (PR #525, still open) because it depends on the `OrchestratorOptions.visionSupported` mechanism that PR adds. **Merge order: #525 first, then this PR**, rebasing onto `main` afterward if needed.

## Summary

Follow-up to #504/#505 (Teams images silently dropped; missing url-fetch vision fallback). PR #525 added an optional `OrchestratorOptions.visionSupported` override to handle providers that serve multiple models with different vision support (e.g. the bundled `mistral` connection: `mistral-large-latest`/`mistral-medium-latest` have vision, `mistral-small-latest` doesn't, but the connection itself reports `capabilities.vision = true` for all of them) — but nothing wired it up, and even wired, a static boolean can't reflect per-turn model **routing** (`modelRouting.simpleModel`/`complexModel`), since the image-embed decision happened before the turn's actual model was resolved.

## What changed

- **Reordered `chatInContextInner` and `chatStreamInner`**: `resolveTurnModel` now runs before the attachment/vision-ingest step, so the image-embed decision reflects the model this turn actually executes on. Verified safe: the only thing that previously ran between the old positions, `resolvePrependRules`, discards the `ContentBlock[]` array either way and has no dependency on the routed model.
- **New `resolveTurnVisionSupported(turnModel)`**: resolves the routed model's vision flag via `resolveModelRef(turnModel, { defaultProvider: this.provider.id })` from `@omadia/llm-provider` — the same call pattern already used elsewhere in this package (`registry/agentRuntime.ts`). Falls back to the provider-connection flag when the routed model isn't in the registry.
- **Precedence, fixed after cross-vendor review caught a regression**: `OrchestratorOptions.visionSupported` (explicit override) wins if set; otherwise `this.provider.capabilities.vision` is a hard floor — `false` short-circuits immediately, before the registry is even consulted. Only when the connection says `true` does the routed model's registry flag get a vote, and only to *narrow* support, never to *widen* it. A registry miss falls back to trusting the connection-level flag alone.
- Corrected the round-6 CHANGELOG entry and matching code comments that claimed `harness-orchestrator` has no dependency on `@omadia/llm-provider` — it's already a peer dependency, used by sibling files in the same package.

## Review history on this branch

- **Round 8** (codex): resolved vision per-turn from the model registry, closing the gap round 6 diagnosed but never wired — introduced a regression where a registry hit could *override* the provider-connection flag outright.
- **Round 9** (codex): caught that regression with a concrete failing input (a vision-disabled Anthropic connection + a registry-vision-capable model id would wrongly embed an image). Fixed by making the provider connection a non-overridable floor (AND, not override).

## Tests

- Regression test mirroring codex's exact example: a non-vision provider connection paired with a registry-vision-capable model id → zero embedded images, existing non-vision note still shown.
- `modelRouting` test: `simpleModel`/`complexModel` routed to different models through the *same* connection (mirroring the real Mistral small/large case) — simple-routed turn never embeds, complex-routed turn does.
- All prior non-routed tests unaffected.

## Verification

`cd middleware && npm run lint && npm run typecheck && npm test` — all green (4739 passed, 0 failed, 4 pre-existing unrelated skips), rerun after rebasing onto #525's latest tip.

Closes #524

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787727773&installation_model_id=428086&pr_number=526&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F526&signature=bd7e4cedec8dd5f21f1bd9fc7424d09780d0034472a2f5daf99c43bb19554a81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->