### PR TITLE
fix(orchestrator): gate unauthenticated plugin tools from the orchestrator's tool surface (#474)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -147,6 +147,23 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   the two current always-ready memory plugins are unaffected as long as they
   haven't reported not-ready — covered by a new test alongside the
   gated-plugin case.
+- Follow-up (review round 12): `OAuthReadinessTracker.isConnected()` read a
+  boolean cached once inside `refresh()` — activation time — instead of
+  re-checking freshness against the current wall clock. A plugin activating
+  with, say, 10 minutes of token freshness left and no refresh token cached
+  as "ready" and stayed that way until the NEXT activation, even after
+  crossing `tokenStore.ts`'s 5-minute `OAUTH_REFRESH_MARGIN_MS`, where a real
+  `ctx.oauthTokens.get()` call would already throw
+  `OAuthTokenError('refresh_failed')` — reproducing the exact wasted
+  round-trip #474 exists to prevent, just shifted into the gap between
+  activations instead of at activation time. `refresh()` now caches only the
+  raw per-field `StoredOAuthTokens` (the genuinely async vault read), and
+  `isConnected()` recomputes `isTokenRefreshable()`/`isTokenStillFresh()`
+  fresh on every call against `Date.now()` — both are pure, synchronous,
+  in-memory checks, so recomputing per read has no latency cost. Mirrors how
+  `ctx.oauthTokens.get()` itself never caches a verdict either. Covered by a
+  new test using `t.mock.timers` to advance the clock past the refresh
+  margin without a new `refresh()` call.
 
 ### Fixed — Teams-uploaded images now reach the model as vision input (#504, #505)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -81,6 +81,23 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   resolution, reusing the existing "Specialist … is no longer available."
   notice already used for a deleted tool, instead of surfacing the internal
   dispatch-error string.
+- Follow-up (review round 5): every gate above depended on the plugin's own
+  code calling `ctx.status.report(...)`. The generic install/Connect flow
+  never does this automatically — `installService.ts` activates a
+  `type:'oauth'` plugin (registering its tools) the moment `configure()`
+  completes, which is BEFORE the operator has clicked "Connect" and the
+  kernel OAuth broker has stored any tokens. A plugin author who never wrote
+  an explicit status-report call for this (the common case) still had its
+  tools offered and invoked, failing with `OAuthTokenError('not_connected')`
+  on the first call — the exact round-trip #474 was filed to eliminate. A
+  new `OAuthReadinessTracker` derives connection state from the same vault
+  state `ctx.oauthTokens` reads, refreshed on every `ToolPluginRuntime` /
+  `DynamicAgentRuntime` `activate()` (fresh install, boot reactivation, and
+  post-Connect reactivation all funnel through this single choke point per
+  runtime). The orchestrator's readiness gate now ANDs this automatic signal
+  with the existing `PluginStatusRegistry` one — either can withhold
+  readiness — kept as two separate caches rather than one merged into the
+  other, so neither can silently clobber the other's verdict.
 
 ### Fixed — templates v2 review round 3: owner-aware publish vs. auth timing (#478)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,15 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   be told about a capability whose spec had just been removed, replacing a
   clean "tool not offered" state with a confusing "documented but missing
   tool" one.
+- Follow-up (review round 3): the gate only covered native tools registered
+  via `ctx.tools.register()` — `Orchestrator.buildToolsList()` still
+  appended every `DomainTool` (the dynamic-agent-plugin tools, e.g.
+  `query_<slug>`) unconditionally, and `dispatchToolInner()` still invoked
+  a matching one without any readiness check. Both call sites now apply
+  the same `isToolAvailable(agentId)` gate `DomainTool.agentId` already
+  carries, so a not-ready plugin's domain tool is excluded from `tools[]`
+  and refused (`Error:`-prefixed, handler never invoked) at dispatch time,
+  matching the native-tool path exactly.
 
 ### Fixed — templates v2 review round 3: owner-aware publish vs. auth timing (#478)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,22 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — orchestrator no longer offers or invokes a not-yet-authenticated plugin's tools (#474)
+
+- A native plugin (`ctx.tools.register` from `activate()`) whose own
+  connection/auth setup is still pending — reported via the existing
+  `ctx.status.report({state: 'needs_action' | 'error'})` — is now excluded
+  from the tool list the orchestrator offers the model
+  (`Orchestrator.buildToolsList`), instead of being offered and failing on
+  the first call. The same check runs again at invocation time
+  (`Orchestrator.dispatchToolInner` and the standalone
+  `ToolDispatchService` used by the subscription-CLI provider), so a status
+  change between list-assembly and the actual call can't slip through
+  either. Plugins that never report a status (the common case — no
+  connection step) are unaffected. Deliberately separate from the
+  MCP-server-specific auth-gap flow (`mcpOAuthService`), which already
+  handles that case for MCP servers.
+
 ### Fixed — templates v2 review round 3: owner-aware publish vs. auth timing (#478)
 
 - The save-as-template dialog no longer reads the viewer's own template id as

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -98,6 +98,26 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   with the existing `PluginStatusRegistry` one — either can withhold
   readiness — kept as two separate caches rather than one merged into the
   other, so neither can silently clobber the other's verdict.
+- Follow-up (review round 8): every gate above only covered
+  `ctx.tools.register()` — `NativeToolRegistry.registerHandler()` (used by
+  `ctx.tools.registerHandler()` for tools whose wire-spec the kernel emits
+  itself, e.g. the Anthropic-native `memory` tool used today by
+  `harness-memory` / `harness-memory-postgres`) never stored an `agentId` on
+  its entry at all, so `isToolAvailable`'s `agentId === undefined ⇒
+  always-available` default — correct for a genuinely kernel-internal
+  registration — incorrectly also applied to ANY plugin using this path
+  instead of `register()`, leaving its `promptDoc` in the system prompt and
+  its handler dispatchable regardless of the plugin's own readiness.
+  `NativeToolHandlerRegistrationOptions` and the stored
+  `NativeToolRegistration` entry both gained the same optional `agentId` the
+  `register()` path already carries, and `ctx.tools.registerHandler()` in
+  `pluginContext.ts` now passes the calling plugin's own id, mirroring
+  `ctx.tools.register()`'s existing wiring exactly — no new gate logic, the
+  entry just flows through the same `isToolAvailable(agentId)` check every
+  other path already uses. The two current `registerHandler()` callers
+  (`harness-memory`, `harness-memory-postgres`) are unaffected in practice:
+  neither reports a connection status, so `PluginStatusRegistry.isReady()`
+  defaults them to ready, exactly as before this fix.
 
 ### Fixed — Teams-uploaded images now reach the model as vision input (#504, #505)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -118,6 +118,35 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   (`harness-memory`, `harness-memory-postgres`) are unaffected in practice:
   neither reports a connection status, so `PluginStatusRegistry.isReady()`
   defaults them to ready, exactly as before this fix.
+- Follow-up (review round 10), two remaining gaps: (1)
+  `OAuthReadinessTracker.refresh()` treated `tokens !== undefined` alone as
+  "connected" — it only checked that SOME token bundle was stored in the
+  vault, not that it was actually usable. `ctx.oauthTokens.get()`
+  (`pluginContext.ts`) throws `OAuthTokenError('refresh_failed')` for a
+  token that's expired AND has no refresh token to renew it with, so a
+  plugin in that state was still reported ready, offered, and dispatched —
+  failing on the first real call with the exact wasted round-trip #474 was
+  filed to eliminate. The "still fresh" expiry check `ctx.oauthTokens.get()`
+  already computes is now factored out into `tokenStore.ts`'s
+  `isTokenStillFresh`/`isTokenRefreshable` and reused by both call sites, so
+  the two can never drift on what counts as expired; a token that's expired
+  but HAS a refresh token still counts as ready (a refresh is expected to
+  succeed transparently). (2) The built-in Anthropic `memory` tool
+  (`{type:'memory_20250818', name:'memory'}`) is special-cased in both
+  `buildToolsList()` and `dispatchToolInner()` and dispatched via the
+  orchestrator's own per-Agent-scoped `memoryToolHandler` BEFORE the general
+  `NativeToolRegistry`/`isToolAvailable(agentId)` gate is ever consulted —
+  so a plugin contributing `memory` via `ctx.tools.registerHandler('memory',
+  ...)` (the same path `harness-memory`/`harness-memory-postgres` use) with
+  `isPluginToolsReady(pluginId) === false` still had it offered and
+  dispatched, completely bypassing round 8's fix. Both call sites now look
+  up the `memory` entry's own `agentId` (if any plugin registered it) and
+  run it through the same `isToolAvailable` gate before taking the fast
+  path. A marker-only / agentId-less entry (nothing registered `memory` via
+  a plugin) keeps the existing "no agentId ⇒ always-available" default, so
+  the two current always-ready memory plugins are unaffected as long as they
+  haven't reported not-ready — covered by a new test alongside the
+  gated-plugin case.
 
 ### Fixed — Teams-uploaded images now reach the model as vision input (#504, #505)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -70,6 +70,17 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   plugin's domain tool as the turn's forced `tool_choice`, which would name a
   tool `buildToolsList()` had already excluded from `tools[]` — now gated the
   same way.
+- Follow-up (review round 4/final): the last unguarded consumer of
+  `domainToolsByName` — the DirectLine (`#token`) candidate resolution in
+  `Orchestrator.executeDirectLine()` — still let a not-ready plugin's
+  `#token` resolve successfully. `dispatchToolInner()` already refused the
+  handler safely, but its raw `Error: tool … is unavailable …` string was
+  then wrapped into a `delegatedAnswer` and shown to the user as though the
+  specialist itself had answered. The resolved candidate's readiness is now
+  checked against the same `isToolAvailable(agentId)` gate right after
+  resolution, reusing the existing "Specialist … is no longer available."
+  notice already used for a deleted tool, instead of surfacing the internal
+  dispatch-error string.
 
 ### Fixed — templates v2 review round 3: owner-aware publish vs. auth timing (#478)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,26 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   carries, so a not-ready plugin's domain tool is excluded from `tools[]`
   and refused (`Error:`-prefixed, handler never invoked) at dispatch time,
   matching the native-tool path exactly.
+- Follow-up (review round 4): two remaining gaps of the same kind. First,
+  `Orchestrator.buildSystemPrompt()`'s "Fach-Agenten" roster block — the
+  human-readable list of domain tools rendered ahead of the tool specs —
+  still listed every `DomainTool` unconditionally, so a not-ready plugin's
+  tool was hidden from `tools[]` but the model was still told to route to it
+  by name. `Orchestrator.getSystemPrompt()` now filters the roster through
+  the same `isToolAvailable(agentId)` gate before it reaches
+  `buildSystemPrompt()`. Second, `PluginStatusRegistry.isReady()` only
+  returned `true` when there was no stored status entry at all — correctness
+  depended entirely on every caller normalizing `state: 'ok'` into `clear()`
+  before it reached the registry's own `set()`, which only the higher-level
+  `StatusAccessor.report()` in `pluginContext.ts` did. `isReady()` now
+  checks the stored entry's `state` directly (`!entry ||
+  (entry.state !== 'needs_action' && entry.state !== 'error')`), so it stays
+  correct even for a caller that stores `{state: 'ok'}` via `set()` directly.
+  Also closed during the same audit: `Orchestrator.directLineObligationState()`
+  (the `#332` forced-delegation primitive) could still resolve a not-ready
+  plugin's domain tool as the turn's forced `tool_choice`, which would name a
+  tool `buildToolsList()` had already excluded from `tools[]` — now gated the
+  same way.
 
 ### Fixed — templates v2 review round 3: owner-aware publish vs. auth timing (#478)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,14 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   connection step) are unaffected. Deliberately separate from the
   MCP-server-specific auth-gap flow (`mcpOAuthService`), which already
   handles that case for MCP servers.
+- Follow-up (review round 2): `Orchestrator.getSystemPrompt()` now applies
+  the same `isToolAvailable` gate to the plugin `promptDoc` collection that
+  `buildToolsList()` already applied to the tool specs — a gated plugin's
+  documentation is no longer spliced into the system prompt while its tool
+  is simultaneously hidden from `tools[]`. Previously the model would still
+  be told about a capability whose spec had just been removed, replacing a
+  clean "tool not offered" state with a confusing "documented but missing
+  tool" one.
 
 ### Fixed — templates v2 review round 3: owner-aware publish vs. auth timing (#478)
 

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -136,6 +136,51 @@ src/
   nutzt Session-Transkripte nur auf Rückbezug, persistiert Learnings
   früh (im nächsten Tool-Call, nicht am Ende).
 
+### Plugin-Tool-Readiness-Gate (#474)
+
+`Orchestrator.isToolAvailable(agentId)` entscheidet pro Tool, ob es dem
+Modell angeboten und bei Dispatch ausgeführt wird. Ohne `agentId`
+(kernel-interne Registrierungen wie `render_diagram`) oder ohne
+verdrahtetes `isPluginToolsReady` (Legacy-Hosts, Unit-Tests) bleibt das
+Verhalten exakt wie vor #474 — immer verfügbar. Konsultiert an jeder Stelle,
+die ein Tool-Name→Handler-Mapping liest: `buildToolsList()` (Tool-Specs,
+inkl. des Anthropic-`memory`-Fast-Path, falls ein Plugin ihn via
+`ctx.tools.registerHandler('memory', …)` registriert hat),
+`dispatchToolInner()` (derselbe Fast-Path plus die generischen
+`NativeToolRegistry`- und `DomainTool`-Handler), `getSystemPrompt()`
+(promptDoc-Splice + Fach-Agenten-Roster — ein gegatetes Tool taucht weder in
+den Specs noch in Doku/Roster auf), `directLineObligationState()` (#332
+Forced-`tool_choice`) und `executeDirectLine()` (`#token`-Kandidatenauflösung,
+degradiert auf die bestehende "Specialist … is no longer available."-Notiz
+statt den internen Dispatch-Fehler zu zeigen). Die parallele
+`ToolDispatchService` (Subscription-CLI-Bridge) trägt dieselbe Gate-Logik
+unabhängig nach, da sie ohne Orchestrator-Instanz läuft.
+
+Zwei unabhängige Readiness-Signale werden UND-verknüpft (jedes kann
+Verfügbarkeit allein verweigern) — bewusst zwei getrennte Caches statt einem
+gemergten, damit keins das Urteil des anderen stillschweigend überschreiben
+kann:
+
+- **`PluginStatusRegistry`** (`middleware/src/platform/pluginStatusRegistry.ts`)
+  — explizit, vom Plugin selbst via
+  `ctx.status.report({state:'needs_action'|'error'})` gesetzt.
+- **`OAuthReadinessTracker`** (`middleware/src/plugins/oauth/oauthReadinessTracker.ts`)
+  — automatisch, aus demselben Vault-Token-State abgeleitet, den
+  `ctx.oauthTokens` liest; refreshed bei jedem
+  `ToolPluginRuntime`/`DynamicAgentRuntime.activate()` (Install,
+  Boot-Reaktivierung, Post-Connect). Deckt den Fall, dass
+  `installService.ts` ein `type:'oauth'`-Plugin schon beim `configure()`
+  aktiviert — bevor der Operator "Connect" geklickt hat —, ohne dass der
+  Plugin-Autor dafür einen eigenen `status.report()`-Call schreiben muss.
+
+Beide werden am Boot hinter dem Service-Registry-Key
+`installedPluginToolsReadyReader` (`middleware/src/index.ts`)
+veröffentlicht und von `harness-orchestrator/src/plugin.ts` als
+`OrchestratorOptions.isPluginToolsReady` verdrahtet. Bewusst getrennt von
+der MCP-Server-spezifischen Auth-Lücke (`mcpOAuthService`), die für
+MCP-Server bereits existiert — dieses Gate deckt nur native
+Plugin-Tool-Registrierungen ab.
+
 ### Sub-Agents (lokal, in-process)
 
 - **Datei:** `services/localSubAgent.ts` (`LocalSubAgent`-Klasse).

--- a/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
@@ -113,6 +113,13 @@ export interface OrchestratorDeps {
     agentId: string,
     configKey: string,
   ) => unknown | undefined;
+  /**
+   * Issue #474 — per-plugin tool-readiness gate (see
+   * `OrchestratorOptions.isPluginToolsReady`). Wired from the harness
+   * runtime's `PluginStatusRegistry`. Optional — when absent every
+   * plugin's tools are always available (pre-#474 behaviour).
+   */
+  readonly isPluginToolsReady?: (agentId: string) => boolean;
   readonly contextRetriever?: ContextRetriever;
   readonly sessionBriefing?: SessionBriefingService;
   readonly factExtractor?: FactExtractor;
@@ -283,6 +290,9 @@ export function buildOrchestratorForAgent(
     ...(deps.pluginConfigGet
       ? { pluginConfigGet: deps.pluginConfigGet }
       : {}),
+    ...(deps.isPluginToolsReady
+      ? { isPluginToolsReady: deps.isPluginToolsReady }
+      : {}),
     nudgeRegistry: deps.nudgeRegistry,
     ...(deps.nudgeStateStore ? { nudgeStateStore: deps.nudgeStateStore } : {}),
     ...(deps.processMemory ? { nudgeProcessMemory: deps.processMemory } : {}),
@@ -333,6 +343,12 @@ export function buildOrchestratorForAgent(
       // sub-agents fail GRACEFULLY (dispatch returns an error result) until they
       // also run on the CLI (recursive Shape 3 — follow-up); tool-less ones work.
       domainToolsProvider: () => orchestrator.listDomainTools(),
+      // Issue #474 — this dispatcher bypasses `Orchestrator.dispatchTool`
+      // entirely (the CLI reaches tools over the loopback MCP server), so
+      // the readiness gate must be repeated here too.
+      ...(deps.isPluginToolsReady
+        ? { isPluginToolsReady: deps.isPluginToolsReady }
+        : {}),
     });
     return {
       orchestrator,

--- a/middleware/packages/harness-orchestrator/src/nativeToolRegistry.ts
+++ b/middleware/packages/harness-orchestrator/src/nativeToolRegistry.ts
@@ -97,6 +97,13 @@ export interface NativeToolHandlerRegistrationOptions {
   handler: NativeToolHandler;
   promptDoc?: string;
   attachmentSink?: NativeToolAttachmentSink;
+  /** Issue #474 (round 8) — see `NativeToolRegistration.agentId`. Set by
+   *  `ToolsAccessor.registerHandler` from the activating plugin's context,
+   *  mirroring `NativeToolRegistrationOptions.agentId` on the `register()`
+   *  path. Absent for a genuinely kernel-internal `registerHandler()` call —
+   *  such an entry stays always-available, matching `register()`'s
+   *  kernel-internal (marker-only) convention. */
+  agentId?: string;
 }
 
 export class NativeToolRegistry {
@@ -147,10 +154,14 @@ export class NativeToolRegistry {
   /**
    * Handler-only registration. Used for tools whose spec the kernel emits
    * itself (e.g. `memory_20250818`). The registry stores the handler,
-   * promptDoc, and attachmentSink — dispatch finds the handler by name but
-   * the system-prompt tool list picks up `spec` only from full registrations,
-   * so this entry never contributes an `input_schema` tool. Throws on
-   * duplicate.
+   * promptDoc, attachmentSink, and (Issue #474 round 8) `agentId` —
+   * dispatch finds the handler by name but the system-prompt tool list
+   * picks up `spec` only from full registrations, so this entry never
+   * contributes an `input_schema` tool. `agentId` still flows through the
+   * exact same `isToolAvailable(agentId)` gate `register()`-contributed
+   * entries use, so a plugin-originated `registerHandler()` tool cannot
+   * bypass the readiness gate just because it took this path instead of
+   * `register()`. Throws on duplicate.
    */
   registerHandler(
     name: string,
@@ -170,6 +181,7 @@ export class NativeToolRegistry {
       ...(options.attachmentSink
         ? { attachmentSink: options.attachmentSink }
         : {}),
+      ...(options.agentId !== undefined ? { agentId: options.agentId } : {}),
     };
     this.entries.set(name, entry);
     return () => {

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -2235,7 +2235,14 @@ export class Orchestrator {
 
     const candidate = resolution.candidate;
     const tool = this.domainToolsByName.get(candidate.toolName);
-    if (!tool) {
+    // Issue #474 (round 4) — a not-ready plugin's domain tool must resolve
+    // the same as a deleted one: `dispatchToolInner` already blocks the
+    // handler safely (no capability leak), but without this check its raw
+    // `Error: tool … is unavailable …` string would be wrapped into a
+    // delegatedAnswer and shown to the user as if the specialist itself had
+    // answered. Reuse the SAME notice as the deleted-tool branch above
+    // instead of surfacing that internal dispatch-error string.
+    if (!tool || !this.isToolAvailable(tool.agentId)) {
       return this.directLineNotice(
         `Specialist "${candidate.label}" is no longer available.`,
       );

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -4609,7 +4609,17 @@ export class Orchestrator {
       return this.bookMeetingTool.handle(input);
     }
     const domainTool = this.domainToolsByName.get(name);
-    if (domainTool) return domainTool.handle(input, observer);
+    if (domainTool) {
+      // Issue #474 — same re-check-at-invocation-time gate as the native-tool
+      // branch above, applied to the second tool-registration path (domain
+      // tools contributed by dynamic agent plugins via DomainTool.agentId).
+      // Without this, a not-ready plugin's domain tool was still invocable
+      // even though its native tools and promptDoc were already hidden.
+      if (!this.isToolAvailable(domainTool.agentId)) {
+        return `Error: tool \`${name}\` is unavailable — plugin \`${domainTool.agentId}\` has not completed its connection/auth setup.`;
+      }
+      return domainTool.handle(input, observer);
+    }
     return `Error: unknown tool \`${name}\`.`;
   }
 
@@ -4898,8 +4908,14 @@ export class Orchestrator {
     }
     // DomainTools dynamically from the map — so hot-registered uploaded
     // agents become visible from the next iteration without reboot.
+    // Issue #474 — same gate as the native-tools loop above: a domain tool
+    // whose owning plugin hasn't completed its connection/auth setup must
+    // not be offered either, otherwise the model discovers the missing
+    // access via a failing dispatch instead of the tool being absent.
     for (const tool of this.domainToolsByName.values()) {
-      tools.push(tool.spec);
+      if (this.isToolAvailable(tool.agentId)) {
+        tools.push(tool.spec);
+      }
     }
     // Privacy-Shield v4 — verb + render tools, offered only when the v4
     // data-plane boundary is active for this turn.

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -4738,7 +4738,22 @@ export class Orchestrator {
     // handler (which wraps the unscoped FilesystemMemoryStore). Checked
     // before the generic `reg?.handler` dispatch below, since `memory` is a
     // plugin-registered native tool and would otherwise win here unscoped.
+    //
+    // Issue #474 (review round 10) — this fast path bypassed the readiness
+    // gate entirely: a plugin that contributes `memory` via
+    // `ctx.tools.registerHandler('memory', ...)` (e.g. harness-memory /
+    // harness-memory-postgres) still has its own `agentId` recorded on the
+    // NativeToolRegistry entry, so re-derive that agentId here and run it
+    // through the same `isToolAvailable` gate the generic `reg?.handler`
+    // path below already uses. A marker-only / agentId-less entry (nothing
+    // registered `memory` via a plugin) keeps its `agentId === undefined ⇒
+    // always-available` default, so the two current always-ready memory
+    // plugins are unaffected as long as they haven't reported not-ready.
     if (name === MEMORY_TOOL_NAME && this.memoryToolHandler) {
+      const memoryAgentId = this.nativeTools.get(MEMORY_TOOL_NAME)?.agentId;
+      if (!this.isToolAvailable(memoryAgentId)) {
+        return `Error: tool \`${name}\` is unavailable — plugin \`${memoryAgentId}\` has not completed its connection/auth setup.`;
+      }
       return this.memoryToolHandler.handle(input);
     }
     // Plugin-contributed handlers win first. Kernel branches below are the
@@ -5196,7 +5211,16 @@ export class Orchestrator {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private buildToolsList(): any[] {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const tools: any[] = [{ type: MEMORY_TOOL_TYPE, name: MEMORY_TOOL_NAME }];
+    const tools: any[] = [];
+    // Issue #474 (review round 10) — the hardcoded `memory` tool spec used
+    // to be pushed unconditionally, bypassing the readiness gate applied to
+    // every other plugin-contributed tool below. Mirror `isToolAvailable`'s
+    // `dispatchToolInner` check: gate on the `agentId` of whichever plugin
+    // (if any) registered `memory` via `ctx.tools.registerHandler('memory')`.
+    const memoryAgentId = this.nativeTools.get(MEMORY_TOOL_NAME)?.agentId;
+    if (this.isToolAvailable(memoryAgentId)) {
+      tools.push({ type: MEMORY_TOOL_TYPE, name: MEMORY_TOOL_NAME });
+    }
     if (this.knowledgeGraphTool) tools.push(knowledgeGraphToolSpec);
     // Diagrams + enrich_company tool specs come from nativeTools registry (plugin-contributed).
     if (this.chatParticipantsTool) tools.push(chatParticipantsToolSpec);

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -383,6 +383,22 @@ export interface OrchestratorOptions {
     configKey: string,
   ) => unknown | undefined;
   /**
+   * Issue #474 — per-plugin tool-readiness gate. Given the `agentId` of a
+   * plugin that contributed a native tool (via `ctx.tools.register`),
+   * returns whether that plugin's connection/auth setup is complete and its
+   * tools may be exposed to and invoked by the orchestrator. Checked both in
+   * `buildToolsList()` (tool-list assembly) and `dispatchToolInner()`
+   * (tool-invocation time) — auth can complete or expire between the two, so
+   * list-time filtering alone is not enough. Kernel-internal tools (no
+   * `agentId` on the registration) are never gated.
+   *
+   * Caller wires this from the harness runtime's `PluginStatusRegistry`
+   * (spec 004): `(agentId) => pluginStatusRegistry.isReady(agentId)`.
+   * Absent ⇒ every plugin's tools are always available (pre-#474 behaviour,
+   * and the correct default for test/migration contexts).
+   */
+  isPluginToolsReady?: (agentId: string) => boolean;
+  /**
    * Palaia Phase 8 (OB-77) — Nudge-Pipeline registry. Plugin-contributed
    * `NudgeProvider`s register against this registry; the orchestrator
    * iterates them after every tool_result. Absent → pipeline is a no-op
@@ -1192,6 +1208,10 @@ export class Orchestrator {
   private readonly pluginConfigGet:
     | ((agentId: string, configKey: string) => unknown | undefined)
     | undefined;
+  /** Issue #474 — per-plugin tool-readiness gate (see OrchestratorOptions). */
+  private readonly isPluginToolsReady:
+    | ((agentId: string) => boolean)
+    | undefined;
   private readonly nudgeRegistry: NudgeRegistry | undefined;
   private readonly nudgeStateStore: NudgeStateStore | undefined;
   private readonly nudgeProcessMemory: ProcessMemoryService | undefined;
@@ -1256,6 +1276,7 @@ export class Orchestrator {
     this.responseGuard = options.responseGuard;
     this.privacyGuard = options.privacyGuard;
     this.pluginConfigGet = options.pluginConfigGet;
+    this.isPluginToolsReady = options.isPluginToolsReady;
     this.nudgeRegistry = options.nudgeRegistry;
     this.nudgeStateStore = options.nudgeStateStore;
     this.nudgeProcessMemory = options.nudgeProcessMemory;
@@ -4554,6 +4575,16 @@ export class Orchestrator {
     // migrates, its hardcoded branch disappears.
     const reg = this.nativeTools.get(name);
     if (reg?.handler) {
+      // Issue #474 — re-check readiness at invocation time, not just at
+      // list-assembly time: a plugin's connection/auth state can complete
+      // or expire between the two, so list-time filtering alone leaves a
+      // race window. Returned (not thrown) as an `Error:`-prefixed string,
+      // matching the `unknown tool` fallback below — both the streaming and
+      // non-streaming dispatch loops key `is_error` off that prefix, and
+      // only the non-streaming one also catches thrown rejections.
+      if (!this.isToolAvailable(reg.agentId)) {
+        return `Error: tool \`${name}\` is unavailable — plugin \`${reg.agentId}\` has not completed its connection/auth setup.`;
+      }
       return reg.handler(input);
     }
     if (name === KNOWLEDGE_GRAPH_TOOL_NAME && this.knowledgeGraphTool) {
@@ -4823,6 +4854,19 @@ export class Orchestrator {
     }
   }
 
+  /**
+   * Issue #474 — true when a plugin-contributed native tool may be exposed
+   * to / invoked by the orchestrator. Kernel-internal registrations (no
+   * `agentId`) are always available; a plugin-owned one is gated on
+   * `isPluginToolsReady`, which defaults to "ready" when the gate was never
+   * wired (byte-identical pre-#474 behaviour).
+   */
+  private isToolAvailable(agentId: string | undefined): boolean {
+    if (agentId === undefined) return true;
+    if (!this.isPluginToolsReady) return true;
+    return this.isPluginToolsReady(agentId);
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private buildToolsList(): any[] {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -4838,8 +4882,13 @@ export class Orchestrator {
     // Plugin-contributed native tools (registered via ctx.tools.register).
     // Live-ingested: activating a tool-kind plugin makes its spec appear on
     // the next iteration without requiring an orchestrator rebuild.
+    // Issue #474 — a plugin that hasn't finished its own connection/auth
+    // setup is excluded here so the orchestrator never offers a tool it
+    // knows will fail, instead of discovering that via a wasted round-trip.
     for (const entry of this.nativeTools.listWithHandler()) {
-      if (entry.spec) tools.push(entry.spec);
+      if (entry.spec && this.isToolAvailable(entry.agentId)) {
+        tools.push(entry.spec);
+      }
     }
     // DomainTools dynamically from the map — so hot-registered uploaded
     // agents become visible from the next iteration without reboot.

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -4629,8 +4629,14 @@ export class Orchestrator {
     // kernel's hardcoded blocks (graph/diagram/…) remain in buildSystemPrompt
     // for their tools; plugin docs land in a separate bullet list so both
     // paths coexist cleanly during the extraction transition.
+    // Issue #474 — mirror the same isToolAvailable gate applied in
+    // buildToolsList(): a plugin whose connection/auth setup hasn't
+    // completed must not have its promptDoc advertised here either,
+    // otherwise the model is told about a capability that buildToolsList()
+    // has already hidden from its `tools[]` for this same turn.
     const extraDocs = this.nativeTools
       .listWithHandler()
+      .filter((e) => this.isToolAvailable(e.agentId))
       .map((e) => e.promptDoc)
       .filter((doc): doc is string => typeof doc === 'string' && doc.length > 0);
     return buildSystemPrompt(

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -2439,8 +2439,16 @@ export class Orchestrator {
     // (if configured), so the forced-delegation primitive has a real,
     // opt-in producer beyond a caller wiring it per turn.
     const requested = input.expectedDomainTool ?? this.requiredConsultToolName;
+    const requestedEntry = requested
+      ? this.domainToolsByName.get(requested)
+      : undefined;
+    // Issue #474 (round 3 self-audit) — a not-ready plugin's domain tool must
+    // not become an obligation: `tool_choice` would then force the model onto
+    // a tool name that buildToolsList() has already excluded from tools[],
+    // which the API rejects. Same isToolAvailable gate as the roster/tools[]
+    // paths above.
     const tool =
-      requested && this.domainToolsByName.has(requested)
+      requestedEntry && this.isToolAvailable(requestedEntry.agentId)
         ? requested
         : undefined;
     return {
@@ -4649,9 +4657,16 @@ export class Orchestrator {
       .filter((e) => this.isToolAvailable(e.agentId))
       .map((e) => e.promptDoc)
       .filter((doc): doc is string => typeof doc === 'string' && doc.length > 0);
+    // Issue #474 (round 3) — same isToolAvailable gate as buildToolsList()'s
+    // domain-tool loop above: a not-ready plugin's DomainTool must not be
+    // advertised in the 'Fach-Agenten' roster either, otherwise the model is
+    // told to route to a tool that tools[] has already hidden this turn.
+    const availableDomainTools = Array.from(this.domainToolsByName.values()).filter((tool) =>
+      this.isToolAvailable(tool.agentId),
+    );
     return buildSystemPrompt(
       personaOverride ?? this.assistantIdentity,
-      Array.from(this.domainToolsByName.values()),
+      availableDomainTools,
       this.knowledgeGraphTool !== undefined,
       // Diagrams is now plugin-contributed — its doc ships via extraDocs.
       false,

--- a/middleware/packages/harness-orchestrator/src/plugin.ts
+++ b/middleware/packages/harness-orchestrator/src/plugin.ts
@@ -363,6 +363,14 @@ export async function activate(
     (agentId: string, configKey: string) => unknown | undefined
   >('installedPluginConfigReader');
 
+  // Issue #474 — per-plugin tool-readiness gate. Published by the kernel at
+  // boot (`middleware/src/index.ts:installedPluginToolsReadyReader`), backed
+  // by `PluginStatusRegistry`. Absent (legacy hosts, unit tests) → every
+  // plugin's tools stay available exactly as before #474.
+  const isPluginToolsReady = ctx.services.get<
+    (agentId: string) => boolean
+  >('installedPluginToolsReadyReader');
+
   // Setup-field config (with defaults)
   const model =
     (ctx.config.get<string>('orchestrator_model') ?? '').trim() ||
@@ -549,6 +557,7 @@ export async function activate(
     responseGuard: responseGuardGetter,
     privacyGuard: privacyGuardGetter,
     ...(pluginConfigGet ? { pluginConfigGet } : {}),
+    ...(isPluginToolsReady ? { isPluginToolsReady } : {}),
     ...(contextRetriever ? { contextRetriever } : {}),
     ...(sessionBriefing ? { sessionBriefing } : {}),
     ...(factExtractor ? { factExtractor } : {}),

--- a/middleware/packages/harness-orchestrator/src/toolDispatchService.ts
+++ b/middleware/packages/harness-orchestrator/src/toolDispatchService.ts
@@ -36,6 +36,15 @@ export class ToolDispatchService {
        *  flow via `registerDomainTool`) are reachable. Takes precedence over the
        *  static list when present. */
       readonly domainToolsProvider?: () => readonly DomainTool[];
+      /**
+       * Issue #474 — per-plugin tool-readiness gate, mirroring
+       * `OrchestratorOptions.isPluginToolsReady`. This dispatcher is a
+       * SEPARATE entry point from `Orchestrator.dispatchTool` (used by the
+       * subscription-CLI provider), so the gate must be repeated here too —
+       * relying on `Orchestrator`'s own check alone would leave this path
+       * ungated. Absent ⇒ every plugin's tools are always available.
+       */
+      readonly isPluginToolsReady?: (agentId: string) => boolean;
     },
   ) {}
 
@@ -43,10 +52,23 @@ export class ToolDispatchService {
     return this.deps.domainToolsProvider?.() ?? this.deps.domainTools ?? [];
   }
 
+  /** Issue #474 — see `Orchestrator.isToolAvailable`; kept in sync with it. */
+  private isToolAvailable(agentId: string | undefined): boolean {
+    if (agentId === undefined) return true;
+    if (!this.deps.isPluginToolsReady) return true;
+    return this.deps.isPluginToolsReady(agentId);
+  }
+
   async dispatch(name: string, input: unknown): Promise<ToolDispatchResult> {
     const nativeRegistration = this.deps.nativeTools.get(name);
     // Mirrors Orchestrator ordering: plugin/native handlers win first.
     if (nativeRegistration?.handler) {
+      if (!this.isToolAvailable(nativeRegistration.agentId)) {
+        return {
+          content: `Error: tool \`${name}\` is unavailable — plugin \`${nativeRegistration.agentId}\` has not completed its connection/auth setup.`,
+          isError: true,
+        };
+      }
       try {
         return { content: await nativeRegistration.handler(input) };
       } catch (error) {
@@ -73,6 +95,11 @@ export class ToolDispatchService {
       if (!registration.spec) {
         // Handler-only registrations remain dispatchable by name, but cannot be
         // advertised without a stable tool spec.
+        continue;
+      }
+      // Issue #474 — same gate as `dispatch()`; a not-yet-ready plugin's
+      // tools are excluded from the advertised list too.
+      if (!this.isToolAvailable(registration.agentId)) {
         continue;
       }
 

--- a/middleware/packages/harness-orchestrator/src/toolDispatchService.ts
+++ b/middleware/packages/harness-orchestrator/src/toolDispatchService.ts
@@ -78,6 +78,15 @@ export class ToolDispatchService {
 
     const domainTool = this.domainTools().find((t) => t.name === name);
     if (domainTool) {
+      // Issue #474 follow-up — same gate as the native-handler branch above;
+      // DomainTools carry an `agentId` too and were previously dispatchable
+      // through this bridge regardless of the owning plugin's readiness.
+      if (!this.isToolAvailable(domainTool.agentId)) {
+        return {
+          content: `Error: tool \`${name}\` is unavailable — plugin \`${domainTool.agentId}\` has not completed its connection/auth setup.`,
+          isError: true,
+        };
+      }
       try {
         return { content: await domainTool.handle(input) };
       } catch (error) {
@@ -113,6 +122,10 @@ export class ToolDispatchService {
     for (const tool of this.domainTools()) {
       // Native tools keep precedence on collisions to mirror dispatch order.
       if (advertised.has(tool.name)) {
+        continue;
+      }
+      // Issue #474 follow-up — same gate as the native-tool loop above.
+      if (!this.isToolAvailable(tool.agentId)) {
         continue;
       }
       advertised.set(tool.name, {

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -743,6 +743,20 @@ async function main(): Promise<void> {
     },
   );
 
+  // Issue #474 — per-plugin tool-readiness gate for the orchestrator. Reuses
+  // the existing, plugin-authored PluginStatusRegistry (spec 004): a plugin
+  // whose latest `ctx.status.report(...)` is `needs_action` / `error` has a
+  // required setup/connection step still pending, so its
+  // `ctx.tools.register()`-contributed tools must stay out of the
+  // orchestrator's tool list and refuse to execute until it reports back
+  // `ok` (or calls `ctx.status.clear()`). Deliberately separate from the
+  // MCP-server-specific auth flow (mcpOAuthService) — this only gates
+  // native-plugin tool registrations.
+  serviceRegistry.provide(
+    'installedPluginToolsReadyReader',
+    (agentId: string): boolean => pluginStatusRegistry.isReady(agentId),
+  );
+
   // Kernel-wide background-job scheduler. Plugin-contributed jobs (cron or
   // interval) register here via `ctx.jobs.register(...)`. Bulk teardown on
   // plugin deactivate is owned by each runtime, so a leaked dispose handle

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -252,6 +252,7 @@ import { installProcessGuards } from './platform/processGuards.js';
 import { PluginRouteRegistry } from './platform/pluginRouteRegistry.js';
 import { NotificationRouter } from './platform/notificationRouter.js';
 import { PluginStatusRegistry } from './platform/pluginStatusRegistry.js';
+import { OAuthReadinessTracker } from './plugins/oauth/oauthReadinessTracker.js';
 import { UiRouteCatalog } from './platform/uiRouteCatalog.js';
 import { CanvasOutputRegistry } from './platform/canvasOutputRegistry.js';
 import { EventCatalogRegistry } from './platform/eventCatalogRegistry.js';
@@ -438,6 +439,11 @@ async function main(): Promise<void> {
   // Spec 004 — kernel store of plugin action statuses (ctx.status). Read by the
   // admin API to surface "Aktion erforderlich" badges/banners in the store UI.
   const pluginStatusRegistry = new PluginStatusRegistry();
+
+  // Issue #474 (round 5) — automatic OAuth-connection readiness signal,
+  // separate from pluginStatusRegistry above. See OAuthReadinessTracker's
+  // doc comment for why the two stay separate caches ANDed at the gate.
+  const oauthConnectionTracker = new OAuthReadinessTracker();
 
   // Shared Anthropic client used by sub-agents (LocalSubAgent inner Claude
   // calls) and the Teams channel (anthropicClient dep). The orchestrator-
@@ -743,18 +749,28 @@ async function main(): Promise<void> {
     },
   );
 
-  // Issue #474 — per-plugin tool-readiness gate for the orchestrator. Reuses
-  // the existing, plugin-authored PluginStatusRegistry (spec 004): a plugin
-  // whose latest `ctx.status.report(...)` is `needs_action` / `error` has a
-  // required setup/connection step still pending, so its
-  // `ctx.tools.register()`-contributed tools must stay out of the
-  // orchestrator's tool list and refuse to execute until it reports back
-  // `ok` (or calls `ctx.status.clear()`). Deliberately separate from the
-  // MCP-server-specific auth flow (mcpOAuthService) — this only gates
-  // native-plugin tool registrations.
+  // Issue #474 — per-plugin tool-readiness gate for the orchestrator. Two
+  // independent signals are ANDed, either can withhold readiness:
+  //   (a) PluginStatusRegistry (spec 004) — the plugin's own, explicit
+  //       `ctx.status.report(...)`: `needs_action` / `error` means a
+  //       required setup/connection step is pending per the plugin's OWN
+  //       code.
+  //   (b) OAuthReadinessTracker (round 5) — automatic: a `type:'oauth'`
+  //       setup field whose Connect flow has not completed yet, derived
+  //       from the same vault state `ctx.oauthTokens` reads, WITHOUT
+  //       requiring the plugin author to write an explicit status.report()
+  //       call for the common OAuth case (installService.ts installs and
+  //       activates a `type:'oauth'` plugin — registering its tools —
+  //       before the operator has clicked Connect).
+  // Either "not ready" keeps the plugin's `ctx.tools.register()`-contributed
+  // tools out of the orchestrator's tool list and refuses them at dispatch.
+  // Deliberately separate from the MCP-server-specific auth flow
+  // (mcpOAuthService) — this only gates native-plugin tool registrations.
   serviceRegistry.provide(
     'installedPluginToolsReadyReader',
-    (agentId: string): boolean => pluginStatusRegistry.isReady(agentId),
+    (agentId: string): boolean =>
+      pluginStatusRegistry.isReady(agentId) &&
+      oauthConnectionTracker.isConnected(agentId),
   );
 
   // Kernel-wide background-job scheduler. Plugin-contributed jobs (cron or
@@ -799,6 +815,7 @@ async function main(): Promise<void> {
     flowSigningKey: sessionSigningKey,
     flowPublicBaseUrl,
     pluginStatusRegistry,
+    oauthConnectionTracker,
     canvasOutputRegistry,
     eventCatalogRegistry,
     deterministicActionRegistry,
@@ -871,6 +888,7 @@ async function main(): Promise<void> {
     flowSigningKey: sessionSigningKey,
     flowPublicBaseUrl,
     pluginStatusRegistry,
+    oauthConnectionTracker,
     selfExtendRegistry,
     extensionStore,
     eventCatalogRegistry,

--- a/middleware/src/platform/pluginContext.ts
+++ b/middleware/src/platform/pluginContext.ts
@@ -79,6 +79,7 @@ import {
   resolveOAuthProvider,
 } from '../plugins/oauth/providerResolve.js';
 import {
+  isTokenStillFresh,
   readStoredTokens,
   writeStoredTokens,
 } from '../plugins/oauth/tokenStore.js';
@@ -552,7 +553,10 @@ export function createPluginContext(
   // rotating the stored refresh token. The refresh token NEVER leaves this
   // closure — only the access token is returned. Resolution shares
   // `resolveOAuthProvider` with the broker so the two can't drift.
-  const REFRESH_MARGIN_MS = 5 * 60 * 1000;
+  //
+  // Issue #474 (round 10) — the "still fresh" check is factored out to
+  // `tokenStore.ts`'s `isTokenStillFresh` so `OAuthReadinessTracker` can
+  // mirror this exact expiry rule instead of inventing its own.
   const hasOAuthField =
     catalog
       .get(agentId)
@@ -567,11 +571,7 @@ export function createPluginContext(
               `oauth field '${fieldKey}' is not connected — complete the Connect flow first`,
             );
           }
-          const expiresMs = Date.parse(stored.expiresAt);
-          const stillFresh =
-            Number.isFinite(expiresMs) &&
-            expiresMs - Date.now() > REFRESH_MARGIN_MS;
-          if (stillFresh) return stored.accessToken;
+          if (isTokenStillFresh(stored)) return stored.accessToken;
 
           if (!stored.refreshToken) {
             throw new OAuthTokenError(

--- a/middleware/src/platform/pluginContext.ts
+++ b/middleware/src/platform/pluginContext.ts
@@ -443,8 +443,17 @@ export function createPluginContext(
       });
     },
     registerHandler(name, handler, options) {
+      // Issue #474 (round 8) — thread the calling plugin's agentId through
+      // this path exactly like `register()` above does, so a plugin that
+      // ships a handler-only tool (e.g. harness-memory's `memory` tool)
+      // flows through the same `isToolAvailable(agentId)` gate as every
+      // other plugin-contributed tool instead of defaulting to always
+      // -available. Kernel-internal callers never reach this shim (they
+      // call `nativeToolRegistry.registerHandler()` directly without an
+      // agentId), so this only ever attaches a real plugin's own id.
       return opts.nativeToolRegistry.registerHandler(name, {
         handler,
+        agentId,
         ...(options?.promptDoc !== undefined
           ? { promptDoc: options.promptDoc }
           : {}),

--- a/middleware/src/platform/pluginStatusRegistry.ts
+++ b/middleware/src/platform/pluginStatusRegistry.ts
@@ -34,8 +34,16 @@ export class PluginStatusRegistry {
    *  whether a plugin's `ctx.tools.register()`-contributed tools may be
    *  surfaced to and invoked by the orchestrator. A plugin that never calls
    *  `ctx.status.report(...)` at all (the common case — most plugins have no
-   *  connection step) is always ready. */
+   *  connection step) is always ready.
+   *
+   *  Checks the stored entry's `state` directly rather than only its
+   *  presence: `StatusAccessor.report()` in pluginContext.ts normalizes
+   *  `state: 'ok'` into `clear()` before it reaches `set()`, but `set()`
+   *  itself is public and does not enforce that normalization. Deciding
+   *  readiness from `state` keeps this correct even for a caller that
+   *  stores `{state: 'ok'}` directly via `set()`. */
   isReady(pluginId: string): boolean {
-    return this.statuses.get(pluginId) === undefined;
+    const entry = this.statuses.get(pluginId);
+    return !entry || (entry.state !== 'needs_action' && entry.state !== 'error');
   }
 }

--- a/middleware/src/platform/pluginStatusRegistry.ts
+++ b/middleware/src/platform/pluginStatusRegistry.ts
@@ -27,4 +27,15 @@ export class PluginStatusRegistry {
   get(pluginId: string): PluginActionStatus | undefined {
     return this.statuses.get(pluginId);
   }
+
+  /** Issue #474 — true when the plugin has no pending `needs_action` /
+   *  `error` status, i.e. its own `activate()`/auth-completion code has not
+   *  flagged a required setup/connection step as outstanding. Used to gate
+   *  whether a plugin's `ctx.tools.register()`-contributed tools may be
+   *  surfaced to and invoked by the orchestrator. A plugin that never calls
+   *  `ctx.status.report(...)` at all (the common case — most plugins have no
+   *  connection step) is always ready. */
+  isReady(pluginId: string): boolean {
+    return this.statuses.get(pluginId) === undefined;
+  }
 }

--- a/middleware/src/plugins/dynamicAgentRuntime.ts
+++ b/middleware/src/plugins/dynamicAgentRuntime.ts
@@ -23,6 +23,7 @@ import type { PluginStatusRegistry } from '../platform/pluginStatusRegistry.js';
 import type { UiRouteCatalog } from '../platform/uiRouteCatalog.js';
 import type { ServiceRegistry } from '../platform/serviceRegistry.js';
 import type { SecretVault } from '../secrets/vault.js';
+import type { OAuthReadinessTracker } from './oauth/oauthReadinessTracker.js';
 import type { NativeToolRegistry } from '@omadia/orchestrator';
 import {
   createCliSubAgent,
@@ -168,6 +169,11 @@ export interface DynamicAgentRuntimeDeps {
   flowPublicBaseUrl?: string;
   /** Spec 004 — backing store for `ctx.status`; cleared on deactivate. */
   pluginStatusRegistry?: PluginStatusRegistry;
+  /** Issue #474 (round 5) — automatic OAuth-connection readiness signal,
+   *  refreshed from the vault on every activate() and cleared on
+   *  deactivate(). Separate from `pluginStatusRegistry` — see
+   *  `OAuthReadinessTracker`'s doc comment for why. */
+  oauthConnectionTracker?: OAuthReadinessTracker;
   /** Canvas-output autodiscovery: manifest capability entries declaring
    *  `canvas_output: true` are resolved into this registry on (de)activation
    *  so the ui-orchestrator can derive its sentinel allow-set without
@@ -341,6 +347,20 @@ export class DynamicAgentRuntime {
     if (catalogEntry.plugin.is_reference_only === true) {
       throw new Error(
         `dynamic-runtime: cannot activate '${agentId}' — plugin is marked is_reference_only=true (Builder-Reference, read_reference-only)`,
+      );
+    }
+
+    // Issue #474 (round 5) — refresh the automatic OAuth-connection signal
+    // BEFORE the plugin's own activate() runs, so a plugin that separately
+    // calls `ctx.status.report(...)` inside activate() lays its own signal
+    // on top rather than this one overwriting it (the two are ANDed at the
+    // gate, not merged into one entry). No-op when the plugin declares no
+    // `type:'oauth'` field.
+    if (this.deps.oauthConnectionTracker) {
+      await this.deps.oauthConnectionTracker.refresh(
+        agentId,
+        catalogEntry,
+        this.deps.vault,
       );
     }
 
@@ -649,6 +669,7 @@ export class DynamicAgentRuntime {
     this.deps.jobScheduler.stopForPlugin(agentId);
     this.deps.uiRouteCatalog.disposeBySource(agentId);
     this.deps.pluginStatusRegistry?.clear(agentId);
+    this.deps.oauthConnectionTracker?.clear(agentId);
     this.active.delete(agentId);
     log(`[dynamic-runtime] DEACTIVATED ${agentId}`);
     return true;

--- a/middleware/src/plugins/oauth/index.ts
+++ b/middleware/src/plugins/oauth/index.ts
@@ -54,3 +54,5 @@ export {
   resolveOAuthProvider,
   type ResolvedOAuthProvider,
 } from './providerResolve.js';
+
+export { OAuthReadinessTracker } from './oauthReadinessTracker.js';

--- a/middleware/src/plugins/oauth/oauthReadinessTracker.ts
+++ b/middleware/src/plugins/oauth/oauthReadinessTracker.ts
@@ -1,0 +1,81 @@
+import type { PluginCatalogEntry } from '../manifestLoader.js';
+import type { SecretVault } from '../../secrets/vault.js';
+import { readStoredTokens } from './tokenStore.js';
+
+/**
+ * Issue #474 (review round 5) — automatic OAuth-connection readiness signal.
+ *
+ * `PluginStatusRegistry` only gates a plugin's tools when the PLUGIN's own
+ * code calls `ctx.status.report(...)`. The generic install/Connect flow
+ * never does this automatically: a `type:'oauth'` plugin's `activate()` runs
+ * — and its `ctx.tools.register(...)`-contributed tools are recorded —
+ * the moment `configure()` completes, which is BEFORE the operator has
+ * clicked "Connect" and the kernel OAuth broker has stored any tokens
+ * (`installService.ts`'s `validateValues` skips `type:'oauth'` fields
+ * entirely at configure time — spec 005). Without this tracker, an
+ * uncompleted OAuth plugin's tools are offered to the model and the first
+ * call fails with `OAuthTokenError('not_connected')` — exactly the
+ * round-trip issue #474 was filed to eliminate, for a plugin author who
+ * never wrote an explicit `ctx.status.report(...)` call.
+ *
+ * Deliberately a SEPARATE cache from `PluginStatusRegistry`, not a write
+ * into it: the composed gate (`installedPluginToolsReadyReader` in
+ * index.ts) reads both signals independently and requires both to say
+ * "ready". Keeping them separate means neither can silently clobber the
+ * other — a plugin's own `ctx.status.report({state: 'ok'})` must not be
+ * able to hide a real "not connected" state, and a connected OAuth field
+ * must not clear an explicit `error`/`needs_action` the plugin reported for
+ * an unrelated reason.
+ *
+ * Synchronous cache, like `PluginStatusRegistry`: the readiness gate is
+ * consulted synchronously on every tool-list build / dispatch, but OAuth
+ * connection state lives in the (async) vault. `refresh()` re-derives the
+ * cached value from the vault and is called once per plugin activation —
+ * the single choke point shared by fresh install, boot-time reactivation,
+ * and post-Connect reactivation (`ToolPluginRuntime.activate` /
+ * `DynamicAgentRuntime.activate`) — so the cache self-heals on every
+ * activation, including a restart.
+ */
+export class OAuthReadinessTracker {
+  private readonly disconnected = new Set<string>();
+
+  /** Re-derive `pluginId`'s connection state from the vault and cache the
+   *  result. Connected (cache cleared) when the plugin declares no
+   *  `type:'oauth'` setup field, or when every declared oauth field has
+   *  stored tokens; not-connected otherwise. */
+  async refresh(
+    pluginId: string,
+    entry: PluginCatalogEntry | undefined,
+    vault: SecretVault,
+  ): Promise<void> {
+    const fieldKeys = (entry?.plugin.setup_fields ?? [])
+      .filter((field) => field.type === 'oauth')
+      .map((field) => field.key);
+    if (fieldKeys.length === 0) {
+      this.disconnected.delete(pluginId);
+      return;
+    }
+    const stored = await Promise.all(
+      fieldKeys.map((fieldKey) => readStoredTokens(vault, pluginId, fieldKey)),
+    );
+    const allConnected = stored.every((tokens) => tokens !== undefined);
+    if (allConnected) {
+      this.disconnected.delete(pluginId);
+    } else {
+      this.disconnected.add(pluginId);
+    }
+  }
+
+  /** Drop any cached state for `pluginId` — called on deactivate so an
+   *  uninstalled/torn-down plugin leaves no stale signal behind (mirrors
+   *  `PluginStatusRegistry.clear`). */
+  clear(pluginId: string): void {
+    this.disconnected.delete(pluginId);
+  }
+
+  /** True unless `pluginId` declares a `type:'oauth'` setup field that has
+   *  not completed the Connect flow yet. */
+  isConnected(pluginId: string): boolean {
+    return !this.disconnected.has(pluginId);
+  }
+}

--- a/middleware/src/plugins/oauth/oauthReadinessTracker.ts
+++ b/middleware/src/plugins/oauth/oauthReadinessTracker.ts
@@ -1,6 +1,10 @@
 import type { PluginCatalogEntry } from '../manifestLoader.js';
 import type { SecretVault } from '../../secrets/vault.js';
-import { isTokenRefreshable, readStoredTokens } from './tokenStore.js';
+import {
+  isTokenRefreshable,
+  readStoredTokens,
+  type StoredOAuthTokens,
+} from './tokenStore.js';
 
 /**
  * Issue #474 (review round 5) — automatic OAuth-connection readiness signal.
@@ -27,29 +31,45 @@ import { isTokenRefreshable, readStoredTokens } from './tokenStore.js';
  * must not clear an explicit `error`/`needs_action` the plugin reported for
  * an unrelated reason.
  *
- * Synchronous cache, like `PluginStatusRegistry`: the readiness gate is
+ * Semi-synchronous cache, like `PluginStatusRegistry`: the readiness gate is
  * consulted synchronously on every tool-list build / dispatch, but OAuth
- * connection state lives in the (async) vault. `refresh()` re-derives the
- * cached value from the vault and is called once per plugin activation —
- * the single choke point shared by fresh install, boot-time reactivation,
- * and post-Connect reactivation (`ToolPluginRuntime.activate` /
- * `DynamicAgentRuntime.activate`) — so the cache self-heals on every
- * activation, including a restart.
+ * connection state lives in the (async) vault. `refresh()` re-reads the
+ * vault and is called once per plugin activation — the single choke point
+ * shared by fresh install, boot-time reactivation, and post-Connect
+ * reactivation (`ToolPluginRuntime.activate` / `DynamicAgentRuntime.activate`)
+ * — so the cached RAW token data self-heals on every activation, including a
+ * restart.
+ *
+ * Issue #474 (review round 12) — `refresh()` caches the vault I/O result
+ * (genuinely async, so it must stay activation-triggered), but it must NOT
+ * additionally cache a pre-computed "is it fresh" boolean: freshness is a
+ * function of wall-clock time, which keeps moving between activations. A
+ * plugin that activates with, say, 10 minutes of token freshness left and no
+ * refresh token would otherwise read as connected for the tracker's entire
+ * lifetime, even 6 minutes later when `ctx.oauthTokens.get()` has crossed
+ * `OAUTH_REFRESH_MARGIN_MS` and started throwing `OAuthTokenError
+ * ('refresh_failed')` — exactly the wasted round-trip #474 exists to
+ * prevent, just deferred from activation time to a few minutes later. So
+ * `refresh()` stores the raw `StoredOAuthTokens` per declared oauth field,
+ * and `isConnected()` recomputes `isTokenRefreshable()` (which itself calls
+ * `isTokenStillFresh()` against `Date.now()`) fresh on every call — mirroring
+ * how `ctx.oauthTokens.get()` itself never caches a verdict either. Both
+ * helpers are pure and synchronous (no I/O), so recomputing per read is
+ * cheap.
  */
 export class OAuthReadinessTracker {
-  private readonly disconnected = new Set<string>();
+  /** Raw per-field token data from the last `refresh()`, keyed by plugin id.
+   *  `undefined` for a field means no tokens are stored for it yet (Connect
+   *  never completed). Absent from the map entirely means the plugin
+   *  declares no `type:'oauth'` setup field (always connected) or was never
+   *  activated. */
+  private readonly fieldTokens = new Map<
+    string,
+    Array<StoredOAuthTokens | undefined>
+  >();
 
-  /** Re-derive `pluginId`'s connection state from the vault and cache the
-   *  result. Connected (cache cleared) when the plugin declares no
-   *  `type:'oauth'` setup field, or when every declared oauth field has
-   *  stored tokens that are either still fresh or expired-with-a-refresh-
-   *  token (mirroring `ctx.oauthTokens.get()`'s own refreshability check via
-   *  `isTokenRefreshable` — see tokenStore.ts); not-connected otherwise.
-   *
-   *  Issue #474 (review round 10) — a token bundle existing in the vault is
-   *  NOT enough: `ctx.oauthTokens.get()` throws `OAuthTokenError
-   *  ('refresh_failed')` for an expired token with no refresh token to renew
-   *  it, so a plugin in that state must not be reported ready either. */
+  /** Re-read `pluginId`'s declared oauth fields from the vault and cache the
+   *  raw token bundles (not a pre-computed verdict — see class doc). */
   async refresh(
     pluginId: string,
     entry: PluginCatalogEntry | undefined,
@@ -59,32 +79,32 @@ export class OAuthReadinessTracker {
       .filter((field) => field.type === 'oauth')
       .map((field) => field.key);
     if (fieldKeys.length === 0) {
-      this.disconnected.delete(pluginId);
+      this.fieldTokens.delete(pluginId);
       return;
     }
     const stored = await Promise.all(
       fieldKeys.map((fieldKey) => readStoredTokens(vault, pluginId, fieldKey)),
     );
-    const allUsable = stored.every(
-      (tokens) => tokens !== undefined && isTokenRefreshable(tokens),
-    );
-    if (allUsable) {
-      this.disconnected.delete(pluginId);
-    } else {
-      this.disconnected.add(pluginId);
-    }
+    this.fieldTokens.set(pluginId, stored);
   }
 
   /** Drop any cached state for `pluginId` — called on deactivate so an
    *  uninstalled/torn-down plugin leaves no stale signal behind (mirrors
    *  `PluginStatusRegistry.clear`). */
   clear(pluginId: string): void {
-    this.disconnected.delete(pluginId);
+    this.fieldTokens.delete(pluginId);
   }
 
-  /** True unless `pluginId` declares a `type:'oauth'` setup field that has
-   *  not completed the Connect flow yet. */
+  /** True unless `pluginId` declares a `type:'oauth'` setup field whose
+   *  stored tokens are, AS OF THIS CALL, either missing or not usable
+   *  (mirroring `ctx.oauthTokens.get()`'s own refreshability check via
+   *  `isTokenRefreshable` — see tokenStore.ts). Recomputed against the
+   *  current wall clock on every call — see class doc for why. */
   isConnected(pluginId: string): boolean {
-    return !this.disconnected.has(pluginId);
+    const stored = this.fieldTokens.get(pluginId);
+    if (stored === undefined) return true;
+    return stored.every(
+      (tokens) => tokens !== undefined && isTokenRefreshable(tokens),
+    );
   }
 }

--- a/middleware/src/plugins/oauth/oauthReadinessTracker.ts
+++ b/middleware/src/plugins/oauth/oauthReadinessTracker.ts
@@ -1,6 +1,6 @@
 import type { PluginCatalogEntry } from '../manifestLoader.js';
 import type { SecretVault } from '../../secrets/vault.js';
-import { readStoredTokens } from './tokenStore.js';
+import { isTokenRefreshable, readStoredTokens } from './tokenStore.js';
 
 /**
  * Issue #474 (review round 5) — automatic OAuth-connection readiness signal.
@@ -42,7 +42,14 @@ export class OAuthReadinessTracker {
   /** Re-derive `pluginId`'s connection state from the vault and cache the
    *  result. Connected (cache cleared) when the plugin declares no
    *  `type:'oauth'` setup field, or when every declared oauth field has
-   *  stored tokens; not-connected otherwise. */
+   *  stored tokens that are either still fresh or expired-with-a-refresh-
+   *  token (mirroring `ctx.oauthTokens.get()`'s own refreshability check via
+   *  `isTokenRefreshable` — see tokenStore.ts); not-connected otherwise.
+   *
+   *  Issue #474 (review round 10) — a token bundle existing in the vault is
+   *  NOT enough: `ctx.oauthTokens.get()` throws `OAuthTokenError
+   *  ('refresh_failed')` for an expired token with no refresh token to renew
+   *  it, so a plugin in that state must not be reported ready either. */
   async refresh(
     pluginId: string,
     entry: PluginCatalogEntry | undefined,
@@ -58,8 +65,10 @@ export class OAuthReadinessTracker {
     const stored = await Promise.all(
       fieldKeys.map((fieldKey) => readStoredTokens(vault, pluginId, fieldKey)),
     );
-    const allConnected = stored.every((tokens) => tokens !== undefined);
-    if (allConnected) {
+    const allUsable = stored.every(
+      (tokens) => tokens !== undefined && isTokenRefreshable(tokens),
+    );
+    if (allUsable) {
       this.disconnected.delete(pluginId);
     } else {
       this.disconnected.add(pluginId);

--- a/middleware/src/plugins/oauth/tokenStore.ts
+++ b/middleware/src/plugins/oauth/tokenStore.ts
@@ -28,6 +28,42 @@ export function oauthVaultKey(fieldKey: string): string {
   return `oauth.${fieldKey}`;
 }
 
+/**
+ * Issue #474 (review round 10) — the refresh margin `ctx.oauthTokens.get()`
+ * (pluginContext.ts) uses to decide whether a stored access token still
+ * needs renewing. Exported so `isTokenRefreshable` below can mirror the
+ * exact same "expired" definition instead of inventing a second one that
+ * could drift from the real consumer's behaviour.
+ */
+export const OAUTH_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+
+/** True when `stored`'s access token has more than the refresh margin left
+ *  before `expiresAt` (an unparseable/missing `expiresAt` counts as NOT
+ *  fresh). Shared by pluginContext.ts's `ctx.oauthTokens.get()` (refreshes
+ *  when this is false) and `OAuthReadinessTracker` (treats "not fresh AND no
+ *  refresh token" as not-ready) so the two can never disagree on what counts
+ *  as expired. */
+export function isTokenStillFresh(
+  stored: Pick<StoredOAuthTokens, 'expiresAt'>,
+): boolean {
+  const expiresMs = Date.parse(stored.expiresAt);
+  return (
+    Number.isFinite(expiresMs) && expiresMs - Date.now() > OAUTH_REFRESH_MARGIN_MS
+  );
+}
+
+/**
+ * Issue #474 (review round 10) — true when `stored` can currently produce a
+ * usable access token: either it's still fresh, or it's expired but has a
+ * refresh token to renew it with (a refresh is expected to succeed
+ * transparently). False only when it's expired/unparseable AND has no
+ * refresh token — the exact case where `ctx.oauthTokens.get()` throws
+ * `OAuthTokenError('refresh_failed')` with no way to recover automatically.
+ */
+export function isTokenRefreshable(stored: StoredOAuthTokens): boolean {
+  return isTokenStillFresh(stored) || stored.refreshToken !== '';
+}
+
 export async function writeStoredTokens(
   vault: SecretVault,
   pluginId: string,

--- a/middleware/src/plugins/toolPluginRuntime.ts
+++ b/middleware/src/plugins/toolPluginRuntime.ts
@@ -10,6 +10,7 @@ import type { PluginStatusRegistry } from '../platform/pluginStatusRegistry.js';
 import type { UiRouteCatalog } from '../platform/uiRouteCatalog.js';
 import type { ServiceRegistry } from '../platform/serviceRegistry.js';
 import type { SecretVault } from '../secrets/vault.js';
+import type { OAuthReadinessTracker } from './oauth/oauthReadinessTracker.js';
 import type { NativeToolRegistry } from '@omadia/orchestrator';
 import type { ApprovedExtension, ExtensionTemplate } from '@omadia/plugin-api';
 import type { BuiltInPackageStore } from './builtInPackageStore.js';
@@ -87,6 +88,11 @@ export interface ToolPluginRuntimeDeps {
   flowPublicBaseUrl?: string;
   /** Spec 004 — backing store for `ctx.status`; cleared on deactivate. */
   pluginStatusRegistry?: PluginStatusRegistry;
+  /** Issue #474 (round 5) — automatic OAuth-connection readiness signal,
+   *  refreshed from the vault on every activate() and cleared on
+   *  deactivate(). Separate from `pluginStatusRegistry` — see
+   *  `OAuthReadinessTracker`'s doc comment for why. */
+  oauthConnectionTracker?: OAuthReadinessTracker;
   /** Event-catalog autodiscovery (US4 Conductor Surface): capability entries declaring
    *  `event_emit: true` are resolved into this registry on (de)activation. This runtime is the
    *  ONLY resolve site for built-in/static tool plugins (landmine K — the dynamic runtime has its
@@ -225,6 +231,20 @@ export class ToolPluginRuntime {
     const catalogEntry = this.deps.catalog.get(agentId);
     if (!catalogEntry) {
       throw new Error(`tool-runtime: ${agentId} not in plugin catalog`);
+    }
+
+    // Issue #474 (round 5) — refresh the automatic OAuth-connection signal
+    // BEFORE the plugin's own activate() runs, so a plugin that separately
+    // calls `ctx.status.report(...)` inside activate() lays its own signal
+    // on top rather than this one overwriting it (the two are ANDed at the
+    // gate, not merged into one entry). No-op when the plugin declares no
+    // `type:'oauth'` field.
+    if (this.deps.oauthConnectionTracker) {
+      await this.deps.oauthConnectionTracker.refresh(
+        agentId,
+        catalogEntry,
+        this.deps.vault,
+      );
     }
 
     const entryRel = extractEntryPath(catalogEntry) ?? 'dist/plugin.js';
@@ -366,6 +386,7 @@ export class ToolPluginRuntime {
     this.deps.jobScheduler.stopForPlugin(agentId);
     this.deps.uiRouteCatalog.disposeBySource(agentId);
     this.deps.pluginStatusRegistry?.clear(agentId);
+    this.deps.oauthConnectionTracker?.clear(agentId);
     this.active.delete(agentId);
 
     if (this.deps.onDeactivated) {

--- a/middleware/test/cliBridge/toolDispatchService.test.ts
+++ b/middleware/test/cliBridge/toolDispatchService.test.ts
@@ -190,6 +190,63 @@ describe('ToolDispatchService', () => {
     assert.equal(specs[1]?.description, 'native shared');
   });
 
+  it('issue #474: refuses to dispatch a not-ready plugin tool and excludes it from the list', async () => {
+    const nativeTools = new NativeToolRegistry();
+    let handlerCalled = false;
+    nativeTools.register('gated_tool', {
+      handler: async () => {
+        handlerCalled = true;
+        return 'should never run';
+      },
+      spec: {
+        name: 'gated_tool',
+        description: 'gated',
+        input_schema: { type: 'object', properties: {} },
+      },
+      domain: 'test.x',
+      agentId: 'gated-plugin',
+    });
+
+    const service = new ToolDispatchService({
+      nativeTools,
+      domainTools: [],
+      isPluginToolsReady: (agentId) => agentId !== 'gated-plugin',
+    });
+
+    const result = await service.dispatch('gated_tool', {});
+    assert.equal(handlerCalled, false);
+    assert.equal(result.isError, true);
+    assert.match(result.content, /gated_tool/);
+
+    assert.deepEqual(
+      service.listDispatchableToolSpecs().map((s) => s.name),
+      [],
+    );
+  });
+
+  it('issue #474: still dispatches every tool when isPluginToolsReady is not wired', async () => {
+    const nativeTools = new NativeToolRegistry();
+    nativeTools.register('plain_tool', {
+      handler: async () => 'ok',
+      spec: {
+        name: 'plain_tool',
+        description: 'plain',
+        input_schema: { type: 'object', properties: {} },
+      },
+      domain: 'test.x',
+      agentId: 'some-plugin',
+    });
+
+    const service = new ToolDispatchService({ nativeTools, domainTools: [] });
+    const result = await service.dispatch('plain_tool', {});
+    assert.equal(result.content, 'ok');
+    assert.equal(result.isError, undefined);
+    assert.deepEqual(
+      service.listDispatchableToolSpecs().map((s) => s.name),
+      ['plain_tool'],
+    );
+  });
+
   it('does not advertise handler-only native entries but still dispatches them', async () => {
     const nativeTools = new NativeToolRegistry();
     nativeTools.registerHandler('mem', {

--- a/middleware/test/cliBridge/toolDispatchService.test.ts
+++ b/middleware/test/cliBridge/toolDispatchService.test.ts
@@ -224,6 +224,41 @@ describe('ToolDispatchService', () => {
     );
   });
 
+  it('issue #474 follow-up: refuses to dispatch a not-ready plugin domain tool and excludes it from the list', async () => {
+    const nativeTools = new NativeToolRegistry();
+    let handlerCalled = false;
+    const gatedDomainTool: DomainTool = {
+      name: 'query_gated',
+      spec: {
+        name: 'query_gated',
+        description: 'gated domain tool',
+        input_schema: { type: 'object', properties: {} },
+      },
+      domain: 'test.domain',
+      agentId: 'gated-plugin',
+      async handle() {
+        handlerCalled = true;
+        return 'should never run';
+      },
+    };
+
+    const service = new ToolDispatchService({
+      nativeTools,
+      domainTools: [gatedDomainTool],
+      isPluginToolsReady: (agentId) => agentId !== 'gated-plugin',
+    });
+
+    const result = await service.dispatch('query_gated', {});
+    assert.equal(handlerCalled, false);
+    assert.equal(result.isError, true);
+    assert.match(result.content, /query_gated/);
+
+    assert.deepEqual(
+      service.listDispatchableToolSpecs().map((s) => s.name),
+      [],
+    );
+  });
+
   it('issue #474: still dispatches every tool when isPluginToolsReady is not wired', async () => {
     const nativeTools = new NativeToolRegistry();
     nativeTools.register('plain_tool', {

--- a/middleware/test/oauth/oauthReadinessTracker.test.ts
+++ b/middleware/test/oauth/oauthReadinessTracker.test.ts
@@ -223,4 +223,58 @@ describe('OAuthReadinessTracker', () => {
 
     assert.equal(tracker.isConnected(ID), true);
   });
+
+  /**
+   * Issue #474 (review round 12) — `isConnected()` must re-evaluate
+   * freshness against the CURRENT wall clock on every call, not read a
+   * boolean verdict computed once inside `refresh()`. Concrete failing
+   * input the review gave: a token with 10 minutes of freshness left and no
+   * refresh token activates (caches "ready"); 6 minutes later — no new
+   * activate()/refresh() call — the token is inside `ctx.oauthTokens.get()`'s
+   * 5-minute refresh margin, where a real call would throw
+   * `OAuthTokenError('refresh_failed')`. A purely activation-cached boolean
+   * would still report ready for that entire window; this test proves the
+   * tracker doesn't. Uses `t.mock.timers` (already the repo convention — see
+   * office.test.ts) instead of a real sleep so the assertion is
+   * deterministic.
+   */
+  it('isConnected() flips to false once the cached token crosses into its refresh margin — WITHOUT a new refresh() call', async (t) => {
+    t.mock.timers.enable({ apis: ['Date'], now: Date.now() });
+    try {
+      const tracker = new OAuthReadinessTracker();
+      const entry = entryWithFields([
+        { key: 'connection', type: 'oauth', label: 'Connect', provider: 'github' },
+      ]);
+      const vault = new FakeVault();
+      // 10 minutes of freshness left, no refresh token — exactly the review's
+      // concrete failing input.
+      await writeStoredTokens(vault, ID, 'connection', {
+        accessToken: 'tok',
+        refreshToken: '',
+        expiresAt: new Date(Date.now() + 10 * 60_000).toISOString(),
+        scope: '',
+      });
+
+      // Single activation — mirrors ToolPluginRuntime/DynamicAgentRuntime's
+      // activate() calling refresh() once.
+      await tracker.refresh(ID, entry, vault);
+      assert.equal(
+        tracker.isConnected(ID),
+        true,
+        'ready immediately after activation, 10 minutes of freshness left',
+      );
+
+      // Advance the clock 6 minutes — now inside tokenStore.ts's 5-minute
+      // OAUTH_REFRESH_MARGIN_MS — WITHOUT calling refresh() again.
+      t.mock.timers.tick(6 * 60_000);
+
+      assert.equal(
+        tracker.isConnected(ID),
+        false,
+        'must recompute freshness at read time, not serve the activation-time verdict',
+      );
+    } finally {
+      t.mock.timers.reset();
+    }
+  });
 });

--- a/middleware/test/oauth/oauthReadinessTracker.test.ts
+++ b/middleware/test/oauth/oauthReadinessTracker.test.ts
@@ -160,4 +160,67 @@ describe('OAuthReadinessTracker', () => {
 
     assert.equal(tracker.isConnected(ID), true);
   });
+
+  /**
+   * Issue #474 (review round 10) — `refresh()` previously treated
+   * `tokens !== undefined` alone as "connected", i.e. it only checked that
+   * SOME token bundle was stored, not that it was actually usable.
+   * `ctx.oauthTokens.get()` (pluginContext.ts) throws
+   * `OAuthTokenError('refresh_failed')` for an expired token with no refresh
+   * token — that plugin's tool must not be reported ready either.
+   */
+  it('marks a plugin with an expired, non-refreshable token as NOT ready', async () => {
+    const tracker = new OAuthReadinessTracker();
+    const entry = entryWithFields([
+      { key: 'connection', type: 'oauth', label: 'Connect', provider: 'github' },
+    ]);
+    const vault = new FakeVault();
+    // Concrete failing input from the review: expired, empty refresh token.
+    await writeStoredTokens(vault, ID, 'connection', {
+      accessToken: 'old',
+      refreshToken: '',
+      expiresAt: '2020-01-01T00:00:00.000Z',
+      scope: '',
+    });
+
+    await tracker.refresh(ID, entry, vault);
+
+    assert.equal(tracker.isConnected(ID), false);
+  });
+
+  it('keeps a plugin with an expired BUT refreshable token ready (refresh is expected to succeed transparently)', async () => {
+    const tracker = new OAuthReadinessTracker();
+    const entry = entryWithFields([
+      { key: 'connection', type: 'oauth', label: 'Connect', provider: 'github' },
+    ]);
+    const vault = new FakeVault();
+    await writeStoredTokens(vault, ID, 'connection', {
+      accessToken: 'old',
+      refreshToken: 'has-a-refresh-token',
+      expiresAt: '2020-01-01T00:00:00.000Z',
+      scope: '',
+    });
+
+    await tracker.refresh(ID, entry, vault);
+
+    assert.equal(tracker.isConnected(ID), true);
+  });
+
+  it('keeps a plugin with a valid, unexpired token ready', async () => {
+    const tracker = new OAuthReadinessTracker();
+    const entry = entryWithFields([
+      { key: 'connection', type: 'oauth', label: 'Connect', provider: 'github' },
+    ]);
+    const vault = new FakeVault();
+    await writeStoredTokens(vault, ID, 'connection', {
+      accessToken: 'fresh',
+      refreshToken: '',
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      scope: '',
+    });
+
+    await tracker.refresh(ID, entry, vault);
+
+    assert.equal(tracker.isConnected(ID), true);
+  });
 });

--- a/middleware/test/oauth/oauthReadinessTracker.test.ts
+++ b/middleware/test/oauth/oauthReadinessTracker.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Issue #474 (review round 5) — OAuthReadinessTracker.refresh() derives
+ * automatic OAuth-connection readiness from the vault, mirroring what
+ * `ctx.oauthTokens.get()` (pluginContext.ts) already reads, without
+ * requiring the plugin to call `ctx.status.report(...)` itself.
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { adaptManifestV1 } from '../../src/plugins/manifestLoader.js';
+import type { PluginCatalogEntry } from '../../src/plugins/manifestLoader.js';
+import { OAuthReadinessTracker } from '../../src/plugins/oauth/oauthReadinessTracker.js';
+import { writeStoredTokens } from '../../src/plugins/oauth/tokenStore.js';
+import type { SecretVault } from '../../src/secrets/vault.js';
+
+const ID = '@test/oauth-readiness';
+
+class FakeVault implements SecretVault {
+  readonly store = new Map<string, string>();
+  async get(agentId: string, key: string): Promise<string | undefined> {
+    return this.store.get(`${agentId}::${key}`);
+  }
+  async set(agentId: string, key: string, value: string): Promise<void> {
+    this.store.set(`${agentId}::${key}`, value);
+  }
+  async setMany(agentId: string, entries: Record<string, string>): Promise<void> {
+    for (const [k, v] of Object.entries(entries)) await this.set(agentId, k, v);
+  }
+  async listKeys(): Promise<string[]> {
+    return [];
+  }
+  async purge(): Promise<void> {}
+  async deleteKey(agentId: string, key: string): Promise<void> {
+    this.store.delete(`${agentId}::${key}`);
+  }
+}
+
+function entryWithFields(fields: Array<Record<string, unknown>>): PluginCatalogEntry {
+  const plugin = adaptManifestV1({
+    schema_version: '1',
+    identity: {
+      id: ID,
+      kind: 'tool',
+      domain: 'test',
+      name: 'OAuth Readiness Test Plugin',
+      version: '0.1.0',
+    },
+    setup: { fields },
+  })!;
+  return { plugin, manifest: {}, source_path: '/dev/null', source_kind: 'manifest-v1' };
+}
+
+describe('OAuthReadinessTracker', () => {
+  it('stays connected for a plugin with no oauth field', async () => {
+    const tracker = new OAuthReadinessTracker();
+    const entry = entryWithFields([
+      { key: 'api_key', type: 'secret', label: 'API Key' },
+    ]);
+    const vault = new FakeVault();
+
+    await tracker.refresh(ID, entry, vault);
+
+    assert.equal(tracker.isConnected(ID), true);
+  });
+
+  it('marks a plugin with an unconnected oauth field as not-ready', async () => {
+    const tracker = new OAuthReadinessTracker();
+    const entry = entryWithFields([
+      { key: 'connection', type: 'oauth', label: 'Connect', provider: 'github' },
+    ]);
+    const vault = new FakeVault();
+
+    // No tokens ever written — mirrors the exact repro: install completes,
+    // activate() runs and registers tools, but Connect was never clicked.
+    await tracker.refresh(ID, entry, vault);
+
+    assert.equal(tracker.isConnected(ID), false);
+  });
+
+  it('marks a plugin ready once its oauth field has stored tokens', async () => {
+    const tracker = new OAuthReadinessTracker();
+    const entry = entryWithFields([
+      { key: 'connection', type: 'oauth', label: 'Connect', provider: 'github' },
+    ]);
+    const vault = new FakeVault();
+    await writeStoredTokens(vault, ID, 'connection', {
+      accessToken: 'tok',
+      refreshToken: '',
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      scope: '',
+    });
+
+    await tracker.refresh(ID, entry, vault);
+
+    assert.equal(tracker.isConnected(ID), true);
+  });
+
+  it('requires EVERY declared oauth field to be connected', async () => {
+    const tracker = new OAuthReadinessTracker();
+    const entry = entryWithFields([
+      { key: 'primary', type: 'oauth', label: 'Primary', provider: 'github' },
+      { key: 'secondary', type: 'oauth', label: 'Secondary', provider: 'slack' },
+    ]);
+    const vault = new FakeVault();
+    await writeStoredTokens(vault, ID, 'primary', {
+      accessToken: 'tok',
+      refreshToken: '',
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      scope: '',
+    });
+    // 'secondary' never connected.
+
+    await tracker.refresh(ID, entry, vault);
+
+    assert.equal(tracker.isConnected(ID), false);
+  });
+
+  it('re-derives on every refresh (self-heals after Connect completes)', async () => {
+    const tracker = new OAuthReadinessTracker();
+    const entry = entryWithFields([
+      { key: 'connection', type: 'oauth', label: 'Connect', provider: 'github' },
+    ]);
+    const vault = new FakeVault();
+
+    await tracker.refresh(ID, entry, vault);
+    assert.equal(tracker.isConnected(ID), false);
+
+    // Simulate the Connect flow completing, then the post-callback
+    // reactivate() re-running activate() → refresh().
+    await writeStoredTokens(vault, ID, 'connection', {
+      accessToken: 'tok',
+      refreshToken: '',
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      scope: '',
+    });
+    await tracker.refresh(ID, entry, vault);
+
+    assert.equal(tracker.isConnected(ID), true);
+  });
+
+  it('clear() resets a plugin back to connected', async () => {
+    const tracker = new OAuthReadinessTracker();
+    const entry = entryWithFields([
+      { key: 'connection', type: 'oauth', label: 'Connect', provider: 'github' },
+    ]);
+    const vault = new FakeVault();
+    await tracker.refresh(ID, entry, vault);
+    assert.equal(tracker.isConnected(ID), false);
+
+    tracker.clear(ID);
+
+    assert.equal(tracker.isConnected(ID), true);
+  });
+
+  it('treats an unknown plugin (no catalog entry) as connected — nothing to gate', async () => {
+    const tracker = new OAuthReadinessTracker();
+    const vault = new FakeVault();
+
+    await tracker.refresh(ID, undefined, vault);
+
+    assert.equal(tracker.isConnected(ID), true);
+  });
+});

--- a/middleware/test/orchestrator/directLine.test.ts
+++ b/middleware/test/orchestrator/directLine.test.ts
@@ -408,6 +408,31 @@ describe('#332 Layer 2 — Direct Line (strict passthrough, non-streaming/Teams)
     assert.equal(sa.text, 'normal LLM answer'); // handled by the LLM, not hijacked
   });
 
+  it('issue #474 round-4 fix — a NOT-READY plugin\'s token surfaces the "no longer available" notice, never a raw dispatch-error string', async () => {
+    let asked = false;
+    const tool = strategistTool(async () => {
+      asked = true;
+      return 'should not run';
+    });
+    const orch = new Orchestrator({
+      provider: neverCalledProvider(),
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [tool],
+      nativeToolRegistry: new NativeToolRegistry(),
+      isPluginToolsReady: (agentId) => agentId !== 'de.byte5.agent.strategist',
+    });
+    const sa = await orch.chat({
+      userMessage: '#strategist What are three risks in plan A?',
+      sessionScope: 's2c',
+    });
+    assert.equal(asked, false, 'the not-ready tool must never be invoked');
+    assert.equal(sa.delegatedAnswer, undefined);
+    assert.doesNotMatch(sa.text, /^Error:/);
+    assert.match(sa.text, /no longer available/i);
+  });
+
   it('an AMBIGUOUS token disambiguates, never a silent wrong route', async () => {
     const a = createDomainTool({
       name: 'ask_twin_a',

--- a/middleware/test/orchestrator/directLine.test.ts
+++ b/middleware/test/orchestrator/directLine.test.ts
@@ -687,6 +687,28 @@ describe('#332 gap-closure — standing requiredConsultToolName (L3 real produce
     assert.equal(sa.text, 'plain answer');
   });
 
+  it('issue #474 round-3 fix — a standing obligation for a not-ready plugin domain tool is ignored (never forces tool_choice onto a tool excluded from tools[])', async () => {
+    let asked = false;
+    const tool = strategistTool(async () => {
+      asked = true;
+      return 'x';
+    });
+    const { provider } = scriptedCompleteProvider([textResponse('plain answer')]);
+    const orch = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 6,
+      domainTools: [tool],
+      nativeToolRegistry: new NativeToolRegistry(),
+      requiredConsultToolName: 'ask_strategist',
+      isPluginToolsReady: (agentId) => agentId !== 'de.byte5.agent.strategist',
+    });
+    const sa = await orch.chat({ userMessage: 'hello', sessionScope: 's7-gated' });
+    assert.equal(asked, false, 'the not-ready tool must never be forced/invoked');
+    assert.equal(sa.text, 'plain answer');
+  });
+
   it('a per-turn expectedDomainTool overrides the standing requiredConsultToolName', async () => {
     const captured: { strategist?: string; twin?: string } = {};
     const strategist = strategistTool(async (q) => {

--- a/middleware/test/orchestrator/pluginToolsReadyGate.test.ts
+++ b/middleware/test/orchestrator/pluginToolsReadyGate.test.ts
@@ -14,6 +14,12 @@ import type {
   LlmStreamEvent,
 } from '@omadia/llm-provider';
 import type { ChatStreamEvent } from '@omadia/channel-sdk';
+import { adaptManifestV1 } from '../../src/plugins/manifestLoader.js';
+import type { PluginCatalogEntry } from '../../src/plugins/manifestLoader.js';
+import { PluginStatusRegistry } from '../../src/platform/pluginStatusRegistry.js';
+import { OAuthReadinessTracker } from '../../src/plugins/oauth/oauthReadinessTracker.js';
+import { writeStoredTokens } from '../../src/plugins/oauth/tokenStore.js';
+import type { SecretVault } from '../../src/secrets/vault.js';
 import {
   createDomainTool,
   NativeToolRegistry,
@@ -448,5 +454,251 @@ describe('Orchestrator — issue #474 plugin tool-readiness gate (domain tools)'
       !systemText?.includes('query_gated'),
       'expected the gated domain tool to be excluded from the Fach-Agenten roster',
     );
+  });
+});
+
+/**
+ * Issue #474 review round 5 — the generic install/Connect flow never calls
+ * `ctx.status.report(...)` on the plugin's behalf: `installService.ts`
+ * activates a `type:'oauth'` plugin (registering its tools) BEFORE the
+ * operator has completed the Connect flow. This block proves the automatic
+ * OAuth-connection signal (`OAuthReadinessTracker`) gates the orchestrator's
+ * tool list and dispatch by itself, with NO `ctx.status.report(...)` call
+ * anywhere in the test — mirroring the explicit-report tests above but
+ * exercising only the new automatic path — and that composing it with
+ * `PluginStatusRegistry` (as `index.ts` wires the real gate) is a true AND:
+ * either signal alone can withhold readiness.
+ */
+class FakeVault implements SecretVault {
+  readonly store = new Map<string, string>();
+  async get(agentId: string, key: string): Promise<string | undefined> {
+    return this.store.get(`${agentId}::${key}`);
+  }
+  async set(agentId: string, key: string, value: string): Promise<void> {
+    this.store.set(`${agentId}::${key}`, value);
+  }
+  async setMany(agentId: string, entries: Record<string, string>): Promise<void> {
+    for (const [k, v] of Object.entries(entries)) await this.set(agentId, k, v);
+  }
+  async listKeys(): Promise<string[]> {
+    return [];
+  }
+  async purge(): Promise<void> {}
+  async deleteKey(agentId: string, key: string): Promise<void> {
+    this.store.delete(`${agentId}::${key}`);
+  }
+}
+
+function oauthPluginEntry(pluginId: string): PluginCatalogEntry {
+  const plugin = adaptManifestV1({
+    schema_version: '1',
+    identity: {
+      id: pluginId,
+      kind: 'tool',
+      domain: 'test',
+      name: 'OAuth Tool Plugin',
+      version: '0.1.0',
+    },
+    setup: {
+      fields: [
+        { key: 'connection', type: 'oauth', label: 'Connect', provider: 'github' },
+      ],
+    },
+  })!;
+  return { plugin, manifest: {}, source_path: '/dev/null', source_kind: 'manifest-v1' };
+}
+
+describe('Orchestrator — issue #474 round 5: automatic OAuth-connection signal', () => {
+  it('excludes an installed-but-not-connected oauth plugin tool from the offered tool list — no ctx.status.report() involved', async () => {
+    const oauthTracker = new OAuthReadinessTracker();
+    const vault = new FakeVault();
+    // The concrete repro: activate() ran (tools registered) but Connect was
+    // never completed, so the vault has no tokens for the declared field.
+    await oauthTracker.refresh('gated-plugin', oauthPluginEntry('gated-plugin'), vault);
+
+    const registry = new NativeToolRegistry();
+    registry.register('ready_tool', {
+      handler: async () => 'ready-output',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      spec: minimalSpec('ready_tool') as any,
+      agentId: 'ready-plugin',
+    });
+    registry.register('github_search', {
+      handler: async () => 'gated-output',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      spec: minimalSpec('github_search') as any,
+      agentId: 'gated-plugin',
+    });
+
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [],
+      nativeToolRegistry: registry,
+      // Composed exactly like index.ts's `installedPluginToolsReadyReader` —
+      // but pluginStatusRegistry never received a report() call for either
+      // plugin, so readiness here comes ENTIRELY from oauthTracker.
+      isPluginToolsReady: (agentId) => oauthTracker.isConnected(agentId),
+    });
+
+    for await (const _ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      // drain
+    }
+
+    const offered = (seenRequests[0]?.tools ?? []).map((t) => t.name);
+    assert.ok(
+      offered.includes('ready_tool'),
+      `expected ready_tool in offered tools, got ${JSON.stringify(offered)}`,
+    );
+    assert.ok(
+      !offered.includes('github_search'),
+      `expected github_search to be excluded (not connected), got ${JSON.stringify(offered)}`,
+    );
+  });
+
+  it('refuses to invoke an installed-but-not-connected oauth plugin tool even if a call for it arrives', async () => {
+    const oauthTracker = new OAuthReadinessTracker();
+    const vault = new FakeVault();
+    await oauthTracker.refresh('gated-plugin', oauthPluginEntry('gated-plugin'), vault);
+
+    const registry = new NativeToolRegistry();
+    let handlerCalled = false;
+    registry.register('github_search', {
+      handler: async () => {
+        handlerCalled = true;
+        return 'should never run';
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      spec: minimalSpec('github_search') as any,
+      agentId: 'gated-plugin',
+    });
+
+    const stream0 = streamWithTools([
+      { id: 'use-1', name: 'github_search', input: {} },
+    ]);
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([stream0, finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [],
+      nativeToolRegistry: registry,
+      isPluginToolsReady: (agentId) => oauthTracker.isConnected(agentId),
+    });
+
+    const events: ChatStreamEvent[] = [];
+    for await (const ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      events.push(ev);
+    }
+
+    assert.equal(handlerCalled, false, 'the not-connected oauth tool must never run');
+    const result = events.find(
+      (e) => e.type === 'tool_result' && e.id === 'use-1',
+    );
+    assert.ok(result, 'expected a tool_result for the gated call');
+    assert.ok(
+      result?.type === 'tool_result' &&
+        result.isError === true &&
+        /Error:/.test(result.output),
+      `expected an Error: result, got ${JSON.stringify(result)}`,
+    );
+  });
+
+  it('becomes ready again once the oauth field connects — an explicit ctx.status.report() is not required', async () => {
+    const oauthTracker = new OAuthReadinessTracker();
+    const vault = new FakeVault();
+    const entry = oauthPluginEntry('reconnected-plugin');
+    // First activation: not connected yet.
+    await oauthTracker.refresh('reconnected-plugin', entry, vault);
+    assert.equal(oauthTracker.isConnected('reconnected-plugin'), false);
+
+    // Connect flow completes (brokerService.callback → writeStoredTokens),
+    // then reactivate() re-runs activate() → refresh() picks it up.
+    await writeStoredTokens(vault, 'reconnected-plugin', 'connection', {
+      accessToken: 'tok',
+      refreshToken: '',
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      scope: '',
+    });
+    await oauthTracker.refresh('reconnected-plugin', entry, vault);
+
+    const registry = new NativeToolRegistry();
+    registry.register('github_search', {
+      handler: async () => 'now-connected-output',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      spec: minimalSpec('github_search') as any,
+      agentId: 'reconnected-plugin',
+    });
+
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [],
+      nativeToolRegistry: registry,
+      isPluginToolsReady: (agentId) => oauthTracker.isConnected(agentId),
+    });
+
+    for await (const _ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      // drain
+    }
+
+    const offered = (seenRequests[0]?.tools ?? []).map((t) => t.name);
+    assert.ok(
+      offered.includes('github_search'),
+      `expected github_search back in offered tools once connected, got ${JSON.stringify(offered)}`,
+    );
+  });
+
+  it('composed gate (as wired in index.ts) is a true AND — either signal alone withholds readiness', async () => {
+    const statusRegistry = new PluginStatusRegistry();
+    const oauthTracker = new OAuthReadinessTracker();
+    const vault = new FakeVault();
+    const isReady = (agentId: string): boolean =>
+      statusRegistry.isReady(agentId) && oauthTracker.isConnected(agentId);
+
+    // Neither signal reported anything — ready by default (most plugins).
+    assert.equal(isReady('plain-plugin'), true);
+
+    // Explicit report says needs_action; oauth signal never touched (no
+    // oauth field on this plugin) — must stay not-ready.
+    statusRegistry.set('explicit-only', {
+      state: 'needs_action',
+      title: 'Nicht verbunden',
+    });
+    assert.equal(isReady('explicit-only'), false);
+
+    // Explicit report says OK, but the automatic oauth signal says
+    // not-connected — the explicit 'ok' must NOT hide the real oauth gap.
+    statusRegistry.set('explicit-ok-oauth-pending', { state: 'ok' });
+    await oauthTracker.refresh(
+      'explicit-ok-oauth-pending',
+      oauthPluginEntry('explicit-ok-oauth-pending'),
+      vault,
+    );
+    assert.equal(isReady('explicit-ok-oauth-pending'), false);
+
+    // Connect the oauth field — both signals now agree ready.
+    await writeStoredTokens(vault, 'explicit-ok-oauth-pending', 'connection', {
+      accessToken: 'tok',
+      refreshToken: '',
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      scope: '',
+    });
+    await oauthTracker.refresh(
+      'explicit-ok-oauth-pending',
+      oauthPluginEntry('explicit-ok-oauth-pending'),
+      vault,
+    );
+    assert.equal(isReady('explicit-ok-oauth-pending'), true);
   });
 });

--- a/middleware/test/orchestrator/pluginToolsReadyGate.test.ts
+++ b/middleware/test/orchestrator/pluginToolsReadyGate.test.ts
@@ -238,4 +238,49 @@ describe('Orchestrator — issue #474 plugin tool-readiness gate', () => {
       `expected an Error: result, got ${JSON.stringify(result)}`,
     );
   });
+
+  it('excludes a not-ready plugin tool promptDoc from the system prompt, keeps a ready one', async () => {
+    const registry = new NativeToolRegistry();
+    registry.register('ready_tool', {
+      handler: async () => 'ready-output',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      spec: minimalSpec('ready_tool') as any,
+      agentId: 'ready-plugin',
+      promptDoc: 'READY_TOOL_PROMPT_DOC_MARKER',
+    });
+    registry.register('gated_tool', {
+      handler: async () => 'gated-output',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      spec: minimalSpec('gated_tool') as any,
+      agentId: 'gated-plugin',
+      promptDoc: 'GATED_TOOL_PROMPT_DOC_MARKER',
+    });
+
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [],
+      nativeToolRegistry: registry,
+      isPluginToolsReady: (agentId) => agentId !== 'gated-plugin',
+    });
+
+    for await (const _ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      // drain
+    }
+
+    const system = seenRequests[0]?.system;
+    const systemText = typeof system === 'string' ? system : JSON.stringify(system);
+    assert.ok(
+      systemText?.includes('READY_TOOL_PROMPT_DOC_MARKER'),
+      'expected the ready plugin promptDoc in the system prompt',
+    );
+    assert.ok(
+      !systemText?.includes('GATED_TOOL_PROMPT_DOC_MARKER'),
+      'expected the gated plugin promptDoc to be excluded from the system prompt',
+    );
+  });
 });

--- a/middleware/test/orchestrator/pluginToolsReadyGate.test.ts
+++ b/middleware/test/orchestrator/pluginToolsReadyGate.test.ts
@@ -408,4 +408,45 @@ describe('Orchestrator — issue #474 plugin tool-readiness gate (domain tools)'
       `expected an Error: result, got ${JSON.stringify(result)}`,
     );
   });
+
+  it('round-3 fix: excludes a not-ready plugin domain tool from the Fach-Agenten roster in the system prompt, keeps a ready one', async () => {
+    const readyTool = makeDomainTool(
+      'query_ready',
+      'ready-plugin',
+      () => {},
+    );
+    const gatedTool = makeDomainTool(
+      'query_gated',
+      'gated-plugin',
+      () => {},
+    );
+
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [readyTool, gatedTool],
+      nativeToolRegistry: new NativeToolRegistry(),
+      isPluginToolsReady: (agentId) => agentId !== 'gated-plugin',
+    });
+
+    for await (const _ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      // drain
+    }
+
+    const system = seenRequests[0]?.system;
+    const systemText =
+      typeof system === 'string' ? system : JSON.stringify(system);
+    assert.ok(
+      systemText?.includes('query_ready'),
+      'expected the ready domain tool in the Fach-Agenten roster',
+    );
+    assert.ok(
+      !systemText?.includes('query_gated'),
+      'expected the gated domain tool to be excluded from the Fach-Agenten roster',
+    );
+  });
 });

--- a/middleware/test/orchestrator/pluginToolsReadyGate.test.ts
+++ b/middleware/test/orchestrator/pluginToolsReadyGate.test.ts
@@ -14,7 +14,11 @@ import type {
   LlmStreamEvent,
 } from '@omadia/llm-provider';
 import type { ChatStreamEvent } from '@omadia/channel-sdk';
-import { NativeToolRegistry, Orchestrator } from '@omadia/orchestrator';
+import {
+  createDomainTool,
+  NativeToolRegistry,
+  Orchestrator,
+} from '@omadia/orchestrator';
 
 interface ScriptedStream {
   events: LlmStreamEvent[];
@@ -281,6 +285,127 @@ describe('Orchestrator — issue #474 plugin tool-readiness gate', () => {
     assert.ok(
       !systemText?.includes('GATED_TOOL_PROMPT_DOC_MARKER'),
       'expected the gated plugin promptDoc to be excluded from the system prompt',
+    );
+  });
+});
+
+/**
+ * Issue #474 follow-up — the same readiness gate applies to the *second*
+ * tool-registration path: DomainTools contributed by dynamic agent plugins
+ * (`domainToolsByName`), as distinct from native tools registered via
+ * `ctx.tools.register()`. Both paths carry an `agentId` and must be gated
+ * identically, otherwise a not-ready plugin's domain tool (e.g.
+ * `query_<slug>`) stays offered and invocable even though its native tools
+ * are already hidden.
+ */
+describe('Orchestrator — issue #474 plugin tool-readiness gate (domain tools)', () => {
+  const makeDomainTool = (
+    name: string,
+    agentId: string,
+    onCall: () => void,
+  ) =>
+    createDomainTool({
+      name,
+      description: `${name} for testing`,
+      domain: 'test.domain',
+      agentId,
+      agent: {
+        ask: async (): Promise<string> => {
+          onCall();
+          return `${name}-output`;
+        },
+      },
+    });
+
+  it('excludes a not-ready plugin domain tool from the offered tool list, keeps a ready one', async () => {
+    const readyTool = makeDomainTool('query_ready', 'ready-plugin', () => {});
+    const gatedTool = makeDomainTool('query_gated', 'gated-plugin', () => {});
+
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [readyTool, gatedTool],
+      nativeToolRegistry: new NativeToolRegistry(),
+      isPluginToolsReady: (agentId) => agentId !== 'gated-plugin',
+    });
+
+    for await (const _ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      // drain
+    }
+
+    const offered = (seenRequests[0]?.tools ?? []).map((t) => t.name);
+    assert.ok(
+      offered.includes('query_ready'),
+      `expected query_ready in offered tools, got ${JSON.stringify(offered)}`,
+    );
+    assert.ok(
+      !offered.includes('query_gated'),
+      `expected query_gated to be excluded, got ${JSON.stringify(offered)}`,
+    );
+  });
+
+  it('still offers every domain tool when isPluginToolsReady is not wired (pre-#474 behaviour)', async () => {
+    const plainTool = makeDomainTool('query_plain', 'some-plugin', () => {});
+
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [plainTool],
+      nativeToolRegistry: new NativeToolRegistry(),
+    });
+
+    for await (const _ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      // drain
+    }
+
+    const offered = (seenRequests[0]?.tools ?? []).map((t) => t.name);
+    assert.ok(offered.includes('query_plain'));
+  });
+
+  it('refuses to invoke a not-ready plugin domain tool even if a call for it arrives (dispatch-time re-check)', async () => {
+    let handlerCalled = false;
+    const gatedTool = makeDomainTool('query_gated', 'gated-plugin', () => {
+      handlerCalled = true;
+    });
+
+    const stream0 = streamWithTools([
+      { id: 'use-1', name: 'query_gated', input: { question: 'hi' } },
+    ]);
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([stream0, finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [gatedTool],
+      nativeToolRegistry: new NativeToolRegistry(),
+      isPluginToolsReady: () => false,
+    });
+
+    const events: ChatStreamEvent[] = [];
+    for await (const ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      events.push(ev);
+    }
+
+    assert.equal(handlerCalled, false, 'the gated domain tool must never run');
+    const result = events.find(
+      (e) => e.type === 'tool_result' && e.id === 'use-1',
+    );
+    assert.ok(result, 'expected a tool_result for the gated call');
+    assert.ok(
+      result?.type === 'tool_result' &&
+        result.isError === true &&
+        /Error:/.test(result.output),
+      `expected an Error: result, got ${JSON.stringify(result)}`,
     );
   });
 });

--- a/middleware/test/orchestrator/pluginToolsReadyGate.test.ts
+++ b/middleware/test/orchestrator/pluginToolsReadyGate.test.ts
@@ -702,3 +702,154 @@ describe('Orchestrator — issue #474 round 5: automatic OAuth-connection signal
     assert.equal(isReady('explicit-ok-oauth-pending'), true);
   });
 });
+
+/**
+ * Issue #474 review round 8 — `NativeToolRegistry.registerHandler()` (the
+ * handler-only path used for tools whose spec the kernel emits itself, e.g.
+ * the Anthropic-native `memory` tool that `harness-memory` /
+ * `harness-memory-postgres` register via `ctx.tools.registerHandler()`)
+ * never stored an `agentId` on its entry, so the `agentId === undefined ⇒
+ * always-available` default meant for genuinely kernel-internal
+ * registrations silently applied to ANY plugin using this path instead of
+ * `register()`. Mirrors the `register()` gate tests above, but exercises
+ * `registerHandler()` specifically.
+ */
+describe('Orchestrator — issue #474 round 8: registerHandler() readiness gate', () => {
+  it('excludes a not-ready plugin registerHandler() tool promptDoc from the system prompt, keeps a ready one', async () => {
+    const registry = new NativeToolRegistry();
+    registry.registerHandler('ready_handler_tool', {
+      handler: async () => 'ready-output',
+      agentId: 'ready-plugin',
+      promptDoc: 'READY_HANDLER_TOOL_PROMPT_DOC_MARKER',
+    });
+    registry.registerHandler('gated_handler_tool', {
+      handler: async () => 'gated-output',
+      agentId: 'gated-plugin',
+      promptDoc: 'GATED_HANDLER_TOOL_PROMPT_DOC_MARKER',
+    });
+
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [],
+      nativeToolRegistry: registry,
+      isPluginToolsReady: (agentId) => agentId !== 'gated-plugin',
+    });
+
+    for await (const _ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      // drain
+    }
+
+    const system = seenRequests[0]?.system;
+    const systemText = typeof system === 'string' ? system : JSON.stringify(system);
+    assert.ok(
+      systemText?.includes('READY_HANDLER_TOOL_PROMPT_DOC_MARKER'),
+      'expected the ready plugin registerHandler() promptDoc in the system prompt',
+    );
+    assert.ok(
+      !systemText?.includes('GATED_HANDLER_TOOL_PROMPT_DOC_MARKER'),
+      'expected the gated plugin registerHandler() promptDoc to be excluded from the system prompt',
+    );
+  });
+
+  it('refuses to invoke a not-ready plugin registerHandler() tool even if a call for it arrives (dispatch-time re-check)', async () => {
+    const registry = new NativeToolRegistry();
+    let handlerCalled = false;
+    registry.registerHandler('gated_handler_tool', {
+      handler: async () => {
+        handlerCalled = true;
+        return 'should never run';
+      },
+      agentId: 'gated-plugin',
+    });
+
+    const stream0 = streamWithTools([
+      { id: 'use-1', name: 'gated_handler_tool', input: {} },
+    ]);
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([stream0, finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [],
+      nativeToolRegistry: registry,
+      isPluginToolsReady: () => false,
+    });
+
+    const events: ChatStreamEvent[] = [];
+    for await (const ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      events.push(ev);
+    }
+
+    assert.equal(handlerCalled, false, 'the gated registerHandler() handler must never run');
+    const result = events.find(
+      (e) => e.type === 'tool_result' && e.id === 'use-1',
+    );
+    assert.ok(result, 'expected a tool_result for the gated call');
+    assert.ok(
+      result?.type === 'tool_result' &&
+        result.isError === true &&
+        /Error:/.test(result.output),
+      `expected an Error: result, got ${JSON.stringify(result)}`,
+    );
+  });
+
+  it('a kernel-internal registerHandler() call (no agentId) stays always-available regardless of isPluginToolsReady', async () => {
+    const registry = new NativeToolRegistry();
+    let handlerCalled = false;
+    // No `agentId` — the genuinely kernel-internal convention `register()`
+    // already follows for marker-only entries.
+    registry.registerHandler('kernel_internal_handler_tool', {
+      handler: async () => {
+        handlerCalled = true;
+        return 'kernel-output';
+      },
+      promptDoc: 'KERNEL_INTERNAL_HANDLER_TOOL_PROMPT_DOC_MARKER',
+    });
+
+    const stream0 = streamWithTools([
+      { id: 'use-1', name: 'kernel_internal_handler_tool', input: {} },
+    ]);
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([stream0, finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [],
+      nativeToolRegistry: registry,
+      // Would gate every plugin-owned tool — must NOT affect this
+      // agentId-less, kernel-internal entry.
+      isPluginToolsReady: () => false,
+    });
+
+    const events: ChatStreamEvent[] = [];
+    for await (const ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      events.push(ev);
+    }
+
+    assert.equal(handlerCalled, true, 'the kernel-internal handler must still run');
+    const result = events.find(
+      (e) => e.type === 'tool_result' && e.id === 'use-1',
+    );
+    assert.ok(result, 'expected a tool_result for the kernel-internal call');
+    assert.ok(
+      result?.type === 'tool_result' && result.isError !== true,
+      `expected a successful result, got ${JSON.stringify(result)}`,
+    );
+
+    const system = seenRequests[0]?.system;
+    const systemText = typeof system === 'string' ? system : JSON.stringify(system);
+    assert.ok(
+      systemText?.includes('KERNEL_INTERNAL_HANDLER_TOOL_PROMPT_DOC_MARKER'),
+      'expected the kernel-internal registerHandler() promptDoc in the system prompt',
+    );
+  });
+});

--- a/middleware/test/orchestrator/pluginToolsReadyGate.test.ts
+++ b/middleware/test/orchestrator/pluginToolsReadyGate.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Issue #474 — a plugin whose `ctx.tools.register()`-contributed tools are
+ * gated by `isPluginToolsReady` must be (a) excluded from the tool list
+ * offered to the model, and (b) refused at dispatch time even if a call for
+ * it arrives anyway (the race the list-only check would miss).
+ */
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import type {
+  LlmProvider,
+  LlmRequest,
+  LlmResponse,
+  LlmStreamEvent,
+} from '@omadia/llm-provider';
+import type { ChatStreamEvent } from '@omadia/channel-sdk';
+import { NativeToolRegistry, Orchestrator } from '@omadia/orchestrator';
+
+interface ScriptedStream {
+  events: LlmStreamEvent[];
+}
+
+const providerCapabilities = {
+  tools: true,
+  vision: true,
+  streaming: true,
+  promptCaching: true,
+  forcedToolChoice: true,
+  parallelToolCalls: true,
+} as const;
+
+/** Records the `tools` array of every request it receives, then plays back
+ *  the scripted streams in order. */
+function fakeStreamProvider(
+  streams: ScriptedStream[],
+  seenRequests: LlmRequest[],
+): LlmProvider {
+  let idx = 0;
+  const provider = {
+    id: 'anthropic',
+    capabilities: providerCapabilities,
+    complete: async (): Promise<LlmResponse> => {
+      throw new Error('fakeStreamProvider: complete() not scripted');
+    },
+    stream: (req: LlmRequest): AsyncIterable<LlmStreamEvent> => {
+      seenRequests.push(req);
+      if (idx >= streams.length) {
+        throw new Error(
+          `fakeStreamProvider: no scripted stream for call ${String(idx + 1)}`,
+        );
+      }
+      const fake = streams[idx]!;
+      idx += 1;
+      return {
+        async *[Symbol.asyncIterator]() {
+          for (const ev of fake.events) yield ev;
+        },
+      };
+    },
+    classifyError: () => ({ retryable: false, kind: 'other' as const }),
+  };
+  return provider as unknown as LlmProvider;
+}
+
+function streamWithTools(
+  toolUses: Array<{ id: string; name: string; input: unknown }>,
+): ScriptedStream {
+  const events: LlmStreamEvent[] = [];
+  toolUses.forEach((u) => {
+    events.push(
+      { type: 'tool_use_start' },
+      { type: 'tool_input_delta', text: JSON.stringify(u.input) },
+    );
+  });
+  events.push({
+    type: 'final',
+    response: {
+      content: toolUses.map((u) => ({
+        type: 'tool_call',
+        id: u.id,
+        name: u.name,
+        input: u.input,
+      })),
+      finishReason: 'tool_calls',
+      providerFinishReason: 'tool_use',
+      model: 'test',
+      usage: {
+        inputTokens: 50,
+        outputTokens: 4,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      },
+    },
+  });
+  return { events };
+}
+
+const finalTextStream: ScriptedStream = {
+  events: [
+    { type: 'text_delta', text: 'done' },
+    {
+      type: 'final',
+      response: {
+        content: [{ type: 'text', text: 'done' }],
+        finishReason: 'stop',
+        providerFinishReason: 'end_turn',
+        model: 'test',
+        usage: {
+          inputTokens: 100,
+          outputTokens: 1,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        },
+      },
+    },
+  ],
+};
+
+const minimalSpec = (name: string): Record<string, unknown> => ({
+  name,
+  description: `${name} for testing`,
+  input_schema: { type: 'object' as const, properties: {}, required: [] },
+});
+
+describe('Orchestrator — issue #474 plugin tool-readiness gate', () => {
+  it('excludes a not-ready plugin tool from the offered tool list, keeps a ready one', async () => {
+    const registry = new NativeToolRegistry();
+    registry.register('ready_tool', {
+      handler: async () => 'ready-output',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      spec: minimalSpec('ready_tool') as any,
+      agentId: 'ready-plugin',
+    });
+    registry.register('gated_tool', {
+      handler: async () => 'gated-output',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      spec: minimalSpec('gated_tool') as any,
+      agentId: 'gated-plugin',
+    });
+
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [],
+      nativeToolRegistry: registry,
+      isPluginToolsReady: (agentId) => agentId !== 'gated-plugin',
+    });
+
+    for await (const _ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      // drain
+    }
+
+    const offered = (seenRequests[0]?.tools ?? []).map((t) => t.name);
+    assert.ok(
+      offered.includes('ready_tool'),
+      `expected ready_tool in offered tools, got ${JSON.stringify(offered)}`,
+    );
+    assert.ok(
+      !offered.includes('gated_tool'),
+      `expected gated_tool to be excluded, got ${JSON.stringify(offered)}`,
+    );
+  });
+
+  it('still offers every tool when isPluginToolsReady is not wired (pre-#474 behaviour)', async () => {
+    const registry = new NativeToolRegistry();
+    registry.register('plain_tool', {
+      handler: async () => 'ok',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      spec: minimalSpec('plain_tool') as any,
+      agentId: 'some-plugin',
+    });
+
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [],
+      nativeToolRegistry: registry,
+    });
+
+    for await (const _ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      // drain
+    }
+
+    const offered = (seenRequests[0]?.tools ?? []).map((t) => t.name);
+    assert.ok(offered.includes('plain_tool'));
+  });
+
+  it('refuses to invoke a not-ready plugin tool even if a call for it arrives (dispatch-time re-check)', async () => {
+    const registry = new NativeToolRegistry();
+    let handlerCalled = false;
+    registry.register('gated_tool', {
+      handler: async () => {
+        handlerCalled = true;
+        return 'should never run';
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      spec: minimalSpec('gated_tool') as any,
+      agentId: 'gated-plugin',
+    });
+
+    const stream0 = streamWithTools([
+      { id: 'use-1', name: 'gated_tool', input: {} },
+    ]);
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([stream0, finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [],
+      nativeToolRegistry: registry,
+      isPluginToolsReady: () => false,
+    });
+
+    const events: ChatStreamEvent[] = [];
+    for await (const ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      events.push(ev);
+    }
+
+    assert.equal(handlerCalled, false, 'the gated handler must never run');
+    const result = events.find(
+      (e) => e.type === 'tool_result' && e.id === 'use-1',
+    );
+    assert.ok(result, 'expected a tool_result for the gated call');
+    assert.ok(
+      result?.type === 'tool_result' &&
+        result.isError === true &&
+        /Error:/.test(result.output),
+      `expected an Error: result, got ${JSON.stringify(result)}`,
+    );
+  });
+});

--- a/middleware/test/orchestrator/pluginToolsReadyGate.test.ts
+++ b/middleware/test/orchestrator/pluginToolsReadyGate.test.ts
@@ -14,6 +14,8 @@ import type {
   LlmStreamEvent,
 } from '@omadia/llm-provider';
 import type { ChatStreamEvent } from '@omadia/channel-sdk';
+import type { MemoryEntry, MemoryStore } from '@omadia/plugin-api';
+import { MemoryToolHandler } from '@omadia/memory';
 import { adaptManifestV1 } from '../../src/plugins/manifestLoader.js';
 import type { PluginCatalogEntry } from '../../src/plugins/manifestLoader.js';
 import { PluginStatusRegistry } from '../../src/platform/pluginStatusRegistry.js';
@@ -850,6 +852,218 @@ describe('Orchestrator — issue #474 round 8: registerHandler() readiness gate'
     assert.ok(
       systemText?.includes('KERNEL_INTERNAL_HANDLER_TOOL_PROMPT_DOC_MARKER'),
       'expected the kernel-internal registerHandler() promptDoc in the system prompt',
+    );
+  });
+});
+
+/**
+ * Issue #474 (review round 10) — the built-in Anthropic `memory` tool
+ * (`{type: 'memory_20250818', name: 'memory'}`) is special-cased in both
+ * `buildToolsList()` and `dispatchToolInner()`, dispatched via
+ * `this.memoryToolHandler` (the orchestrator's own per-Agent-scoped memory
+ * store — see buildOrchestrator.ts) BEFORE the generic
+ * `NativeToolRegistry`/`isToolAvailable(agentId)` path is ever consulted.
+ * A plugin that contributes `memory` via `ctx.tools.registerHandler(...)`
+ * (harness-memory / harness-memory-postgres, or any future one) must be
+ * gated exactly like every other `registerHandler()`-registered tool.
+ */
+class NullMemoryStore implements MemoryStore {
+  async list(): Promise<MemoryEntry[]> {
+    return [];
+  }
+  async fileExists(): Promise<boolean> {
+    return false;
+  }
+  async directoryExists(): Promise<boolean> {
+    return false;
+  }
+  async readFile(): Promise<string> {
+    throw new Error('not implemented in test double');
+  }
+  async createFile(): Promise<void> {}
+  async writeFile(): Promise<void> {}
+  async delete(): Promise<void> {}
+  async rename(): Promise<void> {}
+}
+
+describe('Orchestrator — issue #474 round 10: hardcoded memory-tool fast path', () => {
+  it('excludes the memory tool from the offered tool list when its registering plugin is not ready', async () => {
+    const registry = new NativeToolRegistry();
+    registry.registerHandler('memory', {
+      handler: async () => 'should never run',
+      agentId: 'gated-memory-plugin',
+    });
+
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [],
+      nativeToolRegistry: registry,
+      memoryToolHandler: new MemoryToolHandler(new NullMemoryStore()),
+      isPluginToolsReady: (agentId) => agentId !== 'gated-memory-plugin',
+    });
+
+    for await (const _ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      // drain
+    }
+
+    const offered = (seenRequests[0]?.tools ?? []).map((t) => t.name);
+    assert.ok(
+      !offered.includes('memory'),
+      `expected memory to be excluded from offered tools, got ${JSON.stringify(offered)}`,
+    );
+  });
+
+  it('refuses to dispatch the memory tool via the hardcoded fast path when its registering plugin is not ready', async () => {
+    const registry = new NativeToolRegistry();
+    let registryHandlerCalled = false;
+    registry.registerHandler('memory', {
+      handler: async () => {
+        registryHandlerCalled = true;
+        return 'should never run';
+      },
+      agentId: 'gated-memory-plugin',
+    });
+    let scopedHandlerCalled = false;
+    const memoryToolHandler = new MemoryToolHandler(new NullMemoryStore());
+    const originalHandle = memoryToolHandler.handle.bind(memoryToolHandler);
+    memoryToolHandler.handle = async (input: unknown) => {
+      scopedHandlerCalled = true;
+      return originalHandle(input);
+    };
+
+    const stream0 = streamWithTools([
+      { id: 'use-1', name: 'memory', input: { command: 'view', path: '/' } },
+    ]);
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([stream0, finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [],
+      nativeToolRegistry: registry,
+      memoryToolHandler,
+      isPluginToolsReady: (agentId) => agentId !== 'gated-memory-plugin',
+    });
+
+    const events: ChatStreamEvent[] = [];
+    for await (const ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      events.push(ev);
+    }
+
+    assert.equal(
+      registryHandlerCalled,
+      false,
+      'the registerHandler()-contributed memory handler must never run',
+    );
+    assert.equal(
+      scopedHandlerCalled,
+      false,
+      'the per-orchestrator scoped memoryToolHandler must never run either — the fast path must refuse before reaching it',
+    );
+    const result = events.find(
+      (e) => e.type === 'tool_result' && e.id === 'use-1',
+    );
+    assert.ok(result, 'expected a tool_result for the gated memory call');
+    assert.ok(
+      result?.type === 'tool_result' &&
+        result.isError === true &&
+        /Error:/.test(result.output),
+      `expected an Error: result, got ${JSON.stringify(result)}`,
+    );
+  });
+
+  it('keeps the memory tool available and dispatching when no plugin registered it (kernel marker-only entry)', async () => {
+    // Mirrors production: `Orchestrator`'s own constructor registers a
+    // marker-only 'memory' entry (no agentId) when nothing else did.
+    const registry = new NativeToolRegistry();
+
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [],
+      nativeToolRegistry: registry,
+      memoryToolHandler: new MemoryToolHandler(new NullMemoryStore()),
+      // Would gate every plugin-owned tool — must NOT affect the
+      // agentId-less, kernel-internal memory entry.
+      isPluginToolsReady: () => false,
+    });
+
+    for await (const _ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      // drain
+    }
+
+    const offered = (seenRequests[0]?.tools ?? []).map((t) => t.name);
+    assert.ok(
+      offered.includes('memory'),
+      `expected memory to stay offered with no registering plugin, got ${JSON.stringify(offered)}`,
+    );
+  });
+
+  it('keeps the memory tool available when contributed by a plugin that never reports a connection status (harness-memory / harness-memory-postgres today)', async () => {
+    const registry = new NativeToolRegistry();
+    let handlerCalled = false;
+    registry.registerHandler('memory', {
+      handler: async (input: unknown) => {
+        handlerCalled = true;
+        return `handled:${JSON.stringify(input)}`;
+      },
+      agentId: '@omadia/harness-memory',
+    });
+
+    const stream0 = streamWithTools([
+      { id: 'use-1', name: 'memory', input: { command: 'view', path: '/' } },
+    ]);
+    const seenRequests: LlmRequest[] = [];
+    const provider = fakeStreamProvider([stream0, finalTextStream], seenRequests);
+    const orchestrator = new Orchestrator({
+      provider,
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [],
+      nativeToolRegistry: registry,
+      memoryToolHandler: new MemoryToolHandler(new NullMemoryStore()),
+      // Matches production wiring: only plugins that explicitly reported
+      // not-ready (via status/oauth signals) are excluded — harness-memory
+      // never calls ctx.status.report(...) and has no oauth field, so it
+      // stays ready by default.
+      isPluginToolsReady: (agentId) => agentId !== 'some-other-gated-plugin',
+    });
+
+    const events: ChatStreamEvent[] = [];
+    for await (const ev of orchestrator.chatStream({ userMessage: 'go' })) {
+      events.push(ev);
+    }
+
+    const offered = (seenRequests[0]?.tools ?? []).map((t) => t.name);
+    assert.ok(
+      offered.includes('memory'),
+      `expected memory to stay offered for an always-ready plugin, got ${JSON.stringify(offered)}`,
+    );
+
+    const result = events.find(
+      (e) => e.type === 'tool_result' && e.id === 'use-1',
+    );
+    assert.ok(result, 'expected a tool_result for the memory call');
+    assert.ok(
+      result?.type === 'tool_result' && result.isError !== true,
+      `expected a successful result, got ${JSON.stringify(result)}`,
+    );
+    assert.equal(
+      handlerCalled,
+      false,
+      'the per-orchestrator scoped memoryToolHandler must win (per-orchestrator isolation), not the registry handler',
     );
   });
 });

--- a/middleware/test/pluginContextStatus.test.ts
+++ b/middleware/test/pluginContextStatus.test.ts
@@ -128,3 +128,31 @@ describe('Spec 004 — ctx.status', () => {
     assert.equal(reg.get('plugin-b')?.state, 'needs_action');
   });
 });
+
+describe('Issue #474 — PluginStatusRegistry.isReady', () => {
+  it('is ready when the plugin never reported a status', () => {
+    const reg = new PluginStatusRegistry();
+    assert.equal(reg.isReady('never-reported'), true);
+  });
+
+  it('is not ready after ctx.status.report({state: "needs_action"})', () => {
+    const reg = new PluginStatusRegistry();
+    makeCtx('caller', reg).status.report({ state: 'needs_action' });
+    assert.equal(reg.isReady('caller'), false);
+  });
+
+  it('is not ready after ctx.status.report({state: "error"})', () => {
+    const reg = new PluginStatusRegistry();
+    makeCtx('caller', reg).status.report({ state: 'error' });
+    assert.equal(reg.isReady('caller'), false);
+  });
+
+  it('becomes ready again after ctx.status.clear() / report({state: "ok"})', () => {
+    const reg = new PluginStatusRegistry();
+    const ctx = makeCtx('caller', reg);
+    ctx.status.report({ state: 'needs_action' });
+    assert.equal(reg.isReady('caller'), false);
+    ctx.status.clear();
+    assert.equal(reg.isReady('caller'), true);
+  });
+});

--- a/middleware/test/pluginContextStatus.test.ts
+++ b/middleware/test/pluginContextStatus.test.ts
@@ -155,4 +155,21 @@ describe('Issue #474 — PluginStatusRegistry.isReady', () => {
     ctx.status.clear();
     assert.equal(reg.isReady('caller'), true);
   });
+
+  it('round-3 fix: is ready when a caller stores {state: "ok"} via the ' +
+    'class\'s own set() directly, bypassing the StatusAccessor.report() ' +
+    'normalization that turns "ok" into clear()', () => {
+    const reg = new PluginStatusRegistry();
+    reg.set('gated-plugin', { state: 'ok' });
+    assert.equal(reg.isReady('gated-plugin'), true);
+  });
+
+  it('round-3 fix: stays not-ready when set() is called directly with ' +
+    'needs_action/error, independent of the StatusAccessor', () => {
+    const reg = new PluginStatusRegistry();
+    reg.set('gated-plugin', { state: 'needs_action' });
+    assert.equal(reg.isReady('gated-plugin'), false);
+    reg.set('gated-plugin', { state: 'error' });
+    assert.equal(reg.isReady('gated-plugin'), false);
+  });
 });


### PR DESCRIPTION
## Summary

Closes the gap described in #474: an unauthenticated / not-yet-connected plugin's tools were previously offered to (and dispatchable by) the orchestrator, causing a wasted round-trip that fails with `OAuthTokenError`/status errors on the first real call. The orchestrator now gates every path that offers or dispatches a plugin's tools on that plugin's actual readiness, derived from two independent signals:

- `PluginStatusRegistry` — explicit, set by a plugin via `ctx.status.report({state:'needs_action'|'error'})`.
- `OAuthReadinessTracker` (new) — automatic, derived from the same vault token state `ctx.oauthTokens` reads, for `type:'oauth'` plugins that never call `ctx.status.report()` themselves. Recomputes freshness/refreshability against the wall clock on every read, not just at plugin-activation time.

Both are ANDed together and consulted at every gate site closed over the review rounds below:

- Tool-list assembly (`Orchestrator.buildToolsList`), including the hardcoded `memory` tool fast path
- Tool dispatch (`Orchestrator.dispatchToolInner`), re-checked at invocation time to close the list-vs-dispatch race window
- The standalone `ToolDispatchService` (subscription-CLI provider / loopback-MCP bridge), a separate entry point gated independently
- System prompt `promptDoc` splicing and the "Fach-Agenten" domain-tool roster
- DirectLine `#token` resolution (degrades to the existing "Specialist … is no longer available." notice instead of leaking an internal error string)
- Forced `tool_choice` (`directLineObligationState`, the `#332` primitive)
- `ctx.tools.registerHandler()` (e.g. the Anthropic-native `memory` tool), which previously bypassed the `agentId`-based gate entirely by using a different registration API than `ctx.tools.register()`
- OAuth-token expiry (a stored token that exists but is expired with no refresh token is not "ready")

Deliberately separate from the MCP-server-specific auth-gap flow (`mcpOAuthService`), which already handles unauthenticated MCP servers on its own.

## Review history

This branch went through 12 rounds of adversarial + cross-vendor (codex) review before reaching this state. Each round closed one real, concrete gap a prior round's audit had missed — the commit history below is a genuine iterative-hardening trail, not padding:

1. Native tools gated at list + dispatch time (`buildToolsList`, `dispatchToolInner`), plus the standalone `ToolDispatchService`.
2. `getSystemPrompt()`'s `promptDoc` collection wasn't gated — a hidden tool's documentation still reached the model.
3. Domain tools (`DomainTool`, e.g. `query_<slug>`) weren't gated at all — a second tool-registration path the initial fix missed.
4. The "Fach-Agenten" roster and `PluginStatusRegistry.isReady()`'s correctness (previously dependent on caller discipline, not its own invariant) plus forced `tool_choice` and DirectLine `#token` resolution.
5. The entire mechanism only engaged when a plugin explicitly called `ctx.status.report()` — the repo's own generic OAuth Connect flow never does this automatically, so a standard `type:'oauth'` plugin stayed exempt until Connect completed. Added `OAuthReadinessTracker`, deriving readiness from the same vault state `ctx.oauthTokens` already reads.
6. Branch fell behind `origin/main`, which had since gained a commit touching the same file — merged and re-verified.
7. `registerHandler()` (a second, public plugin-api tool-registration entry point, used by `harness-memory`/`harness-memory-postgres`) didn't carry an `agentId`, so a plugin using it instead of `register()` bypassed the gate.
8. `OAuthReadinessTracker` checked token *presence*, not usability — an expired, non-refreshable token still read as "connected". Extracted the exact expiry/refreshability logic `ctx.oauthTokens.get()` already used into a shared helper so the two can't drift.
9. The hardcoded `memory` tool fast path in `buildToolsList`/`dispatchToolInner` bypassed the registry gate entirely, regardless of round 7's fix.
10. `docs/middleware-agent-handoff.md` needed a section describing the new cross-cutting mechanism, per this repo's own documentation policy.
11. `OAuthReadinessTracker.isConnected()` cached its verdict at plugin-activation time and never re-evaluated it against the wall clock afterward — a token that went stale mid-session (crossed into its refresh margin) kept reading as ready until the next activation. Now recomputes freshness fresh on every read, mirroring how `ctx.oauthTokens.get()` itself never caches a verdict.
12. Final merge of `origin/main` (one more commit landed, unrelated, no code overlap — only a `docs/CHANGELOG.md` `[Unreleased]`-section conflict, resolved by keeping both entries) and full re-verification.

A recurring false-positive flag (files from `attachmentExtract.ts`/`codegen.ts`/`healthScore.ts`/`agentSpec.ts` looking like scope creep) came up repeatedly across rounds — confirmed false each time: those came from already-merged, unrelated `origin/main` commits (#499, #507, #525) pulled in by this branch's own merge commits, not new work. `git diff origin/main...HEAD` shows the true, clean #474-only scope.

## Testing

`cd middleware && npm install && npm run build && npm run lint && npm run typecheck && npm test` — all green on the final merged branch: 4790/4794 pass, 0 fail, 4 pre-existing skips.

New/updated test files: `middleware/test/orchestrator/pluginToolsReadyGate.test.ts`, `middleware/test/oauth/oauthReadinessTracker.test.ts`, `middleware/test/orchestrator/directLine.test.ts`, `middleware/test/cliBridge/toolDispatchService.test.ts`, `middleware/test/pluginContextStatus.test.ts`.

## Docs

- `docs/middleware-agent-handoff.md` — new "Plugin-Tool-Readiness-Gate (#474)" subsection.
- `docs/CHANGELOG.md` — full per-round `[Unreleased]` entry.
- `docs/security-architecture.md` intentionally not touched — this is an internal capability-gating mechanism, not a new auth boundary or credential flow; it doesn't fit that file's existing scope (credential storage, outbound-call proxying, plugin install trust boundary).

Closes #474

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787742284&installation_model_id=428086&pr_number=528&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F528&signature=361c3581c99b703ab82896ddc0958c225e7114743134f358e296e1edf15f773f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->