### PR TITLE
docs: add task-routing guidance for agent workflow selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,25 @@ Wenn die Zuordnung unklar ist: lieber in CHANGELOG notieren als gar nicht — sp
 
 Ohne mindestens Punkte 1–3 darf kein Code geändert werden.
 
+## Task-Routing: welches Werkzeug für welche Aufgabengröße
+
+Bevor eine Aufgabe begonnen wird: welche Größenordnung hat sie, und passt eines der vorhandenen `scripts/*.workflow.mjs`-Pipelines besser als Ad-hoc-Arbeit in der aktuellen Session?
+
+| Umfang | Beispiel | Werkzeug |
+|---|---|---|
+| Einzeldatei / triviale Änderung | Typo-Fix, eine Funktion anpassen | Inline in der aktuellen Session — kein Workflow nötig |
+| Ein Issue, wenige Dateien, ein Package | Bugfix in einem `middleware/packages/@omadia/*`-Package | `issue-triage.workflow.mjs` (Plan/Checklist) → `issue-implement.workflow.mjs` (Umsetzung, worktree-isoliert, zwei unabhängige Reviewer) |
+| Mehrere zusammenhängende Issues / Epic | Cross-Package-Feature | `issue-cluster.workflow.mjs` (Gruppierung nach Datei-Overlap) → `wave-decompose.workflow.mjs` → `wave-implement.workflow.mjs` (cross-family adversarial review, Cato für Security) → `wave-verify.workflow.mjs` |
+| Feature von woanders adaptieren | Existierendes Muster aus anderem Projekt übernehmen | `issue-adapt-plan.workflow.mjs` → `issue-adapt-build.workflow.mjs` |
+
+Alle Skripte in `scripts/*.workflow.mjs` laufen über das `Workflow`-Tool (`Workflow({ scriptPath: "scripts/<name>.workflow.mjs", args: {...} })`), nicht als eigenständige Node-Prozesse. Keines von ihnen pusht oder merged selbstständig nach GitHub — "PR erstellen" bzw. "mergen" bleibt immer ein expliziter, von einer Top-Level-Session oder einem Menschen ausgelöster Schritt.
+
+**Review-Kriterien referenzieren statt duplizieren:**
+- Plugin-Contract (PluginContext, 10-Punkte-Package-Checklist): `middleware/assets/boilerplate/{agent-integration,agent-pure-llm}/CLAUDE.md` — das ist die kanonische Quelle; `docs/harness-platform/` ist nur lokales, gitignored Scratch und darf nicht als Referenz zitiert werden.
+- i18n-Regeln für Frontend-Komponenten: `web-ui/CLAUDE.md`.
+
+**Bekannte offene Baustelle beim Testen:** `middleware/test/builder/builderPreviewRoutes.test.ts:735` — dokumentierte Cross-File-Test-Pollution (Test ist isoliert grün, im vollen `npm run test`-Lauf liefert er 404 statt 401 wegen State-Leak aus einer anderen Testdatei). Bevor Build-/Test-Caching (z. B. Turborepo) für die 28 `middleware/packages/@omadia/*`-Packages eingeführt wird, sollte diese Bug-Klasse behoben werden — sonst wird nur unzuverlässiges Grün schneller ausgeliefert.
+
 ## Working in a multi-session repo
 
 **Convention (enforced):** the main clone never receives commits. Every change — even a single-line typo fix — lands in a worktree. This is branch-agnostic: an agent whose HEAD got switched to `main` by a parallel session is caught here too, not just one that created a feature branch in the wrong tree. Enforced by the `.hooks/pre-commit` hook shipped via the engineering-standards skill.


### PR DESCRIPTION
## What

Adds a "Task-Routing" section to `AGENTS.md` mapping task size → which `scripts/*.workflow.mjs` pipeline to use:

- single-file/trivial → inline, no workflow
- single issue, few files → `issue-triage` → `issue-implement`
- multi-issue epic → `issue-cluster` → `wave-decompose` → `wave-implement` → `wave-verify`
- adapting an external feature → `issue-adapt-plan` → `issue-adapt-build`

Also points reviewers at the canonical plugin-boilerplate contract (`middleware/assets/boilerplate/{agent-integration,agent-pure-llm}/CLAUDE.md`) instead of the gitignored `docs/harness-platform/` copy, and flags the known cross-file test-pollution bug (`middleware/test/builder/builderPreviewRoutes.test.ts:735`) as a prerequisite to fix before adopting build/test caching.

## Why

These `workflow.mjs` pipelines already exist and are sophisticated (worktree isolation, adversarial review, Cato security pass) but were undiscoverable — nothing told a session when to reach for them vs. working inline. This is the single highest-leverage, lowest-risk fix from a broader dev-setup review.

## Scope note

During this review I found `.gitignore` has a blanket `.claude/` rule (deliberate, existing policy). The original proposal included project-scoped `.claude/agents/*.md` subagents and a shared `.claude/settings.json`, but since anything under `.claude/` won't ship via a PR without carving out gitignore exceptions, and the policy decision was to keep `.claude/` fully ignored, that guidance was folded into this `AGENTS.md` section as prose instead.

## Not included (flagged, not actioned)

- Turborepo/Nx adoption for the 28 `middleware/packages/@omadia/*` packages (build caching) — real win, but should follow the test-pollution fix, not precede it.
- The test-pollution bug fix itself — separate, substantial task.
- Two duplicate copies of the plugin-boilerplate `CLAUDE.md` under gitignored `docs/harness-platform/` — local-only cleanup, not a git change (`rm -rf docs/harness-platform/boilerplate/{agent-integration,agent-pure-llm}`).
- A broad `Read(//Users/marcelwege/sources/**)` grant in personal `.claude/settings.local.json` — flagged for review, not touched (personal/security-sensitive).

## Test plan

- [x] Docs-only change, no code paths affected
- [x] Verified all cited paths/line numbers exist before committing

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787825091&installation_model_id=428086&pr_number=530&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F530&signature=971ad388cdaf43fe977dd311ad91a1ea57177a93dc628cb0f6508ac590ff9ee6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->