### PR TITLE
fix: MCP OAuth callback 401 + per-user token key mismatch

### DIFF
--- a/middleware/.env.example
+++ b/middleware/.env.example
@@ -110,6 +110,23 @@ DIAGRAM_PUBLIC_BASE_URL=http://localhost:8080
 # when flow callbacks must land on a different origin than the admin UI (rare).
 # FLOW_PUBLIC_BASE_URL=https://omadia.example.com
 
+# --- Generic MCP-server OAuth (epic #459 W9) --------------------------------
+# Absolute redirect URI the MCP OAuth callback (Notion, etc.) lands on after
+# the provider's consent screen. Defaults to
+# FLOW_PUBLIC_BASE_URL/api/v1/operator/mcp-oauth/callback — but that default
+# only resolves correctly when FLOW_PUBLIC_BASE_URL/PUBLIC_BASE_URL already
+# points AT the middleware directly (true on Fly, where PUBLIC_BASE_URL is
+# the middleware's own public host). It is WRONG whenever the public origin
+# is web-ui in front of the middleware (local dev): web-ui's Next server only
+# rewrites `/bot-api/*` to the middleware — `/api/*` is reserved for Next's
+# own routes and is NOT proxied, so the raw `/api/...` default 404s there.
+# Mirrors the AUTH_REDIRECT_URI precedent: in dev, route the callback through
+# the `/bot-api` prefix on web-ui's origin so Next's rewrite forwards it.
+#   Local dev:  http://localhost:3000/bot-api/v1/operator/mcp-oauth/callback
+#   Fly/prod:   leave unset — the PUBLIC_BASE_URL-derived default is correct
+#               once PUBLIC_BASE_URL is the middleware's own public host.
+# MCP_OAUTH_REDIRECT_URI=http://localhost:3000/bot-api/v1/operator/mcp-oauth/callback
+
 # --- In-app "Create Issue" button (operator GitHub device flow) -------------
 # Lets an operator connect their OWN GitHub account and file issues to the
 # public repo (byte5ai/omadia) as themselves. Uses GitHub's DEVICE FLOW, so

--- a/middleware/src/auth/publicPaths.ts
+++ b/middleware/src/auth/publicPaths.ts
@@ -33,6 +33,15 @@ export const STATIC_PUBLIC_PATHS: readonly RegExp[] = [
   // Epic #470 — GitHub redirects finish the dev-platform GitHub-App setup on a
   // signed state token / installation ownership check, not on an operator session.
   /^\/api\/v1\/dev-platform\/github-app\/(?:callback|setup)(?:\/|$|\?)/,
+  // Epic #459 W9 — generic MCP-server OAuth callback (bugfix). Same shape as
+  // the spec-005 kernel OAuth broker callback above: the provider (Notion,
+  // etc.) redirects the operator's browser back here after consent, and the
+  // session cookie may be absent or expired by the time the round-trip
+  // completes. The route self-secures via the signed, single-use `state`
+  // param (see completeAuthorization in agentBuilder.ts) — it was simply
+  // never added to this list when the feature shipped, so it 401'd before
+  // ever reaching the handler that validates that state token.
+  /^\/api\/v1\/operator\/mcp-oauth\/callback(?:\/|$|\?)/,
   // Plugin-served UI surfaces (`/p/<pluginId>/...`), iframed by Teams where
   // only a Teams SSO token exists. Plugins exposing sensitive data validate
   // that token themselves.

--- a/middleware/src/routes/agentBuilder.ts
+++ b/middleware/src/routes/agentBuilder.ts
@@ -29,7 +29,13 @@ import {
   type SubAgentRow,
   type ToolGrantRow,
 } from '@omadia/orchestrator';
-import { McpManager, mcpToolNameFromRef, type McpCallLogEntry } from '@omadia/orchestrator';
+import {
+  McpManager,
+  mcpToolNameFromRef,
+  turnContext,
+  today,
+  type McpCallLogEntry,
+} from '@omadia/orchestrator';
 import { Router, type Request, type Response } from 'express';
 
 import {
@@ -214,7 +220,13 @@ export function createAgentBuilderRouter(
           ? (await graph.listMcpServers()).find((s) => s.id === cfg.id)
           : undefined;
         if (!server) return null;
-        return options.mcpOAuth.getValidAccessToken(server, options.mcpOAuthUserKey ?? 'operator');
+        // Per-user token (bugfix, mirrors the runtime McpManager in index.ts):
+        // tokens are STORED under the request's session-derived key
+        // (oauthUserKey below) at connect time, so lookup must use the same
+        // key. The static `options.mcpOAuthUserKey` fallback only applies
+        // outside any turn context (no session identity available).
+        const userKey = turnContext.current()?.mcpUserKey ?? options.mcpOAuthUserKey ?? 'operator';
+        return options.mcpOAuth.getValidAccessToken(server, userKey);
       },
       // Discover/test-call surface needs-auth via the route's describeAuth path,
       // so the manager itself doesn't need to synthesize a prompt here.
@@ -1051,6 +1063,17 @@ export function createAgentBuilderRouter(
   router.post('/mcp-servers/:id/discover', async (req: Request, res: Response) => {
     const l = live(res);
     if (!l) return;
+    // Establish the per-request MCP OAuth identity (bugfix): the shared
+    // McpManager's getToken reads turnContext.mcpUserKey to look up the token
+    // under the SAME key it was stored under (oauthUserKey(req) — see
+    // auth-status/authorize below), instead of silently falling back to the
+    // static 'operator' default and missing it. `enter` (not `run`) because
+    // this scope is naturally bounded by the request's own async chain.
+    turnContext.enter({
+      turnId: `mcp-discover-${str(req.params.id)}`,
+      turnDate: today(),
+      mcpUserKey: oauthUserKey(req),
+    });
     try {
       const servers = await l.graph.listMcpServers();
       const row = servers.find((s) => s.id === str(req.params.id));

--- a/middleware/test/publicPaths.test.ts
+++ b/middleware/test/publicPaths.test.ts
@@ -1,0 +1,57 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { publicPaths, STATIC_PUBLIC_PATHS } from '../src/auth/publicPaths.js';
+
+/**
+ * Regression guard for the MCP-OAuth-callback 401 bug: the epic #459 W9
+ * callback (`/api/v1/operator/mcp-oauth/callback`) self-secures via a signed,
+ * single-use `state` token — exactly like the spec-005 kernel OAuth broker
+ * callback — but was never added to the requireAuth allowlist, so the
+ * provider's post-consent redirect 401'd before ever reaching the handler
+ * that validates that token. See publicPaths.ts's own module doc: tests here
+ * must assert against the SAME array production runs.
+ */
+describe('publicPaths — MCP OAuth callback allowlist', () => {
+  const allowlist = publicPaths({ devEndpointsEnabled: false });
+
+  it('allows the generic MCP-server OAuth callback', () => {
+    assert.equal(
+      allowlist.some((p) => p.test('/api/v1/operator/mcp-oauth/callback?code=abc&state=xyz')),
+      true,
+    );
+  });
+
+  it('allows the bare callback path with no query string', () => {
+    assert.equal(
+      allowlist.some((p) => p.test('/api/v1/operator/mcp-oauth/callback')),
+      true,
+    );
+  });
+
+  it('does NOT widen the bypass to other /api/v1/operator routes', () => {
+    assert.equal(
+      allowlist.some((p) => p.test('/api/v1/operator/mcp-servers')),
+      false,
+    );
+    assert.equal(
+      allowlist.some((p) => p.test('/api/v1/operator/mcp-servers/abc123/discover')),
+      false,
+    );
+  });
+
+  it('does NOT match a path merely prefixed by the callback segment', () => {
+    // Guards against an overly loose regex swallowing a sibling route.
+    assert.equal(
+      allowlist.some((p) => p.test('/api/v1/operator/mcp-oauth/callback-something-else')),
+      false,
+    );
+  });
+
+  it('is present in STATIC_PUBLIC_PATHS regardless of devEndpointsEnabled', () => {
+    assert.equal(
+      STATIC_PUBLIC_PATHS.some((p) => p.test('/api/v1/operator/mcp-oauth/callback')),
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Reported: "Discover" on the MCP admin page doesn't work locally even for
servers that show as connected, and connecting a new MCP server (e.g.
Notion) 404s/fails on the Fly deployment's OAuth callback.

Root-caused via live probing against the deployed Fly instance and source
inspection — three distinct bugs, not one shared cause:

1. **`/api/v1/operator/mcp-oauth/callback` 401s in production.** This route
   is mounted behind `requireAuth`, but self-secures via a signed single-use
   `state` token exactly like the already-whitelisted spec-005 kernel OAuth
   broker callback. It was never added to the `publicPaths` allowlist when
   epic #459 W9 shipped, so the provider's post-consent redirect gets
   rejected before the handler that validates that token ever runs.
   Confirmed live:
   ```
   GET https://odoo-bot-middleware.fly.dev/api/v1/operator/mcp-oauth/callback
   -> HTTP 401 {"code":"auth.missing","message":"no session"}
   ```

2. **Discover fails even when "connected."** The shared `McpManager`'s
   `getToken` closure in `agentBuilder.ts` always looked up the OAuth token
   using the static `options.mcpOAuthUserKey ?? 'operator'`, while the token
   is actually *stored* under the per-request `oauthUserKey(req)` (session
   `sub`/`email`) — the same key `auth-status`/`authorize`/`token-delete`
   already use. So `auth-status` correctly reports "connected" (right key),
   but Discover's real `mcp.listTools()` call misses the token (wrong key)
   and fails as unauthenticated.

3. **Local OAuth redirect URI points at a path Next.js doesn't proxy.**
   `PUBLIC_BASE_URL` in local dev is web-ui's origin (correct for the
   *admin-login* callback per its own precedent — cookies must land on the
   browser's actual origin). But the MCP OAuth redirect URI derives from the
   same var, and web-ui's Next server only rewrites `/bot-api/*` — `/api/*`
   is reserved for Next's own routes and isn't proxied. Documented the
   existing `MCP_OAUTH_REDIRECT_URI` override in `.env.example`, mirroring
   the `AUTH_REDIRECT_URI` precedent. No derivation/code change needed for
   Fly: `PUBLIC_BASE_URL` there already points directly at the middleware,
   so once (1) ships the existing default resolves correctly.

## Changes

- `middleware/src/auth/publicPaths.ts` — whitelist the MCP OAuth callback.
- `middleware/src/routes/agentBuilder.ts` — read the per-request OAuth
  identity via `turnContext.mcpUserKey` (same mechanism the runtime
  `McpManager` in `index.ts` already uses) instead of the static default;
  set it at the top of the discover route via `turnContext.enter(...)`.
- `middleware/.env.example` — document `MCP_OAUTH_REDIRECT_URI` for local
  dev.
- `middleware/test/publicPaths.test.ts` — new regression test for the
  callback allowlist (asserts the callback is public, and that the bypass
  doesn't widen to other `/api/v1/operator` routes).

## Test plan

- [x] `npm test` — full middleware suite green (4803 tests, 0 failures).
- [x] `tsc --noEmit` clean on the touched file.
- [x] New `publicPaths.test.ts` passes (5/5).
- [ ] Manual: connect a protected MCP server (e.g. Notion) end-to-end on a
      deployed instance and confirm the callback completes instead of 401ing.
- [ ] Manual: Discover on an already-connected protected server as a real
      logged-in operator (not the literal `'operator'` fallback identity)
      and confirm tools populate.

Local dev also needs `MCP_OAUTH_REDIRECT_URI` set in your own `.env` (see
the new `.env.example` block) — that file is gitignored so it isn't part of
this diff.
