### PR TITLE
feat(direct-line): sticky multi-turn mode for Direct Line (#445)

### DIFF
--- a/middleware/packages/harness-channel-sdk/src/chatAgent.ts
+++ b/middleware/packages/harness-channel-sdk/src/chatAgent.ts
@@ -2,6 +2,7 @@ import type { ChannelKind, PrivacyReceipt, RecalledContext } from '@omadia/plugi
 import type {
   AgentConsultation,
   DelegatedAnswer,
+  DirectLineSessionState,
   FollowUpOption,
   SemanticAnswer,
 } from './outgoing.js';
@@ -475,6 +476,13 @@ export interface ChatTurnResult {
    * reword it. Omitted on ordinary turns.
    */
   delegatedAnswer?: DelegatedAnswer;
+  /**
+   * #445 — sticky Direct Line indicator for this turn. Set by the harness in
+   * `executeDirectLine`; `toSemanticAnswer` forwards it to
+   * `SemanticAnswer.directLineSession`. Present on every turn while the
+   * feature is enabled (including `{ active: false }`), omitted when off.
+   */
+  directLineSession?: DirectLineSessionState;
 }
 
 /**
@@ -690,6 +698,12 @@ export type ChatStreamEvent =
        * The orchestrator cannot suppress or reword it.
        */
       delegatedAnswer?: DelegatedAnswer;
+      /**
+       * #445 — sticky Direct Line indicator; see ChatTurnResult.directLineSession.
+       * Rides the existing `done` event exactly like `delegatedAnswer` rather
+       * than adding a stream event type, so the web-ui folds it in one hop.
+       */
+      directLineSession?: DirectLineSessionState;
       /**
        * #332 Layer 1 (gap-closure) — curated, tamper-evident projection of
        * `runTrace.agentInvocations`, identical in shape and derivation to

--- a/middleware/packages/harness-channel-sdk/src/index.ts
+++ b/middleware/packages/harness-channel-sdk/src/index.ts
@@ -120,6 +120,7 @@ export type {
   CaptureDisclosure,
   AgentConsultation,
   DelegatedAnswer,
+  DirectLineSessionState,
 } from './outgoing.js';
 
 // Channel-agnostic store interfaces

--- a/middleware/packages/harness-channel-sdk/src/outgoing.ts
+++ b/middleware/packages/harness-channel-sdk/src/outgoing.ts
@@ -132,6 +132,41 @@ export interface SemanticAnswer {
    * Omitted on ordinary turns (no direct-line directive). Sidecar.
    */
   delegatedAnswer?: DelegatedAnswer;
+
+  /**
+   * #445 — sticky Direct Line indicator. Present on EVERY turn while the
+   * feature is enabled, including `{ active: false }` on ordinary turns. That
+   * is deliberate: a field that only appears while bound cannot tell a client
+   * that a binding ENDED, so a restart, a registry rebuild or a TTL expiry
+   * would leave a stale "you are talking to X" banner on screen. Emitting the
+   * negative makes the indicator self-correcting on the very next turn.
+   * Omitted entirely when the feature is off. Sidecar.
+   */
+  directLineSession?: DirectLineSessionState;
+}
+
+/**
+ * #445 — which specialist, if any, this conversation is currently bound to.
+ * `transition` describes what THIS turn did, so a channel can narrate the
+ * change ("now talking to X") without diffing against its own prior state.
+ */
+export interface DirectLineSessionState {
+  /** True while a binding is live at the END of this turn. */
+  readonly active: boolean;
+  /** Stable agent id of the bound specialist. Omitted when inactive. */
+  readonly agentId?: string;
+  /** Human label of the bound specialist. Omitted when inactive. */
+  readonly label?: string;
+  /** What this turn did to the binding. */
+  readonly transition?:
+    | 'entered'
+    | 'switched'
+    | 'continued'
+    | 'left'
+    | 'unavailable'
+    | 'refused';
+  /** Why a requested binding was refused — only with `transition: 'refused'`. */
+  readonly refusedReason?: 'no-scope' | 'shared-scope' | 'synthetic-scope';
 }
 
 /**

--- a/middleware/packages/harness-channel-sdk/src/toSemanticAnswer.ts
+++ b/middleware/packages/harness-channel-sdk/src/toSemanticAnswer.ts
@@ -169,6 +169,10 @@ export function toSemanticAnswer(r: ChatTurnResult): SemanticAnswer {
       ? { agentsConsulted }
       : {}),
     ...(r.delegatedAnswer ? { delegatedAnswer: r.delegatedAnswer } : {}),
+    // #445 — forward the sticky indicator verbatim. Guarded on PRESENCE, not
+    // on `.active`: `{ active: false }` is the signal that clears a stale
+    // banner, so dropping it would be the one bug this field exists to prevent.
+    ...(r.directLineSession ? { directLineSession: r.directLineSession } : {}),
     ...(attachments && attachments.length > 0 ? { attachments } : {}),
     ...(r.followUpOptions && r.followUpOptions.length > 0
       ? { followUps: r.followUpOptions }

--- a/middleware/packages/harness-orchestrator/manifest.yaml
+++ b/middleware/packages/harness-orchestrator/manifest.yaml
@@ -96,6 +96,12 @@ setup:
       type: "boolean"
       required: false
       help: "Wenn an, klassifiziert ein günstiger Haiku-Call jeden Turn: einfach → Simple-Modell, komplex → Complex-Modell. Migriert aus ORCHESTRATOR_MODEL_ROUTING."
+    - key: "orchestrator_direct_line_sticky"
+      label: "Direct Line: Sticky-Modus"
+      type: "boolean"
+      required: false
+      default: "false"
+      help: "Wenn an, bindet ein blosses `#<agent>` das Gespräch an diesen Spezialisten — jede weitere Nachricht geht direkt dorthin, bis `#end` oder `#orchestrator` gesendet wird. Ohne diesen Schalter wirkt `#<agent> <Frage>` weiterhin nur für eine einzelne Nachricht. Standard: aus. Migriert aus ORCHESTRATOR_DIRECT_LINE_STICKY."
     - key: "model_routing_classifier_model"
       label: "Routing: Klassifizierer-Modell"
       type: "string"

--- a/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
@@ -44,6 +44,7 @@ import type { Microsoft365Accessor } from './microsoft365-shim.js';
 import type { NativeToolRegistry } from './nativeToolRegistry.js';
 import type { ModelRoutingConfig } from './modelRouter.js';
 import { Orchestrator, type OrchestratorPersonaSkill } from './orchestrator.js';
+import type { DirectLineStickyStore } from './directLineSticky.js';
 import { CliChatAgent } from './cliChatAgent.js';
 import { ToolDispatchService } from './toolDispatchService.js';
 import { OrchestratorMemoryNamespacer } from './orchestratorMemoryNamespacer.js';
@@ -80,6 +81,8 @@ export interface AgentRuntimeConfig {
   readonly loopRepeatHard?: number;
   /** Optional per-turn wall-clock budget in seconds (0 / omitted = off). */
   readonly maxTurnSeconds?: number;
+  /** #445 — sticky Direct Line for this Agent (see {@link OrchestratorOptions}). */
+  readonly directLineSticky?: boolean;
   /** Wave 8 — this Agent's direct-answer persona-skill candidates, resolved
    *  by the caller from `agent_persona_skills` (see {@link OrchestratorOptions}).
    *  Per-agent, unlike the platform-shared `OrchestratorDeps` fields below. */
@@ -99,6 +102,13 @@ export interface OrchestratorDeps {
   readonly entityRefBus: EntityRefBus;
   readonly nativeToolRegistry: NativeToolRegistry;
   readonly nudgeRegistry: NudgeRegistry;
+  /**
+   * #445 — process-shared sticky Direct Line binding store. Deps, not
+   * per-Agent config, because the registry REPLACES an Orchestrator instance
+   * on any config diff: a per-instance store would silently unbind every live
+   * conversation whenever an operator tweaked something unrelated.
+   */
+  readonly directLineStickyStore?: DirectLineStickyStore;
   /** Late-bound `responseGuard@1` lookup (see `OrchestratorOptions`). */
   readonly responseGuard: () => ResponseGuardService | undefined;
   /** Late-bound `privacy.redact@1` lookup (see `OrchestratorOptions`). */
@@ -253,6 +263,10 @@ export function buildOrchestratorForAgent(
     provider: deps.provider,
     model: config.model,
     ...(config.modelRouting ? { modelRouting: config.modelRouting } : {}),
+    ...(config.directLineSticky ? { directLineSticky: true } : {}),
+    ...(deps.directLineStickyStore
+      ? { directLineStickyStore: deps.directLineStickyStore }
+      : {}),
     ...(config.personaSkills?.length
       ? { personaSkills: config.personaSkills }
       : {}),

--- a/middleware/packages/harness-orchestrator/src/chatSessionStore.ts
+++ b/middleware/packages/harness-orchestrator/src/chatSessionStore.ts
@@ -1,4 +1,5 @@
 import type { MemoryStore } from '@omadia/plugin-api';
+import type { DirectLineSessionState } from '@omadia/channel-sdk';
 
 /**
  * Persisted chat sessions for the dev-UI chat tab. Each session is a
@@ -59,6 +60,11 @@ export interface ChatMessage {
   error?: boolean;
   startedAt: number;
   finishedAt?: number;
+  /**
+   * #445 — sticky Direct-Line indicator as of this turn, so a reload restores
+   * the banner instead of dropping it. Optional: legacy messages pre-date it.
+   */
+  directLineSession?: DirectLineSessionState;
 }
 
 /**

--- a/middleware/packages/harness-orchestrator/src/directLineSticky.ts
+++ b/middleware/packages/harness-orchestrator/src/directLineSticky.ts
@@ -1,0 +1,387 @@
+/**
+ * #445 Layer 2b — sticky Direct Line: the target-SELECTION layer.
+ *
+ * #332 shipped per-message directives (`#<agent> <question>`). Sustaining a
+ * multi-turn sparring session with one specialist meant re-typing the token on
+ * every message. Sticky mode binds a conversation to a specialist until the
+ * user explicitly leaves.
+ *
+ * The whole feature is one idea: **sticky changes only WHICH
+ * `{candidate, payload}` the existing #332 dispatch body receives.** It never
+ * introduces a second dispatch path. Everything downstream — privacy masking,
+ * the `dispatchTool` choke point, verbatim capture, `delegatedAnswer`
+ * attribution, guarded-mode notes, session logging, fact extraction — is the
+ * same physical code on turn 1 and on turn N, so every #332 / #361 / #474
+ * invariant holds by construction rather than by re-implementation.
+ *
+ * Everything here is pure and synchronous: no Orchestrator, no I/O, no
+ * promises. The store being synchronous matters — it means a read-modify-write
+ * is atomic on Node's single thread, so two concurrent turns in one session can
+ * never interleave between a sticky read and its write.
+ */
+
+import {
+  parseDirectLineDirective,
+  resolveDirectLineTarget,
+  type DirectLineCandidate,
+} from './directLine.js';
+
+/** A live binding: this conversation currently talks to this specialist. */
+export interface DirectLineBinding {
+  /** Stable tool name — the key into the orchestrator's whitelist map. */
+  readonly toolName: string;
+  /** Stable agent id when known (re-checked for availability every turn). */
+  readonly agentId?: string;
+  /** Human label for attribution and the on-screen indicator. */
+  readonly label: string;
+  /** When the binding was first established. Stable across touches. */
+  readonly boundAt: number;
+  /** Last turn that used the binding — the idle-TTL clock. */
+  readonly lastTurnAt: number;
+}
+
+/** Why a conversation is not allowed to hold a sticky binding. */
+export type StickyScopeRefusal = 'no-scope' | 'shared-scope' | 'synthetic-scope';
+
+export type StickyScopeClassification =
+  | { readonly kind: 'eligible'; readonly key: string }
+  | { readonly kind: 'refused'; readonly reason: StickyScopeRefusal };
+
+/** Idle lifetime of a binding. Mirrors the conversation-history store. */
+export const STICKY_IDLE_TTL_MS = 2 * 60 * 60 * 1000;
+
+/** LRU cap. A bounded map cannot become a memory leak. */
+export const STICKY_MAX_BINDINGS = 1000;
+
+/**
+ * Reserved exit tokens. Deliberately NOT resolvable agent names: the exit is
+ * honoured only when the token does not resolve to a whitelisted specialist,
+ * so a deployment that ships an `End` agent keeps its agent and loses only one
+ * of the two exit spellings.
+ */
+export const DIRECT_LINE_EXIT_TOKENS: ReadonlySet<string> = new Set(['end', 'orchestrator']);
+
+/**
+ * Session scopes that are NOT per-conversation. `resolveScope` in
+ * `middleware/src/routes/chat.ts` returns the literal `'http-default'` for any
+ * caller that sends neither `scope` nor `sessionId`, so binding on it alone
+ * would hand one caller's specialist to every other anonymous caller.
+ */
+export const SHARED_SCOPES: ReadonlySet<string> = new Set([
+  'http-default',
+  'teams-unknown',
+  'unknown',
+]);
+
+/**
+ * Machine-driven scopes. These repeat verbatim across every execution
+ * (`routine:<id>` is constant), so a binding would outlive any human intent
+ * and accumulate forever. Refused unconditionally — a userId does not redeem
+ * them, because there is no human conversation to be sticky about.
+ */
+export const SYNTHETIC_SCOPE_PREFIXES: readonly string[] = [
+  'routine:',
+  'schedule:',
+  'conductor:',
+  'conductor-builder:',
+];
+
+/**
+ * NUL separator. It cannot occur in a kebab agent slug, in a channel
+ * conversation id, or in a `USER_ID_RE`-validated user id, so no field
+ * combination can collide with another. This key never reaches the knowledge
+ * graph, so the 80-char `sanitizeScope` truncation is structurally irrelevant.
+ */
+const KEY_SEPARATOR = '\0';
+
+export function stickyKeyFor(args: {
+  readonly agentSlug: string;
+  readonly sessionScope: string;
+  readonly userId?: string;
+}): string {
+  return `${args.agentSlug}${KEY_SEPARATOR}${args.sessionScope}${KEY_SEPARATOR}${args.userId ?? ''}`;
+}
+
+/**
+ * Allow-gate for sticky state. Names its refusal instead of silently doing
+ * nothing, so the caller can tell the user why the binding did not take.
+ */
+export function classifyStickyScope(args: {
+  readonly agentSlug: string;
+  readonly sessionScope?: string;
+  readonly userId?: string;
+}): StickyScopeClassification {
+  const scope = args.sessionScope?.trim() ?? '';
+  if (scope.length === 0) return { kind: 'refused', reason: 'no-scope' };
+  if (SYNTHETIC_SCOPE_PREFIXES.some((prefix) => scope.startsWith(prefix))) {
+    return { kind: 'refused', reason: 'synthetic-scope' };
+  }
+  const userId = args.userId?.trim() ?? '';
+  if (SHARED_SCOPES.has(scope) && userId.length === 0) {
+    return { kind: 'refused', reason: 'shared-scope' };
+  }
+  return {
+    kind: 'eligible',
+    key: stickyKeyFor({
+      agentSlug: args.agentSlug,
+      sessionScope: scope,
+      ...(userId.length > 0 ? { userId } : {}),
+    }),
+  };
+}
+
+/** The bare token of a whole-message directive, or undefined. */
+function wholeMessageToken(text: string, prefix: string): string | undefined {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith(prefix)) return undefined;
+  return trimmed.slice(prefix.length).toLowerCase();
+}
+
+/**
+ * True only when the ENTIRE trimmed message is `<prefix><exit-token>`.
+ *
+ * Whole-message-only is what keeps `#end of quarter — what now?` a genuine
+ * question to the specialist rather than a surprise exit that silently eats
+ * the user's text.
+ */
+export function isDirectLineExitMessage(text: string, prefix: string): boolean {
+  const token = wholeMessageToken(text, prefix);
+  return token !== undefined && DIRECT_LINE_EXIT_TOKENS.has(token);
+}
+
+export type DirectLineDecision =
+  /** Not a direct-line turn — proceed with the normal LLM loop. */
+  | { readonly kind: 'ordinary' }
+  /** Bind the conversation to this specialist. No dispatch this turn. */
+  | { readonly kind: 'enter'; readonly candidate: DirectLineCandidate }
+  /** Hand the conversation back to the orchestrator. No dispatch this turn. */
+  | { readonly kind: 'exit' }
+  /** Dispatch to this specialist. `sticky` distinguishes bound from one-shot. */
+  | {
+      readonly kind: 'dispatch';
+      readonly candidate: DirectLineCandidate;
+      readonly payload: string;
+      readonly sticky: boolean;
+    }
+  /** A faithful, non-dispatching reply. */
+  | {
+      readonly kind: 'notice';
+      readonly reason: 'ambiguous' | 'no-question' | 'sticky-refused' | 'already-bound';
+      readonly matches?: readonly DirectLineCandidate[];
+      readonly candidate?: DirectLineCandidate;
+      readonly refusedReason?: StickyScopeRefusal;
+    };
+
+const ORDINARY: DirectLineDecision = { kind: 'ordinary' };
+
+function candidateOf(binding: DirectLineBinding): DirectLineCandidate {
+  return {
+    toolName: binding.toolName,
+    ...(binding.agentId ? { agentId: binding.agentId } : {}),
+    label: binding.label,
+  };
+}
+
+function stickyDispatch(binding: DirectLineBinding, userMessage: string): DirectLineDecision {
+  return {
+    kind: 'dispatch',
+    candidate: candidateOf(binding),
+    payload: userMessage,
+    sticky: true,
+  };
+}
+
+/** Exactly #332's rules — used verbatim when the feature flag is off. */
+function decideWithoutSticky(
+  userMessage: string,
+  prefix: string,
+  candidates: readonly DirectLineCandidate[],
+): DirectLineDecision {
+  const directive = parseDirectLineDirective(userMessage, prefix);
+  if (!directive) return ORDINARY;
+  const resolution = resolveDirectLineTarget(directive.token, candidates);
+  if (resolution.kind === 'unknown') return ORDINARY;
+  if (resolution.kind === 'ambiguous') {
+    return { kind: 'notice', reason: 'ambiguous', matches: resolution.matches };
+  }
+  if (directive.payload.length === 0) {
+    return { kind: 'notice', reason: 'no-question', candidate: resolution.candidate };
+  }
+  return {
+    kind: 'dispatch',
+    candidate: resolution.candidate,
+    payload: directive.payload,
+    sticky: false,
+  };
+}
+
+function decideWithSticky(args: {
+  readonly userMessage: string;
+  readonly prefix: string;
+  readonly candidates: readonly DirectLineCandidate[];
+  readonly binding: DirectLineBinding | undefined;
+  readonly scope: StickyScopeClassification;
+}): DirectLineDecision {
+  const { userMessage, prefix, candidates, binding, scope } = args;
+
+  // Exit is checked FIRST so a live binding can never swallow it.
+  if (binding && isDirectLineExitMessage(userMessage, prefix)) {
+    const token = wholeMessageToken(userMessage, prefix) ?? '';
+    if (resolveDirectLineTarget(token, candidates).kind !== 'resolved') {
+      return { kind: 'exit' };
+    }
+  }
+
+  const directive = parseDirectLineDirective(userMessage, prefix);
+  if (!directive) return binding ? stickyDispatch(binding, userMessage) : ORDINARY;
+
+  const resolution = resolveDirectLineTarget(directive.token, candidates);
+  if (resolution.kind === 'ambiguous') {
+    return { kind: 'notice', reason: 'ambiguous', matches: resolution.matches };
+  }
+  // The #332 collision rule, preserved literally: an unresolvable `#token` is
+  // ordinary text. While bound it belongs to the specialist, verbatim and whole.
+  if (resolution.kind === 'unknown') {
+    return binding ? stickyDispatch(binding, userMessage) : ORDINARY;
+  }
+
+  // A directive WITH a question stays a one-shot and never rebinds — this is
+  // what stops the Teams "Direkt mit X" button (which submits
+  // `#<token> <original message>`) from silently mode-switching a thread.
+  if (directive.payload.length > 0) {
+    return {
+      kind: 'dispatch',
+      candidate: resolution.candidate,
+      payload: directive.payload,
+      sticky: false,
+    };
+  }
+
+  // Bare `#<agent>` — the entry gesture. Today this is the one dead end in
+  // executeDirectLine ("you didn't include a question"), so it is free grammar.
+  if (binding && binding.toolName === resolution.candidate.toolName) {
+    return { kind: 'notice', reason: 'already-bound', candidate: resolution.candidate };
+  }
+  if (scope.kind === 'refused') {
+    return {
+      kind: 'notice',
+      reason: 'sticky-refused',
+      candidate: resolution.candidate,
+      refusedReason: scope.reason,
+    };
+  }
+  return { kind: 'enter', candidate: resolution.candidate };
+}
+
+/**
+ * The whole selection rule, as one pure function. Ordered so that the flag-off
+ * path is provably identical to #332 and the exit can never be shadowed.
+ */
+export function decideDirectLineTurn(args: {
+  readonly userMessage: string;
+  readonly prefix: string;
+  readonly candidates: readonly DirectLineCandidate[];
+  readonly binding: DirectLineBinding | undefined;
+  readonly stickyEnabled: boolean;
+  readonly scope: StickyScopeClassification;
+}): DirectLineDecision {
+  if (!args.stickyEnabled) {
+    return decideWithoutSticky(args.userMessage, args.prefix, args.candidates);
+  }
+  return decideWithSticky({
+    userMessage: args.userMessage,
+    prefix: args.prefix,
+    candidates: args.candidates,
+    binding: args.binding,
+    scope: args.scope,
+  });
+}
+
+/** Synchronous by contract — see the module header. */
+export interface DirectLineStickyStore {
+  get(key: string): DirectLineBinding | undefined;
+  bind(
+    key: string,
+    binding: Pick<DirectLineBinding, 'toolName' | 'agentId' | 'label'>,
+  ): DirectLineBinding;
+  touch(key: string): void;
+  clear(key: string): void;
+  size(): number;
+}
+
+/**
+ * Process-shared, bounded, idle-expiring binding store.
+ *
+ * Deliberately NOT an Orchestrator instance field: the registry replaces the
+ * instance on any config diff, which would silently unbind every live session
+ * on an unrelated operator tweak. Every way a binding can be lost — TTL, LRU
+ * eviction, process restart — fails toward the orchestrator, which is the safe
+ * direction.
+ */
+export class InMemoryDirectLineStickyStore implements DirectLineStickyStore {
+  private readonly bindings = new Map<string, DirectLineBinding>();
+  private readonly now: () => number;
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+
+  constructor(opts?: { now?: () => number; ttlMs?: number; maxEntries?: number }) {
+    this.now = opts?.now ?? (() => Date.now());
+    this.ttlMs = opts?.ttlMs ?? STICKY_IDLE_TTL_MS;
+    this.maxEntries = opts?.maxEntries ?? STICKY_MAX_BINDINGS;
+  }
+
+  get(key: string): DirectLineBinding | undefined {
+    const existing = this.bindings.get(key);
+    if (!existing) return undefined;
+    if (this.now() - existing.lastTurnAt > this.ttlMs) {
+      this.bindings.delete(key);
+      return undefined;
+    }
+    // Re-insert to move the entry to the most-recently-used end.
+    this.bindings.delete(key);
+    this.bindings.set(key, existing);
+    return existing;
+  }
+
+  bind(
+    key: string,
+    binding: Pick<DirectLineBinding, 'toolName' | 'agentId' | 'label'>,
+  ): DirectLineBinding {
+    const at = this.now();
+    const next: DirectLineBinding = {
+      toolName: binding.toolName,
+      ...(binding.agentId ? { agentId: binding.agentId } : {}),
+      label: binding.label,
+      boundAt: at,
+      lastTurnAt: at,
+    };
+    this.bindings.delete(key);
+    this.bindings.set(key, next);
+    this.evictOverflow();
+    return next;
+  }
+
+  touch(key: string): void {
+    const existing = this.bindings.get(key);
+    if (!existing) return;
+    const next: DirectLineBinding = { ...existing, lastTurnAt: this.now() };
+    this.bindings.delete(key);
+    this.bindings.set(key, next);
+  }
+
+  clear(key: string): void {
+    this.bindings.delete(key);
+  }
+
+  size(): number {
+    return this.bindings.size;
+  }
+
+  private evictOverflow(): void {
+    while (this.bindings.size > this.maxEntries) {
+      const oldest = this.bindings.keys().next();
+      if (oldest.done === true) return;
+      this.bindings.delete(oldest.value);
+    }
+  }
+}

--- a/middleware/packages/harness-orchestrator/src/index.ts
+++ b/middleware/packages/harness-orchestrator/src/index.ts
@@ -186,6 +186,30 @@ export type {
   DirectLineMode,
 } from './directLine.js';
 
+// #445 — sticky Direct Line: the pure target-selection layer. Exported so the
+// decision table, the scope allow-gate and the binding store can be unit-tested
+// without an Orchestrator, and so the store can be constructed once at boot and
+// injected (it must outlive any single Orchestrator instance).
+export {
+  classifyStickyScope,
+  decideDirectLineTurn,
+  isDirectLineExitMessage,
+  stickyKeyFor,
+  InMemoryDirectLineStickyStore,
+  DIRECT_LINE_EXIT_TOKENS,
+  SHARED_SCOPES,
+  SYNTHETIC_SCOPE_PREFIXES,
+  STICKY_IDLE_TTL_MS,
+  STICKY_MAX_BINDINGS,
+} from './directLineSticky.js';
+export type {
+  DirectLineBinding,
+  DirectLineDecision,
+  DirectLineStickyStore,
+  StickyScopeClassification,
+  StickyScopeRefusal,
+} from './directLineSticky.js';
+
 // Round-loop guard — exported so it can be unit-tested in isolation and reused
 // by other agentic loops (e.g. the Builder).
 export { LoopGuard, canonicalize } from './loopGuard.js';

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -7,6 +7,7 @@ import {
   type ChatTurnInput,
   type ChatTurnResult,
   type DelegatedAnswer,
+  type DirectLineSessionState,
   type DiagramAttachment,
   type OutgoingFileAttachment,
   type PendingRoutineList,
@@ -118,12 +119,21 @@ import {
 } from './privacyHandle.js';
 import { RunTraceCollector, type InvocationHandle } from './runTraceCollector.js';
 import {
-  parseDirectLineDirective,
   resolveDirectLineTarget,
   directLineLabel,
   type DirectLineCandidate,
   type DirectLineMode,
 } from './directLine.js';
+import {
+  DIRECT_LINE_EXIT_TOKENS,
+  InMemoryDirectLineStickyStore,
+  classifyStickyScope,
+  decideDirectLineTurn,
+  type DirectLineBinding,
+  type DirectLineDecision,
+  type DirectLineStickyStore,
+  type StickyScopeClassification,
+} from './directLineSticky.js';
 import type { NativeToolRegistry } from './nativeToolRegistry.js';
 import { isInternExemptTool } from './privacyInternPolicy.js';
 import { graphScopeFor, type SessionLogger } from './sessionLogger.js';
@@ -261,6 +271,21 @@ export interface OrchestratorOptions {
    * mention/markup parsing (see directLine.ts).
    */
   directLinePrefix?: string;
+  /**
+   * #445 — sticky Direct Line. When true, a bare `#<agent>` binds the
+   * conversation to that specialist until the user sends `#end` /
+   * `#orchestrator`. Off by default: while it is off, `executeDirectLine`
+   * behaves byte-for-byte as #332 did.
+   */
+  directLineSticky?: boolean;
+  /**
+   * #445 — binding store. Injected so it OUTLIVES this Orchestrator instance:
+   * the registry replaces the instance on any config diff, and an instance
+   * field would silently unbind every live session on an unrelated operator
+   * tweak. Absent → a private instance (keeps `new Orchestrator({…})`
+   * unit-testable without boot wiring).
+   */
+  directLineStickyStore?: DirectLineStickyStore;
   /**
    * #332 Layer 3 (gap-closure) — standing, per-orchestrator forced-delegation
    * obligation. When set to one of this orchestrator's whitelisted domain
@@ -1293,6 +1318,10 @@ export class Orchestrator {
   private readonly directLineMode: DirectLineMode;
   /** #332 Layer 2 — directive prefix (default `'#'`). */
   private readonly directLinePrefix: string;
+  /** #445 — sticky Direct Line enabled for this Agent (default off). */
+  private readonly directLineSticky: boolean;
+  /** #445 — binding store; injected at boot so it survives a registry rebuild. */
+  private readonly directLineStickyStore: DirectLineStickyStore;
   /** #332 Layer 3 (gap-closure) — standing forced-consult tool name, if any. */
   private readonly requiredConsultToolName: string | undefined;
   // systemPrompt is rebuilt live per turn from `buildSystemPrompt()` —
@@ -1376,6 +1405,31 @@ export class Orchestrator {
     this.domainToolsByName = new Map(options.domainTools.map((t) => [t.name, t]));
     this.directLineMode = options.directLineMode ?? 'strict';
     this.directLinePrefix = options.directLinePrefix ?? '#';
+    this.directLineSticky = options.directLineSticky ?? false;
+    this.directLineStickyStore =
+      options.directLineStickyStore ?? new InMemoryDirectLineStickyStore();
+    // #445 — a deployment whose specialist normalizes to a reserved exit token
+    // keeps its agent (resolution wins) and loses only that one exit spelling.
+    // Say so once at construction rather than leaving an operator to discover
+    // it from a conversation that will not end.
+    if (this.directLineSticky) {
+      for (const tool of this.domainToolsByName.values()) {
+        const label = directLineLabel(tool.agentId ?? tool.name);
+        for (const token of DIRECT_LINE_EXIT_TOKENS) {
+          if (
+            resolveDirectLineTarget(token, [
+              { toolName: tool.name, ...(tool.agentId ? { agentId: tool.agentId } : {}), label },
+            ]).kind === 'resolved'
+          ) {
+            console.warn(
+              `[orchestrator] direct-line sticky: specialist "${label}" shadows the reserved ` +
+                `exit token "${this.directLinePrefix}${token}" — use ` +
+                `"${this.directLinePrefix}${token === 'end' ? 'orchestrator' : 'end'}" to leave.`,
+            );
+          }
+        }
+      }
+    }
     this.requiredConsultToolName = options.requiredConsultToolName;
     this.knowledgeGraph = options.knowledgeGraph;
     this.knowledgeGraphTool = options.knowledgeGraph
@@ -2242,6 +2296,12 @@ export class Orchestrator {
         let result: ChatTurnResult;
         try {
           result = direct ?? (await this.chatInContext(input, turnId));
+          // #445 — an ordinary turn is by definition an UNBOUND turn (a live
+          // binding would have produced a sticky dispatch), so stamp the
+          // negative. Without it a client could never learn a binding ended.
+          if (!direct && this.directLineSticky) {
+            result = { ...result, directLineSession: { active: false } };
+          }
         } catch (err) {
           // #361 — failure-closed prompt masking: the prompt never reached
           // the model; answer with a generic privacy error instead of a raw
@@ -2325,12 +2385,6 @@ export class Orchestrator {
     input: ChatTurnInput,
     turnId: string,
   ): Promise<ChatTurnResult | undefined> {
-    const directive = parseDirectLineDirective(
-      input.userMessage,
-      this.directLinePrefix,
-    );
-    if (!directive) return undefined; // ordinary turn — proceed with the LLM.
-
     // Candidates = THIS orchestrator's whitelisted sub-agents (OB-29-1 gating).
     const candidates: DirectLineCandidate[] = Array.from(
       this.domainToolsByName.values(),
@@ -2340,31 +2394,80 @@ export class Orchestrator {
       label: directLineLabel(t.agentId ?? t.name),
     }));
 
-    const resolution = resolveDirectLineTarget(directive.token, candidates);
-    // Collision rule (#332 Open Q3): a leading `#token` is only treated as a
-    // Direct-Line directive when it RESOLVES to a whitelisted specialist.
-    // An unknown token falls THROUGH to the normal LLM turn — so an ordinary
-    // message that merely starts with `#` (e.g. `#urgent …`, `#1 priority …`,
-    // a hashtag) is never hijacked into a "no such agent" reply. Ambiguity (the
-    // token matched ≥2 whitelisted agents) IS a directive intent, so we
-    // disambiguate rather than route silently (Pitfall 7).
-    if (resolution.kind === 'unknown') return undefined;
-    if (resolution.kind === 'ambiguous') {
-      const names = resolution.matches.map((c) => c.label).join(', ');
+    // #445 — TARGET SELECTION. This block is the entire sticky feature: it
+    // decides WHICH `{candidate, payload}` the unchanged #332 dispatch body
+    // below receives. With sticky off, `decideDirectLineTurn` reproduces #332's
+    // rules exactly (unknown ⇒ fall through to the LLM, ambiguous ⇒ notice,
+    // empty payload ⇒ notice, else dispatch), so this is a refactor, not a
+    // behaviour change, until an operator turns the flag on.
+    const scope: StickyScopeClassification = this.directLineSticky
+      ? classifyStickyScope({
+          agentSlug: this.agentId,
+          ...(input.sessionScope ? { sessionScope: input.sessionScope } : {}),
+          ...(input.userId ? { userId: input.userId } : {}),
+        })
+      : { kind: 'refused', reason: 'no-scope' };
+    const stickyKey = scope.kind === 'eligible' ? scope.key : undefined;
+    const binding = stickyKey ? this.directLineStickyStore.get(stickyKey) : undefined;
+
+    const decision = decideDirectLineTurn({
+      userMessage: input.userMessage,
+      prefix: this.directLinePrefix,
+      candidates,
+      binding,
+      stickyEnabled: this.directLineSticky,
+      scope,
+    });
+
+    // Ordinary turn — proceed with the LLM. The caller stamps `{active:false}`.
+    if (decision.kind === 'ordinary') return undefined;
+
+    if (decision.kind === 'exit') {
+      if (stickyKey) this.directLineStickyStore.clear(stickyKey);
+      const label = binding?.label ?? 'The specialist';
       return this.directLineNotice(
-        `"${directive.token}" is ambiguous — it matches ${names}. Please name one specifically.`,
+        `Back to the orchestrator — ${label} is no longer answering directly.`,
+        { active: false, transition: 'left' },
       );
     }
 
-    // A resolved specialist with no question — ask for one rather than
-    // dispatching an empty payload.
-    if (directive.payload.length === 0) {
+    if (decision.kind === 'notice') return this.directLineDecisionNotice(decision, binding);
+
+    if (decision.kind === 'enter') {
+      const target = this.domainToolsByName.get(decision.candidate.toolName);
+      if (!target || !this.isToolAvailable(target.agentId)) {
+        return this.directLineNotice(
+          `Specialist "${decision.candidate.label}" is no longer available.`,
+          this.directLineStateFor(binding),
+        );
+      }
+      if (!stickyKey) {
+        // Unreachable via `decideDirectLineTurn` (an ineligible scope yields a
+        // 'sticky-refused' notice), but binding without a key would silently
+        // drop the binding and strand the user in a mode that never engages.
+        return this.directLineNotice(
+          `Direct mode is not available in this conversation.`,
+          { active: false, transition: 'refused', refusedReason: 'no-scope' },
+        );
+      }
+      const bound = this.directLineStickyStore.bind(stickyKey, {
+        toolName: decision.candidate.toolName,
+        ...(decision.candidate.agentId ? { agentId: decision.candidate.agentId } : {}),
+        label: decision.candidate.label,
+      });
       return this.directLineNotice(
-        `You addressed ${resolution.candidate.label} but didn't include a question. Try \`${this.directLinePrefix}${directive.token} <your question>\`.`,
+        `You are now talking to ${bound.label}. Every message goes straight there — ` +
+          `send \`${this.directLinePrefix}end\` to come back to the orchestrator.`,
+        {
+          active: true,
+          ...(bound.agentId ? { agentId: bound.agentId } : {}),
+          label: bound.label,
+          transition: binding ? 'switched' : 'entered',
+        },
       );
     }
 
-    const candidate = resolution.candidate;
+    const candidate = decision.candidate;
     const tool = this.domainToolsByName.get(candidate.toolName);
     // Issue #474 (round 4) — a not-ready plugin's domain tool must resolve
     // the same as a deleted one: `dispatchToolInner` already blocks the
@@ -2373,9 +2476,15 @@ export class Orchestrator {
     // delegatedAnswer and shown to the user as if the specialist itself had
     // answered. Reuse the SAME notice as the deleted-tool branch above
     // instead of surfacing that internal dispatch-error string.
+    // #445 — this now re-runs on EVERY sticky turn, so a mid-session uninstall
+    // unbinds the conversation instead of stranding it on a dead specialist.
     if (!tool || !this.isToolAvailable(tool.agentId)) {
+      if (decision.sticky && stickyKey) this.directLineStickyStore.clear(stickyKey);
       return this.directLineNotice(
         `Specialist "${candidate.label}" is no longer available.`,
+        decision.sticky
+          ? { active: false, transition: 'unavailable' }
+          : this.directLineStateFor(binding),
       );
     }
 
@@ -2386,10 +2495,22 @@ export class Orchestrator {
     // real values (the no-redaction invariant holds on the restored text).
     // Failure-closed: a `blocked` outcome answers with the generic privacy
     // error (audited by the guard) instead of dispatching unmasked.
+    // #445 — slide the idle window BEFORE dispatch, so a long specialist call
+    // cannot let the binding expire underneath the very turn that is using it.
+    if (decision.sticky && stickyKey) this.directLineStickyStore.touch(stickyKey);
+    const directLineSession: DirectLineSessionState | undefined = decision.sticky
+      ? {
+          active: true,
+          ...(candidate.agentId ? { agentId: candidate.agentId } : {}),
+          label: candidate.label,
+          transition: 'continued',
+        }
+      : this.directLineStateFor(binding);
+
     const privacyForPrompt = turnContext.current()?.privacyHandle;
     let wirePayload: string;
     try {
-      wirePayload = await maskPromptForWire(privacyForPrompt, directive.payload);
+      wirePayload = await maskPromptForWire(privacyForPrompt, decision.payload);
     } catch (err) {
       if (err instanceof PromptMaskBlockedError) {
         console.error(`[orchestrator] direct-line dispatch blocked — ${err.message}`);
@@ -2471,7 +2592,7 @@ export class Orchestrator {
     ) {
       const note = await this.maybeDirectLineNote(
         candidate.label,
-        directive.payload,
+        decision.payload,
         verbatim,
       );
       if (note) answer = `${verbatim}\n\n▸ omadia note: ${note}`;
@@ -2547,7 +2668,66 @@ export class Orchestrator {
       runTrace,
       delegatedAnswer,
       ...(persistedTurnId ? { turnId: persistedTurnId } : {}),
+      ...(directLineSession ? { directLineSession } : {}),
     };
+  }
+
+  /**
+   * #445 — the indicator for a turn that did not change the binding. Returns
+   * `undefined` while the feature is off so the field never appears at all;
+   * once on, EVERY turn carries a state (including `{active:false}`), which is
+   * what lets a client clear a stale banner after a restart or a TTL expiry.
+   */
+  private directLineStateFor(
+    binding: DirectLineBinding | undefined,
+  ): DirectLineSessionState | undefined {
+    if (!this.directLineSticky) return undefined;
+    if (!binding) return { active: false };
+    return {
+      active: true,
+      ...(binding.agentId ? { agentId: binding.agentId } : {}),
+      label: binding.label,
+      transition: 'continued',
+    };
+  }
+
+  /** #445 — render a non-dispatching decision as a faithful notice turn. */
+  private directLineDecisionNotice(
+    decision: Extract<DirectLineDecision, { kind: 'notice' }>,
+    binding: DirectLineBinding | undefined,
+  ): ChatTurnResult {
+    switch (decision.reason) {
+      case 'ambiguous': {
+        const names = (decision.matches ?? []).map((c) => c.label).join(', ');
+        return this.directLineNotice(
+          `That name is ambiguous — it matches ${names}. Please name one specifically.`,
+          this.directLineStateFor(binding),
+        );
+      }
+      case 'no-question':
+        return this.directLineNotice(
+          `You addressed ${decision.candidate?.label ?? 'a specialist'} but didn't include a ` +
+            `question. Try \`${this.directLinePrefix}<agent> <your question>\`.`,
+          this.directLineStateFor(binding),
+        );
+      case 'already-bound':
+        return this.directLineNotice(
+          `You are already talking to ${decision.candidate?.label ?? 'that specialist'}. ` +
+            `Send \`${this.directLinePrefix}end\` to come back to the orchestrator.`,
+          this.directLineStateFor(binding),
+        );
+      case 'sticky-refused':
+        return this.directLineNotice(
+          `Direct mode is not available in this conversation. You can still ask ` +
+            `${decision.candidate?.label ?? 'a specialist'} one question at a time with ` +
+            `\`${this.directLinePrefix}<agent> <your question>\`.`,
+          {
+            active: false,
+            transition: 'refused',
+            ...(decision.refusedReason ? { refusedReason: decision.refusedReason } : {}),
+          },
+        );
+    }
   }
 
   /**
@@ -2557,8 +2737,16 @@ export class Orchestrator {
    * Never silently routes to the wrong agent (Pitfall 7). An UNKNOWN token is
    * not handled here — it falls through to the normal LLM turn (collision rule).
    */
-  private directLineNotice(text: string): ChatTurnResult {
-    return { answer: text, toolCalls: 0, iterations: 0 };
+  private directLineNotice(
+    text: string,
+    directLineSession?: DirectLineSessionState,
+  ): ChatTurnResult {
+    return {
+      answer: text,
+      toolCalls: 0,
+      iterations: 0,
+      ...(directLineSession ? { directLineSession } : {}),
+    };
   }
 
   /**
@@ -3514,6 +3702,11 @@ export class Orchestrator {
           ...(directAgentsConsulted && directAgentsConsulted.length > 0
             ? { agentsConsulted: directAgentsConsulted }
             : {}),
+          // #445 — guarded on PRESENCE, never on `.active`: `{active:false}` is
+          // exactly the payload that clears a stale banner.
+          ...(direct.directLineSession
+            ? { directLineSession: direct.directLineSession }
+            : {}),
         };
         if (privacyHandle) {
           try {
@@ -4112,6 +4305,11 @@ export class Orchestrator {
             ...(finalAgentsConsulted && finalAgentsConsulted.length > 0
               ? { agentsConsulted: finalAgentsConsulted }
               : {}),
+            // #445 — reached only on an ordinary (unbound) turn; stamp the
+            // negative so a client can clear a banner it is still showing.
+            ...(this.directLineSticky
+              ? { directLineSession: { active: false } as const }
+              : {}),
           };
           return;
         }
@@ -4352,6 +4550,9 @@ export class Orchestrator {
             ...(choiceAgentsConsulted && choiceAgentsConsulted.length > 0
               ? { agentsConsulted: choiceAgentsConsulted }
               : {}),
+            ...(this.directLineSticky
+              ? { directLineSession: { active: false } as const }
+              : {}),
           };
           return;
         }
@@ -4447,6 +4648,9 @@ export class Orchestrator {
           iterations,
           ...(persistedTurnId ? { turnId: persistedTurnId } : {}),
           ...(runTrace ? { runTrace } : {}),
+          ...(this.directLineSticky
+            ? { directLineSession: { active: false } as const }
+            : {}),
         };
       } else {
         yield {

--- a/middleware/packages/harness-orchestrator/src/plugin.ts
+++ b/middleware/packages/harness-orchestrator/src/plugin.ts
@@ -54,6 +54,7 @@ import type { TurnHookRunner } from './turnHooks.js';
 import type { ChatSessionStore } from './chatSessionStore.js';
 import type { NativeToolRegistry } from './nativeToolRegistry.js';
 import type { Orchestrator } from './orchestrator.js';
+import { InMemoryDirectLineStickyStore } from './directLineSticky.js';
 import { DEFAULT_ORCHESTRATOR_MODEL } from './registry/agentRuntime.js';
 import { ConfigStore } from './registry/configStore.js';
 import {
@@ -576,6 +577,12 @@ export async function activate(
     graphTenantId,
     ...(assistantIdentity ? { assistantIdentity } : {}),
     ...(turnHookRegistry ? { turnHookRegistry } : {}),
+    // #445 — one binding store for the whole process, shared by every Agent
+    // the registry builds and rebuilt by none of them. Constructed
+    // unconditionally: it is an empty Map until the flag is on, and holding it
+    // in deps means toggling the flag at runtime never strands a binding in a
+    // store that has been thrown away.
+    directLineStickyStore: new InMemoryDirectLineStickyStore(),
     attachmentReader,
   };
   // Per-turn Sonnet/Opus routing (opt-in). When `orchestrator_model_routing`
@@ -619,11 +626,26 @@ export async function activate(
     );
   }
 
+  // #445 — sticky Direct Line. Read defensively: the installed-plugin config
+  // may hold a real boolean (persisted by the install service) OR the string
+  // the manifest/bootstrap seeds. `.trim()` on a boolean throws, and `?? ''`
+  // does not protect because `false` is not nullish.
+  const stickyRaw = ctx.config.get<unknown>('orchestrator_direct_line_sticky');
+  const directLineSticky =
+    stickyRaw === true || String(stickyRaw).trim().toLowerCase() === 'true';
+  if (directLineSticky) {
+    console.log(
+      '[harness-orchestrator] direct-line sticky mode ON — a bare `#<agent>` binds the ' +
+        'conversation until `#end`.',
+    );
+  }
+
   const built = buildOrchestratorForAgent(
     {
       agentId: 'default',
       model,
       ...(modelRouting ? { modelRouting } : {}),
+      ...(directLineSticky ? { directLineSticky: true } : {}),
       maxTokens,
       maxToolIterations: maxIterations,
       ...(maxTurnSeconds > 0 ? { maxTurnSeconds } : {}),
@@ -686,6 +708,7 @@ export async function activate(
         defaultRuntimeConfig: {
           model,
           ...(modelRouting ? { modelRouting } : {}),
+          ...(directLineSticky ? { directLineSticky: true } : {}),
           maxTokens,
           maxToolIterations: maxIterations,
           ...(maxTurnSeconds > 0 ? { maxTurnSeconds } : {}),

--- a/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/applyDiff.ts
@@ -243,6 +243,10 @@ export function buildForAgent(
       ...(runtime.maxTurnSeconds !== undefined
         ? { maxTurnSeconds: runtime.maxTurnSeconds }
         : {}),
+      // #445 — registry-managed Agents inherit the platform sticky flag, so
+      // the knob means the same thing for the legacy default Agent and for
+      // every Agent the registry builds.
+      ...(runtime.directLineSticky ? { directLineSticky: true } : {}),
       ...(personaSkills?.length ? { personaSkills } : {}),
     },
     deps,

--- a/middleware/src/config.ts
+++ b/middleware/src/config.ts
@@ -66,6 +66,16 @@ const ConfigSchema = z.object({
     .enum(['true', 'false'])
     .transform((v) => v === 'true')
     .default(false),
+  // #445 — sticky Direct Line. When on, a bare `#<agent>` binds the
+  // conversation to that specialist until the user sends `#end` /
+  // `#orchestrator`. Default OFF: not every channel can show which specialist
+  // is answering (Telegram renders neither the consulted footer nor the
+  // delegated-answer attribution today), and an invisible sticky mode would
+  // break the "never ambiguous who is answering" requirement this exists for.
+  ORCHESTRATOR_DIRECT_LINE_STICKY: z
+    .enum(['true', 'false'])
+    .transform((v) => v === 'true')
+    .default(false),
   MODEL_ROUTING_CLASSIFIER_MODEL: z.string().min(1).optional(),
   MODEL_ROUTING_SIMPLE_MODEL: z.string().min(1).optional(),
   MODEL_ROUTING_COMPLEX_MODEL: z.string().min(1).optional(),

--- a/middleware/src/plugins/bootstrap.ts
+++ b/middleware/src/plugins/bootstrap.ts
@@ -1023,6 +1023,12 @@ async function bootstrapOrchestratorFromEnv(
   config['orchestrator_model_routing'] = deps.config.ORCHESTRATOR_MODEL_ROUTING
     ? 'true'
     : 'false';
+  // #445 — sticky Direct Line. Always seeded so the runtime read has a
+  // definite value rather than depending on an absent key.
+  config['orchestrator_direct_line_sticky'] = deps.config
+    .ORCHESTRATOR_DIRECT_LINE_STICKY
+    ? 'true'
+    : 'false';
   if (deps.config.MODEL_ROUTING_CLASSIFIER_MODEL) {
     config['model_routing_classifier_model'] =
       deps.config.MODEL_ROUTING_CLASSIFIER_MODEL;

--- a/middleware/src/routes/chatSessions.ts
+++ b/middleware/src/routes/chatSessions.ts
@@ -61,6 +61,20 @@ const MessageSchema = z.object({
   error: z.boolean().optional(),
   startedAt: z.number(),
   finishedAt: z.number().optional(),
+  // #445 — persist the sticky Direct-Line indicator so the banner survives a
+  // reload or a cross-device resume. zod strips unknown keys, so without this
+  // the field would be silently dropped by the client's own periodic PUT.
+  directLineSession: z
+    .object({
+      active: z.boolean(),
+      agentId: z.string().optional(),
+      label: z.string().optional(),
+      transition: z
+        .enum(['entered', 'switched', 'continued', 'left', 'unavailable', 'refused'])
+        .optional(),
+      refusedReason: z.enum(['no-scope', 'shared-scope', 'synthetic-scope']).optional(),
+    })
+    .optional(),
 });
 
 const SessionSchema = z.object({

--- a/middleware/test/orchestrator/directLine.test.ts
+++ b/middleware/test/orchestrator/directLine.test.ts
@@ -8,6 +8,7 @@ import type {
   LlmStreamEvent,
 } from '@omadia/llm-provider';
 import {
+  InMemoryDirectLineStickyStore,
   NativeToolRegistry,
   Orchestrator,
   createDomainTool,
@@ -875,5 +876,312 @@ describe('#332 gap-closure — agentsConsulted on the STREAMING done event (web-
       }
     }
     assert.ok(sawAgentsConsulted, 'the done event must carry agentsConsulted');
+  });
+});
+
+// ── #445 — sticky Direct Line (orchestrator behaviour) ───────────────────────
+
+function analystTool(
+  impl: (question: string) => Promise<string>,
+  captured?: { q?: string },
+) {
+  return createDomainTool({
+    name: 'ask_analyst',
+    description: 'Numbers analyst',
+    domain: 'analysis',
+    agentId: 'de.byte5.agent.analyst',
+    agent: {
+      ask: async (question: string): Promise<string> => {
+        if (captured) captured.q = question;
+        return impl(question);
+      },
+    },
+  });
+}
+
+/** A sticky-enabled orchestrator with a fresh, isolated binding store. */
+function stickyOrch(over: {
+  domainTools: ReturnType<typeof strategistTool>[];
+  provider?: LlmProvider;
+  isPluginToolsReady?: (agentId: string | undefined) => boolean;
+  privacyGuard?: unknown;
+}) {
+  return new Orchestrator({
+    provider: over.provider ?? neverCalledProvider(),
+    model: 'test',
+    maxTokens: 1024,
+    maxToolIterations: 5,
+    domainTools: over.domainTools,
+    nativeToolRegistry: new NativeToolRegistry(),
+    directLineSticky: true,
+    // A fresh store per orchestrator keeps every test independent.
+    directLineStickyStore: new InMemoryDirectLineStickyStore(),
+    ...(over.isPluginToolsReady
+      ? { isPluginToolsReady: over.isPluginToolsReady }
+      : {}),
+    ...(over.privacyGuard ? { privacyGuard: over.privacyGuard } : {}),
+  } as ConstructorParameters<typeof Orchestrator>[0]);
+}
+
+describe('#445 sticky Direct Line — the flag is OFF by default', () => {
+  it('a bare #agent is still the no-question notice, and never binds', async () => {
+    const tool = strategistTool(async () => 'should not run');
+    const orch = new Orchestrator({
+      provider: neverCalledProvider(),
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [tool],
+      nativeToolRegistry: new NativeToolRegistry(),
+    });
+    const first = await orch.chat({ userMessage: '#strategist', sessionScope: 'off1' });
+    assert.match(first.text, /didn't include a question/);
+    assert.equal(
+      first.directLineSession,
+      undefined,
+      'the field must not appear at all while the feature is off',
+    );
+  });
+});
+
+describe('#445 sticky Direct Line — entry, continuation, exit', () => {
+  it('binds on a bare #agent, then routes plain messages verbatim to the specialist', async () => {
+    const captured: { q?: string } = {};
+    const tool = strategistTool(async () => 'STICKY-ANSWER', captured);
+    const orch = stickyOrch({ domainTools: [tool] });
+
+    const entry = await orch.chat({ userMessage: '#strategist', sessionScope: 'st1' });
+    assert.equal(entry.directLineSession?.active, true);
+    assert.equal(entry.directLineSession?.label, 'Strategist');
+    assert.equal(entry.directLineSession?.transition, 'entered');
+    assert.equal(entry.delegatedAnswer, undefined, 'entry dispatches nothing');
+
+    // Turn 2 carries NO directive at all — the binding supplies the target.
+    const second = await orch.chat({
+      userMessage: 'and the second risk?',
+      sessionScope: 'st1',
+    });
+    assert.equal(captured.q, 'and the second risk?', 'input bound verbatim');
+    assert.equal(second.delegatedAnswer?.label, 'Strategist');
+    assert.equal(second.delegatedAnswer?.text, 'STICKY-ANSWER');
+    assert.equal(second.directLineSession?.active, true);
+    assert.equal(second.directLineSession?.transition, 'continued');
+  });
+
+  it('#end unbinds, and the next ordinary turn goes back to the LLM', async () => {
+    const tool = strategistTool(async () => 'STICKY-ANSWER');
+    const { provider, calls } = scriptedCompleteProvider([
+      textResponse('orchestrator is back'),
+    ]);
+    const orch = stickyOrch({ domainTools: [tool], provider });
+
+    await orch.chat({ userMessage: '#strategist', sessionScope: 'st2' });
+    const left = await orch.chat({ userMessage: '#end', sessionScope: 'st2' });
+    assert.equal(left.directLineSession?.active, false);
+    assert.equal(left.directLineSession?.transition, 'left');
+    assert.equal(calls(), 0, 'the exit itself must not call the LLM');
+
+    const after = await orch.chat({ userMessage: 'now what?', sessionScope: 'st2' });
+    assert.equal(after.text, 'orchestrator is back');
+    assert.equal(after.delegatedAnswer, undefined);
+    assert.equal(after.directLineSession?.active, false);
+  });
+
+  it('an ordinary unbound turn still reports {active:false} so a stale banner clears', async () => {
+    const tool = strategistTool(async () => 'unused');
+    const { provider } = scriptedCompleteProvider([textResponse('plain answer')]);
+    const orch = stickyOrch({ domainTools: [tool], provider });
+    const sa = await orch.chat({ userMessage: 'hello', sessionScope: 'st3' });
+    assert.equal(sa.directLineSession?.active, false);
+  });
+});
+
+describe('#445 sticky Direct Line — the collision rules survive', () => {
+  it('#urgent still falls through to the LLM when nothing is bound', async () => {
+    const tool = strategistTool(async () => 'must not run');
+    const { provider } = scriptedCompleteProvider([textResponse('normal answer')]);
+    const orch = stickyOrch({ domainTools: [tool], provider });
+    const sa = await orch.chat({
+      userMessage: '#urgent server is down',
+      sessionScope: 'c1',
+    });
+    assert.equal(sa.text, 'normal answer');
+    assert.equal(sa.delegatedAnswer, undefined);
+  });
+
+  it('"#end of quarter" is a QUESTION to the specialist, never an exit', async () => {
+    const captured: { q?: string } = {};
+    const tool = strategistTool(async () => 'ANSWERED', captured);
+    const orch = stickyOrch({ domainTools: [tool] });
+    await orch.chat({ userMessage: '#strategist', sessionScope: 'c2' });
+
+    const sa = await orch.chat({
+      userMessage: '#end of quarter — what now?',
+      sessionScope: 'c2',
+    });
+    assert.equal(captured.q, '#end of quarter — what now?', 'verbatim, nothing eaten');
+    assert.equal(sa.directLineSession?.active, true, 'still bound');
+    assert.equal(sa.delegatedAnswer?.text, 'ANSWERED');
+  });
+
+  it('an unknown #token while bound goes to the specialist whole', async () => {
+    const captured: { q?: string } = {};
+    const tool = strategistTool(async () => 'ANSWERED', captured);
+    const orch = stickyOrch({ domainTools: [tool] });
+    await orch.chat({ userMessage: '#strategist', sessionScope: 'c3' });
+    await orch.chat({ userMessage: '#urgent server is down', sessionScope: 'c3' });
+    assert.equal(captured.q, '#urgent server is down');
+  });
+
+  it('a one-shot #other directive answers but does NOT rebind', async () => {
+    const sCap: { q?: string } = {};
+    const aCap: { q?: string } = {};
+    const s = strategistTool(async () => 'FROM-STRATEGIST', sCap);
+    const a = analystTool(async () => 'FROM-ANALYST', aCap);
+    const orch = stickyOrch({ domainTools: [s, a as unknown as typeof s] });
+
+    await orch.chat({ userMessage: '#strategist', sessionScope: 'c4' });
+    const oneShot = await orch.chat({
+      userMessage: '#analyst crunch these numbers',
+      sessionScope: 'c4',
+    });
+    assert.equal(oneShot.delegatedAnswer?.text, 'FROM-ANALYST');
+    assert.equal(aCap.q, 'crunch these numbers');
+
+    // Still bound to the Strategist.
+    const back = await orch.chat({ userMessage: 'continue', sessionScope: 'c4' });
+    assert.equal(back.delegatedAnswer?.text, 'FROM-STRATEGIST');
+    assert.equal(sCap.q, 'continue');
+  });
+});
+
+describe('#445 sticky Direct Line — multi-user and scope safety', () => {
+  it('two users on ONE sessionScope never share a binding', async () => {
+    const sCap: { q?: string } = {};
+    const aCap: { q?: string } = {};
+    const s = strategistTool(async () => 'FROM-STRATEGIST', sCap);
+    const a = analystTool(async () => 'FROM-ANALYST', aCap);
+    const { provider } = scriptedCompleteProvider([
+      textResponse('bob gets the orchestrator'),
+    ]);
+    const orch = stickyOrch({ domainTools: [s, a as unknown as typeof s], provider });
+
+    const scope = 'teams-conversation-42';
+    await orch.chat({ userMessage: '#strategist', sessionScope: scope, userId: 'alice' });
+
+    // Bob shares the conversation id but must NOT inherit Alice's binding.
+    const bob = await orch.chat({
+      userMessage: 'what is going on?',
+      sessionScope: scope,
+      userId: 'bob',
+    });
+    assert.equal(bob.delegatedAnswer, undefined, "bob must not hit alice's specialist");
+    assert.equal(bob.directLineSession?.active, false);
+
+    const alice = await orch.chat({
+      userMessage: 'continue',
+      sessionScope: scope,
+      userId: 'alice',
+    });
+    assert.equal(alice.delegatedAnswer?.text, 'FROM-STRATEGIST');
+  });
+
+  it("refuses to bind on the shared 'http-default' scope with no userId", async () => {
+    const tool = strategistTool(async () => 'must not run');
+    const orch = stickyOrch({ domainTools: [tool] });
+    const sa = await orch.chat({
+      userMessage: '#strategist',
+      sessionScope: 'http-default',
+    });
+    assert.equal(sa.directLineSession?.active, false);
+    assert.equal(sa.directLineSession?.transition, 'refused');
+    assert.equal(sa.directLineSession?.refusedReason, 'shared-scope');
+  });
+
+  it("binds on 'http-default' once a userId makes the key per-person", async () => {
+    const tool = strategistTool(async () => 'ok');
+    const orch = stickyOrch({ domainTools: [tool] });
+    const sa = await orch.chat({
+      userMessage: '#strategist',
+      sessionScope: 'http-default',
+      userId: 'u1',
+    });
+    assert.equal(sa.directLineSession?.active, true);
+  });
+
+  it('refuses a synthetic routine scope even with a userId', async () => {
+    const tool = strategistTool(async () => 'must not run');
+    const orch = stickyOrch({ domainTools: [tool] });
+    const sa = await orch.chat({
+      userMessage: '#strategist',
+      sessionScope: 'routine:daily-digest',
+      userId: 'u1',
+    });
+    assert.equal(sa.directLineSession?.refusedReason, 'synthetic-scope');
+  });
+});
+
+describe('#445 sticky Direct Line — failure modes fail toward the orchestrator', () => {
+  it('unbinds when the specialist goes unavailable mid-session (#474 carried to turn N)', async () => {
+    const tool = strategistTool(async () => 'STICKY-ANSWER');
+    let ready = true;
+    const orch = stickyOrch({
+      domainTools: [tool],
+      isPluginToolsReady: (agentId) =>
+        agentId === 'de.byte5.agent.strategist' ? ready : true,
+    });
+
+    await orch.chat({ userMessage: '#strategist', sessionScope: 'f1' });
+    ready = false; // the plugin is uninstalled / goes not-ready mid-conversation
+
+    const sa = await orch.chat({ userMessage: 'still there?', sessionScope: 'f1' });
+    assert.match(sa.text, /no longer available/);
+    assert.doesNotMatch(sa.text, /is unavailable/, 'never the raw dispatch-error string');
+    assert.equal(sa.delegatedAnswer, undefined);
+    assert.equal(sa.directLineSession?.active, false);
+    assert.equal(sa.directLineSession?.transition, 'unavailable');
+  });
+
+  it('PII masking still applies on the THIRD consecutive sticky turn', async () => {
+    const tool = strategistTool(async () => 'contact jane.doe@example.com for details');
+    const orch = stickyOrch({
+      domainTools: [tool],
+      privacyGuard: fakePrivacyGuard(),
+    });
+    await orch.chat({ userMessage: '#strategist', sessionScope: 'f2' });
+    await orch.chat({ userMessage: 'turn two', sessionScope: 'f2' });
+    const third = await orch.chat({ userMessage: 'turn three', sessionScope: 'f2' });
+
+    assert.ok(third.delegatedAnswer, 'the third sticky turn still dispatches');
+    assert.doesNotMatch(third.delegatedAnswer?.text ?? '', /jane\.doe@example\.com/);
+    assert.match(third.delegatedAnswer?.text ?? '', /^\[masked:ask_strategist:/);
+    assert.doesNotMatch(third.text, /jane\.doe@example\.com/);
+  });
+
+  it('re-entering the SAME specialist is a no-op notice, not a silent re-bind', async () => {
+    const tool = strategistTool(async () => 'unused');
+    const orch = stickyOrch({ domainTools: [tool] });
+    await orch.chat({ userMessage: '#strategist', sessionScope: 'f3' });
+    const again = await orch.chat({ userMessage: '#strategist', sessionScope: 'f3' });
+    assert.match(again.text, /already talking to Strategist/);
+    assert.equal(again.directLineSession?.active, true);
+  });
+});
+
+describe('#445 sticky Direct Line — streaming path parity', () => {
+  it('a sticky streamed turn carries directLineSession on its done event', async () => {
+    const tool = strategistTool(async () => 'STREAMED-STICKY');
+    const orch = stickyOrch({ domainTools: [tool] });
+    await orch.chat({ userMessage: '#strategist', sessionScope: 'sx1' });
+
+    let seen: { active: boolean; label?: string } | undefined;
+    for await (const event of orch.chatStream({
+      userMessage: 'streamed follow-up',
+      sessionScope: 'sx1',
+    })) {
+      if (event.type === 'done') seen = event.directLineSession;
+    }
+    assert.equal(seen?.active, true);
+    assert.equal(seen?.label, 'Strategist');
   });
 });

--- a/middleware/test/orchestrator/directLineSticky.test.ts
+++ b/middleware/test/orchestrator/directLineSticky.test.ts
@@ -1,0 +1,449 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  DIRECT_LINE_EXIT_TOKENS,
+  InMemoryDirectLineStickyStore,
+  SHARED_SCOPES,
+  STICKY_IDLE_TTL_MS,
+  STICKY_MAX_BINDINGS,
+  SYNTHETIC_SCOPE_PREFIXES,
+  classifyStickyScope,
+  decideDirectLineTurn,
+  isDirectLineExitMessage,
+  stickyKeyFor,
+  type DirectLineBinding,
+  type DirectLineCandidate,
+  type StickyScopeClassification,
+} from '@omadia/orchestrator';
+
+// #445 — sticky Direct Line. Pure decision layer: no Orchestrator, no I/O.
+// Everything here is a single binary probe on the target-SELECTION rules; the
+// dispatch body is #332's and is asserted in directLine.test.ts.
+
+const STRATEGIST: DirectLineCandidate = {
+  toolName: 'ask_strategist',
+  agentId: 'de.byte5.agent.strategist',
+  label: 'Strategist',
+};
+const ANALYST: DirectLineCandidate = {
+  toolName: 'ask_analyst',
+  agentId: 'de.byte5.agent.analyst',
+  label: 'Analyst',
+};
+const CANDIDATES: readonly DirectLineCandidate[] = [STRATEGIST, ANALYST];
+
+const ELIGIBLE: StickyScopeClassification = { kind: 'eligible', key: 'k' };
+
+function bindingFor(
+  c: DirectLineCandidate,
+  at = 1_000,
+): DirectLineBinding {
+  return {
+    toolName: c.toolName,
+    ...(c.agentId ? { agentId: c.agentId } : {}),
+    label: c.label,
+    boundAt: at,
+    lastTurnAt: at,
+  };
+}
+
+function decide(over: {
+  userMessage: string;
+  binding?: DirectLineBinding | undefined;
+  stickyEnabled?: boolean;
+  scope?: StickyScopeClassification;
+  candidates?: readonly DirectLineCandidate[];
+}) {
+  return decideDirectLineTurn({
+    userMessage: over.userMessage,
+    prefix: '#',
+    candidates: over.candidates ?? CANDIDATES,
+    binding: over.binding,
+    stickyEnabled: over.stickyEnabled ?? true,
+    scope: over.scope ?? ELIGIBLE,
+  });
+}
+
+// ── classifyStickyScope ──────────────────────────────────────────────────────
+
+describe('#445 classifyStickyScope', () => {
+  it('refuses when there is no sessionScope at all (cliSubAgent passes none)', () => {
+    const r = classifyStickyScope({ agentSlug: 'default', userId: 'u1' });
+    assert.deepEqual(r, { kind: 'refused', reason: 'no-scope' });
+  });
+
+  it('refuses an empty-string sessionScope', () => {
+    const r = classifyStickyScope({ agentSlug: 'default', sessionScope: '   ' });
+    assert.deepEqual(r, { kind: 'refused', reason: 'no-scope' });
+  });
+
+  it('refuses every synthetic scope prefix REGARDLESS of userId', () => {
+    for (const scope of [
+      'routine:daily-digest',
+      'schedule:7',
+      'conductor:run-1:step-2',
+      'conductor-builder:slug:uuid',
+    ]) {
+      assert.deepEqual(
+        classifyStickyScope({ agentSlug: 'a', sessionScope: scope, userId: 'u1' }),
+        { kind: 'refused', reason: 'synthetic-scope' },
+        `expected ${scope} refused even with a userId`,
+      );
+      assert.deepEqual(
+        classifyStickyScope({ agentSlug: 'a', sessionScope: scope }),
+        { kind: 'refused', reason: 'synthetic-scope' },
+      );
+    }
+  });
+
+  it('refuses a shared scope when no userId disambiguates it', () => {
+    for (const scope of ['http-default', 'teams-unknown', 'unknown']) {
+      assert.deepEqual(
+        classifyStickyScope({ agentSlug: 'a', sessionScope: scope }),
+        { kind: 'refused', reason: 'shared-scope' },
+        `expected ${scope} refused without a userId`,
+      );
+    }
+  });
+
+  it('allows a shared scope once a userId makes the key per-person', () => {
+    for (const scope of ['http-default', 'teams-unknown', 'unknown']) {
+      const r = classifyStickyScope({ agentSlug: 'a', sessionScope: scope, userId: 'u1' });
+      assert.equal(r.kind, 'eligible', `expected ${scope}+userId eligible`);
+    }
+  });
+
+  it('allows a normal per-session scope even without a userId', () => {
+    const r = classifyStickyScope({
+      agentSlug: 'default',
+      sessionScope: '6f1c2a7e-0f2a-4d1b-9a3e-2b1d4c5e6f70',
+    });
+    assert.equal(r.kind, 'eligible');
+  });
+
+  it('exposes the gate constants it reasons over', () => {
+    assert.ok(SHARED_SCOPES.has('http-default'));
+    assert.ok(SYNTHETIC_SCOPE_PREFIXES.includes('routine:'));
+    assert.ok(DIRECT_LINE_EXIT_TOKENS.has('end'));
+    assert.ok(DIRECT_LINE_EXIT_TOKENS.has('orchestrator'));
+  });
+});
+
+// ── stickyKeyFor ─────────────────────────────────────────────────────────────
+
+describe('#445 stickyKeyFor', () => {
+  it('is deterministic for identical inputs', () => {
+    const a = { agentSlug: 'default', sessionScope: 's1', userId: 'u1' };
+    assert.equal(stickyKeyFor(a), stickyKeyFor({ ...a }));
+  });
+
+  it('diverges on agentSlug, sessionScope and userId independently', () => {
+    const base = { agentSlug: 'default', sessionScope: 's1', userId: 'u1' };
+    const k = stickyKeyFor(base);
+    assert.notEqual(k, stickyKeyFor({ ...base, agentSlug: 'other' }));
+    assert.notEqual(k, stickyKeyFor({ ...base, sessionScope: 's2' }));
+    assert.notEqual(k, stickyKeyFor({ ...base, userId: 'u2' }));
+  });
+
+  it('separates fields with NUL so no concatenation collision is possible', () => {
+    const NUL = String.fromCharCode(0);
+    assert.equal(
+      stickyKeyFor({ agentSlug: 'a', sessionScope: 'b', userId: 'c' }),
+      `a${NUL}b${NUL}c`,
+    );
+    // The classic ambiguity: ('a','b','c') vs ('a','b\0c') would collide under
+    // a plain join. With NUL unavailable to real ids, these stay distinct.
+    assert.notEqual(
+      stickyKeyFor({ agentSlug: 'a', sessionScope: 'b', userId: 'c' }),
+      stickyKeyFor({ agentSlug: 'a', sessionScope: 'bc', userId: '' }),
+    );
+  });
+
+  it('treats an absent userId as empty, not as the string "undefined"', () => {
+    const k = stickyKeyFor({ agentSlug: 'a', sessionScope: 'b' });
+    assert.ok(!k.includes('undefined'));
+  });
+});
+
+// ── isDirectLineExitMessage ──────────────────────────────────────────────────
+
+describe('#445 isDirectLineExitMessage', () => {
+  it('matches the reserved exit tokens as a WHOLE message, case-insensitively', () => {
+    assert.equal(isDirectLineExitMessage('#end', '#'), true);
+    assert.equal(isDirectLineExitMessage('  #ORCHESTRATOR  ', '#'), true);
+    assert.equal(isDirectLineExitMessage('#Orchestrator', '#'), true);
+  });
+
+  it('never fires on ordinary text that merely starts with the token', () => {
+    for (const text of [
+      '#end of quarter — what now?',
+      'please #end',
+      '#end.',
+      '#ending',
+      '#endorse this plan',
+      '#e',
+      'end',
+    ]) {
+      assert.equal(
+        isDirectLineExitMessage(text, '#'),
+        false,
+        `expected NOT an exit: ${JSON.stringify(text)}`,
+      );
+    }
+  });
+
+  it('honours a non-default prefix', () => {
+    assert.equal(isDirectLineExitMessage('!end', '!'), true);
+    assert.equal(isDirectLineExitMessage('#end', '!'), false);
+  });
+});
+
+// ── decideDirectLineTurn ─────────────────────────────────────────────────────
+
+describe('#445 decideDirectLineTurn — flag OFF is byte-for-byte #332', () => {
+  it('an unknown token still falls through to the LLM (collision rule)', () => {
+    const d = decide({ userMessage: '#urgent server is down', stickyEnabled: false });
+    assert.deepEqual(d, { kind: 'ordinary' });
+  });
+
+  it('a resolved directive with a payload dispatches, never sticky', () => {
+    const d = decide({ userMessage: '#strategist risks?', stickyEnabled: false });
+    assert.equal(d.kind, 'dispatch');
+    assert.equal(d.kind === 'dispatch' && d.sticky, false);
+    assert.equal(d.kind === 'dispatch' && d.payload, 'risks?');
+  });
+
+  it('a bare #agent is still the no-question notice, NOT an entry', () => {
+    const d = decide({ userMessage: '#strategist', stickyEnabled: false });
+    assert.equal(d.kind, 'notice');
+    assert.equal(d.kind === 'notice' && d.reason, 'no-question');
+  });
+
+  it('an ordinary message is ordinary even when a stale binding exists', () => {
+    const d = decide({
+      userMessage: 'what is the plan?',
+      stickyEnabled: false,
+      binding: bindingFor(STRATEGIST),
+    });
+    assert.deepEqual(d, { kind: 'ordinary' });
+  });
+
+  it('#end is not an exit when the feature is off', () => {
+    const d = decide({
+      userMessage: '#end',
+      stickyEnabled: false,
+      binding: bindingFor(STRATEGIST),
+    });
+    assert.deepEqual(d, { kind: 'ordinary' });
+  });
+});
+
+describe('#445 decideDirectLineTurn — entry', () => {
+  it('a bare #agent binds the conversation when the scope is eligible', () => {
+    const d = decide({ userMessage: '#strategist' });
+    assert.equal(d.kind, 'enter');
+    assert.equal(d.kind === 'enter' && d.candidate.toolName, 'ask_strategist');
+  });
+
+  it('tolerates trailing whitespace on the entry gesture', () => {
+    const d = decide({ userMessage: '  #Strategist   ' });
+    assert.equal(d.kind, 'enter');
+  });
+
+  it('refuses to bind on an ineligible scope and names the reason', () => {
+    const d = decide({
+      userMessage: '#strategist',
+      scope: { kind: 'refused', reason: 'shared-scope' },
+    });
+    assert.equal(d.kind, 'notice');
+    assert.equal(d.kind === 'notice' && d.reason, 'sticky-refused');
+    assert.equal(d.kind === 'notice' && d.refusedReason, 'shared-scope');
+  });
+
+  it('an unknown bare token is ordinary, not an entry (collision rule holds)', () => {
+    const d = decide({ userMessage: '#urgent' });
+    assert.deepEqual(d, { kind: 'ordinary' });
+  });
+
+  it('an ambiguous bare token disambiguates instead of binding', () => {
+    const dupes: readonly DirectLineCandidate[] = [
+      { toolName: 'ask_strategist', agentId: 'a.strategist', label: 'Strategist' },
+      { toolName: 'consult_strategist', agentId: 'b.strategist', label: 'Strategist' },
+    ];
+    const d = decide({ userMessage: '#strategist', candidates: dupes });
+    assert.equal(d.kind, 'notice');
+    assert.equal(d.kind === 'notice' && d.reason, 'ambiguous');
+    assert.equal(d.kind === 'notice' && d.matches?.length, 2);
+  });
+});
+
+describe('#445 decideDirectLineTurn — while bound', () => {
+  const bound = bindingFor(STRATEGIST);
+
+  it('routes a plain message to the bound specialist verbatim', () => {
+    const d = decide({ userMessage: 'and the second risk?', binding: bound });
+    assert.equal(d.kind, 'dispatch');
+    assert.equal(d.kind === 'dispatch' && d.sticky, true);
+    assert.equal(d.kind === 'dispatch' && d.payload, 'and the second risk?');
+    assert.equal(d.kind === 'dispatch' && d.candidate.toolName, 'ask_strategist');
+  });
+
+  it('preserves the message byte-for-byte, including leading # of an unknown token', () => {
+    const d = decide({ userMessage: '#urgent server is down', binding: bound });
+    assert.equal(d.kind, 'dispatch');
+    assert.equal(d.kind === 'dispatch' && d.payload, '#urgent server is down');
+    assert.equal(d.kind === 'dispatch' && d.sticky, true);
+  });
+
+  it('preserves whitespace-significant payloads (fenced code)', () => {
+    const msg = '```ts\n  const x = 1;\n```';
+    const d = decide({ userMessage: msg, binding: bound });
+    assert.equal(d.kind === 'dispatch' && d.payload, msg);
+  });
+
+  it('a one-shot #other directive does NOT rebind — per-message stays per-message', () => {
+    const d = decide({ userMessage: '#analyst crunch these numbers', binding: bound });
+    assert.equal(d.kind, 'dispatch');
+    assert.equal(d.kind === 'dispatch' && d.candidate.toolName, 'ask_analyst');
+    assert.equal(
+      d.kind === 'dispatch' && d.sticky,
+      false,
+      'a one-shot directive must not carry sticky:true',
+    );
+  });
+
+  it('exits on the reserved token', () => {
+    assert.deepEqual(decide({ userMessage: '#end', binding: bound }), { kind: 'exit' });
+    assert.deepEqual(decide({ userMessage: '#orchestrator', binding: bound }), {
+      kind: 'exit',
+    });
+  });
+
+  it('does NOT exit on prose that merely begins with the exit token', () => {
+    const d = decide({ userMessage: '#end of quarter — what now?', binding: bound });
+    assert.equal(d.kind, 'dispatch');
+    assert.equal(d.kind === 'dispatch' && d.payload, '#end of quarter — what now?');
+  });
+
+  it('a bare #agent for the ALREADY bound specialist is a no-op notice, not a rebind', () => {
+    const d = decide({ userMessage: '#strategist', binding: bound });
+    assert.equal(d.kind, 'notice');
+    assert.equal(d.kind === 'notice' && d.reason, 'already-bound');
+  });
+
+  it('a bare #other rebinds to the new specialist', () => {
+    const d = decide({ userMessage: '#analyst', binding: bound });
+    assert.equal(d.kind, 'enter');
+    assert.equal(d.kind === 'enter' && d.candidate.toolName, 'ask_analyst');
+  });
+
+  it('an exit token that RESOLVES to a real specialist is not an exit', () => {
+    const shadowed: readonly DirectLineCandidate[] = [
+      { toolName: 'ask_end', agentId: 'x.end', label: 'End' },
+    ];
+    const d = decide({
+      userMessage: '#end',
+      binding: bindingFor(shadowed[0]!),
+      candidates: shadowed,
+    });
+    assert.notEqual(d.kind, 'exit');
+  });
+});
+
+// ── InMemoryDirectLineStickyStore ────────────────────────────────────────────
+
+describe('#445 InMemoryDirectLineStickyStore', () => {
+  it('binds and reads back an immutable binding', () => {
+    let now = 1_000;
+    const store = new InMemoryDirectLineStickyStore({ now: () => now });
+    const b = store.bind('k1', {
+      toolName: 'ask_strategist',
+      agentId: 'a.strategist',
+      label: 'Strategist',
+    });
+    assert.equal(b.toolName, 'ask_strategist');
+    assert.equal(b.boundAt, 1_000);
+    const read = store.get('k1');
+    assert.deepEqual(read, b);
+    assert.equal(store.size(), 1);
+  });
+
+  it('never mutates a stored binding in place on touch', () => {
+    let now = 1_000;
+    const store = new InMemoryDirectLineStickyStore({ now: () => now });
+    const first = store.bind('k1', { toolName: 't', label: 'T' });
+    now = 5_000;
+    store.touch('k1');
+    const after = store.get('k1');
+    assert.equal(first.lastTurnAt, 1_000, 'the original object must be untouched');
+    assert.equal(after?.lastTurnAt, 5_000);
+    assert.equal(after?.boundAt, 1_000, 'boundAt is stable across touches');
+  });
+
+  it('expires a binding after the idle TTL', () => {
+    let now = 0;
+    const store = new InMemoryDirectLineStickyStore({ now: () => now });
+    store.bind('k1', { toolName: 't', label: 'T' });
+    now = STICKY_IDLE_TTL_MS - 1;
+    assert.ok(store.get('k1'), 'still live just before the TTL');
+    now = STICKY_IDLE_TTL_MS + 1;
+    assert.equal(store.get('k1'), undefined, 'expired after the TTL');
+    assert.equal(store.size(), 0, 'expiry evicts, it does not just hide');
+  });
+
+  it('touch slides the idle window', () => {
+    let now = 0;
+    const store = new InMemoryDirectLineStickyStore({ now: () => now });
+    store.bind('k1', { toolName: 't', label: 'T' });
+    now = STICKY_IDLE_TTL_MS - 10;
+    store.touch('k1');
+    now = STICKY_IDLE_TTL_MS + 10;
+    assert.ok(store.get('k1'), 'the touch reset the idle clock');
+  });
+
+  it('clear() removes a binding', () => {
+    const store = new InMemoryDirectLineStickyStore();
+    store.bind('k1', { toolName: 't', label: 'T' });
+    store.clear('k1');
+    assert.equal(store.get('k1'), undefined);
+    assert.equal(store.size(), 0);
+  });
+
+  it('clear() on an absent key is a silent no-op', () => {
+    const store = new InMemoryDirectLineStickyStore();
+    store.clear('nope');
+    assert.equal(store.size(), 0);
+  });
+
+  it('evicts least-recently-used entries at the cap', () => {
+    const store = new InMemoryDirectLineStickyStore({ maxEntries: 3 });
+    store.bind('a', { toolName: 't', label: 'T' });
+    store.bind('b', { toolName: 't', label: 'T' });
+    store.bind('c', { toolName: 't', label: 'T' });
+    store.get('a'); // 'a' becomes most-recently-used, so 'b' is now the LRU
+    store.bind('d', { toolName: 't', label: 'T' });
+    assert.equal(store.size(), 3);
+    assert.equal(store.get('b'), undefined, 'b was the least recently used');
+    assert.ok(store.get('a'));
+    assert.ok(store.get('c'));
+    assert.ok(store.get('d'));
+  });
+
+  it('defaults are the documented production values', () => {
+    assert.equal(STICKY_IDLE_TTL_MS, 2 * 60 * 60 * 1000);
+    assert.equal(STICKY_MAX_BINDINGS, 1000);
+  });
+
+  it('keeps two userIds on ONE sessionScope isolated end-to-end', () => {
+    const store = new InMemoryDirectLineStickyStore();
+    const shared = 'teams-conversation-42';
+    const kA = stickyKeyFor({ agentSlug: 'default', sessionScope: shared, userId: 'alice' });
+    const kB = stickyKeyFor({ agentSlug: 'default', sessionScope: shared, userId: 'bob' });
+    store.bind(kA, { toolName: 'ask_strategist', label: 'Strategist' });
+    assert.equal(store.get(kB), undefined, "bob must not inherit alice's binding");
+    store.bind(kB, { toolName: 'ask_analyst', label: 'Analyst' });
+    assert.equal(store.get(kA)?.toolName, 'ask_strategist');
+    assert.equal(store.get(kB)?.toolName, 'ask_analyst');
+  });
+});

--- a/middleware/test/orchestratorManifestRoutingFields.test.ts
+++ b/middleware/test/orchestratorManifestRoutingFields.test.ts
@@ -42,3 +42,24 @@ describe('orchestrator manifest — model-routing setup fields', () => {
     }
   });
 });
+
+/**
+ * #445 — the sticky Direct Line flag must stay reachable by an operator.
+ * `directLineMode`, `directLinePrefix` and `requiredConsultToolName` are all
+ * constructor-only and therefore dead in production; this guard exists so the
+ * one Direct-Line knob that IS plumbed does not quietly join them.
+ */
+describe('orchestrator manifest — #445 sticky Direct Line field', () => {
+  it('exposes orchestrator_direct_line_sticky as a boolean defaulting to off', async () => {
+    const entry = await loadManifestFromPath(MANIFEST);
+    assert.ok(entry, 'orchestrator manifest.yaml failed to load');
+    const field = (entry.plugin.setup_fields ?? []).find(
+      (f) => f.key === 'orchestrator_direct_line_sticky',
+    );
+    assert.ok(field, 'missing setup field: orchestrator_direct_line_sticky');
+    assert.equal(field.type, 'boolean');
+    // The loader reads non-`host_list` defaults via `asString`, so the default
+    // must be the STRING "false" — a YAML boolean would read back as undefined.
+    assert.equal(field.default, 'false');
+  });
+});

--- a/web-ui/app/_components/chat/DirectLineStickyBanner.tsx
+++ b/web-ui/app/_components/chat/DirectLineStickyBanner.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import type { DirectLineSessionState } from '../../_lib/chatSessions';
+
+interface DirectLineStickyBannerProps {
+  session: DirectLineSessionState;
+  /** Sends the reserved exit directive through the normal turn path. */
+  onExit: () => void;
+  disabled?: boolean;
+}
+
+/**
+ * #445 — persistent "you are talking to <specialist>" indicator.
+ *
+ * Sits directly above the composer so the binding is visible exactly where the
+ * user types. It renders only while a binding is live; the server sends
+ * `{ active: false }` on every unbound turn, so this disappears on the very
+ * next turn after an exit, a restart or a TTL expiry rather than going stale.
+ *
+ * Lume state recipe: text + edge + a low tint, never a solid fill and never a
+ * spinner — this is a steady state, not activity.
+ */
+export function DirectLineStickyBanner({
+  session,
+  onExit,
+  disabled,
+}: DirectLineStickyBannerProps): React.ReactElement | null {
+  const t = useTranslations('directLine');
+  if (!session.active || !session.label) return null;
+
+  return (
+    <div
+      className="mb-2 flex items-center justify-between gap-3 rounded-lg px-3 py-2 text-sm ring-1 bg-[color:var(--accent)]/6 ring-[color:var(--accent)]/30"
+      role="status"
+      aria-live="polite"
+    >
+      <span className="text-[color:var(--accent)]">
+        {t('stickyActive', { label: session.label })}
+      </span>
+      <button
+        type="button"
+        onClick={onExit}
+        disabled={disabled ?? false}
+        className="shrink-0 rounded-md px-2 py-1 text-xs ring-1 ring-[color:var(--accent)]/30 text-[color:var(--accent)] hover:bg-[color:var(--accent)]/10 disabled:opacity-50"
+      >
+        {t('stickyExit')}
+      </button>
+    </div>
+  );
+}

--- a/web-ui/app/_components/chat/__tests__/DirectLineStickyBanner.test.tsx
+++ b/web-ui/app/_components/chat/__tests__/DirectLineStickyBanner.test.tsx
@@ -1,0 +1,56 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { DirectLineSessionState } from '../../../_lib/chatSessions';
+import { renderWithIntl } from '../../../_lib/test-utils';
+import { DirectLineStickyBanner } from '../DirectLineStickyBanner';
+
+const ACTIVE: DirectLineSessionState = {
+  active: true,
+  agentId: 'de.byte5.agent.strategist',
+  label: 'Strategist',
+  transition: 'entered',
+};
+
+const INACTIVE: DirectLineSessionState = { active: false };
+
+describe('#445 DirectLineStickyBanner', () => {
+  it('names the bound specialist while a binding is live', () => {
+    renderWithIntl(<DirectLineStickyBanner session={ACTIVE} onExit={() => {}} />);
+    expect(screen.getByText(/Strategist/)).toBeInTheDocument();
+  });
+
+  it('renders nothing when the binding has ended', () => {
+    const { container } = renderWithIntl(
+      <DirectLineStickyBanner session={INACTIVE} onExit={() => {}} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when active but unlabelled (never an anonymous banner)', () => {
+    const { container } = renderWithIntl(
+      <DirectLineStickyBanner session={{ active: true }} onExit={() => {}} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('exits through the supplied callback', async () => {
+    const onExit = vi.fn();
+    renderWithIntl(<DirectLineStickyBanner session={ACTIVE} onExit={onExit} />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the exit control while a turn is in flight', () => {
+    renderWithIntl(
+      <DirectLineStickyBanner session={ACTIVE} onExit={() => {}} disabled />,
+    );
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('is announced politely rather than as an alert', () => {
+    renderWithIntl(<DirectLineStickyBanner session={ACTIVE} onExit={() => {}} />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+  });
+});

--- a/web-ui/app/_lib/chatSessions.ts
+++ b/web-ui/app/_lib/chatSessions.ts
@@ -215,6 +215,21 @@ export interface DelegatedAnswer {
   status: 'success' | 'error';
 }
 
+/**
+ * #445 — which specialist, if any, this conversation is bound to at the end of
+ * a turn. Mirrors `DirectLineSessionState` in
+ * `harness-channel-sdk/src/outgoing.ts`. The server sends it on EVERY turn
+ * while sticky mode is on — including `{ active: false }` — so the banner is
+ * self-correcting and can never outlive the binding it describes.
+ */
+export interface DirectLineSessionState {
+  active: boolean;
+  agentId?: string;
+  label?: string;
+  transition?: 'entered' | 'switched' | 'continued' | 'left' | 'unavailable' | 'refused';
+  refusedReason?: 'no-scope' | 'shared-scope' | 'synthetic-scope';
+}
+
 /** Slice 2.5 — one entry in `PrivacyReceipt.bypassedTools`. */
 export interface BypassedToolEntry {
   toolName: string;
@@ -433,6 +448,14 @@ export interface Message {
    * separate from `content`. Absent on ordinary turns.
    */
   delegatedAnswer?: DelegatedAnswer;
+  /**
+   * #445 — sticky Direct Line state as of this turn. Message-level, not
+   * session-level: `coerceMessage` spreads unknown fields through, whereas
+   * `coerceSession` is an explicit field whitelist that would silently drop a
+   * session-level field on the next reload. The banner reads the most recent
+   * message that carries one.
+   */
+  directLineSession?: DirectLineSessionState;
   error?: boolean;
   startedAt: number;
   finishedAt?: number;

--- a/web-ui/app/_lib/chatStreamEvents.ts
+++ b/web-ui/app/_lib/chatStreamEvents.ts
@@ -5,6 +5,7 @@ import type {
   ChatSession,
   DelegatedAnswer,
   DiagramAttachment,
+  DirectLineSessionState,
   FollowUpOption,
   KgWalkEdge,
   KgWalkNode,
@@ -135,6 +136,8 @@ export type ChatStreamEvent =
       agentsConsulted?: AgentConsultation[];
       /** #332 Layer 2 (gap-closure) — see `Message.delegatedAnswer`. */
       delegatedAnswer?: DelegatedAnswer;
+      /** #445 — see `Message.directLineSession`. */
+      directLineSession?: DirectLineSessionState;
     }
   /** #133 (E9) — opaque turn annotation the orchestrator forwarded from a
    *  turn-hook. `channel: 'plan'` carries a live PlanSnapshot. */
@@ -367,6 +370,13 @@ function foldIntoMessage(m: Message, event: ChatStreamEvent): Message {
           : {}),
         ...(event.delegatedAnswer
           ? { delegatedAnswer: event.delegatedAnswer }
+          : {}),
+        // #445 — guard on PRESENCE, never on `.active`. `{active:false}` is
+        // precisely the payload that tells the banner a binding has ended;
+        // dropping it would leave a stale "you are talking to X" on screen
+        // after a restart, a registry rebuild or a TTL expiry.
+        ...(event.directLineSession
+          ? { directLineSession: event.directLineSession }
           : {}),
         finishedAt: Date.now(),
         streaming: false,

--- a/web-ui/app/chat/page.tsx
+++ b/web-ui/app/chat/page.tsx
@@ -23,6 +23,7 @@ import { AutoPromotedBanner } from '../_components/chat/AutoPromotedBanner';
 import { CaptureDisclosure } from '../_components/chat/CaptureDisclosure';
 import { ConfirmDialog } from '../_components/ConfirmDialog';
 import { DelegatedAnswerCard } from '../_components/chat/DelegatedAnswerCard';
+import { DirectLineStickyBanner } from '../_components/chat/DirectLineStickyBanner';
 import { NudgeCard, parseNudgeBlock } from '../_components/chat/NudgeCard';
 import {
   McpAuthRequiredCard,
@@ -54,7 +55,11 @@ import { DevJobChatCard } from '../_components/devjobs/DevJobChatCard';
 import { parseDevJobStartResult } from '../_components/devjobs/devJobChatCardState';
 import { KgWalkPane } from '../_components/KgWalkPane';
 import { PlanDagPane } from '../_components/PlanDagPane';
-import type { KgWalkPayload, PlanSnapshot } from '../_lib/chatSessions';
+import type {
+  DirectLineSessionState,
+  KgWalkPayload,
+  PlanSnapshot,
+} from '../_lib/chatSessions';
 
 /**
  * Dev-only KG-walk fixture. Rendered in the floating pane when the URL carries
@@ -197,6 +202,18 @@ export default function ChatPage(): React.ReactElement {
     }
     return kgMockEnabled ? MOCK_KG_WALK : null;
   }, [activeSession.messages, kgMockEnabled]);
+
+  // #445 — the sticky Direct-Line binding = whatever the most recent carrier
+  // says. The server stamps EVERY turn while the feature is on (including
+  // `{active:false}`), so scanning back to the newest carrier and trusting it
+  // is what keeps the banner from outliving the binding it describes.
+  const activeDirectLine = useMemo<DirectLineSessionState | null>(() => {
+    for (let i = activeSession.messages.length - 1; i >= 0; i -= 1) {
+      const m = activeSession.messages[i];
+      if (m?.directLineSession) return m.directLineSession;
+    }
+    return null;
+  }, [activeSession.messages]);
 
   // The live plan surfaced in the left pane = the most recent assistant message
   // carrying a plan snapshot (re-emitted on every step change / replan).
@@ -609,6 +626,17 @@ export default function ChatPage(): React.ReactElement {
 
       <footer className="border-t border-[color:var(--border)] bg-[color:var(--bg-elevated)]/85 px-6 py-4 backdrop-blur">
         <div className="mx-auto flex max-w-4xl flex-col gap-2">
+          {/* #445 — persistent "you are talking to X" indicator, directly above
+              the composer. Exits via the normal turn path (no new endpoint). */}
+          {activeDirectLine && (
+            <DirectLineStickyBanner
+              session={activeDirectLine}
+              onExit={() => {
+                send('#end');
+              }}
+              disabled={sending || hydrating}
+            />
+          )}
           {/* Mid-turn steering hint / feedback — only while a turn streams. */}
           {sending && (
             <div className="flex items-center gap-2 text-[11px]">

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1058,7 +1058,10 @@
     "viewTrace": "Trace ▾",
     "stepsCount": "{count, plural, one {# Schritt} other {# Schritte}}",
     "delegatedAnswerFrom": "Direkte Antwort von {label}",
-    "delegatedAnswerCaption": "Wortgetreu übermittelt — der Orchestrator kann diese Antwort nicht bearbeiten oder entfernen."
+    "delegatedAnswerCaption": "Wortgetreu übermittelt — der Orchestrator kann diese Antwort nicht bearbeiten oder entfernen.",
+    "stickyActive": "Direkter Draht zu {label} — jede Nachricht geht dorthin.",
+    "stickyExit": "Zurück zum Orchestrator",
+    "stickyPlaceholder": "Nachricht an {label}…"
   },
   "privacyOperator": {
     "eyebrow": "Privacy Operator",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1058,7 +1058,10 @@
     "viewTrace": "trace ▾",
     "stepsCount": "{count, plural, one {# step} other {# steps}}",
     "delegatedAnswerFrom": "Direct answer from {label}",
-    "delegatedAnswerCaption": "Delivered verbatim — the orchestrator cannot edit or remove this answer."
+    "delegatedAnswerCaption": "Delivered verbatim — the orchestrator cannot edit or remove this answer.",
+    "stickyActive": "Talking directly to {label} — every message goes straight there.",
+    "stickyExit": "Back to orchestrator",
+    "stickyPlaceholder": "Message to {label}…"
   },
   "privacyOperator": {
     "eyebrow": "Privacy Operator",


### PR DESCRIPTION
Closes #445.

Direct Line (#332) only supported per-message directives, so sustaining a multi-turn session with one specialist meant re-typing `#<agent>` on every message. This adds an opt-in sticky mode.

## The shape

**Sticky changes exactly one thing: which `{candidate, payload}` the existing #332 dispatch body receives.** It never introduces a second dispatch path. Everything from `maskPromptForWire` → `dispatchTool` → `restorePromptForPersistence` → `delegatedAnswer` → guarded-note → `sessionLogger` → `factExtractor` is the same physical code on turn 1 and on turn N, so every #332 / #361 / #474 invariant holds by construction rather than by re-implementation. That matters because the bug PR #446 had to fix was a *second* dispatch path that skipped the choke point — this shape makes that class of regression structurally impossible.

All sticky reasoning lives in a new pure, synchronous, Orchestrator-free module (`directLineSticky.ts`). Strict/guarded delivery policy is inherited untouched — the sticky path never reads `directLineMode`.

## Entry, exit, and what deliberately does *not* change

**Entry — a bare `#<agent>`.** Today that gesture hits the one dead end in `executeDirectLine` ("you didn't include a question"), so it is free grammar: no parser change, and it inherits the collision rule because it only fires when the token *resolves* to a whitelisted specialist.

I rejected **auto-stick-on-first-use** on concrete evidence: the Teams "💬 Direkt mit X" button submits `#<token> <original message>` as a one-shot re-ask, so under auto-stick one click would put an entire thread into specialist mode — a regression of a shipped affordance. A `#<agent> <question>` with a payload therefore stays a one-shot and **does not rebind**, even while bound elsewhere.

**Exit — `#end` / `#orchestrator`**, honoured only when all three hold: a binding is live, the *entire trimmed message* is the token, and the token does not resolve to a real specialist. Consequences:
- An unbound `#end` is an unknown token and falls through to the LLM exactly as today; the existing collision-rule test stays green untouched.
- `#end of quarter — what now?` is **not** an exit — while bound it goes to the specialist verbatim, so the user never loses text.
- A deployment whose specialist normalizes to `end` keeps its agent (resolution wins) and gets a one-time `console.warn` naming the shadowed token.

Plus three non-typed exits, all failing toward the orchestrator: the web-ui banner button (submits `#end` through the normal turn path — no new endpoint), auto-unbind when the tool goes unavailable, and TTL/restart.

## Multi-user safety — this needed a real fix, not an assumption

Keying on `sessionScope` alone is **not** safe. `resolveScope` (`middleware/src/routes/chat.ts:49-53`) returns the literal `'http-default'` for every caller sending neither `scope` nor `sessionId`, and `resolveUserId` can legitimately return `undefined`.

Bindings are keyed `` `${agentSlug}\0${sessionScope}\0${userId ?? ''}` `` — NUL cannot occur in a kebab agent slug, a channel conversation id, or a `USER_ID_RE` user id, and the key never reaches the KG. It is gated by `classifyStickyScope`, an allow-gate that **names its refusal**:

| Scope | Verdict |
|---|---|
| absent / empty | `no-scope` |
| `routine:` `schedule:` `conductor:` `conductor-builder:` | `synthetic-scope` — refused **always**, even with a userId (`routine:<id>` repeats verbatim forever) |
| `http-default` / `teams-unknown` / `unknown` **without** a userId | `shared-scope` |
| otherwise | eligible |

`userId` is not required unconditionally, because web-ui users often have none; there sticky is keyed per client-generated `sessionId`, and a shared `sessionId` already implies a shared transcript today. In Teams/Telegram, where the scope *is* shared by every participant, `userId` is always present — so the key is genuinely per-person exactly where it matters.

## State

A process-shared, bounded, idle-expiring `InMemoryDirectLineStickyStore`, injected via `OrchestratorDeps` — **not** an Orchestrator instance field, because the registry replaces the instance on any config diff and an instance field would silently unbind every live session on an unrelated operator tweak. Fully synchronous by design, so a read-modify-write is atomic on Node's single thread. 2 h idle TTL, 1000-entry LRU, gone on restart. Every loss falls back to the orchestrator.

## Indicator

A new additive-optional `DirectLineSessionState` on `SemanticAnswer`, `ChatTurnResult` and the streaming `done` arm (sanctioned by the stability contract in `outgoing.ts`).

**It is emitted on every turn while the flag is on, including `{active:false}` on ordinary turns.** That single rule is what makes a stale indicator impossible: after a restart, a rebuild or a TTL expiry the banner clears on the very next turn instead of lying. Both the SDK forwarder and the web-ui fold guard on *object presence*, never on `.active`.

- **web-ui** — persistent Lume banner above the composer (text + edge + low tint, no spinner) with an exit button, plus `MessageSchema` widened so it survives a reload.
- **Teams** — already correct with zero cross-repo work: a sticky turn emits an ordinary `delegatedAnswer`, so the existing "Direkte Antwort von X" chip fires on every reply.

## Config

`orchestrator_direct_line_sticky`, plumbed through all six hops (`config.ts` → `bootstrap.ts` → `manifest.yaml` → `plugin.ts` → `AgentRuntimeConfig` → `buildOrchestrator.ts` → `applyDiff.ts`), **default OFF**. Full plumbing is deliberate — `directLineMode`, `directLinePrefix` and `requiredConsultToolName` are all constructor-only and therefore dead in production; this is the first Direct-Line knob an operator can actually reach.

Two traps, both verified and encoded: the manifest default must be the **string** `"false"` (the loader reads non-`host_list` defaults via `asString`), and the flag must be read defensively (`raw === true || String(raw).trim().toLowerCase() === 'true'`) because the install service may persist a real boolean and `.trim()` on a boolean throws.

## Tests

90 across the two Direct Line suites (58 new). The load-bearing anti-cases:
- `#urgent server is down` still falls through to the LLM when unbound
- `#end of quarter — what now?` never exits and reaches the specialist verbatim
- a one-shot `#other` directive while bound does not rebind
- two `userId`s on one `sessionScope` stay isolated end-to-end
- `http-default` without a `userId` refuses to bind and says why
- a mid-session availability flip unbinds with the existing "no longer available" notice rather than leaking a raw dispatch-error string (#474 round-4 carried to turns 2..N)
- **PII masking still applies on the third consecutive sticky turn** — the direct regression gate for the bypass PR #446 fixed
- flag-off behaviour is byte-for-byte #332 (all 32 pre-existing tests untouched and green)

Plus web-ui vitest coverage for the banner including `{active:false}` and the unlabelled case.

**Gates:** middleware 4905 pass / 0 fail, web-ui 325 pass / 0 fail, typecheck + lint clean (0 errors) in both, `i18n:check` OK (3129 keys, en + de).

## Open decisions for review

1. **Flag default for 1.1.0** — shipped `false`. Telegram renders neither the consulted footer nor the delegated-answer attribution today, so enabling it there would create an *invisible* sticky mode, which breaks this issue's own "never ambiguous who is answering" requirement. Proposal: flip once a Telegram plain-text indicator lands.
2. **Per-user vs per-conversation in group threads** — shipped per-user. Per-conversation is arguably more natural, but it lets one participant bind everyone. Product call.
3. **Session reset does not unbind** — `POST /api/chat/sessions/:id/reset` and `forceInvalidate('drain')` cannot reach a process-local store without a new cross-package resolver. Bounded by the 2 h TTL and an always-visible exit control.

## Honestly deferred

- **The specialist gets no conversation history.** `LocalSubAgent.ask` builds `messages = [{role:'user', content: question}]`, so a sticky session is N independent one-shots. This is faithful to the issue ("sticky only changes HOW THE TARGET IS SELECTED"), but it means v1 is a typing shortcut plus a persistent indicator, not a stateful specialist conversation. The orchestrator still stays aware, because sticky turns persist through the same `sessionLogger`. Adding bounded harness-composed history later is purely additive.
- **A true persistent banner in Teams is impossible**, not merely unimplemented — every reply is a fresh `sendActivity`. The ceiling is a chip re-emitted per reply, which is what ships.
- **`'http-default'` remains a live cross-user shared key for everything else** (`steeringBus` already keys on it). This PR refuses it *for sticky* with zero blast radius; the underlying bug wants its own issue.
- **Sticky amplifies four pre-existing Direct-Line path asymmetries** rather than fixing them (the non-streaming path skips `applyTurnAuthContext` and fires neither turn hook; the streaming direct branch skips the v4 answer swap and the second `restorePromptPseudonyms`; a direct-line streamed turn emits only a `done` event, so a sticky session is non-streaming in the web-ui). Under sticky these become the normal case for a conversation rather than an occasional turn. Fixing them here would balloon the diff; they want separate issues, and the streaming-UX one is user-visible enough to deserve one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787846282&installation_model_id=428086&pr_number=535&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F535&signature=2adf1a0cbd9c1dfb5d253c416f144ab63e52b9b3da5f54a20b7180f24076963e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->