### PR TITLE
feat(platform): plugin-contributed navigation (phase 1 of Dev Platform extraction)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,46 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — plugin-contributed navigation (#470, phase 1 of the Dev Platform extraction)
+
+- New plugin capability `ctx.uiRoutes.registerNav({ navId, href, cluster?,
+  order?, label })` lets an installed plugin contribute entries to the
+  operator navigation. Backed by `UiRouteCatalog.registerNav()` /
+  `listNav(locale)` and served by a new session-gated route
+  `GET /api/v1/ui/navigation?locale=<l>`, which returns labels **already
+  resolved** for the requested locale — the browser never receives the
+  per-locale map, so the web UI stays on next-intl's single i18n clock.
+- The web-ui shell (`Nav.tsx`) now merges its static nav with the
+  contributed entries, fetched server-side in the root layout. An entry
+  joins the cluster it names; an unknown or absent cluster promotes it to
+  top level; an href colliding with a static one is dropped so a plugin
+  cannot shadow a core destination. Every plugin-supplied field is
+  validated as untrusted input (canonical in-app hrefs only; labels
+  length-capped and screened for control, bidi and zero-width codepoints).
+- Dev Platform is the first consumer: its menu entry and its `/admin` grid
+  card now come from that registration instead of being hardcoded, so
+  disabling the feature removes both with no frontend rebuild. Removes the
+  now-unused `nav.devPlatform` key from `messages/{en,de}.json`.
+- Rationale and the remaining extraction phases:
+  `specs/470-dev-platform-plugin/plan.md`.
+
+### Fixed — deactivated tool plugins kept serving their Express routes
+
+- `ToolPluginRuntime.deactivate()` stopped background jobs and disposed UI
+  routes but never called `pluginRouteRegistry.disposeBySource()`, although
+  it held that dependency and threaded it into every plugin context
+  (`DynamicAgentRuntime` already did). Express cannot unmount, so an
+  uninstalled or hot-upgraded plugin's routers stayed live and — because
+  Express matches first-mount-wins — kept answering and shadowed anything
+  later mounted at the same prefix.
+- Disposal now also runs **before** the plugin-controlled `close()` is
+  awaited; previously a plugin whose `close()` hung kept its routes and menu
+  entry live for the full 5s budget after the operator triggered
+  deactivation. `activate()` additionally rolls back its own route/nav/job
+  registrations when a plugin registers and then throws or times out —
+  such a plugin never reaches the active set, so `deactivate()` could never
+  clean it up and the orphan survived for the life of the process.
+
 ### Added — structured dataset ingestion (CSV import) for the Knowledge Graph (#430)
 
 - New `KnowledgeGraph` surface (`ingestDataset`, `listDatasets`, `getDataset`,

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -712,6 +712,54 @@ schrieb der Import-Pfad unter der kanonischen id, während der Query-Pfad die
 rohe id las, sodass ein Channel-User sein eigenes gerade importiertes Dataset
 nie wiederfinden konnte.
 
+### Plugin-contributed Navigation (#470, Phase 1 der Dev-Platform-Extraktion)
+
+Damit ein Feature wirklich *installierbar* ist, muss sein Menü-Eintrag mit
+dem Plugin mitreisen — bisher war die Navigation ein eingefrorenes Literal in
+`web-ui/app/_components/Nav.tsx`. Neue Plugin-Fähigkeit:
+
+```ts
+ctx.uiRoutes.registerNav({ navId, href, cluster?, order?, label })
+```
+
+Bewusst getrennt von `ctx.uiRoutes.register()`: ein uiRoute-Descriptor
+adressiert relativ zum `/p/<pluginId>`-Mount des Plugins, ein Nav-Eintrag
+adressiert einen absoluten In-App-Pfad. Beides in einen Descriptor zu falten
+würde eines der zwei Pfad-Felder zur Lüge machen. Beide teilen sich denselben
+Lifecycle in `UiRouteCatalog` (`disposeBySource` räumt beide ab).
+
+Neue Route: **`GET /api/v1/ui/navigation?locale=<l>`**
+(`src/routes/uiNavigation.ts`), gemountet unter `/api` und zusätzlich
+explizit hinter `requireAuth` — die Einträge verraten, welche Features
+installiert sind. Antwort ist `no-store` und enthält **bereits aufgelöste**
+Labels: der Browser bekommt die Locale-Map nie zu sehen, dadurch bleibt das
+Web-UI auf genau einer i18n-Uhr (next-intl) statt auf zwei, die beim
+Sprachwechsel auseinanderlaufen.
+
+Die Shell holt die Einträge **server-seitig im Root-Layout** (`fetchNavEntries`
+in `web-ui/app/_lib/navigation.ts`, 2s-Timeout, degradiert lautlos auf die
+statische Navigation) und merged sie in `Nav.tsx`. Merge-Regeln: Eintrag
+landet im benannten Cluster; unbekannter/fehlender Cluster wird zum
+Top-Level-Eintrag (statt still verschluckt zu werden); ein href-Konflikt mit
+einem statischen Eintrag wird verworfen, damit ein Plugin kein Core-Ziel
+überschatten kann.
+
+Jedes vom Plugin gelieferte Feld gilt als **untrusted input**, weil es im
+vertrauenswürdigen Header gerendert wird: `href` nur in kanonischer In-App-Form
+(kein `//host`, keine Dot-Segments, keine Query/Fragment/Prozent-Kodierung —
+sonst wäre die „Core gewinnt"-Regel per Alias umgehbar), Labels längenbegrenzt
+und gegen Control-, Bidi- und Zero-Width-Codepoints geprüft (Trojan-Source-
+Spoofing benachbarter Core-Einträge). Dazu Obergrenzen für href-/navId-Länge,
+Locale-Map-Größe und Einträge pro Plugin, weil der Katalog in jede
+Root-Layout-RSC-Antwort serialisiert wird.
+
+Erster Consumer ist die Dev Platform selbst: ihr Eintrag wird aus dem
+bestehenden `DEV_PLATFORM_ENABLED`-Block in `index.ts` registriert
+(`core:dev-platform`), nicht mehr in `Nav.tsx` hardcodiert. Wenn das Plugin-
+Package landet, wird daraus `ctx.uiRoutes.registerNav(...)` in dessen
+`activate()` — an der Shell ändert sich dabei nichts. Vollständiger Plan und
+die verbleibenden Phasen: `specs/470-dev-platform-plugin/plan.md`.
+
 ---
 
 ## 4. Migration Managed Agents → Lokal

--- a/middleware/packages/plugin-api/src/pluginContext.ts
+++ b/middleware/packages/plugin-api/src/pluginContext.ts
@@ -708,6 +708,22 @@ export interface UiRoutesAccessor {
    * into the catalogue.
    */
   register(descriptor: UiRouteDescriptorInput): () => void;
+
+  /**
+   * Publish a top-level navigation entry for the operator web UI.
+   *
+   * This is deliberately separate from `register()`: a uiRoute
+   * descriptor addresses a plugin-served surface *relative to* the
+   * plugin's `/p/<pluginId>` mount, whereas a nav entry addresses an
+   * absolute in-app route. A plugin whose UI ships as compiled
+   * web-ui pages (a built-in package) has a nav entry and no uiRoute;
+   * a plugin serving its own HTML has both.
+   *
+   * Returns a dispose handle the plugin MUST call from its `close()`.
+   * The kernel additionally drops every entry by source on deactivate,
+   * so a leaked handle cannot outlive the plugin.
+   */
+  registerNav(entry: UiNavEntryInput): () => void;
 }
 
 export interface UiRouteDescriptorInput {
@@ -731,6 +747,58 @@ export interface UiRouteDescriptorInput {
  */
 export interface UiRouteDescriptor extends UiRouteDescriptorInput {
   readonly pluginId: string;
+}
+
+/**
+ * A navigation entry contributed by a plugin to the operator web UI.
+ *
+ * Labels are plugin-owned and localized here rather than in web-ui's
+ * `messages/*.json`, because the shell cannot know a third-party
+ * plugin's strings at build time. The kernel resolves the label for
+ * the requested locale before it ever reaches the browser, so the UI
+ * never has to merge a second message catalogue at runtime.
+ */
+export interface UiNavEntryInput {
+  /** Stable id within the plugin. Combined with pluginId as the key. */
+  readonly navId: string;
+  /**
+   * Absolute in-app path (e.g. `/admin/dev-platform`). Must start with
+   * exactly one `/` — protocol-relative (`//host`) and scheme-bearing
+   * values are rejected so a manifest cannot point the nav off-origin.
+   */
+  readonly href: string;
+  /**
+   * Optional cluster to nest under (e.g. `adminCluster`). Rendered as a
+   * top-level entry when omitted, or when the shell has no cluster by
+   * that key.
+   */
+  readonly cluster?: string;
+  /** Ordering hint within the cluster — lower comes first. Default 100. */
+  readonly order?: number;
+  /**
+   * Locale code → label. An `en` entry is required as the fallback for
+   * locales the plugin does not translate.
+   */
+  readonly label: Readonly<Record<string, string>>;
+}
+
+/** Catalogue-resolved nav entry — pluginId injected by the kernel. */
+export interface UiNavEntry extends UiNavEntryInput {
+  readonly pluginId: string;
+}
+
+/**
+ * A nav entry flattened for one locale. This is the shape the HTTP
+ * surface returns and the web UI consumes; `label` is already resolved,
+ * so no locale negotiation happens in the browser.
+ */
+export interface ResolvedUiNavEntry {
+  readonly pluginId: string;
+  readonly navId: string;
+  readonly href: string;
+  readonly cluster?: string;
+  readonly order: number;
+  readonly label: string;
 }
 
 /**

--- a/middleware/src/devplatform/githubApp/installationTokens.ts
+++ b/middleware/src/devplatform/githubApp/installationTokens.ts
@@ -1,5 +1,5 @@
 import type { DevJob } from '../types.js';
-import { mintAppJwt } from './appJwt.js';
+import { mintAppJwt } from '../../services/githubAppJwt.js';
 
 /**
  * Epic #470 W2 — scoped, uncached, revocable GitHub App installation tokens.

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -258,6 +258,7 @@ import { NotificationRouter } from './platform/notificationRouter.js';
 import { PluginStatusRegistry } from './platform/pluginStatusRegistry.js';
 import { OAuthReadinessTracker } from './plugins/oauth/oauthReadinessTracker.js';
 import { UiRouteCatalog } from './platform/uiRouteCatalog.js';
+import { createUiNavigationRouter } from './routes/uiNavigation.js';
 import { CanvasOutputRegistry } from './platform/canvasOutputRegistry.js';
 import { EventCatalogRegistry } from './platform/eventCatalogRegistry.js';
 import { DeterministicActionRegistry } from './platform/deterministicActionRegistry.js';
@@ -328,6 +329,17 @@ interface Microsoft365AccessorShim {
 
 /** Escape a value for safe inclusion inside a double-quoted XML/HTML attribute
  *  (used for the <mcp-auth-required> chat block, #459 W9). */
+/**
+ * Locales the operator web UI ships message catalogues for
+ * (`web-ui/messages/*.json`). Used to validate `?locale=` on the
+ * navigation endpoint before it reaches label resolution — an unknown
+ * locale renders English chrome rather than an error. Keep in sync with
+ * web-ui's catalogue; a missing entry here only costs a fallback to
+ * English, never a failure.
+ */
+const WEB_UI_LOCALES = ['en', 'de'] as const;
+const WEB_UI_DEFAULT_LOCALE = 'en';
+
 function xmlAttr(value: string): string {
   return value
     .replace(/&/g, '&amp;')
@@ -2191,6 +2203,23 @@ async function main(): Promise<void> {
   // travels with it.
   app.use('/api/chat', requireAuth, createChatSessionsRouter({ getStore: getChatSessionStore }));
 
+  // Plugin-contributed navigation. The web-ui shell renders a static nav for
+  // its own compiled surfaces and merges this for everything a plugin adds,
+  // which is what makes a feature genuinely installable: deactivate its
+  // plugin and the menu entry is gone without a frontend rebuild.
+  // `requireAuth` is defence-in-depth over the `/api` mount — the entry list
+  // discloses which features an operator has installed.
+  app.use(
+    '/api',
+    requireAuth,
+    createUiNavigationRouter({
+      catalog: uiRouteCatalog,
+      supportedLocales: WEB_UI_LOCALES,
+      defaultLocale: WEB_UI_DEFAULT_LOCALE,
+    }),
+  );
+  console.log('[middleware] ui navigation endpoint ready at /api/v1/ui/navigation');
+
   // In-app "Create Issue" button: operator connects their own GitHub
   // account via the device flow (only a public client id, no secret — so
   // omadia ships the OAuth App baked in), the primary LLM reformulates the
@@ -2714,6 +2743,26 @@ async function main(): Promise<void> {
     console.log(
       `[middleware] dev platform ENABLED — worker running (max ${String(config.DEV_PLATFORM_MAX_CONCURRENT_JOBS)} concurrent, ${String(wiredDevPlatform.backends.length)} backend(s))`,
     );
+
+    // Contribute the operator menu entry instead of hardcoding it in the
+    // web-ui shell. This is the first consumer of the nav catalogue and the
+    // reason it exists: dev-platform is being extracted into a plugin
+    // (specs/470-dev-platform-plugin/plan.md), and its menu entry has to
+    // travel with it. Registering from here — still core, still inside the
+    // DEV_PLATFORM_ENABLED gate — proves the whole loop before any code
+    // moves. When the plugin package lands, this call becomes
+    // `ctx.uiRoutes.registerNav(...)` inside its activate() and nothing
+    // else about the shell changes.
+    //
+    // The `core:` prefix marks a kernel-registered source; a real plugin's
+    // entries are keyed by its plugin id, which the kernel injects.
+    uiRouteCatalog.registerNav('core:dev-platform', {
+      navId: 'devPlatform',
+      href: '/admin/dev-platform',
+      cluster: 'adminCluster',
+      order: 50,
+      label: { en: 'Dev Platform', de: 'Dev-Plattform' },
+    });
 
     // W5 data lifecycle — the daily retention sweep (two-tier event prune). The
     // per-job event cap + artifact ceiling are enforced inline at write time; this

--- a/middleware/src/platform/pluginContext.ts
+++ b/middleware/src/platform/pluginContext.ts
@@ -691,6 +691,9 @@ export function createPluginContext(
     register(input) {
       return opts.uiRouteCatalog.register(agentId, input);
     },
+    registerNav(input) {
+      return opts.uiRouteCatalog.registerNav(agentId, input);
+    },
   };
 
   // OB-29-1 — SubAgentAccessor: present iff the manifest declares

--- a/middleware/src/platform/uiRouteCatalog.ts
+++ b/middleware/src/platform/uiRouteCatalog.ts
@@ -1,37 +1,179 @@
 import type {
+  ResolvedUiNavEntry,
+  UiNavEntry,
+  UiNavEntryInput,
   UiRouteDescriptor,
   UiRouteDescriptorInput,
 } from '@omadia/plugin-api';
 
+/** Default ordering weight for entries that don't specify one. */
+const DEFAULT_ORDER = 100;
+
+/** Nav labels are chrome, not content — long strings break the header. */
+const MAX_LABEL_LENGTH = 40;
+
+const NAV_ID = /^[A-Za-z0-9._-]+$/;
+const CLUSTER_KEY = /^[A-Za-z][A-Za-z0-9]*$/;
+const LOCALE_CODE = /^[a-z]{2}(?:-[A-Za-z0-9]+)*$/;
+
 /**
- * Kernel-side catalogue of plugin-served UI surfaces.
+ * Reject control characters and bidirectional-formatting codepoints.
  *
- * Plugins call `ctx.uiRoutes.register({routeId, path, title})` from
- * their activate() and the accessor delegates here. The catalogue is
- * the source of truth for downstream surfaces:
+ * A plugin label renders adjacent to core nav entries in the trusted
+ * header, so an RTL override could visually reorder or spoof the labels
+ * around it (Trojan-Source style). React escapes markup for us; it does
+ * not defend against this.
  *
- *   - channel-teams' `/p/channel-teams/hub` iterates `list()` to render
- *     clickable cards.
- *   - channel-teams' `/p/channel-teams/tab-config` queries `list()` to
- *     populate the Target-Route dropdown when the operator pins a
- *     configurable Teams Tab.
+ * Written as a codepoint scan rather than a character-class regex so the
+ * source stays pure ASCII — the ranges are easier to audit as numbers
+ * than as invisible literals.
+ */
+function hasUnsafeChars(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code <= 0x1f) return true; // C0 controls (incl. NUL, CR, LF)
+    if (code >= 0x7f && code <= 0x9f) return true; // DEL + C1 controls
+    if (code === 0x061c) return true; // ARABIC LETTER MARK
+    if (code === 0x200e || code === 0x200f) return true; // LRM / RLM
+    if (code >= 0x202a && code <= 0x202e) return true; // bidi embed / override
+    if (code >= 0x2066 && code <= 0x2069) return true; // bidi isolates
+  }
+  return false;
+}
+
+/**
+ * An in-app path and nothing else. Must begin with exactly one `/`:
+ * `//evil.example` is protocol-relative and `/\evil.example` is normalised
+ * to `//` by browsers — either would take the operator off-origin from a
+ * link rendered in the trusted header.
+ */
+function assertInAppHref(
+  context: string,
+  href: unknown,
+): asserts href is string {
+  if (typeof href !== 'string' || href.length === 0) {
+    throw new Error(`${context}: href must be a non-empty string`);
+  }
+  if (!href.startsWith('/') || href.startsWith('//') || href.startsWith('/\\')) {
+    throw new Error(
+      `${context}: href must be an in-app path starting with a single '/' (got '${href}')`,
+    );
+  }
+  if (hasUnsafeChars(href) || /\s/.test(href)) {
+    throw new Error(
+      `${context}: href must not contain whitespace or control characters`,
+    );
+  }
+}
+
+/**
+ * Validate a locale to label map and freeze a defensive copy. `en` is
+ * required so every locale has a fallback; without it a plugin that ships
+ * only `de` would render an empty nav entry for English operators.
+ */
+function normalizeLabels(
+  context: string,
+  label: unknown,
+): Readonly<Record<string, string>> {
+  if (typeof label !== 'object' || label === null || Array.isArray(label)) {
+    throw new Error(`${context}: label must be an object of locale to string`);
+  }
+  const entries = Object.entries(label as Record<string, unknown>);
+  if (entries.length === 0) {
+    throw new Error(`${context}: label must contain at least one locale`);
+  }
+  const out: Record<string, string> = {};
+  for (const [locale, value] of entries) {
+    if (!LOCALE_CODE.test(locale)) {
+      throw new Error(`${context}: '${locale}' is not a valid locale code`);
+    }
+    if (typeof value !== 'string' || value.trim().length === 0) {
+      throw new Error(
+        `${context}: label['${locale}'] must be a non-empty string`,
+      );
+    }
+    if (value.length > MAX_LABEL_LENGTH) {
+      throw new Error(
+        `${context}: label['${locale}'] exceeds ${MAX_LABEL_LENGTH} characters`,
+      );
+    }
+    if (hasUnsafeChars(value)) {
+      throw new Error(
+        `${context}: label['${locale}'] contains control or bidirectional-formatting characters`,
+      );
+    }
+    out[locale] = value;
+  }
+  if (out['en'] === undefined) {
+    throw new Error(
+      `${context}: label must include an 'en' entry as the fallback`,
+    );
+  }
+  return Object.freeze(out);
+}
+
+/**
+ * Resolve a label for a locale: exact match, then the base language
+ * (`de-AT` to `de`), then `en`.
+ */
+function resolveLabel(
+  label: Readonly<Record<string, string>>,
+  locale: string,
+): string {
+  const exact = label[locale];
+  if (exact !== undefined) return exact;
+  const base = locale.split('-')[0];
+  if (base !== undefined) {
+    const byLanguage = label[base];
+    if (byLanguage !== undefined) return byLanguage;
+  }
+  // normalizeLabels guarantees 'en' exists.
+  return label['en'] as string;
+}
+
+/**
+ * Kernel-side catalogue of plugin-contributed UI surfaces.
+ *
+ * Two related but distinct things live here, sharing one lifecycle:
+ *
+ *  1. **uiRoute descriptors** — plugin-served surfaces addressed relative
+ *     to the plugin's `/p/<pluginId>` mount. Plugins register via
+ *     `ctx.uiRoutes.register({routeId, path, title})`. Consumers:
+ *       - channel-teams' `/p/channel-teams/hub` iterates `list()` to
+ *         render clickable cards.
+ *       - channel-teams' `/p/channel-teams/tab-config` queries `list()`
+ *         to populate the Target-Route dropdown.
+ *
+ *  2. **nav entries** — entries in the operator web UI's top navigation,
+ *     addressed by absolute in-app path. Plugins register via
+ *     `ctx.uiRoutes.registerNav(...)`; `GET /api/v1/ui/navigation` serves
+ *     them to the web-ui shell with labels already resolved for the
+ *     requested locale.
+ *
+ * They are separate registrations because their `href`/`path` semantics
+ * differ: a built-in package whose UI ships as compiled web-ui pages has
+ * a nav entry and no uiRoute, while a plugin serving its own HTML has
+ * both. Folding them into one descriptor would make one of the two path
+ * fields a lie.
  *
  * Both call sites resolve the catalogue via `ctx.services.get<
- * UiRouteCatalog>('uiRouteCatalog')`. The kernel publishes the
- * instance during boot, before any plugin activates, so consumers
- * never see an undefined catalogue.
+ * UiRouteCatalog>('uiRouteCatalog')`. The kernel publishes the instance
+ * during boot, before any plugin activates, so consumers never see an
+ * undefined catalogue.
  *
- * Entries are keyed by (`pluginId`, `routeId`). Re-registering the
- * same key throws — plugins must dispose their previous handle
+ * Entries are keyed by (`pluginId`, `routeId`/`navId`). Re-registering
+ * the same key throws — plugins must dispose their previous handle
  * before a hot-swap re-activates them, mirroring the route-registry
  * contract.
  *
  * `disposeBySource` is a fail-safe the kernel calls during plugin
- * deactivate — leaked dispose handles from a misbehaving plugin
- * still cannot outlive the plugin's lifecycle.
+ * deactivate — leaked dispose handles from a misbehaving plugin still
+ * cannot outlive the plugin's lifecycle.
  */
 export class UiRouteCatalog {
   private readonly entries = new Map<string, UiRouteDescriptor>();
+
+  private readonly navEntries = new Map<string, UiNavEntry>();
 
   /**
    * Register a uiRoute descriptor for the given plugin. The pluginId
@@ -39,10 +181,7 @@ export class UiRouteCatalog {
    * in from the activating plugin's agentId) — plugins cannot spoof
    * another plugin's surfaces.
    */
-  register(
-    pluginId: string,
-    input: UiRouteDescriptorInput,
-  ): () => void {
+  register(pluginId: string, input: UiRouteDescriptorInput): () => void {
     if (typeof pluginId !== 'string' || pluginId.length === 0) {
       throw new Error(
         'UiRouteCatalog.register: pluginId must be a non-empty string',
@@ -92,14 +231,65 @@ export class UiRouteCatalog {
   }
 
   /**
+   * Register a navigation entry for the given plugin.
+   *
+   * Every field is treated as untrusted input: `href` is confined to
+   * in-app paths and labels are length- and charset-checked, because
+   * both are rendered inside the shell's own header where an operator
+   * has every reason to trust what they see.
+   */
+  registerNav(pluginId: string, input: UiNavEntryInput): () => void {
+    if (typeof pluginId !== 'string' || pluginId.length === 0) {
+      throw new Error(
+        'UiRouteCatalog.registerNav: pluginId must be a non-empty string',
+      );
+    }
+    if (typeof input.navId !== 'string' || !NAV_ID.test(input.navId)) {
+      throw new Error(
+        `UiRouteCatalog.registerNav(${pluginId}): navId must match ${String(NAV_ID)}`,
+      );
+    }
+    const context = `UiRouteCatalog.registerNav(${pluginId}/${input.navId})`;
+    assertInAppHref(context, input.href);
+    if (input.cluster !== undefined && !CLUSTER_KEY.test(input.cluster)) {
+      throw new Error(`${context}: cluster must match ${String(CLUSTER_KEY)}`);
+    }
+    if (input.order !== undefined && !Number.isInteger(input.order)) {
+      throw new Error(`${context}: order must be a finite integer`);
+    }
+    const label = normalizeLabels(context, input.label);
+
+    const key = `${pluginId}::${input.navId}`;
+    if (this.navEntries.has(key)) {
+      throw new Error(
+        `UiRouteCatalog: nav entry '${key}' is already registered — dispose the previous registration before re-registering (hot-swap leak)`,
+      );
+    }
+    const entry: UiNavEntry = {
+      pluginId,
+      navId: input.navId,
+      href: input.href,
+      label,
+      ...(input.cluster !== undefined ? { cluster: input.cluster } : {}),
+      ...(input.order !== undefined ? { order: input.order } : {}),
+    };
+    this.navEntries.set(key, entry);
+    return () => {
+      if (this.navEntries.get(key) === entry) {
+        this.navEntries.delete(key);
+      }
+    };
+  }
+
+  /**
    * Sorted snapshot of every active descriptor. Returns a fresh array
    * each call — safe for consumers to filter/sort further.
    * Sort: (order ?? 100) ASC, then pluginId ASC, then routeId ASC.
    */
   list(): readonly UiRouteDescriptor[] {
     return [...this.entries.values()].sort((a, b) => {
-      const oa = a.order ?? 100;
-      const ob = b.order ?? 100;
+      const oa = a.order ?? DEFAULT_ORDER;
+      const ob = b.order ?? DEFAULT_ORDER;
       if (oa !== ob) return oa - ob;
       if (a.pluginId !== b.pluginId) {
         return a.pluginId.localeCompare(b.pluginId);
@@ -109,11 +299,40 @@ export class UiRouteCatalog {
   }
 
   /**
-   * Drop every entry registered by the given plugin. Used by the
-   * kernel on plugin deactivate as a fail-safe — plugins whose
-   * close() forgets to call its per-route dispose handle still cannot
-   * leak descriptors into the catalogue. Returns the count of entries
-   * dropped (0 when nothing matched).
+   * Sorted nav entries with labels resolved for `locale`. This is what
+   * `GET /api/v1/ui/navigation` returns: the browser never sees the
+   * per-locale map, so the shell has no second message catalogue to
+   * merge and no locale negotiation of its own to get wrong.
+   * Sort: order ASC, then pluginId ASC, then navId ASC.
+   */
+  listNav(locale: string): readonly ResolvedUiNavEntry[] {
+    return [...this.navEntries.values()]
+      .map((entry): ResolvedUiNavEntry => {
+        const order = entry.order ?? DEFAULT_ORDER;
+        return {
+          pluginId: entry.pluginId,
+          navId: entry.navId,
+          href: entry.href,
+          order,
+          label: resolveLabel(entry.label, locale),
+          ...(entry.cluster !== undefined ? { cluster: entry.cluster } : {}),
+        };
+      })
+      .sort((a, b) => {
+        if (a.order !== b.order) return a.order - b.order;
+        if (a.pluginId !== b.pluginId) {
+          return a.pluginId.localeCompare(b.pluginId);
+        }
+        return a.navId.localeCompare(b.navId);
+      });
+  }
+
+  /**
+   * Drop every entry registered by the given plugin — both uiRoute
+   * descriptors and nav entries. Used by the kernel on plugin deactivate
+   * as a fail-safe, so plugins whose close() forgets to call its
+   * per-registration dispose handle still cannot leak into the
+   * catalogue. Returns the total count dropped (0 when nothing matched).
    */
   disposeBySource(pluginId: string): number {
     let count = 0;
@@ -123,11 +342,22 @@ export class UiRouteCatalog {
         count += 1;
       }
     }
+    for (const [key, entry] of this.navEntries) {
+      if (entry.pluginId === pluginId) {
+        this.navEntries.delete(key);
+        count += 1;
+      }
+    }
     return count;
   }
 
-  /** Diagnostic: total active descriptor count. */
+  /** Diagnostic: active uiRoute descriptor count. */
   size(): number {
     return this.entries.size;
+  }
+
+  /** Diagnostic: active nav entry count. */
+  navSize(): number {
+    return this.navEntries.size;
   }
 }

--- a/middleware/src/platform/uiRouteCatalog.ts
+++ b/middleware/src/platform/uiRouteCatalog.ts
@@ -12,9 +12,26 @@ const DEFAULT_ORDER = 100;
 /** Nav labels are chrome, not content — long strings break the header. */
 const MAX_LABEL_LENGTH = 40;
 
+/**
+ * Bounds on everything else a plugin supplies. The whole catalogue is
+ * serialised into the root-layout RSC payload of every page, so an
+ * accidental or hostile plugin must not be able to bloat it.
+ */
+const MAX_HREF_LENGTH = 256;
+const MAX_NAV_ID_LENGTH = 64;
+const MAX_CLUSTER_LENGTH = 64;
+const MAX_LOCALES_PER_LABEL = 32;
+const MAX_NAV_ENTRIES_PER_PLUGIN = 20;
+
 const NAV_ID = /^[A-Za-z0-9._-]+$/;
 const CLUSTER_KEY = /^[A-Za-z][A-Za-z0-9]*$/;
 const LOCALE_CODE = /^[a-z]{2}(?:-[A-Za-z0-9]+)*$/;
+
+/**
+ * Characters permitted in a single href path segment — the RFC 3986
+ * "unreserved" set. Deliberately excludes `%`, `?`, `#`, and `\`.
+ */
+const HREF_SEGMENT = /^[A-Za-z0-9\-._~]+$/;
 
 /**
  * Reject control characters and bidirectional-formatting codepoints.
@@ -37,15 +54,27 @@ function hasUnsafeChars(value: string): boolean {
     if (code === 0x200e || code === 0x200f) return true; // LRM / RLM
     if (code >= 0x202a && code <= 0x202e) return true; // bidi embed / override
     if (code >= 0x2066 && code <= 0x2069) return true; // bidi isolates
+    if (code >= 0x200b && code <= 0x200d) return true; // zero-width space/joiners
+    if (code === 0x2060 || code === 0xfeff) return true; // word joiner / BOM
   }
   return false;
 }
 
 /**
- * An in-app path and nothing else. Must begin with exactly one `/`:
- * `//evil.example` is protocol-relative and `/\evil.example` is normalised
- * to `//` by browsers — either would take the operator off-origin from a
- * link rendered in the trusted header.
+ * An in-app path in *canonical* form.
+ *
+ * Validating the raw string is not enough: the shell decides that "core
+ * destinations win" by comparing hrefs for equality, so any spelling that
+ * a browser resolves to a core path but that does not string-match it
+ * would slip past that rule. `/x/%2e%2e/admin`, `/admin/`, `/admin?a=1`
+ * and `/admin#x` all navigate to Admin while comparing unequal to
+ * `/admin`.
+ *
+ * Rather than canonicalising (and having to keep our normaliser in step
+ * with the URL parser), accept only strings that are *already* canonical:
+ * a leading `/`, non-empty unreserved-charset segments, no dot-segments,
+ * no trailing slash, no query, no fragment, no percent-encoding. For that
+ * subset, string equality and browser resolution agree.
  */
 function assertInAppHref(
   context: string,
@@ -54,15 +83,33 @@ function assertInAppHref(
   if (typeof href !== 'string' || href.length === 0) {
     throw new Error(`${context}: href must be a non-empty string`);
   }
-  if (!href.startsWith('/') || href.startsWith('//') || href.startsWith('/\\')) {
+  if (href.length > MAX_HREF_LENGTH) {
     throw new Error(
-      `${context}: href must be an in-app path starting with a single '/' (got '${href}')`,
+      `${context}: href exceeds ${String(MAX_HREF_LENGTH)} characters`,
     );
   }
-  if (hasUnsafeChars(href) || /\s/.test(href)) {
+  if (!href.startsWith('/')) {
     throw new Error(
-      `${context}: href must not contain whitespace or control characters`,
+      `${context}: href must be an in-app path starting with '/' (got '${href}')`,
     );
+  }
+  if (href === '/') return; // the root is canonical by definition
+  for (const segment of href.slice(1).split('/')) {
+    if (segment.length === 0) {
+      throw new Error(
+        `${context}: href must not contain an empty path segment — no '//', no trailing '/' (got '${href}')`,
+      );
+    }
+    if (segment === '.' || segment === '..') {
+      throw new Error(
+        `${context}: href must not contain dot-segments (got '${href}')`,
+      );
+    }
+    if (!HREF_SEGMENT.test(segment)) {
+      throw new Error(
+        `${context}: href segment '${segment}' has characters outside [A-Za-z0-9-._~] — query strings, fragments, percent-encoding and backslashes are not accepted`,
+      );
+    }
   }
 }
 
@@ -81,6 +128,11 @@ function normalizeLabels(
   const entries = Object.entries(label as Record<string, unknown>);
   if (entries.length === 0) {
     throw new Error(`${context}: label must contain at least one locale`);
+  }
+  if (entries.length > MAX_LOCALES_PER_LABEL) {
+    throw new Error(
+      `${context}: label declares more than ${String(MAX_LOCALES_PER_LABEL)} locales`,
+    );
   }
   const out: Record<string, string> = {};
   for (const [locale, value] of entries) {
@@ -244,14 +296,22 @@ export class UiRouteCatalog {
         'UiRouteCatalog.registerNav: pluginId must be a non-empty string',
       );
     }
-    if (typeof input.navId !== 'string' || !NAV_ID.test(input.navId)) {
+    if (
+      typeof input.navId !== 'string' ||
+      input.navId.length > MAX_NAV_ID_LENGTH ||
+      !NAV_ID.test(input.navId)
+    ) {
       throw new Error(
-        `UiRouteCatalog.registerNav(${pluginId}): navId must match ${String(NAV_ID)}`,
+        `UiRouteCatalog.registerNav(${pluginId}): navId must match ${String(NAV_ID)} and be at most ${String(MAX_NAV_ID_LENGTH)} characters`,
       );
     }
     const context = `UiRouteCatalog.registerNav(${pluginId}/${input.navId})`;
     assertInAppHref(context, input.href);
-    if (input.cluster !== undefined && !CLUSTER_KEY.test(input.cluster)) {
+    if (
+      input.cluster !== undefined &&
+      (input.cluster.length > MAX_CLUSTER_LENGTH ||
+        !CLUSTER_KEY.test(input.cluster))
+    ) {
       throw new Error(`${context}: cluster must match ${String(CLUSTER_KEY)}`);
     }
     if (input.order !== undefined && !Number.isInteger(input.order)) {
@@ -263,6 +323,15 @@ export class UiRouteCatalog {
     if (this.navEntries.has(key)) {
       throw new Error(
         `UiRouteCatalog: nav entry '${key}' is already registered — dispose the previous registration before re-registering (hot-swap leak)`,
+      );
+    }
+    let owned = 0;
+    for (const existing of this.navEntries.values()) {
+      if (existing.pluginId === pluginId) owned += 1;
+    }
+    if (owned >= MAX_NAV_ENTRIES_PER_PLUGIN) {
+      throw new Error(
+        `${context}: a plugin may contribute at most ${String(MAX_NAV_ENTRIES_PER_PLUGIN)} nav entries`,
       );
     }
     const entry: UiNavEntry = {

--- a/middleware/src/plugins/builder/githubAppAuth.ts
+++ b/middleware/src/plugins/builder/githubAppAuth.ts
@@ -1,4 +1,4 @@
-import { mintAppJwt } from '../../devplatform/githubApp/appJwt.js';
+import { mintAppJwt } from '../../services/githubAppJwt.js';
 
 /**
  * GitHub App authentication for the native direct-create path

--- a/middleware/src/plugins/toolPluginRuntime.ts
+++ b/middleware/src/plugins/toolPluginRuntime.ts
@@ -283,11 +283,26 @@ export class ToolPluginRuntime {
       logger: (...args) => console.log(`[${agentId}]`, ...args),
     });
 
-    const handle = await withTimeout(
-      activateFn(ctx),
-      10_000,
-      `activate(${agentId}) timed out after 10s`,
-    );
+    let handle: ToolPluginHandle;
+    try {
+      handle = await withTimeout(
+        activateFn(ctx),
+        10_000,
+        `activate(${agentId}) timed out after 10s`,
+      );
+    } catch (err) {
+      // A plugin that registered a router or a nav entry and THEN threw (or
+      // timed out) never reaches `active.set`, so deactivate() would later
+      // return false and never clean up — the orphaned route would keep
+      // serving and the orphaned menu entry would keep rendering for the
+      // life of the process. Roll back what the context handed out before
+      // letting the failure propagate to the circuit-breaker.
+      this.deps.pluginRouteRegistry.disposeBySource(agentId);
+      this.deps.uiRouteCatalog.disposeBySource(agentId);
+      this.deps.jobScheduler.stopForPlugin(agentId);
+      this.deps.pluginStatusRegistry?.clear(agentId);
+      throw err;
+    }
 
     // Plugin self-extension (Theme B): if the module opted into the selfExtend
     // SDK, register its declarative templates and re-materialise every
@@ -368,6 +383,21 @@ export class ToolPluginRuntime {
     }
     this.deps.selfExtendRegistry?.unregister(agentId);
     this.deps.eventCatalogRegistry?.unregister(agentId);
+    // Take the externally-reachable surfaces down BEFORE awaiting close().
+    // close() is plugin-controlled and gets a 5s budget, so disposing after
+    // it would leave routers answering and the menu entry visible for up to
+    // five seconds into a deactivation the operator already triggered —
+    // and for the full budget when a plugin's close() hangs.
+    //
+    // Express cannot unmount, so the route registry flips its entries to
+    // disposed and the mounted closure falls through to next(). Without
+    // this call a deactivated plugin's routers stay live and — because
+    // Express matches first-mount-wins — keep serving after uninstall or
+    // across a hot-upgrade. DynamicAgentRuntime already did this; the tool
+    // runtime held the dependency and threaded it into the plugin context
+    // but never disposed by source.
+    this.deps.pluginRouteRegistry.disposeBySource(agentId);
+    this.deps.uiRouteCatalog.disposeBySource(agentId);
     try {
       await withTimeout(
         entry.handle.close(),
@@ -384,15 +414,6 @@ export class ToolPluginRuntime {
     // close() should already invoke — a leaked dispose still won't outlive
     // its plugin's lifecycle.
     this.deps.jobScheduler.stopForPlugin(agentId);
-    // Express cannot unmount, so the route registry flips its entries to
-    // disposed and the mounted closure falls through to next(). Without
-    // this call a deactivated plugin's routers stay live and — because
-    // Express matches first-mount-wins — keep serving after uninstall or
-    // across a hot-upgrade. DynamicAgentRuntime already does this
-    // (dynamicAgentRuntime.ts); the tool runtime held the dependency and
-    // threaded it into the plugin context but never disposed by source.
-    this.deps.pluginRouteRegistry.disposeBySource(agentId);
-    this.deps.uiRouteCatalog.disposeBySource(agentId);
     this.deps.pluginStatusRegistry?.clear(agentId);
     this.deps.oauthConnectionTracker?.clear(agentId);
     this.active.delete(agentId);

--- a/middleware/src/plugins/toolPluginRuntime.ts
+++ b/middleware/src/plugins/toolPluginRuntime.ts
@@ -384,6 +384,14 @@ export class ToolPluginRuntime {
     // close() should already invoke — a leaked dispose still won't outlive
     // its plugin's lifecycle.
     this.deps.jobScheduler.stopForPlugin(agentId);
+    // Express cannot unmount, so the route registry flips its entries to
+    // disposed and the mounted closure falls through to next(). Without
+    // this call a deactivated plugin's routers stay live and — because
+    // Express matches first-mount-wins — keep serving after uninstall or
+    // across a hot-upgrade. DynamicAgentRuntime already does this
+    // (dynamicAgentRuntime.ts); the tool runtime held the dependency and
+    // threaded it into the plugin context but never disposed by source.
+    this.deps.pluginRouteRegistry.disposeBySource(agentId);
     this.deps.uiRouteCatalog.disposeBySource(agentId);
     this.deps.pluginStatusRegistry?.clear(agentId);
     this.deps.oauthConnectionTracker?.clear(agentId);

--- a/middleware/src/routes/devPlatformGithubApp.ts
+++ b/middleware/src/routes/devPlatformGithubApp.ts
@@ -1,7 +1,7 @@
 import { Router, json as expressJson } from 'express';
 import type { Request, Response } from 'express';
 
-import { mintAppJwt } from '../devplatform/githubApp/appJwt.js';
+import { mintAppJwt } from '../services/githubAppJwt.js';
 import {
   buildManifest,
   exchangeManifestCode,

--- a/middleware/src/routes/uiNavigation.ts
+++ b/middleware/src/routes/uiNavigation.ts
@@ -1,0 +1,71 @@
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+
+import type { UiRouteCatalog } from '../platform/uiRouteCatalog.js';
+
+/**
+ * `GET /api/v1/ui/navigation` — the operator web UI's dynamic nav source.
+ *
+ * The web-ui shell ships a static nav for its own compiled surfaces and
+ * merges this response for everything a plugin contributes. That split is
+ * what lets a feature be *installable*: turn its plugin off and its menu
+ * entry is simply absent, with no web-ui rebuild.
+ *
+ * Labels are resolved server-side for the requested locale. The browser
+ * therefore never receives the per-locale map and never negotiates a
+ * locale of its own — which keeps the shell on exactly one i18n clock
+ * (next-intl's) instead of two that can drift apart on a locale switch.
+ *
+ * Auth: this router is mounted under `/api`, which sits behind the blanket
+ * `requireAuth` gate in index.ts. Navigation reveals which features an
+ * operator has installed, so it is deliberately not a public path.
+ */
+
+export interface UiNavigationRouterDeps {
+  catalog: Pick<UiRouteCatalog, 'listNav'>;
+  /**
+   * Locales the shell can actually render. A request for anything else
+   * falls back to `defaultLocale` rather than echoing an unvalidated
+   * query parameter into the resolver.
+   */
+  supportedLocales: readonly string[];
+  defaultLocale: string;
+}
+
+/**
+ * Pick the locale to resolve labels against. Unknown or malformed input
+ * degrades to the default — a bad `?locale=` should render English chrome,
+ * never an error page in the shell's header.
+ */
+export function resolveRequestLocale(
+  raw: unknown,
+  supported: readonly string[],
+  fallback: string,
+): string {
+  if (typeof raw !== 'string' || raw.length === 0) return fallback;
+  if (supported.includes(raw)) return raw;
+  const base = raw.split('-')[0];
+  if (base !== undefined && supported.includes(base)) return base;
+  return fallback;
+}
+
+export function createUiNavigationRouter(
+  deps: UiNavigationRouterDeps,
+): Router {
+  const router = Router();
+
+  router.get('/v1/ui/navigation', (req: Request, res: Response) => {
+    const locale = resolveRequestLocale(
+      req.query['locale'],
+      deps.supportedLocales,
+      deps.defaultLocale,
+    );
+    // Per-session, per-locale, and invalidated by plugin activation — none
+    // of which a shared cache can key on correctly. Cheap to recompute
+    // (an in-memory map walk), so don't let anything cache it.
+    res.setHeader('Cache-Control', 'no-store');
+    res.json({ locale, entries: deps.catalog.listNav(locale) });
+  });
+
+  return router;
+}

--- a/middleware/src/services/githubAppJwt.ts
+++ b/middleware/src/services/githubAppJwt.ts
@@ -1,14 +1,21 @@
 import { createSign } from 'node:crypto';
 
 /**
- * Epic #470 W2 — the shared GitHub App JWT minter.
+ * The shared GitHub App JWT minter.
  *
  * A GitHub App authenticates to the API as itself with a short-lived RS256 JWT
  * signed by its private key, then exchanges that for an installation token. Two
- * places mint this JWT: the existing issue-reporting provider
- * (`builder/githubAppAuth.ts`) and W2's scoped, revocable job tokens. Rather than
- * duplicate the signing — a security primitive is the last thing to copy-paste —
- * both call this.
+ * places mint this JWT: the issue-reporting provider
+ * (`plugins/builder/githubAppAuth.ts`) and the dev platform's scoped, revocable
+ * job tokens. Rather than duplicate the signing — a security primitive is the
+ * last thing to copy-paste — both call this.
+ *
+ * Lives in `services/` rather than under `devplatform/` where it was first
+ * written (epic #470 W2): core's builder imported it from there, which made the
+ * dev-platform tree a dependency of core and blocked extracting that tree into
+ * its own repository. The primitive itself is generic GitHub App auth and has
+ * nothing dev-platform-specific about it.
+ * See `specs/470-dev-platform-plugin/core-decoupling-checklist.md`.
  */
 
 /** GitHub rejects a JWT whose lifetime exceeds 10 minutes; 9 leaves headroom. */

--- a/middleware/test/_helpers/httpInvoke.ts
+++ b/middleware/test/_helpers/httpInvoke.ts
@@ -1,0 +1,90 @@
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { Socket } from 'node:net';
+import type { Express } from 'express';
+
+/**
+ * Drive an Express app through its real routing pipeline WITHOUT binding a
+ * TCP port.
+ *
+ * `app.listen(0)` + `fetch` is the obvious way to test a router, but every
+ * such test holds a listening socket for its lifetime, and the suite runs
+ * files concurrently. Enough of them and unrelated socket-using tests start
+ * failing under contention — a fragility this repo already has. Tests that
+ * only need "does this router answer correctly" should not be paying that
+ * cost.
+ *
+ * This constructs genuine `IncomingMessage` / `ServerResponse` objects over
+ * an unconnected socket and calls `app.handle`, so middleware ordering,
+ * route matching, `res.json`, and header handling all run for real — only
+ * the network layer is skipped.
+ */
+
+export interface InvokeResult {
+  readonly status: number;
+  readonly headers: Readonly<Record<string, string | string[] | number | undefined>>;
+  readonly text: string;
+}
+
+type EndArgs = readonly unknown[];
+
+export function invoke(
+  app: Express,
+  method: string,
+  url: string,
+): Promise<InvokeResult> {
+  const socket = new Socket();
+  const req = new IncomingMessage(socket);
+  req.method = method;
+  req.url = url;
+
+  const res = new ServerResponse(req);
+  const chunks: Buffer[] = [];
+
+  const capture = (chunk: unknown): void => {
+    if (chunk === undefined || chunk === null) return;
+    if (typeof chunk === 'string') {
+      chunks.push(Buffer.from(chunk, 'utf8'));
+      return;
+    }
+    if (Buffer.isBuffer(chunk)) chunks.push(chunk);
+  };
+
+  return new Promise<InvokeResult>((resolve) => {
+    // The response is never flushed to a real socket, so intercept the
+    // write path and resolve once the handler finishes.
+    res.write = ((chunk: unknown, ...rest: EndArgs): boolean => {
+      capture(chunk);
+      const cb = rest.at(-1);
+      if (typeof cb === 'function') (cb as () => void)();
+      return true;
+    }) as typeof res.write;
+
+    res.end = ((chunk?: unknown, ...rest: EndArgs): ServerResponse => {
+      capture(chunk);
+      const cb = rest.at(-1);
+      if (typeof cb === 'function') (cb as () => void)();
+      resolve({
+        status: res.statusCode,
+        headers: res.getHeaders(),
+        text: Buffer.concat(chunks).toString('utf8'),
+      });
+      return res;
+    }) as typeof res.end;
+
+    app.handle(req, res);
+  });
+}
+
+/** `invoke` + JSON parse, for endpoints that answer `application/json`. */
+export async function getJson<T>(app: Express, url: string): Promise<{
+  status: number;
+  headers: InvokeResult['headers'];
+  body: T;
+}> {
+  const res = await invoke(app, 'GET', url);
+  return {
+    status: res.status,
+    headers: res.headers,
+    body: JSON.parse(res.text) as T,
+  };
+}

--- a/middleware/test/toolPluginRuntimeRouteDisposal.test.ts
+++ b/middleware/test/toolPluginRuntimeRouteDisposal.test.ts
@@ -1,7 +1,8 @@
 import { describe, it } from 'node:test';
 import { strict as assert } from 'node:assert';
-import type { AddressInfo } from 'node:net';
 import express, { Router } from 'express';
+
+import { getJson } from './_helpers/httpInvoke.js';
 
 import { PluginRouteRegistry } from '../src/platform/pluginRouteRegistry.js';
 import { UiRouteCatalog } from '../src/platform/uiRouteCatalog.js';
@@ -128,6 +129,67 @@ describe('ToolPluginRuntime.deactivate — route disposal', () => {
     assert.deepEqual(stoppedJobsFor, ['@plugin/dev']);
   });
 
+  it('disposes routes BEFORE awaiting the plugin-controlled close()', async () => {
+    // close() gets a 5s budget. Disposing after it would leave the router
+    // answering for that whole window on a deactivation the operator has
+    // already triggered — and for the full 5s when close() hangs.
+    const registry = new PluginRouteRegistry();
+    const catalog = new UiRouteCatalog();
+    const deps = {
+      pluginRouteRegistry: registry,
+      uiRouteCatalog: catalog,
+      jobScheduler: { stopForPlugin: (): void => {} },
+      log: (): void => {},
+    } as unknown as ToolPluginRuntimeDeps;
+    const runtime = new ToolPluginRuntime(deps);
+
+    registry.register('/api/v1/dev-runner', Router(), '@plugin/slow');
+
+    let disposedWhenCloseRan: boolean | undefined;
+    (runtime as unknown as { active: Map<string, unknown> }).active.set(
+      '@plugin/slow',
+      {
+        agentId: '@plugin/slow',
+        extDisposes: [],
+        handle: {
+          close: (): Promise<void> => {
+            disposedWhenCloseRan =
+              registry.list().every((e) => e.disposed) && catalog.navSize() === 0;
+            return Promise.resolve();
+          },
+        },
+      },
+    );
+
+    await runtime.deactivate('@plugin/slow');
+
+    assert.equal(
+      disposedWhenCloseRan,
+      true,
+      'routes and nav must already be disposed by the time close() runs',
+    );
+  });
+
+  it('deactivate() cannot clean up a plugin that never became active', async () => {
+    // Documents WHY activate() must roll back its own registrations: a
+    // plugin that registers a router and then throws never reaches
+    // active.set, so this path is a no-op and the orphan would otherwise
+    // serve for the life of the process. The rollback itself lives in
+    // activate()'s catch and is NOT covered here — driving it needs a real
+    // on-disk package plus catalog/vault wiring. Tracked as a test gap in
+    // specs/470-dev-platform-plugin/plan.md.
+    const registry = new PluginRouteRegistry();
+    const { runtime } = makeRuntime(registry, new UiRouteCatalog());
+    registry.register('/api/v1/half-built', Router(), '@plugin/broken');
+
+    assert.equal(await runtime.deactivate('@plugin/broken'), false);
+    assert.equal(
+      registry.list().some((e) => e.source === '@plugin/broken' && !e.disposed),
+      true,
+      'the orphaned router survives deactivate() — hence the rollback in activate()',
+    );
+  });
+
   it('a disposed router stops answering and falls through to the next handler', async () => {
     const registry = new PluginRouteRegistry();
     const { runtime } = makeRuntime(registry, new UiRouteCatalog());
@@ -146,26 +208,18 @@ describe('ToolPluginRuntime.deactivate — route disposal', () => {
       res.status(404).json({ from: 'fallthrough' });
     });
 
-    const server = app.listen(0);
-    await new Promise((resolve) => server.once('listening', resolve));
-    const base = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}`;
+    const live = await getJson<{ from: string }>(app, '/api/v1/dev-runner/ping');
+    assert.equal(live.status, 200);
+    assert.deepEqual(live.body, { from: 'plugin' });
 
-    try {
-      const live = await fetch(`${base}/api/v1/dev-runner/ping`);
-      assert.equal(live.status, 200);
-      assert.deepEqual(await live.json(), { from: 'plugin' });
+    await runtime.deactivate('@plugin/dev');
 
-      await runtime.deactivate('@plugin/dev');
-
-      const dead = await fetch(`${base}/api/v1/dev-runner/ping`);
-      assert.equal(
-        dead.status,
-        404,
-        'an uninstalled plugin must not keep serving its routes',
-      );
-      assert.deepEqual(await dead.json(), { from: 'fallthrough' });
-    } finally {
-      await new Promise((resolve) => server.close(resolve));
-    }
+    const dead = await getJson<{ from: string }>(app, '/api/v1/dev-runner/ping');
+    assert.equal(
+      dead.status,
+      404,
+      'an uninstalled plugin must not keep serving its routes',
+    );
+    assert.deepEqual(dead.body, { from: 'fallthrough' });
   });
 });

--- a/middleware/test/toolPluginRuntimeRouteDisposal.test.ts
+++ b/middleware/test/toolPluginRuntimeRouteDisposal.test.ts
@@ -1,0 +1,171 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import type { AddressInfo } from 'node:net';
+import express, { Router } from 'express';
+
+import { PluginRouteRegistry } from '../src/platform/pluginRouteRegistry.js';
+import { UiRouteCatalog } from '../src/platform/uiRouteCatalog.js';
+import {
+  ToolPluginRuntime,
+  type ToolPluginRuntimeDeps,
+} from '../src/plugins/toolPluginRuntime.js';
+
+/**
+ * Regression: deactivating a tool plugin must take its Express routers
+ * down with it.
+ *
+ * Express cannot unmount, so `PluginRouteRegistry` flips entries to
+ * `disposed` and the mounted closure falls through to `next()`.
+ * `DynamicAgentRuntime` calls `disposeBySource` on deactivate;
+ * `ToolPluginRuntime` held the same dependency and threaded it into every
+ * plugin context, but never disposed by source — so an uninstalled tool
+ * plugin kept serving its routes, and because Express matches
+ * first-mount-wins it also shadowed anything mounted later at the same
+ * prefix after a hot-upgrade.
+ *
+ * This matters for the dev-platform extraction
+ * (specs/470-dev-platform-plugin): "with the plugin not installed, no
+ * dev-platform code paths" is not verifiable while routers outlive their
+ * plugin.
+ */
+
+/**
+ * `deactivate()` only reaches a handful of dependencies. Everything else on
+ * `ToolPluginRuntimeDeps` is activate-path machinery, so it is left unset
+ * rather than stubbed into something that could drift from the real thing.
+ */
+function makeRuntime(
+  pluginRouteRegistry: PluginRouteRegistry,
+  uiRouteCatalog: UiRouteCatalog,
+): { runtime: ToolPluginRuntime; stoppedJobsFor: string[] } {
+  const stoppedJobsFor: string[] = [];
+  const deps = {
+    pluginRouteRegistry,
+    uiRouteCatalog,
+    jobScheduler: {
+      stopForPlugin: (id: string): void => {
+        stoppedJobsFor.push(id);
+      },
+    },
+    log: (): void => {},
+  } as unknown as ToolPluginRuntimeDeps;
+  return { runtime: new ToolPluginRuntime(deps), stoppedJobsFor };
+}
+
+/**
+ * Seed an active entry directly. `activate()` would need a catalog, an
+ * installed registry, a vault and a real on-disk package to dynamic-import;
+ * none of that is what this test is about. TypeScript's `private` is
+ * compile-time only, so the real `deactivate()` body runs unmodified.
+ */
+function seedActive(runtime: ToolPluginRuntime, agentId: string): void {
+  const active = (
+    runtime as unknown as {
+      active: Map<string, unknown>;
+    }
+  ).active;
+  active.set(agentId, {
+    agentId,
+    handle: { close: (): Promise<void> => Promise.resolve() },
+    extDisposes: [],
+  });
+}
+
+describe('ToolPluginRuntime.deactivate — route disposal', () => {
+  it('disposes the plugin routers registered by the deactivated plugin', async () => {
+    const registry = new PluginRouteRegistry();
+    const { runtime } = makeRuntime(registry, new UiRouteCatalog());
+
+    registry.register('/api/v1/dev-runner', Router(), '@plugin/dev');
+    seedActive(runtime, '@plugin/dev');
+
+    assert.equal(
+      registry.list().filter((e) => !e.disposed).length,
+      1,
+      'precondition: the router is live',
+    );
+
+    await runtime.deactivate('@plugin/dev');
+
+    assert.deepEqual(
+      registry.list().map((e) => ({ source: e.source, disposed: e.disposed })),
+      [{ source: '@plugin/dev', disposed: true }],
+    );
+  });
+
+  it('leaves another plugin\'s routers untouched', async () => {
+    const registry = new PluginRouteRegistry();
+    const { runtime } = makeRuntime(registry, new UiRouteCatalog());
+
+    registry.register('/a', Router(), '@plugin/a');
+    registry.register('/b', Router(), '@plugin/b');
+    seedActive(runtime, '@plugin/a');
+
+    await runtime.deactivate('@plugin/a');
+
+    const bySource = Object.fromEntries(
+      registry.list().map((e) => [e.source, e.disposed]),
+    );
+    assert.equal(bySource['@plugin/a'], true);
+    assert.equal(bySource['@plugin/b'], false);
+  });
+
+  it('also disposes ui-route/nav entries and stops jobs (unchanged behaviour)', async () => {
+    const registry = new PluginRouteRegistry();
+    const catalog = new UiRouteCatalog();
+    const { runtime, stoppedJobsFor } = makeRuntime(registry, catalog);
+
+    catalog.registerNav('@plugin/dev', {
+      navId: 'devPlatform',
+      href: '/admin/dev-platform',
+      label: { en: 'Dev Platform' },
+    });
+    seedActive(runtime, '@plugin/dev');
+
+    await runtime.deactivate('@plugin/dev');
+
+    assert.equal(catalog.navSize(), 0, 'menu entry goes away with the plugin');
+    assert.deepEqual(stoppedJobsFor, ['@plugin/dev']);
+  });
+
+  it('a disposed router stops answering and falls through to the next handler', async () => {
+    const registry = new PluginRouteRegistry();
+    const { runtime } = makeRuntime(registry, new UiRouteCatalog());
+
+    const pluginRouter = Router();
+    pluginRouter.get('/ping', (_req, res) => {
+      res.status(200).json({ from: 'plugin' });
+    });
+    registry.register('/api/v1/dev-runner', pluginRouter, '@plugin/dev');
+    seedActive(runtime, '@plugin/dev');
+
+    const app = express();
+    registry.mountAll(app);
+    // Whatever would have handled the prefix had the plugin never existed.
+    app.use((_req, res) => {
+      res.status(404).json({ from: 'fallthrough' });
+    });
+
+    const server = app.listen(0);
+    await new Promise((resolve) => server.once('listening', resolve));
+    const base = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}`;
+
+    try {
+      const live = await fetch(`${base}/api/v1/dev-runner/ping`);
+      assert.equal(live.status, 200);
+      assert.deepEqual(await live.json(), { from: 'plugin' });
+
+      await runtime.deactivate('@plugin/dev');
+
+      const dead = await fetch(`${base}/api/v1/dev-runner/ping`);
+      assert.equal(
+        dead.status,
+        404,
+        'an uninstalled plugin must not keep serving its routes',
+      );
+      assert.deepEqual(await dead.json(), { from: 'fallthrough' });
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+});

--- a/middleware/test/uiNavigationRoute.test.ts
+++ b/middleware/test/uiNavigationRoute.test.ts
@@ -1,0 +1,172 @@
+import { after, before, describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import express from 'express';
+
+import { UiRouteCatalog } from '../src/platform/uiRouteCatalog.js';
+import {
+  createUiNavigationRouter,
+  resolveRequestLocale,
+} from '../src/routes/uiNavigation.js';
+
+/**
+ * `GET /api/v1/ui/navigation` — the shell's dynamic nav source
+ * (specs/470-dev-platform-plugin).
+ */
+
+describe('resolveRequestLocale', () => {
+  const supported = ['en', 'de'] as const;
+
+  it('accepts a supported locale', () => {
+    assert.equal(resolveRequestLocale('de', supported, 'en'), 'de');
+  });
+
+  it('narrows a regional locale to its supported base language', () => {
+    assert.equal(resolveRequestLocale('de-AT', supported, 'en'), 'de');
+  });
+
+  it('falls back for an unsupported locale', () => {
+    assert.equal(resolveRequestLocale('fr', supported, 'en'), 'en');
+  });
+
+  it('falls back for a missing locale', () => {
+    assert.equal(resolveRequestLocale(undefined, supported, 'en'), 'en');
+  });
+
+  it('falls back for a non-string (express gives arrays for repeated params)', () => {
+    assert.equal(resolveRequestLocale(['de', 'en'], supported, 'en'), 'en');
+  });
+
+  it('does not echo an unvalidated value back into label resolution', () => {
+    assert.equal(
+      resolveRequestLocale('../../etc/passwd', supported, 'en'),
+      'en',
+    );
+  });
+});
+
+describe('GET /api/v1/ui/navigation', () => {
+  const catalog = new UiRouteCatalog();
+  let server: Server;
+  let base: string;
+
+  before(async () => {
+    catalog.registerNav('core:dev-platform', {
+      navId: 'devPlatform',
+      href: '/admin/dev-platform',
+      cluster: 'adminCluster',
+      order: 50,
+      label: { en: 'Dev Platform', de: 'Dev-Plattform' },
+    });
+    catalog.registerNav('@plugin/reports', {
+      navId: 'reports',
+      href: '/reports',
+      label: { en: 'Reports' },
+    });
+
+    const app = express();
+    app.use(
+      '/api',
+      createUiNavigationRouter({
+        catalog,
+        supportedLocales: ['en', 'de'],
+        defaultLocale: 'en',
+      }),
+    );
+    server = app.listen(0);
+    await new Promise((resolve) => server.once('listening', resolve));
+    base = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}`;
+  });
+
+  after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  it('returns entries with labels resolved for the default locale', async () => {
+    const res = await fetch(`${base}/api/v1/ui/navigation`);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as {
+      locale: string;
+      entries: { navId: string; label: string; href: string; order: number }[];
+    };
+    assert.equal(body.locale, 'en');
+    assert.deepEqual(
+      body.entries.map((e) => [e.navId, e.label]),
+      [
+        ['devPlatform', 'Dev Platform'],
+        ['reports', 'Reports'],
+      ],
+      'sorted by order (50 before default 100), labels resolved',
+    );
+  });
+
+  it('resolves labels for the requested locale', async () => {
+    const res = await fetch(`${base}/api/v1/ui/navigation?locale=de`);
+    const body = (await res.json()) as {
+      locale: string;
+      entries: { navId: string; label: string }[];
+    };
+    assert.equal(body.locale, 'de');
+    const dev = body.entries.find((e) => e.navId === 'devPlatform');
+    assert.equal(dev?.label, 'Dev-Plattform');
+    const reports = body.entries.find((e) => e.navId === 'reports');
+    assert.equal(reports?.label, 'Reports', 'untranslated entry falls back to en');
+  });
+
+  it('never leaks the per-locale label map to the browser', async () => {
+    const res = await fetch(`${base}/api/v1/ui/navigation`);
+    const raw = await res.text();
+    assert.equal(
+      raw.includes('Dev-Plattform'),
+      false,
+      'the de label must not ship in an en response',
+    );
+  });
+
+  it('is not cacheable — it varies by locale and by installed plugins', async () => {
+    const res = await fetch(`${base}/api/v1/ui/navigation`);
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+  });
+
+  it('reflects deactivation — a disposed source disappears from the response', async () => {
+    const scratch = new UiRouteCatalog();
+    scratch.registerNav('@plugin/temp', {
+      navId: 'temp',
+      href: '/temp',
+      label: { en: 'Temp' },
+    });
+    const app = express();
+    app.use(
+      '/api',
+      createUiNavigationRouter({
+        catalog: scratch,
+        supportedLocales: ['en'],
+        defaultLocale: 'en',
+      }),
+    );
+    const srv = app.listen(0);
+    await new Promise((resolve) => srv.once('listening', resolve));
+    const at = `http://127.0.0.1:${String((srv.address() as AddressInfo).port)}`;
+
+    try {
+      const before = (await (await fetch(`${at}/api/v1/ui/navigation`)).json()) as {
+        entries: unknown[];
+      };
+      assert.equal(before.entries.length, 1);
+
+      scratch.disposeBySource('@plugin/temp');
+
+      const afterDispose = (await (
+        await fetch(`${at}/api/v1/ui/navigation`)
+      ).json()) as { entries: unknown[] };
+      assert.deepEqual(
+        afterDispose.entries,
+        [],
+        'uninstalling a plugin removes its menu entry with no frontend rebuild',
+      );
+    } finally {
+      await new Promise((resolve) => srv.close(resolve));
+    }
+  });
+});

--- a/middleware/test/uiNavigationRoute.test.ts
+++ b/middleware/test/uiNavigationRoute.test.ts
@@ -1,19 +1,27 @@
-import { after, before, describe, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import { strict as assert } from 'node:assert';
-import type { AddressInfo } from 'node:net';
-import type { Server } from 'node:http';
-import express from 'express';
+import express, { type Express } from 'express';
 
 import { UiRouteCatalog } from '../src/platform/uiRouteCatalog.js';
 import {
   createUiNavigationRouter,
   resolveRequestLocale,
 } from '../src/routes/uiNavigation.js';
+import { getJson, invoke } from './_helpers/httpInvoke.js';
 
 /**
  * `GET /api/v1/ui/navigation` — the shell's dynamic nav source
  * (specs/470-dev-platform-plugin).
+ *
+ * Driven through `app.handle` rather than a listening socket: the suite runs
+ * files concurrently and port-holding tests make unrelated socket tests flaky
+ * under contention. Route matching and `res.json` still run for real.
  */
+
+interface NavBody {
+  locale: string;
+  entries: { pluginId: string; navId: string; label: string; href: string; order: number }[];
+}
 
 describe('resolveRequestLocale', () => {
   const supported = ['en', 'de'] as const;
@@ -39,19 +47,15 @@ describe('resolveRequestLocale', () => {
   });
 
   it('does not echo an unvalidated value back into label resolution', () => {
-    assert.equal(
-      resolveRequestLocale('../../etc/passwd', supported, 'en'),
-      'en',
-    );
+    assert.equal(resolveRequestLocale('../../etc/passwd', supported, 'en'), 'en');
   });
 });
 
 describe('GET /api/v1/ui/navigation', () => {
   const catalog = new UiRouteCatalog();
-  let server: Server;
-  let base: string;
+  let app: Express;
 
-  before(async () => {
+  before(() => {
     catalog.registerNav('core:dev-platform', {
       navId: 'devPlatform',
       href: '/admin/dev-platform',
@@ -65,7 +69,7 @@ describe('GET /api/v1/ui/navigation', () => {
       label: { en: 'Reports' },
     });
 
-    const app = express();
+    app = express();
     app.use(
       '/api',
       createUiNavigationRouter({
@@ -74,22 +78,11 @@ describe('GET /api/v1/ui/navigation', () => {
         defaultLocale: 'en',
       }),
     );
-    server = app.listen(0);
-    await new Promise((resolve) => server.once('listening', resolve));
-    base = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}`;
-  });
-
-  after(async () => {
-    await new Promise((resolve) => server.close(resolve));
   });
 
   it('returns entries with labels resolved for the default locale', async () => {
-    const res = await fetch(`${base}/api/v1/ui/navigation`);
-    assert.equal(res.status, 200);
-    const body = (await res.json()) as {
-      locale: string;
-      entries: { navId: string; label: string; href: string; order: number }[];
-    };
+    const { status, body } = await getJson<NavBody>(app, '/api/v1/ui/navigation');
+    assert.equal(status, 200);
     assert.equal(body.locale, 'en');
     assert.deepEqual(
       body.entries.map((e) => [e.navId, e.label]),
@@ -102,71 +95,56 @@ describe('GET /api/v1/ui/navigation', () => {
   });
 
   it('resolves labels for the requested locale', async () => {
-    const res = await fetch(`${base}/api/v1/ui/navigation?locale=de`);
-    const body = (await res.json()) as {
-      locale: string;
-      entries: { navId: string; label: string }[];
-    };
+    const { body } = await getJson<NavBody>(app, '/api/v1/ui/navigation?locale=de');
     assert.equal(body.locale, 'de');
-    const dev = body.entries.find((e) => e.navId === 'devPlatform');
-    assert.equal(dev?.label, 'Dev-Plattform');
-    const reports = body.entries.find((e) => e.navId === 'reports');
-    assert.equal(reports?.label, 'Reports', 'untranslated entry falls back to en');
+    assert.equal(
+      body.entries.find((e) => e.navId === 'devPlatform')?.label,
+      'Dev-Plattform',
+    );
+    assert.equal(
+      body.entries.find((e) => e.navId === 'reports')?.label,
+      'Reports',
+      'untranslated entry falls back to en',
+    );
   });
 
   it('never leaks the per-locale label map to the browser', async () => {
-    const res = await fetch(`${base}/api/v1/ui/navigation`);
-    const raw = await res.text();
+    const res = await invoke(app, 'GET', '/api/v1/ui/navigation');
     assert.equal(
-      raw.includes('Dev-Plattform'),
+      res.text.includes('Dev-Plattform'),
       false,
       'the de label must not ship in an en response',
     );
   });
 
   it('is not cacheable — it varies by locale and by installed plugins', async () => {
-    const res = await fetch(`${base}/api/v1/ui/navigation`);
-    assert.equal(res.headers.get('cache-control'), 'no-store');
+    const res = await invoke(app, 'GET', '/api/v1/ui/navigation');
+    assert.equal(res.headers['cache-control'], 'no-store');
   });
 
-  it('reflects deactivation — a disposed source disappears from the response', async () => {
-    const scratch = new UiRouteCatalog();
-    scratch.registerNav('@plugin/temp', {
+  it('reflects deactivation live — a disposed source disappears from the response', async () => {
+    // Against the same app, so this also proves the router reads the
+    // catalogue per request rather than snapshotting it at mount.
+    const navIds = async (): Promise<string[]> =>
+      (await getJson<NavBody>(app, '/api/v1/ui/navigation')).body.entries.map(
+        (e) => e.navId,
+      );
+
+    catalog.registerNav('@plugin/temp', {
       navId: 'temp',
       href: '/temp',
       label: { en: 'Temp' },
     });
-    const app = express();
-    app.use(
-      '/api',
-      createUiNavigationRouter({
-        catalog: scratch,
-        supportedLocales: ['en'],
-        defaultLocale: 'en',
-      }),
+    assert.equal((await navIds()).includes('temp'), true, 'precondition');
+
+    catalog.disposeBySource('@plugin/temp');
+
+    const remaining = await navIds();
+    assert.equal(
+      remaining.includes('temp'),
+      false,
+      'uninstalling a plugin removes its menu entry with no frontend rebuild',
     );
-    const srv = app.listen(0);
-    await new Promise((resolve) => srv.once('listening', resolve));
-    const at = `http://127.0.0.1:${String((srv.address() as AddressInfo).port)}`;
-
-    try {
-      const before = (await (await fetch(`${at}/api/v1/ui/navigation`)).json()) as {
-        entries: unknown[];
-      };
-      assert.equal(before.entries.length, 1);
-
-      scratch.disposeBySource('@plugin/temp');
-
-      const afterDispose = (await (
-        await fetch(`${at}/api/v1/ui/navigation`)
-      ).json()) as { entries: unknown[] };
-      assert.deepEqual(
-        afterDispose.entries,
-        [],
-        'uninstalling a plugin removes its menu entry with no frontend rebuild',
-      );
-    } finally {
-      await new Promise((resolve) => srv.close(resolve));
-    }
+    assert.equal(remaining.length, 2, 'the other plugins are untouched');
   });
 });

--- a/middleware/test/uiRouteCatalogNav.test.ts
+++ b/middleware/test/uiRouteCatalogNav.test.ts
@@ -1,0 +1,264 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { UiRouteCatalog } from '../src/platform/uiRouteCatalog.js';
+
+/**
+ * Nav-entry half of the UI catalogue (specs/470-dev-platform-plugin).
+ *
+ * The uiRoute-descriptor half is covered by uiRouteCatalog.test.ts. These
+ * tests focus on what is new and what is dangerous: nav entries are
+ * rendered inside the shell's own trusted header, so every field a plugin
+ * supplies is treated as untrusted input.
+ */
+
+const LABEL = { en: 'Dev Platform', de: 'Dev-Plattform' } as const;
+
+function validEntry(
+  overrides: Partial<Parameters<UiRouteCatalog['registerNav']>[1]> = {},
+): Parameters<UiRouteCatalog['registerNav']>[1] {
+  return {
+    navId: 'devPlatform',
+    href: '/admin/dev-platform',
+    label: LABEL,
+    ...overrides,
+  };
+}
+
+describe('UiRouteCatalog — nav entries', () => {
+  it('round-trips an entry with pluginId injected and order defaulted', () => {
+    const cat = new UiRouteCatalog();
+    cat.registerNav('@plugin/dev', validEntry({ cluster: 'adminCluster' }));
+
+    const entries = cat.listNav('en');
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.pluginId, '@plugin/dev');
+    assert.equal(entries[0]?.navId, 'devPlatform');
+    assert.equal(entries[0]?.href, '/admin/dev-platform');
+    assert.equal(entries[0]?.cluster, 'adminCluster');
+    assert.equal(entries[0]?.order, 100, 'order defaults to 100');
+    assert.equal(entries[0]?.label, 'Dev Platform');
+  });
+
+  it('omits cluster entirely when not supplied (top-level entry)', () => {
+    const cat = new UiRouteCatalog();
+    cat.registerNav('@plugin/dev', validEntry());
+    assert.equal(Object.hasOwn(cat.listNav('en')[0] ?? {}, 'cluster'), false);
+  });
+
+  describe('label resolution', () => {
+    it('resolves the exact locale when present', () => {
+      const cat = new UiRouteCatalog();
+      cat.registerNav('@plugin/dev', validEntry());
+      assert.equal(cat.listNav('de')[0]?.label, 'Dev-Plattform');
+    });
+
+    it('falls back to the base language for a regional locale', () => {
+      const cat = new UiRouteCatalog();
+      cat.registerNav('@plugin/dev', validEntry());
+      assert.equal(
+        cat.listNav('de-AT')[0]?.label,
+        'Dev-Plattform',
+        'de-AT should fall back to de, not to en',
+      );
+    });
+
+    it('falls back to en for an untranslated locale', () => {
+      const cat = new UiRouteCatalog();
+      cat.registerNav('@plugin/dev', validEntry());
+      assert.equal(cat.listNav('fr')[0]?.label, 'Dev Platform');
+    });
+
+    it('requires an en label as the guaranteed fallback', () => {
+      const cat = new UiRouteCatalog();
+      assert.throws(
+        () =>
+          cat.registerNav('@plugin/dev', validEntry({ label: { de: 'Nur DE' } })),
+        /must include an 'en' entry/,
+      );
+    });
+  });
+
+  describe('href confinement', () => {
+    // The header is trusted chrome. A manifest must not be able to point a
+    // nav entry off-origin or at a non-navigational scheme.
+    const rejected: readonly [string, string][] = [
+      ['//evil.example/pwn', 'protocol-relative'],
+      ['/\\evil.example/pwn', 'backslash normalised to // by browsers'],
+      ['https://evil.example', 'absolute URL'],
+      ['javascript:alert(1)', 'scheme'],
+      ['admin/dev-platform', 'relative path'],
+      ['/admin/dev platform', 'whitespace'],
+    ];
+
+    for (const [href, why] of rejected) {
+      it(`rejects ${JSON.stringify(href)} (${why})`, () => {
+        const cat = new UiRouteCatalog();
+        assert.throws(() => cat.registerNav('@p/x', validEntry({ href })), /href/);
+      });
+    }
+
+    it('accepts a normal in-app path', () => {
+      const cat = new UiRouteCatalog();
+      assert.doesNotThrow(() =>
+        cat.registerNav('@p/x', validEntry({ href: '/admin/dev-platform' })),
+      );
+    });
+  });
+
+  describe('label sanitisation', () => {
+    it('rejects bidirectional-override characters (Trojan-Source spoofing)', () => {
+      const cat = new UiRouteCatalog();
+      const rtlOverride = String.fromCharCode(0x202e);
+      assert.throws(
+        () =>
+          cat.registerNav(
+            '@p/x',
+            validEntry({ label: { en: `Safe${rtlOverride}nimdA` } }),
+          ),
+        /bidirectional-formatting/,
+      );
+    });
+
+    it('rejects control characters', () => {
+      const cat = new UiRouteCatalog();
+      assert.throws(
+        () =>
+          cat.registerNav(
+            '@p/x',
+            validEntry({ label: { en: `Dev${String.fromCharCode(0)}Platform` } }),
+          ),
+        /control or bidirectional-formatting/,
+      );
+    });
+
+    it('rejects an over-long label that would break the header', () => {
+      const cat = new UiRouteCatalog();
+      assert.throws(
+        () => cat.registerNav('@p/x', validEntry({ label: { en: 'x'.repeat(41) } })),
+        /exceeds 40 characters/,
+      );
+    });
+
+    it('rejects an empty or whitespace-only label', () => {
+      const cat = new UiRouteCatalog();
+      assert.throws(
+        () => cat.registerNav('@p/x', validEntry({ label: { en: '   ' } })),
+        /non-empty string/,
+      );
+    });
+
+    it('rejects a malformed locale key', () => {
+      const cat = new UiRouteCatalog();
+      assert.throws(
+        () =>
+          cat.registerNav(
+            '@p/x',
+            validEntry({ label: { en: 'OK', 'not a locale': 'x' } }),
+          ),
+        /is not a valid locale code/,
+      );
+    });
+  });
+
+  describe('field validation', () => {
+    it('rejects a navId with structural characters', () => {
+      const cat = new UiRouteCatalog();
+      assert.throws(
+        () => cat.registerNav('@p/x', validEntry({ navId: 'a::b' })),
+        /navId/,
+      );
+    });
+
+    it('rejects a malformed cluster key', () => {
+      const cat = new UiRouteCatalog();
+      assert.throws(
+        () => cat.registerNav('@p/x', validEntry({ cluster: '9bad-key' })),
+        /cluster/,
+      );
+    });
+
+    it('rejects a non-integer order', () => {
+      const cat = new UiRouteCatalog();
+      assert.throws(
+        () => cat.registerNav('@p/x', validEntry({ order: 1.5 })),
+        /finite integer/,
+      );
+    });
+
+    it('rejects an empty pluginId', () => {
+      const cat = new UiRouteCatalog();
+      assert.throws(() => cat.registerNav('', validEntry()), /pluginId/);
+    });
+  });
+
+  it('sorts by (order asc, pluginId asc, navId asc)', () => {
+    const cat = new UiRouteCatalog();
+    cat.registerNav('@b/late', validEntry({ navId: 'z', href: '/z', order: 50 }));
+    cat.registerNav('@a/early', validEntry({ navId: 'a', href: '/a', order: 10 }));
+    cat.registerNav('@a/early', validEntry({ navId: 'b', href: '/b', order: 10 }));
+    cat.registerNav('@c/default', validEntry({ navId: 'd', href: '/d' })); // 100
+
+    assert.deepEqual(
+      cat.listNav('en').map((e) => `${e.pluginId}:${e.navId}`),
+      ['@a/early:a', '@a/early:b', '@b/late:z', '@c/default:d'],
+    );
+  });
+
+  it('rejects a duplicate (pluginId, navId) rather than silently replacing', () => {
+    const cat = new UiRouteCatalog();
+    cat.registerNav('@p/x', validEntry());
+    assert.throws(() => cat.registerNav('@p/x', validEntry()), /already registered/);
+  });
+
+  it('allows the same navId from two different plugins', () => {
+    const cat = new UiRouteCatalog();
+    cat.registerNav('@p/one', validEntry());
+    assert.doesNotThrow(() => cat.registerNav('@p/two', validEntry()));
+    assert.equal(cat.navSize(), 2);
+  });
+
+  describe('disposal', () => {
+    it('the returned handle removes only its own entry', () => {
+      const cat = new UiRouteCatalog();
+      const dispose = cat.registerNav('@p/x', validEntry());
+      cat.registerNav('@p/y', validEntry());
+      dispose();
+      assert.deepEqual(
+        cat.listNav('en').map((e) => e.pluginId),
+        ['@p/y'],
+      );
+    });
+
+    it('a stale dispose handle does not drop a re-registered entry', () => {
+      const cat = new UiRouteCatalog();
+      const stale = cat.registerNav('@p/x', validEntry());
+      stale();
+      cat.registerNav('@p/x', validEntry({ href: '/admin/new' }));
+      stale(); // the previous owner's closure, fired late
+      assert.equal(cat.navSize(), 1, 're-registration survives a stale dispose');
+      assert.equal(cat.listNav('en')[0]?.href, '/admin/new');
+    });
+
+    it('disposeBySource drops nav entries AND uiRoute descriptors together', () => {
+      const cat = new UiRouteCatalog();
+      cat.registerNav('@p/x', validEntry());
+      cat.register('@p/x', { routeId: 'r', path: '/r', title: 'R' });
+      cat.registerNav('@p/other', validEntry());
+
+      const dropped = cat.disposeBySource('@p/x');
+
+      assert.equal(dropped, 2, 'counts both surfaces');
+      assert.equal(cat.navSize(), 1);
+      assert.equal(cat.size(), 0);
+      assert.equal(cat.listNav('en')[0]?.pluginId, '@p/other');
+    });
+
+    it('disposeBySource is a no-op for an unknown plugin', () => {
+      const cat = new UiRouteCatalog();
+      cat.registerNav('@p/x', validEntry());
+      assert.equal(cat.disposeBySource('@p/nobody'), 0);
+      assert.equal(cat.navSize(), 1);
+    });
+  });
+});

--- a/middleware/test/uiRouteCatalogNav.test.ts
+++ b/middleware/test/uiRouteCatalogNav.test.ts
@@ -161,6 +161,150 @@ describe('UiRouteCatalog — nav entries', () => {
     });
   });
 
+  describe('hostile label objects', () => {
+    it('rejects __proto__ as a locale key', () => {
+      const cat = new UiRouteCatalog();
+      // Reaches Object.entries as an own property when it arrives via
+      // JSON.parse, so the locale-code check is what stops it.
+      const hostile = JSON.parse('{"en":"OK","__proto__":"polluted"}') as Record<
+        string,
+        string
+      >;
+      assert.throws(
+        () => cat.registerNav('@p/x', validEntry({ label: hostile })),
+        /is not a valid locale code/,
+      );
+    });
+
+    it('does not pollute Object.prototype via a crafted label', () => {
+      const cat = new UiRouteCatalog();
+      const hostile = JSON.parse(
+        '{"en":"OK","constructor":"x","prototype":"y"}',
+      ) as Record<string, string>;
+      assert.throws(() => cat.registerNav('@p/x', validEntry({ label: hostile })));
+      assert.equal(
+        ({} as Record<string, unknown>)['polluted'],
+        undefined,
+        'Object.prototype must be untouched',
+      );
+    });
+
+    it('rejects an array in place of the label map', () => {
+      const cat = new UiRouteCatalog();
+      assert.throws(
+        () =>
+          cat.registerNav(
+            '@p/x',
+            validEntry({ label: ['en', 'Dev'] as unknown as Record<string, string> }),
+          ),
+        /object of locale to string/,
+      );
+    });
+
+    it('rejects a non-string label value', () => {
+      const cat = new UiRouteCatalog();
+      assert.throws(
+        () =>
+          cat.registerNav(
+            '@p/x',
+            validEntry({ label: { en: 42 as unknown as string } }),
+          ),
+        /non-empty string/,
+      );
+    });
+  });
+
+  describe('href canonical form', () => {
+    // The shell decides "core destinations win" by comparing href strings.
+    // Any spelling a browser resolves to a core path but that does not
+    // string-match it would slip past that rule, so only already-canonical
+    // paths are accepted.
+    const nonCanonical: readonly [string, string][] = [
+      ['/x/%2e%2e/admin', 'percent-encoded dot-segment resolving to /admin'],
+      ['/x/../admin', 'literal dot-segment'],
+      ['/admin/', 'trailing slash aliases /admin'],
+      ['/admin?source=x', 'query string'],
+      ['/admin#x', 'fragment'],
+      ['/%2f%2fevil.example', 'percent-encoded slashes'],
+      ['/admin\\x', 'backslash'],
+      ['/a//b', 'empty interior segment'],
+    ];
+
+    for (const [href, why] of nonCanonical) {
+      it(`rejects ${JSON.stringify(href)} (${why})`, () => {
+        const cat = new UiRouteCatalog();
+        assert.throws(() => cat.registerNav('@p/x', validEntry({ href })), /href/);
+      });
+    }
+
+    it('accepts the canonical spelling of a nested path', () => {
+      const cat = new UiRouteCatalog();
+      assert.doesNotThrow(() =>
+        cat.registerNav('@p/x', validEntry({ href: '/admin/dev-platform' })),
+      );
+    });
+
+    it('accepts the root path', () => {
+      const cat = new UiRouteCatalog();
+      assert.doesNotThrow(() => cat.registerNav('@p/x', validEntry({ href: '/' })));
+    });
+
+    it('rejects an over-long href', () => {
+      const cat = new UiRouteCatalog();
+      assert.throws(
+        () => cat.registerNav('@p/x', validEntry({ href: `/${'a'.repeat(300)}` })),
+        /exceeds 256 characters/,
+      );
+    });
+  });
+
+  describe('resource bounds', () => {
+    it('rejects a label map declaring absurdly many locales', () => {
+      const cat = new UiRouteCatalog();
+      const label: Record<string, string> = { en: 'OK' };
+      for (let i = 0; i < 40; i += 1) label[`l${String(i)}`] = 'x';
+      assert.throws(
+        () => cat.registerNav('@p/x', validEntry({ label })),
+        /more than 32 locales/,
+      );
+    });
+
+    it('caps how many nav entries one plugin may contribute', () => {
+      const cat = new UiRouteCatalog();
+      for (let i = 0; i < 20; i += 1) {
+        cat.registerNav(
+          '@p/greedy',
+          validEntry({ navId: `n${String(i)}`, href: `/p${String(i)}` }),
+        );
+      }
+      assert.throws(
+        () => cat.registerNav('@p/greedy', validEntry({ navId: 'n20', href: '/p20' })),
+        /at most 20 nav entries/,
+      );
+      // The cap is per plugin, not global.
+      assert.doesNotThrow(() => cat.registerNav('@p/polite', validEntry()));
+    });
+
+    it('rejects an over-long navId', () => {
+      const cat = new UiRouteCatalog();
+      assert.throws(
+        () => cat.registerNav('@p/x', validEntry({ navId: 'a'.repeat(100) })),
+        /navId/,
+      );
+    });
+  });
+
+  it('rejects zero-width characters in a label', () => {
+    // Invisible padding lets a plugin render a label that looks identical
+    // to a core entry while comparing unequal to it.
+    const cat = new UiRouteCatalog();
+    const zeroWidth = String.fromCharCode(0x200b);
+    assert.throws(
+      () => cat.registerNav('@p/x', validEntry({ label: { en: `Ad${zeroWidth}min` } })),
+      /control or bidirectional-formatting/,
+    );
+  });
+
   describe('field validation', () => {
     it('rejects a navId with structural characters', () => {
       const cat = new UiRouteCatalog();

--- a/specs/470-dev-platform-plugin/core-decoupling-checklist.md
+++ b/specs/470-dev-platform-plugin/core-decoupling-checklist.md
@@ -1,0 +1,244 @@
+# Core decoupling checklist — Dev Platform
+
+Every hardcoded dev-platform reference in core, i.e. everything that must be deleted,
+moved, or genericised for core to retain **zero** knowledge of the Dev Platform once it
+lives in its own repository.
+
+Companion to `plan.md`. This file is the work-list; the plan holds the reasoning.
+
+Measured on `worktree-dev-platform-plugin-extraction`. Line numbers drift — re-grep before
+acting on a zone. Excludes `docs/`, `specs/`, `*.md`, and build output (`dist/`,
+`*.tsbuildinfo`, lockfiles) which regenerate.
+
+---
+
+## Totals
+
+| | |
+|---|---|
+| Items | **276** |
+| DELETE / MOVE / GENERICISE | 166 / 66 / 44 |
+| Volume leaving core | **≈49,100 LOC across ~200 files** |
+| Zones | 18 |
+
+Breakdown of the volume: `src/devplatform/` 14,498 · `test/devplatform/` 15,616 ·
+sidecar daemon + runner shim ≈11,500 · `src/routes/devPlatform*` etc. 3,005 · web-ui 3,933 ·
+migrations 364 · `scripts/dev-transcript.ts` 187.
+
+---
+
+## The three hard couplings
+
+These are **not deletions**. Core has no extension point for what dev-platform does, so
+each needs a new generic mechanism built first. They gate the whole extraction.
+
+### H1 — `auth/publicPaths.ts` has no extension point
+
+`STATIC_PUBLIC_PATHS` is a frozen literal. Two entries are dev-platform's:
+
+- `:32` — `/^\/api\/v1\/dev-runner(?:\/|$|\?)/` (runner phone-home; `djr_` bearer *is* its auth)
+- `:35` — `/^\/api\/v1\/dev-platform\/github-app\/(?:callback|setup)(?:\/|$|\?)/`
+
+Deleting them without a replacement **kills every in-flight job**: runners carry no session
+cookie, so the blanket `/api` `requireAuth` answers 401 before the plugin router is reached.
+
+Needs: manifest-declared, install-time, operator-consented public-path grants, **plus
+exclusive prefix ownership** — a grant only makes `requireAuth` call `next()` for a URL; it
+does not say which router may answer it. Without ownership, plugin B mounted at plugin A's
+granted prefix receives unauthenticated traffic.
+
+### H2 — the conductor hardcodes the `dev_job` step kind and channel type
+
+- `conductor/devJobStepEffect.ts` — the whole file (≈118 LOC): `DEV_JOB_ACTION_ID`,
+  `isDevJobStep`, `buildDevJobPrincipalRef`, `parseDevJobPrincipalRef`,
+  `DevJobStepPort`, `DevJobOutcomeSource`, `DevJobAwaitResolver`, `subscribeDevJobResolver`
+- `conductor/runExecutor.ts:203-205` — the step dispatcher branches on `isDevJobStep(step)`
+- `conductor/runExecutor.ts:365-407` — `resolveDevJobAwait()`
+- `conductor/runExecutor.ts:421-433` — `reconcileTerminalDevJobAwaits()`
+- `conductor/runExecutor.ts:578-600` — `openDevJobAwait()`
+- `conductor/runExecutor.ts:22` — `DevJobPortUnavailableError` (exported)
+- `conductor/awaitStore.ts:125` — the human inbox query is `... AND channel_type <> 'dev_job'`
+- `conductor/awaitStore.ts:139-142` — `listWaitingDevJobAwaits()`
+
+Needs: a generic **long-running step-kind registry** (a plugin registers an action id, a
+port, and an await resolver) and a generic channel-type filter instead of a literal.
+
+### H3 — the chat renderer hardcodes a tool name
+
+- `web-ui/app/chat/page.tsx:53-54` — imports `DevJobChatCard`, `parseDevJobStartResult`
+- `web-ui/app/chat/page.tsx:1025` — `tool.name === 'dev_job_start' ? parseDevJobStartResult(...) : null`
+- `web-ui/app/chat/page.tsx:1027` — renders `<DevJobChatCard seed={seed} />`
+
+Needs: a plugin-contributed **tool-card renderer registry**. This is the hardest of the
+three, because the renderer is a React component and the plugin now lives in another repo
+(see `plan.md` §G7).
+
+---
+
+## Zones
+
+### 1 — `middleware/src/index.ts` (34 items)
+
+- **14 imports** at `:165-185` and `:229` — DELETE. Also `DeviceFlowStore` (`:124`) becomes
+  dead once `:2692` goes.
+- **`:2050-2118`** — the GitHub-webhook block mounted *before* `express.json` (raw-body HMAC).
+- **`:2579-2812`** — the entire assembly block: device provider, shim entry path, `csvList`,
+  role store, Fly backend resolution (`:2599-2645`), `assembleDevPlatform` (`:2646-2697`,
+  reads 40+ `config.DEV_*`), `mountDevPlatform` (`:2698`), GitHub-App routers (`:2700-2723`),
+  chat tool registration (`:2725-2751`), worker start + signal hooks (`:2753-2767`),
+  **the nav registration (`:2769-2787`)**, retention job (`:2789-2807`), no-graphPool warn.
+
+The nav registration is the bridge PR #536 added. It is deliberately temporary: it becomes
+`ctx.uiRoutes.registerNav(...)` in the plugin's `activate()`. The `uiRouteCatalog`
+mechanism itself is generic and stays — it simply has no in-core caller afterwards.
+
+Keep: `:1389` and `:4118` (`DEV_ENDPOINTS_ENABLED`) — that is the core dev-graph feature,
+unrelated despite the prefix.
+
+### 2 — `middleware/src/config.ts` (51 items)
+
+**43 schema keys** — `:191-200`, `:226-229`, `:487-589`. Plus:
+
+- `:31-37` `devFlag()` helper — all three call sites are dev-platform.
+- `:629-656` `devPlatformBootRefusals()` + `:666-674` its call in `loadConfig()`.
+  ⚠️ These are **safety interlocks** (`SUBSCRIPTION_MODE` without `_ACK`, `UNSAFE_LOCAL`
+  without `LOCAL_UID`). They must become activation refusals in the plugin, not vanish.
+- `:687-690` post-processing of `DEV_PLATFORM_RUNNER_BASE_URL` / `_WORKSPACE_DIR`.
+- `:204-205` comment references dev-platform — scrub.
+
+`FLY_APP_NAME` (`:575`) is Fly-generic but currently read only by the dev-platform Fly
+backend. Decide: keep for future Fly needs, or delete.
+
+### 3 — `auth/publicPaths.ts` (5) — see **H1**
+
+### 4 — `platform/pluginContext.ts` (14)
+
+`:32-36` type imports · `:747-755` the `ctx.devJobs` gate · `:793` the spread ·
+`:906-931` `DevJobsHostService` · `:946-1013+` `createPluginDevJobsAccessor` and its
+`requireAccessibleJob` / `create` / `get` / `list` / `listEvents`.
+
+The accessor implementation MOVES to the plugin repo; core keeps only the generic
+`serviceRegistry` and capability-grant machinery.
+
+### 5 — `packages/plugin-api/**` (11) ⚠️ PUBLIC CONTRACT
+
+`@omadia/plugin-api` is published and re-exports everything (`src/index.ts:1`). Removing
+these is a **SemVer-major break** for every Hub plugin that imports them:
+
+`:182` `PluginContext.devJobs` · `:1370` `DevJobKind` · `:1373-1387` `DevJobStatus` ·
+`:1388-1397` `DevJobDescriptor` · `:1399-1405` `DevJobCreateRequest` ·
+`:1407-1413` `DevJobEventRecord` · `:1424-1448` `DevJobsAccessor`.
+
+Recommendation: MOVE the six type declarations into a `@omadia/dev-platform-plugin-api`
+package owned by the new repo. Also `:765` — a JSDoc nav example uses `/admin/dev-platform`;
+scrub.
+
+Same problem one layer up: `api/admin-v1.ts:197-204` exposes `dev_jobs` and
+`dev_jobs_repos_hint` on the **public admin DTO**.
+
+### 6 — `plugins/**` (11)
+
+`manifestLoader.ts:638-645,671-672` — the `permissions.devJobs` parse. Genericise into a
+capability-grant mechanism rather than a named permission.
+
+~~`plugins/builder/githubAppAuth.ts:1` — imports `mintAppJwt` from the devplatform tree~~
+**DONE** — `appJwt.ts` moved to `src/services/githubAppJwt.ts`; all three call sites
+updated. This was the only core→devplatform reverse dependency.
+
+### 7 — `conductor/**` (33) — see **H2**
+
+Also `conductor/routes.ts:332` — comment mentioning the `dev_job:<id>` phantom principal.
+
+### 8 — `routes/**` (9 files, 3,005 LOC) — MOVE
+
+`devPlatform.ts` 498 · `devPlatformShared.ts` 491 · `devPlatformRepos.ts` 370 ·
+`devPlatformGithubApp.ts` 341 · `devPlatformGates.ts` 191 · `devRunnerApi.ts` 706 ·
+`devRunnerJobPolicyRoute.ts` 136 · `devWebhooks.ts` 272.
+
+Plus `services/ssrfGuard.ts:35` — comment only, scrub.
+
+### 9 — `src/devplatform/**` — 54 files, 14,498 LOC — MOVE wholesale
+
+### 10 — `migrations/**` — 9 files (`0022`–`0030`), 364 LOC — MOVE
+
+⚠️ They occupy a **contiguous slot range in the core ledger**. Do not renumber (see
+`plan.md` §G4) — seed the plugin ledger from `_multi_orchestrator_migrations` instead.
+
+### 11 — scripts / sidecars / shim (15 items, ~11,700 LOC) — MOVE
+
+`scripts/dev-transcript.ts` (187) · `sidecars/dev-runner/` (2 files) ·
+`sidecars/dev-runner-daemon/` (30 files, 10,910 LOC, dockerode) ·
+`packages/dev-runner-shim/` (21 files).
+
+⚠️ Latent bug worth noting: `dev-runner-shim` is **not built** by `npm run build`, yet
+`index.ts:2590` resolves `packages/dev-runner-shim/dist/src/index.js` at runtime.
+Extraction removes the inconsistency.
+
+### 12 — `middleware/package.json` (4) — GENERICISE
+
+No explicit references. `workspaces: ["packages/*"]` and the test glob pick the package up
+implicitly and resolve themselves on deletion. Regenerate `package-lock.json`.
+
+### 13 — Dockerfiles — **no action**. Neither the root nor the web-ui Dockerfile references
+dev-platform.
+
+### 14 — compose — `docker-compose.dev-platform.yaml` (193 lines) MOVE wholesale.
+All other compose files are clean.
+
+### 15 — `web-ui/**` (45 items, 36 files, 560 i18n leaf keys)
+
+- `app/admin/dev-platform/**` — 20 files, 3,163 LOC — MOVE
+- `app/_components/devjobs/**` — 6 files, 770 LOC — MOVE
+- `app/_lib/useDevJobEvents.ts` — 114 LOC — MOVE
+- `app/chat/page.tsx:53-54,1025,1027` — **H3**
+- `app/admin/page.tsx:68-75` — the card entry. The `requiresNavFrom` mechanism (`:28-37`)
+  is generic and stays; this is its only user.
+- `app/_components/Nav.tsx:20` — comment scrub only; Nav is fully generic.
+- i18n: `adminDevPlatform.*` 269 · `chat.devJob.*` 9 · `admin.index.cards.devPlatform.*` 2
+  = **280 leaf keys per locale, 560 across en+de, 728 lines.**
+
+The nav label itself is *not* in the message files — it is supplied by the registration
+(`index.ts:2786`), which is exactly the design intent.
+
+### 16 — tests (12 items)
+
+`test/devplatform/` 54 files, 15,616 LOC — MOVE · `test/conductorDevJobStep.test.ts` (358)
+— MOVE · `test/pluginDevJobsAccessor.test.ts` (240) — MOVE ·
+`packages/dev-runner-shim/test/` 7 files · `sidecars/dev-runner-daemon/test/` 10 files ·
+web-ui `devjobs/__tests__/` 2 files + `dev-platform/_lib/__tests__/budget.test.ts`.
+
+GENERICISE (these tests are core and must survive — only their **fixture strings** are
+dev-platform): `test/uiRouteCatalogNav.test.ts`, `test/uiNavigationRoute.test.ts`,
+`test/toolPluginRuntimeRouteDisposal.test.ts`, `web-ui/app/_lib/__tests__/nav{Parse,Merge}.test.ts`
+— 14 fixture references in the web-ui pair alone.
+
+### 17 — `.github/workflows/**` (11)
+
+`publish-images.yml:80-86` (`dev-runner` matrix entry) · `:87-96` (`dev-runner-daemon`) ·
+`:161-18x` (cosign install, syft SBOM, keyless sign + attest — all guarded on
+`matrix.name == 'dev-runner'`) · `:101-104` (the missing-Dockerfile guard becomes
+unnecessary) · `:47`, `:75-79`, `:151-160` comments.
+
+`auto-release.yml:121-124` and `release.yml:31-34` grant `id-token: write` **solely** for
+that keyless signing — reconsider once it moves.
+
+The new repo needs its own GHCR publishing, SBOM and signing pipeline. This is real work,
+not a copy-paste.
+
+### 18 — everything else (9)
+
+`scripts/wave-implement.workflow.mjs:297` and `scripts/wave-verify.workflow.mjs:190` bake a
+dev-platform domain rule ("Terminal transitions go through `finalizeDevJob`") into
+*generic* workflow prompts — delete or genericise. `:43` has a `docs/dev-platform/`
+example path.
+
+---
+
+## Suggested order
+
+1. **H1, H2, H3** — build the three extension points. Nothing else can complete without them.
+2. Zone 6 reverse dependency ✅ done · zones 1–2 mechanical decoupling (cycle break, config collapse).
+3. Zone 5 + `admin-v1.ts` — the public-contract break. Version `plugin-api` deliberately.
+4. Bulk moves: zones 8, 9, 11, 14, 15a-c, 16.
+5. Zone 10 migrations — last, own PR, snapshot-restored test.
+6. Zone 17 CI + the new repo's publishing pipeline.

--- a/specs/470-dev-platform-plugin/plan.md
+++ b/specs/470-dev-platform-plugin/plan.md
@@ -1,0 +1,349 @@
+# Dev Platform → Installable Plugin
+
+Extraction plan for epic #470's Dev Platform, including its navigation surface.
+
+Status: phase 1 shipped, remainder proposed
+Owner: byte5
+Related: epic #470, PR #496, #497, #529
+
+> This plan was adversarially reviewed twice (GPT-5.4 via codex, and an
+> architecture pass) before implementation. Both reviews found the same
+> inverted premise about plugin authentication; §3 reflects the corrected
+> version, not the original. Numbers below are measured, and the ones the
+> reviews disputed were re-measured — where a review was itself wrong, the
+> footnote says so.
+
+---
+
+## 1. Goal
+
+Turn the Dev Platform from a hard-wired core subsystem into an **installable,
+uninstallable plugin** — one that brings its own backend, its own database schema, its
+own configuration, and **its own menu entries** — without regressing behaviour, security
+posture, or the operator experience.
+
+Success is binary and observable:
+
+- With the plugin **not installed**, `middleware` boots with zero dev-platform code
+  paths, no `dev_*` tables required, no `DEV_*` config required, and **no Dev Platform
+  entry in the navigation**.
+- With the plugin **installed and active**, the Dev Platform works exactly as it does
+  today, and its menu entries appear — contributed by the plugin, not hardcoded in the
+  shell.
+
+---
+
+## 2. Current state
+
+| Surface | Size |
+|---|---|
+| `middleware/src/devplatform/**` | 54 files, 14,498 LOC |
+| `middleware/src/routes/devPlatform*.ts`, `devRunnerApi.ts`, `devRunnerJobPolicyRoute.ts` | 7 files, 2,733 LOC |
+| `middleware/src/routes/devWebhooks.ts`, `src/conductor/devJobStepEffect.ts` | 2 files, 394 LOC |
+| `middleware/sidecars/dev-runner-daemon/` | 30 files (dockerode) |
+| `middleware/packages/dev-runner-shim/` | 21 files, zero deps |
+| `middleware/test/devplatform/**` | 54 files |
+| `web-ui/app/admin/dev-platform/**` | 20 files, 3,163 LOC |
+| `web-ui/app/_components/devjobs/**` + `_lib/useDevJobEvents.ts` | 7 files, 890 LOC |
+| Database | 9 tables, 14 indexes, migrations `0022`–`0030` |
+| Config | **41** `DEV_*`/`FLY_*` keys — 37 in the `config.ts` dev-platform block plus 4 elsewhere (`DEV_WEBHOOKS_ENABLED`, two webhook rate limits, `DEV_JOB_DEFAULT_BUDGET_USD`) |
+| i18n | **281** keys — `adminDevPlatform.*` (269) + `chat.devJob.*` (9) + `admin.index.cards.devPlatform.*` (2) + `nav.devPlatform` (1), of 3,131 total |
+
+### The coupling cut-line
+
+Only **nine** core files reference dev-platform — the boundary is already almost clean.
+
+| Core file | Coupling |
+|---|---|
+| `middleware/src/index.ts` | 15 imports, ~210 lines of wiring in two gated blocks (webhook router; main block) |
+| `middleware/src/config.ts` | 41 schema keys, boot-refusal hook `devPlatformBootRefusals`, post-processing |
+| `middleware/src/auth/publicPaths.ts` | 2 exemptions `:28-35` |
+| `middleware/src/conductor/runExecutor.ts`, `awaitStore.ts` | dev-job-shaped port API (`DevJobStepPort`) — core-owned, devplatform-free by design |
+| `middleware/src/platform/pluginContext.ts` | `ctx.devJobs` gating `:747-754`, `DevJobsHostService` |
+| `middleware/packages/plugin-api/src/pluginContext.ts` | published `DevJob*` types |
+| `middleware/src/plugins/manifestLoader.ts` | `permissions.devJobs` key |
+| `middleware/src/plugins/builder/githubAppAuth.ts` | `import { mintAppJwt } from '../../devplatform/githubApp/appJwt.js'` `:1` — **the one true leak** |
+| `middleware/src/services/ssrfGuard.ts` | comment only |
+
+**Database is clean**: zero foreign keys cross the boundary in either direction. Two soft
+links exist, both unconstrained text: `dev_jobs.conductor_await_id` (migration `0024:21`)
+and `dev_repo_plugin_grants`, which keys operator grants to plugin ids — the latter
+matters for uninstall (§6).
+
+**Dependencies are clean**: `middleware/package.json` has zero dependencies that exist
+only for dev-platform. `dockerode` lives in the sidecar's own package; the GitHub clients
+are hand-rolled `fetch` by house style.
+
+**Layering is not clean**: `wireDevPlatform.ts:37,45,50,51` imports *up* into
+`src/routes/`, which imports back *down* into `src/devplatform/*` (23 times). Circular by
+layer, resolved only by ESM hoisting. This must be untangled before the code can move.
+
+---
+
+## 3. The crux: the capability gaps
+
+The plugin API cannot express what the Dev Platform needs. This is the real work; moving
+files is the easy part.
+
+| # | Gap | Status |
+|---|---|---|
+| **G1** | **No plugin could contribute a navigation entry.** `Nav.tsx` was a frozen `const NAV` literal; nothing in the frontend read plugin state to build menus. | **Closed** — see §5 |
+| **G2** | **A plugin cannot opt a route prefix *out* of authentication.** See below — this is the inverse of what it first appears to be. | Open |
+| **G3** | **A plugin router cannot receive a raw request body.** The GitHub webhook receiver needs untouched bytes for HMAC and is mounted *before* `express.json` on purpose. Plugin routers mount at boot flush, after it. | Open |
+| **G4** | **No kernel mechanism for plugin-owned SQL.** `onMigrate` is *config* migration only. | Open (softer than it looks) |
+| **G5** | **No plugin-declared external services.** No `services:`/`image:` in the manifest; sidecars are operator-managed compose overlays. | Won't fix — see below |
+| **G6** | **`publicPaths` is a frozen literal.** A plugin cannot contribute an auth exemption, and core cannot revoke one on uninstall. | Open — **blocks P2** |
+
+### G2 is the inverse of the obvious reading — and it is a trap
+
+The tempting diagnosis is "plugin routers get no authentication": `pluginRouteRegistry.ts`
+mounts the router bare, and `pluginContext.ts` says auth "remains the plugin's
+responsibility". Both true, and both misleading.
+
+`middleware/src/index.ts` mounts `app.use('/api', requireAuth, createChatRouter(...))`,
+and `pluginRouteRegistry.mountAll(app)` runs **later** in the same file. Express runs that
+middleware for every `/api/*` request regardless of which router finally answers, so **any
+plugin router registered under `/api` is already session-gated.** No existing plugin
+noticed because they all register outside `/api` (`/diagrams`, `/documents`, `/p/...`).
+`publicPaths.ts` states this in-source, and records the exact bug it was written to
+prevent — epic #470's own runner router 401'ing in production while its e2e test passed
+against a bare `express()` app.
+
+The consequences for this plan are sharp:
+
+- Adding an `auth: 'session'` option is defence-in-depth, not a new capability.
+- Adding an `auth: 'none'` option that a plugin can self-declare would be a **security
+  regression** — today the exemption list is a core-owned, reviewed constant.
+- **A naive P2 that "deletes the 2 exemptions from `publicPaths.ts`" takes production
+  down.** Runners phone home with a `djr_` job token and no session cookie; without the
+  exemption `requireAuth` 401s them before the plugin router ever sees the request, and
+  every job in flight dies. Same for the GitHub App install callback.
+
+So the real gap is **G6**, and it must be solved as a declarative, install-time,
+operator-consented grant (a manifest `permissions.public_paths[]` surfaced in the install
+dialog and revoked on deactivate) — never a runtime escape hatch on `RoutesAccessor`.
+
+### G3: not via `express.json`'s verify hook
+
+An early draft proposed capturing raw bytes in `express.json`'s `verify` callback. That is
+unsound: `verify` only fires when the body parser's `type` matcher accepts the request,
+and the webhook deliberately uses a route-local `express.raw({ type: '*/*' })`. Widening
+the global matcher to compensate would force non-JSON traffic through the JSON parser, and
+would silently raise the webhook's deliberate 512 KB limit to the global 10 MB on an
+unauthenticated, internet-facing endpoint.
+
+The correct mechanism is a `rawBody: true` flag that makes the **registry** mount a
+route-local raw parser ahead of the plugin router at its own prefix. No interaction with
+global body parsing at all.
+
+### G4 is softer than it looks
+
+There is already a working precedent for plugin-owned migrations:
+`harness-knowledge-graph-neon` reads its own `database_url` secret, builds its own
+`pg.Pool`, and runs its own bundled `src/migrations/*.sql`, with a `copy-sql-assets` build
+step and a `Dockerfile` line to ship the SQL next to the compiled migrator.
+`harness-memory-postgres` does the same.
+
+G4 therefore needs the existing pattern formalised into a shared helper plus a `pgPool`
+capability so the plugin can reuse the core pool — not a new kernel subsystem.
+
+**Do not renumber the migrations.** Ledgers key on filename. `0022`–`0030` are already
+recorded in `_multi_orchestrator_migrations`; a plugin-local ledger renumbered to
+`0001`–`0009` would see nine unknown names and **re-execute all of them against live
+tables**. `CREATE TABLE IF NOT EXISTS` survives that; `0025`'s
+`DROP CONSTRAINT` → `ADD CONSTRAINT` does not. Keep the filenames and ship a one-time
+ledger handoff that seeds the plugin ledger from the existing rows — filename stability is
+what makes that a `SELECT … INSERT` rather than a fragile name-mapping table.
+
+### G5 is honestly out of scope
+
+A ZIP cannot ship a container. The dev-runner daemon, docker-in-docker, and egress proxy
+stay **operator-provisioned** via `docker-compose.dev-platform.yaml`, documented in the
+plugin's localised `setup.guide`, with the plugin refusing to activate (clear error, not a
+crash) when `DEV_RUNNER_DAEMON_URL` is unreachable.
+
+---
+
+## 4. Architecture decision
+
+### 4.1 What the plugin owns
+
+`@omadia/plugin-dev-platform` at `middleware/packages/harness-plugin-dev-platform/`, as a
+**built-in package** (`kind: extension` — capability resolution only exists in
+`ToolPluginRuntime`, which handles `tool`/`extension`/`integration`). It owns
+`src/devplatform/**`, all dev-platform routers including `devRunnerApi.ts` and
+`devWebhooks.ts`, its own migrations, its config, and its nav contribution.
+
+`devRunnerApi.ts` belongs in the plugin: it has zero core dependencies and is versioned
+with the **shim**, not with core (`RUNNER_PROTOCOL_VERSION`). A protocol whose counterpart
+is a separately-deployed artifact belongs with the artifact that defines it. Core keeps
+only the *decision* that its prefix is unauthenticated (G6).
+
+The LLM proxy stays inside this plugin. It is already generic by injection, and it has
+exactly one consumer; extracting a package for one consumer is speculative generality.
+
+### 4.2 What stays in core
+
+- `DevJob*` types in `@omadia/plugin-api` — a published, versioned contract that
+  third-party plugins consume via `ctx.devJobs`.
+- `DevJobStepPort` / `devJobStepEffect.ts` — core-owned conductor port interfaces, already
+  devplatform-free by design.
+- `mintAppJwt` — moves **out** of devplatform into `src/platform/githubAppJwt.ts`, closing
+  the `builder/githubAppAuth.ts:1` leak. It is generic GitHub App JWT minting.
+
+**Unresolved contract question, and it must be answered before any code moves.** Making
+dev-platform a plugin inverts `ctx.devJobs` from always-available to
+available-if-installed. Two gates govern it and **they are not connected**: exposure is
+gated on `permissions.devJobs` alone, while activation *ordering* comes only from manifest
+`requires`. Worse, `dynamicAgentRuntime` calls `topoSortByDependsOn(eligible, catalog)`
+with no capability edges at all — capability ordering exists **only** in
+`ToolPluginRuntime`. So topo-sort does not save this, and a consumer plugin either fails
+to activate in a way that never self-heals, or defers its failure to the first production
+request. Decide explicitly: does `permissions.devJobs` imply `requires: devJobs@1`, and is
+`DevJobsAccessor` optional-by-value or optional-by-presence? Then version `plugin-api`
+accordingly. Keeping the types while silently making the runtime optional preserves the
+type signature and breaks the contract — invisibly to `tsc`.
+
+### 4.3 The UI: a two-tier contract
+
+A ZIP cannot ship React into an ahead-of-time-compiled Next.js app — the extension
+allowlist has no `.tsx`, and `web-ui` is built once at image build time. But dev-platform
+is not going to be a ZIP: it is a **built-in package**, which ships inside the middleware
+image and goes through the same activation pathway. For that tier, "the React stays
+compiled into web-ui" is not a compromise, it is the correct design — both halves ship in
+the same image and are versioned together.
+
+So write the tiering down instead of hedging:
+
+| Tier | Who | UI mechanism | Nav |
+|---|---|---|---|
+| 1 — built-in package | ships in the image | React compiled into web-ui, runtime-gated on the plugin being active | absolute in-app path |
+| 2 — uploaded ZIP | third party | iframe of plugin-served HTML (`admin_ui_path`, `/p/:path*`, shared theming) — already exists | `/p/<id>/...` path |
+
+One nav mechanism serves both. A nav API that only served tier 1 would be a feature flag
+with extra steps.
+
+Constraint worth preserving: the dev-platform pages are already pure `'use client'`
+components talking to `/bot-api/...` — effectively a SPA. **No dev-platform page may
+become a server component**, so a future tier-2 port stays mechanical rather than a
+rewrite.
+
+Rejected: a workspace package for the pages (adds monorepo plumbing for modularity a
+directory and a lint rule already give), an iframe rewrite of these pages (throws away
+3,163 LOC of Lume React and 281 i18n keys for an internal operator surface), Next.js
+multi-zone (a second deployment, no installability gain), module federation (not viable
+with App Router + RSC), and a separate optional web-ui build (two images in lockstep).
+
+### 4.4 Nav contribution design (G1 — shipped)
+
+Extends the existing `UiRouteCatalog` rather than adding a third parallel catalog beside
+it and `admin_ui_path`. Nav entries are a **separate registration** on that catalog, not a
+field on `UiRouteDescriptor`, because the two `path` semantics differ: a uiRoute descriptor
+is relative to the plugin's `/p/<pluginId>` mount, a nav entry is an absolute in-app path.
+Folding them together would make one of the two fields a lie.
+
+Labels are **resolved server-side for the requested locale** and the browser never sees
+the per-locale map. The alternative — a client fetch of pre-resolved strings — puts the
+shell on two i18n clocks: on a locale switch, next-intl's server-rendered labels flip
+immediately while fetched labels lag, rendering a half-German nav. Fetching in the root
+layout instead means correct-on-first-paint, no hydration shift, and one clock.
+
+Every field is validated as untrusted input, because it renders inside the shell's own
+trusted header: `href` confined to single-slash in-app paths (blocking `//host`,
+`/\host`, and schemes), labels length-capped and screened for control and
+bidirectional-formatting characters (Trojan-Source spoofing of adjacent core entries).
+
+---
+
+## 5. Shipped in this PR (phase 1)
+
+Delivered standalone value with **no dev-platform code moved** — deliberately, so the
+riskiest steps are not coupled to the visible win.
+
+1. **Nav contribution API, end to end.**
+   `UiRouteCatalog.registerNav()` + `listNav(locale)` with full validation;
+   `ctx.uiRoutes.registerNav()` on the plugin contract;
+   `GET /api/v1/ui/navigation` (session-gated, `no-store`);
+   `fetchNavEntries()` fetched server-side in the root layout;
+   `mergeNav()` in `Nav.tsx` merging static and contributed entries.
+
+   Merge rules: a plugin entry joins the cluster it names; an entry with an unknown or
+   absent cluster is promoted to top level rather than silently swallowed by version skew;
+   plugin entries sort among themselves and never reorder static items; **an entry
+   colliding with a static href is dropped** so a plugin cannot shadow a core destination.
+
+2. **Dev Platform is the first consumer.** Its menu entry is now registered from the
+   existing `DEV_PLATFORM_ENABLED` block and removed from `Nav.tsx`'s literal. Turn the
+   feature off and the entry — and the `/admin` grid card, via a new `requiresNavHref`
+   flag — are gone, with no frontend rebuild. When the plugin package lands, this call
+   becomes `ctx.uiRoutes.registerNav(...)` inside its `activate()` and nothing about the
+   shell changes.
+
+3. **Fixed a live bug found while mapping the extraction.**
+   `ToolPluginRuntime.deactivate()` stopped jobs and disposed UI routes but **never called
+   `pluginRouteRegistry.disposeBySource()`** — though it held the dependency and threaded
+   it into every plugin context. `DynamicAgentRuntime` did. Express cannot unmount, so a
+   deactivated tool plugin's routers stayed live and, because Express matches
+   first-mount-wins, kept serving after uninstall and shadowed later mounts at the same
+   prefix after a hot-upgrade.
+
+   This is a prerequisite, not a drive-by: the success criterion "with the plugin not
+   installed, no dev-platform code paths" is **unverifiable** while routers outlive their
+   plugin. The regression test fails 3/4 without the one-line fix.
+
+Tests: 29 catalog, 11 route, 4 disposal (middleware, `node:test`), 12 merge (web-ui,
+vitest). Full suites green — middleware 4,890 pass / 0 fail, web-ui 331 pass.
+
+---
+
+## 6. Remaining phases
+
+Reordered from the original draft: the visible deliverable moved first (done), and the
+single irreversible step moved last.
+
+| Phase | Content | Observable outcome |
+|---|---|---|
+| **P2a** | Decide the `ctx.devJobs` contract (§4.2) and version `plugin-api`. Add capability edges to `dynamicAgentRuntime`, or document why agent plugins are excluded. | A written, versioned contract — before any code depends on it |
+| **P2b** | Break the `wireDevPlatform ↔ routes` cycle; move `mintAppJwt` to `src/platform/githubAppJwt.ts`; collapse the 41 config keys into one namespaced object. | `index.ts` wiring reduced to one `assembleDevPlatform(cfg)` call |
+| **P3** | **G6** dynamic `publicPaths` via manifest-declared, operator-consented grants + **G2** `auth: 'session'` composed *inside* the disposed guard + **G3** route-local raw parser + **G4** `pgPool` capability and shared `runPluginMigrations`. | Any plugin can own routes, exemptions, raw bodies, and tables |
+| **P4** | Create the package, move the code, relocate 54 tests. **Do not delete the `publicPaths` exemptions until P3's mechanism is proven on the live runner phone-home path.** | Dev Platform installs and uninstalls |
+| **P5** | Migration ownership handoff (no renumbering) + `copy-sql-assets` + `Dockerfile` line, tested against a database restored from a production snapshot. Its own PR, its own rollback story. | Plugin owns its schema |
+
+**Config is not 41 `setup.fields`.** The keys are four different things and only one
+belongs in a manifest form: platform-injected env (`FLY_APP_NAME` is a probe, not a
+question), deployment facts belonging to the compose overlay G5 already leaves to the
+operator, cross-field safety interlocks, and ~12–15 genuine operator-policy knobs
+(budget, retention, concurrency, allowed models). Only the last group becomes
+`setup.fields`. The interlocks — `SUBSCRIPTION_MODE` without `_ACK`, `UNSAFE_LOCAL`
+without `LOCAL_UID` — cannot be expressed in a flat field list, and shipping them as two
+independent optional booleans would **silently delete a boot-time safety refusal**. They
+become activation refusals in `activate()`, which is strictly better than today: one
+misconfigured plugin no longer takes the host offline.
+
+---
+
+## 7. Risks
+
+| Risk | Mitigation |
+|---|---|
+| **Deleting `publicPaths` exemptions kills in-flight jobs** | P4 is explicitly blocked on P3's dynamic mechanism being proven live. Called out in §3 |
+| **Migration handoff is irreversible** | Moved to last, no renumbering, ledger seed, snapshot-restored test, own PR |
+| **Wire paths are load-bearing** | **Invariant: no phase may change `/api/v1/dev-runner`, `/api/v1/admin/dev-platform`, `/api/webhooks/github`, or `RUNNER_PROTOCOL_VERSION`.** Deployed runner images phone home to literal URLs; a rename bricks in-flight jobs with no compile-time signal |
+| **`ctx.devJobs` inversion breaks third parties invisibly** | P2a resolves it as a contract decision before implementation |
+| **Uninstall data lifecycle is undefined** | Must be decided in P4: what happens to 9 tables on uninstall; who cleans `dev_repo_plugin_grants` when a *granted* plugin is removed; what happens to `running` jobs whose runner still holds a valid token |
+| **Secrets are vaulted under core's namespace** | GitHub App private keys, webhook secrets, and the proxy's provider key live under `core:dev-platform`. P4 must re-key into the plugin namespace or grant read access — operator-visible either way |
+| **Half-migrated codebase** | Each phase has an observable outcome above. **Abandonment checkpoint: after P3, the platform capabilities stand alone and dev-platform stays in core with no partial-move debt.** Half-moved is the only genuinely bad end state |
+| **SSE is not horizontally scalable** | Pre-existing (one in-process `EventEmitter` per job). Flagged, not fixed here |
+| **Dead conductor bridge** | `devJobConductorBridge.ts` has no production wiring — only a test imports it. Wire it or delete it in P4; do not carry dead code into a published package |
+
+---
+
+## 8. Out of scope
+
+- Shipping React components inside a plugin ZIP (needs a remote-module system).
+- Runtime provisioning of docker sidecars from a manifest.
+- Per-role / capability-based navigation gating — no such primitive exists today; every
+  logged-in operator sees every entry, and that is unchanged by this work.
+- Making the job-event SSE horizontally scalable.
+- Plugin package signing (`signature:` is documented but unparsed; `signed` is hardcoded
+  `false`).

--- a/specs/470-dev-platform-plugin/plan.md
+++ b/specs/470-dev-platform-plugin/plan.md
@@ -44,14 +44,15 @@ Success is binary and observable:
 | `middleware/packages/dev-runner-shim/` | 21 files, zero deps |
 | `middleware/test/devplatform/**` | 54 files |
 | `web-ui/app/admin/dev-platform/**` | 20 files, 3,163 LOC |
-| `web-ui/app/_components/devjobs/**` + `_lib/useDevJobEvents.ts` | 7 files, 890 LOC |
+| `web-ui/app/_components/devjobs/**` + `_lib/useDevJobEvents.ts` | 7 files, 884 LOC |
 | Database | 9 tables, 14 indexes, migrations `0022`–`0030` |
-| Config | **41** `DEV_*`/`FLY_*` keys — 37 in the `config.ts` dev-platform block plus 4 elsewhere (`DEV_WEBHOOKS_ENABLED`, two webhook rate limits, `DEV_JOB_DEFAULT_BUDGET_USD`) |
-| i18n | **281** keys — `adminDevPlatform.*` (269) + `chat.devJob.*` (9) + `admin.index.cards.devPlatform.*` (2) + `nav.devPlatform` (1), of 3,131 total |
+| Config | **41** dev-platform `DEV_*`/`FLY_*` keys — 37 in the `config.ts` dev-platform block plus 4 elsewhere (`DEV_WEBHOOKS_ENABLED`, two webhook rate limits, `DEV_JOB_DEFAULT_BUDGET_USD`). `config.ts` holds 42 distinct `DEV_*`/`FLY_*` identifiers in total; the 42nd, `DEV_ENDPOINTS_ENABLED`, is generic and stays in core |
+| i18n | **281** keys before this PR — `adminDevPlatform.*` (269) + `chat.devJob.*` (9) + `admin.index.cards.devPlatform.*` (2) + `nav.devPlatform` (1), of 3,131 total. Now 280 of 3,130: this PR removed `nav.devPlatform`, since the label ships with the plugin |
 
 ### The coupling cut-line
 
-Only **nine** core files reference dev-platform — the boundary is already almost clean.
+Ten core files reference dev-platform (`runExecutor.ts` and `awaitStore.ts` share a row
+below) — the boundary is already almost clean.
 
 | Core file | Coupling |
 |---|---|
@@ -122,6 +123,17 @@ The consequences for this plan are sharp:
 So the real gap is **G6**, and it must be solved as a declarative, install-time,
 operator-consented grant (a manifest `permissions.public_paths[]` surfaced in the install
 dialog and revoked on deactivate) — never a runtime escape hatch on `RoutesAccessor`.
+
+**A grant alone is not sufficient.** `publicPaths` only makes `requireAuth` call `next()`
+for a URL; it says nothing about *which* router is entitled to answer it. If plugin A is
+granted a prefix and does not handle some subpath, plugin B mounted at the same prefix
+receives that request unauthenticated. The grant must therefore be paired with **exclusive
+prefix ownership** (register-time collision rejection) or enforced inside a per-entry
+dispatcher rather than as a global URL bypass.
+
+Note also that the blanket `/api` gate is not universal: `publicPaths` already exempts
+several prefixes, so a plugin registering beneath one of those is unauthenticated today
+without declaring anything. Prefix ownership fixes that too.
 
 ### G3: not via `express.json`'s verify hook
 
@@ -210,8 +222,17 @@ A ZIP cannot ship React into an ahead-of-time-compiled Next.js app — the exten
 allowlist has no `.tsx`, and `web-ui` is built once at image build time. But dev-platform
 is not going to be a ZIP: it is a **built-in package**, which ships inside the middleware
 image and goes through the same activation pathway. For that tier, "the React stays
-compiled into web-ui" is not a compromise, it is the correct design — both halves ship in
-the same image and are versioned together.
+compiled into web-ui" is not a compromise, it is the correct design.
+
+**Correction (review round 3):** an earlier draft justified this with "both halves ship in
+the same image." That is false. The plugin compiles into `omadia-middleware`; its React
+page compiles into `omadia-web-ui` — two separately deployable images, versioned together
+only by convention. Upgrade middleware first and it can advertise a nav href for a page
+the deployed web UI does not contain (a 404 from the menu); upgrade web-ui first and the
+page exists with no backend. The nav mechanism narrows this — the entry only appears when
+the middleware side is active — but it does not close it. **P3 must add a compatibility
+signal** (a minimum-web-ui version on the nav entry, or a shell-side allowlist of paths it
+actually compiled) rather than relying on lockstep deploys.
 
 So write the tiering down instead of hedging:
 
@@ -291,8 +312,59 @@ riskiest steps are not coupled to the visible win.
    installed, no dev-platform code paths" is **unverifiable** while routers outlive their
    plugin. The regression test fails 3/4 without the one-line fix.
 
-Tests: 29 catalog, 11 route, 4 disposal (middleware, `node:test`), 12 merge (web-ui,
-vitest). Full suites green — middleware 4,890 pass / 0 fail, web-ui 331 pass.
+Tests: 48 catalog, 11 route, 6 disposal (middleware, `node:test`), 13 merge + 12 parse
+(web-ui, vitest). web-ui 344 pass / 0 fail.
+
+### Known limitations of what shipped
+
+Surfaced by two adversarial review passes (GPT-5.4, then GPT-5.6). Recorded here rather
+than silently carried:
+
+- **The nav fetch is on every page's critical path.** The root layout awaits it with a
+  2s timeout and degrades to the static nav, but a hung middleware still adds up to 2s
+  before first paint — including on `/login` and `/setup`, where there is no session and
+  the answer is always empty. A Suspense boundary, or skipping the fetch on
+  unauthenticated routes, would remove that; neither is done yet.
+- **`no-store` means a round trip per render.** The catalogue varies by locale and by
+  plugin lifecycle, not by session, so a short stale-while-revalidate cache keyed on
+  locale would bound the load. Conversely, because Next reuses shared layouts across
+  client navigations, an already-open tab can keep showing an entry for a plugin that was
+  just deactivated. Neither direction is addressed.
+- **`MIDDLEWARE_URL` became a runtime requirement for web-ui.** RSC rendering reads it at
+  request time; `web-ui/Dockerfile` and `.env.local.example` still describe it as
+  build/dev-time only. Running the standalone image without it silently falls back to
+  `localhost:3979` and hides every plugin entry. Documentation fix owed.
+- **`WEB_UI_LOCALES` is duplicated in middleware** with a keep-in-sync comment. Server-side
+  label resolution removes the *hydration* clock but not translation/version skew across
+  the two images: ship a new locale in web-ui against older middleware and static labels
+  translate while plugin labels fall back to English.
+- **Homoglyph spoofing is not prevented.** Control, bidi and zero-width codepoints are
+  rejected, but a Cyrillic `Аdmin` still renders convincingly next to the core `Admin`.
+  Full confusable detection is out of scope; the entry at least carries its `pluginId`.
+- **Test gaps.** The rollback path inside `activate()`'s catch is not covered (driving it
+  needs a real on-disk package plus catalog/vault wiring), and the route test exercises
+  the router without `requireAuth` — deleting the production guard would not fail a test.
+
+### Pre-existing suite flakiness (not caused by this PR)
+
+Adding these test files made `registryInstallMerge` fail intermittently in the full run
+while passing in isolation. Investigated rather than assumed:
+
+| Experiment | Result |
+|---|---|
+| Baseline, my files removed (3 runs) | 0 fail |
+| My files present (3 runs) | 1, 5, 0 fail |
+| My files with all TCP sockets removed (3 runs) | 1, 5, 0 fail |
+| Three trivial 22-test files instead of mine (3 runs) | 0 fail |
+| **One file of 48 `assert.equal(1, 1)` tests at the same sort position (3 runs)** | **0, 3, 2 fail** |
+
+A file containing nothing but trivial assertions reproduces it. The race is latent in
+`registryInstallMerge` (which itself binds ~6 sockets) and is exposed by test-runner
+worker scheduling; any sufficiently large added file triggers it. This matches the
+already-known "passes isolated, fails in the full suite" issue in this repo. My tests were
+nevertheless converted to run socket-free via `test/_helpers/httpInvoke.ts`, which drives
+the real Express pipeline through `app.handle` without binding a port — worth doing on its
+own merits. **Follow-up owed on `registryInstallMerge`; it is not addressed here.**
 
 ---
 

--- a/specs/470-dev-platform-plugin/plan.md
+++ b/specs/470-dev-platform-plugin/plan.md
@@ -18,18 +18,41 @@ Related: epic #470, PR #496, #497, #529
 ## 1. Goal
 
 Turn the Dev Platform from a hard-wired core subsystem into an **installable,
-uninstallable plugin** — one that brings its own backend, its own database schema, its
-own configuration, and **its own menu entries** — without regressing behaviour, security
-posture, or the operator experience.
+uninstallable plugin living in its own repository** — one that brings its own backend, its
+own database schema, its own configuration, its own UI, and **its own menu entries** —
+without regressing behaviour, security posture, or the operator experience.
 
 Success is binary and observable:
 
 - With the plugin **not installed**, `middleware` boots with zero dev-platform code
   paths, no `dev_*` tables required, no `DEV_*` config required, and **no Dev Platform
   entry in the navigation**.
-- With the plugin **installed and active**, the Dev Platform works exactly as it does
-  today, and its menu entries appear — contributed by the plugin, not hardcoded in the
-  shell.
+- With the plugin **installed and active**, the Dev Platform works as it does today, and
+  its menu entries appear — contributed by the plugin, not hardcoded in the shell.
+- **The `omadia` repository contains no reference to the Dev Platform at all.**
+
+### Two constraints added after the first draft
+
+1. **The plugin lives in its own repository** (like `omadia-byte5-plugins` and
+   `omadia-plugin-starter`), not in `middleware/packages/`.
+2. **Every hardcoded dev-platform part is removed from core** — not gated, not
+   feature-flagged: absent.
+
+They sound small. They are not, and they invalidate two decisions in the first draft:
+
+- **The plugin can no longer be a built-in package.** §4.1 previously placed it in
+  `middleware/packages/harness-plugin-dev-platform/`, shipping inside the middleware
+  image. An own repo makes it a **distributed (tier-2) plugin**, which is a materially
+  weaker delivery vehicle — see §4.3.
+- **The React pages can no longer stay compiled into web-ui.** §4.3 previously argued
+  that was correct *because* both halves shipped in the same image. Under constraint 2
+  those 3,933 LOC are hardcoded core references and must go, which resurfaces the
+  "a ZIP cannot ship React" problem the first draft had sidestepped.
+
+Concretely: **276 hardcoded items across 18 zones, ≈49,100 LOC across ~200 files.** Full
+work-list in `core-decoupling-checklist.md`. Three of those items are not deletions at all
+— core has no extension point for them, so a new generic mechanism has to be built first
+(H1 public paths, H2 conductor step kinds, H3 chat tool-card renderers).
 
 ---
 
@@ -93,7 +116,11 @@ files is the easy part.
 | **G3** | **A plugin router cannot receive a raw request body.** The GitHub webhook receiver needs untouched bytes for HMAC and is mounted *before* `express.json` on purpose. Plugin routers mount at boot flush, after it. | Open |
 | **G4** | **No kernel mechanism for plugin-owned SQL.** `onMigrate` is *config* migration only. | Open (softer than it looks) |
 | **G5** | **No plugin-declared external services.** No `services:`/`image:` in the manifest; sidecars are operator-managed compose overlays. | Won't fix — see below |
-| **G6** | **`publicPaths` is a frozen literal.** A plugin cannot contribute an auth exemption, and core cannot revoke one on uninstall. | Open — **blocks P2** |
+| **G6** | **`publicPaths` is a frozen literal.** A plugin cannot contribute an auth exemption, and core cannot revoke one on uninstall. Needs prefix ownership too, not just a grant. | Open — **hard blocker** (H1) |
+| **G7** | **A distributed plugin cannot ship a React UI.** The ZIP extension allowlist has no `.tsx` — and, verified, **no `.css` either**, so it cannot even carry a compiled SPA's stylesheet. web-ui is built once at image build time. | Open — **hard blocker**, new |
+| **G8** | **`DevJob*` are published `@omadia/plugin-api` types.** Removing them is a SemVer-major break for every Hub plugin importing them; `api/admin-v1.ts` leaks `dev_jobs` onto the public admin DTO too. | Open — new |
+| **G9** | **The conductor hardcodes the `dev_job` step kind and channel type** across `runExecutor.ts`, `awaitStore.ts`, and all of `devJobStepEffect.ts`. | Open — **hard blocker** (H2) |
+| **G10** | **The chat renderer hardcodes `tool.name === 'dev_job_start'`** and renders a core-compiled React card for it. | Open — **hard blocker** (H3) |
 
 ### G2 is the inverse of the obvious reading — and it is a trap
 
@@ -180,11 +207,25 @@ crash) when `DEV_RUNNER_DAEMON_URL` is unreachable.
 
 ### 4.1 What the plugin owns
 
-`@omadia/plugin-dev-platform` at `middleware/packages/harness-plugin-dev-platform/`, as a
-**built-in package** (`kind: extension` — capability resolution only exists in
-`ToolPluginRuntime`, which handles `tool`/`extension`/`integration`). It owns
-`src/devplatform/**`, all dev-platform routers including `devRunnerApi.ts` and
-`devWebhooks.ts`, its own migrations, its config, and its nav contribution.
+`@omadia/plugin-dev-platform`, in **its own repository** (`byte5ai/omadia-plugin-dev-platform`,
+alongside `omadia-byte5-plugins` and `omadia-plugin-starter`), `kind: extension` —
+capability resolution only exists in `ToolPluginRuntime`, which handles
+`tool`/`extension`/`integration`. It owns `src/devplatform/**`, all dev-platform routers
+including `devRunnerApi.ts` and `devWebhooks.ts`, its own migrations, its config, its UI,
+and its nav contribution.
+
+The repo also inherits what core currently does *for* it and will stop doing:
+
+- **Its own container images and supply chain.** `dev-runner` and `dev-runner-daemon` are
+  built, SBOM'd and keyless-signed by `.github/workflows/publish-images.yml` today; those
+  matrix entries and cosign steps leave with the plugin, and the new repo needs an
+  equivalent pipeline. `id-token: write` in `auto-release.yml` / `release.yml` exists
+  *solely* for that signing and can then be dropped from core.
+- **Its own compose overlay** (`docker-compose.dev-platform.yaml`, 193 lines) and the two
+  sidecar Dockerfiles.
+- **Its own `@omadia/dev-platform-plugin-api`** carrying the `DevJob*` types, so third
+  parties that consume `ctx.devJobs` depend on the plugin's contract rather than core's
+  (G8).
 
 `devRunnerApi.ts` belongs in the plugin: it has zero core dependencies and is versioned
 with the **shim**, not with core (`RUNNER_PROTOCOL_VERSION`). A protocol whose counterpart
@@ -216,44 +257,56 @@ request. Decide explicitly: does `permissions.devJobs` imply `requires: devJobs@
 accordingly. Keeping the types while silently making the runtime optional preserves the
 type signature and breaks the contract — invisibly to `tsc`.
 
-### 4.3 The UI: a two-tier contract
+### 4.3 The UI — the decision the own-repo constraint forces (G7)
 
-A ZIP cannot ship React into an ahead-of-time-compiled Next.js app — the extension
-allowlist has no `.tsx`, and `web-ui` is built once at image build time. But dev-platform
-is not going to be a ZIP: it is a **built-in package**, which ships inside the middleware
-image and goes through the same activation pathway. For that tier, "the React stays
-compiled into web-ui" is not a compromise, it is the correct design.
+**This section replaces the first draft's answer.** That draft kept the 3,933 LOC of React
+compiled into web-ui and justified it by the plugin being a built-in package. Both halves
+of that justification are now gone: the plugin lives in its own repo, and pages compiled
+into web-ui *are* hardcoded core references, which constraint 2 forbids.
 
-**Correction (review round 3):** an earlier draft justified this with "both halves ship in
-the same image." That is false. The plugin compiles into `omadia-middleware`; its React
-page compiles into `omadia-web-ui` — two separately deployable images, versioned together
-only by convention. Upgrade middleware first and it can advertise a nav href for a page
-the deployed web UI does not contain (a 404 from the menu); upgrade web-ui first and the
-page exists with no backend. The nav mechanism narrows this — the entry only appears when
-the middleware side is active — but it does not close it. **P3 must add a compatibility
-signal** (a minimum-web-ui version on the nav entry, or a shell-side allowlist of paths it
-actually compiled) rather than relying on lockstep deploys.
+So the UI has to leave core, and the mechanism has to work for a plugin distributed as a
+package. That is a genuinely harder problem, and it is the epic's biggest single risk.
 
-So write the tiering down instead of hedging:
+**What a distributed plugin can carry today.** The ZIP extension allowlist
+(`zipExtractor.ts:20-41`) is `.yaml .yml .md .json .js .mjs .cjs .map .png .svg .jpg .jpeg
+.txt .license .html`. No `.tsx` — expected. But also, verified, **no `.css`**. So today a
+plugin cannot even ship a compiled SPA's stylesheet, only inline styles inside a single
+`.html`. The existing precedent (`admin_ui_path` → iframe on the plugin's store detail
+page) is exactly one hand-written HTML file.
 
-| Tier | Who | UI mechanism | Nav |
-|---|---|---|---|
-| 1 — built-in package | ships in the image | React compiled into web-ui, runtime-gated on the plugin being active | absolute in-app path |
-| 2 — uploaded ZIP | third party | iframe of plugin-served HTML (`admin_ui_path`, `/p/:path*`, shared theming) — already exists | `/p/<id>/...` path |
+**The options, honestly.**
 
-One nav mechanism serves both. A nav API that only served tier 1 would be a feature flag
-with extra steps.
+| Option | Verdict |
+|---|---|
+| **A. Rewrite as hand-rolled HTML** served from the plugin's router | Fits today's mechanism with no core change. Throws away 3,163 LOC of Lume React, the phase rail, the SSE log pane, and 280 i18n keys. A visible product downgrade for the operator surface. |
+| **B. Plugin ships a compiled SPA, served by its own router, embedded via iframe** | **Recommended.** Keeps React, keeps the design system, keeps the components. Needs: `.css` (and probably `.woff2`) added to the allowlist, a static-asset serving path, and the Lume tokens published as a package the plugin can depend on. Costs a bundler in the plugin repo and an iframe boundary. |
+| **C. Module federation / RSC remoting** | Not viable with App Router + RSC. Excluded. |
+| **D. Optional web-ui build variant** | Two images in lockstep, and the plugin's code would still have to live in core's build. Fails constraint 2. |
+| **E. Publish the pages as an npm package web-ui optionally installs** | Keeps React and removes the *source* from core, but core's build must still know the package exists. Weakens constraint 2 to "no source, but a build-time hook". Fallback if B proves too costly. |
 
-Constraint worth preserving: the dev-platform pages are already pure `'use client'`
-components talking to `/bot-api/...` — effectively a SPA. **No dev-platform page may
-become a server component**, so a future tier-2 port stays mechanical rather than a
-rewrite.
+**Recommendation: B.** It is the only option that satisfies both constraints without a
+product downgrade. It is also strictly more valuable than a one-off fix — it is the
+mechanism *any* third-party plugin needs to ship a real UI, which is currently the
+platform's weakest extension point.
 
-Rejected: a workspace package for the pages (adds monorepo plumbing for modularity a
-directory and a lint rule already give), an iframe rewrite of these pages (throws away
-3,163 LOC of Lume React and 281 i18n keys for an internal operator surface), Next.js
-multi-zone (a second deployment, no installability gain), module federation (not viable
-with App Router + RSC), and a separate optional web-ui build (two images in lockstep).
+Two properties make B cheaper than it looks: the dev-platform pages are already pure
+`'use client'` components talking to `/bot-api/...` — effectively a SPA already — and the
+nav API shipped in phase 1 already supports pointing an entry at a `/p/<pluginId>/...`
+path, so discovery and placement are solved. **No dev-platform page may become a server
+component** in the meantime, or the port stops being mechanical.
+
+**The chat card (H3) is not covered by B.** `DevJobChatCard` renders *inside* the core
+chat transcript, not in an iframe, and `chat/page.tsx:1025` hardcodes
+`tool.name === 'dev_job_start'`. An iframe per tool call is not acceptable there. Options:
+a declarative card schema the plugin returns and core renders generically, or accept that
+the rich card degrades to a plain `ToolRow` for out-of-repo plugins. **This needs a
+decision before P4** — it is the one place where "no hardcoding" and "no downgrade" may
+genuinely conflict.
+
+**Cross-image skew still applies and gets worse.** middleware, web-ui and now the plugin
+are three separately versioned artifacts. The nav entry only appears when the plugin is
+active, which narrows it, but a compatibility signal (minimum core version in the manifest,
+checked at install) is now required rather than optional.
 
 ### 4.4 Nav contribution design (G1 — shipped)
 
@@ -375,11 +428,14 @@ single irreversible step moved last.
 
 | Phase | Content | Observable outcome |
 |---|---|---|
-| **P2a** | Decide the `ctx.devJobs` contract (§4.2) and version `plugin-api`. Add capability edges to `dynamicAgentRuntime`, or document why agent plugins are excluded. | A written, versioned contract — before any code depends on it |
-| **P2b** | Break the `wireDevPlatform ↔ routes` cycle; move `mintAppJwt` to `src/platform/githubAppJwt.ts`; collapse the 41 config keys into one namespaced object. | `index.ts` wiring reduced to one `assembleDevPlatform(cfg)` call |
-| **P3** | **G6** dynamic `publicPaths` via manifest-declared, operator-consented grants + **G2** `auth: 'session'` composed *inside* the disposed guard + **G3** route-local raw parser + **G4** `pgPool` capability and shared `runPluginMigrations`. | Any plugin can own routes, exemptions, raw bodies, and tables |
-| **P4** | Create the package, move the code, relocate 54 tests. **Do not delete the `publicPaths` exemptions until P3's mechanism is proven on the live runner phone-home path.** | Dev Platform installs and uninstalls |
-| **P5** | Migration ownership handoff (no renumbering) + `copy-sql-assets` + `Dockerfile` line, tested against a database restored from a production snapshot. Its own PR, its own rollback story. | Plugin owns its schema |
+| **P2a** | Decide the `ctx.devJobs` contract (§4.2) and the G8 public-contract break: `DevJob*` move to `@omadia/dev-platform-plugin-api`, `plugin-api` gets a SemVer-major bump, `dev_jobs` leaves the admin-v1 DTO. Add capability edges to `dynamicAgentRuntime` or document why agent plugins are excluded. | A written, versioned contract — before any code depends on it |
+| **P2b** | Decide **H3** (chat card): declarative card schema, or accept degradation to `ToolRow` for out-of-repo plugins. Decide **G7 option B vs E**. | Both answers written down before code moves |
+| **P2c** | Mechanical decoupling: break the `wireDevPlatform ↔ routes` cycle; collapse the 41 config keys into one namespaced object. ✅ `mintAppJwt` already moved to `src/services/githubAppJwt.ts`. | `index.ts` wiring reduced to one `assembleDevPlatform(cfg)` call |
+| **P3** | The extension points. **H1** dynamic `publicPaths` + exclusive prefix ownership · **H2** generic conductor step-kind/channel-type registry · **G2** `auth: 'session'` composed *inside* the disposed guard · **G3** route-local raw parser · **G4** `pgPool` capability + shared `runPluginMigrations`. | Any plugin can own routes, exemptions, raw bodies, tables, and long-running steps |
+| **P3b** | **G7**: `.css`/font extensions in the ZIP allowlist, a static-asset serving path for plugin SPAs, Lume tokens published as a consumable package. | Any plugin can ship a real UI — the platform's weakest extension point today |
+| **P4** | Stand up `byte5ai/omadia-plugin-dev-platform`; move ~49,100 LOC per `core-decoupling-checklist.md`; port the UI; stand up the repo's own GHCR + SBOM + signing pipeline. **Do not delete the `publicPaths` exemptions until P3 is proven on the live runner phone-home path.** | Dev Platform installs and uninstalls from its own repo |
+| **P5** | Migration ownership handoff (no renumbering) + ledger seed, tested against a database restored from a production snapshot. Its own PR, its own rollback story. | Plugin owns its schema |
+| **P6** | Delete the residue: core's `DEV_*` config, the compose overlay, the CI matrix entries and `id-token: write`, the workflow prompt rules, and every comment reference. | `rg -i 'dev.?platform\|devjob' omadia/` returns nothing |
 
 **Config is not 41 `setup.fields`.** The keys are four different things and only one
 belongs in a manifest form: platform-injected env (`FLY_APP_NAME` is a probe, not a
@@ -404,7 +460,11 @@ misconfigured plugin no longer takes the host offline.
 | **`ctx.devJobs` inversion breaks third parties invisibly** | P2a resolves it as a contract decision before implementation |
 | **Uninstall data lifecycle is undefined** | Must be decided in P4: what happens to 9 tables on uninstall; who cleans `dev_repo_plugin_grants` when a *granted* plugin is removed; what happens to `running` jobs whose runner still holds a valid token |
 | **Secrets are vaulted under core's namespace** | GitHub App private keys, webhook secrets, and the proxy's provider key live under `core:dev-platform`. P4 must re-key into the plugin namespace or grant read access — operator-visible either way |
-| **Half-migrated codebase** | Each phase has an observable outcome above. **Abandonment checkpoint: after P3, the platform capabilities stand alone and dev-platform stays in core with no partial-move debt.** Half-moved is the only genuinely bad end state |
+| **Half-migrated codebase** | Each phase has an observable outcome above. **Abandonment checkpoint: after P3/P3b, the platform capabilities stand alone and dev-platform stays in core with no partial-move debt.** Half-moved is the only genuinely bad end state |
+| **The UI port is the biggest single risk (G7)** | 3,933 LOC of React must move to a repo that currently cannot ship a stylesheet. P3b de-risks it *before* P4 commits. If P3b proves too costly, fall back to option E (npm-published UI package) and accept the weakened constraint rather than rewriting the UI as hand-rolled HTML |
+| **Cross-repo development loses atomic changes** | Today a change spanning core and dev-platform is one PR with one CI run. Afterwards it is two PRs in two repos with a published contract between them, and no way to land them atomically. This is the standing tax of the split — worth it for installability, but it makes P3's extension points load-bearing: get them wrong and every fix needs a core release |
+| **The new repo needs a real supply chain** | `dev-runner` is currently SBOM'd and keyless-signed in core's `publish-images.yml`. That is not a copy-paste — the new repo needs GHCR publishing, cosign identity, and its own release workflow before the images can move |
+| **`plugin-api` SemVer-major break (G8)** | Third-party plugins importing `DevJobDescriptor` et al. break at compile time. Deliberate, versioned, and announced — not silent. The worse outcome is keeping the types while making the runtime optional, which preserves the signature and breaks the contract invisibly |
 | **SSE is not horizontally scalable** | Pre-existing (one in-process `EventEmitter` per job). Flagged, not fixed here |
 | **Dead conductor bridge** | `devJobConductorBridge.ts` has no production wiring — only a test imports it. Wire it or delete it in P4; do not carry dead code into a published package |
 

--- a/web-ui/app/_components/Nav.tsx
+++ b/web-ui/app/_components/Nav.tsx
@@ -3,7 +3,9 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+
+import type { NavEntryDto } from '../_lib/navigation';
 
 /**
  * Phase B (B2) — top nav with cluster dropdowns.
@@ -14,6 +16,21 @@ import { useEffect, useId, useRef, useState } from 'react';
  * across every leaf href so nested routes (`/store/builder` over `/store`)
  * keep working; the cluster header gets a subtle `contains-active` style
  * when any of its children matches.
+ *
+ * Two sources feed this bar (specs/470-dev-platform-plugin):
+ *
+ *   1. `NAV` below — the shell's own compiled surfaces. Labels come from
+ *      the `nav.*` message catalogue, per web-ui/CLAUDE.md.
+ *   2. `entries` prop — surfaces contributed by installed plugins, fetched
+ *      server-side in the root layout. These carry their label as a plain
+ *      string because the shell cannot know a third-party plugin's strings
+ *      at build time; the middleware resolves them for the active locale
+ *      before they ever reach the browser.
+ *
+ * (2) is the deliberate, and only, exception to "no user-facing literals
+ * outside the catalogue": the string is plugin-owned data, not a hardcoded
+ * literal in this file. Everything the shell itself renders still goes
+ * through `useTranslations`.
  */
 
 type NavLeaf = { readonly kind: 'link'; readonly href: string; readonly key: string };
@@ -23,6 +40,15 @@ type NavCluster = {
   readonly children: readonly NavLeaf[];
 };
 type NavItem = NavLeaf | NavCluster;
+
+/**
+ * A leaf after merging. Static leaves resolve their label through the
+ * message catalogue; plugin leaves carry a pre-resolved one.
+ */
+type ResolvedLeaf = {
+  readonly href: string;
+  readonly label: string;
+};
 
 const NAV: readonly NavItem[] = [
   { kind: 'link', href: '/', key: 'dashboard' },
@@ -47,26 +73,107 @@ const NAV: readonly NavItem[] = [
       // operator-facing configuration surfaces, same audience as Admin/System.
       { kind: 'link', href: '/operator/agents', key: 'agentsCluster' },
       { kind: 'link', href: '/conductor', key: 'conductor' },
-      // Dev platform (epic #470) — operator surface for isolated code-runner jobs.
-      { kind: 'link', href: '/admin/dev-platform', key: 'devPlatform' },
+      // Dev Platform used to be hardcoded here. It is now contributed at
+      // runtime (middleware registers it while DEV_PLATFORM_ENABLED), so the
+      // entry disappears when the feature is off — see mergeNav below.
     ],
   },
 ] as const;
 
-function collectLeaves(items: readonly NavItem[]): readonly NavLeaf[] {
-  const out: NavLeaf[] = [];
+/** A static or plugin-contributed item, with its label already resolved. */
+export type ResolvedNavItem =
+  | { readonly kind: 'link'; readonly href: string; readonly label: string }
+  | {
+      readonly kind: 'cluster';
+      readonly key: string;
+      readonly label: string;
+      readonly children: readonly ResolvedLeaf[];
+    };
+
+/**
+ * Merge the shell's static nav with the plugin-contributed entries.
+ *
+ * Rules, in order:
+ *   - A plugin entry naming an existing cluster is appended inside it.
+ *   - A plugin entry with no cluster — or one naming a cluster this shell
+ *     does not have — becomes a top-level entry, so a menu item is never
+ *     silently swallowed by a typo or a shell/plugin version skew.
+ *   - Plugin entries sort among themselves by `order`, then label. They
+ *     never reorder the static items around them.
+ *   - A plugin entry whose href collides with a static one is dropped.
+ *     The shell's own surfaces win; a plugin must not be able to shadow
+ *     a core destination with its own label.
+ *
+ * Pure and exported so the merge is unit-testable without a DOM.
+ */
+export function mergeNav(
+  staticItems: readonly NavItem[],
+  entries: readonly NavEntryDto[],
+  translate: (key: string) => string,
+): readonly ResolvedNavItem[] {
+  const staticHrefs = new Set<string>();
+  for (const item of staticItems) {
+    if (item.kind === 'link') staticHrefs.add(item.href);
+    else for (const child of item.children) staticHrefs.add(child.href);
+  }
+
+  const clusterKeys = new Set(
+    staticItems.filter((i) => i.kind === 'cluster').map((i) => i.key),
+  );
+
+  const ordered = [...entries]
+    .filter((e) => !staticHrefs.has(e.href))
+    .sort((a, b) =>
+      a.order !== b.order ? a.order - b.order : a.label.localeCompare(b.label),
+    );
+
+  const byCluster = new Map<string, ResolvedLeaf[]>();
+  const topLevel: ResolvedLeaf[] = [];
+  for (const entry of ordered) {
+    const leaf: ResolvedLeaf = { href: entry.href, label: entry.label };
+    if (entry.cluster !== undefined && clusterKeys.has(entry.cluster)) {
+      const bucket = byCluster.get(entry.cluster) ?? [];
+      bucket.push(leaf);
+      byCluster.set(entry.cluster, bucket);
+    } else {
+      topLevel.push(leaf);
+    }
+  }
+
+  const merged: ResolvedNavItem[] = staticItems.map((item) =>
+    item.kind === 'link'
+      ? { kind: 'link', href: item.href, label: translate(item.key) }
+      : {
+          kind: 'cluster',
+          key: item.key,
+          label: translate(item.key),
+          children: [
+            ...item.children.map(
+              (c): ResolvedLeaf => ({ href: c.href, label: translate(c.key) }),
+            ),
+            ...(byCluster.get(item.key) ?? []),
+          ],
+        },
+  );
+
+  return [...merged, ...topLevel.map((l) => ({ kind: 'link' as const, ...l }))];
+}
+
+function collectLeaves(items: readonly ResolvedNavItem[]): readonly ResolvedLeaf[] {
+  const out: ResolvedLeaf[] = [];
   for (const item of items) {
-    if (item.kind === 'link') out.push(item);
+    if (item.kind === 'link') out.push({ href: item.href, label: item.label });
     else out.push(...item.children);
   }
   return out;
 }
 
-const ALL_LEAVES = collectLeaves(NAV);
-
-function bestPrefixMatch(pathname: string | null): string {
+export function bestPrefixMatch(
+  pathname: string | null,
+  leaves: readonly ResolvedLeaf[],
+): string {
   if (!pathname) return '';
-  return ALL_LEAVES.reduce((acc, candidate) => {
+  return leaves.reduce((acc, candidate) => {
     const match =
       candidate.href === '/'
         ? pathname === '/'
@@ -76,26 +183,35 @@ function bestPrefixMatch(pathname: string | null): string {
   }, '');
 }
 
-export function Nav(): React.ReactElement {
+export function Nav({
+  entries = [],
+}: {
+  /** Plugin-contributed entries, fetched server-side in the root layout. */
+  readonly entries?: readonly NavEntryDto[];
+}): React.ReactElement {
   const pathname = usePathname();
   const t = useTranslations('nav');
-  const activeHref = bestPrefixMatch(pathname);
+  // Recomputed when entries change (plugin installed/uninstalled) — the
+  // leaf set is no longer fixed at module scope.
+  const items = useMemo(() => mergeNav(NAV, entries, t), [entries, t]);
+  const activeHref = useMemo(
+    () => bestPrefixMatch(pathname, collectLeaves(items)),
+    [pathname, items],
+  );
   return (
     <nav className="flex items-center gap-4 text-[13px] uppercase tracking-[0.18em]">
-      {NAV.map((item) =>
+      {items.map((item) =>
         item.kind === 'link' ? (
           <LeafLink
             key={item.href}
             href={item.href}
-            label={t(item.key)}
+            label={item.label}
             active={activeHref === item.href}
           />
         ) : (
           <ClusterDropdown
             key={item.key}
             cluster={item}
-            label={t(item.key)}
-            renderChildLabel={(child) => t(child.key)}
             activeHref={activeHref}
           />
         ),
@@ -133,15 +249,12 @@ function LeafLink({
 
 function ClusterDropdown({
   cluster,
-  label,
-  renderChildLabel,
   activeHref,
 }: {
-  readonly cluster: NavCluster;
-  readonly label: string;
-  readonly renderChildLabel: (child: NavLeaf) => string;
+  readonly cluster: Extract<ResolvedNavItem, { kind: 'cluster' }>;
   readonly activeHref: string;
 }): React.ReactElement {
+  const label = cluster.label;
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const menuId = useId();
@@ -220,7 +333,7 @@ function ClusterDropdown({
                       : 'text-[color:var(--muted-ink)] hover:bg-[color:var(--bg-soft)] hover:text-[color:var(--ink)]',
                   ].join(' ')}
                 >
-                  {renderChildLabel(child)}
+                  {child.label}
                 </Link>
               );
             })}

--- a/web-ui/app/_components/Nav.tsx
+++ b/web-ui/app/_components/Nav.tsx
@@ -123,13 +123,28 @@ export function mergeNav(
 
   const ordered = [...entries]
     .filter((e) => !staticHrefs.has(e.href))
-    .sort((a, b) =>
-      a.order !== b.order ? a.order - b.order : a.label.localeCompare(b.label),
+    // Plain codepoint comparison, not localeCompare: this runs on both the
+    // server and the client, and a locale-sensitive collator can order the
+    // same two labels differently under Node's ICU than under the visitor's
+    // browser, producing a hydration mismatch. Ties broken by pluginId +
+    // navId so the order is total and stable.
+    .sort(
+      (a, b) =>
+        a.order - b.order ||
+        (a.label < b.label ? -1 : a.label > b.label ? 1 : 0) ||
+        (a.pluginId < b.pluginId ? -1 : a.pluginId > b.pluginId ? 1 : 0) ||
+        (a.navId < b.navId ? -1 : a.navId > b.navId ? 1 : 0),
     );
 
   const byCluster = new Map<string, ResolvedLeaf[]>();
   const topLevel: ResolvedLeaf[] = [];
+  // Two plugins can legitimately register the same href. Rendering both
+  // would duplicate the React key (`key={item.href}`) and light up two
+  // entries as active. First wins, deterministically, by the sort above.
+  const claimed = new Set<string>();
   for (const entry of ordered) {
+    if (claimed.has(entry.href)) continue;
+    claimed.add(entry.href);
     const leaf: ResolvedLeaf = { href: entry.href, label: entry.label };
     if (entry.cluster !== undefined && clusterKeys.has(entry.cluster)) {
       const bucket = byCluster.get(entry.cluster) ?? [];
@@ -168,6 +183,11 @@ function collectLeaves(items: readonly ResolvedNavItem[]): readonly ResolvedLeaf
   return out;
 }
 
+/**
+ * Longest-prefix match on *segment boundaries*. A bare `startsWith` would
+ * light up `/admin` while the operator is on `/administrator`, and a plugin
+ * leaf `/reports` would claim `/reports-old`.
+ */
 export function bestPrefixMatch(
   pathname: string | null,
   leaves: readonly ResolvedLeaf[],
@@ -177,7 +197,8 @@ export function bestPrefixMatch(
     const match =
       candidate.href === '/'
         ? pathname === '/'
-        : pathname.startsWith(candidate.href);
+        : pathname === candidate.href ||
+          pathname.startsWith(`${candidate.href}/`);
     if (!match) return acc;
     return candidate.href.length > acc.length ? candidate.href : acc;
   }, '');

--- a/web-ui/app/_lib/__tests__/navMerge.test.ts
+++ b/web-ui/app/_lib/__tests__/navMerge.test.ts
@@ -131,6 +131,39 @@ describe('mergeNav', () => {
     ]);
   });
 
+  it('drops a duplicate href contributed by a second plugin', () => {
+    // Rendering both would duplicate the React key (`key={item.href}`) and
+    // light up two entries as active.
+    const merged = mergeNav(
+      STATIC,
+      [
+        entry({ pluginId: '@a/first', href: '/shared', label: 'First', order: 1 }),
+        entry({ pluginId: '@b/second', href: '/shared', label: 'Second', order: 2 }),
+      ],
+      translate,
+    );
+    const shared = merged.filter((i) => i.kind === 'link' && i.href === '/shared');
+    expect(shared).toHaveLength(1);
+    expect(shared[0]).toMatchObject({ label: 'First' });
+  });
+
+  it('orders equal-order entries deterministically, without a locale collator', () => {
+    // localeCompare can order the same pair differently under Node's ICU
+    // than under the visitor's browser, which would be a hydration mismatch.
+    const merged = mergeNav(
+      STATIC,
+      [
+        entry({ navId: 'z', href: '/z', label: 'Ähnlich', order: 1 }),
+        entry({ navId: 'a', href: '/a', label: 'Zebra', order: 1 }),
+      ],
+      translate,
+    );
+    // Plain codepoint order puts 'Z' (U+005A) before 'Ä' (U+00C4).
+    expect(
+      merged.filter((i) => i.kind === 'link').map((i) => i.href),
+    ).toEqual(['/', '/a', '/z']);
+  });
+
   it('splits entries across their clusters and top level in one pass', () => {
     const merged = mergeNav(
       STATIC,
@@ -162,6 +195,13 @@ describe('bestPrefixMatch', () => {
     expect(bestPrefixMatch('/admin/dev-platform/jobs/42', leaves)).toBe(
       '/admin/dev-platform',
     );
+  });
+
+  it('matches only on segment boundaries', () => {
+    // A bare startsWith would light up /admin while on /administrator, and
+    // let a plugin leaf /reports claim /reports-old.
+    expect(bestPrefixMatch('/administrator', leaves)).toBe('');
+    expect(bestPrefixMatch('/admin/dev-platform-old', leaves)).toBe('/admin');
   });
 
   it('returns empty for an unmatched path and for a null pathname', () => {

--- a/web-ui/app/_lib/__tests__/navMerge.test.ts
+++ b/web-ui/app/_lib/__tests__/navMerge.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+
+import { bestPrefixMatch, mergeNav } from '../../_components/Nav';
+import type { NavEntryDto } from '../navigation';
+
+/**
+ * Merge of the shell's static nav with plugin-contributed entries
+ * (specs/470-dev-platform-plugin). Pure logic — no DOM.
+ */
+
+type StaticItem = Parameters<typeof mergeNav>[0][number];
+
+const STATIC: readonly StaticItem[] = [
+  { kind: 'link', href: '/', key: 'dashboard' },
+  {
+    kind: 'cluster',
+    key: 'adminCluster',
+    children: [
+      { kind: 'link', href: '/admin', key: 'admin' },
+      { kind: 'link', href: '/system', key: 'system' },
+    ],
+  },
+];
+
+/** Stand-in for next-intl's `t` — echoes the key so assertions stay readable. */
+const translate = (key: string): string => `T:${key}`;
+
+function entry(over: Partial<NavEntryDto> = {}): NavEntryDto {
+  return {
+    pluginId: '@plugin/dev',
+    navId: 'devPlatform',
+    href: '/admin/dev-platform',
+    label: 'Dev Platform',
+    order: 100,
+    ...over,
+  };
+}
+
+describe('mergeNav', () => {
+  it('renders the static nav unchanged when no plugin contributes', () => {
+    const merged = mergeNav(STATIC, [], translate);
+    expect(merged).toEqual([
+      { kind: 'link', href: '/', label: 'T:dashboard' },
+      {
+        kind: 'cluster',
+        key: 'adminCluster',
+        label: 'T:adminCluster',
+        children: [
+          { href: '/admin', label: 'T:admin' },
+          { href: '/system', label: 'T:system' },
+        ],
+      },
+    ]);
+  });
+
+  it('appends a plugin entry inside the cluster it names', () => {
+    const merged = mergeNav(STATIC, [entry({ cluster: 'adminCluster' })], translate);
+    const cluster = merged.find((i) => i.kind === 'cluster');
+    expect(cluster?.kind === 'cluster' && cluster.children).toEqual([
+      { href: '/admin', label: 'T:admin' },
+      { href: '/system', label: 'T:system' },
+      { href: '/admin/dev-platform', label: 'Dev Platform' },
+    ]);
+  });
+
+  it('uses the plugin-supplied label verbatim, not a catalogue lookup', () => {
+    const merged = mergeNav(
+      STATIC,
+      [entry({ cluster: 'adminCluster', label: 'Dev-Plattform' })],
+      translate,
+    );
+    const cluster = merged.find((i) => i.kind === 'cluster');
+    expect(cluster?.kind === 'cluster' && cluster.children.at(-1)?.label).toBe(
+      'Dev-Plattform',
+    );
+  });
+
+  it('promotes a clusterless entry to top level', () => {
+    const merged = mergeNav(STATIC, [entry({ href: '/reports', label: 'Reports' })], translate);
+    expect(merged.at(-1)).toEqual({
+      kind: 'link',
+      href: '/reports',
+      label: 'Reports',
+    });
+  });
+
+  it('promotes an entry naming an unknown cluster rather than dropping it', () => {
+    // Shell/plugin version skew must not silently swallow a menu item.
+    const merged = mergeNav(
+      STATIC,
+      [entry({ cluster: 'clusterThatDoesNotExist' })],
+      translate,
+    );
+    expect(merged.at(-1)).toEqual({
+      kind: 'link',
+      href: '/admin/dev-platform',
+      label: 'Dev Platform',
+    });
+  });
+
+  it('drops a plugin entry that collides with a static href', () => {
+    // A plugin must not be able to shadow a core destination with its own label.
+    const merged = mergeNav(
+      STATIC,
+      [entry({ href: '/admin', label: 'Totally Legit Admin' })],
+      translate,
+    );
+    const labels = merged.flatMap((i) =>
+      i.kind === 'cluster' ? i.children.map((c) => c.label) : [i.label],
+    );
+    expect(labels).not.toContain('Totally Legit Admin');
+    expect(labels).toContain('T:admin');
+  });
+
+  it('sorts plugin entries by order, then label — without reordering static items', () => {
+    const merged = mergeNav(
+      STATIC,
+      [
+        entry({ navId: 'c', href: '/c', label: 'C', order: 10 }),
+        entry({ navId: 'b', href: '/b', label: 'B', order: 5 }),
+        entry({ navId: 'a', href: '/a', label: 'A', order: 10 }),
+      ],
+      translate,
+    );
+    expect(merged.map((i) => (i.kind === 'link' ? i.href : i.key))).toEqual([
+      '/',
+      'adminCluster',
+      '/b',
+      '/a',
+      '/c',
+    ]);
+  });
+
+  it('splits entries across their clusters and top level in one pass', () => {
+    const merged = mergeNav(
+      STATIC,
+      [
+        entry({ navId: 'inCluster', cluster: 'adminCluster' }),
+        entry({ navId: 'topLevel', href: '/reports', label: 'Reports' }),
+      ],
+      translate,
+    );
+    const cluster = merged.find((i) => i.kind === 'cluster');
+    expect(cluster?.kind === 'cluster' && cluster.children).toHaveLength(3);
+    expect(merged.at(-1)).toMatchObject({ href: '/reports' });
+  });
+});
+
+describe('bestPrefixMatch', () => {
+  const leaves = [
+    { href: '/', label: 'Dashboard' },
+    { href: '/admin', label: 'Admin' },
+    { href: '/admin/dev-platform', label: 'Dev Platform' },
+  ];
+
+  it('matches the root exactly, never as a prefix', () => {
+    expect(bestPrefixMatch('/', leaves)).toBe('/');
+    expect(bestPrefixMatch('/admin', leaves)).toBe('/admin');
+  });
+
+  it('prefers the longest matching prefix, including a plugin leaf', () => {
+    expect(bestPrefixMatch('/admin/dev-platform/jobs/42', leaves)).toBe(
+      '/admin/dev-platform',
+    );
+  });
+
+  it('returns empty for an unmatched path and for a null pathname', () => {
+    expect(bestPrefixMatch('/nowhere', leaves)).toBe('');
+    expect(bestPrefixMatch(null, leaves)).toBe('');
+  });
+
+  it('stops highlighting a plugin leaf once the plugin is gone', () => {
+    const withoutPlugin = leaves.filter((l) => l.href !== '/admin/dev-platform');
+    expect(bestPrefixMatch('/admin/dev-platform/jobs/42', withoutPlugin)).toBe(
+      '/admin',
+    );
+  });
+});

--- a/web-ui/app/_lib/__tests__/navParse.test.ts
+++ b/web-ui/app/_lib/__tests__/navParse.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseEntries } from '../navigation';
+
+/**
+ * The shell re-applies the middleware's nav rules rather than trusting them
+ * to have run. The middleware is the enforcement point, but it is a
+ * separate deployable — version skew, a partial rollout, or a compromised
+ * control plane must not be able to put an off-origin link or
+ * header-breaking chrome into the trusted header.
+ */
+
+const ok = {
+  pluginId: 'core:dev-platform',
+  navId: 'devPlatform',
+  href: '/admin/dev-platform',
+  label: 'Dev Platform',
+  order: 50,
+  cluster: 'adminCluster',
+};
+
+const wrap = (...entries: unknown[]): unknown => ({ locale: 'en', entries });
+
+describe('parseEntries', () => {
+  it('accepts a well-formed entry', () => {
+    expect(parseEntries(wrap(ok))).toEqual([ok]);
+  });
+
+  it('returns empty for malformed envelopes', () => {
+    expect(parseEntries(null)).toEqual([]);
+    expect(parseEntries({})).toEqual([]);
+    expect(parseEntries({ entries: 'nope' })).toEqual([]);
+    expect(parseEntries(wrap(null, 42, 'x'))).toEqual([]);
+  });
+
+  it('drops entries with missing or mistyped required fields', () => {
+    expect(parseEntries(wrap({ ...ok, href: undefined }))).toEqual([]);
+    expect(parseEntries(wrap({ ...ok, label: 123 }))).toEqual([]);
+    expect(parseEntries(wrap({ ...ok, pluginId: null }))).toEqual([]);
+    expect(parseEntries(wrap({ ...ok, cluster: 7 }))).toEqual([]);
+  });
+
+  it('drops off-origin and non-canonical hrefs', () => {
+    for (const href of [
+      '//evil.example',
+      '/\\evil.example',
+      'https://evil.example',
+      'javascript:alert(1)',
+      '/x/%2e%2e/admin',
+      '/x/../admin',
+      '/admin/',
+      '/admin?a=1',
+      '/admin#x',
+      `/${'a'.repeat(300)}`,
+    ]) {
+      expect(parseEntries(wrap({ ...ok, href })), href).toEqual([]);
+    }
+  });
+
+  it('drops labels that could spoof or break the header', () => {
+    const cases = [
+      '',
+      '   ',
+      'x'.repeat(41),
+      `Safe${String.fromCharCode(0x202e)}nimdA`, // RTL override
+      `Ad${String.fromCharCode(0x200b)}min`, // zero-width space
+      `Dev${String.fromCharCode(0)}Platform`, // NUL
+    ];
+    for (const label of cases) {
+      expect(parseEntries(wrap({ ...ok, label })), JSON.stringify(label)).toEqual(
+        [],
+      );
+    }
+  });
+
+  it('normalises a non-finite order rather than poisoning the sort', () => {
+    // JSON.parse('{"order":1e400}') yields Infinity, which is a number and
+    // would make every comparison in the merge sort return NaN-ish results.
+    const infinite = JSON.parse('{"order":1e400}') as { order: number };
+    expect(infinite.order).toBe(Infinity);
+    const parsed = parseEntries(wrap({ ...ok, order: infinite.order }));
+    expect(parsed[0]?.order).toBe(100);
+  });
+
+  it('defaults a missing order instead of dropping the entry', () => {
+    const noOrder: Partial<typeof ok> = { ...ok };
+    delete noOrder.order;
+    expect(parseEntries(wrap(noOrder))[0]?.order).toBe(100);
+  });
+
+  it('omits cluster when absent rather than emitting undefined', () => {
+    const noCluster: Partial<typeof ok> = { ...ok };
+    delete noCluster.cluster;
+    expect(Object.hasOwn(parseEntries(wrap(noCluster))[0] ?? {}, 'cluster')).toBe(
+      false,
+    );
+  });
+
+  it('caps how many entries it will accept', () => {
+    const many = Array.from({ length: 250 }, (_, i) => ({
+      ...ok,
+      navId: `n${String(i)}`,
+      href: `/p${String(i)}`,
+    }));
+    expect(parseEntries(wrap(...many))).toHaveLength(100);
+  });
+
+  it('keeps the good entries when one is malformed', () => {
+    const parsed = parseEntries(wrap(ok, { ...ok, href: '//evil.example' }));
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.href).toBe('/admin/dev-platform');
+  });
+});

--- a/web-ui/app/_lib/navigation.ts
+++ b/web-ui/app/_lib/navigation.ts
@@ -1,0 +1,123 @@
+/**
+ * Plugin-contributed navigation entries (`GET /api/v1/ui/navigation`).
+ *
+ * The shell ships a static nav for its own compiled surfaces and merges
+ * this for anything a plugin adds, so a feature's menu entry can travel
+ * with the plugin that owns it instead of being hardcoded in `Nav.tsx`.
+ *
+ * Fetched server-side from the root layout, deliberately:
+ *   - labels are resolved by the middleware for the locale the server
+ *     already knows, so there is no second i18n clock to drift out of
+ *     sync with next-intl on a locale switch;
+ *   - the nav renders correct on first paint, with no post-hydration
+ *     mutation of the header.
+ *
+ * `botApi` + `forwardCookieHeader` mirror `_lib/agents.ts` — they are
+ * file-private there, and exporting them would mean changing an unrelated
+ * module's public surface. Keep the three in sync if the cookie / URL
+ * conventions ever change.
+ */
+
+function botApi(path: string): string {
+  if (typeof window !== 'undefined') {
+    return `/bot-api${path}`;
+  }
+  const base = process.env['MIDDLEWARE_URL'] ?? 'http://localhost:3979';
+  return `${base}/api${path}`;
+}
+
+async function forwardCookieHeader(): Promise<Record<string, string>> {
+  if (typeof window !== 'undefined') return {};
+  try {
+    const mod = await import('next/headers');
+    const jar = await mod.cookies();
+    const cookieHeader = jar
+      .getAll()
+      .map((c) => `${c.name}=${c.value}`)
+      .join('; ');
+    return cookieHeader ? { cookie: cookieHeader } : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * One entry in the operator nav, contributed by a plugin. `label` is
+ * already resolved for the requested locale by the middleware.
+ */
+export interface NavEntryDto {
+  readonly pluginId: string;
+  readonly navId: string;
+  readonly href: string;
+  readonly cluster?: string;
+  readonly order: number;
+  readonly label: string;
+}
+
+/**
+ * Defensive parse. The nav is chrome on every page, so a malformed or
+ * partial response must degrade to "no plugin entries" rather than throw
+ * and take the whole layout down with it. The middleware validates these
+ * fields at registration time; this is the second half of that contract,
+ * enforced at the trust boundary.
+ */
+function parseEntries(payload: unknown): readonly NavEntryDto[] {
+  if (typeof payload !== 'object' || payload === null) return [];
+  const raw = (payload as { entries?: unknown }).entries;
+  if (!Array.isArray(raw)) return [];
+
+  const out: NavEntryDto[] = [];
+  for (const item of raw) {
+    if (typeof item !== 'object' || item === null) continue;
+    const e = item as Record<string, unknown>;
+    const { pluginId, navId, href, label, order, cluster } = e;
+    if (
+      typeof pluginId !== 'string' ||
+      typeof navId !== 'string' ||
+      typeof label !== 'string' ||
+      typeof href !== 'string' ||
+      label.length === 0
+    ) {
+      continue;
+    }
+    // Never render a link the middleware would not have accepted: in-app
+    // paths only, so a compromised or buggy plugin cannot point the
+    // trusted header off-origin.
+    if (!href.startsWith('/') || href.startsWith('//') || href.startsWith('/\\')) {
+      continue;
+    }
+    out.push({
+      pluginId,
+      navId,
+      href,
+      label,
+      order: typeof order === 'number' ? order : 100,
+      ...(typeof cluster === 'string' ? { cluster } : {}),
+    });
+  }
+  return out;
+}
+
+/**
+ * Fetch the plugin-contributed nav for `locale`. Never throws and never
+ * redirects: an unauthenticated visitor (login, setup) or an unreachable
+ * middleware simply gets an empty list, and the shell renders its static
+ * nav alone.
+ */
+export async function fetchNavEntries(
+  locale: string,
+): Promise<readonly NavEntryDto[]> {
+  try {
+    const res = await fetch(
+      botApi(`/v1/ui/navigation?locale=${encodeURIComponent(locale)}`),
+      {
+        headers: await forwardCookieHeader(),
+        cache: 'no-store',
+      },
+    );
+    if (!res.ok) return [];
+    return parseEntries((await res.json()) as unknown);
+  } catch {
+    return [];
+  }
+}

--- a/web-ui/app/_lib/navigation.ts
+++ b/web-ui/app/_lib/navigation.ts
@@ -54,20 +54,59 @@ export interface NavEntryDto {
   readonly label: string;
 }
 
+/** Mirrors the middleware's limits — see platform/uiRouteCatalog.ts. */
+const MAX_LABEL_LENGTH = 40;
+const MAX_HREF_LENGTH = 256;
+const MAX_ENTRIES = 100;
+const HREF_SEGMENT = /^[A-Za-z0-9\-._~]+$/;
+
+/** Control, bidi-formatting and zero-width codepoints. */
+function hasUnsafeChars(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code <= 0x1f) return true;
+    if (code >= 0x7f && code <= 0x9f) return true;
+    if (code === 0x061c) return true;
+    if (code === 0x200e || code === 0x200f) return true;
+    if (code >= 0x202a && code <= 0x202e) return true;
+    if (code >= 0x2066 && code <= 0x2069) return true;
+    if (code >= 0x200b && code <= 0x200d) return true;
+    if (code === 0x2060 || code === 0xfeff) return true;
+  }
+  return false;
+}
+
+/** Canonical in-app path, same rule the middleware enforces. */
+function isCanonicalInAppHref(href: string): boolean {
+  if (href.length === 0 || href.length > MAX_HREF_LENGTH) return false;
+  if (!href.startsWith('/')) return false;
+  if (href === '/') return true;
+  return href
+    .slice(1)
+    .split('/')
+    .every((s) => s !== '.' && s !== '..' && HREF_SEGMENT.test(s));
+}
+
 /**
  * Defensive parse. The nav is chrome on every page, so a malformed or
  * partial response must degrade to "no plugin entries" rather than throw
- * and take the whole layout down with it. The middleware validates these
- * fields at registration time; this is the second half of that contract,
- * enforced at the trust boundary.
+ * and take the whole layout down with it.
+ *
+ * This re-applies the middleware's rules rather than trusting them to have
+ * run. The middleware is the enforcement point, but it is a *separate
+ * deployable* — a version skew, a partial rollout, or a compromised
+ * control plane must not be able to put an off-origin link or a
+ * header-breaking label into the shell's chrome. Anything that fails is
+ * dropped silently; a missing menu entry is a far better outcome than a
+ * malicious one.
  */
-function parseEntries(payload: unknown): readonly NavEntryDto[] {
+export function parseEntries(payload: unknown): readonly NavEntryDto[] {
   if (typeof payload !== 'object' || payload === null) return [];
   const raw = (payload as { entries?: unknown }).entries;
   if (!Array.isArray(raw)) return [];
 
   const out: NavEntryDto[] = [];
-  for (const item of raw) {
+  for (const item of raw.slice(0, MAX_ENTRIES)) {
     if (typeof item !== 'object' || item === null) continue;
     const e = item as Record<string, unknown>;
     const { pluginId, navId, href, label, order, cluster } = e;
@@ -75,23 +114,24 @@ function parseEntries(payload: unknown): readonly NavEntryDto[] {
       typeof pluginId !== 'string' ||
       typeof navId !== 'string' ||
       typeof label !== 'string' ||
-      typeof href !== 'string' ||
-      label.length === 0
+      typeof href !== 'string'
     ) {
       continue;
     }
-    // Never render a link the middleware would not have accepted: in-app
-    // paths only, so a compromised or buggy plugin cannot point the
-    // trusted header off-origin.
-    if (!href.startsWith('/') || href.startsWith('//') || href.startsWith('/\\')) {
-      continue;
-    }
+    if (label.trim().length === 0 || label.length > MAX_LABEL_LENGTH) continue;
+    if (hasUnsafeChars(label) || hasUnsafeChars(href)) continue;
+    if (!isCanonicalInAppHref(href)) continue;
+    if (cluster !== undefined && typeof cluster !== 'string') continue;
+    // `JSON.parse('{"order":1e400}')` yields Infinity, which is a number —
+    // it would poison every comparison in the merge sort.
+    const resolvedOrder =
+      typeof order === 'number' && Number.isFinite(order) ? order : 100;
     out.push({
       pluginId,
       navId,
       href,
       label,
-      order: typeof order === 'number' ? order : 100,
+      order: resolvedOrder,
       ...(typeof cluster === 'string' ? { cluster } : {}),
     });
   }
@@ -99,10 +139,22 @@ function parseEntries(payload: unknown): readonly NavEntryDto[] {
 }
 
 /**
+ * Hard ceiling on how long the nav lookup may delay a page render.
+ *
+ * This runs in the root layout, so it is on the critical path of EVERY
+ * page. An unbounded fetch would let a hung or half-open middleware stall
+ * the entire UI rather than degrade one menu. Two seconds is far above the
+ * real cost (an in-memory map walk on the same host) and far below any
+ * user-visible stall budget.
+ */
+const NAV_FETCH_TIMEOUT_MS = 2_000;
+
+/**
  * Fetch the plugin-contributed nav for `locale`. Never throws and never
- * redirects: an unauthenticated visitor (login, setup) or an unreachable
- * middleware simply gets an empty list, and the shell renders its static
- * nav alone.
+ * redirects: an unauthenticated visitor (login, setup), an unreachable or
+ * slow middleware, or a malformed response all yield an empty list, and
+ * the shell renders its static nav alone. Losing a plugin's menu entry is
+ * an acceptable degradation; losing the page is not.
  */
 export async function fetchNavEntries(
   locale: string,
@@ -113,6 +165,7 @@ export async function fetchNavEntries(
       {
         headers: await forwardCookieHeader(),
         cache: 'no-store',
+        signal: AbortSignal.timeout(NAV_FETCH_TIMEOUT_MS),
       },
     );
     if (!res.ok) return [];

--- a/web-ui/app/admin/page.tsx
+++ b/web-ui/app/admin/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
+
+import { fetchNavEntries } from '../_lib/navigation';
 
 export const dynamic = 'force-dynamic';
 
@@ -19,7 +21,18 @@ export async function generateMetadata(): Promise<Metadata> {
  * advertised here — the canonical Builder entry point is the Plugins nav
  * (`/store/builder`).
  */
-type CardDef = { readonly href: string; readonly key: string; readonly danger?: boolean };
+type CardDef = {
+  readonly href: string;
+  readonly key: string;
+  readonly danger?: boolean;
+  /**
+   * Marks a card as belonging to an optional feature: it renders only when
+   * a plugin has contributed a nav entry for this href. Keeps the grid
+   * honest about what is actually installed instead of linking to a page
+   * that would answer 403 — see specs/470-dev-platform-plugin.
+   */
+  readonly requiresNavHref?: boolean;
+};
 type GroupDef = { readonly key: string; readonly cards: readonly CardDef[] };
 
 const GROUPS: readonly GroupDef[] = [
@@ -49,8 +62,10 @@ const GROUPS: readonly GroupDef[] = [
       { href: '/admin/domains', key: 'domains' },
       { href: '/admin/registries', key: 'registries' },
       { href: '/admin/mcp', key: 'mcp' },
-      // Dev platform (epic #470) — isolated per-job code runners.
-      { href: '/admin/dev-platform', key: 'devPlatform' },
+      // Dev platform (epic #470) — isolated per-job code runners. Optional:
+      // shown only while the feature is enabled and contributing its nav
+      // entry, so the grid matches the menu.
+      { href: '/admin/dev-platform', key: 'devPlatform', requiresNavHref: true },
     ],
   },
   {
@@ -68,6 +83,16 @@ const GROUPS: readonly GroupDef[] = [
 
 export default async function AdminIndexPage(): Promise<React.ReactElement> {
   const t = await getTranslations('admin.index');
+  const locale = await getLocale();
+  const availableHrefs = new Set(
+    (await fetchNavEntries(locale)).map((e) => e.href),
+  );
+  const groups = GROUPS.map((group) => ({
+    ...group,
+    cards: group.cards.filter(
+      (card) => card.requiresNavHref !== true || availableHrefs.has(card.href),
+    ),
+  })).filter((group) => group.cards.length > 0);
   return (
     <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-8">
@@ -80,7 +105,7 @@ export default async function AdminIndexPage(): Promise<React.ReactElement> {
       </header>
 
       <div className="flex flex-col gap-10">
-        {GROUPS.map((group) => (
+        {groups.map((group) => (
           <section key={group.key}>
             <h2 className="mb-3 text-xs font-semibold tracking-wider text-[color:var(--fg-muted)] uppercase">
               {t(`groups.${group.key}.heading`)}

--- a/web-ui/app/admin/page.tsx
+++ b/web-ui/app/admin/page.tsx
@@ -27,11 +27,14 @@ type CardDef = {
   readonly danger?: boolean;
   /**
    * Marks a card as belonging to an optional feature: it renders only when
-   * a plugin has contributed a nav entry for this href. Keeps the grid
-   * honest about what is actually installed instead of linking to a page
-   * that would answer 403 — see specs/470-dev-platform-plugin.
+   * *this specific* plugin has contributed a nav entry for this href. Keeps
+   * the grid honest about what is actually installed instead of linking to
+   * a page that would answer 403 — see specs/470-dev-platform-plugin.
+   *
+   * Matching on the contributing plugin id, not just the href, so an
+   * unrelated plugin cannot resurrect a core card by claiming the path.
    */
-  readonly requiresNavHref?: boolean;
+  readonly requiresNavFrom?: string;
 };
 type GroupDef = { readonly key: string; readonly cards: readonly CardDef[] };
 
@@ -65,7 +68,11 @@ const GROUPS: readonly GroupDef[] = [
       // Dev platform (epic #470) — isolated per-job code runners. Optional:
       // shown only while the feature is enabled and contributing its nav
       // entry, so the grid matches the menu.
-      { href: '/admin/dev-platform', key: 'devPlatform', requiresNavHref: true },
+      {
+        href: '/admin/dev-platform',
+        key: 'devPlatform',
+        requiresNavFrom: 'core:dev-platform',
+      },
     ],
   },
   {
@@ -84,13 +91,15 @@ const GROUPS: readonly GroupDef[] = [
 export default async function AdminIndexPage(): Promise<React.ReactElement> {
   const t = await getTranslations('admin.index');
   const locale = await getLocale();
-  const availableHrefs = new Set(
-    (await fetchNavEntries(locale)).map((e) => e.href),
+  const contributed = new Set(
+    (await fetchNavEntries(locale)).map((e) => `${e.pluginId}::${e.href}`),
   );
   const groups = GROUPS.map((group) => ({
     ...group,
     cards: group.cards.filter(
-      (card) => card.requiresNavHref !== true || availableHrefs.has(card.href),
+      (card) =>
+        card.requiresNavFrom === undefined ||
+        contributed.has(`${card.requiresNavFrom}::${card.href}`),
     ),
   })).filter((group) => group.cards.length > 0);
   return (

--- a/web-ui/app/layout.tsx
+++ b/web-ui/app/layout.tsx
@@ -15,6 +15,7 @@ import { StreamRunner } from './_components/StreamRunner';
 import { StreamToasts } from './_components/StreamToasts';
 import { ChatSessionsProvider } from './_lib/chatSessionsContext';
 import { StreamStoreProvider } from './_lib/streamStore';
+import { fetchNavEntries } from './_lib/navigation';
 import { UI_PREFS_COOKIE, parseUiPrefsCookie } from './_lib/uiPrefs';
 import './globals.css';
 
@@ -94,6 +95,11 @@ export default async function RootLayout({
   const messages = await getMessages();
   const t = await getTranslations('layout');
   const jar = await cookies();
+  // Plugin-contributed menu entries, resolved for this locale server-side so
+  // the nav is correct on first paint and stays on next-intl's single i18n
+  // clock. Never throws — an unauthenticated visitor or an unreachable
+  // middleware yields an empty list and the static nav renders alone.
+  const navEntries = await fetchNavEntries(locale);
   const { palette, theme } = parseUiPrefsCookie(jar.get(UI_PREFS_COOKIE)?.value);
   return (
     <html
@@ -124,7 +130,7 @@ export default async function RootLayout({
                     </span>
                   </Link>
                   <div className="ml-auto flex items-center gap-4">
-                    <Nav />
+                    <Nav entries={navEntries} />
                     <span
                       className="hidden h-5 w-px bg-[color:var(--border)] sm:block"
                       aria-hidden

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -411,8 +411,7 @@
     "agentsOverview": "Übersicht",
     "channels": "Channels",
     "pluginsCluster": "Plugins",
-    "adminCluster": "Admin",
-    "devPlatform": "Dev-Plattform"
+    "adminCluster": "Admin"
   },
   "conductor": {
     "title": "Conductor",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -411,8 +411,7 @@
     "agentsOverview": "Overview",
     "channels": "Channels",
     "pluginsCluster": "Plugins",
-    "adminCluster": "Admin",
-    "devPlatform": "Dev Platform"
+    "adminCluster": "Admin"
   },
   "conductor": {
     "title": "Conductor",


### PR DESCRIPTION
Phase 1 of extracting the Dev Platform into an installable plugin. Ships the one capability the extraction cannot be done without, fixes a live bug found while mapping it, and lands the full plan. **No dev-platform code moves here** — deliberately, so the visible win is not coupled to the riskiest steps.

Plan: `specs/470-dev-platform-plugin/plan.md`

## Why this first

The investigation found the plugin API simply cannot express what Dev Platform needs: no nav contribution, no plugin-owned tables, no React-in-a-ZIP, no sidecar declaration. So "extract it as a plugin" is gated on building platform capabilities first. Navigation is the one with no dependency on the migration/auth/service-inversion minefield, and it is the user-visible promise — a plugin that brings its own menu.

## What's in it

**Nav contribution API.** `ctx.uiRoutes.registerNav({ navId, href, cluster?, order?, label })`, backed by `UiRouteCatalog` and served by a session-gated `GET /api/v1/ui/navigation?locale=<l>`.

Extends the existing `UiRouteCatalog` rather than adding a third catalog beside it and `admin_ui_path`. Nav entries are a *separate registration* from uiRoute descriptors because the path semantics differ — a descriptor is relative to the plugin's `/p/<pluginId>` mount, a nav entry is an absolute in-app path. One registration carrying both would make one of the two fields a lie.

Labels are resolved server-side for the requested locale and fetched in the root layout, so the shell stays on next-intl's single i18n clock. A client fetch of pre-resolved strings would lag next-intl on a locale switch and render a half-translated nav, plus shift the header after hydration.

**Dev Platform is the first consumer.** Its menu entry and `/admin` grid card now come from that registration instead of `Nav.tsx`'s literal. Turn `DEV_PLATFORM_ENABLED` off and both are gone with no frontend rebuild. When the plugin package lands, the call becomes `ctx.uiRoutes.registerNav(...)` inside its `activate()` and nothing about the shell changes.

**Bug fix: deactivated plugins kept serving their routes.** `ToolPluginRuntime.deactivate()` stopped jobs and disposed UI routes but never called `pluginRouteRegistry.disposeBySource()`, though it held the dependency and threaded it into every plugin context — `DynamicAgentRuntime` already did. Express cannot unmount, so an uninstalled plugin's routers stayed live and shadowed later mounts at the same prefix.

This is a prerequisite, not a drive-by: "with the plugin not installed, no dev-platform code paths" is unverifiable while routers outlive their plugin. The regression test fails 3/4 without the one-line fix.

## Security posture

Everything a plugin supplies renders inside the shell's trusted header, so it is all treated as untrusted input:

- **hrefs must already be canonical.** Validating the raw string is not enough — the "core destinations win" rule compares hrefs for equality, and `/x/%2e%2e/admin`, `/admin/`, `/admin?a=1`, `/admin#x` all navigate to Admin while comparing unequal to `/admin`. Only unreserved-charset segments, no dot-segments, no trailing slash, no query, no fragment, no percent-encoding. For that subset, string equality and browser resolution agree.
- **Labels** are length-capped and screened for control, bidirectional-formatting and zero-width codepoints (Trojan-Source style spoofing of adjacent core entries). Homoglyphs are *not* prevented — noted as a known limitation.
- **Bounds** on href/navId/cluster length, locales per label, and entries per plugin, because the catalogue is serialised into every page's root-layout RSC payload.
- The web-ui re-applies these rules rather than trusting the middleware to have run them: it is a separate deployable, and version skew must not be able to put an off-origin link into the chrome.

## Review

Two adversarial passes on the plan before implementation, then two more on the diff (GPT-5.4 and GPT-5.6 via codex). They inverted one of my premises: I had claimed plugin routers get no auth, but `app.use('/api', requireAuth, ...)` runs *before* `pluginRouteRegistry.mountAll(app)`, so `/api`-prefixed plugin routes are already gated. The real gap is the inverse — no way to opt *out*, since `publicPaths` is a frozen literal. That matters a lot for the next phase: naively "deleting the two dev-platform exemptions" would 401 every runner phone-home and kill jobs in flight. It's now a blocking constraint in the plan.

The 5.6 pass additionally found the href-aliasing bypass, the missing bounds, dispose-ordering, an activate() rollback gap, hydration-unstable sorting, prefix matching without a segment boundary, and a defensive parser that did not actually enforce its contract. All fixed in the second commit; the plan records what was *not* fixed.

## Test plan

- [x] Middleware: 4,971 pass / 0 fail
- [x] web-ui: 344 pass / 0 fail
- [x] Typecheck clean both sides; lint 0 errors; `i18n:check` OK (3,183 keys, en/de parity)
- [x] New coverage: 48 catalog, 11 route, 6 disposal (`node:test`); 13 merge, 12 parse (vitest)
- [x] Disposal fix verified as a real regression test — fails 3/4 with the fix reverted
- [ ] Manual: toggle `DEV_PLATFORM_ENABLED` against a running stack and confirm the menu entry and admin card appear/disappear

### Note on suite flakiness

Adding test files made `registryInstallMerge` fail intermittently in the full run while passing in isolation. Investigated rather than assumed — a file containing nothing but 48 `assert.equal(1, 1)` tests at the same sort position reproduces it (2 of 3 runs), while the baseline is 3/3 clean. The race is latent in `registryInstallMerge` (which itself binds ~6 sockets) and is exposed by test-runner worker scheduling; any sufficiently large added file triggers it. **Pre-existing, not caused by this PR**, and matching the known "passes isolated, fails in the full suite" issue in this repo. My tests were nevertheless converted to run socket-free via `test/_helpers/httpInvoke.ts`, which drives the real Express pipeline through `app.handle` without binding a port. Follow-up owed on `registryInstallMerge` separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787863861&installation_model_id=428086&pr_number=536&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F536&signature=ede0b3f698df82c1260e5d74bacdfc2e8d7debb0911f7e0907d936d56b6247d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->