### PR TITLE
docs(470): plugins use Tailwind, so they ship no CSS (G7 reduced)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,31 @@ permissions:
 
 jobs:
   # ------------------------------------------------------------------
+  # Core-decoupling ratchet (epic #470). The Dev Platform is being
+  # extracted into its own repository; this fails if core re-acquires
+  # references to it. The count may fall freely and never rise without
+  # a hand-edited baseline, so the extraction cannot silently regress
+  # while it is in flight — and "finished" is machine-checked (count 0)
+  # rather than asserted.
+  # ------------------------------------------------------------------
+  decoupling:
+    name: core decoupling ratchet (#470)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - name: Ensure ripgrep
+        run: command -v rg >/dev/null || (sudo apt-get update && sudo apt-get install -y ripgrep)
+
+      - name: Check core is not re-coupling to the Dev Platform
+        run: node scripts/check-core-decoupling.mjs
+
+  # ------------------------------------------------------------------
   # Middleware: lint + typecheck + node:test against tsx
   # ------------------------------------------------------------------
   middleware:

--- a/scripts/check-core-decoupling.mjs
+++ b/scripts/check-core-decoupling.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+/**
+ * Core-decoupling ratchet for the Dev Platform extraction (epic #470).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `specs/470-dev-platform-plugin/core-decoupling-checklist.md` is a snapshot: it
+ * tells you what was coupled the day it was written, and it goes stale the
+ * moment anyone touches the tree. A checklist cannot tell you whether the
+ * extraction is *finished*, and it cannot stop core from quietly re-acquiring a
+ * dependency while the work is in flight.
+ *
+ * This does both, by counting references and refusing to let the count rise.
+ * Extraction is done when the count is zero — that is the definition, and it is
+ * machine-checked rather than asserted.
+ *
+ *   node scripts/check-core-decoupling.mjs            # verify against baseline
+ *   node scripts/check-core-decoupling.mjs --report   # per-zone breakdown
+ *   node scripts/check-core-decoupling.mjs --update   # lower the baseline
+ *
+ * `--update` only ever lowers it. Raising the baseline requires editing the
+ * committed value by hand, which is exactly the kind of change that should
+ * show up in a diff and be argued for in review.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const BASELINE_FILE = path.join(
+  REPO_ROOT,
+  'specs/470-dev-platform-plugin/decoupling-baseline.json',
+);
+
+/**
+ * Identifiers that only exist because the Dev Platform lives in core.
+ * Deliberately literal — a broad `/dev/i` would drown in false positives
+ * ("developer", "device", "devDependencies").
+ */
+const PATTERNS = [
+  'devplatform',
+  'dev-platform',
+  'devPlatform',
+  'DEV_PLATFORM',
+  'devJob',
+  'DevJob',
+  'dev_job',
+  'dev_repo',
+  'dev_github_app',
+  'dev_webhook',
+  'devRunner',
+  'dev-runner',
+  'DEV_RUNNER',
+  'DEV_FLY',
+  'DEV_JOB',
+  'DEV_WEBHOOK',
+  'DEV_EGRESS',
+  'DEV_ARTIFACT',
+  'devWebhook',
+  'devjobs',
+  'djr_',
+];
+
+/**
+ * Core-owned names that merely share the `DEV_` prefix. These are NOT
+ * dev-platform and must never be counted, or the ratchet can never reach zero.
+ */
+const NOT_DEV_PLATFORM = [
+  /DEV_ENDPOINTS_ENABLED/, // core dev-graph endpoints (/api/dev/*)
+  /devteam/i, // dashboard onboarding persona
+  /salesDev/, // builder persona template
+];
+
+/** Zones that must end up clean. Paths are repo-relative. */
+const ZONES = [
+  { name: 'middleware/src', path: 'middleware/src' },
+  { name: 'middleware/test', path: 'middleware/test' },
+  { name: 'middleware/packages', path: 'middleware/packages' },
+  { name: 'middleware/scripts', path: 'middleware/scripts' },
+  { name: 'middleware/sidecars', path: 'middleware/sidecars' },
+  { name: 'middleware/migrations', path: 'middleware/migrations' },
+  { name: 'middleware/package.json', path: 'middleware/package.json' },
+  { name: 'web-ui/app', path: 'web-ui/app' },
+  { name: 'web-ui/messages', path: 'web-ui/messages' },
+  { name: 'ci-workflows', path: '.github/workflows' },
+  { name: 'scripts', path: 'scripts' },
+  { name: 'compose', path: '.', globs: ['docker-compose*.yaml', 'Dockerfile'] },
+];
+
+/** Build output and vendored code regenerate; they are not source. */
+const EXCLUDE_GLOBS = [
+  '!**/node_modules/**',
+  '!**/dist/**',
+  '!**/.next/**',
+  '!**/*.tsbuildinfo',
+  '!**/package-lock.json',
+  '!**/*.map',
+];
+
+function rgCount(zone) {
+  const args = ['--no-config', '--no-heading', '--with-filename', '--line-number'];
+  for (const p of PATTERNS) args.push('-e', p);
+  for (const g of EXCLUDE_GLOBS) args.push('--glob', g);
+  if (zone.globs) for (const g of zone.globs) args.push('--glob', g);
+  args.push('--', zone.path);
+
+  let out = '';
+  try {
+    out = execFileSync('rg', args, {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch (err) {
+    // rg exits 1 when there are no matches — that is success here.
+    if (err.status === 1) return { count: 0, hits: [] };
+    throw err;
+  }
+
+  const hits = out
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .filter((line) => !NOT_DEV_PLATFORM.some((re) => re.test(line)));
+
+  return { count: hits.length, hits };
+}
+
+function scan() {
+  const zones = {};
+  let total = 0;
+  for (const zone of ZONES) {
+    if (!zone.globs && !existsSync(path.join(REPO_ROOT, zone.path))) {
+      zones[zone.name] = 0;
+      continue;
+    }
+    const { count } = rgCount(zone);
+    zones[zone.name] = count;
+    total += count;
+  }
+  return { total, zones };
+}
+
+function loadBaseline() {
+  if (!existsSync(BASELINE_FILE)) return null;
+  return JSON.parse(readFileSync(BASELINE_FILE, 'utf8'));
+}
+
+function saveBaseline(result) {
+  writeFileSync(
+    BASELINE_FILE,
+    `${JSON.stringify({ total: result.total, zones: result.zones }, null, 2)}\n`,
+  );
+}
+
+const mode = process.argv[2];
+const result = scan();
+
+if (mode === '--report') {
+  const baseline = loadBaseline();
+  console.log('Dev Platform references remaining in core\n');
+  for (const [name, count] of Object.entries(result.zones)) {
+    const was = baseline?.zones?.[name];
+    const delta = was === undefined ? '' : ` (baseline ${String(was)})`;
+    console.log(`  ${count === 0 ? 'CLEAN' : String(count).padStart(5)}  ${name}${delta}`);
+  }
+  console.log(`\n  TOTAL ${result.total}${baseline ? ` / baseline ${String(baseline.total)}` : ''}`);
+  console.log(
+    result.total === 0
+      ? '\nExtraction complete — core has no Dev Platform references.'
+      : '\nSee specs/470-dev-platform-plugin/core-decoupling-checklist.md',
+  );
+  process.exit(0);
+}
+
+if (mode === '--update') {
+  const baseline = loadBaseline();
+  if (baseline && result.total > baseline.total) {
+    console.error(
+      `refusing to raise the baseline: ${String(result.total)} > ${String(baseline.total)}.\n` +
+        'The ratchet only goes down. If a new coupling is genuinely required,\n' +
+        'edit the committed baseline by hand so it shows up in review.',
+    );
+    process.exit(1);
+  }
+  saveBaseline(result);
+  console.log(
+    `baseline updated: ${String(baseline?.total ?? 'none')} → ${String(result.total)}`,
+  );
+  process.exit(0);
+}
+
+const baseline = loadBaseline();
+if (!baseline) {
+  console.error(
+    `no baseline at ${path.relative(REPO_ROOT, BASELINE_FILE)} — run with --update to create one.`,
+  );
+  process.exit(1);
+}
+
+if (result.total > baseline.total) {
+  const worse = Object.entries(result.zones)
+    .filter(([name, count]) => count > (baseline.zones[name] ?? 0))
+    .map(([name, count]) => `  ${name}: ${String(baseline.zones[name] ?? 0)} → ${String(count)}`);
+  console.error(
+    `Core re-acquired Dev Platform references: ${String(baseline.total)} → ${String(result.total)}\n\n` +
+      `${worse.join('\n')}\n\n` +
+      'The Dev Platform is being extracted into its own repository (epic #470),\n' +
+      'so new references to it from core move the wrong way. If this is\n' +
+      'unavoidable, raise the baseline in the same commit and say why.\n' +
+      'Run `node scripts/check-core-decoupling.mjs --report` for the breakdown.',
+  );
+  process.exit(1);
+}
+
+if (result.total < baseline.total) {
+  console.log(
+    `Dev Platform references: ${String(baseline.total)} → ${String(result.total)} ` +
+      `(-${String(baseline.total - result.total)}). Run --update to lower the baseline.`,
+  );
+  process.exit(0);
+}
+
+console.log(
+  result.total === 0
+    ? 'Core is free of Dev Platform references.'
+    : `Dev Platform references held at ${String(result.total)}.`,
+);

--- a/specs/470-dev-platform-plugin/acceptance.md
+++ b/specs/470-dev-platform-plugin/acceptance.md
@@ -1,0 +1,174 @@
+# Acceptance — is it all extracted, and does it install?
+
+Two questions the other two documents do **not** answer:
+
+- `core-decoupling-checklist.md` enumerates **files**. You can move all ~200 of them and
+  still silently lose a feature — a file inventory cannot tell you a capability survived.
+- `plan.md` states success criteria in prose. Prose is not a probe.
+
+This file is the functional contract: every capability the Dev Platform provides today,
+who owns it after extraction, and **how you check it still works**. Extraction is done when
+every row passes *and* the decoupling ratchet reads zero.
+
+---
+
+## 1. What is automated today
+
+| Guard | What it proves | Status |
+|---|---|---|
+| `scripts/check-core-decoupling.mjs` + CI job `core decoupling ratchet (#470)` | Core does not re-acquire Dev Platform references while the extraction is in flight; "finished" is machine-checked (count 0), not asserted | **In place.** Baseline **3,171** across 12 zones |
+| `middleware/test/devplatform/**` (54 files) | The behaviour itself, at unit/integration level. These **move with the plugin** and must stay green in the new repo | In place, moves in P4 |
+| §2 capability matrix below | Nothing is silently dropped in the move | **Written here; not yet automated** |
+| §3 install/uninstall | The result is genuinely installable | **Not yet built** — needs P3/P4 |
+
+Run the ratchet:
+
+```bash
+node scripts/check-core-decoupling.mjs            # verify (CI runs this)
+node scripts/check-core-decoupling.mjs --report   # per-zone breakdown
+node scripts/check-core-decoupling.mjs --update   # lower the baseline (never raises)
+```
+
+The count may only fall. Raising it requires hand-editing the committed baseline, so a new
+coupling shows up in review instead of slipping in.
+
+---
+
+## 2. Capability matrix
+
+**34 HTTP endpoints, 3 chat tools, 1 plugin service, 4 background loops, 4 UI screens,
+1 chat surface, 1 CLI, 1 conductor step kind.** Every row must have an owner and a probe
+after extraction. `→` marks a capability whose *mechanism* has to exist in core first —
+those are the H1/H2/H3 blockers from the checklist.
+
+### 2.1 Operator REST — jobs (`/api/v1/admin/dev-platform`)
+
+| Capability | Endpoint | Probe |
+|---|---|---|
+| List jobs, filtered | `GET /jobs` | `curl` returns the seeded job |
+| Job detail | `GET /jobs/:id` | shape matches `DevJobDescriptor` |
+| Start a job | `POST /jobs` | row lands in `dev_jobs`, status `queued` |
+| Cancel | `POST /jobs/:id/cancel` | terminal status, runner torn down |
+| Retry | `POST /jobs/:id/retry` | new job with `retry_of` set |
+| Apply a diff | `POST /jobs/:id/apply` | diff policy still rejects a protected path |
+| Artifacts list / fetch | `GET /jobs/:id/artifacts`, `GET /artifacts/:id` | sha256 matches |
+| **Live job event tail** | `GET /jobs/:id/events` (SSE) | stream opens, replays from `Last-Event-ID`, closes on terminal |
+
+### 2.2 Operator REST — repos & credentials
+
+| Capability | Endpoint | Probe |
+|---|---|---|
+| CRUD repos | `GET/POST /repos`, `GET/PATCH/DELETE /repos/:id` | round-trip |
+| Branch-protection re-check | `POST /repos/:id/check` | verdict rows render |
+| List open issues | `GET /repos/:id/issues` | proxies the forge |
+| GitHub device flow | `POST /github/connect/{start,poll}` | user code issued, token vaulted |
+| Bind a GitHub App credential | `POST /repos/:repoId/credential` | credential kind flips to `github_app` |
+| GitHub App manifest onboarding | `POST /github-app/manifest/start`, `GET /github-apps` | app row created |
+| **App callback / setup** → | `GET /github-app/{callback,setup}` | **unauthenticated by design** — needs H1 |
+
+### 2.3 Human gates
+
+| Capability | Endpoint | Probe |
+|---|---|---|
+| Gate inbox | `GET /gates?status=waiting` | parked job appears |
+| Approve / reject | `POST /gates/:gateId/resolve` | non-holder gets 403; holder resumes the job |
+| Gate deadline sweep | background loop | an expired gate transitions without an operator |
+
+### 2.4 Runner phone-home (`/api/v1/dev-runner`) →
+
+**All seven need H1** — they authenticate with a `djr_` job token and no session, so they
+depend on a plugin being able to declare a public path *and* own its prefix exclusively.
+
+| Capability | Endpoint | Probe |
+|---|---|---|
+| Fetch job spec | `GET /jobs/:id/spec` | wrong token → 401 |
+| Scoped SCM token | `GET /jobs/:id/scm-token` | short-lived, revoked on terminal |
+| Stream events | `POST /jobs/:id/events` | appears in the SSE tail |
+| Heartbeat | `POST /jobs/:id/heartbeat` | missed heartbeat reaps the job |
+| Upload diff | `POST /jobs/:id/diff` | secret scan runs |
+| Phase / final result | `POST /jobs/:id/{phase-result,result}` | phase engine advances |
+| Daemon job policy | `GET /internal/job-policy/:jobId` | daemon token only; runner token rejected |
+| **LLM proxy** | `/llm` passthrough | model allowlist + token cap enforced, usage accounted |
+
+### 2.5 Triggers
+
+| Capability | Surface | Probe |
+|---|---|---|
+| **GitHub webhook** → | `POST /api/webhooks/github` | **needs G3 raw body** — HMAC verifies, replayed delivery GUID dedupes, per-repo/sender rate limit holds |
+| Issue-tracker polling | background loop | a labelled issue creates a job |
+| Comment-back | forge client | result posted to the issue |
+
+### 2.6 Chat & plugin surfaces
+
+| Capability | Surface | Probe |
+|---|---|---|
+| `dev_job_start` / `dev_job_status` / `dev_job_list` | orchestrator native tools | tool call creates/reads a job |
+| **`ctx.devJobs`** (create/get/list/listEvents) → | plugin service | **needs the G8 contract decision** — a third-party plugin still reaches dev jobs, scoped to granted repos |
+| **Chat job card** → | `chat/page.tsx` | **needs H3** — either the rich card still renders, or the accepted `ToolRow` degradation is what ships |
+| **Conductor `dev.job` step** → | workflow step kind | **needs H2** — a workflow parks on a dev job and resumes on its terminal outcome |
+
+### 2.7 Operator UI
+
+| Screen | Probe |
+|---|---|
+| Hub (`/admin/dev-platform`, tabs repos/jobs/apps/gates) | renders, deep-links per `?tab=` |
+| Job detail + phase rail + live log | SSE drives the rail |
+| Repo detail (budget, webhook, bind-app) | settings persist |
+| Add-repo wizard (`/repos/new`) | device flow completes |
+| Nav entry + admin card | **already dynamic** — contributed via `registerNav`, gone when inactive |
+
+### 2.8 Operations
+
+| Capability | Surface | Probe |
+|---|---|---|
+| Claim/lease/reap worker loop | background | a crashed job is re-adoptable |
+| Retention sweep | cron `17 3 * * *` | aged events pruned, audit retained |
+| Transcript / purge CLI | `scripts/dev-transcript.ts` | redaction applied |
+| **Boot safety refusals** | `SUBSCRIPTION_MODE`+`ACK`, `UNSAFE_LOCAL`+`UID` | **must become activation refusals** — misconfiguration must still fail closed, not silently activate |
+
+---
+
+## 3. Install / uninstall acceptance
+
+None of this is built yet. It is the definition of "installable" and belongs in P4.
+
+**Not installed**
+1. Middleware boots with no `DEV_*` config present.
+2. `GET /api/v1/admin/dev-platform/jobs` → 404.
+3. `GET /api/v1/ui/navigation` contains no dev-platform entry; `/admin` shows no card.
+4. No `dev_*` table is required for boot.
+5. `node scripts/check-core-decoupling.mjs` → **0**.
+
+**Install**
+6. Install from the plugin repo's artifact; setup fields render from the manifest.
+7. Plugin runs its own migrations; the 9 tables appear.
+8. Public-path grant is shown to the operator and consented to (H1).
+9. Nav entry and admin card appear.
+10. Every §2 row passes.
+
+**Uninstall**
+11. Routers stop answering — the fix in PR #536 makes this real, and its test pins it.
+12. Nav entry and card disappear.
+13. Background loops stop.
+14. Public-path grant is revoked — `/api/v1/dev-runner` is no longer exempt.
+15. **Data lifecycle decision required:** what happens to 9 tables of rows, to
+    `dev_repo_plugin_grants` when a *granted* plugin is removed, and to jobs still
+    `running` whose runner holds a valid token. Currently unanswered.
+
+**Upgrade**
+16. Reinstall a newer version with jobs in flight; no duplicate routes, no orphaned nav
+    entry (both now covered by the disposal fix).
+
+---
+
+## 4. Honest gaps
+
+1. **§2 is not automated.** It is a review checklist. The strongest cheap improvement is a
+   smoke suite in the plugin repo that walks §2.1–§2.4 against a running stack; until then
+   completeness depends on someone working the table.
+2. **§3 does not exist yet.** Install/uninstall cannot be tested before P3 and P4.
+3. **The inventory came from one sweep.** The ratchet compensates: even if a reference was
+   missed here, it is counted there, and the count cannot reach zero while it survives.
+4. **Cross-repo drift has no guard.** Once the plugin leaves, nothing in this repo verifies
+   the plugin still satisfies §2 — that becomes the plugin repo's CI, against a published
+   core contract.

--- a/specs/470-dev-platform-plugin/decoupling-baseline.json
+++ b/specs/470-dev-platform-plugin/decoupling-baseline.json
@@ -1,0 +1,17 @@
+{
+  "total": 3171,
+  "zones": {
+    "middleware/src": 1621,
+    "middleware/test": 925,
+    "middleware/packages": 86,
+    "middleware/scripts": 8,
+    "middleware/sidecars": 180,
+    "middleware/migrations": 70,
+    "middleware/package.json": 0,
+    "web-ui/app": 192,
+    "web-ui/messages": 4,
+    "ci-workflows": 16,
+    "scripts": 30,
+    "compose": 39
+  }
+}

--- a/specs/470-dev-platform-plugin/plan.md
+++ b/specs/470-dev-platform-plugin/plan.md
@@ -487,7 +487,23 @@ single irreversible step moved last.
 | **P3b** | **G7** (§4.3a): extract the `@theme inline` bridge out of `globals.css`; build the plugin Tailwind subset from it and serve it — replacing the 345 hand-written lines of `harness-admin-css.ts`; add a static-asset serving path for plugin SPA bundles; reject arbitrary-value classes at ingest. | Any plugin can ship a real UI in the house design system — the platform's weakest extension point today |
 | **P4** | Stand up `byte5ai/omadia-plugin-dev-platform`; move ~49,100 LOC per `core-decoupling-checklist.md`; port the UI; stand up the repo's own GHCR + SBOM + signing pipeline. **Do not delete the `publicPaths` exemptions until P3 is proven on the live runner phone-home path.** | Dev Platform installs and uninstalls from its own repo |
 | **P5** | Migration ownership handoff (no renumbering) + ledger seed, tested against a database restored from a production snapshot. Its own PR, its own rollback story. | Plugin owns its schema |
-| **P6** | Delete the residue: core's `DEV_*` config, the compose overlay, the CI matrix entries and `id-token: write`, the workflow prompt rules, and every comment reference. | `rg -i 'dev.?platform\|devjob' omadia/` returns nothing |
+| **P6** | Delete the residue: core's `DEV_*` config, the compose overlay, the CI matrix entries and `id-token: write`, the workflow prompt rules, and every comment reference. | `node scripts/check-core-decoupling.mjs --report` reads **0**, and every row of `acceptance.md` §2 and §3 passes |
+
+### How we know it is actually complete
+
+Three documents, three different jobs — a file inventory alone cannot answer either half of
+"all the functions extracted and installable":
+
+| Document | Answers | Enforcement |
+|---|---|---|
+| `core-decoupling-checklist.md` | *What is still coupled?* (276 items, file-level) | Snapshot — goes stale on contact |
+| `acceptance.md` | *Did every capability survive, and does it install?* (34 endpoints, 3 tools, 4 loops, 4 screens + install/uninstall) | Review checklist today; wants a smoke suite in the plugin repo |
+| `scripts/check-core-decoupling.mjs` | *Is core still coupled at all?* | **Automated** — CI job `core decoupling ratchet (#470)`, baseline **3,171**, may only fall |
+
+The ratchet is what makes the checklist's staleness survivable: even if the sweep missed a
+reference, the count still sees it, and the count cannot reach zero while it survives. It
+also stops core re-acquiring a dependency mid-extraction, which is the realistic failure
+mode for a multi-week epic touching ~200 files.
 
 **Config is not 41 `setup.fields`.** The keys are four different things and only one
 belongs in a manifest form: platform-injected env (`FLY_APP_NAME` is a probe, not a

--- a/specs/470-dev-platform-plugin/plan.md
+++ b/specs/470-dev-platform-plugin/plan.md
@@ -117,7 +117,7 @@ files is the easy part.
 | **G4** | **No kernel mechanism for plugin-owned SQL.** `onMigrate` is *config* migration only. | Open (softer than it looks) |
 | **G5** | **No plugin-declared external services.** No `services:`/`image:` in the manifest; sidecars are operator-managed compose overlays. | Won't fix — see below |
 | **G6** | **`publicPaths` is a frozen literal.** A plugin cannot contribute an auth exemption, and core cannot revoke one on uninstall. Needs prefix ownership too, not just a grant. | Open — **hard blocker** (H1) |
-| **G7** | **A distributed plugin cannot ship a React UI.** The ZIP extension allowlist has no `.tsx` — and, verified, **no `.css` either**, so it cannot even carry a compiled SPA's stylesheet. web-ui is built once at image build time. | Open — **hard blocker**, new |
+| **G7** | **A distributed plugin cannot ship a React UI.** The ZIP allowlist has no `.tsx`, and web-ui is built once at image build time. The missing `.css` is **no longer the blocker** — a core-served Tailwind subset removes the need for plugin CSS entirely (§4.3a, measured). | Open — reduced to the JS-bundle question |
 | **G8** | **`DevJob*` are published `@omadia/plugin-api` types.** Removing them is a SemVer-major break for every Hub plugin importing them; `api/admin-v1.ts` leaks `dev_jobs` onto the public admin DTO too. | Open — new |
 | **G9** | **The conductor hardcodes the `dev_job` step kind and channel type** across `runExecutor.ts`, `awaitStore.ts`, and all of `devJobStepEffect.ts`. | Open — **hard blocker** (H2) |
 | **G10** | **The chat renderer hardcodes `tool.name === 'dev_job_start'`** and renders a core-compiled React card for it. | Open — **hard blocker** (H3) |
@@ -284,8 +284,60 @@ page) is exactly one hand-written HTML file.
 | **D. Optional web-ui build variant** | Two images in lockstep, and the plugin's code would still have to live in core's build. Fails constraint 2. |
 | **E. Publish the pages as an npm package web-ui optionally installs** | Keeps React and removes the *source* from core, but core's build must still know the package exists. Weakens constraint 2 to "no source, but a build-time hook". Fallback if B proves too costly. |
 
-**Recommendation: B.** It is the only option that satisfies both constraints without a
-product downgrade. It is also strictly more valuable than a one-off fix — it is the
+### 4.3a Plugins use Tailwind — so they ship no CSS at all
+
+The `.css` gap above is real but it is the **wrong thing to fix**. web-ui is a Tailwind v4
+project; if plugin markup is required to use Tailwind utilities, a plugin never needs to
+ship a stylesheet — it links one that core serves.
+
+The catch, and it is the whole design: **Tailwind emits only classes it has seen.** v4
+detects classes by scanning source files at build time, and a plugin installed at runtime
+from another repository is never scanned. So "plugins use Tailwind" only works if core
+**pre-generates a documented, finite utility vocabulary**. v4 supports exactly this —
+`@source inline(...)` (the replacement for v3's `safelist`, brace-expandable) combined with
+`@import "tailwindcss" source(none)` to disable scanning, producing a stylesheet containing
+precisely that set.
+
+**Measured, not estimated.** Built with the repo's own `tailwindcss@4.3.3` +
+`@tailwindcss/postcss` — see `plugin-tailwind-subset.probe.css`:
+
+| | |
+|---|---|
+| Vocabulary | layout, flex/grid, spacing 0–12, typography, borders, shadows, `sm:`/`md:`/`lg:`, `hover:`/`focus:`/`disabled:` |
+| Colours | **the Lume tokens only** — `bg-accent`, `text-fg-muted`, `border-border`, `text-danger` … verified present |
+| Size | 43,199 B raw → **7,704 B gzip** → 5.7 KB brotli |
+
+Three things that makes better, beyond unblocking the extraction:
+
+1. **Plugins inherit the design system by construction.** They get *our* colour names
+   wired to the runtime CSS variables, so they follow the active palette and light/dark
+   automatically. A plugin cannot hardcode a hex and drift.
+2. **It retires a known drift hazard.** `middleware/src/admin-ui/harness-admin-css.ts` is
+   345 hand-maintained lines whose own header says "mirror `web-ui/app/_lib/theme.css`;
+   keep the two roughly in sync when the design system changes." Generating from the same
+   tokens removes the sync obligation instead of restating it.
+3. **It is enforceable, cheaply.** Reject `[` in class attributes at package ingest.
+
+**The hard constraint to write into the plugin contract:** no **arbitrary values**
+(`w-[137px]`, `bg-[#abc]`). That space is unbounded and cannot be pre-generated, so such a
+class silently renders unstyled — the worst failure mode. The documented vocabulary plus an
+ingest check is the enforcement; widen the vocabulary from what the ported pages actually
+use rather than guessing.
+
+Two implementation notes: the `@theme inline` token bridge currently lives inside
+`globals.css:16-48` and must be **extracted to its own file** that both it and the plugin
+stylesheet import, or the two drift — the exact failure this is meant to end. And an
+iframe is a separate document, so it links the sheet itself; nothing is inherited from the
+parent.
+
+**What remains of G7 after this:** only the JavaScript bundle. `.js` and `.map` are already
+allowlisted, so a compiled SPA can ship today; what is missing is a static-asset serving
+path from the plugin's router. That is a much smaller problem than a styling story.
+
+### Back to the option table
+
+**Recommendation: B**, now materially cheaper than when first written — with §4.3a it is
+the only option that satisfies both constraints without a product downgrade. It is also strictly more valuable than a one-off fix — it is the
 mechanism *any* third-party plugin needs to ship a real UI, which is currently the
 platform's weakest extension point.
 
@@ -432,7 +484,7 @@ single irreversible step moved last.
 | **P2b** | Decide **H3** (chat card): declarative card schema, or accept degradation to `ToolRow` for out-of-repo plugins. Decide **G7 option B vs E**. | Both answers written down before code moves |
 | **P2c** | Mechanical decoupling: break the `wireDevPlatform ↔ routes` cycle; collapse the 41 config keys into one namespaced object. ✅ `mintAppJwt` already moved to `src/services/githubAppJwt.ts`. | `index.ts` wiring reduced to one `assembleDevPlatform(cfg)` call |
 | **P3** | The extension points. **H1** dynamic `publicPaths` + exclusive prefix ownership · **H2** generic conductor step-kind/channel-type registry · **G2** `auth: 'session'` composed *inside* the disposed guard · **G3** route-local raw parser · **G4** `pgPool` capability + shared `runPluginMigrations`. | Any plugin can own routes, exemptions, raw bodies, tables, and long-running steps |
-| **P3b** | **G7**: `.css`/font extensions in the ZIP allowlist, a static-asset serving path for plugin SPAs, Lume tokens published as a consumable package. | Any plugin can ship a real UI — the platform's weakest extension point today |
+| **P3b** | **G7** (§4.3a): extract the `@theme inline` bridge out of `globals.css`; build the plugin Tailwind subset from it and serve it — replacing the 345 hand-written lines of `harness-admin-css.ts`; add a static-asset serving path for plugin SPA bundles; reject arbitrary-value classes at ingest. | Any plugin can ship a real UI in the house design system — the platform's weakest extension point today |
 | **P4** | Stand up `byte5ai/omadia-plugin-dev-platform`; move ~49,100 LOC per `core-decoupling-checklist.md`; port the UI; stand up the repo's own GHCR + SBOM + signing pipeline. **Do not delete the `publicPaths` exemptions until P3 is proven on the live runner phone-home path.** | Dev Platform installs and uninstalls from its own repo |
 | **P5** | Migration ownership handoff (no renumbering) + ledger seed, tested against a database restored from a production snapshot. Its own PR, its own rollback story. | Plugin owns its schema |
 | **P6** | Delete the residue: core's `DEV_*` config, the compose overlay, the CI matrix entries and `id-token: write`, the workflow prompt rules, and every comment reference. | `rg -i 'dev.?platform\|devjob' omadia/` returns nothing |
@@ -461,7 +513,8 @@ misconfigured plugin no longer takes the host offline.
 | **Uninstall data lifecycle is undefined** | Must be decided in P4: what happens to 9 tables on uninstall; who cleans `dev_repo_plugin_grants` when a *granted* plugin is removed; what happens to `running` jobs whose runner still holds a valid token |
 | **Secrets are vaulted under core's namespace** | GitHub App private keys, webhook secrets, and the proxy's provider key live under `core:dev-platform`. P4 must re-key into the plugin namespace or grant read access — operator-visible either way |
 | **Half-migrated codebase** | Each phase has an observable outcome above. **Abandonment checkpoint: after P3/P3b, the platform capabilities stand alone and dev-platform stays in core with no partial-move debt.** Half-moved is the only genuinely bad end state |
-| **The UI port is the biggest single risk (G7)** | 3,933 LOC of React must move to a repo that currently cannot ship a stylesheet. P3b de-risks it *before* P4 commits. If P3b proves too costly, fall back to option E (npm-published UI package) and accept the weakened constraint rather than rewriting the UI as hand-rolled HTML |
+| **The UI port is the biggest single risk (G7)** | 3,933 LOC of React must move out of core. §4.3a removes the styling half of the problem for ~7.7 KB gzip, leaving only static-asset serving. P3b de-risks the rest *before* P4 commits. If it still proves too costly, fall back to option E (npm-published UI package) and accept the weakened constraint rather than rewriting the UI as hand-rolled HTML |
+| **Arbitrary Tailwind values fail silently** | `w-[137px]` cannot be pre-generated, so it renders unstyled rather than erroring — a plugin author would see a subtly broken layout with no diagnostic. Mitigation is an ingest-time rejection of `[` in class attributes, not documentation alone |
 | **Cross-repo development loses atomic changes** | Today a change spanning core and dev-platform is one PR with one CI run. Afterwards it is two PRs in two repos with a published contract between them, and no way to land them atomically. This is the standing tax of the split — worth it for installability, but it makes P3's extension points load-bearing: get them wrong and every fix needs a core release |
 | **The new repo needs a real supply chain** | `dev-runner` is currently SBOM'd and keyless-signed in core's `publish-images.yml`. That is not a copy-paste — the new repo needs GHCR publishing, cosign identity, and its own release workflow before the images can move |
 | **`plugin-api` SemVer-major break (G8)** | Third-party plugins importing `DevJobDescriptor` et al. break at compile time. Deliberate, versioned, and announced — not silent. The worse outcome is keeping the types while making the runtime optional, which preserves the signature and breaks the contract invisibly |

--- a/specs/470-dev-platform-plugin/plugin-tailwind-subset.probe.css
+++ b/specs/470-dev-platform-plugin/plugin-tailwind-subset.probe.css
@@ -1,0 +1,103 @@
+/* PROBE — not shipped, not built by web-ui. Reference artifact for plan.md §G7.
+ *
+ * Answers: can a plugin use Tailwind instead of shipping its own CSS?
+ * Yes — but only for utilities core pre-generates, because Tailwind v4 emits
+ * only what it finds when scanning source, and a plugin installed at runtime
+ * from another repository is never scanned. `@source inline(...)` (v4's
+ * replacement for `safelist`) forces generation without scanning; combined
+ * with `source(none)` it produces a stylesheet containing exactly this set
+ * and nothing else.
+ *
+ * Measured with the repo's own tailwindcss 4.3.3 + @tailwindcss/postcss:
+ *   43,199 bytes raw → 7,704 gzip → 5.7 KB brotli
+ * carrying the real Lume tokens (.bg-accent, .text-fg-muted, .border-border,
+ * .hover:bg-accent, .text-danger all verified present), plus sm:/md:/lg:
+ * and hover:/focus:/disabled: variants.
+ *
+ * HARD CONSTRAINT this implies: plugins may NOT use arbitrary values
+ * (`w-[137px]`, `bg-[#abc]`). That space is unbounded and cannot be
+ * pre-generated — such a class silently renders unstyled. Enforce at package
+ * ingest by rejecting `[...]` in class attributes.
+ *
+ * Starting point, not a final vocabulary — widen it from what the ported
+ * dev-platform pages actually use.
+ */
+@import 'tailwindcss' source(none);
+@import './app/_lib/theme.css';
+
+/* The Lume token bridge — copied from globals.css for the probe. In the real
+   implementation this block gets extracted into its own file that both
+   globals.css and the plugin stylesheet import, so they cannot drift. */
+@theme inline {
+  --color-bg: var(--bg);
+  --color-bg-soft: var(--bg-soft);
+  --color-bg-elevated: var(--bg-elevated);
+  --color-surface: var(--surface);
+  --color-fg: var(--fg);
+  --color-fg-strong: var(--fg-strong);
+  --color-fg-muted: var(--fg-muted);
+  --color-fg-subtle: var(--fg-subtle);
+  --color-accent: var(--accent);
+  --color-accent-hover: var(--accent-hover);
+  --color-accent-subtle: var(--accent-subtle);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-danger: var(--danger);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
+  --font-serif: var(--font-serif);
+  --radius-sm: var(--radius-sm);
+  --radius-md: var(--radius-md);
+  --radius-lg: var(--radius-lg);
+  --shadow-sm: var(--shadow-sm);
+  --shadow-md: var(--shadow-md);
+  --shadow-lg: var(--shadow-lg);
+}
+
+/* Layout */
+@source inline("{flex,inline-flex,grid,block,inline-block,hidden}");
+@source inline("flex-{row,col,wrap,1,none}");
+@source inline("items-{start,center,end,baseline,stretch}");
+@source inline("justify-{start,center,end,between,around}");
+@source inline("grid-cols-{1..6}");
+@source inline("{gap,gap-x,gap-y}-{0..8}");
+@source inline("{w,h}-full");
+@source inline("{min-w,max-w}-{0,full,xs,sm,md,lg,xl,2xl}");
+@source inline("overflow-{auto,hidden,x-auto,y-auto}");
+@source inline("relative,absolute,sticky,static");
+
+/* Spacing */
+@source inline("{p,px,py,pt,pr,pb,pl}-{0..12}");
+@source inline("{m,mx,my,mt,mr,mb,ml}-{0..12}");
+@source inline("space-{x,y}-{1..6}");
+
+/* Typography */
+@source inline("text-{xs,sm,base,lg,xl,2xl,3xl}");
+@source inline("font-{normal,medium,semibold,bold,mono,sans}");
+@source inline("{text-left,text-center,text-right}");
+@source inline("truncate,uppercase,lowercase,capitalize");
+@source inline("leading-{none,tight,snug,normal,relaxed}");
+@source inline("tracking-{tight,normal,wide,wider}");
+
+/* Design-system colours only — the Lume tokens, not Tailwind's palette.
+   This is the point: plugins get OUR colours, so they cannot drift. */
+@source inline("{hover:,focus:,}bg-{bg,bg-soft,bg-elevated,surface,accent,danger,success,warning}");
+@source inline("{hover:,}text-{fg,fg-strong,fg-muted,fg-subtle,accent,danger,success,warning}");
+@source inline("border-{border,border-strong,accent,danger}");
+
+/* Borders / shape */
+@source inline("border,border-{0,2},border-{t,r,b,l}");
+@source inline("rounded{,-sm,-md,-lg,-full}");
+@source inline("shadow{,-sm,-md,-lg}");
+
+/* Interaction */
+@source inline("{hover:,focus:,}opacity-{0,50,75,100}");
+@source inline("cursor-{pointer,not-allowed}");
+@source inline("transition,transition-colors");
+@source inline("disabled:{opacity-50,cursor-not-allowed}");
+
+/* Responsive — one breakpoint for the common cases */
+@source inline("{sm:,md:,lg:}{flex,grid,hidden,block}");
+@source inline("{sm:,md:,lg:}grid-cols-{1..4}");


### PR DESCRIPTION
Follow-up to #536. Documentation + a measured reference artifact — no runtime code.

## The idea

Marcel's, and it's better than the workaround it replaces: web-ui is a Tailwind v4 project, so **require Tailwind in plugin markup and a plugin never needs to ship CSS at all** — it links a stylesheet core serves.

This matters for the Dev Platform extraction (`specs/470-dev-platform-plugin/plan.md`), where G7 — "a distributed plugin cannot ship a React UI" — was rated a hard blocker partly because the ZIP extension allowlist has no `.css`. That turns out to be the wrong thing to fix.

## The catch, which is the whole design

**Tailwind emits only classes it has seen.** v4 detects them by scanning source files at build time, and a plugin installed at runtime from another repository is never scanned. So "plugins use Tailwind" only works if core **pre-generates a documented, finite vocabulary**.

v4 supports exactly that: `@source inline(...)` — the replacement for v3's `safelist`, brace-expandable — combined with `@import "tailwindcss" source(none)` to disable scanning, producing a stylesheet containing precisely that set and nothing else.

## Measured, not estimated

Built with the repo's own `tailwindcss@4.3.3` + `@tailwindcss/postcss`. Probe kept at `specs/470-dev-platform-plugin/plugin-tailwind-subset.probe.css` (reference artifact — not shipped, not built by web-ui):

| | |
|---|---|
| Vocabulary | layout, flex/grid, spacing 0–12, typography, borders, shadows, `sm:`/`md:`/`lg:`, `hover:`/`focus:`/`disabled:` |
| Colours | **Lume tokens only** — `.bg-accent`, `.text-fg-muted`, `.border-border`, `.text-danger` verified present in the output |
| Size | 43,199 B raw → **7,704 B gzip** → 5.7 KB brotli |

## Why this is worth more than unblocking one extraction

1. **Plugins inherit the design system by construction.** They get *our* colour names wired to the runtime CSS variables, so they follow the active palette and light/dark automatically. A plugin cannot hardcode a hex and drift.
2. **It retires a known drift hazard.** `middleware/src/admin-ui/harness-admin-css.ts` is 345 hand-maintained lines whose own header says *"mirror `web-ui/app/_lib/theme.css`; keep the two roughly in sync when the design system changes."* Generating both from the same tokens removes the sync obligation instead of restating it.
3. **It is enforceable cheaply** — reject `[` in class attributes at package ingest.

## The constraint this puts in the plugin contract

**No arbitrary values** (`w-[137px]`, `bg-[#abc]`). That space is unbounded and cannot be pre-generated, so such a class renders **unstyled with no diagnostic** — the worst failure mode. Documentation alone won't hold it; it needs the ingest check.

Implementation note: the `@theme inline` token bridge currently lives inside `globals.css:16-48` and must be **extracted to its own file** that both it and the plugin stylesheet import — otherwise the two drift, which is the exact failure this is meant to end.

## Effect on the plan

G7 drops from "hard blocker" to the JS-bundle question alone: `.js` and `.map` are already allowlisted, so a compiled SPA can ship today; what is still missing is a static-asset serving path from the plugin's router. Phase P3b is re-scoped accordingly.

## Test plan

- [x] Probe compiles with the repo's own Tailwind toolchain; output inspected for the Lume colour utilities and the `sm:`/`md:`/`hover:` variants
- [x] Sizes measured (raw / gzip / brotli)
- [x] No change to any shipped file — the probe lives under `specs/`, is not imported by `web-ui`, and is not part of any build
- [ ] Implementation itself (extract the `@theme` bridge, build + serve the sheet, ingest check) is P3b, not this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787898674&installation_model_id=428086&pr_number=538&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F538&signature=e02f3fdc6c58dad3d475cb59bd211732a2eae5e89811f08aea42ace28f35e75b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->