### PR TITLE
feat(web-ui): admin UI for public API keys (issues #438/#439)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -95,6 +95,20 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
   primitives, and `middleware/src` imports no channel plugin), because
   "where does this code live" is a property no runtime assertion can express
   and the cheapest one to regress.
+- **Admin UI** (`web-ui/app/admin/api-keys/`): create/list/revoke against
+  `/api/public/v1/admin/keys`. A created key's plaintext token is shown
+  exactly once, right after creation, and creation is blocked while that
+  one-time reveal is still on screen — the create button and every form
+  field stay disabled until the operator explicitly dismisses it, so a
+  second key can never silently overwrite the first one's only-ever-shown
+  token in React state before it's copied. Revoking is a two-step
+  confirm-then-revoke per row, with independent busy/confirm state per key
+  (concurrent revokes on different rows don't clobber each other), and the
+  list reload is guarded against out-of-order responses (a slower in-flight
+  fetch can't stomp a newer one's result). Errors map known backend codes
+  (`not_found`, `operator_auth.unavailable`, `auth.missing`/`auth.invalid`,
+  `invalid_request`) to translated messages rather than surfacing the raw
+  response body.
 
 ### Added — public API channel: chat over HTTP with per-key auth (#438)
 

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -966,6 +966,14 @@ vom eigenen Server aus aufruft, ohne menschliche Session.
 - **`publicPaths.ts` bleibt unverändert eng:** weiterhin nur
   `/api/public/v1/chat`. Wer `requireApiKey` auf eine neue Route mountet,
   braucht dort einen eigenen, möglichst engen Eintrag.
+- **Admin-UI (`web-ui/app/admin/api-keys/`)** — separate, auf diesem Branch
+  gestackte Web-UI-PR. `ApiKeysPanel.tsx` deckt create/list/revoke gegen
+  genau die drei Routen oben ab, keine neuen Backend-Endpunkte. `scopes: []`
+  wird nie gesendet — die Checkbox für `chat:write` muss angehakt bleiben,
+  sonst bleibt der Create-Button deaktiviert, statt den Footgun aus dem
+  `CreateKeyRequestSchema`-Kommentar oben zu reproduzieren. Details zum
+  Reveal-/Revoke-/Fehler-Verhalten stehen direkt nach der Testliste unten,
+  um Doppelung zu vermeiden.
 
 Tests: `test/auth/requireApiKey.test.ts` (Auth/Scope/Rate-Limit/Audit der
 Middleware), `test/auth/apiKeyScopes.test.ts` (Scope-Modell inkl.
@@ -974,6 +982,24 @@ Zusicherung, dass das Plugin keine zweite Kopie der Primitive hält und der
 Kernel kein Channel-Plugin importiert). Die bestehenden `test/channelApi/`-
 Suites laufen inhaltlich unverändert weiter, nur die Importpfade der
 verschobenen Module zeigen jetzt auf `packages/harness-api-key-auth/`.
+
+**Admin-UI** (`web-ui/app/admin/api-keys/`, Issue #438/#439): Create/List/
+Revoke gegen `/api/public/v1/admin/keys` (`ApiKeysPanel.tsx`). Das
+Klartext-Token wird — wie beim Webhook-Secret-Reveal — genau einmal direkt
+nach dem Create angezeigt, nie erneut aus einem Reload rekonstruiert (die
+Listen-Response enthält nie ein Token-Feld). Solange dieser Reveal auf dem
+Schirm ist, ist das Erstellen eines weiteren Keys blockiert (Formular
+disabled) — sonst würde ein zweiter Create das erste, noch nicht kopierte
+Token in React-State kommentarlos überschreiben. Revoke ist zweistufig
+(Arm → Confirm) mit Busy-/Confirm-State **pro Key-Id** (Set statt einem
+einzelnen globalen Id-String), damit ein gleichzeitiges Revoke auf einer
+anderen Zeile den Confirm-/Busy-Zustand dieser Zeile nicht zurücksetzt; der
+Listen-Reload trägt eine Sequenznummer, damit ein langsamer, überholter
+Fetch nicht das Ergebnis eines neueren überschreibt. Fehler werden über
+bekannte Backend-Codes (`not_found`, `operator_auth.unavailable`,
+`auth.missing`/`auth.invalid`, `invalid_request`) auf übersetzte
+Catalog-Strings gemappt statt den rohen Response-Body anzuzeigen (web-ui
+i18n Hard Rule, `web-ui/CLAUDE.md`).
 
 ---
 

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -4525,3 +4525,57 @@ export async function listWebhookSubscriptionDeliveries(
 ): Promise<{ deliveries: ConductorWebhookOutboundDelivery[] }> {
   return getJson(`${WEBHOOKS_BASE}/subscriptions/${encodeURIComponent(id)}/deliveries`);
 }
+
+// -----------------------------------------------------------------------------
+// Public API keys (issues #438/#439) — /api/public/v1/admin/keys.
+//
+// This router lives in @omadia/channel-api, not under /v1/operator/* like the
+// rest of this file's admin surfaces — it is mounted at API_PREFIX
+// `/api/public/v1`, gated by the same operator-session cookie via its own
+// `operatorAuth` middleware (see adminKeysRouter.ts). getJson/postJson still
+// apply here unchanged: same cookie, same 401-bounces-to-/login behavior.
+// -----------------------------------------------------------------------------
+
+const API_KEYS_BASE = '/public/v1/admin/keys';
+
+export interface ApiKeyPublicView {
+  id: string;
+  label?: string;
+  rateLimitPerMinute: number;
+  scopes: string[];
+  /** Epoch ms. */
+  createdAt: number;
+  /** Epoch ms. Present iff the key has been revoked. */
+  revokedAt?: number;
+}
+
+export interface CreateApiKeyInput {
+  label?: string;
+  rateLimitPerMinute?: number;
+  /**
+   * Omit this field entirely to accept the backend's legacy default
+   * (`['chat:write']`). An explicitly empty array is REJECTED by the
+   * backend with 400 — it reads `[]` as a deliberate "grant nothing"
+   * request, never as "use the default". Callers must never pass `[]`.
+   */
+  scopes?: string[];
+}
+
+export interface CreateApiKeyResult {
+  key: ApiKeyPublicView;
+  /** Plaintext — present only in this one response. Never returned again by
+   *  any other endpoint; do not persist it beyond the reveal-once UI. */
+  token: string;
+}
+
+export async function listApiKeys(): Promise<{ keys: ApiKeyPublicView[] }> {
+  return getJson(API_KEYS_BASE);
+}
+
+export async function createApiKey(input: CreateApiKeyInput): Promise<CreateApiKeyResult> {
+  return postJson(API_KEYS_BASE, input);
+}
+
+export async function revokeApiKey(id: string): Promise<{ key: ApiKeyPublicView }> {
+  return postJson(`${API_KEYS_BASE}/${encodeURIComponent(id)}/revoke`, {});
+}

--- a/web-ui/app/admin/api-keys/_components/ApiKeysPanel.tsx
+++ b/web-ui/app/admin/api-keys/_components/ApiKeysPanel.tsx
@@ -1,0 +1,327 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useTranslations } from 'next-intl';
+
+import { Button } from '@/app/_components/ui/Button';
+import {
+  createApiKey,
+  listApiKeys,
+  revokeApiKey,
+  type ApiKeyPublicView,
+} from '@/app/_lib/api';
+
+import { KeyStatusBadge, card, chipCls, inputCls, toFriendlyError } from './shared';
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ready'; keys: ApiKeyPublicView[] }
+  | { kind: 'error'; message: string };
+
+/**
+ * The only real scope today (issue #439). Kept as a single hardcoded
+ * checkbox rather than a generic scope picker — there is nothing else valid
+ * to pick from yet. Not read from a backend catalog endpoint because none
+ * exists; if a second scope ships, this is the one place to widen (ideally
+ * to a list driven by a real catalog at that point, not a second hardcode).
+ */
+const CHAT_WRITE_SCOPE = 'chat:write';
+
+const MIN_RATE_LIMIT = 1;
+const MAX_RATE_LIMIT = 6000;
+const DEFAULT_RATE_LIMIT_HINT = 60;
+
+function parseRateLimitInput(raw: string): number | undefined {
+  const trimmed = raw.trim();
+  if (trimmed === '') return undefined;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n)) return undefined;
+  return Math.trunc(n);
+}
+
+export function ApiKeysPanel(): React.ReactElement {
+  const t = useTranslations('adminApiKeys');
+
+  const [state, setState] = useState<State>({ kind: 'loading' });
+
+  // Create form.
+  const [label, setLabel] = useState('');
+  const [rateLimitInput, setRateLimitInput] = useState('');
+  const [grantChatWrite, setGrantChatWrite] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  // Reveal-once token, set only by a successful create. Cleared by an
+  // explicit dismiss — never auto-hidden, never re-derived from a fetch (the
+  // list endpoint never returns a token field, so there is nothing to leak
+  // even if this state were repopulated from a reload).
+  const [revealed, setRevealed] = useState<{ id: string; token: string } | null>(null);
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
+
+  // Revoke flow.
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const reload = useCallback(async (): Promise<void> => {
+    try {
+      const res = await listApiKeys();
+      setState({ kind: 'ready', keys: res.keys });
+    } catch (err) {
+      setState({ kind: 'error', message: toFriendlyError(err) });
+    }
+  }, []);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void reload();
+  }, [reload]);
+
+  const rateLimitValue = useMemo(() => parseRateLimitInput(rateLimitInput), [rateLimitInput]);
+  const rateLimitInvalid =
+    rateLimitInput.trim() !== '' &&
+    (rateLimitValue === undefined || rateLimitValue < MIN_RATE_LIMIT || rateLimitValue > MAX_RATE_LIMIT);
+
+  // A key with zero scopes is a credential that authenticates and can do
+  // nothing — not a useful thing to mint, and the backend rejects an
+  // explicit `scopes: []` outright (see CreateApiKeyInput doc comment).
+  // Blocking submission here keeps that a clear, explained dead end instead
+  // of a 400 the operator has to decode.
+  const canSubmit = grantChatWrite && !rateLimitInvalid && !creating;
+
+  const onCreate = useCallback(async (): Promise<void> => {
+    if (!canSubmit) return;
+    setCreateError(null);
+    setCreating(true);
+    try {
+      const created = await createApiKey({
+        ...(label.trim() ? { label: label.trim() } : {}),
+        ...(rateLimitValue !== undefined ? { rateLimitPerMinute: rateLimitValue } : {}),
+        // Sent explicitly (never omitted) so the request always reflects
+        // exactly what the checkbox shows — omitting would coincidentally
+        // resolve to the same legacy default today, but that's an
+        // implementation detail of the backend this UI shouldn't lean on.
+        scopes: [CHAT_WRITE_SCOPE],
+      });
+      setLabel('');
+      setRateLimitInput('');
+      setCopyState('idle');
+      setRevealed({ id: created.key.id, token: created.token });
+      await reload();
+    } catch (err) {
+      setCreateError(toFriendlyError(err));
+    } finally {
+      setCreating(false);
+    }
+  }, [canSubmit, label, rateLimitValue, reload]);
+
+  const onCopyToken = useCallback(async (): Promise<void> => {
+    if (!revealed) return;
+    try {
+      await navigator.clipboard.writeText(revealed.token);
+      setCopyState('copied');
+    } catch {
+      // Clipboard API can fail (permissions, insecure context). The token
+      // stays visible and selectable — this is a soft failure, not an error
+      // banner: the operator can still copy it manually.
+      setCopyState('failed');
+    }
+  }, [revealed]);
+
+  const onDismissRevealed = useCallback((): void => {
+    setRevealed(null);
+    setCopyState('idle');
+  }, []);
+
+  const onConfirmRevoke = useCallback(
+    async (id: string): Promise<void> => {
+      setActionError(null);
+      setPendingId(id);
+      try {
+        const { key } = await revokeApiKey(id);
+        setState((prev) =>
+          prev.kind === 'ready'
+            ? { kind: 'ready', keys: prev.keys.map((k) => (k.id === id ? key : k)) }
+            : prev,
+        );
+      } catch (err) {
+        setActionError(toFriendlyError(err));
+        // The key may have been revoked/removed by someone else already —
+        // resync the list rather than leaving a stale row on screen.
+        await reload();
+      } finally {
+        setPendingId(null);
+        setConfirmingId(null);
+      }
+    },
+    [reload],
+  );
+
+  return (
+    <>
+      <section className={`${card} mb-6`}>
+        <h2 className="mb-3 text-[13px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
+          {t('create.heading')}
+        </h2>
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
+              {t('create.fields.label')}
+            </span>
+            <input
+              className={inputCls}
+              value={label}
+              maxLength={120}
+              onChange={(e) => setLabel(e.target.value)}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
+              {t('create.fields.rateLimit')}
+            </span>
+            <input
+              className={inputCls}
+              type="number"
+              min={MIN_RATE_LIMIT}
+              max={MAX_RATE_LIMIT}
+              placeholder={String(DEFAULT_RATE_LIMIT_HINT)}
+              value={rateLimitInput}
+              onChange={(e) => setRateLimitInput(e.target.value)}
+            />
+          </label>
+          <label className="flex items-center gap-2 pb-2">
+            <input
+              type="checkbox"
+              checked={grantChatWrite}
+              onChange={(e) => setGrantChatWrite(e.target.checked)}
+            />
+            <span className="type-mono-data text-[13px] text-[color:var(--fg)]">
+              {CHAT_WRITE_SCOPE}
+            </span>
+          </label>
+          <Button variant="primary" onClick={() => void onCreate()} disabled={!canSubmit} busy={creating} busyLabel={t('create.creating')}>
+            {t('create.submit')}
+          </Button>
+        </div>
+        {rateLimitInvalid && (
+          <p className="mt-2 text-[13px] text-[color:var(--danger)]">
+            {t('create.rateLimitInvalid', { min: MIN_RATE_LIMIT, max: MAX_RATE_LIMIT })}
+          </p>
+        )}
+        {!grantChatWrite && (
+          <p className="mt-2 text-[13px] text-[color:var(--danger)]">{t('create.scopesRequired')}</p>
+        )}
+        {createError && <p className="mt-2 text-[13px] text-[color:var(--danger)]">{createError}</p>}
+      </section>
+
+      {revealed && (
+        <section
+          className="mb-6 rounded-lg border border-[color:var(--accent)] bg-[color:var(--accent)]/5 p-4"
+          role="alert"
+        >
+          <p className="mb-1 text-[13px] font-semibold text-[color:var(--fg-strong)]">
+            {t('reveal.heading')}
+          </p>
+          <p className="mb-3 text-[13px] text-[color:var(--fg-muted)]">{t('reveal.warning')}</p>
+          <code className="type-mono-data block break-all rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] p-3 text-[13px] text-[color:var(--fg-strong)]">
+            {revealed.token}
+          </code>
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            <Button variant="secondary" onClick={() => void onCopyToken()}>
+              {copyState === 'copied' ? t('reveal.copied') : t('reveal.copy')}
+            </Button>
+            <Button variant="ghost" onClick={onDismissRevealed}>
+              {t('reveal.dismiss')}
+            </Button>
+            {copyState === 'failed' && (
+              <span className="text-[12px] text-[color:var(--danger)]">{t('reveal.copyFailed')}</span>
+            )}
+          </div>
+        </section>
+      )}
+
+      <section>
+        <h2 className="mb-3 text-[13px] font-semibold uppercase tracking-wider text-[color:var(--fg-muted)]">
+          {t('list.heading')}
+        </h2>
+
+        {state.kind === 'loading' ? (
+          <p className="text-sm opacity-70">{t('list.loading')}</p>
+        ) : state.kind === 'error' ? (
+          <p className="text-sm text-[color:var(--danger)]">{state.message}</p>
+        ) : state.keys.length === 0 ? (
+          <p className="text-sm text-[color:var(--fg-muted)]">{t('list.empty')}</p>
+        ) : (
+          <ul className="flex flex-col gap-3">
+            {state.keys.map((key) => {
+              const isActive = key.revokedAt === undefined;
+              const isPending = pendingId === key.id;
+              const isConfirming = confirmingId === key.id;
+              return (
+                <li key={key.id} className={card}>
+                  <div className="flex flex-wrap items-center justify-between gap-4">
+                    <div className="flex flex-1 flex-col gap-1.5">
+                      <div className="flex items-center gap-2">
+                        <span className="text-[15px] font-semibold text-[color:var(--fg-strong)]">
+                          {key.label || t('list.unlabeled')}
+                        </span>
+                        <KeyStatusBadge revokedAt={key.revokedAt} />
+                      </div>
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        {key.scopes.map((scope) => (
+                          <span key={scope} className={chipCls}>
+                            {scope}
+                          </span>
+                        ))}
+                      </div>
+                      <span className="text-[12px] text-[color:var(--fg-muted)]">
+                        {t('list.rateLimitValue', { value: key.rateLimitPerMinute })}
+                        {' · '}
+                        {t('list.createdAt', { date: new Date(key.createdAt).toLocaleString() })}
+                      </span>
+                    </div>
+                    {isActive && !isConfirming && (
+                      <Button variant="danger" size="sm" onClick={() => setConfirmingId(key.id)}>
+                        {t('list.revoke')}
+                      </Button>
+                    )}
+                  </div>
+
+                  {isActive && isConfirming && (
+                    <div className="mt-3 border-t border-[color:var(--border)] pt-3">
+                      <p className="mb-2 text-[13px] text-[color:var(--fg)]">
+                        {t('list.confirmRevoke.message')}
+                      </p>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Button
+                          variant="danger"
+                          size="sm"
+                          onClick={() => void onConfirmRevoke(key.id)}
+                          busy={isPending}
+                          busyLabel={t('list.revoking')}
+                        >
+                          {t('list.confirmRevoke.confirm')}
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setConfirmingId(null)}
+                          disabled={isPending}
+                        >
+                          {t('list.confirmRevoke.cancel')}
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        {actionError && <p className="mt-4 text-sm text-[color:var(--danger)]">{actionError}</p>}
+      </section>
+    </>
+  );
+}

--- a/web-ui/app/admin/api-keys/_components/ApiKeysPanel.tsx
+++ b/web-ui/app/admin/api-keys/_components/ApiKeysPanel.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { useTranslations } from 'next-intl';
+import { useFormatter, useTranslations } from 'next-intl';
 
 import { Button } from '@/app/_components/ui/Button';
 import {
@@ -12,7 +12,7 @@ import {
   type ApiKeyPublicView,
 } from '@/app/_lib/api';
 
-import { KeyStatusBadge, card, chipCls, inputCls, toFriendlyError } from './shared';
+import { KeyStatusBadge, card, chipCls, errorInlineCls, errorTextCls, inputCls, toFriendlyError } from './shared';
 
 type State =
   | { kind: 'loading' }
@@ -37,13 +37,34 @@ function parseRateLimitInput(raw: string): number | undefined {
   if (trimmed === '') return undefined;
   const n = Number(trimmed);
   if (!Number.isFinite(n)) return undefined;
-  return Math.trunc(n);
+  return n;
+}
+
+/** Immutable add/remove for the per-key id sets below (`pendingIds`,
+ *  `confirmingIds`) — every row's transient UI state is tracked by its own
+ *  key id rather than a single shared value, so two rows can be mid-action
+ *  at once without one clobbering the other's state (codex review finding). */
+function withId(set: ReadonlySet<string>, id: string): ReadonlySet<string> {
+  if (set.has(id)) return set;
+  return new Set(set).add(id);
+}
+function withoutId(set: ReadonlySet<string>, id: string): ReadonlySet<string> {
+  if (!set.has(id)) return set;
+  const next = new Set(set);
+  next.delete(id);
+  return next;
 }
 
 export function ApiKeysPanel(): React.ReactElement {
   const t = useTranslations('adminApiKeys');
+  const format = useFormatter();
 
   const [state, setState] = useState<State>({ kind: 'loading' });
+  // Guards against out-of-order responses: only the most recently ISSUED
+  // reload's result is ever applied to `state`. Without this, a slow initial
+  // mount fetch that resolves AFTER a post-create reload (which already
+  // reflects the new key) could stomp the newer state with stale data.
+  const reloadSeqRef = useRef(0);
 
   // Create form.
   const [label, setLabel] = useState('');
@@ -55,23 +76,31 @@ export function ApiKeysPanel(): React.ReactElement {
   // Reveal-once token, set only by a successful create. Cleared by an
   // explicit dismiss — never auto-hidden, never re-derived from a fetch (the
   // list endpoint never returns a token field, so there is nothing to leak
-  // even if this state were repopulated from a reload).
+  // even if this state were repopulated from a reload). Creation is BLOCKED
+  // while a reveal is on screen (see `canSubmit`) — otherwise a second
+  // create would silently overwrite the first key's only-ever-shown token
+  // before the operator had a chance to copy it.
   const [revealed, setRevealed] = useState<{ id: string; token: string } | null>(null);
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
 
-  // Revoke flow.
-  const [confirmingId, setConfirmingId] = useState<string | null>(null);
-  const [pendingId, setPendingId] = useState<string | null>(null);
+  // Revoke flow. Both sets are keyed by key id (not a single shared value)
+  // so two different rows can be armed/revoked concurrently without one's
+  // confirm/busy state clobbering the other's.
+  const [confirmingIds, setConfirmingIds] = useState<ReadonlySet<string>>(new Set());
+  const [pendingIds, setPendingIds] = useState<ReadonlySet<string>>(new Set());
   const [actionError, setActionError] = useState<string | null>(null);
 
   const reload = useCallback(async (): Promise<void> => {
+    const seq = ++reloadSeqRef.current;
     try {
       const res = await listApiKeys();
+      if (seq !== reloadSeqRef.current) return; // superseded by a newer reload
       setState({ kind: 'ready', keys: res.keys });
     } catch (err) {
-      setState({ kind: 'error', message: toFriendlyError(err) });
+      if (seq !== reloadSeqRef.current) return;
+      setState({ kind: 'error', message: toFriendlyError(err, t) });
     }
-  }, []);
+  }, [t]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -81,14 +110,18 @@ export function ApiKeysPanel(): React.ReactElement {
   const rateLimitValue = useMemo(() => parseRateLimitInput(rateLimitInput), [rateLimitInput]);
   const rateLimitInvalid =
     rateLimitInput.trim() !== '' &&
-    (rateLimitValue === undefined || rateLimitValue < MIN_RATE_LIMIT || rateLimitValue > MAX_RATE_LIMIT);
+    (rateLimitValue === undefined ||
+      !Number.isInteger(rateLimitValue) ||
+      rateLimitValue < MIN_RATE_LIMIT ||
+      rateLimitValue > MAX_RATE_LIMIT);
 
   // A key with zero scopes is a credential that authenticates and can do
   // nothing — not a useful thing to mint, and the backend rejects an
   // explicit `scopes: []` outright (see CreateApiKeyInput doc comment).
   // Blocking submission here keeps that a clear, explained dead end instead
-  // of a 400 the operator has to decode.
-  const canSubmit = grantChatWrite && !rateLimitInvalid && !creating;
+  // of a 400 the operator has to decode. `!revealed` blocks a second create
+  // while the previous key's one-time token is still on screen unconfirmed.
+  const canSubmit = grantChatWrite && !rateLimitInvalid && !creating && !revealed;
 
   const onCreate = useCallback(async (): Promise<void> => {
     if (!canSubmit) return;
@@ -110,11 +143,11 @@ export function ApiKeysPanel(): React.ReactElement {
       setRevealed({ id: created.key.id, token: created.token });
       await reload();
     } catch (err) {
-      setCreateError(toFriendlyError(err));
+      setCreateError(toFriendlyError(err, t));
     } finally {
       setCreating(false);
     }
-  }, [canSubmit, label, rateLimitValue, reload]);
+  }, [canSubmit, label, rateLimitValue, reload, t]);
 
   const onCopyToken = useCallback(async (): Promise<void> => {
     if (!revealed) return;
@@ -137,7 +170,7 @@ export function ApiKeysPanel(): React.ReactElement {
   const onConfirmRevoke = useCallback(
     async (id: string): Promise<void> => {
       setActionError(null);
-      setPendingId(id);
+      setPendingIds((prev) => withId(prev, id));
       try {
         const { key } = await revokeApiKey(id);
         setState((prev) =>
@@ -146,16 +179,16 @@ export function ApiKeysPanel(): React.ReactElement {
             : prev,
         );
       } catch (err) {
-        setActionError(toFriendlyError(err));
+        setActionError(toFriendlyError(err, t));
         // The key may have been revoked/removed by someone else already —
         // resync the list rather than leaving a stale row on screen.
         await reload();
       } finally {
-        setPendingId(null);
-        setConfirmingId(null);
+        setPendingIds((prev) => withoutId(prev, id));
+        setConfirmingIds((prev) => withoutId(prev, id));
       }
     },
-    [reload],
+    [reload, t],
   );
 
   return (
@@ -173,6 +206,7 @@ export function ApiKeysPanel(): React.ReactElement {
               className={inputCls}
               value={label}
               maxLength={120}
+              disabled={!!revealed}
               onChange={(e) => setLabel(e.target.value)}
             />
           </label>
@@ -187,6 +221,7 @@ export function ApiKeysPanel(): React.ReactElement {
               max={MAX_RATE_LIMIT}
               placeholder={String(DEFAULT_RATE_LIMIT_HINT)}
               value={rateLimitInput}
+              disabled={!!revealed}
               onChange={(e) => setRateLimitInput(e.target.value)}
             />
           </label>
@@ -194,6 +229,7 @@ export function ApiKeysPanel(): React.ReactElement {
             <input
               type="checkbox"
               checked={grantChatWrite}
+              disabled={!!revealed}
               onChange={(e) => setGrantChatWrite(e.target.checked)}
             />
             <span className="type-mono-data text-[13px] text-[color:var(--fg)]">
@@ -205,14 +241,15 @@ export function ApiKeysPanel(): React.ReactElement {
           </Button>
         </div>
         {rateLimitInvalid && (
-          <p className="mt-2 text-[13px] text-[color:var(--danger)]">
+          <p className={`mt-2 ${errorTextCls}`}>
             {t('create.rateLimitInvalid', { min: MIN_RATE_LIMIT, max: MAX_RATE_LIMIT })}
           </p>
         )}
         {!grantChatWrite && (
-          <p className="mt-2 text-[13px] text-[color:var(--danger)]">{t('create.scopesRequired')}</p>
+          <p className={`mt-2 ${errorTextCls}`}>{t('create.scopesRequired')}</p>
         )}
-        {createError && <p className="mt-2 text-[13px] text-[color:var(--danger)]">{createError}</p>}
+        {revealed && <p className="mt-2 text-[13px] text-[color:var(--fg-muted)]">{t('create.blockedByReveal')}</p>}
+        {createError && <p className={`mt-2 ${errorTextCls}`}>{createError}</p>}
       </section>
 
       {revealed && (
@@ -235,7 +272,7 @@ export function ApiKeysPanel(): React.ReactElement {
               {t('reveal.dismiss')}
             </Button>
             {copyState === 'failed' && (
-              <span className="text-[12px] text-[color:var(--danger)]">{t('reveal.copyFailed')}</span>
+              <span className={errorInlineCls}>{t('reveal.copyFailed')}</span>
             )}
           </div>
         </section>
@@ -249,15 +286,15 @@ export function ApiKeysPanel(): React.ReactElement {
         {state.kind === 'loading' ? (
           <p className="text-sm opacity-70">{t('list.loading')}</p>
         ) : state.kind === 'error' ? (
-          <p className="text-sm text-[color:var(--danger)]">{state.message}</p>
+          <p className={errorTextCls}>{state.message}</p>
         ) : state.keys.length === 0 ? (
           <p className="text-sm text-[color:var(--fg-muted)]">{t('list.empty')}</p>
         ) : (
           <ul className="flex flex-col gap-3">
             {state.keys.map((key) => {
               const isActive = key.revokedAt === undefined;
-              const isPending = pendingId === key.id;
-              const isConfirming = confirmingId === key.id;
+              const isPending = pendingIds.has(key.id);
+              const isConfirming = confirmingIds.has(key.id);
               return (
                 <li key={key.id} className={card}>
                   <div className="flex flex-wrap items-center justify-between gap-4">
@@ -278,11 +315,20 @@ export function ApiKeysPanel(): React.ReactElement {
                       <span className="text-[12px] text-[color:var(--fg-muted)]">
                         {t('list.rateLimitValue', { value: key.rateLimitPerMinute })}
                         {' · '}
-                        {t('list.createdAt', { date: new Date(key.createdAt).toLocaleString() })}
+                        {t('list.createdAt', {
+                          date: format.dateTime(new Date(key.createdAt), {
+                            dateStyle: 'medium',
+                            timeStyle: 'short',
+                          }),
+                        })}
                       </span>
                     </div>
                     {isActive && !isConfirming && (
-                      <Button variant="danger" size="sm" onClick={() => setConfirmingId(key.id)}>
+                      <Button
+                        variant="danger"
+                        size="sm"
+                        onClick={() => setConfirmingIds((prev) => withId(prev, key.id))}
+                      >
                         {t('list.revoke')}
                       </Button>
                     )}
@@ -306,7 +352,7 @@ export function ApiKeysPanel(): React.ReactElement {
                         <Button
                           variant="ghost"
                           size="sm"
-                          onClick={() => setConfirmingId(null)}
+                          onClick={() => setConfirmingIds((prev) => withoutId(prev, key.id))}
                           disabled={isPending}
                         >
                           {t('list.confirmRevoke.cancel')}
@@ -320,7 +366,7 @@ export function ApiKeysPanel(): React.ReactElement {
           </ul>
         )}
 
-        {actionError && <p className="mt-4 text-sm text-[color:var(--danger)]">{actionError}</p>}
+        {actionError && <p className={`mt-4 ${errorTextCls}`}>{actionError}</p>}
       </section>
     </>
   );

--- a/web-ui/app/admin/api-keys/_components/__tests__/ApiKeysPanel.test.tsx
+++ b/web-ui/app/admin/api-keys/_components/__tests__/ApiKeysPanel.test.tsx
@@ -1,0 +1,189 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithIntl } from '../../../../_lib/test-utils';
+import { ApiKeysPanel } from '../ApiKeysPanel';
+import type { ApiKeyPublicView } from '../../../../_lib/api';
+
+const { mockListApiKeys, mockCreateApiKey, mockRevokeApiKey } = vi.hoisted(() => ({
+  mockListApiKeys: vi.fn(),
+  mockCreateApiKey: vi.fn(),
+  mockRevokeApiKey: vi.fn(),
+}));
+
+vi.mock('../../../../_lib/api', () => ({
+  listApiKeys: mockListApiKeys,
+  createApiKey: mockCreateApiKey,
+  revokeApiKey: mockRevokeApiKey,
+  ApiError: class ApiError extends Error {
+    constructor(
+      public status: number,
+      message: string,
+      public body?: string,
+    ) {
+      super(message);
+    }
+  },
+}));
+
+function key(over: Partial<ApiKeyPublicView> = {}): ApiKeyPublicView {
+  return {
+    id: 'key-1',
+    label: 'CI bot',
+    rateLimitPerMinute: 60,
+    scopes: ['chat:write'],
+    createdAt: Date.parse('2026-07-01T00:00:00Z'),
+    ...over,
+  };
+}
+
+describe('<ApiKeysPanel />', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+    // Sane defaults so tests that only assert *whether* the API was called
+    // (not its resolved shape) don't hit a destructuring TypeError on an
+    // unmocked resolved value.
+    mockRevokeApiKey.mockResolvedValue({ key: key() });
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the empty state when there are no keys', async () => {
+    mockListApiKeys.mockResolvedValue({ keys: [] });
+    renderWithIntl(<ApiKeysPanel />);
+
+    expect(await screen.findByText(/No API keys yet/i)).toBeTruthy();
+  });
+
+  it('renders an existing key with its label, scope chip, and Active status', async () => {
+    mockListApiKeys.mockResolvedValue({ keys: [key()] });
+    renderWithIntl(<ApiKeysPanel />);
+
+    expect(await screen.findByText('CI bot')).toBeTruthy();
+    // The scope also appears as the (checked) create-form checkbox label, so
+    // there are two "chat:write" nodes on the page — the chip is one of them.
+    expect(screen.getAllByText('chat:write').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText('Active')).toBeTruthy();
+  });
+
+  it('falls back to "Unlabeled" when a key has no label', async () => {
+    mockListApiKeys.mockResolvedValue({ keys: [key({ label: undefined })] });
+    renderWithIntl(<ApiKeysPanel />);
+
+    expect(await screen.findByText('Unlabeled')).toBeTruthy();
+  });
+
+  it('shows a revoked key with Revoked status and no revoke button', async () => {
+    mockListApiKeys.mockResolvedValue({
+      keys: [key({ revokedAt: Date.parse('2026-07-02T00:00:00Z') })],
+    });
+    renderWithIntl(<ApiKeysPanel />);
+
+    expect(await screen.findByText('Revoked')).toBeTruthy();
+    expect(screen.queryByText('Revoke')).toBeNull();
+  });
+
+  it('creates a key with the checked default scope and never sends an empty scopes array', async () => {
+    mockListApiKeys.mockResolvedValue({ keys: [] });
+    mockCreateApiKey.mockResolvedValue({
+      key: key(),
+      token: 'sk-live-plaintext-token-value',
+    });
+    renderWithIntl(<ApiKeysPanel />);
+
+    await screen.findByText(/No API keys yet/i);
+    fireEvent.click(screen.getByText('Create key'));
+
+    await waitFor(() => expect(mockCreateApiKey).toHaveBeenCalledTimes(1));
+    const call = mockCreateApiKey.mock.calls[0];
+    expect(call).toBeDefined();
+    const payload = call?.[0];
+    expect(payload.scopes).toEqual(['chat:write']);
+    expect(payload.scopes.length).toBeGreaterThan(0); // regression guard: never []
+  });
+
+  it('reveals the plaintext token exactly once after creation, with a dismiss-to-confirm reveal', async () => {
+    mockListApiKeys.mockResolvedValue({ keys: [] });
+    mockCreateApiKey.mockResolvedValue({
+      key: key(),
+      token: 'sk-live-plaintext-token-value',
+    });
+    renderWithIntl(<ApiKeysPanel />);
+
+    await screen.findByText(/No API keys yet/i);
+    fireEvent.click(screen.getByText('Create key'));
+
+    expect(await screen.findByText('sk-live-plaintext-token-value')).toBeTruthy();
+    expect(screen.getByText(/only time this token is shown/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByText(/dismiss/i));
+    expect(screen.queryByText('sk-live-plaintext-token-value')).toBeNull();
+  });
+
+  it('blocks submission and explains why when the only scope checkbox is unchecked', async () => {
+    mockListApiKeys.mockResolvedValue({ keys: [] });
+    renderWithIntl(<ApiKeysPanel />);
+
+    await screen.findByText(/No API keys yet/i);
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(screen.getByText('Create key')).toHaveProperty('disabled', true);
+    expect(screen.getByText(/at least one scope/i)).toBeTruthy();
+    expect(mockCreateApiKey).not.toHaveBeenCalled();
+  });
+
+  it('requires a confirmation step before revoking — the first click only arms it', async () => {
+    mockListApiKeys.mockResolvedValue({ keys: [key()] });
+    renderWithIntl(<ApiKeysPanel />);
+
+    await screen.findByText('CI bot');
+    fireEvent.click(screen.getByText('Revoke'));
+
+    expect(mockRevokeApiKey).not.toHaveBeenCalled();
+    expect(screen.getByText(/can't be undone/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Confirm revoke'));
+    await waitFor(() => expect(mockRevokeApiKey).toHaveBeenCalledWith('key-1'));
+  });
+
+  it('cancelling the revoke confirmation does not call the API', async () => {
+    mockListApiKeys.mockResolvedValue({ keys: [key()] });
+    renderWithIntl(<ApiKeysPanel />);
+
+    await screen.findByText('CI bot');
+    fireEvent.click(screen.getByText('Revoke'));
+    fireEvent.click(screen.getByText('Cancel'));
+
+    expect(mockRevokeApiKey).not.toHaveBeenCalled();
+    expect(screen.getByText('Revoke')).toBeTruthy();
+  });
+
+  it('updates the row to Revoked in place after a confirmed revoke', async () => {
+    mockListApiKeys.mockResolvedValue({ keys: [key()] });
+    mockRevokeApiKey.mockResolvedValue({
+      key: key({ revokedAt: Date.parse('2026-07-03T00:00:00Z') }),
+    });
+    renderWithIntl(<ApiKeysPanel />);
+
+    await screen.findByText('CI bot');
+    fireEvent.click(screen.getByText('Revoke'));
+    fireEvent.click(screen.getByText('Confirm revoke'));
+
+    expect(await screen.findByText('Revoked')).toBeTruthy();
+    expect(screen.queryByText('Confirm revoke')).toBeNull();
+  });
+
+  it('shows a validation error and disables submit for an out-of-range rate limit', async () => {
+    mockListApiKeys.mockResolvedValue({ keys: [] });
+    renderWithIntl(<ApiKeysPanel />);
+
+    await screen.findByText(/No API keys yet/i);
+    const rateLimitInput = screen.getByPlaceholderText('60');
+    fireEvent.change(rateLimitInput, { target: { value: '99999' } });
+
+    expect(screen.getByText('Create key')).toHaveProperty('disabled', true);
+    expect(mockCreateApiKey).not.toHaveBeenCalled();
+  });
+});

--- a/web-ui/app/admin/api-keys/_components/__tests__/ApiKeysPanel.test.tsx
+++ b/web-ui/app/admin/api-keys/_components/__tests__/ApiKeysPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { renderWithIntl } from '../../../../_lib/test-utils';
@@ -118,7 +118,7 @@ describe('<ApiKeysPanel />', () => {
     expect(await screen.findByText('sk-live-plaintext-token-value')).toBeTruthy();
     expect(screen.getByText(/only time this token is shown/i)).toBeTruthy();
 
-    fireEvent.click(screen.getByText(/dismiss/i));
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
     expect(screen.queryByText('sk-live-plaintext-token-value')).toBeNull();
   });
 
@@ -185,5 +185,91 @@ describe('<ApiKeysPanel />', () => {
 
     expect(screen.getByText('Create key')).toHaveProperty('disabled', true);
     expect(mockCreateApiKey).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-integer rate limit instead of silently truncating it', async () => {
+    mockListApiKeys.mockResolvedValue({ keys: [] });
+    renderWithIntl(<ApiKeysPanel />);
+
+    await screen.findByText(/No API keys yet/i);
+    fireEvent.change(screen.getByPlaceholderText('60'), { target: { value: '60.7' } });
+
+    expect(screen.getByText('Create key')).toHaveProperty('disabled', true);
+    expect(mockCreateApiKey).not.toHaveBeenCalled();
+  });
+
+  // Regression guard for a codex review finding: creating a second key while
+  // the first one's plaintext token is still displayed would silently
+  // overwrite it in React state before the operator could copy it — the
+  // create form must stay blocked until the reveal is explicitly dismissed.
+  it('blocks creating a second key while a token reveal is still showing', async () => {
+    mockListApiKeys.mockResolvedValue({ keys: [] });
+    mockCreateApiKey.mockResolvedValue({
+      key: key(),
+      token: 'sk-live-plaintext-token-value',
+    });
+    renderWithIntl(<ApiKeysPanel />);
+
+    await screen.findByText(/No API keys yet/i);
+    fireEvent.click(screen.getByText('Create key'));
+
+    expect(await screen.findByText('sk-live-plaintext-token-value')).toBeTruthy();
+    expect(screen.getByText('Create key')).toHaveProperty('disabled', true);
+    expect(screen.getByText(/Dismiss the token above/i)).toBeTruthy();
+    expect(mockCreateApiKey).toHaveBeenCalledTimes(1);
+
+    // Dismissing re-enables it.
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(screen.getByText('Create key')).toHaveProperty('disabled', false);
+  });
+
+  // Regression guard for a codex review finding: a single global `pendingId`
+  // meant a second row's revoke could clear the first row's busy/confirm
+  // state (and vice versa) when either promise settled.
+  it('revokes two different keys concurrently without one clobbering the other\'s confirm state', async () => {
+    mockListApiKeys.mockResolvedValue({ keys: [key({ id: 'key-1' }), key({ id: 'key-2', label: 'Second bot' })] });
+    let resolveFirst: ((v: { key: ApiKeyPublicView }) => void) | undefined;
+    mockRevokeApiKey.mockImplementation((id: string) => {
+      if (id === 'key-1') {
+        return new Promise((resolve) => {
+          resolveFirst = resolve;
+        });
+      }
+      return Promise.resolve({ key: key({ id: 'key-2', label: 'Second bot', revokedAt: Date.now() }) });
+    });
+    renderWithIntl(<ApiKeysPanel />);
+
+    await screen.findByText('CI bot');
+    await screen.findByText('Second bot');
+
+    // Arm + confirm the first row — its revoke call hangs (not yet resolved).
+    const firstRevokeButton = screen.getAllByText('Revoke')[0];
+    expect(firstRevokeButton).toBeDefined();
+    fireEvent.click(firstRevokeButton as HTMLElement);
+    fireEvent.click(screen.getByText('Confirm revoke'));
+    await waitFor(() => expect(mockRevokeApiKey).toHaveBeenCalledWith('key-1'));
+
+    // Arm + confirm the second row while the first is still in flight. Only
+    // one "Revoke" button remains (row 1 is now showing its confirm UI).
+    const secondRevokeButton = screen.getAllByText('Revoke')[0];
+    expect(secondRevokeButton).toBeDefined();
+    fireEvent.click(secondRevokeButton as HTMLElement);
+    fireEvent.click(screen.getByText('Confirm revoke'));
+    await waitFor(() => expect(mockRevokeApiKey).toHaveBeenCalledWith('key-2'));
+
+    // Row 2 finishing must not resurrect row 1's plain "Revoke" button or
+    // otherwise clear row 1's still-pending confirm state. Row 1's confirm
+    // button itself now reads "Revoking" (it's genuinely busy), so assert on
+    // the stable confirm-panel copy rather than the label that flips to busy
+    // text — and assert the plain (non-armed) "Revoke" button is gone from
+    // that row.
+    await screen.findByText('Revoked');
+    const row1 = screen.queryByText('CI bot')?.closest('li') as HTMLElement;
+    expect(within(row1).getByText(/can't be undone/i)).toBeTruthy();
+    expect(within(row1).queryByText('Revoke')).toBeNull();
+
+    // Now let row 1 resolve too.
+    resolveFirst?.({ key: key({ id: 'key-1', revokedAt: Date.now() }) });
+    await waitFor(() => expect(screen.getAllByText('Revoked').length).toBe(2));
   });
 });

--- a/web-ui/app/admin/api-keys/_components/shared.tsx
+++ b/web-ui/app/admin/api-keys/_components/shared.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { ApiError } from '@/app/_lib/api';
+
+/** Shared styling + error-formatting for the API-keys admin panel — mirrors
+ *  the same tiny per-feature `shared.tsx` pattern already used by
+ *  `admin/webhooks/_components/shared.tsx` rather than reaching for a
+ *  cross-feature util module. */
+
+export const inputCls =
+  'w-full rounded-md border border-[color:var(--border)] bg-transparent px-3 py-2 text-sm outline-none focus:border-[color:var(--accent)]';
+
+export const card = 'rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4';
+
+/** Scope / data chip — Geist Mono register per the Lume type-scale (§2.7,
+ *  `.type-mono-data`), since a scope string is data, not UI chrome. */
+export const chipCls =
+  'type-mono-data inline-flex items-center rounded-full border border-[color:var(--border)] px-2 py-0.5 text-[11px] lowercase text-[color:var(--fg-muted)]';
+
+export function toFriendlyError(err: unknown): string {
+  if (err instanceof ApiError) return err.body || err.message;
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Active/revoked status — text + a 1px edge + at most a light tint, never a
+ * solid-filled pill (Lume state-color rule, spec §2.6). Same recipe as
+ * `admin/webhooks/_components/shared.tsx`'s `StatusBadge`.
+ */
+export function KeyStatusBadge({ revokedAt }: { revokedAt?: number }): React.ReactElement {
+  const t = useTranslations('adminApiKeys.list.status');
+  const revoked = revokedAt !== undefined;
+  return (
+    <span
+      className={[
+        'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] uppercase tracking-[0.16em]',
+        revoked
+          ? 'border-[color:var(--danger-edge)]/50 bg-[color:var(--danger)]/8 text-[color:var(--danger)]'
+          : 'border-[color:var(--success)]/50 bg-[color:var(--success)]/8 text-[color:var(--success)]',
+      ].join(' ')}
+    >
+      {revoked ? t('revoked') : t('active')}
+    </span>
+  );
+}

--- a/web-ui/app/admin/api-keys/_components/shared.tsx
+++ b/web-ui/app/admin/api-keys/_components/shared.tsx
@@ -19,8 +19,41 @@ export const card = 'rounded-lg border border-[color:var(--border)] bg-[color:va
 export const chipCls =
   'type-mono-data inline-flex items-center rounded-full border border-[color:var(--border)] px-2 py-0.5 text-[11px] lowercase text-[color:var(--fg-muted)]';
 
-export function toFriendlyError(err: unknown): string {
-  if (err instanceof ApiError) return err.body || err.message;
+/**
+ * Block-level error text — text + a 1px edge + a light tint, never
+ * text-only and never a solid fill (Lume state-color rule, spec §2.6). Same
+ * recipe used repo-wide for inline error banners, e.g.
+ * `admin/domains/page.tsx`'s `loadError` paragraph.
+ */
+export const errorTextCls =
+  'rounded-md border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/10 px-3 py-2 text-[13px] text-[color:var(--danger)]';
+
+/** Compact inline variant of `errorTextCls` for a short note sitting next to
+ *  buttons rather than a full-width paragraph (e.g. a copy-to-clipboard
+ *  fallback notice) — same border+tint recipe, smaller footprint. */
+export const errorInlineCls =
+  'inline-flex items-center gap-1 rounded-md border border-[color:var(--danger-edge)]/50 bg-[color:var(--danger)]/8 px-2 py-0.5 text-[12px] text-[color:var(--danger)]';
+
+type TFn = (key: string, values?: Record<string, string | number>) => string;
+
+/**
+ * web-ui/CLAUDE.md hard rule #3: never render a raw ApiError/exception
+ * message as the primary UI text. Maps the backend's known `{error|code}`
+ * response shapes (see `adminKeysRouter.ts`) to translated catalog messages
+ * and falls back to a generic "request failed (status N)" message — never
+ * the raw response body, which for a 400 can be a zod `issues` array dumped
+ * as JSON. Mirrors `admin/registries/page.tsx`'s `toFriendlyError`.
+ */
+export function toFriendlyError(err: unknown, t: TFn): string {
+  if (err instanceof ApiError) {
+    if (err.body.includes('not_found')) return t('errors.notFound');
+    if (err.body.includes('operator_auth.unavailable')) return t('errors.authUnavailable');
+    if (err.body.includes('auth.missing') || err.body.includes('auth.invalid')) {
+      return t('errors.sessionExpired');
+    }
+    if (err.body.includes('invalid_request')) return t('errors.invalidRequest');
+    return t('errors.generic', { status: err.status });
+  }
   return err instanceof Error ? err.message : String(err);
 }
 

--- a/web-ui/app/admin/api-keys/page.tsx
+++ b/web-ui/app/admin/api-keys/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import { ApiKeysPanel } from './_components/ApiKeysPanel';
+
+/**
+ * Issues #438/#439 admin surface — server-to-server bearer credentials for
+ * the public chat API (`POST /api/public/v1/chat`). Create/list/revoke only;
+ * there is no update or rotate — a key that needs different scopes or a
+ * different rate limit is revoked and replaced by a new one, keeping the
+ * "plaintext shown exactly once, at creation" invariant simple to reason
+ * about (no second code path that could leak a token after the fact).
+ */
+export default function AdminApiKeysPage(): React.ReactElement {
+  const t = useTranslations('adminApiKeys');
+
+  return (
+    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-8 lg:py-16">
+      <header className="mb-8">
+        <h1 className="font-display text-[clamp(1.75rem,3.5vw,2.5rem)] leading-[1.1] text-[color:var(--fg-strong)]">
+          {t('title')}
+        </h1>
+        <p className="mt-3 max-w-2xl text-[15px] leading-[1.55] text-[color:var(--fg-muted)]">
+          {t('intro')}
+        </p>
+      </header>
+
+      <ApiKeysPanel />
+    </main>
+  );
+}

--- a/web-ui/app/admin/page.tsx
+++ b/web-ui/app/admin/page.tsx
@@ -84,6 +84,7 @@ const GROUPS: readonly GroupDef[] = [
     cards: [
       { href: '/admin/auth', key: 'auth' },
       { href: '/admin/users', key: 'users' },
+      { href: '/admin/api-keys', key: 'apiKeys' },
     ],
   },
   {

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -240,6 +240,10 @@
         "dangerZone": {
           "title": "Memory-Purge",
           "description": "Memory unwiderruflich entlang einer Achse löschen (Alles, Agent, User, Team, Channel); Vorschau-gated mit Confirm-Phrase, kein Undo."
+        },
+        "apiKeys": {
+          "title": "Öffentliche API-Schlüssel",
+          "description": "Bearer-Zugangsdaten für die öffentliche Chat-API erstellen, auflisten und widerrufen (Issues #438/#439)."
         }
       }
     },
@@ -4137,6 +4141,48 @@
       "dotInactive": "Inaktiv",
       "keySourceDevFile": "dev-file (nicht für Produktion)",
       "keySourceDevFileCreated": "dev-file (neu generiert — DEV ONLY)"
+    }
+  },
+  "adminApiKeys": {
+    "title": "Öffentliche API-Schlüssel",
+    "intro": "Server-zu-Server-Bearer-Zugangsdaten für die öffentliche Chat-API. Das Klartext-Token eines Schlüssels wird genau einmal angezeigt, direkt nach dem Erstellen — sofort kopieren, es kann danach nicht erneut abgerufen werden, auch nicht von einem Operator.",
+    "create": {
+      "heading": "Neuen Schlüssel erstellen",
+      "fields": {
+        "label": "Label (optional)",
+        "rateLimit": "Rate-Limit (Anfragen/Minute, optional)"
+      },
+      "rateLimitInvalid": "Rate-Limit muss zwischen {min} und {max} Anfragen/Minute liegen.",
+      "scopesRequired": "Mindestens einen Scope auswählen — ein Schlüssel ohne Scope kann nichts tun.",
+      "submit": "Schlüssel erstellen",
+      "creating": "Wird erstellt"
+    },
+    "reveal": {
+      "heading": "Neuer API-Schlüssel erstellt",
+      "warning": "Dieses Token wird nur dieses eine Mal angezeigt. Jetzt kopieren — es kann danach nicht erneut abgerufen werden, auch nicht von einem Operator.",
+      "copy": "Kopieren",
+      "copied": "Kopiert",
+      "copyFailed": "Automatisches Kopieren fehlgeschlagen — Token oben markieren und manuell kopieren.",
+      "dismiss": "Kopiert, ausblenden"
+    },
+    "list": {
+      "heading": "Vorhandene Schlüssel",
+      "loading": "Lädt …",
+      "empty": "Noch keine API-Schlüssel. Oben einen erstellen, um loszulegen.",
+      "unlabeled": "Ohne Label",
+      "createdAt": "Erstellt {date}",
+      "rateLimitValue": "{value}/Min",
+      "status": {
+        "active": "Aktiv",
+        "revoked": "Widerrufen"
+      },
+      "revoke": "Widerrufen",
+      "revoking": "Wird widerrufen",
+      "confirmRevoke": {
+        "message": "Diesen Schlüssel widerrufen? Alles, was ihn verwendet, hört sofort auf zu funktionieren — das kann nicht rückgängig gemacht werden.",
+        "confirm": "Widerruf bestätigen",
+        "cancel": "Abbrechen"
+      }
     }
   }
 }

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -4154,6 +4154,7 @@
       },
       "rateLimitInvalid": "Rate-Limit muss zwischen {min} und {max} Anfragen/Minute liegen.",
       "scopesRequired": "Mindestens einen Scope auswählen — ein Schlüssel ohne Scope kann nichts tun.",
+      "blockedByReveal": "Das Token oben zuerst ausblenden, bevor ein weiterer Schlüssel erstellt wird.",
       "submit": "Schlüssel erstellen",
       "creating": "Wird erstellt"
     },
@@ -4183,6 +4184,13 @@
         "confirm": "Widerruf bestätigen",
         "cancel": "Abbrechen"
       }
+    },
+    "errors": {
+      "notFound": "Dieser Schlüssel existiert nicht mehr — die Liste wurde aktualisiert.",
+      "authUnavailable": "Operator-Authentifizierung ist gerade nicht verfügbar. Bitte in Kürze erneut versuchen.",
+      "sessionExpired": "Die Sitzung ist abgelaufen. Weiterleitung zur Anmeldung …",
+      "invalidRequest": "Die Anfrage war ungültig — bitte die Werte oben prüfen und erneut versuchen.",
+      "generic": "Etwas ist schiefgelaufen (Fehler {status})."
     }
   }
 }

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -4154,6 +4154,7 @@
       },
       "rateLimitInvalid": "Rate limit must be between {min} and {max} requests/minute.",
       "scopesRequired": "Select at least one scope — a key with none cannot do anything.",
+      "blockedByReveal": "Dismiss the token above before creating another key.",
       "submit": "Create key",
       "creating": "Creating"
     },
@@ -4183,6 +4184,13 @@
         "confirm": "Confirm revoke",
         "cancel": "Cancel"
       }
+    },
+    "errors": {
+      "notFound": "That key no longer exists — the list has been refreshed.",
+      "authUnavailable": "Operator authentication is unavailable right now. Try again shortly.",
+      "sessionExpired": "Your session has expired. Redirecting to sign in…",
+      "invalidRequest": "That request was invalid — check the values above and try again.",
+      "generic": "Something went wrong (error {status})."
     }
   }
 }

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -240,6 +240,10 @@
         "dangerZone": {
           "title": "Memory Purge",
           "description": "Irreversibly delete memory along one axis (all, agent, user, team, channel); preview-gated with a confirm phrase, no undo."
+        },
+        "apiKeys": {
+          "title": "Public API Keys",
+          "description": "Create, list, and revoke bearer credentials for the public chat API (issues #438/#439)."
         }
       }
     },
@@ -4137,6 +4141,48 @@
       "dotInactive": "Inactive",
       "keySourceDevFile": "dev file (not for production)",
       "keySourceDevFileCreated": "dev file (newly generated — DEV ONLY)"
+    }
+  },
+  "adminApiKeys": {
+    "title": "Public API Keys",
+    "intro": "Server-to-server bearer credentials for the public chat API. A key’s plaintext token is shown exactly once, right after creation — copy it immediately, it cannot be retrieved again, even by an operator.",
+    "create": {
+      "heading": "Create a new key",
+      "fields": {
+        "label": "Label (optional)",
+        "rateLimit": "Rate limit (requests/minute, optional)"
+      },
+      "rateLimitInvalid": "Rate limit must be between {min} and {max} requests/minute.",
+      "scopesRequired": "Select at least one scope — a key with none cannot do anything.",
+      "submit": "Create key",
+      "creating": "Creating"
+    },
+    "reveal": {
+      "heading": "New API key created",
+      "warning": "This is the only time this token is shown. Copy it now — it cannot be retrieved again, even by an operator.",
+      "copy": "Copy",
+      "copied": "Copied",
+      "copyFailed": "Couldn't copy automatically — select the token above and copy it manually.",
+      "dismiss": "I've copied it, dismiss"
+    },
+    "list": {
+      "heading": "Existing keys",
+      "loading": "Loading …",
+      "empty": "No API keys yet. Create one above to get started.",
+      "unlabeled": "Unlabeled",
+      "createdAt": "Created {date}",
+      "rateLimitValue": "{value}/min",
+      "status": {
+        "active": "Active",
+        "revoked": "Revoked"
+      },
+      "revoke": "Revoke",
+      "revoking": "Revoking",
+      "confirmRevoke": {
+        "message": "Revoke this key? Anything using it stops working immediately — this can't be undone.",
+        "confirm": "Confirm revoke",
+        "cancel": "Cancel"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds the admin UI for the public API keys introduced by #438/#439: create,
list, and revoke server-to-server bearer credentials for
`POST /api/public/v1/chat` at `/admin/api-keys` — create/list/revoke against
`/api/public/v1/admin/keys`, gated by the same operator-session cookie every
other admin page uses.

Stacked on #549 (`feat/issue-438-439-public-api`) since that hasn't merged
yet — this PR targets that branch, not `main`.

## What's in this page

- **Create**: label (optional), rate limit (optional, 1–6000 req/min,
  integers only), and the single `chat:write` scope checkbox (hardcoded —
  it's the only scope that exists today).
- **Reveal-once token**: a created key's plaintext token is shown exactly
  once, right after creation, and is never re-derived from a list reload
  (the list endpoint never returns a token field). The create form —
  button and every field — is disabled while that reveal is still on
  screen, so a second create can never silently overwrite the first key's
  only-ever-shown token before it's copied.
- **Revoke**: two-step arm-then-confirm per row. Busy/confirm state is
  tracked per key id (not a single shared value), so concurrent revokes on
  different rows don't clobber each other's UI state.
- **List reload sequencing**: a monotonic counter guards against an
  out-of-order response (a slower in-flight fetch) overwriting a newer
  one's result.
- **Errors**: known backend error shapes (`not_found`,
  `operator_auth.unavailable`, `auth.missing`/`auth.invalid`,
  `invalid_request`) map to translated catalog messages under
  `adminApiKeys.errors.*`; nothing renders the raw backend response body.
- Dates use `useFormatter().dateTime(...)`, not `toLocaleString()`.

## Review history

A codex adversarial review round found 5 blocking findings against the
initial version of this page (token-overwrite bug, two race conditions,
a Lume state-color violation, and a hard i18n-rule violation) plus one
lower-severity note (decimal rate-limit input silently truncated). All 5
are fixed in this PR — see the commit for the fix-by-fix breakdown — and
a re-review round confirmed the fixes.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` (api-keys dir) — clean
- [x] `npm run i18n:check` — 0 errors, no new "identical to en" warnings
- [x] `npx vitest run` — 409/409 tests, 54/54 files (under the repo's
      pinned Node 22.22.3 — a system Node version mismatch in the sandbox
      breaks 5 unrelated, pre-existing tests in `toolTemplates.test.ts` on
      newer Node; confirmed unrelated to this diff)
- [x] Two new interaction-level tests exercise the token-overwrite fix and
      the concurrent-revoke race-condition fix directly via React Testing
      Library `fireEvent`
- [ ] Live-browser (Interceptor) visual check — attempted, blocked by an
      unrelated pre-existing dev-server bug (Turbopack/Tailwind 500s on
      every page due to a literal `text-[color:var(...)]` example string in
      doc comments in two untouched test files); not something this PR
      introduced or is in scope to fix

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787993960&installation_model_id=428086&pr_number=551&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F551&signature=d73e0dc0dd652961678878b427cce801b175573cbddd4e2a824d104eaf8cb2d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->