### PR TITLE
fix(ci): restore core-decoupling ratchet to baseline — main is red after #549

### DIFF
--- a/middleware/packages/harness-api-key-auth/src/apiKeyToken.ts
+++ b/middleware/packages/harness-api-key-auth/src/apiKeyToken.ts
@@ -4,9 +4,11 @@
  * any plugin can share the SAME implementation (core must never import from a
  * channel plugin).
  *
- * Mirrors `middleware/src/devplatform/jobToken.ts` (the dev-runner's one-time
- * job token), the closest existing precedent for a bearer credential this
- * codebase hashes at rest and verifies in constant time. The plaintext exists
+ * Follows the shape this codebase already uses for one-time bearer credentials
+ * elsewhere: hashed at rest, verified in constant time, plaintext shown once.
+ * (The path is deliberately not cited — the closest precedent lives in the Dev
+ * Platform, which epic #470 is extracting into its own repository.) The
+ * plaintext exists
  * exactly once — at creation time, returned to the operator — and is never
  * persisted. Only its sha256 hex lands in the vault (`apiKeyStore.ts`).
  * Verification hashes the presented token and compares digests with
@@ -16,7 +18,7 @@
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 
 /** Every minted key carries this prefix so it is greppable in logs/incidents
- *  and visually distinct from other omadia tokens (e.g. `djr_`). */
+ *  and visually distinct from the other prefixed token families omadia mints. */
 export const API_KEY_PREFIX = 'omk_';
 
 /** 32 random bytes → 43 base64url chars; with the prefix, a 47-char key. */

--- a/middleware/test/channelApi/apiKeyToken.test.ts
+++ b/middleware/test/channelApi/apiKeyToken.test.ts
@@ -12,9 +12,10 @@ import {
 } from '../../packages/harness-api-key-auth/src/apiKeyToken.js';
 
 /**
- * Issue #438 — pure-unit coverage for the API-key token, mirroring
- * `test/devplatform/jobToken.test.ts` (the closest existing precedent for a
- * hashed, constant-time-verified bearer credential in this codebase).
+ * Issue #438 — pure-unit coverage for the API-key token, following the coverage
+ * shape this codebase already uses for hashed, constant-time-verified bearer
+ * credentials: prefix and entropy, hash-only persistence, and a verify path
+ * that rejects on any mismatch without leaking timing.
  */
 describe('channelApi/apiKeyToken', () => {
   it('mints `omk_` + 32 random bytes base64url, and stores only the sha256 hex', () => {


### PR DESCRIPTION
## Summary

`main` is currently red. PR #549 was auto-merged (squash, `f437622e`) while its
`core decoupling ratchet (#470)` check was failing, so the violation landed on
`main` — where it is now the **only** failing job on CI run
[30535047184](https://github.com/byte5ai/omadia/actions/runs/30535047184).

```
Core re-acquired Dev Platform references: 3303 → 3306
  middleware/test: 965 → 966
  middleware/packages: 97 → 99
```

## What actually regressed

Nothing structural. All three new hits are **doc comments**, not code coupling:

| File | Reference |
|---|---|
| `middleware/packages/harness-api-key-auth/src/apiKeyToken.ts:7` | `middleware/src/devplatform/jobToken.ts`, `dev-runner` |
| `middleware/packages/harness-api-key-auth/src/apiKeyToken.ts:19` | `djr_` token prefix |
| `middleware/test/channelApi/apiKeyToken.test.ts:16` | `test/devplatform/jobToken.test.ts` |

They cited the Dev Platform's one-time job token as the precedent for a bearer
credential that is hashed at rest and verified in constant time. The precedent
is real and the reasoning was sound — but naming it re-couples core to the Dev
Platform, and the cited paths go stale the moment epic #470 extracts it into its
own repository. So this was a latent documentation bug sitting on top of a
ratchet violation.

## Fix

Reworded all three to describe the *pattern* rather than point at the file.
No source or test behaviour changes — the diff is comments only.

**The baseline is not raised.** It stays at 3303, which is the point: the
ratchet only ever goes down.

## Verification

- `node scripts/check-core-decoupling.mjs` → `Dev Platform references held at 3303.` (exit 0)
- `npm run typecheck` → clean
- `npm run lint` → 0 errors (1 pre-existing warning in the untouched `harness-orchestrator/src/mcp/mcpClient.ts`)
- `npx tsx --test test/channelApi/*.test.ts test/auth/*.test.ts` → **147/147 pass**
- Diff verified comment-only (no non-comment line changed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788002168&installation_model_id=428086&pr_number=553&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F553&signature=dac4357b27782f852db5b3c7c1a8fe8348ebc0732d1276a9ef2706296262acbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->