### PR TITLE
fix(ci): auto-release never detects feat/fix once the log exceeds the pipe buffer

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -67,20 +67,33 @@ jobs:
           if [ -z "$latest" ]; then latest="v0.0.0"; range="HEAD"; else range="${latest}..HEAD"; fi
           echo "latest tag: $latest (range: $range)"
 
-          msgs=$(git log --no-merges --pretty=format:'%s%n%b' $range)
+          # Write the log to a file rather than piping it into `grep -q`.
+          # `grep -q` exits at the first match, so a pipe writer that still has
+          # data buffered gets EPIPE — and under `set -o pipefail` that failed
+          # writer, not grep's 0, becomes the pipeline's status. The condition
+          # then reads as "no match" precisely BECAUSE there was a match. It only
+          # bites once the log exceeds the 64 KiB pipe buffer, so the release
+          # workflow worked until enough commits accumulated and then wedged
+          # permanently: no release -> no new tag -> a longer range next time.
+          # See v0.56.0 (2026-06-30) .. v0.57.0. grep reading a file cannot EPIPE.
+          msgs=$(mktemp)
+          git log --no-merges --pretty=format:'%s%n%b' $range > "$msgs"
 
           bump=""
-          if printf '%s\n' "$msgs" | grep -qE 'BREAKING CHANGE' \
-             || printf '%s\n' "$msgs" | grep -qE '^[a-z]+(\(.+\))?!:'; then
+          if grep -qE 'BREAKING CHANGE' "$msgs" \
+             || grep -qE '^[a-z]+(\(.+\))?!:' "$msgs"; then
             bump="minor"                       # pre-1.0: breaking -> minor
-          elif printf '%s\n' "$msgs" | grep -qE '^feat(\(.+\))?:'; then
+          elif grep -qE '^feat(\(.+\))?:' "$msgs"; then
             bump="minor"
-          elif printf '%s\n' "$msgs" | grep -qE '^fix(\(.+\))?:'; then
+          elif grep -qE '^fix(\(.+\))?:' "$msgs"; then
             bump="patch"
           fi
 
           if [ -z "$bump" ]; then
-            echo "No feat/fix commits since $latest — skipping release."
+            # Print the range size too: "0 commits" is a normal skip, whereas
+            # "no feat/fix among N commits" for a large N is the signature of a
+            # detection bug and should be visible in the log, not silent.
+            echo "No feat/fix commits among $(git rev-list --no-merges --count $range) commit(s) since $latest — skipping release."
             exit 0
           fi
 


### PR DESCRIPTION
## Problem

The release pipeline has not cut a release since **v0.56.0 (2026-06-30)**, despite 19 `feat:`/`fix:` commits landing on `main`. Every `auto-release` run since has succeeded while logging `No feat/fix commits since v0.56.0 — skipping release`, which also skipped `publish-images` and `desktop-apps` (no images, no desktop installers for a month).

## Root cause

The bump detection piped the entire `git log` into `grep -q`:

```bash
elif printf '%s\n' "$msgs" | grep -qE '^feat(\(.+\))?:'; then
```

`grep -q` exits at the **first match**. If `printf` still has data buffered at that point, it gets `EPIPE`. Under `set -o pipefail` the pipeline's exit status is that failed writer, not grep's `0` — so the condition evaluates as *no match* **precisely because there was a match**.

Below ~64 KiB (the pipe buffer) `printf` completes before grep exits, so the pipeline is correct and the workflow worked for months. Past that threshold it inverts. And it wedges **permanently** rather than intermittently: no release → no new tag → a longer commit range on the next run.

The tell is visible in the log of [run 30552280319](https://github.com/byte5ai/omadia/actions/runs/30552280319) — `printf: write error: Broken pipe` on script lines 13 and 15, which map to exactly the `feat` and `fix` grep lines:

```
latest tag: v0.56.0 (range: v0.56.0..HEAD)
...: line 13: printf: write error: Broken pipe
...: line 15: printf: write error: Broken pipe
No feat/fix commits since v0.56.0 — skipping release.
```

Reproduced deterministically against the real range (655 KiB of log): `bump=[]` with 19 matching commits present.

## Fix

- Write the log to a file and let `grep` read the file. A file read cannot `EPIPE`, so the `pipefail` interaction disappears at the source rather than being papered over (e.g. by dropping `pipefail` or adding `|| true`, both of which would mask genuine failures).
- Report the range's commit count on the skip path. `No feat/fix among 0 commits` is a normal skip; `among 19 commits` is visibly wrong. This class of bug was silent for a month because the message was plausible either way.

`.github/workflows/auto-release.yml` was the only occurrence of the pattern in CI. The `| grep -q` uses in `desktop-apps.yml` read tiny `codesign`/`file` output and are unaffected.

## Verification

Replayed the real `v0.56.0..main` range with the fixed script, mutations (`git tag`/`git push`/`gh release create`) stubbed:

```
latest tag: v0.56.0 (range: v0.56.0..origin/main)
Releasing v0.57.0 (bump=minor)
STUB git tag v0.57.0
STUB gh release create v0.57.0
GITHUB_OUTPUT -> new_tag=v0.57.0
```

- `generate-changelog.mjs notes v0.56.0 main` exits 0 and produces 39 lines across `Added` / `Changed` / `Fixed`.
- `new_tag` is set, so `publish-images` and `desktop-apps` are no longer skipped.

## Note on merging

Merging this PR is itself a push to `main`, so it will trigger `auto-release` and cut **v0.57.0** covering the full month of accumulated commits — one release with the complete backlog rather than the 19 individual ones that were missed. Images and desktop installers will build for it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788064774&installation_model_id=428086&pr_number=556&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F556&signature=a995dd152195c7e2ea9395e50f176dedda6dd66355043a2cff7301e090018987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->