### PR TITLE
feat(desktop): build and ship a macOS Intel (x64) installer

### DIFF
--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -84,8 +84,13 @@ jobs:
           - os: windows-latest
             args: --win
     runs-on: ${{ matrix.os }}
-    # Hard cap so a stuck native build can never run for hours.
-    timeout-minutes: 30
+    # Hard cap so a stuck native build can never run for hours. Measured on a
+    # full signed+notarized run: linux 5 min, windows 9 min, macOS arm64 21 min,
+    # macOS Intel >30 min — the Intel runner is materially slower and blew the
+    # previous 30-minute cap mid-signing, which then took the update-feed merge
+    # down with it. 60 keeps the runaway protection with real headroom, and
+    # notarization wait times are set by Apple, not by us.
+    timeout-minutes: 60
     env:
       TAG: ${{ github.event.release.tag_name || inputs.tag }}
       # 'yes' unless a workflow_dispatch explicitly passed notarize=false. The

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -64,11 +64,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # macOS is Apple Silicon (arm64) only for v1 — see the rationale in
-          # desktop/electron-builder.yml (extraResources can't be arch-split, and
-          # Intel runners queue for hours). Intel x64 is a tracked follow-up.
+          # macOS ships BOTH architectures, each built on a runner of its own
+          # architecture. That is mandatory, not a preference: the omadia runtime
+          # rides along as unpacked extraResources (native node modules + the
+          # embedded Postgres engine) which electron-builder copies verbatim and
+          # cannot arch-split, so an x64 bundle produced on an arm64 host would
+          # contain arm64 binaries and crash on Intel.
           - os: macos-latest
             args: --mac --arm64
+          # macos-13 was retired in Dec 2025; macos-26-intel is the current
+          # x86_64 image. GitHub drops x86_64 entirely in August 2027, at which
+          # point this entry has to go (or move to a self-hosted Intel runner).
+          - os: macos-26-intel
+            args: --mac --x64
           # Linux + Windows each provision a PG17 pgvector for their embedded
           # engine below (apt pgdg / MSVC nmake build) before staging. x64 only.
           - os: ubuntu-latest
@@ -184,12 +192,32 @@ jobs:
         run: |
           brew install pgvector
           PV="$(brew --prefix pgvector)"
-          NATIVE="desktop/node_modules/@embedded-postgres/darwin-arm64/native"
+          # Must follow the RUNNER's architecture, not a fixed value: the Intel
+          # runner installs an x86_64 pgvector and needs it staged into the
+          # darwin-x64 engine. Homebrew also lives at a different prefix per arch
+          # (/usr/local vs /opt/homebrew), which `brew --prefix` already handles.
+          ARCH="$(node -p 'process.arch')"      # arm64 | x64
+          NATIVE="desktop/node_modules/@embedded-postgres/darwin-$ARCH/native"
+          if [ ! -d "$(dirname "$NATIVE")" ]; then
+            echo "FAIL: @embedded-postgres/darwin-$ARCH is not installed — the" >&2
+            echo "      engine for this architecture is missing, so the staged app" >&2
+            echo "      would ship without a database." >&2
+            exit 1
+          fi
           mkdir -p "$NATIVE/lib/postgresql" "$NATIVE/share/postgresql/extension"
           cp "$PV/lib/postgresql@17/vector.dylib" "$NATIVE/lib/postgresql/vector.dylib"
           cp "$PV/share/postgresql@17/extension/vector.control" "$NATIVE/share/postgresql/extension/"
           cp "$PV"/share/postgresql@17/extension/vector--*.sql "$NATIVE/share/postgresql/extension/"
-          echo "✓ pgvector staged into the embedded PG17 engine (darwin-arm64)"
+          # Prove the dylib really is this runner's architecture — a silently
+          # mismatched vector.dylib would only fail at CREATE EXTENSION, inside
+          # the shipped app, on a user's machine.
+          file "$NATIVE/lib/postgresql/vector.dylib"
+          EXPECT="$([ "$ARCH" = arm64 ] && echo arm64 || echo x86_64)"
+          if ! file "$NATIVE/lib/postgresql/vector.dylib" | grep -q "$EXPECT"; then
+            echo "FAIL: vector.dylib is not $EXPECT — wrong architecture staged." >&2
+            exit 1
+          fi
+          echo "✓ pgvector staged into the embedded PG17 engine (darwin-$ARCH, $EXPECT)"
 
       # Linux: the PostgreSQL APT repo (pgdg) ships a prebuilt postgresql-17-pgvector.
       # A PG17 vector.so loads in the embedded PG17 (extensions are ABI-stable within
@@ -454,6 +482,18 @@ jobs:
         run: |
           shopt -s nullglob
           files=(release/*.dmg release/*.zip release/*.exe release/*.AppImage release/*.deb release/*.blockmap release/latest*.yml)
+          # macOS is built once per architecture, and each run emits a
+          # `latest-mac.yml` listing only ITS OWN artifacts. Uploading both would
+          # leave whichever job finished last as the only updatable architecture.
+          # The `mac-update-feed` job below merges them and uploads the result.
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            keep=()
+            for f in "${files[@]}"; do
+              [[ "$(basename "$f")" == "latest-mac.yml" ]] || keep+=("$f")
+            done
+            files=("${keep[@]}")
+            echo "holding back latest-mac.yml — merged across architectures by the mac-update-feed job"
+          fi
           if [ ${#files[@]} -eq 0 ]; then
             echo "no installer artifacts found in desktop/release/" >&2
             exit 1
@@ -465,3 +505,66 @@ jobs:
             exit 0
           fi
           gh release upload "$TAG" "${files[@]}" --clobber
+
+  # Publishes the ONE `latest-mac.yml` that covers both architectures.
+  #
+  # electron-updater's MacUpdater picks its download by testing the file URL for
+  # "arm64", so a feed listing a single architecture leaves the other with no
+  # matching file (Intel) or silently pushes everyone onto Rosetta (arm64). The
+  # two mac jobs cannot produce this file between them — each only knows its own
+  # artifacts — so it is assembled here from both run artifacts.
+  mac-update-feed:
+    needs: build
+    # Runs even when another matrix leg failed (fail-fast is off), so a broken
+    # Windows build does not also cost macOS its update feed. If a mac artifact
+    # is genuinely missing the step below fails loudly rather than publishing a
+    # feed that covers only half the users.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Download the macOS build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: artifacts
+          pattern: omadia-installers-macos-*
+
+      - name: Merge the per-architecture update feeds
+        run: |
+          set -e
+          ARM="artifacts/omadia-installers-macos-latest/latest-mac.yml"
+          INTEL="artifacts/omadia-installers-macos-26-intel/latest-mac.yml"
+          for f in "$ARM" "$INTEL"; do
+            if [ ! -f "$f" ]; then
+              echo "FAIL: missing $f — one macOS architecture did not produce an" >&2
+              echo "      update feed. Refusing to publish a single-architecture" >&2
+              echo "      latest-mac.yml, which would break auto-update for the other." >&2
+              exit 1
+            fi
+          done
+          # arm64 goes first: it supplies the legacy top-level path/sha512 that
+          # pre-arch-aware updaters follow, and it is the majority of Macs.
+          node desktop/scripts/merge-mac-update-feed.mjs "$ARM" "$INTEL" latest-mac.yml
+          echo "--- merged latest-mac.yml ---"
+          cat latest-mac.yml
+
+      - name: Upload the merged feed to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            echo "no GitHub Release for '$TAG' — merge validated, skipping upload."
+            exit 0
+          fi
+          gh release upload "$TAG" latest-mac.yml --clobber

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -341,7 +341,12 @@ jobs:
             # and set its partition list with the CORRECT password, so point
             # electron-builder at it and skip the buggy detour.
             echo "CSC_KEYCHAIN=$KEYCHAIN"
-            echo "CSC_NAME=$IDENT"
+            # WITHOUT the "Developer ID Application: " prefix — electron-builder
+            # rejects it outright ("Please remove prefix ... from the specified
+            # name"); it adds the certificate type itself. afterPack, which calls
+            # codesign directly, still gets the full identity via
+            # MAC_SIGN_IDENTITY below.
+            echo "CSC_NAME=${IDENT#Developer ID Application: }"
             echo "APPLE_API_KEY=$RUNNER_TEMP/asc-key.p8"
             echo "APPLE_API_KEY_ID=$APPLE_ASC_KEY_ID"
             echo "APPLE_API_ISSUER=$APPLE_ASC_ISSUER_ID"

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -288,12 +288,11 @@ jobs:
           printf '%s' "$APPLE_P12_BASE64" | base64 -d > "$RUNNER_TEMP/developer-id.p12"
           printf '%s' "$APPLE_ASC_KEY_P8_BASE64" | base64 -d > "$RUNNER_TEMP/asc-key.p8"
 
-          # Import the Developer ID into a keychain NOW (before afterPack signs the
-          # nested native modules). electron-builder imports CSC_LINK into its own
-          # temp keychain only during its sign step, which runs AFTER afterPack —
-          # so afterPack would otherwise have no usable private key. We create our
-          # own keychain, import the key, and put it on the search list so both
-          # afterPack's `codesign --sign` and electron-builder find the key.
+          # This keychain is the ONLY one used for signing — see the CSC_KEYCHAIN
+          # note below for why electron-builder is deliberately kept from making
+          # its own. It must exist before afterPack, which signs the nested
+          # extraResources binaries and runs ahead of electron-builder's own sign
+          # step. Put it on the search list so both find the key.
           KEYCHAIN="$RUNNER_TEMP/omadia-signing.keychain-db"
           KCPASS="$(openssl rand -base64 24)"
           security create-keychain -p "$KCPASS" "$KEYCHAIN"
@@ -318,9 +317,31 @@ jobs:
           IDENT=$(security find-identity -v -p codesigning "$KEYCHAIN" \
             | sed -n 's/.*"\(Developer ID Application:[^"]*\)".*/\1/p' | head -1)
 
+          if [ -z "$IDENT" ]; then
+            echo "FAIL: the Developer ID was imported but no codesigning identity" >&2
+            echo "      is visible in the keychain — refusing to continue." >&2
+            exit 1
+          fi
+
           {
-            echo "CSC_LINK=file://$RUNNER_TEMP/developer-id.p12"
-            echo "CSC_KEY_PASSWORD=$APPLE_P12_PASSWORD"
+            # Deliberately NOT CSC_LINK. With CSC_LINK set, electron-builder
+            # builds its OWN temp keychain and then runs:
+            #
+            #   security set-key-partition-list -S apple-tool:,apple: -s -k <pw> <keychain>
+            #
+            # passing the *P12 passphrase* as <pw> while the keychain was created
+            # with a different, random password (app-builder-lib macCodeSign.js
+            # importCerts). That only works while the keychain happens to still be
+            # unlocked from moments earlier — it broke outright on the Intel
+            # runner with "SecKeychainUnlock: The user name or passphrase you
+            # entered is not correct", and was luck on arm64.
+            #
+            # macPackager.js: when CSC_LINK is absent it skips that path entirely
+            # and uses CSC_KEYCHAIN + CSC_NAME. We already built a keychain above
+            # and set its partition list with the CORRECT password, so point
+            # electron-builder at it and skip the buggy detour.
+            echo "CSC_KEYCHAIN=$KEYCHAIN"
+            echo "CSC_NAME=$IDENT"
             echo "APPLE_API_KEY=$RUNNER_TEMP/asc-key.p8"
             echo "APPLE_API_KEY_ID=$APPLE_ASC_KEY_ID"
             echo "APPLE_API_ISSUER=$APPLE_ASC_ISSUER_ID"
@@ -334,8 +355,10 @@ jobs:
             fi
             echo "MAC_SIGN_KEYCHAIN=$KEYCHAIN"
             echo "MAC_SIGN_EXPECTED=1"
+            # afterPack signs the nested extraResources binaries with this.
+            echo "MAC_SIGN_IDENTITY=$IDENT"
           } >> "$GITHUB_ENV"
-          if [ -n "$IDENT" ]; then echo "MAC_SIGN_IDENTITY=$IDENT" >> "$GITHUB_ENV"; fi
+          echo "signing identity: $IDENT"
 
       # --- Windows Authenticode signing (optional) --------------------------
       - name: Prepare Windows signing (optional — needs WINDOWS_CSC_* secrets)

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -123,6 +123,31 @@ Accepted v1 limitations (tracked for a follow-up):
 - No app/tray icons shipped yet (Electron defaults used).
 - No Linux target in v1 (mac + win only), though the code paths are cross-platform.
 
+## macOS: two architectures
+
+macOS ships **arm64 and x64 separately**, each built on a runner of its own
+architecture. That is forced by the design, not a preference: the omadia runtime
+rides along as unpacked `extraResources` (native node modules plus the embedded
+Postgres engine), which electron-builder copies verbatim and cannot arch-split.
+An x64 bundle produced on an arm64 host would contain arm64 binaries and crash on
+Intel — so a universal binary is not an option while the runtime ships this way.
+
+Consequences worth knowing before touching this:
+
+- Each run emits its own `latest-mac.yml` listing only its own artifacts, and
+  both target the same release. electron-updater's `MacUpdater` picks a download
+  by testing the file URL for `arm64`, so a single-architecture feed leaves Intel
+  users with no matching file, or pushes every Apple Silicon user onto Rosetta.
+  The mac jobs therefore **hold back** that file and the `mac-update-feed` job
+  merges both (`scripts/merge-mac-update-feed.mjs`, covered by `npm test`).
+- `stage-runtime.mjs` follows `process.arch`, so it needs no changes — but
+  anything that hardcodes `darwin-arm64` does. The pgvector CI step now derives
+  the architecture and asserts the resulting `vector.dylib` really is that
+  architecture, because a mismatch would only surface at `CREATE EXTENSION`
+  inside the shipped app on a user's machine.
+- GitHub retires x86_64 runners in **August 2027**. At that point the Intel
+  matrix entry has to go, or move to a self-hosted Intel runner.
+
 ## Data + uninstall
 
 Everything mutable lives under the per-user app-data directory (or a folder you

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -53,22 +53,35 @@ mac:
   gatekeeperAssess: false
   entitlements: buildResources/entitlements.mac.plist
   entitlementsInherit: buildResources/entitlements.mac.plist
-  # Apple Silicon only for v1. The native modules ship as extraResources (copied
-  # verbatim, not arch-split), and GitHub's Intel (macos-13) runners queue for
-  # hours — impractical for a release. An x64 DMG built on an arm64 runner would
-  # contain arm64 native modules and crash on Intel. Intel support is a follow-up
-  # (cross-compile x64 prebuilds on the arm64 runner into a second staged tree).
+  # Architecture is NOT pinned here — CI passes `--arm64` or `--x64` explicitly
+  # and each arch is built on a runner of that architecture.
+  #
+  # It has to work that way: the omadia runtime ships as unpacked extraResources
+  # (middleware node_modules with better-sqlite3/argon2/sharp, plus the embedded
+  # Postgres engine), and extraResources are copied verbatim — they cannot be
+  # arch-split within one bundle. Building x64 on an arm64 host would therefore
+  # produce a DMG containing arm64 binaries that crashes on Intel.
+  #
+  # The old "Intel runners queue for hours" rationale is obsolete: macos-13 was
+  # retired in December 2025 and `macos-26-intel` is a standard runner.
+  # Note x86_64 support on GitHub Actions ends August 2027.
   target:
     - target: dmg
-      arch: [arm64]
     - target: zip          # required by electron-updater on macOS
-      arch: [arm64]
+  # Always carry the arch in the filename — electron-builder omits it for x64 by
+  # default, which would drop a nondescript `omadia-<version>.zip` next to the
+  # arm64 one. This is the ZIP name (electron-updater's payload); the DMG name is
+  # set under `dmg:` below. Both keep the existing arm64 filenames unchanged.
+  artifactName: ${productName}-${version}-${arch}-mac.${ext}
   # Notarization is left unset here so it's driven entirely by CI: the workflow
   # adds `--config.mac.notarize=true` only when the Apple secrets are present
   # (and electron-builder skips it without notary credentials). A hard-coded
   # `notarize: false` here would fight that CLI override.
 
 dmg:
+  # Target-level name wins over mac.artifactName, keeping the DMG exactly as it
+  # was for arm64 (`omadia-<version>-arm64.dmg`) while x64 gets `-x64`.
+  artifactName: ${productName}-${version}-${arch}.${ext}
   title: ${productName} ${version}
   contents:
     - x: 130

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -18,6 +18,7 @@
     "build": "tsc -p tsconfig.json && node scripts/bundle-preload.mjs && node scripts/copy-renderer.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "stage": "node scripts/stage-runtime.mjs",
+    "test": "node --test scripts/*.test.mjs",
     "start": "npm run build && electron .",
     "dev": "OMADIA_DESKTOP_DEV=1 npm run start",
     "pack:mac": "npm run build && npm run stage && electron-builder --mac --publish never",

--- a/desktop/scripts/merge-mac-update-feed.mjs
+++ b/desktop/scripts/merge-mac-update-feed.mjs
@@ -1,0 +1,166 @@
+// Merges the per-architecture `latest-mac.yml` files that electron-updater reads.
+//
+// WHY THIS EXISTS
+// arm64 and x64 have to be built on separate runners: the omadia runtime ships as
+// unpacked extraResources (native node modules + the embedded Postgres engine),
+// which electron-builder copies verbatim and cannot arch-split. Each run therefore
+// emits its OWN `latest-mac.yml` listing only its own artifacts, and both would be
+// uploaded to the same release — last write wins.
+//
+// That silently half-breaks auto-update, because MacUpdater picks the download by
+// looking for "arm64" in the file URL:
+//
+//   const isArm64 = (file) => file.url.pathname.includes("arm64") || ...
+//
+// A feed containing only arm64 entries leaves Intel users with no matching file;
+// a feed containing only x64 entries pushes every Apple Silicon user onto the
+// Rosetta build. Merging the `files` arrays fixes both.
+//
+// Usage: node merge-mac-update-feed.mjs <primary.yml> <secondary.yml> <out.yml>
+// The PRIMARY feed supplies the legacy top-level `path`/`sha512` fields, which
+// pre-arch-aware updaters follow — pass the arm64 feed as primary.
+//
+// Deliberately dependency-free: this runs in a CI job that does not `npm ci`.
+// The input is machine-generated with a fixed shape, so the parser is strict and
+// throws on anything it does not recognise rather than guessing — a malformed
+// merge would break updates for every user at once.
+import fs from 'node:fs';
+
+const SCALARS = new Set(['version', 'path', 'sha512', 'releaseDate']);
+
+/** Strips one layer of YAML quoting. electron-builder quotes only releaseDate. */
+function unquote(v) {
+  const t = v.trim();
+  if (t.length >= 2) {
+    const q = t[0];
+    if ((q === "'" || q === '"') && t.endsWith(q)) return t.slice(1, -1);
+  }
+  return t;
+}
+
+/**
+ * Parses the exact shape electron-builder emits:
+ *   version: <scalar>
+ *   files:
+ *     - url: <scalar>
+ *       sha512: <scalar>
+ *       size: <number>
+ *   path: <scalar>
+ *   sha512: <scalar>
+ *   releaseDate: <quoted scalar>
+ * Throws on any line that does not fit.
+ */
+export function parseFeed(text, label) {
+  const out = { scalars: {}, files: [] };
+  let inFiles = false;
+  let current = null;
+
+  text.split('\n').forEach((rawLine, i) => {
+    const line = rawLine.replace(/\r$/, '');
+    if (line.trim() === '') return;
+    const where = `${label}:${i + 1}`;
+
+    const topLevel = line.match(/^([a-zA-Z0-9_]+):\s*(.*)$/);
+    if (topLevel) {
+      const [, key, value] = topLevel;
+      if (key === 'files') {
+        if (value.trim() !== '') throw new Error(`${where}: expected "files:" to start a block`);
+        inFiles = true;
+        current = null;
+        return;
+      }
+      if (!SCALARS.has(key)) throw new Error(`${where}: unexpected top-level key "${key}"`);
+      inFiles = false;
+      current = null;
+      out.scalars[key] = unquote(value);
+      return;
+    }
+
+    if (!inFiles) throw new Error(`${where}: indented line outside the files block: "${line}"`);
+
+    const entryStart = line.match(/^\s*-\s+([a-zA-Z0-9_]+):\s*(.*)$/);
+    if (entryStart) {
+      current = {};
+      out.files.push(current);
+      current[entryStart[1]] = unquote(entryStart[2]);
+      return;
+    }
+
+    const entryProp = line.match(/^\s+([a-zA-Z0-9_]+):\s*(.*)$/);
+    if (entryProp) {
+      if (current == null) throw new Error(`${where}: property before any list entry`);
+      current[entryProp[1]] = unquote(entryProp[2]);
+      return;
+    }
+
+    throw new Error(`${where}: unparseable line: "${line}"`);
+  });
+
+  if (!out.scalars.version) throw new Error(`${label}: no "version" field`);
+  if (out.files.length === 0) throw new Error(`${label}: no files listed`);
+  for (const f of out.files) {
+    for (const k of ['url', 'sha512', 'size']) {
+      if (f[k] === undefined) throw new Error(`${label}: file entry missing "${k}": ${JSON.stringify(f)}`);
+    }
+  }
+  return out;
+}
+
+/** Re-emits the structure in electron-builder's own formatting. */
+export function serializeFeed(feed) {
+  const lines = [`version: ${feed.scalars.version}`, 'files:'];
+  for (const f of feed.files) {
+    lines.push(`  - url: ${f.url}`);
+    lines.push(`    sha512: ${f.sha512}`);
+    lines.push(`    size: ${f.size}`);
+  }
+  if (feed.scalars.path) lines.push(`path: ${feed.scalars.path}`);
+  if (feed.scalars.sha512) lines.push(`sha512: ${feed.scalars.sha512}`);
+  if (feed.scalars.releaseDate) lines.push(`releaseDate: '${feed.scalars.releaseDate}'`);
+  return lines.join('\n') + '\n';
+}
+
+export function mergeFeeds(primary, secondary) {
+  if (primary.scalars.version !== secondary.scalars.version) {
+    throw new Error(
+      `version mismatch: primary=${primary.scalars.version} secondary=${secondary.scalars.version} — ` +
+        'the two architectures were built from different sources; refusing to merge.',
+    );
+  }
+  const seen = new Set();
+  const files = [];
+  for (const f of [...primary.files, ...secondary.files]) {
+    if (seen.has(f.url)) continue; // same artifact listed twice — keep the first
+    seen.add(f.url);
+    files.push(f);
+  }
+  // An updater that finds no arch-matching entry cannot update at all, so make
+  // the arch split explicit rather than discovering it in the field.
+  const arm = files.filter((f) => f.url.includes('arm64')).length;
+  const intel = files.length - arm;
+  if (arm === 0 || intel === 0) {
+    throw new Error(
+      `merged feed covers only one architecture (arm64=${arm}, x64=${intel}) — ` +
+        'auto-update would break for the other. Refusing to write it.',
+    );
+  }
+  return { scalars: { ...primary.scalars }, files };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const [primaryPath, secondaryPath, outPath] = process.argv.slice(2);
+  if (!primaryPath || !secondaryPath || !outPath) {
+    console.error('usage: merge-mac-update-feed.mjs <primary.yml> <secondary.yml> <out.yml>');
+    process.exit(1);
+  }
+  const primary = parseFeed(fs.readFileSync(primaryPath, 'utf8'), primaryPath);
+  const secondary = parseFeed(fs.readFileSync(secondaryPath, 'utf8'), secondaryPath);
+  const merged = mergeFeeds(primary, secondary);
+  fs.writeFileSync(outPath, serializeFeed(merged));
+  const arm = merged.files.filter((f) => f.url.includes('arm64')).length;
+  console.log(
+    `[merge-mac-update-feed] ${merged.files.length} file(s) — ${arm} arm64, ${merged.files.length - arm} x64 → ${outPath}`,
+  );
+  for (const f of merged.files) console.log(`  ${f.url}`);
+}

--- a/desktop/scripts/merge-mac-update-feed.test.mjs
+++ b/desktop/scripts/merge-mac-update-feed.test.mjs
@@ -1,0 +1,101 @@
+// Tests for the macOS update-feed merge.
+//
+// This script decides what every installed macOS app downloads on update, and a
+// silently wrong merge would break updates for all users at once — so the guard
+// rails matter more than the happy path and are covered individually.
+//
+// Run: node --test desktop/scripts/
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseFeed, serializeFeed, mergeFeeds } from './merge-mac-update-feed.mjs';
+
+// Verbatim from the v0.57.1 release, so the parser is pinned to real
+// electron-builder output rather than to an idealised sample.
+const ARM64 = `version: 0.1.0
+files:
+  - url: omadia-0.1.0-arm64-mac.zip
+    sha512: bPQD94yVv5wGIpvW5zqqZT6o9hzIlWaRsMqlAZYuzGgbtcgOBuR8txufO12TafkdKt9YVaHzv3aoNylOUjgu+w==
+    size: 277721721
+  - url: omadia-0.1.0-arm64.dmg
+    sha512: +lNAsNIlNZlFtiYNzo8eEbf+1STpusNy8MXX+tMfZck4Rxd5s8bnEKRnrbrQVDCJ1rXb6gSMsIjo6VU/aZyY1Q==
+    size: 283467184
+path: omadia-0.1.0-arm64-mac.zip
+sha512: bPQD94yVv5wGIpvW5zqqZT6o9hzIlWaRsMqlAZYuzGgbtcgOBuR8txufO12TafkdKt9YVaHzv3aoNylOUjgu+w==
+releaseDate: '2026-07-31T09:43:18.403Z'
+`;
+
+const X64 = ARM64.replaceAll('arm64', 'x64');
+
+test('parses real electron-builder output', () => {
+  const feed = parseFeed(ARM64, 'arm64');
+  assert.equal(feed.scalars.version, '0.1.0');
+  assert.equal(feed.files.length, 2);
+  assert.equal(feed.files[0].url, 'omadia-0.1.0-arm64-mac.zip');
+  assert.equal(feed.files[0].size, '277721721');
+  // releaseDate is the only quoted scalar; the quotes must not survive parsing.
+  assert.equal(feed.scalars.releaseDate, '2026-07-31T09:43:18.403Z');
+});
+
+test('round-trips without changing the document', () => {
+  assert.equal(serializeFeed(parseFeed(ARM64, 'arm64')), ARM64);
+});
+
+test('merges both architectures, arm64 first', () => {
+  const merged = mergeFeeds(parseFeed(ARM64, 'a'), parseFeed(X64, 'b'));
+  assert.deepEqual(
+    merged.files.map((f) => f.url),
+    [
+      'omadia-0.1.0-arm64-mac.zip',
+      'omadia-0.1.0-arm64.dmg',
+      'omadia-0.1.0-x64-mac.zip',
+      'omadia-0.1.0-x64.dmg',
+    ],
+  );
+  // MacUpdater matches on "arm64" appearing in the URL — assert the property it
+  // actually relies on, not merely the count.
+  assert.ok(merged.files.some((f) => f.url.includes('arm64')));
+  assert.ok(merged.files.some((f) => !f.url.includes('arm64')));
+});
+
+test('keeps the primary feed legacy path/sha512 for pre-arch-aware updaters', () => {
+  const merged = mergeFeeds(parseFeed(ARM64, 'a'), parseFeed(X64, 'b'));
+  assert.equal(merged.scalars.path, 'omadia-0.1.0-arm64-mac.zip');
+});
+
+test('serialized merge stays parseable', () => {
+  const merged = mergeFeeds(parseFeed(ARM64, 'a'), parseFeed(X64, 'b'));
+  assert.equal(parseFeed(serializeFeed(merged), 'merged').files.length, 4);
+});
+
+test('rejects a single-architecture merge', () => {
+  // The dangerous case: two arm64 feeds merge "successfully" into a feed that
+  // leaves every Intel user unable to update.
+  assert.throws(() => mergeFeeds(parseFeed(ARM64, 'a'), parseFeed(ARM64, 'b')), /only one architecture/);
+});
+
+test('rejects mismatched versions', () => {
+  const other = X64.replace('version: 0.1.0', 'version: 0.2.0');
+  assert.throws(() => mergeFeeds(parseFeed(ARM64, 'a'), parseFeed(other, 'b')), /version mismatch/);
+});
+
+test('deduplicates an artifact listed in both feeds', () => {
+  const merged = mergeFeeds(parseFeed(ARM64, 'a'), parseFeed(ARM64 + X64.split('\n').slice(1).join('\n'), 'b'));
+  const urls = merged.files.map((f) => f.url);
+  assert.equal(new Set(urls).size, urls.length);
+});
+
+test('rejects an unknown top-level key rather than dropping it', () => {
+  assert.throws(() => parseFeed('version: 1\nbogus: x\nfiles:\n  - url: a-arm64.z\n    sha512: s\n    size: 1\n', 'f'), /unexpected top-level key "bogus"/);
+});
+
+test('rejects an unparseable line', () => {
+  assert.throws(() => parseFeed('version: 1\nfiles:\n  - url: a-arm64.z\n    sha512: s\n    size: 1\n!!!garbage\n', 'f'), /unparseable line/);
+});
+
+test('rejects a file entry missing a field', () => {
+  assert.throws(() => parseFeed('version: 1\nfiles:\n  - url: a-arm64.z\n    size: 1\n', 'f'), /missing "sha512"/);
+});
+
+test('rejects a feed with no files', () => {
+  assert.throws(() => parseFeed('version: 1\nfiles:\n', 'f'), /no files listed/);
+});


### PR DESCRIPTION
## Problem

macOS ships **arm64 only**. The stated reason in `electron-builder.yml` — *"GitHub's Intel (macos-13) runners queue for hours"* — is **obsolete**: `macos-13` was retired in December 2025, and `macos-26-intel` is now a standard runner. Intel therefore builds **natively**, and none of the cross-compilation the old comment proposed is needed.

(Worth calendaring: GitHub drops x86_64 entirely in **August 2027**.)

## Why one job per architecture

Not a preference — a constraint. The omadia runtime ships as unpacked `extraResources` (native node modules plus the embedded Postgres engine), which electron-builder copies verbatim and **cannot arch-split**. An x64 bundle produced on an arm64 host would contain arm64 binaries and crash on Intel. A universal binary is off the table while the runtime ships this way.

## The non-obvious part: auto-update

Each mac run emits its own `latest-mac.yml` listing only its own artifacts, and both upload to the same release with `--clobber` — so whichever job finished last would silently become the **only updatable architecture**.

That matters because `MacUpdater` selects the download by testing the file URL:

```js
const isArm64 = (file) => file.url.pathname.includes("arm64") || file.info.url?.includes("arm64");
```

A feed listing only arm64 leaves Intel users with **no matching file**; a feed listing only x64 pushes **every Apple Silicon user onto Rosetta**. So the mac jobs now hold that file back, and a new `mac-update-feed` job merges both — and refuses to publish a feed covering only one architecture.

## Changes

| File | Change |
|---|---|
| `.github/workflows/desktop-apps.yml` | `macos-26-intel` matrix entry (`--mac --x64`) |
| `.github/workflows/desktop-apps.yml` | pgvector step derives the architecture instead of hardcoding `darwin-arm64`, and asserts the staged `vector.dylib` really is that architecture |
| `.github/workflows/desktop-apps.yml` | mac jobs hold back `latest-mac.yml`; new `mac-update-feed` job merges and uploads it |
| `desktop/scripts/merge-mac-update-feed.mjs` | New. Dependency-free strict parser/merger — the job does not `npm ci` |
| `desktop/scripts/merge-mac-update-feed.test.mjs` | New. 12 tests |
| `desktop/electron-builder.yml` | arch no longer pinned; artifact names always carry it |
| `desktop/README.md` | Documents the two-architecture setup and its consequences |

**No release asset is renamed.** Existing arm64 filenames stay byte-identical (`omadia-<v>-arm64.dmg`, `omadia-<v>-arm64-mac.zip`); x64 gets the matching `-x64` names. electron-builder omits the arch for x64 by default, which would have dropped a nondescript `omadia-<v>.dmg` next to the arm64 one — hence the explicit `artifactName`.

The architecture assertion on `vector.dylib` is deliberate: a mismatch there would not fail the build, it would fail at `CREATE EXTENSION` **inside the shipped app, on a user's machine**.

## Verification

- Merge tested against the **real `latest-mac.yml` from v0.57.1** — round-trips byte-identically
- 12 unit tests (`npm test` in `desktop/`) covering the merge plus every guard: single-architecture result, version mismatch, unknown top-level key, unparseable line, missing field, empty feed, deduplication
- Upload-filter logic simulated: `latest-mac.yml` removed, all other artifacts retained
- `actionlint` clean apart from the pre-existing `SC2086`
- Replaced a `${{ matrix.os }}` interpolation inside a `run` block with `RUNNER_OS` (fixes `SC2193`, and avoids interpolating an expression into a shell script)

## Not yet validated

**The Intel runner itself has never been exercised.** A dispatch on this branch is the acceptance test — specifically whether `brew install pgvector` yields a PG17 x86_64 `vector.dylib`, and whether `@embedded-postgres/darwin-x64` installs cleanly. Those are the two places where an Intel-specific surprise would show up.

## Test plan

- [x] Merge verified against real release output + unit tests
- [ ] Dispatch on this branch; `macos-26-intel` job goes green
- [ ] x64 DMG signed + notarized, `spctl --assess` → accepted
- [ ] Merged `latest-mac.yml` lists all four artifacts
- [ ] Smoke-test the x64 app on an Intel Mac (or under Rosetta) — the embedded Postgres + pgvector path is the risk

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788098324&installation_model_id=428086&pr_number=574&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F574&signature=4c68c8ac4925442bc884e35631776c34f199dbe5ff90c436998e89ab25cc9cb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->