### PR TITLE
docu(read-me): docs: hoist Prerequisites and Quickstart above the 2-m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ data stays in the house and never leaves in clear text. Every answer is checked
 before it ships. Every action carries a receipt. Bring your own LLM key and switch
 providers by config, not code.
 
-#### 🎬 The 2-minute pitch
-
-https://github.com/user-attachments/assets/644f9dae-c8a9-44af-a47f-183d2fcdcf34
-
 ---
 
 ## Prerequisites
@@ -80,6 +76,10 @@ docker compose -f docker-compose.yaml -f docker-compose.build.yaml up -d --build
 > **Pull fails with `manifest unknown`?** The GHCR images publish on each
 > release, so a brand-new checkout can briefly predate the first published
 > image. Build from source with the `--build` line above until a release lands.
+
+## 🎬 The 2-minute pitch
+
+https://github.com/user-attachments/assets/644f9dae-c8a9-44af-a47f-183d2fcdcf34
 
 ## 🚀 First run: from prompt to audit receipt
 


### PR DESCRIPTION
## What
  Reorder README top: hoist Prerequisites and ⚡ Quickstart above 🎬 The 2-minute pitch, so a dev arriving for setup reaches the install command before the video. Pure reordering, no copy rewrite. Closes #400.

  ## Why
  Marketing site is now business-led; developers land here via "View on GitHub", making this README the dev-first entry point. A dev who came for setup should hit `docker compose up -d` fast, not scroll past a video first. Video keeps its place in the narrative, now right after the command ("read it, then watch it run").

  ## Test plan
  - [ ] `git diff` shows only moved lines (+ heading level `####`→`##`), zero wording edits
  - [ ] Video embed URL byte-identical to previous (`644f9dae-…`)
  - [ ] Rendered order: header → intro → Prerequisites → ⚡ Quickstart → 🎬 pitch → 🚀 First run
  - [ ] Anchors still resolve: `#-quickstart`, `#why-omadia`, `#status--roadmap`, `#optional-features`

  ## Risk / blast radius
  Docs-only, single file. No code, schema, API, CI, or env-var impact. Heading promoted `####`→`##` for consistency with sibling sections (either level defensible per triage); no anchor referenced the pitch, so nav/badge links unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788339669&installation_model_id=428086&pr_number=597&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F597&signature=b0ac8bf2b800dc3700c0e369176caa1432fd13ff05893857982835ddd7e1a013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->