### PR TITLE
chore(deps): consolidated dependency batch 2026-08-04

### DIFF
--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -568,7 +568,7 @@ jobs:
           node-version: 22
 
       - name: Download the macOS build artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           pattern: omadia-installers-macos-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # botbuilder (@azure/msal-node family) have post-install hooks that break on
 # Alpine's musl libc without extra build tools. Slim keeps the image small
 # while staying on glibc.
-FROM node:22.23.1-slim AS builder
+FROM node:22.23.2-slim AS builder
 ARG TARGETARCH
 WORKDIR /app
 
@@ -38,7 +38,7 @@ COPY middleware/scripts ./scripts
 RUN npm run build
 
 # --- runtime ----------------------------------------------------------------
-FROM node:22.23.1-slim AS runtime
+FROM node:22.23.2-slim AS runtime
 ARG TARGETARCH
 WORKDIR /app
 

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -5244,9 +5244,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -86,14 +86,14 @@
       }
     },
     "node_modules/@aws-sdk/checksums": {
-      "version": "3.1000.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.20.tgz",
-      "integrity": "sha512-uc5PMNcLcs+UBSLGsRjbMZKi3mgnPSalXpABw9Xjo0DMrv4gjIa/E4a02yJsuU4FF6Tmvis/JgGdKNIOoN4DQw==",
+      "version": "3.1000.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.25.tgz",
+      "integrity": "sha512-zUjEceMw6vhAxMayAlF/vkkKqP9gHbENqvz11t4FbfDlxB/WtW/Az1orJAQ00Pc/yORLQJXKE24w11Ktu/XBcg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.5",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -102,20 +102,20 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1095.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1095.0.tgz",
-      "integrity": "sha512-eeobm3TKci47CTTHIxc5s5UDjLL0gTKfjlcyzKU+NMoeIJ3flKPq51Fhi2nUDiMNbzsY5HAynM3bHAQFHxRTUw==",
+      "version": "3.1102.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1102.0.tgz",
+      "integrity": "sha512-VQL/oWlt0+Rj2QZcAnp3+hMHW/T01EmkPQXf9ise2gz6d95U82eVE1dPBpMlnv4aDiz99TrMR0DHmceCjCkCmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/checksums": "^3.1000.20",
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/credential-provider-node": "^3.972.72",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.66",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/checksums": "^3.1000.25",
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/credential-provider-node": "^3.972.77",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.71",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -124,16 +124,16 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.1.tgz",
-      "integrity": "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==",
+      "version": "3.977.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.5.tgz",
+      "integrity": "sha512-O5otOc1c6UZh5HsHAaPdYBcUUR9HL6mtnKqvc8nxN/CKDGUBUpsdh0q8K04Uz/dd1i0TaGyIQuQNqoO7+ad2TQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
         "@aws-sdk/xml-builder": "^3.972.37",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.8",
-        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -143,14 +143,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.61",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.61.tgz",
-      "integrity": "sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==",
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.66.tgz",
+      "integrity": "sha512-bOzP2+zdJ0XrghywB4FaJXtGZCx9yS0AGps+VJ5yEgg30wVyHNmVDBwVDXcRypzQY5iLGCS3NSn0nsuISqjFCQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.5",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -159,16 +159,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.63.tgz",
-      "integrity": "sha512-yfozsS8wkWZEi/n6IsrodcFKBWZ0iNAezhJbTReMNc0z1Px17qdeAeuL1/wziCAmCZyXiW7QzP75ggJkBQv8jQ==",
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.68.tgz",
+      "integrity": "sha512-lkunS8X+H6V76WE+t/uGQm/U8v0JXK5mLfNFTUAMlE1kqaCjwlmqKJrgCVtqjK/vqnlrSWsLK4Lr4NANBWlfTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.5",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -177,22 +177,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.6.tgz",
-      "integrity": "sha512-jGLTW1bj148GL/6/IMlfY2fMYS9FtHOG+NahkFD4y0qkzYudNUahelxryY68/HGMslYuHClk1XaS/3b3eJzEkg==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.11.tgz",
+      "integrity": "sha512-KoDEolYtLHG/8C+IiZpXbJWyBOMkrHV+j66Kb9PBXmLv5euGb7aELvuCmLenoGAV6gBW2wM7TsG/1e5iulH4kA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/credential-provider-env": "^3.972.61",
-        "@aws-sdk/credential-provider-http": "^3.972.63",
-        "@aws-sdk/credential-provider-login": "^3.972.68",
-        "@aws-sdk/credential-provider-process": "^3.972.61",
-        "@aws-sdk/credential-provider-sso": "^3.973.5",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/credential-provider-env": "^3.972.66",
+        "@aws-sdk/credential-provider-http": "^3.972.68",
+        "@aws-sdk/credential-provider-login": "^3.972.73",
+        "@aws-sdk/credential-provider-process": "^3.972.66",
+        "@aws-sdk/credential-provider-sso": "^3.973.10",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.72",
+        "@aws-sdk/nested-clients": "^3.997.40",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -201,15 +201,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.68",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.68.tgz",
-      "integrity": "sha512-w6tNci6g7RqFpLhj1f5xseBvaNojb4Pkgp5Jp5apl9hrJtaf2AA+rX9+qlhlWUK6kcyAFYPA7emO+55zj+S98Q==",
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.73.tgz",
+      "integrity": "sha512-tjsxMkTAFkmiV9ycmymapb9nLECWVOwFs0bZMQ9gB9bnbY8/HwfukHZlWbXZZp7qkPU6EXAfOcMm3DioFFEywA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/nested-clients": "^3.997.40",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -218,20 +218,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.72",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.72.tgz",
-      "integrity": "sha512-blQ7F5QGzylnzeh5549zQLoCAiMHkXFLjFovEMaVy4b2X8JhUu+u9NXro1hyK95YHdVFNmBHKs2hIHtZchxKlQ==",
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.77.tgz",
+      "integrity": "sha512-l4nitYCN/Ls57vtUfdextCjTjW41JD7lQiAnuR0RTbdByFc/6OmEAzwGd+lrp6CUtiXGQL1FCaYiamfHASrwBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.61",
-        "@aws-sdk/credential-provider-http": "^3.972.63",
-        "@aws-sdk/credential-provider-ini": "^3.973.6",
-        "@aws-sdk/credential-provider-process": "^3.972.61",
-        "@aws-sdk/credential-provider-sso": "^3.973.5",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
+        "@aws-sdk/credential-provider-env": "^3.972.66",
+        "@aws-sdk/credential-provider-http": "^3.972.68",
+        "@aws-sdk/credential-provider-ini": "^3.973.11",
+        "@aws-sdk/credential-provider-process": "^3.972.66",
+        "@aws-sdk/credential-provider-sso": "^3.973.10",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.72",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -240,14 +240,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.61",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.61.tgz",
-      "integrity": "sha512-xzRuj+fUVO4nkafKQJVKAF97kGpeQbfjuwmRrtGZNf42/1dkmcz6o7dswBy7alY0htQn5sCL1GWQYEykviWZkA==",
+      "version": "3.972.66",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.66.tgz",
+      "integrity": "sha512-YOnX6bIhdjx0QfaENu2PB0eFm5MEc9ft8XNGQ+NxMfeLSq9aE+XjWCwDupEnV4UWv5ZFpBLJbTREIx7KNOoqpQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.5",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -256,16 +256,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.5.tgz",
-      "integrity": "sha512-fZRjjWhLFelsDoOYjqShQTrIGYC3Pf9Mx9Czf+1ikfQDgktxjze33dVo1q1/ZQ+T0qbtejVoHNHrfD5aJVpv/w==",
+      "version": "3.973.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.10.tgz",
+      "integrity": "sha512-IsXnQ35j5VE+3ZK6aIhT5ypB+Jim3zRwVz0nYuVwyBKZyu/SYx+O2/LQpng8c2EiuwyqceabsDlYrICHDlJPsA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
-        "@aws-sdk/token-providers": "3.1095.0",
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/nested-clients": "^3.997.40",
+        "@aws-sdk/token-providers": "3.1102.0",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -274,15 +274,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.67.tgz",
-      "integrity": "sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw==",
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.72.tgz",
+      "integrity": "sha512-nj9Zlsy7ya+fy+jhWTJwgfr7YdtDM4xHyZvgKuftuny0UgROVx9lxwvsWJSLvpKk4lig0m0tHng3k1fEnt0LeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/nested-clients": "^3.997.40",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -291,15 +291,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.66",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.66.tgz",
-      "integrity": "sha512-sTZKP1+SvyzWc/3alO8AM/PUiEzDCmn2P/KOcFFSk2UKzKZkB5ZxXdlHVtACE7DHaMFvx6DY0bognwHa1qTv4g==",
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.71.tgz",
+      "integrity": "sha512-5fpExT7JOIZSIWExXCgJVbZzbaOlNrS/rE5Eoesnp0ONMbnCtiyYsCkahNIdlXtKrO6XHqXI6ceqssVWMYKmWQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -308,17 +308,17 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.35.tgz",
-      "integrity": "sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw==",
+      "version": "3.997.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.40.tgz",
+      "integrity": "sha512-hEdHT0PBR4fkGxWhwKG5EtEYKnAM7HKkp0vD10ufk4YcXejH4r4q6G/XhPzjUc6Yxo5kBS2vHg7llj4ViR9VTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -327,13 +327,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
-      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
+      "version": "3.996.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -342,15 +342,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1095.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1095.0.tgz",
-      "integrity": "sha512-65SudS6y4nzaYHybtqcpm3sHe5jLhdMn68HRKS1nUx690BtQeaAQOoujQ+dpOjBATIVGVgKKjEP8tR+U06QJQA==",
+      "version": "3.1102.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1102.0.tgz",
+      "integrity": "sha512-Ua700vVvM1q105yABSUQWkCK6FeTrNfU6ORGetJe5BzkZWY7QhkF7SVTOlmDGWRDNd6jbyY0Dv5e+E4bMBEmLg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.5",
+        "@aws-sdk/nested-clients": "^3.997.40",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -554,16 +554,25 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.4.2.tgz",
-      "integrity": "sha512-fnqOpGYAV+i0RH4W5HB6Oy1IhqGZoCdnp7Y2Sa9k18FlT8aBkCA7L8Hv19hUHLDUK6kVjUO29AfnGX6wgAHyNg==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.4.3.tgz",
+      "integrity": "sha512-tumCMmzrRhKmTbYQg/7OlfbrIKcKaf8Ed0Fw3suUpRT3owFYljznVgxcfHe8RycQXY9uyROGiLD1GjhpF45AwA==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.11.2",
+        "@azure/msal-common": "16.11.3",
         "jsonwebtoken": "^9.0.0"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "16.11.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.3.tgz",
+      "integrity": "sha512-VeXOW+t3Rdd9XGX6lVyIg3DhtjMR1JD8ARKcsnGbJFUWwAmF3sHL7GwZc/ZjEUfHESResAonETRYCuG06OBT7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -1864,46 +1873,6 @@
         }
       }
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.5",
-        "eventsource": "^3.0.2",
-        "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        },
-        "zod": {
-          "optional": false
-        }
-      }
-    },
     "node_modules/@napi-rs/canvas": {
       "version": "0.1.80",
       "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
@@ -2530,9 +2499,9 @@
       "license": "MIT"
     },
     "node_modules/@smithy/core": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.30.0.tgz",
-      "integrity": "sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==",
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -2543,12 +2512,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.14",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.14.tgz",
-      "integrity": "sha512-QgbuahIb2qxQeZQvNK0sw3aF3JH5zwH8j2lLp5DUasVXexGGMWULAR+7z0omPXFolCP/m5wN9M5lm9EGdSviTQ==",
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2557,12 +2526,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.11",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.11.tgz",
-      "integrity": "sha512-o0Zkj1nKqJAoq+a+BrkhU39tRftMNjLwpc/z06Frfl43wpbHrJMaSAVZE4vTqlxtVkNaGaT0bIDxOp7tkFTuQQ==",
+      "version": "5.6.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2571,12 +2540,12 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.11",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.11.tgz",
-      "integrity": "sha512-slbzbz8taEOzoXv/9y34YNBoE+ZHmddLykCgjDAjvMAsu2nM5s2Gzwa5OGF721tD8s+CKeFUBds5lSj9lcbuDg==",
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -2585,12 +2554,12 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.10",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.10.tgz",
-      "integrity": "sha512-EXhWePm3SXJAX38npIy4TXL2Aex/OVgCClTjelN2QHw/U+8CQUH8C7AaxsVzQcYieYPseywn48s89DmvuGjiAg==",
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -3721,9 +3690,9 @@
       }
     },
     "node_modules/bonjour-service": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.3.tgz",
-      "integrity": "sha512-2Kd5UYlFUVgAKMTyuBLl6w49wqfOnbxHqmuH0oCl/n7TfAikR0zoowNOP5BU4dfXmm+Vr9JyEN370auSMx+CNg==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.4.tgz",
+      "integrity": "sha512-jCZcVv7eoc4QesRscwEZtSROBen+6LpKAmBIsQYQrsAeVHLyMXWX/t6eIV5KiRZYNUBl8eVqImEEMQ8L5+c/Kw==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -6003,9 +5972,9 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
-      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -9431,7 +9400,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "csv-parse": "^7.0.1",
         "mammoth": "^1.8.0",
         "pdf-parse": "^2.4.5"
@@ -9469,6 +9438,46 @@
         "@omadia/plugin-api": "*",
         "@omadia/usage-telemetry": "*",
         "pg": "^8.13.0"
+      }
+    },
+    "packages/harness-orchestrator/node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "packages/harness-plugin-office": {

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -3943,9 +3943,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -96,7 +96,7 @@
   "overrides": {
     "esbuild": "^0.28.1",
     "axios": "1.18.1",
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "postcss": "8.5.23",
     "brace-expansion": "5.0.9"
   }

--- a/middleware/package.json
+++ b/middleware/package.json
@@ -98,6 +98,6 @@
     "axios": "1.18.1",
     "fast-uri": "3.1.4",
     "postcss": "8.5.23",
-    "brace-expansion": "5.0.8"
+    "brace-expansion": "5.0.9"
   }
 }

--- a/middleware/packages/harness-orchestrator/package.json
+++ b/middleware/packages/harness-orchestrator/package.json
@@ -28,7 +28,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "csv-parse": "^7.0.1",
     "mammoth": "^1.8.0",
     "pdf-parse": "^2.4.5"

--- a/middleware/sidecars/dev-runner-daemon/Dockerfile
+++ b/middleware/sidecars/dev-runner-daemon/Dockerfile
@@ -10,7 +10,7 @@
 # node >= 22.18 strips the TS types at load time, so no separate build step is
 # needed for this scaffold. `tini` reaps the child processes the daemon spawns;
 # the container runs as a non-root user.
-FROM node:22.23.1-alpine
+FROM node:22.23.2-alpine
 
 RUN apk add --no-cache tini
 

--- a/middleware/sidecars/dev-runner/Dockerfile
+++ b/middleware/sidecars/dev-runner/Dockerfile
@@ -19,7 +19,7 @@
 # dev-runner-shim). It has ONLY devDependencies (typescript/tsx/@types/node) and
 # no runtime node_modules, so we compile it with tsc and ship the emitted dist/
 # tree — no bundler, and zero runtime dependency surface in the final image.
-FROM node:22.23.1-slim AS shim-builder
+FROM node:22.23.2-slim AS shim-builder
 WORKDIR /build
 COPY middleware/packages/dev-runner-shim/package.json ./
 # No package-lock.json in the workspace package (the root middleware lockfile
@@ -29,7 +29,7 @@ COPY middleware/packages/dev-runner-shim/ ./
 RUN npm run build
 
 # --- runtime stage ----------------------------------------------------------
-FROM node:22.23.1-slim
+FROM node:22.23.2-slim
 # Pin the Claude CLI to the SAME version as the middleware Dockerfile (repo-root
 # ./Dockerfile ARG CLAUDE_CODE_VERSION). Bump both together — a drift here means
 # a dev job runs a different CLI than the rest of the platform.

--- a/web-ui/Dockerfile
+++ b/web-ui/Dockerfile
@@ -5,13 +5,13 @@
 # Final image ~150 MB (node 22 slim + standalone server + static assets).
 
 # --- deps -------------------------------------------------------------------
-FROM node:22.23.1-slim AS deps
+FROM node:22.23.2-slim AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --no-audit --no-fund
 
 # --- builder ----------------------------------------------------------------
-FROM node:22.23.1-slim AS builder
+FROM node:22.23.2-slim AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -26,7 +26,7 @@ ENV MIDDLEWARE_URL=${MIDDLEWARE_URL}
 RUN npm run build
 
 # --- runtime ----------------------------------------------------------------
-FROM node:22.23.1-slim AS runtime
+FROM node:22.23.2-slim AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -43,7 +43,7 @@
         "@vitejs/plugin-react": "^6.0.3",
         "eslint": "^9.39.5",
         "eslint-config-next": "^16.2.12",
-        "jsdom": "^29.1.1",
+        "jsdom": "^30.0.1",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.3",
         "vitest": "^4.1.10"
@@ -70,55 +70,57 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
-      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.5.tgz",
+      "integrity": "sha512-mbhpPMmnw/kwW19aRNmSUl1QzLbdGo1SCuE49BT98MNwqF6zaHb3o2owssFc/PEO/4t2UjqtCNwocuDtJornzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/generational-cache": "^1.0.1",
-        "@csstools/css-calc": "^3.2.0",
-        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-color-parser": "^4.1.9",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
-      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/generational-cache": "^1.0.1",
-        "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
         "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1"
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "^22.13.0 || >=24.0.0"
       }
     },
-    "node_modules/@asamuzakjp/generational-cache": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
-      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
-      "license": "MIT",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": "20 || >=22"
       }
-    },
-    "node_modules/@asamuzakjp/nwsapi": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -2745,6 +2747,72 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
@@ -3060,18 +3128,18 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3678,9 +3746,9 @@
       ]
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.4.tgz",
-      "integrity": "sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz",
+      "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5934,12 +6002,12 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.42.2",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
-      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.43.0.tgz",
+      "integrity": "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.42.2",
+        "motion-dom": "^12.43.0",
         "motion-utils": "^12.39.0",
         "tslib": "^2.4.0"
       },
@@ -7030,39 +7098,39 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "29.1.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
-      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^5.1.11",
-        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
         "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
-        "@exodus/bytes": "^1.15.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
         "css-tree": "^3.2.1",
         "data-urls": "^7.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.3.5",
+        "lru-cache": "^11.5.2",
         "parse5": "^8.0.1",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.1",
-        "undici": "^7.25.0",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.1",
+        "whatwg-url": "^17.1.0",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       },
       "peerDependencies": {
-        "canvas": "^3.0.0"
+        "canvas": "^3.2.3"
       },
       "peerDependenciesMeta": {
         "canvas": {
@@ -7078,6 +7146,21 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -7528,9 +7611,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.27.0.tgz",
-      "integrity": "sha512-rJicGl/3Fly/E0rOH1YmPZ6e49JCnKknh1ox1vpHnkfjujAkKA6sqUZvH3MTAaXXjgexyUwgNwTJzTtYuAFYJw==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.28.0.tgz",
+      "integrity": "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -8511,9 +8594,9 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.42.2",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
-      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
+      "integrity": "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.39.0"

--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -4294,9 +4294,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -72,7 +72,7 @@
     "undici": "^7.28.0",
     "postcss": "8.5.23",
     "sharp": "0.35.3",
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "minimatch": "10.2.5",
     "dompurify": "3.4.12"
   }

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -61,7 +61,7 @@
     "@vitejs/plugin-react": "^6.0.3",
     "eslint": "^9.39.5",
     "eslint-config-next": "^16.2.12",
-    "jsdom": "^29.1.1",
+    "jsdom": "^30.0.1",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.3",
     "vitest": "^4.1.10"


### PR DESCRIPTION
Consolidates the open Dependabot backlog into one verified batch. Replaces **11** individual PRs; **2** are deliberately excluded and **1** is already obsolete.

## Included (11 PRs superseded)

| Dependabot PR | Package | From → To | Notes |
|---|---|---|---|
| #594 | `@modelcontextprotocol/sdk` | 1.29.0 → 1.30.0 | in `harness-orchestrator` |
| #593 | `@aws-sdk/client-s3` | 3.1095.0 → **3.1102.0** | newer than proposed |
| #589 | `@azure/msal-node` | 5.4.2 → 5.4.3 | runtime-patches group |
| #589 | `bonjour-service` | 1.4.3 → 1.4.4 | runtime-patches group |
| #589 | `jose` | 6.2.4 → **6.2.8** | newer than proposed |
| #591 | `lucide-react` | 1.27.0 → 1.28.0 | |
| #587 | `framer-motion` | 12.42.2 → 12.43.0 | |
| #588 | `jsdom` | 29.1.1 → 30.0.1 | **major**, devDep |
| #586 | `@types/react` | 19.2.17 → 19.2.18 | dev-tooling group |
| #586 | `@types/react-dom` | 19.2.3 → 19.2.4 | dev-tooling group |
| #586 | `@vitejs/plugin-react` | 6.0.4 → 6.0.5 | dev-tooling group |
| #592 / #590 | `node` (docker) | 22.23.1-slim → 22.23.2-slim | |
| #585 | `actions/download-artifact` | v7 → v8 | **major** |

`@aws-sdk/client-s3` and `jose` land one patch beyond what Dependabot proposed — those PRs were cut on 2026-08-03 and newer patches shipped since. Taking the newer resolution rather than pinning backwards.

### Also included, beyond Dependabot's scope

Dependabot only offered the node bump for the root and `web-ui` Dockerfiles. Two more images were still on the old base and would have drifted:

- `middleware/sidecars/dev-runner/Dockerfile` (2 stages) → `22.23.2-slim`
- `middleware/sidecars/dev-runner-daemon/Dockerfile` → `22.23.2-alpine`

All 8 node stages across the 4 Dockerfiles are now on the same patch. Both tags were confirmed to exist on Docker Hub.

## Excluded — with reasons

### #595 `typescript` 5.9.3 → 7.0.2 — blocked upstream, recommend close

Hard peer-dependency wall, not a flaky build. `typescript-eslint` declares:

```
peer typescript@">=4.8.4 <6.1.0"
```

That range is unchanged in the newest release (8.66.0), so TypeScript 7 cannot resolve at all — `npm ci` dies with `ERESOLVE` before any code is compiled, which is why 4 checks failed rather than 1.

The PR is also stale: it proposes 5.9.3 as the base, but `middleware/package.json` is already on `^6.0.2`. TypeScript 6.0.2 satisfies the peer range; 7.x does not.

Recommend closing #595 and revisiting when `typescript-eslint` ships TS 7 support.

### #596 `better-sqlite3` 12.11.1 → 13.0.2 — needs a Dockerfile change first

Not a version-compatibility problem — a packaging change. v12 shipped an install hook that fetched a prebuilt binary:

```
"install": "prebuild-install || node-gyp rebuild --release"
```

v13.0.2 removes that hook entirely. With `binding.gyp` still present, npm falls back to compiling from source, and our `node:*-slim` image has no Python:

```
npm error command sh -c node-gyp rebuild
npm error gyp ERR! find Python
npm error gyp ERR! stack Error: Could not find any Python installation to use
```

Adopting v13 means adding `python3` / `make` / `g++` to the builder stage. That is a real image-surface change and does not belong in a routine dependency batch — it deserves its own PR and its own review.

### #250 `cytoscape` 3.33.4 → 3.34.0 — already on main, recommend close

`web-ui` is already at `^3.34.0` / locked `3.34.0`. The PR is a no-op left over from June.

## Verification

Run locally on node 22.22.3 (`.nvmrc`), full install from the regenerated lockfiles:

| Workspace | Build | Lint | Typecheck | Tests |
|---|---|---|---|---|
| `middleware` | pass | 0 errors | pass | **5502 passed**, 0 failed, 4 skipped (5506 total) |
| `web-ui` | — | 0 errors | pass | **552 passed**, 0 failed (68 files) |

Lint warning counts are unchanged from main (38 in web-ui, 1 in middleware — all pre-existing).

### Security audit

This branch introduces **no new advisories** — verified by auditing main's lockfile side by side, which produced byte-identical output. It then goes further and *removes* advisories; see "Update: the audit gate" below for the full picture, which supersedes this paragraph.

### On the two majors

**`jsdom` 30** requires node `^22.22.2 || ^24.15.0 || >=26.0.0`; `.nvmrc` (22.22.3) and CI (node 22) both satisfy it. It is the vitest environment, so the entire 552-test web-ui suite exercises it — all green.

**`download-artifact` v8** has three breaking changes, checked against the single call site (the macOS update-feed merge job):

- *ESM migration* — transparent to callers.
- *Hash mismatch now errors instead of warning* — a correctness improvement; only trips on a genuinely corrupt artifact.
- *No longer unzips non-zipped downloads* — only affects the new direct-upload path. This repo uploads via `actions/upload-artifact@v7` with default compression, so artifacts stay zipped and are extracted exactly as before.

## Test plan

- [x] `middleware`: build, lint, typecheck, full test suite (5502 pass / 0 fail)
- [x] `web-ui`: lint, typecheck, full test suite (552 pass / 0 fail)
- [x] Audit compared against main — no new high/critical
- [x] Both docker tags confirmed to exist upstream
- [x] Docker images build — `middleware (build, no push)` and `web-ui (build, no push)` both green
- [x] `audit (web-ui)` — **green** (was red before `bfcf880`)
- [x] `audit (middleware)` — **green** (was red before `af4d8f0`)
- [x] `npm ci` verifies the hand-pinned `fast-uri` integrity hash against the real tarball
- [x] `npm ls fast-uri` — no `invalid`/`overridden` markers

**main is currently red on both audit jobs. This branch is green on both** — it does not merely avoid regressing the gate, it repairs it.

---

## Update: the audit gate, and why main is also red

The first CI run on this branch failed both `audit (high+critical block)` jobs. That is **not** a regression from this branch — **main is red on the same gate** ([run 30887391724](https://github.com/byte5ai/omadia/actions/runs/30887391724) on `1e72b007`, 2026-08-04 07:20Z). The three runs before it were green.

What changed is npm's side, not ours. The gate carries a deliberate bypass:

```
if grep -q 'audit endpoint returned an error' audit-stderr.log; then ... exit 0
```

npm's audit registry endpoint had been erroring, so that bypass swallowed **every** result. It recovered on 2026-08-04, the gate started returning real data, and pre-existing advisories became blocking for the first time. The gate was effectively dark for a while — worth knowing independently of this PR.

### Fixed here: `brace-expansion` (commit `bfcf880`)

Both workspaces pinned `brace-expansion` to exactly `5.0.8` via `overrides` — a fix from an earlier batch. A new advisory now covers that version:

> `brace-expansion`: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation — vulnerable `>=4.0.0 <5.0.9`

Because the pin was exact, it *held the vulnerable version in place* and `npm update` could not move it. Bumping the pin to `5.0.9` clears the entire cascade:

| Workspace | High advisories before | After |
|---|---|---|
| `web-ui` | 15 | **0** — gate passes |
| `middleware` | 4 | **1** (then 0, see `fast-uri` below) |

web-ui's 15 were almost entirely phantom depth: the whole `eslint` / `typescript-eslint` / `eslint-config-next` tree was flagged only transitively via `brace-expansion` → `minimatch`. One pin bump clears all of them.

### Also fixed here: `fast-uri` (commit `af4d8f0`)

The last middleware advisory was `fast-uri@3.1.4` (vulnerable `>=3.0.0 <3.1.5`, host confusion via backslash authority introducer), reached through `ajv@8.20.0`, which requires `fast-uri: ^3.0.1`. `ajv` is already at its latest release, so there is no upstream fix to take.

This one needed care, because **npm refuses to re-apply a changed override to an already-locked transitive dependency**. `npm update`, `npm install`, and even a clean `rm -rf node_modules && npm install` all keep 3.1.4 — while `npm ls` simultaneously reports:

```
fast-uri@3.1.4 invalid: "3.1.5" from node_modules/ajv overridden
```

npm knows about the override and declines to act on it. The only npm-native way to force it is deleting the lockfile and regenerating — which does produce 3.1.5, but also rewrites **75 unrelated package versions**, including:

- `@hono/node-server` **1.19.17 → 2.1.0** (major, runtime HTTP server — undeclared, so it floats freely on a regen)
- `vite` 8.1.5 → 8.2.0, `rolldown` 1.1.5 → 1.2.2, `tsx` 4.23.1 → 4.23.5
- `typescript-eslint` 8.65.0 → 8.66.0
- a hoisting change moving `ajv@8` out of the root into five per-workspace copies

Smuggling a `@hono/node-server` major into a dependency-hygiene batch is exactly the kind of unreviewed breaking change this PR exists to prevent. So instead the override is set to `3.1.5` and **the single lockfile entry is edited to exactly what a correct resolution would produce** — three lines: `version`, `resolved`, `integrity`.

This is not taken on trust. The integrity hash is the registry's own for 3.1.5, and `npm ci` verifies it against the downloaded tarball — a wrong hash would fail the install outright. Afterwards `npm ls fast-uri` reports **no invalid markers**, so the tree and the declared override agree.

Blast radius: **28 changed lockfile entries vs main, not 75.**

Verified beyond the gate: `ajv` relative `$ref` resolution — the code path that actually delegates to fast-uri — still resolves and still rejects correctly on 3.1.5.

## Recommended follow-ups (not in this PR)

1. **A deliberate middleware lockfile regeneration**, reviewing the `@hono/node-server` **1.19 → 2.1** major on its own merits. The lockfile has drifted well behind the declared ranges — a regen moves 75 packages. That is worth doing intentionally, once, rather than discovering it inside an unrelated PR.
2. **Close #595** (typescript 7) and **#250** (cytoscape, already on main).
3. **Config gap:** the `typescript` major-ignore lives only in the `/web-ui` npm block. The `/middleware` block lacks it, which is why #595 was raised despite the comment already documenting that TS 7 is blocked. It will regenerate every Monday until the ignore is mirrored.
4. **Config gap:** the docker ecosystem covers only `/` and `/web-ui`. `middleware/sidecars/dev-runner/Dockerfile` and `.../dev-runner-daemon/Dockerfile` are unmanaged and had silently drifted — this PR bumps them by hand, but they will drift again.
5. **The audit bypass deserves a second look.** It is reasonable in intent, but it hid a real result set for as long as the endpoint was down. A warning annotation that is impossible to miss, or a periodic non-bypassed run, would make the blind spot visible.