### PR TITLE
fix(chat): route background stream writes by session id, not active t…

### DIFF
--- a/web-ui/app/_components/StreamRunner.tsx
+++ b/web-ui/app/_components/StreamRunner.tsx
@@ -238,7 +238,10 @@ export async function runOneTurn(
     }
   } finally {
     finalizePending(depsRef.current.sessions, sessionId, pendingMessageId);
-    void depsRef.current.sessions.persistActive();
+    // Persist the turn's OWN session, not whichever tab is active now — the
+    // user may have switched away while this background turn was streaming
+    // (#617).
+    void depsRef.current.sessions.persistById(sessionId);
   }
 }
 
@@ -247,18 +250,15 @@ function finalizePending(
   sessionId: string,
   pendingMessageId: string,
 ): void {
-  sessions.mutateActive((session) => {
-    if (session.id !== sessionId) return session;
-    return {
-      ...session,
-      messages: session.messages.map((m) =>
-        m.id === pendingMessageId && m.streaming
-          ? { ...m, streaming: false, finishedAt: Date.now() }
-          : m,
-      ),
-      updatedAt: Date.now(),
-    };
-  });
+  sessions.mutateById(sessionId, (session) => ({
+    ...session,
+    messages: session.messages.map((m) =>
+      m.id === pendingMessageId && m.streaming
+        ? { ...m, streaming: false, finishedAt: Date.now() }
+        : m,
+    ),
+    updatedAt: Date.now(),
+  }));
 }
 
 interface AccumulatorState {

--- a/web-ui/app/_components/__tests__/StreamRunner.test.tsx
+++ b/web-ui/app/_components/__tests__/StreamRunner.test.tsx
@@ -1,7 +1,11 @@
 import { act, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import type { UseChatSessionsResult } from '../../_lib/chatSessions';
+import type {
+  ChatSession,
+  Message,
+  UseChatSessionsResult,
+} from '../../_lib/chatSessions';
 import {
   StreamStoreProvider,
   useStreamStore,
@@ -45,14 +49,14 @@ function captureStore(): { latest: () => StoreValue } {
 }
 
 /**
- * Minimal chat-sessions stub. `runOneTurn` only ever touches `mutateActive`
- * (via applyStreamEvent + finalizePending) and `persistActive`; everything else
+ * Minimal chat-sessions stub. `runOneTurn` only ever touches `mutateById`
+ * (via applyStreamEvent + finalizePending) and `persistById`; everything else
  * on the context is irrelevant to the store-outcome decision under test.
  */
 function stubSessions(): UseChatSessionsResult {
   return {
-    mutateActive: vi.fn(),
-    persistActive: vi.fn().mockResolvedValue(undefined),
+    mutateById: vi.fn(),
+    persistById: vi.fn().mockResolvedValue(undefined),
   } as unknown as UseChatSessionsResult;
 }
 
@@ -153,5 +157,119 @@ describe('runOneTurn — in-band error on a 200 stream (#403)', () => {
     const record = latest().get(sessionId);
     expect(record?.phase).toBe('done');
     expect(record?.error).toBeUndefined();
+  });
+});
+
+/**
+ * #617 — a background turn (its tab is NOT the active one) must fold every
+ * event into the session that OWNS it. The pre-fix route went through
+ * `mutateActive`/`persistActive`, which only ever touched the active tab, so
+ * switching away mid-stream truncated the answer and discarded the `done`
+ * event even though the tab advertised "response ready".
+ *
+ * The stateful fake below is the point of the test: it distinguishes writes by
+ * id (like the real store) instead of stubbing them into a black hole, so the
+ * assertions fail if the runner ever routes back through the active-tab
+ * helpers.
+ */
+describe('runOneTurn — background session (non-active tab) (#617)', () => {
+  /** A stateful sessions fake that routes writes by id, like the real store. */
+  function fakeSessions(
+    initial: ChatSession[],
+    activeId: string,
+  ): {
+    ctx: UseChatSessionsResult;
+    session: (id: string) => ChatSession | undefined;
+    persistActiveSpy: ReturnType<typeof vi.fn>;
+    persistByIdSpy: ReturnType<typeof vi.fn>;
+  } {
+    let sessions = initial;
+    const persistActiveSpy = vi.fn().mockResolvedValue(undefined);
+    const persistByIdSpy = vi.fn().mockResolvedValue(undefined);
+    const mutateById = (
+      id: string,
+      mut: (s: ChatSession) => ChatSession,
+    ): void => {
+      sessions = sessions.map((s) => (s.id === id ? mut(s) : s));
+    };
+    const ctx = {
+      mutateById,
+      mutateActive: (mut: (s: ChatSession) => ChatSession) =>
+        mutateById(activeId, mut),
+      persistById: persistByIdSpy,
+      persistActive: persistActiveSpy,
+    } as unknown as UseChatSessionsResult;
+    return {
+      ctx,
+      session: (id: string) => sessions.find((s) => s.id === id),
+      persistActiveSpy,
+      persistByIdSpy,
+    };
+  }
+
+  function streamingAssistant(id: string): Message {
+    return { id, role: 'assistant', content: '', streaming: true, startedAt: 0 };
+  }
+
+  function sessionWith(id: string, messages: Message[]): ChatSession {
+    return { id, title: id, createdAt: 0, updatedAt: 0, messages };
+  }
+
+  async function driveInto(
+    store: StoreValue,
+    ctx: UseChatSessionsResult,
+    sessionId: string,
+    pendingMessageId: string,
+    response: Response,
+  ): Promise<void> {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(response);
+    let claim: ClaimedRequest | undefined;
+    await act(async () => {
+      store.startTurn({ sessionId, pendingMessageId, message: 'hi' });
+      claim = store.claimRequest();
+    });
+    if (!claim) throw new Error('claimRequest returned nothing');
+    const depsRef: DepsRef = { current: { t: tStub, sessions: ctx, store } };
+    await act(async () => {
+      await runOneTurn(claim as ClaimedRequest, depsRef);
+    });
+  }
+
+  it('lands the streamed deltas AND the done answer in a non-active session', async () => {
+    const { latest } = captureStore();
+    const store = latest();
+
+    const bgId = 'session-bg';
+    const pendingId = 'pending-bg';
+    const fake = fakeSessions(
+      [
+        sessionWith('session-active', []), // the tab the user is looking at
+        sessionWith(bgId, [streamingAssistant(pendingId)]),
+      ],
+      'session-active', // active tab is NOT the streaming one
+    );
+
+    // A delta, then the authoritative done answer — as two NDJSON lines.
+    const body =
+      `${JSON.stringify({ type: 'text_delta', text: 'partial ' })}\n` +
+      `${JSON.stringify({
+        type: 'done',
+        answer: 'the complete answer',
+        toolCalls: 0,
+        iterations: 1,
+      })}\n`;
+
+    await driveInto(store, fake.ctx, bgId, pendingId, ndjson200(body));
+
+    const msg = fake.session(bgId)?.messages.find((m) => m.id === pendingId);
+    // Content is the done answer (mutation guard: 'partial ' alone or '' both fail).
+    expect(msg?.content).toBe('the complete answer');
+    // Turn is finalized on its own session, not left mid-stream.
+    expect(msg?.streaming).toBe(false);
+    // The active tab was never touched.
+    expect(fake.session('session-active')?.messages).toHaveLength(0);
+    // Persistence targeted the turn's session, never the active-tab helper.
+    expect(fake.persistByIdSpy).toHaveBeenCalledWith(bgId);
+    expect(fake.persistActiveSpy).not.toHaveBeenCalled();
   });
 });

--- a/web-ui/app/_lib/chatSessions.ts
+++ b/web-ui/app/_lib/chatSessions.ts
@@ -752,7 +752,16 @@ export interface UseChatSessionsResult {
   setActive(id: string): void;
   clearMessages(id: string): Promise<void>;
   mutateActive(mutator: (session: ChatSession) => ChatSession): void;
+  /**
+   * Mutate a session by id, whether or not it is the active tab. This is the
+   * primitive `mutateActive` delegates to; the stream-runner uses it directly
+   * so a background turn writes into the session that owns it (#617) rather
+   * than into whichever tab the user happens to be looking at.
+   */
+  mutateById(id: string, mutator: (session: ChatSession) => ChatSession): void;
   persistActive(): Promise<void>;
+  /** Persist a session by id — the by-id counterpart of `persistActive` (#617). */
+  persistById(id: string): Promise<void>;
 }
 
 /**
@@ -1009,13 +1018,18 @@ export function useChatSessions(): UseChatSessionsResult {
     [],
   );
 
+  const mutateById = useCallback(
+    (id: string, mutator: (session: ChatSession) => ChatSession): void => {
+      setSessions((prev) => prev.map((s) => (s.id === id ? mutator(s) : s)));
+    },
+    [],
+  );
+
   const mutateActive = useCallback(
     (mutator: (session: ChatSession) => ChatSession): void => {
-      setSessions((prev) =>
-        prev.map((s) => (s.id === activeId ? mutator(s) : s)),
-      );
+      mutateById(activeId, mutator);
     },
-    [activeId],
+    [activeId, mutateById],
   );
 
   // Refs kept in sync with state so persistActive reads the latest snapshot
@@ -1033,18 +1047,23 @@ export function useChatSessions(): UseChatSessionsResult {
     activeIdRef.current = activeId;
   }, [activeId]);
 
-  const persistActive = useCallback(async (): Promise<void> => {
-    const snapshot = sessionsRef.current.find((s) => s.id === activeIdRef.current);
+  const persistById = useCallback(async (id: string): Promise<void> => {
+    const snapshot = sessionsRef.current.find((s) => s.id === id);
     if (!snapshot) return;
     try {
       await putRemoteSession(snapshot);
     } catch (err) {
       console.warn(
-        '[chat-sessions] persistActive failed:',
+        '[chat-sessions] persistById failed:',
         err instanceof Error ? err.message : err,
       );
     }
   }, []);
+
+  const persistActive = useCallback(
+    (): Promise<void> => persistById(activeIdRef.current),
+    [persistById],
+  );
 
   // Always return *some* active session so the caller doesn't have to guard.
   // Build an ephemeral empty one during the brief hydrating window.
@@ -1064,6 +1083,8 @@ export function useChatSessions(): UseChatSessionsResult {
     setActive: setActiveId,
     clearMessages,
     mutateActive,
+    mutateById,
     persistActive,
+    persistById,
   };
 }

--- a/web-ui/app/_lib/chatStreamEvents.ts
+++ b/web-ui/app/_lib/chatStreamEvents.ts
@@ -149,15 +149,10 @@ export type ChatStreamEvent =
 
 /**
  * Fold one stream event into the session that owns the pending assistant
- * message. Pure-ish: writes go through `sessions.mutateActive`. The session
- * is matched by id; events for non-active sessions are no-ops here — the
- * caller (StreamRunner) is responsible for routing to the right pending id.
- *
- * Note: mutateActive only writes to the *currently active* session. The
- * stream-runner uses it because in practice a stream's session and the
- * active session coincide while a turn is firing. If we ever want to run
- * background turns for a non-active session we'll need a per-session
- * `mutateById` helper.
+ * message. Pure-ish: the write goes through `sessions.mutateById`, so it lands
+ * in the session the turn belongs to even when that tab is in the background
+ * (#617) — the previous `mutateActive` route silently discarded events, and the
+ * final `done` answer, whenever the user switched tabs mid-stream.
  */
 export function applyStreamEvent(
   sessions: UseChatSessionsResult,
@@ -165,10 +160,9 @@ export function applyStreamEvent(
   pendingMessageId: string,
   event: ChatStreamEvent,
 ): void {
-  sessions.mutateActive((session) => {
-    if (session.id !== sessionId) return session;
-    return foldEvent(session, pendingMessageId, event);
-  });
+  sessions.mutateById(sessionId, (session) =>
+    foldEvent(session, pendingMessageId, event),
+  );
 }
 
 function foldEvent(


### PR DESCRIPTION
## What
  Closes #617. Background chat turns now fold every event — deltas and the final `done` answer — into the session that owns them, instead of only ever writing to the active tab.

  ## Why
  Stream writes went through `mutateActive`/`persistActive`, which by design only touch the currently active session. Switching tabs mid-stream discarded the turn's deltas and its authoritative `done` answer, leaving the message truncated and stuck `streaming` while its tab still advertised "response ready". Added `mutateById`/`persistById` (the per-session primitive the old code comment anticipated) and routed all stream writes + finalization + persistence through them; `mutateActive`/`persistActive` now delegate to them.

  ## Test plan
  - [x] `npx tsc --noEmit` — clean (only pre-existing generated `.next/dev-button-check` noise)
  - [x] `npm run lint` — 0 errors (38 pre-existing warnings, unrelated files)
  - [x] `npm run test` — 69 files / 578 tests pass
  - [x] `npm run i18n:check` — OK, 3327 keys, en+de parity
  - [x] Added regression test: drives delta+`done` into a **non-active** session, asserts the full answer lands, `streaming:false`, active tab untouched, `persistById(bgId)` called and `persistActive` never called (assertions mutation-guarded)

  ## Risk / blast radius
  `mutateActive`/`persistActive` refactored to delegate to the new by-id helpers — active-tab behavior is unchanged, and the 3 `chat/page.tsx` callers are untouched. No schema, public API, CI, or env-var changes. UI-only; no new user-facing strings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788528080&installation_model_id=428086&pr_number=618&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F618&signature=972d90cfe4933a944a64faacb78741b9a6ec4e0eaee9452e3388b2bdf3edef09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->