### PR TITLE
fix: background chat turns lose content on mid-stream tab switch

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,26 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — background chat turns write into their own session (#617)
+
+- A turn that was still streaming when the user switched to another chat tab
+  lost its content: every transcript write went through the active-session
+  helpers, so the fold landed in whichever session happened to be in the
+  foreground — nowhere at all, in practice. The tab marker reported a finished
+  answer that the transcript never received, and the pending bubble stayed
+  stuck in its `streaming` state.
+- The chat-sessions store now exposes `mutateById(sessionId, mutator)` and
+  `persistById(sessionId)`; `applyStreamEvent`, `finalizePending` and the
+  stream runner's terminal persist all address the session the turn belongs to.
+  `mutateActive` / `persistActive` are gone — the active-scoped call sites on
+  the chat page pass their id explicitly.
+- `persistById` also fixes a second half of the bug: it enqueues rather than
+  reading an effect-synced ref, so the PUT carries state from *after* the
+  `done` fold committed. Without that, a background answer survived in memory
+  but not across a reload — a background turn gets no corrective follow-up turn
+  to repair the snapshot. A session deleted mid-stream is never resurrected:
+  the queued write is dropped when the id is gone.
+
 ### Changed — background chat streams surface in-context, not as toasts (#286)
 
 - **Removed `StreamToasts`** (the bottom-right floating cards for background

--- a/web-ui/app/_components/StreamRunner.tsx
+++ b/web-ui/app/_components/StreamRunner.tsx
@@ -238,7 +238,7 @@ export async function runOneTurn(
     }
   } finally {
     finalizePending(depsRef.current.sessions, sessionId, pendingMessageId);
-    void depsRef.current.sessions.persistActive();
+    depsRef.current.sessions.persistById(sessionId);
   }
 }
 
@@ -247,18 +247,15 @@ function finalizePending(
   sessionId: string,
   pendingMessageId: string,
 ): void {
-  sessions.mutateActive((session) => {
-    if (session.id !== sessionId) return session;
-    return {
-      ...session,
-      messages: session.messages.map((m) =>
-        m.id === pendingMessageId && m.streaming
-          ? { ...m, streaming: false, finishedAt: Date.now() }
-          : m,
-      ),
-      updatedAt: Date.now(),
-    };
-  });
+  sessions.mutateById(sessionId, (session) => ({
+    ...session,
+    messages: session.messages.map((m) =>
+      m.id === pendingMessageId && m.streaming
+        ? { ...m, streaming: false, finishedAt: Date.now() }
+        : m,
+    ),
+    updatedAt: Date.now(),
+  }));
 }
 
 interface AccumulatorState {

--- a/web-ui/app/_components/__tests__/StreamRunner.test.tsx
+++ b/web-ui/app/_components/__tests__/StreamRunner.test.tsx
@@ -1,7 +1,11 @@
 import { act, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import type { UseChatSessionsResult } from '../../_lib/chatSessions';
+import type {
+  ChatSession,
+  Message,
+  UseChatSessionsResult,
+} from '../../_lib/chatSessions';
 import {
   StreamStoreProvider,
   useStreamStore,
@@ -44,16 +48,78 @@ function captureStore(): { latest: () => StoreValue } {
   };
 }
 
-/**
- * Minimal chat-sessions stub. `runOneTurn` only ever touches `mutateActive`
- * (via applyStreamEvent + finalizePending) and `persistActive`; everything else
- * on the context is irrelevant to the store-outcome decision under test.
- */
-function stubSessions(): UseChatSessionsResult {
+interface StatefulSessions {
+  sessions: UseChatSessionsResult;
+  /** Live transcript, so a test can assert the content actually landed. */
+  get(id: string): ChatSession | undefined;
+  /** Every id `runOneTurn` asked to persist, in call order. */
+  persisted: string[];
+}
+
+function pendingMessage(): Message {
   return {
-    mutateActive: vi.fn(),
-    persistActive: vi.fn().mockResolvedValue(undefined),
+    id: 'pending-1',
+    role: 'assistant',
+    content: '',
+    tools: [],
+    startedAt: 1_000,
+    streaming: true,
+  };
+}
+
+/**
+ * Stateful chat-sessions fake. A `vi.fn()`-only stub can assert that
+ * `mutateById` was called but not that the answer arrived, which is precisely
+ * the failure mode of #617 — so this one holds a real transcript and applies
+ * the mutator with production semantics (`id` match, otherwise untouched).
+ *
+ * `activeId` is deliberately a session that is NOT the one being streamed:
+ * that is the "user switched chat tabs mid-stream" situation.
+ */
+function statefulSessions(activeId = 'other'): StatefulSessions {
+  let state: ChatSession[] = [
+    {
+      id: 'other',
+      title: 'Foreground',
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      messages: [],
+    },
+    {
+      id: 'bg',
+      title: 'Background',
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      messages: [pendingMessage()],
+    },
+    {
+      id: 'session-403',
+      title: '#403',
+      createdAt: 1_000,
+      updatedAt: 1_000,
+      messages: [pendingMessage()],
+    },
+  ];
+  const persisted: string[] = [];
+
+  const sessions = {
+    activeId,
+    mutateById(
+      sessionId: string,
+      mutator: (session: ChatSession) => ChatSession,
+    ): void {
+      state = state.map((s) => (s.id === sessionId ? mutator(s) : s));
+    },
+    persistById(sessionId: string): void {
+      persisted.push(sessionId);
+    },
   } as unknown as UseChatSessionsResult;
+
+  return {
+    sessions,
+    get: (id: string) => state.find((s) => s.id === id),
+    persisted,
+  };
 }
 
 const GENERIC_FALLBACK = 'Something went wrong talking to the provider.';
@@ -75,8 +141,12 @@ function ndjson200(body: string): Response {
  * sessions/translations. Returns the sessionId so the caller can read the
  * terminal record.
  */
-async function drive(store: StoreValue, response: Response): Promise<string> {
-  const sessionId = 'session-403';
+async function drive(
+  store: StoreValue,
+  response: Response,
+  opts: { sessionId?: string; sessions?: StatefulSessions } = {},
+): Promise<string> {
+  const sessionId = opts.sessionId ?? 'session-403';
   vi.spyOn(globalThis, 'fetch').mockResolvedValue(response);
 
   let claim: ClaimedRequest | undefined;
@@ -87,7 +157,11 @@ async function drive(store: StoreValue, response: Response): Promise<string> {
   if (!claim) throw new Error('claimRequest returned nothing');
 
   const depsRef: DepsRef = {
-    current: { t: tStub, sessions: stubSessions(), store },
+    current: {
+      t: tStub,
+      sessions: (opts.sessions ?? statefulSessions()).sessions,
+      store,
+    },
   };
   await act(async () => {
     await runOneTurn(claim as ClaimedRequest, depsRef);
@@ -153,5 +227,78 @@ describe('runOneTurn — in-band error on a 200 stream (#403)', () => {
     const record = latest().get(sessionId);
     expect(record?.phase).toBe('done');
     expect(record?.error).toBeUndefined();
+  });
+});
+
+/**
+ * #617 — a turn whose session is NOT the active one used to write into the
+ * void: every store write went through the active-session mutator, so the
+ * answer arrived in the tab marker but never in the transcript. These tests drive a real
+ * background turn ('bg' streaming while 'other' is active) against a stateful
+ * sessions fake and assert the content landed.
+ */
+describe('runOneTurn — background session (#617)', () => {
+  it('folds a background turn into its own session, not the active one', async () => {
+    const { latest } = captureStore();
+    const store = latest();
+    const fake = statefulSessions('other');
+
+    const body = [
+      JSON.stringify({ type: 'text_delta', text: 'partial ' }),
+      JSON.stringify({ type: 'text_delta', text: 'stream' }),
+      JSON.stringify({
+        type: 'done',
+        answer: 'the authoritative answer',
+        toolCalls: 0,
+        iterations: 1,
+      }),
+      '',
+    ].join('\n');
+
+    await drive(store, ndjson200(body), { sessionId: 'bg', sessions: fake });
+
+    const pending = fake.get('bg')?.messages[0];
+    expect(pending?.content).toBe('the authoritative answer');
+    expect(pending?.streaming).toBe(false);
+    // The active session must not have been touched at all.
+    expect(fake.get('other')?.messages).toHaveLength(0);
+  });
+
+  it('keeps the streamed deltas when the stream ends without a done event', async () => {
+    const { latest } = captureStore();
+    const store = latest();
+    const fake = statefulSessions('other');
+
+    const body = [
+      JSON.stringify({ type: 'text_delta', text: 'half an ' }),
+      JSON.stringify({ type: 'text_delta', text: 'answer' }),
+      '',
+    ].join('\n');
+
+    await drive(store, ndjson200(body), { sessionId: 'bg', sessions: fake });
+
+    const pending = fake.get('bg')?.messages[0];
+    expect(pending?.content).toBe('half an answer');
+    // finalizePending must clear the flag even without `done`, otherwise the
+    // bubble animates its dots forever.
+    expect(pending?.streaming).toBe(false);
+  });
+
+  it('persists the session the turn belongs to', async () => {
+    const { latest } = captureStore();
+    const store = latest();
+    const fake = statefulSessions('other');
+
+    const body = `${JSON.stringify({
+      type: 'done',
+      answer: 'persisted',
+      toolCalls: 0,
+      iterations: 1,
+    })}\n`;
+
+    await drive(store, ndjson200(body), { sessionId: 'bg', sessions: fake });
+
+    expect(fake.persisted).toEqual(['bg']);
+    expect(fake.persisted).not.toContain('other');
   });
 });

--- a/web-ui/app/_lib/__tests__/chatSessions.persistById.test.ts
+++ b/web-ui/app/_lib/__tests__/chatSessions.persistById.test.ts
@@ -1,0 +1,154 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useChatSessions, type ChatSession, type Message } from '../chatSessions';
+
+/**
+ * #617 — the old active-session persist helper resolved its snapshot through
+ * an active-id ref and an effect-synced sessions ref, so a background turn PUT
+ * whichever session the user happened to be looking at, from state that could
+ * still predate the `done` fold. A background turn gets no corrective follow-up
+ * turn, so that stale snapshot was the FINAL persisted state and the answer did
+ * not survive a reload.
+ *
+ * These tests pin the replacement contract: `persistById` writes the session
+ * it was handed, from state that has already committed, and it silently drops
+ * the write when that session is gone.
+ */
+
+const ID_A = 'session-a';
+const ID_B = 'session-b';
+
+interface RecordedCall {
+  url: string;
+  method: string;
+  body: string | undefined;
+}
+
+let calls: RecordedCall[] = [];
+
+function assistantMessage(content: string): Message {
+  return {
+    id: `msg-${content}`,
+    role: 'assistant',
+    content,
+    startedAt: 1_000,
+  };
+}
+
+function remoteSession(id: string, updatedAt: number): ChatSession {
+  return {
+    id,
+    title: id,
+    createdAt: 1_000,
+    updatedAt,
+    messages: [assistantMessage('hello')],
+  };
+}
+
+function json(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/**
+ * Backend fake: two sessions, `ID_A` newer so hydration makes it the active
+ * one and `ID_B` is the background session under test.
+ */
+function installFetchMock(): void {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(
+    (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      calls.push({
+        url,
+        method,
+        body: typeof init?.body === 'string' ? init.body : undefined,
+      });
+
+      if (method === 'GET' && url === '/bot-api/chat/sessions') {
+        return Promise.resolve(
+          json({
+            sessions: [
+              { id: ID_A, title: ID_A, createdAt: 1_000, updatedAt: 2_000, messageCount: 1 },
+              { id: ID_B, title: ID_B, createdAt: 1_000, updatedAt: 1_500, messageCount: 1 },
+            ],
+          }),
+        );
+      }
+      if (method === 'GET' && url.endsWith(ID_A)) {
+        return Promise.resolve(json(remoteSession(ID_A, 2_000)));
+      }
+      if (method === 'GET' && url.endsWith(ID_B)) {
+        return Promise.resolve(json(remoteSession(ID_B, 1_500)));
+      }
+      return Promise.resolve(new Response('', { status: 200 }));
+    },
+  );
+}
+
+function putsFor(id: string): RecordedCall[] {
+  return calls.filter((c) => c.method === 'PUT' && c.url.endsWith(id));
+}
+
+async function hydrated(): Promise<
+  ReturnType<typeof renderHook<ReturnType<typeof useChatSessions>, unknown>>
+> {
+  const view = renderHook(() => useChatSessions());
+  await waitFor(() => {
+    expect(view.result.current.hydrating).toBe(false);
+  });
+  expect(view.result.current.activeId).toBe(ID_A);
+  return view;
+}
+
+beforeEach(() => {
+  calls = [];
+  window.localStorage.clear();
+  installFetchMock();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useChatSessions — persistById (#617)', () => {
+  it('PUTs the named background session from post-commit state', async () => {
+    const view = await hydrated();
+    calls = [];
+
+    act(() => {
+      view.result.current.mutateById(ID_B, (s) => ({
+        ...s,
+        messages: [...s.messages, assistantMessage('final answer')],
+        updatedAt: 3_000,
+      }));
+      view.result.current.persistById(ID_B);
+    });
+
+    const puts = putsFor(ID_B);
+    expect(puts).toHaveLength(1);
+
+    const payload = JSON.parse(puts[0]?.body ?? '{}') as ChatSession;
+    expect(payload.messages.at(-1)?.content).toBe('final answer');
+    // The active session is a bystander — it must not be written.
+    expect(putsFor(ID_A)).toHaveLength(0);
+  });
+
+  it('drops the PUT when the session was deleted before the turn finished', async () => {
+    const view = await hydrated();
+
+    await act(async () => {
+      await view.result.current.deleteSession(ID_B);
+    });
+    calls = [];
+
+    act(() => {
+      view.result.current.persistById(ID_B);
+    });
+
+    expect(putsFor(ID_B)).toHaveLength(0);
+  });
+});

--- a/web-ui/app/_lib/__tests__/chatStreamEvents.test.ts
+++ b/web-ui/app/_lib/__tests__/chatStreamEvents.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { applyStreamEvent } from '../chatStreamEvents';
+import type {
+  ChatSession,
+  Message,
+  UseChatSessionsResult,
+} from '../chatSessions';
+
+/**
+ * #617 — `applyStreamEvent` used to write through the active-session mutator,
+ * which only ever reached the *currently active* session. A turn streaming
+ * into a chat tab the user had switched away from therefore folded its events
+ * into nothing. These tests pin the routing contract: the fold is addressed by the
+ * turn's own session id, and the mutator handed over touches exactly the
+ * pending message.
+ */
+
+function assistantMessage(id: string, content: string): Message {
+  return {
+    id,
+    role: 'assistant',
+    content,
+    startedAt: 1_000,
+    streaming: true,
+  };
+}
+
+function session(id: string): ChatSession {
+  return {
+    id,
+    title: 'Background',
+    createdAt: 1_000,
+    updatedAt: 1_000,
+    messages: [
+      assistantMessage('other', 'untouched'),
+      assistantMessage('pending-1', 'so far'),
+    ],
+  };
+}
+
+/**
+ * Records the `(sessionId, mutator)` pair `applyStreamEvent` hands to the
+ * store, so the test can both assert the routing and replay the mutator.
+ */
+function stubSessions(): {
+  sessions: UseChatSessionsResult;
+  mutateById: ReturnType<typeof vi.fn>;
+} {
+  const mutateById = vi.fn();
+  return {
+    sessions: { mutateById } as unknown as UseChatSessionsResult,
+    mutateById,
+  };
+}
+
+function applied(
+  mutateById: ReturnType<typeof vi.fn>,
+  target: ChatSession,
+): ChatSession {
+  const mutator = mutateById.mock.calls[0]?.[1] as (s: ChatSession) => ChatSession;
+  return mutator(target);
+}
+
+describe('applyStreamEvent — writes are addressed by session id (#617)', () => {
+  it('routes a text_delta to the session the turn belongs to and folds it into the pending message', () => {
+    const { sessions, mutateById } = stubSessions();
+
+    applyStreamEvent(sessions, 'bg', 'pending-1', {
+      type: 'text_delta',
+      text: ' more',
+    });
+
+    expect(mutateById).toHaveBeenCalledTimes(1);
+    expect(mutateById.mock.calls[0]?.[0]).toBe('bg');
+
+    const before = session('bg');
+    const next = applied(mutateById, before);
+    expect(next.messages[1]?.content).toBe('so far more');
+    // Sibling messages survive the fold untouched.
+    expect(next.messages[0]).toBe(before.messages[0]);
+    expect(next.updatedAt).toBeGreaterThanOrEqual(before.updatedAt);
+  });
+
+  it('replaces the content wholesale with the authoritative done answer', () => {
+    const { sessions, mutateById } = stubSessions();
+
+    applyStreamEvent(sessions, 'bg', 'pending-1', {
+      type: 'done',
+      answer: 'the authoritative answer',
+      toolCalls: 0,
+      iterations: 1,
+    });
+
+    expect(mutateById.mock.calls[0]?.[0]).toBe('bg');
+
+    const next = applied(mutateById, session('bg'));
+    expect(next.messages[1]?.content).toBe('the authoritative answer');
+    expect(next.messages[1]?.streaming).toBe(false);
+  });
+});

--- a/web-ui/app/_lib/chatSessions.ts
+++ b/web-ui/app/_lib/chatSessions.ts
@@ -751,8 +751,11 @@ export interface UseChatSessionsResult {
   renameSession(id: string, title: string): Promise<void>;
   setActive(id: string): void;
   clearMessages(id: string): Promise<void>;
-  mutateActive(mutator: (session: ChatSession) => ChatSession): void;
-  persistActive(): Promise<void>;
+  mutateById(
+    sessionId: string,
+    mutator: (session: ChatSession) => ChatSession,
+  ): void;
+  persistById(sessionId: string): void;
 }
 
 /**
@@ -1009,42 +1012,58 @@ export function useChatSessions(): UseChatSessionsResult {
     [],
   );
 
-  const mutateActive = useCallback(
-    (mutator: (session: ChatSession) => ChatSession): void => {
+  // #617 — mutation is addressed by session id, never by "whatever is active".
+  // A background turn (the user switched chat tabs while it was streaming)
+  // must fold its events into its OWN session. Note the empty dep array: the
+  // callback closes over nothing, so its identity is stable for the lifetime
+  // of the hook and a long-running stream closure can never go stale.
+  const mutateById = useCallback(
+    (
+      sessionId: string,
+      mutator: (session: ChatSession) => ChatSession,
+    ): void => {
       setSessions((prev) =>
-        prev.map((s) => (s.id === activeId ? mutator(s) : s)),
+        prev.map((s) => (s.id === sessionId ? mutator(s) : s)),
       );
     },
-    [activeId],
+    [],
   );
 
-  // Refs kept in sync with state so persistActive reads the latest snapshot
-  // without forcing callers to resubscribe on every message delta. Declared —
-  // and synced — *before* persistActive so the React-Compiler `immutability`
-  // rule sees the `.current` writes happen before the useCallback closes over
-  // the refs. Initialised with throwaway literals (identical to the `useState`
-  // initial values); the effects below own the actual sync.
-  const sessionsRef = useRef<ChatSession[]>([]);
-  const activeIdRef = useRef<string>('');
-  useEffect(() => {
-    sessionsRef.current = sessions;
-  }, [sessions]);
-  useEffect(() => {
-    activeIdRef.current = activeId;
-  }, [activeId]);
+  // #617 — commit-ordered persistence. A background turn is followed by no
+  // corrective user turn in its session, so the PUT it fires from the stream
+  // runner's `finally` is the FINAL persisted state; reading the snapshot from
+  // an effect-synced ref would write state that predates the `done` fold.
+  // Instead `persistById` only enqueues, and the effect below drains the queue
+  // against the `sessions` value from render scope — i.e. state that has
+  // already committed. Deliberately NOT resolved inside a `setSessions`
+  // updater: that is a side effect in a function React may double-invoke, and
+  // it conflicts with the React-Compiler `immutability` rule.
+  const persistQueueRef = useRef<Set<string>>(new Set());
+  const [persistTick, setPersistTick] = useState(0);
 
-  const persistActive = useCallback(async (): Promise<void> => {
-    const snapshot = sessionsRef.current.find((s) => s.id === activeIdRef.current);
-    if (!snapshot) return;
-    try {
-      await putRemoteSession(snapshot);
-    } catch (err) {
-      console.warn(
-        '[chat-sessions] persistActive failed:',
-        err instanceof Error ? err.message : err,
-      );
-    }
+  const persistById = useCallback((sessionId: string): void => {
+    persistQueueRef.current.add(sessionId);
+    setPersistTick((n) => n + 1);
   }, []);
+
+  useEffect(() => {
+    if (persistQueueRef.current.size === 0) return;
+    const queued = [...persistQueueRef.current];
+    persistQueueRef.current.clear();
+    for (const id of queued) {
+      const snapshot = sessions.find((s) => s.id === id);
+      // Deleted or cleared while the turn was still in flight. Dropping the
+      // PUT is what keeps a late background turn from resurrecting a session
+      // the user already threw away.
+      if (!snapshot) continue;
+      putRemoteSession(snapshot).catch((err: unknown) => {
+        console.warn(
+          '[chat-sessions] persistById failed:',
+          err instanceof Error ? err.message : err,
+        );
+      });
+    }
+  }, [persistTick, sessions]);
 
   // Always return *some* active session so the caller doesn't have to guard.
   // Build an ephemeral empty one during the brief hydrating window.
@@ -1063,7 +1082,7 @@ export function useChatSessions(): UseChatSessionsResult {
     renameSession,
     setActive: setActiveId,
     clearMessages,
-    mutateActive,
-    persistActive,
+    mutateById,
+    persistById,
   };
 }

--- a/web-ui/app/_lib/chatSessionsContext.tsx
+++ b/web-ui/app/_lib/chatSessionsContext.tsx
@@ -5,10 +5,10 @@ import { createContext, useContext } from 'react';
 import { useChatSessions, type UseChatSessionsResult } from './chatSessions';
 
 /**
- * Lifts the chat-sessions state (sessions, activeId, mutateActive, …) to
+ * Lifts the chat-sessions state (sessions, activeId, mutateById, …) to
  * a layout-level provider. Without this, the state lived inside
  * `<ChatPage>` and was destroyed whenever the user navigated away — taking
- * any in-flight stream's `mutateActive` closure down with it. With this,
+ * any in-flight stream's `mutateById` closure down with it. With this,
  * the provider is mounted in `RootLayout`, so `<StreamRunner>` (also in
  * the layout) keeps writing message deltas into the same store regardless
  * of which page is currently rendered.

--- a/web-ui/app/_lib/chatStreamEvents.ts
+++ b/web-ui/app/_lib/chatStreamEvents.ts
@@ -149,15 +149,11 @@ export type ChatStreamEvent =
 
 /**
  * Fold one stream event into the session that owns the pending assistant
- * message. Pure-ish: writes go through `sessions.mutateActive`. The session
- * is matched by id; events for non-active sessions are no-ops here — the
- * caller (StreamRunner) is responsible for routing to the right pending id.
- *
- * Note: mutateActive only writes to the *currently active* session. The
- * stream-runner uses it because in practice a stream's session and the
- * active session coincide while a turn is firing. If we ever want to run
- * background turns for a non-active session we'll need a per-session
- * `mutateById` helper.
+ * message. Pure-ish: writes go through `sessions.mutateById`, so the fold
+ * lands in the session the turn belongs to and not in whichever session
+ * happens to be active. That is what lets a background turn keep filling its
+ * own transcript after the user switched chat tabs mid-stream (#617); the
+ * caller (StreamRunner) stays responsible for routing to the right pending id.
  */
 export function applyStreamEvent(
   sessions: UseChatSessionsResult,
@@ -165,10 +161,9 @@ export function applyStreamEvent(
   pendingMessageId: string,
   event: ChatStreamEvent,
 ): void {
-  sessions.mutateActive((session) => {
-    if (session.id !== sessionId) return session;
-    return foldEvent(session, pendingMessageId, event);
-  });
+  sessions.mutateById(sessionId, (session) =>
+    foldEvent(session, pendingMessageId, event),
+  );
 }
 
 function foldEvent(

--- a/web-ui/app/chat/__tests__/page.keyboard.test.tsx
+++ b/web-ui/app/chat/__tests__/page.keyboard.test.tsx
@@ -17,13 +17,13 @@ const {
   mockStartTurn,
   mockAbort,
   mockIsActive,
-  mockMutateActive,
+  mockMutateById,
   mockSteerActiveTurn,
 } = vi.hoisted(() => ({
   mockStartTurn: vi.fn(),
   mockAbort: vi.fn(),
   mockIsActive: vi.fn(() => false),
-  mockMutateActive: vi.fn(),
+  mockMutateById: vi.fn(),
   mockSteerActiveTurn: vi.fn(),
 }));
 
@@ -71,7 +71,7 @@ vi.mock('../../_lib/chatSessionsContext', () => ({
     renameSession: vi.fn(),
     setActive: vi.fn(),
     clearMessages: vi.fn(),
-    mutateActive: mockMutateActive,
+    mutateById: mockMutateById,
   }),
 }));
 

--- a/web-ui/app/chat/page.tsx
+++ b/web-ui/app/chat/page.tsx
@@ -185,7 +185,7 @@ export default function ChatPage(): React.ReactElement {
     renameSession,
     setActive,
     clearMessages,
-    mutateActive,
+    mutateById,
   } = useChatSessionsCtx();
   const streamStore = useStreamStore();
   const sending = streamStore.isActive(activeId);
@@ -253,7 +253,7 @@ export default function ChatPage(): React.ReactElement {
   // the user can re-save with their own classification.
   const clearAutoPromoted = useCallback(
     (messageId: string): void => {
-      mutateActive((session) => {
+      mutateById(activeId, (session) => {
         const nextMessages = session.messages.map((m) => {
           if (m.id !== messageId) return m;
           const { autoPromotedMkId: _drop, ...rest } = m;
@@ -262,7 +262,7 @@ export default function ChatPage(): React.ReactElement {
         return { ...session, messages: nextMessages, updatedAt: Date.now() };
       });
     },
-    [mutateActive],
+    [mutateById, activeId],
   );
 
   const send = useCallback(
@@ -290,8 +290,7 @@ export default function ChatPage(): React.ReactElement {
         streaming: true,
       };
 
-      mutateActive((session) => {
-        if (session.id !== targetSessionId) return session;
+      mutateById(targetSessionId, (session) => {
         const isFirst = session.messages.length === 0;
         // Strip pendingUserChoice AND followUpOptions from older assistant
         // messages so the button rows disappear as soon as the user commits
@@ -339,7 +338,7 @@ export default function ChatPage(): React.ReactElement {
       sending,
       hydrating,
       activeId,
-      mutateActive,
+      mutateById,
       streamStore,
       activeSession.messages.length,
       selectedAgentSlug,
@@ -597,8 +596,7 @@ export default function ChatPage(): React.ReactElement {
               streamStore.patch(activeId, { agentUnavailableSlug: undefined });
               // Drop the pinned snapshot in the local session so the
               // header picker becomes available again for the next turn.
-              mutateActive((s) => {
-                if (s.id !== activeId) return s;
+              mutateById(activeId, (s) => {
                 const { snapshot: _drop, ...rest } = s;
                 return rest;
               });


### PR DESCRIPTION
A chat turn that was still streaming when the user switched to another tab lost its content, because every transcript write went through the active-session helpers and therefore landed in whichever session happened to be in the foreground. The chat-sessions store now exposes `mutateById(sessionId, mutator)` and `persistById(sessionId)`, and `applyStreamEvent`, `finalizePending` and the stream runner's terminal persist all address the session the turn actually belongs to; `mutateActive` / `persistActive` are gone and the previously active-scoped call sites on the chat page pass their id explicitly. `persistById` enqueues instead of reading an effect-synced ref, so the PUT carries state from after the `done` fold committed and a background answer now survives a reload; a session deleted mid-stream is never resurrected, since the queued write is dropped once the id is gone. The change is confined to `web-ui/app/**` plus a `docs/CHANGELOG.md` entry, and it adds regression coverage for the background-session path in `StreamRunner`, `chatStreamEvents` and the persist queue. The Spec, Review and Plan paths listed below are local harness scratch, gitignored, and are not part of this diff.

Spec: specs/ISSUE_617.md
Review: reviews/ISSUE_617.md
Plan: plans/ISSUE_617.md

Tests: green -- in `web-ui/`: `npm run lint` (0 errors), `npm run typecheck`, `npm run test` (584 tests), `npm run i18n:check`.

Two non-blocking follow-ups were noted in review, neither changing behaviour on this branch. The drain-effect comment says the PUT is dropped when a session was "deleted or cleared", but `clearMessages` keeps the session in state, so a cleared session still gets a PUT of its cleared transcript — the code is right, the comment overstates. And `persistById` is deferred by one commit where `persistActive` started its fetch synchronously, so a provider unmount between enqueue and drain would silently drop the remote write; the provider lives in `RootLayout`, so that window is sub-millisecond.

Closes #617

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788596592&installation_model_id=428086&pr_number=620&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F620&signature=4423039882d324a467bf8b3207484036887c31a1219d7bc177c767fa27118fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->