### PR TITLE
fix(web-ui): override js-yaml to ^4.3.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -7075,9 +7075,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -74,6 +74,7 @@
     "sharp": "0.35.3",
     "brace-expansion": "5.0.9",
     "minimatch": "10.2.5",
-    "dompurify": "3.4.12"
+    "dompurify": "3.4.12",
+    "js-yaml": "^4.3.1"
   }
 }


### PR DESCRIPTION
## What

Pins `js-yaml` to `^4.3.1` through web-ui's existing `overrides` block, clearing the high-severity advisory [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj).

## Why

The advisory (quadratic CPU consumption in `!!omap` resolution; the CVE-2026-59870 fix was not backported) covers `4.0.0 - 4.3.0`. web-ui resolves `js-yaml@4.3.0` transitively:

```
eslint@9.39.5 -> @eslint/eslintrc@3.3.6 -> js-yaml@4.3.0
```

That trips the `audit (high+critical block) (web-ui)` job. The advisory published after main's last CI run (2026-08-06 09:07 UTC), so main is green only because it has not re-run — **every open PR fails this job until it lands.** It is not specific to any one branch.

`4.3.1` is a patch inside the 4.x line, so eslint itself is untouched. The `overrides` mechanism is the one already used here for `brace-expansion`, `minimatch` and `dompurify`.

middleware has no `js-yaml` in its tree at all (`npm ls js-yaml` → empty) and needs no change — its audit job already passes.

Dev-only dependency: eslint never reaches the shipped bundle. The gate is still repo-wide, which is what makes this blocking.

## Test plan

- [x] `npm audit --audit-level=high` → **found 0 vulnerabilities** (was: 1 high)
- [x] `npm ls js-yaml` → `js-yaml@4.3.1 overridden`
- [x] `npm run lint` → 0 errors (38 pre-existing warnings) — confirms eslint still loads with the patched js-yaml
- [x] `npm run typecheck` → clean
- [x] `npm run i18n:check` → OK
- [x] `npx vitest run` → 584/584 across 71 files

## Risk / blast radius

- Lockfile-only change plus one `overrides` line: 5 insertions, 4 deletions.
- No production code, no runtime dependency, no shipped-bundle change.
- Worst case is an eslint plugin that depended on 4.3.0-specific behaviour; `npm run lint` passing rules that out.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788673857&installation_model_id=428086&pr_number=623&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F623&signature=579460f187d2f6d81dec92ca252ecf02829a4b1aba780743f0e8c18c1cc385e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->