### PR TITLE
feat(privacy): account MCP structured output in the turn receipt (#569)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,38 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — MCP structured output is accounted in the privacy receipt (#547 / #569)
+
+- External MCP tools that return `structuredContent` now surface in the turn's
+  Privacy Shield receipt, as a neutral "structured output received" section
+  (tool name, server name, byte count, and whether the tool declared an
+  `outputSchema`). This closes the #569 gap: the structured-content sidecar
+  fires inside `McpManager.callTool`, beneath every dispatcher, so structured
+  content previously appeared in **no** receipt or dataset accounting at all —
+  an operator auditing what a turn touched could not see it. Scope note: like
+  every receipt line, this appears only when a `privacy.redact@1` provider is
+  active; with no Privacy Shield installed there is no receipt and the sink
+  no-ops (it produces no receipt entry and nothing observable — the one change
+  in that case is that the previously-inert structured sidecar now has a wired
+  consumer at all).
+- **Accounting, not masking.** Privacy Shield's data-plane boundary is server ↔
+  LLM provider, not server ↔ browser. The structured payload is emitted
+  out-of-band and never crosses the model wire (the model still sees only the
+  interned digest of the tool's text result), so nothing is masked — the browser
+  is the trusted side. The receipt entry is PII-free by construction: counts and
+  names only, never the structured value. A regression test pins that the
+  accounting metadata carries none of the raw values the sidecar legitimately
+  still holds, over a real MCP socket.
+- New optional `PrivacyGuardService.recordStructuredPayload` on the published
+  `@omadia/plugin-api` surface, mirroring `recordBypassedTool`; the boot-wired
+  `McpManager.structuredSink` is its first consumer. Fail-closed: an accounting
+  failure never breaks a tool call, and a payload with no turn identity is
+  skipped rather than mis-filed.
+- Deliberately **not** included: a renderer that draws a canvas card from the
+  structured payload. That is #547's remaining half, unblocked by this
+  accounting decision — the decision #569 asked for *before* anything renders
+  from the sidecar.
+
 ### Fixed — a mistyped id no longer produces a dead-but-configured-looking public MCP binding
 
 - `public_mcp_key_bindings.key_id` and `agent_id` are not foreign keys — the key

--- a/middleware/packages/harness-orchestrator/src/mcp/mcpClient.ts
+++ b/middleware/packages/harness-orchestrator/src/mcp/mcpClient.ts
@@ -308,6 +308,11 @@ export interface McpSidecarIdentity {
 /** An MCP tool returned a `structuredContent` payload alongside its text. */
 export interface McpStructuredOutputSidecar extends McpSidecarIdentity {
   readonly kind: 'structured_output';
+  /** The operator-configured server display name (`cfg.name`), so a consumer
+   *  (e.g. #569 receipt accounting) can attribute the payload to a readable
+   *  source rather than the opaque `serverId` UUID. Mirrors why the
+   *  `input_required` sidecar carries `pending.serverName`. */
+  readonly serverName: string;
   /** The parsed payload exactly as the server sent it — object, or an array for
    *  off-spec hosted servers. Never a re-parse of the rendered string. */
   readonly structured: unknown;
@@ -577,6 +582,7 @@ export class McpManager {
       this.options.structuredSink({
         kind: 'structured_output',
         serverId: cfg.id,
+        serverName: cfg.name,
         toolName,
         turnId: ctx !== undefined && ctx.turnId !== '' ? ctx.turnId : null,
         structured,

--- a/middleware/packages/harness-plugin-privacy-guard/src/service.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/service.ts
@@ -18,6 +18,8 @@
 import type {
   BypassedToolEntry,
   PrivacyBypassedToolRequest,
+  PrivacyStructuredPayloadRequest,
+  StructuredPayloadEntry,
   PrivacyGuardService,
   PrivacyPromptMaskRequest,
   PrivacyPromptMaskResult,
@@ -192,6 +194,13 @@ export function createPrivacyGuardService(deps?: {
   // plugin). Drained into the receipt by `finalizeTurn`. Entries carry
   // only tool/plugin names + a byte count (no values).
   const bypassedTools = new Map<string, BypassedToolEntry[]>();
+  // #547 / #569 — per-turn list of external MCP tools that returned
+  // `structuredContent`. Recorded by the boot-wired `structuredSink` so the
+  // receipt accounts for the sidecar that otherwise fires beneath every
+  // dispatcher. Drained into the receipt by `finalizeTurn`. Accounting only —
+  // the payload never crossed the model boundary, so nothing here is masked;
+  // entries carry tool/server names + a byte count + a schema flag, no value.
+  const structuredPayloads = new Map<string, StructuredPayloadEntry[]>();
   // #361 — per-turn prompt-surrogate map (real↔surrogate), server-side
   // only. Extended across repeated mask calls within one turn (message +
   // ingested attachment tail) so surrogates stay stable; inverted over the
@@ -326,6 +335,28 @@ export function createPrivacyGuardService(deps?: {
         `[privacy-guard v4] bypass turn=${request.turnId} ` +
           `tool=${request.toolName} plugin=${request.pluginId} ` +
           `bytes=${String(request.bytes)} reason=${request.reason}`,
+      );
+    },
+
+    async recordStructuredPayload(
+      request: PrivacyStructuredPayloadRequest,
+    ): Promise<void> {
+      let list = structuredPayloads.get(request.turnId);
+      if (list === undefined) {
+        list = [];
+        structuredPayloads.set(request.turnId, list);
+      }
+      list.push({
+        toolName: request.toolName,
+        serverName: request.serverName,
+        bytes: request.bytes,
+        hasOutputSchema: request.hasOutputSchema,
+      });
+      console.log(
+        `[privacy-guard v4] structured turn=${request.turnId} ` +
+          `tool=${request.toolName} server=${request.serverName} ` +
+          `bytes=${String(request.bytes)} ` +
+          `outputSchema=${String(request.hasOutputSchema)}`,
       );
     },
 
@@ -575,14 +606,18 @@ export function createPrivacyGuardService(deps?: {
       turnPiiValues.delete(turnId);
       const bypassed = bypassedTools.get(turnId);
       bypassedTools.delete(turnId);
+      const structured = structuredPayloads.get(turnId);
+      structuredPayloads.delete(turnId);
       // No receipt for a turn that touched neither the boundary, a bypass,
-      // nor prompt masking — there is nothing to report and a zero receipt
-      // is just noise in the channel UI.
+      // structured output, nor prompt masking — there is nothing to report and
+      // a zero receipt is just noise in the channel UI.
       const hasInterned = accum !== undefined && accum.datasetsInterned > 0;
       const hasBypassed = bypassed !== undefined && bypassed.length > 0;
+      const hasStructured = structured !== undefined && structured.length > 0;
       const hasMaskedPrompt =
         accum !== undefined && accum.maskedPromptSpans.length > 0;
-      if (!hasInterned && !hasBypassed && !hasMaskedPrompt) return undefined;
+      if (!hasInterned && !hasBypassed && !hasStructured && !hasMaskedPrompt)
+        return undefined;
       // identityValuesOnWire — personal-identity values the requester named
       // in their own message text. A transparency notice (the user put a
       // real identity on the wire), NOT a leak of tool data.
@@ -599,6 +634,7 @@ export function createPrivacyGuardService(deps?: {
           `cleartext=${String(accum?.fieldsCleartext ?? 0)} ` +
           `verbs=[${(accum?.verbsExecuted ?? []).join(',')}] ` +
           `bypassed=${String(bypassed?.length ?? 0)} ` +
+          `structured=${String(structured?.length ?? 0)} ` +
           `identityOnWire=${String(identityValuesOnWire)}`,
       );
       return {
@@ -609,6 +645,7 @@ export function createPrivacyGuardService(deps?: {
         pseudonymProjectionUsed: accum?.pseudonymProjectionUsed ?? false,
         identityValuesOnWire,
         ...(hasBypassed ? { bypassedTools: [...bypassed] } : {}),
+        ...(hasStructured ? { structuredPayloads: [...structured] } : {}),
         ...(hasMaskedPrompt
           ? { maskedPromptSpans: [...accum.maskedPromptSpans] }
           : {}),

--- a/middleware/packages/plugin-api/src/privacyReceipt.ts
+++ b/middleware/packages/plugin-api/src/privacyReceipt.ts
@@ -43,6 +43,45 @@ export interface BypassedToolEntry {
 }
 
 /**
+ * #547 / #569 — one external MCP tool that returned `structuredContent` this
+ * turn, recorded so the turn's privacy receipt accounts for it.
+ *
+ * WHY THIS IS ACCOUNTING, NOT MASKING. Privacy Shield v4's data-plane boundary
+ * is server ↔ LLM PROVIDER, not server ↔ browser. The structured payload is
+ * emitted out-of-band from `McpManager.callTool` (the `structuredSink`) and
+ * never crosses the model wire — the model still sees only the interned digest
+ * of the tool's TEXT result. So no masking is owed on this path; the browser is
+ * the trusted side and legitimately receives real values. What WAS missing
+ * (#569) is that the sidecar fires beneath every dispatcher, so structured
+ * content never appeared in the receipt or dataset accounting at all. This
+ * entry closes that: an operator auditing what a turn touched now sees the
+ * structured payload the same way they see an interned dataset or a bypass.
+ *
+ * MUST stay PII-free — tool name + server name + a byte count + a schema flag
+ * only, never the structured value itself (that is exactly what does NOT need
+ * masking, but also must not be copied into a receipt that is PII-free by
+ * construction).
+ */
+export interface StructuredPayloadEntry {
+  /** The tool name as it appears in the LLM's `tool_use` block, e.g.
+   *  `crm_lookup_customer`. */
+  readonly toolName: string;
+  /** The operator-configured display name of the external MCP server the tool
+   *  belongs to (`cfg.name`, e.g. `Kunden-CRM`) — the MCP analogue of
+   *  `BypassedToolEntry.pluginId`, and readable in the receipt rather than the
+   *  opaque server UUID. The stable id already lives in `mcp_call_log`. */
+  readonly serverName: string;
+  /** Byte length of the `JSON.stringify`d structured payload. For UI
+   *  transparency only — never the payload itself. */
+  readonly bytes: number;
+  /** Whether tool discovery captured an `outputSchema` for this tool, i.e.
+   *  whether a deterministic renderer could bind the payload without an LLM
+   *  round-trip. Surfaced so the receipt distinguishes schema-backed
+   *  structured output from schema-less. */
+  readonly hasOutputSchema: boolean;
+}
+
+/**
  * The per-turn user-facing privacy report. Emitted by `finalizeTurn` and
  * attached to the assistant message metadata; channel renderers (Teams
  * card, Web disclosure) consume it to build their collapsible UI.
@@ -87,6 +126,15 @@ export interface PrivacyReceipt {
    * carry the span TYPE + detector id only, never the value.
    */
   readonly maskedPromptSpans?: readonly PromptMaskedSpanInfo[];
+  /**
+   * #547 / #569 — external MCP tools that returned `structuredContent` this
+   * turn. Absent / empty when no connected tool emitted structured output.
+   * NOT a masking record — the payload never crossed the model boundary (see
+   * {@link StructuredPayloadEntry}); this is the dataset-accounting entry that
+   * was missing while the sidecar fired beneath every dispatcher. PII-free:
+   * tool name + server name + byte count + schema flag only.
+   */
+  readonly structuredPayloads?: readonly StructuredPayloadEntry[];
 }
 
 // ---------------------------------------------------------------------------
@@ -186,6 +234,25 @@ export interface PrivacyBypassedToolRequest {
   readonly pluginId: string;
   readonly reason: 'operator_setting';
   readonly bytes: number;
+}
+
+/**
+ * #547 / #569 — record that an external MCP tool returned `structuredContent`
+ * this turn. Called from the boot-wired `McpManager.structuredSink`, which is
+ * the sidecar's first (accounting) consumer — above the manager, so it holds
+ * the turn id the payload carries, but still below no masking obligation (the
+ * payload never reaches the model). The entry lands verbatim in the per-turn
+ * receipt; one call per structured tool result. PII-free by contract.
+ */
+export interface PrivacyStructuredPayloadRequest {
+  readonly turnId: string;
+  readonly toolName: string;
+  /** Operator-configured server display name (`cfg.name`), readable in the
+   *  receipt — not the opaque server UUID. */
+  readonly serverName: string;
+  /** Byte length of the `JSON.stringify`d payload — never the payload. */
+  readonly bytes: number;
+  readonly hasOutputSchema: boolean;
 }
 
 /**
@@ -294,6 +361,22 @@ export interface PrivacyGuardService {
    * may call this for every bypassed dispatch and every entry is kept.
    */
   recordBypassedTool(request: PrivacyBypassedToolRequest): Promise<void>;
+  /**
+   * #547 / #569 — record that an external MCP tool returned `structuredContent`
+   * this turn so the receipt accounts for it. Accounting only: the payload is
+   * emitted out-of-band and never crosses the LLM wire, so nothing is masked —
+   * this closes the gap where the sidecar fired beneath every dispatcher and so
+   * appeared in no receipt. The entry is PII-free (tool + server + byte count +
+   * schema flag). Idempotent within a turn: every structured tool result may
+   * call this and every entry is kept.
+   *
+   * Optional on the interface so alternative privacy providers (and test stubs)
+   * need not implement it; the boot-wired sink feature-detects and no-ops when
+   * absent (byte-identical to before).
+   */
+  recordStructuredPayload?(
+    request: PrivacyStructuredPayloadRequest,
+  ): Promise<void>;
   /**
    * Privacy Shield v4 — run a v4 verb tool or the terminal render tool the
    * LLM called. Returns the text to place in the `tool_result` block. A

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -293,7 +293,13 @@ import { NativeToolRegistry } from '@omadia/orchestrator';
 import { assertTimeoutHierarchy } from '@omadia/orchestrator';
 // W2-2 (issue #543) — generic long-running task seam.
 import { InMemoryTaskStore, startTaskReaper } from '@omadia/orchestrator';
-import { McpManager, type McpCallLogEntry, type McpServerConfig } from '@omadia/orchestrator';
+import {
+  McpManager,
+  type McpCallLogEntry,
+  type McpServerConfig,
+  type McpSidecarPayload,
+  type McpStructuredSink,
+} from '@omadia/orchestrator';
 // W2-1 (#544) — MRTR mid-call user input: the process-shared park store and the
 // replayer registration. See `mcp/pendingMcpInput.ts` for why these are shared.
 import {
@@ -1884,9 +1890,69 @@ async function main(): Promise<void> {
       // mcp_call_log, fire-and-forget so the tool-call path never blocks on
       // the database. Identity comes from turnContext inside the manager.
       const mcpAuditStore = graphPool ? new AgentGraphStore(graphPool) : undefined;
+      // #547 / #569 — the structured-output sidecar's first consumer: privacy
+      // ACCOUNTING, not rendering. The payload is emitted out-of-band from
+      // `McpManager.callTool` and never reaches the model wire (the model sees
+      // only the interned digest of the TEXT result), so nothing here is
+      // masked — but the sidecar fired beneath every dispatcher, so structured
+      // content appeared in no turn receipt at all. This records a PII-free
+      // entry (tool + server + byte count + schema flag) into the turn's
+      // privacy receipt so an operator audit accounts for it. Deliberately does
+      // NOT forward the payload anywhere a renderer could consume it — that is
+      // #547's remaining half, unblocked by this accounting decision but out of
+      // scope here. Fail-closed: an accounting failure must never break a tool
+      // call, and a payload with no turn identity is skipped (there is no
+      // receipt to attribute it to) rather than mis-filed.
+      const mcpStructuredSink: McpStructuredSink = (payload: McpSidecarPayload) => {
+        if (payload.kind !== 'structured_output') return;
+        if (payload.turnId === null) {
+          console.warn(
+            `[middleware] structured sidecar for '${payload.toolName}' has no turnId — not accounted`,
+          );
+          return;
+        }
+        const privacy = serviceRegistry.get<PrivacyGuardService>(
+          PRIVACY_REDACT_SERVICE_NAME,
+        );
+        // Feature-detected: a privacy provider that predates #569 (or none
+        // installed at all) makes the sink a no-op — no receipt entry, no side
+        // effect. (Not byte-identical at the manager: wiring this sink means
+        // `emitStructured` now runs its body per structured result where before
+        // it early-returned on the absent sink. The work is a turnContext read
+        // and a Map lookup, and produces nothing observable without a provider.)
+        if (privacy?.recordStructuredPayload === undefined) return;
+        // Fail closed on our OWN terms, not on the manager's `emitStructured`
+        // try/catch: `structuredContent` is a post-`JSON.parse` value so
+        // re-serialising it cannot realistically throw, but a byte count that
+        // could take down accounting is not worth trusting a caller's guard
+        // for. An unmeasurable payload is still worth accounting — record it
+        // with `bytes: 0` rather than dropping the entry.
+        let bytes = 0;
+        try {
+          bytes = Buffer.byteLength(JSON.stringify(payload.structured), 'utf8');
+        } catch {
+          /* leave bytes at 0 — the entry still records that structured output
+             was received, which is the load-bearing accounting fact */
+        }
+        void privacy
+          .recordStructuredPayload({
+            turnId: payload.turnId,
+            toolName: payload.toolName,
+            serverName: payload.serverName,
+            bytes,
+            hasOutputSchema: payload.outputSchema !== undefined,
+          })
+          .catch((err: unknown) => {
+            console.warn(
+              `[middleware] structured sidecar accounting failed for '${payload.toolName}': ${String(err)}`,
+            );
+          });
+      };
       // Generic MCP OAuth (epic #459 W9) wired as the manager's auth provider;
       // the service instance is created at outer scope (shared with the router).
       const mcpManager = new McpManager({
+        // #547 / #569 — see `mcpStructuredSink` above (accounting only).
+        structuredSink: mcpStructuredSink,
         // W2-1 (#544) — where a `resultType: "input_required"` call is parked.
         // The process-shared instance, so the Orchestrator's turn drain reads
         // exactly what this manager wrote.

--- a/middleware/test/mcpStructuredContent.test.ts
+++ b/middleware/test/mcpStructuredContent.test.ts
@@ -343,6 +343,9 @@ describe('structured-content sidecar over a real MCP connection (#547 W1-3)', ()
     const payload = seen[0]!;
     assert.equal(payload.kind, 'structured_output');
     assert.equal(payload.serverId, FAKE_CFG.id);
+    // #569 — the readable server name rides the sidecar so the receipt can
+    // attribute the payload without the opaque UUID.
+    assert.equal(payload.serverName, FAKE_CFG.name);
     assert.equal(payload.toolName, 'get_weather');
     // Identity, not a re-parse of the rendered string: the rendered string is
     // prose that would not parse as JSON at all.

--- a/middleware/test/mcpStructuredOutputPrivacy.test.ts
+++ b/middleware/test/mcpStructuredOutputPrivacy.test.ts
@@ -9,6 +9,18 @@
  * a regression guard — if someone later makes the sidecar mask, the sidecar
  * test below turns red and this file must be revisited on purpose.
  *
+ * REVISITED ON PURPOSE (#569). The sink now HAS a first consumer, and it is
+ * accounting — NOT rendering. `index.ts` wires `structuredSink` to
+ * `PrivacyGuardService.recordStructuredPayload`, which records a PII-free entry
+ * (tool + server + byte count + schema flag) into the turn's privacy receipt.
+ * That closes #569: the sidecar fired beneath every dispatcher, so structured
+ * content appeared in no receipt at all even though masking was never owed on
+ * this path. The final describe block below pins that the accounting seam is
+ * PII-free by construction — the recorded metadata carries none of the raw
+ * values the sidecar payload legitimately still holds. The renderer (the `done`
+ * stream event + UI card) remains deliberately unbuilt: this commit is the
+ * accounting decision #569 asked for BEFORE anything renders.
+ *
  * WHICH BOUNDARY THIS IS ABOUT — read this before calling anything a leak.
  * Privacy Shield v4's data-plane boundary is server <-> LLM PROVIDER, not
  * server <-> browser. The browser sits on the TRUSTED side and legitimately
@@ -43,15 +55,18 @@
  * interning contract asserted here is the same one the chat path uses and is
  * documented as parity in `toolDispatchPrivacySeam.test.ts`.
  *
- * There is also no way to close that asymmetry inside W5-2's scope. The whole privacy
- * contract (`PrivacyTurnHandle`) is string-in/string-out:
- * `internToolResultV4({rawResult: string}) -> {digestText: string}`. Feeding a
- * structured payload through it returns a digest STRING — the structure the
- * card exists to render is destroyed, leaving something strictly worse than
- * the `ToolRow` that already shows that digest. Masking structure while
- * preserving it needs a NEW method on the published `@omadia/plugin-api`
- * surface plus a privacy-guard implementation and boot wiring. That is an
- * issue, not a commit.
+ * That asymmetry is NOT closed by masking, and #569 corrected the earlier
+ * reading that it needed to be. The whole privacy contract (`PrivacyTurnHandle`)
+ * is string-in/string-out: `internToolResultV4({rawResult: string}) ->
+ * {digestText: string}`. Feeding a structured payload through it returns a
+ * digest STRING — the structure the card exists to render is destroyed. But
+ * masking is not owed here at all: the boundary is server <-> LLM provider, and
+ * the payload never crosses it. What WAS owed, and was missing, is accounting —
+ * an operator auditing the turn could not see the structured payload. That is
+ * the NEW method on the published `@omadia/plugin-api` surface this file's
+ * header now points at (`recordStructuredPayload`), with a privacy-guard
+ * implementation and boot wiring — shipped, PII-free, and pinned below. The
+ * renderer that consumes the accounted payload is the remaining, separate half.
  *
  * MUTATION-CHECK DISCIPLINE (same as `toolDispatchPrivacySeam.test.ts`): every
  * assertion inspects CONTENT that crosses a boundary. None asserts "a masking
@@ -68,7 +83,7 @@ import {
   type Server as HttpServer,
   type ServerResponse,
 } from 'node:http';
-import type { AddressInfo } from 'node:net';
+import type { AddressInfo, Socket } from 'node:net';
 
 import { Server as McpSdkServer } from '@modelcontextprotocol/sdk/server/index.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -226,7 +241,7 @@ async function startFakeMcpServer(): Promise<FakeServerHandle> {
       res.end();
     });
   });
-  const sockets = new Set<import('node:net').Socket>();
+  const sockets = new Set<Socket>();
   http.on('connection', (socket) => {
     sockets.add(socket);
     socket.on('close', () => sockets.delete(socket));
@@ -375,10 +390,12 @@ describe('#547 structured-output sidecar vs. the privacy boundary (W5-2)', () =>
     );
   });
 
-  it('carries the declared `outputSchema`, so a generic renderer is buildable once masking exists', async () => {
-    // Not an exposure assertion — it records that the ONLY blocker is masking. The
-    // renderer contract the brief specifies (render from `outputSchema`, never
-    // by tool name) is already satisfiable end-to-end over a real wire.
+  it('carries the declared `outputSchema`, so a generic renderer is buildable on top of the accounted payload', async () => {
+    // Not an exposure assertion. #569 corrected the earlier reading that masking
+    // was the blocker — it is not owed here (see the header). What was owed,
+    // accounting, ships in this commit; the renderer contract the brief
+    // specifies (render from `outputSchema`, never by tool name) is already
+    // satisfiable end-to-end over a real wire, and is the remaining half.
     const h = harness();
     await h.manager.listTools(CFG); // discovery caches the schema
 
@@ -423,5 +440,127 @@ describe('#547 structured-output sidecar vs. the privacy boundary (W5-2)', () =>
 
     assert.equal(result.content, 'just text');
     assert.deepEqual(structuredSidecars(sidecars), []);
+  });
+});
+
+// ── #569 accounting: the sink's first consumer records PII-free metadata ─────
+
+/**
+ * A minimal recorder that reproduces the boot sink's contract
+ * (`index.ts` -> `PrivacyGuardService.recordStructuredPayload`) so the seam can
+ * be exercised over the same real socket the block above uses. The point is not
+ * the recorder — it is that the ACCOUNTING PAYLOAD the seam produces carries
+ * only metadata, never the raw values the sidecar legitimately still holds.
+ */
+interface AccountedStructured {
+  readonly turnId: string;
+  readonly toolName: string;
+  readonly serverName: string;
+  readonly bytes: number;
+  readonly hasOutputSchema: boolean;
+}
+
+/** Reproduces the boot sink's field mapping (`index.ts`) on the happy path:
+ *  discriminate on `kind`, skip a null `turnId`, and derive `bytes` +
+ *  `hasOutputSchema`. The production sink additionally fails `bytes` closed to 0
+ *  on an unserialisable payload — not reproduced here because these fixtures are
+ *  always serialisable, and the assertions below are about the field mapping,
+ *  not that guard. */
+function accountingSink(sink: AccountedStructured[]): (p: McpSidecarPayload) => void {
+  return (payload) => {
+    if (payload.kind !== 'structured_output') return;
+    if (payload.turnId === null) return; // no receipt to attribute to
+    sink.push({
+      turnId: payload.turnId,
+      toolName: payload.toolName,
+      serverName: payload.serverName,
+      bytes: Buffer.byteLength(JSON.stringify(payload.structured), 'utf8'),
+      hasOutputSchema: payload.outputSchema !== undefined,
+    });
+  };
+}
+
+describe('#569 structured-output accounting seam (PII-free by construction)', () => {
+  it('records tool + server + byte count + schema flag, and NONE of the raw values', async () => {
+    const accounted: AccountedStructured[] = [];
+    const rawSidecars: McpSidecarPayload[] = [];
+    const manager = new McpManager({
+      structuredSink: (p) => {
+        rawSidecars.push(p);
+        accountingSink(accounted)(p);
+      },
+    });
+    managers.push(manager);
+    await manager.listTools(CFG); // discovery caches the outputSchema
+
+    const nativeTools = new NativeToolRegistry();
+    nativeTools.register(TOOL, {
+      handler: mcpNativeHandler(manager, CFG, TOOL),
+      spec: {
+        name: TOOL,
+        description: 'look up a customer record',
+        input_schema: { type: 'object', properties: {} },
+      },
+      domain: 'mcp.kunden-crm',
+    });
+    const service = new ToolDispatchService({
+      nativeTools,
+      domainTools: [],
+      privacy: () => redactingPrivacyHandle(),
+    });
+
+    await turnContext.run(
+      { turnId: 't-569', turnDate: '2026-07-31', agentSlug: 'main', userId: 'u1' } as never,
+      () => service.dispatch(TOOL, {}),
+    );
+
+    assert.equal(accounted.length, 1, 'one structured tool result -> one accounting entry');
+    const entry = accounted[0]!;
+    assert.equal(entry.turnId, 't-569');
+    assert.equal(entry.toolName, TOOL);
+    assert.equal(entry.serverName, CFG.name);
+    assert.equal(entry.hasOutputSchema, true, 'discovery captured the outputSchema');
+    assert.equal(
+      entry.bytes,
+      Buffer.byteLength(JSON.stringify(STRUCTURED_PAYLOAD), 'utf8'),
+      'byte count is the payload size, computed at the seam',
+    );
+
+    // The load-bearing privacy assertion: the raw sidecar still carries the PII
+    // (the browser is the trusted side), but the ACCOUNTING entry the receipt
+    // will hold carries none of it. Serialize the whole entry and prove it.
+    const rawStructured = structuredSidecars(rawSidecars)[0]!;
+    assert.equal(
+      (rawStructured.structured as Record<string, unknown>)['email'],
+      EMAIL,
+      'precondition: the sidecar payload itself is unmasked',
+    );
+    const accountedJson = JSON.stringify(entry);
+    assert.equal(accountedJson.includes(EMAIL), false, 'the email never reaches the receipt entry');
+    assert.equal(accountedJson.includes(IBAN), false, 'the IBAN never reaches the receipt entry');
+    assert.equal(accountedJson.includes(PERSON), false, 'the name never reaches the receipt entry');
+  });
+
+  it('accounts nothing for a payload with no turn identity (nothing to attribute to)', async () => {
+    const accounted: AccountedStructured[] = [];
+    const manager = new McpManager({ structuredSink: accountingSink(accounted) });
+    managers.push(manager);
+
+    const nativeTools = new NativeToolRegistry();
+    nativeTools.register(TOOL, {
+      handler: mcpNativeHandler(manager, CFG, TOOL),
+      spec: {
+        name: TOOL,
+        description: 'look up a customer record',
+        input_schema: { type: 'object', properties: {} },
+      },
+      domain: 'mcp.kunden-crm',
+    });
+    const service = new ToolDispatchService({ nativeTools, domainTools: [] });
+
+    // No turnContext.run wrapper -> the sidecar's turnId is null.
+    await service.dispatch(TOOL, {});
+
+    assert.deepEqual(accounted, [], 'a turnId-less payload is skipped, not mis-filed');
   });
 });

--- a/middleware/test/privacyV4Bypass.test.ts
+++ b/middleware/test/privacyV4Bypass.test.ts
@@ -19,7 +19,11 @@ import {
   parseScopes,
   resolveEffectivePrivacyMode,
 } from '@omadia/plugin-api';
-import { createPrivacyGuardService } from '@omadia/plugin-privacy-guard/dist/index.js';
+// Imported from SOURCE, not the `dist/` barrel: a mutation applied to
+// `service.ts` src is then visible without a rebuild, so a mutation check
+// cannot report GREEN over stale compiled code (same discipline as
+// `mcpStructuredOutputPrivacy.test.ts`).
+import { createPrivacyGuardService } from '../packages/harness-plugin-privacy-guard/src/index.js';
 
 describe('resolveEffectivePrivacyMode', () => {
   it('defaults to guarded when no mode is stored', () => {
@@ -259,5 +263,122 @@ describe('PrivacyGuardService.recordBypassedTool', () => {
     const svc = createPrivacyGuardService();
     const receipt = await svc.finalizeTurn('t-empty');
     assert.equal(receipt, undefined);
+  });
+});
+
+/**
+ * #547 / #569 — structured-output accounting. The MCP structured-content
+ * sidecar fires beneath every dispatcher, so before this it appeared in NO
+ * receipt. `recordStructuredPayload` closes that gap. Accounting only: nothing
+ * here is masked (the payload never crosses the model wire — the browser is the
+ * trusted side), so the assertions pin that the metadata is recorded and stays
+ * PII-free, NOT that anything is redacted.
+ */
+describe('PrivacyGuardService.recordStructuredPayload', () => {
+  it('accumulates entries and emits them on finalizeTurn (structured-only turn)', async () => {
+    const svc = createPrivacyGuardService();
+    assert.ok(
+      svc.recordStructuredPayload,
+      'the shipped provider must implement the #569 accounting method',
+    );
+    const turnId = 't-structured-1';
+    await svc.recordStructuredPayload({
+      turnId,
+      toolName: 'crm_lookup_customer',
+      serverName: 'Kunden-CRM',
+      bytes: 128,
+      hasOutputSchema: true,
+    });
+    await svc.recordStructuredPayload({
+      turnId,
+      toolName: 'weather_now',
+      serverName: 'Wetterdienst',
+      bytes: 64,
+      hasOutputSchema: false,
+    });
+    const receipt = await svc.finalizeTurn(turnId);
+    assert.ok(receipt, 'structured-only turn must still emit a receipt');
+    // Byte-identical to the masking counters staying at zero — accounting is
+    // orthogonal to interning.
+    assert.equal(receipt.datasetsInterned, 0);
+    assert.equal(receipt.fieldsMasked, 0);
+    assert.equal(receipt.fieldsCleartext, 0);
+    assert.ok(receipt.structuredPayloads);
+    assert.equal(receipt.structuredPayloads.length, 2);
+    // Order-preserving, content-checked (a call-count assertion would survive a
+    // method that dropped every entry).
+    assert.equal(receipt.structuredPayloads[0]?.toolName, 'crm_lookup_customer');
+    assert.equal(receipt.structuredPayloads[0]?.serverName, 'Kunden-CRM');
+    assert.equal(receipt.structuredPayloads[0]?.bytes, 128);
+    assert.equal(receipt.structuredPayloads[0]?.hasOutputSchema, true);
+    assert.equal(receipt.structuredPayloads[1]?.hasOutputSchema, false);
+  });
+
+  it('keeps every entry PII-free: metadata keys only, never a value', async () => {
+    const svc = createPrivacyGuardService();
+    const turnId = 't-structured-pii';
+    await svc.recordStructuredPayload?.({
+      turnId,
+      toolName: 'crm_lookup_customer',
+      serverName: 'Kunden-CRM',
+      bytes: 256,
+      hasOutputSchema: true,
+    });
+    const receipt = await svc.finalizeTurn(turnId);
+    const entry = receipt?.structuredPayloads?.[0];
+    assert.ok(entry);
+    // The entry may carry EXACTLY these four metadata fields. A future edit
+    // that threads the structured payload itself into the receipt (the exact
+    // regression #569 guards) would add a key and fail here.
+    assert.deepEqual(Object.keys(entry).sort(), [
+      'bytes',
+      'hasOutputSchema',
+      'serverName',
+      'toolName',
+    ]);
+  });
+
+  it('drops structured state on finalizeTurn (no leakage to next turn)', async () => {
+    const svc = createPrivacyGuardService();
+    await svc.recordStructuredPayload?.({
+      turnId: 't-s-a',
+      toolName: 't',
+      serverName: 's',
+      bytes: 1,
+      hasOutputSchema: false,
+    });
+    await svc.finalizeTurn('t-s-a');
+    const receipt2 = await svc.finalizeTurn('t-s-a');
+    assert.equal(receipt2, undefined, 'second finalize of same turn is idempotent');
+  });
+
+  it('co-exists with internToolResultV4 and bypass in one receipt', async () => {
+    const svc = createPrivacyGuardService();
+    const turnId = 't-s-mix';
+    await svc.internToolResultV4({
+      sessionId: 's',
+      turnId,
+      toolName: 'confluence_search',
+      rawResult: JSON.stringify([{ id: 1, title: 'OKR' }]),
+    });
+    await svc.recordBypassedTool({
+      turnId,
+      toolName: 'confluence_get_page',
+      pluginId: '@omadia/integration-confluence',
+      reason: 'operator_setting',
+      bytes: 8192,
+    });
+    await svc.recordStructuredPayload?.({
+      turnId,
+      toolName: 'crm_lookup_customer',
+      serverName: 'Kunden-CRM',
+      bytes: 512,
+      hasOutputSchema: true,
+    });
+    const receipt = await svc.finalizeTurn(turnId);
+    assert.ok(receipt);
+    assert.equal(receipt.datasetsInterned, 1);
+    assert.equal((receipt.bypassedTools ?? []).length, 1);
+    assert.equal((receipt.structuredPayloads ?? []).length, 1);
   });
 });

--- a/web-ui/app/_components/chat/PrivacyReceiptCard.tsx
+++ b/web-ui/app/_components/chat/PrivacyReceiptCard.tsx
@@ -40,6 +40,7 @@ export function PrivacyReceiptCard({
   const verbs = receipt.verbsExecuted;
   const bypassed = receipt.bypassedTools ?? [];
   const promptSpans = receipt.maskedPromptSpans ?? [];
+  const structured = receipt.structuredPayloads ?? [];
 
   // Palette precedence: identity-breach (red) wins over bypass-warning
   // (amber) wins over default (emerald). Breach is a transparency notice
@@ -148,6 +149,41 @@ export function PrivacyReceiptCard({
             </ul>
           </div>
         )}
+        {structured.length > 0 && (
+          <div>
+            <div
+              className={[
+                'text-[10px] font-semibold uppercase tracking-wider',
+                palette.label,
+              ].join(' ')}
+            >
+              {t('factStructured')}
+            </div>
+            <ul className="mt-1 space-y-0.5">
+              {structured.map((entry, i) => (
+                <li
+                  key={`${entry.serverName}-${entry.toolName}-${String(i)}`}
+                  className="font-mono-num flex flex-wrap items-baseline gap-x-2"
+                >
+                  <span className="font-medium">{entry.toolName}</span>
+                  <span className={palette.label}>{entry.serverName}</span>
+                  <span className={['text-[10px]', palette.label].join(' ')}>
+                    {t('structuredBytes', {
+                      kb: (entry.bytes / 1024).toFixed(1),
+                    })}
+                  </span>
+                  {/* Lume §8 — the schema state is carried by a text token, not
+                      colour alone. */}
+                  <span className={['text-[10px]', palette.label].join(' ')}>
+                    {entry.hasOutputSchema
+                      ? t('structuredSchemaYes')
+                      : t('structuredSchemaNo')}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
         <div className={['text-[11px] italic', palette.muted].join(' ')}>
           {t(explainerKey)}
         </div>
@@ -159,6 +195,11 @@ export function PrivacyReceiptCard({
         {hasBypass && (
           <div className={['text-[11px] italic', palette.muted].join(' ')}>
             {t('explainerBypassed')}
+          </div>
+        )}
+        {structured.length > 0 && (
+          <div className={['text-[11px] italic', palette.muted].join(' ')}>
+            {t('explainerStructured')}
           </div>
         )}
       </div>
@@ -231,6 +272,10 @@ export function summarisePrivacyReceipt(r: PrivacyReceipt, t: TFn): string {
   const promptSpans = r.maskedPromptSpans ?? [];
   if (promptSpans.length > 0) {
     parts.push(t('summaryPromptMasked', { count: promptSpans.length }));
+  }
+  const structured = r.structuredPayloads ?? [];
+  if (structured.length > 0) {
+    parts.push(t('summaryStructured', { count: structured.length }));
   }
   const onWire = r.identityValuesOnWire ?? 0;
   if (onWire > 0) {

--- a/web-ui/app/_components/chat/__tests__/PrivacyReceiptCard.test.tsx
+++ b/web-ui/app/_components/chat/__tests__/PrivacyReceiptCard.test.tsx
@@ -53,6 +53,16 @@ const PROMPT_MASKED: PrivacyReceipt = {
   ],
 };
 
+/** #547 / #569 — two external MCP tools returned structuredContent this turn.
+ *  Accounting only: neutral, never changes the palette. */
+const STRUCTURED: PrivacyReceipt = {
+  ...RANKED,
+  structuredPayloads: [
+    { toolName: 'crm_lookup_customer', serverName: 'Kunden-CRM', bytes: 2048, hasOutputSchema: true },
+    { toolName: 'weather_now', serverName: 'Wetterdienst', bytes: 512, hasOutputSchema: false },
+  ],
+};
+
 describe('<PrivacyReceiptCard />', () => {
   it('renders the collapsed summary with dataset + masked-field counts', () => {
     renderWithIntl(<PrivacyReceiptCard receipt={RANKED} />, { locale: 'de' });
@@ -176,6 +186,51 @@ describe('<PrivacyReceiptCard />', () => {
     );
   });
 
+  it('lists structured-output tools with server + schema token (#547/#569)', () => {
+    renderWithIntl(<PrivacyReceiptCard receipt={STRUCTURED} />, { locale: 'de' });
+    expect(screen.getByText('Strukturierte Ausgabe empfangen')).toBeInTheDocument();
+    expect(screen.getByText('crm_lookup_customer')).toBeInTheDocument();
+    expect(screen.getByText('Kunden-CRM')).toBeInTheDocument();
+    // Lume §8 — the schema state is a text token, not colour alone.
+    expect(screen.getByText('Output-Schema')).toBeInTheDocument();
+    expect(screen.getByText('kein Schema')).toBeInTheDocument();
+    // 2048 B -> 2.0 KB.
+    expect(screen.getByText('2.0 KB')).toBeInTheDocument();
+  });
+
+  it('shows the structured summary chunk when payloads exist', () => {
+    renderWithIntl(<PrivacyReceiptCard receipt={STRUCTURED} />, { locale: 'de' });
+    expect(screen.getByText(/Privacy Shield/).textContent).toContain(
+      '2 strukturierte Ergebnisse',
+    );
+  });
+
+  it('stays emerald for structured output — accounting is neutral, not a warning', () => {
+    const { container } = renderWithIntl(
+      <PrivacyReceiptCard receipt={STRUCTURED} />,
+      { locale: 'de' },
+    );
+    const root = container.querySelector('details');
+    expect(root?.className).toMatch(/success/);
+    expect(root?.className).not.toMatch(/danger/);
+    expect(root?.className).not.toMatch(/warning/);
+  });
+
+  it('omits the structured section when no tool returned structured output', () => {
+    renderWithIntl(<PrivacyReceiptCard receipt={RANKED} />, { locale: 'de' });
+    expect(
+      screen.queryByText('Strukturierte Ausgabe empfangen'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('treats an empty structuredPayloads array as absent', () => {
+    const receipt: PrivacyReceipt = { ...RANKED, structuredPayloads: [] };
+    renderWithIntl(<PrivacyReceiptCard receipt={receipt} />, { locale: 'de' });
+    expect(
+      screen.queryByText('Strukturierte Ausgabe empfangen'),
+    ).not.toBeInTheDocument();
+  });
+
   it('never leaks a PII-shaped value — the receipt carries only counts', () => {
     // The v4 receipt is PII-free by construction: counts and verb names
     // only. This pins the contract — if the schema ever regains a value
@@ -233,6 +288,21 @@ describe('summarisePrivacyReceipt()', () => {
     expect(
       summarisePrivacyReceipt({ ...RANKED, maskedPromptSpans: [] }, t),
     ).not.toContain('summaryPromptMasked');
+  });
+
+  it('adds the structured clause when payloads exist (#547/#569)', () => {
+    expect(summarisePrivacyReceipt(STRUCTURED, t)).toContain(
+      'summaryStructured:2',
+    );
+  });
+
+  it('omits the structured clause when the field is absent or empty', () => {
+    expect(summarisePrivacyReceipt(RANKED, t)).not.toContain(
+      'summaryStructured',
+    );
+    expect(
+      summarisePrivacyReceipt({ ...RANKED, structuredPayloads: [] }, t),
+    ).not.toContain('summaryStructured');
   });
 });
 

--- a/web-ui/app/_lib/chatSessions.ts
+++ b/web-ui/app/_lib/chatSessions.ts
@@ -230,6 +230,24 @@ export interface PrivacyReceipt {
    * carry the span TYPE + detector id only, never the value.
    */
   maskedPromptSpans?: readonly PromptMaskedSpanInfo[];
+  /**
+   * #547 / #569 — external MCP tools that returned `structuredContent` this
+   * turn. NOT a masking record: the payload is emitted out-of-band and never
+   * crossed the model boundary (the browser is the trusted side), so nothing
+   * was masked. This is the accounting entry — surfaced as a neutral "received
+   * structured output" section so an operator audit sees it. Absent / empty
+   * when no connected tool emitted structured output. PII-free.
+   */
+  structuredPayloads?: readonly StructuredPayloadEntry[];
+}
+
+/** #547 / #569 — one entry in `PrivacyReceipt.structuredPayloads`. Mirrors
+ *  `StructuredPayloadEntry` from `@omadia/plugin-api`. PII-free. */
+export interface StructuredPayloadEntry {
+  toolName: string;
+  serverName: string;
+  bytes: number;
+  hasOutputSchema: boolean;
 }
 
 /** #361 — PII-free record of one prompt span masked before the LLM wire.

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1081,7 +1081,13 @@
     "explainerBypassed": "Der Operator hat für mindestens ein Plugin den Privacy-Mode auf »Bypass« gestellt — dessen Tool-Ergebnisse erreichten das Modell unmaskiert. Eingesetzt für vertrauenswürdige interne Quellen, deren Inhalte der Privacy Shield strukturell nicht sinnvoll digestieren kann.",
     "summaryPromptMasked": "Prompt: {count} maskiert",
     "factPromptMasked": "Maskierte PII in deiner Nachricht",
-    "explainerPromptMasked": "In deiner eigenen Nachricht erkannte Identifikatoren wurden vor dem Modellaufruf durch Pseudonyme ersetzt und in der Antwort wiederhergestellt."
+    "explainerPromptMasked": "In deiner eigenen Nachricht erkannte Identifikatoren wurden vor dem Modellaufruf durch Pseudonyme ersetzt und in der Antwort wiederhergestellt.",
+    "summaryStructured": "{count, plural, one {# strukturiertes Ergebnis} other {# strukturierte Ergebnisse}}",
+    "factStructured": "Strukturierte Ausgabe empfangen",
+    "structuredBytes": "{kb} KB",
+    "structuredSchemaYes": "Output-Schema",
+    "structuredSchemaNo": "kein Schema",
+    "explainerStructured": "Ein verbundenes Tool lieferte strukturierte Daten. Sie erreichten den Browser — die vertrauenswürdige Seite — aber nie das Modell, das nur den internen Digest sah. Hier zur Transparenz aufgeführt; es wurde nichts maskiert, weil auf diesem Pfad nichts zu maskieren war."
   },
   "directLine": {
     "consultedLabel": "🔎 Konsultiert",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1081,7 +1081,13 @@
     "explainerBypassed": "The operator set Privacy Mode to »Bypass« for at least one plugin — its tool results reached the model unmasked. Used for trusted internal sources whose content the Privacy Shield cannot usefully digest structurally.",
     "summaryPromptMasked": "prompt: {count} masked",
     "factPromptMasked": "PII masked in your prompt",
-    "explainerPromptMasked": "Identifiers detected in your own message were replaced with pseudonyms before the model call and restored in the answer."
+    "explainerPromptMasked": "Identifiers detected in your own message were replaced with pseudonyms before the model call and restored in the answer.",
+    "summaryStructured": "{count, plural, one {# structured result} other {# structured results}}",
+    "factStructured": "Structured output received",
+    "structuredBytes": "{kb} KB",
+    "structuredSchemaYes": "output schema",
+    "structuredSchemaNo": "no schema",
+    "explainerStructured": "A connected tool returned structured data. It reached the browser — the trusted side — but never the model, which saw only the interned digest. Listed here for transparency; nothing was masked because none was owed on this path."
   },
   "directLine": {
     "consultedLabel": "🔎 Consulted",


### PR DESCRIPTION
## What

Account MCP `structuredContent` in the Privacy Shield turn receipt.

Closes #569. **Unblocks** #547 (does not close it — see Scope below).

## Why

The structured-content sidecar fires inside `McpManager.callTool`, beneath every
dispatcher, so structured output appeared in **no** turn receipt and no dataset
accounting at all. An operator auditing what a turn touched could not see it.

This wires the sidecar's first consumer as **accounting, not rendering**.
Masking isn't owed — the payload never crosses the model wire (the model still
sees only the interned digest of the tool's *text* result), and Privacy Shield's
data-plane boundary is server ↔ LLM provider, not server ↔ browser. Only the
accounting was missing.

## Scope

Deliberately **not** included: a renderer that draws a canvas card from the
structured payload. That is #547's remaining half, unblocked by this accounting
decision but out of scope here.

## Changes

| Area | Change |
|---|---|
| `plugin-api/privacyReceipt.ts` | New `StructuredPayloadEntry` + optional `PrivacyGuardService.recordStructuredPayload` (additive, feature-detected) |
| `harness-plugin-privacy-guard/service.ts` | Per-turn accumulator, drained by `finalizeTurn` into the receipt |
| `harness-orchestrator/mcp/mcpClient.ts` | `serverName` on the structured sidecar (one producer, internal package) |
| `middleware/src/index.ts` | Boot-wires the prod `structuredSink` — fail-closed, inert without a `privacy.redact@1` provider |
| `web-ui` PrivacyReceiptCard | Neutral "structured output received" section (tool, server, bytes, schema flag) |
| `web-ui/messages/{en,de}.json` | New receipt strings, en/de parity |

## Risk / blast radius

- **Additive on the published contract.** `recordStructuredPayload` is *optional*
  on `PrivacyGuardService`, so third-party privacy providers and test stubs are
  unaffected. `@omadia/plugin-api` gains types only.
- `McpStructuredOutputSidecar.serverName` is required, but the type lives in the
  internal `@omadia/orchestrator` package and has exactly **one** producer in the
  repo, updated here.
- The prod `structuredSink` was previously absent. It is fail-closed: an
  accounting failure never breaks a tool call, a payload with no `turnId` is
  skipped rather than mis-filed, and an unmeasurable payload is recorded with
  `bytes: 0` rather than dropped. Masking/interning path is byte-identical.
- Receipt entries are PII-free by construction: tool name + server name + byte
  count + schema flag, never the structured value. Pinned by a regression test
  over a real MCP socket.
- No schema, migration, or env changes.

## Test plan

- [x] middleware build + `tsc` — clean
- [x] middleware lint — 0 errors
- [x] middleware full suite — 6060/6065 pass (1 known pre-existing order-dependent
      failure in `skillVerdictReadPathRedaction.test.ts`, unrelated; passes in
      isolation and alongside every file this PR touches)
- [x] MCP + privacy suites — 257/257
- [x] web-ui `tsc --noEmit` — clean
- [x] web-ui vitest — 626/626 across 76 files
- [x] web-ui `i18n:check` — OK, 3404 keys, en/de parity

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788677554&installation_model_id=428086&pr_number=624&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F624&signature=25521fe6f1d3cfb94e958e4ab645a2287591869b5606bf23a5706c21e6aef893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
