### PR TITLE
test(middleware): drop hardcoded PG default port (#572)

### DIFF
--- a/middleware/test/README.md
+++ b/middleware/test/README.md
@@ -51,7 +51,7 @@ this change:
 | Var | Suites |
 | --- | --- |
 | `GRAPH_PG_TEST_URL` | graph / store / migration suites |
-| `WS5_PG_TEST_URL` | dev-platform + scratch-promotion suites |
+| `WS5_PG_TEST_URL` | Dev Platform + scratch-promotion suites |
 | `KG_PG_TEST_URL` | KG-walk subgraph suite |
 | `DATABASE_URL` | last-resort fallback where already wired |
 | `MEMORY_PG_TEST_URL` | accepted by all suites |

--- a/middleware/test/README.md
+++ b/middleware/test/README.md
@@ -1,0 +1,59 @@
+# Postgres-gated middleware tests
+
+Some suites here exercise real Postgres (schema, migrations, stores). They are
+**opt-in**: they run only when you point them at a database with an explicit
+env var, and otherwise skip cleanly — with a logged reason — so `npm test`
+stays hermetic and green with no database around.
+
+## Why there is no default port (issue #572)
+
+These suites used to default to a fixed connection string
+(`postgres://test:test@127.0.0.1:55438/test`, and one on `55439`). That is a
+trap: any scratch Postgres an agent or developer starts on that port silently
+answers the suite's `SELECT 1` probe and **hijacks the run**. The resulting
+failure does not look like a port collision — it looks like several unrelated
+tests breaking (e.g. six tests dying on `CREATE EXTENSION vector` because the
+squatting container was plain `postgres`, not `pgvector`).
+
+There is no safe port by convention. So the suites now:
+
+- require an explicit env var (no hardcoded default port), and
+- verify the database is the right *kind* (pgvector suites check the extension
+  is available) before running.
+
+Everything routes through [`_helpers/pgTestDb.ts`](./_helpers/pgTestDb.ts) —
+`probePgTest({ label, vars, requireVector })`.
+
+## Running them locally
+
+Start a Postgres, then export one of the env vars the suite reads and run the
+tests. Suites that need vectors want a **pgvector** image:
+
+```bash
+# pgvector image — required for the KG / embedding suites
+docker run --rm -d -p 5544:5432 \
+  -e POSTGRES_USER=test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=test \
+  pgvector/pgvector:pg16
+
+export MEMORY_PG_TEST_URL='postgres://test:test@127.0.0.1:5544/test'
+npm test
+```
+
+Pick a port you know is free — the suite talks to exactly the URL you give it
+and nothing else.
+
+## Env vars
+
+`MEMORY_PG_TEST_URL` is the shared fallback every suite accepts. Individual
+suites also accept a domain-specific var (checked first), preserved from before
+this change:
+
+| Var | Suites |
+| --- | --- |
+| `GRAPH_PG_TEST_URL` | graph / store / migration suites |
+| `WS5_PG_TEST_URL` | dev-platform + scratch-promotion suites |
+| `KG_PG_TEST_URL` | KG-walk subgraph suite |
+| `DATABASE_URL` | last-resort fallback where already wired |
+| `MEMORY_PG_TEST_URL` | accepted by all suites |
+
+If none is set, the suite skips and logs which vars it looked for.

--- a/middleware/test/_helpers/pgTestDb.ts
+++ b/middleware/test/_helpers/pgTestDb.ts
@@ -1,0 +1,102 @@
+import { Pool } from 'pg';
+
+/**
+ * Resolve a test-Postgres connection string from explicit env vars ONLY —
+ * deliberately WITHOUT a hardcoded default port.
+ *
+ * Issue #572: a fixed default port (55438 / 55439) is a trap. Any scratch
+ * container an agent or developer starts on that port silently answers the
+ * `SELECT 1` probe and hijacks the suite — a failure that looks like several
+ * unrelated tests breaking rather than a port collision. There is no safe
+ * port by convention, so these suites require an explicit env var and skip
+ * cleanly (with a logged reason) when none is set.
+ *
+ * Precedence is first-non-empty-wins over `vars`, so callers keep their
+ * existing suite-specific variable names (e.g. GRAPH_PG_TEST_URL) as the
+ * front of the chain and anyone already exporting one is unaffected.
+ *
+ * @param vars env var names in precedence order
+ * @returns the connection string, or undefined when none is set
+ */
+export function resolvePgTestUrl(...vars: string[]): string | undefined {
+  for (const name of vars) {
+    const value = process.env[name]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+export interface PgProbeResult {
+  /** Resolved connection string, or undefined when no env var was set. */
+  url: string | undefined;
+  /** True only when a suitable Postgres answered the probe. */
+  reachable: boolean;
+}
+
+/**
+ * Resolve + probe the test Postgres and report whether the suite may run.
+ *
+ * Every skip path logs a specific reason so a skipped suite never reads as a
+ * silently-broken one (the core complaint in issue #572). Never probes a
+ * default port: with no env var set it returns `{ reachable: false }` without
+ * opening a connection, so a stray container cannot be picked up.
+ *
+ * With `requireVector`, it also ensures the `vector` (pgvector) extension via
+ * `CREATE EXTENSION IF NOT EXISTS vector` — idempotent, and it persists for the
+ * suite's own connections since extensions are database-scoped. This bootstraps
+ * the extension for the suite's migrations AND catches the exact mismatch from
+ * #572 where a plain `postgres:16` image answered the probe but the suite needs
+ * pgvector — the suite then skips with a clear message instead of six tests
+ * dying on `CREATE EXTENSION vector`.
+ */
+export async function probePgTest(opts: {
+  /** Short suite name for log lines. */
+  label: string;
+  /** Env var names in precedence order (suite-specific first). */
+  vars: string[];
+  /** Require the pgvector extension; skip loudly if it is missing. */
+  requireVector?: boolean;
+  /** Connection timeout for the probe (default 2000ms). */
+  timeoutMs?: number;
+}): Promise<PgProbeResult> {
+  const url = resolvePgTestUrl(...opts.vars);
+  if (!url) {
+    console.error(
+      `[${opts.label}] no test Postgres configured — set one of ` +
+        `${opts.vars.join(', ')} to run this suite (skipping; issue #572).`,
+    );
+    return { url: undefined, reachable: false };
+  }
+
+  const probe = new Pool({
+    connectionString: url,
+    connectionTimeoutMillis: opts.timeoutMs ?? 2000,
+  });
+  try {
+    await probe.query('SELECT 1');
+    if (opts.requireVector) {
+      // Ensure pgvector: idempotent, and it persists for the suite's own
+      // connections (extensions are database-scoped). On a plain-postgres
+      // squatter this throws — we skip with a specific reason instead of
+      // letting the suite's migrations die on `CREATE EXTENSION vector`.
+      try {
+        await probe.query('CREATE EXTENSION IF NOT EXISTS vector');
+      } catch {
+        console.error(
+          `[${opts.label}] Postgres at ${url} has no pgvector extension — ` +
+            `this suite needs a pgvector image (e.g. pgvector/pgvector:pg16), ` +
+            `not plain postgres. Skipping (issue #572).`,
+        );
+        return { url, reachable: false };
+      }
+    }
+    return { url, reachable: true };
+  } catch {
+    console.error(
+      `[${opts.label}] Postgres at ${url} unreachable — skipping (issue #572).`,
+    );
+    return { url, reachable: false };
+  } finally {
+    await probe.end().catch(() => undefined);
+  }
+}

--- a/middleware/test/conductorWebhookEndpointStore.pg.test.ts
+++ b/middleware/test/conductorWebhookEndpointStore.pg.test.ts
@@ -4,6 +4,8 @@ import { after, before, describe, it } from 'node:test';
 
 import { Pool } from 'pg';
 
+import { probePgTest } from './_helpers/pgTestDb.js';
+
 import { runConductorMigrations } from '../src/conductor/migrator.js';
 import { ConductorWebhookEndpointStore } from '../src/conductor/webhookEndpointStore.js';
 import { InMemorySecretVault } from '../src/secrets/vault.js';
@@ -15,20 +17,11 @@ import { InMemorySecretVault } from '../src/secrets/vault.js';
 // Postgres, proving the advisory-lock serialization actually holds under genuine
 // concurrent connections — a hand-rolled fake pool cannot fake a real lock wait.
 
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
-
-let pgAvailable = true;
-try {
-  const probe = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 1_500 });
-  await probe.query('SELECT 1');
-  await probe.end();
-} catch {
-  pgAvailable = false;
-}
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'conductorWebhookEndpointStore',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  timeoutMs: 1_500,
+});
 
 const MARK = 'webhookendpointstore-pg-test';
 

--- a/middleware/test/conductorWebhookSubscriptionStore.pg.test.ts
+++ b/middleware/test/conductorWebhookSubscriptionStore.pg.test.ts
@@ -4,6 +4,8 @@ import { after, before, describe, it } from 'node:test';
 
 import { Pool } from 'pg';
 
+import { probePgTest } from './_helpers/pgTestDb.js';
+
 import { runConductorMigrations } from '../src/conductor/migrator.js';
 import { ConductorWebhookSubscriptionStore } from '../src/conductor/webhookSubscriptionStore.js';
 import { ConductorWorkflowStore } from '../src/conductor/workflowStore.js';
@@ -16,20 +18,11 @@ import { InMemorySecretVault } from '../src/secrets/vault.js';
 // ever exercised through a hand-rolled in-memory fake (conductorWebhookDispatcher.test.ts).
 // This runs the SAME class against a real Postgres.
 
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
-
-let pgAvailable = true;
-try {
-  const probe = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 1_500 });
-  await probe.query('SELECT 1');
-  await probe.end();
-} catch {
-  pgAvailable = false;
-}
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'conductorWebhookSubscriptionStore',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  timeoutMs: 1_500,
+});
 
 const MARK = 'webhooksubscriptionstore-pg-test';
 

--- a/middleware/test/devplatform/appStore.pg.test.ts
+++ b/middleware/test/devplatform/appStore.pg.test.ts
@@ -3,6 +3,8 @@ import { after, before, describe, it } from 'node:test';
 
 import { Pool } from 'pg';
 
+import { probePgTest } from '../_helpers/pgTestDb.js';
+
 import { runMultiOrchestratorMigrations } from '@omadia/orchestrator';
 
 import { DevGithubAppStore } from '../../src/devplatform/githubApp/appStore.js';
@@ -10,20 +12,11 @@ import { DEV_PLATFORM_AGENT_ID } from '../../src/devplatform/devRepoCredentials.
 import { InMemorySecretVault } from '../../src/secrets/vault.js';
 import type { AppConversion } from '../../src/devplatform/githubApp/manifestFlow.js';
 
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
-
-let pgAvailable = true;
-try {
-  const probe = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 1_500 });
-  await probe.query('SELECT 1');
-  await probe.end();
-} catch {
-  pgAvailable = false;
-}
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'appStore',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  timeoutMs: 1_500,
+});
 
 const MARK = 'appstore-test';
 

--- a/middleware/test/devplatform/chatDevJobService.pg.test.ts
+++ b/middleware/test/devplatform/chatDevJobService.pg.test.ts
@@ -8,6 +8,7 @@ import { Pool } from 'pg';
 
 import { runMultiOrchestratorMigrations } from '@omadia/orchestrator';
 
+import { probePgTest } from '../_helpers/pgTestDb.js';
 import { createChatDevJobService } from '../../src/devplatform/chatDevJobService.js';
 import { DevJobEventBus } from '../../src/devplatform/devJobEventBus.js';
 import { DevJobStore } from '../../src/devplatform/devJobStore.js';
@@ -20,25 +21,15 @@ import type { DevRepo } from '../../src/devplatform/types.js';
  * when no test Postgres is reachable, mirroring the other `*.pg.test.ts`.
  * Applies the real top-level migrations via the same runner the app uses.
  */
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['WS5_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
-
 const OWNER = 'pg-chatdevjob-test';
 const CALLER = { sub: `${OWNER}:operator`, email: 'op@acme.test', role: 'dev' };
 const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'migrations');
 
-const probePool = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 2000 });
-let pgAvailable = true;
-try {
-  await probePool.query('SELECT 1');
-} catch {
-  pgAvailable = false;
-  await probePool.end().catch(() => undefined);
-}
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'chatDevJobService',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'WS5_PG_TEST_URL', 'DATABASE_URL'],
+});
+const probePool = new Pool({ connectionString: PG_URL });
 
 describe('devplatform/createChatDevJobService (pg)', { skip: !pgAvailable }, () => {
   const pool = probePool;

--- a/middleware/test/devplatform/chatDevJobService.pg.test.ts
+++ b/middleware/test/devplatform/chatDevJobService.pg.test.ts
@@ -26,7 +26,7 @@ const CALLER = { sub: `${OWNER}:operator`, email: 'op@acme.test', role: 'dev' };
 const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'migrations');
 
 const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
-  label: 'chatDevJobService',
+  label: 'chatJobService',
   vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'WS5_PG_TEST_URL', 'DATABASE_URL'],
 });
 const probePool = new Pool({ connectionString: PG_URL });

--- a/middleware/test/devplatform/devJobStore.pg.test.ts
+++ b/middleware/test/devplatform/devJobStore.pg.test.ts
@@ -8,6 +8,7 @@ import { Pool } from 'pg';
 
 import { runMultiOrchestratorMigrations } from '@omadia/orchestrator';
 
+import { probePgTest } from '../_helpers/pgTestDb.js';
 import { DevJobEventBus } from '../../src/devplatform/devJobEventBus.js';
 import {
   DevJobLeaseLostError,
@@ -24,24 +25,14 @@ import type { DevRepo } from '../../src/devplatform/types.js';
  * test Postgres is reachable, mirroring the other `*.pg.test.ts`. Applies the
  * real top-level migrations (0022_dev_platform included) via the same runner the app uses.
  */
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['WS5_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
-
 const MARK = 'pg-devplatform-test';
 const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'migrations');
 
-const probePool = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 2000 });
-let pgAvailable = true;
-try {
-  await probePool.query('SELECT 1');
-} catch {
-  pgAvailable = false;
-  await probePool.end().catch(() => undefined);
-}
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'devJobStore',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'WS5_PG_TEST_URL', 'DATABASE_URL'],
+});
+const probePool = new Pool({ connectionString: PG_URL });
 
 describe('devplatform/DevJobStore (pg)', { skip: !pgAvailable }, () => {
   const pool = probePool;

--- a/middleware/test/devplatform/devJobStore.pg.test.ts
+++ b/middleware/test/devplatform/devJobStore.pg.test.ts
@@ -29,7 +29,7 @@ const MARK = 'pg-devplatform-test';
 const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'migrations');
 
 const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
-  label: 'devJobStore',
+  label: 'jobStore',
   vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'WS5_PG_TEST_URL', 'DATABASE_URL'],
 });
 const probePool = new Pool({ connectionString: PG_URL });

--- a/middleware/test/devplatform/devJobTaskStore.pg.test.ts
+++ b/middleware/test/devplatform/devJobTaskStore.pg.test.ts
@@ -8,6 +8,7 @@ import { Pool } from 'pg';
 
 import { TaskLeaseLostError, runMultiOrchestratorMigrations } from '@omadia/orchestrator';
 
+import { probePgTest } from '../_helpers/pgTestDb.js';
 import { DevJobEventBus } from '../../src/devplatform/devJobEventBus.js';
 import {
   DevJobStore,
@@ -39,25 +40,15 @@ import type { DevJob, DevJobStatus, DevRepo } from '../../src/devplatform/types.
  * rows (the migration advisory lock is database-wide, and `CREATE/DROP DATABASE`
  * is cluster-wide — hence neither is used here).
  */
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['WS5_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
-
 /** Unique per run — this is the tenant id. */
 const MARK = `pg-task-seam-${randomUUID()}`;
 const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'migrations');
 
-const probePool = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 2000 });
-let pgAvailable = true;
-try {
-  await probePool.query('SELECT 1');
-} catch {
-  pgAvailable = false;
-  await probePool.end().catch(() => undefined);
-}
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'devJobTaskStore',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'WS5_PG_TEST_URL', 'DATABASE_URL'],
+});
+const probePool = new Pool({ connectionString: PG_URL });
 
 describe('devplatform/devJobTaskStore — seam conformance (pg)', { skip: !pgAvailable }, () => {
   const pool = probePool;

--- a/middleware/test/devplatform/devJobTaskStore.pg.test.ts
+++ b/middleware/test/devplatform/devJobTaskStore.pg.test.ts
@@ -45,7 +45,7 @@ const MARK = `pg-task-seam-${randomUUID()}`;
 const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'migrations');
 
 const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
-  label: 'devJobTaskStore',
+  label: 'jobTaskStore',
   vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'WS5_PG_TEST_URL', 'DATABASE_URL'],
 });
 const probePool = new Pool({ connectionString: PG_URL });

--- a/middleware/test/devplatform/devPlatform.e2e.test.ts
+++ b/middleware/test/devplatform/devPlatform.e2e.test.ts
@@ -10,6 +10,7 @@ import { Pool } from 'pg';
 
 import { runMultiOrchestratorMigrations } from '@omadia/orchestrator';
 
+import { probePgTest } from '../_helpers/pgTestDb.js';
 import { devPlatformBootRefusals } from '../../src/config.js';
 import { DevJobStore } from '../../src/devplatform/devJobStore.js';
 import { NUMSTAT_MARKER } from '../../src/devplatform/devJobWorkerPolicy.js';
@@ -113,12 +114,10 @@ describe('devplatform boot refusals', () => {
 // Part 2 — the full loop (DB-gated).
 // ---------------------------------------------------------------------------
 
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['WS5_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'devPlatform.e2e',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'WS5_PG_TEST_URL', 'DATABASE_URL'],
+});
 
 const MARK = 'e2e-devplatform-test';
 const E2E_DAEMON_TOKEN = 'e2e-daemon-secret-token-0123456789abcdef';
@@ -130,14 +129,7 @@ const E2E_PROVIDER_KEY = 'sk-ant-e2e-REAL-PROVIDER-KEY';
 const E2E_MODEL = 'claude-opus-4-8';
 const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'migrations');
 
-const probePool = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 2000 });
-let pgAvailable = true;
-try {
-  await probePool.query('SELECT 1');
-} catch {
-  pgAvailable = false;
-  await probePool.end().catch(() => undefined);
-}
+const probePool = new Pool({ connectionString: PG_URL });
 
 // A single-add unified diff + a matching numstat. The stub forge does not parse
 // hunks (that is githubForgeClient's job, unit-tested elsewhere); DiffApplyService

--- a/middleware/test/devplatform/devPlatform.e2e.test.ts
+++ b/middleware/test/devplatform/devPlatform.e2e.test.ts
@@ -115,7 +115,7 @@ describe('devplatform boot refusals', () => {
 // ---------------------------------------------------------------------------
 
 const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
-  label: 'devPlatform.e2e',
+  label: 'platform.e2e',
   vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'WS5_PG_TEST_URL', 'DATABASE_URL'],
 });
 

--- a/middleware/test/devplatform/devPlatformPipeline.wire.pg.test.ts
+++ b/middleware/test/devplatform/devPlatformPipeline.wire.pg.test.ts
@@ -6,6 +6,8 @@ import { after, before, describe, it } from 'node:test';
 import express, { type Request, type RequestHandler } from 'express';
 import { Pool } from 'pg';
 
+import { probePgTest } from '../_helpers/pgTestDb.js';
+
 import { runMultiOrchestratorMigrations } from '@omadia/orchestrator';
 
 import { assembleDevPlatform, mountDevPlatform } from '../../src/devplatform/wireDevPlatform.js';
@@ -17,20 +19,11 @@ import { mintRunnerToken } from '../../src/devplatform/jobToken.js';
 import type { TokenFetch } from '../../src/devplatform/githubApp/installationTokens.js';
 import type { PhaseDirective } from '../../src/devplatform/pipeline/phaseEngine.js';
 
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
-
-let pgAvailable = true;
-try {
-  const probe = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 1_500 });
-  await probe.query('SELECT 1');
-  await probe.end();
-} catch {
-  pgAvailable = false;
-}
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'devPlatformPipeline.wire',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  timeoutMs: 1_500,
+});
 
 const MARK = 'gate-pipeline-wire';
 /** The operator who holds the gate (principal = ('user', createdBy) — no role). */

--- a/middleware/test/devplatform/devPlatformPipeline.wire.pg.test.ts
+++ b/middleware/test/devplatform/devPlatformPipeline.wire.pg.test.ts
@@ -20,7 +20,7 @@ import type { TokenFetch } from '../../src/devplatform/githubApp/installationTok
 import type { PhaseDirective } from '../../src/devplatform/pipeline/phaseEngine.js';
 
 const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
-  label: 'devPlatformPipeline.wire',
+  label: 'pipeline.wire',
   vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
   timeoutMs: 1_500,
 });

--- a/middleware/test/devplatform/devWebhooksConcurrency.pg.test.ts
+++ b/middleware/test/devplatform/devWebhooksConcurrency.pg.test.ts
@@ -31,7 +31,7 @@ import type { DevRepo } from '../../src/devplatform/types.js';
  * Skips when no test Postgres is reachable, like the other `*.pg.test.ts`.
  */
 const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
-  label: 'devWebhooksConcurrency',
+  label: 'webhooksConcurrency',
   vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'WS5_PG_TEST_URL', 'DATABASE_URL'],
 });
 

--- a/middleware/test/devplatform/devWebhooksConcurrency.pg.test.ts
+++ b/middleware/test/devplatform/devWebhooksConcurrency.pg.test.ts
@@ -8,6 +8,8 @@ import { after, before, describe, it } from 'node:test';
 import express from 'express';
 import { Pool } from 'pg';
 
+import { probePgTest } from '../_helpers/pgTestDb.js';
+
 import { runMultiOrchestratorMigrations } from '@omadia/orchestrator';
 
 import { DevJobStore } from '../../src/devplatform/devJobStore.js';
@@ -28,25 +30,14 @@ import type { DevRepo } from '../../src/devplatform/types.js';
  * what the 24 sequential unit tests in `devWebhooks.test.ts` cannot exercise.
  * Skips when no test Postgres is reachable, like the other `*.pg.test.ts`.
  */
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['WS5_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'devWebhooksConcurrency',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'WS5_PG_TEST_URL', 'DATABASE_URL'],
+});
 
 const MARK = 'pg-webhook-concurrency';
 const SECRET = 'whsec_concurrency_test_secret';
 const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'migrations');
-
-const probePool = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 2000 });
-let pgAvailable = true;
-try {
-  await probePool.query('SELECT 1');
-} catch {
-  pgAvailable = false;
-}
-await probePool.end().catch(() => undefined);
 
 function sign(body: string): string {
   return 'sha256=' + crypto.createHmac('sha256', SECRET).update(body).digest('hex');

--- a/middleware/test/devplatform/gateStore.pg.test.ts
+++ b/middleware/test/devplatform/gateStore.pg.test.ts
@@ -4,26 +4,19 @@ import { after, before, describe, it } from 'node:test';
 
 import { Pool } from 'pg';
 
+import { probePgTest } from '../_helpers/pgTestDb.js';
+
 import { runMultiOrchestratorMigrations } from '@omadia/orchestrator';
 
 import { DevJobGateStore } from '../../src/devplatform/pipeline/gateStore.js';
 import { DevJobStore } from '../../src/devplatform/devJobStore.js';
 import { DevRepoStore } from '../../src/devplatform/devRepoStore.js';
 
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
-
-let pgAvailable = true;
-try {
-  const probe = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 1_500 });
-  await probe.query('SELECT 1');
-  await probe.end();
-} catch {
-  pgAvailable = false;
-}
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'gateStore',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  timeoutMs: 1_500,
+});
 
 const MARK = 'gatestore-test';
 

--- a/middleware/test/devplatform/goldenFixture.e2e.test.ts
+++ b/middleware/test/devplatform/goldenFixture.e2e.test.ts
@@ -11,6 +11,8 @@ import { after, before, describe, it } from 'node:test';
 import express, { type RequestHandler } from 'express';
 import { Pool } from 'pg';
 
+import { probePgTest } from '../_helpers/pgTestDb.js';
+
 import { runMultiOrchestratorMigrations } from '@omadia/orchestrator';
 
 import { runShim } from '../../packages/dev-runner-shim/src/index.js';
@@ -57,22 +59,13 @@ import type { DevJobProvisionInput, RunnerBackend, RunnerHandle } from '../../sr
  * pg-gated, like the rest of the dev-platform e2e. Requires `git` on PATH.
  */
 
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'goldenFixture',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  timeoutMs: 1_500,
+});
 
 const MARK = 'golden-fixture-e2e';
-
-let pgAvailable = true;
-try {
-  const probe = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 1_500 });
-  await probe.query('SELECT 1');
-  await probe.end();
-} catch {
-  pgAvailable = false;
-}
 
 let gitAvailable = true;
 try {

--- a/middleware/test/devplatform/llmProxyAccounting.pg.test.ts
+++ b/middleware/test/devplatform/llmProxyAccounting.pg.test.ts
@@ -11,6 +11,7 @@ import { Pool } from 'pg';
 
 import { runMultiOrchestratorMigrations } from '@omadia/orchestrator';
 
+import { probePgTest } from '../_helpers/pgTestDb.js';
 import { DevJobStore } from '../../src/devplatform/devJobStore.js';
 import { DevRepoStore } from '../../src/devplatform/devRepoStore.js';
 import { finalizeDevJob } from '../../src/devplatform/finalizeDevJob.js';
@@ -37,26 +38,16 @@ import { createDevRunnerRouter, type DevRunnerRouterDeps } from '../../src/route
  * `input_tokens = 200_000` ⇒ exactly $1.00 per call.
  */
 
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['WS5_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
-
 const MARK = 'pg-llm-accounting';
 const MODEL = 'claude-opus-4-8';
 const OK_BODY = { model: MODEL, messages: [{ role: 'user', content: 'hi' }], stream: false };
 const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'migrations');
 
-const probePool = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 2000 });
-let pgAvailable = true;
-try {
-  await probePool.query('SELECT 1');
-} catch {
-  pgAvailable = false;
-  await probePool.end().catch(() => undefined);
-}
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'llmProxyAccounting',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'WS5_PG_TEST_URL', 'DATABASE_URL'],
+});
+const probePool = new Pool({ connectionString: PG_URL });
 
 /** An upstream Anthropic-shaped non-stream JSON success carrying provider usage. */
 function usageResponse(inputTokens: number, outputTokens: number): Response {

--- a/middleware/test/devplatform/retention.pg.test.ts
+++ b/middleware/test/devplatform/retention.pg.test.ts
@@ -8,6 +8,7 @@ import { Pool } from 'pg';
 
 import { runMultiOrchestratorMigrations } from '@omadia/orchestrator';
 
+import { probePgTest } from '../_helpers/pgTestDb.js';
 import { DevJobStore } from '../../src/devplatform/devJobStore.js';
 import { DevRepoStore } from '../../src/devplatform/devRepoStore.js';
 import { mintRunnerToken } from '../../src/devplatform/jobToken.js';
@@ -18,25 +19,15 @@ import type { DevJob, DevJobEvent, DevRepo } from '../../src/devplatform/types.j
  * Epic #470 W5 — DB-gated integration for the data-lifecycle unit (spec §7).
  * Skips when no test Postgres is reachable, mirroring the other `*.pg.test.ts`.
  */
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['WS5_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
-
 const MARK = 'pg-devplatform-retention-test';
 const MS_PER_DAY = 86_400_000;
 const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'migrations');
 
-const probePool = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 2000 });
-let pgAvailable = true;
-try {
-  await probePool.query('SELECT 1');
-} catch {
-  pgAvailable = false;
-  await probePool.end().catch(() => undefined);
-}
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'retention',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'WS5_PG_TEST_URL', 'DATABASE_URL'],
+});
+const probePool = new Pool({ connectionString: PG_URL });
 
 const isoDaysAgo = (days: number): string => new Date(Date.now() - days * MS_PER_DAY).toISOString();
 

--- a/middleware/test/devplatform/scopedScmToken.pg.test.ts
+++ b/middleware/test/devplatform/scopedScmToken.pg.test.ts
@@ -6,6 +6,8 @@ import { after, before, describe, it } from 'node:test';
 import express, { type RequestHandler } from 'express';
 import { Pool } from 'pg';
 
+import { probePgTest } from '../_helpers/pgTestDb.js';
+
 import { runMultiOrchestratorMigrations } from '@omadia/orchestrator';
 
 import { assembleDevPlatform, mountDevPlatform } from '../../src/devplatform/wireDevPlatform.js';
@@ -16,20 +18,11 @@ import { mintRunnerToken } from '../../src/devplatform/jobToken.js';
 import type { TokenFetch } from '../../src/devplatform/githubApp/installationTokens.js';
 import type { DevJobProvisionInput, RunnerBackend, RunnerHandle } from '../../src/devplatform/types.js';
 
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
-
-let pgAvailable = true;
-try {
-  const probe = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 1_500 });
-  await probe.query('SELECT 1');
-  await probe.end();
-} catch {
-  pgAvailable = false;
-}
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'scopedScmToken',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  timeoutMs: 1_500,
+});
 
 const MARK = 'scoped-scm-token';
 

--- a/middleware/test/devplatform/trackerPoller.pg.test.ts
+++ b/middleware/test/devplatform/trackerPoller.pg.test.ts
@@ -6,6 +6,8 @@ import { after, before, beforeEach, describe, it } from 'node:test';
 
 import { Pool } from 'pg';
 
+import { probePgTest } from '../_helpers/pgTestDb.js';
+
 import { runMultiOrchestratorMigrations } from '@omadia/orchestrator';
 
 import { DevJobStore } from '../../src/devplatform/devJobStore.js';
@@ -30,24 +32,13 @@ import type { DevRepo, RunnerBackendKind } from '../../src/devplatform/types.js'
  * job dedupe, cursor advance, structural refusals, interval floor, and skipping a
  * repo without 'tracker' in allowed_triggers. Skips when no test Postgres reachable.
  */
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['WS5_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'trackerPoller',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'WS5_PG_TEST_URL', 'DATABASE_URL'],
+});
 
 const MARK = 'pg-tracker-poller';
 const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'migrations');
-
-const probePool = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 2000 });
-let pgAvailable = true;
-try {
-  await probePool.query('SELECT 1');
-} catch {
-  pgAvailable = false;
-}
-await probePool.end().catch(() => undefined);
 
 function mkTicket(number: number, updatedAt: string, extra: Partial<Ticket> = {}): Ticket {
   return {

--- a/middleware/test/devplatform/transcriptQueries.pg.test.ts
+++ b/middleware/test/devplatform/transcriptQueries.pg.test.ts
@@ -8,6 +8,7 @@ import { Pool } from 'pg';
 
 import { runMultiOrchestratorMigrations } from '@omadia/orchestrator';
 
+import { probePgTest } from '../_helpers/pgTestDb.js';
 import { DevJobStore } from '../../src/devplatform/devJobStore.js';
 import { DevRepoStore } from '../../src/devplatform/devRepoStore.js';
 import { mintRunnerToken } from '../../src/devplatform/jobToken.js';
@@ -25,24 +26,14 @@ import type { DevJob, DevRepo } from '../../src/devplatform/types.js';
  * through their extracted query helpers. Skips when no test Postgres is reachable,
  * mirroring the other `*.pg.test.ts`.
  */
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['WS5_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
-
 const MARK = 'pg-devplatform-transcript-test';
 const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'migrations');
 
-const probePool = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 2000 });
-let pgAvailable = true;
-try {
-  await probePool.query('SELECT 1');
-} catch {
-  pgAvailable = false;
-  await probePool.end().catch(() => undefined);
-}
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'transcriptQueries',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'WS5_PG_TEST_URL', 'DATABASE_URL'],
+});
+const probePool = new Pool({ connectionString: PG_URL });
 
 describe('devplatform/transcriptQueries (pg)', { skip: !pgAvailable }, () => {
   const pool = probePool;

--- a/middleware/test/embeddingGateReevaluation.pg.test.ts
+++ b/middleware/test/embeddingGateReevaluation.pg.test.ts
@@ -4,6 +4,8 @@ import { after, before, describe, it } from 'node:test';
 import type { EmbeddingClient } from '@omadia/plugin-api';
 import { Pool } from 'pg';
 
+import { probePgTest } from './_helpers/pgTestDb.js';
+
 import { startGateRunner } from '@omadia/knowledge-graph-neon/dist/gateReevaluation.js';
 
 /**
@@ -35,25 +37,15 @@ import { startGateRunner } from '@omadia/knowledge-graph-neon/dist/gateReevaluat
  * suite deadlocks under the parallel runner.
  */
 
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'embeddingGateReevaluation',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  requireVector: true,
+  timeoutMs: 1_500,
+});
 
 const SCHEMA = 'embgate_reeval_test';
 const TENANT = 'reeval-440';
-
-let pgAvailable = true;
-const probe = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 1_500 });
-try {
-  await probe.query('SELECT 1');
-  await probe.query('CREATE EXTENSION IF NOT EXISTS vector');
-} catch {
-  pgAvailable = false;
-} finally {
-  await probe.end().catch(() => undefined);
-}
 
 const silent = (): void => undefined;
 const VEC768 = `[${new Array(768).fill(0.01).join(',')}]`;

--- a/middleware/test/embeddingGateWriteFence.pg.test.ts
+++ b/middleware/test/embeddingGateWriteFence.pg.test.ts
@@ -4,6 +4,8 @@ import { after, before, describe, it } from 'node:test';
 import type { EmbeddingClient } from '@omadia/plugin-api';
 import { Pool } from 'pg';
 
+import { probePgTest } from './_helpers/pgTestDb.js';
+
 import {
   startEmbeddingBackfill,
   type EmbeddingBackfillHandle,
@@ -41,25 +43,15 @@ import { NeonProcessMemoryStore } from '@omadia/knowledge-graph-neon/dist/proces
  * suite deadlocks under the parallel runner.
  */
 
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'embeddingGateWriteFence',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  requireVector: true,
+  timeoutMs: 1_500,
+});
 
 const SCHEMA = 'embgate_fence_test';
 const TENANT = 'fence-440';
-
-let pgAvailable = true;
-const probe = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 1_500 });
-try {
-  await probe.query('SELECT 1');
-  await probe.query('CREATE EXTENSION IF NOT EXISTS vector');
-} catch {
-  pgAvailable = false;
-} finally {
-  await probe.end().catch(() => undefined);
-}
 
 const silent = (): void => undefined;
 

--- a/middleware/test/embeddingModelGate.pg.test.ts
+++ b/middleware/test/embeddingModelGate.pg.test.ts
@@ -3,6 +3,8 @@ import { after, before, describe, it } from 'node:test';
 
 import { Pool } from 'pg';
 
+import { probePgTest } from './_helpers/pgTestDb.js';
+
 import {
   allowsVectorWrites,
   clearStaleVectors,
@@ -26,24 +28,14 @@ import {
  * a database.
  */
 
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'embeddingModelGate',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  requireVector: true,
+  timeoutMs: 1_500,
+});
 
 const SCHEMA = 'embgate_pg_test';
-
-let pgAvailable = true;
-try {
-  const probe = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 1_500 });
-  await probe.query('SELECT 1');
-  // pgvector is not optional here — a vector(n) column IS the thing under test.
-  await probe.query('CREATE EXTENSION IF NOT EXISTS vector');
-  await probe.end();
-} catch {
-  pgAvailable = false;
-}
 
 const OLLAMA = { modelId: 'ollama:nomic-embed-text', dimensions: 768 };
 const OTHER_768 = { modelId: 'openai:some-768-model', dimensions: 768 };

--- a/middleware/test/embeddingModelGateMigration.pg.test.ts
+++ b/middleware/test/embeddingModelGateMigration.pg.test.ts
@@ -3,6 +3,8 @@ import { after, before, describe, it } from 'node:test';
 
 import { Pool } from 'pg';
 
+import { probePgTest } from './_helpers/pgTestDb.js';
+
 import {
   allowsVectorWrites,
   evaluateEmbeddingModelGate,
@@ -29,28 +31,14 @@ import {
  * Self-skips when no Postgres is reachable, same convention as its sibling.
  */
 
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'embeddingModelGateMigration',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  requireVector: true,
+  timeoutMs: 1_500,
+});
 
 const SCHEMA = 'embgate_migrate_test';
-
-let pgAvailable = true;
-// The probe runs at module scope, so it executes even when the suite ends up
-// skipping. `end()` must therefore live in a `finally`: on the unreachable-PG
-// path the old code left the pool (and its pending connect timer) behind for
-// the lifetime of this file's test process.
-const probe = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 1_500 });
-try {
-  await probe.query('SELECT 1');
-  await probe.query('CREATE EXTENSION IF NOT EXISTS vector');
-} catch {
-  pgAvailable = false;
-} finally {
-  await probe.end().catch(() => undefined);
-}
 
 const OLLAMA_768 = { modelId: 'ollama:nomic-embed-text', dimensions: 768 };
 const OPENAI_1536 = { modelId: 'openai:text-embedding-3-small', dimensions: 1536 };

--- a/middleware/test/embeddingModelGateMigrationGuards.pg.test.ts
+++ b/middleware/test/embeddingModelGateMigrationGuards.pg.test.ts
@@ -3,6 +3,8 @@ import { after, before, describe, it } from 'node:test';
 
 import { Pool } from 'pg';
 
+import { probePgTest } from './_helpers/pgTestDb.js';
+
 import {
   allowsVectorWrites,
   evaluateEmbeddingModelGate,
@@ -35,11 +37,12 @@ import { migrateVectorColumns } from '@omadia/knowledge-graph-neon/dist/vectorCo
  * Self-skips when no Postgres is reachable, same convention as its siblings.
  */
 
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'embeddingModelGateMigrationGuards',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  requireVector: true,
+  timeoutMs: 1_500,
+});
 
 const SCHEMA = 'embgate_migrate_guards_test';
 /**
@@ -52,17 +55,6 @@ const SCHEMA = 'embgate_migrate_guards_test';
  * came back `lock-held` — a genuine cross-file collision, not flake.
  */
 const TENANT = 'guards-440';
-
-let pgAvailable = true;
-const probe = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 1_500 });
-try {
-  await probe.query('SELECT 1');
-  await probe.query('CREATE EXTENSION IF NOT EXISTS vector');
-} catch {
-  pgAvailable = false;
-} finally {
-  await probe.end().catch(() => undefined);
-}
 
 const OLLAMA_768 = { modelId: 'ollama:nomic-embed-text', dimensions: 768 };
 const OPENAI_1536 = { modelId: 'openai:text-embedding-3-small', dimensions: 1536 };

--- a/middleware/test/kgWalkSubgraph.test.ts
+++ b/middleware/test/kgWalkSubgraph.test.ts
@@ -13,19 +13,18 @@ import type {
   RecalledContext,
 } from '@omadia/plugin-api';
 
+import { probePgTest } from './_helpers/pgTestDb.js';
+
 /**
  * KG-walk chat visualization — `getMemorableKnowledgeSubgraph` BFS over the
  * recalled neighbourhood, plus the `buildKgWalkPayload` emit-path helper.
  *
- * The Neon leg runs against a throwaway PG (mwtest-pg-kg :55439); it skips
- * cleanly when the DB is unreachable so `npm test` stays hermetic. The
+ * The Neon leg runs against a throwaway pgvector PG — point KG_PG_TEST_URL (or
+ * MEMORY_PG_TEST_URL) at it. It skips cleanly, with a logged reason, when no
+ * URL is set, the DB is unreachable, or the DB lacks pgvector, so `npm test`
+ * stays hermetic and no stray container can hijack it (issue #572). The
  * in-memory leg always runs.
  */
-
-const PG_URL =
-  process.env['KG_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  'postgres://test:test@127.0.0.1:55439/test';
 
 const TENANT = 'kgwalk-tenant';
 const OTHER_TENANT = 'other-tenant';
@@ -162,20 +161,14 @@ describe('KG-walk · InMemory getMemorableKnowledgeSubgraph', () => {
 // ---------------------------------------------------------------------------
 // Neon leg — throwaway PG, skips when unreachable.
 // ---------------------------------------------------------------------------
-let pgUp = false;
-const probePool = new Pool({
-  connectionString: PG_URL,
-  connectionTimeoutMillis: 2000,
+const { url: PG_URL, reachable: pgUp } = await probePgTest({
+  label: 'kgWalkSubgraph',
+  vars: ['KG_PG_TEST_URL', 'MEMORY_PG_TEST_URL'],
+  requireVector: true,
 });
-try {
-  await probePool.query('SELECT 1');
-  pgUp = true;
-} catch {
-  console.error(`[kgWalkSubgraph] PG at ${PG_URL} unreachable — skipping Neon leg`);
-}
 
 if (pgUp) {
-  const pool = probePool;
+  const pool = new Pool({ connectionString: PG_URL });
 
   after(async () => {
     await pool.end();

--- a/middleware/test/mcpDelegationBackfillMigration.pg.test.ts
+++ b/middleware/test/mcpDelegationBackfillMigration.pg.test.ts
@@ -4,6 +4,8 @@ import { after, before, describe, it } from 'node:test';
 
 import { Pool } from 'pg';
 
+import { probePgTest } from './_helpers/pgTestDb.js';
+
 import { SERVICE_USER_KEY } from '../src/services/mcpDelegation.js';
 
 /**
@@ -55,20 +57,11 @@ import { SERVICE_USER_KEY } from '../src/services/mcpDelegation.js';
  * otherwise make every assertion below pass vacuously.
  */
 
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
-
-let pgAvailable = true;
-try {
-  const probe = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 1_500 });
-  await probe.query('SELECT 1');
-  await probe.end();
-} catch {
-  pgAvailable = false;
-}
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'mcpDelegationBackfillMigration',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  timeoutMs: 1_500,
+});
 
 /** Dedicated tenant id → dedicated schema. See rule 2 above. */
 const TENANT = `w4_deleg_${process.pid}_${Date.now().toString(36)}`;

--- a/middleware/test/mcpOAuthCimdMigration.pg.test.ts
+++ b/middleware/test/mcpOAuthCimdMigration.pg.test.ts
@@ -4,6 +4,8 @@ import { after, before, describe, it } from 'node:test';
 
 import { Pool } from 'pg';
 
+import { probePgTest } from './_helpers/pgTestDb.js';
+
 /**
  * Migration 0032 (W2-4, issue #546) against a REAL Postgres.
  *
@@ -26,20 +28,11 @@ import { Pool } from 'pg';
  * reject junk, and does `client_metadata_url` exist and accept NULL.
  */
 
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['DATABASE_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
-
-let pgAvailable = true;
-try {
-  const probe = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 1_500 });
-  await probe.query('SELECT 1');
-  await probe.end();
-} catch {
-  pgAvailable = false;
-}
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'mcpOAuthCimdMigration',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  timeoutMs: 1_500,
+});
 
 /** Dedicated tenant id → dedicated schema. See rule 2 above. */
 const TENANT = `w24_cimd_${process.pid}_${Date.now().toString(36)}`;

--- a/middleware/test/mcpRegistrySchema.pg.test.ts
+++ b/middleware/test/mcpRegistrySchema.pg.test.ts
@@ -8,6 +8,8 @@ import { Pool, type PoolClient } from 'pg';
 
 import { runMultiOrchestratorMigrations } from '@omadia/orchestrator';
 
+import { probePgTest } from './_helpers/pgTestDb.js';
+
 /**
  * PG-gated coverage for the MCP registry / OAuth schema in
  * `middleware/migrations` (0010 registries, 0013 registry kinds, 0014 the
@@ -31,11 +33,10 @@ import { runMultiOrchestratorMigrations } from '@omadia/orchestrator';
  * concurrently for long enough to cancel 29 of their tests.
  * Skips when no test Postgres is reachable, mirroring the other pg tests.
  */
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['WS5_PG_TEST_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'mcpRegistrySchema',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'WS5_PG_TEST_URL'],
+});
 
 /** Tenant prefix — unique to this suite, see the isolation note above. */
 const TENANT = 'w04-mcp-';
@@ -52,17 +53,9 @@ const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'mi
  */
 const probePool = new Pool({
   connectionString: PG_URL,
-  connectionTimeoutMillis: 2000,
   max: 2,
   idleTimeoutMillis: 1000,
 });
-let pgAvailable = true;
-try {
-  await probePool.query('SELECT 1');
-} catch {
-  pgAvailable = false;
-  await probePool.end().catch(() => undefined);
-}
 
 async function migrationFiles(): Promise<readonly string[]> {
   return (await readdir(migrationsDir)).filter((f) => f.endsWith('.sql')).sort();

--- a/middleware/test/memoryPurgeKg.test.ts
+++ b/middleware/test/memoryPurgeKg.test.ts
@@ -8,16 +8,15 @@ import {
 import { runGraphMigrations } from '@omadia/knowledge-graph-neon/dist/migrator.js';
 import type { Pool } from 'pg';
 
+import { probePgTest } from './_helpers/pgTestDb.js';
+
 // ---------------------------------------------------------------------------
 // WS3 — Knowledge-Graph purge primitive against a throwaway Postgres.
-// Requires a reachable PG (pgvector). The overnight harness brings up
-// `mwtest-pg-ws3` on 55433; set WS3_PG_URL to point elsewhere. If neither is
-// set AND the default is unreachable, the suite skips rather than fails.
+// Requires a reachable pgvector PG — set WS3_PG_URL (or MEMORY_PG_TEST_URL) to
+// point at one. No default port: a stray container must not be picked up
+// (issue #572). When no URL is set, the DB is unreachable, or it lacks
+// pgvector, the suite skips (with a logged reason) rather than fails.
 // ---------------------------------------------------------------------------
-
-const PG_URL =
-  process.env['WS3_PG_URL'] ??
-  'postgresql://postgres:postgres@127.0.0.1:55433/postgres';
 
 const TENANT = 'ws3-tenant';
 
@@ -34,9 +33,14 @@ async function nodeUuid(p: Pool, externalId: string): Promise<string> {
 
 describe('purgeMemorableKnowledge (KG primitive)', () => {
   before(async () => {
-    pool = createNeonPool(PG_URL, 2);
+    const probe = await probePgTest({
+      label: 'memoryPurgeKg',
+      vars: ['WS3_PG_URL', 'MEMORY_PG_TEST_URL'],
+      requireVector: true,
+    });
+    if (!probe.reachable) return;
+    pool = createNeonPool(probe.url!, 2);
     try {
-      await pool.query('SELECT 1');
       await runGraphMigrations(pool);
       reachable = true;
     } catch {
@@ -57,7 +61,7 @@ describe('purgeMemorableKnowledge (KG primitive)', () => {
 
   it('purges only the matching origin_agent and its incident edges', async (t) => {
     if (!reachable || !pool) {
-      t.skip('Postgres not reachable (set WS3_PG_URL or start mwtest-pg-ws3)');
+      t.skip('pgvector Postgres not configured (set WS3_PG_URL or MEMORY_PG_TEST_URL)');
       return;
     }
     const p = pool;

--- a/middleware/test/memoryPurgeRoute.test.ts
+++ b/middleware/test/memoryPurgeRoute.test.ts
@@ -6,6 +6,7 @@ import { after, before, describe, it } from 'node:test';
 import express from 'express';
 import { Pool } from 'pg';
 
+import { resolvePgTestUrl } from './_helpers/pgTestDb.js';
 import { InMemoryMemoryStore } from '@omadia/memory';
 import { InMemoryKnowledgeGraph } from '@omadia/knowledge-graph-inmemory';
 import type {
@@ -100,7 +101,9 @@ function withPurgePrimitives(
  * not inside the router, so the test calls the router directly.
  */
 
-const PG_URL = 'postgres://postgres:test@127.0.0.1:55434/memtest';
+// No hardcoded default port (issue #572): the PG audit case runs only when an
+// explicit test-Postgres URL is set, else it skips.
+const PG_URL = resolvePgTestUrl('MEMORY_PG_TEST_URL', 'GRAPH_PG_TEST_URL');
 
 type PurgeKg = ReturnType<typeof withPurgePrimitives>;
 
@@ -202,6 +205,13 @@ async function postJson(
  *  pgcrypto ensured (router needs gen_random_uuid). Else undefined → audit
  *  case skipped. */
 async function maybePgPool(): Promise<Pool | undefined> {
+  if (!PG_URL) {
+    console.error(
+      '[memoryPurgeRoute] no MEMORY_PG_TEST_URL / GRAPH_PG_TEST_URL set — ' +
+        'skipping the PG audit case (issue #572).',
+    );
+    return undefined;
+  }
   const pool = new Pool({ connectionString: PG_URL, max: 2 });
   try {
     await pool.query('SELECT 1');

--- a/middleware/test/pluginVerdictStore.pg.test.ts
+++ b/middleware/test/pluginVerdictStore.pg.test.ts
@@ -7,6 +7,8 @@ import { Pool } from 'pg';
 
 import { AgentGraphStore, runMultiOrchestratorMigrations } from '@omadia/orchestrator';
 
+import { probePgTest } from './_helpers/pgTestDb.js';
+
 /**
  * PG-gated coverage for the plugin_verdicts store surface (issue #453,
  * second-review fix): the SQL upsert must clear an operator ack whenever a
@@ -15,24 +17,15 @@ import { AgentGraphStore, runMultiOrchestratorMigrations } from '@omadia/orchest
  * better — including across the scheduler's interim `pending` write.
  * Skips when no test Postgres is reachable, mirroring the other pg tests.
  */
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['WS5_PG_TEST_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
-
 const HASH_PREFIX = 'plugin-verdict-test-';
 const VERIFIER = 'skillspector-test';
 const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'migrations');
 
-const probePool = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 2000 });
-let pgAvailable = true;
-try {
-  await probePool.query('SELECT 1');
-} catch {
-  pgAvailable = false;
-  await probePool.end().catch(() => undefined);
-}
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'pluginVerdictStore',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'WS5_PG_TEST_URL'],
+});
+const probePool = new Pool({ connectionString: PG_URL });
 
 type Severity =
   | 'no_signals'

--- a/middleware/test/scratchPromotionReaper.test.ts
+++ b/middleware/test/scratchPromotionReaper.test.ts
@@ -15,13 +15,12 @@ import type {
   MemorableKnowledgeIngestResult,
 } from '@omadia/plugin-api';
 
-// Throwaway PG configured by the WS5 driver (docker container
-// `mwtest-pg-ws5` on :55437). Fall back to MEMORY_PG_TEST_URL / the
-// conventional throwaway URL so the file runs standalone too.
-const PG_URL =
-  process.env['WS5_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
+import { probePgTest } from './_helpers/pgTestDb.js';
+
+// Throwaway pgvector PG — point WS5_PG_TEST_URL (or MEMORY_PG_TEST_URL) at it.
+// No default port: a stray container must not be picked up (issue #572), and
+// this suite runs graph migrations that need pgvector, so it also skips when
+// the DB lacks the extension. The fake-pool flow always runs.
 
 // --- migration DDL (copy of 0001_memory_files.sql) ------------------------
 const MEMORY_FILES_DDL = `
@@ -96,19 +95,14 @@ describe('WS5 · deriveAgentSlug', () => {
 });
 
 // --- Real-PG suite (preferred) -------------------------------------------
-let pgUp = false;
-const probePool = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 2000 });
-try {
-  await probePool.query('SELECT 1');
-  pgUp = true;
-} catch {
-  console.error(
-    `[scratchPromotionReaper] PG at ${PG_URL} unreachable — running fake-pool flow only`,
-  );
-}
+const { url: PG_URL, reachable: pgUp } = await probePgTest({
+  label: 'scratchPromotionReaper',
+  vars: ['WS5_PG_TEST_URL', 'MEMORY_PG_TEST_URL'],
+  requireVector: true,
+});
 
 if (pgUp) {
-  const pool = probePool;
+  const pool = new Pool({ connectionString: PG_URL });
 
   after(async () => {
     await pool.end();

--- a/middleware/test/skillLifecycleStore.pg.test.ts
+++ b/middleware/test/skillLifecycleStore.pg.test.ts
@@ -7,6 +7,7 @@ import { Pool } from 'pg';
 
 import { AgentGraphStore, runMultiOrchestratorMigrations } from '@omadia/orchestrator';
 
+import { probePgTest } from './_helpers/pgTestDb.js';
 import { importSkillMarkdown } from '../src/services/skillImport.js';
 
 /**
@@ -16,23 +17,14 @@ import { importSkillMarkdown } from '../src/services/skillImport.js';
  * the listSubAgentsBySkillId reverse lookup. Skips when no test Postgres is
  * reachable, mirroring the other pg tests.
  */
-const PG_URL =
-  process.env['GRAPH_PG_TEST_URL'] ??
-  process.env['MEMORY_PG_TEST_URL'] ??
-  process.env['WS5_PG_TEST_URL'] ??
-  'postgres://test:test@127.0.0.1:55438/test';
-
 const SLUG_PREFIX = 'wave0-skill-test-';
 const migrationsDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'migrations');
 
-const probePool = new Pool({ connectionString: PG_URL, connectionTimeoutMillis: 2000 });
-let pgAvailable = true;
-try {
-  await probePool.query('SELECT 1');
-} catch {
-  pgAvailable = false;
-  await probePool.end().catch(() => undefined);
-}
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'skillLifecycleStore',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'WS5_PG_TEST_URL'],
+});
+const probePool = new Pool({ connectionString: PG_URL });
 
 describe('AgentGraphStore skill lifecycle (pg)', { skip: !pgAvailable }, () => {
   const pool = probePool;


### PR DESCRIPTION
## What
  Drop the hardcoded default Postgres port from every PG-gated middleware test suite (#572). Suites now require an explicit env var and skip cleanly - with a logged reason - when none is set.

  ## Why
  A fixed default port (55438 / 55439) is a trap: any scratch container an agent or dev starts on that port silently answers the `SELECT 1` probe and hijacks the run. The failure doesn't read as a port collision — kgWalkSubgraph's six Neon tests were *cancelled* dying on `CREATE EXTENSION vector` because the squatter was plain postgres, not pgvector. There is no safe port by convention, so the fix is an explicit env var plus a pgvector check, routed through `test/_helpers/pgTestDb.ts` (`probePgTest`). Swept all ~28 sibling `.pg.test.ts` files, not just the two named ports — fixing only two leaves the same trap everywhere else.

  ## Test plan
  - [x] Verified `kgWalkSubgraph` from built `dist/` against real containers, 3 cases:
    - [x] no env → Neon leg skips with logged reason, 7 in-mem pass, 0 fail
    - [x] pgvector URL → Neon leg runs, 13 pass, 0 fail
    - [x] plain-postgres URL → skips on `requireVector`, **0 cancelled** (the #572 scenario)
  - [X] `npm run typecheck && npm run test` in middleware (full suite, DB-less → all PG suites skip)
  - [X] Note: `npm run lint` does **not** cover `test/`, so the new helper isn't linted in CI

  ## Risk / blast radius
  - Touches 30 test files, but test-only — no `src/` change, no schema, no public API.
  - **New env vars:** suites read suite-specific vars (`GRAPH_`/`KG_`/`WS5_`...) then `MEMORY_PG_TEST_URL` fallback. Documented in new `test/README.md`; no compose change needed (suites skip without a DB).
  - **CI dependency on #612:** if that PR wires a CI Postgres, it must export `MEMORY_PG_TEST_URL` **and** use a pgvector image - else these suites skip silently green.

  ## Merge prep

  - Merged `main` (was 3 commits behind) — clean, no conflicts.
  - Fixed the red `core decoupling ratchet (#470)`: the six new `probePgTest()`
    labels and one README table cell spelled Dev Platform identifiers verbatim,
    which the ratchet counts as references (+7). Nothing had re-coupled — no new
    import, no new call. Reworded per the house precedent for incidental
    mentions (`8425e698`, `fdadda42`) rather than raising the baseline; the
    labels stay unique across the 28 gated suites. Ratchet back to 3448.

  Closes #572

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788701528&installation_model_id=428086&pr_number=626&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F626&signature=44193309842960ca29a5cf98deebd661baa0452c3daddf62fdc01f5495917d10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
