### PR TITLE
fix(deps): bump nanoid to 3.3.18 — unblock the repo-wide audit gate

### DIFF
--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -6890,9 +6890,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/web-ui/package-lock.json
+++ b/web-ui/package-lock.json
@@ -8615,9 +8615,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What

Lockfile-only bump of `nanoid` 3.3.16 → 3.3.18 in **both** `middleware/` and `web-ui/`. 3 changed lines per lockfile, `nanoid` only — no `package.json` and no `overrides` entry.

## Why

The required checks `audit (high+critical block) (middleware)` and `(web-ui)` went **red on `main`** at `f5b70381`. This is not a code regression — it is a newly published advisory that flipped previously-green commits:

- **GHSA-2v37-7h3g-55p8** — `nanoid` `<3.3.17`, severity **high**

`nanoid` reaches both trees transitively via `postcss` (itself already pinned to `8.5.23` in `overrides`). `3.3.18` satisfies postcss's existing `^3.3.11` range, so a plain lockfile bump resolves it — no new override needed.

Because `audit` is a **required** check and branch protection is `strict: true`, every open PR is currently blocked on this. This PR unblocks the queue.

## Verification

`npm audit --audit-level=high` run locally on this branch (node 22.22.3):

| package | before | after |
|---|---|---|
| `middleware` | 1 high, 10 moderate | **0 high, 0 critical** (10 moderate) |
| `web-ui` | 1 high, 2 moderate | **0 high, 0 critical** (2 moderate) |

Moderate findings are below the gate's `--audit-level=high` threshold and unchanged by this PR.

## Risk

Minimal. Patch-level bump of a transitive dev-path dependency, within the range its parent already declares. No source, schema, API, or env-var change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788861480&installation_model_id=428086&pr_number=627&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F627&signature=e37b55e6ef0f64bc713128f6d2efd60bd16f2e422812ebb8adeac3e190e63f44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->