### PR TITLE
fix(#665): stop the KG plugin ending the process-wide pg pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,8 @@ jobs:
       # skip does NOT increment "skipped": its tests simply never register
       # and vanish from the total. So "skipped == 0" is blind to exactly the
       # silent-skip this issue is about; only a floor on the test COUNT
-      # catches it. The 25 *.pg.test.ts files register 238 tests today. If
+      # catches it. The *.pg.test.ts files register 240 tests today (+2 from
+      # kgPluginPoolLifetime.pg.test.ts, issue #665). If
       # the count drops (broken DSN, a future suite reading an env var we
       # don't set here, a cold-connection flake), a suite silently vanished —
       # go red. Raise PG_TEST_FLOOR when you add Postgres tests, same
@@ -199,7 +200,7 @@ jobs:
         env:
           GRAPH_PG_TEST_URL: postgres://omadia:omadia-ci@localhost:5432/omadia
           MEMORY_PG_TEST_URL: postgres://omadia:omadia-ci@localhost:5432/omadia
-          PG_TEST_FLOOR: '238'
+          PG_TEST_FLOOR: '240'
         run: |
           set -eo pipefail
           npm run test:pg 2>&1 | tee pg-test.out

--- a/middleware/packages/harness-knowledge-graph-neon/src/plugin.ts
+++ b/middleware/packages/harness-knowledge-graph-neon/src/plugin.ts
@@ -47,9 +47,14 @@ import { NeonNudgeStateStore } from './nudgeStateStore.js';
  *     correlation is preserved.
  *
  * Lifetime: activate() constructs Pool + Migrations + Graph + Bus +
- * Backfill scheduler. close() reverses (stop scheduler → dispose service
- * registrations → drain Pool with end()). SIGTERM/SIGINT shutdown is owned
- * by the kernel runtime which calls close() on every active plugin.
+ * Backfill scheduler. close() reverses it — stop scheduler → dispose service
+ * registrations → drop the Pool REFERENCE. It deliberately does NOT call
+ * `pool.end()` (issue #665): close() is not only the shutdown path, it also
+ * runs on deactivate and on the config editor's reactivate, and the kernel
+ * shares one boot-resolved pool with ~40 subsystems that never re-resolve it.
+ * Ending it there took the whole process down until restart. SIGTERM/SIGINT
+ * shutdown is owned by the kernel runtime, which calls close() on every active
+ * plugin; the pool is released with the process.
  *
  * S+11-2b: capability ownership flipped here from the legacy
  * @omadia/knowledge-graph plugin. Mutual exclusion with the
@@ -674,11 +679,29 @@ export async function activate(
       disposePool();
       disposeBus();
       disposeGraph();
-      try {
-        await graphPool.end();
-      } catch {
-        // process exit path — pool draining is best-effort
-      }
+      // DO NOT call graphPool.end() here (issue #665).
+      //
+      // This plugin creates the pool, but `close()` is NOT a process-exit
+      // path — it also runs on every deactivate and on the reactivate that
+      // the config editor triggers after any settings save. The kernel
+      // resolves `graphPool` ONCE at boot (src/index.ts) and hands that same
+      // object to ~40 subsystems, which never re-resolve it. Ending it here
+      // therefore did not release "our" pool; it killed the one the whole
+      // process was still using, and every later query failed with
+      // `Cannot use a pool after calling end on the pool` until the machine
+      // was restarted.
+      //
+      // Dropping the reference without ending it is the same contract
+      // memory-postgres already follows ("The pool is owned by the graphPool
+      // provider — do NOT call pool.end() here"). The pool is released when
+      // the process exits, which is the only moment no one can still hold it.
+      //
+      // Cost of this choice, stated plainly: a reactivate leaves the previous
+      // pool open, because `activate()` builds a fresh one. That is a bounded
+      // leak on an operator-initiated action, and it is strictly better than
+      // a live outage — but it is the reason a future change should let
+      // `activate()` reuse an already-provided pool rather than always
+      // creating one.
     },
   };
 }

--- a/middleware/src/health/kgHealth.ts
+++ b/middleware/src/health/kgHealth.ts
@@ -87,8 +87,79 @@ export interface KgHealth {
   durableTier: boolean;
   /** Stored-process reuse — requires neon (only it provides processMemory) + embeddings. */
   processReuse: boolean;
+  /** Liveness of the shared pg pool behind the neon backend (#665).
+   *  `skipped` when there is no neon backend to probe — that is not a fault. */
+  pool: 'live' | 'dead' | 'skipped';
   /** Human-readable degradation notes, empty when fully healthy. */
   warnings: string[];
+}
+
+/** Outcome of {@link probeGraphPool}. Kept separate from KgHealth so the
+ *  snapshot builder stays synchronous and pure — the I/O happens in the route,
+ *  the projection is still a function of its inputs. */
+export interface PoolProbe {
+  state: 'live' | 'dead' | 'skipped';
+  /** Failure text, for the warning line. Never surfaced when `live`. */
+  error?: string;
+}
+
+/** Minimal structural view of a pg Pool — avoids a `pg` type import here. */
+interface QueryablePool {
+  query(sql: string): Promise<unknown>;
+}
+
+/**
+ * Ask the shared pg pool whether it is still usable (#665).
+ *
+ * WHY THIS EXISTS: every other field in this file is a projection of the
+ * REGISTRY — what the operator installed and what the gate decided. None of it
+ * touches the database, so the outage in #665 was structurally invisible: the
+ * knowledge-graph plugin ended the process-wide pool, every query in the
+ * process began failing with `Cannot use a pool after calling end on the pool`,
+ * and `/health` kept answering `ok` because a registry entry still said
+ * `active`. That is precisely the lie the header of this file claims to
+ * prevent, in a dimension the file did not yet cover.
+ *
+ * `SELECT 1` is the cheapest question that distinguishes "the object still
+ * works" from "someone called end() on it" — an ended pool rejects it
+ * immediately, without I/O, so the common failure costs nothing. The timeout
+ * bounds the other case (a genuinely unreachable database) so a health probe
+ * can never hang the endpoint that is supposed to report the hang.
+ *
+ * Never throws: a health endpoint that 500s tells a load balancer far less
+ * than one that answers `degraded`.
+ */
+export async function probeGraphPool(
+  pool: unknown,
+  timeoutMs = 1000,
+): Promise<PoolProbe> {
+  if (!pool || typeof (pool as QueryablePool).query !== 'function') {
+    return { state: 'skipped' };
+  }
+  // The timer is cleared in `finally` rather than unref'd. Unref'ing looks
+  // tidier but takes the timer out of the event loop, so if the query never
+  // settles there is nothing left holding the process and the race is decided
+  // by whatever else happens to be running — which is exactly the case this
+  // timeout exists for.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      (pool as QueryablePool).query('SELECT 1'),
+      new Promise((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`pool probe timed out after ${String(timeoutMs)}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+    return { state: 'live' };
+  } catch (err) {
+    return {
+      state: 'dead',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
 }
 
 /**
@@ -102,6 +173,7 @@ export interface KgHealth {
 export function buildKgHealth(
   registry: InstalledRegistry,
   gate?: EmbeddingGateStatus,
+  poolProbe?: PoolProbe,
 ): KgHealth {
   const isActive = (id: string): boolean => registry.get(id)?.status === 'active';
 
@@ -169,6 +241,20 @@ export function buildKgHealth(
     warnings.push(describeColumnMigration(gate));
   }
 
+  // #665. Only meaningful for neon — the inmemory backend has no pool, and
+  // `none` has nothing to probe. Reported before the other warnings because a
+  // dead pool makes every capability above it academic: they describe what the
+  // deployment is CONFIGURED to do, this says whether it can do anything.
+  const pool: KgHealth['pool'] =
+    backend === 'neon' ? (poolProbe?.state ?? 'skipped') : 'skipped';
+  if (pool === 'dead') {
+    warnings.unshift(
+      `knowledge-graph pg pool is not usable${
+        poolProbe?.error ? ` (${poolProbe.error})` : ''
+      } — the process shares one pool across ~40 subsystems, so this is an outage, not a degradation; restart the instance`,
+    );
+  }
+
   return {
     backend,
     durable,
@@ -176,6 +262,7 @@ export function buildKgHealth(
     semanticRecall,
     durableTier,
     processReuse,
+    pool,
     warnings,
   };
 }

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -238,6 +238,7 @@ import { PluginCatalog } from './plugins/manifestLoader.js';
 import {
   EMBEDDING_GATE_STATUS_SERVICE,
   buildKgHealth,
+  probeGraphPool,
   type EmbeddingGateStatus,
 } from './health/kgHealth.js';
 import { FileInstalledRegistry } from './plugins/fileInstalledRegistry.js';
@@ -2438,10 +2439,24 @@ async function main(): Promise<void> {
     // model/dimension gate actually let the knowledge-graph write vectors, so
     // the gate outcome is read here too. Resolved per request rather than
     // captured at boot: plugins can be toggled at runtime.
-    const gate = serviceRegistry.get<EmbeddingGateStatus>(
-      EMBEDDING_GATE_STATUS_SERVICE,
-    );
-    res.json({ status: 'ok', kg: buildKgHealth(installedRegistry, gate) });
+    //
+    // #665 — everything above is a projection of the REGISTRY, so it could not
+    // see the instance being dead: the KG plugin ended the process-wide pg
+    // pool, every query started failing, and this endpoint still answered
+    // `ok` because the registry entry said `active`. The pool is now asked
+    // directly. Async because that is a query; it is bounded by its own
+    // timeout and never throws, so /health cannot hang or 500 on it.
+    void (async (): Promise<void> => {
+      const gate = serviceRegistry.get<EmbeddingGateStatus>(
+        EMBEDDING_GATE_STATUS_SERVICE,
+      );
+      const probe = await probeGraphPool(serviceRegistry.get('graphPool'));
+      const kg = buildKgHealth(installedRegistry, gate, probe);
+      // A dead pool is not a degradation to report at 200 — nothing in the
+      // process can serve a request. 503 is what a load balancer needs to see.
+      const status = kg.pool === 'dead' ? 'error' : 'ok';
+      res.status(kg.pool === 'dead' ? 503 : 200).json({ status, kg });
+    })();
   });
 
   // Friction-free pairing discovery (#293). Public-by-design (lives outside

--- a/middleware/test/kgHealth.test.ts
+++ b/middleware/test/kgHealth.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { buildKgHealth } from '../src/health/kgHealth.js';
+import { buildKgHealth, probeGraphPool } from '../src/health/kgHealth.js';
 import type { EmbeddingGateStatus } from '../src/health/kgHealth.js';
 import type { InstalledRegistry } from '../src/plugins/installedRegistry.js';
 import { InMemoryInstalledRegistry } from '../src/plugins/installedRegistry.js';
@@ -232,5 +232,114 @@ describe('buildKgHealth', () => {
       'one warning, not two — the operator has no provider to un-block',
     );
     assert.ok(h.warnings.some((w) => w.includes('embeddings disabled')));
+  });
+});
+
+/**
+ * #665 — the pool dimension.
+ *
+ * Everything above projects the REGISTRY, which is why the outage in #665 was
+ * invisible here: the plugin ended the process-wide pg pool, every query in
+ * the process failed, and this snapshot still reported a healthy neon backend
+ * because the registry entry said `active`. These cases pin the one field that
+ * can contradict the registry.
+ */
+describe('buildKgHealth — pg pool liveness (#665)', () => {
+  it('reports the pool dead and leads with it, so it cannot read as a degradation', async () => {
+    const h = buildKgHealth(await reg([{ id: KG_NEON }]), undefined, {
+      state: 'dead',
+      error: 'Cannot use a pool after calling end on the pool',
+    });
+    assert.equal(h.pool, 'dead');
+    // First, not merely present: the capability warnings below it describe what
+    // the deployment is configured to do, which is academic once nothing runs.
+    assert.ok(
+      h.warnings[0]?.includes('pg pool is not usable'),
+      'the outage must be the first warning',
+    );
+    assert.ok(
+      h.warnings[0]?.includes('Cannot use a pool after calling end on the pool'),
+      'the underlying error belongs in the payload — it names the cause',
+    );
+  });
+
+  it('reports a live pool without adding noise', async () => {
+    const h = buildKgHealth(
+      await reg([
+        { id: KG_NEON },
+        { id: EMBEDDINGS, config: { ollama_base_url: 'http://ollama:11434' } },
+      ]),
+      undefined,
+      { state: 'live' },
+    );
+    assert.equal(h.pool, 'live');
+    assert.deepEqual(h.warnings, [], 'a healthy pool says nothing');
+  });
+
+  it('skips the pool for backends that do not have one', async () => {
+    const h = buildKgHealth(await reg([{ id: KG_INMEMORY }]), undefined, {
+      state: 'dead',
+    });
+    // inmemory has no pg pool, so a probe result must not be projected onto it
+    // as a fault — otherwise every inmemory deployment reports an outage.
+    assert.equal(h.pool, 'skipped');
+    assert.ok(!h.warnings.some((w) => w.includes('pg pool is not usable')));
+  });
+
+  it('treats a missing probe as skipped rather than healthy', async () => {
+    const h = buildKgHealth(await reg([{ id: KG_NEON }]));
+    assert.equal(
+      h.pool,
+      'skipped',
+      'no probe is not evidence of health — it must not claim `live`',
+    );
+  });
+});
+
+describe('probeGraphPool (#665)', () => {
+  it('calls the pool and reports live', async () => {
+    let asked = '';
+    const probe = await probeGraphPool({
+      query: async (sql: string) => {
+        asked = sql;
+        return { rows: [] };
+      },
+    });
+    assert.deepEqual(probe, { state: 'live' });
+    assert.equal(asked, 'SELECT 1', 'the cheapest question that still proves usability');
+  });
+
+  it('reports dead with the pg error text when the pool was ended', async () => {
+    const probe = await probeGraphPool({
+      query: async () => {
+        throw new Error('Cannot use a pool after calling end on the pool');
+      },
+    });
+    assert.equal(probe.state, 'dead');
+    assert.equal(probe.error, 'Cannot use a pool after calling end on the pool');
+  });
+
+  it('skips when there is no pool at all', async () => {
+    assert.deepEqual(await probeGraphPool(undefined), { state: 'skipped' });
+    assert.deepEqual(await probeGraphPool({}), { state: 'skipped' });
+  });
+
+  it('bounds a hanging pool instead of hanging /health with it', async () => {
+    const started = Date.now();
+    const probe = await probeGraphPool(
+      {
+        query: () =>
+          new Promise(() => {
+            /* never settles — an unreachable database */
+          }),
+      },
+      50,
+    );
+    assert.equal(probe.state, 'dead');
+    assert.ok(probe.error?.includes('timed out'));
+    assert.ok(
+      Date.now() - started < 2000,
+      'the probe must return on its own timeout, not wait for the query',
+    );
   });
 });

--- a/middleware/test/kgPluginPoolLifetime.pg.test.ts
+++ b/middleware/test/kgPluginPoolLifetime.pg.test.ts
@@ -1,0 +1,175 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { Pool } from 'pg';
+
+import { probePgTest } from './_helpers/pgTestDb.js';
+
+import { activate } from '@omadia/knowledge-graph-neon/dist/plugin.js';
+import { InstallService } from '../src/plugins/installService.js';
+
+/**
+ * Issue #665 — the knowledge-graph plugin must not end the pg pool the whole
+ * process is using.
+ *
+ * WHAT WENT WRONG
+ * ---------------
+ * This plugin CREATES the pool, so ending it in `close()` reads as correct
+ * ownership. It is not, because `close()` is not a process-exit path: it also
+ * runs on every deactivate and on the reactivate the config editor fires after
+ * any settings save. The kernel resolves `graphPool` ONCE at boot
+ * (`src/index.ts`) and hands that same object to ~40 subsystems that never
+ * re-resolve it. So `await graphPool.end()` did not release "our" pool — it
+ * killed the one everything else still held, and every later query failed with
+ * `Cannot use a pool after calling end on the pool` until the machine was
+ * restarted. `/health` reported `ok` throughout.
+ *
+ * WHY THIS TEST IS SHAPED LIKE THIS
+ * ---------------------------------
+ * The oracle is a QUERY, not a flag. Asserting on a spy or on some `ended`
+ * property would pass against a plugin that still ends a pool it merely
+ * stopped handing out. The only question that matters is whether the object
+ * the kernel is holding still works, so that is what is asked.
+ *
+ * The pool is not injected — the plugin builds its own via `createNeonPool`.
+ * It is captured from `ctx.services.provide('graphPool', …)`, which is exactly
+ * how the kernel gets it, so the test holds the same reference index.ts does.
+ *
+ * MUTATION CHECK (run it before trusting this file): restore
+ * `await graphPool.end()` in the plugin's `close()` and both cases below must
+ * go red. If they stay green the test is decorative.
+ *
+ * The suite owns its own schema and tenant: the registry advisory lock is
+ * database-wide, so sharing either with a sibling suite deadlocks under the
+ * parallel runner.
+ */
+
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'kgPluginPoolLifetime',
+  vars: ['KG_POOL_PG_TEST_URL', 'GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL'],
+  requireVector: true,
+});
+
+const KG_ID = '@omadia/knowledge-graph-neon';
+
+/** Minimal PluginContext — the plugin only touches these six members. */
+function makeCtx(captured: { pool?: Pool }): {
+  ctx: unknown;
+  provided: string[];
+} {
+  const provided: string[] = [];
+  const ctx = {
+    log: (): void => {
+      /* quiet */
+    },
+    secrets: {
+      get: async (key: string): Promise<string | undefined> =>
+        key === 'database_url' ? PG_URL : undefined,
+    },
+    config: {
+      // Everything optional. Embeddings stay off, so the gate parks itself and
+      // no Ollama/OpenAI call is attempted — this suite is about the pool.
+      get: (): undefined => undefined,
+    },
+    services: {
+      get: (): undefined => undefined,
+      provide: (name: string, value: unknown): (() => void) => {
+        provided.push(name);
+        if (name === 'graphPool') captured.pool = value as Pool;
+        return () => {
+          /* dispose */
+        };
+      },
+    },
+    jobs: {
+      register: (): (() => void) => () => {
+        /* dispose */
+      },
+    },
+  };
+  return { ctx, provided };
+}
+
+// Skipping is per-test via `t.skip()`, not a `before` hook: this file matches
+// the plain `test/**/*.test.ts` glob as well as `test:pg`, so it runs in the
+// no-database step too and must self-skip there. A suite-level hook cannot —
+// `SuiteContext` has no `skip()`, and calling it throws the suite red.
+describe('#665 — KG plugin close() must not end the shared pg pool', () => {
+  it('leaves the pool the kernel holds usable after close()', async (t) => {
+    if (!pgAvailable) return t.skip('no test Postgres');
+
+    const captured: { pool?: Pool } = {};
+    const { ctx, provided } = makeCtx(captured);
+
+    const handle = await activate(ctx as never);
+
+    // Guard the guard: if the plugin ever stops publishing the pool this way,
+    // `captured.pool` would be undefined and every assertion below would
+    // vacuously pass. Fail loudly instead.
+    assert.ok(
+      provided.includes('graphPool'),
+      'plugin must still publish graphPool — otherwise this test proves nothing',
+    );
+    const pool = captured.pool;
+    assert.ok(pool, 'graphPool was published but not captured');
+
+    // Sanity: the pool works BEFORE close(), so a failure after it means
+    // close() did it, not a broken fixture.
+    await pool.query('SELECT 1');
+
+    await handle.close();
+
+    // The oracle. With `graphPool.end()` restored this throws
+    // `Cannot use a pool after calling end on the pool`.
+    const after = await pool.query<{ ok: number }>('SELECT 1 AS ok');
+    assert.equal(
+      after.rows[0]?.ok,
+      1,
+      'the pool the kernel shares with ~40 subsystems must survive close()',
+    );
+
+    await pool.end();
+  });
+
+  it('survives the reactivate() path every admin route funnels through', async (t) => {
+    if (!pgAvailable) return t.skip('no test Postgres');
+
+    const captured: { pool?: Pool } = {};
+    const { ctx } = makeCtx(captured);
+    const handle = await activate(ctx as never);
+    const pool = captured.pool;
+    assert.ok(pool);
+
+    // Every unprotected call site in #665 — adminSettings.ts, adminProviders.ts,
+    // runtime.ts (x3), auth.ts, selfExtension/service.ts, and the
+    // `reactivatePlugin` exposed to plugins from index.ts — reaches the plugin
+    // through this one method. Driving it once therefore covers all of them,
+    // and doing it through the REAL InstallService keeps that true if the
+    // funnel is ever rewired.
+    let reactivations = 0;
+    const service = new InstallService({
+      catalog: { list: () => [], get: () => undefined } as never,
+      registry: { has: (id: string) => id === KG_ID } as never,
+      vault: {} as never,
+      onUninstall: async (): Promise<void> => {
+        await handle.close();
+      },
+      onInstalled: async (): Promise<void> => {
+        reactivations += 1;
+      },
+    } as never);
+
+    await service.reactivate(KG_ID);
+
+    assert.equal(reactivations, 1, 'reactivate must have driven the full hook pair');
+
+    const after = await pool.query<{ ok: number }>('SELECT 1 AS ok');
+    assert.equal(
+      after.rows[0]?.ok,
+      1,
+      'a config save must not take the process-wide pool down with it',
+    );
+
+    await pool.end();
+  });
+});


### PR DESCRIPTION
Closes #665

Two defects. The third one in the issue (`chat.errorMiddlewareUnreachable`) is deliberately **not** here — filed separately as #667, because it is a different component and would have made this diff hard to review.

All five facts in the issue were re-confirmed against current `main` before touching anything; line numbers had shifted since it was written.

## P0 — the pool

The plugin **creates** the pool, so ending it in `close()` reads as correct ownership. It is not, and the reason is one sentence: **`close()` is not a process-exit path.** It also runs on every deactivate and on the reactivate the config editor fires after any settings save.

The kernel resolves `graphPool` **once** at boot (`src/index.ts`) and hands that object to ~40 subsystems that never re-resolve it. So `await graphPool.end()` never released "our" pool — it killed the one the whole process was still holding. Every later query failed with `Cannot use a pool after calling end on the pool`, until the machine was restarted.

Dropping the reference without ending it is the contract `memory-postgres` already documents:

> The pool is owned by the graphPool provider — do NOT call pool.end() here.

The KG plugin was the outlier.

### One thing this PR does not hide

Not ending the pool means a **reactivate leaves the previous pool open**, because `activate()` always builds a fresh one. That is a bounded leak on an operator-initiated action, and it is strictly better than a live outage — but it is real, it is written into the code comment, and it is the reason `activate()` should eventually reuse an already-provided pool instead of always creating one. I did not do that here because it widens the change well past the outage.

### The test, and why it is shaped this way

- **The oracle is a query, not a flag.** Asserting on a spy or an `ended` property would pass against a plugin that ends a pool it merely stopped handing out. The only question that matters is whether the object the kernel holds still works, so the test asks it.
- **The pool is not injected** — the plugin builds its own via `createNeonPool`. It is captured from `ctx.services.provide('graphPool', …)`, i.e. the same way the kernel gets it, so the test holds the same reference `index.ts` does. If the plugin ever stops publishing it, the test fails loudly rather than passing vacuously.
- **All eight unprotected call sites funnel through one method.** Verified rather than assumed: `adminSettings.ts:326`, `adminProviders.ts:516`, `runtime.ts:197/341/552`, `auth.ts:489`, `selfExtension/service.ts:104`, and the `reactivatePlugin` exposed from `index.ts` all reach the plugin via `InstallService.reactivate`. The second case drives that method on the **real** service, so the coverage claim stays true if the funnel is rewired — better than restating the list in a comment.

### Mutation check (the part that makes the test worth anything)

Restoring `await graphPool.end()` and rebuilding `dist/`:

```
✖ leaves the pool the kernel holds usable after close()
  Error: Cannot use a pool after calling end on the pool
✖ survives the reactivate() path every admin route funnels through
  Error: Cannot use a pool after calling end on the pool
```

Both red, with the production error text. Restored → both green.

Also corrected: the file header still said `close()` reverses activate by *"drain Pool with end()"*. That is instructions for reintroducing the bug.

**Prior art worth knowing:** `test/embeddingGateReevaluation.pg.test.ts` already documents this exact hazard and spies on `end()` for the provider-switch path. So the danger was known and worked around locally, but the cause was left in the plugin — which is why every *other* reactivate path stayed lethal.

## P1 — /health could not see it

Every field `/health` reports is a projection of the **registry**: what was installed, and what the #440 gate decided. Nothing touched the database. So the outage was structurally invisible — the registry entry said `active`, so the endpoint said `ok`, while no request in the process could be served.

The header of `kgHealth.ts` describes exactly this failure mode for a different dimension:

> A registry-only projection reports that as fully healthy, i.e. it reproduces exactly the lie this file exists to prevent.

Now:

- `probeGraphPool()` runs `SELECT 1` — the cheapest question that separates "the object works" from "someone called `end()` on it". An ended pool rejects it immediately with no I/O, so the common case is free.
- Bounded by its own timeout and **never throws**: a health endpoint that hangs or 500s tells a load balancer less than one that answers `degraded`. (The timer is cleared in `finally`, not `unref`'d — unref'ing removes it from the event loop, so a never-settling query would leave the race to be decided by whatever else happens to be running. That was caught by the timeout test itself.)
- `pool: 'live' | 'dead' | 'skipped'` in the payload, `skipped` for inmemory/none — those have no pool, and projecting a fault onto them would make every inmemory deployment report an outage.
- A **missing** probe is `skipped`, never `live`. No evidence is not evidence of health.
- The outage **leads** the warnings, because the capability warnings below it describe what the deployment is configured to do, which is academic once nothing runs.
- `503`, not `200`, when the pool is dead.

Four mutations of that logic are covered: probe always-live, warning no longer first, pool state projected onto inmemory, missing probe read as live — each turns the suite red.

## Verification

| Gate | Result |
|---|---|
| build | ✅ |
| `npm test` | **6184 tests, 0 fail**, 6 skipped |
| `npm run test:pg` (real pgvector) | **240 tests, 0 fail, 0 skipped** |
| lint / typecheck | ✅ / ✅ |
| `typecheck:test` ratchet | 406, unchanged — no new debt |
| decoupling ratchet | held at 3288 |
| `test:filetimes` (#566) | 573 files, 21.3× headroom |

`PG_TEST_FLOOR` raised 238 → 240 for the two new Postgres tests, per the convention in that step's comment.

The new suite is `.pg.test.ts`, which the plain `test/**/*.test.ts` glob also matches, so it must self-skip cleanly in the no-database step. Both modes are verified: **2 skipped / exit 0** without a DB, **2 passed** with one. (Skipping is per-test via `t.skip()`; a `before` hook cannot do it — `SuiteContext` has no `skip()` and calling it throws the suite red. That bit me first.)

The collision warning in the plan about PR #557 no longer applies — #557 merged, and this branch is on current `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789125530&installation_model_id=428086&pr_number=668&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F668&signature=7dd1d3b3f2b2512132118a76cb49b058ea0f34f0da90881f51208be0e4aa4279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->