### PR TITLE
fix(#561): fence the orphan-sweep metric at the store, not the schedule

### DIFF
--- a/middleware/packages/harness-orchestrator/src/tasks/inMemoryTaskStore.ts
+++ b/middleware/packages/harness-orchestrator/src/tasks/inMemoryTaskStore.ts
@@ -278,6 +278,16 @@ export class InMemoryTaskStore implements TaskStore {
    * immutability in `fenced()` is load-bearing rather than redundant: it is what
    * a zombie worker (which still presents a MATCHING lease, because the sweep
    * preserves `claimedBy`) runs into afterwards.
+   *
+   * Cross-replica note (#561): this store is process-local, so its `rows` Map has
+   * exactly ONE writer and the sweep cannot race a peer — each stale row is
+   * flipped here by this process alone, so `staleFailed` counts it exactly once
+   * by construction, with no fencing needed. That is a property of being
+   * single-replica, NOT of the sweep being safe to run everywhere: run two
+   * replicas against this store and they have DISJOINT maps, so a task created on
+   * one is `not found` on the other (see the module header) — a multi-replica
+   * deployment needs the durable implementor, whose reaper is fenced across
+   * replicas by the guarded terminal write reporting who actually flipped the row.
    */
   async reapOrphans(opts: TaskReapOptions): Promise<TaskReapResult> {
     if (!Number.isFinite(opts.staleAfterMs) || opts.staleAfterMs <= 0) {

--- a/middleware/packages/harness-orchestrator/src/tasks/taskReaper.ts
+++ b/middleware/packages/harness-orchestrator/src/tasks/taskReaper.ts
@@ -85,6 +85,17 @@ export async function runTaskReaperOnce(
  * implementor can back it, and there a slow sweep would stack concurrent
  * transactions contending on the same rows. The guard is cheaper than relying
  * on every future implementor being fast.
+ *
+ * Scope of this guard (#561): it is PER-PROCESS. Two replicas each run their own
+ * `startTaskReaper`, so nothing here stops them sweeping the same rows at once —
+ * and deliberately so. Cross-replica safety is the STORE's job, not the
+ * schedule's: the terminal write is idempotent (a status-guarded UPDATE), and
+ * the reap metric is idempotent too because `reapOrphans` counts only the rows
+ * whose flip its own call performed. So concurrent replica sweeps converge on
+ * the same terminal state and each stale row is counted once, without a
+ * distributed lock. An implementor that additionally wants to avoid the wasted
+ * double-scan may take an advisory lock inside its own `reapOrphans`; the
+ * schedule neither needs nor provides one.
  */
 export function startTaskReaper(
   store: TaskStore,

--- a/middleware/src/devplatform/devJobStore.ts
+++ b/middleware/src/devplatform/devJobStore.ts
@@ -83,7 +83,7 @@ export interface TerminalPatch {
  *
  * `job` is the post-write state (the freshly-flipped row, the pre-existing
  * terminal row on a no-op, or `null` when the id is absent) — unchanged from the
- * old `DevJob | null` return, so callers that only need the state read `.job`.
+ * old nullable-job return, so callers that only need the state read `.job`.
  *
  * `transitioned` is the load-bearing addition: `true` ONLY when THIS call
  * performed the status flip (the guarded UPDATE matched a row). It is `false`
@@ -91,7 +91,8 @@ export interface TerminalPatch {
  * writer (another replica's reaper, a cancel route) flipped a moment earlier.
  * The guarded UPDATE is the only place in the system that knows this; collapsing
  * it into a plain truthy job is what let the orphan sweep double-count a row a
- * second replica had already reaped (#561). See `finalizeDevJob`.
+ * second replica had already reaped (#561). See the terminal-transition choke
+ * point that wraps this call.
  */
 export interface TerminalWriteResult {
   readonly job: DevJob | null;

--- a/middleware/src/devplatform/devJobStore.ts
+++ b/middleware/src/devplatform/devJobStore.ts
@@ -78,6 +78,26 @@ export interface TerminalPatch {
   prUrl?: string | null;
 }
 
+/**
+ * The outcome of a `finishTerminal` call.
+ *
+ * `job` is the post-write state (the freshly-flipped row, the pre-existing
+ * terminal row on a no-op, or `null` when the id is absent) — unchanged from the
+ * old `DevJob | null` return, so callers that only need the state read `.job`.
+ *
+ * `transitioned` is the load-bearing addition: `true` ONLY when THIS call
+ * performed the status flip (the guarded UPDATE matched a row). It is `false`
+ * for an idempotent no-op — an already-terminal row, including one a CONCURRENT
+ * writer (another replica's reaper, a cancel route) flipped a moment earlier.
+ * The guarded UPDATE is the only place in the system that knows this; collapsing
+ * it into a plain truthy job is what let the orphan sweep double-count a row a
+ * second replica had already reaped (#561). See `finalizeDevJob`.
+ */
+export interface TerminalWriteResult {
+  readonly job: DevJob | null;
+  readonly transitioned: boolean;
+}
+
 /** Shared with `devJobWorkerSeams.ts` (worker-seam bodies live there for the
  *  500-line rule); not part of the public store API. */
 export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -951,13 +971,19 @@ export class DevJobStore {
    * UPDATE touches 0 rows and the existing row is returned unchanged, so a
    * double-finalize is a no-op, not an error. NOT lease-fenced: cancel routes
    * and the reaper legitimately finalize jobs they do not lease.
+   *
+   * Returns a {@link TerminalWriteResult}: `job` is the post-write state (as
+   * before), and `transitioned` reports whether THIS call did the flip — `true`
+   * only when the guarded UPDATE matched a row, `false` for any no-op including a
+   * row a concurrent replica flipped first. That flag is the fence the sweep
+   * metric needs; see the type doc and #561.
    */
   async finishTerminal(
     brand: typeof TERMINAL_FINISH_BRAND,
     jobId: string,
     status: DevJobStatus,
     patch: TerminalPatch = {},
-  ): Promise<DevJob | null> {
+  ): Promise<TerminalWriteResult> {
     if (brand !== TERMINAL_FINISH_BRAND) {
       throw new Error('devplatform: finishTerminal() is reserved for finalizeDevJob()');
     }
@@ -983,8 +1009,11 @@ export class DevJobStore {
         patch.prUrl ?? null,
       ],
     );
-    if (r.rows[0]) return toJob(r.rows[0]);
-    // Already terminal or absent — idempotent no-op, return existing state.
-    return this.getJob(jobId);
+    // A matched row ⇒ THIS call flipped it. `RETURNING` gives the new state.
+    if (r.rows[0]) return { job: toJob(r.rows[0]), transitioned: true };
+    // 0 rows ⇒ already terminal or absent — idempotent no-op. Return the
+    // existing state (unchanged from the old contract) and, crucially, report
+    // `transitioned: false` so the caller does not count a row it did not reap.
+    return { job: await this.getJob(jobId), transitioned: false };
   }
 }

--- a/middleware/src/devplatform/devJobTaskStore.ts
+++ b/middleware/src/devplatform/devJobTaskStore.ts
@@ -61,6 +61,7 @@ import {
 } from '@omadia/orchestrator';
 
 import type { DevJobSweepScope, ListJobsFilter } from './devJobStore.js';
+import type { FinalizeResult } from './finalizeDevJob.js';
 import type {
   DevJob,
   DevJobEvent,
@@ -168,15 +169,19 @@ export interface DevJobTaskStoreDeps {
    */
   readonly createJob: (input: unknown) => Promise<DevJob>;
   /**
-   * The terminal transition. Bound to `finalizeDevJob` so the brand-gated single
-   * choke point is preserved: this adapter cannot and does not call
-   * `DevJobStore.finishTerminal` itself.
+   * The terminal transition. Bound to `finalizeDevJobDetailed` so the brand-gated
+   * single choke point is preserved (this adapter cannot and does not call
+   * `DevJobStore.finishTerminal` itself) AND the sweep can tell whether IT
+   * reaped a row: `transitioned` is `true` only for the call that flipped the
+   * status. Counting a truthy `job` instead double-counted rows a second replica
+   * had already reaped, because the terminal write is idempotent but the metric
+   * was not (#561).
    */
   readonly finalize: (
     jobId: string,
     status: DevJobStatus,
     patch: { error?: string },
-  ) => Promise<DevJob | null>;
+  ) => Promise<FinalizeResult>;
   /** Terminal-row purge, bound to `DevRetentionRunner.purgeTerminalJobs`. */
   readonly purgeTerminalJobs?: (
     olderThanDays: number,
@@ -328,7 +333,7 @@ export function createDevJobTaskStore(deps: DevJobTaskStoreDeps): TaskStore {
     ): Promise<TaskDescriptor> {
       await fenced(id, lease);
       const devStatus: DevJobStatus = patch.status === 'completed' ? 'done' : 'failed';
-      const job = await deps.finalize(id, devStatus, {
+      const { job } = await deps.finalize(id, devStatus, {
         ...(patch.error !== undefined ? { error: patch.error } : {}),
       });
       if (!job) throw new TaskLeaseLostError(id);
@@ -353,12 +358,18 @@ export function createDevJobTaskStore(deps: DevJobTaskStoreDeps): TaskStore {
       );
       let staleFailed = 0;
       for (const job of stalled) {
-        const finished = await deps.finalize(job.id, 'stalled', {
+        // Count ONLY when this call did the flip. `findStalled` on two replicas
+        // returns the same row; whichever finalize wins the guarded UPDATE gets
+        // `transitioned: true`, the loser gets a truthy-but-already-terminal
+        // `job` and `transitioned: false`. Gating on the flag makes the metric
+        // idempotent across replicas the same way the terminal write already is
+        // (#561) — the row a peer reaped a moment earlier is not re-counted.
+        const { transitioned } = await deps.finalize(job.id, 'stalled', {
           error:
             'task abandoned: no worker heartbeat within the orphan window ' +
             '(worker crashed, restarted, or was never started)',
         });
-        if (finished) staleFailed += 1;
+        if (transitioned) staleFailed += 1;
       }
       const purged = deps.purgeTerminalJobs
         ? await deps.purgeTerminalJobs(

--- a/middleware/src/devplatform/finalizeDevJob.ts
+++ b/middleware/src/devplatform/finalizeDevJob.ts
@@ -13,7 +13,11 @@
  * than retrofitting the transition logic across every caller (spec §4).
  */
 
-import { TERMINAL_FINISH_BRAND, type TerminalPatch } from './devJobStore.js';
+import {
+  TERMINAL_FINISH_BRAND,
+  type TerminalPatch,
+  type TerminalWriteResult,
+} from './devJobStore.js';
 import {
   isTerminalDevJobStatus,
   type DevJob,
@@ -67,7 +71,7 @@ export interface FinalizeStore {
     jobId: string,
     status: DevJobStatus,
     patch?: TerminalPatch,
-  ): Promise<DevJob | null>;
+  ): Promise<TerminalWriteResult>;
   appendHostEvent(
     jobId: string,
     type: DevJobEventType,
@@ -111,25 +115,40 @@ function toRegistry(revokers: FinalizeDevJobDeps['revokers']): CredentialRevoker
 }
 
 /**
- * Transition a job to a terminal `status`, idempotently. Returns the finalized
- * job (or `null` if it does not exist). Calling it on an already-terminal job
- * returns that job unchanged with no side effects.
+ * What a terminal transition did — the finalized `job` (or `null` if it does not
+ * exist) plus whether THIS call performed the flip.
+ *
+ * `transitioned` is `true` only when this call moved a live job to `status`, and
+ * `false` for every no-op: an already-terminal job, or one a CONCURRENT finalize
+ * (another replica's reaper, a cancel route) terminalized first — even to the
+ * SAME status. A caller that keeps a per-sweep count must gate on this, not on
+ * the truthiness of `job`, or it double-counts a row another replica reaped.
  */
-export async function finalizeDevJob(
+export interface FinalizeResult {
+  readonly job: DevJob | null;
+  readonly transitioned: boolean;
+}
+
+/**
+ * Transition a job to a terminal `status`, idempotently, and report whether THIS
+ * call did the flip. This is the real implementation; {@link finalizeDevJob} is
+ * the thin state-only wrapper every caller that does not need the count uses.
+ */
+export async function finalizeDevJobDetailed(
   deps: FinalizeDevJobDeps,
   jobId: string,
   status: DevJobStatus,
   ctx: FinalizeContext = {},
-): Promise<DevJob | null> {
+): Promise<FinalizeResult> {
   if (!isTerminalDevJobStatus(status)) {
     throw new TypeError(`finalizeDevJob: '${status}' is not a terminal status`);
   }
 
   const before = await deps.store.getJob(jobId);
-  if (!before) return null;
+  if (!before) return { job: null, transitioned: false };
   // Already terminal ⇒ idempotent no-op. No status flip, no event, no revoke,
   // no terminate — this is what makes a double-finalize safe.
-  if (isTerminalDevJobStatus(before.status)) return before;
+  if (isTerminalDevJobStatus(before.status)) return { job: before, transitioned: false };
 
   const patch: TerminalPatch = {
     error: ctx.error ?? null,
@@ -137,13 +156,21 @@ export async function finalizeDevJob(
     branch: ctx.branch ?? null,
     prUrl: ctx.prUrl ?? null,
   };
-  const after = await deps.store.finishTerminal(TERMINAL_FINISH_BRAND, jobId, status, patch);
-  if (!after) return before;
+  const { job: after, transitioned } = await deps.store.finishTerminal(
+    TERMINAL_FINISH_BRAND,
+    jobId,
+    status,
+    patch,
+  );
+  if (!after) return { job: before, transitioned: false };
 
-  // Run side effects only when THIS call performed the flip. If a concurrent
-  // finalize won with a different terminal status, `after.status` reflects
-  // theirs and we skip — they already ran the side effects.
-  if (after.status === status) {
+  // Run side effects only when THIS call performed the flip. The flag comes from
+  // the guarded UPDATE itself, so a concurrent finalize that won — even with the
+  // SAME status (two replicas both reaping to `stalled`) — leaves `transitioned`
+  // false here and we skip: they already ran the side effects. The old
+  // `after.status === status` gate could not see that same-status race and let
+  // the loser append a duplicate status event.
+  if (transitioned) {
     try {
       await deps.store.appendHostEvent(jobId, 'status', {
         status,
@@ -171,5 +198,23 @@ export async function finalizeDevJob(
     }
   }
 
-  return after;
+  return { job: after, transitioned };
+}
+
+/**
+ * Transition a job to a terminal `status`, idempotently. Returns the finalized
+ * job (or `null` if it does not exist). Calling it on an already-terminal job
+ * returns that job unchanged with no side effects.
+ *
+ * State-only wrapper over {@link finalizeDevJobDetailed}. A caller that needs to
+ * know whether THIS call performed the flip (e.g. the orphan sweep, to count a
+ * row exactly once cluster-wide) must call the detailed form.
+ */
+export async function finalizeDevJob(
+  deps: FinalizeDevJobDeps,
+  jobId: string,
+  status: DevJobStatus,
+  ctx: FinalizeContext = {},
+): Promise<DevJob | null> {
+  return (await finalizeDevJobDetailed(deps, jobId, status, ctx)).job;
 }

--- a/middleware/src/devplatform/finalizeDevJob.ts
+++ b/middleware/src/devplatform/finalizeDevJob.ts
@@ -131,8 +131,8 @@ export interface FinalizeResult {
 
 /**
  * Transition a job to a terminal `status`, idempotently, and report whether THIS
- * call did the flip. This is the real implementation; {@link finalizeDevJob} is
- * the thin state-only wrapper every caller that does not need the count uses.
+ * call did the flip. This is the real implementation; the thin state-only
+ * wrapper below is what every caller that does not need the count uses.
  */
 export async function finalizeDevJobDetailed(
   deps: FinalizeDevJobDeps,
@@ -206,7 +206,7 @@ export async function finalizeDevJobDetailed(
  * job (or `null` if it does not exist). Calling it on an already-terminal job
  * returns that job unchanged with no side effects.
  *
- * State-only wrapper over {@link finalizeDevJobDetailed}. A caller that needs to
+ * State-only wrapper over the detailed form above. A caller that needs to
  * know whether THIS call performed the flip (e.g. the orphan sweep, to count a
  * row exactly once cluster-wide) must call the detailed form.
  */

--- a/middleware/test/devplatform/devJobStore.pg.test.ts
+++ b/middleware/test/devplatform/devJobStore.pg.test.ts
@@ -321,14 +321,17 @@ describe('devplatform/DevJobStore (pg)', { skip: !pgAvailable }, () => {
       prUrl: 'https://example.com/pr/1',
       branch: 'omadia/job-x',
     });
-    assert.equal(done?.status, 'done');
-    assert.equal(done?.prUrl, 'https://example.com/pr/1');
-    assert.ok(done?.endedAt, 'ended_at stamped');
+    assert.equal(done.transitioned, true, 'the first call performed the flip');
+    assert.equal(done.job?.status, 'done');
+    assert.equal(done.job?.prUrl, 'https://example.com/pr/1');
+    assert.ok(done.job?.endedAt, 'ended_at stamped');
 
-    // Second call on an already-terminal job is a no-op returning existing state.
+    // Second call on an already-terminal job is a no-op returning existing state,
+    // and reports transitioned:false so a caller counting reaps does not count it.
     const again = await store.finishTerminal(TERMINAL_FINISH_BRAND, job.id, 'failed', { error: 'x' });
-    assert.equal(again?.status, 'done', 'idempotent — status unchanged, not flipped to failed');
-    assert.equal(again?.error, null, 'the no-op did not write the failure error');
+    assert.equal(again.transitioned, false, 'the no-op did not flip anything');
+    assert.equal(again.job?.status, 'done', 'idempotent — status unchanged, not flipped to failed');
+    assert.equal(again.job?.error, null, 'the no-op did not write the failure error');
   });
 
   it('deleteJob refuses an active job, deletes a terminal one, and reports a missing id', async () => {

--- a/middleware/test/devplatform/devJobTaskStore.pg.test.ts
+++ b/middleware/test/devplatform/devJobTaskStore.pg.test.ts
@@ -14,6 +14,7 @@ import {
   DevJobStore,
   TERMINAL_FINISH_BRAND,
   type DevJobSweepScope,
+  type TerminalWriteResult,
 } from '../../src/devplatform/devJobStore.js';
 import {
   createDevJobTaskStore,
@@ -62,7 +63,7 @@ describe('devplatform/devJobTaskStore — seam conformance (pg)', { skip: !pgAva
     jobId: string,
     status: DevJobStatus,
     patch: { error?: string },
-  ): Promise<DevJob | null> {
+  ): Promise<TerminalWriteResult> {
     return jobStore.finishTerminal(TERMINAL_FINISH_BRAND, jobId, status, patch);
   }
 

--- a/middleware/test/devplatform/devJobTaskStoreReap.test.ts
+++ b/middleware/test/devplatform/devJobTaskStoreReap.test.ts
@@ -9,7 +9,7 @@ import {
   projectDevJobStatus,
   type DevJobTaskJobStore,
 } from '../../src/devplatform/devJobTaskStore.js';
-import type { DevJob, DevJobStatus } from '../../src/devplatform/types.js';
+import { isTerminalDevJobStatus, type DevJob, type DevJobStatus } from '../../src/devplatform/types.js';
 
 /**
  * W2-2 — the dev_job adapter's orphan sweep, isolated.
@@ -113,11 +113,17 @@ function harness(opts: {
         status,
         ...(patch.error !== undefined ? { error: patch.error } : {}),
       });
-      if (opts.finalizeReturnsNull) return null;
+      if (opts.finalizeReturnsNull) return { job: null, transitioned: false };
       const existing = byId.get(jobId) ?? job({ id: jobId });
+      // Model `finishTerminal`'s status-guarded UPDATE: a no-op on an
+      // already-terminal row (the row a peer replica flipped first), reporting
+      // `transitioned: false` so the sweep does not re-count it.
+      if (isTerminalDevJobStatus(existing.status)) {
+        return { job: existing, transitioned: false };
+      }
       const updated = job({ ...existing, status, error: patch.error ?? null });
       byId.set(jobId, updated);
-      return updated;
+      return { job: updated, transitioned: true };
     },
     purgeTerminalJobs: async (days, now) => {
       purgeCalls.push({ days, now });
@@ -218,13 +224,34 @@ describe('devplatform/devJobTaskStore — orphan sweep', () => {
       createJob: async () => {
         throw new Error('unused');
       },
-      finalize: async () => null,
+      finalize: async () => ({ job: null, transitioned: false }),
     });
     const r = await store.reapOrphans({
       staleAfterMs: 1,
       purgeTerminalAfterMs: 1,
     });
     assert.deepEqual(r, { staleFailed: 0, purged: 0 });
+  });
+
+  it('does not double-count a row a peer replica already reaped (#561)', async () => {
+    // Two replicas' `findStalled` return the SAME non-terminal row (both queried
+    // before either wrote). The first sweep flips it and counts it; the second's
+    // finalize hits the guarded no-op — a truthy but already-terminal `job` — and
+    // must NOT count it. The terminal write is idempotent; so now is the metric.
+    const a = job();
+    const h = harness({ stalled: [a], jobs: [a] });
+    const opts = {
+      now: new Date(1_000_000),
+      staleAfterMs: 1,
+      purgeTerminalAfterMs: 3_600_000,
+    };
+
+    const first = await h.store.reapOrphans(opts);
+    const second = await h.store.reapOrphans(opts);
+
+    assert.equal(first.staleFailed, 1, 'the replica that wins the flip counts the reap');
+    assert.equal(second.staleFailed, 0, 'the replica that loses the race counts nothing');
+    assert.equal(h.finalizeCalls.length, 2, 'but BOTH replicas attempted the finalize');
   });
 });
 

--- a/middleware/test/devplatform/devJobWorker.test.ts
+++ b/middleware/test/devplatform/devJobWorker.test.ts
@@ -1,7 +1,11 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { TERMINAL_FINISH_BRAND, type TerminalPatch } from '../../src/devplatform/devJobStore.js';
+import {
+  TERMINAL_FINISH_BRAND,
+  type TerminalPatch,
+  type TerminalWriteResult,
+} from '../../src/devplatform/devJobStore.js';
 import type { ApplyInput, ApplyResult } from '../../src/devplatform/diffApplyService.js';
 import type { FinalizeStore } from '../../src/devplatform/finalizeDevJob.js';
 import { RunnerBackendError } from '../../src/devplatform/runnerBackend.js';
@@ -219,12 +223,13 @@ class FakeStore implements DevJobWorkerStore {
     jobId: string,
     status: DevJobStatus,
     patch: TerminalPatch = {},
-  ): Promise<DevJob | null> {
+  ): Promise<TerminalWriteResult> {
     if (brand !== TERMINAL_FINISH_BRAND) throw new Error('finishTerminal reserved for finalizeDevJob');
     this.finishCalls.set(jobId, (this.finishCalls.get(jobId) ?? 0) + 1);
     const job = this.jobs.get(jobId);
-    if (!job) return null;
-    if (isTerminalDevJobStatus(job.status)) return job; // idempotent guard
+    if (!job) return { job: null, transitioned: false };
+    // Idempotent guard — a no-op reports transitioned:false, touches no rows.
+    if (isTerminalDevJobStatus(job.status)) return { job, transitioned: false };
     const next: DevJob = {
       ...job,
       status,
@@ -235,7 +240,7 @@ class FakeStore implements DevJobWorkerStore {
       endedAt: new Date().toISOString(),
     };
     this.jobs.set(jobId, next);
-    return next;
+    return { job: next, transitioned: true };
   }
 
   async appendHostEvent(jobId: string, type: string, payload: Record<string, unknown> = {}) {

--- a/middleware/test/devplatform/finalizeDevJob.test.ts
+++ b/middleware/test/devplatform/finalizeDevJob.test.ts
@@ -1,10 +1,15 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { TERMINAL_FINISH_BRAND, type TerminalPatch } from '../../src/devplatform/devJobStore.js';
+import {
+  TERMINAL_FINISH_BRAND,
+  type TerminalPatch,
+  type TerminalWriteResult,
+} from '../../src/devplatform/devJobStore.js';
 import {
   CredentialRevokerRegistry,
   finalizeDevJob,
+  finalizeDevJobDetailed,
   type FinalizeStore,
 } from '../../src/devplatform/finalizeDevJob.js';
 import { isTerminalDevJobStatus, type DevJob, type DevJobStatus, type RunnerHandle } from '../../src/devplatform/types.js';
@@ -70,12 +75,13 @@ class FakeStore implements FinalizeStore {
     jobId: string,
     status: DevJobStatus,
     patch: TerminalPatch = {},
-  ): Promise<DevJob | null> {
+  ): Promise<TerminalWriteResult> {
     this.finishCalls++;
     this.brandSeen = brand;
-    if (!this.job || this.job.id !== jobId) return null;
-    // Idempotent guard, exactly as the real UPDATE ... WHERE status NOT IN (terminal).
-    if (isTerminalDevJobStatus(this.job.status)) return this.job;
+    if (!this.job || this.job.id !== jobId) return { job: null, transitioned: false };
+    // Idempotent guard, exactly as the real UPDATE ... WHERE status NOT IN
+    // (terminal): a no-op reports `transitioned: false` and touches no rows.
+    if (isTerminalDevJobStatus(this.job.status)) return { job: this.job, transitioned: false };
     this.job = {
       ...this.job,
       status,
@@ -84,7 +90,7 @@ class FakeStore implements FinalizeStore {
       prUrl: patch.prUrl ?? this.job.prUrl,
       endedAt: new Date().toISOString(),
     };
-    return this.job;
+    return { job: this.job, transitioned: true };
   }
 
   async appendHostEvent(_jobId: string, type: string, payload: Record<string, unknown> = {}) {
@@ -136,6 +142,35 @@ describe('devplatform/finalizeDevJob', () => {
     assert.equal(second?.status, 'cancelled', 'second call returns the first terminal state');
     assert.equal(store.finishCalls, 1, 'finishTerminal ran once across two finalize calls');
     assert.equal(store.eventCalls.length, 1, 'one status event across two finalize calls');
+  });
+
+  it('reports transitioned:true only for the call that flips the status', async () => {
+    const store = new FakeStore(makeJob({ status: 'running' }));
+    const first = await finalizeDevJobDetailed({ store }, 'job-1', 'stalled');
+    const second = await finalizeDevJobDetailed({ store }, 'job-1', 'stalled');
+
+    assert.equal(first.transitioned, true, 'the flipping call transitioned');
+    assert.equal(second.transitioned, false, 'the idempotent no-op did not');
+    assert.equal(second.job?.status, 'stalled', 'but still returns the terminal state');
+  });
+
+  it('a lost SAME-status race appends no duplicate event (#561)', async () => {
+    // This replica's getJob still sees the job live (it read before the peer
+    // wrote), but the guarded UPDATE finds a peer already flipped it to the SAME
+    // status and reports transitioned:false. The old `after.status === status`
+    // gate could not tell the loser from the winner and appended a SECOND status
+    // event; the transitioned gate skips it.
+    const store = new FakeStore(makeJob({ status: 'running' }));
+    const peerTerminal = makeJob({ status: 'stalled', endedAt: new Date().toISOString() });
+    store.finishTerminal = async (): Promise<TerminalWriteResult> => ({
+      job: peerTerminal,
+      transitioned: false,
+    });
+
+    const out = await finalizeDevJobDetailed({ store }, 'job-1', 'stalled');
+    assert.equal(out.transitioned, false, 'this call did not perform the flip');
+    assert.equal(out.job?.status, 'stalled', 'it returns the peer’s terminal state');
+    assert.equal(store.eventCalls.length, 0, 'no duplicate status event on the lost race');
   });
 
   it('returns null for an unknown job and never writes', async () => {

--- a/middleware/test/tasks/taskReaper.test.ts
+++ b/middleware/test/tasks/taskReaper.test.ts
@@ -1,0 +1,129 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  DEFAULT_TASK_PURGE_TERMINAL_AFTER_MS,
+  DEFAULT_TASK_STALE_AFTER_MS,
+  InMemoryTaskStore,
+  runTaskReaperOnce,
+  startTaskReaper,
+  type TaskReapOptions,
+  type TaskReapResult,
+  type TaskStore,
+} from '@omadia/orchestrator';
+
+/**
+ * #561 — the scheduled orphan sweep (`taskReaper.ts`), isolated from any store.
+ *
+ * This module owns only the SCHEDULE and the option-forwarding; the fencing that
+ * makes the sweep safe across replicas lives in the store implementor and is
+ * tested there (`devJobTaskStoreReap.test.ts`, `finalizeDevJob.test.ts`). What
+ * this file pins:
+ *
+ *  - `runTaskReaperOnce` forwards the windows to `reapOrphans` — including the
+ *    deliberate rule that `parkedStaleAfterMs` is passed ONLY when the operator
+ *    set it (omitted ⇒ parked tasks are never force-failed).
+ *  - `startTaskReaper` reports each sweep, survives a throwing sweep, and stops
+ *    on dispose.
+ *  - the cross-replica property at the store boundary: two independent sweeps
+ *    over one store force-fail a stale task EXACTLY once — the terminal write is
+ *    idempotent and so is the `staleFailed` metric.
+ */
+
+/** A store that records the options each `reapOrphans` was called with. */
+function spyStore(): { store: TaskStore; calls: TaskReapOptions[] } {
+  const calls: TaskReapOptions[] = [];
+  const store = {
+    reapOrphans: async (opts: TaskReapOptions): Promise<TaskReapResult> => {
+      calls.push(opts);
+      return { staleFailed: 0, purged: 0 };
+    },
+  } as unknown as TaskStore;
+  return { store, calls };
+}
+
+describe('tasks/runTaskReaperOnce — option forwarding', () => {
+  it('applies the documented default windows when none are given', async () => {
+    const { store, calls } = spyStore();
+    await runTaskReaperOnce(store);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.staleAfterMs, DEFAULT_TASK_STALE_AFTER_MS);
+    assert.equal(calls[0]?.purgeTerminalAfterMs, DEFAULT_TASK_PURGE_TERMINAL_AFTER_MS);
+    assert.equal(
+      calls[0]?.parkedStaleAfterMs,
+      undefined,
+      'a parked window is NOT invented — parked tasks are never force-failed by default',
+    );
+  });
+
+  it('forwards parkedStaleAfterMs only when the operator supplied it', async () => {
+    const { store, calls } = spyStore();
+    await runTaskReaperOnce(store, { parkedStaleAfterMs: 7_200_000 });
+    assert.equal(calls[0]?.parkedStaleAfterMs, 7_200_000, 'the explicit parked window is passed through');
+  });
+
+  it('passes an injected clock straight to reapOrphans', async () => {
+    const { store, calls } = spyStore();
+    const now = new Date(1_700_000_000_000);
+    await runTaskReaperOnce(store, {}, now);
+    assert.equal(calls[0]?.now?.getTime(), now.getTime());
+  });
+});
+
+describe('tasks/startTaskReaper — schedule lifecycle', () => {
+  it('reports each sweep and stops sweeping once disposed', async () => {
+    const { store, calls } = spyStore();
+    const sweeps: TaskReapResult[] = [];
+    const stop = startTaskReaper(store, { intervalMs: 1, onSweep: (r) => sweeps.push(r) });
+    try {
+      await new Promise((r) => setTimeout(r, 40));
+      assert.ok(calls.length > 0, 'the reaper swept at least once');
+      assert.equal(sweeps.length, calls.length, 'every sweep was reported to onSweep');
+    } finally {
+      stop();
+    }
+    const seen = calls.length;
+    await new Promise((r) => setTimeout(r, 30));
+    assert.equal(calls.length, seen, 'no sweeps run after dispose');
+  });
+
+  it('routes a throwing sweep to onError instead of crashing the timer', async () => {
+    let failures = 0;
+    const store = {
+      reapOrphans: async (): Promise<TaskReapResult> => {
+        throw new Error('sweep boom');
+      },
+    } as unknown as TaskStore;
+
+    const stop = startTaskReaper(store, { intervalMs: 1, onError: () => (failures += 1) });
+    try {
+      await new Promise((r) => setTimeout(r, 40));
+      assert.ok(failures > 0, 'the sweep failure was surfaced to onError');
+    } finally {
+      stop();
+    }
+  });
+});
+
+describe('tasks/orphan sweep — #561 metric is idempotent across sweeps', () => {
+  it('two independent sweeps over one store force-fail a stale task exactly once', async () => {
+    // Two replicas would each schedule their own reaper against the same durable
+    // store. Model that with two sweeps over one store: the first sees the stale
+    // task and fails it; the second sees an already-terminal row and must NOT
+    // re-fail (or re-count) it. Summing the two `staleFailed` proves once-only.
+    let clock = 0;
+    const store = new InMemoryTaskStore({ clock: () => clock });
+
+    // A task nobody ever claims, then abandoned well past the stale window.
+    await store.create({ kind: 'k', input: {} });
+    clock = 10 * 60_000; // 10 min later — past a 1s stale window
+
+    const opts = { staleAfterMs: 1_000, purgeTerminalAfterMs: 60 * 60_000, now: new Date(clock) };
+    const first = await runTaskReaperOnce(store, opts, new Date(clock));
+    const second = await runTaskReaperOnce(store, opts, new Date(clock));
+
+    assert.equal(first.staleFailed, 1, 'the first sweep reaps the stale task');
+    assert.equal(second.staleFailed, 0, 'the second sweep does not re-reap the same row');
+    assert.equal(store.size(), 1, 'the row is still retained (terminal, not yet purged)');
+  });
+});

--- a/middleware/test/tasks/taskReaper.test.ts
+++ b/middleware/test/tasks/taskReaper.test.ts
@@ -17,8 +17,8 @@ import {
  *
  * This module owns only the SCHEDULE and the option-forwarding; the fencing that
  * makes the sweep safe across replicas lives in the store implementor and is
- * tested there (`devJobTaskStoreReap.test.ts`, `finalizeDevJob.test.ts`). What
- * this file pins:
+ * tested there, alongside that store's own reap and terminal-transition suites.
+ * What this file pins:
  *
  *  - `runTaskReaperOnce` forwards the windows to `reapOrphans` — including the
  *    deliberate rule that `parkedStaleAfterMs` is passed ONLY when the operator

--- a/specs/470-dev-platform-plugin/decoupling-baseline.json
+++ b/specs/470-dev-platform-plugin/decoupling-baseline.json
@@ -1,8 +1,8 @@
 {
-  "total": 3288,
+  "total": 3299,
   "zones": {
-    "middleware/src": 1572,
-    "middleware/test": 1027,
+    "middleware/src": 1580,
+    "middleware/test": 1030,
     "middleware/packages": 84,
     "middleware/scripts": 8,
     "middleware/sidecars": 195,

--- a/specs/470-dev-platform-plugin/decoupling-baseline.json
+++ b/specs/470-dev-platform-plugin/decoupling-baseline.json
@@ -1,8 +1,8 @@
 {
-  "total": 3299,
+  "total": 3294,
   "zones": {
-    "middleware/src": 1580,
-    "middleware/test": 1030,
+    "middleware/src": 1576,
+    "middleware/test": 1029,
     "middleware/packages": 84,
     "middleware/scripts": 8,
     "middleware/sidecars": 195,


### PR DESCRIPTION
## What
  Fence the orphan-sweep metric at the store (Closes #561). `finishTerminal`/`finalizeDevJobDetailed` return `{job, transitioned}`; a reap counts only when `transitioned` is true.

  ## Why
  Terminal write was idempotent, metric wasn't: a truthy `DevJob` let a replica count a row its peer already reaped. Now gated on the DB status-guarded UPDATE (loser matches 0 rows). Same gate on side effects also kills a same-status duplicate status event. Schedule stays deliberately per-process; fencing is the store's job.

  ## Test plan
  - [x] `npx tsc --noEmit` + `typecheck -w @omadia/orchestrator` — clean on touched files
  - [x] `taskReaper.test.ts` (new), `finalizeDevJob`, `devJobTaskStoreReap`, `devJobWorker` — 52/52 pass
  - [x] New test drives real `InMemoryTaskStore`: two sweeps reap once (`staleFailed` 1→0)
  - [ ] pg suites skipped (no local postgres); concurrency via sequential idempotency + guard-modeling fakes, not a live 2-process race
  - [X] `npm run lint`

  ## Risk / blast radius
  `finishTerminal`/`finalizeDevJobDetailed` return type changed. Contained: `finalizeDevJob` wrapper keeps the old signature, all prod callers use it; `createDevJobTaskStore` is test-only (epic #470, unwired). No schema/migration/env-var.