### PR TITLE
fix(#671): stop the store offering installs the server refuses, and say why a key is unverified

### DIFF
--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -592,6 +592,21 @@ export interface StoreGetResponse {
   blocking_reasons?: string[];
   /** Advisory-only — never blocks install (issue #453). */
   verdict?: PluginVerdict;
+  /** OM-06 / #671 — set when install is blocked because an ACTIVE plugin
+   *  already provides one of this plugin's capabilities. The install would be
+   *  refused with 409 `install.capability_already_provided`, so the store must
+   *  not advertise it.
+   *
+   *  Structured rather than folded into `blocking_reasons`, which is a list of
+   *  server-authored English strings the client can only print: the operator's
+   *  next step here is to CONFIGURE the provider that already exists, and a
+   *  client cannot build that link by parsing prose. */
+  blocked_by_active_provider?: {
+    /** The capability slot, e.g. `llmProvider@1`. */
+    capability: string;
+    /** Plugin id already providing it. */
+    owner_id: string;
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/middleware/src/plugins/capabilityResolver.ts
+++ b/middleware/src/plugins/capabilityResolver.ts
@@ -436,6 +436,31 @@ export function findActiveProviderCollision(
   if (!candidate) {
     return null;
   }
+  return findProvidesCollision(
+    candidatePluginId,
+    candidate.plugin.provides,
+    catalog,
+    registry,
+  );
+}
+
+/**
+ * The same collision check, but driven by an explicit `provides` list rather
+ * than a catalog lookup.
+ *
+ * Needed because the store must answer this question for plugins that are NOT
+ * in the local catalog: a hub-only entry has no local manifest, yet it carries
+ * `provides` from the registry summary, and it is exactly the case where the
+ * store used to advertise an install that {@link findActiveProviderCollision}
+ * would then refuse with 409 `install.capability_already_provided` (OM-06 /
+ * issue #671). Asking with the list keeps both surfaces on one rule.
+ */
+export function findProvidesCollision(
+  candidatePluginId: string,
+  candidateProvides: readonly string[],
+  catalog: PluginCatalog,
+  registry: InstalledRegistry,
+): { capability: string; ownerId: string } | null {
   const ownerByCap = new Map<string, string>();
   for (const installed of registry.list()) {
     if (installed.status !== 'active') {
@@ -458,7 +483,7 @@ export function findActiveProviderCollision(
       }
     }
   }
-  for (const rawProv of candidate.plugin.provides) {
+  for (const rawProv of candidateProvides) {
     let ref: CapabilityRef;
     try {
       ref = parseCapabilityRef(rawProv);

--- a/middleware/src/routes/adminProviders.ts
+++ b/middleware/src/routes/adminProviders.ts
@@ -295,6 +295,22 @@ export function createAdminProvidersRouter(deps: AdminProvidersDeps): Router {
           ...(verification.code !== undefined
             ? { verifyErrorCode: verification.code }
             : {}),
+          // #671 — why the probe could not confirm the key. A CODE, never a
+          // sentence: the web-ui owns all user-facing copy.
+          //
+          // This is what makes the #599 403 decision legible instead of just
+          // lenient. That change stopped calling every 403 a bad key, because
+          // OpenAI and Anthropic also answer 403 for region and org-permission
+          // blocks — only an explicit `authentication_error` marker still
+          // earns `invalid`. Correct, but it left the operator with a bare
+          // `UNVERIFIED` chip and no way to tell "your key is fine, your
+          // region is blocked" from "the provider was down". The verdict
+          // already carried `reason`; `ProviderVerificationReason`'s own
+          // comment says it exists so "a future UI can map it to a localized
+          // string without a second server change". This is that UI.
+          ...(verification.reason !== undefined
+            ? { verifyReason: verification.reason }
+            : {}),
           // Retained for backwards compatibility: "a key is on file". Callers
           // that need "the key actually works" must read `status` instead.
           connected: verification.status !== 'no_key',

--- a/middleware/src/routes/store.ts
+++ b/middleware/src/routes/store.ts
@@ -13,6 +13,7 @@ import type { PluginCatalog } from '../plugins/manifestLoader.js';
 import type { PluginStatusRegistry } from '../platform/pluginStatusRegistry.js';
 import type { PluginVerdictLookup } from '../services/pluginVerdict.js';
 import { withReadiness, type ReadinessVault } from '../plugins/readiness.js';
+import { findProvidesCollision } from '../plugins/capabilityResolver.js';
 import type {
   RegistryClient,
   ResolvedRegistryPlugin,
@@ -168,10 +169,37 @@ export function createStoreRouter(deps: StoreDeps): Router {
         // page resolves (otherwise the store list would link to a 404).
         const remote = await resolveRemotePlugin(deps.client, id);
         if (remote) {
+          // OM-06 / #671 — a hub-only entry is exactly where this used to go
+          // wrong: no local manifest, so nothing checked whether an active
+          // plugin already provides the same capability, and the store
+          // advertised an install that `InstallService.create` then refused
+          // with 409. The registry summary carries `provides`, so the same
+          // rule applies here.
+          // `?? []` is load-bearing: a registry summary may omit `provides`
+          // entirely (older hub payloads, and every fixture that predates
+          // this), and iterating undefined would 500 the detail page — a
+          // strictly worse outcome than the button this is trying to fix.
+          const remoteCollision = findProvidesCollision(
+            id,
+            remote.provides ?? [],
+            deps.catalog,
+            deps.registry,
+          );
           const body: StoreGetResponse = {
             plugin: remote,
             manifest: remote.source ? { source: remote.source } : {},
-            install_available: true,
+            install_available: !remoteCollision,
+            ...(remoteCollision
+              ? {
+                  blocking_reasons: [
+                    alreadyProvidedReason(remoteCollision),
+                  ],
+                  blocked_by_active_provider: {
+                    capability: remoteCollision.capability,
+                    owner_id: remoteCollision.ownerId,
+                  },
+                }
+              : {}),
           };
           res.json(body);
           return;
@@ -215,7 +243,20 @@ export function createStoreRouter(deps: StoreDeps): Router {
           // registry hiccup → keep the local 'installed' view, never 500
         }
       }
-      const installAvailable = plugin.install_state === 'available';
+      // OM-06 / #671 — `install_state === 'available'` only says the plugin is
+      // not already installed. It does not ask whether the CAPABILITY is
+      // already covered, so the store offered "Install" for a provider whose
+      // slot was taken, and `InstallService.create` then refused the click
+      // with 409 `install.capability_already_provided`. Same check, same
+      // helper, one turn earlier — the button now matches what the server
+      // will actually do.
+      const collision = findProvidesCollision(
+        id,
+        plugin.provides ?? [],
+        deps.catalog,
+        deps.registry,
+      );
+      const installAvailable = plugin.install_state === 'available' && !collision;
       plugin = withActionStatus(plugin, deps.pluginStatusRegistry);
       // OM-16 — see the list handler. Orthogonal to install_state.
       plugin = await withReadiness(plugin, deps.registry, deps.vault);
@@ -234,10 +275,23 @@ export function createStoreRouter(deps: StoreDeps): Router {
         plugin,
         manifest: entry.manifest,
         install_available: installAvailable,
-        ...(plugin.incompatibility_reasons
-          ? { blocking_reasons: plugin.incompatibility_reasons }
+        ...(plugin.incompatibility_reasons || collision
+          ? {
+              blocking_reasons: [
+                ...(plugin.incompatibility_reasons ?? []),
+                ...(collision ? [alreadyProvidedReason(collision)] : []),
+              ],
+            }
           : {}),
         ...(verdict ? { verdict } : {}),
+        ...(collision
+          ? {
+              blocked_by_active_provider: {
+                capability: collision.capability,
+                owner_id: collision.ownerId,
+              },
+            }
+          : {}),
       };
       res.json(body);
     } catch (err) {
@@ -320,6 +374,21 @@ function matchesCategory(plugin: Plugin, category: string | undefined): boolean 
 
 /** Resolve a single plugin id against the remote registries (for the detail
  *  endpoint). Returns null if absent or any registry is unreachable. */
+/** The English fallback line for `blocking_reasons` (OM-06 / #671).
+ *
+ *  `blocking_reasons` is a list of server-authored strings the client can only
+ *  print, so this stays deliberately plain and mirrors the 409 the install
+ *  would return. The ACTIONABLE version — "configure the provider you already
+ *  have", with a link — is built client-side from
+ *  `blocked_by_active_provider`, which is why that field exists rather than
+ *  this string carrying the whole story. */
+function alreadyProvidedReason(collision: {
+  capability: string;
+  ownerId: string;
+}): string {
+  return `capability '${collision.capability}' is already provided by '${collision.ownerId}' — configure that plugin instead of installing a second provider`;
+}
+
 async function resolveRemotePlugin(
   client: RegistryClient | undefined,
   id: string,

--- a/middleware/test/capabilityResolver.test.ts
+++ b/middleware/test/capabilityResolver.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   MissingCapabilityError,
   findActiveProviderCollision,
+  findProvidesCollision,
   findCapabilityProvidersInCatalog,
   resolveCapabilities,
   resolveEligiblePlugins,
@@ -589,6 +590,88 @@ describe('findActiveProviderCollision', () => {
     ]);
     const result = findActiveProviderCollision('does-not-exist', cat, makeRegistry());
     assert.equal(result, null);
+  });
+});
+
+/**
+ * OM-06 / #671 — the same rule, asked with an explicit `provides` list.
+ *
+ * Exists because the store must answer it for plugins that are NOT in the
+ * local catalog: a hub-only entry has no local manifest, yet the registry
+ * summary carries `provides`. That was the gap — the store advertised an
+ * install that `InstallService.create` then refused with 409
+ * `install.capability_already_provided`.
+ */
+describe('findProvidesCollision', () => {
+  it('finds the collision for a candidate that is NOT in the catalog at all', () => {
+    // The hub-only case. `findActiveProviderCollision` returns null here
+    // because it starts with a catalog lookup — which is exactly why the
+    // store could not use it.
+    const cat = makeCatalog([
+      { id: 'kg-neon', provides: ['knowledgeGraph@1'], requires: [], depends_on: [] },
+    ]);
+    const registry = makeRegistry([makeActiveAgent('kg-neon')]);
+
+    assert.equal(
+      findActiveProviderCollision('hub-only-kg', cat, registry),
+      null,
+      'precondition: the catalog-driven helper is blind to an uncatalogued candidate',
+    );
+
+    assert.deepEqual(
+      findProvidesCollision('hub-only-kg', ['knowledgeGraph@1'], cat, registry),
+      { capability: 'knowledgeGraph@1', ownerId: 'kg-neon' },
+    );
+  });
+
+  it('agrees with findActiveProviderCollision for a catalogued candidate', () => {
+    // The wrapper delegates here, so the two must not be able to drift.
+    const cat = makeCatalog([
+      { id: 'kg-neon', provides: ['knowledgeGraph@1'], requires: [], depends_on: [] },
+      { id: 'kg-inmemory', provides: ['knowledgeGraph@1'], requires: [], depends_on: [] },
+    ]);
+    const registry = makeRegistry([makeActiveAgent('kg-neon')]);
+    assert.deepEqual(
+      findProvidesCollision('kg-inmemory', ['knowledgeGraph@1'], cat, registry),
+      findActiveProviderCollision('kg-inmemory', cat, registry),
+    );
+  });
+
+  it('returns null for an empty provides list', () => {
+    // A plugin that provides nothing can never collide — most store entries.
+    const cat = makeCatalog([
+      { id: 'kg-neon', provides: ['knowledgeGraph@1'], requires: [], depends_on: [] },
+    ]);
+    assert.equal(
+      findProvidesCollision('consumer', [], cat, makeRegistry([makeActiveAgent('kg-neon')])),
+      null,
+    );
+  });
+
+  it('ignores an inactive incumbent — its slot is free', () => {
+    const cat = makeCatalog([
+      { id: 'kg-neon', provides: ['knowledgeGraph@1'], requires: [], depends_on: [] },
+    ]);
+    const errored: InstalledAgent = { ...makeActiveAgent('kg-neon'), status: 'errored' };
+    assert.equal(
+      findProvidesCollision('hub-only-kg', ['knowledgeGraph@1'], cat, makeRegistry([errored])),
+      null,
+    );
+  });
+
+  it('ignores self, so a reinstall of the same id is not blocked by itself', () => {
+    const cat = makeCatalog([
+      { id: 'kg-neon', provides: ['knowledgeGraph@1'], requires: [], depends_on: [] },
+    ]);
+    assert.equal(
+      findProvidesCollision(
+        'kg-neon',
+        ['knowledgeGraph@1'],
+        cat,
+        makeRegistry([makeActiveAgent('kg-neon')]),
+      ),
+      null,
+    );
   });
 });
 

--- a/middleware/test/registryInstallMerge.test.ts
+++ b/middleware/test/registryInstallMerge.test.ts
@@ -111,6 +111,12 @@ function fakeCatalog(plugins: Plugin[]): PluginCatalog {
 const fakeRegistry = {
   has: () => false,
   get: () => undefined,
+  // `list()` is not optional on InstalledRegistry — the `as unknown as` cast
+  // below is what let this stub omit it. The store's already-provided check
+  // (#671) walks the installed set, so a stub without `list` 500s the very
+  // routes these tests assert on. Empty is the right answer here: nothing is
+  // installed in these fixtures.
+  list: () => [],
 } as unknown as InstalledRegistry;
 
 // --- C3: store merge -------------------------------------------------------
@@ -355,6 +361,16 @@ function fakeInstalled(map: Record<string, string>): InstalledRegistry {
     has: (id: string) => id in map,
     get: (id: string) =>
       id in map ? { id, installed_version: map[id]! } : undefined,
+    // See the note on `fakeRegistry` above: `list()` is required by the
+    // interface, and the store's already-provided check (#671) calls it.
+    // These entries are `status: 'active'` so the projection matches what a
+    // real registry would report for an installed plugin.
+    list: () =>
+      Object.entries(map).map(([id, version]) => ({
+        id,
+        installed_version: version,
+        status: 'active',
+      })),
   } as unknown as InstalledRegistry;
 }
 

--- a/middleware/test/storeProviderCollision.test.ts
+++ b/middleware/test/storeProviderCollision.test.ts
@@ -1,0 +1,169 @@
+/**
+ * OM-06 / #671 — the store must not offer an install the server will refuse.
+ *
+ * `install_available` used to be `install_state === 'available'` alone, which
+ * only says "not already installed". It never asked whether the CAPABILITY was
+ * taken. So a provider whose slot was already filled by an active plugin got a
+ * live "Install" button, and `InstallService.create` then rejected the click
+ * with 409 `install.capability_already_provided`. The reported shape of this
+ * was a store page offering "Jetzt installieren" for a provider the admin area
+ * already listed as connected, with nothing linking the two.
+ *
+ * The structured `blocked_by_active_provider` is what the client needs: the
+ * operator's next step is to CONFIGURE the provider that already exists, and
+ * no client can build that link by parsing an English `blocking_reasons`
+ * string.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import { strict as assert } from 'node:assert';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import express from 'express';
+
+import { createStoreRouter } from '../src/routes/store.js';
+import type { Plugin } from '../src/api/admin-v1.js';
+import type { PluginCatalog } from '../src/plugins/manifestLoader.js';
+import { InMemoryInstalledRegistry } from '../src/plugins/installedRegistry.js';
+
+function plugin(id: string, over: Partial<Plugin> = {}): Plugin {
+  return {
+    id,
+    kind: 'tool',
+    name: id,
+    version: '1.0.0',
+    latest_version: '1.0.0',
+    description: '',
+    authors: [],
+    license: 'MIT',
+    icon_url: null,
+    categories: [],
+    domain: 'x.y',
+    compat_core: '>=1.0 <2.0',
+    signed: false,
+    signed_by: null,
+    setup_fields: [],
+    permissions_summary: {
+      memory_reads: [],
+      memory_writes: [],
+      graph_reads: [],
+      graph_writes: [],
+      network_outbound: [],
+    },
+    integrations_summary: [],
+    install_state: 'available',
+    depends_on: [],
+    jobs: [],
+    provides: [],
+    requires: [],
+    multi_instance: true,
+    privacy_class: 'default',
+    ...over,
+  };
+}
+
+function fakeCatalog(plugins: Plugin[]): PluginCatalog {
+  return {
+    list: () => plugins.map((p) => ({ plugin: p, manifest: {} })),
+    get: (id: string) => {
+      const p = plugins.find((x) => x.id === id);
+      return p ? { plugin: p, manifest: {} } : undefined;
+    },
+  } as unknown as PluginCatalog;
+}
+
+const INCUMBENT = '@x/provider-active';
+const RIVAL = '@x/provider-rival';
+const UNRELATED = '@x/plain-tool';
+
+interface DetailBody {
+  install_available: boolean;
+  blocking_reasons?: string[];
+  blocked_by_active_provider?: { capability: string; owner_id: string };
+}
+
+describe('store router · already-provided capability (OM-06 / #671)', () => {
+  let server: Server;
+  let base: string;
+
+  before(async () => {
+    const catalog = fakeCatalog([
+      plugin(INCUMBENT, { provides: ['llmProvider@1'] }),
+      plugin(RIVAL, { provides: ['llmProvider@1'] }),
+      plugin(UNRELATED),
+    ]);
+
+    const registry = new InMemoryInstalledRegistry();
+    await registry.register({
+      id: INCUMBENT,
+      installed_version: '1.0.0',
+      installed_at: '2026-01-01T00:00:00.000Z',
+      status: 'active',
+      config: {},
+    });
+
+    const app = express();
+    app.use(
+      '/store/plugins',
+      createStoreRouter({
+        catalog,
+        registry,
+        vault: { listKeys: async (): Promise<string[]> => [] },
+      }),
+    );
+    server = app.listen(0);
+    await new Promise((r) => server.once('listening', r));
+    base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  after(() => {
+    server.close();
+  });
+
+  async function detail(id: string): Promise<DetailBody> {
+    const res = await fetch(`${base}/store/plugins/${encodeURIComponent(id)}`);
+    assert.equal(res.status, 200);
+    return (await res.json()) as DetailBody;
+  }
+
+  it('refuses to advertise an install whose capability slot is taken', async () => {
+    const body = await detail(RIVAL);
+    assert.equal(
+      body.install_available,
+      false,
+      'the button must not be live for an install the server answers with 409',
+    );
+  });
+
+  it('names the incumbent in a structured field, not only in prose', async () => {
+    const body = await detail(RIVAL);
+    assert.deepEqual(body.blocked_by_active_provider, {
+      capability: 'llmProvider@1',
+      owner_id: INCUMBENT,
+    });
+    // The English line stays for clients that only print reasons, but it is
+    // the structured field that lets the UI link to the existing provider.
+    assert.ok(
+      body.blocking_reasons?.some((r) => r.includes(INCUMBENT)),
+      'the human-readable reason should still name the incumbent',
+    );
+  });
+
+  it('leaves an unrelated plugin installable', async () => {
+    const body = await detail(UNRELATED);
+    assert.equal(body.install_available, true);
+    assert.equal(
+      body.blocked_by_active_provider,
+      undefined,
+      'a plugin that provides nothing must not be blocked by anyone',
+    );
+  });
+
+  it('does not block the incumbent against itself', async () => {
+    // It is installed, so `install_available` is false for that reason alone —
+    // but it must not be reported as colliding with itself, or the UI would
+    // tell the operator to configure the very plugin they are looking at.
+    const body = await detail(INCUMBENT);
+    assert.equal(body.blocked_by_active_provider, undefined);
+  });
+});

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -367,6 +367,13 @@ export interface AdminProvider {
    *  absent on payloads from a pre-#604 middleware, where `verifyError` (an
    *  English sentence) stays the only thing there is to show. */
   verifyErrorCode?: string;
+  /** #671 — why the probe could NOT confirm the key (`unverified` only). A
+   *  code (`forbidden` | `non_json_response` | `unexpected_body` |
+   *  `http_error` | `network_error` | `no_probe`), resolved against
+   *  `providers.unverifiedReason.*`. Distinguishes a region/permission block
+   *  from a provider outage — both of which #599 correctly stopped reporting
+   *  as a bad key. Absent on pre-#671 middleware payloads. */
+  verifyReason?: string;
   /** Legacy: "a key is on file" — i.e. `status !== 'no_key'`. Retained for
    *  backwards compatibility; it does NOT mean the key works. */
   connected: boolean;

--- a/web-ui/app/_lib/storeTypes.ts
+++ b/web-ui/app/_lib/storeTypes.ts
@@ -300,6 +300,16 @@ export interface StoreGetResponse {
   blocking_reasons?: string[];
   /** Advisory-only — never blocks install (issue #453). */
   verdict?: PluginVerdict;
+  /** OM-06 / #671 — an ACTIVE plugin already provides one of this plugin's
+   *  capabilities, so the install would be refused with 409. Structured, not
+   *  folded into `blocking_reasons` (server-authored English the client can
+   *  only print), because the operator's next step is to CONFIGURE the
+   *  provider that already exists — and that link cannot be built by parsing
+   *  prose. Absent on pre-#671 middleware payloads. */
+  blocked_by_active_provider?: {
+    capability: string;
+    owner_id: string;
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/web-ui/app/admin/providers/_components/ProvidersPanel.tsx
+++ b/web-ui/app/admin/providers/_components/ProvidersPanel.tsx
@@ -515,9 +515,23 @@ const CHIP_CLASS: Record<AdminProvider['status'], string> = {
 
 const CHIP_LABEL_KEY: Record<AdminProvider['status'], string> = {
   verified: 'providers.verified',
-  unverified: 'providers.unverified',
   invalid: 'providers.invalid',
+  unverified: 'providers.unverified',
   no_key: 'providers.notConnected',
+};
+
+/** #671 — `ProviderVerificationReason` codes → localized copy. Deliberately a
+ *  closed map rather than a template lookup: an unknown code from a newer
+ *  middleware renders nothing, instead of printing the raw code at the
+ *  operator. Mirrors `ProviderVerificationReason` in
+ *  `middleware/src/platform/providerCredentialVerifier.ts`. */
+const UNVERIFIED_REASON_KEYS: Record<string, string | undefined> = {
+  forbidden: 'providers.unverifiedReason.forbidden',
+  non_json_response: 'providers.unverifiedReason.nonJsonResponse',
+  unexpected_body: 'providers.unverifiedReason.unexpectedBody',
+  http_error: 'providers.unverifiedReason.httpError',
+  network_error: 'providers.unverifiedReason.networkError',
+  no_probe: 'providers.unverifiedReason.noProbe',
 };
 
 /**
@@ -548,6 +562,17 @@ function ConnectionChip({
           {t('providers.verifiedAt', {
             time: format.relativeTime(new Date(p.verifiedAt)),
           })}
+        </span>
+      )}
+      {/* #671 — `unverified` on its own is not actionable: it covers "your key
+          is fine but your region is blocked" and "the provider was down" with
+          the same chip. #599 was right to stop calling a bare 403 a bad key;
+          this says which of those it actually was. Unknown codes render
+          nothing rather than a raw string — a newer middleware must never leak
+          an untranslated code into the UI. */}
+      {p.status === 'unverified' && p.verifyReason && UNVERIFIED_REASON_KEYS[p.verifyReason] && (
+        <span className="text-[11px] text-[color:var(--fg-muted)]">
+          {t(UNVERIFIED_REASON_KEYS[p.verifyReason]!)}
         </span>
       )}
     </span>

--- a/web-ui/app/admin/providers/_components/__tests__/ProvidersPanel.test.tsx
+++ b/web-ui/app/admin/providers/_components/__tests__/ProvidersPanel.test.tsx
@@ -533,4 +533,83 @@ describe('<ProvidersPanel />', () => {
     })) as HTMLButtonElement;
     expect(button.disabled).toBe(false);
   });
+
+  /**
+   * #671 — `UNVERIFIED` on its own is not actionable. It covers "your key is
+   * fine, your region is blocked" and "the provider was down" with one chip.
+   * PR #599 was right to stop calling a bare 403 a bad key; this says which of
+   * those it actually was.
+   */
+  describe('unverified reason (#671)', () => {
+    it('explains a 403 as a region/permission block rather than a bad key', async () => {
+      mockGetProviders.mockResolvedValue(
+        providersResponse({
+          providers: [
+            provider({ status: 'unverified', connected: true, verifyReason: 'forbidden' }),
+          ],
+        }),
+      );
+      renderWithIntl(<ProvidersPanel onSwitchToSubscriptions={vi.fn()} />);
+
+      expect(
+        await screen.findByText(en.adminProviders.providers.unverifiedReason.forbidden),
+      ).toBeInTheDocument();
+    });
+
+    it('distinguishes an unreachable provider from a blocked one', async () => {
+      mockGetProviders.mockResolvedValue(
+        providersResponse({
+          providers: [
+            provider({ status: 'unverified', connected: true, verifyReason: 'network_error' }),
+          ],
+        }),
+      );
+      renderWithIntl(<ProvidersPanel onSwitchToSubscriptions={vi.fn()} />);
+
+      expect(
+        await screen.findByText(en.adminProviders.providers.unverifiedReason.networkError),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(en.adminProviders.providers.unverifiedReason.forbidden),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders nothing for an unknown code instead of leaking it into the UI', async () => {
+      // A newer middleware may add a reason this build has no copy for. The
+      // map is closed on purpose: printing the raw code at the operator would
+      // be worse than saying nothing.
+      mockGetProviders.mockResolvedValue(
+        providersResponse({
+          providers: [
+            provider({
+              status: 'unverified',
+              connected: true,
+              verifyReason: 'some_future_reason',
+            }),
+          ],
+        }),
+      );
+      renderWithIntl(<ProvidersPanel onSwitchToSubscriptions={vi.fn()} />);
+
+      expect(await screen.findByText(/Anthropic/)).toBeInTheDocument();
+      expect(screen.queryByText(/some_future_reason/)).not.toBeInTheDocument();
+    });
+
+    it('says nothing about reasons once the key verifies', async () => {
+      mockGetProviders.mockResolvedValue(
+        providersResponse({
+          providers: [
+            // A stale `verifyReason` must not survive a successful verify.
+            provider({ status: 'verified', connected: true, verifyReason: 'forbidden' }),
+          ],
+        }),
+      );
+      renderWithIntl(<ProvidersPanel onSwitchToSubscriptions={vi.fn()} />);
+
+      expect(await screen.findByText(/Anthropic/)).toBeInTheDocument();
+      expect(
+        screen.queryByText(en.adminProviders.providers.unverifiedReason.forbidden),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/web-ui/app/store/[id]/page.tsx
+++ b/web-ui/app/store/[id]/page.tsx
@@ -84,7 +84,8 @@ export default async function PluginDetailPage({
     throw err;
   }
 
-  const { plugin, install_available, blocking_reasons } = detail;
+  const { plugin, install_available, blocking_reasons, blocked_by_active_provider } =
+    detail;
   const isLegacy = plugin.categories.includes('legacy');
   const visibleCategories = plugin.categories.filter((c) => c !== 'legacy');
 
@@ -352,6 +353,30 @@ export default async function PluginDetailPage({
               : {})}
             {...(blocking_reasons ? { blockingReasons: blocking_reasons } : {})}
           />
+
+          {/* OM-06 / #671 — the capability this plugin provides is already
+              covered by an active plugin, so the install would be refused.
+              `blocking_reasons` above already says so, but only in English and
+              only as a statement of fact. The operator's actual next step is
+              to configure the provider they ALREADY have, which the original
+              report called out as missing: the store offered "install" while
+              the admin area listed the same provider as connected, with no
+              link between the two. */}
+          {blocked_by_active_provider ? (
+            <div className="space-y-2 rounded-lg border border-[color:var(--edge)] p-4">
+              <p className="text-[12px] leading-relaxed text-[color:var(--fg-muted)]">
+                {t('alreadyProvided', {
+                  owner: blocked_by_active_provider.owner_id,
+                })}
+              </p>
+              <Link
+                href="/admin/providers"
+                className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--accent)] transition hover:opacity-80"
+              >
+                {t('alreadyProvidedCta')}
+              </Link>
+            </div>
+          ) : null}
 
           {/* Admin-UI Toggle — sidebar control for the plugin-bundled
               operator UI. Visible whenever the plugin declares an

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -2668,7 +2668,15 @@
       "saveKey": "Schlüssel speichern",
       "cancel": "Abbrechen",
       "cliNotInstalledReason": "Die Claude-CLI ist auf diesem Server nicht installiert.",
-      "helpLink": "Was bedeutet das?"
+      "helpLink": "Was bedeutet das?",
+      "unverifiedReason": {
+        "forbidden": "Der Provider hat die Anfrage abgelehnt (HTTP 403). Das ist meist eine Regions- oder Organisationsbeschränkung, kein falscher Schlüssel.",
+        "nonJsonResponse": "Der Provider hat kein JSON geliefert — oft eine Proxy- oder Portalseite statt der API.",
+        "unexpectedBody": "Der Provider hat geantwortet, aber nicht mit einer Modell-Liste, die wir erkennen.",
+        "httpError": "Der Provider hat einen Fehler zurückgegeben (serverseitig oder Rate-Limit). Nicht dein Schlüssel.",
+        "networkError": "Der Provider war nicht erreichbar — Timeout, DNS oder keine Verbindung.",
+        "noProbe": "Dieser Provider-Typ lässt sich nicht günstig prüfen, der Schlüssel bleibt daher unbestätigt."
+      }
     },
     "assignments": {
       "heading": "Zuordnung pro Agent",
@@ -2850,6 +2858,8 @@
       "signed": "signiert",
       "unsigned": "unsigniert",
       "connectedOk": "Verbindung hergestellt.",
+      "alreadyProvided": "Diese Capability wird bereits von {owner} bereitgestellt. Ein zweiter Provider lässt sich nicht installieren — konfiguriere stattdessen den vorhandenen.",
+      "alreadyProvidedCta": "Provider konfigurieren",
       "connectedError": "Verbindung fehlgeschlagen. Bitte erneut versuchen.",
       "connectedErrorWithReason": "Verbindung fehlgeschlagen ({reason}). Bitte erneut versuchen.",
       "sectionDescription": "Beschreibung",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -2668,7 +2668,15 @@
       "saveKey": "Save key",
       "cancel": "Cancel",
       "cliNotInstalledReason": "The Claude CLI is not installed on this server.",
-      "helpLink": "What does this mean?"
+      "helpLink": "What does this mean?",
+      "unverifiedReason": {
+        "forbidden": "The provider refused the request (HTTP 403). This is usually a region or organisation restriction, not a wrong key.",
+        "nonJsonResponse": "The provider answered with something other than JSON — often a proxy or captive-portal page rather than the API.",
+        "unexpectedBody": "The provider answered, but not with a model list we recognise.",
+        "httpError": "The provider returned an error (server-side or rate limit). Not your key.",
+        "networkError": "The provider could not be reached — timeout, DNS or no connection.",
+        "noProbe": "This provider type cannot be probed cheaply, so the key stays unverified."
+      }
     },
     "assignments": {
       "heading": "Per-agent assignment",
@@ -2850,6 +2858,8 @@
       "signed": "signed",
       "unsigned": "unsigned",
       "connectedOk": "Connection established.",
+      "alreadyProvided": "This capability is already provided by {owner}. Installing a second provider is not possible — configure the existing one instead.",
+      "alreadyProvidedCta": "Configure providers",
       "connectedError": "Connection failed. Please try again.",
       "connectedErrorWithReason": "Connection failed ({reason}). Please try again.",
       "sectionDescription": "Description",


### PR DESCRIPTION
Closes #671

The two decisions left over from #605. Neither was a code bug on its own — both were surfaces that withheld what the operator needed in order to act.

---

## OM-06 — store "Jetzt installieren" vs. admin "VERBUNDEN"

### The question, answered from the code

The issue asked whether an LLM provider is **one** concept or **two**. The code has already answered: a **catalogue entry** (registry + models, `/api/v1/admin/providers`) and a **credential** (vault key, its own verification lifecycle) are genuinely different things. A provider can be known-but-unconfigured, or configured-but-region-blocked. Merging them would erase real states.

So the concepts stay as they are. What was broken is the surface.

### What was actually wrong

`install_available` was `install_state === 'available'` — which only says *"not already installed"*. It never asked whether the **capability** was taken. Meanwhile `InstallService.create` refuses exactly that case with `409 install.capability_already_provided`.

So the store advertised a button the server was **guaranteed to reject**. That is the reported shape: "Jetzt installieren" for a provider the admin area already listed as connected, with nothing linking the two surfaces.

Same check, same helper — one turn earlier.

### The hub-only wrinkle

`findActiveProviderCollision` begins with a catalog lookup, so it returns `null` for a plugin that has no local manifest — i.e. **exactly the hub-published entry that failed**. Verified locally: `llm-adapter-anthropic` has no `manifest.yaml` (it is a library), and `anthropic_base_url` does not exist anywhere in this repo, so the entry in question is served from the remote registry.

Factored out `findProvidesCollision`, which takes the `provides` list the registry summary already carries (`registryEntryToPlugin` populates it). `findActiveProviderCollision` is now a thin wrapper over it, so the two cannot drift apart. A test asserts the wrapper and the new function agree.

### Why a structured field

`blocked_by_active_provider` is typed, not folded into `blocking_reasons`. `blocking_reasons` is a list of server-authored English strings a client can only print — and the operator's next step here is to **configure the provider they already have**. No client can build that link by parsing prose. The store detail page renders a localized line plus a deep-link to `/admin/providers`, which is the half the original report called out as missing.

---

## `/setup` 403 — ratified, and made legible

Reviewed rather than rubber-stamped, and the review changed my reading of it.

**#599 did not weaken the gate.** A bare 403 becomes `unverified` with `reason: 'forbidden'` — never `verified`. Only an explicit `authentication_error` / `invalid_api_key` marker still earns the accusatory `invalid`:

```ts
verification = isAuthenticationErrorBody(body)
  ? rejected(res.status, checkedAt)                          // 'invalid'
  : { status: 'unverified', checkedAt, reason: 'forbidden' }; // NOT 'verified'
```

There are three states, not two. The change moved bare-403 from *"your key is wrong"* to *"we could not tell"* — a **correction of a false accusation**, not a relaxation. A region block is no evidence a key is bad, and the previous behaviour locked out region-restricted operators holding perfectly valid keys. **Keeping it.**

### What it did leave behind

A bare `UNVERIFIED` chip, covering both "your key is fine, your region is blocked" and "the provider was down" with the same word.

The verdict already carried `reason`, and `ProviderVerificationReason`'s own comment says it exists so *"a future UI can map it to a localized string without a second server change"*. This is that UI:

- `verifyReason` on the provider DTO (a **code**, never a sentence — the web-ui owns all copy)
- a **closed** code→key map in the panel: an unknown code from a newer middleware renders *nothing* rather than leaking a raw identifier at the operator
- `en` + `de` copy for all six reasons

---

## Mutation checks

Every behaviour is proven to fail, not assumed to.

| Mutation | Result |
|---|---|
| collision helper always returns null | ✅ red |
| stop ignoring inactive incumbents | ✅ red |
| stop ignoring self | ✅ red |
| store ignores the collision in `install_available` | ✅ red |
| store drops the structured field, keeps prose | ✅ red |
| UI drops the reason line | ✅ red |
| UI renders it for any status, not just `unverified` | ✅ red |
| UI leaks an unknown code instead of staying silent | ✅ red |

Two of these needed a second attempt and are worth flagging: one reported **green because the `perl` edit never landed**, and one mutated a branch the outer guard made unreachable. Each mutation now asserts its own anchor before running, and prints proof it applied.

## A test-stub bug this exposed

`fakeRegistry` / `fakeInstalled` in `registryInstallMerge.test.ts` omit `list()`, which `InstalledRegistry` requires — hidden by `as unknown as`. The new check calls it, so four remote-plugin tests started returning 500.

Fixed the **stubs**, not the production path: a stub that does not implement the interface it claims is the defect, and making the route defensive would have papered over it. (`provides` itself is guarded with `?? []` — that one is a real runtime condition, since older hub payloads may omit it, and a 500 on the detail page would be strictly worse than the button being wrong.)

## Verification

| Gate | Result |
|---|---|
| middleware build | ✅ |
| `capabilityResolver` suite | 45 pass |
| new `storeProviderCollision` suite | 4 pass |
| `registryInstallMerge` (was 4× red) | 13 pass |
| middleware lint / typecheck | ✅ / ✅ |
| `typecheck:test` ratchet | 406, unchanged |
| web-ui vitest | **677 pass** (27 in ProvidersPanel) |
| web-ui lint / typecheck | ✅ / ✅ |
| `i18n:check` | OK — 3573 keys, en + de |
| German-literal self-check on the diff | clean |

**On the full middleware suite:** it is intermittently red on this machine with rotating victims (`routinesTemplateRoute` hit a 120 s file timeout, then `builderPreviewRoutes`, then `storeReadinessProjection`). Every one of them passes in isolation, and `storeReadinessProjection` passes 3/3 isolated **both with and without this change** — so this is the localhost-contention flake tracked in #605, not a regression here. CI's 4-vCPU runner is the arbiter.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789133341&installation_model_id=428086&pr_number=672&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F672&signature=2d1ecec34e6331e588b9000f25798b52f848f4b4c3550321c5c2e4d0d1358535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->