### PR TITLE
feat(#602): localized setup-field labels + store-card setup profile (…

### DIFF
--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -47,11 +47,20 @@ export type SetupFieldType =
 
 export interface PluginSetupField {
   key: string;
-  label: string;
+  /**
+   * #602 (OM-17) — the field's label, as a `{ <locale>: text }` map. Authored
+   * either localized (`{ en: "…", de: "…" }`) or as a bare string the loader
+   * reads as English. Resolve with `pickLocalized` at the active locale; falls
+   * back to the field `key` when the map is empty. Localized because a manifest
+   * that shows an English label above German setup instructions is exactly the
+   * two-languages-on-one-page defect OM-17 was raised for.
+   */
+  label: LocalizedMarkdown;
   type: SetupFieldType;
-  /** Manifest-defined help text. Surfaced on the post-install credentials
-   *  editor so the operator sees the same hint as in the install wizard. */
-  help?: string;
+  /** #602 (OM-17) — Manifest-defined help text as a `{ <locale>: text }` map
+   *  (bare string tolerated, read as English). Surfaced on the install wizard
+   *  and the post-install credentials editor; render with `pickLocalized`. */
+  help?: LocalizedMarkdown;
   /** Manifest-defined input placeholder. Optional UI hint surfaced by the
    *  install wizard and post-install editor; loader passes it through
    *  unchanged. */
@@ -518,6 +527,39 @@ export interface Plugin {
    * never parsed for behaviour.
    */
   setup_guide?: LocalizedMarkdown;
+  /**
+   * OM-15 (#602) — installation-effort profile surfaced on the store CARD,
+   * BEFORE install. Declared in the manifest's `listing.setup_profile`. Exists
+   * because a tester installed a plugin, then discovered it needed a Google
+   * Cloud service account, seven enabled APIs and Workspace super-admin rights —
+   * information they should have had while still deciding whether to install.
+   * Optional and additive; absent for plugins that declare no profile.
+   */
+  setup_profile?: SetupProfile;
+}
+
+/**
+ * OM-15 (#602) — who has to perform the setup. Renders as a localized label on
+ * the card (`it_admin` → "Einrichtung durch IT-Administrator"). Unknown values
+ * are dropped by the loader rather than shown raw.
+ */
+export type SetupAudience = 'it_admin' | 'operator' | 'end_user';
+
+/**
+ * OM-15 (#602) — structured installation-effort metadata for the store card.
+ * The platform COMPOSES the display line from these fields via next-intl (so the
+ * card stays localized and the plugin author does not hand-write German), e.g.
+ * "Einrichtung durch IT-Administrator · ca. 15 Min · Google-Workspace-Super-Admin
+ * erforderlich". Every field is optional; the card renders only the parts present.
+ */
+export interface SetupProfile {
+  /** Who performs the setup. Omitted when the manifest value is unrecognised. */
+  audience?: SetupAudience;
+  /** Rough hands-on setup time in minutes. Positive integer; omitted otherwise. */
+  estimated_minutes?: number;
+  /** A single extra prerequisite worth calling out up front (e.g. required
+   *  admin role), as a `{ <locale>: text }` map. Render with `pickLocalized`. */
+  requirement?: LocalizedMarkdown;
 }
 
 /**
@@ -609,8 +651,12 @@ export type InstallJobState =
 export interface InstallSetupField {
   key: string;
   type: SetupFieldType;
-  label: string;
-  help?: string;
+  /** #602 (OM-17) — localized label map; see `PluginSetupField.label`. Both
+   *  projections normalise it identically so the install wizard and the store
+   *  view render the same text. */
+  label: LocalizedMarkdown;
+  /** #602 (OM-17) — localized help map; see `PluginSetupField.help`. */
+  help?: LocalizedMarkdown;
   required: boolean;
   default?: unknown;
   enum?: Array<{ value: string; label: string }>;

--- a/middleware/src/api/registry-v1.ts
+++ b/middleware/src/api/registry-v1.ts
@@ -14,7 +14,12 @@
 // `GET /registry/index.json` implementation.
 // ===========================================================================
 
-import type { ISO8601, LocalizedMarkdown, PluginKind } from './admin-v1.js';
+import type {
+  ISO8601,
+  LocalizedMarkdown,
+  PluginKind,
+  SetupProfile,
+} from './admin-v1.js';
 
 /** A single installable version of a plugin, as advertised by a registry. */
 export interface RegistryVersionEntry {
@@ -49,6 +54,10 @@ export interface RegistryManifestSummary {
    *  `setup.guide`. Display-only — rendered on the hub detail page and the
    *  Omadia store; never parsed for behaviour. */
   setup_guide?: LocalizedMarkdown;
+  /** OM-15 (#602) — installation-effort profile for the store card (audience,
+   *  time, a key prerequisite). Kept loose; the store re-validates it through
+   *  the same parser the local catalog uses before rendering. */
+  setup_profile?: SetupProfile;
   permissions?: Record<string, unknown>;
 }
 

--- a/middleware/src/plugins/installService.ts
+++ b/middleware/src/plugins/installService.ts
@@ -30,6 +30,7 @@ import {
   checkSetupFieldPattern,
   compileSetupPattern,
 } from './setupFieldPattern.js';
+import { normalizeLocalized, resolveLocalized } from './manifestLocalized.js';
 
 export interface InstallServiceDeps {
   catalog: PluginCatalog;
@@ -510,10 +511,13 @@ export function extractSetupSchema(
     const field: InstallSetupField = {
       key,
       type,
-      label: asString(f['label']) ?? key,
+      // #602 (OM-17) — localized label map, byte-for-byte identical to the
+      // catalog projection in manifestLoader (bare string → English, empty →
+      // the field key). The shared-fixture test guards that agreement.
+      label: normalizeLocalized(f['label']) ?? { en: key },
       required: f['required'] !== false,
     };
-    const help = asString(f['help']);
+    const help = normalizeLocalized(f['help']);
     if (help) field.help = help;
     // OM-17 — forward the manifest placeholder to the install wizard, which
     // previously masked every secret field with a hardcoded `••••••••`.
@@ -528,7 +532,7 @@ export function extractSetupSchema(
     if (pattern) {
       if (compileSetupPattern(pattern, `install/${key}`)) {
         field.pattern = pattern;
-        const patternHint = asLocalizedHint(f['pattern_hint']);
+        const patternHint = normalizeLocalized(f['pattern_hint']);
         if (patternHint) field.pattern_hint = patternHint;
       } else {
         // OM-17 / F2 — a DROPPED pattern must never silently look like a field
@@ -635,10 +639,13 @@ function privacyModeField(entry: PluginCatalogEntry): InstallSetupField {
   return {
     key: PRIVACY_MODE_CONFIG_KEY,
     type: 'enum',
-    label: 'Privacy Mode',
+    // #602 (OM-17) — label/help are localized maps now. These kernel-injected
+    // fields carry German copy, so tag them `de`; a non-German UI resolves via
+    // the same fallback and still shows this text (unchanged from before).
+    label: { de: 'Privacy Mode' },
     required: false,
     default: PRIVACY_MODE_DEFAULT,
-    help,
+    help: { de: help },
     enum: PRIVACY_MODE_VALUES.map((value) => ({
       value,
       label: privacyModeLabel(value),
@@ -671,14 +678,17 @@ function privacyBypassScopesField(): InstallSetupField {
   return {
     key: PRIVACY_BYPASS_SCOPES_CONFIG_KEY,
     type: 'string',
-    label: 'Bypass-Tool-Whitelist (nur bei Privacy Mode = Per-Tool)',
+    // #602 (OM-17) — German kernel copy tagged `de`; see privacyModeField.
+    label: { de: 'Bypass-Tool-Whitelist (nur bei Privacy Mode = Per-Tool)' },
     required: false,
-    help:
-      'Komma- oder Leerzeichen-getrennte Liste von Tool-Namen, die bei ' +
-      'Privacy Mode "Per-Tool" unmaskiert durchgelassen werden. Beispiel: ' +
-      '"confluence_get_page, confluence_get_page_by_title". Tools die hier ' +
-      'NICHT stehen bleiben "guarded". Wird ignoriert wenn Privacy Mode auf ' +
-      '"Geschützt" oder "Bypass" steht.',
+    help: {
+      de:
+        'Komma- oder Leerzeichen-getrennte Liste von Tool-Namen, die bei ' +
+        'Privacy Mode "Per-Tool" unmaskiert durchgelassen werden. Beispiel: ' +
+        '"confluence_get_page, confluence_get_page_by_title". Tools die hier ' +
+        'NICHT stehen bleiben "guarded". Wird ignoriert wenn Privacy Mode auf ' +
+        '"Geschützt" oder "Bypass" steht.',
+    },
   };
 }
 
@@ -712,6 +722,14 @@ async function validateValues(
   const errors: Array<{ key: string; code: string; message: string }> = [];
 
   for (const field of schema.fields) {
+    // #602 (OM-17) — these validation messages are German templates and this
+    // path has no request locale, so resolve the localized label to German
+    // (falling back to en/any, else the key). A German sentence with a German
+    // label beats the mixed-locale message that was a named cause of OM-17.
+    // NB: 'de' is hardcoded because the surrounding templates are German-only;
+    // if they ever localize, thread the request locale here — same root cause
+    // as the server-side always-English pattern hint tracked in #605.
+    const label = resolveLocalized(field.label, 'de') ?? field.key;
     const raw = incoming[field.key];
     const missing =
       raw === undefined ||
@@ -732,7 +750,7 @@ async function validateValues(
         errors.push({
           key: field.key,
           code: 'required',
-          message: `Feld "${field.label}" ist erforderlich.`,
+          message: `Feld "${label}" ist erforderlich.`,
         });
       } else if (field.default !== undefined) {
         values[field.key] = field.default;
@@ -775,7 +793,7 @@ async function validateValues(
           // reads German. See `setupFieldPattern.ts` → `PatternViolation.hint`.
           message:
             violation.hint ??
-            `"${field.label}" entspricht nicht dem erwarteten Muster.`,
+            `"${label}" entspricht nicht dem erwarteten Muster.`,
         });
         continue;
       }
@@ -792,6 +810,8 @@ type CoerceResult =
   | { error: { code: string; message: string } };
 
 function coerce(field: InstallSetupField, raw: unknown): CoerceResult {
+  // #602 (OM-17) — see validateValues: German templates, no request locale.
+  const label = resolveLocalized(field.label, 'de') ?? field.key;
   switch (field.type) {
     case 'string':
     case 'secret':
@@ -800,7 +820,7 @@ function coerce(field: InstallSetupField, raw: unknown): CoerceResult {
         : {
             error: {
               code: 'wrong_type',
-              message: `"${field.label}" muss Text sein.`,
+              message: `"${label}" muss Text sein.`,
             },
           };
     case 'url': {
@@ -808,7 +828,7 @@ function coerce(field: InstallSetupField, raw: unknown): CoerceResult {
         return {
           error: {
             code: 'wrong_type',
-            message: `"${field.label}" muss eine URL sein.`,
+            message: `"${label}" muss eine URL sein.`,
           },
         };
       }
@@ -821,7 +841,7 @@ function coerce(field: InstallSetupField, raw: unknown): CoerceResult {
         return {
           error: {
             code: 'invalid_url',
-            message: `"${field.label}" ist keine gültige http(s)-URL.`,
+            message: `"${label}" ist keine gültige http(s)-URL.`,
           },
         };
       }
@@ -834,7 +854,7 @@ function coerce(field: InstallSetupField, raw: unknown): CoerceResult {
       return {
         error: {
           code: 'wrong_type',
-          message: `"${field.label}" muss true oder false sein.`,
+          message: `"${label}" muss true oder false sein.`,
         },
       };
     case 'integer': {
@@ -843,7 +863,7 @@ function coerce(field: InstallSetupField, raw: unknown): CoerceResult {
         return {
           error: {
             code: 'wrong_type',
-            message: `"${field.label}" muss eine ganze Zahl sein.`,
+            message: `"${label}" muss eine ganze Zahl sein.`,
           },
         };
       }
@@ -854,7 +874,7 @@ function coerce(field: InstallSetupField, raw: unknown): CoerceResult {
         return {
           error: {
             code: 'wrong_type',
-            message: `"${field.label}" muss ein Text sein.`,
+            message: `"${label}" muss ein Text sein.`,
           },
         };
       }
@@ -863,7 +883,7 @@ function coerce(field: InstallSetupField, raw: unknown): CoerceResult {
         return {
           error: {
             code: 'enum_mismatch',
-            message: `"${field.label}" muss einer der erlaubten Werte sein: ${allowed.join(', ')}.`,
+            message: `"${label}" muss einer der erlaubten Werte sein: ${allowed.join(', ')}.`,
           },
         };
       }
@@ -880,7 +900,7 @@ function coerce(field: InstallSetupField, raw: unknown): CoerceResult {
         return {
           error: {
             code: 'wrong_type',
-            message: `"${field.label}" muss eine Liste von Hostnamen sein.`,
+            message: `"${label}" muss eine Liste von Hostnamen sein.`,
           },
         };
       }
@@ -890,7 +910,7 @@ function coerce(field: InstallSetupField, raw: unknown): CoerceResult {
           return {
             error: {
               code: 'wrong_type',
-              message: `"${field.label}" darf nur Text-Hostnamen enthalten.`,
+              message: `"${label}" darf nur Text-Hostnamen enthalten.`,
             },
           };
         }
@@ -961,25 +981,4 @@ function isSupportedType(t: string): t is InstallSetupField['type'] {
 
 function asString(v: unknown): string | undefined {
   return typeof v === 'string' && v.length > 0 ? v : undefined;
-}
-
-/**
- * OM-17 — normalise a manifest `pattern_hint` into a `{ locale: text }` map.
- * Mirrors `manifestLoader.asLocalizedGuide`: accepts the canonical object form
- * and tolerates a bare string (treated as English).
- */
-function asLocalizedHint(value: unknown): Record<string, string> | undefined {
-  if (typeof value === 'string') {
-    return value.trim().length > 0 ? { en: value } : undefined;
-  }
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return undefined;
-  }
-  const out: Record<string, string> = {};
-  for (const [locale, text] of Object.entries(
-    value as Record<string, unknown>,
-  )) {
-    if (typeof text === 'string' && text.trim().length > 0) out[locale] = text;
-  }
-  return Object.keys(out).length > 0 ? out : undefined;
 }

--- a/middleware/src/plugins/manifestLoader.ts
+++ b/middleware/src/plugins/manifestLoader.ts
@@ -22,8 +22,11 @@ import type {
   PluginPermissionsSummary,
   PluginSetupField,
   ServiceTypeDecl,
+  SetupAudience,
+  SetupProfile,
 } from '../api/admin-v1.js';
 import { compileSetupPattern } from './setupFieldPattern.js';
+import { normalizeLocalized } from './manifestLocalized.js';
 
 /**
  * Loads plugin manifests from a single source:
@@ -223,7 +226,10 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
     const key = asString(f['key']);
     const type = asString(f['type']);
     if (!key || !type) continue;
-    const label = asString(f['label']) ?? key;
+    // #602 (OM-17) — label is a localized map; a bare string is read as English,
+    // and a field with no usable label falls back to its own key. Kept
+    // byte-for-byte identical to installService's projection.
+    const label = normalizeLocalized(f['label']) ?? { en: key };
     if (!isSetupFieldType(type)) continue;
     const entry: PluginSetupField = { key, label, type };
     // OM-16 — required-by-default. MUST stay byte-for-byte the same rule as
@@ -242,7 +248,7 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
     if (pattern) {
       if (compileSetupPattern(pattern, `${id}/${key}`)) {
         entry.pattern = pattern;
-        const patternHint = asLocalizedGuide(f['pattern_hint']);
+        const patternHint = normalizeLocalized(f['pattern_hint']);
         if (patternHint) entry.pattern_hint = patternHint;
       } else {
         // OM-17 / F2 — fail-open for the WRITE (bricking a plugin because its
@@ -252,7 +258,7 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
         entry.pattern_unavailable = true;
       }
     }
-    const help = asString(f['help']);
+    const help = normalizeLocalized(f['help']);
     if (help) entry.help = help;
     const placeholder = asString(f['placeholder']);
     if (placeholder) entry.placeholder = placeholder;
@@ -387,7 +393,8 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
   const privacyClass: 'strict' | 'default' =
     privacyClassRaw === 'strict' ? 'strict' : 'default';
 
-  const setupGuide = asLocalizedGuide(setup?.['guide']);
+  const setupGuide = normalizeLocalized(setup?.['guide']);
+  const setupProfile = extractSetupProfile(doc['listing']);
 
   // Spec 005 — declarative OAuth-provider descriptors. Inert data the kernel
   // broker reads at flow time; no plugin code runs during the OAuth dance.
@@ -431,6 +438,7 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
     result = { ...result, service_types: serviceTypes };
   }
   if (setupGuide) result = { ...result, setup_guide: setupGuide };
+  if (setupProfile) result = { ...result, setup_profile: setupProfile };
   if (channel) result = { ...result, channel };
   if (adminUiPath) result = { ...result, admin_ui_path: adminUiPath };
   if (isReferenceOnly) result = { ...result, is_reference_only: true };
@@ -882,24 +890,54 @@ function asString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
+const SETUP_AUDIENCES: readonly SetupAudience[] = [
+  'it_admin',
+  'operator',
+  'end_user',
+];
+
 /**
- * Normalise a manifest `setup.guide` into a `{ <locale>: markdown }` map.
- * Accepts the canonical object form (`{ en: "…", de: "…" }`) and tolerates a
- * bare string (treated as English). Empty strings and non-string values are
- * dropped; returns undefined when nothing usable remains.
+ * OM-15 (#602) — parse a `setup_profile` object. Additive and lenient: an
+ * unknown `audience`, a non-positive / non-integer `estimated_minutes`, or an
+ * empty `requirement` is DROPPED (not rejected), and an object with nothing
+ * usable returns undefined so the card renders no prerequisites row. Never
+ * throws — malformed input (manifest OR untrusted registry teaser) must not
+ * break the catalog. Exported so the store's remote-registry projection
+ * validates the same way the local catalog does.
  */
-function asLocalizedGuide(value: unknown): Record<string, string> | undefined {
-  if (typeof value === 'string') {
-    const s = value.trim();
-    return s.length > 0 ? { en: value } : undefined;
-  }
-  const rec = asRecord(value);
+export function parseSetupProfile(raw: unknown): SetupProfile | undefined {
+  const rec = asRecord(raw);
   if (!rec) return undefined;
-  const out: Record<string, string> = {};
-  for (const [locale, text] of Object.entries(rec)) {
-    if (typeof text === 'string' && text.trim().length > 0) out[locale] = text;
+
+  const profile: SetupProfile = {};
+
+  const audience = asString(rec['audience']);
+  if (audience && (SETUP_AUDIENCES as readonly string[]).includes(audience)) {
+    profile.audience = audience as SetupAudience;
   }
-  return Object.keys(out).length > 0 ? out : undefined;
+
+  const minutes = rec['estimated_minutes'];
+  if (typeof minutes === 'number' && Number.isInteger(minutes) && minutes > 0) {
+    profile.estimated_minutes = minutes;
+  }
+
+  const requirement = normalizeLocalized(rec['requirement']);
+  if (requirement) profile.requirement = requirement;
+
+  return Object.keys(profile).length > 0 ? profile : undefined;
+}
+
+/**
+ * Read `listing.setup_profile` from a full manifest doc's `listing` block.
+ *
+ * Deliberately under `listing`, NOT `setup` (where `setup.guide` lives): the
+ * profile is store-CARD presentation shown BEFORE install (audience/effort,
+ * alongside the card's name/description), not setup-wizard content the operator
+ * reads DURING install. Keeping the pre-install teaser separate from the
+ * install-step copy is why it gets its own block.
+ */
+function extractSetupProfile(listing: unknown): SetupProfile | undefined {
+  return parseSetupProfile(asRecord(listing)?.['setup_profile']);
 }
 
 function extractStringArray(value: unknown): string[] {

--- a/middleware/src/plugins/manifestLocalized.ts
+++ b/middleware/src/plugins/manifestLocalized.ts
@@ -1,0 +1,63 @@
+// Manifest-borne localizable setup text (OM-17 / #602).
+//
+// The manifest's setup-field family — `setup.guide`, `pattern_hint`, and now
+// `label` / `help` — is authored as a `{ <locale>: text }` map (a bare string is
+// tolerated and read as English). The catalog projection (`manifestLoader`) and
+// the install-schema projection (`installService`) both normalise with the SAME
+// function here so the store view and the install wizard can never disagree on
+// what a field says — the shared-fixture test guards that agreement.
+//
+// This is deliberately the map convention `pickLocalized` (web-ui) already
+// resolves, NOT conductor-core's `LocalizedText` (which requires an `en` base and
+// resolves differently). Setup text follows the setup-text precedent.
+
+import type { LocalizedMarkdown } from '../api/admin-v1.js';
+
+/**
+ * Normalise a manifest value into a `{ <locale>: text }` map. Accepts the
+ * canonical object form (`{ en: "…", de: "…" }`) and tolerates a bare string
+ * (treated as English). Empty strings and non-string values are dropped;
+ * returns undefined when nothing usable remains.
+ */
+export function normalizeLocalized(
+  value: unknown,
+): LocalizedMarkdown | undefined {
+  if (typeof value === 'string') {
+    return value.trim().length > 0 ? { en: value } : undefined;
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const out: LocalizedMarkdown = {};
+  for (const [locale, text] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof text === 'string' && text.trim().length > 0) out[locale] = text;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Resolve a localized map to a single display string for a server path that has
+ * NO request locale (validation-error templates, orchestrator prompt headers).
+ * Tries `preferred` first, then the same `en → de → any` fallback the web-ui's
+ * `pickLocalized` uses, so the two sides pick the same string when they can.
+ * Returns undefined when the map is empty or absent.
+ *
+ * Callers pass the locale their surrounding TEXT is written in — the install
+ * validator's error strings are German, so it passes `'de'` and a German label
+ * lands in a German sentence.
+ */
+export function resolveLocalized(
+  map: LocalizedMarkdown | undefined,
+  preferred?: string,
+): string | undefined {
+  if (!map) return undefined;
+  for (const key of [preferred, 'en', 'de']) {
+    if (!key) continue;
+    const v = map[key];
+    if (v && v.trim().length > 0) return v;
+  }
+  for (const v of Object.values(map)) {
+    if (v && v.trim().length > 0) return v;
+  }
+  return undefined;
+}

--- a/middleware/src/plugins/setupFieldPattern.ts
+++ b/middleware/src/plugins/setupFieldPattern.ts
@@ -767,7 +767,6 @@ export async function shutdownPatternWorker(): Promise<void> {
 /** The subset of a setup field this module needs. */
 export interface PatternCheckableField {
   key: string;
-  label?: string;
   pattern?: string;
   pattern_hint?: Record<string, string> | undefined;
 }

--- a/middleware/src/routes/store.ts
+++ b/middleware/src/routes/store.ts
@@ -10,6 +10,7 @@ import type {
 } from '../api/admin-v1.js';
 import type { InstalledRegistry } from '../plugins/installedRegistry.js';
 import type { PluginCatalog } from '../plugins/manifestLoader.js';
+import { parseSetupProfile } from '../plugins/manifestLoader.js';
 import type { PluginStatusRegistry } from '../platform/pluginStatusRegistry.js';
 import type { PluginVerdictLookup } from '../services/pluginVerdict.js';
 import { withReadiness, type ReadinessVault } from '../plugins/readiness.js';
@@ -420,6 +421,10 @@ function registryEntryToPlugin(resolved: ResolvedRegistryPlugin): Plugin {
     summary.setup_guide && Object.keys(summary.setup_guide).length > 0
       ? summary.setup_guide
       : undefined;
+  // OM-15 (#602) — re-validate the untrusted registry teaser through the same
+  // parser the local catalog uses, so a malformed remote profile degrades to
+  // "no prerequisites row" instead of a raw/partial object on the card.
+  const setupProfile = parseSetupProfile(summary.setup_profile);
 
   return {
     id: entry.id,
@@ -447,6 +452,7 @@ function registryEntryToPlugin(resolved: ResolvedRegistryPlugin): Plugin {
     multi_instance: true,
     privacy_class: 'default',
     ...(setupGuide ? { setup_guide: setupGuide } : {}),
+    ...(setupProfile ? { setup_profile: setupProfile } : {}),
     source: registrySource(resolved),
   };
 }

--- a/middleware/test/installServicePrivacyMode.test.ts
+++ b/middleware/test/installServicePrivacyMode.test.ts
@@ -76,11 +76,13 @@ describe('extractSetupSchema — synthetic _privacy_mode field', () => {
       }),
     );
     const f = schema?.fields.find((x) => x.key === PRIVACY_MODE_CONFIG_KEY);
-    assert.ok(f?.help);
-    assert.ok(f.help.includes('📌'), 'help text marks the author recommendation');
-    assert.ok(f.help.includes('Bypass'), 'help text names the recommended mode');
+    // #602 (OM-17) — help is a localized map now; this kernel copy is German.
+    const help = f?.help?.de ?? '';
+    assert.ok(help);
+    assert.ok(help.includes('📌'), 'help text marks the author recommendation');
+    assert.ok(help.includes('Bypass'), 'help text names the recommended mode');
     assert.ok(
-      f.help.includes('Document-shaped bodies'),
+      help.includes('Document-shaped bodies'),
       'help text includes the author reason',
     );
   });
@@ -109,7 +111,7 @@ describe('extractSetupSchema — synthetic _privacy_mode field', () => {
         ['guarded', 'bypass', 'per_tool'].includes(rec.mode);
       if (!validMode) {
         assert.ok(
-          !(f.help ?? '').includes('📌'),
+          !(f.help?.de ?? '').includes('📌'),
           'invalid recommendation must not surface as a hint',
         );
       }

--- a/middleware/test/manifestLoaderSetupFields.test.ts
+++ b/middleware/test/manifestLoaderSetupFields.test.ts
@@ -21,8 +21,17 @@ import type { PluginCatalogEntry } from '../src/plugins/manifestLoader.js';
 
 /** The one fixture both paths are measured against. */
 const SETUP_FIELDS: Array<Record<string, unknown>> = [
+  // #602 (OM-17) — a bare-string label is read as English on BOTH paths.
   { key: 'base_url', type: 'url', label: 'Base URL' },
-  { key: 'api_key', type: 'secret', label: 'API key', required: true },
+  {
+    key: 'api_key',
+    type: 'secret',
+    // #602 (OM-17) — a localized label/help map must survive identically on
+    // both projections, or a German operator and the install wizard disagree.
+    label: { en: 'API key', de: 'API-Schlüssel' },
+    help: { en: 'From the provider console', de: 'Aus der Anbieter-Konsole' },
+    required: true,
+  },
   { key: 'note', type: 'string', label: 'Note', required: false },
   {
     key: 'tenant',
@@ -73,6 +82,35 @@ test('`pattern` is passed through unchanged, and absent when not declared', () =
   assert.equal(loadedFields().get('base_url')?.pattern, undefined);
 });
 
+// #602 (OM-17) — label/help are localized maps.
+test('a bare-string label is read as English (`{ en }`)', () => {
+  assert.deepEqual(loadedFields().get('base_url')?.label, { en: 'Base URL' });
+});
+
+test('a localized label/help map is preserved verbatim', () => {
+  const f = loadedFields().get('api_key');
+  assert.deepEqual(f?.label, { en: 'API key', de: 'API-Schlüssel' });
+  assert.deepEqual(f?.help, {
+    en: 'From the provider console',
+    de: 'Aus der Anbieter-Konsole',
+  });
+});
+
+test('a label-less field falls back to `{ en: <key> }` on the store view', () => {
+  const plugin = adaptManifestV1({
+    schema_version: '1',
+    identity: {
+      id: 'de.byte5.integration.test',
+      kind: 'integration',
+      domain: 'test',
+      name: 'Test Plugin',
+      version: '1.0.0',
+    },
+    setup: { fields: [{ key: 'lonely', type: 'string' }] },
+  })!;
+  assert.deepEqual(plugin.setup_fields[0]?.label, { en: 'lonely' });
+});
+
 test('store and install-wizard paths agree on required for the SAME fixture', () => {
   const store = loadedFields();
   const entry = {
@@ -102,6 +140,19 @@ test('store and install-wizard paths agree on required for the SAME fixture', ()
       storeField.pattern,
       installField.pattern,
       `pattern drift on '${installField.key}'`,
+    );
+    // #602 (OM-17) — the localized label/help maps must be identical on both
+    // projections, or the store card and the install wizard say different
+    // things (or different languages) about the same field.
+    assert.deepEqual(
+      storeField.label,
+      installField.label,
+      `label drift on '${installField.key}'`,
+    );
+    assert.deepEqual(
+      storeField.help,
+      installField.help,
+      `help drift on '${installField.key}'`,
     );
   }
 });

--- a/middleware/test/manifestLocalized.test.ts
+++ b/middleware/test/manifestLocalized.test.ts
@@ -1,0 +1,52 @@
+// #602 (OM-17) — the shared normaliser/resolver both manifest projections use
+// for the localized setup-text family (label, help, pattern_hint, setup_guide).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normalizeLocalized,
+  resolveLocalized,
+} from '../src/plugins/manifestLocalized.js';
+
+test('normalizeLocalized reads a bare string as English', () => {
+  assert.deepEqual(normalizeLocalized('hello'), { en: 'hello' });
+});
+
+test('normalizeLocalized keeps a locale map and drops empty entries', () => {
+  assert.deepEqual(normalizeLocalized({ en: 'hi', de: 'hallo', fr: '  ' }), {
+    en: 'hi',
+    de: 'hallo',
+  });
+});
+
+test('normalizeLocalized returns undefined for empty / non-text input', () => {
+  assert.equal(normalizeLocalized(''), undefined);
+  assert.equal(normalizeLocalized('   '), undefined);
+  assert.equal(normalizeLocalized({}), undefined);
+  assert.equal(normalizeLocalized({ en: '' }), undefined);
+  assert.equal(normalizeLocalized(['en', 'de']), undefined);
+  assert.equal(normalizeLocalized(42), undefined);
+  assert.equal(normalizeLocalized(undefined), undefined);
+});
+
+test('resolveLocalized honours the preferred locale first', () => {
+  const map = { en: 'English', de: 'Deutsch' };
+  assert.equal(resolveLocalized(map, 'de'), 'Deutsch');
+  assert.equal(resolveLocalized(map, 'en'), 'English');
+});
+
+test('resolveLocalized falls back preferred → en → de → any', () => {
+  // Preferred locale absent → English base.
+  assert.equal(resolveLocalized({ en: 'E', de: 'D' }, 'fr'), 'E');
+  // Preferred + en absent → German (the install validator's German templates
+  // rely on this de fallback).
+  assert.equal(resolveLocalized({ de: 'D', fr: 'F' }, 'es'), 'D');
+  // Neither preferred/en/de → the one remaining locale.
+  assert.equal(resolveLocalized({ fr: 'F' }, 'es'), 'F');
+});
+
+test('resolveLocalized returns undefined for an absent map', () => {
+  assert.equal(resolveLocalized(undefined, 'de'), undefined);
+  assert.equal(resolveLocalized({}, 'de'), undefined);
+});

--- a/middleware/test/pluginContextRuntimeWrite.test.ts
+++ b/middleware/test/pluginContextRuntimeWrite.test.ts
@@ -82,8 +82,8 @@ function makeStubs() {
 }
 
 const SETUP_FIELDS: PluginSetupField[] = [
-  { key: 'app_id', label: 'App ID', type: 'string' },
-  { key: 'private_key', label: 'Key', type: 'secret' },
+  { key: 'app_id', label: { en: 'App ID' }, type: 'string' },
+  { key: 'private_key', label: { en: 'Key' }, type: 'secret' },
 ];
 
 function makeCatalog(runtimeWrite: boolean): PluginCatalog {

--- a/middleware/test/registrySetupProfile.test.ts
+++ b/middleware/test/registrySetupProfile.test.ts
@@ -1,0 +1,145 @@
+// OM-15 (#602) — read-back for the REMOTE path of the store card's
+// installation-effort profile. The local catalog path is covered by
+// `setupProfileManifest.test.ts`; this proves the branch that actually matters
+// for the Google Workspace plugin, which ships via `hub.omadia.ai` and reaches
+// the store only through the registry teaser (`manifest_summary.setup_profile`)
+// projected by `registryEntryToPlugin`. Assertions read the plugin OUT of the
+// real GET /store response, not a projection helper in isolation.
+
+import { describe, it, before, after } from 'node:test';
+import { strict as assert } from 'node:assert';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import express from 'express';
+
+import { RegistryClient, type RegistryClientDeps } from '../src/plugins/registryClient.js';
+import { createStoreRouter } from '../src/routes/store.js';
+import type { Plugin } from '../src/api/admin-v1.js';
+import type { PluginCatalog } from '../src/plugins/manifestLoader.js';
+import type { InstalledRegistry } from '../src/plugins/installedRegistry.js';
+
+const HUB = 'https://hub.test';
+
+function remotePlugin(id: string, setupProfile: unknown): unknown {
+  return {
+    id,
+    name: id,
+    kind: 'integration',
+    domain: 'productivity.google',
+    description: 'Connect Google Workspace.',
+    categories: ['productivity'],
+    authors: [{ name: 'byte5' }],
+    license: 'MIT',
+    icon_url: null,
+    latest_version: '1.0.0',
+    versions: [
+      {
+        version: '1.0.0',
+        compat_core: '>=1.0 <2.0',
+        sha256: 'a'.repeat(64),
+        size_bytes: 1,
+        download_url: `${HUB}/registry/${id}/1.0.0/plugin.zip`,
+        published_at: '2026-05-29T11:00:00Z',
+        // The hub flattens the manifest's `listing.setup_profile` into the
+        // teaser here; store.ts re-validates it through the SAME parser the
+        // local catalog uses (parseSetupProfile).
+        manifest_summary: { setup_profile: setupProfile },
+      },
+    ],
+  };
+}
+
+function indexJson(plugins: unknown[]): string {
+  return JSON.stringify({
+    schema_version: '1',
+    registry: { name: 'omadia-public', url: HUB },
+    generated_at: '2026-05-29T12:00:00Z',
+    plugins,
+  });
+}
+
+function mockFetch(body: string): RegistryClientDeps['fetchImpl'] {
+  return async (input) => {
+    const url = typeof input === 'string' ? input : String(input);
+    return url === `${HUB}/registry/index.json`
+      ? new Response(body)
+      : new Response('nf', { status: 404 });
+  };
+}
+
+const emptyCatalog = {
+  list: () => [],
+  get: () => undefined,
+} as unknown as PluginCatalog;
+
+const fakeRegistry = {
+  has: () => false,
+  get: () => undefined,
+} as unknown as InstalledRegistry;
+
+const FULL_PROFILE = {
+  audience: 'it_admin',
+  estimated_minutes: 15,
+  requirement: {
+    en: 'Google Workspace super-admin required',
+    de: 'Google-Workspace-Super-Admin erforderlich',
+  },
+};
+
+describe('store router · remote setup_profile projection (OM-15 #602)', () => {
+  let server: Server;
+  let base: string;
+
+  before(() => {
+    const client = new RegistryClient({
+      registries: [{ name: 'omadia-public', url: HUB }],
+      log: () => {},
+      fetchImpl: mockFetch(
+        indexJson([
+          remotePlugin('@omadia/google-workspace', FULL_PROFILE),
+          // A malformed remote teaser must degrade to "no prerequisites row",
+          // never a raw/partial object on the card.
+          remotePlugin('@omadia/bad-profile', {
+            audience: 'wizard',
+            estimated_minutes: 0,
+          }),
+          // A plugin that declares no profile carries none.
+          remotePlugin('@omadia/no-profile', undefined),
+        ]),
+      ),
+    });
+    const app = express();
+    app.use(
+      '/store',
+      createStoreRouter({ catalog: emptyCatalog, registry: fakeRegistry, client }),
+    );
+    server = app.listen(0);
+    base = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}/store`;
+  });
+
+  after(async () => {
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  it('a valid remote setup_profile lands on the store plugin verbatim', async () => {
+    const body = (await (await fetch(base)).json()) as { items: Plugin[] };
+    const gw = body.items.find((p) => p.id === '@omadia/google-workspace');
+    assert.ok(gw, 'the remote GW plugin is in the store list');
+    assert.deepEqual(gw.setup_profile, FULL_PROFILE);
+  });
+
+  it('a malformed remote setup_profile is dropped, not shown raw', async () => {
+    const body = (await (await fetch(base)).json()) as { items: Plugin[] };
+    const bad = body.items.find((p) => p.id === '@omadia/bad-profile');
+    assert.ok(bad, 'the malformed-profile plugin still lists');
+    // unknown audience + non-positive minutes → nothing usable → no row
+    assert.equal(bad.setup_profile, undefined);
+  });
+
+  it('a remote plugin with no profile carries none', async () => {
+    const body = (await (await fetch(base)).json()) as { items: Plugin[] };
+    const none = body.items.find((p) => p.id === '@omadia/no-profile');
+    assert.ok(none, 'the no-profile plugin still lists');
+    assert.equal(none.setup_profile, undefined);
+  });
+});

--- a/middleware/test/setupFieldPatternValidation.test.ts
+++ b/middleware/test/setupFieldPatternValidation.test.ts
@@ -282,7 +282,7 @@ describe('OM-17 — compileSetupPattern safety screen', () => {
   it('omits `hint` when the manifest declared no pattern_hint', async () => {
     // The API must never invent user-facing prose; the web-ui owns that copy.
     const violation = await checkSetupFieldPattern(
-      { key: 'k', label: 'Key', pattern: '^abc$' },
+      { key: 'k', pattern: '^abc$' },
       'nope',
     );
     assert.equal(violation?.field, 'k');

--- a/middleware/test/setupProfileManifest.test.ts
+++ b/middleware/test/setupProfileManifest.test.ts
@@ -1,0 +1,75 @@
+// OM-15 (#602) — the store card's installation-effort block, parsed from the
+// manifest's `listing.setup_profile`. Structured (audience · minutes ·
+// requirement) so the platform composes a LOCALIZED line rather than the plugin
+// baking German into the manifest. Lenient: malformed parts are dropped, never
+// thrown, so a bad listing degrades to "no prerequisites row".
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { adaptManifestV1, parseSetupProfile } from '../src/plugins/manifestLoader.js';
+
+function manifestWithListing(listing: unknown): Record<string, unknown> {
+  return {
+    schema_version: '1',
+    identity: {
+      id: 'de.byte5.integration.test',
+      kind: 'integration',
+      domain: 'test',
+      name: 'Test Plugin',
+      version: '1.0.0',
+    },
+    listing,
+  };
+}
+
+test('a full setup_profile lands on Plugin.setup_profile', () => {
+  const plugin = adaptManifestV1(
+    manifestWithListing({
+      setup_profile: {
+        audience: 'it_admin',
+        estimated_minutes: 15,
+        requirement: {
+          en: 'Google Workspace super-admin required',
+          de: 'Google-Workspace-Super-Admin erforderlich',
+        },
+      },
+    }),
+  )!;
+  assert.deepEqual(plugin.setup_profile, {
+    audience: 'it_admin',
+    estimated_minutes: 15,
+    requirement: {
+      en: 'Google Workspace super-admin required',
+      de: 'Google-Workspace-Super-Admin erforderlich',
+    },
+  });
+});
+
+test('an unknown audience is dropped, not rendered raw', () => {
+  const p = parseSetupProfile({ audience: 'wizard', estimated_minutes: 5 });
+  assert.equal(p?.audience, undefined);
+  assert.equal(p?.estimated_minutes, 5);
+});
+
+test('a non-positive / non-integer estimated_minutes is dropped', () => {
+  assert.equal(parseSetupProfile({ estimated_minutes: 0 }), undefined);
+  assert.equal(parseSetupProfile({ estimated_minutes: -3 }), undefined);
+  assert.equal(parseSetupProfile({ estimated_minutes: 2.5 }), undefined);
+  assert.equal(parseSetupProfile({ estimated_minutes: '15' }), undefined);
+});
+
+test('a bare-string requirement is read as English', () => {
+  assert.deepEqual(parseSetupProfile({ requirement: 'super-admin' })?.requirement, {
+    en: 'super-admin',
+  });
+});
+
+test('an empty / malformed profile yields undefined (no card row)', () => {
+  assert.equal(parseSetupProfile({}), undefined);
+  assert.equal(parseSetupProfile({ audience: 'nope', estimated_minutes: 0 }), undefined);
+  assert.equal(parseSetupProfile(null), undefined);
+  assert.equal(parseSetupProfile('nonsense'), undefined);
+  // A manifest without a `listing` block simply has no profile.
+  assert.equal(adaptManifestV1(manifestWithListing(undefined))!.setup_profile, undefined);
+});

--- a/middleware/test/storeReadinessProjection.test.ts
+++ b/middleware/test/storeReadinessProjection.test.ts
@@ -68,12 +68,12 @@ function fakeCatalog(plugins: Plugin[]): PluginCatalog {
 
 const secretField: PluginSetupField = {
   key: 'api_key',
-  label: 'API key',
+  label: { en: 'API key' },
   type: 'secret',
 };
 const configField: PluginSetupField = {
   key: 'workspace',
-  label: 'Workspace',
+  label: { en: 'Workspace' },
   type: 'string',
 };
 

--- a/web-ui/app/_components/store/CredentialsEditor.tsx
+++ b/web-ui/app/_components/store/CredentialsEditor.tsx
@@ -284,6 +284,10 @@ export function CredentialsEditor({
             field.type === 'oauth'
               ? undefined
               : pickLocalized(field.pattern_hint, locale);
+          // #602 (OM-17) — label/help are localized maps; resolve at the active
+          // locale so this editor shows the same language as the install wizard.
+          const fieldLabel = pickLocalized(field.label, locale);
+          const fieldHelp = pickLocalized(field.help, locale);
           return (
             <li
               key={field.key}
@@ -317,14 +321,14 @@ export function CredentialsEditor({
                     {isSecret ? 'Secret · Vault' : 'Config'}
                   </span>
                 </div>
-                {field.label ? (
+                {fieldLabel ? (
                   <div className="mt-0.5 text-[11px] text-[color:var(--muted-ink)]">
-                    {field.label}
+                    {fieldLabel}
                   </div>
                 ) : null}
-                {field.help ? (
+                {fieldHelp ? (
                   <div className="mt-1 text-[11px] leading-relaxed text-[color:var(--faint-ink)]">
-                    {field.help}
+                    {fieldHelp}
                   </div>
                 ) : null}
                 {/* OM-17 — THE single highest-value line in this file.

--- a/web-ui/app/_components/store/PluginCard.tsx
+++ b/web-ui/app/_components/store/PluginCard.tsx
@@ -1,7 +1,8 @@
 import Link from 'next/link';
-import { AlertTriangle, ArrowUpRight, RefreshCw, Store } from 'lucide-react';
-import { useTranslations } from 'next-intl';
+import { AlertTriangle, ArrowUpRight, RefreshCw, Store, Wrench } from 'lucide-react';
+import { useLocale, useTranslations } from 'next-intl';
 
+import { pickLocalized } from '../../_lib/localized';
 import type { Plugin } from '../../_lib/storeTypes';
 import { Chip } from './Chip';
 import { PluginIcon } from './PluginIcon';
@@ -20,6 +21,24 @@ export function PluginCard({
   initials,
 }: PluginCardProps): React.ReactElement {
   const t = useTranslations('store.card');
+  const locale = useLocale();
+  // OM-15 (#602) — installation-effort line composed from the structured
+  // `setup_profile`, so the wording stays localized (next-intl) rather than
+  // baked into the manifest. Only the parts the manifest declared are shown; an
+  // empty profile renders nothing. This is decision-support the tester lacked
+  // BEFORE install ("~15 min · Google Workspace super-admin required").
+  const profile = plugin.setup_profile;
+  const profileParts = profile
+    ? [
+        profile.audience
+          ? t(`setupProfile.audience.${profile.audience}`)
+          : null,
+        typeof profile.estimated_minutes === 'number'
+          ? t('setupProfile.minutes', { minutes: profile.estimated_minutes })
+          : null,
+        pickLocalized(profile.requirement, locale) ?? null,
+      ].filter((p): p is string => Boolean(p))
+    : [];
   const isLegacy = plugin.categories.includes('legacy');
   const visibleCategories = plugin.categories
     .filter((c) => c !== 'legacy')
@@ -87,6 +106,19 @@ export function PluginCard({
       >
         {plugin.description || <em>{t('noDescription')}</em>}
       </p>
+
+      {/* OM-15 (#602) — setup prerequisites, shown BEFORE install so the
+          effort (IT-admin, time, required admin role) is visible while the
+          operator is still deciding. */}
+      {profileParts.length > 0 ? (
+        <p
+          className="mt-3 flex items-start gap-1.5 text-[12px] leading-relaxed text-[color:var(--fg-subtle)]"
+          title={t('setupProfileLabel')}
+        >
+          <Wrench className="mt-px size-3.5 shrink-0" aria-hidden />
+          <span>{profileParts.join(' · ')}</span>
+        </p>
+      ) : null}
 
       {/* Metadata row. An update-available plugin IS installed — show that
           inline; the update itself is the top-right Störer. */}

--- a/web-ui/app/_components/store/__tests__/CredentialsEditorErrorHelp.test.tsx
+++ b/web-ui/app/_components/store/__tests__/CredentialsEditorErrorHelp.test.tsx
@@ -59,7 +59,7 @@ vi.mock('../../../_lib/api', () => ({
 function field(over: Partial<PluginSetupField> = {}): PluginSetupField {
   return {
     key: 'api_token',
-    label: 'API token',
+    label: { en: 'API token' },
     // `string`, not `secret`: a secret renders a password input, which has no
     // ARIA role, and this file is about the error line, not the input.
     type: 'string',

--- a/web-ui/app/_components/store/__tests__/CredentialsEditorPassword.test.tsx
+++ b/web-ui/app/_components/store/__tests__/CredentialsEditorPassword.test.tsx
@@ -46,7 +46,7 @@ const SA_EMAIL_PATTERN = '^[^@\\s]+@[^@\\s]+\\.iam\\.gserviceaccount\\.com$';
 function field(over: Partial<PluginSetupField> = {}): PluginSetupField {
   return {
     key: 'gw_sa_private_key',
-    label: 'Service account private key',
+    label: { en: 'Service account private key' },
     type: 'secret',
     ...over,
   };

--- a/web-ui/app/_components/store/__tests__/PluginCardSetupProfile.test.tsx
+++ b/web-ui/app/_components/store/__tests__/PluginCardSetupProfile.test.tsx
@@ -1,0 +1,89 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { renderWithIntl } from '../../../_lib/test-utils';
+import { PluginCard } from '../PluginCard';
+import type { Plugin } from '../../../_lib/storeTypes';
+
+/**
+ * OM-15 (#602) — the store card shows the installation-effort line BEFORE
+ * install, composed by the PLATFORM from the structured `setup_profile` via
+ * next-intl (so no German is baked into the manifest). The tester only learned
+ * a plugin needed a Google Cloud service account and super-admin rights AFTER
+ * installing; this row is what would have told them up front. Read-back tests:
+ * assert the composed, localized text on screen.
+ */
+
+function plugin(over: Partial<Plugin> = {}): Plugin {
+  return {
+    id: '@omadia/google-workspace',
+    kind: 'integration',
+    name: 'Google Workspace',
+    version: '1.0.0',
+    latest_version: '1.0.0',
+    description: 'Connect Google Workspace.',
+    categories: [],
+    integrations_summary: [],
+    install_state: 'available',
+    ...over,
+  } as Plugin;
+}
+
+const REQUIREMENT = {
+  en: 'Google Workspace super-admin required',
+  de: 'Google-Workspace-Super-Admin erforderlich',
+};
+
+describe('<PluginCard /> — setup prerequisites row', () => {
+  it('composes the German line: audience · time · requirement', () => {
+    renderWithIntl(
+      <PluginCard
+        plugin={plugin({
+          setup_profile: {
+            audience: 'it_admin',
+            estimated_minutes: 15,
+            requirement: REQUIREMENT,
+          },
+        })}
+      />,
+      { locale: 'de' },
+    );
+    const row = screen.getByText(/Einrichtung durch IT-Administrator/);
+    expect(row.textContent).toContain('ca. 15 Min');
+    expect(row.textContent).toContain(REQUIREMENT.de);
+    expect(screen.queryByText(new RegExp(REQUIREMENT.en))).toBeNull();
+  });
+
+  it('composes the English line for an English operator', () => {
+    renderWithIntl(
+      <PluginCard
+        plugin={plugin({
+          setup_profile: {
+            audience: 'it_admin',
+            estimated_minutes: 15,
+            requirement: REQUIREMENT,
+          },
+        })}
+      />,
+      { locale: 'en' },
+    );
+    const row = screen.getByText(/Setup by IT administrator/);
+    expect(row.textContent).toContain('~15 min');
+    expect(row.textContent).toContain(REQUIREMENT.en);
+  });
+
+  it('renders only the parts the manifest declared', () => {
+    renderWithIntl(
+      <PluginCard plugin={plugin({ setup_profile: { estimated_minutes: 5 } })} />,
+      { locale: 'de' },
+    );
+    expect(screen.getByText('ca. 5 Min')).toBeTruthy();
+    expect(screen.queryByText(/Einrichtung durch/)).toBeNull();
+  });
+
+  it('shows no prerequisites row when there is no profile', () => {
+    renderWithIntl(<PluginCard plugin={plugin()} />, { locale: 'de' });
+    expect(screen.queryByText(/Min/)).toBeNull();
+    expect(screen.queryByText(/Einrichtung durch/)).toBeNull();
+  });
+});

--- a/web-ui/app/_components/store/__tests__/setupFormLocalizedLabel.test.tsx
+++ b/web-ui/app/_components/store/__tests__/setupFormLocalizedLabel.test.tsx
@@ -1,0 +1,58 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { renderWithIntl } from '../../../_lib/test-utils';
+import { FieldRow } from '../setupForm';
+import type { InstallSetupField } from '../../../_lib/storeTypes';
+
+/**
+ * #602 (OM-17) — setup-field `label` / `help` are localized maps. The tester's
+ * report named "English field labels and help texts in a German UI" as a
+ * contributing factor. `FieldRow` holds the whole `{ locale: text }` map and
+ * picks the active locale itself (same mechanism as `pattern_hint`). These
+ * assertions read the RENDERED output, not the field input.
+ */
+
+const LABEL = { en: 'Service account email', de: 'Dienstkonto-Adresse' };
+const HELP = { en: 'From the Cloud console', de: 'Aus der Cloud-Konsole' };
+
+function field(over: Partial<InstallSetupField> = {}): InstallSetupField {
+  return {
+    key: 'gw_sa_client_email',
+    label: LABEL,
+    help: HELP,
+    type: 'string',
+    required: true,
+    ...over,
+  };
+}
+
+describe('<FieldRow /> — label/help render in the active locale', () => {
+  it('shows the German label and help for a German operator', () => {
+    renderWithIntl(<FieldRow field={field()} />, { locale: 'de' });
+    expect(screen.getByText(LABEL.de)).toBeTruthy();
+    expect(screen.getByText(HELP.de)).toBeTruthy();
+    expect(screen.queryByText(LABEL.en)).toBeNull();
+    expect(screen.queryByText(HELP.en)).toBeNull();
+  });
+
+  it('shows the English label and help for an English operator', () => {
+    renderWithIntl(<FieldRow field={field()} />, { locale: 'en' });
+    expect(screen.getByText(LABEL.en)).toBeTruthy();
+    expect(screen.getByText(HELP.en)).toBeTruthy();
+  });
+
+  it('falls back to another locale when the active one is absent', () => {
+    // English-only map, German UI → German operator still sees the English
+    // text (fallback) rather than a blank label.
+    renderWithIntl(<FieldRow field={field({ label: { en: 'Only English' } })} />, {
+      locale: 'de',
+    });
+    expect(screen.getByText('Only English')).toBeTruthy();
+  });
+
+  it('falls back to the field key when the label map is empty', () => {
+    renderWithIntl(<FieldRow field={field({ label: {} })} />, { locale: 'de' });
+    expect(screen.getByText('gw_sa_client_email')).toBeTruthy();
+  });
+});

--- a/web-ui/app/_components/store/__tests__/setupFormPatternHint.test.tsx
+++ b/web-ui/app/_components/store/__tests__/setupFormPatternHint.test.tsx
@@ -28,7 +28,7 @@ const DE = 'erwartet eine Dienstkonto-Adresse, kein Personenkonto';
 function field(over: Partial<InstallSetupField> = {}): InstallSetupField {
   return {
     key: 'gw_sa_client_email',
-    label: 'Service account email',
+    label: { en: 'Service account email' },
     type: 'string',
     required: true,
     pattern_hint: { en: EN, de: DE },

--- a/web-ui/app/_components/store/setupForm.tsx
+++ b/web-ui/app/_components/store/setupForm.tsx
@@ -44,6 +44,10 @@ export function FieldRow({
   const locale = useLocale();
   const id = `${idPrefix}-${field.key}`;
   const patternHint = pickLocalized(field.pattern_hint, locale);
+  // #602 (OM-17) — label/help are localized maps; resolve them at the active
+  // locale. A missing label falls back to the field key (never blank).
+  const fieldLabel = pickLocalized(field.label, locale) ?? field.key;
+  const fieldHelp = pickLocalized(field.help, locale);
   // OM-17 — a German operator must not read an English rejection. Only the
   // pattern code is overridden: every other install error is either already a
   // catalog string or a value-shape message the manifest cannot explain.
@@ -73,7 +77,7 @@ export function FieldRow({
         className="flex items-baseline justify-between gap-3 text-[11px] uppercase tracking-[0.16em] text-[color:var(--muted-ink)]"
       >
         <span>
-          {field.label}
+          {fieldLabel}
           {field.required ? (
             <span className="ml-1 text-[color:var(--oxblood)]">*</span>
           ) : null}
@@ -97,7 +101,7 @@ export function FieldRow({
               className="size-4 accent-[color:var(--oxblood)]"
             />
             <span className="text-[color:var(--muted-ink)]">
-              {field.help ?? t('enable')}
+              {fieldHelp ?? t('enable')}
             </span>
           </label>
         ) : field.type === 'enum' ? (
@@ -215,9 +219,9 @@ export function FieldRow({
         </p>
       ) : null}
 
-      {field.help && field.type !== 'boolean' ? (
+      {fieldHelp && field.type !== 'boolean' ? (
         <p className="mt-1 text-[11px] leading-relaxed text-[color:var(--faint-ink)]">
-          {field.help}
+          {fieldHelp}
         </p>
       ) : null}
       {errorText ? (

--- a/web-ui/app/_lib/storeTypes.ts
+++ b/web-ui/app/_lib/storeTypes.ts
@@ -20,11 +20,14 @@ export type AuditMode = 'single-host' | 'allowlist' | 'public-web';
 
 export interface PluginSetupField {
   key: string;
-  label: string;
+  /** #602 (OM-17) — localized label map (`{ en, de, … }`); a manifest may also
+   *  ship a bare string that the loader reads as English. Resolve with
+   *  `pickLocalized`; falls back to `key`. Mirrors middleware admin-v1. */
+  label: LocalizedMarkdown;
   type: SetupFieldType;
-  /** Optional help text from the manifest. Surfaced inline in the
-   *  post-install credentials editor. */
-  help?: string;
+  /** #602 (OM-17) — localized help map from the manifest. Surfaced in the
+   *  install wizard and the post-install editor; render with `pickLocalized`. */
+  help?: LocalizedMarkdown;
   /** Manifest default. The post-install editor pre-selects this value in
    *  an `enum` dropdown when nothing is stored yet. */
   default?: string;
@@ -258,11 +261,28 @@ export interface Plugin {
    *  page and in the install drawer ("how to create a Discord bot", "how to get
    *  M365 credentials"). Mirrors middleware admin-v1. */
   setup_guide?: LocalizedMarkdown;
+  /** OM-15 (#602) — installation-effort profile shown on the store card BEFORE
+   *  install (audience · time · a key prerequisite). From the manifest's
+   *  `listing.setup_profile`. Mirrors middleware admin-v1. Optional. */
+  setup_profile?: SetupProfile;
 }
 
 /** UI text available in several languages, keyed by locale (`en`, `de`, …).
  *  Mirrors `LocalizedMarkdown` in middleware admin-v1. */
 export type LocalizedMarkdown = Record<string, string>;
+
+/** OM-15 (#602) — who performs the plugin's setup. The card resolves this to a
+ *  localized label via next-intl. Mirrors middleware admin-v1 `SetupAudience`. */
+export type SetupAudience = 'it_admin' | 'operator' | 'end_user';
+
+/** OM-15 (#602) — structured install-effort metadata for the store card. The
+ *  card COMPOSES a localized line from these parts (next-intl), so no wording is
+ *  baked into the manifest. Mirrors middleware admin-v1 `SetupProfile`. */
+export interface SetupProfile {
+  audience?: SetupAudience;
+  estimated_minutes?: number;
+  requirement?: LocalizedMarkdown;
+}
 
 export interface StoreListResponse {
   items: Plugin[];
@@ -317,8 +337,10 @@ export type InstallJobState =
 export interface InstallSetupField {
   key: string;
   type: SetupFieldType;
-  label: string;
-  help?: string;
+  /** #602 (OM-17) — localized label map; see `PluginSetupField.label`. */
+  label: LocalizedMarkdown;
+  /** #602 (OM-17) — localized help map; see `PluginSetupField.help`. */
+  help?: LocalizedMarkdown;
   required: boolean;
   default?: unknown;
   enum?: Array<{ value: string; label: string }>;

--- a/web-ui/app/store/[id]/page.tsx
+++ b/web-ui/app/store/[id]/page.tsx
@@ -227,7 +227,7 @@ export default async function PluginDetailPage({
             >
               <div className="divide-y divide-[color:var(--rule)] border-y border-[color:var(--rule)]">
                 {plugin.setup_fields.map((field) => (
-                  <SecretRow key={field.key} field={field} />
+                  <SecretRow key={field.key} field={field} locale={locale} />
                 ))}
               </div>
             </Section>
@@ -491,8 +491,10 @@ function Section({
 
 function SecretRow({
   field,
+  locale,
 }: {
   field: PluginSetupField;
+  locale: string;
 }): React.ReactElement {
   return (
     <div className="flex items-baseline gap-4 py-3">
@@ -500,7 +502,9 @@ function SecretRow({
         {field.key}
       </span>
       <span className="min-w-0 flex-1 text-sm text-[color:var(--muted-ink)]">
-        {field.label}
+        {/* #602 (OM-17) — label is a localized map; resolve at the active
+            locale, fall back to the field key. */}
+        {pickLocalized(field.label, locale) ?? field.key}
       </span>
       <Chip tone={field.type === 'secret' ? 'accent' : 'muted'}>
         {field.type}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -2894,7 +2894,16 @@
       "updateTitleWithVersion": "Update verfügbar: {from} → {to}",
       "updateSticker": "Update",
       "noDescription": "Keine Beschreibung hinterlegt.",
-      "actionRequired": "Aktion erforderlich"
+      "actionRequired": "Aktion erforderlich",
+      "setupProfileLabel": "Einrichtung",
+      "setupProfile": {
+        "audience": {
+          "it_admin": "Einrichtung durch IT-Administrator",
+          "operator": "Einrichtung durch Betreiber",
+          "end_user": "Einrichtung durch Endnutzer"
+        },
+        "minutes": "ca. {minutes} Min"
+      }
     },
     "stateBadge": {
       "available": "Verfügbar",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -2894,7 +2894,16 @@
       "updateTitleWithVersion": "Update available: {from} → {to}",
       "updateSticker": "Update",
       "noDescription": "No description provided.",
-      "actionRequired": "Action required"
+      "actionRequired": "Action required",
+      "setupProfileLabel": "Setup",
+      "setupProfile": {
+        "audience": {
+          "it_admin": "Setup by IT administrator",
+          "operator": "Setup by operator",
+          "end_user": "Setup by end user"
+        },
+        "minutes": "~{minutes} min"
+      }
     },
     "stateBadge": {
       "available": "Available",


### PR DESCRIPTION
## What
  Platform half of #602. Setup-field `label`/`help` become localized maps (bare string still read as English, backward-compatible). New manifest `listing.setup_profile` (audience · minutes · requirement) shows install effort on the store card before install.

  ## Why
  Tester saw English labels above German instructions, and only learned a plugin needed a service account + Workspace super-admin after installing. Labels were typed `string` (no German possible) and there was no pre-install effort surface. Platform composes the localized line via next-intl.

  ## Test plan
  - [x] `npx tsc --noEmit` middleware — clean (only pre-existing unrelated `cookie.parseCookie`)
  - [x] middleware `node --test`: new localized/profile/remote-readback suites + flagged suites green
  - [x] web-ui `vitest` store suites (card row, localized label/help) — 16/16
  - [X] manual: `de` UI shows German label/help + card effort line

  ## Risk / blast radius
  - No migration; `label`/`help` widen `string → LocalizedMarkdown`, loader normalizes bare strings.
  - Types hand-mirrored in web-ui (no codegen — drift hazard).
  - Remote card row needs hub to flatten `listing.setup_profile` into the registry teaser + republish (separate step).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789140133&installation_model_id=428086&pr_number=673&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F673&signature=0c4ce085806aec03edc888e2110d6f5c0a442ff6df0dcff9dddf505c278aa530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->