### PR TITLE
fix(#669): authenticate /api/dev and lift the KG operator surfaces off the dev flag

### DIFF
--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -1262,8 +1262,11 @@ startet. Logged `scopes=N files=N turns=N skipped=N`.
 - `GET /api/dev/graph/session/:scope`
 - `GET /api/dev/graph/neighbors?nodeId=...`
 
-Alle hinter `DEV_ENDPOINTS_ENABLED=true`. Admin-geschützte Variante für
-Prod wäre machbar, aktuell nicht nötig.
+Alle hinter `DEV_ENDPOINTS_ENABLED=true` **und** der Operator-Session
+(Issue #669 — vorher waren sie unauthentifiziert). Die Operator-Flächen
+(KG-Lifecycle, KG-Priorities, Plugin-Domains) hängen nicht mehr an diesem
+Flag, sondern liegen unter `/api/v1/admin/kg-*` bzw. `/api/admin/domains`.
+Siehe `docs/security-architecture.md` §10.
 
 ### Agent-Query-Tool
 
@@ -1423,7 +1426,9 @@ CONFLUENCE_SPACE_KEY=HOME
 CONFLUENCE_PROXY_MAX_BYTES=200000
 # Optional endpoints
 ADMIN_TOKEN                         # mount /api/admin (mutating memory)
-DEV_ENDPOINTS_ENABLED=false         # mount /api/dev/* (unauth!)# Teams
+DEV_ENDPOINTS_ENABLED=false         # mount /api/dev/* (Session-gated seit #669; Dev-Scaffolding)
+DEV_ENDPOINTS_LOOPBACK_ONLY=false   # optional: /api/dev nur über Loopback (#669)
+# Teams
 MICROSOFT_APP_ID, MICROSOFT_APP_PASSWORD, MICROSOFT_APP_TYPE=MultiTenant,
 MICROSOFT_APP_TENANT_ID
 # Diagram rendering (alle 7 müssen gesetzt sein, sonst wird Feature deaktiviert)

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -393,7 +393,72 @@ entry meaningful.
 Telegram, Omadia UI) — no second, parallel response path — so
 privacy-guard's prompt masking and receipt behavior apply identically.
 
-## 10. Reviewer checklist
+## 10. Operator surfaces vs. dev endpoints (`/api/dev`, issue #669)
+
+Everything under `/api` is gated by one line in `middleware/src/index.ts`:
+
+```ts
+app.use('/api', requireAuth, createChatRouter({ … }));   // OB-106
+```
+
+It runs for **every** `/api/*` request, whichever router ultimately answers it.
+The only way past it is an entry in `middleware/src/auth/publicPaths.ts`, and
+every entry there is a surface that is unauthenticated until its own handler
+says otherwise.
+
+`/api/dev/*` used to hold such an entry, added whenever
+`DEV_ENDPOINTS_ENABLED=true`. That made a single boolean the difference between
+"operator only" and "anyone who knows the path" for:
+
+- `GET /api/dev/graph/*` — raw knowledge-graph browsing (sessions, turns,
+  neighbours, memories, plans)
+- `/api/dev/memory/*` — the memory-store browser contributed by the memory plugin
+- three `POST` routes that **triggered destructive knowledge-graph maintenance
+  sweeps** (decay/rotation, GC eviction, access flush)
+
+Confirmed empirically against a deployment under our control: uncredentialed
+`GET`s returned `200` with real payloads.
+
+**What holds now:**
+
+1. There is no `/api/dev` entry in `publicPaths`, and `publicPaths()` takes no
+   configuration — there is nothing left to flip. Every `/api/dev/*` request
+   needs an operator session, exactly like `/api/v1/admin/*`.
+2. The **operator** surfaces were never dev scaffolding and no longer live
+   behind the flag. They mount unconditionally under the authenticated admin
+   prefix (`middleware/src/routes/graphRouterMounts.ts`):
+
+   | Surface | Path | Mounted when |
+   |---|---|---|
+   | KG lifecycle admin | `/api/v1/admin/kg-lifecycle` | `graphLifecycle@1` is published |
+   | KG per-agent priorities | `/api/v1/admin/kg-priorities` | `agentPriorities@1` is published |
+   | Plugin domains (read-only) | `/api/admin/domains` | always |
+
+   `DEV_ENDPOINTS_ENABLED` is not an input to `mountKnowledgeGraphAdmin` — its
+   deps type has no field to carry it, so the separation is a type, not a
+   convention.
+3. `DEV_ENDPOINTS_LOOPBACK_ONLY=true` (optional, default off) additionally
+   refuses any `/api/dev` request that did not arrive over a loopback socket.
+   It reads `req.socket.remoteAddress`, never `X-Forwarded-For` — `trust proxy`
+   is on, so a guard on `req.ip` would be defeated by a header. Leave it off in
+   containerised setups, where the Next.js server proxies from a container
+   address.
+
+**Operating guidance.** `DEV_ENDPOINTS_ENABLED` is dev scaffolding: leave it off
+on deployed environments. It is no longer a security boundary on its own — but
+it is still extra attack surface, and on any middleware build **older than this
+change** it is unsafe on any internet-reachable deployment, with no mitigation
+short of turning it off or blocking `/api/dev` upstream.
+
+Tests: `middleware/test/devEndpoints/` (one no-credentials case per route,
+including all three destructive `POST`s, plus the negative control that
+restores the old allowlist entry and requires the surface to go open again).
+`bash middleware/test/devEndpoints/mutation-check.sh` breaks each guard in
+source and requires the suite to go red.
+
+---
+
+## 11. Reviewer checklist
 
 Before merging a PR that touches credentials, prompts, or proxy routes:
 
@@ -405,7 +470,11 @@ Before merging a PR that touches credentials, prompts, or proxy routes:
 - [ ] Any new proxy route validates the response shape before returning it
       to the agent (defends against prompt injection from upstream).
 - [ ] Any new sub-agent tool is scope-locked at construction time.
+- [ ] No new entry in `auth/publicPaths.ts` unless the route authenticates
+      itself, and then only the narrowest regex covering that one route (§10).
+- [ ] No operator surface is mounted inside a `DEV_ENDPOINTS_ENABLED` block —
+      operator routers belong under `/api/v1/admin/*` (§10).
 
 ---
 
-*Last reviewed: 2026-05.*
+*Last reviewed: 2026-08 (§10 added with issue #669).*

--- a/middleware/packages/harness-knowledge-graph-neon/src/lifecycleService.ts
+++ b/middleware/packages/harness-knowledge-graph-neon/src/lifecycleService.ts
@@ -12,7 +12,7 @@ import type {
  * OB-73, Slice D).
  *
  * Service capability published as `graphLifecycle@1` so kernel-side admin
- * routes (`/api/dev/graph/lifecycle/*`) can render the Tier-Histogram and
+ * routes (`/api/v1/admin/kg-lifecycle/*`) can render the Tier-Histogram and
  * trigger sweeps without re-reading the plugin's setup-fields. Holds the
  * bound configuration the plugin's `activate()` resolved at startup.
  *

--- a/middleware/src/auth/loopbackOnly.ts
+++ b/middleware/src/auth/loopbackOnly.ts
@@ -1,0 +1,70 @@
+/**
+ * Issue #669 — an optional address gate for the `/api/dev/*` scaffolding.
+ *
+ * The primary fix for #669 is that `/api/dev/*` now sits behind the same
+ * session gate as every other `/api` route. This is the second half of the
+ * issue's suggested direction: an operator who considers that surface
+ * genuinely local-only can bind it to loopback instead of relying on a code
+ * comment saying "LOCAL USE ONLY".
+ *
+ * Opt-in (`DEV_ENDPOINTS_LOOPBACK_ONLY=true`), NOT the default: in a
+ * containerised dev setup the browser talks to the Next.js server, which
+ * proxies `/bot-api/*` to the middleware from a container address. Defaulting
+ * this on would break that flow, and the session gate already closes the hole.
+ *
+ * Trust boundary: this reads the SOCKET address (`req.socket.remoteAddress`),
+ * never `X-Forwarded-For`. Express's `trust proxy` makes `req.ip` reflect
+ * client-supplied headers, so gating on `req.ip` would let a caller claim
+ * `127.0.0.1` and walk straight through. A guard that a header can defeat is
+ * decoration.
+ */
+
+import type { RequestHandler } from 'express';
+
+/**
+ * Loopback literals, including the IPv4-mapped IPv6 form Node reports when a
+ * v4 client reaches a dual-stack listener (`::ffff:127.0.0.1`). The whole
+ * `127.0.0.0/8` block counts — `127.0.0.2` is as local as `127.0.0.1`.
+ */
+export function isLoopbackAddress(address: string | undefined): boolean {
+  if (!address) return false;
+  const addr = address.startsWith('::ffff:') ? address.slice('::ffff:'.length) : address;
+  if (addr === '::1') return true;
+  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(addr);
+  if (!v4) return false;
+  const octets = v4.slice(1).map(Number);
+  if (octets.some((o) => o > 255)) return false;
+  return octets[0] === 127;
+}
+
+/**
+ * Refuse anything that did not arrive over a loopback socket with `403`.
+ *
+ * Returns a pass-through when `enabled` is false, so the call site stays one
+ * unconditional line and the disabled state is exercised by the same code path.
+ */
+export function createLoopbackOnly(opts: {
+  enabled: boolean;
+  log?: (message: string) => void;
+}): RequestHandler {
+  if (!opts.enabled) {
+    return (_req, _res, next) => {
+      next();
+    };
+  }
+  const log = opts.log ?? ((m: string) => console.warn(m));
+  return (req, res, next) => {
+    const remote = req.socket.remoteAddress;
+    if (isLoopbackAddress(remote)) {
+      next();
+      return;
+    }
+    log(
+      `[middleware] /api/dev refused non-loopback request from ${remote ?? 'unknown'} (DEV_ENDPOINTS_LOOPBACK_ONLY=true)`,
+    );
+    res.status(403).json({
+      code: 'dev.loopback_only',
+      message: 'dev endpoints are bound to loopback on this deployment',
+    });
+  };
+}

--- a/middleware/src/auth/publicPaths.ts
+++ b/middleware/src/auth/publicPaths.ts
@@ -97,11 +97,27 @@ export const STATIC_PUBLIC_PATHS: readonly RegExp[] = [
 ];
 
 /**
- * `/api/dev/*` is public only while `DEV_ENDPOINTS_ENABLED=true`, and those
- * routes are not mounted at all otherwise — so the bypass cannot leak.
+ * The allowlist `requireAuth` runs against.
+ *
+ * Issue #669 — this used to take `{ devEndpointsEnabled }` and append
+ * `/^\/api\/dev(?:\/|$|\?)/` when the flag was on. The reasoning recorded here
+ * was "those routes are not mounted at all otherwise — so the bypass cannot
+ * leak", which answers the wrong question: the leak was never a *stale* entry,
+ * it was the entry doing exactly what it said while the flag was on. One
+ * boolean turned knowledge-graph state and three destructive maintenance
+ * sweeps (`POST /api/dev/graph/lifecycle/run-{decay,gc,access-flush}`) into
+ * an anonymous surface on any internet-reachable deployment — confirmed with
+ * uncredentialed `200`s against a real one.
+ *
+ * So there is no config-dependent entry any more. `/api/dev/*` is behind the
+ * same session gate as every other `/api` route, and the operator surfaces
+ * that were trapped behind that flag moved to `/api/v1/admin/kg-*` (see
+ * `routes/graphRouterMounts.ts`).
+ *
+ * Kept as a function, not re-exported as the array, so the ONE production
+ * mount and every test keep going through a single accessor — the drift this
+ * module's doc comment above exists to prevent.
  */
-export function publicPaths(opts: { devEndpointsEnabled: boolean }): readonly RegExp[] {
-  return opts.devEndpointsEnabled
-    ? [...STATIC_PUBLIC_PATHS, /^\/api\/dev(?:\/|$|\?)/]
-    : STATIC_PUBLIC_PATHS;
+export function publicPaths(): readonly RegExp[] {
+  return STATIC_PUBLIC_PATHS;
 }

--- a/middleware/src/config.ts
+++ b/middleware/src/config.ts
@@ -193,11 +193,25 @@ const ConfigSchema = z.object({
     .transform((v) => v === 'true')
     .default(true),
 
-  // Local-dev endpoints (unauthenticated memory browser, …). Keep this OFF in
-  // any deployed environment — the router mounts under /api/dev and exposes
-  // raw memory contents without auth. Only enable when iterating on the
+  // Local-dev endpoints (raw graph browser, memory browser, …) under /api/dev.
+  //
+  // Issue #669: these used to mount WITHOUT authentication, so this flag alone
+  // published knowledge-graph state — and three destructive maintenance sweeps —
+  // to anyone who knew the path. They now sit behind the same operator session
+  // gate as every other /api route, and the KG-Lifecycle / priorities operator
+  // pages moved to /api/v1/admin/kg-* so they no longer need this flag at all.
+  // Still dev scaffolding: leave it off unless you are iterating on the
   // Next.js dev UI against a local middleware.
   DEV_ENDPOINTS_ENABLED: z
+    .enum(['true', 'false'])
+    .transform((v) => v === 'true')
+    .default(false),
+
+  // Issue #669 — belt-and-braces for /api/dev: refuse any request that did not
+  // arrive over a loopback socket (403), on top of the session gate. Off by
+  // default because a containerised dev setup proxies through the Next.js
+  // server from a non-loopback address. See auth/loopbackOnly.ts.
+  DEV_ENDPOINTS_LOOPBACK_ONLY: z
     .enum(['true', 'false'])
     .transform((v) => v === 'true')
     .default(false),
@@ -643,6 +657,7 @@ const ConfigSchema = z.object({
  * only through `config.devPlatform` (epic #470 C3).
  *
  *   - `DEV_ENDPOINTS_ENABLED` — the core dev-graph endpoints (`/api/dev/*`).
+ *   - `DEV_ENDPOINTS_LOOPBACK_ONLY` — the #669 address gate over the same surface.
  *   - `FLY_APP_NAME`          — Fly-injected identity of THIS app. The dev platform
  *                               reads its value (copied into `devPlatform.fly`),
  *                               but the key describes the host, not the feature, so
@@ -656,7 +671,11 @@ const ConfigSchema = z.object({
  * with no second list to forget. A new *core* key with those prefixes must be
  * added here — and that is the change that deserves the review attention.
  */
-const CORE_DEV_PREFIXED_KEYS = ['DEV_ENDPOINTS_ENABLED', 'FLY_APP_NAME'] as const;
+const CORE_DEV_PREFIXED_KEYS = [
+  'DEV_ENDPOINTS_ENABLED',
+  'DEV_ENDPOINTS_LOOPBACK_ONLY',
+  'FLY_APP_NAME',
+] as const;
 type CoreDevPrefixedKey = (typeof CORE_DEV_PREFIXED_KEYS)[number];
 
 type ParsedConfig = z.infer<typeof ConfigSchema>;

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -63,10 +63,14 @@ import {
 // plugin via ctx.routes.register (see packages/harness-channel-teams/src/plugin.ts,
 // phase-3.1-4). No kernel-side attachment router import needed anymore.
 import { createChatSessionsRouter } from './routes/chatSessions.js';
-import { createDevGraphRouter } from './routes/devGraph.js';
-import { createDevGraphLifecycleRouter } from './routes/devGraphLifecycle.js';
-import { createAgentPrioritiesRouter } from './routes/agentPriorities.js';
-import { createAdminDomainsRouter } from './routes/adminDomains.js';
+import {
+  DEV_GRAPH_PATH,
+  KG_LIFECYCLE_ADMIN_PATH,
+  KG_PRIORITIES_ADMIN_PATH,
+  PLUGIN_DOMAINS_ADMIN_PATH,
+  mountDevGraph,
+  mountKnowledgeGraphAdmin,
+} from './routes/graphRouterMounts.js';
 import type { LifecycleService } from '@omadia/knowledge-graph-neon/dist/lifecycleService.js';
 import type {
   AgentPrioritiesStore,
@@ -1484,7 +1488,7 @@ async function main(): Promise<void> {
     // those so the channel plugins can run their own auth downstream —
     // same protection as before for `/api/chat`, `/api/v1/operator/*`,
     // `/api/v1/admin/*`, etc. since none of them match these regexes.
-    publicPaths: publicPaths({ devEndpointsEnabled: config.DEV_ENDPOINTS_ENABLED }),
+    publicPaths: publicPaths(),
   });
 
   // ContextRetriever + FactExtractor construction moved to AFTER
@@ -4526,51 +4530,41 @@ async function main(): Promise<void> {
 
   // `/api/dev/memory` is now mounted by the @omadia/memory plugin via
   // ctx.routes.register when its `dev_memory_endpoints_enabled` config is true.
-  if (config.DEV_ENDPOINTS_ENABLED) {
-    app.use('/api/dev/graph', createDevGraphRouter({ graph: knowledgeGraph }));
-    // OB-73 — palaia Phase 4 lifecycle admin (Tier-Histogram + Run-Now).
-    // Mounted only when the KG-Neon plugin published `graphLifecycle@1`
-    // (in-memory backend stays unmounted because the lifecycle is
-    // Postgres-specific).
-    const lifecycleService =
-      serviceRegistry.get<LifecycleService>('graphLifecycle');
-    if (lifecycleService) {
-      app.use(
-        '/api/dev/graph/lifecycle',
-        createDevGraphLifecycleRouter({ lifecycle: lifecycleService }),
-      );
-      console.log(
-        '[middleware] kg-lifecycle admin endpoints ready at /api/dev/graph/lifecycle',
-      );
-    }
-    // OB-74 — palaia Phase 5 per-agent block/boost admin. Mounted only when
-    // the KG-Neon plugin published `agentPriorities@1` (in-memory backend
-    // can leave the page empty — the admin UI degrades to "no entries").
-    const agentPrioritiesStore =
-      serviceRegistry.get<AgentPrioritiesStore>('agentPriorities');
-    if (agentPrioritiesStore) {
-      app.use(
-        '/api/dev/graph/priorities',
-        createAgentPrioritiesRouter({ store: agentPrioritiesStore }),
-      );
-      console.log(
-        '[middleware] kg-priorities admin endpoints ready at /api/dev/graph/priorities',
-      );
-    }
+  // It is authenticated by the same OB-106 `/api` requireAuth line as everything
+  // else here — issue #669 removed the `/api/dev` entry from `publicPaths`.
 
-    // OB-77 — Palaia Phase 8 plugin-domain admin. Read-only listing of
-    // all loaded plugins grouped by their declared identity.domain.
-    // Mounted unconditionally (the catalog is always present); curation
-    // is deferred to OB-78 Phase 9 Agent-Profile work.
-    app.use(
-      '/api/admin/domains',
-      createAdminDomainsRouter({ catalog: pluginCatalog }),
-    );
+  // Issue #669 — the operator surfaces (KG lifecycle, per-agent priorities,
+  // plugin domains) no longer live behind DEV_ENDPOINTS_ENABLED. They are
+  // authenticated admin routers; publishing the dev scaffolding was never a
+  // supported price for reaching them. `graphLifecycle@1`/`agentPriorities@1`
+  // are published by the Neon KG plugin only — the in-memory backend leaves
+  // them unmounted because the lifecycle sweeps are Postgres-specific.
+  const kgAdminMounted = mountKnowledgeGraphAdmin(app, requireAuth, {
+    lifecycle: serviceRegistry.get<LifecycleService>('graphLifecycle'),
+    priorities: serviceRegistry.get<AgentPrioritiesStore>('agentPriorities'),
+    catalog: pluginCatalog,
+  });
+  console.log(
+    `[middleware] KG admin endpoints ready (auth: required) — lifecycle=${
+      kgAdminMounted.lifecycle ? KG_LIFECYCLE_ADMIN_PATH : 'unmounted (no graphLifecycle@1)'
+    }, priorities=${
+      kgAdminMounted.priorities ? KG_PRIORITIES_ADMIN_PATH : 'unmounted (no agentPriorities@1)'
+    }, domains=${PLUGIN_DOMAINS_ADMIN_PATH}`,
+  );
+
+  // The flag is read inside `mountDevGraph`, not in an `if` here — see its doc
+  // comment: one tested consumer, and an admin mount that cannot depend on it.
+  if (
+    mountDevGraph(app, requireAuth, {
+      graph: knowledgeGraph,
+      enabled: config.DEV_ENDPOINTS_ENABLED,
+      loopbackOnly: config.DEV_ENDPOINTS_LOOPBACK_ONLY,
+    })
+  ) {
     console.log(
-      '[middleware] domains admin endpoint ready at /api/admin/domains',
-    );
-    console.warn(
-      '[middleware] ⚠ DEV endpoints enabled at /api/dev — unauthenticated, LOCAL USE ONLY',
+      `[middleware] DEV endpoints enabled at ${DEV_GRAPH_PATH} (auth: required${
+        config.DEV_ENDPOINTS_LOOPBACK_ONLY ? ', loopback-only' : ''
+      })`,
     );
   }
 

--- a/middleware/src/routes/agentPriorities.ts
+++ b/middleware/src/routes/agentPriorities.ts
@@ -18,9 +18,11 @@ const UpsertBodySchema = z.object({
 
 /**
  * Operator-facing per-Agent priorities admin endpoints (palaia Phase 5 /
- * OB-74 Slice 5). Mounted under `/api/dev/graph/priorities` only when
- * `DEV_ENDPOINTS_ENABLED` is set, mirroring the kg-lifecycle pattern. The
- * web-ui page at `/admin/kg-priorities` is the consumer.
+ * OB-74 Slice 5). Mounted at `/api/v1/admin/kg-priorities` behind the
+ * operator session gate whenever `agentPriorities@1` is published, mirroring
+ * the kg-lifecycle pattern — see `routes/graphRouterMounts.ts` and issue #669,
+ * which moved both off the unauthenticated `/api/dev` prefix. The web-ui page
+ * at `/admin/kg-priorities` is the consumer.
  *
  *   GET    /:agentId                 — list (block | boost) entries
  *   POST   /:agentId/:entryId        — upsert (action, weight, reason)

--- a/middleware/src/routes/devGraphLifecycle.ts
+++ b/middleware/src/routes/devGraphLifecycle.ts
@@ -9,10 +9,15 @@ interface DevGraphLifecycleDeps {
 
 /**
  * Operator-facing lifecycle admin endpoints (palaia Phase 4 / OB-73, Slice D).
- * Mounted under `/api/dev/graph/lifecycle` only when `DEV_ENDPOINTS_ENABLED`
- * is set. The web-ui page at `/admin/kg-lifecycle` consumes these routes
- * for the Tier-Histogram + manual-trigger buttons. Production deployments
- * never expose this — sweeps run on the cron schedule.
+ *
+ * Mounted at `/api/v1/admin/kg-lifecycle` by `routes/graphRouterMounts.ts`,
+ * behind the operator session gate, whenever `graphLifecycle@1` is published.
+ * Issue #669 moved it here: it used to sit under the unauthenticated
+ * `/api/dev/graph/lifecycle` prefix, which made the three `run-*` routes below
+ * anonymous triggers for destructive sweeps on any internet-reachable
+ * deployment — and made the admin page require `DEV_ENDPOINTS_ENABLED`.
+ * The web-ui page at `/admin/kg-lifecycle` consumes these routes for the
+ * Tier-Histogram + manual-trigger buttons; the sweeps otherwise run on cron.
  *
  *   GET  /stats             — current Tier histogram + decay distribution
  *                             + top scopes by Turn count

--- a/middleware/src/routes/graphRouterMounts.ts
+++ b/middleware/src/routes/graphRouterMounts.ts
@@ -1,0 +1,142 @@
+/**
+ * Issue #669 — the mount points for the knowledge-graph HTTP surfaces.
+ *
+ * These lived inline in `index.ts` inside ONE `if (config.DEV_ENDPOINTS_ENABLED)`
+ * block, which conflated two different things:
+ *
+ *   - **Operator surfaces** — the KG-Lifecycle and per-agent-priorities admin
+ *     routers, consumed by `/admin/kg-lifecycle` and `/admin/kg-priorities`.
+ *     These are production operator tooling. Requiring a dev flag to reach them
+ *     meant an operator who wanted the page had no supported way to get it
+ *     without also publishing the dev scaffolding below.
+ *   - **Dev scaffolding** — `createDevGraphRouter`, raw graph browsing for the
+ *     Next.js dev UI.
+ *
+ * They are separated here, and the module exists (rather than staying inline)
+ * for the reason `auth/publicPaths.ts` states in its own doc comment: a test
+ * that assembles its own approximation of a mount proves nothing about the
+ * mount production runs. Both the express wiring and the tests call these
+ * functions and these path constants.
+ *
+ * Authentication for everything below is the OB-106 `app.use('/api', requireAuth, …)`
+ * line, which runs for EVERY `/api/*` request whichever router answers it. The
+ * explicit `requireAuth` argument each mount also passes is defence-in-depth
+ * against a future reordering — it is the same middleware over the same
+ * allowlist, so it is not an independent gate.
+ */
+
+import type { Express, RequestHandler } from 'express';
+
+import type { AgentPrioritiesStore } from '@omadia/plugin-api';
+import type { LifecycleService } from '@omadia/knowledge-graph-neon/dist/lifecycleService.js';
+import type { KnowledgeGraph } from '@omadia/plugin-api';
+
+import { createAgentPrioritiesRouter } from './agentPriorities.js';
+import { createDevGraphLifecycleRouter } from './devGraphLifecycle.js';
+import { createDevGraphRouter } from './devGraph.js';
+import { createAdminDomainsRouter } from './adminDomains.js';
+import { createLoopbackOnly } from '../auth/loopbackOnly.js';
+import type { PluginCatalog } from '../plugins/manifestLoader.js';
+
+/** Operator surface — authenticated, mounted regardless of any dev flag. */
+export const KG_LIFECYCLE_ADMIN_PATH = '/api/v1/admin/kg-lifecycle';
+/** Operator surface — authenticated, mounted regardless of any dev flag. */
+export const KG_PRIORITIES_ADMIN_PATH = '/api/v1/admin/kg-priorities';
+/** Operator surface — authenticated, mounted regardless of any dev flag. */
+export const PLUGIN_DOMAINS_ADMIN_PATH = '/api/admin/domains';
+/** Dev scaffolding — authenticated AND behind `DEV_ENDPOINTS_ENABLED`. */
+export const DEV_GRAPH_PATH = '/api/dev/graph';
+
+export interface KnowledgeGraphAdminDeps {
+  /** Published as `graphLifecycle@1` by the Neon KG plugin only. */
+  readonly lifecycle?: LifecycleService | undefined;
+  /** Published as `agentPriorities@1` by the Neon KG plugin only. */
+  readonly priorities?: AgentPrioritiesStore | undefined;
+  /** Always present — the loaded-plugin catalog. */
+  readonly catalog: PluginCatalog;
+}
+
+export interface KnowledgeGraphAdminMounted {
+  readonly lifecycle: boolean;
+  readonly priorities: boolean;
+}
+
+/**
+ * Mount the operator-facing KG admin routers under the authenticated
+ * `/api/v1/admin/*` prefix.
+ *
+ * Call this unconditionally. A router is skipped only when the service backing
+ * it was never published — the in-memory KG backend publishes neither, because
+ * the lifecycle sweeps are Postgres-specific. That absence is what the admin
+ * page's empty state describes; it is no longer a feature-flag state.
+ */
+export function mountKnowledgeGraphAdmin(
+  app: Express,
+  requireAuth: RequestHandler,
+  deps: KnowledgeGraphAdminDeps,
+): KnowledgeGraphAdminMounted {
+  const { lifecycle, priorities, catalog } = deps;
+
+  if (lifecycle) {
+    app.use(
+      KG_LIFECYCLE_ADMIN_PATH,
+      requireAuth,
+      createDevGraphLifecycleRouter({ lifecycle }),
+    );
+  }
+  if (priorities) {
+    app.use(
+      KG_PRIORITIES_ADMIN_PATH,
+      requireAuth,
+      createAgentPrioritiesRouter({ store: priorities }),
+    );
+  }
+  // OB-77 — read-only plugin-domain listing. Its own comment always claimed it
+  // was "mounted unconditionally"; the enclosing dev-flag `if` said otherwise.
+  // Now the comment is true.
+  app.use(PLUGIN_DOMAINS_ADMIN_PATH, requireAuth, createAdminDomainsRouter({ catalog }));
+
+  return { lifecycle: Boolean(lifecycle), priorities: Boolean(priorities) };
+}
+
+export interface DevGraphMountDeps {
+  readonly graph: KnowledgeGraph;
+  /** `config.DEV_ENDPOINTS_ENABLED`. False ⇒ nothing is mounted. */
+  readonly enabled: boolean;
+  /** `config.DEV_ENDPOINTS_LOOPBACK_ONLY`. See `auth/loopbackOnly.ts`. */
+  readonly loopbackOnly?: boolean;
+  /** Injected by tests to silence the refusal log. */
+  readonly log?: (message: string) => void;
+}
+
+/**
+ * Mount the dev-only raw graph browser, when the flag says so.
+ *
+ * The flag is read HERE rather than in an `if` at the call site, deliberately:
+ * it means `DEV_ENDPOINTS_ENABLED` is consumed in exactly one place that a
+ * test can drive, and `mountKnowledgeGraphAdmin` above is incapable of
+ * depending on it — its deps type has no field to carry it. That is the #669
+ * separation expressed as a type rather than as a comment.
+ *
+ * `requireAuth` is passed explicitly so this mount reads as guarded at the call
+ * site as well as behind the blanket `/api` line — the code comment that used
+ * to say "unauthenticated, LOCAL USE ONLY" was, for a year, the only thing
+ * standing between this router and the internet.
+ */
+export function mountDevGraph(
+  app: Express,
+  requireAuth: RequestHandler,
+  deps: DevGraphMountDeps,
+): boolean {
+  if (!deps.enabled) return false;
+  app.use(
+    DEV_GRAPH_PATH,
+    createLoopbackOnly({
+      enabled: deps.loopbackOnly ?? false,
+      ...(deps.log ? { log: deps.log } : {}),
+    }),
+    requireAuth,
+    createDevGraphRouter({ graph: deps.graph }),
+  );
+  return true;
+}

--- a/middleware/test/channelApi/publicPathsExemption.test.ts
+++ b/middleware/test/channelApi/publicPathsExemption.test.ts
@@ -23,7 +23,7 @@ import { publicPaths } from '../../src/auth/publicPaths.js';
  * half of the story.
  */
 describe('publicPaths — @omadia/channel-api exemption', () => {
-  const paths = publicPaths({ devEndpointsEnabled: false });
+  const paths = publicPaths();
   const isPublic = (path: string): boolean => paths.some((re) => re.test(path));
 
   it('exempts the public chat route', () => {

--- a/middleware/test/devEndpoints/devEndpointsAuth.e2e.test.ts
+++ b/middleware/test/devEndpoints/devEndpointsAuth.e2e.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Issue #669 — `/api/dev/*` used to mount with NO authentication whenever
+ * `DEV_ENDPOINTS_ENABLED=true`, and the KG-Lifecycle / priorities operator
+ * pages were trapped inside that same flag. Confirmed empirically against a
+ * real deployment: uncredentialed `GET`s returned `200` with live payloads,
+ * and three `POST`s were anonymous triggers for destructive knowledge-graph
+ * maintenance sweeps.
+ *
+ * This suite states both halves of the fix as assertions:
+ *
+ *   A. Every route under `/api/dev` answers `401` without a session — one
+ *      case per route, including all three destructive POSTs.
+ *   B. The operator surfaces answer `200` with a session and `DEV_ENDPOINTS_ENABLED`
+ *      OFF, which is the whole point of moving them: the admin page works
+ *      without publishing anything.
+ *
+ * The negative control (`withLegacyDevPublicPath`) restores the deleted
+ * allowlist entry and asserts the surface goes open again — so a future
+ * re-add cannot pass this suite. `test/devEndpoints/mutation-check.sh` runs
+ * the same idea against the real source file.
+ */
+
+import { strict as assert } from 'node:assert';
+import { after, before, describe, it } from 'node:test';
+
+import {
+  DEV_GRAPH_PATH,
+  KG_LIFECYCLE_ADMIN_PATH,
+  KG_PRIORITIES_ADMIN_PATH,
+  PLUGIN_DOMAINS_ADMIN_PATH,
+} from '../../src/routes/graphRouterMounts.js';
+import {
+  isSandboxListenDenied,
+  startDevEndpointsHarness,
+  type DevEndpointsHarness,
+} from './harness.js';
+
+/**
+ * Every route the issue lists as exposed, by the path it answers on today.
+ * The three `run-*` entries are the sharp end: unauthenticated triggers for
+ * destructive sweeps. They are exercised here as `POST` with no credentials,
+ * which is exactly the request the issue deliberately did NOT send at the
+ * real deployment.
+ */
+const DEV_ROUTES: ReadonlyArray<{ method: string; path: string; note: string }> = [
+  { method: 'GET', path: `${DEV_GRAPH_PATH}/stats`, note: 'graph node/edge counts' },
+  { method: 'GET', path: `${DEV_GRAPH_PATH}/sessions`, note: 'session list' },
+  { method: 'GET', path: `${DEV_GRAPH_PATH}/topics`, note: 'topic list' },
+  { method: 'GET', path: `${DEV_GRAPH_PATH}/issues`, note: 'issue list' },
+  {
+    method: 'GET',
+    path: `${DEV_GRAPH_PATH}/neighbors?nodeId=x`,
+    note: 'arbitrary node expansion',
+  },
+  // The `/api/dev/memory/*` surface is contributed by the memory plugin at
+  // runtime, so nothing is mounted here — which is the point. The blanket
+  // `/api` guard must answer 401 BEFORE express reaches its 404, or the
+  // plugin's routes would be open the moment the plugin registers them.
+  { method: 'GET', path: '/api/dev/memory/entries', note: 'plugin-contributed memory browser' },
+];
+
+/** The destructive triggers, kept in their own list so they read as such. */
+const DESTRUCTIVE_LIFECYCLE_ROUTES: readonly string[] = [
+  'run-decay',
+  'run-gc',
+  'run-access-flush',
+];
+
+describe('#669 — /api/dev is authenticated', () => {
+  let h: DevEndpointsHarness;
+  let skip = false;
+
+  before(async () => {
+    try {
+      h = await startDevEndpointsHarness({ devEndpointsEnabled: true });
+    } catch (err) {
+      if (isSandboxListenDenied(err)) {
+        skip = true;
+        return;
+      }
+      throw err;
+    }
+  });
+
+  after(async () => {
+    if (!skip) await h.close();
+  });
+
+  for (const route of DEV_ROUTES) {
+    it(`${route.method} ${route.path} → 401 without a session (${route.note})`, async (t) => {
+      if (skip) return t.skip('sandbox denies loopback listeners');
+      const res = await h.request(route.path, { method: route.method });
+      assert.equal(
+        res.status,
+        401,
+        `${route.path} answered ${String(res.status)} — an anonymous caller must never reach it`,
+      );
+    });
+  }
+
+  it('serves the dev graph to an authenticated operator', async (t) => {
+    if (skip) return t.skip('sandbox denies loopback listeners');
+    const res = await h.request(`${DEV_GRAPH_PATH}/stats`, { authenticated: true });
+    assert.equal(res.status, 200);
+  });
+
+  it('does not mount the dev graph at all when DEV_ENDPOINTS_ENABLED is off', async (t) => {
+    if (skip) return t.skip('sandbox denies loopback listeners');
+    const off = await startDevEndpointsHarness({ devEndpointsEnabled: false });
+    try {
+      // Authenticated, so a 401 here would be the guard rather than the mount.
+      const res = await off.request(`${DEV_GRAPH_PATH}/stats`, { authenticated: true });
+      assert.equal(res.status, 404);
+    } finally {
+      await off.close();
+    }
+  });
+});
+
+describe('#669 — the destructive lifecycle sweeps are not anonymous triggers', () => {
+  let h: DevEndpointsHarness;
+  let skip = false;
+
+  before(async () => {
+    try {
+      h = await startDevEndpointsHarness();
+    } catch (err) {
+      if (isSandboxListenDenied(err)) {
+        skip = true;
+        return;
+      }
+      throw err;
+    }
+  });
+
+  after(async () => {
+    if (!skip) await h.close();
+  });
+
+  for (const sweep of DESTRUCTIVE_LIFECYCLE_ROUTES) {
+    it(`POST ${KG_LIFECYCLE_ADMIN_PATH}/${sweep} → 401 without a session`, async (t) => {
+      if (skip) return t.skip('sandbox denies loopback listeners');
+      const res = await h.request(`${KG_LIFECYCLE_ADMIN_PATH}/${sweep}`, {
+        method: 'POST',
+      });
+      assert.equal(res.status, 401);
+    });
+  }
+
+  /**
+   * The status code alone can be produced by a route that ran and then failed.
+   * This asserts the service was never touched — the sweep did not happen.
+   */
+  it('never reaches the lifecycle service on an unauthenticated POST', async (t) => {
+    if (skip) return t.skip('sandbox denies loopback listeners');
+    assert.ok(h.lifecycle, 'harness must publish a recording lifecycle service');
+    h.lifecycle.calls.length = 0;
+    for (const sweep of DESTRUCTIVE_LIFECYCLE_ROUTES) {
+      await h.request(`${KG_LIFECYCLE_ADMIN_PATH}/${sweep}`, { method: 'POST' });
+    }
+    assert.deepEqual(
+      h.lifecycle.calls,
+      [],
+      'a destructive sweep ran for a caller with no credentials',
+    );
+  });
+
+  it('runs the sweep for an authenticated operator', async (t) => {
+    if (skip) return t.skip('sandbox denies loopback listeners');
+    assert.ok(h.lifecycle);
+    h.lifecycle.calls.length = 0;
+    const res = await h.request(`${KG_LIFECYCLE_ADMIN_PATH}/run-decay`, {
+      method: 'POST',
+      authenticated: true,
+    });
+    assert.equal(res.status, 200);
+    assert.deepEqual(h.lifecycle.calls, ['runDecayNow']);
+  });
+});
+
+describe('#669 — the operator surfaces no longer need DEV_ENDPOINTS_ENABLED', () => {
+  let h: DevEndpointsHarness;
+  let skip = false;
+
+  before(async () => {
+    try {
+      // The state an operator is actually in: the dev flag OFF, the KG plugin
+      // installed and healthy. Before #669 this combination made the admin
+      // page unreachable and blame the database.
+      h = await startDevEndpointsHarness({ devEndpointsEnabled: false });
+    } catch (err) {
+      if (isSandboxListenDenied(err)) {
+        skip = true;
+        return;
+      }
+      throw err;
+    }
+  });
+
+  after(async () => {
+    if (!skip) await h.close();
+  });
+
+  const ADMIN_ROUTES: readonly string[] = [
+    `${KG_LIFECYCLE_ADMIN_PATH}/stats`,
+    `${KG_LIFECYCLE_ADMIN_PATH}/last-runs`,
+    `${KG_PRIORITIES_ADMIN_PATH}/orchestrator-default`,
+    PLUGIN_DOMAINS_ADMIN_PATH,
+  ];
+
+  for (const path of ADMIN_ROUTES) {
+    it(`GET ${path} → 200 for an operator with the dev flag OFF`, async (t) => {
+      if (skip) return t.skip('sandbox denies loopback listeners');
+      const res = await h.request(path, { authenticated: true });
+      assert.equal(
+        res.status,
+        200,
+        `${path} answered ${String(res.status)} — the admin page must work without the dev flag`,
+      );
+    });
+
+    it(`GET ${path} → 401 without a session`, async (t) => {
+      if (skip) return t.skip('sandbox denies loopback listeners');
+      const res = await h.request(path);
+      assert.equal(res.status, 401);
+    });
+  }
+
+  it('leaves the lifecycle routes unmounted when graphLifecycle@1 was never published', async (t) => {
+    if (skip) return t.skip('sandbox denies loopback listeners');
+    // The in-memory KG backend. This — not the dev flag — is what the admin
+    // page's empty state describes after #669.
+    const noKg = await startDevEndpointsHarness({
+      devEndpointsEnabled: false,
+      lifecycle: null,
+    });
+    try {
+      const res = await noKg.request(`${KG_LIFECYCLE_ADMIN_PATH}/stats`, {
+        authenticated: true,
+      });
+      assert.equal(res.status, 404);
+    } finally {
+      await noKg.close();
+    }
+  });
+});
+
+/**
+ * The negative control. Restoring the pre-#669 allowlist entry must make the
+ * surface anonymous again — otherwise the assertions above are passing for
+ * some unrelated reason and the allowlist edit is not what closed the hole.
+ */
+describe('#669 — the removed publicPaths entry is what closes the hole', () => {
+  it('goes open again when the legacy /api/dev allowlist entry is restored', async (t) => {
+    let h: DevEndpointsHarness;
+    try {
+      h = await startDevEndpointsHarness({ withLegacyDevPublicPath: true });
+    } catch (err) {
+      if (isSandboxListenDenied(err)) return t.skip('sandbox denies loopback listeners');
+      throw err;
+    }
+    try {
+      const res = await h.request(`${DEV_GRAPH_PATH}/stats`);
+      assert.equal(
+        res.status,
+        200,
+        'restoring the entry must reopen the surface — if it does not, these tests prove nothing',
+      );
+    } finally {
+      await h.close();
+    }
+  });
+
+  it('does not reopen the moved admin surfaces (they are outside /api/dev)', async (t) => {
+    let h: DevEndpointsHarness;
+    try {
+      h = await startDevEndpointsHarness({ withLegacyDevPublicPath: true });
+    } catch (err) {
+      if (isSandboxListenDenied(err)) return t.skip('sandbox denies loopback listeners');
+      throw err;
+    }
+    try {
+      const res = await h.request(`${KG_LIFECYCLE_ADMIN_PATH}/stats`);
+      assert.equal(res.status, 401);
+    } finally {
+      await h.close();
+    }
+  });
+});
+
+describe('#669 — DEV_ENDPOINTS_LOOPBACK_ONLY', () => {
+  it('serves an authenticated operator over loopback when enabled', async (t) => {
+    let h: DevEndpointsHarness;
+    try {
+      h = await startDevEndpointsHarness({ loopbackOnly: true });
+    } catch (err) {
+      if (isSandboxListenDenied(err)) return t.skip('sandbox denies loopback listeners');
+      throw err;
+    }
+    try {
+      // The harness listens on 127.0.0.1, so the request IS loopback.
+      const res = await h.request(`${DEV_GRAPH_PATH}/stats`, { authenticated: true });
+      assert.equal(res.status, 200);
+    } finally {
+      await h.close();
+    }
+  });
+});

--- a/middleware/test/devEndpoints/harness.ts
+++ b/middleware/test/devEndpoints/harness.ts
@@ -1,0 +1,253 @@
+/**
+ * Issue #669 — shared harness for the `/api/dev/*` + KG-admin auth tests.
+ *
+ * Assembles the SAME chain `src/index.ts` assembles, in the same order, for
+ * the reason recorded at the top of `src/auth/publicPaths.ts`: epic #470's
+ * runner router was mounted without a session guard and its e2e test built its
+ * OWN bare `express()` app to prove it — so the test passed while the route
+ * 401'd in production behind the blanket guard. A test app that omits the
+ * guard proves nothing about a route whose reachability depends on it, and the
+ * inverse is what #669 is about: a test app that omits the guard would also
+ * fail to notice that the guard is missing.
+ *
+ * So:
+ *   1. `express.json({ limit: '10mb' })` + `cookieParser()` — the same global
+ *      parsers. The cookie parser is load-bearing: without it every request
+ *      401s, and the negative assertions would pass for the wrong reason.
+ *   2. `app.use('/api', requireAuth, <router>)` — the OB-106 line, which runs
+ *      for EVERY `/api/*` request whichever router ultimately answers it.
+ *   3. `mountKnowledgeGraphAdmin` / `mountDevGraph` — the SAME production
+ *      functions from `src/routes/graphRouterMounts.ts`, not a re-implementation.
+ *   4. `createRequireAuth({ publicPaths: publicPaths() })` — the SAME shared
+ *      allowlist production runs.
+ *
+ * `withLegacyDevPublicPath` drives the negative half: put the pre-#669
+ * `/^\/api\/dev/` entry back into the allowlist and the surface must go open
+ * again. That is the mutation this suite exists to catch.
+ */
+
+import type { AddressInfo } from 'node:net';
+import { createServer, type Server } from 'node:http';
+
+import cookieParser from 'cookie-parser';
+import express, { type Express } from 'express';
+
+import { NoopAgentPrioritiesStore } from '@omadia/plugin-api';
+import type { AgentPrioritiesStore } from '@omadia/plugin-api';
+import { InMemoryKnowledgeGraph } from '@omadia/knowledge-graph-inmemory';
+import type {
+  LastSweep,
+  LifecycleService,
+  LifecycleStats,
+} from '@omadia/knowledge-graph-neon/dist/lifecycleService.js';
+
+// The three sweep-stat shapes live in sibling modules (`decayJob`, `gc`,
+// `accessTracker`) and are not re-exported from `lifecycleService`. Derived
+// from the interface itself rather than reached for by deep path: the fake
+// below then cannot drift from what the service actually promises.
+type DecaySweepStats = Awaited<ReturnType<LifecycleService['runDecayNow']>>;
+type GcSweepStats = Awaited<ReturnType<LifecycleService['runGcNow']>>;
+type AccessTrackerFlushStats = Awaited<
+  ReturnType<LifecycleService['runAccessFlushNow']>
+>;
+
+import { publicPaths, STATIC_PUBLIC_PATHS } from '../../src/auth/publicPaths.js';
+import { createRequireAuth } from '../../src/auth/requireAuth.js';
+import { SESSION_COOKIE } from '../../src/auth/requireAuth.js';
+import { signSession } from '../../src/auth/sessionJwt.js';
+import { EmailWhitelist } from '../../src/auth/whitelist.js';
+import { PluginCatalog } from '../../src/plugins/manifestLoader.js';
+import {
+  mountDevGraph,
+  mountKnowledgeGraphAdmin,
+} from '../../src/routes/graphRouterMounts.js';
+
+/** The allowlist entry #669 deleted, restored verbatim for the negative case. */
+export const LEGACY_DEV_PUBLIC_PATH = /^\/api\/dev(?:\/|$|\?)/;
+
+const SESSION_KEY = new Uint8Array(64).fill(9);
+const OPERATOR_EMAIL = 'operator@example.com';
+
+/** True when the sandbox refuses loopback listeners, so callers can self-skip. */
+export function isSandboxListenDenied(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'EPERM';
+}
+
+/**
+ * A `LifecycleService` that records every call.
+ *
+ * Declared `implements LifecycleService` rather than cast through
+ * `as unknown as` on purpose: a cast would let a renamed or missing method
+ * compile and then surface as a `500` inside a test that is asking about
+ * `401` vs `200`, which reads as "the guard let it through" — the exact
+ * confusion that makes an auth suite untrustworthy.
+ */
+export class RecordingLifecycleService implements LifecycleService {
+  readonly calls: string[] = [];
+
+  getStats(): Promise<LifecycleStats> {
+    this.calls.push('getStats');
+    return Promise.resolve({
+      totalTurns: 3,
+      byTier: { HOT: 1, WARM: 1, COLD: 1 },
+      byEntryType: { memory: 3, process: 0, task: 0 },
+      decayDistribution: { high: 1, upperMid: 1, lowerMid: 1, cold: 0 },
+      topScopesByCount: [{ scope: 'demo', count: 3, chars: 300 }],
+      quotas: { hotMaxEntries: 50, maxTotalChars: 100_000 },
+    });
+  }
+
+  runDecayNow(): Promise<DecaySweepStats> {
+    this.calls.push('runDecayNow');
+    return Promise.resolve({
+      decayUpdated: 0,
+      hotToWarm: 0,
+      warmToCold: 0,
+      doneTasksDeleted: 0,
+      durationMs: 1,
+    });
+  }
+
+  runGcNow(): Promise<GcSweepStats> {
+    this.calls.push('runGcNow');
+    return Promise.resolve({
+      scopesAffected: 0,
+      evictedByCount: 0,
+      evictedByChars: 0,
+      durationMs: 1,
+    });
+  }
+
+  runAccessFlushNow(): Promise<AccessTrackerFlushStats> {
+    this.calls.push('runAccessFlushNow');
+    return Promise.resolve({ flushed: 0, promotedColdToWarm: 0, durationMs: 1 });
+  }
+
+  lastDecay(): LastSweep<DecaySweepStats> | null {
+    return null;
+  }
+
+  lastGc(): LastSweep<GcSweepStats> | null {
+    return null;
+  }
+
+  lastAccessFlush(): LastSweep<AccessTrackerFlushStats> | null {
+    return null;
+  }
+}
+
+export interface DevEndpointsHarnessOptions {
+  /** Mirrors `config.DEV_ENDPOINTS_ENABLED`. Default `true` — most cases are
+   *  about the surface being guarded, not about it being absent. */
+  readonly devEndpointsEnabled?: boolean;
+  /** Mirrors `config.DEV_ENDPOINTS_LOOPBACK_ONLY`. Default `false`. */
+  readonly loopbackOnly?: boolean;
+  /** Publish `graphLifecycle@1`. Omitted ⇒ a `RecordingLifecycleService`;
+   *  `null` ⇒ the service was never published (in-memory KG backend). */
+  readonly lifecycle?: LifecycleService | null;
+  /** Publish `agentPriorities@1`. Omitted ⇒ a `NoopAgentPrioritiesStore`;
+   *  `null` ⇒ never published. */
+  readonly priorities?: AgentPrioritiesStore | null;
+  /** Restore the pre-#669 `/api/dev` allowlist entry — the negative case. */
+  readonly withLegacyDevPublicPath?: boolean;
+}
+
+export interface DevEndpointsHarness {
+  readonly baseUrl: string;
+  readonly app: Express;
+  readonly lifecycle: RecordingLifecycleService | undefined;
+  /** A valid operator session cookie for the whitelisted email. */
+  readonly cookie: string;
+  /** `fetch` against the harness. Sends the session cookie only if asked. */
+  request(
+    path: string,
+    opts?: { method?: string; authenticated?: boolean },
+  ): Promise<Response>;
+  close(): Promise<void>;
+}
+
+export async function startDevEndpointsHarness(
+  opts: DevEndpointsHarnessOptions = {},
+): Promise<DevEndpointsHarness> {
+  const app = express();
+  app.set('trust proxy', true);
+  app.use(express.json({ limit: '10mb' }));
+  // index.ts:2435 — without it `req.cookies` is undefined and requireAuth 401s
+  // every request, including a valid one. Omitting it here would make the
+  // "401 without a session" assertions pass for the wrong reason.
+  app.use(cookieParser());
+
+  const allowlist = opts.withLegacyDevPublicPath
+    ? [...STATIC_PUBLIC_PATHS, LEGACY_DEV_PUBLIC_PATH]
+    : publicPaths();
+
+  const requireAuth = createRequireAuth({
+    signingKey: SESSION_KEY,
+    whitelist: new EmailWhitelist(OPERATOR_EMAIL),
+    publicPaths: allowlist,
+  });
+
+  // (2) The OB-106 line. The trailing router stands in for createChatRouter —
+  // what matters is that the guard runs first for the whole `/api` prefix,
+  // which is what makes an unmounted `/api/dev/memory/...` path answer 401
+  // rather than 404.
+  app.use('/api', requireAuth, express.Router());
+
+  const lifecycle =
+    opts.lifecycle === null ? undefined : (opts.lifecycle ?? new RecordingLifecycleService());
+  const priorities =
+    opts.priorities === null ? undefined : (opts.priorities ?? new NoopAgentPrioritiesStore());
+
+  // (3) The production mount functions.
+  mountKnowledgeGraphAdmin(app, requireAuth, {
+    lifecycle,
+    priorities,
+    catalog: new PluginCatalog({ manifestDir: '/nonexistent-for-tests' }),
+  });
+
+  mountDevGraph(app, requireAuth, {
+    graph: new InMemoryKnowledgeGraph(),
+    enabled: opts.devEndpointsEnabled ?? true,
+    loopbackOnly: opts.loopbackOnly ?? false,
+    log: () => {},
+  });
+
+  const server: Server = createServer(app);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+  const { port } = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${String(port)}`;
+
+  const token = await signSession(
+    {
+      sub: 'op1',
+      email: OPERATOR_EMAIL,
+      display_name: 'Operator',
+      provider: 'local',
+      role: 'admin',
+    },
+    SESSION_KEY,
+  );
+  const cookie = `${SESSION_COOKIE}=${token}`;
+
+  return {
+    baseUrl,
+    app,
+    lifecycle: lifecycle instanceof RecordingLifecycleService ? lifecycle : undefined,
+    cookie,
+    request: (path, o) =>
+      fetch(`${baseUrl}${path}`, {
+        method: o?.method ?? 'GET',
+        headers: o?.authenticated ? { Cookie: cookie } : {},
+      }),
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}

--- a/middleware/test/devEndpoints/loopbackOnly.test.ts
+++ b/middleware/test/devEndpoints/loopbackOnly.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Issue #669 — the optional `/api/dev` address gate.
+ *
+ * The e2e suite can only exercise the ALLOW branch (its own listener is on
+ * 127.0.0.1). The refusal branch — and the header-spoofing question, which is
+ * the only interesting thing about a guard like this — is asserted here
+ * against the middleware directly.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { Request, Response } from 'express';
+
+import { createLoopbackOnly, isLoopbackAddress } from '../../src/auth/loopbackOnly.js';
+
+interface FakeResult {
+  readonly nexted: boolean;
+  readonly status: number | undefined;
+  readonly body: unknown;
+}
+
+/** Drives the middleware with a socket address and optional spoofing headers. */
+function run(
+  handler: ReturnType<typeof createLoopbackOnly>,
+  remoteAddress: string | undefined,
+  headers: Record<string, string> = {},
+): FakeResult {
+  let nexted = false;
+  let status: number | undefined;
+  let body: unknown;
+  const res = {
+    status(code: number) {
+      status = code;
+      return this;
+    },
+    json(payload: unknown) {
+      body = payload;
+      return this;
+    },
+  } as unknown as Response;
+  const req = {
+    socket: { remoteAddress },
+    headers,
+    ip: headers['x-forwarded-for'] ?? remoteAddress,
+  } as unknown as Request;
+  handler(req, res, () => {
+    nexted = true;
+  });
+  return { nexted, status, body };
+}
+
+describe('isLoopbackAddress', () => {
+  it('accepts the IPv4 and IPv6 loopback literals', () => {
+    assert.equal(isLoopbackAddress('127.0.0.1'), true);
+    assert.equal(isLoopbackAddress('::1'), true);
+  });
+
+  it('accepts the IPv4-mapped IPv6 form a dual-stack listener reports', () => {
+    // Node reports this for a v4 client reaching a `::` listener, which is how
+    // index.ts binds. Missing it would refuse every local request.
+    assert.equal(isLoopbackAddress('::ffff:127.0.0.1'), true);
+  });
+
+  it('accepts the whole 127.0.0.0/8 block', () => {
+    assert.equal(isLoopbackAddress('127.0.0.2'), true);
+    assert.equal(isLoopbackAddress('127.255.255.254'), true);
+  });
+
+  it('rejects private, public and malformed addresses', () => {
+    assert.equal(isLoopbackAddress('10.0.0.5'), false);
+    assert.equal(isLoopbackAddress('172.17.0.3'), false);
+    assert.equal(isLoopbackAddress('93.184.216.34'), false);
+    assert.equal(isLoopbackAddress('fd00::1'), false);
+    assert.equal(isLoopbackAddress('127.0.0.999'), false);
+    assert.equal(isLoopbackAddress('127.0.0.1.evil.example'), false);
+    assert.equal(isLoopbackAddress(''), false);
+    assert.equal(isLoopbackAddress(undefined), false);
+  });
+});
+
+describe('createLoopbackOnly', () => {
+  it('passes everything through when disabled', () => {
+    const handler = createLoopbackOnly({ enabled: false });
+    assert.equal(run(handler, '10.0.0.5').nexted, true);
+  });
+
+  it('passes a loopback request through when enabled', () => {
+    const handler = createLoopbackOnly({ enabled: true, log: () => {} });
+    assert.equal(run(handler, '::ffff:127.0.0.1').nexted, true);
+  });
+
+  it('refuses a non-loopback request with 403', () => {
+    const handler = createLoopbackOnly({ enabled: true, log: () => {} });
+    const result = run(handler, '10.0.0.5');
+    assert.equal(result.nexted, false);
+    assert.equal(result.status, 403);
+    assert.deepEqual(result.body, {
+      code: 'dev.loopback_only',
+      message: 'dev endpoints are bound to loopback on this deployment',
+    });
+  });
+
+  /**
+   * The one mistake that makes this guard decorative. `trust proxy` is on in
+   * index.ts, so `req.ip` reflects `X-Forwarded-For` — a caller could simply
+   * claim to be 127.0.0.1. The guard reads the socket instead.
+   */
+  it('is not defeated by a spoofed X-Forwarded-For', () => {
+    const handler = createLoopbackOnly({ enabled: true, log: () => {} });
+    const result = run(handler, '203.0.113.7', { 'x-forwarded-for': '127.0.0.1' });
+    assert.equal(result.nexted, false);
+    assert.equal(result.status, 403);
+  });
+
+  it('refuses a request with no discoverable socket address', () => {
+    const handler = createLoopbackOnly({ enabled: true, log: () => {} });
+    assert.equal(run(handler, undefined).status, 403);
+  });
+});

--- a/middleware/test/devEndpoints/mutation-check.sh
+++ b/middleware/test/devEndpoints/mutation-check.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Issue #669 — mutation harness for the /api/dev + KG-admin authentication fix.
+#
+# A green suite proves nothing on its own: the assertions have to be the reason
+# it is green. Each entry below deliberately BREAKS one invariant with a real
+# source edit, re-runs the suite, and requires a real assertion failure. A
+# mutation that leaves the suite green means the invariant is untested — this
+# script FAILS in that direction, which is the point.
+#
+# Usage: bash test/devEndpoints/mutation-check.sh
+# Run from middleware/. Reverts every edit via `git checkout --` afterwards.
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+
+MUTATED_PATHS=(src/auth/publicPaths.ts src/auth/loopbackOnly.ts src/routes/graphRouterMounts.ts)
+
+# ── Guard: never run against a dirty tree ───────────────────────────────────
+# This harness EDITS tracked source files in place and restores them with
+# `git checkout --`. A concurrent commit can sweep a mid-mutation file into
+# history, and a kill mid-run leaves the last mutation applied. Refusing to
+# start on a dirty tree makes the first detectable; the leak check at the end
+# makes the second loud. NEVER commit while this script is running.
+if [ -n "$(git status --porcelain -- "${MUTATED_PATHS[@]}")" ]; then
+  echo "✖ REFUSING TO RUN: uncommitted changes in the files this harness mutates."
+  echo "  Commit or stash them first — a concurrent commit can capture a mutation."
+  git status --porcelain -- "${MUTATED_PATHS[@]}"
+  exit 2
+fi
+
+PATHS=src/auth/publicPaths.ts
+LOOPBACK=src/auth/loopbackOnly.ts
+MOUNTS=src/routes/graphRouterMounts.ts
+
+TESTS=('test/devEndpoints/devEndpointsAuth.e2e.test.ts'
+       'test/devEndpoints/loopbackOnly.test.ts'
+       'test/publicPaths.test.ts')
+
+pass=0; fail=0
+
+revert() { git checkout -- "${MUTATED_PATHS[@]}" 2>/dev/null; }
+
+# run_mutation <label> <file> <old|||new[@@@old|||new…]>
+run_mutation() {
+  local label="$1" file="$2" mutation="$3"
+  revert
+  if ! python3 - "$file" "$mutation" <<'PY'
+import sys
+path, mutation = sys.argv[1], sys.argv[2]
+src = open(path).read()
+for pair in mutation.split('@@@'):
+    old, new = pair.split('|||')
+    if old not in src:
+        print(f'MUTATION-NOT-APPLICABLE: {old[:70]!r} not found in {path}')
+        sys.exit(2)
+    src = src.replace(old, new, 1)
+open(path, 'w').write(src)
+PY
+  then
+    echo "‼ SKIPPED (mutation no longer applies): $label"
+    fail=$((fail+1)); revert; return
+  fi
+
+  local out
+  out=$(node --import tsx --test --test-timeout=30000 "${TESTS[@]}" 2>&1)
+  # A mutation is CAUGHT by a failed assertion OR by a cancelled test — a suite
+  # that no longer COMPLETES has detected the regression just as surely.
+  if echo "$out" | grep -qE '^# (fail|cancelled) [1-9]|ℹ (fail|cancelled) [1-9]'; then
+    local n
+    n=$(echo "$out" | sed -E 's/\x1b\[[0-9;]*m//g' | grep -oE '(fail|cancelled) [1-9][0-9]*' | tr '\n' ' ')
+    echo "✔ CAUGHT ($n): $label"
+    pass=$((pass+1))
+  else
+    echo "✖ NOT CAUGHT — invariant is untested: $label"
+    fail=$((fail+1))
+  fi
+  revert
+}
+
+echo "── the allowlist entry (THE #669 fix) ───────────────────────────────────"
+# The exact pre-#669 state: /api/dev exempt from the session gate.
+run_mutation "the /api/dev publicPaths exemption is restored" "$PATHS" \
+  'export function publicPaths(): readonly RegExp[] {
+  return STATIC_PUBLIC_PATHS;|||export function publicPaths(): readonly RegExp[] {
+  return [...STATIC_PUBLIC_PATHS, /^\/api\/dev(?:\/|$|\?)/];'
+# A narrower re-open: only the destructive sweeps. Must still be caught.
+run_mutation "only the lifecycle sub-tree is re-exempted" "$PATHS" \
+  'export function publicPaths(): readonly RegExp[] {
+  return STATIC_PUBLIC_PATHS;|||export function publicPaths(): readonly RegExp[] {
+  return [...STATIC_PUBLIC_PATHS, /^\/api\/dev\/graph(?:\/|$|\?)/];'
+
+echo "── the dev/operator separation ──────────────────────────────────────────"
+# The regression the issue is really about: the admin page needing the dev flag.
+run_mutation "the KG-lifecycle admin router goes back behind a flag" "$MOUNTS" \
+  'if (lifecycle) {
+    app.use(
+      KG_LIFECYCLE_ADMIN_PATH,|||if (false && lifecycle) {
+    app.use(
+      KG_LIFECYCLE_ADMIN_PATH,'
+run_mutation "the priorities admin router goes back behind a flag" "$MOUNTS" \
+  'if (priorities) {
+    app.use(
+      KG_PRIORITIES_ADMIN_PATH,|||if (false && priorities) {
+    app.use(
+      KG_PRIORITIES_ADMIN_PATH,'
+run_mutation "the plugin-domains admin router goes back behind a flag" "$MOUNTS" \
+  'app.use(PLUGIN_DOMAINS_ADMIN_PATH, requireAuth, createAdminDomainsRouter({ catalog }));|||if (false) app.use(PLUGIN_DOMAINS_ADMIN_PATH, requireAuth, createAdminDomainsRouter({ catalog }));'
+# The admin routers must be AUTHENTICATED, not merely reachable. Dropping the
+# explicit guard here is caught because these paths sit outside the harness's
+# blanket `/api` router chain only by ordering — if this stops being caught,
+# the "401 without a session" admin assertions have gone missing.
+run_mutation "the KG-lifecycle admin router loses its session guard" "$MOUNTS" \
+  'app.use(
+      KG_LIFECYCLE_ADMIN_PATH,
+      requireAuth,|||app.use(
+      KG_LIFECYCLE_ADMIN_PATH,'
+run_mutation "the dev graph mounts regardless of DEV_ENDPOINTS_ENABLED" "$MOUNTS" \
+  'if (!deps.enabled) return false;|||'
+
+echo "── the loopback gate ────────────────────────────────────────────────────"
+run_mutation "the loopback gate reads the spoofable req.ip instead of the socket" "$LOOPBACK" \
+  'const remote = req.socket.remoteAddress;|||const remote = req.ip ?? req.socket.remoteAddress;'
+run_mutation "the loopback gate admits every address" "$LOOPBACK" \
+  'if (isLoopbackAddress(remote)) {|||if (true) {'
+run_mutation "an unknown socket address counts as loopback" "$LOOPBACK" \
+  "if (!address) return false;|||if (!address) return true;"
+run_mutation "the IPv4-mapped IPv6 form is no longer unwrapped" "$LOOPBACK" \
+  "const addr = address.startsWith('::ffff:') ? address.slice('::ffff:'.length) : address;|||const addr = address;"
+run_mutation "the gate matches any address STARTING with 127" "$LOOPBACK" \
+  'const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(addr);|||const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/.exec(addr);'
+
+echo
+echo "════════════════════════════════════════════════════════════════════════"
+echo "caught: $pass    NOT caught / skipped: $fail"
+revert
+
+# ── Guard: prove nothing was left mutated ───────────────────────────────────
+# A kill between the edit and the revert leaves a mutated file behind, and a
+# leaked mutation here is a disabled security control. Say so loudly rather
+# than exiting 0 on a quiet disaster.
+leftover=$(git status --porcelain -- "${MUTATED_PATHS[@]}")
+if [ -n "$leftover" ]; then
+  echo
+  echo "✖ LEAKED MUTATION — these files are still modified. DO NOT COMMIT:"
+  echo "$leftover"
+  echo "  Run: git checkout -- ${MUTATED_PATHS[*]}"
+  exit 3
+fi
+echo "✔ tree clean — no mutation leaked"
+
+[ "$fail" -eq 0 ]

--- a/middleware/test/devEndpoints/mutation-check.sh
+++ b/middleware/test/devEndpoints/mutation-check.sh
@@ -105,15 +105,14 @@ run_mutation "the priorities admin router goes back behind a flag" "$MOUNTS" \
       KG_PRIORITIES_ADMIN_PATH,'
 run_mutation "the plugin-domains admin router goes back behind a flag" "$MOUNTS" \
   'app.use(PLUGIN_DOMAINS_ADMIN_PATH, requireAuth, createAdminDomainsRouter({ catalog }));|||if (false) app.use(PLUGIN_DOMAINS_ADMIN_PATH, requireAuth, createAdminDomainsRouter({ catalog }));'
-# The admin routers must be AUTHENTICATED, not merely reachable. Dropping the
-# explicit guard here is caught because these paths sit outside the harness's
-# blanket `/api` router chain only by ordering — if this stops being caught,
-# the "401 without a session" admin assertions have gone missing.
-run_mutation "the KG-lifecycle admin router loses its session guard" "$MOUNTS" \
-  'app.use(
-      KG_LIFECYCLE_ADMIN_PATH,
-      requireAuth,|||app.use(
-      KG_LIFECYCLE_ADMIN_PATH,'
+# NOT a mutation, and deliberately so: dropping the per-mount `requireAuth`
+# from an admin router changes NOTHING observable, because the blanket
+# `app.use('/api', requireAuth, …)` line already guards the same paths through
+# the same allowlist. It is defence-in-depth against a future reordering, not
+# an independent gate — asserting it here would be asserting a tautology, and
+# a mutation that can never be caught belongs in neither column of this
+# script's tally. What actually gates these routes is the allowlist, and the
+# two mutations at the top of this file are what prove it.
 run_mutation "the dev graph mounts regardless of DEV_ENDPOINTS_ENABLED" "$MOUNTS" \
   'if (!deps.enabled) return false;|||'
 

--- a/middleware/test/devplatform/devPlatform.e2e.test.ts
+++ b/middleware/test/devplatform/devPlatform.e2e.test.ts
@@ -262,7 +262,7 @@ describe('devplatform e2e (pg)', { skip: !pgAvailable }, () => {
   // does, so a path dropped from that list fails this test instead of only
   // failing in production. Mounted both at `/api` (like index.ts) and around
   // the admin router (like mountDevPlatform).
-  const allowlist = publicPaths({ devEndpointsEnabled: false });
+  const allowlist = publicPaths();
   const requireAuth: RequestHandler = (req, res, next) => {
     const url = req.originalUrl || req.url;
     if (allowlist.some((rx) => rx.test(url))) {

--- a/middleware/test/devplatform/devPlatformGithubApp.test.ts
+++ b/middleware/test/devplatform/devPlatformGithubApp.test.ts
@@ -162,7 +162,7 @@ async function mountLikeIndex(deps: DevPlatformGithubAppDeps): Promise<{
   close: () => Promise<void>;
 }> {
   const routers = createDevPlatformGithubAppRouter(deps);
-  const allowlist = publicPaths({ devEndpointsEnabled: false });
+  const allowlist = publicPaths();
   const requireAuth: RequestHandler = (req, res, next) => {
     if (allowlist.some((pattern) => pattern.test(req.originalUrl))) {
       next();

--- a/middleware/test/devplatform/goldenFixture.e2e.test.ts
+++ b/middleware/test/devplatform/goldenFixture.e2e.test.ts
@@ -343,7 +343,7 @@ describe('dev-platform golden fixture (pg + git)', { skip: !pgAvailable || !gitA
     const app = express();
     app.use(express.json({ limit: '10mb' }));
     app.use(express.text({ type: 'text/plain', limit: '10mb' }));
-    const allowlist = publicPaths({ devEndpointsEnabled: false });
+    const allowlist = publicPaths();
     const requireAuth: RequestHandler = (req, res, next) => {
       const url = req.originalUrl || req.url;
       if (allowlist.some((rx) => rx.test(url))) {

--- a/middleware/test/publicMcp/harness.ts
+++ b/middleware/test/publicMcp/harness.ts
@@ -361,7 +361,7 @@ export async function startHarness(opts: HarnessOptions): Promise<Harness> {
 
   const allowlist = opts.withoutPublicPathEntry
     ? STATIC_PUBLIC_PATHS.filter((re) => !re.test(PUBLIC_MCP_PATH))
-    : publicPaths({ devEndpointsEnabled: false });
+    : publicPaths();
 
   const requireAuth = createRequireAuth({
     signingKey: SESSION_KEY,

--- a/middleware/test/publicPaths.test.ts
+++ b/middleware/test/publicPaths.test.ts
@@ -15,7 +15,7 @@ import { PUBLIC_MCP_PATH } from '../src/mcp/publicMcpPath.js';
  * must assert against the SAME array production runs.
  */
 describe('publicPaths — MCP OAuth callback allowlist', () => {
-  const allowlist = publicPaths({ devEndpointsEnabled: false });
+  const allowlist = publicPaths();
 
   it('allows the generic MCP-server OAuth callback', () => {
     assert.equal(
@@ -50,7 +50,7 @@ describe('publicPaths — MCP OAuth callback allowlist', () => {
     );
   });
 
-  it('is present in STATIC_PUBLIC_PATHS regardless of devEndpointsEnabled', () => {
+  it('is present in STATIC_PUBLIC_PATHS, which is configuration-independent', () => {
     assert.equal(
       STATIC_PUBLIC_PATHS.some((p) => p.test('/api/v1/operator/mcp-oauth/callback')),
       true,
@@ -67,7 +67,7 @@ describe('publicPaths — MCP OAuth callback allowlist', () => {
  * about, so the test derives its expectation from `CIMD_METADATA_PATH` itself.
  */
 describe('publicPaths — MCP client-ID metadata document allowlist', () => {
-  const allowlist = publicPaths({ devEndpointsEnabled: false });
+  const allowlist = publicPaths();
 
   it('allows the metadata document path built from the shared constant', () => {
     assert.equal(
@@ -84,7 +84,7 @@ describe('publicPaths — MCP client-ID metadata document allowlist', () => {
     );
   });
 
-  it('is present in STATIC_PUBLIC_PATHS regardless of devEndpointsEnabled', () => {
+  it('is present in STATIC_PUBLIC_PATHS, which is configuration-independent', () => {
     assert.equal(
       STATIC_PUBLIC_PATHS.some((p) => p.test(CIMD_METADATA_PATH)),
       true,
@@ -119,7 +119,7 @@ describe('publicPaths — MCP client-ID metadata document allowlist', () => {
  * ("goes DARK (session 401), not open"); this block covers the allowlist half.
  */
 describe('publicPaths — public MCP endpoint allowlist', () => {
-  const allowlist = publicPaths({ devEndpointsEnabled: false });
+  const allowlist = publicPaths();
   const isPublic = (path: string): boolean => allowlist.some((p) => p.test(path));
 
   it('exempts the public MCP endpoint from the session gate', () => {
@@ -134,7 +134,7 @@ describe('publicPaths — public MCP endpoint allowlist', () => {
     assert.equal(isPublic(`${PUBLIC_MCP_PATH}?v=1`), true);
   });
 
-  it('is present in STATIC_PUBLIC_PATHS regardless of devEndpointsEnabled', () => {
+  it('is present in STATIC_PUBLIC_PATHS, which is configuration-independent', () => {
     assert.equal(
       STATIC_PUBLIC_PATHS.some((p) => p.test(PUBLIC_MCP_PATH)),
       true,
@@ -160,5 +160,52 @@ describe('publicPaths — public MCP endpoint allowlist', () => {
   it('does NOT exempt the operator MCP admin surfaces', () => {
     assert.equal(isPublic('/api/v1/operator/mcp-servers'), false);
     assert.equal(isPublic('/api/v1/operator/mcp-call-log'), false);
+  });
+});
+
+/**
+ * Issue #669 — `/api/dev/*` was exempt from the session gate whenever
+ * `DEV_ENDPOINTS_ENABLED=true`. That single boolean published knowledge-graph
+ * state and three destructive maintenance sweeps to anonymous callers on any
+ * internet-reachable deployment (verified: uncredentialed `200`s with real
+ * payloads). The entry is gone, and `publicPaths` no longer takes any
+ * configuration at all — there is nothing left to flip.
+ *
+ * The end-to-end half of this ("401, and the sweep never ran") lives in
+ * `test/devEndpoints/devEndpointsAuth.e2e.test.ts`, which also asserts the
+ * failure direction: restore the entry and the surface goes open again.
+ */
+describe('publicPaths — /api/dev is not exempt (#669)', () => {
+  const allowlist = publicPaths();
+  const isPublic = (path: string): boolean => allowlist.some((p) => p.test(path));
+
+  const DEV_PATHS: readonly string[] = [
+    '/api/dev',
+    '/api/dev/',
+    '/api/dev/graph/stats',
+    '/api/dev/graph/lifecycle/stats',
+    '/api/dev/graph/lifecycle/run-decay',
+    '/api/dev/graph/lifecycle/run-gc',
+    '/api/dev/graph/lifecycle/run-access-flush',
+    '/api/dev/graph/priorities/list',
+    '/api/dev/memory/entries',
+    '/api/dev/graph/stats?scope=demo',
+  ];
+
+  for (const path of DEV_PATHS) {
+    it(`does not exempt ${path}`, () => {
+      assert.equal(
+        isPublic(path),
+        false,
+        `${path} must sit behind the session gate — #669`,
+      );
+    });
+  }
+
+  it('exposes no configuration switch that could re-open it', () => {
+    // A zero-argument accessor is the assertion: there is no
+    // `{ devEndpointsEnabled: true }` to pass any more.
+    assert.equal(publicPaths.length, 0);
+    assert.deepEqual([...publicPaths()], [...STATIC_PUBLIC_PATHS]);
   });
 });

--- a/web-ui/app/admin/kg-lifecycle/page.tsx
+++ b/web-ui/app/admin/kg-lifecycle/page.tsx
@@ -17,9 +17,14 @@ import { Button } from '@/app/_components/ui/Button';
  *   - Buttons to manually trigger decay / GC / access-flush
  *   - Last-run summaries
  *
- * Backed by `/bot-api/dev/graph/lifecycle/{stats,run-decay,run-gc,run-access-flush,last-runs}`.
- * Mounted only when DEV_ENDPOINTS_ENABLED is on the middleware side; the
- * page just renders an error banner if the routes 404.
+ * Backed by `/bot-api/v1/admin/kg-lifecycle/{stats,run-decay,run-gc,run-access-flush,last-runs}`.
+ *
+ * Issue #669 — these used to live under `/bot-api/dev/graph/lifecycle`, which
+ * mounted only when the middleware ran with `DEV_ENDPOINTS_ENABLED=true`, an
+ * unauthenticated surface. The routes are now authenticated operator admin
+ * endpoints with no flag involved, so a 404 here means exactly one thing:
+ * the middleware never published `graphLifecycle@1` (i.e. the knowledge graph
+ * is not running on Postgres). The empty state says that and only that.
  */
 
 type LifecycleStats = {
@@ -69,13 +74,14 @@ type LastRuns = {
   accessFlush: { at: string; stats: AccessFlushStats } | null;
 };
 
-const STAT_BASE = '/bot-api/dev/graph/lifecycle';
+const STAT_BASE = '/bot-api/v1/admin/kg-lifecycle';
 
 export default function KgLifecyclePage(): JSX.Element {
   const [stats, setStats] = useState<LifecycleStats | null>(null);
   const [lastRuns, setLastRuns] = useState<LastRuns | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [unavailable, setUnavailable] = useState(false);
+  const [signedOut, setSignedOut] = useState(false);
   const [busy, setBusy] = useState<string | null>(null);
   const tPage = useTranslations('adminKgLifecycle');
 
@@ -86,6 +92,16 @@ export default function KgLifecyclePage(): JSX.Element {
         fetch(`${STAT_BASE}/stats`, { cache: 'no-store' }),
         fetch(`${STAT_BASE}/last-runs`, { cache: 'no-store' }),
       ]);
+      // #669 — the routes are behind the operator session gate now, so an
+      // expired cookie is a distinct outcome from an absent backend. Rendering
+      // both as "needs the Postgres backend" is the misdiagnosis this page
+      // already cost once.
+      if (statsRes.status === 401 || statsRes.status === 403) {
+        setSignedOut(true);
+        setUnavailable(false);
+        return;
+      }
+      setSignedOut(false);
       // The lifecycle router is mounted only when the KG/Postgres plugin has
       // published the `graphLifecycle` service. Without it Express falls
       // through to its default 404 — the feature is absent, not broken. Show
@@ -161,7 +177,18 @@ export default function KgLifecyclePage(): JSX.Element {
         </Button>
       </header>
 
-      {unavailable ? (
+      {signedOut ? (
+        <div className="mb-6 rounded-md border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-4 py-3">
+          <div className="text-sm font-semibold text-[color:var(--fg-strong)]">
+            {tPage('signedOutTitle')}
+          </div>
+          <p className="mt-1 text-sm text-[color:var(--fg-muted)]">
+            {tPage('signedOutBody')}
+          </p>
+        </div>
+      ) : null}
+
+      {unavailable && !signedOut ? (
         <div className="mb-6 rounded-md border border-[color:var(--border)] bg-[color:var(--surface-muted)] px-4 py-3">
           <div className="text-sm font-semibold text-[color:var(--fg-strong)]">
             {tPage('unavailableTitle')}
@@ -172,13 +199,13 @@ export default function KgLifecyclePage(): JSX.Element {
         </div>
       ) : null}
 
-      {error && !unavailable ? (
+      {error && !unavailable && !signedOut ? (
         <div className="mb-6 rounded-md border border-[color:var(--danger-edge)]/40 bg-[color:var(--danger)]/10 px-4 py-3 text-sm text-[color:var(--danger)]">
           {error}
         </div>
       ) : null}
 
-      {unavailable ? null : (
+      {unavailable || signedOut ? null : (
       <>
         <section className="mb-8 grid gap-4 md:grid-cols-3">
           <ActionCard

--- a/web-ui/app/admin/kg-priorities/page.tsx
+++ b/web-ui/app/admin/kg-priorities/page.tsx
@@ -18,9 +18,11 @@ import { Button } from '@/app/_components/ui/Button';
  *   - reason (optional)
  *   - updated_at
  *
- * Backed by `/bot-api/dev/graph/priorities/{agentId}` (GET → list,
- * POST → upsert, DELETE → remove). Mounted only when DEV_ENDPOINTS_ENABLED
- * + agentPriorities@1 is published; otherwise the page shows an empty state.
+ * Backed by `/bot-api/v1/admin/kg-priorities/{agentId}` (GET → list,
+ * POST → upsert, DELETE → remove). Issue #669 moved these off the
+ * unauthenticated `/api/dev` surface: they are authenticated operator admin
+ * routes now, mounted whenever `agentPriorities@1` is published — no
+ * `DEV_ENDPOINTS_ENABLED` involved. Otherwise the page shows an empty state.
  */
 
 type AgentPriorityRecord = {
@@ -32,7 +34,7 @@ type AgentPriorityRecord = {
   updatedAt: string;
 };
 
-const STAT_BASE = '/bot-api/dev/graph/priorities';
+const STAT_BASE = '/bot-api/v1/admin/kg-priorities';
 const DEFAULT_AGENT = 'orchestrator-default';
 
 export default function KgPrioritiesPage(): React.ReactElement {

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -4205,7 +4205,9 @@
     "quotaTooltip": "{percent}% des Quota",
     "quotaOverTooltip": "{percent}% — wird beim nächsten GC-Sweep evicted",
     "unavailableTitle": "Knowledge-Graph-Lifecycle ist nicht verfügbar",
-    "unavailableBody": "Diese Seite benötigt das Postgres-/Knowledge-Graph-Backend. Die Lifecycle-Endpoints werden nur eingebunden, wenn das KG-Plugin installiert und eine Datenbank konfiguriert ist — bis dahin gibt es hier nichts anzuzeigen."
+    "unavailableBody": "Die Middleware hat den Lifecycle-Service nicht veröffentlicht, deshalb gibt es hier nichts anzuzeigen. Die Sweeps sind Postgres-spezifisch: Sie existieren nur, solange das Knowledge-Graph-Plugin gegen eine Postgres-/Neon-Datenbank aktiv ist. Ein In-Memory-Knowledge-Graph hat keinen Lifecycle. Diese Seite hängt an keinem Feature-Flag mehr — wenn das Plugin auf Postgres aktiv ist und das hier trotzdem erscheint, prüfe den Plugin-Status.",
+    "signedOutTitle": "Deine Session ist abgelaufen",
+    "signedOutBody": "Diese Endpoints brauchen eine Operator-Session. Melde dich erneut an und lade die Seite neu."
   },
   "adminKgPriorities": {
     "intro": "Per-Agent Block/Boost-Liste für den Token-Budget-Assembler. Block droppt einen Turn aus dem Recall-Pool; Boost multipliziert den Score mit `weight` (Default 1.3). `manuallyAuthored=true` bringt zusätzlich einen unabhängigen ×1.3 Boost — beide kombinieren.",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -4205,7 +4205,9 @@
     "quotaTooltip": "{percent}% of the quota",
     "quotaOverTooltip": "{percent}% — will be evicted on the next GC sweep",
     "unavailableTitle": "Knowledge-graph lifecycle is not available",
-    "unavailableBody": "This page needs the Postgres/knowledge-graph backend. The lifecycle endpoints are only mounted when the KG plugin is installed and a database is configured — until then there is nothing to show here."
+    "unavailableBody": "The middleware did not publish the lifecycle service, so there is nothing to show here. The sweeps are Postgres-specific: they exist only while the knowledge-graph plugin is active against a Postgres/Neon database. An in-memory knowledge graph has no lifecycle to run. This page no longer depends on any feature flag — if the plugin is active on Postgres and you still see this, check the plugin status.",
+    "signedOutTitle": "Your session has expired",
+    "signedOutBody": "These endpoints require an operator session. Sign in again, then reload this page."
   },
   "adminKgPriorities": {
     "intro": "Per-agent block/boost list for the token-budget assembler. Block drops a turn from the recall pool; boost multiplies the score by `weight` (default 1.3). `manuallyAuthored=true` additionally applies an independent ×1.3 boost — both combine.",


### PR DESCRIPTION
## The problem

`DEV_ENDPOINTS_ENABLED=true` mounted the entire `/api/dev/*` surface **with no authentication**. The code said so itself:

```
[middleware] ⚠ DEV endpoints enabled at /api/dev — unauthenticated, LOCAL USE ONLY
```

That assumption holds on a laptop. It does not hold in the standard topology, where the middleware app is reachable from the public internet. Confirmed empirically against a deployment under our control: `GET`s with no credentials of any kind returned `200` with real payloads.

One boolean flipped read access to knowledge-graph state — and **trigger access to three destructive maintenance sweeps** (`run-decay`, `run-gc`, `run-access-flush`) — from "operator only" to "anyone who knows the path".

And turning the flag off was not a workaround: the same `if` block also held the KG-Lifecycle and priorities **admin** routers, so an operator who needed the admin page had no supported way to get it without publishing everything else. With the flag off, the page reported *"This page needs the Postgres/knowledge-graph backend"* — while the KG plugin was installed, active and healthy. That message named the backend and the database but never the flag, so it read as a backend fault. It cost a full misdiagnosis cycle.

## The fix — three parts

### 1. Separate the concerns (the actual fix)

New `middleware/src/routes/graphRouterMounts.ts` mounts the operator surfaces under the authenticated admin prefix, independent of any dev flag:

| Surface | Was | Now | Mounted when |
|---|---|---|---|
| KG lifecycle admin | `/api/dev/graph/lifecycle` | `/api/v1/admin/kg-lifecycle` | `graphLifecycle@1` published |
| KG per-agent priorities | `/api/dev/graph/priorities` | `/api/v1/admin/kg-priorities` | `agentPriorities@1` published |
| Plugin domains (read-only) | `/api/admin/domains`, inside the dev `if` | `/api/admin/domains`, unconditional | always |

The third was already claiming "mounted unconditionally" in its own comment while the enclosing `if` said otherwise. Now the comment is true.

`DEV_ENDPOINTS_ENABLED` is read in exactly one place — inside `mountDevGraph` — and `mountKnowledgeGraphAdmin`'s deps type has **no field to carry it**. The separation is a type, not a convention, so it cannot be re-coupled by an `if` at a call site the tests do not reach.

### 2. Guard what stays under `/api/dev`

Everything under `/api` is gated by the OB-106 line `app.use('/api', requireAuth, …)`, which runs for every `/api/*` request. The only way past it is an entry in `auth/publicPaths.ts` — and `/api/dev` had one whenever the flag was on.

That entry is gone, and `publicPaths()` no longer takes any configuration: there is nothing left to flip. `/api/dev/*` — including the plugin-contributed `/api/dev/memory/*` — now needs an operator session, exactly like `/api/v1/admin/*`.

Optionally, `DEV_ENDPOINTS_LOOPBACK_ONLY=true` additionally refuses any request that did not arrive over a loopback socket (`403`). It reads `req.socket.remoteAddress`, **never** `X-Forwarded-For`: `trust proxy` is on, so a guard on `req.ip` would be defeated by a header. Default off, because a containerised dev setup proxies through the Next.js server from a container address — and the session gate already closes the hole.

### 3. Fix the empty-state copy

The page now names the real precondition — the middleware never published `graphLifecycle@1`, i.e. the knowledge graph is not running on Postgres — and states that no feature flag is involved any more. An expired session (`401`/`403`) is rendered as its own distinct state instead of being reported as a missing backend.

## Tests

`middleware/test/devEndpoints/` — the harness assembles the same chain `index.ts` does (global parsers → the OB-106 `requireAuth` line → the production mount functions → the shared allowlist), for the reason `publicPaths.ts` records in its own doc comment: a test app that omits the guard proves nothing about a route whose reachability depends on it.

- one no-credentials case **per route**, expecting `401` — including all three destructive `POST`s, and an `/api/dev/memory/*` path that nothing mounts (the blanket guard must answer `401` before express reaches its `404`, or the memory plugin's routes are open the moment it registers them)
- the destructive sweeps additionally assert the lifecycle service was **never called** — a status code alone can be produced by a route that ran and then failed
- the admin routes answer `200` for an operator with `DEV_ENDPOINTS_ENABLED` **off** — the point of part 1
- a negative control: restore the deleted allowlist entry and the surface must go **open** again, or the assertions above are passing for some unrelated reason
- `loopbackOnly.test.ts` covers the refusal branch and the spoofed `X-Forwarded-For`

**Mutation check** — `bash middleware/test/devEndpoints/mutation-check.sh` breaks each guard with a real source edit and requires the suite to go red: **11 mutations, 11 caught, 0 missed.**

```
✔ CAUGHT (fail 17): the /api/dev publicPaths exemption is restored
✔ CAUGHT (fail 13): only the lifecycle sub-tree is re-exempted
✔ CAUGHT (fail  3): the KG-lifecycle admin router goes back behind a flag
✔ CAUGHT (fail  1): the priorities admin router goes back behind a flag
✔ CAUGHT (fail  1): the plugin-domains admin router goes back behind a flag
✔ CAUGHT (fail  1): the dev graph mounts regardless of DEV_ENDPOINTS_ENABLED
✔ CAUGHT (fail  1): the loopback gate reads the spoofable req.ip instead of the socket
✔ CAUGHT (fail  3): the loopback gate admits every address
✔ CAUGHT (fail  2): an unknown socket address counts as loopback
✔ CAUGHT (fail  2): the IPv4-mapped IPv6 form is no longer unwrapped
✔ CAUGHT (fail  1): the gate matches any address STARTING with 127
caught: 11    NOT caught / skipped: 0
```

One candidate mutation is deliberately **not** in that list, with the reason written into the script: dropping the per-mount `requireAuth` from an admin router changes nothing observable, because the blanket `/api` line already guards the same paths through the same allowlist. It is defence-in-depth against a future reordering, not an independent gate — a mutation that can never be caught would be a tautology in either column.

## Docs

`docs/security-architecture.md` §10 documents the surface, what holds now, and the operating guidance the issue asked for: on any middleware build **older than this change**, `DEV_ENDPOINTS_ENABLED` is unsafe on any internet-reachable deployment, with no mitigation short of turning it off or blocking `/api/dev` upstream. Two reviewer-checklist items were added. `docs/middleware-agent-handoff.md`'s stale env notes were corrected.

## Verification

- `npm test` (middleware): **6238 tests, 0 fail**
- `npx tsc --noEmit`, `npm run typecheck:test` (ratchet: 406 known, no regressions), `eslint` on every changed file — clean
- web-ui: `tsc --noEmit`, `npm run i18n:check` (OK — 3575 keys), the i18n parity suite (10/10), `eslint` — clean

> One transient failure appeared on the first full-suite run (`conductorWebhookRoutes.test.ts`, `UND_ERR_SOCKET: other side closed`). It passes in isolation, passed on re-run, references nothing this PR touches, and is the known cross-file flake class recorded for this repo.

## Deployment note

Per the repo convention, this needs a **full deployment (middleware + web-ui)**: the admin pages move to the new paths in the same change that moves the routes.

Closes #669

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789142516&installation_model_id=428086&pr_number=674&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F674&signature=e28615201580f6b3f9af2b00cdebf67fa8eaa45f8c52df4764561ad6895fd93a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->