### PR TITLE
fix(ci): stop source-building better-sqlite3 in the desktop build

### DIFF
--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -101,8 +101,6 @@ jobs:
       # web-ui bakes this kernel URL into its routes-manifest at BUILD time, so
       # it cannot be a per-launch random port.
       KERNEL_URL: http://127.0.0.1:8769
-      # node-gyp's VS auto-detection is unreliable on windows-latest; pin VS2022.
-      GYP_MSVS_VERSION: '2022'
       # macOS signing (hoisted so they're addressable in step-level `if:`).
       APPLE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64_HIGH5 }}
       APPLE_P12_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD_HIGH5 }}
@@ -142,10 +140,23 @@ jobs:
           git config --global url."https://github.com/".insteadOf "git@github.com:"
 
       # --- build the omadia runtime the installer bundles -------------------
+      # `--ignore-scripts` is load-bearing, not hardening theatre — the same
+      # reason it is load-bearing in the root Dockerfile. better-sqlite3 v13
+      # ships N-API prebuilds for every platform (including win32-x64) inside
+      # its own tarball and declares `gypfile: false` to say "do not build me".
+      # npm ignores that field and synthesises `install: node-gyp rebuild`
+      # anyway, purely because a `binding.gyp` is present in the package.
+      # macOS/Linux merely waste time on that pointless compile; Windows has no
+      # Visual Studio node-gyp can find, so it fails outright and the Windows
+      # installer silently stopped shipping (last `.exe`: v0.63.0). Skipping
+      # scripts lets the bundled prebuild be used. argon2 + esbuild are the only
+      # middleware packages with a real install script, so rebuild those two by
+      # hand (fsevents is macOS-only and resolves as an optional dependency).
       - name: Build middleware kernel
         working-directory: middleware
         run: |
-          npm ci
+          npm ci --ignore-scripts --no-audit --no-fund
+          npm rebuild argon2 esbuild
           npm run build
 
       - name: Build web-ui (bake the fixed kernel URL into the standalone build)
@@ -160,27 +171,26 @@ jobs:
         working-directory: desktop
         run: npm ci
 
-      # Make the middleware's native modules load under Electron's Node (the kernel
-      # runs via ELECTRON_RUN_AS_NODE). argon2 + sharp are N-API → ABI-stable across
-      # node/electron, so their shipped binaries already work, no rebuild needed.
-      # Only better-sqlite3 (non-N-API) needs an Electron-ABI build — and it
-      # publishes Electron PREBUILDS, so fetch one with prebuild-install (no
-      # node-gyp / Visual Studio). Fall back to a source rebuild if no prebuild
-      # exists for this Electron version on this platform.
-      - name: Provision better-sqlite3 for Electron
+      # Verify the middleware's native modules load under Electron's Node (the
+      # kernel runs via ELECTRON_RUN_AS_NODE). All three are N-API → ABI-stable
+      # across node/electron, so their shipped binaries already work and NONE of
+      # them needs an Electron-ABI rebuild.
+      #
+      # better-sqlite3 needed one back when it was v12 and non-N-API. Since v13
+      # it ships N-API prebuilds in its own tarball (`prebuilds/<platform>-<arch>.node`)
+      # and — decisively — its loader in `lib/binding.js` checks that `prebuilds/`
+      # directory FIRST and only falls back to `build/Release/` if nothing is
+      # there. So an electron-rebuild artefact would be written and then never
+      # loaded. The old step was therefore a no-op that could only fail: upstream
+      # publishes no GitHub release assets for v13, so `prebuild-install` always
+      # missed and fell through to a source rebuild needing a full toolchain.
+      #
+      # The verification below is the real gate and is deliberately kept: if the
+      # N-API/ABI-stability assumption is ever wrong, this fails here instead of
+      # crashing the kernel at boot in the shipped app.
+      - name: Verify native modules load under the Electron ABI
         shell: bash
         run: |
-          EV="$(node -p "require('./desktop/node_modules/electron/package.json').version")"
-          echo "provisioning better-sqlite3 for Electron $EV"
-          ( cd middleware/node_modules/better-sqlite3 \
-            && npx --yes prebuild-install -r electron -t "$EV" --verbose ) \
-          || ( cd desktop \
-            && npx electron-rebuild --version "$EV" --module-dir ../middleware --only better-sqlite3 --force )
-          # Verify ALL three native modules actually load under Electron's runtime
-          # — not just the rebuilt better-sqlite3, but also argon2 + sharp, whose
-          # (un-rebuilt) prebuilds we ASSUME are N-API/ABI-stable. If that
-          # assumption is wrong, this fails here instead of crashing the kernel at
-          # boot in the shipped app.
           ELECTRON_RUN_AS_NODE=1 ./desktop/node_modules/.bin/electron -e \
             "require('./middleware/node_modules/better-sqlite3'); require('./middleware/node_modules/argon2'); require('./middleware/node_modules/sharp'); console.log('better-sqlite3 + argon2 + sharp load under Electron ABI OK')"
 


### PR DESCRIPTION
## Problem

The Windows leg of `desktop-apps` has failed on **every** release since **v0.64.0 (2026-08-11)**. No `.exe` installer has shipped since **v0.63.0**.

This stayed quiet because nothing else broke: the `release` job, `publish-images`, and the macOS/Linux installers are all green. Only the `windows-latest` matrix entry goes red — which is enough to paint every `auto-release` run as failed.

Confirmed across the last 10 failing runs: identical job, identical step.

```
desktop-apps / build (windows-latest, --win) :: Build middleware kernel
npm error command cmd /d /s /c node-gyp rebuild
gyp ERR! find VS could not find a version of Visual Studio 2017 or newer
```

| Release | Windows `.exe` |
|---|---|
| v0.63.0 (2026-08-10) | ✅ |
| v0.64.0 … v0.70.0 | ❌ (0 assets) |

## Root cause

`better-sqlite3` was bumped 12 → 13 in a42b1d56 (#615), merged 2026-08-11 06:20 UTC. The first red `auto-release` ran 07:49 UTC the same day.

v13 is N-API and ships prebuilt binaries for **every** platform inside its own tarball — including `prebuilds/win32-x64.node`. That is why it declares `gypfile: false`: "do not build me". npm ignores that field and synthesises `install: node-gyp rebuild` regardless, purely because a `binding.gyp` is present in the package.

macOS and Linux merely waste time on that pointless compile. `windows-latest` has no Visual Studio node-gyp can locate, so `npm ci` fails outright.

**This exact defect was already diagnosed and fixed for the container build in #615** — the root `Dockerfile` carries `npm ci --ignore-scripts` plus an explicit `npm rebuild argon2 esbuild`, with a comment spelling out the same reasoning. The desktop workflow was simply missed. This PR applies the identical, already-proven treatment.

## Changes

1. **`npm ci --ignore-scripts --no-audit --no-fund` + `npm rebuild argon2 esbuild`** in *Build middleware kernel*, mirroring the Dockerfile. `argon2` and `esbuild` are the only middleware packages with a real install script (`fsevents` is macOS-only and optional).

2. **Drop `GYP_MSVS_VERSION: '2022'`** — dead twice over. It never had any effect (node-gyp reads `npm_config_msvs_version`; the failing run logs *"msvs_version not set from command line or npm config"*), and the value is wrong anyway: the runner image now ships **Visual Studio 18**, which node-gyp 11.5.0 rejects as `unknown version "undefined"`. Worth stressing: "just install MSVC" would **not** have been a reliable fix.

3. **Replace *Provision better-sqlite3 for Electron* with the verification it already contained.** That step could only fail or no-op:
   - upstream publishes **no** GitHub release assets for v13, so `prebuild-install -r electron` always missed and fell through to a source rebuild — which needs the very toolchain Windows lacks;
   - and even when that rebuild succeeded, its artefact was **never loaded**: v13's loader (`lib/binding.js`) resolves `prebuilds/` **first** and only falls back to `build/Release/`.

   So today's macOS/Linux builds already run on the bundled prebuild, not on the electron-rebuild output. Removing the rebuild changes nothing observable there.

## Verification

Reproduced and verified locally against `better-sqlite3@13.0.3`:

- `npm ci` (and `npm install`) run `node-gyp rebuild` despite `gypfile: false` being present in **both** the registry manifest and the tarball's own `package.json`. *(Note: the Dockerfile comment claims `npm install` honours the field — measured on npm 11.16.0, both ignore it. Not corrected here to keep this diff scoped.)*
- The published tarball contains prebuilds for all 8 platform/arch combos, `win32-x64.node` included.
- `npm ci --ignore-scripts` produces **no** `build/` directory, invokes **no** node-gyp, and the module loads and executes SQL from the bundled prebuild.

The Electron ABI check is deliberately kept as the real gate: if the N-API/ABI-stability assumption is ever wrong, the build fails there rather than crashing the kernel at boot in the shipped app.

**Merge check:** the first `auto-release` run after merge should attach a Windows `.exe` again. Worth watching, since the Windows leg has not progressed past step 1 in two days — `web-ui` and `desktop` carry no `better-sqlite3` and no node-gyp packages, so they are expected to pass, but that is an expectation this PR cannot prove on its own.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789191895&installation_model_id=428086&pr_number=675&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F675&signature=095e2d689fb631e9fc2c020fcbb946413c12ac818e9d4775ecb1e8e4b8b9d249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->