### PR TITLE
fix(#641,#667): give turn errors a correlation handle and stop blaming the middleware

### DIFF
--- a/middleware/packages/harness-channel-sdk/src/chatAgent.ts
+++ b/middleware/packages/harness-channel-sdk/src/chatAgent.ts
@@ -847,7 +847,25 @@ export type ChatStreamEvent =
    * Additive; clients that don't recognise it ignore it.
    */
   | { type: 'steer_applied'; iteration: number; message: string }
-  | { type: 'error'; message: string }
+  /**
+   * #641 — a failed turn, with a handle the user can act on.
+   *
+   * `message` alone leaves a genuine failure undiagnosable by anyone not
+   * reading server logs: no code, no id, nothing to hand to support. The
+   * information exists (the orchestrator `console.error`s the technical
+   * detail) — it just never reached the person who hit the problem, whose only
+   * anchor was a wall-clock timestamp.
+   *
+   * `correlationId` is the turn id the orchestrator already mints per turn —
+   * deliberately NOT a second identifier invented for errors. It is the same
+   * value MCP call auditing and the session logger key on, so a support query
+   * by this token joins against records that already exist. It also appears in
+   * the server-side `console.error` line, so grepping for it is exact.
+   *
+   * Optional so existing adapters keep compiling; an adapter that does not
+   * render it behaves exactly as before.
+   */
+  | { type: 'error'; message: string; correlationId?: string }
   /**
    * Omadia UI canvas surface events (omadia-canvas-protocol/1.0). Additive;
    * channels not declaring the `'canvas'` capability default-ignore these.

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -5472,6 +5472,14 @@ export class Orchestrator {
 
       yield {
         type: 'error',
+        // #641 — see the `correlationId` doc on `ChatStreamEvent`. Read from the
+        // turn context rather than threaded as a parameter, for the same reason
+        // `privacyHandle` is: every call site here already runs inside the
+        // turn's `runGenerator` scope, and the value is the id the session
+        // logger and MCP audit already key on.
+        ...(turnContext.currentTurnId()
+          ? { correlationId: turnContext.currentTurnId() as string }
+          : {}),
         message: `Orchestrator exceeded maxToolIterations (${String(this.maxIterations)}) without reaching a final answer.`,
       };
     } catch (err) {
@@ -5480,8 +5488,12 @@ export class Orchestrator {
       // invisible in the server logs. Log the technical detail here. The
       // user-facing error-message wording is handled separately (Privacy
       // Shield v4).
+      // #641 — the correlation id goes in the LOG LINE, not just on the event.
+      // The whole point of handing the user a token is that someone can then
+      // find this entry by it; a token that appears only in the user's message
+      // is a token that joins nothing.
       console.error(
-        '[orchestrator] turn failed:',
+        `[orchestrator] turn failed (correlationId=${turnContext.currentTurnId() ?? 'unknown'}):`,
         err instanceof Error ? (err.stack ?? err.message) : err,
       );
       // Issue #506 — a tool call earlier in this turn may have already
@@ -5567,6 +5579,11 @@ export class Orchestrator {
       } else {
         yield {
           type: 'error',
+          // #641 — the token that makes this failure diagnosable. Same value as
+          // the one in the `console.error` above, so a log query by it is exact.
+          ...(turnContext.currentTurnId()
+            ? { correlationId: turnContext.currentTurnId() as string }
+            : {}),
           message: err instanceof Error ? err.message : String(err),
         };
       }

--- a/middleware/test/orchestrator/turnErrorCorrelation.test.ts
+++ b/middleware/test/orchestrator/turnErrorCorrelation.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Issue #641 — a failed turn must hand the user something they can act on.
+ *
+ * #506 narrowed *when* an error is shown. It did not change *what* an error
+ * carries: no code, no id, nothing to give to support. The technical detail was
+ * `console.error`d server-side, so the information existed — it just never
+ * reached the person who hit the problem, whose only anchor was a wall-clock
+ * timestamp.
+ *
+ * The load-bearing invariant is NOT "an id is present". It is that **the token
+ * the user is shown is the token in the server log**. A correlation id that
+ * does not join the log entry is decoration, and a test asserting only its
+ * presence would pass over exactly that defect — which is why the central test
+ * here captures `console.error` and compares the two values.
+ *
+ * Deliberately reuses the turn id the orchestrator already mints per turn
+ * rather than introducing a second identifier: it is the same value the session
+ * logger and MCP call auditing key on, so the token joins records that already
+ * exist.
+ *
+ * Imported from SOURCE, not the `@omadia/orchestrator` barrel — the barrel
+ * resolves to `dist/`, so a mutation in `src/` would otherwise be invisible
+ * without a rebuild and a mutation check could report GREEN over stale code.
+ */
+
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import type { LlmProvider, LlmStreamEvent } from '@omadia/llm-provider';
+import type { ChatStreamEvent } from '@omadia/channel-sdk';
+
+import { NativeToolRegistry } from '../../packages/harness-orchestrator/src/nativeToolRegistry.js';
+import { Orchestrator } from '../../packages/harness-orchestrator/src/orchestrator.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const providerCapabilities = {
+  tools: true,
+  vision: true,
+  streaming: true,
+  promptCaching: true,
+  forcedToolChoice: true,
+  parallelToolCalls: true,
+} as const;
+
+/** A provider whose stream throws on the FIRST call, so the failure reaches
+ *  `chatStreamInner`'s outer catch exactly like a genuine hard failure. */
+function throwingProvider(err: unknown): LlmProvider {
+  return {
+    id: 'anthropic',
+    capabilities: providerCapabilities,
+    complete: async () => {
+      throw err;
+    },
+    stream: (): AsyncIterable<LlmStreamEvent> => ({
+      async *[Symbol.asyncIterator]() {
+        throw err;
+      },
+    }),
+    // Non-retryable, or the orchestrator would retry instead of failing.
+    classifyError: () => ({ retryable: false, kind: 'other' as const }),
+  } as unknown as LlmProvider;
+}
+
+function buildOrchestrator(provider: LlmProvider): Orchestrator {
+  return new Orchestrator({
+    provider,
+    model: 'test',
+    maxTokens: 1024,
+    maxToolIterations: 5,
+    domainTools: [],
+    nativeToolRegistry: new NativeToolRegistry(),
+  });
+}
+
+async function runStream(orchestrator: Orchestrator): Promise<ChatStreamEvent[]> {
+  const events: ChatStreamEvent[] = [];
+  for await (const ev of orchestrator.chatStream({
+    userMessage: 'hallo',
+    sessionScope: 'sess-641',
+    userId: 'u641',
+  })) {
+    events.push(ev);
+  }
+  return events;
+}
+
+function errorEvent(
+  events: readonly ChatStreamEvent[],
+): { type: 'error'; message: string; correlationId?: string } {
+  const found = events.find((e) => e.type === 'error');
+  assert.ok(found, `no error event in stream: ${events.map((e) => e.type).join(', ')}`);
+  return found as never;
+}
+
+/** Runs `fn` with `console.error` captured. Always restores, including on throw
+ *  — a leaked stub would silently swallow every later test's diagnostics. */
+async function withCapturedConsoleError<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; lines: string[] }> {
+  const lines: string[] = [];
+  const original = console.error;
+  console.error = (...args: unknown[]): void => {
+    lines.push(args.map((a) => (typeof a === 'string' ? a : String(a))).join(' '));
+  };
+  try {
+    const result = await fn();
+    return { result, lines };
+  } finally {
+    console.error = original;
+  }
+}
+
+describe('#641 — a failed turn carries a correlation handle', () => {
+  it('MUTATION CHECK: the error event carries a correlation id', async () => {
+    const orchestrator = buildOrchestrator(throwingProvider(new Error('provider exploded')));
+    const { result: events } = await withCapturedConsoleError(() => runStream(orchestrator));
+    const error = errorEvent(events);
+
+    assert.ok(
+      error.correlationId !== undefined && error.correlationId !== '',
+      'the error reached the user with nothing to hand to support (#641)',
+    );
+    assert.match(
+      error.correlationId,
+      UUID_RE,
+      `correlationId is not the turn id: ${error.correlationId}`,
+    );
+  });
+
+  it('MUTATION CHECK: the token the user sees is the token in the server log', async () => {
+    // THE invariant. An id that does not join the log entry is decoration: the
+    // user can quote it and nobody can find anything. Asserting only presence
+    // would pass straight over that.
+    const orchestrator = buildOrchestrator(throwingProvider(new Error('provider exploded')));
+    const { result: events, lines } = await withCapturedConsoleError(() =>
+      runStream(orchestrator),
+    );
+    const id = errorEvent(events).correlationId;
+    assert.ok(id, 'no correlationId to correlate');
+
+    const logged = lines.filter((l) => l.includes('[orchestrator] turn failed'));
+    assert.equal(logged.length, 1, `expected exactly one failure log line, got ${logged.length}`);
+    assert.ok(
+      logged[0]?.includes(id),
+      `the log line does not carry the user's token '${id}': ${logged[0] ?? '<none>'}`,
+    );
+    // And the technical detail is still logged — #506 deliberately keeps it
+    // server-side, so the token is the join key TO something, not a replacement.
+    assert.ok(
+      logged[0]?.includes('provider exploded'),
+      `the failure detail vanished from the log: ${logged[0] ?? '<none>'}`,
+    );
+  });
+
+  it('MUTATION CHECK: two turns get different tokens', async () => {
+    // A constant or per-process id would satisfy "an id is present" while being
+    // useless for finding ONE failure.
+    const first = buildOrchestrator(throwingProvider(new Error('boom one')));
+    const second = buildOrchestrator(throwingProvider(new Error('boom two')));
+    const { result: e1 } = await withCapturedConsoleError(() => runStream(first));
+    const { result: e2 } = await withCapturedConsoleError(() => runStream(second));
+
+    const a = errorEvent(e1).correlationId;
+    const b = errorEvent(e2).correlationId;
+    assert.ok(a && b);
+    assert.notEqual(a, b, 'both turns reported the same correlation id');
+  });
+
+  it('the user-facing message itself is unchanged — the id is additive', async () => {
+    const orchestrator = buildOrchestrator(throwingProvider(new Error('provider exploded')));
+    const { result: events } = await withCapturedConsoleError(() => runStream(orchestrator));
+    assert.equal(errorEvent(events).message, 'provider exploded');
+  });
+});

--- a/web-ui/app/_components/StreamRunner.tsx
+++ b/web-ui/app/_components/StreamRunner.tsx
@@ -106,10 +106,23 @@ export async function runOneTurn(
     let outgoing = event;
     if (event.type === 'error') {
       const clean = humanizeProviderError(event.message, t('errorProviderGeneric'));
-      inbandErrorMessage = clean;
-      if (clean !== event.message) {
-        console.warn('[chat] provider error', event.message);
-        outgoing = { ...event, message: clean };
+      // #641 — a failed turn used to reach the user with nothing they could act
+      // on: no code, no id, nothing to hand to support. The detail was logged
+      // server-side, so the information existed and simply never arrived. The
+      // orchestrator now sends the turn's correlation id (the same one in its
+      // `console.error` line); append it so the message is a handle rather than
+      // just an apology. Absent on older middleware — then this is a no-op and
+      // the bubble reads exactly as before.
+      const withRef =
+        event.correlationId !== undefined && event.correlationId !== ''
+          ? `${clean}\n\n${t('errorCorrelationRef', { id: event.correlationId })}`
+          : clean;
+      inbandErrorMessage = withRef;
+      if (withRef !== event.message) {
+        if (clean !== event.message) {
+          console.warn('[chat] provider error', event.message);
+        }
+        outgoing = { ...event, message: withRef };
       }
     }
     applyStreamEvent(liveSessions, sessionId, pendingMessageId, outgoing);
@@ -160,9 +173,16 @@ export async function runOneTurn(
       const { t } = depsRef.current;
       let msg: string;
       if (looksHtml || contentType.includes('text/html')) {
+        // #667 — this used to claim the middleware was UNREACHABLE and name
+        // `localhost:3979`. Both are things the client has not checked: a 500
+        // means something answered, and the dev host is meaningless on a hosted
+        // instance. In #665 the middleware was up and serving — its pg pool was
+        // dead — and this string sent the investigation at `MIDDLEWARE_URL`
+        // while the real fault was a plugin's pool lifetime. Say only what is
+        // known: an upstream 500 with a non-JSON body.
         msg =
           res.status === 500
-            ? t('errorMiddlewareUnreachable')
+            ? t('errorUpstreamErrorPage')
             : t('errorProxyFailure', { status: String(res.status) });
       } else if (contentType.includes('application/json')) {
         try {

--- a/web-ui/app/_lib/chatStreamEvents.ts
+++ b/web-ui/app/_lib/chatStreamEvents.ts
@@ -148,7 +148,16 @@ export type ChatStreamEvent =
   /** Mid-turn steering — a user message injected via `/chat/steer` was folded
    *  into the running turn at iteration `iteration`. */
   | { type: 'steer_applied'; iteration: number; message: string }
-  | { type: 'error'; message: string };
+  /**
+   * #641 — `correlationId` is the orchestrator's per-turn id, the same value it
+   * writes into its own `console.error` line, so a support query by the token
+   * the user was shown finds the log entry exactly. Mirrors the `error` variant
+   * in `@omadia/channel-sdk`'s `ChatStreamEvent`.
+   *
+   * Optional because middleware older than this change does not send it; the
+   * renderer then behaves exactly as before.
+   */
+  | { type: 'error'; message: string; correlationId?: string };
 
 /**
  * Fold one stream event into the session that owns the pending assistant

--- a/web-ui/app/_lib/error-copy.test.ts
+++ b/web-ui/app/_lib/error-copy.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Issue #667 — an error message must not assert a cause the client never checked.
+ *
+ * `errorMiddlewareUnreachable` was shown for ANY HTTP 500 with an HTML body and
+ * claimed two things it had not verified: that the middleware was unreachable
+ * (a 500 means something *answered*), and that the deployment was a local dev
+ * setup (`localhost:3979`, `npm run dev`). In #665 the middleware was up and
+ * serving — its pg pool was dead — and this string sent the investigation at
+ * `MIDDLEWARE_URL` while the real fault was a plugin's pool lifetime. That is
+ * worse than an unhelpful error: it points at a healthy component, on an
+ * address that does not exist in the deployment being debugged.
+ *
+ * These are catalogue-level guards rather than component tests on purpose. The
+ * defect was never in the rendering — it was in the *words*, in both locales, at
+ * two call sites. A guard on the words is the one that keeps holding when a
+ * third call site appears.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import de from '../../messages/de.json';
+import en from '../../messages/en.json';
+
+type Catalog = Record<string, unknown>;
+
+function flatten(obj: Catalog, prefix = ''): Array<[string, string]> {
+  return Object.entries(obj).flatMap(([key, value]) => {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      return flatten(value as Catalog, path);
+    }
+    return typeof value === 'string' ? [[path, value] as [string, string]] : [];
+  });
+}
+
+const LOCALES: Array<[string, Catalog]> = [
+  ['en', en as Catalog],
+  ['de', de as Catalog],
+];
+
+describe('#667 — no user-facing string names a dev-only endpoint', () => {
+  /**
+   * The generalised form of the bug. The original string hardcoded
+   * `localhost:3979`, which is meaningless — and actively misleading — on a
+   * hosted instance. Guarding the whole catalogue rather than the one key means
+   * the next copy that reaches for a dev address fails here instead of in
+   * someone's incident.
+   */
+  it.each(LOCALES)('%s carries no localhost/dev-port literal', (_name, catalog) => {
+    const offenders = flatten(catalog).filter(([, value]) =>
+      /localhost:\d+|127\.0\.0\.1:\d+|npm run dev/i.test(value),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it.each(LOCALES)('%s no longer ships the retired errorMiddlewareUnreachable key', (_name, catalog) => {
+    const keys = flatten(catalog).map(([key]) => key);
+    expect(keys.filter((k) => k.endsWith('errorMiddlewareUnreachable'))).toEqual([]);
+  });
+});
+
+describe('#667 — the replacement says only what is known', () => {
+  it.each(LOCALES)('%s does not assert unreachability', (_name, catalog) => {
+    const map = new Map(flatten(catalog));
+    for (const key of ['chat.errorUpstreamErrorPage', 'memory.errorUpstreamErrorPage']) {
+      const value = map.get(key);
+      expect(value, `${key} missing`).toBeTruthy();
+      // "unreachable"/"nicht erreichbar" is precisely the claim the client
+      // cannot make: the request WAS answered, with a 500.
+      expect(value).not.toMatch(/unreachable|nicht erreichbar/i);
+      // It must still name the observable fact, or it is merely vague rather
+      // than wrong — which would be a different failure, not a fix.
+      expect(value).toMatch(/500/);
+    }
+  });
+});
+
+describe('#641 — the correlation reference is available to render', () => {
+  it.each(LOCALES)('%s has errorCorrelationRef with an {id} placeholder', (_name, catalog) => {
+    const value = new Map(flatten(catalog)).get('chat.errorCorrelationRef');
+    expect(value, 'chat.errorCorrelationRef missing').toBeTruthy();
+    // Without the placeholder the token never reaches the user, which is the
+    // entire point of #641.
+    expect(value).toContain('{id}');
+  });
+});

--- a/web-ui/app/memory/page.tsx
+++ b/web-ui/app/memory/page.tsx
@@ -45,7 +45,10 @@ export default function MemoryPage(): React.ReactElement {
           contentType.includes('text/html') ||
           body.trimStart().toLowerCase().startsWith('<!doctype');
         if (res.status === 500 && looksHtml) {
-          setListError(t('errorMiddlewareUnreachable'));
+          // #667 — same misdiagnosis as the chat path: a 500 means something
+          // answered, so "middleware unreachable" (on a hardcoded dev host) is
+          // an assertion this code never checked.
+          setListError(t('errorUpstreamErrorPage'));
         } else if (res.status === 404) {
           setListError(t('errorDevEndpointUnavailable'));
         } else {

--- a/web-ui/app/store/page.tsx
+++ b/web-ui/app/store/page.tsx
@@ -416,12 +416,13 @@ async function LoadErrorState({
         {message}
       </p>
       <p className="mt-4 text-sm leading-relaxed text-[color:var(--fg-muted)]">
+        {/*
+          #667 — the `host` chunk is gone with the string that carried it. It
+          named `http://localhost:3979`, which is meaningless on a hosted
+          instance and, in #665, pointed the operator at a component that was
+          healthy. The endpoint PATH stays: it is a fact the reader can check.
+        */}
         {t.rich('errorHint', {
-          host: (chunks) => (
-            <span className="font-mono-num text-[color:var(--fg)]">
-              {chunks}
-            </span>
-          ),
           endpoint: (chunks) => (
             <span className="font-mono-num text-[color:var(--fg)]">
               {chunks}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1111,7 +1111,6 @@
     "pillTitle": "{id} — Details anzeigen"
   },
   "chat": {
-    "errorMiddlewareUnreachable": "Middleware nicht erreichbar auf localhost:3979. Läuft `npm run dev` im middleware-Ordner?",
     "errorProxyFailure": "Proxy-Fehler (HTTP {status}). Prüf die Middleware-Logs.",
     "errorAborted": "Abgebrochen.",
     "errorProviderGeneric": "Beim Zugriff auf den KI-Anbieter ist etwas schiefgelaufen. Bitte versuch es erneut.",
@@ -1307,7 +1306,9 @@
       "factNotEmbedded": "— kein Vektor",
       "factPrivateBlocks": "'<private>'-Blöcke",
       "factHintTags": "'<palaia-hint>'-Tags"
-    }
+    },
+    "errorUpstreamErrorPage": "Der Server hat statt einer Antwort eine Fehlerseite geliefert (HTTP 500). Es hat also etwas geantwortet, der Fehler liegt serverseitig — prüfe die Middleware-Logs oder melde das deinem Betreiber.",
+    "errorCorrelationRef": "Referenz für den Support: {id}"
   },
   "privacyReceipt": {
     "summary": "🛡 Privacy Shield · {summary}",
@@ -2849,7 +2850,7 @@
       "emptyHubBody": "Verbinde eine Registry unter <adminLink>Admin · Registries</adminLink> — oder lade ein eigenes Paket im <localLink>Lokal</localLink>-Tab hoch.",
       "errorKicker": "Fehler",
       "errorTitle": "Katalog konnte nicht geladen werden.",
-      "errorHint": "Prüfe, ob die Middleware unter <host>http://localhost:3979</host> erreichbar ist und der Endpoint <endpoint>/api/v1/store/plugins</endpoint> antwortet.",
+      "errorHint": "Prüfe, ob die Middleware erreichbar ist und der Endpoint <endpoint>/api/v1/store/plugins</endpoint> antwortet.",
       "footerSource": "Quelle:"
     },
     "detail": {
@@ -4402,7 +4403,6 @@
     }
   },
   "memory": {
-    "errorMiddlewareUnreachable": "Middleware nicht erreichbar (localhost:3979). Läuft `npm run dev` im middleware-Ordner?",
     "errorDevEndpointUnavailable": "Dev-Memory-Endpoint nicht verfügbar. Setze DEV_ENDPOINTS_ENABLED=true in middleware/.env und starte die Middleware neu.",
     "errorListFailed": "List fehlgeschlagen (HTTP {status})",
     "errorFileFailed": "File fehlgeschlagen (HTTP {status})",
@@ -4414,7 +4414,8 @@
     "reload": "↻ neu laden",
     "loading": "lädt…",
     "empty": "leer",
-    "selectEntry": "Eintrag links wählen…"
+    "selectEntry": "Eintrag links wählen…",
+    "errorUpstreamErrorPage": "Der Server hat statt einer Antwort eine Fehlerseite geliefert (HTTP 500). Es hat also etwas geantwortet, der Fehler liegt serverseitig — prüfe die Middleware-Logs oder melde das deinem Betreiber."
   },
   "memories": {
     "kinds": {

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1111,7 +1111,6 @@
     "pillTitle": "{id} — show details"
   },
   "chat": {
-    "errorMiddlewareUnreachable": "Middleware unreachable on localhost:3979. Is `npm run dev` running in the middleware folder?",
     "errorProxyFailure": "Proxy error (HTTP {status}). Check the middleware logs.",
     "errorAborted": "Aborted.",
     "errorProviderGeneric": "Something went wrong while talking to the AI provider. Please try again.",
@@ -1307,7 +1306,9 @@
       "factNotEmbedded": "— no vector",
       "factPrivateBlocks": "'<private>' blocks",
       "factHintTags": "'<palaia-hint>' tags"
-    }
+    },
+    "errorUpstreamErrorPage": "The server returned an error page instead of a response (HTTP 500). Something answered, so the fault is server-side — check the middleware logs or report this to your operator.",
+    "errorCorrelationRef": "Reference for support: {id}"
   },
   "privacyReceipt": {
     "summary": "🛡 Privacy Shield · {summary}",
@@ -2849,7 +2850,7 @@
       "emptyHubBody": "Connect a registry under <adminLink>Admin · Registries</adminLink> — or upload your own package in the <localLink>Local</localLink> tab.",
       "errorKicker": "Error",
       "errorTitle": "The catalog could not be loaded.",
-      "errorHint": "Check that the middleware is reachable at <host>http://localhost:3979</host> and that the endpoint <endpoint>/api/v1/store/plugins</endpoint> responds.",
+      "errorHint": "Check that the middleware is reachable and that the endpoint <endpoint>/api/v1/store/plugins</endpoint> responds.",
       "footerSource": "Source:"
     },
     "detail": {
@@ -4402,7 +4403,6 @@
     }
   },
   "memory": {
-    "errorMiddlewareUnreachable": "Middleware unreachable (localhost:3979). Is `npm run dev` running in the middleware folder?",
     "errorDevEndpointUnavailable": "Dev memory endpoint unavailable. Set DEV_ENDPOINTS_ENABLED=true in middleware/.env and restart the middleware.",
     "errorListFailed": "Listing failed (HTTP {status})",
     "errorFileFailed": "File load failed (HTTP {status})",
@@ -4414,7 +4414,8 @@
     "reload": "↻ Reload",
     "loading": "Loading…",
     "empty": "empty",
-    "selectEntry": "Select an entry on the left…"
+    "selectEntry": "Select an entry on the left…",
+    "errorUpstreamErrorPage": "The server returned an error page instead of a response (HTTP 500). Something answered, so the fault is server-side — check the middleware logs or report this to your operator."
   },
   "memories": {
     "kinds": {


### PR DESCRIPTION
Two halves of the same experience: a turn fails and the user is shown something that helps nobody. **#667** is the misleading half, **#641** the missing half — and the id from #641 is what the message from #667 should carry, so they ship together.

## #641 — the error carries a handle

A failed turn reached the user with no code, no id, nothing to give to support. The technical detail *was* logged server-side (#506 deliberately keeps it there), so the information existed and simply never arrived. The user's only anchor was a wall-clock timestamp.

**Deliberately not a new identifier.** `chatStream` already mints a per-turn `randomUUID` and threads it through `turnContext` — the same value the session logger and MCP call auditing key on. Surfacing *that* one means a support query by the token joins records that already exist, instead of introducing a second id that correlates with nothing.

It is read from the turn context rather than threaded as a parameter, for the same reason `privacyHandle` is: every emission site already runs inside the turn's `runGenerator` scope.

**The id goes in the log line too:**

```
[orchestrator] turn failed (correlationId=…): <stack>
```

A token that appears only in the user's message is a token that joins nothing.

`correlationId` is **optional** on the `error` variant of `ChatStreamEvent` (`@omadia/channel-sdk`, mirrored in web-ui's local `chatStreamEvents.ts`), so existing adapters keep compiling and one that ignores it behaves exactly as before.

Scope: steps 1–3 of the issue. Step 4 (redeeming the token via *"was ist bei &lt;token&gt; passiert?"*) is a separate feature.

## #667 — the message stops asserting a cause it never checked

`errorMiddlewareUnreachable` was shown for **any** HTTP 500 with an HTML body, and claimed two things it had not verified:

1. **that the middleware was unreachable** — a 500 means something *answered*;
2. **that the deployment was a local dev setup** — `localhost:3979`, `npm run dev`.

In #665 the middleware was up and serving with a dead pg pool, and this string sent the investigation at `MIDDLEWARE_URL` while the real fault was a plugin's pool lifetime. Pointing at a healthy component, on an address that does not exist in the deployment being debugged, is worse than an unhelpful error.

**The key is retired rather than reworded** — its *name* was part of the false claim. `errorUpstreamErrorPage` states only what is observable: an upstream 500 with a non-JSON body, and that the fault is server-side. Both call sites updated (`StreamRunner.tsx`, `memory/page.tsx`), both locales written together as #667 asked.

### A third instance the issue did not list

The catalogue-wide guard immediately found one more: **`store.page.errorHint`** also hardcoded `http://localhost:3979`. Fixed the same way — the host claim is gone, the endpoint **path** stays because it is a fact the reader can check. Its now-unused `<host>` rich-text chunk is removed from `store/page.tsx` alongside it.

## Tests

| File | Count |
|---|---|
| `middleware/test/orchestrator/turnErrorCorrelation.test.ts` | 4 |
| `web-ui/app/_lib/error-copy.test.ts` | 8 |

The middleware test imports from `src/`, not the `@omadia/orchestrator` barrel (which resolves to `dist/`), so a mutation cannot report green over stale build output.

The copy guards are **catalogue-level, not component-level**, on purpose: the defect was never in the rendering but in the words, in both locales, at multiple call sites. A guard on the words is the one that still holds when a fourth call site appears — which is exactly how the `store.page.errorHint` instance surfaced.

### Mutation checks (both verified red)

1. **Remove `correlationId` from the error yield** → 3 of 4 fail.
2. **Replace it with a fresh `randomUUID()`** — present, unique, but *not* the one in the log → passes the presence test *and* the uniqueness test, and is caught **only** by `the token the user sees is the token in the server log`.

The second one is the point. Asserting mere presence would have shipped a decorative id that no one can look up; that assertion is what makes the test do real work.

## Verification

- web-ui suite: **693/693**
- `test/orchestrator/*`: **235/235**
- `tsc --noEmit`: clean on both sides
- `typecheck:test` ratchet: 406 = baseline
- eslint: 0 errors (both packages)
- `i18n-validate`: exit 0 — the hard gate from #678 still passes with the new keys

Closes #641
Closes #667

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789205235&installation_model_id=428086&pr_number=680&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F680&signature=162e049c9bb75d3d9ac7cafc624c0f2720b478cca17409e86f77f98af458f2fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->