### PR TITLE
feat(#603): json_file setup fields — upload the key, do not transcribe it

### DIFF
--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -43,7 +43,18 @@ export type SetupFieldType =
   | 'integer'
   /** #91: operator-curated list of bare hostnames. Values are unioned into
    *  the plugin's effective `ctx.http` allowlist at runtime (Option B). */
-  | 'host_list';
+  | 'host_list'
+  /**
+   * #603 (OM-17): upload a JSON credential file instead of transcribing values
+   * out of it. The field itself stores NOTHING — the server parses the upload
+   * and explodes it into the keys named in `extracts`, which remain ordinary
+   * `secret`/`string` fields for every other code path.
+   *
+   * Exists because hand-transcribing a service-account key into an email field
+   * and a masked field stacked beneath it is the visual pattern of a login, and
+   * a tester duly typed their real password into it.
+   */
+  | 'json_file';
 
 export interface PluginSetupField {
   key: string;
@@ -65,6 +76,25 @@ export interface PluginSetupField {
    *  install wizard and post-install editor; loader passes it through
    *  unchanged. */
   placeholder?: string;
+  /**
+   * #603 — `json_file` only. MIME type for the file picker's `accept`
+   * attribute. Advisory: a picker hint, never a validation. The server decides
+   * what the upload is, and `expect` is what actually rejects the wrong file.
+   */
+  accept?: string;
+  /**
+   * #603 — `json_file` only. Target setup-field key → `$.dotted.path` into the
+   * uploaded document. The extracted values are stored under those keys; the
+   * `json_file` field itself stores nothing. See `setupJsonFile.ts` for the
+   * supported path subset and why it is not full JSONPath.
+   */
+  extracts?: Record<string, string>;
+  /**
+   * #603 — `json_file` only. Shallow equality assertions the uploaded document
+   * must satisfy (e.g. `{ type: 'service_account' }`), checked BEFORE any value
+   * is extracted so the wrong file is rejected rather than half-consumed.
+   */
+  expect?: Record<string, unknown>;
   /** Manifest default. Forwarded so the post-install editor can pre-select
    *  the default option in an `enum` dropdown when no value is stored yet.
    *  A `string[]` for `type === 'host_list'`, a `string` otherwise. */
@@ -700,6 +730,27 @@ export interface InstallSetupField {
    *  it just isn't shown at install time. For flow-populated credentials.
    *  Older UIs ignore the flag and render the field as usual. */
   install_hidden?: boolean;
+  /**
+   * #603 — `json_file` only. Mirrors {@link PluginSetupField.accept}: the file
+   * picker's `accept` hint. Advisory — the server, not the picker, decides what
+   * an upload actually is.
+   */
+  accept?: string;
+  /**
+   * #603 — `json_file` only. Mirrors {@link PluginSetupField.extracts}.
+   *
+   * Carried on the INSTALL projection too, not just the catalog one, because
+   * `POST …/secrets/from-json` resolves the extraction map through
+   * `extractSetupSchema` — which returns THIS type. A `json_file` field that
+   * reaches the route without it carries no upload contract and is refused,
+   * so an omission here is a silently dead upload button.
+   */
+  extracts?: Record<string, string>;
+  /**
+   * #603 — `json_file` only. Mirrors {@link PluginSetupField.expect}: shallow
+   * assertions the uploaded document must satisfy before anything is extracted.
+   */
+  expect?: Record<string, unknown>;
 }
 
 export interface InstallSetupSchema {

--- a/middleware/src/plugins/builder/agentSpec.ts
+++ b/middleware/src/plugins/builder/agentSpec.ts
@@ -154,6 +154,10 @@ const SetupFieldSchema = z
       'boolean',
       'integer',
       'host_list',
+      // #603 (OM-17). This schema is `.strict()`, so an unknown member is
+      // REJECTED outright rather than ignored — a builder spec declaring
+      // `json_file` fails to load until this list carries it.
+      'json_file',
     ]),
     required: z.boolean().optional(),
     description: z.string().optional(),

--- a/middleware/src/plugins/installService.ts
+++ b/middleware/src/plugins/installService.ts
@@ -523,6 +523,32 @@ export function extractSetupSchema(
     // previously masked every secret field with a hardcoded `••••••••`.
     const placeholder = asString(f['placeholder']);
     if (placeholder) field.placeholder = placeholder;
+    // #603 (OM-17) — the `json_file` upload contract. Must stay in agreement
+    // with the catalog projection in `manifestLoader.ts`, which applies the SAME
+    // "no usable extracts ⇒ drop the field" rule: a `json_file` field that
+    // survives one projection but not the other is a file picker that renders on
+    // one screen and cannot save from the other.
+    if (type === 'json_file') {
+      const extractsRaw = f['extracts'];
+      const extracts: Record<string, string> = {};
+      if (extractsRaw && typeof extractsRaw === 'object' && !Array.isArray(extractsRaw)) {
+        for (const [target, path] of Object.entries(
+          extractsRaw as Record<string, unknown>,
+        )) {
+          const p = asString(path);
+          if (target.length > 0 && p !== undefined) extracts[target] = p;
+        }
+      }
+      if (Object.keys(extracts).length === 0) continue;
+      field.extracts = extracts;
+      const expectRaw = f['expect'];
+      if (expectRaw && typeof expectRaw === 'object' && !Array.isArray(expectRaw)) {
+        const expect = expectRaw as Record<string, unknown>;
+        if (Object.keys(expect).length > 0) field.expect = expect;
+      }
+      const accept = asString(f['accept']);
+      if (accept) field.accept = accept;
+    }
     if (f['default'] !== undefined) field.default = f['default'];
     // OM-17 — same load-time compile gate as manifestLoader: an uncompilable or
     // catastrophically-backtracking pattern is dropped (warned once, cached) so
@@ -813,6 +839,20 @@ function coerce(field: InstallSetupField, raw: unknown): CoerceResult {
   // #602 (OM-17) — see validateValues: German templates, no request locale.
   const label = resolveLocalized(field.label, 'de') ?? field.key;
   switch (field.type) {
+    // #603 (OM-17) — a `json_file` field is an INPUT affordance, not a stored
+    // value: the server explodes the upload into the keys named in `extracts`
+    // and stores only those. So nothing may be submitted under this field's own
+    // key, and a value arriving here means the client tried to write the raw
+    // document into the vault — which is exactly what this feature exists to
+    // avoid. Refused rather than ignored: silently dropping it would let a
+    // client believe it had stored a credential.
+    case 'json_file':
+      return {
+        error: {
+          code: 'not_submittable',
+          message: `"${label}" wird hochgeladen, nicht eingegeben — es kann nicht direkt gesetzt werden.`,
+        },
+      };
     case 'string':
     case 'secret':
       return typeof raw === 'string'
@@ -973,6 +1013,12 @@ const SUPPORTED_TYPES = new Set<string>([
   'boolean',
   'integer',
   'host_list',
+  // #603 (OM-17). Fifth place this union is mirrored — the issue named three
+  // (`admin-v1.ts`, `manifestLoader.isSetupFieldType`, `agentSpec`'s z.enum);
+  // this set and `InstallSetupField`'s shape are the other two. A member missing
+  // HERE does not error: `isSupportedType` simply skips the field, so the upload
+  // disappears from the install wizard with no diagnostic at all.
+  'json_file',
 ]);
 
 function isSupportedType(t: string): t is InstallSetupField['type'] {

--- a/middleware/src/plugins/manifestLoader.ts
+++ b/middleware/src/plugins/manifestLoader.ts
@@ -275,6 +275,34 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
       const defaultValue = asString(f['default']);
       if (defaultValue !== undefined) entry.default = defaultValue;
     }
+    if (type === 'json_file') {
+      // #603 (OM-17) — the upload's extraction map. Validated HERE, at load
+      // time, for the same reason `pattern` is: a manifest is untrusted input,
+      // and a `json_file` field whose `extracts` is missing or unusable would
+      // otherwise reach the operator as a file picker that silently produces
+      // nothing. Dropping the field entirely is the honest degradation — the
+      // form then shows the underlying `secret` fields, i.e. exactly the
+      // pre-#603 behaviour, instead of an upload that cannot work.
+      const extractsRaw = asRecord(f['extracts']);
+      const extracts: Record<string, string> = {};
+      for (const [target, path] of Object.entries(extractsRaw ?? {})) {
+        const p = asString(path);
+        if (target.length > 0 && p !== undefined) extracts[target] = p;
+      }
+      if (Object.keys(extracts).length === 0) {
+        console.warn(
+          `[manifestLoader] ${id}: setup field '${key}' is type json_file but declares no usable 'extracts' — dropping the field.`,
+        );
+        continue;
+      }
+      entry.extracts = extracts;
+      const expectRaw = asRecord(f['expect']);
+      if (expectRaw && Object.keys(expectRaw).length > 0) {
+        entry.expect = expectRaw;
+      }
+      const accept = asString(f['accept']);
+      if (accept) entry.accept = accept;
+    }
     if (type === 'enum') {
       const enumRaw = f['enum'];
       if (Array.isArray(enumRaw)) {
@@ -974,6 +1002,8 @@ function isSetupFieldType(value: string): value is PluginSetupField['type'] {
     value === 'enum' ||
     value === 'boolean' ||
     value === 'integer' ||
-    value === 'host_list'
+    value === 'host_list' ||
+    // #603 (OM-17) — upload a JSON credential file instead of transcribing it.
+    value === 'json_file'
   );
 }

--- a/middleware/src/plugins/setupJsonFile.ts
+++ b/middleware/src/plugins/setupJsonFile.ts
@@ -1,0 +1,237 @@
+/**
+ * `json_file` setup fields — server-side extraction (issue #603, OM-17).
+ *
+ * ## What this exists to prevent
+ *
+ * The first customer test produced a near-miss: a tester typed their real Google
+ * account password into `gw_sa_private_key`. Nothing about them was careless —
+ * the form asked them to hand-transcribe two values out of a service-account
+ * JSON key file into an email field and a masked field stacked directly beneath
+ * it, which is the visual pattern of a login. #599 added a caution and `pattern`
+ * validation, so the mistake is now *detected*. Uploading the file removes the
+ * opportunity to make it.
+ *
+ * The tester named this fix themselves, and they were right: it is structural,
+ * and it saves a step rather than adding one.
+ *
+ * ## Why the parsing is here and not in the browser
+ *
+ * A `json_file` field never reaches storage as a file. The client posts the
+ * file's text, the server parses it, validates it, explodes it into the
+ * underlying keys, and stores ONLY the derived values. The browser is not
+ * trusted to do the extraction, because a client that decides which bytes become
+ * `gw_sa_private_key` is a client that can be made to decide wrongly.
+ *
+ * Downstream, nothing else changes: the derived fields stay ordinary `secret`
+ * fields for readiness, vault storage and rotation. `json_file` is an INPUT
+ * affordance, not a new kind of credential.
+ *
+ * ## Path syntax — a deliberate subset
+ *
+ * `extracts` maps a target key to `$.a.b`: a `$` root followed by dot-separated
+ * object keys. Not JSONPath. Service-account files are flat records and the full
+ * grammar (filters, wildcards, recursive descent, scripts) would add a
+ * dependency and an evaluation surface to parse an operator-supplied string
+ * against operator-supplied data — for no case anyone has. A manifest asking for
+ * more than this fails loudly at load time rather than silently matching nothing.
+ */
+
+/** Hard ceiling on an uploaded key file. Service-account keys are ~2.3 KB; this
+ *  leaves generous room while keeping a hostile upload from reaching `JSON.parse`
+ *  at all. Checked on the RAW text, before parsing. */
+export const JSON_FILE_MAX_BYTES = 64 * 1024;
+
+/** Cap on how many values one field may explode into. Bounds both the response
+ *  and the number of vault writes a single upload can trigger. */
+export const JSON_FILE_MAX_EXTRACTS = 16;
+
+/** The `json_file` half of a setup-field declaration. */
+export interface JsonFileFieldSpec {
+  /** The `json_file` field's own key. Never stored — it names the upload, not a
+   *  secret. */
+  readonly key: string;
+  /** target setup-field key → `$.dotted.path` into the uploaded document. */
+  readonly extracts: Readonly<Record<string, string>>;
+  /** Shallow equality assertions against the document, e.g.
+   *  `{ type: 'service_account' }`. Catches the wrong file before any value is
+   *  extracted — an OAuth client secret and a service-account key look alike
+   *  enough to confuse at a glance. */
+  readonly expect?: Readonly<Record<string, unknown>>;
+}
+
+/** The discriminant of {@link JsonFileFailure}. Exported so a caller can map
+ *  every kind exhaustively — the route does, so a new kind cannot ship without
+ *  a wire code and operator help copy. */
+export type JsonFileFailureCode =
+  | 'too_large'
+  | 'not_json'
+  | 'not_an_object'
+  | 'unexpected_document'
+  | 'bad_extract_path'
+  | 'missing_value'
+  | 'invalid_spec';
+
+export type JsonFileFailure =
+  | { readonly code: 'too_large'; readonly message: string }
+  | { readonly code: 'not_json'; readonly message: string }
+  | { readonly code: 'not_an_object'; readonly message: string }
+  | { readonly code: 'unexpected_document'; readonly message: string }
+  | { readonly code: 'bad_extract_path'; readonly message: string }
+  | { readonly code: 'missing_value'; readonly message: string }
+  | { readonly code: 'invalid_spec'; readonly message: string };
+
+export type JsonFileOutcome =
+  | { readonly ok: true; readonly values: Record<string, string> }
+  | { readonly ok: false; readonly failure: JsonFileFailure };
+
+const PATH_RE = /^\$(?:\.[A-Za-z_][A-Za-z0-9_-]*)+$/;
+
+/**
+ * Resolve `$.a.b` against `doc`. Returns `undefined` for any miss — a missing
+ * segment, a non-object on the way down, or an inherited property.
+ *
+ * `Object.hasOwn` matters: without it `$.constructor` resolves through the
+ * prototype chain and a manifest could extract a function into a secret.
+ */
+function resolvePath(doc: Record<string, unknown>, path: string): unknown {
+  const segments = path.slice(2).split('.');
+  let node: unknown = doc;
+  for (const segment of segments) {
+    if (node === null || typeof node !== 'object' || Array.isArray(node)) {
+      return undefined;
+    }
+    if (!Object.hasOwn(node as object, segment)) return undefined;
+    node = (node as Record<string, unknown>)[segment];
+  }
+  return node;
+}
+
+/** Render a value for an `expect` mismatch message. Only ever called on the
+ *  DECLARED expectation and on scalars from the document that the operator
+ *  chose to assert on — never on an extracted secret. */
+function describe(value: unknown): string {
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (value === null || ['number', 'boolean'].includes(typeof value)) {
+    return String(value);
+  }
+  return typeof value;
+}
+
+/**
+ * Parse an uploaded document and produce the derived setup values.
+ *
+ * On success the caller receives ONLY the extracted values. `raw` is never
+ * returned, never logged, and must never be persisted — the whole point is that
+ * the file itself does not become state.
+ *
+ * Every failure names what is wrong in a sentence an operator can act on. A
+ * silent empty secret is the one outcome this must never produce: it would look
+ * like a successful setup and fail later, far from the cause.
+ */
+export function extractFromJsonFile(
+  raw: string,
+  spec: JsonFileFieldSpec,
+): JsonFileOutcome {
+  const entries = Object.entries(spec.extracts ?? {});
+  if (entries.length === 0) {
+    return {
+      ok: false,
+      failure: {
+        code: 'invalid_spec',
+        message: `Setup field '${spec.key}' declares no 'extracts', so the upload could not produce any value.`,
+      },
+    };
+  }
+  if (entries.length > JSON_FILE_MAX_EXTRACTS) {
+    return {
+      ok: false,
+      failure: {
+        code: 'invalid_spec',
+        message: `Setup field '${spec.key}' declares ${String(entries.length)} extracts; at most ${String(JSON_FILE_MAX_EXTRACTS)} are allowed.`,
+      },
+    };
+  }
+
+  // Size is checked on the raw text, BEFORE parsing: the cap exists so a hostile
+  // upload never reaches `JSON.parse` in the first place.
+  const bytes = Buffer.byteLength(raw, 'utf8');
+  if (bytes > JSON_FILE_MAX_BYTES) {
+    return {
+      ok: false,
+      failure: {
+        code: 'too_large',
+        message: `The uploaded file is ${String(bytes)} bytes; the limit is ${String(JSON_FILE_MAX_BYTES)}.`,
+      },
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {
+      ok: false,
+      failure: {
+        code: 'not_json',
+        message: 'The uploaded file is not valid JSON.',
+      },
+    };
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      failure: {
+        code: 'not_an_object',
+        message: 'The uploaded file must contain a JSON object.',
+      },
+    };
+  }
+  const doc = parsed as Record<string, unknown>;
+
+  // `expect` runs BEFORE extraction, so the wrong file is rejected without any
+  // value being pulled out of it.
+  for (const [key, want] of Object.entries(spec.expect ?? {})) {
+    const got = Object.hasOwn(doc, key) ? doc[key] : undefined;
+    if (got !== want) {
+      return {
+        ok: false,
+        failure: {
+          code: 'unexpected_document',
+          message:
+            `This does not look like the expected file: '${key}' is ` +
+            `${got === undefined ? 'missing' : describe(got)}, expected ${describe(want)}.`,
+        },
+      };
+    }
+  }
+
+  const values: Record<string, string> = {};
+  for (const [target, path] of entries) {
+    if (!PATH_RE.test(path)) {
+      return {
+        ok: false,
+        failure: {
+          code: 'bad_extract_path',
+          message: `Setup field '${spec.key}' declares an unsupported extract path '${path}' for '${target}'. Use '$.key' or '$.nested.key'.`,
+        },
+      };
+    }
+    const found = resolvePath(doc, path);
+    // Only strings become secrets. A number or object at the path means the
+    // manifest and the file disagree about the shape, which is a setup error,
+    // not something to coerce.
+    if (typeof found !== 'string' || found === '') {
+      return {
+        ok: false,
+        failure: {
+          code: 'missing_value',
+          message:
+            `The uploaded file has no usable value at '${path}' (needed for '${target}'). ` +
+            'Check that you selected the right file.',
+        },
+      };
+    }
+    values[target] = found;
+  }
+  return { ok: true, values };
+}

--- a/middleware/src/routes/runtime.ts
+++ b/middleware/src/routes/runtime.ts
@@ -17,6 +17,8 @@ import type { InstalledRegistry } from '../plugins/installedRegistry.js';
 import type { PluginCatalog } from '../plugins/manifestLoader.js';
 import { checkSetupFieldPattern } from '../plugins/setupFieldPattern.js';
 import type { PatternViolation } from '../plugins/setupFieldPattern.js';
+import { extractFromJsonFile } from '../plugins/setupJsonFile.js';
+import type { JsonFileFailureCode, JsonFileFieldSpec } from '../plugins/setupJsonFile.js';
 import type { SecretVault } from '../secrets/vault.js';
 
 /** Per-call budget for invoking a plugin's dynamic options provider. */
@@ -513,57 +515,98 @@ export function createRuntimeRouter(deps: RuntimeDeps): Router {
         return;
       }
 
-      const secretFieldKeys = resolveSecretFieldKeys(deps.catalog, id);
-      const isSecret = (key: string): boolean =>
-        secretFieldKeys === null ? true : secretFieldKeys.has(key);
+      await applySetupValues(deps, id, installed, setEntries, deleteKeys, res);
+    },
+  );
 
-      const vaultSet: Record<string, string> = {};
-      const vaultDelete: string[] = [];
-      const configSet: Record<string, unknown> = {};
-      const configDelete: string[] = [];
-      for (const [k, v] of Object.entries(setEntries)) {
-        if (isSecret(k)) vaultSet[k] = v;
-        else configSet[k] = v;
+  // ── POST /installed/:id/secrets/from-json ──────────────────────────
+  // #603 (OM-17) — a `json_file` setup field: the operator uploads the
+  // credential file instead of transcribing values out of it.
+  //
+  // The near-miss this closes: a tester typed their real Google account
+  // password into `gw_sa_private_key`, because the form asked them to copy two
+  // values out of a service-account key into an email field and a masked field
+  // stacked beneath it — the visual pattern of a login. #599 made that mistake
+  // detectable; this makes it unavailable.
+  //
+  // The parse happens HERE, not in the browser: a client that decides which
+  // bytes become `gw_sa_private_key` is a client that can be made to decide
+  // wrongly. The raw document is never persisted and never echoed back — the
+  // response names the derived KEYS only, exactly like the PATCH above.
+  //
+  // The derived values then go down the SAME `applySetupValues` path as typed
+  // ones, so pattern validation, the vault/config split, reactivation and the
+  // response shape cannot drift between "typed it" and "uploaded it".
+  router.post(
+    '/installed/:id/secrets/from-json',
+    async (req: Request, res: Response) => {
+      const id = readId(req);
+      if (!id) {
+        res.status(400).json({ code: 'runtime.invalid_id', message: 'missing id' });
+        return;
       }
-      for (const k of deleteKeys) {
-        if (isSecret(k)) vaultDelete.push(k);
-        else configDelete.push(k);
-      }
-
-      try {
-        if (Object.keys(vaultSet).length > 0) {
-          await deps.vault.setMany(id, vaultSet);
-        }
-        for (const key of vaultDelete) {
-          await deps.vault.deleteKey(id, key);
-        }
-        if (
-          Object.keys(configSet).length > 0 ||
-          configDelete.length > 0
-        ) {
-          const nextConfig: Record<string, unknown> = {
-            ...installed.config,
-            ...configSet,
-          };
-          for (const k of configDelete) delete nextConfig[k];
-          await deps.installedRegistry.updateConfig(id, nextConfig);
-        }
-        if (deps.reactivate) {
-          await deps.reactivate(id);
-        }
-        const keys = await deps.vault.listKeys(id);
-        const updated = deps.installedRegistry.get(id);
-        const configValues = stringifyConfigValues(updated?.config);
-        const configKeys = Object.keys(configValues);
-        res.json({
-          keys: keys.sort(),
-          config_keys: configKeys.sort(),
-          config_values: configValues,
+      const installed = deps.installedRegistry.get(id);
+      if (!installed) {
+        res.status(404).json({
+          code: 'runtime.not_installed',
+          message: `agent '${id}' is not installed`,
         });
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        res.status(500).json({ code: 'runtime.vault_write_failed', message });
+        return;
       }
+      if (!deps.vault) {
+        res.status(503).json({
+          code: 'runtime.vault_unavailable',
+          message: 'vault not wired into runtime route',
+        });
+        return;
+      }
+      const body: unknown = req.body;
+      const fieldKey =
+        typeof body === 'object' && body !== null && !Array.isArray(body)
+          ? (body as { field?: unknown }).field
+          : undefined;
+      const content =
+        typeof body === 'object' && body !== null && !Array.isArray(body)
+          ? (body as { content?: unknown }).content
+          : undefined;
+      if (typeof fieldKey !== 'string' || typeof content !== 'string') {
+        res.status(400).json({
+          code: 'runtime.invalid_json_file_body',
+          message: 'body must be { field: string, content: string }',
+        });
+        return;
+      }
+
+      // The SPEC comes from the manifest, never from the request: the caller
+      // names which field it is uploading for, and the server looks up what
+      // that field is allowed to extract. A caller-supplied `extracts` would let
+      // anyone write any vault key from any file.
+      const spec = resolveJsonFileField(deps.catalog, id, fieldKey);
+      if (!spec) {
+        res.status(400).json({
+          code: 'runtime.unknown_json_file_field',
+          message: `'${fieldKey}' is not a json_file setup field of '${id}'`,
+        });
+        return;
+      }
+
+      const outcome = extractFromJsonFile(content, spec);
+      if (!outcome.ok) {
+        res.status(400).json({
+          // Spelled out as LITERALS in JSON_FILE_ERROR_CODES rather than built
+          // with a template. The errorHelp coverage guard
+          // (`web-ui/app/_lib/__tests__/errorHelpCoverage.test.ts`) scans these
+          // sources for error-code literals to prove every emitted one has
+          // operator help copy — a template-built value is invisible to it, so
+          // the copy could silently rot. Literals also make each value greppable
+          // from the message catalogue back to the line that emits it.
+          code: JSON_FILE_ERROR_CODES[outcome.failure.code],
+          message: outcome.failure.message,
+          field: fieldKey,
+        });
+        return;
+      }
+      await applySetupValues(deps, id, installed, outcome.values, [], res);
     },
   );
 
@@ -591,6 +634,23 @@ export function createRuntimeRouter(deps: RuntimeDeps): Router {
 
   return router;
 }
+
+/**
+ * #603 — `JsonFileFailure['code']` → the wire error code.
+ *
+ * Exhaustive by type: adding a failure kind to `setupJsonFile.ts` without a
+ * code here is a compile error, which is the point. Each value is a literal so
+ * the errorHelp coverage guard can see it.
+ */
+const JSON_FILE_ERROR_CODES: Record<JsonFileFailureCode, string> = {
+  too_large: 'runtime.json_file_too_large',
+  not_json: 'runtime.json_file_not_json',
+  not_an_object: 'runtime.json_file_not_an_object',
+  unexpected_document: 'runtime.json_file_unexpected_document',
+  bad_extract_path: 'runtime.json_file_bad_extract_path',
+  missing_value: 'runtime.json_file_missing_value',
+  invalid_spec: 'runtime.json_file_invalid_spec',
+};
 
 function readId(req: Request): string | null {
   const raw = req.params['id'];
@@ -646,6 +706,139 @@ function parseDeleteKeys(raw: unknown): string[] | 'invalid' {
  * PATCH handler treats `null` as "route everything to the vault" — preserving
  * the legacy behaviour for plugins without a setup schema.
  */
+/**
+ * #603 — resolve the manifest's declaration for ONE `json_file` field.
+ *
+ * The extraction map is looked up here rather than accepted from the request, on
+ * purpose: a caller-supplied `extracts` would let anyone write any vault key
+ * from any file. The request names WHICH field it is uploading for; the manifest
+ * decides what that field may produce.
+ *
+ * Returns undefined for an unknown field, a field of any other type, or a
+ * plugin with no setup schema — all of which are "there is no upload contract
+ * here", which the route reports as a 400 rather than inventing one.
+ */
+function resolveJsonFileField(
+  catalog: PluginCatalog | undefined,
+  pluginId: string,
+  fieldKey: string,
+): JsonFileFieldSpec | undefined {
+  const entry = catalog?.get(pluginId);
+  if (!entry) return undefined;
+  const schema = extractSetupSchema(entry);
+  if (!schema) return undefined;
+  const field = schema.fields.find((f) => f.key === fieldKey);
+  if (!field || field.type !== 'json_file' || !field.extracts) return undefined;
+  return {
+    key: field.key,
+    extracts: field.extracts,
+    ...(field.expect ? { expect: field.expect } : {}),
+  };
+}
+
+/**
+ * The write half of a setup-value update, shared by the typed path
+ * (`PATCH …/secrets`) and the uploaded path (`POST …/secrets/from-json`).
+ *
+ * Shared deliberately rather than copied. The security claim of #603 is that an
+ * extracted value is treated EXACTLY like a typed one — same pattern
+ * validation, same vault/config split, same reactivation, same response. Two
+ * implementations of that would be two implementations that can drift, and the
+ * drift would be invisible until a `json_file` field quietly skipped a check the
+ * typed path applies.
+ *
+ * Writes NOTHING on a validation failure: a partial write leaves the plugin
+ * half-configured, which the readiness computation would then report as
+ * configured.
+ *
+ * Sends the response itself (including error responses), so callers must not
+ * write to `res` afterwards.
+ */
+async function applySetupValues(
+  deps: RuntimeDeps,
+  id: string,
+  installed: { config?: Record<string, unknown> },
+  setEntries: Record<string, string>,
+  deleteKeys: readonly string[],
+  res: Response,
+): Promise<void> {
+  const vault = deps.vault;
+  if (!vault) {
+    res.status(503).json({
+      code: 'runtime.vault_unavailable',
+      message: 'vault not wired into runtime route',
+    });
+    return;
+  }
+  // OM-17 — validate VALUES before anything is written. Until this landed, the
+  // only checks were shape checks, so a masked field happily accepted a Google
+  // account password and reported "gespeichert". The vault write is the
+  // server's responsibility, so the gate has to be here — a client-side check
+  // alone is theatre.
+  const violation = await findPatternViolation(deps.catalog, id, setEntries);
+  if (violation) {
+    res.status(400).json({
+      code: 'runtime.setup_field_invalid',
+      message: `value for '${violation.field}' does not match the expected format`,
+      field: violation.field,
+      // Only ever the manifest's own hint, resolved to ENGLISH — this process
+      // has no request locale. See `setupFieldPattern.ts` → `PatternViolation`.
+      ...(violation.hint !== undefined ? { hint: violation.hint } : {}),
+    });
+    return;
+  }
+
+  const secretFieldKeys = resolveSecretFieldKeys(deps.catalog, id);
+  const isSecret = (key: string): boolean =>
+    secretFieldKeys === null ? true : secretFieldKeys.has(key);
+
+  const vaultSet: Record<string, string> = {};
+  const vaultDelete: string[] = [];
+  const configSet: Record<string, unknown> = {};
+  const configDelete: string[] = [];
+  for (const [k, v] of Object.entries(setEntries)) {
+    if (isSecret(k)) vaultSet[k] = v;
+    else configSet[k] = v;
+  }
+  for (const k of deleteKeys) {
+    if (isSecret(k)) vaultDelete.push(k);
+    else configDelete.push(k);
+  }
+
+  try {
+    if (Object.keys(vaultSet).length > 0) {
+      await vault.setMany(id, vaultSet);
+    }
+    for (const key of vaultDelete) {
+      await vault.deleteKey(id, key);
+    }
+    if (Object.keys(configSet).length > 0 || configDelete.length > 0) {
+      const nextConfig: Record<string, unknown> = {
+        ...installed.config,
+        ...configSet,
+      };
+      for (const k of configDelete) delete nextConfig[k];
+      await deps.installedRegistry.updateConfig(id, nextConfig);
+    }
+    if (deps.reactivate) {
+      await deps.reactivate(id);
+    }
+    const keys = await vault.listKeys(id);
+    const updated = deps.installedRegistry.get(id);
+    const configValues = stringifyConfigValues(updated?.config);
+    const configKeys = Object.keys(configValues);
+    // Key NAMES only — never a value, not even masked. Identical on both paths.
+    res.json({
+      keys: keys.sort(),
+      config_keys: configKeys.sort(),
+      config_values: configValues,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    res.status(500).json({ code: 'runtime.vault_write_failed', message });
+  }
+}
+
 function resolveSecretFieldKeys(
   catalog: PluginCatalog | undefined,
   pluginId: string,

--- a/middleware/test/setupJsonFile.test.ts
+++ b/middleware/test/setupJsonFile.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Issue #603 (OM-17) — server-side extraction for `json_file` setup fields.
+ *
+ * The near-miss this closes: a tester typed their real Google account password
+ * into `gw_sa_private_key`, because the form asked them to hand-transcribe two
+ * values out of a service-account key file into an email field and a masked
+ * field stacked beneath it — the visual pattern of a login. #599 made that
+ * mistake detectable; uploading the file removes the opportunity to make it.
+ *
+ * The guarantees under test are the ones an upload path has to earn, because it
+ * turns operator-supplied bytes into vault contents:
+ *   - the size cap is applied to the RAW text, before `JSON.parse` runs;
+ *   - `expect` rejects the wrong file BEFORE any value is extracted;
+ *   - a missing path is a readable error, never a silently empty secret;
+ *   - prototype properties are not reachable through an extract path;
+ *   - the raw document never appears in a success result.
+ */
+
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  JSON_FILE_MAX_BYTES,
+  JSON_FILE_MAX_EXTRACTS,
+  extractFromJsonFile,
+  type JsonFileFieldSpec,
+} from '../src/plugins/setupJsonFile.js';
+
+const EMAIL = 'svc@proj.iam.gserviceaccount.com';
+const KEY = '-----BEGIN PRIVATE KEY-----\nMIIEv...\n-----END PRIVATE KEY-----\n';
+
+const SPEC: JsonFileFieldSpec = {
+  key: 'gw_sa_key',
+  extracts: {
+    gw_sa_client_email: '$.client_email',
+    gw_sa_private_key: '$.private_key',
+  },
+  expect: { type: 'service_account' },
+};
+
+function serviceAccount(over: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    type: 'service_account',
+    project_id: 'proj',
+    client_email: EMAIL,
+    private_key: KEY,
+    ...over,
+  });
+}
+
+describe('#603 — extracting a service-account key', () => {
+  it('MUTATION CHECK: explodes the upload into exactly the declared keys', () => {
+    const out = extractFromJsonFile(serviceAccount(), SPEC);
+    assert.ok(out.ok, out.ok ? '' : out.failure.message);
+    assert.deepEqual(out.values, {
+      gw_sa_client_email: EMAIL,
+      gw_sa_private_key: KEY,
+    });
+  });
+
+  it('MUTATION CHECK: the raw document never rides along in the result', () => {
+    // The file must not become state. A result that carried the parsed document
+    // (or the raw text) would put project_id and anything else in the file one
+    // careless `Object.assign` away from the vault.
+    const out = extractFromJsonFile(serviceAccount(), SPEC);
+    assert.ok(out.ok);
+    assert.deepEqual(Object.keys(out.values).sort(), [
+      'gw_sa_client_email',
+      'gw_sa_private_key',
+    ]);
+    assert.equal(JSON.stringify(out).includes('project_id'), false);
+  });
+
+  it('supports a nested path', () => {
+    const spec: JsonFileFieldSpec = { key: 'f', extracts: { token: '$.a.b.c' } };
+    const out = extractFromJsonFile(JSON.stringify({ a: { b: { c: 'deep' } } }), spec);
+    assert.ok(out.ok);
+    assert.equal(out.values['token'], 'deep');
+  });
+});
+
+describe('#603 — the wrong file is refused before anything is extracted', () => {
+  it('MUTATION CHECK: expect rejects an OAuth client secret', () => {
+    // The realistic confusion: an OAuth client-secret JSON and a service-account
+    // key look alike at a glance. `expect` is what tells them apart.
+    const out = extractFromJsonFile(
+      JSON.stringify({ type: 'authorized_user', client_email: EMAIL, private_key: KEY }),
+      SPEC,
+    );
+    assert.equal(out.ok, false);
+    assert.equal(out.ok === false && out.failure.code, 'unexpected_document');
+    assert.match(
+      out.ok === false ? out.failure.message : '',
+      /type/,
+      'the message must name the field that disagreed',
+    );
+  });
+
+  it('MUTATION CHECK: a missing key is a readable error, not an empty secret', () => {
+    // The one outcome this must never produce: a "successful" setup that stored
+    // nothing, failing later and far from the cause.
+    const out = extractFromJsonFile(serviceAccount({ private_key: undefined }), SPEC);
+    assert.equal(out.ok, false);
+    assert.equal(out.ok === false && out.failure.code, 'missing_value');
+    assert.match(out.ok === false ? out.failure.message : '', /gw_sa_private_key/);
+  });
+
+  it('MUTATION CHECK: an empty string is a missing value, not a stored secret', () => {
+    const out = extractFromJsonFile(serviceAccount({ private_key: '' }), SPEC);
+    assert.equal(out.ok, false);
+    assert.equal(out.ok === false && out.failure.code, 'missing_value');
+  });
+
+  it('refuses a non-string value rather than coercing it', () => {
+    const out = extractFromJsonFile(serviceAccount({ private_key: 42 }), SPEC);
+    assert.equal(out.ok, false);
+    assert.equal(out.ok === false && out.failure.code, 'missing_value');
+  });
+});
+
+describe('#603 — guard rails on the upload itself', () => {
+  it('MUTATION CHECK: the size cap is applied before parsing', () => {
+    // Checked on the RAW text so a hostile upload never reaches `JSON.parse`.
+    // Built as valid JSON on purpose: if the cap ran after parsing, this would
+    // succeed and the test would be asserting nothing.
+    const huge = JSON.stringify({
+      type: 'service_account',
+      client_email: EMAIL,
+      private_key: 'x'.repeat(JSON_FILE_MAX_BYTES),
+    });
+    assert.ok(huge.length > JSON_FILE_MAX_BYTES, 'fixture is not actually oversized');
+    const out = extractFromJsonFile(huge, SPEC);
+    assert.equal(out.ok, false);
+    assert.equal(out.ok === false && out.failure.code, 'too_large');
+  });
+
+  it('MUTATION CHECK: non-JSON and non-object payloads are refused', () => {
+    for (const [raw, code] of [
+      ['not json at all', 'not_json'],
+      ['[1,2,3]', 'not_an_object'],
+      ['"a string"', 'not_an_object'],
+      ['null', 'not_an_object'],
+    ] as const) {
+      const out = extractFromJsonFile(raw, SPEC);
+      assert.equal(out.ok, false, `unexpectedly accepted: ${raw}`);
+      assert.equal(out.ok === false && out.failure.code, code, `wrong code for ${raw}`);
+    }
+  });
+
+  it('MUTATION CHECK: an extract path cannot reach a prototype property', () => {
+    // Without an own-property check `$.constructor` resolves through the
+    // prototype chain, and a manifest could extract a function into a secret.
+    const spec: JsonFileFieldSpec = { key: 'f', extracts: { x: '$.constructor' } };
+    const out = extractFromJsonFile(JSON.stringify({ a: 1 }), spec);
+    assert.equal(out.ok, false);
+    assert.equal(out.ok === false && out.failure.code, 'missing_value');
+  });
+
+  it('MUTATION CHECK: an unsupported path syntax fails loudly', () => {
+    // Not JSONPath — see the module doc for why the grammar is a subset. A
+    // manifest asking for more must fail rather than silently match nothing.
+    for (const path of ['$..private_key', '$.a[0]', 'private_key', '$', '$.']) {
+      const out = extractFromJsonFile(serviceAccount(), {
+        key: 'f',
+        extracts: { x: path },
+      });
+      assert.equal(out.ok, false, `unexpectedly accepted path: ${path}`);
+      assert.equal(
+        out.ok === false && out.failure.code,
+        'bad_extract_path',
+        `wrong code for ${path}`,
+      );
+    }
+  });
+
+  it('refuses a spec with no extracts, and one with too many', () => {
+    const none = extractFromJsonFile(serviceAccount(), { key: 'f', extracts: {} });
+    assert.equal(none.ok, false);
+    assert.equal(none.ok === false && none.failure.code, 'invalid_spec');
+
+    const many: Record<string, string> = {};
+    for (let i = 0; i <= JSON_FILE_MAX_EXTRACTS; i += 1) many[`k${String(i)}`] = '$.a';
+    const tooMany = extractFromJsonFile(serviceAccount(), { key: 'f', extracts: many });
+    assert.equal(tooMany.ok, false);
+    assert.equal(tooMany.ok === false && tooMany.failure.code, 'invalid_spec');
+  });
+});

--- a/web-ui/app/_components/store/CredentialsEditor.tsx
+++ b/web-ui/app/_components/store/CredentialsEditor.tsx
@@ -260,7 +260,19 @@ export function CredentialsEditor({
       </div>
 
       <ul className="divide-y divide-[color:var(--rule)] border-y border-[color:var(--rule)]">
-        {setupFields.map((field) => {
+        {/*
+          #603 (OM-17) — `json_file` fields are omitted here on purpose.
+          They carry no value of their own (the server explodes the upload into
+          the keys named in `extracts`), and every row below renders a text
+          input — so leaving them in would show a text box asking for a
+          service-account key, which is precisely the transcription step #603
+          exists to remove. The DERIVED fields are ordinary `secret` fields and
+          are listed here as usual, so post-install editing still works.
+          Offering the upload here too is a follow-up, not a gap in the flow.
+        */}
+        {setupFields
+          .filter((field) => field.type !== 'json_file')
+          .map((field) => {
           const state =
             fieldStates[field.key] ??
             ({ draft: '', dirty: false, pendingDelete: false } as FieldState);

--- a/web-ui/app/_components/store/setupForm.tsx
+++ b/web-ui/app/_components/store/setupForm.tsx
@@ -88,7 +88,24 @@ export function FieldRow({
       </label>
 
       <div className="mt-2">
-        {field.type === 'boolean' ? (
+        {/*
+          #603 (OM-17) — a `json_file` field is a FILE PICKER, never a text box.
+          Falling through to the text input below would be worse than not having
+          the type at all: it would ask the operator to paste a raw
+          service-account key into a field, which is the transcription step this
+          feature exists to remove. The upload is posted to
+          `…/secrets/from-json`, parsed server-side, and only the derived keys
+          are stored — so this input has no `name` and submits nothing itself.
+        */}
+        {field.type === 'json_file' ? (
+          <input
+            id={id}
+            type="file"
+            accept={field.accept ?? 'application/json'}
+            data-json-file-field={field.key}
+            className="block w-full border border-[color:var(--rule-strong)] bg-[color:var(--paper)] px-3 py-2 text-sm file:mr-3 file:border-0 file:bg-[color:var(--rule)] file:px-3 file:py-1 file:text-sm"
+          />
+        ) : field.type === 'boolean' ? (
           <label
             htmlFor={id}
             className="flex items-center gap-3 border border-[color:var(--rule-strong)] bg-[color:var(--paper)] px-3 py-2 text-sm"
@@ -248,6 +265,13 @@ export function extractValues(
 ): Record<string, unknown> {
   const values: Record<string, unknown> = {};
   for (const field of fields) {
+    // #603 (OM-17) — a `json_file` field submits NOTHING under its own key. The
+    // file goes to `…/secrets/from-json`, where the server parses it and stores
+    // only the derived keys; the middleware's `coerce()` refuses a value here
+    // for the same reason. Skipping it in one place and not the other would send
+    // the raw document to an endpoint that rejects it, and the operator would
+    // see a validation error for a field they never typed in.
+    if (field.type === 'json_file') continue;
     if (field.type === 'boolean') {
       values[field.key] = formData.get(field.key) === 'on';
       continue;

--- a/web-ui/app/_lib/__tests__/errorHelpCoverage.test.ts
+++ b/web-ui/app/_lib/__tests__/errorHelpCoverage.test.ts
@@ -76,6 +76,25 @@ const FORWARDED_CODE_SOURCES = [
     /** Throw sites present when this forwarder was registered. */
     minCodes: 11,
   },
+  {
+    /**
+     * #603 (OM-17) — `POST …/secrets/from-json` maps `JsonFileFailure['code']`
+     * onto a wire code through the `JSON_FILE_ERROR_CODES` table, so the
+     * `code:` expression at the emission site is an index, not a literal. The
+     * literals all live in that table, in this same file.
+     *
+     * The table exists BECAUSE of this guard: the route originally built the
+     * code with a template (`runtime.json_file_${failure.code}`), which this
+     * extractor cannot see at all — the codes would have shipped with no
+     * operator copy while the suite stayed green.
+     */
+    route: 'runtime.ts',
+    forwards: 'code: JSON_FILE_ERROR_CODES[outcome.failure.code]',
+    source: ['middleware', 'src', 'routes', 'runtime.ts'],
+    /** `too_large: 'runtime.json_file_too_large',` */
+    literal: /:\s*'(runtime\.json_file_[a-z_]+)'/g,
+    minCodes: 7,
+  },
 ] as const;
 
 /**
@@ -106,6 +125,10 @@ const ACKNOWLEDGED_NON_LITERAL_CODE: Readonly<
     {
       expr: 'code: string;',
       why: "type annotation on validateMultiselectValue's error result",
+    },
+    {
+      expr: 'code: JSON_FILE_ERROR_CODES[outcome.failure.code]',
+      why: '#603 json_file extraction failure — followed via FORWARDED_CODE_SOURCES',
     },
   ],
 };

--- a/web-ui/app/_lib/errorHelp.ts
+++ b/web-ui/app/_lib/errorHelp.ts
@@ -72,8 +72,22 @@ export const ERROR_HELP_CODES = [
   'runtime.invalid_audit_mode',
   'runtime.invalid_config',
   'runtime.invalid_id',
+  // #603 (OM-17) — the `json_file` upload path. The `json_file_*` codes mirror
+  // `JsonFileFailure` in `middleware/src/plugins/setupJsonFile.ts`; the two
+  // spec-level ones say plainly that the fault is in the plugin, not in the
+  // operator's file, because that distinction is the whole difference between
+  // "try another file" and "report this".
+  'runtime.invalid_json_file_body',
   'runtime.invalid_multiselect',
   'runtime.invalid_secrets_body',
+  'runtime.json_file_bad_extract_path',
+  'runtime.json_file_invalid_spec',
+  'runtime.json_file_missing_value',
+  'runtime.json_file_not_an_object',
+  'runtime.json_file_not_json',
+  'runtime.json_file_too_large',
+  'runtime.json_file_unexpected_document',
+  'runtime.unknown_json_file_field',
   'runtime.no_options_provider',
   'runtime.not_installed',
   'runtime.not_web_scanner',

--- a/web-ui/app/_lib/storeTypes.ts
+++ b/web-ui/app/_lib/storeTypes.ts
@@ -13,7 +13,15 @@ export type SetupFieldType =
   | 'boolean'
   | 'integer'
   /** #91 — operator-curated list of bare hostnames. */
-  | 'host_list';
+  | 'host_list'
+  /**
+   * #603 (OM-17) — upload a JSON credential file instead of transcribing it.
+   * Sixth place this union is mirrored (three in the middleware's own sources,
+   * `SUPPORTED_TYPES` in installService, and `agents.ts` next door). The field
+   * stores nothing itself: the server explodes the upload into the keys named
+   * in `extracts`.
+   */
+  | 'json_file';
 
 /** #91 — operator-selected egress mode for an audit/scanner plugin. */
 export type AuditMode = 'single-host' | 'allowlist' | 'public-web';
@@ -66,6 +74,14 @@ export interface PluginSetupField {
    *  show the SHAPE of the expected value, which is exactly the information a
    *  tester lacked when they typed a password into a private-key field. */
   placeholder?: string;
+  /**
+   * #603 (OM-17) — `json_file` only. `accept` is the file picker's hint; the
+   * server, not the picker, decides what an upload actually is. `extracts` names
+   * the setup keys the upload explodes into — carried here so the renderer can
+   * tell the operator which fields the file will fill in.
+   */
+  accept?: string;
+  extracts?: Record<string, string>;
 }
 
 /** Spec 005 — how a declarative OAuth descriptor authenticates to the token
@@ -367,6 +383,14 @@ export interface InstallSetupField {
    *  `'••••••••'` for every secret field, hiding the one piece of information
    *  that distinguishes a service-account key from an account password. */
   placeholder?: string;
+  /**
+   * #603 (OM-17) — `json_file` only. `accept` is the file picker's hint; the
+   * server, not the picker, decides what an upload actually is. `extracts` names
+   * the setup keys the upload explodes into — carried here so the renderer can
+   * tell the operator which fields the file will fill in.
+   */
+  accept?: string;
+  extracts?: Record<string, string>;
   multiline?: boolean;
   /** Omitted from the install flyout (flow-managed / editable later). */
   install_hidden?: boolean;

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -946,6 +946,10 @@
         "what": "Die Anfrage nennt nicht, um welches Plugin es geht.",
         "next": "Lade die Seite neu und wiederhole die Aktion auf dem Plugin-Screen."
       },
+      "invalid_json_file_body": {
+        "what": "Die Upload-Anfrage nannte nicht zugleich ein Setup-Feld und eine Datei — der Server konnte nicht erkennen, was er auswerten soll.",
+        "next": "Lade die Seite neu und wähle die Datei erneut aus."
+      },
       "invalid_multiselect": {
         "what": "Einer der ausgewählten Werte hat nicht die Form, die der Server akzeptiert.",
         "next": "Leere die Auswahl und wähle die Einträge erneut aus der Liste."
@@ -953,6 +957,34 @@
       "invalid_secrets_body": {
         "what": "Die Zugangsdaten kamen in einer Form an, die der Server ablehnt.",
         "next": "Lade die Seite neu und trage die Zugangsdaten erneut ein."
+      },
+      "json_file_bad_extract_path": {
+        "what": "Das Plugin deklariert einen Upload-Pfad, den der Server nicht unterstützt — die Datei konnte nicht gelesen werden.",
+        "next": "Das liegt am Plugin, nicht an deiner Datei — melde es dem Plugin-Autor."
+      },
+      "json_file_invalid_spec": {
+        "what": "Das Plugin deklariert diesen Datei-Upload fehlerhaft, er kann keinen Wert erzeugen.",
+        "next": "Das liegt am Plugin, nicht an deiner Datei — melde es dem Plugin-Autor."
+      },
+      "json_file_missing_value": {
+        "what": "In der hochgeladenen Datei fehlt einer der Werte, die dieses Feld braucht.",
+        "next": "Prüfe, ob du die richtige Datei ausgewählt hast — die Meldung unten nennt den fehlenden Wert."
+      },
+      "json_file_not_an_object": {
+        "what": "Die Datei ist zwar gültiges JSON, aber kein JSON-Objekt — sie enthält also keine benannten Werte.",
+        "next": "Lade die Zugangsdatei hoch, die der Anbieter ausgestellt hat, keine Liste und keinen Ausschnitt davon."
+      },
+      "json_file_not_json": {
+        "what": "Die hochgeladene Datei ist kein gültiges JSON, es konnte also nichts daraus gelesen werden.",
+        "next": "Lade die Schlüsseldatei beim Anbieter erneut herunter und lade sie unverändert hoch."
+      },
+      "json_file_too_large": {
+        "what": "Die hochgeladene Datei ist größer, als der Server für eine Zugangsdatei akzeptiert.",
+        "next": "Prüfe, ob du die Schlüsseldatei selbst ausgewählt hast und kein Archiv oder einen Export."
+      },
+      "json_file_unexpected_document": {
+        "what": "Die hochgeladene Datei ist die falsche Art von Zugangsdatei — ihr Inhalt passt nicht zu dem, was dieses Feld erwartet.",
+        "next": "Die Meldung unten nennt den abweichenden Wert; lade anschließend die richtige Datei hoch."
       },
       "no_options_provider": {
         "what": "Dieses Feld hat keine Live-Quelle für Optionen, es lässt sich also nichts nachladen.",
@@ -986,6 +1018,10 @@
       "setup_field_invalid": {
         "what": "Einer der Werte passt nicht zum Format, das dieses Feld erwartet.",
         "next": "Korrigiere das markierte Feld und speichere erneut."
+      },
+      "unknown_json_file_field": {
+        "what": "Der Upload nennt ein Setup-Feld, das dieses Plugin nicht als Datei-Upload anbietet.",
+        "next": "Lade die Seite neu, damit das Formular zum Plugin passt, und lade die Datei erneut hoch."
       },
       "update_failed": {
         "what": "Die Änderung konnte nicht geschrieben werden.",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -946,6 +946,10 @@
         "what": "The request did not name which plugin it is about.",
         "next": "Reload the page and repeat the action from the plugin screen."
       },
+      "invalid_json_file_body": {
+        "what": "The upload request did not name both a setup field and a file, so the server could not tell what to parse.",
+        "next": "Reload the page and pick the file again."
+      },
       "invalid_multiselect": {
         "what": "One of the selected values is not in a shape the server accepts.",
         "next": "Clear the selection and pick the entries again from the list."
@@ -953,6 +957,34 @@
       "invalid_secrets_body": {
         "what": "The credential change was sent in a shape the server rejected.",
         "next": "Reload the page and enter the credentials again."
+      },
+      "json_file_bad_extract_path": {
+        "what": "The plugin declares an upload path the server does not support, so the file could not be read.",
+        "next": "This is a fault in the plugin, not in your file — report it to the plugin author."
+      },
+      "json_file_invalid_spec": {
+        "what": "The plugin declares this file upload incorrectly, so it cannot produce any value.",
+        "next": "This is a fault in the plugin, not in your file — report it to the plugin author."
+      },
+      "json_file_missing_value": {
+        "what": "The uploaded file does not contain one of the values this field needs.",
+        "next": "Check that you selected the right file; the message below names the missing value."
+      },
+      "json_file_not_an_object": {
+        "what": "The uploaded file is valid JSON but not a JSON object, so it holds no named values.",
+        "next": "Upload the credential file the provider issued, not a list or a fragment of one."
+      },
+      "json_file_not_json": {
+        "what": "The uploaded file is not valid JSON, so nothing could be read out of it.",
+        "next": "Download the key file again from the provider and upload it unchanged."
+      },
+      "json_file_too_large": {
+        "what": "The uploaded file is larger than the server accepts for a credential file.",
+        "next": "Check that you picked the key file itself and not an archive or export."
+      },
+      "json_file_unexpected_document": {
+        "what": "The uploaded file is the wrong kind of credential — its contents do not match what this field expects.",
+        "next": "Check the message below for which value disagreed, then upload the right file."
       },
       "no_options_provider": {
         "what": "This field has no live option source, so nothing can be fetched for it.",
@@ -986,6 +1018,10 @@
       "setup_field_invalid": {
         "what": "One of the values does not match the format this field expects.",
         "next": "Correct the flagged field and save again."
+      },
+      "unknown_json_file_field": {
+        "what": "The upload names a setup field this plugin does not offer as a file upload.",
+        "next": "Reload the page so the form matches the plugin, then upload the file again."
       },
       "update_failed": {
         "what": "The change could not be written.",


### PR DESCRIPTION
OM-17, structural fix. The reported near-miss: a tester typed their real Google account password into `gw_sa_private_key`. Nothing careless about it — the form asked them to hand-transcribe two values out of a service-account key file into an **email field and a masked field stacked directly beneath it**, which is the visual pattern of a login.

#599 made that mistake *detectable* (caution copy + `pattern` validation). Uploading the file removes the opportunity to make it. The tester proposed exactly this, and they were right: it is structural, and it removes a step rather than adding one.

## The type is mirrored in six places, not three

The issue named three. Two more only surface when you follow the value, and a sixth lives in web-ui:

| # | Where | What a missing member does |
|---|---|---|
| 1 | `admin-v1.ts` — the `SetupFieldType` union | type error |
| 2 | `manifestLoader.isSetupFieldType` | field dropped from the catalog |
| 3 | `agentSpec`'s `.strict()` z.enum | spec rejected outright |
| 4 | **`SUPPORTED_TYPES` in `installService.ts`** | **no error at all** — `isSupportedType` skips the field and the upload vanishes from the install wizard silently |
| 5 | **`InstallSetupField`'s shape** | what `extractSetupSchema` returns, i.e. what the new route reads |
| 6 | `web-ui/app/_lib/storeTypes.ts` | renderer cannot match on it |

All six carry `json_file` now, each commented with a pointer to the others.

## Server-side extraction

`middleware/src/plugins/setupJsonFile.ts`. The client posts the file's **text**; the server parses, validates, explodes it into the keys named in `extracts`, and stores only those. The browser is never trusted to decide which bytes become `gw_sa_private_key`.

Guard rails, each pinned by a test:

- the **size cap runs on the raw text, before `JSON.parse`** — the fixture is valid JSON on purpose, so the test would catch a cap that ran after parsing;
- **`expect` rejects the wrong file before any value is extracted** — an OAuth client secret and a service-account key look alike at a glance;
- a missing / empty / non-string value is a **readable error, never a silently empty secret** — that outcome would look like a successful setup and fail later, far from the cause;
- `Object.hasOwn` on every path segment, so `$.constructor` cannot reach a prototype property;
- the raw document is never returned, logged, or persisted.

Paths are a deliberate subset (`$.a.b`), **not JSONPath**: service-account files are flat, and the full grammar would add a dependency plus an evaluation surface for no case anyone has. An unsupported path fails loudly instead of matching nothing.

## The write path is shared, not copied

`POST /installed/:id/secrets/from-json` extracts, then hands the derived values to the same `applySetupValues` that the typed `PATCH …/secrets` now uses.

The security claim of #603 is that an extracted value is treated **exactly** like a typed one — same `pattern` validation, same vault/config split, same reactivation, same response (key *names* only, never a value). Two implementations of that would be two implementations that can drift, and the drift would be invisible until a `json_file` field quietly skipped a check the typed path applies.

The extraction map comes from the **manifest**, never the request: a caller-supplied `extracts` would let anyone write any vault key from any file.

`coerce()` **refuses** a value submitted under a `json_file` key rather than ignoring it — silently dropping it would let a client believe it had stored a credential. The install form skips the field for the same reason, so both sides agree.

## UI

The install wizard renders a file picker. Falling through to the text input would be *worse* than not shipping the type: it would ask the operator to paste a raw key into a field, which is the transcription step this removes.

The post-install `CredentialsEditor` omits `json_file` fields — every row there is a text input, and the **derived** fields are ordinary secrets listed as usual, so post-install editing still works. Offering the upload there too is a follow-up, not a gap in the flow.

## The errorHelp guard earned its keep

The new codes were first built with a template (`runtime.json_file_${failure.code}`), which the coverage guard **cannot see** — they would have shipped with no operator copy while the suite stayed green.

Now a `JSON_FILE_ERROR_CODES` table holds literals, typed exhaustively over `JsonFileFailureCode` so a new failure kind cannot ship without a wire code, and the forwarder is registered in the guard. 11 new help entries per locale; the two spec-level ones say plainly that the fault is in the **plugin**, not the operator's file — that distinction is the difference between "try another file" and "report this".

(Amusingly, the guard then caught my own explanatory comment, because it cannot tell a comment from code. Reworded.)

## Verification

- `test/setupJsonFile.test.ts`: **12/12**
- related middleware suites (manifest loader, install service): **45/45**
- web-ui: **693/693**
- `tsc --noEmit`: clean on both sides
- `typecheck:test` ratchet: 406 = baseline
- eslint: 0 errors

`TemplateInstantiateForm.test.tsx` failed once in a full-suite run and passes both in isolation (22/22) and on a full-suite re-run (693/693) — the repo's known cross-file pollution, not this change.

## Not included

- The Google Workspace manifest itself (separate repo — see the linked issue).
- Upload from the post-install credentials editor.

Closes #603

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789208979&installation_model_id=428086&pr_number=682&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F682&signature=14f0d371ea59932031b2e643437252300bbd031bfe35ecb2a512f15c05a01ee6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->