### PR TITLE
feat(#650): record model and provider on the persisted run trace

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,31 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — the persisted run trace records which model answered (#650, epic #642)
+
+- **`RunTrace` / `RunTracePayload`** gain optional `model` and `provider`. The
+  trace recorded how long a turn ran, which sub-agents ran and which tools were
+  called, but not the one fact a provenance question about a past turn starts
+  from. The model id already existed on the `done` event and in the cost
+  telemetry; it just never reached the persisted record.
+- **Stamped once per turn**, right after model routing resolves
+  (`RunTraceCollector.recordModel`), on both the buffered and streaming paths —
+  not threaded through `finish()`'s five call sites, where missing one would
+  leave the field absent on a single exit path and looking recorded elsewhere.
+- **Both knowledge-graph backends** write it, so the answer to "which model
+  wrote this?" does not depend on which store a deployment runs.
+- **No schema migration, and none was needed.** The issue's acceptance criteria
+  asked for one; that premise does not hold for this table.
+  `graph_nodes.properties` is a generic `JSONB` column (`0001_graph_init.sql`)
+  and `RunPropsSchema` is `.passthrough()`, so adding a property is a
+  schema-level change only. The fields are declared optional in the Zod schema
+  anyway — passthrough means "tolerated", and a provenance field that is merely
+  tolerated is one nothing validates and nothing documents. Run nodes written
+  before this change stay valid and readable, which is what a migration would
+  have existed to guarantee.
+- Absent rather than empty when unknown: a trace carrying `model: ''` claims to
+  know and does not.
+
 ### Added — admin UI for the public API keys (#567)
 
 - **Admin UI** (`web-ui/app/admin/api-keys/`): create/list/revoke against

--- a/middleware/packages/harness-channel-sdk/src/chatAgent.ts
+++ b/middleware/packages/harness-channel-sdk/src/chatAgent.ts
@@ -244,6 +244,16 @@ export interface RunTracePayload {
   orchestratorToolCalls: RunToolCall[];
   /** One entry per sub-agent invocation in invocation-order. */
   agentInvocations: RunAgentInvocation[];
+  /**
+   * #650 (epic #642) — the model that produced the answer, and the provider
+   * that served it. Mirrors `RunTrace` in `@omadia/plugin-api`; this payload is
+   * a structural copy of it (see the note on `RunTracePayload` in
+   * `runTraceCollector.ts` for why the shape is duplicated rather than imported).
+   *
+   * Optional so every trace written before this existed stays readable.
+   */
+  model?: string;
+  provider?: string;
 }
 
 /** Compact verifier summary attached to `ChatTurnResult` and the streaming

--- a/middleware/packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.ts
+++ b/middleware/packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.ts
@@ -594,6 +594,13 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
             (acc, inv) => acc + inv.toolCalls.length,
             0,
           ),
+        // #650 (epic #642) — the model that produced the answer and the
+        // provider that served it. Written here as well as in the Neon
+        // implementation: a provenance field present in one backend and absent
+        // in the other means the answer to "which model wrote this?" depends on
+        // which store the deployment happens to run.
+        ...(trace.model ? { model: trace.model } : {}),
+        ...(trace.provider ? { provider: trace.provider } : {}),
         ...(trace.error ? { error: trace.error } : {}),
       },
     });

--- a/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
+++ b/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
@@ -1262,6 +1262,12 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
         status: trace.status,
         iterations: trace.iterations,
         toolCalls: totalToolCalls,
+        // #650 (epic #642) — model + provider on the persisted Run node.
+        // `graph_nodes.properties` is generic JSONB, so this needs no SQL
+        // migration; the twin write in the in-memory implementation keeps the
+        // two backends answering "which model wrote this?" the same way.
+        ...(trace.model ? { model: trace.model } : {}),
+        ...(trace.provider ? { provider: trace.provider } : {}),
         ...(trace.error ? { error: trace.error } : {}),
       });
       const runUuid = await this.upsertNode(client, {

--- a/middleware/packages/harness-knowledge-graph-neon/src/schema.ts
+++ b/middleware/packages/harness-knowledge-graph-neon/src/schema.ts
@@ -210,6 +210,19 @@ const RunPropsSchema = z
     iterations: z.number().int().nonnegative(),
     toolCalls: z.number().int().nonnegative(),
     error: z.string().optional(),
+    // #650 (epic #642) — which model produced the answer, and who served it.
+    //
+    // Declared explicitly even though the schema is `.passthrough()` and would
+    // carry them regardless: passthrough means "tolerated", and a provenance
+    // field that is merely tolerated is one nothing validates and nothing
+    // documents. Optional, so every Run node written before this stays valid.
+    //
+    // NO SQL MIGRATION. `graph_nodes.properties` is a generic JSONB column
+    // (`0001_graph_init.sql`), so adding a property is a schema-level change
+    // only — the issue's assumption that a migration was required does not hold
+    // for this table.
+    model: z.string().optional(),
+    provider: z.string().optional(),
   })
   .passthrough();
 

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -3860,6 +3860,9 @@ export class Orchestrator {
     ]);
     const turnModel = turnModelResolved.model;
     const turnPersonaBody = turnPersonaResolved.skillBody;
+    // #650 — stamp the resolved model on the trace here, once, rather than at
+    // each of `finish()`'s call sites. Buffered path.
+    traceCollector?.recordModel(turnModel, this.provider.id);
 
     try {
       for (let iteration = 0; iteration < this.maxIterations; iteration++) {
@@ -4852,6 +4855,10 @@ export class Orchestrator {
     ]);
     const turnModel = resolved.model;
     const turnPersonaBody = resolvedPersona.skillBody;
+    // #650 — streaming mirror of the buffered stamp above. Both paths, or the
+    // field is present on some traces and absent on others for no visible
+    // reason, which is worse for a provenance record than not having it.
+    traceCollector?.recordModel(turnModel, this.provider.id);
     // Surface the Haiku-triage decision inline, before the first model call —
     // the UI renders it at the top of the turn card so the operator sees the
     // classifier's verdict (simple/complex → model) as soon as it lands.

--- a/middleware/packages/harness-orchestrator/src/runTraceCollector.ts
+++ b/middleware/packages/harness-orchestrator/src/runTraceCollector.ts
@@ -122,6 +122,26 @@ export class RunTraceCollector {
     };
   }
 
+  /**
+   * #650 — record which model produced this turn's answer, and who served it.
+   *
+   * Set ONCE, right after per-turn model routing resolves, rather than passed
+   * to `finish()`. `finish()` has five call sites across the buffered and
+   * streaming paths; threading two more arguments through all of them is five
+   * chances to miss one, and a trace that silently lacks the model on exactly
+   * one exit path is worse than not having the field — it looks recorded.
+   *
+   * Last write wins, so a turn that re-routes mid-flight reports the model that
+   * actually answered.
+   */
+  recordModel(model: string, provider?: string): void {
+    this.model = model;
+    this.provider = provider;
+  }
+
+  private model?: string;
+  private provider?: string;
+
   finish(opts: {
     iterations: number;
     status: RunStatus;
@@ -141,6 +161,10 @@ export class RunTraceCollector {
       iterations: opts.iterations,
       orchestratorToolCalls: this.orchestratorToolCalls,
       agentInvocations: this.agentInvocations,
+      // #650 — omitted entirely when unknown rather than written as an empty
+      // string: a trace that carries `model: ''` claims to know and does not.
+      ...(this.model ? { model: this.model } : {}),
+      ...(this.provider ? { provider: this.provider } : {}),
       ...(opts.error ? { error: opts.error } : {}),
     };
     return payload;

--- a/middleware/packages/plugin-api/src/knowledgeGraph.ts
+++ b/middleware/packages/plugin-api/src/knowledgeGraph.ts
@@ -1612,6 +1612,30 @@ export interface RunTrace {
   /** One entry per sub-agent invocation in invocation-order. */
   agentInvocations: RunAgentInvocation[];
   error?: string;
+  /**
+   * #650 (epic #642) — which model actually produced the answer, e.g.
+   * `claude-sonnet-4-5-20250929`.
+   *
+   * The trace recorded how long a turn ran, which sub-agents ran and which
+   * tools were called, but not the one fact a provenance question about a past
+   * turn starts from. The id already existed in the system (on the `done` event
+   * and in the cost telemetry); it just never reached the persisted record.
+   *
+   * Optional, and that is load-bearing: every trace written before this field
+   * existed stays readable. `graph_nodes.properties` is a generic JSONB column
+   * and `RunPropsSchema` is `.passthrough()`, so no schema migration is
+   * involved — a row simply does not carry the key.
+   */
+  model?: string;
+  /**
+   * #650 — the provider that served the turn (`anthropic`, `openai`, …).
+   *
+   * Recorded alongside the model rather than derived from it: the same model id
+   * can be served through different providers (direct, Bedrock, a gateway), and
+   * a provenance record that infers the route instead of stating it is a
+   * record that can be wrong.
+   */
+  provider?: string;
 }
 
 export interface RunIngestResult {

--- a/middleware/test/runTraceModelProvenance.test.ts
+++ b/middleware/test/runTraceModelProvenance.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Issue #650 (epic #642) — the persisted `RunTrace` records WHICH MODEL
+ * produced the answer.
+ *
+ * The trace held how long a turn ran, which sub-agents ran and which tools were
+ * called — but not the one fact a provenance question about a past turn starts
+ * from. The model id already existed in the system (on the `done` event, in the
+ * cost telemetry); it simply never reached the persisted record.
+ *
+ * ## The migration the issue asked for is not needed
+ *
+ * #650's acceptance criteria call for a schema migration. That premise does not
+ * hold for this table: `graph_nodes.properties` is a generic `JSONB` column
+ * (`0001_graph_init.sql`) and `RunPropsSchema` is `.passthrough()`, so adding a
+ * property is a schema-level change only. The tests below pin the two things a
+ * migration would have been FOR — new traces carry the fields, and traces
+ * written before they existed stay readable — which is the actual requirement.
+ *
+ * Imported from SOURCE, not the built barrels, so a mutation in `src/` cannot
+ * report green over stale `dist/`.
+ */
+
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { RunTraceCollector } from '../packages/harness-orchestrator/src/runTraceCollector.js';
+import { InMemoryKnowledgeGraph } from '../packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.js';
+import { NodePropsSchemaByType } from '../packages/harness-knowledge-graph-neon/src/schema.js';
+import type { RunTrace } from '../packages/plugin-api/src/knowledgeGraph.js';
+
+const MODEL = 'claude-sonnet-4-5-20250929';
+const PROVIDER = 'anthropic';
+
+function baseTrace(over: Partial<RunTrace> = {}): RunTrace {
+  return {
+    turnId: 'turn-650',
+    scope: 'sess-650',
+    startedAt: '2026-08-13T10:00:00.000Z',
+    finishedAt: '2026-08-13T10:00:02.000Z',
+    durationMs: 2000,
+    status: 'success',
+    iterations: 1,
+    orchestratorToolCalls: [],
+    agentInvocations: [],
+    ...over,
+  };
+}
+
+describe('#650 — the collector carries the model onto the trace', () => {
+  it('MUTATION CHECK: a recorded model reaches the finished payload', () => {
+    const collector = new RunTraceCollector({ scope: 'sess-650' });
+    collector.recordModel(MODEL, PROVIDER);
+    const payload = collector.finish({ iterations: 2, status: 'success' });
+
+    assert.equal(payload.model, MODEL);
+    assert.equal(payload.provider, PROVIDER);
+  });
+
+  it('MUTATION CHECK: an unrecorded model is OMITTED, never an empty string', () => {
+    // A trace carrying `model: ''` claims to know and does not. Absence is the
+    // honest encoding, and it is what keeps the field meaningful.
+    const payload = new RunTraceCollector({ scope: 'sess-650' }).finish({
+      iterations: 1,
+      status: 'success',
+    });
+    assert.equal('model' in payload, false);
+    assert.equal('provider' in payload, false);
+  });
+
+  it('MUTATION CHECK: the last routing decision wins', () => {
+    // A turn that re-routes mid-flight must report the model that ANSWERED,
+    // not the one it started with.
+    const collector = new RunTraceCollector({ scope: 'sess-650' });
+    collector.recordModel('claude-haiku-4-5-20251001', PROVIDER);
+    collector.recordModel(MODEL, PROVIDER);
+    assert.equal(collector.finish({ iterations: 1, status: 'success' }).model, MODEL);
+  });
+
+  it('records the model without a provider when none is known', () => {
+    const collector = new RunTraceCollector({ scope: 'sess-650' });
+    collector.recordModel(MODEL);
+    const payload = collector.finish({ iterations: 1, status: 'success' });
+    assert.equal(payload.model, MODEL);
+    assert.equal('provider' in payload, false);
+  });
+});
+
+/**
+ * Ingests a real Turn first, then the Run for it, and reads the Run back
+ * through the public `getRunForTurn`. Going through the real read path rather
+ * than poking at internals is what makes this a test of the STORED record: a
+ * field written into a node nobody can retrieve is not persisted provenance.
+ */
+async function storeRun(
+  over: Partial<RunTrace>,
+): Promise<Record<string, unknown>> {
+  const graph = new InMemoryKnowledgeGraph();
+  const { turnId } = await graph.ingestTurn({
+    scope: 'sess-650',
+    time: '2026-08-13T10:00:02.000Z',
+    userMessage: 'wer hat das geschrieben?',
+    assistantAnswer: 'ich',
+    entityRefs: [],
+  });
+  await graph.ingestRun(baseTrace({ ...over, turnId }));
+  const view = await graph.getRunForTurn(turnId);
+  assert.ok(view, 'the Run node was not retrievable for its Turn');
+  return view.run.props;
+}
+
+describe('#650 — both knowledge-graph backends agree', () => {
+  it('MUTATION CHECK: the in-memory graph persists model and provider on the Run node', async () => {
+    const props = await storeRun({ model: MODEL, provider: PROVIDER });
+    assert.equal(props['model'], MODEL);
+    assert.equal(props['provider'], PROVIDER);
+  });
+
+  it('MUTATION CHECK: a trace without the fields writes no empty keys', async () => {
+    // "Existing traces stay readable" is an acceptance criterion. Writing
+    // `model: undefined` would satisfy the type and corrupt the record.
+    const props = await storeRun({});
+    assert.equal('model' in props, false);
+    assert.equal('provider' in props, false);
+  });
+});
+
+describe('#650 — the Neon Run schema accepts both shapes', () => {
+  const schema = NodePropsSchemaByType['Run'];
+
+  const stored = {
+    turnId: 'turn-650',
+    scope: 'sess-650',
+    startedAt: '2026-08-13T10:00:00.000Z',
+    finishedAt: '2026-08-13T10:00:02.000Z',
+    durationMs: 2000,
+    status: 'success' as const,
+    iterations: 1,
+    toolCalls: 0,
+  };
+
+  it('MUTATION CHECK: a Run WITH model and provider validates', () => {
+    assert.ok(schema, 'no Run schema registered');
+    const parsed = schema.safeParse({ ...stored, model: MODEL, provider: PROVIDER });
+    assert.equal(parsed.success, true, JSON.stringify(parsed));
+  });
+
+  it('MUTATION CHECK: a Run WITHOUT them still validates — old rows stay readable', () => {
+    // This is what the issue's requested migration would have existed to
+    // guarantee. Optional fields on a JSONB column give it for free.
+    assert.ok(schema);
+    assert.equal(schema.safeParse(stored).success, true);
+  });
+
+  it('rejects a non-string model rather than storing it', () => {
+    assert.ok(schema);
+    assert.equal(schema.safeParse({ ...stored, model: 42 }).success, false);
+  });
+});


### PR DESCRIPTION
Part of epic #642. The `RunTrace` held how long a turn ran, which sub-agents ran and which tools were called — but not the one fact a provenance question about a past turn starts from: **which model produced the answer**. The id already existed in the system (on the `done` event, in the cost telemetry); it simply never reached the persisted record.

## The migration the issue asks for is not needed

#650's acceptance criteria call for a schema migration. **That premise does not hold for this table** — verified before implementing rather than taken from the issue:

- `graph_nodes.properties` is a generic `JSONB` column (`0001_graph_init.sql`);
- `RunPropsSchema` is already `.passthrough()`.

So adding a property is a schema-level change only.

The two fields are still **declared** optional in the Zod schema. Passthrough means *tolerated*, and a provenance field that is merely tolerated is one nothing validates and nothing documents. Two tests pin exactly what a migration would have existed to guarantee:

- a Run **with** the fields validates;
- a Run **without** them still validates → rows written before this change stay readable.

## Stamped once, not per exit path

`RunTraceCollector.recordModel()` is called right after per-turn model routing resolves, on **both** the buffered and the streaming path.

`finish()` has five call sites. Threading two more arguments through all of them is five chances to miss one, and a trace that silently lacks the model on exactly one exit path is *worse* than not having the field — it looks recorded. Last write wins, so a turn that re-routes mid-flight reports the model that actually answered.

`provider` is **recorded, not derived** from the model id: the same model can be served through different providers (direct, Bedrock, a gateway), and a provenance record that infers the route instead of stating it can be wrong.

Absent rather than empty when unknown — a trace carrying `model: ''` claims to know and does not.

## Both backends

Neon and in-memory both write the fields. A provenance field present in one backend and absent in the other means the answer to "which model wrote this?" depends on which store the deployment happens to run.

## Tests

`middleware/test/runTraceModelProvenance.test.ts` — 9 tests, source-imported so a mutation cannot report green over stale `dist/`.

The storage test goes through the real `ingestTurn` → `ingestRun` → `getRunForTurn` path rather than poking at internals: **a field written into a node nobody can retrieve is not persisted provenance.** (My first draft asserted against a node dump and passed for the wrong reason — it never proved the Run was retrievable for its Turn.)

**Mutation check, verified red:** dropping the two fields from the finished payload kills 3 of 9.

## Verification

- 253/253 across the new file plus `test/orchestrator/*` and the knowledge-graph suites
- `tsc --noEmit`: clean
- `typecheck:test` ratchet: 406 = baseline
- eslint: 0 errors

CHANGELOG entry added under `## [Unreleased]`, including why no migration id appears.

## Left open deliberately

#650's last acceptance criterion asks for a **decision** on the run-trace ingest gap it describes as a side finding: `ingestRun` is dropped when no matching user-cluster node exists (`inMemoryKnowledgeGraph.ts`, documented in `chatRouter.ts`), and `SessionLogger` swallows graph errors — so the trace is not guaranteed per turn.

That is a behaviour change to the ingest contract, not a field addition, and it wants its own issue rather than riding here. Bundling it would make both harder to review, which is the same reason #650 was split out of the epic's first PR. Filing it separately once this lands.

Refs #650

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789210032&installation_model_id=428086&pr_number=683&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F683&signature=00ce2a3131de5fd1d9a03d4b5a0797d7ac5781a3bd83767bb8b87188b724fd8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->