### PR TITLE
docs(#684): declare the run trace best-effort telemetry and count its gaps

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,35 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Changed — the run trace is best-effort telemetry, and its gaps are now countable (#684, epic #642)
+
+- **Decision recorded, not behaviour changed.** #650 added `model` / `provider`
+  to the persisted trace and deliberately left the harder question open: is the
+  record guaranteed? It is not, and #684 settled that it should not be promised
+  to be. A missing trace now means "not recorded" — never "no such turn".
+- **Why telemetry and not a provenance record.** The graph sink is optional by
+  construction (`SessionLogger` guards every ingest behind `if (this.graph)`);
+  the Markdown transcript is the surface that is actually guaranteed, and the
+  logger already refuses graph ingest when the transcript write fails so the two
+  can never disagree. Promoting the trace to a record would require
+  auto-creating User-Cluster nodes — which both backends refuse on purpose,
+  because orphan clusters with no `IS_IDENTITY_OF` edges would hide exactly the
+  channel-resolution bugs the refusal exists to surface. That trades a visible
+  gap for an invisible data-integrity defect.
+- **Named where a reader looks**: `RunTrace` and `KnowledgeGraph.ingestRun` now
+  state the contract in their own doc comments, so nobody builds a compliance
+  answer on a best-effort store by inference.
+- **Every drop is now observable** (`runTraceObservability.ts`): one greppable
+  `console.warn` naming the reason, plus per-outcome tallies on
+  `SessionLogger.runTraceStats`. The issue described the drops as silent; three
+  of the four paths already logged. The genuinely invisible one was **no graph
+  sink configured**, which returned with no signal at all — a deployment that
+  had never recorded a single trace looked identical to a healthy one.
+- **`warn`, not `error`**: the turn succeeded. Logging at error level would flag
+  every single turn in a deployment that simply runs without a knowledge graph.
+- A turn that carried no trace is not counted as a drop — counting it would make
+  the drop total meaningless.
+
 ### Added — the persisted run trace records which model answered (#650, epic #642)
 
 - **`RunTrace` / `RunTracePayload`** gain optional `model` and `provider`. The

--- a/middleware/packages/harness-orchestrator/src/index.ts
+++ b/middleware/packages/harness-orchestrator/src/index.ts
@@ -402,6 +402,19 @@ export type { SteerEnqueueResult } from './steeringBus.js';
 // Session logger + chat-session store
 export { SessionLogger, graphScopeFor } from './sessionLogger.js';
 export type { SessionLogEntry } from './sessionLogger.js';
+
+// #684 — run-trace outcome tallies. Exported so an operator surface can read
+// how often the trace was dropped without SessionLogger growing a reporting
+// responsibility of its own.
+export {
+  RunTraceOutcomeStats,
+  recordRunTraceOutcome,
+  RUN_TRACE_RECORDED,
+} from './runTraceObservability.js';
+export type {
+  RunTraceOutcome,
+  RunTraceOutcomeCounts,
+} from './runTraceObservability.js';
 export {
   ChatSessionStore,
   InvalidSessionIdError,

--- a/middleware/packages/harness-orchestrator/src/runTraceObservability.ts
+++ b/middleware/packages/harness-orchestrator/src/runTraceObservability.ts
@@ -1,0 +1,145 @@
+/**
+ * #684 (epic #642) — the run trace is best-effort TELEMETRY, not a guaranteed
+ * provenance record. This module records WHY a turn ended up without one.
+ *
+ * ## The decision, and why it went this way
+ *
+ * #650 put `model` and `provider` on the persisted Run node so a provenance
+ * question about a past turn could be answered. #684 asked the question #650
+ * deliberately left open: is that record *guaranteed*? It is not, and three
+ * properties of the surrounding code say it should not be promised to be:
+ *
+ *  1. **The graph sink is optional by construction.** `SessionLogger` guards
+ *     every ingest behind `if (this.graph)`; an operator can run omadia with no
+ *     knowledge-graph plugin at all. A record that exists only when an optional
+ *     subsystem happens to be installed cannot be the artefact a compliance
+ *     answer rests on.
+ *  2. **The Markdown transcript is the surface that IS guaranteed**, and the
+ *     logger already says so: a failed transcript write skips graph ingest
+ *     outright, "either both recorded the turn, or neither".
+ *  3. **Guaranteeing the ingest would require auto-creating User-Cluster
+ *     nodes**, which both knowledge-graph implementations refuse ON PURPOSE —
+ *     "doing so would mask channel-resolution bugs by silently producing orphan
+ *     clusters with no IS_IDENTITY_OF edges" (`neonKnowledgeGraph.ts`,
+ *     `inMemoryKnowledgeGraph.ts`). Promoting the trace to a record would trade
+ *     a gap that is visible for a data-integrity defect that is not.
+ *
+ * So: telemetry. The obligation that follows is not to make the trace complete
+ * but to stop it being silently incomplete — which is what this module does,
+ * and why `RunTrace` and `KnowledgeGraph.ingestRun` now say "telemetry" in
+ * their own doc comments rather than leaving a reader to infer "audit receipt".
+ *
+ * ## What was actually invisible
+ *
+ * #684 described the drops as silent. Measured against the code, three of the
+ * four paths already wrote a `console.error`; the genuinely invisible one is
+ * **no graph sink configured**, which returned early with no signal at all. The
+ * gap was therefore not "no logging" but "no single, greppable statement of the
+ * outcome, and nothing that counts". Both are supplied here.
+ */
+
+/**
+ * Why a collected run trace did or did not reach the graph. Every value except
+ * {@link RUN_TRACE_RECORDED} means the turn happened but its trace did not
+ * survive — the state a reader of the trace store must be able to distinguish
+ * from "this turn never ran".
+ */
+export type RunTraceOutcome =
+  /** The trace reached the graph. */
+  | 'recorded'
+  /** No knowledge-graph plugin is wired — nothing to write to. */
+  | 'no-graph-sink'
+  /** The Markdown transcript write failed, so graph ingest was skipped to keep
+   *  the two surfaces consistent. */
+  | 'transcript-failed'
+  /** `ingestTurn` failed, so the Run would have pointed at a missing Turn. */
+  | 'turn-ingest-failed'
+  /** `ingestRun` itself threw — most commonly the missing User-Cluster node
+   *  described in #684. */
+  | 'run-ingest-failed';
+
+/** The one outcome that is not a drop. `satisfies` rather than a type
+ *  annotation on purpose: the annotation would widen this to `RunTraceOutcome`
+ *  and an `=== RUN_TRACE_RECORDED` check would then narrow nothing. */
+export const RUN_TRACE_RECORDED = 'recorded' satisfies RunTraceOutcome;
+
+/** Monotonic per-outcome tallies since process start. */
+export type RunTraceOutcomeCounts = Readonly<Record<RunTraceOutcome, number>>;
+
+const ZERO_COUNTS: RunTraceOutcomeCounts = Object.freeze({
+  recorded: 0,
+  'no-graph-sink': 0,
+  'transcript-failed': 0,
+  'turn-ingest-failed': 0,
+  'run-ingest-failed': 0,
+});
+
+/**
+ * Process-local tallies of run-trace outcomes.
+ *
+ * Deliberately an injectable object rather than module-level mutable state: the
+ * counters are asserted on in tests, and a shared global would make two tests
+ * in one process read each other's turns. The kernel holds one instance; a test
+ * constructs its own.
+ */
+export class RunTraceOutcomeStats {
+  #counts: Record<RunTraceOutcome, number> = { ...ZERO_COUNTS };
+
+  /** Tally one outcome. */
+  record(outcome: RunTraceOutcome): void {
+    this.#counts[outcome] += 1;
+  }
+
+  /** Immutable snapshot — callers cannot write back into the tally. */
+  snapshot(): RunTraceOutcomeCounts {
+    return Object.freeze({ ...this.#counts });
+  }
+
+  /** Total traces that were collected but never reached the graph. */
+  droppedTotal(): number {
+    return Object.entries(this.#counts).reduce(
+      (acc, [outcome, n]) => (outcome === RUN_TRACE_RECORDED ? acc : acc + n),
+      0,
+    );
+  }
+}
+
+/** Operator-facing explanation per drop reason. Kept next to the union so a new
+ *  member cannot be added without a line a human can act on. */
+const DROP_REASON_TEXT: Readonly<Record<Exclude<RunTraceOutcome, 'recorded'>, string>> =
+  Object.freeze({
+    'no-graph-sink':
+      'no knowledge-graph plugin is configured — the run trace has nowhere to go; the Markdown transcript is unaffected',
+    'transcript-failed':
+      'the Markdown transcript write failed, so graph ingest was skipped to keep both surfaces consistent',
+    'turn-ingest-failed':
+      'ingestTurn failed, so the run trace was skipped rather than left pointing at a missing Turn',
+    'run-ingest-failed':
+      'ingestRun failed — most often no User-Cluster node exists for this user yet (see #684); channel identity is resolved only on the browser-login path',
+  });
+
+/**
+ * Record one run-trace outcome: tally it, and — for every drop — emit ONE
+ * greppable warn line naming the reason.
+ *
+ * `console.warn`, not `console.error`: a missing trace is a known, accepted
+ * property of best-effort telemetry, and logging it at error level in a
+ * deployment with no knowledge-graph plugin would flag every single turn as a
+ * failure. The turn itself succeeded — that is the whole point of the decision.
+ */
+export function recordRunTraceOutcome(
+  stats: RunTraceOutcomeStats,
+  outcome: RunTraceOutcome,
+  detail?: unknown,
+): void {
+  stats.record(outcome);
+  if (outcome === RUN_TRACE_RECORDED) return;
+  const suffix = detail === undefined ? '' : `: ${describe(detail)}`;
+  console.warn(
+    `[session-log] run trace not recorded (${outcome}) — ${DROP_REASON_TEXT[outcome]}${suffix}`,
+  );
+}
+
+function describe(detail: unknown): string {
+  return detail instanceof Error ? detail.message : String(detail);
+}

--- a/middleware/packages/harness-orchestrator/src/sessionLogger.ts
+++ b/middleware/packages/harness-orchestrator/src/sessionLogger.ts
@@ -7,6 +7,10 @@ import {
 } from '@omadia/plugin-api';
 import { isValidSessionId, type ChatSessionStore } from './chatSessionStore.js';
 import type { RunTracePayload } from './runTraceCollector.js';
+import {
+  recordRunTraceOutcome,
+  RunTraceOutcomeStats,
+} from './runTraceObservability.js';
 
 export interface SessionLogEntry {
   /** Scope identifier — Teams conversation id, 'http', etc. Becomes a safe dir name. */
@@ -74,6 +78,15 @@ export class SessionLogger {
      * so `turnNodeId` agrees on both the write and the recall side.
      */
     private readonly agentSlug?: string,
+    /**
+     * #684 — per-process tallies of run-trace outcomes. Public so an operator
+     * surface can read the drop counts without this class growing a reporting
+     * responsibility; injectable so two tests in one process cannot read each
+     * other's turns. Only ever written for a turn that actually CARRIED a
+     * trace: a turn with no `runTrace` is not a drop, it is a turn the
+     * orchestrator collected nothing for.
+     */
+    readonly runTraceStats: RunTraceOutcomeStats = new RunTraceOutcomeStats(),
   ) {}
 
   async log(entry: SessionLogEntry): Promise<{ turnExternalId: string }> {
@@ -117,6 +130,9 @@ export class SessionLogger {
       );
       // Don't try graph ingest if the markdown write fell over — keeps the
       // two surfaces consistent (either both recorded the turn, or neither).
+      if (entry.runTrace) {
+        recordRunTraceOutcome(this.runTraceStats, 'transcript-failed', err);
+      }
       return { turnExternalId: earlyTurnId };
     }
 
@@ -168,6 +184,9 @@ export class SessionLogger {
         );
         // Skip run-trace ingest if the turn write failed — keeps the graph
         // internally consistent (no Run pointing at a missing Turn).
+        if (entry.runTrace) {
+          recordRunTraceOutcome(this.runTraceStats, 'turn-ingest-failed', err);
+        }
         return { turnExternalId };
       }
 
@@ -177,14 +196,22 @@ export class SessionLogger {
             ...entry.runTrace,
             turnId: turnExternalId,
           });
+          recordRunTraceOutcome(this.runTraceStats, 'recorded');
         } catch (err) {
-          console.error(
-            '[session-log] run-trace ingest failed:',
-            err instanceof Error ? err.message : err,
-          );
+          // #684 — this is the drop the issue was filed about: `ingestRun`
+          // throws when no User-Cluster node exists for the user, which is the
+          // NORMAL state for every channel except the browser-login flow. The
+          // turn still succeeded and the transcript still holds it; only the
+          // trace is missing. Recorded as telemetry loss, not as a turn error.
+          recordRunTraceOutcome(this.runTraceStats, 'run-ingest-failed', err);
         }
       }
       return { turnExternalId };
+    }
+    // No graph sink at all. Before #684 this returned in silence, which made a
+    // permanently trace-less deployment indistinguishable from a healthy one.
+    if (entry.runTrace) {
+      recordRunTraceOutcome(this.runTraceStats, 'no-graph-sink');
     }
     return { turnExternalId: turnNodeId(gScope, iso) };
   }

--- a/middleware/packages/plugin-api/src/knowledgeGraph.ts
+++ b/middleware/packages/plugin-api/src/knowledgeGraph.ts
@@ -54,6 +54,13 @@ export interface KnowledgeGraph {
    * EXECUTED / INVOKED_* / PRODUCED edges. Safe to call independently of
    * {@link ingestTurn}; missing Turn/Entity nodes are tolerated (edges
    * pointing at non-existent external ids are skipped rather than aborting).
+   *
+   * #684 — BEST-EFFORT. This call MAY throw and its caller
+   * (`SessionLogger`) deliberately does not fail the user's turn when it does:
+   * implementations refuse to write a Run whose Turn or User-Cluster node does
+   * not exist, and no channel except the browser-login flow resolves a
+   * User-Cluster per turn. Treat a present trace as evidence and an absent one
+   * as no evidence either way — see {@link RunTrace} for the full contract.
    */
   ingestRun(trace: RunTrace): Promise<RunIngestResult>;
   /**
@@ -1597,6 +1604,35 @@ export interface RunAgentInvocation {
   toolCalls: RunToolCall[];
 }
 
+/**
+ * The agentic trace of one turn.
+ *
+ * #684 (epic #642) — **this is best-effort telemetry, not a provenance
+ * record.** The distinction is load-bearing and was decided rather than
+ * inherited: a missing trace means "not recorded", never "no such turn".
+ *
+ * A turn can complete successfully and leave no trace at all, for four reasons
+ * that are all deliberate:
+ *
+ *  - no knowledge-graph plugin is configured (the sink is optional — the
+ *    Markdown transcript is the guaranteed surface, not this);
+ *  - the transcript write failed, so graph ingest was skipped on purpose to
+ *    keep both surfaces consistent;
+ *  - `ingestTurn` failed, so no Run is written that would dangle off a missing
+ *    Turn;
+ *  - `ingestRun` refused because no User-Cluster node exists for the user —
+ *    which is the ordinary state for every channel except the browser-login
+ *    flow, since nothing else calls `resolveOrCreateChannelIdentity` per turn.
+ *
+ * The alternative — guaranteeing the ingest — was rejected because it would
+ * require auto-creating User-Cluster nodes, which both implementations refuse
+ * precisely so that channel-resolution bugs cannot hide behind orphan clusters.
+ *
+ * Consequence for anyone building on this: do not phrase a compliance or audit
+ * claim as "the trace shows". Drops are counted and warned about at the call
+ * site (`runTraceObservability.ts`), so the size of the gap is at least
+ * knowable.
+ */
 export interface RunTrace {
   /** Must match the turn-id returned by a matching ingestTurn call. */
   turnId: string;

--- a/middleware/test/runTraceIngestGuarantee.test.ts
+++ b/middleware/test/runTraceIngestGuarantee.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Issue #684 (epic #642) — the run trace is best-effort TELEMETRY, and every
+ * drop is observable.
+ *
+ * #650 added `model` / `provider` to the persisted trace so a provenance
+ * question about a past turn could be answered, then explicitly deferred the
+ * harder question: is that record guaranteed? It is not. #684 decided it should
+ * NOT be promised to be — the graph sink is optional, the Markdown transcript
+ * is the surface that is guaranteed, and forcing the ingest through would mean
+ * auto-creating User-Cluster nodes, which both graph implementations refuse on
+ * purpose so channel-resolution bugs cannot hide behind orphan clusters.
+ *
+ * What the decision obliges is therefore not completeness but honesty: a turn
+ * may leave no trace, and when it does that must be countable and greppable
+ * rather than silent. These tests pin exactly that.
+ *
+ * The sharpest case is `no-graph-sink`. Before #684 three of the four drop
+ * paths already wrote a `console.error`; that one returned in total silence, so
+ * a deployment that had never recorded a single trace was indistinguishable
+ * from a healthy one. Its test is the one that matters most here.
+ *
+ * Imported from SOURCE, not the built barrels, so a mutation in `src/` cannot
+ * report green over stale `dist/`.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { InMemoryMemoryStore } from '../packages/harness-memory/src/inMemoryMemoryStore.js';
+import { InMemoryKnowledgeGraph } from '../packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.js';
+import { SessionLogger } from '../packages/harness-orchestrator/src/sessionLogger.js';
+import { RunTraceOutcomeStats } from '../packages/harness-orchestrator/src/runTraceObservability.js';
+import type { RunTracePayload } from '../packages/harness-channel-sdk/src/chatAgent.js';
+
+function payload(over: Partial<RunTracePayload> = {}): RunTracePayload {
+  return {
+    scope: 'sess-684',
+    startedAt: '2026-08-13T10:00:00.000Z',
+    finishedAt: '2026-08-13T10:00:02.000Z',
+    durationMs: 2000,
+    status: 'success',
+    iterations: 1,
+    orchestratorToolCalls: [],
+    agentInvocations: [],
+    model: 'claude-sonnet-4-5-20250929',
+    provider: 'anthropic',
+    ...over,
+  };
+}
+
+const ENTRY = {
+  scope: 'sess-684',
+  userMessage: 'Wer hat das Angebot freigegeben?',
+  assistantAnswer: 'Anna Müller.',
+};
+
+/** Capture warn output so "a warn line is emitted" is an assertion rather than
+ *  something a reader has to take on faith. */
+let warnings: string[] = [];
+const realWarn = console.warn;
+
+beforeEach(() => {
+  warnings = [];
+  console.warn = (...args: unknown[]): void => {
+    warnings.push(args.map(String).join(' '));
+  };
+});
+
+afterEach(() => {
+  console.warn = realWarn;
+});
+
+describe('#684 — run-trace ingest is best-effort, and every drop is observable', () => {
+  it('counts and warns when there is NO graph sink at all (previously silent)', async () => {
+    const stats = new RunTraceOutcomeStats();
+    const store = new InMemoryMemoryStore();
+    // No graph argument: the deployment shape that recorded nothing, forever,
+    // without ever saying so.
+    const logger = new SessionLogger(store, undefined, undefined, undefined, stats);
+
+    await logger.log({ ...ENTRY, runTrace: payload() });
+
+    assert.equal(stats.snapshot()['no-graph-sink'], 1);
+    assert.equal(stats.droppedTotal(), 1);
+    assert.equal(
+      warnings.filter((w) => w.includes('no-graph-sink')).length,
+      1,
+      'the drop must produce exactly one greppable warn line',
+    );
+
+    // The guaranteed surface is untouched — that is the whole basis of the
+    // "telemetry, not record" decision.
+    const files = (await store.list('/memories/sessions/sess-684')).filter(
+      (e) => !e.isDirectory,
+    );
+    assert.equal(files.length, 1);
+  });
+
+  it('counts and warns when ingestRun refuses for a missing User-Cluster node', async () => {
+    const stats = new RunTraceOutcomeStats();
+    const store = new InMemoryMemoryStore();
+    const graph = new InMemoryKnowledgeGraph();
+    const logger = new SessionLogger(store, graph, undefined, undefined, stats);
+
+    // `userId` with no User-Cluster node is the ORDINARY state for every
+    // channel except the browser-login flow — nothing else calls
+    // `resolveOrCreateChannelIdentity` per turn. This is the exact drop #684
+    // was filed about, reproduced through the real implementation rather than
+    // a stub that merely throws.
+    await logger.log({
+      ...ENTRY,
+      userId: 'omadia-user-with-no-cluster',
+      runTrace: payload({ userId: 'omadia-user-with-no-cluster' }),
+    });
+
+    assert.equal(stats.snapshot()['run-ingest-failed'], 1);
+    assert.equal(stats.snapshot().recorded, 0);
+    assert.ok(
+      warnings.some((w) => w.includes('run-ingest-failed')),
+      'the drop #684 is about must be visible in the log',
+    );
+
+    // The turn itself survived: transcript written, Turn node ingested. Only
+    // the Run is missing — "not recorded", never "no such turn".
+    const graphStats = await graph.stats();
+    assert.equal(graphStats.byNodeType.Turn, 1);
+    assert.equal(graphStats.byNodeType.Run ?? 0, 0);
+  });
+
+  it('counts a successful ingest as recorded and stays quiet', async () => {
+    const stats = new RunTraceOutcomeStats();
+    const store = new InMemoryMemoryStore();
+    const graph = new InMemoryKnowledgeGraph();
+    const logger = new SessionLogger(store, graph, undefined, undefined, stats);
+
+    // No `userId` — the BELONGS_TO branch that needs a User-Cluster is skipped
+    // entirely, so this is the path that genuinely records.
+    await logger.log({ ...ENTRY, runTrace: payload() });
+
+    assert.equal(stats.snapshot().recorded, 1);
+    assert.equal(stats.droppedTotal(), 0);
+    assert.deepEqual(
+      warnings.filter((w) => w.includes('run trace not recorded')),
+      [],
+      'a recorded trace must not warn',
+    );
+
+    const graphStats = await graph.stats();
+    assert.equal(graphStats.byNodeType.Run, 1);
+  });
+
+  it('does not count a turn that carried no trace as a drop', async () => {
+    const stats = new RunTraceOutcomeStats();
+    const store = new InMemoryMemoryStore();
+    const logger = new SessionLogger(store, undefined, undefined, undefined, stats);
+
+    // No `runTrace`: the orchestrator collected nothing. That is not telemetry
+    // loss, and counting it would make the drop total meaningless.
+    await logger.log(ENTRY);
+
+    assert.equal(stats.droppedTotal(), 0);
+    assert.deepEqual(stats.snapshot(), {
+      recorded: 0,
+      'no-graph-sink': 0,
+      'transcript-failed': 0,
+      'turn-ingest-failed': 0,
+      'run-ingest-failed': 0,
+    });
+    assert.deepEqual(warnings, []);
+  });
+});


### PR DESCRIPTION
Closes #684.

## The decision

**The run trace is best-effort telemetry, not a provenance record.** A missing trace means "not recorded" — never "no such turn".

#650 added `model` / `provider` to the persisted trace and deliberately left this open, because changing the ingest contract is not the same kind of change as adding a property. Three properties of the surrounding code settle it:

1. **The graph sink is optional by construction.** `SessionLogger` guards every ingest behind `if (this.graph)`. A record that exists only when an optional subsystem happens to be installed cannot be what a compliance answer rests on.
2. **The Markdown transcript is the surface that *is* guaranteed** — and the logger already says so, skipping graph ingest when the transcript write fails so the two can never disagree.
3. **Guaranteeing the ingest would require auto-creating User-Cluster nodes**, which `neonKnowledgeGraph.ts` and `inMemoryKnowledgeGraph.ts` both refuse on purpose: orphan clusters with no `IS_IDENTITY_OF` edges would mask exactly the channel-resolution bugs the refusal exists to surface. That trades a gap that is visible for a data-integrity defect that is not.

The *provenance-record* branch is the one that would have needed Marcel's sign-off, since it changes error behaviour in the hot path. It is not the branch taken.

## One premise in the issue did not survive measurement

#684 says a dropped ingest is invisible today. Three of the four drop paths already wrote a `console.error`. The genuinely invisible one is **no graph sink configured**, which returned early with no signal at all — so a deployment that had never recorded a single trace was indistinguishable from a healthy one. That is the case the sharpest test in this PR pins.

## What changed

| File | Change |
|---|---|
| `packages/plugin-api/src/knowledgeGraph.ts` | `RunTrace` + `KnowledgeGraph.ingestRun` state the telemetry contract and enumerate the four ways a turn leaves no trace |
| `packages/harness-orchestrator/src/runTraceObservability.ts` *(new)* | `RunTraceOutcome` union, `RunTraceOutcomeStats` tallies, `recordRunTraceOutcome` — one greppable warn line per drop |
| `packages/harness-orchestrator/src/sessionLogger.ts` | records an outcome on all four exit paths; public injectable `runTraceStats` |
| `packages/harness-orchestrator/src/index.ts` | exports the new surface so an operator view can read the tallies without `SessionLogger` growing a reporting job |
| `docs/CHANGELOG.md` | entry |

`console.warn`, not `error`: the turn succeeded. At error level, every turn in a deployment that simply runs without a knowledge graph would read as a failure. A turn that carried no trace at all is not counted as a drop — counting it would make the drop total meaningless.

## No behaviour change in the hot path

Nothing about which turns succeed, what a user sees, or what reaches the graph changed. This PR states a contract and makes its gaps countable.

## Verification

- `test/runTraceIngestGuarantee.test.ts` — 4 tests, imported from **source** so a `src/` mutation cannot report green over stale `dist/`.
- **Mutation checks (2, both confirmed to land before running):**
  - remove the `no-graph-sink` recording → **1 fail** (the previously-silent path).
  - replace the `run-ingest-failed` recording with `void err` → **1 fail**.
- Neighbouring suites: `sessionLoggerGraph`, `sessionLoggerGraphScope`, `runTraceModelProvenance` + this file → **19/19 pass**.
- `npm run build` and `npm run typecheck` → exit 0.
- `scripts/check-core-decoupling.mjs` → green, baseline **unchanged at 3294** (reworded rather than raised).

## Follow-on

`docs/architecture.md:44` still calls the full trace "the run's audit receipt", which this decision contradicts. That line is corrected in #649, which is where the transparency documentation lands — noted so the two do not race each other on the same file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789212955&installation_model_id=428086&pr_number=685&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F685&signature=62766eb927863dab650abe154151ae0fe26515af6dbae8b16f945c004482e428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->