### PR TITLE
feat(#648): make the AI-marking posture readable per channel

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,37 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — the AI-marking posture is readable per channel (#648, epic #642)
+
+- **`GET /health` gains a `disclosure` block**: the resolved AI-Act Art. 50
+  marking level per channel, whether it came from the shipping default or the
+  operator, and whether it deviates from the delivered state. Builds on the
+  post-#665 shape (`{ status, kg }` → `{ status, kg, disclosure }`) rather than
+  the older registry-projector form.
+- **Boot warning on deviation only.** A delivered-state instance logs nothing —
+  a line that fires on every default install is one nobody reads.
+- **Operator channels dashboard** shows an informing hint when the instance
+  deviates, DE/EN through the message catalogue. In the delivered state the
+  surface is unchanged and completely quiet.
+- **Why**: the operator may grade the marking down per channel or switch it off
+  — omadia is self-hosted, that is their decision. The problem was that the
+  decision was visible nowhere, so a copied config or a leftover from a test
+  setup was never noticed. The hint describes the state and blocks nothing.
+- **One derivation, not two.** `resolveDisclosureLevelForChannel` is now the
+  single place the override → global → shipped precedence lives;
+  `Orchestrator.resolveTurnDisclosure` calls it per turn and the posture view
+  calls it per channel. A second copy of those rules would let the reported
+  posture disagree with what turns actually do, silently — the exact failure
+  this feature exists to prevent.
+- **An override that cannot fire says so.** Only `teams` / `slack` / `telegram`
+  currently carry a `channelKind` into a turn, so a configured `web=off` never
+  takes effect. Both `/health` and the dashboard report that instead of letting
+  the operator conclude their override is in force.
+- **Nothing that permits conclusions about content or users leaves the process**:
+  levels, sources and booleans only. The assistant name and the free-form
+  operator note are reported as *configured* / *not configured*, never by value
+  — asserted against the serialised payload, not left to review.
+
 ### Added — the persisted run trace records which model answered (#650, epic #642)
 
 - **`RunTrace` / `RunTracePayload`** gain optional `model` and `provider`. The

--- a/middleware/packages/harness-orchestrator/src/aiDisclosurePosture.ts
+++ b/middleware/packages/harness-orchestrator/src/aiDisclosurePosture.ts
@@ -1,0 +1,206 @@
+/**
+ * AI-Act Art. 50 (#648, epic #642) — the operator's RESOLVED marking posture,
+ * per channel, as a readable value.
+ *
+ * ## Why this exists
+ *
+ * The operator can grade the disclosure down per channel and switch it off
+ * entirely — omadia is self-hosted, that is their call. #648's point is that
+ * today the decision is invisible: a reduced marking shows up nowhere, so a
+ * copy-paste error in a config or a leftover from a test setup is never
+ * noticed. This module turns the same resolution the hot path performs into a
+ * value `/health`, the boot log and the operator dashboard can all read.
+ *
+ * ## Why the level resolution lives HERE and not in the Orchestrator
+ *
+ * A posture view that recomputes the level with its own copy of the precedence
+ * rules is a view that can disagree with what turns actually do — and it would
+ * disagree silently, which is the exact failure #648 exists to prevent. So
+ * {@link resolveDisclosureLevelForChannel} is the single derivation:
+ * `Orchestrator.resolveTurnDisclosure` calls it per turn, and
+ * {@link describeAiDisclosurePosture} calls it per channel. Same reason
+ * `deriveAgentsConsulted` and `resolveAiDisclosure` were extracted.
+ *
+ * ## What must NOT be in here
+ *
+ * #648's sharpest acceptance criterion: no field that permits conclusions about
+ * content or users. The posture therefore carries levels, sources and booleans
+ * only — never the assistant name, never the operator note, never a composed
+ * disclosure line. Whether those are SET is the operator-relevant fact; their
+ * text is not, and the operator note in particular is free-form.
+ */
+
+import {
+  DEFAULT_AI_DISCLOSURE_POLICY,
+  type AiDisclosureLevel,
+} from '@omadia/channel-sdk';
+import type { AiDisclosureSetup } from './orchestrator.js';
+
+/**
+ * The channel kinds a per-channel override may key on — the full `ChannelKind`
+ * set. Single source of truth for BOTH the setup-field parser (which rejects
+ * anything else, so a typo cannot silently disable the marking) and the posture
+ * view (which reports one row per entry). Two lists would drift into a posture
+ * that omits a channel the parser accepts.
+ *
+ * NOTE, and it is the honest caveat this whole feature has to carry: only
+ * `teams` / `slack` / `telegram` are ever produced as a per-turn `channelKind`
+ * (`orchestratorDispatcher.toChannelKind` is the sole setter). `email` and
+ * `web` turns carry none yet, as do discord / whatsapp / canvas-custom / the
+ * HTTP dev path — those all resolve to the global level regardless of what an
+ * override says. {@link ChannelPosture.effective} says so per row rather than
+ * letting a dashboard imply an override is doing something it is not.
+ */
+export const AI_DISCLOSURE_CHANNEL_KINDS = [
+  'teams',
+  'telegram',
+  'slack',
+  'email',
+  'web',
+] as const;
+
+export type AiDisclosureChannelKind =
+  (typeof AI_DISCLOSURE_CHANNEL_KINDS)[number];
+
+/**
+ * Channel kinds that actually reach `resolveTurnDisclosure` with a
+ * `channelIdentity.channelKind` set. An override for any other kind parses,
+ * stores and displays — but never fires.
+ */
+const DISPATCHED_CHANNEL_KINDS: ReadonlySet<string> = new Set([
+  'teams',
+  'telegram',
+  'slack',
+]);
+
+/**
+ * Resolve the disclosure level for one channel: a per-channel override wins
+ * over the operator's global default, which wins over the shipping default. A
+ * turn whose channel does not resolve to a `ChannelKind` uses the global level
+ * — the safe direction, since the marking stays active.
+ *
+ * THE single derivation. `Orchestrator.resolveTurnDisclosure` and the posture
+ * view below both call it; neither reimplements the precedence.
+ */
+export function resolveDisclosureLevelForChannel(
+  setup: AiDisclosureSetup | undefined,
+  channelKind: string | undefined,
+): AiDisclosureLevel {
+  const override =
+    channelKind !== undefined ? setup?.overrides?.[channelKind] : undefined;
+  return override ?? setup?.level ?? DEFAULT_AI_DISCLOSURE_POLICY.level;
+}
+
+/** The resolved marking posture for one channel. */
+export interface ChannelPosture {
+  readonly channel: AiDisclosureChannelKind;
+  /** Resolved verbosity for this channel. */
+  readonly level: AiDisclosureLevel;
+  /** `true` when this channel's level came from a per-channel override rather
+   *  than the global level. */
+  readonly overridden: boolean;
+  /** `true` when this level differs from the SHIPPING default (`standard`) —
+   *  i.e. the thing an operator would want to be told about. */
+  readonly deviates: boolean;
+  /**
+   * `false` when this channel never carries a `channelKind` into a turn, so an
+   * override configured for it cannot take effect today. Reported rather than
+   * hidden: an operator who set `web=off` and still sees the marking deserves
+   * the reason, not a mystery.
+   */
+  readonly effective: boolean;
+}
+
+/**
+ * The whole instance's marking posture. Levels, sources and booleans only —
+ * see the note on omitted fields in this file's header.
+ */
+export interface AiDisclosurePosture {
+  /** Where the effective policy came from. `'default'` means the operator set
+   *  no disclosure field at all. */
+  readonly source: 'default' | 'operator';
+  /** The global level per-channel overrides fall back to. */
+  readonly defaultLevel: AiDisclosureLevel;
+  /** The delivered level, for comparison. Always `standard`. */
+  readonly shippedLevel: AiDisclosureLevel;
+  /** `true` when ANY channel deviates from the delivered state. The single
+   *  flag a dashboard or a boot log branches on. */
+  readonly deviates: boolean;
+  /** One row per channel kind, in a stable order. */
+  readonly channels: readonly ChannelPosture[];
+  /** Operator pinned a wording language rather than letting the turn decide. */
+  readonly localeConfigured: boolean;
+  /** Operator gave the assistant a name woven into the marking. The name
+   *  itself is deliberately NOT reported. */
+  readonly assistantNameConfigured: boolean;
+  /** Operator attached a verbatim addendum. Its text is deliberately NOT
+   *  reported — it is free-form. */
+  readonly operatorNoteConfigured: boolean;
+}
+
+/** ServiceRegistry name the orchestrator plugin publishes the posture under.
+ *  Structural contract — the plugin publishes a plain object and the kernel
+ *  only reads it, so neither side imports the other. Spelled again in
+ *  `middleware/src/health/disclosureHealth.ts`; keep the two in sync. */
+export const AI_DISCLOSURE_POSTURE_SERVICE = 'aiDisclosurePosture';
+
+/**
+ * Project the operator's resolved setup into the posture view.
+ *
+ * `setup === undefined` is the zero-config instance: shipping default on every
+ * channel, `source: 'default'`, nothing deviating. That is exactly the state
+ * #648 requires the UI to stay quiet for.
+ */
+export function describeAiDisclosurePosture(
+  setup: AiDisclosureSetup | undefined,
+): AiDisclosurePosture {
+  const shippedLevel = DEFAULT_AI_DISCLOSURE_POLICY.level;
+  const defaultLevel = setup?.level ?? shippedLevel;
+  const channels = AI_DISCLOSURE_CHANNEL_KINDS.map((channel) => {
+    const level = resolveDisclosureLevelForChannel(setup, channel);
+    return Object.freeze({
+      channel,
+      level,
+      overridden: setup?.overrides?.[channel] !== undefined,
+      deviates: level !== shippedLevel,
+      effective: DISPATCHED_CHANNEL_KINDS.has(channel),
+    });
+  });
+  return Object.freeze({
+    // Mirrors `resolveTurnDisclosure`: a resolved setup object exists ONLY when
+    // the operator set at least one disclosure field, so its mere presence
+    // makes the policy operator-sourced.
+    source: setup !== undefined ? 'operator' : DEFAULT_AI_DISCLOSURE_POLICY.source,
+    defaultLevel,
+    shippedLevel,
+    // The global level counts too: an operator who set `ai_disclosure_level=off`
+    // and no overrides has deviated on every channel at once.
+    deviates:
+      defaultLevel !== shippedLevel || channels.some((c) => c.deviates),
+    channels: Object.freeze(channels),
+    localeConfigured: setup?.locale !== undefined,
+    assistantNameConfigured: setup?.assistantName !== undefined,
+    operatorNoteConfigured: setup?.operatorNote !== undefined,
+  });
+}
+
+/**
+ * The boot line. Returns `undefined` for a delivered-state instance — #648
+ * wants a warning ONLY on deviation, so a default deployment's log stays clean
+ * and the line keeps its signal.
+ */
+export function formatDisclosureBootWarning(
+  posture: AiDisclosurePosture,
+): string | undefined {
+  if (!posture.deviates) return undefined;
+  const changed = posture.channels
+    .filter((c) => c.deviates)
+    .map((c) => `${c.channel}=${c.level}${c.effective ? '' : ' (not dispatched yet)'}`)
+    .join(', ');
+  return (
+    `[orchestrator] AI-Act marking deviates from the delivered state: ` +
+    `default=${posture.defaultLevel} (shipped ${posture.shippedLevel}); ${changed}. ` +
+    `This is an operator decision and nothing is blocked — logged so a config ` +
+    `left over from a test setup does not go unnoticed.`
+  );
+}

--- a/middleware/packages/harness-orchestrator/src/index.ts
+++ b/middleware/packages/harness-orchestrator/src/index.ts
@@ -399,6 +399,21 @@ export type { RunTracePayload } from '@omadia/channel-sdk';
 export { SteeringBus, steeringBus, MAX_STEER_LENGTH } from './steeringBus.js';
 export type { SteerEnqueueResult } from './steeringBus.js';
 
+// #648 — resolved AI-Act marking posture, published to the ServiceRegistry and
+// projected onto `/health` + the operator dashboard.
+export {
+  AI_DISCLOSURE_CHANNEL_KINDS,
+  AI_DISCLOSURE_POSTURE_SERVICE,
+  describeAiDisclosurePosture,
+  formatDisclosureBootWarning,
+  resolveDisclosureLevelForChannel,
+} from './aiDisclosurePosture.js';
+export type {
+  AiDisclosureChannelKind,
+  AiDisclosurePosture,
+  ChannelPosture,
+} from './aiDisclosurePosture.js';
+
 // Session logger + chat-session store
 export { SessionLogger, graphScopeFor } from './sessionLogger.js';
 export type { SessionLogEntry } from './sessionLogger.js';

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -4,6 +4,7 @@ import {
   mcpDomainForServer,
   resolveMcpCallTimeouts,
 } from './mcp/mcpClient.js';
+import { resolveDisclosureLevelForChannel } from './aiDisclosurePosture.js';
 import {
   deriveAgentsConsulted,
   toSemanticAnswer,
@@ -2777,10 +2778,15 @@ export class Orchestrator {
   private resolveTurnDisclosure(input: ChatTurnInput): AiDisclosure | undefined {
     const setup = this.aiDisclosure;
     const channelKind = input.channelIdentity?.channelKind;
-    const override =
-      channelKind !== undefined ? setup?.overrides?.[channelKind] : undefined;
-    const level: AiDisclosureLevel =
-      override ?? setup?.level ?? DEFAULT_AI_DISCLOSURE_POLICY.level;
+    // #648 — the precedence lives in ONE place now. `/health`, the boot log and
+    // the operator dashboard project the same function over every channel; a
+    // second copy of these rules here would let the reported posture disagree
+    // with what turns actually do, silently, which is the failure #648 exists
+    // to prevent.
+    const level: AiDisclosureLevel = resolveDisclosureLevelForChannel(
+      setup,
+      channelKind,
+    );
     // `source` gates the `'off'` opt-out: only an operator-sourced policy may
     // silence a turn. A resolved `setup` object exists ONLY when the operator
     // configured at least one disclosure field (the plugin passes `undefined`

--- a/middleware/packages/harness-orchestrator/src/plugin.ts
+++ b/middleware/packages/harness-orchestrator/src/plugin.ts
@@ -13,6 +13,12 @@ import {
 // narrow accessor shape that matches what the plugin publishes under
 // `microsoft365.graph`.
 import type { Microsoft365Accessor } from './microsoft365-shim.js';
+import {
+  AI_DISCLOSURE_CHANNEL_KINDS as AI_DISCLOSURE_CHANNEL_KIND_LIST,
+  AI_DISCLOSURE_POSTURE_SERVICE,
+  describeAiDisclosurePosture,
+  formatDisclosureBootWarning,
+} from './aiDisclosurePosture.js';
 import type {
   EntityRefBus,
   KnowledgeGraph,
@@ -207,14 +213,14 @@ function parseNumberOrDefault(raw: unknown, fallback: number): number {
  *  marking. NOTE: today only `teams`/`slack`/`telegram` are ever produced as a
  *  per-turn `channelKind` (`orchestratorDispatcher.toChannelKind`); `email` and
  *  `web` are accepted here but currently resolve to the global level, same as
- *  the kind-less channels — see the `ai_disclosure_level_overrides` help text. */
-const AI_DISCLOSURE_CHANNEL_KINDS = new Set([
-  'teams',
-  'telegram',
-  'slack',
-  'email',
-  'web',
-]);
+ *  the kind-less channels — see the `ai_disclosure_level_overrides` help text.
+ *
+ *  #648 — derived from the shared list rather than spelled again here. The
+ *  posture view reports one row per accepted kind, so a second literal would
+ *  let the parser accept a channel the dashboard never shows (or vice versa). */
+const AI_DISCLOSURE_CHANNEL_KINDS = new Set<string>(
+  AI_DISCLOSURE_CHANNEL_KIND_LIST,
+);
 
 const AI_DISCLOSURE_LEVELS = new Set<AiDisclosureLevel>([
   'standard',
@@ -511,6 +517,24 @@ export async function activate(
   // channel; a set value flips the whole policy to operator-sourced.
   const aiDisclosure = resolveAiDisclosureSetup((key) =>
     ctx.config.get<unknown>(key),
+  );
+  // #648 — publish the RESOLVED posture so `/health` and the operator
+  // dashboard can read what this instance actually does, and warn once at boot
+  // when it deviates from the delivered state. A reduced marking is a
+  // legitimate operator decision; the failure mode #648 is about is that it was
+  // previously invisible, so a copy-paste error in a config or a leftover from
+  // a test setup was never noticed by anyone.
+  //
+  // A plain frozen snapshot, unlike the embedding gate's live getter object:
+  // this posture is derived from setup fields read once at activation, and a
+  // config change re-activates the plugin, which re-publishes. Nothing mutates
+  // it underneath a reader.
+  const disclosurePosture = describeAiDisclosurePosture(aiDisclosure);
+  const disclosureWarning = formatDisclosureBootWarning(disclosurePosture);
+  if (disclosureWarning) console.warn(disclosureWarning);
+  const disposeDisclosurePosture = ctx.services.provide(
+    AI_DISCLOSURE_POSTURE_SERVICE,
+    disclosurePosture,
   );
   // Floor at DEFAULT_MAX_TOKENS: a stale installed config (older deployments
   // persisted 4096) would otherwise truncate large file-building tool calls.
@@ -929,6 +953,14 @@ export async function activate(
       }
       try {
         disposeNudgeRegistry();
+      } catch {
+        // best-effort
+      }
+      // #648 — released like every other published service, so a reactivate
+      // (the path a disclosure config change takes) can re-publish the posture
+      // instead of failing with "duplicate provider".
+      try {
+        disposeDisclosurePosture();
       } catch {
         // best-effort
       }

--- a/middleware/src/health/disclosureHealth.ts
+++ b/middleware/src/health/disclosureHealth.ts
@@ -1,0 +1,145 @@
+/**
+ * AI-Act Art. 50 marking posture on `/health` (#648, epic #642).
+ *
+ * ## Why this is on a health endpoint at all
+ *
+ * The operator can grade the marking down per channel and switch it off — that
+ * is their decision to make, omadia is self-hosted. #648's concern is narrower
+ * and practical: a reduced marking is visible NOWHERE, so an operator who set
+ * it by accident (a copied config, a leftover from a test setup) never finds
+ * out. Same motivation as the KG snapshot next door: a silently-degraded
+ * deployment should be observable at a glance instead of diagnosed by
+ * archaeology through boot logs.
+ *
+ * ## Structural contract
+ *
+ * `@omadia/orchestrator` publishes a plain object under
+ * `aiDisclosurePosture`; this module only reads it. Neither side imports the
+ * other's types — the same arrangement `EMBEDDING_GATE_STATUS_SERVICE` uses,
+ * and the reason the service name is spelled as a literal on both sides.
+ *
+ * ## Privacy
+ *
+ * #648's sharpest acceptance criterion is that nothing here may permit
+ * conclusions about content or users. The published posture carries levels,
+ * sources and booleans only; the assistant name, the operator note and any
+ * composed disclosure line are deliberately absent at the source. This module
+ * narrows further rather than widening: it forwards the fields as published
+ * and adds no lookup of its own.
+ */
+
+/**
+ * ServiceRegistry name `@omadia/orchestrator` publishes the posture under.
+ * Structural contract — the literal is spelled in
+ * `packages/harness-orchestrator/src/aiDisclosurePosture.ts` too; keep the two
+ * in sync.
+ */
+export const AI_DISCLOSURE_POSTURE_SERVICE = 'aiDisclosurePosture';
+
+/** Marking verbosity, as published. */
+export type DisclosureLevel = 'standard' | 'concise' | 'off';
+
+/** One channel's resolved posture, as published. `readonly` throughout: this
+ *  module only ever reads the published object, and the publisher freezes it. */
+export interface DisclosureChannelPosture {
+  readonly channel: string;
+  readonly level: DisclosureLevel;
+  readonly overridden: boolean;
+  readonly deviates: boolean;
+  /** `false` when this channel never carries a `channelKind` into a turn, so a
+   *  configured override cannot take effect yet. */
+  readonly effective: boolean;
+}
+
+/** The posture object the orchestrator plugin publishes. */
+export interface AiDisclosurePostureStatus {
+  readonly source: 'default' | 'operator';
+  readonly defaultLevel: DisclosureLevel;
+  readonly shippedLevel: DisclosureLevel;
+  readonly deviates: boolean;
+  readonly channels: readonly DisclosureChannelPosture[];
+  readonly localeConfigured: boolean;
+  readonly assistantNameConfigured: boolean;
+  readonly operatorNoteConfigured: boolean;
+}
+
+/** The `/health` projection. */
+export interface DisclosureHealth {
+  /** `false` when no orchestrator is active to publish a posture — reported
+   *  rather than guessed, since "we could not read it" and "it is at the
+   *  delivered state" are different facts and only one of them is reassuring. */
+  known: boolean;
+  /** Where the effective policy came from. */
+  source: 'default' | 'operator' | 'unknown';
+  /** `true` when any channel deviates from the delivered state. */
+  deviates: boolean;
+  /** Resolved level per channel, `{ teams: 'standard', … }`. Empty when
+   *  unknown. */
+  channels: Record<string, DisclosureLevel>;
+  /** Channels whose configured override cannot fire yet because no turn
+   *  carries their `channelKind`. Only listed when actually overridden — an
+   *  un-overridden channel is not a surprise worth reporting. */
+  inertOverrides: string[];
+  /** Operator-facing notes, empty at the delivered state. */
+  warnings: string[];
+}
+
+const UNKNOWN: DisclosureHealth = {
+  known: false,
+  source: 'unknown',
+  deviates: false,
+  channels: {},
+  inertOverrides: [],
+  warnings: [
+    'no orchestrator is active, so the AI-marking posture could not be read',
+  ],
+};
+
+/**
+ * Project the published posture for `/health`.
+ *
+ * A missing service is NOT reported as healthy. That is the specific lie the
+ * neighbouring KG snapshot exists to prevent, and repeating it here would mean
+ * an instance with no orchestrator answers "marking at the delivered state"
+ * when in truth nothing was asked.
+ */
+export function buildDisclosureHealth(
+  posture: AiDisclosurePostureStatus | undefined,
+): DisclosureHealth {
+  if (!posture || !Array.isArray(posture.channels)) return UNKNOWN;
+
+  const channels: Record<string, DisclosureLevel> = {};
+  for (const c of posture.channels) channels[c.channel] = c.level;
+
+  const inertOverrides = posture.channels
+    .filter((c) => c.overridden && !c.effective)
+    .map((c) => c.channel);
+
+  const warnings: string[] = [];
+  if (posture.deviates) {
+    const changed = posture.channels
+      .filter((c) => c.deviates)
+      .map((c) => `${c.channel}=${c.level}`)
+      .join(', ');
+    warnings.push(
+      `AI marking deviates from the delivered state (${posture.shippedLevel}): ${changed || `default=${posture.defaultLevel}`}`,
+    );
+  }
+  if (inertOverrides.length > 0) {
+    // Worth a line of its own: an operator who set `web=off` and still sees the
+    // marking is looking at a correct system and a stale expectation. Silence
+    // here reads as "your override is in force".
+    warnings.push(
+      `override configured but not yet dispatched for: ${inertOverrides.join(', ')} — turns on these channels carry no channelKind, so they use the global level`,
+    );
+  }
+
+  return {
+    known: true,
+    source: posture.source,
+    deviates: Boolean(posture.deviates),
+    channels,
+    inertOverrides,
+    warnings,
+  };
+}

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -245,6 +245,11 @@ import {
   probeGraphPool,
   type EmbeddingGateStatus,
 } from './health/kgHealth.js';
+import {
+  AI_DISCLOSURE_POSTURE_SERVICE,
+  buildDisclosureHealth,
+  type AiDisclosurePostureStatus,
+} from './health/disclosureHealth.js';
 import { FileInstalledRegistry } from './plugins/fileInstalledRegistry.js';
 import { InstallService } from './plugins/installService.js';
 import { registerInstalledPluginTemplates } from './plugins/pluginTemplates.js';
@@ -2498,10 +2503,24 @@ async function main(): Promise<void> {
       );
       const probe = await probeGraphPool(serviceRegistry.get('graphPool'));
       const kg = buildKgHealth(installedRegistry, gate, probe);
+      // #648 (epic #642) — the resolved AI-Act marking posture per channel.
+      // Read per request for the same reason the embedding gate is: a config
+      // change re-activates the orchestrator and re-publishes, and a boot-time
+      // capture would keep reporting the old posture until a restart.
+      // Non-sensitive by construction: levels, sources and booleans only, no
+      // assistant name, operator note or composed line — see disclosureHealth.ts.
+      const disclosure = buildDisclosureHealth(
+        serviceRegistry.get<AiDisclosurePostureStatus>(
+          AI_DISCLOSURE_POSTURE_SERVICE,
+        ),
+      );
       // A dead pool is not a degradation to report at 200 — nothing in the
       // process can serve a request. 503 is what a load balancer needs to see.
+      // A deviating marking posture deliberately does NOT change the status:
+      // it is a legitimate operator decision, and #648 is explicit that the
+      // hint informs rather than blocks.
       const status = kg.pool === 'dead' ? 'error' : 'ok';
-      res.status(kg.pool === 'dead' ? 503 : 200).json({ status, kg });
+      res.status(kg.pool === 'dead' ? 503 : 200).json({ status, kg, disclosure });
     })();
   });
 

--- a/middleware/test/aiDisclosurePosture.test.ts
+++ b/middleware/test/aiDisclosurePosture.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Issue #648 (epic #642) — the operator's AI-Act marking posture is readable.
+ *
+ * The operator may grade the marking down per channel or switch it off; omadia
+ * is self-hosted and that is their decision. #648 is about the fact that the
+ * decision was invisible: a reduced marking showed up nowhere, so a copied
+ * config or a leftover from a test setup was never noticed by anyone.
+ *
+ * Two properties carry the whole feature and both are pinned below:
+ *
+ *  - **at the delivered state everything stays quiet** — no boot warning, no
+ *    health warning, nothing for a dashboard to render. A hint that fires on a
+ *    default install is a hint operators learn to ignore;
+ *  - **nothing that permits conclusions about content or users leaves the
+ *    process.** That is #648's sharpest acceptance criterion, so it is asserted
+ *    against the serialised payload rather than trusted to review.
+ *
+ * Imported from SOURCE, not the built barrels, so a mutation in `src/` cannot
+ * report green over stale `dist/`.
+ */
+
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  describeAiDisclosurePosture,
+  formatDisclosureBootWarning,
+  resolveDisclosureLevelForChannel,
+} from '../packages/harness-orchestrator/src/aiDisclosurePosture.js';
+import { buildDisclosureHealth } from '../src/health/disclosureHealth.js';
+import type { AiDisclosureSetup } from '../packages/harness-orchestrator/src/orchestrator.js';
+
+const ASSISTANT_NAME = 'Heinemann-Assistent';
+const OPERATOR_NOTE = 'Bei Rückfragen wenden Sie sich an service@example.invalid';
+
+describe('#648 — resolved AI-marking posture', () => {
+  it('is quiet at the delivered state: no deviation, no boot warning', () => {
+    // `undefined` is the zero-config instance — the operator set no disclosure
+    // field at all.
+    const posture = describeAiDisclosurePosture(undefined);
+
+    assert.equal(posture.source, 'default');
+    assert.equal(posture.deviates, false);
+    assert.equal(posture.defaultLevel, 'standard');
+    assert.deepEqual(
+      posture.channels.map((c) => c.level),
+      ['standard', 'standard', 'standard', 'standard', 'standard'],
+    );
+    assert.equal(formatDisclosureBootWarning(posture), undefined);
+
+    const health = buildDisclosureHealth(posture);
+    assert.equal(health.known, true);
+    assert.equal(health.deviates, false);
+    assert.deepEqual(health.warnings, [], 'a default install must not warn');
+  });
+
+  it('reports a per-channel override as a deviation and warns at boot', () => {
+    const setup: AiDisclosureSetup = {
+      level: 'standard',
+      overrides: { telegram: 'concise' },
+    };
+    const posture = describeAiDisclosurePosture(setup);
+
+    const telegram = posture.channels.find((c) => c.channel === 'telegram');
+    assert.equal(telegram?.level, 'concise');
+    assert.equal(telegram?.overridden, true);
+    assert.equal(telegram?.deviates, true);
+    // …and only that one.
+    assert.deepEqual(
+      posture.channels.filter((c) => c.deviates).map((c) => c.channel),
+      ['telegram'],
+    );
+    assert.equal(posture.deviates, true);
+    assert.equal(posture.source, 'operator');
+
+    const warning = formatDisclosureBootWarning(posture);
+    assert.ok(warning?.includes('telegram=concise'));
+
+    const health = buildDisclosureHealth(posture);
+    assert.equal(health.channels['telegram'], 'concise');
+    assert.equal(health.channels['teams'], 'standard');
+    assert.equal(health.warnings.length, 1);
+  });
+
+  it('treats a global level change as a deviation on every channel', () => {
+    // The case a per-channel-only check would miss: no overrides at all, but
+    // the operator switched the global default off.
+    const posture = describeAiDisclosurePosture({ level: 'off' });
+
+    assert.equal(posture.deviates, true);
+    assert.ok(posture.channels.every((c) => c.level === 'off'));
+    assert.ok(posture.channels.every((c) => c.overridden === false));
+    assert.ok(formatDisclosureBootWarning(posture)?.includes('default=off'));
+  });
+
+  it('says so when an override cannot fire yet instead of implying it does', () => {
+    // Only teams/slack/telegram ever carry a `channelKind` into a turn. An
+    // operator who sets `web=off` and still sees the marking is looking at a
+    // correct system and a stale expectation — silence here would read as
+    // "your override is in force".
+    const posture = describeAiDisclosurePosture({
+      level: 'standard',
+      overrides: { web: 'off' },
+    });
+
+    const web = posture.channels.find((c) => c.channel === 'web');
+    assert.equal(web?.overridden, true);
+    assert.equal(web?.effective, false);
+
+    const health = buildDisclosureHealth(posture);
+    assert.deepEqual(health.inertOverrides, ['web']);
+    assert.ok(
+      health.warnings.some((w) => w.includes('not yet dispatched')),
+      'an inert override must be called out',
+    );
+
+    // A dispatched channel must NOT be flagged as inert.
+    const dispatched = describeAiDisclosurePosture({
+      level: 'standard',
+      overrides: { teams: 'off' },
+    });
+    assert.deepEqual(buildDisclosureHealth(dispatched).inertOverrides, []);
+  });
+
+  it('never exposes the assistant name or the operator note', () => {
+    // #648: "Keine Angabe im Health-Output, die Rückschlüsse auf Inhalte oder
+    // Nutzer erlaubt." The operator note is free-form, so this is asserted
+    // against the actual serialised payload rather than the type.
+    const setup: AiDisclosureSetup = {
+      level: 'concise',
+      locale: 'en',
+      assistantName: ASSISTANT_NAME,
+      operatorNote: OPERATOR_NOTE,
+    };
+    const posture = describeAiDisclosurePosture(setup);
+    const wire = JSON.stringify(buildDisclosureHealth(posture));
+
+    assert.ok(!wire.includes(ASSISTANT_NAME), 'assistant name must not reach /health');
+    assert.ok(!wire.includes(OPERATOR_NOTE), 'operator note must not reach /health');
+    assert.ok(!wire.includes('service@example.invalid'));
+
+    // The operator-relevant fact — that they are SET — is still reported.
+    assert.equal(posture.assistantNameConfigured, true);
+    assert.equal(posture.operatorNoteConfigured, true);
+    assert.equal(posture.localeConfigured, true);
+    // …and the posture object itself carries no values either.
+    const postureWire = JSON.stringify(posture);
+    assert.ok(!postureWire.includes(ASSISTANT_NAME));
+    assert.ok(!postureWire.includes(OPERATOR_NOTE));
+  });
+
+  it('does not report an unreadable posture as the delivered state', () => {
+    // No orchestrator active. "We could not read it" and "it is at the
+    // delivered state" are different facts, and only one of them is
+    // reassuring — the same lie the KG snapshot next door exists to prevent.
+    const health = buildDisclosureHealth(undefined);
+
+    assert.equal(health.known, false);
+    assert.equal(health.source, 'unknown');
+    assert.deepEqual(health.channels, {});
+    assert.equal(health.warnings.length, 1);
+  });
+
+  it('resolves a channel level with override > global > shipped precedence', () => {
+    // The single derivation the Orchestrator's per-turn path also calls. A
+    // channel with no `channelKind` falls back to the global level — the safe
+    // direction, because the marking stays active.
+    const setup: AiDisclosureSetup = {
+      level: 'concise',
+      overrides: { teams: 'off' },
+    };
+
+    assert.equal(resolveDisclosureLevelForChannel(setup, 'teams'), 'off');
+    assert.equal(resolveDisclosureLevelForChannel(setup, 'slack'), 'concise');
+    assert.equal(resolveDisclosureLevelForChannel(setup, undefined), 'concise');
+    assert.equal(resolveDisclosureLevelForChannel(undefined, 'teams'), 'standard');
+  });
+});

--- a/web-ui/app/_lib/disclosure.test.ts
+++ b/web-ui/app/_lib/disclosure.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Issue #648 (epic #642) — when the operator dashboard shows the AI-marking
+ * deviation hint, and when it must stay silent.
+ *
+ * The silence cases carry more weight than the firing case. #648 asks for a
+ * surface that is "unverändert ruhig" in the delivered state; a hint that fires
+ * on a default install is one operators learn to scroll past, which would cost
+ * exactly the signal the feature exists to create.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  deviatingChannels,
+  shouldShowDisclosureNotice,
+  type DisclosureHealthDto,
+} from './disclosure';
+
+function posture(over: Partial<DisclosureHealthDto> = {}): DisclosureHealthDto {
+  return {
+    known: true,
+    source: 'default',
+    deviates: false,
+    channels: {
+      teams: 'standard',
+      telegram: 'standard',
+      slack: 'standard',
+      email: 'standard',
+      web: 'standard',
+    },
+    inertOverrides: [],
+    warnings: [],
+    ...over,
+  };
+}
+
+describe('#648 — disclosure deviation hint', () => {
+  it('stays silent in the delivered state', () => {
+    expect(shouldShowDisclosureNotice(posture())).toBe(false);
+    expect(deviatingChannels(posture())).toEqual([]);
+  });
+
+  it('stays silent when the posture could not be read', () => {
+    // An unreachable middleware, or one older than this feature. "We could not
+    // read it" is not "it deviates" — claiming a deviation here would train the
+    // operator to distrust the hint.
+    expect(shouldShowDisclosureNotice(null)).toBe(false);
+    expect(shouldShowDisclosureNotice(posture({ known: false }))).toBe(false);
+  });
+
+  it('fires for a per-channel override and names only the changed channel', () => {
+    const p = posture({
+      source: 'operator',
+      deviates: true,
+      channels: { ...posture().channels, telegram: 'concise' },
+    });
+
+    expect(shouldShowDisclosureNotice(p)).toBe(true);
+    expect(deviatingChannels(p)).toEqual([['telegram', 'concise']]);
+  });
+
+  it('names every channel when the operator changed the GLOBAL level', () => {
+    // The case a "compare against this instance's own default" implementation
+    // would report as nothing at all: no per-channel override exists, but the
+    // operator switched marking off everywhere.
+    const p = posture({
+      source: 'operator',
+      deviates: true,
+      channels: {
+        teams: 'off',
+        telegram: 'off',
+        slack: 'off',
+        email: 'off',
+        web: 'off',
+      },
+    });
+
+    expect(shouldShowDisclosureNotice(p)).toBe(true);
+    expect(deviatingChannels(p).map(([c]) => c)).toEqual([
+      'teams',
+      'telegram',
+      'slack',
+      'email',
+      'web',
+    ]);
+  });
+
+  it('stays silent for an override that merely pins the shipping level', () => {
+    // `web=standard` configures an override that can never fire, but it
+    // deviates from nothing — so it is not worth a warning banner.
+    const p = posture({ source: 'operator', inertOverrides: ['web'] });
+
+    expect(shouldShowDisclosureNotice(p)).toBe(false);
+  });
+});

--- a/web-ui/app/_lib/disclosure.ts
+++ b/web-ui/app/_lib/disclosure.ts
@@ -1,0 +1,106 @@
+/**
+ * AI-Act marking posture, read for the operator channels dashboard (#648).
+ *
+ * ## Why this reads `/health` rather than a new operator endpoint
+ *
+ * The middleware already projects the resolved posture there
+ * (`src/health/disclosureHealth.ts`), deliberately stripped of anything that
+ * permits conclusions about content or users — levels, sources and booleans
+ * only. Adding a second endpoint would mean a second projection of the same
+ * config, and two projections of one config drift. The dashboard shows exactly
+ * what `/health` shows.
+ *
+ * ## Server-only
+ *
+ * `/health` lives OUTSIDE the `/api` mount, so the browser-side `/bot-api`
+ * proxy does not reach it. This module is called from the server component
+ * only; the posture arrives at the client component as a prop.
+ */
+
+/** Marking verbosity, as the middleware publishes it. */
+export type DisclosureLevel = 'standard' | 'concise' | 'off';
+
+/** The `disclosure` block of `GET /health`. */
+export interface DisclosureHealthDto {
+  known: boolean;
+  source: 'default' | 'operator' | 'unknown';
+  deviates: boolean;
+  channels: Record<string, DisclosureLevel>;
+  inertOverrides: string[];
+  warnings: string[];
+}
+
+interface HealthDto {
+  disclosure?: DisclosureHealthDto;
+}
+
+/**
+ * Should the operator see the deviation hint?
+ *
+ * Deviation is the ONLY trigger, and that is deliberate. #648 requires the
+ * surface to stay completely quiet in the delivered state — a hint that fires
+ * on a default install is one operators learn to scroll past, which would cost
+ * exactly the signal this feature exists to create. So: not when the posture
+ * could not be read (nothing to claim), not when the middleware is older than
+ * this feature, and not for an override that merely pins a channel to the
+ * shipping level (`web=standard` configures something inert, but deviates from
+ * nothing).
+ *
+ * Extracted from the component so the rule is testable without rendering an
+ * async server component.
+ */
+export function shouldShowDisclosureNotice(
+  posture: DisclosureHealthDto | null,
+): boolean {
+  return Boolean(posture?.known && posture.deviates);
+}
+
+/**
+ * The channels whose marking differs from the delivered state, as
+ * `[channel, level]` pairs in the order `/health` reported them.
+ *
+ * Compares against the shipping level rather than against the instance's own
+ * global default: an operator who set `ai_disclosure_level=off` globally has
+ * deviated on every channel, and a list that quietly treated their global
+ * setting as the baseline would report nothing at all.
+ */
+export function deviatingChannels(
+  posture: DisclosureHealthDto,
+): Array<[string, DisclosureLevel]> {
+  return Object.entries(posture.channels).filter(
+    ([, level]) => level !== SHIPPED_LEVEL,
+  );
+}
+
+/** The delivered marking level. Mirrors `DEFAULT_AI_DISCLOSURE_POLICY.level`
+ *  in `@omadia/channel-sdk`; `/health` reports it as `shippedLevel`. */
+const SHIPPED_LEVEL: DisclosureLevel = 'standard';
+
+function healthUrl(): string {
+  const base = process.env['MIDDLEWARE_URL'] ?? 'http://localhost:3979';
+  return `${base}/health`;
+}
+
+/**
+ * Fetch the resolved marking posture.
+ *
+ * Returns `null` on any failure — an unreachable middleware, a 503 from a dead
+ * pool, an older build whose `/health` has no `disclosure` block. The dashboard
+ * renders nothing at all in that case: this is an informational hint, and a
+ * channels page that fails to load because a hint could not be fetched would be
+ * a worse outcome than a missing hint.
+ */
+export async function fetchDisclosurePosture(): Promise<DisclosureHealthDto | null> {
+  try {
+    const res = await fetch(healthUrl(), {
+      headers: { accept: 'application/json' },
+      cache: 'no-store',
+    });
+    // A 503 still carries a body (#665 — a dead pool answers 503 with the full
+    // snapshot), so parse regardless of status rather than bailing on !ok.
+    const body = (await res.json()) as HealthDto;
+    return body.disclosure ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/web-ui/app/operator/channels/_components/DisclosureNotice.tsx
+++ b/web-ui/app/operator/channels/_components/DisclosureNotice.tsx
@@ -1,0 +1,56 @@
+import { getTranslations } from 'next-intl/server';
+
+import {
+  deviatingChannels,
+  shouldShowDisclosureNotice,
+  type DisclosureHealthDto,
+} from '../../../_lib/disclosure';
+
+interface Props {
+  posture: DisclosureHealthDto | null;
+}
+
+/**
+ * AI-Act marking deviation hint (#648, epic #642).
+ *
+ * The operator may grade the marking down per channel or switch it off —
+ * omadia is self-hosted, that is their call. This notice exists because the
+ * decision was previously visible NOWHERE, so a copied config or a leftover
+ * from a test setup was never noticed by anyone.
+ *
+ * Informing, not paternalistic: it describes the state and blocks nothing. It
+ * renders `null` at the delivered state, when the posture could not be read,
+ * and on an older middleware whose `/health` has no `disclosure` block — #648
+ * requires the surface to stay completely quiet in the delivered state, and a
+ * hint that fires on a default install is a hint operators learn to ignore.
+ *
+ * Server component: the posture is fetched server-side (`/health` sits outside
+ * the `/api` mount the browser proxy reaches), so there is nothing to hydrate.
+ */
+export async function DisclosureNotice({
+  posture,
+}: Props): Promise<React.ReactElement | null> {
+  if (!shouldShowDisclosureNotice(posture) || !posture) return null;
+  const t = await getTranslations('operatorChannels.disclosure');
+
+  const deviating = deviatingChannels(posture)
+    .map(([channel, level]) => `${channel} · ${t(`level.${level}`)}`)
+    .join(', ');
+
+  return (
+    <div className="mb-6 rounded border border-[color:var(--warning)] bg-[color:var(--warning)]/8 p-4 text-sm">
+      <p className="font-medium text-[color:var(--fg)]">{t('heading')}</p>
+      {posture.deviates && deviating.length > 0 && (
+        <p className="mt-1 text-[color:var(--fg-muted)]">
+          {t('body', { channels: deviating })}
+        </p>
+      )}
+      {posture.inertOverrides.length > 0 && (
+        <p className="mt-2 text-xs text-[color:var(--fg-muted)]">
+          {t('inert', { channels: posture.inertOverrides.join(', ') })}
+        </p>
+      )}
+      <p className="mt-2 text-xs text-[color:var(--fg-muted)]">{t('note')}</p>
+    </div>
+  );
+}

--- a/web-ui/app/operator/channels/page.tsx
+++ b/web-ui/app/operator/channels/page.tsx
@@ -6,7 +6,9 @@ import {
   listOperatorChannels,
   type ChannelsListDto,
 } from '../../_lib/channels';
+import { fetchDisclosurePosture } from '../../_lib/disclosure';
 import { ChannelsDashboard } from './_components/ChannelsDashboard';
+import { DisclosureNotice } from './_components/DisclosureNotice';
 
 /**
  * Phase B+ — operator-facing channels dashboard.
@@ -33,6 +35,12 @@ export default async function OperatorChannelsPage(): Promise<React.ReactElement
     await redirectIfUnauthorized(err);
     loadError = err instanceof Error ? err.message : t('loadError');
   }
+  // #648 — the resolved AI-Act marking posture. Fetched separately and
+  // never allowed to fail the page: it feeds an informational hint, and a
+  // channels dashboard that 500s because a hint could not be read would be a
+  // worse outcome than a missing hint. `fetchDisclosurePosture` swallows its
+  // own errors and returns null.
+  const disclosurePosture = await fetchDisclosurePosture();
 
   return (
     <main className="mx-auto w-full max-w-[1400px] px-6 py-12 lg:px-8 lg:py-16">
@@ -42,6 +50,7 @@ export default async function OperatorChannelsPage(): Promise<React.ReactElement
           {t('subtitle')}
         </p>
       </header>
+      <DisclosureNotice posture={disclosurePosture} />
       {loadError ? (
         <div className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-4 text-sm text-[color:var(--danger)]">
           {loadError}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -709,7 +709,18 @@
     "staleBadge": "veraltet",
     "routesTo": "→ Orchestrator:",
     "routesToFallback": "(Standard · {fallback})",
-    "clearStale": "Binding entfernen"
+    "clearStale": "Binding entfernen",
+    "disclosure": {
+      "heading": "KI-Kennzeichnung weicht vom Auslieferungszustand ab",
+      "body": "Auf diesen Channels werden Antworten anders gekennzeichnet als im Auslieferungszustand: {channels}.",
+      "inert": "Konfiguriert, aber noch nicht wirksam: {channels}. Turns auf diesen Channels melden ihren Channel-Typ nicht, daher gilt dort die globale Einstellung.",
+      "note": "Das ist deine Entscheidung als Betreiber — es wird nichts blockiert. Angezeigt, damit eine Einstellung aus einem Test-Setup nicht unbemerkt bleibt.",
+      "level": {
+        "standard": "volle Kennzeichnung",
+        "concise": "kurze Kennzeichnung",
+        "off": "keine Kennzeichnung"
+      }
+    }
   },
   "layout": {
     "logoAriaLabel": "omadia · Startseite",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -709,7 +709,18 @@
     "staleBadge": "stale",
     "routesTo": "→ Orchestrator:",
     "routesToFallback": "(standard · {fallback})",
-    "clearStale": "Clear binding"
+    "clearStale": "Clear binding",
+    "disclosure": {
+      "heading": "AI marking differs from the delivered state",
+      "body": "Answers on these channels are marked differently than on delivery: {channels}.",
+      "inert": "Configured but not yet in effect: {channels}. Turns on these channels do not report their channel type, so they use the global setting.",
+      "note": "This is your decision as the operator — nothing is blocked. Shown so a setting from a test setup does not go unnoticed.",
+      "level": {
+        "standard": "full marking",
+        "concise": "short marking",
+        "off": "no marking"
+      }
+    }
   },
   "layout": {
     "logoAriaLabel": "omadia · Home",


### PR DESCRIPTION
Closes #648. Part of epic #642.

The operator may grade the AI-Act Art. 50 marking down per channel or switch it off — omadia is self-hosted, that is their decision. #648's concern is narrower and practical: the decision was visible **nowhere**, so an operator who set it by accident (a copied config, a leftover from a test setup) never found out.

## What now reports the posture

| Surface | Behaviour |
|---|---|
| `GET /health` | new `disclosure` block: resolved level per channel, source, deviation flag, inert overrides, warnings |
| Boot log | one `console.warn` — **on deviation only** |
| Operator channels dashboard | informing hint, DE/EN via the catalogue — **renders nothing at the delivered state** |

`/health` is built on the **post-#665 shape** (`{ status, kg }` → `{ status, kg, disclosure }`), not the older registry-projector form the issue text describes.

## Two design points that carry more than the plumbing

**One derivation, not two.** `resolveDisclosureLevelForChannel` is now the single place the `override → global → shipped` precedence lives. `Orchestrator.resolveTurnDisclosure` calls it per turn; the posture view calls it per channel. A posture view that recomputed the precedence with its own copy could disagree with what turns actually do — *silently* — which is the exact failure this feature exists to prevent.

**Nothing that permits conclusions about content or users leaves the process.** That is #648's sharpest acceptance criterion, so it is asserted against the serialised payload rather than left to review: levels, sources and booleans only. The assistant name and the free-form operator note are reported as *configured / not configured*, never by value.

## An override that cannot fire says so

Only `teams` / `slack` / `telegram` ever carry a `channelKind` into a turn (`orchestratorDispatcher.toChannelKind` is the sole setter), so a configured `web=off` never takes effect. Both `/health` and the dashboard call that out. An operator who set it and still sees the marking is looking at a correct system and a stale expectation — silence there would read as "your override is in force".

## Informing, not blocking

A deviating posture deliberately does **not** change the `/health` status code. It is a legitimate operator decision; #648 is explicit that the hint describes the state and blocks nothing.

## Files

| File | Change |
|---|---|
| `packages/harness-orchestrator/src/aiDisclosurePosture.ts` *(new)* | the shared precedence function, the posture projection, the boot-warning formatter |
| `packages/harness-orchestrator/src/orchestrator.ts` | `resolveTurnDisclosure` now calls the shared function instead of inlining the rules |
| `packages/harness-orchestrator/src/plugin.ts` | publishes the posture as a service, warns at boot on deviation, disposes on deactivate; the override allowlist is derived from the shared list so parser and view cannot drift |
| `src/health/disclosureHealth.ts` *(new)* | the `/health` projection |
| `src/index.ts` | `/health` reads the posture per request (a config change re-activates and re-publishes) |
| `web-ui/app/_lib/disclosure.ts` *(new)* | server-side posture fetch + the show/hide rule, extracted so it is testable |
| `web-ui/app/operator/channels/_components/DisclosureNotice.tsx` *(new)* | the hint |
| `web-ui/app/operator/channels/page.tsx`, `messages/{de,en}.json` | wiring + copy |

## Verification

- `middleware/test/aiDisclosurePosture.test.ts` — 7 tests; `web-ui/app/_lib/disclosure.test.ts` — 5 tests. Both import from **source**, so a `src/` mutation cannot report green over stale `dist/`.
- **Mutation checks (3, each verified to LAND before running — one candidate silently no-matched and was retried):**
  - leak `assistantName` / `operatorNote` into the posture → **1 fail** (the privacy criterion).
  - drop the per-channel override from the precedence → **2 fail**.
  - make the dashboard notice always fire → **3 fail** (the silence cases).
- All disclosure-related middleware tests: **52/52 pass**. web-ui `disclosure` + `i18n-parity`: **15/15 pass**.
- `npm run build`, `npm run typecheck` (middleware + web-ui) → exit 0.
- `npm run typecheck:test` → **406, baseline 406, no regressions**.
- `npm run i18n:check` → OK, 3606 keys, `en` + `de` in parity.
- `npm run lint` (web-ui) → **0 errors**; zero warnings in the added files.
- `scripts/check-core-decoupling.mjs` → green, baseline **unchanged at 3294**.

## Note on scope

Earlier research suggested splitting this into a server PR and a UI PR. Kept as one: the three surfaces share a single projection, and splitting would ship a published service nothing reads, then a UI whose only test is the half already merged. The wave plan also asks for one PR per issue.

The hint is rendered from `page.tsx` above the dashboard rather than inside `ChannelsDashboard`, which has two return paths (empty state and populated) — the posture is instance-wide, not per row, so one placement beats duplicating it in both.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789213814&installation_model_id=428086&pr_number=686&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F686&signature=f796c2f14200523077ee410481bc749ccd73c0c254d4f4f6f7dc0ba02b5e184b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->