### PR TITLE
ci: re-pin PG_TEST_FLOOR to the measured pg-test count (240 -> 269)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,17 +196,27 @@ jobs:
       # skip does NOT increment "skipped": its tests simply never register
       # and vanish from the total. So "skipped == 0" is blind to exactly the
       # silent-skip this issue is about; only a floor on the test COUNT
-      # catches it. The *.pg.test.ts files register 240 tests today (+2 from
-      # kgPluginPoolLifetime.pg.test.ts, issue #665). If
+      # catches it. The *.pg.test.ts files register 269 tests today (+6 from
+      # channelIdentityAuthSubject.pg.test.ts, issue #568; +8 from
+      # updateAuditStore.pg.test.ts, issue #432). If
       # the count drops (broken DSN, a future suite reading an env var we
       # don't set here, a cold-connection flake), a suite silently vanished —
       # go red. Raise PG_TEST_FLOOR when you add Postgres tests, same
       # baseline-ratchet convention as the core-decoupling job above.
+      #
+      # NOTE — this floor is the INVERSE of the core-decoupling ratchet, and
+      # the reflex from that one is wrong here. It is a MINIMUM on desirable
+      # coverage, so raising it as suites land is the intended move; there the
+      # counted thing is debt and the rule is reword-don't-raise. It had
+      # drifted to 240 against an actual 269, i.e. 29 tests of slack in which
+      # a whole suite could self-skip unnoticed — precisely the #565 failure
+      # this guard exists to catch. Re-pinned to the measured count (the
+      # step below prints `ran=` on every run; read it there, don't guess).
       - name: Test — Postgres suites (serial, real pgvector)
         env:
           GRAPH_PG_TEST_URL: postgres://omadia:omadia-ci@localhost:5432/omadia
           MEMORY_PG_TEST_URL: postgres://omadia:omadia-ci@localhost:5432/omadia
-          PG_TEST_FLOOR: '240'
+          PG_TEST_FLOOR: '269'
         run: |
           set -eo pipefail
           npm run test:pg 2>&1 | tee pg-test.out


### PR DESCRIPTION
## What

Re-pins `PG_TEST_FLOOR` from `240` to the measured **269**.

Split out of #691. That PR carried this change, but its squash merge landed **11 files and `.github/workflows/ci.yml` was not among them** — so it never reached main. Verified by reading the file on `main` rather than trusting the merged flag.

## Why it matters

The floor is the anti-#565 guard. A `*.pg.test.ts` suite that self-skips does **not** increment `skipped`: a describe-level skip means its tests never register at all, so they simply vanish from the total. Only a floor on the test COUNT can see that.

Main today reports `ran=269` against `floor=240` — **29 tests of slack**. An entire pg suite can disappear inside that gap and CI stays green, which is exactly the failure this guard was built to catch.

The drift came from two PRs adding suites without moving the floor:

| Source | Suite | Tests |
|---|---|---|
| #432 (PR #692) | `updateAuditStore.pg.test.ts` | +8 |
| #568 (PR #691) | `channelIdentityAuthSubject.pg.test.ts` | +6 |

## Not debt acceptance — the inverse ratchet

Worth stating explicitly, because this repo's other ratchet trains the opposite reflex: the core-decoupling counter counts **debt**, so the rule there is reword-don't-raise. This floor is a **minimum on desirable coverage**, so raising it as suites land is the intended move. Applying the decoupling reflex here would quietly disarm the guard. The comment in `ci.yml` now says so.

## Verification

The number is measured, not estimated — the step prints `Postgres suites: ran=N skipped=N (floor=N)` on every run, and the comment now records that as the place to read it. This PR's own CI run is the check: with the floor at 269 there is zero slack left, so `ran` must land exactly on it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789274947&installation_model_id=428086&pr_number=694&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F694&signature=8d0bf0cd051851ed0da5c7eb4afa0521bd915f1fb727fa961fd8763c16ba6749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->