### PR TITLE
feat(#562): serve the loopback MCP server on the v2 SDK family (phase 1)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,28 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Changed — the loopback MCP server runs on the `@modelcontextprotocol/*@2` family (#562, phase 1)
+
+- **`createMcpHandler` replaces a hand-rolled per-request dance.** The loopback
+  server built a fresh `Server` + stateless `StreamableHTTPServerTransport` for
+  every request and tore both down in a `finally`, purely because v1 throws
+  `'Stateless transport cannot be reused across requests'` on a transport's
+  second use. v2 offers that per-request-instance model as the serving entry
+  itself, so the workaround and its teardown block are deleted rather than
+  ported. `toNodeHandler` bridges the handler's web-standard `fetch` to the
+  Node `(req, res)` this server speaks.
+- **No wire change.** Statelessness, the POST-only `405` on the standalone SSE
+  stream, the `413` body cap, bearer auth, and name-sorted `tools/list` all
+  behave exactly as before — the existing suite passes unmodified, and the
+  omadia MCP *client* (still on v1) talks to the ported server unchanged, which
+  is the cross-era interop check.
+- **Scope is deliberately one surface.** The public MCP endpoint is NOT ported
+  in this phase: it serves MRTR (`resultType: "input_required"`, #544/#570), and
+  v2 offers no mode that reproduces that wire shape on a 2025-era connection —
+  its legacy shim converts the return into server→client `elicitation/create`
+  requests, and disabling the shim makes the same return fail loudly. Tracked on
+  #562.
+
 ### Fixed — skill import no longer drops frontmatter silently
 
 - **`parseSkillMarkdown` reports what it cannot read.** omadia's SKILL.md

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1873,6 +1873,39 @@
         }
       }
     },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+      "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0",
+        "hono": "^4.11.4"
+      },
+      "peerDependenciesMeta": {
+        "hono": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
@@ -1911,6 +1944,19 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+      "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -9219,7 +9265,10 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/core": "^2.0.0",
+        "@modelcontextprotocol/node": "^2.0.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
+        "@modelcontextprotocol/server": "^2.0.0",
         "csv-parse": "^7.0.2",
         "mammoth": "^1.8.0",
         "pdf-parse": "^2.4.5"

--- a/middleware/packages/harness-orchestrator/package.json
+++ b/middleware/packages/harness-orchestrator/package.json
@@ -28,7 +28,10 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@modelcontextprotocol/core": "^2.0.0",
+    "@modelcontextprotocol/node": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "csv-parse": "^7.0.2",
     "mammoth": "^1.8.0",
     "pdf-parse": "^2.4.5"

--- a/middleware/packages/harness-orchestrator/src/loopbackMcpServer.ts
+++ b/middleware/packages/harness-orchestrator/src/loopbackMcpServer.ts
@@ -14,14 +14,18 @@ import {
   type ServerResponse,
 } from 'node:http';
 import type { AddressInfo } from 'node:net';
-import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import {
-  CallToolRequestSchema,
-  ErrorCode,
-  ListToolsRequestSchema,
-  McpError,
-} from '@modelcontextprotocol/sdk/types.js';
+// #562 Phase 1 — this surface is served by the `@modelcontextprotocol/*@2`
+// family. `createMcpHandler` IS the per-request-instance model this file used
+// to hand-roll (see `handleHttp`), and `toNodeHandler` bridges its
+// web-standard `fetch` back to the Node `(req, res)` this server speaks.
+//
+// The v1 SDK stays a dependency of this package: the MCP *client*
+// (`mcp/mcpClient.ts`) is deliberately NOT ported in this phase, because v2
+// changes how `input_required` (MRTR, #544/#570) travels on a 2025-era
+// connection. See the #562 issue thread.
+import { createMcpHandler, McpServer, type Tool } from '@modelcontextprotocol/server';
+import { toNodeHandler } from '@modelcontextprotocol/node';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 
 import type {
   DispatchableToolSpec,
@@ -50,6 +54,8 @@ export interface LoopbackMcpServerHandle {
 export class LoopbackMcpServer {
   private http?: HttpServer;
   private started = false;
+  /** #562 — the long-lived serving entry; see `nodeHandler()`. */
+  private handler?: ReturnType<typeof toNodeHandler>;
 
   constructor(private readonly deps: LoopbackMcpServerDeps) {
     if (!deps.bearer) {
@@ -110,28 +116,24 @@ export class LoopbackMcpServer {
   }
 
   /**
-   * Builds a fresh MCP server + transport pair for a single HTTP request.
+   * Builds a fresh MCP server for a single HTTP request.
    *
-   * W1-2 — `sessionIdGenerator: undefined` selects the SDK's stateless mode:
-   * no session id is issued and no session validation happens, so a client may
-   * skip the `initialize` handshake and never send `Mcp-Session-Id`. The SDK
-   * enforces the other half of that contract — a stateless transport throws
-   * "Stateless transport cannot be reused across requests" on its second use —
-   * so the transport (and the `Server` bound to it) is per-request by
-   * construction, matching the SDK's own stateless example.
+   * #562 — the per-request lifetime is unchanged, but it is now the SERVING
+   * ENTRY's model rather than something this file arranges. `createMcpHandler`
+   * calls this factory once per request and owns the transport, so the
+   * hand-rolled "build a stateless transport, connect, handle, tear down" dance
+   * is gone along with the constraint that produced it (v1 threw "Stateless
+   * transport cannot be reused across requests" on second use, which is why the
+   * pair had to be per-request in the first place).
    *
-   * Cost is negligible: both objects are pure in-memory handler tables with no
-   * I/O, and this server sees a handful of requests per CLI turn. Nothing here
-   * held cross-request state worth keeping — the tool list and the dispatch
-   * service are owned by `deps`, and the bearer token is what actually scopes
-   * access. `enableJsonResponse` stays on: JSON replies keep the client simple
-   * and also guarantee the response is fully written by the time
-   * `handleRequest` resolves, which is what makes per-request teardown safe.
+   * Statelessness is preserved and is still the point: no session id is issued
+   * and none is validated, so a client may skip `initialize` and never send
+   * `Mcp-Session-Id`. Cost stays negligible — a pure in-memory handler table,
+   * no I/O, a handful of requests per CLI turn. Nothing here held cross-request
+   * state worth keeping: the tool list and dispatch service are owned by
+   * `deps`, and the bearer token is what actually scopes access.
    */
-  private createRequestScopedServer(): {
-    mcp: McpServer;
-    transport: StreamableHTTPServerTransport;
-  } {
+  private createRequestScopedServer(): McpServer {
     const mcp = new McpServer(
       {
         name: this.deps.serverName ?? 'omadia-loopback',
@@ -140,18 +142,26 @@ export class LoopbackMcpServer {
       { capabilities: { tools: {} } },
     );
 
+    // #562 — v2 keys handlers on the method string instead of a Zod schema,
+    // and they hang off `.server`. Same two methods, same shapes on the wire.
+    //
     // W0-3 — advertise name-sorted. `ToolDispatchService` already sorts, but
     // `deps.tools` is caller-supplied, so sorting here makes the wire order a
     // property of this server rather than a convention every caller must know.
-    mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
+    mcp.server.setRequestHandler('tools/list', async () => ({
       tools: sortByToolName(this.deps.tools).map((tool) => ({
         name: tool.name,
         description: tool.description,
-        inputSchema: tool.input_schema,
+        // `input_schema` is a JSON Schema object whose `properties` we model as
+        // `Record<string, unknown>`; v2 types the field as a concrete JSON
+        // value. The runtime value is the same object v1 put on the wire — the
+        // cast asserts what TypeScript cannot prove about caller-supplied JSON,
+        // and nothing here reshapes it.
+        inputSchema: tool.input_schema as unknown as Tool['inputSchema'],
       })),
     }));
 
-    mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
+    mcp.server.setRequestHandler('tools/call', async (request) => {
       const { name, arguments: args } = request.params;
       const result = await this.deps.dispatch.dispatch(name, args ?? {});
       return {
@@ -160,12 +170,22 @@ export class LoopbackMcpServer {
       };
     });
 
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: undefined,
-      enableJsonResponse: true,
-    });
+    return mcp;
+  }
 
-    return { mcp, transport };
+  /**
+   * The web-standard MCP handler, adapted to Node.
+   *
+   * Built lazily and then reused: `createMcpHandler` is the long-lived object
+   * (it instantiates a server PER REQUEST via the factory above), so rebuilding
+   * it per request would defeat its own model. `toNodeHandler` converts the
+   * Node request, calls `fetch`, and writes the `Response` back to `res`.
+   */
+  private nodeHandler(): ReturnType<typeof toNodeHandler> {
+    this.handler ??= toNodeHandler(
+      createMcpHandler(() => this.createRequestScopedServer()),
+    );
+    return this.handler;
   }
 
   private async handleHttp(
@@ -222,15 +242,12 @@ export class LoopbackMcpServer {
       return;
     }
 
-    // Read the body BEFORE building the per-request server so an oversized
-    // POST still fails with 413 without paying for the handler wiring.
-    let session: ReturnType<typeof this.createRequestScopedServer> | undefined;
+    // Read the body BEFORE handing off so an oversized POST still fails with
+    // 413 without paying for the handler wiring. The parsed value is passed
+    // through, so the adapter does not re-read a stream we already consumed.
     try {
       const parsedBody = await this.parsePostBody(req);
-
-      session = this.createRequestScopedServer();
-      await session.mcp.connect(session.transport);
-      await session.transport.handleRequest(req, res, parsedBody);
+      await this.nodeHandler()(req, res, parsedBody);
     } catch (error) {
       if (res.headersSent) {
         res.end();
@@ -259,14 +276,10 @@ export class LoopbackMcpServer {
           id: null,
         }),
       );
-    } finally {
-      // A stateless transport is single-use; dropping it here is what keeps
-      // the next request from hitting the SDK's reuse guard. Safe at this
-      // point because `enableJsonResponse` means the response is already
-      // fully written when `handleRequest` resolves.
-      await session?.transport.close().catch(() => {});
-      await session?.mcp.close().catch(() => {});
     }
+    // #562 — no `finally` teardown any more. The per-request server and its
+    // transport are created and disposed by `createMcpHandler`; the old block
+    // existed only to dodge v1's single-use stateless transport.
   }
 
   /** Reads and JSON-parses a POST body, or `undefined` when the body is empty. */


### PR DESCRIPTION
## What

Phase 1 of #562: the **loopback MCP server** now runs on `@modelcontextprotocol/{core,server,node}@2`.

The spike on #562 cleared the blocker — v2 does not silently strip `resultType`, and it negotiates the 2026-07-28 era at the HTTP edge through `createMcpHandler`. This lands the first of the two server surfaces.

## The workaround this deletes

`loopbackMcpServer` built a fresh `Server` plus a stateless `StreamableHTTPServerTransport` for **every request**, then disposed both in a `finally`. That was never a design preference: v1 throws `'Stateless transport cannot be reused across requests'` on a transport's second use, so the pair *had* to be per-request, and the teardown existed to stay ahead of that guard.

v2 offers per-request instantiation as the serving entry's own model. So the code is removed rather than ported:

| Before (v1) | After (v2) |
|---|---|
| Hand-rolled per-request `Server` + transport | `createMcpHandler(factory)` — one long-lived entry, one instance per request |
| `finally { transport.close(); mcp.close() }` | gone; the entry owns the lifecycle |
| `mcp.connect(transport)` + `transport.handleRequest(req, res, body)` | `toNodeHandler(handler)(req, res, parsedBody)` |
| `setRequestHandler(ListToolsRequestSchema, …)` | `mcp.server.setRequestHandler('tools/list', …)` |

The already-parsed body is passed through, so the adapter never re-reads a stream we consumed for the 413 check.

## Nothing changes on the wire

Statelessness, POST-only with `405` on the standalone SSE stream, the `413` body cap, bearer auth, and name-sorted `tools/list` all behave exactly as before. **The existing suite passes unmodified** — no test was adjusted to fit the port.

The omadia MCP *client* stays on v1 and still drives this server, so `mcpClient` and `mcpWriteIdempotency` are a genuine **cross-era interop check**: v1 client ↔ v2 server, green.

## Deliberately one surface

`publicMcpServer` is **not** ported here, and that is a measured decision rather than a scoping convenience. It serves MRTR (`resultType: "input_required"`, #544/#570), and v2 has no mode that reproduces omadia's current wire shape on a 2025-era connection:

| `inputRequired.legacyShim` | v2 behaviour on a 2025-era request | Matches omadia today? |
|---|---|---|
| `true` (default) | Shim fulfils it server-side: real server→client `elicitation/create` requests + handler re-entry | ✗ our client reads `resultType` **inline** |
| `false` | The `input_required` return **fails loudly** | ✗ MRTR would be dead |

Confirmed in the spike: on a legacy-era connection `resultType` never reaches the wire. Since #570/#544 only just made MRTR functional, changing its wire shape is a contract decision for #562, not something to slip into a port.

## Verification

- Existing suites green, unmodified: `loopbackMcpServer` (6), `mcpClient` + `mcpWriteIdempotency` (10) — **16/16**.
- **Refactor-appropriate check.** A normal mutation check does not apply (the tests are supposed to pass before *and* after). Instead the check proves they bind to the **new** path: reversing the sort inside the v2 handler and rebuilding `dist/` turns `advertises tools sorted by name` red (1 of 6); the other five correctly survive. Restored, rebuilt, green.
- `build` / `lint` / `typecheck` all exit 0 — gated on exit codes, because `grep "error TS"` misses tsc's ANSI-coloured `error TS2322` and reports a clean run on a failing build.
- Test-typecheck ratchet 406 (baseline 406, not raised); decoupling ratchet held at 3294; `npm audit` 0 high/critical.

## Follow-up

Phase 2 (client `http` transport on `versionNegotiation: { mode: 'auto' }`) and the `publicMcpServer` MRTR decision stay on #562. `Refs #562` rather than `Closes` — the issue covers more than this phase.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789279379&installation_model_id=428086&pr_number=695&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F695&signature=37f77b5ced07c64d4111f768e8099dc8a9c3374552012dbe7eba8d202fe667e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->