### PR TITLE
feat(#562): connect http MCP servers on the v2 client family (phase 2)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,41 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Changed — the MCP **client** speaks `@modelcontextprotocol/client@2` over `http` (#562, phase 2)
+
+- **Only `http` moved.** `McpManager` now connects streamable-HTTP servers with
+  the v2 `Client` + `StreamableHTTPClientTransport` and
+  `versionNegotiation: { mode: 'auto' }`, so a 2026-07-28 peer is negotiated as
+  such and a 2025-era peer still falls back to the plain `initialize` handshake.
+  Deliberately **not** a pin: a pin has no fallback and most third-party servers
+  are 2025-era, so pinning would break exactly the peers that work today.
+- **`stdio` and `sse` stay on v1**, from measurement rather than convenience:
+  `McpServer` never answers `server/discover` off the HTTP edge, so an `'auto'`
+  probe there can only fall back and a pin fails with `ERA_NEGOTIATION_FAILED`.
+  Porting them would swap the API and buy no protocol capability.
+- **MRTR on 2025-era peers keeps working — this is the part the port could have
+  broken in silence.** v2 treats `resultType` as a wire-only discriminator and
+  strips it when it decodes a legacy `tools/call` reply as a complete result,
+  while leaving `inputRequests` in place. Unrepaired, `isInputRequiredResult`
+  goes false, the call is never parked, the human is never asked, and the model
+  is handed the server's holding text as if it were the answer — with nothing
+  red anywhere. `restoreLegacyInputRequired` puts the discriminator back on
+  legacy-era connections only (on a modern one `resultType` arrives verbatim and
+  inventing one would mask a real divergence). Removing it turns eleven tests in
+  `mcpPendingInput.test.ts` red.
+- **Two v2 behaviours are switched off on purpose.** Auto-fulfilment of
+  `input_required` (`inputRequired: { autoFulfill: false }`) — omadia parks the
+  call and asks a *human* over a channel, possibly hours later, and letting the
+  driver answer in-process would mean the human silently stops being asked. And
+  client-side output-schema validation, by fetching `tools/list` with
+  `cacheMode: 'bypass'` — it would turn a server whose `structuredContent` does
+  not match its declared `outputSchema` into a hard call failure on `http` only,
+  and its validator is reachable only through an `ajv` that neither
+  `@modelcontextprotocol/client` nor `/core` declares as a dependency.
+- Coverage runs on **both eras**: the existing live round-trip suite plus a new
+  modern-era assertion against the phase-1 loopback server, and a hand-rolled
+  2025-era peer that refuses `server/discover`.
+
 ### Changed — the loopback MCP server runs on the `@modelcontextprotocol/*@2` family (#562, phase 1)
 
 - **`createMcpHandler` replaces a hand-rolled per-request dance.** The loopback

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -1873,6 +1873,24 @@
         }
       }
     },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@modelcontextprotocol/core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
@@ -3637,6 +3655,7 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"
@@ -9265,6 +9284,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/client": "^2.0.0",
         "@modelcontextprotocol/core": "^2.0.0",
         "@modelcontextprotocol/node": "^2.0.0",
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/middleware/packages/harness-orchestrator/package.json
+++ b/middleware/packages/harness-orchestrator/package.json
@@ -28,6 +28,7 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/core": "^2.0.0",
     "@modelcontextprotocol/node": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.30.0",

--- a/middleware/packages/harness-orchestrator/src/mcp/mcpClient.ts
+++ b/middleware/packages/harness-orchestrator/src/mcp/mcpClient.ts
@@ -35,13 +35,16 @@
 
 import { createHash, randomUUID } from 'node:crypto';
 
+import {
+  Client as ModernClient,
+  StreamableHTTPClientTransport as ModernStreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import {
   StdioClientTransport,
   getDefaultEnvironment,
 } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
@@ -66,7 +69,13 @@ import {
 } from './pendingMcpInput.js';
 
 /**
- * Relaxed CallToolResult schema: the MCP spec says `structuredContent` MUST be a
+ * Relaxed CallToolResult schema for the **v1-backed** transports (`stdio`,
+ * `sse`). The v2 family has no result-schema parameter at all and types
+ * `structuredContent` as `unknown` by spec (SEP-2106), so the `http` path gets
+ * the same leniency without asking for it — see {@link modernSdkSession} for
+ * the one place v2 is stricter than v1 and what that costs.
+ *
+ * The MCP spec says `structuredContent` MUST be a
  * JSON object, but some hosted proxies (e.g. strava.run.mcp.com.ai) return it as
  * an array. The SDK's strict schema rejects the entire result, and callTool then
  * throws — which we surface as "-32000 Connection closed", making every call on
@@ -127,7 +136,7 @@ export type McpTransportKind = 'stdio' | 'http' | 'sse';
  * marketplace importer prefers an `http` remote when a catalog entry offers
  * both. Nothing is hard-blocked: the removal window is open, existing rows
  * keep working unchanged (`SSEClientTransport` stays wired in
- * `McpManager.transportFor`), and the `agent_mcp_servers.transport` CHECK
+ * `McpManager.makeTransport`), and the `agent_mcp_servers.transport` CHECK
  * constraint still accepts `'sse'`, so a legacy server can be re-created.
  *
  * This array is the single source of truth for "which transports are
@@ -435,8 +444,148 @@ function looksTransient(text: string): boolean {
   );
 }
 
+/**
+ * The MCP protocol revision a live connection settled on (issue #562 phase 2).
+ * `'legacy'` is the 2025-era `initialize` handshake, `'modern'` the 2026-07-28
+ * `server/discover` negotiation. `null` means the backing SDK cannot negotiate
+ * at all — the v1 line is frozen at 2025-11-25, so a v1-backed session is
+ * `'legacy'` by construction rather than by measurement.
+ */
+export type McpProtocolEra = 'legacy' | 'modern';
+
+/** The per-request policy `callTool` applies. See {@link resolveMcpCallTimeouts}. */
+interface McpRequestPolicy {
+  readonly timeout: number;
+  readonly resetTimeoutOnProgress: boolean;
+  readonly maxTotalTimeout: number;
+}
+
+/** `tools/call` params, as both SDK families accept them. */
+interface McpCallParams {
+  readonly name: string;
+  readonly arguments: Record<string, unknown>;
+  readonly _meta?: Record<string, unknown>;
+}
+
+/** One `tools/list` entry, typed only as far as `listTools` reads it. Both SDK
+ *  families put the same four fields on the wire; nothing here reshapes them. */
+interface McpToolListEntry {
+  readonly name?: unknown;
+  readonly description?: unknown;
+  readonly inputSchema?: unknown;
+  readonly outputSchema?: unknown;
+}
+
+interface McpListToolsResult {
+  readonly tools?: readonly McpToolListEntry[];
+}
+
+/**
+ * One pooled connection, reduced to the three verbs the manager actually uses.
+ *
+ * Issue #562 phase 2 — omadia now speaks TWO SDK families at once, and this is
+ * the seam between them: `http` connects with `@modelcontextprotocol/client@2`
+ * (which can negotiate the 2026-07-28 era), `stdio` and `sse` stay on the v1
+ * `@modelcontextprotocol/sdk`. Everything above this interface — pooling,
+ * retry, audit, MRTR parking — is family-agnostic and stayed unchanged.
+ *
+ * Why the other two transports did NOT move, measured rather than assumed:
+ * `McpServer` never answers `server/discover` off the HTTP edge, so an `'auto'`
+ * probe on stdio/sse can only ever fall back to `initialize` and a pin fails
+ * with `ERA_NEGOTIATION_FAILED`. Porting them would swap the API and gain no
+ * protocol capability.
+ */
+interface McpSession {
+  /** Which SDK family backs this session. Diagnostics and tests read it. */
+  readonly family: 'v1' | 'v2';
+  /** The negotiated era, once connected. */
+  era(): McpProtocolEra;
+  listTools(): Promise<McpListToolsResult>;
+  callTool(params: McpCallParams, policy: McpRequestPolicy): Promise<unknown>;
+  close(): Promise<void>;
+}
+
 interface Pooled {
-  readonly client: Client;
+  readonly client: McpSession;
+}
+
+/**
+ * v1-backed session (`stdio`, `sse`). Byte-identical to what the manager did
+ * before phase 2, including the lenient result schema.
+ */
+function legacySdkSession(client: Client): McpSession {
+  return {
+    family: 'v1',
+    era: () => 'legacy',
+    listTools: () => client.listTools(),
+    callTool: (params, policy) =>
+      client.callTool(params, LENIENT_CALL_TOOL_RESULT_SCHEMA, policy),
+    close: () => client.close(),
+  };
+}
+
+/**
+ * v2-backed session (`http`), with three deliberate settings. Each one exists
+ * because the alternative was measured and was worse:
+ *
+ *  - **`versionNegotiation: { mode: 'auto' }`, never a pin.** A pin has no
+ *    fallback and most third-party servers are 2025-era, so pinning breaks
+ *    exactly the peers that work today.
+ *  - **`inputRequired: { autoFulfill: false }`.** v2's driver would otherwise
+ *    fulfil an `input_required` result IN-PROCESS against a round limit.
+ *    omadia does not answer these itself — it parks the call and asks a HUMAN
+ *    over a channel, possibly hours later. Auto-fulfilment is not a faster
+ *    version of that; it is a different behaviour in which the human is never
+ *    asked and nothing turns red. Manual mode is the only correct setting here.
+ *  - **`listTools` with `cacheMode: 'bypass'`.** A cached `tools/list` is what
+ *    arms v2's client-side output-schema validation, which turns a server whose
+ *    `structuredContent` does not match its declared `outputSchema` — or which
+ *    declares one and sometimes omits the content — into a HARD `callTool`
+ *    failure. v1 never validated, this file already carries the scar of a
+ *    strict result schema breaking every call on a real server, and the
+ *    validator is only reachable through an `ajv` neither `@modelcontextprotocol
+ *    /client` nor `/core` declares as a dependency. Bypass keeps `http` behaving
+ *    exactly like `stdio`/`sse` instead of diverging by transport.
+ */
+function modernSdkSession(client: ModernClient): McpSession {
+  return {
+    family: 'v2',
+    era: () => (client.getProtocolEra() === 'modern' ? 'modern' : 'legacy'),
+    listTools: () => client.listTools(undefined, { cacheMode: 'bypass' }),
+    async callTool(params, policy) {
+      const res = await client.callTool(params, policy);
+      return restoreLegacyInputRequired(res, client.getProtocolEra());
+    },
+    close: () => client.close(),
+  };
+}
+
+/**
+ * Put back the MRTR discriminator v2 removes on a 2025-era connection.
+ *
+ * MEASURED, and it is the one thing that would have made this port a silent
+ * regression: `resultType` is wire-only in v2's type system, and a LEGACY-era
+ * `tools/call` decode lifts the body to a plain complete result — dropping
+ * `resultType` while leaving `inputRequests` (and `requestState`) in place.
+ * `isInputRequiredResult` therefore goes false, the call is never parked, and
+ * the model is handed the server's holding text as if it were an answer. The
+ * user simply stops being asked, and no test that only checks "the call
+ * returned something" can see it. #570/#544 made MRTR work on exactly these
+ * 2025-era peers; the port is not allowed to take it away again.
+ *
+ * The recovery is evidence-based, not a guess: `inputRequests` is MRTR-only
+ * vocabulary, it does not appear on a complete result, and v2 has already
+ * rejected the body if it carried `inputRequests` without `content`. On a
+ * MODERN connection nothing is restored — there `resultType` arrives verbatim
+ * (with `allowInputRequired`) and inventing one would mask a real divergence.
+ */
+function restoreLegacyInputRequired(res: unknown, era: string | undefined): unknown {
+  if (era === 'modern') return res;
+  if (!isPlainObject(res)) return res;
+  if (res['resultType'] !== undefined) return res;
+  if (res['inputRequests'] === undefined) return res;
+  if (res['isError'] === true) return res;
+  return { ...res, resultType: MCP_RESULT_TYPE_INPUT_REQUIRED };
 }
 
 /** One pooled connection. `promise` is the single source of truth for the
@@ -448,6 +597,16 @@ interface PoolEntry {
 }
 
 const CLIENT_INFO = { name: 'omadia-agent-builder', version: '0.1.0' } as const;
+
+/**
+ * Client options for the v2 (`http`) family. Rationale for each field is on
+ * {@link modernSdkSession}; they live here so a reader sees the whole opt-in
+ * surface in one place rather than spread across a factory.
+ */
+const MODERN_CLIENT_OPTIONS = {
+  versionNegotiation: { mode: 'auto' },
+  inputRequired: { autoFulfill: false },
+} as const;
 
 /**
  * W0-2 — explicit per-call MCP request policy. `callTool` used to pass no
@@ -884,12 +1043,6 @@ export class McpManager {
               ? { _meta: { idempotencyKey: idempotency.key } }
               : {}),
           },
-          // Tolerate off-spec `structuredContent` (some third-party MCP servers —
-          // e.g. the hosted Strava proxy — return it as a JSON array instead of an
-          // object). The strict SDK schema otherwise rejects the whole result and
-          // the failure surfaces to the model as "-32000 Connection closed",
-          // making every tool call on that server look like a transport failure.
-          LENIENT_CALL_TOOL_RESULT_SCHEMA,
           // Stated request policy instead of the SDK's implicit 60s default —
           // see DEFAULT_MCP_CALL_TIMEOUT_MS. `maxTotalTimeout` is the SHARED
           // remainder, not a fresh allowance per attempt, so N attempts still
@@ -1094,10 +1247,19 @@ export class McpManager {
   }
 
   private async connect(cfg: McpServerConfig, token: string | null): Promise<Pooled> {
-    const transport = this.makeTransport(cfg, token);
+    // #562 phase 2 — `http` is the only transport that moved to the v2 family.
+    // The branch is here rather than inside `makeTransport` because the two
+    // families' `Transport` interfaces are NOT interchangeable: a v2 transport
+    // cannot drive a v1 `Client`, and era negotiation lives in the v2 client,
+    // not in its transport. Picking the transport therefore picks the client.
+    if (cfg.transport === 'http') {
+      const client = new ModernClient(CLIENT_INFO, MODERN_CLIENT_OPTIONS);
+      await client.connect(this.makeModernHttpTransport(cfg, token));
+      return { client: modernSdkSession(client) };
+    }
     const client = new Client(CLIENT_INFO);
-    await client.connect(transport);
-    return { client };
+    await client.connect(this.makeTransport(cfg, token));
+    return { client: legacySdkSession(client) };
   }
 
   /** Resolve Vault-backed config into a cfg (epic #459): secret headers for
@@ -1147,19 +1309,38 @@ export class McpManager {
       return new StdioClientTransport({ command, args, ...(env ? { env } : {}) });
     }
     const url = new URL(cfg.endpoint);
-    // Merge the OAuth bearer token (issue #459 W9) with any configured headers;
-    // bearer_methods_supported is 'header' for spec-compliant servers.
-    const headers: Record<string, string> = { ...(cfg.headers ?? {}) };
-    if (token) headers['Authorization'] = `Bearer ${token}`;
-    const requestInit = Object.keys(headers).length > 0 ? { headers } : undefined;
-    if (cfg.transport === 'sse') {
-      return new SSEClientTransport(url, requestInit ? { requestInit } : {});
+    const requestInit = httpRequestInit(cfg, token);
+    return new SSEClientTransport(url, requestInit ? { requestInit } : {});
+  }
+
+  /** The v2 Streamable-HTTP transport (#562 phase 2). Same URL and the same
+   *  merged headers the v1 transport got — `requestInit` is byte-identical
+   *  between the families, so nothing about authentication changed. */
+  private makeModernHttpTransport(
+    cfg: McpServerConfig,
+    token: string | null,
+  ): ModernStreamableHTTPClientTransport {
+    if (!cfg.endpoint) {
+      throw new Error(`MCP server "${cfg.name}" has no endpoint configured`);
     }
-    return new StreamableHTTPClientTransport(
-      url,
+    const requestInit = httpRequestInit(cfg, token);
+    return new ModernStreamableHTTPClientTransport(
+      new URL(cfg.endpoint),
       requestInit ? { requestInit } : {},
     );
   }
+}
+
+/** Merge the OAuth bearer token (issue #459 W9) with any configured headers;
+ *  `bearer_methods_supported` is 'header' for spec-compliant servers. Shared by
+ *  both SDK families so the two HTTP-shaped transports cannot drift. */
+function httpRequestInit(
+  cfg: McpServerConfig,
+  token: string | null,
+): { headers: Record<string, string> } | undefined {
+  const headers: Record<string, string> = { ...(cfg.headers ?? {}) };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return Object.keys(headers).length > 0 ? { headers } : undefined;
 }
 
 // ── adapters ────────────────────────────────────────────────────────────────

--- a/middleware/test/mcpClient.test.ts
+++ b/middleware/test/mcpClient.test.ts
@@ -190,6 +190,100 @@ async function startRecordingProxy(
   };
 }
 
+/** The negotiated era lives on the pooled session, which is private — reach it
+ *  through the same narrow cast `mcpTransportDeprecation.test.ts` uses rather
+ *  than widening the manager's public API for a test. */
+async function pooledSession(
+  manager: McpManager,
+  cfg: McpServerConfig,
+): Promise<{ family: string; era: () => string }> {
+  return (
+    manager as unknown as {
+      getOrConnect(
+        c: McpServerConfig,
+        token: string | null,
+      ): Promise<{ client: { family: string; era: () => string } }>;
+    }
+  )
+    .getOrConnect(cfg, null)
+    .then((pooled) => pooled.client);
+}
+
+/**
+ * A genuine 2025-era Streamable-HTTP peer: hand-rolled JSON-RPC that answers
+ * `initialize` and refuses `server/discover` with `-32601`, exactly as a server
+ * built on the frozen v1 line does. Hand-rolled on purpose — driving the v1 SDK
+ * server here would pin the test to that SDK's own behaviour rather than to the
+ * wire shape the client has to cope with.
+ */
+async function startLegacyEraPeer(): Promise<{ url: string; stop: () => Promise<void> }> {
+  const server = createServer((req, res) => {
+    void (async () => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) {
+        chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk);
+      }
+      const text = Buffer.concat(chunks).toString('utf8');
+      if (req.method !== 'POST' || text === '') {
+        res.writeHead(405).end();
+        return;
+      }
+      const message = JSON.parse(text) as { id?: unknown; method?: string };
+      const reply = (payload: Record<string, unknown>): void => {
+        res.writeHead(200, {
+          'content-type': 'application/json',
+          'mcp-session-id': 'legacy-era-session',
+        });
+        res.end(JSON.stringify({ jsonrpc: '2.0', id: message.id ?? null, ...payload }));
+      };
+      if (message.method === 'initialize') {
+        reply({
+          result: {
+            protocolVersion: '2025-06-18',
+            capabilities: { tools: {} },
+            serverInfo: { name: 'legacy-era-peer', version: '0.0.0' },
+          },
+        });
+        return;
+      }
+      if (message.id === undefined) {
+        res.writeHead(202).end();
+        return;
+      }
+      if (message.method === 'tools/list') {
+        reply({
+          result: {
+            tools: [
+              { name: TOOL, description: 'echo', inputSchema: { type: 'object', properties: {} } },
+            ],
+          },
+        });
+        return;
+      }
+      if (message.method === 'tools/call') {
+        reply({ result: { content: [{ type: 'text', text: 'legacy-pong' }] } });
+        return;
+      }
+      // `server/discover` lands here — a 2025 server has never heard of it.
+      reply({ error: { code: -32601, message: `Method not found: ${String(message.method)}` } });
+    })().catch(() => {
+      if (!res.headersSent) res.writeHead(502);
+      res.end();
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${String(port)}/mcp`,
+    stop: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+
 describe('McpManager against a live MCP server (W0-5)', () => {
   const servers: LoopbackMcpServer[] = [];
   let proxy: RecordingProxy | undefined;
@@ -328,6 +422,53 @@ describe('McpManager against a live MCP server (W0-5)', () => {
       'the retry must drop the pooled connection once so it reconnects fresh',
     );
     assert.deepEqual(seen, [{ name: TOOL, input: { value: 'retry-me' } }]);
+  });
+
+  it('negotiates the MODERN era against a v2 server, on the v2 client family (#562 phase 2)', async (t) => {
+    // The five tests above are the port's real regression net — they were
+    // written against the v1 client and now run, unchanged, over
+    // `@modelcontextprotocol/client@2`. This one pins the thing that is
+    // genuinely NEW: `versionNegotiation: { mode: 'auto' }` probes with
+    // `server/discover` and lands on the 2026-07-28 era against the v2 server
+    // phase 1 landed. Without the probe the same connection would silently be
+    // an ordinary 2025 `initialize` and nothing else here would notice.
+    const url = await startServer(t);
+    if (!url) return;
+
+    manager = new McpManager();
+    const session = await pooledSession(
+      manager,
+      serverConfig(url, { headers: { Authorization: `Bearer ${BEARER}` } }),
+    );
+
+    assert.equal(session.family, 'v2', 'http must connect on the v2 SDK family');
+    assert.equal(session.era(), 'modern', 'an `auto` probe against a v2 server must select 2026-07-28');
+  });
+
+  it('falls back to the LEGACY era against a 2025-era http peer, and still round-trips', async () => {
+    // The other half of the matrix, and the reason the mode is `'auto'` and not
+    // a pin: most third-party servers are 2025-era. A pin has no fallback and
+    // would break exactly these peers. This one answers `server/discover` with
+    // `-32601`, which is what a 2025 server does.
+    const peer = await startLegacyEraPeer();
+    try {
+      manager = new McpManager();
+      const cfg = serverConfig(peer.url, { name: 'legacy-peer' });
+      const session = await pooledSession(manager, cfg);
+
+      assert.equal(session.family, 'v2', 'http is on the v2 client regardless of the peer era');
+      assert.equal(session.era(), 'legacy', 'a server without `server/discover` must fall back');
+
+      const tools = await manager.listTools(cfg);
+      assert.deepEqual(
+        tools.map((tool) => tool.name),
+        [TOOL],
+      );
+      const result = await manager.callTool(cfg, TOOL, { value: 'hello' });
+      assert.equal(result, 'legacy-pong');
+    } finally {
+      await peer.stop();
+    }
   });
 
   it('a stale token invalidates the pool and the next call reconnects and succeeds', async (t) => {

--- a/middleware/test/mcpPendingInput.test.ts
+++ b/middleware/test/mcpPendingInput.test.ts
@@ -635,11 +635,22 @@ async function inTurn<T>(
 }
 
 describe('callTool parks an input_required result (#544 W2-1)', () => {
-  it('reads resultType + inputRequests off the shipped SDK 1.29.0 over a real wire', async () => {
-    // Criterion 1, end to end: both fields survive `tools/call` on the SDK we
-    // actually ship, so MRTR needs no version bump and no v2 family (#540).
+  it('reads resultType + inputRequests off a 2025-era peer over a real wire', async () => {
+    // Criterion 1, end to end: both fields survive `tools/call` against the
+    // era most peers actually run — `startFakeMcpServer` above is hand-rolled
+    // 2025-era JSON-RPC and has never heard of `server/discover`.
     //
-    // NOT labelled a mutation check, deliberately: reverting the
+    // #562 phase 2 moved `transport: 'http'` (which is what `CFG` is) onto
+    // `@modelcontextprotocol/client@2`, so this file now exercises the v2
+    // client against a LEGACY-era peer. That combination is the one the port
+    // could have broken silently: v2 treats `resultType` as a wire-only
+    // discriminator and strips it when it decodes a legacy `tools/call` reply
+    // as a complete result, which would leave `isInputRequiredResult` false,
+    // the call unparked, and the holding text handed to the model as if it
+    // were the answer. `restoreLegacyInputRequired` in `mcpClient.ts` puts the
+    // discriminator back; deleting it turns ELEVEN tests in this file red.
+    //
+    // NOT labelled a mutation check for the schema, deliberately: reverting the
     // `LENIENT_CALL_TOOL_RESULT_SCHEMA` extension leaves this GREEN, because
     // `ResultSchema` is `.passthrough()` (characterized in the test below). The
     // extension makes the dependency explicit and typed rather than possible —
@@ -653,6 +664,24 @@ describe('callTool parks an input_required result (#544 W2-1)', () => {
       out.startsWith(MCP_INPUT_REQUIRED_SENTINEL_PREFIX),
       `resultType/inputRequests were stripped — got: ${out}`,
     );
+  });
+
+  it('MUTATION CHECK: the peer this file drives really is 2025-era (#562 phase 2)', async () => {
+    // Without this, every assertion above would still pass if the fake server
+    // silently became a modern-era peer — and the legacy path, where the
+    // discriminator is stripped and has to be restored, would stop being
+    // covered at all while the file kept reporting green.
+    const h = harness();
+    const session = await (
+      h.manager as unknown as {
+        getOrConnect(
+          cfg: McpServerConfig,
+          token: string | null,
+        ): Promise<{ client: { family: string; era: () => string } }>;
+      }
+    ).getOrConnect(CFG, null);
+    assert.equal(session.client.family, 'v2', 'http connects on the v2 client family');
+    assert.equal(session.client.era(), 'legacy', 'this file must cover the 2025 era');
   });
 
   it('returns a stable sentinel instead of the rendered text', async () => {

--- a/middleware/test/mcpTransportDeprecation.test.ts
+++ b/middleware/test/mcpTransportDeprecation.test.ts
@@ -13,8 +13,8 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
+import { StreamableHTTPClientTransport as ModernStreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import {
   DEPRECATED_MCP_TRANSPORTS,
   isDeprecatedMcpTransport,
@@ -59,6 +59,16 @@ function makeTransport(cfg: McpServerConfig): unknown {
   return (
     manager as unknown as { makeTransport(c: McpServerConfig, token?: string | null): unknown }
   ).makeTransport(cfg);
+}
+
+/** Same narrow cast for the v2 (`http`) factory #562 phase 2 introduced. */
+function makeModernHttpTransport(cfg: McpServerConfig): unknown {
+  const manager = new McpManager();
+  return (
+    manager as unknown as {
+      makeModernHttpTransport(c: McpServerConfig, token: string | null): unknown;
+    }
+  ).makeModernHttpTransport(cfg, null);
 }
 
 function serverConfig(transport: McpTransportKind, endpoint: string): McpServerConfig {
@@ -110,8 +120,21 @@ describe('sse regression — deprecation must not change runtime behaviour (#541
     );
   });
 
-  it('still builds a StreamableHTTPClientTransport for an http server', () => {
-    const transport = makeTransport(serverConfig('http', 'https://modern.example/mcp'));
-    assert.ok(transport instanceof StreamableHTTPClientTransport);
+  it('builds the v2 Streamable-HTTP transport for an http server (#562 phase 2)', () => {
+    const transport = makeModernHttpTransport(serverConfig('http', 'https://modern.example/mcp'));
+    assert.ok(
+      transport instanceof ModernStreamableHTTPClientTransport,
+      'http is the one transport that moved to @modelcontextprotocol/client@2',
+    );
+  });
+
+  it('leaves sse on the v1 family — it is NOT a v2 transport (#562 phase 2)', () => {
+    // Deliberate, and measured rather than assumed: `McpServer` never answers
+    // `server/discover` off the HTTP edge, so an `'auto'` probe on sse can only
+    // fall back to `initialize` and a pin fails outright. Porting sse would
+    // swap the API and buy no protocol capability, so it stays on v1.
+    const transport = makeTransport(serverConfig('sse', 'https://legacy.example/sse'));
+    assert.ok(!(transport instanceof ModernStreamableHTTPClientTransport));
+    assert.ok(transport instanceof SSEClientTransport);
   });
 });


### PR DESCRIPTION
Phase 2 of #562. Phase 1 (#695, `7c86a628`) moved the loopback **server** onto `@modelcontextprotocol/*@2`; this moves the **client**, for `transport: 'http'` only.

## What changed

`McpManager` dials streamable-HTTP servers with the v2 `Client` + `StreamableHTTPClientTransport` and `versionNegotiation: { mode: 'auto' }`. `stdio` and `sse` stay on the v1 SDK.

The two families' `Transport` interfaces are not interchangeable and era negotiation lives in the v2 *client*, not its transport — so picking the transport picks the client. A small `McpSession` seam (`family` / `era()` / `listTools` / `callTool` / `close`) is the only place the two families meet; pooling, retry, audit and MRTR parking above it are unchanged.

**`'auto'`, never a pin.** A pin has no fallback and the majority of third-party servers are 2025-era, so pinning breaks exactly the peers that work today.

**Why `stdio`/`sse` did not move** — measured, not assumed: `McpServer` never answers `server/discover` off the HTTP edge, so an `'auto'` probe there can only ever fall back to `initialize`, and a pin fails with `ERA_NEGOTIATION_FAILED`. Porting them would swap the API and buy no protocol capability.

## The finding that shaped this PR

A straight port would have been a **silent MRTR regression on every 2025-era HTTP peer** — the peers #570/#544 had only just made work.

v2 treats `resultType` as a wire-only discriminator. On a legacy-era connection it decodes a `tools/call` reply as a *complete* result and strips `resultType`, while leaving `inputRequests` (and `requestState`) in place. Measured on a hand-rolled 2025-era peer:

| peer era | wire body | what the caller receives |
|---|---|---|
| legacy | `{content, resultType: 'input_required', inputRequests}` | `{content, inputRequests}` — **`resultType` gone** |
| modern (`allowInputRequired: true`) | same, spec-shaped | `{resultType, inputRequests, requestState}` verbatim |

Unrepaired, `isInputRequiredResult` goes false, the call is never parked, the human is never asked, and the model is handed the server's holding text as if it were the answer — with nothing red anywhere. `restoreLegacyInputRequired` restores the discriminator on legacy connections only (on a modern one it arrives verbatim and inventing one would mask a real divergence). The recovery is evidence-based rather than a guess: `inputRequests` is MRTR-only vocabulary and v2 has already rejected the body if it carried `inputRequests` without `content`.

**Mutation check:** disabling `restoreLegacyInputRequired` turns **11 of 45** tests in `mcpPendingInput.test.ts` red (`dist/` rebuilt first). Restored, 45/45 pass.

## Two v2 behaviours switched off on purpose

- **`inputRequired: { autoFulfill: false }`.** v2's driver would otherwise fulfil an `input_required` result in-process against a round limit. omadia does not answer these itself — it parks the call and asks a *human* over a channel, possibly hours later. Auto-fulfilment is not a faster version of that; it is a different behaviour in which the human is never asked and nothing turns red.
- **`listTools(..., { cacheMode: 'bypass' })`.** A cached `tools/list` is what arms v2's client-side output-schema validation, which turns a server whose `structuredContent` does not match its declared `outputSchema` — or which declares one and sometimes omits the content — into a hard `callTool` failure. v1 never validated; making that true on `http` alone is transport-dependent divergence. Its validator is also reachable only through an `ajv` that neither `@modelcontextprotocol/client` nor `/core` declares as a dependency (it resolves today only because something else in the tree hoists it).

## Coverage

- The five existing live round-trip tests in `mcpClient.test.ts` are unmodified and now run over the v2 client — that is the regression net for the port itself.
- New: the `http` connection negotiates **modern** against the phase-1 loopback server, on `family === 'v2'`.
- New: a hand-rolled **2025-era** peer that answers `server/discover` with `-32601` negotiates `legacy` and still round-trips `listTools` + `callTool`.
- New mutation check in `mcpPendingInput.test.ts` pins that its fake server really is legacy-era, so that file cannot silently stop covering the stripped-discriminator path.
- `mcpTransportDeprecation.test.ts` now asserts both halves: `http` builds the v2 transport, `sse` is explicitly *not* a v2 transport.

## Verification

- `npm run build` — clean
- `npm run typecheck` — clean
- `npm run typecheck:test` — 406 known errors, no regressions (baseline 406)
- `npm run lint` — clean
- `npm test` — **6405 pass / 0 fail / 12 skipped** (6417 tests, 1340 suites)

## Out of scope

Phase 3 (MRTR against the declared contract: `allowInputRequired`, `requestState`, and teaching the parser the spec's map-shaped `inputRequests`) follows in its own PR. `tasks/*` stays out in every form — #543 is closed as superseded.

Refs #562

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789282548&installation_model_id=428086&pr_number=697&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F697&signature=5796db60644772da2afb3cd8f8efddd5135cac46a1d6aee66c363e85c129e0fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->