### PR TITLE
fix(#696): thread the Fly lease nonce so the updater stops blocking itself

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,28 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — the Fly updater was blocked by its own lease (#696)
+
+- **Applying an update on Fly always failed and rolled back.** `replace()`
+  leases the Machine, and Fly gates every write to a leased Machine behind the
+  `fly-machine-lease-nonce` header — which was sent nowhere. `updateMachine`
+  declared `leaseNonce` in its signature but never read it, the engine never
+  passed it, and the HTTP helper had no way to carry a header at all. Every
+  real update therefore came back
+  `409 aborted: … lease currently held by …@tokens.fly.io` and rolled back,
+  seconds after taking that lease itself. Threaded end to end now: per-call
+  headers on the client, the nonce on the update, the lease from the engine.
+- **The lease is handed back in a `finally`.** It was acquired and abandoned,
+  so it kept blocking writes for the rest of its 300s TTL — which also meant
+  the rollback after a failed update hit the same 409, and the machine stayed
+  locked against a human `fly deploy` for minutes.
+- **The test fake now enforces the lease.** It returned a nonce and ignored it
+  on writes, so it could not produce Fly's 409 and 263 lines of green tests
+  said the path worked. It now rejects an unnonced write and validates the
+  nonce on release. New wire-level `flyApi.test.mjs` asserts against the bytes
+  an HTTP server actually receives, because a fake can only ever prove the
+  engine *passes* a value, never that the client *sends* it.
+
 ### Added — one-click updates on Fly.io (#696, follow-up to #432)
 
 - **A Fly executor for the rolling self-update.** Fly Machines are Firecracker

--- a/middleware/sidecars/updater/src/engine/fly.mjs
+++ b/middleware/sidecars/updater/src/engine/fly.mjs
@@ -39,9 +39,7 @@ export function createFlyEngine({ config, api, manifestCheck = manifestExists })
   function appFor(service) {
     const app = config.flyApps?.[service];
     if (typeof app !== 'string' || app.length === 0) {
-      throw new Error(
-        `no Fly app configured for service "${service}" — set UPDATER_FLY_APPS`,
-      );
+      throw new Error(`no Fly app configured for service "${service}" — set UPDATER_FLY_APPS`);
     }
     return app;
   }
@@ -55,9 +53,7 @@ export function createFlyEngine({ config, api, manifestCheck = manifestExists })
     async resolveTarget(service) {
       const app = appFor(service);
       const machines = await api.listMachines(app);
-      const live = machines.filter(
-        (m) => m?.state !== 'destroyed' && m?.config?.image,
-      );
+      const live = machines.filter((m) => m?.state !== 'destroyed' && m?.config?.image);
       if (live.length === 0) {
         throw new Error(`no machine found for Fly app "${app}"`);
       }
@@ -123,23 +119,44 @@ export function createFlyEngine({ config, api, manifestCheck = manifestExists })
       }
       if (lease !== null) log(`leased ${app}/${machineId}`);
 
-      // Read-then-change-one-field. Never build this object from scratch.
-      const machine = await api.getMachine(app, machineId);
-      const current = machine?.config;
-      if (current === undefined || current === null) {
-        throw new Error(`machine ${app}/${machineId} returned no config to update`);
+      try {
+        // Read-then-change-one-field. Never build this object from scratch.
+        const machine = await api.getMachine(app, machineId);
+        const current = machine?.config;
+        if (current === undefined || current === null) {
+          throw new Error(`machine ${app}/${machineId} returned no config to update`);
+        }
+
+        log(`updating ${app}/${machineId} → ${image}`);
+        await api.updateMachine(app, machineId, {
+          config: { ...current, image },
+          ...(typeof machine.instance_id === 'string'
+            ? { currentVersion: machine.instance_id }
+            : {}),
+          // The lease we just took gates this write. Passing it is what makes
+          // the update possible at all; without it Fly answers 409 and we are
+          // blocked by our own lease.
+          ...(lease !== null ? { leaseNonce: lease } : {}),
+        });
+
+        log(`waiting for ${app}/${machineId} to start`);
+        await api.waitForState(app, machineId, 'started');
+      } finally {
+        // Always hand the lease back — including on the failure path. An
+        // abandoned lease keeps blocking writes for the rest of its TTL, so
+        // the rollback that follows a failed update would hit 409 as well and
+        // the machine would stay locked against `fly deploy` for minutes.
+        if (lease !== null) {
+          try {
+            await api.releaseLease(app, machineId, lease);
+            log(`released lease on ${app}/${machineId}`);
+          } catch (err) {
+            log(
+              `could not release the lease on ${app}/${machineId}: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
       }
-
-      log(`updating ${app}/${machineId} → ${image}`);
-      await api.updateMachine(app, machineId, {
-        config: { ...current, image },
-        ...(typeof machine.instance_id === 'string'
-          ? { currentVersion: machine.instance_id }
-          : {}),
-      });
-
-      log(`waiting for ${app}/${machineId} to start`);
-      await api.waitForState(app, machineId, 'started');
     },
   };
 }

--- a/middleware/sidecars/updater/src/flyApi.mjs
+++ b/middleware/sidecars/updater/src/flyApi.mjs
@@ -26,6 +26,15 @@ export class FlyApiError extends Error {
 }
 
 /**
+ * The header Fly gates writes to a leased Machine on. One definition, used by
+ * both the write path and the release path, so the two can never drift.
+ *
+ * @param {string} nonce
+ * @returns {Record<string, string>}
+ */
+const LEASE_HEADER = (nonce) => ({ 'fly-machine-lease-nonce': nonce });
+
+/**
  * @param {{ baseUrl?: string, tokenFor: (app: string) => string, timeoutMs?: number }} opts
  */
 export function createFlyApi(opts) {
@@ -38,13 +47,12 @@ export function createFlyApi(opts) {
    * @param {string} method
    * @param {string} path
    * @param {unknown} [body]
-   * @param {{ timeoutMs?: number }} [callOpts]
+   * @param {{ timeoutMs?: number, headers?: Record<string, string> }} [callOpts]
    * @returns {Promise<{ statusCode: number, body: string }>}
    */
   function raw(app, method, path, body, callOpts = {}) {
     return new Promise((resolve, reject) => {
-      const payload =
-        body === undefined ? undefined : Buffer.from(JSON.stringify(body));
+      const payload = body === undefined ? undefined : Buffer.from(JSON.stringify(body));
       const req = transport.request(
         {
           protocol: base.protocol,
@@ -61,6 +69,11 @@ export function createFlyApi(opts) {
                   'content-length': String(payload.byteLength),
                 }
               : {}),
+            // Per-call headers last: a lease nonce must be able to ride along
+            // on writes to a leased Machine. Without a way to send it here the
+            // caller's nonce has nowhere to go and Fly rejects the write with
+            // 409 "lease currently held by" — its own lease.
+            ...(callOpts.headers ?? {}),
           },
           timeout: callOpts.timeoutMs ?? timeoutMs,
         },
@@ -86,7 +99,8 @@ export function createFlyApi(opts) {
 
   /**
    * @param {string} app @param {string} method @param {string} path
-   * @param {unknown} [body] @param {{ timeoutMs?: number }} [callOpts]
+   * @param {unknown} [body]
+   * @param {{ timeoutMs?: number, headers?: Record<string, string> }} [callOpts]
    * @returns {Promise<any>}
    */
   async function json(app, method, path, body, callOpts) {
@@ -108,9 +122,7 @@ export function createFlyApi(opts) {
   return {
     /** @param {string} app @returns {Promise<any[]>} */
     async listMachines(app) {
-      return (
-        (await json(app, 'GET', `/v1/apps/${encodeURIComponent(app)}/machines`)) ?? []
-      );
+      return (await json(app, 'GET', `/v1/apps/${encodeURIComponent(app)}/machines`)) ?? [];
     },
 
     /** @param {string} app @param {string} id @returns {Promise<any>} */
@@ -131,6 +143,10 @@ export function createFlyApi(opts) {
      * single field they mean to change. `current_version` makes a concurrent
      * change fail loudly instead of being overwritten.
      *
+     * `leaseNonce` is REQUIRED whenever the Machine is leased — which is the
+     * normal case here, because `replace()` leases it first. It travels as the
+     * `fly-machine-lease-nonce` header, not in the body.
+     *
      * @param {string} app @param {string} id
      * @param {{ config: any, currentVersion?: string, leaseNonce?: string }} input
      */
@@ -141,11 +157,16 @@ export function createFlyApi(opts) {
         `/v1/apps/${encodeURIComponent(app)}/machines/${encodeURIComponent(id)}`,
         {
           config: input.config,
-          ...(input.currentVersion !== undefined
-            ? { current_version: input.currentVersion }
-            : {}),
+          ...(input.currentVersion !== undefined ? { current_version: input.currentVersion } : {}),
         },
-        { timeoutMs: 5 * 60_000 },
+        {
+          timeoutMs: 5 * 60_000,
+          // Writing to a LEASED Machine requires the lease nonce. Omitting it
+          // makes Fly answer 409 "lease currently held by …" — and since the
+          // caller takes the lease itself moments earlier, the updater ends up
+          // blocked by its own lease and every update rolls back.
+          ...(input.leaseNonce ? { headers: LEASE_HEADER(input.leaseNonce) } : {}),
+        },
       );
     },
 
@@ -176,6 +197,27 @@ export function createFlyApi(opts) {
       );
       const nonce = res?.data?.nonce ?? res?.nonce;
       return typeof nonce === 'string' ? nonce : null;
+    },
+
+    /**
+     * Hand the lease back.
+     *
+     * Not cosmetic: an unreleased lease keeps blocking writes for the rest of
+     * its TTL, so a failed run would lock the machine against its own retry
+     * (and against a human running `fly deploy`) for minutes afterwards.
+     * Releasing also needs the nonce — a lease can only be dropped by whoever
+     * holds it.
+     *
+     * @param {string} app @param {string} id @param {string} nonce
+     */
+    async releaseLease(app, id, nonce) {
+      await json(
+        app,
+        'DELETE',
+        `/v1/apps/${encodeURIComponent(app)}/machines/${encodeURIComponent(id)}/lease`,
+        undefined,
+        { headers: LEASE_HEADER(nonce) },
+      );
     },
   };
 }

--- a/middleware/sidecars/updater/test/_fakeFlyApi.mjs
+++ b/middleware/sidecars/updater/test/_fakeFlyApi.mjs
@@ -18,6 +18,8 @@ export function createFakeFlyApi(options = {}) {
 
   const calls = [];
   const machines = new Map();
+  /** app -> nonce currently holding the lease. Mirrors Fly's real gate. */
+  const leases = new Map();
   let nextId = 1;
 
   for (const [app, image] of Object.entries(apps)) {
@@ -60,7 +62,24 @@ export function createFakeFlyApi(options = {}) {
     },
 
     async updateMachine(app, id, input) {
-      calls.push({ op: 'update', app, id, config: input.config, currentVersion: input.currentVersion });
+      calls.push({
+        op: 'update',
+        app,
+        id,
+        config: input.config,
+        currentVersion: input.currentVersion,
+        leaseNonce: input.leaseNonce,
+      });
+      // Fly gates every write on a LEASED machine behind the lease nonce. A
+      // fake that skips this check cannot fail when the caller forgets to send
+      // it — which is exactly how the missing nonce shipped green.
+      const held = leases.get(app);
+      if (held !== undefined && input.leaseNonce !== held) {
+        throw new Error(
+          `fly api POST /v1/apps/${app}/machines/${id} → 409: ` +
+            `{"error":"aborted: machine ID ${id} lease currently held by tokens.fly.io"}`,
+        );
+      }
       if (failUpdateFor !== null && String(input.config.image).includes(failUpdateFor)) {
         throw new Error(`update ${app}/${id} failed: image not found`);
       }
@@ -77,7 +96,25 @@ export function createFakeFlyApi(options = {}) {
     async acquireLease(app, id) {
       calls.push({ op: 'lease', app, id });
       if (leaseThrows) throw new Error('lease unavailable');
-      return `nonce-${id}`;
+      if (leases.has(app)) {
+        throw new Error(`lease on ${app}/${id} is already held`);
+      }
+      const nonce = `nonce-${id}`;
+      leases.set(app, nonce);
+      return nonce;
+    },
+
+    async releaseLease(app, id, nonce) {
+      calls.push({ op: 'release', app, id, nonce });
+      const held = leases.get(app);
+      if (held === undefined) throw new Error(`no lease held on ${app}/${id}`);
+      if (held !== nonce) throw new Error(`wrong nonce for the lease on ${app}/${id}`);
+      leases.delete(app);
+    },
+
+    /** Test helper: is a lease still outstanding? */
+    leaseHeld(app) {
+      return leases.get(app) ?? null;
     },
   };
 }

--- a/middleware/sidecars/updater/test/flyApi.test.mjs
+++ b/middleware/sidecars/updater/test/flyApi.test.mjs
@@ -1,0 +1,114 @@
+/**
+ * Wire-level tests for the Fly Machines client.
+ *
+ * WHY THESE EXIST. `flyEngine.test.mjs` drives a fake API object, so it can
+ * only prove that the engine *passes* a lease nonce. It cannot prove the
+ * client puts it on the wire — and that gap is precisely where the bug lived:
+ * `updateMachine` declared `leaseNonce` in its signature and never sent it, so
+ * every real update came back `409 lease currently held by …` and rolled back
+ * while 263 lines of green tests said otherwise.
+ *
+ * These tests therefore assert against the ORACLE — the bytes an HTTP server
+ * actually receives — not against a value stored in a mock.
+ */
+
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { after, before, describe, it } from 'node:test';
+
+import { createFlyApi } from '../src/flyApi.mjs';
+
+/** Requests the stub server saw, newest last. */
+const seen = [];
+let server;
+let baseUrl;
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => {
+      seen.push({
+        method: req.method,
+        url: req.url,
+        headers: req.headers,
+        body: Buffer.concat(chunks).toString('utf8'),
+      });
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ data: { nonce: 'nonce-from-fly' } }));
+    });
+  });
+  await new Promise((resolve) => {
+    // Bind an explicit IPv4 host: `listen(0)` alone can land on IPv6-only and
+    // the client would dial a port nothing reserved.
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(() => new Promise((resolve) => server.close(resolve)));
+
+const api = () => createFlyApi({ baseUrl, tokenFor: () => 'tok-abc', timeoutMs: 5_000 });
+
+const lastRequest = () => seen[seen.length - 1];
+
+describe('flyApi — lease nonce on the wire', () => {
+  it('sends fly-machine-lease-nonce when updating a leased machine', async () => {
+    await api().updateMachine('app1', 'm1', {
+      config: { image: 'img:2' },
+      currentVersion: 'v1',
+      leaseNonce: 'nonce-xyz',
+    });
+
+    const req = lastRequest();
+    assert.equal(req.method, 'POST');
+    assert.equal(req.headers['fly-machine-lease-nonce'], 'nonce-xyz');
+  });
+
+  it('omits the header when there is no lease', async () => {
+    await api().updateMachine('app1', 'm1', { config: { image: 'img:2' } });
+
+    assert.equal(lastRequest().headers['fly-machine-lease-nonce'], undefined);
+  });
+
+  it('keeps auth and content-type alongside the nonce', async () => {
+    await api().updateMachine('app1', 'm1', {
+      config: { image: 'img:3' },
+      leaseNonce: 'nonce-xyz',
+    });
+
+    const req = lastRequest();
+    assert.equal(req.headers.authorization, 'Bearer tok-abc');
+    assert.equal(req.headers['content-type'], 'application/json');
+    assert.equal(req.headers['fly-machine-lease-nonce'], 'nonce-xyz');
+  });
+
+  it('sends the config and current_version in the body, not the nonce', async () => {
+    await api().updateMachine('app1', 'm1', {
+      config: { image: 'img:4', mounts: [{ volume: 'vol_1' }] },
+      currentVersion: 'inst-9',
+      leaseNonce: 'nonce-xyz',
+    });
+
+    const body = JSON.parse(lastRequest().body);
+    assert.deepEqual(body.config, { image: 'img:4', mounts: [{ volume: 'vol_1' }] });
+    assert.equal(body.current_version, 'inst-9');
+    assert.equal(body.leaseNonce, undefined);
+  });
+
+  it('releases a lease with DELETE and the nonce', async () => {
+    await api().releaseLease('app1', 'm1', 'nonce-xyz');
+
+    const req = lastRequest();
+    assert.equal(req.method, 'DELETE');
+    assert.match(req.url, /\/v1\/apps\/app1\/machines\/m1\/lease$/);
+    assert.equal(req.headers['fly-machine-lease-nonce'], 'nonce-xyz');
+  });
+
+  it('reads the nonce out of the lease response envelope', async () => {
+    const nonce = await api().acquireLease('app1', 'm1', 300);
+
+    assert.equal(nonce, 'nonce-from-fly');
+    assert.match(lastRequest().url, /\/lease\?ttl=300$/);
+  });
+});

--- a/middleware/sidecars/updater/test/flyEngine.test.mjs
+++ b/middleware/sidecars/updater/test/flyEngine.test.mjs
@@ -67,10 +67,7 @@ describe('fly engine — resolving targets', () => {
   it('ignores destroyed machines when counting', async () => {
     const api = createFakeFlyApi();
     const original = api.machines.get('omadia-middleware-x');
-    api.listMachines = async () => [
-      { ...original, id: 'm-old', state: 'destroyed' },
-      original,
-    ];
+    api.listMachines = async () => [{ ...original, id: 'm-old', state: 'destroyed' }, original];
     const engine = createFlyEngine({ config: CONFIG, api, manifestCheck: ok });
 
     const target = await engine.resolveTarget('middleware');
@@ -121,13 +118,42 @@ describe('fly engine — replacing a machine', () => {
     assert.equal(update.currentVersion, `01HVERSION${target.handle.machineId}`);
   });
 
-  it('takes a lease first and waits for the machine to start', async () => {
+  it('takes a lease first, waits for the machine to start, then releases', async () => {
     const target = await engine.resolveTarget('middleware');
     await engine.replace(target, 'img:2', (m) => logs.push(m));
 
     const sequence = flyOps(api);
     assert.ok(sequence.indexOf('lease') < sequence.indexOf('update'));
-    assert.equal(sequence[sequence.length - 1], 'wait');
+    assert.ok(sequence.indexOf('update') < sequence.indexOf('wait'));
+    // The lease must be handed back last, not abandoned: it would keep
+    // blocking writes for the rest of its TTL otherwise.
+    assert.equal(sequence[sequence.length - 1], 'release');
+    assert.equal(api.leaseHeld('omadia-middleware-x'), null);
+  });
+
+  it('sends the lease nonce with the update, or Fly rejects its own lease', async () => {
+    const target = await engine.resolveTarget('middleware');
+    await engine.replace(target, 'img:2', (m) => logs.push(m));
+
+    // The regression this guards: the nonce was declared in updateMachine's
+    // signature but threaded from nowhere, so every real update came back
+    // 409 "lease currently held by …" and rolled back.
+    const update = api.calls.find((c) => c.op === 'update');
+    const lease = api.calls.find((c) => c.op === 'lease');
+    assert.equal(update.leaseNonce, `nonce-${lease.id}`);
+  });
+
+  it('releases the lease even when the update fails', async () => {
+    const failing = createFakeFlyApi({ failUpdateFor: 'boom' });
+    const e = createFlyEngine({ config: CONFIG, api: failing, manifestCheck: ok });
+    const target = await e.resolveTarget('middleware');
+
+    await assert.rejects(() => e.replace(target, 'boom:1', (m) => logs.push(m)));
+
+    // Without this the rollback that follows a failed update hits 409 too,
+    // and the machine stays locked against `fly deploy` for the full TTL.
+    assert.ok(flyOps(failing).includes('release'));
+    assert.equal(failing.leaseHeld('omadia-middleware-x'), null);
   });
 
   it('continues without a lease rather than refusing to update', async () => {


### PR DESCRIPTION
Applying an update from Admin → Update on Fly has never worked. Found by running it against a real deployment; the job log is at the bottom.

## The bug

`replace()` leases the Machine first, and Fly gates **every write to a leased Machine** behind the `fly-machine-lease-nonce` header. The nonce was threaded from nowhere:

| Layer | State on `main` |
|---|---|
| `engine/fly.mjs:118` | acquires the lease into `let lease` … |
| `engine/fly.mjs:134` | … and calls `updateMachine()` with `config` + `currentVersion` only — **never the lease** |
| `flyApi.mjs:137` | `updateMachine` declares `leaseNonce` in its JSDoc param type — **zero occurrences in the body** |
| `flyApi.mjs:92` | `json()` / `raw()` have **no headers parameter**, so there was no transport for it either way |

So the updater took a lease and was then rejected by that same lease, seconds later:

```
leased odoo-bot-middleware/78419dec230468
updating odoo-bot-middleware/78419dec230468 → ghcr.io/byte5ai/omadia-middleware:v0.79.0
replace failed: fly api POST /v1/apps/.../machines/... → 409:
  {"error":"aborted: machine ID ... lease currently held by <id>@tokens.fly.io,
   expires at 2026-08-14T09:57:35Z"}
rolling back
```

A second defect sits behind it: **the lease was never released**. It was acquired and abandoned, so it kept blocking writes for the rest of its 300s TTL — the rollback that follows a failed update hit the same 409, and the machine stayed locked against a human `fly deploy` for minutes. The `expires at 09:57:35` in the log is exactly `09:52:35 + LEASE_TTL_SECONDS`.

## The fix

- `raw()` accepts per-call `headers`; `json()` passes them through.
- `updateMachine` sends `fly-machine-lease-nonce` when a nonce is supplied. One `LEASE_HEADER` helper, shared with the release path so the two cannot drift.
- `replace()` passes its lease to the update, and hands it back in a `finally` — including on the failure path.
- New `releaseLease(app, id, nonce)` (`DELETE …/lease`), which also needs the nonce: a lease can only be dropped by its holder.

No behaviour change on the Docker engine; nothing outside `sidecars/updater` is touched.

## Why the existing tests were green

`test/_fakeFlyApi.mjs` returned `nonce-${id}` from `acquireLease` and then **ignored it on writes**. It could not produce Fly's 409, so 263 lines of tests asserted a path that could never work against the real API.

Two changes close that:

1. **The fake now models the gate** — it tracks the outstanding lease, rejects an unnonced or mismatched write with a 409-shaped error, and validates the nonce on release. This alone makes the pre-existing tests fail on `main`'s code.
2. **New `flyApi.test.mjs` tests the wire.** A fake can only prove the engine *passes* a value; it can never prove the client *sends* it — and that is the exact gap the bug lived in. These tests run a real `http` server and assert on the headers and body it receives.

## Verification

`node --test 'sidecars/updater/test/*.test.mjs'` → **90 pass, 0 fail** (was 82).

Each part of the fix was mutation-checked — the mutation was applied, verified to have landed, the suite run, then restored:

| Mutation | Tests that fail |
|---|---|
| Drop the header from `updateMachine` | 2 — both wire-level |
| Stop passing `leaseNonce` from the engine | 5 — incl. 3 pre-existing, now that the fake enforces the lease |
| Stop releasing the lease | 4 — incl. **2 rollback tests I did not write**, confirming the abandoned lease really does break rollback |

Restored: 90/90 green again.

## How to test this yourself

**1. Unit + wire tests**

```bash
cd middleware
node --test 'sidecars/updater/test/*.test.mjs'
```

**2. Confirm the tests actually catch it** — put the bug back and watch them fail:

```bash
# remove the header again
perl -0pi -e 's/\.\.\.\(input\.leaseNonce \? \{ headers: LEASE_HEADER\(input\.leaseNonce\) \} : \{\}\),//' \
  middleware/sidecars/updater/src/flyApi.mjs
cd middleware && node --test 'sidecars/updater/test/*.test.mjs'   # expect: 2 failures
git checkout -- sidecars/updater/src/flyApi.mjs
```

**3. End to end against a real Fly deployment.** The published `omadia-updater` images do not contain this fix yet, so build and push the sidecar from this branch, then point the updater app at it:

```bash
BRANCH_TAG=ghcr.io/byte5ai/omadia-updater:lease-nonce-test

docker build -t "$BRANCH_TAG" middleware/sidecars/updater
docker push "$BRANCH_TAG"

fly deploy --app <your-updater-app> --config fly/updater.fly.toml \
  --image "$BRANCH_TAG" --ha=false
```

Then open **Admin → Update** and apply a release. Expected in the job log, where it previously died with 409:

```
leased <app>/<machine>
updating <app>/<machine> → ghcr.io/byte5ai/omadia-middleware:vX.Y.Z
waiting for <app>/<machine> to start
released lease on <app>/<machine>
```

Sanity check that no lease is left behind afterwards — this should print nothing:

```bash
fly machine status <machine-id> --app <app> | grep -i lease
```

**4. The failure path.** Aim it at a tag that does not exist. It must roll back cleanly *and* still release the lease, so a retry works immediately instead of waiting out the TTL.

## Not addressed here

`pinPersisted: false` is unrelated and stays true: `fly deploy` reads the operator's local `fly.toml`, so a later routine deploy still reverts a UI-applied update. That is already surfaced in the UI and in `docs/upgrading.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789293904&installation_model_id=428086&pr_number=705&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F705&signature=a30166881b61bea3b96fc1dafa1bc3f8349c79a373b48fd2517920249225c70d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->