### PR TITLE
fix(#696): cap the Fly machine-wait at the API limit and roll back what was really replaced

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,27 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — the Fly updater asked for a wait longer than Fly allows (#696)
+
+- **`/wait?timeout=120` is rejected outright.** Fly caps the machine-wait at
+  60s and answers anything larger with
+  `400 invalid WaitMachineRequest.Timeout: value must be inside range
+  [1s, 1m0s]` — asking for more does not buy a longer wait, it buys no wait at
+  all. `waitForState`'s 120s default therefore failed every update on the step
+  right after the image was written. Found on a real deployment, once the
+  lease-nonce fix let the update get that far. The request is now capped at the
+  API maximum and re-issued until the caller's own budget is spent, and the
+  machine's state is re-read and checked explicitly instead of trusting the
+  long-poll's timeout semantics — a `/wait` that errors is not the oracle.
+- **A "rolled back" job now really rolls back.** `replace()` can fail *past the
+  point of mutation*: on Fly the machine is already carrying the new image when
+  the wait step throws. The bookkeeping entry was written only after `replace()`
+  returned, so that case left `replaced` empty, rollback restored nothing, and
+  the operator was told the update had been rolled back while the service ran
+  the new build — exactly what happened in production. The entry is now recorded
+  before the call; restoring an image the service never left is a no-op, so
+  pessimistic bookkeeping is safe in the other direction.
+
 ### Fixed — the Fly updater was blocked by its own lease (#696)
 
 - **Applying an update on Fly always failed and rolled back.** `replace()`

--- a/middleware/sidecars/updater/src/flyApi.mjs
+++ b/middleware/sidecars/updater/src/flyApi.mjs
@@ -34,6 +34,9 @@ export class FlyApiError extends Error {
  */
 const LEASE_HEADER = (nonce) => ({ 'fly-machine-lease-nonce': nonce });
 
+/** Hard ceiling Fly enforces on `/wait?timeout=` — `[1s, 1m0s]`, 400 above it. */
+const FLY_MAX_WAIT_SECONDS = 60;
+
 /**
  * @param {{ baseUrl?: string, tokenFor: (app: string) => string, timeoutMs?: number }} opts
  */
@@ -171,20 +174,57 @@ export function createFlyApi(opts) {
     },
 
     /**
-     * Block until a Machine reaches a state. Fly caps this server-side; the
-     * caller still runs its own health gate afterwards, because "started" only
-     * means the VM booted, not that the new build is serving.
+     * Block until a Machine reaches a state. The caller still runs its own
+     * health gate afterwards, because "started" only means the VM booted, not
+     * that the new build is serving.
+     *
+     * Fly rejects a `timeout` above 60s outright:
+     * `400 invalid WaitMachineRequest.Timeout: value must be inside range
+     * [1s, 1m0s]`. Asking for more does not get you a longer wait, it gets you
+     * no wait at all — which is how a 120s default turned every update into a
+     * failed one. So the request is capped at the API's maximum and re-issued
+     * until the caller's own budget runs out.
+     *
+     * A wait that returns without reaching the state is not an error, so the
+     * machine is re-read and its state checked explicitly rather than trusting
+     * the endpoint's timeout semantics.
      *
      * @param {string} app @param {string} id @param {string} state @param {number} [seconds]
      */
     async waitForState(app, id, state, seconds = 120) {
-      const query = new URLSearchParams({ state, timeout: String(seconds) });
-      await json(
-        app,
-        'GET',
-        `/v1/apps/${encodeURIComponent(app)}/machines/${encodeURIComponent(id)}/wait?${query.toString()}`,
-        undefined,
-        { timeoutMs: (seconds + 30) * 1000 },
+      const budgetMs = Math.max(1, seconds) * 1000;
+      const startedAt = Date.now();
+      let lastError = null;
+
+      for (;;) {
+        const remainingS = Math.ceil((budgetMs - (Date.now() - startedAt)) / 1000);
+        if (remainingS <= 0) break;
+
+        const slice = Math.min(FLY_MAX_WAIT_SECONDS, remainingS);
+        const query = new URLSearchParams({ state, timeout: String(slice) });
+        try {
+          await json(
+            app,
+            'GET',
+            `/v1/apps/${encodeURIComponent(app)}/machines/${encodeURIComponent(id)}/wait?${query.toString()}`,
+            undefined,
+            { timeoutMs: (slice + 30) * 1000 },
+          );
+        } catch (err) {
+          lastError = err;
+        }
+
+        const machine = await json(
+          app,
+          'GET',
+          `/v1/apps/${encodeURIComponent(app)}/machines/${encodeURIComponent(id)}`,
+        );
+        if (machine?.state === state) return;
+      }
+
+      throw new FlyApiError(
+        `machine ${app}/${id} did not reach "${state}" within ${seconds}s` +
+          (lastError instanceof Error ? `: ${lastError.message}` : ''),
       );
     },
 

--- a/middleware/sidecars/updater/src/updateJob.mjs
+++ b/middleware/sidecars/updater/src/updateJob.mjs
@@ -86,8 +86,16 @@ export async function runUpdate(opts) {
   const replaced = [];
   try {
     for (const target of targets) {
-      await engine.replace(target, target.newImage, log);
+      // Recorded BEFORE the call, not after. `replace()` can fail *past the
+      // point of mutation* — on Fly the machine is already carrying the new
+      // image when the wait-for-started step throws — and a bookkeeping entry
+      // written only on success makes that invisible: rollback finds nothing
+      // to restore and the operator is told "rolled back" while the service
+      // is running the new build. Recording pessimistically is safe in the
+      // other direction, because restoring an image the service never left is
+      // a no-op.
       replaced.push({ service: target.service, previousImage: target.currentImage });
+      await engine.replace(target, target.newImage, log);
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/middleware/sidecars/updater/test/_fakeFlyApi.mjs
+++ b/middleware/sidecars/updater/test/_fakeFlyApi.mjs
@@ -14,6 +14,10 @@ export function createFakeFlyApi(options = {}) {
     },
     failUpdateFor = null,
     leaseThrows = false,
+    // Fail the wait-for-started step, i.e. AFTER the machine already carries
+    // the new image. This is the shape the real 400 on `/wait?timeout=120`
+    // had, and the one that made rollback a no-op.
+    waitThrows = false,
   } = options;
 
   const calls = [];
@@ -91,6 +95,12 @@ export function createFakeFlyApi(options = {}) {
 
     async waitForState(app, id, state) {
       calls.push({ op: 'wait', app, id, state });
+      if (waitThrows) {
+        throw new Error(
+          `fly api GET /v1/apps/${app}/machines/${id}/wait?state=${state}&timeout=120 → 400: ` +
+            `{"error":"invalid_argument: invalid WaitMachineRequest.Timeout"}`,
+        );
+      }
     },
 
     async acquireLease(app, id) {

--- a/middleware/sidecars/updater/test/flyApi.test.mjs
+++ b/middleware/sidecars/updater/test/flyApi.test.mjs
@@ -23,6 +23,23 @@ const seen = [];
 let server;
 let baseUrl;
 
+/**
+ * Stub behaviour the individual tests steer.
+ *
+ * `machineStates` is consumed one entry per `GET …/machines/<id>` so a test can
+ * say "not started yet, not started yet, started" and assert that the client
+ * keeps waiting instead of giving up after one round.
+ */
+let machineStates = [];
+/** Status code the `/wait` endpoint answers with. Fly 400s on timeout > 60. */
+let waitStatus = 200;
+
+function resetStub() {
+  seen.length = 0;
+  machineStates = [];
+  waitStatus = 200;
+}
+
 before(async () => {
   server = http.createServer((req, res) => {
     const chunks = [];
@@ -34,6 +51,33 @@ before(async () => {
         headers: req.headers,
         body: Buffer.concat(chunks).toString('utf8'),
       });
+
+      if (req.url.includes('/wait?')) {
+        const timeout = Number(new URL(req.url, 'http://x').searchParams.get('timeout'));
+        // Mirror the real API's hard ceiling rather than accepting anything.
+        if (timeout > 60 || timeout < 1) {
+          res.writeHead(400, { 'content-type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              error:
+                'invalid_argument: invalid WaitMachineRequest.Timeout: value must be inside range [1s, 1m0s]',
+            }),
+          );
+          return;
+        }
+        res.writeHead(waitStatus, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+        return;
+      }
+
+      // A machine read: hand out the next scripted state, keeping the last.
+      if (/\/machines\/[^/?]+$/.test(req.url) && req.method === 'GET') {
+        const state = machineStates.length > 1 ? machineStates.shift() : machineStates[0];
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ id: 'm1', state: state ?? 'started', config: {} }));
+        return;
+      }
+
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ data: { nonce: 'nonce-from-fly' } }));
     });
@@ -110,5 +154,57 @@ describe('flyApi — lease nonce on the wire', () => {
 
     assert.equal(nonce, 'nonce-from-fly');
     assert.match(lastRequest().url, /\/lease\?ttl=300$/);
+  });
+});
+
+describe('flyApi — waiting for a machine state', () => {
+  const waitRequests = () => seen.filter((r) => r.url.includes('/wait?'));
+  const timeoutsAsked = () =>
+    waitRequests().map((r) => Number(new URL(r.url, 'http://x').searchParams.get('timeout')));
+
+  it('never asks for more than Fly allows, even with a larger budget', async () => {
+    resetStub();
+    machineStates = ['started'];
+
+    await api().waitForState('app1', 'm1', 'started', 120);
+
+    // The regression: a 120s default was sent verbatim and Fly answered
+    // `400 invalid WaitMachineRequest.Timeout … [1s, 1m0s]`, so the update
+    // step that followed never ran and the whole job rolled back.
+    assert.ok(timeoutsAsked().length > 0, 'it must actually call /wait');
+    for (const t of timeoutsAsked()) {
+      assert.ok(t >= 1 && t <= 60, `timeout ${t} is outside Fly's [1s, 60s]`);
+    }
+  });
+
+  it('keeps waiting until the machine reports the state', async () => {
+    resetStub();
+    machineStates = ['starting', 'starting', 'started'];
+
+    await api().waitForState('app1', 'm1', 'started', 180);
+
+    assert.ok(
+      waitRequests().length >= 2,
+      'a single 60s slice cannot cover a longer budget — it must re-issue',
+    );
+  });
+
+  it('gives up with a clear error when the budget is spent', async () => {
+    resetStub();
+    machineStates = ['starting'];
+
+    await assert.rejects(
+      () => api().waitForState('app1', 'm1', 'started', 1),
+      /did not reach "started" within 1s/,
+    );
+  });
+
+  it('survives a /wait that errors, as long as the machine got there', async () => {
+    resetStub();
+    waitStatus = 500;
+    machineStates = ['started'];
+
+    // A failing long-poll is not the oracle; the machine's own state is.
+    await api().waitForState('app1', 'm1', 'started', 5);
   });
 });

--- a/middleware/sidecars/updater/test/flyEngine.test.mjs
+++ b/middleware/sidecars/updater/test/flyEngine.test.mjs
@@ -222,6 +222,32 @@ describe('fly engine — end to end through runUpdate', () => {
     );
   });
 
+  it('rolls back a machine whose replace failed AFTER the image was written', async () => {
+    // The shape that hit production: the update landed, the wait-for-started
+    // step then failed, and because the bookkeeping entry was only written on
+    // success there was nothing to roll back. The job reported "rolled back"
+    // while the machine was serving the new build.
+    const api = createFakeFlyApi({ waitThrows: true });
+    const engine = createFlyEngine({ config: CONFIG, api, manifestCheck: ok });
+    const before = api.machines.get('omadia-middleware-x').config.image;
+
+    const result = await runUpdate({
+      engine,
+      config: CONFIG,
+      targetVersion: 'v0.75.0',
+      log,
+      healthWaiter: async () => ({ ok: true, reason: 'version_match' }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.rolledBack, true);
+    assert.equal(
+      api.machines.get('omadia-middleware-x').config.image,
+      before,
+      'a "rolled back" job must actually leave the previous image running',
+    );
+  });
+
   it('rolls both apps back when the health gate fails', async () => {
     const api = createFakeFlyApi();
     const engine = createFlyEngine({ config: CONFIG, api, manifestCheck: ok });


### PR DESCRIPTION
Follow-up to #705. Both defects were found the same way: by running an update from Admin → Update against a real Fly deployment, which #705 finally made possible.

The lease fix worked — the job got all the way to the step *after* the image was written, and died there:

```
leased odoo-bot-middleware/78419dec230468
updating odoo-bot-middleware/78419dec230468 → ghcr.io/byte5ai/omadia-middleware:v0.79.1
waiting for odoo-bot-middleware/78419dec230468 to start
released lease on odoo-bot-middleware/78419dec230468
replace failed: fly api GET /v1/apps/.../wait?state=started&timeout=120 → 400:
  {"error":"invalid_argument: invalid WaitMachineRequest.Timeout: value must be inside range [1s, 1m0s]"}
rolling back
```

## 1 — the wait asked for more than Fly allows

`waitForState(app, id, state, seconds = 120)` sent that 120 verbatim. Fly caps the machine-wait at **60s** and rejects anything larger with a 400 — asking for more does not buy a longer wait, it buys **no wait at all**. So every update failed on the step right after the image was written.

The existing doc comment even said *"Fly caps this server-side"*; the number was simply never reconciled with the limit.

Now: the request is capped at `FLY_MAX_WAIT_SECONDS = 60` and re-issued until the caller's own budget is spent. After each slice the machine is **re-read and its state checked explicitly**, instead of inferring success from the long-poll returning — a `/wait` that errors is not the oracle, the machine's own state is. That also makes the client survive a flaky long-poll.

## 2 — "rolled back" rolled nothing back

Look at the log again: the job reported a rollback, but the middleware ended up **on the new version** and stayed there. Prod was left split — middleware `v0.79.1`, web-ui `v0.75.0`.

The cause is bookkeeping order in `updateJob.mjs`:

```js
for (const target of targets) {
  await engine.replace(target, target.newImage, log);
  replaced.push({ service: target.service, previousImage: target.currentImage });  // ← only on success
}
```

`replace()` can fail **past the point of mutation** — on Fly the machine already carries the new image when the wait step throws. The entry is then never recorded, `rollback()` iterates an empty list, and the operator is told the update was rolled back while the service runs the new build. That is the worst possible failure report: it is confidently wrong in the direction that stops you from looking.

The entry is now recorded **before** the call. Restoring an image the service never left is a no-op, so pessimistic bookkeeping is safe in the other direction.

## Verification

`node --test 'sidecars/updater/test/*.test.mjs'` → **95 pass, 0 fail** (was 90).

Both fixes mutation-checked — mutation applied, verified landed, suite run, restored:

| Mutation | Tests that fail |
|---|---|
| send the full budget as the wait timeout again | 2 (`never asks for more than Fly allows`, + its suite) |
| move `replaced.push` back after `replace()` | 2 (`rolls back a machine whose replace failed AFTER the image was written`, + its suite) |

Restored: 95/95 green.

Two test-harness changes were needed to make these failures expressible at all:

- the wire-level stub now **mirrors Fly's 400** on an out-of-range `timeout` instead of accepting anything, and serves scripted machine states so "not started yet → started" can be asserted;
- `_fakeFlyApi` gained `waitThrows`, which is the only way to reproduce a failure *after* the image was written.

## How to test this yourself

**1. Unit + wire tests**

```bash
cd middleware
node --test 'sidecars/updater/test/*.test.mjs'
```

**2. Confirm the tests catch it** — put each bug back and watch the matching test fail:

```bash
# (a) uncap the wait
perl -0pi -e 's/const slice = Math\.min\(FLY_MAX_WAIT_SECONDS, remainingS\);/const slice = seconds;/' \
  middleware/sidecars/updater/src/flyApi.mjs
cd middleware && node --test 'sidecars/updater/test/*.test.mjs'   # expect: "never asks for more than Fly allows" fails
git checkout -- sidecars/updater/src/flyApi.mjs
```

For (b), swap the `replaced.push(...)` line back to *after* `await engine.replace(...)` in `updateJob.mjs` — `rolls back a machine whose replace failed AFTER the image was written` must fail.

**3. End to end on a real Fly deployment.** The published images do not carry this yet, so build the sidecar from this branch:

```bash
BRANCH_TAG=ghcr.io/byte5ai/omadia-updater:wait-timeout-test

docker build -t "$BRANCH_TAG" middleware/sidecars/updater
docker push "$BRANCH_TAG"

fly deploy --app <your-updater-app> --config fly/updater.fly.toml \
  --image "$BRANCH_TAG" --ha=false
```

Then apply a release from Admin → Update. Expected, where it previously died at the wait:

```
leased <app>/<machine>
updating <app>/<machine> → ghcr.io/byte5ai/omadia-middleware:vX.Y.Z
waiting for <app>/<machine> to start
released lease on <app>/<machine>
… same for web-ui …
waiting for <health-url> to report vX.Y.Z
```

and both apps end on the new version:

```bash
curl -s https://<middleware-host>/health | jq .version
fly image show --app <web-ui-app>
```

**4. The rollback path.** Point the updater at a release whose middleware image exists but whose health gate will not pass (e.g. block the health URL). The job must report `rolled_back` **and** leave both apps on the previous image — that is the property #2 restores. Before this change, a failure during the wait left the new image running while claiming a rollback.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789296333&installation_model_id=428086&pr_number=706&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F706&signature=a5633a3f89977680bf320dd39f2c55c28cfc07ab221b5ab47c812b7ce13db17b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->