### PR TITLE
fix(#709): anchor the resume/reaper test on the store's own clock

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,29 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — the resume/reaper conformance test raced the wall clock
+
+- **`a RESUMED task survives the reaper` could fail for reasons unrelated to
+  the behaviour it guards.** It aged a parked task by `sleep(120)`, resumed it,
+  and then swept with `staleAfterMs: 60` using the reaper's *default real-time*
+  `now`. That left a 60ms budget between `provideInput` returning and the sweep
+  running: any stall longer than that — a GC pause, a loaded CI box, the serial
+  Postgres job sharing a runner — aged the freshly reset heartbeat past its own
+  window, so the reaper failed the task and the test went red while the code
+  was correct. Reproduced deterministically by inserting an 80ms stall before
+  the sweep.
+- The sweep now takes an explicit `now` anchored on the resume's own
+  `updatedAt`. `provideInput` writes `updatedAt` and `lastHeartbeatAt` in one
+  statement, so that timestamp comes from the same clock that stamped the row —
+  the database's for the durable store, the process's for the in-memory one —
+  and the comparison no longer depends on how long the test itself takes. With
+  the fix the test survives even a 3s injected stall.
+- `updatedAt` is the anchor precisely because it stays correct when the
+  behaviour regresses: dropping the `lastHeartbeatAt` reset still advances
+  `updatedAt`, so the frozen heartbeat lands outside the window and the test
+  goes red. Verified by mutation against **both** stores — in-memory and real
+  Postgres.
+
 ### Fixed — the rest of the test servers now bind the port they dial (#707)
 
 - **The remaining 57 `listen(0)` sites are converted.** #703 fixed the

--- a/middleware/test/tasks/taskStoreConformance.ts
+++ b/middleware/test/tasks/taskStoreConformance.ts
@@ -292,10 +292,27 @@ export function runTaskStoreConformance(
         'provideInput advanced lastHeartbeatAt past creation',
       );
 
-      // Reap immediately with a window (60ms) that sits BETWEEN the frozen
-      // pre-park heartbeat (~120ms old) and the just-reset one (~0ms old). Uses
-      // the reaper's default real-time `now`, so both stores' wall clocks agree.
+      // Reap with a window (60ms) that sits BETWEEN the frozen pre-park
+      // heartbeat (>=120ms before the resume) and the just-reset one.
+      //
+      // `now` is anchored on the resume's OWN timestamp rather than the wall
+      // clock. `provideInput` writes `updatedAt` and `lastHeartbeatAt` in one
+      // statement, so `updatedAt` marks the instant of the resume in whichever
+      // clock the store uses — the database's for the durable store, the
+      // process's for the in-memory one — which is the same clock the row's
+      // `lastHeartbeatAt` was stamped by. Reading the default real-time `now`
+      // instead left a 60ms budget between `provideInput` returning and the
+      // sweep running: a GC pause or a loaded CI box aged the freshly reset
+      // heartbeat past its own window and failed this test for reasons that had
+      // nothing to do with the behaviour under test.
+      //
+      // `updatedAt` is the right anchor precisely because it stays correct when
+      // the behaviour under test regresses: drop the `lastHeartbeatAt` reset and
+      // `updatedAt` still advances, so the frozen heartbeat lands outside the
+      // window and this test goes red — which is the whole point of it.
+      const resumeAt = Date.parse(afterResume.updatedAt);
       const result = await store.reapOrphans({
+        now: new Date(resumeAt + 30),
         staleAfterMs: 60,
         purgeTerminalAfterMs: HOUR_MS,
       });


### PR DESCRIPTION
Closes #709. Follow-up to the CI-flake work in #703 / #708 — different mechanism, same class: a test whose pass/fail depended on how long the test process itself took.

## The race

`a RESUMED task survives the reaper: provideInput resets the liveness clock` aged a parked task by `sleep(120)`, resumed it, then swept with `staleAfterMs: 60` and **no `now`** — so the reaper used real time.

That left a **60ms budget** between `provideInput` returning and the sweep running. Any stall longer than that aged the *freshly reset* heartbeat past its own window, the reaper failed the task, and the test went red while the code under test was correct. The suite runs against both stores, so it exposed the normal `npm test` run and the `schema (migrations on pgvector)` job.

## Reproduction — deterministic

An 80ms stall before the sweep, standing in for a GC pause or a loaded runner:

| | in-memory store | real Postgres |
|---|---|---|
| **before**, +80ms stall | ✖ `the resumed task is NOT abandoned` | ✖ same |
| **after**, +80ms stall | ✔ | ✔ |
| **after**, +3000ms stall | ✔ | — |

The 3s case is the point: the race is *eliminated*, not widened.

## The fix

```ts
const resumeAt = Date.parse(afterResume.updatedAt);
const result = await store.reapOrphans({
  now: new Date(resumeAt + 30),
  staleAfterMs: 60,
  purgeTerminalAfterMs: HOUR_MS,
});
```

`provideInput` writes `updatedAt` and `lastHeartbeatAt` in a **single statement** in both stores (`last_heartbeat_at = now(), updated_at = now()` in SQL; `lastHeartbeatAt: ts, updatedAt: ts` in memory). So `updatedAt` is stamped by the same clock as the heartbeat it is compared against — the database's for the durable store, the process's for the in-memory one. That matters: `reapOrphans` computes its cutoff in JS while the durable store's rows are stamped by Postgres, so an anchor invented in the test process would not be in the row's clock domain. This one is.

## Why not the obvious alternatives

- **Lengthen the sleep / widen the window** — only makes the race rarer and slows the suite. The budget still exists.
- **Pass an arbitrary `now`** — breaks the cross-clock property above.
- **Drop the reaper assertion** — loses the regression coverage this test exists for.

## The anchor is not a tautology

`updatedAt` was chosen precisely because it stays correct when the guarded behaviour regresses: remove the `lastHeartbeatAt` reset and `updatedAt` still advances, so the frozen pre-park heartbeat lands outside the window and the test goes red.

Mutation-checked both ways:

| Store | mutation | result |
|---|---|---|
| in-memory | drop `lastHeartbeatAt: ts` from `provideInput` | ✖ test red |
| Postgres | drop `last_heartbeat_at = now()` from the resume UPDATE | ✖ `the resumed task is NOT abandoned` |

Both restored afterwards; only the test file and the changelog are in this diff.

## Verification

| Gate | Result |
|---|---|
| `npm run test` | green **×2**, 6459 tests, 0 fail, 0 cancelled |
| pg conformance (real pgvector, throwaway DB) | 15/15 |
| `npm run typecheck:test` | baseline 406, no regressions |
| `npm run lint` | clean |
| `core decoupling ratchet (#470)` | held at 3294 |
| `PG_TEST_FLOOR` | unchanged at 269 — no pg tests added or removed |

The Postgres run used a scratch `flakeprobe` database created and dropped inside the existing dev container, so no developer data was touched.

No lengthened sleeps, no retries, no timeout bumps, no skips.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789458291&installation_model_id=428086&pr_number=710&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F710&signature=0f003e1203924f391fca6db6bd2037e0db3f557cd3e18b989c1987b12d314720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->