### PR TITLE
docs(#575): correct the producer inventory from the private plugin repo (closes D6)

### DIFF
--- a/specs/575-scope-and-identity-foundation/spec.md
+++ b/specs/575-scope-and-identity-foundation/spec.md
@@ -2,9 +2,15 @@
 
 > **Status: DRAFT — awaiting sign-off. This document implements nothing.**
 > Phase 1 (code) is not authorized until the decisions in §8 are answered.
+>
+> **Rev 2** — after PR #711 merged, the private plugin repo (`omadia-byte5-plugins`
+> @ `7dcce57`) was inspected, which **closed D6 and corrected two findings in Rev 1**: the
+> two production channels bypass `CoreApi` and build their own `sessionScope`, and
+> `'teams-unknown'` has a live producer. See §2.2. New open item **D7**.
 
-**Measured against `origin/main` @ `e4e892e7`.** Every `file:line` in this document was
-re-read at that commit; §9 lists what I could *not* verify.
+**Measured against `origin/main` @ `e4e892e7`** (OSS tree) **and `omadia-byte5-plugins`
+@ `7dcce57`** (private plugins). Every `file:line` in this document was re-read at those
+commits; §10 lists what remains unverified.
 
 ---
 
@@ -49,23 +55,42 @@ collision that will land on `main` before #575 does — see decision **D5**.
 | HTTP chat, explicit `scope` | `routes/chat.ts:52` | `` `http-${scope}` `` |
 | HTTP chat, `sessionId` | `routes/chat.ts:53` | bare `sessionId`, `[A-Za-z0-9_-]{1,80}` |
 | HTTP chat, anonymous | `routes/chat.ts:54` | **`'http-default'`** — shared by *every* anonymous caller |
-| Channel turn (all channels) | `channels/coreApi.ts:80` | `` `${channelId}::${conversationId}` `` |
+| `CoreApi` channel path | `channels/coreApi.ts:80` | `` `${channelId}::${conversationId}` `` |
+| **Teams (private plugin)** | `omadia-byte5-plugins` `channel-teams/src/teamsBot.ts:441` | `` `teams-${conversationId}` ``, with `conversationId ?? 'unknown'` at `:440` |
+| **Telegram (private plugin)** | `omadia-byte5-plugins` `channel-telegram/src/telegramBot.ts:993` | `` `telegram:${chat.id}` `` |
 | Routine run | `plugins/routines/routineRunner.ts:671,707` | `` `routine:${routine.id}` `` |
 | Schedule run | `scheduler/scheduleWorker.ts:119` | `` `schedule:${scheduleId}` `` |
 | Conductor step | `conductor/realStepEffects.ts:116` | `` `conductor:${runId}:${step.id}` `` |
 | Conductor builder | `conductor/builderAgent.ts:189` | `` `conductor-builder:${slug}:${uuid}` `` |
 | Orchestrator fallback | `turnContext.ts:84` (doc) | the turn id, when the caller supplied none |
 
-Three separator conventions coexist: `-` (`http-…`), `::` (channels), `:` (machine scopes).
-A fourth shape — the bare `sessionId` — has no separator at all and is therefore
-**indistinguishable from a scope kind name** by inspection.
+**Five** separator conventions coexist: `-` (`http-…`, `teams-…`), `::` (`CoreApi`), `:`
+(machine scopes, `telegram:`), and the bare `sessionId` with no separator at all — the last
+being **indistinguishable from a scope kind name** by inspection.
 
-> **Finding — two denylist entries have no producer.** `'teams-unknown'` and `'unknown'`
-> (`directLineSticky.ts:70`) are emitted **nowhere** in the tree: grep over
-> `middleware/src` + `middleware/packages`, excluding the denylist itself and tests,
-> returns **0** hits. They defend against values that either never existed or came from a
-> since-removed adapter. **Caveat before deleting:** the private byte5 channel plugins ship
-> as gitignored `dist/`, so a producer could live in `omadia-byte5-plugins`. See **D6**.
+> ### ⚠️ The two production channels bypass `CoreApi` and build their own scope
+>
+> **This corrects the first published version of this document** (PR #711), which listed
+> `channels/coreApi.ts:80` as the producer for "all channels" and reported the
+> `directLineSticky` denylist entries as dead. Measured in `~/sources/omadia-byte5-plugins`
+> @ `7dcce57`:
+>
+> - Neither `channel-teams` nor `channel-telegram` calls `coreApi.handleTurnStream` at all
+>   (0 hits for `handleTurnStream` / `coreApi.` in either package's `src/`). They construct
+>   `sessionScope` themselves. **`${channelId}::${conversationId}` is therefore not the
+>   shape real channel traffic carries** — it is the shape the in-tree `CoreApi` path would
+>   produce for a channel that used it.
+> - **`'teams-unknown'` has a live producer.** `teamsBot.ts:440-441` is
+>   `const conversationId = context.activity.conversation?.id ?? 'unknown'` followed by
+>   `` const sessionScope = `teams-${conversationId}` ``. When Teams omits a conversation id,
+>   the scope is literally `teams-unknown`. **The denylist entry is load-bearing, not dead —
+>   it must not be deleted, it must be expressed in the type.**
+> - `'unknown'` **bare** still has no observed producer, in either repo.
+>
+> **This is a second live instance of the `'http-default'` hole, in production Teams**: every
+> Teams turn that arrives without a conversation id shares one scope. Today `SHARED_SCOPES`
+> is the only thing preventing a sticky binding from leaking across those callers — which is
+> precisely why §3(b) makes "no resolvable scope" a *type* rather than a value.
 
 ### 2.3 The hardest constraint: the graph key is a *lossy* projection
 
@@ -157,7 +182,8 @@ against the values measured in §2.2:
 | qm form | omadia value that maps to it | Verdict |
 |---|---|---|
 | `personal:<id>` | *none* — no producer emits a per-person scope today | **NEW** |
-| `channel:<ref>` | `` `${channelId}::${conversationId}` `` | maps (separator must change) |
+| `channel:<ref>` | `` `${channelId}::${conversationId}` `` (CoreApi), `` `teams-${conversationId}` ``, `` `telegram:${chat.id}` `` | maps — but **three** incompatible spellings, see §2.2 |
+| — | `'teams-unknown'` (Teams with no conversation id) | ❌ **does not map** — same class as `http-default` |
 | `group:<ref>` | *none* | NEW |
 | `team:<id>` | *none* | NEW — and undistinguished from `group:` |
 | `org:<id>` | *none* | NEW |
@@ -390,11 +416,12 @@ two-meanings-of-scope ambiguity in the setup surface.
 | ID | Decision | Recommendation | If deferred |
 |---|---|---|---|
 | **D1** | `ScopeId` shape — 6 variants incl. `system:` and `unscoped`, `conversation` over `channel`, drop `team` | §3 | Phase 1 cannot start |
-| **D2** | Does `sessionScope: string` change in the **published** channel-SDK contract? | **No** — keep `string` at the plugin boundary, type internally; parse at ingress | breaks byte5 private plugins across a repo boundary, silently |
+| **D2** | Does `sessionScope: string` change in the **published** channel-SDK contract? | **No** — keep `string` at the plugin boundary, type internally; parse at ingress. *Now measured:* consumed in both private plugins' `kernel-types.ts` and ~25 call sites in `teamsBot.ts` | breaks byte5 private plugins across a repo boundary, silently |
 | **D3** | Does the graph scope key become injective? | **Yes — but as its own PR *before* scope becomes a security boundary** | a silent cross-scope isolation bug (§2.3) |
 | **D4** | Mid-turn joiner: snapshot vs re-evaluate | **split by reversibility** — snapshot rendered context, re-evaluate egress | Phase 2 is undefined |
 | **D5** | Ask sneumannb5 to rename `security_posture_scope` → `security_posture_override` | **yes**, before #681 merges | permanent name collision in the setup surface |
-| **D6** | Confirm `'teams-unknown'` / `'unknown'` have no producer in `omadia-byte5-plugins` | check before deleting the denylist | deleting the denylist breaks a live private channel |
+| **D6** | ~~Confirm `'teams-unknown'` / `'unknown'` have no producer in `omadia-byte5-plugins`~~ | ✅ **RESOLVED by measurement — answer was NO.** `teams-unknown` has a live producer (`teamsBot.ts:440-441`); the denylist entry must be **expressed in the type, never deleted**. See §2.2. | — |
+| **D7** | *(new, raised by D6)* Do the private channel plugins keep building `sessionScope` themselves, or move onto the typed resolver? | **move them** — otherwise `ScopeId` governs only the paths that were already safe, and the two real production channels stay untyped | the type is decorative for actual channel traffic |
 
 ---
 
@@ -424,10 +451,15 @@ its description.
 
 **Not verified — carry as open risk:**
 
-1. **Private byte5 plugins were not inspected.** `omadia-byte5-plugins` is a separate
-   repository; `harness-channel-teams` / `-telegram` exist here only as gitignored `dist/`.
-   Producers of scope values, and consumers of the `sessionScope` plugin contract, may exist
-   there. This is why **D2** and **D6** are decisions rather than findings.
+1. ~~**Private byte5 plugins were not inspected.**~~ ✅ **Now inspected**
+   (`~/sources/omadia-byte5-plugins` @ `7dcce57`) — and the risk materialized. It produced
+   two corrections to the first published version of this document: the two production
+   channels **bypass `CoreApi`** and build their own scope, and **`'teams-unknown'` has a
+   live producer**, so the denylist entry is load-bearing rather than dead (§2.2). It also
+   confirmed **D2**: `sessionScope?: string` is consumed in both plugins' `kernel-types.ts`
+   (`channel-teams/src/kernel-types.ts:204`, `channel-telegram/src/kernel-types.ts:105`) and
+   threaded through ~25 call sites in `teamsBot.ts` alone — keeping `string` at the plugin
+   boundary is now measured, not assumed. New open item: **D7**.
 2. **The 6/10 decision-vs-mechanical split in §4 is a judgement**, made by reading each
    call site's role, not by attempting the migration. A mechanical entry could turn out to
    need a decision.


### PR DESCRIPTION
Follow-up to #711. Closes **D6** by measuring `~/sources/omadia-byte5-plugins` @ `7dcce57` —
the repository #711 explicitly flagged as uninspected in its §10 open-risk list.

**The risk materialized.** D6 asked whether the `directLineSticky` denylist entries have a
producer in the private plugins. The answer is **yes**, which corrects two findings in Rev 1.

## Correction 1 — the two production channels bypass `CoreApi`

Rev 1 listed `channels/coreApi.ts:80` (`` `${channelId}::${conversationId}` ``) as the
producer for "all channels". Neither production channel uses it: **0 hits** for
`handleTurnStream` or `coreApi.` in `channel-teams/src/` and `channel-telegram/src/`. Both
build the scope themselves:

| Channel | Producer | Shape |
|---|---|---|
| Teams | `channel-teams/src/teamsBot.ts:441` | `` `teams-${conversationId}` `` |
| Telegram | `channel-telegram/src/telegramBot.ts:993` | `` `telegram:${chat.id}` `` |

So `${channelId}::${conversationId}` is the shape the *in-tree* `CoreApi` path would produce,
not the shape real channel traffic carries. **Five** separator conventions coexist, not three.

## Correction 2 — `'teams-unknown'` is live, not dead

Rev 1 reported it as having zero producers and therefore a candidate for deletion.
`teamsBot.ts:440-441`:

```ts
const conversationId = context.activity.conversation?.id ?? 'unknown';
const sessionScope = `teams-${conversationId}`;
```

A Teams turn arriving without a conversation id yields exactly `teams-unknown`. **The
denylist entry is load-bearing and must be expressed in the type, never deleted.**

This is a **second live instance of the `'http-default'` shared-scope hole, in production
Teams**: every such turn shares one scope, and `SHARED_SCOPES` is currently the only thing
stopping a sticky binding from leaking across those callers. It is the strongest argument yet
for §3(b) — "no resolvable scope" must be a *type*, not a value.

`'unknown'` bare still has no observed producer in either repo.

## Also settled

- **D2 confirmed by measurement, no longer an assumption.** `sessionScope?: string` is
  consumed in both plugins' `kernel-types.ts` (`channel-teams:204`, `channel-telegram:105`)
  and threaded through ~25 call sites in `teamsBot.ts` alone. Keeping `string` at the plugin
  boundary is the right call.
- **New D7 raised:** do the private plugins move onto the typed resolver? If they do not,
  `ScopeId` governs only the paths that were already safe while the two real production
  channels stay untyped.

## Test plan

- [x] Docs-only; no code, no tests affected.
- [x] Every new `file:line` read at `omadia-byte5-plugins` @ `7dcce57`.
- [x] Bypass claim verified as an absence (0 hits for `handleTurnStream`/`coreApi.` in both plugin `src/` trees), not inferred.

## Risk / blast radius

None — one markdown file under `specs/`.

> Rev 2 of a document still awaiting sign-off. D1, D3, D4, D5 and now D7 remain open; D2 and
> D6 are now answered.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789476932&installation_model_id=428086&pr_number=712&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F712&signature=d476aca75bce44e7c7c23b9088831c1e295aa1426282891f8431ab487d31b85a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->