### PR TITLE
feat(#575): ScopeId, and directLineSticky drops both denylists

### DIFF
--- a/middleware/packages/harness-channel-sdk/src/index.ts
+++ b/middleware/packages/harness-channel-sdk/src/index.ts
@@ -193,3 +193,20 @@ export type {
   ChannelKeyDirectory,
   ChannelKeyEntry,
 } from './channelKeyDirectory.js';
+
+// #575 Phase 1 — the typed session scope. Lives in the channel SDK because it
+// is consumed by the orchestrator, the kernel AND the channel plugins, and this
+// package is the leaf all three already depend on. `sessionScope` stays a
+// `string` on the plugin-facing contract (spec §8 D2); the type is produced and
+// consumed internally by parsing at ingress.
+export {
+  SHARED_SCOPE_TOKENS,
+  SYSTEM_SCOPE_ORIGINS,
+  formatSessionScope,
+  isAddressableScope,
+  parseSessionScope,
+  scopeGraphKey,
+  type ScopeId,
+  type SystemScopeOrigin,
+  type UnscopedReason,
+} from './scopeId.js';

--- a/middleware/packages/harness-channel-sdk/src/scopeId.ts
+++ b/middleware/packages/harness-channel-sdk/src/scopeId.ts
@@ -1,0 +1,244 @@
+/**
+ * #575 Phase 1 — `ScopeId`: the typed form of a turn's session scope.
+ *
+ * Today `sessionScope` is a bare `string` used as the partition key for memory,
+ * the knowledge graph, sticky Direct Line bindings and parked MCP input. Five
+ * different producers spell it five different ways, and two of those spellings
+ * (`'http-default'`, `'teams-unknown'`) are SHARED buckets that several distinct
+ * callers land in — the cross-user hole #445 had to paper over with a denylist.
+ *
+ * The measured producer inventory and the reasoning behind this shape live in
+ * `specs/575-scope-and-identity-foundation/spec.md` (§2.2, §3).
+ *
+ * Two design commitments make this safe to introduce:
+ *
+ *  1. **"No resolvable scope" is a TYPE, not a value.** `unscoped` forces every
+ *     consumer to decide what to do about it instead of silently sharing a
+ *     bucket. It carries `reason` because absence and shared-bucket are
+ *     genuinely different: an absent scope can never be redeemed, a shared one
+ *     can be made per-person by pairing it with a user id.
+ *  2. **Machine scopes are their own kind.** `routine:`/`schedule:`/`conductor:`
+ *     have no audience at all — no human is present — so "the rights of everyone
+ *     present" is undefined for them rather than merely restrictive. Modelling
+ *     them as a variant is what lets `directLineSticky` delete its
+ *     `SYNTHETIC_SCOPE_PREFIXES` denylist instead of renaming it.
+ *
+ * Everything here is pure and synchronous.
+ */
+
+import { createHash } from 'node:crypto';
+
+/** Machine-driven scope origins. No human is present in any of them. */
+export type SystemScopeOrigin = 'routine' | 'schedule' | 'conductor' | 'conductor-builder';
+
+/**
+ * The recognised machine origins.
+ *
+ * Order is deliberately NOT load-bearing, and that is a property worth stating
+ * because it is easy to assume otherwise: `'conductor'` and `'conductor-builder'`
+ * look like an overlapping-prefix hazard, but `parseSessionScope` matches on
+ * `` `${origin}:` `` — and `'conductor-builder:x'` does not start with
+ * `'conductor:'`, because the character after `conductor` is `-`, not `:`. The
+ * trailing colon is what makes the set unambiguous.
+ *
+ * (Verified by mutation: reordering this array leaves the suite green. If a
+ * future change drops the trailing colon from the match, order becomes
+ * load-bearing again and the `conductor-builder` case in `scopeId.test.ts`
+ * fails — which is the guard that actually matters.)
+ */
+export const SYSTEM_SCOPE_ORIGINS: readonly SystemScopeOrigin[] = Object.freeze([
+  'conductor-builder',
+  'conductor',
+  'routine',
+  'schedule',
+]);
+
+/**
+ * Scope strings that are NOT per-conversation — several unrelated callers land
+ * in each. Measured producers:
+ *
+ *  - `'http-default'`  — `middleware/src/routes/chat.ts:54`, for any caller that
+ *    sends neither `scope` nor `sessionId`.
+ *  - `'teams-unknown'` — `omadia-byte5-plugins` `channel-teams/src/teamsBot.ts:440-441`,
+ *    `conversation?.id ?? 'unknown'` folded into `` `teams-${conversationId}` ``.
+ *  - `'unknown'`       — no observed producer in either repository, retained
+ *    because it costs nothing and its absence is not provable across every
+ *    deployment's plugin set.
+ */
+export const SHARED_SCOPE_TOKENS: ReadonlySet<string> = new Set([
+  'http-default',
+  'teams-unknown',
+  'unknown',
+]);
+
+/** Why a scope carries no addressable audience. */
+export type UnscopedReason =
+  /** No scope was supplied at all. Cannot be redeemed by anything. */
+  | 'absent'
+  /** A shared bucket several callers land in. A user id can make it per-person. */
+  | 'shared';
+
+export type ScopeId =
+  | { readonly kind: 'personal'; readonly userId: string }
+  | {
+      readonly kind: 'conversation';
+      readonly conversationId: string;
+      /** Present only when the producer stated it. See `parseSessionScope`. */
+      readonly channelId?: string;
+    }
+  | { readonly kind: 'group'; readonly groupRef: string }
+  | { readonly kind: 'org'; readonly orgId: string }
+  | { readonly kind: 'system'; readonly origin: SystemScopeOrigin; readonly id: string }
+  | {
+      readonly kind: 'unscoped';
+      readonly reason: UnscopedReason;
+      /** The shared bucket's literal token. Absent when `reason` is `'absent'`. */
+      readonly token?: string;
+    };
+
+/** The `channelId::conversationId` separator used by `channels/coreApi.ts:80`. */
+const CONVERSATION_SEPARATOR = '::';
+
+/**
+ * Classify a raw `sessionScope` string.
+ *
+ * This is a MIGRATION ADAPTER, not a general parser. Its contract is that it
+ * classifies every value the tree actually produces while `formatSessionScope`
+ * round-trips it byte-identically — introducing the type must not move a single
+ * scope string, because moving one would move its graph partition and orphan
+ * that conversation's memory.
+ *
+ * That contract is why it stays deliberately conservative on two shapes it
+ * *could* decode further:
+ *
+ *  - `` `teams-${conversationId}` `` — splitting on `-` is unsafe (a chat-tab id
+ *    may contain dashes, and `http-…` would be misread as channel `http`).
+ *  - `` `telegram:${chat.id}` `` — decoding it would re-emit `telegram::<id>`,
+ *    a different string and therefore a different partition.
+ *
+ * Both stay opaque `conversation` scopes here. **D7 migrates the producers** to
+ * emit the canonical form; that is the correct place to fix the spelling,
+ * because the producer knows its own channel id and the adapter can only guess.
+ */
+export function parseSessionScope(raw: string | undefined): ScopeId {
+  const trimmed = raw?.trim() ?? '';
+  if (trimmed.length === 0) return { kind: 'unscoped', reason: 'absent' };
+
+  if (SHARED_SCOPE_TOKENS.has(trimmed)) {
+    return { kind: 'unscoped', reason: 'shared', token: trimmed };
+  }
+
+  for (const origin of SYSTEM_SCOPE_ORIGINS) {
+    const prefix = `${origin}:`;
+    if (trimmed.startsWith(prefix)) {
+      return { kind: 'system', origin, id: trimmed.slice(prefix.length) };
+    }
+  }
+
+  if (trimmed.startsWith('personal:')) {
+    return { kind: 'personal', userId: trimmed.slice('personal:'.length) };
+  }
+  if (trimmed.startsWith('group:')) {
+    return { kind: 'group', groupRef: trimmed.slice('group:'.length) };
+  }
+  if (trimmed.startsWith('org:')) {
+    return { kind: 'org', orgId: trimmed.slice('org:'.length) };
+  }
+
+  const separatorAt = trimmed.indexOf(CONVERSATION_SEPARATOR);
+  if (separatorAt > 0) {
+    const channelId = trimmed.slice(0, separatorAt);
+    const conversationId = trimmed.slice(separatorAt + CONVERSATION_SEPARATOR.length);
+    // An empty half is not a channel-qualified scope — keep it opaque so it
+    // still round-trips rather than becoming a half-decoded pair.
+    if (conversationId.length > 0) return { kind: 'conversation', channelId, conversationId };
+  }
+
+  return { kind: 'conversation', conversationId: trimmed };
+}
+
+/**
+ * Render a `ScopeId` back to its wire string. Inverse of `parseSessionScope`
+ * for every value the tree produces — asserted in `test/scopeId.test.ts`.
+ */
+export function formatSessionScope(scope: ScopeId): string {
+  switch (scope.kind) {
+    case 'personal':
+      return `personal:${scope.userId}`;
+    case 'group':
+      return `group:${scope.groupRef}`;
+    case 'org':
+      return `org:${scope.orgId}`;
+    case 'system':
+      return `${scope.origin}:${scope.id}`;
+    case 'conversation':
+      return scope.channelId === undefined
+        ? scope.conversationId
+        : `${scope.channelId}${CONVERSATION_SEPARATOR}${scope.conversationId}`;
+    case 'unscoped':
+      return scope.token ?? '';
+  }
+}
+
+/**
+ * Whether a scope identifies an audience that can hold per-conversation state.
+ * `false` for machine scopes (no human present) and for both unscoped reasons.
+ */
+export function isAddressableScope(scope: ScopeId): boolean {
+  return scope.kind !== 'system' && scope.kind !== 'unscoped';
+}
+
+/** Legacy graph-key constraints, preserved verbatim from `sessionLogger.ts`. */
+const GRAPH_KEY_MAX_LEN = 80;
+const GRAPH_KEY_SAFE = /^[a-z0-9_-]{1,80}$/;
+const DIGEST_LEN = 16;
+
+/**
+ * #575 D3 — the injective replacement for `sanitizeScope`.
+ *
+ * `sanitizeScope` (`harness-orchestrator/src/sessionLogger.ts`) maps a scope to
+ * the graph partition key by collapsing every non-`[a-zA-Z0-9_-]` run to `-`,
+ * truncating at 80 characters and lowercasing. That mapping is **not
+ * injective**: `teams::c1`, `teams:c1` and `teams-c1` all become `teams-c1`, as
+ * do any two scopes agreeing on their first 80 sanitized characters or
+ * differing only in case. While scope is merely a recall hint that is a quality
+ * nuisance; once scope is a security boundary — the point of #575 — two scopes
+ * that must not see each other's memory can share one partition while the
+ * isolation check (string equality on `excludeScope`) still passes.
+ *
+ * This function keeps the same output alphabet and length budget while being
+ * injective in practice:
+ *
+ *  - A scope that was ALREADY lossless (it matches the safe pattern) is
+ *    returned byte-identically, so every partition that was never at risk keeps
+ *    its existing data. `'http-default'`, `'teams-unknown'` and ordinary
+ *    chat-tab ids all take this path.
+ *  - Anything else keeps a readable sanitized stem and gains a digest of the
+ *    RAW string, which is what makes the mapping injective.
+ *
+ * A genuinely empty scope still maps to `'unscoped'`, exactly as before. A
+ * non-empty scope never does — conflating "no scope" with "a scope made of
+ * punctuation" is part of the bug.
+ *
+ * **Migration:** for any scope that was lossy — which is every `teams-<conv>`,
+ * `telegram:<id>`, `routine:<id>`, `conductor:<run>:<step>` and every
+ * `channelId::conversationId` — this returns a DIFFERENT key than
+ * `sanitizeScope` did, so its existing graph partition is orphaned. That is why
+ * the caller gates it behind an explicit opt-in rather than switching
+ * deployments over silently.
+ */
+export function scopeGraphKey(rawScope: string): string {
+  const trimmed = rawScope?.trim() ?? '';
+  if (trimmed.length === 0) return 'unscoped';
+  if (GRAPH_KEY_SAFE.test(trimmed)) return trimmed;
+
+  const digest = createHash('sha256').update(trimmed, 'utf8').digest('hex').slice(0, DIGEST_LEN);
+  const stem = trimmed
+    .replace(/[^a-zA-Z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+    .slice(0, GRAPH_KEY_MAX_LEN - DIGEST_LEN - 1);
+  // `stem` is empty when the scope was punctuation-only. A fixed placeholder
+  // keeps the key well-formed without collapsing it onto `'unscoped'`.
+  return `${stem.length > 0 ? stem : 'scope'}-${digest}`;
+}

--- a/middleware/packages/harness-orchestrator/src/directLineSticky.ts
+++ b/middleware/packages/harness-orchestrator/src/directLineSticky.ts
@@ -20,6 +20,8 @@
  * never interleave between a sticky read and its write.
  */
 
+import { formatSessionScope, parseSessionScope } from '@omadia/channel-sdk';
+
 import {
   parseDirectLineDirective,
   resolveDirectLineTarget,
@@ -62,31 +64,6 @@ export const STICKY_MAX_BINDINGS = 1000;
 export const DIRECT_LINE_EXIT_TOKENS: ReadonlySet<string> = new Set(['end', 'orchestrator']);
 
 /**
- * Session scopes that are NOT per-conversation. `resolveScope` in
- * `middleware/src/routes/chat.ts` returns the literal `'http-default'` for any
- * caller that sends neither `scope` nor `sessionId`, so binding on it alone
- * would hand one caller's specialist to every other anonymous caller.
- */
-export const SHARED_SCOPES: ReadonlySet<string> = new Set([
-  'http-default',
-  'teams-unknown',
-  'unknown',
-]);
-
-/**
- * Machine-driven scopes. These repeat verbatim across every execution
- * (`routine:<id>` is constant), so a binding would outlive any human intent
- * and accumulate forever. Refused unconditionally — a userId does not redeem
- * them, because there is no human conversation to be sticky about.
- */
-export const SYNTHETIC_SCOPE_PREFIXES: readonly string[] = [
-  'routine:',
-  'schedule:',
-  'conductor:',
-  'conductor-builder:',
-];
-
-/**
  * NUL separator. It cannot occur in a kebab agent slug, in a channel
  * conversation id, or in a `USER_ID_RE`-validated user id, so no field
  * combination can collide with another. This key never reaches the knowledge
@@ -105,26 +82,44 @@ export function stickyKeyFor(args: {
 /**
  * Allow-gate for sticky state. Names its refusal instead of silently doing
  * nothing, so the caller can tell the user why the binding did not take.
+ *
+ * #575 Phase 1: this used to carry its own `SHARED_SCOPES` and
+ * `SYNTHETIC_SCOPE_PREFIXES` denylists — a feature-local reconstruction of the
+ * scope model that did not exist. Both are gone; the three refusal reasons now
+ * fall out of `ScopeId` directly:
+ *
+ *   `unscoped`/`absent`  → `'no-scope'`      (nothing to be sticky about)
+ *   `unscoped`/`shared`  → `'shared-scope'`  (redeemable by a user id)
+ *   `system`             → `'synthetic-scope'` (no human conversation at all)
+ *
+ * That the mapping is total and reason-for-reason identical is the evidence
+ * that the type covers what the denylists were covering. If a future scope
+ * spelling needs a fourth denylist entry here, the type is wrong — fix the type.
  */
 export function classifyStickyScope(args: {
   readonly agentSlug: string;
   readonly sessionScope?: string;
   readonly userId?: string;
 }): StickyScopeClassification {
-  const scope = args.sessionScope?.trim() ?? '';
-  if (scope.length === 0) return { kind: 'refused', reason: 'no-scope' };
-  if (SYNTHETIC_SCOPE_PREFIXES.some((prefix) => scope.startsWith(prefix))) {
-    return { kind: 'refused', reason: 'synthetic-scope' };
+  const scope = parseSessionScope(args.sessionScope);
+  if (scope.kind === 'system') return { kind: 'refused', reason: 'synthetic-scope' };
+  if (scope.kind === 'unscoped' && scope.reason === 'absent') {
+    return { kind: 'refused', reason: 'no-scope' };
   }
+
   const userId = args.userId?.trim() ?? '';
-  if (SHARED_SCOPES.has(scope) && userId.length === 0) {
+  if (scope.kind === 'unscoped' && userId.length === 0) {
+    // A shared bucket. Only a user id makes the key per-person.
     return { kind: 'refused', reason: 'shared-scope' };
   }
+
   return {
     kind: 'eligible',
     key: stickyKeyFor({
       agentSlug: args.agentSlug,
-      sessionScope: scope,
+      // The wire spelling, unchanged — `formatSessionScope` round-trips, so the
+      // key is byte-identical to the pre-#575 one for every existing binding.
+      sessionScope: formatSessionScope(scope),
       ...(userId.length > 0 ? { userId } : {}),
     }),
   };

--- a/middleware/packages/harness-orchestrator/src/index.ts
+++ b/middleware/packages/harness-orchestrator/src/index.ts
@@ -283,8 +283,6 @@ export {
   stickyKeyFor,
   InMemoryDirectLineStickyStore,
   DIRECT_LINE_EXIT_TOKENS,
-  SHARED_SCOPES,
-  SYNTHETIC_SCOPE_PREFIXES,
   STICKY_IDLE_TTL_MS,
   STICKY_MAX_BINDINGS,
 } from './directLineSticky.js';

--- a/middleware/packages/harness-orchestrator/src/sessionLogger.ts
+++ b/middleware/packages/harness-orchestrator/src/sessionLogger.ts
@@ -1,4 +1,5 @@
 import type { MemoryStore } from '@omadia/plugin-api';
+import { scopeGraphKey } from '@omadia/channel-sdk';
 import {
   qualifyScope,
   turnNodeId,
@@ -229,8 +230,32 @@ export function graphScopeFor(
   agentSlug: string | undefined,
   rawScope: string,
 ): string {
-  const base = sanitizeScope(rawScope);
+  const base = injectiveScopeKeysEnabled() ? scopeGraphKey(rawScope) : sanitizeScope(rawScope);
   return agentSlug !== undefined ? qualifyScope(agentSlug, base) : base;
+}
+
+/**
+ * #575 D3 — opt-in switch for the injective graph key.
+ *
+ * `sanitizeScope` is not injective (spec §2.3): `teams::c1`, `teams:c1` and
+ * `teams-c1` share one partition, as do scopes differing only in case or beyond
+ * 80 characters. `scopeGraphKey` fixes that — but for any scope that WAS lossy
+ * it necessarily produces a different key, which orphans that scope's existing
+ * graph partition. In practice that is every `teams-<conv>`, `telegram:<id>`,
+ * `routine:<id>`, `conductor:<run>:<step>` and `channelId::conversationId` in a
+ * live deployment: their accumulated memory would stop being recalled.
+ *
+ * So the fix ships DISABLED and a deployment opts in deliberately, rather than
+ * discovering the discontinuity after an upgrade. Scopes that were already
+ * lossless keep a byte-identical key either way, so enabling it is a no-op for
+ * plain chat-tab ids, `'http-default'` and `'teams-unknown'`.
+ *
+ * Flipping this default to on is a migration, not a patch — it needs a
+ * partition rewrite or an accepted recall reset, and that decision is #575
+ * Phase 2's, not this PR's.
+ */
+function injectiveScopeKeysEnabled(): boolean {
+  return process.env['OMADIA_INJECTIVE_SCOPE_KEYS'] === '1';
 }
 
 function sanitizeScope(scope: string): string {

--- a/middleware/test/orchestrator/directLineSticky.test.ts
+++ b/middleware/test/orchestrator/directLineSticky.test.ts
@@ -4,10 +4,8 @@ import { strict as assert } from 'node:assert';
 import {
   DIRECT_LINE_EXIT_TOKENS,
   InMemoryDirectLineStickyStore,
-  SHARED_SCOPES,
   STICKY_IDLE_TTL_MS,
   STICKY_MAX_BINDINGS,
-  SYNTHETIC_SCOPE_PREFIXES,
   classifyStickyScope,
   decideDirectLineTurn,
   isDirectLineExitMessage,
@@ -123,10 +121,40 @@ describe('#445 classifyStickyScope', () => {
   });
 
   it('exposes the gate constants it reasons over', () => {
-    assert.ok(SHARED_SCOPES.has('http-default'));
-    assert.ok(SYNTHETIC_SCOPE_PREFIXES.includes('routine:'));
     assert.ok(DIRECT_LINE_EXIT_TOKENS.has('end'));
     assert.ok(DIRECT_LINE_EXIT_TOKENS.has('orchestrator'));
+  });
+
+  // #575 Phase 1 — the denylists this module used to own (`SHARED_SCOPES`,
+  // `SYNTHETIC_SCOPE_PREFIXES`) are deleted; the same refusals now come out of
+  // `ScopeId`. These lock the behaviour to the TYPE rather than to a list, so a
+  // regression that reintroduces a list-shaped gate fails here.
+  it('derives every refusal from the scope type, not from a local denylist', () => {
+    assert.equal(
+      classifyStickyScope({ agentSlug: 'a', sessionScope: 'teams-unknown' }).kind === 'refused' &&
+        classifyStickyScope({ agentSlug: 'a', sessionScope: 'teams-unknown' }).kind,
+      'refused',
+    );
+    // A machine scope the old prefix list would have had to enumerate.
+    assert.deepEqual(
+      classifyStickyScope({ agentSlug: 'a', sessionScope: 'conductor-builder:x:y', userId: 'u1' }),
+      { kind: 'refused', reason: 'synthetic-scope' },
+      'a userId must NOT redeem a machine scope',
+    );
+  });
+
+  it('keeps the sticky key byte-identical to the pre-#575 key', () => {
+    // The key is derived through parse+format now. If that round-trip were
+    // lossy, every live binding would be silently orphaned on deploy.
+    for (const scope of ['http-default', 'teams::19:abc@thread.tacv2', 'telegram:12345', 'tab-7']) {
+      const classified = classifyStickyScope({ agentSlug: 'a', sessionScope: scope, userId: 'u1' });
+      assert.equal(classified.kind, 'eligible', `expected ${scope} eligible`);
+      assert.equal(
+        classified.kind === 'eligible' && classified.key,
+        stickyKeyFor({ agentSlug: 'a', sessionScope: scope, userId: 'u1' }),
+        `key moved for ${scope}`,
+      );
+    }
   });
 });
 

--- a/middleware/test/scopeId.test.ts
+++ b/middleware/test/scopeId.test.ts
@@ -1,0 +1,235 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  SHARED_SCOPE_TOKENS,
+  SYSTEM_SCOPE_ORIGINS,
+  formatSessionScope,
+  parseSessionScope,
+  scopeGraphKey,
+  type ScopeId,
+} from '@omadia/channel-sdk';
+
+/**
+ * Compile-time guard: every variant of the union must be constructible and
+ * formattable here. If a variant is added without a round-trip case, this
+ * array stops type-checking before the runtime suite even runs.
+ */
+const EVERY_KIND: readonly ScopeId[] = [
+  { kind: 'personal', userId: 'u1' },
+  { kind: 'conversation', conversationId: 'c1' },
+  { kind: 'conversation', channelId: 'teams', conversationId: 'c1' },
+  { kind: 'group', groupRef: 'g1' },
+  { kind: 'org', orgId: 'o1' },
+  { kind: 'system', origin: 'routine', id: 'r1' },
+  { kind: 'unscoped', reason: 'absent' },
+  { kind: 'unscoped', reason: 'shared', token: 'http-default' },
+];
+
+// #575 Phase 1 — the ScopeId type and its migration adapter.
+//
+// `parseSessionScope` is deliberately a MIGRATION adapter, not a general
+// parser: its contract is that it classifies every value the tree actually
+// produces (measured in specs/575-scope-and-identity-foundation/spec.md §2.2)
+// while round-tripping byte-identically, so introducing the type cannot move
+// a single existing scope string.
+
+describe('#575 parseSessionScope — the values the tree actually produces', () => {
+  it('classifies an absent scope as unscoped/absent, not as a shared bucket', () => {
+    for (const raw of [undefined, '', '   ', '\t\n']) {
+      const scope = parseSessionScope(raw);
+      assert.deepEqual(scope, { kind: 'unscoped', reason: 'absent' }, `raw=${JSON.stringify(raw)}`);
+    }
+  });
+
+  it("classifies 'http-default' as unscoped/shared — the #445 cross-user hole, as a type", () => {
+    // routes/chat.ts:54 returns this literal for every anonymous caller.
+    assert.deepEqual(parseSessionScope('http-default'), {
+      kind: 'unscoped',
+      reason: 'shared',
+      token: 'http-default',
+    });
+  });
+
+  it("classifies 'teams-unknown' as unscoped/shared — it has a LIVE producer", () => {
+    // omadia-byte5-plugins channel-teams/src/teamsBot.ts:440-441 —
+    // `conversation?.id ?? 'unknown'` + `teams-${conversationId}`.
+    assert.deepEqual(parseSessionScope('teams-unknown'), {
+      kind: 'unscoped',
+      reason: 'shared',
+      token: 'teams-unknown',
+    });
+  });
+
+  it('classifies every machine scope as system, with its origin recovered', () => {
+    assert.deepEqual(parseSessionScope('routine:abc'), {
+      kind: 'system',
+      origin: 'routine',
+      id: 'abc',
+    });
+    assert.deepEqual(parseSessionScope('schedule:s1'), {
+      kind: 'system',
+      origin: 'schedule',
+      id: 's1',
+    });
+    // conductor:<runId>:<stepId> — the id keeps everything after the FIRST colon.
+    assert.deepEqual(parseSessionScope('conductor:run1:step2'), {
+      kind: 'system',
+      origin: 'conductor',
+      id: 'run1:step2',
+    });
+  });
+
+  // The two origins LOOK like an overlapping-prefix hazard. They are not,
+  // because the match carries a trailing colon and `conductor-builder:x` does
+  // not start with `conductor:`. Verified by mutation: reordering the origin
+  // array does not break this; dropping the colon from the match does.
+  it("keeps 'conductor-builder' distinct from 'conductor'", () => {
+    const scope = parseSessionScope('conductor-builder:slug:uuid');
+    assert.equal(scope.kind, 'system');
+    assert.equal(scope.kind === 'system' && scope.origin, 'conductor-builder');
+    assert.equal(scope.kind === 'system' && scope.id, 'slug:uuid');
+  });
+
+  it('splits the CoreApi `channelId::conversationId` form on the FIRST separator', () => {
+    assert.deepEqual(parseSessionScope('teams::conv::with::colons'), {
+      kind: 'conversation',
+      channelId: 'teams',
+      conversationId: 'conv::with::colons',
+    });
+  });
+
+  it('leaves an unrecognised scope opaque rather than guessing its channel', () => {
+    // `teams-<conv>` and `telegram:<id>` are produced by the private plugins.
+    // Phase 1 must NOT re-spell them — that would move their graph partition.
+    // D7 migrates the PRODUCERS; the adapter stays conservative.
+    for (const raw of ['teams-19:abc@thread.tacv2', 'telegram:12345', 'my-chat-tab', 'http-cli']) {
+      const scope = parseSessionScope(raw);
+      assert.deepEqual(scope, { kind: 'conversation', conversationId: raw }, `raw=${raw}`);
+    }
+  });
+
+  it('recognises the canonical personal/group/org spellings', () => {
+    assert.deepEqual(parseSessionScope('personal:u1'), { kind: 'personal', userId: 'u1' });
+    assert.deepEqual(parseSessionScope('group:g1'), { kind: 'group', groupRef: 'g1' });
+    assert.deepEqual(parseSessionScope('org:o1'), { kind: 'org', orgId: 'o1' });
+  });
+
+  it('exposes the shared tokens and system origins it recognises', () => {
+    assert.ok(SHARED_SCOPE_TOKENS.has('http-default'));
+    assert.ok(SHARED_SCOPE_TOKENS.has('teams-unknown'));
+    assert.ok(SHARED_SCOPE_TOKENS.has('unknown'));
+    assert.deepEqual([...SYSTEM_SCOPE_ORIGINS].sort(), [
+      'conductor',
+      'conductor-builder',
+      'routine',
+      'schedule',
+    ]);
+  });
+});
+
+describe('#575 formatSessionScope — round-trips every produced value byte-identically', () => {
+  // Introducing the type must not move a single scope string on the wire.
+  const PRODUCED_BY_THE_TREE: readonly string[] = [
+    'http-default',
+    'http-cli-john',
+    'teams-unknown',
+    'unknown',
+    'my-session-tab',
+    'teams::19:abc@thread.tacv2',
+    'teams-19:abc@thread.tacv2',
+    'telegram:12345',
+    'routine:daily-digest',
+    'schedule:sched-7',
+    'conductor:run1:step2',
+    'conductor-builder:my-agent:0f8c',
+    'personal:u1',
+    'group:g1',
+    'org:o1',
+    'a::',
+  ];
+
+  for (const raw of PRODUCED_BY_THE_TREE) {
+    it(`round-trips ${JSON.stringify(raw)}`, () => {
+      assert.equal(formatSessionScope(parseSessionScope(raw)), raw);
+    });
+  }
+
+  it('formats an absent scope back to the empty string', () => {
+    assert.equal(formatSessionScope({ kind: 'unscoped', reason: 'absent' }), '');
+  });
+
+  it('round-trips every variant of the union, not just the observed strings', () => {
+    for (const scope of EVERY_KIND) {
+      const wire = formatSessionScope(scope);
+      assert.deepEqual(parseSessionScope(wire), scope, `variant ${scope.kind} wire=${wire}`);
+    }
+  });
+
+  it('re-parses to an identical ScopeId (parse ∘ format ∘ parse is stable)', () => {
+    for (const raw of PRODUCED_BY_THE_TREE) {
+      const once = parseSessionScope(raw);
+      const twice = parseSessionScope(formatSessionScope(once));
+      assert.deepEqual(twice, once, `raw=${raw}`);
+    }
+  });
+});
+
+describe('#575 D3 — scopeGraphKey is injective where sanitizeScope was not', () => {
+  it('leaves an already-safe scope byte-identical, so its partition is preserved', () => {
+    // These match /^[a-z0-9_-]{1,80}$/ and so were never lossy. Existing
+    // deployments must keep reading the same graph partition for them.
+    for (const raw of ['http-default', 'teams-unknown', 'unknown', 'my-session-tab']) {
+      assert.equal(scopeGraphKey(raw), raw, `raw=${raw}`);
+    }
+  });
+
+  it('separates the scopes that sanitizeScope collapsed into one key', () => {
+    // The spec §2.3 collision: ':' and '::' both became '-'.
+    const collided = ['teams::c1', 'teams:c1', 'teams-c1'];
+    const keys = collided.map(scopeGraphKey);
+    assert.equal(new Set(keys).size, collided.length, `keys=${JSON.stringify(keys)}`);
+  });
+
+  it('separates scopes that differed only by case', () => {
+    const keys = ['Teams::C1', 'teams::c1'].map(scopeGraphKey);
+    assert.notEqual(keys[0], keys[1]);
+  });
+
+  it('separates scopes that agree on their first 80 sanitized characters', () => {
+    const prefix = 'x'.repeat(90);
+    const keys = [`${prefix}alpha`, `${prefix}beta`].map(scopeGraphKey);
+    assert.notEqual(keys[0], keys[1]);
+  });
+
+  it('always emits a graph-safe key of at most 80 characters', () => {
+    const samples = [
+      'teams::19:AbC@thread.tacv2',
+      'x'.repeat(500),
+      'conductor:run1:step2',
+      'ÄÖÜ-umlauts-and-emoji-🙂',
+      '///',
+    ];
+    for (const raw of samples) {
+      const key = scopeGraphKey(raw);
+      assert.match(key, /^[a-z0-9_-]{1,80}$/, `raw=${raw} key=${key}`);
+    }
+  });
+
+  it("maps a genuinely EMPTY scope to 'unscoped', exactly as sanitizeScope did", () => {
+    assert.equal(scopeGraphKey(''), 'unscoped');
+    assert.equal(scopeGraphKey('   '), 'unscoped');
+  });
+
+  it("does NOT collapse a non-empty unsafe scope onto 'unscoped'", () => {
+    // sanitizeScope mapped '///' to 'unscoped' — indistinguishable from a
+    // turn that carried no scope at all. That conflation is the bug.
+    assert.notEqual(scopeGraphKey('///'), 'unscoped');
+    assert.notEqual(scopeGraphKey('///'), scopeGraphKey('***'));
+  });
+
+  it('is deterministic', () => {
+    const raw = 'teams::19:abc@thread.tacv2';
+    assert.equal(scopeGraphKey(raw), scopeGraphKey(raw));
+  });
+});


### PR DESCRIPTION
Phase 1 of the #575 scope model, implementing decisions **D1**, **D2** and **D3** from `specs/575-scope-and-identity-foundation/spec.md` §8 (merged in #711 / #712).

## What

**`ScopeId`** — the six-variant union from spec §3, in `@omadia/channel-sdk`:

```ts
type ScopeId =
  | { kind: 'personal';     userId }
  | { kind: 'conversation'; conversationId; channelId? }
  | { kind: 'group';        groupRef }
  | { kind: 'org';          orgId }
  | { kind: 'system';       origin: 'routine'|'schedule'|'conductor'|'conductor-builder'; id }
  | { kind: 'unscoped';     reason: 'absent'|'shared'; token? }
```

It lives in the channel SDK because the orchestrator, the kernel **and** the channel plugins all consume it, and that package is the leaf all three already depend on. Per **D2** the plugin-facing `sessionScope?: string` is untouched — the type is produced and consumed internally by parsing at ingress.

**The point of the phase:** `directLineSticky` deletes `SHARED_SCOPES` and `SYNTHETIC_SCOPE_PREFIXES`. Those denylists were a feature-local reconstruction of the scope model that did not exist. The three refusal reasons now fall out of the type, reason for reason:

| `ScopeId` | refusal |
|---|---|
| `unscoped` / `absent` | `'no-scope'` |
| `unscoped` / `shared` | `'shared-scope'` (redeemable by a user id) |
| `system` | `'synthetic-scope'` |

That the mapping is total and one-to-one is the evidence that the type covers what the lists covered. If a future scope spelling ever needs a fourth entry here, the type is wrong — fix the type.

## Two things deliberately NOT done, and why

**1. D3 ships behind `OMADIA_INJECTIVE_SCOPE_KEYS=1`, defaulting OFF.**

`scopeGraphKey` is implemented and tested: it fixes the non-injective graph key from spec §2.3, where `teams::c1`, `teams:c1` and `teams-c1` all collapsed to one partition, as did scopes differing only in case or beyond 80 characters.

But for any scope that *was* lossy, the new key is necessarily a **different** key — which orphans that scope's existing graph partition. In a live deployment that is every `teams-<conv>`, `telegram:<id>`, `routine:<id>`, `conductor:<run>:<step>` and `channelId::conversationId`: their accumulated memory would silently stop being recalled after an upgrade. Scopes that were already lossless (`http-default`, `teams-unknown`, ordinary chat-tab ids) keep byte-identical keys either way.

Turning it on is a migration decision — a partition rewrite or an accepted recall reset — not a side effect of deploying this PR. **Happy to flip the default if you'd rather take the reset now**; I defaulted to the conservative side because the failure mode is silent.

**2. `teams-<conv>` and `telegram:<id>` stay opaque `conversation` scopes.**

The adapter *could* decode them, but decoding `telegram:12345` would re-emit `telegram::12345` — a different string, therefore a different partition. The adapter can only guess a channel id; the producer knows it. **D7** migrates the producers in `omadia-byte5-plugins`, which is the correct place.

`scopeAncestors` / `resolvePostureFor` (spec §7, for #579) are not here: they fold `tightenPosture`, which is still in the unmerged #681.

## Test plan

- [x] `build` exit 0, `typecheck` exit 0 (gated on exit code, not on grepping for `error TS`)
- [x] `typecheck:test` ratchet — 406 known errors, **no regressions** (baseline 406)
- [x] core-decoupling ratchet (#470) — held at 3294
- [x] `scopeId.test.ts` 36 pass · `directLineSticky.test.ts` 44 pass · `directLine.test.ts` 48 pass · 0 fail, 0 cancelled
- [x] Round-trip test over all 16 scope spellings the tree actually produces, plus every variant of the union — proving the type moves no scope string and therefore no partition
- [x] Sticky keys asserted byte-identical to the pre-#575 keys, so no live binding is orphaned
- [x] Full middleware suite run locally

### Mutation checks (`dist/` rebuilt between each, or the check lies)

| Mutation | Result |
|---|---|
| `scopeGraphKey` drops the digest | 4 tests red |
| prefix match loses its trailing colon | 7 tests red |
| shared-token branch disabled | 2 tests red |
| sticky gate stops refusing `system` | 2 tests red |
| restore | green, sources byte-identical |

**One mutation survived, and it should have.** Reordering `SYSTEM_SCOPE_ORIGINS` left the suite green — because the order genuinely is *not* load-bearing: the match carries a trailing colon, and `conductor-builder:x` does not start with `conductor:`. My code comment claimed the opposite. The comment was wrong, not the code; both it and the test name are corrected to name the real invariant, which the dropped-colon mutation does catch.

## Risk / blast radius

- `graphScopeFor` is behaviourally unchanged with the flag off — same `sanitizeScope` path, byte-identical keys.
- `classifyStickyScope` keeps all three refusal reasons and byte-identical keys; `directLine.test.ts` (48 tests) covers the dispatch body it feeds.
- `SHARED_SCOPES` / `SYNTHETIC_SCOPE_PREFIXES` are removed from the `@omadia/orchestrator` public exports. Verified: **no remaining code consumers** in this repo or in `omadia-byte5-plugins` — only comments referencing the deletion.
- New file `middleware/test/scopeId.test.ts` adds no dev-platform references (ratchet held) and no new type errors (baseline held).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789488436&installation_model_id=428086&pr_number=713&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F713&signature=1e9eb625156dcd8f0a432801fe1ee318c52f6a940ce46560f2e0c097da4ef9d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->