### PR TITLE
feat(#575): unsharedConversationScope — a channel turn never lands in a shared scope

### DIFF
--- a/middleware/packages/harness-channel-sdk/src/index.ts
+++ b/middleware/packages/harness-channel-sdk/src/index.ts
@@ -206,6 +206,7 @@ export {
   isAddressableScope,
   parseSessionScope,
   scopeGraphKey,
+  unsharedConversationScope,
   type ScopeId,
   type SystemScopeOrigin,
   type UnscopedReason,

--- a/middleware/packages/harness-channel-sdk/src/scopeId.ts
+++ b/middleware/packages/harness-channel-sdk/src/scopeId.ts
@@ -26,7 +26,7 @@
  * Everything here is pure and synchronous.
  */
 
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 
 /** Machine-driven scope origins. No human is present in any of them. */
 export type SystemScopeOrigin = 'routine' | 'schedule' | 'conductor' | 'conductor-builder';
@@ -186,6 +186,51 @@ export function formatSessionScope(scope: ScopeId): string {
  */
 export function isAddressableScope(scope: ScopeId): boolean {
   return scope.kind !== 'system' && scope.kind !== 'unscoped';
+}
+
+/**
+ * #575 D7 — derive a channel turn's scope, refusing to land it in a SHARED one.
+ *
+ * A channel adapter builds its scope from the conversation id its platform
+ * supplies. When that id is missing, the natural `?? 'unknown'` fallback
+ * produces a literal that EVERY such turn shares — measured live in
+ * `omadia-byte5-plugins` `channel-teams/src/teamsBot.ts:440-441`, where a Teams
+ * activity without a conversation id yields `teams-unknown`. That single bucket
+ * then keys conversation history and the knowledge-graph partition for every
+ * unrelated caller who hits the same gap: the `'http-default'` hole again, in a
+ * second place.
+ *
+ * This helper is the one decision point for that gap:
+ *
+ *  - A scope that resolves to a real conversation is returned **untouched**, so
+ *    the wire form does not move and no existing partition is orphaned.
+ *  - A scope that resolves to `unscoped` — absent OR any known shared token —
+ *    is replaced by a scope unique to this turn. Two callers who both hit the
+ *    gap get two scopes, which is the entire point.
+ *  - Anything else (a machine scope arriving at a channel ingress — a routing
+ *    bug) is returned as-is rather than laundered into a conversation.
+ *
+ * Because the decision is driven by `parseSessionScope`, a shared token added
+ * to `SHARED_SCOPE_TOKENS` later is handled here automatically; no channel
+ * plugin has to learn about it.
+ *
+ * `uniqueSuffix` should be the platform's per-message id (a Bot Framework
+ * activity id, a Telegram update id) so a retry of the SAME message resolves to
+ * the same scope. When the platform offers nothing to key on, a random id is
+ * used — isolation is preserved, continuity genuinely is not recoverable.
+ */
+export function unsharedConversationScope(args: {
+  readonly scope: string | undefined;
+  readonly uniqueSuffix?: string | undefined;
+}): ScopeId {
+  const parsed = parseSessionScope(args.scope);
+  if (parsed.kind !== 'unscoped') return parsed;
+
+  const suffix =
+    args.uniqueSuffix !== undefined && args.uniqueSuffix.trim().length > 0
+      ? args.uniqueSuffix.trim()
+      : randomUUID();
+  return { kind: 'conversation', conversationId: `unresolved-${suffix}` };
 }
 
 /** Legacy graph-key constraints, preserved verbatim from `sessionLogger.ts`. */

--- a/middleware/test/unsharedConversationScope.test.ts
+++ b/middleware/test/unsharedConversationScope.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  formatSessionScope,
+  parseSessionScope,
+  unsharedConversationScope,
+} from '@omadia/channel-sdk';
+
+// #575 D7 — a channel turn must never land in a SHARED scope.
+//
+// Measured live producer (specs/575-scope-and-identity-foundation/spec.md §2.2):
+// `omadia-byte5-plugins` channel-teams/src/teamsBot.ts:440-441 does
+// `conversation?.id ?? 'unknown'` folded into `teams-${conversationId}`, so a
+// Teams activity with no conversation id yields the literal `teams-unknown` —
+// one bucket that every such caller shares, for conversation history AND for
+// the knowledge-graph partition.
+//
+// This helper is the fix, and it lives here rather than in the plugin because
+// the plugin repository has no test runner wired: the risky decision belongs
+// where it can be proven.
+
+const ACTIVITY = 'activity-1';
+
+describe('#575 D7 unsharedConversationScope', () => {
+  it('passes a real conversation scope through untouched, byte for byte', () => {
+    // The wire form MUST NOT move — moving it moves the graph partition and
+    // orphans that conversation's accumulated memory.
+    for (const scope of [
+      'teams-19:abc@thread.tacv2',
+      'telegram:12345',
+      'teams::19:abc@thread.tacv2',
+      'my-chat-tab',
+    ]) {
+      const out = formatSessionScope(
+        unsharedConversationScope({ scope, uniqueSuffix: ACTIVITY }),
+      );
+      assert.equal(out, scope, `scope moved: ${scope} -> ${out}`);
+    }
+  });
+
+  it('replaces the shared teams-unknown bucket with a per-turn scope', () => {
+    const out = formatSessionScope(
+      unsharedConversationScope({ scope: 'teams-unknown', uniqueSuffix: ACTIVITY }),
+    );
+    assert.notEqual(out, 'teams-unknown');
+    assert.ok(out.includes(ACTIVITY), `expected the unique suffix in ${out}`);
+  });
+
+  it('replaces every known shared token, not just the Teams one', () => {
+    for (const shared of ['http-default', 'teams-unknown', 'unknown']) {
+      const out = formatSessionScope(
+        unsharedConversationScope({ scope: shared, uniqueSuffix: ACTIVITY }),
+      );
+      assert.notEqual(out, shared, `${shared} still shared`);
+    }
+  });
+
+  it('replaces an absent scope too', () => {
+    for (const scope of [undefined, '', '   ']) {
+      const out = formatSessionScope(
+        unsharedConversationScope({ scope, uniqueSuffix: ACTIVITY }),
+      );
+      assert.ok(out.length > 0, 'expected a concrete scope');
+      assert.ok(out.includes(ACTIVITY));
+    }
+  });
+
+  it('gives two different turns two different scopes — the whole point', () => {
+    const a = formatSessionScope(
+      unsharedConversationScope({ scope: 'teams-unknown', uniqueSuffix: 'act-a' }),
+    );
+    const b = formatSessionScope(
+      unsharedConversationScope({ scope: 'teams-unknown', uniqueSuffix: 'act-b' }),
+    );
+    assert.notEqual(a, b);
+  });
+
+  it('is still unique when the channel supplies no id to key on', () => {
+    const a = formatSessionScope(unsharedConversationScope({ scope: undefined }));
+    const b = formatSessionScope(unsharedConversationScope({ scope: undefined }));
+    assert.notEqual(a, b, 'two id-less turns must not share a scope');
+  });
+
+  it('produces a scope that parses back as an addressable conversation', () => {
+    const out = formatSessionScope(
+      unsharedConversationScope({ scope: 'teams-unknown', uniqueSuffix: ACTIVITY }),
+    );
+    const reparsed = parseSessionScope(out);
+    assert.equal(reparsed.kind, 'conversation');
+  });
+
+  it('never hands back a machine scope disguised as a conversation', () => {
+    // A routine scope reaching a channel ingress would be a routing bug; the
+    // helper must not silently launder it into a conversation.
+    const scope = unsharedConversationScope({ scope: 'routine:daily', uniqueSuffix: ACTIVITY });
+    assert.equal(scope.kind, 'system');
+  });
+});


### PR DESCRIPTION
**D7(a)** from `specs/575-scope-and-identity-foundation/spec.md` — the SDK half. Follows #713.

## The hole this closes

`omadia-byte5-plugins` `channel-teams/src/teamsBot.ts:440-441`:

```ts
const conversationId = context.activity.conversation?.id ?? 'unknown';
const sessionScope = `teams-${conversationId}`;
```

A Teams activity arriving without a conversation id produces the literal `teams-unknown`. That **one bucket** then keys conversation history *and* the knowledge-graph partition for every unrelated caller who hits the same gap — the `'http-default'` hole from #445, a second time, in production Teams. It is the finding that corrected the Phase 0 spec in #712.

## The fix

```ts
unsharedConversationScope({ scope, uniqueSuffix }): ScopeId
```

| Input resolves to | Result |
|---|---|
| a real conversation | returned **untouched** — wire form does not move, no partition orphaned |
| `unscoped` (absent **or** any known shared token) | replaced by a scope unique to this turn |
| a machine scope (routing bug at a channel ingress) | returned as-is, not laundered into a conversation |

`uniqueSuffix` should be the platform's per-message id (Bot Framework activity id, Telegram update id) so a **retry of the same message** resolves to the same scope. With nothing to key on, a random id is used: isolation is preserved, continuity genuinely is not recoverable.

Because the decision routes through `parseSessionScope`, a token added to `SHARED_SCOPE_TOKENS` later is handled here automatically — no channel plugin has to learn about it.

## Why the logic is here and not in the plugin

The plugin repository has **no test runner wired** — no `test` script, no tsx/vitest in `node_modules/.bin`. Putting the shared-bucket decision there would mean shipping an unprovable change to a production channel. Here it is unit-tested and mutation-checked; the plugin change reduces to a single call, which is the follow-up PR in `omadia-byte5-plugins`.

## What this PR deliberately does NOT do

**It does not re-spell healthy conversations.** `teams-<conv>` → `teams::<conv>` would move *every* existing Teams partition and silently drop their accumulated memory — the identical migration to the `OMADIA_INJECTIVE_SCOPE_KEYS` flip from #713. Both belong in one deliberate migration step, not scattered across PRs that each move partitions as a side effect.

## Test plan

- [x] `build` 0 · `typecheck` 0
- [x] `typecheck:test` ratchet 406 = baseline · core-decoupling ratchet held at 3294
- [x] `unsharedConversationScope.test.ts` 8 pass · `scopeId.test.ts` 36 pass · 0 fail, 0 cancelled
- [x] Pass-through asserted byte-identical for `teams-…`, `telegram:…`, `teams::…` and bare tab ids

### Mutation checks (`dist/` rebuilt between each)

| Mutation | Result |
|---|---|
| shared token kept instead of replaced | **6 red** |
| unique suffix ignored (gap-turns share again) | 4 red |
| a real conversation scope gets rewritten | 2 red |
| restore | green, source byte-identical |

A fourth mutation (early `return parsed`) **does not compile** — the type checker rejects it before any test runs. Recorded honestly as compiler-caught, not test-caught.

## Risk / blast radius

Purely additive: one new exported function plus its test. No existing call site changes, so nothing in this repo behaves differently until the plugin adopts it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789527865&installation_model_id=428086&pr_number=714&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F714&signature=d9fdcb1b5d923ef8201409d399bb75c592d54c57881175ec85cd81c8ce010db3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->