### PR TITLE
feat(#333): Principal — the platform's typed answer to "who is this?" (phase 1)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,46 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — `Principal`, the platform's typed answer to "who is this?" (#333, phase 1)
+
+- **A `Principal` type in the channel SDK**, the same home as `ScopeId` and for
+  the same reason: the orchestrator, the kernel and `middleware/src` all depend
+  on that package and it depends on none of them. Until now only Conductor could
+  name a principal, and only as two loose columns (`principal_kind`,
+  `principal_ref`) plus a bare-string canonicalizer. `specs/575-scope-and-identity-foundation/spec.md`
+  §6 draws the line this implements: **#333 produces Principals, #575 consumes
+  them and produces decisions.** Nothing in the new code evaluates a permission.
+- **`user` and `role` do not share a canonicalization rule, and now cannot be
+  written as if they did.** User ids are trimmed and lowercased, because the SQL
+  deciding whether a reminder reaches a person is a case-sensitive `=`. Role keys
+  are trimmed only, because `createRole` writes them verbatim — lowercasing them
+  would stop matching every mixed-case row already in a deployment's
+  `conductor_roles` table. The two variants therefore carry differently-named
+  fields (`userId` / `roleKey`), so the difference is visible at each use site
+  rather than hidden behind a shared `ref: string`.
+- **`parsePrincipal` splits on the first separator only.** Principal references
+  legitimately contain colons — `coreApi.resolveIdentity` builds its platform id
+  as `` `${kind}:${id}` `` — so `user:teams:29:1a2b` is a real value that a naive
+  `split(':')` would truncate into a principal addressing the wrong person. An
+  unparseable string yields `undefined`, never a `user`: a role key misread as a
+  user id routes an approval to somebody who does not exist.
+- **Conductor's `canonicalizePrincipalId` now delegates to that rule** instead of
+  keeping its own copy, so the two cannot drift apart and reintroduce the
+  case-sensitive miss both exist to prevent.
+- **`resolveTurnOwnerIdentity` also returns the turn owner as a `Principal`**,
+  widening the `{ omadiaUserId?, authSubjectKey? }` answer #568 shipped. Derived
+  from the canonical omadia id only — an IdP subject names an account at a
+  *provider*, not a subject in omadia's id space, so a turn with a login but no
+  canonical id still has no principal.
+
+### Added — a wiring test for the injective graph-scope key (#575 D3)
+
+- **`OMADIA_INJECTIVE_SCOPE_KEYS` now has a test proving `graphScopeFor` reads
+  it.** `scopeGraphKey`'s own tests show the *function* is injective; they say
+  nothing about whether the formula both the write and the read side use ever
+  consults the flag. A gate that is declared but never read passes every test
+  while the fix it guards is unreachable.
+
 ### Fixed — the resume/reaper conformance test raced the wall clock
 
 - **`a RESUMED task survives the reaper` could fail for reasons unrelated to

--- a/middleware/packages/harness-channel-sdk/src/index.ts
+++ b/middleware/packages/harness-channel-sdk/src/index.ts
@@ -233,3 +233,20 @@ export {
   type SystemScopeOrigin,
   type UnscopedReason,
 } from './scopeId.js';
+
+// #333 Phase 1 — the typed principal. Same home as `ScopeId` and for the same
+// reason: Conductor (`middleware/src`), the orchestrator and the kernel all
+// depend on this package and it depends on none of them. `Principal` says WHO;
+// it carries no entitlement, because #575 — not #333 — evaluates permissions
+// (spec §6).
+export {
+  PRINCIPAL_KINDS,
+  canonicalizePrincipalRef,
+  formatPrincipal,
+  makePrincipal,
+  parsePrincipal,
+  principalRef,
+  principalsEqual,
+  type Principal,
+  type PrincipalKind,
+} from './principal.js';

--- a/middleware/packages/harness-channel-sdk/src/principal.ts
+++ b/middleware/packages/harness-channel-sdk/src/principal.ts
@@ -1,0 +1,153 @@
+/**
+ * #333 Phase 1 — `Principal`: the typed form of "who a decision is about".
+ *
+ * Conductor already has this concept in its schema
+ * (`conductor/migrations/0001_conductor.sql:77`,
+ * `principal_kind IN ('user', 'role')`) and in a canonicalizer
+ * (`conductor/principalId.ts:11`), but only as two loose columns and a bare
+ * `string`. Nothing outside Conductor can name a principal, which is why
+ * `specs/575-scope-and-identity-foundation/spec.md` §6 assigns the type to
+ * #333 and makes it the hand-off to #575:
+ *
+ * > **#333 produces Principals. #575 consumes Principals and produces
+ * > decisions. #575 never resolves an identity; #333 never evaluates a
+ * > permission.**
+ *
+ * Nothing in this file evaluates a permission. It is pure, synchronous, and
+ * carries no entitlements — a `Principal` says *who*, never *may they*.
+ *
+ * It lives in the channel SDK for the same reason `ScopeId` does: the
+ * orchestrator, the kernel and `middleware/src` all already depend on this
+ * package, and it depends on none of them. Adding exports here is additive —
+ * the published plugin contract (D2) is untouched.
+ *
+ * ## The two kinds do NOT share a canonicalization rule
+ *
+ * This is the finding that makes a shared `ref: string` field the wrong shape,
+ * and it is measured, not assumed:
+ *
+ *  - **`user`** ids are canonicalized **trim + lowercase**. They arrive from
+ *    unrelated sources — a channel plugin's `principalRef` (a Teams email), an
+ *    operator-typed role holder, an AAD object id — and the SQL that decides
+ *    whether a reminder reaches a person is a case-sensitive `=`
+ *    (`channelBindingStore.ts:23,38,50`). Email and UPN ids are
+ *    case-insensitive and GUIDs are already lowercase, so folding case is safe
+ *    and lossless for every id in that space.
+ *  - **`role`** keys are canonicalized **trim only**. `createRole`
+ *    (`conductor/roleStore.ts:26`) writes `key` verbatim — it never folds case
+ *    — and `resolve()` matches with `role_key = $1`. Lowercasing a role key
+ *    here would stop matching every mixed-case row already sitting in a live
+ *    deployment's `conductor_roles` table. The asymmetry is not an oversight;
+ *    it is the existing data.
+ *
+ * Collapsing the two rules into one would be a silent routing bug in whichever
+ * direction it was collapsed: lowercase roles and approvals stop reaching their
+ * holders, preserve user case and a reminder addressed to `Jane@Co.com` never
+ * matches the binding stored as `jane@co.com`.
+ */
+
+/** The two principal kinds Conductor's schema already constrains to. */
+export type PrincipalKind = 'user' | 'role';
+
+/** Iterable form of {@link PrincipalKind}, for validating untrusted input. */
+export const PRINCIPAL_KINDS: readonly PrincipalKind[] = Object.freeze(['user', 'role']);
+
+/**
+ * Who a turn, an approval or a grant is about.
+ *
+ * The two variants carry differently-named fields on purpose. A single
+ * `ref: string` would read identically at every call site while obeying two
+ * different canonicalization rules (see the file header), which is exactly the
+ * kind of invisible difference that survives review.
+ */
+export type Principal =
+  | { readonly kind: 'user'; readonly userId: string }
+  | { readonly kind: 'role'; readonly roleKey: string };
+
+/** The wire separator between a principal's kind and its reference. */
+const PRINCIPAL_SEPARATOR = ':';
+
+/**
+ * The canonical spelling of a principal reference for its kind.
+ *
+ * Exported because `middleware/src/conductor/principalId.ts` delegates to it:
+ * two implementations of "canonical" that drift apart reintroduce precisely the
+ * case-sensitive miss the canonicalizer exists to prevent.
+ */
+export function canonicalizePrincipalRef(kind: PrincipalKind, ref: string): string {
+  const trimmed = ref.trim();
+  return kind === 'user' ? trimmed.toLowerCase() : trimmed;
+}
+
+/**
+ * Builds a `Principal` from a kind and a raw reference, canonicalizing the
+ * reference for that kind.
+ *
+ * Returns `undefined` for an empty reference rather than a principal nobody can
+ * match. `roleStore.ts` already had to defend against this shape by hand —
+ * `bindingKeyForTurn` uses `||` rather than `??` so a blank `principalRef`
+ * falls back instead of writing "an empty, never-matched binding key". Here the
+ * emptiness is refused at construction instead.
+ */
+export function makePrincipal(kind: PrincipalKind, ref: string): Principal | undefined {
+  const canonical = canonicalizePrincipalRef(kind, ref);
+  if (canonical.length === 0) return undefined;
+  return kind === 'user' ? { kind: 'user', userId: canonical } : { kind: 'role', roleKey: canonical };
+}
+
+/** The kind-appropriate reference of a principal, as a plain string. */
+export function principalRef(principal: Principal): string {
+  return principal.kind === 'user' ? principal.userId : principal.roleKey;
+}
+
+/**
+ * Parses the wire form `user:<id>` / `role:<key>`.
+ *
+ * **Splits on the FIRST separator only.** Principal references legitimately
+ * contain colons: `coreApi.resolveIdentity` builds its platform id as
+ * `` `${ref.kind}:${ref.id}` `` (`channels/coreApi.ts:111`), so `user:teams:<aad-oid>`
+ * is a real value. A naive `split(':')` would either drop everything after the
+ * second colon or reject the string outright, and the failure mode is a
+ * principal that silently addresses the wrong person.
+ *
+ * Returns `undefined` — never a `user` — for anything it cannot parse. An
+ * unrecognised prefix must not fall back to `{ kind: 'user' }`: a role key
+ * misread as a user id routes an approval to a person who does not exist, and
+ * the caller is the only layer that knows whether that is recoverable. Same
+ * reasoning as `ScopeId`'s `unscoped` variant: the absence is a type, not a
+ * value.
+ */
+export function parsePrincipal(raw: string | undefined): Principal | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  const separatorAt = trimmed.indexOf(PRINCIPAL_SEPARATOR);
+  if (separatorAt <= 0) return undefined;
+  const kind = trimmed.slice(0, separatorAt);
+  if (!isPrincipalKind(kind)) return undefined;
+  return makePrincipal(kind, trimmed.slice(separatorAt + 1));
+}
+
+/**
+ * The wire form of a principal — the inverse of {@link parsePrincipal} for any
+ * principal that came from {@link makePrincipal} or {@link parsePrincipal},
+ * both of which have already canonicalized the reference.
+ */
+export function formatPrincipal(principal: Principal): string {
+  return `${principal.kind}${PRINCIPAL_SEPARATOR}${principalRef(principal)}`;
+}
+
+/**
+ * Whether two principals address the same subject.
+ *
+ * A `user` and a `role` are never equal even when their references match — a
+ * role key that happens to spell a user id is still a late-bound indirection
+ * that `resolveAwaitHolders` (`conductor/awaitStore.ts:26`) expands through the
+ * resolver, not a person.
+ */
+export function principalsEqual(a: Principal, b: Principal): boolean {
+  return a.kind === b.kind && principalRef(a) === principalRef(b);
+}
+
+function isPrincipalKind(value: string): value is PrincipalKind {
+  return (PRINCIPAL_KINDS as readonly string[]).includes(value);
+}

--- a/middleware/packages/harness-orchestrator/src/resolveTurnOwnerIdentity.ts
+++ b/middleware/packages/harness-orchestrator/src/resolveTurnOwnerIdentity.ts
@@ -1,4 +1,4 @@
-import type { ChatTurnInput } from '@omadia/channel-sdk';
+import { makePrincipal, type ChatTurnInput, type Principal } from '@omadia/channel-sdk';
 import type { KnowledgeGraph } from '@omadia/plugin-api';
 
 /**
@@ -38,6 +38,35 @@ export interface TurnOwnerIdentity {
    * read as "no token to inherit", never as licence to substitute a key.
    */
   authSubjectKey?: string;
+  /**
+   * Issue #333 — the turn owner as a `Principal`, the platform-wide way to name
+   * *who* a decision is about. This is the widening the Phase-0 spec (§6) calls
+   * for: #691 answered identity as two loose optional strings, and #575 needs a
+   * subject it can intersect entitlements over without re-deriving one.
+   *
+   * Derived from {@link TurnOwnerIdentity.omadiaUserId} only, never from
+   * `authSubjectKey`. An IdP subject names an account at a *provider*; a
+   * `Principal` names a subject in omadia's own id space. They are not
+   * interchangeable, and a turn whose cluster has a login but no canonical
+   * omadia id has no principal — the same fail-closed absence `omadiaUserId`
+   * already expresses.
+   *
+   * Always the `user` kind. A `role:` principal is a late-bound indirection
+   * over holders, which nothing about a single turn's caller can produce.
+   */
+  principal?: Principal;
+}
+
+/**
+ * #333 — attaches the `Principal` projection of an identity answer.
+ *
+ * A single place so both return paths agree by construction. `makePrincipal`
+ * canonicalizes, and refuses a blank id rather than minting a principal no
+ * binding row can ever match.
+ */
+function withPrincipal(identity: TurnOwnerIdentity): TurnOwnerIdentity {
+  const principal = identity.omadiaUserId ? makePrincipal('user', identity.omadiaUserId) : undefined;
+  return principal ? { ...identity, principal } : identity;
 }
 
 export async function resolveTurnOwnerIdentity(
@@ -47,7 +76,7 @@ export async function resolveTurnOwnerIdentity(
   if (!input.channelIdentity) {
     // Non-channel turns carry no cluster to read a subject from; the HTTP
     // path produces its own `mcpUserKey` from the live session instead.
-    return input.userId ? { omadiaUserId: input.userId } : {};
+    return input.userId ? withPrincipal({ omadiaUserId: input.userId }) : {};
   }
   // No KnowledgeGraph wired up ⇒ no way to resolve a channel identity into a
   // canonical uuid. Deliberately returns nothing rather than guessing with
@@ -60,12 +89,12 @@ export async function resolveTurnOwnerIdentity(
         channelKind: input.channelIdentity.channelKind,
         channelUserId: input.channelIdentity.channelUserId,
       });
-    return {
+    return withPrincipal({
       ...(omadiaUserId ? { omadiaUserId } : {}),
       ...(clusterAuthSubject
         ? { authSubjectKey: clusterAuthSubject.providerUserId }
         : {}),
-    };
+    });
   } catch (err) {
     console.warn(
       `[harness-orchestrator] resolveTurnOwnerIdentity: channel identity resolution failed — ${

--- a/middleware/src/conductor/principalId.ts
+++ b/middleware/src/conductor/principalId.ts
@@ -1,3 +1,5 @@
+import { canonicalizePrincipalRef } from '@omadia/channel-sdk';
+
 // Canonical id space for Conductor principals (US5 reminder/approval delivery).
 //
 // A reminder reaches a person only if the channel-binding key and the human-step principal /
@@ -8,8 +10,14 @@
 // Email/UPN ids are case-insensitive; AAD-object-id GUIDs are already lowercase — so trimming +
 // lowercasing is safe and lossless for both.
 
+// #333 Phase 1 — the rule itself now lives with the `Principal` type in the channel
+// SDK, so Conductor and every future Principal producer canonicalize identically.
+// Two independent implementations of "canonical" drifting apart would reintroduce
+// exactly the case-sensitive miss this function exists to prevent. Conductor's
+// principal ids are the `user` kind: `role` keys are canonicalized differently
+// (trim only) because `createRole` writes them verbatim — see `principal.ts`.
 export function canonicalizePrincipalId(id: string): string {
-  return id.trim().toLowerCase();
+  return canonicalizePrincipalRef('user', id);
 }
 
 /**

--- a/middleware/test/principal.test.ts
+++ b/middleware/test/principal.test.ts
@@ -1,0 +1,134 @@
+/**
+ * #333 Phase 1 — `Principal`.
+ *
+ * The assertions that matter here are the ones covering the two ways this type
+ * could be quietly wrong:
+ *
+ *  1. **The two kinds canonicalize differently** (user: trim+lowercase, role:
+ *     trim only). Collapsing them is a silent routing bug in either direction.
+ *  2. **A reference may contain colons**, because `coreApi.resolveIdentity`
+ *     builds `` `${kind}:${id}` `` platform ids. Parsing must split on the
+ *     first separator only.
+ *
+ * Plus a drift guard: Conductor's `canonicalizePrincipalId` and the SDK rule
+ * must stay byte-identical, since the SQL that decides whether a reminder
+ * reaches a person is a case-sensitive `=`.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  PRINCIPAL_KINDS,
+  canonicalizePrincipalRef,
+  formatPrincipal,
+  makePrincipal,
+  parsePrincipal,
+  principalRef,
+  principalsEqual,
+  type Principal,
+} from '../packages/harness-channel-sdk/src/principal.js';
+import { canonicalizePrincipalId } from '../src/conductor/principalId.js';
+
+describe('canonicalization is asymmetric by kind, and that is deliberate', () => {
+  it('user ids fold case, because the binding match is a case-sensitive =', () => {
+    assert.equal(canonicalizePrincipalRef('user', '  Jane@Co.COM '), 'jane@co.com');
+  });
+
+  it('role keys keep their case, because createRole writes them verbatim', () => {
+    // Lowercasing here would stop matching every mixed-case row already in a
+    // live deployment's `conductor_roles` table.
+    assert.equal(canonicalizePrincipalRef('role', '  Head-Of-Sales '), 'Head-Of-Sales');
+  });
+
+  it('the two rules actually differ for the same input', () => {
+    const raw = 'Approver';
+    assert.notEqual(canonicalizePrincipalRef('user', raw), canonicalizePrincipalRef('role', raw));
+  });
+});
+
+describe('makePrincipal', () => {
+  it('canonicalizes per kind', () => {
+    assert.deepEqual(makePrincipal('user', ' A@B.COM '), { kind: 'user', userId: 'a@b.com' });
+    assert.deepEqual(makePrincipal('role', ' Approver '), { kind: 'role', roleKey: 'Approver' });
+  });
+
+  it('refuses an empty reference rather than minting an unmatchable principal', () => {
+    assert.equal(makePrincipal('user', ''), undefined);
+    assert.equal(makePrincipal('user', '   '), undefined);
+    assert.equal(makePrincipal('role', '\t'), undefined);
+  });
+});
+
+describe('parsePrincipal', () => {
+  it('parses both kinds', () => {
+    assert.deepEqual(parsePrincipal('user:jane@co.com'), { kind: 'user', userId: 'jane@co.com' });
+    assert.deepEqual(parsePrincipal('role:Approver'), { kind: 'role', roleKey: 'Approver' });
+  });
+
+  it('splits on the FIRST colon — a platform id like `user:teams:<oid>` survives whole', () => {
+    // `coreApi.resolveIdentity` builds `${ref.kind}:${ref.id}`, so this is a
+    // real value, not a synthetic edge case. A naive split(':') truncates it.
+    const parsed = parsePrincipal('user:teams:29:1a2b3c');
+    assert.deepEqual(parsed, { kind: 'user', userId: 'teams:29:1a2b3c' });
+  });
+
+  it('round-trips through formatPrincipal', () => {
+    for (const wire of ['user:teams:29:1a2b3c', 'role:Head-Of-Sales', 'user:jane@co.com']) {
+      const parsed = parsePrincipal(wire);
+      assert.ok(parsed, wire);
+      assert.equal(formatPrincipal(parsed), wire);
+    }
+  });
+
+  it('returns undefined — never a user — for anything unparseable', () => {
+    // An unrecognised prefix falling back to `user` would route an approval to
+    // a person who does not exist.
+    for (const bad of [undefined, '', '   ', 'jane@co.com', 'group:eng', ':jane', 'user:', 'user:   ']) {
+      assert.equal(parsePrincipal(bad), undefined, JSON.stringify(bad));
+    }
+  });
+
+  it('canonicalizes what it parses', () => {
+    assert.deepEqual(parsePrincipal('  user:Jane@CO.com '), { kind: 'user', userId: 'jane@co.com' });
+  });
+});
+
+describe('principalsEqual', () => {
+  it('same kind + same ref is equal', () => {
+    assert.ok(principalsEqual({ kind: 'user', userId: 'a' }, { kind: 'user', userId: 'a' }));
+  });
+
+  it('a role is never a user, even spelled identically', () => {
+    // `role:` is a late-bound indirection resolved through the role resolver;
+    // treating it as the person of the same name skips that expansion.
+    const asUser: Principal = { kind: 'user', userId: 'approver' };
+    const asRole: Principal = { kind: 'role', roleKey: 'approver' };
+    assert.equal(principalsEqual(asUser, asRole), false);
+  });
+});
+
+describe('principalRef', () => {
+  it('reads the kind-appropriate field', () => {
+    assert.equal(principalRef({ kind: 'user', userId: 'u1' }), 'u1');
+    assert.equal(principalRef({ kind: 'role', roleKey: 'r1' }), 'r1');
+  });
+});
+
+describe('the kind list matches the Conductor schema constraint', () => {
+  it('is exactly the two kinds `principal_kind IN (user, role)` allows', () => {
+    // `conductor/migrations/0001_conductor.sql:77`. A third kind added here
+    // without a migration would be rejected by the database at write time.
+    assert.deepEqual([...PRINCIPAL_KINDS].sort(), ['role', 'user']);
+  });
+});
+
+describe('drift guard — Conductor delegates to the SDK rule', () => {
+  it('canonicalizePrincipalId is byte-identical to the user rule', () => {
+    // Two independent implementations of "canonical" drifting apart
+    // reintroduces exactly the case-sensitive miss both exist to prevent.
+    for (const raw of ['  Jane@Co.COM ', 'ALREADY-LOWER', 'a1b2-C3D4', '', '   ', 'teams:29:1a2b']) {
+      assert.equal(canonicalizePrincipalId(raw), canonicalizePrincipalRef('user', raw), JSON.stringify(raw));
+    }
+  });
+});

--- a/middleware/test/resolveTurnOwnerPrincipal.test.ts
+++ b/middleware/test/resolveTurnOwnerPrincipal.test.ts
@@ -1,0 +1,82 @@
+/**
+ * #333 Phase 1 — the turn seam produces a `Principal`.
+ *
+ * Spec §6: "#333 produces Principals. #575 consumes Principals and produces
+ * decisions." `resolveTurnOwnerIdentity` is where a turn's caller becomes a
+ * canonical omadia identity, so it is where the projection belongs — #575 must
+ * never have to re-derive one.
+ *
+ * The two properties worth pinning:
+ *
+ *  1. The principal mirrors `omadiaUserId` and NOTHING ELSE. In particular an
+ *     `authSubjectKey` present without a canonical id yields no principal — an
+ *     IdP subject names an account at a provider, not a subject in omadia's id
+ *     space, and substituting one for the other is a cross-space identity mixup.
+ *  2. Absence stays absence. A turn with no resolvable identity gets no
+ *     principal rather than a blank one, matching how `omadiaUserId` already
+ *     fails closed.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveTurnOwnerIdentity } from '../packages/harness-orchestrator/src/resolveTurnOwnerIdentity.js';
+
+type KgStub = Parameters<typeof resolveTurnOwnerIdentity>[0];
+
+function knowledgeGraphReturning(result: {
+  omadiaUserId?: string;
+  clusterAuthSubject?: { providerUserId: string };
+}): KgStub {
+  return {
+    resolveOrCreateChannelIdentity: async () => result,
+  } as unknown as KgStub;
+}
+
+const channelInput = {
+  userId: 'raw-channel-id',
+  channelIdentity: { channelKind: 'teams', channelUserId: 'aad-oid-1' },
+} as Parameters<typeof resolveTurnOwnerIdentity>[1];
+
+describe('#333 — resolveTurnOwnerIdentity projects a Principal', () => {
+  it('an HTTP turn: the canonical id becomes a user principal', async () => {
+    const identity = await resolveTurnOwnerIdentity(undefined, { userId: 'USER-Uuid-1' });
+    assert.equal(identity.omadiaUserId, 'USER-Uuid-1');
+    // Canonicalized by `makePrincipal`, so it matches a stored binding row.
+    assert.deepEqual(identity.principal, { kind: 'user', userId: 'user-uuid-1' });
+  });
+
+  it('a channel turn: the principal follows the RESOLVED id, not the raw channel id', async () => {
+    // The whole point of the join — `raw-channel-id` must never become the
+    // principal, or a dataset imported in Teams is unfindable by the same user.
+    const identity = await resolveTurnOwnerIdentity(
+      knowledgeGraphReturning({ omadiaUserId: 'canonical-uuid' }),
+      channelInput,
+    );
+    assert.deepEqual(identity.principal, { kind: 'user', userId: 'canonical-uuid' });
+  });
+
+  it('an authSubjectKey WITHOUT a canonical id yields no principal', async () => {
+    const identity = await resolveTurnOwnerIdentity(
+      knowledgeGraphReturning({ clusterAuthSubject: { providerUserId: 'idp-sub-9' } }),
+      channelInput,
+    );
+    assert.equal(identity.authSubjectKey, 'idp-sub-9');
+    assert.equal(identity.principal, undefined);
+  });
+
+  it('no identity at all: no principal', async () => {
+    assert.equal((await resolveTurnOwnerIdentity(undefined, { userId: '' })).principal, undefined);
+    assert.equal((await resolveTurnOwnerIdentity(undefined, channelInput)).principal, undefined);
+  });
+
+  it('a resolution failure degrades to no principal, not a guessed one', async () => {
+    const throwing = {
+      resolveOrCreateChannelIdentity: async () => {
+        throw new Error('graph down');
+      },
+    } as unknown as KgStub;
+    const identity = await resolveTurnOwnerIdentity(throwing, channelInput);
+    assert.deepEqual(identity, {});
+  });
+});

--- a/middleware/test/sessionLoggerGraphScope.test.ts
+++ b/middleware/test/sessionLoggerGraphScope.test.ts
@@ -27,6 +27,42 @@ test('graphScopeFor qualifies with the agent slug; sanitizes the base; undefined
   assert.equal(graphScopeFor(undefined, 'conv'), 'conv');
 });
 
+/**
+ * #575 D3 — the injective graph key is behind `OMADIA_INJECTIVE_SCOPE_KEYS`.
+ *
+ * `scopeGraphKey` has its own unit tests (`scopeId.test.ts`), but those prove
+ * only that the FUNCTION is injective. They say nothing about whether
+ * `graphScopeFor` — the single formula both the write and the read side use —
+ * actually consults the flag. A gate that is declared but never read passes
+ * every test while the fix it guards is unreachable, so the wiring needs its
+ * own assertion.
+ */
+test('OMADIA_INJECTIVE_SCOPE_KEYS switches graphScopeFor onto the injective key', () => {
+  const previous = process.env['OMADIA_INJECTIVE_SCOPE_KEYS'];
+  // `teams::c1` and `teams-c1` are distinct scopes that `sanitizeScope` folds
+  // onto one partition — the isolation hazard D3 exists for.
+  const collidingA = 'teams::c1';
+  const collidingB = 'teams-c1';
+  try {
+    delete process.env['OMADIA_INJECTIVE_SCOPE_KEYS'];
+    assert.equal(graphScopeFor(undefined, collidingA), graphScopeFor(undefined, collidingB));
+
+    process.env['OMADIA_INJECTIVE_SCOPE_KEYS'] = '1';
+    assert.notEqual(graphScopeFor(undefined, collidingA), graphScopeFor(undefined, collidingB));
+    // Already-lossless scopes keep a byte-identical key, so opting in does not
+    // orphan the partitions that were never at risk.
+    assert.equal(graphScopeFor(undefined, 'http-default'), 'http-default');
+    assert.equal(graphScopeFor('agent-a', 'conv'), 'agent-a::conv');
+
+    // Only the exact opt-in value counts — anything else stays on the old key.
+    process.env['OMADIA_INJECTIVE_SCOPE_KEYS'] = 'true';
+    assert.equal(graphScopeFor(undefined, collidingA), graphScopeFor(undefined, collidingB));
+  } finally {
+    if (previous === undefined) delete process.env['OMADIA_INJECTIVE_SCOPE_KEYS'];
+    else process.env['OMADIA_INJECTIVE_SCOPE_KEYS'] = previous;
+  }
+});
+
 test('an agent-bound SessionLogger ingests Turns under the qualified scope', async () => {
   const store = new InMemoryMemoryStore();
   const graph = new InMemoryKnowledgeGraph();


### PR DESCRIPTION
Phase 1 of #333's platform identity layer, cut along the line the Phase-0 spec (`specs/575-scope-and-identity-foundation/spec.md` §6) draws:

> **#333 produces Principals. #575 consumes Principals and produces decisions.**
> **#575 never resolves an identity; #333 never evaluates a permission.**

Nothing in this PR evaluates a permission.

## What this cut deliberately leaves out

The issue reads as greenfield; measured, it is not. `resolveTurnOwnerIdentity.ts` (#568, PR #691) already resolves a channel user to a canonical omadia id and the caller's cluster subject — that is the working seed of the join layer. So this PR is a **relocation and a widening**, not a new subsystem, and it stops well short of all of #333:

| In this PR | Deferred to a later phase |
|---|---|
| the `Principal` type + its wire form | role/attribute source registry (Entra groups, Odoo HR) — the `ProviderRegistry` generalization |
| Conductor delegating its canonicalizer | Conductor's `RoleResolver` moving from local to external |
| the turn seam producing a `Principal` | anything that reads an entitlement |

A 60-file PR is not reviewable; this one is 8 files.

**Untouched on purpose:** `index.ts:2074` / `routes/agentBuilder.ts:296`. That is `mcpClient.auth.resolveIdentity`, an unrelated contract that shares only the name — the spec marks it "#333 must not touch it."

## Where the type lives, and why it is additive

`harness-channel-sdk`, the same home as `ScopeId`: the orchestrator, the kernel and `middleware/src` all already depend on that package and it depends on none of them. These are **new exports only** — the published plugin contract (spec D2) is untouched, so the private byte5 channel plugins are unaffected across the repo boundary.

## The two findings the shape is built around

**1. `user` and `role` do not share a canonicalization rule.**

- User ids are **trimmed and lowercased**, because the SQL deciding whether a reminder actually reaches a person is a case-sensitive `=` (`channelBindingStore.ts:23,38,50`), and ids enter from unrelated sources (a Teams email, an operator-typed holder, an AAD object id).
- Role keys are **trimmed only**, because `createRole` (`roleStore.ts:26`) writes `key` verbatim and `resolve()` matches `role_key = $1`. Lowercasing here would stop matching every mixed-case row already sitting in a live deployment's `conductor_roles` table.

Collapsing the two is a silent routing bug in whichever direction it is collapsed. The variants therefore carry differently-named fields (`userId` / `roleKey`) rather than a shared `ref: string`, so the difference is visible at every use site instead of being the kind of invisible distinction that survives review.

**2. A principal reference can legitimately contain colons.**

`coreApi.resolveIdentity` builds its platform id as `` `${ref.kind}:${ref.id}` `` (`channels/coreApi.ts:111`), so `user:teams:29:1a2b` is real traffic. `parsePrincipal` splits on the **first** separator only — a naive `split(':')` truncates it into a principal that addresses the wrong person.

Anything unparseable returns `undefined`, **never a `user`**. An unrecognised prefix falling back to `{ kind: 'user' }` routes an approval to somebody who does not exist. Same reasoning as `ScopeId`'s `unscoped` variant: the absence is a type, not a value.

## Also in here: the wiring test #575 D3 was missing

`scopeGraphKey` shipped with #713/#714 behind `OMADIA_INJECTIVE_SCOPE_KEYS`, and `scopeId.test.ts` proves the **function** is injective. Nothing proved that `graphScopeFor` — the single formula both the write and the read side use — ever *consults* the flag. A gate that is declared but never read passes every test while the fix it guards sits unreachable. That test now exists, and it covers both directions plus the "only the exact opt-in value counts" case.

## Blast radius

| Surface | Effect |
|---|---|
| Published channel-SDK contract | none — additive exports only; `sessionScope` stays `string` (D2) |
| Private byte5 channel plugins | none — nothing they consume changed shape |
| `canonicalizePrincipalId` behaviour | byte-identical; the rule moved, the output did not |
| `TurnOwnerIdentity` | one new **optional** field; every existing reader is unaffected |
| Runtime behaviour | none — no call site branches on the new field yet |
| Database | none — no migration, no schema change |

## Verification

- Full suite: **6574 tests, 0 fail, 0 cancelled**, 12 pre-existing skips.
- `npm run typecheck` ✅ · `npm run lint` ✅
- #470 core-decoupling ratchet: held at 3294 ✅
- #573 test/scripts typecheck ratchet: 406 known, no regressions ✅

### Mutation checks (`dist/` rebuilt each time, or the check lies)

| Mutation | Result |
|---|---|
| collapse both canonicalization rules onto lowercase | **killed** — 5 tests |
| `parsePrincipal` splits on the last colon | **killed** — 2 tests |
| unknown prefix falls back to `{ kind: 'user' }` | **killed** — 1 test |
| `makePrincipal` accepts an empty reference | **killed** |
| `principalsEqual` ignores `kind` | **killed** — 1 test |
| principal derived from `authSubjectKey` too | **killed** — 1 test |
| `graphScopeFor` ignores `OMADIA_INJECTIVE_SCOPE_KEYS` | **killed** — 1 test |
| drop the lowercase from the shared SDK rule, rebuild `dist/` | **killed — 3 Conductor binding tests** |

The last one is the one that matters: it is what proves Conductor's delegation is **live through `dist/`**, not merely declared. A delegation that is written but not actually reached would leave every test green.

Refs #333

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789535795&installation_model_id=428086&pr_number=724&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F724&signature=119851efd585c52eafdbcaaec85e3c9a1a8bb46a6cca76dd79b8c266c8bade9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->