### PR TITLE
feat(#333): role sources + pluggable role→holder resolution (phases 2 and 3)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,32 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — an approval quorum could complete with too few approvals (#333, phase 3)
+
+- **Conductor's role→holder resolution is now pluggable — and two decisions built
+  on it were fail-open.** Holders used to come only from
+  `conductor_role_assignments`, so a *partially known* holder list could not
+  exist. Sourcing holders from an Entra group or an Odoo HR reporting line makes
+  it possible, and it turns out two places treated a shrunken list as the truth:
+  - **`quorum='all'` completed with too few approvals.** Every holder still
+    visible may have answered while the people an unreachable directory knows
+    about were never asked — a four-eyes approval silently becoming two-eyes.
+    The pre-existing guard covered only the *empty* list; the partial one looks
+    legitimate. It now refuses to complete and lets the deadline fallback run.
+  - **A human step could be skipped entirely.** "Role has no holder" triggers
+    the step's fallback by design (FR-024), but an empty list from a failed
+    lookup is *"we could not ask"*, not *"nobody holds this"*. It now parks the
+    await instead, so the real holders still get their chance.
+- **The authorization gate is deliberately left alone.** A shrunken list there
+  only rejects a genuine holder — it fails closed, which is the safe direction.
+- **The local assignment table is registered as an ordinary holder source**
+  rather than special-cased, so there is one merge path and the local store gets
+  the same throw-becomes-`unavailable` handling as any remote directory. A
+  source may not claim the reserved `conductor-local` id — that would substitute
+  its own approver list, so it is a boot-time collision.
+- With no external source configured the behaviour is unchanged: one source,
+  never partial.
+
 ### Added — role and attribute sources: what a `Principal` is entitled to (#333, phase 2)
 
 - **A pluggable `RoleSource` registry in the channel SDK.** Phase 1 answered

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,34 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — role and attribute sources: what a `Principal` is entitled to (#333, phase 2)
+
+- **A pluggable `RoleSource` registry in the channel SDK.** Phase 1 answered
+  *who* a turn's caller is; this answers *what they are entitled to* — the roles
+  an Entra group membership or an Odoo HR record confers. It still evaluates no
+  permission: the audience floor, grants and per-recipient filtering belong to
+  #575, which consumes these facts.
+- **Absence is a type, not an empty array.** `rolesFor` returns
+  `resolved | unavailable`, and the aggregate carries a `partial` flag. An empty
+  role set and "the directory was unreachable" are different facts, and merging
+  them is an authorization bug in whichever direction the caller guesses: read as
+  "this user has no roles" an outage silently strips every entitlement; read as
+  "unknown, so allow" it is a silent full grant. The same reasoning that made
+  `ScopeId`'s `unscoped` and `Principal`'s `undefined` types rather than values.
+- **The operator gate from `ProviderRegistry` is mirrored, and matters more
+  here.** Sources must be catalogued before they can be activated. An auth
+  provider decides whether you get in; a role source decides what you *are* once
+  inside, so registering one silently is privilege escalation with no login
+  event to notice.
+- **A throwing source degrades to `unavailable` instead of failing the turn** —
+  but it still appears in the per-source breakdown and still sets `partial`, so
+  a directory outage is diagnosable rather than invisible. Sources are queried
+  concurrently; they are independent network reads on a turn's hot path.
+- **A `role:` principal short-circuits without consulting any source.** Asking
+  what roles a role has is a category error — a role is an indirection over
+  holders — and answering it would invite a source to invent role nesting that
+  #575 has not specified.
+
 ### Added — `Principal`, the platform's typed answer to "who is this?" (#333, phase 1)
 
 - **A `Principal` type in the channel SDK**, the same home as `ScopeId` and for

--- a/middleware/packages/harness-channel-sdk/src/index.ts
+++ b/middleware/packages/harness-channel-sdk/src/index.ts
@@ -264,3 +264,18 @@ export {
   type RoleLookupUnavailableCode,
   type RoleSource,
 } from './roleSource.js';
+
+// #333 Phase 3 — the inverse direction: role → holders, which Conductor already
+// depends on (`roleStore.ts:22` calls the external resolver "a follow-up").
+// Introducing sources beyond the local table makes a PARTIALLY-known holder list
+// possible for the first time, and two Conductor decisions fail OPEN on one —
+// `quorum='all'` completeness and "no holder → take the fallback". Hence
+// `AggregateHolderLookup.partial`.
+export {
+  RoleHolderCatalog,
+  RoleHolderRegistry,
+  type AggregateHolderLookup,
+  type HolderLookup,
+  type HolderLookupUnavailableCode,
+  type RoleHolderSource,
+} from './roleHolderSource.js';

--- a/middleware/packages/harness-channel-sdk/src/index.ts
+++ b/middleware/packages/harness-channel-sdk/src/index.ts
@@ -250,3 +250,17 @@ export {
   type Principal,
   type PrincipalKind,
 } from './principal.js';
+
+// #333 Phase 2 — where a Principal's roles come from. Still no permission is
+// evaluated here: these resolve FACTS (Entra group membership, an Odoo HR
+// record) that #575 later intersects into decisions. The catalog/registry split
+// mirrors `auth/providerRegistry.ts` — and matters more, because a role source
+// decides what you ARE once inside, not merely whether you get in.
+export {
+  RoleSourceCatalog,
+  RoleSourceRegistry,
+  type AggregateRoleLookup,
+  type RoleLookup,
+  type RoleLookupUnavailableCode,
+  type RoleSource,
+} from './roleSource.js';

--- a/middleware/packages/harness-channel-sdk/src/roleHolderSource.ts
+++ b/middleware/packages/harness-channel-sdk/src/roleHolderSource.ts
@@ -1,0 +1,223 @@
+/**
+ * #333 Phase 3 — role → holders, resolved from pluggable sources.
+ *
+ * Phase 2 answered "what roles does this principal have?". This is the inverse
+ * direction, and it is the one Conductor already depends on:
+ * `conductor/roleStore.ts:22` calls an external resolver "a follow-up", and the
+ * Phase-0 spec (§6) assigns that follow-up to #333.
+ *
+ * Today a role's holders come only from `conductor_role_assignments`. With an
+ * Entra group or an Odoo HR org chart as a source, the holder set becomes a
+ * union across systems — which introduces a state that could not exist before:
+ * **a partially-known holder list**.
+ *
+ * ## Why partiality is not a nicety here
+ *
+ * Conductor makes three decisions from the holder list, and two of them fail
+ * OPEN if a shrunken list is mistaken for the truth:
+ *
+ * | Decision | Shrunken list does what | |
+ * |---|---|---|
+ * | "may this responder resolve the await?" | rejects a real holder | fail-closed, safe |
+ * | **`quorum='all'` completeness** | **completes with too few approvals** | fail-OPEN |
+ * | **"role has no holder → take the fallback"** | **skips the human step entirely** | fail-OPEN |
+ *
+ * A four-eyes approval silently becoming two-eyes during a directory outage, or
+ * an approval step being skipped altogether, are exactly the outcomes an
+ * approval workflow exists to prevent. So this module never hands out a bare
+ * `string[]`: {@link AggregateHolderLookup} carries `partial`, and the callers
+ * that can fail open are required to consult it.
+ *
+ * Same discipline as `roleSource.ts` and, before it, `ScopeId`'s `unscoped` and
+ * `Principal`'s `undefined`: **absence is a type, not a value.**
+ */
+
+import { canonicalizePrincipalRef } from './principal.js';
+
+/** Why a source could not answer. Never means "this role has no holders". */
+export type HolderLookupUnavailableCode =
+  /** The backing directory/API failed, timed out, or refused the read. */
+  | 'source_error'
+  /** Registered but not configured enough to answer yet. */
+  | 'not_configured'
+  /** The source has no concept of this role (not an error — it simply is not its role). */
+  | 'unknown_role';
+
+/**
+ * One source's answer about one role key.
+ *
+ * `resolved` with an empty `holders` array is a real answer: this source knows
+ * the role and nobody currently holds it. That is what legitimately triggers
+ * Conductor's fallback path — and it is precisely what `unavailable` must never
+ * be mistaken for.
+ */
+export type HolderLookup =
+  | { readonly outcome: 'resolved'; readonly holders: readonly string[] }
+  | {
+      readonly outcome: 'unavailable';
+      readonly code: HolderLookupUnavailableCode;
+      /** Operator-readable. Belongs in logs, never in an HTTP body. */
+      readonly message: string;
+    };
+
+/**
+ * A pluggable origin of role-holder facts — the local assignment table, an
+ * Entra group, an Odoo HR reporting line.
+ *
+ * The local Conductor store is registered as one of these rather than being
+ * special-cased, so composition has exactly one code path and the local store
+ * enjoys the same failure handling as any remote directory.
+ */
+export interface RoleHolderSource {
+  readonly id: string;
+  readonly displayName: string;
+  /**
+   * Current holders of `roleKey`, as principal ids.
+   *
+   * Implementations should **return** `unavailable` rather than throw; the
+   * registry defends against throwing anyway, because one unreachable directory
+   * must not take down a run.
+   */
+  holdersFor(roleKey: string): Promise<HolderLookup>;
+}
+
+/**
+ * The union across every active source.
+ *
+ * `partial` means `holders` is a LOWER BOUND: more people may hold this role
+ * than are listed. Nothing may be concluded from an id's absence — in
+ * particular not "this role has no holders" and not "everyone required has
+ * answered".
+ */
+export interface AggregateHolderLookup {
+  /** Canonical (trim + lowercase), de-duplicated, sorted for comparability. */
+  readonly holders: readonly string[];
+  /** True iff at least one active source failed to answer. */
+  readonly partial: boolean;
+  /** Per-source outcome, in registration order. For operator diagnostics. */
+  readonly bySource: readonly { readonly sourceId: string; readonly lookup: HolderLookup }[];
+}
+
+/**
+ * The superset of holder sources the operator allowed. Immutable after boot;
+ * the admin UI may only activate what is already here.
+ *
+ * Same two-tier gate as `auth/providerRegistry.ts`, and for a sharper reason: a
+ * holder source decides **who may approve**. Registering one silently would let
+ * an attacker nominate themselves as an approver with no login event to notice.
+ */
+export class RoleHolderCatalog {
+  private readonly sources = new Map<string, RoleHolderSource>();
+
+  add(source: RoleHolderSource): void {
+    if (this.sources.has(source.id)) {
+      throw new Error(`role-holder catalog id collision: ${source.id} already added`);
+    }
+    this.sources.set(source.id, source);
+  }
+
+  get(id: string): RoleHolderSource | undefined {
+    return this.sources.get(id);
+  }
+
+  has(id: string): boolean {
+    return this.sources.has(id);
+  }
+
+  list(): RoleHolderSource[] {
+    return Array.from(this.sources.values());
+  }
+}
+
+/** The currently-active holder sources, in registration order. */
+export class RoleHolderRegistry {
+  private readonly sources = new Map<string, RoleHolderSource>();
+
+  register(source: RoleHolderSource): void {
+    if (this.sources.has(source.id)) {
+      throw new Error(`role-holder source id collision: ${source.id} already registered`);
+    }
+    this.sources.set(source.id, source);
+  }
+
+  /**
+   * Activate a catalogued source by id. `false` means "not catalogued" and must
+   * be treated as refused — never worked around by constructing the source.
+   */
+  activate(catalog: RoleHolderCatalog, id: string): boolean {
+    const source = catalog.get(id);
+    if (!source) return false;
+    if (this.sources.has(id)) return true;
+    this.sources.set(id, source);
+    return true;
+  }
+
+  unregister(id: string): boolean {
+    return this.sources.delete(id);
+  }
+
+  has(id: string): boolean {
+    return this.sources.has(id);
+  }
+
+  list(): RoleHolderSource[] {
+    return Array.from(this.sources.values());
+  }
+
+  size(): number {
+    return this.sources.size;
+  }
+
+  /**
+   * Union the holders every active source reports for `roleKey`.
+   *
+   * Holder ids are canonicalized with the **user** rule (trim + lowercase),
+   * because a holder id IS a user principal — the same rule
+   * `canonicalizePrincipalId` applies before Conductor's case-sensitive `=`
+   * comparisons. Role KEYS keep their case; holder ids do not. Mixing the two
+   * rules up is a silent routing miss (see `principal.ts`).
+   *
+   * Sources are queried concurrently, and a throwing source becomes
+   * `unavailable` rather than rejecting — but it still appears in `bySource`
+   * and still sets `partial`, so it cannot disappear quietly.
+   *
+   * With no active sources the result is `partial: false` and empty: a
+   * deployment that configured nothing has genuinely no holders, which is a
+   * complete answer rather than a failed lookup.
+   */
+  async resolveHolders(roleKey: string): Promise<AggregateHolderLookup> {
+    const bySource = await Promise.all(
+      this.list().map(async (source) => ({
+        sourceId: source.id,
+        lookup: await safeHoldersFor(source, roleKey),
+      })),
+    );
+
+    const holders = new Set<string>();
+    let partial = false;
+    for (const { lookup } of bySource) {
+      if (lookup.outcome === 'unavailable') {
+        partial = true;
+        continue;
+      }
+      for (const holder of lookup.holders) {
+        const canonical = canonicalizePrincipalRef('user', holder);
+        if (canonical.length > 0) holders.add(canonical);
+      }
+    }
+
+    return { holders: [...holders].sort(), partial, bySource };
+  }
+}
+
+async function safeHoldersFor(source: RoleHolderSource, roleKey: string): Promise<HolderLookup> {
+  try {
+    return await source.holdersFor(roleKey);
+  } catch (err) {
+    return {
+      outcome: 'unavailable',
+      code: 'source_error',
+      message: `role-holder source ${source.id} threw: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}

--- a/middleware/packages/harness-channel-sdk/src/roleSource.ts
+++ b/middleware/packages/harness-channel-sdk/src/roleSource.ts
@@ -1,0 +1,248 @@
+/**
+ * #333 Phase 2 — role and attribute sources: "what is this Principal entitled to?"
+ *
+ * Phase 1 gave the platform a `Principal` — a typed answer to *who*. This is
+ * the other half of the question `specs/575-scope-and-identity-foundation/spec.md`
+ * §6 assigns to #333:
+ *
+ * > **#333 answers "who is this, and what are they entitled to?"**
+ * > **#333 produces Principals. #575 consumes Principals and produces decisions.**
+ *
+ * So this file resolves **facts about a principal** — the roles an Entra group
+ * membership or an Odoo HR record confers. It never decides whether those roles
+ * permit anything. The audience floor, grants and per-recipient filtering are
+ * #575's, and they consume what this returns.
+ *
+ * ## Shape borrowed from `ProviderRegistry`, and why the split matters MORE here
+ *
+ * `auth/providerRegistry.ts` separates a **catalog** (the superset an operator
+ * allowed via env) from the **active registry** (what the admin UI switched on),
+ * so "a compromised admin can never enable a provider the operator didn't
+ * intend". A role source is strictly more dangerous than an auth provider: an
+ * auth provider decides *whether you get in*, a role source decides *what you
+ * are once inside*. Silently registering one is privilege escalation with no
+ * login event to notice. The same two-tier gate is therefore mandatory here,
+ * not decorative.
+ *
+ * ## The one property everything else hangs on: absence is a TYPE
+ *
+ * `rolesFor` never returns a bare array. An empty array and "the directory was
+ * unreachable" are different facts, and collapsing them is an authorization bug
+ * in whichever direction the caller happens to guess:
+ *
+ *  - Read as *"this user has no roles"*, an unreachable Entra tenant quietly
+ *    strips every entitlement — a self-inflicted outage that looks like policy.
+ *  - Read as *"unknown, so allow"*, it is a silent full grant.
+ *
+ * `RoleLookup` forces the caller to see the difference, and
+ * {@link AggregateRoleLookup.partial} carries it through aggregation so a
+ * consumer cannot accidentally treat a half-answered lookup as complete. This
+ * is the same reasoning that made `ScopeId`'s `unscoped` and `Principal`'s
+ * `undefined` types rather than values.
+ */
+
+import { canonicalizePrincipalRef, type Principal } from './principal.js';
+
+/** Why a source could not answer. Never means "the principal has no roles". */
+export type RoleLookupUnavailableCode =
+  /** The backing directory/API failed, timed out, or refused the read. */
+  | 'source_error'
+  /** The source is registered but not configured enough to answer yet. */
+  | 'not_configured'
+  /** The source does not know this principal at all (no record, not an error). */
+  | 'unknown_principal';
+
+/**
+ * One source's answer about one principal.
+ *
+ * `resolved` with an empty `roles` array is a real, trustworthy answer: the
+ * source knows this principal and confers nothing. That is NOT the same as
+ * `unavailable`.
+ */
+export type RoleLookup =
+  | { readonly outcome: 'resolved'; readonly roles: readonly string[] }
+  | {
+      readonly outcome: 'unavailable';
+      readonly code: RoleLookupUnavailableCode;
+      /** Operator-readable. Belongs in logs, never in an HTTP body. */
+      readonly message: string;
+    };
+
+/**
+ * A pluggable origin of role/attribute facts — Entra group membership, an Odoo
+ * HR record, a local table.
+ *
+ * Mirrors `AuthProvider`: a stable `id` the registry keys on, a `displayName`
+ * for operator surfaces, and one async method. Implementations live outside
+ * this package (`middleware/src`), so this file stays dependency-free and
+ * importable from the orchestrator, the kernel and the middleware alike.
+ */
+export interface RoleSource {
+  readonly id: string;
+  readonly displayName: string;
+  /**
+   * Roles this source confers on `principal`.
+   *
+   * Implementations should **return** `unavailable` rather than throw, but the
+   * registry defends against throwing anyway — a source that rejects must not
+   * be able to take down a turn (see {@link RoleSourceRegistry.resolveRoles}).
+   */
+  rolesFor(principal: Principal): Promise<RoleLookup>;
+}
+
+/**
+ * The combined answer across every active source.
+ *
+ * `partial` is the field that matters. It is `true` when at least one source
+ * could not answer, which means `roles` is a LOWER BOUND and nothing may be
+ * concluded from a role's absence. A consumer that ignores it will eventually
+ * deny a legitimate action during a directory outage, or — worse — treat the
+ * empty set as "no restrictions apply".
+ */
+export interface AggregateRoleLookup {
+  /** Canonical, de-duplicated, sorted. Sorted so results are comparable. */
+  readonly roles: readonly string[];
+  /** True iff at least one active source failed to answer. */
+  readonly partial: boolean;
+  /** Per-source outcome, in registration order. For operator diagnostics. */
+  readonly bySource: readonly { readonly sourceId: string; readonly lookup: RoleLookup }[];
+}
+
+/**
+ * The superset of sources the operator allowed. Built once at boot from
+ * configuration and immutable thereafter — the admin UI may only activate
+ * something that already exists here.
+ */
+export class RoleSourceCatalog {
+  private readonly sources = new Map<string, RoleSource>();
+
+  add(source: RoleSource): void {
+    if (this.sources.has(source.id)) {
+      throw new Error(`role-source catalog id collision: ${source.id} already added`);
+    }
+    this.sources.set(source.id, source);
+  }
+
+  get(id: string): RoleSource | undefined {
+    return this.sources.get(id);
+  }
+
+  has(id: string): boolean {
+    return this.sources.has(id);
+  }
+
+  list(): RoleSource[] {
+    return Array.from(this.sources.values());
+  }
+}
+
+/**
+ * The currently-active sources, in registration order.
+ *
+ * Activation goes through {@link RoleSourceRegistry.activate}, which takes the
+ * catalog as its gate — there is deliberately no way to register an arbitrary
+ * object. `register` exists for boot-time wiring and tests, where the caller
+ * already holds the instance it intends to trust.
+ */
+export class RoleSourceRegistry {
+  private readonly sources = new Map<string, RoleSource>();
+
+  register(source: RoleSource): void {
+    if (this.sources.has(source.id)) {
+      throw new Error(`role-source id collision: ${source.id} already registered`);
+    }
+    this.sources.set(source.id, source);
+  }
+
+  /**
+   * Activate a catalogued source by id. Returns false when the id is not in the
+   * catalog — the operator gate. Callers must treat `false` as "refused", never
+   * retry by constructing the source themselves.
+   */
+  activate(catalog: RoleSourceCatalog, id: string): boolean {
+    const source = catalog.get(id);
+    if (!source) return false;
+    if (this.sources.has(id)) return true;
+    this.sources.set(id, source);
+    return true;
+  }
+
+  unregister(id: string): boolean {
+    return this.sources.delete(id);
+  }
+
+  has(id: string): boolean {
+    return this.sources.has(id);
+  }
+
+  list(): RoleSource[] {
+    return Array.from(this.sources.values());
+  }
+
+  size(): number {
+    return this.sources.size;
+  }
+
+  /**
+   * Ask every active source about `principal` and merge the answers.
+   *
+   * Three deliberate behaviours:
+   *
+   *  1. **A `role:` principal short-circuits.** Asking "what roles does this
+   *     role have?" is a category error — a role is an indirection over
+   *     holders, not a subject with entitlements. Resolving it here would
+   *     invite a source to invent an answer, and role nesting is a design
+   *     decision #575 has not made. It resolves to no roles, with no source
+   *     consulted, so the outcome is `resolved` and NOT `partial`: this is a
+   *     complete answer, not a failed one.
+   *  2. **Sources run concurrently.** They are independent network reads on a
+   *     turn's hot path; serialising them would add every directory's latency
+   *     together.
+   *  3. **A throwing source becomes `unavailable`, never an exception.** One
+   *     misbehaving directory must not fail the turn — but it must also not
+   *     vanish, so it lands in `bySource` and sets `partial`.
+   */
+  async resolveRoles(principal: Principal): Promise<AggregateRoleLookup> {
+    if (principal.kind === 'role') {
+      return { roles: [], partial: false, bySource: [] };
+    }
+
+    const active = this.list();
+    const bySource = await Promise.all(
+      active.map(async (source) => ({
+        sourceId: source.id,
+        lookup: await safeRolesFor(source, principal),
+      })),
+    );
+
+    const roles = new Set<string>();
+    let partial = false;
+    for (const { lookup } of bySource) {
+      if (lookup.outcome === 'unavailable') {
+        partial = true;
+        continue;
+      }
+      for (const role of lookup.roles) {
+        // Canonicalized with the `role` rule — trim only. Lowercasing here
+        // would stop matching the mixed-case keys `createRole` writes verbatim
+        // (see `principal.ts`), which is how a role silently stops resolving.
+        const canonical = canonicalizePrincipalRef('role', role);
+        if (canonical.length > 0) roles.add(canonical);
+      }
+    }
+
+    return { roles: [...roles].sort(), partial, bySource };
+  }
+}
+
+async function safeRolesFor(source: RoleSource, principal: Principal): Promise<RoleLookup> {
+  try {
+    return await source.rolesFor(principal);
+  } catch (err) {
+    return {
+      outcome: 'unavailable',
+      code: 'source_error',
+      message: `role source ${source.id} threw: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}

--- a/middleware/src/conductor/index.ts
+++ b/middleware/src/conductor/index.ts
@@ -5,7 +5,10 @@ import type { Pool } from 'pg';
 import type { OrchestratorRegistry } from '@omadia/orchestrator';
 import type { JsonObject, KnownRefs } from '@omadia/conductor-core';
 
+import type { RoleHolderSource } from '@omadia/channel-sdk';
+
 import { runConductorMigrations } from './migrator.js';
+import { buildRoleHolderRegistry, holdersOnly } from './roleHolderResolver.js';
 import { ConductorWorkflowStore } from './workflowStore.js';
 import { ConductorRunStore } from './runStore.js';
 import type { ConductorRun } from './runStore.js';
@@ -136,6 +139,15 @@ export async function wireConductor(deps: {
   eventCatalog?: { list(): string[]; byPluginId(): Record<string, string[]> };
   /** resolves a proactive sender for a channel (US5 reminders) — from the routines senderRegistry. */
   getProactiveSender?: (channel: string) => ProactiveSenderLike | undefined;
+  /**
+   * #333 phase 3 — external role→holder sources (Entra group, Odoo HR reporting line) unioned
+   * with Conductor's own assignment table. Omit for local-only behaviour, which is what every
+   * deployment has today: one source, never a partial lookup.
+   *
+   * Each source must be one the operator allowed; the registry rejects a duplicate id, so an
+   * external source cannot shadow `conductor-local` and substitute its own approver list.
+   */
+  roleHolderSources?: readonly RoleHolderSource[];
   /** Per-agent-scoped secret vault (issue #437) — inbound endpoint secrets and outbound
    *  subscription signing secrets live here under the `core:conductor` namespace, never
    *  in a Postgres column or an API response body beyond their one-time creation reply. */
@@ -161,6 +173,10 @@ export async function wireConductor(deps: {
   const runStore = new ConductorRunStore(deps.pool);
   const awaitStore = new ConductorAwaitStore(deps.pool);
   const roleStore = new ConductorRoleStore(deps.pool);
+  // #333 phase 3 — role→holder resolution goes through a registry, with the local assignment
+  // table registered as an ordinary source. `deps.roleHolderSources` is where an integration
+  // (Entra group, Odoo HR reporting line) plugs in; empty today, so behaviour is unchanged.
+  const roleHolderRegistry = buildRoleHolderRegistry(roleStore, deps.roleHolderSources ?? []);
   const scheduleStore = new ConductorScheduleStore(deps.pool);
   const channelBindingStore = new ConductorChannelBindingStore(deps.pool);
 
@@ -215,7 +231,11 @@ export async function wireConductor(deps: {
       ...(deps.invokeAction ? { invokeAction: deps.invokeAction } : {}),
       log,
     }),
-    resolveRoleHolders: (key) => roleStore.resolve(key), // quorum='all' required-responder resolution
+    // #333 phase 3 — resolved through the holder registry rather than the assignment table
+    // directly. With no external source activated this is byte-for-byte today's behaviour (one
+    // source, never partial); once one is, the executor sees `partial` and refuses to complete a
+    // quorum='all' or take a fallback on a holder list it could not fully read.
+    resolveRoleHolders: (key) => roleHolderRegistry.resolveHolders(key),
     // Issue #437 — run-lifecycle outbound webhooks. Best-effort and fire-and-forget;
     // a delivery lost to a crash in this exact window is recovered by
     // `reconcileMissingWebhookDeliveries` above (issue #437 finding).
@@ -264,7 +284,11 @@ export async function wireConductor(deps: {
     awaitStore,
     executor,
     bindingStore: channelBindingStore,
-    resolveRoleHolders: (key) => roleStore.resolve(key),
+    // Same registry as the executor, flattened to a list: nudging is the one consumer where a
+    // partial lookup degrades safely — reminding fewer people is a missed nudge, not a wrong
+    // decision, and the await's deadline still fires. `holdersOnly` marks that choice explicitly
+    // rather than letting a `.holders` access hide it.
+    resolveRoleHolders: holdersOnly((key) => roleHolderRegistry.resolveHolders(key)),
     ...(deps.getProactiveSender ? { getProactiveSender: deps.getProactiveSender } : {}),
     describeApproval,
     log,

--- a/middleware/src/conductor/roleHolderResolver.ts
+++ b/middleware/src/conductor/roleHolderResolver.ts
@@ -1,0 +1,81 @@
+import {
+  RoleHolderRegistry,
+  type AggregateHolderLookup,
+  type HolderLookup,
+  type RoleHolderSource,
+} from '@omadia/channel-sdk';
+
+import type { ConductorRoleStore } from './roleStore.js';
+
+/**
+ * #333 Phase 3 — wires Conductor's role→holder resolution onto the pluggable
+ * registry that `roleStore.ts:22` has been calling "a follow-up" since US5.
+ *
+ * The local assignment table is registered as an ordinary `RoleHolderSource`
+ * rather than being special-cased ahead of the others. That is deliberate: with
+ * one code path, the local store gets the same throw-becomes-`unavailable`
+ * handling as any remote directory, and there is no second merge routine that
+ * could drift from the first.
+ *
+ * ## The id is load-bearing for the operator gate
+ *
+ * `'conductor-local'` is reserved for this source. An external source claiming
+ * that id would collide at registration (the registry throws) rather than
+ * silently shadowing the assignment table — which would be a way to substitute
+ * one's own approver list.
+ */
+export const LOCAL_ROLE_HOLDER_SOURCE_ID = 'conductor-local';
+
+/**
+ * The `conductor_role_assignments` table as a holder source.
+ *
+ * A database error surfaces as `unavailable`, NOT as "no holders". Before this
+ * the distinction did not exist: `roleStore.resolve()` rejected, and the
+ * rejection propagated. Now the caller sees a partial result and can refuse to
+ * conclude from it — which is the entire point of the phase.
+ */
+export function localRoleHolderSource(roleStore: ConductorRoleStore): RoleHolderSource {
+  return {
+    id: LOCAL_ROLE_HOLDER_SOURCE_ID,
+    displayName: 'Conductor role assignments',
+    async holdersFor(roleKey: string): Promise<HolderLookup> {
+      const holders = await roleStore.resolve(roleKey);
+      return { outcome: 'resolved', holders };
+    },
+  };
+}
+
+/**
+ * Builds the registry Conductor resolves through: the local table plus whatever
+ * external sources the operator activated.
+ *
+ * Passing no external sources reproduces today's behaviour exactly — one
+ * source, never partial — so introducing this seam changes nothing until a
+ * deployment opts in.
+ */
+export function buildRoleHolderRegistry(
+  roleStore: ConductorRoleStore,
+  externals: readonly RoleHolderSource[] = [],
+): RoleHolderRegistry {
+  const registry = new RoleHolderRegistry();
+  registry.register(localRoleHolderSource(roleStore));
+  for (const source of externals) registry.register(source);
+  return registry;
+}
+
+/** The resolver shape Conductor's executor and workers consume. */
+export type RoleHolderResolver = (roleKey: string) => Promise<AggregateHolderLookup>;
+
+/**
+ * Adapter for the call sites that legitimately only need a list — the operator
+ * inbox and the reminder nudger. Both degrade gracefully on a partial result:
+ * they show or nudge whoever is known, and showing fewer people is not a
+ * correctness failure the way completing a quorum with fewer people is.
+ *
+ * Deliberately NOT used by `RunExecutor`. Its two decisions
+ * (`quorum='all'` completeness and "no holder → take the fallback") fail OPEN on
+ * a shrunken list, so they must see `partial` and are typed to receive it.
+ */
+export function holdersOnly(resolver: RoleHolderResolver): (roleKey: string) => Promise<string[]> {
+  return async (roleKey) => [...(await resolver(roleKey)).holders];
+}

--- a/middleware/src/conductor/runExecutor.ts
+++ b/middleware/src/conductor/runExecutor.ts
@@ -9,6 +9,8 @@ import { RunLeaseLostError } from './runStore.js';
 import type { ConductorAwaitStore } from './awaitStore.js';
 import type { StepEffects } from './stepEffects.js';
 import { canonicalizePrincipalId } from './principalId.js';
+import type { RoleHolderResolver } from './roleHolderResolver.js';
+import type { AggregateHolderLookup } from '@omadia/channel-sdk';
 
 export class WorkflowNotFoundError extends Error {}
 export class WorkflowDisabledError extends Error {}
@@ -75,8 +77,14 @@ export class ConductorRunExecutor {
   private readonly awaitStore: ConductorAwaitStore;
   private readonly effects: StepEffects;
   /** Late-bound role→holders resolver — the required responders for a quorum='all' role await.
-   *  Required (not optional) so a role-based 'all' can never silently degrade to 'any' when unwired. */
-  private readonly resolveRoleHolders: (roleKey: string) => Promise<string[]>;
+   *  Required (not optional) so a role-based 'all' can never silently degrade to 'any' when unwired.
+   *
+   *  #333 phase 3 — returns an `AggregateHolderLookup`, not a bare list, because both decisions
+   *  this executor makes from it fail OPEN on a shrunken list: a quorum='all' would complete with
+   *  too few approvals, and `openHumanAwait` would mistake "we could not ask" for "nobody holds
+   *  this role" and take the fallback, skipping the human step entirely. The type forces both
+   *  sites to see `partial`. */
+  private readonly resolveRoleHolders: RoleHolderResolver;
   /** Issue #437 — fired once a REAL (non-dry-run) run reaches a terminal status
    *  ('completed'/'failed'). Feeds the outbound webhook dispatcher; best-effort and
    *  never awaited inline — a slow/broken subscriber must not stall run driving. */
@@ -88,7 +96,7 @@ export class ConductorRunExecutor {
     runStore: ConductorRunStore;
     awaitStore: ConductorAwaitStore;
     effects: StepEffects;
-    resolveRoleHolders: (roleKey: string) => Promise<string[]>;
+    resolveRoleHolders: RoleHolderResolver;
     notifyRunEnded?: (run: ConductorRun) => void;
     log?: (msg: string) => void;
   }) {
@@ -276,9 +284,17 @@ export class ConductorRunExecutor {
     // Holders resolved LIVE (baton moves re-target) and canonicalized so a lowercased-email responder
     // (the channel layer always lowercases) matches an operator-typed holder. Used for BOTH the
     // authorization gate below and the quorum='all' completeness check.
-    const required = (
-      aw.principalKind === 'role' ? await this.resolveRoleHolders(aw.principalRef) : [aw.principalRef]
-    ).map(canonicalizePrincipalId);
+    //
+    // #333 phase 3 — `holdersPartial` is true when a holder source could not answer, which makes
+    // `required` a LOWER BOUND rather than the truth. It is deliberately NOT applied to the
+    // authorization gate: a shrunken list there merely rejects a real holder, which fails closed.
+    // It IS applied to the quorum='all' completeness check below, which fails OPEN.
+    const roleHolders: AggregateHolderLookup =
+      aw.principalKind === 'role'
+        ? await this.resolveRoleHolders(aw.principalRef)
+        : { holders: [aw.principalRef], partial: false, bySource: [] };
+    const required = [...roleHolders.holders].map(canonicalizePrincipalId);
+    const holdersPartial = roleHolders.partial;
     const requiredSet = new Set(required);
     const responder = canonicalizePrincipalId(responderId);
 
@@ -303,8 +319,24 @@ export class ConductorRunExecutor {
       // Empty `required` (a role with no current holders, e.g. all batons moved away) is NOT
       // vacuously complete — that would let one stray response resolve a no-holder await. Such a
       // run stays waiting until its deadline fires the fallback (FR-024).
-      const complete = required.length > 0 && required.every((h) => respondedRequired.has(h));
+      //
+      // #333 phase 3 — nor is a PARTIAL holder list ever complete. The pre-existing guard above
+      // covers the empty case; the partial case could not arise while holders came only from the
+      // local table, and it is the more dangerous one: `required` looks plausible and non-empty
+      // while silently omitting whoever the unreachable source knows about, so a four-eyes
+      // approval would complete on two. Failing closed stalls the run until its deadline fires
+      // the fallback — the same well-trodden path an unanswered await already takes.
+      const complete =
+        !holdersPartial && required.length > 0 && required.every((h) => respondedRequired.has(h));
       if (!complete) {
+        if (holdersPartial) {
+          this.log(
+            `[conductor] await ${awaitId} quorum 'all': REFUSING to complete — holder list is partial (${roleHolders.bySource
+              .filter((s) => s.lookup.outcome === 'unavailable')
+              .map((s) => s.sourceId)
+              .join(', ')} unavailable)`,
+          );
+        }
         this.log(`[conductor] await ${awaitId} quorum 'all': ${respondedRequired.size}/${required.length} required responded`);
         return (await this.runStore.get(aw.runId)) ?? (await this.requireRun(aw.runId));
       }
@@ -434,8 +466,17 @@ export class ConductorRunExecutor {
   private async openHumanAwait(runId: string, step: Step, context: JsonObject, lease: string): Promise<boolean> {
     const h = step.human;
     if (h?.principal.kind === 'role') {
-      const holders = await this.resolveRoleHolders(h.principal.ref);
-      if (holders.length === 0) {
+      const lookup = await this.resolveRoleHolders(h.principal.ref);
+      // #333 phase 3 — "no holders" may only trigger the fallback when we actually KNOW there are
+      // none. On a partial lookup an empty list means "we could not ask", and taking the fallback
+      // there would skip the human step altogether — an approval silently bypassed by a directory
+      // outage. Park instead: the await's own deadline reaches the same fallback later, but only
+      // after giving the real holders a chance to answer.
+      if (lookup.holders.length === 0 && lookup.partial) {
+        this.log(
+          `[conductor] run ${runId} human step '${step.id}' role '${h.principal.ref}': holder lookup is PARTIAL and empty — parking rather than taking the fallback`,
+        );
+      } else if (lookup.holders.length === 0) {
         this.log(`[conductor] run ${runId} human step '${step.id}' role '${h.principal.ref}' has no current holder`);
         return false;
       }

--- a/middleware/test/conductorQuorumAndTimeout.test.ts
+++ b/middleware/test/conductorQuorumAndTimeout.test.ts
@@ -52,7 +52,13 @@ describe('ConductorRunExecutor.resolveAwait quorum=all', () => {
     transitions: [],
   };
 
-  function makeExecutor(opts: { responders: string[]; holders: string[]; onClose: () => void }) {
+  function makeExecutor(opts: {
+    responders: string[];
+    holders: string[];
+    onClose: () => void;
+    /** #333 phase 3 — simulates a holder source that could not answer. */
+    partial?: boolean;
+  }) {
     const responses = opts.responders.map((id) => ({ responderId: id, response: { approved: true } }));
     const awaitRow = {
       id: 'aw1', runId: 'run1', stepId: 'h1', principalKind: 'role', principalRef: 'approvers',
@@ -83,7 +89,16 @@ describe('ConductorRunExecutor.resolveAwait quorum=all', () => {
       runStore: runStore as never,
       awaitStore: awaitStore as never,
       effects: {} as never,
-      resolveRoleHolders: async () => opts.holders,
+      // #333 phase 3 — the resolver returns an AggregateHolderLookup so the executor can see a
+      // partially-known holder list. `partial: false` here reproduces the pre-phase-3 world:
+      // one authoritative source, fully readable.
+      resolveRoleHolders: async () => ({
+        holders: opts.holders,
+        partial: opts.partial ?? false,
+        bySource: opts.partial
+          ? [{ sourceId: 'entra', lookup: { outcome: 'unavailable' as const, code: 'source_error' as const, message: 'down' } }]
+          : [],
+      }),
     });
   }
 
@@ -99,6 +114,39 @@ describe('ConductorRunExecutor.resolveAwait quorum=all', () => {
     let closed = false;
     const exec = makeExecutor({ responders: ['alice', 'bob'], holders: ['alice', 'bob'], onClose: () => { closed = true; } });
     await exec.resolveAwait('aw1', 'bob', { approved: true });
+    assert.equal(closed, true);
+  });
+
+  // #333 phase 3 — the fail-OPEN case this phase had to close.
+  //
+  // Once holders can come from more than the local table, an unreachable source shrinks the
+  // required set. Every holder the executor still knows about may then have answered, so the
+  // quorum looks satisfied — while the people the failed source knows about were never asked.
+  // A four-eyes approval would complete on two. The pre-existing `required.length > 0` guard
+  // covers the EMPTY case only; the partial case is the one that looks legitimate.
+  it('REFUSES to close when the holder list is partial, even though everyone known has responded', async () => {
+    let closed = false;
+    const exec = makeExecutor({
+      responders: ['alice'],
+      holders: ['alice'], // all *known* holders answered …
+      partial: true, // … but a source was unreachable, so this is a lower bound
+      onClose: () => { closed = true; },
+    });
+    await exec.resolveAwait('aw1', 'alice', { approved: true });
+    assert.equal(closed, false, 'a partial holder list must never satisfy quorum=all');
+  });
+
+  it('the same responses DO close once the holder list is complete', async () => {
+    // Control for the test above: identical inputs, `partial: false`. Without this pair the
+    // refusal could pass for an unrelated reason and nobody would notice.
+    let closed = false;
+    const exec = makeExecutor({
+      responders: ['alice'],
+      holders: ['alice'],
+      partial: false,
+      onClose: () => { closed = true; },
+    });
+    await exec.resolveAwait('aw1', 'alice', { approved: true });
     assert.equal(closed, true);
   });
 });

--- a/middleware/test/conductorRunExecutorNotifyRunEnded.test.ts
+++ b/middleware/test/conductorRunExecutorNotifyRunEnded.test.ts
@@ -69,7 +69,7 @@ function makeHarness(opts: { isDryRun: boolean; fallbackTransitionId?: string | 
     runStore: runStore as never,
     awaitStore: awaitStore as never,
     effects: {} as never,
-    resolveRoleHolders: async () => [],
+    resolveRoleHolders: async () => ({ holders: [], partial: false, bySource: [] }),
     notifyRunEnded: (endedRun) => notified.push(endedRun),
   });
   return { executor, notified };
@@ -135,7 +135,7 @@ describe('ConductorRunExecutor — notifyRunEnded (issue #437)', () => {
       runStore: runStore as never,
       awaitStore: awaitStore as never,
       effects: {} as never,
-      resolveRoleHolders: async () => [],
+      resolveRoleHolders: async () => ({ holders: [], partial: false, bySource: [] }),
       notifyRunEnded: () => {
         throw new Error('dispatcher blew up');
       },

--- a/middleware/test/roleHolderSource.test.ts
+++ b/middleware/test/roleHolderSource.test.ts
@@ -1,0 +1,180 @@
+/**
+ * #333 Phase 3 — role → holders from pluggable sources.
+ *
+ * The registry tests mirror phase 2's; the ones that earn their keep are at the
+ * bottom, where a partial holder list meets Conductor's two decisions that fail
+ * OPEN on one:
+ *
+ *   - `quorum='all'` completing with too few approvals, and
+ *   - "role has no holder → take the fallback" skipping the human step.
+ *
+ * Both were unreachable while holders came only from the local table. This
+ * phase makes them reachable, so it also has to make them safe.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  RoleHolderCatalog,
+  RoleHolderRegistry,
+  type HolderLookup,
+  type RoleHolderSource,
+} from '../packages/harness-channel-sdk/src/roleHolderSource.js';
+import {
+  LOCAL_ROLE_HOLDER_SOURCE_ID,
+  buildRoleHolderRegistry,
+  holdersOnly,
+} from '../src/conductor/roleHolderResolver.js';
+
+function source(id: string, lookup: HolderLookup | (() => Promise<HolderLookup>)): RoleHolderSource {
+  return {
+    id,
+    displayName: id,
+    holdersFor: typeof lookup === 'function' ? lookup : async () => lookup,
+  };
+}
+
+const resolved = (...holders: string[]): HolderLookup => ({ outcome: 'resolved', holders });
+const down = (): HolderLookup => ({
+  outcome: 'unavailable',
+  code: 'source_error',
+  message: 'entra unreachable',
+});
+
+describe('a partial holder list is never mistaken for the truth', () => {
+  it('a source that knows the role and reports nobody is NOT partial', async () => {
+    const reg = new RoleHolderRegistry();
+    reg.register(source('local', resolved()));
+    const out = await reg.resolveHolders('approver');
+    assert.deepEqual(out.holders, []);
+    assert.equal(out.partial, false);
+  });
+
+  it('a source that cannot answer IS partial — with an identical empty list', async () => {
+    // The two cases are indistinguishable by `holders` alone. That is the whole
+    // reason `partial` exists: one legitimately triggers Conductor's fallback,
+    // the other must never be allowed to.
+    const reg = new RoleHolderRegistry();
+    reg.register(source('entra', down()));
+    const out = await reg.resolveHolders('approver');
+    assert.deepEqual(out.holders, []);
+    assert.equal(out.partial, true);
+  });
+
+  it('a plausible NON-empty list is still flagged when a source dropped out', async () => {
+    // The dangerous shape: two holders come back, so nothing looks wrong, while
+    // whoever the unreachable directory knows about is silently missing.
+    const reg = new RoleHolderRegistry();
+    reg.register(source('local', resolved('ada', 'grace')));
+    reg.register(source('entra', down()));
+    const out = await reg.resolveHolders('approver');
+    assert.deepEqual(out.holders, ['ada', 'grace']);
+    assert.equal(out.partial, true);
+  });
+});
+
+describe('union semantics', () => {
+  it('unions across sources, de-duplicates and sorts', async () => {
+    const reg = new RoleHolderRegistry();
+    reg.register(source('local', resolved('grace', 'ada')));
+    reg.register(source('entra', resolved('ada', 'linus')));
+    const out = await reg.resolveHolders('approver');
+    assert.deepEqual(out.holders, ['ada', 'grace', 'linus']);
+    assert.equal(out.partial, false);
+  });
+
+  it('canonicalizes holder ids with the USER rule — trim AND lowercase', async () => {
+    // Holder ids are user principals, matched by a case-sensitive `=` in the
+    // binding store. Role KEYS keep their case; holder ids must not, or an
+    // operator-typed `Jane@Co.com` never matches the stored `jane@co.com`.
+    const reg = new RoleHolderRegistry();
+    reg.register(source('local', resolved('  Jane@Co.COM ', 'jane@co.com')));
+    const out = await reg.resolveHolders('approver');
+    assert.deepEqual(out.holders, ['jane@co.com']);
+  });
+
+  it('drops blank holder ids rather than admitting an unmatchable one', async () => {
+    const reg = new RoleHolderRegistry();
+    reg.register(source('local', resolved('', '  ', 'ada')));
+    assert.deepEqual((await reg.resolveHolders('approver')).holders, ['ada']);
+  });
+
+  it('no active sources is a complete answer, not a partial one', async () => {
+    const out = await new RoleHolderRegistry().resolveHolders('approver');
+    assert.deepEqual(out, { holders: [], partial: false, bySource: [] });
+  });
+});
+
+describe('a throwing source cannot take down a run', () => {
+  it('becomes unavailable, stays visible, and does not suppress its peers', async () => {
+    const reg = new RoleHolderRegistry();
+    reg.register(
+      source('entra', async () => {
+        throw new Error('ECONNRESET');
+      }),
+    );
+    reg.register(source('local', resolved('ada')));
+    const out = await reg.resolveHolders('approver');
+    assert.deepEqual(out.holders, ['ada']);
+    assert.equal(out.partial, true);
+    const entra = out.bySource.find((s) => s.sourceId === 'entra')?.lookup;
+    assert.equal(entra?.outcome, 'unavailable');
+    assert.match(entra?.outcome === 'unavailable' ? entra.message : '', /ECONNRESET/);
+  });
+});
+
+describe('the catalog gate', () => {
+  it('refuses an uncatalogued id and admits a catalogued one idempotently', () => {
+    const catalog = new RoleHolderCatalog();
+    const reg = new RoleHolderRegistry();
+    assert.equal(reg.activate(catalog, 'entra'), false);
+    catalog.add(source('entra', resolved()));
+    assert.equal(reg.activate(catalog, 'entra'), true);
+    assert.equal(reg.activate(catalog, 'entra'), true);
+    assert.equal(reg.size(), 1);
+  });
+});
+
+describe('Conductor composition', () => {
+  const fakeStore = (holders: string[]) =>
+    ({ resolve: async () => holders }) as unknown as Parameters<typeof buildRoleHolderRegistry>[0];
+
+  it('registers the local assignment table as an ordinary source', async () => {
+    const reg = buildRoleHolderRegistry(fakeStore(['ada']));
+    assert.equal(reg.has(LOCAL_ROLE_HOLDER_SOURCE_ID), true);
+    const out = await reg.resolveHolders('approver');
+    assert.deepEqual(out.holders, ['ada']);
+    assert.equal(out.partial, false);
+  });
+
+  it('local-only is never partial — today’s behaviour is unchanged', async () => {
+    const out = await buildRoleHolderRegistry(fakeStore([])).resolveHolders('approver');
+    assert.equal(out.partial, false);
+  });
+
+  it('an external source may not shadow the local one', () => {
+    // Claiming `conductor-local` would substitute an attacker's approver list
+    // for the assignment table. The id collision makes that a boot failure.
+    assert.throws(
+      () => buildRoleHolderRegistry(fakeStore(['ada']), [source(LOCAL_ROLE_HOLDER_SOURCE_ID, resolved('mallory'))]),
+      /collision/,
+    );
+  });
+
+  it('a failing LOCAL store surfaces as partial, not as "no holders"', async () => {
+    const broken = {
+      resolve: async () => {
+        throw new Error('pool exhausted');
+      },
+    } as unknown as Parameters<typeof buildRoleHolderRegistry>[0];
+    const out = await buildRoleHolderRegistry(broken).resolveHolders('approver');
+    assert.deepEqual(out.holders, []);
+    assert.equal(out.partial, true);
+  });
+
+  it('holdersOnly flattens for the consumers that may degrade', async () => {
+    const reg = buildRoleHolderRegistry(fakeStore(['ada', 'grace']));
+    assert.deepEqual(await holdersOnly((k) => reg.resolveHolders(k))('approver'), ['ada', 'grace']);
+  });
+});

--- a/middleware/test/roleSource.test.ts
+++ b/middleware/test/roleSource.test.ts
@@ -1,0 +1,214 @@
+/**
+ * #333 Phase 2 — role sources.
+ *
+ * The assertions that carry weight are the ones about **absence**. Everything
+ * else here is plumbing; the bug this design exists to prevent is a consumer
+ * being unable to tell "this user has no roles" from "we could not find out".
+ * Read as the former, a directory outage silently strips entitlements; read as
+ * the latter with a permissive default, it is a silent full grant.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  RoleSourceCatalog,
+  RoleSourceRegistry,
+  type RoleLookup,
+  type RoleSource,
+} from '../packages/harness-channel-sdk/src/roleSource.js';
+import type { Principal } from '../packages/harness-channel-sdk/src/principal.js';
+
+const alice: Principal = { kind: 'user', userId: 'alice' };
+
+function source(id: string, lookup: RoleLookup | (() => Promise<RoleLookup>)): RoleSource {
+  return {
+    id,
+    displayName: id,
+    rolesFor: typeof lookup === 'function' ? lookup : async () => lookup,
+  };
+}
+
+const resolved = (...roles: string[]): RoleLookup => ({ outcome: 'resolved', roles });
+const unavailable = (): RoleLookup => ({
+  outcome: 'unavailable',
+  code: 'source_error',
+  message: 'directory unreachable',
+});
+
+describe('absence is distinguishable from emptiness', () => {
+  it('a source that resolves to NO roles is a complete answer — not partial', async () => {
+    const reg = new RoleSourceRegistry();
+    reg.register(source('entra', resolved()));
+    const out = await reg.resolveRoles(alice);
+    assert.deepEqual(out.roles, []);
+    assert.equal(out.partial, false);
+  });
+
+  it('a source that cannot answer marks the result partial — with the SAME empty roles', async () => {
+    // Both cases yield `roles: []`. Only `partial` separates them, which is
+    // exactly why it has to exist.
+    const reg = new RoleSourceRegistry();
+    reg.register(source('entra', unavailable()));
+    const out = await reg.resolveRoles(alice);
+    assert.deepEqual(out.roles, []);
+    assert.equal(out.partial, true);
+  });
+
+  it('one failing source among healthy ones still marks the whole result partial', async () => {
+    // The dangerous case: roles come back non-empty, so a caller glancing at
+    // `roles` alone sees a plausible answer that is missing an entire source.
+    const reg = new RoleSourceRegistry();
+    reg.register(source('entra', resolved('approver')));
+    reg.register(source('odoo-hr', unavailable()));
+    const out = await reg.resolveRoles(alice);
+    assert.deepEqual(out.roles, ['approver']);
+    assert.equal(out.partial, true);
+  });
+
+  it('every source is reported individually, so an outage is diagnosable', async () => {
+    const reg = new RoleSourceRegistry();
+    reg.register(source('entra', resolved('a')));
+    reg.register(source('odoo-hr', unavailable()));
+    const out = await reg.resolveRoles(alice);
+    assert.deepEqual(out.bySource.map((s) => s.sourceId), ['entra', 'odoo-hr']);
+    assert.equal(out.bySource[1]?.lookup.outcome, 'unavailable');
+  });
+});
+
+describe('a throwing source cannot fail the turn', () => {
+  it('becomes unavailable rather than rejecting', async () => {
+    const reg = new RoleSourceRegistry();
+    reg.register(
+      source('boom', async () => {
+        throw new Error('socket hang up');
+      }),
+    );
+    const out = await reg.resolveRoles(alice);
+    assert.equal(out.partial, true);
+    const lookup = out.bySource[0]?.lookup;
+    assert.equal(lookup?.outcome, 'unavailable');
+    // The cause survives into the operator-facing message.
+    assert.match(lookup?.outcome === 'unavailable' ? lookup.message : '', /socket hang up/);
+  });
+
+  it('does not suppress the healthy sources alongside it', async () => {
+    const reg = new RoleSourceRegistry();
+    reg.register(
+      source('boom', async () => {
+        throw new Error('nope');
+      }),
+    );
+    reg.register(source('entra', resolved('approver')));
+    const out = await reg.resolveRoles(alice);
+    assert.deepEqual(out.roles, ['approver']);
+  });
+});
+
+describe('merging', () => {
+  it('de-duplicates across sources and sorts, so results are comparable', async () => {
+    const reg = new RoleSourceRegistry();
+    reg.register(source('a', resolved('reviewer', 'approver')));
+    reg.register(source('b', resolved('approver', 'admin')));
+    const out = await reg.resolveRoles(alice);
+    assert.deepEqual(out.roles, ['admin', 'approver', 'reviewer']);
+  });
+
+  it('canonicalizes role keys with the ROLE rule — trim only, case preserved', async () => {
+    // Lowercasing here would stop matching the mixed-case keys `createRole`
+    // writes verbatim; `Approver` and `approver` are genuinely different keys.
+    const reg = new RoleSourceRegistry();
+    reg.register(source('a', resolved('  Head-Of-Sales  ', 'approver')));
+    const out = await reg.resolveRoles(alice);
+    assert.deepEqual(out.roles, ['Head-Of-Sales', 'approver']);
+  });
+
+  it('drops blank role keys rather than admitting an unmatchable one', async () => {
+    const reg = new RoleSourceRegistry();
+    reg.register(source('a', resolved('', '   ', 'real')));
+    const out = await reg.resolveRoles(alice);
+    assert.deepEqual(out.roles, ['real']);
+  });
+
+  it('no active sources is a complete answer, not a partial one', async () => {
+    const out = await new RoleSourceRegistry().resolveRoles(alice);
+    assert.deepEqual(out, { roles: [], partial: false, bySource: [] });
+  });
+});
+
+describe('a role principal is a category error, and is short-circuited', () => {
+  it('resolves to nothing WITHOUT consulting any source, and is not partial', async () => {
+    // A role is an indirection over holders, not a subject with entitlements.
+    // Letting a source answer would invite it to invent role nesting, which
+    // #575 has not specified.
+    let consulted = false;
+    const reg = new RoleSourceRegistry();
+    reg.register(
+      source('entra', async () => {
+        consulted = true;
+        return resolved('should-not-appear');
+      }),
+    );
+    const out = await reg.resolveRoles({ kind: 'role', roleKey: 'approver' });
+    assert.equal(consulted, false);
+    assert.deepEqual(out.roles, []);
+    assert.equal(out.partial, false);
+  });
+});
+
+describe('the catalog is an operator gate, not a formality', () => {
+  it('activate refuses an id that is not catalogued', () => {
+    const catalog = new RoleSourceCatalog();
+    const reg = new RoleSourceRegistry();
+    assert.equal(reg.activate(catalog, 'entra'), false);
+    assert.equal(reg.size(), 0);
+  });
+
+  it('activate admits a catalogued id, and is idempotent', () => {
+    const catalog = new RoleSourceCatalog();
+    catalog.add(source('entra', resolved()));
+    const reg = new RoleSourceRegistry();
+    assert.equal(reg.activate(catalog, 'entra'), true);
+    assert.equal(reg.activate(catalog, 'entra'), true);
+    assert.equal(reg.size(), 1);
+  });
+
+  it('rejects duplicate ids in both catalog and registry', () => {
+    const catalog = new RoleSourceCatalog();
+    catalog.add(source('entra', resolved()));
+    assert.throws(() => catalog.add(source('entra', resolved())), /collision/);
+
+    const reg = new RoleSourceRegistry();
+    reg.register(source('entra', resolved()));
+    assert.throws(() => reg.register(source('entra', resolved())), /collision/);
+  });
+
+  it('unregister removes an active source', () => {
+    const reg = new RoleSourceRegistry();
+    reg.register(source('entra', resolved()));
+    assert.equal(reg.unregister('entra'), true);
+    assert.equal(reg.unregister('entra'), false);
+    assert.equal(reg.has('entra'), false);
+  });
+});
+
+describe('sources run concurrently, not one after another', () => {
+  it('total time tracks the slowest source, not their sum', async () => {
+    const delay = (ms: number, role: string): RoleSource =>
+      source(`s-${role}`, async () => {
+        await new Promise((r) => setTimeout(r, ms));
+        return resolved(role);
+      });
+    const reg = new RoleSourceRegistry();
+    for (const r of ['a', 'b', 'c', 'd']) reg.register(delay(60, r));
+
+    const started = process.hrtime.bigint();
+    const out = await reg.resolveRoles(alice);
+    const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+
+    assert.deepEqual(out.roles, ['a', 'b', 'c', 'd']);
+    // Serial would be ~240ms. Generous bound so a loaded CI box cannot flake it,
+    // while still failing outright if the awaits are serialised.
+    assert.ok(elapsedMs < 200, `expected concurrent (<200ms), took ${elapsedMs.toFixed(0)}ms`);
+  });
+});


### PR DESCRIPTION
Phase 1 (#724) answered **who** a turn's caller is. This answers the other half of the question the Phase-0 spec (§6) assigns to #333 — *"and what are they entitled to?"* — as the pluggable registry over role/attribute sources (Entra groups, Odoo HR) that the spec's artifact table calls for, generalizing `auth/providerRegistry.ts`.

**Nothing here evaluates a permission.** These are facts; #575 turns them into decisions. The boundary stays exactly where the spec drew it:

> **#333 produces Principals. #575 consumes Principals and produces decisions.**

Conductor's `RoleResolver` becoming external is **phase 3** and is deliberately not in this cut — 4 files, reviewable.

## The property everything else hangs on: absence is a type

`rolesFor` never returns a bare array:

| Outcome | Means |
|---|---|
| `resolved`, `roles: []` | the source knows this principal and confers nothing — a real, trustworthy answer |
| `unavailable` | we could not find out |

Collapsing the two is an authorization bug **in whichever direction the caller guesses**:

- read as *"this user has no roles"*, an unreachable Entra tenant quietly strips every entitlement — a self-inflicted outage that looks like policy;
- read as *"unknown, so allow"*, it is a silent full grant.

`AggregateRoleLookup.partial` carries that distinction through the merge, so a half-answered lookup cannot pass for a complete one. The dangerous case is not the empty result — it is a **non-empty** result that is silently missing a source, which a caller glancing at `roles` alone would accept. Same reasoning that made `ScopeId`'s `unscoped` and `Principal`'s `undefined` types rather than values.

## Three further deliberate behaviours

**The catalog/registry split is mirrored from `ProviderRegistry` — and matters more here.** That file's rationale is that "a compromised admin can never enable a provider the operator didn't intend". An auth provider decides *whether you get in*; a role source decides *what you are* once inside. Registering one silently is privilege escalation with no login event to notice, so the two-tier gate is mandatory rather than decorative.

**A throwing source degrades to `unavailable` instead of rejecting.** One misbehaving directory must not fail a turn — but it must not vanish either, so it still lands in `bySource` and still sets `partial`. Sources are queried concurrently; they are independent network reads on a turn's hot path, and serialising them would add every directory's latency together.

**A `role:` principal short-circuits with no source consulted.** Asking what roles a role has is a category error — a role is an indirection over holders, not a subject with entitlements — and answering it would invite a source to invent role nesting that #575 has not specified. It resolves `partial: false`: a complete answer, not a failed one.

Role keys are canonicalized with phase 1's **role** rule (trim only, case preserved). Lowercasing would stop matching the mixed-case keys `createRole` writes verbatim.

## Blast radius

| Surface | Effect |
|---|---|
| Published plugin contract | none — additive exports only |
| Runtime behaviour | **none** — nothing constructs a registry yet; this is the seam, its consumers come with #575 |
| Database | none |
| Existing call sites | none touched |

## Verification

- Full suite: **6590 tests, 0 fail, 0 cancelled** (16 new)
- `npm run typecheck` ✅ · `npm run lint` ✅
- #470 core-decoupling ratchet: held at 3294 ✅
- #573 test/scripts typecheck ratchet: 406 known, no regressions ✅

### Mutation checks

| Mutation | Result |
|---|---|
| an `unavailable` source no longer sets `partial` | **killed** — 3 tests |
| remove the `role:` short-circuit | **killed** — 1 test |
| `activate` admits an uncatalogued id | **killed** — 1 test |

Refs #333

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789564502&installation_model_id=428086&pr_number=726&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F726&signature=58522e20e220fcd1f78bd1a491de4e9a9a23055b55817b217329913e287af1a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->