### PR TITLE
feat(#532): datasets admin UI — upload, schema, row preview, delete

### DIFF
--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -1864,17 +1864,34 @@ gekettet, weil `requires` beim Boot enforced wird): docs-RFC (diese PR)
 omadia-ui-Orchestrator-Consumer. Details + per-PR-Doc-Pflichten in §15
 des RFC.
 
-### Phase 14 — Admin-UI für Dataset-Upload/Schema/Delete (#430 Follow-up)
+### Phase 14 — Admin-UI für Dataset-Upload/Schema/Delete (#430 Follow-up) — **erledigt (#532)**
 
-Der #430-Scope (CSV-Import + `query_dataset`-Tool, siehe §3 und §7) deckt
-absichtlich **keine** Admin-UI ab — Upload/Schema-Browse/Delete bleibt
+Der #430-Scope (CSV-Import + `query_dataset`-Tool, siehe §3 und §7) deckte
+absichtlich **keine** Admin-UI ab — Upload/Schema-Browse/Delete blieb
 API-only (`POST/GET/DELETE /api/v1/datasets*`, siehe §3). #430's eigene
-Triage-Acceptance-Criteria verlangen aber genau diese UI; der Branch
-schließt das Issue deshalb NICHT, sondern "addresses" es — ein
-Folge-Issue für die Admin-UI-Seite (`web-ui/app/admin/datasets/` o.ä.,
-Upload-Dropzone + Schema-Tabelle + Zeilen-Preview + Delete-Bestätigung,
-Pattern analog zur bestehenden Package-Upload-Seite) ist offen zu
-erfassen.
+Triage-Acceptance-Criteria verlangen aber genau diese UI; das
+Folge-Issue #532 hat sie nachgezogen.
+
+Geliefert, rein `web-ui`-seitig — an der REST-Surface aus §3 wurde nichts
+geändert:
+
+- `web-ui/app/admin/datasets/page.tsx` — Upload (Datei + optionaler Name),
+  Liste, aufklappbares Detail mit Schema-Tabelle und Zeilen-Vorschau,
+  Delete mit Bestätigung.
+- Der Client (`web-ui/app/_lib/api.ts`) spiegelt `DatasetSummary` /
+  `DatasetColumnSchema` / den unaggregierten Zweig von
+  `DatasetQueryResult`, weil `web-ui` nicht gegen den
+  middleware-Workspace baut.
+- Die Zeilen-Vorschau paginiert **server-seitig** über `limit`/`offset`
+  (25 pro Seite, Server clamped auf [1, 200]). Ein Datensatz fasst bis zu
+  `MAX_DATASET_ROWS` (50 000) Zeilen — genau der Fall, gegen den
+  `queryDatasetRows` existiert.
+- Nach einem Import werden `privacyScan.scannedCells` /
+  `maskedCells` und eine etwaige Zell-Truncation angezeigt: der Scan läuft
+  auf diesem Pfad genauso wie beim Chat-Attachment-Auto-Ingest, und das
+  soll sichtbar sein statt geglaubt werden zu müssen.
+- ACL unverändert owner-only: die Seite zeigt ausschließlich Datensätze
+  des eingeloggten Kontos, nicht die der Instanz.
 
 ---
 

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -3488,6 +3488,132 @@ export async function reclusterTopics(opts: {
 }
 
 // -----------------------------------------------------------------------------
+// Structured datasets (#430 / #532). Backed by /api/v1/datasets, gated by
+// `requireAuth` plus a per-route session-user ACL — the same shape as
+// /api/v1/memory above, so a dataset is only ever visible to its importer.
+//
+// The types mirror `DatasetSummary` / `DatasetColumnSchema` / `DatasetQueryResult`
+// in `@omadia/plugin-api` rather than importing them: web-ui does not depend on
+// the middleware workspace, so every backend shape it consumes is re-declared
+// here (same convention as `MemorableKnowledgeNode` above).
+// -----------------------------------------------------------------------------
+
+/** Inferred per-column type from the CSV import. No `unknown` catch-all — a
+ *  column with no confidently-typed values falls back to `'string'`. */
+export type DatasetColumnType = 'string' | 'number' | 'boolean' | 'date';
+
+export interface DatasetColumnSchema {
+  name: string;
+  type: DatasetColumnType;
+  /** First non-empty value seen for this column — schema preview only. */
+  sample?: string;
+}
+
+export interface DatasetSummary {
+  id: string;
+  name: string;
+  sourceFileName: string;
+  ownerOmadiaUserId: string;
+  rowCount: number;
+  columns: DatasetColumnSchema[];
+  createdAt: string;
+}
+
+/**
+ * `GET /:id/rows` — the unaggregated branch of `queryDatasetRows`, so `rows`
+ * is always populated and `groups` / `aggregateValue` never are. `totalMatched`
+ * is the count BEFORE limit/offset, which is what lets the preview say
+ * "showing 25 of 4,213" instead of silently truncating.
+ */
+export interface DatasetRowsPage {
+  rows?: Array<Record<string, unknown>>;
+  totalMatched: number;
+}
+
+/**
+ * `POST /` — the import receipt. `privacyScan` is the count of cells the
+ * privacy pipeline looked at and masked; surfacing it is the point, since the
+ * REST upload runs the SAME scan as the chat-attachment auto-ingest path.
+ * `truncation` reports cells cut at the 4 000-char per-cell cap.
+ */
+export interface DatasetUploadResponse {
+  dataset: { datasetId: string; rowCount: number; graphNodeId: string };
+  privacyScan: { scannedCells: number; maskedCells: number };
+  truncation: { truncatedCellCount: number; truncatedColumns: string[] };
+}
+
+export async function listDatasets(): Promise<DatasetSummary[]> {
+  const res = await getJson<{ items: DatasetSummary[] }>('/v1/datasets');
+  return expectArray<DatasetSummary>(res.items, '/v1/datasets', 'items');
+}
+
+export async function getDataset(id: string): Promise<DatasetSummary> {
+  return getJson<DatasetSummary>(`/v1/datasets/${encodeURIComponent(id)}`);
+}
+
+export async function getDatasetRows(
+  id: string,
+  opts: { limit?: number; offset?: number } = {},
+): Promise<DatasetRowsPage> {
+  const qs = new URLSearchParams();
+  if (opts.limit !== undefined) qs.set('limit', String(opts.limit));
+  if (opts.offset !== undefined) qs.set('offset', String(opts.offset));
+  const suffix = qs.toString() ? `?${qs.toString()}` : '';
+  return getJson<DatasetRowsPage>(
+    `/v1/datasets/${encodeURIComponent(id)}/rows${suffix}`,
+  );
+}
+
+export async function deleteDataset(id: string): Promise<void> {
+  const forwarded = await forwardCookieHeader();
+  const res = await fetch(botApi(`/v1/datasets/${encodeURIComponent(id)}`), {
+    method: 'DELETE',
+    headers: { accept: 'application/json', ...forwarded },
+    credentials: 'include',
+    cache: 'no-store',
+  });
+  if (res.status === 204) return;
+  const text = await res.text().catch(() => '');
+  maybeNavigateToLogin(res.status);
+  throw new ApiError(
+    res.status,
+    `DELETE datasets/${id} failed: ${res.status}`,
+    text,
+  );
+}
+
+/**
+ * Multipart CSV upload. Same contract as `uploadPackage` above — exactly one
+ * `file` field and NO manual content-type, so the browser writes the boundary.
+ * `name` is optional; the route falls back to the file name when it is absent
+ * or blank.
+ */
+export async function uploadDataset(
+  file: File,
+  name?: string,
+): Promise<DatasetUploadResponse> {
+  const forwarded = await forwardCookieHeader();
+  const form = new FormData();
+  form.append('file', file, file.name);
+  if (name !== undefined && name.trim().length > 0) {
+    form.append('name', name.trim());
+  }
+  const res = await fetch(botApi('/v1/datasets'), {
+    method: 'POST',
+    body: form,
+    headers: { accept: 'application/json', ...forwarded },
+    credentials: 'include',
+    cache: 'no-store',
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    maybeNavigateToLogin(res.status);
+    throw new ApiError(res.status, `POST /v1/datasets failed: ${res.status}`, text);
+  }
+  return JSON.parse(text) as DatasetUploadResponse;
+}
+
+// -----------------------------------------------------------------------------
 // Chat session reset (2026-05-26).
 // -----------------------------------------------------------------------------
 

--- a/web-ui/app/admin/datasets/__tests__/page.test.tsx
+++ b/web-ui/app/admin/datasets/__tests__/page.test.tsx
@@ -1,0 +1,339 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithIntl } from '../../../_lib/test-utils';
+import AdminDatasetsPage from '../page';
+
+/**
+ * Coverage for /admin/datasets (#532):
+ *   - lists datasets with their row/column counts,
+ *   - pages the row preview SERVER-side (limit/offset), never client-side —
+ *     a dataset holds up to 50 000 rows, so a "fetch all, slice locally"
+ *     regression is the failure this page exists to avoid,
+ *   - surfaces the privacy-scan counts on a successful import,
+ *   - refuses to delete without a confirmation,
+ *   - maps the route's `dataset.*` error codes to localized copy rather than
+ *     rendering the middleware's English `message` as the headline.
+ */
+
+// Hoisted together with the mock factory: `vi.mock` is lifted above the
+// imports, so the stand-in ApiError has to exist by then too — the page's
+// `err instanceof ApiError` branch is exactly what these tests exercise.
+const {
+  MockApiError,
+  mockListDatasets,
+  mockGetDataset,
+  mockGetDatasetRows,
+  mockDeleteDataset,
+  mockUploadDataset,
+} = vi.hoisted(() => ({
+  MockApiError: class MockApiError extends Error {
+    public readonly code: string | null;
+    constructor(
+      public status: number,
+      message: string,
+      public body = '',
+    ) {
+      super(message);
+      try {
+        const parsed = JSON.parse(body) as { code?: unknown };
+        this.code = typeof parsed.code === 'string' ? parsed.code : null;
+      } catch {
+        this.code = null;
+      }
+    }
+  },
+  mockListDatasets: vi.fn(),
+  mockGetDataset: vi.fn(),
+  mockGetDatasetRows: vi.fn(),
+  mockDeleteDataset: vi.fn(),
+  mockUploadDataset: vi.fn(),
+}));
+
+vi.mock('../../../_lib/api', () => ({
+  ApiError: MockApiError,
+  listDatasets: mockListDatasets,
+  getDataset: mockGetDataset,
+  getDatasetRows: mockGetDatasetRows,
+  deleteDataset: mockDeleteDataset,
+  uploadDataset: mockUploadDataset,
+}));
+
+const DATASET = {
+  id: 'ds-1',
+  name: 'Q3 orders',
+  sourceFileName: 'orders-q3.csv',
+  ownerOmadiaUserId: 'user-1',
+  rowCount: 4213,
+  columns: [
+    { name: 'order_ref', type: 'string' as const, sample: 'SO-1001' },
+    { name: 'amount', type: 'number' as const, sample: '19.99' },
+  ],
+  createdAt: '2026-08-01T09:30:00.000Z',
+};
+
+/** Row refs start at SO-2000 so they never collide with the schema's own
+ *  `sample` (SO-1001) — the two tables must be told apart in assertions. */
+function rowPage(offset: number) {
+  return {
+    rows: Array.from({ length: 25 }, (_, i) => ({
+      order_ref: `SO-${String(2000 + offset + i)}`,
+      amount: 19.99,
+    })),
+    totalMatched: 4213,
+  };
+}
+
+beforeEach(() => {
+  mockListDatasets.mockResolvedValue([DATASET]);
+  mockGetDataset.mockResolvedValue(DATASET);
+  mockGetDatasetRows.mockImplementation((_id: string, opts: { offset?: number }) =>
+    Promise.resolve(rowPage(opts.offset ?? 0)),
+  );
+  mockDeleteDataset.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('<AdminDatasetsPage />', () => {
+  it('lists datasets with row and column counts', async () => {
+    renderWithIntl(<AdminDatasetsPage />);
+
+    expect(await screen.findByText('Q3 orders')).toBeTruthy();
+    expect(screen.getByText('orders-q3.csv')).toBeTruthy();
+    expect(screen.getByText(/4,213 rows · 2 columns/)).toBeTruthy();
+  });
+
+  it('renders the empty state when the account has imported nothing', async () => {
+    mockListDatasets.mockResolvedValue([]);
+    renderWithIntl(<AdminDatasetsPage />);
+
+    expect(await screen.findByText('No datasets imported yet.')).toBeTruthy();
+  });
+
+  it('loads the schema and the first row page only when details are opened', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<AdminDatasetsPage />);
+
+    await screen.findByText('Q3 orders');
+    // Nothing is fetched for a collapsed row — the list alone must not cost
+    // one detail + one rows request per dataset.
+    expect(mockGetDatasetRows).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'Schema & rows' }));
+
+    await waitFor(() =>
+      expect(mockGetDatasetRows).toHaveBeenCalledWith('ds-1', {
+        limit: 25,
+        offset: 0,
+      }),
+    );
+    // Twice on purpose: once as a schema row, once as a preview-table header.
+    expect(await screen.findAllByText('order_ref')).toHaveLength(2);
+    // The type the importer derived, not the raw CSV string it came from.
+    expect(screen.getByText('number')).toBeTruthy();
+    // Schema sample value…
+    expect(screen.getByText('SO-1001')).toBeTruthy();
+    // …and a real row from the preview page.
+    expect(screen.getByText('SO-2000')).toBeTruthy();
+    expect(screen.getByText('Showing 1–25 of 4,213 rows')).toBeTruthy();
+  });
+
+  it('pages the preview server-side with a new offset', async () => {
+    const user = userEvent.setup();
+    renderWithIntl(<AdminDatasetsPage />);
+
+    await screen.findByText('Q3 orders');
+    await user.click(screen.getByRole('button', { name: 'Schema & rows' }));
+    await screen.findByText('Showing 1–25 of 4,213 rows');
+
+    // "Back" is unreachable on the first page.
+    expect(
+      (screen.getByRole('button', { name: 'Back' }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+
+    await waitFor(() =>
+      expect(mockGetDatasetRows).toHaveBeenLastCalledWith('ds-1', {
+        limit: 25,
+        offset: 25,
+      }),
+    );
+    expect(await screen.findByText('Showing 26–50 of 4,213 rows')).toBeTruthy();
+    // The schema is read once, on open — turning a page costs one request,
+    // not two.
+    expect(mockGetDataset).toHaveBeenCalledTimes(1);
+  });
+
+  it('says so when the listing hits the endpoint cap instead of ending silently', async () => {
+    mockListDatasets.mockResolvedValue(
+      Array.from({ length: 50 }, (_, i) => ({
+        ...DATASET,
+        id: `ds-${String(i)}`,
+        name: `Dataset ${String(i)}`,
+      })),
+    );
+    renderWithIntl(<AdminDatasetsPage />);
+
+    expect(await screen.findByText(/Showing the 50 most recent datasets/)).toBeTruthy();
+  });
+
+  it('stays quiet about the cap when the listing is short', async () => {
+    renderWithIntl(<AdminDatasetsPage />);
+
+    await screen.findByText('Q3 orders');
+    expect(screen.queryByText(/most recent datasets/)).toBeNull();
+  });
+
+  it('reports the privacy-scan counts after an import', async () => {
+    const user = userEvent.setup();
+    mockUploadDataset.mockResolvedValue({
+      dataset: { datasetId: 'ds-2', rowCount: 120, graphNodeId: 'node-2' },
+      privacyScan: { scannedCells: 480, maskedCells: 12 },
+      truncation: { truncatedCellCount: 0, truncatedColumns: [] },
+    });
+    renderWithIntl(<AdminDatasetsPage />);
+    await screen.findByText('Q3 orders');
+
+    const file = new File(['a,b\n1,2\n'], 'sales.csv', { type: 'text/csv' });
+    await user.upload(screen.getByLabelText('CSV file'), file);
+    await user.click(screen.getByRole('button', { name: 'Import' }));
+
+    expect(
+      await screen.findByText('Privacy scan: 480 cells checked, 12 masked.'),
+    ).toBeTruthy();
+    expect(screen.getByText('Import complete — 120 rows stored.')).toBeTruthy();
+    // The list is re-read so the new dataset appears without a manual refresh.
+    expect(mockListDatasets).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the file input after an import so the SAME file can be re-imported', async () => {
+    // Found by clicking the real page: a file input is uncontrolled, so
+    // resetting `file` state leaves the element holding the old filename.
+    // Re-picking that same file fires no `change` event, and the Import
+    // button stays disabled with the element still showing a file — dead UI
+    // with no explanation. The element itself must be reset.
+    const user = userEvent.setup();
+    mockUploadDataset.mockResolvedValue({
+      dataset: { datasetId: 'ds-4', rowCount: 2, graphNodeId: 'node-4' },
+      privacyScan: { scannedCells: 4, maskedCells: 0 },
+      truncation: { truncatedCellCount: 0, truncatedColumns: [] },
+    });
+    renderWithIntl(<AdminDatasetsPage />);
+    await screen.findByText('Q3 orders');
+
+    const input = screen.getByLabelText('CSV file') as HTMLInputElement;
+    const file = new File(['a,b\n1,2\n'], 'again.csv', { type: 'text/csv' });
+
+    await user.upload(input, file);
+    await user.click(screen.getByRole('button', { name: 'Import' }));
+    await screen.findByText('Import complete — 2 rows stored.');
+
+    // The element is empty, so selecting the same file again is a real change.
+    expect(input.value).toBe('');
+    expect(input.files?.length ?? 0).toBe(0);
+
+    await user.upload(input, file);
+    expect(
+      (screen.getByRole('button', { name: 'Import' }) as HTMLButtonElement).disabled,
+    ).toBe(false);
+  });
+
+  it('flags truncated cells instead of importing them silently', async () => {
+    const user = userEvent.setup();
+    mockUploadDataset.mockResolvedValue({
+      dataset: { datasetId: 'ds-3', rowCount: 4, graphNodeId: 'node-3' },
+      privacyScan: { scannedCells: 16, maskedCells: 0 },
+      truncation: { truncatedCellCount: 3, truncatedColumns: ['notes'] },
+    });
+    renderWithIntl(<AdminDatasetsPage />);
+    await screen.findByText('Q3 orders');
+
+    await user.upload(
+      screen.getByLabelText('CSV file'),
+      new File(['x'], 'big.csv', { type: 'text/csv' }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Import' }));
+
+    expect(await screen.findByText(/3 cells exceeded/)).toBeTruthy();
+    expect(screen.getByText(/Affected columns: notes/)).toBeTruthy();
+  });
+
+  it('never deletes without a confirmation', async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(false));
+    renderWithIntl(<AdminDatasetsPage />);
+
+    await screen.findByText('Q3 orders');
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(mockDeleteDataset).not.toHaveBeenCalled();
+  });
+
+  it('deletes and reloads once confirmed', async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+    renderWithIntl(<AdminDatasetsPage />);
+
+    await screen.findByText('Q3 orders');
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(mockDeleteDataset).toHaveBeenCalledWith('ds-1'));
+    expect(mockListDatasets).toHaveBeenCalledTimes(2);
+  });
+
+  it('translates a dataset.* error code rather than showing the raw message', async () => {
+    const user = userEvent.setup();
+    mockUploadDataset.mockRejectedValue(
+      new MockApiError(
+        422,
+        'POST /v1/datasets failed: 422',
+        JSON.stringify({
+          code: 'dataset.unsupported_type',
+          message: 'Nur CSV-Dateien werden aktuell unterstützt (v1 scope, siehe #430).',
+        }),
+      ),
+    );
+    renderWithIntl(<AdminDatasetsPage />);
+    await screen.findByText('Q3 orders');
+
+    // Named .csv so the input's own `accept` filter lets it through — the
+    // rejection under test is the SERVER's (`isCsvAttachment` also inspects
+    // the mimetype), which is the only one that can be trusted anyway.
+    await user.upload(
+      screen.getByLabelText('CSV file'),
+      new File(['x'], 'notes.csv', { type: 'text/plain' }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Import' }));
+
+    expect(
+      await screen.findByText('Only CSV files are supported so far.'),
+    ).toBeTruthy();
+    // The server's own (English-only, untranslated) message is not the headline.
+    expect(screen.queryByText(/v1 scope, siehe #430/)).toBeNull();
+  });
+
+  it('maps a 413 to the upload-limit copy', async () => {
+    const user = userEvent.setup();
+    mockUploadDataset.mockRejectedValue(
+      new MockApiError(413, 'too large', JSON.stringify({ code: 'dataset.limit_file_size' })),
+    );
+    renderWithIntl(<AdminDatasetsPage />);
+    await screen.findByText('Q3 orders');
+
+    await user.upload(
+      screen.getByLabelText('CSV file'),
+      new File(['x'], 'huge.csv', { type: 'text/csv' }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Import' }));
+
+    expect(
+      await screen.findByText('The file exceeds the 25 MB upload limit.'),
+    ).toBeTruthy();
+  });
+});

--- a/web-ui/app/admin/datasets/page.tsx
+++ b/web-ui/app/admin/datasets/page.tsx
@@ -1,0 +1,590 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import Link from 'next/link';
+import { useFormatter, useTranslations } from 'next-intl';
+
+import { Button } from '@/app/_components/ui/Button';
+import {
+  ApiError,
+  deleteDataset,
+  getDataset,
+  getDatasetRows,
+  listDatasets,
+  uploadDataset,
+  type DatasetSummary,
+  type DatasetUploadResponse,
+} from '../../_lib/api';
+
+/**
+ * Admin → Knowledge · Datasets (#532, the admin half of #430).
+ *
+ * Upload a CSV, read back its inferred schema and a row preview, delete it
+ * again. Backed by `/bot-api/v1/datasets` — `requireAuth` plus a per-route
+ * session-user ACL, so this page only ever shows datasets the logged-in
+ * operator imported themselves. There is no team or public visibility tier
+ * yet; "no datasets" here does not mean the instance has none.
+ *
+ * The row preview is deliberately server-paginated (`limit`/`offset`, clamped
+ * to 200 server-side) rather than fetched whole: a dataset can hold up to
+ * `MAX_DATASET_ROWS` (50 000) rows and pulling that into the DOM to show the
+ * first screenful would be the same mistake `queryDatasetRows` exists to
+ * prevent.
+ *
+ * Upload receipt: every imported row runs through the SAME privacy scan as the
+ * chat-attachment auto-ingest path, so the scanned/masked cell counts are
+ * shown on success — an operator uploading customer data should be able to see
+ * that the masking actually ran, not take it on trust.
+ */
+
+/** Row-preview page size. Server clamps `limit` to [1, 200]. */
+const ROWS_PER_PAGE = 25;
+/** Mirrors `MAX_DATASET_ROWS` in `@omadia/orchestrator`'s `datasetImport.ts` —
+ *  stated up front so an operator learns the cap before a 50 001-row CSV is
+ *  rejected, not after. Display only; the server owns enforcement. */
+const MAX_DATASET_ROWS = 50_000;
+/** Mirrors `MAX_UPLOAD_BYTES` in the datasets route (25 MiB), same reason. */
+const MAX_UPLOAD_MB = 25;
+/**
+ * `GET /v1/datasets` passes no `limit`, so `listDatasets` applies its own
+ * default of 50 and the route exposes no way to raise it. Hitting exactly this
+ * many is therefore indistinguishable from "there are more" — say so rather
+ * than let the list quietly end.
+ */
+const LIST_CAP = 50;
+
+type ListState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; datasets: DatasetSummary[] }
+  | { kind: 'error'; message: string };
+
+/** The expanded dataset's schema + current row page. */
+type DetailState = {
+  id: string;
+  dataset: DatasetSummary | null;
+  rows: Array<Record<string, unknown>>;
+  totalMatched: number;
+  offset: number;
+  loading: boolean;
+  error: string | null;
+};
+
+type TFn = (key: string, values?: Record<string, string | number>) => string;
+
+export default function AdminDatasetsPage(): React.ReactElement {
+  const t = useTranslations('adminDatasets');
+  const format = useFormatter();
+
+  const [state, setState] = useState<ListState>({ kind: 'loading' });
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  // upload form
+  const [file, setFile] = useState<File | null>(null);
+  const [name, setName] = useState('');
+  const [uploading, setUploading] = useState(false);
+  const [receipt, setReceipt] = useState<DatasetUploadResponse | null>(null);
+  /**
+   * A file input is uncontrolled: clearing `file` state does NOT clear the
+   * element, and re-picking the SAME file then fires no `change` event
+   * (the element's value is unchanged), so state would stay `null` while the
+   * element still shows a filename — the Import button dead with no
+   * explanation. Reset the element itself after a successful import.
+   */
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // per-row pending delete + the single expanded detail panel
+  const [pending, setPending] = useState<string | null>(null);
+  const [detail, setDetail] = useState<DetailState | null>(null);
+
+  const reload = useCallback(async (): Promise<void> => {
+    try {
+      setState({ kind: 'ready', datasets: await listDatasets() });
+    } catch (err) {
+      setState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    // Fetch-on-mount: `state` already starts at `loading`, so the awaited
+    // fetch is the only thing that moves it.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void reload();
+  }, [reload]);
+
+  /**
+   * Open (or re-page) the detail panel. `known` is the schema already held for
+   * this dataset, so turning a page costs ONE request — the schema is fetched
+   * on the first open and never again while the panel stays open.
+   */
+  const loadDetail = useCallback(
+    async (
+      id: string,
+      offset: number,
+      known: DatasetSummary | null,
+    ): Promise<void> => {
+      setDetail((prev) =>
+        prev?.id === id
+          ? { ...prev, loading: true, error: null }
+          : {
+              id,
+              dataset: known,
+              rows: [],
+              totalMatched: 0,
+              offset,
+              loading: true,
+              error: null,
+            },
+      );
+      try {
+        const [dataset, page] = await Promise.all([
+          known ?? getDataset(id),
+          getDatasetRows(id, { limit: ROWS_PER_PAGE, offset }),
+        ]);
+        setDetail({
+          id,
+          dataset,
+          rows: page.rows ?? [],
+          totalMatched: page.totalMatched,
+          offset,
+          loading: false,
+          error: null,
+        });
+      } catch (err) {
+        setDetail({
+          id,
+          dataset: null,
+          rows: [],
+          totalMatched: 0,
+          offset,
+          loading: false,
+          error: toFriendlyError(err, t),
+        });
+      }
+    },
+    [t],
+  );
+
+  const onToggleDetail = useCallback(
+    (id: string): void => {
+      if (detail?.id === id) {
+        setDetail(null);
+        return;
+      }
+      // `null`, not the summary already in the list: on open the schema is
+      // re-read alongside the rows, so the preview table's headers and its
+      // rows are guaranteed to describe the same moment. The listing can be
+      // minutes old (another tab, another import).
+      void loadDetail(id, 0, null);
+    },
+    [detail, loadDetail],
+  );
+
+  const onUpload = useCallback(async (): Promise<void> => {
+    if (!file) return;
+    setActionError(null);
+    setReceipt(null);
+    setUploading(true);
+    try {
+      const result = await uploadDataset(file, name);
+      setReceipt(result);
+      setFile(null);
+      setName('');
+      if (fileInputRef.current) fileInputRef.current.value = '';
+      await reload();
+    } catch (err) {
+      setActionError(toFriendlyError(err, t));
+    } finally {
+      setUploading(false);
+    }
+  }, [file, name, reload, t]);
+
+  const onDelete = useCallback(
+    async (d: DatasetSummary): Promise<void> => {
+      if (!confirm(t('confirmDelete', { name: d.name }))) return;
+      setActionError(null);
+      setPending(d.id);
+      try {
+        await deleteDataset(d.id);
+        setDetail((prev) => (prev?.id === d.id ? null : prev));
+        await reload();
+      } catch (err) {
+        setActionError(toFriendlyError(err, t));
+      } finally {
+        setPending(null);
+      }
+    },
+    [reload, t],
+  );
+
+  return (
+    <main className="mx-auto max-w-[960px] px-6 py-12 lg:px-8 lg:py-16">
+      <header className="mb-8">
+        <Link
+          href="/admin"
+          className="text-xs text-[color:var(--fg-muted)] hover:text-[color:var(--fg-strong)]"
+        >
+          ← /admin
+        </Link>
+        <h1 className="mt-2 font-display text-[clamp(1.75rem,3.5vw,2.5rem)] leading-[1.1] text-[color:var(--fg-strong)]">
+          {t('title')}
+        </h1>
+        <p className="mt-3 max-w-2xl text-[15px] leading-[1.55] text-[color:var(--fg-muted)]">
+          {t.rich('intro', {
+            code: (chunks) => (
+              <code className="rounded bg-[color:var(--card)] px-1 py-0.5 text-[12px]">
+                {chunks}
+              </code>
+            ),
+          })}
+        </p>
+      </header>
+
+      {/* Upload */}
+      <section className="mb-8 rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4">
+        <h2 className="mb-4 text-[15px] font-semibold text-[color:var(--fg-strong)]">
+          {t('uploadHeading')}
+        </h2>
+        <div className="grid gap-3 sm:grid-cols-[2fr_2fr_auto] sm:items-end">
+          <Field label={t('fields.file')}>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".csv,text/csv"
+              aria-label={t('fields.file')}
+              onChange={(e) => {
+                setFile(e.target.files?.[0] ?? null);
+                setReceipt(null);
+                setActionError(null);
+              }}
+              className={inputCls}
+            />
+          </Field>
+          <Field label={t('fields.nameOptional')}>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={file?.name ?? t('placeholders.name')}
+              className={inputCls}
+            />
+          </Field>
+          <Button
+            variant="primary"
+            onClick={() => void onUpload()}
+            disabled={file === null || uploading}
+            busy={uploading}
+            busyLabel={t('uploading')}
+          >
+            {t('upload')}
+          </Button>
+        </div>
+        <p className="mt-3 text-[13px] text-[color:var(--fg-muted)]">
+          {t('uploadLimits', {
+            maxRows: format.number(MAX_DATASET_ROWS),
+            maxMb: format.number(MAX_UPLOAD_MB),
+          })}
+        </p>
+      </section>
+
+      {receipt !== null && (
+        <section className="mb-8 rounded-lg border border-[color:var(--success)]/50 bg-[color:var(--success)]/8 p-4 text-sm">
+          <p className="font-semibold text-[color:var(--success)]">
+            {t('receipt.imported', {
+              rows: format.number(receipt.dataset.rowCount),
+            })}
+          </p>
+          <p className="mt-1 text-[color:var(--fg-muted)]">
+            {t('receipt.privacyScan', {
+              scanned: format.number(receipt.privacyScan.scannedCells),
+              masked: format.number(receipt.privacyScan.maskedCells),
+            })}
+          </p>
+          {receipt.truncation.truncatedCellCount > 0 && (
+            <p className="mt-1 text-[color:var(--warning)]">
+              {t('receipt.truncated', {
+                cells: format.number(receipt.truncation.truncatedCellCount),
+                columns: receipt.truncation.truncatedColumns.join(', '),
+              })}
+            </p>
+          )}
+        </section>
+      )}
+
+      {actionError !== null && (
+        <p className="mb-6 text-sm text-[color:var(--danger)]">{actionError}</p>
+      )}
+
+      {/* Listing */}
+      {state.kind === 'loading' ? (
+        <p className="text-sm opacity-70">{t('loading')}</p>
+      ) : state.kind === 'error' ? (
+        <p className="text-sm text-[color:var(--danger)]">
+          {t('loadError', { message: state.message })}
+        </p>
+      ) : state.datasets.length === 0 ? (
+        <p className="text-sm text-[color:var(--fg-muted)]">{t('empty')}</p>
+      ) : (
+        <>
+          {state.datasets.length >= LIST_CAP && (
+            <p className="mb-3 text-[13px] text-[color:var(--fg-muted)]">
+              {t('listCapped', { cap: format.number(LIST_CAP) })}
+            </p>
+          )}
+          <ul className="flex flex-col gap-3">
+            {state.datasets.map((d) => (
+              <li
+                key={d.id}
+                className="rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                  <div className="flex flex-1 flex-col gap-1">
+                    <span className="text-[15px] font-semibold text-[color:var(--fg-strong)]">
+                      {d.name}
+                    </span>
+                    <span className="text-[13px] text-[color:var(--fg-muted)]">
+                      {t('meta', {
+                        rows: format.number(d.rowCount),
+                        columns: format.number(d.columns.length),
+                        created: format.dateTime(new Date(d.createdAt), {
+                          dateStyle: 'medium',
+                          timeStyle: 'short',
+                        }),
+                      })}
+                    </span>
+                    <code className="text-[12px] text-[color:var(--fg-muted)]">
+                      {d.sourceFileName}
+                    </code>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      variant="secondary"
+                      onClick={() => onToggleDetail(d.id)}
+                      aria-expanded={detail?.id === d.id}
+                    >
+                      {detail?.id === d.id ? t('hideDetails') : t('showDetails')}
+                    </Button>
+                    <Button
+                      variant="danger"
+                      onClick={() => void onDelete(d)}
+                      busy={pending === d.id}
+                      busyLabel={t('remove')}
+                    >
+                      {t('remove')}
+                    </Button>
+                  </div>
+                </div>
+
+                {detail?.id === d.id && (
+                  <DatasetDetail
+                    detail={detail}
+                    onPage={(offset) =>
+                      void loadDetail(d.id, offset, detail.dataset)
+                    }
+                  />
+                )}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </main>
+  );
+}
+
+/** Schema table + paginated row preview for the one expanded dataset. */
+function DatasetDetail({
+  detail,
+  onPage,
+}: {
+  detail: DetailState;
+  onPage: (offset: number) => void;
+}): React.ReactElement {
+  const t = useTranslations('adminDatasets');
+  const format = useFormatter();
+
+  if (detail.error !== null) {
+    return (
+      <p className="mt-4 border-t border-[color:var(--border)] pt-4 text-sm text-[color:var(--danger)]">
+        {detail.error}
+      </p>
+    );
+  }
+  if (detail.dataset === null) {
+    return (
+      <p className="mt-4 border-t border-[color:var(--border)] pt-4 text-sm opacity-70">
+        {t('loading')}
+      </p>
+    );
+  }
+
+  const columns = detail.dataset.columns;
+  const from = detail.totalMatched === 0 ? 0 : detail.offset + 1;
+  const to = Math.min(detail.offset + detail.rows.length, detail.totalMatched);
+
+  return (
+    <div className="mt-4 border-t border-[color:var(--border)] pt-4">
+      <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
+        {t('schemaHeading')}
+      </h3>
+      <div className="overflow-x-auto">
+        <table className="w-full text-left text-[13px]">
+          <thead>
+            <tr className="text-[color:var(--fg-muted)]">
+              <th className={thCls}>{t('schema.column')}</th>
+              <th className={thCls}>{t('schema.type')}</th>
+              <th className={thCls}>{t('schema.sample')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {columns.map((c) => (
+              <tr key={c.name} className="border-t border-[color:var(--border)]">
+                <td className={tdCls}>{c.name}</td>
+                <td className={`${tdCls} font-mono`}>{c.type}</td>
+                <td className={`${tdCls} text-[color:var(--fg-muted)]`}>
+                  {c.sample ?? '—'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h3 className="mt-6 mb-2 text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
+        {t('rowsHeading')}
+      </h3>
+      {detail.loading ? (
+        <p className="text-sm opacity-70">{t('loading')}</p>
+      ) : detail.rows.length === 0 ? (
+        <p className="text-sm text-[color:var(--fg-muted)]">{t('noRows')}</p>
+      ) : (
+        <>
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-[13px]">
+              <thead>
+                <tr className="text-[color:var(--fg-muted)]">
+                  {columns.map((c) => (
+                    <th key={c.name} className={thCls}>
+                      {c.name}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {detail.rows.map((row, i) => (
+                  <tr
+                    key={detail.offset + i}
+                    className="border-t border-[color:var(--border)]"
+                  >
+                    {columns.map((c) => (
+                      <td key={c.name} className={tdCls}>
+                        {renderCell(row[c.name])}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="mt-3 flex items-center justify-between gap-4">
+            <span className="text-[13px] text-[color:var(--fg-muted)]">
+              {t('rowsRange', {
+                from: format.number(from),
+                to: format.number(to),
+                total: format.number(detail.totalMatched),
+              })}
+            </span>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => onPage(Math.max(0, detail.offset - ROWS_PER_PAGE))}
+                disabled={detail.offset === 0}
+              >
+                {t('previousPage')}
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => onPage(detail.offset + ROWS_PER_PAGE)}
+                disabled={to >= detail.totalMatched}
+              >
+                {t('nextPage')}
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+const inputCls =
+  'w-full rounded-md border border-[color:var(--border)] bg-transparent px-3 py-2 text-sm outline-none focus:border-[color:var(--accent)]';
+const thCls = 'px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.12em]';
+const tdCls = 'px-2 py-1 align-top';
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <label className="flex flex-col gap-2">
+      <span className="text-[11px] uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+/**
+ * Cells arrive as `unknown` — the row store keeps the CSV's own values, which
+ * are strings today but typed loosely enough that a future non-string backend
+ * value would otherwise render as `[object Object]` or crash React.
+ */
+function renderCell(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+/**
+ * The `dataset.*` codes the route emits, mapped to localized copy. Kept local
+ * rather than added to `errorHelp.ts`: that catalogue's coverage test scopes it
+ * to five specific route files and fails on codes from anywhere else as
+ * orphans. Same local-mapping shape as `/admin/registries`.
+ */
+function toFriendlyError(err: unknown, t: TFn): string {
+  if (err instanceof ApiError) {
+    if (err.status === 413 || err.code === 'dataset.limit_file_size') {
+      return t('errors.tooLarge');
+    }
+    if (err.code === 'dataset.unsupported_type') return t('errors.notCsv');
+    if (err.code === 'dataset.no_file') return t('errors.noFile');
+    if (err.code === 'dataset.import_failed') {
+      // The route's `reason` is the parser's own diagnostic (ragged rows, row
+      // cap, empty file) and has no stable code behind it — surface it as
+      // detail under a localized headline rather than as the headline.
+      return t('errors.importFailed', { detail: apiMessage(err) });
+    }
+    if (err.code === 'dataset.not_found') return t('errors.notFound');
+    return t('errors.generic', { status: err.status });
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** The server's untranslated `message`, for use as secondary detail only. */
+function apiMessage(err: ApiError): string {
+  try {
+    const parsed = JSON.parse(err.body) as { message?: unknown };
+    return typeof parsed.message === 'string' ? parsed.message : '';
+  } catch {
+    return '';
+  }
+}

--- a/web-ui/app/admin/page.tsx
+++ b/web-ui/app/admin/page.tsx
@@ -54,6 +54,8 @@ const GROUPS: readonly GroupDef[] = [
     cards: [
       { href: '/admin/kg-lifecycle', key: 'kgLifecycle' },
       { href: '/admin/kg-priorities', key: 'kgPriorities' },
+      // #532 — the admin half of #430's CSV dataset pipeline.
+      { href: '/admin/datasets', key: 'datasets' },
       { href: '/admin/bulk-promote', key: 'bulkPromote' },
       { href: '/admin/inconsistencies', key: 'inconsistencies' },
       { href: '/admin/memory-backend', key: 'memoryBackend' },

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -195,6 +195,10 @@
           "title": "Knowledge-Graph Prioritäten",
           "description": "Pro Agent Block- und Boost-Listen setzen, die Recall-Treffer im Token-Budget-Assembler überschreiben."
         },
+        "datasets": {
+          "title": "Datensätze",
+          "description": "CSVs als strukturierte Datensätze importieren, die Agenten abfragen können, Schema und Zeilen prüfen und sie wieder löschen."
+        },
         "bulkPromote": {
           "title": "Bulk-Promotion",
           "description": "Historische Turns nachträglich scoren und hoch bewertete als dauerhaftes Wissen promoten (idempotent)."
@@ -4395,6 +4399,54 @@
     "weightIgnoredTitle": "weight ignoriert für block",
     "weightMultiplierTitle": "Score-Multiplikator",
     "empty": "Keine Einträge für diesen Agent."
+  },
+  "adminDatasets": {
+    "title": "Wissen · Datensätze",
+    "intro": "Eine CSV als strukturierten Datensatz importieren, das von omadia abgeleitete Schema nachlesen und ihn wieder löschen. Agenten greifen über das Tool <code>query_dataset</code> darauf zu — serverseitig gefiltert und aggregiert, nie als ganze Tabelle in einem Turn. Ein Datensatz ist nur für das Konto sichtbar, das ihn importiert hat: Diese Liste ist Ihre, nicht die der Instanz.",
+    "uploadHeading": "CSV importieren",
+    "fields": {
+      "file": "CSV-Datei",
+      "nameOptional": "Name (optional)"
+    },
+    "placeholders": {
+      "name": "Standard ist der Dateiname"
+    },
+    "upload": "Importieren",
+    "uploading": "Importiert",
+    "uploadLimits": "Höchstens {maxRows} Zeilen und {maxMb} MB pro Datei. Jede Zelle durchläuft vor dem Speichern den Privacy-Scan.",
+    "receipt": {
+      "imported": "Import abgeschlossen — {rows} Zeilen gespeichert.",
+      "privacyScan": "Privacy-Scan: {scanned} Zellen geprüft, {masked} maskiert.",
+      "truncated": "{cells} Zellen überschritten das Limit von 4.000 Zeichen pro Zelle und wurden gekürzt. Betroffene Spalten: {columns}."
+    },
+    "loading": "lädt…",
+    "loadError": "Laden fehlgeschlagen: {message}",
+    "empty": "Noch keine Datensätze importiert.",
+    "listCapped": "Es werden die {cap} neuesten Datensätze angezeigt — mehr liefert der Endpunkt nicht zurück, ältere können also existieren, ohne hier aufzutauchen.",
+    "meta": "{rows} Zeilen · {columns} Spalten · importiert {created}",
+    "showDetails": "Schema & Zeilen",
+    "hideDetails": "Schließen",
+    "remove": "Löschen",
+    "confirmDelete": "Den Datensatz „{name}“ mit allen Zeilen und seinem Graph-Knoten löschen? Das lässt sich nicht rückgängig machen.",
+    "schemaHeading": "Abgeleitetes Schema",
+    "schema": {
+      "column": "Spalte",
+      "type": "Typ",
+      "sample": "Beispielwert"
+    },
+    "rowsHeading": "Zeilenvorschau",
+    "noRows": "Dieser Datensatz enthält keine Zeilen.",
+    "rowsRange": "{from}–{to} von {total} Zeilen",
+    "previousPage": "Zurück",
+    "nextPage": "Weiter",
+    "errors": {
+      "tooLarge": "Die Datei überschreitet das Upload-Limit von 25 MB.",
+      "notCsv": "Bisher werden ausschließlich CSV-Dateien unterstützt.",
+      "noFile": "Es kam keine Datei an — bitte zuerst eine CSV auswählen.",
+      "importFailed": "Die CSV konnte nicht importiert werden. {detail}",
+      "notFound": "Diesen Datensatz gibt es nicht mehr — womöglich wurde er in einem anderen Tab gelöscht.",
+      "generic": "Die Anfrage ist fehlgeschlagen (HTTP {status})."
+    }
   },
   "adminMemoryBackend": {
     "title": "Memory · Speicher-Backend",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -195,6 +195,10 @@
           "title": "Knowledge-Graph Priorities",
           "description": "Set per-agent block and boost lists that override recall hits in the token-budget assembler."
         },
+        "datasets": {
+          "title": "Datasets",
+          "description": "Import CSVs as structured datasets agents can query, inspect the inferred schema and rows, and delete them again."
+        },
         "bulkPromote": {
           "title": "Bulk Promotion",
           "description": "Re-score historical turns and promote high-significance ones to durable knowledge (idempotent)."
@@ -4395,6 +4399,54 @@
     "weightIgnoredTitle": "weight ignored for block",
     "weightMultiplierTitle": "score multiplier",
     "empty": "No entries for this agent."
+  },
+  "adminDatasets": {
+    "title": "Knowledge · Datasets",
+    "intro": "Import a CSV as a structured dataset, read back the schema omadia inferred from it, and delete it again. Agents reach a dataset through the <code>query_dataset</code> tool — filtered and aggregated server-side, never as a whole table pulled into a turn. A dataset is visible only to the account that imported it, so this list is yours, not the instance's.",
+    "uploadHeading": "Import CSV",
+    "fields": {
+      "file": "CSV file",
+      "nameOptional": "Name (optional)"
+    },
+    "placeholders": {
+      "name": "Defaults to the file name"
+    },
+    "upload": "Import",
+    "uploading": "Importing",
+    "uploadLimits": "Up to {maxRows} rows and {maxMb} MB per file. Every cell passes the privacy scan before it is stored.",
+    "receipt": {
+      "imported": "Import complete — {rows} rows stored.",
+      "privacyScan": "Privacy scan: {scanned} cells checked, {masked} masked.",
+      "truncated": "{cells} cells exceeded the 4,000-character per-cell cap and were cut. Affected columns: {columns}."
+    },
+    "loading": "loading…",
+    "loadError": "Loading failed: {message}",
+    "empty": "No datasets imported yet.",
+    "listCapped": "Showing the {cap} most recent datasets — the endpoint returns no more than that, so older ones may exist without appearing here.",
+    "meta": "{rows} rows · {columns} columns · imported {created}",
+    "showDetails": "Schema & rows",
+    "hideDetails": "Close",
+    "remove": "Delete",
+    "confirmDelete": "Delete the dataset “{name}” with all its rows and its graph node? This cannot be undone.",
+    "schemaHeading": "Inferred schema",
+    "schema": {
+      "column": "Column",
+      "type": "Type",
+      "sample": "Sample value"
+    },
+    "rowsHeading": "Row preview",
+    "noRows": "This dataset holds no rows.",
+    "rowsRange": "Showing {from}–{to} of {total} rows",
+    "previousPage": "Back",
+    "nextPage": "Next",
+    "errors": {
+      "tooLarge": "The file exceeds the 25 MB upload limit.",
+      "notCsv": "Only CSV files are supported so far.",
+      "noFile": "No file arrived — pick a CSV first.",
+      "importFailed": "The CSV could not be imported. {detail}",
+      "notFound": "This dataset no longer exists — it may have been deleted in another tab.",
+      "generic": "The request failed (HTTP {status})."
+    }
   },
   "adminMemoryBackend": {
     "title": "Memory · Storage Backend",

--- a/web-ui/scripts/i18n-identical-allowlist.json
+++ b/web-ui/scripts/i18n-identical-allowlist.json
@@ -23,6 +23,7 @@
     "                 it stops being useful for diagnosis."
   ],
   "keys": {
+    "adminDatasets.fields.nameOptional": "loanword",
     "dashboard.onboarding.cases.hr.name": "loanword",
     "conductor.graphLabel": "loanword",
     "conductor.guardLabel": "glossary",


### PR DESCRIPTION
## What

Closes #532 — the admin UI for the CSV datasets that #430 shipped API-only. Upload a CSV, read back the inferred schema and a paginated row preview, delete it again. Frontend-only: the five endpoints under `/api/v1/datasets` already existed and are untouched.

## Why

#430's own triage criteria asked for this ("deletable via admin UI") but the PR deliberately kept scope to backend work that could be typechecked and tested, so upload/browse/delete has been curl-only since. Tracked as "Phase 14" in `docs/middleware-agent-handoff.md` §13, now marked done there.

Three decisions worth a reviewer's attention:

- **The row preview paginates server-side** (`limit`/`offset`, 25 per page) rather than fetching the table and slicing locally. A dataset holds up to `MAX_DATASET_ROWS` (50 000) rows — pulling that into the DOM to show one screenful is precisely the case `queryDatasetRows` exists to prevent. The schema is read once on open, so turning a page costs one request, not two.
- **`GET /v1/datasets` passes no `limit`**, so `listDatasets` applies its own default of 50 and the route exposes no way to raise it. Hitting exactly 50 is indistinguishable from "there are more", so the page says so rather than letting the list end silently. Raising it properly means a query param on the route — backend work, out of scope here.
- **The ACL is owner-only server-side**, so this page lists only datasets the logged-in account imported. That is stated in the UI copy: on an admin page, a silently personal subset would otherwise read as the instance's.

The import receipt surfaces `privacyScan` scanned/masked cell counts, because this path runs the same scan as chat-attachment auto-ingest — an operator uploading customer data should be able to see that masking ran rather than take it on trust.

## Test plan

- [x] `npm run typecheck && npm run test && npm run lint && npm run i18n:check && npm run build` in `web-ui/` — 748 tests pass (13 new), lint unchanged at its 43-warning baseline (0 from the new files), `i18n:check` OK across 3763 keys, build registers `ƒ /admin/datasets`
- [x] manual, against a real middleware + Postgres (not mocks): imported a 10-row / 8-column CSV, confirmed the receipt (`10 Zeilen gespeichert`, `60 Zellen geprüft, 30 maskiert`), read back the inferred schema and row preview, deleted it, and verified in Postgres that `datasets`, `dataset_rows` **and** the `system='dataset'` graph node were all gone
- [x] manual: German UI end to end, locale formatting via `useFormatter` (`50.000`, `17.08.2026, 16:10`), zero console errors

The live click-through found one bug the jsdom tests could not: a file input is uncontrolled, so clearing `file` state left the element holding the old filename, and re-picking the **same** file fired no `change` event — the Import button stayed disabled with a filename visible. Fixed by resetting the element, with a regression test that imports the same file twice (mutation-checked: it fails on `expected 'C:\fakepath\again.csv' to be ''` without the fix).

## Risk / blast radius

Low. No schema change, no migration, no new env var, no public API change. One new route (`/admin/datasets`) and one new card in the Knowledge & Memory group on `/admin`. `web-ui/app/_lib/api.ts` gains five functions and their types; nothing existing in it changed.

**One thing that will look like a defect in this page but is not:** #727. `maskPrompt` masks ISO-8601 dates (`2026-07-02`) with a **phone** surrogate, and on the dataset path the masked value is what gets persisted — so a CSV with an ISO date column stores phone numbers in a column the schema still types `date`. Reviewers trying this page with such a CSV will see exactly that. The page is rendering stored values faithfully; the bug is in the middleware masker on a path shared with chat prompts, and is filed separately with a repro and root cause. Nothing for it is fixed here.

Arguably that is the strongest argument for this page existing: the corruption has been shipping since #430 and nothing made it visible.
