### PR TITLE
feat(#575): wire the audience floor's egress guard into tool dispatch

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,30 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — the audience floor now guards tool egress (#575)
+
+- **The first of the floor's three guards is wired**, at `dispatchTool` — the
+  single choke point every tool call passes through. Placed before the dispatch
+  deadline so a refused call costs nothing, and before the Privacy Shield
+  boundary because the floor decides *whether* an effect happens while Privacy
+  Shield decides what a permitted one may carry.
+- **Evaluated per call, not per turn.** A turn-start snapshot is a TOCTOU hole:
+  somebody can join between the model choosing a tool and the call firing. This
+  is also the half of decision D4 that re-evaluates — rendered context cannot be
+  un-sent, but an unfired call can still be refused.
+- **Inert unless a deployment opts in.** No audience source installed means the
+  floor is *not enforced*, which is emphatically not the same as *closed*. A
+  closed floor denies everything, so reading "nobody configured this" as
+  "closed" would silently disable every tool everywhere. Same shape and same
+  reasoning as `turnContext.privacyHandle`.
+- **But a provider that throws closes rather than opens** — deliberately the
+  opposite of the privacy precedent. Privacy degrading to "unmodified"
+  over-shares detail; this degrading to "allowed" performs an effect nobody
+  authorized.
+- A refusal comes back as a tool result, not an exception, and says that
+  retrying will not help — a policy decision should not read as an outage, and
+  an unexplained denial just produces a retry loop.
+
 ### Added — the audience floor and capability grants (#575, phase 2)
 
 - **The first module in this cluster that decides something.** #333 produces

--- a/middleware/packages/harness-orchestrator/src/audienceFloorGuard.ts
+++ b/middleware/packages/harness-orchestrator/src/audienceFloorGuard.ts
@@ -1,0 +1,115 @@
+import { floorPermits, type AudienceFloor, type Capability } from '@omadia/channel-sdk';
+
+import { turnContext } from './turnContext.js';
+
+/**
+ * #575 — the egress guard: the first of the audience floor's three call sites.
+ *
+ * `audienceFloor.ts` in the channel SDK computes *what this room may do*. This
+ * is where that answer is enforced for outbound effects, and it is deliberately
+ * the ONLY thing in the orchestrator that knows about the floor — the other two
+ * guards (context retrieval, handle resolution) share the same intersection
+ * function rather than re-deriving one.
+ *
+ * ## Why per call, and not once per turn
+ *
+ * Spec §5.2: a turn-start snapshot is a TOCTOU hole. Somebody can join the
+ * conversation between the model deciding to call a tool and the call actually
+ * firing, and the floor must have narrowed by then. So the provider is invoked
+ * **per dispatch**, which is affordable because `audienceFloor` is pure and the
+ * expensive part (resolving the roster) is the provider's own business to cache
+ * within a turn.
+ *
+ * This is also the half of decision **D4** that re-evaluates. Rendered context
+ * cannot be un-sent so the context guard snapshots; an outbound call that has
+ * not fired yet can still be refused, so this one recomputes.
+ *
+ * ## Absent provider means the feature is OFF, not that the floor is CLOSED
+ *
+ * This distinction is the whole reason introducing the guard does not break
+ * every existing deployment, and getting it wrong would be spectacular: a
+ * `closed` floor denies everything, so treating "nobody configured an audience
+ * source" as `closed` would silently disable every tool in every turn.
+ *
+ * The precedent is right next door. `turnContext.privacyHandle` is documented as
+ * "undefined when no provider is installed (then tool results flow through
+ * unmodified)" — the same shape, for the same reason. So:
+ *
+ *  - **no provider** → not enforced. There is no floor, because nobody asked
+ *    for one.
+ *  - **provider present, floor `closed`** → refuse. The deployment opted in and
+ *    the audience could not be established, which §5.1 says must fail closed.
+ *
+ * "Unknown audience" only means "deny" once somebody has said they want the
+ * room bounded at all.
+ *
+ * ## A refusal is a tool result, not an exception
+ *
+ * It reads back to the model the way the dispatch deadline does — a plain
+ * `Error: …` string in the tool's result slot. Throwing would abort the turn,
+ * which turns a policy decision into an outage and denies the model the chance
+ * to explain the refusal or take another route.
+ */
+
+/**
+ * Resolves the floor for the current turn. Installed by whatever knows how to
+ * enumerate the audience; absent in every deployment that has not opted in.
+ */
+export type AudienceFloorProvider = () => Promise<AudienceFloor>;
+
+/**
+ * The capability a tool dispatch requires.
+ *
+ * `tool:<name>` — a flat namespace on purpose. Capabilities are opaque tokens
+ * (see `audienceFloor.ts`), and the grant store is what decides which of them a
+ * role confers; encoding structure here would put policy in the wrong layer.
+ */
+export function toolCapability(name: string): Capability {
+  return `tool:${name}`;
+}
+
+/**
+ * Check whether the current audience permits dispatching `name`.
+ *
+ * Returns `undefined` when the call may proceed — including when no provider is
+ * installed — or the refusal string to hand back as the tool's result.
+ *
+ * A provider that throws is treated as a closed floor rather than an open one:
+ * the deployment asked for the room to be bounded, and an audience source that
+ * blew up has not bounded it. That is the same reasoning as `partial` in #333
+ * and `unresolved` in the floor itself, and it is the opposite of the
+ * `privacyHandle` precedent for a reason — privacy degrades to "unmodified"
+ * because its failure mode is over-sharing detail, while this one's failure
+ * mode is performing an effect nobody authorized.
+ */
+export async function guardToolEgress(name: string): Promise<string | undefined> {
+  const provider = turnContext.current()?.audienceFloor;
+  if (!provider) return undefined;
+
+  let floor: AudienceFloor;
+  try {
+    floor = await provider();
+  } catch (err) {
+    return audienceRefusal(
+      name,
+      `the audience could not be resolved (${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+
+  if (floorPermits(floor, toolCapability(name))) return undefined;
+
+  return audienceRefusal(
+    name,
+    floor.outcome === 'closed'
+      ? floor.reason
+      : 'not every participant in this conversation is permitted to use it',
+  );
+}
+
+/**
+ * The refusal text. Names the tool and the reason, and tells the model what to
+ * do next — an unexplained denial produces a retry loop against a wall.
+ */
+function audienceRefusal(name: string, reason: string): string {
+  return `Error: tool \`${name}\` was refused for this conversation — ${reason}. This is a permission boundary, not a transient failure: retrying will not help. Continue without it, or tell the user which participants would need access.`;
+}

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -203,6 +203,7 @@ import {
   turnContext,
   type TurnContextValue,
 } from './turnContext.js';
+import { guardToolEgress } from './audienceFloorGuard.js';
 import { resolveTurnOwnerIdentity } from './resolveTurnOwnerIdentity.js';
 import { isMcpServerPrivacyBypassed } from './mcpPrivacyBypass.js';
 import { isMcpServerKgIngest } from './mcpKgIngest.js';
@@ -5971,6 +5972,16 @@ export class Orchestrator {
     input: unknown,
     observer?: AskObserver,
   ): Promise<string> {
+    // #575 — the audience floor's egress guard, at the ONE choke point every
+    // tool dispatch passes through. Placed before the deadline machinery so a
+    // refused call costs nothing, and before the Privacy Shield boundary in
+    // `dispatchToolDeadlined` because the floor decides WHETHER an effect
+    // happens while Privacy Shield decides what a permitted one may carry
+    // (spec §5.4). Re-evaluated per call, not per turn: a turn-start snapshot
+    // is a TOCTOU hole. Inert unless an audience source is installed.
+    const refusal = await guardToolEgress(name);
+    if (refusal !== undefined) return refusal;
+
     const timeoutMs = resolveToolDispatchTimeoutMs();
     if (timeoutMs === 0) {
       // Deadline explicitly disabled by the operator — legacy behaviour.

--- a/middleware/packages/harness-orchestrator/src/turnContext.ts
+++ b/middleware/packages/harness-orchestrator/src/turnContext.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
+import type { AudienceFloorProvider } from './audienceFloorGuard.js';
 import type { ChatParticipantsProvider } from './chatParticipants.js';
 import type { McpInputSentinelMint } from './mcp/pendingMcpInput.js';
 import type { PrivacyTurnHandle } from './privacyHandle.js';
@@ -83,6 +84,20 @@ export interface TurnContextValue {
    */
   sessionScope?: string;
   chatParticipants?: ChatParticipantsProvider;
+  /**
+   * #575 — resolves the audience floor for this turn: what everyone currently
+   * present is jointly permitted to do. Invoked PER tool dispatch rather than
+   * once per turn, because a turn-start snapshot is a TOCTOU hole (spec §5.2) —
+   * somebody can join between the model deciding to call a tool and the call
+   * firing.
+   *
+   * `undefined` when no audience source is installed, and that means the floor
+   * is **not enforced** — not that it is closed. The distinction matters
+   * enormously: a closed floor denies everything, so reading "nobody configured
+   * this" as "closed" would silently disable every tool in every deployment.
+   * Same shape and same reasoning as `privacyHandle` below.
+   */
+  audienceFloor?: AudienceFloorProvider;
   /**
    * Privacy-Proxy Slice 2.1: per-turn privacy handle threaded through the
    * call tree so every tool-dispatch site can intern raw tool results

--- a/middleware/test/audienceFloorGuard.test.ts
+++ b/middleware/test/audienceFloorGuard.test.ts
@@ -1,0 +1,154 @@
+/**
+ * #575 — the egress guard.
+ *
+ * The single most consequential test here is the first one: **without an
+ * audience provider, nothing is refused.** A closed floor denies everything, so
+ * if "nobody configured this" were read as "closed", introducing the guard
+ * would silently disable every tool in every existing deployment. The rest of
+ * the file pins the opposite direction — once a deployment HAS opted in, an
+ * unestablished audience must deny rather than wave things through.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  guardToolEgress,
+  toolCapability,
+} from '../packages/harness-orchestrator/src/audienceFloorGuard.js';
+import { turnContext } from '../packages/harness-orchestrator/src/turnContext.js';
+import type { AudienceFloor } from '../packages/harness-channel-sdk/src/audienceFloor.js';
+
+const open = (...caps: string[]): AudienceFloor => ({
+  outcome: 'open',
+  capabilities: new Set(caps),
+});
+const closed = (reason: string): AudienceFloor => ({ outcome: 'closed', reason });
+
+/** Runs `fn` inside a turn whose audience floor resolves to `floor`. */
+async function withFloor<T>(
+  floor: (() => Promise<AudienceFloor>) | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return turnContext.run(
+    { turnId: 't1', turnDate: '2026-08-18', ...(floor ? { audienceFloor: floor } : {}) },
+    fn,
+  );
+}
+
+describe('an unconfigured deployment is not affected at all', () => {
+  it('no provider installed → nothing is refused', async () => {
+    // If this ever fails, every tool in every deployment without an audience
+    // source stops working. "Not enforced" is not the same as "closed".
+    const refusal = await withFloor(undefined, () => guardToolEgress('web_search'));
+    assert.equal(refusal, undefined);
+  });
+
+  it('outside a turn context entirely → nothing is refused', async () => {
+    assert.equal(await guardToolEgress('web_search'), undefined);
+  });
+});
+
+describe('once a provider IS installed, the floor is enforced', () => {
+  it('permits a tool the whole room may use', async () => {
+    const refusal = await withFloor(
+      async () => open('tool:web_search'),
+      () => guardToolEgress('web_search'),
+    );
+    assert.equal(refusal, undefined);
+  });
+
+  it('refuses a tool that is not in the floor', async () => {
+    const refusal = await withFloor(
+      async () => open('tool:something_else'),
+      () => guardToolEgress('web_search'),
+    );
+    assert.ok(refusal, 'expected a refusal');
+    assert.match(refusal ?? '', /web_search/);
+  });
+
+  it('refuses everything when the floor is closed, and says why', async () => {
+    const refusal = await withFloor(
+      async () => closed('audience unknown (empty_roster)'),
+      () => guardToolEgress('web_search'),
+    );
+    assert.match(refusal ?? '', /empty_roster/);
+  });
+
+  it('a throwing provider closes rather than opens', async () => {
+    // The opposite of the `privacyHandle` precedent, on purpose: privacy
+    // degrading to "unmodified" over-shares detail, while this degrading to
+    // "allowed" performs an effect nobody authorized.
+    const refusal = await withFloor(
+      async () => {
+        throw new Error('roster fetch failed');
+      },
+      () => guardToolEgress('web_search'),
+    );
+    assert.match(refusal ?? '', /roster fetch failed/);
+  });
+});
+
+describe('the refusal is usable', () => {
+  it('reads as a tool result, not an exception', async () => {
+    // Throwing would abort the turn — turning a policy decision into an outage.
+    const refusal = await withFloor(async () => closed('nope'), () => guardToolEgress('t'));
+    assert.equal(typeof refusal, 'string');
+    assert.match(refusal ?? '', /^Error: /);
+  });
+
+  it('tells the model retrying will not help', async () => {
+    // Without this the model burns the turn retrying against a wall.
+    const refusal = await withFloor(async () => closed('nope'), () => guardToolEgress('t'));
+    assert.match(refusal ?? '', /retrying will not help/i);
+  });
+});
+
+describe('capability naming', () => {
+  it('a tool needs its own `tool:<name>` capability', () => {
+    assert.equal(toolCapability('web_search'), 'tool:web_search');
+  });
+
+  it('holding a different tool’s capability does not transfer', async () => {
+    const refusal = await withFloor(
+      async () => open(toolCapability('read_file')),
+      () => guardToolEgress('write_file'),
+    );
+    assert.ok(refusal);
+  });
+});
+
+describe('re-evaluation, not a snapshot', () => {
+  it('the provider is consulted on EVERY dispatch', async () => {
+    // Spec §5.2: a turn-start snapshot is a TOCTOU hole — somebody can join
+    // between the model choosing a tool and the call firing.
+    let calls = 0;
+    await withFloor(
+      async () => {
+        calls += 1;
+        return open('tool:t');
+      },
+      async () => {
+        await guardToolEgress('t');
+        await guardToolEgress('t');
+        await guardToolEgress('t');
+      },
+    );
+    assert.equal(calls, 3);
+  });
+
+  it('a floor that narrows mid-turn refuses the later call', async () => {
+    let joined = false;
+    const refusals: (string | undefined)[] = [];
+    await withFloor(
+      async () => (joined ? open() : open('tool:t')),
+      async () => {
+        refusals.push(await guardToolEgress('t'));
+        joined = true; // a less-privileged participant arrives
+        refusals.push(await guardToolEgress('t'));
+      },
+    );
+    assert.equal(refusals[0], undefined, 'permitted before the joiner');
+    assert.ok(refusals[1], 'refused after the joiner');
+  });
+});


### PR DESCRIPTION
Follows #729, which shipped the floor as a pure function with no consumer. This wires the **first of its three guards** (spec §5.2) at `dispatchTool` — the one choke point every tool call passes through, reached from all three call sites.

## Placement is deliberate on both sides

- **Before the dispatch deadline machinery**, so a refused call costs no timer, no `AbortController`, no abandoned promise.
- **Before the Privacy Shield boundary** in `dispatchToolDeadlined`, because the floor decides *whether* an effect happens and Privacy Shield decides what a permitted one may **carry**. Reversing them would mean minimizing data for a call that should never have been made (§5.4).

Evaluated **per call**, not once per turn: a turn-start snapshot is a TOCTOU hole — somebody can join between the model choosing a tool and the call firing. This is also the half of **D4** that re-evaluates; rendered context cannot be un-sent, but an unfired call can still be refused.

## The property that keeps this from breaking every deployment

> **An absent provider means the floor is NOT ENFORCED. That is not the same as CLOSED.**

A closed floor denies everything. So reading *"nobody configured an audience source"* as *"closed"* would silently disable **every tool in every existing deployment**. `turnContext.privacyHandle` sets the precedent right next door — *"undefined when no provider is installed"* — and this follows it.

The full suite is the evidence, not just the argument: **6637 tests pass with the guard live in the real dispatch path, and not one of them installs a provider.**

**But a provider that throws closes rather than opens** — deliberately the opposite of the privacy precedent. Privacy degrading to "unmodified" over-shares detail; this degrading to "allowed" performs an effect nobody authorized.

## A refusal is a tool result, not an exception

Throwing would abort the turn, turning a policy decision into an outage. The text names the tool, quotes the floor's own reason, and states that retrying will not help — otherwise the model burns the turn looping against a wall.

## Blast radius

| Surface | Effect |
|---|---|
| Deployments without an audience source | **none** — the guard returns immediately |
| Deployments with one | tool calls the room is not jointly permitted are refused |
| Published plugin contract | none |
| Database | none |

## Verification

- Full suite: **6637 tests, 0 fail, 0 cancelled** (12 new)
- `npm run typecheck` ✅ · `npm run lint` ✅ · #470 ratchet 3294 ✅ · #573 ratchet 406/406 ✅

### Mutation checks

| Mutation | Result |
|---|---|
| treat a missing provider as closed | **killed** — exactly the two "unconfigured deployment" tests |
| let a throwing provider fall through to allowed | **killed** — the "closes rather than opens" test |

## Still to come

The other two guards — **context/memory retrieval** (per retrieval, per recipient) and **file/credential handle resolution** — plus a persistent grant store. They share this intersection function rather than re-deriving one.

Refs #575

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789629741&installation_model_id=428086&pr_number=731&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F731&signature=087cf553d4920758aae243bbdc7fcce7f469904c8515fb0b67ad2bd6e0973a4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->