### PR TITLE
feat(#575): wire the audience floor's context-recall guard

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,33 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — the audience floor now guards context recall (#575)
+
+- **The floor's second guard**, at the single context-assembly call site. In a
+  shared room the recalled context is rendered into one prompt that everyone's
+  reply derives from, so the room may only recall what **everyone present** may
+  read. That is the same intersection, applied to a `memory:recall` capability.
+- **This one snapshots, while egress re-computes** — the two halves of decision
+  D4. Rendered context cannot be un-sent, so re-filtering it later in the turn
+  would be theatre; an unfired tool call can still be refused, so that one
+  recomputes per call.
+- **A denial is a skip, not an error.** The turn proceeds without prior context,
+  exactly as it already does when no retriever is configured, and the reason is
+  logged. Dressing a policy decision up as a fault would be misleading.
+- **Recall and tool use are separate capabilities.** Being allowed to run a tool
+  says nothing about being allowed to read the room's history, and neither
+  grants the other.
+- Same inertness as the egress guard: with no audience source installed, recall
+  behaves exactly as before.
+
+> **Known limitation, stated rather than papered over.** The spec asks for "per
+> retrieval, **per recipient**", and this is not that. Two preconditions do not
+> exist in the tree yet: context is assembled once per turn into a single prompt
+> (there is no per-recipient render for a per-recipient context to go to), and
+> recalled items carry scores and scopes but no capability labels (there is
+> nothing per item to check). A per-item filter would have to invent a labelling
+> scheme, which is policy and not this layer's to invent.
+
 ### Added — the audience floor now guards tool egress (#575)
 
 - **The first of the floor's three guards is wired**, at `dispatchTool` — the

--- a/middleware/packages/harness-orchestrator/src/audienceFloorGuard.ts
+++ b/middleware/packages/harness-orchestrator/src/audienceFloorGuard.ts
@@ -69,6 +69,79 @@ export function toolCapability(name: string): Capability {
 }
 
 /**
+ * The capability recalling prior context into the prompt requires.
+ *
+ * One flat token rather than a per-item permission, and that is a measured
+ * limitation rather than a shortcut — see {@link guardContextRecall}.
+ */
+export const MEMORY_RECALL_CAPABILITY: Capability = 'memory:recall';
+
+/**
+ * #575 — the second guard: context / memory recall.
+ *
+ * ## Why this one SNAPSHOTS while egress re-computes
+ *
+ * Decision **D4** splits by reversibility. Once recalled context has been
+ * rendered into the prompt it cannot be un-sent, so re-filtering it later in
+ * the turn is theatre. This guard therefore evaluates the floor **once**, at
+ * the moment of recall, and that answer stands for the assembled context. The
+ * egress guard does the opposite because an unfired tool call can still be
+ * refused.
+ *
+ * ## Why it is one gate and not a per-item, per-recipient filter
+ *
+ * Spec §5.2 asks for "per retrieval, per recipient", and that is the right
+ * target. It is not what this wires, because two of its preconditions do not
+ * exist in the tree today, and pretending otherwise would ship a filter that
+ * only looks like one:
+ *
+ *  1. **There is no per-recipient render.** Context is assembled once per turn
+ *     into a single prompt string; every participant sees the same model reply
+ *     derived from it. Until output is rendered per person, "the context for
+ *     Alice" has nowhere to go.
+ *  2. **Recalled items carry no capability labels.** The retriever returns
+ *     turns and memories from the knowledge graph with scores and scopes, not
+ *     entitlements. There is nothing per item to check against, so a per-item
+ *     filter would have to invent a labelling scheme — policy, and not this
+ *     layer's to invent.
+ *
+ * What IS enforceable today is the honest reduction of the same rule: in a
+ * shared room the recalled context reaches everyone present, so the room may
+ * only recall what **everyone** present may read. That is exactly the
+ * intersection, applied to one capability.
+ *
+ * ## A denial here is a skip, not an error
+ *
+ * Unlike a refused tool call, a refused recall has a natural degraded mode: the
+ * turn proceeds without prior context, which is precisely what already happens
+ * when no retriever is configured. So this returns a *reason to log*, and the
+ * caller takes its existing "skip recall" path rather than surfacing anything
+ * to the model. Turning a missing memory into an error would make a policy
+ * decision look like a fault.
+ *
+ * Returns `undefined` when recall may proceed — including when no audience
+ * provider is installed, for the same "not enforced ≠ closed" reason spelled
+ * out at the top of this file.
+ */
+export async function guardContextRecall(): Promise<string | undefined> {
+  const provider = turnContext.current()?.audienceFloor;
+  if (!provider) return undefined;
+
+  let floor: AudienceFloor;
+  try {
+    floor = await provider();
+  } catch (err) {
+    return `audience unresolvable (${err instanceof Error ? err.message : String(err)})`;
+  }
+
+  if (floorPermits(floor, MEMORY_RECALL_CAPABILITY)) return undefined;
+
+  return floor.outcome === 'closed'
+    ? floor.reason
+    : 'not every participant in this conversation may read recalled context';
+}
+
+/**
  * Check whether the current audience permits dispatching `name`.
  *
  * Returns `undefined` when the call may proceed — including when no provider is

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -203,7 +203,7 @@ import {
   turnContext,
   type TurnContextValue,
 } from './turnContext.js';
-import { guardToolEgress } from './audienceFloorGuard.js';
+import { guardContextRecall, guardToolEgress } from './audienceFloorGuard.js';
 import { resolveTurnOwnerIdentity } from './resolveTurnOwnerIdentity.js';
 import { isMcpServerPrivacyBypassed } from './mcpPrivacyBypass.js';
 import { isMcpServerKgIngest } from './mcpKgIngest.js';
@@ -2637,6 +2637,19 @@ export class Orchestrator {
     }
     if (!input.sessionScope && !input.userId) {
       console.error('[context] SKIP no-scope-no-user');
+      return { text: undefined, recalled: undefined };
+    }
+    // #575 — the audience floor's context guard. Recalled context is rendered
+    // into one prompt that every participant's reply derives from, so the room
+    // may only recall what EVERYONE present may read. Evaluated once here and
+    // not revisited: rendered context cannot be un-sent, which is the half of
+    // decision D4 that snapshots (egress re-computes instead). Inert unless an
+    // audience source is installed. A denial is a skip, not an error — the turn
+    // simply proceeds without prior context, exactly as it already does when no
+    // retriever is configured.
+    const recallRefusal = await guardContextRecall();
+    if (recallRefusal !== undefined) {
+      console.error(`[context] SKIP audience-floor: ${recallRefusal}`);
       return { text: undefined, recalled: undefined };
     }
     try {

--- a/middleware/test/audienceFloorGuard.test.ts
+++ b/middleware/test/audienceFloorGuard.test.ts
@@ -13,6 +13,8 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  MEMORY_RECALL_CAPABILITY,
+  guardContextRecall,
   guardToolEgress,
   toolCapability,
 } from '../packages/harness-orchestrator/src/audienceFloorGuard.js';
@@ -115,6 +117,66 @@ describe('capability naming', () => {
       () => guardToolEgress('write_file'),
     );
     assert.ok(refusal);
+  });
+});
+
+// ─── guard 2: context / memory recall ──────────────────────────────────────
+
+describe('the context guard', () => {
+  it('an unconfigured deployment recalls exactly as before', async () => {
+    // Same load-bearing property as the egress guard: "not enforced" is not
+    // "closed". If this fails, every deployment silently loses its memory.
+    assert.equal(await withFloor(undefined, () => guardContextRecall()), undefined);
+  });
+
+  it('permits recall when the whole room may read it', async () => {
+    const refusal = await withFloor(
+      async () => open(MEMORY_RECALL_CAPABILITY),
+      () => guardContextRecall(),
+    );
+    assert.equal(refusal, undefined);
+  });
+
+  it('refuses recall when someone present may not read it', async () => {
+    // A shared room renders ONE prompt that everyone's reply derives from, so
+    // recalled context reaches everyone. The room may only recall what
+    // everyone may read.
+    const refusal = await withFloor(async () => open('tool:t'), () => guardContextRecall());
+    assert.match(refusal ?? '', /not every participant/);
+  });
+
+  it('a closed floor blocks recall and passes its reason through', async () => {
+    const refusal = await withFloor(
+      async () => closed('audience unknown (no_provider)'),
+      () => guardContextRecall(),
+    );
+    assert.match(refusal ?? '', /no_provider/);
+  });
+
+  it('a throwing provider blocks recall rather than allowing it', async () => {
+    const refusal = await withFloor(
+      async () => {
+        throw new Error('roster exploded');
+      },
+      () => guardContextRecall(),
+    );
+    assert.match(refusal ?? '', /roster exploded/);
+  });
+
+  it('a reason to log, not an Error string for the model', async () => {
+    // Unlike a refused tool call, a refused recall has a natural degraded
+    // mode — the turn proceeds without prior context. Dressing that up as an
+    // error would make a policy decision look like a fault.
+    const refusal = await withFloor(async () => closed('nope'), () => guardContextRecall());
+    assert.ok(refusal);
+    assert.doesNotMatch(refusal ?? '', /^Error: /);
+  });
+
+  it('the tool capability does NOT grant recall, and vice versa', async () => {
+    // Two distinct capabilities: being allowed to run a tool says nothing
+    // about being allowed to read the room's history.
+    assert.ok(await withFloor(async () => open(toolCapability('t')), () => guardContextRecall()));
+    assert.ok(await withFloor(async () => open(MEMORY_RECALL_CAPABILITY), () => guardToolEgress('t')));
   });
 });
 


### PR DESCRIPTION
The floor's **second** guard (spec §5.2), after #731 wired the first. At the single context-assembly call site.

In a shared room the recalled context is rendered into **one** prompt that everyone's reply derives from — so the room may only recall what **everyone present** may read. Same intersection function, applied to a `memory:recall` capability.

## This one snapshots; egress re-computes

The two halves of decision **D4**, split by reversibility:

| Guard | Timing | Why |
|---|---|---|
| Context recall (this PR) | **snapshot**, once at recall | rendered context cannot be un-sent, so re-filtering later is theatre |
| Tool egress (#731) | **re-compute**, per call | an unfired call can still be refused |

## A denial is a skip, not an error

A refused recall has a natural degraded mode — the turn proceeds without prior context, exactly as it already does when no retriever is configured. So the guard returns a reason to **log**, and the caller takes its existing `[context] SKIP` path. Dressing a policy decision up as a fault would misreport it.

Recall and tool use are **separate capabilities**: being allowed to run a tool says nothing about being allowed to read the room's history, and neither grants the other.

## Known limitation — named, not papered over

The spec asks for "per retrieval, **per recipient**". **This is not that**, because two preconditions do not exist in the tree today:

1. **There is no per-recipient render.** Context is assembled once per turn into a single prompt string, so "the context for Alice" has nowhere to go.
2. **Recalled items carry no capability labels.** The retriever returns turns and memories with scores and scopes, not entitlements — there is nothing per item to check against. A per-item filter would have to invent a labelling scheme, which is policy and not this layer's to invent.

What *is* enforceable today is the honest reduction of the same rule, and that is what ships. A filter that only looked like a per-recipient one would be worse than naming the gap.

## Blast radius

| Surface | Effect |
|---|---|
| Deployments without an audience source | **none** — recall behaves exactly as before |
| Deployments with one | recall is skipped when the room may not jointly read it, and the reason is logged |
| Published plugin contract | none |
| Database | none |

## Verification

- Full suite: **6644 tests, 0 fail, 0 cancelled** (7 new). None of them installs an audience provider — which is the evidence for the inertness claim, not just the argument.
- `npm run typecheck` ✅ · `npm run lint` ✅ · #470 ratchet 3294 ✅ · #573 ratchet 406/406 ✅
- **Mutation:** letting any open floor grant recall (rather than requiring `memory:recall` specifically) kills the "someone present may not read it" test *and* the capability-separation test.

## Still to come

The third guard — **file / credential handle resolution**, which must ride with the handle because it outlives the turn — plus a persistent grant store.

Refs #575

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789635305&installation_model_id=428086&pr_number=732&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F732&signature=fd54f1c635907d1a031a0a76254eb2ffb9bd3eff3ee42c75c4c7865249598b40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->