### PR TITLE
fix(channel-sdk): keep NO_REPLY suppressible after the Art. 50 disclosure fold

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,27 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — a withheld answer no longer ships its full reasoning to the channel
+
+- **`NO_REPLY` stopped suppressing delivery the moment the AI-Act Art. 50
+  marking shipped (#661, #662).** `isNoReply` anchors the sentinel at the END of
+  the message; `applyAiDisclosure` folds the marking line into that same `text`.
+  Folded onto a sentinel answer, the anchor stops matching and the agent's
+  entire turn goes out.
+- **Seen in production.** A weekly approval routine emitted the sentinel in all
+  four of its recorded runs and still pushed 9,381 characters of intermediate
+  reasoning into a Teams chat on the first Monday after the deploy. Every
+  routine on every channel that relies on the sentinel was affected, and both
+  sentinel forms were — the mandated bare `NO_REPLY` as much as the lenient
+  trailing one.
+- **Suppression now precedes decoration.** The guard sits in the one shared
+  derivation, so the streaming and non-streaming paths, and every channel that
+  renders `text`, are covered by construction rather than per call site.
+- **A withheld message no longer spends the scope's first-turn marking slot.**
+  The guard short-circuits before `shouldFold`, which marks a scope seen as a
+  side effect; otherwise the next answer that really was delivered would have
+  shipped without its Art. 50 marking.
+
 ### Added — the audience floor now guards attachment-handle resolution (#575)
 
 - **The floor's third and last guard**, completing the trio the spec names. A

--- a/middleware/packages/harness-channel-sdk/src/aiDisclosure.ts
+++ b/middleware/packages/harness-channel-sdk/src/aiDisclosure.ts
@@ -22,6 +22,8 @@
  * marker for the API/MCP paths is the separate #647 (provenance.ts).
  */
 
+import { isNoReply } from './noReply.js';
+
 /**
  * Disclosure verbosity. `'off'` is reachable ONLY through explicit operator
  * configuration — never the shipping default, and not settable from within a
@@ -289,11 +291,19 @@ export function applyAiDisclosure(
 ): ApplyAiDisclosureResult {
   const aiDisclosure = ctx.disclosure ?? resolveFromPolicy(ctx);
   if (aiDisclosure === undefined) return { text: answer };
+  // Suppression precedes decoration. `isNoReply` anchors the sentinel at the
+  // END of the message, so folding a marking line onto a NO_REPLY answer makes
+  // the anchor stop matching and delivers a message the agent deliberately
+  // wanted withheld. There is also nothing to disclose: the text never reaches
+  // a human. Short-circuit BEFORE `shouldFold`, which marks the scope seen —
+  // a withheld message must not consume the scope's first-turn marking slot,
+  // or the next delivered answer would ship unmarked.
   // The note rides the carrier (`aiDisclosure.operatorNote`), so a pre-resolved
   // marker folds its own note and a policy-resolved one folds the note the
   // policy carried — both without re-reading `ctx.operatorNote` here.
-  const text = shouldFold(ctx.scope, ctx.seen)
-    ? foldDisclosure(answer, aiDisclosure.text, aiDisclosure.operatorNote)
-    : answer;
+  const text =
+    !isNoReply({ text: answer }) && shouldFold(ctx.scope, ctx.seen)
+      ? foldDisclosure(answer, aiDisclosure.text, aiDisclosure.operatorNote)
+      : answer;
   return { text, aiDisclosure };
 }

--- a/middleware/test/noReplyDisclosure.test.ts
+++ b/middleware/test/noReplyDisclosure.test.ts
@@ -1,0 +1,112 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  applyAiDisclosure,
+  isNoReply,
+  resolveAiDisclosure,
+  toSemanticAnswer,
+} from '@omadia/channel-sdk';
+
+const DE_STANDARD = 'Diese Antwort wurde von einem KI-System erzeugt.';
+
+/**
+ * Regression guard: suppression must precede decoration.
+ *
+ * `isNoReply` anchors the lenient sentinel form at the END of the message
+ * (`/(?:^|\n)\s*NO_REPLY\s*$/`). The AI-Act Art. 50 marking (#643/#644) folds
+ * a line into the very same `text`. Folding it onto a NO_REPLY answer appends
+ * text AFTER the sentinel, the end-anchor stops matching, and a routine that
+ * deliberately had nothing to report delivers its full reasoning instead.
+ *
+ * That is the 2026-08-17 incident: the weekly "Urlaubsanträge zur Genehmigung"
+ * routine emitted the sentinel exactly as instructed (it does in all four
+ * recorded runs) and still pushed 9,381 characters into the operator's Teams
+ * chat, because the middleware deployed on 2026-08-14 had started folding the
+ * marking.
+ */
+
+/** The literal tail of the 2026-08-17 routine answer. */
+const PROSE_SENTINEL =
+  "Per the task instruction, no notification when there's nothing to approve.\n\nNO_REPLY";
+
+function turn(answer: string) {
+  return { answer, toolCalls: 0, iterations: 1 };
+}
+
+describe('NO_REPLY survives the AI-Act disclosure fold', () => {
+  it('keeps the strict sentinel suppressible', () => {
+    const out = applyAiDisclosure('NO_REPLY');
+    assert.equal(out.text, 'NO_REPLY', 'the marking must not be folded onto a sentinel');
+    assert.ok(isNoReply({ text: out.text }), 'the sentinel still suppresses delivery');
+  });
+
+  it('keeps the lenient trailing sentinel suppressible', () => {
+    const out = applyAiDisclosure(PROSE_SENTINEL);
+    assert.ok(
+      isNoReply({ text: out.text }),
+      'prose + trailing NO_REPLY must stay suppressible after disclosure resolution',
+    );
+    assert.ok(!out.text.includes(DE_STANDARD), 'no marking is appended after the sentinel');
+  });
+
+  it('still forwards the structured marker for the audit trail', () => {
+    const out = applyAiDisclosure(PROSE_SENTINEL);
+    assert.ok(out.aiDisclosure, 'the resolved marker is still returned — only the fold is skipped');
+  });
+
+  it('reproduces the routine delivery path end to end (the 2026-08-17 incident)', () => {
+    // routineRunner.ts: `toSemanticAnswer(result)` with NO ctx — the marking
+    // rides `result.aiDisclosure`, resolved by the orchestrator (#644).
+    const sa = toSemanticAnswer({
+      ...turn(PROSE_SENTINEL),
+      aiDisclosure: resolveAiDisclosure(),
+    });
+    assert.ok(
+      isNoReply(sa),
+      'the message handed to the channel sender must still be recognised as NO_REPLY',
+    );
+  });
+
+  it('does NOT weaken the marking on a real answer', () => {
+    const sa = toSemanticAnswer({
+      ...turn('Es liegen 3 Urlaubsanträge zur Genehmigung vor.'),
+      aiDisclosure: resolveAiDisclosure(),
+    });
+    assert.match(sa.text, /KI-System/, 'a deliverable answer keeps its Art. 50 marking');
+    assert.ok(!isNoReply(sa), 'a real answer is delivered');
+  });
+
+  it('does not spend the scope first-turn marking slot on a withheld message', () => {
+    // `shouldFold` marks the scope seen as a side effect, and the marking is
+    // folded only on a scope's FIRST turn. A withheld message must not consume
+    // that one slot — otherwise the next answer that really is delivered would
+    // ship without its Art. 50 marking.
+    const seen = new Set<string>();
+    const store = {
+      hasSeen: (scope: string) => seen.has(scope),
+      markSeen: (scope: string) => {
+        seen.add(scope);
+      },
+    };
+
+    const withheld = applyAiDisclosure(PROSE_SENTINEL, { scope: 'routine:abc', seen: store });
+    assert.ok(isNoReply({ text: withheld.text }), 'the withheld turn stays suppressible');
+    assert.equal(seen.size, 0, 'a withheld turn does not mark the scope seen');
+
+    const delivered = applyAiDisclosure('Es liegen 3 Anträge vor.', {
+      scope: 'routine:abc',
+      seen: store,
+    });
+    assert.match(delivered.text, /KI-System/, 'the next delivered answer still gets marked');
+  });
+
+  it('does not treat a quoted sentinel mid-answer as a suppression', () => {
+    const sa = toSemanticAnswer({
+      ...turn('Die Routine antwortet mit NO_REPLY, wenn nichts anliegt. Heute: 2 Anträge.'),
+      aiDisclosure: resolveAiDisclosure(),
+    });
+    assert.ok(!isNoReply(sa), 'a mid-answer mention is not a sentinel');
+    assert.match(sa.text, /KI-System/, 'and it keeps its marking');
+  });
+});


### PR DESCRIPTION
## What broke

`NO_REPLY` stopped suppressing delivery. Routines that deliberately had nothing
to report started pushing their **entire turn** — including intermediate
reasoning — into the operator's chat.

Observed in production: the weekly approval routine emitted the sentinel in
**all four** of its recorded runs and still delivered **9,381 characters** into a
Teams chat on the first run after the deploy that shipped #661/#662.

## Root cause

Two features write to the same field, in the wrong order.

- `isNoReply` matches the sentinel **anchored at the END** of the message:
  `/(?:^|\n)\s*NO_REPLY\s*$/` (`noReply.ts`).
- `applyAiDisclosure` folds the AI-Act Art. 50 marking line **into that same
  `text`** (`aiDisclosure.ts`, #643/#644) — deliberately, because `text` is the
  one field every connector must render.

Folded onto a sentinel answer, the result is `…\n\nNO_REPLY\n\nDiese Antwort
wurde von einem KI-System erzeugt.` The end-anchor no longer matches, `isNoReply`
returns `false`, and the channel sender runs.

Both sentinel forms were affected — the **mandated bare `NO_REPLY`** as much as
the lenient trailing one. The filter itself was never broken and is correctly
wired on every path; it was simply handed already-decorated text.

The run history made this hard to see: `routine_runs.answer` stores
`result.answer`, the **raw** model output, which still ends in the sentinel.
Only the delivered `toSemanticAnswer(result).text` carries the fold.

## The fix

Suppression precedes decoration, in the one shared derivation:

```ts
const text =
  !isNoReply({ text: answer }) && shouldFold(ctx.scope, ctx.seen)
    ? foldDisclosure(answer, aiDisclosure.text, aiDisclosure.operatorNote)
    : answer;
```

Placing it in `applyAiDisclosure` rather than at a call site covers the
streaming `done` path and the non-streaming path, and therefore every channel,
by construction — the same reason #644 put the derivation there.

**The short-circuit order is load-bearing.** `shouldFold` marks the scope seen
as a side effect, and the marking is folded only on a scope's first turn. Had
the guard run after it, a withheld message would have silently consumed the
scope's one marking slot and the next answer that really was delivered would
have shipped **without** its Art. 50 marking. Evaluating `isNoReply` first keeps
the slot. That property has its own test.

The structured `aiDisclosure` field is still returned for a withheld turn, so
the audit trail is unchanged. Only the text fold is skipped — a message that
never reaches a human has nothing to disclose.

## Tests

New `middleware/test/noReplyDisclosure.test.ts` (7 cases). Three of them fail on
`main` and pass here — the guard is the only change between the two runs:

| Case | On `main` | Here |
|---|---|---|
| strict `NO_REPLY` stays suppressible | ✖ | ✔ |
| prose + trailing `NO_REPLY` stays suppressible | ✖ | ✔ |
| routine delivery path end to end (the incident) | ✖ | ✔ |
| structured marker still forwarded (audit) | ✔ | ✔ |
| a real answer keeps its Art. 50 marking | ✔ | ✔ |
| a withheld turn does not spend the first-turn slot | — | ✔ |
| a quoted mid-answer `NO_REPLY` is not a sentinel | ✔ | ✔ |

The end-to-end case reconstructs the production path exactly:
`toSemanticAnswer(result)` with no ctx, the marking riding
`result.aiDisclosure` as the orchestrator resolves it in #644.

Neighbouring suites stay green, including the #644 `AC4 proactive routine path`
test that asserts the fold **does** happen for a deliverable routine answer:
`aiDisclosure` + `aiDisclosure644` + `aiDisclosurePosture` + `routineRunner` +
`routinesIntegrationBinding` → 106/106.

## Blast radius

Every routine on every channel that relies on the sentinel, since the build that
shipped #661/#662. Report-style routines that always deliver were unaffected.

Behaviour narrows only: no answer that was folded before stops being folded,
except one that was never going to be delivered.

## After merge

Production is running an affected build — this needs a redeploy to take effect,
not just a merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789640617&installation_model_id=428086&pr_number=735&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F735&signature=c5fa019727cdd86c640206e9f38a36c5c73d1de66606a2dec74242118e1cbb54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->