### PR TITLE
feat(#575): durable audience-floor grants + an operator surface for them

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,28 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — audience-floor grants survive a restart, and an operator can see them
+
+- **The audience floor had no durable store (#575).** `InMemoryGrantStore` was
+  the only implementation, so a deployment that switched the floor on lost every
+  grant on restart. Because the floor fails closed, that did not degrade the
+  feature — an empty grant table means "nobody may do anything", so a restart
+  shut every room until someone re-seeded by hand.
+- **New:** `AUDIENCE_FLOOR_ENABLED` (default off) plus Postgres-backed grants
+  (migration `0035_audience_grants.sql`) and an operator surface at
+  `/api/v1/admin/audience-grants` (cookie auth, like the other admin routers).
+- **The admin surface is available whenever Postgres is, independently of
+  enforcement** — grants have to be seedable and reviewable *before* the floor
+  starts enforcing, or the only way to populate the table would be to switch the
+  floor on against an empty one.
+- **Enabling the floor without Postgres refuses to boot.** The alternative is
+  worse than a crash: every lookup would throw, every room would refuse every
+  tool, recall nothing and read no attachment, and the deployment would look
+  configured while behaving as though someone had forbidden everything.
+- Role grants additionally need a role source registered (#333 phase 2); direct
+  grants work on their own, because an empty role registry is a complete answer
+  rather than a partial one.
+
 ### Fixed — a withheld answer no longer ships its full reasoning to the channel
 
 - **`NO_REPLY` stopped suppressing delivery the moment the AI-Act Art. 50

--- a/middleware/migrations/0035_audience_grants.sql
+++ b/middleware/migrations/0035_audience_grants.sql
@@ -1,0 +1,68 @@
+-- ── Audience-floor capability grants (#575 phase 2) ────────────────────────
+-- The durable backing for `GrantStore`. Until now the only implementation was
+-- `InMemoryGrantStore`, which means a deployment that switched the audience
+-- floor on lost every grant on restart — and because the floor fails closed, an
+-- empty grant table is not "no policy", it is "nobody may do anything". A
+-- restart therefore did not degrade the feature, it shut the rooms.
+--
+-- Two tables rather than one with a nullable discriminator: a direct grant and
+-- a role grant are looked up by different keys on different code paths
+-- (`directGrants(principal)` vs `roleGrants(roleKey)`), and the SDK keeps them
+-- separate for exactly that reason. One table with a half-empty key column
+-- would need a partial index per path and could express a row that is neither.
+--
+-- Capability strings are opaque here on purpose. The floor intersects sets of
+-- them; what they mean (`tool:send_email`, `memory:recall`, `attachment:read`)
+-- is the guards' business, and a CHECK constraint listing today's namespaces
+-- would have to be migrated every time a guard learns a new one.
+
+-- ---------------------------------------------------------------------------
+-- Direct grants: a Principal holds a capability in their own right.
+--
+-- `principal_kind` is always 'user' today — `resolveCapabilities` refuses a
+-- `role:` principal outright, because a role is an indirection over holders and
+-- not a subject with entitlements. The column exists anyway so the table does
+-- not have to be migrated if #333 ever grows a third kind; a row with any other
+-- kind is simply never read.
+--
+-- `principal_ref` holds the CANONICAL form (`canonicalizePrincipalRef`), which
+-- for a user means lower-cased. Writing the raw form here would let the same
+-- person miss their own grants depending on how a channel spelled their id.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS audience_direct_grants (
+  principal_kind TEXT        NOT NULL,
+  principal_ref  TEXT        NOT NULL,
+  capability     TEXT        NOT NULL,
+  granted_by     TEXT        NOT NULL,
+  granted_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (principal_kind, principal_ref, capability)
+);
+
+-- ---------------------------------------------------------------------------
+-- Role grants: everyone who currently holds the role holds the capability.
+--
+-- DELIBERATELY NO FOREIGN KEY to conductor_roles(key).
+--
+-- #333 phase 2 made role membership answerable by a registry of sources, and a
+-- source may be an external directory this deployment has no local row for. A
+-- foreign key would make "grant a capability to the Entra group everyone in
+-- support belongs to" unrepresentable — the exact case the role-source registry
+-- exists to serve. The cost is that a typo'd role key is accepted and silently
+-- grants nothing; that fails in the safe direction, and the admin surface lists
+-- what is stored so the typo is visible.
+--
+-- Role keys keep their case: `conductor_roles.key` is written verbatim by
+-- `createRole`, so lower-casing here would miss every mixed-case role.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS audience_role_grants (
+  role_key   TEXT        NOT NULL,
+  capability TEXT        NOT NULL,
+  granted_by TEXT        NOT NULL,
+  granted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (role_key, capability)
+);
+
+-- The hot path reads every capability for one key, which the primary key's
+-- leading column already serves. No secondary index is added for it.
+
+-- rollback: DROP TABLE audience_role_grants; DROP TABLE audience_direct_grants;

--- a/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
@@ -14,7 +14,7 @@
  * than once in one process.
  */
 
-import type { ChatAgent, DisclosureSeenStore } from '@omadia/channel-sdk';
+import type { ChatAgent, DisclosureSeenStore, GrantStore } from '@omadia/channel-sdk';
 import type { EmbeddingClient } from '@omadia/embeddings';
 import type { LlmProvider } from '@omadia/llm-provider';
 import type {
@@ -201,6 +201,18 @@ export interface OrchestratorDeps {
    * `OrchestratorOptions.securityScreener` / `securityAuditSink`.
    */
   readonly securityPosture?: SecurityPostureSetup;
+  /**
+   * #575 — durable capability grants for the audience floor.
+   *
+   * Present ONLY when the operator enabled the floor: the kernel publishes the
+   * `audienceGrants` service behind `AUDIENCE_FLOOR_ENABLED`. Absent ⇒ the
+   * orchestrator installs no audience provider and the three guards
+   * short-circuit, which is the "not enforced ≠ closed" rule they are built on.
+   * Passing a store is therefore the switch, and the reason it is a switch
+   * rather than a default is that the floor fails closed — an empty grant table
+   * bounds every room to nothing.
+   */
+  readonly audienceGrants?: GrantStore;
   /** #133 E0 — side-channel turn-hook runner, fired during each turn. */
   readonly turnHookRegistry?: TurnHookRunner;
   /**
@@ -416,6 +428,8 @@ export function buildOrchestratorForAgent(
     // orchestrator applies the shipping default (`auto`); the screener + sink
     // are always wired (inert unless screening is enabled for the posture).
     ...(deps.securityPosture ? { securityPosture: deps.securityPosture } : {}),
+    // #575 — supplying this is what makes the audience guards non-inert.
+    ...(deps.audienceGrants ? { audienceGrants: deps.audienceGrants } : {}),
     securityScreener,
     securityAuditSink,
     ...(deps.turnHookRegistry

--- a/middleware/packages/harness-orchestrator/src/plugin.ts
+++ b/middleware/packages/harness-orchestrator/src/plugin.ts
@@ -3,6 +3,7 @@ import {
   POSTURE_ORDER,
   type ChatAgent,
   type AiDisclosureLevel,
+  type GrantStore,
   type SecurityPosture,
 } from '@omadia/channel-sdk';
 import type {
@@ -621,6 +622,13 @@ export async function activate(
   const securityPosture = resolveSecurityPostureSetup((key) =>
     ctx.config.get<unknown>(key),
   );
+  // #575 — the audience floor's capability grants. Published by the kernel
+  // BEFORE plugin activation (as a late-bound wrapper, because the Postgres
+  // pool it needs is published by the knowledge-graph plugin during this same
+  // pass) and ONLY when `AUDIENCE_FLOOR_ENABLED` is set. Undefined is the
+  // ordinary case: the orchestrator then installs no audience provider at all
+  // and every guard short-circuits, leaving behaviour unchanged.
+  const audienceGrants = ctx.services.get<GrantStore>('audienceGrants');
   // #648 — publish the RESOLVED posture so `/health` and the operator
   // dashboard can read what this instance actually does, and warn once at boot
   // when it deviates from the delivered state. A reduced marking is a
@@ -837,6 +845,10 @@ export async function activate(
     // #579 — org security posture (org floor + optional scope tighten + mode +
     // screen URL). Undefined → the orchestrator's shipping default (`auto`).
     ...(securityPosture ? { securityPosture } : {}),
+    // #575 — the audience floor's grant store, published by the kernel only
+    // when the operator enabled the floor. Absent is the normal case and means
+    // the guards stay inert; see `OrchestratorDeps.audienceGrants`.
+    ...(audienceGrants ? { audienceGrants } : {}),
     // #644 — one fold-dedup store for the whole process, shared by every Agent
     // the registry builds (same lifetime rationale as `directLineStickyStore`
     // below): a per-instance store would re-fold the marking into a live

--- a/middleware/src/audience/lateBoundGrantStore.ts
+++ b/middleware/src/audience/lateBoundGrantStore.ts
@@ -1,0 +1,69 @@
+/**
+ * #575 phase 2 — a {@link GrantStore} that resolves its backing store later.
+ *
+ * ## Why this indirection has to exist
+ *
+ * The orchestrator plugin reads the services it consumes at **activation**, and
+ * `index.ts` publishes those before `toolPluginRuntime.activateAllInstalled()`
+ * for exactly that reason. But `graphPool` is published BY a plugin — the
+ * knowledge-graph one — during that same activation pass, and is only readable
+ * afterwards. So at the moment the grant store must be published, the pool it
+ * needs does not exist yet.
+ *
+ * The codebase already solves this shape with a forward reference (see
+ * `conductorTemplateRegistrarRef` in `index.ts`): publish something now, point
+ * it at a holder, fill the holder in once the dependency resolves.
+ *
+ * ## Not-yet-hydrated must THROW, not return an empty list
+ *
+ * This is the whole reason the file has a header rather than being three lines
+ * inline. `GrantStore`'s contract says a store that cannot answer must throw,
+ * and `resolveCapabilities` turns that throw into an `unresolved` audience
+ * member — which closes the floor **with a reason an operator can act on**.
+ *
+ * Returning `[]` instead would be catastrophic in a way that looks harmless:
+ * an empty capability list is a perfectly well-formed answer, so the floor
+ * would intersect it into a smaller set and refuse things silently. The room
+ * would behave as though an operator had decided to forbid everything, and the
+ * actual cause — the store was consulted before it was ready — would leave no
+ * trace anywhere.
+ *
+ * Between "closed, and here is why" and "closed, cause unknown", only the first
+ * is a system anyone can operate.
+ */
+
+import type { Capability, GrantStore, Principal } from '@omadia/channel-sdk';
+
+export class GrantStoreNotReadyError extends Error {
+  constructor() {
+    super(
+      'audience grant store is not hydrated yet — the audience floor was consulted before Postgres resolved. ' +
+        'The floor is closed until the store is available; this is not a policy decision.',
+    );
+    this.name = 'GrantStoreNotReadyError';
+  }
+}
+
+/**
+ * Wrap a holder that is filled in later.
+ *
+ * @param resolve returns the real store, or `undefined` while still unhydrated.
+ */
+export function createLateBoundGrantStore(
+  resolve: () => GrantStore | undefined,
+): GrantStore {
+  const target = (): GrantStore => {
+    const store = resolve();
+    if (!store) throw new GrantStoreNotReadyError();
+    return store;
+  };
+
+  return {
+    async directGrants(principal: Principal): Promise<readonly Capability[]> {
+      return target().directGrants(principal);
+    },
+    async roleGrants(roleKey: string): Promise<readonly Capability[]> {
+      return target().roleGrants(roleKey);
+    },
+  };
+}

--- a/middleware/src/audience/postgresGrantStore.ts
+++ b/middleware/src/audience/postgresGrantStore.ts
@@ -1,0 +1,201 @@
+/**
+ * #575 phase 2 — the durable {@link GrantStore}.
+ *
+ * `InMemoryGrantStore` was the only implementation, which made the audience
+ * floor unusable for a real deployment in a way that is worth stating plainly:
+ * the floor **fails closed**, so an empty grant table does not mean "no policy
+ * configured", it means "nobody may do anything". A restart did not degrade the
+ * feature — it shut every room until someone re-seeded the grants by hand.
+ *
+ * ## Why this class must be allowed to throw
+ *
+ * The `GrantStore` contract says a store that cannot answer must throw, and
+ * that is the single property this file exists to preserve. `resolveCapabilities`
+ * catches the throw and turns it into an `unresolved` audience member, which
+ * closes the floor **with a reason**. A store that swallowed a database error
+ * and returned `[]` would instead hand the floor a *smaller* capability set —
+ * indistinguishable from a deliberate policy — and the intersection would
+ * quietly narrow. The operator would read "the floor forbids it" and never
+ * learn that Postgres was unreachable.
+ *
+ * So there is no try/catch on the read path here. That is not an oversight, and
+ * a well-meaning "let's make this robust" edit would reintroduce the exact
+ * failure the layer below was designed to make visible.
+ *
+ * ## It does not own the pool
+ *
+ * The pool is injected and never closed by this class. Issue #665 was precisely
+ * this mistake elsewhere: one subsystem called `close()` on a pool that ~40
+ * others shared, taking the process down with it. `close()` is not a
+ * process-exit path, and a store is not the owner of its connection.
+ *
+ * ## Canonicalisation happens on both sides
+ *
+ * Writes and reads both canonicalise, with the two different rules #333 phase 1
+ * established: user references lower-case, role keys keep their case. Applying
+ * only one side would mean a grant written through the admin API could not be
+ * found by the lookup that is supposed to honour it.
+ */
+
+import type { Pool } from 'pg';
+
+import {
+  canonicalizePrincipalRef,
+  principalRef,
+  type Capability,
+  type GrantStore,
+  type Principal,
+} from '@omadia/channel-sdk';
+
+/** One stored direct grant, as the admin surface lists it. */
+export interface DirectGrantRow {
+  readonly principalKind: string;
+  readonly principalRef: string;
+  readonly capability: Capability;
+  readonly grantedBy: string;
+  readonly grantedAt: Date;
+}
+
+/** One stored role grant, as the admin surface lists it. */
+export interface RoleGrantRow {
+  readonly roleKey: string;
+  readonly capability: Capability;
+  readonly grantedBy: string;
+  readonly grantedAt: Date;
+}
+
+/**
+ * A capability is stored verbatim apart from surrounding whitespace, matching
+ * what `resolveCapabilities` does when it builds the set. Rejecting the empty
+ * string at the boundary keeps a row that can never match anything out of the
+ * table — the floor treats `''` as absent, so such a row would read as a grant
+ * in the admin list while granting nothing.
+ */
+export function normalizeCapability(capability: string): string {
+  return capability.trim();
+}
+
+export class PostgresGrantStore implements GrantStore {
+  constructor(private readonly pool: Pool) {}
+
+  // ── read path (hot; used by resolveCapabilities on every evaluation) ──────
+
+  async directGrants(principal: Principal): Promise<readonly Capability[]> {
+    // A role principal never has direct grants — `resolveCapabilities` refuses
+    // it before reaching here, so this is defence for a direct caller rather
+    // than a code path the floor takes.
+    const ref = canonicalizePrincipalRef(principal.kind, principalRef(principal));
+    const result = await this.pool.query<{ capability: string }>(
+      `SELECT capability FROM audience_direct_grants
+        WHERE principal_kind = $1 AND principal_ref = $2`,
+      [principal.kind, ref],
+    );
+    return result.rows.map((row) => row.capability);
+  }
+
+  async roleGrants(roleKey: string): Promise<readonly Capability[]> {
+    const key = canonicalizePrincipalRef('role', roleKey);
+    const result = await this.pool.query<{ capability: string }>(
+      `SELECT capability FROM audience_role_grants WHERE role_key = $1`,
+      [key],
+    );
+    return result.rows.map((row) => row.capability);
+  }
+
+  // ── admin path (operator surface; never on a turn's hot path) ─────────────
+
+  /**
+   * Idempotent by primary key: re-granting an existing capability refreshes who
+   * granted it and when, rather than failing. An operator re-running a seeding
+   * script must not have to care whether it ran before.
+   */
+  async grantToPrincipal(
+    principal: Principal,
+    capability: string,
+    grantedBy: string,
+  ): Promise<void> {
+    const value = normalizeCapability(capability);
+    if (value.length === 0) throw new Error('capability must not be empty');
+    const ref = canonicalizePrincipalRef(principal.kind, principalRef(principal));
+    await this.pool.query(
+      `INSERT INTO audience_direct_grants (principal_kind, principal_ref, capability, granted_by)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (principal_kind, principal_ref, capability)
+       DO UPDATE SET granted_by = EXCLUDED.granted_by, granted_at = now()`,
+      [principal.kind, ref, value, grantedBy],
+    );
+  }
+
+  async grantToRole(roleKey: string, capability: string, grantedBy: string): Promise<void> {
+    const value = normalizeCapability(capability);
+    if (value.length === 0) throw new Error('capability must not be empty');
+    const key = canonicalizePrincipalRef('role', roleKey);
+    if (key.length === 0) throw new Error('role key must not be empty');
+    await this.pool.query(
+      `INSERT INTO audience_role_grants (role_key, capability, granted_by)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (role_key, capability)
+       DO UPDATE SET granted_by = EXCLUDED.granted_by, granted_at = now()`,
+      [key, value, grantedBy],
+    );
+  }
+
+  /** @returns whether a row was actually removed, so the API can 404 honestly. */
+  async revokeFromPrincipal(principal: Principal, capability: string): Promise<boolean> {
+    const ref = canonicalizePrincipalRef(principal.kind, principalRef(principal));
+    const result = await this.pool.query(
+      `DELETE FROM audience_direct_grants
+        WHERE principal_kind = $1 AND principal_ref = $2 AND capability = $3`,
+      [principal.kind, ref, normalizeCapability(capability)],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async revokeFromRole(roleKey: string, capability: string): Promise<boolean> {
+    const result = await this.pool.query(
+      `DELETE FROM audience_role_grants WHERE role_key = $1 AND capability = $2`,
+      [canonicalizePrincipalRef('role', roleKey), normalizeCapability(capability)],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async listDirectGrants(): Promise<DirectGrantRow[]> {
+    const result = await this.pool.query<{
+      principal_kind: string;
+      principal_ref: string;
+      capability: string;
+      granted_by: string;
+      granted_at: Date;
+    }>(
+      `SELECT principal_kind, principal_ref, capability, granted_by, granted_at
+         FROM audience_direct_grants
+        ORDER BY principal_kind, principal_ref, capability`,
+    );
+    return result.rows.map((row) => ({
+      principalKind: row.principal_kind,
+      principalRef: row.principal_ref,
+      capability: row.capability,
+      grantedBy: row.granted_by,
+      grantedAt: row.granted_at,
+    }));
+  }
+
+  async listRoleGrants(): Promise<RoleGrantRow[]> {
+    const result = await this.pool.query<{
+      role_key: string;
+      capability: string;
+      granted_by: string;
+      granted_at: Date;
+    }>(
+      `SELECT role_key, capability, granted_by, granted_at
+         FROM audience_role_grants
+        ORDER BY role_key, capability`,
+    );
+    return result.rows.map((row) => ({
+      roleKey: row.role_key,
+      capability: row.capability,
+      grantedBy: row.granted_by,
+      grantedAt: row.granted_at,
+    }));
+  }
+}

--- a/middleware/src/audience/routes.ts
+++ b/middleware/src/audience/routes.ts
@@ -1,0 +1,169 @@
+/**
+ * #575 phase 2 — the operator surface for audience-floor grants.
+ *
+ * The floor was switched on by #734 but had nowhere durable to read grants
+ * from, and no way for an operator to see or change them. That combination is
+ * worse than it sounds: because the floor fails closed, "I cannot see the
+ * grants" and "there are no grants" produce the same observable behaviour —
+ * every tool refused, no context recalled — with no way to tell them apart.
+ * This router exists so that state is inspectable before it is enforced.
+ *
+ * ## Everything here is operator-gated
+ *
+ * Mounted behind `requireAuth`, like every other `/api/v1/admin/*` router.
+ * Issue #669 is the reason that is stated rather than assumed: `/api/dev/*`
+ * shipped unauthenticated because a single `publicPaths` entry made a whole
+ * subtree public, and nobody noticed until it was audited.
+ *
+ * ## Writing a grant is not the same as enabling enforcement
+ *
+ * These endpoints are available whenever a Postgres grant store exists. They do
+ * NOT switch the floor on — that is `AUDIENCE_FLOOR_ENABLED`. The separation is
+ * deliberate: an operator must be able to seed and review a grant table BEFORE
+ * enforcement begins, because enabling the floor against an empty table shuts
+ * every room at once.
+ */
+
+import { Router, type Request, type Response } from 'express';
+
+import { makePrincipal, type Principal } from '@omadia/channel-sdk';
+
+import type { PostgresGrantStore } from './postgresGrantStore.js';
+
+export interface AudienceGrantRoutesDeps {
+  readonly store: PostgresGrantStore;
+  /** Who is making the change, for the `granted_by` trail. */
+  readonly actor: (req: Request) => string;
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function asObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+/**
+ * Only `user:` principals are accepted.
+ *
+ * `resolveCapabilities` refuses a `role:` principal outright — a role is an
+ * indirection over holders, not a subject with entitlements — so a direct grant
+ * to one would be stored and then never read. Rejecting it at the boundary
+ * turns a silently-inert row into a 400 that says which endpoint to use
+ * instead.
+ */
+function parseUserPrincipal(userId: string): Principal | undefined {
+  const trimmed = userId.trim();
+  if (trimmed.length === 0) return undefined;
+  return makePrincipal('user', trimmed);
+}
+
+export function createAudienceGrantRouter(deps: AudienceGrantRoutesDeps): Router {
+  const router = Router();
+
+  router.get('/', async (_req: Request, res: Response): Promise<void> => {
+    try {
+      const [direct, roles] = await Promise.all([
+        deps.store.listDirectGrants(),
+        deps.store.listRoleGrants(),
+      ]);
+      res.json({ direct, roles });
+    } catch (err) {
+      res.status(500).json({ code: 'audience.grants_list_failed', message: errMsg(err) });
+    }
+  });
+
+  router.post('/direct', async (req: Request, res: Response): Promise<void> => {
+    const body = asObject(req.body);
+    const principal = parseUserPrincipal(str(body.userId));
+    const capability = str(body.capability).trim();
+    if (!principal || !capability) {
+      res.status(400).json({
+        code: 'audience.invalid_input',
+        message: 'userId and capability are required (role grants use /roles)',
+      });
+      return;
+    }
+    try {
+      await deps.store.grantToPrincipal(principal, capability, deps.actor(req));
+      res.status(201).json({ ok: true });
+    } catch (err) {
+      res.status(500).json({ code: 'audience.grant_failed', message: errMsg(err) });
+    }
+  });
+
+  router.delete('/direct', async (req: Request, res: Response): Promise<void> => {
+    const body = asObject(req.body);
+    const principal = parseUserPrincipal(str(body.userId));
+    const capability = str(body.capability).trim();
+    if (!principal || !capability) {
+      res.status(400).json({
+        code: 'audience.invalid_input',
+        message: 'userId and capability are required',
+      });
+      return;
+    }
+    try {
+      const removed = await deps.store.revokeFromPrincipal(principal, capability);
+      // 404 rather than a cheerful 200: an operator revoking a capability needs
+      // to know the grant was not there, because the usual cause is a
+      // mis-spelled id and the room's behaviour will not change.
+      if (!removed) {
+        res.status(404).json({ code: 'audience.grant_not_found', message: 'no such grant' });
+        return;
+      }
+      res.json({ ok: true });
+    } catch (err) {
+      res.status(500).json({ code: 'audience.revoke_failed', message: errMsg(err) });
+    }
+  });
+
+  router.post('/roles', async (req: Request, res: Response): Promise<void> => {
+    const body = asObject(req.body);
+    const roleKey = str(body.roleKey).trim();
+    const capability = str(body.capability).trim();
+    if (!roleKey || !capability) {
+      res.status(400).json({
+        code: 'audience.invalid_input',
+        message: 'roleKey and capability are required',
+      });
+      return;
+    }
+    try {
+      await deps.store.grantToRole(roleKey, capability, deps.actor(req));
+      res.status(201).json({ ok: true });
+    } catch (err) {
+      res.status(500).json({ code: 'audience.grant_failed', message: errMsg(err) });
+    }
+  });
+
+  router.delete('/roles', async (req: Request, res: Response): Promise<void> => {
+    const body = asObject(req.body);
+    const roleKey = str(body.roleKey).trim();
+    const capability = str(body.capability).trim();
+    if (!roleKey || !capability) {
+      res.status(400).json({
+        code: 'audience.invalid_input',
+        message: 'roleKey and capability are required',
+      });
+      return;
+    }
+    try {
+      const removed = await deps.store.revokeFromRole(roleKey, capability);
+      if (!removed) {
+        res.status(404).json({ code: 'audience.grant_not_found', message: 'no such grant' });
+        return;
+      }
+      res.json({ ok: true });
+    } catch (err) {
+      res.status(500).json({ code: 'audience.revoke_failed', message: errMsg(err) });
+    }
+  });
+
+  return router;
+}

--- a/middleware/src/config.ts
+++ b/middleware/src/config.ts
@@ -193,6 +193,20 @@ const ConfigSchema = z.object({
     .transform((v) => v === 'true')
     .default(true),
 
+  // #575 — enforce the audience floor: a room may only do what EVERY
+  // participant is granted. Off by default, and that default is load-bearing
+  // rather than cautious. The floor fails closed by design, so switching it on
+  // against an empty grant table does not mean "no policy yet" — it means every
+  // tool refused, no context recalled and no attachment readable, in every
+  // room, at once. Seed and review the grants through
+  // /api/v1/admin/audience-grants (available whenever Postgres is), THEN set
+  // this. It also needs Postgres: with the in-memory backend there is nowhere
+  // durable for grants to live, and a restart would shut the rooms.
+  AUDIENCE_FLOOR_ENABLED: z
+    .enum(['true', 'false'])
+    .transform((v) => v === 'true')
+    .default(false),
+
   // Local-dev endpoints (raw graph browser, memory browser, …) under /api/dev.
   //
   // Issue #669: these used to mount WITHOUT authentication, so this flag alone

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -303,6 +303,9 @@ import { CanvasOutputRegistry } from './platform/canvasOutputRegistry.js';
 import { EventCatalogRegistry } from './platform/eventCatalogRegistry.js';
 import { DeterministicActionRegistry } from './platform/deterministicActionRegistry.js';
 import { ServiceRegistry } from './platform/serviceRegistry.js';
+import { createLateBoundGrantStore } from './audience/lateBoundGrantStore.js';
+import { PostgresGrantStore } from './audience/postgresGrantStore.js';
+import { createAudienceGrantRouter } from './audience/routes.js';
 import { TurnHookRegistry } from './platform/turnHookRegistry.js';
 import { NativeToolRegistry } from '@omadia/orchestrator';
 // W3-A / W4 — boot-time enforcement of the tool-timeout ordering invariant.
@@ -834,6 +837,30 @@ async function main(): Promise<void> {
   for (const entry of pluginCatalog.list()) {
     if (!installedRegistry.has(entry.plugin.id)) continue;
     registerProviderFromPlugin(entry.plugin.id);
+  }
+
+  // #575 — the audience floor's grant store. Published HERE, before
+  // `activateAllInstalled()`, because the orchestrator plugin reads the
+  // services it consumes at its own activate(); published as a LATE-BOUND
+  // wrapper because the Postgres pool it needs is itself published by the
+  // knowledge-graph plugin during that same activation pass and is only
+  // readable afterwards. `audienceGrantStoreRef` is filled in below, where
+  // `graphPool` resolves — the same forward-reference shape the conductor's
+  // template registrar uses.
+  //
+  // Nothing is published when the flag is off, and that absence is what keeps
+  // the three guards inert: the orchestrator installs an audience provider only
+  // when it received a grant store, so an unconfigured deployment behaves
+  // exactly as before ("not enforced ≠ closed").
+  let audienceGrantStoreRef: PostgresGrantStore | undefined;
+  if (config.AUDIENCE_FLOOR_ENABLED) {
+    serviceRegistry.provide(
+      'audienceGrants',
+      createLateBoundGrantStore(() => audienceGrantStoreRef),
+    );
+    console.log(
+      '[middleware] #575 audience floor ENABLED — grants read from Postgres; rooms are limited to what every participant is granted',
+    );
   }
 
   // Phase B (B1) — publish `pluginCapabilities@1` so the orchestrator's
@@ -1617,6 +1644,32 @@ async function main(): Promise<void> {
   }
   const graphPool = serviceRegistry.get<Pool>('graphPool');
   const graphTenantId = process.env['GRAPH_TENANT_ID'] ?? 'default';
+
+  // #575 — hydrate the forward reference published before activation.
+  //
+  // Refusing to boot without Postgres is deliberate, and it is the kinder
+  // failure. The floor fails closed, so an enabled floor with no durable store
+  // would not degrade to "unenforced" — every lookup would throw, every room
+  // would refuse every tool, recall nothing and read no attachment, and the
+  // operator would see a system that looks configured and behaves as though
+  // someone had forbidden everything. A boot refusal names the cause once,
+  // at the only moment it is still cheap to fix.
+  //
+  // The store is built whenever Postgres is present, NOT only when the floor is
+  // enabled — the admin surface has to be usable before enforcement starts, or
+  // the only way to seed grants would be to switch the floor on against an
+  // empty table first.
+  const audienceGrantStore = graphPool ? new PostgresGrantStore(graphPool) : undefined;
+  if (config.AUDIENCE_FLOOR_ENABLED) {
+    if (!audienceGrantStore) {
+      throw new Error(
+        '[middleware] AUDIENCE_FLOOR_ENABLED=true requires Postgres (DATABASE_URL) — ' +
+          'the in-memory backend has nowhere to store grants, and the floor fails closed, ' +
+          'so booting like this would silently refuse every tool call in every room.',
+      );
+    }
+    audienceGrantStoreRef = audienceGrantStore;
+  }
 
   // Issue #560 — now that graphPool is known, back the long-running task seam
   // durably when Postgres is present (tasks survive a restart; the `tasks` table
@@ -2807,6 +2860,27 @@ async function main(): Promise<void> {
   console.log(
     '[middleware] memory-purge endpoint ready at /api/v1/admin/memory/purge',
   );
+
+  // #575 — audience-floor grants. Cookie-auth admin surface like the routers
+  // above. Mounted whenever Postgres is present, INDEPENDENTLY of whether the
+  // floor is enforcing: an operator has to be able to seed and review the grant
+  // table before enforcement starts, because the floor fails closed and
+  // switching it on against an empty table bounds every room to nothing.
+  if (audienceGrantStore) {
+    app.use(
+      '/api/v1/admin/audience-grants',
+      requireAuth,
+      createAudienceGrantRouter({
+        store: audienceGrantStore,
+        actor: (req) => req.session?.email ?? 'unknown',
+      }),
+    );
+    console.log(
+      `[middleware] audience-grants endpoint ready at /api/v1/admin/audience-grants (enforcement ${
+        config.AUDIENCE_FLOOR_ENABLED ? 'ON' : 'off'
+      })`,
+    );
+  }
 
   // Rolling self-update (#432). Cookie-auth admin surface like the Danger Zone
   // above. Three capability tiers, and the endpoint reports honestly which one

--- a/middleware/test/audienceGrantStore.test.ts
+++ b/middleware/test/audienceGrantStore.test.ts
@@ -1,0 +1,150 @@
+/**
+ * #575 phase 2 — the grant store's failure semantics.
+ *
+ * The round-trip behaviour is exercised against a real Postgres in
+ * `postgresGrantStore.pg.test.ts`. This file covers the two properties that
+ * matter more and that a database cannot easily be made to demonstrate: what
+ * happens when the store **cannot answer**.
+ *
+ * Both are load-bearing in the same direction. `GrantStore`'s contract says a
+ * store that cannot answer must throw, because `resolveCapabilities` converts a
+ * throw into an `unresolved` audience member and closes the floor WITH A REASON.
+ * A store that swallowed the failure and returned `[]` would hand the floor a
+ * perfectly well-formed smaller capability set instead — the room would narrow
+ * silently, and an operator reading "the floor forbids it" would have no way to
+ * discover that Postgres was unreachable or that the store had not been
+ * hydrated yet.
+ *
+ * So these are not "error handling" tests. They pin the difference between a
+ * closed door with a sign on it and a closed door without one.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { makePrincipal, resolveCapabilities, RoleSourceRegistry } from '@omadia/channel-sdk';
+import type { Principal } from '@omadia/channel-sdk';
+import type { Pool } from 'pg';
+
+import { createLateBoundGrantStore, GrantStoreNotReadyError } from '../src/audience/lateBoundGrantStore.js';
+import { PostgresGrantStore } from '../src/audience/postgresGrantStore.js';
+
+const ALICE = makePrincipal('user', 'Alice@Example.com') as Principal;
+
+/** A pool whose every query rejects — stands in for "Postgres is unreachable". */
+function failingPool(message = 'connection terminated unexpectedly'): Pool {
+  return {
+    query: async (): Promise<never> => {
+      throw new Error(message);
+    },
+  } as unknown as Pool;
+}
+
+/** A pool that records the SQL + params it was handed and returns fixed rows. */
+function recordingPool(rows: Array<Record<string, unknown>>): {
+  pool: Pool;
+  calls: Array<{ sql: string; params: unknown[] }>;
+} {
+  const calls: Array<{ sql: string; params: unknown[] }> = [];
+  const pool = {
+    query: async (sql: string, params: unknown[] = []) => {
+      calls.push({ sql, params });
+      return { rows, rowCount: rows.length };
+    },
+  } as unknown as Pool;
+  return { pool, calls };
+}
+
+describe('#575 PostgresGrantStore — an unreachable store must throw, not answer', () => {
+  it('propagates a database failure out of directGrants', async () => {
+    const store = new PostgresGrantStore(failingPool());
+    await assert.rejects(
+      () => store.directGrants(ALICE),
+      /connection terminated/,
+      'a database failure must reach the caller; returning [] would read as "no grants"',
+    );
+  });
+
+  it('propagates a database failure out of roleGrants', async () => {
+    const store = new PostgresGrantStore(failingPool());
+    await assert.rejects(() => store.roleGrants('Approver'), /connection terminated/);
+  });
+
+  it('a failing store closes the floor instead of shrinking it', async () => {
+    // The end-to-end consequence, stated as a test so the chain cannot be
+    // broken silently: resolveCapabilities turns the throw into `undefined`
+    // (an unresolved member), which the floor reads as "close, with a reason".
+    // If the store returned [] instead, this would be a RESOLVED member with an
+    // empty capability set — indistinguishable from a deliberate policy.
+    const member = await resolveCapabilities(
+      ALICE,
+      new RoleSourceRegistry(),
+      new PostgresGrantStore(failingPool()),
+    );
+    assert.equal(member, undefined);
+  });
+});
+
+describe('#575 late-bound grant store — unhydrated is an outage, not an empty answer', () => {
+  it('throws while the backing store is still unset', async () => {
+    const store = createLateBoundGrantStore(() => undefined);
+    await assert.rejects(() => store.directGrants(ALICE), GrantStoreNotReadyError);
+    await assert.rejects(() => store.roleGrants('Approver'), GrantStoreNotReadyError);
+  });
+
+  it('delegates once the backing store arrives', async () => {
+    // The forward reference the kernel fills in after `graphPool` resolves.
+    let backing: PostgresGrantStore | undefined;
+    const store = createLateBoundGrantStore(() => backing);
+
+    await assert.rejects(() => store.directGrants(ALICE), GrantStoreNotReadyError);
+
+    const { pool } = recordingPool([{ capability: 'tool:send_email' }]);
+    backing = new PostgresGrantStore(pool);
+
+    assert.deepEqual([...(await store.directGrants(ALICE))], ['tool:send_email']);
+  });
+
+  it('resolves the holder on every call rather than latching the first answer', async () => {
+    // A store swapped out later (a pool rebuilt, a backend switched) must be
+    // seen. Capturing the resolved value once would pin the floor to whatever
+    // existed at publish time — which, published before plugin activation, is
+    // nothing.
+    const first = recordingPool([{ capability: 'memory:recall' }]);
+    const second = recordingPool([{ capability: 'attachment:read' }]);
+    let backing = new PostgresGrantStore(first.pool);
+    const store = createLateBoundGrantStore(() => backing);
+
+    assert.deepEqual([...(await store.roleGrants('Approver'))], ['memory:recall']);
+    backing = new PostgresGrantStore(second.pool);
+    assert.deepEqual([...(await store.roleGrants('Approver'))], ['attachment:read']);
+  });
+});
+
+describe('#575 PostgresGrantStore — canonicalisation matches the lookup that honours it', () => {
+  it('lower-cases a user reference on read, so a differently-cased id still finds its grants', async () => {
+    const { pool, calls } = recordingPool([]);
+    await new PostgresGrantStore(pool).directGrants(ALICE);
+    assert.equal(calls.length, 1);
+    // #333 phase 1: user refs canonicalise to lower case. Querying the raw
+    // spelling would miss every grant written through the admin API.
+    assert.deepEqual(calls[0]?.params, ['user', 'alice@example.com']);
+  });
+
+  it('does NOT lower-case a role key', async () => {
+    const { pool, calls } = recordingPool([]);
+    await new PostgresGrantStore(pool).roleGrants('  Approver  ');
+    // `conductor_roles.key` is written verbatim by `createRole`, so lower-casing
+    // here would miss every mixed-case role — while still trimming whitespace.
+    assert.deepEqual(calls[0]?.params, ['Approver']);
+  });
+
+  it('refuses an empty capability rather than storing a row that can never match', async () => {
+    const { pool } = recordingPool([]);
+    const store = new PostgresGrantStore(pool);
+    // The floor skips empty capabilities when building its set, so such a row
+    // would show up in the admin list while granting nothing.
+    await assert.rejects(() => store.grantToPrincipal(ALICE, '   ', 'operator'), /must not be empty/);
+    await assert.rejects(() => store.grantToRole('Approver', '', 'operator'), /must not be empty/);
+  });
+});

--- a/middleware/test/postgresGrantStore.pg.test.ts
+++ b/middleware/test/postgresGrantStore.pg.test.ts
@@ -1,0 +1,131 @@
+/**
+ * #575 phase 2 — the grant store against a real Postgres.
+ *
+ * The failure semantics (throw rather than answer) are pinned in
+ * `audienceGrantStore.test.ts` with a fake pool, because an unreachable
+ * database is easier to fake than to arrange. What a fake pool CANNOT prove is
+ * that the SQL is right: that the primary keys make a re-grant idempotent
+ * rather than a 23505, that a delete reports whether it removed anything, and
+ * that a grant written through the admin path is found by the lookup the floor
+ * actually calls.
+ *
+ * That last one is the point of the whole file. Writes and reads canonicalise
+ * independently — user references lower-case, role keys keep their case (#333
+ * phase 1) — and if those two ever disagree, every test that only checks one
+ * side stays green while the floor silently stops honouring grants an operator
+ * can plainly see in the admin list.
+ *
+ * Skips cleanly (issue #572: no hardcoded default port) when no test database
+ * is configured.
+ */
+
+import { strict as assert } from 'node:assert';
+import { randomUUID } from 'node:crypto';
+import { after, before, describe, it } from 'node:test';
+
+import { makePrincipal, resolveCapabilities, RoleSourceRegistry } from '@omadia/channel-sdk';
+import type { Principal } from '@omadia/channel-sdk';
+import { Pool } from 'pg';
+
+import { probePgTest } from './_helpers/pgTestDb.js';
+
+import { PostgresGrantStore } from '../src/audience/postgresGrantStore.js';
+
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'postgresGrantStore',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  timeoutMs: 1_500,
+});
+
+/** The two tables from migration 0035, created directly so this suite does not
+ *  depend on the multi-orchestrator migrator having run against the test DB. */
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS audience_direct_grants (
+  principal_kind TEXT        NOT NULL,
+  principal_ref  TEXT        NOT NULL,
+  capability     TEXT        NOT NULL,
+  granted_by     TEXT        NOT NULL,
+  granted_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (principal_kind, principal_ref, capability)
+);
+CREATE TABLE IF NOT EXISTS audience_role_grants (
+  role_key   TEXT        NOT NULL,
+  capability TEXT        NOT NULL,
+  granted_by TEXT        NOT NULL,
+  granted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (role_key, capability)
+);`;
+
+describe('#575 PostgresGrantStore against a real Postgres', { skip: !pgAvailable }, () => {
+  let pool: Pool;
+  let store: PostgresGrantStore;
+  // Unique per run so concurrent test files cannot collide on shared tables.
+  const mark = randomUUID().slice(0, 8);
+  const alice = makePrincipal('user', `Alice-${mark}@Example.com`) as Principal;
+  const roleKey = `Approver-${mark}`;
+
+  before(async () => {
+    pool = new Pool({ connectionString: PG_URL, max: 4 });
+    await pool.query(SCHEMA);
+    store = new PostgresGrantStore(pool);
+  });
+
+  after(async () => {
+    await pool.query(`DELETE FROM audience_direct_grants WHERE principal_ref LIKE $1`, [
+      `%${mark}%`,
+    ]);
+    await pool.query(`DELETE FROM audience_role_grants WHERE role_key LIKE $1`, [`%${mark}%`]);
+    await pool.end();
+  });
+
+  it('a grant written through the admin path is found by the floor lookup', async () => {
+    await store.grantToPrincipal(alice, 'tool:send_email', 'operator@example.com');
+    assert.deepEqual([...(await store.directGrants(alice))], ['tool:send_email']);
+  });
+
+  it('finds the grant through a differently-cased spelling of the same user', async () => {
+    // The whole reason canonicalisation is applied on BOTH sides: a channel may
+    // hand over `ALICE@EXAMPLE.COM` where the operator typed `Alice@…`.
+    const shouty = makePrincipal('user', `ALICE-${mark}@EXAMPLE.COM`) as Principal;
+    assert.deepEqual([...(await store.directGrants(shouty))], ['tool:send_email']);
+  });
+
+  it('re-granting is idempotent and refreshes the trail rather than failing', async () => {
+    await store.grantToPrincipal(alice, 'tool:send_email', 'second-operator@example.com');
+    const rows = (await store.listDirectGrants()).filter((r) => r.principalRef.includes(mark));
+    assert.equal(rows.length, 1, 'the primary key must collapse a repeat grant into one row');
+    assert.equal(rows[0]?.grantedBy, 'second-operator@example.com');
+  });
+
+  it('keeps a role key case-sensitive, matching conductor_roles', async () => {
+    await store.grantToRole(roleKey, 'memory:recall', 'operator@example.com');
+    assert.deepEqual([...(await store.roleGrants(roleKey))], ['memory:recall']);
+    // Lower-casing role keys would make this find the grant — it must not.
+    assert.deepEqual([...(await store.roleGrants(roleKey.toLowerCase()))], []);
+  });
+
+  it('reports honestly whether a revoke removed anything', async () => {
+    assert.equal(await store.revokeFromRole(roleKey, 'never:granted'), false);
+    assert.equal(await store.revokeFromRole(roleKey, 'memory:recall'), true);
+    assert.deepEqual([...(await store.roleGrants(roleKey))], []);
+  });
+
+  it('feeds resolveCapabilities the union of what it stored', async () => {
+    // End to end through the real consumer, with no role sources registered:
+    // direct grants alone must produce a RESOLVED member (not `undefined`),
+    // because an empty role registry is a complete answer, not a partial one.
+    await store.grantToPrincipal(alice, 'memory:recall', 'operator@example.com');
+    const member = await resolveCapabilities(alice, new RoleSourceRegistry(), store);
+    assert.ok(member, 'a reachable store with no role sources must resolve');
+    assert.deepEqual(
+      [...member.capabilities].sort(),
+      ['memory:recall', 'tool:send_email'],
+    );
+  });
+
+  it('revokes a direct grant', async () => {
+    assert.equal(await store.revokeFromPrincipal(alice, 'memory:recall'), true);
+    assert.equal(await store.revokeFromPrincipal(alice, 'memory:recall'), false);
+    assert.deepEqual([...(await store.directGrants(alice))], ['tool:send_email']);
+  });
+});


### PR DESCRIPTION
The floor, all three guards and the provider are merged. The only `GrantStore` was `InMemoryGrantStore`.

That did not make #575 "not production-ready yet" — it made it **actively dangerous**, and the reason is the one property this whole cluster is built on: the floor **fails closed**. An empty grant table is not "no policy configured", it is *nobody may do anything*. So a restart did not degrade the feature. It shut every room, and kept them shut until somebody re-seeded grants by hand.

## What lands

| | |
|---|---|
| `middleware/migrations/0035_audience_grants.sql` | `audience_direct_grants` + `audience_role_grants` |
| `src/audience/postgresGrantStore.ts` | the durable `GrantStore`, plus the admin mutations |
| `src/audience/lateBoundGrantStore.ts` | publishes before the pool exists (see below) |
| `src/audience/routes.ts` | `/api/v1/admin/audience-grants`, cookie auth |
| `AUDIENCE_FLOOR_ENABLED` | default **off** — this is the switch |

## Three decisions, each of which fails in a way that looks fine

### 1. The store must be allowed to throw

`GrantStore`'s contract says a store that cannot answer must **throw**, because `resolveCapabilities` converts that throw into an `unresolved` audience member — which closes the floor **with a reason an operator can act on**.

A store that caught a database error and returned `[]` would instead hand the floor a perfectly well-formed *smaller* capability set. The intersection narrows, the room quietly refuses things, and the operator reads "the floor forbids it" while the actual cause — Postgres was unreachable — leaves no trace anywhere.

So there is **no try/catch on the read path**, that is deliberate, and it is pinned by a test — including end-to-end through `resolveCapabilities`, so the property cannot be broken by a well-meaning "let's make this robust" edit two layers away.

### 2. The service is published late-bound

The orchestrator plugin reads the services it consumes **at activation**, which is why `index.ts` publishes them before `activateAllInstalled()`. But `graphPool` is published **by** the knowledge-graph plugin *during that same pass*. At the moment the grant store must be published, the pool it needs does not exist.

Same forward-reference shape the conductor's template registrar already uses: publish a wrapper now, point it at a holder, fill the holder in when `graphPool` resolves. An **unhydrated** store throws, for exactly the reason in (1) — returning `[]` there would silently narrow every room during boot, which is the worst possible moment for an invisible failure.

The wrapper re-resolves on every call rather than latching the first answer; a test covers that too, since capturing once would pin the floor to what existed at publish time, which is nothing.

### 3. Enabling the floor without Postgres refuses to boot

Not a crash out of pedantry — the kinder failure. Unenforced would be one thing, but the floor fails closed, so an enabled floor with no durable store means every lookup throws, every room refuses every tool, recalls nothing and reads no attachment, while the deployment *looks* configured. A boot refusal names the cause once, at the only moment it is still cheap to fix.

## Why the admin surface is not behind the same flag

It mounts whenever Postgres is present, **independently of enforcement**. Grants have to be seedable and reviewable *before* the floor starts enforcing — otherwise the only way to populate the table is to switch the floor on against an empty one, which is precisely the outage this PR exists to prevent.

Revoking something that was not granted returns **404**, not a cheerful 200: the usual cause is a mis-spelled id, and the room's behaviour will not change.

## No foreign key on `role_key`

`audience_role_grants.role_key` deliberately does **not** reference `conductor_roles(key)`.

#333 phase 2 made role membership answerable by a registry of sources, and a source may be an external directory this deployment holds no local row for. A foreign key would make *"grant a capability to the Entra group everyone in support belongs to"* unrepresentable — the exact case the role-source registry exists to serve. The cost is that a typo'd role key is accepted and grants nothing; that fails safe, and the admin list makes it visible.

## Scope, stated honestly

Role grants additionally need a **role source registered** (#333 phase 2). Direct grants work on their own — an empty role registry is a *complete* answer, not a partial one, so it resolves rather than closing. There is no UI page; this is the API surface the gate needed.

## Verification

- middleware suite: **6678 tests, 0 fail, 0 cancelled** (12 pg suites skip without a database)
- new pg suite: **7/7** against a real Postgres in a throwaway container
- `npm run typecheck` ✅ · `npm run lint` ✅ · #470 ratchet **3294** ✅ · #573 ratchet **406, unchanged** ✅

**Mutation-checked — all three died:**

| Mutation | Result |
|---|---|
| `directGrants` swallows DB errors, returns `[]` | kills 2, including *"a failing store closes the floor instead of shrinking it"* |
| an unhydrated late-bound store returns `[]` | kills 2 |
| role keys lower-cased on read | kills 1 unit + 1 pg test |

> One caveat I would rather state than hide: running the full suite with a **single shared** test database produces one failure in `devplatform/devJobTaskStore.pg.test.ts`. It is **pre-existing cross-file pollution, not this branch** — measured by running the other 28 pg suites concurrently with this branch's suite *excluded*, which still fails the same test. Isolated, that suite passes 15/15, and alongside this branch's suite 22/22.

Refs #575

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/737"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789649558&installation_model_id=428086&pr_number=737&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F737&signature=6ce350363aa532a71b138b08495d94daddff4b7d6bf6b1f3aa6c5b4fde2df0a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->