### PR TITLE
feat(#575): bind an attachment handle to the room that minted it

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,27 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — an attachment handle only redeems in the room that minted it
+
+- **A storage key was just a string (#575).** The handle guard checked the floor
+  at *redemption* — may this room read attachments — but not at *minting*. So a
+  key issued in a private chat stayed redeemable in any room that happened to
+  hold `attachment:read`, which is what "a string can be pasted into a group
+  chat" means in practice.
+- **New:** each key is pinned on first sighting to the `ScopeId` it was resolved
+  in (migration `0036_attachment_scope_bindings.sql`), and every later
+  resolution must come from the same room.
+- **The binding rides on the reader, not on the call sites** — a storage key
+  outlives its turn, so a check at one resolution site holds only until somebody
+  adds the next one.
+- **Non-addressable scopes are deliberately not bound.** `'http-default'` is
+  shared by every unscoped HTTP caller (the #445 cross-user hole) and
+  `teams-unknown` by every Teams activity without a conversation id. Binding to
+  one of those would declare all of them the same room — enforcement in
+  appearance, universal access in fact.
+- Enabled by the same `AUDIENCE_FLOOR_ENABLED` flag; without it the check stands
+  down and the reader behaves exactly as before.
+
 ### Added — audience-floor grants survive a restart, and an operator can see them
 
 - **The audience floor had no durable store (#575).** `InMemoryGrantStore` was

--- a/middleware/migrations/0036_attachment_scope_bindings.sql
+++ b/middleware/migrations/0036_attachment_scope_bindings.sql
@@ -1,0 +1,44 @@
+-- ── Attachment handles bound to the room that minted them (#575) ───────────
+-- Guard 3 checks the floor at REDEMPTION: may this room redeem a storage
+-- handle at all. It could not check the floor at MINTING, so a key issued in a
+-- private chat stayed redeemable in any room that happened to hold
+-- `attachment:read`. A storage key is just a string, and a string can be
+-- pasted somewhere else — that is the gap this table closes.
+--
+-- One row per storage key, written on FIRST sighting (which is the ingest of
+-- the turn the file arrived on) and compared on every later resolution.
+--
+-- ---------------------------------------------------------------------------
+-- Why the scope is stored as two columns rather than one formatted string
+-- ---------------------------------------------------------------------------
+-- `formatSessionScope` is deliberately lossy in one direction: a `personal`
+-- scope renders as `personal:<id>`, and a `conversation` scope renders as its
+-- raw conversation id — which could itself literally be the string
+-- `personal:<id>`. Comparing formatted strings would let two different kinds of
+-- room look like the same room. Kind and reference are therefore kept apart and
+-- compared as a pair.
+--
+-- ---------------------------------------------------------------------------
+-- Why only ADDRESSABLE scopes are ever written here
+-- ---------------------------------------------------------------------------
+-- `ScopeId`'s `unscoped` kind exists because some scope strings identify no
+-- room at all: `'http-default'` is shared by every unscoped HTTP caller (the
+-- live cross-user hole in #445) and `teams-unknown` by every Teams activity
+-- that arrived without a conversation id. Binding a handle to one of those
+-- would not restrict anything — it would declare every unrelated caller to be
+-- "the same room", which is worse than not binding at all, because it reads as
+-- enforcement. `isAddressableScope` is the gate, and a non-addressable scope
+-- means this table is not consulted.
+--
+-- `system` scopes (routines, schedules, the conductor) are non-addressable for
+-- the same reason from the other end: there is no room, so there is nothing to
+-- bind to.
+
+CREATE TABLE IF NOT EXISTS attachment_scope_bindings (
+  storage_key TEXT        PRIMARY KEY,
+  scope_kind  TEXT        NOT NULL,
+  scope_ref   TEXT        NOT NULL,
+  bound_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- rollback: DROP TABLE attachment_scope_bindings;

--- a/middleware/packages/harness-orchestrator/src/attachmentBinding.ts
+++ b/middleware/packages/harness-orchestrator/src/attachmentBinding.ts
@@ -1,0 +1,95 @@
+/**
+ * #575 — bind an attachment handle to the room that minted it.
+ *
+ * Guard 3 (`audienceFloorGuard.guardAttachmentRead`) checks the floor at
+ * **redemption**: may this room redeem a storage handle at all. What it could
+ * not check was the floor at **minting**, and its own header says so. The gap:
+ * a storage key issued in a private chat is just a string, and a string can be
+ * pasted into a group chat that happens to hold `attachment:read`.
+ *
+ * This module closes it. The rule is deliberately simple, because a rule about
+ * who may read a document has to be explainable:
+ *
+ *   **A handle is redeemable only in the room it was minted in.**
+ *
+ * ## Why the room is a `ScopeId` and never a raw scope string
+ *
+ * `turnContext.sessionScope` carries its own warning: it is "NOT safe as a key
+ * on its own", because `resolveScope` hands every unscoped HTTP turn the
+ * literal `'http-default'`. That was the live cross-user hole in #445, and
+ * `teams-unknown` was the same hole in a second place.
+ *
+ * Keying a security binding on that string would not merely fail to restrict —
+ * it would declare every unrelated caller to be *the same room*, which is worse
+ * than no binding at all because it reads as enforcement. So the scope is
+ * parsed into `ScopeId` and only **addressable** scopes are bound. A
+ * non-addressable scope disables the check rather than approximating it.
+ *
+ * ## First sighting is the minting
+ *
+ * The binding is written the first time a key is resolved, which is the ingest
+ * of the turn the file arrived on — the orchestrator resolves storage keys off
+ * the inbound turn before anything else can. Writing at first sighting rather
+ * than at an explicit "mint" hook means the binding cannot be bypassed by a
+ * resolution path somebody adds later, which is the same argument that put the
+ * floor check on the reader instead of on its call sites.
+ */
+
+import {
+  formatSessionScope,
+  isAddressableScope,
+  parseSessionScope,
+  type ScopeId,
+} from '@omadia/channel-sdk';
+
+/** The room a handle belongs to, as stored. */
+export interface AttachmentScopeBinding {
+  readonly scopeKind: string;
+  readonly scopeRef: string;
+}
+
+/**
+ * Durable storage for handle→room bindings.
+ *
+ * Like `GrantStore`, an implementation that **cannot answer must throw**: the
+ * caller turns that into a refusal. Returning "no binding" on a database error
+ * would silently unbind every handle in the deployment, and the failure would
+ * look exactly like the ordinary un-bound case.
+ */
+export interface AttachmentBindingStore {
+  /** The room this key was minted in, or `undefined` if never bound. */
+  get(storageKey: string): Promise<AttachmentScopeBinding | undefined>;
+  /**
+   * Record the minting room. MUST NOT overwrite an existing row — the first
+   * sighting is the minting, and a later write would let a wider room re-bind a
+   * handle to itself and then read it.
+   */
+  bindIfAbsent(storageKey: string, binding: AttachmentScopeBinding): Promise<void>;
+}
+
+/**
+ * The binding for a scope, or `undefined` when the scope cannot identify a room.
+ *
+ * Exported for the tests that pin the `unscoped` / `system` exclusions, since
+ * those are the cases where a wrong answer is invisible.
+ */
+export function bindingForScope(scope: ScopeId): AttachmentScopeBinding | undefined {
+  if (!isAddressableScope(scope)) return undefined;
+  return { scopeKind: scope.kind, scopeRef: formatSessionScope(scope) };
+}
+
+/** Same, from the raw turn-context string. */
+export function bindingForRawScope(raw: string | undefined): AttachmentScopeBinding | undefined {
+  return bindingForScope(parseSessionScope(raw));
+}
+
+export function bindingsEqual(
+  a: AttachmentScopeBinding,
+  b: AttachmentScopeBinding,
+): boolean {
+  // Kind AND reference: `formatSessionScope` renders a conversation scope as
+  // its bare conversation id, which could itself be the string `personal:x`.
+  // Comparing references alone would let two different kinds of room look
+  // like one.
+  return a.scopeKind === b.scopeKind && a.scopeRef === b.scopeRef;
+}

--- a/middleware/packages/harness-orchestrator/src/attachmentReaderFactory.ts
+++ b/middleware/packages/harness-orchestrator/src/attachmentReaderFactory.ts
@@ -17,6 +17,12 @@ import type { Readable } from 'node:stream';
 
 import type { AttachmentReader } from './tools/readAttachmentTool.js';
 import { guardAttachmentRead } from './audienceFloorGuard.js';
+import {
+  bindingForRawScope,
+  bindingsEqual,
+  type AttachmentBindingStore,
+} from './attachmentBinding.js';
+import { turnContext } from './turnContext.js';
 
 /** Minimal structural view of the kernel's `tigrisStore` service. */
 export interface AttachmentByteStore {
@@ -59,13 +65,42 @@ function fileNameFromKey(key: string): string | undefined {
  * a side channel.
  *
  * Inert when no audience source is installed, like every other guard here.
+ *
+ * ## The second check: the room that MINTED the handle
+ *
+ * The floor check above answers "may this room redeem a storage handle at all".
+ * With a `bindings` store it is joined by "and was this handle minted here" —
+ * closing the gap `audienceFloorGuard`'s own header names, where a key issued
+ * in a private chat stays redeemable in any room holding `attachment:read`.
+ *
+ * The binding rides with the handle for the same reason the floor check does:
+ * a storage key outlives its turn, so a check placed at a call site holds only
+ * until somebody adds the next one.
+ *
+ * Order matters. The floor is evaluated FIRST, so a room that may not read
+ * attachments at all is refused without this ever touching the database — and
+ * without a row being written that would bind the handle to a room that was
+ * never allowed to see it.
+ *
+ * `readByUrl` is deliberately untouched: a URL is not a storage key, carries no
+ * binding, and its own reachability is the channel's business.
  */
-export function audienceGuardedAttachmentReader(inner: AttachmentReader): AttachmentReader {
+export function audienceGuardedAttachmentReader(
+  inner: AttachmentReader,
+  bindings?: AttachmentBindingStore,
+): AttachmentReader {
   return {
     async readByStorageKey(storageKey) {
       const refusal = await guardAttachmentRead();
       if (refusal !== undefined) {
         console.warn(`[harness-orchestrator] attachment read refused by audience floor: ${refusal}`);
+        return undefined;
+      }
+      const bindingRefusal = await enforceScopeBinding(bindings, storageKey);
+      if (bindingRefusal !== undefined) {
+        console.warn(
+          `[harness-orchestrator] attachment read refused by handle binding: ${bindingRefusal}`,
+        );
         return undefined;
       }
       return inner.readByStorageKey(storageKey);
@@ -79,6 +114,48 @@ export function audienceGuardedAttachmentReader(inner: AttachmentReader): Attach
       return inner.readByUrl(url);
     },
   };
+}
+
+/**
+ * Compare this turn's room against the one the handle was minted in, recording
+ * the binding on first sighting.
+ *
+ * @returns an operator-readable reason to refuse, or `undefined` to allow.
+ */
+async function enforceScopeBinding(
+  bindings: AttachmentBindingStore | undefined,
+  storageKey: string,
+): Promise<string | undefined> {
+  // No store ⇒ not enforced, exactly like an absent audience provider. A
+  // deployment that has not opted in must behave as it did before.
+  if (!bindings) return undefined;
+
+  // A non-addressable scope identifies no room — `'http-default'` is shared by
+  // every unscoped HTTP caller (#445), `teams-unknown` by every Teams activity
+  // missing a conversation id. Binding to one would declare all of them the
+  // same room, so the check stands down rather than approximating.
+  const current = bindingForRawScope(turnContext.current()?.sessionScope);
+  if (!current) return undefined;
+
+  try {
+    const minted = await bindings.get(storageKey);
+    if (!minted) {
+      // First sighting is the minting. Recorded only now that the floor has
+      // already permitted this room to read attachments.
+      await bindings.bindIfAbsent(storageKey, current);
+      return undefined;
+    }
+    if (bindingsEqual(minted, current)) return undefined;
+    // The reason names both rooms for the operator log. The caller turns this
+    // into the reader's ordinary "unavailable", so the model learns nothing
+    // about the handle's existence — see the wrapper's header.
+    return `handle was minted for ${minted.scopeKind}:${minted.scopeRef}, redeemed from ${current.scopeKind}:${current.scopeRef}`;
+  } catch (err) {
+    // A store that cannot answer must not read as "unbound". Same asymmetry as
+    // the grant store: degrading to "allowed" would execute a read nobody
+    // authorised, while degrading to "refused" only withholds one.
+    return `binding store unavailable (${err instanceof Error ? err.message : String(err)})`;
+  }
 }
 
 /**

--- a/middleware/packages/harness-orchestrator/src/audienceFloorGuard.ts
+++ b/middleware/packages/harness-orchestrator/src/audienceFloorGuard.ts
@@ -107,15 +107,24 @@ export const ATTACHMENT_READ_CAPABILITY: Capability = 'attachment:read';
  * itself (`attachmentReaderFactory.ts`). Every consumer, present and future, is
  * covered by construction.
  *
- * ## What this version does NOT do
+ * ## What this function does NOT do — and what now does it
  *
- * It checks the floor **at redemption**, not the floor **at minting**. So it
- * stops a room from redeeming a handle that room may not read — but it cannot
- * yet stop a handle minted in a narrow room from being redeemed in a room that
- * happens to hold the capability. Binding the minting audience to the handle
- * needs the attachment store to persist it, and that store lives in the channel
- * plugins rather than here. Stated so the remaining gap is visible rather than
- * assumed closed.
+ * It checks the floor **at redemption**: may this room redeem a handle at all.
+ * That leaves a handle minted in a narrow room redeemable by any room that
+ * happens to hold the capability, because a storage key is just a string.
+ *
+ * That second half is no longer open, but it is deliberately NOT here:
+ * `attachmentBinding.ts` pins each key to the `ScopeId` it was first resolved
+ * in, and the reader wrapper enforces both checks in order. Two separate
+ * questions — *may this room read attachments* and *was this handle minted
+ * here* — kept in two places, because collapsing them would make a capability
+ * answer look like an identity answer.
+ *
+ * The residual gap, stated rather than assumed closed: a handle first resolved
+ * from a **non-addressable** scope (`'http-default'`, `teams-unknown`, a system
+ * scope) is not bound at all, because those strings identify no room. See
+ * `attachmentBinding.ts` for why approximating there would be worse than
+ * standing down.
  */
 export async function guardAttachmentRead(): Promise<string | undefined> {
   const provider = turnContext.current()?.audienceFloor;

--- a/middleware/packages/harness-orchestrator/src/index.ts
+++ b/middleware/packages/harness-orchestrator/src/index.ts
@@ -534,6 +534,18 @@ export {
 export type { AttachmentReader } from './tools/readAttachmentTool.js';
 export { createAttachmentReader } from './attachmentReaderFactory.js';
 export type { AttachmentByteStore } from './attachmentReaderFactory.js';
+// #575 — the handle→room binding contract. Exported so the kernel can supply a
+// Postgres implementation; the enforcement itself stays inside the reader
+// wrapper, where every resolution path is covered by construction.
+export {
+  bindingForRawScope,
+  bindingForScope,
+  bindingsEqual,
+} from './attachmentBinding.js';
+export type {
+  AttachmentBindingStore,
+  AttachmentScopeBinding,
+} from './attachmentBinding.js';
 export {
   QUERY_DATASET_TOOL_NAME,
   QueryDatasetTool,

--- a/middleware/packages/harness-orchestrator/src/plugin.ts
+++ b/middleware/packages/harness-orchestrator/src/plugin.ts
@@ -68,6 +68,7 @@ import {
   createAttachmentReader,
   type AttachmentByteStore,
 } from './attachmentReaderFactory.js';
+import type { AttachmentBindingStore } from './attachmentBinding.js';
 import type { TurnHookRunner } from './turnHooks.js';
 import type { ChatSessionStore } from './chatSessionStore.js';
 import type { NativeToolRegistry } from './nativeToolRegistry.js';
@@ -560,8 +561,14 @@ export async function activate(
   // here, at the ONE construction site, so the check rides with the handle rather
   // than depending on each resolution site remembering to ask. Inert unless an
   // audience source is installed.
+  // The binding store additionally pins each handle to the room that minted it
+  // (#575). Published by the kernel only when the audience floor is enabled —
+  // absent means that second check stands down, and the reader behaves exactly
+  // as it did before.
+  const attachmentBindings = ctx.services.get<AttachmentBindingStore>('attachmentBindings');
   const attachmentReader = audienceGuardedAttachmentReader(
     createAttachmentReader(attachmentByteStore),
+    attachmentBindings,
   );
   // Phase-1 of the Kemia integration. Late-bound `responseGuard@1` getter —
   // the orchestrator generally activates BEFORE its tool plugins, so a

--- a/middleware/src/audience/lateBoundGrantStore.ts
+++ b/middleware/src/audience/lateBoundGrantStore.ts
@@ -33,6 +33,10 @@
  */
 
 import type { Capability, GrantStore, Principal } from '@omadia/channel-sdk';
+import type {
+  AttachmentBindingStore,
+  AttachmentScopeBinding,
+} from '@omadia/orchestrator';
 
 export class GrantStoreNotReadyError extends Error {
   constructor() {
@@ -64,6 +68,35 @@ export function createLateBoundGrantStore(
     },
     async roleGrants(roleKey: string): Promise<readonly Capability[]> {
       return target().roleGrants(roleKey);
+    },
+  };
+}
+
+/**
+ * The same forward reference for #575's handle→room bindings, which the
+ * orchestrator plugin also consumes at activation.
+ *
+ * Unhydrated throws here too, and the consequence is the mirror image of the
+ * grant case: the reader wrapper turns a throwing binding store into a
+ * **refusal**, so a handle is withheld rather than read. Reporting "no binding"
+ * instead would silently unbind every handle in the deployment for as long as
+ * the store stayed unresolved.
+ */
+export function createLateBoundAttachmentBindingStore(
+  resolve: () => AttachmentBindingStore | undefined,
+): AttachmentBindingStore {
+  const target = (): AttachmentBindingStore => {
+    const store = resolve();
+    if (!store) throw new GrantStoreNotReadyError();
+    return store;
+  };
+
+  return {
+    async get(storageKey: string): Promise<AttachmentScopeBinding | undefined> {
+      return target().get(storageKey);
+    },
+    async bindIfAbsent(storageKey: string, binding: AttachmentScopeBinding): Promise<void> {
+      return target().bindIfAbsent(storageKey, binding);
     },
   };
 }

--- a/middleware/src/audience/postgresAttachmentBindingStore.ts
+++ b/middleware/src/audience/postgresAttachmentBindingStore.ts
@@ -1,0 +1,53 @@
+/**
+ * #575 — durable handle→room bindings (migration 0036).
+ *
+ * The contract lives in `harness-orchestrator/src/attachmentBinding.ts`; this
+ * is the Postgres side, built the same way as `PostgresGrantStore` and for the
+ * same reasons:
+ *
+ *  - **It does not own the pool.** Injected, never closed. Issue #665 was one
+ *    subsystem calling `close()` on a pool ~40 others shared.
+ *  - **It is allowed to throw.** The caller turns a failure into a refusal.
+ *    Swallowing a database error and reporting "no binding" would silently
+ *    unbind every handle in the deployment, and the failure would be
+ *    indistinguishable from the ordinary un-bound case — the same trap the
+ *    grant store's header describes.
+ *
+ * ## `bindIfAbsent` must not overwrite
+ *
+ * The write is `ON CONFLICT DO NOTHING`, and that single clause is the security
+ * property. An `UPSERT` would let a wider room re-bind a handle to itself and
+ * then read it — the exact leak the binding exists to prevent, reintroduced by
+ * a one-word change. It is also what makes a concurrent first sighting safe:
+ * two turns racing on the same key leave exactly one row, and the loser's room
+ * is compared against the winner's rather than replacing it.
+ */
+
+import type { Pool } from 'pg';
+
+import type {
+  AttachmentBindingStore,
+  AttachmentScopeBinding,
+} from '@omadia/orchestrator';
+
+export class PostgresAttachmentBindingStore implements AttachmentBindingStore {
+  constructor(private readonly pool: Pool) {}
+
+  async get(storageKey: string): Promise<AttachmentScopeBinding | undefined> {
+    const result = await this.pool.query<{ scope_kind: string; scope_ref: string }>(
+      `SELECT scope_kind, scope_ref FROM attachment_scope_bindings WHERE storage_key = $1`,
+      [storageKey],
+    );
+    const row = result.rows[0];
+    return row ? { scopeKind: row.scope_kind, scopeRef: row.scope_ref } : undefined;
+  }
+
+  async bindIfAbsent(storageKey: string, binding: AttachmentScopeBinding): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO attachment_scope_bindings (storage_key, scope_kind, scope_ref)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (storage_key) DO NOTHING`,
+      [storageKey, binding.scopeKind, binding.scopeRef],
+    );
+  }
+}

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -303,7 +303,11 @@ import { CanvasOutputRegistry } from './platform/canvasOutputRegistry.js';
 import { EventCatalogRegistry } from './platform/eventCatalogRegistry.js';
 import { DeterministicActionRegistry } from './platform/deterministicActionRegistry.js';
 import { ServiceRegistry } from './platform/serviceRegistry.js';
-import { createLateBoundGrantStore } from './audience/lateBoundGrantStore.js';
+import {
+  createLateBoundAttachmentBindingStore,
+  createLateBoundGrantStore,
+} from './audience/lateBoundGrantStore.js';
+import { PostgresAttachmentBindingStore } from './audience/postgresAttachmentBindingStore.js';
 import { PostgresGrantStore } from './audience/postgresGrantStore.js';
 import { createAudienceGrantRouter } from './audience/routes.js';
 import { TurnHookRegistry } from './platform/turnHookRegistry.js';
@@ -853,13 +857,22 @@ async function main(): Promise<void> {
   // when it received a grant store, so an unconfigured deployment behaves
   // exactly as before ("not enforced ≠ closed").
   let audienceGrantStoreRef: PostgresGrantStore | undefined;
+  let attachmentBindingStoreRef: PostgresAttachmentBindingStore | undefined;
   if (config.AUDIENCE_FLOOR_ENABLED) {
     serviceRegistry.provide(
       'audienceGrants',
       createLateBoundGrantStore(() => audienceGrantStoreRef),
     );
+    // #575 — pins each attachment handle to the room that minted it. Same flag,
+    // because it is the same policy: without the floor there is no notion of a
+    // room to bind to, and enforcing one alone would refuse handles for a
+    // deployment that never opted into audience control at all.
+    serviceRegistry.provide(
+      'attachmentBindings',
+      createLateBoundAttachmentBindingStore(() => attachmentBindingStoreRef),
+    );
     console.log(
-      '[middleware] #575 audience floor ENABLED — grants read from Postgres; rooms are limited to what every participant is granted',
+      '[middleware] #575 audience floor ENABLED — grants read from Postgres; rooms are limited to what every participant is granted, and attachment handles only redeem in the room that minted them',
     );
   }
 
@@ -1661,7 +1674,7 @@ async function main(): Promise<void> {
   // empty table first.
   const audienceGrantStore = graphPool ? new PostgresGrantStore(graphPool) : undefined;
   if (config.AUDIENCE_FLOOR_ENABLED) {
-    if (!audienceGrantStore) {
+    if (!graphPool || !audienceGrantStore) {
       throw new Error(
         '[middleware] AUDIENCE_FLOOR_ENABLED=true requires Postgres (DATABASE_URL) — ' +
           'the in-memory backend has nowhere to store grants, and the floor fails closed, ' +
@@ -1669,6 +1682,7 @@ async function main(): Promise<void> {
       );
     }
     audienceGrantStoreRef = audienceGrantStore;
+    attachmentBindingStoreRef = new PostgresAttachmentBindingStore(graphPool);
   }
 
   // Issue #560 — now that graphPool is known, back the long-running task seam

--- a/middleware/test/attachmentBindingStore.pg.test.ts
+++ b/middleware/test/attachmentBindingStore.pg.test.ts
@@ -1,0 +1,104 @@
+/**
+ * #575 — `bindIfAbsent` against a real Postgres.
+ *
+ * There is exactly one clause in this store that carries a security property:
+ * `ON CONFLICT (storage_key) DO NOTHING`. An `UPSERT` there would let a room
+ * that was just refused re-bind the handle to itself and read it on the next
+ * attempt — the leak the binding exists to prevent, reintroduced by one word.
+ *
+ * That clause cannot be exercised by a hand-rolled fake: a fake with
+ * first-sighting-wins semantics proves only that the *fake* has them. So this
+ * suite runs the real class against a real database, including two writers
+ * racing on the same key — where DO NOTHING is also what makes a concurrent
+ * first sighting safe rather than a primary-key violation.
+ *
+ * Skips cleanly (issue #572: no hardcoded default port) when no test database
+ * is configured.
+ */
+
+import { strict as assert } from 'node:assert';
+import { randomUUID } from 'node:crypto';
+import { after, before, describe, it } from 'node:test';
+
+import { Pool } from 'pg';
+
+import { probePgTest } from './_helpers/pgTestDb.js';
+
+import { PostgresAttachmentBindingStore } from '../src/audience/postgresAttachmentBindingStore.js';
+
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'attachmentBindingStore',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  timeoutMs: 1_500,
+});
+
+/** Migration 0036, applied directly so this suite does not depend on the
+ *  multi-orchestrator migrator having run against the test database. */
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS attachment_scope_bindings (
+  storage_key TEXT        PRIMARY KEY,
+  scope_kind  TEXT        NOT NULL,
+  scope_ref   TEXT        NOT NULL,
+  bound_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);`;
+
+describe('#575 PostgresAttachmentBindingStore', { skip: !pgAvailable }, () => {
+  let pool: Pool;
+  let store: PostgresAttachmentBindingStore;
+  const mark = randomUUID().slice(0, 8);
+  const key = `att/${mark}/report.pdf`;
+
+  before(async () => {
+    pool = new Pool({ connectionString: PG_URL, max: 4 });
+    await pool.query(SCHEMA);
+    store = new PostgresAttachmentBindingStore(pool);
+  });
+
+  after(async () => {
+    await pool.query(`DELETE FROM attachment_scope_bindings WHERE storage_key LIKE $1`, [
+      `%${mark}%`,
+    ]);
+    await pool.end();
+  });
+
+  it('returns undefined for a key it has never seen', async () => {
+    assert.equal(await store.get(`${key}-unknown`), undefined);
+  });
+
+  it('records the minting room and reads it back', async () => {
+    await store.bindIfAbsent(key, { scopeKind: 'conversation', scopeRef: 'teams::conv-A' });
+    assert.deepEqual(await store.get(key), {
+      scopeKind: 'conversation',
+      scopeRef: 'teams::conv-A',
+    });
+  });
+
+  it('does NOT overwrite an existing binding', async () => {
+    // The security clause. An UPSERT here would hand the handle to conv-B.
+    await store.bindIfAbsent(key, { scopeKind: 'conversation', scopeRef: 'teams::conv-B' });
+    assert.deepEqual(await store.get(key), {
+      scopeKind: 'conversation',
+      scopeRef: 'teams::conv-A',
+    });
+  });
+
+  it('survives two rooms racing on the same key', async () => {
+    // Concurrent first sightings: DO NOTHING makes the loser a no-op instead of
+    // a 23505, and exactly one room ends up owning the handle.
+    const raced = `att/${mark}/raced.pdf`;
+    await Promise.all([
+      store.bindIfAbsent(raced, { scopeKind: 'conversation', scopeRef: 'room-1' }),
+      store.bindIfAbsent(raced, { scopeKind: 'conversation', scopeRef: 'room-2' }),
+      store.bindIfAbsent(raced, { scopeKind: 'conversation', scopeRef: 'room-3' }),
+    ]);
+    const winner = await store.get(raced);
+    assert.ok(winner);
+    assert.ok(['room-1', 'room-2', 'room-3'].includes(winner.scopeRef));
+
+    const count = await pool.query<{ n: string }>(
+      `SELECT count(*)::text AS n FROM attachment_scope_bindings WHERE storage_key = $1`,
+      [raced],
+    );
+    assert.equal(count.rows[0]?.n, '1');
+  });
+});

--- a/middleware/test/attachmentScopeBinding.test.ts
+++ b/middleware/test/attachmentScopeBinding.test.ts
@@ -1,0 +1,203 @@
+/**
+ * #575 — a handle only redeems in the room that minted it.
+ *
+ * Guard 3 already refused a room that may not read attachments at all. What it
+ * could not stop was the case its own header named: a storage key issued in a
+ * private chat is a string, and a string can be pasted into a group chat that
+ * happens to hold `attachment:read`. These tests pin that second check.
+ *
+ * The interesting cases are the ones where a wrong answer is INVISIBLE:
+ *
+ *  - a non-addressable scope (`'http-default'`, `teams-unknown`) must disable
+ *    the check rather than approximate it — binding to one of those would
+ *    declare every unrelated caller to be the same room, and it would read as
+ *    enforcement while granting everyone access to everything;
+ *  - a binding store that throws must REFUSE, not report "unbound", because
+ *    "unbound" is exactly what the ordinary first-sighting looks like;
+ *  - the first sighting must WIN, or a wider room could re-bind a handle to
+ *    itself and then read it — the leak, reintroduced through the fix.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { audienceGuardedAttachmentReader } from '../packages/harness-orchestrator/src/attachmentReaderFactory.js';
+import {
+  bindingForRawScope,
+  bindingsEqual,
+  type AttachmentBindingStore,
+  type AttachmentScopeBinding,
+} from '../packages/harness-orchestrator/src/attachmentBinding.js';
+import { turnContext } from '../packages/harness-orchestrator/src/turnContext.js';
+import type { AttachmentReader } from '../packages/harness-orchestrator/src/tools/readAttachmentTool.js';
+
+/** A reader that records whether the inner byte source was reached at all. */
+function spyReader(): { reader: AttachmentReader; reads: string[] } {
+  const reads: string[] = [];
+  return {
+    reads,
+    reader: {
+      async readByStorageKey(key) {
+        reads.push(key);
+        return { bytes: Buffer.from('payload') };
+      },
+      async readByUrl(url) {
+        reads.push(url);
+        return { bytes: Buffer.from('payload') };
+      },
+    },
+  };
+}
+
+/** An in-memory binding store with first-sighting-wins semantics. */
+function memoryBindings(seed?: Record<string, AttachmentScopeBinding>): AttachmentBindingStore {
+  const rows = new Map<string, AttachmentScopeBinding>(Object.entries(seed ?? {}));
+  return {
+    async get(key) {
+      return rows.get(key);
+    },
+    async bindIfAbsent(key, binding) {
+      if (!rows.has(key)) rows.set(key, binding);
+    },
+  };
+}
+
+const failingBindings: AttachmentBindingStore = {
+  async get() {
+    throw new Error('connection terminated unexpectedly');
+  },
+  async bindIfAbsent() {
+    throw new Error('connection terminated unexpectedly');
+  },
+};
+
+/** Run `fn` inside a turn whose sessionScope is `scope`. */
+async function inScope<T>(scope: string | undefined, fn: () => Promise<T>): Promise<T> {
+  return turnContext.run(
+    { turnId: 't1', turnDate: '2026-08-18', ...(scope ? { sessionScope: scope } : {}) },
+    fn,
+  );
+}
+
+describe('#575 handle binding — the room that minted it', () => {
+  it('binds on first sighting and lets the same room read again', async () => {
+    const spy = spyReader();
+    const bindings = memoryBindings();
+    const reader = audienceGuardedAttachmentReader(spy.reader, bindings);
+
+    await inScope('teams::conv-A', () => reader.readByStorageKey('att/1'));
+    await inScope('teams::conv-A', () => reader.readByStorageKey('att/1'));
+
+    assert.deepEqual(spy.reads, ['att/1', 'att/1']);
+    assert.deepEqual(await bindings.get('att/1'), {
+      scopeKind: 'conversation',
+      scopeRef: 'teams::conv-A',
+    });
+  });
+
+  it('refuses the same handle in a different room', async () => {
+    const spy = spyReader();
+    const reader = audienceGuardedAttachmentReader(spy.reader, memoryBindings());
+
+    await inScope('teams::conv-A', () => reader.readByStorageKey('att/1'));
+    const leaked = await inScope('teams::conv-B', () => reader.readByStorageKey('att/1'));
+
+    assert.equal(leaked, undefined, 'a handle minted in conv-A must not redeem in conv-B');
+    assert.deepEqual(spy.reads, ['att/1'], 'the inner byte source must never be reached');
+  });
+
+  it('does not let a second room re-bind the handle to itself', async () => {
+    // The leak, reintroduced through the fix: if the write overwrote, the
+    // refused room would own the binding and its NEXT read would succeed.
+    const spy = spyReader();
+    const bindings = memoryBindings();
+    const reader = audienceGuardedAttachmentReader(spy.reader, bindings);
+
+    await inScope('teams::conv-A', () => reader.readByStorageKey('att/1'));
+    await inScope('teams::conv-B', () => reader.readByStorageKey('att/1'));
+    const secondAttempt = await inScope('teams::conv-B', () => reader.readByStorageKey('att/1'));
+
+    assert.equal(secondAttempt, undefined);
+    assert.equal((await bindings.get('att/1'))?.scopeRef, 'teams::conv-A');
+  });
+
+  it('compares kind as well as reference', async () => {
+    // `formatSessionScope` renders a personal scope as `personal:<id>` and a
+    // conversation scope as its bare conversation id — which could itself be
+    // that same string. Comparing references alone would make two different
+    // kinds of room look like one.
+    //
+    // Asserted on `bindingsEqual` directly rather than through a raw scope
+    // string, because `parseSessionScope` classifies `personal:u1` as personal:
+    // the collision is not reachable from today's producers, so the kind check
+    // is defensive. Pinning it here says so honestly instead of dressing an
+    // unreachable case up as an end-to-end test.
+    assert.equal(
+      bindingsEqual(
+        { scopeKind: 'personal', scopeRef: 'personal:u1' },
+        { scopeKind: 'conversation', scopeRef: 'personal:u1' },
+      ),
+      false,
+    );
+    assert.equal(bindingForRawScope('personal:u1')?.scopeKind, 'personal');
+  });
+});
+
+describe('#575 handle binding — where it deliberately stands down', () => {
+  it('does not bind a shared, non-addressable scope', async () => {
+    // `http-default` is shared by every unscoped HTTP caller — the live
+    // cross-user hole in #445. Binding to it would declare all of them one
+    // room: enforcement in appearance, universal access in fact.
+    const spy = spyReader();
+    const bindings = memoryBindings();
+    const reader = audienceGuardedAttachmentReader(spy.reader, bindings);
+
+    const first = await inScope('http-default', () => reader.readByStorageKey('att/3'));
+    const second = await inScope('http-default', () => reader.readByStorageKey('att/3'));
+
+    assert.ok(first);
+    assert.ok(second);
+    assert.equal(await bindings.get('att/3'), undefined, 'nothing may be written for a shared scope');
+  });
+
+  it('does not bind when there is no scope at all', async () => {
+    const spy = spyReader();
+    const bindings = memoryBindings();
+    const reader = audienceGuardedAttachmentReader(spy.reader, bindings);
+
+    assert.ok(await inScope(undefined, () => reader.readByStorageKey('att/4')));
+    assert.equal(await bindings.get('att/4'), undefined);
+  });
+
+  it('is inert without a binding store', async () => {
+    // A deployment that has not opted in must behave exactly as before.
+    const spy = spyReader();
+    const reader = audienceGuardedAttachmentReader(spy.reader);
+
+    assert.ok(await inScope('teams::conv-A', () => reader.readByStorageKey('att/5')));
+    assert.ok(await inScope('teams::conv-B', () => reader.readByStorageKey('att/5')));
+    assert.deepEqual(spy.reads, ['att/5', 'att/5']);
+  });
+
+  it('leaves readByUrl alone — a URL is not a storage key', async () => {
+    const spy = spyReader();
+    const reader = audienceGuardedAttachmentReader(
+      spy.reader,
+      memoryBindings({ 'https://x/y': { scopeKind: 'conversation', scopeRef: 'other' } }),
+    );
+    assert.ok(await inScope('teams::conv-A', () => reader.readByUrl('https://x/y')));
+  });
+});
+
+describe('#575 handle binding — an unreadable store refuses rather than unbinds', () => {
+  it('refuses when the binding store throws', async () => {
+    // "No binding" is what an ordinary first sighting looks like, so reporting
+    // it on an outage would silently unbind every handle in the deployment.
+    const spy = spyReader();
+    const reader = audienceGuardedAttachmentReader(spy.reader, failingBindings);
+
+    const result = await inScope('teams::conv-A', () => reader.readByStorageKey('att/6'));
+    assert.equal(result, undefined);
+    assert.deepEqual(spy.reads, [], 'the inner byte source must never be reached');
+  });
+});


### PR DESCRIPTION
The last open piece of #575, and the one `audienceFloorGuard`'s own header has been advertising:

> It checks the floor **at redemption**, not the floor **at minting**. So it stops a room from redeeming a handle that room may not read — but it cannot yet stop a handle minted in a narrow room from being redeemed in a room that happens to hold the capability.

A storage key is just a string, and a string can be pasted into a group chat.

Each key is now pinned, on first sighting, to the `ScopeId` it was resolved in. Every later resolution has to come from the same room.

## The room is a `ScopeId`, never the raw scope string

This is the decision the whole change turns on. `turnContext.sessionScope` carries its own warning:

> NOT safe as a key on its own: `resolveScope` returns the literal `'http-default'` for unscoped HTTP turns, so every such caller shares this value — that was the live cross-user hole in #445.

And `unsharedConversationScope`'s header records the same hole in a second place: a Teams activity without a conversation id yields `teams-unknown`, shared by every unrelated caller who hits that gap.

Keying a security binding on those strings would not merely fail to restrict — it would declare every unrelated caller to be **the same room**, which is worse than no binding at all, because it reads as enforcement. So the scope is parsed into `ScopeId` and only **addressable** scopes are bound. A non-addressable scope switches the check off rather than approximating it, and two tests pin that.

## Three smaller decisions, each with a failure mode that looks fine

**The check rides on the reader, not the call sites.** Same argument that put the floor check there in #733: a storage key outlives the turn that minted it, so a check at one resolution site holds exactly until somebody adds the next site and forgets.

**The floor is evaluated first.** A room that may not read attachments at all is refused before this touches the database — so no row is ever written that would bind a handle to a room that was never allowed to see it.

**`bindIfAbsent` is `ON CONFLICT DO NOTHING`, and that clause is the security property.** An `UPSERT` would let a room that was just refused re-bind the handle to itself and succeed on the next attempt — the leak reintroduced through the fix, by one word. It is also what makes a concurrent first sighting safe rather than a `23505`; a pg test races three writers to prove it.

`readByUrl` is deliberately untouched: a URL is not a storage key, carries no binding, and its reachability is the channel's business.

## Blast radius

| Surface | Effect |
|---|---|
| Deployments with `AUDIENCE_FLOOR_ENABLED` unset | **none** — no store is published, the check stands down |
| Deployments with it set | a handle redeems only in the room that minted it |
| Handles first resolved from a non-addressable scope | not bound, not enforced (see above) |
| Published plugin contract | none |

## Verification

- middleware suite: **6687 tests, 0 fail, 0 cancelled** (13 new)
- pg suite against a real Postgres in a throwaway container: **4/4**
- `npm run typecheck` ✅ · `npm run lint` ✅ · #470 ratchet **3294** ✅ · #573 ratchet **406, unchanged** ✅

**Mutation-checked — all four died:**

| Mutation | Result |
|---|---|
| `ON CONFLICT DO UPDATE` instead of `DO NOTHING` | kills the no-overwrite test |
| bind non-addressable scopes too | kills both stand-down tests |
| a failing binding store reads as "unbound" | kills the outage test |
| compare `scope_ref` without `scope_kind` | kills the kind test |

> One test in this file asserts less than it first appears to, and I would rather say so than let it read as coverage: the cross-*kind* collision (`personal:u1` as a conversation id) is **not reachable** from today's producers, because `parseSessionScope` classifies that string as `personal`. The kind comparison is therefore defensive, and the test asserts `bindingsEqual` directly instead of dressing an unreachable case up as end-to-end.

## Where #575 stands

| Piece | State |
|---|---|
| `ScopeId` (phase 1) | merged |
| Floor + grants (phase 2) | merged #729 |
| Guards 1–3 | merged #731, #732, #733 |
| Switching it on | merged #734 |
| Durable grant store + admin surface | merged #737 |
| **Handle bound at minting** | **this PR** |

Refs #575

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789651187&installation_model_id=428086&pr_number=738&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F738&signature=28a6f5a542929daffc4495e8a843bb676576c1fb009fdd25b0ce0074eb50fcb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->