### PR TITLE
feat(#575): prohibitions — one participant's veto binds the whole room

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,24 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — one participant's prohibition binds the whole room
+
+- **The audience floor could express "may" but not "must not" (#575).** It
+  intersected allowances, which is half of what spec §5.2 asks for
+  ("allowlist ∩, denylist ∪"). There was no way to say *this person must never
+  do X* at all.
+- **New:** explicit denials for a principal or a role (migration
+  `0037_audience_denials.sql`), with endpoints under
+  `/api/v1/admin/audience-grants/{direct,roles}/deny`.
+- **Allowances intersect, prohibitions union — deliberately asymmetric.** An
+  allowance says what someone *may* do, so the room may do what everyone may;
+  a prohibition binds the room even when only one participant carries it.
+  Applying intersection to prohibitions would mean a rule only bites when
+  everybody is under it.
+- **A denial overrides a grant**, rather than being modelled as "simply do not
+  grant it" — otherwise any role that happens to confer the capability would
+  silently lift an operator's explicit prohibition.
+
 ### Added — an attachment handle only redeems in the room that minted it
 
 - **A storage key was just a string (#575).** The handle guard checked the floor

--- a/middleware/migrations/0037_audience_denials.sql
+++ b/middleware/migrations/0037_audience_denials.sql
@@ -1,0 +1,45 @@
+-- ── Audience-floor prohibitions (#575, spec §5.2 "allowlist ∩, denylist ∪") ──
+-- Migration 0035 stored what a principal MAY do. This stores what a principal
+-- must NOT be party to — a different kind of statement, and one that behaves
+-- differently at every level:
+--
+--   * a grant is intersected across the audience (the room may do what everyone
+--     may do), a denial is UNIONED (one participant's prohibition binds the
+--     whole room);
+--   * a grant is additive, a denial OVERRIDES — it is subtracted after the
+--     intersection, so an unrelated role assignment cannot silently lift an
+--     operator's explicit "this person must never do X".
+--
+-- Separate tables rather than an `effect` column on 0035's:
+--
+--   * the two are read on different code paths and unioned/intersected
+--     differently, so a shared table would need the discriminator in every
+--     query and in the primary key;
+--   * 0035 already ships, and widening a live table's primary key is a worse
+--     migration than adding two new ones;
+--   * a schema in which "grant" and "deny" are visibly different things is
+--     harder to confuse than one where they differ by a string column — and
+--     confusing them is a permission bug in the dangerous direction.
+--
+-- No foreign key to conductor_roles(key), for the same reason as 0035: #333
+-- phase 2 lets role membership come from an external directory this deployment
+-- holds no local row for.
+
+CREATE TABLE IF NOT EXISTS audience_direct_denials (
+  principal_kind TEXT        NOT NULL,
+  principal_ref  TEXT        NOT NULL,
+  capability     TEXT        NOT NULL,
+  denied_by      TEXT        NOT NULL,
+  denied_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (principal_kind, principal_ref, capability)
+);
+
+CREATE TABLE IF NOT EXISTS audience_role_denials (
+  role_key   TEXT        NOT NULL,
+  capability TEXT        NOT NULL,
+  denied_by  TEXT        NOT NULL,
+  denied_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (role_key, capability)
+);
+
+-- rollback: DROP TABLE audience_role_denials; DROP TABLE audience_direct_denials;

--- a/middleware/packages/harness-channel-sdk/src/audienceFloor.ts
+++ b/middleware/packages/harness-channel-sdk/src/audienceFloor.ts
@@ -94,6 +94,15 @@ export type AudienceMember =
       readonly principal: Principal;
       /** What this principal may do. Empty is a real answer: they may do nothing. */
       readonly capabilities: ReadonlySet<Capability>;
+      /**
+       * What this principal is explicitly FORBIDDEN, whatever their grants say.
+       *
+       * Required rather than optional, deliberately. An optional field that a
+       * caller forgets to thread produces an empty denial set — which is the
+       * direction that silently WIDENS the floor. Making it mandatory turns
+       * that omission into a compile error instead of a permission bug.
+       */
+      readonly denials: ReadonlySet<Capability>;
     }
   | {
       readonly kind: 'unresolved';
@@ -132,6 +141,8 @@ export type AudienceFloor =
 export interface ResolvedAudienceMember {
   readonly principal: Principal;
   readonly capabilities: ReadonlySet<Capability>;
+  /** Explicit prohibitions. See {@link AudienceMember} for why it is required. */
+  readonly denials: ReadonlySet<Capability>;
 }
 
 /**
@@ -157,7 +168,12 @@ export async function resolveAudience<TParticipant>(
       try {
         const resolved = await resolve(participant);
         return resolved
-          ? { kind: 'resolved', principal: resolved.principal, capabilities: resolved.capabilities }
+          ? {
+              kind: 'resolved',
+              principal: resolved.principal,
+              capabilities: resolved.capabilities,
+              denials: resolved.denials,
+            }
           : { kind: 'unresolved', reason: 'no principal could be resolved for this participant' };
       } catch (err) {
         return {
@@ -185,8 +201,32 @@ export async function resolveAudience<TParticipant>(
  *     intersecting it would yield "everything", so it is refused explicitly
  *     rather than left to the reduce.
  *
- * Otherwise the floor is the set intersection across resolved members. An empty
- * intersection is `open` with nothing in it — a real answer, not a failure.
+ * Otherwise the floor is the set intersection across resolved members, minus
+ * every explicit denial. An empty result is `open` with nothing in it — a real
+ * answer, not a failure.
+ *
+ * ## Allowances INTERSECT, prohibitions UNION — and the asymmetry is the point
+ *
+ * Spec §5.2 states the rule as "allowlist ∩, denylist ∪". They are not two
+ * spellings of one operation:
+ *
+ *  - An **allowance** is a statement about what a principal MAY do, so a room
+ *    may only do what everyone may do. Intersect.
+ *  - A **prohibition** is a statement about what a principal must NOT be party
+ *    to, and it binds the room even if only one participant carries it. Union.
+ *
+ * Applying intersection to prohibitions would mean a rule only bites when
+ * *everyone* is under it — which inverts what a prohibition is for. Applying
+ * union to allowances would hand the room the most permissive participant's
+ * rights, which is the classic full-permission grant.
+ *
+ * ## A denial beats a grant, rather than merely being absent from one
+ *
+ * Subtracting denials AFTER the intersection is what makes them override roles.
+ * If a prohibition were expressed as "simply do not grant it", then adding any
+ * role that happens to confer the capability would silently lift it — an
+ * operator's explicit "this person must never do X" would be undone by an
+ * unrelated role assignment somewhere else.
  */
 export function audienceFloor(audience: Audience): AudienceFloor {
   if (audience.kind === 'unknown') {
@@ -215,7 +255,19 @@ export function audienceFloor(audience: Audience): AudienceFloor {
     if (capabilities.size === 0) break;
   }
 
-  return { outcome: 'open', capabilities };
+  // Prohibitions are collected across EVERY resolved member, including the ones
+  // whose allowances the intersection has already discarded: a denial is not a
+  // missing grant, it is a veto, and it must be read even from a participant who
+  // was granted nothing.
+  const denied = new Set<Capability>();
+  for (const member of resolved) {
+    for (const capability of member.denials) denied.add(capability);
+  }
+
+  return {
+    outcome: 'open',
+    capabilities: new Set([...capabilities].filter((c) => !denied.has(c))),
+  };
 }
 
 /**

--- a/middleware/packages/harness-channel-sdk/src/grants.ts
+++ b/middleware/packages/harness-channel-sdk/src/grants.ts
@@ -61,6 +61,21 @@ export interface GrantStore {
   directGrants(principal: Principal): Promise<readonly Capability[]>;
   /** Capabilities granted to a role, held by whoever currently holds it. */
   roleGrants(roleKey: string): Promise<readonly Capability[]>;
+  /**
+   * Capabilities explicitly FORBIDDEN to this principal, whatever their grants
+   * say. Unioned across the audience and subtracted from the intersection — see
+   * `audienceFloor` for why the two directions differ.
+   *
+   * Optional so a store with no concept of prohibitions stays valid; **absent**
+   * means this implementation has none. That is safe in a way a *failing*
+   * lookup is not: absent is a static property of the implementation, whereas a
+   * throw means the answer is unknown, and an unknown prohibition read as "none"
+   * would widen the floor. A store that has denials must therefore throw rather
+   * than return `[]` when it cannot read them — same rule as the grant side.
+   */
+  directDenials?(principal: Principal): Promise<readonly Capability[]>;
+  /** Capabilities forbidden to everyone currently holding this role. */
+  roleDenials?(roleKey: string): Promise<readonly Capability[]>;
 }
 
 /**
@@ -98,6 +113,16 @@ export async function resolveCapabilities(
       if (trimmed.length > 0) capabilities.add(trimmed);
     }
 
+    // Prohibitions are collected alongside, never subtracted here: they must
+    // reach the floor intact so it can UNION them across the audience. Applying
+    // them per principal first would make a veto bind only the person carrying
+    // it, which is the opposite of what a prohibition is for.
+    const denials = new Set<Capability>();
+    for (const capability of (await grants.directDenials?.(principal)) ?? []) {
+      const trimmed = capability.trim();
+      if (trimmed.length > 0) denials.add(trimmed);
+    }
+
     // Role keys keep their case (#333 phase 1: `createRole` writes them
     // verbatim), so they are canonicalized with the ROLE rule before lookup —
     // lowercasing here would miss every mixed-case grant row.
@@ -111,7 +136,19 @@ export async function resolveCapabilities(
       }
     }
 
-    return { principal, capabilities };
+    const perRoleDenials = await Promise.all(
+      roleLookup.roles.map(
+        (role) => grants.roleDenials?.(canonicalizePrincipalRef('role', role)) ?? [],
+      ),
+    );
+    for (const forbidden of perRoleDenials) {
+      for (const capability of forbidden) {
+        const trimmed = capability.trim();
+        if (trimmed.length > 0) denials.add(trimmed);
+      }
+    }
+
+    return { principal, capabilities, denials };
   } catch {
     // Deliberately swallowed here and surfaced as `unresolved` by the caller:
     // the floor's `closed` reason is the operator-facing signal, and letting
@@ -131,6 +168,8 @@ export async function resolveCapabilities(
 export class InMemoryGrantStore implements GrantStore {
   private readonly direct = new Map<string, Set<Capability>>();
   private readonly byRole = new Map<string, Set<Capability>>();
+  private readonly directDenied = new Map<string, Set<Capability>>();
+  private readonly roleDenied = new Map<string, Set<Capability>>();
 
   grantToPrincipal(principal: Principal, ...capabilities: Capability[]): this {
     const key = principalKey(principal);
@@ -154,6 +193,31 @@ export class InMemoryGrantStore implements GrantStore {
 
   async roleGrants(roleKey: string): Promise<readonly Capability[]> {
     return [...(this.byRole.get(canonicalizePrincipalRef('role', roleKey)) ?? [])];
+  }
+
+  /** Forbid a capability outright — beats any grant the principal holds. */
+  denyToPrincipal(principal: Principal, ...capabilities: Capability[]): this {
+    const key = principalKey(principal);
+    const set = this.directDenied.get(key) ?? new Set<Capability>();
+    for (const c of capabilities) set.add(c);
+    this.directDenied.set(key, set);
+    return this;
+  }
+
+  denyToRole(roleKey: string, ...capabilities: Capability[]): this {
+    const key = canonicalizePrincipalRef('role', roleKey);
+    const set = this.roleDenied.get(key) ?? new Set<Capability>();
+    for (const c of capabilities) set.add(c);
+    this.roleDenied.set(key, set);
+    return this;
+  }
+
+  async directDenials(principal: Principal): Promise<readonly Capability[]> {
+    return [...(this.directDenied.get(principalKey(principal)) ?? [])];
+  }
+
+  async roleDenials(roleKey: string): Promise<readonly Capability[]> {
+    return [...(this.roleDenied.get(canonicalizePrincipalRef('role', roleKey)) ?? [])];
   }
 }
 

--- a/middleware/src/audience/lateBoundGrantStore.ts
+++ b/middleware/src/audience/lateBoundGrantStore.ts
@@ -69,6 +69,15 @@ export function createLateBoundGrantStore(
     async roleGrants(roleKey: string): Promise<readonly Capability[]> {
       return target().roleGrants(roleKey);
     },
+    // Forwarded, not omitted. `GrantStore` treats an ABSENT denial method as
+    // "this implementation has none" — so dropping these here would quietly
+    // strip every prohibition in the deployment while the grants kept working.
+    async directDenials(principal: Principal): Promise<readonly Capability[]> {
+      return target().directDenials?.(principal) ?? [];
+    },
+    async roleDenials(roleKey: string): Promise<readonly Capability[]> {
+      return target().roleDenials?.(roleKey) ?? [];
+    },
   };
 }
 

--- a/middleware/src/audience/postgresGrantStore.ts
+++ b/middleware/src/audience/postgresGrantStore.ts
@@ -64,6 +64,23 @@ export interface RoleGrantRow {
   readonly grantedAt: Date;
 }
 
+/** One stored prohibition against a principal. */
+export interface DirectDenialRow {
+  readonly principalKind: string;
+  readonly principalRef: string;
+  readonly capability: Capability;
+  readonly deniedBy: string;
+  readonly deniedAt: Date;
+}
+
+/** One stored prohibition against a role. */
+export interface RoleDenialRow {
+  readonly roleKey: string;
+  readonly capability: Capability;
+  readonly deniedBy: string;
+  readonly deniedAt: Date;
+}
+
 /**
  * A capability is stored verbatim apart from surrounding whitespace, matching
  * what `resolveCapabilities` does when it builds the set. Rejecting the empty
@@ -97,6 +114,29 @@ export class PostgresGrantStore implements GrantStore {
     const key = canonicalizePrincipalRef('role', roleKey);
     const result = await this.pool.query<{ capability: string }>(
       `SELECT capability FROM audience_role_grants WHERE role_key = $1`,
+      [key],
+    );
+    return result.rows.map((row) => row.capability);
+  }
+
+  // Prohibitions. Same no-try/catch rule as the grant side, and it matters more
+  // here: an unread denial that came back as `[]` would not merely under-report
+  // permissions, it would REMOVE a veto the operator put in place.
+
+  async directDenials(principal: Principal): Promise<readonly Capability[]> {
+    const ref = canonicalizePrincipalRef(principal.kind, principalRef(principal));
+    const result = await this.pool.query<{ capability: string }>(
+      `SELECT capability FROM audience_direct_denials
+        WHERE principal_kind = $1 AND principal_ref = $2`,
+      [principal.kind, ref],
+    );
+    return result.rows.map((row) => row.capability);
+  }
+
+  async roleDenials(roleKey: string): Promise<readonly Capability[]> {
+    const key = canonicalizePrincipalRef('role', roleKey);
+    const result = await this.pool.query<{ capability: string }>(
+      `SELECT capability FROM audience_role_denials WHERE role_key = $1`,
       [key],
     );
     return result.rows.map((row) => row.capability);
@@ -157,6 +197,95 @@ export class PostgresGrantStore implements GrantStore {
       [canonicalizePrincipalRef('role', roleKey), normalizeCapability(capability)],
     );
     return (result.rowCount ?? 0) > 0;
+  }
+
+  async denyToPrincipal(
+    principal: Principal,
+    capability: string,
+    deniedBy: string,
+  ): Promise<void> {
+    const value = normalizeCapability(capability);
+    if (value.length === 0) throw new Error('capability must not be empty');
+    const ref = canonicalizePrincipalRef(principal.kind, principalRef(principal));
+    await this.pool.query(
+      `INSERT INTO audience_direct_denials (principal_kind, principal_ref, capability, denied_by)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (principal_kind, principal_ref, capability)
+       DO UPDATE SET denied_by = EXCLUDED.denied_by, denied_at = now()`,
+      [principal.kind, ref, value, deniedBy],
+    );
+  }
+
+  async denyToRole(roleKey: string, capability: string, deniedBy: string): Promise<void> {
+    const value = normalizeCapability(capability);
+    if (value.length === 0) throw new Error('capability must not be empty');
+    const key = canonicalizePrincipalRef('role', roleKey);
+    if (key.length === 0) throw new Error('role key must not be empty');
+    await this.pool.query(
+      `INSERT INTO audience_role_denials (role_key, capability, denied_by)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (role_key, capability)
+       DO UPDATE SET denied_by = EXCLUDED.denied_by, denied_at = now()`,
+      [key, value, deniedBy],
+    );
+  }
+
+  async liftPrincipalDenial(principal: Principal, capability: string): Promise<boolean> {
+    const ref = canonicalizePrincipalRef(principal.kind, principalRef(principal));
+    const result = await this.pool.query(
+      `DELETE FROM audience_direct_denials
+        WHERE principal_kind = $1 AND principal_ref = $2 AND capability = $3`,
+      [principal.kind, ref, normalizeCapability(capability)],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async liftRoleDenial(roleKey: string, capability: string): Promise<boolean> {
+    const result = await this.pool.query(
+      `DELETE FROM audience_role_denials WHERE role_key = $1 AND capability = $2`,
+      [canonicalizePrincipalRef('role', roleKey), normalizeCapability(capability)],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async listDirectDenials(): Promise<DirectDenialRow[]> {
+    const result = await this.pool.query<{
+      principal_kind: string;
+      principal_ref: string;
+      capability: string;
+      denied_by: string;
+      denied_at: Date;
+    }>(
+      `SELECT principal_kind, principal_ref, capability, denied_by, denied_at
+         FROM audience_direct_denials
+        ORDER BY principal_kind, principal_ref, capability`,
+    );
+    return result.rows.map((row) => ({
+      principalKind: row.principal_kind,
+      principalRef: row.principal_ref,
+      capability: row.capability,
+      deniedBy: row.denied_by,
+      deniedAt: row.denied_at,
+    }));
+  }
+
+  async listRoleDenials(): Promise<RoleDenialRow[]> {
+    const result = await this.pool.query<{
+      role_key: string;
+      capability: string;
+      denied_by: string;
+      denied_at: Date;
+    }>(
+      `SELECT role_key, capability, denied_by, denied_at
+         FROM audience_role_denials
+        ORDER BY role_key, capability`,
+    );
+    return result.rows.map((row) => ({
+      roleKey: row.role_key,
+      capability: row.capability,
+      deniedBy: row.denied_by,
+      deniedAt: row.denied_at,
+    }));
   }
 
   async listDirectGrants(): Promise<DirectGrantRow[]> {

--- a/middleware/src/audience/routes.ts
+++ b/middleware/src/audience/routes.ts
@@ -68,11 +68,16 @@ export function createAudienceGrantRouter(deps: AudienceGrantRoutesDeps): Router
 
   router.get('/', async (_req: Request, res: Response): Promise<void> => {
     try {
-      const [direct, roles] = await Promise.all([
+      const [direct, roles, deniedDirect, deniedRoles] = await Promise.all([
         deps.store.listDirectGrants(),
         deps.store.listRoleGrants(),
+        deps.store.listDirectDenials(),
+        deps.store.listRoleDenials(),
       ]);
-      res.json({ direct, roles });
+      // Prohibitions are listed alongside rather than merged into the grant
+      // lists: they do not cancel a grant row, they override it at evaluation
+      // time, and an operator reading this needs to see both statements.
+      res.json({ direct, roles, denials: { direct: deniedDirect, roles: deniedRoles } });
     } catch (err) {
       res.status(500).json({ code: 'audience.grants_list_failed', message: errMsg(err) });
     }
@@ -162,6 +167,97 @@ export function createAudienceGrantRouter(deps: AudienceGrantRoutesDeps): Router
       res.json({ ok: true });
     } catch (err) {
       res.status(500).json({ code: 'audience.revoke_failed', message: errMsg(err) });
+    }
+  });
+
+  // ── prohibitions ─────────────────────────────────────────────────────────
+  // A denial is not "revoke a grant". Revoking removes an allowance and any
+  // role may hand it straight back; a denial survives every role and is
+  // unioned across the audience, so one participant's prohibition binds the
+  // whole room. Separate endpoints so the two are not confused at the API
+  // either.
+
+  router.post('/direct/deny', async (req: Request, res: Response): Promise<void> => {
+    const body = asObject(req.body);
+    const principal = parseUserPrincipal(str(body.userId));
+    const capability = str(body.capability).trim();
+    if (!principal || !capability) {
+      res.status(400).json({
+        code: 'audience.invalid_input',
+        message: 'userId and capability are required',
+      });
+      return;
+    }
+    try {
+      await deps.store.denyToPrincipal(principal, capability, deps.actor(req));
+      res.status(201).json({ ok: true });
+    } catch (err) {
+      res.status(500).json({ code: 'audience.deny_failed', message: errMsg(err) });
+    }
+  });
+
+  router.delete('/direct/deny', async (req: Request, res: Response): Promise<void> => {
+    const body = asObject(req.body);
+    const principal = parseUserPrincipal(str(body.userId));
+    const capability = str(body.capability).trim();
+    if (!principal || !capability) {
+      res.status(400).json({
+        code: 'audience.invalid_input',
+        message: 'userId and capability are required',
+      });
+      return;
+    }
+    try {
+      const lifted = await deps.store.liftPrincipalDenial(principal, capability);
+      if (!lifted) {
+        res.status(404).json({ code: 'audience.denial_not_found', message: 'no such denial' });
+        return;
+      }
+      res.json({ ok: true });
+    } catch (err) {
+      res.status(500).json({ code: 'audience.lift_failed', message: errMsg(err) });
+    }
+  });
+
+  router.post('/roles/deny', async (req: Request, res: Response): Promise<void> => {
+    const body = asObject(req.body);
+    const roleKey = str(body.roleKey).trim();
+    const capability = str(body.capability).trim();
+    if (!roleKey || !capability) {
+      res.status(400).json({
+        code: 'audience.invalid_input',
+        message: 'roleKey and capability are required',
+      });
+      return;
+    }
+    try {
+      await deps.store.denyToRole(roleKey, capability, deps.actor(req));
+      res.status(201).json({ ok: true });
+    } catch (err) {
+      res.status(500).json({ code: 'audience.deny_failed', message: errMsg(err) });
+    }
+  });
+
+  router.delete('/roles/deny', async (req: Request, res: Response): Promise<void> => {
+    const body = asObject(req.body);
+    const roleKey = str(body.roleKey).trim();
+    const capability = str(body.capability).trim();
+    if (!roleKey || !capability) {
+      res.status(400).json({
+        code: 'audience.invalid_input',
+        message: 'roleKey and capability are required',
+      });
+      return;
+    }
+    try {
+      const lifted = await deps.store.liftRoleDenial(roleKey, capability);
+      if (!lifted) {
+        res.status(404).json({ code: 'audience.denial_not_found', message: 'no such denial' });
+        return;
+      }
+      res.json({ ok: true });
+    } catch (err) {
+      res.status(500).json({ code: 'audience.lift_failed', message: errMsg(err) });
     }
   });
 

--- a/middleware/test/audienceDenials.test.ts
+++ b/middleware/test/audienceDenials.test.ts
@@ -1,0 +1,187 @@
+/**
+ * #575 — prohibitions: "allowlist ∩, denylist ∪" (spec §5.2).
+ *
+ * The floor already intersected allowances. What it had no notion of was a
+ * PROHIBITION, and the two are not two spellings of one operation:
+ *
+ *  - an allowance says what a principal MAY do, so the room may do what
+ *    *everyone* may do → intersect;
+ *  - a prohibition says what a principal must not be party to, and it binds the
+ *    room even when only one participant carries it → union.
+ *
+ * Both directions fail in a way that looks reasonable if you get them backwards,
+ * so each has a test that only passes under the correct one:
+ *
+ *  - union applied to allowances hands the room the most permissive
+ *    participant's rights;
+ *  - intersection applied to prohibitions means a rule only bites when
+ *    *everybody* is under it, which is the opposite of what a prohibition is.
+ *
+ * And the third property, which is why a denial is not simply "do not grant it":
+ * a denial must SURVIVE a role that confers the same capability.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  audienceFloor,
+  floorPermits,
+  makePrincipal,
+  resolveCapabilities,
+  InMemoryGrantStore,
+  RoleSourceCatalog,
+  RoleSourceRegistry,
+  type Audience,
+  type Capability,
+  type Principal,
+  type RoleSource,
+} from '../packages/harness-channel-sdk/src/index.js';
+
+const ALICE = makePrincipal('user', 'alice@example.com') as Principal;
+const BOB = makePrincipal('user', 'bob@example.com') as Principal;
+
+function member(principal: Principal, allow: Capability[], deny: Capability[] = []) {
+  return {
+    kind: 'resolved' as const,
+    principal,
+    capabilities: new Set(allow),
+    denials: new Set(deny),
+  };
+}
+
+/** A role source that reports fixed roles for everyone. */
+function rolesFor(roles: string[]): RoleSourceRegistry {
+  const source: RoleSource = {
+    id: 'test-roles',
+    displayName: 'test roles',
+    async rolesFor() {
+      return { outcome: 'resolved', roles };
+    },
+  };
+  const registry = new RoleSourceRegistry();
+  registry.register(source);
+  return registry;
+}
+
+describe('#575 the floor — allowances intersect, prohibitions union', () => {
+  it('a prohibition carried by ONE participant binds the whole room', async () => {
+    // Both may send email; Alice is explicitly forbidden. Under intersection
+    // semantics for denials this would still be allowed — which is exactly the
+    // bug this test exists to make impossible.
+    const audience: Audience = {
+      kind: 'known',
+      members: [
+        member(ALICE, ['tool:send_email'], ['tool:send_email']),
+        member(BOB, ['tool:send_email']),
+      ],
+    };
+    const floor = audienceFloor(audience);
+    assert.equal(floor.outcome, 'open');
+    assert.equal(floorPermits(floor, 'tool:send_email'), false);
+  });
+
+  it('still intersects allowances — one participant is not enough to permit', async () => {
+    const floor = audienceFloor({
+      kind: 'known',
+      members: [member(ALICE, ['tool:send_email']), member(BOB, [])],
+    });
+    assert.equal(floorPermits(floor, 'tool:send_email'), false);
+  });
+
+  it('leaves untouched capabilities alone', async () => {
+    const floor = audienceFloor({
+      kind: 'known',
+      members: [
+        member(ALICE, ['tool:send_email', 'memory:recall'], ['tool:send_email']),
+        member(BOB, ['tool:send_email', 'memory:recall']),
+      ],
+    });
+    assert.equal(floorPermits(floor, 'tool:send_email'), false);
+    assert.equal(floorPermits(floor, 'memory:recall'), true);
+  });
+
+  it('reads a prohibition even from a participant who was granted nothing', async () => {
+    // A guest with no allowances at all still closes the room's email. If
+    // denials were only collected from members that survived the intersection,
+    // this veto would be dropped.
+    const floor = audienceFloor({
+      kind: 'known',
+      members: [member(ALICE, ['tool:send_email']), member(BOB, [], ['tool:send_email'])],
+    });
+    assert.equal(floorPermits(floor, 'tool:send_email'), false);
+  });
+});
+
+describe('#575 a denial overrides a grant rather than merely being absent from one', () => {
+  it('survives a role that confers the same capability', async () => {
+    // The reason a prohibition cannot be modelled as "just do not grant it":
+    // an unrelated role assignment would silently lift it.
+    const store = new InMemoryGrantStore()
+      .grantToRole('approver', 'tool:send_email')
+      .denyToPrincipal(ALICE, 'tool:send_email');
+
+    const resolved = await resolveCapabilities(ALICE, rolesFor(['approver']), store);
+    assert.ok(resolved);
+    assert.equal(resolved.capabilities.has('tool:send_email'), true, 'the role still grants it');
+    assert.equal(resolved.denials.has('tool:send_email'), true, 'and the denial still stands');
+
+    const floor = audienceFloor({
+      kind: 'known',
+      members: [{ kind: 'resolved', ...resolved }],
+    });
+    assert.equal(floorPermits(floor, 'tool:send_email'), false, 'the denial must win');
+  });
+
+  it('carries a ROLE-level prohibition to everyone holding that role', async () => {
+    const store = new InMemoryGrantStore()
+      .grantToPrincipal(ALICE, 'tool:send_email')
+      .denyToRole('contractor', 'tool:send_email');
+
+    const resolved = await resolveCapabilities(ALICE, rolesFor(['contractor']), store);
+    assert.ok(resolved);
+    assert.equal(resolved.denials.has('tool:send_email'), true);
+  });
+
+  it('does not subtract the denial per principal — the floor must see it', async () => {
+    // If `resolveCapabilities` applied denials itself, a veto would bind only
+    // the person carrying it and the union across the audience would never
+    // happen. The capability must still be present on the member.
+    const store = new InMemoryGrantStore()
+      .grantToPrincipal(ALICE, 'tool:send_email')
+      .denyToPrincipal(ALICE, 'tool:send_email');
+
+    const resolved = await resolveCapabilities(ALICE, new RoleSourceRegistry(), store);
+    assert.ok(resolved);
+    assert.equal(resolved.capabilities.has('tool:send_email'), true);
+    assert.equal(resolved.denials.has('tool:send_email'), true);
+  });
+});
+
+describe('#575 a store with no denial concept stays valid', () => {
+  it('treats absent denial methods as "this implementation has none"', async () => {
+    // Absence is a static property of the implementation — safe. A THROW would
+    // mean the answer is unknown, which must close the floor instead; that is
+    // pinned in audienceGrantStore.test.ts.
+    const legacy = {
+      async directGrants() {
+        return ['tool:send_email'] as Capability[];
+      },
+      async roleGrants() {
+        return [] as Capability[];
+      },
+    };
+    const resolved = await resolveCapabilities(ALICE, new RoleSourceRegistry(), legacy);
+    assert.ok(resolved);
+    assert.equal(resolved.denials.size, 0);
+    assert.equal(
+      floorPermits(audienceFloor({ kind: 'known', members: [{ kind: 'resolved', ...resolved }] }), 'tool:send_email'),
+      true,
+    );
+  });
+
+  it('keeps the catalog/registry gate unchanged', () => {
+    // Guard against this change accidentally widening the role-source surface.
+    assert.equal(new RoleSourceCatalog().get('nope'), undefined);
+  });
+});

--- a/middleware/test/audienceFloor.test.ts
+++ b/middleware/test/audienceFloor.test.ts
@@ -32,10 +32,14 @@ import {
 const alice: Principal = { kind: 'user', userId: 'alice' };
 const bob: Principal = { kind: 'user', userId: 'bob' };
 
+// `denials` is required on a resolved member (see `audienceFloor.ts`): an
+// optional field that a caller forgets to thread would silently widen the
+// floor. These cases are about the intersection, so they carry none.
 const member = (principal: Principal, ...caps: Capability[]): AudienceMember => ({
   kind: 'resolved',
   principal,
   capabilities: new Set(caps),
+  denials: new Set<Capability>(),
 });
 
 const known = (...members: AudienceMember[]): Audience => ({ kind: 'known', members });
@@ -104,7 +108,13 @@ describe('the intersection itself', () => {
 
 describe('resolveAudience refuses to invent a room', () => {
   const join = async (p: string) =>
-    p === 'unknown-person' ? undefined : { principal: { kind: 'user' as const, userId: p }, capabilities: new Set(['read']) };
+    p === 'unknown-person'
+      ? undefined
+      : {
+          principal: { kind: 'user' as const, userId: p },
+          capabilities: new Set(['read']),
+          denials: new Set<Capability>(),
+        };
 
   it('no provider installed → unknown, not an empty room', async () => {
     // HTTP and web turns install no participant provider (spec §5.1).


### PR DESCRIPTION
Spec §5.2 states the egress rule as **"allowlist ∩, denylist ∪"**. Only the first half existed.

The floor intersected allowances, so it could answer *may this room do X*. It had no way to express **"this person must never be party to X"** at all — and that is not a shade of the same thing.

## The asymmetry is the point

| | statement | operation | if reversed |
|---|---|---|---|
| **Allowance** | what a principal *may* do | **intersect** — the room may do what everyone may | unioning hands the room the most permissive participant's rights |
| **Prohibition** | what a principal must *not* be party to | **union** — one participant's veto binds the room | intersecting means a rule only bites when *everybody* is under it |

Both reversals look reasonable in a diff, and both are permission bugs in the dangerous direction. Each has a test that passes only under the correct operation.

## A denial overrides a grant, rather than being absent from one

The denial is subtracted **after** the intersection. That ordering is what makes it beat a role.

Modelled the other way — "a prohibition is just: don't grant it" — adding any role that happens to confer the capability would silently lift an operator's explicit *this person must never do X*. The prohibition has to be a statement in its own right, or it is only as durable as the role graph around it.

Denials are also collected from **every** resolved member, including those whose allowances the intersection already discarded: a guest granted nothing can still carry a veto, and reading vetoes only from members that "survived" would drop exactly the ones most likely to have one.

## `denials` is required, not optional — and the ratchet proved why

`ResolvedAudienceMember.denials` is a **required** field.

An optional one that a caller forgets to thread yields an empty denial set, which is the direction that silently **widens** the floor. Making it mandatory turns that omission into a compile error — and the #573 test-typecheck ratchet then found all four call sites that needed it. **Fixed, not baselined**; the baseline is still 406.

## Absent vs. throwing

`GrantStore.directDenials` / `roleDenials` are **optional methods**, so a store with no concept of prohibitions stays valid.

- **Absent** ⇒ this implementation has none. Safe: it is a static property of the implementation.
- **Throwing** ⇒ the answer is unknown, and an unknown prohibition read as "none" would remove a veto. Must close the floor, same rule as the grant side.

The late-bound wrapper forwards both explicitly rather than omitting them — dropping them there would have quietly stripped every prohibition in the deployment while the grants kept working.

## Blast radius

| Surface | Effect |
|---|---|
| Deployments with `AUDIENCE_FLOOR_ENABLED` unset | **none** |
| Deployments with it set, no denials recorded | **none** — the floor is the same intersection as before |
| Deployments with denials recorded | one participant's prohibition binds the room |
| `GrantStore` implementations outside this repo | none — the new methods are optional |

## Verification

- middleware suite: **6696 tests, 0 fail, 0 cancelled** (9 new)
- `npm run typecheck` ✅ · `npm run lint` ✅ · #470 ratchet **3294** ✅ · #573 ratchet **406, unchanged** ✅

**Mutation-checked — all four died:**

| Mutation | Result |
|---|---|
| intersect denials instead of unioning | kills 2 |
| do not subtract them at all | kills 3 |
| subtract per principal, so the veto never reaches the floor | kills 3 |
| drop role-level denials | kills 1 |

## What this closes, and what #575 still names

This is the `denylist ∪` half of the egress rule. Two things from the issue text remain open, and I would rather list them than let the cluster read as finished:

1. **Host-level egress** — the issue speaks of allowed/denied *hosts*. This works on opaque capability tokens, so a host policy is expressible (`net:example.com`) but not modelled.
2. **Per-recipient context filtering with tool-call-ID-preserving stubs** — #732 documented why per-recipient is not possible today (context is rendered once per turn into one prompt, and recall items carry no capability labels). The stub mechanism does not exist.

Refs #575

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789652425&installation_model_id=428086&pr_number=739&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F739&signature=33325a3507887d183df2619b2385a3368a61f91a8befc699399da06e91757eb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->