### PR TITLE
feat(#575): a room can forbid an outbound host

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,25 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — a room can forbid an outbound host
+
+- **Host-level egress (#575).** A `net:<host>` prohibition now narrows a
+  plugin's manifest outbound allow-list for the duration of a turn, enforced in
+  `ctx.http` — the accessor that already carries the manifest allow-list, the
+  SSRF guard and the rate limiter.
+- **It binds `public-web` audit mode too**, so a `web_scanner` plugin is not a
+  way around a host an operator forbade, and it is checked *before* the rate
+  limiter so a refused call costs the plugin nothing.
+- **Prohibitions only — the allow-side intersection is deliberately not
+  shipped.** Outbound hosts are granted by the plugin manifest, not by the grant
+  store, so intersecting would reduce every room's effective allow-list to the
+  empty set the moment the floor is switched on. A prohibition can only ever
+  narrow, and only where an operator wrote one.
+- `AudienceFloor` now exposes the union of prohibitions alongside the permitted
+  set: with only the difference, "explicitly forbidden" and "never granted" are
+  indistinguishable, and a consumer with its own allow-list has to tell them
+  apart.
+
 ### Added — one participant's prohibition binds the whole room
 
 - **The audience floor could express "may" but not "must not" (#575).** It

--- a/middleware/packages/harness-channel-sdk/src/audienceFloor.ts
+++ b/middleware/packages/harness-channel-sdk/src/audienceFloor.ts
@@ -134,7 +134,23 @@ export type Audience =
  * #333's role lookups.
  */
 export type AudienceFloor =
-  | { readonly outcome: 'open'; readonly capabilities: ReadonlySet<Capability> }
+  | {
+      readonly outcome: 'open';
+      readonly capabilities: ReadonlySet<Capability>;
+      /**
+       * The union of every explicit prohibition in the room, already subtracted
+       * from `capabilities` above.
+       *
+       * Exposed rather than discarded because "denied" and "never granted" are
+       * indistinguishable once only the difference survives — both simply mean
+       * "absent from `capabilities`". A consumer that has its own allow-list to
+       * narrow (the per-plugin HTTP accessor's outbound hosts, say) must be able
+       * to tell them apart: a capability nobody was granted says nothing about
+       * that list, while a capability somebody explicitly forbade has to be
+       * removed from it.
+       */
+      readonly denied: ReadonlySet<Capability>;
+    }
   | { readonly outcome: 'closed'; readonly reason: string };
 
 /** What #333's join hands back for one participant. */
@@ -267,6 +283,7 @@ export function audienceFloor(audience: Audience): AudienceFloor {
   return {
     outcome: 'open',
     capabilities: new Set([...capabilities].filter((c) => !denied.has(c))),
+    denied,
   };
 }
 
@@ -279,4 +296,34 @@ export function audienceFloor(audience: Audience): AudienceFloor {
  */
 export function floorPermits(floor: AudienceFloor, capability: Capability): boolean {
   return floor.outcome === 'open' && floor.capabilities.has(capability);
+}
+
+/**
+ * The capability token for reaching one outbound host.
+ *
+ * Hosts live in the same flat, opaque token space as everything else the floor
+ * intersects — `net:api.example.com` alongside `tool:send_email`. Giving them a
+ * structured type of their own would put a network model in the layer that is
+ * supposed to know nothing about what a capability means.
+ *
+ * Lower-cased because a hostname is case-insensitive, so `API.example.com` and
+ * `api.example.com` must not be two different prohibitions.
+ */
+export function hostCapability(host: string): Capability {
+  return `net:${host.trim().toLowerCase()}`;
+}
+
+/**
+ * Whether the room explicitly FORBIDS reaching `host`.
+ *
+ * Deliberately not the negation of {@link floorPermits}. A host absent from
+ * `capabilities` merely means nobody granted it through the floor — which says
+ * nothing, because outbound hosts are granted by a plugin's manifest, not by
+ * the grant store. Only an explicit prohibition may narrow that manifest list.
+ *
+ * A `closed` floor denies everything, so it denies every host too.
+ */
+export function floorDeniesHost(floor: AudienceFloor, host: string): boolean {
+  if (floor.outcome === 'closed') return true;
+  return floor.denied.has(hostCapability(host));
 }

--- a/middleware/packages/harness-channel-sdk/src/index.ts
+++ b/middleware/packages/harness-channel-sdk/src/index.ts
@@ -287,7 +287,9 @@ export {
 // already means "unknown" in `ChatParticipantsProvider`'s own contract.
 export {
   audienceFloor,
+  floorDeniesHost,
   floorPermits,
+  hostCapability,
   resolveAudience,
   type Audience,
   type AudienceFloor,

--- a/middleware/src/platform/audienceHostPolicy.ts
+++ b/middleware/src/platform/audienceHostPolicy.ts
@@ -1,0 +1,78 @@
+/**
+ * #575 — "may the current room reach this host?", for the per-plugin HTTP
+ * accessor.
+ *
+ * The issue asks for egress as "allowlist = intersection of allowed hosts,
+ * deny = union of denied hosts". This delivers the **deny half**, and the
+ * asymmetry in what is shipped is deliberate rather than partial work — see
+ * below.
+ *
+ * ## Why prohibitions can land now and the intersection cannot
+ *
+ * Outbound hosts are granted by a plugin's **manifest**, not by the grant
+ * store: `permissions.network.outbound` is what an operator approved at install
+ * time, and `createHttpAccessor` already enforces it. So the two directions are
+ * not symmetric here:
+ *
+ *  - A **prohibition** composes cleanly with that list. It can only narrow it,
+ *    it only applies where an operator explicitly wrote one, and a deployment
+ *    that has written none is unaffected.
+ *  - An **intersection** would need the floor to carry positive host grants for
+ *    every host every plugin may legitimately reach. Applying it before those
+ *    grants exist would reduce every room's effective allow-list to the empty
+ *    set — every plugin's HTTP calls refused, everywhere, the moment the floor
+ *    is switched on. That is the same failure the grant store's boot refusal
+ *    exists to prevent, and shipping it "for completeness" would make the
+ *    feature unusable rather than more complete.
+ *
+ * The intersection also needs something the floor does not expose yet: whether
+ * host policy was expressed *anywhere in the audience*. `AudienceFloor` carries
+ * the already-intersected capability set, so "no `net:` token survived" cannot
+ * be told apart from "nobody ever granted one" — the same distinction that made
+ * `denied` a separate field on the floor. Stated here so the remaining half is
+ * visible rather than assumed.
+ *
+ * ## Asked per request, never captured
+ *
+ * `ctx.http` is built once when a plugin activates; the audience changes within
+ * a turn. A denial resolved at construction time would be a snapshot of a room
+ * that may no longer exist — the same TOCTOU argument that makes the egress
+ * guard re-evaluate per tool call (spec §5.2).
+ */
+
+import { floorDeniesHost, type AudienceFloor } from '@omadia/channel-sdk';
+import { turnContext } from '@omadia/orchestrator';
+
+/**
+ * Resolve the current turn's floor and ask whether it forbids `host`.
+ *
+ * Returns `false` — not enforced — when no audience provider is installed,
+ * which is every deployment that has not opted into the floor. "Nobody
+ * configured this" must never read as "closed"; that rule is what keeps the
+ * whole cluster from disabling itself in deployments that never asked for it.
+ *
+ * A provider that THROWS is the opposite case and denies: the deployment did
+ * opt in, and an unresolvable audience must fail closed.
+ */
+export async function audienceDeniesHost(host: string): Promise<boolean> {
+  const provider = turnContext.current()?.audienceFloor;
+  if (!provider) return false;
+
+  let floor: AudienceFloor;
+  try {
+    floor = await provider();
+  } catch (err) {
+    console.warn(
+      `[platform] outbound host '${host}' refused — audience unresolvable: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return true;
+  }
+
+  const denied = floorDeniesHost(floor, host);
+  if (denied) {
+    console.warn(`[platform] outbound host '${host}' refused by the audience floor`);
+  }
+  return denied;
+}

--- a/middleware/src/platform/httpAccessor.ts
+++ b/middleware/src/platform/httpAccessor.ts
@@ -63,6 +63,19 @@ export function createHttpAccessor(opts: {
    *  uses undici's OWN fetch — it must match the guarded undici `Agent`, or
    *  the global (version-skewed) fetch throws "invalid onRequestStart method". */
   guardedFetch?: (url: string, init: Record<string, unknown>) => Promise<Response>;
+  /**
+   * #575 — "may the CURRENT ROOM reach this host at all", asked per request.
+   *
+   * Passed in rather than read from the orchestrator's turn context directly,
+   * so this module keeps knowing nothing about turns; the caller that builds a
+   * plugin context owns that wiring.
+   *
+   * It can only ever NARROW the manifest allow-list: a host absent from the
+   * floor's grants says nothing here, because outbound hosts are granted by the
+   * manifest, not by the grant store. Only an explicit prohibition subtracts.
+   * Absent ⇒ not enforced, the same rule every other audience guard follows.
+   */
+  audienceDeniesHost?: (host: string) => Promise<boolean>;
 }): HttpAccessor {
   const { agentId, outbound } = opts;
   const limit = opts.rateLimitPerMinute ?? DEFAULT_RATE_LIMIT_PER_MINUTE;
@@ -113,6 +126,15 @@ export function createHttpAccessor(opts: {
         rawHost.startsWith('[') && rawHost.endsWith(']')
           ? rawHost.slice(1, -1)
           : rawHost;
+
+      // #575 — the room's prohibition is checked BEFORE the mode branches, so
+      // it also binds `public-web`: a web_scanner must not be the way around a
+      // host an operator forbade. Also before the rate-limit bucket, so a
+      // refused call costs the plugin nothing — same ordering as the egress
+      // guard sitting ahead of the dispatch deadline.
+      if (opts.audienceDeniesHost && (await opts.audienceDeniesHost(host))) {
+        throw new HttpForbiddenError(agentId, host);
+      }
 
       if (mode === 'public-web') {
         // Any public host is permitted; the guarded dispatcher enforces the

--- a/middleware/src/platform/pluginContext.ts
+++ b/middleware/src/platform/pluginContext.ts
@@ -85,6 +85,7 @@ import type { PluginRouteRegistry } from './pluginRouteRegistry.js';
 import type { NotificationRouter } from './notificationRouter.js';
 import type { UiRouteCatalog } from './uiRouteCatalog.js';
 import { createHttpAccessor, isAuditMode, type AuditMode } from './httpAccessor.js';
+import { audienceDeniesHost } from './audienceHostPolicy.js';
 import { createNetAccessor, type NetTarget } from './netAccessor.js';
 import { signFlowState, verifyFlowState } from './flowState.js';
 import type { PluginStatusRegistry } from './pluginStatusRegistry.js';
@@ -399,6 +400,11 @@ export function createPluginContext(
           ...(auditConfig.auditMode
             ? { auditMode: auditConfig.auditMode }
             : {}),
+          // #575 — the room's host prohibitions, asked per request rather than
+          // captured here: the accessor is built once at activation and the
+          // audience changes within a turn, so a value bound now would be a
+          // snapshot of a room that no longer exists.
+          audienceDeniesHost,
         })
       : undefined;
 

--- a/middleware/test/audienceFloorGuard.test.ts
+++ b/middleware/test/audienceFloorGuard.test.ts
@@ -24,9 +24,14 @@ import { audienceGuardedAttachmentReader } from '../packages/harness-orchestrato
 import { turnContext } from '../packages/harness-orchestrator/src/turnContext.js';
 import type { AudienceFloor } from '../packages/harness-channel-sdk/src/audienceFloor.js';
 
+// `denied` is required on an open floor: a consumer with its own allow-list to
+// narrow must be able to tell "explicitly forbidden" from "never granted", and
+// an optional field would collapse the two. These cases are about the
+// capability set, so they carry no prohibitions.
 const open = (...caps: string[]): AudienceFloor => ({
   outcome: 'open',
   capabilities: new Set(caps),
+  denied: new Set<string>(),
 });
 const closed = (reason: string): AudienceFloor => ({ outcome: 'closed', reason });
 

--- a/middleware/test/audienceHostEgress.test.ts
+++ b/middleware/test/audienceHostEgress.test.ts
@@ -1,0 +1,201 @@
+/**
+ * #575 — host-level egress: a room's prohibition narrows a plugin's manifest
+ * allow-list.
+ *
+ * Two things are pinned here, and the second is the one that usually rots.
+ *
+ * **The rule.** A denied host is refused in EVERY audit mode, before the rate
+ * limiter, and independently of what the manifest allows. `public-web` in
+ * particular must not become the way around a host an operator forbade.
+ *
+ * **The wiring.** The check is an injected dependency, which is exactly the
+ * shape that gets declared and then never threaded — this repo has hit that
+ * defect repeatedly. So there is a test that the kernel's own plugin-context
+ * builder actually passes it, asserted against the real accessor rather than a
+ * hand-rolled double.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+
+import { HttpForbiddenError } from '@omadia/plugin-api';
+
+import {
+  audienceFloor,
+  floorDeniesHost,
+  hostCapability,
+  type Audience,
+  type Capability,
+  type Principal,
+} from '../packages/harness-channel-sdk/src/index.js';
+import { createHttpAccessor } from '../src/platform/httpAccessor.js';
+
+const ALICE: Principal = { kind: 'user', userId: 'alice' };
+const BOB: Principal = { kind: 'user', userId: 'bob' };
+
+function room(deny: Capability[] = [], allow: Capability[] = []): Audience {
+  return {
+    kind: 'known',
+    members: [
+      {
+        kind: 'resolved',
+        principal: ALICE,
+        capabilities: new Set(allow),
+        denials: new Set(deny),
+      },
+      {
+        kind: 'resolved',
+        principal: BOB,
+        capabilities: new Set(allow),
+        denials: new Set<Capability>(),
+      },
+    ],
+  };
+}
+
+/** A fetch that records what it was asked for and never leaves the process. */
+function spyFetch(): { fn: (u: string, i: Record<string, unknown>) => Promise<Response>; calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    fn: async (u: string) => {
+      calls.push(u);
+      return new Response('ok');
+    },
+  };
+}
+
+describe('#575 hostCapability / floorDeniesHost', () => {
+  it('lower-cases the host, because a hostname is case-insensitive', () => {
+    assert.equal(hostCapability('API.Example.COM'), 'net:api.example.com');
+    assert.equal(hostCapability('  api.example.com  '), 'net:api.example.com');
+  });
+
+  it('reports a denial regardless of whether anyone granted the host', () => {
+    // The distinction the `denied` field exists for: outbound hosts are granted
+    // by the MANIFEST, so "absent from capabilities" says nothing at all.
+    const floor = audienceFloor(room([hostCapability('evil.example.com')]));
+    assert.equal(floor.outcome, 'open');
+    assert.equal(floorDeniesHost(floor, 'evil.example.com'), true);
+    assert.equal(floorDeniesHost(floor, 'api.example.com'), false);
+  });
+
+  it('a closed floor denies every host', () => {
+    const closed = audienceFloor({ kind: 'unknown', reason: 'empty_roster' });
+    assert.equal(closed.outcome, 'closed');
+    assert.equal(floorDeniesHost(closed, 'api.example.com'), true);
+  });
+
+  it('one participant is enough — prohibitions union', () => {
+    // Alice carries the veto, Bob does not. The room is bound anyway.
+    const floor = audienceFloor(room([hostCapability('evil.example.com')]));
+    assert.equal(floorDeniesHost(floor, 'evil.example.com'), true);
+  });
+});
+
+describe('#575 the HTTP accessor honours a host prohibition', () => {
+  it('refuses a manifest-allowed host the room forbids', async () => {
+    const spy = spyFetch();
+    const http = createHttpAccessor({
+      agentId: 'test-plugin',
+      outbound: ['api.example.com'],
+      guardedFetch: spy.fn,
+      audienceDeniesHost: async (host) => host === 'api.example.com',
+    });
+    await assert.rejects(() => http.fetch('https://api.example.com/x'), HttpForbiddenError);
+    assert.deepEqual(spy.calls, []);
+  });
+
+  it('still allows a host the room says nothing about', async () => {
+    const http = createHttpAccessor({
+      agentId: 'test-plugin',
+      outbound: ['api.example.com'],
+      audienceDeniesHost: async () => false,
+    });
+    // Reaches the manifest check and passes it; the actual fetch is not made
+    // here because that would leave the process — the forbidden case above is
+    // what this pairs with.
+    await assert.rejects(
+      () => http.fetch('https://not-allowed.example.com/x'),
+      HttpForbiddenError,
+      'a host outside the manifest list is still refused by the existing rule',
+    );
+  });
+
+  it('binds public-web mode too — a scanner is not the way around a prohibition', async () => {
+    const spy = spyFetch();
+    const http = createHttpAccessor({
+      agentId: 'scanner-plugin',
+      outbound: [],
+      webScanner: true,
+      auditMode: 'public-web',
+      guardedFetch: spy.fn,
+      audienceDeniesHost: async (host) => host === 'evil.example.com',
+    });
+    await assert.rejects(() => http.fetch('https://evil.example.com/x'), HttpForbiddenError);
+    assert.deepEqual(spy.calls, [], 'the guarded dispatcher must never be reached');
+  });
+
+  it('is inert when no check is supplied', async () => {
+    // Every deployment that has not opted into the floor.
+    const http = createHttpAccessor({ agentId: 'test-plugin', outbound: ['api.example.com'] });
+    await assert.rejects(
+      () => http.fetch('https://blocked.example.com/x'),
+      HttpForbiddenError,
+      'the manifest rule is unchanged',
+    );
+  });
+
+  it('refuses before spending a rate-limit token', async () => {
+    // A refused call must cost the plugin nothing — same ordering as the egress
+    // guard sitting ahead of the dispatch deadline.
+    let denied = true;
+    const spy = spyFetch();
+    const http = createHttpAccessor({
+      agentId: 'test-plugin',
+      outbound: ['api.example.com'],
+      rateLimitPerMinute: 1,
+      webScanner: true,
+      auditMode: 'public-web',
+      guardedFetch: spy.fn,
+      audienceDeniesHost: async () => denied,
+    });
+
+    await assert.rejects(() => http.fetch('https://api.example.com/a'), HttpForbiddenError);
+    denied = false;
+    // The single token must still be there.
+    const res = await http.fetch('https://api.example.com/b');
+    assert.equal(res.status, 200);
+    assert.deepEqual(spy.calls, ['https://api.example.com/b']);
+  });
+});
+
+describe('#575 the kernel actually threads the check', () => {
+  it('the plugin-context builder passes audienceDeniesHost to the accessor', async () => {
+    // A guard against the defect shape this repo keeps hitting: an injection
+    // point declared and never threaded to its consumer. Asserting that the
+    // option merely EXISTS would test the compiler, not the wiring — so this
+    // reads the construction site itself.
+    //
+    // Crude, and deliberately so: the alternative is standing up a full plugin
+    // context, and a test that expensive is one nobody keeps working. What this
+    // catches is the case that actually happens — somebody removes the argument
+    // while everything still compiles, because the option is optional.
+    const source = await readFile(
+      new URL('../src/platform/pluginContext.ts', import.meta.url),
+      'utf8',
+    );
+    // The call body contains nested `})` (the conditional auditMode spread), so
+    // it is bounded by the assignment's terminator instead of by brace
+    // matching — the point is only that the argument sits inside THIS call.
+    const start = source.indexOf('createHttpAccessor({');
+    assert.notEqual(start, -1, 'the construction site itself must still exist');
+    const end = source.indexOf(': undefined;', start);
+    assert.notEqual(end, -1, 'the accessor is still built conditionally');
+    assert.ok(
+      source.slice(start, end).includes('audienceDeniesHost'),
+      'platform/pluginContext.ts must pass audienceDeniesHost into createHttpAccessor',
+    );
+  });
+});


### PR DESCRIPTION
The issue asks for egress as *"allowlist = intersection of allowed hosts, deny = union of denied hosts"*. This lands the **deny half**.

## First, a correction to what I reported earlier

I said there was no runtime host check anywhere and that host egress would mean building enforcement from scratch. **That was wrong** — I had searched for the wrong names. `ctx.http` / `createHttpAccessor` has enforced manifest outbound allow-listing, an SSRF guard and per-plugin rate limiting all along. This PR hooks into that, rather than inventing a second egress path beside it.

## What lands

A `net:<host>` prohibition narrows a plugin's manifest allow-list for the duration of a turn.

Two ordering decisions, both load-bearing:

- **Checked before the mode branches**, so it binds `public-web` too. A `web_scanner` plugin must not be the way around a host an operator forbade.
- **Checked before the rate-limit bucket**, so a refused call costs the plugin nothing — the same ordering that puts the egress guard ahead of the dispatch deadline.

## Why only the deny half — a decision, not partial work

Outbound hosts are granted by a plugin's **manifest**, not by the grant store: `permissions.network.outbound` is what an operator approved at install time.

That makes the two directions genuinely asymmetric *here*:

- A **prohibition** composes with that list cleanly. It can only narrow it, it applies only where an operator explicitly wrote one, and a deployment that has written none is unaffected.
- An **intersection** would need the floor to carry positive host grants for every host every plugin may legitimately reach. Applied before those grants exist, it would reduce every room's effective allow-list to the **empty set** the moment the floor is switched on — every plugin's HTTP call refused, everywhere. That is the same failure the grant store's boot refusal exists to prevent, and shipping it "for completeness" would make the feature unusable rather than more complete.

The intersection also needs something the floor still does not expose: whether host policy was expressed *anywhere in the audience*. `AudienceFloor` carries the already-intersected set, so "no `net:` token survived" cannot be told apart from "nobody ever granted one".

## `AudienceFloor` now exposes its prohibitions

New `denied` field on the open variant: the union of every prohibition in the room, already subtracted from `capabilities`.

Without it this PR is impossible. A host absent from `capabilities` says **nothing** — outbound hosts are never granted through the floor in the first place — so "explicitly forbidden" and "never granted" collapse into the same observation. A consumer with its own allow-list to narrow has to tell them apart.

It is a **required** field for the same reason `denials` was in #739: an optional one that a caller forgets to thread reads as "nothing forbidden", which is the direction that widens. The #573 ratchet found the one test helper that needed it — **fixed, not baselined** (still 406).

## The injection is tested, not just declared

`audienceDeniesHost` is passed into the accessor rather than read from the turn context there, so `httpAccessor` keeps knowing nothing about turns.

That shape — an injection point declared and never threaded to its consumer — is one this repo has hit repeatedly, and an optional option makes it compile either way. So a test reads the kernel's construction site and asserts the argument is actually passed. Crude on purpose; the mutation table below shows it bites.

## Blast radius

| Surface | Effect |
|---|---|
| Deployments with `AUDIENCE_FLOOR_ENABLED` unset | **none** — no provider, the check returns "not enforced" |
| Deployments with it set, no `net:` denials recorded | **none** — a prohibition only applies where one was written |
| Deployments with `net:` denials | that host is refused in every audit mode, for the turn |
| Plugins | none — `ctx.http` throws the `HttpForbiddenError` they already handle |

## Verification

- middleware suite: **6706 tests, 0 fail, 0 cancelled** (10 new)
- `npm run typecheck` ✅ · `npm run lint` ✅ · #470 ratchet **3294** ✅ · #573 ratchet **406, unchanged** ✅

**Mutation-checked — all five died:**

| Mutation | Result |
|---|---|
| do not check at all | kills 3 |
| move the check after the rate limiter | kills 1 |
| read "not permitted" instead of the denial set | kills 1 |
| a closed floor stops denying hosts | kills 1 |
| the kernel stops threading the option | kills the wiring test |

## What #575 still names

- **the allow-side host intersection** — needs positive host grants and a way to know host policy was expressed at all (above);
- **per-recipient context filtering with tool-call-ID-preserving stubs** — #732 measured why this is not possible today: context is rendered once per turn into one prompt, and recall items carry no capability labels.

Refs #575

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789656879&installation_model_id=428086&pr_number=740&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F740&signature=d36e4a40aad5a0d9b8e9a4c4745df07e975019fdf3593108a8c82b935b51a0fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->