### PR TITLE
feat(#575): read outbound hosts as an allow-list, behind a flag

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,23 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — outbound hosts can be read as an allow-list, not just prohibitions
+
+- **`AUDIENCE_HOST_ALLOWLIST_ENABLED` (default off, #575).** With it, a host must
+  also be granted through the audience floor — `net:<host>` per host, or `net:*`
+  for unrestricted — and the grants intersect across everyone present. This is
+  the "allowlist = intersection of allowed hosts" half of the issue.
+- **Off by default because switching it on is consequential**, not out of
+  caution: outbound hosts are granted by a plugin's manifest, so a room whose
+  participants hold no host grants reaches nothing at all. Seed grants first.
+- **A prohibition beats `net:*`.** The unrestricted grant is a convenience for
+  operators who should not have to enumerate hosts; if it also overrode an
+  explicit veto, the veto would be worthless exactly where it matters, since
+  `net:*` is what a broad role is most likely to carry.
+- **`net:*` intersects like any other capability** — the room is unrestricted
+  only when *everyone* present is. One host-restricted participant restricts the
+  room.
+
 ### Added — a room can forbid an outbound host
 
 - **Host-level egress (#575).** A `net:<host>` prohibition now narrows a

--- a/middleware/packages/harness-channel-sdk/src/audienceFloor.ts
+++ b/middleware/packages/harness-channel-sdk/src/audienceFloor.ts
@@ -314,6 +314,45 @@ export function hostCapability(host: string): Capability {
 }
 
 /**
+ * "May reach any host at all."
+ *
+ * The escape hatch that makes the host allow-list usable. Without it an
+ * operator switching the intersection on would have to enumerate, per
+ * principal, every host every installed plugin might legitimately reach — and
+ * anything they missed would break silently at the worst moment.
+ *
+ * It is an ordinary capability, so it INTERSECTS like every other one: the room
+ * is unrestricted only when *everyone present* is. One host-restricted
+ * participant restricts the room, which is the whole point of a floor.
+ */
+export const UNRESTRICTED_HOST_CAPABILITY: Capability = 'net:*';
+
+/**
+ * Whether the room may reach `host`, under the allow-list reading.
+ *
+ * Only consulted by deployments that switched the host allow-list on. The
+ * default reading is {@link floorDeniesHost} — prohibitions only — because
+ * outbound hosts are granted by a plugin's manifest, so intersecting before
+ * positive host grants exist would bound every room to nothing.
+ *
+ * Order matters and is not interchangeable:
+ *
+ *  1. a `closed` floor allows nothing;
+ *  2. an explicit **prohibition wins over everything**, including `net:*` —
+ *     otherwise the unrestricted grant would quietly undo an operator's veto,
+ *     which is the one thing a veto must survive;
+ *  3. `net:*` allows the rest;
+ *  4. otherwise the host must be granted by name.
+ */
+export function floorAllowsHost(floor: AudienceFloor, host: string): boolean {
+  if (floor.outcome === 'closed') return false;
+  const token = hostCapability(host);
+  if (floor.denied.has(token)) return false;
+  if (floor.capabilities.has(UNRESTRICTED_HOST_CAPABILITY)) return true;
+  return floor.capabilities.has(token);
+}
+
+/**
  * Whether the room explicitly FORBIDS reaching `host`.
  *
  * Deliberately not the negation of {@link floorPermits}. A host absent from

--- a/middleware/packages/harness-channel-sdk/src/index.ts
+++ b/middleware/packages/harness-channel-sdk/src/index.ts
@@ -287,6 +287,8 @@ export {
 // already means "unknown" in `ChatParticipantsProvider`'s own contract.
 export {
   audienceFloor,
+  UNRESTRICTED_HOST_CAPABILITY,
+  floorAllowsHost,
   floorDeniesHost,
   floorPermits,
   hostCapability,

--- a/middleware/src/config.ts
+++ b/middleware/src/config.ts
@@ -207,6 +207,24 @@ const ConfigSchema = z.object({
     .transform((v) => v === 'true')
     .default(false),
 
+  // #575 — read the audience floor's host policy as an ALLOW-LIST rather than
+  // as prohibitions only.
+  //
+  // Off by default, and this default is not caution — it is the difference
+  // between a usable feature and a broken deployment. Outbound hosts are
+  // granted by a plugin's MANIFEST (`permissions.network.outbound`), never by
+  // the grant store. Switching this on means every host a room may reach must
+  // ALSO be granted through the floor, per principal, and anything not granted
+  // is refused. Grant `net:*` to principals who should stay unrestricted, and
+  // `net:<host>` for the narrow ones, BEFORE setting this.
+  //
+  // Requires AUDIENCE_FLOOR_ENABLED; without a floor there is no room to
+  // intersect and the setting does nothing.
+  AUDIENCE_HOST_ALLOWLIST_ENABLED: z
+    .enum(['true', 'false'])
+    .transform((v) => v === 'true')
+    .default(false),
+
   // Local-dev endpoints (raw graph browser, memory browser, …) under /api/dev.
   //
   // Issue #669: these used to mount WITHOUT authentication, so this flag alone

--- a/middleware/src/platform/audienceHostPolicy.ts
+++ b/middleware/src/platform/audienceHostPolicy.ts
@@ -40,8 +40,10 @@
  * guard re-evaluate per tool call (spec §5.2).
  */
 
-import { floorDeniesHost, type AudienceFloor } from '@omadia/channel-sdk';
+import { floorAllowsHost, floorDeniesHost, type AudienceFloor } from '@omadia/channel-sdk';
 import { turnContext } from '@omadia/orchestrator';
+
+import { config } from '../config.js';
 
 /**
  * Resolve the current turn's floor and ask whether it forbids `host`.
@@ -70,9 +72,30 @@ export async function audienceDeniesHost(host: string): Promise<boolean> {
     return true;
   }
 
-  const denied = floorDeniesHost(floor, host);
+  const denied = allowlistMode()
+    ? !floorAllowsHost(floor, host)
+    : floorDeniesHost(floor, host);
   if (denied) {
-    console.warn(`[platform] outbound host '${host}' refused by the audience floor`);
+    console.warn(
+      `[platform] outbound host '${host}' refused by the audience floor (${
+        allowlistMode() ? 'allow-list' : 'prohibitions'
+      } mode)`,
+    );
   }
   return denied;
+}
+
+/**
+ * Whether this deployment reads host policy as an allow-list.
+ *
+ * Read per call rather than captured at module load so a test — and an operator
+ * restarting into a different setting — sees the current value rather than
+ * whichever one happened to be set when this file was first imported.
+ *
+ * Gated on the floor being enabled at all: without a floor there is no room to
+ * intersect, and honouring the allow-list flag alone would refuse every
+ * outbound call in a deployment that never opted into audience control.
+ */
+function allowlistMode(): boolean {
+  return config.AUDIENCE_FLOOR_ENABLED && config.AUDIENCE_HOST_ALLOWLIST_ENABLED;
 }

--- a/middleware/test/audienceHostAllowlist.test.ts
+++ b/middleware/test/audienceHostAllowlist.test.ts
@@ -1,0 +1,128 @@
+/**
+ * #575 — the allow-list half of host egress.
+ *
+ * `floorDeniesHost` (#740) narrows a plugin's manifest list by prohibitions.
+ * This is the other direction: when a deployment opts in, a host must ALSO be
+ * granted through the floor, and the grants intersect across the room.
+ *
+ * The cases worth pinning are the ones where an intuitive implementation is
+ * wrong in a way nobody notices:
+ *
+ *  - **a prohibition must beat `net:*`.** The unrestricted grant is a
+ *    convenience so operators need not enumerate hosts; if it also overrode an
+ *    explicit veto, the veto would be worth nothing — and `net:*` is exactly
+ *    the grant a broad role is most likely to carry.
+ *  - **`net:*` must intersect like any other capability.** One host-restricted
+ *    participant restricts the room. Special-casing it as "somebody is
+ *    unrestricted, so the room is" inverts the floor.
+ *  - **a room where nobody holds host grants reaches nothing** once the
+ *    allow-list is on. That is correct and it is also the reason the mode is
+ *    off by default.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  UNRESTRICTED_HOST_CAPABILITY,
+  audienceFloor,
+  floorAllowsHost,
+  floorDeniesHost,
+  hostCapability,
+  type Audience,
+  type Capability,
+  type Principal,
+} from '../packages/harness-channel-sdk/src/index.js';
+
+const ALICE: Principal = { kind: 'user', userId: 'alice' };
+const BOB: Principal = { kind: 'user', userId: 'bob' };
+
+function room(
+  alice: { allow?: Capability[]; deny?: Capability[] },
+  bob: { allow?: Capability[]; deny?: Capability[] } = {},
+): Audience {
+  const mk = (principal: Principal, spec: { allow?: Capability[]; deny?: Capability[] }) => ({
+    kind: 'resolved' as const,
+    principal,
+    capabilities: new Set(spec.allow ?? []),
+    denials: new Set(spec.deny ?? []),
+  });
+  return { kind: 'known', members: [mk(ALICE, alice), mk(BOB, bob)] };
+}
+
+const API = hostCapability('api.example.com');
+const OTHER = hostCapability('other.example.com');
+
+describe('#575 floorAllowsHost — the intersection reading', () => {
+  it('allows a host both participants were granted', () => {
+    const floor = audienceFloor(room({ allow: [API] }, { allow: [API] }));
+    assert.equal(floorAllowsHost(floor, 'api.example.com'), true);
+  });
+
+  it('refuses a host only one participant was granted', () => {
+    const floor = audienceFloor(room({ allow: [API] }, { allow: [OTHER] }));
+    assert.equal(floorAllowsHost(floor, 'api.example.com'), false);
+    assert.equal(floorAllowsHost(floor, 'other.example.com'), false);
+  });
+
+  it('refuses everything when nobody holds host grants', () => {
+    // Correct under the intersection, and precisely why the mode is opt-in:
+    // switching it on without seeding grants bounds every room to nothing.
+    const floor = audienceFloor(room({}, {}));
+    assert.equal(floorAllowsHost(floor, 'api.example.com'), false);
+  });
+
+  it('lower-cases the host, matching hostCapability', () => {
+    const floor = audienceFloor(room({ allow: [API] }, { allow: [API] }));
+    assert.equal(floorAllowsHost(floor, 'API.Example.COM'), true);
+  });
+
+  it('a closed floor allows nothing', () => {
+    const closed = audienceFloor({ kind: 'unknown', reason: 'no_provider' });
+    assert.equal(floorAllowsHost(closed, 'api.example.com'), false);
+  });
+});
+
+describe('#575 net:* — the escape hatch, and its limits', () => {
+  it('allows any host when EVERY participant is unrestricted', () => {
+    const floor = audienceFloor(
+      room({ allow: [UNRESTRICTED_HOST_CAPABILITY] }, { allow: [UNRESTRICTED_HOST_CAPABILITY] }),
+    );
+    assert.equal(floorAllowsHost(floor, 'anything.example.com'), true);
+  });
+
+  it('does NOT allow when only one participant is unrestricted', () => {
+    // net:* is an ordinary capability and intersects like one. Treating it as
+    // "somebody is unrestricted, so the room is" would invert the floor.
+    const floor = audienceFloor(room({ allow: [UNRESTRICTED_HOST_CAPABILITY] }, { allow: [API] }));
+    assert.equal(floorAllowsHost(floor, 'anything.example.com'), false);
+    // …and the named host Bob holds is not rescued either: Alice does not
+    // carry it, so the intersection drops it.
+    assert.equal(floorAllowsHost(floor, 'api.example.com'), false);
+  });
+
+  it('a prohibition beats net:*', () => {
+    // The one thing a veto must survive. net:* is what a broad role is most
+    // likely to carry, so if it overrode prohibitions the veto would be
+    // worthless exactly where it matters.
+    const floor = audienceFloor(
+      room(
+        { allow: [UNRESTRICTED_HOST_CAPABILITY], deny: [API] },
+        { allow: [UNRESTRICTED_HOST_CAPABILITY] },
+      ),
+    );
+    assert.equal(floorAllowsHost(floor, 'other.example.com'), true);
+    assert.equal(floorAllowsHost(floor, 'api.example.com'), false);
+  });
+});
+
+describe('#575 the two readings stay distinct', () => {
+  it('a host nobody granted is NOT denied — it is merely not allowed', () => {
+    // The distinction #740 introduced `denied` for. Under prohibitions-only
+    // this host is reachable (the manifest decides); under the allow-list it is
+    // not. Collapsing the two readings would silently change every deployment.
+    const floor = audienceFloor(room({}, {}));
+    assert.equal(floorDeniesHost(floor, 'api.example.com'), false, 'not forbidden');
+    assert.equal(floorAllowsHost(floor, 'api.example.com'), false, 'but not granted either');
+  });
+});

--- a/middleware/test/audienceHostPolicyMode.test.ts
+++ b/middleware/test/audienceHostPolicyMode.test.ts
@@ -1,0 +1,147 @@
+/**
+ * #575 — the host-policy MODE switch actually switches something.
+ *
+ * `audienceHostPolicy.audienceDeniesHost` reads two flags and picks between two
+ * readings of the same floor:
+ *
+ *  - prohibitions only (the default): a host is refused when explicitly denied;
+ *  - allow-list: a host is refused unless the room was granted it.
+ *
+ * A flag that is declared, documented and never consulted is a defect this repo
+ * has shipped before, and here it would be invisible in the worst direction —
+ * an operator switching the allow-list on would believe egress is now bounded
+ * while every manifest host stayed reachable. So the switch is exercised
+ * end-to-end rather than assumed.
+ *
+ * ## Two traps this file walked into first, worth recording
+ *
+ * 1. **`turnContext` must be imported the way the module under test imports
+ *    it.** `audienceHostPolicy` resolves `@omadia/orchestrator` (the built
+ *    package); a test importing `../packages/harness-orchestrator/src/…` gets a
+ *    DIFFERENT AsyncLocalStorage instance, so the provider it installs is
+ *    invisible to the code under test and every verdict silently becomes "no
+ *    provider ⇒ not enforced". The tests still pass wherever `false` is the
+ *    expected answer, which is exactly how this stays hidden.
+ *
+ * 2. **`config` is parsed once at import**, so setting `process.env` before a
+ *    cache-busted re-import does not change it — the second import gets fresh
+ *    module code and the same cached config. The flags are therefore set on the
+ *    config object itself, which is what `allowlistMode()` actually reads.
+ */
+
+import { strict as assert } from 'node:assert';
+import { afterEach, describe, it } from 'node:test';
+
+import { turnContext } from '@omadia/orchestrator';
+
+import {
+  audienceFloor,
+  hostCapability,
+  type Audience,
+  type AudienceFloor,
+  type Capability,
+  type Principal,
+} from '../packages/harness-channel-sdk/src/index.js';
+import { config } from '../src/config.js';
+import { audienceDeniesHost } from '../src/platform/audienceHostPolicy.js';
+
+const ALICE: Principal = { kind: 'user', userId: 'alice' };
+
+const original = {
+  floor: config.AUDIENCE_FLOOR_ENABLED,
+  allowlist: config.AUDIENCE_HOST_ALLOWLIST_ENABLED,
+};
+
+afterEach(() => {
+  setFlags(original.floor, original.allowlist);
+});
+
+function setFlags(floor: boolean, allowlist: boolean): void {
+  (config as { AUDIENCE_FLOOR_ENABLED: boolean }).AUDIENCE_FLOOR_ENABLED = floor;
+  (config as { AUDIENCE_HOST_ALLOWLIST_ENABLED: boolean }).AUDIENCE_HOST_ALLOWLIST_ENABLED =
+    allowlist;
+}
+
+function floorWith(allow: Capability[], deny: Capability[]): AudienceFloor {
+  const audience: Audience = {
+    kind: 'known',
+    members: [
+      {
+        kind: 'resolved',
+        principal: ALICE,
+        capabilities: new Set(allow),
+        denials: new Set(deny),
+      },
+    ],
+  };
+  return audienceFloor(audience);
+}
+
+async function ask(floor: AudienceFloor, host: string): Promise<boolean> {
+  return turnContext.run(
+    { turnId: 't', turnDate: '2026-08-19', audienceFloor: async () => floor },
+    () => audienceDeniesHost(host),
+  );
+}
+
+describe('#575 host-policy mode switch', () => {
+  it('prohibitions-only: an ungranted host is reachable', async () => {
+    // The manifest decides. This is the shipped default, and it is what keeps
+    // #740 from changing any existing deployment.
+    setFlags(true, false);
+    assert.equal(await ask(floorWith([], []), 'api.example.com'), false);
+  });
+
+  it('prohibitions-only: an explicitly denied host is refused', async () => {
+    setFlags(true, false);
+    assert.equal(
+      await ask(floorWith([], [hostCapability('api.example.com')]), 'api.example.com'),
+      true,
+    );
+  });
+
+  it('allow-list: the same ungranted host is refused', async () => {
+    // Same floor, same host, opposite verdict — the whole point of the flag,
+    // and what a declared-but-unread flag would fail to produce.
+    setFlags(true, true);
+    assert.equal(await ask(floorWith([], []), 'api.example.com'), true);
+  });
+
+  it('allow-list: a granted host is reachable again', async () => {
+    setFlags(true, true);
+    assert.equal(
+      await ask(floorWith([hostCapability('api.example.com')], []), 'api.example.com'),
+      false,
+    );
+  });
+
+  it('the allow-list flag alone does nothing without the floor', async () => {
+    // Honouring it on its own would refuse every outbound call in a deployment
+    // that never opted into audience control at all.
+    setFlags(false, true);
+    assert.equal(await ask(floorWith([], []), 'api.example.com'), false);
+  });
+
+  it('no provider installed ⇒ not enforced, in either mode', async () => {
+    setFlags(true, true);
+    const verdict = await turnContext.run({ turnId: 't', turnDate: '2026-08-19' }, () =>
+      audienceDeniesHost('api.example.com'),
+    );
+    assert.equal(verdict, false);
+  });
+
+  it('a throwing provider refuses — the deployment opted in', async () => {
+    setFlags(true, false);
+    const verdict = await turnContext.run(
+      {
+        turnId: 't',
+        turnDate: '2026-08-19',
+        audienceFloor: async () => {
+          throw new Error('directory down');
+        },
+      },
+      () => audienceDeniesHost('api.example.com'),
+    );
+    assert.equal(verdict, true);
+  });
+});


### PR DESCRIPTION
The other half of *"allowlist = intersection of allowed hosts, deny = union of denied hosts"*.

#740 landed the deny half and stated why the intersection could not simply follow: outbound hosts are granted by a plugin's **manifest**, so intersecting before positive host grants exist would bound every room to nothing the moment the floor is switched on.

The answer is not to *derive* the mode from whether any host grant happens to exist — that would make granting one person one host silently change how every room behaves. It is an explicit operator decision: **`AUDIENCE_HOST_ALLOWLIST_ENABLED`**, default off, gated on the floor being enabled at all.

## What it does

With the flag on, a host must also be granted through the floor, and the grants **intersect** across everyone present:

- `net:<host>` — this principal may reach that host
- `net:*` — this principal is unrestricted

`net:*` exists because without it an operator switching this on would have to enumerate, per principal, every host every installed plugin might legitimately reach — and anything missed would break silently at the worst moment.

## Two orderings that are not interchangeable

**A prohibition beats `net:*`.** `net:*` is exactly the grant a broad role is most likely to carry, so if it also overrode an explicit veto the veto would be worthless precisely where it matters. Deny is checked first.

**`net:*` intersects like any other capability.** The room is unrestricted only when *everyone present* is. Special-casing it as "somebody here is unrestricted, so the room is" would invert what a floor is.

## The consequence I would rather state than bury

Once the flag is on, **a room whose participants hold no host grants reaches nothing at all**. That is the intersection behaving correctly, and it is the whole reason the flag exists instead of the mode being inferred. Seed grants first; the config comment says so at the setting itself.

The enforcement point is untouched: `httpAccessor` still calls one injected `audienceDeniesHost`, and the policy module decides which reading to apply. No second egress path.

## Two test traps, both of which produced silently-passing tests first

Recording these because each one *looked* green:

1. **`turnContext` must be imported the way the module under test imports it.** `audienceHostPolicy` resolves `@omadia/orchestrator` (the built package); a test importing `packages/harness-orchestrator/src/…` gets a **different** `AsyncLocalStorage`, so the provider it installs is invisible to the code under test and every verdict degrades to *"no provider ⇒ not enforced"*. That still passes wherever `false` is the expected answer — which is how it hides.
2. **`config` is parsed once at import**, so setting `process.env` before a cache-busted re-import changes nothing: the second import gets fresh module code and the same cached config.

## Blast radius

| Surface | Effect |
|---|---|
| `AUDIENCE_HOST_ALLOWLIST_ENABLED` unset | **none** — the prohibitions reading from #740 is unchanged |
| Flag set without `AUDIENCE_FLOOR_ENABLED` | **none** — honouring it alone would refuse every outbound call in a deployment that never opted in |
| Flag set, grants seeded | hosts intersect across the room |
| Plugins | none — `ctx.http` throws the `HttpForbiddenError` they already handle |

## Verification

- middleware suite: **6722 tests, 0 fail, 0 cancelled** (17 new)
- `npm run typecheck` ✅ · `npm run lint` ✅ · #470 ratchet **3294** ✅ · #573 ratchet **406, unchanged** ✅

**Mutation-checked — all seven died:**

| Mutation | Result |
|---|---|
| `net:*` checked before the prohibition | kills 1 |
| prohibitions ignored in the allow-list reading | kills 1 |
| a closed floor allowing hosts | kills 1 |
| matching the raw host instead of via `hostCapability` | kills 1 |
| the mode flag never consulted | kills 1 |
| the allow-list flag honoured without the floor | kills 1 |
| a throwing provider treated as not-enforced | kills 1 |

## #575 after this

Egress is complete in both directions. The one remaining item from the issue text is **per-recipient context filtering with tool-call-ID-preserving stubs** — #732 measured why it is not possible today, and it is the next thing I am picking up.

Refs #575

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789705630&installation_model_id=428086&pr_number=741&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F741&signature=1618f533ab1b6dbbc09b793a960f31c681903b7b9284e0c48eed9e804dc7d81d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->