### PR TITLE
feat(#575): a restricted room narrows its recall instead of losing it

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,21 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Changed — a restricted room narrows its recall instead of losing it
+
+- **`memory:recall:cross_scope` (#575).** Recall used to be all-or-nothing: a
+  room that could not satisfy `memory:recall` got no prior context at all. A
+  room can now hold `memory:recall` without the new capability — it recalls its
+  **own** history and drops hits from other conversations.
+- **Why it matters:** recall is ACL-gated by the *recalling* user, so in a
+  shared room a hit from that person's other chats lands in the single prompt
+  everyone's answer is derived from. Only one participant was entitled to it.
+- **The cross-session legs are skipped too** — plans, processes and curated
+  insights bypass the candidate pool and render their own blocks, so filtering
+  candidates alone would have looked thorough while letting those through.
+- Dropped hits are recorded as exclusions with reason `audience-scope`, so a
+  thin context block is explainable rather than mysterious.
+
 ### Added — outbound hosts can be read as an allow-list, not just prohibitions
 
 - **`AUDIENCE_HOST_ALLOWLIST_ENABLED` (default off, #575).** With it, a host must

--- a/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
@@ -240,6 +240,25 @@ export interface AssembleForBudgetInput {
    * (direct-retriever callers and sub-agents are unaffected).
    */
   agentScopePrefix?: string;
+  /**
+   * #575 — admit only turns from THIS conversation, dropping cross-session
+   * hits before they are rendered.
+   *
+   * Set by the orchestrator when the audience floor is installed and the room
+   * does not hold `memory:recall:cross_scope`. Recall is ACL-gated by the
+   * RECALLING user (`viewerOmadiaUserId`), so in a shared room a hit from that
+   * person's other conversations lands in the one prompt everyone's answer is
+   * derived from — the participant it belongs to is the only one entitled to
+   * it, and the rest of the room never asked for it.
+   *
+   * It has to be applied HERE rather than by the caller: `build` returns
+   * rendered text, so a consumer filtering `sources` afterwards would be
+   * editing a trace, not the prompt.
+   *
+   * Undefined ⇒ unrestricted, which is every deployment that has not opted into
+   * the floor and every 1:1 conversation.
+   */
+  restrictToScope?: string;
   /** Optional override; otherwise `defaultBudgetTokens` from ContextRetriever-Opts. */
   budget?: { tokens: number };
 }
@@ -265,7 +284,7 @@ export interface AssembledHit {
 
 export interface AssembledExclusion {
   turnId: string;
-  reason: 'budget-exceeded' | 'agent-blocked';
+  reason: 'budget-exceeded' | 'agent-blocked' | 'audience-scope';
 }
 
 // Cross-session recall payload types (RecalledContext / RecalledPlan /
@@ -538,8 +557,16 @@ export class ContextRetriever {
     // continuation) would otherwise surface the most-recent-N plans/processes/
     // insights regardless of relevance — the "earlier sessions" panel showing
     // unrelated content. In-session recall (tail / entity / FTS) is unaffected.
+    //
+    // #575 adds a second, independent reason to skip them: a room restricted to
+    // its own scope must not receive plans, processes or curated insights from
+    // other sessions either. They bypass the candidate pool entirely and are
+    // rendered as their own blocks, so the scope filter further down would never
+    // see them — gating here is what makes that filter honest rather than
+    // partial.
     const runCrossSessionRecall =
-      !this.opts.recallRequiresTerms || extractedTerms.length > 0;
+      input.restrictToScope === undefined &&
+      (!this.opts.recallRequiresTerms || extractedTerms.length > 0);
     const emptyPlans: Promise<RecalledPlan[]> = Promise.resolve([]);
     const emptyProcesses: Promise<RecalledProcess[]> = Promise.resolve([]);
     const emptyMemory: Promise<MemoryRecallHit[]> = Promise.resolve([]);
@@ -630,6 +657,14 @@ export class ContextRetriever {
     const excluded: AssembledExclusion[] = [];
     const filtered: CandidateHit[] = [];
     for (const c of candidates) {
+      // #575 — drop hits from other conversations before ranking, so a
+      // restricted room narrows its recall instead of losing it entirely.
+      // Recorded as an exclusion rather than skipped silently: an operator
+      // looking at a thin context block needs to see that the floor trimmed it.
+      if (input.restrictToScope !== undefined && c.scope !== input.restrictToScope) {
+        excluded.push({ turnId: c.turnId, reason: 'audience-scope' });
+        continue;
+      }
       const pri = prioritiesIndex.get(c.turnId);
       if (pri?.action === 'block') {
         excluded.push({ turnId: c.turnId, reason: 'agent-blocked' });

--- a/middleware/packages/harness-orchestrator/src/audienceFloorGuard.ts
+++ b/middleware/packages/harness-orchestrator/src/audienceFloorGuard.ts
@@ -210,6 +210,50 @@ export async function guardContextRecall(): Promise<string | undefined> {
 }
 
 /**
+ * The capability recalling from OTHER conversations requires.
+ *
+ * Separate from {@link MEMORY_RECALL_CAPABILITY}, because the two questions are
+ * not the same one. Recall is ACL-gated by the RECALLING user, so a hit from
+ * their other conversations lands in the single prompt everyone's answer is
+ * derived from — the room learns something only one participant was entitled
+ * to, and never asked for.
+ *
+ * Splitting it turns the previous all-or-nothing into a narrowing: a room that
+ * holds `memory:recall` but not this one still recalls its OWN history, and
+ * only cross-session hits are dropped. #732 named the missing granularity as a
+ * limitation; this is the part of it that today's data actually supports,
+ * because recall hits carry a `scope` even though they carry no entitlement
+ * labels.
+ */
+export const CROSS_SCOPE_RECALL_CAPABILITY: Capability = 'memory:recall:cross_scope';
+
+/**
+ * Whether recall must be restricted to the current conversation.
+ *
+ * Returns `false` — unrestricted — when no provider is installed, the same
+ * "not enforced ≠ closed" rule as every other guard here. A `closed` floor is
+ * not answered here at all: {@link guardContextRecall} has already refused the
+ * whole recall by then, and answering "restrict" would suggest something still
+ * gets through.
+ */
+export async function crossScopeRecallRefused(): Promise<boolean> {
+  const provider = turnContext.current()?.audienceFloor;
+  if (!provider) return false;
+
+  let floor: AudienceFloor;
+  try {
+    floor = await provider();
+  } catch {
+    // An unresolvable audience restricts. The turn is not aborted — the
+    // recall simply stays inside the room, which is the safe half of what
+    // `guardContextRecall` would do with the same failure.
+    return true;
+  }
+
+  return !floorPermits(floor, CROSS_SCOPE_RECALL_CAPABILITY);
+}
+
+/**
  * Check whether the current audience permits dispatching `name`.
  *
  * Returns `undefined` when the call may proceed — including when no provider is

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -203,7 +203,11 @@ import {
   turnContext,
   type TurnContextValue,
 } from './turnContext.js';
-import { guardContextRecall, guardToolEgress } from './audienceFloorGuard.js';
+import {
+  crossScopeRecallRefused,
+  guardContextRecall,
+  guardToolEgress,
+} from './audienceFloorGuard.js';
 import {
   createAudienceFloorProvider,
   knowledgeGraphPrincipalResolver,
@@ -2682,6 +2686,18 @@ export class Orchestrator {
       console.error(`[context] SKIP audience-floor: ${recallRefusal}`);
       return { text: undefined, recalled: undefined };
     }
+    // #575 — a room that may recall, but may not recall from OTHER
+    // conversations, narrows instead of losing recall entirely. Only meaningful
+    // when this turn HAS a scope to be restricted to; without one there is
+    // nothing to compare a hit against, so the restriction would silently drop
+    // every candidate rather than the cross-session ones.
+    const restrictRecallScope =
+      input.sessionScope !== undefined && (await crossScopeRecallRefused())
+        ? graphScopeFor(this.agentId, input.sessionScope)
+        : undefined;
+    if (restrictRecallScope !== undefined) {
+      console.error('[context] audience-floor: recall restricted to this conversation');
+    }
     try {
       // OB-74 (Palaia Phase 5) — switch to the token-budget assembler. The
       // recall legs are unchanged (tail + entity + hybrid-FTS); the
@@ -2704,6 +2720,9 @@ export class Orchestrator {
           ? { sessionScope: graphScopeFor(this.agentId, input.sessionScope) }
           : {}),
         ...(input.userId ? { userId: input.userId } : {}),
+        ...(restrictRecallScope !== undefined
+          ? { restrictToScope: restrictRecallScope }
+          : {}),
       });
       console.error(
         `[context] assembled scope=${input.sessionScope ?? '-'} user=${input.userId ?? '-'} pool=${String(result.stats.candidatePool)} included=${String(result.included.length)} excluded=${String(result.excluded.length)} compact=${String(result.stats.compactMode)} tokens=${String(result.stats.tokensUsed)} rendered=${String(result.text.length)}B`,

--- a/middleware/test/audienceScopedRecall.test.ts
+++ b/middleware/test/audienceScopedRecall.test.ts
@@ -1,0 +1,136 @@
+/**
+ * #575 — a restricted room narrows its recall instead of losing it.
+ *
+ * #732 gated recall all-or-nothing on `memory:recall`, and said the missing
+ * per-item granularity was a measured limitation. Part of it turned out to be
+ * available after all: recall hits carry a `scope`, even though they carry no
+ * entitlement labels.
+ *
+ * So a room can now hold `memory:recall` without
+ * `memory:recall:cross_scope` — it recalls its OWN history and drops hits from
+ * other conversations. That matters because recall is ACL-gated by the
+ * RECALLING user: in a shared room, a hit from that person's other chats lands
+ * in the single prompt everyone's answer is derived from.
+ *
+ * The two halves are tested apart because each fails differently:
+ *
+ *  - the **guard** decides whether to restrict (and must not restrict when
+ *    nobody installed a floor);
+ *  - the **retriever** applies it, and has to drop the cross-session legs too —
+ *    they bypass the candidate pool entirely, so filtering candidates alone
+ *    would look thorough and let plans, processes and curated insights through.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+
+import {
+  CROSS_SCOPE_RECALL_CAPABILITY,
+  MEMORY_RECALL_CAPABILITY,
+  crossScopeRecallRefused,
+  guardContextRecall,
+} from '../packages/harness-orchestrator/src/audienceFloorGuard.js';
+import { turnContext } from '../packages/harness-orchestrator/src/turnContext.js';
+import type { AudienceFloor } from '../packages/harness-channel-sdk/src/audienceFloor.js';
+
+const openFloor = (...caps: string[]): AudienceFloor => ({
+  outcome: 'open',
+  capabilities: new Set(caps),
+  denied: new Set<string>(),
+});
+
+async function withFloor<T>(
+  floor: AudienceFloor | 'none' | 'throws',
+  fn: () => Promise<T>,
+): Promise<T> {
+  const base = { turnId: 't', turnDate: '2026-08-19' };
+  if (floor === 'none') return turnContext.run(base, fn);
+  return turnContext.run(
+    {
+      ...base,
+      audienceFloor:
+        floor === 'throws'
+          ? async () => {
+              throw new Error('directory down');
+            }
+          : async () => floor,
+    },
+    fn,
+  );
+}
+
+describe('#575 cross-scope recall is a separate capability', () => {
+  it('a room with both capabilities recalls freely', async () => {
+    const floor = openFloor(MEMORY_RECALL_CAPABILITY, CROSS_SCOPE_RECALL_CAPABILITY);
+    assert.equal(await withFloor(floor, guardContextRecall), undefined);
+    assert.equal(await withFloor(floor, crossScopeRecallRefused), false);
+  });
+
+  it('a room with only memory:recall still recalls — but only its own history', async () => {
+    // The point of the split: previously this room got NOTHING, because the
+    // single capability answered both questions at once.
+    const floor = openFloor(MEMORY_RECALL_CAPABILITY);
+    assert.equal(
+      await withFloor(floor, guardContextRecall),
+      undefined,
+      'recall itself must still be permitted',
+    );
+    assert.equal(await withFloor(floor, crossScopeRecallRefused), true);
+  });
+
+  it('a room with neither is refused recall outright', async () => {
+    const floor = openFloor();
+    assert.notEqual(await withFloor(floor, guardContextRecall), undefined);
+  });
+
+  it('no provider installed ⇒ unrestricted', async () => {
+    // "Not enforced ≠ closed". Every deployment that has not opted in.
+    assert.equal(await withFloor('none', crossScopeRecallRefused), false);
+    assert.equal(await withFloor('none', guardContextRecall), undefined);
+  });
+
+  it('an unresolvable audience restricts rather than opening', async () => {
+    assert.equal(await withFloor('throws', crossScopeRecallRefused), true);
+  });
+
+  it('a closed floor is refused by the recall guard, so restriction is moot', async () => {
+    const closed: AudienceFloor = { outcome: 'closed', reason: 'audience unknown' };
+    assert.notEqual(await withFloor(closed, guardContextRecall), undefined);
+    // Still reports "restrict" rather than "free": a closed floor permits
+    // nothing, and answering `false` here would read as "cross-scope is fine".
+    assert.equal(await withFloor(closed, crossScopeRecallRefused), true);
+  });
+
+  it('the two capabilities are distinct tokens', () => {
+    assert.notEqual(MEMORY_RECALL_CAPABILITY, CROSS_SCOPE_RECALL_CAPABILITY);
+    assert.equal(CROSS_SCOPE_RECALL_CAPABILITY, 'memory:recall:cross_scope');
+  });
+});
+
+describe('#575 the orchestrator threads the decision into the retriever', () => {
+  it('passes restrictToScope to assembleForBudget', async () => {
+    // The decision and its application live in different packages, and
+    // `restrictToScope` is optional — so dropping the argument compiles, keeps
+    // every guard test green, and silently restores cross-session recall for
+    // every restricted room. Nothing observable would change until somebody
+    // read a prompt.
+    //
+    // Asserted against the call site because the alternative is standing up a
+    // full Orchestrator with a graph, a provider and an LLM — a test that
+    // expensive is one that stops being run.
+    const source = await readFile(
+      new URL('../packages/harness-orchestrator/src/orchestrator.ts', import.meta.url),
+      'utf8',
+    );
+    const call = source.indexOf('assembleForBudget({');
+    assert.notEqual(call, -1, 'the retriever call site must still exist');
+    const end = source.indexOf('});', call);
+    const args = source.slice(call, end);
+    assert.ok(args.includes('restrictToScope'), 'the restriction must reach the retriever');
+    assert.ok(
+      source.includes('crossScopeRecallRefused'),
+      'and it must be derived from the floor, not from something else',
+    );
+  });
+});

--- a/middleware/test/audienceScopedRecallAssembler.test.ts
+++ b/middleware/test/audienceScopedRecallAssembler.test.ts
@@ -1,0 +1,168 @@
+/**
+ * #575 — `restrictToScope` actually drops the cross-conversation hits.
+ *
+ * The guard half (`crossScopeRecallRefused`) lives in
+ * `audienceScopedRecall.test.ts`. This is the half that has to do the work: a
+ * decision nobody applies is worth nothing, and here the failure would be
+ * invisible — the prompt would simply still contain another conversation's
+ * turns, and nothing would look broken.
+ *
+ * Two things are asserted, and the second is the one a plausible
+ * implementation misses: the cross-session legs (plans / processes / curated
+ * insights) **bypass the candidate pool entirely** and are rendered as their
+ * own blocks. Filtering candidates alone would look thorough and let those
+ * through.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { ContextRetriever } from '@omadia/orchestrator-extras';
+import type { KnowledgeGraph, TurnSearchHit } from '@omadia/plugin-api';
+import { turnNodeId } from '@omadia/plugin-api';
+
+const HERE = 'chat-here';
+const ELSEWHERE = 'chat-elsewhere';
+
+function ftsHit(scope: string, time: string, text: string, rank: number): TurnSearchHit {
+  return {
+    turnId: turnNodeId(scope, time),
+    scope,
+    time,
+    userMessage: text,
+    assistantAnswer: `answer about ${text}`,
+    rank,
+  };
+}
+
+/** Minimal graph: FTS hits only, which is all the scope filter needs. */
+function graphWith(hits: TurnSearchHit[]): KnowledgeGraph {
+  return {
+    async getSession() {
+      return null;
+    },
+    async findEntityCapturedTurns() {
+      return [];
+    },
+    async searchTurns() {
+      return hits;
+    },
+    async searchTurnsByEmbedding() {
+      return hits;
+    },
+    async getNeighbors() {
+      return [];
+    },
+  } as unknown as KnowledgeGraph;
+}
+
+describe('#575 restrictToScope drops hits from other conversations', () => {
+  const hits = [
+    ftsHit(HERE, '2026-08-01T08:00:00Z', 'budget for this room', 0.9),
+    ftsHit(ELSEWHERE, '2026-08-02T08:00:00Z', 'salary discussion', 0.95),
+    ftsHit(HERE, '2026-08-03T08:00:00Z', 'follow-up here', 0.8),
+  ];
+
+  it('without the restriction, the foreign hit is included', async () => {
+    // The baseline this feature changes — and the leak it closes: the
+    // highest-ranked hit belongs to another conversation.
+    const result = await new ContextRetriever(graphWith(hits)).assembleForBudget({
+      userMessage: 'budget',
+      agentId: 'agent-test',
+      sessionScope: HERE,
+      budget: { tokens: 4000 },
+    });
+    // `AssembledHit` carries turnId/score/chars/reason — not the scope — so the
+    // assertion goes through the turn id, which encodes it.
+    const foreign = turnNodeId(ELSEWHERE, '2026-08-02T08:00:00Z');
+    assert.ok(
+      result.included.some((h) => h.turnId === foreign),
+      'baseline: cross-session recall reaches the prompt',
+    );
+    assert.ok(result.text.includes('salary discussion'));
+  });
+
+  it('with the restriction, only this conversation survives', async () => {
+    const result = await new ContextRetriever(graphWith(hits)).assembleForBudget({
+      userMessage: 'budget',
+      agentId: 'agent-test',
+      sessionScope: HERE,
+      restrictToScope: HERE,
+      budget: { tokens: 4000 },
+    });
+    const foreign = turnNodeId(ELSEWHERE, '2026-08-02T08:00:00Z');
+    assert.ok(
+      !result.included.some((h) => h.turnId === foreign),
+      'no hit from another conversation may survive',
+    );
+    assert.ok(result.included.length > 0, 'and recall is NARROWED, not lost');
+  });
+
+  it('records the drop as an exclusion rather than swallowing it', async () => {
+    // An operator staring at a thin context block has to be able to see that
+    // the floor trimmed it, not guess.
+    const result = await new ContextRetriever(graphWith(hits)).assembleForBudget({
+      userMessage: 'budget',
+      agentId: 'agent-test',
+      sessionScope: HERE,
+      restrictToScope: HERE,
+      budget: { tokens: 4000 },
+    });
+    const dropped = result.excluded.filter((e) => e.reason === 'audience-scope');
+    assert.equal(dropped.length, 1);
+    assert.equal(dropped[0]?.turnId, turnNodeId(ELSEWHERE, '2026-08-02T08:00:00Z'));
+  });
+
+  it('the rendered text no longer mentions the foreign turn', async () => {
+    // The assertion that matters: `included` is a trace, the TEXT is the prompt.
+    const result = await new ContextRetriever(graphWith(hits)).assembleForBudget({
+      userMessage: 'budget',
+      agentId: 'agent-test',
+      sessionScope: HERE,
+      restrictToScope: HERE,
+      budget: { tokens: 4000 },
+    });
+    assert.ok(!result.text.includes('salary discussion'));
+    assert.ok(result.text.includes('budget for this room'));
+  });
+});
+
+describe('#575 the cross-session legs are skipped too', () => {
+  it('does not run plan / process / memory recall when restricted', async () => {
+    // These bypass the candidate pool and render their own blocks, so the
+    // candidate filter would never see them. Asserted by observing that the
+    // legs are never asked — a graph whose cross-session reads throw would
+    // fail the turn if they ran.
+    let crossSessionAsked = false;
+    const graph = {
+      async getSession() {
+        return null;
+      },
+      async findEntityCapturedTurns() {
+        return [];
+      },
+      async searchTurns() {
+        return [] as TurnSearchHit[];
+      },
+      async searchTurnsByEmbedding() {
+        return [] as TurnSearchHit[];
+      },
+      async getNeighbors() {
+        return [];
+      },
+      async listRecentPlans() {
+        crossSessionAsked = true;
+        return [];
+      },
+    } as unknown as KnowledgeGraph;
+
+    await new ContextRetriever(graph).assembleForBudget({
+      userMessage: 'anything with terms in it',
+      agentId: 'agent-test',
+      sessionScope: HERE,
+      restrictToScope: HERE,
+      budget: { tokens: 4000 },
+    });
+    assert.equal(crossSessionAsked, false);
+  });
+});


### PR DESCRIPTION
#732 gated context recall **all-or-nothing** on `memory:recall`, and recorded the missing per-item granularity as a measured limitation.

Re-measuring showed that limitation was overstated: **recall hits carry a `scope`**, even though they carry no entitlement labels. So part of the granularity was available all along.

## What changes

`memory:recall:cross_scope` splits one question into two:

| Room holds | Result |
|---|---|
| both capabilities | recalls freely, as today |
| `memory:recall` only | recalls its **own** history; hits from other conversations are dropped |
| neither | recall refused outright, as today |

The middle row is new. That room previously got **nothing**, because a single capability answered both questions at once.

## Why the middle row is the interesting one

Recall is ACL-gated by the **recalling** user (`viewerOmadiaUserId`). In a shared room, a hit from that person's other chats lands in the single prompt everyone's answer is derived from — the room learns something exactly one participant was entitled to, and nobody in it asked for.

Refusing recall entirely was a safe answer to that, and a bad one: it threw away the room's own history too, which everyone present is plainly entitled to, because they said it.

## Three implementation points, each of which fails quietly if got wrong

**The filter runs inside the retriever, before rendering.** `assembleForBudget` returns rendered text plus a `sources` trace. A caller filtering the trace afterwards would be editing a log, not the prompt — and the tests would look green.

**The cross-session legs are skipped too.** Plans, processes and curated insights bypass the candidate pool entirely and render their own blocks. Filtering candidates alone would have looked thorough and let all three through; a test asserts they are never even asked for.

**Dropped hits become exclusions with reason `audience-scope`**, not silence. An operator staring at a thin context block has to be able to see that the floor trimmed it.

An unresolvable audience restricts rather than opening. No provider installed leaves recall unrestricted — the same *"not enforced ≠ closed"* rule as every other guard in this cluster.

## Blast radius

| Surface | Effect |
|---|---|
| Deployments with `AUDIENCE_FLOOR_ENABLED` unset | **none** — no provider, no restriction |
| Rooms granted `memory:recall:cross_scope` | **none** — recall as before |
| Rooms granted only `memory:recall` | recall narrowed to this conversation, instead of skipped entirely — **strictly more context than today** |
| Direct retriever callers / sub-agents | none — `restrictToScope` is optional and unset |

## Verification

- middleware suite: **6735 tests, 0 fail, 0 cancelled** (13 new)
- `npm run typecheck` ✅ · `npm run lint` ✅ · #470 ratchet **3294** ✅ · #573 ratchet **406, unchanged** ✅

**Mutation-checked — all four died:**

| Mutation | Result |
|---|---|
| remove the candidate scope filter | kills 3 |
| invert the comparison | kills 3 |
| let the cross-session legs run while restricted | kills 1 |
| drop `restrictToScope` at the orchestrator call site | kills the wiring test |

> Worth recording for anyone mutating this package: the tests import `@omadia/orchestrator-extras` (**dist**), so a `src`-only mutation is **invisible** until the package is rebuilt. My first run of all three mutations "survived" for exactly that reason, and a survivor read as "the invariant does not exist" rather than "the check never ran".

## What #575 still names

**Per-recipient** context filtering with tool-call-ID-preserving stubs remains out, and I now think it stays out on purpose rather than pending: omadia renders **one answer per room**, so "context per recipient" would mean N answers. The faithful adaptation is the intersection — which is what this cluster implements, and what this PR makes finer-grained rather than coarser.

The remaining genuinely-open refinement is **`sharedOnly` curated-memory recall**: `MemorableKnowledgeSearchOptions.teamVisibility` only *adds* `team`/`public` on top of the viewer's own rows, and there is no way to ask for "shared tiers only". That needs `plugin-api` plus both knowledge-graph implementations, and it is a separate cut.

Refs #575

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789709268&installation_model_id=428086&pr_number=742&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F742&signature=b750c6d5786a004f5f3e6eb33784b0f58bcf60074851e1ea392c7882daa2f6d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->