### PR TITLE
fix(#326): render masked columns on the canvas dataset-publish path

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,25 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — shielded result tables no longer render blank columns
+
+- **Masked columns came out empty on the canvas (#326).** A privacy-shield
+  dataset resolves to rows *keyed by the source's column paths*, but the canvas
+  composer looked cells up under the **agent's** field keys. Where the agent
+  called a column `invoice_number` and Odoo's path was `name`, the lookup missed
+  and the cell was silently blanked — so an invoice table rendered without
+  invoice numbers or customers.
+- Columns that happened to reuse the real field name filled correctly, which is
+  why this looked like a rendering glitch rather than a mapping fault.
+- **Fixed by deriving the table's columns from the resolved dataset**, so values
+  resolve by path. Shielded columns now also carry
+  `privacy: "guard-protected"` — a marking the canvas protocol already defined
+  and the `v4_render_answer` path already emitted; only this path never did.
+- **Labels are matched positionally**, and only when the agent's and the
+  dataset's column lists are the same length; otherwise the raw path is shown.
+  No field-key↔path mapping exists anywhere in the system, so the alternative
+  would be a header that confidently names the wrong column.
+
 ### Changed — a restricted room narrows its recall instead of losing it
 
 - **`memory:recall:cross_scope` (#575).** Recall used to be all-or-nothing: a

--- a/middleware/packages/harness-plugin-privacy-guard/src/service.ts
+++ b/middleware/packages/harness-plugin-privacy-guard/src/service.ts
@@ -577,7 +577,13 @@ export function createPrivacyGuardService(deps?: {
       );
       return {
         rowCount: dataset.rows.length,
-        columns: dataset.schema.fields.map((f) => ({ path: f.path, type: f.type })),
+        // The classification travels with the column. Dropping it here was why
+        // a renderer had no way to tell a shielded column from an ordinary one.
+        columns: dataset.schema.fields.map((f) => ({
+          path: f.path,
+          type: f.type,
+          classification: f.classification,
+        })),
         rows: dataset.rows as ReadonlyArray<Record<string, unknown>>,
       };
     },

--- a/middleware/packages/omadia-ui-orchestrator/src/patchComposition.ts
+++ b/middleware/packages/omadia-ui-orchestrator/src/patchComposition.ts
@@ -43,7 +43,7 @@ export interface ComposedPatch {
 interface TableNode {
   type: 'table';
   loading?: string;
-  columns?: Array<{ fieldKey: string; label: string }>;
+  columns?: Array<{ fieldKey: string; label: string; privacy?: 'guard-protected' }>;
   rows: Array<{ rowKey: string; cells: Record<string, unknown> }>;
   [key: string]: unknown;
 }
@@ -454,7 +454,36 @@ export function composeStructuredPayloadPatch(opts: {
 
   // Cells are mapped against the SKELETON's own columns — the contract the
   // [canvas-context] handoff asked Tier 3 to fill.
-  const fieldKeys = (table.node.columns ?? []).map((c) => c.fieldKey);
+  //
+  // #326: that contract does NOT hold for a privacy-shield dataset publish.
+  // `resolveDatasetForRender` returns rows "keyed by column path" — the
+  // source's own field names — while the skeleton carries the agent's naming.
+  // Reading `row[fieldKey]` then misses and the cell is silently blanked, so a
+  // masked column renders as if the data did not exist. When the publish
+  // carried the dataset schema, THOSE paths are authoritative.
+  const datasetColumns = readDatasetColumns(opts.payload.data);
+  const skeletonColumns = table.node.columns ?? [];
+  const effectiveColumns = datasetColumns
+    ? datasetColumns.map((c, i) => ({
+        // The path is the row key, so values can never land in the wrong
+        // column — the one property that must not depend on a guess.
+        fieldKey: c.path,
+        // The agent's human label is a display nicety and the ONLY thing
+        // matched positionally. There is no semantic link between an agent
+        // field key and a source path anywhere in the system (checked:
+        // `DataRequirement.fields` carries agent keys only), so this is a
+        // guess — taken only when the two column lists are the same length,
+        // and otherwise declined in favour of the raw path.
+        label:
+          datasetColumns.length === skeletonColumns.length
+            ? (skeletonColumns[i]?.label ?? c.path)
+            : c.path,
+        ...(c.classification === 'sensitive-masked'
+          ? { privacy: 'guard-protected' as const }
+          : {}),
+      }))
+    : skeletonColumns;
+  const fieldKeys = effectiveColumns.map((c) => c.fieldKey);
   if (fieldKeys.length === 0) {
     opts.log?.(`[patch-composition] skip: table ${String(table.node['id'])} has no columns`);
     return null;
@@ -481,6 +510,12 @@ export function composeStructuredPayloadPatch(opts: {
   const patches: TreePatchOp[] = [];
   if (table.node.loading === 'skeleton') {
     patches.push({ op: 'replace', path: `${table.path}/loading`, value: 'none' });
+  }
+  if (datasetColumns) {
+    // The rows are keyed by path, so the client's column list has to be too —
+    // otherwise it would look up cells that are no longer there. This is also
+    // what carries the guard marking to the renderer.
+    patches.push({ op: 'replace', path: `${table.path}/columns`, value: effectiveColumns });
   }
   const replaceRows = opts.refreshContainers?.delete(String(table.node['id'])) === true;
   if (replaceRows) {
@@ -541,4 +576,31 @@ export function composeStructuredPayloadPatch(opts: {
     return null;
   }
   return { patches, nextTree };
+}
+
+/**
+ * #326 — the dataset column schema a privacy-shield publish forwards.
+ *
+ * Read defensively: `PendingStructuredPayload.data` is `unknown` by contract,
+ * and a malformed or absent schema must leave the pre-existing skeleton
+ * mapping untouched rather than produce a half-derived column list.
+ */
+function readDatasetColumns(
+  data: unknown,
+): Array<{ path: string; type: string; classification?: string }> | undefined {
+  if (typeof data !== 'object' || data === null) return undefined;
+  const raw = (data as { datasetColumns?: unknown }).datasetColumns;
+  if (!Array.isArray(raw) || raw.length === 0) return undefined;
+  const columns: Array<{ path: string; type: string; classification?: string }> = [];
+  for (const entry of raw) {
+    if (typeof entry !== 'object' || entry === null) return undefined;
+    const c = entry as { path?: unknown; type?: unknown; classification?: unknown };
+    if (typeof c.path !== 'string' || c.path.length === 0) return undefined;
+    columns.push({
+      path: c.path,
+      type: typeof c.type === 'string' ? c.type : 'string',
+      ...(typeof c.classification === 'string' ? { classification: c.classification } : {}),
+    });
+  }
+  return columns;
 }

--- a/middleware/packages/omadia-ui-orchestrator/src/plugin.ts
+++ b/middleware/packages/omadia-ui-orchestrator/src/plugin.ts
@@ -199,6 +199,13 @@ export async function handleCanvasPublishRows(
     );
   }
   let truncatedFrom: number | undefined;
+  /** #326 — the resolved dataset's authoritative column schema, forwarded to
+   *  the composer so cells resolve by PATH rather than by the skeleton's own
+   *  field keys. Undefined for a plain `rows` publish, where the agent's keys
+   *  already are the row keys and nothing needs remapping. */
+  let datasetColumns:
+    | Array<{ path: string; type: string; classification?: string }>
+    | undefined;
   if (datasetId !== undefined) {
     const resolved = resolveDataset === undefined ? 'unavailable' : resolveDataset(datasetId);
     if (resolved === 'unavailable') {
@@ -214,6 +221,16 @@ export async function handleCanvasPublishRows(
       );
     }
     rows = resolved.rows.map((r) => ({ ...r }));
+    // The dataset's own column schema travels with the rows. Without it the
+    // composer maps cells by the SKELETON's field keys, which are the agent's
+    // naming — `invoice_number` where the source path is Odoo's `name` — and
+    // every mismatched column renders blank. The paths here are authoritative
+    // because they are the keys the rows are actually built on.
+    datasetColumns = resolved.columns.map((c) => ({
+      path: c.path,
+      type: c.type,
+      ...(c.classification ? { classification: c.classification } : {}),
+    }));
     if (rows.length > MAX_DATASET_PUBLISH_ROWS) {
       truncatedFrom = rows.length;
       rows = rows.slice(0, MAX_DATASET_PUBLISH_ROWS);
@@ -276,6 +293,7 @@ export async function handleCanvasPublishRows(
         // A fields publish targets a scalar/KPI container; omit `rows` so the
         // synthesis layer routes it through the fields branch, not the table one.
         ...(hasMappableFields ? { fields } : { rows }),
+        ...(datasetColumns ? { datasetColumns } : {}),
         ...(source ? { source } : {}),
         ...(actions.length > 0 ? { actions } : {}),
         ...(chartType ? { chartType } : {}),

--- a/middleware/packages/plugin-api/src/privacyReceipt.ts
+++ b/middleware/packages/plugin-api/src/privacyReceipt.ts
@@ -267,8 +267,25 @@ export interface PrivacyStructuredPayloadRequest {
 export interface PrivacyResolvedDataset {
   /** Number of rows the dataset holds (the postcondition target). */
   readonly rowCount: number;
-  /** Column schema — `path` is the row-object key, `type` the field type. */
-  readonly columns: ReadonlyArray<{ readonly path: string; readonly type: string }>;
+  /**
+   * Column schema — `path` is the row-object key, `type` the field type.
+   *
+   * `classification` says whether the shield considers this column sensitive.
+   * It is what lets a renderer mark a column as guard-protected instead of
+   * showing a bare value with no indication of where it came from; the verdict
+   * exists on the interned dataset either way, and used to be dropped here.
+   *
+   * Optional so an alternative privacy provider stays compilable. **Absent
+   * means unknown, never "safe"** — a consumer must not render a
+   * cleartext-looking column on the strength of a missing field, because the
+   * one thing worse than an unmarked masked value is a value marked safe that
+   * is not.
+   */
+  readonly columns: ReadonlyArray<{
+    readonly path: string;
+    readonly type: string;
+    readonly classification?: 'safe-cleartext' | 'sensitive-masked';
+  }>;
   /** The full real rows, keyed by column `path`. */
   readonly rows: ReadonlyArray<Record<string, unknown>>;
 }

--- a/middleware/test/canvasPublishMaskedColumns.test.ts
+++ b/middleware/test/canvasPublishMaskedColumns.test.ts
@@ -1,0 +1,145 @@
+/**
+ * PR #326 — step 1: does the defect still exist on today's `main`?
+ *
+ * The claim, from June: result tables on Privacy-Shield turns render **empty
+ * cells** for masked columns. The diagnosed cause was not the renderer but a
+ * key mismatch on the `canvas_publish_rows` + server-resolved `datasetId`
+ * path:
+ *
+ *   - `PrivacyResolvedDataset.rows` is documented as "the full real rows,
+ *     **keyed by column `path`**" (`plugin-api/privacyReceipt.ts`);
+ *   - `handleCanvasPublishRows` passes those rows through untouched
+ *     (`rows = resolved.rows.map((r) => ({ ...r }))`);
+ *   - `composeStructuredPayloadPatch` then reads each cell as `row[fieldKey]`
+ *     using the **skeleton's** own column keys.
+ *
+ * When the agent's skeleton names a column `invoice_number` and the dataset
+ * path is Odoo's `name`, the lookup misses and the cell silently becomes `''`.
+ * Columns that happen to use the real field name fill correctly, which is why
+ * the bug looked partial in production rather than total.
+ *
+ * This test asserts the CURRENT behaviour. It passing means the defect is
+ * still live and the PR's diagnosis holds on v4; it is written so that a fix
+ * turns it red at the exact assertion that describes the damage.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { composeStructuredPayloadPatch } from '../packages/omadia-ui-orchestrator/src/patchComposition.js';
+
+/** An agent-authored skeleton: human column keys, not the source's paths. */
+const INVOICE_SKELETON = {
+  type: 'container',
+  id: 'root',
+  layout: 'stack',
+  children: [
+    {
+      type: 'table',
+      id: 'invoices',
+      loading: 'skeleton',
+      columns: [
+        // These three are the agent's own naming …
+        { fieldKey: 'invoice_number', label: 'Rechnungsnummer' },
+        { fieldKey: 'customer_name', label: 'Kunde' },
+        { fieldKey: 'due_date', label: 'Fällig am' },
+        // … while these two happen to match the source field names.
+        { fieldKey: 'invoice_date', label: 'Rechnungsdatum' },
+        { fieldKey: 'amount_total', label: 'Betrag' },
+      ],
+      rows: [],
+    },
+  ],
+};
+
+/**
+ * A row exactly as `resolveDatasetForRender` hands it back: keyed by the
+ * dataset's column `path`s (Odoo's field names), carrying the real — masked —
+ * values.
+ */
+const RESOLVED_ROW = {
+  name: 'RE-2026-0042',
+  partner_id: 'Muster GmbH',
+  invoice_date_due: '2026-09-01',
+  invoice_date: '2026-08-01',
+  amount_total: 1190.5,
+};
+
+function tableFromPatch(patch: ReturnType<typeof composeStructuredPayloadPatch>): {
+  cells: Record<string, unknown>;
+} {
+  assert.ok(patch, 'a patch must be composed at all');
+  const addRow = patch.patches.find(
+    (op) => op.op === 'add' && String(op.path).endsWith('/rows/-'),
+  ) as { value: { cells: Record<string, unknown> } } | undefined;
+  assert.ok(addRow, 'the patch must add a row');
+  return addRow.value;
+}
+
+describe('PR #326 — masked columns on the canvas_publish_rows dataset path', () => {
+  it('renders cells whose key matches the source field name', () => {
+    // The half that always worked, and the reason the defect reads as a
+    // rendering glitch rather than a mapping bug.
+    const row = tableFromPatch(
+      composeStructuredPayloadPatch({
+        baseTree: INVOICE_SKELETON,
+        payload: {
+          prose: 'offene Debitorenrechnungen',
+          dataRefId: 'ds-1',
+          data: { containerId: 'invoices', rows: [RESOLVED_ROW] },
+        },
+        dataRequirements: [],
+      }),
+    );
+    assert.equal(row.cells['invoice_date'], '2026-08-01');
+    assert.equal(row.cells['amount_total'], 1190.5);
+  });
+
+  it('LEAVES THE MASKED COLUMNS EMPTY — the defect, still live', () => {
+    // The three agent-named columns carry real values in the resolved row,
+    // under the dataset's own paths. The lookup misses and the cell is
+    // silently blanked rather than skipped, so the table renders as if the
+    // data did not exist.
+    const row = tableFromPatch(
+      composeStructuredPayloadPatch({
+        baseTree: INVOICE_SKELETON,
+        payload: {
+          prose: 'offene Debitorenrechnungen',
+          dataRefId: 'ds-1',
+          data: { containerId: 'invoices', rows: [RESOLVED_ROW] },
+        },
+        dataRequirements: [],
+      }),
+    );
+
+    assert.equal(row.cells['invoice_number'], '', 'RE-2026-0042 is lost');
+    assert.equal(row.cells['customer_name'], '', 'Muster GmbH is lost');
+    assert.equal(row.cells['due_date'], '', '2026-09-01 is lost');
+
+    // And the values ARE present in the payload — nothing was withheld
+    // upstream, the mapping simply cannot find them.
+    assert.equal(RESOLVED_ROW.name, 'RE-2026-0042');
+    assert.equal(RESOLVED_ROW.partner_id, 'Muster GmbH');
+  });
+
+  it('carries no privacy marking on the column either', () => {
+    // The second half of the PR's claim: even where a cell IS blank because
+    // the value is shielded, nothing tells the client to show a guard badge.
+    // `patchComposition`'s column type is `{ fieldKey, label }` — there is no
+    // field to carry it.
+    const patch = composeStructuredPayloadPatch({
+      baseTree: INVOICE_SKELETON,
+      payload: {
+        prose: 'offene Debitorenrechnungen',
+        dataRefId: 'ds-1',
+        data: { containerId: 'invoices', rows: [RESOLVED_ROW] },
+      },
+      dataRequirements: [],
+    });
+    assert.ok(patch);
+    assert.ok(
+      !JSON.stringify(patch).includes('guard-protected'),
+      'no privacy marking reaches the client today',
+    );
+  });
+});

--- a/middleware/test/canvasPublishMaskedColumns.test.ts
+++ b/middleware/test/canvasPublishMaskedColumns.test.ts
@@ -1,26 +1,33 @@
 /**
- * PR #326 — step 1: does the defect still exist on today's `main`?
+ * PR #326 — masked columns on the `canvas_publish_rows` dataset path.
  *
- * The claim, from June: result tables on Privacy-Shield turns render **empty
- * cells** for masked columns. The diagnosed cause was not the renderer but a
- * key mismatch on the `canvas_publish_rows` + server-resolved `datasetId`
- * path:
+ * ## The defect, verified on today's `main` before anything was changed
  *
  *   - `PrivacyResolvedDataset.rows` is documented as "the full real rows,
- *     **keyed by column `path`**" (`plugin-api/privacyReceipt.ts`);
- *   - `handleCanvasPublishRows` passes those rows through untouched
- *     (`rows = resolved.rows.map((r) => ({ ...r }))`);
- *   - `composeStructuredPayloadPatch` then reads each cell as `row[fieldKey]`
- *     using the **skeleton's** own column keys.
+ *     **keyed by column `path`**";
+ *   - `handleCanvasPublishRows` passes them through untouched;
+ *   - `composeStructuredPayloadPatch` read each cell as `row[fieldKey]` using
+ *     the **skeleton's** column keys, which are the agent's naming.
  *
- * When the agent's skeleton names a column `invoice_number` and the dataset
- * path is Odoo's `name`, the lookup misses and the cell silently becomes `''`.
- * Columns that happen to use the real field name fill correctly, which is why
- * the bug looked partial in production rather than total.
+ * Where the agent names a column `invoice_number` and the source path is
+ * Odoo's `name`, the lookup missed and the cell was silently blanked. Columns
+ * that happened to use the real field name filled correctly — which is why the
+ * bug presented as a partial rendering glitch rather than a mapping fault.
  *
- * This test asserts the CURRENT behaviour. It passing means the defect is
- * still live and the PR's diagnosis holds on v4; it is written so that a fix
- * turns it red at the exact assertion that describes the damage.
+ * ## What the fix may and may not guess
+ *
+ * There is **no semantic link** between an agent field key and a source path
+ * anywhere in the system — `DataRequirement.fields` carries agent keys only.
+ * Position is the only available correspondence, and it is a guess. So:
+ *
+ *   - **values** resolve by `path`, never positionally. A value in the wrong
+ *     column is worse than a blank one;
+ *   - **labels** are the only place the guess is taken, and only when the two
+ *     column lists are the same length. Otherwise the raw path is shown, which
+ *     is ugly and correct rather than pretty and wrong.
+ *
+ * That order dependency is pinned below, so nobody can "tidy" it away without
+ * a test going red.
  */
 
 import { strict as assert } from 'node:assert';
@@ -39,11 +46,9 @@ const INVOICE_SKELETON = {
       id: 'invoices',
       loading: 'skeleton',
       columns: [
-        // These three are the agent's own naming …
         { fieldKey: 'invoice_number', label: 'Rechnungsnummer' },
         { fieldKey: 'customer_name', label: 'Kunde' },
         { fieldKey: 'due_date', label: 'Fällig am' },
-        // … while these two happen to match the source field names.
         { fieldKey: 'invoice_date', label: 'Rechnungsdatum' },
         { fieldKey: 'amount_total', label: 'Betrag' },
       ],
@@ -52,11 +57,7 @@ const INVOICE_SKELETON = {
   ],
 };
 
-/**
- * A row exactly as `resolveDatasetForRender` hands it back: keyed by the
- * dataset's column `path`s (Odoo's field names), carrying the real — masked —
- * values.
- */
+/** A row exactly as `resolveDatasetForRender` hands it back: keyed by path. */
 const RESOLVED_ROW = {
   name: 'RE-2026-0042',
   partner_id: 'Muster GmbH',
@@ -65,81 +66,149 @@ const RESOLVED_ROW = {
   amount_total: 1190.5,
 };
 
-function tableFromPatch(patch: ReturnType<typeof composeStructuredPayloadPatch>): {
-  cells: Record<string, unknown>;
-} {
-  assert.ok(patch, 'a patch must be composed at all');
-  const addRow = patch.patches.find(
-    (op) => op.op === 'add' && String(op.path).endsWith('/rows/-'),
-  ) as { value: { cells: Record<string, unknown> } } | undefined;
-  assert.ok(addRow, 'the patch must add a row');
-  return addRow.value;
+/** …and the schema that now travels with it. */
+const DATASET_COLUMNS = [
+  { path: 'name', type: 'string', classification: 'sensitive-masked' },
+  { path: 'partner_id', type: 'string', classification: 'sensitive-masked' },
+  { path: 'invoice_date_due', type: 'date', classification: 'safe-cleartext' },
+  { path: 'invoice_date', type: 'date', classification: 'safe-cleartext' },
+  { path: 'amount_total', type: 'number', classification: 'safe-cleartext' },
+];
+
+type Composed = ReturnType<typeof composeStructuredPayloadPatch>;
+
+function compose(data: Record<string, unknown>): Composed {
+  return composeStructuredPayloadPatch({
+    baseTree: INVOICE_SKELETON,
+    payload: { prose: 'offene Debitorenrechnungen', dataRefId: 'ds-1', data },
+    dataRequirements: [],
+  });
 }
 
-describe('PR #326 — masked columns on the canvas_publish_rows dataset path', () => {
-  it('renders cells whose key matches the source field name', () => {
-    // The half that always worked, and the reason the defect reads as a
-    // rendering glitch rather than a mapping bug.
-    const row = tableFromPatch(
-      composeStructuredPayloadPatch({
-        baseTree: INVOICE_SKELETON,
-        payload: {
-          prose: 'offene Debitorenrechnungen',
-          dataRefId: 'ds-1',
-          data: { containerId: 'invoices', rows: [RESOLVED_ROW] },
-        },
-        dataRequirements: [],
-      }),
-    );
-    assert.equal(row.cells['invoice_date'], '2026-08-01');
-    assert.equal(row.cells['amount_total'], 1190.5);
+function rowCells(patch: Composed): Record<string, unknown> {
+  assert.ok(patch, 'a patch must be composed at all');
+  const add = patch.patches.find(
+    (op) => op.op === 'add' && String(op.path).endsWith('/rows/-'),
+  ) as { value: { cells: Record<string, unknown> } } | undefined;
+  assert.ok(add, 'the patch must add a row');
+  return add.value.cells;
+}
+
+function columns(patch: Composed): Array<{ fieldKey: string; label: string; privacy?: string }> {
+  assert.ok(patch);
+  const replace = patch.patches.find(
+    (op) => op.op === 'replace' && String(op.path).endsWith('/columns'),
+  ) as { value: Array<{ fieldKey: string; label: string; privacy?: string }> } | undefined;
+  assert.ok(replace, 'the dataset path must publish its own column list');
+  return replace.value;
+}
+
+describe('PR #326 — a shielded dataset renders its values', () => {
+  const patch = compose({
+    containerId: 'invoices',
+    rows: [RESOLVED_ROW],
+    datasetColumns: DATASET_COLUMNS,
   });
 
-  it('LEAVES THE MASKED COLUMNS EMPTY — the defect, still live', () => {
-    // The three agent-named columns carry real values in the resolved row,
-    // under the dataset's own paths. The lookup misses and the cell is
-    // silently blanked rather than skipped, so the table renders as if the
-    // data did not exist.
-    const row = tableFromPatch(
-      composeStructuredPayloadPatch({
-        baseTree: INVOICE_SKELETON,
-        payload: {
-          prose: 'offene Debitorenrechnungen',
-          dataRefId: 'ds-1',
-          data: { containerId: 'invoices', rows: [RESOLVED_ROW] },
-        },
-        dataRequirements: [],
-      }),
-    );
-
-    assert.equal(row.cells['invoice_number'], '', 'RE-2026-0042 is lost');
-    assert.equal(row.cells['customer_name'], '', 'Muster GmbH is lost');
-    assert.equal(row.cells['due_date'], '', '2026-09-01 is lost');
-
-    // And the values ARE present in the payload — nothing was withheld
-    // upstream, the mapping simply cannot find them.
-    assert.equal(RESOLVED_ROW.name, 'RE-2026-0042');
-    assert.equal(RESOLVED_ROW.partner_id, 'Muster GmbH');
+  it('renders the columns the agent named differently from the source', () => {
+    // The defect: these three were blank because `row['invoice_number']` and
+    // friends do not exist — the row is keyed `name` / `partner_id` / …
+    const cells = rowCells(patch);
+    assert.equal(cells['name'], 'RE-2026-0042');
+    assert.equal(cells['partner_id'], 'Muster GmbH');
+    assert.equal(cells['invoice_date_due'], '2026-09-01');
   });
 
-  it('carries no privacy marking on the column either', () => {
-    // The second half of the PR's claim: even where a cell IS blank because
-    // the value is shielded, nothing tells the client to show a guard badge.
-    // `patchComposition`'s column type is `{ fieldKey, label }` — there is no
-    // field to carry it.
-    const patch = composeStructuredPayloadPatch({
-      baseTree: INVOICE_SKELETON,
-      payload: {
-        prose: 'offene Debitorenrechnungen',
-        dataRefId: 'ds-1',
-        data: { containerId: 'invoices', rows: [RESOLVED_ROW] },
-      },
-      dataRequirements: [],
+  it('still renders the columns that always worked', () => {
+    const cells = rowCells(patch);
+    assert.equal(cells['invoice_date'], '2026-08-01');
+    assert.equal(cells['amount_total'], 1190.5);
+  });
+
+  it('marks the shielded columns as guard-protected', () => {
+    const cols = columns(patch);
+    const byKey = new Map(cols.map((c) => [c.fieldKey, c]));
+    assert.equal(byKey.get('name')?.privacy, 'guard-protected');
+    assert.equal(byKey.get('partner_id')?.privacy, 'guard-protected');
+    // …and does NOT mark the cleartext ones, which would train the user to
+    // ignore the badge.
+    assert.equal(byKey.get('amount_total')?.privacy, undefined);
+  });
+
+  it('keeps the agent’s human labels', () => {
+    const cols = columns(patch);
+    assert.deepEqual(
+      cols.map((c) => c.label),
+      ['Rechnungsnummer', 'Kunde', 'Fällig am', 'Rechnungsdatum', 'Betrag'],
+    );
+  });
+});
+
+describe('PR #326 — what the fix refuses to guess', () => {
+  it('falls back to the raw path when the column counts disagree', () => {
+    // Labels are matched positionally. With a different number of columns the
+    // correspondence is not merely uncertain, it is meaningless — so no label
+    // is claimed at all. An ugly header beats "Kunde" over invoice numbers.
+    const cols = columns(
+      compose({
+        containerId: 'invoices',
+        rows: [RESOLVED_ROW],
+        datasetColumns: DATASET_COLUMNS.slice(0, 3),
+      }),
+    );
+    assert.deepEqual(
+      cols.map((c) => c.label),
+      ['name', 'partner_id', 'invoice_date_due'],
+    );
+  });
+
+  it('is order-dependent for labels, by design — pinned so it cannot drift', () => {
+    // Reordering the DATASET columns re-pairs the agent's labels. This test
+    // exists to make that dependency explicit: it is the residual risk the
+    // original PR flagged and could not remove, because no field-key↔path
+    // mapping exists to remove it with.
+    const swapped = [DATASET_COLUMNS[1]!, DATASET_COLUMNS[0]!, ...DATASET_COLUMNS.slice(2)];
+    const cols = columns(
+      compose({ containerId: 'invoices', rows: [RESOLVED_ROW], datasetColumns: swapped }),
+    );
+    assert.equal(cols[0]?.fieldKey, 'partner_id');
+    assert.equal(cols[0]?.label, 'Rechnungsnummer', 'the label followed the POSITION, not the key');
+    // The values, however, are keyed by path and stay correct — which is the
+    // property that actually matters.
+    assert.equal(rowCells(compose({
+      containerId: 'invoices',
+      rows: [RESOLVED_ROW],
+      datasetColumns: swapped,
+    }))['partner_id'], 'Muster GmbH');
+  });
+
+  it('leaves a plain rows publish completely untouched', () => {
+    // No dataset schema ⇒ the pre-existing skeleton mapping, unchanged. This
+    // is every non-shielded publish in the product.
+    const patch = compose({
+      containerId: 'invoices',
+      rows: [{ invoice_number: 'RE-1', customer_name: 'ACME' }],
     });
     assert.ok(patch);
-    assert.ok(
-      !JSON.stringify(patch).includes('guard-protected'),
-      'no privacy marking reaches the client today',
+    assert.equal(
+      patch.patches.some((op) => String(op.path).endsWith('/columns')),
+      false,
+      'no column rewrite without a dataset schema',
+    );
+    assert.equal(rowCells(patch)['invoice_number'], 'RE-1');
+  });
+
+  it('ignores a malformed schema rather than half-deriving one', () => {
+    const patch = compose({
+      containerId: 'invoices',
+      rows: [RESOLVED_ROW],
+      datasetColumns: [{ path: 'name', type: 'string' }, { type: 'string' }],
+    });
+    assert.ok(patch);
+    assert.equal(
+      patch.patches.some((op) => String(op.path).endsWith('/columns')),
+      false,
+      'a broken schema must not produce a partial column list',
     );
   });
 });

--- a/middleware/test/privacyResolvedDatasetClassification.test.ts
+++ b/middleware/test/privacyResolvedDatasetClassification.test.ts
@@ -1,0 +1,116 @@
+/**
+ * PR #326 — the producer side: `resolveDatasetForRender` must carry the
+ * classification, not just the path.
+ *
+ * ## Why this file exists
+ *
+ * The renderer-side tests (`canvasPublishMaskedColumns.test.ts`) feed a column
+ * schema straight into the composer, so they never execute the privacy-guard
+ * service that produces it. A mutation run caught that: **deleting
+ * `classification: f.classification` from `resolveDatasetForRender` failed no
+ * test at all.** Every guard badge in the product would have disappeared while
+ * the suite stayed green.
+ *
+ * The verdict has always existed on the interned dataset; it was simply dropped
+ * at the boundary. So the assertions run against the **real service** — a fake
+ * would only prove that the fake forwards it.
+ *
+ * Note for future mutation runs: this suite imports
+ * `@omadia/plugin-privacy-guard/dist`, so a `src`-only mutation is invisible
+ * until the package is rebuilt.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { createPrivacyGuardService } from '@omadia/plugin-privacy-guard/dist/index.js';
+
+interface DigestField {
+  path: string;
+  classification: string;
+}
+
+/** The digest is prose followed by one JSON object; the verdicts live in it. */
+function digestFields(digestText: string): DigestField[] {
+  const start = digestText.indexOf('{');
+  assert.notEqual(start, -1, 'the digest must carry a JSON payload');
+  const parsed = JSON.parse(digestText.slice(start)) as { fields?: DigestField[] };
+  const fields = parsed.fields ?? [];
+  assert.ok(fields.length > 0, 'the digest must describe its fields');
+  return fields;
+}
+
+async function intern(svc: ReturnType<typeof createPrivacyGuardService>, turnId: string, rows: unknown[]) {
+  return svc.internToolResultV4({
+    sessionId: `session-${turnId}`,
+    turnId,
+    toolName: 'odoo_fetch_dataset',
+    rawResult: JSON.stringify(rows),
+  });
+}
+
+describe('PR #326 — resolveDatasetForRender carries the classification', () => {
+  it('returns a verdict per column, and both verdicts are representable', async () => {
+    const svc = createPrivacyGuardService();
+    const turnId = 'turn-326';
+    // `partner` is unique per row and name-shaped → masked; `amount` is
+    // numeric → cleartext. The point is not WHICH verdict the classifier
+    // reaches, but that whichever it reaches survives the boundary.
+    const interned = await intern(svc, turnId, [
+      { partner: 'Acme GmbH', amount: 100 },
+      { partner: 'Beta AG', amount: 200 },
+      { partner: 'Gamma KG', amount: 300 },
+    ]);
+    const resolved = svc.resolveDatasetForRender?.(turnId, interned.datasetId);
+    assert.ok(resolved, 'dataset resolves within the turn');
+
+    for (const column of resolved.columns) {
+      assert.ok(
+        column.classification === 'sensitive-masked' ||
+          column.classification === 'safe-cleartext',
+        `column ${column.path} must carry a verdict, got ${String(column.classification)}`,
+      );
+    }
+    // A resolver that hard-coded either value would satisfy the loop above.
+    assert.equal(
+      new Set(resolved.columns.map((c) => c.classification)).size,
+      2,
+      'both verdicts must be representable',
+    );
+  });
+
+  it('forwards the interned verdict rather than re-deciding it', async () => {
+    // Two sources of truth for the same column would drift, and the one the
+    // renderer sees is this one. Compared against the digest the model was
+    // handed, so the two cannot disagree without a test noticing.
+    const svc = createPrivacyGuardService();
+    const turnId = 'turn-326-b';
+    const interned = await intern(svc, turnId, [
+      { employee_id: 'E-1', full_name: 'Anna Becker', salary: 50000 },
+      { employee_id: 'E-2', full_name: 'Bernd Roth', salary: 60000 },
+      { employee_id: 'E-3', full_name: 'Clara Diehl', salary: 70000 },
+    ]);
+    const resolved = svc.resolveDatasetForRender?.(turnId, interned.datasetId);
+    assert.ok(resolved);
+
+    const fields = digestFields(interned.digestText);
+    for (const field of fields) {
+      // Explicit annotation: `assert.ok` is an assertion function, and letting
+      // TS infer through it makes the binding circular (TS7022).
+      const column: { path: string; classification?: string } | undefined =
+        resolved.columns.find((c) => c.path === field.path);
+      assert.ok(column, `column ${field.path} must survive to the render boundary`);
+      assert.equal(
+        column.classification,
+        field.classification,
+        `column ${field.path} must keep the interned verdict`,
+      );
+    }
+    // And the comparison must not be vacuous: at least one masked column has
+    // to be in play, or this proves only that cleartext survives.
+    assert.ok(
+      fields.some((f) => f.classification === 'sensitive-masked'),
+      'this fixture must produce at least one masked column',
+    );
+  });
+});


### PR DESCRIPTION
Supersedes #326, rebuilt rather than rebased. The June diagnosis held; its code did not, because all four production files moved when Privacy Shield **v4** landed.

## The defect was verified before anything was changed

The first commit on this branch adds a test that reproduces the failure on today's `main`, so this is not an argument from the old PR's description:

- `PrivacyResolvedDataset.rows` is documented as *"the full real rows, **keyed by column `path`**"*
- `handleCanvasPublishRows` passed them through untouched
- `composeStructuredPayloadPatch` read each cell as `row[fieldKey]` — using the **skeleton's** column keys, which are the agent's naming

Where the agent names a column `invoice_number` and the source path is Odoo's `name`, the lookup missed and the cell was **silently blanked**. Columns that happened to reuse the real field name filled correctly, which is exactly why this presented as a rendering glitch rather than a mapping fault.

## The fix

| Layer | Change |
|---|---|
| `plugin-api` | `PrivacyResolvedDataset.columns` may carry `classification` |
| `privacy-guard/service.ts` | stops **dropping** it — the verdict always existed on the interned dataset |
| `ui-orchestrator/plugin.ts` | the publish carries the dataset's column schema alongside the rows |
| `patchComposition.ts` | derives the table's columns from those paths, so values resolve by path |

## What it may and may not guess

There is **no semantic link** between an agent field key and a source path anywhere in the system — `DataRequirement.fields` carries agent keys only. Position is the only available correspondence, and it is a guess. So the guess is spent where it costs least:

- **Values resolve by path, never positionally.** A value under the wrong header is worse than a blank one.
- **Labels take the guess**, and only when the two column lists are the same length. Otherwise the raw path is shown — ugly and correct beats pretty and wrong.

That order dependency is the residual risk the original PR flagged and could not remove. It still cannot be removed; it is now **bounded and asserted**, by a test that pins the behaviour when the dataset columns are reordered.

## No new contract was invented

`privacy: 'guard-protected'` is already in the canvas protocol — `canvas-tree.schema.json` defines it as an enum on the column object, with the description *"set when this column was masked from the LLM by the Privacy Guard … The renderer marks the column as never-seen-by-an-LLM."* The sibling `v4_render_answer` path already emits it (`v4/materializer.ts`), and a test already asserts it there.

This path simply never did. `type` is deliberately **not** added, because the schema sets `additionalProperties: false`.

## Verification

- middleware suite: **6745 tests, 0 fail, 0 cancelled** (11 new)
- `npm run typecheck` ✅ · `npm run lint` ✅ · #470 ratchet **3294** ✅ · #573 ratchet **406, unchanged** ✅

> The #573 ratchet surfaced 4 new type errors in my own tests, one of which had made an assertion **vacuous** (it reached for a `digest` field that does not exist on the result and silently took an else-branch). Fixed, not baselined.

### Mutation results — six run, and the survivor was the point

| Mutation | Result |
|---|---|
| revert cell mapping to the skeleton's keys | kills 2 |
| guess labels even when the column counts differ | kills 1 |
| mark every column guard-protected | kills 1 |
| never publish the derived column list | kills 4 |
| accept a malformed schema | kills 1 |
| **service drops `classification` again** | **SURVIVED** |

That survivor is the most useful thing this run produced. The renderer tests feed a column schema straight into the composer, so the **producing service was never executed** — someone could have reverted that one line and every guard badge in the product would have disappeared with a green suite.

Closed by adding `privacyResolvedDatasetClassification.test.ts` against the **real** service (a fake would only prove the fake forwards it). The mutation now kills 2/2.

> Recording the trap: that suite imports `@omadia/plugin-privacy-guard/dist`, so the package must be rebuilt between mutating `src` and re-running — otherwise the mutation is invisible and "survives" for the wrong reason.

Closes #326

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789713798&installation_model_id=428086&pr_number=743&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F743&signature=97c87db133f4979b276367dce93ae862e2128c0896a212ab5a029820089024c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->