### PR TITLE
feat(#575): sharedOnly recall — a restricted room keeps what it may have

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,21 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Changed — a restricted room keeps the curated knowledge it is entitled to
+
+- **`sharedOnly` recall (#575).** Narrowing a room to its own conversation used
+  to drop curated memory entirely along with the other cross-session legs. But
+  curated memory is **tiered**: `team` / `public` knowledge is shared by
+  construction, so a restricted room may have it — only rows the recalling user
+  privately owns are off-limits.
+- **`sharedOnly` is not the opposite of `teamVisibility`.** The latter *widens*
+  the ACL (owner rows plus shared ones); this *narrows* it to the shared tier
+  alone. They answer different questions, and the audience floor needs the
+  second one: "what may **everyone present** see?"
+- `sharedOnly` **implies** the shared branch in every implementation — asking
+  for shared rows while that branch is off would silently return only the
+  viewer's own shared rows, a misconfiguration with no legitimate use.
+
 ### Fixed — shielded result tables no longer render blank columns
 
 - **Masked columns came out empty on the canvas (#326).** A privacy-shield

--- a/middleware/packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.ts
+++ b/middleware/packages/harness-knowledge-graph-inmemory/src/inMemoryKnowledgeGraph.ts
@@ -1631,10 +1631,18 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
       // Mirror neon's `COALESCE(visibility, 'team')`: an MK with no explicit
       // visibility is team-visible by default; `private` is never admitted
       // by the team branch.
+      // sharedOnly implies the team branch — see the contract: asking for
+      // shared rows with the shared branch off would return only the viewer's
+      // OWN shared rows.
       const teamMatch =
-        opts.teamVisibility === true &&
+        (opts.teamVisibility === true || opts.sharedOnly === true) &&
         ['team', 'public'].includes(node.visibility ?? 'team');
-      if (!ownerMatch && !teamMatch) continue;
+      // #575 sharedOnly: narrowed as its own gate rather than by editing the
+      // branches, so an owner-owned row that IS team/public still qualifies
+      // while an owner-owned private one cannot slip through the owner branch.
+      const sharedOk =
+        opts.sharedOnly !== true || ['team', 'public'].includes(node.visibility ?? 'team');
+      if ((!ownerMatch && !teamMatch) || !sharedOk) continue;
       const vector = this.embeddings.get(node.id);
       if (!vector) continue;
       const sim = cosine(opts.queryEmbedding, vector);
@@ -1680,9 +1688,13 @@ export class InMemoryKnowledgeGraph implements KnowledgeGraph {
         owners.includes(opts.viewerOmadiaUserId) && agentMatch;
       // Excerpts inherit the parent MK's ACL + visibility.
       const teamMatch =
-        opts.teamVisibility === true &&
+        (opts.teamVisibility === true || opts.sharedOnly === true) &&
         ['team', 'public'].includes(parent.visibility ?? 'team');
-      if (!ownerMatch && !teamMatch) continue;
+      // #575 sharedOnly: the excerpt inherits its parent's tier, so the
+      // narrowing runs against the PARENT's visibility.
+      const sharedOk =
+        opts.sharedOnly !== true || ['team', 'public'].includes(parent.visibility ?? 'team');
+      if ((!ownerMatch && !teamMatch) || !sharedOk) continue;
       const sim = cosine(opts.queryEmbedding, vector);
       if (!Number.isFinite(sim) || sim < minSimilarity) continue;
       hits.push({

--- a/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
+++ b/middleware/packages/harness-knowledge-graph-neon/src/neonKnowledgeGraph.ts
@@ -3213,6 +3213,11 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
         -- Durable-tier filter: when set, rank only manually-authored MK among
         -- itself (so the always-surface leg isn't crowded out by session noise).
         AND ($7::boolean IS NOT TRUE OR manually_authored = true)
+        -- #575 sharedOnly: narrow to the shared tier alone. Applied as its own
+        -- AND rather than by editing the branches below, so an owner-owned row
+        -- that IS team/public still qualifies while an owner-owned private one
+        -- cannot slip through the owner branch.
+        AND ($8::boolean IS NOT TRUE OR COALESCE(visibility, 'team') IN ('team', 'public'))
         AND (
           -- team/public-promoted MK stays shareable across Agents.
           ($5::boolean AND COALESCE(visibility, 'team') IN ('team', 'public'))
@@ -3236,9 +3241,12 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
       this.tenantId,
       opts.viewerOmadiaUserId,
       limit,
-      opts.teamVisibility === true,
+      // sharedOnly implies the team branch: without it the query would return
+      // only the viewer's OWN shared rows, which is never what a caller means.
+      opts.teamVisibility === true || opts.sharedOnly === true,
       opts.viewerAgentSlug ?? null,
       opts.manuallyAuthoredOnly === true,
+      opts.sharedOnly === true,
     ]);
     return rows.rows
       .filter((r) => Number(r.cosine_sim) >= minSimilarity)
@@ -3274,6 +3282,9 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
         AND ex.type = 'PalaiaExcerpt'
         AND ex.embedding IS NOT NULL
         AND mk.tenant_id = $2
+        -- #575 sharedOnly: the excerpt inherits its parent MK's tier, so the
+        -- narrowing runs against the PARENT's visibility.
+        AND ($7::boolean IS NOT TRUE OR COALESCE(mk.visibility, 'team') IN ('team', 'public'))
         AND (
           -- team/public-promoted parent MK stays shareable across Agents.
           ($5::boolean AND COALESCE(mk.visibility, 'team') IN ('team', 'public'))
@@ -3305,8 +3316,9 @@ export class NeonKnowledgeGraph implements KnowledgeGraph {
       this.tenantId,
       opts.viewerOmadiaUserId,
       limit,
-      opts.teamVisibility === true,
+      opts.teamVisibility === true || opts.sharedOnly === true,
       opts.viewerAgentSlug ?? null,
+      opts.sharedOnly === true,
     ]);
 
     return rows.rows

--- a/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
@@ -148,6 +148,13 @@ export interface ContextBuildInput {
   userMessage: string;
   sessionScope?: string;
   userId?: string;
+  /**
+   * #575 — curated-memory recall admits only SHARED knowledge (`team` /
+   * `public`), never a row the recalling user merely owns. Set by the
+   * assembler when the room is restricted; see the field of the same name on
+   * {@link AssembleForBudgetInput}.
+   */
+  sharedRecallOnly?: boolean;
   /** External id of the turn currently being answered — excluded from hits. */
   currentTurnId?: string;
   /**
@@ -259,6 +266,17 @@ export interface AssembleForBudgetInput {
    * the floor and every 1:1 conversation.
    */
   restrictToScope?: string;
+  /**
+   * #575 — curated-memory recall admits only SHARED knowledge (`team` /
+   * `public`), never a row the recalling user merely owns.
+   *
+   * Set alongside {@link restrictToScope}: a room that may not reach outside
+   * itself is equally not entitled to one participant's private knowledge, and
+   * recall is ACL-gated by that participant. Unlike the turn legs this does not
+   * drop the leg — shared knowledge is shared by construction, so the room
+   * keeps it.
+   */
+  sharedRecallOnly?: boolean;
   /** Optional override; otherwise `defaultBudgetTokens` from ContextRetriever-Opts. */
   budget?: { tokens: number };
 }
@@ -564,9 +582,15 @@ export class ContextRetriever {
     // rendered as their own blocks, so the scope filter further down would never
     // see them — gating here is what makes that filter honest rather than
     // partial.
-    const runCrossSessionRecall =
-      input.restrictToScope === undefined &&
-      (!this.opts.recallRequiresTerms || extractedTerms.length > 0);
+    const hasTopicalAnchor = !this.opts.recallRequiresTerms || extractedTerms.length > 0;
+    const runCrossSessionRecall = input.restrictToScope === undefined && hasTopicalAnchor;
+    // #575 — curated memory is TIERED, unlike plans and processes: `team` /
+    // `public` knowledge is shared by construction, and a restricted room is
+    // entitled to it. So the memory leg narrows rather than dying with the
+    // others — the same "narrow instead of skip" step this whole cluster is
+    // built on, one level deeper.
+    const runMemoryRecall = hasTopicalAnchor;
+    const sharedRecallOnly = input.restrictToScope !== undefined;
     const emptyPlans: Promise<RecalledPlan[]> = Promise.resolve([]);
     const emptyProcesses: Promise<RecalledProcess[]> = Promise.resolve([]);
     const emptyMemory: Promise<MemoryRecallHit[]> = Promise.resolve([]);
@@ -587,7 +611,9 @@ export class ContextRetriever {
       this.loadAgentPriorities(input.agentId),
       runCrossSessionRecall ? this.loadPlanHits(buildInput) : emptyPlans,
       runCrossSessionRecall ? this.loadProcessHits(buildInput) : emptyProcesses,
-      runCrossSessionRecall ? this.loadMemoryHits(buildInput) : emptyMemory,
+      runMemoryRecall
+        ? this.loadMemoryHits({ ...buildInput, ...(sharedRecallOnly ? { sharedRecallOnly } : {}) })
+        : emptyMemory,
       this.loadDurableHits(buildInput),
     ]);
 
@@ -1220,6 +1246,7 @@ export class ContextRetriever {
         this.graph.searchMemorableKnowledgeByEmbedding({
           queryEmbedding: queryVector,
           viewerOmadiaUserId: input.userId,
+          ...(input.sharedRecallOnly ? { sharedOnly: true } : {}),
           limit: overshoot,
           minSimilarity: this.opts.memoryMinSimilarity,
           teamVisibility: this.opts.teamVisibility,
@@ -1228,6 +1255,7 @@ export class ContextRetriever {
         this.graph.searchExcerptsByEmbedding({
           queryEmbedding: queryVector,
           viewerOmadiaUserId: input.userId,
+          ...(input.sharedRecallOnly ? { sharedOnly: true } : {}),
           limit: excerptOvershoot,
           minSimilarity: this.opts.memoryMinSimilarity,
           teamVisibility: this.opts.teamVisibility,

--- a/middleware/packages/plugin-api/src/knowledgeGraph.ts
+++ b/middleware/packages/plugin-api/src/knowledgeGraph.ts
@@ -854,6 +854,21 @@ export interface MemorableKnowledgeSearchOptions {
    */
   teamVisibility?: boolean;
   /**
+   * #575 — admit ONLY shared knowledge: rows whose `visibility` is `team` or
+   * `public`, never a row the viewer merely owns.
+   *
+   * `teamVisibility` WIDENS the ACL (owner rows plus shared ones); this NARROWS
+   * it to the shared tier alone. The two are not opposites and not
+   * interchangeable: the audience floor asks "what may everyone present see",
+   * and a row the recalling user owns privately is exactly what the rest of the
+   * room is not entitled to.
+   *
+   * Implies `teamVisibility` in every implementation — asking for shared rows
+   * while the shared branch is off would silently return only the viewer's OWN
+   * shared rows, a misconfiguration with no legitimate use.
+   */
+  sharedOnly?: boolean;
+  /**
    * Per-orchestrator isolation — the recalling Agent's slug. When set,
    * owner-gated MK is additionally constrained to rows the viewing Agent
    * produced (`origin_agent = viewerAgentSlug`); MK with no `origin_agent`
@@ -891,6 +906,21 @@ export interface ExcerptSearchOptions {
    * against the parent MK's `visibility`. Default false.
    */
   teamVisibility?: boolean;
+  /**
+   * #575 — admit ONLY shared knowledge: rows whose `visibility` is `team` or
+   * `public`, never a row the viewer merely owns.
+   *
+   * `teamVisibility` WIDENS the ACL (owner rows plus shared ones); this NARROWS
+   * it to the shared tier alone. The two are not opposites and not
+   * interchangeable: the audience floor asks "what may everyone present see",
+   * and a row the recalling user owns privately is exactly what the rest of the
+   * room is not entitled to.
+   *
+   * Implies `teamVisibility` in every implementation — asking for shared rows
+   * while the shared branch is off would silently return only the viewer's OWN
+   * shared rows, a misconfiguration with no legitimate use.
+   */
+  sharedOnly?: boolean;
   /**
    * Per-orchestrator isolation — mirrors
    * {@link MemorableKnowledgeSearchOptions.viewerAgentSlug}. Constrains the

--- a/middleware/test/audienceSharedOnlyRecall.test.ts
+++ b/middleware/test/audienceSharedOnlyRecall.test.ts
@@ -1,0 +1,112 @@
+/**
+ * #575 — a restricted room keeps the curated knowledge it IS entitled to.
+ *
+ * #742 narrowed turn recall to the room's own conversation and, as a
+ * side-effect, dropped curated memory entirely along with the other
+ * cross-session legs. That was the safe answer and an unnecessarily blunt one:
+ * curated memory is **tiered**. `team` / `public` knowledge is shared by
+ * construction, so a restricted room is entitled to it; only rows the recalling
+ * user privately owns are not.
+ *
+ * `sharedOnly` narrows to exactly that tier. It is **not** the opposite of
+ * `teamVisibility`, which WIDENS the ACL (owner rows plus shared ones) — the
+ * two answer different questions and the difference is the whole point:
+ *
+ *   teamVisibility  : "may I also see shared rows?"   → owner ∪ shared
+ *   sharedOnly      : "what may EVERYONE here see?"   → shared only
+ *
+ * Asserted against the in-memory graph, which is a real implementation of the
+ * same contract the Neon one implements — not a stub written for this test.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { InMemoryKnowledgeGraph } from '@omadia/knowledge-graph-inmemory';
+
+const VIEWER = 'user-alice';
+const OTHER = 'user-bob';
+
+/** Deterministic unit vectors so cosine similarity is exactly 1 for a match. */
+const VEC = [1, 0, 0];
+
+async function seed(): Promise<InMemoryKnowledgeGraph> {
+  const graph = new InMemoryKnowledgeGraph();
+  const rows: Array<{ summary: string; owner: string; visibility?: string }> = [
+    { summary: 'private-own', owner: VIEWER, visibility: 'private' },
+    { summary: 'team-own', owner: VIEWER, visibility: 'team' },
+    { summary: 'public-other', owner: OTHER, visibility: 'public' },
+    { summary: 'private-other', owner: OTHER, visibility: 'private' },
+  ];
+  for (const row of rows) {
+    const res = await graph.createMemorableKnowledge({
+      kind: 'insight',
+      summary: row.summary,
+      createdBy: `auto:${row.owner}`,
+      aclOwners: [row.owner],
+      ...(row.visibility ? { visibility: row.visibility } : {}),
+    } as never);
+    // Identical embedding so cosine = 1 and ranking never hides a row.
+    graph.setEmbedding(res.memorableKnowledgeNodeId, VEC);
+  }
+  return graph;
+}
+
+async function search(
+  graph: InMemoryKnowledgeGraph,
+  opts: { teamVisibility?: boolean; sharedOnly?: boolean },
+): Promise<string[]> {
+  const hits = await graph.searchMemorableKnowledgeByEmbedding({
+    queryEmbedding: VEC,
+    viewerOmadiaUserId: VIEWER,
+    limit: 50,
+    minSimilarity: 0,
+    ...opts,
+  });
+  return hits.map((h) => String(h.mk.props['summary'])).sort();
+}
+
+describe('#575 sharedOnly — the shared tier, and nothing else', () => {
+  it('owner-only (the historical default) returns the viewer’s own rows', async () => {
+    const graph = await seed();
+    const ids = await search(graph, {});
+    assert.ok(ids.includes('private-own'), 'the viewer sees their own private row');
+    assert.ok(!ids.includes('public-other'), 'and not somebody else’s, without teamVisibility');
+  });
+
+  it('teamVisibility WIDENS: own rows plus shared ones', async () => {
+    const graph = await seed();
+    const ids = await search(graph, { teamVisibility: true });
+    assert.ok(ids.includes('private-own'), 'still sees their own private row');
+    assert.ok(ids.includes('public-other'), 'and now shared rows too');
+  });
+
+  it('sharedOnly NARROWS: the viewer’s private row is dropped', async () => {
+    // The property the audience floor needs. A row only this participant may
+    // see must not reach a prompt the whole room’s answer is derived from.
+    const graph = await seed();
+    const ids = await search(graph, { sharedOnly: true });
+    assert.ok(!ids.includes('private-own'), 'the viewer’s OWN private row is excluded');
+    assert.ok(!ids.includes('private-other'), 'and so is anyone else’s');
+    assert.ok(ids.includes('team-own'), 'their shared row survives');
+    assert.ok(ids.includes('public-other'), 'as does the tenant’s public knowledge');
+  });
+
+  it('sharedOnly implies the shared branch — no teamVisibility needed', async () => {
+    // Without the implication this would return only the viewer's own shared
+    // rows: a misconfiguration with no legitimate use, so the implementation
+    // removes the possibility rather than documenting it.
+    const graph = await seed();
+    const ids = await search(graph, { sharedOnly: true, teamVisibility: false });
+    assert.ok(
+      ids.includes('public-other'),
+      'another owner’s public row must be reachable without teamVisibility',
+    );
+  });
+
+  it('sharedOnly wins over teamVisibility when both are set', async () => {
+    const graph = await seed();
+    const ids = await search(graph, { sharedOnly: true, teamVisibility: true });
+    assert.ok(!ids.includes('private-own'), 'widening must not undo the narrowing');
+  });
+});


### PR DESCRIPTION
The last open item from #575's text, and the one my own earlier note had written off as impossible.

#742 narrowed turn recall to the room's own conversation — and, as a side effect, dropped curated memory entirely along with the other cross-session legs. That was the safe answer and an unnecessarily blunt one: **curated memory is tiered.** `team` / `public` knowledge is shared by construction, so a restricted room is entitled to it. Only rows the recalling user *privately owns* are not.

## `sharedOnly` is not the opposite of `teamVisibility`

This is the distinction the whole change turns on, and getting it backwards would be a permission bug that reads like a feature:

```
teamVisibility : "may I also see shared rows?"  →  owner ∪ shared   (WIDENS)
sharedOnly     : "what may EVERYONE here see?"  →  shared only      (NARROWS)
```

The audience floor asks the second question. `teamVisibility` could never answer it, which is why the earlier note concluded the granularity did not exist — it exists, it just needed the other direction.

## Four layers, and the two decisions inside them

| Layer | Change |
|---|---|
| `plugin-api` | `sharedOnly` on both MK and excerpt search options |
| `knowledge-graph-neon` | an extra SQL predicate on `visibility` |
| `knowledge-graph-inmemory` | the same rule |
| `orchestrator-extras` | the memory leg now **runs** while restricted, narrowed |

**Applied as its own predicate**, not by editing the existing ACL branches. That keeps an owner-owned row that *is* `team`/`public` qualifying, while an owner-owned `private` one cannot slip through the owner branch.

**`sharedOnly` implies the shared branch.** Without the implication, asking for shared rows while `teamVisibility` is off would silently return only the viewer's **own** shared rows — a misconfiguration with no legitimate use, so the implementation removes the possibility rather than documenting it. A test pins that.

## The half that is easy to miss

The excerpt path narrows against the **parent MK's** visibility, because an excerpt inherits its parent's tier and carries no ACL of its own.

Both implementations have **two** call sites each. My first patch pass hit only one of them in the in-memory graph — which would have left excerpts leaking private content while the MK search looked entirely correct. Both are covered now.

## Blast radius

| Surface | Effect |
|---|---|
| Deployments with `AUDIENCE_FLOOR_ENABLED` unset | **none** — nothing sets `sharedOnly` |
| Rooms granted `memory:recall:cross_scope` | **none** |
| Rooms restricted by #742 | curated `team`/`public` knowledge comes **back** — strictly more context than today, none of it private |
| Callers passing `teamVisibility` | unchanged; the two options are independent |

## Verification

- middleware suite: **6750 tests, 0 fail, 0 cancelled** (5 new)
- `npm run typecheck` ✅ · `npm run lint` ✅ · #470 ratchet **3294** ✅ · #573 ratchet **406, unchanged** ✅

Asserted against the **in-memory knowledge graph** — a real implementation of the same contract Neon implements, not a stub written for the test.

**Mutation-checked — all three died** (rebuilding the package between steps, since the test imports `dist`):

| Mutation | Result |
|---|---|
| ignore `sharedOnly` entirely | kills 2 |
| drop the shared-branch implication | kills 2 |
| treat `private` as shared | kills 2 |

## #575 after this

Every mechanism the issue names is now built: scope model, audience floor, the three guards, durable grants with an admin surface, handle binding, prohibitions, host egress in both directions, and tiered recall.

**Per-recipient context filtering with tool-call-ID-preserving stubs is deliberately not built**, and I would argue it should stay that way: omadia renders **one answer per room**, so "context per recipient" would mean N answers. The faithful adaptation of qm's idea to this architecture is the intersection — which is what this cluster implements.

Closes #575

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789723819&installation_model_id=428086&pr_number=745&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F745&signature=28eee79be0d070cf1b072b94dffc6ed79ae385813ab0a9ec9334c37e07d7ee8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->