### PR TITLE
fix(#687): measure i18n literals with an AST scan, sweep ListView

### DIFF
--- a/web-ui/app/_lib/i18n-structural.test.ts
+++ b/web-ui/app/_lib/i18n-structural.test.ts
@@ -18,6 +18,10 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+// Typed by `scripts/i18n-literal-scan.d.mts` — the scanner stays plain JS so it
+// runs with a bare `node scripts/…`, but the test still typechecks against it.
+import { scanFile } from '../../scripts/i18n-literal-scan.mjs';
+
 import { isSeededAgentDescription } from './agents';
 
 const APP_DIR = path.resolve(__dirname, '..');
@@ -117,15 +121,33 @@ describe('#679 / I5 — the boot-seeded agent description is recognised', () => 
 });
 
 describe('#679 / I3 — swept components carry no user-facing literals', () => {
-  it('ListView renders no German literal', () => {
-    // This component held three German sentences — the rule in
-    // `web-ui/CLAUDE.md` broken twice over: hardcoded, and hardcoded in the
-    // language that is supposed to exist only in `messages/de.json`.
-    const src = read('graph/_components/ListView.tsx');
+  // #687 — the previous form of this guard named three literal strings and
+  // asserted they were gone. It passed while a FOURTH German sentence sat 100
+  // lines below in the same file, in a sibling component that never called
+  // `useTranslations` at all. A guard built from a hand-made list only ever
+  // guards what happened to be on the list.
+  //
+  // So the ratchet now asks the scanner the same question the CLI asks:
+  // does this file still contain a user-facing literal? Files join `SWEPT`
+  // once they answer no, and can never silently regress afterwards.
+  const SWEPT_COMPONENTS = ['graph/_components/ListView.tsx'];
 
-    expect(src).not.toContain('keine Entities in diesem Turn');
-    expect(src).not.toContain('lade Run…');
-    expect(src).not.toContain('keine Run-Trace erfasst');
-    expect(src).toContain("useTranslations('graph.listView')");
+  for (const file of SWEPT_COMPONENTS) {
+    it(`${file} has no untranslated user-facing literal`, () => {
+      const { hits } = scanFile(file);
+      const actionable = hits
+        .filter((h) => h.reason === 'translate' || h.reason === 'review')
+        .map((h) => `${String(h.line)}: ${h.text}`);
+
+      expect(actionable).toEqual([]);
+    });
+  }
+
+  it('ListView resolves its strings through the catalogue', () => {
+    // The other direction: a file could satisfy the check above by deleting
+    // its text instead of translating it.
+    expect(read('graph/_components/ListView.tsx')).toContain(
+      "useTranslations('graph.listView')",
+    );
   });
 });

--- a/web-ui/app/graph/_components/ListView.tsx
+++ b/web-ui/app/graph/_components/ListView.tsx
@@ -67,7 +67,9 @@ function TurnCard({
     .replace('T', ' ')
     .slice(0, 19);
   const user = String(turn.props['userMessage'] ?? '');
-  const tools = turn.props['toolCalls'];
+  // `props` is untyped JSON; coerce once and render only when it really is a
+  // number, rather than stringifying whatever came back.
+  const toolCount = Number(turn.props['toolCalls']);
 
   const toggle = (): void => {
     const next = !open;
@@ -79,7 +81,9 @@ function TurnCard({
     <div className="rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-4 text-sm shadow-sm">
       <div className="mb-2 flex items-center gap-3 text-[11px] text-[color:var(--fg-muted)]">
         <span className="font-mono">{time}</span>
-        {tools !== undefined && <span>tools={String(tools)}</span>}
+        {Number.isFinite(toolCount) && (
+          <span>{t('toolsLabel', { count: toolCount })}</span>
+        )}
         <Button
           variant="secondary"
           size="sm"
@@ -145,6 +149,7 @@ function RunTracePanel({
   run: RunTraceView;
   onEntityClick: (id: string) => void;
 }): React.ReactElement {
+  const t = useTranslations('graph.listView');
   const status = String(run.run.props['status'] ?? 'unknown');
   const duration = Number(run.run.props['durationMs'] ?? 0);
   const iterations = Number(run.run.props['iterations'] ?? 0);
@@ -156,7 +161,7 @@ function RunTracePanel({
         <StatusPill status={status} />
         <span>{formatMs(duration)}</span>
         <span>·</span>
-        <span>{iterations} iter</span>
+        <span>{t('iterations', { count: iterations })}</span>
         {user && (
           <>
             <span>·</span>
@@ -168,7 +173,7 @@ function RunTracePanel({
       {run.orchestratorToolCalls.length > 0 && (
         <div className="flex flex-col gap-1 rounded border border-[color:var(--border)] bg-[color:var(--bg-soft)] p-2">
           <div className="text-[10px] font-semibold uppercase tracking-wide text-[color:var(--fg-subtle)]">
-            Orchestrator-Tools
+            {t('orchestratorTools')}
           </div>
           {run.orchestratorToolCalls.map((tc) => (
             <ToolCallRow
@@ -200,11 +205,12 @@ function RunTracePanel({
               <span className="font-semibold">🤖 {agentName}</span>
               <span className="text-[color:var(--fg-muted)]">{formatMs(invDur)}</span>
               <span className="text-[color:var(--fg-muted)]">·</span>
-              <span className="text-[color:var(--fg-muted)]">{subIter} iter</span>
+              <span className="text-[color:var(--fg-muted)]">
+                {t('iterations', { count: subIter })}
+              </span>
               <span className="text-[color:var(--fg-muted)]">·</span>
               <span className="text-[color:var(--fg-muted)]">
-                {inv.toolCalls.length} tool-call
-                {inv.toolCalls.length === 1 ? '' : 's'}
+                {t('toolCalls', { count: inv.toolCalls.length })}
               </span>
             </div>
             {inv.toolCalls.length > 0 && (
@@ -225,7 +231,7 @@ function RunTracePanel({
       {run.orchestratorToolCalls.length === 0 &&
         run.agentInvocations.length === 0 && (
           <div className="text-[11px] italic text-[color:var(--fg-subtle)]">
-            Run ohne Tool-Calls (reine Textantwort)
+            {t('noToolCalls')}
           </div>
         )}
     </div>

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -4572,7 +4572,12 @@
       "runTrace": "Run-Trace",
       "noEntities": "Keine Entities in diesem Turn",
       "loadingRun": "lade Run…",
-      "noRunTrace": "Kein Run-Trace erfasst"
+      "noRunTrace": "Kein Run-Trace erfasst",
+      "noToolCalls": "Run ohne Tool-Calls (reine Textantwort)",
+      "toolsLabel": "Tools={count}",
+      "iterations": "{count} Iter.",
+      "orchestratorTools": "Orchestrator-Tools",
+      "toolCalls": "{count, plural, one {# Tool-Call} other {# Tool-Calls}}"
     }
   },
   "memory": {

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -4572,7 +4572,12 @@
       "runTrace": "Run trace",
       "noEntities": "No entities in this turn",
       "loadingRun": "loading run…",
-      "noRunTrace": "No run trace recorded"
+      "noRunTrace": "No run trace recorded",
+      "noToolCalls": "Run without tool calls (plain text answer)",
+      "toolsLabel": "tools={count}",
+      "iterations": "{count} iter",
+      "orchestratorTools": "Orchestrator tools",
+      "toolCalls": "{count, plural, one {# tool call} other {# tool calls}}"
     }
   },
   "memory": {

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -24,7 +24,8 @@
     "lint:fix": "eslint . --fix",
     "test": "vitest run",
     "test:watch": "vitest",
-    "i18n:check": "node scripts/i18n-validate.mjs"
+    "i18n:check": "node scripts/i18n-validate.mjs",
+    "i18n:literals": "node scripts/i18n-literal-scan.mjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/web-ui/scripts/i18n-literal-scan.d.mts
+++ b/web-ui/scripts/i18n-literal-scan.d.mts
@@ -1,0 +1,32 @@
+/**
+ * Type contract for the plain-JS scanner, so `i18n-structural.test.ts` can
+ * ratchet against it under `tsc --noEmit`. The scanner itself stays JS: it is
+ * tooling that must run with a bare `node scripts/…` and no build step.
+ */
+export type LiteralReason =
+  | 'translate'
+  | 'review'
+  | 'spec-keyword'
+  | 'api-enum'
+  | 'code'
+  | 'placeholder'
+  | 'brand'
+  | 'symbol';
+
+export interface LiteralHit {
+  file: string;
+  line: number;
+  /** `jsx-text`, `jsx-child-string`, or `prop:<name>`. */
+  kind: string;
+  text: string;
+  reason: LiteralReason;
+}
+
+export interface ScanResult {
+  hits: LiteralHit[];
+  /** Whether the file already imports a next-intl hook. */
+  wired: boolean;
+}
+
+/** @param rel path relative to `web-ui/app`. */
+export function scanFile(rel: string): ScanResult;

--- a/web-ui/scripts/i18n-literal-scan.mjs
+++ b/web-ui/scripts/i18n-literal-scan.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+/**
+ * Issue #687 / category I3 — find user-facing string literals in `app/**`.
+ *
+ * #601 estimated this category with `grep` and reported 87 hits, of which only
+ * 44 were real translations. The other 43 were JSON-Schema keywords, API enum
+ * values, format-illustrating placeholders and type-signature noise — strings
+ * that a translator MUST NOT touch. Feeding that list to a translation pass is
+ * how you get `"Zeichenkette"` where the API expects `"string"`.
+ *
+ * So this scan does two things `grep` cannot:
+ *
+ *  1. It parses TSX with the TypeScript compiler and collects only JSX text
+ *     nodes and the string-valued props a user actually reads. A `t('key')`
+ *     argument, an import path or a `className` never enters the list, because
+ *     they are never in those syntactic positions.
+ *  2. It assigns every hit a REASON CODE, using the same vocabulary as
+ *     `messages/GLOSSARY.md` and `scripts/i18n-identical-allowlist.json`.
+ *     Only `translate` is work; the rest is documented non-work.
+ *
+ * This is a report, not a gate: it always exits 0. The gate is the per-file
+ * ratchet in `app/_lib/i18n-structural.test.ts` — a file is added to its list
+ * once it is clean, so the category cannot silently grow back.
+ *
+ * Usage:
+ *   node scripts/i18n-literal-scan.mjs                 # summary + per-file counts
+ *   node scripts/i18n-literal-scan.mjs --reason translate   # only real work
+ *   node scripts/i18n-literal-scan.mjs --file admin/usage/page.tsx
+ *   node scripts/i18n-literal-scan.mjs --json          # machine-readable
+ */
+import { readFileSync } from 'node:fs';
+import { globSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const APP_DIR = resolve(HERE, '..', 'app');
+
+/**
+ * Props whose string value is rendered to, or read aloud to, a human. Kept
+ * closed on purpose: an open list ("any prop ending in `label`") re-imports the
+ * false-positive problem this script exists to remove.
+ */
+const USER_FACING_PROPS = new Set([
+  'alt',
+  'aria-label',
+  'aria-description',
+  'aria-placeholder',
+  'aria-roledescription',
+  'aria-valuetext',
+  'confirmLabel',
+  'description',
+  'emptyMessage',
+  'error',
+  'heading',
+  'hint',
+  'label',
+  'message',
+  'placeholder',
+  'subtitle',
+  'title',
+  'tooltip',
+]);
+
+/**
+ * JSON-Schema and TypeScript vocabulary. These appear in the schema editors and
+ * the tool-parameter tables, where they name the type the API will accept.
+ * Translating them changes what the user believes they may type.
+ */
+const SPEC_KEYWORDS = new Set([
+  'any', 'array', 'boolean', 'const', 'enum', 'false', 'float', 'int',
+  'integer', 'null', 'number', 'object', 'string', 'true', 'undefined',
+  'unknown', 'void', 'anyOf', 'oneOf', 'allOf', 'items', 'properties',
+  'required', 'additionalProperties', 'json', 'yaml', 'text', 'markdown',
+]);
+
+/** Product nouns from `messages/GLOSSARY.md` — English by decision, not by neglect. */
+const BRAND_TERMS = new Set([
+  'omadia', 'byte5', 'privacy shield', 'orchestrator', 'orchestrators',
+  'conductor', 'turn', 'run', 'tool', 'tools', 'skill', 'skills', 'guard',
+  'trace', 'token', 'tokens', 'cache', 'stream', 'sycophancy',
+]);
+
+/**
+ * Algorithm and encoding names. They read like ordinary lowercase words, which
+ * is exactly why `grep` mistook them for prose in #601 — but `sha256` localised
+ * is a wrong value, not a translation.
+ */
+const TECH_TERMS = new Set([
+  'sha1', 'sha256', 'sha512', 'md5', 'base64', 'utf-8', 'utf8', 'uuid', 'ulid',
+  'cosine', 'euclidean', 'dotproduct', 'jaccard', 'bm25', 'regex', 'cron',
+  'http', 'https', 'csv', 'tsv', 'xml', 'html', 'svg', 'png', 'jpg', 'pdf',
+  'id', 'url', 'uri', 'api', 'sql', 'jwt', 'oauth', 'mcp', 'sse',
+]);
+
+/**
+ * The exceptions `web-ui/CLAUDE.md` already documents, encoded so the scan does
+ * not re-open a decision that was made once. Reading the rule beats re-arguing
+ * it in every review — and a file listed here is a deliberate exception, not an
+ * untouched one.
+ */
+const DOCUMENTED_EXCEPTIONS = new Map([
+  ['global-error.tsx', 'renders when the intl provider itself has failed; intentionally bilingual'],
+  ['chat/page.tsx', 'MOCK_KG_WALK is a dev-only fixture behind ?kgmock=1'],
+]);
+
+const REASONS = ['translate', 'review', 'spec-keyword', 'api-enum', 'code', 'placeholder', 'brand', 'symbol'];
+
+/** A token that names something the machine reads, not something a human reads. */
+function isCodeToken(tok) {
+  const lower = tok.toLowerCase();
+  if (TECH_TERMS.has(lower)) return true;
+  if (SPEC_KEYWORDS.has(lower)) return true;
+  if (tok.startsWith('/')) return true;                 // route: `/admin/duplicates`
+  if (/[._\\/<>()[\]$@]/.test(tok)) return true;          // punctuation only code carries
+  if (/^[a-z]+[A-Z]/.test(tok)) return true;            // camelCase
+  return false;
+}
+
+/**
+ * Order matters: the narrow, provable exemptions run before the catch-all.
+ * `translate` is what is left over, which is the safe direction — a
+ * misclassified exemption hides work, a misclassified `translate` only costs a
+ * review comment.
+ */
+function classify(text) {
+  const t = text.trim();
+  const lower = t.toLowerCase();
+
+  if (!/\p{L}/u.test(t)) return 'symbol';
+  if (BRAND_TERMS.has(lower)) return 'brand';
+  if (SPEC_KEYWORDS.has(lower)) return 'spec-keyword';
+
+  // `HOT`, `WARM | COLD`, `PENDING/DONE` — API enum values echoed into a badge.
+  if (/^[A-Z][A-Z0-9_]*([\s]*[|/,][\s]*[A-Z][A-Z0-9_]*)*$/.test(t)) return 'api-enum';
+
+  // A format being demonstrated, not a sentence: `https://…`, `{orgId}`,
+  // `user@example.com`. Localising these teaches a wrong value.
+  //
+  // Deliberately NOT keyed on a trailing ellipsis: `Suche…` is prose with an
+  // ellipsis, and exempting it would hide real work — the failure direction
+  // this script exists to avoid.
+  if (/:\/\/|\{[^}]*\}|%[sd]/.test(t)) return 'placeholder';
+  if (/^[\w.+-]+@[\w.-]+\.\w+$/.test(t)) return 'placeholder';
+
+  // Classify by TOKEN, not by the whole string. `← /admin` is an arrow plus a
+  // route; reading it as one blob made it look like prose in #601.
+  const words = t.split(/\s+/).filter((w) => /\p{L}|\d/u.test(w));
+  if (words.length > 0 && words.every(isCodeToken)) return 'code';
+
+  if (t.length < 2) return 'symbol';
+
+  // A single bare word is genuinely ambiguous: `Status` is a label to
+  // translate, `triage` is an enum value to leave alone, and nothing in the
+  // syntax distinguishes them. Splitting it out keeps `translate` a list
+  // somebody can act on without re-reading every entry.
+  return words.length === 1 ? 'review' : 'translate';
+}
+
+function stringValueOf(node) {
+  if (node === undefined) return undefined;
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
+  if (ts.isJsxExpression(node)) return stringValueOf(node.expression);
+  return undefined;
+}
+
+/**
+ * Exported so `app/_lib/i18n-structural.test.ts` can ratchet on the SAME
+ * classification the CLI reports. A test that re-implemented the rule would
+ * drift from it, which is how #679's guard ended up naming three literal
+ * strings while a fourth survived in the same file.
+ */
+export function scanFile(rel) {
+  const src = readFileSync(resolve(APP_DIR, rel), 'utf8');
+  const sf = ts.createSourceFile(rel, src, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const hits = [];
+
+  const record = (node, text, kind, forcedReason) => {
+    const trimmed = text.trim();
+    if (trimmed === '') return;
+    const { line } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+    hits.push({
+      file: rel,
+      line: line + 1,
+      kind,
+      text: trimmed,
+      reason: forcedReason ?? classify(trimmed),
+    });
+  };
+
+  const walk = (node) => {
+    if (ts.isJsxText(node)) {
+      // JSX collapses whitespace-only text between elements; those carry no
+      // meaning and would otherwise dominate the report.
+      record(node, node.text, 'jsx-text');
+    } else if (ts.isJsxAttribute(node) && ts.isIdentifier(node.name) === false) {
+      // namespaced attribute — ignore
+    } else if (ts.isJsxAttribute(node)) {
+      const name = node.name.getText(sf);
+      if (USER_FACING_PROPS.has(name)) {
+        const value = stringValueOf(node.initializer);
+        if (value !== undefined) {
+          // A one-word `placeholder=` is a format demo — `acme`, `api`,
+          // `github_pat_…`. GLOSSARY.md: "a form hint teaches a FORMAT;
+          // localising it teaches a wrong value."
+          const forced =
+            name === 'placeholder' && !/\s/.test(value.trim()) ? 'placeholder' : undefined;
+          record(node, value, `prop:${name}`, forced);
+        }
+      }
+    } else if (ts.isJsxExpression(node) && node.parent && ts.isJsxElement(node.parent)) {
+      // `<p>{'literal'}</p>` — same thing as JSX text, written differently.
+      const value = stringValueOf(node);
+      if (value !== undefined) record(node, value, 'jsx-child-string');
+    }
+    ts.forEachChild(node, walk);
+  };
+
+  walk(sf);
+  return { hits, wired: /use(Translations|Format)|getTranslations/.test(src) };
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const flag = (name) => {
+    const i = argv.indexOf(`--${name}`);
+    return i === -1 ? undefined : argv[i + 1];
+  };
+  const asJson = argv.includes('--json');
+  const wantReason = flag('reason');
+  const wantFile = flag('file');
+
+  const files = globSync('**/*.tsx', { cwd: APP_DIR })
+    .filter((f) => !f.includes('.test.') && !f.includes('__tests__'))
+    .filter((f) => !DOCUMENTED_EXCEPTIONS.has(f))
+    .filter((f) => (wantFile === undefined ? true : f.includes(wantFile)))
+    .sort();
+
+  const all = [];
+  const unwired = [];
+  for (const f of files) {
+    const { hits, wired } = scanFile(f);
+    all.push(...hits);
+    if (!wired && hits.some((h) => h.reason === 'translate')) unwired.push(f);
+  }
+
+  const shown = wantReason === undefined ? all : all.filter((h) => h.reason === wantReason);
+
+  if (asJson) {
+    console.log(JSON.stringify({ files: files.length, hits: shown, unwired }, null, 2));
+    return;
+  }
+
+  const byReason = Object.fromEntries(REASONS.map((r) => [r, 0]));
+  for (const h of all) byReason[h.reason] += 1;
+
+  console.log(`i18n-literal-scan: ${String(files.length)} files, ${String(all.length)} literals`);
+  console.log(`(${String(DOCUMENTED_EXCEPTIONS.size)} file(s) skipped as documented exceptions — see web-ui/CLAUDE.md)\n`);
+  for (const r of REASONS) {
+    const note = r === 'translate' ? '  <- work' : r === 'review' ? '  <- needs a human call' : '';
+    console.log(`  ${r.padEnd(13)} ${String(byReason[r]).padStart(4)}${note}`);
+  }
+
+  const perFile = new Map();
+  for (const h of shown) perFile.set(h.file, (perFile.get(h.file) ?? 0) + 1);
+  const ranked = [...perFile.entries()].sort((a, b) => b[1] - a[1]);
+
+  console.log(`\n${String(ranked.length)} file(s)${wantReason === undefined ? '' : ` with reason '${wantReason}'`}:`);
+  for (const [file, n] of ranked) {
+    console.log(`  ${String(n).padStart(3)}  ${file}${unwired.includes(file) ? '   (no i18n hook yet)' : ''}`);
+  }
+
+  if (wantFile !== undefined || wantReason !== undefined) {
+    console.log('');
+    for (const h of shown) {
+      console.log(`  ${h.file}:${String(h.line)}  [${h.reason}/${h.kind}]  ${JSON.stringify(h.text)}`);
+    }
+  }
+}
+
+// Only run the report when invoked as a CLI; the test imports `scanFile`.
+if (process.argv[1] !== undefined && process.argv[1].endsWith('i18n-literal-scan.mjs')) {
+  main();
+}


### PR DESCRIPTION
Closes part of #687 (steps 1–3 of the I3 category).

## Why grep was not enough

`#601` measured this category with `grep` and reported 87 hits, of which **44 were real translations**. The rest were JSON-Schema keywords, API enum values and format-illustrating placeholders — strings a translator must *not* touch. Feeding that list to a translation pass is how you get `"Zeichenkette"` where the API expects `"string"`.

So the throwaway scan is promoted to `web-ui/scripts/i18n-literal-scan.mjs` and does two things grep cannot:

1. **Parses TSX with the TypeScript compiler.** It collects only JSX text nodes and the string-valued props a user actually reads. A `t('key')` argument, an import path or a `className` never enters the list, because they are never in those syntactic positions.
2. **Assigns every hit a reason code**, reusing the vocabulary already established by `messages/GLOSSARY.md` and `scripts/i18n-identical-allowlist.json`. Only `translate` is work; the rest is *documented* non-work.

The exceptions `web-ui/CLAUDE.md` already documents (`global-error.tsx`, the `?kgmock=1` fixture) are encoded in the scanner rather than re-argued in every review.

Run it with `npm run i18n:literals`. It always exits 0 — it is a report. The gate is the ratchet below.

## The defect it found on the first run

`#679` pinned `graph/_components/ListView.tsx` as swept. Its guard asserted that **three named strings** were gone:

```ts
expect(src).not.toContain('keine Entities in diesem Turn');
expect(src).not.toContain('lade Run…');
expect(src).not.toContain('keine Run-Trace erfasst');
```

It passed — while a **fourth German sentence** sat 100 lines below at `ListView.tsx:228`:

```tsx
<div className="text-[11px] italic …">
  Run ohne Tool-Calls (reine Textantwort)
</div>
```

Root cause: `useTranslations` was called in `TurnCard`, but this markup lives in `RunTracePanel`, a sibling component in the same file that **never called it at all**. The file looked wired, so nobody looked twice.

**A ratchet built from a hand-made list only ever guards what happened to be on the list.** The I3 guard now asks the scanner the same question the CLI asks — does this file still contain a user-facing literal? — so files join `SWEPT_COMPONENTS` once they answer no and cannot silently regress.

## What changed in ListView

Six sites now resolve through the catalogue. One of them was a second bug:

```tsx
{inv.toolCalls.length} tool-call
{inv.toolCalls.length === 1 ? '' : 's'}
```

Manual English pluralisation produces wrong German regardless of the catalogue. It is now an ICU plural (`graph.listView.toolCalls`), which the existing parity suite checks for argument/tag agreement across locales.

Also: `turn.props['toolCalls']` is untyped JSON and was rendered via `String(…)`. It is coerced once and rendered only when it really is a number, rather than stringifying whatever came back.

## Measured state of I3

| | Issue estimate | Measured |
|---|---|---|
| I3 candidates | ~217 across 63 files | **553 literals across 232 files** |
|  of which actionable | — | **40 `translate`** + **132 `review`**, across 134 files |
|  of which documented non-work | — | 383 — `code` 47 · `placeholder` 31 · `spec-keyword` 16 · `api-enum` 9 · `symbol` 274 |
| I4 `export const metadata` | listed as open | **0 files** — #679 did close this category |

`review` is kept separate from `translate` on purpose: a single bare word is genuinely ambiguous. `Status` is a label to translate; `triage` is an enum value to leave alone, and nothing in the syntax distinguishes them. Collapsing the two is precisely what made #601's list unusable without re-reading every entry.

The remaining 40 + 132 are the triage backlog for the rest of #687; this PR clears `ListView.tsx` and puts the measurement on a reproducible footing.

## Verification

- `npm run i18n:check` — OK, 3730 keys, locales en + de
- `npm run typecheck` (`tsc --noEmit`) — clean. The scanner stays plain JS so it runs with a bare `node scripts/…`; `scripts/i18n-literal-scan.d.mts` gives the test a typed contract against it.
- `npx eslint` on all changed files — clean
- `npm test` — **736/736 passed across 88 files**
- **Mutation check:** restoring the German literal at `ListView.tsx:228` turns exactly the new ratchet red and nothing else; reverting the mutation returns 9/9.

## Blast radius

The scanner and its `.d.mts` are new files. `package.json` gains one script target. `messages/{en,de}.json` gain five keys under `graph.listView`, additive only. `ListView.tsx` and `i18n-structural.test.ts` are the only behavioural changes, both confined to the `graph` route.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789731864&installation_model_id=428086&pr_number=747&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F747&signature=ba2418563e9c3f67aadfad36654373e481dbdc0e0c781f87d6e8a078845f9fd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->