### PR TITLE
fix: drop temperature for models that reject it — inbound security screening was fail-open

### DIFF
--- a/middleware/packages/llm-adapter-anthropic/src/anthropicProvider.ts
+++ b/middleware/packages/llm-adapter-anthropic/src/anthropicProvider.ts
@@ -223,6 +223,47 @@ function buildSystem(req: LlmRequest): unknown {
   }));
 }
 
+/**
+ * Model families that reject any `temperature` other than the default.
+ *
+ * Measured against the live API on 2026-08-19, because the rule is NOT
+ * derivable from the version number and guessing it wrong fails a security
+ * control silently:
+ *
+ * | model              | omitted | 0   | 0.5 | 1  |
+ * |--------------------|---------|-----|-----|----|
+ * | claude-opus-4-6    | OK      | OK  | OK  | OK |
+ * | claude-opus-4-7    | OK      | 400 | 400 | OK |
+ * | claude-opus-4-8    | OK      | 400 | 400 | OK |
+ * | claude-opus-5      | OK      | 400 | 400 | OK |
+ * | claude-sonnet-4-6  | OK      | OK  | OK  | OK |
+ * | claude-sonnet-5    | OK      | 400 | 400 | OK |
+ * | claude-haiku-4-5   | OK      | OK  | OK  | OK |
+ *
+ * Note `opus-4-6` accepts it while `opus-4-7` does not — so "newer than X"
+ * is not the rule, and a version comparison would be a plausible, wrong gate.
+ * `temperature: 1` is always accepted because it IS the default; the API only
+ * objects to being asked for a value it no longer honours.
+ */
+const TEMPERATURE_UNSUPPORTED = [
+  'claude-opus-4-7',
+  'claude-opus-4-8',
+  'claude-opus-5',
+  'claude-sonnet-5',
+  'claude-fable-5',
+];
+
+/**
+ * Whether this model still honours `temperature`.
+ *
+ * Exported for the test and for callers that want to know their determinism
+ * request will be dropped. The match is a prefix so dated ids
+ * (`claude-sonnet-5-20260101`) and provider-qualified ids resolve correctly.
+ */
+export function supportsTemperature(model: string): boolean {
+  return !TEMPERATURE_UNSUPPORTED.some((m) => model.includes(m));
+}
+
 function buildParams(req: LlmRequest): Record<string, unknown> {
   const system = buildSystem(req);
   return {
@@ -230,7 +271,13 @@ function buildParams(req: LlmRequest): Record<string, unknown> {
     max_tokens: req.maxTokens,
     messages: toAnthropicMessages(req.messages),
     ...(system !== undefined ? { system } : {}),
-    ...(req.temperature !== undefined ? { temperature: req.temperature } : {}),
+    // Sending a temperature a model no longer honours is a hard 400, not a
+    // warning. Callers ask for determinism (`temperature: 0`) on paths where
+    // an exception degrades to fail-open — the security screener is one — so
+    // dropping the parameter is strictly better than raising.
+    ...(req.temperature !== undefined && supportsTemperature(req.model)
+      ? { temperature: req.temperature }
+      : {}),
     ...(req.tools !== undefined && req.tools.length > 0
       ? { tools: toAnthropicTools(req.tools, req.cacheHints) }
       : {}),

--- a/middleware/packages/llm-adapter-anthropic/src/index.ts
+++ b/middleware/packages/llm-adapter-anthropic/src/index.ts
@@ -11,6 +11,7 @@ export { anthropicAdapter, registerAnthropicAdapter } from './adapter.js';
 export {
   createAnthropicProvider,
   classifyAnthropicError,
+  supportsTemperature,
   type AnthropicProviderOptions,
 } from './anthropicProvider.js';
 

--- a/middleware/test/llmProviderAnthropicAdapter.test.ts
+++ b/middleware/test/llmProviderAnthropicAdapter.test.ts
@@ -573,3 +573,72 @@ test('legacy plugin wrapper preserves stop_sequence', async () => {
   });
   assert.equal(res.stopReason, 'stop_sequence');
 });
+
+/**
+ * Regression: `temperature` is a hard 400 on some models, and the adapter is
+ * the layer that knows the wire contract.
+ *
+ * Found when the adversarial eval ran for the first time (its API key had only
+ * just been set) and crashed with "`temperature` is deprecated for this
+ * model". The eval was the loud symptom; the quiet one is
+ * `LlmScreener.screen()`, which sends `temperature: 0` on every inbound turn
+ * and whose caller turns any exception into `unscreenable` — fail-open. With
+ * the repo's own `DEFAULT_ORCHESTRATOR_MODEL` (`claude-opus-4-8`), #579's
+ * inbound screening was therefore a no-op that reported no error.
+ *
+ * The table in `supportsTemperature` is measured, not inferred: `opus-4-6`
+ * accepts the parameter and `opus-4-7` rejects it, so "newer than X" is a
+ * plausible and wrong rule.
+ */
+test('complete() drops temperature for models that reject it', async () => {
+  for (const model of [
+    'claude-opus-4-7',
+    'claude-opus-4-8',
+    'claude-opus-5',
+    'claude-sonnet-5',
+    'claude-sonnet-5-20260101',
+  ]) {
+    const captured: Captured = {};
+    const provider = createAnthropicProvider({
+      client: mockClient(captured, textResponse()),
+    });
+
+    await provider.complete({
+      model,
+      maxTokens: 16,
+      temperature: 0,
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+    });
+
+    assert.equal(
+      captured.params?.['temperature'],
+      undefined,
+      `${model} must not receive a temperature`,
+    );
+  }
+});
+
+test('complete() still sends temperature for models that honour it', async () => {
+  // The other direction: a gate that dropped the parameter everywhere would
+  // pass the test above while silently removing determinism from the models
+  // that still support it.
+  for (const model of [
+    'claude-opus-4-6',
+    'claude-sonnet-4-6',
+    'claude-haiku-4-5-20251001',
+  ]) {
+    const captured: Captured = {};
+    const provider = createAnthropicProvider({
+      client: mockClient(captured, textResponse()),
+    });
+
+    await provider.complete({
+      model,
+      maxTokens: 16,
+      temperature: 0,
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+    });
+
+    assert.equal(captured.params?.['temperature'], 0, `${model} lost its temperature`);
+  }
+});


### PR DESCRIPTION
## The loud symptom

The adversarial eval crashed on its **first real run** (it had never executed before, because `ANTHROPIC_API_KEY` was only just set):

```
BadRequestError: 400 `temperature` is deprecated for this model.
  at Object.vote (middleware/test/adversarial/adversarialModel.ts:330)
```

## The quiet one

`LlmScreener.screen()` sends `temperature: 0` on **every inbound turn**:

```ts
// securityScreener.ts:218
const req: LlmRequest = { model: this.#model, …, temperature: 0 };
```

Its caller turns any exception into `unscreenable` — an explicit, documented **fail-open** (`securityScreener.ts:92`: *"the screener was unavailable/errored/timed out: fail open"*). And the screener is constructed with **the agent's own model**:

```ts
// buildOrchestrator.ts:329
new LlmScreener({ provider: deps.provider, model: config.model })
```

whose default is `DEFAULT_ORCHESTRATOR_MODEL = 'claude-opus-4-8'` — a model that rejects `temperature: 0`.

**So on the repo's own default configuration, #579's inbound security screening returned `unscreenable` for every payload, and reported no error while doing it.** Same failure shape as the permanently-green `golden-eval` guard-skip, but on a security control.

Five further production call sites pass `temperature: 0` through the same adapter: the plan-runner's `materializer`, `replanner` (×2), `gate` and `gc`.

## Why the gate is a measured table, not a version comparison

Measured against the live API on 2026-08-19:

| model | omitted | `0` | `0.5` | `1` |
|---|---|---|---|---|
| `claude-opus-4-6` | OK | OK | OK | OK |
| `claude-opus-4-7` | OK | **400** | **400** | OK |
| `claude-opus-4-8` | OK | **400** | **400** | OK |
| `claude-opus-5` | OK | **400** | **400** | OK |
| `claude-sonnet-4-6` | OK | OK | OK | OK |
| `claude-sonnet-5` | OK | **400** | **400** | OK |
| `claude-haiku-4-5` | OK | OK | OK | OK |

Two things this table says that a guess would get wrong:

1. **`opus-4-6` accepts the parameter and `opus-4-7` rejects it.** "Newer than X" is a plausible and wrong rule; so is "the Claude 5 family". Only an explicit list is defensible, so the table lives in the source next to the list.
2. **`temperature: 1` is always accepted**, because it *is* the default — the API only objects to being asked for a value it no longer honours. That is why the eval's attacker step (temperature 1, on `claude-opus-4-8`) survived and only the juror (temperature 0) raised. Without this, the stack trace points at the juror and invites the wrong conclusion.

## The fix

`buildParams` in `llm-adapter-anthropic` omits `temperature` when the model does not honour it. The adapter is the layer that owns the wire contract, so **one change covers all seven call sites**, including `createLlmProviderFromNeutral` (the legacy v1 wrapper), which delegates through the same neutral provider rather than building its own params.

`supportsTemperature(model)` is exported so a caller can tell in advance that its determinism request will be dropped. On the affected models there is no way to obtain `temperature: 0` at all, so dropping it is the only available behaviour — and strictly better than raising into a fail-open catch.

## Not fallout from #730

Worth stating plainly, because the stack trace suggests otherwise: the juror ran on `claude-opus-4-8` at `temperature: 0` **before** #730's juror-model knob and would have raised the identical 400. The knob changed which model name appears in the error, nothing else.

## Verification

- `npm test` — **6841 tests, 0 fail, 0 cancelled** (baseline 6839 + the two added here)
- `tsc --noEmit` clean; `npm run lint` clean
- **Mutation check**, rebuilding `dist/` between runs because the test resolves the package through it — forcing the gate to always-`true` and to always-`false` each turns exactly one of the two new tests red. (The first attempt without a rebuild killed neither mutant and looked green; noted here because it is the standing trap in this repo.)

The second test guards the other direction: a gate that dropped `temperature` everywhere would satisfy the first test while silently removing determinism from the models that still support it.

## Follow-up worth its own issue

The screener's fail-open is correct as a *policy* but has no signal attached: a screener that errors on 100% of calls looks identical to one that is merely occasionally unavailable. A counter or a log on repeated `unscreenable` verdicts would have surfaced this in a day.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789732298&installation_model_id=428086&pr_number=748&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F748&signature=4798d2e6e1fd89105b25f513182c247f06d3eb50567509f11ccb36a93e8cebe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->