### PR TITLE
feat(#749): make a failing security screener visible

### DIFF
--- a/middleware/packages/harness-orchestrator/src/index.ts
+++ b/middleware/packages/harness-orchestrator/src/index.ts
@@ -261,6 +261,18 @@ export type { OrchestratorOptions, AiDisclosureSetup } from './orchestrator.js';
 // screener backends + per-turn outcome resolution; the shared primitives live
 // in `@omadia/channel-sdk`.
 export {
+  type ScreenOutcomeKind,
+  type SecurityScreenMetrics,
+  UNSCREENABLE_STREAK_ALERT,
+  getSecurityScreenMetrics,
+  recordScreenOutcome,
+  resetSecurityScreenMetrics,
+} from './securityScreenMetrics.js';
+
+export {
+  type ScreenFailureCause,
+  ScreenerFailure,
+  screenFailureCause,
   LlmScreener,
   HttpProxyScreener,
   screenProvenance,

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -41,6 +41,7 @@ import {
   type SecurityAuditEvent,
   type ScreenOutcome,
 } from './securityScreener.js';
+import { recordScreenOutcome } from './securityScreenMetrics.js';
 import type { EmbeddingClient } from '@omadia/embeddings';
 import type { LlmProvider } from '@omadia/llm-provider';
 import type {
@@ -3056,10 +3057,22 @@ export class Orchestrator {
     } else if (hasScreenableContent(pairs)) {
       // Screening is ON and there is non-human content, but no screener is
       // wired → UNSCREENABLE. Fail open with evidence, never silently clear.
-      outcome = { status: 'unscreenable', reason: 'no screener configured' };
+      outcome = {
+        status: 'unscreenable',
+        reason: 'no screener configured',
+        cause: 'not-configured',
+      };
     } else {
       outcome = { status: 'allow' };
     }
+
+    // #749 — count every resolved attempt before acting on it. The fail-open
+    // policy below is unchanged; this only makes its exercise visible, so a
+    // screener that fails on EVERY turn stops looking like one that failed once.
+    recordScreenOutcome(
+      outcome.status,
+      outcome.status === 'unscreenable' ? outcome.cause : undefined,
+    );
 
     switch (outcome.status) {
       case 'allow':
@@ -3083,6 +3096,7 @@ export class Orchestrator {
           mode: setup.mode,
           posture,
           reason: outcome.reason,
+          cause: outcome.cause,
           ...(input.sessionScope ? { sessionScope: input.sessionScope } : {}),
           sourceTags,
         });

--- a/middleware/packages/harness-orchestrator/src/securityScreenMetrics.ts
+++ b/middleware/packages/harness-orchestrator/src/securityScreenMetrics.ts
@@ -1,0 +1,167 @@
+/**
+ * #749 — counters for the inbound security screener (#579).
+ *
+ * ## Why this exists
+ *
+ * `screenProvenance` is fail-open by design: a screener that raises yields
+ * `unscreenable` and the turn proceeds. That policy is right — an unavailable
+ * judge must not take the product down — but before this module the only trace
+ * was one `console.warn` per event. At turn volume, a screener that is broken
+ * for **every** request and one that blipped once produce the same shape of
+ * output, differing only in a volume nobody watches.
+ *
+ * That is not hypothetical. Until #748, `LlmScreener` sent a `temperature` the
+ * default model rejects, so every screen raised, every turn was `unscreenable`,
+ * and screening was a no-op that reported no error. It was found because an
+ * unrelated eval crashed on the same root cause — not because anything here
+ * said so.
+ *
+ * ## Why in-process and not the usage recorder
+ *
+ * `@omadia/usage-telemetry` is the obvious host and is the wrong one: it
+ * buffers into Postgres and, by its own contract, "no-ops until wired — in
+ * in-memory-KG mode where no pool exists, `recordUsage` silently drops". A
+ * security counter that disappears in exactly the deployments nobody is
+ * watching rebuilds the original bug one layer up.
+ *
+ * So the counters live in memory, always work, and cost an integer increment.
+ * They are process-scoped and reset on restart — a deliberate trade: this
+ * answers "is screening working *now*", which is the question that was
+ * unanswerable. Durable history belongs with the audit store the
+ * `securityAuditSink` extension point is waiting for.
+ */
+
+import type { ScreenFailureCause } from './securityScreener.js';
+
+/** A screening attempt's terminal state, as counted here. */
+export type ScreenOutcomeKind = 'allow' | 'quarantine' | 'unscreenable';
+
+export interface SecurityScreenMetrics {
+  /** Attempts that reached a screener. Skipped turns are not counted. */
+  readonly screened: number;
+  readonly allowed: number;
+  readonly quarantined: number;
+  readonly unscreenable: number;
+  /**
+   * The number that actually matters. `unscreenable / screened`, or 0 when
+   * nothing has been screened — deliberately not `NaN`, so a caller can render
+   * it without a guard.
+   */
+  readonly unscreenableRate: number;
+  /** Consecutive `unscreenable` results ending at the most recent attempt. */
+  readonly consecutiveUnscreenable: number;
+  /** Longest such run seen this process — survives a lull that resets the streak. */
+  readonly worstConsecutiveUnscreenable: number;
+  /** Per-cause totals. Every cause is present, so a reader needs no fallback. */
+  readonly byCause: Readonly<Record<ScreenFailureCause, number>>;
+}
+
+/**
+ * A run this long says "broken", not "busy".
+ *
+ * Chosen against the failure it exists to catch: the #748 bug produced a 100%
+ * failure rate from the first turn, so any small threshold fires. It is not 1,
+ * because a single miss is exactly the transient the fail-open policy is FOR,
+ * and alerting on it would train operators to ignore the signal.
+ */
+export const UNSCREENABLE_STREAK_ALERT = 5;
+
+const ZERO_BY_CAUSE: Record<ScreenFailureCause, number> = {
+  'not-configured': 0,
+  'provider-rejected': 0,
+  'provider-unavailable': 0,
+  'proxy-unreachable': 0,
+  'unparseable-verdict': 0,
+  unknown: 0,
+};
+
+interface MutableState {
+  screened: number;
+  allowed: number;
+  quarantined: number;
+  unscreenable: number;
+  consecutive: number;
+  worstConsecutive: number;
+  byCause: Record<ScreenFailureCause, number>;
+  /** Whether the current streak has already been announced, so a wedged
+   *  screener logs once per episode instead of once per turn. */
+  alerted: boolean;
+}
+
+function emptyState(): MutableState {
+  return {
+    screened: 0,
+    allowed: 0,
+    quarantined: 0,
+    unscreenable: 0,
+    consecutive: 0,
+    worstConsecutive: 0,
+    byCause: { ...ZERO_BY_CAUSE },
+    alerted: false,
+  };
+}
+
+let state: MutableState = emptyState();
+
+/**
+ * Count one screening attempt.
+ *
+ * Never throws: this is evidence, and evidence must not be able to break the
+ * turn it is evidence about — the same contract as `emitSecurityAudit`.
+ */
+export function recordScreenOutcome(
+  kind: ScreenOutcomeKind,
+  cause?: ScreenFailureCause,
+  onAlert: (metrics: SecurityScreenMetrics) => void = defaultAlert,
+): void {
+  try {
+    state.screened += 1;
+    if (kind === 'unscreenable') {
+      state.unscreenable += 1;
+      state.byCause[cause ?? 'unknown'] += 1;
+      state.consecutive += 1;
+      state.worstConsecutive = Math.max(state.worstConsecutive, state.consecutive);
+      if (state.consecutive >= UNSCREENABLE_STREAK_ALERT && !state.alerted) {
+        state.alerted = true;
+        onAlert(getSecurityScreenMetrics());
+      }
+      return;
+    }
+    if (kind === 'quarantine') state.quarantined += 1;
+    else state.allowed += 1;
+    // A single success ends the episode: the next streak is a NEW incident and
+    // deserves its own alert.
+    state.consecutive = 0;
+    state.alerted = false;
+  } catch {
+    /* counters are best-effort */
+  }
+}
+
+function defaultAlert(metrics: SecurityScreenMetrics): void {
+  console.error(
+    `[security-screen] ${String(metrics.consecutiveUnscreenable)} consecutive unscreenable results — ` +
+      'inbound screening is failing open on every turn. ' +
+      `causes=${JSON.stringify(metrics.byCause)}`,
+  );
+}
+
+/** An immutable snapshot. Callers cannot mutate the counters through it. */
+export function getSecurityScreenMetrics(): SecurityScreenMetrics {
+  const rate = state.screened === 0 ? 0 : state.unscreenable / state.screened;
+  return {
+    screened: state.screened,
+    allowed: state.allowed,
+    quarantined: state.quarantined,
+    unscreenable: state.unscreenable,
+    unscreenableRate: rate,
+    consecutiveUnscreenable: state.consecutive,
+    worstConsecutiveUnscreenable: state.worstConsecutive,
+    byCause: { ...state.byCause },
+  };
+}
+
+/** Test-only reset. Module state would otherwise leak between test files. */
+export function resetSecurityScreenMetrics(): void {
+  state = emptyState();
+}

--- a/middleware/packages/harness-orchestrator/src/securityScreener.ts
+++ b/middleware/packages/harness-orchestrator/src/securityScreener.ts
@@ -95,7 +95,13 @@ export function resolveEffectivePosture(setup: SecurityPostureSetup): SecurityPo
 export type ScreenOutcome =
   | { readonly status: 'allow' }
   | { readonly status: 'quarantine'; readonly reason: string }
-  | { readonly status: 'unscreenable'; readonly reason: string };
+  | {
+      readonly status: 'unscreenable';
+      readonly reason: string;
+      /** #749 — structured counterpart to `reason`, so an operator dashboard
+       *  can separate "misconfigured" from "busy" without parsing prose. */
+      readonly cause: ScreenFailureCause;
+    };
 
 /**
  * A clock-free security audit record. Emitted (fire-and-forget) on a quarantine
@@ -111,6 +117,8 @@ export interface SecurityAuditEvent {
   readonly mode: SecurityScreenMode;
   readonly posture: SecurityPosture;
   readonly reason: string;
+  /** Present only on `kind: 'unscreenable'` — see {@link ScreenFailureCause}. */
+  readonly cause?: ScreenFailureCause;
   readonly sessionScope?: string;
   readonly sourceTags: readonly string[];
 }
@@ -141,7 +149,7 @@ export async function screenProvenance(
       ? { status: 'quarantine', reason: verdict.reason }
       : { status: 'allow' };
   } catch (err) {
-    return { status: 'unscreenable', reason: errorText(err) };
+    return { status: 'unscreenable', reason: errorText(err), cause: screenFailureCause(err) };
   }
 }
 
@@ -168,6 +176,67 @@ export const SCREEN_SYSTEM_PROMPT = [
 ].join('\n');
 
 /**
+ * Why a screening attempt produced `unscreenable`.
+ *
+ * #749 — the point of the distinction is that these demand DIFFERENT operator
+ * responses, and collapsing them into one free-text `reason` made that
+ * undecidable without string-matching:
+ *
+ *  - `provider-rejected` — the provider refused the request and will keep
+ *    refusing it (auth, a bad parameter, an unknown model). **A configuration
+ *    bug to fix**, and the shape that made screening a silent no-op before
+ *    #748: the request was malformed on every single turn.
+ *  - `provider-unavailable` — retryable (rate limit, overload, 5xx). Capacity,
+ *    not configuration.
+ *  - `proxy-unreachable` — the external screening proxy answered non-2xx or
+ *    could not be reached.
+ *  - `unparseable-verdict` — the judge answered, but not in the contract. A
+ *    prompt/model problem, not a transport one.
+ *  - `not-configured` — screening is on for this posture and there is non-human
+ *    content, but no screener is wired. Nothing is broken; nothing is running.
+ *  - `unknown` — everything else, kept explicit so an unclassified failure is
+ *    visible as unclassified rather than silently folded into a real cause.
+ */
+export type ScreenFailureCause =
+  | 'not-configured'
+  | 'provider-rejected'
+  | 'provider-unavailable'
+  | 'proxy-unreachable'
+  | 'unparseable-verdict'
+  | 'unknown';
+
+/**
+ * An error that carries its {@link ScreenFailureCause}.
+ *
+ * The classification is attached where the knowledge lives — inside the
+ * screener, which holds the provider and can call its `classifyError` — rather
+ * than reconstructed later by matching on a message string. `screenProvenance`
+ * only reads the tag.
+ */
+export class ScreenerFailure extends Error {
+  /**
+   * Deliberately NOT named `cause`: `Error.cause` is the standard slot for the
+   * underlying exception, and narrowing it to a string union would both need an
+   * `override` and mislead anyone who expects an error there.
+   */
+  readonly failureCause: ScreenFailureCause;
+
+  constructor(cause: ScreenFailureCause, message: string, options?: { readonly from?: unknown }) {
+    super(message, options?.from === undefined ? undefined : { cause: options.from });
+    this.name = 'ScreenerFailure';
+    this.failureCause = cause;
+    if (options?.from instanceof Error && options.from.stack !== undefined) {
+      this.stack = options.from.stack;
+    }
+  }
+}
+
+/** The tag off an error, or `'unknown'` for anything not classified at source. */
+export function screenFailureCause(err: unknown): ScreenFailureCause {
+  return err instanceof ScreenerFailure ? err.failureCause : 'unknown';
+}
+
+/**
  * Parse the judge's single-line verdict. `QUARANTINE: reason` → quarantine;
  * `ALLOW` → allow. Anything else is UNPARSEABLE and throws — the caller turns
  * that into `unscreenable` (fail open), never a silent allow: an
@@ -181,7 +250,10 @@ export function parseVerdict(raw: string): SecurityVerdict {
     return { decision: 'quarantine', reason: reason.length > 0 ? reason : 'flagged by judge' };
   }
   if (/^allow\b/i.test(line)) return { decision: 'allow' };
-  throw new Error(`unparseable screening verdict: ${JSON.stringify(line.slice(0, 80))}`);
+  throw new ScreenerFailure(
+    'unparseable-verdict',
+    `unparseable screening verdict: ${JSON.stringify(line.slice(0, 80))}`,
+  );
 }
 
 /** Options for {@link LlmScreener}. */
@@ -217,7 +289,20 @@ export class LlmScreener implements SecurityScreener {
       maxTokens: this.#maxTokens,
       temperature: 0,
     };
-    const res = await this.#provider.complete(req);
+    let res;
+    try {
+      res = await this.#provider.complete(req);
+    } catch (err) {
+      // The provider knows its own errors; ask it rather than reading the
+      // message. `retryable` is the axis that matters here — a non-retryable
+      // rejection repeats on every turn and is an operator's job to fix.
+      const classified = this.#provider.classifyError?.(err);
+      throw new ScreenerFailure(
+        classified?.retryable === true ? 'provider-unavailable' : 'provider-rejected',
+        err instanceof Error ? err.message : String(err),
+        { from: err },
+      );
+    }
     return parseVerdict(collectText(res.content));
   }
 }
@@ -296,7 +381,9 @@ export class HttpProxyScreener implements SecurityScreener {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ payload }),
     });
-    if (!res.ok) throw new Error(`screen proxy HTTP ${res.status}`);
+    if (!res.ok) {
+      throw new ScreenerFailure('proxy-unreachable', `screen proxy HTTP ${String(res.status)}`);
+    }
     const body = (await res.json()) as { decision?: unknown; reason?: unknown };
     if (body.decision === 'quarantine') {
       const reason = typeof body.reason === 'string' && body.reason.trim().length > 0

--- a/middleware/src/routes/admin.ts
+++ b/middleware/src/routes/admin.ts
@@ -2,6 +2,10 @@ import { Router } from 'express';
 import type { NextFunction, Request, Response } from 'express';
 import { z } from 'zod';
 import type { MemoryStore } from '@omadia/plugin-api';
+import {
+  getSecurityScreenMetrics,
+  UNSCREENABLE_STREAK_ALERT,
+} from '@omadia/orchestrator';
 
 const PutBodySchema = z.object({
   path: z.string().min(1).startsWith('/memories'),
@@ -37,6 +41,29 @@ export function createAdminRouter(deps: AdminDeps): Router {
       return;
     }
     next();
+  });
+
+  /**
+   * #749 — is inbound security screening (#579) actually running?
+   *
+   * The counters are the answer to a question that had none. Screening is
+   * fail-open: a screener that raises yields `unscreenable` and the turn
+   * proceeds, so a totally broken screener is invisible from the outside. Until
+   * #748 that was not hypothetical — every turn failed, screening was a no-op,
+   * and nothing reported it.
+   *
+   * `healthy` is the derived judgement so an operator (or a probe) does not have
+   * to know the threshold. It is false only on a RUN of failures, never on a
+   * single miss: a transient miss is precisely what the fail-open policy exists
+   * for, and flagging it would teach people to ignore this endpoint.
+   */
+  router.get('/security/screening', (_req: Request, res: Response) => {
+    const metrics = getSecurityScreenMetrics();
+    res.json({
+      ...metrics,
+      alertThreshold: UNSCREENABLE_STREAK_ALERT,
+      healthy: metrics.consecutiveUnscreenable < UNSCREENABLE_STREAK_ALERT,
+    });
   });
 
   router.put('/memory', async (req: Request, res: Response) => {

--- a/middleware/test/adminSecurityScreeningRoute.test.ts
+++ b/middleware/test/adminSecurityScreeningRoute.test.ts
@@ -1,0 +1,115 @@
+import { strict as assert } from 'node:assert';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { after, before, beforeEach, describe, it } from 'node:test';
+
+import express from 'express';
+
+import {
+  recordScreenOutcome,
+  resetSecurityScreenMetrics,
+  UNSCREENABLE_STREAK_ALERT,
+} from '@omadia/orchestrator';
+import { createAdminRouter } from '../src/routes/admin.js';
+
+/**
+ * #749 — `/security/screening`, the answer to "is inbound screening running?"
+ *
+ * Written against the state that was invisible before #748: a screener failing
+ * on every single turn, with the fail-open policy quietly letting each turn
+ * through. The happy path is the least interesting case here.
+ */
+
+const TOKEN = 'test-admin-token';
+let server: Server;
+let base: string;
+
+before(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/admin',
+    createAdminRouter({
+      token: TOKEN,
+      store: {} as never, // this route touches no store
+    }),
+  );
+  await new Promise<void>((resolve) => {
+    // Bind on loopback explicitly: a wildcard listen(0) plus a 127.0.0.1 dial
+    // has produced cross-process port collisions in this suite before.
+    server = app.listen(0, '127.0.0.1', resolve);
+  });
+  base = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}`;
+});
+
+after(() => {
+  server.close();
+});
+
+beforeEach(() => {
+  resetSecurityScreenMetrics();
+});
+
+const get = async (): Promise<{ status: number; body: Record<string, unknown> }> => {
+  const res = await fetch(`${base}/admin/security/screening`, {
+    headers: { authorization: `Bearer ${TOKEN}` },
+  });
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+};
+
+describe('#749 GET /admin/security/screening', () => {
+  it('requires the admin token', async () => {
+    const res = await fetch(`${base}/admin/security/screening`);
+    assert.equal(res.status, 401);
+  });
+
+  it('reports healthy with nothing screened yet, and no NaN rate', async () => {
+    const { status, body } = await get();
+
+    assert.equal(status, 200);
+    assert.equal(body['healthy'], true);
+    assert.equal(body['screened'], 0);
+    assert.equal(body['unscreenableRate'], 0);
+    assert.equal(body['alertThreshold'], UNSCREENABLE_STREAK_ALERT);
+  });
+
+  it('reports UNHEALTHY when the screener fails on every turn', async () => {
+    // The pre-#748 state, verbatim: every screen raised, every turn ran anyway.
+    for (let i = 0; i < 30; i++) {
+      recordScreenOutcome('unscreenable', 'provider-rejected', () => {});
+    }
+
+    const { body } = await get();
+
+    assert.equal(body['healthy'], false);
+    assert.equal(body['unscreenableRate'], 1);
+    assert.equal(body['consecutiveUnscreenable'], 30);
+    assert.deepEqual(
+      (body['byCause'] as Record<string, number>)['provider-rejected'],
+      30,
+      'the cause must survive to the wire — a bare count would not say WHY',
+    );
+  });
+
+  it('stays healthy through an isolated miss', async () => {
+    // Guards the other direction. An endpoint that flips to unhealthy on one
+    // transient failure is an endpoint operators learn to ignore.
+    for (let i = 0; i < 40; i++) recordScreenOutcome('allow', undefined, () => {});
+    recordScreenOutcome('unscreenable', 'provider-unavailable', () => {});
+
+    const { body } = await get();
+
+    assert.equal(body['healthy'], true);
+    assert.equal(body['consecutiveUnscreenable'], 1);
+  });
+
+  it('still reports the worst streak after a recovery', async () => {
+    for (let i = 0; i < 12; i++) recordScreenOutcome('unscreenable', 'unknown', () => {});
+    recordScreenOutcome('allow', undefined, () => {});
+
+    const { body } = await get();
+
+    assert.equal(body['healthy'], true, 'it recovered');
+    assert.equal(body['worstConsecutiveUnscreenable'], 12, 'but the episode is on record');
+  });
+});

--- a/middleware/test/adminSecurityScreeningRoute.test.ts
+++ b/middleware/test/adminSecurityScreeningRoute.test.ts
@@ -37,7 +37,9 @@ before(async () => {
   await new Promise<void>((resolve) => {
     // Bind on loopback explicitly: a wildcard listen(0) plus a 127.0.0.1 dial
     // has produced cross-process port collisions in this suite before.
-    server = app.listen(0, '127.0.0.1', resolve);
+    server = app.listen(0, '127.0.0.1', () => {
+      resolve();
+    });
   });
   base = `http://127.0.0.1:${String((server.address() as AddressInfo).port)}`;
 });

--- a/middleware/test/securityScreenMetrics749.test.ts
+++ b/middleware/test/securityScreenMetrics749.test.ts
@@ -1,0 +1,202 @@
+/**
+ * #749 — the screener must be able to say that it is failing.
+ *
+ * The bug that motivated this (PR #748) produced **zero** failing tests: every
+ * inbound turn raised, `screenProvenance` caught it, returned `unscreenable`,
+ * and the fail-open policy let the turn run. Screening was off and nothing said
+ * so. These tests therefore drive the permanent-failure state directly — a
+ * happy-path test would have passed then too, which is the whole point.
+ */
+import assert from 'node:assert/strict';
+import { beforeEach, describe, test } from 'node:test';
+
+import {
+  LlmScreener,
+  HttpProxyScreener,
+  ScreenerFailure,
+  screenFailureCause,
+  screenProvenance,
+  parseVerdict,
+  recordScreenOutcome,
+  getSecurityScreenMetrics,
+  resetSecurityScreenMetrics,
+  UNSCREENABLE_STREAK_ALERT,
+} from '@omadia/orchestrator';
+import type { LlmProvider, LlmRequest, LlmResponse } from '@omadia/llm-provider';
+import type { ProvenancePair } from '@omadia/channel-sdk';
+
+/** A provider that always refuses, the way the pre-#748 400 did. */
+function refusingProvider(opts: { retryable: boolean; message: string }): LlmProvider {
+  return {
+    complete: () => Promise.reject(new Error(opts.message)),
+    classifyError: () => ({ retryable: opts.retryable, kind: 'other' as const }),
+  } as unknown as LlmProvider;
+}
+
+function answeringProvider(text: string): LlmProvider {
+  return {
+    complete: (): Promise<LlmResponse> =>
+      Promise.resolve({
+        content: [{ type: 'text', text }],
+        finishReason: 'stop',
+        model: 'stub',
+        usage: { inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0 },
+      } as unknown as LlmResponse),
+    classifyError: () => ({ retryable: false, kind: 'other' as const }),
+  } as unknown as LlmProvider;
+}
+
+/** One non-human pair, so screening is not skipped as human-only input. */
+const PAIRS: ProvenancePair[] = [
+  { source: { kind: 'attachment', label: 'notes.txt' }, content: 'hello' } as unknown as ProvenancePair,
+];
+
+describe('#749 — screen failure causes are structured, not prose', () => {
+  test('a non-retryable provider refusal is provider-rejected', async () => {
+    const screener = new LlmScreener({
+      provider: refusingProvider({ retryable: false, message: '`temperature` is deprecated for this model.' }),
+      model: 'claude-opus-4-8',
+    });
+
+    const outcome = await screenProvenance(screener, PAIRS);
+
+    assert.equal(outcome.status, 'unscreenable');
+    assert.equal(outcome.status === 'unscreenable' ? outcome.cause : undefined, 'provider-rejected');
+  });
+
+  test('a retryable provider error is provider-unavailable, not the same bucket', async () => {
+    // The distinction #749 exists for: this one is capacity and self-heals;
+    // the one above repeats forever and needs a human.
+    const screener = new LlmScreener({
+      provider: refusingProvider({ retryable: true, message: 'overloaded_error' }),
+      model: 'claude-opus-4-8',
+    });
+
+    const outcome = await screenProvenance(screener, PAIRS);
+
+    assert.equal(outcome.status === 'unscreenable' ? outcome.cause : undefined, 'provider-unavailable');
+  });
+
+  test('an uninterpretable judge reply is unparseable-verdict', async () => {
+    const screener = new LlmScreener({ provider: answeringProvider('maybe?'), model: 'stub' });
+
+    const outcome = await screenProvenance(screener, PAIRS);
+
+    assert.equal(outcome.status === 'unscreenable' ? outcome.cause : undefined, 'unparseable-verdict');
+  });
+
+  test('a non-2xx screening proxy is proxy-unreachable', async () => {
+    const screener = new HttpProxyScreener({
+      url: 'https://screen.invalid/x',
+      fetchImpl: () => Promise.resolve({ ok: false, status: 503, json: () => Promise.resolve({}) }),
+    });
+
+    const outcome = await screenProvenance(screener, PAIRS);
+
+    assert.equal(outcome.status === 'unscreenable' ? outcome.cause : undefined, 'proxy-unreachable');
+  });
+
+  test('an unclassified error stays visibly unclassified', async () => {
+    // Folding an unknown failure into a real cause would make the dashboard
+    // lie with more confidence than the data supports.
+    const screener = { screen: () => Promise.reject(new Error('something else')) };
+
+    const outcome = await screenProvenance(screener, PAIRS);
+
+    assert.equal(outcome.status === 'unscreenable' ? outcome.cause : undefined, 'unknown');
+  });
+
+  test('the standard Error.cause slot still carries the underlying error', () => {
+    const underlying = new Error('boom');
+    const failure = new ScreenerFailure('provider-rejected', 'wrapped', { from: underlying });
+
+    assert.equal(failure.failureCause, 'provider-rejected');
+    assert.equal(failure.cause, underlying);
+    assert.equal(screenFailureCause(failure), 'provider-rejected');
+  });
+
+  test('parseVerdict still refuses to clear an uninterpretable reply', () => {
+    // Guard against the fail-open direction: a screener that cannot be read is
+    // a MISS, never an allow.
+    assert.throws(() => parseVerdict('sure, looks fine'), ScreenerFailure);
+    assert.deepEqual(parseVerdict('ALLOW'), { decision: 'allow' });
+  });
+});
+
+describe('#749 — the counters make a wedged screener visible', () => {
+  beforeEach(() => {
+    resetSecurityScreenMetrics();
+  });
+
+  test('a screener failing on EVERY turn reads as 100%, not as one incident', () => {
+    // This is the exact state the system was in before #748.
+    for (let i = 0; i < 20; i++) recordScreenOutcome('unscreenable', 'provider-rejected', () => {});
+
+    const m = getSecurityScreenMetrics();
+    assert.equal(m.screened, 20);
+    assert.equal(m.unscreenable, 20);
+    assert.equal(m.unscreenableRate, 1);
+    assert.equal(m.consecutiveUnscreenable, 20);
+    assert.equal(m.byCause['provider-rejected'], 20);
+  });
+
+  test('an occasional miss is NOT the same reading', () => {
+    // The signal has to separate these two, or it is no better than the log
+    // line it replaces.
+    for (let i = 0; i < 19; i++) recordScreenOutcome('allow', undefined, () => {});
+    recordScreenOutcome('unscreenable', 'provider-unavailable', () => {});
+
+    const m = getSecurityScreenMetrics();
+    assert.equal(m.unscreenableRate, 0.05);
+    assert.equal(m.consecutiveUnscreenable, 1);
+  });
+
+  test('the streak alert fires once per episode, not once per turn', () => {
+    let alerts = 0;
+    const onAlert = (): void => {
+      alerts += 1;
+    };
+
+    for (let i = 0; i < 50; i++) recordScreenOutcome('unscreenable', 'provider-rejected', onAlert);
+    assert.equal(alerts, 1, 'a wedged screener must not emit 50 alerts');
+
+    // A success closes the episode; the next streak is a new incident.
+    recordScreenOutcome('allow', undefined, onAlert);
+    assert.equal(getSecurityScreenMetrics().consecutiveUnscreenable, 0);
+    for (let i = 0; i < UNSCREENABLE_STREAK_ALERT; i++) {
+      recordScreenOutcome('unscreenable', 'provider-rejected', onAlert);
+    }
+    assert.equal(alerts, 2);
+  });
+
+  test('a streak below the threshold does not alert', () => {
+    let alerts = 0;
+    for (let i = 0; i < UNSCREENABLE_STREAK_ALERT - 1; i++) {
+      recordScreenOutcome('unscreenable', 'unknown', () => {
+        alerts += 1;
+      });
+    }
+    assert.equal(alerts, 0, 'a transient miss is what fail-open is FOR');
+  });
+
+  test('the worst streak survives a recovery', () => {
+    for (let i = 0; i < 7; i++) recordScreenOutcome('unscreenable', 'unknown', () => {});
+    recordScreenOutcome('allow', undefined, () => {});
+
+    const m = getSecurityScreenMetrics();
+    assert.equal(m.consecutiveUnscreenable, 0);
+    assert.equal(m.worstConsecutiveUnscreenable, 7, 'a lull must not erase the evidence');
+  });
+
+  test('the rate is 0 rather than NaN before anything is screened', () => {
+    assert.equal(getSecurityScreenMetrics().unscreenableRate, 0);
+  });
+
+  test('the snapshot cannot be used to mutate the counters', () => {
+    recordScreenOutcome('unscreenable', 'provider-rejected', () => {});
+    const snapshot = getSecurityScreenMetrics();
+    (snapshot.byCause as Record<string, number>)['provider-rejected'] = 999;
+
+    assert.equal(getSecurityScreenMetrics().byCause['provider-rejected'], 1);
+  });
+});


### PR DESCRIPTION
Closes #749.

## The problem

Inbound screening (#579) is fail-open by design: a screener that raises yields `unscreenable` and the turn proceeds. That policy is right — an unavailable judge must not take the product down. But until now the only trace was one line:

```ts
console.warn(`[security-audit] ${JSON.stringify(event)}`);
```

At turn volume, a screener broken for **every** request and one that blipped once produce the same shape of output, differing only in a volume nobody watches.

That is not hypothetical. Until #748, `LlmScreener` sent a `temperature` the default model rejects, so **every** screen raised, **every** turn was `unscreenable`, and screening was a no-op that reported no error. It was found because an unrelated eval crashed on the same root cause — not because anything here said so.

## 1. Structured failure causes

`unscreenable` carried only a free-text `reason`, so "misconfigured" and "busy" were indistinguishable without matching on prose. `ScreenFailureCause` separates them:

| cause | what it means for an operator |
|---|---|
| `provider-rejected` | The provider refuses and will keep refusing (auth, bad parameter, unknown model). **A config bug to fix** — and the exact shape of the #748 outage. |
| `provider-unavailable` | Retryable: rate limit, overload, 5xx. Capacity, not configuration. |
| `proxy-unreachable` | The external screening proxy answered non-2xx. |
| `unparseable-verdict` | The judge answered, but not in the contract. A prompt/model problem, not transport. |
| `not-configured` | Screening is on and there is non-human content, but no screener is wired. Nothing broken; nothing running. |
| `unknown` | Everything else — kept explicit so an unclassified failure is visibly unclassified rather than folded into a real cause. |

The tag is attached **where the knowledge lives**: `LlmScreener` holds the provider, so it asks the provider's own `classifyError` and keys on `retryable` — it does not read the message. `HttpProxyScreener` tags at its own throw site. `screenProvenance` only reads the tag.

## 2. In-process counters — deliberately *not* in `@omadia/usage-telemetry`

The issue suggested reusing the usage recorder. It is the obvious host and it is the wrong one, by its own docstring:

> **No-op until wired.** Before `initUsageRecorder(pool)` runs — or in in-memory-KG mode where no pool exists — `recordUsage` silently drops.

**A security counter that disappears in exactly the deployments nobody is watching rebuilds the original bug one layer up.** So these are integers in memory that always work and cost an increment. They are process-scoped and reset on restart — a deliberate trade: this answers *"is screening working right now"*, which is the question that had no answer. Durable history belongs with the audit store the `securityAuditSink` extension point is still waiting for.

Alongside the raw counts the snapshot carries `unscreenableRate`, `consecutiveUnscreenable`, `worstConsecutiveUnscreenable` (so a lull does not erase the evidence) and per-cause totals with every key present, so a reader needs no fallback.

## 3. `GET /admin/security/screening`

Returns the snapshot plus a derived `healthy`, so an operator or a probe does not have to know the threshold.

`healthy` is false only on a **run** of failures (`UNSCREENABLE_STREAK_ALERT = 5`), never on a single miss. A single miss is precisely what the fail-open policy exists for; flagging it would teach people to ignore the endpoint. The threshold was chosen against the failure it must catch — #748 produced a 100% failure rate from the first turn, so any small number fires — and against the failure it must *not* catch.

The streak alert logs **once per episode**, not once per turn, and a single success closes the episode so the next run is reported as a new incident.

## Not changed

The fail-open behaviour itself. This PR is evidence, not enforcement.

One naming note: `ScreenerFailure.failureCause` is deliberately not called `cause`. `Error.cause` is the standard slot for the underlying exception and still carries it — narrowing it to a string union would both require an `override` and mislead anyone expecting an error there.

## Verification

- `npm test` — **6849 tests, 0 fail, 0 cancelled** (baseline 6830 measured on `main` in the same environment, + the 19 added here)
- `tsc --noEmit` clean; `npm run lint` clean; decoupling ratchet unchanged at 3295
- **Mutation check**, rebuilding `dist/` between runs (the package resolves through it — skipping the rebuild silently keeps every mutant alive, as it did in #748):

| mutation | result |
|---|---|
| streak not reset on success | 2 tests red |
| snapshot shares the internal object | 1 test red |
| alert fires per turn instead of per episode | 1 test red |
| provider classification ignored (everything `provider-rejected`) | 1 test red |

The tests are written against the permanent-failure state rather than the happy path — the bug this exists to prevent produced **zero** failing tests, so a happy-path test would have passed then too. Both suites also guard the opposite direction: an isolated miss must stay `healthy`, and `parseVerdict` must still refuse to clear an uninterpretable reply.

## Follow-up

A durable audit store remains out of scope; that is the larger thing `securityAuditSink` is waiting for. Surfacing these counters in the web-ui admin screen (rather than only over the API) is the natural next slice.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789744567&installation_model_id=428086&pr_number=750&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F750&signature=b308df4c0cbf6d90f42fff6ea49988bb2a75d26605e87a2af27493c214f624fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->