### PR TITLE
fix(#687): triage the I3 literal tail — 21 sites, 7 files on the ratchet

### DIFF
--- a/web-ui/app/_components/store/AdminUiPanel.tsx
+++ b/web-ui/app/_components/store/AdminUiPanel.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from 'react';
 import { Globe } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 
 import { cn } from '../../_lib/cn';
 
@@ -80,6 +81,7 @@ export function AdminUiArticleSwap({
   pluginName: string;
   children: React.ReactNode;
 }): React.ReactElement {
+  const t = useTranslations('store.adminUi');
   const { open, panelId } = useAdminUi();
   const ref = useRef<HTMLElement | null>(null);
 
@@ -108,7 +110,7 @@ export function AdminUiArticleSwap({
       </header>
       <iframe
         src={iframeSrc}
-        title={`${pluginName} Admin UI`}
+        title={t('iframeTitle', { plugin: pluginName })}
         className="h-[1000px] w-full rounded border border-[color:var(--rule)] bg-[color:var(--bg)]"
         loading="lazy"
       />

--- a/web-ui/app/_lib/i18n-structural.test.ts
+++ b/web-ui/app/_lib/i18n-structural.test.ts
@@ -130,7 +130,15 @@ describe('#679 / I3 — swept components carry no user-facing literals', () => {
   // So the ratchet now asks the scanner the same question the CLI asks:
   // does this file still contain a user-facing literal? Files join `SWEPT`
   // once they answer no, and can never silently regress afterwards.
-  const SWEPT_COMPONENTS = ['graph/_components/ListView.tsx'];
+  const SWEPT_COMPONENTS = [
+    'graph/_components/ListView.tsx',
+    'graph/_components/GraphCanvas.tsx',
+    'admin/duplicates/[id]/page.tsx',
+    'admin/duplicates/excerpt/[id]/page.tsx',
+    'admin/inconsistencies/[id]/page.tsx',
+    'admin/kg-priorities/page.tsx',
+    'system/_components/VaultStatusCard.tsx',
+  ];
 
   for (const file of SWEPT_COMPONENTS) {
     it(`${file} has no untranslated user-facing literal`, () => {

--- a/web-ui/app/admin/duplicates/[id]/page.tsx
+++ b/web-ui/app/admin/duplicates/[id]/page.tsx
@@ -124,11 +124,11 @@ export default function DuplicateDetailPage(): React.ReactElement {
               })}
             </p>
             <dl className="mt-3 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-[11px]">
-              <dt className="text-[color:var(--fg-muted)]">Status</dt>
+              <dt className="text-[color:var(--fg-muted)]">{t('status')}</dt>
               <dd className="font-mono">{detail.props.status}</dd>
               {detail.props.resolution && (
                 <>
-                  <dt className="text-[color:var(--fg-muted)]">Resolution</dt>
+                  <dt className="text-[color:var(--fg-muted)]">{t('resolution')}</dt>
                   <dd className="font-mono">{detail.props.resolution}</dd>
                 </>
               )}
@@ -136,8 +136,8 @@ export default function DuplicateDetailPage(): React.ReactElement {
           </section>
 
           <div className="grid gap-4 lg:grid-cols-2">
-            <MemoryCard label="Memory A" mk={detail.mkA} />
-            <MemoryCard label="Memory B" mk={detail.mkB} />
+            <MemoryCard label={t('memoryA')} mk={detail.mkA} />
+            <MemoryCard label={t('memoryB')} mk={detail.mkB} />
           </div>
 
           {detail.props.status === 'open' && (

--- a/web-ui/app/admin/duplicates/excerpt/[id]/page.tsx
+++ b/web-ui/app/admin/duplicates/excerpt/[id]/page.tsx
@@ -122,11 +122,11 @@ export default function ExcerptDuplicateDetailPage(): React.ReactElement {
               })}
             </p>
             <dl className="mt-3 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-[11px]">
-              <dt className="text-[color:var(--fg-muted)]">Status</dt>
+              <dt className="text-[color:var(--fg-muted)]">{t('status')}</dt>
               <dd className="font-mono">{detail.props.status}</dd>
               {detail.props.resolution && (
                 <>
-                  <dt className="text-[color:var(--fg-muted)]">Resolution</dt>
+                  <dt className="text-[color:var(--fg-muted)]">{t('resolution')}</dt>
                   <dd className="font-mono">{detail.props.resolution}</dd>
                 </>
               )}
@@ -135,12 +135,12 @@ export default function ExcerptDuplicateDetailPage(): React.ReactElement {
 
           <div className="grid gap-4 lg:grid-cols-2">
             <ExcerptCard
-              label="Excerpt A"
+              label={t('excerptA')}
               excerpt={detail.excerptA}
               parentMk={detail.mkA}
             />
             <ExcerptCard
-              label="Excerpt B"
+              label={t('excerptB')}
               excerpt={detail.excerptB}
               parentMk={detail.mkB}
             />

--- a/web-ui/app/admin/inconsistencies/[id]/page.tsx
+++ b/web-ui/app/admin/inconsistencies/[id]/page.tsx
@@ -118,13 +118,13 @@ export default function InconsistencyDetailPage(): React.ReactElement {
             </h2>
             <p className="text-sm">{detail.props.summary}</p>
             <dl className="mt-3 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-[11px]">
-              <dt className="text-[color:var(--fg-muted)]">Severity</dt>
+              <dt className="text-[color:var(--fg-muted)]">{t('severity')}</dt>
               <dd className="font-mono">{detail.props.severity}</dd>
-              <dt className="text-[color:var(--fg-muted)]">Status</dt>
+              <dt className="text-[color:var(--fg-muted)]">{t('status')}</dt>
               <dd className="font-mono">{detail.props.status}</dd>
               {detail.props.resolution && (
                 <>
-                  <dt className="text-[color:var(--fg-muted)]">Resolution</dt>
+                  <dt className="text-[color:var(--fg-muted)]">{t('resolution')}</dt>
                   <dd className="font-mono">{detail.props.resolution}</dd>
                 </>
               )}
@@ -132,8 +132,8 @@ export default function InconsistencyDetailPage(): React.ReactElement {
           </section>
 
           <div className="grid gap-4 lg:grid-cols-2">
-            <MemoryCard label="Memory A" mk={detail.mkA} />
-            <MemoryCard label="Memory B" mk={detail.mkB} />
+            <MemoryCard label={t('memoryA')} mk={detail.mkA} />
+            <MemoryCard label={t('memoryB')} mk={detail.mkB} />
           </div>
 
           {detail.props.status === 'open' && (

--- a/web-ui/app/admin/kg-priorities/page.tsx
+++ b/web-ui/app/admin/kg-priorities/page.tsx
@@ -146,7 +146,7 @@ export default function KgPrioritiesPage(): React.ReactElement {
     <main className="mx-auto max-w-[1200px] px-6 py-12 lg:px-8 lg:py-16">
       <header className="mb-8">
         <h1 className="font-display text-[clamp(2rem,4vw,3rem)] leading-[1.1] text-[color:var(--fg-strong)]">
-          Knowledge-Graph Priorities
+          {t('title')}
         </h1>
         <p className="mt-3 max-w-3xl text-[16px] leading-[1.55] text-[color:var(--fg-muted)]">
           {t('intro')}
@@ -194,8 +194,8 @@ export default function KgPrioritiesPage(): React.ReactElement {
             onChange={(e) => { setDraftAction(e.target.value as 'block' | 'boost'); }}
             className="lg:col-span-2 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-3 py-2 text-sm text-[color:var(--fg-strong)]"
           >
-            <option value="block">block</option>
-            <option value="boost">boost</option>
+            <option value="block">{t('actionBlock')}</option>
+            <option value="boost">{t('actionBoost')}</option>
           </select>
           <input
             type="number"
@@ -215,7 +215,7 @@ export default function KgPrioritiesPage(): React.ReactElement {
             type="text"
             value={draftReason}
             onChange={(e) => { setDraftReason(e.target.value); }}
-            placeholder="Reason (optional)"
+            placeholder={t('reasonPlaceholder')}
             className="lg:col-span-3 rounded-md border border-[color:var(--border)] bg-[color:var(--bg)] px-3 py-2 text-sm text-[color:var(--fg-strong)]"
           />
           <Button
@@ -241,11 +241,11 @@ export default function KgPrioritiesPage(): React.ReactElement {
         <table className="w-full text-sm">
           <thead className="border-b border-[color:var(--border)] text-left text-[color:var(--fg-muted)]">
             <tr>
-              <th className="px-4 py-3 font-semibold">Entry External ID</th>
-              <th className="px-4 py-3 font-semibold">Action</th>
-              <th className="px-4 py-3 font-semibold">Weight</th>
-              <th className="px-4 py-3 font-semibold">Reason</th>
-              <th className="px-4 py-3 font-semibold">Updated</th>
+              <th className="px-4 py-3 font-semibold">{t('colEntryExternalId')}</th>
+              <th className="px-4 py-3 font-semibold">{t('colAction')}</th>
+              <th className="px-4 py-3 font-semibold">{t('colWeight')}</th>
+              <th className="px-4 py-3 font-semibold">{t('colReason')}</th>
+              <th className="px-4 py-3 font-semibold">{t('colUpdated')}</th>
               <th className="px-4 py-3"></th>
             </tr>
           </thead>

--- a/web-ui/app/chat/page.tsx
+++ b/web-ui/app/chat/page.tsx
@@ -1230,17 +1230,18 @@ function TriageBadge({
     model: string;
   };
 }): React.ReactElement {
+  const t = useTranslations('chat.routing');
   const verdict: Record<typeof routing.bucket, { label: string; cls: string }> = {
     simple: {
-      label: 'einfach',
+      label: t('bucketSimple'),
       cls: 'bg-[color:var(--success)]/10 text-[color:var(--success)] ring-[color:var(--success)]',
     },
     complex: {
-      label: 'komplex',
+      label: t('bucketComplex'),
       cls: 'bg-[color:var(--accent)]/10 text-[color:var(--accent)] ring-[color:var(--accent)]',
     },
     fallback: {
-      label: 'Fallback',
+      label: t('bucketFallback'),
       cls: 'bg-[color:var(--warning)]/10 text-[color:var(--warning)] ring-[color:var(--warning)]',
     },
   };
@@ -1248,7 +1249,11 @@ function TriageBadge({
   return (
     <div
       className="mb-2 inline-flex flex-wrap items-center gap-2 text-[11px] text-[color:var(--fg-muted)]"
-      title={`Triage-Klassifizierer: ${routing.classifierModel} → ${routing.bucket} → ${routing.model}`}
+      title={t('classifierTooltip', {
+        classifier: routing.classifierModel,
+        bucket: routing.bucket,
+        model: routing.model,
+      })}
     >
       <span className="font-medium uppercase tracking-[0.12em]">Triage</span>
       <span className="text-[color:var(--fg-subtle)]">

--- a/web-ui/app/graph/_components/GraphCanvas.tsx
+++ b/web-ui/app/graph/_components/GraphCanvas.tsx
@@ -915,10 +915,10 @@ export default function GraphCanvas({
       <div className="pointer-events-none absolute inset-0 flex items-start justify-between p-3">
         <Legend dark={dark} filter={filter} />
         <div className="pointer-events-auto flex flex-col gap-2 rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-elevated)]/90 p-2 shadow-sm backdrop-blur">
-          <IconBtn title="Zoom in" onClick={zoomIn}>＋</IconBtn>
-          <IconBtn title="Zoom out" onClick={zoomOut}>−</IconBtn>
-          <IconBtn title="Fit" onClick={fit}>⤢</IconBtn>
-          <IconBtn title="Re-Layout" onClick={relayout}>↻</IconBtn>
+          <IconBtn title={t('zoomIn')} onClick={zoomIn}>＋</IconBtn>
+          <IconBtn title={t('zoomOut')} onClick={zoomOut}>−</IconBtn>
+          <IconBtn title={t('fit')} onClick={fit}>⤢</IconBtn>
+          <IconBtn title={t('relayout')} onClick={relayout}>↻</IconBtn>
         </div>
       </div>
       {elements.length === 0 && (

--- a/web-ui/app/graph/_components/ListView.tsx
+++ b/web-ui/app/graph/_components/ListView.tsx
@@ -165,7 +165,7 @@ function RunTracePanel({
         {user && (
           <>
             <span>·</span>
-            <span title={`User: ${user}`}>👤 {user.slice(0, 16)}</span>
+            <span title={t('userTooltip', { user })}>👤 {user.slice(0, 16)}</span>
           </>
         )}
       </div>

--- a/web-ui/app/system/_components/VaultStatusCard.tsx
+++ b/web-ui/app/system/_components/VaultStatusCard.tsx
@@ -28,10 +28,10 @@ export async function VaultStatusCard({
       <header className="flex items-baseline justify-between gap-3">
         <div>
           <div className="text-[11px] uppercase tracking-[0.22em] text-[color:var(--fg-subtle)]">
-            Encrypted Secret Vault
+            {t('eyebrow')}
           </div>
           <h2 className="font-display mt-1 text-2xl text-[color:var(--fg-strong)]">
-            Vault
+            {t('heading')}
           </h2>
         </div>
         <StatusDot tone={keyTone} label={dotLabel(keyTone, t)} />
@@ -79,8 +79,8 @@ export async function VaultStatusCard({
 
       {backup.enabled ? (
         <dl className="mt-4 grid grid-cols-1 gap-x-6 gap-y-3 text-sm sm:grid-cols-2">
-          <Row label="Bucket" value={backup.bucket} mono />
-          <Row label="Prefix" value={backup.prefix} mono />
+          <Row label={t('bucket')} value={backup.bucket} mono />
+          <Row label={t('prefix')} value={backup.prefix} mono />
           <Row
             label={t('interval')}
             value={t('intervalValue', {

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -4243,7 +4243,11 @@
         }
       },
       "openMemory": "zur Memory →",
-      "memoryUnavailable": "Memory nicht zugänglich (gelöscht oder kein Owner)."
+      "memoryUnavailable": "Memory nicht zugänglich (gelöscht oder kein Owner).",
+      "memoryA": "Memory A",
+      "memoryB": "Memory B",
+      "status": "Status",
+      "resolution": "Behebung"
     },
     "excerptDetail": {
       "title": "Excerpt-Duplikat auflösen",
@@ -4273,7 +4277,11 @@
       "excerptUnavailable": "Excerpt nicht zugänglich (gelöscht oder kein Owner).",
       "positionLine": "Position {position} · {source}",
       "quotedText": "„{text}“",
-      "parentMemory": "Parent-Memory: {summary}"
+      "parentMemory": "Parent-Memory: {summary}",
+      "excerptA": "Auszug A",
+      "excerptB": "Auszug B",
+      "status": "Status",
+      "resolution": "Behebung"
     }
   },
   "adminInconsistencies": {
@@ -4332,7 +4340,12 @@
         }
       },
       "openMemory": "zur Memory →",
-      "memoryUnavailable": "Memory nicht zugänglich (gelöscht oder kein Owner)."
+      "memoryUnavailable": "Memory nicht zugänglich (gelöscht oder kein Owner).",
+      "memoryA": "Memory A",
+      "memoryB": "Memory B",
+      "severity": "Schweregrad",
+      "status": "Status",
+      "resolution": "Behebung"
     }
   },
   "adminKgLifecycle": {
@@ -4394,7 +4407,16 @@
     "newEntryTitle": "Neuer Eintrag",
     "weightIgnoredTitle": "weight ignoriert für block",
     "weightMultiplierTitle": "Score-Multiplikator",
-    "empty": "Keine Einträge für diesen Agent."
+    "empty": "Keine Einträge für diesen Agent.",
+    "title": "Knowledge-Graph-Prioritäten",
+    "colEntryExternalId": "Externe Eintrags-ID",
+    "actionBlock": "blockieren",
+    "actionBoost": "hervorheben",
+    "reasonPlaceholder": "Grund (optional)",
+    "colAction": "Aktion",
+    "colWeight": "Gewicht",
+    "colReason": "Grund",
+    "colUpdated": "Aktualisiert"
   },
   "adminMemoryBackend": {
     "title": "Memory · Speicher-Backend",
@@ -4540,7 +4562,11 @@
         "excerptDuplicate": "Excerpt-Duplikat",
         "planStep": "Plan-Schritt",
         "hasTopicTransitive": "HAS_TOPIC (Excerpt, transitiv)"
-      }
+      },
+      "zoomIn": "Vergrößern",
+      "zoomOut": "Verkleinern",
+      "fit": "Einpassen",
+      "relayout": "Neu anordnen"
     },
     "detailPanel": {
       "manualTitle": "manuell erfasst — Score-Boost ×1.3 im Token-Budget-Assembler",
@@ -4786,7 +4812,11 @@
       "dotDanger": "Fehler",
       "dotInactive": "Inaktiv",
       "keySourceDevFile": "dev-file (nicht für Produktion)",
-      "keySourceDevFileCreated": "dev-file (neu generiert — DEV ONLY)"
+      "keySourceDevFileCreated": "dev-file (neu generiert — DEV ONLY)",
+      "eyebrow": "Verschlüsselter Secret Vault",
+      "heading": "Vault",
+      "bucket": "Bucket",
+      "prefix": "Präfix"
     }
   },
   "help": {

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1373,7 +1373,13 @@
       "factHintTags": "'<palaia-hint>'-Tags"
     },
     "errorUpstreamErrorPage": "Der Server hat statt einer Antwort eine Fehlerseite geliefert (HTTP 500). Es hat also etwas geantwortet, der Fehler liegt serverseitig — prüfe die Middleware-Logs oder melde das deinem Betreiber.",
-    "errorCorrelationRef": "Referenz für den Support: {id}"
+    "errorCorrelationRef": "Referenz für den Support: {id}",
+    "routing": {
+      "classifierTooltip": "Triage-Klassifizierer: {classifier} → {bucket} → {model}",
+      "bucketSimple": "einfach",
+      "bucketComplex": "komplex",
+      "bucketFallback": "Fallback"
+    }
   },
   "privacyReceipt": {
     "summary": "🛡 Privacy Shield · {summary}",
@@ -3156,6 +3162,9 @@
       "dontSet": "(nicht setzen)",
       "noPasswordWarning": "Hier gehört kein Konto-Passwort hinein. Erwartet wird ein technischer Schlüssel aus der Anbieter-Konsole.",
       "patternUnavailable": "Dieses Feld deklariert eine Formatprüfung, die nicht angewendet werden konnte — der Wert wird nicht validiert."
+    },
+    "adminUi": {
+      "iframeTitle": "{plugin} Admin-UI"
     }
   },
   "adminAuth": {
@@ -4603,7 +4612,8 @@
       "toolsLabel": "Tools={count}",
       "iterations": "{count} Iter.",
       "orchestratorTools": "Orchestrator-Tools",
-      "toolCalls": "{count, plural, one {# Tool-Call} other {# Tool-Calls}}"
+      "toolCalls": "{count, plural, one {# Tool-Call} other {# Tool-Calls}}",
+      "userTooltip": "Benutzer: {user}"
     }
   },
   "memory": {

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -4243,7 +4243,11 @@
         }
       },
       "openMemory": "View memory →",
-      "memoryUnavailable": "Memory not accessible (deleted or no owner)."
+      "memoryUnavailable": "Memory not accessible (deleted or no owner).",
+      "memoryA": "Memory A",
+      "memoryB": "Memory B",
+      "status": "Status",
+      "resolution": "Resolution"
     },
     "excerptDetail": {
       "title": "Resolve excerpt duplicate",
@@ -4273,7 +4277,11 @@
       "excerptUnavailable": "Excerpt not accessible (deleted or no owner).",
       "positionLine": "Position {position} · {source}",
       "quotedText": "“{text}”",
-      "parentMemory": "Parent memory: {summary}"
+      "parentMemory": "Parent memory: {summary}",
+      "excerptA": "Excerpt A",
+      "excerptB": "Excerpt B",
+      "status": "Status",
+      "resolution": "Resolution"
     }
   },
   "adminInconsistencies": {
@@ -4332,7 +4340,12 @@
         }
       },
       "openMemory": "View memory →",
-      "memoryUnavailable": "Memory not accessible (deleted or no owner)."
+      "memoryUnavailable": "Memory not accessible (deleted or no owner).",
+      "memoryA": "Memory A",
+      "memoryB": "Memory B",
+      "severity": "Severity",
+      "status": "Status",
+      "resolution": "Resolution"
     }
   },
   "adminKgLifecycle": {
@@ -4394,7 +4407,16 @@
     "newEntryTitle": "New entry",
     "weightIgnoredTitle": "weight ignored for block",
     "weightMultiplierTitle": "score multiplier",
-    "empty": "No entries for this agent."
+    "empty": "No entries for this agent.",
+    "title": "Knowledge Graph priorities",
+    "colEntryExternalId": "Entry external ID",
+    "actionBlock": "block",
+    "actionBoost": "boost",
+    "reasonPlaceholder": "Reason (optional)",
+    "colAction": "Action",
+    "colWeight": "Weight",
+    "colReason": "Reason",
+    "colUpdated": "Updated"
   },
   "adminMemoryBackend": {
     "title": "Memory · Storage Backend",
@@ -4540,7 +4562,11 @@
         "excerptDuplicate": "Excerpt duplicate",
         "planStep": "Plan step",
         "hasTopicTransitive": "HAS_TOPIC (excerpt, transitive)"
-      }
+      },
+      "zoomIn": "Zoom in",
+      "zoomOut": "Zoom out",
+      "fit": "Fit",
+      "relayout": "Re-layout"
     },
     "detailPanel": {
       "manualTitle": "manually captured — score boost ×1.3 in the token-budget assembler",
@@ -4786,7 +4812,11 @@
       "dotDanger": "Error",
       "dotInactive": "Inactive",
       "keySourceDevFile": "dev file (not for production)",
-      "keySourceDevFileCreated": "dev file (newly generated — DEV ONLY)"
+      "keySourceDevFileCreated": "dev file (newly generated — DEV ONLY)",
+      "eyebrow": "Encrypted secret vault",
+      "heading": "Vault",
+      "bucket": "Bucket",
+      "prefix": "Prefix"
     }
   },
   "help": {

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1373,7 +1373,13 @@
       "factHintTags": "'<palaia-hint>' tags"
     },
     "errorUpstreamErrorPage": "The server returned an error page instead of a response (HTTP 500). Something answered, so the fault is server-side — check the middleware logs or report this to your operator.",
-    "errorCorrelationRef": "Reference for support: {id}"
+    "errorCorrelationRef": "Reference for support: {id}",
+    "routing": {
+      "classifierTooltip": "Triage classifier: {classifier} → {bucket} → {model}",
+      "bucketSimple": "simple",
+      "bucketComplex": "complex",
+      "bucketFallback": "Fallback"
+    }
   },
   "privacyReceipt": {
     "summary": "🛡 Privacy Shield · {summary}",
@@ -3156,6 +3162,9 @@
       "dontSet": "(leave unset)",
       "noPasswordWarning": "No account password belongs here. This expects a technical key from the provider's console.",
       "patternUnavailable": "This field declares a format check that could not be applied — its value is not validated."
+    },
+    "adminUi": {
+      "iframeTitle": "{plugin} admin UI"
     }
   },
   "adminAuth": {
@@ -4603,7 +4612,8 @@
       "toolsLabel": "tools={count}",
       "iterations": "{count} iter",
       "orchestratorTools": "Orchestrator tools",
-      "toolCalls": "{count, plural, one {# tool call} other {# tool calls}}"
+      "toolCalls": "{count, plural, one {# tool call} other {# tool calls}}",
+      "userTooltip": "User: {user}"
     }
   },
   "memory": {

--- a/web-ui/scripts/i18n-identical-allowlist.json
+++ b/web-ui/scripts/i18n-identical-allowlist.json
@@ -69,6 +69,11 @@
     "adminDangerZone.selectorPlaceholder.agent": "placeholder",
     "adminMemoryBackend.backends.postgres": "brand",
     "adminEmbeddingProvider.title": "loanword",
-    "graph.filters.traceHint": "glossary"
+    "graph.filters.traceHint": "glossary",
+    "adminDuplicates.detail.status": "loanword",
+    "adminDuplicates.excerptDetail.status": "loanword",
+    "adminInconsistencies.detail.status": "loanword",
+    "system.vaultStatus.heading": "brand",
+    "system.vaultStatus.bucket": "loanword"
   }
 }

--- a/web-ui/scripts/i18n-identical-allowlist.json
+++ b/web-ui/scripts/i18n-identical-allowlist.json
@@ -74,6 +74,7 @@
     "adminDuplicates.excerptDetail.status": "loanword",
     "adminInconsistencies.detail.status": "loanword",
     "system.vaultStatus.heading": "brand",
-    "system.vaultStatus.bucket": "loanword"
+    "system.vaultStatus.bucket": "loanword",
+    "chat.routing.bucketFallback": "loanword"
   }
 }

--- a/web-ui/scripts/i18n-literal-scan.mjs
+++ b/web-ui/scripts/i18n-literal-scan.mjs
@@ -106,7 +106,7 @@ const DOCUMENTED_EXCEPTIONS = new Map([
   ['chat/page.tsx', 'MOCK_KG_WALK is a dev-only fixture behind ?kgmock=1'],
 ]);
 
-const REASONS = ['translate', 'review', 'spec-keyword', 'api-enum', 'code', 'placeholder', 'brand', 'symbol'];
+const REASONS = ['translate', 'review', 'diagnostic', 'spec-keyword', 'api-enum', 'code', 'placeholder', 'brand', 'symbol'];
 
 /** A token that names something the machine reads, not something a human reads. */
 function isCodeToken(tok) {
@@ -135,6 +135,14 @@ function classify(text) {
 
   // `HOT`, `WARM | COLD`, `PENDING/DONE` — API enum values echoed into a badge.
   if (/^[A-Z][A-Z0-9_]*([\s]*[|/,][\s]*[A-Z][A-Z0-9_]*)*$/.test(t)) return 'api-enum';
+
+  // A version, phase or build stamp: `omadia · v1`, `B.0 Draft-Store`,
+  // `Phase B.5 (Workspace-UI)`, `omadia · v1 · Slice 1.1`. These sit in product
+  // footers and read like prose, but localising them changes an identifier an
+  // operator quotes back in a bug report. Whether they belong in the UI at all
+  // is a product question — the scan's job is only to keep them out of the
+  // translation list.
+  if (/(^|[\s·])(v\d+|[A-Z]\.?\d+(\.\d+)*)([\s·]|$)/.test(t)) return 'diagnostic';
 
   // A format being demonstrated, not a sentence: `https://…`, `{orgId}`,
   // `user@example.com`. Localising these teaches a wrong value.
@@ -202,11 +210,21 @@ export function scanFile(rel) {
       if (USER_FACING_PROPS.has(name)) {
         const value = stringValueOf(node.initializer);
         if (value !== undefined) {
-          // A one-word `placeholder=` is a format demo — `acme`, `api`,
-          // `github_pat_…`. GLOSSARY.md: "a form hint teaches a FORMAT;
-          // localising it teaches a wrong value."
+          // A `placeholder=` is a judgement call by nature, and the first
+          // triage pass proved it: of six hits, five were example VALUES that
+          // must not be translated (`Release sign-off`, `Release approver`,
+          // `id-1, id-2, …`, `email | uri | date-time | uuid`) and one was a
+          // real instruction (`Reason (optional)`). GLOSSARY.md: "a form hint
+          // teaches a FORMAT; localising it teaches a wrong value." Nothing in
+          // the syntax separates the two, so they go to `review` — except the
+          // single-token case, which is unambiguously a format demo.
+          const trimmedValue = value.trim();
           const forced =
-            name === 'placeholder' && !/\s/.test(value.trim()) ? 'placeholder' : undefined;
+            name !== 'placeholder'
+              ? undefined
+              : /\s/.test(trimmedValue)
+                ? 'review'
+                : 'placeholder';
           record(node, value, `prop:${name}`, forced);
         }
       }

--- a/web-ui/scripts/i18n-literal-scan.mjs
+++ b/web-ui/scripts/i18n-literal-scan.mjs
@@ -103,8 +103,27 @@ const TECH_TERMS = new Set([
  */
 const DOCUMENTED_EXCEPTIONS = new Map([
   ['global-error.tsx', 'renders when the intl provider itself has failed; intentionally bilingual'],
-  ['chat/page.tsx', 'MOCK_KG_WALK is a dev-only fixture behind ?kgmock=1'],
 ]);
+
+/**
+ * Exemptions that are scoped to a SYMBOL, not a file.
+ *
+ * `web-ui/CLAUDE.md` exempts `MOCK_KG_WALK` — a dev-only fixture behind
+ * `?kgmock=1` — not all of `chat/page.tsx`. Skipping the whole file was the
+ * cheap reading, and it hid a hardcoded German `title=` tooltip 1100 lines
+ * below the fixture. An exemption must be no wider than the thing it excuses.
+ */
+const EXEMPT_DECLARATIONS = new Map([['chat/page.tsx', ['MOCK_KG_WALK']]]);
+
+/** True when `node` sits inside one of the file's exempt declarations. */
+function isInExemptDeclaration(node, rel, sf) {
+  const names = EXEMPT_DECLARATIONS.get(rel);
+  if (names === undefined) return false;
+  for (let p = node.parent; p !== undefined && !ts.isSourceFile(p); p = p.parent) {
+    if (ts.isVariableDeclaration(p) && names.includes(p.name.getText(sf))) return true;
+  }
+  return false;
+}
 
 const REASONS = ['translate', 'review', 'diagnostic', 'spec-keyword', 'api-enum', 'code', 'placeholder', 'brand', 'symbol'];
 
@@ -130,6 +149,18 @@ function classify(text) {
   const lower = t.toLowerCase();
 
   if (!/\p{L}/u.test(t)) return 'symbol';
+
+  // German in a component file is the severest class in `web-ui/CLAUDE.md`
+  // ("German belongs only in messages/de.json"), so it outranks every
+  // exemption below — a German string is never a placeholder or an enum value.
+  //
+  // Precision over recall on purpose: umlauts and ß never appear in the English
+  // source, so this cannot false-positive, but it also cannot catch
+  // umlaut-free German like `Triage-Klassifizierer`. Those still surface as
+  // `review`, which is the honest answer — no cheap test tells the two
+  // languages apart, and guessing would put real English labels in the wrong
+  // bucket.
+  if (/[äöüÄÖÜß]/.test(t)) return 'translate';
   if (BRAND_TERMS.has(lower)) return 'brand';
   if (SPEC_KEYWORDS.has(lower)) return 'spec-keyword';
 
@@ -171,7 +202,35 @@ function stringValueOf(node) {
   if (node === undefined) return undefined;
   if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
   if (ts.isJsxExpression(node)) return stringValueOf(node.expression);
+  // A template literal WITH substitutions is the shape interpolated status
+  // lines use — `title={`Triage classifier: ${a} → ${b}`}`. The first version
+  // of this scan could not see them at all, which hid a hardcoded GERMAN
+  // tooltip that the repo's own `git diff | grep '[äöüÄÖÜß]'` self-check also
+  // misses (no umlauts in "Triage-Klassifizierer"). Rendered with `{}` in
+  // place of each substitution, which is both what the ICU key will look like
+  // and enough for the classifier to judge the surrounding prose.
+  if (ts.isTemplateExpression(node)) {
+    return [node.head.text, ...node.templateSpans.map((sp) => `{}${sp.literal.text}`)].join('');
+  }
   return undefined;
+}
+
+/**
+ * The text a hit is CLASSIFIED on, which is not always the text it is SHOWN as.
+ *
+ * A template literal is displayed with `{}` where each substitution was — that
+ * is what the eventual ICU key looks like. But `{...}` is also how `classify`
+ * recognises a format-illustrating placeholder, so classifying the display form
+ * would mark every interpolated string as an exempt placeholder and silently
+ * re-hide the class this scan was just extended to see. Classify on the literal
+ * parts alone.
+ */
+function classifiableText(node, display) {
+  const inner = ts.isJsxExpression(node) ? node.expression : node;
+  if (inner !== undefined && ts.isTemplateExpression(inner)) {
+    return [inner.head.text, ...inner.templateSpans.map((sp) => sp.literal.text)].join(' ');
+  }
+  return display;
 }
 
 /**
@@ -185,16 +244,17 @@ export function scanFile(rel) {
   const sf = ts.createSourceFile(rel, src, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
   const hits = [];
 
-  const record = (node, text, kind, forcedReason) => {
+  const record = (node, text, kind, forcedReason, valueNode) => {
     const trimmed = text.trim();
     if (trimmed === '') return;
+    if (isInExemptDeclaration(node, rel, sf)) return;
     const { line } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
     hits.push({
       file: rel,
       line: line + 1,
       kind,
       text: trimmed,
-      reason: forcedReason ?? classify(trimmed),
+      reason: forcedReason ?? classify(classifiableText(valueNode ?? node, trimmed).trim()),
     });
   };
 
@@ -225,13 +285,28 @@ export function scanFile(rel) {
               : /\s/.test(trimmedValue)
                 ? 'review'
                 : 'placeholder';
-          record(node, value, `prop:${name}`, forced);
+          record(node, value, `prop:${name}`, forced, node.initializer);
         }
+      }
+    } else if (
+      ts.isPropertyAssignment(node) &&
+      USER_FACING_PROPS.has(node.name.getText(sf))
+    ) {
+      // A user-facing string can also live in a plain object that is rendered
+      // later — `const verdict = { simple: { label: 'einfach' } }` then
+      // `<span>{v.label}</span>`. Neither JSX text nor a JSX prop, so the first
+      // version of this scan could not see it, and two GERMAN badge labels sat
+      // there. Restricted to the same closed prop list, so a `label` on an API
+      // payload is the only kind of false positive this can produce — and a
+      // false `review` costs a comment, while a miss costs a shipped bug.
+      const value = stringValueOf(node.initializer);
+      if (value !== undefined) {
+        record(node, value, `obj:${node.name.getText(sf)}`, undefined, node.initializer);
       }
     } else if (ts.isJsxExpression(node) && node.parent && ts.isJsxElement(node.parent)) {
       // `<p>{'literal'}</p>` — same thing as JSX text, written differently.
       const value = stringValueOf(node);
-      if (value !== undefined) record(node, value, 'jsx-child-string');
+      if (value !== undefined) record(node, value, 'jsx-child-string', undefined, node);
     }
     ts.forEachChild(node, walk);
   };


### PR DESCRIPTION
Follow-on to #747, which made the I3 category measurable. This spends that measurement: `translate` goes from **40 → 19**, and the per-file ratchet grows from **1 → 7 files**.

## Two scanner rules, learned from the triage

Neither was guessed — both come from looking at what the first pass actually returned.

**1. Version / phase / build stamps are `diagnostic`, not prose.**

| site | literal |
|---|---|
| `store/page.tsx:229` | `omadia · v1` |
| `store/[id]/page.tsx:464` | `omadia · v1 · Slice 1.1` |
| `store/builder/page.tsx:181` | `B.0 Draft-Store` |
| `Workspace.tsx:2070` | `Phase B.5 (Workspace-UI)` |

They sit in product footers and read like text, but localising them changes an identifier an operator quotes back in a bug report. One of them is telling: `store/builder/page.tsx` already renders `{t('footer.phaseLabel')}` and then the hardcoded value right beside it — the label was translated, the value was not.

Checked in the dangerous direction: the `diagnostic` bucket contains **exactly** those four and nothing legitimate.

> Whether internal roadmap vocabulary (`Slice 1.1`, `Phase B.5`) belongs in a shipped footer at all is a product question. Flagged, not answered.

**2. Every `placeholder=` is a judgement call, not only the one-word ones.**

#747 forced single-token placeholders to `placeholder` and left multi-word ones in `translate`. The triage showed that was the wrong cut — of six hits, **five were example values** that must not be translated (`Release sign-off`, `Release approver`, `id-1, id-2, …`, `email | uri | date-time | uuid`) and **one was a real instruction** (`Reason (optional)`). Nothing in the syntax separates an example value from an instruction, so multi-word placeholders now land in `review` — the bucket that means "a human decides", which is exactly true here.

## The translations

27 keys across six files, all of which reach **zero** actionable hits and join `SWEPT_COMPONENTS`.

The judgement calls worth naming, since that is what `review` exists to force:

- **`block` / `boost`** (kg-priorities action select) → German. GLOSSARY.md puts *descriptions of what is happening* in German and keeps *product nouns* English; these are actions an operator picks, so `blockieren` / `hervorheben`. The `value` attributes stay `block` / `boost` — the wire contract is untouched.
- **`Vault`, `Bucket`** → stay English (product noun, established loanword) but are now catalogue keys with explicit `brand` / `loanword` entries in `i18n-identical-allowlist.json`, rather than implicit exemptions.
- **`Status`** → identical in both locales, allowlisted as `loanword`.
- **`Resolution`** → `Behebung`. Not `Auflösung`, which in German software reads as screen resolution.

On that allowlist point: these five would have passed **silently** either way. `i18n-validate` exempts short capitalised nouns from the identical-value gate by design — a gap its own comment names as the follow-up. Listing them anyway puts the decision where a reader looks instead of relying on a rule that happens not to fire.

## Verification

- `npm run i18n:check` — OK, 3760 keys
- `tsc --noEmit` clean; `eslint` clean on every changed file
- `npm test` — **742/742 across 88 files**
- **Mutation check:** restoring one literal (`label={t('prefix')}` → `label="Prefix"`) turns exactly the new per-file ratchet red; reverting returns 15/15.

## What is left, and why

19 `translate` hits remain. Most are **sentences split across JSX elements** — the scanner sees `rendered markdown (`, `Stream live ·`, `· last activity`, `s tool-time`, `User · Tenant` — where the fix is an ICU message with placeholders, not a 1:1 key. Restructuring those changes markup rather than just extracting strings, so it belongs in its own pass rather than being smuggled into a translation PR.

The rest are taglines (`an Agentic OS`) and format names (`OpenAPI 3 (JSON)`) that need a brand decision before a key.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789745253&installation_model_id=428086&pr_number=751&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F751&signature=f68163b1b24f565669c27529eddc39b54bb3d3ddbb851476cbb8ce1c3c756555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->