### PR TITLE
fix(ci): the decoupling ratchet was timing out before it ran

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,13 @@ jobs:
   decoupling:
     name: core decoupling ratchet (#470)
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Was 5. `Ensure ripgrep` alone took 3:28 on a good run and 5:07 on a bad
+    # one, so this job routinely had ~90 seconds of headroom and intermittently
+    # blew the budget. A timed-out job reports as `cancelled`, and its remaining
+    # steps are `skipped` — so the ratchet was a REQUIRED check that silently
+    # did not run, which is the same failure family as a permanently-green
+    # guard-skip: not red, not passing, just absent.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -50,7 +56,15 @@ jobs:
           node-version: '22'
 
       - name: Ensure ripgrep
-        run: command -v rg >/dev/null || (sudo apt-get update && sudo apt-get install -y ripgrep)
+        # `apt-get update` is the expensive half — it refetches every package
+        # index to install one small binary. Try the cached indices first and
+        # only refresh when that actually fails. `rg` is genuinely needed:
+        # `check-core-decoupling.mjs` shells out to it (`execFileSync('rg', …)`).
+        run: |
+          if ! command -v rg >/dev/null; then
+            sudo apt-get install -y ripgrep \
+              || (sudo apt-get update && sudo apt-get install -y ripgrep)
+          fi
 
       - name: Check core is not re-coupling to the Dev Platform
         run: node scripts/check-core-decoupling.mjs


### PR DESCRIPTION
`core decoupling ratchet (#470)` reported `cancelled` on two PRs in a row. That reads like a transient — a push cancelling an in-flight run. It was not: when a push cancels a run, **every** job is cancelled, and here the siblings all succeeded on the same SHA while only this one died.

## What actually happened

From the job's own step timings:

| step | window | result |
|---|---|---|
| Set up job → setup-node | 15:35:41 → 15:35:47 | success |
| **Ensure ripgrep** | 15:35:47 → 15:40:54 | **cancelled (5:07)** |
| **Check core is not re-coupling** | — | **skipped** |

The job's `timeout-minutes: 5` fired *inside the install step*, so **the step that does the actual checking never executed**.

And the run that passed was not comfortable either — the same install took **3:28** there. The job routinely had about ninety seconds of headroom, which is why this surfaces as an intermittent rather than a permanent failure.

**A timed-out job reports as `cancelled` and skips its remaining steps.** So a required check was silently not running: not red, not passing, just absent. That is the same failure family as a permanently-green guard-skip — the gate is gone and nothing about the PR page says so.

## The fix

**`apt-get update` is the expensive half.** It refetches every package index in order to install one small binary. The step now tries the cached indices first and only refreshes when that actually fails; worst case costs a few seconds more than today, best case skips minutes.

`rg` is genuinely required and the step cannot just be deleted — `scripts/check-core-decoupling.mjs` shells out to it (`execFileSync('rg', args, …)` at line 119).

**Timeout 5 → 10**, so a slow package mirror cannot take out a required check. The install is the only unbounded thing in the job; the check itself is a single `rg` over the repo.

## One deliberate detail

The guard is an explicit `if`:

```bash
if ! command -v rg >/dev/null; then
  sudo apt-get install -y ripgrep \
    || (sudo apt-get update && sudo apt-get install -y ripgrep)
fi
```

not `command -v rg >/dev/null && exit 0`. Whether `set -e` aborts on the first half of an `&&` list is precisely the kind of shell subtlety that has produced a silent CI failure in this repo before (the `printf | grep -q` EPIPE inversion that left the release pipeline dead for a month). Both branches were verified under `bash -e`.

## Verification

The real verification is this PR's own run: if the ratchet check comes back `success` rather than `cancelled`, the step completed and the check executed. Worth glancing at its duration too — the point is headroom, not just a pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789746244&installation_model_id=428086&pr_number=752&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F752&signature=72e097c60507af32428bbb2f4fb327f8943721c485035a76a1b799df1eb93564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->