### PR TITLE
feat: persist per-turn privacy receipts with operator API (#757)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,22 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — persistent per-turn privacy receipts (#757)
+
+- **`turn_receipts` (migration `0039`).** The per-turn `PrivacyReceipt` is no
+  longer ephemeral UI state: every completed turn writes its PII-free receipt
+  (counts + routing metadata, never a value) synchronously to Postgres — no
+  optional graph sink, no user-cluster precondition. Failures are counted and
+  logged, never silent. Schema note: `turn_id` unique (idempotent on replayed
+  `done` events); retention bounded by the new `RECEIPT_RETENTION_DAYS`
+  (default 90) via an unref'd reaper anchored on the DB clock.
+- **Operator surface.** Auth-gated `GET /api/v1/operator/receipts` (+
+  `/:turnId`) with composite-keyset pagination, and a web-ui page under
+  `/operator/receipts` rendering the exact receipt card the user saw.
+- Not yet tamper-evident — hash chaining, signatures, and verification are
+  #758/#761; `docs/ai-act-transparency.md` §6 keeps "cryptographically
+  verifiable" a non-claim until they ship.
+
 ### Added — a command policy that reads what a command actually does
 
 - **Shell-normalizing command policy (#580).** Command gating is not

--- a/docs/ai-act-transparency.md
+++ b/docs/ai-act-transparency.md
@@ -158,6 +158,15 @@ User-Cluster-Knoten existiert — der Normalfall für jeden Kanal außer dem Bro
 fehlender Trace heißt "nicht aufgezeichnet", nie "diesen Turn gab es nicht". Entschieden
 und begründet in #684; jeder Ausfall wird seitdem gezählt und protokolliert.
 
+**Seit #757 gibt es daneben einen persistierten Per-Turn-Receipt** (`turn_receipts`,
+Migration `0039`): der PII-freie Privacy-Receipt jedes abgeschlossenen Turns wird auf dem
+Postgres-Backend synchron gespeichert — ohne Graph-Sink, ohne User-Cluster-Vorbedingung —
+und ist unter `/api/v1/operator/receipts` (auth-gated) sowie im Operator-UI abrufbar.
+Fehlschläge werden gezählt und protokolliert, nie still verworfen. Der Receipt ist ein
+*Record*, aber (noch) nicht manipulationssicher: Hash-Verkettung, Signaturen und
+Verifikation sind #758/#761 — bis dahin bleibt „kryptographisch nachweisbar" eine
+Nicht-Zusage.
+
 **C2PA ist offen.** Im Code existiert keine C2PA-Implementierung. Für Bilder wäre das der
 naheliegende nächste Schritt; heute ist es keine Zusage, sondern ein offener Punkt.
 

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -1103,6 +1103,21 @@ Emission-Asserts in `test/cliBridge/loopbackMcpServer.test.ts` und
 
 ---
 
+### Turn-Receipts (#757) — persistierte Per-Turn-Privacy-Receipts
+
+Jeder abgeschlossene Turn persistiert seinen PII-freien `PrivacyReceipt`
+synchron nach `turn_receipts` (Migration `0039`, Postgres-Backend only). Der
+Orchestrator löst den Store late-bound über den Service
+`turnReceiptStore` auf (Kernel provided in `index.ts`, gleiches Muster wie
+`privacyRedact`); ohne Service bleiben Receipts ephemer. Fehlschläge werden
+gezählt (`persistFailures` in `src/receipts/store.ts`) und greppbar geloggt
+(`turn-receipt persist failed`), scheitern aber nie den Turn. Read-API:
+auth-gated **`GET /api/v1/operator/receipts`** (Liste, Composite-Keyset-Cursor
+`(created_at, id)`) und **`GET /api/v1/operator/receipts/:turnId`**; UI unter
+`/operator/receipts`. Retention: `RECEIPT_RETENTION_DAYS` (Default 90),
+Reaper mit Eager-Boot-Tick, Cutoff auf der DB-Uhr. Tests:
+`test/turnReceipts.test.ts`, `test/orchestrator/turnReceiptPersistence.test.ts`.
+
 ## 4. Migration Managed Agents → Lokal
 
 ### Warum migriert
@@ -1452,6 +1467,8 @@ SKILLS_DIR=../skills                # relativ zum middleware root
 MEMORY_DIR=./.memory
 MEMORY_SEED_DIR=./seed/memory
 MEMORY_SEED_MODE=missing            # missing | overwrite | skip
+# Turn receipts (#757)
+RECEIPT_RETENTION_DAYS=90           # bounded retention for turn_receipts
 # Odoo
 ODOO_URL, ODOO_DB, ODOO_LOGIN, ODOO_API_KEY
 ODOO_PROXY_MAX_BYTES=500000

--- a/middleware/.env.example
+++ b/middleware/.env.example
@@ -236,6 +236,12 @@ DEV_PLATFORM_EVENT_RETENTION_DAYS=30
 # so the credential is INSIDE the runner. Off by default; boot REFUSES the flag
 # unless DEV_PLATFORM_SUBSCRIPTION_ACK is also set.
 DEV_PLATFORM_SUBSCRIPTION_MODE=false
+
+# --- Turn receipts (#757) ---------------------------------------------------
+# Every completed turn persists its PII-free privacy receipt (turn_receipts,
+# Postgres backend only). turn_id + scope are personal-data linkage, so rows
+# are reaped after this many days.
+RECEIPT_RETENTION_DAYS=90
 # DEV_PLATFORM_SUBSCRIPTION_ACK=   # required acknowledgment string when SUBSCRIPTION_MODE=true
 
 # --- Conductor generic webhooks (issue #437) --------------------------------

--- a/middleware/migrations/0039_turn_receipts.sql
+++ b/middleware/migrations/0039_turn_receipts.sql
@@ -1,0 +1,34 @@
+-- #757 — persistent per-turn audit receipts.
+--
+-- The per-turn PrivacyReceipt was, until now, attached to the `done` event and
+-- discarded — nothing let an operator answer "what did the system disclose or
+-- mask for turn X last Tuesday?". This table persists it, one row per turn,
+-- written synchronously by the orchestrator at turn end (no optional graph
+-- sink, no user-cluster precondition — deliberately NOT the RunTrace, which is
+-- best-effort telemetry).
+--
+-- The payload is PII-free by construction (counts + verb names, see
+-- plugin-api/src/privacyReceipt.ts); turn_id + scope are personal-data
+-- LINKAGE, so retention is bounded by RECEIPT_RETENTION_DAYS via a reaper.
+--
+-- 0038 is reserved for the Satellites epic (#746); this series continues at 0039.
+
+CREATE TABLE IF NOT EXISTS turn_receipts (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  turn_id       TEXT NOT NULL,
+  session_scope TEXT,
+  channel       TEXT,
+  model         TEXT,
+  receipt       JSONB NOT NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Idempotence key: a replayed `done` event must not duplicate the row.
+CREATE UNIQUE INDEX IF NOT EXISTS turn_receipts_turn_id
+  ON turn_receipts (turn_id);
+
+-- Operator list view: newest first, optionally filtered by scope.
+CREATE INDEX IF NOT EXISTS turn_receipts_scope_created
+  ON turn_receipts (session_scope, created_at DESC);
+CREATE INDEX IF NOT EXISTS turn_receipts_created
+  ON turn_receipts (created_at DESC);

--- a/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/buildOrchestrator.ts
@@ -33,6 +33,7 @@ import type {
   ProcessMemoryService,
   ResponseGuardService,
   SessionBriefingService,
+  TurnReceiptStore,
 } from '@omadia/plugin-api';
 import type { VerifierBundle } from '@omadia/verifier';
 import type { Pool } from 'pg';
@@ -140,6 +141,10 @@ export interface OrchestratorDeps {
   readonly responseGuard: () => ResponseGuardService | undefined;
   /** Late-bound `privacy.redact@1` lookup (see `OrchestratorOptions`). */
   readonly privacyGuard: () => PrivacyGuardService | undefined;
+  /** #757 — late-bound persistent per-turn receipt store lookup (see
+   *  `OrchestratorOptions.turnReceiptStore`). Optional: absent ⇒ receipts
+   *  stay ephemeral. */
+  readonly turnReceiptStore?: () => TurnReceiptStore | undefined;
   /**
    * Slice 2.5 — cross-plugin runtime-config lookup for the privacy bypass
    * resolver (see `OrchestratorOptions.pluginConfigGet`). Wired from the
@@ -393,6 +398,9 @@ export function buildOrchestratorForAgent(
     ...(deps.embeddingClient ? { embeddingClient: deps.embeddingClient } : {}),
     responseGuard: deps.responseGuard,
     privacyGuard: deps.privacyGuard,
+    ...(deps.turnReceiptStore
+      ? { turnReceiptStore: deps.turnReceiptStore }
+      : {}),
     ...(deps.pluginConfigGet
       ? { pluginConfigGet: deps.pluginConfigGet }
       : {}),

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -139,9 +139,11 @@ import type {
   PalaiaExcerpt,
   PalaiaExcerptExtractor,
   PrivacyGuardService,
+  PrivacyReceipt,
   ProcessMemoryService,
   ResponseGuardService,
   SessionBriefingService,
+  TurnReceiptStore,
 } from '@omadia/plugin-api';
 import {
   agentScopePrefix,
@@ -557,6 +559,16 @@ export interface OrchestratorOptions {
    * attached to the returned `ChatTurnResult.privacyReceipt`.
    */
   privacyGuard?: () => PrivacyGuardService | undefined;
+  /**
+   * #757 — persistent per-turn receipt store lookup. Same late-bound thunk
+   * shape as `privacyGuard` (the kernel provides the service once its pg
+   * pool resolves; a per-turn lookup needs no restart). When present, every
+   * receipt `finalizeTurn` emits is ALSO persisted before the `done` event
+   * is considered flushed; persistence failure is logged + counted by the
+   * store, never fails the turn. Absent ⇒ receipts stay ephemeral
+   * (pre-#757 behaviour: UI-only).
+   */
+  turnReceiptStore?: () => TurnReceiptStore | undefined;
   /**
    * Slice 2.5 — cross-plugin runtime-config lookup for the privacy
    * dispatch hook. Given `(agentId, configKey)` returns the operator-set
@@ -1747,6 +1759,7 @@ export class Orchestrator {
   private readonly bookMeetingTool: BookMeetingTool | undefined;
   private readonly responseGuard: (() => ResponseGuardService | undefined) | undefined;
   private readonly privacyGuard: (() => PrivacyGuardService | undefined) | undefined;
+  private readonly turnReceiptStore: (() => TurnReceiptStore | undefined) | undefined;
   /** Slice 2.5 — cross-plugin runtime-config lookup (see OrchestratorOptions). */
   private readonly pluginConfigGet:
     | ((agentId: string, configKey: string) => unknown | undefined)
@@ -1871,6 +1884,7 @@ export class Orchestrator {
     this.bookMeetingTool = options.bookMeetingTool;
     this.responseGuard = options.responseGuard;
     this.privacyGuard = options.privacyGuard;
+    this.turnReceiptStore = options.turnReceiptStore;
     this.pluginConfigGet = options.pluginConfigGet;
     this.isPluginToolsReady = options.isPluginToolsReady;
     this.nudgeRegistry = options.nudgeRegistry;
@@ -3327,6 +3341,7 @@ export class Orchestrator {
           try {
             const receipt = await privacyHandle.finalize(input.userMessage);
             if (receipt) {
+              await this.persistTurnReceipt(turnId, input, receipt);
               return { ...result, privacyReceipt: receipt };
             }
           } catch (err) {
@@ -3339,6 +3354,38 @@ export class Orchestrator {
         return result;
       },
     );
+  }
+
+  /**
+   * #757 — persist the turn's privacy receipt into the kernel-provided
+   * store, when one is wired. Called at every site that obtains a receipt
+   * from `finalizeTurn` (non-streaming, direct-line, streaming done) so a
+   * receipt that reaches the user also reaches the record. Never fails the
+   * turn: the user's answer outranks the audit row; the store counts the
+   * failure (`persistFailures`) and this logs it greppably — the exact
+   * inversion of the RunTrace defect (#684), where the drop was invisible.
+   */
+  private async persistTurnReceipt(
+    turnId: string,
+    input: ChatTurnInput,
+    receipt: PrivacyReceipt,
+  ): Promise<void> {
+    const store = this.turnReceiptStore?.();
+    if (!store) return;
+    try {
+      await store.record({
+        turnId,
+        sessionScope: input.sessionScope,
+        channel: input.channelIdentity?.channelKind,
+        model: this.model,
+        receipt,
+      });
+    } catch (err) {
+      console.error(
+        `[orchestrator] turn-receipt persist failed for turn ${turnId}:`,
+        err,
+      );
+    }
   }
 
   /**
@@ -4894,6 +4941,7 @@ export class Orchestrator {
           try {
             const receipt = await privacyHandle.finalize(input.userMessage);
             if (receipt) {
+              await this.persistTurnReceipt(turnId, input, receipt);
               doneEvent = { ...doneEvent, privacyReceipt: receipt };
             }
           } catch (err) {
@@ -4995,6 +5043,7 @@ export class Orchestrator {
           try {
             const receipt = await privacyHandle.finalize(input.userMessage);
             if (receipt) {
+              await this.persistTurnReceipt(turnId, input, receipt);
               doneEvent = { ...doneEvent, privacyReceipt: receipt };
             }
           } catch (err) {

--- a/middleware/packages/harness-orchestrator/src/plugin.ts
+++ b/middleware/packages/harness-orchestrator/src/plugin.ts
@@ -52,7 +52,9 @@ import type { MemoryStore, PluginContext } from '@omadia/plugin-api';
 import {
   PRIVACY_REDACT_SERVICE_NAME,
   RESPONSE_GUARD_SERVICE_NAME,
+  TURN_RECEIPT_STORE_SERVICE_NAME,
   type PrivacyGuardService,
+  type TurnReceiptStore,
 } from '@omadia/plugin-api';
 import type { VerifierBundle } from '@omadia/verifier';
 
@@ -587,6 +589,12 @@ export async function activate(
   const privacyGuardGetter = (): PrivacyGuardService | undefined =>
     ctx.services.get<PrivacyGuardService>(PRIVACY_REDACT_SERVICE_NAME);
 
+  // #757 — persistent per-turn receipt store, published by the kernel once
+  // its pg pool resolves (in-memory backend: never provided, receipts stay
+  // ephemeral). Same late-bound shape as the two getters above.
+  const turnReceiptStoreGetter = (): TurnReceiptStore | undefined =>
+    ctx.services.get<TurnReceiptStore>(TURN_RECEIPT_STORE_SERVICE_NAME);
+
   // Slice 2.5 — cross-plugin runtime-config reader for the privacy
   // bypass resolver. Published by the kernel at boot
   // (`middleware/src/index.ts:installedPluginConfigReader`). When absent
@@ -829,6 +837,7 @@ export async function activate(
     nudgeRegistry,
     responseGuard: responseGuardGetter,
     privacyGuard: privacyGuardGetter,
+    turnReceiptStore: turnReceiptStoreGetter,
     ...(pluginConfigGet ? { pluginConfigGet } : {}),
     ...(isPluginToolsReady ? { isPluginToolsReady } : {}),
     ...(contextRetriever ? { contextRetriever } : {}),

--- a/middleware/packages/plugin-api/src/index.ts
+++ b/middleware/packages/plugin-api/src/index.ts
@@ -58,6 +58,9 @@ export * from './agentPriorities.js';
 // renderers build against the fixtures here.
 export * from './privacyReceipt.js';
 export * from './privacyReceiptFixtures.js';
+// #757 — persistent per-turn audit receipts (kernel-provided store the
+// orchestrator resolves late-bound; receipts stay ephemeral when absent).
+export * from './turnReceiptStore.js';
 
 // Slice 2.5 — operator-owned per-plugin Privacy Mode contract. Shared by
 // the orchestrator dispatch hook (resolves mode at dispatch time) and the

--- a/middleware/packages/plugin-api/src/turnReceiptStore.ts
+++ b/middleware/packages/plugin-api/src/turnReceiptStore.ts
@@ -1,0 +1,55 @@
+/**
+ * #757 — persistent per-turn audit receipts.
+ *
+ * The `PrivacyReceipt` (see `privacyReceipt.ts`) is emitted once per turn and
+ * was, until #757, attached to the `done` event and then gone — an operator
+ * could never answer "what did the system disclose or mask for turn X last
+ * Tuesday?". This service persists that receipt, guaranteed per turn, into a
+ * kernel-owned store (`turn_receipts`, migration `0039`).
+ *
+ * Deliberately NOT the RunTrace: the trace is best-effort telemetry behind an
+ * optional graph sink (`runTraceObservability.ts` documents why it must not be
+ * promised as a record). This store has no user-cluster precondition and no
+ * optional sink — a turn either lands here or the failure is counted and
+ * logged loudly.
+ *
+ * The record stays PII-free by construction: it carries the receipt's counts
+ * plus routing metadata (turn id, session scope, channel kind, model). The
+ * `turnId`+`scope` pair is personal-data *linkage*, so retention is bounded
+ * (`RECEIPT_RETENTION_DAYS`) and enforced by a reaper.
+ */
+
+import type { PrivacyReceipt } from './privacyReceipt.js';
+
+/**
+ * Service-registry name the kernel publishes its store under. The
+ * harness-orchestrator resolves it late-bound (per turn, like
+ * `privacyRedact`) so boot order does not matter; absent service — e.g. the
+ * in-memory backend, unit tests — means receipts stay ephemeral, exactly the
+ * pre-#757 behaviour.
+ */
+export const TURN_RECEIPT_STORE_SERVICE_NAME = 'turnReceiptStore';
+
+/** One persisted per-turn receipt row. PII-free: counts + routing metadata. */
+export interface TurnReceiptRecordInput {
+  /** The orchestrator's per-turn id — unique key of the row. */
+  readonly turnId: string;
+  /** Session-transcript bucket the turn ran in (`ChatTurnInput.sessionScope`). */
+  readonly sessionScope?: string;
+  /** Channel kind when the dispatcher mapped one (`channelIdentity.channelKind`). */
+  readonly channel?: string;
+  /** Model id the orchestrator was configured with for this turn. */
+  readonly model?: string;
+  /** The turn's aggregated privacy receipt, verbatim. */
+  readonly receipt: PrivacyReceipt;
+}
+
+export interface TurnReceiptStore {
+  /**
+   * Persist one turn's receipt. Idempotent on `turnId` (a replayed `done`
+   * event must not duplicate the row). Implementations throw on storage
+   * failure — the caller decides whether the turn survives (it does; the
+   * failure is counted and logged, never swallowed silently).
+   */
+  record(entry: TurnReceiptRecordInput): Promise<void>;
+}

--- a/middleware/src/config.ts
+++ b/middleware/src/config.ts
@@ -283,6 +283,11 @@ const ConfigSchema = z.object({
   // origin in dev, while the webhook route only ever lives on the middleware).
   CONDUCTOR_WEBHOOK_PUBLIC_BASE_URL: z.string().url().optional(),
 
+  // #757 — bounded retention for persisted per-turn privacy receipts
+  // (`turn_receipts`). The payload is PII-free (counts only) but turn_id +
+  // scope are personal-data linkage, so rows are reaped after this many days.
+  RECEIPT_RETENTION_DAYS: z.coerce.number().int().positive().default(90),
+
   // Epic #470 W4 — default per-job LLM cost budget (USD) applied when neither the
   // job nor its repo sets one (spec §5). Token budgets have NO default: they are
   // enforced only when explicitly set on the job or repo.

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -31,6 +31,9 @@ import { createMemoryBackendRouter } from './routes/memoryBackend.js';
 import { createChatRouter } from './routes/chat.js';
 import { createOperatorAgentsRouter } from './routes/operatorAgents.js';
 import { wireConductor, AwaitNotPendingError, AwaitResponderNotHolderError, ConductorRoleStore } from './conductor/index.js';
+import { TURN_RECEIPT_STORE_SERVICE_NAME } from '@omadia/plugin-api';
+import { PgTurnReceiptStore, startTurnReceiptReaper } from './receipts/store.js';
+import { createReceiptRoutes } from './receipts/routes.js';
 import { bindingKeyForTurn } from './conductor/principalId.js';
 import { createOperatorChannelsRouter } from './routes/operatorChannels.js';
 import { createAgentBuilderRouter } from './routes/agentBuilder.js';
@@ -3482,6 +3485,26 @@ async function main(): Promise<void> {
       log: (m) => console.log(m),
     });
     console.log('[middleware] conductor wired at /api/v1/operator/conductors/* (auth-gated)');
+
+    // #757 — persistent per-turn privacy receipts. The store is published as
+    // a service the orchestrator resolves late-bound at turn end (same shape
+    // as `privacyRedact`); the read API mounts auth-gated next to the
+    // Conductor's operator surface; retention is enforced by an unref'd
+    // reaper (`RECEIPT_RETENTION_DAYS`). Postgres-only by construction —
+    // on the in-memory backend none of this wiring runs and receipts stay
+    // ephemeral, exactly the pre-#757 behaviour.
+    serviceRegistry.provide(
+      TURN_RECEIPT_STORE_SERVICE_NAME,
+      new PgTurnReceiptStore(graphPool),
+    );
+    app.use('/api/v1/operator/receipts', requireAuth, createReceiptRoutes(graphPool));
+    startTurnReceiptReaper(graphPool, {
+      retentionDays: config.RECEIPT_RETENTION_DAYS,
+    });
+    console.log(
+      `[middleware] turn receipts wired at /api/v1/operator/receipts (auth-gated, retention ${config.RECEIPT_RETENTION_DAYS}d)`,
+    );
+
     const userStore = new UserStore(graphPool);
 
     const bootstrapResult = await runAuthBootstrap({

--- a/middleware/src/receipts/routes.ts
+++ b/middleware/src/receipts/routes.ts
@@ -1,0 +1,164 @@
+/**
+ * #757 — operator read API for persisted per-turn receipts.
+ *
+ * Mounted under `/api/v1/operator/receipts` behind `requireAuth` (same
+ * posture as the Conductor's operator API — mounting happens at the caller,
+ * `middleware/src/index.ts`, which owns the auth middleware).
+ *
+ * Read-only by design: rows are written solely by the orchestrator's turn
+ * path. Query params are validated at the boundary; the receipt payload is
+ * PII-free by construction, so no masking is owed on this surface.
+ *
+ * Pagination is a composite keyset cursor `(created_at, id)`. A bare
+ * `created_at` cursor would lose rows on this surface twice over: exact-tie
+ * rows cut off by LIMIT would be skipped for good, and node-postgres
+ * truncates pg's microseconds to JS milliseconds, so a `< cursor` filter on
+ * a round-tripped ISO string swallows the sub-millisecond remainder. The
+ * cursor therefore carries pg's own text form of the timestamp (full
+ * microseconds, cast back with `::timestamptz`) plus the row id as the
+ * tiebreaker — "no receipt silently disappears" is this feature's promise,
+ * and paging is not allowed to break it.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import type { Pool } from 'pg';
+import { z } from 'zod';
+
+const LIST_MAX_LIMIT = 100;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/** Opaque list cursor: `<pg timestamptz text>|<row uuid>`. */
+function parseCursor(raw: string): { ts: string; id: string } | undefined {
+  const sep = raw.lastIndexOf('|');
+  if (sep <= 0) return undefined;
+  const ts = raw.slice(0, sep);
+  const id = raw.slice(sep + 1);
+  if (!UUID_RE.test(id)) return undefined;
+  if (ts.length === 0 || ts.length > 64 || Number.isNaN(Date.parse(ts))) {
+    return undefined;
+  }
+  return { ts, id };
+}
+
+const listQuerySchema = z.object({
+  scope: z.string().min(1).max(512).optional(),
+  from: z.coerce.date().optional(),
+  to: z.coerce.date().optional(),
+  limit: z.coerce.number().int().min(1).max(LIST_MAX_LIMIT).default(25),
+  cursor: z
+    .string()
+    .max(128)
+    .transform((raw, ctx) => {
+      const parsed = parseCursor(raw);
+      if (!parsed) {
+        ctx.addIssue({ code: 'custom', message: 'malformed cursor' });
+        return z.NEVER;
+      }
+      return parsed;
+    })
+    .optional(),
+});
+
+interface TurnReceiptRow {
+  id: string;
+  turn_id: string;
+  session_scope: string | null;
+  channel: string | null;
+  model: string | null;
+  receipt: unknown;
+  created_at: Date;
+  /** pg's own text rendering of created_at — microsecond-exact, used only
+   *  to build the outgoing cursor. */
+  created_at_cursor: string;
+}
+
+function toApiShape(row: TurnReceiptRow): Record<string, unknown> {
+  return {
+    turnId: row.turn_id,
+    sessionScope: row.session_scope ?? undefined,
+    channel: row.channel ?? undefined,
+    model: row.model ?? undefined,
+    receipt: row.receipt,
+    createdAt: row.created_at.toISOString(),
+  };
+}
+
+const SELECT_COLUMNS = `id, turn_id, session_scope, channel, model, receipt,
+       created_at, created_at::text AS created_at_cursor`;
+
+export function createReceiptRoutes(pool: Pool): Router {
+  const router = Router();
+
+  router.get('/', async (req: Request, res: Response) => {
+    const parsed = listQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'invalid_query', detail: parsed.error.issues });
+      return;
+    }
+    const { scope, from, to, limit, cursor } = parsed.data;
+    const where: string[] = [];
+    const params: unknown[] = [];
+    const add = (clause: string, value: unknown): void => {
+      params.push(value);
+      where.push(clause.replace('?', `$${params.length}`));
+    };
+    if (scope) add('session_scope = ?', scope);
+    if (from) add('created_at >= ?', from);
+    if (to) add('created_at <= ?', to);
+    if (cursor) {
+      // Composite keyset: strictly after the boundary row in (created_at
+      // DESC, id DESC) order — ascending row comparison inverts to `<`.
+      params.push(cursor.ts, cursor.id);
+      where.push(
+        `(created_at, id) < ($${params.length - 1}::timestamptz, $${params.length}::uuid)`,
+      );
+    }
+    params.push(limit);
+    const sql = `SELECT ${SELECT_COLUMNS}
+                   FROM turn_receipts
+                  ${where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''}
+                  ORDER BY created_at DESC, id DESC
+                  LIMIT $${params.length}`;
+    try {
+      const result = await pool.query<TurnReceiptRow>(sql, params);
+      const items = result.rows.map(toApiShape);
+      // Next-page cursor only when the page was full — a short page is the end.
+      const lastRow = result.rows[result.rows.length - 1];
+      const nextCursor =
+        result.rows.length === limit && lastRow
+          ? `${lastRow.created_at_cursor}|${lastRow.id}`
+          : undefined;
+      res.json({ items, ...(nextCursor ? { nextCursor } : {}) });
+    } catch (err) {
+      console.error('[receipts] list query failed:', err);
+      res.status(500).json({ error: 'receipts_query_failed' });
+    }
+  });
+
+  router.get('/:turnId', async (req: Request, res: Response) => {
+    const turnId = String(req.params.turnId ?? '');
+    if (turnId.length === 0 || turnId.length > 512) {
+      res.status(400).json({ error: 'invalid_turn_id' });
+      return;
+    }
+    try {
+      const result = await pool.query<TurnReceiptRow>(
+        `SELECT ${SELECT_COLUMNS}
+           FROM turn_receipts WHERE turn_id = $1`,
+        [turnId],
+      );
+      const row = result.rows[0];
+      if (!row) {
+        res.status(404).json({ error: 'receipt_not_found' });
+        return;
+      }
+      res.json(toApiShape(row));
+    } catch (err) {
+      console.error('[receipts] get query failed:', err);
+      res.status(500).json({ error: 'receipts_query_failed' });
+    }
+  });
+
+  return router;
+}

--- a/middleware/src/receipts/store.ts
+++ b/middleware/src/receipts/store.ts
@@ -1,0 +1,112 @@
+/**
+ * #757 — Postgres-backed persistent per-turn receipt store.
+ *
+ * Backs the `turnReceiptStore` service the orchestrator resolves late-bound
+ * at turn end (see `plugin-api/src/turnReceiptStore.ts` for the contract and
+ * why this is deliberately NOT the RunTrace). Postgres-only, like the
+ * Conductor: on the in-memory backend the service is simply never provided
+ * and receipts stay ephemeral.
+ *
+ * Failure posture: `record()` throws to its caller; the orchestrator counts
+ * and logs the failure but never fails the turn over it — the user's answer
+ * outranks the audit row, and the loss is observable (`persistFailures`),
+ * never silent. That is the exact inversion of the RunTrace defect (#684):
+ * there the drop was invisible; here it is counted.
+ */
+
+import type { Pool } from 'pg';
+import type {
+  TurnReceiptRecordInput,
+  TurnReceiptStore,
+} from '@omadia/plugin-api';
+
+/** Process-wide failure counters, exported for /health-style introspection
+ *  and asserted in tests. Mirrors `runTraceObservability.ts`'s "count what
+ *  would otherwise be silently incomplete" obligation. */
+export interface TurnReceiptObservability {
+  persisted: number;
+  persistFailures: number;
+}
+
+const counters: TurnReceiptObservability = { persisted: 0, persistFailures: 0 };
+
+export function turnReceiptCounters(): Readonly<TurnReceiptObservability> {
+  return counters;
+}
+
+/** Test seam only. */
+export function resetTurnReceiptCounters(): void {
+  counters.persisted = 0;
+  counters.persistFailures = 0;
+}
+
+export class PgTurnReceiptStore implements TurnReceiptStore {
+  constructor(private readonly pool: Pool) {}
+
+  async record(entry: TurnReceiptRecordInput): Promise<void> {
+    try {
+      // Idempotent on turn_id: a replayed `done` event (retry, double flush)
+      // must not duplicate the row; first write wins.
+      const result = await this.pool.query(
+        `INSERT INTO turn_receipts (turn_id, session_scope, channel, model, receipt)
+         VALUES ($1, $2, $3, $4, $5::jsonb)
+         ON CONFLICT (turn_id) DO NOTHING`,
+        [
+          entry.turnId,
+          entry.sessionScope ?? null,
+          entry.channel ?? null,
+          entry.model ?? null,
+          JSON.stringify(entry.receipt),
+        ],
+      );
+      // A replayed turn hits DO NOTHING (rowCount 0) — that is not a
+      // persist, and the counter must not overstate the record.
+      if ((result.rowCount ?? 0) > 0) {
+        counters.persisted += 1;
+      }
+    } catch (err) {
+      counters.persistFailures += 1;
+      throw err;
+    }
+  }
+}
+
+/**
+ * Retention reaper: deletes receipt rows older than `retentionDays`. Runs on
+ * an unref'd interval so it never keeps the process alive; each tick is
+ * best-effort and logged on failure. The `created_at` anchor is the DB's own
+ * clock (`NOW()`), never the process clock — the reaper-clock-race lesson
+ * from #709: the anchor must not be a value the test (or a lagging process)
+ * also controls.
+ */
+export function startTurnReceiptReaper(
+  pool: Pool,
+  opts: { retentionDays: number; intervalMs?: number },
+): { stop: () => void } {
+  const intervalMs = opts.intervalMs ?? 6 * 60 * 60 * 1000; // 6h
+  const tick = async (): Promise<void> => {
+    try {
+      const result = await pool.query(
+        `DELETE FROM turn_receipts
+          WHERE created_at < NOW() - make_interval(days => $1)`,
+        [opts.retentionDays],
+      );
+      if ((result.rowCount ?? 0) > 0) {
+        console.log(
+          `[receipts] reaper removed ${result.rowCount} receipt(s) past ${opts.retentionDays}d retention`,
+        );
+      }
+    } catch (err) {
+      console.error('[receipts] retention reaper tick failed:', err);
+    }
+  };
+  const timer = setInterval(() => void tick(), intervalMs);
+  timer.unref();
+  // Eager first pass: plugin activation (which applies the numbered
+  // migrations, incl. `0039_turn_receipts`) runs well before this wiring in
+  // `index.ts`, so the table exists here — and without the boot tick a
+  // process restarting more often than the interval would never enforce
+  // retention at all.
+  void tick();
+  return { stop: () => clearInterval(timer) };
+}

--- a/middleware/test/orchestrator/turnReceiptPersistence.test.ts
+++ b/middleware/test/orchestrator/turnReceiptPersistence.test.ts
@@ -1,0 +1,154 @@
+/**
+ * #757 — orchestrator-side wiring: a receipt that reaches the user also
+ * reaches the persistent store, and a failing store never fails the turn.
+ *
+ * Setup mirrors `promptMaskPipeline.test.ts`: the REAL privacy-guard service
+ * with `mask_user_prompt` forced on produces a real receipt (masked email
+ * span) on a real `runTurn`; the store is a fake capturing `record()` calls.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type {
+  LlmProvider,
+  LlmRequest,
+  LlmResponse,
+  LlmStreamEvent,
+} from '@omadia/llm-provider';
+import { NativeToolRegistry, Orchestrator } from '@omadia/orchestrator';
+import type { TurnReceiptRecordInput } from '@omadia/plugin-api';
+import { createPrivacyGuardService } from '@omadia/plugin-privacy-guard/dist/index.js';
+
+const providerCapabilities = {
+  tools: true,
+  vision: true,
+  streaming: true,
+  promptCaching: true,
+  forcedToolChoice: true,
+  parallelToolCalls: true,
+} as const;
+
+const RAW_EMAIL = 'anna.schmidt@firma.de';
+
+function maskingService(): ReturnType<typeof createPrivacyGuardService> {
+  return createPrivacyGuardService({
+    readConfig: (key: string) => (key === 'mask_user_prompt' ? 'on' : undefined),
+  });
+}
+
+function textResponse(text: string): LlmResponse {
+  return {
+    content: [{ type: 'text', text }],
+    finishReason: 'stop',
+    providerFinishReason: 'end_turn',
+    model: 'test',
+    usage: { inputTokens: 10, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0 },
+  };
+}
+
+function staticProvider(): LlmProvider {
+  const provider = {
+    id: 'anthropic',
+    capabilities: providerCapabilities,
+    complete: async (_req: LlmRequest): Promise<LlmResponse> =>
+      textResponse('Alles klar.'),
+    stream: (): AsyncIterable<LlmStreamEvent> => {
+      throw new Error('staticProvider: stream() not scripted');
+    },
+    classifyError: () => ({ retryable: false, kind: 'other' as const }),
+  };
+  return provider as unknown as LlmProvider;
+}
+
+type OrchestratorOptions = ConstructorParameters<typeof Orchestrator>[0];
+
+const sessionLogger = {
+  log: async (): Promise<{ turnExternalId: string }> => ({
+    turnExternalId: 'turn:sess-1:t1',
+  }),
+} as unknown as OrchestratorOptions['sessionLogger'];
+
+function buildOrch(store: {
+  record: (entry: TurnReceiptRecordInput) => Promise<void>;
+}): Orchestrator {
+  return new Orchestrator({
+    provider: staticProvider(),
+    model: 'test-model',
+    maxTokens: 1024,
+    maxToolIterations: 3,
+    domainTools: [],
+    nativeToolRegistry: new NativeToolRegistry(),
+    sessionLogger,
+    privacyGuard: () => maskingService(),
+    turnReceiptStore: () => store,
+  });
+}
+
+describe('#757 turn-receipt persistence — orchestrator wiring', () => {
+  it('persists the receipt the turn attaches, with routing metadata', async () => {
+    const recorded: TurnReceiptRecordInput[] = [];
+    const orch = buildOrch({
+      record: async (entry) => {
+        recorded.push(entry);
+      },
+    });
+    const result = await orch.runTurn({
+      userMessage: `Bitte schreibe an ${RAW_EMAIL}.`,
+      sessionScope: 'sess-1',
+      userId: 'u1',
+      channelIdentity: { channelKind: 'teams', channelUserId: 'aad-1' },
+    });
+    assert.ok(result.privacyReceipt, 'turn must attach a receipt');
+    assert.equal(recorded.length, 1, 'exactly one persisted receipt per turn');
+    const entry = recorded[0]!;
+    assert.ok(entry.turnId.length > 0, 'a non-empty turn id must be recorded');
+    assert.equal(entry.sessionScope, 'sess-1');
+    assert.equal(entry.channel, 'teams');
+    assert.equal(entry.model, 'test-model');
+    // The persisted receipt is the SAME object the user saw — no divergence
+    // between UI truth and record truth.
+    assert.deepEqual(entry.receipt, result.privacyReceipt);
+    const spans = entry.receipt.maskedPromptSpans ?? [];
+    assert.ok(
+      spans.some((s) => s.type === 'email'),
+      'persisted receipt must carry the masked email span',
+    );
+  });
+
+  it('a throwing store is loud but never fails the turn', async () => {
+    const orch = buildOrch({
+      record: async () => {
+        throw new Error('pg down');
+      },
+    });
+    const result = await orch.runTurn({
+      userMessage: `Bitte schreibe an ${RAW_EMAIL}.`,
+      sessionScope: 'sess-1',
+      userId: 'u1',
+    });
+    // The user's answer outranks the audit row.
+    assert.ok(result.answer.length > 0);
+    assert.ok(result.privacyReceipt, 'receipt still reaches the user');
+  });
+
+  it('no store wired ⇒ byte-identical pre-#757 behaviour', async () => {
+    const orch = new Orchestrator({
+      provider: staticProvider(),
+      model: 'test-model',
+      maxTokens: 1024,
+      maxToolIterations: 3,
+      domainTools: [],
+      nativeToolRegistry: new NativeToolRegistry(),
+      sessionLogger,
+      privacyGuard: () => maskingService(),
+      // deliberately: no turnReceiptStore option
+    });
+    const result = await orch.runTurn({
+      userMessage: `Bitte schreibe an ${RAW_EMAIL}.`,
+      sessionScope: 'sess-1',
+      userId: 'u1',
+    });
+    assert.ok(result.privacyReceipt);
+  });
+});

--- a/middleware/test/turnReceipts.test.ts
+++ b/middleware/test/turnReceipts.test.ts
@@ -1,0 +1,250 @@
+/**
+ * #757 — persistent per-turn receipts: kernel store, retention reaper, and
+ * operator read API. The orchestrator-side wiring (receipt reaches the store
+ * on a real turn) lives in `test/orchestrator/turnReceiptPersistence.test.ts`;
+ * here the units are exercised against a fake pg pool.
+ */
+
+import { strict as assert } from 'node:assert';
+import { after, describe, it } from 'node:test';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import express from 'express';
+import type { Pool } from 'pg';
+
+import {
+  PgTurnReceiptStore,
+  resetTurnReceiptCounters,
+  startTurnReceiptReaper,
+  turnReceiptCounters,
+} from '../src/receipts/store.js';
+import { createReceiptRoutes } from '../src/receipts/routes.js';
+
+interface RecordedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+/** Minimal fake pg pool: records queries, answers from a script. */
+function fakePool(
+  handler: (sql: string, params: unknown[]) => { rows?: unknown[]; rowCount?: number } | Error,
+): { pool: Pool; queries: RecordedQuery[] } {
+  const queries: RecordedQuery[] = [];
+  const pool = {
+    query: async (sql: string, params: unknown[] = []) => {
+      queries.push({ sql, params });
+      const result = handler(sql, params);
+      if (result instanceof Error) throw result;
+      return { rows: result.rows ?? [], rowCount: result.rowCount ?? (result.rows?.length ?? 0) };
+    },
+  } as unknown as Pool;
+  return { pool, queries };
+}
+
+const RECEIPT = {
+  datasetsInterned: 2,
+  fieldsMasked: 7,
+  fieldsCleartext: 3,
+  verbsExecuted: ['v4_sort'],
+  pseudonymProjectionUsed: false,
+};
+
+describe('#757 PgTurnReceiptStore', () => {
+  it('inserts one idempotent row per turn and counts the persist', async () => {
+    resetTurnReceiptCounters();
+    const { pool, queries } = fakePool(() => ({ rowCount: 1 }));
+    const store = new PgTurnReceiptStore(pool);
+    await store.record({
+      turnId: 't-1',
+      sessionScope: 'sess-1',
+      channel: 'teams',
+      model: 'claude-test',
+      receipt: RECEIPT,
+    });
+    assert.equal(queries.length, 1);
+    const q = queries[0]!;
+    assert.match(q.sql, /INSERT INTO turn_receipts/);
+    // Idempotence is the SQL's job: a replayed done event must hit the
+    // turn_id conflict target, not add a second row.
+    assert.match(q.sql, /ON CONFLICT \(turn_id\) DO NOTHING/);
+    assert.deepEqual(q.params.slice(0, 4), ['t-1', 'sess-1', 'teams', 'claude-test']);
+    assert.deepEqual(JSON.parse(q.params[4] as string), RECEIPT);
+    assert.equal(turnReceiptCounters().persisted, 1);
+    assert.equal(turnReceiptCounters().persistFailures, 0);
+  });
+
+  it('counts a storage failure and rethrows (caller decides turn fate)', async () => {
+    resetTurnReceiptCounters();
+    const { pool } = fakePool(() => new Error('pg down'));
+    const store = new PgTurnReceiptStore(pool);
+    await assert.rejects(
+      store.record({ turnId: 't-2', receipt: RECEIPT }),
+      /pg down/,
+    );
+    assert.equal(turnReceiptCounters().persistFailures, 1);
+    assert.equal(turnReceiptCounters().persisted, 0);
+  });
+
+  it('stores absent metadata as NULL, not as the string "undefined"', async () => {
+    resetTurnReceiptCounters();
+    const { pool, queries } = fakePool(() => ({ rowCount: 1 }));
+    await new PgTurnReceiptStore(pool).record({ turnId: 't-3', receipt: RECEIPT });
+    assert.deepEqual(queries[0]!.params.slice(0, 4), ['t-3', null, null, null]);
+  });
+
+  it('a replayed turn (ON CONFLICT no-op) does not inflate the persisted counter', async () => {
+    resetTurnReceiptCounters();
+    const { pool } = fakePool(() => ({ rowCount: 0 }));
+    await new PgTurnReceiptStore(pool).record({ turnId: 't-4', receipt: RECEIPT });
+    assert.equal(turnReceiptCounters().persisted, 0);
+    assert.equal(turnReceiptCounters().persistFailures, 0);
+  });
+});
+
+describe('#757 retention reaper', () => {
+  it('deletes past-retention rows eagerly at start, anchored on the DB clock', async () => {
+    const { pool, queries } = fakePool(() => ({ rowCount: 2 }));
+    const reaper = startTurnReceiptReaper(pool, { retentionDays: 30, intervalMs: 60_000 });
+    try {
+      // Eager boot tick: a process restarting more often than the interval
+      // must still enforce retention — so the first pass fires immediately,
+      // without waiting for the (long) interval.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      assert.ok(queries.length >= 1, 'reaper must have ticked at least once');
+      const q = queries[0]!;
+      assert.match(q.sql, /DELETE FROM turn_receipts/);
+      // The cutoff must be computed from NOW() in the database — never a
+      // process-clock timestamp parameter (#709: anchor ≠ what a lagging
+      // process controls).
+      assert.match(q.sql, /NOW\(\) - make_interval/);
+      assert.deepEqual(q.params, [30]);
+    } finally {
+      reaper.stop();
+    }
+  });
+
+  it('a failing tick logs but never throws out of the timer', async () => {
+    const { pool, queries } = fakePool(() => new Error('relation missing'));
+    const reaper = startTurnReceiptReaper(pool, { retentionDays: 30, intervalMs: 5 });
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      assert.ok(queries.length >= 1);
+      // Reaching this line without an unhandled rejection IS the assertion.
+    } finally {
+      reaper.stop();
+    }
+  });
+});
+
+describe('#757 operator receipts API', () => {
+  const servers: Server[] = [];
+  after(async () => {
+    await Promise.all(
+      servers.map((s) => new Promise<void>((resolve) => s.close(() => resolve()))),
+    );
+  });
+
+  const ROW_ID = '0f5c1c3a-1111-4222-8333-444455556666';
+  const ROW = {
+    id: ROW_ID,
+    turn_id: 't-1',
+    session_scope: 'sess-1',
+    channel: 'teams',
+    model: 'claude-test',
+    receipt: RECEIPT,
+    created_at: new Date('2026-08-20T10:00:00.123Z'),
+    // pg's own text rendering — microsecond-exact, beyond JS Date precision.
+    created_at_cursor: '2026-08-20 10:00:00.123456+00',
+  };
+
+  async function serve(
+    handler: Parameters<typeof fakePool>[0],
+  ): Promise<{ baseUrl: string; queries: RecordedQuery[] }> {
+    const { pool, queries } = fakePool(handler);
+    const app = express();
+    app.use('/api/v1/operator/receipts', createReceiptRoutes(pool));
+    const server: Server = await new Promise((resolve) => {
+      const s = app.listen(0, '127.0.0.1', () => resolve(s));
+    });
+    servers.push(server);
+    const port = (server.address() as AddressInfo).port;
+    return { baseUrl: `http://127.0.0.1:${String(port)}/api/v1/operator/receipts`, queries };
+  }
+
+  it('lists receipts newest-first with camelCase mapping and no cursor on a short page', async () => {
+    const { baseUrl } = await serve(() => ({ rows: [ROW] }));
+    const res = await fetch(`${baseUrl}?limit=25`);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { items: Array<Record<string, unknown>>; nextCursor?: string };
+    assert.equal(body.items.length, 1);
+    assert.equal(body.items[0]!.turnId, 't-1');
+    assert.equal(body.items[0]!.sessionScope, 'sess-1');
+    assert.equal(body.items[0]!.createdAt, '2026-08-20T10:00:00.123Z');
+    // The keyset internals never leak into the item shape.
+    assert.equal('id' in body.items[0]!, false);
+    assert.equal('created_at_cursor' in body.items[0]!, false);
+    assert.deepEqual(body.items[0]!.receipt, RECEIPT);
+    assert.equal(body.nextCursor, undefined);
+  });
+
+  it('emits a composite keyset nextCursor exactly when the page is full', async () => {
+    const { baseUrl } = await serve(() => ({ rows: [ROW] }));
+    const res = await fetch(`${baseUrl}?limit=1`);
+    const body = (await res.json()) as { nextCursor?: string };
+    // pg's microsecond-exact text stamp + row id — a bare ISO(ms) cursor
+    // would lose exact-tie and truncation-gap rows at page boundaries.
+    assert.equal(body.nextCursor, `2026-08-20 10:00:00.123456+00|${ROW_ID}`);
+  });
+
+  it('threads scope + composite cursor filters into the query parameters', async () => {
+    const { baseUrl, queries } = await serve(() => ({ rows: [] }));
+    const cursor = encodeURIComponent(`2026-08-20 10:00:00.123456+00|${ROW_ID}`);
+    const res = await fetch(`${baseUrl}?scope=sess-1&cursor=${cursor}&limit=10`);
+    assert.equal(res.status, 200);
+    const q = queries[0]!;
+    assert.ok(q.params.includes('sess-1'));
+    assert.ok(q.params.includes('2026-08-20 10:00:00.123456+00'));
+    assert.ok(q.params.includes(ROW_ID));
+    assert.equal(q.params[q.params.length - 1], 10);
+    assert.match(q.sql, /session_scope = \$1/);
+    assert.match(q.sql, /\(created_at, id\) < \(\$2::timestamptz, \$3::uuid\)/);
+    assert.match(q.sql, /ORDER BY created_at DESC, id DESC/);
+  });
+
+  it('rejects a malformed cursor with 400 before the pool is touched', async () => {
+    const { baseUrl, queries } = await serve(() => ({ rows: [] }));
+    for (const bad of ['not-a-cursor', '2026-08-20 10:00:00+00|not-a-uuid', `|${ROW_ID}`]) {
+      const res = await fetch(`${baseUrl}?cursor=${encodeURIComponent(bad)}`);
+      assert.equal(res.status, 400, `cursor ${JSON.stringify(bad)} must 400`);
+    }
+    assert.equal(queries.length, 0);
+  });
+
+  it('rejects an invalid limit with 400 instead of clamping silently', async () => {
+    const { baseUrl, queries } = await serve(() => ({ rows: [] }));
+    const res = await fetch(`${baseUrl}?limit=5000`);
+    assert.equal(res.status, 400);
+    assert.equal(queries.length, 0, 'invalid input must never reach the pool');
+  });
+
+  it('serves a single receipt by turn id and 404s an unknown one', async () => {
+    const { baseUrl } = await serve((_sql, params) =>
+      params[0] === 't-1' ? { rows: [ROW] } : { rows: [] },
+    );
+    const hit = await fetch(`${baseUrl}/t-1`);
+    assert.equal(hit.status, 200);
+    assert.equal(((await hit.json()) as { turnId: string }).turnId, 't-1');
+    const miss = await fetch(`${baseUrl}/t-unknown`);
+    assert.equal(miss.status, 404);
+  });
+
+  it('maps a pool failure to 500 without leaking the error', async () => {
+    const { baseUrl } = await serve(() => new Error('secret dsn in message'));
+    const res = await fetch(`${baseUrl}`);
+    assert.equal(res.status, 500);
+    const body = (await res.json()) as { error: string };
+    assert.equal(body.error, 'receipts_query_failed');
+    assert.ok(!JSON.stringify(body).includes('secret dsn'));
+  });
+});

--- a/web-ui/app/_components/Nav.tsx
+++ b/web-ui/app/_components/Nav.tsx
@@ -73,6 +73,8 @@ const NAV: readonly NavItem[] = [
       // operator-facing configuration surfaces, same audience as Admin/System.
       { kind: 'link', href: '/operator/agents', key: 'agentsCluster' },
       { kind: 'link', href: '/conductor', key: 'conductor' },
+      // #757 — persisted per-turn privacy receipts, same operator audience.
+      { kind: 'link', href: '/operator/receipts', key: 'receipts' },
       // Dev Platform used to be hardcoded here. It is now contributed at
       // runtime (middleware registers it while DEV_PLATFORM_ENABLED), so the
       // entry disappears when the feature is off — see mergeNav below.

--- a/web-ui/app/_lib/receipts.ts
+++ b/web-ui/app/_lib/receipts.ts
@@ -1,0 +1,66 @@
+import { ApiError } from './api';
+import type { PrivacyReceipt } from './chatSessions';
+
+/**
+ * #757 — typed client for the operator receipts REST surface
+ * (`/api/v1/operator/receipts`). Mirrors the `channels.ts` pattern: works
+ * from both server components (MIDDLEWARE_URL + forwarded cookies) and the
+ * browser (`/bot-api` catch-all route).
+ */
+
+function botApi(path: string): string {
+  if (typeof window !== 'undefined') {
+    return `/bot-api${path}`;
+  }
+  const base = process.env['MIDDLEWARE_URL'] ?? 'http://localhost:3979';
+  return `${base}/api${path}`;
+}
+
+async function forwardCookieHeader(): Promise<Record<string, string>> {
+  if (typeof window !== 'undefined') return {};
+  try {
+    const mod = await import('next/headers');
+    const jar = await mod.cookies();
+    const cookieHeader = jar
+      .getAll()
+      .map((c) => `${c.name}=${c.value}`)
+      .join('; ');
+    return cookieHeader ? { cookie: cookieHeader } : {};
+  } catch {
+    return {};
+  }
+}
+
+export interface TurnReceiptDto {
+  turnId: string;
+  sessionScope?: string;
+  channel?: string;
+  model?: string;
+  receipt: PrivacyReceipt;
+  createdAt: string;
+}
+
+export interface ReceiptsPageDto {
+  items: TurnReceiptDto[];
+  nextCursor?: string;
+}
+
+export async function listReceipts(opts?: {
+  scope?: string;
+  cursor?: string;
+  limit?: number;
+}): Promise<ReceiptsPageDto> {
+  const params = new URLSearchParams();
+  if (opts?.scope) params.set('scope', opts.scope);
+  if (opts?.cursor) params.set('cursor', opts.cursor);
+  if (opts?.limit) params.set('limit', String(opts.limit));
+  const qs = params.size > 0 ? `?${params.toString()}` : '';
+  const res = await fetch(botApi(`/v1/operator/receipts${qs}`), {
+    headers: { ...(await forwardCookieHeader()) },
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    throw new ApiError(res.status, `receipts list failed: ${String(res.status)}`);
+  }
+  return (await res.json()) as ReceiptsPageDto;
+}

--- a/web-ui/app/operator/receipts/_components/ReceiptsList.tsx
+++ b/web-ui/app/operator/receipts/_components/ReceiptsList.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useFormatter, useTranslations } from 'next-intl';
 
 import { PrivacyReceiptCard } from '../../../_components/chat/PrivacyReceiptCard';
+import { Button } from '../../../_components/ui/Button';
 import {
   listReceipts,
   type ReceiptsPageDto,
@@ -106,14 +107,16 @@ export function ReceiptsList({ initial }: ReceiptsListProps): React.ReactElement
         <p className="text-sm text-[color:var(--danger)]">{loadError}</p>
       ) : null}
       {nextCursor ? (
-        <button
+        <Button
           type="button"
+          variant="secondary"
           onClick={() => void loadMore()}
           disabled={loading}
-          className="rounded border border-[color:var(--edge)] px-4 py-2 text-sm hover:bg-[color:var(--bg-subtle)] disabled:opacity-50"
+          busy={loading}
+          busyLabel={t('loadingMore')}
         >
-          {loading ? t('loadingMore') : t('loadMore')}
-        </button>
+          {t('loadMore')}
+        </Button>
       ) : null}
     </div>
   );

--- a/web-ui/app/operator/receipts/_components/ReceiptsList.tsx
+++ b/web-ui/app/operator/receipts/_components/ReceiptsList.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useState } from 'react';
+import { useFormatter, useTranslations } from 'next-intl';
+
+import { PrivacyReceiptCard } from '../../../_components/chat/PrivacyReceiptCard';
+import {
+  listReceipts,
+  type ReceiptsPageDto,
+  type TurnReceiptDto,
+} from '../../../_lib/receipts';
+
+interface ReceiptsListProps {
+  initial: ReceiptsPageDto;
+}
+
+/**
+ * #757 — expandable per-turn receipt rows with cursor pagination. Each row
+ * shows routing metadata (when, scope, channel, model) plus the shield's
+ * headline counts; expanding renders the exact `PrivacyReceiptCard` the
+ * user saw in the chat — the record and the UI share one truth.
+ */
+export function ReceiptsList({ initial }: ReceiptsListProps): React.ReactElement {
+  const t = useTranslations('operatorReceipts');
+  const format = useFormatter();
+  const [items, setItems] = useState<TurnReceiptDto[]>(initial.items);
+  const [nextCursor, setNextCursor] = useState<string | undefined>(initial.nextCursor);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  async function loadMore(): Promise<void> {
+    if (!nextCursor || loading) return;
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const page = await listReceipts({ cursor: nextCursor, limit: 25 });
+      setItems((prev) => [...prev, ...page.items]);
+      setNextCursor(page.nextCursor);
+    } catch {
+      setLoadError(t('loadError'));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (items.length === 0) {
+    return (
+      <p className="rounded border border-[color:var(--edge)] p-6 text-sm text-[color:var(--fg-muted)]">
+        {t('empty')}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <ul className="space-y-3">
+        {items.map((item) => (
+          <li
+            key={item.turnId}
+            className="rounded border border-[color:var(--edge)] p-4"
+          >
+            <details>
+              <summary className="flex cursor-pointer flex-wrap items-baseline gap-x-4 gap-y-1 text-sm">
+                <time
+                  dateTime={item.createdAt}
+                  className="font-medium tabular-nums"
+                >
+                  {format.dateTime(new Date(item.createdAt), {
+                    dateStyle: 'medium',
+                    timeStyle: 'short',
+                  })}
+                </time>
+                {item.sessionScope ? (
+                  <span className="text-[color:var(--fg-muted)]">
+                    {t('scopeLabel')}: {item.sessionScope}
+                  </span>
+                ) : null}
+                {item.channel ? (
+                  <span className="text-[color:var(--fg-muted)]">
+                    {t('channelLabel')}: {item.channel}
+                  </span>
+                ) : null}
+                {item.model ? (
+                  <span className="text-[color:var(--fg-muted)]">
+                    {t('modelLabel')}: {item.model}
+                  </span>
+                ) : null}
+                <span className="text-[color:var(--fg-muted)]">
+                  {t('summaryCounts', {
+                    masked: item.receipt.fieldsMasked,
+                    datasets: item.receipt.datasetsInterned,
+                  })}
+                </span>
+              </summary>
+              <div className="mt-3">
+                <PrivacyReceiptCard receipt={item.receipt} />
+                <p className="mt-2 break-all text-xs text-[color:var(--fg-muted)]">
+                  {t('turnIdLabel')}: {item.turnId}
+                </p>
+              </div>
+            </details>
+          </li>
+        ))}
+      </ul>
+      {loadError ? (
+        <p className="text-sm text-[color:var(--danger)]">{loadError}</p>
+      ) : null}
+      {nextCursor ? (
+        <button
+          type="button"
+          onClick={() => void loadMore()}
+          disabled={loading}
+          className="rounded border border-[color:var(--edge)] px-4 py-2 text-sm hover:bg-[color:var(--bg-subtle)] disabled:opacity-50"
+        >
+          {loading ? t('loadingMore') : t('loadMore')}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/web-ui/app/operator/receipts/page.tsx
+++ b/web-ui/app/operator/receipts/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+
+import { redirectIfUnauthorized } from '../../_lib/authRedirect';
+import { listReceipts, type ReceiptsPageDto } from '../../_lib/receipts';
+import { ReceiptsList } from './_components/ReceiptsList';
+
+/**
+ * #757 — operator-facing list of persisted per-turn privacy receipts.
+ *
+ * Every completed turn writes its PII-free receipt to the middleware's
+ * `turn_receipts` store; this page is the read surface: what did the shield
+ * intern, mask, and (where the operator opted into bypass) pass through —
+ * per turn, after the fact, not only while the answer was on screen.
+ */
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('operatorReceipts');
+  return { title: t('metaTitle') };
+}
+
+export const dynamic = 'force-dynamic';
+
+export default async function OperatorReceiptsPage(): Promise<React.ReactElement> {
+  const t = await getTranslations('operatorReceipts');
+  let initial: ReceiptsPageDto | null = null;
+  let loadError: string | null = null;
+  try {
+    initial = await listReceipts({ limit: 25 });
+  } catch (err) {
+    await redirectIfUnauthorized(err);
+    // Catalog key first (checklist rule 3) — the raw error is a technical
+    // detail that belongs in the server log, not as the page's primary text.
+    console.error('[operator/receipts] initial load failed:', err);
+    loadError = t('loadError');
+  }
+
+  return (
+    <main className="mx-auto w-full max-w-[1100px] px-6 py-12 lg:px-8 lg:py-16">
+      <header className="mb-8">
+        <h1 className="text-3xl font-semibold tracking-tight">{t('title')}</h1>
+        <p className="mt-2 max-w-2xl text-sm text-[color:var(--fg-muted)]">
+          {t('subtitle')}
+        </p>
+      </header>
+      {loadError ? (
+        <div className="rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-4 text-sm text-[color:var(--danger)]">
+          {loadError}
+        </div>
+      ) : (
+        <ReceiptsList initial={initial!} />
+      )}
+    </main>
+  );
+}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -428,6 +428,7 @@
     "graph": "Graph",
     "routines": "Routinen",
     "conductor": "Conductor",
+    "receipts": "Receipts",
     "admin": "Admin",
     "system": "System",
     "agentsCluster": "Orchestratoren",
@@ -706,6 +707,20 @@
     "templateRejecting": "Wird abgelehnt",
     "templatePendingEmpty": "Keine Vorlagen warten auf Review",
     "templateNoMatches": "Keine Vorlagen entsprechen deinen Filtern."
+  },
+  "operatorReceipts": {
+    "metaTitle": "Receipts · omadia",
+    "title": "Privacy-Receipts",
+    "subtitle": "Jeder abgeschlossene Turn schreibt seinen PII-freien Privacy-Receipt hierher — was der Shield interniert, maskiert und durchgereicht hat. Der Beleg überlebt die Chat-Ansicht; die Aufbewahrung begrenzt RECEIPT_RETENTION_DAYS der Middleware.",
+    "loadError": "Receipts konnten nicht geladen werden",
+    "empty": "Noch keine Receipts vorhanden. Sobald ein Turn mit Privacy-Shield-Aktivität abschließt, erscheint er hier.",
+    "scopeLabel": "Scope",
+    "channelLabel": "Channel",
+    "modelLabel": "Modell",
+    "turnIdLabel": "Turn",
+    "summaryCounts": "{masked} maskiert · {datasets} Datasets",
+    "loadMore": "Mehr laden",
+    "loadingMore": "Lädt…"
   },
   "operatorChannels": {
     "metaTitle": "Channels · omadia",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -428,6 +428,7 @@
     "graph": "Graph",
     "routines": "Routines",
     "conductor": "Conductor",
+    "receipts": "Receipts",
     "admin": "Admin",
     "system": "System",
     "agentsCluster": "Orchestrators",
@@ -706,6 +707,20 @@
     "templateRejecting": "Rejecting",
     "templatePendingEmpty": "No templates waiting for review",
     "templateNoMatches": "No templates match your filters."
+  },
+  "operatorReceipts": {
+    "metaTitle": "Receipts · omadia",
+    "title": "Privacy receipts",
+    "subtitle": "Every completed turn writes its PII-free privacy receipt here — what the shield interned, masked, and passed through. The record survives the chat view; retention is bounded by the middleware's RECEIPT_RETENTION_DAYS.",
+    "loadError": "Failed to load receipts",
+    "empty": "No receipts recorded yet. Receipts appear here as soon as a turn with privacy-shield activity completes.",
+    "scopeLabel": "Scope",
+    "channelLabel": "Channel",
+    "modelLabel": "Model",
+    "turnIdLabel": "Turn",
+    "summaryCounts": "{masked} masked · {datasets} datasets",
+    "loadMore": "Load more",
+    "loadingMore": "Loading…"
   },
   "operatorChannels": {
     "metaTitle": "Channels · omadia",


### PR DESCRIPTION
Closes #757.

## What

Every completed turn now persists its PII-free `PrivacyReceipt` into a new kernel-owned `turn_receipts` table — guaranteed per turn, not best-effort — with an auth-gated operator read API and a web-ui receipts page. Until now the receipt existed only while the answer was on screen; nothing could answer "what did the shield disclose or mask for turn X last Tuesday?" (`RunTrace` is explicitly telemetry, per #684).

## How

- **Contract** (`plugin-api/src/turnReceiptStore.ts`): `TurnReceiptStore.record()` + `TURN_RECEIPT_STORE_SERVICE_NAME`, resolved late-bound by the orchestrator exactly like `privacyRedact` — absent service ⇒ byte-identical pre-#757 behaviour (in-memory backend, tests).
- **Migration `0039_turn_receipts.sql`**: `turn_id` unique (idempotent on replayed `done` events), scope/channel/model metadata, `receipt` JSONB. `0038` stays reserved for the Satellites epic (#746).
- **Orchestrator**: one `persistTurnReceipt` helper, called at all three receipt sites (non-streaming, direct-line, streaming done). A throwing store is logged greppably and counted (`persistFailures`) but never fails the turn — the user's answer outranks the audit row; the loss is observable, never silent (the exact inversion of the RunTrace defect).
- **Kernel wiring** (`src/index.ts`, graphPool block): provides the service, mounts `GET /api/v1/operator/receipts` (+ `/:turnId`) behind `requireAuth`, starts an unref'd retention reaper (`RECEIPT_RETENTION_DAYS`, default 90 — turn_id+scope are personal-data linkage, so retention is bounded). The reaper anchors its cutoff on the DB clock (`NOW() - make_interval`), never the process clock (#709), and fires an eager boot tick so short-lived processes still enforce retention (plugin activation applies the migrations well before this wiring). Pagination is a composite keyset cursor `(created_at, id)` carrying pg's microsecond-exact timestamp text — a bare ISO(ms) cursor would silently lose exact-tie and truncation-gap rows at page boundaries, unacceptable on an audit surface.
- **Web-UI**: `/operator/receipts` — expandable rows rendering the exact `PrivacyReceiptCard` the user saw (record and UI share one truth), cursor pagination, en+de messages, nav entry in the admin cluster.
- **Docs**: `docs/ai-act-transparency.md` §6 now names the new record — and explicitly keeps "cryptographically verifiable" a non-claim until #758/#761 ship.

## Tests

- `test/turnReceipts.test.ts` (13): store insert shape + `ON CONFLICT` idempotence + NULL metadata + replayed-turn counter (rowCount 0 does not inflate `persisted`), failure counting, reaper eager boot tick + params + error-tick, routes (list mapping, composite keyset cursor emitted exactly on full pages, filter threading, 400 on invalid limit AND malformed cursor before the pool is touched, 404, 500 without error leakage).
- `test/orchestrator/turnReceiptPersistence.test.ts` (3): real turn pipeline with the real privacy-guard service — receipt persisted with routing metadata and `deepEqual` to the user-visible receipt; throwing store never fails the turn; no store wired ⇒ pre-#757 behaviour.
- **Mutation check**: removing the persist call at the non-streaming site turns the wiring test red (verified against rebuilt `dist/`).
- Full middleware suite and web-ui suite (88 files / 742 tests, incl. i18n parity) green; `npm run typecheck` green in both workspaces.

## Notes for review

- Streaming/direct-line sites are exercised indirectly (same helper, same contract); an e2e streaming assertion would need a scripted streaming provider — follow-up welcome.
- `#758` (hash chain, signed checkpoints, anchoring) builds directly on this table; `#761` adds the verify surface.
