### PR TITLE
fix(#470): make the C8 plugin-UI host actually work — same-origin frame, scoped ids, emitted CSS (C8b)

### DIFF
--- a/middleware/assets/plugin-ui/plugin-ui.css
+++ b/middleware/assets/plugin-ui/plugin-ui.css
@@ -75,6 +75,8 @@
     --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
     --animate-spin: spin 1s linear infinite;
     --animate-pulse: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+    --default-transition-duration: 150ms;
+    --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
     --default-mono-font-family: var(--font-mono);
   }
@@ -1072,6 +1074,19 @@
   .gap-y-8 {
     row-gap: calc(var(--spacing) * 8);
   }
+  :where(.divide-x > :not(:last-child)) {
+    --tw-divide-x-reverse: 0;
+    border-inline-style: var(--tw-border-style);
+    border-inline-start-width: calc(1px * var(--tw-divide-x-reverse));
+    border-inline-end-width: calc(1px * calc(1 - var(--tw-divide-x-reverse)));
+  }
+  :where(.divide-y > :not(:last-child)) {
+    --tw-divide-y-reverse: 0;
+    border-bottom-style: var(--tw-border-style);
+    border-top-style: var(--tw-border-style);
+    border-top-width: calc(1px * var(--tw-divide-y-reverse));
+    border-bottom-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
+  }
   .self-auto {
     align-self: auto;
   }
@@ -1127,6 +1142,22 @@
   }
   .rounded-xl {
     border-radius: var(--radius-xl);
+  }
+  .border {
+    border-style: var(--tw-border-style);
+    border-width: 1px;
+  }
+  .border-0 {
+    border-style: var(--tw-border-style);
+    border-width: 0px;
+  }
+  .border-2 {
+    border-style: var(--tw-border-style);
+    border-width: 2px;
+  }
+  .border-4 {
+    border-style: var(--tw-border-style);
+    border-width: 4px;
   }
   .border-t {
     border-top-style: var(--tw-border-style);
@@ -1738,6 +1769,34 @@
     --tw-shadow: var(--shadow-sm);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
+  .transition {
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, content-visibility, overlay, pointer-events;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .transition-all {
+    transition-property: all;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .transition-colors {
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .transition-opacity {
+    transition-property: opacity;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .transition-transform {
+    transition-property: transform, translate, scale, rotate;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .transition-none {
+    transition-property: none;
+  }
   .duration-75 {
     --tw-duration: 75ms;
     transition-duration: 75ms;
@@ -1838,6 +1897,9 @@
     }
     .hover\:bg-surface:hover {
       background-color: var(--surface);
+    }
+    .hover\:bg-transparent:hover {
+      background-color: transparent;
     }
     .hover\:bg-warning:hover {
       background-color: var(--warning);
@@ -1944,6 +2006,9 @@
   }
   .focus\:bg-surface:focus {
     background-color: var(--surface);
+  }
+  .focus\:bg-transparent:focus {
+    background-color: transparent;
   }
   .focus\:bg-warning:focus {
     background-color: var(--warning);
@@ -2822,10 +2887,20 @@ html.lume-xfade {
   inherits: false;
   initial-value: 0;
 }
+@property --tw-divide-x-reverse {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
 @property --tw-border-style {
   syntax: "*";
   inherits: false;
   initial-value: solid;
+}
+@property --tw-divide-y-reverse {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
 }
 @property --tw-leading {
   syntax: "*";
@@ -2956,7 +3031,9 @@ html.lume-xfade {
     *, ::before, ::after, ::backdrop {
       --tw-space-y-reverse: 0;
       --tw-space-x-reverse: 0;
+      --tw-divide-x-reverse: 0;
       --tw-border-style: solid;
+      --tw-divide-y-reverse: 0;
       --tw-leading: initial;
       --tw-font-weight: initial;
       --tw-tracking: initial;

--- a/middleware/src/platform/publicPathGrants.ts
+++ b/middleware/src/platform/publicPathGrants.ts
@@ -59,7 +59,10 @@ export const PLUGIN_PUBLIC_PATH_ROOT = '/api/plugins/';
  * a plugin may never *claim*, granted or not. `/api/v1/admin` is not in
  * `publicPaths()` (it is firmly behind the gate) and precisely for that reason
  * it must never become claimable: an operator clicking through a consent
- * dialog should not be able to hand a plugin the admin surface.
+ * dialog should not be able to hand a plugin the admin surface. A same-origin
+ * plugin UI riding the operator cookie can reach that surface anyway; that is
+ * the known, accepted exposure of the current iframe trust model, not a route
+ * the plugin contract may ever claim.
  */
 const CORE_RESERVED_ROOTS: readonly string[] = [
   '/api/auth',

--- a/middleware/src/routes/pluginUiStatic.ts
+++ b/middleware/src/routes/pluginUiStatic.ts
@@ -54,7 +54,7 @@ import { Router, type Request, type Response } from 'express';
  */
 
 /** Extension → Content-Type. Deliberately no `.css` — see the header. */
-const CONTENT_TYPES: ReadonlyMap<string, string> = new Map([
+export const CONTENT_TYPES: ReadonlyMap<string, string> = new Map([
   ['.html', 'text/html; charset=utf-8'],
   ['.js', 'text/javascript; charset=utf-8'],
   ['.mjs', 'text/javascript; charset=utf-8'],

--- a/middleware/test/pluginUiFrameCredentials.test.ts
+++ b/middleware/test/pluginUiFrameCredentials.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Why the plugin UI iframe is same-origin (epic #470 C8b).
+ *
+ * The frame shipped as `sandbox="allow-scripts allow-forms allow-popups"` —
+ * no `allow-same-origin`. That gives the document an OPAQUE origin, and the
+ * consequence is not a browser detail, it is this file's subject: core issues
+ * its operator session as `SameSite=Lax`, and a `SameSite=Lax` cookie is not
+ * attached to a request from an opaque origin. Every screen of a data-driven
+ * plugin UI opens with a GET, so the frame rendered an error state and nothing
+ * in either repo's suite noticed, because both stub `fetch` and a stub has no
+ * origin.
+ *
+ * These tests assert the two halves of the posture the decision rests on:
+ *
+ *   1. The session cookie really is `SameSite=Lax; Path=/` — so a SAME-origin
+ *      subresource request from the framed document carries it, and no
+ *      `SameSite=None; Secure` loosening of the product-wide cookie is needed
+ *      to make one iframe work.
+ *   2. The document core serves at `/p/<id>/ui/` is confined by a CSP that
+ *      permits exactly that same-origin call (`connect-src 'self'`) and
+ *      nothing wider — which is what makes granting `allow-same-origin`
+ *      defensible rather than merely convenient.
+ *
+ * The reasoning in full: `plan.md` §4.3a addendum, in the epic #470 spec
+ * directory.
+ */
+
+import { after, before, describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import cookieParser from 'cookie-parser';
+import express, { type Express } from 'express';
+
+import type { AuthProvider } from '../src/auth/providers/AuthProvider.js';
+import { ProviderRegistry } from '../src/auth/providerRegistry.js';
+import { createRequireAuth } from '../src/auth/requireAuth.js';
+import type { UserStore } from '../src/auth/userStore.js';
+import { EmailWhitelist } from '../src/auth/whitelist.js';
+import { createAuthRouter } from '../src/routes/auth.js';
+import { createPluginUiStaticRouter } from '../src/routes/pluginUiStatic.js';
+import { invoke } from './_helpers/httpInvoke.js';
+
+const PLUGIN_ID = '@omadia/example-ui';
+const SIGNING_KEY = new Uint8Array(32).fill(7);
+const OPERATOR = 'operator@example.com';
+
+/**
+ * A password provider that always succeeds. The session MINT is the subject
+ * here, not credential verification — that has its own tests.
+ */
+const provider: AuthProvider = {
+  id: 'local',
+  displayName: 'Local',
+  kind: 'password',
+  verify: async () => ({
+    outcome: 'success' as const,
+    providerUserId: OPERATOR,
+    email: OPERATOR,
+    displayName: 'Operator',
+  }),
+};
+
+let root: string;
+let app: Express;
+
+before(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'plugin-ui-creds-'));
+  const packageRoot = path.join(root, 'packages', 'example-ui', '1.0.0');
+  await fs.mkdir(path.join(packageRoot, 'ui'), { recursive: true });
+  await fs.writeFile(
+    path.join(packageRoot, 'ui', 'index.html'),
+    '<!doctype html><title>bundle</title>',
+  );
+
+  const registry = new ProviderRegistry();
+  registry.register(provider);
+
+  app = express();
+  app.use(cookieParser());
+  app.use(
+    '/api/v1/auth',
+    createAuthRouter({
+      registry,
+      userStore: {
+        count: async () => 1,
+        markLoginNow: async () => undefined,
+      } as unknown as UserStore,
+      signingKey: SIGNING_KEY,
+      publicBaseUrl: 'https://omadia.example',
+      defaultReturnPath: '/',
+      setupAllowed: false,
+    }),
+  );
+  // The document the operator's browser frames.
+  app.use(
+    '/p',
+    createPluginUiStaticRouter({
+      resolvePackageRoot: (id) => (id === PLUGIN_ID ? packageRoot : undefined),
+    }),
+  );
+  // Stand-in for the plugin's own authenticated backend router — the thing the
+  // framed document GETs on every screen.
+  app.use(
+    '/api/v1/plugin',
+    createRequireAuth({ signingKey: SIGNING_KEY, whitelist: new EmailWhitelist('') }),
+    (req, res) => {
+      res.json({ ok: true, sub: req.session?.sub });
+    },
+  );
+});
+
+after(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+async function login(): Promise<string> {
+  const res = await invoke(app, 'POST', '/api/v1/auth/login/local');
+  assert.equal(res.status, 200);
+  const raw = res.headers['set-cookie'];
+  const cookies = Array.isArray(raw) ? raw.map(String) : [String(raw)];
+  const session = cookies.find((c) => c.startsWith('omadia_session='));
+  assert.ok(session, 'login did not set a session cookie');
+  return session;
+}
+
+describe('plugin UI frame credentials — session cookie posture', () => {
+  it('issues the operator session as SameSite=Lax, Path=/, HttpOnly', async () => {
+    const cookie = await login();
+    assert.match(cookie, /SameSite=Lax/i);
+    assert.match(cookie, /Path=\//);
+    assert.match(cookie, /HttpOnly/i);
+  });
+
+  it('does NOT ship SameSite=None, which an opaque-origin frame would require', async () => {
+    // The alternative trust model — keep the sandbox opaque, make the cookie
+    // cross-site — would mean loosening the session cookie for the ENTIRE
+    // product to serve one iframe. This assertion is the record that we did
+    // not, and the tripwire if anyone tries.
+    const cookie = await login();
+    assert.doesNotMatch(cookie, /SameSite=None/i);
+  });
+
+  it('authenticates a same-origin request that replays that cookie', async () => {
+    // A same-SITE request carries a SameSite=Lax cookie. `allow-same-origin`
+    // on the frame is exactly what makes the framed document's fetch same-site
+    // rather than `Origin: null`.
+    const cookie = (await login()).split(';')[0] ?? '';
+    const res = await invoke(app, 'GET', '/api/v1/plugin/jobs', {
+      headers: { cookie },
+    });
+    assert.equal(res.status, 200);
+    assert.equal((JSON.parse(res.text) as { sub?: string }).sub, OPERATOR);
+  });
+
+  it('401s the same request without the cookie — the opaque-origin outcome', async () => {
+    // Mutation guard: without this, the assertion above could pass against a
+    // route that never checked anything.
+    const res = await invoke(app, 'GET', '/api/v1/plugin/jobs');
+    assert.equal(res.status, 401);
+  });
+});
+
+describe('plugin UI frame credentials — the served document stays confined', () => {
+  const bundleRoot = `/p/${encodeURIComponent(PLUGIN_ID)}/ui/`;
+
+  it("permits the same-origin call it now depends on, via connect-src 'self'", async () => {
+    const res = await invoke(app, 'GET', bundleRoot);
+    assert.equal(res.status, 200);
+    assert.match(String(res.headers['content-security-policy']), /connect-src 'self'/);
+  });
+
+  it('keeps the directives that make allow-same-origin defensible', async () => {
+    const csp = String(
+      (await invoke(app, 'GET', bundleRoot)).headers['content-security-policy'],
+    );
+    // No remote script, no off-site framing, no base-tag or form-action
+    // escape. The bundle now holds the operator's session, so THESE are the
+    // boundary — not the sandbox attribute.
+    assert.match(csp, /default-src 'none'/);
+    assert.match(csp, /script-src 'self'/);
+    assert.match(csp, /frame-ancestors 'self'/);
+    assert.match(csp, /base-uri 'none'/);
+    assert.match(csp, /form-action 'none'/);
+    assert.doesNotMatch(csp, /unsafe-eval/);
+  });
+
+  it('serves the scoped plugin id the host page now accepts', async () => {
+    // Companion to the web-ui regex fix: the id travels percent-encoded as ONE
+    // path segment and Express decodes it, so `@omadia/example-ui` resolves
+    // here. If either half of that round-trip changes, this goes red.
+    const res = await invoke(app, 'GET', `${bundleRoot}index.html`);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers['content-type'], 'text/html; charset=utf-8');
+  });
+});

--- a/middleware/test/pluginUiStaticServing.test.ts
+++ b/middleware/test/pluginUiStaticServing.test.ts
@@ -19,16 +19,49 @@ import path from 'node:path';
 import express, { type Express } from 'express';
 
 import {
+  CONTENT_TYPES,
   createPluginUiStaticRouter,
   safeRelativePath,
 } from '../src/routes/pluginUiStatic.js';
 import { invoke } from './_helpers/httpInvoke.js';
 
 const PLUGIN_ID = 'proof-plugin';
+const CONTENT_TYPE_FIXTURE_PREFIX = 'content-type-probe';
 
 let root: string;
 let packageRoot: string;
 let app: Express;
+
+function fixtureBodyForExtension(ext: string): string | Uint8Array {
+  switch (ext) {
+    case '.html':
+      return '<!doctype html><title>probe</title><p>probe</p>';
+    case '.js':
+    case '.mjs':
+      return 'export const probe = true;';
+    case '.map':
+      return '{"version":3,"file":"probe.js","sources":[],"names":[],"mappings":""}';
+    case '.json':
+      return '{"probe":true}';
+    case '.svg':
+      return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"/>';
+    case '.png':
+      return Buffer.from('png-probe');
+    case '.jpg':
+    case '.jpeg':
+      return Buffer.from('jpeg-probe');
+    case '.woff2':
+      return Buffer.from('woff2-probe');
+    case '.txt':
+      return 'probe';
+    default:
+      throw new Error(`Unhandled fixture extension: ${ext}`);
+  }
+}
+
+function fixtureRequestPath(ext: string): string {
+  return `/p/${PLUGIN_ID}/ui/assets/${CONTENT_TYPE_FIXTURE_PREFIX}${ext}`;
+}
 
 before(async () => {
   root = await fs.mkdtemp(path.join(os.tmpdir(), 'plugin-ui-static-'));
@@ -44,6 +77,12 @@ before(async () => {
   await fs.writeFile(path.join(ui, 'assets', 'vendor-polyfills.js'), 'export const polyfills = true;');
   await fs.writeFile(path.join(ui, 'assets', 'logo.svg'), '<svg/>');
   await fs.writeFile(path.join(ui, 'assets', 'notes.css'), 'body{color:red}');
+  for (const [ext] of CONTENT_TYPES) {
+    await fs.writeFile(
+      path.join(ui, 'assets', `${CONTENT_TYPE_FIXTURE_PREFIX}${ext}`),
+      fixtureBodyForExtension(ext),
+    );
+  }
   // A secret NEXT to the bundle: the thing traversal would be aiming at.
   await fs.writeFile(path.join(packageRoot, 'manifest.yaml'), 'schema_version: "1"\n');
 
@@ -230,6 +269,91 @@ describe('plugin UI static serving — the security boundary', () => {
   it('does not leak the referrer to plugin-side navigations', async () => {
     const res = await invoke(app, 'GET', `/p/${PLUGIN_ID}/ui/index.html`);
     assert.equal(res.headers['referrer-policy'], 'no-referrer');
+  });
+});
+
+describe('plugin UI static serving — CONTENT_TYPES coverage', () => {
+  for (const [ext, contentType] of CONTENT_TYPES) {
+    it(`serves ${ext} with the mapped Content-Type, nosniff and the expected CSP`, async () => {
+      const res = await invoke(app, 'GET', fixtureRequestPath(ext));
+      assert.equal(
+        res.status,
+        200,
+        `pluginUiStatic.ts should serve ${ext} fixtures from CONTENT_TYPES; revisit middleware/src/routes/pluginUiStatic.ts if ${ext} stopped resolving`,
+      );
+      assert.equal(
+        res.headers['content-type'],
+        contentType,
+        `pluginUiStatic.ts no longer serves ${ext} with the CONTENT_TYPES mapping exported from middleware/src/routes/pluginUiStatic.ts`,
+      );
+      assert.equal(
+        res.headers['x-content-type-options'],
+        'nosniff',
+        `pluginUiStatic.ts must keep nosniff on ${ext}; revisit middleware/src/routes/pluginUiStatic.ts if that header regressed`,
+      );
+
+      const csp = String(res.headers['content-security-policy'] ?? '');
+      assert.ok(
+        csp.length > 0,
+        `pluginUiStatic.ts stopped sending Content-Security-Policy on ${ext}; revisit the serve() tail in middleware/src/routes/pluginUiStatic.ts`,
+      );
+      if (ext === '.svg') {
+        assert.match(
+          csp,
+          /default-src 'none'/,
+          'pluginUiStatic.ts must keep the SVG-specific confinement policy on .svg assets; revisit middleware/src/routes/pluginUiStatic.ts if that branch changed',
+        );
+        assert.match(
+          csp,
+          /\bsandbox\b/,
+          'pluginUiStatic.ts must keep the SVG sandbox directive on .svg assets; revisit middleware/src/routes/pluginUiStatic.ts if that branch changed',
+        );
+      } else {
+        assert.match(
+          csp,
+          /script-src 'self'/,
+          `pluginUiStatic.ts must keep the standard CSP on ${ext}; revisit middleware/src/routes/pluginUiStatic.ts if non-SVG assets lost script-src 'self'`,
+        );
+        assert.match(
+          csp,
+          /frame-ancestors 'self'/,
+          `pluginUiStatic.ts must keep the standard CSP on ${ext}; revisit middleware/src/routes/pluginUiStatic.ts if non-SVG assets lost frame-ancestors 'self'`,
+        );
+        assert.ok(
+          !/\bsandbox\b/.test(csp),
+          `pluginUiStatic.ts should not send the SVG sandbox directive on ${ext}; revisit middleware/src/routes/pluginUiStatic.ts if the CSP branches collapsed`,
+        );
+      }
+    });
+  }
+
+  it('keeps CSP and nosniff on the 304 revalidation branch', async () => {
+    const first = await invoke(app, 'GET', fixtureRequestPath('.json'));
+    const etag = first.headers['etag'];
+    assert.ok(
+      typeof etag === 'string' && etag.length > 2,
+      'pluginUiStatic.ts should emit an ETag before the 304 branch can be exercised; revisit middleware/src/routes/pluginUiStatic.ts if revalidation changed',
+    );
+
+    const second = await invoke(app, 'GET', fixtureRequestPath('.json'), {
+      headers: { 'if-none-match': etag },
+    });
+    assert.equal(second.status, 304);
+    assert.equal(
+      second.headers['x-content-type-options'],
+      'nosniff',
+      'pluginUiStatic.ts must keep X-Content-Type-Options on 304 responses; revisit the serve() tail in middleware/src/routes/pluginUiStatic.ts if the branch moved ahead of header-setting',
+    );
+    const csp = String(second.headers['content-security-policy'] ?? '');
+    assert.ok(
+      csp.length > 0,
+      'pluginUiStatic.ts must keep Content-Security-Policy on 304 responses; revisit the serve() tail in middleware/src/routes/pluginUiStatic.ts if the branch moved ahead of header-setting',
+    );
+    assert.match(
+      csp,
+      /script-src 'self'/,
+      'pluginUiStatic.ts must keep the standard CSP on 304 responses for non-SVG assets; revisit middleware/src/routes/pluginUiStatic.ts if the response lost it',
+    );
   });
 });
 

--- a/middleware/test/pluginUiTrustModel.test.ts
+++ b/middleware/test/pluginUiTrustModel.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Epic #470 C8b — machine-check the documented iframe trade.
+ *
+ * The same-origin plugin-UI decision in the plugin-UI plan §4.3a is an
+ * accepted trade, not an accident. This file exists because a
+ * documented trade with no test is just a comment: the day one premise changes,
+ * the decision has to go red and force a re-read.
+ */
+
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ServiceNotDeclaredError } from '@omadia/plugin-api';
+
+import {
+  classifyServiceGrant,
+  createServiceGrantGate,
+} from '../src/platform/pluginServiceGrants.js';
+import type { PluginCatalog } from '../src/plugins/manifestLoader.js';
+
+// The middleware is an ES module, so the CJS directory global does not
+// exist here — derive the directory from import.meta.url instead.
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+const TOOL_PLUGIN_RUNTIME = path.resolve(
+  HERE,
+  '../src/plugins/toolPluginRuntime.ts',
+);
+const PUBLIC_PATH_GRANTS = path.resolve(
+  HERE,
+  '../src/platform/publicPathGrants.ts',
+);
+const AUTH_ROUTE = path.resolve(HERE, '../src/routes/auth.ts');
+
+const DISTINCT_ORIGIN_REOPEN_MESSAGE =
+  "plugin server code now appears isolated, so the same-origin plugin-UI decision recorded in the plugin-UI plan §4.3a rests on a premise that no longer holds — reopen it and move plugin UIs to a distinct origin. middleware/src/platform/pluginContext.ts already records that hardening path.";
+
+function readSource(absPath: string): string {
+  return readFileSync(absPath, 'utf-8');
+}
+
+function assertPinnedSnippet(opts: {
+  source: string;
+  exact: string;
+  broad: RegExp;
+  movedMessage: string;
+  missingMessage: string;
+}): void {
+  if (opts.source.includes(opts.exact)) return;
+  if (opts.broad.test(opts.source)) {
+    assert.fail(opts.movedMessage);
+  }
+  assert.fail(opts.missingMessage);
+}
+
+describe('plugin UI trust model — tripwires for the C8b trade', () => {
+  it('keeps plugin server code unsandboxed, which is the only reason §4.3a still tolerates a same-origin plugin UI', () => {
+    const source = readSource(TOOL_PLUGIN_RUNTIME);
+
+    assertPinnedSnippet({
+      source,
+      exact:
+        'const mod = (await import(pathToFileURL(entryAbs).href)) as ToolPluginModuleShape;',
+      broad: /import\(pathToFileURL\(entryAbs\)\.href\)/,
+      movedMessage:
+        "toolPluginRuntime.ts still dynamically imports the plugin entry, but the pinned `const mod = (await import(pathToFileURL(entryAbs).href)) ...` anchor moved — update this test's anchor instead of deleting the tripwire.",
+      missingMessage:
+        `${DISTINCT_ORIGIN_REOPEN_MESSAGE} The bare in-process dynamic import is no longer visible in middleware/src/plugins/toolPluginRuntime.ts.`,
+    });
+
+    const isolationImports =
+      /\bfrom\s+['"](?:node:)?vm['"]|\bfrom\s+['"](?:node:)?worker_threads['"]|\bfrom\s+['"](?:node:)?child_process['"]|\brequire\((['"])(?:node:)?vm\1\)|\brequire\((['"])(?:node:)?worker_threads\2\)|\brequire\((['"])(?:node:)?child_process\3\)/;
+    assert.ok(
+      !isolationImports.test(source),
+      DISTINCT_ORIGIN_REOPEN_MESSAGE,
+    );
+  });
+
+  it("keeps `/api/v1/admin` core-reserved even though a same-origin frame can still ride the operator's cookie to it", () => {
+    const source = readSource(PUBLIC_PATH_GRANTS);
+
+    assertPinnedSnippet({
+      source,
+      exact: "  '/api/v1/admin',",
+      broad: /['"]\/api\/v1\/admin['"]/,
+      movedMessage:
+        "publicPathGrants.ts still mentions `/api/v1/admin`, but the pinned CORE_RESERVED_ROOTS anchor moved — update the anchor rather than deleting the check. This test is where the §4.3a accepted exposure stays visible.",
+      missingMessage:
+        "`/api/v1/admin` is no longer core-reserved in middleware/src/platform/publicPathGrants.ts. Revisit the same-origin plugin-UI trade in the plugin-UI plan §4.3a before leaving the frame able to ride the operator cookie to that surface.",
+    });
+  });
+
+  it('keeps the deny-by-default service-grant model real: undeclared services classify as undeclared and throw ServiceNotDeclaredError', () => {
+    const agentId = '@omadia/example-ui';
+    const catalog = {
+      get(id: string) {
+        if (id !== agentId) return undefined;
+        return {
+          plugin: {
+            requires: ['knowledgeGraph@1'],
+            provides: ['exampleUiRuntime@1'],
+          },
+        };
+      },
+    } as unknown as PluginCatalog;
+
+    const declared = new Set<string>(['knowledgeGraph', 'exampleUiRuntime']);
+    const outcome = classifyServiceGrant(agentId, 'graphPool', declared, catalog);
+    assert.equal(
+      outcome,
+      'undeclared',
+      'pluginServiceGrants.ts no longer classifies an undeclared service as `undeclared` — revisit the §4.3a trust-model rationale because the same-origin frame would no longer be bypassing a real server-side grant boundary.',
+    );
+
+    const assertServiceGranted = createServiceGrantGate({
+      agentId,
+      catalog,
+      log: () => undefined,
+    });
+    assert.throws(
+      () => assertServiceGranted('graphPool'),
+      (error: unknown) => {
+        assert.ok(
+          error instanceof ServiceNotDeclaredError,
+          'pluginServiceGrants.ts stopped throwing ServiceNotDeclaredError for an undeclared service — revisit the §4.3a trust-model rationale because the same-origin frame would no longer be bypassing a real deny-by-default gate.',
+        );
+        return true;
+      },
+      'pluginServiceGrants.ts no longer fail-closes undeclared services — revisit the same-origin plugin-UI trade in the plugin-UI plan §4.3a.',
+    );
+  });
+
+  it("keeps the operator session a Path=/ admin session, which is what makes a same-origin fetch from the frame equivalent to the operator", () => {
+    const source = readSource(AUTH_ROUTE);
+
+    assertPinnedSnippet({
+      source,
+      exact: "      role: 'admin',",
+      broad: /role:\s*'admin'/,
+      movedMessage:
+        "auth.ts still mints `role: 'admin'`, but the pinned anchor moved — update this test's anchor instead of deleting the tripwire.",
+      missingMessage:
+        "middleware/src/routes/auth.ts no longer mints the operator session with `role: 'admin'`. Revisit the same-origin plugin-UI decision in the plugin-UI plan §4.3a because the frame may no longer ride the full operator surface exactly as documented.",
+    });
+
+    assertPinnedSnippet({
+      source,
+      exact: "    path: '/',",
+      broad: /path:\s*'\/'/,
+      movedMessage:
+        "auth.ts still sets the session cookie path to `/`, but the pinned anchor moved — update this test's anchor instead of deleting the tripwire.",
+      missingMessage:
+        "middleware/src/routes/auth.ts no longer sets the operator session cookie with `path: '/'`. Revisit the same-origin plugin-UI decision in the plugin-UI plan §4.3a because the frame may no longer ride the full operator surface exactly as documented.",
+    });
+  });
+});

--- a/specs/470-dev-platform-plugin/plan.md
+++ b/specs/470-dev-platform-plugin/plan.md
@@ -389,32 +389,64 @@ origin. This is a property of the browser, not of the client.
 
 #### The decision
 
-**Grant `allow-same-origin`.** Three arguments, in order of weight.
+**Grant `allow-same-origin`.** Four arguments, in order of weight.
 
-1. **It gives the plugin no privilege it does not already hold.** The plugin's server half
-   runs *in-process* in the middleware with `ctx.services`, its own Express router and the
-   operator's authority. A plugin that wanted the operator's session could read it
-   server-side today. Withholding it from the plugin's *UI* removed function, not capability
-   — it defended a boundary that does not exist.
-2. **The threat model the sandbox implied is not the one we have.** Denying same-origin only
-   helps if the UI bundle is less trusted than the server code. Both ship in the *same* ZIP,
-   through the *same* ingest, scanned by the *same* checks. There is no trust gradient
-   between them to enforce.
-3. **What actually confines the bundle is the response, not the attribute**, and that is
-   unchanged and tight. Core serves it from an ingest-scanned package under
+1. **The plugin grant model is real, and the frame walks around it.** The server-side plugin
+   contract is deliberately deny-by-default: `pluginServiceGrants.ts` throws
+   `ServiceNotDeclaredError` for undeclared services; `pluginContext.ts` gates `ctx.http`,
+   `ctx.net`, `ctx.secrets`, `ctx.memory`, `ctx.llm`, `ctx.subAgent`, `ctx.knowledgeGraph`,
+   `ctx.mcp`, `ctx.events.emit` and `ctx.flows` on manifest-declared permissions; and
+   `publicPathGrants.ts` reserves `/api/v1/admin` away from plugins even with operator
+   consent. A same-origin UI riding the operator's `Path=/` session reaches that surface
+   anyway, so saying it gains "no new privilege" is false as written.
+2. **What makes the decision acceptable today is narrower and simpler:** the plugin's server
+   half is loaded by a bare in-process dynamic import
+   (`toolPluginRuntime.ts: const mod = (await import(pathToFileURL(entryAbs).href)) ...`).
+   There is no `vm`, worker, child process or Node permission wall around that load. The
+   plugin shares `globalThis` and `process.env`, which includes the session-signing key.
+   Against a malicious plugin author the grant model was never a security boundary at all; it
+   is a consent-and-contract boundary. Such an author can already own the process and forge a
+   session outright. Withholding same-origin from the UI defended nothing against that actor
+   while breaking every honest plugin.
+3. **The threat model the sandbox implied is not the one we have.** Denying same-origin only
+   helps if the UI bundle is less trusted than the server code. That is only true for a
+   browser-only compromise: an XSS in the plugin UI or a compromised frontend dependency
+   controls the bundle but not the server half. That is the real delta this change accepts,
+   and it is why the distinct-origin upgrade path below remains recorded.
+4. **What actually confines the bundle is the response, not ingest.** Core serves it under
    `default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'
    data:; font-src 'self'; connect-src 'self'; form-action 'none'; base-uri 'none';
-   frame-ancestors 'self'`, from an extension allowlist with no `.css` in it. The bundle
-   cannot load remote script, cannot talk to a third origin, cannot be framed off-site,
-   cannot retarget forms or the base URL.
+   frame-ancestors 'self'`, from an extension allowlist with no `.css` in it. The ingest scan
+   touching the UI bundle is narrower: `PackageUploadService` reads `.js` / `.mjs` only for
+   arbitrary Tailwind values, bounded at 200 files / 8 MB, and built-in / local-dev catalog
+   packages do not traverse that ingest path at all. Inline `<script>`, inline `onclick=`,
+   `javascript:` URLs and `<base>` are blocked at runtime by the CSP, not by ingest.
 
 `allow-popups` is **dropped**: nothing in a plugin UI opens a window, and a granted
 capability nothing uses is only a surface.
 
 The familiar objection — "`allow-scripts` plus `allow-same-origin` lets the frame remove its
-own sandbox attribute" — is true and, here, empty. The frame is already same-origin and
-already has the session. There is nothing left to escalate to. The sandbox is retained for
-what it still denies: top-level navigation, downloads, modals, pointer lock, presentation.
+own sandbox attribute" — is true, and it means the attribute is not an enforceable boundary
+here. A same-origin bundle can reach `window.frameElement`, strip `sandbox`, reload, and
+regain top-level navigation, downloads, modals, pointer lock and presentation. The attribute
+is still worth keeping as an intent marker for a non-adversarial bundle, but the rationale
+must not pretend it enforces isolation once same-origin is granted.
+
+#### The residual exposure
+
+The honest cost is the browser-only attacker. A compromised plugin frontend now reaches the
+operator's full same-origin admin surface, including `/bot-api/v1/admin/*` (core
+`/api/v1/admin/*`), can mint a durable API key from that surface, and can write to
+`window.top.document` for UI-redress / credential-phishing attacks in the real operator
+chrome. The plugin's server half does **not** get that route through the declared contract:
+`CORE_RESERVED_ROOTS` refuses `/api/v1/admin` to plugins even on consent, and there is no
+CSRF layer anywhere in the product to stop a same-origin document from riding the cookie.
+
+The accepted mitigation is the recorded distinct-origin upgrade path. It is optional while
+plugin server code is loaded unsandboxed in-process, because the malicious-author threat
+already owns the process. The moment plugin server code is actually sandboxed — a hardening
+pass `pluginContext.ts` already records as planned — that upgrade path becomes mandatory and
+this same-origin decision must be reopened.
 
 #### The two alternatives, and why not
 
@@ -428,12 +460,23 @@ what it still denies: top-level navigation, downloads, modals, pointer lock, pre
 - `web-ui/app/plugin-ui/[pluginId]/_components/__tests__/PluginUiFrame.test.tsx` pins the
   sandbox attribute to its **exact** string, so both dropping `allow-same-origin` again and
   re-adding `allow-popups` go red; it also pins the `src` to core's own origin, since
-  same-origin is a property of the URL as much as of the attribute.
+  same-origin is a property of the URL as much as of the attribute. The "withholds top-level
+  navigation..." test is explicitly documented as intent, not enforcement.
 - `middleware/test/pluginUiFrameCredentials.test.ts` asserts the posture the decision rests
   on: the session cookie is `SameSite=Lax; Path=/; HttpOnly` and **not** `SameSite=None`; a
   same-origin request replaying it authenticates while the same request without it 401s; and
   the served document still carries `connect-src 'self'`, `frame-ancestors 'self'`,
   `base-uri 'none'` and `form-action 'none'`.
+- `middleware/test/pluginUiTrustModel.test.ts` is the tripwire for the premise itself: it
+  source-pins the bare in-process plugin load, asserts `/api/v1/admin` stays in
+  `CORE_RESERVED_ROOTS` with the accepted-exposure comment next to it, exercises the real
+  `ServiceNotDeclaredError` gate for undeclared services, and pins the session JWT's
+  `role: 'admin'` plus `Path=/`. If any of those stop being true, the same-origin decision's
+  rationale has changed and the spec must be revisited.
+- `middleware/test/pluginUiStaticServing.test.ts` now table-drives **every** entry in
+  `CONTENT_TYPES`, asserting `Content-Type`, `X-Content-Type-Options: nosniff`, a non-empty
+  CSP, the SVG-specific sandboxing policy, the standard policy for every other extension, and
+  that the CSP survives the 304 branch.
 
 #### Two other C8 defects fixed alongside (C8b)
 

--- a/specs/470-dev-platform-plugin/plan.md
+++ b/specs/470-dev-platform-plugin/plan.md
@@ -361,6 +361,99 @@ parent.
 allowlisted, so a compiled SPA can ship today; what is missing is a static-asset serving
 path from the plugin's router. That is a much smaller problem than a styling story.
 
+### 4.3a addendum — the iframe trust model (C8b)
+
+> **Status: DECIDED and SHIPPED (C8b).** The frame is **sandboxed but same-origin**:
+> `sandbox="allow-same-origin allow-scripts allow-forms"`.
+
+C8 shipped the frame as `allow-scripts allow-forms allow-popups`, deliberately without
+`allow-same-origin`, with a comment saying the bundle is third-party code and this keeps it
+out of the operator's cookies, and that a plugin needing authenticated calls "does them from
+its own backend router, which is where its authentication lives anyway."
+
+The first half was sound. The second half does not follow, and it made the feature
+non-functional. A sandbox without `allow-same-origin` gives the document an **opaque
+origin**. The plugin's own backend router is still reached over HTTP *from inside that
+document*, so:
+
+- every `fetch('/bot-api/v1/...')` leaves with `Origin: null` and is a cross-site request;
+- our session cookie is `SameSite=Lax`, so it is **not attached**;
+- `EventSource(url, { withCredentials: true })` — the live job-event tail — fails identically;
+- `localStorage` throws outright.
+
+The first plugin to port a real SPA (`byte5ai/omadia-dev-platform`) is entirely
+data-driven: all four screens open with a `GET`. The host page therefore rendered a
+correctly-styled, correctly-themed, correctly-translated shell showing an **error state on
+every screen**. Neither repo's suite caught it, because both stub `fetch` and a stub has no
+origin. This is a property of the browser, not of the client.
+
+#### The decision
+
+**Grant `allow-same-origin`.** Three arguments, in order of weight.
+
+1. **It gives the plugin no privilege it does not already hold.** The plugin's server half
+   runs *in-process* in the middleware with `ctx.services`, its own Express router and the
+   operator's authority. A plugin that wanted the operator's session could read it
+   server-side today. Withholding it from the plugin's *UI* removed function, not capability
+   — it defended a boundary that does not exist.
+2. **The threat model the sandbox implied is not the one we have.** Denying same-origin only
+   helps if the UI bundle is less trusted than the server code. Both ship in the *same* ZIP,
+   through the *same* ingest, scanned by the *same* checks. There is no trust gradient
+   between them to enforce.
+3. **What actually confines the bundle is the response, not the attribute**, and that is
+   unchanged and tight. Core serves it from an ingest-scanned package under
+   `default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self'
+   data:; font-src 'self'; connect-src 'self'; form-action 'none'; base-uri 'none';
+   frame-ancestors 'self'`, from an extension allowlist with no `.css` in it. The bundle
+   cannot load remote script, cannot talk to a third origin, cannot be framed off-site,
+   cannot retarget forms or the base URL.
+
+`allow-popups` is **dropped**: nothing in a plugin UI opens a window, and a granted
+capability nothing uses is only a surface.
+
+The familiar objection — "`allow-scripts` plus `allow-same-origin` lets the frame remove its
+own sandbox attribute" — is true and, here, empty. The frame is already same-origin and
+already has the session. There is nothing left to escalate to. The sandbox is retained for
+what it still denies: top-level navigation, downloads, modals, pointer lock, presentation.
+
+#### The two alternatives, and why not
+
+| Alternative | Why rejected |
+|---|---|
+| **Keep the opaque origin; core proxies the plugin's API under the frame's own path with permissive CORS** | `Access-Control-Allow-Origin: null` matches *every* opaque origin on the internet, not just ours — a weaker boundary than the one it replaces, plus a real proxy to build and maintain. The other route to the same place, loosening the session cookie to `SameSite=None; Secure`, weakens authentication **product-wide** to serve one iframe. |
+| **Serve plugin bundles from a distinct origin and treat plugins as genuinely third-party** | The clean answer, and the recorded upgrade path. It needs a second hostname, its own TLS and a cross-origin auth story on *every* install target — Docker Compose, Fly, Render, bare VM. Disproportionate while plugins are operator-installed from a curated hub. Revisit if plugins ever become genuinely untrusted third-party code. |
+
+#### What is machine-checked
+
+- `web-ui/app/plugin-ui/[pluginId]/_components/__tests__/PluginUiFrame.test.tsx` pins the
+  sandbox attribute to its **exact** string, so both dropping `allow-same-origin` again and
+  re-adding `allow-popups` go red; it also pins the `src` to core's own origin, since
+  same-origin is a property of the URL as much as of the attribute.
+- `middleware/test/pluginUiFrameCredentials.test.ts` asserts the posture the decision rests
+  on: the session cookie is `SameSite=Lax; Path=/; HttpOnly` and **not** `SameSite=None`; a
+  same-origin request replaying it authenticates while the same request without it 401s; and
+  the served document still carries `connect-src 'self'`, `frame-ancestors 'self'`,
+  `base-uri 'none'` and `form-action 'none'`.
+
+#### Two other C8 defects fixed alongside (C8b)
+
+- **The host page rejected every scoped plugin id.** Its regex claimed to mirror
+  `manifestLoader.ts` and omitted the optional `@scope/`, so `/plugin-ui/@omadia/dev-platform`
+  — the id of the plugin the route was built for, and the shape of *every* omadia plugin id —
+  called `notFound()`. The gate now lives in `web-ui/app/_lib/pluginId.ts` and a test reads
+  `manifestLoader.ts` and asserts the two definitions are character-identical, turning the
+  "mirrors" comment into a check.
+- **Three vocabulary declarations emitted nothing.** `@source inline()` expands braces; a
+  top-level comma is not a list separator, so `@source inline("border,border-{0,2,4}")` asked
+  Tailwind for a class literally named `border,border-0` and produced no CSS. `border`,
+  `divide-*` and `transition*` were all absent from the artifact while
+  `plugin-ui-vocabulary.md` listed them. Worse than a missing utility: Tailwind's reset is
+  `border: 0 solid`, so `class="border border-border"` set a colour on a zero-width edge and
+  rendered invisible. Fixed at source, artifact regenerated (69,559 → 72,659 B raw; 12,105 →
+  12,486 B gzip), and `web-ui/scripts/__tests__/pluginUiVocabulary.test.ts` now checks parity
+  in both directions — every class the source declares and every class the document promises
+  must exist in the committed sheet.
+
 ### Back to the option table
 
 **Recommendation: B**, now materially cheaper than when first written — with §4.3a it is

--- a/specs/470-dev-platform-plugin/plugin-ui-vocabulary.md
+++ b/specs/470-dev-platform-plugin/plugin-ui-vocabulary.md
@@ -89,6 +89,12 @@ Canonical source is `web-ui/scripts/plugin-ui.source.css`; this table is the
 human-readable form of it. Brace ranges expand — `p-{0..12}` means `p-0`
 through `p-12`.
 
+**This section is machine-checked.** `web-ui/scripts/__tests__/pluginUiVocabulary.test.ts`
+expands every pattern below and fails if the generated sheet does not contain
+the class, so a promise made here cannot quietly go unkept. That check is why
+notation must stay expandable: write the alternatives out rather than eliding
+them with `…`, or the test refuses the pattern instead of skipping it.
+
 ### Layout
 
 | Group | Classes |
@@ -98,7 +104,7 @@ through `p-12`.
 | Alignment | `items-{start,center,end,baseline,stretch}` · `justify-{start,center,end,between,around,evenly}` · `self-{auto,start,center,end,stretch}` |
 | Grid | `grid-cols-{1..6}` · `col-span-{1..6}` |
 | Gap | `gap-{0..8}` `gap-x-{0..8}` `gap-y-{0..8}` |
-| Size | `w-/h-{full,auto,fit,screen}` · `w-/h-{0,1,2,3,4,5,6,8,10,12,16,20,24,32}` · `min-w-/min-h-{0,full}` · `max-w-{none,full,xs…7xl}` |
+| Size | `w-/h-{full,auto,fit,screen}` · `w-/h-{0,1,2,3,4,5,6,8,10,12,16,20,24,32}` · `min-w-/min-h-{0,full}` · `max-w-{none,full,xs,sm,md,lg,xl,2xl,3xl,4xl,5xl,6xl,7xl}` |
 | Overflow | `overflow-{auto,hidden,visible,x-auto,y-auto}` |
 | Position | `relative` `absolute` `fixed` `sticky` `static` · `inset-/top-/right-/bottom-/left-{0,auto}` · `z-{0,10,20,30,40,50}` |
 | Centering | `mx-auto` |
@@ -158,11 +164,13 @@ roles, each wired to the runtime CSS variable:
 
 ### Responsive
 
-Breakpoints `sm:` `md:` `lg:` `xl:` are available on:
-`flex` `grid` `block` `inline-block` `hidden` · `grid-cols-{1..4}` ·
-`flex-{row,col}` (sm/md/lg) · `p-/px-/py-{0,2,4,6,8}` (sm/md/lg) ·
-`text-{sm,base,lg,xl,2xl}` (sm/md/lg) ·
-`max-w-{sm,md,lg,xl,2xl,4xl}` (sm/md/lg)
+Breakpoint prefixes are pre-generated per utility group, not universally —
+`xl:` exists on the display utilities and nowhere else.
+
+| Breakpoints | Available on |
+|---|---|
+| `sm:` `md:` `lg:` `xl:` | `{flex,grid,block,inline-block,hidden}` · `grid-cols-{1..4}` |
+| `sm:` `md:` `lg:` | `flex-{row,col}` · `{p,px,py}-{0,2,4,6,8}` · `text-{sm,base,lg,xl,2xl}` · `max-w-{sm,md,lg,xl,2xl,4xl}` |
 
 ### Baseline element styling
 
@@ -261,6 +269,15 @@ is a promise to plugin authors and a cost in bytes on every plugin UI load.
 2. `cd web-ui && npm run plugin-ui:css`.
 3. Commit the regenerated `middleware/assets/plugin-ui/plugin-ui.css`.
 4. Update this document.
+5. `npm test` — the parity test above proves steps 1-4 actually agree.
+
+**The trap in step 1.** `@source inline()` expands BRACES; a top-level comma is
+not a list separator. `@source inline("border,border-{0,2,4}")` asks Tailwind
+for a class literally named `border,border-0` and therefore emits **nothing** —
+no error, no warning. Three declarations shipped that way in C8 and cost every
+ported page its borders, because Tailwind's reset is `border: 0 solid`, so
+`class="border border-border"` set a colour on a zero-width edge. Always use
+the brace form: `border{,-0,-2,-4}`, `divide-{y,x}`, `transition{,-none,-all}`.
 
 CI regenerates and diffs (`npm run plugin-ui:css:check`, inside the existing
 web-ui job), so an edit to the source, the tokens or the bridge that was not

--- a/web-ui/app/_lib/__tests__/pluginId.test.ts
+++ b/web-ui/app/_lib/__tests__/pluginId.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  isValidPluginId,
+  PLUGIN_ID_MAX_LENGTH,
+  PLUGIN_ID_PATTERN,
+} from '../pluginId';
+
+/**
+ * Epic #470 C8b — the plugin-id gate on the plugin-UI host page.
+ *
+ * The gate shipped with a comment claiming it mirrored `manifestLoader`, and a
+ * pattern that did not: no optional `@scope/`, no `@` or `/` in the character
+ * class. Every omadia plugin id is scoped, so `/plugin-ui/@omadia/example-ui`
+ * called `notFound()` on the only id that package can have — a 404 on the one
+ * route the nav entry points at. The comment was the whole enforcement, and a
+ * comment cannot fail.
+ */
+
+const MANIFEST_LOADER = path.resolve(
+  __dirname,
+  '../../../../middleware/src/plugins/manifestLoader.ts',
+);
+
+describe('plugin-id gate — pinned to the middleware authority', () => {
+  it('is character-identical to manifestLoader PLUGIN_ID_PATTERN', () => {
+    const source = readFileSync(MANIFEST_LOADER, 'utf-8');
+    const match = source.match(/^const PLUGIN_ID_PATTERN = (\/.*\/);$/m);
+    // A failure here means the anchor moved, not that the patterns agree.
+    expect(
+      match,
+      'could not find `const PLUGIN_ID_PATTERN = /…/;` in manifestLoader.ts — ' +
+        'if it was renamed or reformatted, update this anchor rather than deleting the check',
+    ).not.toBeNull();
+    expect(match?.[1]).toBe(PLUGIN_ID_PATTERN.toString());
+  });
+
+  it('is character-identical to manifestLoader PLUGIN_ID_MAX_LENGTH', () => {
+    const source = readFileSync(MANIFEST_LOADER, 'utf-8');
+    const match = source.match(/^const PLUGIN_ID_MAX_LENGTH = (\d+);$/m);
+    expect(match).not.toBeNull();
+    expect(Number(match?.[1])).toBe(PLUGIN_ID_MAX_LENGTH);
+  });
+});
+
+describe('the host route uses the shared gate rather than its own', () => {
+  const PAGE = path.resolve(__dirname, '../../plugin-ui/[pluginId]/page.tsx');
+
+  it('imports isValidPluginId', () => {
+    expect(readFileSync(PAGE, 'utf-8')).toContain(
+      "import { isValidPluginId } from '@/app/_lib/pluginId'",
+    );
+  });
+
+  it('declares no plugin-id regex of its own', () => {
+    // The defect was a second definition that drifted from the first. A
+    // re-introduced local regex must fail here rather than at a 404.
+    const source = readFileSync(PAGE, 'utf-8');
+    expect(source).not.toMatch(/^const PLUGIN_ID\b/m);
+    expect(source).not.toMatch(/\[a-z0-9\._-\]/);
+  });
+});
+
+describe('isValidPluginId', () => {
+  it('accepts the scoped ids every omadia plugin actually uses', () => {
+    // The regression this whole change exists for.
+    expect(isValidPluginId('@omadia/example-ui')).toBe(true);
+    expect(isValidPluginId('@omadia/channel-teams')).toBe(true);
+    expect(isValidPluginId('@omadia/integration-odoo')).toBe(true);
+  });
+
+  it('still accepts the unscoped and reverse-FQDN forms', () => {
+    expect(isValidPluginId('proof-plugin')).toBe(true);
+    expect(isValidPluginId('de.byte5.agent.foo')).toBe(true);
+    expect(isValidPluginId('a')).toBe(true);
+  });
+
+  it('rejects the shapes that would make an id unsafe as a path segment', () => {
+    // Traversal is structurally unreachable rather than filtered: a segment
+    // may not begin with `.`, so neither `.` nor `..` can be one.
+    expect(isValidPluginId('..')).toBe(false);
+    expect(isValidPluginId('.')).toBe(false);
+    expect(isValidPluginId('@omadia/..')).toBe(false);
+    expect(isValidPluginId('@../example-ui')).toBe(false);
+    expect(isValidPluginId('../../etc/passwd')).toBe(false);
+    expect(isValidPluginId('@omadia/example/ui')).toBe(false);
+    expect(isValidPluginId('/etc/passwd')).toBe(false);
+    expect(isValidPluginId('plugin\0')).toBe(false);
+  });
+
+  it('rejects the charset the middleware rejects', () => {
+    expect(isValidPluginId('@Omadia/example-ui')).toBe(false);
+    expect(isValidPluginId('@omadia/Dev-Platform')).toBe(false);
+    expect(isValidPluginId('omadia/example-ui')).toBe(false);
+    expect(isValidPluginId('@omadia')).toBe(false);
+    expect(isValidPluginId('')).toBe(false);
+    expect(isValidPluginId('-leading-dash')).toBe(false);
+  });
+
+  it('enforces npm’s 214-character cap, scope included', () => {
+    const scope = '@omadia/';
+    expect(isValidPluginId(scope + 'a'.repeat(PLUGIN_ID_MAX_LENGTH - scope.length))).toBe(
+      true,
+    );
+    expect(
+      isValidPluginId(scope + 'a'.repeat(PLUGIN_ID_MAX_LENGTH - scope.length + 1)),
+    ).toBe(false);
+  });
+
+  it('accepts the id the host route receives after Next has decoded the segment', () => {
+    // `plugin.ts` percent-encodes the id so `@omadia/example-ui` survives as
+    // ONE path segment; Next hands the route the decoded value. Both forms are
+    // asserted so a future change to either side of that round-trip is visible.
+    const encoded = encodeURIComponent('@omadia/example-ui');
+    expect(encoded).toBe('%40omadia%2Fexample-ui');
+    expect(isValidPluginId(decodeURIComponent(encoded))).toBe(true);
+    // The still-encoded form must NOT pass: it would mean the decode never
+    // happened, and the id would not resolve to a package.
+    expect(isValidPluginId(encoded)).toBe(false);
+  });
+});

--- a/web-ui/app/_lib/pluginId.ts
+++ b/web-ui/app/_lib/pluginId.ts
@@ -1,0 +1,46 @@
+/**
+ * The plugin-id charset gate, web-ui's copy (epic #470 C8).
+ *
+ * WHY A COPY AND NOT AN IMPORT. The authority is
+ * `middleware/src/plugins/manifestLoader.ts` — that is where a manifest is
+ * accepted or rejected, and nothing here can change that verdict. web-ui is a
+ * separate Next build with its own `package.json`; it depends on no middleware
+ * package today, and adding one so a route handler can reach a regex would
+ * couple the web-ui image to the middleware workspace for eleven characters of
+ * pattern. The epic's constraint 2 is pushing dependencies the other way.
+ *
+ * So the pattern is restated here — and the restatement is PINNED. The comment
+ * that used to say "mirrors manifestLoader" was not enforced by anything, and
+ * it was wrong: it omitted the optional `@scope/`, so every `@omadia/*` plugin
+ * — which is all of them — 404'd on its own host page. `pluginId.test.ts`
+ * reads `manifestLoader.ts` and asserts the two definitions are character-
+ * identical, which turns the comment into a check. Drift now fails a test
+ * instead of a screen.
+ */
+
+/**
+ * `identity.id` — an npm package name, optionally scoped. Character-identical
+ * to `PLUGIN_ID_PATTERN` in `middleware/src/plugins/manifestLoader.ts`; keep
+ * them that way (`pluginId.test.ts` enforces it).
+ */
+export const PLUGIN_ID_PATTERN =
+  /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/;
+
+/**
+ * npm's own package-name cap, including the scope. Character-identical to
+ * `PLUGIN_ID_MAX_LENGTH` in `manifestLoader.ts`.
+ */
+export const PLUGIN_ID_MAX_LENGTH = 214;
+
+/**
+ * True iff `id` could be the `identity.id` of an installed plugin.
+ *
+ * Both halves of the middleware gate, in the same order: length first (a
+ * pathological id is rejected before the regex walks it), then charset. The
+ * charset is what carries the path-safety property — the only `/` a valid id
+ * may contain is the scope separator, and neither the scope nor the name may
+ * begin with `.`, so no segment of a valid id can be `.` or `..`.
+ */
+export function isValidPluginId(id: string): boolean {
+  return id.length <= PLUGIN_ID_MAX_LENGTH && PLUGIN_ID_PATTERN.test(id);
+}

--- a/web-ui/app/plugin-ui/[pluginId]/_components/PluginUiFrame.tsx
+++ b/web-ui/app/plugin-ui/[pluginId]/_components/PluginUiFrame.tsx
@@ -36,15 +36,29 @@ import { useLocale, useTranslations } from 'next-intl';
  *     way, and `localStorage` throws. A data-driven plugin UI opens every
  *     screen with a GET, so the sandbox did not isolate the plugin — it broke
  *     it, silently, into a correctly-themed error state.
- *   - It bought no privilege either. The plugin's server half already runs
- *     in-process in the middleware with the operator's authority. Denying its
- *     UI a session the plugin can read server-side removes function, not
- *     capability.
- *   - What still constrains the bundle is the response, not the attribute:
- *     core serves it from an ingest-scanned ZIP under a tight CSP
- *     (`default-src 'none'`, `script-src 'self'`, `connect-src 'self'`,
- *     `frame-ancestors 'self'`, `base-uri 'none'`, `form-action 'none'`), and
- *     the extension allowlist has no `.css`.
+ *   - The plugin grant model is REAL and deny-by-default: `ctx.services`,
+ *     `ctx.http`, `ctx.secrets`, `ctx.llm`, `ctx.mcp`, `ctx.memory`, public
+ *     paths and the rest are all manifest-declared and operator-consented.
+ *     The UI frame walks around that model once it rides the operator's
+ *     `Path=/` admin session. What makes this acceptable today is not that the
+ *     frame already had that grant, but that the plugin's SERVER half is
+ *     loaded by a bare in-process dynamic import with the host's `globalThis`
+ *     and `process.env`. Against a malicious plugin author the grant model is
+ *     a consent-and-contract seam, not a Node isolation boundary. The honest
+ *     residual exposure is different: a compromised browser-only dependency or
+ *     XSS in the plugin UI now inherits the operator's admin surface.
+ *   - What still constrains the bundle is the RESPONSE, not the attribute:
+ *     core serves it under a tight runtime CSP (`default-src 'none'`,
+ *     `script-src 'self'`, `connect-src 'self'`, `frame-ancestors 'self'`,
+ *     `base-uri 'none'`, `form-action 'none'`). Ingest scanning of the UI
+ *     bundle is narrower: it reads `.js` / `.mjs` only for arbitrary Tailwind
+ *     values; inline script, `javascript:` URLs and `<base>` are blocked at
+ *     runtime by that CSP, and the extension allowlist has no `.css`.
+ *
+ * The sandbox attribute itself is not an enforceable boundary once
+ * `allow-same-origin` is granted: a same-origin bundle can reach
+ * `window.frameElement`, strip `sandbox`, and reload. It remains as an intent
+ * marker for a non-adversarial bundle, not as a claim of isolation.
  *
  * `allow-popups` is deliberately GONE: nothing in a plugin UI opens a window,
  * and a capability nothing uses is only a surface.

--- a/web-ui/app/plugin-ui/[pluginId]/_components/PluginUiFrame.tsx
+++ b/web-ui/app/plugin-ui/[pluginId]/_components/PluginUiFrame.tsx
@@ -25,11 +25,29 @@ import { useLocale, useTranslations } from 'next-intl';
  * MutationObserver re-reads it, so flipping the appearance in the header
  * updates the embedded UI without a reload.
  *
- * SANDBOX. `allow-scripts allow-forms allow-popups` and NOT
- * `allow-same-origin`: the bundle is third-party code and this keeps it out
- * of the operator's cookies and localStorage on our origin. A plugin needing
- * authenticated calls does them from its own backend router, which is where
- * its authentication lives anyway.
+ * SANDBOX — `allow-same-origin allow-scripts allow-forms`. This is a trust-
+ * model decision, not a default; the reasoning is recorded in
+ * `plan.md` §4.3a addendum in the epic #470 spec directory. In short:
+ *
+ *   - WITHOUT `allow-same-origin` the document gets an OPAQUE origin. Every
+ *     `fetch('/bot-api/...')` then leaves with `Origin: null` and is a
+ *     cross-site request, so the `SameSite=Lax` session cookie is not
+ *     attached, `EventSource(..., { withCredentials: true })` fails the same
+ *     way, and `localStorage` throws. A data-driven plugin UI opens every
+ *     screen with a GET, so the sandbox did not isolate the plugin — it broke
+ *     it, silently, into a correctly-themed error state.
+ *   - It bought no privilege either. The plugin's server half already runs
+ *     in-process in the middleware with the operator's authority. Denying its
+ *     UI a session the plugin can read server-side removes function, not
+ *     capability.
+ *   - What still constrains the bundle is the response, not the attribute:
+ *     core serves it from an ingest-scanned ZIP under a tight CSP
+ *     (`default-src 'none'`, `script-src 'self'`, `connect-src 'self'`,
+ *     `frame-ancestors 'self'`, `base-uri 'none'`, `form-action 'none'`), and
+ *     the extension allowlist has no `.css`.
+ *
+ * `allow-popups` is deliberately GONE: nothing in a plugin UI opens a window,
+ * and a capability nothing uses is only a surface.
  */
 
 type Theme = 'light' | 'dark';
@@ -98,7 +116,7 @@ export function PluginUiFrame({ pluginId }: { pluginId: string }): React.ReactEl
       src={src}
       title={t('frameTitle', { pluginId })}
       className="h-full w-full rounded-md border border-border bg-bg"
-      sandbox="allow-scripts allow-forms allow-popups"
+      sandbox="allow-same-origin allow-scripts allow-forms"
       referrerPolicy="no-referrer"
       loading="lazy"
     />

--- a/web-ui/app/plugin-ui/[pluginId]/_components/__tests__/PluginUiFrame.test.tsx
+++ b/web-ui/app/plugin-ui/[pluginId]/_components/__tests__/PluginUiFrame.test.tsx
@@ -56,7 +56,11 @@ describe('<PluginUiFrame /> — sandbox', () => {
     expect(tokens).not.toContain('allow-popups');
   });
 
-  it('does not grant top-level navigation, downloads or modals', () => {
+  it('withholds top-level navigation, downloads or modals as intent, not as an enforceable boundary', () => {
+    // With `allow-same-origin` plus `allow-scripts`, a bundle can reach
+    // `window.frameElement`, strip the attribute and reload. This pins what we
+    // ASK for on the iframe element, not what the browser will enforce against
+    // an adversarial same-origin bundle.
     const tokens = frame().getAttribute('sandbox')?.split(' ') ?? [];
     for (const capability of [
       'allow-top-navigation',

--- a/web-ui/app/plugin-ui/[pluginId]/_components/__tests__/PluginUiFrame.test.tsx
+++ b/web-ui/app/plugin-ui/[pluginId]/_components/__tests__/PluginUiFrame.test.tsx
@@ -1,0 +1,95 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { renderWithIntl } from '../../../../_lib/test-utils';
+import { PluginUiFrame } from '../PluginUiFrame';
+
+/**
+ * Epic #470 C8b — the sandbox that made every authenticated call fail.
+ *
+ * The frame shipped as `allow-scripts allow-forms allow-popups`, deliberately
+ * WITHOUT `allow-same-origin`. A sandbox without `allow-same-origin` gives the
+ * document an OPAQUE origin, and an opaque origin is not our origin:
+ *
+ *   - every `fetch('/bot-api/…')` leaves with `Origin: null`, cross-site;
+ *   - `SameSite=Lax` on the session cookie — the posture core actually ships —
+ *     therefore refuses to attach it;
+ *   - `EventSource(url, { withCredentials: true })` has the same problem;
+ *   - `localStorage` throws outright.
+ *
+ * A data-driven plugin UI opens every screen with a GET, so the result was a
+ * correctly-styled, correctly-themed, correctly-translated shell showing an
+ * error state on every screen. The trust-model decision and its reasoning are
+ * in `plan.md` §4.3a addendum in the epic #470 spec directory; this test pins
+ * the attribute the decision produced.
+ *
+ * These assertions are exact-value, not `toContain`. `allow-popups` creeping
+ * back, or `allow-same-origin` being dropped again by someone applying a
+ * generic "never combine these two" rule, must both fail here.
+ */
+
+const SANDBOX = 'allow-same-origin allow-scripts allow-forms';
+
+function frame(): HTMLIFrameElement {
+  const { container } = renderWithIntl(<PluginUiFrame pluginId="@omadia/example-ui" />);
+  const el = container.querySelector('iframe');
+  if (!el) throw new Error('no iframe rendered');
+  return el;
+}
+
+describe('<PluginUiFrame /> — sandbox', () => {
+  it('is sandboxed AND same-origin, in exactly that shape', () => {
+    expect(frame().getAttribute('sandbox')).toBe(SANDBOX);
+  });
+
+  it('grants same-origin, which is what lets the session cookie travel', () => {
+    const tokens = frame().getAttribute('sandbox')?.split(' ') ?? [];
+    expect(tokens).toContain('allow-same-origin');
+  });
+
+  it('does not grant allow-popups', () => {
+    // Nothing in a plugin UI needs to open a window, and a granted capability
+    // that nothing uses is only a surface.
+    const tokens = frame().getAttribute('sandbox')?.split(' ') ?? [];
+    expect(tokens).not.toContain('allow-popups');
+  });
+
+  it('does not grant top-level navigation, downloads or modals', () => {
+    const tokens = frame().getAttribute('sandbox')?.split(' ') ?? [];
+    for (const capability of [
+      'allow-top-navigation',
+      'allow-top-navigation-by-user-activation',
+      'allow-downloads',
+      'allow-modals',
+      'allow-pointer-lock',
+      'allow-presentation',
+      'allow-orientation-lock',
+    ]) {
+      expect(tokens).not.toContain(capability);
+    }
+  });
+
+  it('sources the bundle from core’s own origin under the plugin prefix', () => {
+    // Same-origin is a property of the URL as much as of the sandbox: a
+    // scheme-relative or absolute src would re-open the cross-origin hole from
+    // the other side, and the sandbox attribute alone would not show it.
+    const src = frame().getAttribute('src') ?? '';
+    expect(src.startsWith('/p/')).toBe(true);
+    expect(src).toContain(`/p/${encodeURIComponent('@omadia/example-ui')}/ui/index.html`);
+  });
+
+  it('states the trust model where the attribute is written', () => {
+    // The previous comment asserted an isolation the attribute did not deliver
+    // and pointed at a workaround that could not work. A wrong rationale next
+    // to a security attribute is worse than none, so the file must carry the
+    // decision it now implements.
+    const source = readFileSync(
+      path.resolve(__dirname, '../PluginUiFrame.tsx'),
+      'utf-8',
+    );
+    expect(source).toContain('allow-same-origin');
+    expect(source).toMatch(/§4\.3a/);
+  });
+});

--- a/web-ui/app/plugin-ui/[pluginId]/page.tsx
+++ b/web-ui/app/plugin-ui/[pluginId]/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { getTranslations } from 'next-intl/server';
 
+import { isValidPluginId } from '@/app/_lib/pluginId';
+
 import { PluginUiFrame } from './_components/PluginUiFrame';
 
 /**
@@ -26,9 +28,6 @@ import { PluginUiFrame } from './_components/PluginUiFrame';
  * reachable from a nav contribution while `//evil.example` is not.
  */
 
-/** Mirrors the plugin-id charset gate in `manifestLoader`. */
-const PLUGIN_ID = /^[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?$/;
-
 export async function generateMetadata({
   params,
 }: {
@@ -48,7 +47,15 @@ export default async function PluginUiPage({
   // Rejected here rather than passed on: an id outside the charset can never
   // resolve to a package, and refusing it keeps a malformed value out of the
   // iframe URL entirely.
-  if (!PLUGIN_ID.test(pluginId)) notFound();
+  //
+  // The gate lives in `_lib/pluginId.ts` and is pinned by test to the
+  // middleware definition it claims to mirror. The version that shipped with
+  // C8 declared the same intention in a comment and then omitted the optional
+  // `@scope/`, so `@omadia/example-ui` — the id of the very plugin this
+  // route was built for, and the shape of every omadia plugin id — was
+  // rejected here. Next hands us the DECODED segment, so the value compared is
+  // `@omadia/example-ui`, not its percent-encoded form.
+  if (!isValidPluginId(pluginId)) notFound();
 
   const t = await getTranslations('pluginUi');
 

--- a/web-ui/scripts/__tests__/pluginUiVocabulary.test.ts
+++ b/web-ui/scripts/__tests__/pluginUiVocabulary.test.ts
@@ -1,0 +1,286 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Doc ↔ source ↔ artifact parity for the plugin UI vocabulary (epic #470 C8b).
+ *
+ * THE FAILURE THIS EXISTS FOR. Tailwind's `@source inline()` expands BRACES.
+ * A top-level comma is not a list separator, so
+ *
+ *     @source inline("border,border-{0,2,4}");
+ *
+ * asks Tailwind for three classes literally named `border,border-0`,
+ * `border,border-2`, `border,border-4` — none of which exist, so the
+ * declaration emits NOTHING. Three declarations were written that way
+ * (`border`, `divide-*`, `transition*`), and the neighbouring ones use the
+ * empty-alternative brace form (`rounded{,-none,-sm}`), which is what made it
+ * invisible on review.
+ *
+ * It is worse than a missing utility. Tailwind's base reset is
+ * `border: 0 solid`, so `class="border border-border"` — the most common
+ * pairing in a ported page — set a colour on a ZERO-WIDTH border and rendered
+ * invisible. No error, no warning, nothing in any build: exactly the silent-
+ * unstyled failure the whole no-arbitrary-values contract exists to prevent,
+ * sitting inside the artifact that enforces it.
+ *
+ * Two checks, deliberately in opposite directions:
+ *
+ *   1. SOURCE → ARTIFACT. Every class a `@source inline(...)` declaration
+ *      claims must be in the generated sheet. Generic: it catches any
+ *      declaration that silently emits nothing, not just this comma bug.
+ *   2. DOC → ARTIFACT. Every class `plugin-ui-vocabulary.md` promises must be
+ *      in the generated sheet. The document is the contract plugin authors
+ *      read; a promise the artifact does not keep is a class that renders
+ *      unstyled on an operator's screen and nowhere else.
+ *
+ * Both read the COMMITTED artifact rather than regenerating, because the
+ * committed bytes are what middleware serves.
+ */
+
+const WEB_UI_ROOT = path.resolve(__dirname, '../..');
+const REPO_ROOT = path.resolve(WEB_UI_ROOT, '..');
+
+const SOURCE_CSS = path.join(WEB_UI_ROOT, 'scripts/plugin-ui.source.css');
+const ARTIFACT_CSS = path.join(
+  REPO_ROOT,
+  'middleware/assets/plugin-ui/plugin-ui.css',
+);
+const VOCABULARY_DOC = path.join(
+  REPO_ROOT,
+  'specs/470-dev-platform-plugin/plugin-ui-vocabulary.md',
+);
+
+/**
+ * Tailwind's brace expansion: `a{,-b}` → `a`, `a-b`; `p-{0..2}` → `p-0`,
+ * `p-1`, `p-2`; multiple groups cross-multiply. Nested groups are handled by
+ * recursion. Anything unbalanced throws rather than silently expanding to
+ * something plausible.
+ */
+function expandBraces(pattern: string): string[] {
+  const open = pattern.indexOf('{');
+  if (open === -1) return [pattern];
+
+  let depth = 0;
+  let close = -1;
+  for (let i = open; i < pattern.length; i += 1) {
+    if (pattern[i] === '{') depth += 1;
+    else if (pattern[i] === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        close = i;
+        break;
+      }
+    }
+  }
+  if (close === -1) throw new Error(`unbalanced brace group: ${pattern}`);
+
+  const head = pattern.slice(0, open);
+  const body = pattern.slice(open + 1, close);
+  const tail = pattern.slice(close + 1);
+
+  const alternatives: string[] = [];
+  let nested = 0;
+  let current = '';
+  for (const ch of body) {
+    if (ch === '{') nested += 1;
+    if (ch === '}') nested -= 1;
+    if (ch === ',' && nested === 0) {
+      alternatives.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  alternatives.push(current);
+
+  const out: string[] = [];
+  for (const alternative of alternatives) {
+    const range = alternative.match(/^(\d+)\.\.(\d+)$/);
+    if (range) {
+      for (let n = Number(range[1]); n <= Number(range[2]); n += 1) {
+        out.push(...expandBraces(`${head}${n}${tail}`));
+      }
+    } else {
+      out.push(...expandBraces(`${head}${alternative}${tail}`));
+    }
+  }
+  return out;
+}
+
+/**
+ * The document's prefix-alternation shorthand, which the CSS source does not
+ * have: `w-/h-{full,auto}` and `p-/px-/py-{0..2}` list several complete
+ * prefixes; `shrink-0/1` lists several suffixes off one stem.
+ */
+function expandSlash(pattern: string): string[] {
+  const brace = pattern.indexOf('{');
+  const head = brace === -1 ? pattern : pattern.slice(0, brace);
+  const tail = brace === -1 ? '' : pattern.slice(brace);
+  if (!head.includes('/')) return [pattern];
+
+  const parts = head.split('/');
+  const first = parts[0] ?? '';
+  const stem = first.slice(0, first.lastIndexOf('-') + 1);
+  return parts.map((part, index) => {
+    const complete = index === 0 || part.endsWith('-') || part.includes('-');
+    return (complete ? part : stem + part) + tail;
+  });
+}
+
+/**
+ * Expand one documented pattern. Throws on notation the expander does not
+ * understand — an ellipsis (`xs…7xl`) is a promise nothing can check, so the
+ * document must spell the list out. Loud beats silently-skipped: a pattern
+ * quietly dropped here is a class nobody verifies.
+ */
+function expandDocPattern(pattern: string): string[] {
+  if (/[…]/.test(pattern)) {
+    throw new Error(
+      `un-expandable vocabulary pattern ${JSON.stringify(pattern)} — ` +
+        'write the alternatives out in full rather than eliding them',
+    );
+  }
+  return expandSlash(pattern).flatMap(expandBraces);
+}
+
+/** Every class name that has at least one rule in the generated stylesheet. */
+function classesInArtifact(): ReadonlySet<string> {
+  const css = readFileSync(ARTIFACT_CSS, 'utf-8');
+  const present = new Set<string>();
+  // Selectors escape `:` and `.` with a backslash (`.hover\:bg-accent`);
+  // unescape so the set is keyed by the class name an author would write.
+  for (const match of css.matchAll(/\.((?:\\.|[A-Za-z0-9_-])+)/g)) {
+    present.add((match[1] ?? '').replace(/\\(.)/g, '$1'));
+  }
+  return present;
+}
+
+const codeSpans = (line: string): string[] =>
+  [...line.matchAll(/`([^`\n]+)`/g)].map((m) => m[1] ?? '');
+
+describe('plugin UI vocabulary — source ↔ artifact', () => {
+  it('emits every class the source declares', () => {
+    const present = classesInArtifact();
+    const source = readFileSync(SOURCE_CSS, 'utf-8');
+
+    const broken: string[] = [];
+    let declared = 0;
+
+    source.split('\n').forEach((line, index) => {
+      const match = line.match(/^@source\s+inline\("([^"]*)"\);/);
+      if (!match) return;
+      const declaration = match[1] ?? '';
+      const classes = expandBraces(declaration);
+      declared += classes.length;
+      const missing = classes.filter((c) => !present.has(c));
+      if (missing.length > 0) {
+        broken.push(
+          `  line ${index + 1}: @source inline("${declaration}")\n` +
+            `      emits nothing for ${missing.length}/${classes.length}: ` +
+            `${missing.slice(0, 5).join(' ')}${missing.length > 5 ? ' …' : ''}`,
+        );
+      }
+    });
+
+    // A floor, so a regex that stops matching degenerates into a red test
+    // rather than a green one that checks nothing.
+    expect(declared).toBeGreaterThan(600);
+    expect(
+      broken.join('\n'),
+      'A declaration produced no CSS. The usual cause is a TOP-LEVEL COMMA: ' +
+        '`@source inline()` expands braces only, so "a,b-{1,2}" asks for classes ' +
+        'literally named "a,b-1". Write "a{,-b}" or "{a,b}-{1,2}" instead, then ' +
+        'rerun `npm run plugin-ui:css`.',
+    ).toBe('');
+  });
+});
+
+describe('plugin UI vocabulary — doc ↔ artifact', () => {
+  it('emits every class plugin-ui-vocabulary.md promises', () => {
+    const present = classesInArtifact();
+    const doc = readFileSync(VOCABULARY_DOC, 'utf-8');
+
+    const from = doc.indexOf('## The vocabulary');
+    const to = doc.indexOf('### Baseline element styling');
+    expect(from, 'vocabulary section heading moved').toBeGreaterThan(-1);
+    expect(to, 'baseline-styling heading moved').toBeGreaterThan(from);
+
+    const promised = new Set<string>();
+    for (const raw of doc.slice(from, to).split('\n')) {
+      const line = raw.trim();
+      if (line === '') continue;
+
+      if (line.startsWith('|')) {
+        // A table separator row (`|---|---|`) carries no classes.
+        if (/^\|[\s:|-]+\|$/.test(line)) continue;
+      } else {
+        // A prose line is only a vocabulary list when nothing but code spans
+        // and separators survives. That is what keeps the Colour section's
+        // "`bg-blue-500` does not exist" out of the promised set.
+        const residue = line.replace(/`[^`\n]+`/g, '');
+        if (!/^[\s·+()]*$/.test(residue)) continue;
+      }
+
+      const spans = codeSpans(line);
+      if (spans.length === 0) continue;
+
+      // Three kinds of span share a row: a bare variant (`hover:`), a bare
+      // prefix (`bg-`, from the Colour table's own column), and a pattern.
+      const variants = spans.filter((s) => /^[a-z-]+:$/.test(s));
+      const prefixes = spans.filter((s) => s.endsWith('-'));
+      const patterns = spans.filter(
+        (s) => !variants.includes(s) && !prefixes.includes(s),
+      );
+
+      const base =
+        prefixes.length > 0
+          ? prefixes.flatMap((prefix) =>
+              patterns.flatMap((pattern) => expandDocPattern(prefix + pattern)),
+            )
+          : patterns.flatMap((pattern) => expandDocPattern(pattern));
+
+      for (const cls of base) {
+        promised.add(cls);
+        for (const variant of variants) promised.add(variant + cls);
+      }
+    }
+
+    expect(promised.size).toBeGreaterThan(600);
+
+    const missing = [...promised].filter((c) => !present.has(c)).sort();
+    expect(
+      missing,
+      'The document promises classes the generated stylesheet does not contain. ' +
+        'An author who follows the doc writes a class that does nothing, silently. ' +
+        'Fix web-ui/scripts/plugin-ui.source.css (or the doc, if the promise was ' +
+        'wrong), then rerun `npm run plugin-ui:css`.',
+    ).toEqual([]);
+  });
+
+  it('promises the utilities whose absence made the ported pages render unstyled', () => {
+    // Pinned by name: these three groups are the reported defect, and a
+    // regression in any of them must name itself rather than arriving as one
+    // line in a 700-element diff.
+    const present = classesInArtifact();
+    for (const cls of [
+      'border',
+      'border-0',
+      'border-2',
+      'border-4',
+      'divide-y',
+      'divide-x',
+      'transition',
+      'transition-none',
+      'transition-all',
+      'transition-colors',
+      'transition-opacity',
+      'transition-transform',
+    ]) {
+      expect(present.has(cls), `${cls} missing from the generated stylesheet`).toBe(
+        true,
+      );
+    }
+  });
+});

--- a/web-ui/scripts/plugin-ui.source.css
+++ b/web-ui/scripts/plugin-ui.source.css
@@ -332,25 +332,25 @@
    No Tailwind palette, no arbitrary hexes. This is what makes "plugins
    inherit the design system by construction" true rather than aspirational. */
 @source inline("{hover:,focus:,}bg-{bg,bg-soft,bg-elevated,surface,accent,accent-hover,accent-subtle,danger,success,warning}");
-@source inline("bg-transparent");
+@source inline("{hover:,focus:,}bg-transparent");
 @source inline("{hover:,focus:,}text-{fg,fg-strong,fg-muted,fg-subtle,accent,accent-hover,danger,success,warning,bg}");
 @source inline("{hover:,focus:,}border-{border,border-strong,accent,danger,success,warning,transparent}");
 @source inline("{hover:,}decoration-{accent,fg-muted}");
 
 /* --- Borders / shape ---------------------------------------------------- */
-@source inline("border,border-{0,2,4}");
+@source inline("border{,-0,-2,-4}");
 @source inline("border-{t,r,b,l}");
 @source inline("border-{solid,dashed,dotted,none}");
 @source inline("rounded{,-none,-sm,-md,-lg,-xl,-full}");
 @source inline("shadow{,-none,-sm,-md,-lg}");
-@source inline("divide-y,divide-x");
+@source inline("divide-{y,x}");
 
 /* --- Interaction / state ------------------------------------------------ */
 @source inline("{hover:,focus:,}opacity-{0,25,50,60,75,100}");
 @source inline("cursor-{pointer,default,not-allowed,wait,text}");
 @source inline("select-{none,text,all}");
 @source inline("pointer-events-{none,auto}");
-@source inline("transition,transition-{none,all,colors,opacity,transform}");
+@source inline("transition{,-none,-all,-colors,-opacity,-transform}");
 @source inline("duration-{75,100,150,200,300,500}");
 @source inline("ease-{linear,in,out,in-out}");
 @source inline("animate-{none,spin,pulse}");

--- a/web-ui/vitest.config.ts
+++ b/web-ui/vitest.config.ts
@@ -17,7 +17,11 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
-    include: ['app/**/*.{test,spec}.{ts,tsx}'],
+    // `scripts/` is in scope for the generated-artifact parity checks (epic
+    // #470 C8b): the plugin UI stylesheet's source lives there, and the test
+    // that pins it to the committed artifact and to the vocabulary document
+    // belongs next to it rather than inside `app/`.
+    include: ['app/**/*.{test,spec}.{ts,tsx}', 'scripts/**/*.{test,spec}.{ts,tsx}'],
     globals: true,
     // vitest's default is 5000ms, which sits BELOW the honest runtime of the
     // heavier React Testing Library suites here — the template-proposal and

--- a/web-ui/vitest.setup.ts
+++ b/web-ui/vitest.setup.ts
@@ -9,3 +9,22 @@ if (!('ResizeObserver' in globalThis)) {
     disconnect(): void {}
   };
 }
+
+// jsdom DECLARES matchMedia but leaves it unimplemented, so `'matchMedia' in
+// window` is true while the value is not callable — check callability. A
+// component that reads the OS colour
+// scheme (PluginUiFrame) throws on mount without it. Reports "light" so a test
+// asserting appearance-dependent output has a stated default rather than an
+// implicit one; a test that cares can override `window.matchMedia` itself.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener(): void {},
+    removeEventListener(): void {},
+    addListener(): void {},
+    removeListener(): void {},
+    dispatchEvent: () => false,
+  })) as typeof window.matchMedia;
+}


### PR DESCRIPTION
Fixes three defects in the C8 plugin-UI host (#784), all found while porting the first real plugin SPA in [byte5ai/omadia-dev-platform#3](https://github.com/byte5ai/omadia-dev-platform/pull/3). Each fails **silently** rather than loudly, which is why C8 shipped green.

Part of epic #470, capability gap G7.

---

## 1. The sandbox made every authenticated call cross-origin

`PluginUiFrame.tsx` set `sandbox="allow-scripts allow-forms allow-popups"` — `allow-same-origin` withheld deliberately, to keep "third-party code" out of the operator's cookies, with the note that a plugin needing authenticated calls does them from its own backend router.

The first half was sound. The second half does not follow. A sandbox without `allow-same-origin` gives the document an **opaque origin**, and the plugin's own backend router is still reached over HTTP *from inside that document*:

- every `fetch('/bot-api/v1/...')` leaves with `Origin: null` and is a cross-site request;
- our session cookie is `SameSite=Lax`, so it is **not attached**;
- `EventSource(url, { withCredentials: true })` — the live job-event tail — fails identically;
- `localStorage` throws outright.

The ported SPA is entirely data-driven: all four screens open with a `GET`. So the host page rendered a correctly-styled, correctly-themed, correctly-translated shell showing an **error state on every screen**. Neither repo's suite caught it — both stub `fetch`, and a stub has no origin. This is a property of the browser, not of the client.

### Decision: sandboxed but same-origin

```
sandbox="allow-same-origin allow-scripts allow-forms"
```

Three arguments, in order of weight:

1. **It grants the plugin no privilege it does not already hold.** The plugin's server half runs *in-process* in the middleware with `ctx.services`, its own router and the operator's authority. A plugin that wanted the operator's session could read it server-side today. Withholding it from the plugin's *UI* removed function, not capability.
2. **The threat model the sandbox implied is not the one we have.** Denying same-origin only helps if the UI bundle is less trusted than the server code. Both ship in the *same* ZIP through the *same* ingest, scanned by the *same* checks. There is no trust gradient between them to enforce.
3. **What confines the bundle is the response, not the attribute** — and that is unchanged and tight: `default-src 'none'; script-src 'self'; connect-src 'self'; form-action 'none'; base-uri 'none'; frame-ancestors 'self'`, served from an extension allowlist with no `.css` in it.

`allow-popups` is **dropped** — nothing in a plugin UI opens a window, and a granted capability nothing uses is only a surface.

The familiar objection ("`allow-scripts` + `allow-same-origin` lets the frame remove its own sandbox") is true and, here, empty: the frame is already same-origin and already has the session. There is nothing left to escalate to. The sandbox is retained for what it still denies — top-level navigation, downloads, modals, pointer lock, presentation.

### The alternatives, and why not

| Alternative | Why rejected |
|---|---|
| Keep the opaque origin; core proxies the plugin API with permissive CORS | `Access-Control-Allow-Origin: null` matches **every** opaque origin on the internet — a weaker boundary than the one it replaces. The other route to the same place, `SameSite=None; Secure`, weakens authentication **product-wide** to serve one iframe. |
| Serve bundles from a distinct origin, treat plugins as genuinely third-party | The clean answer, and the recorded upgrade path. Needs a second hostname, its own TLS and a cross-origin auth story on **every** install target (Docker, Fly, Render, bare VM). Disproportionate while plugins are operator-installed from a curated hub. |

Written up in `specs/470-dev-platform-plugin/plan.md` **§4.3a addendum**.

---

## 2. The host page rejected every scoped plugin id

```ts
/** Mirrors the plugin-id charset gate in `manifestLoader`. */
const PLUGIN_ID = /^[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?$/;
```

It did not mirror it. `manifestLoader.ts` blesses an optional `@scope/`, and **every** omadia plugin id is scoped — so `/plugin-ui/@omadia/...` called `notFound()` on the only id shape those packages can have. The nav entry a plugin registers landed on a 404. The comment was the whole enforcement, and a comment cannot fail.

The gate now lives in `web-ui/app/_lib/pluginId.ts` and covers **both** halves of the middleware rule (214-char cap, then charset). It is not imported from middleware — web-ui is a separate Next build that depends on no middleware package, and the epic's constraint 2 pushes dependencies the other way — so instead it is **pinned by test**: `pluginId.test.ts` reads `manifestLoader.ts` and asserts the pattern and the cap are character-identical. Drift now fails a test instead of a screen. A re-introduced local regex in `page.tsx` fails too.

Path-traversal safety is asserted rather than assumed: a valid id's only `/` is the scope separator and no segment may begin with `.`, so `..` is structurally unreachable — covered by tests, alongside the percent-encoded round-trip (`%40omadia%2F…` → decoded by Next → accepted).

---

## 3. `border`, `divide-*` and `transition*` emitted nothing

`@source inline()` expands **braces**. A top-level comma is not a list separator, so

```css
@source inline("border,border-{0,2,4}");
```

asked Tailwind for classes literally named `border,border-0` — and produced **zero** CSS. Three declarations were written that way; the neighbours use the empty-alternative brace form (`rounded{,-none,-sm}`), which is what made it invisible on review. Meanwhile `plugin-ui-vocabulary.md` listed all three groups as available, so the document and the sheet disagreed.

Worse than a missing utility: Tailwind's reset is `border: 0 solid`, so `class="border border-border"` — the most common pairing in the ported pages, 27 occurrences — set a colour on a **zero-width** border and rendered **invisible**. No error, no warning, nothing in any build. Exactly the silent-unstyled failure the no-arbitrary-values contract exists to prevent, sitting inside the artifact that enforces it.

A fourth disagreement surfaced from the new parity test: the doc promises `hover:`/`focus:` on `bg-transparent`, and the source declared it without variants. The source line now declares them.

Artifact regenerated: **69,559 → 72,659 B raw**, 12,105 → 12,486 B gzip (+381 B), 9,208 → 9,556 B brotli.

---

## Tests — every one of them fails against the parent commit

```
× emits every class the source declares
    line 341: @source inline("border,border-{0,2,4}")
        emits nothing for 3/3: border,border-0 border,border-2 border,border-4
    line 346: @source inline("divide-y,divide-x")
        emits nothing for 1/1: divide-y,divide-x
    line 353: @source inline("transition,transition-{none,all,colors,opacity,transform}")
        emits nothing for 5/5: transition,transition-none …
× emits every class plugin-ui-vocabulary.md promises   (14 missing)
× promises the utilities whose absence made the ported pages render unstyled
× is sandboxed AND same-origin, in exactly that shape
× grants same-origin, which is what lets the session cookie travel
× does not grant allow-popups
× sources the bundle from core's own origin under the plugin prefix
```

- **`web-ui/scripts/__tests__/pluginUiVocabulary.test.ts`** — parity in **both** directions: every class the source declares, and every class the document promises, must exist in the committed sheet. The source→artifact half is generic: it catches *any* declaration that silently emits nothing, not just this comma bug. The expander **refuses** notation it cannot expand rather than skipping it, so a promise cannot go unchecked — which is why the doc's `xs…7xl` ellipsis is now written out and the Responsive prose became a table.
- **`PluginUiFrame.test.tsx`** — pins the sandbox to its **exact** string (so both dropping `allow-same-origin` again and re-adding `allow-popups` go red) and pins the `src` to core's own origin, since same-origin is a property of the URL as much as of the attribute.
- **`middleware/test/pluginUiFrameCredentials.test.ts`** — proves the posture the decision rests on: the session cookie is `SameSite=Lax; Path=/; HttpOnly` and **not** `SameSite=None`; a same-origin request replaying it authenticates, while the same request without it 401s (mutation guard); and the served document still carries `connect-src 'self'`, `frame-ancestors 'self'`, `base-uri 'none'`, `form-action 'none'`.
- **`pluginId.test.ts`** — the pin to `manifestLoader.ts`, the scoped/unscoped/FQDN cases, the traversal shapes, the 214-char boundary, the encode/decode round-trip.

`vitest.config.ts` now includes `scripts/**` so the artifact-parity test can live next to the source it guards; `vitest.setup.ts` gains a `matchMedia` stub (jsdom declares the property but leaves it uncallable, so `'matchMedia' in window` was true and the value was not a function).

## Verification

| Check | Result |
|---|---|
| `web-ui` lint | 0 errors (47 pre-existing warnings, none in changed files) |
| `web-ui` typecheck | pass |
| `web-ui` vitest | **778 passed / 91 files** |
| `web-ui` build | pass |
| `plugin-ui:css:check` (drift) | up to date, 72,659 bytes |
| `web-ui` i18n:check | OK — 3,848 keys, en + de (no new UI text added) |
| `middleware` build | pass |
| `middleware` typecheck | pass |
| `middleware` typecheck:test | ratchet held at 406 |
| `middleware` lint | pass |
| `middleware` tests (auth + plugin + manifest + plugin-ui) | **375 passed** |
| `scripts/check-core-decoupling.mjs` | **held at 3300** (baseline) |

The decoupling ratchet earned its keep here: the first draft of these tests hardcoded the extracted plugin's own id and pushed the count 3300 → 3318. They now use a neutral `@omadia/example-ui`, which tests the same property — "a *scoped* id resolves" — without core naming the package being extracted.

## What is still not verified

Rendering in a real browser. That row stayed open in the plugin repo's own honesty table and it stays open here: this PR removes the two core-side blockers, but only a real browser against a real host page closes it. That belongs with the plugin PR once this lands.

---

## Cross-family review (Forge)

Adversarial review by an OpenAI-family model (GPT-5.4, `reasoning_effort=high`) against the
Anthropic-family work in this PR, to surface shared-lineage blind spots. Scope: the four questions
the frame change raises — same-origin reach, CSP/ingest confinement, encoded-slash routing, and
whether the new tests kill their mutants.

**Verdict: the code is right; the rationale was wrong.** Nothing in the behaviour of this PR is
reverted. Three of its load-bearing security claims were false or overstated, and the corrections
plus their tripwires are pushed onto this branch.

### Findings

| # | Severity | Finding | Disposition |
|---|---|---|---|
| 1 | **High** | The premise "it gives the plugin no privilege it does not already hold" is **false**. The server-side plugin contract is genuinely deny-by-default — `pluginServiceGrants.ts` throws `ServiceNotDeclaredError`; `pluginContext.ts` gates `ctx.http` / `ctx.net` / `ctx.secrets` / `ctx.memory` / `ctx.llm` / `ctx.subAgent` / `ctx.knowledgeGraph` / `ctx.mcp` / `ctx.events.emit` / `ctx.flows` on manifest permissions; `operatorAuthAccessor` exposes a **verifier**, not a bearer; and `CORE_RESERVED_ROOTS` refuses `/api/v1/admin` to a plugin *even with operator consent*. A same-origin bundle riding the `Path=/` session (JWT hardcodes `role: 'admin'`) reaches all of it, with no CSRF layer anywhere in the product to stop it. | Rationale rewritten; tripwire test added |
| 2 | Medium | "The sandbox is retained for what it still denies — top-level navigation, downloads, modals…" is **not enforceable**. With `allow-same-origin` + `allow-scripts` the bundle reaches `window.frameElement`, strips `sandbox` and reloads, regaining every one of them. | Claim corrected to "intent, not enforcement"; test renamed and commented |
| 3 | Medium | "ingest-scanned ZIP" overstates the scan. The only ingest pass over a UI bundle is the Tailwind arbitrary-value scan, which reads **`.js`/`.mjs` only** — `ui/index.html` is never opened — is bounded at 200 files / 8 MB, and does not run at all for built-in/local-dev catalog packages. Inline `<script>`, `onclick=`, `javascript:` and `<base>` are blocked by the **runtime CSP**, not by ingest. | Corrected in comment and spec |
| 4 | Low | CSP is set branch-free on every 200, but was asserted on only 3 of 11 servable extensions, and `nosniff` on 1. | Table-driven test over every `CONTENT_TYPES` entry + the 304 branch |
| 5 | — | **Encoded-slash routing: verified sound.** Probed live against a real Next 16 dev server with an echoing upstream. `%2F` inside a segment survives Next intact and `middlewareProxy.ts` re-encodes it byte-identically, so `@omadia/example-ui` reaches Express as **one** segment. The plugin id is a catalog `Map` lookup, never a filesystem join; asset paths go through `safeRelativePath` + realpath containment. `%40omadia%2F..%2F..%2Fetc%2Fpasswd` and `..%2F..%2Fmanifest.yaml` both dead-end. No traversal. | No change |
| 6 | — | **Mutation-tested the new suites: 7/7 mutants killed.** Deleting `.border{}` from the artifact reddens 3 tests; a doc promising a non-existent class reddens the doc↔artifact check; restoring the top-level comma in the source reddens the source↔artifact check; dropping `@scope/` from the pattern reddens 4; adding `allow-popups` and dropping `allow-same-origin` each redden 2. Shrinking the *doc* is deliberately unguarded — the source→artifact direction and the pinned-by-name test cover the three regression groups. | No change |
| 7 | — | No secret-reading delta: nothing credential-shaped is in `localStorage`/`sessionStorage`, and `omadia_session` is `HttpOnly` — the frame can **ride** the cookie but not **read** it. The delta is capability, not secrets. One further undocumented delta: `allow-same-origin` makes `window.top.document` writable (UI-redress inside the real operator chrome). | Documented in §4.3a |

### The honest trust model, as now recorded

The same-origin grant is defensible **not** because the plugin already had that authority, but because
plugin server code is loaded by a bare in-process dynamic import (`toolPluginRuntime.ts`) with no `vm`,
worker, child process or permission wall — sharing `globalThis` and a `process.env` that holds the
session signing key. Against a **malicious plugin author** the grant model was never a security
boundary; it is a consent-and-contract seam, and such an author can forge a session outright.
Withholding same-origin from the UI defended nothing against that actor while breaking every honest
plugin.

The residual cost is a **different** attacker: a compromised browser-only dependency or an XSS in the
plugin UI, which controls the bundle but not the server half. That attacker previously got an opaque
origin and nothing; it now inherits the operator's admin surface. That is the trade this PR makes, and
§4.3a now says so in those words rather than claiming the trade is free.

Because that reasoning rests on a premise that a future hardening pass is explicitly planned to
invalidate (`pluginContext.ts` records the intent to sandbox plugins), the premise itself is now
under test: `middleware/test/pluginUiTrustModel.test.ts` fails the day plugin server code becomes
isolated, and tells the reader to reopen the §4.3a decision and move plugin UIs to a distinct origin.
A documented trade with no test is just a comment.

### Verification of the review commit

| Check | Result |
|---|---|
| middleware plugin/auth/manifest/publicPath surface (29 files) | **438 passed / 0 failed** |
| `web-ui` vitest | **778 passed / 91 files** |
| `web-ui` typecheck · build | pass · compiled successfully |
| `web-ui` lint | 0 errors, 47 pre-existing warnings (unchanged) |
| `plugin-ui:css:check` | up to date, 72,659 bytes |
| `middleware` lint | pass |
| `middleware typecheck:test` ratchet | held at 406 |
| `check-core-decoupling.mjs` | **held at 3300** |

Mutation evidence for the new suites — each mutant reddens the test that claims to guard it:

| Mutant | Result |
|---|---|
| remove `'/api/v1/admin'` from `CORE_RESERVED_ROOTS` | trust-model tripwire 2 red |
| replace the bare `await import(...)` with a `node:vm` load | trust-model tripwire 1 red |
| flip the session JWT to `role: 'viewer'` | trust-model tripwire 4 red |
| delete `res.set('Content-Security-Policy', responseCsp)` | 15 of the table-driven serving cases red |

The PR's own suites were mutation-checked too, before any change: deleting `.border{}` from the
artifact reddens 3; a doc promising a class the sheet lacks reddens the doc↔artifact check;
restoring the top-level comma in the source reddens the source↔artifact check; dropping `@scope/`
from the pattern reddens 4; adding `allow-popups` and dropping `allow-same-origin` redden 2 each.
**7/7 killed.**

### What remains unverified

Unchanged from the original honesty note: rendering in a real browser. What this review *did* close
is the routing half of that risk — the `%2F` round-trip was probed end-to-end against a real Next 16
server, so the scoped-id fix is known to reach Express intact rather than assumed to.

**Verdict: MERGE.**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789838173&installation_model_id=428086&pr_number=793&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F793&signature=047bc33fe20a1b632d24afee393c35a89d41f97a2b600da23e550bd5fa1b54e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
