### PR TITLE
fix(install): report a failed activation as errored, not active (#470 P5)

### DIFF
--- a/middleware/src/plugins/installService.ts
+++ b/middleware/src/plugins/installService.ts
@@ -295,10 +295,32 @@ export class InstallService {
         try {
           await this.deps.onInstalled(job.plugin_id);
         } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
           console.error(
             `[install] onInstalled hook failed for ${job.plugin_id}:`,
-            err instanceof Error ? err.message : err,
+            message,
           );
+          // The registry was written `status: 'active'` a few lines above —
+          // BEFORE the hook that does the activating. Swallowing the hook's
+          // failure there left the entry claiming `active` while the plugin's
+          // own `undo()` had rolled back every route, tool and nav entry it
+          // registered: a green status over a plugin serving nothing, with the
+          // only trace a console line. Correct it here.
+          //
+          // Two writes, because they answer different questions.
+          // `markActivationFailed` records WHY and feeds
+          // `bootstrap.retryErroredPlugins`. It does not flip the status on its
+          // own — `CIRCUIT_BREAKER_THRESHOLD` is 3, which is right for a boot
+          // loop retrying a transient failure and wrong here: an install-time
+          // activation failure is a single definitive event an operator is
+          // watching, not the first of three strikes. So the status is set
+          // explicitly, and only when the entry still reads `active` (the
+          // threshold may already have done it).
+          await this.deps.registry.markActivationFailed(job.plugin_id, message);
+          const entry = this.deps.registry.get(job.plugin_id);
+          if (entry && entry.status === 'active') {
+            await this.deps.registry.register({ ...entry, status: 'errored' });
+          }
         }
       }
     } catch (err) {

--- a/middleware/test/installServiceActivationTruthful.test.ts
+++ b/middleware/test/installServiceActivationTruthful.test.ts
@@ -1,0 +1,131 @@
+/**
+ * A failed activation must not read as `active` (epic #470 P5).
+ *
+ * `completeInstall` writes `status: 'active'` to the registry BEFORE calling
+ * `onInstalled`, which is the hook that actually activates the plugin. That
+ * hook's failure used to be caught, logged to the console, and dropped — so a
+ * plugin whose `activate()` threw was left claiming `active` while its own
+ * `undo()` had rolled back every route, tool and nav entry it registered. The
+ * operator saw a green plugin serving nothing, and the only trace was one line
+ * of stderr.
+ *
+ * Found by installing the extracted dev-platform plugin: the registry answered
+ * `{"status":"active"}` while every one of its routes 404'd.
+ *
+ * The boot path has always done this correctly (`toolPluginRuntime.ts` calls
+ * `markActivationFailed`); these tests pin the install path to the same
+ * behaviour, and pin that a SUCCESSFUL install is still reported as active —
+ * without which "never report active" would pass trivially.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { adaptManifestV1 } from '../src/plugins/manifestLoader.js';
+import type {
+  PluginCatalog,
+  PluginCatalogEntry,
+} from '../src/plugins/manifestLoader.js';
+import { InstallService } from '../src/plugins/installService.js';
+import { InMemoryInstalledRegistry } from '../src/plugins/installedRegistry.js';
+import type { SecretVault } from '../src/secrets/vault.js';
+
+const MANIFEST = {
+  schema_version: '1',
+  identity: {
+    id: '@test/activation-truthful',
+    kind: 'extension',
+    domain: 'test',
+    name: 'Activation Truthful',
+    version: '0.1.0',
+  },
+  setup: { fields: [] },
+};
+
+function makeService(onInstalled: (id: string) => Promise<void>) {
+  const plugin = adaptManifestV1(MANIFEST)!;
+  const entry = {
+    plugin,
+    manifest: MANIFEST,
+    source_path: '<test>/manifest.yaml',
+    source_kind: 'manifest-v1',
+  } as unknown as PluginCatalogEntry;
+  const catalog = {
+    get: (id: string) => (id === plugin.id ? entry : undefined),
+    list: () => [entry],
+  } as unknown as PluginCatalog;
+
+  const registry = new InMemoryInstalledRegistry();
+  const vault = {
+    get: async () => undefined,
+    set: async () => {},
+    setMany: async () => {},
+    purge: async () => {},
+  } as unknown as SecretVault;
+
+  const service = new InstallService({ catalog, registry, vault, onInstalled });
+  return { service, registry, pluginId: plugin.id };
+}
+
+/** Drive a plugin through create → configure, which is where activation runs. */
+async function install(service: InstallService, pluginId: string) {
+  const job = service.create(pluginId);
+  return service.configure(job.id, {});
+}
+
+void describe('install reports activation truthfully (#470 P5)', () => {
+  void it('marks the entry errored when the onInstalled hook throws', async () => {
+    const boom = "NativeToolRegistry: duplicate native-tool name 'dev_job_start'";
+    const { service, registry, pluginId } = makeService(async () => {
+      throw new Error(boom);
+    });
+
+    await install(service, pluginId);
+
+    const entry = registry.get(pluginId);
+    assert.ok(entry, 'the plugin should still be INSTALLED — only not active');
+    assert.equal(
+      entry.status,
+      'errored',
+      'a plugin whose activation threw must not read as active',
+    );
+    assert.match(
+      String(entry.last_activation_error),
+      /duplicate native-tool name/,
+      'the hook error must be recorded, not just logged to stderr',
+    );
+  });
+
+  void it('still reports active when the hook succeeds', async () => {
+    // The inverse guard. Without it, a change that marked EVERY install errored
+    // would pass the assertion above.
+    const { service, registry, pluginId } = makeService(async () => {});
+
+    await install(service, pluginId);
+
+    const entry = registry.get(pluginId);
+    assert.ok(entry);
+    assert.equal(entry.status, 'active');
+    assert.equal(
+      entry.last_activation_error,
+      undefined,
+      'a clean install must carry no activation error',
+    );
+  });
+
+  void it('does not wait for the circuit breaker to flip the status', async () => {
+    // `markActivationFailed` alone would NOT do it: CIRCUIT_BREAKER_THRESHOLD
+    // is 3, which is right for a boot loop retrying a transient failure and
+    // wrong here. An install-time activation failure is a single definitive
+    // event an operator is watching, so ONE failure must be enough.
+    const { service, registry, pluginId } = makeService(async () => {
+      throw new Error('first and only failure');
+    });
+
+    await install(service, pluginId);
+
+    const entry = registry.get(pluginId);
+    assert.equal(entry?.activation_failure_count, 1, 'exactly one attempt');
+    assert.equal(entry?.status, 'errored', 'one failure is enough at install time');
+  });
+});


### PR DESCRIPTION
Closes #797. Found by the epic #470 **P5** acceptance run (local install of the extracted dev-platform plugin).

## The bug

`completeInstall` writes `status: 'active'` to the registry **before** calling `onInstalled` — the hook that actually activates the plugin — and then caught that hook's failure, logged it to the console, and dropped it (`installService.ts:274-306`).

So a plugin whose `activate()` threw was left claiming `active` while its own `undo()` had rolled back every route, tool and nav entry it registered. Measured during the run:

```
$ curl -b jar /api/v1/admin/runtime/installed/%40omadia%2Fdev-platform
{"id":"@omadia/dev-platform","status":"active"}

$ curl -b jar /api/v1/admin/dev-platform/jobs   → 404
$ curl -b jar /api/v1/ui/navigation             → no devPlatform entry
```

The only trace was one line of stderr:

```
[install] onInstalled hook failed for @omadia/dev-platform:
  NativeToolRegistry: duplicate native-tool name 'dev_job_start'
```

**A green status over a plugin serving nothing is worse than a red one** — it is the state an operator stops investigating.

## Why the install path and not the boot path

The boot path already does this correctly: `toolPluginRuntime.ts:230` calls `markActivationFailed`. The install path is the asymmetric one.

The asymmetry has a second-order effect: the boot loop only considers entries with `status === 'active'` (`toolPluginRuntime.ts:210-212`), so an entry that is *wrongly* `active` gets retried at boot while one honestly marked `errored` is skipped — the two paths disagree about what the same registry value means.

## The fix

Two writes, because they answer different questions:

- `markActivationFailed` records **why**, and feeds `bootstrap.retryErroredPlugins`.
- The status is then set explicitly — because `markActivationFailed` will not flip it on its own. `CIRCUIT_BREAKER_THRESHOLD` is 3, which is right for a boot loop retrying a transient failure and wrong here: an install-time activation failure is a single definitive event an operator is watching, not the first of three strikes.

Guarded with `if (entry && entry.status === 'active')`, so it does not fight the threshold when that has already flipped it.

The plugin stays **installed** — only not active. That is the truthful state, and it is what the boot path would report.

## Tests

`middleware/test/installServiceActivationTruthful.test.ts`, three cases:

1. hook throws → entry is `errored` and carries the hook's message
2. **inverse guard**: hook succeeds → entry is still `active` with no error (without this, "never report active" would pass trivially)
3. one failure is enough — pins that the fix does not wait for the circuit breaker

**Mutation-checked:** removing the status correction fails 1 and 3; 2 correctly survives.

## Not fixed here

The trigger in this particular case was a plugin-side double tool registration (fixed in `byte5ai/omadia-dev-platform#5`), but the reporting bug is independent of it — any activation throw reproduces it, because the registry write and the hook are unconditionally ordered this way.

The other five core gaps from the same run are #794, #795, #796, #798 and C12's static `publicPaths.ts` literals. Each needs a design decision rather than a patch, so they are issues, not PRs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789840521&installation_model_id=428086&pr_number=799&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F799&signature=31337e1236d5aaa8f8c6dc4b0ec3edbfa97bce1d5a98c39b92855da56ab518e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->