### PR TITLE
fix(platform): bundled plugins reach graphPool through the C7 SQL gate (#794)

### DIFF
--- a/middleware/packages/harness-memory-postgres/manifest.yaml
+++ b/middleware/packages/harness-memory-postgres/manifest.yaml
@@ -56,6 +56,26 @@ playbook:
     gleichzeitig installiert sein.
 
 permissions:
+  # Epic #470 C7 / issue #794 — this plugin holds the operator's Postgres pool
+  # (the shared `graphPool`) and owns its own tables (`memory_files`), so it
+  # must declare that intent here. Without this block the C7 gate refuses
+  # `ctx.services.get('graphPool')` and the middleware does not boot.
+  #
+  # NOTE the ledger is DECLARED BUT CURRENTLY UNUSED. `ledger` names the
+  # bookkeeping table the KERNEL's migration runner (`ctx.sql.runMigrations()`)
+  # would use. This plugin predates that runner and ships its own migrator
+  # (`src/migrator.ts`), which tracks applied files in its own
+  # `_memory_migrations` table under an advisory lock. So:
+  #   * `migrations:` is deliberately OMITTED — declaring it would tell the
+  #     kernel to scan a migrations directory this package does not ship, and
+  #     would be a false claim about who applies the schema.
+  #   * the ledger name is reserved so that the eventual cutover to core-run
+  #     migrations does not have to re-ask the operator for a different one.
+  # Moving `_memory_migrations` onto the kernel runner is follow-up work, not
+  # part of this hotfix: it is a data migration on live deployments and has no
+  # business riding along with a boot fix.
+  sql:
+    ledger: "plg_omadia_memory_postgres_migrations"
   memory:
     reads: []
     writes: []

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -776,7 +776,15 @@ async function main(): Promise<void> {
 
   const pluginCatalog = new PluginCatalog({
     extraSources: () => [
-      ...builtInPackageStore.list().map((p) => ({ packageRoot: p.path })),
+      // #794 — `bundled` is asserted HERE and nowhere else. These packages
+      // ship inside the middleware image under `middleware/packages/*`, which
+      // is what makes them eligible for the dated built-in SQL ramp in
+      // `platform/pluginSqlGrants.ts`. Uploaded and local-dev packages are
+      // deliberately left at the default `installed`: an upload must never be
+      // able to inherit a bundled plugin's ramp by claiming its id.
+      ...builtInPackageStore
+        .list()
+        .map((p) => ({ packageRoot: p.path, origin: 'bundled' as const })),
       ...uploadedPackageStore.list().map((p) => ({ packageRoot: p.path })),
       ...localDevPackageStore.list().map((p) => ({ packageRoot: p.path })),
     ],

--- a/middleware/src/platform/pluginSqlGrants.ts
+++ b/middleware/src/platform/pluginSqlGrants.ts
@@ -46,6 +46,78 @@ import {
 import type { PluginCatalog } from '../plugins/manifestLoader.js';
 
 /**
+ * The C7 ramp for BUNDLED plugins — issue #794. Dated, closed, and keyed on a
+ * question C2b's list does not answer.
+ *
+ * WHY THIS LIST HAD TO EXIST SEPARATELY
+ * ------------------------------------
+ * C7 originally borrowed `LEGACY_UNDECLARED_SERVICE_GRANTS_2026_08_20` as its
+ * ramp. That list means "this plugin did not declare the SERVICE"; C7's gate
+ * asks "this plugin did not declare `permissions.sql`". For a plugin that has
+ * done C2b's work the two sets are DISJOINT, so borrowing the list produced a
+ * rule with a perverse shape: doing the C2b migration correctly is what
+ * removed a plugin from C7's ramp. `@omadia/memory-postgres` had done exactly
+ * that, and the middleware stopped booting.
+ *
+ * The fix is not a wider gate — it is a ramp keyed on the right question. This
+ * list covers EVERY bundled `graphPool` consumer, including the four that
+ * happen to be covered by C2b's list today. That redundancy is the point: when
+ * one of them finishes its C2b migration and drops off C2b's list, it must not
+ * fall through into a boot failure the way memory-postgres did. The trap is
+ * disarmed for the whole class, not just for the plugin that sprang it.
+ *
+ * TWO PROPERTIES, BOTH LOAD-BEARING
+ * ---------------------------------
+ *  1. Consulted ONLY for `origin === 'bundled'` (see {@link
+ *     bundledSqlRampCapabilities}). An uploaded package that names itself
+ *     `@omadia/memory-postgres` inherits nothing — origin is derived by the
+ *     loader from where the package was found, never from the manifest.
+ *  2. CLOSED SET. Adding a row means a bundled plugin regressed and needs a
+ *     manifest fix plus an operator grant, not a wider gate. It retires when
+ *     the operator grant surface ships and these plugins have been granted —
+ *     `plugin_sql_grants` still has no caller of `grant()` in `src/`, which is
+ *     why `granted` cannot yet be true for anyone, which is why a ramp is
+ *     needed at all.
+ *
+ * `@omadia/channel-teams` is deliberately ABSENT: it left this repository for
+ * `byte5ai/omadia-channel-teams` and is no longer bundled, so it arrives as an
+ * installed package and stays on C2b's list. Adding it here would be a grant
+ * this repo cannot honour and a claim it cannot audit.
+ */
+export const LEGACY_SQL_GRANTS_2026_08_20: Readonly<
+  Record<string, readonly string[]>
+> = Object.freeze({
+  // Declares `permissions.sql` and `requires: graphPool@^1`, runs its own
+  // migrator (`_memory_migrations`). The one whose absence was a hard startup
+  // error — see issue #794.
+  '@omadia/memory-postgres': Object.freeze(['graphPool']),
+  // The remaining bundled pool consumers. All four are on C2b's list TODAY,
+  // so they are not currently reachable through this branch; they are listed
+  // so that finishing their C2b migration cannot break boot.
+  '@omadia/orchestrator': Object.freeze(['graphPool']),
+  '@omadia/orchestrator-extras': Object.freeze(['graphPool']),
+  '@omadia/verifier': Object.freeze(['graphPool']),
+});
+
+/**
+ * The ramp capabilities in force for one plugin — empty unless the catalog
+ * says the package is bundled.
+ *
+ * Reads `origin` from the CATALOG rather than taking a boolean parameter on
+ * purpose: a parameter is one more thing a call site can get wrong, and the
+ * catalog is where the loader already recorded the answer. A plugin the
+ * catalog cannot resolve gets no ramp — the same fail-closed reading
+ * `sqlPermissionOf` uses.
+ */
+export function bundledSqlRampCapabilities(
+  agentId: string,
+  catalog: PluginCatalog,
+): readonly string[] {
+  if (catalog.get(agentId)?.origin !== 'bundled') return [];
+  return LEGACY_SQL_GRANTS_2026_08_20[agentId] ?? [];
+}
+
+/**
  * Capabilities that hand over a raw Postgres pool.
  *
  * A CLOSED set, deliberately. The alternative — a heuristic on the name, or on
@@ -230,6 +302,7 @@ export type SqlAccessOutcome =
   | 'not-pool-shaped'
   | 'allowed'
   | 'legacy-allowlist'
+  | 'bundled-legacy'
   | 'undeclared'
   | 'ungranted';
 
@@ -243,6 +316,14 @@ export interface SqlAccessInput {
   /** True when C2b's dated legacy allowlist already covers this exact
    *  (plugin, capability) pair. */
   readonly legacy: boolean;
+  /** #794 — true when C7's OWN dated ramp covers this pair AND the catalog
+   *  says the package is bundled. Required, not optional: an optional flag
+   *  here would let a new call site inherit a default it never considered,
+   *  and every call site in this subsystem is a place where "may this plugin
+   *  touch the operator's database?" is being answered. Compute it with
+   *  {@link bundledSqlRampCapabilities}, which is the only thing that reads
+   *  the origin. */
+  readonly bundledLegacy: boolean;
 }
 
 /**
@@ -253,12 +334,18 @@ export interface SqlAccessInput {
 export function classifySqlAccess(input: SqlAccessInput): SqlAccessOutcome {
   if (!POOL_SHAPED_CAPABILITIES.has(input.capability)) return 'not-pool-shaped';
   if (input.declared && input.granted) return 'allowed';
-  // The legacy ramp is checked only AFTER the clean path fails, so a plugin
-  // that has done the work is never reported as legacy. It is checked before
-  // the denials because C2b's audit found these pairs consuming the pool
-  // today: turning them off in this PR would break shipped Hub plugins that
-  // this PR cannot edit. It expires with C2b's allowlist, not separately —
-  // one retirement date for one migration ramp.
+  // Both ramps are checked only AFTER the clean path fails, so a plugin that
+  // has done the work is never reported as legacy — otherwise a ramp could
+  // never be observed to be empty.
+  //
+  // #794: the BUNDLED ramp is checked first, because when both apply it is
+  // the more specific and more accurate reason — the plugin ships in this
+  // image, which is a stronger statement than "C2b found it undeclared", and
+  // it is the one whose warning names the right remedy.
+  if (input.bundledLegacy) return 'bundled-legacy';
+  // C2b's ramp. Checked before the denials because C2b's audit found these
+  // pairs consuming the pool today: turning them off would break shipped Hub
+  // plugins this repo cannot edit. It expires with C2b's allowlist.
   if (input.legacy) return 'legacy-allowlist';
   return input.declared ? 'ungranted' : 'undeclared';
 }
@@ -290,6 +377,10 @@ export function createSqlGate(
 ): (capability: string) => void {
   const { agentId, catalog, granted, legacyCapabilities, log } = opts;
   const declared = sqlPermissionOf(agentId, catalog);
+  // #794 — resolved from the catalog, once, at context-build time. Read here
+  // rather than threaded in as an option so there is exactly one place that
+  // decides what "bundled" means, and no call site that can assert it.
+  const bundledRamp = bundledSqlRampCapabilities(agentId, catalog);
   const warned = new Set<string>();
 
   return function assertSqlAccess(capability: string): void {
@@ -298,9 +389,19 @@ export function createSqlGate(
       declared,
       granted,
       legacy: legacyCapabilities.includes(capability),
+      bundledLegacy: bundledRamp.includes(capability),
     });
     if (outcome === 'undeclared' || outcome === 'ungranted') {
       throw new SqlPermissionError(agentId, capability, outcome);
+    }
+    if (outcome === 'bundled-legacy' && !warned.has(capability)) {
+      warned.add(capability);
+      log(
+        `[sql] bundled plugin '${agentId}' resolved the database capability '${capability}' without an operator grant — ` +
+          'allowed by the dated built-in ramp (LEGACY_SQL_GRANTS_2026_08_20). It ships inside this middleware image, so ' +
+          'installing the middleware is the consent; the ramp retires once the operator grant surface ships and these ' +
+          'plugins have been granted. A ramp is not a permission.',
+      );
     }
     if (outcome === 'legacy-allowlist' && !warned.has(capability)) {
       warned.add(capability);

--- a/middleware/src/platform/pluginSqlGrants.ts
+++ b/middleware/src/platform/pluginSqlGrants.ts
@@ -60,11 +60,12 @@ import type { PluginCatalog } from '../plugins/manifestLoader.js';
  * that, and the middleware stopped booting.
  *
  * The fix is not a wider gate — it is a ramp keyed on the right question. This
- * list covers EVERY bundled `graphPool` consumer, including the four that
- * happen to be covered by C2b's list today. That redundancy is the point: when
- * one of them finishes its C2b migration and drops off C2b's list, it must not
- * fall through into a boot failure the way memory-postgres did. The trap is
- * disarmed for the whole class, not just for the plugin that sprang it.
+ * list covers EVERY bundled `graphPool` consumer — all four of them —
+ * including the three that are ALSO covered by C2b's list today. That
+ * redundancy is the point: when one of those three finishes its C2b migration
+ * and drops off C2b's list, it must not fall through into a boot failure the
+ * way memory-postgres did. The trap is disarmed for the whole class, not just
+ * for the plugin that sprang it.
  *
  * TWO PROPERTIES, BOTH LOAD-BEARING
  * ---------------------------------
@@ -91,9 +92,10 @@ export const LEGACY_SQL_GRANTS_2026_08_20: Readonly<
   // migrator (`_memory_migrations`). The one whose absence was a hard startup
   // error — see issue #794.
   '@omadia/memory-postgres': Object.freeze(['graphPool']),
-  // The remaining bundled pool consumers. All four are on C2b's list TODAY,
-  // so they are not currently reachable through this branch; they are listed
-  // so that finishing their C2b migration cannot break boot.
+  // The remaining three bundled pool consumers. All three are on C2b's list
+  // TODAY, so they are not currently reachable through this branch; they are
+  // listed so that finishing their C2b migration cannot break boot.
+  // (@omadia/memory-postgres above is NOT on C2b's list — that is issue #794.)
   '@omadia/orchestrator': Object.freeze(['graphPool']),
   '@omadia/orchestrator-extras': Object.freeze(['graphPool']),
   '@omadia/verifier': Object.freeze(['graphPool']),

--- a/middleware/src/plugins/manifestLoader.ts
+++ b/middleware/src/plugins/manifestLoader.ts
@@ -57,12 +57,36 @@ const DEFAULT_MANIFEST_DIR =
   process.env['PLUGIN_MANIFEST_DIR'] ??
   path.join(REPO_ROOT, 'docs', 'harness-platform', 'examples');
 
+/**
+ * Where a catalog entry came from — issue #794.
+ *
+ * `bundled` means the package ships INSIDE the middleware image, under
+ * `middleware/packages/*`, and is therefore code this repository controls and
+ * reviews. `installed` means everything else: uploaded zips, local-dev
+ * packages, and the example manifests. The distinction exists because the
+ * dated SQL migration ramp (`LEGACY_SQL_GRANTS_2026_08_20`) may only ever
+ * apply to code we ship — an upload must never be able to reach it.
+ *
+ * It is derived by the LOADER, never read from the manifest. A manifest is
+ * author-supplied data; letting a package declare its own origin would make
+ * the security boundary a self-assessment, which is exactly the bar C7 was
+ * written to raise above.
+ *
+ * Default is `installed` at every construction site: an entry whose origin
+ * nobody asserted is not privileged.
+ */
+export type PluginOrigin = 'bundled' | 'installed';
+
 export interface PluginCatalogOptions {
   manifestDir?: string;
   /** Additional manifest sources (e.g. extracted zip uploads). Each entry
    *  points at a package-root directory that contains a `manifest.yaml`.
-   *  On ID collision with the built-in catalog the uploaded version wins. */
-  extraSources?: () => Array<{ packageRoot: string }>;
+   *  On ID collision with the built-in catalog the uploaded version wins.
+   *
+   *  `origin` is asserted by the CALLER (see the wiring in `index.ts`, which
+   *  is the only place that passes `'bundled'`, and only for the built-in
+   *  package store). Omitting it means `installed`. */
+  extraSources?: () => Array<{ packageRoot: string; origin?: PluginOrigin }>;
 }
 
 export interface PluginCatalogEntry {
@@ -73,6 +97,9 @@ export interface PluginCatalogEntry {
   source_path: string;
   /** Loader that produced this entry. Only manifest-v1 is supported today. */
   source_kind: 'manifest-v1';
+  /** #794 — whether this package ships inside the middleware image. Set by the
+   *  loader from WHERE the manifest was found, never from its content. */
+  origin: PluginOrigin;
 }
 
 export class PluginCatalog {
@@ -91,7 +118,11 @@ export class PluginCatalog {
       const manifestPath = path.join(src.packageRoot, 'manifest.yaml');
       const entry = await loadManifestFromPath(manifestPath);
       if (entry) {
-        next.set(entry.plugin.id, entry);
+        // #794 — the origin the CALLER asserted, not one the package claimed.
+        next.set(entry.plugin.id, {
+          ...entry,
+          origin: src.origin ?? 'installed',
+        });
       } else {
         console.warn(
           `[catalog] skipped uploaded manifest at ${manifestPath}: not a recognised schema-v1 manifest`,
@@ -130,6 +161,10 @@ export async function loadManifestFromPath(
       manifest: doc,
       source_path: absPath,
       source_kind: 'manifest-v1',
+      // #794 — a single manifest read in isolation carries no evidence of
+      // where the package came from, so it gets the unprivileged origin.
+      // `PluginCatalog.load` re-stamps it from the source that asked for it.
+      origin: 'installed',
     };
   } catch (err) {
     console.warn(`[catalog] failed to parse ${absPath}:`, err);
@@ -159,6 +194,11 @@ async function loadManifestV1Entries(
           manifest: doc,
           source_path: fullPath,
           source_kind: 'manifest-v1',
+          // #794 — the example-manifest directory is operator-pointable via
+          // `PLUGIN_MANIFEST_DIR` and carries no package code (so these
+          // entries cannot even be activated: `resolvePackagePath` finds no
+          // package root for them). Unprivileged.
+          origin: 'installed',
         });
       } else {
         console.warn(

--- a/middleware/test/agent-reference-maximum/kgAccessor.test.ts
+++ b/middleware/test/agent-reference-maximum/kgAccessor.test.ts
@@ -87,6 +87,9 @@ function makeFakeCatalog(plugins: Plugin[]): PluginCatalog {
     manifest: {},
     source_path: `/abs/${plugin.id}/manifest.yaml`,
     source_kind: 'manifest-v1',
+    // #794 — test fixtures are unprivileged: only the built-in package
+    // store may assert 'bundled'.
+    origin: 'installed',
   }));
   return {
     list: () => entries,

--- a/middleware/test/agent-reference-maximum/llmAccessor.test.ts
+++ b/middleware/test/agent-reference-maximum/llmAccessor.test.ts
@@ -88,6 +88,9 @@ function makeFakeCatalog(plugins: Plugin[]): PluginCatalog {
     manifest: {},
     source_path: `/abs/${plugin.id}/manifest.yaml`,
     source_kind: 'manifest-v1',
+    // #794 — test fixtures are unprivileged: only the built-in package
+    // store may assert 'bundled'.
+    origin: 'installed',
   }));
   return {
     list: () => entries,

--- a/middleware/test/agent-reference-maximum/storeFilter.test.ts
+++ b/middleware/test/agent-reference-maximum/storeFilter.test.ts
@@ -50,6 +50,9 @@ function makeFakeCatalog(plugins: Plugin[]): PluginCatalog {
     manifest: {},
     source_path: `/abs/${plugin.id}/manifest.yaml`,
     source_kind: 'manifest-v1',
+    // #794 — test fixtures are unprivileged: only the built-in package
+    // store may assert 'bundled'.
+    origin: 'installed',
   }));
   return {
     list: () => entries,

--- a/middleware/test/agent-reference-maximum/subAgentAccessor.test.ts
+++ b/middleware/test/agent-reference-maximum/subAgentAccessor.test.ts
@@ -93,6 +93,9 @@ function makeFakeCatalog(plugins: Plugin[]): PluginCatalog {
     manifest: {},
     source_path: `/abs/${plugin.id}/manifest.yaml`,
     source_kind: 'manifest-v1',
+    // #794 — test fixtures are unprivileged: only the built-in package
+    // store may assert 'bundled'.
+    origin: 'installed',
   }));
   return {
     list: () => entries,

--- a/middleware/test/bootstrap.test.ts
+++ b/middleware/test/bootstrap.test.ts
@@ -86,6 +86,9 @@ function makeCatalog(plugins: Partial_Plugin[]): PluginCatalog {
       manifest: {},
       source_path: `<test>/${p.id}.manifest.yaml`,
       source_kind: 'manifest-v1',
+      // #794 — test fixtures are unprivileged: only the built-in package
+      // store may assert 'bundled'.
+      origin: 'installed',
     });
   }
   return {

--- a/middleware/test/builder/builderReferenceCatalog.test.ts
+++ b/middleware/test/builder/builderReferenceCatalog.test.ts
@@ -25,6 +25,9 @@ function makeEntry(opts: {
     manifest: {},
     source_path: opts.source_path,
     source_kind: 'manifest-v1',
+    // #794 — test fixtures are unprivileged: only the built-in package
+    // store may assert 'bundled'.
+    origin: 'installed',
   };
 }
 

--- a/middleware/test/bundledPluginSqlGateBoot.pg.test.ts
+++ b/middleware/test/bundledPluginSqlGateBoot.pg.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Issue #794 — C7's SQL gate must not stop the middleware booting.
+ *
+ * WHAT WENT WRONG
+ * ---------------
+ * C7 (#787) made a pool-shaped `ctx.services.get('graphPool')` require BOTH a
+ * `permissions.sql` declaration AND an operator grant row, with C2b's dated
+ * `LEGACY_UNDECLARED_SERVICE_GRANTS_2026_08_20` as the only ramp. But that
+ * list answers a DIFFERENT question — "this plugin did not declare the
+ * SERVICE" — and `@omadia/memory-postgres` had already done C2b's work
+ * correctly (`requires: ["graphPool@^1"]`). Doing the C2b migration properly
+ * is exactly what removed it from C2b's list, and therefore from C7's ramp.
+ *
+ * The result was not a degradation. `activate()` threw, `memoryStore` was
+ * never published, and `index.ts` aborted boot with "MemoryStore service
+ * missing after tool-plugin activation".
+ *
+ * WHY C7'S OWN 452-LINE TEST FILE DID NOT CATCH IT
+ * ------------------------------------------------
+ * `pluginSqlPermission.test.ts` is entirely unit-level: every case builds a
+ * hand-written catalog stub via `catalogWith({...})`. A hand-written catalog
+ * cannot disagree with the real manifests, so no amount of that kind of
+ * coverage can see a manifest that is missing a block. The gap was never in
+ * the decision table — it was between the table and the shipped manifests.
+ *
+ * So these two suites are deliberately shaped to close that seam:
+ *
+ *   1. `cold-boot classification` reads the REAL bundled manifests through the
+ *      REAL `PluginCatalog` + `BuiltInPackageStore` and asserts the cold-boot
+ *      decision for every bundled plugin that DECLARES `graphPool`. No
+ *      database, so it runs in the ordinary CI step. It is keyed on the
+ *      manifest's own `requires:` rather than on a hardcoded list of plugin
+ *      names, which means it starts covering each remaining bundled plugin
+ *      automatically the moment that plugin finishes its C2b migration — i.e.
+ *      at exactly the moment #794's trap would otherwise re-arm for it.
+ *
+ *   2. `real boot` drives the REAL `ToolPluginRuntime.activate()` against a
+ *      real pg pool. The oracle is `serviceRegistry.has('memoryStore')`, not
+ *      "activate did not throw": the plugin's no-pool path returns a handle
+ *      WITHOUT publishing `memoryStore` (see its `activate()`), so only a run
+ *      that actually resolved the pool through both gates can satisfy it. A
+ *      test asserting merely "no throw" would pass against a plugin that
+ *      silently degraded to the no-pool branch — which is the same
+ *      boot-failure, one frame later.
+ *
+ * MUTATION CHECK (run it before trusting this file): drop
+ * `@omadia/memory-postgres` from `LEGACY_SQL_GRANTS_2026_08_20` in
+ * `src/platform/pluginSqlGrants.ts`. Both suites must go red. If they stay
+ * green the test is decorative.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Pool } from 'pg';
+
+import { probePgTest } from './_helpers/pgTestDb.js';
+import { newTestRouteRegistry } from './_helpers/routeRegistry.js';
+
+import { PluginCatalog } from '../src/plugins/manifestLoader.js';
+import { BuiltInPackageStore } from '../src/plugins/builtInPackageStore.js';
+import {
+  ToolPluginRuntime,
+  type ToolPluginRuntimeDeps,
+} from '../src/plugins/toolPluginRuntime.js';
+import { ServiceRegistry } from '../src/platform/serviceRegistry.js';
+import { UiRouteCatalog } from '../src/platform/uiRouteCatalog.js';
+import {
+  classifySqlAccess,
+  POOL_SHAPED_CAPABILITIES,
+  sqlPermissionOf,
+  bundledSqlRampCapabilities,
+} from '../src/platform/pluginSqlGrants.js';
+import { parseCapabilityRef } from '@omadia/plugin-api';
+import { LEGACY_UNDECLARED_SERVICE_GRANTS_2026_08_20 } from '../src/platform/pluginServiceGrants.js';
+
+const MEMORY_PG = '@omadia/memory-postgres';
+
+/** `graphPool@^1` -> `graphPool`. Malformed refs are dropped rather than
+ *  thrown on: the loader has already accepted the manifest by this point, and
+ *  a capability this helper cannot parse is one the gate will not match
+ *  either, so treating it as "not pool-shaped" keeps the two in agreement. */
+function capabilityName(raw: string): string {
+  try {
+    return parseCapabilityRef(raw).name;
+  } catch {
+    return '';
+  }
+}
+
+/** `middleware/packages` — the same directory `BUILT_IN_PACKAGES_DIR` points
+ *  at in production. Resolved from this file so the suite does not depend on
+ *  the runner's CWD. */
+const PACKAGES_DIR = path.resolve(
+  fileURLToPath(new URL('../packages', import.meta.url)),
+);
+
+/**
+ * The real catalog over the real bundled packages, wired EXACTLY as
+ * `src/index.ts` wires it — built-ins marked `bundled`, which is what the C7
+ * ramp keys on. Wiring it any other way would test a catalog production never
+ * builds.
+ */
+async function loadBundledCatalog(): Promise<{
+  catalog: PluginCatalog;
+  builtInStore: BuiltInPackageStore;
+}> {
+  const builtInStore = new BuiltInPackageStore(PACKAGES_DIR);
+  await builtInStore.load();
+  const catalog = new PluginCatalog({
+    extraSources: () =>
+      builtInStore.list().map((p) => ({
+        packageRoot: p.path,
+        origin: 'bundled' as const,
+      })),
+  });
+  await catalog.load();
+  return { catalog, builtInStore };
+}
+
+describe('#794 — cold-boot SQL classification of the real bundled manifests', () => {
+  it('marks the built-in packages as bundled (the ramp key)', async () => {
+    const { catalog } = await loadBundledCatalog();
+    const entry = catalog.get(MEMORY_PG);
+    assert.ok(entry, `${MEMORY_PG} must be in the bundled catalog`);
+    // Guard the guard: if `origin` ever stops being set here, every ramp
+    // assertion below would be asking about a plugin the gate no longer
+    // considers bundled, and would pass for the wrong reason.
+    assert.equal(
+      entry.origin,
+      'bundled',
+      'built-in packages must carry origin=bundled or the SQL ramp cannot key on it',
+    );
+  });
+
+  it('never classifies an UPLOADED plugin as bundled, whatever its id', async () => {
+    // The ramp must be unreachable by upload. An uploaded package that names
+    // itself `@omadia/memory-postgres` must not inherit the built-in's ramp —
+    // that is the whole reason the key is (id AND origin) and not id alone.
+    const builtInStore = new BuiltInPackageStore(PACKAGES_DIR);
+    await builtInStore.load();
+    const impostorRoot = builtInStore.get(MEMORY_PG)?.path;
+    assert.ok(impostorRoot, 'precondition: the built-in package resolves');
+
+    const catalog = new PluginCatalog({
+      // Same package root, but arriving the way an UPLOAD arrives: with no
+      // origin, which must default to 'installed'.
+      extraSources: () => [{ packageRoot: impostorRoot }],
+    });
+    await catalog.load();
+
+    assert.equal(catalog.get(MEMORY_PG)?.origin, 'installed');
+    assert.deepEqual(
+      bundledSqlRampCapabilities(MEMORY_PG, catalog),
+      [],
+      'an installed plugin must get NO ramp capabilities even under a built-in id',
+    );
+  });
+
+  it('every bundled plugin that declares graphPool still boots cold', async () => {
+    const { catalog } = await loadBundledCatalog();
+
+    // Keyed on the manifest's own `requires:`, not on a hardcoded name list.
+    // A plugin that finishes its C2b migration (and so drops off C2b's ramp)
+    // walks into this assertion automatically — which is precisely the trap
+    // #794 was.
+    const declaringPoolAccess = catalog
+      .list()
+      .filter((entry) =>
+        entry.plugin.requires.some((raw) =>
+          POOL_SHAPED_CAPABILITIES.has(capabilityName(raw)),
+        ),
+      );
+
+    assert.ok(
+      declaringPoolAccess.some((e) => e.plugin.id === MEMORY_PG),
+      `precondition: ${MEMORY_PG} declares a pool-shaped capability`,
+    );
+
+    for (const entry of declaringPoolAccess) {
+      const id = entry.plugin.id;
+      for (const raw of entry.plugin.requires) {
+        const capability = capabilityName(raw);
+        if (!POOL_SHAPED_CAPABILITIES.has(capability)) continue;
+
+        const outcome = classifySqlAccess({
+          capability,
+          declared: sqlPermissionOf(id, catalog),
+          // Cold boot on a fresh install: `plugin_sql_grants` is empty, and
+          // nothing in `src/` calls `grant()` yet, so `false` is not a
+          // pessimistic choice — it is the only value reachable today.
+          granted: false,
+          legacy: (
+            LEGACY_UNDECLARED_SERVICE_GRANTS_2026_08_20[id] ?? []
+          ).includes(capability),
+          bundledLegacy:
+            bundledSqlRampCapabilities(id, catalog).includes(capability),
+        });
+
+        assert.notEqual(
+          outcome,
+          'undeclared',
+          `bundled '${id}' would throw SqlPermissionError(undeclared) for '${capability}' at boot`,
+        );
+        assert.notEqual(
+          outcome,
+          'ungranted',
+          `bundled '${id}' would throw SqlPermissionError(ungranted) for '${capability}' at boot`,
+        );
+      }
+    }
+  });
+
+  it('memory-postgres declares permissions.sql with a ledger it may own', async () => {
+    // The ramp is the belt; the declaration is the braces. It is also what
+    // makes the request visible in the admin API at install time, and what
+    // the operator will grant against once the grant surface ships.
+    const { catalog } = await loadBundledCatalog();
+    const declared = sqlPermissionOf(MEMORY_PG, catalog);
+    assert.ok(
+      declared,
+      `${MEMORY_PG} must declare permissions.sql — a malformed block is DROPPED by the loader with a warning, so undefined here also means "declared it wrong"`,
+    );
+    assert.equal(declared.ledger, 'plg_omadia_memory_postgres_migrations');
+    // It self-migrates via its own `_memory_migrations` table, so it must NOT
+    // claim core-run migrations — that would make `ctx.sql.runMigrations()`
+    // scan a directory this package does not ship.
+    assert.equal(
+      declared.migrations,
+      undefined,
+      'memory-postgres runs its own migrator; declaring `migrations:` would be a false claim',
+    );
+  });
+});
+
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'bundledPluginSqlGateBoot',
+  vars: ['MEMORY_PG_TEST_URL', 'GRAPH_PG_TEST_URL', 'DATABASE_URL'],
+});
+
+describe('#794 — real boot: memory-postgres activates against a real pool', () => {
+  it('publishes memoryStore through the real ToolPluginRuntime', async (t) => {
+    if (!pgAvailable || !PG_URL) return t.skip('no test Postgres');
+
+    const { catalog, builtInStore } = await loadBundledCatalog();
+    const serviceRegistry = new ServiceRegistry();
+
+    // The pool the kernel holds. Registered under the same capability name
+    // `@omadia/knowledge-graph-neon` publishes at boot, because that is the
+    // object the gate decides about.
+    const pool = new Pool({ connectionString: PG_URL, max: 2 });
+    serviceRegistry.provide('graphPool', pool);
+
+    const nativeTools: string[] = [];
+    const deps = {
+      catalog,
+      builtInStore,
+      uploadedStore: { get: () => undefined, list: () => [] },
+      registry: {
+        has: () => true,
+        list: () => [],
+        // The plugin reads `seed_dir` / `seed_mode` / the dev-endpoint flag
+        // from here. Seeding is turned OFF so the suite asserts the gate, not
+        // the seeder.
+        get: () => ({ id: MEMORY_PG, config: { seed_mode: 'skip' } }),
+        updateConfig: async () => undefined,
+        markActivationFailed: async () => undefined,
+      },
+      vault: {
+        get: async () => undefined,
+        listKeys: async () => [],
+      },
+      serviceRegistry,
+      nativeToolRegistry: {
+        register: (name: string) => {
+          nativeTools.push(name);
+          return () => undefined;
+        },
+        registerHandler: () => () => undefined,
+      },
+      pluginRouteRegistry: newTestRouteRegistry(),
+      uiRouteCatalog: new UiRouteCatalog(),
+      jobScheduler: {
+        register: () => () => undefined,
+        stopForPlugin: () => undefined,
+      },
+      notificationRouter: { emit: () => undefined },
+      log: () => undefined,
+    } as unknown as ToolPluginRuntimeDeps;
+
+    const runtime = new ToolPluginRuntime(deps);
+
+    try {
+      // On `main` this throws:
+      //   plugin '@omadia/memory-postgres' reached for the database
+      //   capability 'graphPool' but its manifest does not declare
+      //   `permissions.sql`
+      await runtime.activate(MEMORY_PG);
+
+      // THE ORACLE. The plugin's no-pool branch returns a handle without ever
+      // calling `ctx.services.provide('memoryStore', …)`, so this is true only
+      // if the pool was actually resolved through BOTH gates. `index.ts` aborts
+      // boot on exactly this condition ("MemoryStore service missing after
+      // tool-plugin activation"), so this assertion is the boot check itself,
+      // not a proxy for it.
+      assert.equal(
+        serviceRegistry.has('memoryStore'),
+        true,
+        'memory-postgres must publish memoryStore — this is the check index.ts aborts boot on',
+      );
+
+      // And the store must be usable, not merely registered: the migrator ran
+      // against the borrowed pool.
+      const store = serviceRegistry.get('memoryStore');
+      assert.ok(store, 'memoryStore resolved');
+
+      const applied = await pool.query<{ n: string }>(
+        'SELECT count(*)::text AS n FROM _memory_migrations',
+      );
+      assert.ok(
+        Number(applied.rows[0]?.n ?? 0) > 0,
+        'the plugin migrator must have applied its schema through the borrowed pool',
+      );
+    } finally {
+      await runtime.deactivate(MEMORY_PG).catch(() => undefined);
+      await pool.end();
+    }
+  });
+
+  it('borrows the pool rather than owning it', async (t) => {
+    if (!pgAvailable || !PG_URL) return t.skip('no test Postgres');
+
+    // C7 hands plugins a BORROWED pool so one plugin's `.end()` cannot tear
+    // down the connection pool core writes user data through. Asserted here
+    // because the borrow only happens on the path that survives the gate —
+    // it is untestable while activation throws.
+    const { catalog, builtInStore } = await loadBundledCatalog();
+    const serviceRegistry = new ServiceRegistry();
+    const pool = new Pool({ connectionString: PG_URL, max: 2 });
+    serviceRegistry.provide('graphPool', pool);
+
+    const deps = {
+      catalog,
+      builtInStore,
+      uploadedStore: { get: () => undefined, list: () => [] },
+      registry: {
+        has: () => true,
+        list: () => [],
+        get: () => ({ id: MEMORY_PG, config: { seed_mode: 'skip' } }),
+        updateConfig: async () => undefined,
+        markActivationFailed: async () => undefined,
+      },
+      vault: { get: async () => undefined, listKeys: async () => [] },
+      serviceRegistry,
+      nativeToolRegistry: {
+        register: () => () => undefined,
+        registerHandler: () => () => undefined,
+      },
+      pluginRouteRegistry: newTestRouteRegistry(),
+      uiRouteCatalog: new UiRouteCatalog(),
+      jobScheduler: {
+        register: () => () => undefined,
+        stopForPlugin: () => undefined,
+      },
+      notificationRouter: { emit: () => undefined },
+      log: () => undefined,
+    } as unknown as ToolPluginRuntimeDeps;
+
+    const runtime = new ToolPluginRuntime(deps);
+    try {
+      await runtime.activate(MEMORY_PG);
+      await runtime.deactivate(MEMORY_PG);
+
+      // The kernel's own pool must still answer after the plugin went away.
+      const after = await pool.query<{ ok: number }>('SELECT 1 AS ok');
+      assert.equal(after.rows[0]?.ok, 1);
+    } finally {
+      await pool.end();
+    }
+  });
+});

--- a/middleware/test/capabilityResolver.test.ts
+++ b/middleware/test/capabilityResolver.test.ts
@@ -73,6 +73,9 @@ function makeCatalog(plugins: Partial_Plugin[]): PluginCatalog {
       manifest: {},
       source_path: `<test>/${p.id}.manifest.yaml`,
       source_kind: 'manifest-v1',
+      // #794 — test fixtures are unprivileged: only the built-in package
+      // store may assert 'bundled'.
+      origin: 'installed',
     });
   }
   // Cast to the public interface — we exercise `get(id)` and `list()`,

--- a/middleware/test/installService.test.ts
+++ b/middleware/test/installService.test.ts
@@ -80,6 +80,7 @@ function makeCatalog(plugins: Partial_Plugin[]): PluginCatalog {
       manifest: unknown;
       source_path: string;
       source_kind: 'manifest-v1';
+      origin: 'installed';
     }
   >();
   for (const p of plugins) {
@@ -88,6 +89,9 @@ function makeCatalog(plugins: Partial_Plugin[]): PluginCatalog {
       manifest: {},
       source_path: `<test>/${p.id}.manifest.yaml`,
       source_kind: 'manifest-v1',
+      // #794 — test fixtures are unprivileged: only the built-in package
+      // store may assert 'bundled'.
+      origin: 'installed',
     });
   }
   return {
@@ -450,6 +454,9 @@ describe('extractSetupSchema — multiline flag', () => {
       manifest: { setup: { fields } },
       source_path: '<test>/multiline-test.manifest.yaml',
       source_kind: 'manifest-v1',
+      // #794 — test fixtures are unprivileged: only the built-in package
+      // store may assert 'bundled'.
+      origin: 'installed',
     } as unknown as PluginCatalogEntry;
   }
 
@@ -511,6 +518,9 @@ describe('extractSetupSchema — install_hidden flag', () => {
       manifest: { setup: { fields } },
       source_path: '<test>/install-hidden-test.manifest.yaml',
       source_kind: 'manifest-v1',
+      // #794 — test fixtures are unprivileged: only the built-in package
+      // store may assert 'bundled'.
+      origin: 'installed',
     } as unknown as PluginCatalogEntry;
   }
 

--- a/middleware/test/installServiceOAuthField.test.ts
+++ b/middleware/test/installServiceOAuthField.test.ts
@@ -66,6 +66,9 @@ function makeDeps() {
     manifest: MANIFEST,
     source_path: '<test>/manifest.yaml',
     source_kind: 'manifest-v1',
+    // #794 — test fixtures are unprivileged: only the built-in package
+    // store may assert 'bundled'.
+    origin: 'installed',
   } as unknown as PluginCatalogEntry;
   const catalog = {
     get: (id: string) => (id === plugin.id ? entry : undefined),

--- a/middleware/test/llmClassRefGate.test.ts
+++ b/middleware/test/llmClassRefGate.test.ts
@@ -121,6 +121,9 @@ function makeFakeCatalog(plugins: Plugin[]): PluginCatalog {
     manifest: {},
     source_path: `/abs/${plugin.id}/manifest.yaml`,
     source_kind: 'manifest-v1',
+    // #794 — test fixtures are unprivileged: only the built-in package
+    // store may assert 'bundled'.
+    origin: 'installed',
   })) as unknown as PluginCatalogEntry[];
   return {
     list: () => entries,

--- a/middleware/test/manifestDevJobsLegacyKey.test.ts
+++ b/middleware/test/manifestDevJobsLegacyKey.test.ts
@@ -148,6 +148,9 @@ function catalogOf(plugin: Plugin): PluginCatalog {
     manifest: {},
     source_path: `/abs/${plugin.id}/manifest.yaml`,
     source_kind: 'manifest-v1',
+    // #794 — test fixtures are unprivileged: only the built-in package
+    // store may assert 'bundled'.
+    origin: 'installed',
   } as unknown as PluginCatalogEntry;
   return {
     list: () => [entry],

--- a/middleware/test/oauth/oauthReadinessTracker.test.ts
+++ b/middleware/test/oauth/oauthReadinessTracker.test.ts
@@ -47,7 +47,14 @@ function entryWithFields(fields: Array<Record<string, unknown>>): PluginCatalogE
     },
     setup: { fields },
   })!;
-  return { plugin, manifest: {}, source_path: '/dev/null', source_kind: 'manifest-v1' };
+  // #794 — an unprivileged fixture: only the built-in package store asserts 'bundled'.
+  return {
+    plugin,
+    manifest: {},
+    source_path: '/dev/null',
+    source_kind: 'manifest-v1',
+    origin: 'installed',
+  };
 }
 
 describe('OAuthReadinessTracker', () => {

--- a/middleware/test/orchestrator/pluginToolsReadyGate.test.ts
+++ b/middleware/test/orchestrator/pluginToolsReadyGate.test.ts
@@ -507,7 +507,14 @@ function oauthPluginEntry(pluginId: string): PluginCatalogEntry {
       ],
     },
   })!;
-  return { plugin, manifest: {}, source_path: '/dev/null', source_kind: 'manifest-v1' };
+  // #794 — an unprivileged fixture: only the built-in package store asserts 'bundled'.
+  return {
+    plugin,
+    manifest: {},
+    source_path: '/dev/null',
+    source_kind: 'manifest-v1',
+    origin: 'installed',
+  };
 }
 
 describe('Orchestrator — issue #474 round 5: automatic OAuth-connection signal', () => {

--- a/middleware/test/pluginContextFlows.test.ts
+++ b/middleware/test/pluginContextFlows.test.ts
@@ -84,6 +84,9 @@ function makeCatalog(id: string, flows: boolean): PluginCatalog {
     manifest: {},
     source_path: `/abs/${id}/manifest.yaml`,
     source_kind: 'manifest-v1',
+    // #794 — test fixtures are unprivileged: only the built-in package
+    // store may assert 'bundled'.
+    origin: 'installed',
   } as unknown as PluginCatalogEntry;
   return {
     list: () => [entry],

--- a/middleware/test/pluginContextRouteAuthDeclaration.test.ts
+++ b/middleware/test/pluginContextRouteAuthDeclaration.test.ts
@@ -92,6 +92,9 @@ function makeCatalog(id: string, publicPathDecls: readonly string[]): PluginCata
     manifest: {},
     source_path: `/abs/${id}/manifest.yaml`,
     source_kind: 'manifest-v1',
+    // #794 — test fixtures are unprivileged: only the built-in package
+    // store may assert 'bundled'.
+    origin: 'installed',
   } as unknown as PluginCatalogEntry;
   return {
     list: () => [entry],

--- a/middleware/test/pluginContextRuntimeWrite.test.ts
+++ b/middleware/test/pluginContextRuntimeWrite.test.ts
@@ -111,6 +111,9 @@ function makeCatalog(runtimeWrite: boolean): PluginCatalog {
     manifest: {},
     source_path: '/abs/caller/manifest.yaml',
     source_kind: 'manifest-v1',
+    // #794 — test fixtures are unprivileged: only the built-in package
+    // store may assert 'bundled'.
+    origin: 'installed',
   } as unknown as PluginCatalogEntry;
   return {
     list: () => [entry],

--- a/middleware/test/pluginContextStatus.test.ts
+++ b/middleware/test/pluginContextStatus.test.ts
@@ -42,6 +42,9 @@ function makeCatalog(id: string): PluginCatalog {
     manifest: {},
     source_path: `/abs/${id}/manifest.yaml`,
     source_kind: 'manifest-v1',
+    // #794 — test fixtures are unprivileged: only the built-in package
+    // store may assert 'bundled'.
+    origin: 'installed',
   } as unknown as PluginCatalogEntry;
   return {
     list: () => [entry],

--- a/middleware/test/pluginServiceGrantGate.test.ts
+++ b/middleware/test/pluginServiceGrantGate.test.ts
@@ -102,6 +102,9 @@ function catalogOf(...plugins: Plugin[]): PluginCatalog {
         manifest: rawManifestByPlugin.get(plugin) ?? {},
         source_path: 'test',
         source_kind: 'manifest-v1',
+        // #794 — test fixtures are unprivileged: only the built-in package
+        // store may assert 'bundled'.
+        origin: 'installed',
       },
     ]),
   );

--- a/middleware/test/pluginSqlPermission.test.ts
+++ b/middleware/test/pluginSqlPermission.test.ts
@@ -230,7 +230,11 @@ describe('#470 C7 — permissions.sql parsing', () => {
 });
 
 describe('#470 C7 — pool-gate decision table', () => {
-  const base = { capability: 'graphPool', legacy: false } as const;
+  const base = {
+    capability: 'graphPool',
+    legacy: false,
+    bundledLegacy: false,
+  } as const;
   const declared = { ledger: LEDGER };
 
   it('graphPool is the gated capability — and the gate set is closed', () => {
@@ -247,6 +251,7 @@ describe('#470 C7 — pool-gate decision table', () => {
         declared: undefined,
         granted: false,
         legacy: false,
+        bundledLegacy: false,
       }),
       'not-pool-shaped',
     );
@@ -293,6 +298,63 @@ describe('#470 C7 — pool-gate decision table', () => {
     // legacy — otherwise the ramp could never be observed to be empty.
     assert.equal(
       classifySqlAccess({ ...base, declared, granted: true, legacy: true }),
+      'allowed',
+    );
+  });
+
+  it('#794 — the BUNDLED ramp covers a plugin that did C2b\'s work correctly', () => {
+    // The #794 shape exactly: `permissions.sql` declared, no operator grant
+    // (nothing in `src/` calls `grant()` yet), and NOT on C2b's list precisely
+    // because its `requires:` is correct. Before the bundled ramp this fell
+    // through to `ungranted` and threw on the boot path.
+    assert.equal(
+      classifySqlAccess({
+        ...base,
+        declared,
+        granted: false,
+        legacy: false,
+        bundledLegacy: true,
+      }),
+      'bundled-legacy',
+    );
+    // Same for a bundled plugin that has not declared yet — the ramp keeps it
+    // booting rather than making the manifest fix a prerequisite for boot.
+    assert.equal(
+      classifySqlAccess({
+        ...base,
+        declared: undefined,
+        granted: false,
+        bundledLegacy: true,
+      }),
+      'bundled-legacy',
+    );
+  });
+
+  it('#794 — the bundled ramp is the reason reported when both ramps apply', () => {
+    // Both true is the normal state for orchestrator/verifier/extras. The
+    // bundled reason is the accurate one and names the right remedy.
+    assert.equal(
+      classifySqlAccess({
+        ...base,
+        declared: undefined,
+        granted: false,
+        legacy: true,
+        bundledLegacy: true,
+      }),
+      'bundled-legacy',
+    );
+  });
+
+  it('#794 — a granted, declared plugin is never reported as bundled-legacy', () => {
+    // Otherwise the ramp could never be observed to be empty, and its
+    // retirement date would be unfalsifiable.
+    assert.equal(
+      classifySqlAccess({
+        ...base,
+        declared,
+        granted: true,
+        bundledLegacy: true,
+      }),
       'allowed',
     );
   });

--- a/middleware/test/profilesRouter.test.ts
+++ b/middleware/test/profilesRouter.test.ts
@@ -73,6 +73,9 @@ function makeCatalog(plugins: Partial_Plugin[]): PluginCatalog {
       manifest: {},
       source_path: `<test>/${p.id}.manifest.yaml`,
       source_kind: 'manifest-v1',
+      // #794 — test fixtures are unprivileged: only the built-in package
+      // store may assert 'bundled'.
+      origin: 'installed',
     });
   }
   return {

--- a/middleware/test/publicPathGrants.test.ts
+++ b/middleware/test/publicPathGrants.test.ts
@@ -550,6 +550,9 @@ async function makeConsentHarness(opts: {
     manifest: {},
     source_path: '<test>',
     source_kind: 'manifest-v1',
+    // #794 — test fixtures are unprivileged: only the built-in package
+    // store may assert 'bundled'.
+    origin: 'installed',
   } as unknown as PluginCatalogEntry;
   const catalog = {
     get: (id: string): PluginCatalogEntry | undefined =>

--- a/middleware/test/runtimeAuditModeRoute.test.ts
+++ b/middleware/test/runtimeAuditModeRoute.test.ts
@@ -51,6 +51,9 @@ async function makeHarness(opts: {
     manifest: {},
     source_path: '<test>',
     source_kind: 'manifest-v1',
+    // #794 — test fixtures are unprivileged: only the built-in package
+    // store may assert 'bundled'.
+    origin: 'installed',
   };
   const catalog = {
     get: (id: string): PluginCatalogEntry | undefined =>

--- a/middleware/test/runtimeSecretsRoute.test.ts
+++ b/middleware/test/runtimeSecretsRoute.test.ts
@@ -66,6 +66,9 @@ async function makeHarness(opts: HarnessOpts = {}): Promise<Harness> {
       manifest: { setup: { fields } },
       source_path: '<test>',
       source_kind: 'manifest-v1',
+      // #794 — test fixtures are unprivileged: only the built-in package
+      // store may assert 'bundled'.
+      origin: 'installed',
     };
     catalog = {
       get: (id: string): PluginCatalogEntry | undefined =>

--- a/middleware/test/setupFieldPatternValidation.test.ts
+++ b/middleware/test/setupFieldPatternValidation.test.ts
@@ -78,6 +78,9 @@ async function makeHarness(fields: SetupFieldSpec[]): Promise<Harness> {
     manifest: { setup: { fields } },
     source_path: '<test>',
     source_kind: 'manifest-v1',
+    // #794 — test fixtures are unprivileged: only the built-in package
+    // store may assert 'bundled'.
+    origin: 'installed',
   };
   const catalog = {
     get: (id: string): PluginCatalogEntry | undefined =>
@@ -671,6 +674,9 @@ describe('OM-17 / F2 — a refused pattern is SURFACED, not just logged', () => 
       },
       source_path: '<test>',
       source_kind: 'manifest-v1',
+      // #794 — test fixtures are unprivileged: only the built-in package
+      // store may assert 'bundled'.
+      origin: 'installed',
     } as unknown as PluginCatalogEntry);
     const f = schema?.fields[0];
     assert.equal(f?.pattern, undefined);


### PR DESCRIPTION
Fixes #794

## The bug

C7 (#787) gated pool-shaped capabilities behind a `permissions.sql` declaration **plus** an operator grant, and reused C2b's `LEGACY_UNDECLARED_SERVICE_GRANTS_2026_08_20` as its migration ramp.

That list answers a *different question* — "this plugin did not declare the SERVICE" — while C7's gate asks "this plugin did not declare `permissions.sql`". For a plugin that has done C2b's work the two sets are **disjoint**. `@omadia/memory-postgres` declares `requires: ["graphPool@^1"]` correctly, and that is precisely what kept it off C2b's list and therefore out of C7's ramp.

**Doing the C2b migration correctly is what disqualified a plugin from C7's ramp.** The middleware did not boot:

```
[tool-runtime] activate FAILED for @omadia/memory-postgres: ... does not declare `permissions.sql`
[middleware] fatal startup error: Error: [middleware] MemoryStore service missing after tool-plugin activation
```

## Audit — every bundled plugin touching a pool-shaped capability

Scanned all 21 bundled manifests under `middleware/packages/*` plus their `src/` for `services.get`/`services.provide` on `POOL_SHAPED_CAPABILITIES`:

| Plugin | gets `graphPool` | declared `permissions.sql` (before) | on C2b's list | cold boot on `main` |
|---|---|---|---|---|
| `@omadia/memory-postgres` | yes | no | **no** | **BREAKS** |
| `@omadia/orchestrator` | yes | no | yes | legacy-ok |
| `@omadia/orchestrator-extras` | yes | no | yes | legacy-ok |
| `@omadia/verifier` | yes | no | yes | legacy-ok |
| `@omadia/knowledge-graph-neon` | no — **provides** it | no | n/a | n/a |

Exactly one breaks, confirming the issue's own analysis. `@omadia/channel-teams` has no `graphPool` call in this repo's `src/` any more — it lives in `byte5ai/omadia-channel-teams` and arrives as an installed package, so it stays on C2b's list.

## Approach — both (a) and (b), and neither weakens the gate for uploads

**(a) Manifest declaration.** `harness-memory-postgres/manifest.yaml` now declares:

```yaml
sql:
  ledger: "plg_omadia_memory_postgres_migrations"
```

`migrations:` is **deliberately omitted and documented**. The plugin predates the kernel migration runner and ships its own migrator (`src/migrator.ts`), tracking applied files in its own `_memory_migrations` table under an advisory lock. Declaring `migrations:` would tell the kernel to scan a directory this package does not ship — a false claim about who applies the schema. So **the ledger is declared but currently unused**; it is reserved so the eventual cutover to core-run migrations does not have to re-ask the operator for a different name. That cutover is a data migration on live deployments and is not riding along with a boot fix.

Declaration alone cannot fix boot: with no grant row the outcome moves from `undeclared` to `ungranted`, which still throws. Nothing in `src/` calls `grant()` yet, so `granted` **cannot be true for anyone today** — which is why a ramp is needed at all.

**(b) C7's own dated ramp.**

- `PluginCatalogEntry.origin` (`'bundled' | 'installed'`) is derived by the **loader** from *where* a package was found, never from its manifest — letting a package declare its own origin would make the security boundary a self-assessment. `index.ts` asserts `'bundled'` for the built-in package store **and nowhere else**; uploaded and local-dev packages keep the unprivileged default.
- `LEGACY_SQL_GRANTS_2026_08_20` is closed, dated, and consulted only through `bundledSqlRampCapabilities(id, catalog)`, which returns `[]` unless `origin === 'bundled'`. **An upload naming itself `@omadia/memory-postgres` inherits nothing** — there is a test for exactly that.
- It lists **all four** bundled `graphPool` consumers, not just the broken one. The three currently covered by C2b's list are unreachable through this branch today; they are listed so that finishing their C2b migration cannot spring the same trap. This preempts #789's class.
- `classifySqlAccess` gains a required `bundledLegacy` input and a `bundled-legacy` outcome with its own warn-then-allow log line, kept distinct from C2b's because the two retire on different schedules.

## Boot test — and why C7's existing 452-line suite could not catch this

`pluginSqlPermission.test.ts` is entirely unit-level: every case builds a hand-written catalog stub via `catalogWith({...})`. **A stub cannot disagree with a shipped manifest**, so no amount of that coverage can see a manifest missing a block. The gap was never in the decision table — it was between the table and the real manifests.

New `middleware/test/bundledPluginSqlGateBoot.pg.test.ts`:

1. **Cold-boot classification (no database, runs in the ordinary CI step).** Reads the REAL bundled manifests through the REAL `PluginCatalog` + `BuiltInPackageStore`, wired exactly as `index.ts` wires them, and asserts the cold-boot outcome is never `undeclared`/`ungranted`. Keyed on each manifest's own `requires:` rather than a hardcoded name list — so it **starts covering each remaining bundled plugin automatically the moment that plugin finishes its C2b migration**, i.e. at exactly the moment the trap would otherwise re-arm.
2. **Real boot (pg).** Drives the REAL `ToolPluginRuntime.activate()` against a real pool. The oracle is `serviceRegistry.has('memoryStore')`, **not** "did not throw": the plugin's no-pool branch returns a handle *without* publishing the store, so a no-throw assertion would pass on a silent degradation — the same boot failure one frame later. It also asserts the migrator actually applied schema through the borrowed pool, and that the pool survives deactivate.

### Proof

**RED on `main`** — real runtime, real pool, pre-fix code:

```
[@omadia/memory-postgres] activating memory-postgres plugin
ACTIVATE THREW: plugin '@omadia/memory-postgres' reached for the database capability
  'graphPool' but its manifest does not declare `permissions.sql` ...
memoryStore published? false
=> index.ts would ABORT BOOT ("MemoryStore service missing")
```

**GREEN with the fix** — 6/6, zero skipped:

```
✔ marks the built-in packages as bundled (the ramp key)
✔ never classifies an UPLOADED plugin as bundled, whatever its id
✔ every bundled plugin that declares graphPool still boots cold
✔ memory-postgres declares permissions.sql with a ledger it may own
✔ publishes memoryStore through the real ToolPluginRuntime
✔ borrows the pool rather than owning it
```

**Mutation check** — dropping `@omadia/memory-postgres` from the ramp turns **both** suites red:

```
AssertionError: bundled '@omadia/memory-postgres' would throw SqlPermissionError(ungranted) for 'graphPool' at boot
Error [SqlPermissionError]: ... declares `permissions.sql` but the operator has not granted it
```

## Checks

| Check | Result |
|---|---|
| `npm run build` | pass |
| `npm run typecheck` | pass |
| `npm run typecheck:test` | pass — 406 known errors, **baseline 406, no debt raised** |
| `npm run lint` | pass |
| `npm test` (full) | **7867/7869 pass, 0 fail**, 2 pre-existing skips |
| `npm run test:pg` | **346/346 pass, 0 fail, 0 skipped** |
| `node scripts/check-core-decoupling.mjs` | 3300 — **unchanged vs. `main`** (verified by stashing the diff) |

The 24 test files touched are mechanical: `origin: 'installed'` added to catalog-entry fixtures, since `origin` is required rather than optional so every construction site must state where a package came from. An unprivileged default is the right answer for a fixture.

## Not in scope

- Moving `_memory_migrations` onto the kernel's migration runner (data migration on live deployments).
- The operator grant surface: `plugin_sql_grants` still has no `grant()` caller in `src/`. Until it ships, the ramp is what keeps bundled plugins booting — and it is dated so it cannot quietly become permanent.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789841777&installation_model_id=428086&pr_number=801&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F801&signature=3ab108c652040d150e271eab0c162951eb050ca5d4332cede1cd4a7671ad5745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

## Cross-family review (Forge)

GPT-5.4-family review of the hotfix, run against the code rather than the PR narrative. Five claims were checked; all five hold. One defect was found and fixed in `67bf3971`.

### 1. Coverage — every bundled `graphPool` consumer is on the ramp

The first pass of this audit used `grep 'services\.get('`, which finds **nothing**: every real call site is written `ctx.services.get<Pool>('graphPool')`, and the type parameter breaks the pattern. Grepping `services\.get` (no paren) plus resolving the three `const GRAPH_POOL_SERVICE = 'graphPool'` indirections gives the true set of bundled consumers:

| Plugin | Call site | On ramp? |
|---|---|---|
| `@omadia/memory-postgres` | `src/plugin.ts:43` (via `GRAPH_POOL_SERVICE`) | yes |
| `@omadia/verifier` | `src/plugin.ts:133` | yes |
| `@omadia/orchestrator` | `src/plugin.ts:757` (via `GRAPH_POOL_SERVICE`) | yes |
| `@omadia/orchestrator-extras` | `src/plugin.ts:332`, `:562`, `:772` | yes |

`@omadia/knowledge-graph-neon` is the **provider** — it builds its own pool with `createNeonPool` and calls `ctx.services.provide('graphPool', …)` at `src/plugin.ts:433`. It never resolves the capability, so it never reaches the gate. Correctly absent.

No other pool-shaped name exists to miss: `POOL_SHAPED_CAPABILITIES` is a closed one-element set, so `graphPool` is the whole gated surface by construction.

Cold-boot classification was evaluated for all four against the real catalog — none classifies as `undeclared` or `ungranted`. The other three reach `bundled-legacy` (C2b's list also covers them; the bundled branch is checked first and is the accurate reason).

### 2. Ramp is keyed on (id AND `origin === 'bundled'`) — issue #789 class

`bundledSqlRampCapabilities` reads `catalog.get(agentId)?.origin` and returns `[]` for anything not `bundled`. `origin` is asserted at exactly one place in `src/` (`index.ts:781`, the built-in store) and defaults to `'installed'` at all three loader construction sites. It is never read from manifest content.

The collision path was traced end to end. `PluginCatalog.load` is last-set-wins and `index.ts` orders built-in → uploaded → local-dev, so an upload claiming `@omadia/memory-postgres` **replaces** the bundled entry with `origin: 'installed'` and gets no ramp. `ToolPluginRuntime.resolvePackagePath` (`:626`) also prefers `uploadedStore` over `builtInStore`, so the code that runs and the origin that was recorded agree — the upload cannot run bundled code under an installed origin, or vice versa.

Test exists: *"never classifies an UPLOADED plugin as bundled, whatever its id"*, which loads the **real** built-in package root through an origin-less `extraSources` and asserts both `origin === 'installed'` and an empty ramp. Mutation-verified below.

### 3. Ledger name and the empty-migrations-dir trap

`plg_omadia_memory_postgres_migrations` is correct for `@omadia/memory-postgres`: `sanitizedPluginPrefix` folds the **full** id to `omadia_memory_postgres`, giving the mandatory prefix `plg_omadia_memory_postgres_`; the name is 37 chars, inside `NAMEDATALEN`, and matches `LEDGER_NAME_RE`.

The empty-dir throw is genuinely avoided, and for the right reason. `runPluginMigrations` does throw `SqlMigrationError` on a directory with no `.sql` files — but the kernel only calls it under `if (declaredSql?.migrations && ctx.sql)` (`toolPluginRuntime.ts:373`). The manifest deliberately declares `sql.ledger` **without** `migrations:`, so the kernel migration runner is never armed and the plugin keeps using its own `_memory_migrations` migrator. A test pins this explicitly (`declared.migrations === undefined`), so re-adding `migrations:` cannot pass silently. Confirmed live: activation applies schema through the borrowed pool and `_memory_migrations` is non-empty afterwards.

### 4. The boot test asserts activation success, not a mock's silence

It drives the real `ToolPluginRuntime.activate()` against a real pg pool, and the oracle is `serviceRegistry.has('memoryStore')` — not "did not throw". That matters here: the plugin's no-pool branch **returns a handle successfully** without publishing `memoryStore`, so a no-throw assertion would pass against the silently-degraded path, which is the same boot failure one frame later. `index.ts` aborts boot on exactly this condition, so the assertion is the boot check itself. It additionally queries `_memory_migrations` to prove the store is usable rather than merely registered.

The test cannot be run on `main` as written (`origin` does not exist there), so "fails on main" was verified by mutation instead — the strictly stronger check, since it isolates each load-bearing element:

| Mutation | Result |
|---|---|
| Drop `@omadia/memory-postgres` from `LEGACY_SQL_GRANTS_2026_08_20` | **3 of 6 fail** (cold-boot classification, real boot, pool borrow) |
| Strip `permissions.sql` from the memory-postgres manifest | **1 of 6 fails** |
| `origin: src.origin ?? 'installed'` → `?? 'bundled'` in the loader | **1 of 6 fails** (the upload-impostor guard) |

Every mutation was grep-confirmed to have landed before the run, and the tree was restored after each. Nothing here is decorative.

### 5. Ratchet

`3300`, unchanged from `origin/main` — the baseline file is not in the diff and the PR consumes zero headroom. `node scripts/check-core-decoupling.mjs` → *"Dev Platform references held at 3300."*

### Defect found and fixed — `67bf3971`

The ramp's own doc comment miscounted itself: it claimed *"the four that happen to be covered by C2b's list"* and *"All four are on C2b's list TODAY"* directly above a block of **three** entries. Enumerating both lists against each other:

```
@omadia/memory-postgres     -> on C2b's list with graphPool: no
@omadia/orchestrator        -> yes
@omadia/orchestrator-extras -> yes
@omadia/verifier            -> yes
```

The ramp has four members and three of them are on C2b's list. `memory-postgres` is the fourth and is precisely the one that is **not** — and that disjointness *is* issue #794. A comment folding it in with the other three erases the reason this list had to exist separately from C2b's, which is the single most important thing a future reader of a dated security ramp needs to understand. In a module where the comment is the audit record, an off-by-one that contradicts the code below it is a real defect. Corrected, with the exception called out inline.

### Notes for follow-up (not blocking)

- **Local-dev shadowing is now boot-critical.** `localDevPackageStore` is in the catalog's `extraSources` (winning collisions, `origin: 'installed'`) but is *not* in `ToolPluginRuntime`'s deps, so `resolvePackagePath` still resolves to the **built-in** path. A dev shadowing a bundled pool consumer's id would therefore run bundled code with the ramp withheld → boot abort. Pre-existing wiring asymmetry, but this PR is what makes it boot-critical. `PLUGIN_DEV_DIR` is opt-in and off by default.
- **An upload can brick boot** by claiming a bundled pool consumer's id — it wins the catalog, loses the ramp, and `activate()` throws. Strictly better than `main` (which is bricked unconditionally), and it needs upload rights, but it is a new denial-of-boot edge the grant surface should close.
- **`BUILT_IN_PACKAGES_DIR` is env-configurable** (`config.ts:559`), so "ships inside the middleware image" is an operator-trust statement, not a filesystem invariant. Fine under the current threat model — an operator setting env vars already owns the process — but the comment reads stronger than the code guarantees.

### Verification run

Worktree `fix/794-sql-gate-boot`, Node v22.22.3, Postgres via `MEMORY_PG_TEST_URL`/`GRAPH_PG_TEST_URL` on `127.0.0.1:55438`.

| Gate | Result |
|---|---|
| `npm run build` | pass |
| `npm run typecheck` | pass |
| `npm run typecheck:test` | pass — 406 known errors, no regressions (baseline 406) |
| `npm run lint` | pass |
| `npm test` (full suite, `pipefail`) | **7869 tests, 7867 pass, 0 fail, 2 skipped**, exit 0 |
| `bundledPluginSqlGateBoot.pg` + `pluginSqlPermission` | **34/34 pass, 0 skipped** — the pg suites really ran, they did not skip |
| `check-core-decoupling.mjs` | held at 3300 |
| Mutation check (3 mutations) | all three killed |

All gates re-run after the comment fix.

### Verdict: **MERGE**

The gate is narrowed on the correct axis rather than widened, the ramp is keyed on a question the manifest cannot answer about itself, and the boot test's oracle is the same condition `index.ts` aborts on. Mutation testing kills every load-bearing element. Ship it.
