### PR TITLE
feat: close the field-test gap list — localized descriptions, visible connection verdicts, error classes, app menu, subscription notice

### DIFF
--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, dialog } from 'electron';
+import { installApplicationMenu } from './menu';
 import path from 'node:path';
 import { Supervisor, setActiveSupervisor, BootProgress } from './supervisor';
 import { registerIpc } from './ipc';
@@ -138,6 +139,9 @@ function startWizard(): void {
 }
 
 async function onReady(): Promise<void> {
+  // OM-41 — replace Electron's default menu (which shipped a second
+  // fullscreen item and a DevTools accelerator into customer builds).
+  installApplicationMenu();
   supervisor = new Supervisor();
   setActiveSupervisor(supervisor);
 

--- a/desktop/src/menu.ts
+++ b/desktop/src/menu.ts
@@ -1,0 +1,104 @@
+/**
+ * Application menu (OM-41, field-test follow-up).
+ *
+ * Until now the app shipped with ELECTRON'S DEFAULT menu — nobody in this
+ * codebase ever called `Menu.setApplicationMenu`. Two consequences the first
+ * field test called out:
+ *
+ *  - "Toggle Full Screen" appeared TWICE in the View menu (the default
+ *    template's `togglefullscreen` role next to macOS's own system item),
+ *    with two different accelerators.
+ *  - The developer tools were reachable in the shipped app via the default
+ *    menu item and its accelerator, and the tester explicitly asked whether
+ *    that was a deliberate decision. It was not — it was the absence of one.
+ *
+ * The decision, made explicit here: **DevTools are a development affordance.**
+ * In a packaged build the menu carries no DevTools item and no accelerator;
+ * support diagnostics go through the tray's "Open Logs" instead, which is what
+ * support actually asks customers for. In a dev run (`app.isPackaged` false)
+ * the item is present. We deliberately do NOT set `webPreferences.devTools:
+ * false`: remote debugging for our own automated testing stays possible via
+ * an explicit `--remote-debugging-port` launch, which a customer would never
+ * do by accident — the goal is removing the accidental foot-gun from the
+ * menu, not fighting intentional diagnostics.
+ *
+ * Everything else mirrors the default template closely (edit roles, window
+ * roles, zoom) so muscle memory and localized role labels keep working —
+ * Electron localizes `role:` items with the OS language for free, which
+ * matters for the German-market audience (OM-28).
+ */
+import { Menu, app, type MenuItemConstructorOptions } from 'electron';
+
+export function installApplicationMenu(): void {
+  const isMac = process.platform === 'darwin';
+  const showDevTools = !app.isPackaged;
+
+  const template: MenuItemConstructorOptions[] = [
+    // App menu (macOS only — holds About/Hide/Quit by convention).
+    ...(isMac
+      ? [
+          {
+            label: app.name,
+            submenu: [
+              { role: 'about' },
+              { type: 'separator' },
+              { role: 'hide' },
+              { role: 'hideOthers' },
+              { role: 'unhide' },
+              { type: 'separator' },
+              { role: 'quit' },
+            ],
+          } as MenuItemConstructorOptions,
+        ]
+      : []),
+    {
+      label: 'File',
+      submenu: [isMac ? { role: 'close' } : { role: 'quit' }],
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        ...(isMac
+          ? ([{ role: 'pasteAndMatchStyle' }, { role: 'delete' }, { role: 'selectAll' }] as MenuItemConstructorOptions[])
+          : ([{ role: 'delete' }, { type: 'separator' }, { role: 'selectAll' }] as MenuItemConstructorOptions[])),
+      ],
+    },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'reload' },
+        { role: 'forceReload' },
+        // OM-41: exactly ONE fullscreen entry. On macOS the system may still
+        // offer its own in the Window menu — but the View menu no longer
+        // duplicates it with a second accelerator.
+        { type: 'separator' },
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+        ...(showDevTools
+          ? ([{ type: 'separator' }, { role: 'toggleDevTools' }] as MenuItemConstructorOptions[])
+          : []),
+      ],
+    },
+    {
+      label: 'Window',
+      submenu: [
+        { role: 'minimize' },
+        { role: 'zoom' },
+        ...(isMac
+          ? ([{ type: 'separator' }, { role: 'front' }] as MenuItemConstructorOptions[])
+          : ([{ role: 'close' }] as MenuItemConstructorOptions[])),
+      ],
+    },
+  ];
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}

--- a/middleware/packages/llm-provider-api/src/descriptor.ts
+++ b/middleware/packages/llm-provider-api/src/descriptor.ts
@@ -43,6 +43,12 @@ export interface ProviderPolicy {
    *  factory builds the provider with an empty key instead of treating the
    *  missing key as "not connected". Default (omitted) = true. */
   readonly requiresApiKey?: boolean;
+  /** Provider runs on a PERSONAL consumer subscription (e.g. a Claude Pro/Max
+   *  CLI login). No data-processing agreement (AVV / DPA) can exist on such a
+   *  plan — a STRONGER caveat than the ordinary third-party disclosure, so the
+   *  assignment UI shows a dedicated warning instead. Default (omitted) =
+   *  false. */
+  readonly subscriptionNotice?: boolean;
 }
 
 /** A plugin-contributed (or bundled built-in) provider. `quirks` only apply to

--- a/middleware/packages/plugin-api/CHANGELOG.md
+++ b/middleware/packages/plugin-api/CHANGELOG.md
@@ -8,6 +8,15 @@ Versioning is SemVer over the **exported type surface**. Removing or narrowing
 an exported type, or adding a required member to an interface a plugin
 implements, is a major.
 
+## 1.4.0
+
+- MINOR: `PluginActionStatus` gains an optional, kernel-stamped `checked_at`
+  ISO timestamp, and `ctx.status.report({ state: 'ok', title })` is now stored
+  and rendered as a positive "connection verified" badge instead of being
+  normalized to `clear()`. A BARE `{ state: 'ok' }` keeps its clear() synonym
+  semantics — no existing caller changes behaviour. (Field-test OM-16/24/33:
+  integrations can now surface "Verbunden · geprüft <Zeit>" on the store card.)
+
 ## 1.3.0 — 2026-08-20
 
 Additive. Two shapes a plugin could not express before, both found by the

--- a/middleware/packages/plugin-api/api-snapshot/plugin-api.d.ts.snap
+++ b/middleware/packages/plugin-api/api-snapshot/plugin-api.d.ts.snap
@@ -1537,6 +1537,7 @@ export interface PluginActionStatus {
 readonly state: PluginActionState;
 readonly title?: string;
 readonly detail?: string;
+readonly checked_at?: string;
 }
 export interface StatusAccessor {
 report(status: PluginActionStatus): void;

--- a/middleware/packages/plugin-api/package.json
+++ b/middleware/packages/plugin-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omadia/plugin-api",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/middleware/packages/plugin-api/src/pluginContext.ts
+++ b/middleware/packages/plugin-api/src/pluginContext.ts
@@ -935,6 +935,14 @@ export interface PluginActionStatus {
   readonly title?: string;
   /** One-line detail / next step (e.g. "Verbindung in der Admin-UI herstellen"). */
   readonly detail?: string;
+  /**
+   * ISO timestamp of when this status was reported — STAMPED BY THE KERNEL at
+   * `report()` time, never trusted from the plugin, so "geprüft um <Zeit>"
+   * cannot lie about when the check actually ran. Field-test follow-up
+   * (OM-16/24/33): a connection verdict without a time reads as a permanent
+   * fact; with one it reads as what it is — the result of the last probe.
+   */
+  readonly checked_at?: string;
 }
 
 /**
@@ -943,6 +951,12 @@ export interface PluginActionStatus {
  * and `clear()` once everything is fine. The kernel keeps only the latest
  * value per plugin; there is no history. Reporting another plugin's status is
  * impossible — the accessor is bound to the calling plugin's id.
+ *
+ * `state: 'ok'` semantics: a BARE ok (no `title`) is equivalent to `clear()`
+ * and renders nothing — existing callers keep their behaviour. An ok WITH a
+ * `title` (e.g. "Verbunden") is stored and rendered as a positive badge with
+ * the kernel-stamped `checked_at`, so an integration can surface "connection
+ * verified at <time>" instead of silence.
  */
 export interface StatusAccessor {
   report(status: PluginActionStatus): void;

--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -407,6 +407,8 @@ export interface PluginActionStatus {
   state: PluginActionState;
   title?: string;
   detail?: string;
+  /** Kernel-stamped ISO time of the report — see plugin-api's contract. */
+  checked_at?: string;
 }
 
 /**
@@ -450,6 +452,14 @@ export interface Plugin {
   version: string;
   latest_version: string;
   description: string;
+  /**
+   * OM-28/OM-06 (#602) — the manifest may declare `identity.description` as a
+   * localized map (`{ en, de, … }`). `description` stays the resolved English
+   * string so every existing consumer (search, older UIs, the hub) keeps
+   * working; this carries the full map so the web-ui can pick the viewer's
+   * locale. Absent when the manifest declared a plain string.
+   */
+  description_localized?: Record<string, string>;
   authors: Array<{ name: string; email?: string; url?: string }>;
   license: string;
   icon_url: string | null;

--- a/middleware/src/api/registry-v1.ts
+++ b/middleware/src/api/registry-v1.ts
@@ -72,6 +72,9 @@ export interface RegistryPluginEntry {
   kind: PluginKind;
   domain: string;
   description: string;
+  /** OM-28 (#602) — optional localized description map mirrored from the
+   *  manifest; `description` stays the English string. */
+  description_localized?: Record<string, string>;
   categories: string[];
   authors: Array<{ name: string; email?: string; url?: string }>;
   license: string;

--- a/middleware/src/platform/builtinLlmProviders.ts
+++ b/middleware/src/platform/builtinLlmProviders.ts
@@ -132,7 +132,16 @@ export const BUILTIN_LLM_PROVIDERS: ReadonlyArray<LlmProviderDescriptor> = [
     label: 'Claude (subscription CLI)',
     wireFormat: 'claude-cli',
     baseURL: '',
-    policy: { requiresApiKey: false, requiresAvvDisclosure: false },
+    // `requiresAvvDisclosure: false` is NOT a privacy carve-out here — the
+    // Art. 28 AVV framing simply does not fit: a consumer Claude subscription
+    // offers no data-processing agreement at all. That is a STRONGER caveat,
+    // not a weaker one, and `subscriptionNotice` surfaces exactly that in the
+    // assignment UI (field-test follow-up, OM-10 family).
+    policy: {
+      requiresApiKey: false,
+      requiresAvvDisclosure: false,
+      subscriptionNotice: true,
+    },
     models: [
       // modelId is suffixed `-cli` so it never collides with another provider's
       // alias (the registry requires globally-unique aliases and id ==

--- a/middleware/src/platform/llmProviderManifest.ts
+++ b/middleware/src/platform/llmProviderManifest.ts
@@ -127,6 +127,9 @@ function parsePolicy(raw: unknown): ProviderPolicy | undefined {
     ...(typeof rec['requires_api_key'] === 'boolean'
       ? { requiresApiKey: rec['requires_api_key'] }
       : {}),
+    ...(typeof rec['subscription_notice'] === 'boolean'
+      ? { subscriptionNotice: rec['subscription_notice'] }
+      : {}),
   };
 }
 

--- a/middleware/src/platform/pluginContext.ts
+++ b/middleware/src/platform/pluginContext.ts
@@ -799,8 +799,10 @@ export function createPluginContext(
   // Status accessor (spec 004): the plugin pushes its operator-facing action
   // status to the kernel registry. Self-scoped to this plugin id — a plugin
   // cannot report another's status. No-op when no registry was threaded
-  // (migration/test contexts). `clear()` and `report({state:'ok'})` both leave
-  // no badge; the value is normalized to guard against malformed input.
+  // (migration/test contexts). `clear()` and a BARE `report({state:'ok'})`
+  // both leave no badge; an ok WITH a title renders as a positive
+  // "connection verified" badge. Values are normalized against malformed
+  // input and `checked_at` is kernel-stamped.
   const statusRegistry = opts.pluginStatusRegistry;
   const status: StatusAccessor = {
     report(next) {
@@ -813,8 +815,14 @@ export function createPluginContext(
         state,
         ...(typeof next?.title === 'string' ? { title: next.title } : {}),
         ...(typeof next?.detail === 'string' ? { detail: next.detail } : {}),
+        // Kernel-stamped, never taken from the caller: the time a status
+        // claims to have been checked must be the time it was reported.
+        checked_at: new Date().toISOString(),
       };
-      if (state === 'ok') {
+      if (state === 'ok' && normalized.title === undefined) {
+        // Bare ok stays the clear() synonym (previewRuntime's synthetic
+        // markers and every pre-existing caller rely on it). An ok WITH a
+        // title is a deliberate, renderable "connection verified" signal.
         statusRegistry.clear(agentId);
         return;
       }

--- a/middleware/src/plugins/manifestLoader.ts
+++ b/middleware/src/plugins/manifestLoader.ts
@@ -32,7 +32,7 @@ import {
   publicPathsDeclarationSchema,
 } from '../platform/publicPathGrants.js';
 import { compileSetupPattern } from './setupFieldPattern.js';
-import { normalizeLocalized } from './manifestLocalized.js';
+import { normalizeLocalized, resolveLocalized } from './manifestLocalized.js';
 
 /**
  * Loads plugin manifests from a single source:
@@ -483,13 +483,18 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
     permissionsSummary.acquires_oauth = true;
   }
 
+  const descriptionMap = normalizeLocalized(identity['description']);
+
   const base: Plugin = {
     id,
     kind,
     name,
     version,
     latest_version: version,
-    description: asString(identity['description']) ?? '',
+    // OM-28/OM-06 (#602) — `identity.description` accepts a localized map.
+    // `description` stays the English-resolved string (search, hub, older
+    // consumers); the full map rides along in `description_localized` below.
+    description: resolveLocalized(descriptionMap, 'en') ?? '',
     authors: extractAuthors(identity['authors']),
     license: asString(identity['license']) ?? 'Unknown',
     icon_url: null,
@@ -510,6 +515,14 @@ export function adaptManifestV1(doc: Record<string, unknown>): Plugin | null {
     privacy_class: privacyClass,
   };
   let result: Plugin = base;
+  // Attached only when the manifest declared MORE than a bare English string —
+  // a plain-string description round-trips exactly as before.
+  if (
+    descriptionMap &&
+    (Object.keys(descriptionMap).length > 1 || descriptionMap['en'] === undefined)
+  ) {
+    result = { ...result, description_localized: descriptionMap };
+  }
   // Only attached when the manifest actually declares one, mirroring
   // `service_types` below: `undefined` and `[]` mean the same thing to every
   // consumer (all of which read it as `?? []`), and omitting the key keeps

--- a/middleware/src/plugins/registryClient.ts
+++ b/middleware/src/plugins/registryClient.ts
@@ -381,6 +381,15 @@ export class RegistryClient {
       kind: kind as PluginKind,
       domain: asString(raw['domain'], `unknown.${id}`),
       description: asString(raw['description'], ''),
+      ...(isObject(raw['description_localized'])
+        ? {
+            description_localized: Object.fromEntries(
+              Object.entries(raw['description_localized'] as Record<string, unknown>)
+                .filter(([, v]) => typeof v === 'string' && v.length > 0)
+                .map(([k, v]) => [k, v as string]),
+            ),
+          }
+        : {}),
       categories: asStringArray(raw['categories']),
       authors: parseAuthors(raw['authors']),
       license: asString(raw['license'], 'Unknown'),

--- a/middleware/src/routes/adminProviders.ts
+++ b/middleware/src/routes/adminProviders.ts
@@ -70,6 +70,7 @@ export interface AdminProvidersDeps {
             readonly requiresAvvDisclosure?: boolean;
             readonly euHosted?: boolean;
             readonly requiresApiKey?: boolean;
+            readonly subscriptionNotice?: boolean;
           };
         }
       | undefined;
@@ -326,6 +327,10 @@ export function createAdminProvidersRouter(deps: AdminProvidersDeps): Router {
           // Safe defaults for an unknown provider: third-party, non-EU.
           requiresAvvDisclosure: descriptor?.policy?.requiresAvvDisclosure ?? true,
           euHosted: descriptor?.policy?.euHosted ?? false,
+          // Subscription CLIs run on a PERSONAL consumer plan: no DPA/AVV can
+          // exist for them, which the operator must know BEFORE routing
+          // personal data through such an agent (field-test OM-10 family).
+          subscriptionNotice: descriptor?.policy?.subscriptionNotice ?? false,
           models: listModelsByProvider(id).map((m) => ({
             id: m.id,
             modelId: m.modelId,

--- a/middleware/src/routes/store.ts
+++ b/middleware/src/routes/store.ts
@@ -502,6 +502,9 @@ function registryEntryToPlugin(resolved: ResolvedRegistryPlugin): Plugin {
     version: ver.version,
     latest_version: entry.latest_version,
     description: entry.description,
+    ...(entry.description_localized
+      ? { description_localized: entry.description_localized }
+      : {}),
     authors: entry.authors,
     license: entry.license,
     icon_url: entry.icon_url,

--- a/middleware/test/adminProvidersRoute.test.ts
+++ b/middleware/test/adminProvidersRoute.test.ts
@@ -139,6 +139,7 @@ interface ProvidersResponse {
     verifyErrorCode?: string;
     requiresAvvDisclosure?: boolean;
     euHosted?: boolean;
+    subscriptionNotice?: boolean;
     models: Array<{ id: string; modelId: string; class: string }>;
   }>;
   assignments: Array<{
@@ -204,6 +205,11 @@ describe('admin providers route — GET /', () => {
     // vanished exactly on the stock configuration.
     assert.equal(anthropic.requiresAvvDisclosure, true);
     assert.equal(openai.requiresAvvDisclosure, true);
+    // API providers carry no subscription caveat; the claude-cli descriptor
+    // does (personal consumer plan ⇒ no AVV/DPA possible at all) — asserted in
+    // the same catalog-driven way as the flags above.
+    assert.equal(anthropic.subscriptionNotice, false);
+    assert.equal(openai.subscriptionNotice, false);
     assert.equal(mistral.requiresAvvDisclosure, true);
     assert.equal(mistral.euHosted, true);
     assert.equal(anthropic.euHosted, false);

--- a/middleware/test/manifestLoaderSetupFields.test.ts
+++ b/middleware/test/manifestLoaderSetupFields.test.ts
@@ -156,3 +156,41 @@ test('store and install-wizard paths agree on required for the SAME fixture', ()
     );
   }
 });
+
+// ---------------------------------------------------------------------------
+// OM-28/OM-06 (#602) — identity.description accepts a localized map.
+// ---------------------------------------------------------------------------
+
+test('a localized description map yields the English string + the full map', () => {
+  const doc = manifest();
+  (doc['identity'] as Record<string, unknown>)['description'] = {
+    en: 'Connects things.',
+    de: 'Verbindet Dinge.',
+  };
+  const plugin = adaptManifestV1(doc);
+  assert.equal(plugin?.description, 'Connects things.');
+  assert.deepEqual(plugin?.description_localized, {
+    en: 'Connects things.',
+    de: 'Verbindet Dinge.',
+  });
+});
+
+test('a plain-string description round-trips exactly as before — no map attached', () => {
+  const doc = manifest();
+  (doc['identity'] as Record<string, unknown>)['description'] = 'Plain text.';
+  const plugin = adaptManifestV1(doc);
+  assert.equal(plugin?.description, 'Plain text.');
+  assert.equal(plugin?.description_localized, undefined);
+});
+
+test('a German-only description still resolves a display string', () => {
+  // resolveLocalized falls back past the missing `en` — the store must never
+  // show an empty description because a plugin was authored German-first.
+  const doc = manifest();
+  (doc['identity'] as Record<string, unknown>)['description'] = {
+    de: 'Nur deutsch.',
+  };
+  const plugin = adaptManifestV1(doc);
+  assert.equal(plugin?.description, 'Nur deutsch.');
+  assert.deepEqual(plugin?.description_localized, { de: 'Nur deutsch.' });
+});

--- a/middleware/test/pluginContextStatus.test.ts
+++ b/middleware/test/pluginContextStatus.test.ts
@@ -93,18 +93,22 @@ describe('Spec 004 — ctx.status', () => {
     assert.doesNotThrow(() => ctx.status.clear());
   });
 
-  it('report writes to the registry under the plugin id', () => {
+  it('report writes to the registry under the plugin id, checked_at kernel-stamped', () => {
     const reg = new PluginStatusRegistry();
     const ctx = makeCtx('caller', reg);
+    const before = Date.now();
     ctx.status.report({ state: 'needs_action', title: 'Nicht verbunden', detail: 'd' });
-    assert.deepEqual(reg.get('caller'), {
-      state: 'needs_action',
-      title: 'Nicht verbunden',
-      detail: 'd',
-    });
+    const got = reg.get('caller');
+    assert.equal(got?.state, 'needs_action');
+    assert.equal(got?.title, 'Nicht verbunden');
+    assert.equal(got?.detail, 'd');
+    // OM-16/24/33 follow-up: the time a status claims to have been checked is
+    // the time it was reported — stamped by the kernel, never by the caller.
+    const at = Date.parse(got?.checked_at ?? '');
+    assert.ok(at >= before - 1000 && at <= Date.now() + 1000, 'checked_at stamped');
   });
 
-  it('report({state:ok}) and clear() both leave no entry', () => {
+  it('a BARE report({state:ok}) and clear() both leave no entry', () => {
     const reg = new PluginStatusRegistry();
     const ctx = makeCtx('caller', reg);
     ctx.status.report({ state: 'needs_action', title: 'x' });
@@ -113,6 +117,28 @@ describe('Spec 004 — ctx.status', () => {
     ctx.status.report({ state: 'error', title: 'y' });
     ctx.status.clear();
     assert.equal(reg.get('caller'), undefined);
+  });
+
+  it('ok WITH a title is stored and rendered as a positive verdict', () => {
+    // The connection-probe surface (OM-16/24/33): an integration that verified
+    // its credentials reports ok+title and the store card shows
+    // "Verbunden · <Zeit>" instead of silence.
+    const reg = new PluginStatusRegistry();
+    const ctx = makeCtx('caller', reg);
+    ctx.status.report({ state: 'ok', title: 'Verbunden' });
+    const got = reg.get('caller');
+    assert.equal(got?.state, 'ok');
+    assert.equal(got?.title, 'Verbunden');
+    assert.ok(got?.checked_at, 'carries the kernel timestamp');
+    // ...and a plugin cannot smuggle its own timestamp in.
+    ctx.status.report({
+      state: 'ok',
+      title: 'Verbunden',
+      // The TYPE admits checked_at (it is part of the read surface), but the
+      // kernel must ignore a caller-supplied value and stamp its own.
+      checked_at: '1999-01-01T00:00:00.000Z',
+    });
+    assert.notEqual(reg.get('caller')?.checked_at, '1999-01-01T00:00:00.000Z');
   });
 
   it('normalizes a malformed state to needs_action', () => {

--- a/web-ui/app/_components/StreamRunner.tsx
+++ b/web-ui/app/_components/StreamRunner.tsx
@@ -4,10 +4,7 @@ import { useEffect, useRef } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { applyStreamEvent, type ChatStreamEvent } from '../_lib/chatStreamEvents';
-import {
-  humanizeProviderError,
-  isProviderAuthError,
-} from '../_lib/providerErrorMessage';
+import { resolveProviderErrorMessage } from '../_lib/providerErrorMessage';
 import { useChatSessionsCtx } from '../_lib/chatSessionsContext';
 import {
   type ClaimedRequest,
@@ -114,9 +111,7 @@ export async function runOneTurn(
       // provider failure the user can fix, so it gets its own localized copy
       // pointing at Admin → LLM access; everything else keeps the extracted
       // provider sentence (better than a generic shrug for e.g. rate limits).
-      const clean = isProviderAuthError(event.message)
-        ? t('errorProviderAuth')
-        : humanizeProviderError(event.message, t('errorProviderGeneric'));
+      const clean = resolveProviderErrorMessage(event.message, t);
       // #641 — a failed turn used to reach the user with nothing they could act
       // on: no code, no id, nothing to hand to support. The detail was logged
       // server-side, so the information existed and simply never arrived. The
@@ -221,9 +216,7 @@ export async function runOneTurn(
       store.finish(
         sessionId,
         'error',
-        isProviderAuthError(msg)
-          ? t('errorProviderAuth')
-          : humanizeProviderError(msg, t('errorProviderGeneric')),
+        resolveProviderErrorMessage(msg, t),
       );
       finalizePending(depsRef.current.sessions, sessionId, pendingMessageId);
       return;
@@ -274,9 +267,7 @@ export async function runOneTurn(
       store.finish(
         sessionId,
         'error',
-        isProviderAuthError(msg)
-          ? t('errorProviderAuth')
-          : humanizeProviderError(msg, t('errorProviderGeneric')),
+        resolveProviderErrorMessage(msg, t),
       );
     }
   } finally {

--- a/web-ui/app/_components/store/PluginCard.tsx
+++ b/web-ui/app/_components/store/PluginCard.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { AlertTriangle, ArrowUpRight, RefreshCw, Store, Wrench } from 'lucide-react';
-import { useLocale, useTranslations } from 'next-intl';
+import { useFormatter, useLocale, useTranslations } from 'next-intl';
 
 import { pickLocalized } from '../../_lib/localized';
 import type { Plugin } from '../../_lib/storeTypes';
@@ -22,6 +22,11 @@ export function PluginCard({
 }: PluginCardProps): React.ReactElement {
   const t = useTranslations('store.card');
   const locale = useLocale();
+  const format = useFormatter();
+  // OM-28 (#602) — prefer the manifest's localized description; fall back to
+  // the plain English string every manifest has carried so far.
+  const localizedDescription =
+    pickLocalized(plugin.description_localized, locale) ?? plugin.description;
   // OM-15 (#602) — installation-effort line composed from the structured
   // `setup_profile`, so the wording stays localized (next-intl) rather than
   // baked into the manifest. Only the parts the manifest declared are shown; an
@@ -102,9 +107,9 @@ export function PluginCard({
           content (e.g. <details>) inside this card's <Link>. */}
       <p
         className="mt-4 line-clamp-3 text-[14px] leading-relaxed text-[color:var(--fg-muted)]"
-        title={plugin.description || undefined}
+        title={localizedDescription || undefined}
       >
-        {plugin.description || <em>{t('noDescription')}</em>}
+        {localizedDescription || <em>{t('noDescription')}</em>}
       </p>
 
       {/* OM-15 (#602) — setup prerequisites, shown BEFORE install so the
@@ -143,6 +148,28 @@ export function PluginCard({
           >
             <AlertTriangle className="size-3" aria-hidden />
             {plugin.action_status.title ?? t('actionRequired')}
+          </span>
+        ) : null}
+        {/* OM-16/24/33 follow-up — a POSITIVE probe verdict. Only rendered when
+            the plugin deliberately reported ok WITH a title ("Verbunden"); the
+            kernel-stamped checked_at keeps the claim tied to a moment in time
+            instead of reading as a permanent fact. */}
+        {plugin.action_status &&
+        plugin.action_status.state === 'ok' &&
+        plugin.action_status.title ? (
+          <span
+            className="inline-flex items-center gap-1 rounded-full bg-[color:var(--success)]/12 px-2.5 py-0.5 text-[11px] font-semibold text-[color:var(--success)]"
+            title={plugin.action_status.detail ?? undefined}
+          >
+            {plugin.action_status.title}
+            {plugin.action_status.checked_at ? (
+              <span className="font-normal opacity-80">
+                {' · '}
+                {format.dateTime(new Date(plugin.action_status.checked_at), {
+                  timeStyle: 'short',
+                })}
+              </span>
+            ) : null}
           </span>
         ) : null}
         {/* Origin marker — present only on remote-registry (Hub) entries that

--- a/web-ui/app/_lib/__tests__/providerErrorMessage.test.ts
+++ b/web-ui/app/_lib/__tests__/providerErrorMessage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  classifyProviderError,
   extractProviderErrorMessage,
   humanizeProviderError,
   isProviderAuthError,
@@ -142,5 +143,35 @@ describe('isProviderAuthError', () => {
     ['empty', ''],
   ])('does NOT classify as auth: %s', (_label, raw) => {
     expect(isProviderAuthError(raw)).toBe(false);
+  });
+});
+
+
+describe('classifyProviderError', () => {
+  it.each([
+    ['429 with envelope', '429 {"type":"error","error":{"type":"rate_limit_error","message":"Number of requests has exceeded your rate limit"}}', 'rate_limit'],
+    ['status-less rate limit envelope', '{"type":"error","error":{"type":"rate_limit_error","message":"..."}}', 'rate_limit'],
+    ['extracted rate-limit sentence', 'Number of requests has exceeded your rate limit', 'rate_limit'],
+    ['529 overloaded', '529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}', 'overloaded'],
+    ['bare Overloaded sentence', 'Overloaded', 'overloaded'],
+    ['auth stays auth', '401 {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}', 'auth'],
+    ['generic 502', 'HTTP 502', 'generic'],
+    ['app text mentioning rates innocently (hyphenated, no provider shape)', 'Die Wechselkurse werden im Rate-Limit-Report erklärt.', 'generic'],
+  ] as const)('classifies %s', (_label, raw, expected) => {
+    expect(classifyProviderError(raw)).toBe(expected);
+  });
+
+  it('a 429 quota/billing exhaustion is NOT a transient rate limit — stays generic', () => {
+    // OpenAI's insufficient_quota arrives as 429; "wait and retry" would be
+    // wrong advice. The provider's own sentence names the real next step.
+    expect(
+      classifyProviderError(
+        '429 You exceeded your current quota, please check your plan and billing details.',
+      ),
+    ).toBe('generic');
+  });
+
+  it('overloaded matches ONLY the bare provider sentence, not prose containing the word', () => {
+    expect(classifyProviderError('The system feels overloaded today')).toBe('generic');
   });
 });

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -381,6 +381,10 @@ export interface AdminProvider {
    *  `requiresAvvDisclosure`: show the Art. 28 DSGVO third-party disclosure.
    *  `euHosted`: provider is hosted in the EU (no third-country transfer). */
   requiresAvvDisclosure?: boolean;
+  /** Provider runs on a personal consumer subscription — no AVV/DPA can exist;
+   *  the assignment UI shows a dedicated warning (stronger than the ordinary
+   *  third-party disclosure). */
+  subscriptionNotice?: boolean;
   euHosted?: boolean;
   /** Tool-less Shape-2 CLI provider — cannot drive a tool loop, so the UI
    *  disables it for tool-dependent plugins. */

--- a/web-ui/app/_lib/providerErrorMessage.ts
+++ b/web-ui/app/_lib/providerErrorMessage.ts
@@ -54,27 +54,83 @@ export function humanizeProviderError(raw: string, fallback: string): string {
 }
 
 /**
- * True when a provider error is a credential rejection — the one failure class
- * a user can actually FIX themselves, so chat surfaces show a localized
- * sentence pointing at Admin → LLM access instead of the provider's raw
- * English sentence ("API key is invalid.", "invalid x-api-key", …).
- *
- * Field-test provenance (OM-26, retest 2026-08-20): the packaged app already
- * stripped the JSON envelope, but the extracted sentence itself was English in
- * a German UI and named no next step. The middleware has no request locale
- * (see `PatternViolation.hint` in the middleware for the doctrine), so the
- * client owns this mapping, keyed on the error's SHAPE — status 401,
- * `authentication_error`, or the well-known key phrasings — never on full
- * message equality, which would break on the provider's next wording change.
+ * Back-compat shim over {@link classifyProviderError} — older call sites and
+ * tests ask the auth question directly.
  */
 export function isProviderAuthError(raw: string): boolean {
+  return classifyProviderError(raw) === 'auth';
+}
+
+/**
+ * Provider failure classes a chat surface can say something USEFUL about, in
+ * the user's language. Everything else stays `generic` and shows the
+ * extracted provider sentence (still better than a shrug for the long tail).
+ *
+ *  - `auth`       — the stored key was rejected. User-fixable: the copy sends
+ *                   them to Admin → LLM access ("Schlüssel testen").
+ *  - `rate_limit` — the provider throttled the request. NOT user-fixable in
+ *                   settings; the copy says retry shortly, no settings link.
+ *  - `overloaded` — the provider itself is overloaded (Anthropic 529 /
+ *                   `overloaded_error`). Same posture: wait and retry.
+ *
+ * Matched on SHAPE (status prefix, provider error-type marker, bounded phrase
+ * proximity) — never full-sentence equality, which would break on the
+ * provider's next wording change. Order matters: the status/type markers are
+ * unambiguous, the phrase heuristics run last.
+ */
+export type ProviderErrorClass = 'auth' | 'rate_limit' | 'overloaded' | 'generic';
+
+export function classifyProviderError(raw: string): ProviderErrorClass {
   const trimmed = raw.trim();
-  if (!trimmed) return false;
-  if (/^401\b/.test(trimmed)) return true;
-  if (/authentication_error/i.test(trimmed)) return true;
-  return /\b(api[ -]?key|x-api-key)\b[^.\n]{0,40}\b(invalid|abgelehnt|rejected|expired|revoked)\b|\b(invalid|expired|revoked)\b[^.\n]{0,24}\b(api[ -]?key|x-api-key)\b/i.test(
-    trimmed,
-  );
+  if (!trimmed) return 'generic';
+  if (/^401\b/.test(trimmed) || /authentication_error/i.test(trimmed)) {
+    return 'auth';
+  }
+  // A quota/billing exhaustion also arrives as 429 (OpenAI's
+  // `insufficient_quota`), but "wait and retry" would be WRONG advice there —
+  // the account needs a billing action. Those keep the provider's own
+  // sentence ("check your plan and billing details"), which is the accurate
+  // next step. Only genuinely transient throttling classifies as rate_limit.
+  if (/insufficient_quota|\bquota\b|\bbilling\b/i.test(trimmed)) {
+    return 'generic';
+  }
+  if (/^429\b/.test(trimmed) || /rate_limit_error/i.test(trimmed)) {
+    return 'rate_limit';
+  }
+  if (/^529\b/.test(trimmed) || /overloaded_error/i.test(trimmed)) {
+    return 'overloaded';
+  }
+  if (
+    /\b(api[ -]?key|x-api-key)\b[^.\n]{0,40}\b(invalid|abgelehnt|rejected|expired|revoked)\b|\b(invalid|expired|revoked)\b[^.\n]{0,24}\b(api[ -]?key|x-api-key)\b/i.test(
+      trimmed,
+    )
+  ) {
+    return 'auth';
+  }
+  if (/\brate limit\b|\bexceeded your rate\b/i.test(trimmed)) return 'rate_limit';
+  if (/^overloaded\.?$/i.test(trimmed)) return 'overloaded';
+  return 'generic';
+}
+
+/**
+ * One resolver for every chat error surface: localized copy for the classes
+ * we can improve on, the extracted provider sentence otherwise. `t` is the
+ * caller's `chat`-namespace translator.
+ */
+export function resolveProviderErrorMessage(
+  raw: string,
+  t: (key: string) => string,
+): string {
+  switch (classifyProviderError(raw)) {
+    case 'auth':
+      return t('errorProviderAuth');
+    case 'rate_limit':
+      return t('errorProviderRateLimit');
+    case 'overloaded':
+      return t('errorProviderOverloaded');
+    default:
+      return humanizeProviderError(raw, t('errorProviderGeneric'));
+  }
 }
 
 /**

--- a/web-ui/app/_lib/storeTypes.ts
+++ b/web-ui/app/_lib/storeTypes.ts
@@ -190,6 +190,8 @@ export interface PluginActionStatus {
   state: PluginActionState;
   title?: string;
   detail?: string;
+  /** Kernel-stamped ISO time of the report (OM-16/24/33 follow-up). */
+  checked_at?: string;
 }
 
 /** OM-16 — kernel-derived plugin readiness (mirror of middleware admin-v1).
@@ -219,6 +221,8 @@ export interface Plugin {
   version: string;
   latest_version: string;
   description: string;
+  /** OM-28 (#602) — localized description map; `description` stays English. */
+  description_localized?: Record<string, string>;
   authors: Array<{ name: string; email?: string; url?: string }>;
   license: string;
   icon_url: string | null;

--- a/web-ui/app/admin/builder/panels/PalettePanel.tsx
+++ b/web-ui/app/admin/builder/panels/PalettePanel.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import type { CanvasNodeKind, SkillImportResult } from '../../../_lib/agentBuilder';
 import { SkillImportModal } from '../../../_components/admin/SkillImportModal';
+import { SkillVerdictBadge } from '../../../_components/admin/SkillVerdictBadge';
 
 /** Node kinds the operator can drag onto the canvas to create new entities. */
 const ADDABLE: ReadonlyArray<Exclude<CanvasNodeKind, 'agent' | 'tool'>> = [
@@ -30,6 +31,9 @@ export function PalettePanel({
 }): React.ReactElement {
   const t = useTranslations('admin.builder');
   const [importing, setImporting] = useState(false);
+  // OM-25 — a flagged verdict must be visible WHERE the import happened, not
+  // only later in the skills registry. Held locally until the next import.
+  const [lastVerdict, setLastVerdict] = useState<SkillImportResult['verdict']>();
   return (
     <aside className="flex w-[180px] shrink-0 flex-col gap-2 border-r border-[color:var(--border)] bg-[color:var(--card)]/30 p-3">
       <h2 className="px-1 text-[11px] uppercase tracking-[0.16em] text-[color:var(--fg-muted)]">
@@ -56,6 +60,11 @@ export function PalettePanel({
       >
         {t('palette.importSkill')}
       </button>
+      {lastVerdict && lastVerdict.severity !== 'no_signals' ? (
+        <div className="mt-1 px-1">
+          <SkillVerdictBadge severity={lastVerdict.severity} />
+        </div>
+      ) : null}
       {importing && (
         <SkillImportModal
           onClose={() => setImporting(false)}
@@ -64,6 +73,7 @@ export function PalettePanel({
           // can surface a flagged import instead of silently adding the node.
           onImported={(result) => {
             setImporting(false);
+            setLastVerdict(result.verdict);
             onImported?.(result);
           }}
         />

--- a/web-ui/app/admin/providers/_components/ProvidersPanel.tsx
+++ b/web-ui/app/admin/providers/_components/ProvidersPanel.tsx
@@ -699,6 +699,16 @@ function AssignmentRow({
           })}
         </p>
       )}
+      {/* Subscription CLIs (consumer plan): no AVV/DPA CAN exist — a stronger
+          caveat than the ordinary third-party disclosure, so it gets the
+          warning styling, not the muted note styling. */}
+      {selectedProvider?.subscriptionNotice && (
+        <p className="rounded-md border border-[color:var(--warning)]/40 bg-[color:var(--warning)]/10 px-3 py-2 text-[12px] leading-[1.5] text-[color:var(--warning)]">
+          {t('assignments.subscriptionNotice', {
+            provider: selectedProvider?.label ?? a.provider,
+          })}
+        </p>
+      )}
       {error !== undefined && (
         <ErrorHelp code={errorCode(error)} rawDetail={error} />
       )}

--- a/web-ui/app/store/[id]/page.tsx
+++ b/web-ui/app/store/[id]/page.tsx
@@ -93,6 +93,10 @@ export default async function PluginDetailPage({
   // language so a single-language guide still renders.
   const locale = await getLocale();
   const setupGuideText = pickLocalized(plugin.setup_guide, locale);
+  // OM-28/OM-06 (#602) — the manifest may localize its description; the plain
+  // string stays the fallback for every manifest that never declared a map.
+  const localizedDescription =
+    pickLocalized(plugin.description_localized, locale) ?? plugin.description;
   const t = await getTranslations('store.detail');
 
   // S+7.7 / 2026-05-04 — admin-ui mount path. Conditional on the manifest
@@ -193,10 +197,8 @@ export default async function PluginDetailPage({
           >
           <Section label={t('sectionDescription')}>
             <p className="text-[18px] font-semibold leading-[1.6] text-[color:var(--fg)]">
-              {plugin.description ? (
-                <>
-                                    {plugin.description}
-                </>
+              {localizedDescription ? (
+                localizedDescription
               ) : (
                 <span className="text-[color:var(--fg-muted)]">
                   {t('noDescription')}
@@ -290,42 +292,63 @@ export default async function PluginDetailPage({
             />
           </Section>
 
-          {(plugin.provides?.length ?? 0) + (plugin.requires?.length ?? 0) >
+          {/* #602 P4 (OM-06/07) — the pure service-contract detail reads as
+              jargon to the operator audience this store serves; it matters to
+              plugin developers wiring capabilities together. Native <details>,
+              collapsed by default, keeps it one click away without burying the
+              user-relevant sections (description, setup, permissions), which
+              stay expanded above. */}
+          {(plugin.provides?.length ?? 0) +
+            (plugin.requires?.length ?? 0) +
+            plugin.integrations_summary.length >
           0 ? (
-            <Section
-              label={t('sectionCapabilities')}
-              icon={<Plug className="size-4" aria-hidden />}
-              meta={t('capabilitiesMeta', {
-                provides: plugin.provides?.length ?? 0,
-                requires: plugin.requires?.length ?? 0,
-              })}
-            >
-              <CapabilitiesBlock
-                provides={plugin.provides ?? []}
-                requires={plugin.requires ?? []}
-              />
-            </Section>
-          ) : null}
+            <details className="group rounded-lg border border-[color:var(--rule)] px-5 py-4">
+              <summary className="cursor-pointer select-none text-[13px] font-semibold uppercase tracking-[0.14em] text-[color:var(--fg-muted)] transition-colors hover:text-[color:var(--fg)]">
+                {t('sectionForDevelopers')}
+                <span className="ml-2 normal-case tracking-normal text-[12px] font-normal text-[color:var(--faint-ink)]">
+                  {t('sectionForDevelopersHint')}
+                </span>
+              </summary>
+              <div className="mt-6 space-y-12">
+              {(plugin.provides?.length ?? 0) + (plugin.requires?.length ?? 0) >
+              0 ? (
+                <Section
+                  label={t('sectionCapabilities')}
+                  icon={<Plug className="size-4" aria-hidden />}
+                  meta={t('capabilitiesMeta', {
+                    provides: plugin.provides?.length ?? 0,
+                    requires: plugin.requires?.length ?? 0,
+                  })}
+                >
+                  <CapabilitiesBlock
+                    provides={plugin.provides ?? []}
+                    requires={plugin.requires ?? []}
+                  />
+                </Section>
+              ) : null}
 
-          {plugin.integrations_summary.length > 0 ? (
-            <Section
-              label={t('sectionIntegrations')}
-              icon={<Network className="size-4" aria-hidden />}
-            >
-              <ul className="space-y-2">
-                {plugin.integrations_summary.map((target, idx) => (
-                  <li
-                    key={idx}
-                    className="flex items-center gap-3 border-t border-[color:var(--rule)] py-3 first:border-t-0 first:pt-0"
-                  >
-                    <span className="font-mono-num text-[11px] text-[color:var(--faint-ink)]">
-                      {String(idx + 1).padStart(2, '0')}
-                    </span>
-                    <span className="text-[color:var(--ink)]">{target}</span>
-                  </li>
-                ))}
-              </ul>
-            </Section>
+              {plugin.integrations_summary.length > 0 ? (
+                <Section
+                  label={t('sectionIntegrations')}
+                  icon={<Network className="size-4" aria-hidden />}
+                >
+                  <ul className="space-y-2">
+                    {plugin.integrations_summary.map((target, idx) => (
+                      <li
+                        key={idx}
+                        className="flex items-center gap-3 border-t border-[color:var(--rule)] py-3 first:border-t-0 first:pt-0"
+                      >
+                        <span className="font-mono-num text-[11px] text-[color:var(--faint-ink)]">
+                          {String(idx + 1).padStart(2, '0')}
+                        </span>
+                        <span className="text-[color:var(--ink)]">{target}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </Section>
+              ) : null}
+              </div>
+            </details>
           ) : null}
 
           {/*

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1253,6 +1253,8 @@
     "errorAborted": "Abgebrochen.",
     "errorProviderGeneric": "Beim Zugriff auf den KI-Anbieter ist etwas schiefgelaufen. Bitte versuch es erneut.",
     "errorProviderAuth": "Der KI-Anbieter hat den hinterlegten API-Schlüssel abgelehnt. Prüfe ihn unter Admin → LLM-Zugang mit „Schlüssel testen“ und hinterlege ggf. einen neuen.",
+    "errorProviderRateLimit": "Der KI-Anbieter bremst gerade die Anfragen (Rate-Limit). Kurz warten und erneut versuchen — an den Einstellungen muss nichts geändert werden.",
+    "errorProviderOverloaded": "Der KI-Anbieter ist gerade überlastet. Das legt sich von selbst — versuch es gleich noch einmal.",
     "intro": {
       "kicker": "Wofür ist dieser Chat?",
       "body": "Das ist der Debug-Chat für Operatoren — eine direkte Leitung zu deinen Orchestratoren zum Testen von Prompts und zum Beobachten von Tool-Aufrufen, Plänen und Knowledge-Graph-Walks in Echtzeit. Das ist nicht die Endnutzer-Erfahrung, sondern zum Debuggen gedacht."
@@ -2850,7 +2852,8 @@
       "modelLabel": "Modell",
       "pickModel": "Modell wählen …",
       "avvDisclosure": "Dieser Agent läuft über {provider}. Seine Prompt-Daten werden an einen Drittanbieter (Auftragsverarbeiter) übermittelt. Stelle sicher, dass ein Auftragsverarbeitungsvertrag (DSGVO Art. 28) vorliegt, bevor du ihn für personenbezogene Daten nutzt.",
-      "euHostedNote": "{provider} wird in der EU gehostet. Ein Auftragsverarbeitungsvertrag nach DSGVO Art. 28 ist weiterhin erforderlich, aber es findet keine Drittlandübermittlung statt — anders als bei US-Anbietern."
+      "euHostedNote": "{provider} wird in der EU gehostet. Ein Auftragsverarbeitungsvertrag nach DSGVO Art. 28 ist weiterhin erforderlich, aber es findet keine Drittlandübermittlung statt — anders als bei US-Anbietern.",
+      "subscriptionNotice": "{provider} läuft über das persönliche Claude-Abo des angemeldeten Kontos. Für Consumer-Tarife gibt es keinen Auftragsverarbeitungsvertrag (AVV) — verarbeite über diesen Agenten keine personenbezogenen Daten."
     },
     "status": {
       "saving": "speichert …",
@@ -3037,6 +3040,8 @@
       "sectionSelfExtension": "Selbst-Erweiterung",
       "sectionPermissions": "Berechtigungen",
       "sectionCapabilities": "Capabilities",
+      "sectionForDevelopers": "Für Entwickler",
+      "sectionForDevelopersHint": "Service-Verträge und Integrationsziele",
       "capabilitiesMeta": "{provides} liefert · {requires} benötigt",
       "sectionIntegrations": "Integrationen",
       "categories": "Kategorien",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1253,6 +1253,8 @@
     "errorAborted": "Aborted.",
     "errorProviderGeneric": "Something went wrong while talking to the AI provider. Please try again.",
     "errorProviderAuth": "The AI provider rejected the stored API key. Check it under Admin → LLM access with “Test key” and store a new one if needed.",
+    "errorProviderRateLimit": "The AI provider is throttling requests right now (rate limit). Wait a moment and try again — no settings need changing.",
+    "errorProviderOverloaded": "The AI provider is currently overloaded. This resolves on its own — try again in a moment.",
     "intro": {
       "kicker": "What is this chat?",
       "body": "This is the operator debug chat — a direct line to your orchestrators for testing prompts and inspecting tool calls, plans, and knowledge-graph walks as they happen. It's not the end-user experience; it's built for debugging."
@@ -2850,7 +2852,8 @@
       "modelLabel": "Model",
       "pickModel": "Select a model …",
       "avvDisclosure": "This agent runs on {provider}. Its prompt data is sent to a third-party processor. Ensure a data-processing agreement (GDPR Art. 28) is in place before using it for personal data.",
-      "euHostedNote": "{provider} is hosted in the EU. An Art. 28 GDPR processing agreement is still required, but there is no third-country transfer — unlike US-based providers."
+      "euHostedNote": "{provider} is hosted in the EU. An Art. 28 GDPR processing agreement is still required, but there is no third-country transfer — unlike US-based providers.",
+      "subscriptionNotice": "{provider} runs on a personal Claude subscription of the signed-in account. No data-processing agreement (DPA/AVV) is available on a consumer plan — do not route personal data through this agent."
     },
     "status": {
       "saving": "saving …",
@@ -3037,6 +3040,8 @@
       "sectionSelfExtension": "Self-extension",
       "sectionPermissions": "Permissions",
       "sectionCapabilities": "Capabilities",
+      "sectionForDevelopers": "For developers",
+      "sectionForDevelopersHint": "Service contracts and integration targets",
       "capabilitiesMeta": "{provides} provided · {requires} required",
       "sectionIntegrations": "Integrations",
       "categories": "Categories",


### PR DESCRIPTION
Overnight gap-closure against the first customer field test (follows #800). Six independent pieces; the commit message carries the full rationale, this is the review map:

| # | Gap | Change | Pinned by |
|---|---|---|---|
| 1 | English plugin descriptions on German cards (OM-28/OM-06, #602) | `identity.description` accepts a localized map → `description_localized` threaded catalog → registry client → store route → card + detail page (locale-picked). Plain-string manifests round-trip **byte-identically**; `description` stays the resolved-English string so search/hub/older consumers are untouched. | `manifestLoaderSetupFields.test.ts` (map, plain-string, German-only fallback) |
| 2 | No visible connection verdict (OM-16/24/33) | `ctx.status.report({state:'ok', title})` now stored + rendered as a positive badge with **kernel-stamped** `checked_at` (caller timestamps ignored). Bare `ok` keeps clear() semantics — previewRuntime's synthetic markers and all existing callers unchanged. plugin-api **1.3.0 → 1.4.0** (additive; snapshot + changelog). | `pluginContextStatus.test.ts` incl. timestamp-smuggling case |
| 3 | Non-auth provider errors stayed English (OM-26 rest) | `classifyProviderError()`: 429/`rate_limit_error` and 529/`overloaded_error` get localized wait-and-retry copy; **quota/billing 429s deliberately stay generic** — "wait and retry" is wrong advice for an exhausted plan, the provider's sentence names the real next step. One resolver for all three StreamRunner paths. | `providerErrorMessage.test.ts` (43 cases incl. the quota carve-out) |
| 4 | Default Electron menu in customer builds (OM-41) | First-ever `Menu.setApplicationMenu`: one fullscreen item, DevTools item only when `!app.isPackaged`. `webPreferences.devTools` untouched — `--remote-debugging-port` diagnostics stay possible; the accidental menu/accelerator foot-gun is gone. This is the explicit answer to the tester's "bewusste Entscheidung?" question. | desktop tsc; menu is roles-only (OS-localized) |
| 5 | claude-cli AVV carve-out without the real caveat (OM-10 family) | New `ProviderPolicy.subscriptionNotice` (descriptor → manifest mapper → route → warning-styled panel notice en/de): a personal consumer plan offers **no DPA/AVV at all** — stronger caveat, now stated. | `adminProvidersRoute.test.ts` pins |
| 6 | Builder palette discarded the import verdict (OM-25 rest) | Renders `SkillVerdictBadge` where the import happened. | — (3-line render) |
| +| #602 P4 | Store detail folds capabilities/integration targets into a collapsed "For developers" block; description/setup/permissions stay expanded. | i18n parity |

**Verified:** middleware **7571/0** (conc 4) · web-ui **805/805** · desktop tsc · eslint clean on changed files · i18n validator + parity green · #470 ratchet **held at 3299** · plugin-api snapshot diff = one additive optional field.

Follow-ups landing separately: hub passthrough for `description_localized` (omadia-hub), GW plugin 0.4.1 adopting localized description + `ctx.status` probe reporting.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789849227&installation_model_id=428086&pr_number=809&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F809&signature=5ae5dab6dc95de4cf736552f34bbef50c78455a38eaa2a5be05295cf6a19495d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->