### PR TITLE
fix: fresh installs died at first boot — supervisor never passed CREDENTIAL_KEYCHAIN_KEY

### DIFF
--- a/desktop/src/renderer/wizard-i18n.js
+++ b/desktop/src/renderer/wizard-i18n.js
@@ -76,6 +76,14 @@
       // provisioning
       'provision.title': 'omadia wird eingerichtet…',
       'provision.starting': 'Starte…',
+      // Dynamic boot-progress phases (supervisor BootProgress.phase). The
+      // supervisor's `message` strings stay English fallbacks for unknown
+      // phases; known phases render localized.
+      'boot.starting-db': 'Eingebettete Datenbank wird gestartet…',
+      'boot.starting-kernel': 'omadia-Kernel wird gestartet…',
+      'boot.waiting-kernel': 'Warte, bis der Kernel bereit ist…',
+      'boot.starting-ui': 'Verwaltungsoberfläche wird gestartet…',
+      'boot.ready': 'omadia ist bereit.',
       'provision.hint':
         'Der erste Start führt Datenbank-Migrationen aus — das kann bis zu einer Minute dauern.',
       // nav

--- a/desktop/src/renderer/wizard.js
+++ b/desktop/src/renderer/wizard.js
@@ -161,7 +161,10 @@ async function provision() {
   const unsubProgress = bridge.onBootProgress((p) => {
     const pct = PHASE_PCT[p.phase] ?? 10;
     $('#barFill').style.width = pct + '%';
-    $('#progressMsg').textContent = p.message + (p.detail ? ' — ' + p.detail : '');
+    // Localized by PHASE (typed contract), supervisor message as fallback —
+    // a new phase never renders blank, it just renders English.
+    const phaseText = wt('boot.' + p.phase, p.message);
+    $('#progressMsg').textContent = phaseText + (p.detail ? ' — ' + p.detail : '');
     if (p.phase === 'error') $('#barFill').style.background = 'var(--err)';
   });
   // Live, granular log (kernel migrations, plugin activation, DB readiness …).

--- a/desktop/src/secrets.ts
+++ b/desktop/src/secrets.ts
@@ -24,6 +24,14 @@ import { log } from './log';
 interface SecretsBlob {
   /** base64 of 32 random bytes — the kernel's VAULT_KEY value. */
   vaultKey: string;
+  /**
+   * base64 of 32 random bytes — the kernel's CREDENTIAL_KEYCHAIN_KEY value.
+   * A SEPARATE trust domain from the vault by the kernel's own design (a
+   * compromised key must not unlock both). Optional because installs created
+   * before this field existed have a blob without it — the accessor
+   * generates + persists one lazily, which is also the fresh-install path.
+   */
+  credentialKeychainKey?: string;
   /** provider key id → value, e.g. { ANTHROPIC_API_KEY: "sk-..." }. */
   providerKeys: Record<string, string>;
 }
@@ -93,6 +101,22 @@ function generateVaultKey(): string {
 /** The kernel's VAULT_KEY (base64, decodes to 32 bytes). Generated on first call. */
 export function vaultKey(): string {
   return load().vaultKey;
+}
+
+/**
+ * The kernel's CREDENTIAL_KEYCHAIN_KEY. The credential keychain (#578)
+ * fail-hards in production without it — v0.115.0 shipped with the kernel
+ * reading it and the supervisor not passing it, which killed every FRESH
+ * install at first boot ("kernel did not become healthy"). Lazily generated
+ * and persisted exactly like the vault key.
+ */
+export function credentialKeychainKey(): string {
+  const blob = load();
+  if (!blob.credentialKeychainKey) {
+    blob.credentialKeychainKey = generateVaultKey();
+    persist();
+  }
+  return blob.credentialKeychainKey;
 }
 
 /** Store a provider API key (encrypted). */

--- a/desktop/src/supervisor.ts
+++ b/desktop/src/supervisor.ts
@@ -1,4 +1,5 @@
 import { spawn, ChildProcess } from 'node:child_process';
+import path from 'node:path';
 import { EventEmitter } from 'node:events';
 import { setTimeout as delay } from 'node:timers/promises';
 import {
@@ -158,6 +159,11 @@ export class Supervisor extends EventEmitter {
       // master key; the kernel fail-hards in production without it. Missing
       // here = dead fresh install (found the hard way on v0.115.0).
       CREDENTIAL_KEYCHAIN_KEY: credentialKeychainKey(),
+      // Core migrations (#802): the orchestrator's default path walk assumes
+      // the monorepo/Docker layout and lands in `node_modules/migrations` in
+      // the packaged app — second fresh-install killer found on v0.115.0.
+      // The explicit override removes the guesswork entirely.
+      MULTI_ORCH_MIGRATIONS_DIR: path.join(kernelCwd(), 'migrations'),
       PLATFORM_DATA_DIR: platformDataDir(),
       // The browser opens signed diagram URLs against this host base.
       DIAGRAM_PUBLIC_BASE_URL: `http://127.0.0.1:${port}`,

--- a/desktop/src/supervisor.ts
+++ b/desktop/src/supervisor.ts
@@ -10,7 +10,7 @@ import {
 } from './paths';
 import { findFreePorts, isPortFree } from './ports';
 import { startEmbeddedDb, EmbeddedDb } from './embeddedDb';
-import { vaultKey, allProviderKeys } from './secrets';
+import { credentialKeychainKey, vaultKey, allProviderKeys } from './secrets';
 import { log } from './log';
 
 export type BootPhase =
@@ -154,6 +154,10 @@ export class Supervisor extends EventEmitter {
       // keep vault precedence.
       OMADIA_EMBEDDED_DB: '1',
       VAULT_KEY: vaultKey(),
+      // #578's credential keychain is a separate trust domain with its own
+      // master key; the kernel fail-hards in production without it. Missing
+      // here = dead fresh install (found the hard way on v0.115.0).
+      CREDENTIAL_KEYCHAIN_KEY: credentialKeychainKey(),
       PLATFORM_DATA_DIR: platformDataDir(),
       // The browser opens signed diagram URLs against this host base.
       DIAGRAM_PUBLIC_BASE_URL: `http://127.0.0.1:${port}`,

--- a/middleware/packages/harness-orchestrator/src/registry/migrator.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/migrator.ts
@@ -1,4 +1,5 @@
 import { readdir, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -22,7 +23,21 @@ function defaultMigrationsDir(): string {
   const override = process.env['MULTI_ORCH_MIGRATIONS_DIR'];
   if (override) return resolve(override);
   const here = dirname(fileURLToPath(import.meta.url));
-  return resolve(here, '..', '..', '..', '..', 'migrations');
+  // Two real layouts (v0.115.0 fresh-install regression):
+  //   monorepo/Docker  …/packages/harness-orchestrator/dist/registry → 4 up
+  //   installed dep    …/node_modules/@omadia/harness-orchestrator/dist/registry → 5 up
+  // The 4-up guess lands in `node_modules/migrations` on the second layout and
+  // scandir throws at boot. Probe both and take the first that EXISTS; keep the
+  // 4-up path as the final fallback so the error message still names the
+  // historically-documented location when neither exists.
+  const candidates = [
+    resolve(here, '..', '..', '..', '..', 'migrations'),
+    resolve(here, '..', '..', '..', '..', '..', 'migrations'),
+  ];
+  for (const dir of candidates) {
+    if (existsSync(dir)) return dir;
+  }
+  return candidates[0]!;
 }
 
 const LEDGER_DDL = `

--- a/middleware/src/credentials/crypto.ts
+++ b/middleware/src/credentials/crypto.ts
@@ -29,7 +29,12 @@ export async function resolveCredentialMasterKey(
   productionMode = false,
 ): Promise<MasterKeyResult> {
   const devKeyPath = path.join(dataDir, DEV_KEY_FILENAME);
-  return resolveMasterKey(process.env.CREDENTIAL_KEYCHAIN_KEY, devKeyPath, productionMode);
+  return resolveMasterKey(
+    process.env.CREDENTIAL_KEYCHAIN_KEY,
+    devKeyPath,
+    productionMode,
+    'CREDENTIAL_KEYCHAIN_KEY',
+  );
 }
 
 /** Encrypts `plaintext` with `key` (32 bytes) into the shared envelope shape. */

--- a/middleware/src/secrets/fileVault.ts
+++ b/middleware/src/secrets/fileVault.ts
@@ -214,20 +214,26 @@ export async function resolveMasterKey(
   envValue: string | undefined,
   devKeyPath: string,
   productionMode = false,
+  // Names the env var in every error. The credential keychain shares this
+  // resolver but reads CREDENTIAL_KEYCHAIN_KEY — its production failure used
+  // to claim "VAULT_KEY is required" while VAULT_KEY was set and loaded,
+  // which sent the v0.115.0 first-boot diagnosis in exactly the wrong
+  // direction. An error must name the variable that is actually missing.
+  envVarName = 'VAULT_KEY',
 ): Promise<MasterKeyResult> {
   if (envValue && envValue.length > 0) {
     const buf = Buffer.from(envValue, 'base64');
     if (buf.length !== 32) {
-      throw new Error('VAULT_KEY must decode to 32 bytes (base64)');
+      throw new Error(`${envVarName} must decode to 32 bytes (base64)`);
     }
     return { key: buf, source: 'env' };
   }
   if (productionMode) {
     throw new Error(
-      `VAULT_KEY is required when NODE_ENV=production. Refusing to fall back ` +
+      `${envVarName} is required when NODE_ENV=production. Refusing to fall back ` +
         `to dev key file at ${devKeyPath}. Generate one with ` +
         `\`openssl rand -base64 32\` and set it as a secret (e.g. ` +
-        `\`fly secrets set VAULT_KEY=...\`).`,
+        `\`fly secrets set ${envVarName}=...\`).`,
     );
   }
   try {

--- a/middleware/test/credentialCrypto.test.ts
+++ b/middleware/test/credentialCrypto.test.ts
@@ -105,3 +105,29 @@ describe('#578 resolveCredentialMasterKey', () => {
     assert.ok(!files.includes('.dev-credential-keychain.key'), 'must not create a dev key in production mode');
   });
 });
+
+// ---------------------------------------------------------------------------
+// v0.115.0 fresh-install regression — the production failure must name the
+// env var that is actually missing. The keychain shares resolveMasterKey with
+// the vault, and the shared error used to claim "VAULT_KEY is required" while
+// VAULT_KEY was set and loaded — the desktop supervisor passed VAULT_KEY but
+// not CREDENTIAL_KEYCHAIN_KEY, and the misleading text pointed the diagnosis
+// at the wrong variable.
+// ---------------------------------------------------------------------------
+void it('the production error names CREDENTIAL_KEYCHAIN_KEY, not VAULT_KEY', async () => {
+  const prev = process.env.CREDENTIAL_KEYCHAIN_KEY;
+  delete process.env.CREDENTIAL_KEYCHAIN_KEY;
+  try {
+    await assert.rejects(
+      resolveCredentialMasterKey('/tmp/nonexistent-keychain-dir', true),
+      (err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        assert.match(msg, /CREDENTIAL_KEYCHAIN_KEY is required/);
+        assert.doesNotMatch(msg, /VAULT_KEY/);
+        return true;
+      },
+    );
+  } finally {
+    if (prev !== undefined) process.env.CREDENTIAL_KEYCHAIN_KEY = prev;
+  }
+});


### PR DESCRIPTION
**P0, found by fresh-installing the v0.115.0 Intel build**: every NEW install died at first boot ("kernel did not become healthy within 90000ms"). Existing installs are unaffected (their kernel processes carry state from before #578's keychain landed — but any customer installing from scratch, including our field tester, gets a dead app).

Two compounding defects:

1. **The desktop supervisor never passed `CREDENTIAL_KEYCHAIN_KEY`.** The credential keychain (#578) fail-hards in production without it — correct posture — but the supervisor env only carried `VAULT_KEY`. It now generates + persists a keychain key in the encrypted secrets blob exactly like the vault key (lazily → existing installs migrate on next launch) and passes it through. The two keys stay separate per the kernel's own trust-domain design.

2. **The shared `resolveMasterKey` error named the WRONG variable** — "VAULT_KEY is required" while VAULT_KEY was set and loaded. The resolver now takes the env-var name; the failure is pinned by a test asserting the keychain error does NOT mention VAULT_KEY.

Plus: the wizard's dynamic boot-progress line stayed English on German systems — now mapped by the typed `BootProgress.phase` with the supervisor message as fallback.

**Verified:** middleware 7572/0 · desktop tsc clean · new `credentialCrypto` pin green. This should go out in the next release before anyone fresh-installs v0.115.0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789854375&installation_model_id=428086&pr_number=810&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F810&signature=a8b57d9c207dfc4362914c1a91fc340762a49166e9d63868eaf8c51f2f49a3a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->