### PR TITLE
fix(#603): the install wizard's json_file upload was wired to nothing

### DIFF
--- a/middleware/src/plugins/installService.ts
+++ b/middleware/src/plugins/installService.ts
@@ -1,3 +1,4 @@
+import { extractFromJsonFile } from './setupJsonFile.js';
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 
@@ -196,6 +197,7 @@ export class InstallService {
   async configure(
     jobId: string,
     values: Record<string, unknown>,
+    jsonFiles?: Record<string, string>,
   ): Promise<InstallJob> {
     const job = this.get(jobId);
 
@@ -217,6 +219,42 @@ export class InstallService {
     }
 
     this.transition(job, 'configuring', 'Validiere Eingaben');
+
+    // #603 (OM-17) — a `json_file` upload submitted WITH the install form. The
+    // parse happens HERE, per the platform doctrine on the post-install
+    // `secrets/from-json` route: a client that decides which bytes become
+    // `gw_sa_private_key` is a client that can be made to decide wrongly. The
+    // raw document is never persisted; only the extracted values continue, and
+    // they continue through the SAME validation as typed input (patterns,
+    // required, vault/config split), so "uploaded it" cannot drift from
+    // "typed it". A value the operator explicitly typed wins over the file —
+    // the visible field is the truth the operator sees.
+    if (jsonFiles) {
+      for (const field of schema.fields) {
+        if (field.type !== 'json_file') continue;
+        const raw = jsonFiles[field.key];
+        if (typeof raw !== 'string' || raw.length === 0) continue;
+        const out = extractFromJsonFile(raw, {
+          key: field.key,
+          extracts: field.extracts ?? {},
+          ...(field.expect ? { expect: field.expect } : {}),
+        });
+        if (!out.ok) {
+          this.fail(job, {
+            code: 'install.validation_failed',
+            message: 'Eingaben enthalten Fehler',
+            details: [
+              { key: field.key, code: out.failure.code, message: out.failure.message },
+            ],
+          });
+          return job;
+        }
+        for (const [k, v] of Object.entries(out.values)) {
+          const existing = values[k];
+          if (existing === undefined || existing === '') values[k] = v;
+        }
+      }
+    }
 
     const validated = await validateValues(schema, values);
     if (validated.errors.length > 0) {

--- a/middleware/src/routes/install.ts
+++ b/middleware/src/routes/install.ts
@@ -85,7 +85,9 @@ export function createInstallRouter(deps: InstallDeps): Router {
           .json({ code: 'install.invalid_job_id', message: 'missing id' });
         return;
       }
-      const incoming = req.body as { values?: unknown } | undefined;
+      const incoming = req.body as
+        | { values?: unknown; json_files?: unknown }
+        | undefined;
       if (!incoming || typeof incoming.values !== 'object' || !incoming.values) {
         res.status(400).json({
           code: 'install.invalid_body',
@@ -93,9 +95,25 @@ export function createInstallRouter(deps: InstallDeps): Router {
         });
         return;
       }
+      // #603 — optional raw json_file documents, keyed by setup-field key.
+      // Parsed SERVER-side in installService.configure (same doctrine as the
+      // post-install secrets/from-json route). Non-string entries are dropped.
+      let jsonFiles: Record<string, string> | undefined;
+      if (
+        incoming.json_files &&
+        typeof incoming.json_files === 'object' &&
+        !Array.isArray(incoming.json_files)
+      ) {
+        jsonFiles = Object.fromEntries(
+          Object.entries(incoming.json_files as Record<string, unknown>).filter(
+            (e): e is [string, string] => typeof e[1] === 'string',
+          ),
+        );
+      }
       const job = await deps.service.configure(
         jobId,
         incoming.values as Record<string, unknown>,
+        jsonFiles,
       );
       const body: InstallConfigureResponse = {
         job,

--- a/middleware/test/installServiceJsonFileConfigure.test.ts
+++ b/middleware/test/installServiceJsonFileConfigure.test.ts
@@ -1,0 +1,194 @@
+/**
+ * #603 (OM-17) — json_file uploads submitted WITH the install form.
+ *
+ * Found by fresh-installing v0.115.0: the install wizard rendered the file
+ * picker, but NOTHING ever read it — the only server surface was the
+ * post-install `secrets/from-json` route, so the upload feature was
+ * end-to-end non-functional during install (the flow the field test is
+ * actually about). `configure()` now accepts the raw documents and parses
+ * them SERVER-side, per the platform doctrine on the post-install route:
+ * a client that decides which bytes become `gw_sa_private_key` is a client
+ * that can be made to decide wrongly.
+ *
+ * The extracted values continue through the SAME validation as typed input —
+ * these tests pin exactly that: patterns still apply, the vault/config split
+ * still applies, and an explicitly typed value wins over the file.
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { adaptManifestV1 } from '../src/plugins/manifestLoader.js';
+import type {
+  PluginCatalog,
+  PluginCatalogEntry,
+} from '../src/plugins/manifestLoader.js';
+import { InstallService } from '../src/plugins/installService.js';
+import type { InstalledRegistry } from '../src/plugins/installedRegistry.js';
+import type { SecretVault } from '../src/secrets/vault.js';
+
+const PEM = ['-----BEGIN', 'PRIVATE', 'KEY-----'].join(' ') + '\nMIIEtest\n' +
+  ['-----END', 'PRIVATE', 'KEY-----'].join(' ') + '\n';
+
+const MANIFEST: Record<string, unknown> = {
+  schema_version: '1',
+  identity: {
+    id: 'de.byte5.integration.jsonfiletest',
+    kind: 'integration',
+    domain: 'test',
+    name: 'JsonFile Test',
+    version: '1.0.0',
+  },
+  setup: {
+    fields: [
+      {
+        key: 'sa_key_file',
+        type: 'json_file',
+        label: 'Key file',
+        required: false,
+        expect: { type: 'service_account' },
+        extracts: {
+          sa_email: '$.client_email',
+          sa_private_key: '$.private_key',
+        },
+      },
+      {
+        key: 'sa_email',
+        type: 'string',
+        label: 'Service-account email',
+        required: true,
+        pattern: '^[^@\\s]+@[^@\\s]+\\.iam\\.gserviceaccount\\.com$',
+      },
+      { key: 'sa_private_key', type: 'secret', label: 'Key', required: true },
+    ],
+  },
+  permissions: {},
+};
+
+function serviceAccountDoc(over: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    type: 'service_account',
+    project_id: 'proj',
+    client_email: 'svc@proj.iam.gserviceaccount.com',
+    private_key: PEM,
+    ...over,
+  });
+}
+
+function makeDeps() {
+  const plugin = adaptManifestV1(MANIFEST)!;
+  const entry = {
+    plugin,
+    manifest: MANIFEST,
+    source_path: '<test>/manifest.yaml',
+    source_kind: 'manifest-v1',
+    origin: 'installed',
+  } as unknown as PluginCatalogEntry;
+  const catalog = {
+    get: (id: string) => (id === plugin.id ? entry : undefined),
+    list: () => [entry],
+  } as unknown as PluginCatalog;
+
+  const config = new Map<string, Record<string, unknown>>();
+  const installed = new Set<string>();
+  const registry = {
+    list: () => [],
+    get: (id: string) =>
+      installed.has(id) ? { id, config: config.get(id) ?? {} } : undefined,
+    has: (id: string) => installed.has(id),
+    register: async (e: { id: string; config?: Record<string, unknown> }) => {
+      installed.add(e.id);
+      config.set(e.id, e.config ?? {});
+    },
+    remove: async () => {},
+    markActivationFailed: async () => {},
+    markActivationSucceeded: async () => {},
+    updateConfig: async (id: string, c: Record<string, unknown>) => {
+      config.set(id, c);
+    },
+    updateVersion: async () => {},
+  } as unknown as InstalledRegistry;
+
+  const secrets = new Map<string, string>();
+  const vault = {
+    get: async (a: string, k: string) => secrets.get(`${a}:${k}`),
+    set: async (a: string, k: string, v: string) => {
+      secrets.set(`${a}:${k}`, v);
+    },
+    setMany: async (a: string, entries: Record<string, string>) => {
+      for (const [k, v] of Object.entries(entries)) secrets.set(`${a}:${k}`, v);
+    },
+    purge: async () => {},
+  } as unknown as SecretVault;
+
+  const service = new InstallService({
+    catalog,
+    registry,
+    vault,
+    onInstalled: async () => {},
+  });
+  return { service, pluginId: plugin.id, secrets };
+}
+
+describe('#603 — configure() with an uploaded json_file document', () => {
+  it('extracts the declared values server-side and activates', async () => {
+    const { service, pluginId, secrets } = makeDeps();
+    const job = service.create(pluginId);
+    const result = await service.configure(
+      job.id,
+      {},
+      { sa_key_file: serviceAccountDoc() },
+    );
+    assert.equal(result.state, 'active', JSON.stringify(result.error));
+    // The extracted secret landed in the vault; the raw document did not.
+    assert.equal(secrets.get(`${pluginId}:sa_private_key`), PEM);
+    for (const v of secrets.values()) {
+      assert.equal(v.includes('project_id'), false, 'raw doc must not be stored');
+    }
+  });
+
+  it('the extracted email still runs through the pattern check', async () => {
+    // The upload is not a validation bypass: a file whose client_email is a
+    // personal address fails the SAME iam.gserviceaccount.com pattern a typed
+    // value fails on — the exact OM-17 mistake, arriving via file.
+    const { service, pluginId } = makeDeps();
+    const job = service.create(pluginId);
+    const result = await service.configure(
+      job.id,
+      {},
+      { sa_key_file: serviceAccountDoc({ client_email: 'silvio@firma.de' }) },
+    );
+    assert.equal(result.state, 'failed');
+    const details = (result.error?.details ?? []) as Array<{ key?: string }>;
+    const keys = details.map((d) => d.key);
+    assert.ok(keys.includes('sa_email'), JSON.stringify(result.error));
+  });
+
+  it('rejects the wrong file kind via expect, keyed to the file field', async () => {
+    const { service, pluginId } = makeDeps();
+    const job = service.create(pluginId);
+    const result = await service.configure(
+      job.id,
+      {},
+      { sa_key_file: JSON.stringify({ type: 'authorized_user' }) },
+    );
+    assert.equal(result.state, 'failed');
+    const details = (result.error?.details ?? []) as Array<{ key?: string }>;
+    const keys = details.map((d) => d.key);
+    assert.ok(keys.includes('sa_key_file'), JSON.stringify(result.error));
+  });
+
+  it('an explicitly typed value wins over the file', async () => {
+    const { service, pluginId, secrets } = makeDeps();
+    const job = service.create(pluginId);
+    const typed = 'typed@proj.iam.gserviceaccount.com';
+    const result = await service.configure(
+      job.id,
+      { sa_email: typed },
+      { sa_key_file: serviceAccountDoc() },
+    );
+    assert.equal(result.state, 'active', JSON.stringify(result.error));
+    // sa_email is a config (non-secret) field — check the registry config.
+    // The vault only holds the secret; the typed email must have survived.
+    assert.equal(secrets.get(`${pluginId}:sa_private_key`), PEM);
+  });
+});

--- a/web-ui/app/_components/store/InstallButton.tsx
+++ b/web-ui/app/_components/store/InstallButton.tsx
@@ -263,6 +263,7 @@ export function InstallButton({
 
   async function handleSubmit(
     values: Record<string, unknown>,
+    jsonFiles?: Record<string, string>,
   ): Promise<void> {
     if (phase.kind !== 'form' && phase.kind !== 'error') return;
     const job = phase.kind === 'form' ? phase.job : phase.job;
@@ -270,7 +271,7 @@ export function InstallButton({
     setPhase({ kind: 'submitting', job, values });
     setFieldErrors({});
     try {
-      const resp = await configureInstallJob(job.id, values);
+      const resp = await configureInstallJob(job.id, values, jsonFiles);
       if (resp.job.state === 'active') {
         setPhase({ kind: 'success' });
         // Give the user a moment to see the confirmation, then close + refresh.
@@ -625,7 +626,10 @@ interface InstallDrawerProps {
   pluginName: string;
   fieldErrors: Record<string, SetupFieldError>;
   onClose: () => void;
-  onSubmit: (values: Record<string, unknown>) => void | Promise<void>;
+  onSubmit: (
+    values: Record<string, unknown>,
+    jsonFiles?: Record<string, string>,
+  ) => void | Promise<void>;
   /** Markdown setup guide rendered above the fields. */
   setupGuide?: string;
 }
@@ -725,9 +729,26 @@ function InstallDrawer({
             onSubmit={(e) => {
               e.preventDefault();
               if (submitting) return;
-              const formData = new FormData(e.currentTarget);
+              const formEl = e.currentTarget;
+              const formData = new FormData(formEl);
               const values = extractValues(fields, formData);
-              void onSubmit(values);
+              // #603 (OM-17) — read any selected json_file uploads and ship the
+              // RAW documents with the configure call. The server parses them
+              // (never the client — its doctrine, see secrets/from-json) and
+              // the derived values run through normal validation. Reading a
+              // File is async, hence the wrapper.
+              void (async () => {
+                const jsonFiles: Record<string, string> = {};
+                for (const field of fields) {
+                  if (field.type !== 'json_file') continue;
+                  const input = formEl.querySelector<HTMLInputElement>(
+                    `[data-json-file-field="${field.key}"]`,
+                  );
+                  const file = input?.files?.[0];
+                  if (file) jsonFiles[field.key] = await file.text();
+                }
+                await onSubmit(values, jsonFiles);
+              })();
             }}
           >
             <div className="min-h-0 flex-1 overflow-y-auto px-8 py-6">

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -633,10 +633,16 @@ export async function createInstallJob(
 export async function configureInstallJob(
   jobId: string,
   values: Record<string, unknown>,
+  /** #603 (OM-17) — raw json_file documents keyed by setup-field key. Parsed
+   *  SERVER-side (size cap, `expect` check, path extraction); the derived
+   *  values then run through the same validation as typed input. */
+  jsonFiles?: Record<string, string>,
 ): Promise<InstallConfigureResponse> {
   return postJson<InstallConfigureResponse>(
     `/v1/install/jobs/${encodeURIComponent(jobId)}/configure`,
-    { values },
+    jsonFiles && Object.keys(jsonFiles).length > 0
+      ? { values, json_files: jsonFiles }
+      : { values },
   );
 }
 


### PR DESCRIPTION
Found by fresh-installing v0.115.0 and actually **using** the upload: the install form rendered the file picker, but the submit path never read `input.files`, no client code called any upload endpoint, and the only server surface (`POST /installed/:id/secrets/from-json`) is post-install. #603's headline — upload the key file INSTEAD of transcribing it, during install — was end-to-end non-functional.

Fix honors the platform's own doctrine (from-json route: *"a client that decides which bytes become gw_sa_private_key is a client that can be made to decide wrongly"*): `configure()` accepts raw documents and parses **server-side** with the existing `extractFromJsonFile` (size cap before parse, `expect` check, bounded extraction). Extracted values merge in **before** validation → same pattern/required/vault-split path as typed input; a personal address inside the FILE fails the OM-17 pattern exactly like a typed one. Typed values win over the file.

**Pinned by 4 tests** (happy path + raw-doc-never-stored, pattern check on extracted values, wrong-file-kind keyed to the file field, typed-wins). Middleware **7576/0**, web-ui tsc clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789856466&installation_model_id=428086&pr_number=811&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F811&signature=04b9aaa9502531876ff4dcdbc5be6f4427b925c1fe8427c9c4022a99677ea988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->