### PR TITLE
fix(#603): native required on upload-covered fields blocked the submit silently

### DIFF
--- a/web-ui/app/_components/store/InstallButton.tsx
+++ b/web-ui/app/_components/store/InstallButton.tsx
@@ -39,6 +39,7 @@ import { RequiresWizard } from './RequiresWizard';
 import {
   FieldRow,
   extractValues,
+  uploadCoveredKeys,
   type SetupFieldError,
 } from './setupForm';
 import { Markdown } from '../Markdown';
@@ -659,6 +660,9 @@ function InstallDrawer({
   const fields = (jobFromPhase?.setup_schema?.fields ?? []).filter(
     (f) => !f.install_hidden,
   );
+  // #603 — fields a json_file upload supplies; their native `required` is off
+  // so the browser cannot silently refuse a submit that has the file attached.
+  const coveredByUpload = uploadCoveredKeys(fields);
   const submitting = phase.kind === 'submitting';
 
   // Portal to <body> so the drawer escapes the store sidebar's
@@ -772,6 +776,7 @@ function InstallDrawer({
                       key={field.key}
                       field={field}
                       error={fieldErrors[field.key]}
+                      coveredByUpload={coveredByUpload.has(field.key)}
                     />
                   ))}
                 </div>

--- a/web-ui/app/_components/store/__tests__/setupFormUploadCovered.test.tsx
+++ b/web-ui/app/_components/store/__tests__/setupFormUploadCovered.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { uploadCoveredKeys } from '../setupForm';
+import type { InstallSetupField } from '../../../_lib/storeTypes';
+
+/**
+ * #603 (OM-17) — found on the v0.115.2 fresh-install smoke: with the key file
+ * attached, the install form still would not submit. The browser's NATIVE
+ * `required` check on the two fields the upload supplies refused the submit
+ * silently (an unlocalizable native tooltip). These pins keep the covered-key
+ * derivation honest; `FieldRow` drops native `required` for exactly this set.
+ */
+describe('uploadCoveredKeys', () => {
+  const fields = [
+    {
+      key: 'sa_key_file',
+      type: 'json_file',
+      label: { en: 'Key file' },
+      required: false,
+      extracts: { sa_email: '$.client_email', sa_private_key: '$.private_key' },
+    },
+    { key: 'sa_email', type: 'string', label: { en: 'Email' }, required: true },
+    { key: 'sa_private_key', type: 'secret', label: { en: 'Key' }, required: true },
+    { key: 'subject', type: 'string', label: { en: 'User' }, required: true },
+  ] as unknown as InstallSetupField[];
+
+  it('names exactly the extracts targets', () => {
+    const covered = uploadCoveredKeys(fields);
+    expect([...covered].sort()).toEqual(['sa_email', 'sa_private_key']);
+  });
+
+  it('leaves fields no upload supplies untouched', () => {
+    expect(uploadCoveredKeys(fields).has('subject')).toBe(false);
+  });
+
+  it('is empty when no json_file field exists', () => {
+    expect(uploadCoveredKeys(fields.slice(1)).size).toBe(0);
+  });
+});

--- a/web-ui/app/_components/store/setupForm.tsx
+++ b/web-ui/app/_components/store/setupForm.tsx
@@ -35,14 +35,25 @@ export function FieldRow({
   field,
   error,
   idPrefix = 'install-field',
+  coveredByUpload = false,
 }: {
   field: InstallSetupField;
   error?: SetupFieldError;
   idPrefix?: string;
+  /**
+   * #603 (OM-17) — true when a `json_file` field in the same form declares
+   * this field as an `extracts` target. The browser's NATIVE `required` check
+   * then must not fire: it would refuse the submit silently (a native tooltip
+   * the app cannot localize) while the operator has attached the file that
+   * supplies the value. Requiredness is still enforced — by the server, AFTER
+   * it merged the extracted values — so nothing is lost, only the false stop.
+   */
+  coveredByUpload?: boolean;
 }): React.ReactElement {
   const t = useTranslations('store.setupForm');
   const locale = useLocale();
   const id = `${idPrefix}-${field.key}`;
+  const nativeRequired = field.required && !coveredByUpload;
   const patternHint = pickLocalized(field.pattern_hint, locale);
   // #602 (OM-17) — label/help are localized maps; resolve them at the active
   // locale. A missing label falls back to the field key (never blank).
@@ -125,7 +136,7 @@ export function FieldRow({
           <select
             id={id}
             name={field.key}
-            required={field.required}
+            required={nativeRequired}
             defaultValue={typeof field.default === 'string' ? field.default : ''}
             className={common}
           >
@@ -144,7 +155,7 @@ export function FieldRow({
             name={field.key}
             type="number"
             step={1}
-            required={field.required}
+            required={nativeRequired}
             defaultValue={
               typeof field.default === 'number' ? String(field.default) : ''
             }
@@ -156,7 +167,7 @@ export function FieldRow({
             id={id}
             name={field.key}
             rows={6}
-            required={field.required}
+            required={nativeRequired}
             placeholder={
               field.type === 'secret' ? secretPlaceholder : field.placeholder
             }
@@ -178,7 +189,7 @@ export function FieldRow({
                   ? 'url'
                   : 'text'
             }
-            required={field.required}
+            required={nativeRequired}
             // OM-17 — client-side mirror of the server's `pattern` check. The
             // server is the load-bearing half (it owns the vault write); this
             // makes the browser refuse the submit before the round trip.
@@ -288,4 +299,18 @@ export function extractValues(
     values[field.key] = raw;
   }
   return values;
+}
+
+
+/**
+ * #603 (OM-17) — keys supplied by at least one `json_file` field's `extracts`
+ * in this form. Used to drop the native `required` attribute on those inputs.
+ */
+export function uploadCoveredKeys(fields: InstallSetupField[]): Set<string> {
+  const covered = new Set<string>();
+  for (const f of fields) {
+    if (f.type !== 'json_file' || !f.extracts) continue;
+    for (const target of Object.keys(f.extracts)) covered.add(target);
+  }
+  return covered;
 }


### PR DESCRIPTION
Found on the v0.115.2 fresh-install smoke (the build that carries #811): with the service-account key file attached, "Installation bestätigen" did nothing. `form.checkValidity()` showed why — the two fields the upload supplies (`gw_sa_client_email`, `gw_sa_private_key`) still carried the browser's NATIVE `required`, which refuses the submit with an unlocalizable native tooltip ("Please fill in this field.") the app never sees.

Fix: `FieldRow` drops native `required` for fields that a `json_file` field's `extracts` covers (`uploadCoveredKeys()`). Requiredness is still enforced — by the server, after it merged the extracted values (#811) — so a form with neither file nor value gets the per-field "required" error as before; only the false stop is gone.

Pinned by 3 vitest cases on the covered-key derivation. web-ui **808/808**, tsc + eslint clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789862634&installation_model_id=428086&pr_number=812&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F812&signature=2819accf00e858625045c731bc375326af674097470f35a77b14510a9dad5c76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->