### PR TITLE
feat: pattern-based ephemeral conductor workflows with TTL reaper (#330 Workstream A)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,14 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — pattern-based ephemeral Conductor workflows with TTL reaper (#330 Workstream A)
+
+- Workflows now carry an `origin` (`manual` | `ephemeral`, migration `0009_ephemeral_workflows.sql`): agent-generated JIT workflows live in the reserved `eph-` slug namespace, never appear in the workflow library (`list()` filters to `manual`), and the create/instantiate routes reject the reserved prefix (`conductor.reserved_slug_prefix`).
+- New kernel service `conductorEphemeralRuns` (deny-by-default like every plugin service — no grants-catalog entry yet, the Facilitator plugin adds one): `createEphemeralRun({ agentId, patternId, slots, payload, ttlMs })` instantiates a curated pattern from the new bundled `src/conductor/patterns/` catalog (slot-fill via the existing template machinery — agents can never submit arbitrary graphs), publishes it as `origin='ephemeral'` and starts the run with the previously call-site-less `triggerKind: 'agent'`.
+- Guardrails (env-tunable, `CONDUCTOR_EPHEMERAL_*`): mandatory clamped TTL (default 24h, max 7d), per-agent concurrent-run cap (3) and hourly create rate limit (10).
+- Disposal is "discard the scaffold, never the minutes": on a terminal run state (immediate hook) or TTL expiry (new reaper worker) the definition is disabled + stamped `reaped_at`; expired-but-active runs get a #759 cancel request; a physical DELETE only happens for definitions no run references. Run history and version graph are retained as the audit trace.
+- First bundled pattern: `facilitation` (moderate → initiator confirmation with 24h deadline → report / abort-report) — the Conductor substrate for the #330 Facilitator.
+
 ### Removed — the core-decoupling ratchet is retired (#470 C14)
 
 - `scripts/check-core-decoupling.mjs`, its colocated detector test

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -1186,6 +1186,44 @@ Nachzug hier). UI: Chain-Status-Karte auf `/operator/receipts`. Doku +
 Tamper-Demo: `docs/provenance-verification.md`. Tests:
 `test/provenanceVerify.test.ts` (inkl. Offline-Verifier via spawnSync).
 
+### Conductor Ephemeral/JIT-Workflows (#330 Workstream A)
+
+Agent-generierte, run-scoped Workflows: `conductor_workflows.origin`
+(`manual` | `ephemeral`, Migration `0009_ephemeral_workflows.sql` — plus
+`expires_at`, `created_by_agent`, `reaped_at`). Ephemere Workflows entstehen
+NUR über den Kernel-Service **`conductorEphemeralRuns`**
+(`createEphemeralRun({ agentId, patternId, slots, payload, ttlMs })`,
+provided in `src/index.ts` neben `conductorAwaitResolver`; deny-by-default —
+kein `pluginServiceGrants`-Eintrag, den liefert erst das Facilitator-Plugin).
+Der Graph kommt aus dem kuratierten **Pattern-Katalog**
+`src/conductor/patterns/` (`patternCatalog.ts`, Patterns = TemplateManifests,
+Slot-Fill über die bestehende Template-Maschinerie — Agents können keine
+freien Graphen einreichen; erstes Pattern: `facilitation`). Create+Start in
+einem Call: `createOrPublish({ origin:'ephemeral', expectNew, enable })` →
+`startRun({ triggerKind:'agent' })` (erste Call-Site dieses TriggerKinds).
+
+Namespace: Slug-Präfix **`eph-`** ist reserviert — `POST /`,
+Template-Instantiate, `POST /:slug/status` und `POST /:slug/runs` lehnen es
+mit `conductor.reserved_slug_prefix` ab (Status/Runs: der Reaper owned den
+Lifecycle, sonst Zombie-Risiko). `workflowStore.list()` filtert auf
+`origin='manual'` — Library-UI UND EventRouter sehen ephemere Workflows nie
+(run-scoped, nicht event-triggerbar).
+
+Lifecycle („discard the scaffold, never the minutes"): bei terminalem
+Run-State (Hook in `notifyRunEnded`) oder TTL-Ablauf
+(`ephemeralReaper.ts`, scheduleWorker-Muster) wird die Definition disabled +
+`reaped_at` gestempelt; abgelaufene aktive Runs bekommen den #759
+Cancel-Request; physisches DELETE nur für referenzlose Definitionen
+(`hardDeleteUnreferenced`, NOT-EXISTS-Guard; FK conductor_runs →
+versions blockt ohnehin). Run-Historie + Version-Graph bleiben als
+Audit-Trace. Guardrails env-tunable (`CONDUCTOR_EPHEMERAL_*`, §10): Pflicht-TTL
+mit Clamp (Default 24h, Max 7d), max. 3 concurrent Runs + 10 Creates/h pro
+Agent. Tests: `test/conductorEphemeral*.test.ts`,
+`test/conductorPatternCatalog.test.ts`. Achtung: das Schema-CI-Gate re-applied
+`src/conductor/migrations` noch NICHT (Verzeichnis steht in ci.yml unter
+"still uncovered") — 0009 ist nach 0008-Muster idempotent geschrieben, aber
+CI-unbewiesen.
+
 ## 4. Migration Managed Agents → Lokal
 
 ### Warum migriert
@@ -1564,6 +1602,12 @@ BUCKET_NAME, AWS_ENDPOINT_URL_S3, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
 # Conductor generic webhooks (issue #437) — Kill-Switch für POST /api/hooks/:endpointId
 CONDUCTOR_WEBHOOKS_ENABLED=true
 CONDUCTOR_WEBHOOK_MAX_DELIVERIES_PER_MINUTE=60   # Rate-Limit pro Endpoint (rolling minute)
+# Conductor ephemeral/JIT workflows (#330 Workstream A) — Guardrails für createEphemeralRun
+CONDUCTOR_EPHEMERAL_DEFAULT_TTL_MS=86400000      # 24h Default-TTL
+CONDUCTOR_EPHEMERAL_MAX_TTL_MS=604800000         # 7d Obergrenze (Requests werden geclampt)
+CONDUCTOR_EPHEMERAL_MAX_ACTIVE_PER_AGENT=3       # concurrent ephemeral Runs pro Agent
+CONDUCTOR_EPHEMERAL_MAX_CREATES_PER_HOUR=10      # Create-Rate pro Agent
+CONDUCTOR_EPHEMERAL_REAPER_INTERVAL_MS=60000     # Reaper-Poll
 # Tenant-Scope (auch für Diagramm-Cache-Keys genutzt)
 GRAPH_TENANT_ID=byte5
 # Prompt-PII C1-Detector (GLiNER-Sidecar, #361) — optional

--- a/middleware/.env.example
+++ b/middleware/.env.example
@@ -261,3 +261,14 @@ CONDUCTOR_WEBHOOK_MAX_DELIVERIES_PER_MINUTE=60
 # explicitly if PUBLIC_BASE_URL points at the Next.js dev-server origin (which
 # does not proxy /api/hooks/*, only /bot-api/*) rather than the middleware itself.
 # CONDUCTOR_WEBHOOK_PUBLIC_BASE_URL=http://localhost:3979
+
+# --- Conductor ephemeral / JIT workflows (#330 Workstream A) -----------------
+# Guardrails for agent-generated workflows (conductor.createEphemeralRun):
+# a mandatory TTL (requested values are clamped to the max), per-agent caps on
+# concurrent ephemeral runs and creations per hour, and the reaper poll that
+# disposes of expired/terminal scaffolds while retaining the run's audit trace.
+CONDUCTOR_EPHEMERAL_DEFAULT_TTL_MS=86400000
+CONDUCTOR_EPHEMERAL_MAX_TTL_MS=604800000
+CONDUCTOR_EPHEMERAL_MAX_ACTIVE_PER_AGENT=3
+CONDUCTOR_EPHEMERAL_MAX_CREATES_PER_HOUR=10
+CONDUCTOR_EPHEMERAL_REAPER_INTERVAL_MS=60000

--- a/middleware/scripts/copy-build-assets.mjs
+++ b/middleware/scripts/copy-build-assets.mjs
@@ -35,6 +35,9 @@ const ASSETS = [
   // Conductor workflow-template catalog (#429) — templateCatalog.ts scans the
   // JSON manifests next to its compiled module (dist/conductor/templates).
   { from: 'src/conductor/templates', to: 'dist/conductor/templates' },
+  // #330 — curated ephemeral-workflow patterns, loaded dirname-relative by
+  // patternCatalog.ts exactly like the templates above.
+  { from: 'src/conductor/patterns', to: 'dist/conductor/patterns' },
   // Conductor SQL migrations (#478) — runConductorMigrations scans the directory
   // next to its compiled module. Previously mirrored only by the Dockerfile COPY,
   // so a plain `npm run build` dist (desktop-installer staging) missed them.

--- a/middleware/src/conductor/ephemeralReaper.ts
+++ b/middleware/src/conductor/ephemeralReaper.ts
@@ -1,0 +1,77 @@
+// Ephemeral-workflow reaper (#330 Workstream A). Same worker discipline as
+// scheduleWorker.ts: unref'd interval, a `ticking` re-entrancy flag, injectable
+// now/log/interval, and per-row error isolation (one bad row never aborts the
+// tick). Disposal semantics: an expired workflow first gets a #759
+// cancel-request for its still-active runs (honoured at the next step
+// boundary), then the definition is logically reaped (disabled + reaped_at);
+// a physical DELETE only happens for rows no run references — the run history
+// and version graph are the retained audit trace.
+
+import type { ConductorEphemeralStore } from './ephemeralStore.js';
+
+const REAPER_ACTOR = 'conductor-ephemeral-reaper';
+
+export class ConductorEphemeralReaper {
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private ticking = false;
+
+  constructor(
+    private readonly deps: {
+      store: ConductorEphemeralStore;
+      intervalMs?: number;
+      now?: () => Date;
+      log?: (msg: string) => void;
+    },
+  ) {}
+
+  start(): void {
+    if (this.timer) return;
+    const interval = this.deps.intervalMs ?? 60_000;
+    void this.tick();
+    this.timer = setInterval(() => void this.tick(), interval);
+    if (typeof this.timer.unref === 'function') this.timer.unref();
+    this.deps.log?.('[conductor] ephemeral reaper started');
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  async tick(): Promise<void> {
+    if (this.ticking) return;
+    this.ticking = true;
+    try {
+      const now = (this.deps.now ?? (() => new Date()))();
+      let reapable;
+      try {
+        reapable = await this.deps.store.listReapable(now);
+      } catch (err) {
+        this.deps.log?.(`[conductor] ephemeral reaper list failed: ${err instanceof Error ? err.message : String(err)}`);
+        return;
+      }
+
+      for (const wf of reapable) {
+        try {
+          if (wf.expired) {
+            const cancelled = await this.deps.store.requestCancelActiveRuns(wf.id, REAPER_ACTOR);
+            if (cancelled > 0) {
+              this.deps.log?.(`[conductor] ephemeral '${wf.slug}' expired — cancel requested for ${cancelled} active run(s)`);
+            }
+          }
+          await this.deps.store.markReaped(wf.id);
+          const deleted = await this.deps.store.hardDeleteUnreferenced(wf.id);
+          this.deps.log?.(
+            `[conductor] ephemeral '${wf.slug}' reaped (${deleted ? 'deleted — no runs referenced it' : 'definition retained as audit trace'})`,
+          );
+        } catch (err) {
+          this.deps.log?.(`[conductor] ephemeral reap of '${wf.slug}' failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+    } finally {
+      this.ticking = false;
+    }
+  }
+}

--- a/middleware/src/conductor/ephemeralRunService.ts
+++ b/middleware/src/conductor/ephemeralRunService.ts
@@ -1,0 +1,187 @@
+// `conductor.createEphemeralRun` (#330 Workstream A) — create + start an
+// agent-generated JIT workflow in one call. Generative but governed: the graph
+// comes from a curated pattern (patternCatalog.ts) with the agent only filling
+// validated slots; a mandatory, clamped TTL plus per-agent concurrency and
+// rate guardrails keep runaway generation structurally impossible. The
+// resulting workflow never appears in the library (origin 'ephemeral' +
+// reserved `eph-` slug prefix); the reaper disposes of it after the run.
+
+import { randomUUID } from 'node:crypto';
+
+import type { JsonObject, TemplateMissingSlot, TemplateSlotMapping } from '@omadia/conductor-core';
+import { applyTemplateSlots, missingSlotMappings, resolveLocalizedText } from '@omadia/conductor-core';
+
+import type { ConductorEphemeralStore } from './ephemeralStore.js';
+import type { PatternCatalog } from './patternCatalog.js';
+import type { ConductorRunExecutor } from './runExecutor.js';
+import type { ConductorWorkflowStore } from './workflowStore.js';
+
+/** Reserved prefix for agent-generated workflows — the manual create/instantiate
+ *  routes reject it, so the namespaces cannot collide. */
+export const EPHEMERAL_SLUG_PREFIX = 'eph-';
+
+export class PatternNotFoundError extends Error {
+  constructor(readonly patternId: string) {
+    super(`ephemeral pattern '${patternId}' not found`);
+    this.name = 'PatternNotFoundError';
+  }
+}
+
+export class EphemeralSlotsMissingError extends Error {
+  constructor(readonly missing: TemplateMissingSlot[]) {
+    super(`ephemeral pattern slots unmapped: ${missing.map((m) => `${m.kind}:${m.key}`).join(', ')}`);
+    this.name = 'EphemeralSlotsMissingError';
+  }
+}
+
+export class EphemeralQuotaExceededError extends Error {
+  constructor(
+    readonly kind: 'concurrent' | 'rate',
+    readonly limit: number,
+  ) {
+    super(
+      kind === 'concurrent'
+        ? `ephemeral run quota exceeded: ${limit} concurrent run(s) per agent`
+        : `ephemeral create rate exceeded: ${limit} per hour per agent`,
+    );
+    this.name = 'EphemeralQuotaExceededError';
+  }
+}
+
+export class EphemeralInvalidInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EphemeralInvalidInputError';
+  }
+}
+
+export interface CreateEphemeralRunInput {
+  /** The agent creating the run — quota/rate accounting key and audit provenance. */
+  agentId: string;
+  patternId: string;
+  /** Slot mapping for the pattern (agents/roles/channels/…, see TemplateSlotMapping). */
+  slots: TemplateSlotMapping;
+  /** Run context payload ({{ctx.*}} in pattern prompts — e.g. goal, definitionOfDone). */
+  payload?: JsonObject;
+  /** Requested TTL; clamped to [1ms, maxTtlMs], defaulted to defaultTtlMs. */
+  ttlMs?: number;
+}
+
+export interface EphemeralRunHandle {
+  runId: string;
+  workflowId: string;
+  workflowSlug: string;
+  /** ISO timestamp after which the reaper disposes of the workflow definition. */
+  expiresAt: string;
+}
+
+export interface EphemeralRunLimits {
+  defaultTtlMs: number;
+  maxTtlMs: number;
+  maxActivePerAgent: number;
+  maxCreatesPerHour: number;
+}
+
+const RATE_WINDOW_MS = 60 * 60 * 1000;
+
+export class ConductorEphemeralRunService {
+  constructor(
+    private readonly deps: {
+      patterns: PatternCatalog;
+      workflowStore: ConductorWorkflowStore;
+      ephemeralStore: ConductorEphemeralStore;
+      executor: ConductorRunExecutor;
+      limits: EphemeralRunLimits;
+      now?: () => Date;
+      log?: (msg: string) => void;
+    },
+  ) {}
+
+  async createEphemeralRun(input: CreateEphemeralRunInput): Promise<EphemeralRunHandle> {
+    // Boundary validation — callers are plugins, the input is untrusted.
+    if (typeof input.agentId !== 'string' || input.agentId.trim().length === 0) {
+      throw new EphemeralInvalidInputError('agentId is required');
+    }
+    if (typeof input.patternId !== 'string' || input.patternId.trim().length === 0) {
+      throw new EphemeralInvalidInputError('patternId is required');
+    }
+    if (typeof input.slots !== 'object' || input.slots === null || Array.isArray(input.slots)) {
+      throw new EphemeralInvalidInputError('slots must be a slot-mapping object');
+    }
+    if (input.ttlMs !== undefined && (!Number.isFinite(input.ttlMs) || input.ttlMs <= 0)) {
+      throw new EphemeralInvalidInputError('ttlMs must be a positive number when present');
+    }
+    const agentId = input.agentId.trim();
+
+    const pattern = this.deps.patterns.get(input.patternId);
+    if (!pattern) throw new PatternNotFoundError(input.patternId);
+
+    const missing = missingSlotMappings(pattern, input.slots);
+    if (missing.length > 0) throw new EphemeralSlotsMissingError(missing);
+
+    const { limits } = this.deps;
+    const active = await this.deps.ephemeralStore.countActiveRunsByAgent(agentId);
+    if (active >= limits.maxActivePerAgent) {
+      throw new EphemeralQuotaExceededError('concurrent', limits.maxActivePerAgent);
+    }
+    const now = (this.deps.now ?? (() => new Date()))();
+    const recent = await this.deps.ephemeralStore.countRecentCreatesByAgent(
+      agentId,
+      new Date(now.getTime() - RATE_WINDOW_MS),
+    );
+    if (recent >= limits.maxCreatesPerHour) {
+      throw new EphemeralQuotaExceededError('rate', limits.maxCreatesPerHour);
+    }
+
+    // TTL is mandatory and bounded — an unbounded ephemeral definition is the
+    // exact clutter #330 forbids (also CHECK-enforced in the schema).
+    const ttlMs = Math.min(input.ttlMs ?? limits.defaultTtlMs, limits.maxTtlMs);
+    const expiresAt = new Date(now.getTime() + ttlMs);
+
+    const graph = applyTemplateSlots(pattern, input.slots);
+    const slug = `${EPHEMERAL_SLUG_PREFIX}${input.patternId}-${randomUUID().slice(0, 8)}`;
+
+    const published = await this.deps.workflowStore.createOrPublish({
+      slug,
+      name: resolveLocalizedText(pattern.name),
+      description: resolveLocalizedText(pattern.description),
+      graph,
+      enable: true,
+      expectNew: true,
+      origin: 'ephemeral',
+      expiresAt,
+      createdByAgent: agentId,
+      publishedBy: `agent:${agentId}`,
+    });
+
+    try {
+      const run = await this.deps.executor.startRun({
+        slug,
+        payload: input.payload ?? {},
+        triggerKind: 'agent',
+        triggerSource: { agentId, patternId: input.patternId },
+      });
+      return {
+        runId: run.id,
+        workflowId: published.workflow.id,
+        workflowSlug: slug,
+        expiresAt: expiresAt.toISOString(),
+      };
+    } catch (err) {
+      // Best-effort immediate disposal of the never-started scaffold; the reaper
+      // is the safety net if this cleanup itself fails. startRun CAN throw after
+      // the durable run row exists (a drive crash) — the cancel request below
+      // covers that window, since a reaped definition leaves listReapable and the
+      // reaper would otherwise never cancel the orphan.
+      await this.deps.ephemeralStore
+        .requestCancelActiveRuns(published.workflow.id, `agent:${agentId}`)
+        .catch(() => undefined);
+      await this.deps.ephemeralStore.markReaped(published.workflow.id).catch(() => undefined);
+      await this.deps.ephemeralStore.hardDeleteUnreferenced(published.workflow.id).catch(() => undefined);
+      this.deps.log?.(
+        `[conductor] ephemeral start of '${slug}' failed — scaffold reaped: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      throw err;
+    }
+  }
+}

--- a/middleware/src/conductor/ephemeralStore.ts
+++ b/middleware/src/conductor/ephemeralStore.ts
@@ -1,0 +1,130 @@
+// Persistence for the ephemeral-workflow lifecycle (#330 Workstream A):
+// guardrail counters, the reapable-row query, and the two removal shapes.
+// "Removal" is logical by default (disable + reaped_at — the run history and
+// version graph stay as audit trace); a physical DELETE happens only for rows
+// no run references (a failed start left them behind), which the versions
+// FK cascades while conductor_runs.workflow_version_id (RESTRICT) guarantees
+// referenced rows can never be deleted by accident.
+
+import type { Pool } from 'pg';
+
+export interface ReapableWorkflow {
+  id: string;
+  slug: string;
+  /** true when the TTL elapsed — active runs get a cancel request before the reap. */
+  expired: boolean;
+}
+
+export class ConductorEphemeralStore {
+  constructor(private readonly pool: Pool) {}
+
+  /** Active (running/waiting) runs across all ephemeral workflows this agent created. */
+  async countActiveRunsByAgent(agentId: string): Promise<number> {
+    const r = await this.pool.query<{ count: string }>(
+      `SELECT count(*) AS count
+         FROM conductor_runs r
+         JOIN conductor_workflow_versions v ON r.workflow_version_id = v.id
+         JOIN conductor_workflows w ON v.workflow_id = w.id
+        WHERE w.origin = 'ephemeral'
+          AND w.created_by_agent = $1
+          AND r.status IN ('running', 'waiting')`,
+      [agentId],
+    );
+    return Number(r.rows[0]?.count ?? 0);
+  }
+
+  /** Ephemeral workflows this agent created since `cutoff` (rate-limit window). */
+  async countRecentCreatesByAgent(agentId: string, cutoff: Date): Promise<number> {
+    const r = await this.pool.query<{ count: string }>(
+      `SELECT count(*) AS count
+         FROM conductor_workflows
+        WHERE origin = 'ephemeral'
+          AND created_by_agent = $1
+          AND created_at > $2`,
+      [agentId, cutoff],
+    );
+    return Number(r.rows[0]?.count ?? 0);
+  }
+
+  /**
+   * Un-reaped ephemeral workflows due for removal: TTL elapsed, OR every run
+   * reached a terminal state (at least one run must exist — a freshly created
+   * workflow whose start is still in flight is not reapable before its TTL).
+   */
+  async listReapable(now: Date): Promise<ReapableWorkflow[]> {
+    const r = await this.pool.query<{ id: string; slug: string; expired: boolean }>(
+      `SELECT w.id, w.slug, (w.expires_at <= $1) AS expired
+         FROM conductor_workflows w
+        WHERE w.origin = 'ephemeral'
+          AND w.reaped_at IS NULL
+          AND (
+            w.expires_at <= $1
+            OR (
+              EXISTS (
+                SELECT 1 FROM conductor_workflow_versions v
+                  JOIN conductor_runs r ON r.workflow_version_id = v.id
+                 WHERE v.workflow_id = w.id
+              )
+              AND NOT EXISTS (
+                SELECT 1 FROM conductor_workflow_versions v
+                  JOIN conductor_runs r ON r.workflow_version_id = v.id
+                 WHERE v.workflow_id = w.id
+                   AND r.status IN ('running', 'waiting')
+              )
+            )
+          )`,
+      [now],
+    );
+    return r.rows.map((row) => ({ id: row.id, slug: row.slug, expired: row.expired }));
+  }
+
+  /**
+   * #759 cancel-request for every still-active run of the workflow — the driver
+   * honours it at the next step boundary; a 'waiting' run cancels immediately.
+   * Idempotent: rows that already carry a request are left untouched.
+   */
+  async requestCancelActiveRuns(workflowId: string, requestedBy: string): Promise<number> {
+    const r = await this.pool.query(
+      `UPDATE conductor_runs
+          SET cancel_requested_by = $2, cancel_requested_at = now()
+        WHERE workflow_version_id IN (
+                SELECT id FROM conductor_workflow_versions WHERE workflow_id = $1
+              )
+          AND status IN ('running', 'waiting')
+          AND cancel_requested_at IS NULL`,
+      [workflowId, requestedBy],
+    );
+    return r.rowCount ?? 0;
+  }
+
+  /** Logical removal: not startable (disabled), never listed (origin filter),
+   *  stamped `reaped_at`. Idempotent — a reaped row is never re-stamped. */
+  async markReaped(workflowId: string): Promise<void> {
+    await this.pool.query(
+      `UPDATE conductor_workflows
+          SET status = 'disabled', reaped_at = now(), updated_at = now()
+        WHERE id = $1 AND origin = 'ephemeral' AND reaped_at IS NULL`,
+      [workflowId],
+    );
+  }
+
+  /**
+   * Physical removal, guarded: only an ephemeral workflow no run references
+   * (versions cascade with it). Referenced rows stay — discard the scaffold,
+   * never the minutes.
+   */
+  async hardDeleteUnreferenced(workflowId: string): Promise<boolean> {
+    const r = await this.pool.query(
+      `DELETE FROM conductor_workflows w
+        WHERE w.id = $1
+          AND w.origin = 'ephemeral'
+          AND NOT EXISTS (
+            SELECT 1 FROM conductor_workflow_versions v
+              JOIN conductor_runs r ON r.workflow_version_id = v.id
+             WHERE v.workflow_id = w.id
+          )`,
+      [workflowId],
+    );
+    return (r.rowCount ?? 0) > 0;
+  }
+}

--- a/middleware/src/conductor/index.ts
+++ b/middleware/src/conductor/index.ts
@@ -28,6 +28,11 @@ import { RealStepEffects } from './realStepEffects.js';
 import { ConductorBuilderAgent } from './builderAgent.js';
 import { createCompositeTemplateCatalog, loadTemplateCatalog } from './templateCatalog.js';
 import type { CompositeTemplateCatalog } from './templateCatalog.js';
+import { loadPatternCatalog } from './patternCatalog.js';
+import type { PatternCatalog } from './patternCatalog.js';
+import { ConductorEphemeralStore } from './ephemeralStore.js';
+import { ConductorEphemeralRunService } from './ephemeralRunService.js';
+import { ConductorEphemeralReaper } from './ephemeralReaper.js';
 import { createTemplateStore } from './templateStore.js';
 import type { ConductorTemplateStore } from './templateStore.js';
 import { createConductorRouter } from './routes.js';
@@ -89,6 +94,20 @@ export { ConductorWebhookDispatcher } from './webhookDispatcher.js';
 export { ConductorWebhookRetryWorker } from './webhookRetryWorker.js';
 export { WEBHOOK_POST_ACTION_ID, invokeWebhookPostAction } from './webhookPostAction.js';
 export { assertOutboundUrlAllowed, WebhookUrlNotAllowedError } from './webhookOutbound.js';
+export { loadPatternCatalog } from './patternCatalog.js';
+export type { PatternCatalog } from './patternCatalog.js';
+export { ConductorEphemeralStore } from './ephemeralStore.js';
+export type { ReapableWorkflow } from './ephemeralStore.js';
+export {
+  ConductorEphemeralRunService,
+  EPHEMERAL_SLUG_PREFIX,
+  PatternNotFoundError,
+  EphemeralSlotsMissingError,
+  EphemeralQuotaExceededError,
+  EphemeralInvalidInputError,
+} from './ephemeralRunService.js';
+export type { CreateEphemeralRunInput, EphemeralRunHandle, EphemeralRunLimits } from './ephemeralRunService.js';
+export { ConductorEphemeralReaper } from './ephemeralReaper.js';
 
 export interface ConductorWiring {
   workflowStore: ConductorWorkflowStore;
@@ -113,6 +132,12 @@ export interface ConductorWiring {
   webhookSubscriptions: ConductorWebhookSubscriptionStore;
   webhookDispatcher: ConductorWebhookDispatcher;
   webhookRetryWorker: ConductorWebhookRetryWorker;
+  /** #330 — curated patterns + create/start seam + lifecycle for agent-generated
+   *  JIT workflows; the service is what `conductorEphemeralRuns` exposes to plugins. */
+  patternCatalog: PatternCatalog;
+  ephemeralStore: ConductorEphemeralStore;
+  ephemeralRunService: ConductorEphemeralRunService;
+  ephemeralReaper: ConductorEphemeralReaper;
   /** Deps for the unauthenticated `/api/hooks/:endpointId` router, which is mounted
    *  much earlier in `index.ts` (before `express.json()`) via a forward reference —
    *  `index.ts` assigns this once `wireConductor` returns. */
@@ -162,6 +187,16 @@ export async function wireConductor(deps: {
     holderId: string;
     holdersAfter: string[];
   }) => Promise<void>;
+  /** #330 — guardrails for agent-generated ephemeral workflows. Every field
+   *  optional; defaults: TTL 24h (max 7d), 3 concurrent runs + 10 creates/hour
+   *  per agent, 60s reaper poll. */
+  ephemeral?: {
+    defaultTtlMs?: number;
+    maxTtlMs?: number;
+    maxActivePerAgent?: number;
+    maxCreatesPerHour?: number;
+    reaperIntervalMs?: number;
+  };
   /** Global inbound kill switch (`CONDUCTOR_WEBHOOKS_ENABLED`). Default true. */
   webhooksEnabled?: boolean;
   /** Outbound delivery attempt cap + per-attempt timeout — defaults live in webhookDispatcher.ts. */
@@ -232,6 +267,19 @@ export async function wireConductor(deps: {
   });
   webhookRetryWorker.start();
 
+  // #330 — ephemeral lifecycle store, built before the executor so the terminal
+  // hook below can dispose of an agent-generated workflow the moment its run ends
+  // (the reaper's TTL poll is the safety net, not the primary path).
+  const ephemeralStore = new ConductorEphemeralStore(deps.pool);
+  const reapIfEphemeral = async (workflowVersionId: string): Promise<void> => {
+    const version = await workflowStore.getVersion(workflowVersionId);
+    const workflow = version ? await workflowStore.getById(version.workflowId) : null;
+    if (workflow?.origin !== 'ephemeral' || workflow.reapedAt) return;
+    await ephemeralStore.markReaped(workflow.id);
+    await ephemeralStore.hardDeleteUnreferenced(workflow.id);
+    log(`[conductor] ephemeral '${workflow.slug}' reaped on terminal run state (audit trace retained)`);
+  };
+
   const executor = new ConductorRunExecutor({
     workflowStore,
     runStore,
@@ -256,6 +304,12 @@ export async function wireConductor(deps: {
         await webhookDispatcher.deliverEvent(event, payload);
       })().catch((err: unknown) => {
         log(`[conductor] webhook dispatch for run ${run.id} failed: ${err instanceof Error ? err.message : String(err)}`);
+      });
+      // #330 — an ephemeral workflow is disposed of the moment its run reaches a
+      // terminal state. Best-effort like the webhook dispatch: a miss here is
+      // recovered by the reaper's poll, never lost.
+      void reapIfEphemeral(run.workflowVersionId).catch((err: unknown) => {
+        log(`[conductor] ephemeral reap after run ${run.id} failed: ${err instanceof Error ? err.message : String(err)}`);
       });
     },
     log,
@@ -312,6 +366,29 @@ export async function wireConductor(deps: {
   // Schedule worker — fires workflows on their cron triggers (US4 cron).
   const scheduleWorker = new ConductorScheduleWorker({ scheduleStore, executor, log });
   scheduleWorker.start();
+
+  // #330 — curated pattern catalog + the create/start seam agents get via the
+  // `conductorEphemeralRuns` service, plus the TTL reaper (scheduleWorker discipline).
+  const patternCatalog = loadPatternCatalog({ log });
+  const ephemeralRunService = new ConductorEphemeralRunService({
+    patterns: patternCatalog,
+    workflowStore,
+    ephemeralStore,
+    executor,
+    limits: {
+      defaultTtlMs: deps.ephemeral?.defaultTtlMs ?? 24 * 60 * 60 * 1000,
+      maxTtlMs: deps.ephemeral?.maxTtlMs ?? 7 * 24 * 60 * 60 * 1000,
+      maxActivePerAgent: deps.ephemeral?.maxActivePerAgent ?? 3,
+      maxCreatesPerHour: deps.ephemeral?.maxCreatesPerHour ?? 10,
+    },
+    log,
+  });
+  const ephemeralReaper = new ConductorEphemeralReaper({
+    store: ephemeralStore,
+    ...(deps.ephemeral?.reaperIntervalMs !== undefined ? { intervalMs: deps.ephemeral.reaperIntervalMs } : {}),
+    log,
+  });
+  ephemeralReaper.start();
 
   // Event router — a domain event starts every subscribed workflow's run (US4).
   const eventRouter = new ConductorEventRouter({ workflowStore, executor, log });
@@ -398,5 +475,6 @@ export async function wireConductor(deps: {
     workflowStore, runStore, awaitStore, roleStore, scheduleStore, channelBindingStore, executor, awaitWorker,
     resumeWorker, scheduleWorker, eventRouter, builderAgent, templateStore, templateCatalog,
     webhookEndpoints, webhookSubscriptions, webhookDispatcher, webhookRetryWorker, webhookInboundDeps,
+    patternCatalog, ephemeralStore, ephemeralRunService, ephemeralReaper,
   };
 }

--- a/middleware/src/conductor/migrations/0009_ephemeral_workflows.sql
+++ b/middleware/src/conductor/migrations/0009_ephemeral_workflows.sql
@@ -1,0 +1,28 @@
+-- #330 Workstream A — ephemeral / JIT workflows.
+--
+-- Agent-generated workflows are instances of curated facilitation patterns,
+-- namespaced away from the user-authored library via `origin` plus a reserved
+-- `eph-` slug prefix (the create/instantiate routes reject it). "Removal" on
+-- terminal state / TTL expiry is logical: the reaper disables the workflow and
+-- stamps `reaped_at` — the run history and its version graph (the audit trace)
+-- are retained; conductor_runs.workflow_version_id carries no ON DELETE clause
+-- (Postgres default NO ACTION — blocks the delete exactly like RESTRICT here),
+-- so a physical DELETE only ever happens for rows no run references.
+
+ALTER TABLE conductor_workflows ADD COLUMN IF NOT EXISTS origin TEXT NOT NULL DEFAULT 'manual';
+ALTER TABLE conductor_workflows DROP CONSTRAINT IF EXISTS conductor_workflows_origin_check;
+ALTER TABLE conductor_workflows ADD CONSTRAINT conductor_workflows_origin_check
+  CHECK (origin IN ('manual', 'ephemeral'));
+
+ALTER TABLE conductor_workflows ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ;
+ALTER TABLE conductor_workflows ADD COLUMN IF NOT EXISTS created_by_agent TEXT;
+ALTER TABLE conductor_workflows ADD COLUMN IF NOT EXISTS reaped_at TIMESTAMPTZ;
+
+-- An ephemeral workflow without a TTL could outlive its run forever — exactly
+-- the clutter #330 forbids. Mandatory at the schema level, not just in code.
+ALTER TABLE conductor_workflows DROP CONSTRAINT IF EXISTS conductor_workflows_ephemeral_ttl_check;
+ALTER TABLE conductor_workflows ADD CONSTRAINT conductor_workflows_ephemeral_ttl_check
+  CHECK (origin <> 'ephemeral' OR expires_at IS NOT NULL);
+
+CREATE INDEX IF NOT EXISTS conductor_workflows_ephemeral_reap_idx
+  ON conductor_workflows (expires_at) WHERE origin = 'ephemeral' AND reaped_at IS NULL;

--- a/middleware/src/conductor/patternCatalog.ts
+++ b/middleware/src/conductor/patternCatalog.ts
@@ -1,0 +1,76 @@
+// Curated ephemeral-workflow patterns (#330 Workstream A). A pattern IS a
+// TemplateManifest — same slot machinery, same validation — but it lives in a
+// separate, deliberately smaller catalog: `conductor.createEphemeralRun` may
+// only instantiate what ships in `patterns/` (mirrored into dist/ by
+// scripts/copy-build-assets.mjs), never user- or plugin-contributed templates.
+// That keeps agent-generated workflows generative AND validatable: the agent
+// fills slots in an engine-checked graph, it cannot submit arbitrary graphs.
+//
+// Same resilience contract as templateCatalog.ts: an invalid bundled file is
+// skipped with a loud log line and the CI test over the shipped patterns is
+// the hard completeness gate.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { checkTemplateManifest, type TemplateManifest } from '@omadia/conductor-core';
+
+const DEFAULT_DIR = join(dirname(fileURLToPath(import.meta.url)), 'patterns');
+
+export interface PatternCatalog {
+  /** All valid patterns, sorted by id. Returns a fresh array on every call. */
+  list(): TemplateManifest[];
+  get(id: string): TemplateManifest | undefined;
+}
+
+/**
+ * Read every `*.json` in the patterns dir (dirname-relative by default so it
+ * works from src under tsx and from dist in production; overridable for tests),
+ * keep the manifests that pass `checkTemplateManifest`, and serve them from an
+ * in-memory map. Duplicate ids keep the first file (filename order) and log
+ * the collision.
+ */
+export function loadPatternCatalog(opts?: {
+  dir?: string;
+  log?: (msg: string) => void;
+}): PatternCatalog {
+  const dir = opts?.dir ?? DEFAULT_DIR;
+  const log = opts?.log ?? ((msg: string) => console.warn(msg));
+
+  let files: string[] = [];
+  try {
+    files = readdirSync(dir)
+      .filter((f) => f.endsWith('.json'))
+      .sort();
+  } catch (err) {
+    log(`[conductor] pattern dir '${dir}' unreadable: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  const byId = new Map<string, TemplateManifest>();
+  for (const file of files) {
+    let manifest: TemplateManifest;
+    try {
+      manifest = JSON.parse(readFileSync(join(dir, file), 'utf8')) as TemplateManifest;
+      const result = checkTemplateManifest(manifest);
+      if (!result.ok) {
+        log(`[conductor] pattern ${file} invalid: ${result.errors.map((e) => e.message).join('; ')}`);
+        continue;
+      }
+    } catch (err) {
+      log(`[conductor] pattern ${file} invalid: ${err instanceof Error ? err.message : String(err)}`);
+      continue;
+    }
+    if (byId.has(manifest.id)) {
+      log(`[conductor] pattern ${file} duplicates id '${manifest.id}' — keeping the first occurrence`);
+      continue;
+    }
+    byId.set(manifest.id, manifest);
+  }
+
+  const patterns = [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
+  return {
+    list: () => [...patterns],
+    get: (id: string) => byId.get(id),
+  };
+}

--- a/middleware/src/conductor/patterns/facilitation.json
+++ b/middleware/src/conductor/patterns/facilitation.json
@@ -1,0 +1,106 @@
+{
+  "id": "facilitation",
+  "name": {
+    "en": "Facilitated group outcome",
+    "de": "Moderiertes Gruppenergebnis"
+  },
+  "description": {
+    "en": "Scaffold for an agent-moderated group conversation: a facilitator agent moderates toward a stated goal until the definition of done is met, the initiator confirms the outcome, and a final report is produced. Unconfirmed outcomes fall back to an abort report at the deadline.",
+    "de": "Gerüst für eine agentenmoderierte Gruppenkonversation: Ein Moderations-Agent moderiert auf ein erklärtes Ziel hin, bis die Definition-of-Done erfüllt ist, der Initiator bestätigt das Ergebnis, und ein Abschlussbericht wird erstellt. Unbestätigte Ergebnisse fallen zur Frist auf einen Abbruchbericht zurück."
+  },
+  "useCase": {
+    "en": "facilitation",
+    "de": "Moderation"
+  },
+  "defaultSlug": "facilitation",
+  "version": 1,
+  "graph": {
+    "entryStepId": "moderate",
+    "steps": [
+      {
+        "id": "moderate",
+        "kind": "agent",
+        "agentId": "slot:agent:facilitator",
+        "prompt": "You are facilitating a group conversation toward a defined outcome. Goal: {{ctx.goal}}. Definition of done: {{ctx.definitionOfDone}}. Moderate the group until the definition of done is met, then produce a concise outcome summary: the result itself, how the group reached it, and the key insights along the way.",
+        "position": { "x": 80, "y": 160 }
+      },
+      {
+        "id": "confirm",
+        "kind": "human",
+        "human": {
+          "principal": { "kind": "role", "ref": "slot:role:initiator" },
+          "channel": "slot:channel:report",
+          "message": "The facilitation toward \"{{ctx.goal}}\" has concluded. Outcome summary: {{steps.moderate.text}}. Please approve the result.",
+          "deadline": "PT24H"
+        },
+        "fallbackTransitionId": "t-confirm-timeout",
+        "position": { "x": 340, "y": 160 }
+      },
+      {
+        "id": "report",
+        "kind": "agent",
+        "agentId": "slot:agent:facilitator",
+        "prompt": "The initiator approved the facilitation outcome for the goal {{ctx.goal}}. Produce the final report: the confirmed result, the path the group took to reach it, and the insights that emerged.",
+        "position": { "x": 600, "y": 160 }
+      },
+      {
+        "id": "abort-report",
+        "kind": "agent",
+        "agentId": "slot:agent:facilitator",
+        "prompt": "The facilitation outcome for the goal {{ctx.goal}} was not confirmed before the deadline. Produce a failure report: the state that was reached, why no confirmed result exists, and what the group would need to continue.",
+        "position": { "x": 600, "y": 320 }
+      }
+    ],
+    "transitions": [
+      { "id": "t-moderated", "source": "moderate", "target": "confirm" },
+      {
+        "id": "t-confirmed",
+        "source": "confirm",
+        "target": "report",
+        "guard": { "op": "eq", "path": "stepResult.approved", "value": true }
+      },
+      { "id": "t-confirm-timeout", "source": "confirm", "target": "abort-report" }
+    ]
+  },
+  "slots": {
+    "agents": [
+      {
+        "key": "facilitator",
+        "label": {
+          "en": "Facilitator agent",
+          "de": "Moderations-Agent"
+        },
+        "description": {
+          "en": "Agent that moderates the group, summarizes the outcome, and writes the final report.",
+          "de": "Agent, der die Gruppe moderiert, das Ergebnis zusammenfasst und den Abschlussbericht schreibt."
+        }
+      }
+    ],
+    "roles": [
+      {
+        "key": "initiator",
+        "label": {
+          "en": "Initiator role",
+          "de": "Initiator-Rolle"
+        },
+        "description": {
+          "en": "Role that commissioned the facilitation and confirms the outcome.",
+          "de": "Rolle, die die Moderation beauftragt hat und das Ergebnis bestätigt."
+        }
+      }
+    ],
+    "channels": [
+      {
+        "key": "report",
+        "label": {
+          "en": "Report channel",
+          "de": "Berichtskanal"
+        },
+        "description": {
+          "en": "Channel used to reach the initiator for confirmation and reporting.",
+          "de": "Kanal, über den der Initiator für Bestätigung und Bericht erreicht wird."
+        }
+      }
+    ]
+  }
+}

--- a/middleware/src/conductor/routes.ts
+++ b/middleware/src/conductor/routes.ts
@@ -7,6 +7,7 @@ import type { JsonObject, KnownRefs, WorkflowGraph } from '@omadia/conductor-cor
 import { ConductorBuilderUnavailableError } from './builderAgent.js';
 import type { BuilderChatMessage, ConductorBuilderAgent } from './builderAgent.js';
 import { emptyGraph } from './graphPatch.js';
+import { EPHEMERAL_SLUG_PREFIX } from './ephemeralRunService.js';
 import type { ConductorWorkflowStore } from './workflowStore.js';
 import type { ConductorRunStore } from './runStore.js';
 import { resolveAwaitHolders } from './awaitStore.js';
@@ -138,6 +139,12 @@ export function createConductorRouter(deps: ConductorRouterDeps): Router {
     const name = typeof body.name === 'string' ? body.name : '';
     if (!slug || !name) {
       res.status(400).json({ code: 'conductor.invalid_input', message: 'slug and name are required' });
+      return;
+    }
+    // #330 — 'eph-' is the agent-generated namespace (createEphemeralRun); a manual
+    // workflow squatting on it would collide with the reaper's lifecycle.
+    if (slug.startsWith(EPHEMERAL_SLUG_PREFIX)) {
+      res.status(400).json({ code: 'conductor.reserved_slug_prefix', message: `slug prefix '${EPHEMERAL_SLUG_PREFIX}' is reserved for ephemeral workflows` });
       return;
     }
     const graph = body.graph as unknown as WorkflowGraph;
@@ -400,6 +407,13 @@ export function createConductorRouter(deps: ConductorRouterDeps): Router {
       res.status(400).json({ code: 'conductor.invalid_input', message: "status must be 'enabled' or 'disabled'" });
       return;
     }
+    // #330 — ephemeral workflows are lifecycle-managed by their reaper, never by
+    // operators: re-enabling a reaped definition would create a permanently
+    // startable zombie the reaper can no longer see (reaped_at is stamped once).
+    if (paramStr(req.params.slug).startsWith(EPHEMERAL_SLUG_PREFIX)) {
+      res.status(400).json({ code: 'conductor.reserved_slug_prefix', message: `status of '${EPHEMERAL_SLUG_PREFIX}' workflows is managed by the ephemeral lifecycle` });
+      return;
+    }
     try {
       await deps.workflowStore.setStatus(paramStr(req.params.slug), status);
       res.status(204).end();
@@ -431,6 +445,13 @@ export function createConductorRouter(deps: ConductorRouterDeps): Router {
   router.post('/:slug/runs', async (req: Request, res: Response): Promise<void> => {
     const slug = paramStr(req.params.slug);
     const payload = asObject(asObject(req.body).payload);
+    // #330 — an ephemeral workflow is run-scoped: exactly one run, started by
+    // createEphemeralRun. A manual run would delay the reap (listReapable waits
+    // for all-terminal) and count against the creating agent's quota.
+    if (slug.startsWith(EPHEMERAL_SLUG_PREFIX)) {
+      res.status(400).json({ code: 'conductor.reserved_slug_prefix', message: `runs of '${EPHEMERAL_SLUG_PREFIX}' workflows are managed by the ephemeral lifecycle` });
+      return;
+    }
     try {
       // Async: the run is created + driven in the background (real agent turns are slow).
       // 202 Accepted; the client polls GET /:slug/runs/:runId for the final status + trace.

--- a/middleware/src/conductor/templateRoutes.ts
+++ b/middleware/src/conductor/templateRoutes.ts
@@ -21,6 +21,7 @@ import {
 } from '@omadia/conductor-core';
 import type { JsonObject, LocalizedText, TemplateManifest, TemplateSlotMapping, WorkflowGraph } from '@omadia/conductor-core';
 
+import { EPHEMERAL_SLUG_PREFIX } from './ephemeralRunService.js';
 import { WorkflowSlugExistsError } from './workflowStore.js';
 import { TemplateIdExistsError, TemplateInvalidError } from './templateStore.js';
 import type { TemplateSummary } from './templateCatalog.js';
@@ -352,6 +353,12 @@ export function registerTemplateRoutes(router: Router, deps: ConductorRouterDeps
     const slug = typeof body.slug === 'string' ? body.slug.trim() : '';
     if (!slug) {
       res.status(400).json({ code: 'conductor.invalid_input', message: 'slug is required' });
+      return;
+    }
+    // #330 — same reservation as 'POST /': the 'eph-' namespace belongs to
+    // agent-generated ephemeral workflows and their reaper.
+    if (slug.startsWith(EPHEMERAL_SLUG_PREFIX)) {
+      res.status(400).json({ code: 'conductor.reserved_slug_prefix', message: `slug prefix '${EPHEMERAL_SLUG_PREFIX}' is reserved for ephemeral workflows` });
       return;
     }
     try {

--- a/middleware/src/conductor/workflowStore.ts
+++ b/middleware/src/conductor/workflowStore.ts
@@ -15,6 +15,17 @@ export interface ConductorWorkflow {
    *  workflow was not instantiated from a template. */
   templateId?: string | null;
   templateVersion?: number | null;
+  /** #330 — 'manual' = user-authored library entry, 'ephemeral' = agent-generated
+   *  JIT instance of a curated pattern. Optional so pre-#330 fakes/fixtures keep
+   *  typechecking; absent reads as 'manual'. */
+  origin?: 'manual' | 'ephemeral';
+  /** #330 — mandatory TTL for ephemeral workflows (CHECK-enforced); null on manual. */
+  expiresAt?: Date | null;
+  /** #330 — the agent that generated an ephemeral workflow; null on manual. */
+  createdByAgent?: string | null;
+  /** #330 — set when the reaper logically removed the definition (disabled +
+   *  hidden). The run history and version graph are retained as audit trace. */
+  reapedAt?: Date | null;
 }
 
 export interface ConductorVersion {
@@ -33,6 +44,10 @@ interface WorkflowRow {
   active_version_id: string | null;
   template_id: string | null;
   template_version: number | null;
+  origin: 'manual' | 'ephemeral';
+  expires_at: Date | null;
+  created_by_agent: string | null;
+  reaped_at: Date | null;
 }
 
 interface VersionRow {
@@ -62,10 +77,14 @@ function toWorkflow(r: WorkflowRow): ConductorWorkflow {
     activeVersionId: r.active_version_id,
     templateId: r.template_id,
     templateVersion: r.template_version,
+    origin: r.origin,
+    expiresAt: r.expires_at,
+    createdByAgent: r.created_by_agent,
+    reapedAt: r.reaped_at,
   };
 }
 
-const WORKFLOW_COLS = 'id, slug, name, description, status, active_version_id, template_id, template_version';
+const WORKFLOW_COLS = 'id, slug, name, description, status, active_version_id, template_id, template_version, origin, expires_at, created_by_agent, reaped_at';
 
 /**
  * Persistence for workflow headers + immutable versions. A publish snapshots the
@@ -92,8 +111,14 @@ export class ConductorWorkflowStore {
   }
 
   async list(): Promise<ConductorWorkflow[]> {
+    // #330 — the library is the user-authored surface: ephemeral (agent-generated)
+    // workflows never appear here, whatever their lifecycle state. Filtering in the
+    // store covers both consumers at once — the library route stays clutter-free AND
+    // the event router never event-triggers an ephemeral workflow: those are
+    // run-scoped (exactly one run, started by createEphemeralRun), not standing
+    // event subscribers.
     const r = await this.pool.query<WorkflowRow>(
-      `SELECT ${WORKFLOW_COLS} FROM conductor_workflows ORDER BY created_at DESC`,
+      `SELECT ${WORKFLOW_COLS} FROM conductor_workflows WHERE origin = 'manual' ORDER BY created_at DESC`,
     );
     return r.rows.map(toWorkflow);
   }
@@ -124,6 +149,12 @@ export class ConductorWorkflowStore {
      *  "create new" contract). Atomic -- the INSERT's conflict clause decides, not a
      *  racy SELECT-then-INSERT. Default (absent/false) keeps the idempotent upsert. */
     expectNew?: boolean;
+    /** #330 — create-time provenance for ephemeral (agent-generated) workflows. Only
+     *  honoured on first create (the conflict branch never rewrites origin); callers
+     *  passing origin 'ephemeral' must pass expiresAt too (schema CHECK). */
+    origin?: 'manual' | 'ephemeral';
+    expiresAt?: Date | null;
+    createdByAgent?: string | null;
     /** Runs inside the publish transaction after the version is set active — used to reconcile cron
      *  schedules atomically with the publish (a throw rolls the whole publish back, so a failed
      *  reconcile never leaves stale schedules behind). */
@@ -143,11 +174,19 @@ export class ConductorWorkflowStore {
         : `ON CONFLICT (slug) DO UPDATE
            SET name = EXCLUDED.name, description = EXCLUDED.description, updated_at = now()`;
       const upserted = await client.query<{ id: string }>(
-        `INSERT INTO conductor_workflows (slug, name, description, status)
-         VALUES ($1, $2, $3, $4)
+        `INSERT INTO conductor_workflows (slug, name, description, status, origin, expires_at, created_by_agent)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
          ${conflictClause}
          RETURNING id`,
-        [input.slug, input.name, input.description ?? null, input.enable ? 'enabled' : 'disabled'],
+        [
+          input.slug,
+          input.name,
+          input.description ?? null,
+          input.enable ? 'enabled' : 'disabled',
+          input.origin ?? 'manual',
+          input.expiresAt ?? null,
+          input.createdByAgent ?? null,
+        ],
       );
       const workflowId = upserted.rows[0]?.id;
       if (workflowId === undefined) throw new WorkflowSlugExistsError(input.slug);

--- a/middleware/src/config.ts
+++ b/middleware/src/config.ts
@@ -266,6 +266,16 @@ const ConfigSchema = z.object({
   // origin in dev, while the webhook route only ever lives on the middleware).
   CONDUCTOR_WEBHOOK_PUBLIC_BASE_URL: z.string().url().optional(),
 
+  // #330 — guardrails for agent-generated ephemeral workflows
+  // (conductor.createEphemeralRun): a mandatory, clamped TTL plus per-agent
+  // concurrency and creation-rate caps make runaway generation structurally
+  // impossible; the reaper poll disposes of expired/terminal scaffolds.
+  CONDUCTOR_EPHEMERAL_DEFAULT_TTL_MS: z.coerce.number().int().positive().default(24 * 60 * 60 * 1000),
+  CONDUCTOR_EPHEMERAL_MAX_TTL_MS: z.coerce.number().int().positive().default(7 * 24 * 60 * 60 * 1000),
+  CONDUCTOR_EPHEMERAL_MAX_ACTIVE_PER_AGENT: z.coerce.number().int().positive().default(3),
+  CONDUCTOR_EPHEMERAL_MAX_CREATES_PER_HOUR: z.coerce.number().int().positive().default(10),
+  CONDUCTOR_EPHEMERAL_REAPER_INTERVAL_MS: z.coerce.number().int().positive().default(60_000),
+
   // #757 — bounded retention for persisted per-turn privacy receipts
   // (`turn_receipts`). The payload is PII-free (counts only) but turn_id +
   // scope are personal-data linkage, so rows are reaped after this many days.

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -3433,6 +3433,14 @@ async function main(): Promise<void> {
         });
       },
       webhooksEnabled: config.CONDUCTOR_WEBHOOKS_ENABLED,
+      // #330 — guardrails for agent-generated ephemeral workflows (env-tunable).
+      ephemeral: {
+        defaultTtlMs: config.CONDUCTOR_EPHEMERAL_DEFAULT_TTL_MS,
+        maxTtlMs: config.CONDUCTOR_EPHEMERAL_MAX_TTL_MS,
+        maxActivePerAgent: config.CONDUCTOR_EPHEMERAL_MAX_ACTIVE_PER_AGENT,
+        maxCreatesPerHour: config.CONDUCTOR_EPHEMERAL_MAX_CREATES_PER_HOUR,
+        reaperIntervalMs: config.CONDUCTOR_EPHEMERAL_REAPER_INTERVAL_MS,
+      },
       webhookInboundMaxPerMinute: config.CONDUCTOR_WEBHOOK_MAX_DELIVERIES_PER_MINUTE,
       // Review finding — the operator UI must display an inbound endpoint URL it can
       // actually reach; PUBLIC_BASE_URL alone isn't reliable here since it may
@@ -3469,6 +3477,10 @@ async function main(): Promise<void> {
         }
       },
     });
+    // #330 — agent-facing create+start seam for ephemeral (JIT) workflows.
+    // Deny-by-default like every kernel service: a plugin only reaches it after
+    // declaring the service name in its manifest (pluginServiceGrants catalog).
+    serviceRegistry.provide('conductorEphemeralRuns', conductorWiring.ephemeralRunService);
     // #478 — plugin-borne workflow templates: hand the composite catalog's
     // registrar to the install service (runtime installs/uninstalls) and
     // re-register templates of already-installed plugins (registrations are

--- a/middleware/test/conductorEphemeralReaper.test.ts
+++ b/middleware/test/conductorEphemeralReaper.test.ts
@@ -1,0 +1,90 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { ConductorEphemeralReaper } from '../src/conductor/ephemeralReaper.js';
+import type { ConductorEphemeralStore, ReapableWorkflow } from '../src/conductor/ephemeralStore.js';
+
+// #330 — reaper semantics: TTL-expired rows get a cancel request for their
+// active runs, every reapable row is soft-reaped (disable + reaped_at), and a
+// physical delete is only ever attempted through the guarded store method.
+// Fakes throughout, per-row error isolation verified explicitly.
+
+interface Calls {
+  cancelled: Array<{ id: string; by: string }>;
+  reaped: string[];
+  hardDeleted: string[];
+}
+
+function fakeStore(opts: {
+  reapable: ReapableWorkflow[];
+  listError?: Error;
+  reapErrorFor?: string;
+}): { store: ConductorEphemeralStore; calls: Calls } {
+  const calls: Calls = { cancelled: [], reaped: [], hardDeleted: [] };
+  const store = {
+    listReapable: async () => {
+      if (opts.listError) throw opts.listError;
+      return opts.reapable;
+    },
+    requestCancelActiveRuns: async (id: string, by: string) => {
+      calls.cancelled.push({ id, by });
+      return 1;
+    },
+    markReaped: async (id: string) => {
+      if (opts.reapErrorFor === id) throw new Error(`reap of ${id} failed`);
+      calls.reaped.push(id);
+    },
+    hardDeleteUnreferenced: async (id: string) => {
+      calls.hardDeleted.push(id);
+      return false;
+    },
+  } as unknown as ConductorEphemeralStore;
+  return { store, calls };
+}
+
+describe('ConductorEphemeralReaper.tick', () => {
+  it('cancels active runs of an expired workflow, then soft-reaps it', async () => {
+    const { store, calls } = fakeStore({ reapable: [{ id: 'wf-1', slug: 'eph-a', expired: true }] });
+    await new ConductorEphemeralReaper({ store }).tick();
+
+    assert.deepEqual(calls.cancelled, [{ id: 'wf-1', by: 'conductor-ephemeral-reaper' }]);
+    assert.deepEqual(calls.reaped, ['wf-1']);
+    assert.deepEqual(calls.hardDeleted, ['wf-1']);
+  });
+
+  it('reaps a terminal (non-expired) workflow without any cancel request, retaining run history', async () => {
+    const { store, calls } = fakeStore({ reapable: [{ id: 'wf-2', slug: 'eph-b', expired: false }] });
+    await new ConductorEphemeralReaper({ store }).tick();
+
+    assert.deepEqual(calls.cancelled, []);
+    assert.deepEqual(calls.reaped, ['wf-2']);
+    // The delete is the GUARDED store method — the fake reports 'row referenced,
+    // not deleted', i.e. the definition is retained as audit trace. No other
+    // deletion path exists in the reaper.
+    assert.deepEqual(calls.hardDeleted, ['wf-2']);
+  });
+
+  it('isolates a failing row — later rows are still reaped', async () => {
+    const { store, calls } = fakeStore({
+      reapable: [
+        { id: 'wf-bad', slug: 'eph-bad', expired: false },
+        { id: 'wf-good', slug: 'eph-good', expired: false },
+      ],
+      reapErrorFor: 'wf-bad',
+    });
+    const logs: string[] = [];
+    await new ConductorEphemeralReaper({ store, log: (m) => logs.push(m) }).tick();
+
+    assert.deepEqual(calls.reaped, ['wf-good']);
+    assert.ok(logs.some((l) => l.includes("reap of 'eph-bad' failed")));
+  });
+
+  it('survives a listReapable failure without throwing', async () => {
+    const { store, calls } = fakeStore({ reapable: [], listError: new Error('db down') });
+    const logs: string[] = [];
+    await new ConductorEphemeralReaper({ store, log: (m) => logs.push(m) }).tick();
+
+    assert.deepEqual(calls.reaped, []);
+    assert.ok(logs.some((l) => l.includes('reaper list failed')));
+  });
+});

--- a/middleware/test/conductorEphemeralRunService.test.ts
+++ b/middleware/test/conductorEphemeralRunService.test.ts
@@ -1,0 +1,200 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import type { TemplateManifest } from '@omadia/conductor-core';
+
+import {
+  ConductorEphemeralRunService,
+  EPHEMERAL_SLUG_PREFIX,
+  EphemeralInvalidInputError,
+  EphemeralQuotaExceededError,
+  EphemeralSlotsMissingError,
+  PatternNotFoundError,
+} from '../src/conductor/ephemeralRunService.js';
+import type { ConductorEphemeralStore } from '../src/conductor/ephemeralStore.js';
+import type { PatternCatalog } from '../src/conductor/patternCatalog.js';
+import type { ConductorRunExecutor } from '../src/conductor/runExecutor.js';
+import type { ConductorWorkflowStore } from '../src/conductor/workflowStore.js';
+
+// #330 — the create+start seam behind `conductorEphemeralRuns`. All fakes, no DB:
+// the service's contract is guardrails + provenance + one-call create/start, and
+// that is fully observable through what it hands the store/executor.
+
+const PATTERN: TemplateManifest = {
+  id: 'demo',
+  name: { en: 'Demo pattern' },
+  description: { en: 'A demo' },
+  useCase: { en: 'demo' },
+  defaultSlug: 'demo',
+  graph: {
+    entryStepId: 's1',
+    steps: [{ id: 's1', kind: 'agent', agentId: 'slot:agent:worker', prompt: 'Do {{ctx.goal}}' }],
+    transitions: [],
+  },
+  slots: { agents: [{ key: 'worker', label: { en: 'Worker' } }] },
+};
+
+const NOW = new Date('2026-08-21T10:00:00.000Z');
+const HOUR_MS = 60 * 60 * 1000;
+const LIMITS = { defaultTtlMs: 24 * HOUR_MS, maxTtlMs: 7 * 24 * HOUR_MS, maxActivePerAgent: 3, maxCreatesPerHour: 10 };
+
+interface Harness {
+  service: ConductorEphemeralRunService;
+  published: Array<Record<string, unknown>>;
+  started: Array<Record<string, unknown>>;
+  reaped: string[];
+  hardDeleted: string[];
+  cancelRequests: Array<{ id: string; by: string }>;
+}
+
+function harness(opts?: {
+  activeRuns?: number;
+  recentCreates?: number;
+  startRunError?: Error;
+  limits?: Partial<typeof LIMITS>;
+}): Harness {
+  const published: Array<Record<string, unknown>> = [];
+  const started: Array<Record<string, unknown>> = [];
+  const reaped: string[] = [];
+  const hardDeleted: string[] = [];
+  const cancelRequests: Array<{ id: string; by: string }> = [];
+
+  const patterns: PatternCatalog = { list: () => [PATTERN], get: (id) => (id === 'demo' ? PATTERN : undefined) };
+  const workflowStore = {
+    createOrPublish: async (input: Record<string, unknown>) => {
+      published.push(input);
+      return { workflow: { id: 'wf-1', slug: input.slug }, version: { id: 'ver-1', workflowId: 'wf-1', version: 1 } };
+    },
+  } as unknown as ConductorWorkflowStore;
+  const ephemeralStore = {
+    countActiveRunsByAgent: async () => opts?.activeRuns ?? 0,
+    countRecentCreatesByAgent: async () => opts?.recentCreates ?? 0,
+    markReaped: async (id: string) => {
+      reaped.push(id);
+    },
+    hardDeleteUnreferenced: async (id: string) => {
+      hardDeleted.push(id);
+      return true;
+    },
+    requestCancelActiveRuns: async (id: string, by: string) => {
+      cancelRequests.push({ id, by });
+      return 0;
+    },
+  } as unknown as ConductorEphemeralStore;
+  const executor = {
+    startRun: async (input: Record<string, unknown>) => {
+      if (opts?.startRunError) throw opts.startRunError;
+      started.push(input);
+      return { id: 'run-1', status: 'running' };
+    },
+  } as unknown as ConductorRunExecutor;
+
+  const service = new ConductorEphemeralRunService({
+    patterns,
+    workflowStore,
+    ephemeralStore,
+    executor,
+    limits: { ...LIMITS, ...opts?.limits },
+    now: () => NOW,
+  });
+  return { service, published, started, reaped, hardDeleted, cancelRequests };
+}
+
+const VALID_INPUT = { agentId: 'facilitator-1', patternId: 'demo', slots: { agents: { worker: 'real-agent' } } };
+
+describe('ConductorEphemeralRunService.createEphemeralRun', () => {
+  it('rejects invalid boundary input with typed errors', async () => {
+    const { service } = harness();
+    await assert.rejects(service.createEphemeralRun({ ...VALID_INPUT, agentId: '  ' }), EphemeralInvalidInputError);
+    await assert.rejects(service.createEphemeralRun({ ...VALID_INPUT, patternId: '' }), EphemeralInvalidInputError);
+    await assert.rejects(
+      service.createEphemeralRun({ ...VALID_INPUT, slots: [] as unknown as typeof VALID_INPUT.slots }),
+      EphemeralInvalidInputError,
+    );
+    await assert.rejects(service.createEphemeralRun({ ...VALID_INPUT, ttlMs: -5 }), EphemeralInvalidInputError);
+  });
+
+  it('throws PatternNotFoundError for an unknown pattern id', async () => {
+    const { service, published } = harness();
+    await assert.rejects(service.createEphemeralRun({ ...VALID_INPUT, patternId: 'nope' }), PatternNotFoundError);
+    assert.equal(published.length, 0);
+  });
+
+  it('throws EphemeralSlotsMissingError when a declared slot is unmapped', async () => {
+    const { service, published } = harness();
+    await assert.rejects(
+      service.createEphemeralRun({ ...VALID_INPUT, slots: {} }),
+      (err: unknown) => err instanceof EphemeralSlotsMissingError && err.missing[0]?.key === 'worker',
+    );
+    assert.equal(published.length, 0);
+  });
+
+  it('denies at the concurrent-runs quota before touching the store', async () => {
+    const { service, published } = harness({ activeRuns: 3 });
+    await assert.rejects(
+      service.createEphemeralRun(VALID_INPUT),
+      (err: unknown) => err instanceof EphemeralQuotaExceededError && err.kind === 'concurrent',
+    );
+    assert.equal(published.length, 0);
+  });
+
+  it('denies at the hourly create rate limit', async () => {
+    const { service, published } = harness({ recentCreates: 10 });
+    await assert.rejects(
+      service.createEphemeralRun(VALID_INPUT),
+      (err: unknown) => err instanceof EphemeralQuotaExceededError && err.kind === 'rate',
+    );
+    assert.equal(published.length, 0);
+  });
+
+  it('clamps a requested TTL to the configured maximum', async () => {
+    const { service, published } = harness();
+    const out = await service.createEphemeralRun({ ...VALID_INPUT, ttlMs: 30 * 24 * HOUR_MS });
+    assert.equal(out.expiresAt, new Date(NOW.getTime() + LIMITS.maxTtlMs).toISOString());
+    assert.deepEqual(published[0]!.expiresAt, new Date(NOW.getTime() + LIMITS.maxTtlMs));
+  });
+
+  it('defaults the TTL when none is requested', async () => {
+    const { service } = harness();
+    const out = await service.createEphemeralRun(VALID_INPUT);
+    assert.equal(out.expiresAt, new Date(NOW.getTime() + LIMITS.defaultTtlMs).toISOString());
+  });
+
+  it('creates + starts in one call: ephemeral origin, eph- slug, expectNew, agent trigger', async () => {
+    const { service, published, started } = harness();
+    const out = await service.createEphemeralRun({ ...VALID_INPUT, payload: { goal: 'sort roles' } });
+
+    assert.equal(published.length, 1);
+    const pub = published[0]!;
+    assert.equal(pub.origin, 'ephemeral');
+    assert.equal(pub.expectNew, true);
+    assert.equal(pub.enable, true);
+    assert.equal(pub.createdByAgent, 'facilitator-1');
+    assert.ok((pub.slug as string).startsWith(`${EPHEMERAL_SLUG_PREFIX}demo-`));
+    // The slot was substituted — the published graph carries the concrete ref.
+    const graph = pub.graph as { steps: Array<{ agentId?: string }> };
+    assert.equal(graph.steps[0]!.agentId, 'real-agent');
+
+    assert.equal(started.length, 1);
+    const start = started[0]!;
+    assert.equal(start.slug, pub.slug);
+    assert.equal(start.triggerKind, 'agent');
+    assert.deepEqual(start.triggerSource, { agentId: 'facilitator-1', patternId: 'demo' });
+    assert.deepEqual(start.payload, { goal: 'sort roles' });
+
+    assert.equal(out.runId, 'run-1');
+    assert.equal(out.workflowId, 'wf-1');
+    assert.equal(out.workflowSlug, pub.slug);
+  });
+
+  it('best-effort cancels + reaps the scaffold and rethrows when startRun fails', async () => {
+    const boom = new Error('start failed');
+    const { service, reaped, hardDeleted, cancelRequests } = harness({ startRunError: boom });
+    await assert.rejects(service.createEphemeralRun(VALID_INPUT), boom);
+    // startRun can throw AFTER the durable run row exists — the cancel request
+    // covers that orphan before the definition leaves listReapable via the reap.
+    assert.deepEqual(cancelRequests, [{ id: 'wf-1', by: 'agent:facilitator-1' }]);
+    assert.deepEqual(reaped, ['wf-1']);
+    assert.deepEqual(hardDeleted, ['wf-1']);
+  });
+});

--- a/middleware/test/conductorEphemeralSlugGuard.test.ts
+++ b/middleware/test/conductorEphemeralSlugGuard.test.ts
@@ -1,0 +1,121 @@
+import { after, describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import express from 'express';
+import type { Express } from 'express';
+
+import { createConductorRouter } from '../src/conductor/routes.js';
+import type { ConductorRouterDeps } from '../src/conductor/routes.js';
+
+// #330 — the 'eph-' slug prefix is the ephemeral namespace: the manual create
+// route AND the template-instantiate route must reject it before touching any
+// store, so a user-authored workflow can never collide with the reaper's
+// lifecycle. Same in-process express harness as conductorTemplateRoutes.test.ts.
+
+const servers: Server[] = [];
+
+async function startApp(): Promise<{ baseUrl: string; publishCalls: number[] }> {
+  const publishCalls: number[] = [];
+  const deps = {
+    workflowStore: {
+      createOrPublish: async () => {
+        publishCalls.push(1);
+        throw new Error('unexpected publish in slug-guard test');
+      },
+    },
+    runStore: {},
+    awaitStore: {},
+    roleStore: {},
+    scheduleStore: {},
+    executor: {},
+    eventRouter: {},
+    templateKnownRefs: async () => ({ agentIds: [], actionIds: [], roleKeys: [], eventIds: [] }),
+  } as unknown as ConductorRouterDeps;
+
+  const app: Express = express();
+  app.use(express.json());
+  app.use('/api/v1/operator/conductors', createConductorRouter(deps));
+  const server: Server = await new Promise((resolve) => {
+    const s = app.listen(0, '127.0.0.1', () => resolve(s));
+  });
+  servers.push(server);
+  const port = (server.address() as AddressInfo).port;
+  return { baseUrl: `http://127.0.0.1:${String(port)}/api/v1/operator/conductors`, publishCalls };
+}
+
+after(async () => {
+  await Promise.all(servers.map((s) => new Promise<void>((resolve) => s.close(() => resolve()))));
+});
+
+const JSON_HEADERS = { 'content-type': 'application/json' };
+
+describe("reserved 'eph-' slug prefix (#330)", () => {
+  it("POST / rejects an 'eph-' slug before any store access", async () => {
+    const { baseUrl, publishCalls } = await startApp();
+    const res = await fetch(baseUrl, {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ slug: 'eph-sneaky', name: 'Sneaky', graph: {} }),
+    });
+    const body = (await res.json()) as { code?: string };
+
+    assert.equal(res.status, 400);
+    assert.equal(body.code, 'conductor.reserved_slug_prefix');
+    assert.equal(publishCalls.length, 0);
+  });
+
+  it('POST / still validates ordinary slugs normally (guard is prefix-scoped)', async () => {
+    const { baseUrl } = await startApp();
+    const res = await fetch(baseUrl, {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ slug: 'ordinary', name: 'Ordinary', graph: {} }),
+    });
+    const body = (await res.json()) as { code?: string };
+
+    assert.equal(res.status, 400);
+    assert.equal(body.code, 'conductor.invalid_graph'); // past the guard, into validate()
+  });
+
+  it("POST /:slug/status rejects 'eph-' workflows — the reaper owns their lifecycle", async () => {
+    const { baseUrl } = await startApp();
+    const res = await fetch(`${baseUrl}/eph-demo-1/status`, {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ status: 'enabled' }),
+    });
+    const body = (await res.json()) as { code?: string };
+
+    assert.equal(res.status, 400);
+    assert.equal(body.code, 'conductor.reserved_slug_prefix');
+  });
+
+  it("POST /:slug/runs rejects manual runs on 'eph-' workflows", async () => {
+    const { baseUrl } = await startApp();
+    const res = await fetch(`${baseUrl}/eph-demo-1/runs`, {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ payload: {} }),
+    });
+    const body = (await res.json()) as { code?: string };
+
+    assert.equal(res.status, 400);
+    assert.equal(body.code, 'conductor.reserved_slug_prefix');
+  });
+
+  it("POST /templates/:id/instantiate rejects an 'eph-' slug before template resolution", async () => {
+    const { baseUrl, publishCalls } = await startApp();
+    const res = await fetch(`${baseUrl}/templates/anything/instantiate`, {
+      method: 'POST',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ slug: 'eph-sneaky' }),
+    });
+    const body = (await res.json()) as { code?: string };
+
+    assert.equal(res.status, 400);
+    assert.equal(body.code, 'conductor.reserved_slug_prefix');
+    assert.equal(publishCalls.length, 0);
+  });
+});

--- a/middleware/test/conductorEphemeralStore.test.ts
+++ b/middleware/test/conductorEphemeralStore.test.ts
@@ -1,0 +1,111 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import type { Pool } from 'pg';
+
+import { ConductorEphemeralStore } from '../src/conductor/ephemeralStore.js';
+
+// #330 — fake-pool harness in the conductorWorkflowStore.test.ts style: pg
+// responses are scripted by SQL shape, and the assertions pin the predicates
+// that carry the semantics (origin filter, reaped_at guard, the NOT-EXISTS
+// delete guard, the idempotent cancel-request).
+
+interface IssuedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+function fakePool(respond: (sql: string) => { rows: unknown[]; rowCount?: number }): {
+  pool: Pool;
+  queries: IssuedQuery[];
+} {
+  const queries: IssuedQuery[] = [];
+  const pool = {
+    query: async (sql: string, params: unknown[] = []): Promise<{ rows: unknown[]; rowCount?: number }> => {
+      queries.push({ sql, params });
+      return respond(sql.replace(/\s+/g, ' ').trim());
+    },
+  } as unknown as Pool;
+  return { pool, queries };
+}
+
+function norm(q: IssuedQuery): string {
+  return q.sql.replace(/\s+/g, ' ').trim();
+}
+
+describe('ConductorEphemeralStore', () => {
+  it('counts active runs per agent over ephemeral workflows only', async () => {
+    const { pool, queries } = fakePool(() => ({ rows: [{ count: '2' }] }));
+    const n = await new ConductorEphemeralStore(pool).countActiveRunsByAgent('agent-1');
+
+    assert.equal(n, 2);
+    const sql = norm(queries[0]!);
+    assert.ok(sql.includes("w.origin = 'ephemeral'"));
+    assert.ok(sql.includes('w.created_by_agent = $1'));
+    assert.ok(sql.includes("r.status IN ('running', 'waiting')"));
+    assert.deepEqual(queries[0]!.params, ['agent-1']);
+  });
+
+  it('counts recent creates per agent since the cutoff', async () => {
+    const cutoff = new Date('2026-08-21T09:00:00.000Z');
+    const { pool, queries } = fakePool(() => ({ rows: [{ count: '7' }] }));
+    const n = await new ConductorEphemeralStore(pool).countRecentCreatesByAgent('agent-1', cutoff);
+
+    assert.equal(n, 7);
+    const sql = norm(queries[0]!);
+    assert.ok(sql.includes("origin = 'ephemeral'"));
+    assert.ok(sql.includes('created_at > $2'));
+    assert.deepEqual(queries[0]!.params, ['agent-1', cutoff]);
+  });
+
+  it('listReapable selects expired OR all-runs-terminal, never already-reaped rows', async () => {
+    const { pool, queries } = fakePool(() => ({
+      rows: [{ id: 'wf-1', slug: 'eph-x', expired: true }],
+    }));
+    const now = new Date('2026-08-21T10:00:00.000Z');
+    const rows = await new ConductorEphemeralStore(pool).listReapable(now);
+
+    assert.deepEqual(rows, [{ id: 'wf-1', slug: 'eph-x', expired: true }]);
+    const sql = norm(queries[0]!);
+    assert.ok(sql.includes('w.reaped_at IS NULL'));
+    assert.ok(sql.includes('w.expires_at <= $1'));
+    // Terminal branch: at least one run exists AND none is still active.
+    assert.ok(sql.includes('EXISTS'));
+    assert.ok(sql.includes('NOT EXISTS'));
+    assert.deepEqual(queries[0]!.params, [now]);
+  });
+
+  it('requestCancelActiveRuns only touches active runs without an existing request', async () => {
+    const { pool, queries } = fakePool(() => ({ rows: [], rowCount: 2 }));
+    const n = await new ConductorEphemeralStore(pool).requestCancelActiveRuns('wf-1', 'reaper');
+
+    assert.equal(n, 2);
+    const sql = norm(queries[0]!);
+    assert.ok(sql.startsWith('UPDATE conductor_runs'));
+    assert.ok(sql.includes("status IN ('running', 'waiting')"));
+    assert.ok(sql.includes('cancel_requested_at IS NULL'));
+    assert.deepEqual(queries[0]!.params, ['wf-1', 'reaper']);
+  });
+
+  it('markReaped disables + stamps exactly once (idempotent WHERE)', async () => {
+    const { pool, queries } = fakePool(() => ({ rows: [] }));
+    await new ConductorEphemeralStore(pool).markReaped('wf-1');
+
+    const sql = norm(queries[0]!);
+    assert.ok(sql.includes("SET status = 'disabled', reaped_at = now()"));
+    assert.ok(sql.includes("origin = 'ephemeral'"));
+    assert.ok(sql.includes('reaped_at IS NULL'));
+  });
+
+  it('hardDeleteUnreferenced deletes only when no run references the workflow', async () => {
+    const { pool, queries } = fakePool(() => ({ rows: [], rowCount: 0 }));
+    const deleted = await new ConductorEphemeralStore(pool).hardDeleteUnreferenced('wf-1');
+
+    assert.equal(deleted, false);
+    const sql = norm(queries[0]!);
+    assert.ok(sql.startsWith('DELETE FROM conductor_workflows'));
+    assert.ok(sql.includes("w.origin = 'ephemeral'"));
+    assert.ok(sql.includes('NOT EXISTS'));
+    assert.ok(sql.includes('conductor_runs'));
+  });
+});

--- a/middleware/test/conductorPatternCatalog.test.ts
+++ b/middleware/test/conductorPatternCatalog.test.ts
@@ -1,0 +1,77 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { checkTemplateManifest } from '@omadia/conductor-core';
+
+import { loadPatternCatalog } from '../src/conductor/patternCatalog.js';
+
+// #330 — the shipped patterns/ dir is the curated allowlist behind
+// createEphemeralRun. This test is the CI gate that the bundle is complete and
+// valid (same contract as conductorTemplateCatalog.test.ts for templates/).
+
+describe('bundled pattern catalog', () => {
+  it('ships a valid facilitation pattern (id, slots, checkTemplateManifest)', () => {
+    const catalog = loadPatternCatalog({ log: (m) => assert.fail(`unexpected loader warning: ${m}`) });
+    const facilitation = catalog.get('facilitation');
+
+    assert.ok(facilitation, 'patterns/facilitation.json must load');
+    const result = checkTemplateManifest(facilitation);
+    assert.deepEqual(result.errors, []);
+    // The Facilitator (Workstream C) fills exactly these slots.
+    assert.deepEqual(
+      {
+        agents: facilitation.slots.agents?.map((s) => s.key),
+        roles: facilitation.slots.roles?.map((s) => s.key),
+        channels: facilitation.slots.channels?.map((s) => s.key),
+      },
+      { agents: ['facilitator'], roles: ['initiator'], channels: ['report'] },
+    );
+  });
+
+  it('every bundled pattern passes the manifest gate', () => {
+    const catalog = loadPatternCatalog({ log: () => undefined });
+    const patterns = catalog.list();
+    assert.ok(patterns.length >= 1);
+    for (const pattern of patterns) {
+      const result = checkTemplateManifest(pattern);
+      assert.deepEqual(result.errors, [], `pattern '${pattern.id}' must be valid`);
+    }
+  });
+});
+
+describe('loadPatternCatalog resilience', () => {
+  it('skips an invalid file with a log line instead of throwing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'patterns-'));
+    writeFileSync(join(dir, 'broken.json'), '{ not json');
+    writeFileSync(join(dir, 'empty.json'), JSON.stringify({ id: 'empty' }));
+
+    const logs: string[] = [];
+    const catalog = loadPatternCatalog({ dir, log: (m) => logs.push(m) });
+
+    assert.deepEqual(catalog.list(), []);
+    assert.equal(logs.filter((l) => l.includes('invalid')).length, 2);
+  });
+
+  it('keeps the first file on a duplicate id and logs the collision', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'patterns-'));
+    const manifest = {
+      id: 'dup',
+      name: { en: 'Dup' },
+      description: { en: 'Dup' },
+      defaultSlug: 'dup',
+      graph: { entryStepId: 's', steps: [{ id: 's', kind: 'agent', agentId: 'slot:agent:a', prompt: 'p' }], transitions: [] },
+      slots: { agents: [{ key: 'a', label: { en: 'A' } }] },
+    };
+    writeFileSync(join(dir, 'a-first.json'), JSON.stringify({ ...manifest, defaultSlug: 'first' }));
+    writeFileSync(join(dir, 'b-second.json'), JSON.stringify({ ...manifest, defaultSlug: 'second' }));
+
+    const logs: string[] = [];
+    const catalog = loadPatternCatalog({ dir, log: (m) => logs.push(m) });
+
+    assert.equal(catalog.get('dup')?.defaultSlug, 'first');
+    assert.ok(logs.some((l) => l.includes("duplicates id 'dup'")));
+  });
+});

--- a/middleware/test/conductorWorkflowStore.test.ts
+++ b/middleware/test/conductorWorkflowStore.test.ts
@@ -86,4 +86,40 @@ describe('ConductorWorkflowStore.createOrPublish expectNew', () => {
     assert.ok(!insert?.includes('DO NOTHING'), insert);
     assert.ok(sqlOf(queries).includes('COMMIT'));
   });
+
+  // #330 — ephemeral provenance flows through the same INSERT; absent input
+  // defaults to the manual namespace so every pre-#330 caller is unchanged.
+  it('persists origin/expiresAt/createdByAgent on create and defaults them to manual', async () => {
+    const expiresAt = new Date('2026-08-22T10:00:00.000Z');
+    const { pool, queries } = fakePool({ slugTaken: false });
+    await new ConductorWorkflowStore(pool).createOrPublish({
+      slug: 'eph-demo-1', name: 'Demo', graph: GRAPH, expectNew: true,
+      origin: 'ephemeral', expiresAt, createdByAgent: 'agent-1',
+    });
+    const insert = queries.find((q) => q.sql.replace(/\s+/g, ' ').trim().startsWith('INSERT INTO conductor_workflows '));
+    assert.deepEqual(insert?.params.slice(4), ['ephemeral', expiresAt, 'agent-1']);
+
+    const plain = fakePool({ slugTaken: false });
+    await new ConductorWorkflowStore(plain.pool).createOrPublish({ slug: 'plain', name: 'Plain', graph: GRAPH });
+    const plainInsert = plain.queries.find((q) => q.sql.replace(/\s+/g, ' ').trim().startsWith('INSERT INTO conductor_workflows '));
+    assert.deepEqual(plainInsert?.params.slice(4), ['manual', null, null]);
+  });
+});
+
+// #330 — the library list is the user-authored surface: the manual-origin
+// filter lives in the store so every list consumer is clutter-free at once.
+describe('ConductorWorkflowStore.list', () => {
+  it("emits the origin = 'manual' filter", async () => {
+    const issued: string[] = [];
+    const pool = {
+      query: async (sql: string): Promise<{ rows: unknown[] }> => {
+        issued.push(sql.replace(/\s+/g, ' ').trim());
+        return { rows: [] };
+      },
+    } as unknown as Pool;
+
+    await new ConductorWorkflowStore(pool).list();
+    assert.equal(issued.length, 1);
+    assert.ok(issued[0]!.includes("WHERE origin = 'manual'"), issued[0]);
+  });
 });

--- a/middleware/test/conductorWorkflowStore.test.ts
+++ b/middleware/test/conductorWorkflowStore.test.ts
@@ -120,6 +120,6 @@ describe('ConductorWorkflowStore.list', () => {
 
     await new ConductorWorkflowStore(pool).list();
     assert.equal(issued.length, 1);
-    assert.ok(issued[0]!.includes("WHERE origin = 'manual'"), issued[0]);
+    assert.ok(issued[0]!.includes("WHERE origin = 'manual'"));
   });
 });


### PR DESCRIPTION
## Summary

Workstream A of the **omadia Facilitator** epic (#330): agent-generated JIT workflows as **governed instances of curated patterns** — generative, validated, self-disposing.

- **`origin: manual | ephemeral`** on `conductor_workflows` (migration `0009_ephemeral_workflows.sql`: `expires_at`, `created_by_agent`, `reaped_at`, CHECK constraints, partial reap index). Written double-run-idempotent per the 0008 pattern — note: the schema CI gate does **not** yet re-apply `src/conductor/migrations` (listed as "still uncovered" in ci.yml), so idempotence is by-construction, not CI-proven.
- **Reserved `eph-` slug namespace**: `POST /`, template instantiate, `POST /:slug/status` and `POST /:slug/runs` reject it (`conductor.reserved_slug_prefix`) — the reaper owns the ephemeral lifecycle, no operator zombie-revival. `workflowStore.list()` filters to `manual`, so the workflow library **and** the event router never see ephemeral workflows (run-scoped, not event-triggerable).
- **Kernel service `conductorEphemeralRuns`** — `createEphemeralRun({ agentId, patternId, slots, payload, ttlMs })`: slot-fills a curated pattern from the new bundled `src/conductor/patterns/` catalog via the existing template machinery (agents can never submit arbitrary graphs), publishes with `origin='ephemeral'` + `expectNew`, starts via the previously call-site-less `triggerKind: 'agent'`. **Deny-by-default**: no `pluginServiceGrants` catalog entry in this PR — the Facilitator plugin (Workstream C) declares it; until then no plugin can reach the service.
- **Guardrails** (env-tunable `CONDUCTOR_EPHEMERAL_*`): mandatory clamped TTL (default 24h, max 7d), 3 concurrent runs + 10 creates/hour per agent (check-then-act by design — anti-runaway guardrails, not billing invariants).
- **Disposal — discard the scaffold, never the minutes**: terminal-state hook in `notifyRunEnded` + TTL reaper (scheduleWorker discipline) disable + stamp `reaped_at`; expired active runs get the #759 cancel request; physical DELETE only for definitions no run references (NOT-EXISTS guard; the runs→versions FK blocks it anyway). Run history + version graph are retained as audit trace.
- First bundled pattern: **`facilitation`** (moderate → initiator confirmation, 24h deadline → report / abort-report), en+de localized — the Conductor substrate for the Facilitator.

## Test plan

- [x] `npm run typecheck` + `npm run lint` green
- [x] Full suite: **7042 tests, 0 fail** (16 pre-existing skips)
- [x] New/extended suites (isolated + full-suite green): `conductorEphemeralRunService` (quota/rate deny, TTL clamp, slot validation, create+start contract, start-failure cancel+reap), `conductorEphemeralReaper` (expired→cancel+soft-reap, terminal→reap with retained history, per-row error isolation), `conductorEphemeralStore` (SQL predicate pins: origin filter, reaped_at guard, NOT-EXISTS delete guard, idempotent cancel), `conductorPatternCatalog` (bundled facilitation pattern passes the manifest gate; loader resilience), `conductorEphemeralSlugGuard` (all four route guards), `conductorWorkflowStore` (manual-origin list filter, provenance columns + manual defaults)
- [ ] Live check post-merge: create an ephemeral run via the service seam and watch reap-on-terminal in the operator run list

Reviewed by omadia-reviewer; all findings addressed (operator mutation guards, start-failure orphan cancel, NO-ACTION comment precision, handoff doc §3/§10 + CHANGELOG).

Part of #330 — next slices: Workstream B1 (channel-SDK group primitives), B2 (Teams adapter, plugin repo), C (Facilitator plugin, new repo).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789888369&installation_model_id=428086&pr_number=818&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F818&signature=b7273668c3865ea2e3e47882633f5f6978e004581c76e15584825313cc1de603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->