### PR TITLE
test(#754): pin the missing no-holder-fallback regression + comment cleanup

### DIFF
--- a/middleware/src/conductor/roleStore.ts
+++ b/middleware/src/conductor/roleStore.ts
@@ -18,8 +18,14 @@ interface RoleRow {
 /**
  * Roles + assignments (the "baton"). The default RoleResolver: a role's current holders are the
  * assignment rows that are still open (valid_to null or future). `resolve()` is late-bound — call
- * it at dispatch and on every reminder so a moved baton routes to the current holder (FR-022). An
- * integration could register an external resolver in front of this; that seam is a follow-up.
+ * it at dispatch and on every reminder so a moved baton routes to the current holder (FR-022).
+ *
+ * #754 — the external-resolver seam is filled: this store is registered as the
+ * `'conductor-local'` `RoleHolderSource` (see `roleHolderResolver.ts`) alongside whatever
+ * external sources (Entra, an Odoo HR org chart) the operator activates. Conductor's executor
+ * and workers resolve role → holders through the `RoleHolderRegistry`, never through this
+ * class's `resolve()` directly — that union carries the `partial`/`unavailable` discipline this
+ * store's own `string[]` return type cannot express.
  */
 export class ConductorRoleStore {
   constructor(private readonly pool: Pool) {}

--- a/middleware/test/conductorQuorumAndTimeout.test.ts
+++ b/middleware/test/conductorQuorumAndTimeout.test.ts
@@ -150,3 +150,89 @@ describe('ConductorRunExecutor.resolveAwait quorum=all', () => {
     assert.equal(closed, true);
   });
 });
+
+// #754 — the other fail-OPEN path `roleHolderSource.ts` documents: "role has no holder →
+// take the fallback" may only fire on a RESOLVED empty list. On `unavailable` an empty list
+// means "we could not ask", and taking the fallback would skip the human step entirely —
+// exactly the outage-shaped bypass this regression pins down (openHumanAwait, runExecutor.ts).
+describe('ConductorRunExecutor.startRun — no-holder fallback fires on resolved-empty only (#754)', () => {
+  // Single human role step, no fallbackTransitionId → "no holder" records the step 'failed'
+  // with actor.noHolder=true instead of parking; a partial+empty lookup must park instead of
+  // reaching that record at all. Which of the two store calls fires is the assertion — not the
+  // run's final status, which this minimal fake doesn't attempt to model faithfully.
+  const graph = {
+    entryStepId: 'h1',
+    steps: [{ id: 'h1', kind: 'human', human: { principal: { kind: 'role', ref: 'approvers' }, channel: 'teams', message: 'ok?' } }],
+    transitions: [],
+  };
+
+  function makeExecutor(lookup: { holders: string[]; partial: boolean }) {
+    const recorded: Array<{ actor: unknown; status: string }> = [];
+    let parkCount = 0;
+    let awaitCreateCount = 0;
+    const run = {
+      id: 'run1', workflowVersionId: 'v1', status: 'running', currentStepId: 'h1', context: {},
+      triggerKind: 'manual', triggerSource: null, isDryRun: false, startedAt: new Date(0), endedAt: null,
+    };
+    const workflowStore = {
+      async getBySlug() { return { id: 'w1', slug: 'wf', status: 'published', activeVersionId: 'v1' }; },
+      async getVersion() { return { id: 'v1', workflowId: 'w1', version: 1, graph }; },
+    };
+    const runStore = {
+      async create() { return run; },
+      async get() { return run; },
+      async acquireLease() {},
+      async stepsForRun() { return []; },
+      async isCancelRequested() { return false; },
+      async park() { parkCount += 1; },
+      async recordStepAndAdvance(input: { actor: unknown; status: string }) {
+        recorded.push({ actor: input.actor, status: input.status });
+      },
+    };
+    const awaitStore = {
+      async create() { awaitCreateCount += 1; },
+    };
+    const executor = new ConductorRunExecutor({
+      workflowStore: workflowStore as never,
+      runStore: runStore as never,
+      awaitStore: awaitStore as never,
+      effects: {
+        async runAgentStep() { throw new Error('effects must not run in these tests'); },
+        async runActionStep() { throw new Error('effects must not run in these tests'); },
+      } as never,
+      // #754 — the resolver Conductor is required to consult: an AggregateHolderLookup, not a
+      // bare list, so `openHumanAwait` can distinguish "genuinely resolved, nobody holds this
+      // role" from "a source could not answer, so we don't actually know".
+      resolveRoleHolders: async () => ({
+        holders: lookup.holders,
+        partial: lookup.partial,
+        bySource: lookup.partial
+          ? [{ sourceId: 'entra', lookup: { outcome: 'unavailable' as const, code: 'source_error' as const, message: 'down' } }]
+          : [],
+      }),
+    });
+    return { executor, recorded, getParkCount: () => parkCount, getAwaitCreateCount: () => awaitCreateCount };
+  }
+
+  it('a RESOLVED empty holder list ("nobody holds this role") takes the fallback — never parks', async () => {
+    const { executor, recorded, getParkCount, getAwaitCreateCount } = makeExecutor({ holders: [], partial: false });
+    await executor.startRun({ slug: 'wf', payload: {}, awaitCompletion: true });
+    assert.equal(getAwaitCreateCount(), 0, 'a resolved-empty role must never open an await for holders that do not exist');
+    assert.equal(getParkCount(), 0);
+    assert.equal(recorded.length, 1, 'the no-holder fallback path must record exactly one step');
+    assert.deepEqual(recorded[0]!.actor, { kind: 'human', noHolder: true });
+    assert.equal(recorded[0]!.status, 'failed'); // no fallbackTransitionId on this step
+  });
+
+  it('an UNAVAILABLE (partial) holder lookup does NOT take the fallback — it parks instead', async () => {
+    const { executor, recorded, getParkCount, getAwaitCreateCount } = makeExecutor({ holders: [], partial: true });
+    await executor.startRun({ slug: 'wf', payload: {}, awaitCompletion: true });
+    assert.equal(
+      recorded.length,
+      0,
+      'an unreachable holder source must never be mistaken for "no holders" and skip the human step',
+    );
+    assert.equal(getAwaitCreateCount(), 1, 'must park waiting for the real holders once the source recovers');
+    assert.equal(getParkCount(), 1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #754. The scope was almost entirely already delivered by #333 Phase 3 (PR #726) — this PR
finds and fills the one gap: the second mandatory regression test the issue calls out, plus a
stale comment.

## What #726 already shipped (verified, not re-designed)

- `middleware/packages/harness-channel-sdk/src/roleHolderSource.ts` — `RoleHolderSource`,
  `RoleHolderRegistry`, `AggregateHolderLookup` with the `resolved | unavailable` + `partial`
  discipline the issue requires (never a bare `string[]`).
- `middleware/src/conductor/roleHolderResolver.ts` — wires `ConductorRoleStore` in as the
  `'conductor-local'` source, `buildRoleHolderRegistry()`, and `holdersOnly()` for the
  call sites that may legitimately degrade (operator inbox, reminder nudger).
- `middleware/src/conductor/index.ts` — already builds the registry
  (`buildRoleHolderRegistry(roleStore, deps.roleHolderSources ?? [])`) and threads it into both
  `RunExecutor` (`resolveRoleHolders`) and the await worker (`holdersOnly(...)`).
- `middleware/src/conductor/runExecutor.ts`:
  - `resolveAwait`'s `quorum='all'` completeness check already refuses to close on a partial
    holder list, even if every currently-known holder responded.
  - `openHumanAwait`'s "role has no holder → take the fallback" already only fires on a
    **resolved**-empty lookup; a partial-empty lookup parks instead (the run reaches the same
    fallback later via its deadline, but only after the real holders had a chance to answer).

I verified this by reading `roleHolderResolver.ts`/`runExecutor.ts` end to end before touching
anything — the "check whether wiring is the entire remaining scope" the issue asks for. It is.

## What was missing

Of the issue's two mandatory regression tests:

1. `quorum='all'` non-completion on `partial`/`unavailable` — **already existed**
   (`conductorQuorumAndTimeout.test.ts:127`, from #726), with a same-inputs `partial:false`
   control right below it.
2. "no holder → fallback" firing **only** on `resolved`-empty, never on `unavailable` — **had no
   test**. `openHumanAwait`'s fail-closed branch was implemented but unexercised.

Added the missing pair in `middleware/test/conductorQuorumAndTimeout.test.ts` (new describe
block, same minimal-fake-harness pattern as the existing quorum tests, driven through the public
`ConductorRunExecutor.startRun`):

- a RESOLVED empty holder list takes the fallback path — records the step `'failed'` with
  `actor: { kind: 'human', noHolder: true }`, opens **zero** awaits.
- an UNAVAILABLE (partial) holder lookup does **not** take the fallback — it parks (opens an
  await, calls `runStore.park`) exactly as if a real, not-yet-answered holder existed.

Also updated the `roleStore.ts:22` comment (issue requirement #5): it still described the
external-resolver seam as future work after #726 had already filled it.

## Blast radius

- `middleware/src/conductor/roleStore.ts` — comment-only change (no behavior change).
- `middleware/test/conductorQuorumAndTimeout.test.ts` — additive; no existing test modified.
- No production code paths changed. No migration needed — no schema change.
- Untouched (per scope guardrails): `credentials/` namespaces, `src/index.ts`.

## Test + mutation evidence

- `npx tsx --test test/conductorQuorumAndTimeout.test.ts` — 9/9 pass (4 suites).
- `npx tsx --test test/conductor*.ts` (full conductor suite) — 229/229 pass (58 suites).
- `npx tsx --test test/roleHolderSource.test.ts test/roleSource.test.ts
  test/conductorCancelAndStrictApproval.test.ts test/conductorReminders.test.ts
  test/conductorRunExecutorNotifyRunEnded.test.ts` — 59/59 pass.
- `npm run build` — clean.
- `npm run typecheck:test` — ratchet unchanged (371 known errors, baseline 371, no regressions).
- **Mutation check**: reverted each fail-closed guard in `runExecutor.ts` one at a time against a
  clean rebuild —
  - removing the `partial` branch in `openHumanAwait` → new test #2 (unavailable → no fallback)
    goes red.
  - dropping the `!holdersPartial` conjunct from the `quorum='all'` completeness check → the
    pre-existing #726 test goes red.
  Restored both, rebuilt, reran — clean diff, 9/9 green again.

## Open questions

None — the scope really was "wiring is already the entire remaining work," confirmed before
writing anything new, per the issue's own instruction.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789890281&installation_model_id=428086&pr_number=819&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F819&signature=f10d2792fbc62b8f5eed66dc8808226132b8efe197c606de230f4215e10461c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->