### PR TITLE
feat: channel-SDK group-conversation primitives + principal-addressed targeted delivery (#330 Workstream B1)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,13 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — group-conversation primitives in the channel SDK + Principal-addressed targeted delivery (#330 Workstream B1)
+
+- Channel SDK (strictly additive; Teams 0.12.7 / Telegram 0.2.0 run unchanged): `IncomingTurn.conversationType` (`'direct' | 'group'`, absent = unknown → treated as direct via the new `isGroupConversation`), a `ConversationRoster` contract with `partial` lower-bound semantics, typed `ConversationMembershipEvent`s (`bot_added` incl. WHO invited the agent, `members_added`/`members_removed`), and a `TargetedSendProvider` that only ever delivers to ONE already-resolved user.
+- Three new optional `CoreApi` methods in the `registerWebSocket` feature-detect mould: `registerRosterProvider`, `registerTargetedSendProvider`, `emitConversationEvent` — defined only when the kernel wired the matching registry; channel deactivation drops the channel's contributions.
+- Kernel: per-channel roster + targeted-send registries, a conversation-event hub with per-subscriber isolation, and a `targetedSend` kernel service (deny-by-default) that resolves Principals — `user:<id>` → one delivery, `role:<key>` → late-bound fan-out to ALL current holders (notification semantics, one delivery per holder, no quorum). Empty roles, partial holder lists and unreachable holders are named diagnostics, never silent drops; on the no-Postgres path role sends degrade to `role_resolution_unavailable` while user sends keep working.
+- `@omadia/plugin-api` 1.7.0 (additive MINOR, snapshot updated): `TARGETED_SEND_SERVICE_NAME` + request/result shapes so an agent plugin (the #330 Facilitator) can send reports without depending on the channel SDK.
+
 ### Added — pattern-based ephemeral Conductor workflows with TTL reaper (#330 Workstream A)
 
 - Workflows now carry an `origin` (`manual` | `ephemeral`, migration `0009_ephemeral_workflows.sql`): agent-generated JIT workflows live in the reserved `eph-` slug namespace, never appear in the workflow library (`list()` filters to `manual`), and the create/instantiate routes reject the reserved prefix (`conductor.reserved_slug_prefix`).

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -1224,6 +1224,42 @@ Agent. Tests: `test/conductorEphemeral*.test.ts`,
 "still uncovered") — 0009 ist nach 0008-Muster idempotent geschrieben, aber
 CI-unbewiesen.
 
+### Group-Conversation-Primitives im Channel-SDK (#330 Workstream B1)
+
+Strikt additive SDK-Erweiterung (Teams 0.12.7 / Telegram 0.2.0 laufen
+unverändert): `IncomingTurn.conversationType` (`'direct'|'group'`, absent =
+unknown → wie direct behandelt, Helper `isGroupConversation`),
+`ConversationRoster` (+`partial`-Lower-Bound-Semantik wie
+`roleHolderSource.ts`), typisierte `ConversationMembershipEvent`s
+(`bot_added` inkl. `addedBy` — der Facilitator-Handshake-Trigger,
+`members_added`/`members_removed`) und `TargetedSendProvider` (liefert immer
+nur an EINEN bereits aufgelösten User).
+
+Drei neue **optionale** `CoreApi`-Methoden nach dem
+`registerWebSocket`-Feature-Detect-Muster: `registerRosterProvider`,
+`registerTargetedSendProvider`, `emitConversationEvent` — nur definiert, wenn
+der Kernel die jeweilige Registry verdrahtet hat
+(`src/channels/{rosterRegistry,targetedSendRegistry,conversationEventHub}.ts`);
+`channelRegistry.deactivate` räumt die Beiträge des Channels ab.
+
+**Principal-Auflösung ist Kernel-Sache** (`targetedDeliveryService.ts`,
+Service `targetedSend`, deny-by-default): `user:<id>` → 1 Delivery;
+`role:<key>` → late-bound Fan-out an ALLE aktuellen Holder (Notification, eine
+Delivery pro Holder, KEIN Quorum — anders als Decision-Awaits). Leere Rolle →
+`role_has_no_holders`, Partial-Liste → `role_resolution_partial` (Deliveries
+an bekannte Holder laufen trotzdem), unreachable Holder →
+per-Holder-Diagnostic; nie silent drop, nie Throw. Ohne Postgres degradieren
+role-Sends zu `role_resolution_unavailable`, user-Sends funktionieren.
+Rollen-Auflösung nutzt eine zweite `buildRoleHolderRegistry`-Instanz über
+`conductorWiring.roleStore` (TODO #330: Conductor exponiert seine Registry),
+Conversation-Refs kommen aus `conductorWiring.channelBindingStore.getMany`.
+
+`@omadia/plugin-api` **1.7.0**: `TARGETED_SEND_SERVICE_NAME` + Shapes
+(plugin-api-eigen, da Dependency-Richtung sdk→plugin-api) — Workstream C
+(Facilitator) konsumiert das. Tests: `test/conversationRoster.test.ts`,
+`test/conversationEventHub.test.ts`, `test/targetedDelivery.test.ts`,
+`test/coreApiOptionalCapabilities.test.ts`.
+
 ## 4. Migration Managed Agents → Lokal
 
 ### Warum migriert

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -268,6 +268,23 @@ explicit here so a deployment can reason about them:
        permission gate on POST/DELETE /roles/:key/holders (four-eyes or
        admin-only) — the audit trail alone stops being sufficient the moment
        non-admin operators exist. -->
+- **Role batons now also decide who RECEIVES targeted reports (#330 B3).**
+  The `targetedSend` kernel service resolves `role:<key>` addressees through
+  the SAME holder registry the executor uses for approvals (one instance,
+  exposed from `wireConductor` — "who may approve" and "who gets the report"
+  cannot drift). That widens the blast radius of the unaudited-but-logged
+  self-assignment above: assigning yourself a role means receiving every
+  report addressed to it. The compensating controls are the same baton audit
+  trail plus the delivery report itself (holders, `partial`, per-holder
+  outcomes are all named — no silent recipient). Principal resolution is
+  kernel-only by construction: channel plugins receive one already-resolved
+  user per delivery and can neither enumerate nor widen a role. The
+  `targetedSend` / `conversationRosters` / `conversationEvents` services are
+  deny-by-default like every kernel service, and `conversationEvents` is
+  published subscribe-only — emitting membership events (e.g. the
+  Facilitator's `bot_added` handshake trigger) stays a channel-adapter
+  privilege on the CoreApi, so a granted agent plugin cannot spoof an
+  invitation.
 
 ## 8. What lives in the vault
 

--- a/middleware/packages/harness-channel-sdk/src/conversationRoster.ts
+++ b/middleware/packages/harness-channel-sdk/src/conversationRoster.ts
@@ -1,0 +1,56 @@
+// Group-conversation primitives (#330 B1): conversation type + participant
+// roster, defined at the SDK contract level so ANY group-aware agent can use
+// them — Teams implements first, Telegram/Discord follow. Strictly additive:
+// a classic adapter that never touches any of this keeps working unchanged.
+
+import type { ChannelUserRef, IncomingTurn } from './incoming.js';
+
+export type ConversationType = 'direct' | 'group';
+
+/** One member of a conversation, as the channel knows it. Field names align
+ *  with the orchestrator's ChatParticipant deliberately WITHOUT importing it —
+ *  the SDK must not depend on the orchestrator package. */
+export interface ConversationParticipant {
+  userRef: ChannelUserRef;
+  /** True for bot/agent identities (including the agent's own). */
+  isBot?: boolean;
+  /** Channel-native stable id where it differs from userRef.id (e.g. AAD oid). */
+  externalId?: string | null;
+  /** e.g. the Entra userPrincipalName, when the channel can resolve it. */
+  userPrincipalName?: string | null;
+}
+
+/**
+ * A conversation's current membership. Same "absence is a type" discipline as
+ * roleHolderSource.ts: an empty `participants` with `partial: false` is a real
+ * answer ("nobody but you"), while `partial: true` means the source could not
+ * read the full roster — nothing may be concluded from an id's absence then.
+ */
+export interface ConversationRoster {
+  conversationType: ConversationType;
+  participants: readonly ConversationParticipant[];
+  /** The agent's own identity in this conversation, when the channel knows it. */
+  self?: ConversationParticipant;
+  partial: boolean;
+}
+
+/**
+ * Optional per-channel roster capability. A channel plugin registers one via
+ * `core.registerRosterProvider?.(channelId, provider)` (feature-detect — older
+ * kernels do not define the method). `getRoster` returns undefined for a
+ * conversation the channel cannot resolve; it must not throw for that case.
+ */
+export interface ConversationRosterProvider {
+  /** The `channel_bindings.channel_type` this provider serves (e.g. 'teams'). */
+  channelType: string;
+  getRoster(conversationId: string): Promise<ConversationRoster | undefined>;
+}
+
+/**
+ * Group-vs-direct in one place. `conversationType` is additive and optional on
+ * IncomingTurn: absent means "unknown" (a classic adapter) and consumers treat
+ * unknown as direct — no group semantics without a positive statement.
+ */
+export function isGroupConversation(turn: Pick<IncomingTurn, 'conversationType'>): boolean {
+  return turn.conversationType === 'group';
+}

--- a/middleware/packages/harness-channel-sdk/src/coreApi.ts
+++ b/middleware/packages/harness-channel-sdk/src/coreApi.ts
@@ -2,6 +2,9 @@ import type { RequestHandler, Router } from 'express';
 
 import type { IncomingTurn, ChannelUserRef, PlatformIdentity } from './incoming.js';
 import type { ChatStreamEvent } from './streamEvent.js';
+import type { ConversationRosterProvider } from './conversationRoster.js';
+import type { ConversationMembershipEvent } from './membershipEvent.js';
+import type { TargetedSendProvider } from './targetedSend.js';
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
@@ -121,4 +124,31 @@ export interface CoreApi {
     path: string,
     handler: ChannelSocketHandler,
   ): void;
+
+  /**
+   * Register the channel's participant-roster capability (#330 B1). Optional:
+   * present only when the kernel wired a roster registry into `createCoreApi`.
+   * Channels MUST feature-detect
+   * (`typeof core.registerRosterProvider === 'function'`) before using it.
+   * Same active-flag lifecycle as routes: the kernel drops the provider when
+   * the channel deactivates.
+   */
+  registerRosterProvider?(channelId: string, provider: ConversationRosterProvider): void;
+
+  /**
+   * Register the channel's targeted-send (DM one participant) capability
+   * (#330 B3). Optional — same feature-detect + deactivate lifecycle as
+   * {@link registerRosterProvider}. Principal→user resolution (incl. role
+   * fan-out) happens in the kernel; the provider only ever delivers to one
+   * already-resolved user.
+   */
+  registerTargetedSendProvider?(channelId: string, provider: TargetedSendProvider): void;
+
+  /**
+   * Emit a conversation-membership event (#330 B2): the agent was invited,
+   * members joined/left. Optional — feature-detect. Fire-and-forget from the
+   * adapter's perspective; the kernel fans it out to subscribers (e.g. a
+   * Facilitator waiting for its `bot_added` handshake trigger).
+   */
+  emitConversationEvent?(event: ConversationMembershipEvent): void;
 }

--- a/middleware/packages/harness-channel-sdk/src/incoming.ts
+++ b/middleware/packages/harness-channel-sdk/src/incoming.ts
@@ -30,6 +30,13 @@ export interface IncomingTurn {
   channelKey?: string;
   /** channel-native user ref */
   userRef: ChannelUserRef;
+  /**
+   * Whether this turn arrived in a group conversation or a 1:1 (#330 B1).
+   * Additive: classic adapters never set it; absent = unknown, and consumers
+   * treat unknown as 'direct' — no group semantics without a positive
+   * statement (see `isGroupConversation`).
+   */
+  conversationType?: 'direct' | 'group';
   /** user's message as plain text (mentions resolved, markup stripped) */
   text: string;
   attachments?: IncomingAttachment[];

--- a/middleware/packages/harness-channel-sdk/src/index.ts
+++ b/middleware/packages/harness-channel-sdk/src/index.ts
@@ -16,6 +16,30 @@ export type {
   ChannelSessionClaims,
 } from './coreApi.js';
 
+// #330 B1 — group-conversation primitives: conversation type + roster,
+// membership lifecycle events, and Principal-addressed targeted delivery.
+// All optional capabilities; classic adapters are untouched.
+export {
+  isGroupConversation,
+  type ConversationType,
+  type ConversationParticipant,
+  type ConversationRoster,
+  type ConversationRosterProvider,
+} from './conversationRoster.js';
+export type {
+  BotAddedEvent,
+  ConversationMembershipEvent,
+  MembersAddedEvent,
+  MembersRemovedEvent,
+} from './membershipEvent.js';
+export type {
+  TargetedDeliveryOutcome,
+  TargetedMessage,
+  TargetedSendDiagnostic,
+  TargetedSendProvider,
+  TargetedSendReport,
+} from './targetedSend.js';
+
 // Orchestrator access — the typed, blessed way for a channel to resolve the
 // ChatAgent it drives turns with (alternative to CoreApi.handleTurnStream when
 // a folded SemanticAnswer / richer control is wanted).

--- a/middleware/packages/harness-channel-sdk/src/membershipEvent.ts
+++ b/middleware/packages/harness-channel-sdk/src/membershipEvent.ts
@@ -1,0 +1,41 @@
+// Conversation-membership lifecycle events (#330 B2 seam, shipped with B1):
+// "the agent was invited / members changed", emitted by a channel adapter via
+// `core.emitConversationEvent?.(event)`. The Facilitator uses `bot_added` (and
+// WHO added it) as its explicit, announced entry into a group — nobody is
+// moderated covertly.
+
+import type { ChannelUserRef } from './incoming.js';
+import type { ConversationType } from './conversationRoster.js';
+
+interface ConversationEventBase {
+  /** The emitting channel plugin's catalog id (e.g. 'de.byte5.channel.teams'). */
+  channelId: string;
+  /** The `channel_bindings.channel_type` selector, when the adapter knows it. */
+  channelType?: string;
+  conversationId: string;
+  conversationType?: ConversationType;
+  /** The members this event is about (added or removed, per kind). */
+  members: readonly ChannelUserRef[];
+  /** ISO 8601 timestamp of the platform event. */
+  occurredAt: string;
+  /** The original platform event, opaque to the kernel. */
+  rawEvent?: unknown;
+}
+
+/** The agent itself was added to the conversation. `addedBy` is best-effort:
+ *  Teams carries it in `conversationUpdate`; channels that cannot resolve the
+ *  inviter simply omit it. */
+export interface BotAddedEvent extends ConversationEventBase {
+  kind: 'bot_added';
+  addedBy?: ChannelUserRef;
+}
+
+export interface MembersAddedEvent extends ConversationEventBase {
+  kind: 'members_added';
+}
+
+export interface MembersRemovedEvent extends ConversationEventBase {
+  kind: 'members_removed';
+}
+
+export type ConversationMembershipEvent = BotAddedEvent | MembersAddedEvent | MembersRemovedEvent;

--- a/middleware/packages/harness-channel-sdk/src/targetedSend.ts
+++ b/middleware/packages/harness-channel-sdk/src/targetedSend.ts
@@ -1,0 +1,78 @@
+// Targeted delivery (#330 B3): post to ONE participant (a DM) distinct from
+// posting to the group, addressed by Principal ('user:<id>' | 'role:<key>').
+// The kernel resolves the principal — a role fans out to ALL current holders
+// at send time (notification semantics: one delivery per holder, no quorum,
+// late-bound membership) — and hands the channel plugin exactly ONE resolved
+// user per delivery. Role→holder resolution stays a kernel invariant (the
+// holder-source union is security-critical, see roleHolderSource.ts); channel
+// plugins never resolve principals themselves.
+
+import type { ChannelUserRef } from './incoming.js';
+import type { OutgoingAttachment } from './outgoing.js';
+import type { Principal } from './principal.js';
+
+/** Deliberately narrower than SemanticAnswer: a targeted message is a report /
+ *  status ping, not a full conversational reply. */
+export interface TargetedMessage {
+  text: string;
+  attachments?: OutgoingAttachment[];
+}
+
+/** Per-delivery outcome. Providers RETURN unreachability (like holdersFor in
+ *  roleHolderSource.ts) — they never throw for it, so one unreachable holder
+ *  cannot abort the remaining fan-out deliveries. */
+export type TargetedDeliveryOutcome =
+  | { outcome: 'delivered' }
+  | {
+      outcome: 'unreachable';
+      code: 'no_binding' | 'user_not_found' | 'channel_error' | 'not_permitted';
+      message: string;
+    };
+
+/**
+ * Optional per-channel delivery capability. A channel plugin registers one via
+ * `core.registerTargetedSendProvider?.(channelId, provider)` (feature-detect).
+ * `target.principalId` is the canonical user id; `conversationRef` is the
+ * kernel-cached per-user conversation reference when one exists (Teams:
+ * channel_bindings row) — a provider that can materialize a 1:1 conversation
+ * itself (proactive messaging) may ignore it.
+ */
+export interface TargetedSendProvider {
+  /** The `channel_bindings.channel_type` this provider serves (e.g. 'teams'). */
+  channelType: string;
+  sendToUser(
+    target: { principalId: string; conversationRef?: unknown; userRef?: ChannelUserRef },
+    message: TargetedMessage,
+  ): Promise<TargetedDeliveryOutcome>;
+}
+
+/** Why a send produced fewer deliveries than the caller may expect. Never a
+ *  silent drop: every non-delivery is named. */
+export interface TargetedSendDiagnostic {
+  code:
+    | 'invalid_principal'
+    | 'no_targeted_send_provider'
+    | 'role_resolution_unavailable'
+    | 'role_has_no_holders'
+    | 'role_resolution_partial'
+    | 'holder_unreachable';
+  message: string;
+  /** The holder a per-holder diagnostic is about. */
+  principalId?: string;
+}
+
+/**
+ * The full, honest result of one targeted send. `resolution.partial` mirrors
+ * AggregateHolderLookup: the holder list was a lower bound, so "delivered to
+ * everyone listed" must NOT be read as "delivered to every holder".
+ */
+export interface TargetedSendReport {
+  /** Absent when the input was not a parseable principal (see the
+   *  'invalid_principal' diagnostic) — never a fabricated empty user. */
+  principal?: Principal;
+  resolution:
+    | { kind: 'single-user' }
+    | { kind: 'role'; holders: readonly string[]; partial: boolean };
+  deliveries: readonly { principalId: string; outcome: TargetedDeliveryOutcome }[];
+  diagnostics: readonly TargetedSendDiagnostic[];
+}

--- a/middleware/packages/plugin-api/api-snapshot/plugin-api.d.ts.snap
+++ b/middleware/packages/plugin-api/api-snapshot/plugin-api.d.ts.snap
@@ -390,6 +390,7 @@ export * from './bulkInconsistency.js';
 export * from './mergeCandidate.js';
 export * from './topic.js';
 export * from './excerptMerge.js';
+export * from './targetedSend.js';
 
 // ===== knowledgeGraph.d.ts =====
 import type { EntityRef } from './entityRef.js';
@@ -2329,6 +2330,45 @@ kind: 'rect' | 'polygon' | 'mask';
 points?: Array<[number, number]>;
 maskHash?: string;
 };
+}
+
+// ===== targetedSend.d.ts =====
+export declare const TARGETED_SEND_SERVICE_NAME = "targetedSend";
+export interface TargetedSendRequest {
+channelType: string;
+principal: string;
+message: {
+text: string;
+};
+}
+export type TargetedSendDeliveryOutcome = {
+outcome: 'delivered';
+} | {
+outcome: 'unreachable';
+code: string;
+message: string;
+};
+export interface TargetedSendResultDiagnostic {
+code: string;
+message: string;
+principalId?: string;
+}
+export interface TargetedSendResult {
+resolution: {
+kind: 'single-user';
+} | {
+kind: 'role';
+holders: readonly string[];
+partial: boolean;
+};
+deliveries: readonly {
+principalId: string;
+outcome: TargetedSendDeliveryOutcome;
+}[];
+diagnostics: readonly TargetedSendResultDiagnostic[];
+}
+export interface TargetedSendService {
+sendToPrincipal(request: TargetedSendRequest): Promise<TargetedSendResult>;
 }
 
 // ===== topic.d.ts =====

--- a/middleware/packages/plugin-api/package.json
+++ b/middleware/packages/plugin-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omadia/plugin-api",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/middleware/packages/plugin-api/src/index.ts
+++ b/middleware/packages/plugin-api/src/index.ts
@@ -155,3 +155,8 @@ export * from './topic.js';
 // /admin/duplicates (Excerpts tab); keep_a/keep_b deletes the loser
 // excerpt via the new `deleteExcerpt` KG method.
 export * from './excerptMerge.js';
+
+// #330 B3 — Principal-addressed targeted delivery ('targetedSend' kernel
+// service): how an agent plugin DMs a user or fans a report out to a role's
+// current holders. Optional service; plugins must feature-detect.
+export * from './targetedSend.js';

--- a/middleware/packages/plugin-api/src/targetedSend.ts
+++ b/middleware/packages/plugin-api/src/targetedSend.ts
@@ -1,0 +1,50 @@
+// Targeted delivery service surface (#330 B3) — how an AGENT plugin (e.g. the
+// Facilitator) sends a report/DM to one Principal. Published by the kernel via
+// `serviceRegistry.provide(TARGETED_SEND_SERVICE_NAME, …)`; plugins MUST treat
+// the service as optional (older kernels, no-Postgres deployments degrade the
+// role path) and reach it through `ctx.services.get(...)` after declaring the
+// service name in their manifest (deny-by-default) — as `optional_requires`,
+// NOT `requires`: no plugin provides this capability (the kernel does), so a
+// hard `requires` is unresolvable and keeps the consumer from ever activating.
+//
+// The shapes are plugin-api-OWN on purpose: the dependency direction is
+// channel-sdk → plugin-api, so this file must not import the channel-sdk. They
+// stay structurally compatible with the channel-sdk's TargetedSendReport.
+
+export const TARGETED_SEND_SERVICE_NAME = 'targetedSend';
+
+export interface TargetedSendRequest {
+  /** The `channel_bindings.channel_type` to deliver on (e.g. 'teams'). */
+  channelType: string;
+  /** Wire-form principal: 'user:<id>' | 'role:<key>'. A role fans out to ALL
+   *  current holders at send time (one delivery per holder, no quorum). */
+  principal: string;
+  message: {
+    text: string;
+  };
+}
+
+export type TargetedSendDeliveryOutcome =
+  | { outcome: 'delivered' }
+  | { outcome: 'unreachable'; code: string; message: string };
+
+export interface TargetedSendResultDiagnostic {
+  code: string;
+  message: string;
+  principalId?: string;
+}
+
+/** Structurally mirrors the channel-sdk's TargetedSendReport. `resolution.partial`
+ *  means the holder list was a lower bound — "delivered to everyone listed" must
+ *  not be read as "delivered to every holder". */
+export interface TargetedSendResult {
+  resolution:
+    | { kind: 'single-user' }
+    | { kind: 'role'; holders: readonly string[]; partial: boolean };
+  deliveries: readonly { principalId: string; outcome: TargetedSendDeliveryOutcome }[];
+  diagnostics: readonly TargetedSendResultDiagnostic[];
+}
+
+export interface TargetedSendService {
+  sendToPrincipal(request: TargetedSendRequest): Promise<TargetedSendResult>;
+}

--- a/middleware/src/channels/channelRegistry.ts
+++ b/middleware/src/channels/channelRegistry.ts
@@ -22,6 +22,8 @@ import type {
 } from '@omadia/channel-sdk';
 import type { ExpressRouteRegistry } from './routeRegistry.js';
 import type { WebSocketRegistry } from './webSocketRegistry.js';
+import type { ConversationRosterRegistry } from './rosterRegistry.js';
+import type { TargetedSendRegistry } from './targetedSendRegistry.js';
 
 /**
  * Runtime registry for installed channel packages. At middleware startup it
@@ -66,6 +68,10 @@ export interface ChannelRegistryDeps {
   routes: ExpressRouteRegistry;
   /** Optional — WebSocket lifecycle mirror of `routes` (Omadia UI canvas). */
   webSockets?: WebSocketRegistry;
+  /** #330 B1 — optional group-conversation registries; deactivation drops the
+   *  channel's roster + targeted-send contributions like routes/webSockets. */
+  rosterRegistry?: ConversationRosterRegistry;
+  targetedSends?: TargetedSendRegistry;
 }
 
 export class DefaultChannelRegistry implements ChannelRegistry {
@@ -148,6 +154,9 @@ export class DefaultChannelRegistry implements ChannelRegistry {
     const handle = this.handles.get(agentId);
     this.deps.routes.deactivateChannel(agentId);
     this.deps.webSockets?.deactivateChannel(agentId);
+    // #330 B1 — drop this channel's roster + targeted-send contributions.
+    this.deps.rosterRegistry?.unregisterChannel(agentId);
+    this.deps.targetedSends?.unregisterChannel(agentId);
     // Drop the cached ChannelPlugin implementation BEFORE the rest of
     // teardown so an immediately-following re-activate (upgrade flow)
     // can never observe the stale module. Without this, the resolver's

--- a/middleware/src/channels/conversationEventHub.ts
+++ b/middleware/src/channels/conversationEventHub.ts
@@ -1,0 +1,51 @@
+// Conversation-membership event fan-out (#330 B2 seam). Channel adapters emit
+// via `core.emitConversationEvent?.(event)`; kernel-side consumers (the
+// Facilitator's bot_added handshake, future group-aware agents) subscribe
+// here. Deliberately separate from ctx.events.emit / the Conductor
+// EventRouter: these are typed transport-lifecycle events, not
+// manifest-declared domain events — a bridge can be added by a consumer
+// without widening this hub.
+//
+// No persistence in B1: an event with no subscriber is logged and dropped.
+// Fan-out is synchronous with per-subscriber isolation — one throwing
+// subscriber must never break the emitting webhook turn or its siblings.
+
+import type { ConversationMembershipEvent } from '@omadia/channel-sdk';
+
+export type ConversationEventSubscriber = (event: ConversationMembershipEvent) => void;
+
+export class ConversationEventHub {
+  private readonly subscribers = new Set<ConversationEventSubscriber>();
+
+  constructor(
+    private readonly log: (msg: string, fields?: Record<string, unknown>) => void = () => undefined,
+  ) {}
+
+  /** Returns the unsubscribe function. */
+  subscribe(fn: ConversationEventSubscriber): () => void {
+    this.subscribers.add(fn);
+    return () => {
+      this.subscribers.delete(fn);
+    };
+  }
+
+  emit(event: ConversationMembershipEvent): void {
+    this.log(`conversationEventHub: ${event.kind} in ${event.conversationId}`, {
+      kind: event.kind,
+      channelId: event.channelId,
+      conversationId: event.conversationId,
+      members: event.members.length,
+      subscribers: this.subscribers.size,
+    });
+    for (const fn of this.subscribers) {
+      try {
+        fn(event);
+      } catch (err) {
+        this.log('conversationEventHub: subscriber threw — isolated', {
+          kind: event.kind,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+}

--- a/middleware/src/channels/coreApi.ts
+++ b/middleware/src/channels/coreApi.ts
@@ -4,14 +4,20 @@ import type {
   ChatStreamEvent,
   ChannelSocketHandler,
   ChannelUserRef,
+  ConversationMembershipEvent,
+  ConversationRosterProvider,
   CoreApi,
   HttpMethod,
   IncomingTurn,
   LogLevel,
   PlatformIdentity,
+  TargetedSendProvider,
 } from '@omadia/channel-sdk';
 import type { ExpressRouteRegistry } from './routeRegistry.js';
 import type { WebSocketRegistry } from './webSocketRegistry.js';
+import type { ConversationRosterRegistry } from './rosterRegistry.js';
+import type { ConversationEventHub } from './conversationEventHub.js';
+import type { TargetedSendRegistry } from './targetedSendRegistry.js';
 
 /**
  * Orchestrator adapter the CoreApi delegates to. Intentionally narrow — we
@@ -59,6 +65,14 @@ export interface CreateCoreApiOptions {
    * channels feature-detect and non-WS wirings stay untouched.
    */
   webSockets?: WebSocketRegistry;
+  /**
+   * #330 B1 — optional group-conversation registries. Each follows the
+   * `webSockets` pattern: when absent, the corresponding CoreApi method is
+   * simply not defined, so old plugins and non-group wirings stay untouched.
+   */
+  rosterRegistry?: ConversationRosterRegistry;
+  targetedSends?: TargetedSendRegistry;
+  conversationEvents?: ConversationEventHub;
   log?: (level: LogLevel, message: string, context?: Record<string, unknown>) => void;
 }
 
@@ -135,6 +149,27 @@ export function createCoreApi(opts: CreateCoreApiOptions): CoreApi {
       handler: ChannelSocketHandler,
     ): void => {
       webSockets.register(channelId, path, handler);
+    };
+  }
+
+  // #330 B1 — optional group-conversation capabilities, defined only when the
+  // kernel wired the matching registry (the registerWebSocket pattern).
+  if (opts.rosterRegistry) {
+    const rosters = opts.rosterRegistry;
+    api.registerRosterProvider = (channelId: string, provider: ConversationRosterProvider): void => {
+      rosters.register(channelId, provider);
+    };
+  }
+  if (opts.targetedSends) {
+    const targetedSends = opts.targetedSends;
+    api.registerTargetedSendProvider = (channelId: string, provider: TargetedSendProvider): void => {
+      targetedSends.register(channelId, provider);
+    };
+  }
+  if (opts.conversationEvents) {
+    const conversationEvents = opts.conversationEvents;
+    api.emitConversationEvent = (event: ConversationMembershipEvent): void => {
+      conversationEvents.emit(event);
     };
   }
 

--- a/middleware/src/channels/rosterRegistry.ts
+++ b/middleware/src/channels/rosterRegistry.ts
@@ -1,0 +1,72 @@
+// Per-channel roster providers (#330 B1). One provider per channelType, in
+// the ChannelDirectoryRegistry mould (and for the same reason: the
+// ServiceRegistry is keyed by capability name — a second channel registering
+// would silently replace the first, while this map preserves one contribution
+// per channel type). Provider failures are isolated: a throwing provider
+// degrades to "roster unknown", never to a crashed caller.
+
+import type { ConversationRoster, ConversationRosterProvider } from '@omadia/channel-sdk';
+
+export class ConversationRosterRegistry {
+  private readonly providers = new Map<string, ConversationRosterProvider>();
+  /** Which channel plugin (catalog id) registered which channelType — so a
+   *  channel deactivation can drop exactly its own contributions. */
+  private readonly owners = new Map<string, string>();
+
+  constructor(
+    private readonly log: (msg: string, fields?: Record<string, unknown>) => void = () => undefined,
+  ) {}
+
+  register(channelId: string, provider: ConversationRosterProvider): void {
+    // Same ownership rule as routeRegistry / targetedSendRegistry: first
+    // registrant owns the channel type; a foreign replace is rejected (a
+    // hijacked roster would feed wrong participant lists to group-aware
+    // agents). Re-registering your own provider stays allowed.
+    const owner = this.owners.get(provider.channelType);
+    if (owner !== undefined && owner !== channelId) {
+      throw new Error(
+        `roster provider for '${provider.channelType}' already owned by channel '${owner}' (attempted: '${channelId}')`,
+      );
+    }
+    const replaced = this.providers.has(provider.channelType);
+    this.providers.set(provider.channelType, provider);
+    this.owners.set(provider.channelType, channelId);
+    this.log(`rosterRegistry: ${replaced ? 'replaced' : 'registered'} provider for ${provider.channelType}`, {
+      channelType: provider.channelType,
+      channelId,
+    });
+  }
+
+  /** Drop every provider a channel plugin registered. Idempotent. */
+  unregisterChannel(channelId: string): void {
+    for (const [channelType, owner] of this.owners) {
+      if (owner !== channelId) continue;
+      this.providers.delete(channelType);
+      this.owners.delete(channelType);
+      this.log(`rosterRegistry: unregistered ${channelType} (channel ${channelId} deactivated)`);
+    }
+  }
+
+  types(): readonly string[] {
+    return Array.from(this.providers.keys()).sort();
+  }
+
+  /**
+   * Resolve a conversation's roster. Undefined when no provider serves the
+   * channel type, the provider cannot resolve the conversation, or it threw
+   * (logged) — callers treat all three as "roster unknown", never invent one.
+   */
+  async getRoster(channelType: string, conversationId: string): Promise<ConversationRoster | undefined> {
+    const provider = this.providers.get(channelType);
+    if (!provider) return undefined;
+    try {
+      return await provider.getRoster(conversationId);
+    } catch (err) {
+      this.log(`rosterRegistry: ${channelType} getRoster FAILED — treating as unknown`, {
+        channelType,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return undefined;
+    }
+  }
+}

--- a/middleware/src/channels/targetedDeliveryService.ts
+++ b/middleware/src/channels/targetedDeliveryService.ts
@@ -1,0 +1,195 @@
+// Principal-addressed targeted delivery (#330 B3). THE place principal
+// resolution happens for DMs: 'user:<id>' resolves to one target, 'role:<key>'
+// fans out to ALL current holders at send time (late-bound; notification
+// semantics — one delivery per holder, no quorum). Role→holder resolution is
+// a kernel invariant (the holder-source union decides who may approve — see
+// roleHolderSource.ts); a channel plugin only ever receives one resolved user
+// per delivery. Never a silent drop and never a throw for emptiness or
+// unreachability: every non-delivery lands in the report's diagnostics.
+
+import type {
+  AggregateHolderLookup,
+  TargetedDeliveryOutcome,
+  TargetedMessage,
+  TargetedSendDiagnostic,
+  TargetedSendReport,
+} from '@omadia/channel-sdk';
+import { parsePrincipal } from '@omadia/channel-sdk';
+
+import type { TargetedSendRegistry } from './targetedSendRegistry.js';
+
+export interface TargetedDeliveryService {
+  /** `principal` is the wire form: 'user:<id>' | 'role:<key>'. */
+  sendToPrincipal(input: {
+    channelType: string;
+    principal: string;
+    message: TargetedMessage;
+  }): Promise<TargetedSendReport>;
+}
+
+export function createTargetedDeliveryService(deps: {
+  providers: TargetedSendRegistry;
+  /** Role→holders resolver (the Conductor holder registry). Absent on the
+   *  no-Postgres path — role sends then report 'role_resolution_unavailable'
+   *  while user sends keep working. */
+  resolveRoleHolders?: (roleKey: string) => Promise<AggregateHolderLookup>;
+  /** Cached per-user conversation references for a channel type (the
+   *  conductor channel-binding store). Absent = providers materialize 1:1
+   *  conversations themselves (Teams proactive messaging can). */
+  lookupConversationRefs?: (principalIds: string[], channelType: string) => Promise<Map<string, unknown>>;
+  log?: (msg: string) => void;
+}): TargetedDeliveryService {
+  const log = deps.log ?? (() => undefined);
+
+  async function deliverAll(
+    channelType: string,
+    principalIds: readonly string[],
+    message: TargetedMessage,
+  ): Promise<{
+    deliveries: { principalId: string; outcome: TargetedDeliveryOutcome }[];
+    diagnostics: TargetedSendDiagnostic[];
+  }> {
+    const provider = deps.providers.get(channelType);
+    if (!provider) {
+      return {
+        deliveries: [],
+        diagnostics: [
+          {
+            code: 'no_targeted_send_provider',
+            message: `no targeted-send provider registered for channel type '${channelType}'`,
+          },
+        ],
+      };
+    }
+
+    // Skip the lookup entirely for an empty fan-out (role_has_no_holders path).
+    const refs =
+      deps.lookupConversationRefs && principalIds.length > 0
+        ? await deps.lookupConversationRefs([...principalIds], channelType).catch((err: unknown) => {
+            // Degraded, not silent: downstream this surfaces as per-holder
+            // 'no_binding' outcomes, so name the real cause once here.
+            log(
+              `[channels] targeted send: conversation-ref lookup for ${channelType} failed (falling back to provider-side resolution): ${err instanceof Error ? err.message : String(err)}`,
+            );
+            return new Map<string, unknown>();
+          })
+        : new Map<string, unknown>();
+
+    const deliveries: { principalId: string; outcome: TargetedDeliveryOutcome }[] = [];
+    const diagnostics: TargetedSendDiagnostic[] = [];
+    for (const principalId of principalIds) {
+      const conversationRef = refs.get(principalId);
+      let outcome: TargetedDeliveryOutcome;
+      try {
+        outcome = await provider.sendToUser(
+          { principalId, ...(conversationRef !== undefined ? { conversationRef } : {}) },
+          message,
+        );
+      } catch (err) {
+        // Providers should RETURN unreachability; a throw is still confined to
+        // this holder so the remaining fan-out continues.
+        outcome = {
+          outcome: 'unreachable',
+          code: 'channel_error',
+          message: err instanceof Error ? err.message : String(err),
+        };
+      }
+      deliveries.push({ principalId, outcome });
+      if (outcome.outcome === 'unreachable') {
+        diagnostics.push({
+          code: 'holder_unreachable',
+          message: `delivery to '${principalId}' failed: ${outcome.code} — ${outcome.message}`,
+          principalId,
+        });
+        log(`[channels] targeted send to '${principalId}' (${channelType}) unreachable: ${outcome.code}`);
+      }
+    }
+    return { deliveries, diagnostics };
+  }
+
+  return {
+    async sendToPrincipal(input) {
+      const principal = parsePrincipal(input.principal);
+      if (!principal) {
+        // No fabricated empty principal — its absence plus the diagnostic IS
+        // the answer.
+        return {
+          resolution: { kind: 'single-user' },
+          deliveries: [],
+          diagnostics: [
+            {
+              code: 'invalid_principal',
+              message: `'${input.principal}' is not a valid principal ('user:<id>' | 'role:<key>')`,
+            },
+          ],
+        };
+      }
+
+      if (principal.kind === 'user') {
+        const { deliveries, diagnostics } = await deliverAll(input.channelType, [principal.userId], input.message);
+        return { principal, resolution: { kind: 'single-user' }, deliveries, diagnostics };
+      }
+
+      // role: late-bound fan-out to all current holders — broadcast, no quorum.
+      if (!deps.resolveRoleHolders) {
+        return {
+          principal,
+          resolution: { kind: 'role', holders: [], partial: true },
+          deliveries: [],
+          diagnostics: [
+            {
+              code: 'role_resolution_unavailable',
+              message: `role '${principal.roleKey}' cannot be resolved: no role-holder resolver wired (no graph database?)`,
+            },
+          ],
+        };
+      }
+
+      let lookup: AggregateHolderLookup;
+      try {
+        lookup = await deps.resolveRoleHolders(principal.roleKey);
+      } catch (err) {
+        return {
+          principal,
+          resolution: { kind: 'role', holders: [], partial: true },
+          deliveries: [],
+          diagnostics: [
+            {
+              code: 'role_resolution_unavailable',
+              message: `role '${principal.roleKey}' resolution failed: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        };
+      }
+
+      const diagnostics: TargetedSendDiagnostic[] = [];
+      if (lookup.partial) {
+        // Lower-bound semantics surfaced, never hidden: deliveries to the known
+        // holders still go out, but the report says the list may be incomplete.
+        diagnostics.push({
+          code: 'role_resolution_partial',
+          message: `role '${principal.roleKey}' holder list is partial — delivered to the known holders only`,
+        });
+      }
+      if (lookup.holders.length === 0 && !lookup.partial) {
+        // An empty role is a delivery diagnostic / escalation, not a silent drop.
+        diagnostics.push({
+          code: 'role_has_no_holders',
+          message: `role '${principal.roleKey}' has no current holder — nothing was delivered`,
+        });
+      }
+
+      const { deliveries, diagnostics: deliveryDiagnostics } = await deliverAll(
+        input.channelType,
+        lookup.holders,
+        input.message,
+      );
+      return {
+        principal,
+        resolution: { kind: 'role', holders: lookup.holders, partial: lookup.partial },
+        deliveries,
+        diagnostics: [...diagnostics, ...deliveryDiagnostics],
+      };
+    },
+  };
+}

--- a/middleware/src/channels/targetedSendRegistry.ts
+++ b/middleware/src/channels/targetedSendRegistry.ts
@@ -1,0 +1,54 @@
+// Per-channel targeted-send providers (#330 B3). Same shape and rationale as
+// ConversationRosterRegistry: one provider per channelType (a channel type is
+// owned by exactly one plugin), owner-tracked so deactivation drops exactly
+// that channel's contribution.
+
+import type { TargetedSendProvider } from '@omadia/channel-sdk';
+
+export class TargetedSendRegistry {
+  private readonly providers = new Map<string, TargetedSendProvider>();
+  private readonly owners = new Map<string, string>();
+
+  constructor(
+    private readonly log: (msg: string, fields?: Record<string, unknown>) => void = () => undefined,
+  ) {}
+
+  register(channelId: string, provider: TargetedSendProvider): void {
+    // Ownership is enforced like routeRegistry's route conflict: a channel type
+    // belongs to the plugin that registered it first. Silently replacing a
+    // FOREIGN provider would let plugin B redirect plugin A's report DMs —
+    // delivery redirection is security-relevant. Re-registering your own
+    // provider (re-activate / upgrade) stays allowed.
+    const owner = this.owners.get(provider.channelType);
+    if (owner !== undefined && owner !== channelId) {
+      throw new Error(
+        `targeted-send provider for '${provider.channelType}' already owned by channel '${owner}' (attempted: '${channelId}')`,
+      );
+    }
+    const replaced = this.providers.has(provider.channelType);
+    this.providers.set(provider.channelType, provider);
+    this.owners.set(provider.channelType, channelId);
+    this.log(
+      `targetedSendRegistry: ${replaced ? 'replaced' : 'registered'} provider for ${provider.channelType}`,
+      { channelType: provider.channelType, channelId },
+    );
+  }
+
+  /** Drop every provider a channel plugin registered. Idempotent. */
+  unregisterChannel(channelId: string): void {
+    for (const [channelType, owner] of this.owners) {
+      if (owner !== channelId) continue;
+      this.providers.delete(channelType);
+      this.owners.delete(channelType);
+      this.log(`targetedSendRegistry: unregistered ${channelType} (channel ${channelId} deactivated)`);
+    }
+  }
+
+  get(channelType: string): TargetedSendProvider | undefined {
+    return this.providers.get(channelType);
+  }
+
+  types(): readonly string[] {
+    return Array.from(this.providers.keys()).sort();
+  }
+}

--- a/middleware/src/conductor/index.ts
+++ b/middleware/src/conductor/index.ts
@@ -5,7 +5,7 @@ import type { Pool } from 'pg';
 import type { OrchestratorRegistry } from '@omadia/orchestrator';
 import type { JsonObject, KnownRefs } from '@omadia/conductor-core';
 
-import type { RoleHolderSource } from '@omadia/channel-sdk';
+import type { RoleHolderRegistry, RoleHolderSource } from '@omadia/channel-sdk';
 
 import { runConductorMigrations } from './migrator.js';
 import { buildRoleHolderRegistry, holdersOnly } from './roleHolderResolver.js';
@@ -138,6 +138,11 @@ export interface ConductorWiring {
   ephemeralStore: ConductorEphemeralStore;
   ephemeralRunService: ConductorEphemeralRunService;
   ephemeralReaper: ConductorEphemeralReaper;
+  /** #330 B3 — THE role→holder registry (local assignment table + any external
+   *  sources). Exposed so the kernel's targeted-delivery fan-out resolves
+   *  through the same instance the executor uses for approvals: "who gets the
+   *  report" and "who may approve" must never drift apart. */
+  roleHolderRegistry: RoleHolderRegistry;
   /** Deps for the unauthenticated `/api/hooks/:endpointId` router, which is mounted
    *  much earlier in `index.ts` (before `express.json()`) via a forward reference —
    *  `index.ts` assigns this once `wireConductor` returns. */
@@ -475,6 +480,6 @@ export async function wireConductor(deps: {
     workflowStore, runStore, awaitStore, roleStore, scheduleStore, channelBindingStore, executor, awaitWorker,
     resumeWorker, scheduleWorker, eventRouter, builderAgent, templateStore, templateCatalog,
     webhookEndpoints, webhookSubscriptions, webhookDispatcher, webhookRetryWorker, webhookInboundDeps,
-    patternCatalog, ephemeralStore, ephemeralRunService, ephemeralReaper,
+    patternCatalog, ephemeralStore, ephemeralRunService, ephemeralReaper, roleHolderRegistry,
   };
 }

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -381,8 +381,12 @@ import { ExpressRouteRegistry } from './channels/routeRegistry.js';
 import { WebSocketRegistry } from './channels/webSocketRegistry.js';
 import { createCoreApi } from './channels/coreApi.js';
 import { ChannelDirectoryRegistry } from './channels/channelDirectoryRegistry.js';
+import { ConversationRosterRegistry } from './channels/rosterRegistry.js';
+import { ConversationEventHub } from './channels/conversationEventHub.js';
+import { TargetedSendRegistry } from './channels/targetedSendRegistry.js';
+import { createTargetedDeliveryService } from './channels/targetedDeliveryService.js';
 import { DefaultChannelRegistry } from './channels/channelRegistry.js';
-import type { ChannelRegistry, ChannelBindingResolver } from '@omadia/channel-sdk';
+import type { AggregateHolderLookup, ChannelRegistry, ChannelBindingResolver } from '@omadia/channel-sdk';
 import { DynamicChannelPluginResolver } from './channels/dynamicChannelResolver.js';
 import type { TurnDispatcher } from './channels/coreApi.js';
 import { createOrchestratorDispatcher } from './channels/orchestratorDispatcher.js';
@@ -588,10 +592,26 @@ async function main(): Promise<void> {
   // Phase B+ — directory aggregator for the /operator/channels dashboard.
   // Channel-kind plugins register their ChannelKeyDirectory contributions
   // during activate(); the kernel exposes the union over REST.
-  const channelDirectoryRegistry = new ChannelDirectoryRegistry((msg, fields) =>
-    console.log(`[middleware] ${msg}${fields ? ' ' + JSON.stringify(fields) : ''}`),
-  );
+  const registryLog = (msg: string, fields?: Record<string, unknown>): void =>
+    console.log(`[middleware] ${msg}${fields ? ' ' + JSON.stringify(fields) : ''}`);
+  const channelDirectoryRegistry = new ChannelDirectoryRegistry(registryLog);
   serviceRegistry.provide('channelDirectoryRegistry', channelDirectoryRegistry);
+
+  // #330 B1 — group-conversation registries. Constructed here (dep-free) so
+  // both the conductor block below and the channel runtime at the bottom can
+  // reference them; wired into createCoreApi + the channel registry there.
+  const conversationRosterRegistry = new ConversationRosterRegistry(registryLog);
+  const targetedSendRegistry = new TargetedSendRegistry(registryLog);
+  const conversationEventHub = new ConversationEventHub(registryLog);
+  serviceRegistry.provide('conversationRosters', conversationRosterRegistry);
+  // Subscribe-only facade: agent plugins may LISTEN for membership events, but
+  // emitting stays a channel-adapter privilege (CoreApi). A service-published
+  // emit() would let any granted plugin spoof `bot_added` — the Facilitator's
+  // handshake trigger — for conversations nobody invited it into.
+  serviceRegistry.provide('conversationEvents', {
+    subscribe: (fn: Parameters<ConversationEventHub['subscribe']>[0]) => conversationEventHub.subscribe(fn),
+  });
+
   const uiRouteCatalog = new UiRouteCatalog();
   // Publish the catalogue so plugin code (notably channel-teams' Hub +
   // Tab-Config) can read it via `ctx.services.get<UiRouteCatalog>(
@@ -3390,6 +3410,13 @@ async function main(): Promise<void> {
   // adminAudit hoisted from inside the graphPool block so the profiles
   // router (Phase 2.2 Slice D) can pass it to its snapshot mutation paths.
   let adminAudit: AdminAuditLog | undefined;
+  // #330 B3 — hoisted like adminAudit: filled inside the graphPool block once
+  // the Conductor's role store exists, read when the targeted-delivery service
+  // is constructed further down (before the channel runtime). On the
+  // no-Postgres path both stay undefined and role sends degrade to a
+  // 'role_resolution_unavailable' diagnostic while user sends keep working.
+  let targetedRoleResolver: ((roleKey: string) => Promise<AggregateHolderLookup>) | undefined;
+  let targetedBindingLookup: ((principalIds: string[], channelType: string) => Promise<Map<string, unknown>>) | undefined;
   if (graphPool) {
     await runAuthMigrations(graphPool, (m) => console.log(m));
     await runProfileStorageMigrations(graphPool, (m) => console.log(m));
@@ -3481,6 +3508,14 @@ async function main(): Promise<void> {
     // Deny-by-default like every kernel service: a plugin only reaches it after
     // declaring the service name in its manifest (pluginServiceGrants catalog).
     serviceRegistry.provide('conductorEphemeralRuns', conductorWiring.ephemeralRunService);
+    // #330 B3 — role fan-out + cached 1:1 conversation refs for targeted sends.
+    // Deliberately THE SAME holder registry the executor resolves approvals
+    // through: "who gets the report" and "who may approve" come from one
+    // instance, so a future external holder source (Entra group, Odoo HR)
+    // reaches both paths at once — no drift.
+    targetedRoleResolver = (roleKey) => conductorWiring.roleHolderRegistry.resolveHolders(roleKey);
+    targetedBindingLookup = (principalIds, channelType) =>
+      conductorWiring.channelBindingStore.getMany(principalIds, channelType);
     // #478 — plugin-borne workflow templates: hand the composite catalog's
     // registrar to the install service (runtime installs/uninstalls) and
     // re-register templates of already-installed plugins (registrations are
@@ -4954,10 +4989,25 @@ async function main(): Promise<void> {
     whitelist: emailWhitelist,
   });
 
+  // #330 B3 — Principal-addressed targeted delivery ('targetedSend' service).
+  // Constructed after the conductor block so the role resolver + binding
+  // lookup are already set when Postgres is available; deny-by-default for
+  // plugins like every other kernel service.
+  const targetedDeliveryService = createTargetedDeliveryService({
+    providers: targetedSendRegistry,
+    ...(targetedRoleResolver ? { resolveRoleHolders: targetedRoleResolver } : {}),
+    ...(targetedBindingLookup ? { lookupConversationRefs: targetedBindingLookup } : {}),
+    log: (m) => console.log(m),
+  });
+  serviceRegistry.provide('targetedSend', targetedDeliveryService);
+
   const channelCoreApi = createCoreApi({
     dispatcher: orchestratorDispatcher,
     routes: routeRegistry,
     webSockets: webSocketRegistry,
+    rosterRegistry: conversationRosterRegistry,
+    targetedSends: targetedSendRegistry,
+    conversationEvents: conversationEventHub,
   });
 
   // Phase 5B: channel discovery flips to plugin-store-flow. The
@@ -4996,6 +5046,8 @@ async function main(): Promise<void> {
     coreApi: channelCoreApi,
     routes: routeRegistry,
     webSockets: webSocketRegistry,
+    rosterRegistry: conversationRosterRegistry,
+    targetedSends: targetedSendRegistry,
   });
   channelRegistryRef = channelRegistry;
   await channelRegistry.activateAllInstalled();

--- a/middleware/test/conversationEventHub.test.ts
+++ b/middleware/test/conversationEventHub.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import type { ConversationMembershipEvent } from '@omadia/channel-sdk';
+
+import { ConversationEventHub } from '../src/channels/conversationEventHub.js';
+
+// #330 B2 seam — membership-event fan-out with per-subscriber isolation.
+
+const BOT_ADDED: ConversationMembershipEvent = {
+  kind: 'bot_added',
+  channelId: 'de.byte5.channel.teams',
+  channelType: 'teams',
+  conversationId: 'conv-1',
+  conversationType: 'group',
+  members: [{ kind: 'teams-aad', id: 'bot-1' }],
+  addedBy: { kind: 'teams-aad', id: 'owner-1' },
+  occurredAt: '2026-08-21T10:00:00.000Z',
+};
+
+describe('ConversationEventHub', () => {
+  it('emitting with no subscriber is a logged no-op', () => {
+    const logs: string[] = [];
+    const hub = new ConversationEventHub((msg) => logs.push(msg));
+    hub.emit(BOT_ADDED);
+    assert.ok(logs.some((l) => l.includes('bot_added')));
+  });
+
+  it('fans out to every subscriber and transports addedBy unchanged', () => {
+    const hub = new ConversationEventHub();
+    const seen: ConversationMembershipEvent[] = [];
+    hub.subscribe((e) => seen.push(e));
+    hub.subscribe((e) => seen.push(e));
+
+    hub.emit(BOT_ADDED);
+    assert.equal(seen.length, 2);
+    const first = seen[0]!;
+    assert.equal(first.kind, 'bot_added');
+    assert.deepEqual(first.kind === 'bot_added' ? first.addedBy : undefined, { kind: 'teams-aad', id: 'owner-1' });
+  });
+
+  it('a throwing subscriber is isolated — siblings still receive the event', () => {
+    const logs: string[] = [];
+    const hub = new ConversationEventHub((msg) => logs.push(msg));
+    const seen: string[] = [];
+    hub.subscribe(() => {
+      throw new Error('bad subscriber');
+    });
+    hub.subscribe((e) => seen.push(e.kind));
+
+    hub.emit(BOT_ADDED);
+    assert.deepEqual(seen, ['bot_added']);
+    assert.ok(logs.some((l) => l.includes('subscriber threw')));
+  });
+
+  it('unsubscribe stops delivery', () => {
+    const hub = new ConversationEventHub();
+    const seen: string[] = [];
+    const unsubscribe = hub.subscribe((e) => seen.push(e.kind));
+    unsubscribe();
+    hub.emit(BOT_ADDED);
+    assert.deepEqual(seen, []);
+  });
+});

--- a/middleware/test/conversationRoster.test.ts
+++ b/middleware/test/conversationRoster.test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { isGroupConversation } from '@omadia/channel-sdk';
+import type { ConversationRoster, ConversationRosterProvider } from '@omadia/channel-sdk';
+
+import { ConversationRosterRegistry } from '../src/channels/rosterRegistry.js';
+
+// #330 B1 — conversationType semantics + the kernel roster registry.
+
+describe('isGroupConversation', () => {
+  it("is true only for an explicit 'group' — absent means unknown, treated as direct", () => {
+    assert.equal(isGroupConversation({ conversationType: 'group' }), true);
+    assert.equal(isGroupConversation({ conversationType: 'direct' }), false);
+    assert.equal(isGroupConversation({}), false);
+  });
+});
+
+const ROSTER: ConversationRoster = {
+  conversationType: 'group',
+  participants: [{ userRef: { kind: 'teams-aad', id: 'u1' } }, { userRef: { kind: 'teams-aad', id: 'u2' } }],
+  partial: false,
+};
+
+function provider(channelType: string, impl?: ConversationRosterProvider['getRoster']): ConversationRosterProvider {
+  return { channelType, getRoster: impl ?? (async () => ROSTER) };
+}
+
+describe('ConversationRosterRegistry', () => {
+  it('serves the registered provider per channel type and replaces on re-register', async () => {
+    const registry = new ConversationRosterRegistry();
+    registry.register('plugin-a', provider('teams'));
+    assert.deepEqual(await registry.getRoster('teams', 'conv-1'), ROSTER);
+
+    const replacement: ConversationRoster = { conversationType: 'direct', participants: [], partial: false };
+    registry.register('plugin-a', provider('teams', async () => replacement));
+    assert.deepEqual(await registry.getRoster('teams', 'conv-1'), replacement);
+    assert.deepEqual(registry.types(), ['teams']);
+  });
+
+  it('returns undefined for an unserved channel type', async () => {
+    const registry = new ConversationRosterRegistry();
+    assert.equal(await registry.getRoster('telegram', 'conv-1'), undefined);
+  });
+
+  it('unregisterChannel drops exactly that channel plugin\'s contributions', async () => {
+    const registry = new ConversationRosterRegistry();
+    registry.register('plugin-a', provider('teams'));
+    registry.register('plugin-b', provider('telegram'));
+
+    registry.unregisterChannel('plugin-a');
+    assert.equal(await registry.getRoster('teams', 'conv-1'), undefined);
+    assert.deepEqual(await registry.getRoster('telegram', 'conv-1'), ROSTER);
+    registry.unregisterChannel('plugin-a'); // idempotent
+  });
+
+  it('rejects a FOREIGN replace — first registrant owns the channel type (no roster hijack)', async () => {
+    const registry = new ConversationRosterRegistry();
+    registry.register('plugin-a', provider('teams'));
+    assert.throws(
+      () => registry.register('plugin-b', provider('teams')),
+      /already owned by channel 'plugin-a'/,
+    );
+    // The owner's provider is untouched.
+    assert.deepEqual(await registry.getRoster('teams', 'conv-1'), ROSTER);
+  });
+
+  it('isolates a throwing provider — roster degrades to unknown, no crash', async () => {
+    const logs: string[] = [];
+    const registry = new ConversationRosterRegistry((msg) => logs.push(msg));
+    registry.register('plugin-a', provider('teams', async () => {
+      throw new Error('graph offline');
+    }));
+
+    assert.equal(await registry.getRoster('teams', 'conv-1'), undefined);
+    assert.ok(logs.some((l) => l.includes('FAILED')));
+  });
+});

--- a/middleware/test/coreApiOptionalCapabilities.test.ts
+++ b/middleware/test/coreApiOptionalCapabilities.test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import type { ChatStreamEvent, ConversationRosterProvider, TargetedSendProvider } from '@omadia/channel-sdk';
+
+import { createCoreApi } from '../src/channels/coreApi.js';
+import type { CreateCoreApiOptions } from '../src/channels/coreApi.js';
+import { ConversationRosterRegistry } from '../src/channels/rosterRegistry.js';
+import { ConversationEventHub } from '../src/channels/conversationEventHub.js';
+import { TargetedSendRegistry } from '../src/channels/targetedSendRegistry.js';
+
+// #330 B1 — the additivity contract: without the new registries the three new
+// CoreApi methods are simply NOT defined (the registerWebSocket pattern), so
+// an old kernel wiring and an old plugin against a new kernel both stay
+// byte-for-byte on today's behaviour.
+
+function baseOptions(): CreateCoreApiOptions {
+  return {
+    dispatcher: {
+      streamTurn(): AsyncIterable<ChatStreamEvent> {
+        return (async function* () {})();
+      },
+    },
+    routes: {
+      register: () => undefined,
+      registerRouter: () => undefined,
+    } as unknown as CreateCoreApiOptions['routes'],
+    log: () => undefined,
+  };
+}
+
+describe('createCoreApi — #330 optional group capabilities', () => {
+  it('without the registries the new methods are undefined (feature-detect holds)', () => {
+    const api = createCoreApi(baseOptions());
+    assert.equal(api.registerRosterProvider, undefined);
+    assert.equal(api.registerTargetedSendProvider, undefined);
+    assert.equal(api.emitConversationEvent, undefined);
+    // The pre-existing optional capability behaves identically.
+    assert.equal(api.registerWebSocket, undefined);
+  });
+
+  it('with the registries, registration round-trips into them', async () => {
+    const rosterRegistry = new ConversationRosterRegistry();
+    const targetedSends = new TargetedSendRegistry();
+    const conversationEvents = new ConversationEventHub();
+    const api = createCoreApi({ ...baseOptions(), rosterRegistry, targetedSends, conversationEvents });
+
+    const roster: ConversationRosterProvider = {
+      channelType: 'teams',
+      getRoster: async () => ({ conversationType: 'group', participants: [], partial: false }),
+    };
+    api.registerRosterProvider?.('plugin-teams', roster);
+    assert.deepEqual(rosterRegistry.types(), ['teams']);
+    assert.deepEqual(await rosterRegistry.getRoster('teams', 'c1'), {
+      conversationType: 'group',
+      participants: [],
+      partial: false,
+    });
+
+    const sender: TargetedSendProvider = {
+      channelType: 'teams',
+      sendToUser: async () => ({ outcome: 'delivered' }),
+    };
+    api.registerTargetedSendProvider?.('plugin-teams', sender);
+    assert.equal(targetedSends.get('teams'), sender);
+
+    const kinds: string[] = [];
+    conversationEvents.subscribe((e) => kinds.push(e.kind));
+    api.emitConversationEvent?.({
+      kind: 'members_added',
+      channelId: 'de.byte5.channel.teams',
+      conversationId: 'c1',
+      members: [],
+      occurredAt: '2026-08-21T10:00:00.000Z',
+    });
+    assert.deepEqual(kinds, ['members_added']);
+  });
+});

--- a/middleware/test/targetedDelivery.test.ts
+++ b/middleware/test/targetedDelivery.test.ts
@@ -1,0 +1,167 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import type { AggregateHolderLookup, TargetedSendProvider } from '@omadia/channel-sdk';
+
+import { createTargetedDeliveryService } from '../src/channels/targetedDeliveryService.js';
+import { TargetedSendRegistry } from '../src/channels/targetedSendRegistry.js';
+
+// #330 B3 — Principal fan-out semantics: one delivery per current role holder
+// (notification, no quorum), partial surfaced, empty role = diagnostic, never
+// a silent drop or a throw.
+
+function lookup(holders: string[], partial = false): AggregateHolderLookup {
+  return { holders, partial, bySource: [] };
+}
+
+function harness(opts?: {
+  unreachableFor?: string[];
+  holders?: AggregateHolderLookup;
+  resolverError?: Error;
+  noResolver?: boolean;
+  noProvider?: boolean;
+  refs?: Map<string, unknown>;
+}): {
+  service: ReturnType<typeof createTargetedDeliveryService>;
+  sent: Array<{ principalId: string; conversationRef?: unknown }>;
+} {
+  const sent: Array<{ principalId: string; conversationRef?: unknown }> = [];
+  const providers = new TargetedSendRegistry();
+  if (!opts?.noProvider) {
+    const provider: TargetedSendProvider = {
+      channelType: 'teams',
+      sendToUser: async (target) => {
+        sent.push(target);
+        if (opts?.unreachableFor?.includes(target.principalId)) {
+          return { outcome: 'unreachable', code: 'no_binding', message: 'no 1:1 conversation known' };
+        }
+        return { outcome: 'delivered' };
+      },
+    };
+    providers.register('plugin-teams', provider);
+  }
+
+  const service = createTargetedDeliveryService({
+    providers,
+    ...(opts?.noResolver
+      ? {}
+      : {
+          resolveRoleHolders: async () => {
+            if (opts?.resolverError) throw opts.resolverError;
+            return opts?.holders ?? lookup([]);
+          },
+        }),
+    ...(opts?.refs ? { lookupConversationRefs: async () => opts.refs! } : {}),
+  });
+  return { service, sent };
+}
+
+describe('TargetedSendRegistry ownership', () => {
+  it('rejects a FOREIGN replace — delivery redirection is security-relevant', () => {
+    const providers = new TargetedSendRegistry();
+    const mine: TargetedSendProvider = { channelType: 'teams', sendToUser: async () => ({ outcome: 'delivered' }) };
+    const thief: TargetedSendProvider = { channelType: 'teams', sendToUser: async () => ({ outcome: 'delivered' }) };
+    providers.register('plugin-a', mine);
+    assert.throws(() => providers.register('plugin-b', thief), /already owned by channel 'plugin-a'/);
+    assert.equal(providers.get('teams'), mine);
+    // Re-registering your OWN provider (re-activate / upgrade) stays allowed.
+    providers.register('plugin-a', thief);
+    assert.equal(providers.get('teams'), thief);
+  });
+});
+
+describe('targeted delivery — user principal', () => {
+  it('delivers exactly once to the canonicalized user', async () => {
+    const { service, sent } = harness();
+    const report = await service.sendToPrincipal({
+      channelType: 'teams',
+      principal: 'user:Jane@Co.com ',
+      message: { text: 'hi' },
+    });
+
+    assert.deepEqual(report.resolution, { kind: 'single-user' });
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0]!.principalId, 'jane@co.com');
+    assert.deepEqual(report.deliveries, [{ principalId: 'jane@co.com', outcome: { outcome: 'delivered' } }]);
+    assert.deepEqual(report.diagnostics, []);
+  });
+
+  it('passes the cached conversationRef through when the kernel has one', async () => {
+    const refs = new Map<string, unknown>([['jane@co.com', { convId: 'c-1' }]]);
+    const { service, sent } = harness({ refs });
+    await service.sendToPrincipal({ channelType: 'teams', principal: 'user:jane@co.com', message: { text: 'hi' } });
+    assert.deepEqual(sent[0]!.conversationRef, { convId: 'c-1' });
+  });
+
+  it("reports 'invalid_principal' for garbage — no throw", async () => {
+    const { service, sent } = harness();
+    const report = await service.sendToPrincipal({ channelType: 'teams', principal: 'banana', message: { text: 'x' } });
+    assert.equal(report.diagnostics[0]?.code, 'invalid_principal');
+    assert.equal(sent.length, 0);
+  });
+
+  it("reports 'no_targeted_send_provider' for an unserved channel type", async () => {
+    const { service } = harness({ noProvider: true });
+    const report = await service.sendToPrincipal({ channelType: 'teams', principal: 'user:jane@co.com', message: { text: 'x' } });
+    assert.equal(report.diagnostics[0]?.code, 'no_targeted_send_provider');
+    assert.deepEqual(report.deliveries, []);
+  });
+});
+
+describe('targeted delivery — role principal (late-bound fan-out, no quorum)', () => {
+  it('a role with two holders produces exactly two deliveries', async () => {
+    const { service, sent } = harness({ holders: lookup(['a@co.com', 'b@co.com']) });
+    const report = await service.sendToPrincipal({ channelType: 'teams', principal: 'role:management', message: { text: 'report' } });
+
+    assert.deepEqual(report.resolution, { kind: 'role', holders: ['a@co.com', 'b@co.com'], partial: false });
+    assert.equal(sent.length, 2);
+    assert.deepEqual(report.deliveries.map((d) => d.principalId), ['a@co.com', 'b@co.com']);
+    assert.deepEqual(report.diagnostics, []);
+  });
+
+  it("an empty role yields zero deliveries + 'role_has_no_holders' — no silent drop, no throw", async () => {
+    const { service, sent } = harness({ holders: lookup([]) });
+    const report = await service.sendToPrincipal({ channelType: 'teams', principal: 'role:management', message: { text: 'x' } });
+
+    assert.equal(sent.length, 0);
+    assert.equal(report.diagnostics[0]?.code, 'role_has_no_holders');
+  });
+
+  it('a partial holder list is surfaced AND the known holders are still delivered to', async () => {
+    const { service, sent } = harness({ holders: lookup(['a@co.com'], true) });
+    const report = await service.sendToPrincipal({ channelType: 'teams', principal: 'role:management', message: { text: 'x' } });
+
+    assert.equal(sent.length, 1);
+    assert.deepEqual(report.resolution, { kind: 'role', holders: ['a@co.com'], partial: true });
+    assert.equal(report.diagnostics[0]?.code, 'role_resolution_partial');
+  });
+
+  it('one unreachable holder gets a per-holder diagnostic while the second is still delivered', async () => {
+    const { service } = harness({ holders: lookup(['a@co.com', 'b@co.com']), unreachableFor: ['a@co.com'] });
+    const report = await service.sendToPrincipal({ channelType: 'teams', principal: 'role:management', message: { text: 'x' } });
+
+    assert.deepEqual(
+      report.deliveries.map((d) => ({ id: d.principalId, ok: d.outcome.outcome === 'delivered' })),
+      [{ id: 'a@co.com', ok: false }, { id: 'b@co.com', ok: true }],
+    );
+    const diag = report.diagnostics.find((d) => d.code === 'holder_unreachable');
+    assert.equal(diag?.principalId, 'a@co.com');
+  });
+
+  it("without a role resolver (no Postgres) roles degrade to 'role_resolution_unavailable' while users keep working", async () => {
+    const { service, sent } = harness({ noResolver: true });
+    const roleReport = await service.sendToPrincipal({ channelType: 'teams', principal: 'role:management', message: { text: 'x' } });
+    assert.equal(roleReport.diagnostics[0]?.code, 'role_resolution_unavailable');
+    assert.equal(sent.length, 0);
+
+    const userReport = await service.sendToPrincipal({ channelType: 'teams', principal: 'user:jane@co.com', message: { text: 'x' } });
+    assert.deepEqual(userReport.deliveries, [{ principalId: 'jane@co.com', outcome: { outcome: 'delivered' } }]);
+  });
+
+  it("a throwing resolver is reported as 'role_resolution_unavailable', not thrown", async () => {
+    const { service } = harness({ resolverError: new Error('graph down') });
+    const report = await service.sendToPrincipal({ channelType: 'teams', principal: 'role:management', message: { text: 'x' } });
+    assert.equal(report.diagnostics[0]?.code, 'role_resolution_unavailable');
+    assert.ok(report.diagnostics[0]?.message.includes('graph down'));
+  });
+});


### PR DESCRIPTION
## Summary

Workstream B1 of the **omadia Facilitator** epic (#330): group-conversation primitives as **reusable Core capabilities** — defined generically at the channel-SDK level, Teams adapter follows in `omadia-channel-teams`, Telegram/Discord after.

**Channel SDK (strictly additive — Teams 0.12.7 / Telegram 0.2.0 run unchanged):**
- `IncomingTurn.conversationType` (`'direct' | 'group'`; absent = unknown → treated as direct via the new `isGroupConversation`)
- `ConversationRoster` contract with the `partial` lower-bound discipline from `roleHolderSource.ts` (an empty roster is an answer; a partial one forbids conclusions from absence)
- typed `ConversationMembershipEvent`s: `bot_added` (incl. **who** invited the agent — the Facilitator's explicit, announced entry), `members_added`/`members_removed`
- `TargetedSendProvider`: a channel only ever delivers to **one already-resolved user**; unreachability is returned, never thrown

**Three new optional `CoreApi` methods** in the `registerWebSocket` feature-detect mould (`registerRosterProvider`, `registerTargetedSendProvider`, `emitConversationEvent`) — defined only when the kernel wired the matching registry; channel deactivation drops the channel's contributions; registries enforce **first-registrant ownership** per channel type (a foreign replace would redirect report DMs — hijack rejected, own re-register allowed).

**Kernel `targetedSend` service (deny-by-default, #330 B3):** `user:<id>` → one delivery; `role:<key>` → **late-bound fan-out to ALL current holders** (notification semantics: one delivery per holder, **no quorum**) — resolved through the **same holder registry the executor uses for approvals** (now exposed from `wireConductor`, so "who may approve" and "who gets the report" can never drift). Empty role → `role_has_no_holders`; partial list → surfaced AND known holders still delivered; unreachable holder → per-holder diagnostic, siblings continue. Never a silent drop, never a throw. Without Postgres, role sends degrade to `role_resolution_unavailable` while user sends keep working.

**Hardening (from omadia-reviewer, all findings addressed):** provider-hijack rejection (HIGH), `conversationEvents` published **subscribe-only** so a granted agent plugin cannot spoof the `bot_added` handshake trigger (MEDIUM), single shared holder registry (MEDIUM), `docs/security-architecture.md` §7a extended — role batons now also decide report recipients (MEDIUM), plus the LOW nits (no fabricated empty principal, logged binding-lookup outage, `optional_requires` guidance for Workstream C).

**`@omadia/plugin-api` 1.7.0** (additive MINOR, api-snapshot +40 lines, `api:check` green): `TARGETED_SEND_SERVICE_NAME` + request/result shapes so the Facilitator (Workstream C) can send reports without depending on the channel SDK.

## Test plan

- [x] `npm run build` + `npm run typecheck` + `npm run lint` green; test-tree ratchet flat (371 baseline, no regressions)
- [x] Full suite: **7098 tests, 0 fail** (16 pre-existing skips)
- [x] New suites (23 tests): `conversationRoster` (isGroupConversation semantics, registry replace/unregister/throw-isolation, hijack rejection), `conversationEventHub` (fan-out, subscriber isolation, addedBy transport, unsubscribe), `targetedDelivery` (canonicalized user delivery, cached conversationRef pass-through, role fan-out 2 holders → 2 deliveries, empty role diagnostic, partial surfaced + still delivered, per-holder unreachable isolation, no-resolver degradation, resolver-throw containment, provider hijack rejection), `coreApiOptionalCapabilities` (methods undefined without registries; round-trip with them)
- [ ] Live check with the Teams adapter lands in `omadia-channel-teams` (B2 — next slice)

Part of #330 — done: Workstream A (#818). Next: B2 (Teams adapter, plugin repo), C (Facilitator plugin, new repo).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789891908&installation_model_id=428086&pr_number=822&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F822&signature=381116d4f13618930bcefc5505be3721158aca58af9d5305a84aa6f13bbedd1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->