### PR TITLE
feat: zero-touch facilitator setup — agent provisioning, invite-guarded auto-bind, scoped role assignments (#330 C2a)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,12 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — zero-touch Facilitator setup: agent provisioning, invite-guarded auto-bind, scoped role assignments (#330 C2a)
+
+- Three new plugin-facing, deny-by-default kernel services remove the manual Facilitator setup: `agentProvisioning` (`ensureAgent` — idempotently creates a top-level Agent, seeds its persona create-only via the Wave-8 `agent_persona_skills` path with the skill slug namespaced under the agent, and attaches the calling plugin; an existing agent — and an existing operator-configured `agent_plugins` row — is never touched, the `fallback` slug never managed), `conversationBindings` (`bind` only for conversations the KERNEL itself observed a group `bot_added` for, via a hub-direct invite index keyed by channel type + conversation; `unbind` is equally guarded to the caller's own ephemeral attachments, so operator bindings are out of reach and the `channel_bindings` PK plus guard close the steal path; both mutations land in the new `channel.binding_change` audit action), and `conductorRoleAssignments` (role writes hard-confined to the `facilitation-` namespace, every holder mutation audited through the #759 `conductor.role_holders_change` sink).
+- Migration `0010_ephemeral_attachments.sql`: auto-provisioned bindings/roles are recorded per facilitation and live exactly as long as its ephemeral workflow. Both reap paths (terminal-state hook + TTL reaper) dispose of them through one shared cleanup, and rows only disappear AFTER a successful cleanup — an attachment sweep retries expired `pending` (invite never became a facilitation) and expired `attached` (reap-time cleanup failed or ran before the kernel stores were up) rows. A pre-existing operator binding is never adopted into this self-disposing lifecycle.
+- `configStore`/`orchestratorRegistry` are resolved lazily per call (the orchestrator plugin publishes them at its own activation), so the seam is independent of plugin boot order.
+
 ### Added — "Sign in with ChatGPT" subscription provider (#294, experimental)
 
 - **Connect a ChatGPT subscription as an LLM provider via OAuth, no API key.**

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -1263,6 +1263,50 @@ Conversation-Refs kommen aus `conductorWiring.channelBindingStore.getMany`.
 `test/conversationEventHub.test.ts`, `test/targetedDelivery.test.ts`,
 `test/coreApiOptionalCapabilities.test.ts`.
 
+### Zero-Touch-Facilitator-Setup (#330 C2a)
+
+Drei neue deny-by-default Kernel-Services (Manifest-`optional_requires` ist
+das Gate, kein Katalogeintrag):
+
+- **`agentProvisioning`** (`src/platform/agentSetupService.ts`):
+  `ensureAgent({slug, name, description, pluginId, personaSkill?})` —
+  idempotent; Persona via `skills`-Upsert + `agent_persona_skills`-Link
+  (Wave 8 — Agents haben KEINE instructions-Spalte); attached nur das
+  aufrufende Plugin; `fallback`-Slug verboten; bestehende Agenten werden nie
+  mutiert. `configStore`/`orchestratorRegistry` werden **lazy pro Call**
+  aufgelöst (das Orchestrator-Plugin published sie erst bei seiner eigenen
+  Aktivierung).
+- **`conversationBindings`**: `bind()` nur für Conversations, für die der
+  Kernel selbst ein Gruppen-`bot_added` beobachtet hat
+  (`src/platform/observedConversationInvites.ts` — subscribed DIREKT am
+  ConversationEventHub, vor jedem Plugin; Key channelType::conversationId,
+  TTL 24h). Fremd-gebundene Conversations: Refusal via `channel_bindings`-PK.
+  `unbind()` ist gleich hart geguarded: nur eigene Ephemeral-Attachment-Rows
+  — Operator-Bindings sind von dieser Fläche aus unerreichbar, und ein
+  vorbestehendes Operator-Binding wird NIE in den Ephemeral-Lifecycle
+  adoptiert. bind/unbind laufen als `channel.binding_change` ins admin_audit.
+  `attachWorkflow()` (guarded: nur eigene pending-Row) koppelt das Binding an
+  den Facilitation-Run.
+- **`conductorRoleAssignments`** (`src/conductor/scopedRoleAssignments.ts`):
+  Rollen-Writes hart auf Präfix `facilitation-` beschränkt; jede
+  Holder-Mutation läuft durch den #759-Audit-Sink
+  (`conductor.role_holders_change`, actor = Plugin bzw. Reaper).
+
+**Ephemere Kopplung:** Migration `0010_ephemeral_attachments.sql` +
+`ephemeralAttachmentsStore.ts`. Beide Reap-Pfade (Terminal-Hook in
+`wireConductor.reapIfEphemeral` + `ephemeralReaper.onReaped`) rufen EINEN
+gemeinsamen, in `src/index.ts` VOR wireConductor konstruierten
+Cleanup-Pfad (`disposeEphemeralAttachment`): Binding entfernen,
+Rollen-Holder schließen (auditiert), erst DANN Row löschen. Retry-Wahrheit:
+schlägt das Cleanup fehl (oder läuft der Reaper-Boot-Tick, bevor
+configStore/orchestratorRegistry published sind), bleibt die Row stehen und
+der **Attachment-Sweep** räumt sie nach Ablauf ab — expired `pending`
+(Invite ohne Facilitation) UND expired `attached` (verpasstes
+Reap-Cleanup). Tests: `test/agentSetupService.test.ts`,
+`test/observedConversationInvites.test.ts`,
+`test/conductorScopedRoleAssignments.test.ts`,
+`test/conductorEphemeralAttachments.test.ts`.
+
 ## 4. Migration Managed Agents → Lokal
 
 ### Warum migriert

--- a/middleware/src/auth/adminAuditLog.ts
+++ b/middleware/src/auth/adminAuditLog.ts
@@ -26,7 +26,11 @@ export type AuditAction =
   // #759 — Conductor role-holder (baton) changes: who may approve is a
   // security decision and belongs in the trail (any operator can assign
   // themselves — the single-role system has no finer permission today).
-  | 'conductor.role_holders_change';
+  | 'conductor.role_holders_change'
+  // #330 C2a — plugin-driven conversation bind/unbind: a binding decides
+  // which Agent answers a group, so the auto-bind lifecycle belongs in the
+  // same trail as the role batons.
+  | 'channel.binding_change';
 
 export interface AuditActor {
   id?: string;

--- a/middleware/src/conductor/ephemeralAttachmentsStore.ts
+++ b/middleware/src/conductor/ephemeralAttachmentsStore.ts
@@ -1,0 +1,144 @@
+// Persistence for ephemeral attachments (#330 C2a): the auto-provisioned
+// conversation binding + per-conversation initiator role tied to one
+// facilitation. Lifecycle mirrors the ephemeral workflow — 'pending' from
+// auto-bind until facilitation_start, 'attached' once a workflow exists,
+// gone after the reap callback (or the pending-expiry sweep) cleaned up.
+
+import type { Pool } from 'pg';
+
+export interface EphemeralAttachment {
+  id: string;
+  workflowId: string | null;
+  agentSlug: string;
+  channelType: string;
+  channelKey: string;
+  roleKey: string | null;
+  state: 'pending' | 'attached';
+  expiresAt: Date;
+}
+
+interface AttachmentRow {
+  id: string;
+  workflow_id: string | null;
+  agent_slug: string;
+  channel_type: string;
+  channel_key: string;
+  role_key: string | null;
+  state: 'pending' | 'attached';
+  expires_at: Date;
+}
+
+const COLS = 'id, workflow_id, agent_slug, channel_type, channel_key, role_key, state, expires_at';
+
+function toAttachment(r: AttachmentRow): EphemeralAttachment {
+  return {
+    id: String(r.id),
+    workflowId: r.workflow_id,
+    agentSlug: r.agent_slug,
+    channelType: r.channel_type,
+    channelKey: r.channel_key,
+    roleKey: r.role_key,
+    state: r.state,
+    expiresAt: r.expires_at,
+  };
+}
+
+export class ConductorEphemeralAttachmentsStore {
+  constructor(private readonly pool: Pool) {}
+
+  /** Record the auto-bind for a conversation. Idempotent per conversation:
+   *  a repeated invite refreshes the pending expiry (and re-stamps the owning
+   *  agent, review L2) but never resets an 'attached' row back to pending —
+   *  the running facilitation owns it. */
+  async upsertPending(input: {
+    agentSlug: string;
+    channelType: string;
+    channelKey: string;
+    expiresAt: Date;
+  }): Promise<EphemeralAttachment> {
+    const r = await this.pool.query<AttachmentRow>(
+      `INSERT INTO conductor_ephemeral_attachments (agent_slug, channel_type, channel_key, expires_at)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (channel_type, channel_key) DO UPDATE
+         SET expires_at = CASE
+               WHEN conductor_ephemeral_attachments.state = 'pending' THEN EXCLUDED.expires_at
+               ELSE conductor_ephemeral_attachments.expires_at
+             END,
+             agent_slug = CASE
+               WHEN conductor_ephemeral_attachments.state = 'pending' THEN EXCLUDED.agent_slug
+               ELSE conductor_ephemeral_attachments.agent_slug
+             END
+       RETURNING ${COLS}`,
+      [input.agentSlug, input.channelType, input.channelKey, input.expiresAt],
+    );
+    return toAttachment(r.rows[0]!);
+  }
+
+  /** Tie the attachment to its facilitation run. Guarded (review M1): only a
+   *  'pending' row owned by the SAME agent can be attached — a foreign or
+   *  already-attached row is left untouched (undefined return). */
+  async attachToWorkflow(input: {
+    agentSlug: string;
+    channelType: string;
+    channelKey: string;
+    workflowId: string;
+    roleKey: string | null;
+    expiresAt: Date;
+  }): Promise<EphemeralAttachment | undefined> {
+    const r = await this.pool.query<AttachmentRow>(
+      `UPDATE conductor_ephemeral_attachments
+          SET workflow_id = $4, role_key = $5, state = 'attached', expires_at = $6
+        WHERE channel_type = $2 AND channel_key = $3
+          AND agent_slug = $1 AND state = 'pending'
+      RETURNING ${COLS}`,
+      [input.agentSlug, input.channelType, input.channelKey, input.workflowId, input.roleKey, input.expiresAt],
+    );
+    return r.rows[0] ? toAttachment(r.rows[0]) : undefined;
+  }
+
+  async getByConversation(channelType: string, channelKey: string): Promise<EphemeralAttachment | undefined> {
+    const r = await this.pool.query<AttachmentRow>(
+      `SELECT ${COLS} FROM conductor_ephemeral_attachments
+        WHERE channel_type = $1 AND channel_key = $2`,
+      [channelType, channelKey],
+    );
+    return r.rows[0] ? toAttachment(r.rows[0]) : undefined;
+  }
+
+  async getByWorkflow(workflowId: string): Promise<EphemeralAttachment[]> {
+    const r = await this.pool.query<AttachmentRow>(
+      `SELECT ${COLS} FROM conductor_ephemeral_attachments WHERE workflow_id = $1`,
+      [workflowId],
+    );
+    return r.rows.map(toAttachment);
+  }
+
+  /** Pending rows past their expiry — invites that never became a
+   *  facilitation. The sweep unbinds them so a blank invite cannot hold a
+   *  group's conversation binding forever. */
+  async listExpiredPending(now: Date): Promise<EphemeralAttachment[]> {
+    const r = await this.pool.query<AttachmentRow>(
+      `SELECT ${COLS} FROM conductor_ephemeral_attachments
+        WHERE state = 'pending' AND expires_at <= $1`,
+      [now],
+    );
+    return r.rows.map(toAttachment);
+  }
+
+  /** Attached rows past their expiry — the RETRY path (review H2): a row only
+   *  disappears after successful cleanup, so an attachment whose reap-time
+   *  disposal failed (or ran before the cleanup impl was wired at boot) is
+   *  picked up again here once its workflow TTL horizon has passed. */
+  async listExpiredAttached(now: Date): Promise<EphemeralAttachment[]> {
+    const r = await this.pool.query<AttachmentRow>(
+      `SELECT ${COLS} FROM conductor_ephemeral_attachments
+        WHERE state = 'attached' AND expires_at <= $1`,
+      [now],
+    );
+    return r.rows.map(toAttachment);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.pool.query('DELETE FROM conductor_ephemeral_attachments WHERE id = $1', [id]);
+  }
+}

--- a/middleware/src/conductor/ephemeralReaper.ts
+++ b/middleware/src/conductor/ephemeralReaper.ts
@@ -7,7 +7,7 @@
 // a physical DELETE only happens for rows no run references — the run history
 // and version graph are the retained audit trace.
 
-import type { ConductorEphemeralStore } from './ephemeralStore.js';
+import type { ConductorEphemeralStore, ReapableWorkflow } from './ephemeralStore.js';
 
 const REAPER_ACTOR = 'conductor-ephemeral-reaper';
 
@@ -18,6 +18,12 @@ export class ConductorEphemeralReaper {
   constructor(
     private readonly deps: {
       store: ConductorEphemeralStore;
+      /** #330 C2a — dispose of the workflow's ephemeral attachments (auto-bind,
+       *  per-conversation role) BEFORE the definition is reaped. Failures are
+       *  logged and do not block the reap: a leftover binding is caught by the
+       *  next tick / the pending-expiry sweep, while a never-reaped workflow
+       *  would grow forever. */
+      onReaped?: (workflow: ReapableWorkflow) => Promise<void>;
       intervalMs?: number;
       now?: () => Date;
       log?: (msg: string) => void;
@@ -60,6 +66,11 @@ export class ConductorEphemeralReaper {
             if (cancelled > 0) {
               this.deps.log?.(`[conductor] ephemeral '${wf.slug}' expired — cancel requested for ${cancelled} active run(s)`);
             }
+          }
+          if (this.deps.onReaped) {
+            await this.deps.onReaped(wf).catch((err: unknown) => {
+              this.deps.log?.(`[conductor] ephemeral attachment cleanup for '${wf.slug}' failed (reap continues): ${err instanceof Error ? err.message : String(err)}`);
+            });
           }
           await this.deps.store.markReaped(wf.id);
           const deleted = await this.deps.store.hardDeleteUnreferenced(wf.id);

--- a/middleware/src/conductor/index.ts
+++ b/middleware/src/conductor/index.ts
@@ -33,6 +33,7 @@ import type { PatternCatalog } from './patternCatalog.js';
 import { ConductorEphemeralStore } from './ephemeralStore.js';
 import { ConductorEphemeralRunService } from './ephemeralRunService.js';
 import { ConductorEphemeralReaper } from './ephemeralReaper.js';
+import { ConductorEphemeralAttachmentsStore } from './ephemeralAttachmentsStore.js';
 import { createTemplateStore } from './templateStore.js';
 import type { ConductorTemplateStore } from './templateStore.js';
 import { createConductorRouter } from './routes.js';
@@ -108,6 +109,10 @@ export {
 } from './ephemeralRunService.js';
 export type { CreateEphemeralRunInput, EphemeralRunHandle, EphemeralRunLimits } from './ephemeralRunService.js';
 export { ConductorEphemeralReaper } from './ephemeralReaper.js';
+export { ConductorEphemeralAttachmentsStore } from './ephemeralAttachmentsStore.js';
+export type { EphemeralAttachment } from './ephemeralAttachmentsStore.js';
+export { createScopedRoleAssignments, FACILITATION_ROLE_PREFIX, RoleKeyOutOfScopeError } from './scopedRoleAssignments.js';
+export type { ScopedRoleAssignments } from './scopedRoleAssignments.js';
 
 export interface ConductorWiring {
   workflowStore: ConductorWorkflowStore;
@@ -143,6 +148,9 @@ export interface ConductorWiring {
    *  through the same instance the executor uses for approvals: "who gets the
    *  report" and "who may approve" must never drift apart. */
   roleHolderRegistry: RoleHolderRegistry;
+  /** #330 C2a — auto-provisioned binding/role rows tied to ephemeral workflows;
+   *  consumed by the kernel's onEphemeralReaped cleanup + the agent-setup seam. */
+  ephemeralAttachments: ConductorEphemeralAttachmentsStore;
   /** Deps for the unauthenticated `/api/hooks/:endpointId` router, which is mounted
    *  much earlier in `index.ts` (before `express.json()`) via a forward reference —
    *  `index.ts` assigns this once `wireConductor` returns. */
@@ -202,6 +210,11 @@ export async function wireConductor(deps: {
     maxCreatesPerHour?: number;
     reaperIntervalMs?: number;
   };
+  /** #330 C2a — invoked on BOTH reap paths (terminal-state hook + TTL reaper)
+   *  before the definition is disposed of, so auto-provisioned bindings/roles
+   *  die with their workflow. Best-effort: a throw is logged, never blocks
+   *  the reap. Implemented in src/index.ts — wireConductor has no ConfigStore. */
+  onEphemeralReaped?: (workflow: { id: string; slug: string }) => Promise<void>;
   /** Global inbound kill switch (`CONDUCTOR_WEBHOOKS_ENABLED`). Default true. */
   webhooksEnabled?: boolean;
   /** Outbound delivery attempt cap + per-attempt timeout — defaults live in webhookDispatcher.ts. */
@@ -276,10 +289,18 @@ export async function wireConductor(deps: {
   // hook below can dispose of an agent-generated workflow the moment its run ends
   // (the reaper's TTL poll is the safety net, not the primary path).
   const ephemeralStore = new ConductorEphemeralStore(deps.pool);
+  const ephemeralAttachments = new ConductorEphemeralAttachmentsStore(deps.pool);
   const reapIfEphemeral = async (workflowVersionId: string): Promise<void> => {
     const version = await workflowStore.getVersion(workflowVersionId);
     const workflow = version ? await workflowStore.getById(version.workflowId) : null;
     if (workflow?.origin !== 'ephemeral' || workflow.reapedAt) return;
+    // #330 C2a — dispose of auto-provisioned attachments (binding, role) first;
+    // best-effort like the webhook dispatch, the TTL reaper is the safety net.
+    if (deps.onEphemeralReaped) {
+      await deps.onEphemeralReaped({ id: workflow.id, slug: workflow.slug }).catch((err: unknown) => {
+        log(`[conductor] ephemeral attachment cleanup for '${workflow.slug}' failed (reap continues): ${err instanceof Error ? err.message : String(err)}`);
+      });
+    }
     await ephemeralStore.markReaped(workflow.id);
     await ephemeralStore.hardDeleteUnreferenced(workflow.id);
     log(`[conductor] ephemeral '${workflow.slug}' reaped on terminal run state (audit trace retained)`);
@@ -390,6 +411,7 @@ export async function wireConductor(deps: {
   });
   const ephemeralReaper = new ConductorEphemeralReaper({
     store: ephemeralStore,
+    ...(deps.onEphemeralReaped ? { onReaped: (wf: { id: string; slug: string }) => deps.onEphemeralReaped!(wf) } : {}),
     ...(deps.ephemeral?.reaperIntervalMs !== undefined ? { intervalMs: deps.ephemeral.reaperIntervalMs } : {}),
     log,
   });
@@ -481,5 +503,6 @@ export async function wireConductor(deps: {
     resumeWorker, scheduleWorker, eventRouter, builderAgent, templateStore, templateCatalog,
     webhookEndpoints, webhookSubscriptions, webhookDispatcher, webhookRetryWorker, webhookInboundDeps,
     patternCatalog, ephemeralStore, ephemeralRunService, ephemeralReaper, roleHolderRegistry,
+    ephemeralAttachments,
   };
 }

--- a/middleware/src/conductor/migrations/0010_ephemeral_attachments.sql
+++ b/middleware/src/conductor/migrations/0010_ephemeral_attachments.sql
@@ -1,0 +1,34 @@
+-- #330 C2a — ephemeral attachments: the conversation binding and the
+-- per-conversation initiator role that were auto-provisioned for a
+-- facilitation live exactly as long as its ephemeral workflow. This table is
+-- the reaper's back-channel: on reap (terminal state or TTL) the kernel's
+-- onEphemeralReaped callback reads the rows, removes the channel binding,
+-- closes the role holders, and deletes the rows.
+--
+-- 'pending' rows exist between the bot_added auto-bind and facilitation_start
+-- (no workflow yet); a sweep expires them so an invite that never starts a
+-- facilitation cannot hold a group binding forever. Deliberately NO FK onto
+-- conductor_workflows: hard-delete order must stay free, and a dangling
+-- workflow_id only ever makes a row eligible for cleanup.
+
+CREATE TABLE IF NOT EXISTS conductor_ephemeral_attachments (
+  id            BIGSERIAL PRIMARY KEY,
+  workflow_id   TEXT,
+  agent_slug    TEXT NOT NULL,
+  channel_type  TEXT NOT NULL,
+  channel_key   TEXT NOT NULL,
+  role_key      TEXT,
+  state         TEXT NOT NULL DEFAULT 'pending',
+  expires_at    TIMESTAMPTZ NOT NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (channel_type, channel_key)
+);
+
+ALTER TABLE conductor_ephemeral_attachments DROP CONSTRAINT IF EXISTS conductor_ephemeral_attachments_state_check;
+ALTER TABLE conductor_ephemeral_attachments ADD CONSTRAINT conductor_ephemeral_attachments_state_check
+  CHECK (state IN ('pending', 'attached'));
+
+CREATE INDEX IF NOT EXISTS conductor_ephemeral_attachments_workflow_idx
+  ON conductor_ephemeral_attachments (workflow_id) WHERE workflow_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS conductor_ephemeral_attachments_expiry_idx
+  ON conductor_ephemeral_attachments (expires_at) WHERE state = 'pending';

--- a/middleware/src/conductor/scopedRoleAssignments.ts
+++ b/middleware/src/conductor/scopedRoleAssignments.ts
@@ -1,0 +1,95 @@
+// Prefix-scoped role assignment service (#330 C2a). What the Facilitator
+// plugin reaches as 'conductorRoleAssignments': it may create roles and move
+// holders ONLY inside the 'facilitation-' namespace — the per-conversation
+// initiator roles — never touch operator-authored roles ('management',
+// 'on-duty', …). Every mutation goes through the SAME audit sink as the
+// operator baton routes (#759, `conductor.role_holders_change`), with the
+// plugin as the named actor: role assignment decides who receives reports
+// (and could decide approvals), so an unaudited plugin write path would be
+// exactly the hole docs/security-architecture.md §7a warns about.
+
+import type { ConductorRoleStore } from './roleStore.js';
+
+export const FACILITATION_ROLE_PREFIX = 'facilitation-';
+
+export class RoleKeyOutOfScopeError extends Error {
+  constructor(readonly roleKey: string) {
+    super(`role '${roleKey}' is outside the '${FACILITATION_ROLE_PREFIX}' namespace this service is scoped to`);
+    this.name = 'RoleKeyOutOfScopeError';
+  }
+}
+
+export interface ScopedRoleAssignments {
+  ensureRole(input: { roleKey: string; label: string; description?: string }): Promise<void>;
+  addHolder(input: { roleKey: string; holderId: string; actor: string }): Promise<void>;
+  removeHolder(input: { roleKey: string; holderId: string; actor: string }): Promise<void>;
+  holders(roleKey: string): Promise<string[]>;
+}
+
+export function createScopedRoleAssignments(deps: {
+  roleStore: ConductorRoleStore;
+  auditRoleChange: (entry: {
+    actor: string;
+    roleKey: string;
+    action: 'add' | 'remove';
+    holderId: string;
+    holdersAfter: string[];
+  }) => Promise<void>;
+  log?: (msg: string) => void;
+}): ScopedRoleAssignments {
+  const log = deps.log ?? (() => undefined);
+
+  function assertScoped(roleKey: string): void {
+    if (!roleKey.startsWith(FACILITATION_ROLE_PREFIX) || roleKey.length <= FACILITATION_ROLE_PREFIX.length) {
+      throw new RoleKeyOutOfScopeError(roleKey);
+    }
+  }
+
+  return {
+    async ensureRole(input) {
+      assertScoped(input.roleKey);
+      await deps.roleStore.createRole({
+        key: input.roleKey,
+        label: input.label,
+        description: input.description ?? null,
+        scope: 'facilitation',
+      });
+    },
+
+    async addHolder(input) {
+      assertScoped(input.roleKey);
+      await deps.roleStore.addHolder(input.roleKey, input.holderId);
+      const holdersAfter = await deps.roleStore.resolve(input.roleKey);
+      await deps.auditRoleChange({
+        actor: input.actor,
+        roleKey: input.roleKey,
+        action: 'add',
+        holderId: input.holderId,
+        holdersAfter,
+      }).catch((err: unknown) => {
+        // The assignment stands; a failed audit write is loud, never silent.
+        log(`[conductor] scoped role audit (add ${input.roleKey}) failed: ${err instanceof Error ? err.message : String(err)}`);
+      });
+    },
+
+    async removeHolder(input) {
+      assertScoped(input.roleKey);
+      await deps.roleStore.removeHolder(input.roleKey, input.holderId);
+      const holdersAfter = await deps.roleStore.resolve(input.roleKey);
+      await deps.auditRoleChange({
+        actor: input.actor,
+        roleKey: input.roleKey,
+        action: 'remove',
+        holderId: input.holderId,
+        holdersAfter,
+      }).catch((err: unknown) => {
+        log(`[conductor] scoped role audit (remove ${input.roleKey}) failed: ${err instanceof Error ? err.message : String(err)}`);
+      });
+    },
+
+    async holders(roleKey) {
+      assertScoped(roleKey);
+      return deps.roleStore.resolve(roleKey);
+    },
+  };
+}

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -37,7 +37,7 @@ import { resolveAppVersion } from './update/version.js';
 import { createMemoryBackendRouter } from './routes/memoryBackend.js';
 import { createChatRouter } from './routes/chat.js';
 import { createOperatorAgentsRouter } from './routes/operatorAgents.js';
-import { wireConductor, AwaitNotPendingError, AwaitResponderNotHolderError } from './conductor/index.js';
+import { wireConductor, AwaitNotPendingError, AwaitResponderNotHolderError, ConductorRoleStore, ConductorEphemeralAttachmentsStore } from './conductor/index.js';
 import { createMissReportRoutes } from './privacy/missReportRoutes.js';
 import { TURN_RECEIPT_STORE_SERVICE_NAME } from '@omadia/plugin-api';
 import { PgTurnReceiptStore, startTurnReceiptReaper } from './receipts/store.js';
@@ -391,6 +391,9 @@ import { ConversationRosterRegistry } from './channels/rosterRegistry.js';
 import { ConversationEventHub } from './channels/conversationEventHub.js';
 import { TargetedSendRegistry } from './channels/targetedSendRegistry.js';
 import { createTargetedDeliveryService } from './channels/targetedDeliveryService.js';
+import { ObservedConversationInvites } from './platform/observedConversationInvites.js';
+import { createAgentSetupServices } from './platform/agentSetupService.js';
+import { createScopedRoleAssignments } from './conductor/scopedRoleAssignments.js';
 import { DefaultChannelRegistry } from './channels/channelRegistry.js';
 import type { AggregateHolderLookup, ChannelRegistry, ChannelBindingResolver } from '@omadia/channel-sdk';
 import { DynamicChannelPluginResolver } from './channels/dynamicChannelResolver.js';
@@ -628,6 +631,11 @@ async function main(): Promise<void> {
   const conversationRosterRegistry = new ConversationRosterRegistry(registryLog);
   const targetedSendRegistry = new TargetedSendRegistry(registryLog);
   const conversationEventHub = new ConversationEventHub(registryLog);
+  // #330 C2a — kernel-side invite index: subscribes directly at the hub (before
+  // any plugin) and is the scope guard for plugin auto-binds. A plugin can only
+  // bind conversations the transport actually reported a group bot_added for.
+  const observedInvites = new ObservedConversationInvites({ log: (m) => console.log(`[middleware] ${m}`) });
+  observedInvites.attach(conversationEventHub);
   serviceRegistry.provide('conversationRosters', conversationRosterRegistry);
   // Subscribe-only facade: agent plugins may LISTEN for membership events, but
   // emitting stays a channel-adapter privilege (CoreApi). A service-published
@@ -3454,8 +3462,85 @@ async function main(): Promise<void> {
     // run executor + operator API, all behind the graphPool (inert in-memory).
     // Agent steps run real turns on Agents (orchestrator instances) resolved by slug
     // from the registry; action steps invoke real connector tools.
+    // #330 C2a — the full attachment-cleanup chain is built BEFORE wireConductor
+    // (review H2b): the reaper's first tick fires inside wireConductor, and a
+    // boot with expired ephemerals is the normal restart case. Everything here
+    // is pool-backed or lazily resolved, so no wiring output is needed.
+    const ephemeralAttachmentsStore = new ConductorEphemeralAttachmentsStore(graphPool);
+    const facilitationRoleStore = new ConductorRoleStore(graphPool);
+    const scopedRoleAssignments = createScopedRoleAssignments({
+      roleStore: facilitationRoleStore,
+      auditRoleChange: async (entry) => {
+        await adminAudit?.record({
+          actor: { id: entry.actor },
+          action: 'conductor.role_holders_change',
+          target: `conductor-role:${entry.roleKey}`,
+          before: { action: entry.action, holderId: entry.holderId },
+          after: { holders: entry.holdersAfter },
+        });
+      },
+      log: (m) => console.log(m),
+    });
+    const auditBindingChange = async (entry: {
+      actor: string;
+      action: 'bind' | 'unbind';
+      channelType: string;
+      channelKey: string;
+      agentSlug: string;
+    }): Promise<void> => {
+      await adminAudit?.record({
+        actor: { id: entry.actor },
+        action: 'channel.binding_change',
+        target: `channel-binding:${entry.channelType}/${entry.channelKey}`,
+        before: { action: entry.action },
+        after: { agentSlug: entry.agentSlug },
+      });
+    };
+    // THE one disposal path (reap hook, guarded unbind, retry sweep): remove
+    // the binding, close the role holders (audited), and only then delete the
+    // row — a failure keeps the row, so the attachment sweep retries it.
+    const disposeEphemeralAttachment = async (
+      attachment: { id: string; agentSlug: string; channelType: string; channelKey: string; roleKey: string | null },
+      actor: string,
+    ): Promise<void> => {
+      const lateConfigStore = serviceRegistry.get<MultiOrchestratorConfigStore>('configStore');
+      const lateRegistry = serviceRegistry.get<MultiOrchestratorRegistry>('orchestratorRegistry');
+      if (!lateConfigStore || !lateRegistry) {
+        throw new Error('configStore/orchestratorRegistry not ready — attachment kept for retry');
+      }
+      await lateConfigStore.removeChannelBinding(attachment.channelType, attachment.channelKey);
+      await lateRegistry.reload();
+      if (attachment.roleKey) {
+        const holders = await scopedRoleAssignments.holders(attachment.roleKey);
+        for (const holderId of holders) {
+          await scopedRoleAssignments.removeHolder({ roleKey: attachment.roleKey, holderId, actor });
+        }
+      }
+      await ephemeralAttachmentsStore.delete(attachment.id);
+      await auditBindingChange({
+        actor,
+        action: 'unbind',
+        channelType: attachment.channelType,
+        channelKey: attachment.channelKey,
+        agentSlug: attachment.agentSlug,
+      }).catch(() => undefined);
+      console.log(`[conductor] disposed ephemeral attachment ${attachment.channelType}/${attachment.channelKey}${attachment.roleKey ? ` (role ${attachment.roleKey})` : ''} by ${actor}`);
+    };
+    const onEphemeralReaped = async (workflow: { id: string; slug: string }): Promise<void> => {
+      const rows = await ephemeralAttachmentsStore.getByWorkflow(workflow.id);
+      for (const row of rows) {
+        try {
+          await disposeEphemeralAttachment(row, 'conductor-ephemeral-reaper');
+        } catch (err) {
+          console.log(
+            `[conductor] ephemeral attachment disposal for '${workflow.slug}' failed (sweep retries after expiry): ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    };
     const conductorWiring = await wireConductor({
       pool: graphPool,
+      onEphemeralReaped,
       app,
       requireAuth,
       getRegistry,
@@ -3533,6 +3618,22 @@ async function main(): Promise<void> {
     // Deny-by-default like every kernel service: a plugin only reaches it after
     // declaring the service name in its manifest (pluginServiceGrants catalog).
     serviceRegistry.provide('conductorEphemeralRuns', conductorWiring.ephemeralRunService);
+    // #330 C2a — the three zero-touch-setup services (all deny-by-default via
+    // the manifest grant gate). Constructed above, BEFORE wireConductor.
+    serviceRegistry.provide('conductorRoleAssignments', scopedRoleAssignments);
+    const agentSetup = createAgentSetupServices({
+      pool: graphPool,
+      getConfigStore: () => serviceRegistry.get<MultiOrchestratorConfigStore>('configStore'),
+      getRegistry: () => serviceRegistry.get<MultiOrchestratorRegistry>('orchestratorRegistry'),
+      invites: observedInvites,
+      attachments: ephemeralAttachmentsStore,
+      disposeAttachment: disposeEphemeralAttachment,
+      auditBindingChange,
+      log: (m) => console.log(m),
+    });
+    serviceRegistry.provide('agentProvisioning', agentSetup.agentProvisioning);
+    serviceRegistry.provide('conversationBindings', agentSetup.conversationBindings);
+    agentSetup.startAttachmentSweep();
     // #330 B3 — role fan-out + cached 1:1 conversation refs for targeted sends.
     // Deliberately THE SAME holder registry the executor resolves approvals
     // through: "who gets the report" and "who may approve" come from one

--- a/middleware/src/platform/agentSetupService.ts
+++ b/middleware/src/platform/agentSetupService.ts
@@ -1,0 +1,339 @@
+// Agent auto-provisioning + guarded conversation bindings (#330 C2a).
+//
+// Two plugin-facing, deny-by-default kernel services that remove the manual
+// Facilitator setup steps:
+//
+//   'agentProvisioning'   — ensureAgent(): idempotently create a top-level
+//                           Agent, seed a persona skill (create-only, slug
+//                           namespaced to the agent — agents have no
+//                           instructions column, the Wave-8
+//                           agent_persona_skills path IS the persona) and
+//                           attach the calling plugin. An EXISTING agent is
+//                           never mutated: no create, no persona write, and
+//                           an existing agent_plugins row is left exactly as
+//                           the operator configured it (no config wipe, no
+//                           re-enable — review H4).
+//
+//   'conversationBindings' — bind(): create a conversation-scoped channel
+//                           binding, ONLY for a conversation the kernel
+//                           itself observed a group bot_added for (the
+//                           ObservedConversationInvites index — populated
+//                           straight from the ConversationEventHub, so a
+//                           plugin cannot fabricate eligibility), and only
+//                           when nobody else holds it (channel_bindings PK).
+//                           unbind() is equally guarded (review H1): a plugin
+//                           can only release bindings recorded in
+//                           conductor_ephemeral_attachments under its OWN
+//                           agent slug — operator-authored bindings are out
+//                           of reach, and a pre-existing operator binding is
+//                           never adopted into the ephemeral lifecycle
+//                           (review H5). Both mutations are audited.
+//
+// Cleanup truth lives in conductor_ephemeral_attachments: a row only
+// disappears after its binding/role were successfully disposed of, so the
+// sweep below retries what a reap-time cleanup missed (review H2).
+//
+// Trust model: like conductorEphemeralRuns' `agentId`, the caller names its
+// plugin/agent identity itself — in-process plugins are code the operator
+// installed; the parameter is attribution, not authentication. The guards
+// above bound what even a misbehaving plugin can reach.
+
+import type { AgentRow, ConfigStore } from '@omadia/orchestrator';
+import { AgentGraphStore, ConfigValidationError } from '@omadia/orchestrator';
+import type { Pool } from 'pg';
+
+import type { ConductorEphemeralAttachmentsStore, EphemeralAttachment } from '../conductor/ephemeralAttachmentsStore.js';
+import type { ObservedConversationInvites, ObservedInvite } from './observedConversationInvites.js';
+
+/** Structural — all this module needs from the multi-orchestrator registry. */
+interface ReloadableRegistry {
+  reload(): Promise<unknown>;
+}
+
+const FALLBACK_SLUG = 'fallback';
+const DEFAULT_PENDING_TTL_MS = 24 * 60 * 60 * 1000;
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
+export interface EnsureAgentInput {
+  slug: string;
+  name: string;
+  description?: string;
+  /** The calling plugin (attached to the agent, enabled). Attribution — see trust model. */
+  pluginId: string;
+  /** Persona seed. Create-only and namespaced: `slug` MUST start with
+   *  `<agent slug>-`, and an existing skills row is NEVER overwritten
+   *  (review H3 — upsert here would be a cross-agent prompt-injection
+   *  vector). Only applied when THIS call creates the agent. */
+  personaSkill?: { slug: string; name: string; body: string };
+}
+
+export interface EnsureAgentResult {
+  created: boolean;
+  agentSlug: string;
+}
+
+export interface AgentProvisioningService {
+  ensureAgent(input: EnsureAgentInput): Promise<EnsureAgentResult>;
+}
+
+export interface BindResult {
+  bound: boolean;
+  reason?: 'not_observed' | 'bound_to_other_agent' | 'agent_missing' | 'kernel_not_ready';
+  /** true when the conversation was already bound to this agent by the
+   *  OPERATOR — the binding works, but it is deliberately NOT adopted into
+   *  the ephemeral lifecycle (the sweep must never delete operator setup). */
+  preexistingOperatorBinding?: boolean;
+  invite?: ObservedInvite;
+}
+
+export interface BindingAuditEntry {
+  actor: string;
+  action: 'bind' | 'unbind';
+  channelType: string;
+  channelKey: string;
+  agentSlug: string;
+}
+
+export interface ConversationBindingsService {
+  bind(input: { agentSlug: string; channelType: string; conversationId: string; pendingTtlMs?: number }): Promise<BindResult>;
+  /** Guarded: releases the binding only when an ephemeral-attachment row for
+   *  this conversation exists AND carries the caller's own agentSlug. */
+  unbind(input: { agentSlug: string; channelType: string; conversationId: string }): Promise<{ unbound: boolean }>;
+  /** Tie the pending attachment to its facilitation run (after
+   *  createEphemeralRun) so the reaper disposes of binding + role with it.
+   *  Guarded to the caller's own pending row. */
+  attachWorkflow(input: {
+    agentSlug: string;
+    channelType: string;
+    conversationId: string;
+    workflowId: string;
+    roleKey?: string;
+    expiresAt: Date;
+  }): Promise<{ attached: boolean }>;
+  /** The observed invite for a conversation (inviter, channel) — how the
+   *  plugin learns WHO to assign the initiator role to. */
+  observedInvite(channelType: string, conversationId: string): ObservedInvite | undefined;
+}
+
+export function createAgentSetupServices(deps: {
+  pool: Pool;
+  /** LAZY on purpose: 'configStore' / 'orchestratorRegistry' are provided by
+   *  the orchestrator plugin at ITS activation — resolving at call time keeps
+   *  this seam independent of plugin boot order. */
+  getConfigStore: () => ConfigStore | undefined;
+  getRegistry: () => ReloadableRegistry | undefined;
+  invites: ObservedConversationInvites;
+  attachments: ConductorEphemeralAttachmentsStore;
+  /** The ONE cleanup path (shared with onEphemeralReaped in index.ts):
+   *  remove binding, close role holders, delete the row — and only delete
+   *  the row on success, so retries stay possible. */
+  disposeAttachment: (attachment: EphemeralAttachment, actor: string) => Promise<void>;
+  auditBindingChange?: (entry: BindingAuditEntry) => Promise<void>;
+  now?: () => Date;
+  log?: (msg: string) => void;
+}): {
+  agentProvisioning: AgentProvisioningService;
+  conversationBindings: ConversationBindingsService;
+  startAttachmentSweep: (opts?: { intervalMs?: number }) => () => void;
+} {
+  const log = deps.log ?? (() => undefined);
+  const graph = new AgentGraphStore(deps.pool);
+
+  function stores(): { configStore: ConfigStore; registry: ReloadableRegistry } | undefined {
+    const configStore = deps.getConfigStore();
+    const registry = deps.getRegistry();
+    return configStore && registry ? { configStore, registry } : undefined;
+  }
+
+  async function audit(entry: BindingAuditEntry): Promise<void> {
+    await deps.auditBindingChange?.(entry).catch((err: unknown) => {
+      log(`[agent-setup] binding audit (${entry.action} ${entry.channelKey}) failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  }
+
+  const agentProvisioning: AgentProvisioningService = {
+    async ensureAgent(input) {
+      const slug = input.slug.trim();
+      if (slug === FALLBACK_SLUG) {
+        throw new ConfigValidationError(`ensureAgent may not manage the '${FALLBACK_SLUG}' agent`);
+      }
+      if (input.personaSkill && !input.personaSkill.slug.startsWith(`${slug}-`)) {
+        throw new ConfigValidationError(
+          `ensureAgent: personaSkill.slug must be namespaced under '${slug}-' (got '${input.personaSkill.slug}')`,
+        );
+      }
+      const kernel = stores();
+      if (!kernel) throw new Error('agentProvisioning: configStore/orchestratorRegistry not published yet (orchestrator plugin inactive?)');
+      const { configStore, registry } = kernel;
+
+      const ensureAttachment = async (agent: AgentRow): Promise<void> => {
+        // Insert-if-absent only: an existing agent_plugins row carries operator
+        // decisions (config, enabled=false) that an upsert would wipe (H4).
+        const attached = (await configStore.listAgentPlugins(agent.id)).some((p) => p.pluginId === input.pluginId);
+        if (attached) return;
+        await configStore.upsertAgentPlugin(agent.id, { pluginId: input.pluginId, enabled: true });
+      };
+
+      const existing = await configStore.getAgentBySlug(slug);
+      if (existing) {
+        await ensureAttachment(existing);
+        await registry.reload();
+        return { created: false, agentSlug: slug };
+      }
+
+      let agent: AgentRow;
+      try {
+        agent = await configStore.createAgent({
+          slug,
+          name: input.name,
+          description: input.description ?? null,
+        });
+      } catch (err) {
+        // Lost a create race — treat like the existing-agent path.
+        if (err instanceof ConfigValidationError) {
+          const raced = await configStore.getAgentBySlug(slug);
+          if (raced) {
+            await ensureAttachment(raced);
+            await registry.reload();
+            return { created: false, agentSlug: slug };
+          }
+        }
+        throw err;
+      }
+
+      if (input.personaSkill) {
+        // Create-only (H3): a taken slug is skipped loudly, never clobbered.
+        const skill = await graph.insertSkill({
+          slug: input.personaSkill.slug,
+          name: input.personaSkill.name,
+          body: input.personaSkill.body,
+          source: 'db',
+        });
+        if (skill) {
+          await graph.addPersonaSkill(agent.id, skill.id);
+        } else {
+          log(`[agent-setup] persona skill slug '${input.personaSkill.slug}' already exists — left untouched, agent '${slug}' starts without it`);
+        }
+      }
+      await configStore.upsertAgentPlugin(agent.id, { pluginId: input.pluginId, enabled: true });
+      await registry.reload();
+      log(`[agent-setup] provisioned agent '${slug}' for ${input.pluginId} (persona skill: ${input.personaSkill ? input.personaSkill.slug : 'none'})`);
+      return { created: true, agentSlug: slug };
+    },
+  };
+
+  const conversationBindings: ConversationBindingsService = {
+    async bind(input) {
+      const invite = deps.invites.get(input.channelType, input.conversationId);
+      if (!invite) {
+        return { bound: false, reason: 'not_observed' };
+      }
+      const kernel = stores();
+      if (!kernel) return { bound: false, reason: 'kernel_not_ready', invite };
+      const { configStore, registry } = kernel;
+      const agent = await configStore.getAgentBySlug(input.agentSlug);
+      if (!agent) return { bound: false, reason: 'agent_missing', invite };
+
+      const expiresAt = new Date((deps.now ?? (() => new Date()))().getTime() + (input.pendingTtlMs ?? DEFAULT_PENDING_TTL_MS));
+      try {
+        await configStore.createChannelBinding(agent.id, {
+          channelType: input.channelType,
+          channelKey: input.conversationId,
+        });
+      } catch (err) {
+        if (err instanceof ConfigValidationError) {
+          const bindings = await configStore.listChannelBindingsForAgent(agent.id);
+          const mine = bindings.some(
+            (b) => b.channelType === input.channelType && b.channelKey === input.conversationId,
+          );
+          if (!mine) return { bound: false, reason: 'bound_to_other_agent', invite };
+          // Bound to this agent already. Ephemeral row present → OUR earlier
+          // auto-bind, refresh it. No row → an OPERATOR binding: usable, but
+          // never adopted into the self-disposing lifecycle (H5 — the sweep
+          // must not delete hand-made setup).
+          const row = await deps.attachments.getByConversation(input.channelType, input.conversationId);
+          if (row && row.agentSlug === input.agentSlug) {
+            await deps.attachments.upsertPending({
+              agentSlug: input.agentSlug,
+              channelType: input.channelType,
+              channelKey: input.conversationId,
+              expiresAt,
+            });
+            return { bound: true, invite };
+          }
+          return { bound: true, preexistingOperatorBinding: true, invite };
+        }
+        throw err;
+      }
+      await deps.attachments.upsertPending({
+        agentSlug: input.agentSlug,
+        channelType: input.channelType,
+        channelKey: input.conversationId,
+        expiresAt,
+      });
+      await registry.reload();
+      await audit({ actor: `agent:${input.agentSlug}`, action: 'bind', channelType: input.channelType, channelKey: input.conversationId, agentSlug: input.agentSlug });
+      log(`[agent-setup] auto-bound ${input.channelType}/${input.conversationId} → '${input.agentSlug}' (invite-guarded)`);
+      return { bound: true, invite };
+    },
+
+    async unbind(input) {
+      // H1 — a plugin may only release what the ephemeral lifecycle recorded
+      // under its own agent slug. Operator bindings and other agents'
+      // attachments are unreachable from this surface.
+      const row = await deps.attachments.getByConversation(input.channelType, input.conversationId);
+      if (!row || row.agentSlug !== input.agentSlug) {
+        log(`[agent-setup] unbind of ${input.channelType}/${input.conversationId} by '${input.agentSlug}' refused (no owned ephemeral attachment)`);
+        return { unbound: false };
+      }
+      await deps.disposeAttachment(row, `agent:${input.agentSlug}`);
+      return { unbound: true };
+    },
+
+    async attachWorkflow(input) {
+      const attached = await deps.attachments.attachToWorkflow({
+        agentSlug: input.agentSlug,
+        channelType: input.channelType,
+        channelKey: input.conversationId,
+        workflowId: input.workflowId,
+        roleKey: input.roleKey ?? null,
+        expiresAt: input.expiresAt,
+      });
+      return { attached: attached !== undefined };
+    },
+
+    observedInvite(channelType, conversationId) {
+      return deps.invites.get(channelType, conversationId);
+    },
+  };
+
+  /** Retry + expiry sweep over BOTH states: expired 'pending' rows are
+   *  invites that never became a facilitation; expired 'attached' rows are
+   *  the H2 retry path for cleanups the reap missed. One shared disposal. */
+  function startAttachmentSweep(opts?: { intervalMs?: number }): () => void {
+    const tick = async (): Promise<void> => {
+      try {
+        const now = (deps.now ?? (() => new Date()))();
+        const expired = [
+          ...(await deps.attachments.listExpiredPending(now)),
+          ...(await deps.attachments.listExpiredAttached(now)),
+        ];
+        for (const attachment of expired) {
+          try {
+            await deps.disposeAttachment(attachment, 'attachment-sweep');
+          } catch (err) {
+            log(`[agent-setup] sweep disposal of ${attachment.channelType}/${attachment.channelKey} failed (kept for retry): ${err instanceof Error ? err.message : String(err)}`);
+          }
+        }
+      } catch (err) {
+        log(`[agent-setup] attachment sweep failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    };
+    void tick();
+    const timer = setInterval(() => void tick(), opts?.intervalMs ?? SWEEP_INTERVAL_MS);
+    if (typeof timer.unref === 'function') timer.unref();
+    return () => clearInterval(timer);
+  }
+
+  return { agentProvisioning, conversationBindings, startAttachmentSweep };
+}

--- a/middleware/src/platform/observedConversationInvites.ts
+++ b/middleware/src/platform/observedConversationInvites.ts
@@ -1,0 +1,85 @@
+// Kernel-side invite index (#330 C2a). Subscribes DIRECTLY to the
+// ConversationEventHub — before any plugin sees the event and independent of
+// the subscribe-only service facade — and remembers which GROUP conversations
+// this deployment's channel adapters reported a bot_added for. The
+// conversationBindings service consults it as its scope guard: a plugin can
+// only auto-bind a conversation the transport actually observed an invite
+// for, never an arbitrary conversation id it made up.
+
+import type { ChannelUserRef, ConversationMembershipEvent } from '@omadia/channel-sdk';
+
+import type { ConversationEventHub } from '../channels/conversationEventHub.js';
+
+export interface ObservedInvite {
+  channelId: string;
+  channelType: string;
+  conversationId: string;
+  addedBy?: ChannelUserRef;
+  occurredAt: string;
+}
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+const MAX_ENTRIES = 1000;
+
+export class ObservedConversationInvites {
+  private readonly invites = new Map<string, { invite: ObservedInvite; seenAt: number }>();
+
+  constructor(
+    private readonly opts: {
+      ttlMs?: number;
+      now?: () => number;
+      log?: (msg: string) => void;
+    } = {},
+  ) {}
+
+  /** Wire into the hub; returns the unsubscribe function. */
+  attach(hub: ConversationEventHub): () => void {
+    return hub.subscribe((event) => this.observe(event));
+  }
+
+  /** Composite key (review M3): two channels with colliding conversation ids
+   *  must never shadow each other, and an invite without a channelType is
+   *  not eligible at all — no positive statement, no eligibility. */
+  private key(channelType: string, conversationId: string): string {
+    return `${channelType}::${conversationId}`;
+  }
+
+  observe(event: ConversationMembershipEvent): void {
+    if (event.kind !== 'bot_added') return;
+    // Group-only by design: a 1:1 never needs a facilitation binding, and
+    // treating an unknown type as group would widen the guard on a guess.
+    if (event.conversationType !== 'group') return;
+    if (!event.channelType) return;
+    const now = (this.opts.now ?? Date.now)();
+    const key = this.key(event.channelType, event.conversationId);
+    this.invites.delete(key);
+    this.invites.set(key, {
+      invite: {
+        channelId: event.channelId,
+        channelType: event.channelType,
+        conversationId: event.conversationId,
+        ...(event.addedBy ? { addedBy: event.addedBy } : {}),
+        occurredAt: event.occurredAt,
+      },
+      seenAt: now,
+    });
+    if (this.invites.size > MAX_ENTRIES) {
+      const oldest = this.invites.keys().next().value;
+      if (oldest !== undefined) this.invites.delete(oldest);
+    }
+    this.opts.log?.(`observed group invite for ${event.conversationId} (${event.channelType})`);
+  }
+
+  /** The invite for a conversation, if one was observed within the TTL. */
+  get(channelType: string, conversationId: string): ObservedInvite | undefined {
+    const key = this.key(channelType, conversationId);
+    const entry = this.invites.get(key);
+    if (!entry) return undefined;
+    const now = (this.opts.now ?? Date.now)();
+    if (now - entry.seenAt > (this.opts.ttlMs ?? DEFAULT_TTL_MS)) {
+      this.invites.delete(key);
+      return undefined;
+    }
+    return entry.invite;
+  }
+}

--- a/middleware/test/agentSetupService.test.ts
+++ b/middleware/test/agentSetupService.test.ts
@@ -1,0 +1,292 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { ConfigValidationError } from '@omadia/orchestrator';
+import type { ConfigStore } from '@omadia/orchestrator';
+import type { Pool } from 'pg';
+
+import { createAgentSetupServices } from '../src/platform/agentSetupService.js';
+import { ObservedConversationInvites } from '../src/platform/observedConversationInvites.js';
+import type { ConductorEphemeralAttachmentsStore, EphemeralAttachment } from '../src/conductor/ephemeralAttachmentsStore.js';
+
+// #330 C2a — the two plugin-facing setup services, including the review-driven
+// security regressions: no config wipe on existing agents (H4), guarded unbind
+// (H1), namespaced create-only persona skills (H3), and never adopting an
+// operator binding into the ephemeral lifecycle (H5).
+
+interface Calls {
+  createdAgents: string[];
+  attachedPlugins: Array<{ agentId: string; pluginId: string }>;
+  bindings: Array<{ agentId: string; channelKey: string }>;
+  reloads: number;
+  pendingUpserts: string[];
+  disposed: Array<{ channelKey: string; actor: string }>;
+  audits: Array<{ action: string; channelKey: string }>;
+}
+
+function harness(opts?: {
+  existingAgent?: boolean;
+  pluginAlreadyAttached?: boolean;
+  bindingTakenByOther?: boolean;
+  attachmentRow?: Partial<EphemeralAttachment> | null;
+  kernelReady?: boolean;
+}): {
+  services: ReturnType<typeof createAgentSetupServices>;
+  invites: ObservedConversationInvites;
+  calls: Calls;
+} {
+  const calls: Calls = {
+    createdAgents: [], attachedPlugins: [], bindings: [], reloads: 0, pendingUpserts: [], disposed: [], audits: [],
+  };
+  const ready = opts?.kernelReady ?? true;
+  const attachmentRow: EphemeralAttachment | undefined =
+    opts?.attachmentRow === null
+      ? undefined
+      : opts?.attachmentRow
+        ? {
+            id: '1', workflowId: null, agentSlug: 'facilitator', channelType: 'teams', channelKey: 'conv-1',
+            roleKey: null, state: 'pending', expiresAt: new Date('2026-08-22T10:00:00.000Z'),
+            ...opts.attachmentRow,
+          }
+        : undefined;
+
+  const configStore = {
+    getAgentBySlug: async (slug: string) =>
+      opts?.existingAgent ? { id: 'agent-1', slug, name: 'Existing' } : undefined,
+    createAgent: async (input: { slug: string }) => {
+      calls.createdAgents.push(input.slug);
+      return { id: 'agent-1', slug: input.slug };
+    },
+    listAgentPlugins: async () =>
+      opts?.pluginAlreadyAttached ? [{ pluginId: '@omadia/agent-facilitator', enabled: false, config: { keep: true } }] : [],
+    upsertAgentPlugin: async (agentId: string, input: { pluginId: string }) => {
+      calls.attachedPlugins.push({ agentId, pluginId: input.pluginId });
+      return {};
+    },
+    createChannelBinding: async (agentId: string, input: { channelKey: string }) => {
+      if (opts?.bindingTakenByOther || opts?.attachmentRow !== undefined) {
+        throw new ConfigValidationError('already bound');
+      }
+      calls.bindings.push({ agentId, channelKey: input.channelKey });
+      return {};
+    },
+    listChannelBindingsForAgent: async () =>
+      opts?.bindingTakenByOther ? [] : [{ channelType: 'teams', channelKey: 'conv-1' }],
+    removeChannelBinding: async () => undefined,
+  } as unknown as ConfigStore;
+
+  const registry = {
+    reload: async () => {
+      calls.reloads += 1;
+      return {};
+    },
+  };
+
+  const attachments = {
+    upsertPending: async (input: { channelKey: string }) => {
+      calls.pendingUpserts.push(input.channelKey);
+      return {};
+    },
+    attachToWorkflow: async (input: { agentSlug: string }) =>
+      input.agentSlug === 'facilitator' ? ({} as EphemeralAttachment) : undefined,
+    getByConversation: async () => attachmentRow,
+    getByWorkflow: async () => [],
+    listExpiredPending: async () => [],
+    listExpiredAttached: async () => [],
+    delete: async () => undefined,
+  } as unknown as ConductorEphemeralAttachmentsStore;
+
+  const invites = new ObservedConversationInvites();
+  const services = createAgentSetupServices({
+    pool: {} as Pool,
+    getConfigStore: () => (ready ? configStore : undefined),
+    getRegistry: () => (ready ? registry : undefined),
+    invites,
+    attachments,
+    disposeAttachment: async (attachment, actor) => {
+      calls.disposed.push({ channelKey: attachment.channelKey, actor });
+    },
+    auditBindingChange: async (entry) => {
+      calls.audits.push({ action: entry.action, channelKey: entry.channelKey });
+    },
+  });
+  return { services, invites, calls };
+}
+
+function observeInvite(invites: ObservedConversationInvites, conversationId = 'conv-1'): void {
+  invites.observe({
+    kind: 'bot_added',
+    channelId: 'de.byte5.channel.teams',
+    channelType: 'teams',
+    conversationId,
+    conversationType: 'group',
+    members: [],
+    occurredAt: '2026-08-21T10:00:00.000Z',
+  });
+}
+
+describe('agentProvisioning.ensureAgent', () => {
+  it('creates a missing agent and attaches the calling plugin', async () => {
+    const { services, calls } = harness();
+    const out = await services.agentProvisioning.ensureAgent({
+      slug: 'facilitator',
+      name: 'omadia Facilitator',
+      pluginId: '@omadia/agent-facilitator',
+    });
+    assert.deepEqual(out, { created: true, agentSlug: 'facilitator' });
+    assert.deepEqual(calls.createdAgents, ['facilitator']);
+    assert.deepEqual(calls.attachedPlugins, [{ agentId: 'agent-1', pluginId: '@omadia/agent-facilitator' }]);
+  });
+
+  it('H4 — an existing agent_plugins row is NEVER upserted (operator config/enabled stays)', async () => {
+    const { services, calls } = harness({ existingAgent: true, pluginAlreadyAttached: true });
+    const out = await services.agentProvisioning.ensureAgent({
+      slug: 'facilitator',
+      name: 'ignored',
+      pluginId: '@omadia/agent-facilitator',
+    });
+    assert.deepEqual(out, { created: false, agentSlug: 'facilitator' });
+    assert.deepEqual(calls.createdAgents, []);
+    assert.deepEqual(calls.attachedPlugins, [], 'no upsert may touch the operator-configured row');
+  });
+
+  it('H3 — personaSkill.slug must be namespaced under the agent slug', async () => {
+    const { services } = harness();
+    await assert.rejects(
+      services.agentProvisioning.ensureAgent({
+        slug: 'facilitator',
+        name: 'x',
+        pluginId: 'p',
+        personaSkill: { slug: 'someone-elses-skill', name: 'x', body: 'injected' },
+      }),
+      /namespaced under 'facilitator-'/,
+    );
+  });
+
+  it("refuses the 'fallback' agent and fails loudly before the kernel is ready", async () => {
+    const { services } = harness();
+    await assert.rejects(
+      services.agentProvisioning.ensureAgent({ slug: 'fallback', name: 'x', pluginId: 'p' }),
+      ConfigValidationError,
+    );
+    const cold = harness({ kernelReady: false });
+    await assert.rejects(
+      cold.services.agentProvisioning.ensureAgent({ slug: 'facilitator', name: 'x', pluginId: 'p' }),
+      /not published yet/,
+    );
+  });
+});
+
+describe('conversationBindings.bind', () => {
+  it('binds ONLY a kernel-observed group invite, records the pending row, audits', async () => {
+    const { services, invites, calls } = harness({ existingAgent: true });
+    observeInvite(invites);
+
+    const denied = await services.conversationBindings.bind({
+      agentSlug: 'facilitator', channelType: 'teams', conversationId: 'conv-never-invited',
+    });
+    assert.deepEqual(denied, { bound: false, reason: 'not_observed' });
+
+    const bound = await services.conversationBindings.bind({
+      agentSlug: 'facilitator', channelType: 'teams', conversationId: 'conv-1',
+    });
+    assert.equal(bound.bound, true);
+    assert.deepEqual(calls.bindings, [{ agentId: 'agent-1', channelKey: 'conv-1' }]);
+    assert.deepEqual(calls.pendingUpserts, ['conv-1']);
+    assert.deepEqual(calls.audits, [{ action: 'bind', channelKey: 'conv-1' }]);
+  });
+
+  it('a channel-type mismatch is refused (composite invite key)', async () => {
+    const { services, invites } = harness({ existingAgent: true });
+    observeInvite(invites);
+    const out = await services.conversationBindings.bind({
+      agentSlug: 'facilitator', channelType: 'telegram', conversationId: 'conv-1',
+    });
+    assert.deepEqual(out, { bound: false, reason: 'not_observed' });
+  });
+
+  it('never steals a conversation bound to another agent', async () => {
+    const { services, invites, calls } = harness({ bindingTakenByOther: true, existingAgent: true });
+    observeInvite(invites);
+    const out = await services.conversationBindings.bind({
+      agentSlug: 'facilitator', channelType: 'teams', conversationId: 'conv-1',
+    });
+    assert.equal(out.bound, false);
+    assert.equal(out.reason, 'bound_to_other_agent');
+    assert.deepEqual(calls.pendingUpserts, []);
+  });
+
+  it('H5 — a pre-existing OPERATOR binding to this agent is usable but never adopted (no pending row)', async () => {
+    const { services, invites, calls } = harness({ existingAgent: true, attachmentRow: null });
+    observeInvite(invites);
+    const out = await services.conversationBindings.bind({
+      agentSlug: 'facilitator', channelType: 'teams', conversationId: 'conv-1',
+    });
+    assert.equal(out.bound, true);
+    assert.equal(out.preexistingOperatorBinding, true);
+    assert.deepEqual(calls.pendingUpserts, [], 'operator setup must not enter the self-disposing lifecycle');
+  });
+
+  it('a repeated invite on OUR earlier auto-bind refreshes the pending row', async () => {
+    const { services, invites, calls } = harness({ existingAgent: true, attachmentRow: {} });
+    observeInvite(invites);
+    const out = await services.conversationBindings.bind({
+      agentSlug: 'facilitator', channelType: 'teams', conversationId: 'conv-1',
+    });
+    assert.equal(out.bound, true);
+    assert.notEqual(out.preexistingOperatorBinding, true);
+    assert.deepEqual(calls.pendingUpserts, ['conv-1']);
+  });
+
+  it('degrades to kernel_not_ready before the orchestrator plugin published its stores', async () => {
+    const { services, invites } = harness({ kernelReady: false });
+    observeInvite(invites);
+    const out = await services.conversationBindings.bind({
+      agentSlug: 'facilitator', channelType: 'teams', conversationId: 'conv-1',
+    });
+    assert.equal(out.reason, 'kernel_not_ready');
+  });
+});
+
+describe('conversationBindings.unbind (H1 guard)', () => {
+  it('releases only an ephemeral attachment owned by the calling agent — via the shared disposal', async () => {
+    const { services, calls } = harness({ attachmentRow: {} });
+    const out = await services.conversationBindings.unbind({
+      agentSlug: 'facilitator', channelType: 'teams', conversationId: 'conv-1',
+    });
+    assert.deepEqual(out, { unbound: true });
+    assert.deepEqual(calls.disposed, [{ channelKey: 'conv-1', actor: 'agent:facilitator' }]);
+  });
+
+  it('refuses foreign attachments AND operator bindings (no row)', async () => {
+    const foreign = harness({ attachmentRow: { agentSlug: 'someone-else' } });
+    assert.deepEqual(
+      await foreign.services.conversationBindings.unbind({ agentSlug: 'facilitator', channelType: 'teams', conversationId: 'conv-1' }),
+      { unbound: false },
+    );
+    assert.deepEqual(foreign.calls.disposed, []);
+
+    const operator = harness({ attachmentRow: null });
+    assert.deepEqual(
+      await operator.services.conversationBindings.unbind({ agentSlug: 'facilitator', channelType: 'teams', conversationId: 'conv-1' }),
+      { unbound: false },
+    );
+    assert.deepEqual(operator.calls.disposed, []);
+  });
+});
+
+describe('conversationBindings.attachWorkflow (M1 guard)', () => {
+  it('reports whether the guarded attach actually took', async () => {
+    const { services } = harness();
+    const mine = await services.conversationBindings.attachWorkflow({
+      agentSlug: 'facilitator', channelType: 'teams', conversationId: 'conv-1',
+      workflowId: 'wf-1', expiresAt: new Date(),
+    });
+    assert.deepEqual(mine, { attached: true });
+    const foreign = await services.conversationBindings.attachWorkflow({
+      agentSlug: 'intruder', channelType: 'teams', conversationId: 'conv-1',
+      workflowId: 'wf-1', expiresAt: new Date(),
+    });
+    assert.deepEqual(foreign, { attached: false });
+  });
+});

--- a/middleware/test/conductorEphemeralAttachments.test.ts
+++ b/middleware/test/conductorEphemeralAttachments.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import type { Pool } from 'pg';
+
+import { ConductorEphemeralAttachmentsStore } from '../src/conductor/ephemeralAttachmentsStore.js';
+
+// #330 C2a — fake-pool harness (conductorEphemeralStore.test.ts style): the
+// SQL predicates carry the semantics — pending-only expiry refresh, the
+// state check on attach, the pending-only expiry listing.
+
+interface IssuedQuery {
+  sql: string;
+  params: unknown[];
+}
+
+const ROW = {
+  id: '1',
+  workflow_id: null,
+  agent_slug: 'facilitator',
+  channel_type: 'teams',
+  channel_key: 'conv-1',
+  role_key: null,
+  state: 'pending',
+  expires_at: new Date('2026-08-22T10:00:00.000Z'),
+};
+
+function fakePool(rows: unknown[] = [ROW]): { pool: Pool; queries: IssuedQuery[] } {
+  const queries: IssuedQuery[] = [];
+  const pool = {
+    query: async (sql: string, params: unknown[] = []): Promise<{ rows: unknown[] }> => {
+      queries.push({ sql, params });
+      return { rows };
+    },
+  } as unknown as Pool;
+  return { pool, queries };
+}
+
+function norm(q: IssuedQuery): string {
+  return q.sql.replace(/\s+/g, ' ').trim();
+}
+
+describe('ConductorEphemeralAttachmentsStore', () => {
+  it('upsertPending refreshes expiry ONLY while still pending (attached rows are owned by the run)', async () => {
+    const { pool, queries } = fakePool();
+    await new ConductorEphemeralAttachmentsStore(pool).upsertPending({
+      agentSlug: 'facilitator',
+      channelType: 'teams',
+      channelKey: 'conv-1',
+      expiresAt: new Date('2026-08-22T10:00:00.000Z'),
+    });
+    const sql = norm(queries[0]!);
+    assert.ok(sql.includes('ON CONFLICT (channel_type, channel_key) DO UPDATE'));
+    assert.ok(sql.includes("state = 'pending'"), 'expiry refresh must be pending-gated');
+  });
+
+  it('attachToWorkflow ties workflow + role and flips the state', async () => {
+    const { pool, queries } = fakePool([{ ...ROW, workflow_id: 'wf-1', role_key: 'facilitation-x', state: 'attached' }]);
+    const out = await new ConductorEphemeralAttachmentsStore(pool).attachToWorkflow({
+      agentSlug: 'facilitator',
+      channelType: 'teams',
+      channelKey: 'conv-1',
+      workflowId: 'wf-1',
+      roleKey: 'facilitation-x',
+      expiresAt: new Date('2026-08-23T10:00:00.000Z'),
+    });
+    assert.equal(out?.state, 'attached');
+    const sql = norm(queries[0]!);
+    assert.ok(sql.includes("state = 'attached'"));
+    // M1 guard: only the owning agent's still-pending row is attachable.
+    assert.ok(sql.includes("agent_slug = $1 AND state = 'pending'"));
+  });
+
+  it('listExpiredPending only ever selects pending rows', async () => {
+    const { pool, queries } = fakePool([]);
+    await new ConductorEphemeralAttachmentsStore(pool).listExpiredPending(new Date());
+    const sql = norm(queries[0]!);
+    assert.ok(sql.includes("state = 'pending' AND expires_at <= $1"));
+  });
+
+  it('listExpiredAttached is the H2 retry path over attached rows', async () => {
+    const { pool, queries } = fakePool([]);
+    await new ConductorEphemeralAttachmentsStore(pool).listExpiredAttached(new Date());
+    const sql = norm(queries[0]!);
+    assert.ok(sql.includes("state = 'attached' AND expires_at <= $1"));
+  });
+
+  it('upsertPending re-stamps the owning agent while pending (L2)', async () => {
+    const { pool, queries } = fakePool();
+    await new ConductorEphemeralAttachmentsStore(pool).upsertPending({
+      agentSlug: 'facilitator', channelType: 'teams', channelKey: 'conv-1', expiresAt: new Date(),
+    });
+    const sql = norm(queries[0]!);
+    assert.ok(sql.includes('agent_slug = CASE'));
+  });
+});

--- a/middleware/test/conductorEphemeralReaper.test.ts
+++ b/middleware/test/conductorEphemeralReaper.test.ts
@@ -79,6 +79,36 @@ describe('ConductorEphemeralReaper.tick', () => {
     assert.ok(logs.some((l) => l.includes("reap of 'eph-bad' failed")));
   });
 
+  it('#330 C2a — onReaped runs BEFORE the soft-reap; its failure never blocks the reap', async () => {
+    const { store, calls } = fakeStore({ reapable: [{ id: 'wf-1', slug: 'eph-a', expired: false }] });
+    const order: string[] = [];
+    const origMarkReaped = store.markReaped.bind(store);
+    (store as { markReaped: (id: string) => Promise<void> }).markReaped = async (id: string) => {
+      order.push('markReaped');
+      await origMarkReaped(id);
+    };
+    await new ConductorEphemeralReaper({
+      store,
+      onReaped: async (wf) => {
+        order.push(`onReaped:${wf.slug}`);
+      },
+    }).tick();
+    assert.deepEqual(order, ['onReaped:eph-a', 'markReaped']);
+    assert.deepEqual(calls.reaped, ['wf-1']);
+
+    const failing = fakeStore({ reapable: [{ id: 'wf-2', slug: 'eph-b', expired: false }] });
+    const logs: string[] = [];
+    await new ConductorEphemeralReaper({
+      store: failing.store,
+      onReaped: async () => {
+        throw new Error('cleanup down');
+      },
+      log: (m) => logs.push(m),
+    }).tick();
+    assert.deepEqual(failing.calls.reaped, ['wf-2'], 'reap must proceed despite cleanup failure');
+    assert.ok(logs.some((l) => l.includes('attachment cleanup')));
+  });
+
   it('survives a listReapable failure without throwing', async () => {
     const { store, calls } = fakeStore({ reapable: [], listError: new Error('db down') });
     const logs: string[] = [];

--- a/middleware/test/conductorScopedRoleAssignments.test.ts
+++ b/middleware/test/conductorScopedRoleAssignments.test.ts
@@ -1,0 +1,90 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { createScopedRoleAssignments, RoleKeyOutOfScopeError } from '../src/conductor/scopedRoleAssignments.js';
+import type { ConductorRoleStore } from '../src/conductor/roleStore.js';
+
+// #330 C2a — the security property: a plugin-facing role-assignment surface
+// that can NEVER touch a role outside the 'facilitation-' namespace, and
+// whose every holder mutation lands in the same audit sink as the operator
+// baton routes (#759).
+
+function harness(): {
+  service: ReturnType<typeof createScopedRoleAssignments>;
+  calls: string[];
+  audits: Array<{ action: string; roleKey: string; holderId: string; actor: string }>;
+} {
+  const calls: string[] = [];
+  const audits: Array<{ action: string; roleKey: string; holderId: string; actor: string }> = [];
+  const holders = new Set<string>();
+  const roleStore = {
+    createRole: async (input: { key: string }) => {
+      calls.push(`createRole:${input.key}`);
+    },
+    addHolder: async (_key: string, holderId: string) => {
+      holders.add(holderId);
+      calls.push(`addHolder:${holderId}`);
+    },
+    removeHolder: async (_key: string, holderId: string) => {
+      holders.delete(holderId);
+      calls.push(`removeHolder:${holderId}`);
+    },
+    resolve: async () => [...holders],
+  } as unknown as ConductorRoleStore;
+
+  const service = createScopedRoleAssignments({
+    roleStore,
+    auditRoleChange: async (entry) => {
+      audits.push({ action: entry.action, roleKey: entry.roleKey, holderId: entry.holderId, actor: entry.actor });
+    },
+  });
+  return { service, calls, audits };
+}
+
+describe('createScopedRoleAssignments', () => {
+  it("rejects any role outside 'facilitation-' — including the bare prefix", async () => {
+    const { service, calls } = harness();
+    for (const roleKey of ['management', 'on-duty', 'facilitation-', 'Facilitation-x']) {
+      await assert.rejects(service.ensureRole({ roleKey, label: 'x' }), RoleKeyOutOfScopeError);
+      await assert.rejects(service.addHolder({ roleKey, holderId: 'a@co.com', actor: 'p' }), RoleKeyOutOfScopeError);
+      await assert.rejects(service.removeHolder({ roleKey, holderId: 'a@co.com', actor: 'p' }), RoleKeyOutOfScopeError);
+      await assert.rejects(service.holders(roleKey), RoleKeyOutOfScopeError);
+    }
+    assert.deepEqual(calls, [], 'no store call may happen for out-of-scope keys');
+  });
+
+  it('add/remove inside the namespace mutate AND audit with the named actor', async () => {
+    const { service, calls, audits } = harness();
+    await service.ensureRole({ roleKey: 'facilitation-abc', label: 'Initiator conv abc' });
+    await service.addHolder({ roleKey: 'facilitation-abc', holderId: 'owner@co.com', actor: 'plugin:@omadia/agent-facilitator' });
+    await service.removeHolder({ roleKey: 'facilitation-abc', holderId: 'owner@co.com', actor: 'conductor-ephemeral-reaper' });
+
+    assert.deepEqual(calls, ['createRole:facilitation-abc', 'addHolder:owner@co.com', 'removeHolder:owner@co.com']);
+    assert.deepEqual(audits, [
+      { action: 'add', roleKey: 'facilitation-abc', holderId: 'owner@co.com', actor: 'plugin:@omadia/agent-facilitator' },
+      { action: 'remove', roleKey: 'facilitation-abc', holderId: 'owner@co.com', actor: 'conductor-ephemeral-reaper' },
+    ]);
+  });
+
+  it('a failing audit write is logged, never blocks the assignment', async () => {
+    const logs: string[] = [];
+    const holders: string[] = [];
+    const service = createScopedRoleAssignments({
+      roleStore: {
+        createRole: async () => undefined,
+        addHolder: async (_k: string, h: string) => {
+          holders.push(h);
+        },
+        removeHolder: async () => undefined,
+        resolve: async () => holders,
+      } as unknown as ConductorRoleStore,
+      auditRoleChange: async () => {
+        throw new Error('audit sink down');
+      },
+      log: (m) => logs.push(m),
+    });
+    await service.addHolder({ roleKey: 'facilitation-x', holderId: 'a@co.com', actor: 'p' });
+    assert.deepEqual(holders, ['a@co.com']);
+    assert.ok(logs.some((l) => l.includes('audit')));
+  });
+});

--- a/middleware/test/observedConversationInvites.test.ts
+++ b/middleware/test/observedConversationInvites.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import type { ConversationMembershipEvent } from '@omadia/channel-sdk';
+
+import { ConversationEventHub } from '../src/channels/conversationEventHub.js';
+import { ObservedConversationInvites } from '../src/platform/observedConversationInvites.js';
+
+// #330 C2a — the auto-bind scope guard's data source. Only kernel-observed
+// GROUP bot_added events count; everything else must never make a
+// conversation bindable.
+
+function botAdded(overrides: Partial<ConversationMembershipEvent> = {}): ConversationMembershipEvent {
+  return {
+    kind: 'bot_added',
+    channelId: 'de.byte5.channel.teams',
+    channelType: 'teams',
+    conversationId: 'conv-1',
+    conversationType: 'group',
+    members: [{ kind: 'teams-aad', id: 'bot' }],
+    addedBy: { kind: 'teams-aad', id: 'aad-owner', displayName: 'Owner' },
+    occurredAt: '2026-08-21T10:00:00.000Z',
+    ...overrides,
+  } as ConversationMembershipEvent;
+}
+
+describe('ObservedConversationInvites', () => {
+  it('records a group bot_added (via the hub) with the inviter', () => {
+    const hub = new ConversationEventHub();
+    const invites = new ObservedConversationInvites();
+    invites.attach(hub);
+    hub.emit(botAdded());
+
+    const invite = invites.get('teams', 'conv-1');
+    assert.equal(invite?.channelType, 'teams');
+    assert.equal(invite?.addedBy?.id, 'aad-owner');
+  });
+
+  it('ignores 1:1, unknown-type and non-invite events — no positive statement, no eligibility', () => {
+    const invites = new ObservedConversationInvites();
+    invites.observe(botAdded({ conversationType: 'direct', conversationId: 'dm-1' }));
+    const noConvType = botAdded({ conversationId: 'unknown-1' });
+    delete (noConvType as { conversationType?: string }).conversationType;
+    invites.observe(noConvType);
+    const noChannelType = botAdded({ conversationId: 'nochan-1' });
+    delete (noChannelType as { channelType?: string }).channelType;
+    invites.observe(noChannelType);
+    invites.observe(botAdded({ kind: 'members_added', conversationId: 'grp-2' }));
+
+    assert.equal(invites.get('teams', 'dm-1'), undefined);
+    assert.equal(invites.get('teams', 'unknown-1'), undefined);
+    assert.equal(invites.get('teams', 'grp-2'), undefined);
+    assert.equal(invites.get('teams', 'nochan-1'), undefined);
+  });
+
+  it('expires invites after the TTL', () => {
+    let now = 1_000_000;
+    const invites = new ObservedConversationInvites({ ttlMs: 60_000, now: () => now });
+    invites.observe(botAdded());
+    assert.ok(invites.get('teams', 'conv-1'));
+    now += 61_000;
+    assert.equal(invites.get('teams', 'conv-1'), undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Workstream **C2a** of the omadia Facilitator epic (#330): **zero-touch setup**. The three manual operator steps (create the `facilitator` agent, bind the group conversation, assign the initiator role) become kernel-mediated automation — with the guards to make that safe.

**Three new plugin-facing, deny-by-default kernel services** (manifest `optional_requires` is the gate):
- `agentProvisioning.ensureAgent` — idempotent agent creation; persona seeded **create-only** via the Wave-8 `agent_persona_skills` path with the skill slug **namespaced under the agent slug** (an existing skills row is never overwritten — cross-agent prompt-injection guard). An existing agent and its operator-configured `agent_plugins` row are **never mutated** (no config wipe, no re-enable); the `fallback` slug is never manageable. `configStore`/`orchestratorRegistry` are resolved **lazily per call** (the orchestrator plugin publishes them at its own activation).
- `conversationBindings` — `bind` only for conversations the **kernel itself** observed a group `bot_added` for (invite index subscribed directly at the ConversationEventHub, keyed `channelType::conversationId`, TTL 24h); `unbind` guarded to the caller's **own** ephemeral attachments (operator bindings unreachable — the steal path via unbind+rebind is closed); a pre-existing operator binding is usable but **never adopted** into the self-disposing lifecycle; `attachWorkflow` guarded to the caller's own pending row. Bind/unbind land in the new `channel.binding_change` audit action.
- `conductorRoleAssignments` — role writes hard-confined to the `facilitation-` prefix; every holder mutation goes through the #759 `conductor.role_holders_change` audit sink (actor = plugin or reaper).

**Ephemeral coupling** (migration `0010_ephemeral_attachments.sql`): auto-provisioned bindings/roles live exactly as long as their workflow. ONE shared disposal path is constructed **before** `wireConductor` (the reaper's boot tick fires inside it — restart with expired ephemerals is the normal case); rows only disappear **after** successful cleanup, and the attachment sweep retries expired `pending` and expired `attached` rows. No leaked binding survives a failed reap cleanup.

## Test plan

- [x] typecheck / lint green; test-tree ratchet flat (371 baseline)
- [x] Full suite: **7183 tests, 0 fail** (16 pre-existing skips)
- [x] 29 new/extended tests, incl. the review-driven security regressions: unbind refuses foreign attachments AND operator bindings; attachWorkflow only takes the owner's pending row; persona-skill namespace enforcement; no upsert on an existing `agent_plugins` row; operator binding never adopted (no pending row); composite invite key rejects channel-type mismatches; onReaped runs before markReaped and its failure never blocks the reap; expired-attached listing as the retry path
- [ ] Live check post-merge: invite → auto-bind (announced) → facilitation → reap disposes binding + role (audit trail shows `channel.binding_change` + role batons)

**Note:** the `schema` CI job does not yet re-apply `src/conductor/migrations` (pre-existing gap, listed as "still uncovered" in ci.yml) — `0010` is IF-NOT-EXISTS/DROP-ADD idempotent and tracked by the conductor migrator ledger.

Reviewed by omadia-reviewer; all findings addressed (H1 unbind guard + audit, H2/H2b retry truth + pre-wiring cleanup construction, H3 create-only namespaced skills, H4 no operator-config wipe, H5 no adoption of operator bindings, M1 attach guard, M3 composite invite key, L1/L2/L4 audits, agent re-stamp, changelog wording).

Part of #330 — done: A (#818), B1 (#822), B2 (channel-teams 0.13.0), C1 (agent-facilitator 0.1.0). Next: C2b (facilitator 0.2.0 consumes these services).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789900751&installation_model_id=428086&pr_number=827&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F827&signature=a312d22bd1598e223ff89edefc42bdac2505ed2417ab92507d174b62ed6ece15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->