### PR TITLE
feat(update): blocking progress dialog with stepper, visible polling, decoded rollback

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,24 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Changed — Admin → Update shows the run as a blocking progress dialog (#432 follow-up)
+
+- **The updater sidecar reports structured progress.** `GET /status` gains
+  `phase` (`resolve | preflight | pin | replace | health_gate | rollback | done`,
+  `null` while idle) and `failure` (`{kind:'health_gate', reason, observedVersion}`
+  or `{kind:'replace', service}`, `null` otherwise). `runUpdate` takes an
+  optional `setPhase` hook. The middleware's `/api/v1/admin/update/status`
+  passes both through (normalised to `null` for an older sidecar) together
+  with `previousVersion`, `startedAt` and `finishedAt`.
+- **Admin → Update blocks the page while an update runs** and shows a stepper
+  driven by `phase`, the polling itself (cadence, checks, last answer, and the
+  restart gap as "middleware is not answering — expected"), and a decoded
+  outcome. A `never_reachable` health gate is explained with its likely cause
+  (a newly required secret such as `CREDENTIAL_KEYCHAIN_KEY`, a failed
+  migration) and a link to `docs/upgrading.md`. The run is remembered in
+  `localStorage`, so the dialog resumes after the admin UI container itself is
+  replaced; a stale `rolled_back` from an earlier job cannot close a fresh run.
+
 ### Added — "Sign in with ChatGPT" subscription provider (#294, experimental)
 
 - **Connect a ChatGPT subscription as an LLM provider via OAuth, no API key.**

--- a/middleware/sidecars/updater/README.md
+++ b/middleware/sidecars/updater/README.md
@@ -53,9 +53,22 @@ Mirrored by `middleware/src/update/updaterClient.ts`.
   "startedAt": "2026-08-13T…",
   "finishedAt": null,
   "error": null,
-  "steps": ["2026-08-13T… pulling ghcr.io/byte5ai/omadia-middleware:v0.75.0", "…"]
+  "steps": ["2026-08-13T… pulling ghcr.io/byte5ai/omadia-middleware:v0.75.0", "…"],
+  // which of the six numbered steps the job is in; null while idle
+  "phase": "resolve|preflight|pin|replace|health_gate|rollback|done",
+  // structured reason for a failed / rolled_back outcome, null otherwise:
+  //   { "kind": "health_gate", "reason": "never_reachable|version_never_matched", "observedVersion": "v0.90.1"|null }
+  //   { "kind": "replace", "service": "middleware" }
+  "failure": null
 }
 ```
+
+`phase` and `failure` exist so the admin page can render a stepper and a
+decoded failure reason without parsing the English `steps` trail. A health
+gate `never_reachable` with `observedVersion: null` means the new image never
+answered `/health` at all — in practice almost always a boot-time failure of the
+new version (a newly required secret, see `docs/upgrading.md`), not a network
+problem.
 
 `POST /update` answers **before** the work starts, on purpose: the update
 recreates the middleware container that is waiting on the response, so holding

--- a/middleware/sidecars/updater/src/server.mjs
+++ b/middleware/sidecars/updater/src/server.mjs
@@ -40,6 +40,12 @@ function createState() {
     finishedAt: null,
     error: null,
     steps: [],
+    /** Current step of the job (`UpdatePhase` in updateJob.mjs); null while
+     *  idle. Lets the admin page render a stepper instead of parsing `steps`. */
+    phase: null,
+    /** Structured reason for a non-`succeeded` outcome (`UpdateFailure`);
+     *  null while idle, updating, or after success. */
+    failure: null,
   };
 }
 
@@ -149,6 +155,7 @@ export function createServer(deps = {}) {
         config,
         targetVersion,
         log,
+        setPhase: (phase) => { status.phase = phase; },
       });
       status.state = result.ok
         ? 'succeeded'
@@ -156,6 +163,7 @@ export function createServer(deps = {}) {
           ? 'rolled_back'
           : 'failed';
       status.error = result.error ?? null;
+      status.failure = result.failure ?? null;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log(`update aborted: ${message}`);

--- a/middleware/sidecars/updater/src/updateJob.mjs
+++ b/middleware/sidecars/updater/src/updateJob.mjs
@@ -32,14 +32,50 @@ import { waitForHealthyVersion } from './health.mjs';
 export { detectComposeProject } from './engine/docker.mjs';
 
 /**
+ * The six numbered steps above, as a machine-readable progress marker. The
+ * free-text trail (`log`) is for humans reading a log; the phase is what the
+ * admin page renders as a stepper, so it must not depend on parsing English.
+ *
+ * @typedef {'resolve' | 'preflight' | 'pin' | 'replace' | 'health_gate' | 'rollback' | 'done'} UpdatePhase
+ */
+
+/**
+ * Why an update did not land, in a shape the UI can decode without parsing
+ * the human-readable `error` string.
+ *
+ *   - `health_gate` — every service was replaced but the middleware never
+ *     reported the target version. `reason` is the health waiter's verdict
+ *     (`never_reachable` / `version_never_matched`), `observedVersion` what
+ *     `/health` last said, if anything.
+ *   - `replace` — a service could not be moved to the new image.
+ *
+ * @typedef {{
+ *   kind: 'health_gate',
+ *   reason: string,
+ *   observedVersion: string | null,
+ * } | {
+ *   kind: 'replace',
+ *   service: string | null,
+ * }} UpdateFailure
+ *
+ * @typedef {{
+ *   ok: boolean,
+ *   rolledBack: boolean,
+ *   error?: string,
+ *   failure?: UpdateFailure,
+ * }} UpdateResult
+ */
+
+/**
  * @param {{
  *   engine: import('./engine/index.mjs').UpdateEngine,
  *   config: any,
  *   targetVersion: string,
  *   log: (msg: string) => void,
+ *   setPhase?: (phase: UpdatePhase) => void,
  *   healthWaiter?: typeof waitForHealthyVersion,
  * }} opts
- * @returns {Promise<{ ok: boolean, rolledBack: boolean, error?: string }>}
+ * @returns {Promise<UpdateResult>}
  */
 export async function runUpdate(opts) {
   const {
@@ -47,10 +83,12 @@ export async function runUpdate(opts) {
     config,
     targetVersion,
     log,
+    setPhase = () => {},
     healthWaiter = waitForHealthyVersion,
   } = opts;
 
   // 1 — resolve targets before touching anything.
+  setPhase('resolve');
   const targets = [];
   for (const service of config.services) {
     if (PROTECTED_SERVICES.includes(service) || service === config.selfService) {
@@ -63,9 +101,11 @@ export async function runUpdate(opts) {
   }
 
   // 2 — every new image must be obtainable before anything is replaced.
+  setPhase('preflight');
   await engine.preflight(targets, targetVersion, log);
 
   // 3 — persist the pin, where the platform allows it.
+  setPhase('pin');
   let previousPin = null;
   if (engine.canPersistPin) {
     try {
@@ -83,9 +123,12 @@ export async function runUpdate(opts) {
   }
 
   // 4 — replace.
+  setPhase('replace');
   const replaced = [];
+  let replacing = null;
   try {
     for (const target of targets) {
+      replacing = target.service;
       // Recorded BEFORE the call, not after. `replace()` can fail *past the
       // point of mutation* — on Fly the machine is already carrying the new
       // image when the wait-for-started step throws — and a bookkeeping entry
@@ -100,11 +143,18 @@ export async function runUpdate(opts) {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log(`replace failed: ${message}`);
+    setPhase('rollback');
     await rollback({ engine, replaced, previousPin, log });
-    return { ok: false, rolledBack: true, error: message };
+    return {
+      ok: false,
+      rolledBack: true,
+      error: message,
+      failure: { kind: 'replace', service: replacing },
+    };
   }
 
   // 5 — health gate on the NEW version.
+  setPhase('health_gate');
   log(`waiting for ${config.healthUrl} to report ${targetVersion}`);
   const health = await healthWaiter({
     url: config.healthUrl,
@@ -114,14 +164,25 @@ export async function runUpdate(opts) {
   });
   if (health.ok) {
     log(`health gate passed (${health.reason})`);
+    setPhase('done');
     return { ok: true, rolledBack: false };
   }
 
   // 6 — revert.
   const reason = `health gate failed: ${health.reason} (observed version: ${health.observedVersion ?? 'none'})`;
   log(reason);
+  setPhase('rollback');
   await rollback({ engine, replaced, previousPin, log });
-  return { ok: false, rolledBack: true, error: reason };
+  return {
+    ok: false,
+    rolledBack: true,
+    error: reason,
+    failure: {
+      kind: 'health_gate',
+      reason: health.reason,
+      observedVersion: health.observedVersion ?? null,
+    },
+  };
 }
 
 /**

--- a/middleware/sidecars/updater/test/server.test.mjs
+++ b/middleware/sidecars/updater/test/server.test.mjs
@@ -29,12 +29,18 @@ describe('updater HTTP control plane (#432)', () => {
       config: CONFIG,
       docker: {},
       detectProjectImpl: async () => 'omadia',
-      runUpdateImpl: async ({ targetVersion, log }) => {
+      runUpdateImpl: async ({ targetVersion, log, setPhase }) => {
         log(`fake update to ${targetVersion}`);
+        setPhase('health_gate');
         // Hold the job open so the in-progress assertions are not racing a
         // job that already finished.
         await started;
-        return { ok: true, rolledBack: false };
+        return {
+          ok: false,
+          rolledBack: true,
+          error: 'health gate failed: never_reachable (observed version: none)',
+          failure: { kind: 'health_gate', reason: 'never_reachable', observedVersion: null },
+        };
       },
     });
     server = created.server;
@@ -79,6 +85,8 @@ describe('updater HTTP control plane (#432)', () => {
     const body = await res.json();
     assert.equal(body.state, 'idle');
     assert.equal(body.targetVersion, null);
+    assert.equal(body.phase, null);
+    assert.equal(body.failure, null);
   });
 
   it('rejects a floating target tag', async () => {
@@ -106,6 +114,8 @@ describe('updater HTTP control plane (#432)', () => {
     const status = await (await fetch(`${base}/status`, { headers: auth })).json();
     assert.equal(status.state, 'updating');
     assert.equal(status.targetVersion, 'v0.75.0');
+    assert.equal(status.phase, 'health_gate', 'the job phase is exposed while in flight');
+    assert.equal(status.failure, null);
   });
 
   it('refuses a second update while one is in flight', async () => {
@@ -116,6 +126,20 @@ describe('updater HTTP control plane (#432)', () => {
     });
     assert.equal(res.status, 409);
     assert.equal((await res.json()).error, 'update_in_progress');
+  });
+
+  it('exposes the structured failure once the job has rolled back', async () => {
+    resolveStarted();
+    await new Promise((r) => setTimeout(r, 20));
+    const status = await (await fetch(`${base}/status`, { headers: auth })).json();
+    assert.equal(status.state, 'rolled_back');
+    assert.deepEqual(status.failure, {
+      kind: 'health_gate',
+      reason: 'never_reachable',
+      observedVersion: null,
+    });
+    assert.match(status.error, /never_reachable/);
+    assert.ok(status.finishedAt, 'finishedAt is stamped');
   });
 
   it('404s an unknown route', async () => {

--- a/middleware/sidecars/updater/test/updateJob.test.mjs
+++ b/middleware/sidecars/updater/test/updateJob.test.mjs
@@ -171,6 +171,88 @@ describe('runUpdate (#432)', () => {
     assert.equal(middleware.Config.Image, 'ghcr.io/byte5ai/omadia-middleware:v0.74.0');
   });
 
+  it('reports every phase in order and ends on `done` when the gate passes', async () => {
+    const docker = createFakeDocker({ services: SERVICES });
+    const envFile = await makeEnvFile();
+    const phases = [];
+
+    const result = await runUpdate({
+      engine: createDockerEngine({ docker, config: makeConfig(envFile), project: 'omadia' }),
+      config: makeConfig(envFile),
+      targetVersion: 'v0.75.0',
+      log,
+      setPhase: (p) => phases.push(p),
+      healthWaiter: async () => ({ ok: true, reason: 'version_match', observedVersion: 'v0.75.0' }),
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.failure, undefined);
+    assert.deepEqual(phases, ['resolve', 'preflight', 'pin', 'replace', 'health_gate', 'done']);
+  });
+
+  it('returns a structured health_gate failure the UI can decode without parsing text', async () => {
+    const docker = createFakeDocker({ services: SERVICES });
+    const envFile = await makeEnvFile();
+    const phases = [];
+
+    const result = await runUpdate({
+      engine: createDockerEngine({ docker, config: makeConfig(envFile), project: 'omadia' }),
+      config: makeConfig(envFile),
+      targetVersion: 'v0.75.0',
+      log,
+      setPhase: (p) => phases.push(p),
+      healthWaiter: async () => ({ ok: false, reason: 'never_reachable', observedVersion: null }),
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.rolledBack, true);
+    assert.deepEqual(result.failure, {
+      kind: 'health_gate',
+      reason: 'never_reachable',
+      observedVersion: null,
+    });
+    // The human trail still carries the same verdict — the two must not drift.
+    assert.match(result.error, /health gate failed: never_reachable \(observed version: none\)/);
+    assert.equal(phases.at(-1), 'rollback');
+    assert.ok(phases.includes('health_gate'));
+  });
+
+  it('names the service that could not be replaced in the failure', async () => {
+    const docker = createFakeDocker({
+      services: SERVICES,
+      failCreateFor: 'omadia-web-ui:v0.75.0',
+    });
+    const envFile = await makeEnvFile();
+    const phases = [];
+
+    const result = await runUpdate({
+      engine: createDockerEngine({ docker, config: makeConfig(envFile), project: 'omadia' }),
+      config: makeConfig(envFile),
+      targetVersion: 'v0.75.0',
+      log,
+      setPhase: (p) => phases.push(p),
+      healthWaiter: async () => {
+        throw new Error('health gate must not be reached');
+      },
+    });
+
+    assert.deepEqual(result.failure, { kind: 'replace', service: 'web-ui' });
+    assert.deepEqual(phases, ['resolve', 'preflight', 'pin', 'replace', 'rollback']);
+  });
+
+  it('works without a setPhase hook (older callers)', async () => {
+    const docker = createFakeDocker({ services: SERVICES });
+    const envFile = await makeEnvFile();
+    const result = await runUpdate({
+      engine: createDockerEngine({ docker, config: makeConfig(envFile), project: 'omadia' }),
+      config: makeConfig(envFile),
+      targetVersion: 'v0.75.0',
+      log,
+      healthWaiter: async () => ({ ok: true, reason: 'version_match', observedVersion: 'v0.75.0' }),
+    });
+    assert.equal(result.ok, true);
+  });
+
   it('refuses a protected service even if it is configured', async () => {
     const docker = createFakeDocker({ services: { postgres: 'pgvector/pgvector:pg17' } });
     const envFile = await makeEnvFile();

--- a/middleware/src/routes/adminUpdate.ts
+++ b/middleware/src/routes/adminUpdate.ts
@@ -6,7 +6,11 @@ import type { UpdateAuditStore } from '../update/auditStore.js';
 import type { ReleaseLookup } from '../update/releaseLookup.js';
 import { releaseIsNewer } from '../update/releaseLookup.js';
 import { parseVersion, toTag } from '../update/semver.js';
-import type { UpdaterClient } from '../update/updaterClient.js';
+import type {
+  UpdaterClient,
+  UpdaterFailure,
+  UpdaterPhase,
+} from '../update/updaterClient.js';
 import type { PlatformInfo } from '../update/platform.js';
 import type { AppVersion } from '../update/version.js';
 
@@ -76,8 +80,13 @@ export function createAdminUpdateRouter(deps: AdminUpdateDeps): Router {
       reachable: boolean;
       state?: string;
       targetVersion?: string | null;
+      previousVersion?: string | null;
+      startedAt?: string | null;
+      finishedAt?: string | null;
       error?: string;
       steps?: readonly string[];
+      phase?: UpdaterPhase | null;
+      failure?: UpdaterFailure | null;
       engine?: string;
       pinPersisted?: boolean;
     } = { configured: false, reachable: false };
@@ -90,7 +99,16 @@ export function createAdminUpdateRouter(deps: AdminUpdateDeps): Router {
             reachable: true,
             state: status.status.state,
             targetVersion: status.status.targetVersion,
+            previousVersion: status.status.previousVersion,
+            startedAt: status.status.startedAt,
+            finishedAt: status.status.finishedAt,
             steps: status.status.steps,
+            // Structured progress + outcome so the page can render a stepper
+            // and decode a failed health gate instead of parsing `steps`.
+            // Normalised to null (not undefined) so the JSON shape is stable
+            // whether or not the sidecar is new enough to send them.
+            phase: status.status.phase ?? null,
+            failure: status.status.failure ?? null,
             // #696 — the executor tells us which platform it drives and
             // whether it can make the chosen version stick. Both are passed
             // through so the UI can warn instead of implying a guarantee the

--- a/middleware/src/update/updaterClient.ts
+++ b/middleware/src/update/updaterClient.ts
@@ -20,6 +20,28 @@ export type UpdaterState =
   | 'failed'
   | 'rolled_back';
 
+/** Which of the job's numbered steps is running — see
+ *  `sidecars/updater/src/updateJob.mjs`. Absent on an older sidecar. */
+export type UpdaterPhase =
+  | 'resolve'
+  | 'preflight'
+  | 'pin'
+  | 'replace'
+  | 'health_gate'
+  | 'rollback'
+  | 'done';
+
+/** Structured reason for a `failed` / `rolled_back` outcome, so the admin
+ *  page can explain it without parsing the English `error` string. */
+export type UpdaterFailure =
+  | {
+      readonly kind: 'health_gate';
+      /** `never_reachable` | `version_never_matched` (health.mjs verdicts). */
+      readonly reason: string;
+      readonly observedVersion: string | null;
+    }
+  | { readonly kind: 'replace'; readonly service: string | null };
+
 export interface UpdaterStatus {
   readonly state: UpdaterState;
   readonly targetVersion: string | null;
@@ -29,6 +51,10 @@ export interface UpdaterStatus {
   readonly error: string | null;
   /** Human-readable progress trail, newest last. */
   readonly steps: readonly string[];
+  /** Current job step; null while idle. Absent on an older sidecar. */
+  readonly phase?: UpdaterPhase | null;
+  /** Why the last job did not land; null otherwise. Absent on an older sidecar. */
+  readonly failure?: UpdaterFailure | null;
   /** Which executor the sidecar runs (#696). Absent on an older sidecar. */
   readonly engine?: 'docker' | 'fly';
   /**

--- a/middleware/test/adminUpdateRoute.test.ts
+++ b/middleware/test/adminUpdateRoute.test.ts
@@ -189,6 +189,11 @@ interface StatusBody {
     reachable: boolean;
     state?: string;
     error?: string;
+    phase?: string | null;
+    failure?: unknown;
+    startedAt?: string | null;
+    finishedAt?: string | null;
+    previousVersion?: string | null;
   };
   auditAvailable: boolean;
   platform: { kind: string; appName?: string; machineId?: string };
@@ -239,6 +244,39 @@ describe('GET /api/v1/admin/update/status', () => {
     assert.equal(body.executor.configured, true);
     assert.equal(body.executor.reachable, false);
     assert.equal(body.executor.error, 'ECONNREFUSED');
+  });
+
+  it('passes the sidecar job phase, timestamps and structured failure through', async () => {
+    const { client } = fakeUpdater({
+      state: 'rolled_back',
+      targetVersion: 'v0.120.0',
+      previousVersion: 'v0.90.1',
+      startedAt: '2026-08-21T09:56:19.000Z',
+      finishedAt: '2026-08-21T10:02:47.000Z',
+      error: 'health gate failed: never_reachable (observed version: none)',
+      phase: 'rollback',
+      failure: { kind: 'health_gate', reason: 'never_reachable', observedVersion: null },
+    });
+    const { baseUrl } = harness({ updater: client });
+    const body = await readJson<StatusBody>(await fetch(`${baseUrl}/status`));
+    assert.equal(body.executor.state, 'rolled_back');
+    assert.equal(body.executor.phase, 'rollback');
+    assert.deepEqual(body.executor.failure, {
+      kind: 'health_gate',
+      reason: 'never_reachable',
+      observedVersion: null,
+    });
+    assert.equal(body.executor.previousVersion, 'v0.90.1');
+    assert.equal(body.executor.startedAt, '2026-08-21T09:56:19.000Z');
+    assert.equal(body.executor.finishedAt, '2026-08-21T10:02:47.000Z');
+  });
+
+  it('normalises phase/failure to null for a sidecar that predates them', async () => {
+    const { client } = fakeUpdater({ state: 'idle' });
+    const { baseUrl } = harness({ updater: client });
+    const body = await readJson<StatusBody>(await fetch(`${baseUrl}/status`));
+    assert.equal(body.executor.phase, null);
+    assert.equal(body.executor.failure, null);
   });
 
   it('still answers when the release check is offline', async () => {

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -5103,6 +5103,25 @@ export type UpdaterState =
   | 'failed'
   | 'rolled_back';
 
+export type UpdaterPhase =
+  | 'resolve'
+  | 'preflight'
+  | 'pin'
+  | 'replace'
+  | 'health_gate'
+  | 'rollback'
+  | 'done';
+
+export type UpdaterFailure =
+  | {
+      kind: 'health_gate';
+      /** `never_reachable` | `version_never_matched` — the health waiter's
+       *  verdict. Kept as string so an unknown future verdict still renders. */
+      reason: string;
+      observedVersion: string | null;
+    }
+  | { kind: 'replace'; service: string | null };
+
 export interface UpdateStatus {
   current: { version: string; source: AppVersionSource };
   latest: {
@@ -5118,8 +5137,16 @@ export interface UpdateStatus {
     reachable: boolean;
     state?: UpdaterState;
     targetVersion?: string | null;
+    previousVersion?: string | null;
+    startedAt?: string | null;
+    finishedAt?: string | null;
     error?: string;
     steps?: string[];
+    /** Which of the job's steps is running; null while idle or on a sidecar
+     *  that predates the field. Drives the progress stepper. */
+    phase?: UpdaterPhase | null;
+    /** Structured reason for `failed` / `rolled_back`; null otherwise. */
+    failure?: UpdaterFailure | null;
     /** Which executor drives the update (#696). */
     engine?: 'docker' | 'fly';
     /** False on Fly: the chosen version does NOT survive the operator's next

--- a/web-ui/app/admin/update/__tests__/page.test.tsx
+++ b/web-ui/app/admin/update/__tests__/page.test.tsx
@@ -73,7 +73,10 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks();
+  window.localStorage.clear();
 });
+
+const INFLIGHT_KEY = 'omadia.adminUpdate.inflight';
 
 describe('/admin/update', () => {
   it('reports the running version and that a newer release exists', async () => {
@@ -242,7 +245,207 @@ describe('/admin/update', () => {
         confirm: 'v0.75.0',
       });
     });
-    expect(await screen.findByText(/update in progress/i)).toBeInTheDocument();
+    // The page is covered by the progress dialog, not decorated with a box.
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveAttribute('data-outcome', 'running');
+    expect(screen.getByRole('heading', { name: /updating to v0\.75\.0/i })).toBeInTheDocument();
+    expect(screen.getByTestId('polling-indicator')).toBeInTheDocument();
+    // The dialog cannot be dismissed while running.
+    expect(screen.queryByRole('button', { name: /^close$/i })).not.toBeInTheDocument();
+    // And the run is remembered, so a reload of the (replaced) admin UI resumes it.
+    const remembered = JSON.parse(window.localStorage.getItem(INFLIGHT_KEY) ?? 'null') as
+      | { target: string; previous: string | null }
+      | null;
+    expect(remembered).toMatchObject({ target: 'v0.75.0', previous: 'v0.74.0' });
+  });
+
+  it('resumes the dialog after a reload from the remembered run', async () => {
+    window.localStorage.setItem(
+      INFLIGHT_KEY,
+      JSON.stringify({ target: 'v0.75.0', previous: 'v0.74.0', startedAt: Date.now() }),
+    );
+    mockGetUpdateStatus.mockResolvedValue(
+      status({
+        executor: {
+          configured: true, reachable: true, state: 'updating', targetVersion: 'v0.75.0',
+          startedAt: new Date().toISOString(), phase: 'health_gate', steps: ['leased', 'waiting'],
+        },
+      }),
+    );
+    renderWithIntl(<UpdateClient />);
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveAttribute('data-outcome', 'running');
+    // The stepper follows the sidecar's phase, not the text trail.
+    await waitFor(() => {
+      expect(dialog.querySelector('[data-step="health_gate"]')).toHaveAttribute('data-state', 'current');
+    });
+    expect(dialog.querySelector('[data-step="replace"]')).toHaveAttribute('data-state', 'done');
+  });
+
+  it('adopts an update started from somewhere else', async () => {
+    mockGetUpdateStatus.mockResolvedValue(
+      status({
+        executor: {
+          configured: true, reachable: true, state: 'updating', targetVersion: 'v0.75.0',
+          previousVersion: 'v0.74.0', startedAt: new Date().toISOString(), phase: 'replace', steps: [],
+        },
+      }),
+    );
+    renderWithIntl(<UpdateClient />);
+    expect(await screen.findByRole('dialog')).toHaveAttribute('data-outcome', 'running');
+  });
+
+  it('shows the middleware as not answering — not as an error — while it restarts', async () => {
+    window.localStorage.setItem(
+      INFLIGHT_KEY,
+      JSON.stringify({ target: 'v0.75.0', previous: 'v0.74.0', startedAt: Date.now() }),
+    );
+    mockGetUpdateStatus.mockRejectedValue(new Error('fetch failed'));
+    renderWithIntl(<UpdateClient />);
+
+    const indicator = await screen.findByTestId('polling-indicator');
+    await waitFor(() => {
+      expect(indicator).toHaveAttribute('data-reachable', 'false');
+    });
+    expect(screen.getByText(/not answering/i)).toBeInTheDocument();
+    expect(screen.queryByText(/could not load the update status/i)).not.toBeInTheDocument();
+  });
+
+  it('turns into the success view once the middleware reports the target', async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      INFLIGHT_KEY,
+      JSON.stringify({ target: 'v0.75.0', previous: 'v0.74.0', startedAt: Date.now() }),
+    );
+    mockGetUpdateStatus.mockResolvedValue(
+      status({
+        current: { version: 'v0.75.0', source: 'release' },
+        updateAvailable: false,
+        executor: { configured: true, reachable: true, state: 'succeeded', targetVersion: 'v0.75.0', phase: 'done', steps: [] },
+      }),
+    );
+    renderWithIntl(<UpdateClient />);
+
+    const dialog = await screen.findByRole('dialog');
+    await waitFor(() => {
+      expect(dialog).toHaveAttribute('data-outcome', 'succeeded');
+    });
+    expect(screen.getByRole('heading', { name: /updated to v0\.75\.0/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reload admin ui/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^close$/i }));
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(window.localStorage.getItem(INFLIGHT_KEY)).toBeNull();
+  });
+
+  it('explains a health-gate rollback with the likely cause instead of a raw error string', async () => {
+    window.localStorage.setItem(
+      INFLIGHT_KEY,
+      JSON.stringify({ target: 'v0.120.0', previous: 'v0.90.1', startedAt: Date.now() - 6 * 60_000 }),
+    );
+    mockGetUpdateStatus.mockResolvedValue(
+      status({
+        current: { version: 'v0.90.1', source: 'release' },
+        latest: { tag: 'v0.120.0', url: 'https://example.test', publishedAt: '2026-08-21T09:00:00Z', prerelease: false },
+        executor: {
+          configured: true, reachable: true, state: 'rolled_back', targetVersion: 'v0.120.0',
+          previousVersion: 'v0.90.1', startedAt: new Date(Date.now() - 6 * 60_000).toISOString(),
+          finishedAt: new Date().toISOString(), phase: 'rollback',
+          error: 'health gate failed: never_reachable (observed version: none)',
+          failure: { kind: 'health_gate', reason: 'never_reachable', observedVersion: null },
+          steps: ['waiting for http://middleware:8080/health to report v0.120.0', 'health gate failed: never_reachable (observed version: none)', 'rolling back'],
+        },
+      }),
+    );
+    renderWithIntl(<UpdateClient />);
+
+    const dialog = await screen.findByRole('dialog');
+    await waitFor(() => {
+      expect(dialog).toHaveAttribute('data-outcome', 'rolled_back');
+    });
+    expect(screen.getByRole('heading', { name: /update to v0\.120\.0 rolled back/i })).toBeInTheDocument();
+    const explanation = screen.getByTestId('failure-explanation');
+    expect(explanation).toHaveAttribute('data-failure-kind', 'never_reachable');
+    expect(explanation).toHaveTextContent(/never answered \/health/i);
+    expect(explanation).toHaveTextContent(/CREDENTIAL_KEYCHAIN_KEY/);
+    expect(dialog.querySelector('[data-step="health_gate"]')).toHaveAttribute('data-state', 'failed');
+    expect(dialog.querySelector('[data-step="rollback"]')).toHaveAttribute('data-state', 'done');
+    expect(screen.getByRole('link', { name: /docs\/upgrading\.md/i })).toHaveAttribute(
+      'href',
+      expect.stringContaining('docs/upgrading.md'),
+    );
+  });
+
+  it('stays closed after the operator dismisses a stalled run, even while the sidecar still says updating', async () => {
+    const user = userEvent.setup();
+    // A run remembered from 20 minutes ago — past the stall threshold.
+    const startedAt = Date.now() - 20 * 60_000;
+    window.localStorage.setItem(
+      INFLIGHT_KEY,
+      JSON.stringify({ target: 'v0.75.0', previous: 'v0.74.0', startedAt }),
+    );
+    mockGetUpdateStatus.mockResolvedValue(
+      status({
+        executor: {
+          configured: true, reachable: true, state: 'updating', targetVersion: 'v0.75.0',
+          previousVersion: 'v0.74.0', startedAt: new Date(startedAt).toISOString(), phase: 'health_gate', steps: [],
+        },
+      }),
+    );
+    renderWithIntl(<UpdateClient />);
+
+    const dismiss = await screen.findByRole('button', { name: /^dismiss$/i });
+    await user.click(dismiss);
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    // Polls keep returning the same `updating` snapshot; adoption must not reopen it.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(window.localStorage.getItem(INFLIGHT_KEY)).toBeNull();
+  });
+
+  it('drops a remembered run that is older than the TTL instead of resuming it', async () => {
+    window.localStorage.setItem(
+      INFLIGHT_KEY,
+      JSON.stringify({ target: 'v0.75.0', previous: 'v0.74.0', startedAt: Date.now() - 2 * 60 * 60_000 }),
+    );
+    renderWithIntl(<UpdateClient />);
+    await screen.findByText('v0.74.0');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(window.localStorage.getItem(INFLIGHT_KEY)).toBeNull();
+  });
+
+  it('does not let a rollback from an EARLIER run close a freshly started one', async () => {
+    const user = userEvent.setup();
+    // The sidecar still reports last week's rollback for the same target.
+    mockGetUpdateStatus.mockResolvedValue(
+      status({
+        executor: {
+          configured: true, reachable: true, state: 'rolled_back', targetVersion: 'v0.75.0',
+          startedAt: '2026-08-01T00:00:00Z', finishedAt: '2026-08-01T00:06:00Z',
+          failure: { kind: 'health_gate', reason: 'never_reachable', observedVersion: null },
+          error: 'health gate failed', steps: [],
+        },
+      }),
+    );
+    renderWithIntl(<UpdateClient />);
+
+    // Before the click: the decoded banner, not the dialog.
+    expect(await screen.findByTestId('rolled-back-banner')).toHaveTextContent(/never answered \/health/i);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    const input = screen.getByLabelText(/target version/i);
+    await user.type(input, 'v0.75.0');
+    await user.click(screen.getByRole('button', { name: /update to v0\.75\.0/i }));
+
+    const dialog = await screen.findByRole('dialog');
+    // Polls keep returning the OLD rolled_back status; the dialog must stay open.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(dialog).toHaveAttribute('data-outcome', 'running');
   });
 
   it('renders a refused trigger with its own message, not a raw error', async () => {

--- a/web-ui/app/admin/update/__tests__/updateFailure.test.ts
+++ b/web-ui/app/admin/update/__tests__/updateFailure.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+
+import type { UpdateStatus } from '../../../_lib/api';
+import {
+  decodeFailure,
+  deriveOutcome,
+  describesThisRun,
+  stepStates,
+  UPDATE_STEPS,
+  type InflightUpdate,
+} from '../_components/updateFailure';
+
+/**
+ * The pure half of the update dialog: which row is lit, how a failure is
+ * decoded, and — the one that bites — whether the sidecar's status describes
+ * THIS run or a previous one.
+ */
+
+function status(overrides: Partial<UpdateStatus> = {}, executor: Partial<UpdateStatus['executor']> = {}): UpdateStatus {
+  return {
+    current: { version: 'v0.90.1', source: 'release' },
+    latest: null,
+    updateAvailable: true,
+    check: { checkedAt: 1, stale: false },
+    executor: { configured: true, reachable: true, state: 'idle', steps: [], ...executor },
+    auditAvailable: true,
+    ...overrides,
+  };
+}
+
+const RUN: InflightUpdate = { target: 'v0.120.0', previous: 'v0.90.1', startedAt: 1_000_000 };
+
+describe('stepStates', () => {
+  it('lights the current phase and finishes everything before it', () => {
+    const s = stepStates('replace', null, false);
+    expect(s.resolve).toBe('done');
+    expect(s.preflight).toBe('done');
+    expect(s.pin).toBe('done');
+    expect(s.replace).toBe('current');
+    expect(s.health_gate).toBe('pending');
+  });
+
+  it('marks nothing current while the sidecar has not reported a phase', () => {
+    const s = stepStates(null, null, false);
+    expect(Object.values(s).every((v) => v === 'pending')).toBe(true);
+  });
+
+  it('marks every row done on success', () => {
+    const s = stepStates('done', null, true);
+    expect(UPDATE_STEPS.every((step) => s[step] === 'done')).toBe(true);
+  });
+
+  it('marks the health gate failed and the rows before it done after a rollback', () => {
+    const s = stepStates('rollback', { kind: 'health_gate', reason: 'never_reachable', observedVersion: null }, true);
+    expect(s.replace).toBe('done');
+    expect(s.health_gate).toBe('failed');
+  });
+
+  it('marks the row the job was in as failed when it threw without a structured failure', () => {
+    // Unpullable image: the sidecar lands in state=failed, failure=null, phase=preflight.
+    const s = stepStates('preflight', null, true, true);
+    expect(s.resolve).toBe('done');
+    expect(s.preflight).toBe('failed');
+    expect(s.pin).toBe('pending');
+    expect(s.health_gate).toBe('pending');
+  });
+
+  it('does not invent a failed row on success even with the flag unset', () => {
+    const s = stepStates('done', null, true, false);
+    expect(UPDATE_STEPS.every((step) => s[step] === 'done')).toBe(true);
+  });
+
+  it('marks the replace row failed and leaves the gate pending when a service could not be moved', () => {
+    const s = stepStates('rollback', { kind: 'replace', service: 'web-ui' }, true);
+    expect(s.pin).toBe('done');
+    expect(s.replace).toBe('failed');
+    expect(s.health_gate).toBe('pending');
+  });
+});
+
+describe('decodeFailure', () => {
+  it('prefers the structured failure', () => {
+    expect(decodeFailure({ kind: 'health_gate', reason: 'never_reachable', observedVersion: null }, 'whatever'))
+      .toEqual({ kind: 'never_reachable' });
+    expect(decodeFailure({ kind: 'health_gate', reason: 'version_never_matched', observedVersion: 'v0.90.1' }, ''))
+      .toEqual({ kind: 'version_never_matched', observedVersion: 'v0.90.1' });
+    expect(decodeFailure({ kind: 'replace', service: 'middleware' }, ''))
+      .toEqual({ kind: 'replace', service: 'middleware' });
+  });
+
+  it('falls back to the trail line for a sidecar that predates `failure`', () => {
+    expect(decodeFailure(null, 'health gate failed: never_reachable (observed version: none)'))
+      .toEqual({ kind: 'never_reachable' });
+    expect(decodeFailure(undefined, 'something else')).toEqual({ kind: 'unknown', message: 'something else' });
+  });
+
+  it('does not invent a reason for an unknown health verdict', () => {
+    expect(decodeFailure({ kind: 'health_gate', reason: 'future_verdict', observedVersion: null }, 'msg'))
+      .toEqual({ kind: 'unknown', message: 'msg' });
+  });
+});
+
+describe('describesThisRun', () => {
+  it('rejects a status for a different target', () => {
+    expect(describesThisRun(status({}, { targetVersion: 'v0.119.0', startedAt: '2026-08-21T10:00:00Z' }).executor, RUN)).toBe(false);
+  });
+
+  it('rejects a job that started long before this click — last week\'s rollback must not close a fresh dialog', () => {
+    const old = new Date(RUN.startedAt - 10 * 60_000).toISOString();
+    expect(describesThisRun(status({}, { targetVersion: RUN.target, state: 'rolled_back', startedAt: old }).executor, RUN)).toBe(false);
+  });
+
+  it('rejects a job that FINISHED before the click even inside the skew window — fast retry after a replace failure', () => {
+    const started = new Date(RUN.startedAt - 20_000).toISOString();
+    const finished = new Date(RUN.startedAt - 5_000).toISOString();
+    expect(describesThisRun(status({}, { targetVersion: RUN.target, state: 'rolled_back', startedAt: started, finishedAt: finished }).executor, RUN)).toBe(false);
+  });
+
+  it('accepts a job that started shortly before the click (clock skew)', () => {
+    const skewed = new Date(RUN.startedAt - 30_000).toISOString();
+    expect(describesThisRun(status({}, { targetVersion: RUN.target, startedAt: skewed }).executor, RUN)).toBe(true);
+  });
+
+  it('accepts a matching target when the sidecar does not stamp startedAt', () => {
+    expect(describesThisRun(status({}, { targetVersion: RUN.target }).executor, RUN)).toBe(true);
+  });
+
+  it('rejects an unreachable executor outright', () => {
+    expect(describesThisRun({ configured: true, reachable: false, targetVersion: RUN.target }, RUN)).toBe(false);
+  });
+});
+
+describe('deriveOutcome', () => {
+  const fresh = new Date(RUN.startedAt + 1_000).toISOString();
+
+  it('is running while nothing has answered', () => {
+    expect(deriveOutcome(null, RUN)).toBe('running');
+  });
+
+  it('is succeeded as soon as the middleware reports the target, whatever the sidecar says', () => {
+    expect(deriveOutcome(status({ current: { version: 'v0.120.0', source: 'release' } }, { reachable: false }), RUN)).toBe('succeeded');
+  });
+
+  it('is rolled_back only for THIS run', () => {
+    const ex = { targetVersion: RUN.target, state: 'rolled_back' as const, startedAt: fresh };
+    expect(deriveOutcome(status({}, ex), RUN)).toBe('rolled_back');
+    const stale = new Date(RUN.startedAt - 3_600_000).toISOString();
+    expect(deriveOutcome(status({}, { ...ex, startedAt: stale }), RUN)).toBe('running');
+  });
+
+  it('is failed when the sidecar could not even roll back', () => {
+    expect(deriveOutcome(status({}, { targetVersion: RUN.target, state: 'failed', startedAt: fresh }), RUN)).toBe('failed');
+  });
+
+  it('stays running while the sidecar is still updating', () => {
+    expect(deriveOutcome(status({}, { targetVersion: RUN.target, state: 'updating', startedAt: fresh, phase: 'health_gate' }), RUN)).toBe('running');
+  });
+});

--- a/web-ui/app/admin/update/_components/UpdateClient.tsx
+++ b/web-ui/app/admin/update/_components/UpdateClient.tsx
@@ -16,6 +16,9 @@ import {
   type UpdateStatus,
 } from '../../../_lib/api';
 
+import { decodeFailure, deriveOutcome, type InflightUpdate } from './updateFailure';
+import { UpdateProgressModal, type PollingInfo } from './UpdateProgressModal';
+
 /**
  * Admin → Update (#432).
  *
@@ -29,7 +32,13 @@ import {
  *   - Polling, not awaiting. Applying an update recreates the container that
  *     served the request, so the trigger answers 202 and this page then polls
  *     `/status` through the restart. Errors during that window are expected,
- *     not failures, and are swallowed while an update is in flight.
+ *     not failures, and are swallowed while an update is in flight — but they
+ *     are SHOWN, in the progress dialog, as "middleware not answering", so
+ *     the operator sees the restart happening instead of a frozen page.
+ *   - The in-flight run survives this page. The web-ui container is replaced
+ *     too, so the tab may reload mid-update; the run is remembered in
+ *     localStorage and the dialog resumes on the next mount. An update started
+ *     from another browser is picked up from the sidecar's `updating` state.
  *   - Honest capability reporting. With no executor configured the page says
  *     so and shows the manual command instead of offering a button that would
  *     answer 409.
@@ -43,6 +52,47 @@ import {
  */
 const IDLE_POLL_MS = 30_000;
 const ACTIVE_POLL_MS = 4_000;
+
+/** localStorage key for the run this browser is watching. */
+const INFLIGHT_KEY = 'omadia.adminUpdate.inflight';
+/** A remembered run older than this is a leftover (tab closed mid-update,
+ *  sidecar restarted since) and is dropped on read instead of resuming as an
+ *  instantly-stalled dialog. Comfortably above the sidecar's 5 min gate plus
+ *  pull and rollback time. */
+const INFLIGHT_TTL_MS = 60 * 60_000;
+
+function readInflight(): InflightUpdate | null {
+  try {
+    const raw = window.localStorage.getItem(INFLIGHT_KEY);
+    if (raw === null) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed === 'object' && parsed !== null &&
+      typeof (parsed as InflightUpdate).target === 'string' &&
+      typeof (parsed as InflightUpdate).startedAt === 'number'
+    ) {
+      const p = parsed as InflightUpdate;
+      if (Date.now() - p.startedAt > INFLIGHT_TTL_MS) {
+        window.localStorage.removeItem(INFLIGHT_KEY);
+        return null;
+      }
+      return { target: p.target, previous: p.previous ?? null, startedAt: p.startedAt };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeInflight(value: InflightUpdate | null): void {
+  try {
+    if (value === null) window.localStorage.removeItem(INFLIGHT_KEY);
+    else window.localStorage.setItem(INFLIGHT_KEY, JSON.stringify(value));
+  } catch {
+    // Storage can be unavailable (private mode, quota); the dialog then just
+    // does not survive a reload, which is a degradation, not a failure.
+  }
+}
 
 /** Error codes the backend returns for a refused trigger. Anything else falls
  *  back to the generic message with the technical detail behind it. */
@@ -75,19 +125,42 @@ export function UpdateClient({ webUiApp }: UpdateClientProps): React.ReactElemen
   const [confirmInput, setConfirmInput] = useState('');
   const [triggering, setTriggering] = useState(false);
   const [triggerError, setTriggerError] = useState<string | null>(null);
-  const [awaitingRestart, setAwaitingRestart] = useState(false);
+  // The run this browser is watching; null when no dialog is open. Restored
+  // from localStorage on mount so a tab reload mid-update resumes the dialog.
+  const [inflight, setInflight] = useState<InflightUpdate | null>(null);
+  const [polling, setPolling] = useState<Omit<PollingInfo, 'intervalMs'>>({
+    lastAttemptAt: null,
+    lastOkAt: null,
+    attempts: 0,
+  });
+
+  useEffect(() => {
+    const remembered = readInflight();
+    if (remembered !== null) setInflight(remembered);
+  }, []);
+
+  // The run the operator dismissed from the stalled state. Until the sidecar
+  // reports something else, its `updating` snapshot is still in `status`, and
+  // without this marker the adoption effect below would reopen the dialog on
+  // the very next render. Keyed on the sidecar's own startedAt so a genuinely
+  // new job for the same target is still adopted.
+  const dismissedRef = useRef<{ target: string; startedAt: string | null } | null>(null);
 
   // Read inside the interval callback without making it a dependency — the
   // poll must not be torn down and rebuilt on every status change. Mirrored in
   // an effect rather than assigned during render (refs are not render state).
   const awaitingRef = useRef(false);
+  const awaitingRestart = inflight !== null;
   useEffect(() => {
     awaitingRef.current = awaitingRestart;
   }, [awaitingRestart]);
 
   const load = useCallback(async (refresh = false): Promise<void> => {
+    const attemptAt = Date.now();
+    let okAt: number | null = null;
     try {
       const next = await getUpdateStatus(refresh);
+      okAt = Date.now();
       setStatus(next);
       setLoadError(null);
       if (next.auditAvailable) {
@@ -97,13 +170,71 @@ export function UpdateClient({ webUiApp }: UpdateClientProps): React.ReactElemen
     } catch (err) {
       // While the stack is restarting the middleware is legitimately gone;
       // surfacing that as an error would make a working update look broken.
+      // The dialog shows the gap as "not answering" from the polling info.
       if (!awaitingRef.current) {
         setLoadError(err instanceof Error ? err.message : String(err));
       }
+    } finally {
+      // Bookkeeping for the dialog's polling indicator: every attempt counts,
+      // and a failed one leaves `lastOkAt` where it was, so "last answer N s
+      // ago" keeps growing while the middleware is down.
+      setPolling((p) => ({
+        lastAttemptAt: attemptAt,
+        attempts: p.attempts + 1,
+        lastOkAt: okAt ?? p.lastOkAt,
+      }));
     }
   }, []);
 
   const active = awaitingRestart || status?.executor.state === 'updating';
+
+  // An update started elsewhere (another tab, another admin, or this tab
+  // before a reload that lost storage) shows up as the sidecar being
+  // `updating`; adopt it so the dialog covers that run too.
+  useEffect(() => {
+    if (inflight !== null || status?.executor.state !== 'updating') return;
+    const target = status.executor.targetVersion;
+    if (typeof target !== 'string' || target.length === 0) return;
+    const dismissed = dismissedRef.current;
+    if (
+      dismissed !== null &&
+      dismissed.target === target &&
+      dismissed.startedAt === (status.executor.startedAt ?? null)
+    ) {
+      return;
+    }
+    const started = typeof status.executor.startedAt === 'string'
+      ? Date.parse(status.executor.startedAt)
+      : NaN;
+    const adopted: InflightUpdate = {
+      target,
+      previous: status.executor.previousVersion ?? status.current.version,
+      startedAt: Number.isNaN(started) ? Date.now() : started,
+    };
+    setInflight(adopted);
+    writeInflight(adopted);
+  }, [inflight, status]);
+
+  const outcome = inflight === null ? 'running' : deriveOutcome(status, inflight);
+  const currentVersion = status?.current.version ?? null;
+
+  const closeDialog = useCallback((): void => {
+    if (inflight !== null) {
+      dismissedRef.current = {
+        target: inflight.target,
+        startedAt: status?.executor.startedAt ?? null,
+      };
+    }
+    setInflight(null);
+    writeInflight(null);
+    setConfirmInput('');
+    void load(true);
+  }, [inflight, load, status?.executor.startedAt]);
+
+  const reloadPage = useCallback((): void => {
+    writeInflight(null);
+    window.location.reload();
+  }, []);
 
   useEffect(() => {
     void load();
@@ -139,15 +270,6 @@ export function UpdateClient({ webUiApp }: UpdateClientProps): React.ReactElemen
     status?.executor.configured === true && status.executor.reachable;
   const updating = status?.executor.state === 'updating';
 
-  // The restart is over once the running build IS the target.
-  useEffect(() => {
-    if (!awaitingRestart || !status) return;
-    if (status.current.version === target && target.length > 0) {
-      setAwaitingRestart(false);
-      setConfirmInput('');
-    }
-  }, [awaitingRestart, status, target]);
-
   const confirmMatches = useMemo(
     () =>
       target.length > 0 &&
@@ -177,8 +299,18 @@ export function UpdateClient({ webUiApp }: UpdateClientProps): React.ReactElemen
     try {
       await triggerUpdate({ targetVersion: target, confirm: confirmInput.trim() });
       // From here the middleware is expected to disappear and come back on the
-      // new image; polling takes over.
-      setAwaitingRestart(true);
+      // new image; polling takes over and the dialog shows it.
+      const run: InflightUpdate = {
+        target,
+        previous: currentVersion,
+        startedAt: Date.now(),
+      };
+      setInflight(run);
+      writeInflight(run);
+      dismissedRef.current = null;
+      // Fresh counters for the dialog; both timestamps reset together so the
+      // indicator does not read "not answering" for the first tick.
+      setPolling({ attempts: 0, lastOkAt: null, lastAttemptAt: null });
     } catch (err) {
       const code = err instanceof ApiError ? err.code : null;
       setTriggerError(
@@ -191,7 +323,24 @@ export function UpdateClient({ webUiApp }: UpdateClientProps): React.ReactElemen
     } finally {
       setTriggering(false);
     }
-  }, [confirmInput, confirmMatches, target, t]);
+  }, [confirmInput, confirmMatches, currentVersion, target, t]);
+
+  const rolledBackBanner = useMemo(() => {
+    if (status?.executor.state !== 'rolled_back' || awaitingRestart) return null;
+    const decoded = decodeFailure(status.executor.failure, status.executor.error);
+    const from = status.executor.targetVersion ?? '?';
+    const to = status.current.version;
+    switch (decoded.kind) {
+      case 'never_reachable':
+        return t('rolledBackNeverReachable', { from, to });
+      case 'version_never_matched':
+        return t('rolledBackVersionNeverMatched', { from, to, observed: decoded.observedVersion });
+      case 'replace':
+        return t('rolledBackReplace', { from, to, service: decoded.service ?? '?' });
+      default:
+        return t('rolledBack', { message: decoded.message });
+    }
+  }, [awaitingRestart, status, t]);
 
   return (
     <main className="mx-auto max-w-[800px] px-6 py-12 lg:px-8 lg:py-16">
@@ -329,25 +478,33 @@ export function UpdateClient({ webUiApp }: UpdateClientProps): React.ReactElemen
         </section>
       )}
 
-      {(updating || awaitingRestart) && (
+      {inflight !== null && (
+        <UpdateProgressModal
+          inflight={inflight}
+          status={status}
+          outcome={outcome}
+          polling={{ ...polling, intervalMs: active ? ACTIVE_POLL_MS : IDLE_POLL_MS }}
+          onClose={closeDialog}
+          onReload={reloadPage}
+        />
+      )}
+
+      {updating && inflight === null && (
         <section className="mb-6 rounded-lg border border-[color:var(--accent)]/40 bg-[color:var(--accent)]/5 p-4 text-sm">
           <h2 className="mb-2 text-[10px] font-semibold tracking-wider uppercase">
             {t('inProgressTitle')}
           </h2>
           <p>{t('inProgressBody')}</p>
-          {(status?.executor.steps ?? []).length > 0 && (
-            <ol className="mt-3 max-h-48 overflow-y-auto font-mono text-xs text-[color:var(--fg-muted)]">
-              {(status?.executor.steps ?? []).map((step) => (
-                <li key={step}>{step}</li>
-              ))}
-            </ol>
-          )}
         </section>
       )}
 
-      {status?.executor.state === 'rolled_back' && !awaitingRestart && (
-        <section className="mb-6 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-4 text-sm text-[color:var(--danger)]">
-          {t('rolledBack', { message: status.executor.error ?? '' })}
+      {rolledBackBanner !== null && (
+        <section
+          data-testid="rolled-back-banner"
+          className="mb-6 rounded-lg border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-4 text-sm text-[color:var(--danger)]"
+        >
+          <p className="font-medium">{rolledBackBanner}</p>
+          <p className="mt-1 text-xs">{t('rolledBackHint')}</p>
         </section>
       )}
 

--- a/web-ui/app/admin/update/_components/UpdateProgressModal.tsx
+++ b/web-ui/app/admin/update/_components/UpdateProgressModal.tsx
@@ -1,0 +1,372 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import { useTranslations } from 'next-intl';
+
+import { Button } from '@/app/_components/ui/Button';
+
+import type { UpdateStatus } from '../../../_lib/api';
+
+import {
+  decodeFailure,
+  describesThisRun,
+  stepStates,
+  UPDATE_STEPS,
+  type InflightUpdate,
+  type Outcome,
+  type StepState,
+} from './updateFailure';
+
+/**
+ * Blocking progress dialog for a running update (#432 follow-up).
+ *
+ * While an update is in flight the rest of the admin page is not usable in
+ * any meaningful way — the middleware behind it is being replaced — so the
+ * dialog covers the page and cannot be dismissed until the job reached a
+ * terminal state. What it shows is deliberately honest about the mechanics:
+ *
+ *   - a stepper driven by the sidecar's `phase`, not by guessing from text
+ *   - the polling itself: cadence, when the last answer came, and whether the
+ *     middleware is currently unreachable (expected during the restart, and
+ *     shown as such rather than as an error)
+ *   - the outcome decoded from the structured `failure`, with the likely cause
+ *     spelled out for the case that actually happens in the field — a new
+ *     image that never came up because it needs a secret the old one did not
+ *
+ * Lume: state colours are text/edge only, progress is text + the busy-dots
+ * exception, no spinners.
+ */
+
+const DOCS_UPGRADING_URL =
+  'https://github.com/byte5ai/omadia/blob/main/docs/upgrading.md';
+/** After this long without a terminal state the dialog offers a way out; the
+ *  sidecar's own health gate is 5 min, so 12 min covers pull + gate + rollback. */
+const STALL_AFTER_MS = 12 * 60_000;
+
+export interface PollingInfo {
+  readonly intervalMs: number;
+  /** Epoch ms of the last `/status` attempt, null before the first. */
+  readonly lastAttemptAt: number | null;
+  /** Epoch ms of the last SUCCESSFUL `/status`, null if none since open. */
+  readonly lastOkAt: number | null;
+  readonly attempts: number;
+}
+
+export interface UpdateProgressModalProps {
+  readonly inflight: InflightUpdate;
+  readonly status: UpdateStatus | null;
+  readonly outcome: Outcome;
+  readonly polling: PollingInfo;
+  readonly onClose: () => void;
+  readonly onReload: () => void;
+}
+
+function useNow(tickMs: number): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const timer = setInterval(() => { setNow(Date.now()); }, tickMs);
+    return () => { clearInterval(timer); };
+  }, [tickMs]);
+  return now;
+}
+
+function formatElapsed(ms: number, seconds: (n: number) => string): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return m > 0 ? `${m}:${String(s).padStart(2, '0')}` : seconds(s);
+}
+
+const STEP_GLYPH: Record<StepState, string> = {
+  done: '✓',
+  current: '›',
+  pending: '·',
+  failed: '✕',
+};
+
+const STEP_CLASS: Record<StepState, string> = {
+  done: 'text-[color:var(--fg-muted)]',
+  current: 'text-[color:var(--fg-strong)] font-medium',
+  pending: 'text-[color:var(--fg-subtle)]',
+  failed: 'text-[color:var(--danger)] font-medium',
+};
+
+export function UpdateProgressModal({
+  inflight,
+  status,
+  outcome,
+  polling,
+  onClose,
+  onReload,
+}: UpdateProgressModalProps): React.ReactElement {
+  const t = useTranslations('adminUpdate.progress');
+  const now = useNow(1000);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  const terminal = outcome !== 'running';
+  // The sidecar's view of the job, only when it describes THIS run. Right
+  // after a retry the React `status` is still the previous job's snapshot
+  // until the next poll lands; reading its phase/trail would show the old
+  // rollback for the new run.
+  const mine = describesThisRun(status?.executor, inflight);
+  const executor = mine ? status?.executor : undefined;
+  const sidecarStarted =
+    typeof executor?.startedAt === 'string' ? Date.parse(executor.startedAt) : NaN;
+  const startedAt = Number.isNaN(sidecarStarted) ? inflight.startedAt : sidecarStarted;
+  const elapsed = now - startedAt;
+  const stalled = !terminal && elapsed > STALL_AFTER_MS;
+  const seconds = (n: number): string => t('seconds', { seconds: n });
+
+  const phase = executor?.phase ?? null;
+  const failure = terminal ? (executor?.failure ?? null) : null;
+  const steps = stepStates(phase, failure, terminal, outcome === 'failed');
+  const rollingBack = phase === 'rollback' && !terminal;
+
+  const reachable =
+    polling.lastOkAt !== null &&
+    (polling.lastAttemptAt === null || polling.lastOkAt >= polling.lastAttemptAt);
+  const sinceOk = polling.lastOkAt === null ? null : now - polling.lastOkAt;
+
+  const decoded = terminal && outcome !== 'succeeded'
+    ? decodeFailure(executor?.failure, executor?.error)
+    : null;
+
+  // Focus the dialog on open; Escape is deliberately inert while running.
+  useEffect(() => {
+    dialogRef.current?.focus();
+  }, []);
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape' && terminal) onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => { window.removeEventListener('keydown', onKey); };
+  }, [terminal, onClose]);
+
+  const title =
+    outcome === 'succeeded' ? t('titleSucceeded', { version: inflight.target })
+    : outcome === 'rolled_back' ? t('titleRolledBack', { version: inflight.target })
+    : outcome === 'failed' ? t('titleFailed', { version: inflight.target })
+    : rollingBack ? t('titleRollingBack', { version: inflight.target })
+    : t('titleRunning', { version: inflight.target });
+
+  const edgeClass =
+    outcome === 'rolled_back' || outcome === 'failed'
+      ? 'border-[color:var(--danger-edge)]'
+      : outcome === 'succeeded'
+        ? 'border-[color:var(--success)]/60'
+        : 'border-[color:var(--accent)]/50';
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="update-progress-title"
+      aria-busy={!terminal}
+      data-testid="update-progress-modal"
+      data-outcome={outcome}
+    >
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[color:var(--bg-modal-overlay)] backdrop-blur-[2px]"
+      />
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        className={`relative z-10 flex max-h-[85vh] w-full max-w-xl flex-col gap-5 overflow-y-auto rounded-lg border bg-[color:var(--card)] p-6 shadow-lg outline-none ${edgeClass}`}
+      >
+        <header>
+          <p className="text-[10px] font-semibold tracking-wider text-[color:var(--fg-muted)] uppercase">
+            {t('kicker')}
+          </p>
+          <h2
+            id="update-progress-title"
+            className="mt-1 font-display text-2xl leading-tight text-[color:var(--fg-strong)]"
+          >
+            {title}
+          </h2>
+          <p className="mt-1 font-mono text-xs text-[color:var(--fg-muted)]">
+            {inflight.previous ?? '?'} → {inflight.target}
+            <span className="mx-2" aria-hidden="true">·</span>
+            <span>{t('elapsed', { elapsed: formatElapsed(elapsed, seconds) })}</span>
+          </p>
+        </header>
+
+        <ol className="flex w-full flex-col gap-1.5 text-sm" aria-label={t('stepsLabel')}>
+          {UPDATE_STEPS.map((step) => {
+            const state = steps[step];
+            return (
+              <li
+                key={step}
+                data-step={step}
+                data-state={state}
+                className={`grid grid-cols-[1rem_minmax(0,1fr)] items-baseline gap-x-3 ${STEP_CLASS[state]}`}
+              >
+                <span className="font-mono" aria-hidden="true">{STEP_GLYPH[state]}</span>
+                <span className="min-w-0 break-words">
+                  <span className={state === 'current' ? 'lume-busy-dots' : undefined}>
+                    {t(`steps.${step}`)}
+                  </span>
+                  {state === 'current' && step === 'replace' && (
+                    <span className="ml-2 text-xs text-[color:var(--fg-muted)]">
+                      {t('replaceHint')}
+                    </span>
+                  )}
+                  {state === 'current' && step === 'health_gate' && (
+                    <span className="ml-2 text-xs text-[color:var(--fg-muted)]">
+                      {t('healthGateHint')}
+                    </span>
+                  )}
+                </span>
+              </li>
+            );
+          })}
+          {(rollingBack || outcome === 'rolled_back') && (
+            <li
+              data-step="rollback"
+              data-state={outcome === 'rolled_back' ? 'done' : 'current'}
+              className="grid grid-cols-[1rem_minmax(0,1fr)] items-baseline gap-x-3 text-[color:var(--danger)]"
+            >
+              <span className="font-mono" aria-hidden="true">
+                {outcome === 'rolled_back' ? '↩' : '›'}
+              </span>
+              <span className={`min-w-0 break-words ${rollingBack ? 'lume-busy-dots' : ''}`}>
+                {t('steps.rollback', { version: inflight.previous ?? '?' })}
+              </span>
+            </li>
+          )}
+          {phase === null && !terminal && (
+            <li className="col-span-2 text-xs text-[color:var(--fg-muted)]">{t('noPhaseYet')}</li>
+          )}
+        </ol>
+
+        {!terminal && (
+          <section
+            aria-live="polite"
+            data-testid="polling-indicator"
+            data-reachable={reachable}
+            className="rounded border border-[color:var(--border)] px-3 py-2 text-xs text-[color:var(--fg-muted)]"
+          >
+            <p className="flex flex-wrap items-baseline gap-x-3">
+              <span className="lume-busy-dots">
+                {t('pollingEvery', { seconds: Math.round(polling.intervalMs / 1000) })}
+              </span>
+              <span className="font-mono">{t('pollingAttempts', { count: polling.attempts })}</span>
+              {sinceOk !== null && (
+                <span className="font-mono">
+                  {t('pollingLastAnswer', { elapsed: formatElapsed(sinceOk, seconds) })}
+                </span>
+              )}
+            </p>
+            <p className={`mt-1 ${reachable ? '' : 'text-[color:var(--warning)]'}`}>
+              {reachable ? t('middlewareReachable') : t('middlewareUnreachable')}
+            </p>
+          </section>
+        )}
+
+        {stalled && (
+          <section className="rounded border border-[color:var(--warning)]/60 px-3 py-2 text-sm">
+            <p className="font-medium">{t('stalledTitle')}</p>
+            <p className="mt-1 text-xs text-[color:var(--fg-muted)]">{t('stalledBody')}</p>
+          </section>
+        )}
+
+        {outcome === 'succeeded' && (
+          <section className="text-sm">
+            <p>{t('succeededBody', { version: inflight.target })}</p>
+            <p className="mt-1 text-xs text-[color:var(--fg-muted)]">{t('succeededReloadHint')}</p>
+          </section>
+        )}
+
+        {decoded !== null && (
+          <section
+            data-testid="failure-explanation"
+            data-failure-kind={decoded.kind}
+            className="rounded border border-[color:var(--danger-edge)] px-3 py-3 text-sm"
+          >
+            <p className="font-medium text-[color:var(--danger)]">
+              {decoded.kind === 'never_reachable' && t('failure.neverReachable.title')}
+              {decoded.kind === 'version_never_matched' &&
+                t('failure.versionNeverMatched.title', { observed: decoded.observedVersion })}
+              {decoded.kind === 'replace' &&
+                t('failure.replace.title', { service: decoded.service ?? '?' })}
+              {decoded.kind === 'unknown' && t('failure.unknown.title')}
+            </p>
+            <p className="mt-1 text-[color:var(--fg-muted)]">
+              {outcome === 'rolled_back'
+                ? t('failure.rolledBackBody', { version: inflight.previous ?? '?' })
+                : t('failure.notRolledBackBody')}
+            </p>
+            {decoded.kind === 'never_reachable' && (
+              <>
+                <p className="mt-2">{t('failure.neverReachable.body')}</p>
+                <ul className="mt-1 list-disc pl-5 text-[color:var(--fg-muted)]">
+                  <li>{t('failure.neverReachable.causeSecret')}</li>
+                  <li>{t('failure.neverReachable.causeMigration')}</li>
+                  <li>{t('failure.neverReachable.causeLogs')}</li>
+                </ul>
+              </>
+            )}
+            {decoded.kind === 'version_never_matched' && (
+              <p className="mt-2">{t('failure.versionNeverMatched.body')}</p>
+            )}
+            {decoded.kind === 'replace' && (
+              <p className="mt-2">{t('failure.replace.body')}</p>
+            )}
+            {decoded.kind === 'unknown' && decoded.message.length > 0 && (
+              <pre className="mt-2 overflow-x-auto rounded bg-[color:var(--bg)] p-2 font-mono text-xs">
+                {decoded.message}
+              </pre>
+            )}
+            <p className="mt-2 text-xs">
+              <a
+                href={DOCS_UPGRADING_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="underline decoration-dotted"
+              >
+                {t('failure.docsLink')}
+              </a>
+            </p>
+          </section>
+        )}
+
+        {(executor?.steps ?? []).length > 0 && (
+          <details className="text-xs">
+            <summary className="cursor-pointer text-[color:var(--fg-muted)]">
+              {t('trailTitle', { count: executor?.steps?.length ?? 0 })}
+            </summary>
+            <ol className="mt-2 max-h-40 overflow-y-auto font-mono text-[11px] text-[color:var(--fg-muted)]">
+              {(executor?.steps ?? []).map((line) => (
+                <li key={line}>{line}</li>
+              ))}
+            </ol>
+          </details>
+        )}
+
+        <footer className="flex items-center justify-end gap-2">
+          {stalled && (
+            <Button variant="ghost" size="sm" onClick={onClose}>
+              {t('dismissStalled')}
+            </Button>
+          )}
+          {outcome === 'succeeded' && (
+            <Button variant="primary" size="sm" onClick={onReload}>
+              {t('reload')}
+            </Button>
+          )}
+          {terminal && (
+            <Button variant="secondary" size="sm" onClick={onClose}>
+              {t('close')}
+            </Button>
+          )}
+          {!terminal && !stalled && (
+            <span className="text-xs text-[color:var(--fg-muted)]">{t('cannotClose')}</span>
+          )}
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/web-ui/app/admin/update/_components/updateFailure.ts
+++ b/web-ui/app/admin/update/_components/updateFailure.ts
@@ -1,0 +1,149 @@
+import type { UpdateStatus, UpdaterFailure, UpdaterPhase } from '../../../_lib/api';
+
+/**
+ * Shared decoding of the updater's structured outcome, used by both the
+ * progress modal and the page-level banner so the two never disagree.
+ *
+ * Everything here is pure and deterministic — it is the part of the update UX
+ * worth unit-testing without a DOM.
+ */
+
+/** The stepper's rows, in job order. `rollback` is not a row: it replaces the
+ *  tail of the sequence when the job reverts. */
+export const UPDATE_STEPS: readonly Exclude<UpdaterPhase, 'rollback' | 'done'>[] = [
+  'resolve',
+  'preflight',
+  'pin',
+  'replace',
+  'health_gate',
+];
+
+export type StepState = 'done' | 'current' | 'pending' | 'failed';
+
+/**
+ * Maps the sidecar's phase onto a per-row state. A `null` phase while updating
+ * (older sidecar) marks nothing current — the modal then shows the generic
+ * in-progress line instead of a lying stepper.
+ */
+export function stepStates(
+  phase: UpdaterPhase | null | undefined,
+  failure: UpdaterFailure | null | undefined,
+  terminal: boolean,
+  /** The job ended in `failed` (threw, no rollback) without a structured
+   *  failure — e.g. an unpullable image in `preflight`. The row the job was
+   *  in is then the failed one; without this it would render as done. */
+  failedWithoutReason = false,
+): Record<(typeof UPDATE_STEPS)[number], StepState> {
+  const out = {} as Record<(typeof UPDATE_STEPS)[number], StepState>;
+  const phaseRow =
+    phase !== null && phase !== undefined && (UPDATE_STEPS as readonly string[]).includes(phase)
+      ? (phase as (typeof UPDATE_STEPS)[number])
+      : null;
+  const failedAt: (typeof UPDATE_STEPS)[number] | null =
+    failure?.kind === 'health_gate' ? 'health_gate'
+    : failure?.kind === 'replace' ? 'replace'
+    : terminal && failedWithoutReason ? phaseRow
+    : null;
+  // `done` and `rollback` sit past the last row; everything before the phase
+  // is finished.
+  const phaseIndex =
+    phase === null || phase === undefined ? -1
+    : phase === 'done' || phase === 'rollback' ? UPDATE_STEPS.length
+    : UPDATE_STEPS.indexOf(phase);
+  UPDATE_STEPS.forEach((step, i) => {
+    if (failedAt !== null && step === failedAt) {
+      out[step] = 'failed';
+    } else if (failedAt !== null && i > UPDATE_STEPS.indexOf(failedAt)) {
+      out[step] = 'pending';
+    } else if (i < phaseIndex || (terminal && failedAt === null && phaseIndex >= i)) {
+      out[step] = 'done';
+    } else if (i === phaseIndex && !terminal) {
+      out[step] = 'current';
+    } else {
+      out[step] = 'pending';
+    }
+  });
+  return out;
+}
+
+export type DecodedFailure =
+  | { kind: 'never_reachable' }
+  | { kind: 'version_never_matched'; observedVersion: string }
+  | { kind: 'replace'; service: string | null }
+  | { kind: 'unknown'; message: string };
+
+/**
+ * Turns the structured failure (or, on an older sidecar, the raw error
+ * string) into one of a handful of cases the catalog has words for.
+ */
+export function decodeFailure(
+  failure: UpdaterFailure | null | undefined,
+  error: string | undefined,
+): DecodedFailure {
+  if (failure?.kind === 'health_gate') {
+    if (failure.reason === 'never_reachable') return { kind: 'never_reachable' };
+    if (failure.reason === 'version_never_matched') {
+      return {
+        kind: 'version_never_matched',
+        observedVersion: failure.observedVersion ?? '?',
+      };
+    }
+    return { kind: 'unknown', message: error ?? failure.reason };
+  }
+  if (failure?.kind === 'replace') return { kind: 'replace', service: failure.service };
+  // Older sidecar: the only signal is the English trail line.
+  if (error !== undefined && /never_reachable/.test(error)) return { kind: 'never_reachable' };
+  return { kind: 'unknown', message: error ?? '' };
+}
+
+export type Outcome = 'running' | 'succeeded' | 'rolled_back' | 'failed';
+
+export interface InflightUpdate {
+  readonly target: string;
+  readonly previous: string | null;
+  /** Epoch ms when this browser issued the trigger. */
+  readonly startedAt: number;
+}
+
+/**
+ * Whether the sidecar status describes THIS update and not an earlier run.
+ * The sidecar keeps its last job around until the next one starts, so a
+ * `rolled_back` from last week must not close a modal that was just opened.
+ * Clock skew between browser and sidecar is tolerated generously: a job that
+ * started within the last minute before our click is still ours.
+ */
+const CLOCK_SKEW_MS = 60_000;
+export function describesThisRun(
+  executor: UpdateStatus['executor'] | undefined,
+  inflight: InflightUpdate,
+): boolean {
+  if (!executor?.reachable) return false;
+  if (executor.targetVersion !== inflight.target) return false;
+  // A job that FINISHED before this click is a previous job, full stop — this
+  // is what catches a retry of the same target within the skew window after a
+  // fast `replace` failure.
+  if (typeof executor.finishedAt === 'string') {
+    const finished = Date.parse(executor.finishedAt);
+    if (!Number.isNaN(finished) && finished < inflight.startedAt) return false;
+  }
+  if (typeof executor.startedAt !== 'string') return true;
+  const started = Date.parse(executor.startedAt);
+  return Number.isNaN(started) || started >= inflight.startedAt - CLOCK_SKEW_MS;
+}
+
+/** The single source of truth for "is it over, and how did it end". */
+export function deriveOutcome(
+  status: UpdateStatus | null,
+  inflight: InflightUpdate,
+): Outcome {
+  if (status === null) return 'running';
+  // The restart is over once the running build IS the target — true even if
+  // the sidecar is unreachable or predates `state` bookkeeping.
+  if (status.current.version === inflight.target) return 'succeeded';
+  const ex = status.executor;
+  if (!describesThisRun(ex, inflight)) return 'running';
+  if (ex.state === 'rolled_back') return 'rolled_back';
+  if (ex.state === 'failed') return 'failed';
+  if (ex.state === 'succeeded') return 'succeeded';
+  return 'running';
+}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -3930,6 +3930,69 @@
     "inProgressTitle": "Update läuft",
     "inProgressBody": "Die Container werden ersetzt. Diese Seite pollt weiter — die Middleware ist während des Neustarts kurz nicht erreichbar.",
     "rolledBack": "Das letzte Update ist fehlgeschlagen und wurde zurückgerollt: {message}",
+    "rolledBackNeverReachable": "Das Update auf {from} wurde zurückgerollt: Die neue Version hat /health nie beantwortet. Diese Instanz läuft wieder auf {to}.",
+    "rolledBackVersionNeverMatched": "Das Update auf {from} wurde zurückgerollt: /health meldete weiterhin {observed} statt {from}. Diese Instanz läuft wieder auf {to}.",
+    "rolledBackReplace": "Das Update auf {from} wurde zurückgerollt: Der Dienst {service} konnte nicht ersetzt werden. Diese Instanz läuft wieder auf {to}.",
+    "rolledBackHint": "Ein neues Image, das nie hochkommt, braucht beim Start meist etwas, das das alte nicht brauchte — am häufigsten ein Secret wie CREDENTIAL_KEYCHAIN_KEY (Pflicht seit v0.115). Sieh sofort in die Middleware-Logs des fehlgeschlagenen Starts; gehostete Plattformen behalten sie nur kurz. docs/upgrading.md hat die Schritte pro Version.",
+    "progress": {
+      "kicker": "Update",
+      "titleRunning": "Update auf {version} läuft",
+      "titleRollingBack": "Rollback — {version} ist nicht hochgekommen",
+      "titleSucceeded": "Auf {version} aktualisiert",
+      "titleRolledBack": "Update auf {version} zurückgerollt",
+      "titleFailed": "Update auf {version} fehlgeschlagen",
+      "elapsed": "seit {elapsed}",
+      "seconds": "{seconds} s",
+      "stepsLabel": "Update-Schritte",
+      "steps": {
+        "resolve": "Laufende Dienste ermitteln",
+        "preflight": "Neue Images in der Registry prüfen",
+        "pin": "Zielversion festschreiben",
+        "replace": "Middleware und Admin-UI ersetzen",
+        "health_gate": "Warten, bis /health die neue Version meldet",
+        "rollback": "Zurückrollen auf {version}"
+      },
+      "replaceHint": "die Middleware startet jetzt neu — diese Seite verliert sie kurz",
+      "healthGateHint": "bis zu 5 Minuten",
+      "noPhaseYet": "Warte auf den ersten gemeldeten Schritt des Updaters.",
+      "pollingEvery": "Abfrage alle {seconds} s",
+      "pollingAttempts": "{count} Abfragen",
+      "pollingLastAnswer": "letzte Antwort vor {elapsed}",
+      "middlewareReachable": "Die Middleware antwortet.",
+      "middlewareUnreachable": "Die Middleware antwortet nicht — während des Neustarts erwartet.",
+      "stalledTitle": "Das dauert länger als erwartet.",
+      "stalledBody": "Das Health-Gate des Updaters beträgt 5 Minuten; ein so langer Lauf heißt meist, dass der Updater selbst weg ist oder diese Seite ihn aus den Augen verloren hat. Du kannst den Dialog schließen; die Update-Historie unten und die Container-Logs zeigen, was wirklich passiert ist.",
+      "succeededBody": "Die Middleware meldet {version}.",
+      "succeededReloadHint": "Die Admin-UI wurde ebenfalls ersetzt — lade neu, um sicher die neue zu sehen.",
+      "cannotClose": "Dieser Dialog schließt sich, wenn das Update abgeschlossen ist.",
+      "close": "Schließen",
+      "reload": "Admin-UI neu laden",
+      "dismissStalled": "Ausblenden",
+      "trailTitle": "Updater-Log ({count} Zeilen)",
+      "failure": {
+        "rolledBackBody": "Alle Dienste wurden auf {version} zurückgesetzt. Nichts ist verloren, aber Schema-Migrationen laufen nur vorwärts — eine bereits migrierte Datenbank bleibt migriert.",
+        "notRolledBackBody": "Der Updater konnte die vorherige Version nicht wiederherstellen. Prüfe die Dienste von Hand, bevor du etwas anderes tust.",
+        "neverReachable": {
+          "title": "Die neue Version hat /health nie beantwortet.",
+          "body": "Der Container wurde ersetzt, aber innerhalb des Gate-Fensters hat nie etwas auf dem Health-Endpoint gelauscht. Das ist fast immer ein Absturz der neuen Version beim Start, kein Netzwerkproblem. Wahrscheinliche Ursachen:",
+          "causeSecret": "Ein Secret, das die neue Version braucht und die alte nicht — am häufigsten CREDENTIAL_KEYCHAIN_KEY, Pflicht seit v0.115. Setzen, dann das Update erneut starten.",
+          "causeMigration": "Eine Schema-Migration, die an dieser Datenbank gescheitert ist.",
+          "causeLogs": "Lies jetzt die Middleware-Logs des fehlgeschlagenen Starts — gehostete Plattformen behalten sie Minuten, nicht Stunden."
+        },
+        "versionNeverMatched": {
+          "title": "/health meldete weiterhin {observed} statt der neuen Version.",
+          "body": "Es hat etwas geantwortet, aber nicht das neue Image: Der Dienst ist vielleicht auf dem alten Tag neu gestartet, oder ein Proxy davor zeigt noch auf die alte Instanz."
+        },
+        "replace": {
+          "title": "Der Dienst {service} konnte nicht ersetzt werden.",
+          "body": "Die Plattform hat den Wechsel auf das neue Image verweigert. Das Updater-Log unten enthält den genauen Fehler."
+        },
+        "unknown": {
+          "title": "Das Update ist nicht gelandet."
+        },
+        "docsLink": "docs/upgrading.md — Upgrade-Schritte pro Version"
+      }
+    },
     "confirmTitle": "Bestätigen",
     "confirmInstruction": "Zum Bestätigen <code>{phrase}</code> eintippen.",
     "confirmWarning": "Das ersetzt die laufenden Middleware- und Admin-UI-Container. Schema-Migrationen laufen nur vorwärts — ein Rollback stellt die Images wieder her, nicht die Datenbank. Vor einem größeren Sprung ein Volume-Snapshot ziehen.",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -3930,6 +3930,69 @@
     "inProgressTitle": "Update in progress",
     "inProgressBody": "The containers are being replaced. This page keeps polling — the middleware is briefly unavailable while it restarts.",
     "rolledBack": "The last update failed and was rolled back: {message}",
+    "rolledBackNeverReachable": "The update to {from} was rolled back: the new version never answered /health. This instance is back on {to}.",
+    "rolledBackVersionNeverMatched": "The update to {from} was rolled back: /health kept reporting {observed} instead of {from}. This instance is back on {to}.",
+    "rolledBackReplace": "The update to {from} was rolled back: the {service} service could not be replaced. This instance is back on {to}.",
+    "rolledBackHint": "A new image that never comes up usually needs something at boot the old one did not — most often a secret such as CREDENTIAL_KEYCHAIN_KEY (required since v0.115). Check the middleware logs from the failed boot right away; hosted log retention is short. docs/upgrading.md has the per-version steps.",
+    "progress": {
+      "kicker": "Update",
+      "titleRunning": "Updating to {version}",
+      "titleRollingBack": "Rolling back — {version} did not come up",
+      "titleSucceeded": "Updated to {version}",
+      "titleRolledBack": "Update to {version} rolled back",
+      "titleFailed": "Update to {version} failed",
+      "elapsed": "elapsed {elapsed}",
+      "seconds": "{seconds}s",
+      "stepsLabel": "Update steps",
+      "steps": {
+        "resolve": "Resolve running services",
+        "preflight": "Verify new images in the registry",
+        "pin": "Pin the target version",
+        "replace": "Replace middleware and admin UI",
+        "health_gate": "Wait for /health to report the new version",
+        "rollback": "Roll back to {version}"
+      },
+      "replaceHint": "the middleware restarts now — this page may briefly lose it",
+      "healthGateHint": "up to 5 minutes",
+      "noPhaseYet": "Waiting for the updater to report its first step.",
+      "pollingEvery": "Polling every {seconds} s",
+      "pollingAttempts": "{count} checks",
+      "pollingLastAnswer": "last answer {elapsed} ago",
+      "middlewareReachable": "Middleware is answering.",
+      "middlewareUnreachable": "Middleware is not answering — expected while it restarts.",
+      "stalledTitle": "This is taking longer than expected.",
+      "stalledBody": "The updater's own health gate is 5 minutes, so a run this long usually means the updater itself is gone or this page lost track of it. You can dismiss this dialog; the update history below and the container logs tell you what actually happened.",
+      "succeededBody": "The middleware reports {version}.",
+      "succeededReloadHint": "The admin UI was replaced too — reload to make sure you are looking at the new one.",
+      "cannotClose": "This dialog closes when the update has finished.",
+      "close": "Close",
+      "reload": "Reload admin UI",
+      "dismissStalled": "Dismiss",
+      "trailTitle": "Updater log ({count} lines)",
+      "failure": {
+        "rolledBackBody": "Every service was restored to {version}. Nothing was lost, but schema migrations are forward-only — a database the new version already migrated stays migrated.",
+        "notRolledBackBody": "The updater could not restore the previous version. Check the services by hand before doing anything else.",
+        "neverReachable": {
+          "title": "The new version never answered /health.",
+          "body": "The container was replaced, but nothing ever listened on the health endpoint within the gate window. That is almost always the new version dying at boot, not a network problem. Likely causes:",
+          "causeSecret": "A secret the new version requires and the old one did not — most often CREDENTIAL_KEYCHAIN_KEY, mandatory since v0.115. Set it, then run the update again.",
+          "causeMigration": "A schema migration that failed against this database.",
+          "causeLogs": "Read the middleware logs from the failed boot now — hosted platforms keep them for minutes, not hours."
+        },
+        "versionNeverMatched": {
+          "title": "/health kept reporting {observed} instead of the new version.",
+          "body": "Something answered, but it was not the new image: the service may have been restarted on the old tag, or a proxy in front of it is still pointing at the old instance."
+        },
+        "replace": {
+          "title": "The {service} service could not be replaced.",
+          "body": "The platform refused to move the service to the new image. The updater log below has the exact error."
+        },
+        "unknown": {
+          "title": "The update did not land."
+        },
+        "docsLink": "docs/upgrading.md — per-version upgrade steps"
+      }
+    },
     "confirmTitle": "Confirm",
     "confirmInstruction": "Type <code>{phrase}</code> to confirm.",
     "confirmWarning": "This replaces the running middleware and admin UI containers. Schema migrations are forward-only — a rollback restores the images, not the database. Snapshot your volume before a major bump.",


### PR DESCRIPTION
## Why

Today's prod update (v0.90.1 → v0.120.0) rolled back, and the admin page showed a one-line red box: `health gate failed: never_reachable (observed version: none)`. Nothing explained what that meant, what to do, or even that the updater had been polling for five minutes while the page looked frozen. The page also stayed fully interactive during a run that replaces the very containers it talks to.

## What

**Sidecar (`middleware/sidecars/updater`)** — the job now reports *where* it is and *why* it failed as data, not only as English log lines:

- `runUpdate` takes an optional `setPhase` hook and calls it at each numbered step (`resolve → preflight → pin → replace → health_gate → done`, or `rollback`); the result carries a structured `failure` (`{kind:'health_gate', reason, observedVersion}` or `{kind:'replace', service}`).
- `/status` exposes `phase` and `failure` (both `null` while idle / on success). README wire contract updated.

**Middleware** — `adminUpdate` route passes `phase`, `failure`, `previousVersion`, `startedAt`, `finishedAt` through; `phase`/`failure` are normalised to `null` for an older sidecar.

**web-ui (Admin → Update)** — new `UpdateProgressModal`:

- **Blocks the page** while a run is in flight; cannot be dismissed until a terminal state (Escape inert while running).
- **Stepper** driven by the sidecar's `phase` (no text parsing); failed step marked `✕`, rollback row `↩`.
- **Polling made visible**: cadence, number of checks, "last answer N s ago", and an explicit "middleware is not answering — expected while it restarts" line instead of a silent gap. Errors during the restart window are still not treated as failures.
- **Survives its own replacement**: the run is remembered in `localStorage` and the dialog resumes after the admin UI container is swapped / the tab reloads; an update started from another browser is adopted from the sidecar's `updating` state.
- **Stale-run guard**: the sidecar keeps last week's `rolled_back` around until the next job — `describesThisRun` (target + startedAt with 60 s skew) keeps that from closing or mis-labelling a fresh run. Mutation-checked: removing the guard fails 2 tests.
- **Decoded outcome**: `never_reachable` → "the new version never answered /health" + likely causes (newly required secret such as `CREDENTIAL_KEYCHAIN_KEY` since v0.115; failed migration; read the logs now — hosted retention is short) + link to `docs/upgrading.md`. `version_never_matched` and `replace` get their own wording; unknown reasons fall back to the raw message. Works against an older sidecar via the trail line.
- **Success**: "Updated to vX", reload button (the admin UI itself was replaced).
- **Stall**: after 12 min without a terminal state the dialog says so and offers a way out.
- The page-level rolled-back banner uses the same decoding and adds the hint.
- Lume: state colours text/edge only, busy-dots instead of spinners. i18n en + de, `i18n:check` OK.

## Tests

- sidecar: phase sequence, structured failure for health gate and replace, no-hook compatibility, `/status` exposure (100/100)
- middleware route: passthrough + null-normalisation (22/22)
- web-ui: pure helpers (`stepStates`, `decodeFailure`, `describesThisRun`, `deriveOutcome`) + page tests for trigger → dialog, resume after reload, adoption, "not answering" indicator, success view + close clears storage, decoded rollback, stale rollback must not close a fresh run (41/41)
- `tsc` clean, `eslint` 0 errors (3 `set-state-in-effect` warnings on the mount/adopt/poll effects, same class as before)

## Verified in a real browser

Ran the web-ui against a scripted fake middleware that drives the full flow and verified all three end states in Chrome (Interceptor): running (stepper advancing, polling counter, restart gap shown as "not answering"), rolled back (`✕` on the health gate, decoded cause with the `CREDENTIAL_KEYCHAIN_KEY` hint), succeeded (reload button). Also verified the dialog resumes after a full page reload mid-run.

Follow-up to #432 / #696; pairs with #826 (docs for the secret).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789902627&installation_model_id=428086&pr_number=828&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F828&signature=c1fc9193948fdf0cafcb30d0552cf325985b895ffd3fc8b0389f187fb772ce14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->