### PR TITLE
feat: persist observed-invite index across restarts (0048)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Ohne Doku-Update ist eine Änderung **nicht fertig**, selbst wenn der Build grü
 | Security-Entscheidung / Credential-Verschiebung | `docs/security-architecture.md` aktualisieren | Abschnitt |
 | Neue ENV-Variable / Secret | `middleware/.env.example` + `docs/middleware-agent-handoff.md` §10 | Zeile + Erklärung |
 | Neue Route / Tool / Sub-Agent | `docs/middleware-agent-handoff.md` §3 und §8 | Abschnitt |
-| Neue SQL-Migration | Datei in `middleware/src/services/graph/migrations/` — **plus** CHANGELOG-Eintrag mit ID und Zweck | Migration-ID |
+| Neue SQL-Migration | Datei in `middleware/migrations/` (Core-Serie; Subsystem-Serien wie `src/services/graph/migrations/` nur für deren eigene Tabellen) — **plus** CHANGELOG-Eintrag mit ID und Zweck | Migration-ID |
 | Neue Skill-Version | `skills/<name>/SKILL.md` + CHANGELOG | Skill-Name + Kurzzusammenfassung |
 | Offener Punkt / Backlog / TODO | `docs/middleware-agent-handoff.md` §13 Roadmap | Bullet |
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,19 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Changed — the observed-invite index survives restarts (#330 follow-up)
+
+- Migration `0048_observed_invites.sql` (core series, `middleware/migrations/`): new table
+  `observed_conversation_invites` as write-through backing store for the kernel-side invite
+  index (#330 C2a) — the deny-by-default scope guard for plugin auto-binds. Until now the
+  index was in-memory only, so every deploy/restart forced operators to remove and re-invite
+  the bot before a facilitation could start.
+- The in-memory map stays the hot path: writes are fire-and-forget (log-only on failure),
+  boot hydration is TTL-filtered, capped at the in-memory limit, keyed off the table's key
+  COLUMNS (a JSONB payload disagreeing with its columns is dropped — defense in depth for a
+  security guard), and wrapped so a missing table degrades to the old re-invite behaviour
+  instead of failing the boot. Live events observed before hydration win.
+
 ### Changed — Admin → Update shows the run as a blocking progress dialog (#432 follow-up)
 
 - **The updater sidecar reports structured progress.** `GET /status` gains

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -1280,7 +1280,16 @@ das Gate, kein Katalogeintrag):
   Kernel selbst ein Gruppen-`bot_added` beobachtet hat
   (`src/platform/observedConversationInvites.ts` — subscribed DIREKT am
   ConversationEventHub, vor jedem Plugin; Key channelType::conversationId,
-  TTL 24h). Fremd-gebundene Conversations: Refusal via `channel_bindings`-PK.
+  TTL 24h). Der Index **überlebt Restarts** (#330 follow-up): Write-through in
+  `observed_conversation_invites` (Migration `0048`, Core-Serie;
+  `src/platform/observedInvitePersistence.ts`) — Map bleibt der Hot Path,
+  Writes fire-and-forget (log-only), Boot-Hydration TTL-gefiltert, auf
+  MAX_ENTRIES gecappt, Key aus den Tabellen-SPALTEN (JSONB≠Spalten ⇒ Row wird
+  verworfen), try/catch um `hydrate()` (fehlende Tabelle ⇒ altes
+  Re-Invite-Verhalten, nie Boot-Abbruch). Live-Events vor der Hydration
+  gewinnen. Achtung: zwei Instanzen auf EINER DATABASE_URL teilen sich den
+  Index (Annahme: eine Deployment == eine DB).
+  Fremd-gebundene Conversations: Refusal via `channel_bindings`-PK.
   `unbind()` ist gleich hart geguarded: nur eigene Ephemeral-Attachment-Rows
   — Operator-Bindings sind von dieser Fläche aus unerreichbar, und ein
   vorbestehendes Operator-Binding wird NIE in den Ephemeral-Lifecycle

--- a/middleware/migrations/0048_observed_invites.sql
+++ b/middleware/migrations/0048_observed_invites.sql
@@ -1,0 +1,20 @@
+-- ── Observed conversation invites survive restarts (#330 follow-up) ────────
+-- The kernel-side invite index (#330 C2a) is the scope guard for plugin
+-- auto-binds: a plugin can only bind a conversation the transport actually
+-- reported a group bot_added for. Until now that index was purely in-memory,
+-- so every deploy/restart forced operators to remove and re-invite the bot
+-- before a facilitation could start. This table is the write-through backing
+-- store; the in-memory map stays the hot path and is hydrated from here at
+-- boot (TTL-filtered, live events win over hydrated rows).
+--
+-- seen_at is epoch milliseconds (BIGINT) because the index's TTL arithmetic
+-- lives in JS `Date.now()` space — round-tripping through timestamptz would
+-- just invite timezone/precision drift for zero gain.
+
+CREATE TABLE IF NOT EXISTS observed_conversation_invites (
+  channel_type    TEXT   NOT NULL,
+  conversation_id TEXT   NOT NULL,
+  invite          JSONB  NOT NULL,
+  seen_at         BIGINT NOT NULL,
+  PRIMARY KEY (channel_type, conversation_id)
+);

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -397,6 +397,7 @@ import { createTargetedDeliveryService } from './channels/targetedDeliveryServic
 import { ConversationSendRegistry } from './channels/conversationSendRegistry.js';
 import { createConversationSendService } from './channels/conversationSendService.js';
 import { ObservedConversationInvites } from './platform/observedConversationInvites.js';
+import { PgObservedInvitePersistence } from './platform/observedInvitePersistence.js';
 import { createAgentSetupServices } from './platform/agentSetupService.js';
 import { createScopedRoleAssignments } from './conductor/scopedRoleAssignments.js';
 import { DefaultChannelRegistry } from './channels/channelRegistry.js';
@@ -3477,6 +3478,22 @@ async function main(): Promise<void> {
     // boot with expired ephemerals is the normal restart case. Everything here
     // is pool-backed or lazily resolved, so no wiring output is needed.
     const ephemeralAttachmentsStore = new ConductorEphemeralAttachmentsStore(graphPool);
+    // #330 follow-up — the invite index survives restarts: a deploy between
+    // the Teams invite and the facilitation start must not force a re-invite.
+    // Hydration is awaited (cheap, one bounded SELECT) so the scope guard is
+    // warm before the conversationBindings service below can serve its first
+    // bind; writes stay fire-and-forget.
+    observedInvites.attachPersistence(new PgObservedInvitePersistence(graphPool));
+    try {
+      await observedInvites.hydrate();
+    } catch (err) {
+      // Persistence is an upgrade, never a dependency: a missing table or a
+      // flaky pool degrades to the old re-invite-after-restart behaviour —
+      // it must not turn the boot into an outage (review H1).
+      console.log(
+        `[middleware] invite-index hydration skipped: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
     const facilitationRoleStore = new ConductorRoleStore(graphPool);
     const scopedRoleAssignments = createScopedRoleAssignments({
       roleStore: facilitationRoleStore,

--- a/middleware/src/platform/observedConversationInvites.ts
+++ b/middleware/src/platform/observedConversationInvites.ts
@@ -9,6 +9,7 @@
 import type { ChannelUserRef, ConversationMembershipEvent } from '@omadia/channel-sdk';
 
 import type { ConversationEventHub } from '../channels/conversationEventHub.js';
+import type { ObservedInvitePersistence } from './observedInvitePersistence.js';
 
 export interface ObservedInvite {
   channelId: string;
@@ -23,6 +24,7 @@ const MAX_ENTRIES = 1000;
 
 export class ObservedConversationInvites {
   private readonly invites = new Map<string, { invite: ObservedInvite; seenAt: number }>();
+  private persistence?: ObservedInvitePersistence;
 
   constructor(
     private readonly opts: {
@@ -35,6 +37,40 @@ export class ObservedConversationInvites {
   /** Wire into the hub; returns the unsubscribe function. */
   attach(hub: ConversationEventHub): () => void {
     return hub.subscribe((event) => this.observe(event));
+  }
+
+  /** Optional write-through backing store — the map stays the hot path, the
+   *  store only makes it survive restarts. Every write is fire-and-forget
+   *  (log-only on failure): losing a persisted invite degrades to the old
+   *  re-invite behaviour, it must never break the live event path. */
+  attachPersistence(persistence: ObservedInvitePersistence): void {
+    this.persistence = persistence;
+  }
+
+  /** Load persisted, TTL-fresh invites into the map. Call once at boot after
+   *  the pool is up; keys already observed live in this process win. This
+   *  index is a deny-by-default scope guard, so hydration is defensive: the
+   *  key comes from the table's key COLUMNS, and a JSONB payload that names a
+   *  different conversation than its columns is dropped (defense in depth —
+   *  such a row would authorise a bind its column-based expiry could never
+   *  revoke). The in-memory cap applies to hydration too. */
+  async hydrate(): Promise<void> {
+    if (!this.persistence) return;
+    const now = (this.opts.now ?? Date.now)();
+    const rows = await this.persistence.loadFresh(now - (this.opts.ttlMs ?? DEFAULT_TTL_MS));
+    let restored = 0;
+    for (const row of rows) {
+      if (this.invites.size >= MAX_ENTRIES) break;
+      if (row.invite?.channelType !== row.channelType || row.invite?.conversationId !== row.conversationId) {
+        this.opts.log?.(`invite hydration dropped a row whose payload disagrees with its key (${row.channelType}::${row.conversationId})`);
+        continue;
+      }
+      const key = this.key(row.channelType, row.conversationId);
+      if (this.invites.has(key)) continue;
+      this.invites.set(key, { invite: row.invite, seenAt: row.seenAt });
+      restored += 1;
+    }
+    if (restored > 0) this.opts.log?.(`invite index hydrated: ${restored} persisted invite(s) restored`);
   }
 
   /** Composite key (review M3): two channels with colliding conversation ids
@@ -52,20 +88,29 @@ export class ObservedConversationInvites {
     if (!event.channelType) return;
     const now = (this.opts.now ?? Date.now)();
     const key = this.key(event.channelType, event.conversationId);
+    const invite: ObservedInvite = {
+      channelId: event.channelId,
+      channelType: event.channelType,
+      conversationId: event.conversationId,
+      ...(event.addedBy ? { addedBy: event.addedBy } : {}),
+      occurredAt: event.occurredAt,
+    };
     this.invites.delete(key);
-    this.invites.set(key, {
-      invite: {
-        channelId: event.channelId,
-        channelType: event.channelType,
-        conversationId: event.conversationId,
-        ...(event.addedBy ? { addedBy: event.addedBy } : {}),
-        occurredAt: event.occurredAt,
-      },
-      seenAt: now,
-    });
+    this.invites.set(key, { invite, seenAt: now });
+    void this.persistence
+      ?.upsert(invite, now)
+      .catch((err: unknown) => this.opts.log?.(`invite persist failed: ${err instanceof Error ? err.message : String(err)}`));
     if (this.invites.size > MAX_ENTRIES) {
       const oldest = this.invites.keys().next().value;
-      if (oldest !== undefined) this.invites.delete(oldest);
+      if (oldest !== undefined) {
+        const evicted = this.invites.get(oldest);
+        this.invites.delete(oldest);
+        if (evicted) {
+          void this.persistence
+            ?.delete(evicted.invite.channelType, evicted.invite.conversationId)
+            .catch(() => undefined);
+        }
+      }
     }
     this.opts.log?.(`observed group invite for ${event.conversationId} (${event.channelType})`);
   }
@@ -78,6 +123,7 @@ export class ObservedConversationInvites {
     const now = (this.opts.now ?? Date.now)();
     if (now - entry.seenAt > (this.opts.ttlMs ?? DEFAULT_TTL_MS)) {
       this.invites.delete(key);
+      void this.persistence?.delete(channelType, conversationId).catch(() => undefined);
       return undefined;
     }
     return entry.invite;

--- a/middleware/src/platform/observedInvitePersistence.ts
+++ b/middleware/src/platform/observedInvitePersistence.ts
@@ -1,0 +1,62 @@
+// Write-through backing store for the kernel-side invite index (#330
+// follow-up). The in-memory map in ObservedConversationInvites stays the hot
+// path; this store only makes it survive restarts — a deploy between the
+// Teams invite and the facilitation start must not force a re-invite.
+
+import type { Pool } from 'pg';
+
+import type { ObservedInvite } from './observedConversationInvites.js';
+
+export interface PersistedInviteRow {
+  /** Key columns — authoritative for map keys and deletes. The JSONB payload
+   *  must agree with them; hydration drops rows where it does not. */
+  channelType: string;
+  conversationId: string;
+  invite: ObservedInvite;
+  seenAt: number;
+}
+
+export interface ObservedInvitePersistence {
+  upsert(invite: ObservedInvite, seenAtMs: number): Promise<void>;
+  delete(channelType: string, conversationId: string): Promise<void>;
+  /** Rows seen at or after `minSeenAtMs`; anything older is pruned. */
+  loadFresh(minSeenAtMs: number): Promise<PersistedInviteRow[]>;
+}
+
+export class PgObservedInvitePersistence implements ObservedInvitePersistence {
+  constructor(private readonly pool: Pool) {}
+
+  async upsert(invite: ObservedInvite, seenAtMs: number): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO observed_conversation_invites (channel_type, conversation_id, invite, seen_at)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (channel_type, conversation_id)
+       DO UPDATE SET invite = EXCLUDED.invite, seen_at = EXCLUDED.seen_at`,
+      [invite.channelType, invite.conversationId, JSON.stringify(invite), seenAtMs],
+    );
+  }
+
+  async delete(channelType: string, conversationId: string): Promise<void> {
+    await this.pool.query(
+      `DELETE FROM observed_conversation_invites WHERE channel_type = $1 AND conversation_id = $2`,
+      [channelType, conversationId],
+    );
+  }
+
+  async loadFresh(minSeenAtMs: number): Promise<PersistedInviteRow[]> {
+    // Prune first so the table stays bounded by the TTL, not by history.
+    await this.pool.query(`DELETE FROM observed_conversation_invites WHERE seen_at < $1`, [minSeenAtMs]);
+    const r = await this.pool.query<{
+      channel_type: string;
+      conversation_id: string;
+      invite: ObservedInvite;
+      seen_at: string;
+    }>(`SELECT channel_type, conversation_id, invite, seen_at FROM observed_conversation_invites`);
+    return r.rows.map((row) => ({
+      channelType: row.channel_type,
+      conversationId: row.conversation_id,
+      invite: row.invite,
+      seenAt: Number(row.seen_at),
+    }));
+  }
+}

--- a/middleware/test/observedConversationInvites.test.ts
+++ b/middleware/test/observedConversationInvites.test.ts
@@ -5,6 +5,7 @@ import type { ConversationMembershipEvent } from '@omadia/channel-sdk';
 
 import { ConversationEventHub } from '../src/channels/conversationEventHub.js';
 import { ObservedConversationInvites } from '../src/platform/observedConversationInvites.js';
+import type { ObservedInvite } from '../src/platform/observedConversationInvites.js';
 
 // #330 C2a — the auto-bind scope guard's data source. Only kernel-observed
 // GROUP bot_added events count; everything else must never make a
@@ -60,5 +61,101 @@ describe('ObservedConversationInvites', () => {
     assert.ok(invites.get('teams', 'conv-1'));
     now += 61_000;
     assert.equal(invites.get('teams', 'conv-1'), undefined);
+  });
+});
+
+// #330 follow-up — the index survives restarts via a write-through backing
+// store. Losing the store degrades to the old re-invite behaviour; it must
+// never break the live event path.
+describe('ObservedConversationInvites persistence', () => {
+  function fakePersistence(seed: Array<{ invite: ObservedInvite; seenAt: number }> = []) {
+    const rows = new Map(seed.map((r) => [`${r.invite.channelType}::${r.invite.conversationId}`, r]));
+    return {
+      upserts: [] as string[],
+      deletes: [] as string[],
+      store: rows,
+      async upsert(invite: ObservedInvite, seenAt: number) {
+        this.upserts.push(invite.conversationId);
+        rows.set(`${invite.channelType}::${invite.conversationId}`, { invite, seenAt });
+      },
+      async delete(channelType: string, conversationId: string) {
+        this.deletes.push(conversationId);
+        rows.delete(`${channelType}::${conversationId}`);
+      },
+      async loadFresh(minSeenAtMs: number) {
+        return [...rows.entries()]
+          .filter(([, r]) => r.seenAt >= minSeenAtMs)
+          .map(([key, r]) => {
+            const [channelType, conversationId] = key.split('::') as [string, string];
+            return { channelType, conversationId, invite: r.invite, seenAt: r.seenAt };
+          });
+      },
+    };
+  }
+
+  function persistedInvite(conversationId: string, seenAt: number): { invite: ObservedInvite; seenAt: number } {
+    return {
+      invite: { channelId: 'de.byte5.channel.teams', channelType: 'teams', conversationId, occurredAt: '2026-08-21T09:00:00.000Z' },
+      seenAt,
+    };
+  }
+
+  it('writes observed invites through and removes expired ones from the store', async () => {
+    let now = 1_000_000;
+    const persistence = fakePersistence();
+    const invites = new ObservedConversationInvites({ ttlMs: 60_000, now: () => now });
+    invites.attachPersistence(persistence);
+    invites.observe(botAdded());
+    await Promise.resolve();
+    assert.deepEqual(persistence.upserts, ['conv-1']);
+
+    now += 61_000;
+    assert.equal(invites.get('teams', 'conv-1'), undefined);
+    await Promise.resolve();
+    assert.deepEqual(persistence.deletes, ['conv-1']);
+  });
+
+  it('hydrates TTL-fresh rows at boot; stale rows and live observations are respected', async () => {
+    const now = 1_000_000;
+    const persistence = fakePersistence([
+      persistedInvite('conv-restored', now - 30_000),
+      persistedInvite('conv-stale', now - 61_000),
+      { ...persistedInvite('conv-live', now - 30_000), invite: { ...persistedInvite('conv-live', 0).invite, channelId: 'persisted-old' } },
+    ]);
+    const invites = new ObservedConversationInvites({ ttlMs: 60_000, now: () => now });
+    invites.attachPersistence(persistence);
+    // A live event lands BEFORE hydration (boot race) — it must win.
+    invites.observe(botAdded({ conversationId: 'conv-live' }));
+    await invites.hydrate();
+
+    assert.ok(invites.get('teams', 'conv-restored'), 'fresh persisted invite restored');
+    assert.equal(invites.get('teams', 'conv-stale'), undefined);
+    assert.equal(invites.get('teams', 'conv-live')?.channelId, 'de.byte5.channel.teams');
+  });
+
+  it('a restored invite authorises exactly like a live one (restart survival)', async () => {
+    const now = 1_000_000;
+    const persistence = fakePersistence();
+    const before = new ObservedConversationInvites({ ttlMs: 60_000, now: () => now });
+    before.attachPersistence(persistence);
+    before.observe(botAdded());
+    await Promise.resolve();
+
+    // "Restart": a brand-new index over the same backing store.
+    const after = new ObservedConversationInvites({ ttlMs: 60_000, now: () => now });
+    after.attachPersistence(persistence);
+    await after.hydrate();
+    assert.equal(after.get('teams', 'conv-1')?.addedBy?.id, 'aad-owner');
+  });
+
+  it('drops hydrated rows whose payload disagrees with their key columns (scope-guard hardening)', async () => {
+    const persistence = fakePersistence();
+    // A tampered row: key columns say conv-columns, JSONB names conv-other.
+    persistence.store.set('teams::conv-columns', persistedInvite('conv-other', 1_000_000));
+    const invites = new ObservedConversationInvites({ ttlMs: 60_000, now: () => 1_000_000 });
+    invites.attachPersistence(persistence);
+    await invites.hydrate();
+    assert.equal(invites.get('teams', 'conv-columns'), undefined);
+    assert.equal(invites.get('teams', 'conv-other'), undefined);
   });
 });


### PR DESCRIPTION
#330 follow-up, straight from the field test: the kernel-side invite index (#330 C2a) — the deny-by-default scope guard for plugin auto-binds — was in-memory only, so **every middleware deploy/restart forced operators to remove and re-invite the bot** before a facilitation could start.

## What

- **Migration `0048_observed_invites.sql`** (core series, `middleware/migrations/`): `observed_conversation_invites` (PK `channel_type, conversation_id`, `invite JSONB`, `seen_at BIGINT` epoch-ms — the TTL math lives in `Date.now()` space).
- **`PgObservedInvitePersistence`**: parameterized upsert/delete, `loadFresh` prunes stale rows first and returns the key COLUMNS alongside the payload.
- **`ObservedConversationInvites`** gains `attachPersistence()` + `hydrate()`. The map stays the hot path; every persistence write is fire-and-forget (log-only on failure) — losing the store degrades to the old re-invite behaviour, never breaks the live event path.

## Security posture (this index is a scope guard)

- Hydration keys off the table's key **columns**; a JSONB payload naming a different conversation than its columns is dropped (defense in depth — such a row would grant bind eligibility its column-based expiry could never revoke).
- TTL boundaries agree between `loadFresh` and `get()`, and `get()` re-checks the TTL on every read — a hydrated row can never authorise past TTL.
- Hydration respects the in-memory `MAX_ENTRIES` cap; live events observed before hydration win.
- `hydrate()` is wrapped at the call site: a missing table (orchestrator-plugin migration failure) logs and degrades instead of failing the boot.
- No-`DATABASE_URL` deployments unchanged: wiring sits in the `if (graphPool)` block, everything behind `?.`.

## Docs

CHANGELOG (migration ID + purpose), `docs/middleware-agent-handoff.md` (persistence architecture incl. the one-deployment-one-DB assumption), AGENTS.md migration-path row corrected to the core series.

## Test plan

- 4 new tests in `test/observedConversationInvites.test.ts`: write-through + expiry delete, TTL-filtered hydration with live-wins, restart survival (addedBy intact), tampered-row drop (payload ≠ key columns).
- Full middleware verify green: build, typecheck, ratchet 371 flat, full suite.
- omadia-reviewer pass: both HIGHs (boot-failure hydrate, missing docs) + MEDIUMs fixed; LOW notes documented in the handoff doc.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789907894&installation_model_id=428086&pr_number=837&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F837&signature=7781515bfdc9b762bb9539cb96d9a7ce31b3f674126591a9866bf7c12a14e361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->