### PR TITLE
feat: cancel Conductor runs straight from the run list (#330 field report)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,14 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Changed — cancelling Conductor runs no longer requires finding the hidden button (#330 field report)
+
+- The run history offers **Cancel** directly on each running/waiting row (previously only
+  inside an opened trace — the delete guard said "cancel first" while the button was
+  effectively unfindable). Per-run busy state; the row-level cancel does not open the trace.
+- A delete blocked by active runs (409) now **opens the run history automatically** and the
+  message says where to cancel (en+de).
+
 ### Fixed — verifier: judge sees the sentence a fragment claim was cut from (#129 follow-up)
 
 - The claim extractor sometimes emits a subject-less fragment ("in die

--- a/web-ui/app/conductor/_components/ConductorRunTrace.tsx
+++ b/web-ui/app/conductor/_components/ConductorRunTrace.tsx
@@ -165,23 +165,29 @@ export function ConductorRunHistory({ slug, onClose }: { slug: string; onClose: 
 
   // #759 — operator cancel. 'waiting' ends immediately; 'running' shows the
   // pending hint until the driver honours the flag at the next step boundary.
-  const [cancelling, setCancelling] = useState(false);
+  // Offered on the run-list rows too (#330 field report): the delete guard
+  // demands cancelling active runs, so the button must be findable without
+  // knowing to open a single trace first. Busy state is per run id — one
+  // pending cancel must not lock every other row.
+  const [cancellingId, setCancellingId] = useState<string | null>(null);
   const cancelRun = useCallback(
     async (runId: string) => {
       if (!confirm(t('cancelRunConfirm'))) return;
-      setCancelling(true);
+      setCancellingId(runId);
       setError(null);
       try {
         await cancelConductorRun(slug, runId);
-        setSelected(await getConductorRun(slug, runId));
+        // Refresh whichever lens is open: the trace when this run is selected,
+        // and always the list (status badge flips / row button disappears).
+        if (selected?.run.id === runId) setSelected(await getConductorRun(slug, runId));
         await reload();
       } catch (err) {
         setError(err instanceof ApiError ? t('cancelRunFailed') : String(err));
       } finally {
-        setCancelling(false);
+        setCancellingId(null);
       }
     },
-    [slug, t, reload],
+    [slug, t, reload, selected],
   );
 
   return (
@@ -209,7 +215,7 @@ export function ConductorRunHistory({ slug, onClose }: { slug: string; onClose: 
             {(selected.run.status === 'running' || selected.run.status === 'waiting') && (
               <Button
                 variant="danger"
-                busy={cancelling}
+                busy={cancellingId === selected.run.id}
                 busyLabel={t('cancelRunBusy')}
                 onClick={() => void cancelRun(selected.run.id)}
               >
@@ -230,10 +236,10 @@ export function ConductorRunHistory({ slug, onClose }: { slug: string; onClose: 
       ) : (
         <ul className="grid gap-2">
           {runs.map((r) => (
-            <li key={r.id}>
+            <li key={r.id} className="flex items-center gap-2">
               {/* eslint-disable-next-line no-restricted-syntax -- full-width run-list row selector opening a trace, not a §4.2 CTA */}
               <button
-                className="flex w-full items-center justify-between gap-3 rounded-md border border-[color:var(--border)] px-3 py-2 text-left hover:bg-white/5"
+                className="flex min-w-0 flex-1 items-center justify-between gap-3 rounded-md border border-[color:var(--border)] px-3 py-2 text-left hover:bg-white/5"
                 onClick={() => void openRun(r.id)}
               >
                 <span className="flex items-center gap-3">
@@ -242,6 +248,20 @@ export function ConductorRunHistory({ slug, onClose }: { slug: string; onClose: 
                 </span>
                 <span className="font-mono text-[11px] text-[color:var(--fg-muted)]">{fmtTime(r.startedAt, format)}</span>
               </button>
+              {/* #330 field report — the delete guard demands cancelling active
+                  runs; the button has to be visible from the LIST, not hidden
+                  inside a single trace. Sibling (not nested) button: the row
+                  selector stays a plain button, valid HTML. */}
+              {(r.status === 'running' || r.status === 'waiting') && (
+                <Button
+                  variant="danger"
+                  busy={cancellingId === r.id}
+                  busyLabel={t('cancelRunBusy')}
+                  onClick={() => void cancelRun(r.id)}
+                >
+                  {t('cancelRunButton')}
+                </Button>
+              )}
             </li>
           ))}
         </ul>

--- a/web-ui/app/conductor/_components/__tests__/ConductorRunHistory.test.tsx
+++ b/web-ui/app/conductor/_components/__tests__/ConductorRunHistory.test.tsx
@@ -1,0 +1,72 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { cancelConductorRun, getConductorRun, listConductorRuns, type ConductorRun } from '@/app/_lib/api';
+import { renderWithIntl } from '../../../_lib/test-utils';
+import { ConductorRunHistory } from '../ConductorRunTrace';
+
+// Partial mock: only the network layer is stubbed — ApiError and the wire
+// types stay real (same pattern as TemplateInstantiateForm.test).
+vi.mock('@/app/_lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/app/_lib/api')>();
+  return {
+    ...actual,
+    listConductorRuns: vi.fn(),
+    getConductorRun: vi.fn(),
+    cancelConductorRun: vi.fn(),
+  };
+});
+
+function run(overrides: Partial<ConductorRun>): ConductorRun {
+  return {
+    id: 'run-1',
+    status: 'waiting',
+    triggerKind: 'manual',
+    startedAt: '2026-08-22T07:00:00.000Z',
+    endedAt: null,
+    currentStepId: null,
+    isDryRun: false,
+    cancelRequestedAt: null,
+    ...overrides,
+  } as ConductorRun;
+}
+
+// #330 field report — the delete guard demands cancelling active runs, so the
+// cancel affordance must be reachable from the run LIST, not only inside an
+// opened trace.
+describe('ConductorRunHistory — run-list cancel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listConductorRuns).mockResolvedValue({
+      runs: [run({ id: 'run-active', status: 'waiting' }), run({ id: 'run-done', status: 'completed' })],
+    });
+    vi.mocked(cancelConductorRun).mockResolvedValue(undefined as never);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  it('offers cancel on active rows only, and cancels straight from the list', async () => {
+    renderWithIntl(<ConductorRunHistory slug="test-teams" onClose={() => undefined} />);
+
+    // Exactly ONE cancel button: the waiting run's row; the succeeded run has none.
+    const cancelButtons = await screen.findAllByRole('button', { name: 'Cancel run' });
+    expect(cancelButtons).toHaveLength(1);
+
+    await userEvent.click(cancelButtons[0]!);
+    await waitFor(() => {
+      expect(cancelConductorRun).toHaveBeenCalledWith('test-teams', 'run-active');
+    });
+    // List refresh after the cancel — the guard-blocked delete becomes possible.
+    expect(listConductorRuns).toHaveBeenCalledTimes(2);
+    // No trace was open for this run, so the row-level cancel must not fetch one.
+    expect(getConductorRun).not.toHaveBeenCalled();
+  });
+
+  it('a declined confirm dialog cancels nothing', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    renderWithIntl(<ConductorRunHistory slug="test-teams" onClose={() => undefined} />);
+    const cancelButtons = await screen.findAllByRole('button', { name: 'Cancel run' });
+    await userEvent.click(cancelButtons[0]!);
+    expect(cancelConductorRun).not.toHaveBeenCalled();
+  });
+});

--- a/web-ui/app/conductor/page.tsx
+++ b/web-ui/app/conductor/page.tsx
@@ -148,11 +148,14 @@ export default function ConductorPage(): React.JSX.Element {
         await reload();
       } catch (err) {
         // Catalog copy, not the raw ApiError text (i18n hard rule) — the 409
-        // active-runs case gets its own actionable message.
+        // active-runs case gets its own actionable message AND opens the run
+        // history right away (#330 field report): the guard demands cancelling
+        // active runs, so put the cancel buttons on screen instead of making
+        // the operator hunt for them.
         setDeleteSlug(null);
-        setDeleteError(
-          err instanceof ApiError && err.status === 409 ? t('deleteHasActiveRuns') : t('deleteFailed'),
-        );
+        const hasActiveRuns = err instanceof ApiError && err.status === 409;
+        if (hasActiveRuns) setHistorySlug(wfSlug);
+        setDeleteError(hasActiveRuns ? t('deleteHasActiveRuns') : t('deleteFailed'));
       } finally {
         setDeleteBusy(false);
       }

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -465,7 +465,7 @@
     "deleteConfirmButton": "Löschen",
     "deleteCancelButton": "Abbrechen",
     "deleteFailed": "Der Workflow konnte nicht gelöscht werden",
-    "deleteHasActiveRuns": "Dieser Workflow hat laufende oder wartende Läufe — erst abbrechen, dann löschen.",
+    "deleteHasActiveRuns": "Dieser Workflow hat laufende oder wartende Läufe — der Verlauf ist unten geöffnet: dort erst abbrechen, dann löschen.",
     "running": "Läuft…",
     "refreshButton": "Aktualisieren",
     "statusLabel": "Status",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -465,7 +465,7 @@
     "deleteConfirmButton": "Delete",
     "deleteCancelButton": "Cancel",
     "deleteFailed": "The workflow could not be deleted",
-    "deleteHasActiveRuns": "This workflow has running or waiting runs — cancel them first, then delete.",
+    "deleteHasActiveRuns": "This workflow has running or waiting runs — the run history is open below: cancel them there, then delete.",
     "running": "Running…",
     "refreshButton": "Refresh",
     "statusLabel": "Status",


### PR DESCRIPTION
Field report from the #330 live test: the workflow delete guard says **"erst abbrechen, dann löschen"** — but the only cancel button (#759) hid inside a single opened run trace. The operator hit a dead end: no visible way to cancel, so no way to delete.

## What

- **Cancel on the run-list rows**: every `running`/`waiting` run in the history panel gets a Cancel button right on its row (sibling of the row selector — no nested buttons, valid HTML). Per-run busy state (`cancellingId`), so one pending cancel doesn't lock other rows; the row-level cancel does NOT open the trace, but a trace already open for that run refreshes.
- **409 delete opens the history automatically**: a delete blocked by active runs now sets the history panel to that workflow, putting the cancel buttons on screen instead of leaving the operator to hunt.
- **Guard copy points the way** (en+de): "the run history is open below: cancel them there, then delete."

## Test plan

- New `ConductorRunHistory.test.tsx`: cancel offered on active rows only, cancels straight from the list (correct slug/run, list refresh, no trace fetch), declined confirm cancels nothing. 817/817 web-ui tests green.
- `npm run i18n:check` green (3755 keys en+de), `tsc --noEmit` green, `npm run lint` green.
- i18n hard rule: only catalog keys touched, both locales updated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789970379&installation_model_id=428086&pr_number=840&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F840&signature=fbca3923406ea49d86bbec2fd0583412903940769d26ea6e64d1a777676b4092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->