### PR TITLE
feat: bot_present — inbound group messages open facilitation eligibility (#330 round 3)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,16 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — `bot_present`: an inbound group message opens facilitation eligibility (#330 round 3)
+
+- New channel-SDK membership-event kind **`bot_present`** — the adapter observed the agent is
+  ALREADY a member of a group conversation (transport-verified inbound message). A bot added
+  long ago never gets another `bot_added`, so the invite index stayed closed for exactly the
+  chats people talk to the bot in; two live facilitation attempts died on this.
+- The kernel invite index accepts `bot_present` as **eligibility only** — the deliberate,
+  announced entry (and any eager auto-bind by consumers) stays `bot_added`.
+
+
 ### Changed — cancelling Conductor runs no longer requires finding the hidden button (#330 field report)
 
 - The run history offers **Cancel** directly on each running/waiting row (previously only

--- a/middleware/packages/harness-channel-sdk/src/membershipEvent.ts
+++ b/middleware/packages/harness-channel-sdk/src/membershipEvent.ts
@@ -38,4 +38,16 @@ export interface MembersRemovedEvent extends ConversationEventBase {
   kind: 'members_removed';
 }
 
-export type ConversationMembershipEvent = BotAddedEvent | MembersAddedEvent | MembersRemovedEvent;
+/** #330 field report round 3 — the agent observed it is ALREADY a member of a
+ *  group conversation (an inbound group message is transport-verified proof of
+ *  membership; a bot added long ago never gets another `bot_added`). This is
+ *  an ELIGIBILITY signal only: consumers may record that a facilitation COULD
+ *  bind here, but must not eagerly bind or announce anything — the deliberate
+ *  entry stays `bot_added`. `addedBy` carries the message's verified sender
+ *  (the person engaging the agent), best-effort like on `bot_added`. */
+export interface BotPresentEvent extends ConversationEventBase {
+  kind: 'bot_present';
+  addedBy?: ChannelUserRef;
+}
+
+export type ConversationMembershipEvent = BotAddedEvent | MembersAddedEvent | MembersRemovedEvent | BotPresentEvent;

--- a/middleware/src/platform/observedConversationInvites.ts
+++ b/middleware/src/platform/observedConversationInvites.ts
@@ -81,7 +81,11 @@ export class ObservedConversationInvites {
   }
 
   observe(event: ConversationMembershipEvent): void {
-    if (event.kind !== 'bot_added') return;
+    // 'bot_present' (#330 round 3) counts as eligibility too: an inbound
+    // group message is transport-verified proof of membership — a bot that
+    // was added long ago never gets another bot_added, and the guard would
+    // otherwise stay closed for exactly the chats people talk to the bot in.
+    if (event.kind !== 'bot_added' && event.kind !== 'bot_present') return;
     // Group-only by design: a 1:1 never needs a facilitation binding, and
     // treating an unknown type as group would widen the guard on a guess.
     if (event.conversationType !== 'group') return;

--- a/middleware/test/observedConversationInvites.test.ts
+++ b/middleware/test/observedConversationInvites.test.ts
@@ -54,6 +54,14 @@ describe('ObservedConversationInvites', () => {
     assert.equal(invites.get('teams', 'nochan-1'), undefined);
   });
 
+  it("records 'bot_present' (#330 round 3) as eligibility — group-only, like bot_added", () => {
+    const invites = new ObservedConversationInvites();
+    invites.observe(botAdded({ kind: 'bot_present', conversationId: 'grp-present' }));
+    assert.equal(invites.get('teams', 'grp-present')?.addedBy?.id, 'aad-owner');
+    invites.observe(botAdded({ kind: 'bot_present', conversationId: 'dm-present', conversationType: 'direct' }));
+    assert.equal(invites.get('teams', 'dm-present'), undefined);
+  });
+
   it('expires invites after the TTL', () => {
     let now = 1_000_000;
     const invites = new ObservedConversationInvites({ ttlMs: 60_000, now: () => now });


### PR DESCRIPTION
Field report round 3 (identical symptom on 21.08. and 24.08., across two deploys): the facilitator could not start because the invite index never had the conversation. Root cause is structural, not persistence: **a bot that is ALREADY a group member never gets another `bot_added`** — the invite index stays closed for exactly the chats people talk to the bot in, no matter how well we persist it. The operator workaround (remove + re-invite the bot) is unreasonable and was the failure mode twice.

## What

- New channel-SDK membership-event kind **`bot_present`** (additive): the adapter observed the agent is already a member of a group conversation — an inbound group message is transport-verified proof of membership, stronger than `bot_added`.
- The kernel invite index (`ObservedConversationInvites`) accepts `bot_present` as **eligibility only**, group-only like `bot_added`. The deliberate announced entry — and any eager auto-bind by consumers — stays `bot_added`.
- Emitting stays a channel-adapter privilege (CoreApi seam unchanged), so `bot_present` is exactly as spoof-protected as `bot_added`.

## Companion releases (separate repos, merge-ready)

- channel-teams **0.18.0**: emits `bot_present` once per group conversation per 12h (deduped; the kernel's 24h eligibility TTL can therefore never outlive the only emit), with the message's verified sender as `addedBy`.
- facilitator **0.5.0**: `bot_present` → pending record with `bindPending` — **no eager bind** (binding every chat the bot merely talks in would hijack conversations nobody asked to be facilitated); the bind happens lazily inside `facilitation_start`, i.e. on explicit intent.

## Test plan

- Invite-index tests: `bot_present` grants eligibility (group-only, addedBy kept); 8/8.
- Full middleware suite green, ratchet 371 flat.
- CHANGELOG updated; plugin repos: facilitator 42/42 (pending-without-bind, no downgrade of real invites, lazy bind at start, invited records don't re-bind), teams 60/60.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790150041&installation_model_id=428086&pr_number=850&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F850&signature=3b560e0f2320273249bc6c1bed9d7c72fea01e789b8ba3207e851c9be9218f14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->