### PR TITLE
feat(channels): channel directory entries can carry resolved member names

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,16 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — channel directory entries can carry resolved member names
+
+- `ChannelKeyEntry` (`@omadia/channel-sdk`) gained optional `members` (capped list of
+  display names, resolved by the channel plugin — e.g. Teams via Microsoft Graph) and
+  `memberCount` (uncapped total). The kernel forwards both through
+  `ChannelDirectoryRegistry.listAll()` and `GET /api/v1/operator/channels`
+  (`members` / `member_count`); the operator Channels dashboard renders a
+  "Members: Alice, Bob +N more" line (en+de). Older plugins that don't set the
+  fields are unaffected — the fields are additive and optional in both directions.
+
 ### Changed — cancelling Conductor runs no longer requires finding the hidden button (#330 field report)
 
 - The run history offers **Cancel** directly on each running/waiting row (previously only

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -2306,3 +2306,24 @@ Gute Einstiegs-Prompts, geordnet nach erwartetem Gewinn:
   alles"-Antwort.
 - Die Dev-UI unter `http://localhost:3000` ist der schnellste Weg, Agent-
   Verhalten interaktiv zu testen — sie streamt Tool-Calls live.
+
+## Channel-Directory: aufgelöste Namen + Mitglieder (2026-08-24)
+
+Der Channel-Directory-Contract (`@omadia/channel-sdk` 0.2.0,
+`ChannelKeyEntry`) trägt zwei optionale Felder: `members` (gecappte
+Display-Namen, vom Channel-Plugin aufgelöst — Teams macht das via
+Microsoft Graph) und `memberCount` (ungecappte Gesamtzahl). Der Kernel
+reicht beide durch `ChannelDirectoryRegistry.listAll()` →
+`GET /api/v1/operator/channels` (`members` / `member_count`) und cappt
+dabei hart (max. 16 Namen à 120 Zeichen, negative Counts verworfen) —
+Plugins sind untrusted. Das Channels-Dashboard (web-ui, auch eingebettet
+in `/operator/agents`) rendert daraus eine "Mitglieder: …"-Zeile
+(i18n-Keys `operatorChannels.membersLine` / `membersMore`).
+
+Die eigentliche Graph-Auflösung (Group-Chat-Topic, Chat-/Team-Members,
+Org-Name für den Catch-all) lebt im Plugin-Repo
+`byte5ai/omadia-channel-teams` (`teamsGraphResolver.ts`) — nie awaited
+im Render-Pfad, stale-while-revalidate ab `observe()`, degradiert ohne
+Graph-App-Permissions lautlos auf die Bot-Framework-Labels. Benötigte
+Application-Permissions (Admin-Consent im Tenant): `Chat.Read.All`,
+`ChatMember.Read.All`, `TeamMember.Read.All`, `Organization.Read.All`.

--- a/middleware/package-lock.json
+++ b/middleware/package-lock.json
@@ -9132,7 +9132,7 @@
       },
       "peerDependencies": {
         "@omadia/api-key-auth": "^0.1.0",
-        "@omadia/channel-sdk": "^0.1.0",
+        "@omadia/channel-sdk": "^0.2.0",
         "@omadia/plugin-api": "*",
         "express": "^5.1.0",
         "zod": "^4.0.0"
@@ -9140,7 +9140,7 @@
     },
     "packages/harness-channel-sdk": {
       "name": "@omadia/channel-sdk",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/middleware/packages/harness-channel-api/package.json
+++ b/middleware/packages/harness-channel-api/package.json
@@ -13,7 +13,7 @@
   },
   "peerDependencies": {
     "@omadia/api-key-auth": "^0.1.0",
-    "@omadia/channel-sdk": "^0.1.0",
+    "@omadia/channel-sdk": "^0.2.0",
     "@omadia/plugin-api": "*",
     "express": "^5.1.0",
     "zod": "^4.0.0"

--- a/middleware/packages/harness-channel-sdk/package.json
+++ b/middleware/packages/harness-channel-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@omadia/channel-sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/middleware/packages/harness-channel-sdk/src/channelKeyDirectory.ts
+++ b/middleware/packages/harness-channel-sdk/src/channelKeyDirectory.ts
@@ -43,6 +43,16 @@ export interface ChannelKeyEntry {
   /** Free-form context shown beside the label — environment, tenant
    *  hint, conversation name. Optional. */
   readonly hint?: string;
+  /** Display names of the conversation's members, resolved by the plugin
+   *  (e.g. via Graph for Teams). Capped by the plugin (recommended: 8) —
+   *  `memberCount` carries the uncapped total. These are data, not UI
+   *  copy: the dashboard composes the visible sentence from its own
+   *  message catalog. Optional — omitted when the plugin cannot resolve
+   *  members (missing permissions, non-conversation entries). */
+  readonly members?: readonly string[];
+  /** Total number of members in the conversation, including those not
+   *  listed in `members` because of the cap. Optional. */
+  readonly memberCount?: number;
 }
 
 export interface ChannelKeyDirectory {

--- a/middleware/src/channels/channelDirectoryRegistry.ts
+++ b/middleware/src/channels/channelDirectoryRegistry.ts
@@ -96,6 +96,7 @@ export class ChannelDirectoryRegistry {
             key: entry.key,
             label: entry.label,
             ...(entry.hint !== undefined ? { hint: entry.hint } : {}),
+            ...sanitizedMemberFields(entry),
           });
         }
       } catch (err) {
@@ -121,4 +122,35 @@ export class ChannelDirectoryRegistry {
 export interface EnrichedChannelKey extends ChannelKeyEntry {
   readonly channelType: string;
   readonly originPluginId: string;
+}
+
+// Boundary caps for plugin-provided member data. Plugins are asked to cap
+// at 8 themselves (SDK doc); the kernel enforces a hard ceiling so a
+// misbehaving plugin cannot flood the operator API payload / dashboard DOM.
+const MAX_MEMBERS = 16;
+const MAX_MEMBER_NAME_LENGTH = 120;
+
+function sanitizedMemberFields(
+  entry: ChannelKeyEntry,
+): Pick<EnrichedChannelKey, 'members' | 'memberCount'> {
+  const members = Array.isArray(entry.members)
+    ? entry.members
+        .filter((m): m is string => typeof m === 'string' && m.length > 0)
+        .slice(0, MAX_MEMBERS)
+        .map((m) =>
+          m.length > MAX_MEMBER_NAME_LENGTH
+            ? `${m.slice(0, MAX_MEMBER_NAME_LENGTH)}…`
+            : m,
+        )
+    : undefined;
+  const memberCount =
+    typeof entry.memberCount === 'number' &&
+    Number.isFinite(entry.memberCount) &&
+    entry.memberCount >= 0
+      ? Math.floor(entry.memberCount)
+      : undefined;
+  return {
+    ...(members !== undefined && members.length > 0 ? { members } : {}),
+    ...(memberCount !== undefined ? { memberCount } : {}),
+  };
 }

--- a/middleware/src/routes/operatorChannels.ts
+++ b/middleware/src/routes/operatorChannels.ts
@@ -53,6 +53,10 @@ interface OperatorChannelDto {
   readonly channel_key: string;
   readonly label: string;
   readonly hint?: string;
+  /** Member display names resolved by the channel plugin (capped there);
+   *  `member_count` carries the uncapped total. Both optional. */
+  readonly members?: readonly string[];
+  readonly member_count?: number;
   readonly origin_plugin_id: string;
   readonly bound_agent_slug: string | null;
   /** True when this row is only known from the binding table (the channel
@@ -143,6 +147,10 @@ export function createOperatorChannelsRouter(
           channel_key: entry.key,
           label: entry.label,
           ...(entry.hint !== undefined ? { hint: entry.hint } : {}),
+          ...(entry.members !== undefined ? { members: entry.members } : {}),
+          ...(entry.memberCount !== undefined
+            ? { member_count: entry.memberCount }
+            : {}),
           origin_plugin_id: entry.originPluginId,
           bound_agent_slug: slug,
           stale: false,

--- a/middleware/test/channelDirectoryMembers.test.ts
+++ b/middleware/test/channelDirectoryMembers.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import express from 'express';
+import type { Express } from 'express';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import type {
+  ChannelKeyDirectory,
+  ChannelKeyEntry,
+} from '@omadia/channel-sdk';
+import type {
+  ConfigStore,
+  OrchestratorRegistry,
+} from '@omadia/orchestrator';
+
+import { ChannelDirectoryRegistry } from '../src/channels/channelDirectoryRegistry.js';
+import { createOperatorChannelsRouter } from '../src/routes/operatorChannels.js';
+
+/**
+ * `members` / `memberCount` passthrough — the optional member-resolution
+ * fields a channel plugin (e.g. Teams via Graph) can attach to its
+ * directory entries. Two layers under test:
+ *
+ *   1. ChannelDirectoryRegistry.listAll() forwards the fields verbatim
+ *      and omits them when the plugin did not set them.
+ *   2. GET /api/v1/operator/channels maps them to `members` /
+ *      `member_count` in the DTO; stale binding rows never carry them.
+ */
+
+function fakeDirectory(
+  channelType: string,
+  entries: readonly ChannelKeyEntry[],
+): ChannelKeyDirectory {
+  return {
+    channelType,
+    originPluginId: `@omadia/channel-${channelType}`,
+    listKeys: async () => entries,
+  };
+}
+
+describe('ChannelDirectoryRegistry members passthrough', () => {
+  it('forwards members + memberCount and omits them when unset', async () => {
+    const registry = new ChannelDirectoryRegistry();
+    registry.register(
+      fakeDirectory('teams', [
+        {
+          key: '19:chat@thread.skype',
+          label: 'Project Group',
+          members: ['Alice Adams', 'Bob Brown'],
+          memberCount: 5,
+        },
+        { key: '28:bot-app-id', label: 'Teams Bot (all)', hint: 'catch-all' },
+      ]),
+    );
+
+    const all = await registry.listAll();
+    assert.equal(all.length, 2);
+
+    const enriched = all.find((e) => e.key === '19:chat@thread.skype');
+    assert.ok(enriched);
+    assert.deepEqual(enriched.members, ['Alice Adams', 'Bob Brown']);
+    assert.equal(enriched.memberCount, 5);
+
+    const plain = all.find((e) => e.key === '28:bot-app-id');
+    assert.ok(plain);
+    assert.equal('members' in plain, false);
+    assert.equal('memberCount' in plain, false);
+  });
+
+  it('caps oversized member lists and names at the kernel boundary', async () => {
+    const registry = new ChannelDirectoryRegistry();
+    registry.register(
+      fakeDirectory('teams', [
+        {
+          key: '19:big@thread.skype',
+          label: 'Big Group',
+          members: Array.from({ length: 40 }, (_, i) => `Member ${String(i)}`),
+          memberCount: 40,
+        },
+        {
+          key: '19:long@thread.skype',
+          label: 'Long Names',
+          members: ['x'.repeat(500)],
+          memberCount: -3,
+        },
+      ]),
+    );
+
+    const all = await registry.listAll();
+    const big = all.find((e) => e.key === '19:big@thread.skype');
+    assert.ok(big?.members);
+    assert.equal(big.members.length, 16);
+    assert.equal(big.memberCount, 40);
+
+    const long = all.find((e) => e.key === '19:long@thread.skype');
+    assert.ok(long?.members);
+    assert.equal(long.members[0]?.length, 121); // 120 chars + ellipsis
+    assert.equal('memberCount' in long, false); // negative count dropped
+  });
+});
+
+interface Harness {
+  server: Server;
+  baseUrl: string;
+  close(): Promise<void>;
+}
+
+async function makeRouteHarness(
+  entries: readonly ChannelKeyEntry[],
+  bindings: Array<{
+    channelType: string;
+    channelKey: string;
+    agentId: string;
+  }> = [],
+): Promise<Harness> {
+  const directory = new ChannelDirectoryRegistry();
+  directory.register(fakeDirectory('teams', entries));
+
+  const store = {
+    listAgents: async () => [
+      { id: 'a1', slug: 'hr', name: 'HR', status: 'enabled' },
+    ],
+    listChannelBindings: async () => bindings,
+    getPlatformSettings: async () => ({ fallbackAgentId: 'a1' }),
+  } as unknown as ConfigStore;
+  const orchestratorRegistry = {
+    reload: async () => undefined,
+  } as unknown as OrchestratorRegistry;
+
+  const app: Express = express();
+  app.use(express.json());
+  app.use(
+    '/api/v1/operator/channels',
+    createOperatorChannelsRouter({
+      getConfigStore: () => store,
+      getRegistry: () => orchestratorRegistry,
+      getDirectoryRegistry: () => directory,
+    }),
+  );
+  const server = await new Promise<Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve())),
+      ),
+  };
+}
+
+describe('GET /api/v1/operator/channels members mapping', () => {
+  let harness: Harness | undefined;
+  afterEach(async () => {
+    await harness?.close();
+    harness = undefined;
+  });
+
+  it('maps members/memberCount to members/member_count and leaves them off plain rows', async () => {
+    harness = await makeRouteHarness([
+      {
+        key: '19:chat@thread.skype',
+        label: 'Project Group',
+        members: ['Alice Adams', 'Bob Brown'],
+        memberCount: 5,
+      },
+      { key: '28:bot-app-id', label: 'Teams Bot (all)' },
+    ]);
+
+    const res = await fetch(`${harness.baseUrl}/api/v1/operator/channels`);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as {
+      channels: Array<Record<string, unknown>>;
+    };
+
+    const withMembers = body.channels.find(
+      (c) => c['channel_key'] === '19:chat@thread.skype',
+    );
+    assert.ok(withMembers);
+    assert.deepEqual(withMembers['members'], ['Alice Adams', 'Bob Brown']);
+    assert.equal(withMembers['member_count'], 5);
+
+    const plain = body.channels.find(
+      (c) => c['channel_key'] === '28:bot-app-id',
+    );
+    assert.ok(plain);
+    assert.equal('members' in plain, false);
+    assert.equal('member_count' in plain, false);
+  });
+
+  it('never adds members to stale binding rows', async () => {
+    harness = await makeRouteHarness(
+      [{ key: '28:bot-app-id', label: 'Teams Bot (all)' }],
+      [{ channelType: 'teams', channelKey: '19:gone@thread.skype', agentId: 'a1' }],
+    );
+
+    const res = await fetch(`${harness.baseUrl}/api/v1/operator/channels`);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as {
+      channels: Array<Record<string, unknown>>;
+    };
+    const stale = body.channels.find((c) => c['stale'] === true);
+    assert.ok(stale);
+    assert.equal(stale['channel_key'], '19:gone@thread.skype');
+    assert.equal('members' in stale, false);
+    assert.equal('member_count' in stale, false);
+  });
+});

--- a/web-ui/app/_lib/channels.ts
+++ b/web-ui/app/_lib/channels.ts
@@ -37,6 +37,8 @@ export interface OperatorChannelDto {
   channel_key: string;
   label: string;
   hint?: string;
+  members?: string[];
+  member_count?: number;
   origin_plugin_id: string;
   bound_agent_slug: string | null;
   stale: boolean;

--- a/web-ui/app/operator/channels/_components/ChannelsDashboard.tsx
+++ b/web-ui/app/operator/channels/_components/ChannelsDashboard.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
-import { useTranslations } from 'next-intl';
+import { useFormatter, useTranslations } from 'next-intl';
 
 import { ApiError } from '../../../_lib/api';
 import {
@@ -29,6 +29,7 @@ interface Props {
  */
 export function ChannelsDashboard({ initial }: Props): React.ReactElement {
   const t = useTranslations('operatorChannels');
+  const format = useFormatter();
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
@@ -128,6 +129,19 @@ export function ChannelsDashboard({ initial }: Props): React.ReactElement {
                       </span>
                     )}
                   </div>
+                  {c.members && c.members.length > 0 && (
+                    <div className="mt-1 text-[11px] text-[color:var(--fg-muted)]">
+                      {t('membersLine', { names: format.list(c.members) })}
+                      {(c.member_count ?? 0) > c.members.length && (
+                        <>
+                          {' '}
+                          {t('membersMore', {
+                            count: (c.member_count ?? 0) - c.members.length,
+                          })}
+                        </>
+                      )}
+                    </div>
+                  )}
                 </div>
                 <label className="flex items-center gap-2 text-xs text-[color:var(--fg-muted)]">
                   <span>{t('routesTo')}</span>

--- a/web-ui/app/operator/channels/_components/__tests__/ChannelsDashboard.members.test.tsx
+++ b/web-ui/app/operator/channels/_components/__tests__/ChannelsDashboard.members.test.tsx
@@ -1,0 +1,82 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { renderWithIntl } from '../../../../_lib/test-utils';
+import type { ChannelsListDto, OperatorChannelDto } from '../../../../_lib/channels';
+import { ChannelsDashboard } from '../ChannelsDashboard';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+/**
+ * Members line for channel rows (Graph-resolved by the channel plugin).
+ * The gating logic worth guarding: the line renders only when `members`
+ * is non-empty, and the "+N more" suffix appears only when `member_count`
+ * exceeds the listed names — equal counts and a missing `member_count`
+ * must NOT produce a stray "+0 more".
+ */
+
+function channel(over: Partial<OperatorChannelDto>): OperatorChannelDto {
+  return {
+    channel_type: 'teams',
+    channel_key: '19:chat@thread.skype',
+    label: 'Project Group',
+    origin_plugin_id: '@omadia/channel-teams',
+    bound_agent_slug: null,
+    stale: false,
+    ...over,
+  };
+}
+
+function dto(channels: OperatorChannelDto[]): ChannelsListDto {
+  return {
+    channels,
+    agents: [{ slug: 'hr', name: 'HR' }],
+    fallback_slug: 'hr',
+    directory_types: ['teams'],
+  };
+}
+
+describe('ChannelsDashboard members line', () => {
+  it('renders names and the +N suffix when member_count exceeds the list', () => {
+    renderWithIntl(
+      <ChannelsDashboard
+        initial={dto([
+          channel({ members: ['Alice Adams', 'Bob Brown'], member_count: 5 }),
+        ])}
+      />,
+    );
+    expect(
+      screen.getByText(/Members: Alice Adams and Bob Brown/),
+    ).toBeDefined();
+    expect(screen.getByText(/\+3 more/)).toBeDefined();
+  });
+
+  it('omits the +N suffix when member_count equals the listed names', () => {
+    renderWithIntl(
+      <ChannelsDashboard
+        initial={dto([
+          channel({ members: ['Alice Adams', 'Bob Brown'], member_count: 2 }),
+        ])}
+      />,
+    );
+    expect(screen.getByText(/Members: /)).toBeDefined();
+    expect(screen.queryByText(/more/)).toBeNull();
+  });
+
+  it('omits the +N suffix when member_count is missing', () => {
+    renderWithIntl(
+      <ChannelsDashboard
+        initial={dto([channel({ members: ['Alice Adams'] })])}
+      />,
+    );
+    expect(screen.getByText(/Members: Alice Adams/)).toBeDefined();
+    expect(screen.queryByText(/more/)).toBeNull();
+  });
+
+  it('renders no members line when members is absent', () => {
+    renderWithIntl(<ChannelsDashboard initial={dto([channel({})])} />);
+    expect(screen.queryByText(/Members: /)).toBeNull();
+  });
+});

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -784,6 +784,8 @@
     "fallbackHint": "Channels ohne explizite Zuordnung landen beim Standard-Orchestrator ({fallback}).",
     "fallbackHintNone": "kein Standard gesetzt",
     "originLabel": "via",
+    "membersLine": "Mitglieder: {names}",
+    "membersMore": "{count, plural, one {+# weiteres} other {+# weitere}}",
     "staleBadge": "veraltet",
     "routesTo": "→ Orchestrator:",
     "routesToFallback": "(Standard · {fallback})",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -784,6 +784,8 @@
     "fallbackHint": "Channels without an explicit binding fall through to the standard Orchestrator ({fallback}).",
     "fallbackHintNone": "no standard set",
     "originLabel": "via",
+    "membersLine": "Members: {names}",
+    "membersMore": "{count, plural, one {+# more} other {+# more}}",
     "staleBadge": "stale",
     "routesTo": "→ Orchestrator:",
     "routesToFallback": "(standard · {fallback})",


### PR DESCRIPTION
## Summary

The operator Channels dashboard (/operator/channels, embedded in /operator/agents) shows raw Teams keys like 28:<app-id> and 19:...@thread.skype with no idea who is in the conversation. This PR extends the channel-directory contract so channel plugins can attach resolved member names:

- ChannelKeyEntry (@omadia/channel-sdk -> 0.2.0) gains optional members (capped display-name list, resolved by the plugin - e.g. Teams via Microsoft Graph) and memberCount (uncapped total).
- ChannelDirectoryRegistry.listAll() forwards both, enforcing a hard kernel-side boundary cap (max 16 names, 120 chars each, negative counts dropped) - plugin directories are untrusted input.
- GET /api/v1/operator/channels maps them to members / member_count.
- The Channels dashboard renders a muted "Members: Alice, Bob +3 more" line (en+de, ICU plural, locale-aware list formatting via useFormatter().list).

Additive-optional in both directions: old plugins and old hosts keep working unchanged. Stale binding rows never carry members. The actual Graph resolution (group-chat topic, chat/team members, tenant org name for the catch-all) ships separately in byte5ai/omadia-channel-teams.

## Test plan

- [x] middleware/test/channelDirectoryMembers.test.ts - registry passthrough, omission when unset, kernel boundary caps, route DTO mapping, stale rows member-less (4/4)
- [x] web-ui component test for the members line gating (+N only when member_count exceeds the list; no line without members) (4/4)
- [x] middleware full npm run build (workspace chain + tsc) green
- [x] web-ui npm run i18n:check (3757 keys OK) + full vitest incl. i18n-parity green
- [x] eslint clean on changed files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790150874&installation_model_id=428086&pr_number=851&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F851&signature=a4c4d75ae4766766e7f1f28a3446e9be3aadba1fe6215cdd83263c9a412df6e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->