### PR TITLE
fix(publish): allocate versions with an atomic upsert, not SELECT FOR UPDATE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,8 @@ jobs:
           # subsystem left core together with the code they covered (their
           # successors run in the plugin repository). Measured on the C10
           # head, not estimated. 252 → 279 with C11 (27 ledger-handoff pg tests).
-          PG_TEST_FLOOR: '279'
+          # 279 → 281 with #834 (2 publish allocator-race tests).
+          PG_TEST_FLOOR: '281'
         run: |
           set -eo pipefail
           npm run test:pg 2>&1 | tee pg-test.out

--- a/middleware/packages/harness-publish/src/postgresPublishStore.ts
+++ b/middleware/packages/harness-publish/src/postgresPublishStore.ts
@@ -6,14 +6,51 @@ import type { CreateVersionInput, PublishStore } from './publishStore.js';
 /**
  * Postgres-backed `PublishStore` — migration `0045_publish_versions.sql`.
  *
- * Version allocation runs `SELECT ... FOR UPDATE` on the app's counter row
- * inside a transaction, so two concurrent publishes to the same `appId`
- * serialize on that row lock rather than racing for the same version
- * number — the DB-level guarantee backing the same invariant
- * `InMemoryPublishStore` gets from JS's single-threaded execution.
+ * Version allocation is ONE statement — an upsert on the app's counter row
+ * that returns the number it just consumed — so two concurrent publishes to
+ * the same `appId` serialize on that row's lock rather than racing for the
+ * same version number. That is the DB-level guarantee backing the invariant
+ * `InMemoryPublishStore` gets for free from JS's single-threaded execution.
  * `publish_versions`'s primary key `(app_id, version)` is the second,
  * independent line of defense: even a bug in the allocator can only ever
  * fail loudly (a unique-violation) rather than silently overwrite a row.
+ *
+ * WHY ONE STATEMENT (issue #834)
+ * ------------------------------
+ * The allocator used to read the counter with `SELECT ... FOR UPDATE` and
+ * then, when that returned nothing, `INSERT` the row. `FOR UPDATE` locks the
+ * rows it finds, and on the first publish for an app there is no row to find
+ * — so it locked NOTHING and every concurrent caller fell through to the
+ * same bare `INSERT`. One won; the rest died on `publish_apps_pkey`. It read
+ * as an intermittent CI flake because it needs two publishes to a brand-new
+ * app to overlap; with eight racing callers it reproduces every time.
+ *
+ * A read-modify-write cannot be made safe by locking harder at the read: the
+ * row whose absence is the problem is the row the lock has nothing to hold.
+ * So the read-modify-write is gone. `ON CONFLICT ... DO UPDATE` is the one
+ * form Postgres documents as an atomic insert-or-update: a caller that finds
+ * the row missing and a caller that finds it present take the same code path,
+ * and a caller arriving while another's insert is still uncommitted waits for
+ * that transaction and then updates the row it committed.
+ *
+ * Two alternatives were considered and rejected:
+ *
+ *   - **`ON CONFLICT DO NOTHING`, then `SELECT ... FOR UPDATE`.** Correct on
+ *     PG16 (verified: `DO NOTHING` really does wait out the conflicting
+ *     transaction, so the follow-up SELECT sees a committed row), but it is
+ *     three statements where one suffices, and its correctness rests on
+ *     speculative-insertion wait semantics that a future reader cannot check
+ *     by reading the query. Atomic-by-construction beats atomic-if-you-know.
+ *
+ *   - **`pg_advisory_xact_lock(ns, hashtext(app_id))`** around the original
+ *     read-modify-write, the shape core migrators use (namespace 4410) and
+ *     `embeddingModelGate` uses (4401). Those lock a *concept* with no row of
+ *     its own; here the contended thing already IS a row with a primary key,
+ *     so the row lock is both free and exact. An advisory lock would key on
+ *     `hashtext` of a caller-supplied app id, which makes two unrelated apps
+ *     whose ids collide serialize against each other — the same "hash
+ *     collision as an availability lever" that `pluginMigrations.ts` gives a
+ *     whole namespace to avoid. Cheaper and stricter to lock the row itself.
  */
 export class PostgresPublishStore implements PublishStore {
   constructor(private readonly pool: Pool) {}
@@ -46,30 +83,33 @@ export class PostgresPublishStore implements PublishStore {
     }
   }
 
-  /** Row-locks (or creates) `appId`'s counter row and returns the version
-   *  number to use THIS call, leaving the row set to hand out the next one
-   *  after. Caller must already be inside the transaction that also inserts
-   *  the version row, so a crash between the two never leaves a gap a
-   *  concurrent caller could reuse. */
+  /**
+   * Consumes `appId`'s next version number and returns it, creating the
+   * counter row on first publish. Atomic and race-free by construction — see
+   * the class header for why this is one statement and not a read-then-write.
+   *
+   * Both branches advance the counter by exactly one and return the value it
+   * held before: a fresh row is written straight to 2 (having handed out 1),
+   * an existing row goes to `next_version + 1`. `RETURNING next_version - 1`
+   * reads the post-action row, so the same expression is correct either way.
+   *
+   * Caller must already be inside the transaction that also inserts the
+   * version row. That is what makes the number gapless: the upsert holds the
+   * counter row's lock until that transaction ends, so a concurrent allocator
+   * cannot pass it, and a rollback returns the number to the pool instead of
+   * retiring it with no `publish_versions` row to show for it.
+   */
   private async allocateVersion(client: PoolClient, appId: string, now: Date): Promise<number> {
-    const existing = await client.query<{ next_version: number }>(
-      `SELECT next_version FROM publish_apps WHERE app_id = $1 FOR UPDATE`,
-      [appId],
+    const result = await client.query<{ allocated: number }>(
+      `INSERT INTO publish_apps (app_id, next_version, updated_at)
+       VALUES ($1, 2, $2)
+       ON CONFLICT (app_id) DO UPDATE SET
+         next_version = publish_apps.next_version + 1,
+         updated_at = EXCLUDED.updated_at
+       RETURNING next_version - 1 AS allocated`,
+      [appId, now.toISOString()],
     );
-    if (existing.rows.length === 0) {
-      await client.query(
-        `INSERT INTO publish_apps (app_id, next_version, updated_at) VALUES ($1, 2, $2)`,
-        [appId, now.toISOString()],
-      );
-      return 1;
-    }
-    const allocated = existing.rows[0]!.next_version;
-    await client.query(`UPDATE publish_apps SET next_version = $2, updated_at = $3 WHERE app_id = $1`, [
-      appId,
-      allocated + 1,
-      now.toISOString(),
-    ]);
-    return allocated;
+    return result.rows[0]!.allocated;
   }
 
   async getVersion(appId: string, version: number): Promise<PublishVersionRecord | undefined> {

--- a/middleware/test/publish/publishStore.pg.test.ts
+++ b/middleware/test/publish/publishStore.pg.test.ts
@@ -43,12 +43,30 @@ CREATE TABLE IF NOT EXISTS publish_apps (
 
 const describeIf = pgAvailable ? describe : describe.skip;
 
+/**
+ * How many publishes race for the same app in the concurrency test (#834).
+ *
+ * The original suite raced two, which reproduced the allocator bug only
+ * intermittently — that is precisely why #834 surfaced as a CI flake rather
+ * than a red test. Eight makes the pre-fix failure deterministic: against the
+ * broken `SELECT … FOR UPDATE`-on-a-missing-row allocator, seven of the eight
+ * lose the bare-INSERT race and die on `publish_apps_pkey` (measured, 5/5
+ * rounds), so a regression here fails loudly on the first run instead of once
+ * every few CI builds.
+ */
+const CONCURRENT_PUBLISHERS = 8;
+
 describeIf('PostgresPublishStore (#581)', () => {
   let pool: Pool;
   let store: PostgresPublishStore;
 
   before(async () => {
-    pool = new Pool({ connectionString: PG_URL });
+    // `max` is set explicitly rather than left to node-postgres' default of
+    // 10: the concurrency test below needs CONCURRENT_PUBLISHERS real
+    // connections in flight at once to exercise the allocator's race, and a
+    // pool smaller than that would queue them into an accidental serial run
+    // — a test that passes because it never actually raced.
+    pool = new Pool({ connectionString: PG_URL, max: CONCURRENT_PUBLISHERS + 4 });
     await pool.query(SCHEMA);
     store = new PostgresPublishStore(pool);
   });
@@ -79,6 +97,101 @@ describeIf('PostgresPublishStore (#581)', () => {
     const byVersion = new Map(versions.map((v) => [v.version, v]));
     assert.equal(byVersion.get(a.version)!.dirHash, a.dirHash);
     assert.equal(byVersion.get(b.version)!.dirHash, b.dirHash);
+  });
+
+  it(`${String(CONCURRENT_PUBLISHERS)} concurrent createVersion calls for one app allocate unique, gapless versions with no unique-violation (#834)`, async () => {
+    const appId = `pg-race8-${String(Date.now())}`;
+
+    // Pre-warm the pool. Without this the first callers spend their turn in
+    // the TCP/auth handshake and drift apart in time, so the allocations
+    // stagger and the race window the test exists to hit is never opened.
+    const warm = await Promise.all(Array.from({ length: CONCURRENT_PUBLISHERS }, () => pool.connect()));
+    for (const client of warm) client.release();
+
+    const settled = await Promise.allSettled(
+      Array.from({ length: CONCURRENT_PUBLISHERS }, (_, i) =>
+        store.createVersion({
+          appId,
+          name: 'A',
+          entrypoint: `e${String(i)}.js`,
+          dirHash: `hash-${String(i)}`,
+          sourceScopeKey: 's',
+          now: new Date(),
+        }),
+      ),
+    );
+
+    // Report the SQLSTATE rather than just a count: `23505` is the exact
+    // signature of #834, and a different code would mean a different bug.
+    const rejected = settled.filter((r) => r.status === 'rejected');
+    assert.equal(
+      rejected.length,
+      0,
+      `no publish may fail; got ${String(rejected.length)}: ${JSON.stringify(
+        rejected.map((r) => {
+          const err: unknown = r.reason;
+          const code = err instanceof Error ? (err as Error & { code?: string }).code : undefined;
+          const constraint = err instanceof Error ? (err as Error & { constraint?: string }).constraint : undefined;
+          return { code: code ?? String(err), constraint };
+        }),
+      )}`,
+    );
+
+    const allocated = settled
+      .filter((r): r is PromiseFulfilledResult<Awaited<ReturnType<typeof store.createVersion>>> => r.status === 'fulfilled')
+      .map((r) => r.value.version)
+      .sort((x, y) => x - y);
+    assert.deepEqual(
+      allocated,
+      Array.from({ length: CONCURRENT_PUBLISHERS }, (_, i) => i + 1),
+      'versions must be unique and gapless — 1..N with nothing handed out twice and nothing skipped',
+    );
+
+    // Every allocation must also have landed as its own row with its own
+    // content hash: a number handed out twice would show up here as a lost
+    // row, not just as a duplicate above.
+    const rows = await store.listVersions(appId);
+    assert.equal(rows.length, CONCURRENT_PUBLISHERS);
+    const hashes = new Set(rows.map((r) => r.dirHash));
+    assert.equal(hashes.size, CONCURRENT_PUBLISHERS, 'no publish may have been overwritten by another');
+
+    // The counter is left pointing past the last allocation, so the next
+    // publish continues the sequence instead of replaying a used number.
+    const counter = await pool.query<{ next_version: number }>(`SELECT next_version FROM publish_apps WHERE app_id = $1`, [
+      appId,
+    ]);
+    assert.equal(counter.rows[0]!.next_version, CONCURRENT_PUBLISHERS + 1);
+  });
+
+  it('a createVersion whose version insert fails burns no version number — the counter rolls back with it (#834)', async () => {
+    const appId = `pg-gap-${String(Date.now())}`;
+
+    // Occupy version 1 behind the store's back, so the allocation succeeds
+    // but the `publish_versions` insert that follows it inside the same
+    // transaction hits the primary key and forces a ROLLBACK.
+    await pool.query(
+      `INSERT INTO publish_versions (app_id, version, name, entrypoint, dir_hash, source_scope_key)
+       VALUES ($1, 1, 'squatter', 'squat.js', 'squat', 's')`,
+      [appId],
+    );
+    await assert.rejects(() =>
+      store.createVersion({ appId, name: 'A', entrypoint: 'x.js', dirHash: 'h1', sourceScopeKey: 's', now: new Date() }),
+    );
+
+    // With the allocation held inside the caller's transaction, the rollback
+    // takes the counter with it. An allocator that committed the counter
+    // separately would leave version 1 consumed and hand out 2 here — a gap,
+    // and a version number retired without a row to show for it.
+    await pool.query(`DELETE FROM publish_versions WHERE app_id = $1`, [appId]);
+    const retried = await store.createVersion({
+      appId,
+      name: 'A',
+      entrypoint: 'x.js',
+      dirHash: 'h1',
+      sourceScopeKey: 's',
+      now: new Date(),
+    });
+    assert.equal(retried.version, 1);
   });
 
   it('the (app_id, version) primary key rejects a direct duplicate insert at the schema level', async () => {


### PR DESCRIPTION
Fixes #834

## The bug

`PostgresPublishStore.allocateVersion` was a read-modify-write:

```sql
SELECT next_version FROM publish_apps WHERE app_id = $1 FOR UPDATE   -- locks nothing when the row is absent
INSERT INTO publish_apps (app_id, next_version, updated_at) VALUES ($1, 2, $2)   -- unguarded
```

`FOR UPDATE` locks the rows it *finds*. On the first publish for an app there is no row to find, so it locked nothing, and every concurrent caller fell through to the same bare `INSERT`. One won; the rest died on `publish_apps_pkey` (SQLSTATE `23505`).

That is why it read as the intermittent CI flake `#581 concurrent createVersion` rather than a red test: the existing test races only two publishers, so it needs both publishes to a brand-new app to overlap closely enough to lose.

Note the failure mode is not merely noisy — a publish that should have been version 2 is rejected outright. `publish_versions`'s primary key was doing its job (fail loudly, never silently overwrite), but the caller still eats an error for a perfectly valid publish.

## The fix

Allocation is now a single atomic statement:

```sql
INSERT INTO publish_apps (app_id, next_version, updated_at)
VALUES ($1, 2, $2)
ON CONFLICT (app_id) DO UPDATE SET
  next_version = publish_apps.next_version + 1,
  updated_at = EXCLUDED.updated_at
RETURNING next_version - 1 AS allocated
```

A read-modify-write cannot be rescued by locking harder at the read — the row whose *absence* is the problem is the row the lock has nothing to hold. So the read is gone. Both branches advance the counter by one and return the value it held before (a fresh row goes straight to 2 having handed out 1), and `RETURNING` reads the post-action row, so one expression is correct either way.

Monotonicity and gaplessness are preserved because the upsert holds the counter row's lock for the remainder of the caller's transaction — the same transaction that inserts the `publish_versions` row. A concurrent allocator blocks behind it, and a rollback returns the number to the pool instead of retiring it with no version row to show for it.

### Alternatives considered (both rejected — reasoning is in the class header)

- **`ON CONFLICT DO NOTHING` then `SELECT … FOR UPDATE`** — the shape the issue suggests. I probed it against real PG16 and it *is* correct: `DO NOTHING` genuinely waits out the conflicting transaction, so the follow-up `SELECT` sees a committed row. But it is three statements where one suffices, and its correctness rests on speculative-insertion wait semantics that a reader cannot verify by reading the query. Atomic-by-construction beats atomic-if-you-know.
- **`pg_advisory_xact_lock(ns, hashtext(app_id))`** — the shape core migrators use (namespace 4410) and `embeddingModelGate` uses (4401). Those lock a *concept* that owns no row. Here the contended thing already **is** a row with a primary key, so the row lock is both free and exact. An advisory lock would key on `hashtext` of a **caller-supplied** app id, making two unrelated apps whose ids collide serialize against each other — the same "hash collision as an availability lever" that `pluginMigrations.ts` reserves an entire namespace to avoid.

## Tests

Two new Postgres tests in `test/publish/publishStore.pg.test.ts`:

1. **`8 concurrent createVersion calls … allocate unique, gapless versions with no unique-violation`** — raises N from 2 to 8 and pre-warms the pool so the callers actually overlap instead of drifting apart in the TCP/auth handshake. Asserts no rejection (reporting SQLSTATE + constraint on failure, so a *different* bug can't masquerade as this one), versions sorted equal `1..8`, eight distinct `dir_hash` rows landed (a number handed out twice shows up as a lost row, not just a duplicate), and `next_version = 9`.
2. **`a createVersion whose version insert fails burns no version number`** — squats on version 1 behind the store's back so the allocation succeeds but the `publish_versions` insert rolls the transaction back, then proves the retry still gets version 1. This is the regression guard on "allocation lives inside the caller's transaction"; an allocator that committed the counter separately would leave a gap here.

`PG_TEST_FLOOR` 279 → 281 for the two added tests. (The floor is a minimum, so this is deliberately conservative rather than re-pinned — whoever reads `ran=` on this run's CI output can tighten it.)

## Evidence

The N=8 test converts the flake into a **deterministic** gate — it is not a probabilistic improvement:

| Allocator | Repeat runs of `test/publish/publishStore.pg.test.ts` |
|---|---|
| **Fixed (this PR)** | **10 / 10 green** (`pass 7 fail 0` every run) |
| Reverted to `main`'s allocator, tests kept | **0 / 10 green** — every run fails with 7× `{"code":"23505","constraint":"publish_apps_pkey"}` |

Verification run locally against pgvector:pg16:

- `npm run build` — clean
- `npm run typecheck` — clean
- `npm run typecheck:test` — 371 known errors, no regressions (baseline 371)
- `npm run lint` — clean
- publish suites (non-pg) — 32/32
- `npm run test:pg` (full Postgres suite, serial) — **292/292 pass, 0 fail, 0 skipped**

## Blast radius

`allocateVersion` is private and has one production caller path: `harness-orchestrator/src/plugin.ts:923` constructs `PostgresPublishStore(graphPool)` when a graph pool exists. `setPointer`'s own upsert (and its `GREATEST(next_version, …)` monotonicity) is untouched; `migrations/0045_publish_versions.sql` needs no change — the fix uses the primary key the table already has.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790153018&installation_model_id=428086&pr_number=852&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F852&signature=469f3bca55e6ba954d62a8fd3bc2cfb38190e53da273c7bb86325d64e9adc923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Cross-family review (Forge)

Reviewed by **Forge** (OpenAI-family, GPT-5.4 at reasoning=high via `codex exec`) as a cross-vendor gate against Claude-family blind spots. Independent deep review + local verification on PG16 at `127.0.0.1:55438`.

**Verdict: MERGE.** No defects found.

| # | Check | Result |
|---|-------|--------|
| 1 | Monotonic + gapless across rollback | PASS — the upsert runs on the same `PoolClient` inside `createVersion`'s `BEGIN … COMMIT`, with `ROLLBACK` in the same `catch`; the counter bump is undone on any outer rollback (number returned to the pool, not burned). No independent commit. |
| 2 | Off-by-one at the boundary | PASS — insert path writes `next_version=2`, `RETURNING next_version-1 = 1`; update path `2→3`, `RETURNING 2`. Gapless 1,2,3… `RETURNING` on `ON CONFLICT DO UPDATE` reads the actually-inserted/updated row on both paths. |
| 3 | Stale `FOR UPDATE` assumption elsewhere | PASS — `getVersion`/`listVersions` touch only `publish_versions`; `getPointer` reads `current_version`; `setPointer`'s own upsert uses `GREATEST(next_version, EXCLUDED.next_version)` and stays compatible. No method depended on the removed lock. |
| 4 | N=8 test truly races | PASS — pool `max = N+4`, pre-warmed with 8 `connect()`, launched via `Promise.allSettled`; asserts zero failures, exact `[1..8]`, 8 stored rows, 8 distinct hashes, counter `=9`. |
| 5 | `PG_TEST_FLOOR` 279→281 | PASS — exactly 2 new pg `it()` blocks added in `publishStore.pg.test.ts`; no other pg test file changed. Production migration `0045_publish_versions.sql` confirmed to match the test's inline schema on `next_version INTEGER`, PK, defaults, FK. |

**Concurrency crux (MVCC):** under READ COMMITTED, the second concurrent inserter does not reuse a stale snapshot — it blocks on the unique key, then applies `publish_apps.next_version + 1` to the locked committed row (the `SET` references the target table, not `EXCLUDED`). Correct by construction.

**Mutation spot-check (executed):** reverting the allocator to the old `SELECT … FOR UPDATE`-on-a-missing-row shape makes the N=8 test fail deterministically — 7/8 callers die on `23505 / publish_apps_pkey`, the exact #834 signature. The test genuinely catches the regression.

**Local verification (all green):** `build`, full `typecheck`, `typecheck:test` (ratchet 371, no regressions), `lint`, publish pg suite 7/7, non-pg publish suite 32/32.
