### PR TITLE
feat: facilitation details modal; hide the panel when nothing runs (#330 follow-up)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,16 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — facilitation details modal; the panel disappears when there is nothing to show
+
+- Every facilitation card gets a **Details** modal: the summary plus the FULL durable run
+  trace (every assess round with postcondition outcome and transition) — "wo stehen wir
+  gerade?" without leaving the admin.
+- Installations without the facilitator (or without any running facilitation) no longer see
+  an empty box: the panel renders nothing when the listing is empty, and treats a
+  pre-feature kernel's 501 exactly like "feature not present". Real load errors stay visible.
+
+
 ### Changed — facilitation panel readability + tick nudge discipline (#330 round 4 follow-up)
 
 - The "Laufende Facilitations" card is structured now: conversation line, goal as title, the

--- a/web-ui/app/conductor/_components/FacilitationDetailsModal.tsx
+++ b/web-ui/app/conductor/_components/FacilitationDetailsModal.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useFormatter, useTranslations } from 'next-intl';
+
+import { Button } from '@/app/_components/ui/Button';
+import {
+  getConductorRun,
+  type ConductorRunResult,
+  type FacilitationOverview,
+} from '@/app/_lib/api';
+
+import { ConductorRunTrace } from './ConductorRunTrace';
+import { splitDod } from './FacilitationsPanel';
+
+/**
+ * #330 round 4 follow-up — "wo stehen wir gerade?" as a modal: the card's
+ * summary plus the FULL durable run trace (every assess round with its
+ * postcondition outcome and the transition taken). Read-only; the destructive
+ * action stays on the card. Plain overlay in the ConfirmDialog style.
+ */
+export function FacilitationDetailsModal({
+  facilitation,
+  onClose,
+}: {
+  facilitation: FacilitationOverview;
+  onClose: () => void;
+}): React.JSX.Element {
+  const t = useTranslations('conductor');
+  const format = useFormatter();
+  const [trace, setTrace] = useState<ConductorRunResult | null>(null);
+  const [traceError, setTraceError] = useState(false);
+  const f = facilitation;
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [onClose]);
+
+  const loadTrace = useCallback(async () => {
+    if (!f.run) return;
+    setTraceError(false);
+    try {
+      setTrace(await getConductorRun(f.slug, f.run.id));
+    } catch {
+      setTraceError(true);
+    }
+  }, [f.slug, f.run]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- fetch-on-mount loader (same pattern as ConductorRunHistory)
+    void loadTrace();
+  }, [loadTrace]);
+
+  const dodItems = f.run?.definitionOfDone ? splitDod(f.run.definitionOfDone) : null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[color:var(--bg-modal-overlay)] p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('facilitationDetailsHeading')}
+    >
+      {/* eslint-disable-next-line no-restricted-syntax -- invisible backdrop click-catcher, not a §4.2 CTA */}
+      <button
+        type="button"
+        aria-label={t('facilitationDetailsClose')}
+        onClick={onClose}
+        className="absolute inset-0 cursor-default"
+      />
+      <div className="relative z-10 flex max-h-[85vh] w-full max-w-3xl flex-col rounded-lg border border-[color:var(--border)] bg-[color:var(--bg-elevated,var(--card))] shadow-lg">
+        <header className="flex items-start justify-between gap-4 border-b border-[color:var(--border)] px-6 py-4">
+          <div className="min-w-0">
+            <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-[color:var(--fg-subtle,var(--fg-muted))]">
+              {t('facilitationDetailsHeading')}
+            </div>
+            <h3 className="mt-1 text-[17px] font-semibold leading-snug text-[color:var(--fg-strong)]">
+              {f.run?.goal ?? f.name}
+            </h3>
+            {f.conversation && (
+              <p className="mt-1 truncate font-mono text-[11px] text-[color:var(--fg-muted)]">
+                {f.conversation.channelType} · {f.conversation.conversationId}
+              </p>
+            )}
+          </div>
+          <Button variant="ghost" onClick={onClose}>
+            {t('facilitationDetailsClose')}
+          </Button>
+        </header>
+        <div className="grid gap-4 overflow-y-auto px-6 py-4 text-[13px]">
+          {f.run?.lastVerdict && (
+            <div className="rounded-md border border-[color:var(--border)] bg-black/10 px-3 py-2">
+              <span className="font-medium text-[color:var(--fg-strong)]">{t('facilitationLastVerdict')}: </span>
+              <span
+                style={{
+                  color:
+                    f.run.lastVerdict.dodMet === true
+                      ? 'var(--success,#30a46c)'
+                      : f.run.lastVerdict.dodMet === false
+                        ? 'var(--warning,#f5a623)'
+                        : 'var(--fg-muted)',
+                }}
+              >
+                {f.run.lastVerdict.dodMet === true
+                  ? t('facilitationDodMet')
+                  : f.run.lastVerdict.dodMet === false
+                    ? t('facilitationDodOpen')
+                    : '—'}
+              </span>
+              {f.run.lastVerdict.summary && (
+                <span className="text-[color:var(--fg-muted)]"> — {f.run.lastVerdict.summary}</span>
+              )}
+            </div>
+          )}
+          {f.run?.definitionOfDone && (
+            <div className="text-[color:var(--fg-muted)]">
+              <p className="mb-1 font-medium text-[color:var(--fg-strong)]">{t('facilitationDod')}</p>
+              {dodItems ? (
+                <ol className="list-decimal space-y-0.5 pl-5">
+                  {dodItems.map((item, idx) => (
+                    <li key={idx}>{item}</li>
+                  ))}
+                </ol>
+              ) : (
+                <p>{f.run.definitionOfDone}</p>
+              )}
+            </div>
+          )}
+          <div className="flex flex-wrap gap-x-6 gap-y-1 text-[12px] text-[color:var(--fg-muted)]">
+            {f.run && (
+              <span>
+                {t('facilitationRounds')}: <span className="text-[color:var(--fg-strong)]">{f.run.rounds}</span>
+              </span>
+            )}
+            {f.initiators.length > 0 && (
+              <span>
+                {t('facilitationInitiator')}: <span className="font-mono">{f.initiators.join(', ')}</span>
+              </span>
+            )}
+            {(f.participants ?? []).filter((p) => !p.isBot).length > 0 && (
+              <span>
+                {t('facilitationParticipants')}:{' '}
+                {(f.participants ?? [])
+                  .filter((p) => !p.isBot)
+                  .map((p) => p.displayName)
+                  .join(', ')}
+              </span>
+            )}
+            {f.expiresAt && (
+              <span>
+                {t('facilitationExpires')}: {format.dateTime(new Date(f.expiresAt))}
+              </span>
+            )}
+          </div>
+          <div>
+            <p className="mb-2 font-medium text-[color:var(--fg-strong)]">{t('facilitationTraceHeading')}</p>
+            {trace ? (
+              <ConductorRunTrace result={trace} />
+            ) : traceError ? (
+              <p className="text-[color:var(--danger,#e5484d)]">{t('facilitationTraceFailed')}</p>
+            ) : f.run ? (
+              <p className="text-[color:var(--fg-muted)]">{t('facilitationsLoading')}</p>
+            ) : (
+              <p className="text-[color:var(--fg-muted)]">{t('facilitationNoRun')}</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-ui/app/conductor/_components/FacilitationsPanel.tsx
+++ b/web-ui/app/conductor/_components/FacilitationsPanel.tsx
@@ -6,10 +6,13 @@ import { useFormatter, useTranslations } from 'next-intl';
 import { Button } from '@/app/_components/ui/Button';
 import { ConfirmDialog } from '@/app/_components/ConfirmDialog';
 import {
+  ApiError,
   listFacilitations,
   terminateFacilitation,
   type FacilitationOverview,
 } from '@/app/_lib/api';
+
+import { FacilitationDetailsModal } from './FacilitationDetailsModal';
 
 const card = 'rounded-lg border border-[color:var(--border)] bg-[color:var(--card)]/40 p-4';
 
@@ -24,7 +27,7 @@ const STATUS_TONE: Record<string, string> = {
 /** DoD text usually arrives as one flat "1. ... 2. ..." sentence from chat —
  *  split it back into list items for reading. Deterministic string handling
  *  only; anything without the numbering pattern renders as plain text. */
-function splitDod(text: string): string[] | null {
+export function splitDod(text: string): string[] | null {
   const parts = text.split(/(?=(?:^|\s)\d{1,2}\.\s)/).map((part) => part.trim()).filter(Boolean);
   if (parts.length < 2) return null;
   return parts.map((part) => part.replace(/^\d{1,2}\.\s*/, ''));
@@ -54,6 +57,10 @@ export function FacilitationsPanel(): React.JSX.Element {
   const [loading, setLoading] = useState(false);
   const [terminating, setTerminating] = useState<string | null>(null);
   const [confirmId, setConfirmId] = useState<string | null>(null);
+  const [detailsId, setDetailsId] = useState<string | null>(null);
+  // Older kernels answer 501 (facilitation admin not wired) — treat exactly
+  // like "feature not present" and render nothing instead of an error box.
+  const [unavailable, setUnavailable] = useState(false);
 
   const reload = useCallback(async () => {
     setLoading(true);
@@ -62,8 +69,11 @@ export function FacilitationsPanel(): React.JSX.Element {
       const { facilitations } = await listFacilitations();
       setRows(facilitations);
     } catch (err) {
-      void err;
-      setError(t('facilitationsLoadFailed'));
+      if (err instanceof ApiError && err.status === 501) {
+        setUnavailable(true);
+      } else {
+        setError(t('facilitationsLoadFailed'));
+      }
     } finally {
       setLoading(false);
     }
@@ -89,6 +99,12 @@ export function FacilitationsPanel(): React.JSX.Element {
     },
     [reload, t],
   );
+
+  // Nothing to show and nothing wrong: installations without the facilitator
+  // (or without any running facilitation) get no empty box at all.
+  if (unavailable || (!error && !loading && rows.length === 0)) {
+    return <></>;
+  }
 
   return (
     <section className={card}>
@@ -131,14 +147,19 @@ export function FacilitationsPanel(): React.JSX.Element {
                       {f.run?.goal ?? f.name}
                     </p>
                   </div>
-                  <Button
-                    variant="danger"
-                    busy={terminating === f.workflowId}
-                    busyLabel={t('facilitationTerminateBusy')}
-                    onClick={() => setConfirmId(f.workflowId)}
-                  >
-                    {t('facilitationTerminateButton')}
-                  </Button>
+                  <div className="flex shrink-0 gap-2">
+                    <Button variant="ghost" onClick={() => setDetailsId(f.workflowId)}>
+                      {t('facilitationDetailsButton')}
+                    </Button>
+                    <Button
+                      variant="danger"
+                      busy={terminating === f.workflowId}
+                      busyLabel={t('facilitationTerminateBusy')}
+                      onClick={() => setConfirmId(f.workflowId)}
+                    >
+                      {t('facilitationTerminateButton')}
+                    </Button>
+                  </div>
                 </div>
                 {f.incomplete && (
                   <p className="mt-2 text-[12px] text-[color:var(--warning,#f5a623)]">{t('facilitationIncomplete')}</p>
@@ -219,6 +240,12 @@ export function FacilitationsPanel(): React.JSX.Element {
             );
           })}
         </ul>
+      )}
+      {detailsId !== null && rows.some((r) => r.workflowId === detailsId) && (
+        <FacilitationDetailsModal
+          facilitation={rows.find((r) => r.workflowId === detailsId)!}
+          onClose={() => setDetailsId(null)}
+        />
       )}
       <ConfirmDialog
         open={confirmId !== null}

--- a/web-ui/app/conductor/_components/__tests__/FacilitationsPanel.test.tsx
+++ b/web-ui/app/conductor/_components/__tests__/FacilitationsPanel.test.tsx
@@ -2,7 +2,7 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { listFacilitations, terminateFacilitation, type FacilitationOverview } from '@/app/_lib/api';
+import { ApiError, getConductorRun, listFacilitations, terminateFacilitation, type FacilitationOverview } from '@/app/_lib/api';
 import { renderWithIntl } from '../../../_lib/test-utils';
 import { FacilitationsPanel } from '../FacilitationsPanel';
 
@@ -12,6 +12,7 @@ vi.mock('@/app/_lib/api', async (importOriginal) => {
     ...actual,
     listFacilitations: vi.fn(),
     terminateFacilitation: vi.fn(),
+    getConductorRun: vi.fn(),
   };
 });
 
@@ -80,10 +81,38 @@ describe('FacilitationsPanel', () => {
     expect(listFacilitations).toHaveBeenCalledTimes(2);
   });
 
-  it('renders the empty state', async () => {
+  it('renders NOTHING when no facilitation runs — installations without the facilitator see no box', async () => {
     vi.mocked(listFacilitations).mockResolvedValue({ facilitations: [] });
     renderWithIntl(<FacilitationsPanel />);
-    expect(await screen.findByText('No facilitation is running.')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(listFacilitations).toHaveBeenCalled();
+    });
+    expect(screen.queryByText('Running facilitations')).not.toBeInTheDocument();
+  });
+
+  it('renders NOTHING on a pre-feature kernel (501)', async () => {
+    vi.mocked(listFacilitations).mockRejectedValue(new ApiError(501, 'not wired'));
+    renderWithIntl(<FacilitationsPanel />);
+    await waitFor(() => {
+      expect(listFacilitations).toHaveBeenCalled();
+    });
+    expect(screen.queryByText('Running facilitations')).not.toBeInTheDocument();
+  });
+
+  it('opens the details modal with the run trace', async () => {
+    vi.mocked(getConductorRun).mockResolvedValue({
+      run: {
+        id: 'run-1', status: 'waiting', triggerKind: 'agent', startedAt: '2026-08-24T07:00:00.000Z',
+        endedAt: null, currentStepId: 'wait', context: {}, cancelRequestedAt: null,
+      },
+      steps: [],
+    } as never);
+    renderWithIntl(<FacilitationsPanel />);
+    await userEvent.click(await screen.findByRole('button', { name: 'Details' }));
+    expect(await screen.findByText('Facilitation details')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(getConductorRun).toHaveBeenCalledWith('eph-facilitation-ab12cd34', 'run-1');
+    });
   });
 
   it('renders a numbered DoD as an ordered list', async () => {

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -746,7 +746,13 @@
     "facilitationInitiator": "Initiator",
     "facilitationExpires": "Läuft ab",
     "facilitationsLoading": "Facilitations werden geladen…",
-    "facilitationIncomplete": "Einige Details konnten nicht geladen werden — diese Zeile kann unvollständig sein."
+    "facilitationIncomplete": "Einige Details konnten nicht geladen werden — diese Zeile kann unvollständig sein.",
+    "facilitationDetailsButton": "Details",
+    "facilitationDetailsHeading": "Facilitation-Details",
+    "facilitationDetailsClose": "Schließen",
+    "facilitationTraceHeading": "Verlauf (Assess-Runden)",
+    "facilitationTraceFailed": "Der Verlauf konnte nicht geladen werden",
+    "facilitationNoRun": "Für diese Facilitation existiert noch kein Lauf."
   },
   "operatorPrivacyReports": {
     "metaTitle": "Privacy-Reports · omadia",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -746,7 +746,13 @@
     "facilitationInitiator": "Initiator",
     "facilitationExpires": "Expires",
     "facilitationsLoading": "Loading facilitations…",
-    "facilitationIncomplete": "Some details could not be loaded — this row may under-report."
+    "facilitationIncomplete": "Some details could not be loaded — this row may under-report.",
+    "facilitationDetailsButton": "Details",
+    "facilitationDetailsHeading": "Facilitation details",
+    "facilitationDetailsClose": "Close",
+    "facilitationTraceHeading": "Run trace (assess rounds)",
+    "facilitationTraceFailed": "The run trace could not be loaded",
+    "facilitationNoRun": "No run exists for this facilitation yet."
   },
   "operatorPrivacyReports": {
     "metaTitle": "Privacy reports · omadia",


### PR DESCRIPTION
Two operator asks on the fresh facilitation panel (byte5ai/omadia#330):

1. **"Wo stehen wir gerade?" als Details-Modal** — every card gets a read-only **Details** modal: goal, latest assessment, DoD list, participants/initiator/expiry, and the FULL durable run trace (every assess round with its postcondition outcome and transition taken) via the existing `getConductorRun` + `ConductorRunTrace`. Escape/backdrop/button close; the destructive action stays on the card.
2. **Was passiert ohne installierten Facilitator?** — previously an empty "Laufende Facilitations" box. Now the panel renders **nothing** when the listing is empty, and treats a pre-feature kernel's 501 (`conductor.facilitations_unavailable`) exactly like "feature not present". Real load errors stay visible.

## Test plan

- Panel tests 6/6: details modal opens + fetches the right run trace (`slug`, `runId`), empty listing renders nothing, 501 renders nothing, numbered DoD list, humans-only participants, confirm-gated terminate.
- Web-ui suite 827/827, `tsc` clean, lint 0 errors, `i18n:check` green (3783 keys, en+de — 6 new).
- CHANGELOG updated. No kernel changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790182802&installation_model_id=428086&pr_number=856&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F856&signature=675f22ca6822fc37f39098c874bee09c401e56716adb919e819404818ef5eaee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->