### PR TITLE
fix: facilitation lens must read the verdict from ctx.steps.moderate, not ctx.stepResult (#330 follow-up)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,14 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — facilitation lens read the verdict from a context key that never exists
+
+- The facilitation admin lens read the latest assess verdict from `ctx.stepResult` — but
+  the executor persists step results under `ctx.steps[stepId]`; `stepResult` only exists
+  as the transient guard-evaluation argument. Result: `lastVerdict` (and the new interim
+  results table) was ALWAYS null in the admin UI. Now read from `ctx.steps.moderate.data`,
+  with the test fixture matching the executor's real durable shape.
+
 ### Added — interim results table per DoD point in the facilitation details modal
 
 - The moderate tick's fenced-JSON verdict now carries `items[]` — one entry per numbered

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -1385,7 +1385,9 @@ deklariert):
 - **`GET /facilitations`** — Overview aller nicht gereapten ephemeren
   Workflows aus rein durablem State: Conversation (Attachment-Row), Goal/DoD
   + Assess-Runden (`ctx.stepAttempts.moderate`) + letztes Verdict
-  (`ctx.stepResult.data`), Initiator-Role-Holder, Teilnehmer via
+  (`ctx.steps.moderate.data` — accumulate() persistiert pro Step-Id;
+  `ctx.stepResult` existiert nur transient als Guard-Argument, NIE im
+  durablen Context), Initiator-Role-Holder, Teilnehmer via
   Roster-Registry (best-effort, 30s-TTL-Cache — jeder Roster-Read öffnet
   einen proaktiven Channel-Turn). Store-Fehler beim Zusammenbau ⇒ Row-Flag
   `incomplete: true` + Log (unter-reporten ja, erfinden nie).

--- a/middleware/src/conductor/facilitationAdmin.ts
+++ b/middleware/src/conductor/facilitationAdmin.ts
@@ -123,7 +123,11 @@ function verdictItems(value: JsonValue | undefined): FacilitationVerdictItem[] |
 function runOverview(run: ConductorRun): NonNullable<FacilitationOverview['run']> {
   const ctx = asRecord(run.context as JsonValue) ?? {};
   const attempts = asRecord(ctx['stepAttempts']);
-  const verdictData = asRecord(asRecord(ctx['stepResult'])?.['data']);
+  // The executor accumulates step results durably under ctx.steps[stepId]
+  // (`ctx.stepResult` only ever exists as the guard-evaluation argument, never
+  // in the persisted context) — the latest assess verdict lives at
+  // ctx.steps.moderate.data. Keyed by the facilitation pattern's step id.
+  const verdictData = asRecord(asRecord(asRecord(ctx['steps'])?.['moderate'])?.['data']);
   const rounds = typeof attempts?.['moderate'] === 'number' ? (attempts['moderate'] as number) : 0;
   const iso = (value: Date | string | null): string | null =>
     value == null ? null : value instanceof Date ? value.toISOString() : value;

--- a/middleware/test/conductorFacilitationAdmin.test.ts
+++ b/middleware/test/conductorFacilitationAdmin.test.ts
@@ -32,18 +32,24 @@ const RUN = {
     goal: 'omadia Event planen',
     definitionOfDone: '6 Punkte, alle bestätigt',
     stepAttempts: { moderate: 7 },
-    stepResult: {
-      data: {
-        dodMet: false,
-        summary: '3/6 Punkte offen',
-        items: [
-          { point: 1, label: 'Eventformat entschieden', status: 'done', note: 'Meetup, von allen bestätigt' },
-          { point: 2, label: 'Termin fix', status: 'partial', note: 'Vorschlag 12.9. liegt vor' },
-          // malformed entries the model might emit — must be dropped / nulled, never crash:
-          'garbage',
-          { point: 'x', label: 3, status: 'weird', note: null },
-          { point: -2.5, label: 'x'.repeat(500), status: 'open', note: 'ok' },
-        ],
+    // Durable shape as the executor writes it: accumulate() puts each step's
+    // result under ctx.steps[stepId] — ctx.stepResult never exists here.
+    steps: {
+      wait: {},
+      moderate: {
+        text: 'Assess-Antwort …',
+        data: {
+          dodMet: false,
+          summary: '3/6 Punkte offen',
+          items: [
+            { point: 1, label: 'Eventformat entschieden', status: 'done', note: 'Meetup, von allen bestätigt' },
+            { point: 2, label: 'Termin fix', status: 'partial', note: 'Vorschlag 12.9. liegt vor' },
+            // malformed entries the model might emit — must be dropped / nulled, never crash:
+            'garbage',
+            { point: 'x', label: 3, status: 'weird', note: null },
+            { point: -2.5, label: 'x'.repeat(500), status: 'open', note: 'ok' },
+          ],
+        },
       },
     },
   },


### PR DESCRIPTION
Field report on the v0.134.0 interim-results table (byte5ai/omadia#330): the details modal showed neither the table nor the "last verdict" line — for ANY run.

## Root cause

The facilitation admin lens read the latest assess verdict from `ctx.stepResult.data`. But the executor's `accumulate()` persists step results under **`ctx.steps[stepId]`** — `stepResult` exists only as the transient guard-evaluation argument passed to `nextStep()`, never in the durable run context. So `lastVerdict` was structurally ALWAYS `null`; the unit test didn't catch it because its fixture mirrored the same wrong assumption.

## Fix

- Read the verdict from `ctx.steps.moderate.data` (keyed by the facilitation pattern's assess step id; documented inline).
- Test fixture now uses the executor's real durable shape (`steps: { moderate: { text, data } }`).
- CHANGELOG + handoff doc corrected.

This also makes the verdict line work for the currently-running v2 facilitation (its verdicts carry `dodMet`/`summary`); the per-DoD-point items still require a run started under pattern v3, as designed.

## Test plan

- `conductorFacilitationAdmin.test.ts` 5/5 with the corrected durable-shape fixture (validated items passthrough incl. garbage entries).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790232909&installation_model_id=428086&pr_number=858&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F858&signature=eeb96ee4d0c0625b4269719547a0f11336d27806760b6d9dc02d0577907ef821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->