### PR TITLE
fix: Teams-Card-Cleanup — Verifier-Badge nur bei echten Prüfungen, memoryUsed-Signal für Fresh Check

### DIFF
--- a/middleware/packages/harness-channel-sdk/src/chatAgent.ts
+++ b/middleware/packages/harness-channel-sdk/src/chatAgent.ts
@@ -543,6 +543,15 @@ export interface ChatTurnResult {
    */
   recalled?: RecalledContext;
   /**
+   * True when this turn's answer could have been influenced by persisted
+   * memory: an injected prior-context block (session tail + FTS + entity
+   * recall) or a `memory`-tool call by the orchestrator. `toSemanticAnswer`
+   * forwards it to `SemanticAnswer.memoryUsed` so channels can gate their
+   * memory-bypass affordances (Teams' "🔄 Fresh Check" button). Omitted when
+   * no memory contributed — a fresh check would then be a no-op.
+   */
+  memoryUsed?: boolean;
+  /**
    * #332 Layer 2 — Direct Line. The verbatim sub-agent answer for a turn the
    * user directed at a named specialist (`@omadia #strategist …`). Set by the
    * harness inside `chatStream`, NOT by the LLM; `toSemanticAnswer` forwards it

--- a/middleware/packages/harness-channel-sdk/src/outgoing.ts
+++ b/middleware/packages/harness-channel-sdk/src/outgoing.ts
@@ -36,6 +36,16 @@ export interface SemanticAnswer {
   /** Visual verifier state — connectors may render as badge / icon / colour. */
   verifier?: VerifierBadge;
 
+  /**
+   * True when this turn's answer could have been influenced by persisted
+   * memory: an injected prior-context block (session tail + FTS + entity
+   * recall) or a `memory`-tool call by the orchestrator. Connectors use this
+   * to gate memory-bypass affordances (Teams' "🔄 Fresh Check" button) —
+   * absent/false means a re-run without memory would be a no-op, so the
+   * affordance should not be offered.
+   */
+  memoryUsed?: boolean;
+
   /** Soft-disclaimer line appended to the answer (e.g. "unverified claims"). */
   disclaimer?: string;
 

--- a/middleware/packages/harness-channel-sdk/src/toSemanticAnswer.ts
+++ b/middleware/packages/harness-channel-sdk/src/toSemanticAnswer.ts
@@ -202,9 +202,14 @@ export function toSemanticAnswer(
     };
   }
 
-  const verifier: VerifierBadge | undefined = r.verifier
-    ? { status: r.verifier.badge }
-    : undefined;
+  // The badge is only an honest signal when the verifier actually CHECKED
+  // something: with zero extracted claims (small talk, greetings) — and on the
+  // pipeline-failure fallback, which reports `approved` with an empty claim
+  // list — a "✓ geprüft" chip would assert a verification that never happened.
+  const verifier: VerifierBadge | undefined =
+    r.verifier && r.verifier.claimCount > 0
+      ? { status: r.verifier.badge }
+      : undefined;
 
   // #332 Layer 1 — curate a tamper-evident consulted-agents footer from the
   // deterministic run-trace. This is the ONLY sub-agent signal Teams/Telegram
@@ -250,6 +255,7 @@ export function toSemanticAnswer(
     text: disclosed.text,
     ...(disclosed.aiDisclosure ? { aiDisclosure: disclosed.aiDisclosure } : {}),
     ...(verifier ? { verifier } : {}),
+    ...(r.memoryUsed ? { memoryUsed: true } : {}),
     ...(agentsConsulted && agentsConsulted.length > 0
       ? { agentsConsulted }
       : {}),

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -4427,10 +4427,22 @@ export class Orchestrator {
           const pendingSlotCard = this.drainPendingSlotCard();
           const pendingRoutineList = this.drainPendingRoutineList();
           const pendingOAuthConsent = this.drainConsentRequired();
+          // Fresh-Check gate (Teams "🔄 Fresh Check" button): memory influenced
+          // this answer when a prior-context block was injected (tail + FTS +
+          // entity recall) or the orchestrator's own `memory` tool ran. Without
+          // either, a memory-bypassing re-run cannot produce a different answer,
+          // so channels hide the affordance.
+          const memoryUsed =
+            (priorContext !== undefined && priorContext.trim().length > 0) ||
+            (runTrace?.orchestratorToolCalls.some(
+              (tc) => tc.toolName === MEMORY_TOOL_NAME,
+            ) ??
+              false);
           return {
             answer: restoredAnswer,
             toolCalls,
             iterations,
+            ...(memoryUsed ? { memoryUsed: true } : {}),
             ...(persistedTurnId ? { turnId: persistedTurnId } : {}),
             ...(runTrace ? { runTrace } : {}),
             ...(attachments ? { attachments } : {}),

--- a/middleware/test/semanticAnswerGates.test.ts
+++ b/middleware/test/semanticAnswerGates.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+// Imported from source (not the `@omadia/channel-sdk` dist barrel) — same
+// rationale as aiDisclosure.test.ts: fields added after the last dist build.
+import { toSemanticAnswer } from '../packages/harness-channel-sdk/src/toSemanticAnswer.js';
+import type {
+  ChatTurnResult,
+  VerifierResultSummary,
+} from '../packages/harness-channel-sdk/src/chatAgent.js';
+
+const base: ChatTurnResult = { answer: 'Hallo.', toolCalls: 0, iterations: 0 };
+
+function verifierSummary(
+  overrides: Partial<VerifierResultSummary> = {},
+): VerifierResultSummary {
+  return {
+    badge: 'verified',
+    status: 'approved',
+    claimCount: 2,
+    contradictionCount: 0,
+    unverifiedCount: 0,
+    retryCount: 0,
+    latencyMs: 5,
+    mode: 'enforce',
+    ...overrides,
+  };
+}
+
+describe('toSemanticAnswer — verifier badge gate', () => {
+  it('forwards the badge when the verifier actually checked claims', () => {
+    const sa = toSemanticAnswer({ ...base, verifier: verifierSummary() });
+    assert.deepEqual(sa.verifier, { status: 'verified' });
+  });
+
+  it('suppresses the badge when zero claims were extracted (nothing was checked)', () => {
+    const sa = toSemanticAnswer({
+      ...base,
+      verifier: verifierSummary({ claimCount: 0 }),
+    });
+    assert.equal(sa.verifier, undefined);
+  });
+
+  it('suppresses the pipeline-failure fallback (approved with empty claim list)', () => {
+    // verifierService returns `{ status: 'approved', claims: [] }` when the
+    // pipeline throws — that must never render as "✓ Antwort geprüft".
+    const sa = toSemanticAnswer({
+      ...base,
+      verifier: verifierSummary({ claimCount: 0, latencyMs: 0 }),
+    });
+    assert.equal(sa.verifier, undefined);
+  });
+
+  it('keeps corrected/failed badges as long as claims were checked', () => {
+    const sa = toSemanticAnswer({
+      ...base,
+      verifier: verifierSummary({ badge: 'corrected', retryCount: 1 }),
+    });
+    assert.deepEqual(sa.verifier, { status: 'corrected' });
+  });
+});
+
+describe('toSemanticAnswer — memoryUsed forwarding', () => {
+  it('forwards memoryUsed: true so channels can show the Fresh-Check affordance', () => {
+    const sa = toSemanticAnswer({ ...base, memoryUsed: true });
+    assert.equal(sa.memoryUsed, true);
+  });
+
+  it('omits the field when no memory contributed to the answer', () => {
+    const sa = toSemanticAnswer(base);
+    assert.equal(sa.memoryUsed, undefined);
+  });
+});


### PR DESCRIPTION
Feldtest-Feedback (Screenshot: "pong"-Antwort mit ✓ Antwort geprüft ohne dass etwas geprüft wurde).

**1. Verifier-Badge-Gate (`toSemanticAnswer`)**
Badge wird nur noch weitergereicht, wenn `claimCount > 0` — bei 0 extrahierten Claims (Smalltalk) und beim Pipeline-Failure-Fallback (`approved` + leere Claim-Liste) behauptete "✓ Antwort geprüft" eine Prüfung, die nie stattfand.

**2. `memoryUsed`-Signal (ChatTurnResult + SemanticAnswer)**
Neues optionales Feld, gesetzt wenn ein Prior-Context-Block injiziert wurde (Tail + FTS + Entity-Recall) oder das `memory`-Tool des Orchestrators lief. Channels gaten damit ihre Memory-Bypass-Affordance — der Teams-Button "🔄 Fresh Check (ohne Memory)" ist ohne Memory-Einfluss ein No-op und soll dann nicht angeboten werden (Teams-Plugin-Seite folgt in `omadia-channel-teams`).

Tests: `test/semanticAnswerGates.test.ts` (Gate + Forwarding, inkl. Fallback-Fall); Disclosure- und Orchestrator-Suiten grün (126 Tests).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790258902&installation_model_id=428086&pr_number=859&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F859&signature=e1782ab2868ecdb1c0164c1ad6285f2f47b15b96c7a65d28668b1d1ac7c9a8aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->