### PR TITLE
feat: agent factory — Teams identity provisioning via teamsProvisioner@1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,32 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — agent factory: Teams identity provisioning via teamsProvisioner@1 (W1a, #860)
+
+- New CORE migration `0049_agent_teams_identities.sql`: one Teams identity per agent
+  (unique `agent_id`), globally unique `bot_slug`, a seven-state provisioning CHECK
+  (`pending → app_registered → bot_created → package_built → catalog_uploaded →
+  installed`, terminal `failed`), step-evidence columns and a `team_id` install target
+  for boot-time resume. Deliberately NO secret column — the bot's client secret stays
+  in the M365 connector's vault (opaque ref `teams_bot_password:<appId>`).
+- New operator endpoints on the agents router: `POST
+  /api/v1/operator/agents/:slug/teams-identity` (create-or-provision, async — answers
+  202 immediately and hands the chain to the in-process provisioning job runner) and
+  `GET …/teams-identity` (status incl. a paste-ready camelCase `teams_bots[]` entry
+  for channel-teams, `last_error`, and an honest `running` flag). 503 with
+  `teams_provisioner_unavailable` while the connector is not installed; 409
+  `bot_slug_taken` on cross-agent slug collisions.
+- Every Graph/ARM call happens inside the `@omadia/integration-microsoft365`
+  connector plugin (**>= 0.3.1 required**), consumed through the kernel service
+  registry via the new `platform/teamsProvisionerService.ts` choke point (typed
+  errors, secret-stripping boundary, SingleTenant guard, per-bot messaging-endpoint
+  URL builder honoring `TEAMS_PUBLIC_BASE_URL ?? PUBLIC_BASE_URL`). Without the
+  connector, provisioning jobs stay retryable-pending — never a crash.
+- Boot wiring registers `agentTeamsIdentityStore` + `teamsProvisioningJobRunner`
+  (Postgres required) and resumes interrupted provisioning runs idempotently; the
+  Teams app package is rendered from the installed channel-teams package's
+  `appPackage/` template with a deterministic per-agent catalog id.
+
 ### Fixed — facilitation lens read the verdict from a context key that never exists
 
 - The facilitation admin lens read the latest assess verdict from `ctx.stepResult` — but

--- a/docs/middleware-agent-handoff.md
+++ b/docs/middleware-agent-handoff.md
@@ -2370,3 +2370,40 @@ im Render-Pfad, stale-while-revalidate ab `observe()`, degradiert ohne
 Graph-App-Permissions lautlos auf die Bot-Framework-Labels. Benötigte
 Application-Permissions (Admin-Consent im Tenant): `Chat.Read.All`,
 `ChatMember.Read.All`, `TeamMember.Read.All`, `Organization.Read.All`.
+
+
+## Agent Factory: Teams-Identity-Provisioning (W1a, 2026-08-26)
+
+Epic #860, Wave W1a. Ein Agent bekommt per Operator-API eine eigene Microsoft-Teams-
+Identität — Entra-App-Registration → Azure Bot → Teams-App-Package → Tenant-Katalog →
+Team-Install — ohne dass die Middleware selbst je Graph/ARM spricht.
+
+**Architektur (ein Choke-Point, ein Writer, eine State-Quelle):**
+
+| Baustein | Datei | Rolle |
+|---|---|---|
+| Migration | `middleware/migrations/0049_agent_teams_identities.sql` | 1 Identity/Agent (PK `agent_id`), global unique `bot_slug`, State-CHECK (7 Werte), Evidence-Spalten, `team_id` als Resume-Ziel. KEINE Secret-Spalte. |
+| Store | `middleware/src/platform/agentTeamsIdentityStore.ts` | Einziger Writer von `state`/`last_error`; exportiert DIE State-Union (`TEAMS_PROVISIONING_STATES`), die Runner+Router importieren. Query-Fehler surfacen (kein stilles `pending`). |
+| Accessor | `middleware/src/platform/teamsProvisionerService.ts` | Einzige `serviceRegistry.get('teamsProvisioner')`-Stelle (KERNEL_SERVICE_CALLER), gespiegelter Connector-Contract v0.3.1 (inkl. `getCatalogApp`), Duck-typed Error-Guards, Secret-Stripping, SingleTenant-Guard, `buildTeamsBotMessagingEndpoint()` → `https://<base>/api/teams/<botSlug>/messages`. |
+| Job-Runner | `middleware/src/services/teamsProvisioningJob.ts` | Async in-process, idempotenter Resume ab persistiertem State, bounded Retries (Throttle-Hint ≤ `maxRetryDelayMs`), ConsentMissing→`failed`+Scopes, ArmNotConfigured→bleibt `app_registered`+actionable `last_error`; Team-Konflikt-Enqueue wird `rejected`, nie fremdes Ergebnis. `asBackgroundJob()` (Registry-Lifecycle, start() re-armt nach stop()). |
+| Package-Assets | `middleware/src/services/teamsAppPackageAssets.ts` | Liest `appPackage/{manifest.json.template,color.png,outline.png}` aus dem installierten channel-teams-Package, füllt Platzhalter template-getrieben, deterministische Teams-App-GUID pro Agent (Katalog-Idempotenz). |
+| Endpoints | `middleware/src/routes/operatorAgents.ts` | `POST/GET /api/v1/operator/agents/:slug/teams-identity` — 202-async, `{ ok: true }`-Envelope, camelCase `teams_bot`-Projektion (paste-ready für `teams_bots[]`), 503/404/400/409-Reihenfolge korrekt, ehrliches `running`, Enqueue-Fehler landen in `last_error`. |
+| Boot-Wiring | `middleware/src/index.ts` (nach graphPool-Resolution) | Registriert `agentTeamsIdentityStore` + `teamsProvisioningJobRunner`, bindet `TEAMS_PUBLIC_BASE_URL ?? PUBLIC_BASE_URL` in den URL-Builder, `backgroundJobRegistry`, Resume offener Jobs (`listResumable`, nur mit `team_id`, `failed` bleibt geparkt). |
+
+**Secret-Custody:** Das Bot-Passwort verlässt den M365-Connector NIE — dessen Vault hält
+es unter `teams_bot_password:<appId>`; die Status-Projektion leitet den Ref
+deterministisch aus `app_id` ab (nichts wird gespeichert, nichts geloggt).
+
+**Deploy-Voraussetzungen:** Connector-Plugin `@omadia/integration-microsoft365` ≥ 0.3.1
+(publiziert `teamsProvisioner@1`), channel-teams-Package mit `appPackage/` (W0a) für den
+Package-Schritt, Postgres (`DATABASE_URL`). Fehlt der Connector: Jobs bleiben
+retryable-pending, POST antwortet 503 `teams_provisioner_unavailable`.
+
+**Out of scope / Follow-ups:** Automatischer Sync der fertigen Identity in die
+channel-teams-Plugin-Config (`teams_bots[]`) ist dokumentierter Follow-up; Extraktion der
+Teams-Identity-Routen aus `operatorAgents.ts` (Datei > 800 Zeilen) bei nächster Gelegenheit.
+
+**Tests:** `test/teamsProvisioningJob.test.ts` (24), `test/teamsProvisionerService.test.ts`
+(22), `test/operatorAgentsRouter.test.ts` (42), `test/agentTeamsIdentityStore.pg.test.ts`
+(9, gegen echtes Postgres, wendet Migration 0049 doppelt an), `coreMigrations.pg.test.ts`
+(Double-Apply aller 49 Files).

--- a/middleware/migrations/0049_agent_teams_identities.sql
+++ b/middleware/migrations/0049_agent_teams_identities.sql
@@ -1,0 +1,64 @@
+-- ── Agent factory: per-agent Teams identities (epic #860, wave W1a) ─────────
+-- One row per agent that has (or is getting) a provisioned Microsoft Teams
+-- identity: Entra app registration → Azure bot → Teams app package → tenant
+-- catalog upload → team install. The provisioning job runner
+-- (`src/services/teamsProvisioningJob.ts`) walks `state` through the chain
+-- and persists step evidence into the columns below so a resume re-enters
+-- exactly where the last run stopped; the operator endpoints
+-- (`src/routes/operatorAgents.ts`, POST/GET /:slug/teams-identity) create and
+-- project these rows through `src/platform/agentTeamsIdentityStore.ts`.
+--
+-- WHY BOTH KEYS ARE UNIQUE
+-- ------------------------
+-- `PRIMARY KEY (agent_id)` — conservative one-identity-per-agent rule of this
+-- wave; `ensureForAgent` leans on it for its create-if-absent semantics.
+--
+-- `UNIQUE (bot_slug)` — the slug is the bot's ARM handle, the path segment of
+-- the per-bot messaging endpoint (`/api/teams/<botSlug>/messages`,
+-- channel-teams >= 0.20.0) AND the key channel-teams derives per-bot secret
+-- names from. Two agents sharing a slug would share a bot identity and
+-- overwrite each other's credentials, so the collision fails loudly here
+-- instead of silently at provisioning time.
+--
+-- NO SECRET COLUMN — DELIBERATE
+-- -----------------------------
+-- The bot's client secret never reaches this table (or the middleware at
+-- all): the M365 connector's `createAppRegistration` keeps the generated
+-- password in the CONNECTOR's vault and only the opaque reference
+-- (`teams_bot_password:<app_id>`) crosses the service boundary. The status
+-- endpoint derives that ref from `app_id`; nothing stores it.
+--
+-- `team_id` records the install target so boot-time resume can re-enqueue
+-- interrupted provisioning runs (the team is a runner input, not derivable
+-- from the other columns). Nullable: a row created before the first
+-- provisioning request carries none.
+--
+-- Idempotent by construction: the single CREATE TABLE IF NOT EXISTS is a
+-- no-op on re-apply (schema CI double-applies every file in this series).
+CREATE TABLE IF NOT EXISTS agent_teams_identities (
+  agent_id              TEXT        NOT NULL,
+  bot_slug              TEXT        NOT NULL,
+  display_name          TEXT        NOT NULL,
+  state                 TEXT        NOT NULL DEFAULT 'pending'
+    CONSTRAINT agent_teams_identities_state_check CHECK (state IN (
+      'pending',
+      'app_registered',
+      'bot_created',
+      'package_built',
+      'catalog_uploaded',
+      'installed',
+      'failed'
+    )),
+  team_id               TEXT,
+  app_id                TEXT,
+  tenant_id             TEXT,
+  teams_app_id          TEXT,
+  teams_app_external_id TEXT,
+  last_error            TEXT,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (agent_id),
+  UNIQUE (bot_slug)
+);
+
+-- rollback: DROP TABLE agent_teams_identities;

--- a/middleware/src/config.ts
+++ b/middleware/src/config.ts
@@ -329,6 +329,20 @@ const ConfigSchema = z.object({
    */
   TEAMS_SSO_CONNECTION_NAME: z.string().optional(),
 
+  /**
+   * W1a (#860) — public base URL the agent factory advertises to Azure as
+   * the per-bot Teams messaging endpoint
+   * (`<base>/api/teams/<botSlug>/messages`, channel-teams >= 0.20.0) when
+   * provisioning bot identities. Optional override in the
+   * TELEGRAM_/FLOW_/ATTACHMENT_PUBLIC_BASE_URL tradition: the provisioning
+   * wiring falls back to PUBLIC_BASE_URL, so set this only when Bot
+   * Framework traffic reaches the middleware under a different host than
+   * the browser-facing UI. Consumed where the provisioning job runner is
+   * constructed — it is bound into the teamsProvisioner accessor's
+   * messaging-endpoint URL builder, never string-built elsewhere.
+   */
+  TEAMS_PUBLIC_BASE_URL: z.string().url().optional(),
+
   // Telegram channel. When TELEGRAM_BOT_TOKEN is set, the channel package is
   // auto-installed at boot. TELEGRAM_WEBHOOK_SECRET is required alongside it
   // (HMAC-style header validation on the webhook). TELEGRAM_PUBLIC_BASE_URL

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -36,7 +36,11 @@ import { resolvePlatform } from './update/platform.js';
 import { resolveAppVersion } from './update/version.js';
 import { createMemoryBackendRouter } from './routes/memoryBackend.js';
 import { createChatRouter } from './routes/chat.js';
-import { createOperatorAgentsRouter } from './routes/operatorAgents.js';
+import {
+  createOperatorAgentsRouter,
+  type OperatorTeamsIdentityStore,
+  type OperatorTeamsProvisioningRunner,
+} from './routes/operatorAgents.js';
 import { wireConductor, AwaitNotPendingError, AwaitResponderNotHolderError, ConductorRoleStore, ConductorEphemeralAttachmentsStore } from './conductor/index.js';
 import { createMissReportRoutes } from './privacy/missReportRoutes.js';
 import { TURN_RECEIPT_STORE_SERVICE_NAME } from '@omadia/plugin-api';
@@ -3171,10 +3175,35 @@ async function main(): Promise<void> {
       // no DATABASE_URL is set the route degrades to its own 503.
       getAgentGraphStore: () =>
         graphPool ? new AgentGraphStore(graphPool) : undefined,
+      // W1a (#860) — Teams identity provisioning. Resolved live through the
+      // service registry: the agent-factory boot wiring registers the
+      // identity store ('agentTeamsIdentityStore', backed by migration 0049)
+      // and the provisioning job runner ('teamsProvisioningJobRunner',
+      // services/teamsProvisioningJob.ts) once DATABASE_URL is set; the M365
+      // connector publishes 'teamsProvisioner' when installed. Until both
+      // kernel pieces are registered the routes degrade to their own 503,
+      // same shape as the graph-store fallback above. Kernel-side resolution
+      // via serviceRegistry.get carries KERNEL_SERVICE_CALLER, so the
+      // plugin-facing SERVICE grant gate is not involved here.
+      getTeamsIdentity: () => {
+        const identityStore = serviceRegistry.get<OperatorTeamsIdentityStore>(
+          'agentTeamsIdentityStore',
+        );
+        const provisioningRunner =
+          serviceRegistry.get<OperatorTeamsProvisioningRunner>(
+            'teamsProvisioningJobRunner',
+          );
+        if (!identityStore || !provisioningRunner) return undefined;
+        return {
+          store: identityStore,
+          runner: provisioningRunner,
+          isProvisionerInstalled: () => serviceRegistry.has('teamsProvisioner'),
+        };
+      },
     }),
   );
   console.log(
-    '[middleware] operator-agents endpoints ready at /api/v1/operator/agents/* (auth-gated)',
+    '[middleware] operator-agents endpoints ready at /api/v1/operator/agents/* (auth-gated, incl. teams-identity provisioning)',
   );
 
   // Phase B+ — operator channels dashboard.

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -41,6 +41,16 @@ import {
   type OperatorTeamsIdentityStore,
   type OperatorTeamsProvisioningRunner,
 } from './routes/operatorAgents.js';
+import { AgentTeamsIdentityStore } from './platform/agentTeamsIdentityStore.js';
+import { TeamsProvisioningJobRunner } from './services/teamsProvisioningJob.js';
+import {
+  buildTeamsBotMessagingEndpoint,
+  requireTeamsProvisioner,
+} from './platform/teamsProvisionerService.js';
+import {
+  CHANNEL_TEAMS_PLUGIN_ID,
+  createTeamsAppPackageAssetLoader,
+} from './services/teamsAppPackageAssets.js';
 import { wireConductor, AwaitNotPendingError, AwaitResponderNotHolderError, ConductorRoleStore, ConductorEphemeralAttachmentsStore } from './conductor/index.js';
 import { createMissReportRoutes } from './privacy/missReportRoutes.js';
 import { TURN_RECEIPT_STORE_SERVICE_NAME } from '@omadia/plugin-api';
@@ -1855,6 +1865,73 @@ async function main(): Promise<void> {
     }
     audienceGrantStoreRef = audienceGrantStore;
     attachmentBindingStoreRef = new PostgresAttachmentBindingStore(graphPool);
+  }
+
+  // W1a (#860) — agent factory: Teams identity provisioning. Registers the
+  // two kernel boot services the operator teams-identity routes resolve
+  // late-bound (see the /api/v1/operator/agents mount): the identity store
+  // (`agentTeamsIdentityStore`, migration 0049) and the provisioning job
+  // runner (`teamsProvisioningJobRunner`). Requires Postgres — without
+  // DATABASE_URL the routes answer their own 503
+  // (teams_identity_unavailable). The `teamsProvisioner@1` capability itself
+  // is published by the M365 connector plugin (>= 0.3.1) and resolved
+  // lazily PER RUN through the accessor choke point, so installing the
+  // connector after boot is picked up without a restart; until then runs
+  // fail retryable, never crash. No Graph/ARM call happens in this process.
+  if (graphPool) {
+    const agentTeamsIdentityStore = new AgentTeamsIdentityStore(graphPool);
+    serviceRegistry.provide('agentTeamsIdentityStore', agentTeamsIdentityStore);
+    // TEAMS_PUBLIC_BASE_URL ?? PUBLIC_BASE_URL — the binding contract of
+    // config.ts; resolved per call so a config reload wins over boot state.
+    const teamsPublicBaseUrl = (): string =>
+      config.TEAMS_PUBLIC_BASE_URL ?? config.PUBLIC_BASE_URL;
+    const teamsProvisioningRunner = new TeamsProvisioningJobRunner({
+      store: agentTeamsIdentityStore,
+      getProvisioner: () => requireTeamsProvisioner(serviceRegistry),
+      // The accessor module's URL builder, bound to the public base — the
+      // runner never composes the messaging endpoint itself.
+      buildMessagingEndpoint: (botSlug) =>
+        buildTeamsBotMessagingEndpoint(teamsPublicBaseUrl(), botSlug),
+      loadPackageAssets: createTeamsAppPackageAssetLoader({
+        getChannelTeamsPackageRoot: () => {
+          const entry = pluginCatalog.get(CHANNEL_TEAMS_PLUGIN_ID);
+          return entry ? path.dirname(entry.source_path) : undefined;
+        },
+        getPublicBaseUrl: teamsPublicBaseUrl,
+      }),
+    });
+    serviceRegistry.provide('teamsProvisioningJobRunner', teamsProvisioningRunner);
+    backgroundJobRegistry.register(teamsProvisioningRunner.asBackgroundJob());
+    // Resume interrupted provisioning: rows that recorded an install target
+    // but neither completed nor terminally failed re-enqueue once at boot.
+    // Idempotent — the runner re-enters at the persisted state and leans on
+    // the provisioner's already-existed signals. Fire-and-forget: a scan
+    // failure logs and never blocks boot.
+    void agentTeamsIdentityStore
+      .listResumable()
+      .then((rows) => {
+        for (const row of rows) {
+          if (!row.teamId) continue;
+          void teamsProvisioningRunner.enqueue({
+            agentId: row.agentId,
+            teamId: row.teamId,
+          });
+        }
+        if (rows.length > 0) {
+          console.log(
+            `[middleware] teams-identity provisioning: resumed ${rows.length} interrupted job(s)`,
+          );
+        }
+      })
+      .catch((err: unknown) => {
+        console.warn(
+          '[middleware] teams-identity provisioning resume scan failed:',
+          err,
+        );
+      });
+    console.log(
+      '[middleware] agent factory ready: agentTeamsIdentityStore + teamsProvisioningJobRunner registered (teamsProvisioner@1 resolved per run)',
+    );
   }
 
   // Issue #560 — now that graphPool is known, back the long-running task seam

--- a/middleware/src/platform/agentTeamsIdentityStore.ts
+++ b/middleware/src/platform/agentTeamsIdentityStore.ts
@@ -1,0 +1,301 @@
+/**
+ * `agent_teams_identities` store (epic byte5ai/omadia#860, wave W1a) —
+ * backing migration 0049. Sibling of `pluginSqlGrantStore.ts` (0047) and
+ * `publicPathGrantStore.ts` (0046) in shape, with one deliberate posture
+ * difference: those stores are fail-closed on read because an unread row
+ * removes a PERMISSION; here a missing row simply means "no Teams identity
+ * provisioned yet", so query failures SURFACE to the caller instead of
+ * masquerading as a fresh 'pending' identity. A 500 the operator can see is
+ * strictly better than a status endpoint inventing provisioning state.
+ *
+ * SINGLE WRITER RULE. `state` and `last_error` are written exclusively
+ * through this store: the provisioning job runner
+ * (`services/teamsProvisioningJob.ts`) drives the chain
+ * pending → app_registered → bot_created → package_built → catalog_uploaded
+ * → installed (terminal: failed) and the exported
+ * {@link TEAMS_PROVISIONING_STATES} union is the SINGLE vocabulary — its
+ * values mirror the CHECK constraint of migration 0049 exactly, and both the
+ * runner and the operator router import it from here.
+ *
+ * NO SECRET MATERIAL. The row carries only app_id / tenant_id /
+ * teams_app_id / teams_app_external_id — the bot's client secret stays in
+ * the M365 connector's vault (opaque ref `teams_bot_password:<appId>`,
+ * derived from `app_id` by the status projection, never stored).
+ *
+ * ONE IDENTITY PER AGENT, ONE AGENT PER BOT SLUG. `ensureForAgent` is the
+ * create-if-absent gate on the `agent_id` primary key; the `bot_slug` UNIQUE
+ * constraint makes a cross-agent slug collision fail loudly as
+ * {@link BotSlugTakenError} (409 upstream) instead of letting two agents
+ * share one bot identity and credential namespace.
+ */
+
+import type { Pool } from 'pg';
+
+// ---------------------------------------------------------------------------
+// State vocabulary — the CHECK constraint of migration 0049, verbatim.
+// ---------------------------------------------------------------------------
+
+export const TEAMS_PROVISIONING_STATES = [
+  'pending',
+  'app_registered',
+  'bot_created',
+  'package_built',
+  'catalog_uploaded',
+  'installed',
+  'failed',
+] as const;
+
+export type TeamsProvisioningState = (typeof TEAMS_PROVISIONING_STATES)[number];
+
+export function isTeamsProvisioningState(
+  value: unknown,
+): value is TeamsProvisioningState {
+  return (
+    typeof value === 'string' &&
+    (TEAMS_PROVISIONING_STATES as readonly string[]).includes(value)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Records + errors
+// ---------------------------------------------------------------------------
+
+/** One `agent_teams_identities` row, camelCase. */
+export interface AgentTeamsIdentityRecord {
+  readonly agentId: string;
+  readonly botSlug: string;
+  readonly displayName: string;
+  readonly state: TeamsProvisioningState;
+  /** Install target of the last provisioning request — resume evidence. */
+  readonly teamId: string | null;
+  readonly appId: string | null;
+  readonly tenantId: string | null;
+  readonly teamsAppId: string | null;
+  readonly teamsAppExternalId: string | null;
+  readonly lastError: string | null;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+export interface EnsureAgentTeamsIdentityInput {
+  readonly agentId: string;
+  readonly botSlug: string;
+  readonly displayName: string;
+  /** When provided, recorded as the (new) install target — the ONLY field an
+   *  ensure updates on an existing row; bot_slug/display_name stay as
+   *  created (one identity per agent). */
+  readonly teamId?: string;
+}
+
+export interface AgentTeamsIdentityUpdate {
+  readonly state?: TeamsProvisioningState;
+  readonly teamId?: string;
+  readonly appId?: string;
+  readonly tenantId?: string;
+  readonly teamsAppId?: string;
+  readonly teamsAppExternalId?: string;
+  /** `null` clears a previous error. */
+  readonly lastError?: string | null;
+}
+
+/** The requested bot slug is already held by ANOTHER agent's identity. */
+export class BotSlugTakenError extends Error {
+  public readonly code = 'bot_slug_taken';
+  public readonly botSlug: string;
+
+  constructor(botSlug: string) {
+    super(
+      `bot_slug_taken: bot slug '${botSlug}' is already used by another agent's Teams identity — bot slugs are globally unique (they name the Azure bot and its messaging endpoint)`,
+    );
+    this.name = 'BotSlugTakenError';
+    this.botSlug = botSlug;
+  }
+}
+
+/** An update addressed an agent that has no identity row. */
+export class AgentTeamsIdentityNotFoundError extends Error {
+  public readonly code = 'teams_identity_not_found';
+
+  constructor(agentId: string) {
+    super(`no agent_teams_identities row for agent '${agentId}'`);
+    this.name = 'AgentTeamsIdentityNotFoundError';
+  }
+}
+
+/** A write carried a state outside the CHECK-constraint vocabulary. Caught
+ *  here (not by the DB) so the error names the union, and so no partial SET
+ *  clause is ever sent. */
+export class AgentTeamsIdentityStateError extends Error {
+  public readonly code = 'invalid_teams_provisioning_state';
+
+  constructor(value: unknown) {
+    super(
+      `invalid teams provisioning state ${JSON.stringify(value)} — expected one of ${TEAMS_PROVISIONING_STATES.join(', ')}`,
+    );
+    this.name = 'AgentTeamsIdentityStateError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+const COLUMNS =
+  'agent_id, bot_slug, display_name, state, team_id, app_id, tenant_id, teams_app_id, teams_app_external_id, last_error, created_at, updated_at';
+
+interface AgentTeamsIdentityRow {
+  agent_id: string;
+  bot_slug: string;
+  display_name: string;
+  state: string;
+  team_id: string | null;
+  app_id: string | null;
+  tenant_id: string | null;
+  teams_app_id: string | null;
+  teams_app_external_id: string | null;
+  last_error: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+function mapRow(row: AgentTeamsIdentityRow): AgentTeamsIdentityRecord {
+  if (!isTeamsProvisioningState(row.state)) {
+    // Unreachable while the CHECK constraint stands; surfacing beats lying.
+    throw new AgentTeamsIdentityStateError(row.state);
+  }
+  return {
+    agentId: row.agent_id,
+    botSlug: row.bot_slug,
+    displayName: row.display_name,
+    state: row.state,
+    teamId: row.team_id,
+    appId: row.app_id,
+    tenantId: row.tenant_id,
+    teamsAppId: row.teams_app_id,
+    teamsAppExternalId: row.teams_app_external_id,
+    lastError: row.last_error,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function isUniqueViolationOn(err: unknown, constraint: string): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const e = err as { code?: unknown; constraint?: unknown };
+  return e.code === '23505' && e.constraint === constraint;
+}
+
+/** Postgres' default name for the migration's `UNIQUE (bot_slug)`. */
+const BOT_SLUG_UNIQUE_CONSTRAINT = 'agent_teams_identities_bot_slug_key';
+
+export class AgentTeamsIdentityStore {
+  constructor(private readonly pool: Pool) {}
+
+  /** `undefined` = no identity (not provisioned). Query failures surface. */
+  async getByAgentId(
+    agentId: string,
+  ): Promise<AgentTeamsIdentityRecord | undefined> {
+    const res = await this.pool.query<AgentTeamsIdentityRow>(
+      `SELECT ${COLUMNS} FROM agent_teams_identities WHERE agent_id = $1`,
+      [agentId],
+    );
+    const row = res.rows[0];
+    return row === undefined ? undefined : mapRow(row);
+  }
+
+  /**
+   * Create-if-absent (the one-identity-per-agent gate). An existing row is
+   * returned with only `team_id` refreshed (a re-POST may target a new
+   * team); its bot_slug/display_name are NOT touched. A bot_slug held by a
+   * DIFFERENT agent throws {@link BotSlugTakenError}.
+   */
+  async ensureForAgent(
+    input: EnsureAgentTeamsIdentityInput,
+  ): Promise<AgentTeamsIdentityRecord> {
+    try {
+      const res = await this.pool.query<AgentTeamsIdentityRow>(
+        `INSERT INTO agent_teams_identities (agent_id, bot_slug, display_name, team_id)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (agent_id) DO UPDATE SET
+           team_id    = COALESCE(EXCLUDED.team_id, agent_teams_identities.team_id),
+           updated_at = now()
+         RETURNING ${COLUMNS}`,
+        [input.agentId, input.botSlug, input.displayName, input.teamId ?? null],
+      );
+      const row = res.rows[0];
+      if (row === undefined) {
+        // Unreachable: INSERT … ON CONFLICT DO UPDATE always returns the row.
+        throw new AgentTeamsIdentityNotFoundError(input.agentId);
+      }
+      return mapRow(row);
+    } catch (err) {
+      if (isUniqueViolationOn(err, BOT_SLUG_UNIQUE_CONSTRAINT)) {
+        throw new BotSlugTakenError(input.botSlug);
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Patch one row (the job runner's exclusive write path for state /
+   * last_error / step evidence). Throws
+   * {@link AgentTeamsIdentityNotFoundError} for an unknown agent and
+   * {@link AgentTeamsIdentityStateError} for a state outside the union —
+   * never a silent no-op.
+   */
+  async update(
+    agentId: string,
+    patch: AgentTeamsIdentityUpdate,
+  ): Promise<AgentTeamsIdentityRecord> {
+    const sets: string[] = [];
+    const values: unknown[] = [agentId];
+    const add = (column: string, value: unknown): void => {
+      values.push(value);
+      sets.push(`${column} = $${String(values.length)}`);
+    };
+    if (patch.state !== undefined) {
+      if (!isTeamsProvisioningState(patch.state)) {
+        throw new AgentTeamsIdentityStateError(patch.state);
+      }
+      add('state', patch.state);
+    }
+    if (patch.teamId !== undefined) add('team_id', patch.teamId);
+    if (patch.appId !== undefined) add('app_id', patch.appId);
+    if (patch.tenantId !== undefined) add('tenant_id', patch.tenantId);
+    if (patch.teamsAppId !== undefined) add('teams_app_id', patch.teamsAppId);
+    if (patch.teamsAppExternalId !== undefined) {
+      add('teams_app_external_id', patch.teamsAppExternalId);
+    }
+    if (patch.lastError !== undefined) add('last_error', patch.lastError);
+    sets.push('updated_at = now()');
+    const res = await this.pool.query<AgentTeamsIdentityRow>(
+      `UPDATE agent_teams_identities SET ${sets.join(', ')} WHERE agent_id = $1 RETURNING ${COLUMNS}`,
+      values,
+    );
+    const row = res.rows[0];
+    if (row === undefined) throw new AgentTeamsIdentityNotFoundError(agentId);
+    return mapRow(row);
+  }
+
+  /** Persist an enqueue failure so the status endpoint can show WHY nothing
+   *  is running (the POST handler calls this best-effort from its
+   *  fire-and-forget catch). State is deliberately untouched. */
+  async recordEnqueueFailure(agentId: string, message: string): Promise<void> {
+    await this.update(agentId, { lastError: `enqueue_failed: ${message}` });
+  }
+
+  /**
+   * Rows a boot-time resume should re-enqueue: provisioning started (a team
+   * target is recorded) but neither completed nor terminally failed.
+   * 'failed' is deliberately excluded — it stays parked until an operator
+   * re-POSTs.
+   */
+  async listResumable(): Promise<readonly AgentTeamsIdentityRecord[]> {
+    const res = await this.pool.query<AgentTeamsIdentityRow>(
+      `SELECT ${COLUMNS} FROM agent_teams_identities
+       WHERE state NOT IN ('installed', 'failed') AND team_id IS NOT NULL
+       ORDER BY created_at ASC`,
+    );
+    return res.rows.map(mapRow);
+  }
+}

--- a/middleware/src/platform/pluginServiceGrants.ts
+++ b/middleware/src/platform/pluginServiceGrants.ts
@@ -254,6 +254,17 @@ export const STANDALONE_LEGACY_SERVICE_GRANTS_2026_08_20: Readonly<
   // retires when channel-teams declares `permissions.sql` and the operator
   // grants it (C7 / omadia#787), which is independent of #838.
   '@omadia/channel-teams': Object.freeze(['graphPool']),
+
+  // W1a (#860) — 'teamsProvisioner' decision, recorded so nobody re-audits:
+  // NO row is needed for the Teams agent factory. The consumer is the KERNEL
+  // (operator teams-identity routes + provisioning job runner resolve the
+  // accessor through `serviceRegistry.get`, attributed to
+  // KERNEL_SERVICE_CALLER), and this gate sits in front of PLUGIN consumers
+  // (`ctx.services.get`) only. The M365 connector PROVIDES the capability and
+  // declares it in its manifest (`provides: ["teamsProvisioner@1"]`), which
+  // per the #788 rule grants its own readback once registered. A row would be
+  // required only if a plugin other than the provider started consuming
+  // 'teamsProvisioner' without declaring it — none does.
 });
 
 /**

--- a/middleware/src/platform/serviceRegistry.ts
+++ b/middleware/src/platform/serviceRegistry.ts
@@ -67,6 +67,15 @@ export type ServiceName =
   | 'diagrams'
   | 'attachments'
   | 'memory'
+  // W1a (#860) — named for documented intent (the open union below would
+  // accept them anyway): 'teamsProvisioner' is PROVIDED by the M365
+  // connector (teamsProvisioner@1, >= 0.3.0) and consumed kernel-side by
+  // the agent factory; 'agentTeamsIdentityStore' and
+  // 'teamsProvisioningJobRunner' are kernel boot registrations the
+  // operator teams-identity routes resolve late-bound.
+  | 'teamsProvisioner'
+  | 'agentTeamsIdentityStore'
+  | 'teamsProvisioningJobRunner'
   | (string & {});
 
 /** A registration remembered for its owner so `disposeBySource` can unwind

--- a/middleware/src/platform/teamsProvisionerService.ts
+++ b/middleware/src/platform/teamsProvisionerService.ts
@@ -1,0 +1,563 @@
+/**
+ * `teamsProvisioner@1` — the kernel's SINGLE choke point for the Teams
+ * provisioning capability (epic byte5ai/omadia#860, wave W1a).
+ *
+ * The capability itself is implemented and REGISTERED by the
+ * `@omadia/integration-microsoft365` connector plugin (≥ 0.3.1); every
+ * Graph/ARM call happens inside that plugin. The middleware consumes it
+ * through the {@link ServiceRegistry} — this module is the only place that
+ *
+ *   (a) resolves `serviceRegistry.get<TeamsProvisionerAccessor>('teamsProvisioner')`
+ *       (as {@link KERNEL_SERVICE_CALLER} — the kernel's own identity), and
+ *   (b) builds the per-bot messaging endpoint URL
+ *       (`https://<public-base-url>/api/teams/<botSlug>/messages`,
+ *       the per-bot route shipped in channel-teams 0.20.0),
+ *
+ * so the operator router, the provisioning job runner and the status
+ * projection never duplicate either.
+ *
+ * MIRRORED CONTRACT. The connector is not vendored in this checkout, so the
+ * `TeamsProvisionerAccessor` surface and its typed error taxonomy are
+ * mirrored here from the connector repo (`omadia-m365-connector`,
+ * `src/teamsProvisioner/{index,types,errors,appRegistration,botService,
+ * catalog,install,appPackage,secretStore}.ts`, v0.3.1). Keep in sync when
+ * the connector's surface changes. Mirroring the SHIPPED accessor — NOT the
+ * deprecated `TeamsProvisioner` sketch (`registerApplication`/
+ * `addClientSecret`): the connector's own types.ts deprecates that sketch
+ * ("coding against THIS interface compiles but fails at runtime").
+ *
+ * SECRET CUSTODY. The shipped contract never lets a cleartext client secret
+ * cross the service boundary: `createAppRegistration` persists the generated
+ * password into the CONNECTOR's vault and returns only the opaque
+ * `secretRef` (`teams_bot_password:<appId>`). The wrapper returned by
+ * {@link requireTeamsProvisioner} additionally strips any cleartext-looking
+ * field (`secretText`, `clientSecret`) a mis-implemented provider might
+ * attach, so no caller downstream of this choke point can log or persist
+ * one. Nothing here (or in the identity table) stores a secret value.
+ *
+ * SINGLE-TENANT INVARIANT. New MultiTenant Entra registrations are
+ * deprecated (07/2025); the contract models exactly one sign-in audience
+ * (`'AzureADMyOrg'`). The wrapper enforces this at the accessor boundary:
+ * inputs carrying an unknown tenant mode or a foreign `signInAudience` are
+ * rejected with {@link SingleTenantViolationError} before they reach the
+ * connector.
+ *
+ * Typed errors thrown by the CONNECTOR cross the plugin boundary as plain
+ * `Error` instances whose class identity is the plugin's, not ours — so
+ * consumers must never `instanceof` against local mirrors. Use the
+ * duck-typed guards ({@link isConsentMissingError}, …), which match on
+ * `error.name` plus the structured fields.
+ */
+
+import { KERNEL_SERVICE_CALLER, type ServiceRegistry } from './serviceRegistry.js';
+
+/** Service-registry key (bare, unversioned). */
+export const TEAMS_PROVISIONER_SERVICE_NAME = 'teamsProvisioner';
+/** Manifest capability ref (`provides:` / `requires:` form). */
+export const TEAMS_PROVISIONER_CAPABILITY = 'teamsProvisioner@1';
+
+// ---------------------------------------------------------------------------
+// Mirrored contract types (connector v0.3.1) — see module doc.
+// ---------------------------------------------------------------------------
+
+/** Which tenant the provisioner operates against. MultiTenant is NOT a mode. */
+export type TenantMode = 'customer' | 'home';
+
+/** The only sign-in audience the provisioner will ever create. */
+export type SignInAudience = 'AzureADMyOrg';
+
+/** Idempotency signal for steps whose remote API answers 409 on re-runs. */
+export type IdempotentOutcome = 'created' | 'already-existed';
+
+/** Result wrapper carrying the {@link IdempotentOutcome} alongside the value. */
+export interface Idempotent<T> {
+  readonly outcome: IdempotentOutcome;
+  readonly value: T;
+}
+
+/** A provisioned (or found) Entra app registration. */
+export interface AppRegistration {
+  /** Application (client) id — what Bot Framework calls the MSA app id. */
+  readonly appId: string;
+  /** Directory object id of the `application` resource. */
+  readonly objectId: string;
+  readonly tenantId: string;
+  readonly tenantMode: TenantMode;
+  readonly signInAudience: SignInAudience;
+  readonly displayName: string;
+  /** Stable idempotency key the registration was created/found under, if any. */
+  readonly uniqueName?: string;
+}
+
+/** Opaque vault reference to a bot password — NEVER the cleartext value. */
+export type TeamsBotPasswordSecretRef = `teams_bot_password:${string}`;
+
+export interface CreateAppRegistrationInput {
+  readonly displayName: string;
+  /** Label only — the audience is ALWAYS SingleTenant (`'AzureADMyOrg'`). */
+  readonly tenantMode: TenantMode;
+  /** Stable idempotency key (Graph `uniqueName`). */
+  readonly uniqueName?: string;
+  /** Portal label for the generated secret. */
+  readonly secretDisplayName?: string;
+}
+
+/** What `createAppRegistration` hands back — NO secret value, only the ref. */
+export interface ProvisionedAppRegistration {
+  readonly appId: string;
+  /** Opaque vault reference to the generated password (connector custody). */
+  readonly secretRef: TeamsBotPasswordSecretRef;
+  readonly registration: AppRegistration;
+  /** `keyId` of the added password credential. */
+  readonly secretKeyId: string;
+  /** ISO-8601 expiry of the added password credential. */
+  readonly secretEndDateTime: string;
+  readonly servicePrincipalOutcome: IdempotentOutcome;
+}
+
+export type DeleteAppRegistrationOutcome = 'deleted' | 'already-deleted';
+
+export interface DeleteAppRegistrationInput {
+  readonly appId: string;
+  /** When provided, the stored bot password is removed from the vault too. */
+  readonly secretRef?: string;
+}
+
+export interface DeleteAppRegistrationResult {
+  readonly outcome: DeleteAppRegistrationOutcome;
+}
+
+/** An Azure Bot resource created via ARM REST. */
+export interface AzureBot {
+  readonly botName: string;
+  readonly resourceId: string;
+  readonly msaAppId: string;
+  readonly messagingEndpoint: string;
+}
+
+/** Typed degraded outcome: Graph-only config, no ARM — no bot creation. */
+export interface RegistrationOnlyOutcome {
+  readonly kind: 'registration-only';
+  readonly reason: 'arm-not-configured';
+  readonly missingSetupFields: readonly string[];
+}
+
+export interface BotProvisionedOutcome {
+  readonly kind: 'provisioned';
+  readonly bot: Idempotent<AzureBot>;
+}
+
+export type BotProvisioningOutcome = BotProvisionedOutcome | RegistrationOnlyOutcome;
+
+export interface CreateBotInput {
+  /** ARM resource name / bot handle (also the idempotency key). */
+  readonly botName: string;
+  readonly displayName: string;
+  readonly msaAppId: string;
+  readonly msaAppTenantId: string;
+  readonly messagingEndpoint: string;
+}
+
+export type DeleteBotOutcome = 'deleted' | 'already-deleted';
+
+export interface BotDeletedResult {
+  readonly kind: 'deleted';
+  readonly outcome: DeleteBotOutcome;
+}
+
+export type DeleteBotResult = BotDeletedResult | RegistrationOnlyOutcome;
+
+export interface BotFoundResult {
+  readonly kind: 'found';
+  readonly bot: AzureBot;
+}
+
+export interface BotNotFoundResult {
+  readonly kind: 'not-found';
+}
+
+export type GetBotResult = BotFoundResult | BotNotFoundResult | RegistrationOnlyOutcome;
+
+/** Per-agent icon PNGs for the Teams app package. */
+export interface AppPackageIcons {
+  /** PNG bytes for `color.png` (192×192). */
+  readonly color: Uint8Array;
+  /** PNG bytes for `outline.png` (32×32, transparent). */
+  readonly outline: Uint8Array;
+}
+
+export type AppPackageParamValue = string | readonly string[];
+export type AppPackageParams = Readonly<Record<string, AppPackageParamValue>>;
+
+export interface BuildAppPackageInput {
+  /** The `manifest.json.template` text from `omadia-channel-teams`. */
+  readonly manifestTemplate: string;
+  readonly params: AppPackageParams;
+  readonly icons: AppPackageIcons;
+}
+
+/** A Teams app in the tenant app catalog. */
+export interface CatalogTeamsApp {
+  /** Catalog id (`teamsApp.id`) — what installs reference. */
+  readonly teamsAppId: string;
+  /** Manifest id (`externalId`) — the idempotency key for uploads. */
+  readonly externalId: string;
+  readonly displayName: string;
+  readonly version: string;
+}
+
+export interface UploadToCatalogInput {
+  readonly packageZip: Uint8Array;
+  readonly externalId: string;
+}
+
+export interface GetCatalogAppInput {
+  readonly teamsAppExternalId: string;
+}
+
+export interface CatalogAppNotFound {
+  readonly found: false;
+}
+
+export interface CatalogAppFound {
+  readonly found: true;
+  readonly teamsAppId: string;
+  readonly displayName?: string;
+  readonly publishedVersion?: string;
+}
+
+export type GetCatalogAppResult = CatalogAppNotFound | CatalogAppFound;
+
+export type ResourceSpecificPermissionType = 'application' | 'delegated';
+
+export interface ResourceSpecificPermission {
+  readonly permissionValue: string;
+  readonly permissionType: ResourceSpecificPermissionType;
+}
+
+export interface ConsentedPermissionSet {
+  readonly resourceSpecificPermissions: readonly ResourceSpecificPermission[];
+}
+
+export interface InstallToTeamRequest {
+  readonly teamId: string;
+  /** Catalog id (`CatalogTeamsApp.teamsAppId`). */
+  readonly teamsAppId: string;
+  /** Sent to Graph verbatim when present. */
+  readonly consentedPermissionSet?: ConsentedPermissionSet;
+}
+
+export interface TeamAppInstallation {
+  readonly teamId: string;
+  readonly teamsAppId: string;
+  readonly installationId?: string;
+}
+
+/**
+ * The service object the connector publishes under the registry key
+ * `'teamsProvisioner'` — one method per chain step; the caller (the agent
+ * factory's job runner) owns ordering, persistence and retries.
+ */
+export interface TeamsProvisionerAccessor {
+  readonly tenantMode: TenantMode;
+  /** `true` when the ARM setup fields are configured (bot creation possible). */
+  readonly canCreateBots: boolean;
+
+  createAppRegistration(
+    input: CreateAppRegistrationInput,
+  ): Promise<Idempotent<ProvisionedAppRegistration>>;
+  deleteAppRegistration(
+    input: DeleteAppRegistrationInput,
+  ): Promise<DeleteAppRegistrationResult>;
+  getAppRegistration(
+    appId: string,
+    tenantMode: TenantMode,
+  ): Promise<AppRegistration | undefined>;
+
+  /** Pure, no network — renders the per-agent Teams app package zip. */
+  buildAppPackage(input: BuildAppPackageInput): Uint8Array;
+
+  createBot(input: CreateBotInput): Promise<BotProvisioningOutcome>;
+  deleteBot(botName: string): Promise<DeleteBotResult>;
+  getBot(botName: string): Promise<GetBotResult>;
+
+  uploadToCatalog(input: UploadToCatalogInput): Promise<Idempotent<CatalogTeamsApp>>;
+  getCatalogApp(input: GetCatalogAppInput): Promise<GetCatalogAppResult>;
+
+  installToTeam(input: InstallToTeamRequest): Promise<Idempotent<TeamAppInstallation>>;
+}
+
+// ---------------------------------------------------------------------------
+// Connector error taxonomy — duck-typed guards (see module doc on why not
+// `instanceof`). Names/fields mirror `errors.ts` of the connector.
+// ---------------------------------------------------------------------------
+
+export interface ConsentMissingErrorLike extends Error {
+  readonly name: 'ConsentMissingError';
+  readonly missingScopes: readonly string[];
+  readonly resource: 'graph' | 'arm';
+}
+
+export interface ProvisioningThrottledErrorLike extends Error {
+  readonly name: 'ProvisioningThrottledError';
+  readonly resource: 'graph' | 'arm';
+  /** Seconds from the final `Retry-After` header, if the API provided it. */
+  readonly retryAfterSeconds?: number;
+}
+
+export interface ArmNotConfiguredErrorLike extends Error {
+  readonly name: 'ArmNotConfiguredError';
+  readonly missingSetupFields: readonly string[];
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+}
+
+/** Graph/ARM answered 403 — an application permission / admin consent is missing. */
+export function isConsentMissingError(err: unknown): err is ConsentMissingErrorLike {
+  return (
+    err instanceof Error &&
+    err.name === 'ConsentMissingError' &&
+    isStringArray((err as Partial<ConsentMissingErrorLike>).missingScopes)
+  );
+}
+
+/** The connector exhausted its 429 backoff budget — honor `retryAfterSeconds`. */
+export function isProvisioningThrottledError(
+  err: unknown,
+): err is ProvisioningThrottledErrorLike {
+  if (!(err instanceof Error) || err.name !== 'ProvisioningThrottledError') return false;
+  const retryAfter = (err as Partial<ProvisioningThrottledErrorLike>).retryAfterSeconds;
+  return retryAfter === undefined || typeof retryAfter === 'number';
+}
+
+/** An ARM-dependent step ran although the ARM setup fields are not configured. */
+export function isArmNotConfiguredError(err: unknown): err is ArmNotConfiguredErrorLike {
+  return (
+    err instanceof Error &&
+    err.name === 'ArmNotConfiguredError' &&
+    isStringArray((err as Partial<ArmNotConfiguredErrorLike>).missingSetupFields)
+  );
+}
+
+/** Every `error.name` in the connector's `TeamsProvisionerError` taxonomy. */
+const TEAMS_PROVISIONER_ERROR_NAMES: ReadonlySet<string> = new Set([
+  'ConsentMissingError',
+  'ProvisioningThrottledError',
+  'ArmNotConfiguredError',
+  'CapabilityUnavailableError',
+  'AppPackageError',
+]);
+
+/** Does this error belong to the connector's typed taxonomy at all? */
+export function isTeamsProvisionerError(err: unknown): err is Error {
+  return err instanceof Error && TEAMS_PROVISIONER_ERROR_NAMES.has(err.name);
+}
+
+// ---------------------------------------------------------------------------
+// Kernel-side typed errors
+// ---------------------------------------------------------------------------
+
+/**
+ * The `teamsProvisioner` service is not registered — the
+ * `@omadia/integration-microsoft365` connector plugin (≥ 0.3.1) is not
+ * installed or not active. Routers map this to 503 (mirroring the
+ * `orchestratorRegistry@1` unavailable shape), the job runner to a retryable
+ * failure. Never a crash.
+ */
+export class TeamsProvisionerUnavailableError extends Error {
+  public readonly code = 'teams_provisioner_unavailable';
+
+  constructor() {
+    super(
+      `${TEAMS_PROVISIONER_CAPABILITY} is not published — install and activate the @omadia/integration-microsoft365 connector plugin (>= 0.3.1).`,
+    );
+    this.name = 'TeamsProvisionerUnavailableError';
+  }
+}
+
+/**
+ * A caller tried to hand the provisioner a MultiTenant-shaped input. The
+ * contract is SingleTenant-only (`signInAudience: 'AzureADMyOrg'`); this is
+ * rejected at the accessor boundary, before the connector sees it.
+ */
+export class SingleTenantViolationError extends Error {
+  public readonly code = 'single_tenant_only';
+  /** Which input field carried the rejected value. */
+  public readonly field: string;
+
+  constructor(field: string, rejectedValue: unknown) {
+    super(
+      `single_tenant_only: '${field}' = ${JSON.stringify(rejectedValue)} — the Teams provisioner registers SingleTenant ('AzureADMyOrg') apps in tenant mode 'customer' | 'home' only`,
+    );
+    this.name = 'SingleTenantViolationError';
+    this.field = field;
+  }
+}
+
+/** The messaging-endpoint builder rejected its inputs (see {@link buildTeamsBotMessagingEndpoint}). */
+export class TeamsMessagingEndpointError extends Error {
+  public readonly code = 'invalid_teams_messaging_endpoint';
+
+  constructor(problem: string, options?: ErrorOptions) {
+    super(`invalid_teams_messaging_endpoint: ${problem}`, options);
+    this.name = 'TeamsMessagingEndpointError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Resolution — the single `serviceRegistry.get` call site
+// ---------------------------------------------------------------------------
+
+/** The one registry facet this module needs — full registry or test double. */
+export type TeamsProvisionerResolver = Pick<ServiceRegistry, 'get'>;
+
+const TENANT_MODES: ReadonlySet<string> = new Set(['customer', 'home']);
+
+function assertTenantMode(value: unknown): asserts value is TenantMode {
+  if (typeof value !== 'string' || !TENANT_MODES.has(value)) {
+    throw new SingleTenantViolationError('tenantMode', value);
+  }
+}
+
+function assertSingleTenantInput(input: CreateAppRegistrationInput): void {
+  assertTenantMode(input.tenantMode);
+  // The typed input cannot express an audience, but router bodies are runtime
+  // values — a smuggled `signInAudience` other than the single-tenant one is
+  // exactly what this boundary exists to stop.
+  const audience = (input as unknown as Record<string, unknown>)['signInAudience'];
+  if (audience !== undefined && audience !== 'AzureADMyOrg') {
+    throw new SingleTenantViolationError('signInAudience', audience);
+  }
+}
+
+/**
+ * Strip cleartext-looking secret fields from a provider result. The shipped
+ * contract never returns one, but this choke point is where the "no secret
+ * crosses the boundary" invariant is ENFORCED, not assumed.
+ */
+function stripCleartextSecrets<T>(value: T): T {
+  if (value === null || typeof value !== 'object') return value;
+  const record = value as Record<string, unknown>;
+  if (!('secretText' in record) && !('clientSecret' in record)) return value;
+  const { secretText: _secretText, clientSecret: _clientSecret, ...rest } = record;
+  return rest as T;
+}
+
+/** Wrap the raw provider with the boundary guards this module owes callers. */
+function guardAccessor(raw: TeamsProvisionerAccessor): TeamsProvisionerAccessor {
+  return {
+    get tenantMode() {
+      return raw.tenantMode;
+    },
+    get canCreateBots() {
+      return raw.canCreateBots;
+    },
+    async createAppRegistration(input) {
+      assertSingleTenantInput(input);
+      const result = await raw.createAppRegistration(input);
+      return { ...result, value: stripCleartextSecrets(result.value) };
+    },
+    deleteAppRegistration: (input) => raw.deleteAppRegistration(input),
+    // Async so a boundary violation REJECTS like every other failure of this
+    // method, instead of throwing synchronously out of the call expression.
+    getAppRegistration: async (appId, tenantMode) => {
+      assertTenantMode(tenantMode);
+      return raw.getAppRegistration(appId, tenantMode);
+    },
+    buildAppPackage: (input) => raw.buildAppPackage(input),
+    createBot: (input) => raw.createBot(input),
+    deleteBot: (botName) => raw.deleteBot(botName),
+    getBot: (botName) => raw.getBot(botName),
+    uploadToCatalog: (input) => raw.uploadToCatalog(input),
+    getCatalogApp: (input) => raw.getCatalogApp(input),
+    installToTeam: (input) => raw.installToTeam(input),
+  };
+}
+
+/**
+ * Resolve the provisioner, or `undefined` when the connector plugin is not
+ * installed/active. Synchronous — resolution never awaits. Attributed to
+ * {@link KERNEL_SERVICE_CALLER}: the kernel resolves for itself, never on
+ * behalf of a fabricated plugin identity.
+ */
+export function getTeamsProvisioner(
+  services: TeamsProvisionerResolver,
+): TeamsProvisionerAccessor | undefined {
+  const raw = services.get<TeamsProvisionerAccessor>(
+    TEAMS_PROVISIONER_SERVICE_NAME,
+    KERNEL_SERVICE_CALLER,
+  );
+  return raw === undefined ? undefined : guardAccessor(raw);
+}
+
+/**
+ * Resolve the provisioner or throw the typed
+ * {@link TeamsProvisionerUnavailableError} — the failure routers turn into
+ * a 503 and the job runner into a non-crashing, retryable job failure.
+ */
+export function requireTeamsProvisioner(
+  services: TeamsProvisionerResolver,
+): TeamsProvisionerAccessor {
+  const provisioner = getTeamsProvisioner(services);
+  if (provisioner === undefined) throw new TeamsProvisionerUnavailableError();
+  return provisioner;
+}
+
+// ---------------------------------------------------------------------------
+// Per-bot messaging endpoint URL builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Bot slugs land verbatim in the Azure bot's messaging endpoint and in
+ * channel-teams' per-bot route (`/api/teams/:botSlug/messages`, 0.20.0), so
+ * the charset is deliberately conservative: URL-safe, no separators that
+ * could re-shape the path.
+ */
+const BOT_SLUG_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+/**
+ * Build the messaging endpoint handed to Azure for one bot:
+ * `https://<public-base-url>/api/teams/<botSlug>/messages`.
+ *
+ * The base URL is injected by the caller (the wiring unit binds it to
+ * config — `TEAMS_PUBLIC_BASE_URL ?? PUBLIC_BASE_URL`); this builder owns
+ * the invariants: https only (Azure requires a public TLS endpoint), no
+ * credentials/query/fragment in the base, trailing slashes normalised, and
+ * a path-safe slug.
+ */
+export function buildTeamsBotMessagingEndpoint(
+  publicBaseUrl: string,
+  botSlug: string,
+): string {
+  if (!BOT_SLUG_RE.test(botSlug)) {
+    throw new TeamsMessagingEndpointError(
+      `bot slug ${JSON.stringify(botSlug)} must match ${String(BOT_SLUG_RE)}`,
+    );
+  }
+  let base: URL;
+  try {
+    base = new URL(publicBaseUrl);
+  } catch (err) {
+    throw new TeamsMessagingEndpointError(
+      `public base URL ${JSON.stringify(publicBaseUrl)} is not a valid URL`,
+      { cause: err },
+    );
+  }
+  if (base.protocol !== 'https:') {
+    throw new TeamsMessagingEndpointError(
+      `public base URL must be https (Azure rejects non-TLS bot endpoints), got ${JSON.stringify(base.protocol)}`,
+    );
+  }
+  if (base.username !== '' || base.password !== '') {
+    throw new TeamsMessagingEndpointError('public base URL must not carry credentials');
+  }
+  if (base.search !== '' || base.hash !== '') {
+    throw new TeamsMessagingEndpointError(
+      'public base URL must not carry a query string or fragment',
+    );
+  }
+  const basePath = base.pathname.replace(/\/+$/, '');
+  return `${base.origin}${basePath}/api/teams/${encodeURIComponent(botSlug)}/messages`;
+}

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -62,6 +62,8 @@ interface AgentPluginCatalogEntry {
  *   PUT    /api/v1/operator/agents/:slug/plugins         replace agent plugin set
  *   PATCH  /api/v1/operator/agents/:slug/plugins         enable/disable ONE plugin (body: { id, enabled })
  *   GET    /api/v1/operator/agents/:slug/grants          per-agent tool grants + plugin MCP grants + grant epoch
+ *   POST   /api/v1/operator/agents/:slug/teams-identity   create-or-provision Teams identity (async, W1a #860)
+ *   GET    /api/v1/operator/agents/:slug/teams-identity   Teams identity provisioning status
  *   PUT    /api/v1/operator/agents/:slug/bindings        replace agent channel bindings
  *   PUT    /api/v1/operator/agents/fallback              set platform fallback (body: { slug | null })
  *   POST   /api/v1/operator/agents/:slug/drain           drain + clear session snapshots
@@ -126,6 +128,113 @@ const ResolveChannelSchema = z.object({
   channel_key: z.string().min(1).max(500),
 });
 
+/** W1a (#860) — create-or-provision a Teams identity. `team_id` is the Teams
+ *  team (group) id the generated app is installed into. `bot_slug` /
+ *  `display_name` are only honored on FIRST creation — one identity per
+ *  agent (unique agent_id), later POSTs re-run provisioning on the
+ *  existing row. */
+const TeamsIdentityProvisionSchema = z.object({
+  team_id: z.string().min(1).max(200),
+  bot_slug: z
+    .string()
+    .regex(
+      /^[a-z0-9][a-z0-9-]{0,63}$/,
+      'lowercase letters, digits and dashes; must start alphanumeric',
+    )
+    .optional(),
+  display_name: z.string().min(1).max(120).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// W1a (#860) — Teams identity ports.
+//
+// Structural subsets of the modules built in parallel units of this wave:
+// the `agent_teams_identities` store (migration 0049) and the
+// `TeamsProvisioningJobRunner` of `services/teamsProvisioningJob.ts`. The
+// router consumes them late-bound (like the config store) so it stays
+// testable with stubs and degrades to 503 until the boot wiring registers
+// the real implementations.
+// ---------------------------------------------------------------------------
+
+/** One `agent_teams_identities` row, camelCase — mirrors the job runner's
+ *  `TeamsIdentityJobRecord` plus timestamps. `state` follows the
+ *  provisioning chain: pending → app_registered → bot_created →
+ *  package_built → catalog_uploaded → installed (terminal: failed). */
+export interface OperatorTeamsIdentityRecord {
+  readonly agentId: string;
+  readonly botSlug: string;
+  readonly displayName: string;
+  readonly state: string;
+  readonly appId: string | null;
+  readonly tenantId: string | null;
+  readonly teamsAppId: string | null;
+  readonly teamsAppExternalId: string | null;
+  readonly lastError: string | null;
+  readonly createdAt?: Date;
+  readonly updatedAt?: Date;
+}
+
+export interface OperatorTeamsIdentityStore {
+  getByAgentId(
+    agentId: string,
+  ): Promise<OperatorTeamsIdentityRecord | undefined>;
+  /** Create-if-absent. The unique agent_id constraint makes this the
+   *  one-identity-per-agent gate: an existing row is returned as-is
+   *  (bot_slug/display_name of the request are NOT applied to it). */
+  ensureForAgent(input: {
+    readonly agentId: string;
+    readonly botSlug: string;
+    readonly displayName: string;
+  }): Promise<OperatorTeamsIdentityRecord>;
+}
+
+/** Structural subset of `TeamsProvisioningJobRunner` — enqueue is
+ *  fire-and-forget from the route's perspective; the returned promise is
+ *  the run's eventual result and is deliberately not awaited. */
+export interface OperatorTeamsProvisioningRunner {
+  enqueue(request: {
+    readonly agentId: string;
+    readonly teamId: string;
+  }): Promise<unknown>;
+  isRunning(agentId: string): boolean;
+}
+
+export interface OperatorTeamsIdentityDeps {
+  readonly store: OperatorTeamsIdentityStore;
+  readonly runner: OperatorTeamsProvisioningRunner;
+  /** Live check whether the M365 connector currently publishes
+   *  `teamsProvisioner@1`. POST 503s without it; GET only reports it. */
+  readonly isProvisionerInstalled: () => boolean;
+  /** Credential-store ref under which the identity's bot app password
+   *  (the addClientSecret output) is held — surfaced by the status
+   *  endpoint INSTEAD of the secret itself. Defaults to
+   *  {@link defaultTeamsBotSecretRef}. */
+  readonly clientSecretRef?: (record: OperatorTeamsIdentityRecord) => string;
+}
+
+/**
+ * Custody convention for the provisioned bot's app password: the
+ * `agent_teams_identities` table stores NO secret material — the client
+ * secret produced during app registration lives in the credential store
+ * (`postgresCredentialStore.ts`, migration 0042) under this ref. The status
+ * endpoint returns the ref so channel-teams' `teams_bots[]` sync (follow-up,
+ * out of scope for W1a) can resolve it without the secret ever appearing in
+ * an HTTP response.
+ */
+export function defaultTeamsBotSecretRef(botSlug: string): string {
+  return `teams-bot/${botSlug}/app-password`;
+}
+
+/** Derive a URL- and Azure-safe default bot slug from an agent slug. */
+function deriveBotSlug(agentSlug: string): string {
+  const slug = agentSlug
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+  return slug.length > 0 ? slug : 'agent';
+}
+
 export interface OperatorAgentsRouterOptions {
   /** Late-bound lookups so the router survives orchestrator-plugin
    *  re-activation. Each returns undefined when the orchestratorRegistry
@@ -146,6 +255,11 @@ export interface OperatorAgentsRouterOptions {
    *  mounts, or no DATABASE_URL). Read-only: this router never writes through
    *  the graph store. */
   readonly getAgentGraphStore?: () => AgentGraphStore | undefined;
+  /** W1a (#860) — Teams identity provisioning dependencies (identity store +
+   *  job runner + provisioner availability). Late-bound like the config
+   *  store; the teams-identity routes 503 while it returns undefined (boot
+   *  wiring not registered yet, tests / minimal mounts). */
+  readonly getTeamsIdentity?: () => OperatorTeamsIdentityDeps | undefined;
 }
 
 export function createOperatorAgentsRouter(
@@ -530,6 +644,141 @@ export function createOperatorAgentsRouter(
           granted_by: g.grantedBy,
           granted_at: g.grantedAt,
         })),
+      });
+    } catch (err) {
+      badRequest(res, err);
+    }
+  });
+
+  // ── Teams identity: create-or-provision + status (W1a, #860) ────────
+  // POST is ASYNC by contract: it ensures the identity row (one per agent,
+  // unique agent_id) and hands the chain off to the provisioning job
+  // runner, returning immediately — it never blocks on Graph/ARM. GET
+  // projects the store row, including everything channel-teams'
+  // `teams_bots[]` needs; the bot app password is surfaced as a
+  // credential-store REF, never as secret material. Automatic sync into
+  // the channel-teams plugin config is a documented follow-up, not part
+  // of this wave.
+
+  function teamsIdentity(res: Response): OperatorTeamsIdentityDeps | undefined {
+    const deps = options.getTeamsIdentity?.();
+    if (!deps) {
+      res.status(503).json({
+        error: 'teams_identity_unavailable',
+        message:
+          'Teams identity provisioning is not wired — the identity store and job runner register once DATABASE_URL is set and the agent-factory boot wiring ran.',
+      });
+      return undefined;
+    }
+    return deps;
+  }
+
+  router.post('/:slug/teams-identity', async (req: Request, res: Response) => {
+    const live = svc();
+    if (!live) return unavailable(res);
+    const deps = teamsIdentity(res);
+    if (!deps) return;
+    if (!deps.isProvisionerInstalled()) {
+      // Mirror of unavailable(): the mount-level 503 shape, for the
+      // provisioner capability instead of the orchestrator registry.
+      res.status(503).json({
+        error: 'teams_provisioner_unavailable',
+        message:
+          'teamsProvisioner@1 is not installed — install and activate the M365 connector plugin (>= 0.3.0) before provisioning Teams identities.',
+      });
+      return;
+    }
+    try {
+      const body = TeamsIdentityProvisionSchema.parse(req.body);
+      const slug = slugParam(req, res);
+      if (!slug) return;
+      const existing = await live.store.getAgentBySlug(slug);
+      if (!existing) {
+        res.status(404).json({ error: 'not_found' });
+        return;
+      }
+      const row = await deps.store.ensureForAgent({
+        agentId: existing.id,
+        botSlug: body.bot_slug ?? deriveBotSlug(existing.slug),
+        displayName: body.display_name ?? existing.name,
+      });
+      // Fire-and-forget: the runner resolves the run in the background and
+      // never rejects by contract; the catch is a stub/regression guard so
+      // an enqueue failure can never surface as an unhandled rejection.
+      void Promise.resolve(
+        deps.runner.enqueue({ agentId: existing.id, teamId: body.team_id }),
+      ).catch((err: unknown) => {
+        console.error(
+          `[operator-agents] teams-identity enqueue for '${slug}' failed:`,
+          err,
+        );
+      });
+      res.status(202).json({
+        ok: true,
+        agent: existing.slug,
+        bot_slug: row.botSlug,
+        state: row.state,
+        running: true,
+      });
+    } catch (err) {
+      badRequest(res, err);
+    }
+  });
+
+  router.get('/:slug/teams-identity', async (req: Request, res: Response) => {
+    const live = svc();
+    if (!live) return unavailable(res);
+    const deps = teamsIdentity(res);
+    if (!deps) return;
+    try {
+      const slug = slugParam(req, res);
+      if (!slug) return;
+      const existing = await live.store.getAgentBySlug(slug);
+      if (!existing) {
+        res.status(404).json({ error: 'not_found' });
+        return;
+      }
+      const row = await deps.store.getByAgentId(existing.id);
+      if (!row) {
+        res.status(404).json({ error: 'teams_identity_not_found' });
+        return;
+      }
+      const secretRef =
+        deps.clientSecretRef?.(row) ?? defaultTeamsBotSecretRef(row.botSlug);
+      // `teams_bot` is the channel-teams `teams_bots[]` projection — only
+      // complete once the Entra app exists. SingleTenant matches the
+      // epic's provisioning approach (new MultiTenant registrations are
+      // deprecated); the password stays in the credential store, the
+      // entry carries its ref.
+      const teamsBot =
+        row.appId && row.tenantId
+          ? {
+              slug: row.botSlug,
+              display_name: row.displayName,
+              app_id: row.appId,
+              app_type: 'SingleTenant' as const,
+              tenant_id: row.tenantId,
+              app_password_secret_ref: secretRef,
+            }
+          : null;
+      res.json({
+        ok: true,
+        agent: existing.slug,
+        state: row.state,
+        running: deps.runner.isRunning(existing.id),
+        provisioner_installed: deps.isProvisionerInstalled(),
+        identity: {
+          bot_slug: row.botSlug,
+          display_name: row.displayName,
+          app_id: row.appId,
+          tenant_id: row.tenantId,
+          teams_app_id: row.teamsAppId,
+          teams_app_external_id: row.teamsAppExternalId,
+          last_error: row.lastError,
+          created_at: row.createdAt ?? null,
+          updated_at: row.updatedAt ?? null,
+        },
+        teams_bot: teamsBot,
       });
     } catch (err) {
       badRequest(res, err);

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -138,8 +138,10 @@ const TeamsIdentityProvisionSchema = z.object({
   bot_slug: z
     .string()
     .regex(
-      /^[a-z0-9][a-z0-9-]{0,63}$/,
-      'lowercase letters, digits and dashes; must start alphanumeric',
+      // channel-teams' BOT_SLUG_PATTERN (teamsBotsConfig.ts): 1-63 chars —
+      // a 64-char slug would provision a bot the channel plugin rejects.
+      /^[a-z0-9][a-z0-9-]{0,62}$/,
+      'lowercase letters, digits and dashes; must start alphanumeric; max 63 chars',
     )
     .optional(),
   display_name: z.string().min(1).max(120).optional(),
@@ -179,13 +181,21 @@ export interface OperatorTeamsIdentityStore {
     agentId: string,
   ): Promise<OperatorTeamsIdentityRecord | undefined>;
   /** Create-if-absent. The unique agent_id constraint makes this the
-   *  one-identity-per-agent gate: an existing row is returned as-is
-   *  (bot_slug/display_name of the request are NOT applied to it). */
+   *  one-identity-per-agent gate: an existing row is returned with only the
+   *  install target (`teamId`) refreshed — bot_slug/display_name of the
+   *  request are NOT applied to it. A bot_slug already held by ANOTHER
+   *  agent throws (409 upstream; `error.code === 'bot_slug_taken'`). */
   ensureForAgent(input: {
     readonly agentId: string;
     readonly botSlug: string;
     readonly displayName: string;
+    readonly teamId?: string;
   }): Promise<OperatorTeamsIdentityRecord>;
+  /** Optional: persist an enqueue failure into the row's last_error so the
+   *  status endpoint can distinguish 'queueing failed' from 'just created,
+   *  run in flight'. Best-effort — called from the POST fire-and-forget
+   *  catch. */
+  recordEnqueueFailure?(agentId: string, message: string): Promise<void>;
 }
 
 /** Structural subset of `TeamsProvisioningJobRunner` — enqueue is
@@ -205,33 +215,46 @@ export interface OperatorTeamsIdentityDeps {
   /** Live check whether the M365 connector currently publishes
    *  `teamsProvisioner@1`. POST 503s without it; GET only reports it. */
   readonly isProvisionerInstalled: () => boolean;
-  /** Credential-store ref under which the identity's bot app password
-   *  (the addClientSecret output) is held — surfaced by the status
-   *  endpoint INSTEAD of the secret itself. Defaults to
-   *  {@link defaultTeamsBotSecretRef}. */
+  /** Vault ref under which the bot's app password is held — surfaced by the
+   *  status endpoint INSTEAD of the secret itself. Defaults to
+   *  {@link defaultTeamsBotSecretRef} (the connector's deterministic ref).
+   *  Only consulted once the identity carries an `appId`. */
   readonly clientSecretRef?: (record: OperatorTeamsIdentityRecord) => string;
 }
 
 /**
  * Custody convention for the provisioned bot's app password: the
- * `agent_teams_identities` table stores NO secret material — the client
- * secret produced during app registration lives in the credential store
- * (`postgresCredentialStore.ts`, migration 0042) under this ref. The status
- * endpoint returns the ref so channel-teams' `teams_bots[]` sync (follow-up,
- * out of scope for W1a) can resolve it without the secret ever appearing in
- * an HTTP response.
+ * `agent_teams_identities` table stores NO secret material — the M365
+ * connector's `createAppRegistration` keeps the generated client secret in
+ * the CONNECTOR's vault and hands back only the opaque, deterministic ref
+ * `teams_bot_password:<appId>` (teamsProvisioner contract v0.3.1). The
+ * status endpoint re-derives that ref from `app_id` so channel-teams'
+ * `teams_bots[]` sync (follow-up, out of scope for W1a) can reference it
+ * without the secret ever appearing in an HTTP response or a middleware
+ * table. Keyed by appId (globally unique per registration), NOT by bot
+ * slug, so no two identities can ever alias one credential.
  */
-export function defaultTeamsBotSecretRef(botSlug: string): string {
-  return `teams-bot/${botSlug}/app-password`;
+export function defaultTeamsBotSecretRef(record: {
+  readonly appId: string | null;
+}): string {
+  if (!record.appId) {
+    throw new Error(
+      'defaultTeamsBotSecretRef requires a provisioned appId — the secret ref is derived from it',
+    );
+  }
+  return `teams_bot_password:${record.appId}`;
 }
 
-/** Derive a URL- and Azure-safe default bot slug from an agent slug. */
+/** Derive a URL- and Azure-safe default bot slug from an agent slug.
+ *  Bounds and charset follow channel-teams' BOT_SLUG_PATTERN (max 63); the
+ *  dash-trim runs AFTER the length cut so a truncation can never leave a
+ *  trailing separator. */
 function deriveBotSlug(agentSlug: string): string {
   const slug = agentSlug
     .toLowerCase()
     .replace(/[^a-z0-9-]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 64);
+    .slice(0, 63)
+    .replace(/^-+|-+$/g, '');
   return slug.length > 0 ? slug : 'agent';
 }
 
@@ -678,17 +701,10 @@ export function createOperatorAgentsRouter(
     if (!live) return unavailable(res);
     const deps = teamsIdentity(res);
     if (!deps) return;
-    if (!deps.isProvisionerInstalled()) {
-      // Mirror of unavailable(): the mount-level 503 shape, for the
-      // provisioner capability instead of the orchestrator registry.
-      res.status(503).json({
-        error: 'teams_provisioner_unavailable',
-        message:
-          'teamsProvisioner@1 is not installed — install and activate the M365 connector plugin (>= 0.3.0) before provisioning Teams identities.',
-      });
-      return;
-    }
     try {
+      // Client errors first: a missing agent or malformed body is a 4xx even
+      // while the connector is inactive — the 503 gate below only guards the
+      // actual provisioning kick-off.
       const body = TeamsIdentityProvisionSchema.parse(req.body);
       const slug = slugParam(req, res);
       if (!slug) return;
@@ -697,14 +713,40 @@ export function createOperatorAgentsRouter(
         res.status(404).json({ error: 'not_found' });
         return;
       }
-      const row = await deps.store.ensureForAgent({
-        agentId: existing.id,
-        botSlug: body.bot_slug ?? deriveBotSlug(existing.slug),
-        displayName: body.display_name ?? existing.name,
-      });
+      if (!deps.isProvisionerInstalled()) {
+        // Mirror of unavailable(): the mount-level 503 shape, for the
+        // provisioner capability instead of the orchestrator registry.
+        res.status(503).json({
+          error: 'teams_provisioner_unavailable',
+          message:
+            'teamsProvisioner@1 is not installed — install and activate the M365 connector plugin (>= 0.3.1) before provisioning Teams identities.',
+        });
+        return;
+      }
+      let row: OperatorTeamsIdentityRecord;
+      try {
+        row = await deps.store.ensureForAgent({
+          agentId: existing.id,
+          botSlug: body.bot_slug ?? deriveBotSlug(existing.slug),
+          displayName: body.display_name ?? existing.name,
+          teamId: body.team_id,
+        });
+      } catch (err) {
+        if ((err as { code?: unknown } | null)?.code === 'bot_slug_taken') {
+          res.status(409).json({
+            error: 'bot_slug_taken',
+            message:
+              err instanceof Error ? err.message : 'bot slug already in use',
+          });
+          return;
+        }
+        throw err;
+      }
       // Fire-and-forget: the runner resolves the run in the background and
-      // never rejects by contract; the catch is a stub/regression guard so
-      // an enqueue failure can never surface as an unhandled rejection.
+      // never rejects by contract; the catch is a stub/regression guard —
+      // and it persists the failure into last_error (best-effort) so the
+      // status endpoint can show WHY nothing is running instead of looking
+      // like a healthy just-enqueued row.
       void Promise.resolve(
         deps.runner.enqueue({ agentId: existing.id, teamId: body.team_id }),
       ).catch((err: unknown) => {
@@ -712,13 +754,21 @@ export function createOperatorAgentsRouter(
           `[operator-agents] teams-identity enqueue for '${slug}' failed:`,
           err,
         );
+        void deps.store
+          .recordEnqueueFailure?.(
+            existing.id,
+            err instanceof Error ? err.message : String(err),
+          )
+          .catch(() => undefined);
       });
       res.status(202).json({
         ok: true,
         agent: existing.slug,
         bot_slug: row.botSlug,
         state: row.state,
-        running: true,
+        // Honest signal: true only when the runner actually holds a run for
+        // this agent (a rejected enqueue leaves it false).
+        running: deps.runner.isRunning(existing.id),
       });
     } catch (err) {
       badRequest(res, err);
@@ -743,22 +793,24 @@ export function createOperatorAgentsRouter(
         res.status(404).json({ error: 'teams_identity_not_found' });
         return;
       }
-      const secretRef =
-        deps.clientSecretRef?.(row) ?? defaultTeamsBotSecretRef(row.botSlug);
       // `teams_bot` is the channel-teams `teams_bots[]` projection — only
-      // complete once the Entra app exists. SingleTenant matches the
-      // epic's provisioning approach (new MultiTenant registrations are
-      // deprecated); the password stays in the credential store, the
-      // entry carries its ref.
+      // complete once the Entra app exists, and shaped EXACTLY like a
+      // `parseTeamsBotsConfig` entry (camelCase botSlug/appId/tenantId/
+      // appPasswordSecretRef), so an operator can paste it into the
+      // channel-teams config verbatim. SingleTenant matches the epic's
+      // provisioning approach (new MultiTenant registrations are
+      // deprecated); the password stays in the connector's vault, the
+      // entry carries its opaque ref.
       const teamsBot =
         row.appId && row.tenantId
           ? {
-              slug: row.botSlug,
-              display_name: row.displayName,
-              app_id: row.appId,
-              app_type: 'SingleTenant' as const,
-              tenant_id: row.tenantId,
-              app_password_secret_ref: secretRef,
+              botSlug: row.botSlug,
+              displayName: row.displayName,
+              appId: row.appId,
+              appType: 'SingleTenant' as const,
+              tenantId: row.tenantId,
+              appPasswordSecretRef:
+                deps.clientSecretRef?.(row) ?? defaultTeamsBotSecretRef(row),
             }
           : null;
       res.json({

--- a/middleware/src/services/teamsAppPackageAssets.ts
+++ b/middleware/src/services/teamsAppPackageAssets.ts
@@ -1,0 +1,210 @@
+/**
+ * Teams app-package asset loader (epic byte5ai/omadia#860, wave W1a wiring).
+ *
+ * The provisioning job runner's `loadPackageAssets` seam: gathers the three
+ * inputs the connector's PURE `buildAppPackage` needs to render one Teams
+ * app package per agent identity —
+ *
+ *   1. the manifest TEMPLATE + icon PNGs, read from the installed
+ *      `@omadia/channel-teams` package (`appPackage/manifest.json.template`,
+ *      `color.png`, `outline.png` — the canonical, versioned template of
+ *      wave W0a; deliberately NOT vendored into the middleware),
+ *   2. one param per `{{PLACEHOLDER}}` occurring in that template (the
+ *      connector refuses a render with missing or unused placeholders, so
+ *      the fill is driven by scanning the template, not by a fixed list),
+ *   3. the stable `externalId` (the Teams app id / catalog idempotency key):
+ *      a deterministic name-based UUID derived from the agent id, so every
+ *      re-run of the chain targets the same catalog entry.
+ *
+ * NO network, NO Graph/ARM — pure filesystem reads; rendering and uploading
+ * happen behind the `teamsProvisioner@1` accessor.
+ *
+ * Fails LOUDLY with actionable messages: a missing channel-teams package or
+ * an unknown placeholder surfaces in the identity row's `last_error` via the
+ * runner instead of producing a package Teams would reject.
+ */
+
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import * as path from 'node:path';
+
+import type {
+  TeamsAppPackageAssetLoader,
+  TeamsAppPackageParams,
+  TeamsIdentityJobRecord,
+} from './teamsProvisioningJob.js';
+
+/** The plugin whose package ships the canonical app-package template. */
+export const CHANNEL_TEAMS_PLUGIN_ID = '@omadia/channel-teams';
+
+/** Placeholder syntax of the channel-teams template (`{{UPPER_SNAKE}}`). */
+const PLACEHOLDER_RE = /\{\{([A-Z][A-Z0-9_]*)\}\}/g;
+
+export class TeamsAppPackageAssetsError extends Error {
+  public readonly code = 'teams_app_package_assets_unavailable';
+
+  constructor(problem: string) {
+    super(`teams_app_package_assets_unavailable: ${problem}`);
+    this.name = 'TeamsAppPackageAssetsError';
+  }
+}
+
+/**
+ * Deterministic Teams app id (`externalId`, manifest `id`) for one agent:
+ * RFC-4122 name-based (v5-style, SHA-1) UUID in a fixed W1a namespace. Same
+ * agent → same GUID on every run, which is exactly what makes the catalog
+ * upload idempotent; distinct from the bot's Entra `appId` by construction
+ * (the manifest's `id` and `bots[0].botId` are different GUIDs).
+ */
+export function stableTeamsAppExternalId(agentId: string): string {
+  // Fixed namespace for omadia agent-factory Teams app ids (random constant,
+  // never reused elsewhere).
+  const namespace = 'de3c2a76-6f1b-4b6a-9d3e-860a1a7c5b21';
+  const ns = Buffer.from(namespace.replace(/-/g, ''), 'hex');
+  const hash = createHash('sha1')
+    .update(ns)
+    .update(Buffer.from(`omadia-teams-app:${agentId}`, 'utf8'))
+    .digest();
+  const bytes = Buffer.from(hash.subarray(0, 16));
+  bytes[6] = ((bytes[6] as number) & 0x0f) | 0x50; // version 5
+  bytes[8] = ((bytes[8] as number) & 0x3f) | 0x80; // RFC-4122 variant
+  const hex = bytes.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+export interface TeamsAppPackageAssetOptions {
+  /** Package root of the installed channel-teams plugin (the directory
+   *  holding `manifest.yaml` and `appPackage/`), or undefined while the
+   *  plugin is not installed. Resolved per call — an install after boot is
+   *  picked up without a restart. */
+  readonly getChannelTeamsPackageRoot: () => string | undefined;
+  /** The deployment's public base URL (TEAMS_PUBLIC_BASE_URL ??
+   *  PUBLIC_BASE_URL) — host for validDomains / webApplicationInfo and base
+   *  of the plugin's tab pages. */
+  readonly getPublicBaseUrl: () => string | undefined;
+  /** Manifest `version` (per-package semver). Default `1.0.0`. */
+  readonly version?: string;
+  /** Overrides for developer-facing manifest fields. */
+  readonly developer?: {
+    readonly name?: string;
+    readonly websiteUrl?: string;
+    readonly privacyUrl?: string;
+    readonly termsUrl?: string;
+  };
+}
+
+function truncate(value: string, max: number): string {
+  return value.length <= max ? value : value.slice(0, max);
+}
+
+/** Build the param map for exactly the placeholders the template uses. */
+function paramsForTemplate(
+  template: string,
+  identity: TeamsIdentityJobRecord,
+  externalId: string,
+  baseUrl: URL,
+  opts: TeamsAppPackageAssetOptions,
+): TeamsAppPackageParams {
+  const displayName = identity.displayName;
+  const origin = baseUrl.origin;
+  const known: Record<string, string | readonly string[]> = {
+    VERSION: opts.version ?? '1.0.0',
+    // Teams app id (manifest `id`) — NOT the bot's Entra app id.
+    APP_ID: externalId,
+    BOT_ID: identity.appId ?? '',
+    NAME_SHORT: truncate(displayName, 30),
+    NAME_FULL: truncate(displayName, 100),
+    DESCRIPTION: truncate(`${displayName} — Omadia agent for Microsoft Teams`, 80),
+    DESCRIPTION_FULL: truncate(
+      `${displayName} is an Omadia agent provisioned for this tenant. It answers in team channels, group chats and personal scope through the Omadia middleware.`,
+      4000,
+    ),
+    ACCENT_COLOR: '#714B67',
+    DEVELOPER_NAME: opts.developer?.name ?? 'byte5',
+    DEVELOPER_WEBSITE_URL: opts.developer?.websiteUrl ?? 'https://omadia.ai',
+    DEVELOPER_PRIVACY_URL: opts.developer?.privacyUrl ?? 'https://omadia.ai/privacy',
+    DEVELOPER_TERMS_URL: opts.developer?.termsUrl ?? 'https://omadia.ai/terms',
+    // Raw-JSON slots (serialized arrays, per the template README).
+    COMMAND_LISTS: [] as readonly string[],
+    VALID_DOMAINS: [baseUrl.host] as readonly string[],
+    MIDDLEWARE_HOST: baseUrl.host,
+    // The channel-teams web-ui surfaces (uiRouter) under the deployment
+    // origin — README's documented deployment default.
+    TAB_BASE_URL: `${origin}/p/channel-teams`,
+  };
+  const params: Record<string, string | readonly string[]> = {};
+  const unknown: string[] = [];
+  for (const match of template.matchAll(PLACEHOLDER_RE)) {
+    const name = match[1] as string;
+    if (name in known) {
+      params[name] = known[name] as string | readonly string[];
+    } else if (!unknown.includes(name)) {
+      unknown.push(name);
+    }
+  }
+  if (unknown.length > 0) {
+    throw new TeamsAppPackageAssetsError(
+      `the channel-teams app-package template uses placeholder(s) [${unknown.join(', ')}] this middleware does not know how to fill — update teamsAppPackageAssets.ts alongside the template`,
+    );
+  }
+  return params;
+}
+
+/**
+ * The `loadPackageAssets` implementation the boot wiring hands the job
+ * runner. Reads template + icons fresh on every call (provisioning is rare;
+ * a template shipped by a plugin update is picked up immediately).
+ */
+export function createTeamsAppPackageAssetLoader(
+  opts: TeamsAppPackageAssetOptions,
+): TeamsAppPackageAssetLoader {
+  return async (identity: TeamsIdentityJobRecord) => {
+    const root = opts.getChannelTeamsPackageRoot();
+    if (!root) {
+      throw new TeamsAppPackageAssetsError(
+        `the ${CHANNEL_TEAMS_PLUGIN_ID} plugin (>= 0.20.0, with appPackage/ template) is not installed — its app-package template is required to build the agent's Teams app`,
+      );
+    }
+    const rawBase = opts.getPublicBaseUrl();
+    if (!rawBase) {
+      throw new TeamsAppPackageAssetsError(
+        'no public base URL configured — set TEAMS_PUBLIC_BASE_URL or PUBLIC_BASE_URL so validDomains/webApplicationInfo can name the middleware host',
+      );
+    }
+    let baseUrl: URL;
+    try {
+      baseUrl = new URL(rawBase);
+    } catch {
+      throw new TeamsAppPackageAssetsError(
+        `public base URL ${JSON.stringify(rawBase)} is not a valid URL`,
+      );
+    }
+    if (!identity.appId) {
+      throw new TeamsAppPackageAssetsError(
+        `agent '${identity.agentId}' has no Entra appId yet — the app registration step must complete before the package is built`,
+      );
+    }
+    const dir = path.join(root, 'appPackage');
+    let manifestTemplate: string;
+    let color: Uint8Array;
+    let outline: Uint8Array;
+    try {
+      [manifestTemplate, color, outline] = await Promise.all([
+        readFile(path.join(dir, 'manifest.json.template'), 'utf8'),
+        readFile(path.join(dir, 'color.png')),
+        readFile(path.join(dir, 'outline.png')),
+      ]);
+    } catch (err) {
+      throw new TeamsAppPackageAssetsError(
+        `cannot read app-package assets from ${dir} — the installed ${CHANNEL_TEAMS_PLUGIN_ID} package must ship appPackage/{manifest.json.template,color.png,outline.png} (${err instanceof Error ? err.message : String(err)})`,
+      );
+    }
+    const externalId = stableTeamsAppExternalId(identity.agentId);
+    return {
+      manifestTemplate,
+      params: paramsForTemplate(manifestTemplate, identity, externalId, baseUrl, opts),
+      icons: { color, outline },
+      externalId,
+    };
+  };
+}

--- a/middleware/src/services/teamsProvisioningJob.ts
+++ b/middleware/src/services/teamsProvisioningJob.ts
@@ -52,6 +52,10 @@
  * this wave. The real implementations satisfy these ports as-is.
  */
 
+import {
+  TEAMS_PROVISIONING_STATES,
+  type TeamsProvisioningState,
+} from '../platform/agentTeamsIdentityStore.js';
 import type { TimerSeam } from '../plugins/jobScheduler.js';
 import type {
   BackgroundJob,
@@ -59,21 +63,13 @@ import type {
 } from '../platform/backgroundJobRegistry.js';
 
 // ---------------------------------------------------------------------------
-// State vocabulary — mirrors the CHECK constraint of agent_teams_identities
-// (migration 0049) exactly; the store unit exports the same union.
+// State vocabulary — the CHECK constraint of agent_teams_identities
+// (migration 0049): imported from the store module, which owns the single
+// exported union (wave reconciliation of the parallel-unit mirror), and
+// re-exported here for the runner's existing consumers.
 // ---------------------------------------------------------------------------
 
-export const TEAMS_PROVISIONING_STATES = [
-  'pending',
-  'app_registered',
-  'bot_created',
-  'package_built',
-  'catalog_uploaded',
-  'installed',
-  'failed',
-] as const;
-
-export type TeamsProvisioningState = (typeof TEAMS_PROVISIONING_STATES)[number];
+export { TEAMS_PROVISIONING_STATES, type TeamsProvisioningState };
 
 /** Progress rank; 'failed' ranks below everything so a resume re-checks each
  *  step (evidence columns + idempotent calls make that safe). */
@@ -291,6 +287,15 @@ export type ProvisioningRunResult =
       readonly agentId: string;
       readonly detail: string;
     }
+  | {
+      /** A run for the SAME agent but a DIFFERENT team is in flight — this
+       *  request was refused outright (nothing enqueued, nothing joined), so
+       *  a caller can never be handed the other team's success. */
+      readonly status: 'rejected';
+      readonly agentId: string;
+      readonly reason: 'team_conflict';
+      readonly detail: string;
+    }
   | { readonly status: 'stopped'; readonly agentId: string };
 
 export interface TeamsProvisioningJobOptions {
@@ -317,6 +322,9 @@ export interface TeamsProvisioningJobOptions {
 const DEFAULT_MAX_ATTEMPTS = 5;
 const DEFAULT_BASE_RETRY_DELAY_MS = 5_000;
 const DEFAULT_MAX_RETRY_DELAY_MS = 300_000;
+/** Node's setTimeout ceiling (2^31 − 1 ms) — a longer delay would overflow
+ *  to ~1 ms and burn the whole retry budget instantly. */
+const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
 
 const REAL_TIMERS: TimerSeam = {
   setTimeout: (cb, ms) => globalThis.setTimeout(cb, ms),
@@ -337,7 +345,10 @@ export class TeamsProvisioningJobRunner {
   private readonly timers: TimerSeam;
   private readonly log: (msg: string) => void;
 
-  private readonly inFlight = new Map<string, Promise<ProvisioningRunResult>>();
+  private readonly inFlight = new Map<
+    string,
+    { readonly teamId: string; readonly run: Promise<ProvisioningRunResult> }
+  >();
   private readonly pendingSleeps = new Set<() => void>();
   private stopped = false;
 
@@ -349,7 +360,10 @@ export class TeamsProvisioningJobRunner {
     this.tenantMode = opts.tenantMode ?? 'customer';
     this.maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
     this.baseRetryDelayMs = opts.baseRetryDelayMs ?? DEFAULT_BASE_RETRY_DELAY_MS;
-    this.maxRetryDelayMs = opts.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
+    this.maxRetryDelayMs = Math.min(
+      opts.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS,
+      MAX_TIMER_DELAY_MS,
+    );
     this.timers = opts.timers ?? REAL_TIMERS;
     this.log = opts.log ?? ((m) => console.log(m));
   }
@@ -357,11 +371,21 @@ export class TeamsProvisioningJobRunner {
   /**
    * Fire-and-forget entry point for the operator endpoint: starts (or joins)
    * the run for this agent and returns immediately. One run per agent at a
-   * time — a concurrent enqueue joins the in-flight run instead of racing it.
+   * time — a concurrent enqueue for the SAME team joins the in-flight run; a
+   * concurrent enqueue for a DIFFERENT team is refused with a 'rejected'
+   * result (never silently handed the other team's outcome).
    */
   enqueue(request: ProvisionTeamsIdentityRequest): Promise<ProvisioningRunResult> {
     const existing = this.inFlight.get(request.agentId);
-    if (existing) return existing;
+    if (existing) {
+      if (existing.teamId === request.teamId) return existing.run;
+      return Promise.resolve({
+        status: 'rejected',
+        agentId: request.agentId,
+        reason: 'team_conflict',
+        detail: `a provisioning run targeting team '${existing.teamId}' is already in flight for this agent — wait for it to finish, then re-run for team '${request.teamId}'`,
+      });
+    }
     const run = this.runWithRetries(request)
       .catch((err): ProvisioningRunResult => {
         // Defensive: runWithRetries handles its own failures; a throw here is
@@ -379,7 +403,7 @@ export class TeamsProvisioningJobRunner {
       .finally(() => {
         this.inFlight.delete(request.agentId);
       });
-    this.inFlight.set(request.agentId, run);
+    this.inFlight.set(request.agentId, { teamId: request.teamId, run });
     return run;
   }
 
@@ -387,21 +411,29 @@ export class TeamsProvisioningJobRunner {
     return this.inFlight.has(agentId);
   }
 
-  /** Stop accepting work and release every pending retry delay. In-flight
-   *  accessor calls finish on their own; their runs end at the next
-   *  stop-check without touching the store. Idempotent. */
+  /** Stop accepting work and release every pending retry delay. An
+   *  in-flight accessor call finishes on its own; its run then ends at the
+   *  next stop-check between chain steps (that step's own store write has
+   *  already landed; no further step starts). Idempotent; a later
+   *  {@link asBackgroundJob} start() re-arms the runner. */
   stop(): void {
     this.stopped = true;
     for (const release of [...this.pendingSleeps]) release();
     this.pendingSleeps.clear();
   }
 
-  /** Adapter for the BackgroundJobRegistry lifecycle precedent. */
+  /** Adapter for the BackgroundJobRegistry lifecycle precedent. start()
+   *  clears a previous stop() so a stopAll → start cycle (registry restart)
+   *  yields a working runner again instead of one that answers every
+   *  enqueue with 'stopped'. */
   asBackgroundJob(): BackgroundJob {
     const handle: BackgroundJobHandle = { stop: () => this.stop() };
     return {
       name: 'teams-identity-provisioning',
-      start: () => handle,
+      start: () => {
+        this.stopped = false;
+        return handle;
+      },
     };
   }
 
@@ -475,9 +507,12 @@ export class TeamsProvisioningJobRunner {
       return { status: 'failed', agentId, reason: 'error', detail };
     }
 
+    // The hint wins over the exponential backoff but never over the cap:
+    // maxRetryDelayMs bounds EVERY delay (a hint of hours would otherwise
+    // park the attempt loop — and overflow Node's 32-bit setTimeout).
     const delayMs =
       throttle?.retryAfterSeconds !== undefined
-        ? throttle.retryAfterSeconds * 1_000
+        ? Math.min(throttle.retryAfterSeconds * 1_000, this.maxRetryDelayMs)
         : this.backoffDelayMs(attempt);
     this.log(
       `[teams-provisioning] ${agentId} attempt ${attempt}/${this.maxAttempts} failed (${errorMessage(err)}); retrying in ${delayMs}ms`,
@@ -543,6 +578,7 @@ export class TeamsProvisioningJobRunner {
       );
     }
     if (row.state === 'installed') return { status: 'installed', agentId };
+    if (this.stopped) return { status: 'stopped', agentId };
 
     const provisioner = this.getProvisioner();
 
@@ -566,6 +602,8 @@ export class TeamsProvisioningJobRunner {
         lastError: null,
       });
     }
+
+    if (this.stopped) return { status: 'stopped', agentId };
 
     // Step 2 — Azure bot (idempotent by bot handle). The endpoint is built by
     // the accessor module's URL builder, injected — never composed here.
@@ -592,6 +630,8 @@ export class TeamsProvisioningJobRunner {
       }
       row = await this.store.update(agentId, { state: 'bot_created', lastError: null });
     }
+
+    if (this.stopped) return { status: 'stopped', agentId };
 
     // Steps 3+4 — app package + catalog upload (idempotent by externalId).
     if (STATE_RANK[row.state] < STATE_RANK.catalog_uploaded || !row.teamsAppId) {
@@ -629,6 +669,8 @@ export class TeamsProvisioningJobRunner {
         lastError: null,
       });
     }
+
+    if (this.stopped) return { status: 'stopped', agentId };
 
     // Step 5 — install into the team (idempotent on Graph's side).
     await provisioner.installToTeam({

--- a/middleware/src/services/teamsProvisioningJob.ts
+++ b/middleware/src/services/teamsProvisioningJob.ts
@@ -548,6 +548,7 @@ export class TeamsProvisioningJobRunner {
       }
       // `handle` is assigned after setTimeout returns; a synchronous test
       // seam may fire `release` before that, hence the guards.
+      // eslint-disable-next-line prefer-const
       let handle: unknown;
       let done = false;
       const release = (): void => {

--- a/middleware/src/services/teamsProvisioningJob.ts
+++ b/middleware/src/services/teamsProvisioningJob.ts
@@ -1,0 +1,647 @@
+/**
+ * Teams identity provisioning job runner — epic byte5ai/omadia#860, wave W1a.
+ *
+ * Drives one agent's Teams identity through the provisioning chain
+ *
+ *   pending → app_registered → bot_created → package_built
+ *           → catalog_uploaded → installed            (terminal: failed)
+ *
+ * as an ASYNC, IN-PROCESS job: the operator endpoint enqueues and returns
+ * immediately; status is queryable through the identity store row. Follows
+ * the middleware's existing background-job precedents instead of inventing a
+ * scheduler: {@link TimerSeam} (from `plugins/jobScheduler.ts`) makes every
+ * retry/backoff delay injectable in tests, and {@link asBackgroundJob}
+ * adapts the runner to the `BackgroundJobRegistry` lifecycle.
+ *
+ * Idempotent resume: a run re-enters at the stored state and leans on the
+ * provisioner's 'already-existed' signals — completed steps are skipped via
+ * the persisted columns (app_id/tenant_id/teams_app_id), and re-executed
+ * steps are safe because every remote call is idempotent by a stable key
+ * (Graph `uniqueName`, ARM bot handle, catalog `externalId`, team install).
+ * A row left in 'failed' resumes the same way: evidence columns decide the
+ * entry point, so nothing is re-created.
+ *
+ * Error policy (duck-typed guards — connector errors cross the plugin
+ * boundary as plain `Error`s whose class identity is the plugin's, so
+ * `instanceof` against local mirrors would never match):
+ *   - ConsentMissingError   → TERMINAL: state 'failed', the missing scopes
+ *                             recorded in last_error. Retrying cannot help
+ *                             until an admin consents.
+ *   - ArmNotConfiguredError / the accessor's typed 'registration-only'
+ *     outcome → NOT terminal: state stays 'app_registered' with an
+ *     actionable last_error naming the missing ARM setup fields.
+ *   - ProvisioningThrottledError → retried within {@link maxAttempts},
+ *     honoring the error's `retryAfterSeconds` hint over the default
+ *     exponential backoff. Exhaustion keeps the reached state (progress is
+ *     real) and records the throttle in last_error for a later re-run.
+ *   - Provisioner unavailable (connector plugin not installed/active) →
+ *     retried like a throttle without a hint; never a crash, never 'failed'.
+ *   - Anything else → bounded retries, then state 'failed' with last_error.
+ *
+ * Hard constraint honored: NO Graph/ARM call happens here — every outbound
+ * step goes through the injected `teamsProvisioner@1` accessor port, and the
+ * bot messaging endpoint (`https://<public-base-url>/api/teams/<botSlug>/messages`,
+ * per-bot route since channel-teams 0.20.0) is composed by the accessor
+ * module's URL builder, injected as {@link buildMessagingEndpoint} — never
+ * duplicated here.
+ *
+ * WIRING NOTE (reconciled by the wave's wiring unit): the store port and the
+ * provisioner port below are STRUCTURAL subsets of, respectively, the
+ * `agentTeamsIdentityStore` module and the `TeamsProvisionerAccessor` of
+ * `platform/teamsProvisionerService.ts` — both built in parallel units of
+ * this wave. The real implementations satisfy these ports as-is.
+ */
+
+import type { TimerSeam } from '../plugins/jobScheduler.js';
+import type {
+  BackgroundJob,
+  BackgroundJobHandle,
+} from '../platform/backgroundJobRegistry.js';
+
+// ---------------------------------------------------------------------------
+// State vocabulary — mirrors the CHECK constraint of agent_teams_identities
+// (migration 0049) exactly; the store unit exports the same union.
+// ---------------------------------------------------------------------------
+
+export const TEAMS_PROVISIONING_STATES = [
+  'pending',
+  'app_registered',
+  'bot_created',
+  'package_built',
+  'catalog_uploaded',
+  'installed',
+  'failed',
+] as const;
+
+export type TeamsProvisioningState = (typeof TEAMS_PROVISIONING_STATES)[number];
+
+/** Progress rank; 'failed' ranks below everything so a resume re-checks each
+ *  step (evidence columns + idempotent calls make that safe). */
+const STATE_RANK: Readonly<Record<TeamsProvisioningState, number>> = {
+  failed: -1,
+  pending: 0,
+  app_registered: 1,
+  bot_created: 2,
+  package_built: 3,
+  catalog_uploaded: 4,
+  installed: 5,
+};
+
+// ---------------------------------------------------------------------------
+// Store port (structural subset of agentTeamsIdentityStore)
+// ---------------------------------------------------------------------------
+
+export interface TeamsIdentityJobRecord {
+  readonly agentId: string;
+  readonly botSlug: string;
+  readonly displayName: string;
+  readonly state: TeamsProvisioningState;
+  readonly appId: string | null;
+  readonly tenantId: string | null;
+  readonly teamsAppId: string | null;
+  readonly teamsAppExternalId: string | null;
+  readonly lastError: string | null;
+}
+
+export interface TeamsIdentityJobUpdate {
+  readonly state?: TeamsProvisioningState;
+  readonly appId?: string;
+  readonly tenantId?: string;
+  readonly teamsAppId?: string;
+  readonly teamsAppExternalId?: string;
+  /** `null` clears a previous error. */
+  readonly lastError?: string | null;
+}
+
+/** The runner writes state/last_error EXCLUSIVELY through this port. */
+export interface TeamsIdentityJobStore {
+  getByAgentId(agentId: string): Promise<TeamsIdentityJobRecord | undefined>;
+  update(
+    agentId: string,
+    patch: TeamsIdentityJobUpdate,
+  ): Promise<TeamsIdentityJobRecord>;
+}
+
+// ---------------------------------------------------------------------------
+// Provisioner port (structural subset of TeamsProvisionerAccessor)
+// ---------------------------------------------------------------------------
+
+export type IdempotentOutcome = 'created' | 'already-existed';
+
+export interface Idempotent<T> {
+  readonly outcome: IdempotentOutcome;
+  readonly value: T;
+}
+
+export type TenantMode = 'customer' | 'home';
+
+export interface ProvisionerAppRegistrationResult {
+  readonly appId: string;
+  readonly registration: { readonly tenantId: string };
+}
+
+export interface ProvisionerRegistrationOnlyOutcome {
+  readonly kind: 'registration-only';
+  readonly reason: 'arm-not-configured';
+  readonly missingSetupFields: readonly string[];
+}
+
+export interface ProvisionerBotOutcome {
+  readonly kind: 'provisioned';
+  readonly bot: Idempotent<{ readonly botName: string }>;
+}
+
+export interface TeamsAppPackageIcons {
+  readonly color: Uint8Array;
+  readonly outline: Uint8Array;
+}
+
+export type TeamsAppPackageParams = Readonly<
+  Record<string, string | readonly string[]>
+>;
+
+/** The accessor methods the runner drives — one per chain step. */
+export interface TeamsProvisionerPort {
+  createAppRegistration(input: {
+    readonly displayName: string;
+    readonly tenantMode: TenantMode;
+    readonly uniqueName?: string;
+    readonly secretDisplayName?: string;
+  }): Promise<Idempotent<ProvisionerAppRegistrationResult>>;
+
+  createBot(input: {
+    readonly botName: string;
+    readonly displayName: string;
+    readonly msaAppId: string;
+    readonly msaAppTenantId: string;
+    readonly messagingEndpoint: string;
+  }): Promise<ProvisionerBotOutcome | ProvisionerRegistrationOnlyOutcome>;
+
+  /** Pure, no network — renders the per-agent Teams app package zip. */
+  buildAppPackage(input: {
+    readonly manifestTemplate: string;
+    readonly params: TeamsAppPackageParams;
+    readonly icons: TeamsAppPackageIcons;
+  }): Uint8Array;
+
+  uploadToCatalog(input: {
+    readonly packageZip: Uint8Array;
+    readonly externalId: string;
+  }): Promise<Idempotent<{ readonly teamsAppId: string }>>;
+
+  getCatalogApp(input: {
+    readonly teamsAppExternalId: string;
+  }): Promise<{ readonly found: false } | { readonly found: true; readonly teamsAppId: string }>;
+
+  installToTeam(input: {
+    readonly teamId: string;
+    readonly teamsAppId: string;
+  }): Promise<Idempotent<{ readonly teamId: string; readonly teamsAppId: string }>>;
+}
+
+/** App-package inputs for one identity; loading is bound by the wiring unit
+ *  (manifest template + icons ship with the channel-teams package). */
+export interface TeamsAppPackageAssets {
+  readonly manifestTemplate: string;
+  readonly params: TeamsAppPackageParams;
+  readonly icons: TeamsAppPackageIcons;
+  /** Manifest id (`externalId`) — the catalog idempotency key. */
+  readonly externalId: string;
+}
+
+export type TeamsAppPackageAssetLoader = (
+  identity: TeamsIdentityJobRecord,
+) => Promise<TeamsAppPackageAssets>;
+
+// ---------------------------------------------------------------------------
+// Duck-typed connector error guards (see module doc on why not instanceof)
+// ---------------------------------------------------------------------------
+
+function isStringArray(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === 'string');
+}
+
+function missingScopesOf(err: unknown): readonly string[] | undefined {
+  if (!(err instanceof Error) || err.name !== 'ConsentMissingError') return undefined;
+  const scopes = (err as Error & { missingScopes?: unknown }).missingScopes;
+  return isStringArray(scopes) ? scopes : [];
+}
+
+function throttleHintOf(err: unknown): { retryAfterSeconds?: number } | undefined {
+  if (!(err instanceof Error) || err.name !== 'ProvisioningThrottledError') {
+    return undefined;
+  }
+  const hint = (err as Error & { retryAfterSeconds?: unknown }).retryAfterSeconds;
+  return typeof hint === 'number' && Number.isFinite(hint) && hint >= 0
+    ? { retryAfterSeconds: hint }
+    : {};
+}
+
+function missingSetupFieldsOf(err: unknown): readonly string[] | undefined {
+  if (!(err instanceof Error) || err.name !== 'ArmNotConfiguredError') return undefined;
+  const fields = (err as Error & { missingSetupFields?: unknown }).missingSetupFields;
+  return isStringArray(fields) ? fields : [];
+}
+
+function isProvisionerUnavailable(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err.name === 'TeamsProvisionerUnavailableError' ||
+      (err as Error & { code?: unknown }).code === 'teams_provisioner_unavailable')
+  );
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+export class TeamsProvisioningJobError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TeamsProvisioningJobError';
+  }
+}
+
+export interface ProvisionTeamsIdentityRequest {
+  readonly agentId: string;
+  /** Team (group) id the generated app is installed into. */
+  readonly teamId: string;
+}
+
+export type ProvisioningRunResult =
+  | { readonly status: 'installed'; readonly agentId: string }
+  | {
+      readonly status: 'halted';
+      readonly agentId: string;
+      readonly reason: 'arm_not_configured';
+      readonly missingSetupFields: readonly string[];
+    }
+  | {
+      readonly status: 'failed';
+      readonly agentId: string;
+      readonly reason: 'consent_missing' | 'error';
+      readonly detail: string;
+    }
+  | {
+      readonly status: 'retries_exhausted';
+      readonly agentId: string;
+      readonly detail: string;
+    }
+  | { readonly status: 'stopped'; readonly agentId: string };
+
+export interface TeamsProvisioningJobOptions {
+  readonly store: TeamsIdentityJobStore;
+  /** Resolves the accessor; throws its typed 'unavailable' error when the
+   *  connector plugin is not installed/active. */
+  readonly getProvisioner: () => TeamsProvisionerPort;
+  /** The accessor module's URL builder, bound to the public base URL by the
+   *  wiring unit. NEVER reimplemented here. */
+  readonly buildMessagingEndpoint: (botSlug: string) => string;
+  readonly loadPackageAssets: TeamsAppPackageAssetLoader;
+  readonly tenantMode?: TenantMode;
+  /** Chain attempts per run, including the first (default 5). */
+  readonly maxAttempts?: number;
+  /** First retry delay for hint-less retryable failures (default 5s). */
+  readonly baseRetryDelayMs?: number;
+  /** Backoff cap (default 5 min). */
+  readonly maxRetryDelayMs?: number;
+  /** Test seam — defaults to real timers. */
+  readonly timers?: TimerSeam;
+  readonly log?: (msg: string) => void;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_BASE_RETRY_DELAY_MS = 5_000;
+const DEFAULT_MAX_RETRY_DELAY_MS = 300_000;
+
+const REAL_TIMERS: TimerSeam = {
+  setTimeout: (cb, ms) => globalThis.setTimeout(cb, ms),
+  clearTimeout: (h) => globalThis.clearTimeout(h as ReturnType<typeof setTimeout>),
+  setInterval: (cb, ms) => globalThis.setInterval(cb, ms),
+  clearInterval: (h) => globalThis.clearInterval(h as ReturnType<typeof setInterval>),
+};
+
+export class TeamsProvisioningJobRunner {
+  private readonly store: TeamsIdentityJobStore;
+  private readonly getProvisioner: () => TeamsProvisionerPort;
+  private readonly buildMessagingEndpoint: (botSlug: string) => string;
+  private readonly loadPackageAssets: TeamsAppPackageAssetLoader;
+  private readonly tenantMode: TenantMode;
+  private readonly maxAttempts: number;
+  private readonly baseRetryDelayMs: number;
+  private readonly maxRetryDelayMs: number;
+  private readonly timers: TimerSeam;
+  private readonly log: (msg: string) => void;
+
+  private readonly inFlight = new Map<string, Promise<ProvisioningRunResult>>();
+  private readonly pendingSleeps = new Set<() => void>();
+  private stopped = false;
+
+  constructor(opts: TeamsProvisioningJobOptions) {
+    this.store = opts.store;
+    this.getProvisioner = opts.getProvisioner;
+    this.buildMessagingEndpoint = opts.buildMessagingEndpoint;
+    this.loadPackageAssets = opts.loadPackageAssets;
+    this.tenantMode = opts.tenantMode ?? 'customer';
+    this.maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+    this.baseRetryDelayMs = opts.baseRetryDelayMs ?? DEFAULT_BASE_RETRY_DELAY_MS;
+    this.maxRetryDelayMs = opts.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
+    this.timers = opts.timers ?? REAL_TIMERS;
+    this.log = opts.log ?? ((m) => console.log(m));
+  }
+
+  /**
+   * Fire-and-forget entry point for the operator endpoint: starts (or joins)
+   * the run for this agent and returns immediately. One run per agent at a
+   * time — a concurrent enqueue joins the in-flight run instead of racing it.
+   */
+  enqueue(request: ProvisionTeamsIdentityRequest): Promise<ProvisioningRunResult> {
+    const existing = this.inFlight.get(request.agentId);
+    if (existing) return existing;
+    const run = this.runWithRetries(request)
+      .catch((err): ProvisioningRunResult => {
+        // Defensive: runWithRetries handles its own failures; a throw here is
+        // a runner bug. Log, never crash the process from a background job.
+        this.log(
+          `[teams-provisioning] run for ${request.agentId} threw unexpectedly: ${errorMessage(err)}`,
+        );
+        return {
+          status: 'failed',
+          agentId: request.agentId,
+          reason: 'error',
+          detail: errorMessage(err),
+        };
+      })
+      .finally(() => {
+        this.inFlight.delete(request.agentId);
+      });
+    this.inFlight.set(request.agentId, run);
+    return run;
+  }
+
+  isRunning(agentId: string): boolean {
+    return this.inFlight.has(agentId);
+  }
+
+  /** Stop accepting work and release every pending retry delay. In-flight
+   *  accessor calls finish on their own; their runs end at the next
+   *  stop-check without touching the store. Idempotent. */
+  stop(): void {
+    this.stopped = true;
+    for (const release of [...this.pendingSleeps]) release();
+    this.pendingSleeps.clear();
+  }
+
+  /** Adapter for the BackgroundJobRegistry lifecycle precedent. */
+  asBackgroundJob(): BackgroundJob {
+    const handle: BackgroundJobHandle = { stop: () => this.stop() };
+    return {
+      name: 'teams-identity-provisioning',
+      start: () => handle,
+    };
+  }
+
+  private async runWithRetries(
+    request: ProvisionTeamsIdentityRequest,
+  ): Promise<ProvisioningRunResult> {
+    for (let attempt = 1; attempt <= this.maxAttempts; attempt += 1) {
+      if (this.stopped) return { status: 'stopped', agentId: request.agentId };
+      try {
+        return await this.advance(request);
+      } catch (err) {
+        const outcome = await this.handleFailure(request, err, attempt);
+        if (outcome) return outcome;
+        // else: retry delay already awaited — loop again.
+      }
+    }
+    // Unreachable: handleFailure returns a result on the final attempt.
+    return { status: 'stopped', agentId: request.agentId };
+  }
+
+  /** Classify a chain failure. Returns a final result, or undefined after
+   *  having awaited the appropriate retry delay. */
+  private async handleFailure(
+    request: ProvisionTeamsIdentityRequest,
+    err: unknown,
+    attempt: number,
+  ): Promise<ProvisioningRunResult | undefined> {
+    const { agentId } = request;
+
+    if (err instanceof TeamsProvisioningJobError) {
+      // Precondition failure (e.g. no identity row) — retrying cannot help,
+      // and there may be no row to record the error on.
+      return { status: 'failed', agentId, reason: 'error', detail: err.message };
+    }
+
+    const scopes = missingScopesOf(err);
+    if (scopes !== undefined) {
+      // TERMINAL — an admin has to consent; retrying is pointless.
+      const detail = `consent_missing: admin consent required for scopes [${scopes.join(', ')}] — grant them in the customer tenant, then re-run provisioning`;
+      await this.recordError(agentId, { state: 'failed', lastError: detail });
+      return { status: 'failed', agentId, reason: 'consent_missing', detail };
+    }
+
+    const setupFields = missingSetupFieldsOf(err);
+    if (setupFields !== undefined) {
+      // NOT terminal — partial success: the app registration exists, only the
+      // ARM leg is unconfigured. Keep state app_registered, tell the operator
+      // exactly what to configure.
+      const detail = armNotConfiguredDetail(setupFields);
+      await this.recordError(agentId, { state: 'app_registered', lastError: detail });
+      return {
+        status: 'halted',
+        agentId,
+        reason: 'arm_not_configured',
+        missingSetupFields: setupFields,
+      };
+    }
+
+    const throttle = throttleHintOf(err);
+    const retryable = throttle !== undefined || isProvisionerUnavailable(err);
+
+    if (attempt >= this.maxAttempts) {
+      const detail = `${errorMessage(err)} (gave up after ${attempt} attempts)`;
+      if (retryable) {
+        // Progress states are real — keep them, record why the run stopped so
+        // a later re-run resumes from the same point.
+        await this.recordError(agentId, { lastError: detail });
+        return { status: 'retries_exhausted', agentId, detail };
+      }
+      await this.recordError(agentId, { state: 'failed', lastError: detail });
+      return { status: 'failed', agentId, reason: 'error', detail };
+    }
+
+    const delayMs =
+      throttle?.retryAfterSeconds !== undefined
+        ? throttle.retryAfterSeconds * 1_000
+        : this.backoffDelayMs(attempt);
+    this.log(
+      `[teams-provisioning] ${agentId} attempt ${attempt}/${this.maxAttempts} failed (${errorMessage(err)}); retrying in ${delayMs}ms`,
+    );
+    await this.sleep(delayMs);
+    return undefined;
+  }
+
+  private backoffDelayMs(attempt: number): number {
+    return Math.min(this.baseRetryDelayMs * 2 ** (attempt - 1), this.maxRetryDelayMs);
+  }
+
+  /** Best-effort persistence of a failure detail — a store outage while
+   *  recording must not mask the original failure. */
+  private async recordError(
+    agentId: string,
+    patch: TeamsIdentityJobUpdate,
+  ): Promise<void> {
+    try {
+      await this.store.update(agentId, patch);
+    } catch (err) {
+      this.log(
+        `[teams-provisioning] persisting last_error for ${agentId} failed: ${errorMessage(err)}`,
+      );
+    }
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      if (this.stopped) {
+        resolve();
+        return;
+      }
+      // `handle` is assigned after setTimeout returns; a synchronous test
+      // seam may fire `release` before that, hence the guards.
+      let handle: unknown;
+      let done = false;
+      const release = (): void => {
+        if (done) return;
+        done = true;
+        this.pendingSleeps.delete(release);
+        if (handle !== undefined) this.timers.clearTimeout(handle);
+        resolve();
+      };
+      this.pendingSleeps.add(release);
+      handle = this.timers.setTimeout(release, ms);
+    });
+  }
+
+  /**
+   * One pass over the chain, re-entering at the stored state. Completed
+   * steps are skipped by evidence (persisted columns / state rank); the rest
+   * rely on the provisioner's idempotency keys.
+   */
+  private async advance(
+    request: ProvisionTeamsIdentityRequest,
+  ): Promise<ProvisioningRunResult> {
+    const { agentId } = request;
+    let row = await this.store.getByAgentId(agentId);
+    if (!row) {
+      throw new TeamsProvisioningJobError(
+        `no teams identity row for agent '${agentId}' — create it before enqueueing provisioning`,
+      );
+    }
+    if (row.state === 'installed') return { status: 'installed', agentId };
+
+    const provisioner = this.getProvisioner();
+
+    // Step 1 — Entra app registration (idempotent by Graph uniqueName).
+    if (!row.appId || !row.tenantId) {
+      const result = await provisioner.createAppRegistration({
+        displayName: row.displayName,
+        tenantMode: this.tenantMode,
+        uniqueName: `omadia-teams-bot-${row.botSlug}`,
+        secretDisplayName: `omadia-teams-bot-${row.botSlug}`,
+      });
+      row = await this.store.update(agentId, {
+        state: 'app_registered',
+        appId: result.value.appId,
+        tenantId: result.value.registration.tenantId,
+        lastError: null,
+      });
+    } else if (STATE_RANK[row.state] < STATE_RANK.app_registered) {
+      row = await this.store.update(agentId, {
+        state: 'app_registered',
+        lastError: null,
+      });
+    }
+
+    // Step 2 — Azure bot (idempotent by bot handle). The endpoint is built by
+    // the accessor module's URL builder, injected — never composed here.
+    if (STATE_RANK[row.state] < STATE_RANK.bot_created) {
+      const outcome = await provisioner.createBot({
+        botName: row.botSlug,
+        displayName: row.displayName,
+        msaAppId: row.appId as string,
+        msaAppTenantId: row.tenantId as string,
+        messagingEndpoint: this.buildMessagingEndpoint(row.botSlug),
+      });
+      if (outcome.kind === 'registration-only') {
+        const detail = armNotConfiguredDetail(outcome.missingSetupFields);
+        await this.store.update(agentId, {
+          state: 'app_registered',
+          lastError: detail,
+        });
+        return {
+          status: 'halted',
+          agentId,
+          reason: 'arm_not_configured',
+          missingSetupFields: outcome.missingSetupFields,
+        };
+      }
+      row = await this.store.update(agentId, { state: 'bot_created', lastError: null });
+    }
+
+    // Steps 3+4 — app package + catalog upload (idempotent by externalId).
+    if (STATE_RANK[row.state] < STATE_RANK.catalog_uploaded || !row.teamsAppId) {
+      const assets = await this.loadPackageAssets(row);
+      if (STATE_RANK[row.state] < STATE_RANK.package_built) {
+        row = await this.store.update(agentId, {
+          state: 'package_built',
+          teamsAppExternalId: assets.externalId,
+          lastError: null,
+        });
+      }
+      let teamsAppId = row.teamsAppId;
+      if (!teamsAppId) {
+        const existing = await provisioner.getCatalogApp({
+          teamsAppExternalId: assets.externalId,
+        });
+        if (existing.found) {
+          teamsAppId = existing.teamsAppId;
+        } else {
+          const packageZip = provisioner.buildAppPackage({
+            manifestTemplate: assets.manifestTemplate,
+            params: assets.params,
+            icons: assets.icons,
+          });
+          const uploaded = await provisioner.uploadToCatalog({
+            packageZip,
+            externalId: assets.externalId,
+          });
+          teamsAppId = uploaded.value.teamsAppId;
+        }
+      }
+      row = await this.store.update(agentId, {
+        state: 'catalog_uploaded',
+        teamsAppId,
+        lastError: null,
+      });
+    }
+
+    // Step 5 — install into the team (idempotent on Graph's side).
+    await provisioner.installToTeam({
+      teamId: request.teamId,
+      teamsAppId: row.teamsAppId as string,
+    });
+    await this.store.update(agentId, { state: 'installed', lastError: null });
+    return { status: 'installed', agentId };
+  }
+}
+
+function armNotConfiguredDetail(missingSetupFields: readonly string[]): string {
+  const fields =
+    missingSetupFields.length > 0 ? missingSetupFields.join(', ') : 'ARM setup fields';
+  return `arm_not_configured: bot creation needs the ARM setup fields [${fields}] on the M365 connector — configure them, then re-run provisioning (the app registration is kept)`;
+}

--- a/middleware/test/_helpers/stubTeamsProvisioner.ts
+++ b/middleware/test/_helpers/stubTeamsProvisioner.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared test stub for the `teamsProvisioner@1` accessor (wave W1a, epic
+ * byte5ai/omadia#860).
+ *
+ * The `@omadia/integration-microsoft365` connector is not vendored in this
+ * checkout, so tests for every kernel-side consumer (the choke-point module,
+ * the provisioning job runner, the operator teams-identity routes) drive a
+ * stub that IMPLEMENTS the mirrored {@link TeamsProvisionerAccessor}
+ * interface — the compiler keeps the stub honest against the contract.
+ *
+ * Defaults answer every step with a plausible `'created'` outcome; override
+ * individual methods (or `tenantMode`/`canCreateBots`) per test. Every
+ * invocation is recorded in `calls` so tests can assert ordering and inputs.
+ */
+
+import type {
+  AppRegistration,
+  TeamsProvisionerAccessor,
+} from '../../src/platform/teamsProvisionerService.js';
+
+/** One recorded stub invocation: method name plus the arguments it got. */
+export interface StubProvisionerCall {
+  readonly method: keyof TeamsProvisionerAccessor;
+  readonly args: readonly unknown[];
+}
+
+export interface StubTeamsProvisioner {
+  readonly accessor: TeamsProvisionerAccessor;
+  /** Chronological journal of every method invocation. */
+  readonly calls: readonly StubProvisionerCall[];
+}
+
+const STUB_TENANT_ID = '11111111-2222-3333-4444-555555555555';
+
+function stubRegistration(displayName: string, uniqueName?: string): AppRegistration {
+  return {
+    appId: 'app-0000',
+    objectId: 'obj-0000',
+    tenantId: STUB_TENANT_ID,
+    tenantMode: 'customer',
+    signInAudience: 'AzureADMyOrg',
+    displayName,
+    ...(uniqueName === undefined ? {} : { uniqueName }),
+  };
+}
+
+/**
+ * Build a stub accessor. `overrides` replaces whole methods/fields; the
+ * defaults below stay in place for everything else.
+ */
+export function createStubTeamsProvisioner(
+  overrides: Partial<TeamsProvisionerAccessor> = {},
+): StubTeamsProvisioner {
+  const calls: StubProvisionerCall[] = [];
+
+  const defaults: TeamsProvisionerAccessor = {
+    tenantMode: 'customer',
+    canCreateBots: true,
+    createAppRegistration: async (input) => ({
+      outcome: 'created',
+      value: {
+        appId: 'app-0000',
+        secretRef: 'teams_bot_password:app-0000',
+        registration: stubRegistration(input.displayName, input.uniqueName),
+        secretKeyId: 'key-0000',
+        secretEndDateTime: '2028-01-01T00:00:00Z',
+        servicePrincipalOutcome: 'created',
+      },
+    }),
+    deleteAppRegistration: async () => ({ outcome: 'deleted' }),
+    getAppRegistration: async () => undefined,
+    buildAppPackage: () => new Uint8Array([0x50, 0x4b, 0x03, 0x04]),
+    createBot: async (input) => ({
+      kind: 'provisioned',
+      bot: {
+        outcome: 'created',
+        value: {
+          botName: input.botName,
+          resourceId: `/subscriptions/sub/resourceGroups/rg/providers/Microsoft.BotService/botServices/${input.botName}`,
+          msaAppId: input.msaAppId,
+          messagingEndpoint: input.messagingEndpoint,
+        },
+      },
+    }),
+    deleteBot: async () => ({ kind: 'deleted', outcome: 'deleted' }),
+    getBot: async () => ({ kind: 'not-found' }),
+    uploadToCatalog: async (input) => ({
+      outcome: 'created',
+      value: {
+        teamsAppId: 'catalog-0000',
+        externalId: input.externalId,
+        displayName: 'Stub Agent',
+        version: '1.0.0',
+      },
+    }),
+    getCatalogApp: async () => ({ found: false }),
+    installToTeam: async (input) => ({
+      outcome: 'created',
+      value: {
+        teamId: input.teamId,
+        teamsAppId: input.teamsAppId,
+        installationId: 'install-0000',
+      },
+    }),
+  };
+
+  const merged: TeamsProvisionerAccessor = { ...defaults, ...overrides };
+
+  const record = <A extends readonly unknown[], R>(
+    method: keyof TeamsProvisionerAccessor,
+    fn: (...args: A) => R,
+  ): ((...args: A) => R) => {
+    return (...args: A): R => {
+      calls.push({ method, args });
+      return fn(...args);
+    };
+  };
+
+  const accessor: TeamsProvisionerAccessor = {
+    tenantMode: merged.tenantMode,
+    canCreateBots: merged.canCreateBots,
+    createAppRegistration: record('createAppRegistration', merged.createAppRegistration),
+    deleteAppRegistration: record('deleteAppRegistration', merged.deleteAppRegistration),
+    getAppRegistration: record('getAppRegistration', merged.getAppRegistration),
+    buildAppPackage: record('buildAppPackage', merged.buildAppPackage),
+    createBot: record('createBot', merged.createBot),
+    deleteBot: record('deleteBot', merged.deleteBot),
+    getBot: record('getBot', merged.getBot),
+    uploadToCatalog: record('uploadToCatalog', merged.uploadToCatalog),
+    getCatalogApp: record('getCatalogApp', merged.getCatalogApp),
+    installToTeam: record('installToTeam', merged.installToTeam),
+  };
+
+  return { accessor, calls };
+}

--- a/middleware/test/agentTeamsIdentityStore.pg.test.ts
+++ b/middleware/test/agentTeamsIdentityStore.pg.test.ts
@@ -1,0 +1,257 @@
+/**
+ * W1a (#860) — `agent_teams_identities` store against a real Postgres.
+ *
+ * The schema is applied from the ACTUAL migration file (0049), twice, so
+ * this suite doubles as the double-apply proof the migrations README
+ * demands, and so the store and the migration can never drift apart
+ * silently: the exported state union is exercised against the real CHECK
+ * constraint, the one-identity-per-agent rule against the real primary key,
+ * and the cross-agent bot-slug collision against the real UNIQUE constraint.
+ *
+ * Runs in its own schema (search_path pinned per connection), mirroring
+ * coreMigrations.pg.test.ts, so parallel pg suites never collide. Skips
+ * cleanly when no test Postgres is reachable.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { Pool } from 'pg';
+
+import { probePgTest } from './_helpers/pgTestDb.js';
+
+import {
+  AgentTeamsIdentityStore,
+  AgentTeamsIdentityNotFoundError,
+  AgentTeamsIdentityStateError,
+  BotSlugTakenError,
+  TEAMS_PROVISIONING_STATES,
+  type TeamsProvisioningState,
+} from '../src/platform/agentTeamsIdentityStore.js';
+import type { TeamsIdentityJobStore } from '../src/services/teamsProvisioningJob.js';
+
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'agentTeamsIdentityStore',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  timeoutMs: 1_500,
+});
+
+const MIGRATION_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'migrations',
+  '0049_agent_teams_identities.sql',
+);
+
+const SCHEMA = `w1a_teams_ident_${String(process.pid)}`;
+
+describe('W1a AgentTeamsIdentityStore against a real Postgres', { skip: !pgAvailable }, () => {
+  let pool: Pool;
+  let store: AgentTeamsIdentityStore;
+
+  before(async () => {
+    const bootstrap = new Pool({ connectionString: PG_URL, max: 1 });
+    await bootstrap.query(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+    await bootstrap.query(`CREATE SCHEMA ${SCHEMA}`);
+    await bootstrap.end();
+    pool = new Pool({
+      connectionString: PG_URL,
+      max: 2,
+      options: `-c search_path=${SCHEMA}`,
+    });
+    const migration = await readFile(MIGRATION_PATH, 'utf8');
+    // Applied TWICE on purpose — the migrations README requires every file
+    // to be re-applicable (the schema CI gate double-applies).
+    await pool.query(migration);
+    await pool.query(migration);
+    store = new AgentTeamsIdentityStore(pool);
+  });
+
+  beforeEach(async () => {
+    await pool.query('TRUNCATE agent_teams_identities');
+  });
+
+  after(async () => {
+    await pool.query(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+    await pool.end();
+  });
+
+  it('is a drop-in TeamsIdentityJobStore for the provisioning job runner', () => {
+    // Compile-time pin: the runner's structural port must stay satisfied.
+    const jobStore: TeamsIdentityJobStore = store;
+    assert.ok(jobStore);
+  });
+
+  it('getByAgentId returns undefined for an agent without an identity', async () => {
+    assert.equal(await store.getByAgentId('nobody'), undefined);
+  });
+
+  it('ensureForAgent creates a pending row and is create-if-absent', async () => {
+    const created = await store.ensureForAgent({
+      agentId: 'agent-1',
+      botSlug: 'hr-bot',
+      displayName: 'HR Bot',
+      teamId: '19:team-a',
+    });
+    assert.equal(created.state, 'pending');
+    assert.equal(created.botSlug, 'hr-bot');
+    assert.equal(created.teamId, '19:team-a');
+    assert.equal(created.appId, null);
+    assert.equal(created.lastError, null);
+
+    // Re-ensure with different identity fields: row wins, only the install
+    // target is refreshed.
+    const again = await store.ensureForAgent({
+      agentId: 'agent-1',
+      botSlug: 'other-slug',
+      displayName: 'Other Name',
+      teamId: '19:team-b',
+    });
+    assert.equal(again.botSlug, 'hr-bot', 'bot_slug is not re-applied');
+    assert.equal(again.displayName, 'HR Bot', 'display_name is not re-applied');
+    assert.equal(again.teamId, '19:team-b', 'team_id follows the latest request');
+
+    // Without a teamId the stored target is kept.
+    const kept = await store.ensureForAgent({
+      agentId: 'agent-1',
+      botSlug: 'hr-bot',
+      displayName: 'HR Bot',
+    });
+    assert.equal(kept.teamId, '19:team-b');
+  });
+
+  it("a second agent claiming the same bot slug fails loudly (BotSlugTakenError)", async () => {
+    await store.ensureForAgent({
+      agentId: 'agent-1',
+      botSlug: 'hr-bot',
+      displayName: 'HR Bot',
+    });
+    await assert.rejects(
+      store.ensureForAgent({
+        agentId: 'agent-2',
+        botSlug: 'hr-bot',
+        displayName: 'Impostor',
+      }),
+      (err: unknown) => {
+        assert.ok(err instanceof BotSlugTakenError);
+        assert.equal(err.code, 'bot_slug_taken');
+        return true;
+      },
+    );
+    // agent-2 got no row.
+    assert.equal(await store.getByAgentId('agent-2'), undefined);
+  });
+
+  it('update walks the chain states and persists step evidence', async () => {
+    await store.ensureForAgent({
+      agentId: 'agent-1',
+      botSlug: 'hr-bot',
+      displayName: 'HR Bot',
+    });
+    const registered = await store.update('agent-1', {
+      state: 'app_registered',
+      appId: 'app-123',
+      tenantId: 'tenant-9',
+      lastError: null,
+    });
+    assert.equal(registered.state, 'app_registered');
+    assert.equal(registered.appId, 'app-123');
+    assert.equal(registered.tenantId, 'tenant-9');
+
+    const uploaded = await store.update('agent-1', {
+      state: 'catalog_uploaded',
+      teamsAppId: 'catalog-77',
+      teamsAppExternalId: 'ext-1',
+    });
+    assert.equal(uploaded.state, 'catalog_uploaded');
+    assert.equal(uploaded.teamsAppId, 'catalog-77');
+    assert.equal(uploaded.appId, 'app-123', 'earlier evidence survives');
+
+    const failed = await store.update('agent-1', {
+      state: 'failed',
+      lastError: 'consent_missing: scopes [AppCatalog.ReadWrite.All]',
+    });
+    assert.equal(failed.state, 'failed');
+    assert.match(failed.lastError ?? '', /consent_missing/);
+
+    // Clearing the error with null.
+    const cleared = await store.update('agent-1', { lastError: null });
+    assert.equal(cleared.lastError, null);
+  });
+
+  it('update surfaces unknown agents and out-of-union states — never a silent no-op', async () => {
+    await assert.rejects(
+      store.update('nobody', { state: 'app_registered' }),
+      AgentTeamsIdentityNotFoundError,
+    );
+    await store.ensureForAgent({
+      agentId: 'agent-1',
+      botSlug: 'hr-bot',
+      displayName: 'HR Bot',
+    });
+    await assert.rejects(
+      store.update('agent-1', {
+        state: 'exploded' as TeamsProvisioningState,
+      }),
+      AgentTeamsIdentityStateError,
+    );
+  });
+
+  it('the CHECK constraint enforces exactly the exported state union', async () => {
+    // Every union member is accepted…
+    for (const [i, state] of TEAMS_PROVISIONING_STATES.entries()) {
+      await pool.query(
+        `INSERT INTO agent_teams_identities (agent_id, bot_slug, display_name, state)
+         VALUES ($1, $2, $3, $4)`,
+        [`check-${String(i)}`, `check-bot-${String(i)}`, 'Check', state],
+      );
+    }
+    // …and anything else is rejected by the database itself.
+    await assert.rejects(
+      pool.query(
+        `INSERT INTO agent_teams_identities (agent_id, bot_slug, display_name, state)
+         VALUES ('check-x', 'check-bot-x', 'Check', 'exploded')`,
+      ),
+      (err: unknown) => (err as { code?: string }).code === '23514',
+    );
+  });
+
+  it('recordEnqueueFailure stores an actionable last_error without touching state', async () => {
+    await store.ensureForAgent({
+      agentId: 'agent-1',
+      botSlug: 'hr-bot',
+      displayName: 'HR Bot',
+    });
+    await store.recordEnqueueFailure('agent-1', 'queue down');
+    const row = await store.getByAgentId('agent-1');
+    assert.equal(row?.state, 'pending');
+    assert.equal(row?.lastError, 'enqueue_failed: queue down');
+  });
+
+  it('listResumable returns interrupted runs only (non-terminal, with a team target)', async () => {
+    const seed = async (
+      agentId: string,
+      state: TeamsProvisioningState,
+      teamId: string | null,
+    ): Promise<void> => {
+      await pool.query(
+        `INSERT INTO agent_teams_identities (agent_id, bot_slug, display_name, state, team_id)
+         VALUES ($1, $2, 'Seed', $3, $4)`,
+        [agentId, `bot-${agentId}`, state, teamId],
+      );
+    };
+    await seed('resume-1', 'app_registered', '19:t');
+    await seed('resume-2', 'catalog_uploaded', '19:t');
+    await seed('done-1', 'installed', '19:t');
+    await seed('failed-1', 'failed', '19:t');
+    await seed('no-team', 'pending', null);
+    const resumable = await store.listResumable();
+    assert.deepEqual(
+      resumable.map((r) => r.agentId).sort(),
+      ['resume-1', 'resume-2'],
+    );
+  });
+});

--- a/middleware/test/operatorAgentsRouter.test.ts
+++ b/middleware/test/operatorAgentsRouter.test.ts
@@ -269,8 +269,15 @@ interface TeamsIdentityMem {
 
 class FakeTeamsIdentityStore {
   rows = new Map<string, TeamsIdentityMem>();
-  ensureCalls: Array<{ agentId: string; botSlug: string; displayName: string }> =
-    [];
+  ensureCalls: Array<{
+    agentId: string;
+    botSlug: string;
+    displayName: string;
+    teamId?: string;
+  }> = [];
+  enqueueFailures: Array<{ agentId: string; message: string }> = [];
+  /** When set, ensureForAgent throws it (bot_slug_taken shape). */
+  ensureError: Error | undefined;
 
   getByAgentId(agentId: string): Promise<OperatorTeamsIdentityRecord | undefined> {
     return Promise.resolve(this.rows.get(agentId));
@@ -279,8 +286,10 @@ class FakeTeamsIdentityStore {
     agentId: string;
     botSlug: string;
     displayName: string;
+    teamId?: string;
   }): Promise<OperatorTeamsIdentityRecord> {
     this.ensureCalls.push({ ...input });
+    if (this.ensureError) return Promise.reject(this.ensureError);
     const existing = this.rows.get(input.agentId);
     if (existing) return Promise.resolve(existing);
     const row: TeamsIdentityMem = {
@@ -297,6 +306,12 @@ class FakeTeamsIdentityStore {
     this.rows.set(input.agentId, row);
     return Promise.resolve(row);
   }
+  recordEnqueueFailure(agentId: string, message: string): Promise<void> {
+    this.enqueueFailures.push({ agentId, message });
+    const row = this.rows.get(agentId);
+    if (row) row.lastError = `enqueue_failed: ${message}`;
+    return Promise.resolve();
+  }
 }
 
 /** W1a (#860) — stubbed provisioning job runner. `enqueue` returns a promise
@@ -305,9 +320,15 @@ class FakeTeamsIdentityStore {
 class FakeTeamsRunner {
   enqueueCalls: Array<{ agentId: string; teamId: string }> = [];
   running = new Set<string>();
+  /** When set, enqueue rejects with it (and registers nothing in-flight). */
+  enqueueError: Error | undefined;
 
   enqueue(request: { agentId: string; teamId: string }): Promise<unknown> {
     this.enqueueCalls.push({ ...request });
+    if (this.enqueueError) return Promise.reject(this.enqueueError);
+    // Mirrors the real runner: a successful enqueue synchronously holds an
+    // in-flight run, so the POST's `running` flag reads true.
+    this.running.add(request.agentId);
     return new Promise<unknown>(() => {});
   }
   isRunning(agentId: string): boolean {
@@ -931,7 +952,12 @@ describe('createOperatorAgentsRouter', () => {
     ]);
     assert.equal(teamsStore.rows.size, 1);
     assert.deepEqual(teamsStore.ensureCalls, [
-      { agentId: agent.id, botSlug: 'sales', displayName: 'Sales Agent' },
+      {
+        agentId: agent.id,
+        botSlug: 'sales',
+        displayName: 'Sales Agent',
+        teamId: '19:team-abc',
+      },
     ]);
   });
 
@@ -1011,6 +1037,85 @@ describe('createOperatorAgentsRouter', () => {
     assert.equal(teamsRunner.enqueueCalls.length, 0, 'nothing enqueued');
   });
 
+  it('POST /:slug/teams-identity: client errors win over the provisioner 503 (404/400 first)', async () => {
+    provisionerInstalled = false;
+    // Unknown agent → 404, not 503: the operator's mistake is named even
+    // while the connector is inactive.
+    let res = await fetch(`${baseUrl}/ghost/teams-identity`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ team_id: '19:t' }),
+    });
+    assert.equal(res.status, 404);
+    // Malformed body → 400, not 503.
+    await store.createAgent({ slug: 'sales', name: 'Sales' });
+    res = await fetch(`${baseUrl}/sales/teams-identity`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(res.status, 400);
+    assert.equal(((await res.json()) as { error: string }).error, 'invalid_body');
+  });
+
+  it('POST /:slug/teams-identity rejects a bot_slug longer than 63 chars (channel-teams bound)', async () => {
+    await store.createAgent({ slug: 'sales', name: 'Sales' });
+    const res = await fetch(`${baseUrl}/sales/teams-identity`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ team_id: '19:t', bot_slug: 'a'.repeat(64) }),
+    });
+    assert.equal(res.status, 400, 'BOT_SLUG_PATTERN allows at most 63 chars');
+    const ok = await fetch(`${baseUrl}/sales/teams-identity`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ team_id: '19:t', bot_slug: 'a'.repeat(63) }),
+    });
+    assert.equal(ok.status, 202);
+  });
+
+  it('POST /:slug/teams-identity → 409 when the bot slug is taken by another agent', async () => {
+    await store.createAgent({ slug: 'sales', name: 'Sales' });
+    const err = new Error("bot slug 'sales-bot' is already used by another agent");
+    (err as Error & { code?: string }).code = 'bot_slug_taken';
+    teamsStore.ensureError = err;
+    const res = await fetch(`${baseUrl}/sales/teams-identity`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ team_id: '19:t', bot_slug: 'sales-bot' }),
+    });
+    assert.equal(res.status, 409);
+    assert.equal(((await res.json()) as { error: string }).error, 'bot_slug_taken');
+    assert.equal(teamsRunner.enqueueCalls.length, 0, 'nothing enqueued');
+  });
+
+  it('POST /:slug/teams-identity reports running honestly and persists a failed enqueue', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    teamsRunner.enqueueError = new Error('queue down');
+    const res = await fetch(`${baseUrl}/sales/teams-identity`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ team_id: '19:t' }),
+    });
+    assert.equal(res.status, 202);
+    const body = (await res.json()) as { running: boolean };
+    assert.equal(
+      body.running,
+      false,
+      'a rejected enqueue must not be reported as a started run',
+    );
+    // The fire-and-forget catch persists the failure so GET can surface it.
+    await new Promise((r) => setImmediate(r));
+    assert.deepEqual(teamsStore.enqueueFailures, [
+      { agentId: agent.id, message: 'queue down' },
+    ]);
+    const status = await fetch(`${baseUrl}/sales/teams-identity`);
+    const statusBody = (await status.json()) as {
+      identity: { last_error: string | null };
+    };
+    assert.equal(statusBody.identity.last_error, 'enqueue_failed: queue down');
+  });
+
   it('GET /:slug/teams-identity projects the row incl. the teams_bots[] entry with a secret ref', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
     teamsStore.rows.set(agent.id, {
@@ -1043,16 +1148,22 @@ describe('createOperatorAgentsRouter', () => {
     assert.equal(body.provisioner_installed, true);
     assert.equal(body.identity['teams_app_id'], 'teams-app-789');
     assert.equal(body.identity['teams_app_external_id'], 'ext-000');
-    // Everything channel-teams' teams_bots[] needs — with the app password
-    // as a credential-store REF, never as secret material.
+    // Everything channel-teams' teams_bots[] needs — shaped exactly like a
+    // parseTeamsBotsConfig entry (camelCase), with the app password as the
+    // connector's opaque vault REF, never as secret material.
     assert.deepEqual(body.teams_bot, {
-      slug: 'sales-bot',
-      display_name: 'Sales Bot',
-      app_id: 'app-123',
-      app_type: 'SingleTenant',
-      tenant_id: 'tenant-456',
-      app_password_secret_ref: defaultTeamsBotSecretRef('sales-bot'),
+      botSlug: 'sales-bot',
+      displayName: 'Sales Bot',
+      appId: 'app-123',
+      appType: 'SingleTenant',
+      tenantId: 'tenant-456',
+      appPasswordSecretRef: defaultTeamsBotSecretRef({ appId: 'app-123' }),
     });
+    assert.equal(
+      defaultTeamsBotSecretRef({ appId: 'app-123' }),
+      'teams_bot_password:app-123',
+      'the connector-vault ref is derived from the appId, not the bot slug',
+    );
   });
 
   it('GET /:slug/teams-identity: teams_bot stays null before the app registration exists; 404 without a row', async () => {

--- a/middleware/test/operatorAgentsRouter.test.ts
+++ b/middleware/test/operatorAgentsRouter.test.ts
@@ -17,6 +17,11 @@
  *     global config, unassigned+disable → 404); GET /:slug/grants returns
  *     the agent's tool grants (grant epoch included) + the plugin MCP
  *     grants of its assigned plugins, and 503s without a graph store.
+ * 10. W1a (#860): POST /:slug/teams-identity ensures the identity row (one
+ *     per agent) and enqueues the provisioning job WITHOUT awaiting it;
+ *     GET /:slug/teams-identity projects the row incl. the teams_bots[]
+ *     entry with a secret REF (never secret material); both 503 when the
+ *     deps are unwired, POST 503s when teamsProvisioner@1 is missing.
  */
 
 import { strict as assert } from 'node:assert';
@@ -34,7 +39,11 @@ import {
   type ConfigStore,
   type OrchestratorRegistry,
 } from '@omadia/orchestrator';
-import { createOperatorAgentsRouter } from '../src/routes/operatorAgents.js';
+import {
+  createOperatorAgentsRouter,
+  defaultTeamsBotSecretRef,
+  type OperatorTeamsIdentityRecord,
+} from '../src/routes/operatorAgents.js';
 import { listenLoopback } from './_helpers/listenLoopback.js';
 
 interface AgentMem {
@@ -243,6 +252,69 @@ class FakeGraphStore {
   }
 }
 
+/** W1a (#860) — in-memory `agent_teams_identities` store stub. */
+interface TeamsIdentityMem {
+  agentId: string;
+  botSlug: string;
+  displayName: string;
+  state: string;
+  appId: string | null;
+  tenantId: string | null;
+  teamsAppId: string | null;
+  teamsAppExternalId: string | null;
+  lastError: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+class FakeTeamsIdentityStore {
+  rows = new Map<string, TeamsIdentityMem>();
+  ensureCalls: Array<{ agentId: string; botSlug: string; displayName: string }> =
+    [];
+
+  getByAgentId(agentId: string): Promise<OperatorTeamsIdentityRecord | undefined> {
+    return Promise.resolve(this.rows.get(agentId));
+  }
+  ensureForAgent(input: {
+    agentId: string;
+    botSlug: string;
+    displayName: string;
+  }): Promise<OperatorTeamsIdentityRecord> {
+    this.ensureCalls.push({ ...input });
+    const existing = this.rows.get(input.agentId);
+    if (existing) return Promise.resolve(existing);
+    const row: TeamsIdentityMem = {
+      ...input,
+      state: 'pending',
+      appId: null,
+      tenantId: null,
+      teamsAppId: null,
+      teamsAppExternalId: null,
+      lastError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    this.rows.set(input.agentId, row);
+    return Promise.resolve(row);
+  }
+}
+
+/** W1a (#860) — stubbed provisioning job runner. `enqueue` returns a promise
+ *  that NEVER settles: if the POST handler awaited the run, its test would
+ *  hang into the suite timeout, so a green run proves the async contract. */
+class FakeTeamsRunner {
+  enqueueCalls: Array<{ agentId: string; teamId: string }> = [];
+  running = new Set<string>();
+
+  enqueue(request: { agentId: string; teamId: string }): Promise<unknown> {
+    this.enqueueCalls.push({ ...request });
+    return new Promise<unknown>(() => {});
+  }
+  isRunning(agentId: string): boolean {
+    return this.running.has(agentId);
+  }
+}
+
 class FakeRegistry {
   reloadCalls = 0;
   invalidateCalls: Array<{ slug: string; mode: 'drain' | 'kill' }> = [];
@@ -270,12 +342,18 @@ describe('createOperatorAgentsRouter', () => {
   let registry: FakeRegistry;
   let graph: FakeGraphStore;
   let sessionStore: { list: () => Promise<unknown[]> };
+  let teamsStore: FakeTeamsIdentityStore;
+  let teamsRunner: FakeTeamsRunner;
+  let provisionerInstalled: boolean;
 
   before(async () => {
     store = new FakeConfigStore();
     registry = new FakeRegistry();
     graph = new FakeGraphStore();
     sessionStore = { list: () => Promise.resolve([]) };
+    teamsStore = new FakeTeamsIdentityStore();
+    teamsRunner = new FakeTeamsRunner();
+    provisionerInstalled = true;
     const app = express();
     app.use(express.json());
     app.use(
@@ -285,6 +363,12 @@ describe('createOperatorAgentsRouter', () => {
         getRegistry: () => registry as unknown as OrchestratorRegistry,
         getChatSessionStore: () => sessionStore as unknown as ChatSessionStore,
         getAgentGraphStore: () => graph as unknown as AgentGraphStore,
+        // W1a (#860) — getters read the CURRENT fakes so afterEach resets apply.
+        getTeamsIdentity: () => ({
+          store: teamsStore,
+          runner: teamsRunner,
+          isProvisionerInstalled: () => provisionerInstalled,
+        }),
       }),
     );
     server = await listenLoopback(app);
@@ -301,6 +385,9 @@ describe('createOperatorAgentsRouter', () => {
     graph = new FakeGraphStore();
     registry.reloadCalls = 0;
     registry.invalidateCalls = [];
+    teamsStore = new FakeTeamsIdentityStore();
+    teamsRunner = new FakeTeamsRunner();
+    provisionerInstalled = true;
   });
 
   it('POST / creates an agent and triggers a reload', async () => {
@@ -736,6 +823,36 @@ describe('createOperatorAgentsRouter', () => {
     assert.match(mount, /new AgentGraphStore\(graphPool\)/, 'the option must construct the real store from graphPool');
   });
 
+  it('index.ts supplies getTeamsIdentity to the operator-agents mount (wiring pin, W1a #860)', async () => {
+    // Same rationale as the getAgentGraphStore pin above: the route tests
+    // inject their own deps and cannot see a missing option at the REAL
+    // mount. Pin the wiring statically so the teams-identity routes cannot
+    // silently degrade to a permanent 503.
+    const indexSource = await readFile(new URL('../src/index.ts', import.meta.url), 'utf8');
+    const mount = /createOperatorAgentsRouter\(\{([\s\S]*?)\}\)/.exec(indexSource)?.[1];
+    assert.ok(mount, 'index.ts no longer mounts createOperatorAgentsRouter — update this pin');
+    assert.match(
+      mount,
+      /getTeamsIdentity:/,
+      'index.ts must pass getTeamsIdentity to createOperatorAgentsRouter — without it every /:slug/teams-identity request 503s',
+    );
+    assert.match(
+      mount,
+      /'agentTeamsIdentityStore'/,
+      'the option must resolve the identity store through the service registry',
+    );
+    assert.match(
+      mount,
+      /'teamsProvisioningJobRunner'/,
+      'the option must resolve the provisioning job runner through the service registry',
+    );
+    assert.match(
+      mount,
+      /serviceRegistry\.has\('teamsProvisioner'\)/,
+      'provisioner availability must come live from the service registry',
+    );
+  });
+
   it('GET /:slug/grants → grant_epoch null when no grant was ever bumped', async () => {
     const agent = await store.createAgent({ slug: 'public', name: 'Public' });
     graph.toolGrants = [
@@ -779,6 +896,233 @@ describe('createOperatorAgentsRouter', () => {
       assert.equal(
         ((await res.json()) as { error: string }).error,
         'agent_graph_store_unavailable',
+      );
+    } finally {
+      await new Promise<void>((r) => s.close(() => r()));
+    }
+  });
+
+  // ── W1a (#860): Teams identity provisioning endpoints ───────────────
+
+  it('POST /:slug/teams-identity ensures the row, enqueues, and answers 202 without awaiting the run', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales Agent' });
+    const res = await fetch(`${baseUrl}/sales/teams-identity`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ team_id: '19:team-abc' }),
+    });
+    // FakeTeamsRunner.enqueue never settles — reaching these assertions at
+    // all proves the handler returned without awaiting the provisioning run.
+    assert.equal(res.status, 202);
+    const body = (await res.json()) as {
+      ok: boolean;
+      agent: string;
+      bot_slug: string;
+      state: string;
+      running: boolean;
+    };
+    assert.equal(body.ok, true);
+    assert.equal(body.agent, 'sales');
+    assert.equal(body.bot_slug, 'sales');
+    assert.equal(body.state, 'pending');
+    assert.equal(body.running, true);
+    assert.deepEqual(teamsRunner.enqueueCalls, [
+      { agentId: agent.id, teamId: '19:team-abc' },
+    ]);
+    assert.equal(teamsStore.rows.size, 1);
+    assert.deepEqual(teamsStore.ensureCalls, [
+      { agentId: agent.id, botSlug: 'sales', displayName: 'Sales Agent' },
+    ]);
+  });
+
+  it('POST /:slug/teams-identity derives a URL-safe bot slug and honors overrides on first creation', async () => {
+    await store.createAgent({ slug: 'My_Sales.Agent', name: 'Sales' });
+    const res = await fetch(
+      `${baseUrl}/${encodeURIComponent('My_Sales.Agent')}/teams-identity`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          team_id: '19:t',
+          display_name: 'Sales Bot',
+        }),
+      },
+    );
+    assert.equal(res.status, 202);
+    const body = (await res.json()) as { bot_slug: string };
+    assert.equal(body.bot_slug, 'my-sales-agent', 'sanitized from the agent slug');
+    assert.equal(teamsStore.ensureCalls[0]!.displayName, 'Sales Bot');
+  });
+
+  it('POST /:slug/teams-identity is create-or-provision: one identity per agent, a re-POST reuses the row', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    const first = await fetch(`${baseUrl}/sales/teams-identity`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ team_id: '19:t', bot_slug: 'sales-bot' }),
+    });
+    assert.equal(first.status, 202);
+    const second = await fetch(`${baseUrl}/sales/teams-identity`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ team_id: '19:t', bot_slug: 'other-bot' }),
+    });
+    assert.equal(second.status, 202);
+    const body = (await second.json()) as { bot_slug: string };
+    assert.equal(body.bot_slug, 'sales-bot', 'existing row wins over the re-POST');
+    assert.equal(teamsStore.rows.size, 1, 'unique agent_id — no second row');
+    assert.equal(teamsRunner.enqueueCalls.length, 2, 're-POST re-runs provisioning');
+    assert.equal(teamsRunner.enqueueCalls[1]!.agentId, agent.id);
+  });
+
+  it('POST /:slug/teams-identity → 404 for an unknown agent, 400 without team_id', async () => {
+    let res = await fetch(`${baseUrl}/ghost/teams-identity`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ team_id: '19:t' }),
+    });
+    assert.equal(res.status, 404);
+
+    await store.createAgent({ slug: 'sales', name: 'Sales' });
+    res = await fetch(`${baseUrl}/sales/teams-identity`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(res.status, 400);
+    assert.equal(((await res.json()) as { error: string }).error, 'invalid_body');
+    assert.equal(teamsRunner.enqueueCalls.length, 0, 'nothing enqueued');
+  });
+
+  it('POST /:slug/teams-identity 503s when teamsProvisioner@1 is not installed', async () => {
+    provisionerInstalled = false;
+    await store.createAgent({ slug: 'sales', name: 'Sales' });
+    const res = await fetch(`${baseUrl}/sales/teams-identity`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ team_id: '19:t' }),
+    });
+    assert.equal(res.status, 503);
+    assert.equal(
+      ((await res.json()) as { error: string }).error,
+      'teams_provisioner_unavailable',
+    );
+    assert.equal(teamsStore.rows.size, 0, 'no row created');
+    assert.equal(teamsRunner.enqueueCalls.length, 0, 'nothing enqueued');
+  });
+
+  it('GET /:slug/teams-identity projects the row incl. the teams_bots[] entry with a secret ref', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    teamsStore.rows.set(agent.id, {
+      agentId: agent.id,
+      botSlug: 'sales-bot',
+      displayName: 'Sales Bot',
+      state: 'installed',
+      appId: 'app-123',
+      tenantId: 'tenant-456',
+      teamsAppId: 'teams-app-789',
+      teamsAppExternalId: 'ext-000',
+      lastError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    teamsRunner.running.add(agent.id);
+    const res = await fetch(`${baseUrl}/sales/teams-identity`);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      state: string;
+      running: boolean;
+      provisioner_installed: boolean;
+      identity: Record<string, unknown>;
+      teams_bot: Record<string, unknown>;
+    };
+    assert.equal(body.ok, true);
+    assert.equal(body.state, 'installed');
+    assert.equal(body.running, true);
+    assert.equal(body.provisioner_installed, true);
+    assert.equal(body.identity['teams_app_id'], 'teams-app-789');
+    assert.equal(body.identity['teams_app_external_id'], 'ext-000');
+    // Everything channel-teams' teams_bots[] needs — with the app password
+    // as a credential-store REF, never as secret material.
+    assert.deepEqual(body.teams_bot, {
+      slug: 'sales-bot',
+      display_name: 'Sales Bot',
+      app_id: 'app-123',
+      app_type: 'SingleTenant',
+      tenant_id: 'tenant-456',
+      app_password_secret_ref: defaultTeamsBotSecretRef('sales-bot'),
+    });
+  });
+
+  it('GET /:slug/teams-identity: teams_bot stays null before the app registration exists; 404 without a row', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    let res = await fetch(`${baseUrl}/sales/teams-identity`);
+    assert.equal(res.status, 404);
+    assert.equal(
+      ((await res.json()) as { error: string }).error,
+      'teams_identity_not_found',
+    );
+
+    provisionerInstalled = false; // status stays readable without the connector
+    teamsStore.rows.set(agent.id, {
+      agentId: agent.id,
+      botSlug: 'sales-bot',
+      displayName: 'Sales Bot',
+      state: 'pending',
+      appId: null,
+      tenantId: null,
+      teamsAppId: null,
+      teamsAppExternalId: null,
+      lastError: 'consent_missing: admin consent required',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    res = await fetch(`${baseUrl}/sales/teams-identity`);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as {
+      provisioner_installed: boolean;
+      running: boolean;
+      identity: { last_error: string };
+      teams_bot: unknown;
+    };
+    assert.equal(body.teams_bot, null);
+    assert.equal(body.provisioner_installed, false);
+    assert.equal(body.running, false);
+    assert.equal(body.identity.last_error, 'consent_missing: admin consent required');
+  });
+
+  it('teams-identity routes 503 when the deps are not wired', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/api/v1/operator/agents',
+      createOperatorAgentsRouter({
+        getConfigStore: () => store as unknown as ConfigStore,
+        getRegistry: () => registry as unknown as OrchestratorRegistry,
+        getChatSessionStore: () => sessionStore as unknown as ChatSessionStore,
+      }),
+    );
+    const s = await listenLoopback(app);
+    try {
+      await store.createAgent({ slug: 'sales', name: 'Sales' });
+      const addr = s.address() as AddressInfo;
+      const local = `http://127.0.0.1:${String(addr.port)}/api/v1/operator/agents`;
+      const post = await fetch(`${local}/sales/teams-identity`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ team_id: '19:t' }),
+      });
+      assert.equal(post.status, 503);
+      assert.equal(
+        ((await post.json()) as { error: string }).error,
+        'teams_identity_unavailable',
+      );
+      const get = await fetch(`${local}/sales/teams-identity`);
+      assert.equal(get.status, 503);
+      assert.equal(
+        ((await get.json()) as { error: string }).error,
+        'teams_identity_unavailable',
       );
     } finally {
       await new Promise<void>((r) => s.close(() => r()));

--- a/middleware/test/teamsProvisionerService.test.ts
+++ b/middleware/test/teamsProvisionerService.test.ts
@@ -1,0 +1,393 @@
+/**
+ * Tests for the `teamsProvisioner@1` choke point
+ * (`middleware/src/platform/teamsProvisionerService.ts`, wave W1a,
+ * epic byte5ai/omadia#860).
+ *
+ * The connector plugin is not vendored in this checkout, so everything runs
+ * against `createStubTeamsProvisioner` (test/_helpers), which implements the
+ * mirrored accessor interface — the same stub the router and job-runner
+ * suites drive.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { perCallerService, type ServiceCaller } from '@omadia/plugin-api';
+
+import { ServiceRegistry } from '../src/platform/serviceRegistry.js';
+import {
+  buildTeamsBotMessagingEndpoint,
+  getTeamsProvisioner,
+  isArmNotConfiguredError,
+  isConsentMissingError,
+  isProvisioningThrottledError,
+  isTeamsProvisionerError,
+  requireTeamsProvisioner,
+  SingleTenantViolationError,
+  TEAMS_PROVISIONER_SERVICE_NAME,
+  TeamsMessagingEndpointError,
+  TeamsProvisionerUnavailableError,
+  type CreateAppRegistrationInput,
+  type TeamsProvisionerAccessor,
+} from '../src/platform/teamsProvisionerService.js';
+import { createStubTeamsProvisioner } from './_helpers/stubTeamsProvisioner.js';
+
+function registryWith(accessor: TeamsProvisionerAccessor): ServiceRegistry {
+  const registry = new ServiceRegistry();
+  registry.provide(TEAMS_PROVISIONER_SERVICE_NAME, accessor, '@omadia/integration-microsoft365');
+  return registry;
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+describe('teamsProvisioner resolution', () => {
+  it('returns undefined when the connector plugin is not installed', () => {
+    assert.equal(getTeamsProvisioner(new ServiceRegistry()), undefined);
+  });
+
+  it('requireTeamsProvisioner throws the typed unavailable error (router → 503), never crashes', () => {
+    assert.throws(
+      () => requireTeamsProvisioner(new ServiceRegistry()),
+      (err: unknown) => {
+        assert.ok(err instanceof TeamsProvisionerUnavailableError);
+        assert.equal(err.code, 'teams_provisioner_unavailable');
+        assert.match(err.message, /teamsProvisioner@1 is not published/);
+        assert.match(err.message, /@omadia\/integration-microsoft365/);
+        return true;
+      },
+    );
+  });
+
+  it('resolves a registered provider and passes calls through', async () => {
+    const stub = createStubTeamsProvisioner();
+    const provisioner = requireTeamsProvisioner(registryWith(stub.accessor));
+
+    assert.equal(provisioner.tenantMode, 'customer');
+    assert.equal(provisioner.canCreateBots, true);
+
+    const uploaded = await provisioner.uploadToCatalog({
+      packageZip: new Uint8Array([1]),
+      externalId: 'ext-1',
+    });
+    assert.equal(uploaded.outcome, 'created');
+    assert.equal(uploaded.value.externalId, 'ext-1');
+
+    const lookup = await provisioner.getCatalogApp({ teamsAppExternalId: 'ext-1' });
+    assert.deepEqual(lookup, { found: false });
+
+    assert.deepEqual(
+      stub.calls.map((call) => call.method),
+      ['uploadToCatalog', 'getCatalogApp'],
+    );
+  });
+
+  it('resolves per-caller registrations as the kernel, not a fabricated plugin', () => {
+    const stub = createStubTeamsProvisioner();
+    const seen: ServiceCaller[] = [];
+    const registry = new ServiceRegistry();
+    registry.provide(
+      TEAMS_PROVISIONER_SERVICE_NAME,
+      perCallerService((caller) => {
+        seen.push(caller);
+        return stub.accessor;
+      }),
+    );
+
+    const provisioner = getTeamsProvisioner(registry);
+    assert.notEqual(provisioner, undefined);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0]?.agentId, '@omadia/core');
+    assert.equal(seen[0]?.pluginId, '@omadia/core');
+  });
+
+  it('duplicate providers stay a registry-level error (operator must uninstall one)', () => {
+    const registry = registryWith(createStubTeamsProvisioner().accessor);
+    assert.throws(
+      () =>
+        registry.provide(
+          TEAMS_PROVISIONER_SERVICE_NAME,
+          createStubTeamsProvisioner().accessor,
+        ),
+      /duplicate provider for 'teamsProvisioner'/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SingleTenant boundary guard
+// ---------------------------------------------------------------------------
+
+describe('single-tenant guard', () => {
+  it('accepts customer/home tenant modes on createAppRegistration', async () => {
+    const stub = createStubTeamsProvisioner();
+    const provisioner = requireTeamsProvisioner(registryWith(stub.accessor));
+
+    for (const tenantMode of ['customer', 'home'] as const) {
+      const result = await provisioner.createAppRegistration({
+        displayName: 'HR Agent',
+        tenantMode,
+        uniqueName: 'omadia-hr-agent',
+      });
+      assert.equal(result.value.registration.signInAudience, 'AzureADMyOrg');
+    }
+    assert.equal(stub.calls.length, 2);
+  });
+
+  it('rejects unknown tenant modes before the connector sees them', async () => {
+    const stub = createStubTeamsProvisioner();
+    const provisioner = requireTeamsProvisioner(registryWith(stub.accessor));
+
+    const multiTenant = {
+      displayName: 'Rogue',
+      tenantMode: 'multiTenant',
+    } as unknown as CreateAppRegistrationInput;
+
+    await assert.rejects(
+      () => provisioner.createAppRegistration(multiTenant),
+      (err: unknown) => {
+        assert.ok(err instanceof SingleTenantViolationError);
+        assert.equal(err.code, 'single_tenant_only');
+        assert.equal(err.field, 'tenantMode');
+        return true;
+      },
+    );
+    assert.equal(stub.calls.length, 0, 'the connector must never see the input');
+  });
+
+  it('rejects a smuggled non-single-tenant signInAudience', async () => {
+    const stub = createStubTeamsProvisioner();
+    const provisioner = requireTeamsProvisioner(registryWith(stub.accessor));
+
+    const smuggled = {
+      displayName: 'Rogue',
+      tenantMode: 'customer',
+      signInAudience: 'AzureADMultipleOrgs',
+    } as unknown as CreateAppRegistrationInput;
+
+    await assert.rejects(
+      () => provisioner.createAppRegistration(smuggled),
+      (err: unknown) =>
+        err instanceof SingleTenantViolationError && err.field === 'signInAudience',
+    );
+    assert.equal(stub.calls.length, 0);
+  });
+
+  it('guards getAppRegistration tenant-mode probes too', async () => {
+    const stub = createStubTeamsProvisioner();
+    const provisioner = requireTeamsProvisioner(registryWith(stub.accessor));
+
+    await assert.rejects(
+      () =>
+        provisioner.getAppRegistration('app-1', 'AzureADMultipleOrgs' as never),
+      SingleTenantViolationError,
+    );
+    assert.equal(await provisioner.getAppRegistration('app-1', 'customer'), undefined);
+    assert.equal(stub.calls.length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Secret custody
+// ---------------------------------------------------------------------------
+
+describe('secret custody', () => {
+  it('passes through the contract shape: opaque secretRef, no cleartext', async () => {
+    const provisioner = requireTeamsProvisioner(
+      registryWith(createStubTeamsProvisioner().accessor),
+    );
+    const result = await provisioner.createAppRegistration({
+      displayName: 'HR Agent',
+      tenantMode: 'customer',
+    });
+    assert.equal(result.value.secretRef, 'teams_bot_password:app-0000');
+    assert.ok(!('secretText' in result.value));
+  });
+
+  it('strips cleartext-looking fields a mis-implemented provider attaches', async () => {
+    const stub = createStubTeamsProvisioner({
+      createAppRegistration: async (input) => ({
+        outcome: 'created',
+        value: {
+          appId: 'app-9',
+          secretRef: 'teams_bot_password:app-9',
+          registration: {
+            appId: 'app-9',
+            objectId: 'obj-9',
+            tenantId: 't-9',
+            tenantMode: 'customer',
+            signInAudience: 'AzureADMyOrg',
+            displayName: input.displayName,
+          },
+          secretKeyId: 'key-9',
+          secretEndDateTime: '2028-01-01T00:00:00Z',
+          servicePrincipalOutcome: 'created',
+          // A provider bug leaking the cleartext across the boundary:
+          secretText: 'S3CR3T-value',
+          clientSecret: 'S3CR3T-value',
+        } as never,
+      }),
+    });
+    const provisioner = requireTeamsProvisioner(registryWith(stub.accessor));
+
+    const result = await provisioner.createAppRegistration({
+      displayName: 'Leaky',
+      tenantMode: 'customer',
+    });
+
+    assert.ok(!('secretText' in result.value));
+    assert.ok(!('clientSecret' in result.value));
+    assert.ok(!JSON.stringify(result).includes('S3CR3T-value'));
+    // The legitimate fields survive the strip.
+    assert.equal(result.value.appId, 'app-9');
+    assert.equal(result.value.secretRef, 'teams_bot_password:app-9');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Typed-error guards (duck-typed across the plugin boundary)
+// ---------------------------------------------------------------------------
+
+function connectorError(
+  name: string,
+  fields: Record<string, unknown>,
+): Error {
+  const err = new Error(name);
+  err.name = name;
+  Object.assign(err, fields);
+  return err;
+}
+
+describe('connector error guards', () => {
+  it('recognises ConsentMissingError by name + structured fields', () => {
+    const err = connectorError('ConsentMissingError', {
+      missingScopes: ['Application.ReadWrite.OwnedBy'],
+      resource: 'graph',
+    });
+    assert.equal(isConsentMissingError(err), true);
+    if (isConsentMissingError(err)) {
+      assert.deepEqual(err.missingScopes, ['Application.ReadWrite.OwnedBy']);
+    }
+    assert.equal(isConsentMissingError(new Error('ConsentMissingError')), false);
+    assert.equal(isConsentMissingError(undefined), false);
+  });
+
+  it('recognises ProvisioningThrottledError with and without a retry hint', () => {
+    const withHint = connectorError('ProvisioningThrottledError', {
+      resource: 'arm',
+      retryAfterSeconds: 42,
+    });
+    const withoutHint = connectorError('ProvisioningThrottledError', {
+      resource: 'graph',
+    });
+    assert.equal(isProvisioningThrottledError(withHint), true);
+    if (isProvisioningThrottledError(withHint)) {
+      assert.equal(withHint.retryAfterSeconds, 42);
+    }
+    assert.equal(isProvisioningThrottledError(withoutHint), true);
+    assert.equal(isProvisioningThrottledError(new Error('other')), false);
+  });
+
+  it('recognises ArmNotConfiguredError and its missing setup fields', () => {
+    const err = connectorError('ArmNotConfiguredError', {
+      missingSetupFields: ['azure_subscription_id'],
+    });
+    assert.equal(isArmNotConfiguredError(err), true);
+    assert.equal(
+      isArmNotConfiguredError(connectorError('ArmNotConfiguredError', {})),
+      false,
+    );
+  });
+
+  it('isTeamsProvisionerError covers the taxonomy, nothing else', () => {
+    for (const name of [
+      'ConsentMissingError',
+      'ProvisioningThrottledError',
+      'ArmNotConfiguredError',
+      'CapabilityUnavailableError',
+      'AppPackageError',
+    ]) {
+      assert.equal(isTeamsProvisionerError(connectorError(name, {})), true, name);
+    }
+    assert.equal(isTeamsProvisionerError(new Error('boom')), false);
+    assert.equal(isTeamsProvisionerError('ConsentMissingError'), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Messaging endpoint URL builder
+// ---------------------------------------------------------------------------
+
+describe('buildTeamsBotMessagingEndpoint', () => {
+  it('builds the per-bot endpoint shipped in channel-teams 0.20.0', () => {
+    assert.equal(
+      buildTeamsBotMessagingEndpoint('https://bots.example.com', 'hr-agent'),
+      'https://bots.example.com/api/teams/hr-agent/messages',
+    );
+  });
+
+  it('normalises trailing slashes on the base', () => {
+    for (const base of [
+      'https://bots.example.com/',
+      'https://bots.example.com//',
+    ]) {
+      assert.equal(
+        buildTeamsBotMessagingEndpoint(base, 'hr-agent'),
+        'https://bots.example.com/api/teams/hr-agent/messages',
+      );
+    }
+  });
+
+  it('keeps a base path prefix intact', () => {
+    assert.equal(
+      buildTeamsBotMessagingEndpoint('https://example.com/omadia/', 'hr-agent'),
+      'https://example.com/omadia/api/teams/hr-agent/messages',
+    );
+  });
+
+  it('rejects non-https bases — the value is handed to Azure as the bot endpoint', () => {
+    for (const base of ['http://bots.example.com', 'ftp://bots.example.com']) {
+      assert.throws(
+        () => buildTeamsBotMessagingEndpoint(base, 'hr-agent'),
+        (err: unknown) => {
+          assert.ok(err instanceof TeamsMessagingEndpointError);
+          assert.equal(err.code, 'invalid_teams_messaging_endpoint');
+          assert.match(err.message, /https/);
+          return true;
+        },
+      );
+    }
+  });
+
+  it('rejects malformed bases, credentials, query strings and fragments', () => {
+    for (const base of [
+      'not a url',
+      'https://user:pw@bots.example.com',
+      'https://bots.example.com?x=1',
+      'https://bots.example.com#frag',
+    ]) {
+      assert.throws(
+        () => buildTeamsBotMessagingEndpoint(base, 'hr-agent'),
+        TeamsMessagingEndpointError,
+      );
+    }
+  });
+
+  it('rejects slugs that could re-shape the path', () => {
+    for (const slug of ['', 'a/b', '../up', 'a b', 'a?b', '.hidden', 'x'.repeat(65)]) {
+      assert.throws(
+        () => buildTeamsBotMessagingEndpoint('https://bots.example.com', slug),
+        TeamsMessagingEndpointError,
+        JSON.stringify(slug),
+      );
+    }
+  });
+
+  it('accepts dots, underscores and hyphens inside a slug', () => {
+    assert.equal(
+      buildTeamsBotMessagingEndpoint('https://bots.example.com', 'Agent_2.beta-1'),
+      'https://bots.example.com/api/teams/Agent_2.beta-1/messages',
+    );
+  });
+});

--- a/middleware/test/teamsProvisioningJob.test.ts
+++ b/middleware/test/teamsProvisioningJob.test.ts
@@ -190,6 +190,7 @@ function makeRunner(opts: {
   behaviour?: StubBehaviour;
   maxAttempts?: number;
   baseRetryDelayMs?: number;
+  maxRetryDelayMs?: number;
   getProvisioner?: () => TeamsProvisionerPort;
 } = {}): RunnerFixture {
   const store = makeStore(opts.storeOverrides);
@@ -204,6 +205,9 @@ function makeRunner(opts: {
     timers,
     maxAttempts: opts.maxAttempts ?? 5,
     baseRetryDelayMs: opts.baseRetryDelayMs ?? 1000,
+    ...(opts.maxRetryDelayMs !== undefined
+      ? { maxRetryDelayMs: opts.maxRetryDelayMs }
+      : {}),
     log: () => {},
   });
   return { runner, store, provisioner, timers };
@@ -602,5 +606,107 @@ describe('TeamsProvisioningJobRunner — in-process job semantics', () => {
     assert.equal(result.status, 'stopped');
     assert.equal(failures, 1, 'no further attempts after stop');
     assert.equal(store.row?.state, 'pending', 'stop must not fabricate progress');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wave-integration hardening (review findings of the W1a unit reviews)
+// ---------------------------------------------------------------------------
+
+describe('TeamsProvisioningJobRunner — wave-integration hardening', () => {
+  it('caps a ProvisioningThrottledError hint at maxRetryDelayMs', async () => {
+    let uploads = 0;
+    const { runner, timers } = makeRunner({
+      maxRetryDelayMs: 30_000,
+      behaviour: {
+        uploadToCatalog: () => {
+          uploads += 1;
+          if (uploads === 1) {
+            return Promise.reject(
+              namedError('ProvisioningThrottledError', '429 from Graph', {
+                resource: 'graph',
+                // An hour-scale hint (and far beyond the 32-bit setTimeout
+                // ceiling when multiplied) must not park the run.
+                retryAfterSeconds: 3_000_000,
+              }),
+            );
+          }
+          return undefined;
+        },
+      },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'installed');
+    assert.deepEqual(
+      timers.delays,
+      [30_000],
+      'the hint is honored only within the configured delay cap',
+    );
+  });
+
+  it('a stopAll → start cycle re-arms the runner (BackgroundJobRegistry restart)', async () => {
+    const { runner, provisioner } = makeRunner();
+    const job = runner.asBackgroundJob();
+    const handle = await job.start();
+    await handle.stop();
+    const stopped = await runner.enqueue(REQUEST);
+    assert.equal(stopped.status, 'stopped', 'stopped runner refuses work');
+    // Registry restart: start() must clear the stop flag.
+    await job.start();
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'installed');
+    assert.ok(
+      provisioner.calls.some((c) => c.startsWith('installToTeam')),
+      'the re-armed runner drives the chain again',
+    );
+  });
+
+  it('a concurrent enqueue for a DIFFERENT team is rejected, never handed the in-flight result', async () => {
+    let release: (() => void) | undefined;
+    const parked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { runner, provisioner } = makeRunner({
+      behaviour: { createAppRegistration: () => parked },
+    });
+    const first = runner.enqueue(REQUEST);
+    await Promise.resolve();
+    const conflicting = await runner.enqueue({
+      agentId: REQUEST.agentId,
+      teamId: 'team-OTHER',
+    });
+    assert.equal(conflicting.status, 'rejected');
+    assert.ok(
+      conflicting.status === 'rejected' && conflicting.reason === 'team_conflict',
+    );
+    release!();
+    const result = await first;
+    assert.equal(result.status, 'installed');
+    // Exactly one install, and it targeted the FIRST request's team.
+    const installs = provisioner.calls.filter((c) => c.startsWith('installToTeam'));
+    assert.deepEqual(installs, ['installToTeam:team-42:catalog-77']);
+  });
+
+  it('stop() during an in-flight accessor call ends the run at the next step boundary', async () => {
+    let release: (() => void) | undefined;
+    const parked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { runner, store, provisioner } = makeRunner({
+      behaviour: { createAppRegistration: () => parked },
+    });
+    const run = runner.enqueue(REQUEST);
+    await Promise.resolve();
+    runner.stop();
+    release!();
+    const result = await run;
+    assert.equal(result.status, 'stopped');
+    // Step 1 completed (its own store write lands), but no later step ran.
+    assert.equal(store.row?.state, 'app_registered');
+    assert.equal(
+      provisioner.calls.filter((c) => c.startsWith('createBot')).length,
+      0,
+      'no step starts after stop()',
+    );
   });
 });

--- a/middleware/test/teamsProvisioningJob.test.ts
+++ b/middleware/test/teamsProvisioningJob.test.ts
@@ -1,0 +1,606 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { TimerSeam } from '../src/plugins/jobScheduler.js';
+import {
+  TeamsProvisioningJobRunner,
+  type ProvisionTeamsIdentityRequest,
+  type TeamsAppPackageAssets,
+  type TeamsIdentityJobRecord,
+  type TeamsIdentityJobStore,
+  type TeamsIdentityJobUpdate,
+  type TeamsProvisionerPort,
+  type TeamsProvisioningState,
+} from '../src/services/teamsProvisioningJob.js';
+
+/**
+ * Unit-level runner tests with a stubbed accessor and a stubbed store, per
+ * the wave spec — no Postgres, no connector plugin. Timing is deterministic:
+ * the timer seam fires every setTimeout immediately while recording the
+ * requested delay, so retry/backoff behaviour (including the
+ * ProvisioningThrottledError retry hint) is asserted on recorded values,
+ * never on wall-clock waits.
+ */
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+interface RecordingTimers extends TimerSeam {
+  readonly delays: number[];
+}
+
+function immediateTimers(): RecordingTimers {
+  const delays: number[] = [];
+  return {
+    delays,
+    setTimeout(cb, ms) {
+      delays.push(ms);
+      cb();
+      return delays.length;
+    },
+    clearTimeout() {},
+    setInterval() {
+      throw new Error('runner must not use setInterval');
+    },
+    clearInterval() {},
+  };
+}
+
+interface MemoryStore extends TeamsIdentityJobStore {
+  row: TeamsIdentityJobRecord | undefined;
+  readonly updates: TeamsIdentityJobUpdate[];
+}
+
+function makeStore(overrides: Partial<TeamsIdentityJobRecord> = {}): MemoryStore {
+  const initial: TeamsIdentityJobRecord = {
+    agentId: 'agent-1',
+    botSlug: 'hr-bot',
+    displayName: 'HR Bot',
+    state: 'pending',
+    appId: null,
+    tenantId: null,
+    teamsAppId: null,
+    teamsAppExternalId: null,
+    lastError: null,
+    ...overrides,
+  };
+  const updates: TeamsIdentityJobUpdate[] = [];
+  const store: MemoryStore = {
+    row: initial,
+    updates,
+    async getByAgentId(agentId) {
+      return store.row?.agentId === agentId ? store.row : undefined;
+    },
+    async update(agentId, patch) {
+      assert.ok(store.row && store.row.agentId === agentId, 'row must exist');
+      updates.push(patch);
+      store.row = {
+        ...store.row,
+        ...(patch.state !== undefined ? { state: patch.state } : {}),
+        ...(patch.appId !== undefined ? { appId: patch.appId } : {}),
+        ...(patch.tenantId !== undefined ? { tenantId: patch.tenantId } : {}),
+        ...(patch.teamsAppId !== undefined ? { teamsAppId: patch.teamsAppId } : {}),
+        ...(patch.teamsAppExternalId !== undefined
+          ? { teamsAppExternalId: patch.teamsAppExternalId }
+          : {}),
+        ...(patch.lastError !== undefined ? { lastError: patch.lastError } : {}),
+      };
+      return store.row;
+    },
+  };
+  return store;
+}
+
+interface StubProvisioner extends TeamsProvisionerPort {
+  readonly calls: string[];
+}
+
+interface StubBehaviour {
+  createAppRegistration?: () => Promise<void> | void;
+  createBot?: 'registration-only' | (() => Promise<void> | void);
+  uploadToCatalog?: () => Promise<void> | void;
+  installToTeam?: () => Promise<void> | void;
+  catalogAppFound?: string;
+}
+
+function makeProvisioner(behaviour: StubBehaviour = {}): StubProvisioner {
+  const calls: string[] = [];
+  return {
+    calls,
+    async createAppRegistration(input) {
+      calls.push(`createAppRegistration:${input.uniqueName ?? input.displayName}`);
+      await behaviour.createAppRegistration?.();
+      return {
+        outcome: 'created',
+        value: { appId: 'app-123', registration: { tenantId: 'tenant-9' } },
+      };
+    },
+    async createBot(input) {
+      calls.push(`createBot:${input.botName}:${input.messagingEndpoint}`);
+      if (behaviour.createBot === 'registration-only') {
+        return {
+          kind: 'registration-only',
+          reason: 'arm-not-configured',
+          missingSetupFields: ['azureSubscriptionId', 'azureResourceGroup'],
+        };
+      }
+      await behaviour.createBot?.();
+      return { kind: 'provisioned', bot: { outcome: 'created', value: { botName: input.botName } } };
+    },
+    buildAppPackage() {
+      calls.push('buildAppPackage');
+      return new Uint8Array([80, 75]);
+    },
+    async uploadToCatalog(input) {
+      calls.push(`uploadToCatalog:${input.externalId}`);
+      await behaviour.uploadToCatalog?.();
+      return { outcome: 'created', value: { teamsAppId: 'catalog-77' } };
+    },
+    async getCatalogApp(input) {
+      calls.push(`getCatalogApp:${input.teamsAppExternalId}`);
+      if (behaviour.catalogAppFound) {
+        return { found: true, teamsAppId: behaviour.catalogAppFound };
+      }
+      return { found: false };
+    },
+    async installToTeam(input) {
+      calls.push(`installToTeam:${input.teamId}:${input.teamsAppId}`);
+      await behaviour.installToTeam?.();
+      return {
+        outcome: 'created',
+        value: { teamId: input.teamId, teamsAppId: input.teamsAppId },
+      };
+    },
+  };
+}
+
+const ASSETS: TeamsAppPackageAssets = {
+  manifestTemplate: '{"id":"{{APP_ID}}"}',
+  params: { APP_ID: 'app-123' },
+  icons: { color: new Uint8Array([1]), outline: new Uint8Array([2]) },
+  externalId: 'external-abc',
+};
+
+const REQUEST: ProvisionTeamsIdentityRequest = {
+  agentId: 'agent-1',
+  teamId: 'team-42',
+};
+
+function namedError(
+  name: string,
+  message: string,
+  extra: Record<string, unknown> = {},
+): Error {
+  const err = new Error(message);
+  err.name = name;
+  Object.assign(err, extra);
+  return err;
+}
+
+interface RunnerFixture {
+  runner: TeamsProvisioningJobRunner;
+  store: MemoryStore;
+  provisioner: StubProvisioner;
+  timers: RecordingTimers;
+}
+
+function makeRunner(opts: {
+  storeOverrides?: Partial<TeamsIdentityJobRecord>;
+  behaviour?: StubBehaviour;
+  maxAttempts?: number;
+  baseRetryDelayMs?: number;
+  getProvisioner?: () => TeamsProvisionerPort;
+} = {}): RunnerFixture {
+  const store = makeStore(opts.storeOverrides);
+  const provisioner = makeProvisioner(opts.behaviour);
+  const timers = immediateTimers();
+  const runner = new TeamsProvisioningJobRunner({
+    store,
+    getProvisioner: opts.getProvisioner ?? (() => provisioner),
+    buildMessagingEndpoint: (botSlug) =>
+      `https://mw.example.com/api/teams/${botSlug}/messages`,
+    loadPackageAssets: async () => ASSETS,
+    timers,
+    maxAttempts: opts.maxAttempts ?? 5,
+    baseRetryDelayMs: opts.baseRetryDelayMs ?? 1000,
+    log: () => {},
+  });
+  return { runner, store, provisioner, timers };
+}
+
+function statesWalked(store: MemoryStore): TeamsProvisioningState[] {
+  return store.updates
+    .map((u) => u.state)
+    .filter((s): s is TeamsProvisioningState => s !== undefined);
+}
+
+// ---------------------------------------------------------------------------
+// Happy path + resume
+// ---------------------------------------------------------------------------
+
+describe('TeamsProvisioningJobRunner — chain and resume', () => {
+  it('walks pending → … → installed and drives every accessor step', async () => {
+    const { runner, store, provisioner } = makeRunner();
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'installed');
+    assert.deepEqual(statesWalked(store), [
+      'app_registered',
+      'bot_created',
+      'package_built',
+      'catalog_uploaded',
+      'installed',
+    ]);
+    assert.deepEqual(provisioner.calls, [
+      'createAppRegistration:omadia-teams-bot-hr-bot',
+      'createBot:hr-bot:https://mw.example.com/api/teams/hr-bot/messages',
+      'getCatalogApp:external-abc',
+      'buildAppPackage',
+      'uploadToCatalog:external-abc',
+      'installToTeam:team-42:catalog-77',
+    ]);
+    assert.equal(store.row?.state, 'installed');
+    assert.equal(store.row?.appId, 'app-123');
+    assert.equal(store.row?.tenantId, 'tenant-9');
+    assert.equal(store.row?.teamsAppId, 'catalog-77');
+    assert.equal(store.row?.teamsAppExternalId, 'external-abc');
+    assert.equal(store.row?.lastError, null);
+  });
+
+  it('passes the injected messaging endpoint to createBot verbatim', async () => {
+    const { runner, provisioner } = makeRunner();
+    await runner.enqueue(REQUEST);
+    assert.ok(
+      provisioner.calls.includes(
+        'createBot:hr-bot:https://mw.example.com/api/teams/hr-bot/messages',
+      ),
+      'endpoint must come from the injected builder',
+    );
+  });
+
+  it('resumes from app_registered without re-registering the app', async () => {
+    const { runner, provisioner } = makeRunner({
+      storeOverrides: { state: 'app_registered', appId: 'app-old', tenantId: 't-old' },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'installed');
+    assert.ok(
+      !provisioner.calls.some((c) => c.startsWith('createAppRegistration')),
+      'createAppRegistration must not run again',
+    );
+    assert.ok(provisioner.calls.some((c) => c.startsWith('createBot:hr-bot')));
+  });
+
+  it('resumes from bot_created without re-creating the bot', async () => {
+    const { runner, provisioner } = makeRunner({
+      storeOverrides: { state: 'bot_created', appId: 'a', tenantId: 't' },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'installed');
+    assert.ok(!provisioner.calls.some((c) => c.startsWith('createBot')));
+    assert.ok(!provisioner.calls.some((c) => c.startsWith('createAppRegistration')));
+  });
+
+  it('resumes from catalog_uploaded straight to the install step', async () => {
+    const { runner, provisioner } = makeRunner({
+      storeOverrides: {
+        state: 'catalog_uploaded',
+        appId: 'a',
+        tenantId: 't',
+        teamsAppId: 'catalog-known',
+        teamsAppExternalId: 'external-abc',
+      },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'installed');
+    assert.deepEqual(provisioner.calls, ['installToTeam:team-42:catalog-known']);
+  });
+
+  it('reuses an existing catalog app instead of uploading again', async () => {
+    const { runner, store, provisioner } = makeRunner({
+      storeOverrides: { state: 'package_built', appId: 'a', tenantId: 't', teamsAppExternalId: 'external-abc' },
+      behaviour: { catalogAppFound: 'catalog-existing' },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'installed');
+    assert.ok(!provisioner.calls.some((c) => c.startsWith('uploadToCatalog')));
+    assert.equal(store.row?.teamsAppId, 'catalog-existing');
+  });
+
+  it('a row already installed is a no-op success', async () => {
+    const { runner, store, provisioner } = makeRunner({
+      storeOverrides: { state: 'installed', appId: 'a', tenantId: 't', teamsAppId: 'c' },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'installed');
+    assert.deepEqual(provisioner.calls, []);
+    assert.deepEqual(store.updates, []);
+  });
+
+  it('resumes from failed using evidence columns, without re-creating', async () => {
+    const { runner, store, provisioner } = makeRunner({
+      storeOverrides: {
+        state: 'failed',
+        appId: 'app-kept',
+        tenantId: 'tenant-kept',
+        lastError: 'consent_missing: …',
+      },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'installed');
+    assert.ok(
+      !provisioner.calls.some((c) => c.startsWith('createAppRegistration')),
+      'existing registration must be reused',
+    );
+    assert.equal(store.row?.state, 'installed');
+    assert.equal(store.row?.appId, 'app-kept');
+    assert.equal(store.row?.lastError, null);
+  });
+
+  it('fails the run when no identity row exists', async () => {
+    const { runner } = makeRunner({ maxAttempts: 1 });
+    const result = await runner.enqueue({ agentId: 'ghost', teamId: 'team-42' });
+    assert.equal(result.status, 'failed');
+    assert.ok(
+      result.status === 'failed' && result.detail.includes("no teams identity row"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Typed-error policy
+// ---------------------------------------------------------------------------
+
+describe('TeamsProvisioningJobRunner — connector error policy', () => {
+  it('ConsentMissingError is terminal: state failed, scopes recorded, no retry', async () => {
+    const { runner, store, provisioner } = makeRunner({
+      behaviour: {
+        createAppRegistration: () =>
+          Promise.reject(
+            namedError('ConsentMissingError', '403 from Graph', {
+              missingScopes: ['Application.ReadWrite.All', 'AppCatalog.ReadWrite.All'],
+              resource: 'graph',
+            }),
+          ),
+      },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'failed');
+    assert.equal(result.status === 'failed' && result.reason, 'consent_missing');
+    assert.equal(store.row?.state, 'failed');
+    assert.ok(store.row?.lastError?.includes('Application.ReadWrite.All'));
+    assert.ok(store.row?.lastError?.includes('AppCatalog.ReadWrite.All'));
+    assert.equal(
+      provisioner.calls.filter((c) => c.startsWith('createAppRegistration')).length,
+      1,
+      'terminal failure must not be retried',
+    );
+  });
+
+  it("ArmNotConfigured ('registration-only' outcome) keeps app_registered with actionable last_error", async () => {
+    const { runner, store } = makeRunner({ behaviour: { createBot: 'registration-only' } });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'halted');
+    assert.ok(
+      result.status === 'halted' &&
+        result.missingSetupFields.includes('azureSubscriptionId'),
+    );
+    assert.equal(store.row?.state, 'app_registered');
+    assert.ok(store.row?.lastError?.includes('arm_not_configured'));
+    assert.ok(store.row?.lastError?.includes('azureSubscriptionId'));
+    assert.ok(
+      store.row?.lastError?.includes('re-run'),
+      'last_error must tell the operator how to proceed',
+    );
+    // The registration survives — nothing is torn down.
+    assert.equal(store.row?.appId, 'app-123');
+  });
+
+  it('a thrown ArmNotConfiguredError gets the same non-terminal treatment', async () => {
+    const { runner, store } = makeRunner({
+      behaviour: {
+        createBot: () =>
+          Promise.reject(
+            namedError('ArmNotConfiguredError', 'ARM not configured', {
+              missingSetupFields: ['azureSubscriptionId'],
+            }),
+          ),
+      },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'halted');
+    assert.equal(store.row?.state, 'app_registered');
+    assert.ok(store.row?.lastError?.includes('azureSubscriptionId'));
+  });
+
+  it('honors the ProvisioningThrottledError retryAfterSeconds hint', async () => {
+    let uploads = 0;
+    const { runner, timers } = makeRunner({
+      behaviour: {
+        uploadToCatalog: () => {
+          uploads += 1;
+          if (uploads === 1) {
+            return Promise.reject(
+              namedError('ProvisioningThrottledError', '429 from Graph', {
+                resource: 'graph',
+                retryAfterSeconds: 7,
+              }),
+            );
+          }
+          return undefined;
+        },
+      },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'installed');
+    assert.deepEqual(timers.delays, [7000], 'the hint, not the default backoff');
+  });
+
+  it('falls back to exponential backoff when the throttle carries no hint', async () => {
+    let attempts = 0;
+    const { runner, timers } = makeRunner({
+      baseRetryDelayMs: 1000,
+      behaviour: {
+        createBot: () => {
+          attempts += 1;
+          if (attempts <= 2) {
+            return Promise.reject(
+              namedError('ProvisioningThrottledError', '429', { resource: 'arm' }),
+            );
+          }
+          return undefined;
+        },
+      },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'installed');
+    assert.deepEqual(timers.delays, [1000, 2000]);
+  });
+
+  it('bounds throttle retries, keeps the reached state, and records the reason', async () => {
+    const { runner, store, timers } = makeRunner({
+      maxAttempts: 3,
+      behaviour: {
+        installToTeam: () =>
+          Promise.reject(
+            namedError('ProvisioningThrottledError', '429 from Graph', {
+              resource: 'graph',
+              retryAfterSeconds: 1,
+            }),
+          ),
+      },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'retries_exhausted');
+    assert.equal(timers.delays.length, 2, 'maxAttempts=3 → 2 delays between attempts');
+    assert.equal(
+      store.row?.state,
+      'catalog_uploaded',
+      'real progress is kept — throttling is not a provisioning failure',
+    );
+    assert.ok(store.row?.lastError?.includes('gave up after 3 attempts'));
+  });
+
+  it('a missing provisioner service is retryable and never marks the row failed', async () => {
+    const { runner, store } = makeRunner({
+      maxAttempts: 2,
+      getProvisioner: () => {
+        throw namedError('TeamsProvisionerUnavailableError', 'connector not installed', {
+          code: 'teams_provisioner_unavailable',
+        });
+      },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'retries_exhausted');
+    assert.equal(store.row?.state, 'pending', 'no progress faked, no failed state');
+    assert.ok(store.row?.lastError?.includes('connector not installed'));
+  });
+
+  it('unknown errors are retried and end in failed after maxAttempts', async () => {
+    let calls = 0;
+    const { runner, store, timers } = makeRunner({
+      maxAttempts: 2,
+      behaviour: {
+        createAppRegistration: () => {
+          calls += 1;
+          return Promise.reject(new Error('socket hang up'));
+        },
+      },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'failed');
+    assert.equal(calls, 2);
+    assert.equal(timers.delays.length, 1);
+    assert.equal(store.row?.state, 'failed');
+    assert.ok(store.row?.lastError?.includes('socket hang up'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// In-process job semantics
+// ---------------------------------------------------------------------------
+
+describe('TeamsProvisioningJobRunner — in-process job semantics', () => {
+  it('enqueue is deduplicated per agent: a concurrent enqueue joins the run', async () => {
+    let release: (() => void) | undefined;
+    const parked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { runner, provisioner } = makeRunner({
+      behaviour: {
+        createAppRegistration: () => parked,
+      },
+    });
+    // First enqueue parks inside createAppRegistration.
+    const first = runner.enqueue(REQUEST);
+    await Promise.resolve();
+    assert.equal(runner.isRunning('agent-1'), true);
+    const second = runner.enqueue(REQUEST);
+    assert.equal(first, second, 'same in-flight promise, no second chain');
+    assert.equal(
+      provisioner.calls.filter((c) => c.startsWith('createAppRegistration')).length,
+      1,
+    );
+    // Release the parked step; the run completes normally.
+    release!();
+    const result = await first;
+    assert.equal(result.status, 'installed');
+    assert.equal(runner.isRunning('agent-1'), false);
+  });
+
+  it('a finished run leaves the runner free for a follow-up enqueue', async () => {
+    const { runner, provisioner } = makeRunner();
+    const first = await runner.enqueue(REQUEST);
+    assert.equal(first.status, 'installed');
+    const second = await runner.enqueue(REQUEST);
+    assert.equal(second.status, 'installed');
+    // Second run is the no-op resume — installToTeam ran exactly once.
+    assert.equal(
+      provisioner.calls.filter((c) => c.startsWith('installToTeam')).length,
+      1,
+    );
+  });
+
+  it('stop() ends waiting runs without touching the store (BackgroundJob handle)', async () => {
+    let failures = 0;
+    const store = makeStore();
+    const provisioner = makeProvisioner({
+      createAppRegistration: () => {
+        failures += 1;
+        return Promise.reject(
+          namedError('ProvisioningThrottledError', '429', {
+            resource: 'graph',
+            retryAfterSeconds: 60,
+          }),
+        );
+      },
+    });
+    // Timer seam that never fires: the run parks in its retry sleep — then
+    // stop() must release it.
+    const runner = new TeamsProvisioningJobRunner({
+      store,
+      getProvisioner: () => provisioner,
+      buildMessagingEndpoint: (slug) =>
+        `https://mw.example.com/api/teams/${slug}/messages`,
+      loadPackageAssets: async () => ASSETS,
+      timers: {
+        setTimeout: () => 1, // never fires
+        clearTimeout: () => {},
+        setInterval: () => 1,
+        clearInterval: () => {},
+      },
+      log: () => {},
+    });
+    const job = runner.asBackgroundJob();
+    assert.equal(job.name, 'teams-identity-provisioning');
+    const handle = await job.start();
+    const run = runner.enqueue(REQUEST);
+    // Let the first attempt fail and the run park in its sleep.
+    await new Promise((r) => setImmediate(r));
+    await handle.stop();
+    const result = await run;
+    assert.equal(result.status, 'stopped');
+    assert.equal(failures, 1, 'no further attempts after stop');
+    assert.equal(store.row?.state, 'pending', 'stop must not fabricate progress');
+  });
+});


### PR DESCRIPTION
Completes wave **W1a (agent factory)** as one integration branch. Refs #863 #864 #865, part of #860.

An agent gets its own Microsoft Teams identity through the operator API — Entra app registration → Azure bot → Teams app package → tenant catalog upload → team install — with every Graph/ARM call inside the M365 connector plugin, never in the middleware.

## What's in here

**Merged from the wave's unit branches (reviewed by the workflow's cross-family reviewers):**
- `61ec8752` — async in-process provisioning job runner (`services/teamsProvisioningJob.ts`, 20 unit tests): idempotent resume from any state via evidence columns + the provisioner's already-existed signals; typed error policy (ConsentMissing → terminal `failed` with scopes; ArmNotConfigured → stays `app_registered` with actionable `last_error`; throttle/unavailable → bounded retries).
- `03c9a6d9` — operator endpoints + hub wiring (`POST/GET /api/v1/operator/agents/:slug/teams-identity`, `index.ts` mount, `TEAMS_PUBLIC_BASE_URL` config key, named `ServiceName` members, service-grant decision comment).

**New in this integration (the three units the workflow stalled on, plus reconciliation):**
- **Migration `0049_agent_teams_identities.sql`** — unique `agent_id` (one identity per agent), globally unique `bot_slug`, 7-state CHECK, step-evidence columns, `team_id` resume target, `created_at`/`updated_at`. No secret column, by design. Single `CREATE TABLE IF NOT EXISTS` → double-apply safe.
- **`platform/agentTeamsIdentityStore.ts`** — single writer of `state`/`last_error`; exports the canonical `TEAMS_PROVISIONING_STATES` union (runner + router now import it); surfaces query failures instead of inventing `pending`; `BotSlugTakenError` → 409.
- **`platform/teamsProvisionerService.ts`** (recovered from the stalled unit's worktree, verified + typecheck-fixed) — the one `serviceRegistry.get('teamsProvisioner')` call site (KERNEL_SERVICE_CALLER), mirrored connector contract v0.3.1 incl. `getCatalogApp`, duck-typed error guards, cleartext-secret stripping, SingleTenant guard, `buildTeamsBotMessagingEndpoint()`.
- **`services/teamsAppPackageAssets.ts`** — app-package inputs from the installed channel-teams package's `appPackage/` template (template-driven placeholder fill, deterministic per-agent catalog GUID).
- **Boot wiring in `index.ts`** — registers `agentTeamsIdentityStore` + `teamsProvisioningJobRunner` when Postgres is present, binds `TEAMS_PUBLIC_BASE_URL ?? PUBLIC_BASE_URL` into the URL builder, BackgroundJobRegistry lifecycle, boot-time resume of interrupted runs (`failed` stays parked until re-POST).

**Review findings from both unit reviews fixed here:**
- throttle `retryAfterSeconds` hints are capped at `maxRetryDelayMs` (and 32-bit `setTimeout` safe);
- `stop()`/`start()` re-arm across a BackgroundJobRegistry restart; stop-checks between chain steps;
- a concurrent enqueue for a **different team** is `rejected`, never handed the in-flight run's result;
- `teams_bot` status projection is now **camelCase and `parseTeamsBotsConfig`-compatible** (`botSlug`/`appId`/`tenantId`/`appPasswordSecretRef`), paste-ready for `teams_bots[]`;
- `bot_slug` bounded to 63 chars (channel-teams `BOT_SLUG_PATTERN`), derive-trim after the length cut;
- app-password ref is the connector's deterministic vault ref `teams_bot_password:<appId>` (keyed by appId, not slug — no cross-agent credential aliasing; DB-level `UNIQUE (bot_slug)` on top);
- POST reports `running` honestly and persists enqueue failures into `last_error`; 404/400 win over the provisioner 503.

## Spec deltas (declared)
- `team_id` column added beyond the spec's column list — boot resume needs the install target; it is not derivable.
- Secret custody follows the **shipped** connector contract v0.3.1: the client secret never crosses the service boundary (connector vault, opaque ref), so the middleware credential store is not involved; the spec's `addClientSecret` sketch is deprecated by the connector itself.
- `operatorAgents.ts` exceeds the file-size ceiling (pre-existing); extracting the teams-identity routes into their own module is a follow-up, as is the automatic `teams_bots[]` sync into the channel-teams plugin config.

## Gates
- `npm run typecheck` (all workspaces + golden + adversarial): green.
- `npm test`: 7443 tests, 0 failed, 16 skipped (pg suites skip without a test DB).
- Against scratch Postgres 16 (`GRAPH_PG_TEST_URL`): `agentTeamsIdentityStore.pg.test.ts` 9/9 (applies migration 0049 **twice**), `coreMigrations.pg.test.ts` 3/3 (all 49 files, double-apply).
- Focused suites: runner 24/24, accessor 22/22, router 42/42.

## Deploy note
Requires the `@omadia/integration-microsoft365` connector plugin **>= 0.3.1** (publishes `teamsProvisioner@1`) and a channel-teams package shipping `appPackage/` (W0a) for the package step. Without the connector the endpoints answer 503 `teams_provisioner_unavailable` and enqueued jobs stay retryable-pending — no crash. `TEAMS_PUBLIC_BASE_URL` is optional (falls back to `PUBLIC_BASE_URL`; must be https for Azure).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790318437&installation_model_id=428086&pr_number=877&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F877&signature=83b027b605ceeb64a266b05f404e7aa421fb3b895507aa8562f34dc59f76b433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->