### PR TITLE
fix: Fresh-Check-Button nur bei echtem Recall, nicht beim Chat-Tail

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,39 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — Teams answer card: honest badges and a Fresh-Check button that means something (#859, #878)
+
+2026-08-25/26 — Field report on a bare `ping` → `Pong.` turn: the card claimed
+"✓ Antwort geprüft", repeated the AI-Act disclosure sentence that the ✨
+AI-generated chip already carries, and offered "🔄 Fresh Check (ohne Memory)"
+on an answer no memory had touched. Three separate over-triggers, now closed.
+
+- **Verifier badge** (#859): `toSemanticAnswer` forwards it only when
+  `claimCount > 0`. With zero extracted claims — small talk, and the
+  pipeline-failure fallback, which reports `approved` with an empty claim list —
+  the badge asserted a verification that never ran.
+- **Disclosure sentence** (channel-teams 0.20.0): the kernel folds the AI-Act
+  marking into `SemanticAnswer.text` for wire-only channels; Teams marks the
+  answer itself, so the connector strips the folded line (keeping any
+  operator-authored addendum) before rendering and before the history append.
+- **Fresh-Check button** (#859 introduced `memoryUsed`, #878 fixed its meaning):
+  the flag first meant "a prior-context block existed", and that block always
+  carries the verbatim tail of the running chat — so the button never
+  disappeared. It now means memory could actually have changed the answer:
+  topical recall (`AssembledHit.origin !== 'tail'`), a cross-session
+  plan/process/insight, or a successful memory-file read. The live tail and the
+  read-convention's `/memories` directory listing do not count, and neither do
+  memory writes.
+
+Two implementation notes worth remembering. `AssembledHit.reason` is
+presentational — a boost rewrites it, so a boosted tail turn reads as
+`'agent-boost'`; the new sibling `origin` carries the delivering leg and is what
+the gate branches on. And the run trace records only
+`{callId, toolName, durationMs, isError}`, never the tool input, so the memory
+command + result are captured at dispatch onto a mutable turn-context holder —
+a plain field would be lost, because a privacy guard re-enters dispatch inside a
+shallow copy of the turn store.
+
 ### Added — agent factory: Teams identity provisioning via teamsProvisioner@1 (W1a, #860)
 
 - New CORE migration `0049_agent_teams_identities.sql`: one Teams identity per agent

--- a/middleware/packages/harness-channel-sdk/src/chatAgent.ts
+++ b/middleware/packages/harness-channel-sdk/src/chatAgent.ts
@@ -543,12 +543,18 @@ export interface ChatTurnResult {
    */
   recalled?: RecalledContext;
   /**
-   * True when this turn's answer could have been influenced by persisted
-   * memory: an injected prior-context block (session tail + FTS + entity
-   * recall) or a `memory`-tool call by the orchestrator. `toSemanticAnswer`
-   * forwards it to `SemanticAnswer.memoryUsed` so channels can gate their
-   * memory-bypass affordances (Teams' "🔄 Fresh Check" button). Omitted when
-   * no memory contributed — a fresh check would then be a no-op.
+   * True when persisted memory could actually have CHANGED this answer —
+   * topical recall (an entity / FTS hit from outside the live conversation
+   * window), a cross-session plan / process / insight, or a successful read of
+   * a memory file. `toSemanticAnswer` forwards it to
+   * `SemanticAnswer.memoryUsed` so channels can gate their memory-bypass
+   * affordances (Teams' "🔄 Fresh Check" button).
+   *
+   * Deliberately NOT set by the two things that happen on nearly every turn:
+   * the verbatim tail of the running conversation, and the read-convention's
+   * `/memories` directory listing. Neither would change under a memory-free
+   * re-run, so treating them as memory left the affordance permanently on.
+   * Omitted when nothing qualified — a fresh check would then be a no-op.
    */
   memoryUsed?: boolean;
   /**

--- a/middleware/packages/harness-channel-sdk/src/outgoing.ts
+++ b/middleware/packages/harness-channel-sdk/src/outgoing.ts
@@ -37,12 +37,16 @@ export interface SemanticAnswer {
   verifier?: VerifierBadge;
 
   /**
-   * True when this turn's answer could have been influenced by persisted
-   * memory: an injected prior-context block (session tail + FTS + entity
-   * recall) or a `memory`-tool call by the orchestrator. Connectors use this
-   * to gate memory-bypass affordances (Teams' "🔄 Fresh Check" button) —
-   * absent/false means a re-run without memory would be a no-op, so the
-   * affordance should not be offered.
+   * True when persisted memory could actually have CHANGED this answer —
+   * topical recall (an entity / FTS hit from outside the live conversation
+   * window), a cross-session plan / process / insight, or a successful read of
+   * a memory file. Connectors use it to gate memory-bypass affordances (Teams'
+   * "🔄 Fresh Check" button).
+   *
+   * The verbatim tail of the running conversation and the read-convention's
+   * `/memories` directory listing do NOT set it: they occur on nearly every
+   * turn and a memory-free re-run would not change the answer on either.
+   * Absent/false therefore means the affordance should not be offered.
    */
   memoryUsed?: boolean;
 

--- a/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
+++ b/middleware/packages/harness-orchestrator-extras/src/contextRetriever.ts
@@ -288,6 +288,9 @@ export type AssembledHitReason =
   | 'manual-boost'
   | 'agent-boost';
 
+/** The recall leg that produced a hit — never rewritten by a boost. */
+export type AssembledHitOrigin = 'tail' | 'entity' | 'fts';
+
 export interface AssembledHit {
   turnId: string;
   /** Final score after all multipliers (raw × manual × agent). */
@@ -296,8 +299,18 @@ export interface AssembledHit {
   chars: number;
   /** Which recall path delivered this hit / which multiplier boosted it,
    *  if any. `manual-boost` / `agent-boost` only override `entity`/`fts`
-   *  when relevant — the audit card shows the dominant reason. */
+   *  when relevant — the audit card shows the dominant reason.
+   *
+   *  PRESENTATIONAL. A boost overwrites the path that found the hit, so this
+   *  cannot answer "where did this come from" — use {@link origin} for that. */
   reason: AssembledHitReason;
+  /** Which leg actually delivered the hit, before any boost renamed it.
+   *  `'tail'` is the verbatim window of the CURRENT conversation; `'entity'`
+   *  and `'fts'` are topical recall the retriever went looking for. Unlike
+   *  {@link reason} this is never overwritten, so it is the field to branch on
+   *  when the distinction has to hold (e.g. the Fresh-Check gate, which must
+   *  not treat a boosted tail turn as recall). */
+  origin: AssembledHitOrigin;
 }
 
 export interface AssembledExclusion {
@@ -881,6 +894,7 @@ export class ContextRetriever {
         score: c.rawScore,
         chars: chunkChars,
         reason: pickReason(c),
+        origin: c.origin,
       });
       // Defensive: budget check on chars too (rounding can edge out the
       // token estimate by 1-2 tokens; chars cap is the hard ceiling).

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -1214,27 +1214,36 @@ Der Grund für diesen Modus: der User vermutet, dass dich ein früherer Memory-E
 }
 
 /**
- * True when a `memory` tool call READ a concrete memory file. Deliberately
- * narrower than "the memory tool ran":
+ * Prefix `MemoryToolHandler.formatFileContents` puts on a delivered file — the
+ * directory listing (`formatDirectoryListing`) and every error take a different
+ * shape. Both shipped memory plugins (`@omadia/memory`, its Postgres sibling)
+ * construct that SAME handler, so this recognises a real read across both.
+ */
+const MEMORY_FILE_CONTENT_PREFIX = "Here's the content of ";
+
+/**
+ * True when a `memory` tool call actually DELIVERED a memory file's contents.
+ * Deliberately narrower than "the memory tool ran":
  *
  *  - only `view` — a write (`create` / `str_replace` / `insert` / `delete` /
  *    `rename`) records what this turn learned, it does not feed the answer;
- *  - only a FILE path — the standing read-convention opens the `/memories`
- *    DIRECTORY on essentially every turn, so counting that would mark every
- *    answer as memory-fed and the Fresh-Check button would never disappear.
+ *  - only a FILE — the standing read-convention opens the `/memories` DIRECTORY
+ *    on essentially every turn, so counting that would mark every answer as
+ *    memory-fed and the Fresh-Check button would never disappear;
+ *  - only a SUCCESSFUL read — a `view` of a missing or invalid path contributed
+ *    nothing, so it must not arm the button either.
  *
- * A memory file is recognised by an extension on the last path segment, which
- * is what the memory namespace stores (`/memories/observations/foo.md`); an
- * extension-less path is treated as a directory, i.e. NOT a read. Ambiguity
- * therefore resolves toward hiding the affordance rather than showing a button
- * that cannot change the answer.
+ * All three fall out of matching the handler's own file-content prefix rather
+ * than guessing from the path (an extension test would both mis-read a dotted
+ * directory name and miss an extension-less file). A memory plugin that words
+ * its output differently under-arms the gate — the button hides rather than
+ * offering a re-run that cannot change the answer.
  */
-function isMemoryFileRead(input: unknown): boolean {
+function isMemoryFileRead(input: unknown, result: string): boolean {
   if (typeof input !== 'object' || input === null) return false;
-  const { command, path } = input as { command?: unknown; path?: unknown };
-  if (command !== 'view' || typeof path !== 'string') return false;
-  const lastSegment = path.split('/').pop() ?? '';
-  return /\.[A-Za-z0-9]+$/.test(lastSegment);
+  const { command } = input as { command?: unknown };
+  if (command !== 'view') return false;
+  return result.startsWith(MEMORY_FILE_CONTENT_PREFIX);
 }
 
 /**
@@ -2829,16 +2838,20 @@ export class Orchestrator {
           : briefingText.length > 0
             ? briefingText
             : result.text;
-      // Recall vs. tail. `AssembledHit.reason` is the retriever's own
-      // discriminator: `'tail'` is the verbatim window of THIS conversation,
-      // every other reason ('entity' / 'fts' / 'manual-boost' / 'agent-boost')
-      // is a topical hit the retriever went looking for. Only the latter — plus
-      // the cross-session plan/process/insight probe, which never enters
-      // `included` — is something a Fresh Check would actually strip away.
-      // The session briefing is deliberately NOT counted: it summarises the
-      // current session, which the tail already represents.
+      // Recall vs. tail. `AssembledHit.origin` is the leg that DELIVERED the
+      // hit: `'tail'` is the verbatim window of THIS conversation, `'entity'`
+      // and `'fts'` are topical recall the retriever went looking for. Only the
+      // latter — plus the cross-session plan/process/insight probe, which never
+      // enters `included` — is something a Fresh Check would actually strip
+      // away. The session briefing is deliberately NOT counted: it summarises
+      // the current session, which the tail already represents.
+      //
+      // `origin`, not the sibling `reason`: a boost REWRITES `reason`, so a
+      // tail turn that an `agentPriorities@1` entry boosts reports
+      // `'agent-boost'` and would arm the gate on tail alone — the exact case
+      // this gate exists to close.
       const recallUsed =
-        result.included.some((hit) => hit.reason !== 'tail') ||
+        result.included.some((hit) => hit.origin !== 'tail') ||
         hasRecalledContent(result.recalled);
       return {
         text: merged.length > 0 ? merged : undefined,
@@ -3293,6 +3306,10 @@ export class Orchestrator {
         // W2-1 (#544) — one component of the MCP pending-input store key. Never
         // the whole key; see TurnContextValue.sessionScope.
         sessionScope: sessionId,
+        // Fresh-Check gate. Installed here, at turn level, so the box is copied
+        // BY REFERENCE into every nested per-dispatch scope and a memory read
+        // reaches the reader that assembles this turn's result.
+        memoryFileRead: { value: false },
         ...(parent?.chatParticipants
           ? { chatParticipants: parent.chatParticipants }
           : {}),
@@ -4495,7 +4512,7 @@ export class Orchestrator {
           // memory-bypassing re-run cannot differ, so channels hide the button.
           const memoryUsed =
             recallUsed === true ||
-            turnContext.current()?.memoryFileRead === true;
+            turnContext.current()?.memoryFileRead?.value === true;
           return {
             answer: restoredAnswer,
             toolCalls,
@@ -5177,6 +5194,10 @@ export class Orchestrator {
       privacyForPrompt,
       input.userMessage,
     );
+    // `recallUsed` is deliberately not destructured here: the streaming path
+    // builds no `memoryUsed`, and its only consumer is the non-streaming Teams
+    // card (`toSemanticAnswer`). Wire it through with the flag if a streaming
+    // channel ever grows a Fresh-Check affordance.
     const { text: rawPriorContext, recalled } =
       await this.retrievePriorContext(input, wireUserMessage);
     // #361 — the recalled TEXT is LLM-bound wire content; mask through the
@@ -6642,11 +6663,15 @@ export class Orchestrator {
       if (!this.isToolAvailable(memoryAgentId)) {
         return `Error: tool \`${name}\` is unavailable — plugin \`${memoryAgentId}\` has not completed its connection/auth setup.`;
       }
-      if (isMemoryFileRead(input)) {
-        const ctx = turnContext.current();
-        if (ctx) ctx.memoryFileRead = true;
+      const result = await this.memoryToolHandler.handle(input);
+      // Arm the Fresh-Check gate only on a read that actually DELIVERED a file.
+      // Checked after the handler so a `view` of a missing/invalid path — which
+      // contributed nothing — does not mark the answer as memory-fed.
+      if (isMemoryFileRead(input, result)) {
+        const box = turnContext.current()?.memoryFileRead;
+        if (box) box.value = true;
       }
-      return this.memoryToolHandler.handle(input);
+      return result;
     }
     // Plugin-contributed handlers win first. Kernel branches below are the
     // legacy path for tools that have not yet been converted to

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -1214,6 +1214,44 @@ Der Grund für diesen Modus: der User vermutet, dass dich ein früherer Memory-E
 }
 
 /**
+ * True when a `memory` tool call READ a concrete memory file. Deliberately
+ * narrower than "the memory tool ran":
+ *
+ *  - only `view` — a write (`create` / `str_replace` / `insert` / `delete` /
+ *    `rename`) records what this turn learned, it does not feed the answer;
+ *  - only a FILE path — the standing read-convention opens the `/memories`
+ *    DIRECTORY on essentially every turn, so counting that would mark every
+ *    answer as memory-fed and the Fresh-Check button would never disappear.
+ *
+ * A memory file is recognised by an extension on the last path segment, which
+ * is what the memory namespace stores (`/memories/observations/foo.md`); an
+ * extension-less path is treated as a directory, i.e. NOT a read. Ambiguity
+ * therefore resolves toward hiding the affordance rather than showing a button
+ * that cannot change the answer.
+ */
+function isMemoryFileRead(input: unknown): boolean {
+  if (typeof input !== 'object' || input === null) return false;
+  const { command, path } = input as { command?: unknown; path?: unknown };
+  if (command !== 'view' || typeof path !== 'string') return false;
+  const lastSegment = path.split('/').pop() ?? '';
+  return /\.[A-Za-z0-9]+$/.test(lastSegment);
+}
+
+/**
+ * True when the cross-session recall probe surfaced anything at all. Shared by
+ * the `kg_recall` annotation (stay quiet on a cold start) and the Fresh-Check
+ * gate (a probe hit is memory a bypassing re-run would drop).
+ */
+function hasRecalledContent(recalled: RecalledContext | undefined): boolean {
+  if (!recalled) return false;
+  return (
+    recalled.plans.length > 0 ||
+    recalled.processes.length > 0 ||
+    recalled.insights.length > 0
+  );
+}
+
+/**
  * #579 — the refusal delivered when a turn is quarantined by inbound screening.
  * The turn never runs; this stands in for the model's answer. DE-first (the
  * assistant is German-first) with an EN line so wire-only channels stay honest.
@@ -2673,7 +2711,19 @@ export class Orchestrator {
     // text this returns flows INTO the LLM prompt, so the recall query must
     // not itself carry a raw PII span the mask pass just removed.
     wireUserMessage?: string,
-  ): Promise<{ text: string | undefined; recalled: RecalledContext | undefined }> {
+  ): Promise<{
+    text: string | undefined;
+    recalled: RecalledContext | undefined;
+    /**
+     * True when the assembled block carried RECALL — a topically-matched turn
+     * from outside the live conversation window (`reason !== 'tail'`) or a
+     * cross-session plan/process/insight. Drives the Fresh-Check affordance:
+     * the verbatim tail of the current chat is what the user can already see
+     * scrolling up, so a memory-bypassing re-run would not change the answer
+     * on tail alone. Absent on every early return — no retrieval, no recall.
+     */
+    recallUsed?: boolean;
+  }> {
     // Use console.error so the trace lands on stderr — Fly's log aggregator
     // has been observed to drop some stdout INFO lines under load, and this
     // is the one pathway we cannot afford to lose visibility on.
@@ -2779,9 +2829,21 @@ export class Orchestrator {
           : briefingText.length > 0
             ? briefingText
             : result.text;
+      // Recall vs. tail. `AssembledHit.reason` is the retriever's own
+      // discriminator: `'tail'` is the verbatim window of THIS conversation,
+      // every other reason ('entity' / 'fts' / 'manual-boost' / 'agent-boost')
+      // is a topical hit the retriever went looking for. Only the latter — plus
+      // the cross-session plan/process/insight probe, which never enters
+      // `included` — is something a Fresh Check would actually strip away.
+      // The session briefing is deliberately NOT counted: it summarises the
+      // current session, which the tail already represents.
+      const recallUsed =
+        result.included.some((hit) => hit.reason !== 'tail') ||
+        hasRecalledContent(result.recalled);
       return {
         text: merged.length > 0 ? merged : undefined,
         recalled: result.recalled,
+        ...(recallUsed ? { recallUsed: true } : {}),
       };
     } catch (err) {
       console.error(
@@ -2798,12 +2860,7 @@ export class Orchestrator {
   private toRecallAnnotationEvents(
     recalled: RecalledContext | undefined,
   ): ChatStreamEvent[] {
-    if (
-      !recalled ||
-      (recalled.plans.length === 0 &&
-        recalled.processes.length === 0 &&
-        recalled.insights.length === 0)
-    ) {
+    if (!recalled || !hasRecalledContent(recalled)) {
       return [];
     }
     return [
@@ -4077,7 +4134,7 @@ export class Orchestrator {
     // structured `recalled` payload rides out on the ChatTurnResult so
     // non-streaming channels (Teams) can render a recall card (the streaming
     // path emits it as a `kg_recall` annotation instead).
-    const { text: rawPriorContext, recalled } =
+    const { text: rawPriorContext, recalled, recallUsed } =
       await this.retrievePriorContext(input, wireUserMessage);
     // #361 — the recalled TEXT is LLM-bound wire content: it carries real
     // values persisted from earlier turns, so it is masked through the SAME
@@ -4427,17 +4484,18 @@ export class Orchestrator {
           const pendingSlotCard = this.drainPendingSlotCard();
           const pendingRoutineList = this.drainPendingRoutineList();
           const pendingOAuthConsent = this.drainConsentRequired();
-          // Fresh-Check gate (Teams "🔄 Fresh Check" button): memory influenced
-          // this answer when a prior-context block was injected (tail + FTS +
-          // entity recall) or the orchestrator's own `memory` tool ran. Without
-          // either, a memory-bypassing re-run cannot produce a different answer,
-          // so channels hide the affordance.
+          // Fresh-Check gate (Teams "🔄 Fresh Check" button). Memory influenced
+          // this answer when the retriever RECALLED something — a topical hit
+          // from outside the live window, or a cross-session plan/process/
+          // insight — or when the turn read a memory file. Deliberately NOT
+          // triggered by the two things that happen on nearly every turn: the
+          // verbatim tail of the current chat (the user can just scroll up; a
+          // fresh check would not change that answer) and the read-convention's
+          // `/memories` directory listing. Without a real memory contribution a
+          // memory-bypassing re-run cannot differ, so channels hide the button.
           const memoryUsed =
-            (priorContext !== undefined && priorContext.trim().length > 0) ||
-            (runTrace?.orchestratorToolCalls.some(
-              (tc) => tc.toolName === MEMORY_TOOL_NAME,
-            ) ??
-              false);
+            recallUsed === true ||
+            turnContext.current()?.memoryFileRead === true;
           return {
             answer: restoredAnswer,
             toolCalls,
@@ -6583,6 +6641,10 @@ export class Orchestrator {
       const memoryAgentId = this.nativeTools.get(MEMORY_TOOL_NAME)?.agentId;
       if (!this.isToolAvailable(memoryAgentId)) {
         return `Error: tool \`${name}\` is unavailable — plugin \`${memoryAgentId}\` has not completed its connection/auth setup.`;
+      }
+      if (isMemoryFileRead(input)) {
+        const ctx = turnContext.current();
+        if (ctx) ctx.memoryFileRead = true;
       }
       return this.memoryToolHandler.handle(input);
     }

--- a/middleware/packages/harness-orchestrator/src/turnContext.ts
+++ b/middleware/packages/harness-orchestrator/src/turnContext.ts
@@ -249,18 +249,27 @@ export interface TurnContextValue {
    */
   mcpInputSentinelMint?: McpInputSentinelMint;
   /**
-   * True once this turn READ a memory file (`memory` tool, `view` on a concrete
-   * file — not the `/memories` directory listing the read-convention performs on
-   * every turn, and not a write). Drives the Fresh-Check affordance: a re-run
-   * without memory can only differ when memory actually fed this answer.
+   * Set to `true` once this turn READ a memory file (`memory` tool, `view` on a
+   * concrete file — not the `/memories` directory listing the read-convention
+   * performs on every turn, and not a write). Drives the Fresh-Check affordance:
+   * a re-run without memory can only differ when memory actually fed the answer.
    *
    * Rides the turn context because the run trace deliberately records only
    * `{callId, toolName, durationMs, isError}` — the tool INPUT never reaches it,
    * so the command + path are observable at dispatch time and nowhere after.
-   * Written onto the LIVE store inside the turn scope (same technique as
-   * `mcpInputReplayNote`), read once when the turn result is assembled.
+   *
+   * Mutable holder, NOT a bare boolean, for the same reason as
+   * {@link subAgentBypassFlag}: with a privacy guard installed, `dispatchTool`
+   * re-enters a nested scope holding a SHALLOW COPY of this store, so a write to
+   * a plain field would land on the copy and be discarded when that scope
+   * returns — i.e. the flag would work only on guard-less hosts. The box is
+   * copied by reference, so the write survives.
+   *
+   * Installed once per turn, which deliberately makes a SUB-AGENT's memory read
+   * count for the parent turn too: the sub-agent's answer feeds the orchestrator's,
+   * so memory did reach the user either way.
    */
-  memoryFileRead?: boolean;
+  memoryFileRead?: { value: boolean };
 }
 
 const storage = new AsyncLocalStorage<TurnContextValue>();

--- a/middleware/packages/harness-orchestrator/src/turnContext.ts
+++ b/middleware/packages/harness-orchestrator/src/turnContext.ts
@@ -248,6 +248,19 @@ export interface TurnContextValue {
    * See {@link McpInputSentinelMint} for why this is not a string-shape check.
    */
   mcpInputSentinelMint?: McpInputSentinelMint;
+  /**
+   * True once this turn READ a memory file (`memory` tool, `view` on a concrete
+   * file — not the `/memories` directory listing the read-convention performs on
+   * every turn, and not a write). Drives the Fresh-Check affordance: a re-run
+   * without memory can only differ when memory actually fed this answer.
+   *
+   * Rides the turn context because the run trace deliberately records only
+   * `{callId, toolName, durationMs, isError}` — the tool INPUT never reaches it,
+   * so the command + path are observable at dispatch time and nowhere after.
+   * Written onto the LIVE store inside the turn scope (same technique as
+   * `mcpInputReplayNote`), read once when the turn result is assembled.
+   */
+  memoryFileRead?: boolean;
 }
 
 const storage = new AsyncLocalStorage<TurnContextValue>();

--- a/middleware/test/orchestrator/freshCheckGate.test.ts
+++ b/middleware/test/orchestrator/freshCheckGate.test.ts
@@ -91,25 +91,39 @@ const memoryToolMsg = (input: Record<string, unknown>): AnyMessage => ({
   stop_reason: 'tool_use',
 });
 
+// --- verbatim `MemoryToolHandler` output shapes ------------------------------
+// The gate reads the handler's own reply to tell a delivered file from a
+// directory listing or a failure, so the fakes have to speak its exact dialect.
+const DIR_LISTING = (path: string): string =>
+  `Here're the files and directories up to 2 levels deep in ${path}, excluding hidden items and node_modules:\n0B\t${path}/observations`;
+const FILE_CONTENT = (path: string): string =>
+  `Here's the content of ${path} with line numbers:\n     1\t# Routine`;
+const WRITE_OK = 'The memory file has been edited.';
+const READ_FAILED = 'Error: MemoryNotFoundError: no such file';
+
+type Origin = 'tail' | 'entity' | 'fts';
 type Reason = 'tail' | 'entity' | 'fts' | 'manual-boost' | 'agent-boost';
+
+type OrchestratorOpts = ConstructorParameters<typeof Orchestrator>[0];
 
 /**
  * Stand-in for the real `ContextRetriever`. The orchestrator only ever calls
  * `assembleForBudget` on it, so a one-method fake is the whole seam — and it
- * lets each case pin the exact `reason` mix the real retriever would emit.
+ * lets each case pin the exact origin/reason mix the real retriever would emit.
  */
 function fakeRetriever(opts: {
-  reasons: Reason[];
+  hits: Array<{ origin: Origin; reason?: Reason }>;
   insights?: number;
-}): NonNullable<ConstructorParameters<typeof Orchestrator>[0]['contextRetriever']> {
+}): NonNullable<OrchestratorOpts['contextRetriever']> {
   const retriever = {
     assembleForBudget: async () => ({
-      text: opts.reasons.length > 0 ? '## Letzte Turns in diesem Chat\n…' : '',
-      included: opts.reasons.map((reason, i) => ({
+      text: opts.hits.length > 0 ? '## Letzte Turns in diesem Chat\n…' : '',
+      included: opts.hits.map((hit, i) => ({
         turnId: `turn:scope-a:${String(i)}`,
         score: 1,
         chars: 10,
-        reason,
+        reason: hit.reason ?? hit.origin,
+        origin: hit.origin,
       })),
       excluded: [],
       recalled: {
@@ -122,18 +136,41 @@ function fakeRetriever(opts: {
           score: 0.9,
         })),
       },
-      stats: { candidatePool: opts.reasons.length, compactMode: false, tokensUsed: 42 },
+      stats: { candidatePool: opts.hits.length, compactMode: false, tokensUsed: 42 },
     }),
   };
-  return retriever as unknown as NonNullable<
-    ConstructorParameters<typeof Orchestrator>[0]['contextRetriever']
-  >;
+  return retriever as unknown as NonNullable<OrchestratorOpts['contextRetriever']>;
+}
+
+/** Minimal `privacy.redact@1` service — enough that the orchestrator mints a
+ *  privacy handle, which is what makes `dispatchTool` re-enter a nested scope
+ *  holding a SHALLOW COPY of the turn store. */
+function stubPrivacyGuard(): NonNullable<OrchestratorOpts['privacyGuard']> {
+  // Every member `privacyHandle.ts` reaches for — a missing one throws rather
+  // than degrading, and the point of this stub is only to make the handle exist.
+  const service = {
+    v4ToolSpecs: () => [],
+    runV4Tool: async () => ({ text: '[v4]' }),
+    internToolResultV4: async () => ({ digestText: '[digest]', datasetId: 'ds-1' }),
+    subAgentResultV4: async () => ({ digestText: '[digest]' }),
+    takeRenderedAnswerV4: () => undefined,
+    recordBypassedTool: async () => undefined,
+    // The prompt-masking members are OPTIONAL on the contract; omitting them
+    // makes the handle report `disabled` and keeps this stub about the one
+    // thing under test — that a privacy handle EXISTS, which is what makes
+    // dispatch re-enter a nested (shallow-copied) turn scope.
+    finalizeTurn: async () => undefined,
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return () => service as any;
 }
 
 function buildOrchestrator(opts: {
   messages: AnyMessage[];
-  reasons?: Reason[];
+  hits?: Array<{ origin: Origin; reason?: Reason }>;
   insights?: number;
+  memoryResult?: string;
+  withPrivacyGuard?: boolean;
 }): Orchestrator {
   return new Orchestrator({
     provider: fakeCreateProvider(opts.messages),
@@ -143,31 +180,47 @@ function buildOrchestrator(opts: {
     domainTools: [],
     nativeToolRegistry: new NativeToolRegistry(),
     contextRetriever: fakeRetriever({
-      reasons: opts.reasons ?? [],
+      hits: opts.hits ?? [],
       ...(opts.insights !== undefined ? { insights: opts.insights } : {}),
     }),
     memoryToolHandler: {
-      handle: async () => 'ok',
+      handle: async () => opts.memoryResult ?? WRITE_OK,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any,
+    ...(opts.withPrivacyGuard ? { privacyGuard: stubPrivacyGuard() } : {}),
   });
 }
 
 const turn = { userMessage: 'ping', sessionScope: 'scope-a' };
+const TAIL_ONLY: Array<{ origin: Origin }> = [
+  { origin: 'tail' },
+  { origin: 'tail' },
+];
 
 describe('Fresh-Check gate — recalled context vs. the live tail', () => {
   it('stays off when the block carried ONLY the current chat tail', async () => {
     // The field-reported case: "ping" → "Pong." in a running conversation.
     const orch = buildOrchestrator({
       messages: [textMsg('Pong.')],
-      reasons: ['tail', 'tail', 'tail'],
+      hits: TAIL_ONLY,
     });
     const result = await orch.runTurn(turn);
     assert.equal(result.memoryUsed, undefined);
   });
 
   it('stays off when nothing was retrieved at all', async () => {
-    const orch = buildOrchestrator({ messages: [textMsg('Pong.')], reasons: [] });
+    const orch = buildOrchestrator({ messages: [textMsg('Pong.')], hits: [] });
+    const result = await orch.runTurn(turn);
+    assert.equal(result.memoryUsed, undefined);
+  });
+
+  it('stays off for a tail turn whose `reason` an agent-priority boost rewrote', async () => {
+    // `reason` is presentational — a boost overwrites the leg that found the
+    // hit. Branching on it would arm the gate on a pure-tail turn.
+    const orch = buildOrchestrator({
+      messages: [textMsg('Pong.')],
+      hits: [{ origin: 'tail', reason: 'agent-boost' }],
+    });
     const result = await orch.runTurn(turn);
     assert.equal(result.memoryUsed, undefined);
   });
@@ -175,7 +228,7 @@ describe('Fresh-Check gate — recalled context vs. the live tail', () => {
   it('arms on an FTS hit alongside the tail', async () => {
     const orch = buildOrchestrator({
       messages: [textMsg('Antwort.')],
-      reasons: ['tail', 'fts'],
+      hits: [{ origin: 'tail' }, { origin: 'fts' }],
     });
     const result = await orch.runTurn(turn);
     assert.equal(result.memoryUsed, true);
@@ -184,7 +237,7 @@ describe('Fresh-Check gate — recalled context vs. the live tail', () => {
   it('arms on an entity hit (recall from other sessions by construction)', async () => {
     const orch = buildOrchestrator({
       messages: [textMsg('Antwort.')],
-      reasons: ['entity'],
+      hits: [{ origin: 'entity' }],
     });
     const result = await orch.runTurn(turn);
     assert.equal(result.memoryUsed, true);
@@ -195,7 +248,7 @@ describe('Fresh-Check gate — recalled context vs. the live tail', () => {
     // own block, so the gate has to read the recall probe separately.
     const orch = buildOrchestrator({
       messages: [textMsg('Antwort.')],
-      reasons: ['tail'],
+      hits: TAIL_ONLY,
       insights: 1,
     });
     const result = await orch.runTurn(turn);
@@ -207,7 +260,8 @@ describe('Fresh-Check gate — memory tool calls', () => {
   it('stays off for the read-convention `/memories` directory listing', async () => {
     const orch = buildOrchestrator({
       messages: [memoryToolMsg({ command: 'view', path: '/memories' }), textMsg('Pong.')],
-      reasons: ['tail'],
+      hits: TAIL_ONLY,
+      memoryResult: DIR_LISTING('/memories'),
     });
     const result = await orch.runTurn(turn);
     assert.equal(result.memoryUsed, undefined);
@@ -219,7 +273,8 @@ describe('Fresh-Check gate — memory tool calls', () => {
         memoryToolMsg({ command: 'view', path: '/memories/observations' }),
         textMsg('Pong.'),
       ],
-      reasons: ['tail'],
+      hits: TAIL_ONLY,
+      memoryResult: DIR_LISTING('/memories/observations'),
     });
     const result = await orch.runTurn(turn);
     assert.equal(result.memoryUsed, undefined);
@@ -234,10 +289,37 @@ describe('Fresh-Check gate — memory tool calls', () => {
         }),
         textMsg('Antwort.'),
       ],
-      reasons: ['tail'],
+      hits: TAIL_ONLY,
+      memoryResult: FILE_CONTENT('/memories/observations/urlaubsantraege-routine.md'),
     });
     const result = await orch.runTurn(turn);
     assert.equal(result.memoryUsed, true);
+  });
+
+  it('arms on an extension-less memory file — the RESULT decides, not the path', async () => {
+    const orch = buildOrchestrator({
+      messages: [
+        memoryToolMsg({ command: 'view', path: '/memories/observations/urlaub' }),
+        textMsg('Antwort.'),
+      ],
+      hits: TAIL_ONLY,
+      memoryResult: FILE_CONTENT('/memories/observations/urlaub'),
+    });
+    const result = await orch.runTurn(turn);
+    assert.equal(result.memoryUsed, true);
+  });
+
+  it('stays off when the read FAILED — nothing was contributed', async () => {
+    const orch = buildOrchestrator({
+      messages: [
+        memoryToolMsg({ command: 'view', path: '/memories/weg.md' }),
+        textMsg('Pong.'),
+      ],
+      hits: TAIL_ONLY,
+      memoryResult: READ_FAILED,
+    });
+    const result = await orch.runTurn(turn);
+    assert.equal(result.memoryUsed, undefined);
   });
 
   it('stays off for a memory WRITE — it records the turn, it does not feed it', async () => {
@@ -251,7 +333,44 @@ describe('Fresh-Check gate — memory tool calls', () => {
         }),
         textMsg('Notiert.'),
       ],
-      reasons: ['tail'],
+      hits: TAIL_ONLY,
+      memoryResult: WRITE_OK,
+    });
+    const result = await orch.runTurn(turn);
+    assert.equal(result.memoryUsed, undefined);
+  });
+});
+
+describe('Fresh-Check gate — survives the privacy guard (regression)', () => {
+  // With a `privacy.redact@1` provider installed — the production
+  // configuration — `dispatchTool` re-enters a nested turn scope holding a
+  // SHALLOW COPY of the store. A memory read recorded on a plain field would
+  // land on that copy and be discarded when the scope returns, so the gate
+  // would work only on guard-less hosts. The flag is a mutable holder for
+  // exactly this reason; without it this test fails and the others do not.
+  it('still arms on a memory file read when a privacy guard is installed', async () => {
+    const orch = buildOrchestrator({
+      messages: [
+        memoryToolMsg({ command: 'view', path: '/memories/observations/routine.md' }),
+        textMsg('Antwort.'),
+      ],
+      hits: TAIL_ONLY,
+      memoryResult: FILE_CONTENT('/memories/observations/routine.md'),
+      withPrivacyGuard: true,
+    });
+    const result = await orch.runTurn(turn);
+    assert.equal(result.memoryUsed, true);
+  });
+
+  it('still stays off on a tail-only turn when a privacy guard is installed', async () => {
+    const orch = buildOrchestrator({
+      messages: [
+        memoryToolMsg({ command: 'view', path: '/memories' }),
+        textMsg('Pong.'),
+      ],
+      hits: TAIL_ONLY,
+      memoryResult: DIR_LISTING('/memories'),
+      withPrivacyGuard: true,
     });
     const result = await orch.runTurn(turn);
     assert.equal(result.memoryUsed, undefined);

--- a/middleware/test/orchestrator/freshCheckGate.test.ts
+++ b/middleware/test/orchestrator/freshCheckGate.test.ts
@@ -1,0 +1,259 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import type {
+  ContentPart,
+  LlmProvider,
+  LlmRequest,
+  LlmResponse,
+  LlmStreamEvent,
+} from '@omadia/llm-provider';
+import { NativeToolRegistry, Orchestrator } from '@omadia/orchestrator';
+
+/**
+ * Fresh-Check gate (`ChatTurnResult.memoryUsed`) — what the Teams card renders
+ * its "🔄 Fresh Check (ohne Memory)" button from.
+ *
+ * The rule under test: the button appears only when memory could actually have
+ * changed the answer. The verbatim tail of the running conversation and the
+ * read-convention's `/memories` directory listing happen on nearly every turn
+ * and must NOT arm it — that was the field report (a bare "ping" → "Pong."
+ * turn still offered a fresh check).
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyMessage = any;
+
+const providerCapabilities = {
+  tools: true,
+  vision: true,
+  streaming: true,
+  promptCaching: true,
+  forcedToolChoice: true,
+  parallelToolCalls: true,
+} as const;
+
+function toLlmResponse(msg: AnyMessage): LlmResponse {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const content: ContentPart[] = (msg.content as any[]).map((block) => {
+    if (block.type === 'text') {
+      return { type: 'text', text: block.text as string };
+    }
+    return {
+      type: 'tool_call',
+      id: block.id as string,
+      name: block.name as string,
+      input: block.input,
+    };
+  });
+  const stopReason = msg.stop_reason as string;
+  return {
+    content,
+    finishReason: stopReason === 'tool_use' ? 'tool_calls' : 'stop',
+    providerFinishReason: stopReason,
+    model: 'test',
+    usage: {
+      inputTokens: 10,
+      outputTokens: 1,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    },
+  };
+}
+
+function fakeCreateProvider(messages: AnyMessage[]): LlmProvider {
+  let idx = 0;
+  const provider = {
+    id: 'anthropic',
+    capabilities: providerCapabilities,
+    complete: async (_req: LlmRequest): Promise<LlmResponse> => {
+      const m = messages[idx];
+      idx += 1;
+      return toLlmResponse(m);
+    },
+    stream: (): AsyncIterable<LlmStreamEvent> => {
+      throw new Error('fakeCreateProvider: stream() not scripted');
+    },
+    classifyError: () => ({ retryable: false, kind: 'other' as const }),
+  };
+  return provider as unknown as LlmProvider;
+}
+
+const textMsg = (text: string): AnyMessage => ({
+  role: 'assistant',
+  content: [{ type: 'text', text }],
+  stop_reason: 'end_turn',
+});
+
+const memoryToolMsg = (input: Record<string, unknown>): AnyMessage => ({
+  role: 'assistant',
+  content: [{ type: 'tool_use', id: 'mem-1', name: 'memory', input }],
+  stop_reason: 'tool_use',
+});
+
+type Reason = 'tail' | 'entity' | 'fts' | 'manual-boost' | 'agent-boost';
+
+/**
+ * Stand-in for the real `ContextRetriever`. The orchestrator only ever calls
+ * `assembleForBudget` on it, so a one-method fake is the whole seam — and it
+ * lets each case pin the exact `reason` mix the real retriever would emit.
+ */
+function fakeRetriever(opts: {
+  reasons: Reason[];
+  insights?: number;
+}): NonNullable<ConstructorParameters<typeof Orchestrator>[0]['contextRetriever']> {
+  const retriever = {
+    assembleForBudget: async () => ({
+      text: opts.reasons.length > 0 ? '## Letzte Turns in diesem Chat\n…' : '',
+      included: opts.reasons.map((reason, i) => ({
+        turnId: `turn:scope-a:${String(i)}`,
+        score: 1,
+        chars: 10,
+        reason,
+      })),
+      excluded: [],
+      recalled: {
+        plans: [],
+        processes: [],
+        insights: Array.from({ length: opts.insights ?? 0 }, (_, i) => ({
+          mkId: `mk-${String(i)}`,
+          kind: 'observation',
+          summary: 'etwas aus einer früheren Session',
+          score: 0.9,
+        })),
+      },
+      stats: { candidatePool: opts.reasons.length, compactMode: false, tokensUsed: 42 },
+    }),
+  };
+  return retriever as unknown as NonNullable<
+    ConstructorParameters<typeof Orchestrator>[0]['contextRetriever']
+  >;
+}
+
+function buildOrchestrator(opts: {
+  messages: AnyMessage[];
+  reasons?: Reason[];
+  insights?: number;
+}): Orchestrator {
+  return new Orchestrator({
+    provider: fakeCreateProvider(opts.messages),
+    model: 'test',
+    maxTokens: 1024,
+    maxToolIterations: 5,
+    domainTools: [],
+    nativeToolRegistry: new NativeToolRegistry(),
+    contextRetriever: fakeRetriever({
+      reasons: opts.reasons ?? [],
+      ...(opts.insights !== undefined ? { insights: opts.insights } : {}),
+    }),
+    memoryToolHandler: {
+      handle: async () => 'ok',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+  });
+}
+
+const turn = { userMessage: 'ping', sessionScope: 'scope-a' };
+
+describe('Fresh-Check gate — recalled context vs. the live tail', () => {
+  it('stays off when the block carried ONLY the current chat tail', async () => {
+    // The field-reported case: "ping" → "Pong." in a running conversation.
+    const orch = buildOrchestrator({
+      messages: [textMsg('Pong.')],
+      reasons: ['tail', 'tail', 'tail'],
+    });
+    const result = await orch.runTurn(turn);
+    assert.equal(result.memoryUsed, undefined);
+  });
+
+  it('stays off when nothing was retrieved at all', async () => {
+    const orch = buildOrchestrator({ messages: [textMsg('Pong.')], reasons: [] });
+    const result = await orch.runTurn(turn);
+    assert.equal(result.memoryUsed, undefined);
+  });
+
+  it('arms on an FTS hit alongside the tail', async () => {
+    const orch = buildOrchestrator({
+      messages: [textMsg('Antwort.')],
+      reasons: ['tail', 'fts'],
+    });
+    const result = await orch.runTurn(turn);
+    assert.equal(result.memoryUsed, true);
+  });
+
+  it('arms on an entity hit (recall from other sessions by construction)', async () => {
+    const orch = buildOrchestrator({
+      messages: [textMsg('Antwort.')],
+      reasons: ['entity'],
+    });
+    const result = await orch.runTurn(turn);
+    assert.equal(result.memoryUsed, true);
+  });
+
+  it('arms on a cross-session insight even when `included` is tail-only', async () => {
+    // Plans/processes/insights never enter `included` — they render as their
+    // own block, so the gate has to read the recall probe separately.
+    const orch = buildOrchestrator({
+      messages: [textMsg('Antwort.')],
+      reasons: ['tail'],
+      insights: 1,
+    });
+    const result = await orch.runTurn(turn);
+    assert.equal(result.memoryUsed, true);
+  });
+});
+
+describe('Fresh-Check gate — memory tool calls', () => {
+  it('stays off for the read-convention `/memories` directory listing', async () => {
+    const orch = buildOrchestrator({
+      messages: [memoryToolMsg({ command: 'view', path: '/memories' }), textMsg('Pong.')],
+      reasons: ['tail'],
+    });
+    const result = await orch.runTurn(turn);
+    assert.equal(result.memoryUsed, undefined);
+  });
+
+  it('stays off for a sub-directory listing', async () => {
+    const orch = buildOrchestrator({
+      messages: [
+        memoryToolMsg({ command: 'view', path: '/memories/observations' }),
+        textMsg('Pong.'),
+      ],
+      reasons: ['tail'],
+    });
+    const result = await orch.runTurn(turn);
+    assert.equal(result.memoryUsed, undefined);
+  });
+
+  it('arms when an actual memory FILE was read', async () => {
+    const orch = buildOrchestrator({
+      messages: [
+        memoryToolMsg({
+          command: 'view',
+          path: '/memories/observations/urlaubsantraege-routine.md',
+        }),
+        textMsg('Antwort.'),
+      ],
+      reasons: ['tail'],
+    });
+    const result = await orch.runTurn(turn);
+    assert.equal(result.memoryUsed, true);
+  });
+
+  it('stays off for a memory WRITE — it records the turn, it does not feed it', async () => {
+    const orch = buildOrchestrator({
+      messages: [
+        memoryToolMsg({
+          command: 'str_replace',
+          path: '/memories/observations/notiz.md',
+          old_str: 'a',
+          new_str: 'b',
+        }),
+        textMsg('Notiert.'),
+      ],
+      reasons: ['tail'],
+    });
+    const result = await orch.runTurn(turn);
+    assert.equal(result.memoryUsed, undefined);
+  });
+});


### PR DESCRIPTION
Feldtest-Nachtrag zu #859: die Karte zeigte den Button **„🔄 Fresh Check (ohne Memory)"** auch bei einem blanken `ping` → `Pong.`-Turn.

## Ursache

`memoryUsed` war `true`, sobald überhaupt ein Prior-Context-Block existierte — und der trägt **immer** den wörtlichen Tail des laufenden Chats. Damit war das Gate praktisch immer offen. Live-Log des gemeldeten Turns:

```
[context] assembled scope=teams-19:abc8af8ec… pool=8 included=8 … rendered=8793B
```

Ein Fresh Check hätte diese Antwort nicht ändern können — der Tail ist genau das, was der User beim Hochscrollen ohnehin sieht.

## Fix

`memoryUsed` heißt jetzt: *Memory hätte diese Antwort ändern können.*

| zählt | zählt **nicht** |
|---|---|
| topischer Treffer (`reason !== 'tail'`: entity / fts / manual-boost) | wörtlicher Tail des laufenden Chats (`reason === 'tail'`) |
| Cross-Session-Probe (plans / processes / insights) | Session-Briefing (fasst zusammen, was der Tail schon zeigt) |
| `memory`-Tool: `view` auf eine **Datei** | `memory`-Tool: `view` auf das `/memories`-**Verzeichnis** (Lese-Konvention, läuft fast jeden Turn) |
| | `memory`-Schreibzugriffe (halten fest, was der Turn gelernt hat — sie speisen ihn nicht) |

Zwei Details:

- Der Discriminator ist die vom Retriever selbst exportierte `AssembledHit.reason` — keine neue Heuristik. Die Cross-Session-Probe landet nie in `included` und wird deshalb separat gelesen.
- Der Run-Trace speichert bewusst nur `{callId, toolName, durationMs, isError}` — der Tool-**Input** erreicht ihn nie. Command + Pfad werden daher am Dispatch auf den Turn-Context geschrieben (gleiche Technik wie `mcpInputReplayNote`) und beim Zusammenbau des Ergebnisses einmal gelesen.

`hasRecalledContent` teilt sich die Leerprüfung jetzt mit der `kg_recall`-Annotation, die dieselbe Bedingung inline hatte.

## Kein Channel-Change

Teams gated seinen Button bereits auf `memoryUsed` (#859) und ist der einzige Consumer des Feldes — die Semantik-Verengung wirkt ohne Plugin-Release.

## Tests

Neu: `test/orchestrator/freshCheckGate.test.ts` — 9 End-to-End-Fälle gegen den echten Orchestrator (gefakter Retriever + Memory-Tool), inklusive des gemeldeten Tail-only-Falls. Regression: 333 Tests der Orchestrator-/Gate-/Disclosure-/Recall-Suiten grün, lint + typecheck sauber.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790326996&installation_model_id=428086&pr_number=878&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F878&signature=99fb39b7bb465681c240f08fce911b35093476cbf19a385cf89593858c3a9b0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->