### PR TITLE
fix(#882): augment kernel PATH so npm-based CLI install/builder work on desktop

### DIFF
--- a/desktop/src/pathEnv.ts
+++ b/desktop/src/pathEnv.ts
@@ -1,0 +1,100 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const UNIX_BIN_DIRS = [
+  '/opt/homebrew/bin',
+  '/opt/homebrew/sbin',
+  '/usr/local/bin',
+  '/usr/local/sbin',
+  '/usr/bin',
+  '/bin',
+  '/usr/sbin',
+  '/sbin',
+] as const;
+
+export function mergePath(basePath: string | undefined, extraDirs: readonly string[]): string {
+  const mergedEntries = [...splitPath(basePath), ...extraDirs];
+  const seen = new Set<string>();
+  const uniqueEntries: string[] = [];
+
+  for (const entry of mergedEntries) {
+    if (seen.has(entry)) continue;
+    seen.add(entry);
+    uniqueEntries.push(entry);
+  }
+
+  return uniqueEntries.join(path.delimiter);
+}
+
+export function resolveAugmentedPath(
+  basePath: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+  homeDir: string = os.homedir(),
+): string {
+  if (platform === 'win32') {
+    // Windows GUI apps inherit the user's full registry-backed PATH, so the
+    // launcher-truncated PATH problem is specific to macOS/Linux.
+    return basePath ?? '';
+  }
+
+  if (platform !== 'darwin' && platform !== 'linux') {
+    return basePath ?? '';
+  }
+
+  const candidateDirs = [
+    ...UNIX_BIN_DIRS,
+    ...(platform === 'linux' ? ['/snap/bin'] : []),
+    path.join(homeDir, '.volta', 'bin'),
+    path.join(homeDir, '.asdf', 'shims'),
+  ];
+  const extraDirs = existingDirs(candidateDirs);
+  const nvmBinDir = resolveNvmBinDir(homeDir);
+
+  if (nvmBinDir && safeExists(nvmBinDir)) {
+    extraDirs.push(nvmBinDir);
+  }
+
+  return mergePath(basePath, extraDirs);
+}
+
+function splitPath(basePath: string | undefined): string[] {
+  return (basePath ?? '').split(path.delimiter).filter((entry) => entry.length > 0);
+}
+
+function existingDirs(candidateDirs: readonly string[]): string[] {
+  return candidateDirs.filter((candidateDir) => safeExists(candidateDir));
+}
+
+function safeExists(candidatePath: string): boolean {
+  try {
+    return fs.existsSync(candidatePath);
+  } catch {
+    return false;
+  }
+}
+
+function resolveNvmBinDir(homeDir: string): string | null {
+  try {
+    const defaultAliasPath = path.join(homeDir, '.nvm', 'alias', 'default');
+    const defaultAlias = fs.readFileSync(defaultAliasPath, 'utf8').trim();
+    if (!isLiteralNodeVersion(defaultAlias)) return null;
+
+    const versionsDir = path.join(homeDir, '.nvm', 'versions', 'node');
+    const versionEntries = fs.readdirSync(versionsDir).sort();
+    const exactMatch = versionEntries.find((entry) => entry === defaultAlias);
+    if (exactMatch) return path.join(versionsDir, exactMatch, 'bin');
+
+    const versionPrefix = defaultAlias.startsWith('v') ? defaultAlias : `v${defaultAlias}`;
+    const prefixMatch = versionEntries.find((entry) => entry.startsWith(versionPrefix));
+    return prefixMatch ? path.join(versionsDir, prefixMatch, 'bin') : null;
+  } catch {
+    // nvm is optional per-user tooling; any missing/unreadable state is skipped
+    // silently so app boot never depends on probing it.
+    return null;
+  }
+}
+
+function isLiteralNodeVersion(value: string): boolean {
+  return /^(?:v)?\d+(?:\.\d+)*$/.test(value);
+}

--- a/desktop/src/supervisor.ts
+++ b/desktop/src/supervisor.ts
@@ -13,6 +13,9 @@ import { findFreePorts, isPortFree } from './ports';
 import { startEmbeddedDb, EmbeddedDb } from './embeddedDb';
 import { credentialKeychainKey, vaultKey, allProviderKeys } from './secrets';
 import { log } from './log';
+import { resolveAugmentedPath } from './pathEnv';
+
+const augmentedPath = resolveAugmentedPath(process.env['PATH']);
 
 export type BootPhase =
   | 'starting-db'
@@ -140,6 +143,7 @@ export class Supervisor extends EventEmitter {
   private kernelEnv(port: number): NodeJS.ProcessEnv {
     const env: NodeJS.ProcessEnv = {
       ...process.env,
+      PATH: augmentedPath,
       ELECTRON_RUN_AS_NODE: '1',
       NODE_ENV: 'production',
       PORT: String(port),
@@ -178,6 +182,7 @@ export class Supervisor extends EventEmitter {
   private uiEnv(uiPort: number, kernelPort: number): NodeJS.ProcessEnv {
     return {
       ...process.env,
+      PATH: augmentedPath,
       ELECTRON_RUN_AS_NODE: '1',
       NODE_ENV: 'production',
       PORT: String(uiPort),

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,47 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — desktop app augments PATH for forked children (#882)
+
+2026-08-27 — The Electron desktop supervisor used the OS launcher's inherited
+environment as-is when spawning the kernel and web-ui children. On macOS that
+can mean launchd's minimal `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`), so bare
+`npm` lookups inside the kernel failed with `ENOENT` even when Node tooling was
+installed through Homebrew, Volta, asdf, or nvm. The desktop package now
+computes one augmented PATH at app start, merges existing entries first, adds
+only existing well-known tool directories, best-effort resolves nvm's default
+version without shelling out, and injects the result into both child-process
+env builders so every `execFile('npm', ...)` inside the kernel inherits the
+same corrected lookup path.
+
+### Fixed — builder boot observes template install failures and classifies them (#882)
+
+2026-08-27 — The Plugin Builder boot path started `ensureBuildTemplate(...)`
+eagerly, but the promise's logging `.catch(...)` re-threw before any observer
+was attached. When the boot-time template `npm install` failed, Node emitted a
+spurious `unhandledRejection` long before the first real build awaited the same
+promise. The boot wiring now attaches a separate no-op observer to mark that
+promise as handled without altering it, and `BuildPipeline.run()` re-throws a
+rejected `templateReady` gate as `BuildPipelineError('template_not_ready', …)`.
+That keeps the original cause for the real consumer while recording the failure
+phase honestly instead of degrading to `unknown`.
+
+### Fixed — CLI install failure says what actually happened, manual steps carry the prefix (#882)
+
+2026-08-27 — When the kernel could not find `npm` at all, the subscription-CLI
+install failed with no output, and the UI still rendered "npm install failed —
+see the log tail." above an empty `<pre>`: it pointed the operator at a log that
+did not exist. `cliInstallService` now classifies the failure —
+`cli_install.no_output` when npm produced nothing (the command was most likely
+not found) and `cli_install.npm_failed` when it ran and failed — and returns the
+code on the install-status poll. The install box renders through the shared
+`<ErrorHelp>` catalogue instead of its own raw-log block, so both cases get a
+localized what/next line with the server's text moved into the redacted support
+disclosure. The manual-install instructions were also incomplete: they showed a
+bare `npm install -g …` that installs somewhere the server never looks, so
+`detectCliBackends()` now exposes `cliToolsDir` and the shown command carries
+`--prefix <cliToolsDir>`.
+
 ### Added — chat-context memory ACL: per-team/channel/user agent memory (#860 W5, design #870)
 
 2026-08-27 — Agent memory was isolated per AGENT but not per CHAT CONTEXT. What an agent

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -4718,6 +4718,9 @@ async function main(): Promise<void> {
       console.error(`[builder] build template setup failed: ${message}`);
       throw err;
     });
+  // Mark the same boot-time promise as observed so Node does not emit a
+  // spurious unhandledRejection before BuildPipeline.run() awaits it later.
+  void templateReady.catch(() => {});
 
   const builderBuildPipeline = new BuildPipeline({
     draftStore,

--- a/middleware/src/platform/cliBackendDetector.ts
+++ b/middleware/src/platform/cliBackendDetector.ts
@@ -281,6 +281,8 @@ export interface CliBackendsSnapshot {
   readonly backends: ReadonlyArray<CliBackendStatus>;
   /** Epoch ms when this snapshot was produced. */
   readonly generatedAt: number;
+  /** Runtime install prefix so the UI can show accurate manual-install instructions. */
+  readonly cliToolsDir: string;
 }
 
 let cache: CliBackendsSnapshot | undefined;
@@ -298,7 +300,7 @@ export async function detectCliBackends(
     return cache;
   }
   const backends = await Promise.all(CLI_BACKENDS.map((s) => detectOne(s)));
-  cache = { backends, generatedAt: now };
+  cache = { backends, generatedAt: now, cliToolsDir: cliToolsDir() };
   return cache;
 }
 

--- a/middleware/src/platform/cliInstallService.ts
+++ b/middleware/src/platform/cliInstallService.ts
@@ -39,6 +39,8 @@ export interface CliInstallStatus {
   readonly cliId: string;
   readonly status: CliInstallState;
   readonly error?: string;
+  /** Machine-readable classifier the UI maps to install-help text. */
+  readonly code?: string;
   /** Last lines of npm output — enough to diagnose a failure from the UI. */
   readonly logTail?: string;
   readonly startedAt?: number;
@@ -65,6 +67,7 @@ interface InstallJob {
   readonly startedAt: number;
   finishedAt?: number;
   error?: string;
+  code?: string;
   logTail?: string;
 }
 
@@ -168,12 +171,21 @@ export async function startCliInstall(
         }
       } else {
         job.status = 'failed';
-        job.error = 'npm install failed — see the log tail.';
+        if (job.logTail) {
+          job.code = 'cli_install.npm_failed';
+          job.error = 'npm install failed — see the log tail.';
+        } else {
+          job.code = 'cli_install.no_output';
+          job.error = 'npm install failed — no output at all; npm was most likely not found.';
+        }
       }
     })
     .catch((err: unknown) => {
       job.finishedAt = Date.now();
       job.status = 'failed';
+      // A thrown runner error still has a concrete failure message, so keep it
+      // on the generic npm-failed help path rather than the "no output" one.
+      job.code = 'cli_install.npm_failed';
       job.error = err instanceof Error ? err.message : String(err);
     });
 
@@ -189,6 +201,7 @@ export function getCliInstallStatus(cliId: string): CliInstallStatus {
     cliId,
     status: current.status,
     ...(current.error ? { error: current.error } : {}),
+    ...(current.code ? { code: current.code } : {}),
     ...(current.logTail ? { logTail: current.logTail } : {}),
     startedAt: current.startedAt,
     ...(current.finishedAt ? { finishedAt: current.finishedAt } : {}),

--- a/middleware/src/plugins/builder/buildPipeline.ts
+++ b/middleware/src/plugins/builder/buildPipeline.ts
@@ -29,6 +29,7 @@ import type { Draft } from './types.js';
  *   - `draft_not_found` — store returned null (auth scope check)
  *   - `spec_invalid`    — Zod parse failed
  *   - `codegen_failed`  — CodegenError from generate()
+ *   - `template_not_ready` — boot-time build-template install failed
  *   - `staging_failed`  — disk-write or symlink error during prepareStagingDir
  *
  * `run()` does NOT throw on tsc failures — those surface as
@@ -100,7 +101,8 @@ export interface BuildStatusSnapshot {
    * `complete` on success; the failure stage otherwise. For build-produced
    * failures this is the `BuildFailureReason` (`tsc` | `timeout` | …); for
    * pre-build throws it is the `BuildPipelineError` code (`codegen_failed` |
-   * `staging_failed` | `spec_invalid` | `draft_not_found`) or `unknown`.
+   * `template_not_ready` | `staging_failed` | `spec_invalid` |
+   * `draft_not_found`) or `unknown`.
    */
   phase: string;
   /** Monotonic build counter for the build this snapshot describes; absent
@@ -119,6 +121,7 @@ export class BuildPipelineError extends Error {
     | 'draft_not_found'
     | 'spec_invalid'
     | 'codegen_failed'
+    | 'template_not_ready'
     | 'staging_failed';
   override readonly cause?: unknown;
   constructor(
@@ -257,7 +260,15 @@ export class BuildPipeline {
     const buildN = ++this.buildCounter;
 
     if (this.templateReady) {
-      await this.templateReady;
+      try {
+        await this.templateReady;
+      } catch (err) {
+        throw new BuildPipelineError(
+          'template_not_ready',
+          `BuildPipeline: build template not ready for draft '${opts.draftId}' (buildN=${String(buildN)}); boot-time npm install likely failed`,
+          err,
+        );
+      }
     }
 
     let stagingDir: string;

--- a/middleware/test/builder/buildPipeline.test.ts
+++ b/middleware/test/builder/buildPipeline.test.ts
@@ -22,7 +22,12 @@ import {
   build,
   type BuildExecutionResult,
 } from '../../src/plugins/builder/buildSandbox.js';
+import {
+  BuildPipeline,
+  BuildPipelineError,
+} from '../../src/plugins/builder/buildPipeline.js';
 import { BuildQueue } from '../../src/plugins/builder/buildQueue.js';
+import { DraftStore } from '../../src/plugins/builder/draftStore.js';
 
 /**
  * End-to-end smoke test for the Builder pipeline:
@@ -242,6 +247,83 @@ describe('Builder pipeline (B.1 codegen → B.2 build)', () => {
       assert.equal(buildResult.errors[1]?.code, 'TS7006');
       assert.equal(buildResult.errors[0]?.path, 'toolkit.ts');
       assert.equal(buildResult.errors[0]?.line, 169);
+    }
+  });
+
+  it('classifies a rejected templateReady gate without leaking an unhandled rejection', async () => {
+    const dbPath = path.join(
+      tmp,
+      `drafts-${String(Date.now())}-${String(Math.random())}.db`,
+    );
+    const store = new DraftStore({ dbPath });
+    await store.open();
+    const onUnhandledRejectionReasons: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      onUnhandledRejectionReasons.push(reason);
+    };
+
+    try {
+      const minimalSpec = JSON.parse(
+        readFileSync(
+          path.join(import.meta.dirname, 'fixtures', 'minimal-spec.json'),
+          'utf-8',
+        ),
+      ) as Record<string, unknown>;
+      const slots = minimalSpec['slots'] as Record<string, string>;
+      const { slots: _ignored, ...specInput } = minimalSpec;
+      void _ignored;
+      const draft = await store.create('alice@example.com', 'Weather');
+      await store.update('alice@example.com', draft.id, {
+        spec: specInput,
+        slots,
+      });
+
+      const templateError = new Error('boot-time npm install failed');
+      const templateReady = Promise.reject(templateError);
+      void templateReady.catch(() => {});
+      process.on('unhandledRejection', onUnhandledRejection);
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      let sandboxCalls = 0;
+      const pipeline = new BuildPipeline({
+        draftStore: store,
+        buildQueue: new BuildQueue({ concurrency: 1 }),
+        templateRoot: path.join(tmp, 'template-not-ready-root'),
+        stagingBaseDir: path.join(tmp, 'template-not-ready-staging'),
+        templateReady,
+        buildSandbox: async () => {
+          sandboxCalls += 1;
+          return {
+            ok: true,
+            zip: Buffer.from('PK-stub'),
+            zipPath: '/tmp/fake.zip',
+            durationMs: 5,
+          };
+        },
+        logger: () => {},
+      });
+
+      await assert.rejects(
+        pipeline.run({
+          userEmail: 'alice@example.com',
+          draftId: draft.id,
+        }),
+        (err: unknown) => {
+          assert.ok(err instanceof BuildPipelineError);
+          assert.equal(err.code, 'template_not_ready');
+          assert.equal(err.cause, templateError);
+          assert.match(err.message, /boot-time npm install likely failed/);
+          return true;
+        },
+      );
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      assert.equal(sandboxCalls, 0);
+      assert.deepEqual(onUnhandledRejectionReasons, []);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+      await store.close();
     }
   });
 });

--- a/middleware/test/builder/buildPipeline.test.ts
+++ b/middleware/test/builder/buildPipeline.test.ts
@@ -272,9 +272,10 @@ describe('Builder pipeline (B.1 codegen → B.2 build)', () => {
       const slots = minimalSpec['slots'] as Record<string, string>;
       const { slots: _ignored, ...specInput } = minimalSpec;
       void _ignored;
+      const spec = parseAgentSpec(specInput);
       const draft = await store.create('alice@example.com', 'Weather');
       await store.update('alice@example.com', draft.id, {
-        spec: specInput,
+        spec,
         slots,
       });
 

--- a/middleware/test/cliBackendDetector.test.ts
+++ b/middleware/test/cliBackendDetector.test.ts
@@ -8,6 +8,7 @@ import { CLI_ENV_SCRUB_KEYS } from '../packages/harness-orchestrator/src/cliChat
 
 import {
   detectCliBackends,
+  cliToolsDir,
   scrubbedEnv,
   __resetCliBackendCache,
 } from '../src/platform/cliBackendDetector.js';
@@ -69,6 +70,11 @@ describe('cliBackendDetector', () => {
       assert.equal(b.loggedIn, 'no');
       assert.ok(snap.generatedAt > 0, `generatedAt missing while ${b.id} is absent`);
     }
+  });
+
+  it('includes the runtime install prefix in every snapshot', async () => {
+    const snap = await detectCliBackends({ force: true });
+    assert.equal(snap.cliToolsDir, cliToolsDir());
   });
 
   it('caches within the TTL and re-detects on force', async () => {

--- a/middleware/test/cliInstallService.test.ts
+++ b/middleware/test/cliInstallService.test.ts
@@ -122,13 +122,27 @@ describe('cliInstallService', () => {
     assert.deepEqual(seenArgs, ['install', '-g', '--prefix', dir, '@openai/codex@1.2.3']);
   });
 
-  it('a failed npm run surfaces status failed with a diagnosable log tail', async () => {
+  it('a failed npm run with log output reports npm_failed and preserves the log-tail message', async () => {
     __setCliInstallRunner(async () => ({ ok: false, output: 'npm ERR! EAI_AGAIN registry' }));
     await startCliInstall('codex', '1.2.3');
     const done = await waitForTerminal('codex');
     assert.equal(done.status, 'failed');
-    assert.ok(done.error);
+    assert.equal(done.code, 'cli_install.npm_failed');
+    assert.equal(done.error, 'npm install failed — see the log tail.');
     assert.match(done.logTail ?? '', /EAI_AGAIN/);
+  });
+
+  it('a failed npm run with no output reports no_output instead of pointing at an empty log tail', async () => {
+    __setCliInstallRunner(async () => ({ ok: false, output: '' }));
+    await startCliInstall('codex', '1.2.3');
+    const done = await waitForTerminal('codex');
+    assert.equal(done.status, 'failed');
+    assert.equal(done.code, 'cli_install.no_output');
+    assert.equal(
+      done.error,
+      'npm install failed — no output at all; npm was most likely not found.',
+    );
+    assert.equal(done.logTail, undefined);
   });
 
   it('reserves the single-flight slot across the idempotency probe (no TOCTOU race)', async () => {

--- a/middleware/test/cliInstallService.test.ts
+++ b/middleware/test/cliInstallService.test.ts
@@ -48,6 +48,7 @@ const NOTHING_INSTALLED = {
       installable: true,
     },
   ],
+  cliToolsDir: cliToolsDir(),
   generatedAt: 0,
 };
 

--- a/web-ui/app/_lib/__tests__/errorHelpCoverage.test.ts
+++ b/web-ui/app/_lib/__tests__/errorHelpCoverage.test.ts
@@ -70,10 +70,18 @@ const COVERED_ROUTE_FILES = [
  * covering it would silently claim copy for every one of the ~20 `package.*`
  * codes the ingest service can emit, and a coverage guard that overclaims is
  * worse than one with an honest boundary.
+ *
+ * `cli_install.no_output` and `cli_install.npm_failed` are set by
+ * `startCliInstall` in `middleware/src/platform/cliInstallService.ts` and
+ * reach the UI on the `GET /v1/admin/cli-backends/:id/install/status` poll
+ * response, not on an error envelope from a covered route file. A route scan
+ * can therefore never discover them.
  */
 const NON_ROUTE_CODES = [
   'providers.key_rejected',
   'package.id_conflict_bundled',
+  'cli_install.no_output',
+  'cli_install.npm_failed',
 ] as const;
 
 /**

--- a/web-ui/app/_lib/api.ts
+++ b/web-ui/app/_lib/api.ts
@@ -529,6 +529,7 @@ export interface CliBackendStatus {
 
 export interface CliBackendsResponse {
   backends: CliBackendStatus[];
+  cliToolsDir: string;
   generatedAt: number;
 }
 
@@ -584,6 +585,7 @@ export type CliInstallState = 'idle' | 'running' | 'succeeded' | 'failed';
 export interface CliInstallStatus {
   cliId: string;
   status: CliInstallState;
+  code?: string;
   error?: string;
   logTail?: string;
 }

--- a/web-ui/app/_lib/errorHelp.ts
+++ b/web-ui/app/_lib/errorHelp.ts
@@ -15,14 +15,15 @@
  * code-to-copy indirection as `SCAN_FAILURE_CODES` in scanFailure.ts — no
  * third pattern is invented here.
  *
- * SCOPE. The catalogue covers the codes emitted by five route files:
- * `install.ts`, `runtime.ts`, `adminProviders.ts`, `store.ts` and
- * `adminSettings.ts`, plus `providers.key_rejected`, which the credential
- * verifier sets rather than a route. The rest of the middleware's codes are
- * deliberately not covered yet.
+ * SCOPE. The catalogue covers the codes emitted by six route files:
+ * `install.ts`, `runtime.ts`, `runtimeGrants.ts`, `adminProviders.ts`,
+ * `store.ts` and `adminSettings.ts`, plus the non-route codes
+ * `providers.key_rejected`, `package.id_conflict_bundled` and
+ * `cli_install.*`, which their services set rather than a route file. The
+ * rest of the middleware's codes are deliberately not covered yet.
  *
  * `__tests__/errorHelpCoverage.test.ts` holds the scope to that promise. It
- * reads `code: '…'` literals out of the five files, FOLLOWS `install.ts`'s
+ * reads `code: '…'` literals out of the six files, FOLLOWS `install.ts`'s
  * `handleError` into `plugins/installService.ts` for the codes it re-emits
  * from a thrown `InstallError`, and fails on any `code:` in a covered file
  * that is neither a literal nor a registered, explained non-literal. Within
@@ -55,6 +56,11 @@ export const ERROR_HELP_CODES = [
   'install.not_installed',
   'install.unexpected',
   'install.wrong_state',
+  // cli_install.* — set by startCliInstall in
+  // middleware/src/platform/cliInstallService.ts and returned on the
+  // install-status poll response, not on an error envelope.
+  'cli_install.no_output',
+  'cli_install.npm_failed',
   // adminProviders.ts (+ providerCredentialVerifier.ts for key_rejected)
   'providers.apply_failed',
   'providers.invalid_request',

--- a/web-ui/app/admin/subscription-clis/_components/InstallBox.tsx
+++ b/web-ui/app/admin/subscription-clis/_components/InstallBox.tsx
@@ -13,6 +13,7 @@
 import { useEffect, useState } from 'react';
 import type { useTranslations } from 'next-intl';
 
+import { ErrorHelp } from '../../../_components/ErrorHelp';
 import { Button } from '../../../_components/ui/Button';
 import {
   ApiError,
@@ -33,9 +34,11 @@ type T = ReturnType<typeof useTranslations>;
  */
 export function ManualInstallSteps({
   b,
+  cliToolsDir,
   t,
 }: {
   b: CliBackendStatus;
+  cliToolsDir: string;
   t: T;
 }): React.ReactElement {
   return (
@@ -43,7 +46,7 @@ export function ManualInstallSteps({
       <li>
         {t('connect.step1')}{' '}
         <code className="select-all text-[color:var(--fg-strong)]">
-          {t('connect.installCmd')}
+          {t('connect.installCmd', { prefix: cliToolsDir })}
         </code>
       </li>
       <li>
@@ -61,19 +64,31 @@ type InstallPhase =
   | { phase: 'idle' }
   | { phase: 'starting' }
   | { phase: 'running' }
-  | { phase: 'failed'; detail?: string; logTail?: string };
+  | { phase: 'failed'; code?: string; detail?: string; logTail?: string };
 
 /** How often the panel asks the backend whether a running install finished. */
 const INSTALL_POLL_INTERVAL_MS = 3000;
 /** Stop polling after this many consecutive errors (e.g. an expired session). */
 const MAX_POLL_FAILURES = 5;
 
+function combineInstallDetail(
+  detail?: string,
+  logTail?: string,
+): string | undefined {
+  if (detail && logTail) {
+    return detail === logTail ? detail : `${detail}\n\n${logTail}`;
+  }
+  return detail ?? logTail;
+}
+
 export function InstallBox({
   b,
+  cliToolsDir,
   t,
   onChanged,
 }: {
   b: CliBackendStatus;
+  cliToolsDir: string;
   t: T;
   onChanged: () => void;
 }): React.ReactElement {
@@ -96,6 +111,7 @@ export function InstallBox({
             clearInterval(timer);
             setPhase({
               phase: 'failed',
+              ...(s.code ? { code: s.code } : {}),
               ...(s.error ? { detail: s.error } : {}),
               ...(s.logTail ? { logTail: s.logTail } : {}),
             });
@@ -162,15 +178,11 @@ export function InstallBox({
 
       {phase.phase === 'failed' && (
         <div className="mt-3">
-          <p className="text-sm text-[color:var(--danger)]">{t('install.failed')}</p>
-          {phase.detail ? (
-            <p className="mt-1 text-[12px] text-[color:var(--fg-muted)]">{phase.detail}</p>
-          ) : null}
-          {phase.logTail ? (
-            <pre className="mt-2 max-h-40 overflow-auto rounded-md bg-[color:var(--bg)] p-2 text-[11px] text-[color:var(--fg-muted)]">
-              {phase.logTail}
-            </pre>
-          ) : null}
+          <ErrorHelp
+            code={phase.code ?? null}
+            rawDetail={combineInstallDetail(phase.detail, phase.logTail)}
+            fallback={t('install.failed')}
+          />
         </div>
       )}
 
@@ -178,7 +190,7 @@ export function InstallBox({
         <summary className="cursor-pointer text-[12px] text-[color:var(--fg-muted)]">
           {t('install.manualSummary')}
         </summary>
-        <ManualInstallSteps b={b} t={t} />
+        <ManualInstallSteps b={b} cliToolsDir={cliToolsDir} t={t} />
       </details>
     </div>
   );

--- a/web-ui/app/admin/subscription-clis/_components/SubscriptionClisPanel.tsx
+++ b/web-ui/app/admin/subscription-clis/_components/SubscriptionClisPanel.tsx
@@ -185,7 +185,13 @@ export function SubscriptionClisPanel({
           </div>
           <ul className="flex flex-col gap-3">
             {state.data.backends.map((b) => (
-              <CliRow key={b.id} b={b} t={t} onChanged={() => void load(true)} />
+              <CliRow
+                key={b.id}
+                b={b}
+                cliToolsDir={state.data.cliToolsDir}
+                t={t}
+                onChanged={() => void load(true)}
+              />
             ))}
           </ul>
         </section>
@@ -203,10 +209,12 @@ type LoginPhase =
 
 function CliRow({
   b,
+  cliToolsDir,
   t,
   onChanged,
 }: {
   b: CliBackendStatus;
+  cliToolsDir: string;
   t: T;
   onChanged: () => void;
 }): React.ReactElement {
@@ -317,11 +325,16 @@ function CliRow({
             {t('install.heading')}
           </div>
           {b.installable ? (
-            <InstallBox b={b} t={t} onChanged={onChanged} />
+            <InstallBox
+              b={b}
+              cliToolsDir={cliToolsDir}
+              t={t}
+              onChanged={onChanged}
+            />
           ) : (
             <>
               <p className="mt-2 text-sm text-[color:var(--fg-muted)]">{t('install.intro')}</p>
-              <ManualInstallSteps b={b} t={t} />
+              <ManualInstallSteps b={b} cliToolsDir={cliToolsDir} t={t} />
             </>
           )}
         </div>
@@ -348,7 +361,7 @@ function CliRow({
                 <summary className="cursor-pointer text-[12px] text-[color:var(--fg-muted)]">
                   {t('connect.manualSummary')}
                 </summary>
-                <ManualInstallSteps b={b} t={t} />
+                <ManualInstallSteps b={b} cliToolsDir={cliToolsDir} t={t} />
               </details>
             </div>
           )}

--- a/web-ui/app/admin/subscription-clis/_components/__tests__/SubscriptionClisPanel.test.tsx
+++ b/web-ui/app/admin/subscription-clis/_components/__tests__/SubscriptionClisPanel.test.tsx
@@ -24,6 +24,8 @@ const { mockGetCliBackends, mockStartCliInstall, mockGetCliInstallStatus } = vi.
   mockGetCliInstallStatus: vi.fn(),
 }));
 
+const CLI_TOOLS_DIR = '/var/lib/omadia/cli-tools';
+
 vi.mock('../../../../_lib/api', () => ({
   getCliBackends: mockGetCliBackends,
   startCliLogin: vi.fn(),
@@ -61,6 +63,7 @@ describe('<SubscriptionClisPanel />', () => {
           detail: 'claude is not installed in this environment.',
         }),
       ],
+      cliToolsDir: CLI_TOOLS_DIR,
       generatedAt: Date.now(),
     });
 
@@ -76,13 +79,18 @@ describe('<SubscriptionClisPanel />', () => {
     // …so the way OUT of the dead end must be visible instead.
     expect(screen.getByText(/CLI installieren/)).toBeTruthy();
     expect(
-      screen.getByText(/npm install -g @anthropic-ai\/claude-code/),
+      screen.getByText(
+        new RegExp(
+          `npm install -g @anthropic-ai/claude-code --prefix ${CLI_TOOLS_DIR}`,
+        ),
+      ),
     ).toBeTruthy();
   });
 
   it('OM-22: renders the snapshot timestamp so a re-check is observable', async () => {
     mockGetCliBackends.mockResolvedValue({
       backends: [backend({ installed: false })],
+      cliToolsDir: CLI_TOOLS_DIR,
       generatedAt: Date.parse('2026-08-03T09:41:07Z'),
     });
 
@@ -99,6 +107,7 @@ describe('<SubscriptionClisPanel />', () => {
   it('an installed CLI still offers the in-app login', async () => {
     mockGetCliBackends.mockResolvedValue({
       backends: [backend({ installed: true, loggedIn: 'no' })],
+      cliToolsDir: CLI_TOOLS_DIR,
       generatedAt: Date.now(),
     });
 
@@ -112,13 +121,18 @@ describe('<SubscriptionClisPanel />', () => {
       expect(screen.queryByText(/CLI installieren/)).toBeNull();
     });
     expect(
-      screen.getByText(/npm install -g @anthropic-ai\/claude-code/),
+      screen.getByText(
+        new RegExp(
+          `npm install -g @anthropic-ai/claude-code --prefix ${CLI_TOOLS_DIR}`,
+        ),
+      ),
     ).toBeTruthy();
   });
 
   it('an uninstalled installable CLI offers the in-app install button (manual steps collapsed)', async () => {
     mockGetCliBackends.mockResolvedValue({
       backends: [backend({ installed: false, installable: true })],
+      cliToolsDir: CLI_TOOLS_DIR,
       generatedAt: Date.now(),
     });
 
@@ -135,6 +149,7 @@ describe('<SubscriptionClisPanel />', () => {
   it('clicking install triggers the backend job and shows progress', async () => {
     mockGetCliBackends.mockResolvedValue({
       backends: [backend({ installed: false, installable: true })],
+      cliToolsDir: CLI_TOOLS_DIR,
       generatedAt: Date.now(),
     });
     mockStartCliInstall.mockResolvedValue({ status: 'started' });
@@ -152,4 +167,60 @@ describe('<SubscriptionClisPanel />', () => {
     });
     expect(await screen.findByTestId('cli-install-running')).toBeTruthy();
   });
+
+  /**
+   * #882 — the failure the PATH bug actually produces: npm is never found, so
+   * it exits with no output at all and the old UI showed "Installation failed."
+   * above an empty <pre>. The status now carries a code, and the box renders
+   * through the shared <ErrorHelp>, so the operator gets the catalogued
+   * explanation instead of a blank log.
+   *
+   * Real timers on purpose: the install poll runs on a 3s setInterval, and
+   * vitest's fake timers deadlock against testing-library's waitFor (which
+   * needs a working timer to poll the DOM). The extended timeout below covers
+   * one poll tick.
+   */
+  it('a failed install with cli_install.no_output renders catalogued help copy', async () => {
+    mockGetCliBackends.mockResolvedValue({
+      backends: [backend({ installed: false, installable: true })],
+      cliToolsDir: CLI_TOOLS_DIR,
+      generatedAt: Date.now(),
+    });
+    mockStartCliInstall.mockResolvedValue({ status: 'started' });
+    mockGetCliInstallStatus.mockResolvedValue({
+      cliId: 'claude',
+      status: 'failed',
+      code: 'cli_install.no_output',
+      error: 'spawn npm ENOENT',
+      logTail: '',
+    });
+
+    renderWithIntl(<SubscriptionClisPanel onSwitchToProviders={() => {}} />);
+
+    const button = await screen.findByRole('button', { name: /install now/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockStartCliInstall).toHaveBeenCalledWith('claude');
+    });
+
+    // The catalogued `what` line — proof it went through <ErrorHelp> rather
+    // than the old raw-log-tail block.
+    expect(
+      await screen.findByText(
+        'npm produced no output at all, which means the npm command itself could not be run on the server.',
+        {},
+        { timeout: 10_000 },
+      ),
+    ).toBeTruthy();
+    // …and the catalogued `next` line, which names the actual way out.
+    expect(
+      screen.getByText(
+        "Install the CLI manually with the shown command, or make sure Node and npm are on the server's PATH.",
+      ),
+    ).toBeTruthy();
+    // The server's English string is never the headline; it sits in the
+    // redacted support disclosure.
+    expect(screen.getByText('Details for support')).toBeTruthy();
+  }, 20_000);
 });

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1008,6 +1008,16 @@
         "next": "Lade die Seite neu, um zu sehen, wo die Installation wirklich steht."
       }
     },
+    "cli_install": {
+      "no_output": {
+        "what": "npm hat gar keine Ausgabe geliefert — der npm-Befehl selbst konnte auf dem Server nicht gestartet werden.",
+        "next": "Installiere die CLI mit dem angezeigten Befehl manuell oder stelle sicher, dass Node und npm auf dem Server im PATH liegen."
+      },
+      "npm_failed": {
+        "what": "npm wurde ausgeführt, aber die Installation ist fehlgeschlagen.",
+        "next": "Prüfe die Log-Details unten und starte die Installation danach erneut."
+      }
+    },
     "package": {
       "id_conflict_bundled": {
         "what": "Diese Plugin-ID gehört zu einem Plugin, das mit omadia ausgeliefert wird — der Upload wurde abgelehnt.",
@@ -3084,7 +3094,7 @@
       "stillPending": "Noch nicht angemeldet. Öffne den Link, bestätige den Zugriff und sende den Code erneut.",
       "manualSummary": "Lieber das Terminal?",
       "step1": "Stelle sicher, dass die CLI installiert ist (im omadia-Image enthalten oder selbst installieren):",
-      "installCmd": "npm install -g @anthropic-ai/claude-code",
+      "installCmd": "npm install -g @anthropic-ai/claude-code --prefix {prefix}",
       "step2": "Melde dich mit deinem Abo-Konto an:",
       "loginCmd": "{bin} auth login",
       "step3": "Komm hierher zurück und drücke Erneut prüfen. Eine angemeldete CLI zeigt ein grünes Badge."

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1008,6 +1008,16 @@
         "next": "Reload the page to see where the installation actually stands."
       }
     },
+    "cli_install": {
+      "no_output": {
+        "what": "npm produced no output at all, which means the npm command itself could not be run on the server.",
+        "next": "Install the CLI manually with the shown command, or make sure Node and npm are on the server's PATH."
+      },
+      "npm_failed": {
+        "what": "npm ran, but the installation failed.",
+        "next": "Check the log details below, then try the installation again."
+      }
+    },
     "package": {
       "id_conflict_bundled": {
         "what": "This plugin id belongs to a plugin that ships with omadia, so the upload was refused.",
@@ -3084,7 +3094,7 @@
       "stillPending": "Not signed in yet. Open the link, approve access, then submit the code again.",
       "manualSummary": "Prefer the terminal?",
       "step1": "Make sure the CLI is installed (bundled in the omadia image, or install it):",
-      "installCmd": "npm install -g @anthropic-ai/claude-code",
+      "installCmd": "npm install -g @anthropic-ai/claude-code --prefix {prefix}",
       "step2": "Log in with your subscription account:",
       "loginCmd": "{bin} auth login",
       "step3": "Come back here and press Re-check. A logged-in CLI shows a green badge."


### PR DESCRIPTION
Fixes #882.

## Root cause
The desktop app forks the kernel with the OS launcher's minimal PATH (macOS `launchd`: `/usr/bin:/bin:/usr/sbin:/sbin`), so bare `npm` spawns inside it (`cliInstallService.ts`, `buildTemplate.ts`) failed with `ENOENT` even though npm was installed via Homebrew/nvm/volta/asdf. Fixes **OM-44, OM-45, OM-46, OM-49, OM-54** from Silvio Lange's Runde-2 beta report — one root cause, five symptoms.

## Changes
1. **`desktop/src/pathEnv.ts` (new)** — fs-only PATH augmentation: Homebrew/apt-style static dirs, `.volta/bin`, `.asdf/shims`, best-effort nvm-default-alias resolution. No-op on `win32` (GUI apps there already inherit the full registry-backed user PATH; the launcher-truncation problem is macOS/Linux-specific). Deliberately **not** a login-shell probe — no precedent for that in this codebase, would add subprocess/security surface for no real gain over the fs-based approach. Wired into `supervisor.ts`'s `kernelEnv()`/`uiEnv()`.
2. **`cliInstallService.ts`** — the failure message + a new `code` field now depend on whether npm actually produced output: `cli_install.no_output` (npm not found — the actual bug) vs `cli_install.npm_failed` (npm ran and failed for a real reason). Previously always claimed "see the log tail" even when there was none.
3. **`cliBackendDetector.ts`** — exposes `cliToolsDir` so the manual-install instructions can add `--prefix <dir>`, landing a manually-installed CLI exactly where the detector already looks first — independent of PATH/shell/version-manager quirks.
4. **`middleware/src/index.ts` + `buildPipeline.ts`** — the Plugin Builder's boot-time npm failure (same root cause, different call site) no longer surfaces as an unhandled promise rejection; it's now classified as `BuildPipelineError('template_not_ready', ...)`, with the original error preserved via `cause`.
5. **web-ui** — `InstallBox` renders failures via the existing shared `<ErrorHelp>` component instead of a raw (sometimes-empty) log block; new `errorHelp.cli_install.*` catalogue entries in `en.json`/`de.json`.

## Known trade-offs (flagged during planning + review, not blocking)
- `pathEnv.ts` has no dedicated unit tests — `desktop/` has zero `src/*.ts` test infra today (only `scripts/*.test.mjs`), and introducing a new cross-boundary test convention for one file was judged scope creep. Mitigated by `tsc` strict typecheck + code review; **the actual "does this fix a real Dock-launch" claim still needs manual verification** (`pack:mac`, launch from Finder, not Terminal) before OM-44 can be considered fully closed end-to-end.
- `errorHelp.ts`'s top scope comment ("5 route files" → "6") also got corrected in this diff — it was stale from earlier merged PRs (#824/#835), unrelated to #882 but caught in the same file while adding the new codes.
- `desktop/` has no PR-triggered CI (typecheck/test only run in the release-only `desktop-apps.yml`) — pre-existing gap, out of scope here; verified locally instead (see below).

## Verification (all local, pre-commit)
- `desktop`: `tsc --noEmit` — clean
- `middleware`: `tsc --noEmit` — clean; `eslint` on touched files — clean; touched test files — **30/30 pass**
- `web-ui`: `tsc --noEmit` — clean; `eslint` on touched files — clean (1 pre-existing, unrelated warning in `api.ts:115`); touched test files — **14/14 pass**; `i18n-parity` suite — **10/10 pass**; `npm run i18n:check` — OK, 3918 keys
- Independent `omadia-reviewer` pass: no CRITICAL/HIGH findings

## Test plan
- [x] Automated tests above, all green
- [ ] Manual: build `pack:mac`, launch from Finder (not Terminal) with a Homebrew-only npm install, confirm CLI install / manual-fallback re-check / Plugin Builder all succeed without ENOENT
- [ ] Manual/CI: confirm `desktop`'s `tsc --noEmit` stays clean in the Windows/Linux matrix build (`desktop-apps.yml`) on next release

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790408741&installation_model_id=428086&pr_number=891&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F891&signature=d8b51472fc38390d7d45d334ba089fe9510f0b0c69e2c35a1110a4ab5bd398e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->