### PR TITLE
fix(#883): write real version into desktop package before packaging

### DIFF
--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -173,6 +173,13 @@ jobs:
         working-directory: desktop
         run: npm ci
 
+      # desktop/package-lock.json mirrors package.json's version field, so write
+      # the release tag AFTER npm ci validated the lockfile and BEFORE the build
+      # and pack steps consume that version for metadata and artifact names.
+      - name: Set desktop app version from release tag
+        working-directory: desktop
+        run: node scripts/set-desktop-version.mjs "$TAG"
+
       # Verify the middleware's native modules load under Electron's Node (the
       # kernel runs via ELECTRON_RUN_AS_NODE). All three are N-API → ABI-stable
       # across node/electron, so their shipped binaries already work and NONE of

--- a/desktop/scripts/set-desktop-version.mjs
+++ b/desktop/scripts/set-desktop-version.mjs
@@ -1,0 +1,61 @@
+// Writes the release version into desktop/package.json before packaging.
+//
+// WHY THIS EXISTS
+// desktop/package.json intentionally stays at the placeholder version 0.1.0 in
+// git, but electron-builder reads THAT field for three separate release-facing
+// surfaces: the packaged app's Info.plist (what macOS shows in "About omadia"),
+// the generated artifact filenames, and the version electron-updater compares
+// against the release feed. Leaving it at 0.1.0 meant every shipped build
+// claimed to be 0.1.0 and the updater could not compare releases correctly.
+// CI therefore overwrites the field from the release tag immediately before the
+// build/pack steps that consume it.
+//
+// Usage: node set-desktop-version.mjs <tag>
+//
+// Deliberately dependency-free: this runs in CI and needs only Node's stdlib.
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const VERSION_RE = /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/;
+const here = path.dirname(fileURLToPath(import.meta.url));
+const desktopPackageJsonPath = path.join(here, '..', 'package.json');
+
+/**
+ * Converts a release tag into the bare semver electron-builder expects.
+ *
+ * Accepts either `vX.Y.Z` or `X.Y.Z`, strips at most one leading `v`, and
+ * rejects anything else so CI fails before producing mislabeled artifacts.
+ */
+export function deriveVersion(tag) {
+  const value = typeof tag === 'string' ? tag : '';
+  const version = value.startsWith('v') ? value.slice(1) : value;
+  if (!VERSION_RE.test(version)) {
+    throw new Error(`Invalid version tag: "${tag}" — expected vX.Y.Z or X.Y.Z`);
+  }
+  return version;
+}
+
+/**
+ * Rewrites package.json with the release version while preserving the repo's
+ * exact formatting: 2-space indent and one trailing newline.
+ */
+export function setPackageVersion(packageJsonText, version) {
+  const pkg = JSON.parse(packageJsonText);
+  pkg.version = version;
+  return `${JSON.stringify(pkg, null, 2)}\n`;
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const tag = process.argv[2];
+  if (!tag) {
+    console.error('usage: set-desktop-version.mjs <tag>');
+    process.exit(1);
+  }
+
+  const version = deriveVersion(tag);
+  const next = setPackageVersion(fs.readFileSync(desktopPackageJsonPath, 'utf8'), version);
+  fs.writeFileSync(desktopPackageJsonPath, next);
+  console.log(`desktop/package.json version -> ${version}`);
+}

--- a/desktop/scripts/set-desktop-version.test.mjs
+++ b/desktop/scripts/set-desktop-version.test.mjs
@@ -1,0 +1,82 @@
+// Tests for the desktop package-version rewrite.
+//
+// This script decides what version the shipped desktop app claims to be, so the
+// guard rails matter more than the happy path: one bad parse or one sloppy JSON
+// rewrite would label the installer, the app metadata, and the updater wrong.
+//
+// Run: node --test desktop/scripts/
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveVersion, setPackageVersion } from './set-desktop-version.mjs';
+
+test('strips one leading v from a release tag', () => {
+  assert.equal(deriveVersion('v1.2.3'), '1.2.3');
+});
+
+test('passes a bare semver through unchanged', () => {
+  assert.equal(deriveVersion('1.2.3'), '1.2.3');
+});
+
+test('accepts prerelease semver tags', () => {
+  assert.equal(deriveVersion('v1.2.3-beta.1'), '1.2.3-beta.1');
+});
+
+test('rejects incomplete versions', () => {
+  assert.throws(
+    () => deriveVersion('v1.2'),
+    /Invalid version tag: "v1.2" — expected vX.Y.Z or X.Y.Z/,
+  );
+});
+
+test('rejects non-semver tags', () => {
+  assert.throws(
+    () => deriveVersion('latest'),
+    /Invalid version tag: "latest" — expected vX.Y.Z or X.Y.Z/,
+  );
+});
+
+test('rejects the empty string', () => {
+  assert.throws(
+    () => deriveVersion(''),
+    /Invalid version tag: "" — expected vX.Y.Z or X.Y.Z/,
+  );
+});
+
+test('rejects a second leading v rather than stripping twice', () => {
+  assert.throws(
+    () => deriveVersion('vv1.2.3'),
+    /Invalid version tag: "vv1.2.3" — expected vX.Y.Z or X.Y.Z/,
+  );
+});
+
+test('rejects build metadata', () => {
+  assert.throws(
+    () => deriveVersion('v1.2.3+build.4'),
+    /Invalid version tag: "v1.2.3\+build.4" — expected vX.Y.Z or X.Y.Z/,
+  );
+});
+
+test('rejects non-string input with the same clear error', () => {
+  assert.throws(
+    () => deriveVersion(undefined),
+    /Invalid version tag: "undefined" — expected vX.Y.Z or X.Y.Z/,
+  );
+});
+
+test('rewrites package.json with repo-stable formatting', () => {
+  const before = `{
+  "name": "omadia-desktop",
+  "version": "0.1.0",
+  "private": true
+}
+`;
+  assert.equal(
+    setPackageVersion(before, '1.2.3'),
+    `{
+  "name": "omadia-desktop",
+  "version": "1.2.3",
+  "private": true
+}
+`,
+  );
+});

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -5,7 +5,7 @@ import { Supervisor, setActiveSupervisor, BootProgress } from './supervisor';
 import { registerIpc } from './ipc';
 import { CH } from './ipcTypes';
 import { createTray, setTrayStatus, destroyTray, TrayActions } from './tray';
-import { initUpdater, isUpdateInstalling } from './updater';
+import { checkForUpdatesManually, initUpdater, isUpdateInstalling } from './updater';
 import { isSetupComplete } from './setupState';
 import { log, onLog } from './log';
 
@@ -53,6 +53,12 @@ function createWindow(): BrowserWindow {
   return w;
 }
 
+function checkForUpdatesAction(): void {
+  // The updater reports every terminal outcome itself via dialogs/logs, so the
+  // menu and tray can deliberately fire-and-forget the async request.
+  void checkForUpdatesManually();
+}
+
 function trayActions(): TrayActions {
   return {
     open: () => {
@@ -80,6 +86,7 @@ function trayActions(): TrayActions {
         supervisor.off('progress', forwardProgress);
       }
     },
+    checkForUpdates: checkForUpdatesAction,
     quit: () => {
       quitting = true;
       app.quit();
@@ -141,7 +148,7 @@ function startWizard(): void {
 async function onReady(): Promise<void> {
   // OM-41 — replace Electron's default menu (which shipped a second
   // fullscreen item and a DevTools accelerator into customer builds).
-  installApplicationMenu();
+  installApplicationMenu({ checkForUpdates: checkForUpdatesAction });
   supervisor = new Supervisor();
   setActiveSupervisor(supervisor);
 

--- a/desktop/src/menu.ts
+++ b/desktop/src/menu.ts
@@ -22,6 +22,12 @@
  * do by accident — the goal is removing the accidental foot-gun from the
  * menu, not fighting intentional diagnostics.
  *
+ * The other gap was updates: packaged builds had no manual "check now" surface
+ * anywhere, so Windows and Linux users had no honest way to ask the updater for
+ * a visible result. A top-level Help menu fixes that on every platform without
+ * overloading the macOS app menu, which should stay reserved for OS-conventional
+ * items such as About/Hide/Quit.
+ *
  * Everything else mirrors the default template closely (edit roles, window
  * roles, zoom) so muscle memory and localized role labels keep working —
  * Electron localizes `role:` items with the OS language for free, which
@@ -29,7 +35,11 @@
  */
 import { Menu, app, type MenuItemConstructorOptions } from 'electron';
 
-export function installApplicationMenu(): void {
+export interface MenuActions {
+  checkForUpdates: () => void;
+}
+
+export function installApplicationMenu(actions: MenuActions): void {
   const isMac = process.platform === 'darwin';
   const showDevTools = !app.isPackaged;
 
@@ -97,6 +107,10 @@ export function installApplicationMenu(): void {
           ? ([{ type: 'separator' }, { role: 'front' }] as MenuItemConstructorOptions[])
           : ([{ role: 'close' }] as MenuItemConstructorOptions[])),
       ],
+    },
+    {
+      label: 'Help',
+      submenu: [{ label: 'Check for Updates…', click: () => actions.checkForUpdates() }],
     },
   ];
 

--- a/desktop/src/tray.ts
+++ b/desktop/src/tray.ts
@@ -5,11 +5,13 @@ import { logFile } from './log';
 
 /**
  * System tray icon + menu. Lets omadia keep running in the background (the local
- * stack stays up) while giving quick access to Open / Restart / Logs / Quit.
+ * stack stays up) while giving quick access to Open / Restart / Logs / Updates /
+ * Quit.
  */
 export interface TrayActions {
   open: () => void;
   restart: () => void;
+  checkForUpdates: () => void;
   quit: () => void;
 }
 
@@ -36,6 +38,7 @@ function rebuildMenu(actions: TrayActions, status: string): void {
     { label: 'Open omadia', click: () => actions.open() },
     { label: 'Restart', click: () => actions.restart() },
     { label: 'Open Logs', click: () => void shell.openPath(logFile()) },
+    { label: 'Check for Updates…', click: () => actions.checkForUpdates() },
     { type: 'separator' },
     { label: 'Quit', click: () => actions.quit() },
   ]);

--- a/desktop/src/updater.ts
+++ b/desktop/src/updater.ts
@@ -1,4 +1,4 @@
-import { app, dialog } from 'electron';
+import { app, dialog, type MessageBoxOptions } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -7,9 +7,32 @@ import { getActiveSupervisor } from './supervisor';
 import { log } from './log';
 
 let installing = false;
+// This flag is only safe because electron-updater's own checkForUpdates()
+// dedupes internally — a call while one is already in flight (e.g. a manual
+// click landing during the silent startup check) returns the SAME promise
+// instead of firing a second request, so there is always exactly one
+// terminal event to gate a dialog on. Do not add a second concurrent
+// checkForUpdates() call path without re-checking that guarantee still holds.
+let manualCheckPending = false;
 /** True once the user accepted an update and we're handing off to the installer. */
 export function isUpdateInstalling(): boolean {
   return installing;
+}
+
+function takeManualCheckPending(): boolean {
+  if (!manualCheckPending) return false;
+  manualCheckPending = false;
+  return true;
+}
+
+async function showUpdaterDialog(options: MessageBoxOptions): Promise<void> {
+  try {
+    // These status dialogs are intentionally unbounded: the point of a manual
+    // check is to stay visible until the user has seen the updater outcome.
+    await dialog.showMessageBox(options);
+  } catch (err) {
+    log.error(`[updater] failed to show dialog "${options.title}": ${String(err)}`);
+  }
 }
 
 /**
@@ -29,12 +52,40 @@ export function initUpdater(): void {
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = false; // we control install timing (after snapshot)
 
-  autoUpdater.on('error', (err) => log.error(`[updater] ${String(err)}`));
-  autoUpdater.on('update-available', (info) =>
-    log.info(`[updater] update available: ${info.version}`),
-  );
+  autoUpdater.on('error', (err) => {
+    log.error(`[updater] ${String(err)}`);
+    if (!takeManualCheckPending()) return;
+    void showUpdaterDialog({
+      type: 'error',
+      title: 'Update check failed',
+      message: 'omadia could not check for updates.',
+      detail: String(err),
+    });
+  });
+  autoUpdater.on('update-available', (info) => {
+    log.info(`[updater] update available: ${info.version}`);
+    if (!takeManualCheckPending()) return;
+    void showUpdaterDialog({
+      type: 'info',
+      title: 'Update found',
+      message: `omadia ${info.version} is downloading now.`,
+      detail: 'The download is running in the background. You will be prompted to restart once it is ready to install.',
+    });
+  });
+  autoUpdater.on('update-not-available', (info) => {
+    log.info(`[updater] up to date: ${info.version}`);
+    if (!takeManualCheckPending()) return;
+    void showUpdaterDialog({
+      type: 'info',
+      title: 'No update available',
+      message: "You're already on the latest version of omadia.",
+      detail: `Current version: ${info.version}`,
+    });
+  });
   autoUpdater.on('update-downloaded', async (info) => {
     log.info(`[updater] downloaded ${info.version}`);
+    // This restart decision is intentionally unbounded: installing an update
+    // without explicit user consent would be worse than waiting for it here.
     const { response } = await dialog.showMessageBox({
       type: 'info',
       buttons: ['Restart now', 'Later'],
@@ -62,7 +113,36 @@ export function initUpdater(): void {
     autoUpdater.quitAndInstall();
   });
 
+  // electron-updater owns the request lifetime and its own network timeouts; we
+  // deliberately wait for its promise/events instead of racing a second timer.
   autoUpdater.checkForUpdates().catch((err) => log.error(`[updater] check failed: ${String(err)}`));
+}
+
+export async function checkForUpdatesManually(): Promise<void> {
+  if (!app.isPackaged) {
+    await showUpdaterDialog({
+      type: 'info',
+      title: 'Update check unavailable',
+      message: 'Update checks are only available in packaged builds.',
+      detail: 'This development run does not have a published release feed to query.',
+    });
+    return;
+  }
+
+  manualCheckPending = true;
+  try {
+    // electron-updater owns the request lifetime and its own network timeouts;
+    // the promise plus its events are the supported completion signal here.
+    await autoUpdater.checkForUpdates();
+  } catch (err) {
+    if (!takeManualCheckPending()) return;
+    await showUpdaterDialog({
+      type: 'error',
+      title: 'Update check failed',
+      message: 'omadia could not check for updates.',
+      detail: String(err),
+    });
+  }
 }
 
 /** Copy the embedded DB directory into a timestamp-free, version-named snapshot. */

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -59,6 +59,24 @@ bare `npm install -g …` that installs somewhere the server never looks, so
 `detectCliBackends()` now exposes `cliToolsDir` and the shown command carries
 `--prefix <cliToolsDir>`.
 
+### Fixed — desktop app version was hardcoded to 0.1.0 (#883, OM-51/47/52)
+
+`desktop/package.json` shipped every release at the placeholder version `0.1.0`, which
+electron-builder reads for three release-facing surfaces at once: the packaged app's
+"About omadia" panel, the generated artifact filenames, and the version electron-updater
+compares against the release feed — so every build claimed to be `0.1.0` and the updater
+could never detect a newer release.
+
+- **CI now writes the real version before packaging.** A new `desktop/scripts/set-desktop-version.mjs`
+  derives a bare semver from the release tag and rewrites `desktop/package.json` in a new
+  `.github/workflows/desktop-apps.yml` step, placed after `npm ci` (so the lockfile's own
+  `version` field is validated first) and before the build/pack steps that consume it.
+- **Manual "Check for Updates".** Packaged builds previously only checked once, silently, at
+  startup, with no way to ask again and no visible result either way. Both the tray menu and
+  a new cross-platform Help menu now expose a "Check for Updates…" action that shows a
+  dialog for every outcome — found (downloading), already up to date, or the check failed —
+  without changing the silent startup check's existing (dialog-free) behavior.
+
 ### Added — chat-context memory ACL: per-team/channel/user agent memory (#860 W5, design #870)
 
 2026-08-27 — Agent memory was isolated per AGENT but not per CHAT CONTEXT. What an agent


### PR DESCRIPTION
Fixes #883.

## Root cause
`desktop/package.json` hardcoded `"version": "0.1.0"`, never overwritten before packaging. electron-builder reads that one field for three release-facing surfaces at once: the packaged app's "About omadia" panel, the generated artifact filenames, and the version electron-updater compares against the release feed — so every shipped build claimed to be `0.1.0` and the updater could never detect a newer release. Fixes **OM-51, OM-47, OM-52** from Silvio Lange's Runde-2 beta report.

## Changes
1. **`desktop/scripts/set-desktop-version.mjs` (new)** — derives a bare semver from the release tag (`vX.Y.Z` → `X.Y.Z`, rejects anything non-semver) and rewrites `desktop/package.json`'s `version` field in place, preserving its exact formatting.
2. **`.github/workflows/desktop-apps.yml`** — new step running the script, placed after `npm ci` (so the lockfile's mirrored `version` field is validated first — editing before would risk an inconsistent-lockfile error) and before the build/pack steps that consume the version. Confirmed no further `npm ci`/`npm install` runs in `desktop/` afterward in that job.
3. **`desktop/electron-builder.yml` — untouched.** `mac`/`dmg` artifact names already template `${version}` explicitly; `win`/`linux` already use electron-builder's stock `${version}`-templated defaults (confirmed against the issue's own reported filenames, e.g. `omadia-desktop_0.1.0_amd64.deb`). Once `package.json` has the right version, filenames self-correct — OM-47 needed zero config changes.
4. **`desktop/src/updater.ts`** — adds `checkForUpdatesManually()`. Previously the only check was silent, once, at startup, with no way to trigger it again and no visible result. The manual path now shows a dialog for every outcome (update found & downloading / already up to date / check failed), gated by a `manualCheckPending` flag that safely relies on electron-updater's own internal de-dup of concurrent `checkForUpdates()` calls (documented inline, verified against `electron-updater`'s source during review). The silent startup check's existing dialog-free behavior is unchanged for anyone who never opens the menu.
5. **`desktop/src/menu.ts` + `tray.ts` + `main.ts`** — new cross-platform "Help → Check for Updates…" menu entry (Windows/Linux had *no* update-check surface at all, macOS's App menu stays reserved for About/Hide/Quit) and a matching tray menu item.
6. **`docs/CHANGELOG.md`** — `[Unreleased]` entry per repo convention.

## Verification (all local, pre-commit)
- `desktop`: `tsc --noEmit` — clean
- `desktop`: `node --test scripts/*.test.mjs` — **22/22 pass**, including the new `set-desktop-version.test.mjs` (leading-`v` strip, prerelease acceptance, rejects incomplete/non-semver/build-metadata/double-`v` tags)
- Workflow YAML parses cleanly; confirmed no `npm ci`/`npm install` runs in the `desktop/`-scoped part of the job after the new step (no lockfile-invalidation risk)
- Independent `omadia-reviewer` pass: 1 required fix applied (this CHANGELOG entry), 1 documentation note applied (the inline comment on the de-dup dependency in `updater.ts`) — no other findings

## Known trade-offs (flagged during planning + review, not blocking)
- No unit tests for `updater.ts`/`menu.ts`/`tray.ts` logic itself — Electron main-process modules aren't practically unit-testable in this repo's current setup; the pure, testable piece (`set-desktop-version.mjs`) has full coverage.
- electron-builder's stock deb/nsis `${version}`-templated defaults are inferred from the issue's own reported filenames and general electron-builder documentation, not verified by reading `app-builder-lib` source directly (`desktop/node_modules` wasn't installed in this checkout) — worth a visual spot-check of `desktop/release/*` filenames on the next real release build.
- The workflow step's actual correctness (does the version really land right) is only fully verifiable via a real `workflow_dispatch`/release run.

## Test plan
- [x] Automated tests above, all green
- [ ] Post-merge: verify the next tagged desktop build shows the correct version in "About omadia" and in artifact filenames
- [ ] Post-merge: verify an older packaged build's "Check for Updates" correctly detects the newer one (needs two real tagged builds, not practical pre-merge)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790411656&installation_model_id=428086&pr_number=892&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F892&signature=d759cb750dbbd63ac536a582fec65e8f0cab1f8a2f594bdfd2f3c174063ec7af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->