### PR TITLE
fix(#890): desktop first-run wizard offers a subscription path, not just API key

### DIFF
--- a/desktop/src/ipc.ts
+++ b/desktop/src/ipc.ts
@@ -1,6 +1,7 @@
 import { ipcMain, dialog, app, BrowserWindow, WebContents } from 'electron';
 import {
   CH,
+  ApiKeyProvider,
   AppState,
   TestLlmKeyRequest,
   TestLlmKeyResult,
@@ -14,7 +15,7 @@ import { isSetupComplete } from './setupState';
 import { setDataDirOverride } from './paths';
 import { log } from './log';
 
-const PROVIDER_ENV: Record<WizardConfig['provider'], string> = {
+const PROVIDER_ENV: Record<ApiKeyProvider, string> = {
   anthropic: 'ANTHROPIC_API_KEY',
   openai: 'OPENAI_API_KEY',
 };
@@ -24,6 +25,18 @@ export interface IpcDeps {
   boot: (forward: (p: BootProgress) => void) => Promise<string>;
   /** Called once the UI is serving so main can swap the wizard for the app window. */
   onReady: (uiUrl: string) => void;
+}
+
+/**
+ * Whether this provider needs an API key stored and validated.
+ *
+ * `subscription` runs on an existing Claude/Codex CLI login, so there is no key
+ * to enter, probe, or persist. A type predicate rather than a plain boolean so
+ * the true branch narrows to the providers `PROVIDER_ENV` actually has an entry
+ * for — the lookup can then never be reached with an unmapped provider.
+ */
+export function requiresApiKey(provider: WizardConfig['provider']): provider is ApiKeyProvider {
+  return provider !== 'subscription';
 }
 
 export function registerIpc(deps: IpcDeps): void {
@@ -57,8 +70,13 @@ export function registerIpc(deps: IpcDeps): void {
         setDataDirOverride(config.dataDir);
       }
       // Persist the provider key (encrypted) BEFORE writing setup, so a crash
-      // between the two never leaves "configured" without a usable key.
-      setProviderKey(PROVIDER_ENV[config.provider], config.apiKey.trim());
+      // between the two never leaves "configured" without a usable key. A
+      // subscription setup has no key to persist: the kernel boots without one
+      // (both provider vars are optional in the middleware config schema and
+      // `/health` never reads them), and the CLI login is connected after boot.
+      if (requiresApiKey(config.provider)) {
+        setProviderKey(PROVIDER_ENV[config.provider], config.apiKey.trim());
+      }
 
       // Save config as `configured` but NOT yet `completed`: we only mark the
       // install boot-verified once the stack actually comes up, so a failed
@@ -98,10 +116,14 @@ function makeProgressForwarder(sender: WebContents): (p: BootProgress) => void {
 }
 
 function validateConfig(config: WizardConfig): void {
-  if (config.provider !== 'anthropic' && config.provider !== 'openai') {
+  if (
+    config.provider !== 'anthropic' &&
+    config.provider !== 'openai' &&
+    config.provider !== 'subscription'
+  ) {
     throw new Error('Unsupported provider.');
   }
-  if (!config.apiKey || config.apiKey.trim().length < 8) {
+  if (requiresApiKey(config.provider) && (!config.apiKey || config.apiKey.trim().length < 8)) {
     throw new Error('Please enter a valid API key.');
   }
 }

--- a/desktop/src/ipcTypes.ts
+++ b/desktop/src/ipcTypes.ts
@@ -22,8 +22,10 @@ export interface AppState {
   version: string;
 }
 
+export type ApiKeyProvider = 'anthropic' | 'openai';
+
 export interface TestLlmKeyRequest {
-  provider: 'anthropic' | 'openai';
+  provider: ApiKeyProvider;
   apiKey: string;
 }
 
@@ -33,7 +35,8 @@ export interface TestLlmKeyResult {
 }
 
 export interface WizardConfig {
-  provider: 'anthropic' | 'openai';
+  /** `subscription` stores no API key; Claude/Codex CLI is connected after boot. */
+  provider: ApiKeyProvider | 'subscription';
   apiKey: string;
   capabilities: {
     embeddings: boolean;

--- a/desktop/src/renderer/wizard-i18n.js
+++ b/desktop/src/renderer/wizard-i18n.js
@@ -39,15 +39,21 @@
       'welcome.lead':
         'omadia installiert einen vollständigen lokalen Stack — den Kernel, die Verwaltungsoberfläche und eine eingebettete Postgres-Datenbank — und betreibt alles auf diesem Computer. Kein Docker, kein Cloud-Konto. Deine Daten und dein KI-Schlüssel verlassen den Rechner nicht.',
       'welcome.fact1': 'Eingebettete Datenbank mit Vektor-Suche, lokal gespeichert.',
-      'welcome.fact2': 'Du bringst deinen eigenen KI-Anbieter-Schlüssel mit.',
+      'welcome.fact2': 'Nutze deinen eigenen KI-Anbieter-Schlüssel oder ein vorhandenes Claude/Codex-Abo.',
       'welcome.fact3': 'Bei einer Deinstallation wird alles sauber entfernt.',
       // step 1
       'provider.title': 'KI-Anbieter verbinden',
       'provider.lead':
-        'omadia nutzt deinen eigenen Schlüssel. Er wird verschlüsselt im Schlüsselbund deines Betriebssystems gespeichert.',
+        'Nutze jetzt einen API-Schlüssel oder starte ohne ihn und verbinde dein Claude- oder Codex-Abo später. Gespeicherte API-Schlüssel werden verschlüsselt im Schlüsselbund deines Betriebssystems abgelegt.',
+      'provider.mode.apiKey': 'API-Schlüssel eingeben',
+      'provider.mode.apiKeyHint': 'Einen Anthropic- oder OpenAI-API-Schlüssel jetzt verwenden und prüfen.',
+      'provider.mode.subscription': 'Ich habe bereits ein Claude/Codex-Abo',
+      'provider.mode.subscriptionHint': 'omadia jetzt starten und das CLI-Abo danach verbinden.',
       'provider.label': 'Anbieter',
       'provider.keyLabel': 'API-Schlüssel',
       'provider.test': 'Schlüssel testen',
+      'provider.subscriptionHint':
+        'omadia startet ohne API-Schlüssel. Verbinde deine Claude- oder Codex-CLI danach unter Admin → LLM-Zugang → Abos.',
       // step 2
       'caps.title': 'Optionale Funktionen',
       'caps.lead':

--- a/desktop/src/renderer/wizard.css
+++ b/desktop/src/renderer/wizard.css
@@ -40,6 +40,8 @@ html, body { margin: 0; height: 100%; background: var(--bg); color: var(--fg); }
 .panel { position: relative; padding: 48px 56px; display: flex; flex-direction: column; overflow-y: auto; }
 .step { flex: 1; max-width: 620px; }
 .step.hidden { display: none; }
+#apiKeyFields.hidden,
+.hint.hidden { display: none; }
 
 h1 { font-size: 26px; font-weight: 650; margin: 0 0 12px; letter-spacing: -0.02em; }
 .lead { color: var(--muted); font-size: 15px; line-height: 1.55; margin: 0 0 24px; }

--- a/desktop/src/renderer/wizard.html
+++ b/desktop/src/renderer/wizard.html
@@ -35,7 +35,7 @@
           </p>
           <ul class="facts">
             <li data-i18n="welcome.fact1">Embedded database with vector search, persisted locally.</li>
-            <li data-i18n="welcome.fact2">You bring your own AI provider key.</li>
+            <li data-i18n="welcome.fact2">Bring your own AI provider key, or use an existing Claude/Codex subscription.</li>
             <li data-i18n="welcome.fact3">Everything is removed cleanly when you uninstall.</li>
           </ul>
         </section>
@@ -43,22 +43,41 @@
         <!-- 1: Provider -->
         <section class="step hidden" data-step="1">
           <h1 data-i18n="provider.title">Connect an AI provider</h1>
-          <p class="lead" data-i18n="provider.lead">omadia uses your own key. It is stored encrypted in your OS keychain.</p>
-          <label class="field">
-            <span data-i18n="provider.label">Provider</span>
-            <select id="provider">
-              <option value="anthropic">Anthropic (Claude)</option>
-              <option value="openai">OpenAI</option>
-            </select>
+          <p class="lead" data-i18n="provider.lead">Use an API key now, or start without one and connect your Claude or Codex subscription later. Saved API keys are stored encrypted in your OS keychain.</p>
+          <label class="toggle">
+            <input type="radio" name="providerMode" id="modeApiKey" value="apiKey" checked />
+            <span>
+              <strong data-i18n="provider.mode.apiKey">Enter an API key</strong>
+              <em data-i18n="provider.mode.apiKeyHint">Use an Anthropic or OpenAI API key and verify it now.</em>
+            </span>
           </label>
-          <label class="field">
-            <span data-i18n="provider.keyLabel">API key</span>
-            <input id="apiKey" type="password" autocomplete="off" spellcheck="false" placeholder="sk-…" />
+          <label class="toggle">
+            <input type="radio" name="providerMode" id="modeSubscription" value="subscription" />
+            <span>
+              <strong data-i18n="provider.mode.subscription">I already have a Claude/Codex subscription</strong>
+              <em data-i18n="provider.mode.subscriptionHint">Start omadia now and connect the CLI subscription afterwards.</em>
+            </span>
           </label>
-          <div class="row">
-            <button id="testKey" class="btn ghost" type="button" data-i18n="provider.test">Test key</button>
-            <span id="testResult" class="test-result"></span>
+          <div id="apiKeyFields">
+            <label class="field">
+              <span data-i18n="provider.label">Provider</span>
+              <select id="provider">
+                <option value="anthropic">Anthropic (Claude)</option>
+                <option value="openai">OpenAI</option>
+              </select>
+            </label>
+            <label class="field">
+              <span data-i18n="provider.keyLabel">API key</span>
+              <input id="apiKey" type="password" autocomplete="off" spellcheck="false" placeholder="sk-…" />
+            </label>
+            <div class="row">
+              <button id="testKey" class="btn ghost" type="button" data-i18n="provider.test">Test key</button>
+              <span id="testResult" class="test-result"></span>
+            </div>
           </div>
+          <p class="hint hidden" id="subscriptionHint" data-i18n="provider.subscriptionHint">
+            omadia will start without an API key. Connect your Claude or Codex CLI afterwards under Admin → LLM access → Subscriptions.
+          </p>
         </section>
 
         <!-- 2: Capabilities -->

--- a/desktop/src/renderer/wizard.js
+++ b/desktop/src/renderer/wizard.js
@@ -17,6 +17,9 @@ const LAST_STEP = 4;
 const state = {
   step: 0,
   dataDir: null,
+  /* Step 1 mode: `apiKey` keeps the existing flow; `subscription` skips key
+     entry now and expects Claude/Codex CLI setup after boot. */
+  providerMode: 'apiKey',
   /* True only after `testLlmKey` came back ok for the CURRENTLY entered
      provider+key. Reset on every edit below — a verdict about a previous key
      says nothing about this one. */
@@ -75,6 +78,14 @@ function renderNav() {
   $('#next').textContent = state.step === LAST_STEP ? wt('nav.finish', 'Finish & start omadia') : wt('nav.continue', 'Continue');
 }
 
+function renderProviderMode() {
+  const isSubscription = state.providerMode === 'subscription';
+  $('#modeApiKey').checked = !isSubscription;
+  $('#modeSubscription').checked = isSubscription;
+  $('#apiKeyFields').classList.toggle('hidden', isSubscription);
+  $('#subscriptionHint').classList.toggle('hidden', !isSubscription);
+}
+
 function goto(step) {
   state.step = step;
   show(step);
@@ -84,6 +95,7 @@ function goto(step) {
 
 function validateCurrent() {
   if (state.step === 1) {
+    if (state.providerMode === 'subscription') return true;
     const key = $('#apiKey').value.trim();
     if (key.length < 8) {
       flashTest('Please enter your API key first.', false);
@@ -121,10 +133,18 @@ function flashTest(msg, ok) {
   el.className = 'test-result ' + (ok ? 'ok' : 'err');
 }
 
+function clearTestFeedback() {
+  const el = $('#testResult');
+  el.textContent = '';
+  el.className = 'test-result';
+}
+
 function collectConfig() {
+  const provider = state.providerMode === 'subscription' ? 'subscription' : $('#provider').value;
+  const apiKey = state.providerMode === 'subscription' ? '' : $('#apiKey').value.trim();
   return {
-    provider: $('#provider').value,
-    apiKey: $('#apiKey').value.trim(),
+    provider,
+    apiKey,
     capabilities: {
       attachments: $('#capAttachments').checked,
       embeddings: $('#capEmbeddings').checked,
@@ -210,11 +230,24 @@ $('#back').addEventListener('click', () => {
   if (state.step > 0) goto(state.step - 1);
 });
 
+document.querySelectorAll('input[name="providerMode"]').forEach((el) => {
+  el.addEventListener('change', (event) => {
+    const target = event.target;
+    if (!target || !target.checked) return;
+    if (target.value !== 'apiKey' && target.value !== 'subscription') return;
+    state.providerMode = target.value;
+    resetKeyVerification();
+    clearTestFeedback();
+    renderProviderMode();
+  });
+});
+
 $('#apiKey').addEventListener('input', resetKeyVerification);
 $('#provider').addEventListener('change', resetKeyVerification);
 
 $('#testKey').addEventListener('click', async () => {
   if (!bridgeOk()) return;
+  if (state.providerMode === 'subscription') return;
   const provider = $('#provider').value;
   const apiKey = $('#apiKey').value.trim();
   if (apiKey.length < 8) {
@@ -270,6 +303,7 @@ $('#revealKey').addEventListener('click', async () => {
   }
 });
 
+renderProviderMode();
 goto(0);
 // Fail loud, not silent, if the preload bridge is missing.
 if (!bridge) bridgeOk();

--- a/desktop/src/setupState.ts
+++ b/desktop/src/setupState.ts
@@ -10,7 +10,7 @@ export interface SetupState {
   configured: boolean;
   /** The stack has booted successfully at least once (boot-verified). */
   completed: boolean;
-  llmProvider: 'anthropic' | 'openai';
+  llmProvider: 'anthropic' | 'openai' | 'subscription';
   capabilities: {
     /** in-process embeddings for semantic memory / topic detection */
     embeddings: boolean;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,16 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — desktop first-run wizard no longer forces API-key entry (#890)
+
+2026-08-27 — The Electron desktop wizard hard-blocked every first-time setup on
+an API key, even though the app can boot without one and wire a Claude/Codex
+CLI subscription afterwards. Step 1 now offers two explicit paths: the existing
+API-key flow remains the default with its current verification behavior intact,
+and a new subscription path persists `llmProvider: "subscription"` without
+storing a key. The desktop main-process types and setup validation now treat
+that provider as a first-class value instead of an unsupported edge case.
+
 ### Fixed — desktop app augments PATH for forked children (#882)
 
 2026-08-27 — The Electron desktop supervisor used the OS launcher's inherited


### PR DESCRIPTION
Fixes #890.

## Problem
The Electron desktop app's native first-run wizard (`desktop/src/renderer/wizard.html` + `wizard.js`, hand-rolled vanilla JS, no framework) — the very first screen a desktop user sees, before the web-ui even loads — hard-required an API key with no alternative. `ipc.ts`'s `validateConfig()` rejected any config without an `apiKey.trim().length >= 8`. This forecloses byte5's own stated easy on-ramp for non-developer users (an existing Claude/Codex subscription) at the very first screen, on the one platform (desktop) where this wizard runs.

Now that #882 fixed the subscription-CLI install path and #883 fixed desktop versioning, the post-boot subscription flow (`Admin → LLM access → Subscriptions`) this fix defers to is actually functional.

## Changes
1. **`desktop/src/renderer/wizard.html` / `wizard.js` / `wizard.css`** — step 1 gains a mode toggle: "Enter an API key" (default, byte-for-byte unchanged behavior) vs. "I already have a Claude/Codex subscription" (skips key entry/validation/test-probe entirely, shows a hint pointing at the real post-boot admin page).
2. **`desktop/src/ipcTypes.ts` / `ipc.ts`** — `WizardConfig.provider` gains `'subscription'`. New `requiresApiKey(provider): provider is ApiKeyProvider` type predicate narrows every `PROVIDER_ENV` lookup so an unmapped provider can never reach it (verified: TS narrowing is sound, not just visual). `validateConfig()` and the `complete` IPC handler both skip API-key persistence/validation for the subscription branch — confirmed the kernel boots fine with no provider key (`ANTHROPIC_API_KEY`/`OPENAI_API_KEY` are `z.string().optional()` in `middleware/src/config.ts`, and `/health` never checks them).
3. **`desktop/src/setupState.ts`** — `llmProvider` type gains `'subscription'`; `DEFAULT` stays `'anthropic'` for legacy setup files (no runtime schema validation on this interface, so old files parse fine post-change).
4. **`desktop/src/renderer/wizard-i18n.js`** — new EN/DE strings for the toggle + hint text, and an updated `welcome.fact2` that no longer states API-key-only as settled fact. The hint's admin-page breadcrumb (`Admin → LLM access → Subscriptions` / `Admin → LLM-Zugang → Abos`) was verified against the actual `web-ui/messages/{en,de}.json` nav labels, not guessed.
5. **`docs/CHANGELOG.md`** — `[Unreleased]` entry.

## Deliberately out of scope (decided during planning, confidence-gated)
- No inline CLI detection/login (`cliBackendDetector.ts` cannot be imported into `desktop/` — separate build boundary, no workspace dependency; same constraint `ipc.ts`'s existing `testLlmKey` already documents for `providerCredentialVerifier.ts`). Subscription setup defers to the existing, now-functional post-boot admin panel instead of reimplementing its login/detection UX in a CSP-locked, framework-less wizard.
- No optional CLI `--version` existence probe at wizard time — nice-to-have, adds spawn/PATH complexity for no correctness gain.
- #889 (same onboarding gap in the web-ui dashboard, once past first run) is a separate issue/PR.

## Verification (all local, pre-commit)
- `desktop`: `tsc --noEmit` — clean
- `desktop`: `npm run build` (tsc + preload bundle + renderer copy) — succeeds
- `desktop`: `node --test scripts/*.test.mjs` — **22/22 pass**, no regressions
- Independent `omadia-reviewer` pass: traced the full mode-toggle state cycle, confirmed the API-key path is byte-for-byte unchanged, confirmed `requiresApiKey()`'s type narrowing is actually sound (not just visual), confirmed every new i18n key has a matching EN/DE pair with no orphans, independently re-verified the admin breadcrumb text against the real nav labels — no CRITICAL/HIGH findings

## Known trade-off (not blocking)
No automated test for the wizard renderer files themselves (`wizard.js`/`wizard-i18n.js`) — this repo has zero test-runner coverage for `desktop/src/renderer/*` today (plain HTML/CSS/JS, no build step, no DOM test harness wired up), same structural gap already accepted for `desktop/src/*.ts` during #882/#883. A full manual click-through of both wizard paths, in both EN and DE OS locales, on a real `npm run dev` or packaged build is the realistic verification bar and should happen before/shortly after this ships.

## Test plan
- [x] Automated tests above, all green
- [ ] Manual: click through both wizard paths (API key / subscription) end-to-end, confirm the kernel boots successfully with no stored provider key in subscription mode
- [ ] Manual: toggle OS locale to German, confirm both new strings render correctly with no fallback-to-English gaps

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790415507&installation_model_id=428086&pr_number=893&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F893&signature=e3ab430f39ee9dcb0f18b5f173cebb0148d2056cf88c614c8a4355234bc21cd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->