### PR TITLE
fix(#884): plugin Hub stops counting a plugin ready with no verified LLM credential

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,26 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — plugin readiness no longer calls a plugin ready without a verified LLM credential (#884)
+
+2026-08-27 — The Hub reported "14 von 14 einsatzbereit" while no LLM provider
+held a verified credential, because `computeReadiness()` only ever checked a
+plugin's own manifest-required setup fields and had no concept of the provider
+it routes through. The per-provider verdict logic that the providers-admin page
+already computed inline (CLI login, OAuth grant, or key-based cache/durable
+record) is now extracted to `middleware/src/platform/pluginLlmReadiness.ts` and
+shared, so the two surfaces can no longer disagree about the same credential.
+Readiness gained a fifth state, `awaiting_llm`, returned only for an
+LLM-consuming plugin that would otherwise be `ready` and whose assigned
+provider's verdict is anything other than `verified`. The check runs after the
+existing `not_installed`/`errored`/`config_required` steps and degrades to
+`ready` on any probe failure, matching the file's existing rule that an
+infrastructure hiccup must never manufacture a false negative. The web-ui
+mirrors the new state as a warning-toned "Konfiguriert – wartet auf LLM-Zugang"
+badge plus a post-install CTA to `/admin/providers`; the Hub count, the
+dashboard tile and the plugin tiles needed no change, because all three already
+read the shared `isReady` predicate.
+
 ### Fixed — desktop first-run wizard no longer forces API-key entry (#890)
 
 2026-08-27 — The Electron desktop wizard hard-blocked every first-time setup on

--- a/middleware/src/api/admin-v1.ts
+++ b/middleware/src/api/admin-v1.ts
@@ -425,10 +425,18 @@ export interface PluginActionStatus {
  * Unlike `PluginActionStatus` (push-only, plugins that call `ctx.status`),
  * readiness is computed by the kernel and therefore also covers the majority
  * of plugins that never report status at all.
+ *
+ * `awaiting_llm` (#884) is deliberately NOT folded into `config_required`. The
+ * plugin's own manifest-required fields are all satisfied; what is missing is a
+ * VERIFIED credential on the LLM provider it was assigned, and that lives on a
+ * different page (`/admin/providers`) entirely. Saying "configuration required"
+ * would send the operator to the plugin's own setup form, where there is
+ * nothing left to fill in.
  */
 export type PluginReadinessState =
   | 'not_installed'
   | 'config_required'
+  | 'awaiting_llm'
   | 'ready'
   | 'errored';
 

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -148,6 +148,7 @@ import { createAdminEmbeddingProviderRouter } from './routes/adminEmbeddingProvi
 import { createAdminTranscriptionProviderRouter } from './routes/adminTranscriptionProvider.js';
 import { createAdminCliBackendsRouter } from './routes/adminCliBackends.js';
 import { registerClaudeCliAdapter } from './platform/claudeCliAdapter.js';
+import { resolvePluginLlmReadiness } from './platform/pluginLlmReadiness.js';
 import { createServiceRegistryBackedSqlGrantStore } from './platform/pluginSqlGrantStore.js';
 import { createVaultStatusRouter } from './routes/vaultStatus.js';
 import { createBuilderRouter } from './routes/builder.js';
@@ -4161,6 +4162,18 @@ async function main(): Promise<void> {
       // Issue #453 — read-only code-scan verdict on the detail response
       // plus the operator ack endpoint. Lookup only, never scans on GET.
       verdicts: pluginVerdictLookup,
+      // #884 — the Hub's "X of Y ready" count called every plugin ready while
+      // the LLM provider it routes through had no verified credential. This is
+      // the probe that lets readiness see that dependency. Reuses the vault and
+      // catalog already constructed above; a second instance of either would
+      // read a different view of the same state.
+      llmReadiness: {
+        resolve: (pluginId, config) =>
+          resolvePluginLlmReadiness(pluginId, config, {
+            vault: secretVault,
+            llmProviderCatalog,
+          }),
+      },
     }),
   );
   console.log('[middleware] plugin store endpoints ready at /api/v1/store/plugins (auth: required)');

--- a/middleware/src/platform/pluginLlmReadiness.ts
+++ b/middleware/src/platform/pluginLlmReadiness.ts
@@ -1,0 +1,264 @@
+/**
+ * Shared LLM-provider readiness verdicts. This logic used to live inline in
+ * the providers-admin list handler. Plugin readiness (#884) needs the exact
+ * same answer, and duplicating it would have let the Hub's "ready" count and
+ * the providers page disagree about the very same credential — which is the
+ * bug #884 reports.
+ */
+import {
+  isProviderOAuthReconnectRequired,
+  legacyProviderApiKeyVaultKey,
+  providerApiKeyVaultKey,
+  readProviderOAuthTokens,
+  type ProviderId,
+} from '@omadia/llm-provider';
+
+import {
+  detectCliBackends,
+  type CliBackendsSnapshot,
+} from './cliBackendDetector.js';
+import {
+  decodeVerifiedRecord,
+  getCachedVerification,
+  primeVerification,
+  providerVerifiedAtVaultKey,
+  type ProviderVerification,
+} from './providerCredentialVerifier.js';
+
+/**
+ * LLM-consuming plugins whose provider/model is operator-selectable. The
+ * provider key is the standardized `llm_provider` (S4b) for all; the model key
+ * differs per plugin. `extraOnSwitch` is applied when assigning — e.g. the
+ * orchestrator's per-turn model routing must be OFF for a non-Anthropic
+ * provider, else it would emit Claude model ids to a non-Claude provider.
+ */
+export interface LlmPluginDesc {
+  readonly id: string;
+  readonly label: string;
+  /** Model config keys to set (first is the primary shown in the UI). */
+  readonly modelKeys: readonly string[];
+  /** Extra config to apply on a non-Anthropic assignment. */
+  readonly extraOnNonAnthropic?: Readonly<Record<string, string>>;
+  /** This plugin drives a tool loop, so a tool-less provider (e.g. the
+   *  `claude-cli` Shape-2 backend) must NOT be assignable to it — that would
+   *  silently disable its tools. Tool-less plugins (extractors/classifiers)
+   *  omit this. */
+  readonly requiresTools?: boolean;
+}
+
+export const LLM_PLUGINS: ReadonlyArray<LlmPluginDesc> = [
+  {
+    id: '@omadia/orchestrator',
+    label: 'Orchestrator',
+    modelKeys: ['orchestrator_model'],
+    // Per-turn Sonnet/Opus routing only makes sense within Anthropic; the
+    // default chatAgent path now accepts the subscription CLI via Shape 3.
+    extraOnNonAnthropic: { orchestrator_model_routing: 'false' },
+  },
+  {
+    id: '@omadia/verifier',
+    label: 'Verifier',
+    modelKeys: ['verifier_model'],
+    // The verifier uses FORCED single-tool structured output (claimExtractor /
+    // evidenceJudge), which the claude-cli provider now supports via a
+    // JSON-schema prompt — so the subscription CLI is a valid choice here.
+  },
+  {
+    id: '@omadia/orchestrator-extras',
+    label: 'Background-Scorer',
+    modelKeys: ['fact_extractor_model', 'topic_classifier_model'],
+  },
+];
+
+export const DEFAULT_PROVIDER: ProviderId = 'anthropic';
+
+export interface LlmProviderDescriptorView {
+  readonly label: string;
+  readonly wireFormat?: string;
+  readonly baseURL?: string;
+  readonly policy?: {
+    readonly requiresAvvDisclosure?: boolean;
+    readonly euHosted?: boolean;
+    readonly requiresApiKey?: boolean;
+    readonly subscriptionNotice?: boolean;
+  };
+  readonly oauth?: { readonly kind: 'device' };
+}
+
+export interface LlmProviderCatalogView {
+  get(id: string): LlmProviderDescriptorView | undefined;
+}
+
+/** The subset of `SecretVault` the provider-credential lookups need. Structural
+ *  for the same reason `ReadinessVault` is: a test passes a one-line stub and
+ *  the real vault fits without a cast. */
+export interface ProviderKeyVault {
+  get(agentId: string, key: string): Promise<string | undefined>;
+}
+
+export interface StoredProviderKey {
+  /** The LLM-plugin vault scope the key was found in. Durable verification
+   *  records are written to (and read from) this same scope, so the two never
+   *  disagree about which scope owns the provider's state. */
+  readonly scope: string;
+  readonly apiKey: string;
+}
+
+/** First LLM-plugin scope holding this provider's API key (canonical, or the
+ *  legacy flat key for Anthropic), or `undefined` if no scope has one. */
+export async function findProviderKey(
+  vault: ProviderKeyVault | undefined,
+  provider: ProviderId,
+): Promise<StoredProviderKey | undefined> {
+  if (!vault) return undefined;
+  const canonical = providerApiKeyVaultKey(provider);
+  const legacy = legacyProviderApiKeyVaultKey(provider);
+  for (const desc of LLM_PLUGINS) {
+    for (const key of legacy === undefined ? [canonical] : [canonical, legacy]) {
+      const v = await vault.get(desc.id, key);
+      if (typeof v === 'string' && v.trim().length > 0) {
+        return { scope: desc.id, apiKey: v.trim() };
+      }
+    }
+  }
+  return undefined;
+}
+
+/** True when any LLM-plugin scope holds an OAuth access token for the provider
+ *  (#294). "Connected via Sign in with ChatGPT" is exactly this. */
+async function isProviderOAuthConnected(
+  vault: ProviderKeyVault | undefined,
+  provider: ProviderId,
+): Promise<boolean> {
+  if (!vault) return false;
+  for (const desc of LLM_PLUGINS) {
+    const tokens = await readProviderOAuthTokens(
+      (k) => vault.get(desc.id, k),
+      provider,
+    );
+    if (tokens !== undefined) return true;
+  }
+  return false;
+}
+
+/**
+ * The provider's credential verdict, WITHOUT touching the network:
+ *   - no key in any scope                       → `no_key`
+ *   - keyless provider (local/self-hosted)      → `verified`
+ *   - a fresh cached probe for THIS key         → that verdict
+ *   - a durable `verified_at` record for THIS key → `verified`
+ *   - otherwise                                 → `unverified`
+ *
+ * `unverified` is the honest default: a key exists, but nothing has ever proved
+ * it works. That is precisely the state the old boolean rendered as "connected".
+ */
+async function resolveKeyBasedStatus(
+  vault: ProviderKeyVault | undefined,
+  provider: ProviderId,
+  descriptor: LlmProviderDescriptorView | undefined,
+): Promise<ProviderVerification> {
+  // Local / self-hosted providers have no credential to reject.
+  if (descriptor?.policy?.requiresApiKey === false) {
+    return { status: 'verified' };
+  }
+  const found = await findProviderKey(vault, provider);
+  if (found === undefined) return { status: 'no_key' };
+
+  const cached = getCachedVerification(provider, found.apiKey);
+  if (cached !== undefined) return cached;
+
+  // Cold cache (fresh process). A durable record proves an earlier probe
+  // succeeded — but only if it was written for the key that is stored NOW.
+  const raw = await vault?.get(
+    found.scope,
+    providerVerifiedAtVaultKey(provider),
+  );
+  const verifiedAt = decodeVerifiedRecord(raw, found.apiKey);
+  if (verifiedAt !== undefined) {
+    const verification: ProviderVerification = {
+      status: 'verified',
+      verifiedAt,
+      checkedAt: verifiedAt,
+    };
+    primeVerification(provider, found.apiKey, verification);
+    return verification;
+  }
+  return { status: 'unverified' };
+}
+
+export function readStringConfig(
+  cfg: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const v = cfg[key];
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+export interface ProviderVerificationDeps {
+  readonly vault?: ProviderKeyVault;
+  readonly llmProviderCatalog?: LlmProviderCatalogView;
+  /** Pre-detected CLI snapshot. The providers-admin list handler probes ONCE
+   *  and fans the same snapshot across every row; passing it in preserves that
+   *  single-probe property instead of re-detecting per provider. `undefined`
+   *  means "not detected, or detection failed". */
+  readonly cliSnapshot?: CliBackendsSnapshot | undefined;
+}
+
+export async function resolveProviderVerification(
+  provider: ProviderId,
+  deps: ProviderVerificationDeps,
+): Promise<ProviderVerification> {
+  const descriptor = deps.llmProviderCatalog?.get(provider);
+  // #294: an OAuth provider is "connected" when device-flow tokens are
+  // stored — the login IS the credential, so there is no key to probe.
+  const oauthConnect = descriptor?.oauth !== undefined;
+  const cliConnected = (cliId: string): boolean =>
+    deps.cliSnapshot?.backends.find((b) => b.id === cliId)?.loggedIn === 'yes';
+  // #309: a CLI-backed provider is keyless — its "does it work" probe is
+  // the CLI login check above, not a credential probe.
+  return provider === 'claude-cli'
+    ? cliConnected('claude')
+      ? { status: 'verified' }
+      : { status: 'no_key' }
+    : oauthConnect
+      ? // A dead grant (terminal refresh failure) leaves stale tokens
+        // in the vault; the process-wide latch is the truth. Report
+        // `no_key` so the row shows "Reconnect" instead of a green
+        // chip that lies while every call throws.
+        isProviderOAuthReconnectRequired(provider) ||
+        !(await isProviderOAuthConnected(deps.vault, provider))
+        ? { status: 'no_key' }
+        : { status: 'verified' }
+      : await resolveKeyBasedStatus(deps.vault, provider, descriptor);
+}
+
+export interface PluginLlmReadinessDeps extends ProviderVerificationDeps {
+  /** CLI detection for callers that — unlike the providers-admin page — have no
+   *  pre-detected snapshot to hand down. Defaults to the cached
+   *  `detectCliBackends()`; a test injects a stub so no test ever shells out. */
+  readonly detectCli?: () => Promise<CliBackendsSnapshot | undefined>;
+}
+
+const detectCliSnapshot = (): Promise<CliBackendsSnapshot | undefined> =>
+  detectCliBackends().catch(() => undefined);
+
+export async function resolvePluginLlmReadiness(
+  pluginId: string,
+  config: Record<string, unknown> | undefined,
+  deps: PluginLlmReadinessDeps,
+): Promise<ProviderVerification | undefined> {
+  if (!LLM_PLUGINS.some((desc) => desc.id === pluginId)) {
+    return undefined;
+  }
+
+  const provider = (
+    readStringConfig(config ?? {}, 'llm_provider') ?? DEFAULT_PROVIDER
+  ) as ProviderId;
+  const cliSnapshot =
+    'cliSnapshot' in deps
+      ? deps.cliSnapshot
+      : provider === 'claude-cli'
+        ? await (deps.detectCli ?? detectCliSnapshot)()
+        : undefined;
+  return await resolveProviderVerification(provider, { ...deps, cliSnapshot });
+}

--- a/middleware/src/plugins/readiness.ts
+++ b/middleware/src/plugins/readiness.ts
@@ -38,6 +38,7 @@ import type {
   PluginReadiness,
   PluginSetupField,
 } from '../api/admin-v1.js';
+import type { ProviderVerification } from '../platform/providerCredentialVerifier.js';
 import type { InstalledAgent, InstalledRegistry } from './installedRegistry.js';
 
 export type { PluginReadiness } from '../api/admin-v1.js';
@@ -46,6 +47,17 @@ export type { PluginReadiness } from '../api/admin-v1.js';
  *  tests can pass a two-line stub and the real vault fits without a cast. */
 export interface ReadinessVault {
   listKeys(agentId: string): Promise<string[]>;
+}
+
+/** #884 — "does the LLM provider this plugin routes through actually have a
+ *  working credential?". Structural for the same reason `ReadinessVault` is:
+ *  a test passes a one-line stub and the real resolver fits without a cast.
+ *  Returns `undefined` for a plugin that consumes no LLM at all. */
+export interface ReadinessLlmProbe {
+  resolve(
+    pluginId: string,
+    config: Record<string, unknown> | undefined,
+  ): Promise<ProviderVerification | undefined>;
 }
 
 /** Kernel-injected synthetic setup fields (`_privacy_mode`,
@@ -94,7 +106,9 @@ function verifiedAt(entry: InstalledAgent): string | null {
  *   1. not in the installed registry              → 'not_installed'
  *   2. registry entry status === 'errored'        → 'errored' (+ error detail)
  *   3. a required, checkable setup field is empty → 'config_required'
- *   4. otherwise                                  → 'ready'
+ *   4. the plugin's assigned LLM provider has no
+ *      VERIFIED credential                        → 'awaiting_llm'
+ *   5. otherwise                                  → 'ready'
  *
  * Never rejects: a vault failure degrades to 'ready'.
  */
@@ -102,6 +116,7 @@ export async function computeReadiness(
   plugin: Pick<Plugin, 'id' | 'setup_fields'>,
   registry: InstalledRegistry,
   vault?: ReadinessVault,
+  llmProbe?: ReadinessLlmProbe,
 ): Promise<PluginReadiness> {
   const entry = registry.get(plugin.id);
   if (!entry) {
@@ -147,6 +162,21 @@ export async function computeReadiness(
   if (missing.length > 0) {
     return { state: 'config_required', missing_fields: missing, verified_at: null };
   }
+
+  if (!llmProbe) {
+    return { state: 'ready', missing_fields: [], verified_at: verifiedAt(entry) };
+  }
+
+  try {
+    const verdict = await llmProbe.resolve(plugin.id, entry.config);
+    if (verdict !== undefined && verdict.status !== 'verified') {
+      return { state: 'awaiting_llm', missing_fields: [], verified_at: null };
+    }
+  } catch {
+    // Same rule as the vault: a provider-probe hiccup must not flip the whole
+    // catalog away from "ready" based on an infrastructure-side failure.
+  }
+
   return { state: 'ready', missing_fields: [], verified_at: verifiedAt(entry) };
 }
 
@@ -157,9 +187,10 @@ export async function withReadiness(
   plugin: Plugin,
   registry: InstalledRegistry,
   vault?: ReadinessVault,
+  llmProbe?: ReadinessLlmProbe,
 ): Promise<Plugin> {
   try {
-    const readiness = await computeReadiness(plugin, registry, vault);
+    const readiness = await computeReadiness(plugin, registry, vault, llmProbe);
     return { ...plugin, readiness };
   } catch {
     return plugin;

--- a/middleware/src/routes/adminProviders.ts
+++ b/middleware/src/routes/adminProviders.ts
@@ -30,15 +30,11 @@
  */
 import {
   exchangeAuthorizationCode,
-  isProviderOAuthReconnectRequired,
-  legacyProviderApiKeyVaultKey,
   listModels,
   listModelsByProvider,
   OPENAI_CODEX_OAUTH,
   pollDeviceToken,
   primeProviderOAuthTokens,
-  providerApiKeyVaultKey,
-  readProviderOAuthTokens,
   requestUserCode,
   resolveModelRef,
   writeProviderOAuthTokens,
@@ -56,15 +52,20 @@ import type { InstalledRegistry } from '../plugins/installedRegistry.js';
 import type { SecretVault } from '../secrets/vault.js';
 import { detectCliBackends } from '../platform/cliBackendDetector.js';
 import {
-  decodeVerifiedRecord,
   encodeVerifiedRecord,
-  getCachedVerification,
   keyFingerprint,
-  primeVerification,
   providerVerifiedAtVaultKey,
   verifyProviderCredential,
   type ProviderVerification,
 } from '../platform/providerCredentialVerifier.js';
+import {
+  DEFAULT_PROVIDER,
+  LLM_PLUGINS,
+  findProviderKey,
+  readStringConfig,
+  resolveProviderVerification,
+  type LlmProviderCatalogView,
+} from '../platform/pluginLlmReadiness.js';
 
 export interface AdminProvidersDeps {
   readonly installedRegistry: InstalledRegistry;
@@ -73,80 +74,13 @@ export interface AdminProvidersDeps {
   readonly reactivate?: (agentId: string) => Promise<void>;
   /** Provider catalog — supplies display labels + data-protection policy hints
    *  for the admin UI (structural, to avoid a hard dep on the catalog class). */
-  readonly llmProviderCatalog?: {
-    get(id: string):
-      | {
-          readonly label: string;
-          readonly wireFormat?: string;
-          readonly baseURL?: string;
-          readonly policy?: {
-            readonly requiresAvvDisclosure?: boolean;
-            readonly euHosted?: boolean;
-            readonly requiresApiKey?: boolean;
-            readonly subscriptionNotice?: boolean;
-          };
-          readonly oauth?: { readonly kind: 'device' };
-        }
-      | undefined;
-  };
+  readonly llmProviderCatalog?: LlmProviderCatalogView;
   /** OAuth client config for the device flow. Defaults to the OpenAI Codex
    *  client; a test injects a fake pointing at a mock issuer. */
   readonly oauthConfig?: OAuthClientConfig;
   /** Injected fetch for the device-flow HTTP calls (test seam). */
   readonly oauthFetch?: typeof fetch;
 }
-
-/** The subset of a catalog descriptor the credential probe needs. */
-type ProviderDescriptorView = NonNullable<
-  ReturnType<NonNullable<AdminProvidersDeps['llmProviderCatalog']>['get']>
->;
-
-/**
- * LLM-consuming plugins whose provider/model is operator-selectable. The
- * provider key is the standardized `llm_provider` (S4b) for all; the model key
- * differs per plugin. `extraOnSwitch` is applied when assigning — e.g. the
- * orchestrator's per-turn model routing must be OFF for a non-Anthropic
- * provider, else it would emit Claude model ids to a non-Claude provider.
- */
-interface LlmPluginDesc {
-  readonly id: string;
-  readonly label: string;
-  /** Model config keys to set (first is the primary shown in the UI). */
-  readonly modelKeys: readonly string[];
-  /** Extra config to apply on a non-Anthropic assignment. */
-  readonly extraOnNonAnthropic?: Readonly<Record<string, string>>;
-  /** This plugin drives a tool loop, so a tool-less provider (e.g. the
-   *  `claude-cli` Shape-2 backend) must NOT be assignable to it — that would
-   *  silently disable its tools. Tool-less plugins (extractors/classifiers)
-   *  omit this. */
-  readonly requiresTools?: boolean;
-}
-
-const LLM_PLUGINS: ReadonlyArray<LlmPluginDesc> = [
-  {
-    id: '@omadia/orchestrator',
-    label: 'Orchestrator',
-    modelKeys: ['orchestrator_model'],
-    // Per-turn Sonnet/Opus routing only makes sense within Anthropic; the
-    // default chatAgent path now accepts the subscription CLI via Shape 3.
-    extraOnNonAnthropic: { orchestrator_model_routing: 'false' },
-  },
-  {
-    id: '@omadia/verifier',
-    label: 'Verifier',
-    modelKeys: ['verifier_model'],
-    // The verifier uses FORCED single-tool structured output (claimExtractor /
-    // evidenceJudge), which the claude-cli provider now supports via a
-    // JSON-schema prompt — so the subscription CLI is a valid choice here.
-  },
-  {
-    id: '@omadia/orchestrator-extras',
-    label: 'Background-Scorer',
-    modelKeys: ['fact_extractor_model', 'topic_classifier_model'],
-  },
-];
-
-const DEFAULT_PROVIDER: ProviderId = 'anthropic';
 
 function providerLabel(id: ProviderId): string {
   switch (id) {
@@ -161,51 +95,6 @@ function providerLabel(id: ProviderId): string {
     default:
       return id;
   }
-}
-
-interface StoredProviderKey {
-  /** The LLM-plugin vault scope the key was found in. Durable verification
-   *  records are written to (and read from) this same scope, so the two never
-   *  disagree about which scope owns the provider's state. */
-  readonly scope: string;
-  readonly apiKey: string;
-}
-
-/** First LLM-plugin scope holding this provider's API key (canonical, or the
- *  legacy flat key for Anthropic), or `undefined` if no scope has one. */
-async function findProviderKey(
-  vault: SecretVault | undefined,
-  provider: ProviderId,
-): Promise<StoredProviderKey | undefined> {
-  if (!vault) return undefined;
-  const canonical = providerApiKeyVaultKey(provider);
-  const legacy = legacyProviderApiKeyVaultKey(provider);
-  for (const desc of LLM_PLUGINS) {
-    for (const key of legacy === undefined ? [canonical] : [canonical, legacy]) {
-      const v = await vault.get(desc.id, key);
-      if (typeof v === 'string' && v.trim().length > 0) {
-        return { scope: desc.id, apiKey: v.trim() };
-      }
-    }
-  }
-  return undefined;
-}
-
-/** True when any LLM-plugin scope holds an OAuth access token for the provider
- *  (#294). "Connected via Sign in with ChatGPT" is exactly this. */
-async function isProviderOAuthConnected(
-  vault: SecretVault | undefined,
-  provider: ProviderId,
-): Promise<boolean> {
-  if (!vault) return false;
-  for (const desc of LLM_PLUGINS) {
-    const tokens = await readProviderOAuthTokens(
-      (k) => vault.get(desc.id, k),
-      provider,
-    );
-    if (tokens !== undefined) return true;
-  }
-  return false;
 }
 
 /** Fan a provider's OAuth tokens out to EVERY LLM-plugin scope with one shared
@@ -238,51 +127,6 @@ async function fanOutProviderOAuthTokens(
 }
 
 /**
- * The provider's credential verdict, WITHOUT touching the network:
- *   - no key in any scope                       → `no_key`
- *   - keyless provider (local/self-hosted)      → `verified`
- *   - a fresh cached probe for THIS key         → that verdict
- *   - a durable `verified_at` record for THIS key → `verified`
- *   - otherwise                                 → `unverified`
- *
- * `unverified` is the honest default: a key exists, but nothing has ever proved
- * it works. That is precisely the state the old boolean rendered as "connected".
- */
-async function resolveStatus(
-  vault: SecretVault | undefined,
-  provider: ProviderId,
-  descriptor: ProviderDescriptorView | undefined,
-): Promise<ProviderVerification> {
-  // Local / self-hosted providers have no credential to reject.
-  if (descriptor?.policy?.requiresApiKey === false) {
-    return { status: 'verified' };
-  }
-  const found = await findProviderKey(vault, provider);
-  if (found === undefined) return { status: 'no_key' };
-
-  const cached = getCachedVerification(provider, found.apiKey);
-  if (cached !== undefined) return cached;
-
-  // Cold cache (fresh process). A durable record proves an earlier probe
-  // succeeded — but only if it was written for the key that is stored NOW.
-  const raw = await vault?.get(
-    found.scope,
-    providerVerifiedAtVaultKey(provider),
-  );
-  const verifiedAt = decodeVerifiedRecord(raw, found.apiKey);
-  if (verifiedAt !== undefined) {
-    const verification: ProviderVerification = {
-      status: 'verified',
-      verifiedAt,
-      checkedAt: verifiedAt,
-    };
-    primeVerification(provider, found.apiKey, verification);
-    return verification;
-  }
-  return { status: 'unverified' };
-}
-
-/**
  * Stable provider ordering (OM-10b). `listModels()` returns providers in plugin
  * ACTIVATION order, and `reactivate()` after a key save disposes + re-registers
  * that plugin's models — moving the provider the operator just configured to the
@@ -303,14 +147,6 @@ function compareProviders(
   return a.id < b.id ? -1 : 1;
 }
 
-function readStringConfig(
-  cfg: Record<string, unknown>,
-  key: string,
-): string | undefined {
-  const v = cfg[key];
-  return typeof v === 'string' && v.length > 0 ? v : undefined;
-}
-
 export function createAdminProvidersRouter(deps: AdminProvidersDeps): Router {
   const router = Router();
 
@@ -322,8 +158,6 @@ export function createAdminProvidersRouter(deps: AdminProvidersDeps): Router {
       // #309: a CLI-backed provider is keyless — "connected" means the local CLI
       // is installed AND logged in (host capability), not a vault key. Detect once.
       const cliSnap = await detectCliBackends().catch(() => undefined);
-      const cliConnected = (cliId: string): boolean =>
-        cliSnap?.backends.find((b) => b.id === cliId)?.loggedIn === 'yes';
       // OM-11: "is the host binary this provider needs actually present?".
       // Distinct from `connected` — a CLI that is absent can never be logged
       // into, and the UI must not offer "Anmelden" as if it could. Detection
@@ -339,23 +173,11 @@ export function createAdminProvidersRouter(deps: AdminProvidersDeps): Router {
           // #294: an OAuth provider is "connected" when device-flow tokens are
           // stored — the login IS the credential, so there is no key to probe.
           const oauthConnect = descriptor?.oauth !== undefined;
-          // #309: a CLI-backed provider is keyless — its "does it work" probe is
-          // the CLI login check above, not a credential probe.
-          const verification: ProviderVerification =
-            id === 'claude-cli'
-              ? cliConnected('claude')
-                ? { status: 'verified' }
-                : { status: 'no_key' }
-              : oauthConnect
-                ? // A dead grant (terminal refresh failure) leaves stale tokens
-                  // in the vault; the process-wide latch is the truth. Report
-                  // `no_key` so the row shows "Reconnect" instead of a green
-                  // chip that lies while every call throws.
-                  isProviderOAuthReconnectRequired(id) ||
-                  !(await isProviderOAuthConnected(deps.vault, id))
-                  ? { status: 'no_key' }
-                  : { status: 'verified' }
-                : await resolveStatus(deps.vault, id, descriptor);
+          const verification = await resolveProviderVerification(id, {
+            vault: deps.vault,
+            llmProviderCatalog: deps.llmProviderCatalog,
+            cliSnapshot: cliSnap,
+          });
           return {
           id,
           label: descriptor?.label ?? providerLabel(id),

--- a/middleware/src/routes/store.ts
+++ b/middleware/src/routes/store.ts
@@ -13,7 +13,11 @@ import type { PluginCatalog } from '../plugins/manifestLoader.js';
 import { parseSetupProfile } from '../plugins/manifestLoader.js';
 import type { PluginStatusRegistry } from '../platform/pluginStatusRegistry.js';
 import type { PluginVerdictLookup } from '../services/pluginVerdict.js';
-import { withReadiness, type ReadinessVault } from '../plugins/readiness.js';
+import {
+  withReadiness,
+  type ReadinessLlmProbe,
+  type ReadinessVault,
+} from '../plugins/readiness.js';
 import { findProvidesCollision } from '../plugins/capabilityResolver.js';
 import type {
   RegistryClient,
@@ -40,6 +44,11 @@ interface StoreDeps {
    *  without it, secret-typed fields are assumed satisfied and readiness still
    *  reports config/errored state from the registry alone. */
   vault?: ReadinessVault;
+  /** #884 — resolves whether the LLM provider a plugin routes through holds a
+   *  VERIFIED credential. Without it the store counted a plugin as ready while
+   *  every chat turn through it would fail on a missing key. Optional, so an
+   *  older composition root keeps the pre-#884 behaviour. */
+  llmReadiness?: ReadinessLlmProbe;
 }
 
 /** Overlay the live `ctx.status` value (if any) onto a plugin record. Returns
@@ -140,6 +149,7 @@ export function createStoreRouter(deps: StoreDeps): Router {
             withActionStatus(p, deps.pluginStatusRegistry),
             deps.registry,
             deps.vault,
+            deps.llmReadiness,
           ),
         ),
       );
@@ -260,7 +270,12 @@ export function createStoreRouter(deps: StoreDeps): Router {
       const installAvailable = plugin.install_state === 'available' && !collision;
       plugin = withActionStatus(plugin, deps.pluginStatusRegistry);
       // OM-16 — see the list handler. Orthogonal to install_state.
-      plugin = await withReadiness(plugin, deps.registry, deps.vault);
+      plugin = await withReadiness(
+        plugin,
+        deps.registry,
+        deps.vault,
+        deps.llmReadiness,
+      );
       // Issue #453 — decorate with the advisory code-scan verdict. Pure
       // lookup (never triggers a scan); a store hiccup degrades to "no
       // verdict shown", never a 500.

--- a/middleware/test/pluginLlmReadiness.test.ts
+++ b/middleware/test/pluginLlmReadiness.test.ts
@@ -1,0 +1,233 @@
+/**
+ * #884 — this module is the single source of truth for "does this provider
+ * have a working credential". Before #884 one route answered that inline, and
+ * the Hub's ready count did not answer it at all.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { providerApiKeyVaultKey } from '@omadia/llm-provider';
+
+import {
+  DEFAULT_PROVIDER,
+  LLM_PLUGINS,
+  findProviderKey,
+  resolvePluginLlmReadiness,
+  resolveProviderVerification,
+  type LlmProviderCatalogView,
+} from '../src/platform/pluginLlmReadiness.js';
+import { __clearVerificationCache } from '../src/platform/providerCredentialVerifier.js';
+import type {
+  CliBackendsSnapshot,
+  CliBackendStatus,
+  CliLoginState,
+} from '../src/platform/cliBackendDetector.js';
+import { InMemorySecretVault } from '../src/secrets/vault.js';
+
+function catalogRecording(
+  calls: string[],
+  descriptor: ReturnType<LlmProviderCatalogView['get']> = { label: 'provider' },
+): LlmProviderCatalogView {
+  return {
+    get(id: string) {
+      calls.push(id);
+      return descriptor;
+    },
+  };
+}
+
+/** A fully-populated snapshot fixture. The unrelated fields (`label`, `bin`,
+ *  `billing`, `detail`, `installable`) are filled in rather than cast away:
+ *  `CliBackendStatus` is the real host-probe DTO, and a partial cast here would
+ *  keep compiling if the verdict logic ever started reading one of them. */
+function snapshot(
+  backends: Array<{ id: string; loggedIn: CliLoginState }>,
+): CliBackendsSnapshot {
+  return {
+    backends: backends.map(
+      (backend): CliBackendStatus => ({
+        id: backend.id,
+        label: backend.id,
+        bin: backend.id,
+        installed: true,
+        loggedIn: backend.loggedIn,
+        billing: 'subscription',
+        detail: `${backend.id} probe fixture`,
+        installable: true,
+      }),
+    ),
+    generatedAt: 0,
+    cliToolsDir: '/tmp/cli-tools',
+  };
+}
+
+test('resolvePluginLlmReadiness returns undefined for non-LLM plugins without touching deps', async () => {
+  const verdict = await resolvePluginLlmReadiness(
+    'de.byte5.integration.google-workspace',
+    {},
+    {
+      vault: {
+        get: async (): Promise<string | undefined> => {
+          throw new Error('vault should not be read');
+        },
+      },
+      llmProviderCatalog: {
+        get: (): never => {
+          throw new Error('catalog should not be read');
+        },
+      },
+    },
+  );
+  assert.equal(verdict, undefined);
+});
+
+test('every registered LLM plugin id resolves to a defined provider verdict', async () => {
+  __clearVerificationCache();
+  for (const desc of LLM_PLUGINS) {
+    const verdict = await resolvePluginLlmReadiness(desc.id, {}, {
+      vault: { get: async (): Promise<string | undefined> => undefined },
+      llmProviderCatalog: { get: () => ({ label: 'Anthropic' }) },
+      cliSnapshot: undefined,
+    });
+    assert.notEqual(verdict, undefined, desc.id);
+  }
+});
+
+test('default provider falls back to anthropic when llm_provider is absent, empty, or not a string', async () => {
+  __clearVerificationCache();
+  const calls: string[] = [];
+  const catalog = catalogRecording(calls);
+
+  await resolvePluginLlmReadiness('@omadia/orchestrator', {}, {
+    vault: { get: async (): Promise<string | undefined> => undefined },
+    llmProviderCatalog: catalog,
+    cliSnapshot: undefined,
+  });
+  await resolvePluginLlmReadiness('@omadia/orchestrator', { llm_provider: '' }, {
+    vault: { get: async (): Promise<string | undefined> => undefined },
+    llmProviderCatalog: catalog,
+    cliSnapshot: undefined,
+  });
+  await resolvePluginLlmReadiness(
+    '@omadia/orchestrator',
+    { llm_provider: 42 },
+    {
+      vault: { get: async (): Promise<string | undefined> => undefined },
+      llmProviderCatalog: catalog,
+      cliSnapshot: undefined,
+    },
+  );
+
+  assert.deepEqual(calls, [
+    DEFAULT_PROVIDER,
+    DEFAULT_PROVIDER,
+    DEFAULT_PROVIDER,
+  ]);
+});
+
+test('an explicit llm_provider value is the provider that gets probed', async () => {
+  __clearVerificationCache();
+  const calls: string[] = [];
+  const verdict = await resolvePluginLlmReadiness(
+    '@omadia/orchestrator',
+    { llm_provider: 'openai' },
+    {
+      vault: { get: async (): Promise<string | undefined> => undefined },
+      llmProviderCatalog: catalogRecording(calls),
+      cliSnapshot: undefined,
+    },
+  );
+  assert.equal(verdict?.status, 'no_key');
+  assert.deepEqual(calls, ['openai']);
+});
+
+test('resolveProviderVerification maps claude-cli snapshots to verified or no_key', async () => {
+  const verified = await resolveProviderVerification('claude-cli', {
+    cliSnapshot: snapshot([{ id: 'claude', loggedIn: 'yes' }]),
+  });
+  const loggedOut = await resolveProviderVerification('claude-cli', {
+    cliSnapshot: snapshot([{ id: 'claude', loggedIn: 'no' }]),
+  });
+  const unknown = await resolveProviderVerification('claude-cli', {
+    cliSnapshot: snapshot([{ id: 'claude', loggedIn: 'unknown' }]),
+  });
+  const missingBackend = await resolveProviderVerification('claude-cli', {
+    cliSnapshot: snapshot([{ id: 'codex', loggedIn: 'yes' }]),
+  });
+  const missingSnapshot = await resolveProviderVerification('claude-cli', {
+    cliSnapshot: undefined,
+  });
+
+  assert.equal(verified.status, 'verified');
+  assert.equal(loggedOut.status, 'no_key');
+  assert.equal(unknown.status, 'no_key');
+  assert.equal(missingBackend.status, 'no_key');
+  assert.equal(missingSnapshot.status, 'no_key');
+});
+
+test('resolvePluginLlmReadiness calls detectCli once when claude-cli is assigned and no cliSnapshot key is present', async () => {
+  let detectCalls = 0;
+  const verdict = await resolvePluginLlmReadiness(
+    '@omadia/orchestrator',
+    { llm_provider: 'claude-cli' },
+    {
+      detectCli: async () => {
+        detectCalls += 1;
+        return snapshot([{ id: 'claude', loggedIn: 'yes' }]);
+      },
+    },
+  );
+  assert.equal(detectCalls, 1);
+  assert.equal(verdict?.status, 'verified');
+});
+
+test('a descriptor that declares no API key requirement verifies without consulting the vault', async () => {
+  const verdict = await resolveProviderVerification('anthropic', {
+    vault: {
+      get: async (): Promise<string | undefined> => {
+        throw new Error('vault should not be read');
+      },
+    },
+    llmProviderCatalog: {
+      get: () => ({
+        label: 'Ollama',
+        policy: { requiresApiKey: false },
+      }),
+    },
+  });
+  assert.equal(verdict.status, 'verified');
+});
+
+test('a key-based provider with no stored key returns no_key', async () => {
+  __clearVerificationCache();
+  const verdict = await resolveProviderVerification('anthropic', {
+    vault: new InMemorySecretVault(),
+    llmProviderCatalog: { get: () => ({ label: 'Anthropic' }) },
+  });
+  assert.equal(verdict.status, 'no_key');
+});
+
+test('a stored key with no probe history returns unverified, which the Hub must not treat as ready', async () => {
+  __clearVerificationCache();
+  const vault = new InMemorySecretVault();
+  await vault.set('@omadia/orchestrator', providerApiKeyVaultKey('anthropic'), 'sk-ant');
+
+  const verdict = await resolveProviderVerification('anthropic', {
+    vault,
+    llmProviderCatalog: { get: () => ({ label: 'Anthropic' }) },
+  });
+  assert.equal(verdict.status, 'unverified');
+});
+
+test('findProviderKey returns a key stored in a later LLM-plugin scope and reports that scope', async () => {
+  __clearVerificationCache();
+  const vault = new InMemorySecretVault();
+  await vault.set('@omadia/verifier', providerApiKeyVaultKey('anthropic'), 'sk-verifier');
+
+  const found = await findProviderKey(vault, 'anthropic');
+  assert.deepEqual(found, {
+    scope: '@omadia/verifier',
+    apiKey: 'sk-verifier',
+  });
+});

--- a/middleware/test/pluginReadiness.test.ts
+++ b/middleware/test/pluginReadiness.test.ts
@@ -13,11 +13,15 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { computeReadiness } from '../src/plugins/readiness.js';
+import type { ReadinessLlmProbe } from '../src/plugins/readiness.js';
 import { InMemoryInstalledRegistry } from '../src/plugins/installedRegistry.js';
 import type { InstalledAgent } from '../src/plugins/installedRegistry.js';
 import type { Plugin, PluginSetupField } from '../src/api/admin-v1.js';
+import { resolvePluginLlmReadiness } from '../src/platform/pluginLlmReadiness.js';
+import type { ProviderVerification } from '../src/platform/providerCredentialVerifier.js';
 
 const PLUGIN_ID = 'de.byte5.integration.google-workspace';
+const LLM_PLUGIN_ID = '@omadia/orchestrator';
 
 function field(over: Partial<PluginSetupField> & { key: string }): PluginSetupField {
   return {
@@ -29,6 +33,12 @@ function field(over: Partial<PluginSetupField> & { key: string }): PluginSetupFi
 
 function plugin(fields: PluginSetupField[]): Pick<Plugin, 'id' | 'setup_fields'> {
   return { id: PLUGIN_ID, setup_fields: fields };
+}
+
+function llmPlugin(
+  fields: PluginSetupField[],
+): Pick<Plugin, 'id' | 'setup_fields'> {
+  return { id: LLM_PLUGIN_ID, setup_fields: fields };
 }
 
 async function registryWith(entry: Partial<InstalledAgent>) {
@@ -44,9 +54,35 @@ async function registryWith(entry: Partial<InstalledAgent>) {
   return registry;
 }
 
+async function llmRegistryWith(entry: Partial<InstalledAgent>) {
+  const registry = new InMemoryInstalledRegistry();
+  await registry.register({
+    id: LLM_PLUGIN_ID,
+    installed_version: '1.0.0',
+    installed_at: '2026-01-01T00:00:00.000Z',
+    status: 'active',
+    config: {},
+    ...entry,
+  });
+  return registry;
+}
+
 /** Minimal structural vault: only `listKeys` is used, never a value read. */
 function vaultWith(keys: string[]) {
   return { listKeys: async (): Promise<string[]> => keys };
+}
+
+function probeReturning(
+  verdict: ProviderVerification | undefined,
+): ReadinessLlmProbe & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    resolve: async (pluginId) => {
+      calls.push(pluginId);
+      return verdict;
+    },
+  };
 }
 
 test('a plugin absent from the installed registry is not_installed', async () => {
@@ -220,4 +256,157 @@ test('no vault wired at all → secret fields assumed satisfied, config still ch
   );
   assert.equal(r.state, 'config_required');
   assert.deepEqual(r.missing_fields, ['client_id']);
+});
+
+/**
+ * #884 — a plugin can be installed and locally configured while still lacking a
+ * working provider credential. The Hub must expose that separately from the
+ * older install/config projections.
+ */
+
+test('an LLM plugin stays ready when the 4th computeReadiness argument is omitted', async () => {
+  const registry = await llmRegistryWith({
+    config: { workspace: 'acme' },
+  });
+  const r = await computeReadiness(
+    llmPlugin([field({ key: 'workspace' })]),
+    registry,
+    vaultWith([]),
+  );
+  assert.equal(r.state, 'ready');
+});
+
+test('an LLM plugin with a provider verdict of no_key becomes awaiting_llm', async () => {
+  const registry = await llmRegistryWith({ config: { workspace: 'acme' } });
+  const r = await computeReadiness(
+    llmPlugin([field({ key: 'workspace' })]),
+    registry,
+    vaultWith([]),
+    probeReturning({ status: 'no_key' }),
+  );
+  assert.equal(r.state, 'awaiting_llm');
+  assert.deepEqual(r.missing_fields, []);
+  assert.equal(r.verified_at, null);
+});
+
+test('an LLM plugin with an unverified provider verdict becomes awaiting_llm', async () => {
+  const registry = await llmRegistryWith({ config: { workspace: 'acme' } });
+  const r = await computeReadiness(
+    llmPlugin([field({ key: 'workspace' })]),
+    registry,
+    vaultWith([]),
+    probeReturning({ status: 'unverified' }),
+  );
+  assert.equal(r.state, 'awaiting_llm');
+});
+
+test('an LLM plugin with an invalid provider verdict becomes awaiting_llm', async () => {
+  const registry = await llmRegistryWith({ config: { workspace: 'acme' } });
+  const r = await computeReadiness(
+    llmPlugin([field({ key: 'workspace' })]),
+    registry,
+    vaultWith([]),
+    // A stored key the provider rejects is exactly the state the operator was
+    // being lied to about, so it must not read as ready.
+    probeReturning({ status: 'invalid' }),
+  );
+  assert.equal(r.state, 'awaiting_llm');
+});
+
+test('a verified provider verdict keeps an LLM plugin ready and preserves verified_at', async () => {
+  const registry = await llmRegistryWith({
+    config: { workspace: 'acme' },
+    last_activated_at: '2026-04-04T08:30:00.000Z',
+  });
+  const r = await computeReadiness(
+    llmPlugin([field({ key: 'workspace' })]),
+    registry,
+    vaultWith([]),
+    probeReturning({ status: 'verified', verifiedAt: '2026-04-03T00:00:00.000Z' }),
+  );
+  assert.equal(r.state, 'ready');
+  assert.equal(r.verified_at, '2026-04-04T08:30:00.000Z');
+});
+
+test('the real LLM readiness resolver returns undefined for non-LLM plugins without touching deps', async () => {
+  const registry = await registryWith({ config: { client_id: 'abc' } });
+  const explodingVault = {
+    get: async (): Promise<string | undefined> => {
+      throw new Error('vault should not be touched');
+    },
+  };
+  const explodingCatalog = {
+    get: (): never => {
+      throw new Error('catalog should not be touched');
+    },
+  };
+  const r = await computeReadiness(
+    plugin([field({ key: 'client_id' })]),
+    registry,
+    vaultWith([]),
+    {
+      resolve: (id, cfg) =>
+        resolvePluginLlmReadiness(id, cfg, {
+          vault: explodingVault,
+          llmProviderCatalog: explodingCatalog,
+        }),
+    },
+  );
+  assert.equal(r.state, 'ready');
+});
+
+test('a throwing LLM readiness probe degrades to ready', async () => {
+  const registry = await llmRegistryWith({ config: { workspace: 'acme' } });
+  const r = await computeReadiness(
+    llmPlugin([field({ key: 'workspace' })]),
+    registry,
+    vaultWith([]),
+    {
+      resolve: async (): Promise<ProviderVerification | undefined> => {
+        throw new Error('probe failed');
+      },
+    },
+  );
+  assert.equal(r.state, 'ready');
+});
+
+test('config_required wins over awaiting_llm for an LLM plugin', async () => {
+  const registry = await llmRegistryWith({ config: {} });
+  const r = await computeReadiness(
+    llmPlugin([field({ key: 'workspace' })]),
+    registry,
+    vaultWith([]),
+    probeReturning({ status: 'no_key' }),
+  );
+  assert.equal(r.state, 'config_required');
+  assert.deepEqual(r.missing_fields, ['workspace']);
+});
+
+test('errored wins over awaiting_llm for an LLM plugin', async () => {
+  const registry = await llmRegistryWith({
+    status: 'errored',
+    config: { workspace: 'acme' },
+    last_activation_error: 'activation failed',
+  });
+  const r = await computeReadiness(
+    llmPlugin([field({ key: 'workspace' })]),
+    registry,
+    vaultWith([]),
+    probeReturning({ status: 'no_key' }),
+  );
+  assert.equal(r.state, 'errored');
+  assert.equal(r.error_detail, 'activation failed');
+});
+
+test('the LLM readiness probe is skipped for a not_installed plugin', async () => {
+  const registry = new InMemoryInstalledRegistry();
+  const probe = probeReturning({ status: 'no_key' });
+  const r = await computeReadiness(
+    llmPlugin([field({ key: 'workspace' })]),
+    registry,
+    vaultWith([]),
+    probe,
+  );
+  assert.equal(r.state, 'not_installed');
+  assert.deepEqual(probe.calls, []);
 });

--- a/middleware/test/storeReadinessProjection.test.ts
+++ b/middleware/test/storeReadinessProjection.test.ts
@@ -259,3 +259,82 @@ describe('store router · readiness projection (OM-16)', () => {
     }
   });
 });
+
+describe('store router · LLM readiness projection (#884)', () => {
+  const LLM_PLUGIN_ID = '@omadia/orchestrator';
+
+  async function serveWithLlmVerdict(
+    state: 'no_key' | 'verified',
+  ): Promise<{ server: Server; base: string }> {
+    const catalog = fakeCatalog([
+      plugin(LLM_PLUGIN_ID, {
+        setup_fields: [configField],
+      }),
+    ]);
+    const registry = new InMemoryInstalledRegistry();
+    await registry.register({
+      id: LLM_PLUGIN_ID,
+      installed_version: '1.0.0',
+      installed_at: '2026-01-01T00:00:00.000Z',
+      status: 'active',
+      config: { workspace: 'acme' },
+    });
+
+    const app = express();
+    app.use(
+      '/store/plugins',
+      createStoreRouter({
+        catalog,
+        registry,
+        llmReadiness: {
+          resolve: async () => ({ status: state }),
+        },
+      }),
+    );
+    const server = await listenLoopback(app);
+    const base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    return { server, base };
+  }
+
+  it('projects awaiting_llm on list and detail while keeping install_state installed', async () => {
+    const { server, base } = await serveWithLlmVerdict('no_key');
+    try {
+      const listRes = await fetch(`${base}/store/plugins`);
+      assert.equal(listRes.status, 200);
+      const listBody = (await listRes.json()) as { items: Plugin[] };
+      assert.equal(listBody.items[0]?.readiness?.state, 'awaiting_llm');
+      assert.equal(listBody.items[0]?.install_state, 'installed');
+
+      const detailRes = await fetch(
+        `${base}/store/plugins/${encodeURIComponent(LLM_PLUGIN_ID)}`,
+      );
+      assert.equal(detailRes.status, 200);
+      const detailBody = (await detailRes.json()) as { plugin: Plugin };
+      assert.equal(detailBody.plugin.readiness?.state, 'awaiting_llm');
+      assert.equal(detailBody.plugin.install_state, 'installed');
+    } finally {
+      server.close();
+    }
+  });
+
+  it('projects ready on list and detail when the LLM provider is verified', async () => {
+    const { server, base } = await serveWithLlmVerdict('verified');
+    try {
+      const listRes = await fetch(`${base}/store/plugins`);
+      assert.equal(listRes.status, 200);
+      const listBody = (await listRes.json()) as { items: Plugin[] };
+      assert.equal(listBody.items[0]?.readiness?.state, 'ready');
+      assert.equal(listBody.items[0]?.install_state, 'installed');
+
+      const detailRes = await fetch(
+        `${base}/store/plugins/${encodeURIComponent(LLM_PLUGIN_ID)}`,
+      );
+      assert.equal(detailRes.status, 200);
+      const detailBody = (await detailRes.json()) as { plugin: Plugin };
+      assert.equal(detailBody.plugin.readiness?.state, 'ready');
+      assert.equal(detailBody.plugin.install_state, 'installed');
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/web-ui/app/_components/store/InstallButton.tsx
+++ b/web-ui/app/_components/store/InstallButton.tsx
@@ -428,7 +428,8 @@ function InstalledPanel({
   const readinessTone: 'ok' | 'warning' | 'danger' =
     readiness?.state === 'errored'
       ? 'danger'
-      : readiness?.state === 'config_required'
+      : readiness?.state === 'config_required' ||
+          readiness?.state === 'awaiting_llm'
         ? 'warning'
         : 'ok';
   const readinessLabel =
@@ -436,7 +437,9 @@ function InstalledPanel({
       ? tState('errored')
       : readiness?.state === 'config_required'
         ? tState('configRequired')
-        : t('active');
+        : readiness?.state === 'awaiting_llm'
+          ? tState('awaitingLlm')
+          : t('active');
   const missingFieldsTitle =
     readiness?.state === 'config_required' &&
     readiness.missing_fields.length > 0

--- a/web-ui/app/_components/store/PostInstallNextSteps.tsx
+++ b/web-ui/app/_components/store/PostInstallNextSteps.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { Check, KeyRound, MessageSquare, Plug } from 'lucide-react';
+import { Check, KeyRound, MessageSquare, Plug, Sparkles } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 
 import type { PluginReadiness } from '../../_lib/storeTypes';
@@ -9,7 +9,10 @@ import type { PluginReadiness } from '../../_lib/storeTypes';
 interface PostInstallNextStepsProps {
   pluginName: string;
   /** OM-16 — when the freshly-installed plugin still needs credentials, the
-   *  setup link is the FIRST thing offered and carries the missing count. */
+   *  setup link is the FIRST thing offered and carries the missing count.
+   *  #884 — `awaiting_llm` is the same idea one level out: nothing is left to
+   *  fill in on this plugin's own form, so the CTA points at the providers
+   *  admin page instead of the anchor. */
   readiness?: PluginReadiness;
 }
 
@@ -32,6 +35,7 @@ export function PostInstallNextSteps({
 }: PostInstallNextStepsProps): React.ReactElement {
   const t = useTranslations('store.install');
   const needsSetup = readiness?.state === 'config_required';
+  const needsLlmProvider = readiness?.state === 'awaiting_llm';
   const missingCount = readiness?.missing_fields.length ?? 0;
 
   return (
@@ -49,6 +53,12 @@ export function PostInstallNextSteps({
             <KeyRound className="size-3.5" aria-hidden />
             {t('toSetup', { count: missingCount })}
           </a>
+        ) : null}
+        {needsLlmProvider ? (
+          <Link href="/admin/providers" className={LINK_CLASS}>
+            <Sparkles className="size-3.5" aria-hidden />
+            {t('toLlmProvider')}
+          </Link>
         ) : null}
         <Link href="/operator/agents" className={LINK_CLASS}>
           <Plug className="size-3.5" aria-hidden />

--- a/web-ui/app/_components/store/StateBadge.tsx
+++ b/web-ui/app/_components/store/StateBadge.tsx
@@ -96,6 +96,16 @@ export function StateBadge({
     );
   }
 
+  // Both warning states mean "installed but not usable yet".
+  // The label names which admin form the operator must fix.
+  if (isPresent && readiness?.state === 'awaiting_llm') {
+    return (
+      <span className={cn(PILL, WARNING_STYLE, className)}>
+        {t('awaitingLlm')}
+      </span>
+    );
+  }
+
   if (isPresent && readiness?.state === 'ready' && readiness.verified_at) {
     const at = new Date(readiness.verified_at);
     if (!Number.isNaN(at.getTime())) {

--- a/web-ui/app/_components/store/__tests__/StateBadgeAwaitingLlm.test.tsx
+++ b/web-ui/app/_components/store/__tests__/StateBadgeAwaitingLlm.test.tsx
@@ -1,0 +1,57 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import en from '../../../../messages/en.json';
+import { renderWithIntl } from '../../../_lib/test-utils';
+import { StateBadge } from '../StateBadge';
+
+describe('StateBadge awaiting_llm', () => {
+  it('renders the awaiting-llm copy for installed plugins', () => {
+    renderWithIntl(
+      <StateBadge
+        state="installed"
+        readiness={{
+          state: 'awaiting_llm',
+          missing_fields: [],
+          verified_at: null,
+        }}
+      />,
+    );
+
+    expect(screen.getByText(en.store.stateBadge.awaitingLlm)).toBeTruthy();
+    expect(screen.queryByText(en.store.stateBadge.installed)).toBeNull();
+    expect(screen.queryByText(en.store.stateBadge.configRequired)).toBeNull();
+  });
+
+  it('keeps the plain available badge when the plugin is not present', () => {
+    renderWithIntl(
+      <StateBadge
+        state="available"
+        readiness={{
+          state: 'awaiting_llm',
+          missing_fields: [],
+          verified_at: null,
+        }}
+      />,
+    );
+
+    expect(screen.getByText(en.store.stateBadge.available)).toBeTruthy();
+    expect(screen.queryByText(en.store.stateBadge.awaitingLlm)).toBeNull();
+  });
+
+  it('still renders config_required with its own label', () => {
+    renderWithIntl(
+      <StateBadge
+        state="installed"
+        readiness={{
+          state: 'config_required',
+          missing_fields: ['api_key'],
+          verified_at: null,
+        }}
+      />,
+    );
+
+    expect(screen.getByText(en.store.stateBadge.configRequired)).toBeTruthy();
+    expect(screen.queryByText(en.store.stateBadge.awaitingLlm)).toBeNull();
+  });
+});

--- a/web-ui/app/_lib/storeTypes.ts
+++ b/web-ui/app/_lib/storeTypes.ts
@@ -197,10 +197,13 @@ export interface PluginActionStatus {
 /** OM-16 — kernel-derived plugin readiness (mirror of middleware admin-v1).
  *  `install_state` answers "is it present?", readiness answers "can it
  *  actually work?". Unlike `PluginActionStatus` (push-only, from plugins that
- *  call `ctx.status`), this is computed for every plugin. */
+ *  call `ctx.status`), this is computed for every plugin. `awaiting_llm`
+ *  means the plugin's own fields are satisfied, but its assigned LLM provider
+ *  has no verified credential and must be fixed on the providers admin page. */
 export type PluginReadinessState =
   | 'not_installed'
   | 'config_required'
+  | 'awaiting_llm'
   | 'ready'
   | 'errored';
 

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -3296,6 +3296,7 @@
       "incompatible": "Inkompatibel",
       "migrationNeeded": "Migration nötig",
       "configRequired": "Konfiguration erforderlich",
+      "awaitingLlm": "Konfiguriert – wartet auf LLM-Zugang",
       "errored": "Aktivierung fehlgeschlagen",
       "readyVerified": "Aktiv · konfiguriert {time}",
       "missingFields": "Fehlt: {fields}"
@@ -3326,6 +3327,7 @@
       "installedNext": "\"{name}\" installiert — jetzt an einen Orchestrator anhängen.",
       "toOrchestrators": "An Orchestrator anhängen",
       "toSetup": "Einrichtung abschließen ({count} fehlen)",
+      "toLlmProvider": "LLM-Zugang einrichten",
       "toChat": "Im Chat ausprobieren",
       "uninstallAria": "{name} deinstallieren",
       "uninstall": "Deinstallieren",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -3296,6 +3296,7 @@
       "incompatible": "Incompatible",
       "migrationNeeded": "Migration needed",
       "configRequired": "Configuration required",
+      "awaitingLlm": "Configured – waiting for LLM access",
       "errored": "Activation failed",
       "readyVerified": "Active · configured {time}",
       "missingFields": "Missing: {fields}"
@@ -3326,6 +3327,7 @@
       "installedNext": "\"{name}\" installed — attach it to an orchestrator to start using it.",
       "toOrchestrators": "Attach to an orchestrator",
       "toSetup": "Complete setup ({count} missing)",
+      "toLlmProvider": "Connect an LLM provider",
       "toChat": "Try it in chat",
       "uninstallAria": "Uninstall {name}",
       "uninstall": "Uninstall",


### PR DESCRIPTION
Fixes #884.

## Root cause
`computeReadiness()` (the single function feeding the Hub's "X of Y ready" count, every plugin tile, and the dashboard health tile via OM-27's shared `isReady`/`countReadiness` predicate) had zero awareness that an LLM-consuming plugin also depends on an external credential. A freshly installed orchestrator with no Anthropic/OpenAI key or subscription-CLI login showed "AKTIV · KONFIGURIERT" right next to an Admin → LLM access page reporting "KEIN SCHLÜSSEL" for every provider — three UI surfaces disagreeing about the exact same fact.

## Changes
1. **`middleware/src/platform/pluginLlmReadiness.ts` (new)** — the per-provider verdict resolution (claude-cli / OAuth / key-based) extracted **verbatim** from `adminProviders.ts`'s list handler, so the Hub and the providers-admin page read the exact same function and can never disagree about the same credential again. `adminProviders.ts` shrinks by ~206 lines with **zero behavior change** — its own existing test suite (`adminProvidersRoute.test.ts`) passes unmodified, proving the extraction preserved wire format exactly.
2. **`middleware/src/plugins/readiness.ts`** — `computeReadiness()` gains an optional LLM-dependency probe (4th param, structural/injectable like the existing `ReadinessVault` seam) and a new `'awaiting_llm'` state, checked only *after* a plugin's own required manifest fields are satisfied (resolution order: `not_installed` → `errored` → `config_required` → `awaiting_llm` → `ready`, with explicit tests proving `config_required`/`errored` correctly win when a plugin has both problems). Gated strictly on `status === 'verified'` per the issue's literal wording. A probe failure degrades to `ready` — matches the file's existing rule that an infrastructure hiccup must never produce a false negative.
3. **`middleware/src/routes/store.ts` + `index.ts`** — wire the probe through both list and detail readiness projections, reusing the same `secretVault`/`llmProviderCatalog` instances already constructed for the providers-admin router (no duplicate instances).
4. **web-ui** — `StateBadge`/`InstallButton` render the new state as a warning pill ("Konfiguriert – wartet auf LLM-Zugang" / "Configured – waiting for LLM access"); `PostInstallNextSteps` gets a CTA to `/admin/providers` instead of the plugin's own (already-complete) setup form — matching this repo's established pattern of never leaving a status badge without an actionable next step (same fix-shape as OM-45/#882).
5. **Why `pluginCounts.ts`/`page.tsx`/`store/page.tsx` need zero changes**: they already consume `readiness.state` through OM-27's centralized `isReady` predicate (`=== 'ready'`), so once the server reports `awaiting_llm` correctly, the count/badges self-correct everywhere at once — this is the whole point of the fix being surgical to one function.

## Verification (all local, pre-commit)
- `middleware`: root `tsc --noEmit` — clean; `typecheck:test` ratchet — **370 known errors, no regressions** (the exact scoped gate that caught a regression during #882, explicitly re-run here); `eslint` on touched files — clean; **63/63 tests pass**, including a regression guard proving `adminProvidersRoute.test.ts` stays green *unmodified* after the extraction
- `web-ui`: `tsc --noEmit` — clean; `npm run i18n:check` — OK, 3920 keys; `eslint` — clean except one **pre-existing, unrelated** warning in `InstallButton.tsx` (confirmed via `git show HEAD:...` to predate this diff); **13/13 tests pass**
- Independent `omadia-reviewer` pass: diffed the extraction against the pre-change code directly (verified pure), confirmed the resolution order via the actual tests (not just labels), confirmed the `cliSnapshot` `'in'`-operator branch is intentional and tested, confirmed dependency reuse in `index.ts`, confirmed web-ui branch ordering has no shadowing bug — no CRITICAL/HIGH findings

## Known trade-off (not blocking)
Per `AGENTS.md`'s doc decision tree, this new architecture coupling (readiness now depends on LLM-provider verification) arguably belongs in `docs/middleware-agent-handoff.md`. Decided not to add it: that doc has zero mentions of plugin readiness/OM-16 at all — even the original OM-16 feature this builds on never documented it there — so this is a pre-existing gap the PR inherits, not a new violation to fix here.

## Test plan
- [x] Automated tests above, all green
- [ ] Manual/Interceptor: confirm the actual repro scenario (all providers "KEIN SCHLÜSSEL", orchestrator installed) shows the Hub count drop from "14 von 14" to the correct lower number, and the new badge/CTA render correctly in both EN and DE

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790419555&installation_model_id=428086&pr_number=894&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F894&signature=e2ceff1d6a9d46feead0180e8539cdaf42a5097f800b49b7ab630d13c660a3e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->