### PR TITLE
fix(#889): dashboard onboarding step 1 links to both API-key and subscription paths

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,15 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — dashboard onboarding step 1 now exposes both LLM access paths (#889)
+
+2026-08-27 — The web-ui onboarding card promised a choice between API-provider
+setup and a subscription CLI, but step 1 only rendered one CTA to
+`/admin/providers`. The step now shows the existing filled API-key pill and a
+matching accent-outline subscription pill that deep-links to
+`/admin/providers?tab=subscriptions`, with aligned EN/DE catalog keys and a
+dashboard test that pins both labels and both hrefs.
+
 ### Fixed — plugin readiness no longer calls a plugin ready without a verified LLM credential (#884)
 
 2026-08-27 — The Hub reported "14 von 14 einsatzbereit" while no LLM provider

--- a/web-ui/app/_components/dashboard/DashboardOnboarding.tsx
+++ b/web-ui/app/_components/dashboard/DashboardOnboarding.tsx
@@ -343,12 +343,21 @@ export function DashboardOnboarding({
             <p className="mt-2 max-w-2xl text-[13px] leading-relaxed text-[color:var(--fg-muted)]">
               {t('llmStep.description')}
             </p>
-            <div className="mt-4">
+            {/* Step 1 offers both supported LLM access paths directly so the
+                CTA matches the promise in the copy above. */}
+            <div className="mt-4 flex flex-wrap items-center gap-3">
               <Link
                 href="/admin/providers"
                 className="inline-flex items-center gap-2 rounded-full bg-[color:var(--accent)] px-4 py-2 text-[12px] font-semibold uppercase tracking-[0.16em] text-[color:var(--fg-on-dark)] shadow-[var(--shadow-cta)] transition-colors hover:bg-[color:var(--accent-hover)]"
               >
-                {t('llmStep.connect')}
+                {t('llmStep.connectApiKey')}
+                <ArrowRight className="size-3.5" aria-hidden />
+              </Link>
+              <Link
+                href="/admin/providers?tab=subscriptions"
+                className="inline-flex items-center gap-2 rounded-full border border-[color:var(--accent)] px-4 py-2 text-[12px] font-semibold uppercase tracking-[0.16em] text-[color:var(--accent)] transition-colors hover:bg-[color:var(--accent-subtle)]"
+              >
+                {t('llmStep.connectSubscription')}
                 <ArrowRight className="size-3.5" aria-hidden />
               </Link>
             </div>

--- a/web-ui/app/_components/dashboard/__tests__/DashboardOnboarding.test.tsx
+++ b/web-ui/app/_components/dashboard/__tests__/DashboardOnboarding.test.tsx
@@ -91,6 +91,22 @@ describe('<DashboardOnboarding /> — OM-01/12 step model', () => {
     expect(screen.queryByTestId('onboarding-step-1-check')).toBeNull();
   });
 
+  it('shows both step-1 CTAs for API keys and subscriptions', () => {
+    renderCard();
+
+    const step1 = screen.getByTestId('onboarding-step-1');
+    const links = Array.from(step1.querySelectorAll('a'));
+    expect(links).toHaveLength(2);
+    expect(links.map((link) => link.getAttribute('href'))).toEqual(
+      expect.arrayContaining([
+        '/admin/providers',
+        '/admin/providers?tab=subscriptions',
+      ]),
+    );
+    expect(screen.getByText(/API-Schlüssel hinterlegen/)).toBeTruthy();
+    expect(screen.getByText(/Abo verwenden/)).toBeTruthy();
+  });
+
   it('a logged-in subscription CLI also satisfies step 1', () => {
     renderCard({ cliLoggedIn: true });
 

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -108,7 +108,8 @@
         "missingHint": "Noch nicht im Hub"
       },
       "llmStep": {
-        "connect": "LLM-Zugang öffnen",
+        "connectApiKey": "API-Schlüssel hinterlegen",
+        "connectSubscription": "Abo verwenden",
         "title": "LLM verbinden",
         "description": "Ohne verbundenes LLM kann kein Orchestrator laufen. Verbinde zuerst einen API-Provider oder ein Abo-CLI.",
         "doneViaProvider": "Ein LLM-Anbieter ist verbunden und sein Schlüssel wurde geprüft.",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -108,7 +108,8 @@
         "missingHint": "Not in the Hub yet"
       },
       "llmStep": {
-        "connect": "Open LLM access",
+        "connectApiKey": "Enter an API key",
+        "connectSubscription": "Use a subscription",
         "title": "Connect an LLM",
         "description": "Without a connected LLM no orchestrator can run. Connect an API provider or a subscription CLI first.",
         "doneViaProvider": "An LLM provider is connected and its key has been verified.",


### PR DESCRIPTION
Fixes #889.

## Problem
The dashboard onboarding card's step 1 ("LLM verbinden") had only one CTA linking to `/admin/providers` (the API-key page), even though the step's own description text already promised a choice: "Verbinde zuerst einen API-Provider **oder ein Abo-CLI**." The subscription path had no link anywhere in onboarding — a user had to discover `Admin → LLM-Zugang → Abos` on their own.

## Correction from the issue text
The issue's originally cited target route, `/admin/subscription-clis`, is now a **stale redirect-only page** — it just forwards to `/admin/providers?tab=subscriptions`, which is the real, current destination (confirmed by reading `LlmAccessTabs.tsx`). The new CTA links there directly, reusing an already-live, already-tested deep link instead of the dead route the issue named.

## Changes
1. **`DashboardOnboarding.tsx`** — step 1 now shows two CTAs side by side: the existing filled-pill button (API key path, unchanged href/style/behavior) plus a new outline-pill button to `/admin/providers?tab=subscriptions`, reusing the exact class string from this same file's `BringYourSkills` component (byte-identical minus one contextual `mt-4`, confirmed via direct diff — no invented style, no visual regression).
2. **`messages/en.json` / `de.json`** — `llmStep.connect` → `connectApiKey` (confirmed via whole-repo grep: sole usage site, no orphaned callers), new `connectSubscription` key. `title`/`description`/`doneViaProvider`/`doneViaCli` unchanged.
3. **`DashboardOnboarding.test.tsx`** — new test asserting both CTAs render with the correct hrefs and DE labels when step 1 is genuinely not-done (not a short-circuited already-done path).
4. **`docs/CHANGELOG.md`** — `[Unreleased]` entry.

## Deliberately out of scope
P-07 from the original test report (the runtime-offline error message also only naming the API-key path, not the subscription one) is supporting evidence in the issue but explicitly not listed under its own "Fix" section — left as a candidate follow-up, not folded into this diff.

## Verification (all local, pre-commit)
- `web-ui`: `tsc --noEmit` — clean; `npm run i18n:check` — OK, 3921 keys; `eslint` on touched files — clean; **17/17 tests pass** (16 existing unmodified + 1 new)
- Independent `omadia-reviewer` pass: confirmed the subscriptions route is live (not stale) by reading the actual page/tab component, confirmed the key rename orphaned nothing via whole-repo grep, confirmed the new button's classes are a genuine match (not invented), confirmed the new test exercises the correct not-done render path — no CRITICAL/HIGH findings

## Test plan
- [x] Automated tests above, all green
- [ ] Optional polish check: visual side-by-side wrap behavior at narrow viewport (not a correctness concern)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790421056&installation_model_id=428086&pr_number=895&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F895&signature=473b995c37e32241c9b0ea4ef58ec0c9937067e117cd809adedbb287d6b9181d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->