### PR TITLE
fix(#886): dashboard onboarding step 3 shows a result, not a stale CTA, when done

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,19 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — dashboard onboarding step 3 no longer contradicts its own done badge (#886)
+
+2026-08-27 — Step 3 "Plugins installieren" ticked its INSTALLIERT badge from
+`hasInstalledPlugin` but picked its body copy from `selectedCase === null`, so
+clearing the business case turned a completed step back into "Wähle oben einen
+Business-Case, um passende Empfehlungen zu sehen." The body now reads off the
+same `done` signal as the badge and states the result instead — a new
+`dashboard.onboarding.installStep.done` key (EN/DE, ICU plural) counted with the
+shared OM-27 `isInstalled` predicate over the `plugins` array the component
+already receives, so `update-available` counts as installed and the sentence
+cannot drift from the health tile. The recommendation list for a selected case
+is untouched.
+
 ### Added — Nutzungs-Doku: mehrere benannte Agent-Bots in Teams (#860)
 
 2026-08-27 — Neue Operator-Doku `docs/teams-multi-agent-identities.md`, verlinkt aus

--- a/web-ui/app/_components/dashboard/DashboardOnboarding.tsx
+++ b/web-ui/app/_components/dashboard/DashboardOnboarding.tsx
@@ -25,6 +25,7 @@ import {
 import { useTranslations } from 'next-intl';
 
 import type { Plugin } from '../../_lib/storeTypes';
+import { isInstalled } from '../../_lib/pluginCounts';
 import {
   BUSINESS_CASES,
   PLUGIN_CATEGORIES,
@@ -281,6 +282,11 @@ export function DashboardOnboarding({
     { id: 'install', done: hasInstalledPlugin },
   ];
   const llmDone = steps[0].done;
+  // #886 — step 3's RESULT copy. Counted here with the same OM-27 predicate the
+  // dashboard health tile uses, over the same `plugins` array `page.tsx` derives
+  // `hasInstalledPlugin` from — so the badge and the sentence underneath it read
+  // off one source and cannot contradict each other.
+  const installedCount = (plugins ?? []).filter(isInstalled).length;
 
   return (
     <section
@@ -402,8 +408,15 @@ export function DashboardOnboarding({
         title={t('installStep.title')}
       >
         {selectedCase === null ? (
+          // #886 — this branch used to hand out "pick a business case first"
+          // unconditionally, so a card whose step-3 badge already said
+          // INSTALLIERT still told the operator to start over the moment the
+          // case selection was cleared. `done` decides the copy now, exactly as
+          // it decides the badge; the CTA is only for the not-yet-done case.
           <p className="mt-2 text-[13px] leading-relaxed text-[color:var(--fg-muted)]">
-            {t('installStep.pickCaseFirst')}
+            {steps[2].done
+              ? t('installStep.done', { count: installedCount })
+              : t('installStep.pickCaseFirst')}
           </p>
         ) : (
           <Recommendations

--- a/web-ui/app/_components/dashboard/__tests__/DashboardOnboarding.test.tsx
+++ b/web-ui/app/_components/dashboard/__tests__/DashboardOnboarding.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { renderWithIntl } from '../../../_lib/test-utils';
+import type { Plugin } from '../../../_lib/storeTypes';
 import {
   DashboardOnboarding,
   __resetOnboardingStores,
@@ -33,8 +34,24 @@ vi.mock('../../admin/SkillImportModal', () => ({
   SkillImportModal: (): React.ReactElement => <div />,
 }));
 
+function plugin(over: Partial<Plugin> = {}): Plugin {
+  return {
+    id: '@omadia/channel-telegram',
+    kind: 'channel',
+    name: 'Telegram',
+    version: '1.0.0',
+    latest_version: '1.0.0',
+    description: 'Telegram channel.',
+    categories: [],
+    integrations_summary: [],
+    install_state: 'installed',
+    ...over,
+  } as Plugin;
+}
+
 function renderCard(
   over: Partial<{
+    plugins: Plugin[] | null;
     llmVerified: boolean;
     cliLoggedIn: boolean;
     hasInstalledPlugin: boolean;
@@ -135,5 +152,43 @@ describe('<DashboardOnboarding /> — OM-01/12 step model', () => {
     renderCard({ llmVerified: true });
     expect(screen.getByTestId('onboarding-step-2').dataset['done']).toBe('true');
     expect(screen.getByText(/Business-Case: Vertrieb & CRM/)).toBeTruthy();
+  });
+
+  /**
+   * #886 — step 3's badge said INSTALLIERT while the copy right underneath it
+   * still said "Wähle oben einen Business-Case …", because the body ternary was
+   * keyed on `selectedCase === null` instead of on the step's `done` signal.
+   * `update-available` counts as installed (OM-27), which is why the fixture
+   * mixes both states and the expected count is 2.
+   */
+  it('step 3 reports the installed count instead of the CTA once done', () => {
+    renderCard({
+      hasInstalledPlugin: true,
+      plugins: [
+        plugin({ id: '@omadia/channel-telegram', install_state: 'installed' }),
+        plugin({
+          id: '@omadia/integration-odoo',
+          install_state: 'update-available',
+        }),
+        plugin({ id: '@omadia/notion', install_state: 'available' }),
+      ],
+    });
+
+    const step3 = screen.getByTestId('onboarding-step-3');
+    expect(step3.dataset['done']).toBe('true');
+    expect(screen.getByText(/2 Plugins installiert/)).toBeTruthy();
+    expect(screen.queryByText(/Wähle oben einen Business-Case/)).toBeNull();
+  });
+
+  it('step 3 still asks for a business case while nothing is installed', () => {
+    renderCard({
+      hasInstalledPlugin: false,
+      plugins: [plugin({ install_state: 'available' })],
+    });
+
+    const step3 = screen.getByTestId('onboarding-step-3');
+    expect(step3.dataset['done']).toBe('false');
+    expect(screen.getByText(/Wähle oben einen Business-Case/)).toBeTruthy();
+    expect(screen.queryByText(/Plugins? installiert/)).toBeNull();
   });
 });

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -136,7 +136,8 @@
       "caseChosen": "Business-Case: {name}",
       "installStep": {
         "title": "Plugins installieren",
-        "pickCaseFirst": "Wähle oben einen Business-Case, um passende Empfehlungen zu sehen."
+        "pickCaseFirst": "Wähle oben einen Business-Case, um passende Empfehlungen zu sehen.",
+        "done": "{count, plural, one {# Plugin installiert} other {# Plugins installiert}}"
       }
     }
   },

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -136,7 +136,8 @@
       "caseChosen": "Business case: {name}",
       "installStep": {
         "title": "Install plugins",
-        "pickCaseFirst": "Pick a business case above to see matching recommendations."
+        "pickCaseFirst": "Pick a business case above to see matching recommendations.",
+        "done": "{count, plural, one {# plugin installed} other {# plugins installed}}"
       }
     }
   },


### PR DESCRIPTION
Fixes #886.

## Problem
Dashboard onboarding step 3 ("Plugins installieren") showed the checkmark and "INSTALLIERT" badge correctly, but the body text underneath still read "Wähle oben einen Business-Case, um passende Empfehlungen zu sehen" — a completed badge and an active CTA in the same card. Root cause: the body-text ternary was keyed on `selectedCase === null`, not on the step's own done state.

## Changes
1. **`DashboardOnboarding.tsx`** — the `pickCaseFirst` branch now checks `steps[2].done` first, showing a result statement ("14 Plugins installiert") instead of the leftover CTA when the step is actually done. `installedCount` is computed with the same OM-27 `isInstalled` predicate over the same `plugins` array that `hasInstalledPlugin` itself derives from upstream (`page.tsx`), so the badge and the sentence beneath it can never disagree. The `Recommendations` branch (`selectedCase !== null`) is untouched.
2. **`messages/en.json` / `de.json`** — new `installStep.done` ICU-plural key, matching the existing `dashboard.health.plugins.installed` shape.
3. **`DashboardOnboarding.test.tsx`** — new test for the fixed path (done, no case selected → result text, not CTA) and a regression guard (not done → CTA still shows).
4. **`docs/CHANGELOG.md`** — `[Unreleased]` entry.

## Verification (all local, pre-commit)
- `web-ui`: `tsc --noEmit` — clean; `npm run i18n:check` — OK, 4054 keys; `eslint` — clean; **19/19 tests pass** (17 existing unmodified + 2 new)
- Independent `omadia-reviewer` pass: confirmed `steps[2].done` is the literal `hasInstalledPlugin` value (not aliased/derived differently), confirmed `installedCount` and `hasInstalledPlugin` share the exact same upstream source+predicate (can't disagree), confirmed the `Recommendations` branch is byte-identical to before, confirmed the new tests genuinely exercise the fixed branch (not the untouched one) — no CRITICAL/HIGH findings

## Known non-blocking note
`installedCount` would silently read `0` if `plugins` were ever `null` while `hasInstalledPlugin` was `true` — traced as unreachable today (both derive from the same `page.tsx` source), an implicit coupling rather than a live bug. Not addressed here to keep the diff minimal; flagged for awareness.

## Test plan
- [x] Automated tests above, all green

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790425917&installation_model_id=428086&pr_number=901&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F901&signature=7cae00b1ebd12e0d6b865d2afdd23161d9a61f67934274678d77748bb39e2855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->