### PR TITLE
fix(#887): billing-posture badge no longer reads as a second status

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,16 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — billing-posture badge on "Erkannte CLIs" no longer reads as a second status (#887)
+
+2026-08-27 — Each CLI row on Admin → LLM-Zugang → Abo-CLIs showed a detection
+badge ("NICHT GEFUNDEN") next to a billing badge ("Abo" / "Prüfung nötig") with
+nothing distinguishing the two — two entries both "not found" could still show
+different second badges, reading like conflicting statuses. The billing badge
+now carries an explicit "Abrechnung:"/"Billing:" prefix so it's unmistakably a
+billing-model label, not a second detection state. Display-string change only —
+`cliBackendDetector.ts`'s `CliBillingPosture` type and wire field are unchanged.
+
 ### Fixed — dashboard onboarding step 3 no longer contradicts its own done badge (#886)
 
 2026-08-27 — Step 3 "Plugins installieren" ticked its INSTALLIERT badge from

--- a/web-ui/app/admin/subscription-clis/_components/SubscriptionClisPanel.tsx
+++ b/web-ui/app/admin/subscription-clis/_components/SubscriptionClisPanel.tsx
@@ -471,6 +471,12 @@ function InstallBadge({
   );
 }
 
+/**
+ * OM-48 (#887) — this sits beside InstallBadge.
+ * Without an "Abrechnung:"/"Billing:" prefix, the pair can read like
+ * conflicting detection statuses, even though this badge describes billing
+ * posture rather than whether the CLI was found.
+ */
 function BillingBadge({
   billing,
   t,

--- a/web-ui/app/admin/subscription-clis/_components/__tests__/SubscriptionClisPanel.test.tsx
+++ b/web-ui/app/admin/subscription-clis/_components/__tests__/SubscriptionClisPanel.test.tsx
@@ -223,4 +223,43 @@ describe('<SubscriptionClisPanel />', () => {
     // redacted support disclosure.
     expect(screen.getByText('Details for support')).toBeTruthy();
   }, 20_000);
+
+  /**
+   * OM-48 (#887) — both rows can legitimately share the same install-state
+   * badge, so the billing badge copy must self-identify as billing data
+   * instead of reading like a second, contradictory detection result.
+   */
+  it('OM-48: prefixes billing badges so they cannot be read as install-state badges', async () => {
+    mockGetCliBackends.mockResolvedValue({
+      backends: [
+        backend({
+          id: 'claude',
+          installed: false,
+          billing: 'needs-verification',
+          detail: 'claude is not installed in this environment.',
+        }),
+        backend({
+          id: 'codex',
+          label: 'Codex',
+          bin: 'codex',
+          installed: false,
+          billing: 'subscription',
+          detail: 'codex is not installed in this environment.',
+        }),
+      ],
+      cliToolsDir: CLI_TOOLS_DIR,
+      generatedAt: Date.now(),
+    });
+
+    renderWithIntl(<SubscriptionClisPanel onSwitchToProviders={() => {}} />, {
+      locale: 'de',
+    });
+
+    expect(await screen.findAllByText(/^nicht gefunden$/i)).toHaveLength(2);
+
+    await waitFor(() => {
+      expect(screen.getByText(/^Abrechnung: noch zu prüfen$/)).toBeTruthy();
+      expect(screen.getByText(/^Abrechnung: Abo$/)).toBeTruthy();
+    });
+  });
 });

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -3272,8 +3272,8 @@
       "installed": "installiert",
       "needsLogin": "Anmeldung nötig",
       "loggedIn": "angemeldet",
-      "subscription": "Abo",
-      "needsVerification": "Prüfung nötig"
+      "subscription": "Abrechnung: Abo",
+      "needsVerification": "Abrechnung: noch zu prüfen"
     },
     "lastChecked": "Zuletzt geprüft um {time}",
     "refreshed": "Gerade aktualisiert",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -3272,8 +3272,8 @@
       "installed": "installed",
       "needsLogin": "needs login",
       "loggedIn": "logged in",
-      "subscription": "subscription",
-      "needsVerification": "needs verification"
+      "subscription": "Billing: subscription",
+      "needsVerification": "Billing: needs verification"
     },
     "lastChecked": "Last checked at {time}",
     "refreshed": "Updated just now",


### PR DESCRIPTION
Fixes #887.

## Problem
Each row on "Erkannte CLIs" (Admin → LLM-Zugang → Abo-CLIs) showed a detection badge ("NICHT GEFUNDEN") next to a billing-posture badge ("Abo" / "Prüfung nötig"), with nothing distinguishing the two. Two rows could both show "not found" but different billing badges, reading like conflicting statuses — when the second badge actually encodes an unrelated fact (the billing model).

## Changes
1. **`messages/en.json` / `de.json`** — `adminSubscriptionClis.badge.subscription` / `.needsVerification` now carry an explicit "Billing:"/"Abrechnung:" prefix, per the issue's own suggested wording. Same keys, only string values change — no renames.
2. **`SubscriptionClisPanel.tsx`** — doc comment on `BillingBadge` explaining the prefix. `InstallBadge` (the detection-state badge) is completely untouched.
3. **`SubscriptionClisPanel.test.tsx`** — extended with the new prefixed strings for both billing values.
4. **`docs/CHANGELOG.md`** — `[Unreleased]` entry.

Pure display-string fix — `middleware/src/platform/cliBackendDetector.ts`'s `CliBillingPosture` type/wire field is unchanged, zero middleware touch.

## Verification (all local, pre-commit)
- `web-ui`: `tsc --noEmit` — clean; `npm run i18n:check` — OK, 4054 keys; `eslint` — clean; **17/17 tests pass**
- Independent `omadia-reviewer` pass: confirmed pure string-value change with both locales in lockstep (zero key diff via `jq 'paths(scalars)'`), confirmed `InstallBadge` has zero diff lines, confirmed the new tests assert the NEW prefixed text (not trivially passing against the old text), confirmed zero middleware touch — one required fix applied (this CHANGELOG entry, per repo's AGENTS.md doc decision tree + same-day precedent from #884/#886/#889)

## Test plan
- [x] Automated tests above, all green

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790428224&installation_model_id=428086&pr_number=902&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F902&signature=a30b545185ef2070a007e4cacb47ec349142f300af661165545d805f0afdb5e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->