### PR TITLE
feat: make the context-memory ACL switchable from the operator UI

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,39 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — der Kontext-Memory-ACL lässt sich aus der Operator-UI einschalten (#899)
+
+2026-08-27 — W5 (#881) hatte die komplette Chat-Kontext-Memory-ACL ausgeliefert, aber
+hinter `agents.context_memory` — einer Spalte ohne UI und ohne API. Einschalten ging nur
+per Hand-`UPDATE`, womit die ganze Wave praktisch inert war. Neu: `GET`/`PUT
+/api/v1/operator/agents/:slug/context-memory` auf dem bestehenden Operator-Router
+(`{ ok: true }`-Envelope, `requireAuth`) und ein Control auf der Agent-Detailseite.
+`PUT` validiert gegen dieselbe Werteliste wie der CHECK-Constraint der Migration `0050`
+(`off` | `enforce` | `enforce-strict`), lehnt Unbekanntes mit `400 invalid_body` ab
+statt es still auf `off` zu mappen, loggt den Wechsel mit `[security-audit]` und löst
+einen `registry.reload()` aus — der nächste Turn läuft bereits im neuen Scope. Der Modus
+liegt bewusst NICHT auf dem Umbenennen-/Aktivieren-`PATCH`, damit eine Änderung am
+Memory-Scope nicht als Beifang einer unabhängigen Bearbeitung mitreist. Die UI zeigt vor
+dem Einschalten die drei Semantiken (Team-Tier read-write, Agent-Tier read-only,
+API-Turns nur agent-privat) und verlangt eine ausdrückliche Bestätigung; Zurückschalten
+auf `off` ist nicht bestätigungspflichtig. Kein Schema-Change. EN/DE vollständig.
+
+### Fixed — die Turn-Bindung der Memory-ACL kann nicht mehr stillschweigend verloren gehen (#899)
+
+2026-08-27 — `dispatchTool`, `dispatchToolDeadlined` und `dispatchToolInner` nahmen die
+`TurnMemoryBinding` in einer OPTIONALEN Position entgegen, während alle sechs übrigen
+Signaturen auf dem Pfad sie verpflichtend führen. Eine Aufrufstelle, die das Argument
+schlicht vergisst, kompilierte damit sauber und fiel zur Laufzeit still auf den
+agent-globalen Memory-Stack zurück — genau die lautlose Scope-Ausweitung, gegen die die
+Wave gebaut ist. Nachgewiesen, nicht vermutet: das Argument an den beiden Tool-Loop-
+Aufrufstellen zu streichen passierte `tsc`. Die drei Parameter sind jetzt required
+(`TurnMemoryBinding | undefined`), Laufzeitverhalten unverändert; dieselbe Mutation
+scheitert nun im Typecheck. Dazu die erste Integrationsabdeckung der Bindung überhaupt
+(`middleware/test/orchestrator/contextMemoryTurnBinding.test.ts`): echte Turns über
+`runTurn` UND `chatStream` mit einem Teams-`TurnOrigin`, die den physischen Schreibpfad
+im Root-Store prüfen — bislang endete jede W5-Suite beim Handler des `MemoryBinder`,
+und der Streaming-Pfad war nie durchlaufen worden.
+
 ### Fixed — dashboard onboarding step 3 no longer contradicts its own done badge (#886)
 
 2026-08-27 — Step 3 "Plugins installieren" ticked its INSTALLIERT badge from

--- a/docs/teams-multi-agent-identities.md
+++ b/docs/teams-multi-agent-identities.md
@@ -746,9 +746,31 @@ das Memory-Routing nicht verändert. Es gibt **keinen Flag-Day**: jede Kombinati
 alter/neuer Middleware und altem/neuem Channel-Plugin verhält sich wie vorher, bis ein
 Operator einen Agenten bewusst umschaltet.
 
-> **Heute noch von Hand:** Es gibt derzeit **keine Operator-UI und keinen
-> API-Endpunkt**, um `agents.context_memory` zu setzen — der Wert wird direkt in der
-> Datenbank gesetzt. Das ist eine bekannte Lücke, kein Versehen des Rollouts.
+### Wo man den Schalter umlegt
+
+Auf der Agent-Detailseite `/operator/agents/<slug>`, Abschnitt **Chat-Kontext-Memory**,
+neben den anderen Einstellungen des Agenten. Die drei Modi stehen dort als Auswahl;
+beim Wechsel **weg von „Aus"** blendet die Seite die drei Semantiken aus dem nächsten
+Abschnitt ein und verlangt eine ausdrückliche Bestätigung, bevor Speichern aktiv wird.
+Zurück auf „Aus" ist bewusst nicht bestätigungspflichtig — die sichere Richtung darf
+nie schwerer sein als die unsichere.
+
+Dahinter liegen zwei operator-authentifizierte Routen (#899):
+
+```
+GET /api/v1/operator/agents/<slug>/context-memory   → { slug, mode, modes }
+PUT /api/v1/operator/agents/<slug>/context-memory     { mode: 'off' | 'enforce' | 'enforce-strict' }
+```
+
+`PUT` validiert gegen dieselbe Werteliste wie der CHECK-Constraint der Migration `0050`
+— ein unbekannter Modus wird mit `400 invalid_body` **abgelehnt und nicht** still auf
+`off` gemappt — und löst danach einen `registry.reload()` aus. Der nächste Turn läuft
+also bereits im neuen Scope; ein Neustart ist nicht nötig. Der Moduswechsel wird mit
+dem `[security-audit]`-Präfix geloggt.
+
+Der Modus liegt **nicht** auf `PATCH /operator/agents/<slug>` (dem Umbenennen-/
+Aktivieren-Formular). Eine Änderung am Memory-Scope soll nicht als Beifang einer
+unabhängigen Bearbeitung mitreisen.
 
 ### Was Operatoren vor dem Aktivieren wissen müssen
 
@@ -954,8 +976,12 @@ Tiefe Details zur Scope-Auflösung, zur Turn-Bindung und zu den Tests stehen in
 - **`promoteMemory` ist nicht atomar.** Validierungsfehler lassen beide Tiers
   unberührt; ein Store-Fehler mitten im Schreiben nicht. Solche Antworten tragen
   `partial: true` (siehe Abschnitt 8).
-- **Kein Schalter für `agents.context_memory` in UI oder API.** Der Rollout-Modus wird
-  heute direkt in der Datenbank gesetzt.
+- **Der Schalter wirkt nur auf dem Orchestrator-Pfad.** Läuft ein Agent über den
+  `claude-cli`-Provider, beantwortet ein `CliChatAgent` den Turn, nicht der
+  `Orchestrator` — die Bindung wird dort nie gebildet, und der Modus bleibt folgenlos.
+  Ebenso greift die ACL nicht für ein **Sub-Agent**, dem das native `memory`-Tool
+  direkt zugeteilt wurde: dessen Handler zeigt auf den undekorierten Store. Beides ist
+  älter als diese Wave und in #899 dokumentiert (siehe dort den Befund im PR).
 
 ### Was in Arbeit ist
 
@@ -984,6 +1010,9 @@ Tiefe Details zur Scope-Auflösung, zur Turn-Bindung und zu den Tests stehen in
 | App-Paket-Assets | `middleware/src/services/teamsAppPackageAssets.ts` |
 | Tabelle Teams-Identitäten | `middleware/migrations/0049_agent_teams_identities.sql` |
 | Rollout-Flag Memory-ACL | `middleware/migrations/0050_agent_context_memory_flag.sql` |
+| Schalter (API) | `middleware/src/routes/operatorAgents.ts` → `GET`/`PUT /:slug/context-memory` |
+| Schalter (UI) | `web-ui/app/operator/agents/[slug]/_components/AgentContextMemory.tsx` |
+| Turn-Bindung, echter Turn | `middleware/test/orchestrator/contextMemoryTurnBinding.test.ts` |
 | Conversation-Refs pro Bot | `middleware/packages/harness-knowledge-graph-neon/src/migrations/0031_teams_conversation_refs.sql` |
 | Memory-ACL im Detail | [`middleware-agent-handoff.md`](middleware-agent-handoff.md) → „Chat-Kontext-Memory-ACL" |
 | Operator-UI Teams-Identität | `web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentity.tsx`, `AgentTeamsInstalls.tsx` |

--- a/middleware/packages/harness-orchestrator/src/orchestrator.ts
+++ b/middleware/packages/harness-orchestrator/src/orchestrator.ts
@@ -6316,8 +6316,23 @@ export class Orchestrator {
   private async dispatchTool(
     name: string,
     input: unknown,
-    observer?: AskObserver,
-    turnMemory?: TurnMemoryBinding,
+    observer: AskObserver | undefined,
+    /**
+     * W5 (#899) — REQUIRED position, `| undefined` rather than `?`.
+     *
+     * Every other signature on the threading path takes the binding in a
+     * required position; these three took it optionally, so a call site that
+     * simply forgot the argument still compiled and silently fell back to
+     * `this.memoryToolHandler` — the agent-global stack. That was verified,
+     * not assumed: dropping the argument at the two tool-loop call sites
+     * passed `tsc` cleanly and turned every case in
+     * `test/orchestrator/contextMemoryTurnBinding.test.ts` red at runtime.
+     *
+     * A silent widening of the memory scope is the one failure this wave
+     * exists to prevent, so it should be a compile error, not a test failure.
+     * Callers with genuinely no binding pass an explicit `undefined`.
+     */
+    turnMemory: TurnMemoryBinding | undefined,
   ): Promise<string> {
     // #575 — the audience floor's egress guard, at the ONE choke point every
     // tool dispatch passes through. Placed before the deadline machinery so a
@@ -6375,9 +6390,10 @@ export class Orchestrator {
   private async dispatchToolDeadlined(
     name: string,
     input: unknown,
-    observer?: AskObserver,
-    deadlineSignal?: AbortSignal,
-    turnMemory?: TurnMemoryBinding,
+    observer: AskObserver | undefined,
+    deadlineSignal: AbortSignal | undefined,
+    /** Required position — see {@link Orchestrator.dispatchTool}. */
+    turnMemory: TurnMemoryBinding | undefined,
   ): Promise<string> {
     // Privacy Shield v4 — Data-Plane Boundary. The privacy handle is
     // threaded through `turnContext.privacyHandle`; absent ⇒ no privacy
@@ -6753,8 +6769,9 @@ export class Orchestrator {
   private async dispatchToolInner(
     name: string,
     input: unknown,
-    observer?: AskObserver,
-    turnMemory?: TurnMemoryBinding,
+    observer: AskObserver | undefined,
+    /** Required position — see {@link Orchestrator.dispatchTool}. */
+    turnMemory: TurnMemoryBinding | undefined,
   ): Promise<string> {
     // Per-orchestrator memory isolation: when this Agent has a scoped
     // memory-tool handler, it MUST shadow the globally-registered `memory`

--- a/middleware/packages/harness-orchestrator/src/registry/configStore.ts
+++ b/middleware/packages/harness-orchestrator/src/registry/configStore.ts
@@ -100,6 +100,14 @@ export interface AgentPatch {
   readonly status?: AgentStatus;
   readonly modelRouting?: Record<string, unknown> | null;
   readonly canvasPosition?: CanvasPosition | null;
+  /**
+   * W5 memory-ACL rollout switch (#899). Absent leaves the stored value
+   * untouched: the UPDATE below uses `COALESCE`, so a patch that does not
+   * mention the flag can never silently reset an enforcing agent back to
+   * `'off'`. The column's CHECK constraint (migration 0050) covers the same
+   * three values, so a widened union cannot reach the database either.
+   */
+  readonly contextMemory?: ContextMemoryMode;
 }
 
 export interface AgentPluginInput {
@@ -376,6 +384,7 @@ export class ConfigStore {
          status          = COALESCE($5, status),
          model_routing   = COALESCE($6::jsonb, model_routing),
          canvas_position = COALESCE($7::jsonb, canvas_position),
+         context_memory  = COALESCE($8, context_memory),
          updated_at      = now()
        WHERE id = $1
        RETURNING *`,
@@ -387,6 +396,7 @@ export class ConfigStore {
         patch.status ?? null,
         patch.modelRouting ? JSON.stringify(patch.modelRouting) : null,
         patch.canvasPosition ? JSON.stringify(patch.canvasPosition) : null,
+        patch.contextMemory ?? null,
       ],
     );
     const row = rows[0];

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -10,6 +10,7 @@ import {
   type AgentGraphStore,
   type ChatSessionStore,
   type ConfigStore,
+  type ContextMemoryMode,
   type OrchestratorRegistry,
 } from '@omadia/orchestrator';
 
@@ -66,6 +67,8 @@ interface AgentPluginCatalogEntry {
  *   PUT    /api/v1/operator/agents/:slug/plugins         replace agent plugin set
  *   PATCH  /api/v1/operator/agents/:slug/plugins         enable/disable ONE plugin (body: { id, enabled })
  *   GET    /api/v1/operator/agents/:slug/grants          per-agent tool grants + plugin MCP grants + grant epoch
+ *   GET    /api/v1/operator/agents/:slug/context-memory  read the W5 memory-ACL rollout mode (#899)
+ *   PUT    /api/v1/operator/agents/:slug/context-memory  set the W5 memory-ACL rollout mode (body: { mode })
  *   POST   /api/v1/operator/agents/:slug/teams-identity   create-or-provision Teams identity (async, W1a #860)
  *   GET    /api/v1/operator/agents/:slug/teams-identity   Teams identity provisioning status
  *   GET    /api/v1/operator/agents/:slug/teams            teams the agent's app is installed in (derived, W2a #860)
@@ -97,6 +100,28 @@ const AgentPatchSchema = z.object({
   description: z.string().max(2000).nullable().optional(),
   privacy_profile: z.enum(['strict', 'default']).optional(),
   status: z.enum(['enabled', 'disabled']).optional(),
+});
+
+/**
+ * W5 memory-ACL rollout switch (#899).
+ *
+ * The union is spelled out here rather than imported as a value:
+ * `ContextMemoryMode` is a TYPE-only export, and the persisted column carries
+ * its own CHECK constraint (migration 0050) over the same three values. Both
+ * ends validating independently is the point — an operator must not be able to
+ * write a mode the runtime reads back as `off`, which is exactly the failure
+ * that makes a security switch look enabled while changing nothing.
+ *
+ * The assignment below is a compile-time pin: it stops compiling the moment
+ * this runtime union drifts from the type the orchestrator actually consumes.
+ */
+export const CONTEXT_MEMORY_MODES = ['off', 'enforce', 'enforce-strict'] as const;
+
+const _contextMemoryModesPin: readonly ContextMemoryMode[] = CONTEXT_MEMORY_MODES;
+void _contextMemoryModesPin;
+
+const ContextMemorySchema = z.object({
+  mode: z.enum(CONTEXT_MEMORY_MODES),
 });
 
 const AgentPluginsSchema = z.object({
@@ -843,6 +868,70 @@ export function createOperatorAgentsRouter(
       await live.store.deleteAgent(existing.id);
       await live.registry.reload();
       res.json({ ok: true });
+    } catch (err) {
+      badRequest(res, err);
+    }
+  });
+
+  // ── context-memory rollout switch (W5 memory-ACL, #899) ─────────────
+  // `agents.context_memory` (migration 0050) shipped as a bare column: the
+  // only way to enable the ACL was a hand-written UPDATE. These two routes
+  // are the supported path.
+  //
+  // Read and write are separate endpoints rather than fields on
+  // `PATCH /:slug` on purpose. That handler is the dashboard's rename/enable
+  // surface and sends whatever the form holds; folding a security switch into
+  // it would let an unrelated edit carry a memory-scope change along with it.
+  router.get('/:slug/context-memory', async (req: Request, res: Response) => {
+    const live = svc();
+    if (!live) return unavailable(res);
+    try {
+      const slug = slugParam(req, res);
+      if (!slug) return;
+      const agent = await live.store.getAgentBySlug(slug);
+      if (!agent) {
+        res.status(404).json({ error: 'not_found' });
+        return;
+      }
+      // Deny-default read: the store already narrows an unknown/NULL column to
+      // `'off'`, and repeating it here keeps the UI from rendering a mode the
+      // runtime would not honour.
+      const mode: ContextMemoryMode = normalizeContextMemoryMode(
+        agent.contextMemory,
+      );
+      res.json({ slug: agent.slug, mode, modes: CONTEXT_MEMORY_MODES });
+    } catch (err) {
+      badRequest(res, err);
+    }
+  });
+
+  router.put('/:slug/context-memory', async (req: Request, res: Response) => {
+    const live = svc();
+    if (!live) return unavailable(res);
+    try {
+      const body = ContextMemorySchema.parse(req.body);
+      const slug = slugParam(req, res);
+      if (!slug) return;
+      const agent = await live.store.getAgentBySlug(slug);
+      if (!agent) {
+        res.status(404).json({ error: 'not_found' });
+        return;
+      }
+      const previous = normalizeContextMemoryMode(agent.contextMemory);
+      await live.store.updateAgent(agent.id, { contextMemory: body.mode });
+      // Same reload contract as every other write on this router: the running
+      // registry rebuilds the agent's `MemoryBinder` with the new mode, so the
+      // next turn is already scoped. Without it the switch would only take
+      // effect on the next process restart.
+      await live.registry.reload();
+      if (previous !== body.mode) {
+        // Memory-scope changes are the kind of change an incident review wants
+        // to find in the log, so it gets the shared security-audit prefix.
+        console.warn(
+          `[security-audit] context_memory ${previous} -> ${body.mode} for agent ${agent.slug}`,
+        );
+      }
+      res.json({ ok: true, mode: body.mode });
     } catch (err) {
       badRequest(res, err);
     }
@@ -1661,6 +1750,19 @@ export function createOperatorAgentsRouter(
   });
 
   return router;
+}
+
+/**
+ * Deny-default narrowing for the persisted rollout mode (#899).
+ *
+ * Mirrors `parseContextMemoryMode` in the orchestrator's ConfigStore: an
+ * absent, NULL, or unrecognised value reads as `'off'`. Duplicated rather
+ * than imported because the orchestrator keeps it private, and because the
+ * read surface must never be the place where an unknown value gets promoted
+ * into something the operator sees as "on".
+ */
+function normalizeContextMemoryMode(raw: unknown): ContextMemoryMode {
+  return raw === 'enforce' || raw === 'enforce-strict' ? raw : 'off';
 }
 
 function groupBy<T, K>(items: readonly T[], keyFn: (item: T) => K): Map<K, T[]> {

--- a/middleware/test/operatorAgentsRouter.test.ts
+++ b/middleware/test/operatorAgentsRouter.test.ts
@@ -50,6 +50,7 @@ import {
   type OrchestratorRegistry,
 } from '@omadia/orchestrator';
 import {
+  CONTEXT_MEMORY_MODES,
   createOperatorAgentsRouter,
   defaultTeamsBotSecretRef,
   projectInstalledTeams,
@@ -72,6 +73,9 @@ interface AgentMem {
   description: string | null;
   privacyProfile: 'strict' | 'default';
   status: 'enabled' | 'disabled';
+  /** W5 memory-ACL rollout mode (#899). Optional exactly like the real
+   *  `AgentRow`, so a row seeded without it models a pre-0050 agent. */
+  contextMemory?: 'off' | 'enforce' | 'enforce-strict';
   createdAt: Date;
   updatedAt: Date;
 }
@@ -166,6 +170,7 @@ class FakeConfigStore {
       description: string | null;
       privacyProfile: 'strict' | 'default';
       status: 'enabled' | 'disabled';
+      contextMemory: 'off' | 'enforce' | 'enforce-strict';
     }>,
   ): Promise<AgentMem> {
     const row = this.agents.get(id);
@@ -460,6 +465,130 @@ describe('createOperatorAgentsRouter', () => {
     teamsStore = new FakeTeamsIdentityStore();
     teamsRunner = new FakeTeamsRunner();
     provisionerInstalled = true;
+  });
+
+  // ── W5 memory-ACL rollout switch (#899) ─────────────────────────────
+  describe('context-memory rollout switch (#899)', () => {
+    it('GET /:slug/context-memory defaults to off and advertises the union', async () => {
+      await store.createAgent({ slug: 'public', name: 'Public' });
+      const res = await fetch(`${baseUrl}/public/context-memory`);
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as {
+        slug: string;
+        mode: string;
+        modes: string[];
+      };
+      assert.equal(body.slug, 'public');
+      assert.equal(body.mode, 'off');
+      // The UI renders its radio group from this list, so the route owns the
+      // union. A drift here would silently drop a mode from the operator's
+      // choices while the runtime still honours it.
+      assert.deepEqual(body.modes, ['off', 'enforce', 'enforce-strict']);
+    });
+
+    it('GET /:slug/context-memory reads an unknown persisted value as off', async () => {
+      const agent = await store.createAgent({ slug: 'public', name: 'Public' });
+      // A value written by a NEWER middleware during a rolling deploy, or by
+      // hand. Deny-default: the operator must not see "on" for a mode this
+      // process would route as off.
+      store.agents.set(agent.id, {
+        ...agent,
+        contextMemory: 'enforce-super-strict' as never,
+      });
+      const res = await fetch(`${baseUrl}/public/context-memory`);
+      assert.equal(res.status, 200);
+      assert.equal(((await res.json()) as { mode: string }).mode, 'off');
+    });
+
+    it('GET /:slug/context-memory 404s for an unknown agent', async () => {
+      const res = await fetch(`${baseUrl}/nope/context-memory`);
+      assert.equal(res.status, 404);
+      assert.equal(((await res.json()) as { error: string }).error, 'not_found');
+    });
+
+    it('PUT /:slug/context-memory persists the mode and triggers a reload', async () => {
+      await store.createAgent({ slug: 'public', name: 'Public' });
+      const res = await fetch(`${baseUrl}/public/context-memory`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ mode: 'enforce' }),
+      });
+      assert.equal(res.status, 200);
+      assert.deepEqual(await res.json(), { ok: true, mode: 'enforce' });
+      assert.equal((await store.getAgentBySlug('public'))?.contextMemory, 'enforce');
+      // Without the reload the switch would only take effect on the next
+      // process restart, which is the shape of bug that reads as "it did
+      // nothing" in production.
+      assert.equal(registry.reloadCalls, 1);
+    });
+
+    it('PUT /:slug/context-memory accepts enforce-strict and switches back to off', async () => {
+      await store.createAgent({ slug: 'public', name: 'Public' });
+      for (const mode of ['enforce-strict', 'off'] as const) {
+        const res = await fetch(`${baseUrl}/public/context-memory`, {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ mode }),
+        });
+        assert.equal(res.status, 200);
+        assert.equal((await store.getAgentBySlug('public'))?.contextMemory, mode);
+      }
+    });
+
+    it('PUT /:slug/context-memory rejects a mode outside the union with 400', async () => {
+      await store.createAgent({ slug: 'public', name: 'Public' });
+      const res = await fetch(`${baseUrl}/public/context-memory`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ mode: 'enforce-ish' }),
+      });
+      assert.equal(res.status, 400);
+      assert.equal(((await res.json()) as { error: string }).error, 'invalid_body');
+      // Rejected, not coerced: an agent left untouched is auditable, an agent
+      // silently reset to `off` while the UI shows `enforce` is not.
+      assert.equal((await store.getAgentBySlug('public'))?.contextMemory, undefined);
+      assert.equal(registry.reloadCalls, 0);
+    });
+
+    it('PUT /:slug/context-memory 404s for an unknown agent and writes nothing', async () => {
+      const res = await fetch(`${baseUrl}/nope/context-memory`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ mode: 'enforce' }),
+      });
+      assert.equal(res.status, 404);
+      assert.equal(registry.reloadCalls, 0);
+    });
+
+    it('PATCH /:slug leaves an enforcing agent enforcing', async () => {
+      // The dashboard's rename/enable form sends whatever it holds. It must
+      // not be able to carry a memory-scope change along with a rename.
+      const agent = await store.createAgent({ slug: 'public', name: 'Public' });
+      store.agents.set(agent.id, { ...agent, contextMemory: 'enforce' });
+      const res = await fetch(`${baseUrl}/public`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Renamed' }),
+      });
+      assert.equal(res.status, 200);
+      const after = await store.getAgentBySlug('public');
+      assert.equal(after?.name, 'Renamed');
+      assert.equal(after?.contextMemory, 'enforce');
+    });
+
+    it('the advertised union matches the CHECK constraint in migration 0050', async () => {
+      // The column's CHECK is the last line of defence. If the route offered a
+      // fourth mode, the write would fail at the database with a 500 instead
+      // of a validation error — so the two unions are pinned to each other.
+      const sql = await readFile(
+        new URL('../migrations/0050_agent_context_memory_flag.sql', import.meta.url),
+        'utf8',
+      );
+      const match = /context_memory\s+IN\s*\(([^)]*)\)/.exec(sql);
+      assert.ok(match, 'migration 0050 must CHECK context_memory against a value list');
+      const fromSql = [...match[1]!.matchAll(/'([^']+)'/g)].map((m) => m[1]);
+      assert.deepEqual(fromSql, [...CONTEXT_MEMORY_MODES]);
+    });
   });
 
   it('POST / creates an agent and triggers a reload', async () => {

--- a/middleware/test/orchestrator/contextMemoryTurnBinding.test.ts
+++ b/middleware/test/orchestrator/contextMemoryTurnBinding.test.ts
@@ -45,15 +45,21 @@ import type { TurnOrigin } from '../../packages/harness-channel-sdk/src/turnOrig
 const AGENT_SLUG = 'w5-agent';
 const AGENT_ROOT = `/memories/orchestrators/${AGENT_SLUG}`;
 
-/** A Teams turn in team `t-alpha`, channel `c-1` — the origin a channel
- *  plugin builds. `memoryAxesForOrigin` resolves it to a channel tier with a
- *  team tier above it. */
-function teamsOrigin(): TurnOrigin {
+/**
+ * A Teams turn in a channel of team `teamId` — the shape
+ * `omadia-channel-teams` builds beside its `sessionScope`.
+ * `memoryAxesForOrigin` resolves it to a channel tier with a team tier above.
+ *
+ * Built structurally, with no cast: a cast here would let a malformed origin
+ * silently degrade to context-free and turn these tests into assertions about
+ * the fallback rather than about the threading.
+ */
+function teamsOrigin(conversationId = 'c-1', teamId = 't-alpha'): TurnOrigin {
   return {
     channelType: 'teams',
-    scope: { kind: 'channel', id: 'c-1' },
-    container: { kind: 'team', id: 't-alpha' },
-  } as TurnOrigin;
+    scope: { kind: 'conversation', channelId: 'msteams', conversationId },
+    container: { kind: 'team', id: teamId },
+  };
 }
 
 // ── scripted provider ───────────────────────────────────────────────────────
@@ -260,11 +266,7 @@ describe('W5 TurnOrigin threading — a real turn (#899)', () => {
     const alphaPaths = alpha.root.writes;
 
     const beta = harness('enforce', writeThenAnswer('/memories/note.md', 'beta-secret'));
-    await drain(beta.orchestrator, {
-      channelType: 'teams',
-      scope: { kind: 'channel', id: 'c-2' },
-      container: { kind: 'team', id: 't-beta' },
-    } as TurnOrigin);
+    await drain(beta.orchestrator, teamsOrigin('c-2', 't-beta'));
     const betaPaths = beta.root.writes;
 
     assert.equal(alphaPaths.length, 1);
@@ -309,10 +311,9 @@ describe('W5 fail-closed on a real turn (#899)', () => {
     // completes — a dropped user turn would be the wrong trade — but narrower.
     const h = harness('enforce', writeThenAnswer('/memories/note.md', 'x'));
     await drain(h.orchestrator, {
+      ...teamsOrigin(),
       channelType: 'carrier-pigeon',
-      scope: { kind: 'channel', id: 'c-1' },
-      container: { kind: 'team', id: 't-alpha' },
-    } as unknown as TurnOrigin);
+    });
     assert.deepEqual(h.root.writes, [`${AGENT_ROOT}/note.md`]);
   });
 });

--- a/middleware/test/orchestrator/contextMemoryTurnBinding.test.ts
+++ b/middleware/test/orchestrator/contextMemoryTurnBinding.test.ts
@@ -1,0 +1,318 @@
+/**
+ * W5 memory-ACL (#860) — the `TurnOrigin` threading, exercised by a REAL turn.
+ *
+ * Issue #899 asks for the operator surface that makes `agents.context_memory`
+ * switchable, and for someone to read the one part of the wave that shipped
+ * with a stated residual risk: the binding is threaded through ~8 signatures
+ * in `orchestrator.ts`, and the W5 suites all stop at `MemoryBinder`'s
+ * HANDLER. Not one of them constructs an `Orchestrator` and runs a turn, so
+ * every claim about the threading rested on reading the code.
+ *
+ * Reading it is not enough for this axis. The failure mode is silent by
+ * construction: a binding lost at an await boundary, a call site that forgets
+ * the parameter, a streaming generator resumed in the wrong async context —
+ * none of them throw. They fall back to the agent-global tree, the turn
+ * succeeds, and team A's notes are readable in team B. That is the shape of
+ * bug that only a test which asserts the PHYSICAL PATH can catch.
+ *
+ * So these tests drive both entry points — `runTurn` (buffered) and
+ * `chatStream` (streaming, the path every channel and the web-ui use, and the
+ * one the residual-risk note singled out) — with a scripted provider that
+ * calls the `memory` tool, and assert where the bytes actually landed in the
+ * root store.
+ *
+ * Method note: each assertion below was verified to be load-bearing by
+ * breaking the invariant (dropping `turnMemory` at the call site), rebuilding,
+ * and confirming it turns red.
+ */
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import type {
+  LlmProvider,
+  LlmResponse,
+  LlmStreamEvent,
+} from '@omadia/llm-provider';
+import { InMemoryMemoryStore, MemoryToolHandler } from '@omadia/memory';
+import {
+  MemoryBinder,
+  NativeToolRegistry,
+  Orchestrator,
+  type ContextMemoryMode,
+} from '@omadia/orchestrator';
+import type { TurnOrigin } from '../../packages/harness-channel-sdk/src/turnOrigin.js';
+
+const AGENT_SLUG = 'w5-agent';
+const AGENT_ROOT = `/memories/orchestrators/${AGENT_SLUG}`;
+
+/** A Teams turn in team `t-alpha`, channel `c-1` — the origin a channel
+ *  plugin builds. `memoryAxesForOrigin` resolves it to a channel tier with a
+ *  team tier above it. */
+function teamsOrigin(): TurnOrigin {
+  return {
+    channelType: 'teams',
+    scope: { kind: 'channel', id: 'c-1' },
+    container: { kind: 'team', id: 't-alpha' },
+  } as TurnOrigin;
+}
+
+// ── scripted provider ───────────────────────────────────────────────────────
+
+const providerCapabilities = {
+  tools: true,
+  vision: false,
+  streaming: true,
+  promptCaching: false,
+  forcedToolChoice: false,
+  parallelToolCalls: false,
+} as const;
+
+function fakeProvider(streams: LlmStreamEvent[][]): LlmProvider {
+  let idx = 0;
+  const take = (): LlmStreamEvent[] => {
+    if (idx >= streams.length) {
+      throw new Error(`no scripted stream for provider call ${String(idx + 1)}`);
+    }
+    const events = streams[idx]!;
+    idx += 1;
+    return events;
+  };
+  return {
+    id: 'anthropic',
+    capabilities: providerCapabilities,
+    complete: async (): Promise<LlmResponse> => {
+      const events = take();
+      const final = events.at(-1) as { type: string; response: LlmResponse };
+      return final.response;
+    },
+    stream: (): AsyncIterable<LlmStreamEvent> => {
+      const events = take();
+      return {
+        async *[Symbol.asyncIterator]() {
+          for (const ev of events) yield ev;
+        },
+      };
+    },
+    classifyError: () => ({ retryable: false, kind: 'other' as const }),
+  } as unknown as LlmProvider;
+}
+
+function toolCallStream(input: unknown): LlmStreamEvent[] {
+  return [
+    {
+      type: 'final',
+      response: {
+        content: [{ type: 'tool_call', id: 'tu-1', name: 'memory', input }],
+        finishReason: 'tool_calls',
+        providerFinishReason: 'tool_use',
+        model: 'test',
+        usage: {
+          inputTokens: 10,
+          outputTokens: 2,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        },
+      },
+    } as LlmStreamEvent,
+  ];
+}
+
+function textStream(text: string): LlmStreamEvent[] {
+  return [
+    { type: 'text_delta', text },
+    {
+      type: 'final',
+      response: {
+        content: [{ type: 'text', text }],
+        finishReason: 'stop',
+        providerFinishReason: 'end_turn',
+        model: 'test',
+        usage: {
+          inputTokens: 10,
+          outputTokens: 1,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        },
+      },
+    } as LlmStreamEvent,
+  ];
+}
+
+/** One tool iteration that writes `path`, then a plain answer. */
+function writeThenAnswer(path: string, fileText: string): LlmStreamEvent[][] {
+  return [
+    toolCallStream({ command: 'create', path, file_text: fileText }),
+    textStream('fertig'),
+  ];
+}
+
+/**
+ * The undecorated root store, recording the PHYSICAL path of every write.
+ *
+ * Recording at the root is the whole method: every namespacer and scope guard
+ * sits above it, so whatever arrives here is what actually hit storage. An
+ * assertion on a decorated store would only re-state the decorator's own
+ * arithmetic.
+ */
+class RecordingMemoryStore extends InMemoryMemoryStore {
+  readonly writes: string[] = [];
+
+  override async createFile(virtualPath: string, content: string): Promise<void> {
+    this.writes.push(virtualPath);
+    await super.createFile(virtualPath, content);
+  }
+
+  override async writeFile(virtualPath: string, content: string): Promise<void> {
+    this.writes.push(virtualPath);
+    await super.writeFile(virtualPath, content);
+  }
+}
+
+interface Harness {
+  readonly orchestrator: Orchestrator;
+  /** The UNDECORATED root store — assertions read physical paths from here. */
+  readonly root: RecordingMemoryStore;
+}
+
+function harness(mode: ContextMemoryMode, streams: LlmStreamEvent[][]): Harness {
+  const root = new RecordingMemoryStore();
+  const binder = new MemoryBinder({ agentSlug: AGENT_SLUG, root, mode });
+  return {
+    root,
+    orchestrator: new Orchestrator({
+      provider: fakeProvider(streams),
+      model: 'test',
+      maxTokens: 1024,
+      maxToolIterations: 5,
+      domainTools: [],
+      nativeToolRegistry: new NativeToolRegistry(),
+      agentId: AGENT_SLUG,
+      // The build-time handler an unbound turn falls back to. Deliberately
+      // present: if the binding were dropped anywhere the turn would still
+      // succeed and write HERE, which is precisely what the assertions catch.
+      memoryToolHandler: new MemoryToolHandler(root),
+      memoryBinder: binder,
+    }),
+  };
+}
+
+async function drain(orchestrator: Orchestrator, origin?: TurnOrigin): Promise<void> {
+  for await (const _ of orchestrator.chatStream({
+    userMessage: 'los',
+    sessionScope: 'sess-w5',
+    ...(origin ? { origin } : {}),
+  })) {
+    // drain
+  }
+}
+
+// ── 1. a turn WITH an origin lands in the context tier ───────────────────────
+
+describe('W5 TurnOrigin threading — a real turn (#899)', () => {
+  it('MUTATION CHECK: buffered runTurn with an origin writes into the CONTEXT tier', async () => {
+    const h = harness('enforce', writeThenAnswer('/memories/note.md', 'alpha'));
+    await h.orchestrator.runTurn({
+      userMessage: 'los',
+      sessionScope: 'sess-w5',
+      origin: teamsOrigin(),
+    });
+    const paths = h.root.writes;
+    assert.equal(paths.length, 1, `expected exactly one write, got ${paths.join(', ')}`);
+    const written = paths[0]!;
+    // The whole point of the wave: NOT the agent-global tree.
+    assert.ok(
+      !written.startsWith(`${AGENT_ROOT}/`),
+      `write landed in the agent-global tree (${written}) — the binding was lost`,
+    );
+    assert.ok(
+      written.startsWith(`/memories/contexts/${AGENT_SLUG}/`),
+      `write did not land in a context tier: ${written}`,
+    );
+  });
+
+  it('MUTATION CHECK: STREAMING chatStream with an origin writes into the CONTEXT tier', async () => {
+    // THE test the residual-risk note asked for. `chatStream` binds in
+    // `chatStreamInContext`, inside `turnContext.runGenerator`; an async
+    // generator is resumed in the async context of whoever calls `.next()`,
+    // which is exactly how an earlier wave silently lost `turnContext` on
+    // every streaming turn. A binding lost the same way would not fail — it
+    // would quietly write agent-global.
+    const h = harness('enforce', writeThenAnswer('/memories/note.md', 'alpha'));
+    await drain(h.orchestrator, teamsOrigin());
+    const paths = h.root.writes;
+    assert.equal(paths.length, 1, `expected exactly one write, got ${paths.join(', ')}`);
+    const written = paths[0]!;
+    assert.ok(
+      !written.startsWith(`${AGENT_ROOT}/`),
+      `streaming write landed in the agent-global tree (${written}) — the binding was lost`,
+    );
+    assert.ok(
+      written.startsWith(`/memories/contexts/${AGENT_SLUG}/`),
+      `streaming write did not land in a context tier: ${written}`,
+    );
+  });
+
+  it('two different team contexts do not see each other', async () => {
+    // The operator-facing promise in one assertion: what a turn in team alpha
+    // writes is not listable from a turn in team beta.
+    const alpha = harness('enforce', writeThenAnswer('/memories/note.md', 'alpha-secret'));
+    await drain(alpha.orchestrator, teamsOrigin());
+    const alphaPaths = alpha.root.writes;
+
+    const beta = harness('enforce', writeThenAnswer('/memories/note.md', 'beta-secret'));
+    await drain(beta.orchestrator, {
+      channelType: 'teams',
+      scope: { kind: 'channel', id: 'c-2' },
+      container: { kind: 'team', id: 't-beta' },
+    } as TurnOrigin);
+    const betaPaths = beta.root.writes;
+
+    assert.equal(alphaPaths.length, 1);
+    assert.equal(betaPaths.length, 1);
+    assert.notEqual(
+      alphaPaths[0],
+      betaPaths[0],
+      'two distinct team contexts resolved to the SAME physical path',
+    );
+  });
+});
+
+// ── 2. fail-closed: no origin, and mode off ─────────────────────────────────
+
+describe('W5 fail-closed on a real turn (#899)', () => {
+  it('MUTATION CHECK: a turn WITHOUT an origin stays agent-private under enforce', async () => {
+    // An HTTP/API turn emits no `TurnOrigin` on purpose (`routes/chat.ts`).
+    // Under `enforce` it must reduce to the agent-private tree — never to a
+    // context tier it could name, and never to the raw store root.
+    const h = harness('enforce', writeThenAnswer('/memories/note.md', 'api'));
+    await drain(h.orchestrator);
+    assert.deepEqual(h.root.writes, [`${AGENT_ROOT}/note.md`]);
+  });
+
+  it('MUTATION CHECK: streaming without an origin stays agent-private under enforce-strict', async () => {
+    const h = harness('enforce-strict', writeThenAnswer('/memories/note.md', 'api'));
+    await drain(h.orchestrator);
+    assert.deepEqual(h.root.writes, [`${AGENT_ROOT}/note.md`]);
+  });
+
+  it('mode `off` ignores a present origin entirely (byte-identical rollout default)', async () => {
+    // The rollout guarantee: until an operator flips the switch, an origin
+    // arriving from a channel plugin changes nothing. This is what makes
+    // #899's UI safe to ship ahead of any migration.
+    const h = harness('off', writeThenAnswer('/memories/note.md', 'alpha'));
+    await drain(h.orchestrator, teamsOrigin());
+    assert.deepEqual(h.root.writes, [`${AGENT_ROOT}/note.md`]);
+  });
+
+  it('an unusable origin falls back to agent-private rather than throwing', async () => {
+    // `channelType` outside the allowlist. Fail-closed means the turn still
+    // completes — a dropped user turn would be the wrong trade — but narrower.
+    const h = harness('enforce', writeThenAnswer('/memories/note.md', 'x'));
+    await drain(h.orchestrator, {
+      channelType: 'carrier-pigeon',
+      scope: { kind: 'channel', id: 'c-1' },
+      container: { kind: 'team', id: 't-alpha' },
+    } as unknown as TurnOrigin);
+    assert.deepEqual(h.root.writes, [`${AGENT_ROOT}/note.md`]);
+  });
+});

--- a/web-ui/app/_lib/agents.ts
+++ b/web-ui/app/_lib/agents.ts
@@ -220,6 +220,79 @@ export async function toggleAgentPlugin(
   );
 }
 
+// ── W5 memory-ACL rollout switch (#899) ────────────────────────────────
+
+/**
+ * The three modes `agents.context_memory` accepts. Structural contract with
+ * the middleware, same arrangement as {@link TEAMS_PROVISIONING_STATES}: the
+ * column's CHECK constraint (migration 0050) owns the vocabulary, the route
+ * re-states it, and this list mirrors it so the radio group renders without a
+ * round trip. {@link ContextMemoryDto.modes} carries the server's own copy —
+ * the component renders THAT and falls back to this list, so a middleware that
+ * grows a fourth mode does not need a UI release to expose it.
+ */
+export const CONTEXT_MEMORY_MODES = [
+  'off',
+  'enforce',
+  'enforce-strict',
+] as const;
+
+export type ContextMemoryMode = (typeof CONTEXT_MEMORY_MODES)[number];
+
+const CONTEXT_MEMORY_MODE_SET: ReadonlySet<string> = new Set(
+  CONTEXT_MEMORY_MODES,
+);
+
+/**
+ * Narrow an arbitrary string to a known mode, deny-default to `'off'`.
+ *
+ * Mirrors the server's `normalizeContextMemoryMode` and the orchestrator's
+ * `parseContextMemoryMode`: the UI must never claim an agent is enforcing
+ * when the runtime would route it as `off`. A security control that reads
+ * "on" while behaving as "off" is worse than one that is plainly off.
+ */
+export function parseContextMemoryMode(raw: unknown): ContextMemoryMode {
+  return typeof raw === 'string' && CONTEXT_MEMORY_MODE_SET.has(raw)
+    ? (raw as ContextMemoryMode)
+    : 'off';
+}
+
+export interface ContextMemoryDto {
+  slug: string;
+  mode: ContextMemoryMode;
+  /** The union the SERVER accepts. Rendered in preference to the local
+   *  constant so the control follows the middleware, not the bundle. */
+  modes: readonly string[];
+}
+
+/** Read the W5 memory-ACL rollout mode of one agent (issue #899). */
+export async function getAgentContextMemory(
+  slug: string,
+): Promise<ContextMemoryDto> {
+  const res = await callJson<ContextMemoryDto>(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/context-memory`,
+  );
+  return { ...res, mode: parseContextMemoryMode(res.mode) };
+}
+
+/**
+ * Set the W5 memory-ACL rollout mode of one agent (issue #899).
+ *
+ * A dedicated endpoint rather than a field on `patchOperatorAgent`: that call
+ * is the dashboard's rename/enable form and sends whatever it holds, so
+ * folding a memory-scope change into it would let an unrelated edit carry one
+ * along. The server reloads the registry, so the next turn is already scoped.
+ */
+export async function setAgentContextMemory(
+  slug: string,
+  mode: ContextMemoryMode,
+): Promise<{ ok: boolean; mode: ContextMemoryMode }> {
+  return callJson<{ ok: boolean; mode: ContextMemoryMode }>(
+    `/v1/operator/agents/${encodeURIComponent(slug)}/context-memory`,
+    { method: 'PUT', body: JSON.stringify({ mode }) },
+  );
+}
+
 /** One `agent_tool_grants` row of the per-agent grant read model (issue
  *  #861). Snake_case mirrors the REST payload verbatim, like the other
  *  operator-agents DTOs in this file. */

--- a/web-ui/app/operator/agents/[slug]/__tests__/AgentContextMemory.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/AgentContextMemory.test.tsx
@@ -1,0 +1,179 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithIntl } from '../../../../_lib/test-utils';
+import { ApiError } from '../../../../_lib/api';
+import type { ContextMemoryDto } from '../../../../_lib/agents';
+import { AgentContextMemory } from '../_components/AgentContextMemory';
+
+/**
+ * Issue #899 (epic #860) — operator control for the W5 chat-context memory
+ * ACL.
+ *
+ * The behaviours worth pinning are the SAFETY ones, not the rendering:
+ *
+ *  - enabling is gated behind seeing the three semantics, because an operator
+ *    who has not read them will read the ACL's contract as a bug;
+ *  - disabling is NOT gated — the safe direction must never be harder than
+ *    the unsafe one;
+ *  - a mode the client does not know narrows to `off`, so the panel can never
+ *    claim an agent is enforcing when the runtime would route it as off.
+ */
+
+const { mockGet, mockSet } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockSet: vi.fn(),
+}));
+
+// Spread the real module so the mode narrowing and the error-code parser —
+// the shared contracts this UI depends on — stay genuine; only the two
+// network calls are stubbed.
+vi.mock('../../../../_lib/agents', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../_lib/agents')>()),
+  getAgentContextMemory: mockGet,
+  setAgentContextMemory: mockSet,
+}));
+
+function dto(overrides: Partial<ContextMemoryDto> = {}): ContextMemoryDto {
+  return {
+    slug: 'sales-bot',
+    mode: 'off',
+    modes: ['off', 'enforce', 'enforce-strict'],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockSet.mockReset();
+  mockGet.mockResolvedValue(dto());
+  mockSet.mockImplementation((_slug: string, mode: string) =>
+    Promise.resolve({ ok: true, mode }),
+  );
+});
+
+async function render(initial?: Partial<ContextMemoryDto>): Promise<void> {
+  if (initial) mockGet.mockResolvedValue(dto(initial));
+  renderWithIntl(<AgentContextMemory slug="sales-bot" />);
+  await waitFor(() => expect(mockGet).toHaveBeenCalledWith('sales-bot'));
+  await screen.findByRole('radio', { name: /Off/i });
+}
+
+describe('AgentContextMemory (#899)', () => {
+  it('renders one radio per server-advertised mode and preselects the saved one', async () => {
+    await render({ mode: 'enforce' });
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+    expect(screen.getByRole('radio', { name: /Separate per context/i })).toBeChecked();
+  });
+
+  it('follows the SERVER mode list, not the bundled constant', async () => {
+    // A middleware that drops a mode must not leave a dead radio behind: the
+    // control renders what the server says it accepts.
+    await render({ modes: ['off', 'enforce'] });
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+  });
+
+  it('narrows an unknown persisted mode to off', async () => {
+    // Deny-default. Showing "enforcing" for a value the runtime routes as off
+    // is worse than showing off, because it stops the operator from fixing it.
+    await render({ mode: 'enforce-super-strict' as ContextMemoryDto['mode'] });
+    expect(screen.getByRole('radio', { name: /Off/i })).toBeChecked();
+  });
+
+  it('save is disabled until something actually changes', async () => {
+    await render();
+    expect(screen.getByRole('button', { name: /Save/i })).toBeDisabled();
+  });
+
+  it('ENABLING shows the three semantics and blocks save until acknowledged', async () => {
+    const user = userEvent.setup();
+    await render();
+    await user.click(screen.getByRole('radio', { name: /Separate per context/i }));
+
+    // All three semantics from the issue must be on screen BEFORE the switch.
+    expect(screen.getByText(/shared team tier/i)).toBeInTheDocument();
+    expect(screen.getByText(/read-only for context turns/i)).toBeInTheDocument();
+    expect(screen.getByText(/Turns from the API carry no chat context/i)).toBeInTheDocument();
+
+    const save = screen.getByRole('button', { name: /Save/i });
+    expect(save).toBeDisabled();
+    expect(mockSet).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('checkbox'));
+    expect(save).toBeEnabled();
+    await user.click(save);
+    await waitFor(() => expect(mockSet).toHaveBeenCalledWith('sales-bot', 'enforce'));
+  });
+
+  it('re-arms the acknowledgement when the operator picks a different mode', async () => {
+    // An acknowledgement is about the mode it was given for. Carrying it over
+    // would let a click on `enforce` unlock a save of `enforce-strict`.
+    const user = userEvent.setup();
+    await render();
+    await user.click(screen.getByRole('radio', { name: /Separate per context/i }));
+    await user.click(screen.getByRole('checkbox'));
+    expect(screen.getByRole('button', { name: /Save/i })).toBeEnabled();
+
+    await user.click(screen.getByRole('radio', { name: /Separate and sealed/i }));
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+    expect(screen.getByRole('button', { name: /Save/i })).toBeDisabled();
+  });
+
+  it('DISABLING needs no acknowledgement — the safe direction is never gated', async () => {
+    const user = userEvent.setup();
+    await render({ mode: 'enforce' });
+    await user.click(screen.getByRole('radio', { name: /Off/i }));
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /Save/i }));
+    await waitFor(() => expect(mockSet).toHaveBeenCalledWith('sales-bot', 'off'));
+  });
+
+  it('tightening enforce → enforce-strict needs no acknowledgement', async () => {
+    const user = userEvent.setup();
+    await render({ mode: 'enforce' });
+    await user.click(screen.getByRole('radio', { name: /Separate and sealed/i }));
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /Save/i }));
+    await waitFor(() =>
+      expect(mockSet).toHaveBeenCalledWith('sales-bot', 'enforce-strict'),
+    );
+  });
+
+  it('renders a LOCALIZED message for a machine error code, never the raw body', async () => {
+    const user = userEvent.setup();
+    await render();
+    mockSet.mockRejectedValue(
+      new ApiError(404, 'boom', JSON.stringify({ error: 'not_found' })),
+    );
+    await user.click(screen.getByRole('radio', { name: /Separate per context/i }));
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: /Save/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/does not exist anymore/i);
+    expect(alert.textContent).not.toContain('not_found');
+  });
+
+  it('keeps the operator selection after a failed save', async () => {
+    // Re-reading the server value here would erase the choice they are trying
+    // to make and hide which mode the failed write was for.
+    const user = userEvent.setup();
+    await render();
+    mockSet.mockRejectedValue(new ApiError(500, 'boom', '{}'));
+    await user.click(screen.getByRole('radio', { name: /Separate per context/i }));
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByRole('button', { name: /Save/i }));
+
+    await screen.findByRole('alert');
+    expect(screen.getByRole('radio', { name: /Separate per context/i })).toBeChecked();
+  });
+
+  it('surfaces a load failure as localized copy and renders no control', async () => {
+    mockGet.mockRejectedValue(new ApiError(503, 'boom', '{}'));
+    renderWithIntl(<AgentContextMemory slug="sales-bot" />);
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBeTruthy();
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+  });
+});

--- a/web-ui/app/operator/agents/[slug]/_components/AgentContextMemory.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentContextMemory.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { useTranslations } from 'next-intl';
+
+import { Button } from '@/app/_components/ui/Button';
+import {
+  CONTEXT_MEMORY_MODES,
+  getAgentContextMemory,
+  parseContextMemoryMode,
+  parseOperatorAgentErrorCode,
+  setAgentContextMemory,
+  type ContextMemoryMode,
+} from '../../../../_lib/agents';
+import { humanizeApiError } from '../../_components/AgentsDashboard';
+
+interface AgentContextMemoryProps {
+  /** Slug of the orchestrator whose rollout mode is edited. */
+  readonly slug: string;
+}
+
+/**
+ * Issue #899 (epic #860) — operator control for the W5 chat-context memory
+ * ACL (`agents.context_memory`, migration 0050).
+ *
+ * W5 shipped the whole mechanism — scoping, the `/memories/contexts/` tree,
+ * the promote route and its audit log — behind a per-agent column that had no
+ * UI and no API. The only way to enable it was a hand-written `UPDATE`, which
+ * made the wave inert in practice. This is the supported path.
+ *
+ * Two deliberate interaction choices:
+ *
+ *  - The control edits a DEDICATED endpoint (`PUT .../context-memory`), not a
+ *    field on the dashboard's rename/enable PATCH. A memory-scope change
+ *    should never ride along with an unrelated edit.
+ *  - Switching AWAY from `off` requires an explicit acknowledgement of the
+ *    three semantics below. They are not decoration: an operator who expects
+ *    "the agent forgets across teams" but writes to a channel the plugin does
+ *    not scope, or who expects API turns to reach the team tree, will read the
+ *    result as a bug in the ACL rather than as its contract. Switching back to
+ *    `off` needs no acknowledgement — the safe direction is never gated.
+ *
+ * The mode list is INTERSECTED with the server's `modes` array: the server can
+ * take a mode away (an older middleware that does not accept `enforce-strict`
+ * must not offer it), but it cannot add one, because a mode this bundle has no
+ * label for cannot be rendered. Growing the union is therefore a deliberate UI
+ * release, not an accident.
+ *
+ * Everything that arrives from the wire is narrowed through
+ * `parseContextMemoryMode` before it reaches state — not only inside the API
+ * client. A component that renders a security state should not inherit its
+ * trust from a type annotation: the UI must never show "enforcing" for a value
+ * the runtime routes as off, whatever the payload said.
+ *
+ * Error copy: the route emits machine codes as `{ error: '<code>' }`.
+ * `parseOperatorAgentErrorCode` narrows them onto the `detailErrors.*`
+ * catalogue; unknown failures render the localized fallback with the technical
+ * detail as an ICU argument — raw bodies never reach the UI (i18n hard rule).
+ */
+export function AgentContextMemory(
+  props: AgentContextMemoryProps,
+): React.ReactElement {
+  const t = useTranslations('operatorAgents');
+  /** Mode as last confirmed by the server. `null` until the first load lands. */
+  const [saved, setSaved] = useState<ContextMemoryMode | null>(null);
+  const [modes, setModes] =
+    useState<readonly ContextMemoryMode[]>(CONTEXT_MEMORY_MODES);
+  const [selected, setSelected] = useState<ContextMemoryMode | null>(null);
+  const [acknowledged, setAcknowledged] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const localizeError = useCallback(
+    (err: unknown): string => {
+      const code = parseOperatorAgentErrorCode(err);
+      return code !== null
+        ? t(`detailErrors.${code}`)
+        : t('detailErrors.unknown', { detail: humanizeApiError(err) });
+    },
+    [t],
+  );
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    try {
+      const res = await getAgentContextMemory(props.slug);
+      const mode = parseContextMemoryMode(res.mode);
+      setSaved(mode);
+      setSelected(mode);
+      // Intersect, never union: an entry this bundle has no label for is
+      // dropped rather than rendered. Falling back to the local constant when
+      // nothing survives keeps an older or unexpected middleware from leaving
+      // the operator with no control at all.
+      const offered = CONTEXT_MEMORY_MODES.filter((m) => res.modes.includes(m));
+      setModes(offered.length > 0 ? offered : CONTEXT_MEMORY_MODES);
+      setError(null);
+    } catch (err: unknown) {
+      setError(localizeError(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [props.slug, localizeError]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const dirty = selected !== null && saved !== null && selected !== saved;
+  /**
+   * The acknowledgement gate applies to ENABLING only — moving off `off`.
+   * Tightening `enforce` → `enforce-strict` narrows an already-scoped agent,
+   * and turning the ACL back off restores today's behaviour; neither is the
+   * step whose semantics surprise an operator.
+   */
+  const needsAck = dirty && saved === 'off' && selected !== 'off';
+  const canSave = dirty && (!needsAck || acknowledged) && !saving;
+
+  const save = useCallback(async (): Promise<void> => {
+    if (selected === null) return;
+    setSaving(true);
+    try {
+      const res = await setAgentContextMemory(props.slug, selected);
+      const applied = parseContextMemoryMode(res.mode);
+      setSaved(applied);
+      setSelected(applied);
+      setAcknowledged(false);
+      setError(null);
+    } catch (err: unknown) {
+      setError(localizeError(err));
+      // Leave `selected` where the operator put it: re-reading the server
+      // value here would erase the choice they are trying to make and hide
+      // which mode the failed write was for.
+    } finally {
+      setSaving(false);
+    }
+  }, [props.slug, selected, localizeError]);
+
+  return (
+    <section className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-4">
+      <div className="mb-1 flex flex-wrap items-center gap-2">
+        <h2 className="text-lg font-medium">{t('contextMemory.heading')}</h2>
+        <span className="text-xs text-[color:var(--fg-muted)]">
+          {saved === null
+            ? t('contextMemory.stateUnknown')
+            : t('contextMemory.stateSummary', {
+                mode: t(`contextMemory.modes.${saved}.label`),
+              })}
+        </span>
+      </div>
+      <p className="mb-3 text-xs text-[color:var(--fg-muted)]">
+        {t('contextMemory.hint')}
+      </p>
+
+      {error && (
+        <div
+          role="alert"
+          className="mb-3 rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-3 text-sm text-[color:var(--danger)]"
+        >
+          {error}
+        </div>
+      )}
+
+      {loading && saved === null && !error && (
+        <p className="text-sm text-[color:var(--fg-muted)]">
+          {t('contextMemory.loading')}
+        </p>
+      )}
+
+      {selected !== null && (
+        <>
+          <fieldset className="flex flex-col gap-2">
+            <legend className="sr-only">{t('contextMemory.heading')}</legend>
+            {modes.map((mode) => {
+              return (
+                <label
+                  key={mode}
+                  className="flex cursor-pointer items-start gap-2 rounded border border-[color:var(--border)]/60 p-2 text-sm"
+                >
+                  <input
+                    type="radio"
+                    className="mt-1"
+                    name={`context-memory-${props.slug}`}
+                    value={mode}
+                    checked={selected === mode}
+                    disabled={saving}
+                    onChange={() => {
+                      setSelected(mode);
+                      // Every change re-arms the gate: an acknowledgement
+                      // given for one mode must not carry over to another.
+                      setAcknowledged(false);
+                    }}
+                  />
+                  <span>
+                    <span className="font-medium text-[color:var(--fg-strong)]">
+                      {t(`contextMemory.modes.${mode}.label`)}
+                    </span>
+                    <span className="block text-xs text-[color:var(--fg-muted)]">
+                      {t(`contextMemory.modes.${mode}.description`)}
+                    </span>
+                  </span>
+                </label>
+              );
+            })}
+          </fieldset>
+
+          {needsAck && (
+            <div
+              role="note"
+              className="mt-3 rounded border border-[color:var(--border)] bg-[color:var(--bg)] p-3 text-xs"
+            >
+              <p className="mb-2 font-medium text-[color:var(--fg-strong)]">
+                {t('contextMemory.semanticsHeading')}
+              </p>
+              <ul className="mb-3 flex list-disc flex-col gap-1 pl-4 text-[color:var(--fg-muted)]">
+                <li>{t('contextMemory.semanticsTeam')}</li>
+                <li>{t('contextMemory.semanticsAgent')}</li>
+                <li>{t('contextMemory.semanticsApi')}</li>
+              </ul>
+              <label className="flex cursor-pointer items-start gap-2 text-[color:var(--fg-strong)]">
+                <input
+                  type="checkbox"
+                  className="mt-0.5"
+                  checked={acknowledged}
+                  disabled={saving}
+                  onChange={(e) => setAcknowledged(e.target.checked)}
+                />
+                <span>{t('contextMemory.acknowledge')}</span>
+              </label>
+            </div>
+          )}
+
+          <div className="mt-3 flex items-center gap-2">
+            <Button
+              size="sm"
+              busy={saving}
+              busyLabel={t('contextMemory.saving')}
+              disabled={!canSave}
+              onClick={() => void save()}
+            >
+              {t('contextMemory.save')}
+            </Button>
+            {!dirty && !saving && (
+              <span className="text-xs text-[color:var(--fg-muted)]">
+                {t('contextMemory.unchanged')}
+              </span>
+            )}
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/web-ui/app/operator/agents/[slug]/page.tsx
+++ b/web-ui/app/operator/agents/[slug]/page.tsx
@@ -9,6 +9,7 @@ import {
   listOperatorAgents,
   type OperatorAgentsListDto,
 } from '../../../_lib/agents';
+import { AgentContextMemory } from './_components/AgentContextMemory';
 import { AgentDetail } from './_components/AgentDetail';
 import { AgentMcpServers } from './_components/AgentMcpServers';
 import { AgentToolGrants } from './_components/AgentToolGrants';
@@ -110,6 +111,10 @@ export default async function OperatorAgentDetailPage({
           <div className="mt-8 space-y-8">
             <AgentToolGrants slug={agent.slug} />
             <AgentMcpServers slug={agent.slug} />
+            {/* #899 — the W5 memory-ACL rollout switch. Sits with the other
+                per-agent capability settings rather than in a global admin
+                page: the column is per agent, and so is the blast radius. */}
+            <AgentContextMemory slug={agent.slug} />
           </div>
         </>
       )}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1909,6 +1909,35 @@
         "unknown": "Laden der Grants fehlgeschlagen: {detail}"
       }
     },
+    "contextMemory": {
+      "heading": "Chat-Kontext-Memory",
+      "hint": "Legt fest, ob dieser Orchestrator ein gemeinsames Memory führt oder je Chat-Kontext (Team, Kanal, Direktnachricht) ein eigenes. „Aus“ ist die Voreinstellung und entspricht dem Verhalten vor dieser Funktion.",
+      "loading": "Memory-Einstellung wird geladen…",
+      "stateSummary": "Aktuell: {mode}",
+      "stateUnknown": "Aktuell: unbekannt",
+      "save": "Speichern",
+      "saving": "Wird gespeichert",
+      "unchanged": "Keine ungespeicherte Änderung.",
+      "semanticsHeading": "Vor dem Einschalten lesen",
+      "semanticsTeam": "Ein Turn aus einem Team-Kontext schreibt in seine eigene Ebene und in die gemeinsame Team-Ebene — dort lesen sich Teamkolleginnen und -kollegen gegenseitig.",
+      "semanticsAgent": "Das eigene Memory des Orchestrators bleibt lesbar, wird für Kontext-Turns aber schreibgeschützt. „Merk dir das global“ kann damit kein Wissen mehr von Team A nach Team B tragen.",
+      "semanticsApi": "Turns über die API bringen keinen Chat-Kontext mit und erreichen deshalb nur das private Memory des Orchestrators selbst — nie einen Team- oder Kanal-Baum.",
+      "acknowledge": "Mir ist klar, wie das Memory für diesen Orchestrator aufgeteilt wird.",
+      "modes": {
+        "off": {
+          "label": "Aus",
+          "description": "Ein gemeinsames Memory für alle Turns. Voreinstellung und identisch mit dem Verhalten vor dieser Funktion."
+        },
+        "enforce": {
+          "label": "Je Kontext getrennt",
+          "description": "Jeder Chat-Kontext bekommt ein eigenes Memory. Das eigene Memory des Orchestrators bleibt lesbar, vorhandenes Wissen ist also weiter zitierbar."
+        },
+        "enforce-strict": {
+          "label": "Getrennt und abgeschottet",
+          "description": "Jeder Chat-Kontext bekommt ein eigenes Memory und kann das eigene Memory des Orchestrators gar nicht lesen. Für Kontexte, die nichts teilen dürfen."
+        }
+      }
+    },
     "teamsInstalls": {
       "heading": "Teams-Zuordnung",
       "hint": "In welchem Microsoft-Teams-Team die App dieses Orchestrators installiert ist und ob der Tenant den dafür nötigen Berechtigungen zugestimmt hat.",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1909,6 +1909,35 @@
         "unknown": "Loading grants failed: {detail}"
       }
     },
+    "contextMemory": {
+      "heading": "Chat-context memory",
+      "hint": "Controls whether this orchestrator keeps one shared memory tree or a separate tree per chat context (team, channel, direct message). Off is the default and matches the behaviour before this feature existed.",
+      "loading": "Loading the memory setting…",
+      "stateSummary": "Current: {mode}",
+      "stateUnknown": "Current: unknown",
+      "save": "Save",
+      "saving": "Saving",
+      "unchanged": "No unsaved change.",
+      "semanticsHeading": "Read this before switching it on",
+      "semanticsTeam": "A turn from a team context writes into its own tier and into the shared team tier — that is the tier teammates read each other in.",
+      "semanticsAgent": "The orchestrator's own memory stays readable but becomes read-only for context turns, so “remember this globally” can no longer carry knowledge from one team to another.",
+      "semanticsApi": "Turns from the API carry no chat context, so they only ever reach the private memory of the orchestrator itself — never a team or channel tree.",
+      "acknowledge": "I understand how memory will be split for this orchestrator.",
+      "modes": {
+        "off": {
+          "label": "Off",
+          "description": "One shared memory tree for every turn. The default, and identical to the behaviour before this feature."
+        },
+        "enforce": {
+          "label": "Separate per context",
+          "description": "Each chat context gets its own memory tree. The orchestrator's own memory stays readable, so existing knowledge can still be quoted."
+        },
+        "enforce-strict": {
+          "label": "Separate and sealed",
+          "description": "Each chat context gets its own memory tree and cannot read the orchestrator's own memory at all. Choose this when contexts must not share anything."
+        }
+      }
+    },
     "teamsInstalls": {
       "heading": "Teams assignment",
       "hint": "Which Microsoft Teams team this orchestrator's app is installed in, and whether the tenant has consented to the permissions the install needs.",


### PR DESCRIPTION
Closes nothing — `Refs #899, part of #860`.

W5 (#881) shipped the chat-context memory ACL — the scoping, the `/memories/contexts/` tree, the promote route and its audit log — behind `agents.context_memory`, a plain column with no UI and no API endpoint. The only supported way to enable it was a hand-written `UPDATE`, which left the whole wave inert. This adds the operator surface, and reads the one part of the wave that shipped with a stated residual risk.

**No schema change.** The column and its CHECK constraint already exist (migration `0050`).

## What the route can do

```
GET /api/v1/operator/agents/<slug>/context-memory   → { slug, mode, modes }
PUT /api/v1/operator/agents/<slug>/context-memory     { mode: 'off' | 'enforce' | 'enforce-strict' }  → { ok: true, mode }
```

On the existing operator-agents router (`{ ok: true }` envelope, `requireAuth` from the parent mount). The union is taken from the code, not from the docs: `ContextMemoryMode` in `memoryBinder.ts` and the CHECK constraint in `0050` both spell `off | enforce | enforce-strict`, and a test pins the route's list against the migration file so the two cannot drift.

Four deliberate choices:

- **`PUT` rejects an unknown mode with `400 invalid_body` rather than coercing it to `off`.** A security switch that reports success while writing nothing is worse than an error. An untouched agent is auditable; one silently reset to `off` while the UI shows `enforce` is not.
- **`GET` narrows deny-default.** A value written by a newer middleware during a rolling deploy reads back as `off` — the same rule `parseContextMemoryMode` applies in the orchestrator. The UI must never show "enforcing" for a value the runtime routes as off.
- **A write triggers `registry.reload()`**, so the next turn is already scoped. Without it the switch would only take effect on the next process restart — the shape of bug that reads as "it did nothing" in production. The mode change is logged under `[security-audit]`.
- **The mode is NOT a field on `PATCH /:slug`.** That handler is the dashboard's rename/enable form and sends whatever it holds; folding a memory-scope change into it would let an unrelated edit carry one along. A test pins that a rename leaves an enforcing agent enforcing.

`ConfigStore.updateAgent` grew a `contextMemory` field on its patch type; the UPDATE uses `COALESCE`, so a patch that does not mention the flag can never reset an enforcing agent.

## What the UI can do

A **Chat-context memory** section on the agent detail page, next to the other per-agent settings. Radio group, save button, localized error banner.

Switching **away from `off`** surfaces the three semantics before the operator can commit, and requires an explicit acknowledgement:

1. **Team tier is read-write.** A turn from a team context writes into its own tier and into the shared team tier — the tier teammates read each other in.
2. **Agent tier is read-only.** The orchestrator's own memory stays readable but becomes read-only for context turns, so "remember this globally" can no longer carry knowledge from one team to another.
3. **API turns get the agent-private scope only.** Turns from the API carry no chat context, so they only ever reach the private memory of the orchestrator itself — never a team or channel tree.

Switching **back to `off`**, and tightening `enforce` → `enforce-strict`, need no acknowledgement: the safe direction must never be harder than the unsafe one. Changing the selection re-arms the gate, so an acknowledgement given for one mode cannot unlock a save of another.

The mode list is **intersected** with the server's `modes` array — the server can take a mode away, but it cannot add one, since a mode this bundle has no label for cannot be rendered. Everything from the wire is narrowed through `parseContextMemoryMode` before it reaches state; a component that renders a security state should not inherit its trust from a type annotation. (That last point was not planned — the test asserting it failed first, against a component that trusted the DTO.)

i18n: all strings through the catalogue, EN + DE complete, `npm run i18n:check` green.

## `orchestrator.ts` finding — the `TurnOrigin` threading

The W5 integration named one residual risk: the binding is threaded through ~8 signatures in a ~7300-line file, covered by tests but **never exercised by a real streaming turn**. I read that path. Verdict: **the threading itself is correct — and now proven, not asserted — but it had one latent defect, which is fixed here, and it has two boundaries outside the orchestrator where the flag buys nothing.**

### The threading is sound

The binding is created exactly twice, once per turn entry point, both after `input` is final: `runTurnCore` (`orchestrator.ts:3457`) and `chatStreamInContext` (`:5106`). It travels as a required parameter through `executeDirectLine` (`:3583`), `chatInContext` (`:4124`), `chatInContextInner` (`:4234`), `chatStreamInner` (`:5297`) and `prepareStreamSlot` (`:6203`) down to `dispatchToolInner:6782`:

```ts
const memoryHandler = turnMemory ? turnMemory.handler : this.memoryToolHandler;
```

Every one of the four dispatch call sites passes it — the non-streaming tool loop (`:4664`), the streaming slot (`:6216`), sub-agent delegation via Direct Line (`:3739`), and the deadline/retry wrappers (`:6436`, `:6446`, `:6449`). The system prompt gets the matching treatment on **both** paths (`:4415`, `:5539`), so the model is never told about `/memories/~team/` on a turn where that path is not mapped. The `_rules` decorator sits inside the binder's own stack (`memoryBinder.ts:227`), not on a separate orchestrator-side path. **I found no path on which a turn carrying an origin reaches the agent-private handler.**

Fail-closed is real and layered: `mode: 'off'` discards the origin in one branch before axes are resolved (`memoryBinder.ts:162-165`); an absent origin, `unscoped`, `system`, a channelType outside `{teams, telegram, http, api}`, or unusable patterns all resolve context-free (`turnOrigin.ts:233-248`, `scopedMemoryStore.ts:195-220`); a binder that throws is caught and degrades to the agent-private handler with a `[security-audit]` log (`orchestrator.ts:3277-3287`); and the shared trees are granted as `ro:core`, not `core`, so `/memories/core/notes.md` is not a one-line bypass.

### Finding → fix: the binding could be dropped without a compile error

`dispatchTool` (`:6316`), `dispatchToolDeadlined` (`:6375`) and `dispatchToolInner` (`:6753`) took the binding in an **optional** position (`turnMemory?: TurnMemoryBinding`), while all six other signatures on the path take it in a required one. A call site that simply forgot the argument therefore compiled cleanly and fell back to `this.memoryToolHandler` — the agent-global stack — at runtime. That is precisely the silent scope widening the wave exists to prevent, and the code comment two lines above calls it "a structural impossibility".

Verified rather than assumed: I deleted `turnMemory` from the two tool-loop call sites and **`tsc` passed**. All seven cases of the new integration test then turned red.

Fixed by making the three parameters required (`TurnMemoryBinding | undefined`). Zero runtime change — every existing call site already passed all four arguments, so the build was clean on the first try. The same mutation now fails `npm run typecheck` with exit 2. A future call site that forgets the binding is a compile error, not a leak.

### New: the first integration coverage of the binding

`middleware/test/orchestrator/contextMemoryTurnBinding.test.ts` — 7 cases. Every W5 suite so far stopped at `MemoryBinder`'s *handler*; none constructed an `Orchestrator` or ran a turn, and `contextBound` appeared nowhere in `middleware/test/`. These build a real orchestrator with a scripted provider that calls the `memory` tool, drive **both** `runTurn` and `chatStream` with a Teams `TurnOrigin`, and assert the **physical path** recorded at the undecorated root store:

- a turn with an origin lands under `/memories/contexts/<slug>/…` and **not** in the agent-global tree — buffered and streaming;
- two different team contexts never resolve to the same physical path;
- a turn *without* an origin stays agent-private under both `enforce` and `enforce-strict`;
- `mode: 'off'` ignores a present origin entirely (the byte-identical rollout default that makes this UI safe to ship);
- an unusable `channelType` narrows instead of throwing.

The harness deliberately wires a build-time `memoryToolHandler` over the raw root, so a lost binding would still *succeed* and write to the wrong place — which is what makes the assertions load-bearing. All seven were confirmed red under mutation before being reported green.

The streaming case is the one that mattered: an async generator is resumed in the async context of whoever calls `.next()`, which is exactly how an earlier wave silently lost `turnContext` on every streaming turn. It passes.

### Two boundaries where the flag buys nothing (pre-existing, not fixed here)

Both are older than W5 and outside this PR's scope, but an operator flipping the switch should know, so they are now in the doc's "known limits" list:

1. **`claude-cli` provider.** `buildOrchestrator.ts:523-545` returns a `CliChatAgent`, not the `Orchestrator`, so `bindTurnMemory` never runs and `origin` is never read. Tools reach memory through `ToolDispatchService`, which has no memory branch — the divergence is already flagged at `toolDispatchService.ts:568-571` ("scoped-memory shadowing"). Setting `enforce-strict` on a CLI-provider agent changes nothing.
2. **A sub-agent granted the native `memory` tool.** `adaptNativeToolForSubAgent` (`src/agents/subAgentToolHydration.ts:189-208`) returns `handle: (input) => handler(input)` over the process-wide raw handler. The parent's dispatch carries the binding correctly, but the sub-agent's own loop calls the adapted raw handler — writing into the **undecorated** store, with no agent namespace and no context tier. This is reachable through supported operator configuration (an Agent Builder tool grant) and defeats both the W5 context ACL and the pre-existing per-agent isolation. Worth its own issue; the minimal fix is to deny `memory` in `resolveSubAgentTools` until sub-agents can be handed a turn-bound handler.

One boundary worth stating rather than fixing: the knowledge graph is **not** partitioned by context. `maybePromoteTurn` stamps `originAgent`, not a context key, so a fact auto-promoted from a team-A turn is recallable in team B for the same agent even under `enforce-strict`. That may well be an accepted boundary like the session-transcript decision (A3a), but "full quarantine" is not literally true of KG-derived recall. Relatedly, `enforce` means context turns can no longer author durable `_rules` at all (`ro:core` covers top-level `_*`) — a real behaviour change, correctly implemented, and now worth an operator-facing line.

## Docs

- `docs/teams-multi-agent-identities.md` §8 — the "there is no UI and no API endpoint, set it in the database" note is replaced with where the switch is, what the routes do, and why the mode is not on the rename PATCH; the known-limits list swaps the "no switch" entry for the two boundaries above; the file map gains the route, the component and the new test.
- `docs/CHANGELOG.md` — an Added entry for the switch and a Fixed entry for the threading defect.

## Gates

| Gate | Result |
|---|---|
| `middleware`: `npm run build` | pass |
| `middleware`: `npm run typecheck` | pass (all workspaces) |
| `middleware`: `npm run lint` | pass (0 errors) |
| `middleware`: `npm run typecheck:test` | pass — ratchet at 370, no regressions |
| `middleware`: `npm test` | pass — exit 0, zero `not ok` across 12 348 lines of TAP |
| `web-ui`: `npm run lint` | pass (0 errors) |
| `web-ui`: `npm run typecheck` | pass |
| `web-ui`: `npm run test` | pass — 982/982, 109 files |
| `web-ui`: `npm run i18n:check` | pass — 4073 keys, en + de |

New tests: 10 router cases, 7 orchestrator integration cases, 11 UI cases. No test pollution encountered — the full runs were green on both sides.

`origin/main` moved while this was in flight (#902); merged in, with the expected `docs/CHANGELOG.md` `[Unreleased]` collision resolved by keeping both entries. All gates re-run after the merge.
