### PR TITLE
feat: enable team uninstall for provisioned agent identities

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,36 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — team uninstall for provisioned agent identities (#900, part of #860)
+
+2026-08-27 — Assigning an agent to a Team was one-way: `DELETE
+/api/v1/operator/agents/:slug/teams/:teamId` answered `501
+teams_uninstall_unsupported` and the operator UI shipped the control disabled,
+because `teamsProvisioner@1` published an install but no uninstall. Removing an
+agent bot from a team meant going to the Teams admin center.
+
+`@omadia/integration-microsoft365` **0.4.0** adds `uninstallFromTeam({ teamId,
+teamsAppId })` — Graph deletes an installation by its *installation* id, so the
+connector resolves it first
+(`GET /teams/{id}/installedApps?$expand=teamsApp&$filter=teamsApp/id eq '…'`)
+and then deletes it. "Not installed" is an idempotent success
+(`outcome: 'already-absent'`), 403 maps to the same `ConsentMissingError` and
+the same scope as the install direction — **no new Graph permission** — and 429
+rides the shared `Retry-After` backoff.
+
+The middleware mirrors the connector contract structurally rather than
+importing it, so the route **feature-detects**: with a connector `< 0.4.0` it
+keeps answering `501` (now carrying `min_connector_version`), and
+`GET …/teams` reports `capabilities.uninstall: false` with a reason that names
+the fix, so the UI renders a disabled control instead of a button that fails.
+The panel was already capability-driven, so a new-enough connector lights the
+button up on its own.
+
+Graph first, row second: the identity row is only cleared after the connector
+confirms the removal (state back to `catalog_uploaded`, `team_id` `NULL`), so a
+failure mid-way never leaves a live install that nothing tracks. Re-installing
+later resumes from the catalog entry — one Graph call, not the whole chain.
+
 ### Fixed — billing-posture badge on "Erkannte CLIs" no longer reads as a second status (#887)
 
 2026-08-27 — Each CLI row on Admin → LLM-Zugang → Abo-CLIs showed a detection

--- a/docs/teams-multi-agent-identities.md
+++ b/docs/teams-multi-agent-identities.md
@@ -69,7 +69,7 @@ aus omadia:
 
 | Plugin | Mindestversion | Warum |
 |---|---|---|
-| `@omadia/integration-microsoft365` | **0.3.1** | stellt die Capability `teamsProvisioner@1` bereit; ab 0.3.1 zusätzlich `getCatalogApp` (Katalog-Lookup ohne Upload) |
+| `@omadia/integration-microsoft365` | **0.3.1** (für Team-Deinstallation: **0.4.0**) | stellt die Capability `teamsProvisioner@1` bereit; ab 0.3.1 zusätzlich `getCatalogApp` (Katalog-Lookup ohne Upload), ab 0.4.0 `uninstallFromTeam` (App wieder aus einem Team entfernen, siehe 5.1) |
 | `@omadia/channel-teams` | **0.21.0** | `teams_bots[]` (Multi-Bot ab 0.20.0), `teams_agent_apps[]` + Auto-Invite (0.21.0) |
 | omadia-Middleware | **v0.136.2** | ältere Versionen lehnen das Plugin-Paket von channel-teams 0.21.0 am Ingest-Gate ab (siehe Troubleshooting) |
 
@@ -543,6 +543,8 @@ Der Abschnitt **„Teams-Zuordnung"** auf der Agent-Detailseite zeigt
   Sie ist leer, solange die Kette nicht `installed` erreicht hat — ein `team_id` auf
   einem früheren Zustand ist das *Ziel* eines laufenden Laufs, keine Installation.
 - **In ein Team installieren**: Feld „Team-ID" (Pflicht) plus Button „Installieren".
+- **Deinstallieren**: pro installiertem Team ein Button — aktiv ab
+  M365-Connector **0.4.0** (siehe unten).
 
 Die zugehörigen Endpunkte:
 
@@ -550,7 +552,7 @@ Die zugehörigen Endpunkte:
 |---|---|
 | `GET /api/v1/operator/agents/:slug/teams` | abgeleitetes Read-Model + `consent` + `capabilities` + `teams_bot` |
 | `POST /api/v1/operator/agents/:slug/teams` | Body `{"team_id":"…"}` → `202`, setzt das Ziel und lässt die Kette weiterlaufen |
-| `DELETE /api/v1/operator/agents/:slug/teams/:teamId` | **`501 teams_uninstall_unsupported`** — siehe unten |
+| `DELETE /api/v1/operator/agents/:slug/teams/:teamId` | entfernt die App aus dem Team (ab Connector 0.4.0) — siehe unten |
 
 `GET …/teams` liefert ein `capabilities`-Objekt, aus dem die UI ableitet, was sie
 anbieten darf, statt es aus fehlgeschlagenen Requests zu lernen:
@@ -558,16 +560,49 @@ anbieten darf, statt es aus fehlgeschlagenen Requests zu lernen:
 | Capability | Wert | Begründung |
 |---|---|---|
 | `install` | `true` | Installation durch Fortsetzen der Provisioning-Kette |
-| `uninstall` | `false` | `teamsProvisioner@1` veröffentlicht keine Deinstallation |
+| `uninstall` | **abhängig vom Connector** | `true`, sobald das installierte `teamsProvisioner@1` `uninstallFromTeam` veröffentlicht (M365-Connector ≥ 0.4.0); sonst `false` |
 | `enumerate` | `false` | der Connector veröffentlicht keine Installations-Auflistung — die Liste ist abgeleitet, nicht live |
 | `multi_team` | `false` | `agent_teams_identities` speichert **ein** `team_id` pro Agent |
 
-**Der Deinstallieren-Button existiert, ist aber deaktiviert.** Die UI erklärt das:
-„Das Entfernen der App aus einem Team ist ein manueller Schritt für Teams-Admins — der
-Microsoft-365-Connector veröffentlicht keine Deinstallation, omadia kann es dir also
-nicht abnehmen." Die Route würde `501` antworten. Das ist bewusst so gebaut: einen
-`team_id`-Eintrag zu löschen, würde die Middleware nur eine Installation *vergessen*
-lassen, die in Teams weiterläuft.
+#### Deinstallieren (ab Connector 0.4.0)
+
+**Was passiert.** Der Button steht hinter einem Bestätigungsdialog. Bestätigt man,
+ruft die Middleware `uninstallFromTeam({teamId, teamsAppId})` des Connectors auf. Der
+löst die Graph-**Installations-ID** auf
+(`GET /teams/{id}/installedApps?$expand=teamsApp&$filter=teamsApp/id eq '…'`) und
+löscht sie (`DELETE /teams/{id}/installedApps/{installationId}`). Erst **danach** wird
+die Zeile aufgeräumt: `state` fällt auf `catalog_uploaded` zurück, `team_id` wird
+`NULL`. Entra-App, Azure-Bot und Katalog-Eintrag bleiben bestehen — ein späterer
+`POST …/teams` setzt genau dort wieder auf und kostet einen einzigen Graph-Call.
+
+Die Reihenfolge ist Absicht: Graph zuerst, Zeile danach. Bricht etwas dazwischen ab,
+konvergiert ein Retry (die Entfernung ist idempotent). Andersherum bliebe eine noch
+laufende Installation zurück, die nichts mehr führt.
+
+**War die App gar nicht im Team**, ist das trotzdem ein Erfolg: die Antwort trägt
+`outcome: "already-absent"`, die UI meldet „Die App war nicht in Team … installiert —
+die Zuordnung wurde aufgehoben", und die Zeile wird genauso aufgeräumt.
+
+**Ist der Connector älter als 0.4.0**, antwortet die Route weiterhin
+**`501 teams_uninstall_unsupported`** (mit `min_connector_version: "0.4.0"`) — und die
+UI zeigt den Button erst gar nicht aktiv an, weil `capabilities.uninstall` denselben
+Befund meldet. Der Hinweistext nennt die Lösung: *„Das Entfernen der App aus einem Team
+braucht den Microsoft-365-Connector 0.4.0 oder neuer … aktualisiere das Plugin, oder
+lass die App von einem Teams-Admin manuell entfernen."* Die Middleware spiegelt den
+Connector-Contract strukturell statt ihn zu importieren, deshalb ist das eine
+Laufzeit-Feature-Detection (`typeof provisioner.uninstallFromTeam === 'function'`) und
+kein Versionsvergleich.
+
+Weitere Antworten der Route:
+
+| Status | Code | Wann |
+|---|---|---|
+| `200` | — | entfernt (`outcome: "uninstalled"`) oder war nicht installiert (`"already-absent"`) |
+| `404` | `team_install_not_found` | für dieses Team ist keine Installation verzeichnet (auch: Zeile noch nicht `installed`) |
+| `409` | `teams_provisioning_running` | ein Provisioning-Lauf ist unterwegs und würde direkt wieder installieren |
+| `409` | `teams_app_id_missing` | Zeile gilt als `installed`, trägt aber keine `teams_app_id` |
+| `501` | `teams_uninstall_unsupported` | Connector < 0.4.0 |
+| `503` | `teams_provisioner_unavailable` | M365-Connector gar nicht installiert/aktiv |
 
 **`409 team_install_conflict`.** Ein Retarget wird **vor jedem Schreibvorgang**
 abgelehnt — sowohl bei einer bereits `installed`-Zeile mit anderem Team als auch bei
@@ -932,7 +967,7 @@ Tiefe Details zur Scope-Auflösung, zur Turn-Bindung und zu den Tests stehen in
 | Bot antwortet nicht, obwohl der Slug stimmt | `teams_bots[]` wurde nie befüllt — die Provisionierung synct die Identität nicht in die Plugin-Config | `teams_bot`-Block aus der UI kopieren (oder aus `GET …/teams-identity`) und in `teams_bots` einfügen, Plugin-Config speichern |
 | `409 bot_slug_taken` beim POST | Der Slug gehört bereits einer **anderen** Agent-Identität (`UNIQUE (bot_slug)`) | Anderen `bot_slug` wählen — zwei Agenten dürfen sich niemals eine Bot-Identität und deren Credential-Namensraum teilen |
 | `409 team_install_conflict` beim POST | Retarget auf ein anderes Team, während die Zeile schon `installed` ist oder ein Lauf auf ein anderes Team fliegt | Auf den laufenden Lauf warten. Bei bereits installierter App: die alte Installation manuell in Teams entfernen — omadia führt genau ein Team pro Agent |
-| „Deinstallieren" ist ausgegraut / `501 teams_uninstall_unsupported` | `teamsProvisioner@1` veröffentlicht keine Deinstallation | Die App im Teams-Admin manuell aus dem Team entfernen. omadia täuscht das bewusst nicht vor |
+| „Deinstallieren" ist ausgegraut / `501 teams_uninstall_unsupported` | der installierte M365-Connector ist älter als **0.4.0** und veröffentlicht kein `uninstallFromTeam` | `@omadia/integration-microsoft365` auf ≥ 0.4.0 aktualisieren (Middleware-Neustart nicht nötig — die Capability wird pro Request aufgelöst). Bis dahin: App im Teams-Admin manuell entfernen |
 | Card meldet „nicht im Teams-App-Katalog gefunden" | Weder `teamsAppId` konfiguriert noch über `getCatalogApp` auflösbar (App nicht publiziert, oder Connector 0.3.0 ohne Lookup) | App in den Org-Katalog hochladen oder `teamsAppId` in `teams_agent_apps[]` eintragen; danach „🔄 Prüfen" klicken |
 | Nachrichten landen beim falschen Bot / Conversation-Refs kollidieren | Deployment ohne KG-Migration `0031` (`teams_conversation_refs.bot_app_id`) | `0031` einspielen (passiert beim nächsten Boot automatisch). Bis dahin ist Multi-Bot-Betrieb nicht sauber isoliert |
 | `last_error` endet auf `(gave up after N attempts)`, State ist **nicht** `failed` | 429-Drosselung oder Connector zeitweise weg; Retry-Budget (5 Versuche) erschöpft | Später erneut POSTen. Der erreichte Fortschritt bleibt erhalten und wird nicht wiederholt |
@@ -952,11 +987,12 @@ Tiefe Details zur Scope-Auflösung, zur Turn-Bindung und zu den Tests stehen in
   Identität in den Kernel, nicht in `teams_bots[]` von channel-teams. Der Eintrag muss
   manuell übernommen werden; die UI sagt das ausdrücklich.
 - **Ein Team pro Identität.** `agent_teams_identities` speichert genau ein `team_id`
-  (Migration `0049`), und der Connector veröffentlicht keine Deinstallation. Multi-Team
-  ist deshalb **strukturell noch nicht möglich** — dafür braucht es eine
-  Schema-Änderung (eigene Tabelle für das Installations-Set). Ein Retarget wird
-  konsequent mit `409` abgelehnt, statt ein Read-Model zu erzeugen, das eine
-  Installation behauptet, die nie stattgefunden hat.
+  (Migration `0049`). Multi-Team ist deshalb **strukturell noch nicht möglich** — dafür
+  braucht es eine Schema-Änderung (eigene Tabelle für das Installations-Set). Ein
+  Retarget wird konsequent mit `409` abgelehnt, statt ein Read-Model zu erzeugen, das
+  eine Installation behauptet, die nie stattgefunden hat. Seit Connector 0.4.0 ist der
+  Wechsel aber kein Sackgasse mehr: erst deinstallieren (5.1), dann in das neue Team
+  installieren.
 - **Eine Identität pro Agent, ein Agent pro Bot-Slug.** Beides ist als
   Datenbank-Constraint festgeschrieben (`PRIMARY KEY (agent_id)`, `UNIQUE (bot_slug)`)
   und scheitert laut statt still.
@@ -994,8 +1030,10 @@ Tiefe Details zur Scope-Auflösung, zur Turn-Bindung und zu den Tests stehen in
   — die ACL ist also aktivierbar, aber ohne Producer folgenlos.
 - **Operator-Route für Kontext-Labels.** Der Memory-Browser fällt auf den dekodierten
   Kontext-Key zurück, solange kein Label-Resolver deployed ist.
-- **Deinstallation** setzt eine Erweiterung des `teamsProvisioner@1`-Vertrags voraus —
-  eine eigene Entscheidung, kein Nachziehen.
+- **Deinstallation ist erledigt** (#900): `teamsProvisioner@1` veröffentlicht seit
+  M365-Connector **0.4.0** `uninstallFromTeam`, die Route und der UI-Button sind
+  aktiv. Offen bleibt die **Live-Enumeration** von Installationen — dafür fehlt dem
+  Connector-Vertrag weiterhin eine Auflistungs-Methode.
 
 ---
 

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -46,6 +46,7 @@ import { AgentTeamsIdentityStore } from './platform/agentTeamsIdentityStore.js';
 import { TeamsProvisioningJobRunner } from './services/teamsProvisioningJob.js';
 import {
   buildTeamsBotMessagingEndpoint,
+  getTeamsProvisioner,
   requireTeamsProvisioner,
 } from './platform/teamsProvisionerService.js';
 import {
@@ -3296,6 +3297,10 @@ async function main(): Promise<void> {
           store: identityStore,
           runner: provisioningRunner,
           isProvisionerInstalled: () => serviceRegistry.has('teamsProvisioner'),
+          // Resolved per call, never cached: the connector can be installed,
+          // upgraded or removed while the process runs, and the team-uninstall
+          // capability (#900) has to follow it.
+          getProvisioner: () => getTeamsProvisioner(serviceRegistry),
         };
       },
     }),

--- a/middleware/src/platform/agentTeamsIdentityStore.ts
+++ b/middleware/src/platform/agentTeamsIdentityStore.ts
@@ -89,7 +89,9 @@ export interface EnsureAgentTeamsIdentityInput {
 
 export interface AgentTeamsIdentityUpdate {
   readonly state?: TeamsProvisioningState;
-  readonly teamId?: string;
+  /** `null` clears the recorded install target — what an uninstall leaves
+   *  behind (byte5ai/omadia#900). The column is nullable (migration 0049). */
+  readonly teamId?: string | null;
   readonly appId?: string;
   readonly tenantId?: string;
   readonly teamsAppId?: string;
@@ -275,6 +277,27 @@ export class AgentTeamsIdentityStore {
     const row = res.rows[0];
     if (row === undefined) throw new AgentTeamsIdentityNotFoundError(agentId);
     return mapRow(row);
+  }
+
+  /**
+   * Forget the recorded team install after the connector removed the app
+   * from the team (byte5ai/omadia#900).
+   *
+   * The row drops back to `catalog_uploaded`, NOT to `pending`: the Entra
+   * app, the Azure bot and the tenant catalog entry all still exist and are
+   * still this agent's — only the team install is gone. That is exactly the
+   * state a fresh `POST /:slug/teams` resumes from, so re-installing later
+   * costs one Graph call instead of re-running the whole chain.
+   *
+   * `lastError` is cleared with it: whatever failed before, the operator has
+   * just successfully driven the row to a clean state.
+   */
+  async clearTeamInstall(agentId: string): Promise<AgentTeamsIdentityRecord> {
+    return this.update(agentId, {
+      state: 'catalog_uploaded',
+      teamId: null,
+      lastError: null,
+    });
   }
 
   /** Persist an enqueue failure so the status endpoint can show WHY nothing

--- a/middleware/src/platform/teamsProvisionerService.ts
+++ b/middleware/src/platform/teamsProvisionerService.ts
@@ -20,11 +20,21 @@
  * `TeamsProvisionerAccessor` surface and its typed error taxonomy are
  * mirrored here from the connector repo (`omadia-m365-connector`,
  * `src/teamsProvisioner/{index,types,errors,appRegistration,botService,
- * catalog,install,appPackage,secretStore}.ts`, v0.3.1). Keep in sync when
+ * catalog,install,appPackage,secretStore}.ts`, v0.4.0). Keep in sync when
  * the connector's surface changes. Mirroring the SHIPPED accessor — NOT the
  * deprecated `TeamsProvisioner` sketch (`registerApplication`/
  * `addClientSecret`): the connector's own types.ts deprecates that sketch
  * ("coding against THIS interface compiles but fails at runtime").
+ *
+ * VERSION SKEW IS THE NORMAL CASE. The contract is mirrored, not imported,
+ * so this middleware can be NEWER than the connector installed next to it —
+ * an operator upgrades the two independently. Methods the connector gained
+ * after the oldest supported version are therefore declared OPTIONAL here
+ * and callers must FEATURE-DETECT instead of assuming.
+ * {@link supportsTeamUninstall} is the guard for the first such method,
+ * `uninstallFromTeam` (connector >= 0.4.0, byte5ai/omadia#900): against an
+ * older connector the operator route keeps answering its 501 rather than
+ * crashing on an undefined call.
  *
  * SECRET CUSTODY. The shipped contract never lets a cleartext client secret
  * cross the service boundary: `createAppRegistration` persists the generated
@@ -253,23 +263,45 @@ export interface TeamAppInstallation {
   readonly installationId?: string;
 }
 
+/** Input for the uninstall step — the same key `installToTeam` is idempotent on. */
+export interface UninstallFromTeamInput {
+  readonly teamId: string;
+  /** Catalog id (`CatalogTeamsApp.teamsAppId`) — NOT the installation id. */
+  readonly teamsAppId: string;
+}
+
+/**
+ * Idempotency signal of the uninstall direction (connector >= 0.4.0):
+ * `'uninstalled'` when the call removed the installation, `'already-absent'`
+ * when the app was not installed in the team. BOTH are success — the
+ * connector never throws for "not installed".
+ */
+export type UninstallFromTeamOutcome = 'uninstalled' | 'already-absent';
+
+export interface UninstallFromTeamResult {
+  readonly outcome: UninstallFromTeamOutcome;
+  readonly value: TeamAppInstallation;
+}
+
 /**
  * The service object the connector publishes under the registry key
  * `'teamsProvisioner'` — one method per chain step; the caller (the agent
  * factory's job runner) owns ordering, persistence and retries.
  *
- * SURFACE GAP (verified against connector v0.3.1, W2a of epic #860). Team
- * installs are one-way here: `installToTeam` has NO counterpart. There is
- *   - no uninstall / removal method, and
- *   - no way to LIST the teams an app is installed in
- *     (`getCatalogApp` answers tenant-catalog presence, never a team
- *     install).
- * The operator's team↔agent read model therefore derives what it reports
- * from `agent_teams_identities` and marks uninstall/enumeration as
- * unsupported (`routes/operatorAgents.ts` →
- * `TEAMS_ASSIGNMENT_CAPABILITIES`). Widening this mirrored contract is a
- * connector change, not a middleware one: add the methods there first, then
- * mirror them here.
+ * SURFACE GAP (verified against connector v0.4.0, W2a of epic #860). Team
+ * installs are no longer one-way — `uninstallFromTeam` is the counterpart of
+ * `installToTeam` since connector 0.4.0 (byte5ai/omadia#900) — but there is
+ * still no way to LIST the teams an app is installed in (`getCatalogApp`
+ * answers tenant-catalog presence, never a team install). The operator's
+ * team<->agent read model therefore still DERIVES what it reports from
+ * `agent_teams_identities` and marks enumeration as unsupported
+ * (`routes/operatorAgents.ts` -> `teamsAssignmentCapabilities`). Widening
+ * this mirrored contract is a connector change, not a middleware one: add
+ * the methods there first, then mirror them here.
+ *
+ * `uninstallFromTeam` is OPTIONAL on this interface on purpose — see the
+ * module doc's version-skew note. Never call it without
+ * {@link supportsTeamUninstall}.
  */
 export interface TeamsProvisionerAccessor {
   readonly tenantMode: TenantMode;
@@ -298,6 +330,28 @@ export interface TeamsProvisionerAccessor {
   getCatalogApp(input: GetCatalogAppInput): Promise<GetCatalogAppResult>;
 
   installToTeam(input: InstallToTeamRequest): Promise<Idempotent<TeamAppInstallation>>;
+
+  /**
+   * Connector >= 0.4.0 only — ABSENT on older installs. Guard every call
+   * with {@link supportsTeamUninstall}.
+   */
+  uninstallFromTeam?(input: UninstallFromTeamInput): Promise<UninstallFromTeamResult>;
+}
+
+/**
+ * Does the CURRENTLY INSTALLED connector publish the team-uninstall
+ * operation (connector >= 0.4.0)? The one feature-detection predicate for
+ * `uninstallFromTeam`; routers and jobs must consult it instead of calling
+ * an optional method and hoping.
+ *
+ * Deliberately tolerant of `undefined` so a caller can chain it straight
+ * onto {@link getTeamsProvisioner} without a second null check: no
+ * connector at all is also no uninstall.
+ */
+export function supportsTeamUninstall(
+  provisioner: TeamsProvisionerAccessor | undefined,
+): boolean {
+  return typeof provisioner?.uninstallFromTeam === 'function';
 }
 
 // ---------------------------------------------------------------------------
@@ -486,6 +540,19 @@ function guardAccessor(raw: TeamsProvisionerAccessor): TeamsProvisionerAccessor 
     uploadToCatalog: (input) => raw.uploadToCatalog(input),
     getCatalogApp: (input) => raw.getCatalogApp(input),
     installToTeam: (input) => raw.installToTeam(input),
+    // Forwarded ONLY when the raw provider has it, so the wrapper's own
+    // shape answers `supportsTeamUninstall` truthfully. A `uninstallFromTeam:
+    // (input) => raw.uninstallFromTeam?.(input)` here would make every
+    // connector look capable and turn an old one's 501 into a silent
+    // `undefined` at the call site.
+    ...(typeof raw.uninstallFromTeam === 'function'
+      ? {
+          uninstallFromTeam: (input: UninstallFromTeamInput) =>
+            (raw.uninstallFromTeam as NonNullable<
+              TeamsProvisionerAccessor['uninstallFromTeam']
+            >).call(raw, input),
+        }
+      : {}),
   };
 }
 

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -21,6 +21,10 @@ import {
   classifyTeamsProvisioningError,
   type TeamsProvisioningErrorDetail,
 } from '../services/teamsProvisioningJob.js';
+import {
+  supportsTeamUninstall,
+  type TeamsProvisionerAccessor,
+} from '../platform/teamsProvisionerService.js';
 
 /**
  * Phase B — minimal projection of a plugin's catalog entry surfaced to the
@@ -73,7 +77,7 @@ interface AgentPluginCatalogEntry {
  *   GET    /api/v1/operator/agents/:slug/teams-identity   Teams identity provisioning status
  *   GET    /api/v1/operator/agents/:slug/teams            teams the agent's app is installed in (derived, W2a #860)
  *   POST   /api/v1/operator/agents/:slug/teams            install the agent's app into a team (async)
- *   DELETE /api/v1/operator/agents/:slug/teams/:teamId    501 — the connector publishes no uninstall
+ *   DELETE /api/v1/operator/agents/:slug/teams/:teamId    remove the agent's app from a team (#900; 501 on a connector < 0.4.0)
  *   PUT    /api/v1/operator/agents/:slug/bindings        replace agent channel bindings
  *   PUT    /api/v1/operator/agents/fallback              set platform fallback (body: { slug | null })
  *   POST   /api/v1/operator/agents/:slug/drain           drain + clear session snapshots
@@ -241,6 +245,18 @@ export interface OperatorTeamsIdentityStore {
    *  run in flight'. Best-effort — called from the POST fire-and-forget
    *  catch. */
   recordEnqueueFailure?(agentId: string, message: string): Promise<void>;
+  /**
+   * Forget the recorded team install after a successful uninstall
+   * (byte5ai/omadia#900) — the row drops back to `catalog_uploaded` with a
+   * null `team_id`.
+   *
+   * Optional so a store implementation that predates the uninstall route
+   * still satisfies this interface; the route refuses (501) rather than
+   * removing an install it cannot then record as removed, because a
+   * middleware that forgot the removal would keep reporting a team the app
+   * is no longer in.
+   */
+  clearTeamInstall?(agentId: string): Promise<OperatorTeamsIdentityRecord>;
 }
 
 /** Structural subset of `TeamsProvisioningJobRunner` — enqueue is
@@ -267,6 +283,20 @@ export interface OperatorTeamsIdentityDeps {
   /** Live check whether the M365 connector currently publishes
    *  `teamsProvisioner@1`. POST 503s without it; GET only reports it. */
   readonly isProvisionerInstalled: () => boolean;
+  /**
+   * The live provisioner, for the operations the ROUTE performs itself
+   * (today: the team uninstall of byte5ai/omadia#900). Everything in the
+   * provisioning CHAIN still belongs to the job runner — this is not a
+   * second path into it.
+   *
+   * Optional, and `undefined` is a first-class answer: a wiring that does
+   * not bind it, or a connector that is not installed, both mean "no
+   * uninstall", which the route reports as a capability rather than a crash.
+   * `uninstallFromTeam` itself is optional on the accessor too (connector
+   * >= 0.4.0), so callers go through
+   * {@link supportsTeamUninstall}.
+   */
+  readonly getProvisioner?: () => TeamsProvisionerAccessor | undefined;
   /** Vault ref under which the bot's app password is held — surfaced by the
    *  status endpoint INSTEAD of the secret itself. Defaults to
    *  {@link defaultTeamsBotSecretRef} (the connector's deterministic ref).
@@ -424,7 +454,8 @@ export function projectInstalledTeams(
 export interface TeamsAssignmentCapabilities {
   /** Install into a team by resuming the provisioning chain. */
   readonly install: boolean;
-  /** Remove an install — the connector publishes no uninstall method. */
+  /** Remove an install — requires a connector that publishes
+   *  `uninstallFromTeam` (M365 connector >= 0.4.0). */
   readonly uninstall: boolean;
   /** Enumerate installs live — the connector publishes no listing method. */
   readonly enumerate: boolean;
@@ -434,20 +465,59 @@ export interface TeamsAssignmentCapabilities {
   readonly unsupported_reason: Readonly<Record<string, string>>;
 }
 
-export const TEAMS_ASSIGNMENT_CAPABILITIES: TeamsAssignmentCapabilities = {
-  install: true,
-  uninstall: false,
-  enumerate: false,
-  multi_team: false,
-  unsupported_reason: {
-    uninstall:
-      'teamsProvisioner@1 publishes no uninstall method (createAppRegistration/createBot/buildAppPackage/uploadToCatalog/getCatalogApp/installToTeam only) — removing the app from a team is a manual Teams-admin step until the connector contract gains one.',
-    enumerate:
-      'teamsProvisioner@1 publishes no installation-listing method — the team list is derived from the agent_teams_identities row, not enumerated from Graph.',
-    multi_team:
-      'agent_teams_identities stores ONE team_id per agent (migration 0049) — tracking an install set needs a schema change, which is out of scope for this wave.',
-  },
+/** Minimum connector version whose `teamsProvisioner@1` publishes an
+ *  uninstall. Quoted in the operator-facing reason so the fix is actionable
+ *  ("upgrade the plugin"), not just a refusal. */
+export const TEAMS_UNINSTALL_MIN_CONNECTOR_VERSION = '0.4.0';
+
+/** Reason text for a capability that is off because the INSTALLED connector
+ *  is too old — a version skew an operator can fix, unlike the structural
+ *  gaps below. */
+export const TEAMS_UNINSTALL_UNSUPPORTED_REASON =
+  `the installed teamsProvisioner@1 publishes no uninstallFromTeam method — upgrade @omadia/integration-microsoft365 to >= ${TEAMS_UNINSTALL_MIN_CONNECTOR_VERSION}; until then removing the app from a team is a manual Teams-admin step.`;
+
+const STRUCTURAL_UNSUPPORTED_REASONS: Readonly<Record<string, string>> = {
+  enumerate:
+    'teamsProvisioner@1 publishes no installation-listing method — the team list is derived from the agent_teams_identities row, not enumerated from Graph.',
+  multi_team:
+    'agent_teams_identities stores ONE team_id per agent (migration 0049) — tracking an install set needs a schema change, which is out of scope for this wave.',
 };
+
+/**
+ * The capability block for ONE request.
+ *
+ * `uninstall` is the only entry that varies at runtime: it mirrors whether
+ * the connector installed RIGHT NOW publishes `uninstallFromTeam`
+ * (byte5ai/omadia#900). Everything else is a structural property of this
+ * middleware's schema and the capability contract, so it stays constant.
+ *
+ * A `false` always ships with its reason, and the reason distinguishes the
+ * two kinds: a fixable version skew ("upgrade the connector") versus a
+ * structural gap the operator cannot do anything about.
+ */
+export function teamsAssignmentCapabilities(
+  canUninstall: boolean,
+): TeamsAssignmentCapabilities {
+  return {
+    install: true,
+    uninstall: canUninstall,
+    enumerate: false,
+    multi_team: false,
+    unsupported_reason: canUninstall
+      ? STRUCTURAL_UNSUPPORTED_REASONS
+      : {
+          uninstall: TEAMS_UNINSTALL_UNSUPPORTED_REASON,
+          ...STRUCTURAL_UNSUPPORTED_REASONS,
+        },
+  };
+}
+
+/**
+ * The block for a connector that cannot uninstall — the pre-#900 shape, kept
+ * as the named baseline the tests and the UI contract refer to.
+ */
+export const TEAMS_ASSIGNMENT_CAPABILITIES: TeamsAssignmentCapabilities =
+  teamsAssignmentCapabilities(false);
 
 export type TeamsConsentStatus = 'granted' | 'missing' | 'unknown';
 
@@ -1252,12 +1322,27 @@ export function createOperatorAgentsRouter(
     }
   });
 
-  // ── Team ↔ agent assignment (W2a, #860) ─────────────────────────────
+  // ── Team ↔ agent assignment (W2a, #860; uninstall #900) ─────────────
   // The read model is DERIVED from the identity row (see
   // projectInstalledTeams): the schema stores one team per agent and the
-  // connector publishes neither an installation listing nor an uninstall,
-  // so this surface reports what the middleware provably knows and
-  // advertises the rest as an unsupported capability rather than guessing.
+  // connector publishes no installation listing, so this surface reports
+  // what the middleware provably knows and advertises the rest as an
+  // unsupported capability rather than guessing. Uninstall is no longer in
+  // that set — it is a RUNTIME capability now, true exactly when the
+  // installed connector publishes `uninstallFromTeam` (>= 0.4.0).
+
+  /**
+   * Can this middleware remove an install RIGHT NOW? Both halves have to
+   * hold: the connector must publish `uninstallFromTeam` (>= 0.4.0), and
+   * this store must be able to record the removal. Reporting `true` while
+   * either is missing would light up a button that answers 501.
+   */
+  function canUninstallTeams(deps: OperatorTeamsIdentityDeps): boolean {
+    return (
+      typeof deps.store.clearTeamInstall === 'function' &&
+      supportsTeamUninstall(deps.getProvisioner?.())
+    );
+  }
 
   /** Resolve agent + identity row for the team routes, answering the shared
    *  404s. `undefined` means a response was already sent. */
@@ -1310,7 +1395,7 @@ export function createOperatorAgentsRouter(
         consent: projectTeamsConsent(row),
         last_error: row.lastError,
         last_error_detail: projectTeamsIdentityErrorDetail(row),
-        capabilities: TEAMS_ASSIGNMENT_CAPABILITIES,
+        capabilities: teamsAssignmentCapabilities(canUninstallTeams(deps)),
         // Same choke point as GET /:slug/teams-identity — one byte-identical
         // channel-teams `teams_bots[]` entry across every team route.
         teams_bot: projectTeamsBotConfig(row, deps.clientSecretRef),
@@ -1386,6 +1471,23 @@ export function createOperatorAgentsRouter(
     }
   });
 
+  /**
+   * Remove the agent's Teams app from one team (byte5ai/omadia#900).
+   *
+   * FEATURE-DETECTED, not assumed. The middleware mirrors the connector
+   * contract structurally rather than importing it, so a connector below
+   * 0.4.0 has no `uninstallFromTeam` — that install keeps answering the
+   * historical 501 with a reason naming the version to upgrade to, exactly
+   * as it did before this route learned to remove anything. The capability
+   * block on `GET /:slug/teams` reports the same verdict, so the operator UI
+   * renders a disabled control instead of discovering it from a failure.
+   *
+   * ORDER MATTERS. Graph first, row second: the connector's removal is
+   * idempotent (`already-absent` is success), so a crash between the two
+   * leaves a retry that still converges. Clearing the row first and then
+   * failing the Graph call would strand a live install nothing tracks — the
+   * exact state this route refused to create back when it answered 501.
+   */
   router.delete('/:slug/teams/:teamId', async (req: Request, res: Response) => {
     const live = svc();
     if (!live) return unavailable(res);
@@ -1394,17 +1496,103 @@ export function createOperatorAgentsRouter(
     try {
       const found = await teamsIdentityRow(req, res, live, deps);
       if (!found) return;
-      // NOT implemented, and deliberately not faked: `teamsProvisioner@1`
-      // publishes no uninstall, and clearing `team_id` would only make the
-      // middleware forget an install that is still live in Teams. 501 (with
-      // the reason) lets the operator UI render a disabled control instead of
-      // interpreting a 404 as "no such route" or, worse, calling something
-      // that lies. Widening the connector contract is a separate decision.
-      res.status(501).json({
-        error: 'teams_uninstall_unsupported',
-        message: TEAMS_ASSIGNMENT_CAPABILITIES.unsupported_reason['uninstall'],
-        agent: found.agent.slug,
-        team_id: req.params['teamId'] ?? null,
+      const { agent, row } = found;
+      const teamId = req.params['teamId'] ?? null;
+
+      if (!deps.isProvisionerInstalled()) {
+        res.status(503).json({
+          error: 'teams_provisioner_unavailable',
+          message:
+            'teamsProvisioner@1 is not installed — install and activate the M365 connector plugin before removing an agent from a team.',
+        });
+        return;
+      }
+      const provisioner = deps.getProvisioner?.();
+      const clearTeamInstall = deps.store.clearTeamInstall;
+      if (!supportsTeamUninstall(provisioner) || typeof clearTeamInstall !== 'function') {
+        res.status(501).json({
+          error: 'teams_uninstall_unsupported',
+          message: TEAMS_UNINSTALL_UNSUPPORTED_REASON,
+          min_connector_version: TEAMS_UNINSTALL_MIN_CONNECTOR_VERSION,
+          agent: agent.slug,
+          team_id: teamId,
+        });
+        return;
+      }
+
+      // A run in flight owns this row's team_id and would re-install right
+      // behind us. Refuse rather than race the job runner.
+      if (deps.runner.isRunning(agent.id)) {
+        res.status(409).json({
+          error: 'teams_provisioning_running',
+          message: `agent '${agent.slug}' has a provisioning run in flight — wait for it to finish before removing the app from a team.`,
+          agent: agent.slug,
+          team_id: teamId,
+        });
+        return;
+      }
+
+      // The read model only ever reports `row.teamId` on an `installed` row
+      // (projectInstalledTeams), so anything else addresses an install this
+      // middleware does not have. Saying so beats issuing a Graph delete for
+      // a team the operator never installed into through omadia.
+      if (row.state !== 'installed' || row.teamId === null || row.teamId !== teamId) {
+        res.status(404).json({
+          error: 'team_install_not_found',
+          message: `agent '${agent.slug}' has no recorded install in team '${String(teamId)}' — GET /:slug/teams lists what can be removed.`,
+          agent: agent.slug,
+          team_id: teamId,
+        });
+        return;
+      }
+      if (!row.teamsAppId) {
+        // An 'installed' row without a catalog app id cannot be addressed in
+        // Graph. Inconsistent rather than unsupported — say which.
+        res.status(409).json({
+          error: 'teams_app_id_missing',
+          message: `agent '${agent.slug}' is recorded as installed in team '${row.teamId}' but carries no teams_app_id — the row cannot address the installation in Graph.`,
+          agent: agent.slug,
+          team_id: teamId,
+        });
+        return;
+      }
+
+      // Snapshot before any write. `row` is whatever the store handed back,
+      // and a store that patches its rows IN PLACE would otherwise have this
+      // response report the CLEARED value — a 200 claiming `team_id: null`
+      // for the team it just removed the app from.
+      const installedTeamId = row.teamId;
+      const installedAppId = row.teamsAppId;
+
+      const uninstall = provisioner?.uninstallFromTeam;
+      if (uninstall === undefined) {
+        // Unreachable after supportsTeamUninstall; narrows for the compiler
+        // without a non-null assertion.
+        res.status(501).json({
+          error: 'teams_uninstall_unsupported',
+          message: TEAMS_UNINSTALL_UNSUPPORTED_REASON,
+          min_connector_version: TEAMS_UNINSTALL_MIN_CONNECTOR_VERSION,
+          agent: agent.slug,
+          team_id: teamId,
+        });
+        return;
+      }
+      const result = await uninstall.call(provisioner, {
+        teamId: installedTeamId,
+        teamsAppId: installedAppId,
+      });
+      const updated = await clearTeamInstall.call(deps.store, agent.id);
+
+      res.json({
+        ok: true,
+        agent: agent.slug,
+        team_id: installedTeamId,
+        // 'already-absent' is the connector's idempotent success: the app was
+        // not in the team. The row is cleared either way — that is the point
+        // of an idempotent remove.
+        outcome: result.outcome,
+        already_absent: result.outcome === 'already-absent',
+        state: updated.state,
       });
     } catch (err) {
       badRequest(res, err);

--- a/middleware/test/_helpers/stubTeamsProvisioner.ts
+++ b/middleware/test/_helpers/stubTeamsProvisioner.ts
@@ -102,6 +102,18 @@ export function createStubTeamsProvisioner(
         installationId: 'install-0000',
       },
     }),
+    // Connector >= 0.4.0 (byte5ai/omadia#900). Pass
+    // `{ uninstallFromTeam: undefined }` to model an OLDER connector — the
+    // stub then omits the key entirely, which is what feature detection has
+    // to see (a present-but-undefined property would still be a key).
+    uninstallFromTeam: async (input) => ({
+      outcome: 'uninstalled',
+      value: {
+        teamId: input.teamId,
+        teamsAppId: input.teamsAppId,
+        installationId: 'install-0000',
+      },
+    }),
   };
 
   const merged: TeamsProvisionerAccessor = { ...defaults, ...overrides };
@@ -129,6 +141,11 @@ export function createStubTeamsProvisioner(
     uploadToCatalog: record('uploadToCatalog', merged.uploadToCatalog),
     getCatalogApp: record('getCatalogApp', merged.getCatalogApp),
     installToTeam: record('installToTeam', merged.installToTeam),
+    ...(merged.uninstallFromTeam !== undefined
+      ? {
+          uninstallFromTeam: record('uninstallFromTeam', merged.uninstallFromTeam),
+        }
+      : {}),
   };
 
   return { accessor, calls };

--- a/middleware/test/operatorAgentsRouter.test.ts
+++ b/middleware/test/operatorAgentsRouter.test.ts
@@ -57,8 +57,11 @@ import {
   projectTeamsBotConfig,
   projectTeamsConsent,
   TEAMS_ASSIGNMENT_CAPABILITIES,
+  TEAMS_UNINSTALL_MIN_CONNECTOR_VERSION,
+  teamsAssignmentCapabilities,
   type OperatorTeamsIdentityRecord,
 } from '../src/routes/operatorAgents.js';
+import type { TeamsProvisionerAccessor } from '../src/platform/teamsProvisionerService.js';
 import {
   armNotConfiguredDetail,
   consentMissingDetail,
@@ -345,7 +348,46 @@ class FakeTeamsIdentityStore {
     if (row) row.lastError = `enqueue_failed: ${message}`;
     return Promise.resolve();
   }
+  /** #900 — mirrors AgentTeamsIdentityStore.clearTeamInstall. */
+  clearTeamInstalls: string[] = [];
+  clearTeamInstall(agentId: string): Promise<OperatorTeamsIdentityRecord> {
+    this.clearTeamInstalls.push(agentId);
+    const row = this.rows.get(agentId);
+    if (!row) return Promise.reject(new Error(`no identity row for ${agentId}`));
+    row.state = 'catalog_uploaded';
+    row.teamId = null;
+    row.lastError = null;
+    return Promise.resolve(row);
+  }
 }
+
+/**
+ * #900 — the connector's `uninstallFromTeam`, and the ability to LEAVE IT
+ * OUT. A connector < 0.4.0 publishes an accessor without the method at all,
+ * which is exactly what the route has to feature-detect, so the fake models
+ * absence as a missing property rather than a method that throws.
+ */
+class FakeTeamsProvisioner {
+  calls: Array<{ teamId: string; teamsAppId: string }> = [];
+  outcome: 'uninstalled' | 'already-absent' = 'uninstalled';
+  /** When set, uninstallFromTeam rejects with it (e.g. ConsentMissingError). */
+  error: Error | undefined;
+
+  uninstallFromTeam(input: {
+    readonly teamId: string;
+    readonly teamsAppId: string;
+  }): Promise<{
+    readonly outcome: 'uninstalled' | 'already-absent';
+    readonly value: { readonly teamId: string; readonly teamsAppId: string };
+  }> {
+    this.calls.push({ ...input });
+    if (this.error) return Promise.reject(this.error);
+    return Promise.resolve({ outcome: this.outcome, value: { ...input } });
+  }
+}
+
+/** A connector too old to know about uninstalls: no method, not a stub. */
+class LegacyTeamsProvisioner {}
 
 /** W1a (#860) — stubbed provisioning job runner. `enqueue` returns a promise
  *  that NEVER settles: if the POST handler awaited the run, its test would
@@ -422,6 +464,9 @@ describe('createOperatorAgentsRouter', () => {
   let teamsStore: FakeTeamsIdentityStore;
   let teamsRunner: FakeTeamsRunner;
   let provisionerInstalled: boolean;
+  /** #900 — the accessor the route feature-detects on. `undefined` models a
+   *  connector that is not installed at all. */
+  let provisioner: FakeTeamsProvisioner | LegacyTeamsProvisioner | undefined;
 
   before(async () => {
     store = new FakeConfigStore();
@@ -431,6 +476,7 @@ describe('createOperatorAgentsRouter', () => {
     teamsStore = new FakeTeamsIdentityStore();
     teamsRunner = new FakeTeamsRunner();
     provisionerInstalled = true;
+    provisioner = new FakeTeamsProvisioner();
     const app = express();
     app.use(express.json());
     app.use(
@@ -445,6 +491,8 @@ describe('createOperatorAgentsRouter', () => {
           store: teamsStore,
           runner: teamsRunner,
           isProvisionerInstalled: () => provisionerInstalled,
+          getProvisioner: () =>
+            provisioner as unknown as TeamsProvisionerAccessor | undefined,
         }),
       }),
     );
@@ -465,6 +513,7 @@ describe('createOperatorAgentsRouter', () => {
     teamsStore = new FakeTeamsIdentityStore();
     teamsRunner = new FakeTeamsRunner();
     provisionerInstalled = true;
+    provisioner = new FakeTeamsProvisioner();
   });
 
   // ── W5 memory-ACL rollout switch (#899) ─────────────────────────────
@@ -1829,10 +1878,12 @@ describe('createOperatorAgentsRouter', () => {
     });
     // The UI must not have to discover the platform's limits by failing.
     assert.equal(body.capabilities.install, true);
-    assert.equal(body.capabilities.uninstall, false);
+    // #900 — the seeded provisioner publishes uninstallFromTeam, so the
+    // capability is ON and ships no reason for it.
+    assert.equal(body.capabilities.uninstall, true);
+    assert.equal(body.capabilities.unsupported_reason['uninstall'], undefined);
     assert.equal(body.capabilities.enumerate, false);
     assert.equal(body.capabilities.multi_team, false);
-    assert.match(body.capabilities.unsupported_reason['uninstall'] ?? '', /no uninstall/);
     // Same choke point as GET /:slug/teams-identity — byte-identical entry.
     assert.deepEqual(body.teams_bot, projectTeamsBotConfig(row));
   });
@@ -2013,23 +2064,208 @@ describe('createOperatorAgentsRouter', () => {
     assert.deepEqual(teamsRunner.enqueueCalls, []);
   });
 
-  it('DELETE /:slug/teams/:teamId → 501: the connector publishes no uninstall', async () => {
-    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
-    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
-    const res = await fetch(`${baseUrl}/sales/teams/${encodeURIComponent('19:team-a')}`, {
+  // ── DELETE /:slug/teams/:teamId (#900) ──────────────────────────────
+  // The route removes the app through the connector's uninstallFromTeam
+  // (>= 0.4.0) and only then forgets the install. A connector without the
+  // method keeps the historical 501 — that is the whole feature-detection
+  // contract, and both halves are pinned below.
+
+  const deleteTeam = (slug: string, teamId: string): Promise<globalThis.Response> =>
+    fetch(`${baseUrl}/${slug}/teams/${encodeURIComponent(teamId)}`, {
       method: 'DELETE',
     });
+
+  it('DELETE /:slug/teams/:teamId removes the install and clears the row', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
+    const fake = provisioner as FakeTeamsProvisioner;
+
+    const res = await deleteTeam('sales', '19:team-a');
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      agent: string;
+      team_id: string;
+      outcome: string;
+      already_absent: boolean;
+      state: string;
+    };
+    assert.equal(body.ok, true);
+    assert.equal(body.agent, 'sales');
+    assert.equal(body.team_id, '19:team-a');
+    assert.equal(body.outcome, 'uninstalled');
+    assert.equal(body.already_absent, false);
+
+    // Graph got the CATALOG app id, not the installation id — resolving the
+    // latter is the connector's job.
+    assert.deepEqual(fake.calls, [
+      { teamId: '19:team-a', teamsAppId: 'teams-app-789' },
+    ]);
+    // The row drops back to catalog_uploaded with no team — the app, bot and
+    // catalog entry all still exist, only the install is gone.
+    assert.deepEqual(teamsStore.clearTeamInstalls, [agent.id]);
+    assert.equal(teamsStore.rows.get(agent.id)?.teamId, null);
+    assert.equal(teamsStore.rows.get(agent.id)?.state, 'catalog_uploaded');
+    assert.equal(body.state, 'catalog_uploaded');
+  });
+
+  it('DELETE /:slug/teams/:teamId reports the idempotent already-absent outcome', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
+    const fake = provisioner as FakeTeamsProvisioner;
+    fake.outcome = 'already-absent';
+
+    const res = await deleteTeam('sales', '19:team-a');
+    assert.equal(res.status, 200, 'not installed is success, not a failure');
+    const body = (await res.json()) as { outcome: string; already_absent: boolean };
+    assert.equal(body.outcome, 'already-absent');
+    assert.equal(body.already_absent, true);
+    // The row is cleared either way — that is what makes the remove converge.
+    assert.deepEqual(teamsStore.clearTeamInstalls, [agent.id]);
+    assert.equal(teamsStore.rows.get(agent.id)?.teamId, null);
+  });
+
+  it('DELETE /:slug/teams/:teamId → 501 when the connector is too old (no uninstallFromTeam)', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
+    // A connector < 0.4.0: the accessor simply has no such method.
+    provisioner = new LegacyTeamsProvisioner();
+
+    const res = await deleteTeam('sales', '19:team-a');
     assert.equal(res.status, 501);
     const body = (await res.json()) as {
       error: string;
       message: string;
+      min_connector_version: string;
       team_id: string;
     };
     assert.equal(body.error, 'teams_uninstall_unsupported');
     assert.equal(body.team_id, '19:team-a');
-    assert.match(body.message, /teamsProvisioner@1 publishes no uninstall method/);
+    assert.equal(body.min_connector_version, TEAMS_UNINSTALL_MIN_CONNECTOR_VERSION);
+    // The reason names the fix, not just the refusal.
+    assert.match(body.message, /upgrade @omadia\/integration-microsoft365/);
     // Above all: the row is untouched. "Forgetting" the install would leave
     // the app live in Teams with nothing recording it.
+    assert.equal(teamsStore.rows.get(agent.id)?.teamId, '19:team-a');
+    assert.equal(teamsStore.rows.get(agent.id)?.state, 'installed');
+    assert.deepEqual(teamsStore.clearTeamInstalls, []);
+  });
+
+  it('GET /:slug/teams reports uninstall: false against a connector that is too old', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    seedIdentity(agent.id);
+    provisioner = new LegacyTeamsProvisioner();
+
+    const res = await fetch(`${baseUrl}/sales/teams`);
+    const body = (await res.json()) as {
+      capabilities: typeof TEAMS_ASSIGNMENT_CAPABILITIES;
+    };
+    // Same verdict the DELETE would give — the UI disables the control
+    // instead of discovering the 501 by pressing it.
+    assert.equal(body.capabilities.uninstall, false);
+    assert.match(
+      body.capabilities.unsupported_reason['uninstall'] ?? '',
+      /upgrade @omadia\/integration-microsoft365/,
+    );
+    // The structural gaps are unaffected by the connector version.
+    assert.equal(body.capabilities.enumerate, false);
+    assert.equal(body.capabilities.multi_team, false);
+    assert.deepEqual(body.capabilities, TEAMS_ASSIGNMENT_CAPABILITIES);
+  });
+
+  it('teamsAssignmentCapabilities ships a reason for every false', () => {
+    for (const canUninstall of [true, false]) {
+      const caps = teamsAssignmentCapabilities(canUninstall);
+      for (const key of ['install', 'uninstall', 'enumerate', 'multi_team'] as const) {
+        if (caps[key]) {
+          assert.equal(
+            caps.unsupported_reason[key],
+            undefined,
+            `${key} is true — it must not carry an unsupported reason`,
+          );
+        } else {
+          assert.ok(
+            (caps.unsupported_reason[key] ?? '').length > 0,
+            `${key} is false — it must ship a reason`,
+          );
+        }
+      }
+    }
+  });
+
+  it('DELETE /:slug/teams/:teamId → 404 for a team the middleware has no install for', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
+    const fake = provisioner as FakeTeamsProvisioner;
+
+    const res = await deleteTeam('sales', '19:team-b');
+    assert.equal(res.status, 404);
+    const body = (await res.json()) as { error: string };
+    assert.equal(body.error, 'team_install_not_found');
+    // No Graph call for an install we never recorded.
+    assert.deepEqual(fake.calls, []);
+    assert.equal(teamsStore.rows.get(agent.id)?.teamId, '19:team-a');
+  });
+
+  it('DELETE /:slug/teams/:teamId → 404 while the chain has not reached installed', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    seedIdentity(agent.id, { state: 'catalog_uploaded', teamId: '19:team-a' });
+    const fake = provisioner as FakeTeamsProvisioner;
+
+    const res = await deleteTeam('sales', '19:team-a');
+    assert.equal(res.status, 404);
+    // A recorded team below 'installed' is a TARGET, not an install — the
+    // read model does not list it, so the route must not remove it either.
+    assert.deepEqual(fake.calls, []);
+    assert.deepEqual(teamsStore.clearTeamInstalls, []);
+  });
+
+  it('DELETE /:slug/teams/:teamId → 409 while a provisioning run is in flight', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
+    teamsRunner.running.set(agent.id, '19:team-a');
+    const fake = provisioner as FakeTeamsProvisioner;
+
+    const res = await deleteTeam('sales', '19:team-a');
+    assert.equal(res.status, 409);
+    const body = (await res.json()) as { error: string };
+    assert.equal(body.error, 'teams_provisioning_running');
+    // Racing the runner would let it re-install right behind the removal.
+    assert.deepEqual(fake.calls, []);
+    assert.deepEqual(teamsStore.clearTeamInstalls, []);
+    teamsRunner.running.delete(agent.id);
+  });
+
+  it('DELETE /:slug/teams/:teamId → 503 when the connector is not installed at all', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
+    provisionerInstalled = false;
+    provisioner = undefined;
+    try {
+      const res = await deleteTeam('sales', '19:team-a');
+      assert.equal(res.status, 503);
+      const body = (await res.json()) as { error: string };
+      assert.equal(body.error, 'teams_provisioner_unavailable');
+    } finally {
+      provisionerInstalled = true;
+    }
+    assert.equal(teamsStore.rows.get(agent.id)?.teamId, '19:team-a');
+    assert.deepEqual(teamsStore.clearTeamInstalls, []);
+  });
+
+  it('DELETE /:slug/teams/:teamId keeps the row when the connector call fails', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
+    const fake = provisioner as FakeTeamsProvisioner;
+    const consent = new Error('403 from graph');
+    consent.name = 'ConsentMissingError';
+    fake.error = consent;
+
+    const res = await deleteTeam('sales', '19:team-a');
+    assert.notEqual(res.status, 200);
+    // Graph first, row second: a failed removal must not make the middleware
+    // forget an install that is still live in Teams.
+    assert.deepEqual(teamsStore.clearTeamInstalls, []);
     assert.equal(teamsStore.rows.get(agent.id)?.teamId, '19:team-a');
     assert.equal(teamsStore.rows.get(agent.id)?.state, 'installed');
   });

--- a/middleware/test/teamsProvisionerService.test.ts
+++ b/middleware/test/teamsProvisionerService.test.ts
@@ -24,6 +24,7 @@ import {
   isTeamsProvisionerError,
   requireTeamsProvisioner,
   SingleTenantViolationError,
+  supportsTeamUninstall,
   TEAMS_PROVISIONER_SERVICE_NAME,
   TeamsMessagingEndpointError,
   TeamsProvisionerUnavailableError,
@@ -118,6 +119,46 @@ describe('teamsProvisioner resolution', () => {
 // ---------------------------------------------------------------------------
 // SingleTenant boundary guard
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Feature detection — connector version skew (#900)
+// ---------------------------------------------------------------------------
+
+describe('supportsTeamUninstall — connector version skew', () => {
+  it('is true for a connector that publishes uninstallFromTeam (>= 0.4.0)', async () => {
+    const stub = createStubTeamsProvisioner();
+    const provisioner = requireTeamsProvisioner(registryWith(stub.accessor));
+
+    assert.equal(supportsTeamUninstall(provisioner), true);
+    const result = await provisioner.uninstallFromTeam?.({
+      teamId: '19:team-a',
+      teamsAppId: 'catalog-0000',
+    });
+    assert.equal(result?.outcome, 'uninstalled');
+    assert.deepEqual(
+      stub.calls.map((call) => call.method),
+      ['uninstallFromTeam'],
+    );
+  });
+
+  it('is false for an older connector — and the guarded accessor OMITS the method', () => {
+    // A connector < 0.4.0 has no such property at all.
+    const stub = createStubTeamsProvisioner({ uninstallFromTeam: undefined });
+    const provisioner = requireTeamsProvisioner(registryWith(stub.accessor));
+
+    assert.equal(supportsTeamUninstall(provisioner), false);
+    // The wrapper must not manufacture a method the connector lacks: a
+    // forwarding stub would make every connector look capable and turn the
+    // route's 501 into an `undefined` at the call site.
+    assert.equal('uninstallFromTeam' in provisioner, false);
+    assert.equal(provisioner.uninstallFromTeam, undefined);
+  });
+
+  it('is false when no connector is installed at all', () => {
+    assert.equal(supportsTeamUninstall(getTeamsProvisioner(new ServiceRegistry())), false);
+    assert.equal(supportsTeamUninstall(undefined), false);
+  });
+});
 
 describe('single-tenant guard', () => {
   it('accepts customer/home tenant modes on createAppRegistration', async () => {

--- a/web-ui/app/_lib/agents.ts
+++ b/web-ui/app/_lib/agents.ts
@@ -1042,11 +1042,23 @@ export async function installAgentTeam(
  * capability-driven rather than hard-coded: the day the connector contract
  * gains an uninstall, the control lights up with no UI change.
  */
+export interface UninstallAgentTeamResponse {
+  ok: boolean;
+  agent: string;
+  team_id: string;
+  /** `'uninstalled'` when this call removed the install, `'already-absent'`
+   *  when the app was not in the team. Both are success. */
+  outcome: 'uninstalled' | 'already-absent';
+  already_absent: boolean;
+  /** Provisioning state the row dropped back to (`catalog_uploaded`). */
+  state: string;
+}
+
 export async function uninstallAgentTeam(
   slug: string,
   teamId: string,
-): Promise<void> {
-  await callJson(
+): Promise<UninstallAgentTeamResponse> {
+  return callJson<UninstallAgentTeamResponse>(
     `/v1/operator/agents/${encodeURIComponent(slug)}/teams/${encodeURIComponent(teamId)}`,
     { method: 'DELETE' },
   );
@@ -1056,8 +1068,12 @@ export async function uninstallAgentTeam(
  * Machine codes the team-assignment routes emit as `{ error: '<code>' }`.
  *
  * A union of its own, like the identity routes': these add
- * `team_install_conflict` and `teams_uninstall_unsupported`, which no other
- * catalogue on this page has copy for.
+ * `team_install_conflict` and the uninstall codes, which no other catalogue
+ * on this page has copy for.
+ *
+ * `teams_uninstall_unsupported` is NOT dead now that the uninstall works: it
+ * is what a middleware answers when the installed M365 connector is older
+ * than 0.4.0 and publishes no `uninstallFromTeam`.
  *
  * i18n HARD RULE: none of these are user-facing text — each maps to a
  * `teamsInstalls.errors.*` key and the raw body never reaches the UI.
@@ -1068,9 +1084,12 @@ export const TEAMS_ASSIGNMENT_ERROR_CODES = [
   'multi_orchestrator_unavailable',
   'not_found',
   'team_install_conflict',
+  'team_install_not_found',
+  'teams_app_id_missing',
   'teams_identity_not_found',
   'teams_identity_unavailable',
   'teams_provisioner_unavailable',
+  'teams_provisioning_running',
   'teams_uninstall_unsupported',
 ] as const;
 

--- a/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsInstalls.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsInstalls.test.tsx
@@ -61,7 +61,8 @@ function capabilities(
     enumerate: false,
     multi_team: false,
     unsupported_reason: {
-      uninstall: 'teamsProvisioner@1 publishes no uninstall method',
+      uninstall:
+        'the installed teamsProvisioner@1 publishes no uninstallFromTeam method',
       enumerate: 'teamsProvisioner@1 publishes no installation-listing method',
       multi_team: 'agent_teams_identities stores ONE team_id per agent',
     },
@@ -153,21 +154,23 @@ describe('AgentTeamsInstalls (#866)', () => {
     ).toBeTruthy();
   });
 
-  it('disables uninstall and states why while the connector publishes none', async () => {
+  it('disables uninstall and names the fix when the connector is too old (#900)', async () => {
     await renderPanel();
 
     const button = await screen.findByRole('button', { name: 'Uninstall' });
     expect((button as HTMLButtonElement).disabled).toBe(true);
+    // The copy has to be actionable: this is a version skew the operator can
+    // fix by upgrading the plugin, not a platform limit they must live with.
     expect(
       screen.getByText(
-        'Removing the app from a team is a manual Teams-admin step — the Microsoft 365 connector publishes no uninstall, so omadia cannot do it for you.',
+        'Removing the app from a team needs Microsoft 365 connector 0.4.0 or newer. The connector installed here is older and publishes no uninstall — upgrade the plugin, or have a Teams administrator remove the app manually.',
       ),
     ).toBeTruthy();
     // The server's English engineering sentence may appear only as a
     // secondary technical detail, never as the operator-facing copy.
     expect(
       screen.getByText(
-        'Server reason: teamsProvisioner@1 publishes no uninstall method',
+        'Server reason: the installed teamsProvisioner@1 publishes no uninstallFromTeam method',
       ),
     ).toBeTruthy();
   });
@@ -253,7 +256,14 @@ describe('AgentTeamsInstalls (#866)', () => {
     mockGetAgentTeams.mockResolvedValue(
       view({ capabilities: capabilities({ uninstall: true }) }),
     );
-    mockUninstall.mockResolvedValue(undefined);
+    mockUninstall.mockResolvedValue({
+      ok: true,
+      agent: 'odoo',
+      team_id: 'team-abc',
+      outcome: 'uninstalled',
+      already_absent: false,
+      state: 'catalog_uploaded',
+    });
     const user = await renderPanel();
 
     await user.click(await screen.findByRole('button', { name: 'Uninstall' }));
@@ -263,6 +273,56 @@ describe('AgentTeamsInstalls (#866)', () => {
 
     await waitFor(() => expect(mockUninstall).toHaveBeenCalledWith('odoo', 'team-abc'));
     expect(await screen.findByText('Removed the app from team team-abc.')).toBeTruthy();
+    // The capability is on, so no disabled-reason note is rendered with it.
+    expect(screen.queryByText(/upgrade the plugin/)).toBeNull();
+  });
+
+  it('reports the idempotent already-absent removal as its own outcome (#900)', async () => {
+    mockGetAgentTeams.mockResolvedValue(
+      view({ capabilities: capabilities({ uninstall: true }) }),
+    );
+    mockUninstall.mockResolvedValue({
+      ok: true,
+      agent: 'odoo',
+      team_id: 'team-abc',
+      outcome: 'already-absent',
+      already_absent: true,
+      state: 'catalog_uploaded',
+    });
+    const user = await renderPanel();
+
+    await user.click(await screen.findByRole('button', { name: 'Uninstall' }));
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => expect(mockUninstall).toHaveBeenCalledWith('odoo', 'team-abc'));
+    // Saying "removed" here would claim an action that did not happen: the
+    // app was not in the team, only the record was stale.
+    expect(
+      await screen.findByText(
+        'The app was not installed in team team-abc — the assignment has been cleared.',
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText('Removed the app from team team-abc.')).toBeNull();
+  });
+
+  it('localizes a 501 from a too-old connector instead of showing the raw body', async () => {
+    mockGetAgentTeams.mockResolvedValue(
+      view({ capabilities: capabilities({ uninstall: true }) }),
+    );
+    mockUninstall.mockRejectedValue(
+      new ApiError(501, 'Not Implemented', '{"error":"teams_uninstall_unsupported"}'),
+    );
+    const user = await renderPanel();
+
+    await user.click(await screen.findByRole('button', { name: 'Uninstall' }));
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
+
+    expect(
+      await screen.findByText(
+        'The Microsoft 365 connector installed here is too old to remove an app from a team. Upgrade it to 0.4.0 or newer, or have a Teams administrator remove the app manually.',
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText(/teams_uninstall_unsupported/)).toBeNull();
   });
 
   it('renders 404 teams_identity_not_found as an empty state, not an error', async () => {

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsInstalls.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsInstalls.tsx
@@ -28,15 +28,22 @@ import { ApiError } from '../../../../_lib/api';
  * (`DELETE`).
  *
  * The panel is CAPABILITY-DRIVEN, never hard-coded to today's platform
- * limits. `teamsProvisioner@1` publishes neither an installation listing nor
- * an uninstall, and migration 0049 records ONE `team_id` per agent, so the
- * route ships those limits as `capabilities.*` plus a reason per `false`.
- * Every control here reads that block: a `false` renders a DISABLED control
- * with a localized reason instead of a button that answers 501, and the day
- * the connector contract grows an uninstall the same control lights up with
- * no change on this side. An absent or partial block is parsed fail-closed
- * (`parseTeamsAssignmentCapabilities`), so a middleware that never learned to
- * report capabilities disables everything rather than enabling a lie.
+ * limits. `teamsProvisioner@1` publishes no installation listing, and
+ * migration 0049 records ONE `team_id` per agent, so the route ships those
+ * limits as `capabilities.*` plus a reason per `false`. Every control here
+ * reads that block: a `false` renders a DISABLED control with a localized
+ * reason instead of a button that answers 501. An absent or partial block is
+ * parsed fail-closed (`parseTeamsAssignmentCapabilities`), so a middleware
+ * that never learned to report capabilities disables everything rather than
+ * enabling a lie.
+ *
+ * That design is what made the uninstall of byte5ai/omadia#900 a no-op here:
+ * the control was already wired and already read `capabilities.uninstall`,
+ * so a connector that publishes `uninstallFromTeam` (>= 0.4.0) lights it up
+ * on its own. `capabilities.uninstall` is now a RUNTIME verdict about the
+ * INSTALLED connector rather than a constant, so the disabled state means
+ * "your connector is too old" — an upgrade the operator can perform — and
+ * the copy says so.
  *
  * Deliberately NOT rendered here: the provisioning state vocabulary and the
  * `last_error` remediation copy. Both belong to the Teams identity panel
@@ -442,8 +449,13 @@ export function AgentTeamsInstalls({
           setConfirmUninstall(null);
           if (target === null) return;
           void run(`uninstall:${target.team_id}`, async () => {
-            await uninstallAgentTeam(slug, target.team_id);
-            return t('uninstalled', { teamId: target.team_id });
+            const res = await uninstallAgentTeam(slug, target.team_id);
+            // 'already-absent' is success, but a different truth: the app was
+            // not in the team, so saying "removed" would claim an action that
+            // did not happen. The record is cleared either way.
+            return res.already_absent
+              ? t('uninstallAlreadyAbsent', { teamId: target.team_id })
+              : t('uninstalled', { teamId: target.team_id });
           });
         }}
       />

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1977,11 +1977,12 @@
       "uninstallTitle": "App aus diesem Team entfernen?",
       "uninstallBody": "Die App des Orchestrators wird aus Team {teamId} entfernt und antwortet dort nicht mehr.",
       "uninstallConfirm": "Entfernen",
+      "uninstallAlreadyAbsent": "Die App war nicht in Team {teamId} installiert — die Zuordnung wurde aufgehoben.",
       "uninstalled": "App aus Team {teamId} entfernt.",
       "cancel": "Abbrechen",
       "unsupported": {
         "install": "Die Installation in ein Team ist in dieser Installation nicht verfügbar.",
-        "uninstall": "Das Entfernen der App aus einem Team ist ein manueller Schritt für Teams-Admins — der Microsoft-365-Connector veröffentlicht keine Deinstallation, omadia kann es dir also nicht abnehmen.",
+        "uninstall": "Das Entfernen der App aus einem Team braucht den Microsoft-365-Connector 0.4.0 oder neuer. Der hier installierte Connector ist älter und veröffentlicht keine Deinstallation — aktualisiere das Plugin, oder lass die App von einem Teams-Admin manuell entfernen.",
         "enumerate": "Der Connector kann Installationen nicht auflisten. Diese Ansicht zeigt daher, was der Provisionierungs-Datensatz belegt, nicht den aktuellen Stand in Teams.",
         "multi_team": "Pro Orchestrator wird ein Team geführt. Ein zweites Team würde die erste Installation ungeführt zurücklassen und wird deshalb abgelehnt."
       },
@@ -1996,10 +1997,13 @@
         "multi_orchestrator_unavailable": "Die Multi-Orchestrator-Laufzeit ist nicht verfügbar.",
         "not_found": "Diesen Orchestrator gibt es nicht mehr — lade die Seite neu.",
         "team_install_conflict": "Dieser Orchestrator ist bereits einem anderen Team zugeordnet. Löse diese Zuordnung zuerst — pro Orchestrator wird ein Team geführt.",
+        "team_install_not_found": "Für dieses Team ist keine Installation verzeichnet — lade die Seite neu, um zu sehen, was entfernt werden kann.",
+        "teams_app_id_missing": "Dieser Orchestrator gilt als installiert, trägt aber keine Teams-App-ID — die Installation lässt sich damit nicht ansprechen. Provisionierung erneut ausführen.",
         "teams_identity_not_found": "Dieser Orchestrator hat noch keine Teams-Identität.",
         "teams_identity_unavailable": "Die Teams-Provisionierung ist in dieser Installation nicht verdrahtet.",
         "teams_provisioner_unavailable": "Die Teams-Provisioner-Fähigkeit fehlt — installiere das Microsoft-365-Connector-Plugin.",
-        "teams_uninstall_unsupported": "Das Entfernen der App aus einem Team muss ein Teams-Admin erledigen — der Connector veröffentlicht keine Deinstallation.",
+        "teams_provisioning_running": "Für diesen Orchestrator läuft noch eine Provisionierung. Warte, bis sie fertig ist, und versuche es dann erneut.",
+        "teams_uninstall_unsupported": "Der hier installierte Microsoft-365-Connector ist zu alt, um eine App aus einem Team zu entfernen. Aktualisiere ihn auf 0.4.0 oder neuer, oder lass die App von einem Teams-Admin manuell entfernen.",
         "unknown": "Die Anfrage zur Teams-Zuordnung ist fehlgeschlagen: {detail}"
       },
       "pendingStoppedHint": "Team {teamId} ist das hinterlegte Ziel, es läuft aber kein Provisioning — die Kette ist vor dem Installationsschritt stehen geblieben. Den erfassten Fehler zeigt der Abschnitt „Teams-Identität“ oben."

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1977,11 +1977,12 @@
       "uninstallTitle": "Remove the app from this team?",
       "uninstallBody": "The orchestrator's app is removed from team {teamId} and stops answering there.",
       "uninstallConfirm": "Remove",
+      "uninstallAlreadyAbsent": "The app was not installed in team {teamId} — the assignment has been cleared.",
       "uninstalled": "Removed the app from team {teamId}.",
       "cancel": "Cancel",
       "unsupported": {
         "install": "Installing into a team is not available in this deployment.",
-        "uninstall": "Removing the app from a team is a manual Teams-admin step — the Microsoft 365 connector publishes no uninstall, so omadia cannot do it for you.",
+        "uninstall": "Removing the app from a team needs Microsoft 365 connector 0.4.0 or newer. The connector installed here is older and publishes no uninstall — upgrade the plugin, or have a Teams administrator remove the app manually.",
         "enumerate": "The connector cannot list installs, so this view reports what the provisioning record proves rather than what Teams currently holds.",
         "multi_team": "One orchestrator is tracked in one team. Assigning a second team would leave the first install untracked, so it is refused."
       },
@@ -1996,10 +1997,13 @@
         "multi_orchestrator_unavailable": "The multi-orchestrator runtime is not available.",
         "not_found": "This orchestrator does not exist anymore — reload the page.",
         "team_install_conflict": "This orchestrator is already assigned to another team. Remove that assignment first — one orchestrator is tracked in one team.",
+        "team_install_not_found": "There is no recorded install in this team — reload the page to see what can be removed.",
+        "teams_app_id_missing": "This orchestrator is recorded as installed but carries no Teams app id, so the install cannot be addressed. Run provisioning again.",
         "teams_identity_not_found": "This orchestrator has no Teams identity yet.",
         "teams_identity_unavailable": "Teams provisioning is not wired in this deployment.",
         "teams_provisioner_unavailable": "The Teams provisioner capability is missing — install the Microsoft 365 connector plugin.",
-        "teams_uninstall_unsupported": "Removing the app from a team has to be done by a Teams administrator — the connector publishes no uninstall.",
+        "teams_provisioning_running": "A provisioning run is still in flight for this orchestrator. Wait for it to finish, then try again.",
+        "teams_uninstall_unsupported": "The Microsoft 365 connector installed here is too old to remove an app from a team. Upgrade it to 0.4.0 or newer, or have a Teams administrator remove the app manually.",
         "unknown": "The team assignment request failed: {detail}"
       },
       "pendingStoppedHint": "Team {teamId} is the recorded target, but no provisioning run is active — the chain stopped before the install step. See the Teams identity section above for the recorded error."


### PR DESCRIPTION
## What

Team assignment is no longer one-way. `DELETE
/api/v1/operator/agents/:slug/teams/:teamId` removes the agent's Teams app
from a team, and the operator UI's uninstall button is live.

Depends on `@omadia/integration-microsoft365` **0.4.0**
([connector PR #6](https://github.com/byte5ai/omadia-m365-connector/pull/6),
published to `hub.omadia.ai`), which adds `uninstallFromTeam`.

## Feature detection — what happens with an older connector

The middleware mirrors the connector contract **structurally** rather than
importing it, so version skew between middleware and connector is the normal
case, not an error.

- `uninstallFromTeam` is declared **optional** on the mirrored accessor;
  `supportsTeamUninstall()` is the single predicate.
- `guardAccessor` forwards the method **only when the raw provider has it**.
  A `(input) => raw.uninstallFromTeam?.(input)` passthrough would make every
  connector look capable and turn an old one's 501 into a silent `undefined`
  at the call site.
- Connector `< 0.4.0` → the route still answers **`501
  teams_uninstall_unsupported`**, now carrying `min_connector_version:
  "0.4.0"`, and `GET …/teams` reports `capabilities.uninstall: false` with a
  reason that names the fix. The UI renders a **disabled** control with
  "upgrade the Microsoft 365 connector to 0.4.0 or newer", not a dead button
  and not a request that fails.
- The capability is resolved **per request**, so upgrading the plugin lights
  the button up without a middleware restart.

## Ordering and idempotency

**Graph first, row second.** The identity row is cleared only after the
connector confirms the removal (`state` → `catalog_uploaded`, `team_id` →
`NULL`). A crash in between leaves a retry that converges, because the
connector's removal is idempotent. Clearing first would strand a live install
that nothing tracks — the exact state this route refused to create back when
it answered 501.

Re-installing later resumes from the catalog entry: one Graph call, not the
whole chain.

`outcome: 'already-absent'` (the app was not in the team) is surfaced as its
own result — the record is cleared either way, but saying "removed" would
claim an action that did not happen.

## Route responses

| Status | Code | When |
|---|---|---|
| `200` | — | removed (`outcome: "uninstalled"`) or not installed (`"already-absent"`) |
| `404` | `team_install_not_found` | no recorded install in that team (incl. a row below `installed`) |
| `409` | `teams_provisioning_running` | a provisioning run is in flight and would re-install behind us |
| `409` | `teams_app_id_missing` | row is `installed` but carries no `teams_app_id` |
| `501` | `teams_uninstall_unsupported` | connector `< 0.4.0` |
| `503` | `teams_provisioner_unavailable` | connector not installed/active |

No new Graph permission: `TeamsAppInstallation.ReadWriteForTeam.All` already
covers reading and removing an installation.

## web-ui

Almost nothing to do — the panel was already capability-driven, exactly so
this day would need no change on that side. What did change: the
disabled-state copy went from "the platform cannot do this" to "your
connector is too old, upgrade it", and the idempotent `already-absent`
outcome got its own message. **en + de**, `i18n:check` green.

## Docs

`docs/teams-multi-agent-identities.md` §5 (new "Deinstallieren" subsection,
capability table, response table, §2.1 version table, troubleshooting row,
§10 limits/outlook) + `docs/CHANGELOG.md`.

## Gates

| Gate | Result |
|---|---|
| `middleware: npm run typecheck` | pass |
| `middleware: npm test` | **7767 pass, 0 fail**, 16 skipped |
| `web-ui: npm run lint` | 0 errors (52 pre-existing warnings) |
| `web-ui: npm run typecheck` | pass |
| `web-ui: npm run test` | **984 pass**, 109 files |
| `web-ui: npm run i18n:check` | OK — 4077 keys, en + de |

No test pollution encountered — both suites were green in the full run.

New tests: route (removes + clears row, idempotent `already-absent`, 501 on a
too-old connector, capability verdict matches the route, 404 wrong team, 404
below `installed`, 409 run in flight, 503 no connector, row kept when the
connector call fails, every `false` capability ships a reason), mirror service
(feature detection true/false/no-connector, wrapper omits the method), and
web-ui (already-absent copy, localized 501, disabled-reason copy).

Refs #900, part of #860

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790432050&installation_model_id=428086&pr_number=905&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F905&signature=a9b15f47dfab486f598479f971919d8b23a93378566789838101c814ee47b765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->