### PR TITLE
fix(#906): desktop kernel PATH augmentation now checks ~/.local/bin

### DIFF
--- a/desktop/src/pathEnv.ts
+++ b/desktop/src/pathEnv.ts
@@ -47,6 +47,11 @@ export function resolveAugmentedPath(
     ...(platform === 'linux' ? ['/snap/bin'] : []),
     path.join(homeDir, '.volta', 'bin'),
     path.join(homeDir, '.asdf', 'shims'),
+    // Covers pip --user, pipx, and — decisively — Claude Code's own native
+    // installer (claude.ai/install.sh), which symlinks `claude` here. That
+    // install path is entirely independent of Homebrew/npm/nvm/volta/asdf, so
+    // none of the checks above would ever find it.
+    path.join(homeDir, '.local', 'bin'),
   ];
   const extraDirs = existingDirs(candidateDirs);
   const nvmBinDir = resolveNvmBinDir(homeDir);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,16 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Fixed — desktop kernel PATH augmentation missed ~/.local/bin (#906)
+
+2026-08-27 — #882's PATH augmentation checked Homebrew, Volta, asdf, and nvm,
+but not `~/.local/bin` — where Claude Code's own native installer symlinks the
+`claude` binary, independent of any Node package manager. A subscription-CLI
+chat turn still failed with `spawn claude ENOENT` for anyone installed that
+way, even fully logged in. A shell alias masked the symptom in manual
+terminal testing (`which`/`command -v` resolve aliases; `child_process.spawn`
+never does). `resolveAugmentedPath()` now also checks `~/.local/bin`.
+
 ### Added — team uninstall for provisioned agent identities (#900, part of #860)
 
 2026-08-27 — Assigning an agent to a Team was one-way: `DELETE


### PR DESCRIPTION
Fixes #906.

## Problem
#882's PATH augmentation checked Homebrew, Volta, asdf, and nvm — but not `~/.local/bin`, where **Claude Code's own official native installer** symlinks the `claude` binary (`~/.local/bin/claude` → `~/.local/share/claude/versions/<version>`), completely independent of any Node package manager. A subscription-CLI chat turn still failed with `spawn claude ENOENT` for anyone installed that way, even fully logged in.

Found and confirmed on a real machine while smoke-testing a local desktop build: a shell alias (`alias claude='claude --dangerously-skip-permissions'`) masked the symptom during manual terminal testing — `which`/`command -v` resolve aliases and report "found", but `child_process.spawn('claude', …)` never consults shell aliases, only real `PATH` entries.

## Changes
1. **`desktop/src/pathEnv.ts`** — `resolveAugmentedPath()`'s `candidateDirs` list gains `~/.local/bin`, gated by the same `fs.existsSync`-backed `existingDirs()` pattern as the existing Volta/asdf entries right above it — no special-casing.
2. **`docs/CHANGELOG.md`** — `[Unreleased]` entry.

## Verification (all local, pre-commit)
- `desktop`: fresh `npm ci` + `tsc --noEmit` — clean; `node --test scripts/*.test.mjs` — **22/22 pass**, no regression (this file has no dedicated test suite per the accepted gap from #882's original review)
- Manually confirmed via a `node -e` probe against the compiled output that `~/.local/bin` now appears in the augmented PATH when it exists on disk
- This exact fix was built into a local DMG and **empirically confirmed by the reporter** to resolve the real-world `ENOENT` on the machine where it was first found
- Independent `omadia-reviewer` pass: confirmed merge-order is safe (dedup keeps first occurrence, no shadowing risk since `claude` isn't shipped by any of the other checked tools), confirmed the fs-existence gating is consistent with sibling entries, confirmed the trust model is unchanged (same home-directory-owned, same-user boundary as the existing Homebrew/Volta/asdf/nvm entries — no new attacker surface), confirmed CHANGELOG accuracy — one fix applied (an inaccurate "covers cargo" claim in the code comment; cargo actually defaults to `~/.cargo/bin`, swapped for the correct `pipx` reference)

## Test plan
- [x] Automated tests above, all green
- [x] Manual: confirmed by the original reporter against the real broken installation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790433801&installation_model_id=428086&pr_number=907&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F907&signature=b740821b1382e617af6753e79150475404c90f8f082c93926cc50986700b1d6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->