### PR TITLE
feat: write the teams_bots entry automatically after provisioning

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,38 @@ entry. See `CONTRIBUTING.md` § Releases & changelog.
 
 ## [Unreleased]
 
+### Added — provisioning writes the `teams_bots` entry itself (#910)
+
+2026-08-28 — After a successful Teams identity provisioning run the operator
+UI showed a ready-made `teams_bot` JSON block and asked the operator to paste
+it into the `teams_bots` setup field of `@omadia/channel-teams` by hand. Until
+that paste happened the bot existed in Azure, in the tenant catalog and in the
+team — and still did not answer, because the middleware had neither an adapter
+nor a route for it. That was the only manual step in an otherwise fully
+automatic chain.
+
+The provisioning job runner now writes the entry into the plugin config when
+it reaches `installed` (and re-asserts it on a later re-run, so a changed
+display name or a deleted entry is repaired), then reactivates the plugin so
+the bot is live without a restart. The write is idempotent by `botSlug`: a
+re-run replaces its own entry in place, never appends a second one, and every
+foreign entry — above all `teams_bots[0]`, the legacy scalar-shimmed
+production bot — is read as a raw object and written back byte-identical, with
+hand-added keys intact. A no-op run neither writes nor reloads.
+
+Failure is a warning, not a rollback: the identity is already valid in Azure by
+then, so a failed or impossible write leaves the run `installed` and records
+`config_sync_failed: [reason]` in `last_error`. A `teams_bots` value that
+cannot be read as JSON is never overwritten. A missing channel-teams plugin is
+a clean skip, not an error.
+
+The copy-paste block stays in the operator UI as the fallback and for
+operators who configure explicitly. Its leading line now answers whether it is
+still needed, rendered from the new `teams_bots_sync` field of
+`GET /api/v1/operator/agents/:slug/teams-identity` — derived from the live
+plugin config on every read rather than from a stored "we synced it" flag, so
+a hand edit shows up immediately. Copy in EN + DE.
+
 ### Fixed — desktop kernel PATH augmentation missed ~/.local/bin (#906)
 
 2026-08-27 — #882's PATH augmentation checked Homebrew, Volta, asdf, and nvm,

--- a/docs/teams-multi-agent-identities.md
+++ b/docs/teams-multi-agent-identities.md
@@ -544,6 +544,7 @@ Was der Schreibweg garantiert:
 | **Re-Run aktualisiert** | Ändert sich ein Identitätsfeld (z. B. der Anzeigename), wird der eigene Eintrag aktualisiert. Ein Lauf gegen eine bereits `installed`-Identität macht nichts anderes als genau diesen Abgleich |
 | **No-op bleibt no-op** | Steht der Eintrag schon exakt so da, wird **weder geschrieben noch reaktiviert** — ein laufendes Channel-Plugin wird nicht grundlos durchgestartet |
 | **Kein Secret** | Geschrieben wird `appPasswordSecretRef` (`teams_bot_password:<appId>`), nie ein Passwort |
+| **Parallele Läufe kollidieren nicht** | Alle Schreibvorgänge im Prozess sind serialisiert. Zwei Agenten, die gleichzeitig fertig werden (z. B. der Resume-Scan beim Boot), überschreiben sich nicht gegenseitig |
 | **Container-Form bleibt** | War der Wert ein JSON-String (Setup-Wizard), bleibt er ein String; war er ein echtes Array (Install-Registry), bleibt er ein Array. Ein leeres Feld wird als JSON-String angelegt |
 
 Wann der Sync **aussetzt** — und was dann passiert:
@@ -559,7 +560,10 @@ Wann der Sync **aussetzt** — und was dann passiert:
 einer erfolgreichen Identität**. Die UI rendert sie als „Die Teams-Identität ist
 provisioniert und installiert — nur das automatische Schreiben … hat nicht geklappt",
 plus Grund und dem Hinweis, den Block einzufügen **oder** das Provisioning erneut
-auszuführen. In Azure muss dabei nichts wiederholt werden.
+auszuführen. In Azure muss dabei nichts wiederholt werden — ein erneuter Lauf gegen
+eine `installed`-Identität macht ausschließlich den Config-Abgleich. Gelingt er,
+**räumt er die eigene Warnung wieder weg**; ein unbeteiligter Fehler auf der Zeile
+(z. B. `consent_missing`) bleibt dabei unangetastet.
 
 **Der manuelle Weg bleibt** — als Fallback und für Operatoren, die explizit
 konfigurieren wollen:

--- a/docs/teams-multi-agent-identities.md
+++ b/docs/teams-multi-agent-identities.md
@@ -248,10 +248,13 @@ Regeln, die das Plugin hart durchsetzt:
   `microsoft_app_password`, App-Typ aus `MICROSOFT_APP_TYPE`, dort Default
   `MultiTenant`). Bestehende Single-Bot-Deployments laufen dadurch unverändert weiter.
 
-> **Wichtig:** Die Übernahme einer frisch provisionierten Identität in `teams_bots[]`
-> ist **nicht automatisch**. Der Kernel schreibt die Identität in seine eigene Tabelle,
-> nicht in die Plugin-Config. UI und Statusendpunkt liefern unter `teams_bot` einen
-> fertig geformten Eintrag, den man 1:1 in dieses Feld einfügt. Siehe Abschnitt 4.4.
+> **Seit #910 ist dieses Feld im Normalfall nichts, was man von Hand pflegt.** Nach
+> einer erfolgreichen Provisionierung schreibt der Kernel den Eintrag selbst hier
+> hinein und lädt das Plugin neu — der Bot ist ohne Neustart und ohne Copy-Paste live.
+> Von Hand befüllt man das Feld nur noch für den Legacy-/Bestandsbot, für Bots, die
+> nicht über die Agent-Factory entstanden sind, oder wenn der automatische Schreibweg
+> nicht greifen konnte. Was der Sync dabei garantiert und wann er aussetzt: Abschnitt
+> 4.5.
 
 ### Schritt 4 (optional) — `teams_agent_apps` für Auto-Invite
 
@@ -335,23 +338,30 @@ Zwei Zustände sind bewusst **keine** Fehler, sondern graue Hinweise:
 Bei terminalem Zustand erscheint **„Provisioning erneut ausführen"**. Der Button
 re-POSTet die **hinterlegte** `team_id`; ist keine hinterlegt, ist er deaktiviert.
 
-**Der `teams_bots`-Block — mit ehrlichem Hinweis.** Sobald App- und Tenant-ID
+**Der `teams_bots`-Block — und ob er noch gebraucht wird.** Sobald App- und Tenant-ID
 existieren, zeigt der Unterabschnitt „Konfiguration für das Teams-Channel-Plugin" den
 fertigen JSON-Block (Schlüssel in der Reihenfolge `botSlug`, `displayName`, `appId`,
-`appType`, `tenantId`, `appPasswordSecretRef`) mit **Kopieren**-Button. Dabei stehen
-drei Sätze, die man ernst nehmen sollte:
+`appType`, `tenantId`, `appPasswordSecretRef`) mit **Kopieren**-Button.
 
-> „Ein manueller Schritt bleibt: Dieser Block muss von Hand in das
-> Teams-Channel-Plugin eingetragen werden."
->
-> „Diese Konfiguration automatisch zu schreiben ist als Folgeschritt geplant und
-> passiert heute nicht."
->
+Die **erste Zeile über dem Block** ist seit #910 die eigentliche Information: Sie sagt,
+ob noch etwas zu tun ist. Sie wird nicht geraten, sondern aus dem Feld `teams_bots_sync`
+des Statusendpunkts gerendert, und das wiederum liest bei jedem Aufruf die **echte**
+Plugin-Config:
+
+| Zustand | Was oben steht | Was zu tun ist |
+|---|---|---|
+| `synced` | „Bereits übernommen — das Provisioning hat diese Konfiguration in `@omadia/channel-teams` geschrieben und das Plugin neu geladen." | Nichts. Der Block bleibt sichtbar, um ihn gegen das Konfigurierte zu vergleichen oder anderswo wiederzuverwenden |
+| `missing` | „Ein manueller Schritt fehlt noch …" | Provisioning erneut ausführen — oder den Block einfügen |
+| `out_of_sync` | „Im Teams-Channel-Plugin steht eine abweichende Konfiguration für diesen Bot." | Von Hand bearbeitet oder ein Schreibvorgang lief nicht zu Ende: ersetzen oder erneut provisionieren |
+| `plugin_not_installed` | „Das Teams-Channel-Plugin ist nicht installiert …" | Plugin installieren und aktivieren; der nächste Lauf schreibt den Eintrag |
+| `unreadable` | „Im Feld `teams_bots` steht ein Wert, der sich nicht als JSON lesen lässt." | **Es wurde nichts überschrieben.** Feld von Hand reparieren |
+| `not_applicable` | „Die Bot-Konfiguration ist noch nicht vollständig …" | Warten, bis die Entra-Registrierung existiert |
+| `unknown` | „…lässt sich gerade nicht feststellen." | Ältere Middleware ohne dieses Feld, oder keine Plugin-Registry gebunden: manuell vergleichen |
+
+Unverändert gilt in jedem Zustand:
+
 > „Der Block enthält nur eine Referenz auf das Bot-Passwort, niemals das Passwort
 > selbst — das Geheimnis bleibt im Vault des M365-Connectors."
-
-Vor der Entra-Registrierung steht dort: „Es gibt noch keine Bot-Konfiguration — sie
-erscheint, sobald die Entra-App-Registrierung existiert."
 
 ### 4.2 Der REST-Weg
 
@@ -450,9 +460,18 @@ GET /api/v1/operator/agents/<agent-slug>/teams-identity
   das channel-teams parst) — direkt kopierbar. Sie ist `null`, solange noch keine
   Entra-App existiert (`app_id`/`tenant_id` fehlen).
 - `last_error_detail` ist derselbe Fehler, nur strukturiert:
-  `{code, raw, scopes?, fields?, retryAfterSeconds?}` mit
-  `code ∈ {consent_missing, arm_not_configured, throttled, unknown}`. Clients rendern
-  aus `code` plus typisierten Argumenten — nie durch Parsen des englischen Satzes.
+  `{code, raw, scopes?, fields?, retryAfterSeconds?, reason?}` mit
+  `code ∈ {consent_missing, arm_not_configured, throttled, config_sync_failed, unknown}`.
+  Clients rendern aus `code` plus typisierten Argumenten — nie durch Parsen des
+  englischen Satzes. `config_sync_failed` ist die einzige **Warnung** in dieser Liste:
+  die Identität ist gültig, nur der automatische `teams_bots`-Schreibvorgang nicht
+  gelaufen; `reason` trägt den technischen Grund.
+- `teams_bots_sync` (additiv, #910) sagt, ob `teams_bot` **gerade jetzt** in der
+  Plugin-Config steht: `{state, plugin_id, config_key}` mit
+  `state ∈ {synced, out_of_sync, missing, plugin_not_installed, unreadable,
+  not_applicable, unknown}`. Der Wert wird bei jedem Aufruf aus der Live-Config
+  abgeleitet, nicht aus einem gespeicherten „wurde gesynct"-Flag — ein Operator kann
+  den Eintrag jederzeit ändern oder löschen.
 - `appPasswordSecretRef` ist eine **Referenz**, kein Secret: `teams_bot_password:<appId>`.
   Das Client-Secret verlässt nie den Vault des Connectors und steht weder in der Tabelle
   noch in einer HTTP-Antwort — die Tabelle `agent_teams_identities` hat bewusst *keine*
@@ -509,9 +528,41 @@ ausrichten, bevor ein Admin zustimmt). `arm_not_configured` ist *nicht* terminal
 ist ein Teilerfolg. Drosselung und „Connector gerade nicht da" werden im Budget
 wiederholt und stürzen nie ab; der erreichte Zustand bleibt stehen.
 
-### 4.5 Die Identität ins Plugin übernehmen
+### 4.5 Die Identität ins Plugin übernehmen (automatisch, seit #910)
 
-Dieser Schritt ist **manuell** und wird heute von nichts automatisiert:
+**Der Normalfall braucht keinen Handgriff.** Erreicht der Provisioning-Lauf den Zustand
+`installed`, schreibt der Kernel den `teams_bot`-Eintrag selbst in das Setup-Feld
+`teams_bots` von `@omadia/channel-teams` und reaktiviert das Plugin. Damit hat die
+Middleware Adapter und Route für den neuen Bot, ohne Neustart und ohne Copy-Paste.
+
+Was der Schreibweg garantiert:
+
+| Garantie | Verhalten |
+|---|---|
+| **Idempotent nach `botSlug`** | Ein erneuter Lauf **ersetzt den eigenen Eintrag an Ort und Stelle**. Nie ein zweiter Eintrag, nie eine Positionsverschiebung — `teams_bots[0]` bleibt derselbe Bot wie vorher |
+| **Fremde Einträge unangetastet** | Alle anderen Einträge werden als Rohobjekte gelesen und **byte-identisch** zurückgeschrieben: keine Umsortierung, keine nachgetragenen Defaults, auch von Hand ergänzte Zusatzschlüssel bleiben. Insbesondere gilt das für den Legacy-/Bestandsbot auf Position 0 |
+| **Re-Run aktualisiert** | Ändert sich ein Identitätsfeld (z. B. der Anzeigename), wird der eigene Eintrag aktualisiert. Ein Lauf gegen eine bereits `installed`-Identität macht nichts anderes als genau diesen Abgleich |
+| **No-op bleibt no-op** | Steht der Eintrag schon exakt so da, wird **weder geschrieben noch reaktiviert** — ein laufendes Channel-Plugin wird nicht grundlos durchgestartet |
+| **Kein Secret** | Geschrieben wird `appPasswordSecretRef` (`teams_bot_password:<appId>`), nie ein Passwort |
+| **Container-Form bleibt** | War der Wert ein JSON-String (Setup-Wizard), bleibt er ein String; war er ein echtes Array (Install-Registry), bleibt er ein Array. Ein leeres Feld wird als JSON-String angelegt |
+
+Wann der Sync **aussetzt** — und was dann passiert:
+
+| Situation | Verhalten |
+|---|---|
+| `@omadia/channel-teams` nicht installiert | Sauberer Skip. Kein Fehler, kein `last_error`. Die UI zeigt „Plugin nicht installiert" und den Block zum Einfügen |
+| Keine Plugin-Registry gebunden | Skip wie oben (Testmounts, Boot vor der Registry) |
+| `teams_bots` enthält unlesbares JSON | **Es wird nichts überschrieben.** Der Lauf bleibt `installed`, `last_error` bekommt `config_sync_failed: [<Grund>]` |
+| Schreiben oder Reaktivierung schlägt fehl | Ebenso: `installed` bleibt stehen, nichts wird zurückgerollt (die Identität ist in Azure bereits gültig), und `last_error` trägt die handlungsfähige Warnung |
+
+`config_sync_failed` ist bewusst kein Provisioning-Fehler, sondern eine **Warnung auf
+einer erfolgreichen Identität**. Die UI rendert sie als „Die Teams-Identität ist
+provisioniert und installiert — nur das automatische Schreiben … hat nicht geklappt",
+plus Grund und dem Hinweis, den Block einzufügen **oder** das Provisioning erneut
+auszuführen. In Azure muss dabei nichts wiederholt werden.
+
+**Der manuelle Weg bleibt** — als Fallback und für Operatoren, die explizit
+konfigurieren wollen:
 
 1. `teams_bot`-Block aus der UI kopieren (Button „Kopieren") oder aus
    `GET …/teams-identity` entnehmen.
@@ -964,7 +1015,8 @@ Tiefe Details zur Scope-Auflösung, zur Turn-Bindung und zu den Tests stehen in
 | `403` bleibt trotz erteiltem Consent bestehen | Tokens sind gecacht; neu zugestimmte Rollen erscheinen erst in einem frischen Token | Middleware neu starten (oder Token-Ablauf abwarten) |
 | Lauf bleibt bei `app_registered`, `last_error` beginnt mit `arm_not_configured:` | ARM-Setup-Felder am Connector fehlen → Registration-only-Modus | `azure_subscription_id` / `azure_resource_group` / `azure_region` (+ ggf. SP-Credentials) setzen und erneut POSTen — **oder** den Azure-Bot manuell anlegen. Die App-Registrierung bleibt in jedem Fall erhalten |
 | Bot antwortet nicht; Log zeigt einen unbekannten Bot bzw. HTTP 404 auf `/api/teams/<slug>/messages` | Der Messaging-Endpoint im Azure-Bot zeigt auf einen `botSlug`, den `teams_bots[]` nicht kennt (Tippfehler, Slug umbenannt, Eintrag nie eingepflegt) | Slug in Azure-Bot-Konfiguration und `teams_bots[]` angleichen. Es gibt bewusst **keinen** Fallback auf fremde Credentials |
-| Bot antwortet nicht, obwohl der Slug stimmt | `teams_bots[]` wurde nie befüllt — die Provisionierung synct die Identität nicht in die Plugin-Config | `teams_bot`-Block aus der UI kopieren (oder aus `GET …/teams-identity`) und in `teams_bots` einfügen, Plugin-Config speichern |
+| Bot antwortet nicht, obwohl der Slug stimmt | `teams_bots[]` enthält den Eintrag nicht — der automatische Sync (#910) konnte nicht greifen | `teams_bots_sync.state` im Statusendpunkt lesen bzw. die erste Zeile über dem Block in der UI: `plugin_not_installed` → Plugin installieren; `unreadable` → Feld von Hand reparieren; `missing`/`out_of_sync` → Provisioning erneut ausführen oder den Block einfügen |
+| `last_error` beginnt mit `config_sync_failed:` | Identität ist gültig und installiert, nur der automatische `teams_bots`-Schreibvorgang lief nicht durch | Grund aus der Klammer lesen. Danach Provisioning erneut ausführen (wiederholt nur den Schreibvorgang) oder den Block manuell einfügen. In Azure ist nichts zu wiederholen |
 | `409 bot_slug_taken` beim POST | Der Slug gehört bereits einer **anderen** Agent-Identität (`UNIQUE (bot_slug)`) | Anderen `bot_slug` wählen — zwei Agenten dürfen sich niemals eine Bot-Identität und deren Credential-Namensraum teilen |
 | `409 team_install_conflict` beim POST | Retarget auf ein anderes Team, während die Zeile schon `installed` ist oder ein Lauf auf ein anderes Team fliegt | Auf den laufenden Lauf warten. Bei bereits installierter App: die alte Installation manuell in Teams entfernen — omadia führt genau ein Team pro Agent |
 | „Deinstallieren" ist ausgegraut / `501 teams_uninstall_unsupported` | der installierte M365-Connector ist älter als **0.4.0** und veröffentlicht kein `uninstallFromTeam` | `@omadia/integration-microsoft365` auf ≥ 0.4.0 aktualisieren (Middleware-Neustart nicht nötig — die Capability wird pro Request aufgelöst). Bis dahin: App im Teams-Admin manuell entfernen |
@@ -983,9 +1035,10 @@ Tiefe Details zur Scope-Auflösung, zur Turn-Bindung und zu den Tests stehen in
 
 - **Kein Namenswechsel pro Nachricht.** Identität = App-Paket. Wer N sichtbare Agenten
   will, braucht N Teams-Apps und N Bots.
-- **Kein automatischer Sync in die Plugin-Config.** Die Provisionierung schreibt die
-  Identität in den Kernel, nicht in `teams_bots[]` von channel-teams. Der Eintrag muss
-  manuell übernommen werden; die UI sagt das ausdrücklich.
+- ~~**Kein automatischer Sync in die Plugin-Config.**~~ **Erledigt (#910):** Die
+  Provisionierung schreibt den Eintrag nach `installed` selbst in `teams_bots[]` und
+  lädt das Plugin neu. Manuell bleibt es nur, wenn channel-teams nicht installiert ist
+  oder der Schreibvorgang scheitert — die UI sagt beides ausdrücklich. Siehe 4.5.
 - **Ein Team pro Identität.** `agent_teams_identities` speichert genau ein `team_id`
   (Migration `0049`). Multi-Team ist deshalb **strukturell noch nicht möglich** — dafür
   braucht es eine Schema-Änderung (eigene Tabelle für das Installations-Set). Ein
@@ -1033,8 +1086,6 @@ Tiefe Details zur Scope-Auflösung, zur Turn-Bindung und zu den Tests stehen in
 
 ### Was in Arbeit ist
 
-- **Automatische Übernahme der Identität in `teams_bots[]`** — von der UI als
-  Folgeschritt angekündigt („passiert heute nicht").
 - **`TurnOrigin`-Producer in den Channel-Plugins.** Die Middleware-Seite der
   Memory-ACL ist gemergt; `omadia-channel-teams` und `omadia-channel-telegram` bauen
   ihren `TurnOrigin` in ihren **eigenen** Repos und können erst nach dem Release des
@@ -1058,6 +1109,7 @@ Tiefe Details zur Scope-Auflösung, zur Turn-Bindung und zu den Tests stehen in
 | Job-Runner + Fehlerpolitik | `middleware/src/services/teamsProvisioningJob.ts` |
 | Capability-Choke-Point + Endpoint-Builder | `middleware/src/platform/teamsProvisionerService.ts` |
 | App-Paket-Assets | `middleware/src/services/teamsAppPackageAssets.ts` |
+| `teams_bots`-Projektion + automatischer Sync (#910) | `middleware/src/services/teamsBotsConfigSync.ts` |
 | Tabelle Teams-Identitäten | `middleware/migrations/0049_agent_teams_identities.sql` |
 | Rollout-Flag Memory-ACL | `middleware/migrations/0050_agent_context_memory_flag.sql` |
 | Schalter (API) | `middleware/src/routes/operatorAgents.ts` → `GET`/`PUT /:slug/context-memory` |

--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -44,6 +44,7 @@ import {
 } from './routes/operatorAgents.js';
 import { AgentTeamsIdentityStore } from './platform/agentTeamsIdentityStore.js';
 import { TeamsProvisioningJobRunner } from './services/teamsProvisioningJob.js';
+import { syncTeamsBotConfig } from './services/teamsBotsConfigSync.js';
 import {
   buildTeamsBotMessagingEndpoint,
   getTeamsProvisioner,
@@ -1903,6 +1904,23 @@ async function main(): Promise<void> {
         },
         getPublicBaseUrl: teamsPublicBaseUrl,
       }),
+      // #910 — the finishing move: after `installed`, write the identity's
+      // `teams_bots` entry into the channel-teams plugin config and reactivate
+      // the plugin, so the provisioned bot has an adapter and a route without
+      // an operator pasting JSON between two screens. `reactivateAgent` is the
+      // same funnel every other live config change goes through (it also
+      // re-sources host credentials); the write itself is idempotent by
+      // botSlug and never touches an entry it does not own. A failure here is
+      // a WARNING on an identity that is already valid in Azure — the runner
+      // records it and keeps the run `installed`.
+      syncBotConfig: (identity) =>
+        syncTeamsBotConfig(
+          {
+            getInstalledRegistry: () => installedRegistry,
+            reactivate: reactivateAgent,
+          },
+          identity,
+        ),
     });
     serviceRegistry.provide('teamsProvisioningJobRunner', teamsProvisioningRunner);
     backgroundJobRegistry.register(teamsProvisioningRunner.asBackgroundJob());

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -25,6 +25,10 @@ import {
   supportsTeamUninstall,
   type TeamsProvisionerAccessor,
 } from '../platform/teamsProvisionerService.js';
+import {
+  projectTeamsBotConfig,
+  projectTeamsBotsConfigSyncStatus,
+} from '../services/teamsBotsConfigSync.js';
 
 /**
  * Phase B — minimal projection of a plugin's catalog entry surfaced to the
@@ -305,77 +309,19 @@ export interface OperatorTeamsIdentityDeps {
 }
 
 /**
- * Custody convention for the provisioned bot's app password: the
- * `agent_teams_identities` table stores NO secret material — the M365
- * connector's `createAppRegistration` keeps the generated client secret in
- * the CONNECTOR's vault and hands back only the opaque, deterministic ref
- * `teams_bot_password:<appId>` (teamsProvisioner contract v0.3.1). The
- * status endpoint re-derives that ref from `app_id` so channel-teams'
- * `teams_bots[]` sync (follow-up, out of scope for W1a) can reference it
- * without the secret ever appearing in an HTTP response or a middleware
- * table. Keyed by appId (globally unique per registration), NOT by bot
- * slug, so no two identities can ever alias one credential.
+ * The `teams_bots[]` projection and its secret-ref convention MOVED to
+ * `services/teamsBotsConfigSync.ts` (#910): the same entry is now WRITTEN
+ * into the channel-teams plugin config after provisioning, and a projection
+ * that lives in a route module could not be the producer for both. Re-exported
+ * here because this router is still the surface that publishes it, and because
+ * two producers of a config contract is exactly the drift the choke point
+ * exists to prevent.
  */
-export function defaultTeamsBotSecretRef(record: {
-  readonly appId: string | null;
-}): string {
-  if (!record.appId) {
-    throw new Error(
-      'defaultTeamsBotSecretRef requires a provisioned appId — the secret ref is derived from it',
-    );
-  }
-  return `teams_bot_password:${record.appId}`;
-}
-
-/**
- * One `teams_bots[]` entry of channel-teams' plugin config — shaped EXACTLY
- * like a `parseTeamsBotsConfig` entry (camelCase keys), so an operator can
- * paste it into the plugin's `teams_bots` setup field verbatim.
- */
-export interface TeamsBotConfigProjection {
-  readonly botSlug: string;
-  readonly displayName: string;
-  readonly appId: string;
-  /** Literal — the epic provisions SingleTenant apps only (new MultiTenant
-   *  registrations are deprecated since 07/2025). */
-  readonly appType: 'SingleTenant';
-  readonly tenantId: string;
-  /** Opaque connector-vault ref (teamsProvisioner contract v0.3.1), NEVER
-   *  the password itself. */
-  readonly appPasswordSecretRef: string;
-}
-
-/**
- * THE single `teams_bot` projection of this router (W2a, epic #860).
- *
- * Every team↔agent route that surfaces a provisioned identity must project
- * through here rather than re-assembling the block: the entry is a config
- * contract with channel-teams, and a second, drifting copy of it would hand
- * operators a config that silently does not parse.
- *
- * `null` until BOTH the Entra app and its tenant are known — an incomplete
- * entry is worse than none, because channel-teams would reject the whole
- * `teams_bots[]` array over it.
- *
- * NOTE (documented follow-up, deliberately out of scope): pasting the block
- * into channel-teams is a MANUAL operator step. Nothing here syncs it into
- * the plugin's config automatically.
- */
-export function projectTeamsBotConfig(
-  record: OperatorTeamsIdentityRecord,
-  clientSecretRef?: (record: OperatorTeamsIdentityRecord) => string,
-): TeamsBotConfigProjection | null {
-  if (!record.appId || !record.tenantId) return null;
-  return {
-    botSlug: record.botSlug,
-    displayName: record.displayName,
-    appId: record.appId,
-    appType: 'SingleTenant',
-    tenantId: record.tenantId,
-    appPasswordSecretRef:
-      clientSecretRef?.(record) ?? defaultTeamsBotSecretRef(record),
-  };
-}
+export {
+  defaultTeamsBotSecretRef,
+  projectTeamsBotConfig,
+  type TeamsBotConfigProjection,
+} from '../services/teamsBotsConfigSync.js';
 
 /** Structured form of the identity's `last_error`, decoded by the runner's
  *  own classifier so the UI renders from a code + typed arguments instead of
@@ -1284,9 +1230,26 @@ export function createOperatorAgentsRouter(
         return;
       }
       // `teams_bot` is the channel-teams `teams_bots[]` projection. It goes
-      // through the router's ONE choke point so every team↔agent route
-      // emits a byte-identical entry — see projectTeamsBotConfig.
+      // through the platform's ONE choke point so the entry the operator can
+      // paste and the entry provisioning WRITES are the same bytes — see
+      // `services/teamsBotsConfigSync.ts`.
       const teamsBot = projectTeamsBotConfig(row, deps.clientSecretRef);
+      // #910 — does channel-teams actually hold this entry right now? Derived
+      // by LOOKING at the live plugin config, never from a remembered "we
+      // synced it" flag: an operator can edit or delete the entry at any time
+      // and a recorded intention would then tell the UI a comfortable lie.
+      const secretRef = deps.clientSecretRef;
+      const teamsBotsSync = projectTeamsBotsConfigSyncStatus(
+        {
+          getInstalledRegistry: () => options.getInstalledRegistry?.(),
+          // Bound to THIS row rather than passed through: the dependency is
+          // typed for the router's record, the projection for the structural
+          // identity source, and the closure is the honest bridge between
+          // them (it is only ever called with this row anyway).
+          ...(secretRef ? { clientSecretRef: () => secretRef(row) } : {}),
+        },
+        row,
+      );
       res.json({
         ok: true,
         agent: existing.slug,
@@ -1316,6 +1279,10 @@ export function createOperatorAgentsRouter(
           updated_at: row.updatedAt ?? null,
         },
         teams_bot: teamsBot,
+        // Additive (#910): the sync state of `teams_bot` inside the
+        // channel-teams plugin config. The copy-paste block above STAYS —
+        // this tells the operator whether they still need it.
+        teams_bots_sync: teamsBotsSync,
       });
     } catch (err) {
       badRequest(res, err);

--- a/middleware/src/services/teamsBotsConfigSync.ts
+++ b/middleware/src/services/teamsBotsConfigSync.ts
@@ -326,6 +326,31 @@ export interface TeamsBotsConfigSyncDeps {
 }
 
 /**
+ * Serializes every write in this process.
+ *
+ * The write is a read-modify-write over ONE config value, and two agents can
+ * finish provisioning at the same time (the runner's in-flight guard is
+ * per-agent, and the boot-time resume scan re-enqueues every interrupted row
+ * at once). Interleaved, the second read would miss the first write and drop
+ * that entry on the floor — the exact "never lose an entry you do not own"
+ * guarantee this module exists for. A promise chain is enough: the critical
+ * section is a few microseconds of in-memory work plus one registry write,
+ * and this is a single-process concern.
+ */
+let writeQueue: Promise<unknown> = Promise.resolve();
+
+function serialized<T>(work: () => Promise<T>): Promise<T> {
+  // `.then` on the tail regardless of how the previous write ended — a
+  // rejected predecessor must not poison the chain for everyone after it.
+  const next = writeQueue.then(work, work);
+  writeQueue = next.then(
+    () => undefined,
+    () => undefined,
+  );
+  return next;
+}
+
+/**
  * Write this identity's `teams_bots` entry into the channel-teams plugin
  * config and reload the plugin.
  *
@@ -334,7 +359,14 @@ export interface TeamsBotsConfigSyncDeps {
  * must treat that as a WARNING on an otherwise-successful run — see the module
  * header.
  */
-export async function syncTeamsBotConfig(
+export function syncTeamsBotConfig(
+  deps: TeamsBotsConfigSyncDeps,
+  record: TeamsBotIdentitySource,
+): Promise<TeamsBotsConfigSyncOutcome> {
+  return serialized(() => syncOnce(deps, record));
+}
+
+async function syncOnce(
   deps: TeamsBotsConfigSyncDeps,
   record: TeamsBotIdentitySource,
 ): Promise<TeamsBotsConfigSyncOutcome> {

--- a/middleware/src/services/teamsBotsConfigSync.ts
+++ b/middleware/src/services/teamsBotsConfigSync.ts
@@ -1,0 +1,431 @@
+/**
+ * `teams_bots[]` config sync — epic byte5ai/omadia#860, issue #910.
+ *
+ * Closes the last manual step of the agent factory. Provisioning creates an
+ * Entra app, an Azure bot, a Teams app package, a tenant-catalog entry and a
+ * team install without an operator touching anything — and then, until this
+ * module existed, asked them to copy a JSON block from the operator UI into
+ * the `teams_bots` setup field of `@omadia/channel-teams` by hand. Until that
+ * paste happened the bot existed everywhere except in the middleware, which
+ * had neither an adapter nor a route for it, so it stayed silent.
+ *
+ * THE PROJECTION LIVES HERE. {@link projectTeamsBotConfig} moved out of
+ * `routes/operatorAgents.ts` into this module so the UI block and the written
+ * entry come from ONE producer. The router re-exports it for its existing
+ * callers; a second, drifting copy would hand operators a config that silently
+ * does not parse.
+ *
+ * WRITE RULES (each one is a test in `test/teamsBotsConfigSync.test.ts`):
+ *
+ *   - IDEMPOTENT BY `botSlug`. A re-run REPLACES its own entry in place and
+ *     never appends a second one. Position is preserved, so `teams_bots[0]` —
+ *     the default bot of channel-teams' legacy scalar shim, which owns the
+ *     `/api/messages` aliases — never changes identity because some other bot
+ *     was re-provisioned.
+ *   - EVERY FOREIGN ENTRY IS PRESERVED VERBATIM. Entries are read as RAW
+ *     objects and written back untouched; only the entry whose `botSlug`
+ *     matches this identity is replaced. Nothing is normalized, re-ordered or
+ *     re-defaulted, so an operator's hand-tuned entry for another slug comes
+ *     back byte-identical. (This is why the module does not re-use
+ *     channel-teams' `parseTeamsBotsConfig` result shape for the round trip:
+ *     that parser DEFAULTS `appType` and `displayName`, so a parse/serialize
+ *     cycle would silently rewrite entries it was only meant to read past.)
+ *   - THE CONTAINER FORM ROUND-TRIPS. `parseTeamsBotsConfig` accepts both a
+ *     real array (install-registry value) and a JSON string (what the setup
+ *     wizard's string field holds). Whichever form the stored value had is the
+ *     form it is written back in; an absent value is created as a JSON string,
+ *     because that is what the setup field is.
+ *   - NOTHING SECRET IS WRITTEN. The entry carries `appPasswordSecretRef` —
+ *     the opaque `teams_bot_password:<appId>` handle into the M365 connector's
+ *     vault. `parseTeamsBotsConfig` rejects an inline `appPassword` outright,
+ *     and this module never has the password to begin with.
+ *
+ * FAILURE POSTURE: this is a best-effort finishing move on an identity that is
+ * ALREADY valid in Azure. {@link syncTeamsBotConfig} therefore reports rather
+ * than rolls back — the caller (the job runner) records a warning on the
+ * identity and keeps the run `installed`, and the operator UI keeps the
+ * copy-paste block as the documented fallback.
+ */
+
+import type { InstalledRegistry } from '../plugins/installedRegistry.js';
+import { CHANNEL_TEAMS_PLUGIN_ID } from './teamsAppPackageAssets.js';
+
+export { CHANNEL_TEAMS_PLUGIN_ID };
+
+/** The channel-teams setup field this module owns one entry of. */
+export const TEAMS_BOTS_CONFIG_KEY = 'teams_bots';
+
+// ---------------------------------------------------------------------------
+// The projection (moved from routes/operatorAgents.ts — see module header)
+// ---------------------------------------------------------------------------
+
+/** The identity fields a `teams_bots[]` entry is built from. Structural on
+ *  purpose: the store record, the job runner's record and the router's
+ *  camelCase projection all satisfy it without importing each other. */
+export interface TeamsBotIdentitySource {
+  readonly botSlug: string;
+  readonly displayName: string;
+  readonly appId: string | null;
+  readonly tenantId: string | null;
+}
+
+/**
+ * Custody convention for the provisioned bot's app password: the
+ * `agent_teams_identities` table stores NO secret material — the M365
+ * connector's `createAppRegistration` keeps the generated client secret in
+ * the CONNECTOR's vault and hands back only the opaque, deterministic ref
+ * `teams_bot_password:<appId>` (teamsProvisioner contract v0.3.1). Both the
+ * status endpoint and the config write re-derive that ref from `app_id`, so
+ * the secret never appears in an HTTP response, a middleware table or the
+ * plugin's config store. Keyed by appId (globally unique per registration),
+ * NOT by bot slug, so no two identities can ever alias one credential.
+ */
+export function defaultTeamsBotSecretRef(record: {
+  readonly appId: string | null;
+}): string {
+  if (!record.appId) {
+    throw new Error(
+      'defaultTeamsBotSecretRef requires a provisioned appId — the secret ref is derived from it',
+    );
+  }
+  return `teams_bot_password:${record.appId}`;
+}
+
+/**
+ * One `teams_bots[]` entry of channel-teams' plugin config — shaped EXACTLY
+ * like a `parseTeamsBotsConfig` entry (camelCase keys), so the same value is
+ * both written into the plugin config and rendered for an operator to paste.
+ */
+export interface TeamsBotConfigProjection {
+  readonly botSlug: string;
+  readonly displayName: string;
+  readonly appId: string;
+  /** Literal — the epic provisions SingleTenant apps only (new MultiTenant
+   *  registrations are deprecated since 07/2025). */
+  readonly appType: 'SingleTenant';
+  readonly tenantId: string;
+  /** Opaque connector-vault ref (teamsProvisioner contract v0.3.1), NEVER
+   *  the password itself. */
+  readonly appPasswordSecretRef: string;
+}
+
+/**
+ * THE single `teams_bots[]` projection of the platform (W2a #860, #910).
+ *
+ * Every surface that publishes or writes a provisioned identity goes through
+ * here rather than re-assembling the block: the entry is a config contract
+ * with channel-teams, and a second copy of it would drift.
+ *
+ * `null` until BOTH the Entra app and its tenant are known — an incomplete
+ * entry is worse than none, because channel-teams rejects the whole
+ * `teams_bots[]` array over one bad element.
+ */
+export function projectTeamsBotConfig<T extends TeamsBotIdentitySource>(
+  record: T,
+  clientSecretRef?: (record: T) => string,
+): TeamsBotConfigProjection | null {
+  if (!record.appId || !record.tenantId) return null;
+  return {
+    botSlug: record.botSlug,
+    displayName: record.displayName,
+    appId: record.appId,
+    appType: 'SingleTenant',
+    tenantId: record.tenantId,
+    appPasswordSecretRef:
+      clientSecretRef?.(record) ?? defaultTeamsBotSecretRef(record),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reading + rewriting the stored value
+// ---------------------------------------------------------------------------
+
+/** A stored `teams_bots` value that this module refuses to touch. Thrown, not
+ *  swallowed: rewriting a value we could not read would destroy operator
+ *  configuration, so an unreadable field is a loud skip, never a reset. */
+export class TeamsBotsConfigSyncError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TeamsBotsConfigSyncError';
+  }
+}
+
+/**
+ * The stored value, decomposed. `entries` are the RAW objects exactly as they
+ * were stored (see the module header on why nothing is normalized); `form`
+ * records how they were serialized so a write puts them back the same way.
+ */
+export interface TeamsBotsConfigDocument {
+  readonly entries: readonly Record<string, unknown>[];
+  readonly form: 'string' | 'array';
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asEntries(value: unknown, origin: string): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    throw new TeamsBotsConfigSyncError(
+      `the ${TEAMS_BOTS_CONFIG_KEY} setup field of ${CHANNEL_TEAMS_PLUGIN_ID} ${origin} is not a JSON array — refusing to overwrite a value this sync cannot read`,
+    );
+  }
+  return value.map((entry, index) => {
+    if (!isPlainObject(entry)) {
+      throw new TeamsBotsConfigSyncError(
+        `${TEAMS_BOTS_CONFIG_KEY} entry ${String(index)} is not an object — refusing to overwrite a value this sync cannot read`,
+      );
+    }
+    return entry;
+  });
+}
+
+/**
+ * Read the plugin's stored `teams_bots` value.
+ *
+ * Accepts exactly what `parseTeamsBotsConfig` accepts as a CONTAINER —
+ * `undefined` / `null` / `''` / `[]` (nothing configured), a real array, or a
+ * JSON string encoding that array — and rejects everything else loudly.
+ * Entry-level validation is deliberately NOT repeated here: an entry this sync
+ * does not own is none of its business, and re-validating it would turn a
+ * foreign operator mistake into a failure of an unrelated provisioning run.
+ */
+export function readTeamsBotsConfig(raw: unknown): TeamsBotsConfigDocument {
+  if (raw === undefined || raw === null) return { entries: [], form: 'string' };
+  if (typeof raw === 'string') {
+    if (raw.trim().length === 0) return { entries: [], form: 'string' };
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      throw new TeamsBotsConfigSyncError(
+        `the ${TEAMS_BOTS_CONFIG_KEY} setup field of ${CHANNEL_TEAMS_PLUGIN_ID} is not valid JSON (${err instanceof Error ? err.message : String(err)}) — refusing to overwrite a value this sync cannot read`,
+      );
+    }
+    return { entries: asEntries(parsed, 'holds a JSON value that'), form: 'string' };
+  }
+  return { entries: asEntries(raw, 'holds a value that'), form: 'array' };
+}
+
+/** Serialize a document back into a config value of its original form. The
+ *  string form is pretty-printed: an operator who opens the setup field after
+ *  a sync must be able to read and edit what is in it. */
+export function serializeTeamsBotsConfig(
+  doc: TeamsBotsConfigDocument,
+): string | readonly Record<string, unknown>[] {
+  return doc.form === 'array'
+    ? doc.entries
+    : JSON.stringify(doc.entries, null, 2);
+}
+
+/** The projection as a plain entry object, in the key order the operator UI
+ *  renders (`formatTeamsBotsConfig` in web-ui) so a written entry and a pasted
+ *  one are textually identical. */
+export function teamsBotConfigEntry(
+  projection: TeamsBotConfigProjection,
+): Record<string, unknown> {
+  return {
+    botSlug: projection.botSlug,
+    displayName: projection.displayName,
+    appId: projection.appId,
+    appType: projection.appType,
+    tenantId: projection.tenantId,
+    appPasswordSecretRef: projection.appPasswordSecretRef,
+  };
+}
+
+/** `botSlug` of a raw entry, read with `parseTeamsBotsConfig`'s own
+ *  trimmed-non-empty-string semantics. `undefined` for an entry that has none
+ *  — such an entry is foreign by definition and is never matched. */
+function entrySlug(entry: Record<string, unknown>): string | undefined {
+  const value = entry['botSlug'];
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function sameEntry(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  const keysA = Object.keys(a).sort();
+  const keysB = Object.keys(b).sort();
+  if (keysA.length !== keysB.length) return false;
+  if (keysA.some((key, i) => key !== keysB[i])) return false;
+  return keysA.every((key) => JSON.stringify(a[key]) === JSON.stringify(b[key]));
+}
+
+export interface TeamsBotsUpsertResult {
+  readonly document: TeamsBotsConfigDocument;
+  /** `false` when the stored entry already equals the projection — the caller
+   *  then skips the write AND the reactivation, so a no-op re-run does not
+   *  bounce a live channel plugin. */
+  readonly changed: boolean;
+}
+
+/**
+ * Place this identity's entry in the list: replace the entry with the same
+ * `botSlug` IN PLACE, or append when there is none. Every other entry is
+ * carried over by reference, untouched.
+ */
+export function upsertTeamsBotEntry(
+  doc: TeamsBotsConfigDocument,
+  projection: TeamsBotConfigProjection,
+): TeamsBotsUpsertResult {
+  const next = teamsBotConfigEntry(projection);
+  const index = doc.entries.findIndex(
+    (entry) => entrySlug(entry) === projection.botSlug,
+  );
+  if (index === -1) {
+    return {
+      document: { entries: [...doc.entries, next], form: doc.form },
+      changed: true,
+    };
+  }
+  const current = doc.entries[index];
+  if (current !== undefined && sameEntry(current, next)) {
+    return { document: doc, changed: false };
+  }
+  const entries = [...doc.entries];
+  entries[index] = next;
+  return { document: { entries, form: doc.form }, changed: true };
+}
+
+// ---------------------------------------------------------------------------
+// The sync itself
+// ---------------------------------------------------------------------------
+
+export type TeamsBotsConfigSyncSkipReason =
+  /** channel-teams is not installed — a legitimate deployment, not an error:
+   *  the identity is provisioned and the entry has nowhere to go yet. */
+  | 'plugin_not_installed'
+  /** No installed registry is bound (tests, minimal mounts, pre-boot). */
+  | 'registry_unavailable'
+  /** The identity has no `app_id`/`tenant_id` yet, so there is no entry to
+   *  write. Unreachable from the `installed` state; total anyway. */
+  | 'identity_incomplete';
+
+export type TeamsBotsConfigSyncOutcome =
+  | { readonly status: 'synced'; readonly botSlug: string }
+  | { readonly status: 'unchanged'; readonly botSlug: string }
+  | {
+      readonly status: 'skipped';
+      readonly reason: TeamsBotsConfigSyncSkipReason;
+    };
+
+export interface TeamsBotsConfigSyncDeps {
+  /** Late-bound like every other registry accessor in the boot wiring. */
+  readonly getInstalledRegistry: () => InstalledRegistry | undefined;
+  /**
+   * Re-activate the plugin so the new entry is live WITHOUT a restart. This is
+   * the plugin-side equivalent of the operator router's `registry.reload()`:
+   * channel-teams builds its adapters and per-bot routes in `activate()`, so a
+   * config write alone would only take effect on the next boot.
+   */
+  readonly reactivate?: (pluginId: string) => Promise<unknown>;
+  /** Override for tests; defaults to `@omadia/channel-teams`. */
+  readonly pluginId?: string;
+  readonly clientSecretRef?: (record: TeamsBotIdentitySource) => string;
+}
+
+/**
+ * Write this identity's `teams_bots` entry into the channel-teams plugin
+ * config and reload the plugin.
+ *
+ * Throws {@link TeamsBotsConfigSyncError} (unreadable stored value) or
+ * whatever the registry/reactivation threw. Callers on the provisioning path
+ * must treat that as a WARNING on an otherwise-successful run — see the module
+ * header.
+ */
+export async function syncTeamsBotConfig(
+  deps: TeamsBotsConfigSyncDeps,
+  record: TeamsBotIdentitySource,
+): Promise<TeamsBotsConfigSyncOutcome> {
+  const projection = projectTeamsBotConfig(record, deps.clientSecretRef);
+  if (!projection) return { status: 'skipped', reason: 'identity_incomplete' };
+
+  const pluginId = deps.pluginId ?? CHANNEL_TEAMS_PLUGIN_ID;
+  const registry = deps.getInstalledRegistry();
+  if (!registry) return { status: 'skipped', reason: 'registry_unavailable' };
+
+  const installed = registry.get(pluginId);
+  if (!installed) return { status: 'skipped', reason: 'plugin_not_installed' };
+
+  const doc = readTeamsBotsConfig(installed.config[TEAMS_BOTS_CONFIG_KEY]);
+  const { document, changed } = upsertTeamsBotEntry(doc, projection);
+  if (!changed) return { status: 'unchanged', botSlug: projection.botSlug };
+
+  await registry.updateConfig(pluginId, {
+    ...installed.config,
+    [TEAMS_BOTS_CONFIG_KEY]: serializeTeamsBotsConfig(document),
+  });
+  // Reload AFTER the write, and only after a write: an activation failure
+  // must not be able to leave the config unwritten, and a no-op run must not
+  // bounce a plugin that is serving traffic.
+  await deps.reactivate?.(pluginId);
+  return { status: 'synced', botSlug: projection.botSlug };
+}
+
+// ---------------------------------------------------------------------------
+// Status projection (the operator UI's "did the sync take?" signal)
+// ---------------------------------------------------------------------------
+
+export type TeamsBotsConfigSyncState =
+  /** The plugin config holds exactly this identity's entry. */
+  | 'synced'
+  /** An entry for this slug exists but differs — a hand edit, or a sync that
+   *  failed after an identity field changed. */
+  | 'out_of_sync'
+  /** channel-teams is installed and has no entry for this slug. */
+  | 'missing'
+  | 'plugin_not_installed'
+  /** The stored value cannot be read, so nothing was written. */
+  | 'unreadable'
+  /** No entry exists to compare yet (identity before `app_registered`). */
+  | 'not_applicable'
+  /** No installed registry is bound — the status is genuinely unknown. */
+  | 'unknown';
+
+export interface TeamsBotsConfigSyncStatus {
+  readonly state: TeamsBotsConfigSyncState;
+  readonly plugin_id: string;
+  readonly config_key: string;
+}
+
+/**
+ * Answer "is this bot actually configured in channel-teams right now?" by
+ * LOOKING, not by remembering.
+ *
+ * Deliberately derived from the live plugin config instead of a persisted
+ * "we synced it" flag: an operator can edit or delete the entry at any time,
+ * and a recorded intention would then tell the UI a comfortable lie. The
+ * identity row stays free of a column that could disagree with reality.
+ */
+export function projectTeamsBotsConfigSyncStatus(
+  deps: Pick<TeamsBotsConfigSyncDeps, 'getInstalledRegistry' | 'pluginId' | 'clientSecretRef'>,
+  record: TeamsBotIdentitySource,
+): TeamsBotsConfigSyncStatus {
+  const pluginId = deps.pluginId ?? CHANNEL_TEAMS_PLUGIN_ID;
+  const base = { plugin_id: pluginId, config_key: TEAMS_BOTS_CONFIG_KEY };
+  const projection = projectTeamsBotConfig(record, deps.clientSecretRef);
+  if (!projection) return { ...base, state: 'not_applicable' };
+
+  const registry = deps.getInstalledRegistry();
+  if (!registry) return { ...base, state: 'unknown' };
+  const installed = registry.get(pluginId);
+  if (!installed) return { ...base, state: 'plugin_not_installed' };
+
+  let doc: TeamsBotsConfigDocument;
+  try {
+    doc = readTeamsBotsConfig(installed.config[TEAMS_BOTS_CONFIG_KEY]);
+  } catch {
+    return { ...base, state: 'unreadable' };
+  }
+  const current = doc.entries.find(
+    (entry) => entrySlug(entry) === projection.botSlug,
+  );
+  if (current === undefined) return { ...base, state: 'missing' };
+  return {
+    ...base,
+    state: sameEntry(current, teamsBotConfigEntry(projection))
+      ? 'synced'
+      : 'out_of_sync',
+  };
+}

--- a/middleware/src/services/teamsProvisioningJob.ts
+++ b/middleware/src/services/teamsProvisioningJob.ts
@@ -770,6 +770,14 @@ export class TeamsProvisioningJobRunner {
           report.reason !== undefined ? ` (${report.reason})` : ''
         }`,
       );
+      // Retiring OUR OWN stale warning is part of "re-run provisioning to
+      // retry the write": without this, a run that fixed the problem would
+      // leave the operator staring at the warning that sent them here.
+      // Scoped to the `config_sync_failed` prefix on purpose — an unrelated
+      // error on the row is not this method's to clear.
+      if (row.lastError?.startsWith(CONFIG_SYNC_FAILED_PREFIX)) {
+        await this.recordError(row.agentId, { lastError: null });
+      }
     } catch (err) {
       const detail = configSyncFailedDetail(errorMessage(err));
       this.log(
@@ -831,6 +839,10 @@ export function throttledDetail(
  * brackets like the other structured sentences, with bracket and newline
  * characters stripped so the classifier's `[...]` group round-trips exactly.
  */
+/** Machine-readable prefix of {@link configSyncFailedDetail}. Shared by the
+ *  producer, the classifier and the runner's stale-warning cleanup. */
+export const CONFIG_SYNC_FAILED_PREFIX = 'config_sync_failed:';
+
 export function configSyncFailedDetail(reason: string): string {
   const safe = reason.replace(/[[\]]/g, '').replace(/\s+/g, ' ').trim();
   return `config_sync_failed: [${safe.length > 0 ? safe : CONFIG_SYNC_REASON_UNSPECIFIED}] — the Teams identity is provisioned and installed; only the automatic teams_bots entry in the Teams channel plugin was not written. Paste the shown block into that setup field to bring the bot online, or re-run provisioning to retry the write`;
@@ -900,7 +912,7 @@ export function classifyTeamsProvisioningError(
       raw,
     };
   }
-  if (sentence.startsWith('config_sync_failed:')) {
+  if (sentence.startsWith(CONFIG_SYNC_FAILED_PREFIX)) {
     const inner = /\[([^\]]*)\]/.exec(sentence)?.[1]?.trim() ?? '';
     return {
       code: 'config_sync_failed',

--- a/middleware/src/services/teamsProvisioningJob.ts
+++ b/middleware/src/services/teamsProvisioningJob.ts
@@ -298,6 +298,32 @@ export type ProvisioningRunResult =
     }
   | { readonly status: 'stopped'; readonly agentId: string };
 
+/**
+ * Outcome of the post-provisioning `teams_bots` config write (#910). A
+ * structural subset of `TeamsBotsConfigSyncOutcome` in
+ * `services/teamsBotsConfigSync.ts` — the runner only needs to know whether
+ * something was written, so it can log it; every branch is non-fatal.
+ */
+export interface TeamsBotsConfigSyncReport {
+  readonly status: 'synced' | 'unchanged' | 'skipped';
+  readonly reason?: string;
+}
+
+/**
+ * Write this identity's entry into the channel-teams plugin config and reload
+ * the plugin, so the provisioned bot answers without a restart (#910).
+ *
+ * Optional: a wiring without an installed registry (tests, minimal mounts)
+ * simply leaves the operator on the documented copy-paste path.
+ *
+ * MAY REJECT. The runner treats a rejection as a warning on an
+ * already-successful run — see {@link TeamsProvisioningJobRunner} on why the
+ * identity is never rolled back for it.
+ */
+export type TeamsBotsConfigSyncPort = (
+  identity: TeamsIdentityJobRecord,
+) => Promise<TeamsBotsConfigSyncReport>;
+
 export interface TeamsProvisioningJobOptions {
   readonly store: TeamsIdentityJobStore;
   /** Resolves the accessor; throws its typed 'unavailable' error when the
@@ -316,6 +342,9 @@ export interface TeamsProvisioningJobOptions {
   readonly maxRetryDelayMs?: number;
   /** Test seam — defaults to real timers. */
   readonly timers?: TimerSeam;
+  /** #910 — the finishing move that makes the bot live. Absent means the
+   *  operator configures channel-teams by hand, exactly as before. */
+  readonly syncBotConfig?: TeamsBotsConfigSyncPort;
   readonly log?: (msg: string) => void;
 }
 
@@ -343,6 +372,7 @@ export class TeamsProvisioningJobRunner {
   private readonly baseRetryDelayMs: number;
   private readonly maxRetryDelayMs: number;
   private readonly timers: TimerSeam;
+  private readonly syncBotConfig: TeamsBotsConfigSyncPort | undefined;
   private readonly log: (msg: string) => void;
 
   private readonly inFlight = new Map<
@@ -365,6 +395,7 @@ export class TeamsProvisioningJobRunner {
       MAX_TIMER_DELAY_MS,
     );
     this.timers = opts.timers ?? REAL_TIMERS;
+    this.syncBotConfig = opts.syncBotConfig;
     this.log = opts.log ?? ((m) => console.log(m));
   }
 
@@ -599,7 +630,15 @@ export class TeamsProvisioningJobRunner {
         `no teams identity row for agent '${agentId}' — create it before enqueueing provisioning`,
       );
     }
-    if (row.state === 'installed') return { status: 'installed', agentId };
+    if (row.state === 'installed') {
+      // #910 — a re-run of an already-installed identity is the self-healing
+      // path: identity fields may have changed (a new display name), or an
+      // operator may have removed the entry from the plugin config. The chain
+      // itself has nothing left to do, but the config write is re-asserted so
+      // "re-run provisioning" always ends with the bot actually configured.
+      await this.syncTeamsBotsConfig(row);
+      return { status: 'installed', agentId };
+    }
     if (this.stopped) return { status: 'stopped', agentId };
 
     const provisioner = this.getProvisioner();
@@ -699,8 +738,45 @@ export class TeamsProvisioningJobRunner {
       teamId: request.teamId,
       teamsAppId: row.teamsAppId as string,
     });
-    await this.store.update(agentId, { state: 'installed', lastError: null });
+    row = await this.store.update(agentId, { state: 'installed', lastError: null });
+
+    // Step 6 (#910) — the finishing move: write the `teams_bots` entry into
+    // channel-teams and reload it, so the bot answers without an operator
+    // pasting JSON between two screens. Deliberately AFTER the terminal state
+    // write and deliberately unable to change it.
+    await this.syncTeamsBotsConfig(row);
     return { status: 'installed', agentId };
+  }
+
+  /**
+   * Best-effort `teams_bots` config write (#910).
+   *
+   * NEVER throws, never changes `state`. By the time this runs the Entra app,
+   * the Azure bot, the catalog entry and the team install all exist and are
+   * this agent's — failing the run over a config write would report a
+   * provisioning failure that did not happen, and re-running it would re-walk
+   * a chain that is already complete. So a failure is recorded as an
+   * ACTIONABLE warning in `last_error` (`config_sync_failed`, which the
+   * operator UI renders as "paste the block by hand, here is why") while the
+   * identity stays `installed`.
+   */
+  private async syncTeamsBotsConfig(row: TeamsIdentityJobRecord): Promise<void> {
+    const sync = this.syncBotConfig;
+    if (!sync) return;
+    try {
+      const report = await sync(row);
+      this.log(
+        `[teams-provisioning] teams_bots config sync for ${row.agentId} (${row.botSlug}): ${report.status}${
+          report.reason !== undefined ? ` (${report.reason})` : ''
+        }`,
+      );
+    } catch (err) {
+      const detail = configSyncFailedDetail(errorMessage(err));
+      this.log(
+        `[teams-provisioning] teams_bots config sync for ${row.agentId} (${row.botSlug}) failed: ${errorMessage(err)} — identity stays installed; the operator can paste the block manually`,
+      );
+      await this.recordError(row.agentId, { lastError: detail });
+    }
   }
 }
 
@@ -747,10 +823,28 @@ export function throttledDetail(
   return `throttled: ${message} (gave up after ${String(attempts)} attempts${hint})`;
 }
 
+/**
+ * The one sentence this runner writes that is a WARNING, not a failure (#910).
+ *
+ * The identity is provisioned and valid in Azure; only the automatic write of
+ * the channel-teams `teams_bots` entry did not land. The reason is carried in
+ * brackets like the other structured sentences, with bracket and newline
+ * characters stripped so the classifier's `[...]` group round-trips exactly.
+ */
+export function configSyncFailedDetail(reason: string): string {
+  const safe = reason.replace(/[[\]]/g, '').replace(/\s+/g, ' ').trim();
+  return `config_sync_failed: [${safe.length > 0 ? safe : CONFIG_SYNC_REASON_UNSPECIFIED}] — the Teams identity is provisioned and installed; only the automatic teams_bots entry in the Teams channel plugin was not written. Paste the shown block into that setup field to bring the bot online, or re-run provisioning to retry the write`;
+}
+
+/** Bracket filler when the failure carried no usable message. Shared by the
+ *  producer and the classifier so the empty case round-trips. */
+const CONFIG_SYNC_REASON_UNSPECIFIED = 'no reason reported';
+
 export type TeamsProvisioningErrorCode =
   | 'consent_missing'
   | 'arm_not_configured'
   | 'throttled'
+  | 'config_sync_failed'
   | 'unknown';
 
 /** Structured projection of one `last_error` sentence. `raw` is always the
@@ -764,6 +858,10 @@ export interface TeamsProvisioningErrorDetail {
   readonly fields?: readonly string[];
   /** Connector `Retry-After` hint in seconds (`throttled`), when it had one. */
   readonly retryAfterSeconds?: number;
+  /** Why the automatic `teams_bots` write did not land (`config_sync_failed`).
+   *  A technical sentence, shown as the argument of a localized line — never
+   *  as the copy itself. */
+  readonly reason?: string;
   readonly raw: string;
 }
 
@@ -799,6 +897,14 @@ export function classifyTeamsProvisioningError(
     return {
       code: 'arm_not_configured',
       fields: bracketList(sentence, ARM_FIELDS_UNSPECIFIED),
+      raw,
+    };
+  }
+  if (sentence.startsWith('config_sync_failed:')) {
+    const inner = /\[([^\]]*)\]/.exec(sentence)?.[1]?.trim() ?? '';
+    return {
+      code: 'config_sync_failed',
+      reason: inner === CONFIG_SYNC_REASON_UNSPECIFIED ? '' : inner,
       raw,
     };
   }

--- a/middleware/test/operatorAgentsRouter.test.ts
+++ b/middleware/test/operatorAgentsRouter.test.ts
@@ -67,6 +67,14 @@ import {
   consentMissingDetail,
   throttledDetail,
 } from '../src/services/teamsProvisioningJob.js';
+import {
+  InMemoryInstalledRegistry,
+  type InstalledRegistry,
+} from '../src/plugins/installedRegistry.js';
+import {
+  CHANNEL_TEAMS_PLUGIN_ID,
+  TEAMS_BOTS_CONFIG_KEY,
+} from '../src/services/teamsBotsConfigSync.js';
 import { listenLoopback } from './_helpers/listenLoopback.js';
 
 interface AgentMem {
@@ -467,6 +475,10 @@ describe('createOperatorAgentsRouter', () => {
   /** #900 — the accessor the route feature-detects on. `undefined` models a
    *  connector that is not installed at all. */
   let provisioner: FakeTeamsProvisioner | LegacyTeamsProvisioner | undefined;
+  /** #910 — the installed registry the `teams_bots_sync` projection reads.
+   *  `undefined` by default so every pre-existing test keeps the exact mount
+   *  it was written against; the sync tests below bind it per case. */
+  let installedPlugins: InstalledRegistry | undefined;
 
   before(async () => {
     store = new FakeConfigStore();
@@ -477,6 +489,7 @@ describe('createOperatorAgentsRouter', () => {
     teamsRunner = new FakeTeamsRunner();
     provisionerInstalled = true;
     provisioner = new FakeTeamsProvisioner();
+    installedPlugins = undefined;
     const app = express();
     app.use(express.json());
     app.use(
@@ -486,6 +499,8 @@ describe('createOperatorAgentsRouter', () => {
         getRegistry: () => registry as unknown as OrchestratorRegistry,
         getChatSessionStore: () => sessionStore as unknown as ChatSessionStore,
         getAgentGraphStore: () => graph as unknown as AgentGraphStore,
+        // #910 — read live, like every other getter here.
+        getInstalledRegistry: () => installedPlugins,
         // W1a (#860) — getters read the CURRENT fakes so afterEach resets apply.
         getTeamsIdentity: () => ({
           store: teamsStore,
@@ -514,6 +529,7 @@ describe('createOperatorAgentsRouter', () => {
     teamsRunner = new FakeTeamsRunner();
     provisionerInstalled = true;
     provisioner = new FakeTeamsProvisioner();
+    installedPlugins = undefined;
   });
 
   // ── W5 memory-ACL rollout switch (#899) ─────────────────────────────
@@ -1073,6 +1089,36 @@ describe('createOperatorAgentsRouter', () => {
     assert.match(mount, /new AgentGraphStore\(graphPool\)/, 'the option must construct the real store from graphPool');
   });
 
+  it('index.ts wires syncBotConfig into the provisioning runner (wiring pin, #910)', async () => {
+    // The runner treats a missing sync port as "the operator configures
+    // channel-teams by hand" — exactly the pre-#910 behaviour, and exactly the
+    // regression a unit test with an injected port cannot see. Pin the real
+    // boot wiring instead.
+    const indexSource = await readFile(new URL('../src/index.ts', import.meta.url), 'utf8');
+    const runner = /new TeamsProvisioningJobRunner\(\{([\s\S]*?)\n    \}\)/.exec(
+      indexSource,
+    )?.[1];
+    assert.ok(
+      runner,
+      'index.ts no longer constructs TeamsProvisioningJobRunner — update this pin',
+    );
+    assert.match(
+      runner,
+      /syncBotConfig:/,
+      'index.ts must pass syncBotConfig to TeamsProvisioningJobRunner — without it a provisioned bot stays unconfigured until an operator pastes the block by hand',
+    );
+    assert.match(
+      runner,
+      /syncTeamsBotConfig\(/,
+      'the port must delegate to services/teamsBotsConfigSync.ts, not re-implement the write',
+    );
+    assert.match(
+      runner,
+      /reactivate: reactivateAgent/,
+      'the sync must reload the plugin through the same funnel every other live config change uses',
+    );
+  });
+
   it('index.ts supplies getTeamsIdentity to the operator-agents mount (wiring pin, W1a #860)', async () => {
     // Same rationale as the getAgentGraphStore pin above: the route tests
     // inject their own deps and cannot see a missing option at the REAL
@@ -1459,6 +1505,132 @@ describe('createOperatorAgentsRouter', () => {
     // a second, drifting copy would hand operators a config channel-teams
     // silently refuses to parse.
     assert.deepEqual(body.teams_bot, projectTeamsBotConfig(row));
+  });
+
+  // ── #910: the teams_bots sync signal on the status route ────────────
+
+  it('GET /:slug/teams-identity reports the LIVE teams_bots sync state', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    const row: OperatorTeamsIdentityRecord = {
+      agentId: agent.id,
+      botSlug: 'sales-bot',
+      displayName: 'Sales Bot',
+      state: 'installed',
+      teamId: '19:team-a',
+      appId: 'app-123',
+      tenantId: 'tenant-456',
+      teamsAppId: 'teams-app-789',
+      teamsAppExternalId: 'ext-000',
+      lastError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    teamsStore.rows.set(agent.id, row);
+
+    const read = async (): Promise<{
+      state: string;
+      plugin_id: string;
+      config_key: string;
+    }> => {
+      const res = await fetch(`${baseUrl}/sales/teams-identity`);
+      const body = (await res.json()) as {
+        teams_bots_sync: { state: string; plugin_id: string; config_key: string };
+      };
+      return body.teams_bots_sync;
+    };
+
+    // No registry bound at all — the status is genuinely unknown, and the
+    // route says so instead of guessing "not synced".
+    assert.equal((await read()).state, 'unknown');
+
+    const plugins = new InMemoryInstalledRegistry();
+    installedPlugins = plugins;
+    assert.equal((await read()).state, 'plugin_not_installed');
+
+    await plugins.register({
+      id: CHANNEL_TEAMS_PLUGIN_ID,
+      installed_version: '0.21.0',
+      installed_at: new Date(0).toISOString(),
+      status: 'active',
+      config: {},
+    });
+    assert.equal((await read()).state, 'missing');
+
+    // The very block the UI offers for pasting, now actually configured.
+    await plugins.updateConfig(CHANNEL_TEAMS_PLUGIN_ID, {
+      [TEAMS_BOTS_CONFIG_KEY]: JSON.stringify([projectTeamsBotConfig(row)]),
+    });
+    const synced = await read();
+    assert.equal(synced.state, 'synced');
+    // The UI names both in its copy, so both are part of the contract.
+    assert.equal(synced.plugin_id, CHANNEL_TEAMS_PLUGIN_ID);
+    assert.equal(synced.config_key, 'teams_bots');
+
+    // A hand edit is visible immediately — the signal is derived by LOOKING,
+    // never from a stored "we synced it once" flag.
+    await plugins.updateConfig(CHANNEL_TEAMS_PLUGIN_ID, {
+      [TEAMS_BOTS_CONFIG_KEY]: JSON.stringify([
+        { ...projectTeamsBotConfig(row), displayName: 'edited by hand' },
+      ]),
+    });
+    assert.equal((await read()).state, 'out_of_sync');
+  });
+
+  it('GET /:slug/teams-identity: an unreadable teams_bots value is reported, not hidden', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    teamsStore.rows.set(agent.id, {
+      agentId: agent.id,
+      botSlug: 'sales-bot',
+      displayName: 'Sales Bot',
+      state: 'installed',
+      teamId: '19:team-a',
+      appId: 'app-123',
+      tenantId: 'tenant-456',
+      teamsAppId: 'teams-app-789',
+      teamsAppExternalId: 'ext-000',
+      lastError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const plugins = new InMemoryInstalledRegistry();
+    await plugins.register({
+      id: CHANNEL_TEAMS_PLUGIN_ID,
+      installed_version: '0.21.0',
+      installed_at: new Date(0).toISOString(),
+      status: 'active',
+      config: { [TEAMS_BOTS_CONFIG_KEY]: '{ not json' },
+    });
+    installedPlugins = plugins;
+    const res = await fetch(`${baseUrl}/sales/teams-identity`);
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { teams_bots_sync: { state: string } };
+    assert.equal(body.teams_bots_sync.state, 'unreadable');
+  });
+
+  it('GET /:slug/teams-identity: sync is not_applicable before the app registration exists', async () => {
+    const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
+    teamsStore.rows.set(agent.id, {
+      agentId: agent.id,
+      botSlug: 'sales-bot',
+      displayName: 'Sales Bot',
+      state: 'pending',
+      teamId: '19:team-a',
+      appId: null,
+      tenantId: null,
+      teamsAppId: null,
+      teamsAppExternalId: null,
+      lastError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    installedPlugins = new InMemoryInstalledRegistry();
+    const res = await fetch(`${baseUrl}/sales/teams-identity`);
+    const body = (await res.json()) as {
+      teams_bot: unknown;
+      teams_bots_sync: { state: string };
+    };
+    assert.equal(body.teams_bot, null);
+    assert.equal(body.teams_bots_sync.state, 'not_applicable');
   });
 
   it('the GET projects through deps.clientSecretRef — not just through the default', async () => {

--- a/middleware/test/teamsBotsConfigSync.test.ts
+++ b/middleware/test/teamsBotsConfigSync.test.ts
@@ -368,6 +368,58 @@ describe('syncTeamsBotConfig', () => {
     assert.equal(storedEntries(registry).length, 1);
   });
 
+  it('serializes concurrent writes so neither agent loses its entry', async () => {
+    // Two agents finishing provisioning at once is normal (the boot-time
+    // resume scan re-enqueues every interrupted row). Unserialized, the second
+    // read-modify-write would read a config the first had not written yet and
+    // silently drop that entry.
+    const registry = registryWith({
+      [TEAMS_BOTS_CONFIG_KEY]: JSON.stringify([LEGACY_ENTRY]),
+    });
+    // A registry whose write does not land until the next macrotask — the
+    // widest interleaving window a real, async registry could open.
+    const slow: InstalledRegistry = {
+      ...registry,
+      get: (id) => registry.get(id),
+      updateConfig: async (id, config) => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        await registry.updateConfig(id, config);
+      },
+    } as InstalledRegistry;
+    const deps = { getInstalledRegistry: () => slow };
+    await Promise.all([
+      syncTeamsBotConfig(deps, IDENTITY),
+      syncTeamsBotConfig(deps, {
+        botSlug: 'sales-bot-2',
+        displayName: 'Sales Bot 2',
+        appId: 'app-sales-2',
+        tenantId: 'tenant-0001',
+      }),
+      syncTeamsBotConfig(deps, {
+        botSlug: 'ops-bot',
+        displayName: 'Ops Bot',
+        appId: 'app-ops-3',
+        tenantId: 'tenant-0001',
+      }),
+    ]);
+    const slugs = storedEntries(registry).map((entry) => entry['botSlug']);
+    assert.deepEqual(slugs, ['default', 'hr-bot', 'sales-bot-2', 'ops-bot']);
+  });
+
+  it('a failed write does not poison the queue for the next caller', async () => {
+    const broken = registryWith({ [TEAMS_BOTS_CONFIG_KEY]: '{ not json' });
+    const good = registryWith({});
+    await assert.rejects(
+      syncTeamsBotConfig({ getInstalledRegistry: () => broken }, IDENTITY),
+      TeamsBotsConfigSyncError,
+    );
+    const outcome = await syncTeamsBotConfig(
+      { getInstalledRegistry: () => good },
+      IDENTITY,
+    );
+    assert.equal(outcome.status, 'synced');
+  });
+
   it('never writes secret material — only the opaque vault REF', async () => {
     const registry = registryWith({});
     await syncTeamsBotConfig({ getInstalledRegistry: () => registry }, IDENTITY);

--- a/middleware/test/teamsBotsConfigSync.test.ts
+++ b/middleware/test/teamsBotsConfigSync.test.ts
@@ -1,0 +1,440 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  InMemoryInstalledRegistry,
+  type InstalledRegistry,
+} from '../src/plugins/installedRegistry.js';
+import {
+  CHANNEL_TEAMS_PLUGIN_ID,
+  TEAMS_BOTS_CONFIG_KEY,
+  TeamsBotsConfigSyncError,
+  defaultTeamsBotSecretRef,
+  projectTeamsBotConfig,
+  projectTeamsBotsConfigSyncStatus,
+  readTeamsBotsConfig,
+  serializeTeamsBotsConfig,
+  syncTeamsBotConfig,
+  teamsBotConfigEntry,
+  upsertTeamsBotEntry,
+  type TeamsBotIdentitySource,
+} from '../src/services/teamsBotsConfigSync.js';
+
+/**
+ * #910 — the automatic `teams_bots` write.
+ *
+ * The happy path is the least interesting property here. What these tests
+ * exist for is the two guarantees an operator's production deployment depends
+ * on: a re-run must not duplicate its own entry, and NOTHING this sync writes
+ * may disturb an entry it does not own — above all `teams_bots[0]`, the legacy
+ * scalar-shimmed bot that owns the `/api/messages` aliases and is answering
+ * live traffic while this code runs.
+ */
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const IDENTITY: TeamsBotIdentitySource = {
+  botSlug: 'hr-bot',
+  displayName: 'HR Bot',
+  appId: 'app-hr-0001',
+  tenantId: 'tenant-0001',
+};
+
+/** The production bot of a legacy single-bot deployment, shimmed onto entry 0
+ *  by channel-teams. Hand-written on purpose: the operator typed this. */
+const LEGACY_ENTRY = {
+  botSlug: 'default',
+  appId: 'app-legacy-9999',
+  tenantId: 'tenant-0001',
+  appPasswordSecretRef: 'microsoft_app_password',
+  appType: 'MultiTenant',
+  displayName: 'Microsoft Teams Bot',
+};
+
+/** Another agent's entry, hand-tuned by an operator (note the non-default
+ *  secret ref and the extra key the parser ignores). */
+const FOREIGN_ENTRY = {
+  botSlug: 'sales-bot',
+  displayName: 'Sales Bot — do not touch',
+  appId: 'app-sales-4242',
+  appType: 'SingleTenant',
+  tenantId: 'tenant-0001',
+  appPasswordSecretRef: 'custom_vault:sales',
+  note: 'managed by hand, see runbook',
+};
+
+function registryWith(config: Record<string, unknown>): InstalledRegistry {
+  const registry = new InMemoryInstalledRegistry();
+  void registry.register({
+    id: CHANNEL_TEAMS_PLUGIN_ID,
+    installed_version: '0.21.0',
+    installed_at: new Date(0).toISOString(),
+    status: 'active',
+    config,
+  });
+  return registry;
+}
+
+function storedEntries(registry: InstalledRegistry): Record<string, unknown>[] {
+  const value = registry.get(CHANNEL_TEAMS_PLUGIN_ID)?.config[TEAMS_BOTS_CONFIG_KEY];
+  return [...readTeamsBotsConfig(value).entries];
+}
+
+// ---------------------------------------------------------------------------
+// The projection (moved here from routes/operatorAgents.ts)
+// ---------------------------------------------------------------------------
+
+describe('teams_bots projection', () => {
+  it('emits a parseTeamsBotsConfig-shaped entry with the derived secret REF', () => {
+    const projection = projectTeamsBotConfig(IDENTITY);
+    assert.deepEqual(projection, {
+      botSlug: 'hr-bot',
+      displayName: 'HR Bot',
+      appId: 'app-hr-0001',
+      appType: 'SingleTenant',
+      tenantId: 'tenant-0001',
+      appPasswordSecretRef: 'teams_bot_password:app-hr-0001',
+    });
+  });
+
+  it('is null until BOTH app and tenant are known', () => {
+    assert.equal(projectTeamsBotConfig({ ...IDENTITY, appId: null }), null);
+    assert.equal(projectTeamsBotConfig({ ...IDENTITY, tenantId: null }), null);
+  });
+
+  it('derives the secret ref from appId, never from the slug', () => {
+    assert.equal(
+      defaultTeamsBotSecretRef({ appId: 'app-hr-0001' }),
+      'teams_bot_password:app-hr-0001',
+    );
+    assert.throws(() => defaultTeamsBotSecretRef({ appId: null }), /requires a provisioned appId/);
+  });
+
+  it('honours an injected clientSecretRef', () => {
+    const projection = projectTeamsBotConfig(IDENTITY, () => 'vault:custom');
+    assert.equal(projection?.appPasswordSecretRef, 'vault:custom');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reading + rewriting the stored value
+// ---------------------------------------------------------------------------
+
+describe('readTeamsBotsConfig', () => {
+  it('treats every "nothing configured" spelling as an empty string field', () => {
+    for (const raw of [undefined, null, '', '   ']) {
+      assert.deepEqual(readTeamsBotsConfig(raw), { entries: [], form: 'string' });
+    }
+  });
+
+  it('reads the setup wizard string form and the install-registry array form', () => {
+    assert.deepEqual(readTeamsBotsConfig(JSON.stringify([LEGACY_ENTRY])), {
+      entries: [LEGACY_ENTRY],
+      form: 'string',
+    });
+    assert.deepEqual(readTeamsBotsConfig([LEGACY_ENTRY]), {
+      entries: [LEGACY_ENTRY],
+      form: 'array',
+    });
+  });
+
+  it('refuses a value it cannot read rather than resetting it', () => {
+    assert.throws(() => readTeamsBotsConfig('{ not json'), TeamsBotsConfigSyncError);
+    assert.throws(() => readTeamsBotsConfig('{"a":1}'), TeamsBotsConfigSyncError);
+    assert.throws(() => readTeamsBotsConfig(42), TeamsBotsConfigSyncError);
+    assert.throws(() => readTeamsBotsConfig(['nope']), TeamsBotsConfigSyncError);
+  });
+
+  it('does NOT validate foreign entries — a neighbour is none of its business', () => {
+    // No botSlug, no appId: `parseTeamsBotsConfig` would reject this at
+    // activate() time. This sync must still be able to read past it, or one
+    // operator's mistake would break an unrelated agent's provisioning.
+    const doc = readTeamsBotsConfig([{ displayName: 'half-typed' }]);
+    assert.equal(doc.entries.length, 1);
+  });
+
+  it('round-trips the container form it was given', () => {
+    const asString = readTeamsBotsConfig(JSON.stringify([LEGACY_ENTRY]));
+    assert.equal(typeof serializeTeamsBotsConfig(asString), 'string');
+    assert.deepEqual(
+      JSON.parse(serializeTeamsBotsConfig(asString) as string),
+      [LEGACY_ENTRY],
+    );
+    const asArray = readTeamsBotsConfig([LEGACY_ENTRY]);
+    assert.deepEqual(serializeTeamsBotsConfig(asArray), [LEGACY_ENTRY]);
+  });
+});
+
+describe('upsertTeamsBotEntry', () => {
+  const projection = projectTeamsBotConfig(IDENTITY);
+  assert.ok(projection);
+
+  it('appends when the list holds no entry for this slug', () => {
+    const doc = readTeamsBotsConfig([LEGACY_ENTRY, FOREIGN_ENTRY]);
+    const { document, changed } = upsertTeamsBotEntry(doc, projection);
+    assert.equal(changed, true);
+    assert.deepEqual(document.entries, [
+      LEGACY_ENTRY,
+      FOREIGN_ENTRY,
+      teamsBotConfigEntry(projection),
+    ]);
+  });
+
+  it('replaces its own entry IN PLACE — position 0 never changes owner', () => {
+    const mine = { ...teamsBotConfigEntry(projection), displayName: 'stale name' };
+    const doc = readTeamsBotsConfig([mine, LEGACY_ENTRY]);
+    const { document, changed } = upsertTeamsBotEntry(doc, projection);
+    assert.equal(changed, true);
+    assert.equal(document.entries.length, 2);
+    assert.deepEqual(document.entries[0], teamsBotConfigEntry(projection));
+    assert.equal(document.entries[1], LEGACY_ENTRY);
+  });
+
+  it('reports no change when the stored entry already equals the projection', () => {
+    const doc = readTeamsBotsConfig([LEGACY_ENTRY, teamsBotConfigEntry(projection)]);
+    const { document, changed } = upsertTeamsBotEntry(doc, projection);
+    assert.equal(changed, false);
+    assert.equal(document, doc);
+  });
+
+  it('never matches an entry whose botSlug is absent or not a string', () => {
+    const doc = readTeamsBotsConfig([{ appId: 'x' }, { botSlug: 42 }, { botSlug: '  ' }]);
+    const { document } = upsertTeamsBotEntry(doc, projection);
+    assert.equal(document.entries.length, 4);
+    assert.deepEqual(document.entries[3], teamsBotConfigEntry(projection));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The sync
+// ---------------------------------------------------------------------------
+
+describe('syncTeamsBotConfig', () => {
+  it('writes the entry into an empty config and reloads the plugin', async () => {
+    const registry = registryWith({ teams_directory_label: 'byte5' });
+    const reloaded: string[] = [];
+    const outcome = await syncTeamsBotConfig(
+      {
+        getInstalledRegistry: () => registry,
+        reactivate: async (id) => {
+          reloaded.push(id);
+        },
+      },
+      IDENTITY,
+    );
+    assert.deepEqual(outcome, { status: 'synced', botSlug: 'hr-bot' });
+    assert.deepEqual(reloaded, [CHANNEL_TEAMS_PLUGIN_ID]);
+    assert.deepEqual(storedEntries(registry), [
+      {
+        botSlug: 'hr-bot',
+        displayName: 'HR Bot',
+        appId: 'app-hr-0001',
+        appType: 'SingleTenant',
+        tenantId: 'tenant-0001',
+        appPasswordSecretRef: 'teams_bot_password:app-hr-0001',
+      },
+    ]);
+    // Every other setup value survives the write.
+    assert.equal(
+      registry.get(CHANNEL_TEAMS_PLUGIN_ID)?.config['teams_directory_label'],
+      'byte5',
+    );
+  });
+
+  it('writes a JSON STRING, the form the setup field holds', async () => {
+    const registry = registryWith({});
+    await syncTeamsBotConfig({ getInstalledRegistry: () => registry }, IDENTITY);
+    const value = registry.get(CHANNEL_TEAMS_PLUGIN_ID)?.config[TEAMS_BOTS_CONFIG_KEY];
+    assert.equal(typeof value, 'string');
+    // And it round-trips through the plugin's own accepted container shapes.
+    assert.equal(readTeamsBotsConfig(value).entries.length, 1);
+  });
+
+  it('is idempotent by botSlug: two runs leave exactly one entry', async () => {
+    const registry = registryWith({});
+    const deps = { getInstalledRegistry: () => registry };
+    const first = await syncTeamsBotConfig(deps, IDENTITY);
+    const second = await syncTeamsBotConfig(deps, IDENTITY);
+    assert.equal(first.status, 'synced');
+    assert.equal(second.status, 'unchanged');
+    const entries = storedEntries(registry);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.['botSlug'], 'hr-bot');
+  });
+
+  it('does not reload the plugin on a no-op re-run', async () => {
+    const registry = registryWith({});
+    const reloaded: string[] = [];
+    const deps = {
+      getInstalledRegistry: () => registry,
+      reactivate: async (id: string) => {
+        reloaded.push(id);
+      },
+    };
+    await syncTeamsBotConfig(deps, IDENTITY);
+    await syncTeamsBotConfig(deps, IDENTITY);
+    // A live channel plugin is serving traffic; bouncing it for a write that
+    // changed nothing would be a self-inflicted outage.
+    assert.deepEqual(reloaded, [CHANNEL_TEAMS_PLUGIN_ID]);
+  });
+
+  it('leaves the legacy entry 0 and a hand-tuned foreign entry byte-identical', async () => {
+    const before = JSON.stringify([LEGACY_ENTRY, FOREIGN_ENTRY], null, 2);
+    const registry = registryWith({ [TEAMS_BOTS_CONFIG_KEY]: before });
+    await syncTeamsBotConfig({ getInstalledRegistry: () => registry }, IDENTITY);
+    await syncTeamsBotConfig({ getInstalledRegistry: () => registry }, IDENTITY);
+    const entries = storedEntries(registry);
+    assert.equal(entries.length, 3);
+    // Byte-identical, not merely equivalent: no re-ordering, no re-defaulting,
+    // and the extra `note` key an operator added survives.
+    assert.equal(JSON.stringify(entries[0]), JSON.stringify(LEGACY_ENTRY));
+    assert.equal(JSON.stringify(entries[1]), JSON.stringify(FOREIGN_ENTRY));
+    assert.equal(entries[2]?.['botSlug'], 'hr-bot');
+  });
+
+  it('updates its own entry when an identity field changed (new display name)', async () => {
+    const registry = registryWith({
+      [TEAMS_BOTS_CONFIG_KEY]: JSON.stringify([LEGACY_ENTRY]),
+    });
+    const deps = { getInstalledRegistry: () => registry };
+    await syncTeamsBotConfig(deps, IDENTITY);
+    const outcome = await syncTeamsBotConfig(deps, {
+      ...IDENTITY,
+      displayName: 'HR Bot (Renamed)',
+    });
+    assert.equal(outcome.status, 'synced');
+    const entries = storedEntries(registry);
+    assert.equal(entries.length, 2);
+    assert.equal(entries[1]?.['displayName'], 'HR Bot (Renamed)');
+  });
+
+  it('skips cleanly when channel-teams is not installed', async () => {
+    const registry = new InMemoryInstalledRegistry();
+    const outcome = await syncTeamsBotConfig(
+      { getInstalledRegistry: () => registry },
+      IDENTITY,
+    );
+    assert.deepEqual(outcome, { status: 'skipped', reason: 'plugin_not_installed' });
+  });
+
+  it('skips cleanly when no installed registry is bound', async () => {
+    const outcome = await syncTeamsBotConfig(
+      { getInstalledRegistry: () => undefined },
+      IDENTITY,
+    );
+    assert.deepEqual(outcome, { status: 'skipped', reason: 'registry_unavailable' });
+  });
+
+  it('skips an identity that has no app registration yet', async () => {
+    const registry = registryWith({});
+    const outcome = await syncTeamsBotConfig(
+      { getInstalledRegistry: () => registry },
+      { ...IDENTITY, appId: null },
+    );
+    assert.deepEqual(outcome, { status: 'skipped', reason: 'identity_incomplete' });
+  });
+
+  it('throws instead of overwriting a config value it cannot read', async () => {
+    const registry = registryWith({ [TEAMS_BOTS_CONFIG_KEY]: '{ not json' });
+    await assert.rejects(
+      syncTeamsBotConfig({ getInstalledRegistry: () => registry }, IDENTITY),
+      TeamsBotsConfigSyncError,
+    );
+    // The operator's (broken, but theirs) value is still there.
+    assert.equal(
+      registry.get(CHANNEL_TEAMS_PLUGIN_ID)?.config[TEAMS_BOTS_CONFIG_KEY],
+      '{ not json',
+    );
+  });
+
+  it('propagates a reactivation failure AFTER the config was written', async () => {
+    const registry = registryWith({});
+    await assert.rejects(
+      syncTeamsBotConfig(
+        {
+          getInstalledRegistry: () => registry,
+          reactivate: async () => {
+            throw new Error('activate() blew up');
+          },
+        },
+        IDENTITY,
+      ),
+      /activate\(\) blew up/,
+    );
+    // The write landed; only the hot reload did not. A restart picks it up,
+    // and the caller surfaces the warning.
+    assert.equal(storedEntries(registry).length, 1);
+  });
+
+  it('never writes secret material — only the opaque vault REF', async () => {
+    const registry = registryWith({});
+    await syncTeamsBotConfig({ getInstalledRegistry: () => registry }, IDENTITY);
+    const serialized = JSON.stringify(registry.get(CHANNEL_TEAMS_PLUGIN_ID)?.config);
+    assert.ok(serialized.includes('teams_bot_password:app-hr-0001'));
+    assert.ok(!serialized.includes('appPassword"'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The status projection the operator UI renders from
+// ---------------------------------------------------------------------------
+
+describe('projectTeamsBotsConfigSyncStatus', () => {
+  it('reports synced after a sync and out_of_sync after a hand edit', async () => {
+    const registry = registryWith({});
+    const deps = { getInstalledRegistry: () => registry };
+    assert.equal(projectTeamsBotsConfigSyncStatus(deps, IDENTITY).state, 'missing');
+    await syncTeamsBotConfig(deps, IDENTITY);
+    assert.equal(projectTeamsBotsConfigSyncStatus(deps, IDENTITY).state, 'synced');
+
+    const edited = storedEntries(registry);
+    edited[0] = { ...(edited[0] ?? {}), displayName: 'hand edited' };
+    await registry.updateConfig(CHANNEL_TEAMS_PLUGIN_ID, {
+      [TEAMS_BOTS_CONFIG_KEY]: JSON.stringify(edited),
+    });
+    assert.equal(projectTeamsBotsConfigSyncStatus(deps, IDENTITY).state, 'out_of_sync');
+  });
+
+  it('names each reason the entry cannot be there', () => {
+    assert.equal(
+      projectTeamsBotsConfigSyncStatus({ getInstalledRegistry: () => undefined }, IDENTITY)
+        .state,
+      'unknown',
+    );
+    assert.equal(
+      projectTeamsBotsConfigSyncStatus(
+        { getInstalledRegistry: () => new InMemoryInstalledRegistry() },
+        IDENTITY,
+      ).state,
+      'plugin_not_installed',
+    );
+    assert.equal(
+      projectTeamsBotsConfigSyncStatus(
+        { getInstalledRegistry: () => registryWith({}) },
+        { ...IDENTITY, appId: null },
+      ).state,
+      'not_applicable',
+    );
+    assert.equal(
+      projectTeamsBotsConfigSyncStatus(
+        {
+          getInstalledRegistry: () =>
+            registryWith({ [TEAMS_BOTS_CONFIG_KEY]: '{ not json' }),
+        },
+        IDENTITY,
+      ).state,
+      'unreadable',
+    );
+  });
+
+  it('carries the plugin id and config key the UI names in its copy', () => {
+    const status = projectTeamsBotsConfigSyncStatus(
+      { getInstalledRegistry: () => registryWith({}) },
+      IDENTITY,
+    );
+    assert.equal(status.plugin_id, CHANNEL_TEAMS_PLUGIN_ID);
+    assert.equal(status.config_key, 'teams_bots');
+  });
+});

--- a/middleware/test/teamsProvisioningJob.test.ts
+++ b/middleware/test/teamsProvisioningJob.test.ts
@@ -5,6 +5,7 @@ import type { TimerSeam } from '../src/plugins/jobScheduler.js';
 import {
   armNotConfiguredDetail,
   classifyTeamsProvisioningError,
+  configSyncFailedDetail,
   consentMissingDetail,
   throttledDetail,
   TeamsProvisioningJobRunner,
@@ -13,6 +14,7 @@ import {
   type TeamsIdentityJobRecord,
   type TeamsIdentityJobStore,
   type TeamsIdentityJobUpdate,
+  type TeamsBotsConfigSyncPort,
   type TeamsProvisionerPort,
   type TeamsProvisioningState,
 } from '../src/services/teamsProvisioningJob.js';
@@ -196,6 +198,7 @@ function makeRunner(opts: {
   baseRetryDelayMs?: number;
   maxRetryDelayMs?: number;
   getProvisioner?: () => TeamsProvisionerPort;
+  syncBotConfig?: TeamsBotsConfigSyncPort;
 } = {}): RunnerFixture {
   const store = makeStore(opts.storeOverrides);
   const provisioner = makeProvisioner(opts.behaviour);
@@ -212,6 +215,7 @@ function makeRunner(opts: {
     ...(opts.maxRetryDelayMs !== undefined
       ? { maxRetryDelayMs: opts.maxRetryDelayMs }
       : {}),
+    ...(opts.syncBotConfig ? { syncBotConfig: opts.syncBotConfig } : {}),
     log: () => {},
   });
   return { runner, store, provisioner, timers };
@@ -814,5 +818,113 @@ describe('classifyTeamsProvisioningError', () => {
     ]) {
       assert.deepEqual(classifyTeamsProvisioningError(raw), { code: 'unknown', raw });
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #910 — the `teams_bots` config write that ends the run
+//
+// The point of these tests is the FAILURE posture, not the happy path: by the
+// time this port runs, the Entra app, the Azure bot, the catalog entry and the
+// team install all exist in Azure and are this agent's. Failing the run over a
+// config write would report a provisioning failure that did not happen.
+// ---------------------------------------------------------------------------
+
+describe('TeamsProvisioningJobRunner — teams_bots config sync (#910)', () => {
+  it('syncs the identity after reaching installed', async () => {
+    const seen: TeamsIdentityJobRecord[] = [];
+    const { runner, store } = makeRunner({
+      syncBotConfig: async (identity) => {
+        seen.push(identity);
+        return { status: 'synced' };
+      },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'installed');
+    assert.equal(seen.length, 1);
+    // The record handed over is the row AFTER the terminal write, so the
+    // provisioned app/tenant are on it — a projection built from a pre-install
+    // snapshot would be `null` and silently write nothing.
+    assert.equal(seen[0]?.state, 'installed');
+    assert.ok(seen[0]?.appId);
+    assert.ok(seen[0]?.tenantId);
+    assert.equal(store.row?.lastError, null);
+  });
+
+  it('keeps the run installed and records an ACTIONABLE warning when the write fails', async () => {
+    const { runner, store } = makeRunner({
+      syncBotConfig: async () => {
+        throw new Error('teams_bots setup field is not valid JSON');
+      },
+    });
+    const result = await runner.enqueue(REQUEST);
+    // Nothing is rolled back and nothing is retried: the identity is real.
+    assert.equal(result.status, 'installed');
+    assert.equal(store.row?.state, 'installed');
+    const lastError = store.row?.lastError ?? '';
+    assert.ok(lastError.startsWith('config_sync_failed:'));
+    const detail = classifyTeamsProvisioningError(lastError);
+    assert.equal(detail.code, 'config_sync_failed');
+    assert.equal(detail.reason, 'teams_bots setup field is not valid JSON');
+  });
+
+  it('re-asserts the config on a re-run of an ALREADY installed identity', async () => {
+    // The chain has nothing left to do, but an operator may have renamed the
+    // agent or deleted the entry from the plugin config — "re-run provisioning"
+    // must still end with the bot configured.
+    const calls: string[] = [];
+    const { runner, store } = makeRunner({
+      storeOverrides: {
+        state: 'installed',
+        displayName: 'HR Bot (Renamed)',
+        appId: 'app-1',
+        tenantId: 'tenant-1',
+        teamsAppId: 'catalog-1',
+      },
+      syncBotConfig: async (identity) => {
+        calls.push(identity.displayName);
+        return { status: 'synced' };
+      },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'installed');
+    assert.deepEqual(calls, ['HR Bot (Renamed)']);
+    // No chain step ran — the early return is still an early return.
+    assert.deepEqual(store.updates, []);
+  });
+
+  it('is a no-op when no sync port is wired (the pre-#910 manual path)', async () => {
+    const { runner, store } = makeRunner();
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(result.status, 'installed');
+    assert.equal(store.row?.lastError, null);
+  });
+
+  it('does not turn a skip or a no-op report into an error', async () => {
+    for (const report of [
+      { status: 'skipped' as const, reason: 'plugin_not_installed' },
+      { status: 'unchanged' as const },
+    ]) {
+      const { runner, store } = makeRunner({ syncBotConfig: async () => report });
+      const result = await runner.enqueue(REQUEST);
+      assert.equal(result.status, 'installed');
+      assert.equal(store.row?.lastError, null);
+    }
+  });
+
+  it('round-trips the config_sync_failed sentence through its own classifier', () => {
+    const detail = classifyTeamsProvisioningError(
+      configSyncFailedDetail('registry write failed [boom]\n  twice'),
+    );
+    assert.equal(detail.code, 'config_sync_failed');
+    // Brackets and newlines are stripped by the producer so the `[...]` group
+    // the classifier reads can never be cut short by the reason itself.
+    assert.equal(detail.reason, 'registry write failed boom twice');
+  });
+
+  it('round-trips an empty reason to an empty reason, not to "[]"', () => {
+    const detail = classifyTeamsProvisioningError(configSyncFailedDetail('   '));
+    assert.equal(detail.code, 'config_sync_failed');
+    assert.equal(detail.reason, '');
   });
 });

--- a/middleware/test/teamsProvisioningJob.test.ts
+++ b/middleware/test/teamsProvisioningJob.test.ts
@@ -893,6 +893,40 @@ describe('TeamsProvisioningJobRunner — teams_bots config sync (#910)', () => {
     assert.deepEqual(store.updates, []);
   });
 
+  it('retires its OWN stale warning when a re-run finally writes the config', async () => {
+    const { runner, store } = makeRunner({
+      storeOverrides: {
+        state: 'installed',
+        appId: 'app-1',
+        tenantId: 'tenant-1',
+        teamsAppId: 'catalog-1',
+        lastError: configSyncFailedDetail('teams_bots was not valid JSON'),
+      },
+      syncBotConfig: async () => ({ status: 'synced' }),
+    });
+    await runner.enqueue(REQUEST);
+    // Otherwise the operator who followed the warning's own advice ("re-run
+    // provisioning to retry the write") would still be staring at it.
+    assert.equal(store.row?.lastError, null);
+    assert.equal(store.row?.state, 'installed');
+  });
+
+  it('does NOT clear an unrelated error it did not write', async () => {
+    const stale = consentMissingDetail(['Application.ReadWrite.All']);
+    const { runner, store } = makeRunner({
+      storeOverrides: {
+        state: 'installed',
+        appId: 'app-1',
+        tenantId: 'tenant-1',
+        teamsAppId: 'catalog-1',
+        lastError: stale,
+      },
+      syncBotConfig: async () => ({ status: 'synced' }),
+    });
+    await runner.enqueue(REQUEST);
+    assert.equal(store.row?.lastError, stale);
+  });
+
   it('is a no-op when no sync port is wired (the pre-#910 manual path)', async () => {
     const { runner, store } = makeRunner();
     const result = await runner.enqueue(REQUEST);

--- a/web-ui/app/_lib/__tests__/teamsIdentity.test.ts
+++ b/web-ui/app/_lib/__tests__/teamsIdentity.test.ts
@@ -4,13 +4,17 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import type { TeamsIdentityLastErrorDetailDto } from '../agents';
+import {
+  TEAMS_BOTS_SYNC_STATES,
+  type TeamsIdentityLastErrorDetailDto,
+} from '../agents';
 import {
   ENTRA_ADMIN_CONSENT_DOCS_URL,
   TEAMS_BOT_SECRET_REF_PREFIX,
   TEAMS_PROVISIONING_STATES,
   formatTeamsBotsConfig,
   isTeamsBotSecretRef,
+  isTeamsBotConfigApplied,
   parseTeamsIdentityEnvelope,
   teamsBotConfigMessages,
   teamsIdentityErrorLink,
@@ -90,6 +94,17 @@ const UNKNOWN_DETAIL: TeamsIdentityLastErrorDetailDto = {
   code: 'unknown',
   raw: 'ENOTFOUND graph.microsoft.com',
 };
+/** #910 — the one detail that is a WARNING: the identity is fine, only the
+ *  automatic `teams_bots` write did not land. */
+const CONFIG_SYNC_DETAIL: TeamsIdentityLastErrorDetailDto = {
+  code: 'config_sync_failed',
+  reason: 'teams_bots setup field is not valid JSON',
+  raw: 'config_sync_failed: [teams_bots setup field is not valid JSON] — …',
+};
+const CONFIG_SYNC_DETAIL_NO_REASON: TeamsIdentityLastErrorDetailDto = {
+  code: 'config_sync_failed',
+  raw: 'config_sync_failed: [] — …',
+};
 
 // ---------------------------------------------------------------------------
 // The producer contract — read out of the middleware, not assumed
@@ -130,8 +145,24 @@ describe('the classified sentences are the ones the middleware writes', () => {
   });
 
   it('the secret ref convention is still the opaque teams_bot_password handle', () => {
-    const routes = readMiddleware('src', 'routes', 'operatorAgents.ts');
-    expect(routes).toContain(`return \`${TEAMS_BOT_SECRET_REF_PREFIX}\${record.appId}\``);
+    // #910 moved the projection out of the route and into the service that
+    // also WRITES it, so the paste block and the written entry cannot drift.
+    const sync = readMiddleware('src', 'services', 'teamsBotsConfigSync.ts');
+    expect(sync).toContain(`return \`${TEAMS_BOT_SECRET_REF_PREFIX}\${record.appId}\``);
+  });
+
+  it('teamsProvisioningJob still writes the config_sync_failed prefix (#910)', () => {
+    expect(job).toContain('`config_sync_failed: [');
+  });
+
+  it('the sync-state vocabulary matches the middleware projection (#910)', () => {
+    const sync = readMiddleware('src', 'services', 'teamsBotsConfigSync.ts');
+    const block = /export type TeamsBotsConfigSyncState =([\s\S]*?);/.exec(sync);
+    expect(block).not.toBeNull();
+    const serverStates = [...(block?.[1] ?? '').matchAll(/'([a-z_]+)'/g)].map((m) => m[1]);
+    // Order is not a contract here; membership is — an unknown state would
+    // render a bare i18n key on the operator screen.
+    expect([...serverStates].sort()).toEqual([...TEAMS_BOTS_SYNC_STATES].sort());
   });
 });
 
@@ -166,6 +197,11 @@ function envelope(overrides: Record<string, unknown> = {}): Record<string, unkno
       tenantId: '99999999-8888-7777-6666-555555555555',
       appPasswordSecretRef:
         'teams_bot_password:11111111-2222-3333-4444-555555555555',
+    },
+    teams_bots_sync: {
+      state: 'missing',
+      plugin_id: '@omadia/channel-teams',
+      config_key: 'teams_bots',
     },
     ...overrides,
   };
@@ -278,6 +314,8 @@ const ALL_DETAILS: readonly TeamsIdentityLastErrorDetailDto[] = [
   ARM_DETAIL_NO_FIELDS,
   THROTTLED_DETAIL_WITH_HINT,
   THROTTLED_DETAIL_NO_HINT,
+  CONFIG_SYNC_DETAIL,
+  CONFIG_SYNC_DETAIL_NO_REASON,
   UNKNOWN_DETAIL,
 ];
 
@@ -297,10 +335,23 @@ function everyEmittedKey(): readonly string[] {
     if (link) keys.add(link.labelKey);
   }
 
-  const ready = parseTeamsIdentityEnvelope(envelope());
   const notReady = parseTeamsIdentityEnvelope(envelope({ teams_bot: null }));
-  if (ready) collect(teamsBotConfigMessages(ready));
   if (notReady) collect(teamsBotConfigMessages(notReady));
+  // #910 — one view per sync state, so no state can reach a screen as a bare
+  // key. `unknown` is included deliberately: it is what a middleware that
+  // predates this field produces.
+  for (const state of TEAMS_BOTS_SYNC_STATES) {
+    const view = parseTeamsIdentityEnvelope(
+      envelope({
+        teams_bots_sync: {
+          state,
+          plugin_id: '@omadia/channel-teams',
+          config_key: 'teams_bots',
+        },
+      }),
+    );
+    if (view) collect(teamsBotConfigMessages(view));
+  }
 
   return [...keys].sort();
 }
@@ -369,13 +420,88 @@ describe('i18n coverage', () => {
     });
   });
 
-  it('tells the operator the paste is manual', () => {
-    const view = parseTeamsIdentityEnvelope(envelope())!;
-    expect(teamsBotConfigMessages(view).map((m) => m.key)).toEqual([
-      'teamsBot.manualStep',
-      'teamsBot.instructions',
-      'teamsBot.secretRefNote',
-      'teamsBot.followUp',
+  it('names the reason the automatic teams_bots write did not land (#910)', () => {
+    expect(teamsIdentityErrorMessages(CONFIG_SYNC_DETAIL).map((m) => m.key)).toEqual([
+      'errors.config_sync_failed.what',
+      'errors.config_sync_failed.reason',
+      'errors.config_sync_failed.next',
     ]);
+    expect(teamsIdentityErrorMessages(CONFIG_SYNC_DETAIL)[1]?.values).toEqual({
+      reason: 'teams_bots setup field is not valid JSON',
+    });
+  });
+
+  it('omits the reason line when the server sent none (#910)', () => {
+    expect(
+      teamsIdentityErrorMessages(CONFIG_SYNC_DETAIL_NO_REASON).map((m) => m.key),
+    ).toEqual(['errors.config_sync_failed.what', 'errors.config_sync_failed.next']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #910 — the copy answers "do I still have to paste this?"
+// ---------------------------------------------------------------------------
+
+describe('teamsBotConfigMessages reflects the live sync state', () => {
+  function messagesFor(state: string): readonly string[] {
+    const view = parseTeamsIdentityEnvelope(
+      envelope({
+        teams_bots_sync: {
+          state,
+          plugin_id: '@omadia/channel-teams',
+          config_key: 'teams_bots',
+        },
+      }),
+    );
+    return teamsBotConfigMessages(view!).map((m) => m.key);
+  }
+
+  it('says "already applied" and drops the paste instructions when synced', () => {
+    expect(messagesFor('synced')).toEqual([
+      'teamsBot.applied',
+      'teamsBot.appliedFallback',
+      'teamsBot.secretRefNote',
+    ]);
+    // The block itself is still rendered by the component — only the "you
+    // must do this" framing goes away.
+    expect(isTeamsBotConfigApplied('synced')).toBe(true);
+  });
+
+  it('keeps the paste instructions for every state that is not synced', () => {
+    for (const state of TEAMS_BOTS_SYNC_STATES) {
+      if (state === 'synced') continue;
+      expect(isTeamsBotConfigApplied(state)).toBe(false);
+      expect(messagesFor(state)).toEqual([
+        `teamsBot.notApplied.${state}`,
+        'teamsBot.instructions',
+        'teamsBot.secretRefNote',
+      ]);
+    }
+  });
+
+  it('treats an absent teams_bots_sync as unknown, never as synced', () => {
+    // A middleware that predates #910 omits the field entirely. Claiming
+    // "already applied" there would strand the operator with a silent bot.
+    const view = parseTeamsIdentityEnvelope(envelope({ teams_bots_sync: undefined }))!;
+    expect(view.botsSync.state).toBe('unknown');
+    expect(teamsBotConfigMessages(view)[0]?.key).toBe('teamsBot.notApplied.unknown');
+  });
+
+  it('carries the plugin id and the setup-field name as ICU arguments', () => {
+    const view = parseTeamsIdentityEnvelope(
+      envelope({
+        teams_bots_sync: {
+          state: 'missing',
+          plugin_id: '@omadia/channel-teams',
+          config_key: 'teams_bots',
+        },
+      }),
+    )!;
+    const messages = teamsBotConfigMessages(view);
+    expect(messages[0]?.values).toEqual({
+      field: 'teams_bots',
+      plugin: '@omadia/channel-teams',
+    });
+    expect(messages[1]?.values).toEqual({ field: 'teams_bots' });
   });
 });

--- a/web-ui/app/_lib/agents.ts
+++ b/web-ui/app/_lib/agents.ts
@@ -451,6 +451,10 @@ export const TEAMS_IDENTITY_LAST_ERROR_CODES = [
   'consent_missing',
   'arm_not_configured',
   'throttled',
+  // #910 — the one code that is a WARNING, not a failure: the identity is
+  // provisioned and installed, only the automatic `teams_bots` write did not
+  // land, so the operator falls back to the copy-paste block.
+  'config_sync_failed',
   'unknown',
 ] as const;
 
@@ -472,6 +476,10 @@ export interface TeamsIdentityLastErrorDetailDto {
   fields?: string[];
   /** Backoff hint (`throttled`). */
   retryAfterSeconds?: number;
+  /** Why the automatic `teams_bots` write did not land
+   *  (`config_sync_failed`) — a technical sentence, rendered as the ICU
+   *  argument of a localized line, never as the copy itself. */
+  reason?: string;
   raw: string;
 }
 
@@ -508,6 +516,7 @@ export function parseTeamsIdentityLastErrorDetail(
   const scopes = stringList(obj?.['scopes']);
   const fields = stringList(obj?.['fields']);
   const retry = obj?.['retryAfterSeconds'];
+  const reason = obj?.['reason'];
   const rawText = obj?.['raw'];
   return {
     code,
@@ -516,6 +525,7 @@ export function parseTeamsIdentityLastErrorDetail(
     ...(typeof retry === 'number' && Number.isFinite(retry)
       ? { retryAfterSeconds: retry }
       : {}),
+    ...(typeof reason === 'string' && reason !== '' ? { reason } : {}),
     raw: typeof rawText === 'string' && rawText !== '' ? rawText : lastError,
   };
 }
@@ -557,6 +567,65 @@ export interface TeamsBotConfigEntryDto {
   appPasswordSecretRef: string;
 }
 
+/**
+ * #910 — is the `teams_bot` entry above ACTUALLY in the channel-teams plugin
+ * config right now?
+ *
+ * Derived server-side from the live plugin config on every read, never from a
+ * stored "we synced it" flag: an operator can edit or delete the entry at any
+ * time, and a remembered intention would then tell this screen a comfortable
+ * lie. Additive — a middleware predating #910 omits the field, which the
+ * boundary narrows to `unknown`.
+ */
+export const TEAMS_BOTS_SYNC_STATES = [
+  'synced',
+  'out_of_sync',
+  'missing',
+  'plugin_not_installed',
+  'unreadable',
+  'not_applicable',
+  'unknown',
+] as const;
+
+export type TeamsBotsSyncState = (typeof TEAMS_BOTS_SYNC_STATES)[number];
+
+const TEAMS_BOTS_SYNC_STATE_SET: ReadonlySet<string> = new Set(
+  TEAMS_BOTS_SYNC_STATES,
+);
+
+export interface TeamsBotsSyncDto {
+  state: TeamsBotsSyncState;
+  /** The plugin the entry belongs to — named in the operator copy. */
+  plugin_id: string;
+  /** The setup field the entry lives in (`teams_bots`). */
+  config_key: string;
+}
+
+/** Narrow `teams_bots_sync` at the boundary. Total: an absent or unknown
+ *  shape yields `unknown`, which renders as "we cannot tell — the manual
+ *  block below still works". */
+export function parseTeamsBotsSync(value: unknown): TeamsBotsSyncDto {
+  const obj =
+    value !== null && typeof value === 'object'
+      ? (value as Record<string, unknown>)
+      : null;
+  const rawState = obj?.['state'];
+  const pluginId = obj?.['plugin_id'];
+  const configKey = obj?.['config_key'];
+  return {
+    state:
+      typeof rawState === 'string' && TEAMS_BOTS_SYNC_STATE_SET.has(rawState)
+        ? (rawState as TeamsBotsSyncState)
+        : 'unknown',
+    plugin_id:
+      typeof pluginId === 'string' && pluginId !== ''
+        ? pluginId
+        : '@omadia/channel-teams',
+    config_key:
+      typeof configKey === 'string' && configKey !== '' ? configKey : 'teams_bots',
+  };
+}
+
 export interface TeamsIdentityStatusDto {
   ok: boolean;
   agent: string;
@@ -567,6 +636,8 @@ export interface TeamsIdentityStatusDto {
   provisioner_installed: boolean;
   identity: TeamsIdentityDto;
   teams_bot: TeamsBotConfigEntryDto | null;
+  /** Additive (#910) — see {@link parseTeamsBotsSync}. */
+  teams_bots_sync?: unknown;
 }
 
 /** `GET /v1/operator/agents/:slug/teams-identity`. Rejects with a 404

--- a/web-ui/app/_lib/teamsIdentity.ts
+++ b/web-ui/app/_lib/teamsIdentity.ts
@@ -32,14 +32,22 @@
  *      belt-and-braces shape check so a value that is not ref-shaped drops the
  *      whole block instead of being rendered into a copy-paste box.
  *
- * OUT OF SCOPE, ON PURPOSE: pushing this block into channel-teams' config
- * automatically. The operator pastes it, and the copy says so plainly rather
- * than letting them assume a sync that does not exist. Automatic `teams_bots[]`
- * sync is the documented follow-up (see the route's own note at
- * `operatorAgents.ts`, "`teams_bots[]` sync (follow-up)").
+ * SINCE #910 THE PASTE IS A FALLBACK, NOT THE PATH. Provisioning writes this
+ * entry into the channel-teams config itself and reloads the plugin. The block
+ * stays — for operators who configure explicitly, and for every case where the
+ * automatic write could not land (plugin not installed, a value the sync
+ * refuses to overwrite, a failed write). Which of the two applies is not
+ * guessed here: the route reports the LIVE state as `teams_bots_sync`, and
+ * {@link teamsBotConfigMessages} turns it into copy that either says "already
+ * applied" or says why the operator still has to paste.
  */
 
-import type { TeamsIdentityLastErrorDetailDto } from './agents';
+import {
+  parseTeamsBotsSync,
+  type TeamsBotsSyncDto,
+  type TeamsBotsSyncState,
+  type TeamsIdentityLastErrorDetailDto,
+} from './agents';
 
 /**
  * An i18n key plus its ICU arguments. Every user-facing string this module and
@@ -143,6 +151,8 @@ export interface TeamsIdentityView {
   readonly updatedAt: string | null;
   /** `null` until the Entra app exists, or when the ref is not ref-shaped. */
   readonly teamsBot: TeamsBotConfigEntry | null;
+  /** #910 — whether {@link teamsBot} is actually configured in the plugin. */
+  readonly botsSync: TeamsBotsSyncDto;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -217,6 +227,7 @@ export function parseTeamsIdentityEnvelope(value: unknown): TeamsIdentityView | 
     createdAt: optionalString(identity.created_at),
     updatedAt: optionalString(identity.updated_at),
     teamsBot: parseTeamsBot(value.teams_bot),
+    botsSync: parseTeamsBotsSync(value.teams_bots_sync),
   };
 }
 
@@ -248,18 +259,53 @@ export function formatTeamsBotsConfig(
 }
 
 /**
- * The copy around the block. Says the quiet part out loud: pasting is a MANUAL
- * step, and nothing syncs it for you.
+ * Sync states in which provisioning has NOT put the entry into the plugin
+ * config, so the operator still has to paste it. `synced` is the only state
+ * where the manual step is genuinely done; every other state — including
+ * `unknown`, where this build cannot tell — keeps the instructions visible,
+ * because a missing instruction is worse than a redundant one.
+ */
+export function isTeamsBotConfigApplied(state: TeamsBotsSyncState): boolean {
+  return state === 'synced';
+}
+
+/**
+ * The copy around the block.
+ *
+ * Since #910 the leading line is the ANSWER to "do I still have to do
+ * something?": `applied` when provisioning wrote the entry itself, otherwise a
+ * per-state reason followed by the paste instructions. The block itself is
+ * rendered either way — an operator who configures explicitly, or who is
+ * diffing against what is live, wants to see it regardless.
  */
 export function teamsBotConfigMessages(
   view: TeamsIdentityView,
 ): readonly LocalizedMessage[] {
   if (!view.teamsBot) return [{ key: 'teamsBot.notReady' }];
+  const state = view.botsSync.state;
+  if (isTeamsBotConfigApplied(state)) {
+    return [
+      { key: 'teamsBot.applied', values: { plugin: view.botsSync.plugin_id } },
+      { key: 'teamsBot.appliedFallback' },
+      { key: 'teamsBot.secretRefNote' },
+    ];
+  }
   return [
-    { key: 'teamsBot.manualStep' },
-    { key: 'teamsBot.instructions', values: { field: 'teams_bots' } },
+    {
+      key: `teamsBot.notApplied.${state}`,
+      // Both arguments go to every state's line: which plugin, and which
+      // setup field. Only some states name them, and ICU ignores the rest —
+      // that beats a per-state argument table that drifts from the copy.
+      values: {
+        field: view.botsSync.config_key,
+        plugin: view.botsSync.plugin_id,
+      },
+    },
+    {
+      key: 'teamsBot.instructions',
+      values: { field: view.botsSync.config_key },
+    },
     { key: 'teamsBot.secretRefNote' },
-    { key: 'teamsBot.followUp' },
   ];
 }
 
@@ -333,6 +379,15 @@ export function teamsIdentityErrorMessages(
     messages.push({
       key: `${base}.fields`,
       values: { fields: fields.join(', '), count: fields.length },
+    });
+  }
+
+  // #910 — the write failure carries a technical sentence, shown as an ICU
+  // argument on its own line rather than pasted into the copy.
+  if (detail.code === 'config_sync_failed' && (detail.reason ?? '') !== '') {
+    messages.push({
+      key: `${base}.reason`,
+      values: { reason: detail.reason as string },
     });
   }
 

--- a/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentity.config.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentity.config.test.tsx
@@ -83,6 +83,14 @@ function statusDto(
       updated_at: '2026-08-27T08:05:00.000Z',
     },
     teams_bot: TEAMS_BOT,
+    // #910 — the live sync signal. `missing` is the pre-sync default, i.e.
+    // "provisioning has not written it (yet)", which is what most of the
+    // block-rendering assertions below want.
+    teams_bots_sync: {
+      state: 'missing',
+      plugin_id: '@omadia/channel-teams',
+      config_key: 'teams_bots',
+    },
     ...overrides,
   };
 }
@@ -138,23 +146,70 @@ describe('AgentTeamsIdentity — teams_bots config block (#860 W2a)', () => {
     ]);
   });
 
-  it('states plainly that the paste is manual and that automatic sync is a follow-up', async () => {
+  it('asks for the manual paste when the entry is NOT in the plugin config (#910)', async () => {
     renderWithIntl(<AgentTeamsIdentity slug="sales-bot" />);
 
-    expect(
-      await screen.findByText(
-        'One manual step is left: this block has to be pasted into the Teams channel plugin by hand.',
-      ),
-    ).toBeTruthy();
+    const headline = await screen.findByTestId('teams-bot-sync-headline');
+    expect(headline.textContent).toContain('One manual step is left');
     expect(
       screen.getByText(
         'Copy the block and paste it into the teams_bots setup field of the Teams channel plugin, then save.',
       ),
     ).toBeTruthy();
-    // The out-of-scope promise, said out loud rather than left to assumption.
+  });
+
+  it('says the configuration is already applied once provisioning wrote it (#910)', async () => {
+    mockGet.mockResolvedValue(
+      statusDto({
+        teams_bots_sync: {
+          state: 'synced',
+          plugin_id: '@omadia/channel-teams',
+          config_key: 'teams_bots',
+        },
+      }),
+    );
+    renderWithIntl(<AgentTeamsIdentity slug="sales-bot" />);
+
+    const headline = await screen.findByTestId('teams-bot-sync-headline');
+    expect(headline.textContent).toContain('Already applied');
+    expect(headline.textContent).toContain('@omadia/channel-teams');
+    // The instruction to paste is gone — but the block itself is not: an
+    // operator diffing against what is live still needs to see it.
+    expect(
+      screen.queryByText(
+        'Copy the block and paste it into the teams_bots setup field of the Teams channel plugin, then save.',
+      ),
+    ).toBeNull();
+    expect(await readRenderedBlock()).toEqual([TEAMS_BOT]);
+  });
+
+  it('explains a hand-edited plugin entry rather than claiming success (#910)', async () => {
+    mockGet.mockResolvedValue(
+      statusDto({
+        teams_bots_sync: {
+          state: 'out_of_sync',
+          plugin_id: '@omadia/channel-teams',
+          config_key: 'teams_bots',
+        },
+      }),
+    );
+    renderWithIntl(<AgentTeamsIdentity slug="sales-bot" />);
+
+    const headline = await screen.findByTestId('teams-bot-sync-headline');
+    expect(headline.textContent).toContain('a different configuration');
+  });
+
+  it('falls back to "cannot tell" when the middleware sends no sync state (#910)', async () => {
+    // A middleware predating #910 omits the field. Claiming "already applied"
+    // there would strand the operator with a bot that never answers.
+    mockGet.mockResolvedValue(statusDto({ teams_bots_sync: undefined }));
+    renderWithIntl(<AgentTeamsIdentity slug="sales-bot" />);
+
+    const headline = await screen.findByTestId('teams-bot-sync-headline');
+    expect(headline.textContent).toContain('cannot be determined');
     expect(
       screen.getByText(
-        'Writing this configuration automatically is a planned follow-up and does not happen today.',
+        'Copy the block and paste it into the teams_bots setup field of the Teams channel plugin, then save.',
       ),
     ).toBeTruthy();
   });

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentity.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentity.tsx
@@ -14,6 +14,8 @@ import {
 } from '../../../../_lib/agents';
 import {
   formatTeamsBotsConfig,
+  isTeamsBotConfigApplied,
+  teamsBotConfigMessages,
   parseTeamsIdentityEnvelope,
 } from '../../../../_lib/teamsIdentity';
 import { humanizeApiError } from '../../_components/AgentsDashboard';
@@ -418,6 +420,14 @@ function ReadyPanel(props: {
  * `app_registered` step. That is a normal early state, not missing data, so it
  * gets an explanatory line rather than an empty box.
  *
+ * SINCE #910 THE PASTE IS A FALLBACK. Provisioning writes this entry into the
+ * channel-teams config itself, so the copy above the block is not a fixed
+ * "do this by hand" instruction any more: it is derived from the route's
+ * `teams_bots_sync` field (the LIVE state of the plugin config) and either
+ * says the configuration is already applied or names the reason it is not.
+ * The block itself is rendered either way — an operator diffing against what
+ * is configured, or configuring a second deployment, still wants to see it.
+ *
  * `appPasswordSecretRef` is the opaque vault ref `teams_bot_password:<appId>`,
  * never the password. Nothing here fetches or reveals a secret value, and the
  * ref is never logged.
@@ -437,6 +447,15 @@ function TeamsBotConfigBlock(props: {
     () => (teamsBot ? formatTeamsBotsConfig([teamsBot]) : null),
     [teamsBot],
   );
+  // #910 — the copy is DERIVED from the server's live sync state, not
+  // hard-coded here. The first line answers "do I still have to do
+  // something?"; the rest is the instruction set, which stays visible for
+  // every state except `synced`.
+  const messages = useMemo(
+    () => (view ? teamsBotConfigMessages(view) : []),
+    [view],
+  );
+  const applied = view ? isTeamsBotConfigApplied(view.botsSync.state) : false;
 
   const onCopy = useCallback(async (): Promise<void> => {
     if (block === null) return;
@@ -461,12 +480,23 @@ function TeamsBotConfigBlock(props: {
         </p>
       ) : (
         <>
-          <p className="text-xs font-medium text-[color:var(--fg-strong)]">
-            {t('teamsIdentity.teamsBot.manualStep')}
-          </p>
-          <p className="text-xs text-[color:var(--fg-muted)]">
-            {t('teamsIdentity.teamsBot.instructions', { field: 'teams_bots' })}
-          </p>
+          {messages.map((message, index) => (
+            <p
+              key={message.key}
+              data-testid={index === 0 ? 'teams-bot-sync-headline' : undefined}
+              className={
+                index === 0
+                  ? `text-xs font-medium ${
+                      applied
+                        ? 'text-[color:var(--fg-muted)]'
+                        : 'text-[color:var(--fg-strong)]'
+                    }`
+                  : 'text-xs text-[color:var(--fg-muted)]'
+              }
+            >
+              {t(`teamsIdentity.${message.key}`, message.values)}
+            </p>
+          ))}
           <div className="flex items-center gap-2">
             <Button size="sm" variant="ghost" onClick={() => void onCopy()}>
               {copied
@@ -482,12 +512,6 @@ function TeamsBotConfigBlock(props: {
           >
             {block}
           </pre>
-          <p className="text-xs text-[color:var(--fg-muted)]">
-            {t('teamsIdentity.teamsBot.secretRefNote')}
-          </p>
-          <p className="text-xs text-[color:var(--fg-muted)]">
-            {t('teamsIdentity.teamsBot.followUp')}
-          </p>
         </>
       )}
     </div>

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -2088,18 +2088,31 @@
         "unknown": {
           "what": "Das Provisioning wurde aus einem Grund gestoppt, den omadia nicht einordnen kann.",
           "next": "Sieh dir das technische Detail unten an, behebe die Ursache und starte das Provisioning erneut."
+        },
+        "config_sync_failed": {
+          "what": "Die Teams-Identität ist provisioniert und installiert — nur das automatische Schreiben in die Konfiguration des Teams-Channel-Plugins hat nicht geklappt.",
+          "reason": "Grund: {reason}",
+          "next": "Füge den unten gezeigten Konfigurationsblock im Teams-Channel-Plugin ein und speichere, oder starte das Provisioning erneut, um den automatischen Schreibvorgang zu wiederholen. In Azure muss nichts wiederholt werden."
         }
       },
       "teamsBot": {
         "heading": "Konfiguration für das Teams-Channel-Plugin",
         "notReady": "Es gibt noch keine Bot-Konfiguration — sie erscheint, sobald die Entra-App-Registrierung existiert.",
-        "manualStep": "Ein manueller Schritt bleibt: Dieser Block muss von Hand in das Teams-Channel-Plugin eingetragen werden.",
         "instructions": "Kopiere den Block, füge ihn im Setup-Feld {field} des Teams-Channel-Plugins ein und speichere.",
         "secretRefNote": "Der Block enthält nur eine Referenz auf das Bot-Passwort, niemals das Passwort selbst — das Geheimnis bleibt im Vault des M365-Connectors.",
-        "followUp": "Diese Konfiguration automatisch zu schreiben ist als Folgeschritt geplant und passiert heute nicht.",
         "blockLabel": "teams_bots-Konfigurationsblock für {botSlug}",
         "copy": "Kopieren",
-        "copied": "Kopiert"
+        "copied": "Kopiert",
+        "applied": "Bereits übernommen — das Provisioning hat diese Konfiguration in {plugin} geschrieben und das Plugin neu geladen. Der Bot ist live, hier ist nichts mehr zu tun.",
+        "appliedFallback": "Der Block wird weiterhin angezeigt, damit Du ihn mit dem Konfigurierten vergleichen oder in einer anderen Installation wiederverwenden kannst.",
+        "notApplied": {
+          "missing": "Ein manueller Schritt fehlt noch: Dieser Bot steht noch nicht in der Konfiguration des Teams-Channel-Plugins. Normalerweise schreibt das Provisioning ihn automatisch — starte das Provisioning erneut oder füge den Block unten ein.",
+          "out_of_sync": "Achtung: Im Teams-Channel-Plugin steht eine abweichende Konfiguration für diesen Bot. Entweder wurde sie von Hand bearbeitet, oder ein automatischer Schreibvorgang lief nicht zu Ende. Ersetze sie durch den Block unten oder starte das Provisioning erneut.",
+          "plugin_not_installed": "Das Teams-Channel-Plugin ist nicht installiert, es gibt also noch kein Ziel für diese Konfiguration. Installiere und aktiviere es — das Provisioning schreibt den Eintrag beim nächsten Lauf, alternativ fügst Du ihn unten ein.",
+          "unreadable": "Im Feld {field} des Teams-Channel-Plugins steht aktuell ein Wert, der sich nicht als JSON lesen lässt. Es wurde nichts überschrieben. Korrigiere das Feld von Hand und füge dann den Block unten ein.",
+          "not_applicable": "Die Bot-Konfiguration ist noch nicht vollständig — sie erscheint, sobald die Entra-App-Registrierung existiert.",
+          "unknown": "Ob diese Konfiguration bereits übernommen wurde, lässt sich gerade nicht feststellen. Vergleiche sie mit dem Teams-Channel-Plugin und füge den Block unten ein, falls er fehlt."
+        }
       },
       "rerunNeedsTeam": "Für diese Identität ist kein Ziel-Team hinterlegt, deshalb lässt sich das Provisioning hier nicht erneut starten."
     }

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -2088,18 +2088,31 @@
         "unknown": {
           "what": "Provisioning stopped for a reason omadia cannot classify.",
           "next": "Read the technical detail below, fix the cause, then start provisioning again."
+        },
+        "config_sync_failed": {
+          "what": "The Teams identity is provisioned and installed — only the automatic write into the Teams channel plugin configuration did not go through.",
+          "reason": "Reason: {reason}",
+          "next": "Paste the configuration block shown below into the Teams channel plugin and save, or re-run provisioning to retry the automatic write. Nothing in Azure has to be repeated."
         }
       },
       "teamsBot": {
         "heading": "Teams channel plugin configuration",
         "notReady": "There is no bot configuration yet — it appears once the Entra app registration exists.",
-        "manualStep": "One manual step is left: this block has to be pasted into the Teams channel plugin by hand.",
         "instructions": "Copy the block and paste it into the {field} setup field of the Teams channel plugin, then save.",
         "secretRefNote": "The block carries only a reference to the bot password, never the password itself — the secret stays in the M365 connector's vault.",
-        "followUp": "Writing this configuration automatically is a planned follow-up and does not happen today.",
         "blockLabel": "teams_bots configuration block for {botSlug}",
         "copy": "Copy",
-        "copied": "Copied"
+        "copied": "Copied",
+        "applied": "Already applied — provisioning wrote this configuration into {plugin} and reloaded the plugin. The bot is live; there is nothing left to do here.",
+        "appliedFallback": "The block is shown so you can compare it against what is configured, or reuse it in another deployment.",
+        "notApplied": {
+          "missing": "One manual step is left: this bot is not yet in the Teams channel plugin configuration. Provisioning normally writes it automatically — re-run provisioning to retry, or paste it below.",
+          "out_of_sync": "Heads up: the Teams channel plugin holds a different configuration for this bot. Someone edited it by hand, or an automatic write did not finish. Replace it with the block below, or re-run provisioning.",
+          "plugin_not_installed": "The Teams channel plugin is not installed, so there is nowhere to write this configuration yet. Install and activate it — provisioning writes the entry on the next run, or paste it below.",
+          "unreadable": "The {field} setup field of the Teams channel plugin currently holds a value that cannot be read as JSON. Nothing was overwritten. Fix the field by hand, then paste the block below.",
+          "not_applicable": "The bot configuration is not complete yet — it appears once the Entra app registration exists.",
+          "unknown": "Whether this configuration is already applied cannot be determined right now. Compare it against the Teams channel plugin and paste the block below if it is missing."
+        }
       },
       "rerunNeedsTeam": "No target team is recorded for this identity, so provisioning cannot be re-run from here."
     }


### PR DESCRIPTION
Closes the last manual step of the agent factory.

## What happens now, automatically

When the provisioning job runner reaches `installed`, it writes this identity's
`teams_bots` entry into the `@omadia/channel-teams` plugin config and reactivates the
plugin. The provisioned bot has an adapter and a route immediately — no restart, no
copy-paste between two screens.

The same write is re-asserted on a **re-run of an already-installed identity**. The
chain has nothing left to do there, but an identity field may have changed (a new
display name) or an operator may have removed the entry — so "re-run provisioning"
now always ends with the bot actually configured.

## Idempotency and non-interference

Both are the point of the change, and both are tested rather than asserted:

- **Idempotent by `botSlug`.** A re-run replaces its own entry **in place** — never
  appends a second one, never shifts positions. `teams_bots[0]`, the legacy
  scalar-shimmed production bot that owns the `/api/messages` aliases, keeps its slot
  and its identity.
- **Foreign entries survive byte-identical.** Entries are read as **raw objects** and
  written back untouched: no normalization, no re-ordering, no re-defaulting, and an
  operator's extra keys (a `note`, a custom `appPasswordSecretRef`) come back exactly
  as they were. This is why the write does not round-trip through the plugin's
  `parseTeamsBotsConfig` *result* shape — that parser defaults `appType` and
  `displayName`, so a parse/serialize cycle would silently rewrite entries it was only
  meant to read past. The accepted *container* shapes are mirrored exactly (JSON string
  or real array), and whichever form was stored is the form written back.
- **A no-op run is a true no-op.** If the stored entry already equals the projection,
  nothing is written and the plugin is **not** reactivated — bouncing a channel plugin
  that is serving traffic for a write that changed nothing would be a self-inflicted
  outage.
- **No secret is ever written.** Only the opaque `teams_bot_password:<appId>` vault ref.

## Failure and missing-plugin behaviour

By the time this runs, the Entra app, the Azure bot, the catalog entry and the team
install all exist and are this agent's. So the write **cannot fail the run**:

| Situation | Behaviour |
|---|---|
| channel-teams not installed | Clean skip with a named status. No error, no `last_error` |
| No installed registry bound | Clean skip (test mounts, boot before the registry) |
| `teams_bots` holds unreadable JSON | **Nothing is overwritten.** Run stays `installed`, `last_error` gets `config_sync_failed: [reason]` |
| Write or reactivation throws | Same: `installed` stands, nothing is rolled back, the warning is actionable |

`config_sync_failed` is a new classifier code — the only one that is a *warning* on a
successful identity. The UI renders it as "the identity is provisioned and installed,
only the automatic write did not go through", plus the reason and the two ways out
(paste the block, or re-run provisioning to retry just the write).

## What stays in the UI

The copy-paste block **stays** — as the fallback and for operators who configure
explicitly. What changed is the line above it: it no longer states "this is a manual
step" unconditionally, it *answers* whether anything is left to do. That answer comes
from the new `teams_bots_sync` field on `GET /:slug/teams-identity`
(`{state, plugin_id, config_key}`), which is derived from the **live plugin config on
every read** rather than from a stored "we synced it" flag — an operator can edit or
delete the entry at any time, and a remembered intention would tell the screen a
comfortable lie. States: `synced`, `out_of_sync`, `missing`, `plugin_not_installed`,
`unreadable`, `not_applicable`, `unknown`. Copy in EN + DE; a middleware that predates
the field narrows to `unknown`, which keeps the paste instructions visible.

## Structure

`projectTeamsBotConfig` / `defaultTeamsBotSecretRef` moved out of
`routes/operatorAgents.ts` into the new `services/teamsBotsConfigSync.ts`, so the block
an operator pastes and the entry provisioning writes come from **one** producer. The
router re-exports them, so every existing caller and pin keeps working.

## Tests

- `middleware/test/teamsBotsConfigSync.test.ts` (new, 28 cases) — double run leaves
  exactly one entry; legacy entry 0 and a hand-tuned foreign entry stay byte-identical
  across two runs; changed display name updates the entry; container form round-trips;
  unreadable value throws instead of overwriting; reactivation failure leaves the write
  landed; plugin/registry/incomplete-identity skips; no secret material written.
- `middleware/test/teamsProvisioningJob.test.ts` — sync runs after `installed` with the
  post-write row; a write failure keeps the run `installed` and records the warning; a
  re-run of an installed identity re-asserts without walking the chain; no port wired is
  the pre-#910 behaviour; the `config_sync_failed` sentence round-trips through its own
  classifier.
- `middleware/test/operatorAgentsRouter.test.ts` — the status route reports the live
  sync state through every transition, reports `unreadable`/`not_applicable`, and a new
  static pin fails if `index.ts` ever stops wiring `syncBotConfig`.
- web-ui — copy per sync state, the `unknown` fallback for an older middleware, and the
  i18n coverage test now enumerates every sync state and the new error code in EN + DE.

## Gates

`middleware`: `npm run typecheck && npm run typecheck:test && npm test` → **7811 pass,
0 fail** (16 pre-existing skips). `web-ui`: `npm run lint` (0 errors) `&& npm run
typecheck && npm run test` (**994 pass**) `&& npm run i18n:check` (OK, 4086 keys).

## Docs

`docs/teams-multi-agent-identities.md` § 3, 4.1, 4.5, the REST reference, the
troubleshooting table and the limits/roadmap sections rewritten — the manual step is now
documented as the fallback, with a table of what the sync guarantees and when it steps
aside. Plus `docs/CHANGELOG.md`.

Refs #910, part of #860

---

### Follow-up commit `39d232af`

Two gaps found on a review pass of the write path:

- **A successful re-run left its own warning standing.** `config_sync_failed` tells the
  operator to re-run provisioning to retry the write — and then the retry succeeded
  while the warning stayed on the row. The runner now clears `last_error` after a
  successful sync, scoped to the `config_sync_failed:` prefix so an unrelated error
  (a stale `consent_missing`, say) is not swept away with it.
- **Concurrent writes could drop an entry.** The write is a read-modify-write over one
  config value, and two agents can reach `installed` simultaneously — the runner's
  in-flight guard is per-agent, and the boot-time resume scan re-enqueues every
  interrupted row at once. Interleaved, the second read would miss the first write.
  Writes are now serialized through a promise chain, and a rejected write does not
  poison the queue for the next caller. Tested against a registry whose write does not
  land until the next macrotask.
