### PR TITLE
fix(#911): runtime-readiness banner now points to the actual LLM access page

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,23 @@ still needed, rendered from the new `teams_bots_sync` field of
 plugin config on every read rather than from a stored "we synced it" flag, so
 a hand edit shows up immediately. Copy in EN + DE.
 
+### Fixed — runtime-readiness banner now points to the actual LLM access page (#911)
+
+2026-08-28 — The readiness card shown when the runtime is offline had exactly
+one CTA, but it pointed to `/admin/settings`, a directory of miscellaneous
+plugin configuration with no relation to LLM providers or subscriptions. That
+meant the one card whose whole job is "your runtime is offline, go fix your
+LLM access" sent operators to the wrong page.
+
+The CTA now targets `/admin/providers`, the page that actually exposes the
+API-key and subscription-CLI tabs added around #889. The EN/DE body copy now
+names both supported access paths — adding an API key or connecting an
+existing Claude/Codex subscription — instead of only referring to "your key",
+and the title ("LLM API key missing" → "LLM access missing") no longer frames
+the problem as API-key-specific when the body describes both paths. The
+banner test now pins the CTA href so this exact regression is covered
+under #911.
+
 ### Fixed — desktop kernel PATH augmentation missed ~/.local/bin (#906)
 
 2026-08-27 — #882's PATH augmentation checked Homebrew, Volta, asdf, and nvm,

--- a/web-ui/app/_components/RuntimeReadinessBanner.tsx
+++ b/web-ui/app/_components/RuntimeReadinessBanner.tsx
@@ -124,7 +124,7 @@ function ReadinessCard({
       </p>
       <div className="mt-4 flex items-center gap-2">
         <Link
-          href="/admin/settings"
+          href="/admin/providers"
           onClick={onDismiss}
           className="flex-1 border border-[color:var(--ink)] bg-[color:var(--ink)] px-3 py-2 text-center text-[11px] uppercase tracking-[0.16em] text-[color:var(--paper)] transition hover:border-[color:var(--accent)] hover:bg-[color:var(--accent)]"
         >

--- a/web-ui/app/_components/__tests__/RuntimeReadinessBanner.test.tsx
+++ b/web-ui/app/_components/__tests__/RuntimeReadinessBanner.test.tsx
@@ -12,7 +12,7 @@ import { RuntimeReadinessBanner } from '../RuntimeReadinessBanner';
  * heartbeat sees the runtime come up.
  */
 
-const TITLE_DE = 'LLM-API-Key fehlt';
+const TITLE_DE = 'LLM-Zugang fehlt';
 
 const { mockUsePathname } = vi.hoisted(() => ({
   mockUsePathname: vi.fn(() => '/'),
@@ -55,6 +55,9 @@ describe('<RuntimeReadinessBanner />', () => {
     await flush();
 
     expect(screen.getByText(TITLE_DE)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /LLM-Zugang öffnen/i }),
+    ).toHaveAttribute('href', '/admin/providers');
     expect(mockFetch).toHaveBeenCalledWith(
       '/bot-api/v1/operator/agents',
       expect.objectContaining({ credentials: 'include' }),

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1315,9 +1315,9 @@
     "expiredCta": "Neu anmelden"
   },
   "runtimeReadiness": {
-    "title": "LLM-API-Key fehlt",
-    "body": "Die Agent-Runtime ist offline — meistens, weil noch kein LLM-API-Key hinterlegt ist. Hinterlege deinen Key in den Einstellungen; Chat, Agenten, Channels und Skills sind danach sofort verfügbar. Routinen brauchen zusätzlich einen Neustart der Middleware.",
-    "cta": "Einstellungen öffnen",
+    "title": "LLM-Zugang fehlt",
+    "body": "Die Agent-Runtime ist offline — meistens, weil noch kein LLM-API-Key oder Abo hinterlegt ist. Hinterlege einen API-Key oder verbinde ein bestehendes Claude/Codex-Abo im LLM-Zugang; Chat, Agenten, Channels und Skills sind danach sofort verfügbar. Routinen brauchen zusätzlich einen Neustart der Middleware.",
+    "cta": "LLM-Zugang öffnen",
     "dismiss": "Später"
   },
   "agentDetailsModal": {

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1315,9 +1315,9 @@
     "expiredCta": "Sign in again"
   },
   "runtimeReadiness": {
-    "title": "LLM API key missing",
-    "body": "The agent runtime is offline — usually because no LLM API key is configured yet. Add your key in the settings; chat, agents, channels and skills come online right away. Routines additionally need one middleware restart.",
-    "cta": "Open settings",
+    "title": "LLM access missing",
+    "body": "The agent runtime is offline — usually because no LLM API key or subscription is connected yet. Add an API key or connect an existing Claude/Codex subscription in the LLM access settings; chat, agents, channels and skills come online right away. Routines additionally need one middleware restart.",
+    "cta": "Open LLM access",
     "dismiss": "Later"
   },
   "agentDetailsModal": {


### PR DESCRIPTION
Fixes #911.

## Problem
The "runtime offline" toast card's one CTA pointed to `/admin/settings` — a directory of miscellaneous plugin configuration with zero relation to LLM providers or subscriptions. The one card whose entire job is "your runtime is offline, go fix your LLM access" sent operators to the wrong page. This is a more severe version of the gap noted in the Runde-2 test report's P-07 finding, which only observed the copy naming the API-key path and not the subscription one — the actual bug is that the button doesn't reach a fix at all.

## Changes
1. **`RuntimeReadinessBanner.tsx`** — the CTA now targets `/admin/providers`, the page that actually exposes the API-key and subscription-CLI tabs (added around #889). Verified `/admin/providers` renders `LlmAccessTabs`, which explicitly folds both the former `/admin/providers` (API keys) and `/admin/subscription-clis` (Abos) pages into one.
2. **`messages/en.json` / `de.json`** — body copy now names both access paths ("add an API key or connect an existing Claude/Codex subscription") instead of only "your key"; title changed from "LLM API key missing" → "LLM access missing" (caught in review — the old title still framed this as API-key-specific even after the body was broadened to cover both paths).
3. **`RuntimeReadinessBanner.test.tsx`** — pins the CTA `href`. The implementer ran a mutation check: reverted the href, confirmed the new assertion fails with a clear message, restored — proving the regression test actually bites.
4. **`docs/CHANGELOG.md`** — `[Unreleased]` entry.

Deliberately kept to **one CTA** (not two, unlike #889's onboarding-step fix): this is a narrow (`max 24rem`) transient toast whose action row already holds the CTA plus a dismiss button — `/admin/providers` itself surfaces both tabs once the user lands there, so the body copy carries the "both paths" information instead of a second button.

## Verification (all local, pre-commit)
- `web-ui`: `tsc --noEmit` — clean; `npm run i18n:check` — OK, 4077 keys; `eslint` — clean; **16/16 tests pass**
- Independent `omadia-reviewer` pass (two rounds): confirmed `/admin/providers` is the correct destination via `LlmAccessTabs.tsx`'s own doc comment, confirmed no stale references to the old href/strings remain anywhere, confirmed the single-CTA design is justified by the component's actual width constraint, confirmed DE/EN copy tone matches neighboring entries — one finding applied (the title/body framing inconsistency above)

## Test plan
- [x] Automated tests above, all green, including a verified-failing-on-regression assertion

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790493913&installation_model_id=428086&pr_number=913&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F913&signature=7d22d12e46142d380e0692f85e1603bf55c5ee3d82792d2469e4d28d14540ea7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->