### PR TITLE
fix: qualify the Azure bot handle, and stop retrying a taken one

### DIFF
--- a/middleware/src/services/teamsProvisioningJob.ts
+++ b/middleware/src/services/teamsProvisioningJob.ts
@@ -210,6 +210,65 @@ export type TeamsAppPackageAssetLoader = (
 ) => Promise<TeamsAppPackageAssets>;
 
 // ---------------------------------------------------------------------------
+// Bot handle composition (byte5ai/omadia#921)
+// ---------------------------------------------------------------------------
+
+/**
+ * Azure bot handles live in ONE GLOBAL namespace shared by every Azure
+ * customer — they behave like DNS labels, not like tenant- or
+ * subscription-scoped resource names. The operator's `botSlug` is a local
+ * label (`hr`, `sales`, `test-hr`); handing it to ARM raw means every natural
+ * slug collides with a stranger's bot registered years ago, and the operator
+ * reads "already registered to another bot application" as evidence of a
+ * leftover of their own.
+ *
+ * So the runner qualifies the handle here, for the same reason it qualifies
+ * `uniqueName` two steps below: the naming convention is the runner's, not
+ * the connector's. The connector validates the RESULT against the ARM/Bot
+ * Framework grammar (`requireBotName`) — it owns the rules, we own the shape.
+ *
+ * Shape: `omadia-<slug>-<first appId segment>`. The app registration always
+ * runs first, so its `appId` GUID is available and already globally unique;
+ * its first segment is 8 hex chars, enough to separate two omadia
+ * installations that picked the same slug while staying readable in the
+ * portal.
+ *
+ * TRUNCATION CUTS THE SLUG, NEVER THE SUFFIX — shortening the unique part
+ * would reintroduce exactly the collision this function exists to prevent.
+ * The slug is normalised to the handle charset (lowercased, every run of
+ * non-alphanumerics folded to a single hyphen) and then trimmed to whatever
+ * budget the fixed parts leave.
+ */
+export const BOT_HANDLE_PREFIX = 'omadia';
+/** Bot Framework's upper bound; the connector enforces the same number. */
+export const BOT_HANDLE_MAX_LENGTH = 42;
+/** Hex characters of the appId taken as the uniqueness suffix. */
+export const BOT_HANDLE_APP_ID_SEGMENT_LENGTH = 8;
+
+export function buildBotHandle(botSlug: string, appId: string): string {
+  const suffix = appId
+    .replace(/[^0-9a-fA-F]/g, '')
+    .slice(0, BOT_HANDLE_APP_ID_SEGMENT_LENGTH)
+    .toLowerCase();
+  if (suffix.length === 0) {
+    throw new TeamsProvisioningJobError(
+      `cannot build a bot handle: app id '${appId}' has no hex characters to qualify the slug with`,
+    );
+  }
+  // `omadia` + `-` + slug + `-` + suffix — the slug gets whatever is left.
+  const budget =
+    BOT_HANDLE_MAX_LENGTH - BOT_HANDLE_PREFIX.length - 2 - suffix.length;
+  const normalized = botSlug
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const slugPart = normalized.slice(0, Math.max(budget, 0)).replace(/-+$/g, '');
+  return slugPart.length > 0
+    ? `${BOT_HANDLE_PREFIX}-${slugPart}-${suffix}`
+    : `${BOT_HANDLE_PREFIX}-${suffix}`;
+}
+
+// ---------------------------------------------------------------------------
 // Duck-typed connector error guards (see module doc on why not instanceof)
 // ---------------------------------------------------------------------------
 
@@ -237,6 +296,41 @@ function missingSetupFieldsOf(err: unknown): readonly string[] | undefined {
   if (!(err instanceof Error) || err.name !== 'ArmNotConfiguredError') return undefined;
   const fields = (err as Error & { missingSetupFields?: unknown }).missingSetupFields;
   return isStringArray(fields) ? fields : [];
+}
+
+/**
+ * The connector's typed verdict that the global bot handle is taken (#921).
+ * Duck-typed like every other cross-plugin guard in this module.
+ */
+function botHandleUnavailableOf(err: unknown): { readonly botName?: string } | undefined {
+  if (!(err instanceof Error) || err.name !== 'BotHandleUnavailableError') {
+    return undefined;
+  }
+  const botName = (err as Error & { botName?: unknown }).botName;
+  return typeof botName === 'string' ? { botName } : {};
+}
+
+/**
+ * Would re-running this step UNCHANGED plausibly produce a different answer?
+ *
+ * A `ProvisioningRequestError` carrying a deterministic 4xx says no: the
+ * request was rejected on its content, and the content is identical next
+ * time. Retrying it five times (which is what this runner did until #921 —
+ * `retryable` was computed but only consulted at exhaustion) buys nothing but
+ * a slower failure and a misleading "gave up after 5 attempts".
+ *
+ * 408 and 429 are excluded because they ARE time-dependent, and 403 never
+ * reaches here — `ConsentMissingError` is handled above. This guard is
+ * deliberately connector-version-independent: an older connector that still
+ * reports a taken handle as an untyped 400 also stops after one attempt.
+ */
+const TIME_DEPENDENT_CLIENT_STATUSES: ReadonlySet<number> = new Set([408, 429]);
+
+function isDeterministicRequestFailure(err: unknown): boolean {
+  if (!(err instanceof Error) || err.name !== 'ProvisioningRequestError') return false;
+  const status = (err as Error & { status?: unknown }).status;
+  if (typeof status !== 'number') return false;
+  return status >= 400 && status < 500 && !TIME_DEPENDENT_CLIENT_STATUSES.has(status);
 }
 
 function isProvisionerUnavailable(err: unknown): boolean {
@@ -279,7 +373,7 @@ export type ProvisioningRunResult =
   | {
       readonly status: 'failed';
       readonly agentId: string;
-      readonly reason: 'consent_missing' | 'error';
+      readonly reason: 'consent_missing' | 'bot_handle_unavailable' | 'error';
       readonly detail: string;
     }
   | {
@@ -539,7 +633,27 @@ export class TeamsProvisioningJobRunner {
       };
     }
 
+    const takenHandle = botHandleUnavailableOf(err);
+    if (takenHandle !== undefined) {
+      // TERMINAL and DETERMINISTIC — the global namespace will not free the
+      // name on the next attempt. Fail on attempt 1 with an explanation
+      // instead of five identical 400s (#921).
+      const detail = botHandleUnavailableDetail(errorMessage(err), takenHandle.botName);
+      await this.recordError(agentId, { state: 'failed', lastError: detail });
+      return { status: 'failed', agentId, reason: 'bot_handle_unavailable', detail };
+    }
+
     const throttle = throttleHintOf(err);
+
+    if (throttle === undefined && isDeterministicRequestFailure(err)) {
+      // A 4xx on identical input is a verdict, not a hiccup — see
+      // isDeterministicRequestFailure. Stop now, keep the reached state's
+      // evidence, and report the real reason on attempt 1.
+      const detail = `${errorMessage(err)} (deterministic — not retried)`;
+      await this.recordError(agentId, { state: 'failed', lastError: detail });
+      return { status: 'failed', agentId, reason: 'error', detail };
+    }
+
     const retryable = throttle !== undefined || isProvisionerUnavailable(err);
 
     if (attempt >= this.maxAttempts) {
@@ -670,7 +784,8 @@ export class TeamsProvisioningJobRunner {
     // the accessor module's URL builder, injected — never composed here.
     if (STATE_RANK[row.state] < STATE_RANK.bot_created) {
       const outcome = await provisioner.createBot({
-        botName: row.botSlug,
+        // Qualified, NOT the raw slug: the handle namespace is global (#921).
+        botName: buildBotHandle(row.botSlug, row.appId as string),
         displayName: row.displayName,
         msaAppId: row.appId as string,
         msaAppTenantId: row.tenantId as string,
@@ -818,6 +933,27 @@ export function armNotConfiguredDetail(missingSetupFields: readonly string[]): s
   return `arm_not_configured: bot creation needs the ARM setup fields [${fields}] on the M365 connector — configure them, then re-run provisioning (the app registration is kept)`;
 }
 
+/** Machine-readable prefix of {@link botHandleUnavailableDetail}. The
+ *  connector's own message already starts with this code, so the producer
+ *  passes it through rather than double-prefixing. */
+export const BOT_HANDLE_UNAVAILABLE_PREFIX = 'bot_handle_unavailable:';
+
+/**
+ * The global bot handle is taken (#921).
+ *
+ * The explanatory text — global namespace, automatic qualification, rename
+ * the slug — is authored by the CONNECTOR, which is where the ARM semantics
+ * live; the runner only guarantees the sentence carries the code the operator
+ * UI switches on. An older connector reports the same condition without the
+ * prefix, so it is added when missing.
+ */
+export function botHandleUnavailableDetail(message: string, botName?: string): string {
+  const handle = botName !== undefined ? ` [${botName}]` : '';
+  return message.startsWith(BOT_HANDLE_UNAVAILABLE_PREFIX)
+    ? message
+    : `${BOT_HANDLE_UNAVAILABLE_PREFIX}${handle} ${message} — Azure bot handles share one global namespace across all Azure customers, so a name can be taken by a bot outside your tenant. Rename the agent's bot slug and re-run provisioning`;
+}
+
 /** Throttle budget exhausted. The reached state is KEPT — this is a "come
  *  back later", not a failure — so the sentence carries the connector's
  *  `Retry-After` hint when it had one. */
@@ -857,6 +993,7 @@ export type TeamsProvisioningErrorCode =
   | 'arm_not_configured'
   | 'throttled'
   | 'config_sync_failed'
+  | 'bot_handle_unavailable'
   | 'unknown';
 
 /** Structured projection of one `last_error` sentence. `raw` is always the
@@ -911,6 +1048,9 @@ export function classifyTeamsProvisioningError(
       fields: bracketList(sentence, ARM_FIELDS_UNSPECIFIED),
       raw,
     };
+  }
+  if (sentence.startsWith(BOT_HANDLE_UNAVAILABLE_PREFIX)) {
+    return { code: 'bot_handle_unavailable', raw };
   }
   if (sentence.startsWith(CONFIG_SYNC_FAILED_PREFIX)) {
     const inner = /\[([^\]]*)\]/.exec(sentence)?.[1]?.trim() ?? '';

--- a/middleware/test/teamsProvisioningJob.test.ts
+++ b/middleware/test/teamsProvisioningJob.test.ts
@@ -4,6 +4,9 @@ import { describe, it } from 'node:test';
 import type { TimerSeam } from '../src/plugins/jobScheduler.js';
 import {
   armNotConfiguredDetail,
+  botHandleUnavailableDetail,
+  buildBotHandle,
+  BOT_HANDLE_MAX_LENGTH,
   classifyTeamsProvisioningError,
   configSyncFailedDetail,
   consentMissingDetail,
@@ -245,7 +248,8 @@ describe('TeamsProvisioningJobRunner — chain and resume', () => {
     ]);
     assert.deepEqual(provisioner.calls, [
       'createAppRegistration:omadia-teams-bot-hr-bot',
-      'createBot:hr-bot:https://mw.example.com/api/teams/hr-bot/messages',
+      // #921 — ARM gets the QUALIFIED handle; the endpoint keeps the slug.
+      `createBot:${buildBotHandle('hr-bot', 'app-123')}:https://mw.example.com/api/teams/hr-bot/messages`,
       'getCatalogApp:external-abc',
       'buildAppPackage',
       'uploadToCatalog:external-abc',
@@ -264,7 +268,7 @@ describe('TeamsProvisioningJobRunner — chain and resume', () => {
     await runner.enqueue(REQUEST);
     assert.ok(
       provisioner.calls.includes(
-        'createBot:hr-bot:https://mw.example.com/api/teams/hr-bot/messages',
+        `createBot:${buildBotHandle('hr-bot', 'app-123')}:https://mw.example.com/api/teams/hr-bot/messages`,
       ),
       'endpoint must come from the injected builder',
     );
@@ -280,7 +284,11 @@ describe('TeamsProvisioningJobRunner — chain and resume', () => {
       !provisioner.calls.some((c) => c.startsWith('createAppRegistration')),
       'createAppRegistration must not run again',
     );
-    assert.ok(provisioner.calls.some((c) => c.startsWith('createBot:hr-bot')));
+    assert.ok(
+      provisioner.calls.some((c) =>
+        c.startsWith(`createBot:${buildBotHandle('hr-bot', 'app-old')}`),
+      ),
+    );
   });
 
   it('resumes from bot_created without re-creating the bot', async () => {
@@ -960,5 +968,246 @@ describe('TeamsProvisioningJobRunner — teams_bots config sync (#910)', () => {
     const detail = classifyTeamsProvisioningError(configSyncFailedDetail('   '));
     assert.equal(detail.code, 'config_sync_failed');
     assert.equal(detail.reason, '');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// byte5ai/omadia#921 — the Azure bot handle namespace is GLOBAL
+// ---------------------------------------------------------------------------
+
+describe('buildBotHandle (#921)', () => {
+  const APP_ID = '7034c271-6847-4be4-aea4-8b9e0c86fcad';
+  /** The grammar the connector enforces (`requireBotName`), mirrored so a
+   *  divergence between the composer and the validator fails HERE. */
+  const BOT_HANDLE_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{2,40})[A-Za-z0-9]$/;
+
+  it('qualifies the operator slug with the app id — the fix for the reported failure', () => {
+    // `test-hr` is the slug that actually collided on the byte5 tenant.
+    assert.equal(buildBotHandle('test-hr', APP_ID), 'omadia-test-hr-7034c271');
+  });
+
+  it('produces a handle the connector accepts', () => {
+    assert.match(buildBotHandle('test-hr', APP_ID), BOT_HANDLE_RE);
+  });
+
+  it('never exceeds the 42-char bound, however long the slug', () => {
+    for (const length of [1, 10, 26, 27, 40, 64, 200]) {
+      const handle = buildBotHandle('a'.repeat(length), APP_ID);
+      assert.ok(
+        handle.length <= BOT_HANDLE_MAX_LENGTH,
+        `slug of ${String(length)} produced a ${String(handle.length)}-char handle`,
+      );
+      assert.match(handle, BOT_HANDLE_RE, `slug of ${String(length)} produced ${handle}`);
+    }
+  });
+
+  it('TRUNCATES THE SLUG, never the unique suffix', () => {
+    // The whole point: shortening the unique part would reintroduce the
+    // collision the qualification exists to prevent.
+    const handle = buildBotHandle('a'.repeat(200), APP_ID);
+    assert.equal(handle.length, BOT_HANDLE_MAX_LENGTH);
+    assert.ok(handle.endsWith('-7034c271'), `suffix lost in ${handle}`);
+  });
+
+  it('keeps long distinct slugs apart via the suffix even when both truncate', () => {
+    const long = 'a'.repeat(200);
+    const other = '9999aaaa-6847-4be4-aea4-8b9e0c86fcad';
+    assert.notEqual(buildBotHandle(long, APP_ID), buildBotHandle(long, other));
+  });
+
+  it('folds characters no bot handle may carry into hyphens', () => {
+    assert.equal(
+      buildBotHandle('Sales & Support (EMEA)!!', APP_ID),
+      'omadia-sales-support-emea-7034c271',
+    );
+    for (const slug of ['HR_Bot', 'hr.bot', 'hr bot', 'hr---bot', 'Ümläut']) {
+      assert.match(buildBotHandle(slug, APP_ID), BOT_HANDLE_RE, `slug ${slug}`);
+    }
+  });
+
+  it('never leaves a trailing or leading hyphen from truncation or trimming', () => {
+    // A slug whose 26-char budget lands exactly on a hyphen.
+    assert.match(buildBotHandle(`${'x'.repeat(26)}-tail`, APP_ID), BOT_HANDLE_RE);
+    for (const slug of ['-hr-', '---', '!!!']) {
+      const handle = buildBotHandle(slug, APP_ID);
+      assert.match(handle, BOT_HANDLE_RE, `slug ${slug} produced ${handle}`);
+    }
+  });
+
+  it('degrades to prefix+suffix when the slug normalises away entirely', () => {
+    assert.equal(buildBotHandle('!!!', APP_ID), 'omadia-7034c271');
+  });
+
+  it('is deterministic — a re-run keeps the ARM upsert idempotent', () => {
+    assert.equal(buildBotHandle('test-hr', APP_ID), buildBotHandle('test-hr', APP_ID));
+  });
+
+  it('rejects an app id with no hex characters to qualify with', () => {
+    assert.throws(() => buildBotHandle('hr', '----'), /cannot build a bot handle/);
+  });
+});
+
+describe('TeamsProvisioningJobRunner — global bot handle (#921)', () => {
+  it('passes the QUALIFIED handle to createBot, not the raw slug', async () => {
+    const { runner, provisioner } = makeRunner();
+    await runner.enqueue(REQUEST);
+    const call = provisioner.calls.find((c) => c.startsWith('createBot:'));
+    // Default row: botSlug 'hr-bot', appId from createAppRegistration 'app-123'.
+    assert.equal(
+      call?.split(':')[1],
+      buildBotHandle('hr-bot', 'app-123'),
+      'the raw slug must never reach ARM',
+    );
+    assert.notEqual(call?.split(':')[1], 'hr-bot');
+  });
+
+  it('keeps the messaging endpoint keyed on the SLUG, not the handle', async () => {
+    // The endpoint is the channel-teams route (`/api/teams/<botSlug>/messages`)
+    // — qualifying the ARM handle must not silently re-route inbound traffic.
+    const { runner, provisioner } = makeRunner();
+    await runner.enqueue(REQUEST);
+    const call = provisioner.calls.find((c) => c.startsWith('createBot:')) ?? '';
+    assert.ok(
+      call.endsWith('https://mw.example.com/api/teams/hr-bot/messages'),
+      `endpoint lost the slug: ${call}`,
+    );
+  });
+
+  it('BotHandleUnavailableError fails on attempt ONE — no retry storm', async () => {
+    let attempts = 0;
+    const { runner, store, timers } = makeRunner({
+      behaviour: {
+        createBot: () => {
+          attempts += 1;
+          return Promise.reject(
+            namedError(
+              'BotHandleUnavailableError',
+              "bot_handle_unavailable: Azure bot handle 'omadia-hr-bot-app-123' is already registered to another bot application.",
+              { botName: 'omadia-hr-bot-app-123', status: 400 },
+            ),
+          );
+        },
+      },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(attempts, 1, 'a deterministic verdict must not be retried');
+    assert.deepEqual(timers.delays, [], 'no backoff sleep may be scheduled');
+    assert.equal(result.status, 'failed');
+    assert.equal(result.status === 'failed' && result.reason, 'bot_handle_unavailable');
+    assert.equal(store.row?.state, 'failed');
+    assert.ok(
+      !store.row?.lastError?.includes('gave up after'),
+      'the operator must not be told we tried five times',
+    );
+  });
+
+  it('records an operator sentence explaining the GLOBAL namespace', async () => {
+    const { runner, store } = makeRunner({
+      behaviour: {
+        createBot: () =>
+          Promise.reject(
+            namedError(
+              'BotHandleUnavailableError',
+              'bot_handle_unavailable: taken. Bot handles share ONE global namespace across all Azure customers. omadia qualifies the handle automatically',
+              { botName: 'omadia-hr-bot-app-123', status: 400 },
+            ),
+          ),
+      },
+    });
+    await runner.enqueue(REQUEST);
+    const detail = store.row?.lastError ?? '';
+    assert.ok(detail.startsWith('bot_handle_unavailable:'), detail);
+    assert.match(detail, /global namespace/i);
+    assert.match(detail, /qualifies the handle automatically/i);
+    assert.equal(classifyTeamsProvisioningError(detail).code, 'bot_handle_unavailable');
+  });
+
+  it('an OLDER connector reporting a bare 400 also stops after one attempt', async () => {
+    // Version independence: before the connector learned the typed error, the
+    // same condition arrived as an untyped deterministic 4xx.
+    let attempts = 0;
+    const { runner, store } = makeRunner({
+      behaviour: {
+        createBot: () => {
+          attempts += 1;
+          return Promise.reject(
+            namedError(
+              'ProvisioningRequestError',
+              'arm botServices.put 400 PUT https://management.azure.com/... body={"error":{"code":"InvalidBotData"}}',
+              { resource: 'arm', step: 'botServices.put', status: 400 },
+            ),
+          );
+        },
+      },
+    });
+    const result = await runner.enqueue(REQUEST);
+    assert.equal(attempts, 1);
+    assert.equal(result.status, 'failed');
+    assert.ok(
+      store.row?.lastError?.includes('deterministic'),
+      String(store.row?.lastError),
+    );
+    assert.ok(!store.row?.lastError?.includes('gave up after 5'));
+  });
+
+  it('still retries a 5xx — the deterministic guard must not swallow transients', async () => {
+    let attempts = 0;
+    const { runner } = makeRunner({
+      behaviour: {
+        createBot: () => {
+          attempts += 1;
+          return Promise.reject(
+            namedError('ProvisioningRequestError', 'arm botServices.put 503', {
+              resource: 'arm',
+              step: 'botServices.put',
+              status: 503,
+            }),
+          );
+        },
+      },
+    });
+    await runner.enqueue(REQUEST);
+    assert.ok(attempts > 1, `a 503 must still be retried, saw ${String(attempts)} attempt(s)`);
+  });
+
+  it('still retries a 429 — time-dependent, not deterministic', async () => {
+    let attempts = 0;
+    const { runner } = makeRunner({
+      behaviour: {
+        createBot: () => {
+          attempts += 1;
+          return Promise.reject(
+            namedError('ProvisioningRequestError', 'arm botServices.put 429', {
+              resource: 'arm',
+              step: 'botServices.put',
+              status: 429,
+            }),
+          );
+        },
+      },
+    });
+    await runner.enqueue(REQUEST);
+    assert.ok(attempts > 1, `a 429 must still be retried, saw ${String(attempts)} attempt(s)`);
+  });
+});
+
+describe('botHandleUnavailableDetail (#921)', () => {
+  it('passes a connector sentence through — it already carries the code', () => {
+    const connector = 'bot_handle_unavailable: handle taken, rename the slug';
+    assert.equal(botHandleUnavailableDetail(connector), connector);
+  });
+
+  it('prefixes an older connector sentence so the UI can still switch on it', () => {
+    const detail = botHandleUnavailableDetail('400 InvalidBotData', 'omadia-hr-1a2b3c4d');
+    assert.ok(detail.startsWith('bot_handle_unavailable:'));
+    assert.ok(detail.includes('omadia-hr-1a2b3c4d'));
+    assert.equal(classifyTeamsProvisioningError(detail).code, 'bot_handle_unavailable');
+  });
+
+  it('round-trips through the classifier with the raw sentence preserved', () => {
+    const detail = botHandleUnavailableDetail('bot_handle_unavailable: taken');
+    const classified = classifyTeamsProvisioningError(detail);
+    assert.equal(classified.code, 'bot_handle_unavailable');
+    assert.equal(classified.raw, detail);
   });
 });

--- a/web-ui/app/_lib/__tests__/teamsIdentity.test.ts
+++ b/web-ui/app/_lib/__tests__/teamsIdentity.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   TEAMS_BOTS_SYNC_STATES,
+  TEAMS_IDENTITY_LAST_ERROR_CODES,
   type TeamsIdentityLastErrorDetailDto,
 } from '../agents';
 import {
@@ -153,6 +154,15 @@ describe('the classified sentences are the ones the middleware writes', () => {
 
   it('teamsProvisioningJob still writes the config_sync_failed prefix (#910)', () => {
     expect(job).toContain('`config_sync_failed: [');
+  });
+
+  it('the last_error code vocabulary matches the middleware classifier (#921)', () => {
+    // The UI switches on these codes; a code the server can emit but the
+    // client does not know renders a bare i18n key on the operator screen.
+    const block = /export type TeamsProvisioningErrorCode =([\s\S]*?);/.exec(job);
+    expect(block).not.toBeNull();
+    const serverCodes = [...(block?.[1] ?? '').matchAll(/'([a-z_]+)'/g)].map((m) => m[1]);
+    expect([...serverCodes].sort()).toEqual([...TEAMS_IDENTITY_LAST_ERROR_CODES].sort());
   });
 
   it('the sync-state vocabulary matches the middleware projection (#910)', () => {
@@ -435,6 +445,19 @@ describe('i18n coverage', () => {
     expect(
       teamsIdentityErrorMessages(CONFIG_SYNC_DETAIL_NO_REASON).map((m) => m.key),
     ).toEqual(['errors.config_sync_failed.what', 'errors.config_sync_failed.next']);
+  });
+
+  it('renders the taken-global-handle failure with its own copy (#921)', () => {
+    const detail = {
+      code: 'bot_handle_unavailable',
+      raw: "bot_handle_unavailable: Azure bot handle 'omadia-hr-7034c271' is already registered to another bot application",
+    } as const;
+    expect(teamsIdentityErrorMessages(detail).map((m) => m.key)).toEqual([
+      'errors.bot_handle_unavailable.what',
+      'errors.bot_handle_unavailable.next',
+    ]);
+    // No external step to send the operator to — the fix is renaming the slug.
+    expect(teamsIdentityErrorLink(detail)).toBeNull();
   });
 });
 

--- a/web-ui/app/_lib/agents.ts
+++ b/web-ui/app/_lib/agents.ts
@@ -455,6 +455,10 @@ export const TEAMS_IDENTITY_LAST_ERROR_CODES = [
   // provisioned and installed, only the automatic `teams_bots` write did not
   // land, so the operator falls back to the copy-paste block.
   'config_sync_failed',
+  // #921 — the Azure bot handle is taken in the GLOBAL Bot Service namespace.
+  // Terminal and deterministic: re-running changes nothing, the operator has
+  // to rename the bot slug.
+  'bot_handle_unavailable',
   'unknown',
 ] as const;
 

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -2093,6 +2093,10 @@
           "what": "Die Teams-Identität ist provisioniert und installiert — nur das automatische Schreiben in die Konfiguration des Teams-Channel-Plugins hat nicht geklappt.",
           "reason": "Grund: {reason}",
           "next": "Füge den unten gezeigten Konfigurationsblock im Teams-Channel-Plugin ein und speichere, oder starte das Provisioning erneut, um den automatischen Schreibvorgang zu wiederholen. In Azure muss nichts wiederholt werden."
+        },
+        "bot_handle_unavailable": {
+          "what": "Microsoft hat den Bot-Namen abgelehnt: Er ist bereits für eine andere Bot-Anwendung registriert.",
+          "next": "Azure-Bot-Handles teilen sich einen einzigen globalen Namensraum über alle Azure-Kunden hinweg — wie ein Domainname, nicht wie ein Name innerhalb deines Tenants. omadia qualifiziert den Handle bereits automatisch mit der ID der App-Registrierung, dieser Name ist also auch in qualifizierter Form vergeben. Vergib dem Agenten einen anderen Bot-Slug und starte das Provisioning erneut."
         }
       },
       "teamsBot": {

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -2093,6 +2093,10 @@
           "what": "The Teams identity is provisioned and installed — only the automatic write into the Teams channel plugin configuration did not go through.",
           "reason": "Reason: {reason}",
           "next": "Paste the configuration block shown below into the Teams channel plugin and save, or re-run provisioning to retry the automatic write. Nothing in Azure has to be repeated."
+        },
+        "bot_handle_unavailable": {
+          "what": "Microsoft refused the bot name: it is already registered to another bot application.",
+          "next": "Azure bot handles share one global namespace across every Azure customer — like a domain name, not a name inside your tenant. omadia already qualifies the handle automatically with the app registration's id, so this name is taken even in its qualified form. Give the agent a different bot slug and start provisioning again."
         }
       },
       "teamsBot": {


### PR DESCRIPTION
Refs #921, part of #860. Companion PR: byte5ai/omadia-m365-connector#11.

Found on the byte5 tenant during the second real provisioning run. The #916 fix held — the Entra app registration survived and the row reached `app_registered` with a real `app_id` — and the run died one step later:

```
arm botServices.put 400 PUT .../resourceGroups/rg-omadia-bots/providers/Microsoft.BotService/botServices/test-hr
{"error":{"code":"InvalidBotData","message":"Bot is not valid. Errors: The bot name is already registered to another bot application."}}
(gave up after 5 attempts)
```

## The bug

`teamsProvisioningJob.ts` passed `botName: row.botSlug` straight through. An Azure Bot Service **handle is globally unique across every Azure customer** — it behaves like a DNS label, not like a subscription- or resource-group-scoped resource name. `test-hr` was taken by a stranger long ago, and so is every short slug an operator would reasonably pick: `hr`, `sales`, `support`.

The contrast was already sitting two lines above. `uniqueName` is carefully namespaced as `omadia-teams-bot-<slug>` even though Entra's uniqueName is only *tenant*-scoped. The identifier with the **stricter** requirement was the one going through unqualified.

## Where the fix belongs

Split along ownership, not convenience:

| Concern | Owner | Why |
|---|---|---|
| Naming convention | **this repo** (runner) | It already builds `uniqueName`/`secretDisplayName` from the slug, and it is the only place that knows both the slug and the freshly obtained `appId`. |
| Length + charset rules | **connector** | It knows the ARM and Bot Framework grammars; `requireBotName` is the boundary that proves any composition is expressible. |
| `InvalidBotData` → typed verdict | **connector**, consumed here | Only the connector sees the ARM status and body. The runner duck-types the result, as it already does for every cross-plugin error. |

## 1. The handle is now qualified

```ts
buildBotHandle('test-hr', '7034c271-6847-…')  // → 'omadia-test-hr-7034c271'
buildBotHandle('hr',      '7034c271-…')       // → 'omadia-hr-7034c271'
buildBotHandle('Sales & Support (EMEA)!!', …) // → 'omadia-sales-support-emea-7034c271'
buildBotHandle('a'.repeat(200), …)            // → 'omadia-aaaaaaaaaaaaaaaaaaaaaaaaaa-7034c271'  (42 chars)
buildBotHandle('!!!', …)                      // → 'omadia-7034c271'
```

The app registration always runs first, so its `appId` GUID is available and already globally unique; the first 8 hex chars separate two omadia installations that picked the same slug while staying readable in the Azure portal.

**Truncation cuts the slug, never the suffix.** Shortening the unique part would reintroduce exactly the collision the qualification exists to prevent — there is a test asserting distinct long slugs still differ, and one asserting the `-<suffix>` survives a 200-char slug.

Handles are deterministic (the appId is persisted), so ARM's `PUT` stays an idempotent upsert across re-runs.

The **messaging endpoint stays keyed on the slug** — it is the channel-teams route `/api/teams/<botSlug>/messages` — so qualifying the ARM handle does not silently re-route inbound traffic. Pinned by a test.

## 2. No more retry storm

`handleFailure` computed `retryable` but only consulted it *at exhaustion*, so every unclassified error burned the full budget and then reported "gave up after 5 attempts". Two terminal branches now run before the retry logic:

- the connector's typed `BotHandleUnavailableError` → fails on attempt one, records a `bot_handle_unavailable:` sentence,
- any `ProvisioningRequestError` with a **deterministic 4xx** (excluding 408/429) → one attempt. This keeps the fix working against an older connector that still reports the collision as an untyped 400 — the runner does not depend on the connector being upgraded in lockstep.

5xx and 429 keep their retries. Both are covered by tests, because a guard that swallowed transients would be a worse bug than the one it fixes.

## 3. Operator-facing copy

New `bot_handle_unavailable` code in the `last_error` vocabulary, its classifier entry, and en/de copy:

> Microsoft refused the bot name: it is already registered to another bot application.
>
> Azure bot handles share one global namespace across every Azure customer — like a domain name, not a name inside your tenant. omadia already qualifies the handle automatically with the app registration's id, so this name is taken even in its qualified form. Give the agent a different bot slug and start provisioning again.

An operator reading the raw Azure message reasonably concludes they have a leftover bot of their own. Now the screen says otherwise.

## Tests

`middleware/test/teamsProvisioningJob.test.ts` (+13 cases):

- the raw slug never reaches ARM; the qualified handle does
- a long slug stays ≤ 42 chars and keeps the unique suffix
- special characters fold to a valid handle; no leading/trailing hyphen from truncation
- the composer's output matches the grammar the connector validates (mirrored regex, so a divergence fails here)
- `BotHandleUnavailableError` → exactly one attempt, no backoff sleep scheduled, no "gave up after"
- an older connector's bare 400 → also one attempt
- 5xx and 429 still retry
- `botHandleUnavailableDetail` round-trips through `classifyTeamsProvisioningError`

`web-ui/app/_lib/__tests__/teamsIdentity.test.ts` (+2): the new code renders its own copy with no external link, and a new contract test asserts the UI's code union matches the middleware classifier's — a code the server can emit but the client cannot render would show a bare i18n key.

## Gates

- `npm run typecheck` (middleware) — clean
- `npm run typecheck:test` — 370 known errors, **no regressions** (baseline 370)
- `npm test` (middleware) — **7835 pass, 0 fail**, 16 skipped
- `web-ui`: `typecheck` clean, `i18n:check` OK (4088 keys, en + de), targeted vitest 43 pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790507562&installation_model_id=428086&pr_number=922&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F922&signature=01f9c361260748bd84c64684c1640765984bc462d0652e10f4b180411b5d28fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->