### PR TITLE
fix(plugins): localize Hub descriptions so German UI stops reading En…

### DIFF
--- a/middleware/packages/agent-seo-analyst/manifest.yaml
+++ b/middleware/packages/agent-seo-analyst/manifest.yaml
@@ -5,7 +5,11 @@ identity:
   domain: "seo"
   name: "SEO Analyst"
   version: "0.1.0"
-  description: "Analyzes websites from an SEO perspective: on-page, technical, structured data, and crawl audits."
+  # OM-50 (#885) — was English-only, which leaked English into the German Hub.
+  # Now bilingual; `en` stays the fallback for search, the English UI and older consumers.
+  description:
+    en: "Analyzes websites from an SEO perspective: on-page, technical, structured data, and crawl audits."
+    de: "Analysiert Websites aus SEO-Sicht: On-Page, Technik, strukturierte Daten und Crawl-Audits."
   authors:
     - name: "byte5 GmbH"
       email: "info@omadia.ai"

--- a/middleware/packages/harness-diagrams/manifest.yaml
+++ b/middleware/packages/harness-diagrams/manifest.yaml
@@ -6,7 +6,11 @@ identity:
   version: "0.1.0"
   kind: "tool"
   domain: "visualization.diagrams"
-  description: "Rendert Mermaid/Graphviz/PlantUML/Vega-Lite-Diagramme über Kroki und liefert signierte PNG-URLs aus Tigris."
+  # OM-50 (#885) — was German-only, which leaked German into the English Hub.
+  # Now bilingual; `en` is the fallback for search, English UI and old consumers.
+  description:
+    en: "Renders diagrams (Mermaid, Graphviz, PlantUML, Vega-Lite) as images that the assistant can include directly in its replies."
+    de: "Rendert Diagramme (Mermaid, Graphviz, PlantUML, Vega-Lite) als Bilder, die der Assistent direkt in seine Antworten einbetten kann."
   authors:
     - name: "byte5 GmbH"
       email: "info@omadia.ai"

--- a/middleware/packages/harness-embeddings/manifest.yaml
+++ b/middleware/packages/harness-embeddings/manifest.yaml
@@ -6,7 +6,11 @@ identity:
   version: "0.1.0"
   kind: "extension"
   domain: "core.embeddings"
-  description: "Stateless embedding-compute plugin (Ollama-compatible /api/embeddings wrapper, concurrency-limited). Provider des Kernel-Service 'embeddingClient' — konsumiert von KG-Ingest, ContextRetriever, FactExtractor, TopicDetector."
+  # OM-50 (#885) — was English-leaning, which leaked English into the German Hub.
+  # Now bilingual; `en` stays the fallback for search, the English UI and older consumers.
+  description:
+    en: "Computes text embeddings via an Ollama-compatible endpoint. Provides the embedding service that knowledge-graph ingest and context retrieval rely on."
+    de: "Berechnet Text-Embeddings über einen Ollama-kompatiblen Endpunkt. Stellt den Embedding-Dienst bereit, auf den Wissensgraph-Aufnahme und Kontextabruf zugreifen."
   authors:
     - name: "byte5 GmbH"
       email: "info@omadia.ai"

--- a/middleware/packages/harness-plugin-office/manifest.yaml
+++ b/middleware/packages/harness-plugin-office/manifest.yaml
@@ -6,7 +6,11 @@ identity:
   version: "0.1.1"
   kind: "tool"
   domain: "productivity.office"
-  description: "Erzeugt .xlsx/.docx-Dokumente deterministisch aus JSON-Descriptoren, legt sie in Tigris ab und liefert signierte /documents-URLs, die Channels als Datei-Anhang rendern."
+  # OM-50 (#885) — was German-only, which leaked German into the English Hub.
+  # Now bilingual; `en` is the fallback for search, English UI and old consumers.
+  description:
+    en: "Generates Excel (.xlsx) and Word (.docx) documents from the assistant's output and delivers them as downloadable file attachments in your channels."
+    de: "Erzeugt Excel- (.xlsx) und Word-Dokumente (.docx) aus den Ergebnissen des Assistenten und stellt sie als herunterladbare Datei-Anhänge in Ihren Kanälen bereit."
   authors:
     - name: "byte5 GmbH"
       email: "info@omadia.ai"

--- a/middleware/packages/harness-plugin-plan-runner/manifest.yaml
+++ b/middleware/packages/harness-plugin-plan-runner/manifest.yaml
@@ -6,7 +6,11 @@ identity:
   version: "0.1.0"
   kind: "extension"
   domain: "orchestrator.plan-runner"
-  description: "#133 plan-as-data — materialises an explicit per-turn plan DAG (Plan + PlanStep nodes in the knowledge graph) on multi-step turns, so the orchestrator can check progress against named sub-goals instead of relying on the model to remember them. Subscribes to the onBeforeTurn hook; gated by a cheap Haiku classifier. On by default (a cheap Haiku gate keeps simple Q&A neutral); set enabled=off to disarm."
+  # OM-50 (#885) — localized so the German Hub reads German. `en` stays the
+  # fallback for search, the English UI and older consumers.
+  description:
+    en: "On multi-step tasks the assistant first lays out an explicit plan and tracks its progress against it instead of improvising. Simple questions are left untouched. Experimental; on by default."
+    de: "Bei mehrstufigen Aufgaben erstellt der Assistent zuerst einen expliziten Plan und verfolgt seinen Fortschritt daran, statt zu improvisieren. Einfache Fragen bleiben unberührt. Experimentell; standardmäßig aktiv."
   authors:
     - name: "byte5 GmbH"
       email: "info@omadia.ai"

--- a/middleware/packages/harness-plugin-privacy-guard/manifest.yaml
+++ b/middleware/packages/harness-plugin-privacy-guard/manifest.yaml
@@ -6,7 +6,11 @@ identity:
   version: "0.5.0"
   kind: "tool"
   domain: "privacy.redact"
-  description: "Privacy Shield v4 core plugin. Publishes the `privacy.redact@1` capability — a Data-Plane Boundary that interns raw tool results server-side and hands the LLM only an identity-free Digest. Identity-/order-critical work runs through a server-side Verb API; the final answer is materialized from ground truth. Emits a PII-free PrivacyReceipt the channel renderers (Teams Adaptive-Card, Web inline disclosure) consume to surface what was protected on each turn."
+  # OM-50 (#885) — localized so the German Hub reads German. `en` stays the
+  # fallback for search, the English UI and older consumers.
+  description:
+    en: "Keeps personal and sensitive data out of the language model. Raw values stay on the server, the model only sees anonymized placeholders, and every answer records what was protected — shown inline in Teams and the web channel."
+    de: "Hält personenbezogene und sensible Daten vom Sprachmodell fern. Rohwerte bleiben auf dem Server, das Modell sieht nur anonymisierte Platzhalter, und jede Antwort weist aus, was geschützt wurde — direkt sichtbar in Teams und im Web-Kanal."
   authors:
     - name: "byte5 GmbH"
       email: "info@omadia.ai"

--- a/middleware/packages/harness-plugin-quality-guard/manifest.yaml
+++ b/middleware/packages/harness-plugin-quality-guard/manifest.yaml
@@ -6,7 +6,11 @@ identity:
   version: "0.1.0"
   kind: "tool"
   domain: "quality.response-guard"
-  description: "Response-quality core plugin. Publishes the `responseGuard@1` capability with sycophancy-levels (off/low/medium/high) and a boundary-preset library that splices guardrails into the system prompt ahead of body prose."
+  # OM-50 (#885) — localized so the German Hub reads German. `en` stays the
+  # fallback for search, the English UI and older consumers.
+  description:
+    en: "Adds guardrails to the assistant's replies: adjustable anti-flattery levels (off/low/medium/high) and reusable rule presets that shape tone and keep answers within set boundaries."
+    de: "Ergänzt die Antworten des Assistenten um Leitplanken: einstellbare Stufen gegen Gefälligkeitsantworten (aus/niedrig/mittel/hoch) und wiederverwendbare Regel-Vorlagen, die Tonfall und Grenzen der Antworten festlegen."
   authors:
     - name: "byte5 GmbH"
       email: "info@omadia.ai"

--- a/middleware/packages/harness-plugin-web-search/manifest.yaml
+++ b/middleware/packages/harness-plugin-web-search/manifest.yaml
@@ -6,7 +6,11 @@ identity:
   version: "0.1.0"
   kind: "tool"
   domain: "web.search"
-  description: "Live web-search core plugin (Tavily / Brave). Publishes the `webSearch@1` capability and a `web_search` native tool with structured citation objects."
+  # OM-50 (#885) — localized so the German Hub reads German. `en` stays the
+  # fallback for search, the English UI and older consumers.
+  description:
+    en: "Live web search via Tavily or Brave. Lets the assistant look up current information on the web and answer with cited sources."
+    de: "Live-Websuche über Tavily oder Brave. Ermöglicht dem Assistenten, aktuelle Informationen im Web nachzuschlagen und Antworten mit Quellenangaben zu belegen."
   authors:
     - name: "byte5 GmbH"
       email: "info@omadia.ai"

--- a/middleware/test/pluginHubDescriptionsLocalized.test.ts
+++ b/middleware/test/pluginHubDescriptionsLocalized.test.ts
@@ -1,0 +1,117 @@
+/**
+ * OM-50 (#885) — English plugin descriptions leaked into the German Hub because
+ * manifests declared `identity.description` as a bare single-language string.
+ *
+ * Mechanism (verified against `normalizeLocalized`/`pickLocalized`): a bare
+ * string normalises to `{ en: … }`, so it carries NO `de`. The German Hub then
+ * resolves `de → (miss) → en` and the operator reads English prose. (The reverse
+ * also happens — a bare *German* string normalises to `{ en: <German> }` and
+ * leaks German into the *English* Hub — but OM-50's betatest finding is the
+ * English-into-German direction, so that is what this PR closes.)
+ *
+ * The localized-map path already exists (#602 / OM-28): a `{ en, de }` map on
+ * `identity.description` rides along as `description_localized`, which the web-UI
+ * resolves with `pickLocalized` (`PluginCard.tsx`). The Hub store list applies
+ * NO kind filter (`routes/store.ts`) and the web-UI shows every kind under the
+ * default tab, so both `kind:tool` plugins AND the localized extensions surface
+ * to the operator.
+ *
+ * This test DISCOVERS manifests instead of hard-coding an allowlist, so a new
+ * `kind:tool` shipped with a bare (English) description fails HERE — at the
+ * exact silent-scope-cap that let OM-50 sit open across two betatest rounds —
+ * instead of at the next tester's desk. Everything is read back out of the
+ * produced catalog entry (`loadManifestFromPath`), never the raw YAML: that is
+ * the value the Hub actually renders.
+ */
+
+import { strict as assert } from 'node:assert';
+import { access, readdir } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+import { loadManifestFromPath } from '../src/plugins/manifestLoader.js';
+
+const PACKAGES_DIR = fileURLToPath(new URL('../packages/', import.meta.url));
+
+/**
+ * Non-tool plugins that ARE Hub-visible and were English (or English-leaning),
+ * so the German operator hit English prose — localized in this PR. Pinned by id
+ * so a dropped German (or a revert to a bare string) fails loudly. The many
+ * already-German extensions are deliberately NOT here: they read correctly for
+ * the German operator; their reverse leak (German → English Hub) is lower
+ * priority and out of this PR's scope.
+ */
+const EXTRA_LOCALIZED: ReadonlyArray<string> = [
+  '@omadia/plugin-plan-runner',
+  '@omadia/agent-seo-analyst',
+  '@omadia/embeddings',
+];
+
+/** Load every package's manifest.yaml into its catalog entry (skips dirs
+ *  without a manifest — e.g. `plugin-api`). */
+async function loadAllManifestEntries() {
+  const dirs = await readdir(PACKAGES_DIR, { withFileTypes: true });
+  const entries = [];
+  for (const d of dirs) {
+    if (!d.isDirectory()) continue;
+    const manifestPath = `${PACKAGES_DIR}${d.name}/manifest.yaml`;
+    // Skip package dirs without a manifest (e.g. `plugin-api`) before loading,
+    // so the loader never logs a spurious ENOENT into the test output.
+    const hasManifest = await access(manifestPath).then(
+      () => true,
+      () => false,
+    );
+    if (!hasManifest) continue;
+    const entry = await loadManifestFromPath(manifestPath);
+    if (entry) entries.push(entry);
+  }
+  return entries;
+}
+
+/** Assert the catalog entry's rendered German Hub value differs from English —
+ *  i.e. the German operator does NOT fall through to English. */
+function assertBilingual(entry: NonNullable<Awaited<ReturnType<typeof loadManifestFromPath>>>) {
+  const id = entry.plugin.id;
+  const map = entry.plugin.description_localized;
+  assert.ok(
+    map,
+    `${id} must carry description_localized — a bare-string description leaks ` +
+      `the wrong language into the Hub`,
+  );
+  const en = map['en'];
+  const de = map['de'];
+  assert.ok(en && en.trim().length > 0, `${id} description_localized.en must be non-empty`);
+  assert.ok(de && de.trim().length > 0, `${id} description_localized.de must be non-empty`);
+  // If de === en the German operator is still reading English — the whole point.
+  assert.notEqual(de.trim(), en.trim(), `${id} German description must differ from English`);
+  // Plugin.description (search, English UI, older consumers) stays the resolved
+  // English string — the map is additive, never a regression for the English side.
+  assert.equal(
+    entry.plugin.description,
+    en,
+    `${id} resolved English description must equal description_localized.en`,
+  );
+}
+
+describe('OM-50 — the German Hub never falls through to English', () => {
+  it('every kind:tool plugin ships a bilingual (en+de) description', async () => {
+    const entries = await loadAllManifestEntries();
+    const tools = entries.filter(
+      (e) => e.plugin.kind === 'tool' && e.plugin.is_reference_only !== true,
+    );
+    // Guard the discovery itself: if the glob finds nothing the assertions below
+    // pass vacuously and the test would rot into a no-op.
+    assert.ok(tools.length >= 5, `expected to discover the Hub tools, found ${tools.length}`);
+    for (const entry of tools) assertBilingual(entry);
+  });
+
+  it('the extra Hub-visible plugins localized for the English leak stay bilingual', async () => {
+    const entries = await loadAllManifestEntries();
+    const byId = new Map(entries.map((e) => [e.plugin.id, e]));
+    for (const id of EXTRA_LOCALIZED) {
+      const entry = byId.get(id);
+      assert.ok(entry, `${id} manifest must load (it is pinned as a localized Hub plugin)`);
+      assertBilingual(entry);
+    }
+  });
+});


### PR DESCRIPTION
## What
  Localize plugin Hub descriptions so the German Hub stops rendering English developer prose (OM-50, #885). Every `kind:tool` plugin plus the English-leaning extensions (`agent-seo-analyst`, `embeddings`) now ship `{ en, de }` maps on `identity.description`.

  ## Why
  The Hub renders `identity.description` straight from each manifest. A bare single-language string normalises to `{ en: … }`, so the German Hub resolves `de → (miss) → en` and a business user picking what to install reads jargon like "capability", "native tool", "for the byte5 Harness". Open across two betatest rounds. The `{ en, de }` path already exists (#602); this wires the Hub tools into it and rewrites the prose into business language, with `en` staying the fallback for search, the English UI and older consumers.

  ## Test plan
  - [x] `node --test test/pluginHubDescriptionsLocalized.test.ts` — 2/2 pass (discovers manifests, asserts every `kind:tool` + the pinned extras ship a
  non-empty `en`≠`de` description, read back out of the produced catalog entry)
  - [X] `npm run lint && npm run typecheck && npm run test` in middleware
  - [X] manual: German Hub — confirm the 5 tools + plan-runner + seo-analyst + embeddings render German; English Hub still renders English

  ## Risk / blast radius
  - Manifest-only + one test. No schema, API, or env-var change. `description_localized` is additive — English side unchanged (test pins `plugin.description === en`).
  - `package.json` descriptions left as-is: dev/npm metadata, **not** the Hub source (checked only for name+version at upload). Still contains "for the byte5 Harness" by design.
  - Reverse leak (German-jargon extensions → English Hub) deferred, lower priority — documented in the test comment.
  
   ## Scope — OM-50 not fully closed
  The German Hub is served from the **remote registry** (`/registry/index.json`, 30 entries), not only local packages. This PR fixes what this repo owns. The most visible remaining leaks are 4 **fully-English** cards published from **external plugin repos** — not editable here, need their own PRs:

  - `@omadia/integration-dynamics-crm` (Microsoft Dynamics 365)
  - `@omadia/integration-bexio` (Bexio)
  - `@omadia/agent-laravel-cloud` (Laravel Cloud)
  - `@omadia/dev-platform` (Dev Platform)

Lower-priority Denglish (Teams / Telegram / Odoo / Confluence connectors) also lives in those external repos. Recommend keeping OM-50 open, or spinning a follow-up, until the registry side lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790517632&installation_model_id=428086&pr_number=942&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F942&signature=4b8e31e32d4fc203ba412aef75998c7a9c8719408a9d19323ded781dbd605022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->