### PR TITLE
fix: promote a release to latest only once its artifacts exist

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -30,9 +30,11 @@ name: auto-release
 #   2. That choice is conditional on `allowPrerelease`, which AppUpdater derives
 #      from the running version (`hasPrereleaseComponents`). It is false only
 #      because set-desktop-version.mjs writes plain semver. Adopt any prerelease
-#      version scheme and it flips true, activating the first-atom-entry path
-#      where `make_latest` is ignored entirely — and this protection would
-#      silently stop working. A draft is invisible either way.
+#      version scheme and it flips true, moving version selection onto the atom
+#      feed, where `make_latest` is ignored entirely — and this protection would
+#      silently stop working. (Which atom branch depends on the channel: with no
+#      channel it takes the first entry, with one it scans entries for a match.
+#      Either way the flag is not consulted.) A draft is invisible either way.
 # A draft also keeps a half-built release off the Releases page while it is
 # unusable, rather than showing one nobody can install.
 #
@@ -200,7 +202,15 @@ jobs:
   # Failure semantics, deliberately chosen: if the feed never published, the
   # release STAYS A DRAFT and this job fails red. The previous release keeps the
   # latest flag, so existing installs keep updating to the last version that can
-  # actually be downloaded; nothing half-published ever becomes latest. The cost
+  # actually be downloaded; no release lacking its macOS feed becomes latest.
+  #
+  # Note the limit of that promise: this gate is macOS-only, by the same design
+  # decision as gating on the feed output rather than the job result. A red
+  # WINDOWS leg still promotes, so `latest.yml` can be missing while the release
+  # is flagged latest, and Windows clients then hit OM-69's 404 on their own feed.
+  # That is a deliberate trade — withholding promotion on any red leg would leave
+  # macOS auto-update dead until the next fully green release — not a guarantee.
+  # Extending the assertion to `latest.yml` is the obvious follow-up. The cost
   # is that the new release notes stay invisible until someone acts, which is why
   # this job fails loudly instead of exiting 0 — a red run is the signal. Recover
   # by re-running the desktop-apps job, or publish by hand once the artifacts are

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -7,16 +7,34 @@ name: auto-release
 #
 # TWO-PHASE PUBLISH (#928). The release is created as a DRAFT and only promoted
 # to published+latest once `desktop-apps` has attached the merged
-# `latest-mac.yml`. It has to be a draft, not merely `--latest=false`:
-# electron-updater's GitHubProvider resolves "latest" by fetching
-# `<repo>/releases.atom` and taking the FIRST entry, and that feed is ordered by
-# publication with no notion of GitHub's `make_latest` flag — so an unflagged
-# but published release is still the one every client queries. Drafts are absent
-# from the feed entirely, which is the only thing that actually holds clients on
-# the previous release. Before this, every release opened a 30-60 minute window
-# (macOS arm64 21 min + Intel >30 min + Apple-controlled notarization) in which
-# every macOS install asked for a `latest-mac.yml` that did not exist yet and got
-# a 404 — 144 releases since 2026-07-06, five on one day.
+# `latest-mac.yml` AND the installers that feed references.
+#
+# The problem: `desktop-apps` runs `needs: release`, and `latest-mac.yml` only
+# exists once both mac architectures finish and merge-mac-update-feed.mjs has
+# combined them — macOS arm64 21 min + Intel >30 min by that workflow's own
+# measurements, plus notarization on Apple's clock. Flagging the release latest
+# up front therefore opened a 30-60 minute window per release in which every
+# macOS install asked for a file that did not exist yet and got a 404. 144
+# releases since 2026-07-06, five on one day.
+#
+# Why a DRAFT rather than just clearing `make_latest`: clearing the flag alone
+# would in fact work today. electron-updater (6.8.9, GitHubProvider) resolves the
+# version through `getLatestTagName()` -> `GET <repo>/releases/latest` with
+# `Accept: application/json`, reading `tag_name` — and that endpoint honours
+# `make_latest`. It also fetches `releases.atom`, but in our configuration only to
+# locate the matching entry for the release notes.
+#
+# A draft is preferred because it is strictly stronger, in two ways that matter:
+#   1. It is absent from BOTH `/releases/latest` and `releases.atom`, so it does
+#      not depend on which of the two the provider happens to consult.
+#   2. That choice is conditional on `allowPrerelease`, which AppUpdater derives
+#      from the running version (`hasPrereleaseComponents`). It is false only
+#      because set-desktop-version.mjs writes plain semver. Adopt any prerelease
+#      version scheme and it flips true, activating the first-atom-entry path
+#      where `make_latest` is ignored entirely — and this protection would
+#      silently stop working. A draft is invisible either way.
+# A draft also keeps a half-built release off the Releases page while it is
+# unusable, rather than showing one nobody can install.
 #
 # HARD RULE: every tagged release gets a clean, categorized changelog with no
 # manual step required — enforced by construction, since it's part of the
@@ -187,6 +205,14 @@ jobs:
   # this job fails loudly instead of exiting 0 — a red run is the signal. Recover
   # by re-running the desktop-apps job, or publish by hand once the artifacts are
   # attached: `gh release edit <tag> --draft=false --latest`.
+  #
+  # Do not leave a stuck draft sitting, for two reasons beyond the invisible
+  # notes. `publish-images` only needs `release`, so the container `:latest` tag
+  # ships from a version desktop clients cannot get — the two channels drift
+  # apart for as long as the draft stands. And the changelog range comes from
+  # `git tag -l` while the tag is pushed before the release is created, so the
+  # NEXT release's notes start after the stuck tag: those commits then appear in
+  # no published release notes at all unless the draft is published.
   #
   # Note: publishing via GITHUB_TOKEN does NOT fire a `release: published` event
   # (GitHub's Actions loop protection — the same reason publish-images and

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -5,6 +5,19 @@ name: auto-release
 # tag + a GitHub Release with a categorized changelog (Added/Changed/Fixed,
 # generated from commit subjects by .github/scripts/generate-changelog.mjs).
 #
+# TWO-PHASE PUBLISH (#928). The release is created as a DRAFT and only promoted
+# to published+latest once `desktop-apps` has attached the merged
+# `latest-mac.yml`. It has to be a draft, not merely `--latest=false`:
+# electron-updater's GitHubProvider resolves "latest" by fetching
+# `<repo>/releases.atom` and taking the FIRST entry, and that feed is ordered by
+# publication with no notion of GitHub's `make_latest` flag — so an unflagged
+# but published release is still the one every client queries. Drafts are absent
+# from the feed entirely, which is the only thing that actually holds clients on
+# the previous release. Before this, every release opened a 30-60 minute window
+# (macOS arm64 21 min + Intel >30 min + Apple-controlled notarization) in which
+# every macOS install asked for a `latest-mac.yml` that did not exist yet and got
+# a 404 — 144 releases since 2026-07-06, five on one day.
+#
 # HARD RULE: every tagged release gets a clean, categorized changelog with no
 # manual step required — enforced by construction, since it's part of the
 # same job that creates the tag: there is no code path that tags a release
@@ -116,7 +129,10 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$new" -m "omadia $new"
           git push origin "$new"
-          gh release create "$new" --notes-file /tmp/release-notes.md --title "omadia $new" --latest
+          # --draft, NOT --latest: see TWO-PHASE PUBLISH at the top of this file.
+          # The `promote-release` job below publishes it once macOS clients can
+          # actually resolve an update for it.
+          gh release create "$new" --notes-file /tmp/release-notes.md --title "omadia $new" --draft
           # Hand the new tag to the publish-images job below. A GITHUB_TOKEN
           # release does not fire a `release` event, so the image build must run
           # here in the same workflow rather than via an event trigger.
@@ -147,4 +163,60 @@ jobs:
     uses: ./.github/workflows/desktop-apps.yml
     with:
       tag: ${{ needs.release.outputs.new_tag }}
+      # The release exists by construction here, so a lookup miss is a real
+      # fault: fail rather than silently attaching nothing to it.
+      require_release: true
     secrets: inherit
+
+  # Phase two of TWO-PHASE PUBLISH (#928): flip the draft to published + latest,
+  # but only once the merged macOS update feed is attached to it.
+  #
+  # Gated on desktop-apps' `mac_feed_published` output rather than on its result:
+  # `build` is fail-fast:false, so a broken Windows leg fails the called workflow
+  # while the macOS feed published fine — and withholding the promotion for that
+  # would leave macOS auto-update dead until the next fully green release, which
+  # is the failure mode OM-69 describes rather than a fix for it.
+  #
+  # `always()` so this still evaluates when desktop-apps reports failure.
+  #
+  # Failure semantics, deliberately chosen: if the feed never published, the
+  # release STAYS A DRAFT and this job fails red. The previous release keeps the
+  # latest flag, so existing installs keep updating to the last version that can
+  # actually be downloaded; nothing half-published ever becomes latest. The cost
+  # is that the new release notes stay invisible until someone acts, which is why
+  # this job fails loudly instead of exiting 0 — a red run is the signal. Recover
+  # by re-running the desktop-apps job, or publish by hand once the artifacts are
+  # attached: `gh release edit <tag> --draft=false --latest`.
+  #
+  # Note: publishing via GITHUB_TOKEN does NOT fire a `release: published` event
+  # (GitHub's Actions loop protection — the same reason publish-images and
+  # desktop-apps are called in-run here), so this cannot re-trigger
+  # desktop-apps.yml's `release` trigger. Do not "fix" that by switching to a PAT
+  # without re-checking it.
+  promote-release:
+    needs: [release, desktop-apps]
+    if: ${{ always() && needs.release.outputs.new_tag != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish the draft and flag it latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.release.outputs.new_tag }}
+          MAC_FEED_PUBLISHED: ${{ needs.desktop-apps.outputs.mac_feed_published }}
+          DESKTOP_RESULT: ${{ needs.desktop-apps.result }}
+        run: |
+          set -euo pipefail
+
+          if [ "$MAC_FEED_PUBLISHED" != "true" ]; then
+            echo "::error::$TAG stays a DRAFT: desktop-apps finished $DESKTOP_RESULT without" >&2
+            echo "         attaching a merged latest-mac.yml, so a macOS client could not" >&2
+            echo "         download this version. The previous release keeps the latest flag." >&2
+            echo "         Re-run the desktop-apps job, or once its artifacts are attached:" >&2
+            echo "           gh release edit $TAG --draft=false --latest" >&2
+            exit 1
+          fi
+
+          gh release edit "$TAG" --draft=false --latest
+          echo "published $TAG and flagged it latest (desktop-apps: $DESKTOP_RESULT)"

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -546,6 +546,10 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: omadia-installers-${{ matrix.os }}
+          # Artifact names are unique per run, not per attempt. Without this, the
+          # documented stuck-draft recovery ("re-run the failed jobs") 409s here,
+          # skips the release upload below, and wedges the draft a second time.
+          overwrite: true
           if-no-files-found: ignore
           path: |
             desktop/release/*.dmg
@@ -703,8 +707,11 @@ jobs:
           # would flag a release latest whose latest-mac.yml references assets
           # that were never attached — OM-69's exact user-visible symptom, under
           # a green run. So assert attachment before claiming the feed is usable.
+          # `state` is `starter` until the upload body finishes; such a record is
+          # listed but 404s on download. Counting it would let the gate go green
+          # on exactly the transient-upload failure it was added to catch.
           gh api --paginate "repos/$GITHUB_REPOSITORY/releases/$release_id/assets?per_page=100" \
-            --jq '.[].name' > /tmp/release-assets.txt
+            --jq '.[] | select(.state == "uploaded") | .name' > /tmp/release-assets.txt
           node --input-type=module -e '
             import fs from "node:fs";
             const { parseFeed } = await import("./desktop/scripts/merge-mac-update-feed.mjs");

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -70,7 +70,12 @@ on:
         # macOS feed publishes perfectly well. Keying on the workflow result
         # would withhold the promotion and leave the macOS update channel dead
         # until the next fully green release -- the exact outcome OM-69 reports.
-        description: 'true when the merged latest-mac.yml was attached to the release'
+        #
+        # True means: the merged feed is attached AND every installer it
+        # references is attached too. The second half is not redundant -- see the
+        # assertion in the mac-update-feed upload step for why a valid feed alone
+        # proves nothing about the assets.
+        description: 'true when latest-mac.yml and the installers it references are attached'
         value: ${{ jobs.mac-update-feed.outputs.published }}
 
 concurrency:
@@ -576,15 +581,27 @@ jobs:
           fi
           # If TAG has no matching release (e.g. a build-validation dispatch on a
           # branch name), this is a build-only run — skip upload, don't fail.
-          # `gh release view <tag>` is NOT usable for this test any more: since
-          # #928 the release is created as a DRAFT, and GitHub's
-          # `GET /releases/tags/{tag}` does not return drafts. The list endpoint
-          # does, for a token with push access, and returns newest-first so the
-          # release just cut is on the first page.
+          # Resolve the release by tag through the LIST endpoint, which includes
+          # drafts for a token with push access (`GET /releases/tags/{tag}` does
+          # not, and since #928 the release is a draft until promoted).
+          #
+          # `--paginate` is not optional: this repo has 237 releases and a single
+          # per_page=100 page reaches back only to v0.78.0, so a rebuild
+          # dispatched for an older tag would find nothing and — on the dispatch
+          # path, where require_release is false — silently skip the upload and
+          # report a green run that attached nothing. `--jq` is applied per page,
+          # so a hit emits one line and misses emit nothing.
+          #
           # gh's own --jq (gojq) rather than piping to jq: gh is guaranteed on
           # every runner this matrix uses, jq is not part of that contract, and
           # this step also runs on windows-latest.
-          if ! release_id=$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+          #
+          # `gh release upload "$TAG"` below does work against a draft: gh's
+          # FetchRelease looks up a published release by tag and falls back to
+          # finding a draft by its pending tag name. That fallback is the single
+          # assumption the whole draft flow depends on, so it is stated here
+          # rather than left implicit.
+          if ! release_id=$(gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
                  --jq 'map(select(.tag_name == env.TAG)) | .[0].id // empty'); then
             echo "could not query releases for '$TAG'" >&2
             exit 1
@@ -665,10 +682,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # Draft-aware lookup — see the matching note in the installer upload
-          # step above: the release is a draft until auto-release.yml promotes
-          # it, and the by-tag endpoint hides drafts.
-          release_id=$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+          # Draft-aware, paginated lookup — see the matching note in the
+          # installer upload step above for both reasons.
+          release_id=$(gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
             --jq 'map(select(.tag_name == env.TAG)) | .[0].id // empty')
           if [ -z "$release_id" ]; then
             if [ "${REQUIRE_RELEASE:-false}" = "true" ]; then
@@ -679,7 +695,37 @@ jobs:
             echo "no GitHub Release for '$TAG' — merge validated, skipping upload."
             exit 0
           fi
+          # A valid merged feed does NOT prove the installers it points at are on
+          # the release. The feed is assembled from RUN artifacts (uploaded by an
+          # `if: always()` step that runs BEFORE the release upload), so a mac
+          # leg whose "Upload installers to the release" step failed transiently
+          # still yields a complete, mergeable feed. Publishing on that alone
+          # would flag a release latest whose latest-mac.yml references assets
+          # that were never attached — OM-69's exact user-visible symptom, under
+          # a green run. So assert attachment before claiming the feed is usable.
+          gh api --paginate "repos/$GITHUB_REPOSITORY/releases/$release_id/assets?per_page=100" \
+            --jq '.[].name' > /tmp/release-assets.txt
+          node --input-type=module -e '
+            import fs from "node:fs";
+            const { parseFeed } = await import("./desktop/scripts/merge-mac-update-feed.mjs");
+            const feed = parseFeed(fs.readFileSync("latest-mac.yml", "utf8"), "latest-mac.yml");
+            // electron-builder percent-encodes these; release asset names are raw.
+            const refs = new Set();
+            if (feed.scalars.path) refs.add(decodeURIComponent(feed.scalars.path));
+            for (const f of feed.files) if (f.url) refs.add(decodeURIComponent(f.url));
+            const attached = new Set(
+              fs.readFileSync("/tmp/release-assets.txt", "utf8").split("\n").filter(Boolean),
+            );
+            const missing = [...refs].filter((r) => !attached.has(r));
+            if (missing.length > 0) {
+              console.error("::error::latest-mac.yml references files that are NOT attached to");
+              console.error("         the release, so macOS clients could not download this");
+              console.error("         version: " + missing.join(", "));
+              process.exit(1);
+            }
+            console.log("all " + refs.size + " file(s) referenced by latest-mac.yml are attached");
+          '
           gh release upload "$TAG" latest-mac.yml --clobber
-          # Only now is it true that a macOS client can resolve an update for
-          # this tag. auto-release.yml gates the `--latest` promotion on this.
+          # Now it is true that a macOS client can resolve AND download an update
+          # for this tag. auto-release.yml gates the `--latest` promotion on this.
           echo "published=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/desktop-apps.yml
+++ b/.github/workflows/desktop-apps.yml
@@ -51,6 +51,27 @@ on:
         description: 'Release tag to build + attach to'
         required: true
         type: string
+      require_release:
+        # auto-release.yml has just cut the release for this tag, so a missing
+        # one there means something went wrong -- not the build-validation case
+        # that the soft "skipping upload" path exists for. Without this, a
+        # release the upload steps cannot find would produce a GREEN run that
+        # attached nothing: the silent-failure shape this repo's own beta
+        # findings keep hitting.
+        description: 'Fail instead of skipping when the tag has no GitHub Release'
+        required: false
+        default: false
+        type: boolean
+    outputs:
+      mac_feed_published:
+        # Gates the release promotion in auto-release.yml (#928). Deliberately
+        # keyed on the FEED, not on this workflow's overall result: `build` runs
+        # fail-fast:false, so a broken Windows leg fails the workflow while the
+        # macOS feed publishes perfectly well. Keying on the workflow result
+        # would withhold the promotion and leave the macOS update channel dead
+        # until the next fully green release -- the exact outcome OM-69 reports.
+        description: 'true when the merged latest-mac.yml was attached to the release'
+        value: ${{ jobs.mac-update-feed.outputs.published }}
 
 concurrency:
   group: desktop-apps-${{ github.event.release.tag_name || inputs.tag }}
@@ -93,6 +114,9 @@ jobs:
     timeout-minutes: 60
     env:
       TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      # Undefined for the `release` and `workflow_dispatch` triggers, so those
+      # keep the historical soft-skip behaviour; only workflow_call opts in.
+      REQUIRE_RELEASE: ${{ inputs.require_release && 'true' || 'false' }}
       # 'yes' unless a workflow_dispatch explicitly passed notarize=false. The
       # `release` event and workflow_call leave the input undefined, so they
       # always notarize — a release can never accidentally skip it.
@@ -552,7 +576,26 @@ jobs:
           fi
           # If TAG has no matching release (e.g. a build-validation dispatch on a
           # branch name), this is a build-only run — skip upload, don't fail.
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
+          # `gh release view <tag>` is NOT usable for this test any more: since
+          # #928 the release is created as a DRAFT, and GitHub's
+          # `GET /releases/tags/{tag}` does not return drafts. The list endpoint
+          # does, for a token with push access, and returns newest-first so the
+          # release just cut is on the first page.
+          # gh's own --jq (gojq) rather than piping to jq: gh is guaranteed on
+          # every runner this matrix uses, jq is not part of that contract, and
+          # this step also runs on windows-latest.
+          if ! release_id=$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+                 --jq 'map(select(.tag_name == env.TAG)) | .[0].id // empty'); then
+            echo "could not query releases for '$TAG'" >&2
+            exit 1
+          fi
+          if [ -z "$release_id" ]; then
+            if [ "${REQUIRE_RELEASE:-false}" = "true" ]; then
+              echo "::error::no GitHub Release (draft or published) for '$TAG', but this run was" >&2
+              echo "         invoked with require_release — refusing to report success while" >&2
+              echo "         attaching no installers." >&2
+              exit 1
+            fi
             echo "no GitHub Release for '$TAG' — build validated, skipping upload."
             exit 0
           fi
@@ -575,8 +618,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      # Consumed by auto-release.yml to decide whether the draft release may be
+      # published + flagged latest (#928).
+      published: ${{ steps.upload-feed.outputs.published }}
     env:
       TAG: ${{ github.event.release.tag_name || inputs.tag }}
+      REQUIRE_RELEASE: ${{ inputs.require_release && 'true' || 'false' }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -612,11 +660,26 @@ jobs:
           cat latest-mac.yml
 
       - name: Upload the merged feed to the release
+        id: upload-feed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
+          set -euo pipefail
+          # Draft-aware lookup — see the matching note in the installer upload
+          # step above: the release is a draft until auto-release.yml promotes
+          # it, and the by-tag endpoint hides drafts.
+          release_id=$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+            --jq 'map(select(.tag_name == env.TAG)) | .[0].id // empty')
+          if [ -z "$release_id" ]; then
+            if [ "${REQUIRE_RELEASE:-false}" = "true" ]; then
+              echo "::error::no GitHub Release (draft or published) for '$TAG', but this run was" >&2
+              echo "         invoked with require_release — refusing to report a published feed." >&2
+              exit 1
+            fi
             echo "no GitHub Release for '$TAG' — merge validated, skipping upload."
             exit 0
           fi
           gh release upload "$TAG" latest-mac.yml --clobber
+          # Only now is it true that a macOS client can resolve an update for
+          # this tag. auto-release.yml gates the `--latest` promotion on this.
+          echo "published=true" >> "$GITHUB_OUTPUT"

--- a/desktop/src/updater.ts
+++ b/desktop/src/updater.ts
@@ -72,8 +72,8 @@ export function initUpdater(): void {
     if (!shouldNotify) return;
     void showUpdaterDialog({
       type: 'warning',
-      title: 'Update check keeps failing',
-      message: `omadia could not check for updates on the last ${consecutiveFailures} starts.`,
+      title: 'Updates are not getting through',
+      message: `omadia could not fetch an update on the last ${consecutiveFailures} starts.`,
       detail:
         `You are still running ${app.getVersion()}. omadia will keep trying in the background. ` +
         'If this persists, download the current version from ' +
@@ -83,7 +83,6 @@ export function initUpdater(): void {
   });
   autoUpdater.on('update-available', (info) => {
     log.info(`[updater] update available: ${info.version}`);
-    recordCheckReachedFeed();
     if (!takeManualCheckPending()) return;
     void showUpdaterDialog({
       type: 'info',
@@ -105,6 +104,12 @@ export function initUpdater(): void {
   });
   autoUpdater.on('update-downloaded', async (info) => {
     log.info(`[updater] downloaded ${info.version}`);
+    // Deliberately here and NOT on 'update-available': autoDownload is on, so a
+    // download follows immediately and its failures arrive on the same 'error'
+    // event. Resetting when the update was merely ANNOUNCED would clear the
+    // streak on every start before the download could fail, capping it at 1 and
+    // guaranteeing the warning below never fires for a broken download.
+    recordCheckReachedFeed();
     // This restart decision is intentionally unbounded: installing an update
     // without explicit user consent would be worse than waiting for it here.
     const { response } = await dialog.showMessageBox({

--- a/desktop/src/updater.ts
+++ b/desktop/src/updater.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { embeddedDbDir, snapshotDir } from './paths';
 import { getActiveSupervisor } from './supervisor';
 import { log } from './log';
+import { recordCheckFailed, recordCheckReachedFeed } from './updaterCheckHealth';
 
 let installing = false;
 // This flag is only safe because electron-updater's own checkForUpdates()
@@ -54,16 +55,35 @@ export function initUpdater(): void {
 
   autoUpdater.on('error', (err) => {
     log.error(`[updater] ${String(err)}`);
-    if (!takeManualCheckPending()) return;
+    const manual = takeManualCheckPending();
+    const { consecutiveFailures, shouldNotify } = recordCheckFailed(manual);
+    if (manual) {
+      void showUpdaterDialog({
+        type: 'error',
+        title: 'Update check failed',
+        message: 'omadia could not check for updates.',
+        detail: String(err),
+      });
+      return;
+    }
+    // The silent startup check. Logging and nothing else is what let a dead
+    // update channel look exactly like "already up to date" (#928/OM-69), so
+    // break the silence — once per streak, so it can never become a nag.
+    if (!shouldNotify) return;
     void showUpdaterDialog({
-      type: 'error',
-      title: 'Update check failed',
-      message: 'omadia could not check for updates.',
-      detail: String(err),
+      type: 'warning',
+      title: 'Update check keeps failing',
+      message: `omadia could not check for updates on the last ${consecutiveFailures} starts.`,
+      detail:
+        `You are still running ${app.getVersion()}. omadia will keep trying in the background. ` +
+        'If this persists, download the current version from ' +
+        'https://github.com/byte5ai/omadia/releases.\n\n' +
+        `Last error: ${String(err)}`,
     });
   });
   autoUpdater.on('update-available', (info) => {
     log.info(`[updater] update available: ${info.version}`);
+    recordCheckReachedFeed();
     if (!takeManualCheckPending()) return;
     void showUpdaterDialog({
       type: 'info',
@@ -74,6 +94,7 @@ export function initUpdater(): void {
   });
   autoUpdater.on('update-not-available', (info) => {
     log.info(`[updater] up to date: ${info.version}`);
+    recordCheckReachedFeed();
     if (!takeManualCheckPending()) return;
     void showUpdaterDialog({
       type: 'info',

--- a/desktop/src/updaterCheckHealth.ts
+++ b/desktop/src/updaterCheckHealth.ts
@@ -1,0 +1,112 @@
+import { app } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+import { log } from './log';
+
+/**
+ * Consecutive failed *silent* update checks before omadia says so once (#928).
+ *
+ * A failed check is not the same state as "you are up to date", but until now
+ * both looked identical to anyone who never opens the tray menu: the startup
+ * check logs its error and stops there. A dead update channel was therefore
+ * indistinguishable from being current — the mechanism behind OM-52 and OM-69.
+ *
+ * Three is deliberately conservative. `initUpdater()` runs one check per app
+ * start, so this counts app starts, not retries within a session: a single
+ * network blip, or the brief window right after a release, must not produce a
+ * dialog. A channel that stays broken across three starts is not a blip.
+ */
+export const FAILURE_STREAK_BEFORE_NOTICE = 3;
+
+export interface CheckHealth {
+  readonly consecutiveFailures: number;
+  /** True once the user has been told about the CURRENT streak. */
+  readonly noticeShown: boolean;
+}
+
+const HEALTHY: CheckHealth = { consecutiveFailures: 0, noticeShown: false };
+
+/**
+ * Kept in Electron's own userData dir rather than under the user-chosen data
+ * directory: this is updater bookkeeping, not user data, and it must survive
+ * the user moving or resetting their data directory.
+ */
+function healthFile(): string {
+  return path.join(app.getPath('userData'), 'updater-check-health.json');
+}
+
+function read(): CheckHealth {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(healthFile(), 'utf8'));
+    if (typeof parsed !== 'object' || parsed === null) return HEALTHY;
+    const record = parsed as Record<string, unknown>;
+    const failures = record['consecutiveFailures'];
+    return {
+      consecutiveFailures:
+        typeof failures === 'number' && Number.isFinite(failures) && failures > 0
+          ? Math.floor(failures)
+          : 0,
+      noticeShown: record['noticeShown'] === true,
+    };
+  } catch {
+    // A fresh install has no file and a corrupt one is not worth a crash;
+    // either way the safe reading is "no failures recorded yet".
+    return HEALTHY;
+  }
+}
+
+function write(next: CheckHealth): void {
+  try {
+    fs.mkdirSync(path.dirname(healthFile()), { recursive: true });
+    fs.writeFileSync(healthFile(), JSON.stringify(next), 'utf8');
+  } catch (err) {
+    // Bookkeeping must never break the update path it is only observing.
+    log.warn(`[updater] could not persist update-check health: ${String(err)}`);
+  }
+}
+
+/** A check that reached the feed — whether or not it found a new version. */
+export function recordCheckReachedFeed(): void {
+  const current = read();
+  if (current.consecutiveFailures === 0 && !current.noticeShown) return;
+  write(HEALTHY);
+}
+
+export interface FailureVerdict {
+  readonly consecutiveFailures: number;
+  /** True exactly once per streak, on the check that crosses the threshold. */
+  readonly shouldNotify: boolean;
+}
+
+/**
+ * The whole decision, as a pure function of the previous state — kept separate
+ * from the file IO so the notify-once-per-streak rule is verifiable without an
+ * Electron runtime. The desktop test setup arriving with #932 is the intended
+ * home for that test.
+ *
+ * @param alreadySurfaced the failure came from a manual check, so the user is
+ *   being shown the error anyway; count it, but never queue a second notice.
+ */
+export function nextFailureState(
+  current: CheckHealth,
+  alreadySurfaced: boolean,
+): { readonly next: CheckHealth; readonly verdict: FailureVerdict } {
+  const consecutiveFailures = current.consecutiveFailures + 1;
+  const shouldNotify =
+    !alreadySurfaced &&
+    !current.noticeShown &&
+    consecutiveFailures >= FAILURE_STREAK_BEFORE_NOTICE;
+  return {
+    next: {
+      consecutiveFailures,
+      noticeShown: current.noticeShown || shouldNotify || alreadySurfaced,
+    },
+    verdict: { consecutiveFailures, shouldNotify },
+  };
+}
+
+export function recordCheckFailed(alreadySurfaced: boolean): FailureVerdict {
+  const { next, verdict } = nextFailureState(read(), alreadySurfaced);
+  write(next);
+  return verdict;
+}


### PR DESCRIPTION
Closes #928

Beta-test round 3 finding OM-69: after every release the macOS update channel is dead for 30-60 minutes, and it never says so.

## Part 1 — two-phase publish

`auto-release.yml` created the release with `gh release create ... --latest`, and the `desktop-apps` job that attaches the installers runs *after* it (`needs: release`). `latest-mac.yml` only exists once **both** mac architectures finish and `merge-mac-update-feed.mjs` has merged them: arm64 21 min + Intel >30 min by the workflow's own measurements, plus notarization on Apple's clock. In that window every macOS install queries a file that does not exist and gets a 404. 144 releases since 2026-07-06, five on the test day alone.

Now:

1. `release` creates the release with `--draft` (no `--latest`).
2. New `promote-release` job runs `gh release edit "$TAG" --draft=false --latest` once the merged macOS feed **and the installers it references** are attached.

### Why a draft rather than just clearing `make_latest`

**Correcting an earlier version of this PR description, which had this wrong.** I first claimed electron-updater resolves "latest" from the first entry of `releases.atom`, making `--latest=false` useless. That is not what the code does. With `allowPrerelease` false, `GitHubProvider.getLatestVersion()` takes the `else` branch and resolves the version via `getLatestTagName()` → `GET <repo>/releases/latest` with `Accept: application/json`, reading `tag_name` — and that endpoint **does** honour `make_latest`. The atom feed is fetched too, but only to locate the matching entry for the release notes. `allowPrerelease` is false here because `AppUpdater` derives it from the running version via `hasPrereleaseComponents()` and `set-desktop-version.mjs` writes plain semver (`VERSION_RE` enforces `vX.Y.Z`); nothing in `desktop/src/updater.ts` or `electron-builder.yml` overrides it.

So `--latest=false` would have fixed OM-69 on its own. I got this wrong by grepping for the atom fetch and mistaking the notes-lookup path for the version-selection path, without reading the `if/else`.

The draft approach stands, and is strictly stronger in two ways that matter:

1. A draft is absent from **both** `/releases/latest` and `releases.atom`, so the protection does not depend on which the provider consults.
2. That choice is conditional on `allowPrerelease`, which flips true under any prerelease version scheme — activating the first-atom-entry path where `make_latest` is ignored entirely, silently removing the protection. A draft is invisible either way.

A draft also keeps a half-built release off the Releases page while it is unusable.

### The gate proves downloadability, not just a feed

A valid merged feed does **not** prove the installers it points at are on the release. The feed is assembled from **run artifacts**, uploaded by an `if: always()` step that runs *before* the release upload. So a mac leg whose "Upload installers to the release" step failed transiently (API 5xx) still yields a complete, mergeable feed — the merge succeeds, the feed uploads, the release is flagged latest, and `latest-mac.yml` references assets that were never attached. OM-69's exact symptom, under a green run.

The gate now asserts every `path`/`url` in the merged feed against the release's actual asset list before setting `published=true`, reusing the strict `parseFeed()` from `merge-mac-update-feed.mjs` and decoding the percent-escaping electron-builder applies. Tested both directions locally (all-attached passes with correct dedupe of `path` against `files[].url`; one missing installer fails with the name).

### Gating on the output, not the job result

The promotion hangs off `desktop-apps`' `mac_feed_published` output rather than `needs.desktop-apps.result`. `build` runs `fail-fast: false`, so a broken **Windows** leg fails the called workflow while the macOS feed published fine — gating on the result would withhold the promotion and leave macOS auto-update dead until the next fully green release, which is OM-69 rather than a fix for it.

### Failure and cancellation semantics (deliberate)

| Situation | Result |
|---|---|
| feed + referenced installers attached | release published + flagged latest |
| `desktop-apps` fails, feed and installers attached anyway (e.g. Windows leg only) | release **still promoted** — macOS can update |
| feed published but an installer missing | release **stays a draft**, job fails **red** |
| feed not published (mac leg failed, cancelled, skipped) | release **stays a draft**, job fails **red** |
| no release cut (no feat/fix) | all jobs skipped, unchanged |

When it stays a draft the previous release keeps the latest flag, so installs keep updating to the last version they can actually download. Recovery: re-run `desktop-apps`, or `gh release edit <tag> --draft=false --latest`.

Two side effects of leaving a stuck draft are now documented on the job: `publish-images` needs only `release`, so the container `:latest` tag ships a version desktop clients cannot get; and the changelog range comes from `git tag -l` with the tag pushed before the release exists, so the next release's notes start *after* the stuck tag and those commits appear in no published notes until the draft is published.

### Draft-aware, paginated release lookup

`GET /releases/tags/{tag}` does not return drafts, so both upload steps resolve the release through the list endpoint instead.

**A second correction:** I originally justified this by claiming `gh release view` cannot resolve drafts. It can — gh's `FetchRelease` finds a published release by tag *or* a draft by its pending tag name, with a GraphQL fallback on 404. The trap I described did not exist. I kept the replacement anyway because `require_release` is genuinely valuable, and that same fallback is why `gh release upload "$TAG"` works against a draft at all — the single assumption this whole flow depends on, now positively confirmed rather than assumed, and stated in a comment.

The lookups use `--paginate`, which is not optional: the repo has **237** releases and one `per_page=100` page reaches back only to **v0.78.0**. Without it, a rebuild dispatched for an older tag found nothing and — on the dispatch path, where `require_release` is false — took the soft-skip branch and reported a green run that attached nothing. That was a regression this PR introduced by replacing `gh release view`, which resolved any tag regardless of age.

`gh`'s built-in gojq is used rather than piping to `jq`, because the installer step also runs on `windows-latest` where `gh` is guaranteed and `jq` is not.

### No re-trigger loop

`desktop-apps.yml` also triggers on `release: [published]`. Promoting with `GITHUB_TOKEN` does not fire that event (Actions loop protection — the same reason `publish-images` and `desktop-apps` are called in-run here, as this workflow's header already documents). A comment warns against "fixing" this with a PAT.

## Part 2 — a dead channel now says so

The reporter only saw the 404 because he checked manually. On the silent startup check the same error goes to the log only, since the dialog is gated on `takeManualCheckPending()`. A failed check and "you are up to date" were indistinguishable.

`desktop/src/updaterCheckHealth.ts` (new) tracks consecutive failures across app starts in Electron's `userData` dir — updater bookkeeping, not user data, so it survives the user moving their data directory. One warning per failure streak; any check that gets through resets it. Threshold is 3 app starts (`initUpdater()` runs one check per start), so a single blip cannot produce a dialog.

The reset fires on `update-downloaded`, **not** `update-available`. `autoDownload` is on, so a download follows announcement immediately and its failures arrive on the same `error` event; resetting on announcement read "announce → reset to 0, download fails → 1" every start, capping the counter at 1 so the warning could never fire for a broken download — the residual case the asset assertion above cannot cover. `update-not-available` keeps its reset for the healthy path.

The decision is a pure function (`nextFailureState`) kept apart from the file IO, so the notify-once-per-streak rule is unit-testable without an Electron runtime.

## Verification

```
cd desktop && npx tsc -p tsconfig.json --noEmit   -> clean
cd desktop && npm test                            -> 33/33 pass
actionlint auto-release.yml desktop-apps.yml      -> 3x SC2086, all pre-existing
                                                     (identical to the same lint on HEAD)
```
The feed-vs-assets assertion was exercised locally in both directions, including percent-decoding and the relative `import()` resolving from the repo root as it will in the job. Confirmed live: 237 releases with page 1 ending at v0.78.0; `/repos/byte5ai/omadia/releases/latest` returns the `make_latest`-flagged release.

## Notes

- **`docs/CHANGELOG.md` deliberately untouched** — it is the universal merge-conflict point across the round-3 cluster PRs; one consolidated entry lands with #937.
- **Watch the first release after this merges.** The draft path is new; a misbehaving promotion leaves the release a draft and the run red, which is the safe direction but needs someone to see it.
- Known, accepted: one transient failed **manual** check sets `noticeShown` and suppresses the passive warning for the rest of that streak, so a user who clicks "check for updates" during a blip loses the warning. It resets on the next successful check, so it is not a wedge.
- New dialog strings are English, consistent with the rest of `updater.ts`; #935 localizes the desktop-shell dialogs as a set.
- Scope kept off `supervisor.ts`, `main.ts`, `paths.ts`, `ipc.ts`, `renderer/**`, `menu.ts`, `middleware/**`, `web-ui/**`, which other round-3 clusters own. Re-checked against #944 (now 21 files, `updater.ts` +161/-13): still no semantic overlap — it adds and removes nothing in the `error` handler, the `takeManualCheckPending()` gate, or the `update-*` paths that constitute my change. Expect a mechanical conflict in the import block, and now also at the `update-downloaded` opening line, since both add a statement after its `log.info`.
- `omadia-reviewer` was not run against this diff (subagents cannot spawn agents).
