### PR TITLE
fix: the desktop shutdown path stops lying during an update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,47 @@ jobs:
         run: npm run plugin-ui:css:check
 
   # ------------------------------------------------------------------
+  # Desktop: typecheck + node:test for the Electron shell.
+  #
+  # Added for issue #932. Until now desktop/src was the only source tree in
+  # the repo with no tests and no CI job -- and the only one that produced a
+  # blocker in three rounds of beta testing, because it is the whole of the
+  # user's first impression. Electron's own binary is deliberately NOT
+  # downloaded: nothing here launches the app, so the ~100MB fetch would only
+  # slow the job down.
+  # ------------------------------------------------------------------
+  desktop:
+    name: desktop (typecheck + test)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: desktop
+    env:
+      ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: desktop/package-lock.json
+
+      - name: npm ci
+        run: npm ci --no-audit --no-fund
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      # The tests run under node's strip-only TypeScript mode, so they cover the
+      # Electron-free lifecycle modules (child shutdown, PATH resolution,
+      # snapshot retention, synced-path detection, update-attempt bookkeeping)
+      # without needing a display or an Electron runtime.
+      - name: Test (node:test)
+        run: npm test
+
+  # ------------------------------------------------------------------
   # Schema smoke: apply every migration in the repo against pgvector.
   # Catches SQL-only regressions before they hit prod-or-OSS-demo
   # deploys. Domains are listed explicitly in dependency order; files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,10 +334,17 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-      # The tests run under node's strip-only TypeScript mode, so they cover the
-      # Electron-free lifecycle modules (child shutdown, PATH resolution,
-      # snapshot retention, synced-path detection, update-attempt bookkeeping)
-      # without needing a display or an Electron runtime.
+      # The build tsconfig has rootDir: src and emits to dist/, so it cannot
+      # also cover test/. A separate config does, the way middleware/test does,
+      # otherwise a test that type-lies still passes CI.
+      - name: Typecheck (test tree)
+        run: npm run typecheck:test
+
+      # The tests run under node's strip-only TypeScript mode against a stubbed
+      # `electron`, so they cover the lifecycle code (supervisor generation and
+      # single-flight races, child shutdown, PATH resolution, snapshot
+      # retention, synced-path detection, install preflight, update-attempt
+      # bookkeeping) with no display and no Electron runtime.
       - name: Test (node:test)
         run: npm test
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "omadia-desktop",
   "version": "0.1.0",
   "private": true,
-  "description": "omadia native desktop installer — runs the full omadia stack locally with an embedded Postgres+pgvector engine, no Docker.",
+  "description": "omadia native desktop installer \u2014 runs the full omadia stack locally with an embedded Postgres+pgvector engine, no Docker.",
   "author": {
     "name": "byte5 GmbH",
     "email": "mwege@byte5.de"
@@ -18,7 +18,7 @@
     "build": "tsc -p tsconfig.json && node scripts/bundle-preload.mjs && node scripts/copy-renderer.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "stage": "node scripts/stage-runtime.mjs",
-    "test": "node --test scripts/*.test.mjs",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test scripts/*.test.mjs test/*.test.mts",
     "start": "npm run build && electron .",
     "dev": "OMADIA_DESKTOP_DEV=1 npm run start",
     "pack:mac": "npm run build && npm run stage && electron-builder --mac --publish never",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "omadia-desktop",
   "version": "0.1.0",
   "private": true,
-  "description": "omadia native desktop installer \u2014 runs the full omadia stack locally with an embedded Postgres+pgvector engine, no Docker.",
+  "description": "omadia native desktop installer — runs the full omadia stack locally with an embedded Postgres+pgvector engine, no Docker.",
   "author": {
     "name": "byte5 GmbH",
     "email": "mwege@byte5.de"
@@ -17,8 +17,9 @@
   "scripts": {
     "build": "tsc -p tsconfig.json && node scripts/bundle-preload.mjs && node scripts/copy-renderer.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "typecheck:test": "tsc -p test/tsconfig.json --noEmit",
     "stage": "node scripts/stage-runtime.mjs",
-    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test scripts/*.test.mjs test/*.test.mts",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --import ./test/helpers/stub-electron.mjs --test scripts/*.test.mjs test/*.test.mts",
     "start": "npm run build && electron .",
     "dev": "OMADIA_DESKTOP_DEV=1 npm run start",
     "pack:mac": "npm run build && npm run stage && electron-builder --mac --publish never",

--- a/desktop/src/childLifecycle.ts
+++ b/desktop/src/childLifecycle.ts
@@ -6,7 +6,12 @@
  */
 
 /** How a stop attempt actually ended. */
-export type ChildStopOutcome = 'already-exited' | 'exited' | 'deadline';
+export type ChildStopOutcome =
+  | 'already-exited'
+  | 'exited'
+  | 'deadline'
+  /** Signalling the child threw, so we never even got to wait for it. */
+  | 'kill-failed';
 
 /** The slice of ChildProcess this module needs, so tests can pass a double. */
 export interface StoppableChild {
@@ -46,37 +51,66 @@ export function stopChild(
   }
   return new Promise<ChildStopOutcome>((resolve) => {
     let settled = false;
+    // Declared before anything can call finish(), and kill() is issued last.
+    // A child double that exits synchronously from kill() would otherwise send
+    // finish() into the temporal dead zone of these two consts and reject the
+    // promise with a ReferenceError instead of resolving 'exited'. Real
+    // ChildProcess defers 'exit' through libuv, so this was not reachable in
+    // production - but a stop path that can throw is exactly what this module
+    // exists to rule out.
+    let killTimer: NodeJS.Timeout | undefined;
+    let hardStop: NodeJS.Timeout | undefined;
+
     const finish = (outcome: ChildStopOutcome): void => {
       if (settled) return;
       settled = true;
-      clearTimeout(killTimer);
-      clearTimeout(hardStop);
+      if (killTimer !== undefined) clearTimeout(killTimer);
+      if (hardStop !== undefined) clearTimeout(hardStop);
       resolve(outcome);
     };
 
-    child.once('exit', () => finish('exited'));
-    child.kill('SIGTERM');
+    /**
+     * kill() can throw - EPERM against a process that has already gone, for
+     * instance. Reporting that is fine; letting it escape is not. Thrown from
+     * the executor it rejected the promise and leaked both timers, and thrown
+     * from the escalation timer below it became an uncaught exception that took
+     * the process down. Either way a shutdown that must always report an
+     * outcome instead produced an error, which is the failure mode this module
+     * exists to remove.
+     */
+    const trySignal = (signal: NodeJS.Signals): boolean => {
+      try {
+        child.kill(signal);
+        return true;
+      } catch (err) {
+        logger.warn(`[${label}] ${signal} failed: ${String(err)}`);
+        return false;
+      }
+    };
 
     // Escalate if it ignores SIGTERM (notably on Windows, where SIGTERM is not
     // a real graceful signal).
-    const killTimer = setTimeout(() => {
+    killTimer = setTimeout(() => {
       if (child.exitCode === null && child.signalCode === null) {
         logger.warn(`[${label}] did not exit on SIGTERM; sending SIGKILL`);
-        child.kill('SIGKILL');
+        if (!trySignal('SIGKILL')) finish('kill-failed');
       }
     }, graceMs);
 
-    const hardStop = setTimeout(() => {
+    hardStop = setTimeout(() => {
       logger.warn(
         `[${label}] still alive ${graceMs * 2}ms after SIGTERM - giving up waiting. ` +
           'It may still hold files inside the app bundle.',
       );
       finish('deadline');
     }, graceMs * 2);
+
+    child.once('exit', () => finish('exited'));
+    if (!trySignal('SIGTERM')) finish('kill-failed');
   });
 }
 
 /** True only when the process is confirmed gone, not merely given up on. */
 export function isConfirmedStopped(outcome: ChildStopOutcome): boolean {
-  return outcome !== 'deadline';
+  return outcome === 'already-exited' || outcome === 'exited';
 }

--- a/desktop/src/childLifecycle.ts
+++ b/desktop/src/childLifecycle.ts
@@ -1,0 +1,82 @@
+/**
+ * Stopping a child process and reporting, truthfully, whether it is gone.
+ *
+ * Extracted from Supervisor so the lifecycle transitions behind the macOS
+ * update loop can be tested without booting Electron (#932).
+ */
+
+/** How a stop attempt actually ended. */
+export type ChildStopOutcome = 'already-exited' | 'exited' | 'deadline';
+
+/** The slice of ChildProcess this module needs, so tests can pass a double. */
+export interface StoppableChild {
+  readonly exitCode: number | null;
+  readonly signalCode: NodeJS.Signals | null;
+  kill(signal?: NodeJS.Signals): boolean;
+  once(event: 'exit', listener: () => void): unknown;
+}
+
+export interface StopLogger {
+  warn(message: string): void;
+}
+
+export const DEFAULT_GRACE_MS = 4_000;
+
+/**
+ * SIGTERM a child, wait for it to exit, escalate to SIGKILL, and say which of
+ * those actually happened.
+ *
+ * The unconditional backstop is deliberate and stays: a quit must never hang
+ * forever on a child whose 'exit' event never fires. What was missing is the
+ * *distinction*. "I stopped waiting" used to resolve identically to "the
+ * process is gone", so the updater handed a still-running kernel and Postgres
+ * to Squirrel, ShipIt could not replace a bundle that was still in use, and
+ * the same version was offered again on the next launch with no error logged
+ * anywhere (#926, root cause #927). Callers that must know the stack is really
+ * down can now ask.
+ */
+export function stopChild(
+  child: StoppableChild | null,
+  label: string,
+  logger: StopLogger,
+  graceMs: number = DEFAULT_GRACE_MS,
+): Promise<ChildStopOutcome> {
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve('already-exited');
+  }
+  return new Promise<ChildStopOutcome>((resolve) => {
+    let settled = false;
+    const finish = (outcome: ChildStopOutcome): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(killTimer);
+      clearTimeout(hardStop);
+      resolve(outcome);
+    };
+
+    child.once('exit', () => finish('exited'));
+    child.kill('SIGTERM');
+
+    // Escalate if it ignores SIGTERM (notably on Windows, where SIGTERM is not
+    // a real graceful signal).
+    const killTimer = setTimeout(() => {
+      if (child.exitCode === null && child.signalCode === null) {
+        logger.warn(`[${label}] did not exit on SIGTERM; sending SIGKILL`);
+        child.kill('SIGKILL');
+      }
+    }, graceMs);
+
+    const hardStop = setTimeout(() => {
+      logger.warn(
+        `[${label}] still alive ${graceMs * 2}ms after SIGTERM - giving up waiting. ` +
+          'It may still hold files inside the app bundle.',
+      );
+      finish('deadline');
+    }, graceMs * 2);
+  });
+}
+
+/** True only when the process is confirmed gone, not merely given up on. */
+export function isConfirmedStopped(outcome: ChildStopOutcome): boolean {
+  return outcome !== 'deadline';
+}

--- a/desktop/src/dbSnapshot.ts
+++ b/desktop/src/dbSnapshot.ts
@@ -1,0 +1,73 @@
+import { snapshotDirName, snapshotsToPrune } from './snapshotRetention';
+
+/**
+ * Taking a pre-update database snapshot (#934, #926).
+ *
+ * Extracted behind an IO port for one specific reason: the defect this code
+ * fixes was an *ordering* bug (pruning ran after the copy, so a full disk threw
+ * before anything was ever reclaimed and every later update failed the same
+ * way). An ordering invariant that lives only in a comment is not held - the
+ * review's revert experiments demonstrated exactly that - so the order has to
+ * be assertable.
+ */
+
+export interface SnapshotIo {
+  exists(dir: string): boolean;
+  listDirectories(root: string): string[];
+  copy(source: string, destination: string): void;
+  remove(dir: string): void;
+  info(message: string): void;
+  error(message: string): void;
+}
+
+export interface SnapshotRequest {
+  readonly sourceDir: string;
+  readonly snapshotRoot: string;
+  readonly version: string;
+  readonly now: Date;
+  /** How many snapshots may exist once this one has been added. */
+  readonly keep: number;
+}
+
+/**
+ * Prune, then copy. Returns the new snapshot's path, or null when there was
+ * nothing to snapshot.
+ *
+ * Pruning to `keep - 1` first means peak disk usage is `keep` full clusters
+ * rather than `keep + 1`, and - the actual bug - it means space is reclaimed
+ * *before* the copy that might otherwise fail for want of it.
+ */
+export function takeDbSnapshot(io: SnapshotIo, request: SnapshotRequest): string | null {
+  if (!io.exists(request.sourceDir)) return null;
+
+  pruneSnapshots(io, request.snapshotRoot, Math.max(0, request.keep - 1));
+
+  const destination = `${request.snapshotRoot}/${snapshotDirName(request.version, request.now)}`;
+  try {
+    io.copy(request.sourceDir, destination);
+  } catch (err) {
+    // A half-copied directory is worse than none: it looks like a backup and
+    // retention would count it as one. The cleanup gets its own try so a
+    // failure here cannot replace the real cause the caller needs to report.
+    try {
+      io.remove(destination);
+    } catch (cleanupErr) {
+      io.error(`could not remove the partial snapshot ${destination}: ${String(cleanupErr)}`);
+    }
+    throw err;
+  }
+  io.info(`snapshotted DB → ${destination}`);
+  return destination;
+}
+
+function pruneSnapshots(io: SnapshotIo, root: string, keep: number): void {
+  try {
+    for (const stale of snapshotsToPrune(io.listDirectories(root), keep)) {
+      io.remove(`${root}/${stale}`);
+      io.info(`pruned old snapshot ${stale}`);
+    }
+  } catch (err) {
+    // Housekeeping: a failure here must not stop the snapshot that follows.
+    io.error(`snapshot pruning failed: ${String(err)}`);
+  }
+}

--- a/desktop/src/embeddedDb.ts
+++ b/desktop/src/embeddedDb.ts
@@ -35,8 +35,12 @@ export interface EmbeddedDb {
   databaseUrl: string;
   /** The bound loopback port. */
   port: number;
-  /** Stop the Postgres server. */
-  stop(): Promise<void>;
+  /**
+   * Stop the Postgres server. Resolves true only when the process is confirmed
+   * gone; false means the shutdown deadline expired and it may still be
+   * holding files (see #927).
+   */
+  stop(): Promise<boolean>;
 }
 
 let current: { proc: ChildProcess; port: number } | null = null;
@@ -178,29 +182,32 @@ function toHandle(port: number): EmbeddedDb {
     databaseUrl: `postgresql://${DB_USER}@127.0.0.1:${port}/${DB_NAME}`,
     port,
     async stop() {
-      if (current) {
-        stopping = true;
-        await stopProc(current.proc);
-        current = null;
-        stopping = false;
-      }
+      return stopEmbeddedDb();
     },
   };
 }
 
-/** Fast, clean Postgres shutdown: SIGINT → wait → SIGQUIT → SIGKILL. */
-function stopProc(proc: ChildProcess): Promise<void> {
-  if (proc.exitCode !== null || proc.signalCode !== null) return Promise.resolve();
-  return new Promise<void>((resolve) => {
+/**
+ * Fast, clean Postgres shutdown: SIGINT → wait → SIGQUIT → SIGKILL.
+ *
+ * Resolves true when the process is confirmed gone, false when the 8s deadline
+ * expired first. The deadline itself is deliberate (a quit must not hang), but
+ * an expired one used to be indistinguishable from a real exit, and a Postgres
+ * still running out of the app bundle is exactly what blocks the macOS
+ * installer (#926/#927).
+ */
+function stopProc(proc: ChildProcess): Promise<boolean> {
+  if (proc.exitCode !== null || proc.signalCode !== null) return Promise.resolve(true);
+  return new Promise<boolean>((resolve) => {
     let settled = false;
-    const finish = (): void => {
+    const finish = (exited: boolean): void => {
       if (settled) return;
       settled = true;
       clearTimeout(t1);
       clearTimeout(t2);
-      resolve();
+      resolve(exited);
     };
-    proc.once('exit', finish);
+    proc.once('exit', () => finish(true));
     log.info('[db] stopping embedded Postgres (fast shutdown)');
     proc.kill('SIGINT'); // fast shutdown
     const t1 = setTimeout(() => {
@@ -208,9 +215,30 @@ function stopProc(proc: ChildProcess): Promise<void> {
     }, 4_000);
     const t2 = setTimeout(() => {
       if (proc.exitCode === null) proc.kill('SIGKILL');
-      finish();
+      log.warn('[db] embedded Postgres did not exit within 8s of SIGINT');
+      finish(false);
     }, 8_000);
   });
+}
+
+/**
+ * Stop whatever embedded Postgres this process started, whether or not anyone
+ * still holds its handle.
+ *
+ * A `start()` interrupted between `startEmbeddedDb()` and the assignment of the
+ * supervisor's `db` field leaves a running server nobody owns; the old
+ * `if (this.db)` check in Supervisor.stop() then skipped it and Postgres
+ * survived the app quit (#927). Reaping from module state closes that window.
+ */
+export async function stopEmbeddedDb(): Promise<boolean> {
+  if (!current) return true;
+  stopping = true;
+  try {
+    return await stopProc(current.proc);
+  } finally {
+    current = null;
+    stopping = false;
+  }
 }
 
 export function isEmbeddedDbRunning(): boolean {

--- a/desktop/src/embeddedDb.ts
+++ b/desktop/src/embeddedDb.ts
@@ -66,7 +66,7 @@ function pgBin(name: string): string {
   return path.join(pgNativeDir(), 'bin', exe(name));
 }
 
-export async function startEmbeddedDb(): Promise<EmbeddedDb> {
+async function startRealEmbeddedDb(): Promise<EmbeddedDb> {
   if (current) return toHandle(current.port);
 
   const dataDir = embeddedDbDir();
@@ -230,7 +230,7 @@ function stopProc(proc: ChildProcess): Promise<boolean> {
  * `if (this.db)` check in Supervisor.stop() then skipped it and Postgres
  * survived the app quit (#927). Reaping from module state closes that window.
  */
-export async function stopEmbeddedDb(): Promise<boolean> {
+async function stopRealEmbeddedDb(): Promise<boolean> {
   if (!current) return true;
   stopping = true;
   try {
@@ -241,7 +241,7 @@ export async function stopEmbeddedDb(): Promise<boolean> {
   }
 }
 
-export function isEmbeddedDbRunning(): boolean {
+function isRealEmbeddedDbRunning(): boolean {
   return current !== null;
 }
 
@@ -266,4 +266,36 @@ async function stableDbPort(): Promise<number> {
   const port = await findFreePort('127.0.0.1');
   fs.writeFileSync(file, String(port), 'utf8');
   return port;
+}
+
+/**
+ * Test seam for the database lifecycle (#932).
+ *
+ * Same pattern as `cliInstallService.__setCliInstallRunner`. The supervisor's
+ * generation races cannot be exercised against a real Postgres, and the defect
+ * they guard against is specifically about *when* this module registers its
+ * server relative to a concurrent stop() -- so a test has to own that timing.
+ */
+export interface EmbeddedDbHooks {
+  start: () => Promise<EmbeddedDb>;
+  stop: () => Promise<boolean>;
+  isRunning: () => boolean;
+}
+
+let hooks: EmbeddedDbHooks | null = null;
+
+export function __setEmbeddedDbHooks(next: EmbeddedDbHooks | null): void {
+  hooks = next;
+}
+
+export function startEmbeddedDb(): Promise<EmbeddedDb> {
+  return hooks === null ? startRealEmbeddedDb() : hooks.start();
+}
+
+export function stopEmbeddedDb(): Promise<boolean> {
+  return hooks === null ? stopRealEmbeddedDb() : hooks.stop();
+}
+
+export function isEmbeddedDbRunning(): boolean {
+  return hooks === null ? isRealEmbeddedDbRunning() : hooks.isRunning();
 }

--- a/desktop/src/installPreflight.ts
+++ b/desktop/src/installPreflight.ts
@@ -1,0 +1,49 @@
+import type { StopOutcome } from './supervisor';
+
+/**
+ * Deciding whether an update may be handed to the installer (#926).
+ *
+ * Split out from the updater so the abort paths can be tested without Electron
+ * or a release feed. The dialogs stay in `updater.ts`; only the decision lives
+ * here.
+ */
+
+export type InstallPreflight =
+  | { readonly ok: true }
+  /** The stack did not come down, so the app bundle is still in use. */
+  | { readonly ok: false; readonly reason: 'unclean'; readonly survivors: readonly string[] }
+  /** Quiescing or snapshotting threw. */
+  | { readonly ok: false; readonly reason: 'failed'; readonly error: string };
+
+export interface PreflightSteps {
+  /** Bring the stack down. `null` when there is no supervisor to stop. */
+  stop: (() => Promise<StopOutcome>) | null;
+  /** Snapshot the database. Throwing aborts the install. */
+  snapshot: (version: string) => void;
+}
+
+/**
+ * Quiesce, then snapshot, and report whether the installer may proceed.
+ *
+ * Order matters twice over: the stack must be down before the database
+ * directory is copied (a live copy can be torn and unrestorable), and the
+ * result must be checked before handing off, because Squirrel cannot replace a
+ * bundle whose processes are still running out of it.
+ */
+export async function prepareInstall(
+  steps: PreflightSteps,
+  version: string,
+): Promise<InstallPreflight> {
+  try {
+    if (steps.stop !== null) {
+      const outcome = await steps.stop();
+      if (!outcome.clean) {
+        return { ok: false, reason: 'unclean', survivors: outcome.survivors };
+      }
+    }
+    steps.snapshot(version);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, reason: 'failed', error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/desktop/src/ipc.ts
+++ b/desktop/src/ipc.ts
@@ -1,4 +1,5 @@
 import { ipcMain, dialog, app, BrowserWindow, WebContents } from 'electron';
+import os from 'node:os';
 import {
   CH,
   ApiKeyProvider,
@@ -13,6 +14,7 @@ import { setProviderKey, exportRecoveryKey, isEncryptionAvailable } from './secr
 import { readSetup, writeSetup } from './setupState';
 import { isSetupComplete } from './setupState';
 import { setDataDirOverride } from './paths';
+import { detectSyncedLocation } from './syncedPaths';
 import { log } from './log';
 
 const PROVIDER_ENV: Record<ApiKeyProvider, string> = {
@@ -39,6 +41,55 @@ export function requiresApiKey(provider: WizardConfig['provider']): provider is 
   return provider !== 'subscription';
 }
 
+/** Tries before we stop re-opening the picker, so a warning can never trap the user. */
+const MAX_DATA_DIR_PICKS = 3;
+
+/**
+ * Ask for a data directory, and if the answer is inside a cloud-synced folder,
+ * say so before accepting it.
+ *
+ * A business user picks the folder he uses for important data, which is exactly
+ * the folder that gets synced. A live PostgreSQL cluster there is a known
+ * hazard: the sync client can evict, lock or fork files into conflict copies
+ * while the database holds them open. This is a hint and not a ban - the user
+ * may have a good reason, and the choice stays his (#934).
+ */
+async function chooseDataDirWithSyncWarning(
+  win: BrowserWindow | undefined,
+): Promise<string | null> {
+  for (let attempt = 0; attempt < MAX_DATA_DIR_PICKS; attempt += 1) {
+    const res = await dialog.showOpenDialog(win as BrowserWindow, {
+      title: 'Choose where omadia stores its data',
+      properties: ['openDirectory', 'createDirectory'],
+    });
+    if (res.canceled || res.filePaths.length === 0) return null;
+
+    const chosen = res.filePaths[0];
+    if (chosen === undefined) return null;
+
+    const synced = detectSyncedLocation(chosen, os.homedir());
+    if (synced === null) return chosen;
+
+    log.warn(`[setup] chosen data dir is inside ${synced}: ${chosen}`);
+    const { response } = await dialog.showMessageBox(win as BrowserWindow, {
+      type: 'warning',
+      buttons: ['Choose a different folder', 'Use this folder anyway'],
+      defaultId: 0,
+      cancelId: 0,
+      title: 'This folder is synced to the cloud',
+      message: `${chosen} looks like it is inside ${synced}.`,
+      detail:
+        `omadia runs a live PostgreSQL database in this folder. ${synced} can lock, ` +
+        'move or duplicate files while the database has them open, which can corrupt it. ' +
+        'A local folder outside the synced area is the safer choice.\n\n' +
+        'Pre-update database backups will be kept outside the synced folder either way.',
+    });
+    if (response === 1) return chosen;
+  }
+  log.warn('[setup] data dir selection abandoned after repeated cloud-folder warnings');
+  return null;
+}
+
 export function registerIpc(deps: IpcDeps): void {
   ipcMain.handle(CH.getState, (): AppState => ({
     setupComplete: isSetupComplete(),
@@ -52,12 +103,7 @@ export function registerIpc(deps: IpcDeps): void {
 
   ipcMain.handle(CH.chooseDataDir, async (e): Promise<string | null> => {
     const win = BrowserWindow.fromWebContents(e.sender) ?? undefined;
-    const res = await dialog.showOpenDialog(win as BrowserWindow, {
-      title: 'Choose where omadia stores its data',
-      properties: ['openDirectory', 'createDirectory'],
-    });
-    if (res.canceled || res.filePaths.length === 0) return null;
-    return res.filePaths[0] ?? null;
+    return chooseDataDirWithSyncWarning(win as BrowserWindow);
   });
 
   ipcMain.handle(CH.exportRecoveryKey, (): string => exportRecoveryKey());

--- a/desktop/src/paths.ts
+++ b/desktop/src/paths.ts
@@ -1,6 +1,9 @@
 import { app } from 'electron';
 import path from 'node:path';
 import fs from 'node:fs';
+import os from 'node:os';
+import { detectSyncedLocation } from './syncedPaths';
+import { log } from './log';
 
 /**
  * Resolves every on-disk location the desktop app needs, transparently handling
@@ -16,6 +19,9 @@ import fs from 'node:fs';
  */
 
 const isDev = process.env['OMADIA_DESKTOP_DEV'] === '1' || !app.isPackaged;
+
+/** One notice per launch, not one per snapshot call. */
+let syncedSnapshotNoticeLogged = false;
 
 function runtimeRoot(): string {
   if (isDev) {
@@ -89,11 +95,31 @@ export function setupFile(): string {
   return path.join(dataRoot(), 'setup.json');
 }
 
-/** Where a pre-update DB snapshot is written. */
+/**
+ * Where a pre-update DB snapshot is written.
+ *
+ * Normally next to the data it protects, under the chosen data dir. But when
+ * that dir sits in a cloud-synced folder the snapshots are moved to `userData`
+ * instead: a full copy of the cluster per update attempt is exactly the kind of
+ * bulk a sync client should never be asked to carry, and a backup that a sync
+ * client may evict or fork into a conflict copy is not a backup (#934).
+ */
 export function snapshotDir(): string {
-  const dir = path.join(dataRoot(), 'snapshots');
+  const root = dataRoot();
+  const synced = detectSyncedLocation(root, os.homedir());
+  const base = synced === null ? root : app.getPath('userData');
+  if (synced !== null && !syncedSnapshotNoticeLogged) {
+    syncedSnapshotNoticeLogged = true;
+    log.info(`[paths] data dir is in ${synced}; keeping DB snapshots in userData instead`);
+  }
+  const dir = path.join(base, 'snapshots');
   ensureDir(dir);
   return dir;
+}
+
+/** Marker recording which version we last handed to the installer (#926). */
+export function updateAttemptsFile(): string {
+  return path.join(app.getPath('userData'), 'update-attempts.json');
 }
 
 /** A file under userData recording an operator-chosen alternate data dir. */

--- a/desktop/src/snapshotRetention.ts
+++ b/desktop/src/snapshotRetention.ts
@@ -53,6 +53,9 @@ export function parseSnapshotName(name: string): ParsedSnapshotName | null {
 /**
  * The snapshot directory names to delete, oldest first, so that at most `keep`
  * remain. Anything that is not a snapshot name is left completely alone.
+ *
+ * Oldest-first is deliberate: a caller that crashes part-way through the list
+ * has then removed the least valuable backups and kept the most recent one.
  */
 export function snapshotsToPrune(
   names: readonly string[],
@@ -74,5 +77,8 @@ export function snapshotsToPrune(
   });
 
   const surplus = Math.max(0, newestFirst.length - Math.max(0, keep));
-  return newestFirst.slice(newestFirst.length - surplus).map((entry) => entry.name);
+  return newestFirst
+    .slice(newestFirst.length - surplus)
+    .map((entry) => entry.name)
+    .reverse();
 }

--- a/desktop/src/snapshotRetention.ts
+++ b/desktop/src/snapshotRetention.ts
@@ -1,0 +1,78 @@
+/**
+ * Naming and pruning pre-update database snapshots (#934).
+ *
+ * The previous scheme wrote every attempt to the same `pgdata-pre-<version>`
+ * directory after removing it first, so a second update attempt for the same
+ * version destroyed the backup the first one had made. Three attempts in one
+ * morning left exactly one snapshot, and it was the one taken last - after the
+ * stack had already been through two failed handoffs. The safety net got
+ * thinner with every retry instead of thicker.
+ */
+
+export const SNAPSHOT_PREFIX = 'pgdata-pre-';
+
+/** How many snapshots to keep. Each one is a full copy of the cluster. */
+export const SNAPSHOTS_TO_KEEP = 3;
+
+/** `2026-08-28T13:05:32.119Z` -> `20260828T130532119Z`, safe on every filesystem. */
+function compactTimestamp(now: Date): string {
+  return now.toISOString().replace(/[-:.]/g, '');
+}
+
+const TIMESTAMP_RE = /^(\d{8}T\d{9}Z)$/;
+
+/** A unique directory name per attempt, lexically sortable by time. */
+export function snapshotDirName(version: string, now: Date): string {
+  return `${SNAPSHOT_PREFIX}${version}-${compactTimestamp(now)}`;
+}
+
+export interface ParsedSnapshotName {
+  readonly version: string;
+  /** Compact timestamp, or null for a legacy name that carried none. */
+  readonly stamp: string | null;
+}
+
+export function parseSnapshotName(name: string): ParsedSnapshotName | null {
+  if (!name.startsWith(SNAPSHOT_PREFIX)) return null;
+  const rest = name.slice(SNAPSHOT_PREFIX.length);
+  if (rest.length === 0) return null;
+
+  const lastDash = rest.lastIndexOf('-');
+  if (lastDash > 0) {
+    const candidate = rest.slice(lastDash + 1);
+    if (TIMESTAMP_RE.test(candidate)) {
+      return { version: rest.slice(0, lastDash), stamp: candidate };
+    }
+  }
+  // Pre-#934 snapshots have no timestamp segment. They are still real backups,
+  // so they are kept in the ordering rather than ignored - just treated as
+  // oldest, because we cannot tell when they were taken.
+  return { version: rest, stamp: null };
+}
+
+/**
+ * The snapshot directory names to delete, oldest first, so that at most `keep`
+ * remain. Anything that is not a snapshot name is left completely alone.
+ */
+export function snapshotsToPrune(
+  names: readonly string[],
+  keep: number = SNAPSHOTS_TO_KEEP,
+): string[] {
+  const snapshots = names
+    .map((name) => ({ name, parsed: parseSnapshotName(name) }))
+    .filter((entry): entry is { name: string; parsed: ParsedSnapshotName } => entry.parsed !== null);
+
+  // Newest first: a missing stamp sorts last (oldest). Ties fall back to the
+  // name so the result is deterministic.
+  const newestFirst = [...snapshots].sort((a, b) => {
+    const left = a.parsed.stamp;
+    const right = b.parsed.stamp;
+    if (left === right) return a.name.localeCompare(b.name);
+    if (left === null) return 1;
+    if (right === null) return -1;
+    return right.localeCompare(left);
+  });
+
+  const surplus = Math.max(0, newestFirst.length - Math.max(0, keep));
+  return newestFirst.slice(newestFirst.length - surplus).map((entry) => entry.name);
+}

--- a/desktop/src/supervisor.ts
+++ b/desktop/src/supervisor.ts
@@ -14,6 +14,7 @@ import { findFreePorts, isPortFree } from './ports';
 import { startEmbeddedDb, stopEmbeddedDb, isEmbeddedDbRunning } from './embeddedDb';
 import type { EmbeddedDb } from './embeddedDb';
 import { stopChild, isConfirmedStopped } from './childLifecycle';
+import type { ChildStopOutcome } from './childLifecycle';
 import { credentialKeychainKey, vaultKey, allProviderKeys } from './secrets';
 import { log } from './log';
 import { resolveAugmentedPath } from './pathEnv';
@@ -32,6 +33,19 @@ export interface BootProgress {
   phase: BootPhase;
   message: string;
   detail?: string;
+}
+
+/**
+ * A start() or restart() that is still running.
+ *
+ * `survivors` is filled in by the operation's own cleanup, so a stop() waiting
+ * on it can fold the result into its outcome instead of reporting clean by
+ * omission.
+ */
+interface InFlightOp {
+  readonly kind: 'boot' | 'restart';
+  readonly settled: Promise<void>;
+  readonly survivors: string[];
 }
 
 /**
@@ -68,14 +82,27 @@ export class Supervisor extends EventEmitter {
    */
   private stopInFlight: Promise<StopOutcome> | null = null;
   /**
-   * Cleanup promises for boots that have not finished yet, each resolving with
-   * whatever that boot's own teardown could not kill.
+   * True from the synchronous instant a full shutdown is requested until it has
+   * finished, and the one flag every lifecycle entry point checks.
    *
-   * A superseded boot cleans up inside its own catch, which nobody used to
-   * await. So stop() could resolve `{clean: true}` while a superseded boot was
-   * still SIGTERM-ing its kernel - the same lie this class exists to remove.
+   * `state` cannot carry this. A restart() sets `state = 'stopping'` for its
+   * teardown and then puts it back to 'idle' before booting, so a stop() that
+   * consulted `state` alone would see an idle supervisor mid-restart. Before
+   * this branch, main's `if (this.state === 'stopping') return;` in stop() was
+   * accidentally serializing the two; removing it opened the window where
+   * stop() reported the stack down and the restart then booted a kernel and a
+   * database straight back into the bundle the installer was replacing (#926).
    */
-  private bootsInFlight = new Set<Promise<readonly string[]>>();
+  private stopping = false;
+  /**
+   * Lifecycle operations that have not finished yet - boots AND restarts.
+   *
+   * A superseded operation cleans up inside its own catch, which nobody used to
+   * await. So stop() could resolve `{clean: true}` while one was still
+   * SIGTERM-ing its kernel, or was about to start a database - the same lie
+   * this class exists to remove.
+   */
+  private opsInFlight = new Set<InFlightOp>();
   /**
    * Bumped on every stop/restart. A child's exit handler and the in-flight
    * health-poll loops compare against this so a process we intentionally killed
@@ -108,6 +135,9 @@ export class Supervisor extends EventEmitter {
 
   /** Boot the whole stack. Resolves with the UI URL once the UI is serving. */
   async start(): Promise<string> {
+    if (this.stopping) {
+      throw new Error('Cannot start while stopping.');
+    }
     if (this.state === 'starting' || this.state === 'stopping') {
       throw new Error(`Cannot start while ${this.state}.`);
     }
@@ -116,24 +146,26 @@ export class Supervisor extends EventEmitter {
     }
     this.state = 'starting';
     const gen = ++this.generation;
-
-    // Filled by this attempt's own cleanup with anything it could not kill, so
-    // a concurrent stop() can fold it into its outcome instead of reporting
-    // clean by omission.
-    const ownSurvivors: string[] = [];
-    const attempt = this.bootOnce(gen, ownSurvivors);
-    // Deliberately never rejects: the rejection belongs to our caller, while a
-    // waiting stop() only needs to know when cleanup finished and what is left.
-    const tracked = attempt.then(
-      (): readonly string[] => ownSurvivors,
-      (): readonly string[] => ownSurvivors,
-    );
-    this.bootsInFlight.add(tracked);
+    const { op, finish } = this.registerOp('boot');
     try {
-      return await attempt;
+      return await this.bootOnce(gen, op.survivors);
     } finally {
-      this.bootsInFlight.delete(tracked);
+      // finish() before delete: a stop() waiting on this op reads `survivors`
+      // once `settled` resolves, and the boot's catch has filled it by now.
+      finish();
+      this.opsInFlight.delete(op);
     }
+  }
+
+  /** Publish an operation so a concurrent stop() can wait for it. */
+  private registerOp(kind: InFlightOp['kind']): { op: InFlightOp; finish: () => void } {
+    let finish!: () => void;
+    const settled = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const op: InFlightOp = { kind, settled, survivors: [] };
+    this.opsInFlight.add(op);
+    return { op, finish };
   }
 
   private async bootOnce(gen: number, ownSurvivors: string[]): Promise<string> {
@@ -244,27 +276,36 @@ export class Supervisor extends EventEmitter {
     ownDb: EmbeddedDb | null,
     survivors: string[],
   ): Promise<void> {
-    const [uiOutcome, kernelOutcome] = await Promise.all([
-      stopChild(ownUi, 'web-ui', log),
-      stopChild(ownKernel, 'kernel', log),
-    ]);
-    if (!isConfirmedStopped(uiOutcome)) survivors.push('web-ui');
-    if (!isConfirmedStopped(kernelOutcome)) survivors.push('kernel');
-    if (ownUi !== null && this.ui === ownUi) {
-      this.ui = null;
-      this.uiUrl = null;
-    }
-    if (ownKernel !== null && this.kernel === ownKernel) {
-      this.kernel = null;
-    }
-    // Only ever set when this boot started the database itself and was then
-    // superseded, so there is no live generation depending on it.
-    if (ownDb !== null) {
-      try {
-        if (!(await ownDb.stop())) survivors.push('embedded-postgres');
-      } catch (err) {
-        log.error(`[db] stop failed for a superseded boot: ${String(err)}`);
-        survivors.push('embedded-postgres');
+    try {
+      // allSettled, not all: a kill() that throws (EPERM on a process that is
+      // already gone, for instance) must still be recorded as a survivor rather
+      // than aborting this method and skipping the rest of the teardown.
+      const [uiOutcome, kernelOutcome] = await Promise.allSettled([
+        stopChild(ownUi, 'web-ui', log),
+        stopChild(ownKernel, 'kernel', log),
+      ]);
+      if (!settledAndStopped(uiOutcome, 'web-ui')) survivors.push('web-ui');
+      if (!settledAndStopped(kernelOutcome, 'kernel')) survivors.push('kernel');
+      if (ownUi !== null && this.ui === ownUi) {
+        this.ui = null;
+        this.uiUrl = null;
+      }
+      if (ownKernel !== null && this.kernel === ownKernel) {
+        this.kernel = null;
+      }
+    } finally {
+      // In a finally: if anything above throws unexpectedly, skipping the
+      // database teardown would leave a live Postgres AND record no survivor,
+      // which is exactly the false-clean this class exists to prevent.
+      // Only ever set when this boot started the database itself and was then
+      // superseded, so there is no live generation depending on it.
+      if (ownDb !== null) {
+        try {
+          if (!(await ownDb.stop())) survivors.push('embedded-postgres');
+        } catch (err) {
+          log.error(`[db] stop failed for a superseded boot: ${String(err)}`);
+          survivors.push('embedded-postgres');
+        }
       }
     }
   }
@@ -274,10 +315,21 @@ export class Supervisor extends EventEmitter {
    * outlived it. Callers must invalidate the generation FIRST, otherwise a boot
    * happily waits out its full 90s kernel health timeout before noticing.
    */
-  private async settleInFlightBoots(): Promise<string[]> {
-    if (this.bootsInFlight.size === 0) return [];
-    const settled = await Promise.all([...this.bootsInFlight]);
-    return settled.flatMap((survivors) => [...survivors]);
+  private async settleInFlightOps(self?: InFlightOp): Promise<string[]> {
+    const survivors: string[] = [];
+    // Loop instead of snapshotting once. An operation can register another one
+    // while we are waiting - a restart entering its boot phase does exactly
+    // that - and a single `[...set]` snapshot would never see it. That gap is
+    // how a boot started by a restart escaped a concurrent stop() entirely.
+    for (;;) {
+      const pending = [...this.opsInFlight].filter((op) => op !== self);
+      if (pending.length === 0) return survivors;
+      await Promise.all(pending.map((op) => op.settled));
+      for (const op of pending) {
+        survivors.push(...op.survivors);
+        this.opsInFlight.delete(op);
+      }
+    }
   }
 
   private kernelEnv(port: number): NodeJS.ProcessEnv {
@@ -409,23 +461,39 @@ export class Supervisor extends EventEmitter {
 
   /** Stop kernel + UI but keep the embedded DB running, then boot again. */
   async restart(): Promise<string> {
-    // Both guards matter: `state` catches a concurrent restart (whose teardown
-    // sets the state but not the full-stop promise), `stopInFlight` catches a
-    // full shutdown already on its way down.
-    if (this.state === 'stopping' || this.stopInFlight) {
+    if (this.stopping || this.state === 'stopping') {
       throw new Error('Cannot restart while stopping.');
     }
+    // Published like a boot, so a stop() that lands mid-restart waits for the
+    // whole thing - teardown AND the boot it ends with - instead of only for
+    // the boots it happened to see.
+    const { op, finish } = this.registerOp('restart');
+    try {
+      return await this.restartOnce(op);
+    } finally {
+      finish();
+      this.opsInFlight.delete(op);
+    }
+  }
+
+  private async restartOnce(self: InFlightOp): Promise<string> {
     this.state = 'stopping';
     // Invalidate first, then wait. A boot we superseded stops the database it
     // started itself, so restarting on top of one still in flight could
     // otherwise pull the server out from under the boot we are about to do.
     this.generation++;
-    const survivors = [
-      ...(await this.settleInFlightBoots()),
-      ...(await this.teardownChildren()),
-    ];
-    if (survivors.length > 0) {
-      log.warn(`[boot] restarting with ${[...new Set(survivors)].join(' + ')} still alive`);
+    self.survivors.push(...(await this.settleInFlightOps(self)));
+    self.survivors.push(...(await this.teardownChildren()));
+    if (self.survivors.length > 0) {
+      log.warn(`[boot] restarting with ${self.survivors.join(' + ')} still alive`);
+    }
+    // A full shutdown that began while we were tearing down now owns the stack.
+    // Booting on top of it would put a kernel and a database back inside the
+    // very bundle the installer is about to replace, moments after stop() told
+    // it the stack was down (#926). The restart loses; the shutdown wins.
+    if (this.stopping) {
+      this.state = 'idle';
+      throw new Error('restart superseded by shutdown');
     }
     this.state = 'idle';
     return this.start();
@@ -441,12 +509,17 @@ export class Supervisor extends EventEmitter {
    */
   async stop(): Promise<StopOutcome> {
     if (this.stopInFlight) return this.stopInFlight;
+    // Set synchronously, before anything can yield, because this is the flag
+    // start() and restart() consult. Assigning it only inside runStop() would
+    // leave a window in which a restart could still slip past.
+    this.stopping = true;
     const run = this.runStop();
     this.stopInFlight = run;
     try {
       return await run;
     } finally {
       this.stopInFlight = null;
+      this.stopping = false;
     }
   }
 
@@ -457,7 +530,7 @@ export class Supervisor extends EventEmitter {
     // make them bail out promptly. Waiting first would mean sitting through a
     // full 90s kernel health timeout.
     this.generation++;
-    const survivors = [...(await this.settleInFlightBoots())];
+    const survivors = [...(await this.settleInFlightOps())];
     survivors.push(...(await this.teardownChildren()));
 
     // Reap from module state, not from `this.db`: a start() interrupted before
@@ -474,11 +547,14 @@ export class Supervisor extends EventEmitter {
 
     this.db = null;
     this.state = 'idle';
-    const unique = [...new Set(survivors)];
-    if (unique.length > 0) {
-      log.error(`[boot] shutdown incomplete — still alive: ${unique.join(', ')}`);
+    // Not de-duplicated. Two survivors can legitimately share a label - a
+    // superseded boot's kernel and the live generation's kernel are two
+    // processes - and collapsing them understated what was actually left
+    // running, which is the opposite of this method's job.
+    if (survivors.length > 0) {
+      log.error(`[boot] shutdown incomplete — still alive: ${survivors.join(', ')}`);
     }
-    return { clean: unique.length === 0, survivors: unique };
+    return { clean: survivors.length === 0, survivors };
   }
 
   /** Stop the embedded database, returning a survivor label if it outlived it. */
@@ -490,6 +566,18 @@ export class Supervisor extends EventEmitter {
       return ['embedded-postgres'];
     }
   }
+}
+
+/** A rejected stop attempt counts as "did not stop", never as success. */
+function settledAndStopped(
+  result: PromiseSettledResult<ChildStopOutcome>,
+  label: string,
+): boolean {
+  if (result.status === 'rejected') {
+    log.error(`[${label}] stop attempt threw: ${String(result.reason)}`);
+    return false;
+  }
+  return isConfirmedStopped(result.value);
 }
 
 // Track the live supervisor so the app's quit handler (main.ts) can await a

--- a/desktop/src/supervisor.ts
+++ b/desktop/src/supervisor.ts
@@ -1,4 +1,5 @@
-import { spawn, ChildProcess } from 'node:child_process';
+import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 import path from 'node:path';
 import { EventEmitter } from 'node:events';
 import { setTimeout as delay } from 'node:timers/promises';
@@ -10,7 +11,8 @@ import {
   platformDataDir,
 } from './paths';
 import { findFreePorts, isPortFree } from './ports';
-import { startEmbeddedDb, stopEmbeddedDb, EmbeddedDb } from './embeddedDb';
+import { startEmbeddedDb, stopEmbeddedDb, isEmbeddedDbRunning } from './embeddedDb';
+import type { EmbeddedDb } from './embeddedDb';
 import { stopChild, isConfirmedStopped } from './childLifecycle';
 import { credentialKeychainKey, vaultKey, allProviderKeys } from './secrets';
 import { log } from './log';
@@ -66,6 +68,15 @@ export class Supervisor extends EventEmitter {
    */
   private stopInFlight: Promise<StopOutcome> | null = null;
   /**
+   * Cleanup promises for boots that have not finished yet, each resolving with
+   * whatever that boot's own teardown could not kill.
+   *
+   * A superseded boot cleans up inside its own catch, which nobody used to
+   * await. So stop() could resolve `{clean: true}` while a superseded boot was
+   * still SIGTERM-ing its kernel - the same lie this class exists to remove.
+   */
+  private bootsInFlight = new Set<Promise<readonly string[]>>();
+  /**
    * Bumped on every stop/restart. A child's exit handler and the in-flight
    * health-poll loops compare against this so a process we intentionally killed
    * (or a boot we superseded) is never misreported as a crash.
@@ -105,16 +116,51 @@ export class Supervisor extends EventEmitter {
     }
     this.state = 'starting';
     const gen = ++this.generation;
-    // Children this particular boot spawned. `this.kernel`/`this.ui` can be
+
+    // Filled by this attempt's own cleanup with anything it could not kill, so
+    // a concurrent stop() can fold it into its outcome instead of reporting
+    // clean by omission.
+    const ownSurvivors: string[] = [];
+    const attempt = this.bootOnce(gen, ownSurvivors);
+    // Deliberately never rejects: the rejection belongs to our caller, while a
+    // waiting stop() only needs to know when cleanup finished and what is left.
+    const tracked = attempt.then(
+      (): readonly string[] => ownSurvivors,
+      (): readonly string[] => ownSurvivors,
+    );
+    this.bootsInFlight.add(tracked);
+    try {
+      return await attempt;
+    } finally {
+      this.bootsInFlight.delete(tracked);
+    }
+  }
+
+  private async bootOnce(gen: number, ownSurvivors: string[]): Promise<string> {
+    // Processes this particular boot spawned. `this.kernel`/`this.ui` can be
     // reassigned by a newer generation, so a superseded boot must reap what it
     // created from its own locals, not from the shared fields.
     let ownKernel: ChildProcess | null = null;
     let ownUi: ChildProcess | null = null;
+    let ownDb: EmbeddedDb | null = null;
 
     try {
       this.progress('starting-db', 'Starting embedded database…');
       if (!this.db) {
-        this.db = await startEmbeddedDb();
+        const db = await startEmbeddedDb();
+        // startEmbeddedDb() awaits a free port BEFORE it registers anything in
+        // module state, so a stop() inside that window found no database and
+        // reported a clean shutdown. Publishing this handle anyway would leave
+        // a live Postgres running out of the very bundle the installer is about
+        // to replace - the #926 loop, now with false reassurance on top. And
+        // assigning it when a stop() already killed it would poison the next
+        // boot, which skips `startEmbeddedDb()` whenever `this.db` is set and
+        // would then wait out a 90s health timeout against a dead server.
+        if (gen !== this.generation) {
+          ownDb = db;
+          throw new Error('boot superseded');
+        }
+        this.db = db;
       }
       // A stop() that landed while the database was coming up has already run
       // its teardown; anything we spawn from here on would be an orphan.
@@ -159,6 +205,9 @@ export class Supervisor extends EventEmitter {
       this.uiUrl = `http://127.0.0.1:${uiPort}`;
       await this.waitForHttp(`${this.uiUrl}/`, 30_000, 'web-ui', gen);
 
+      // Nothing checks the generation between that poll resolving and the state
+      // flip, and a stop() landing there would otherwise be overwritten.
+      this.assertLiveGeneration(gen);
       this.state = 'running';
       this.progress('ready', 'omadia is ready.');
       return this.uiUrl;
@@ -170,7 +219,7 @@ export class Supervisor extends EventEmitter {
       // cleanup here is what left an unowned kernel and Postgres running out of
       // the app bundle, and ShipIt then waited forever for a bundle it was not
       // allowed to replace (#927 → #926).
-      await this.reapOwnChildren(ownKernel, ownUi);
+      await this.reapOwnChildren(ownKernel, ownUi, ownDb, ownSurvivors);
       // The state and the shared fields belong to the live generation only.
       if (!superseded) {
         this.state = 'idle';
@@ -192,11 +241,15 @@ export class Supervisor extends EventEmitter {
   private async reapOwnChildren(
     ownKernel: ChildProcess | null,
     ownUi: ChildProcess | null,
+    ownDb: EmbeddedDb | null,
+    survivors: string[],
   ): Promise<void> {
-    await Promise.all([
+    const [uiOutcome, kernelOutcome] = await Promise.all([
       stopChild(ownUi, 'web-ui', log),
       stopChild(ownKernel, 'kernel', log),
     ]);
+    if (!isConfirmedStopped(uiOutcome)) survivors.push('web-ui');
+    if (!isConfirmedStopped(kernelOutcome)) survivors.push('kernel');
     if (ownUi !== null && this.ui === ownUi) {
       this.ui = null;
       this.uiUrl = null;
@@ -204,6 +257,27 @@ export class Supervisor extends EventEmitter {
     if (ownKernel !== null && this.kernel === ownKernel) {
       this.kernel = null;
     }
+    // Only ever set when this boot started the database itself and was then
+    // superseded, so there is no live generation depending on it.
+    if (ownDb !== null) {
+      try {
+        if (!(await ownDb.stop())) survivors.push('embedded-postgres');
+      } catch (err) {
+        log.error(`[db] stop failed for a superseded boot: ${String(err)}`);
+        survivors.push('embedded-postgres');
+      }
+    }
+  }
+
+  /**
+   * Wait for every in-flight boot to finish its own cleanup, and report what
+   * outlived it. Callers must invalidate the generation FIRST, otherwise a boot
+   * happily waits out its full 90s kernel health timeout before noticing.
+   */
+  private async settleInFlightBoots(): Promise<string[]> {
+    if (this.bootsInFlight.size === 0) return [];
+    const settled = await Promise.all([...this.bootsInFlight]);
+    return settled.flatMap((survivors) => [...survivors]);
   }
 
   private kernelEnv(port: number): NodeJS.ProcessEnv {
@@ -342,9 +416,16 @@ export class Supervisor extends EventEmitter {
       throw new Error('Cannot restart while stopping.');
     }
     this.state = 'stopping';
-    const survivors = await this.teardownChildren();
+    // Invalidate first, then wait. A boot we superseded stops the database it
+    // started itself, so restarting on top of one still in flight could
+    // otherwise pull the server out from under the boot we are about to do.
+    this.generation++;
+    const survivors = [
+      ...(await this.settleInFlightBoots()),
+      ...(await this.teardownChildren()),
+    ];
     if (survivors.length > 0) {
-      log.warn(`[boot] restarting with ${survivors.join(' + ')} still alive`);
+      log.warn(`[boot] restarting with ${[...new Set(survivors)].join(' + ')} still alive`);
     }
     this.state = 'idle';
     return this.start();
@@ -371,22 +452,43 @@ export class Supervisor extends EventEmitter {
 
   private async runStop(): Promise<StopOutcome> {
     this.state = 'stopping';
-    const survivors = [...(await this.teardownChildren())];
+    // Invalidate in-flight boots BEFORE waiting on them: their next generation
+    // checkpoint and their health polls (which re-check every 750ms) are what
+    // make them bail out promptly. Waiting first would mean sitting through a
+    // full 90s kernel health timeout.
+    this.generation++;
+    const survivors = [...(await this.settleInFlightBoots())];
+    survivors.push(...(await this.teardownChildren()));
+
     // Reap from module state, not from `this.db`: a start() interrupted before
     // it assigned the handle still left a live Postgres, and the old
     // `if (this.db)` guard walked straight past it (#927).
-    try {
-      if (!(await stopEmbeddedDb())) survivors.push('embedded-postgres');
-    } catch (err) {
-      log.error(`[db] stop failed: ${String(err)}`);
-      survivors.push('embedded-postgres');
+    survivors.push(...(await this.stopDatabase()));
+    // A boot that was inside startEmbeddedDb()'s port lookup when we
+    // invalidated it registers its server only afterwards. It has settled by
+    // now, so a database still registered here is a real leak, not a race.
+    if (isEmbeddedDbRunning()) {
+      log.warn('[db] a database was still registered after shutdown; stopping it again');
+      survivors.push(...(await this.stopDatabase()));
     }
+
     this.db = null;
     this.state = 'idle';
-    if (survivors.length > 0) {
-      log.error(`[boot] shutdown incomplete — still alive: ${survivors.join(', ')}`);
+    const unique = [...new Set(survivors)];
+    if (unique.length > 0) {
+      log.error(`[boot] shutdown incomplete — still alive: ${unique.join(', ')}`);
     }
-    return { clean: survivors.length === 0, survivors };
+    return { clean: unique.length === 0, survivors: unique };
+  }
+
+  /** Stop the embedded database, returning a survivor label if it outlived it. */
+  private async stopDatabase(): Promise<string[]> {
+    try {
+      return (await stopEmbeddedDb()) ? [] : ['embedded-postgres'];
+    } catch (err) {
+      log.error(`[db] stop failed: ${String(err)}`);
+      return ['embedded-postgres'];
+    }
   }
 }
 

--- a/desktop/src/supervisor.ts
+++ b/desktop/src/supervisor.ts
@@ -10,7 +10,8 @@ import {
   platformDataDir,
 } from './paths';
 import { findFreePorts, isPortFree } from './ports';
-import { startEmbeddedDb, EmbeddedDb } from './embeddedDb';
+import { startEmbeddedDb, stopEmbeddedDb, EmbeddedDb } from './embeddedDb';
+import { stopChild, isConfirmedStopped } from './childLifecycle';
 import { credentialKeychainKey, vaultKey, allProviderKeys } from './secrets';
 import { log } from './log';
 import { resolveAugmentedPath } from './pathEnv';
@@ -32,6 +33,20 @@ export interface BootProgress {
 }
 
 /**
+ * What a shutdown actually achieved.
+ *
+ * `stop()` used to return `Promise<void>`, so a caller could not tell a real
+ * shutdown from one that gave up waiting. The updater relied on that void
+ * promise to decide it was safe to hand the app bundle to Squirrel (#926).
+ */
+export interface StopOutcome {
+  /** True only when every process this supervisor started is confirmed gone. */
+  readonly clean: boolean;
+  /** Labels of the processes that outlived their shutdown deadline. */
+  readonly survivors: readonly string[];
+}
+
+/**
  * Owns the lifecycle of the local omadia stack: embedded DB → kernel → web-ui.
  * Children are forked from Electron's own binary running in pure-Node mode
  * (ELECTRON_RUN_AS_NODE=1), so we ship no separate Node runtime.
@@ -43,6 +58,13 @@ export class Supervisor extends EventEmitter {
   private uiUrl: string | null = null;
   /** Single-flight guard: only one start/restart/stop runs at a time. */
   private state: 'idle' | 'starting' | 'running' | 'stopping' = 'idle';
+  /**
+   * The in-flight full shutdown, if any. A second `stop()` awaits THIS instead
+   * of returning immediately: the old early return handed its caller a
+   * fulfilled promise while the first stop was still killing children, which
+   * is how the updater came to believe the stack was down (#927).
+   */
+  private stopInFlight: Promise<StopOutcome> | null = null;
   /**
    * Bumped on every stop/restart. A child's exit handler and the in-flight
    * health-poll loops compare against this so a process we intentionally killed
@@ -83,12 +105,20 @@ export class Supervisor extends EventEmitter {
     }
     this.state = 'starting';
     const gen = ++this.generation;
+    // Children this particular boot spawned. `this.kernel`/`this.ui` can be
+    // reassigned by a newer generation, so a superseded boot must reap what it
+    // created from its own locals, not from the shared fields.
+    let ownKernel: ChildProcess | null = null;
+    let ownUi: ChildProcess | null = null;
 
     try {
       this.progress('starting-db', 'Starting embedded database…');
       if (!this.db) {
         this.db = await startEmbeddedDb();
       }
+      // A stop() that landed while the database was coming up has already run
+      // its teardown; anything we spawn from here on would be an orphan.
+      this.assertLiveGeneration(gen);
 
       const kernelPort = Supervisor.KERNEL_PORT;
       // The kernel port is fixed (the web-ui bakes it at build time), so a clash
@@ -114,14 +144,18 @@ export class Supervisor extends EventEmitter {
       }
       const [uiPort] = await findFreePorts(1);
 
+      this.assertLiveGeneration(gen);
       this.progress('starting-kernel', 'Starting omadia kernel…');
-      this.kernel = this.forkNode(kernelEntry(), kernelCwd(), this.kernelEnv(kernelPort), 'kernel', gen);
+      ownKernel = this.forkNode(kernelEntry(), kernelCwd(), this.kernelEnv(kernelPort), 'kernel', gen);
+      this.kernel = ownKernel;
 
       this.progress('waiting-kernel', 'Waiting for the kernel to become healthy…');
       await this.waitForKernel(kernelPort, gen);
 
+      this.assertLiveGeneration(gen);
       this.progress('starting-ui', 'Starting the admin interface…');
-      this.ui = this.forkNode(webUiEntry(), webUiCwd(), this.uiEnv(uiPort, kernelPort), 'web-ui', gen);
+      ownUi = this.forkNode(webUiEntry(), webUiCwd(), this.uiEnv(uiPort, kernelPort), 'web-ui', gen);
+      this.ui = ownUi;
       this.uiUrl = `http://127.0.0.1:${uiPort}`;
       await this.waitForHttp(`${this.uiUrl}/`, 30_000, 'web-ui', gen);
 
@@ -129,14 +163,46 @@ export class Supervisor extends EventEmitter {
       this.progress('ready', 'omadia is ready.');
       return this.uiUrl;
     } catch (err) {
-      // If a concurrent stop()/restart() superseded this boot (it bumped the
-      // generation), it now owns teardown + the state — do NOT double-tear-down
-      // or stomp its state. Only clean up when we're still the live generation.
-      if (gen === this.generation) {
-        await this.teardownChildren();
+      const superseded = gen !== this.generation;
+      // Always reap our OWN children. When we were superseded the concurrent
+      // stop() bumped the generation and tore down whatever existed AT THAT
+      // MOMENT — which, for a boot still between phases, was nothing. Skipping
+      // cleanup here is what left an unowned kernel and Postgres running out of
+      // the app bundle, and ShipIt then waited forever for a bundle it was not
+      // allowed to replace (#927 → #926).
+      await this.reapOwnChildren(ownKernel, ownUi);
+      // The state and the shared fields belong to the live generation only.
+      if (!superseded) {
         this.state = 'idle';
       }
       throw err;
+    }
+  }
+
+  /** Bail out of a boot that a concurrent stop()/restart() has overtaken. */
+  private assertLiveGeneration(gen: number): void {
+    if (gen !== this.generation) throw new Error('boot superseded');
+  }
+
+  /**
+   * Kill the children one specific boot attempt spawned, regardless of which
+   * generation is live, and detach them from the shared fields only if they are
+   * still the ones recorded there.
+   */
+  private async reapOwnChildren(
+    ownKernel: ChildProcess | null,
+    ownUi: ChildProcess | null,
+  ): Promise<void> {
+    await Promise.all([
+      stopChild(ownUi, 'web-ui', log),
+      stopChild(ownKernel, 'kernel', log),
+    ]);
+    if (ownUi !== null && this.ui === ownUi) {
+      this.ui = null;
+      this.uiUrl = null;
+    }
+    if (ownKernel !== null && this.kernel === ownKernel) {
+      this.kernel = null;
     }
   }
 
@@ -250,70 +316,77 @@ export class Supervisor extends EventEmitter {
     throw new Error(`${label} did not become healthy within ${timeoutMs}ms (${lastErr})`);
   }
 
-  /** SIGTERM a child, wait for it to actually exit, escalate to SIGKILL if needed. */
-  private killAndWait(child: ChildProcess | null, label: string, graceMs = 4_000): Promise<void> {
-    if (!child || child.exitCode !== null || child.signalCode !== null) {
-      return Promise.resolve();
-    }
-    return new Promise<void>((resolve) => {
-      let settled = false;
-      const finish = (): void => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(killTimer);
-        clearTimeout(hardStop);
-        resolve();
-      };
-      child.once('exit', finish);
-      child.kill('SIGTERM');
-      // Escalate if it ignores SIGTERM (notably on Windows, where SIGTERM is not
-      // a real graceful signal).
-      const killTimer = setTimeout(() => {
-        if (child.exitCode === null && child.signalCode === null) {
-          log.warn(`[${label}] did not exit on SIGTERM; sending SIGKILL`);
-          child.kill('SIGKILL');
-        }
-      }, graceMs);
-      // Absolute backstop so a never-firing 'exit' can't hang shutdown forever.
-      const hardStop = setTimeout(finish, graceMs * 2);
-    });
-  }
-
-  private async teardownChildren(): Promise<void> {
+  /** Kill kernel + UI, reporting any that outlived their deadline. */
+  private async teardownChildren(): Promise<string[]> {
     // Invalidate exit handlers + in-flight health polls before we kill anything.
     this.generation++;
-    await Promise.all([
-      this.killAndWait(this.ui, 'web-ui'),
-      this.killAndWait(this.kernel, 'kernel'),
+    const [uiOutcome, kernelOutcome] = await Promise.all([
+      stopChild(this.ui, 'web-ui', log),
+      stopChild(this.kernel, 'kernel', log),
     ]);
     this.ui = null;
     this.kernel = null;
     this.uiUrl = null;
+    const survivors: string[] = [];
+    if (!isConfirmedStopped(uiOutcome)) survivors.push('web-ui');
+    if (!isConfirmedStopped(kernelOutcome)) survivors.push('kernel');
+    return survivors;
   }
 
   /** Stop kernel + UI but keep the embedded DB running, then boot again. */
   async restart(): Promise<string> {
-    if (this.state === 'stopping') throw new Error('Cannot restart while stopping.');
+    // Both guards matter: `state` catches a concurrent restart (whose teardown
+    // sets the state but not the full-stop promise), `stopInFlight` catches a
+    // full shutdown already on its way down.
+    if (this.state === 'stopping' || this.stopInFlight) {
+      throw new Error('Cannot restart while stopping.');
+    }
     this.state = 'stopping';
-    await this.teardownChildren();
+    const survivors = await this.teardownChildren();
+    if (survivors.length > 0) {
+      log.warn(`[boot] restarting with ${survivors.join(' + ')} still alive`);
+    }
     this.state = 'idle';
     return this.start();
   }
 
-  /** Full shutdown: children (awaited) then the embedded DB. Call on app quit. */
-  async stop(): Promise<void> {
-    if (this.state === 'stopping') return;
-    this.state = 'stopping';
-    await this.teardownChildren();
-    if (this.db) {
-      try {
-        await this.db.stop();
-      } catch (err) {
-        log.error(`[db] stop failed: ${String(err)}`);
-      }
-      this.db = null;
+  /**
+   * Full shutdown: children (awaited) then the embedded DB. Call on app quit.
+   *
+   * Resolves with what was actually achieved. A second concurrent call awaits
+   * the first one's outcome rather than returning a fulfilled promise while the
+   * first is still working — that early return is what let the updater proceed
+   * to `quitAndInstall()` over a live stack (#927).
+   */
+  async stop(): Promise<StopOutcome> {
+    if (this.stopInFlight) return this.stopInFlight;
+    const run = this.runStop();
+    this.stopInFlight = run;
+    try {
+      return await run;
+    } finally {
+      this.stopInFlight = null;
     }
+  }
+
+  private async runStop(): Promise<StopOutcome> {
+    this.state = 'stopping';
+    const survivors = [...(await this.teardownChildren())];
+    // Reap from module state, not from `this.db`: a start() interrupted before
+    // it assigned the handle still left a live Postgres, and the old
+    // `if (this.db)` guard walked straight past it (#927).
+    try {
+      if (!(await stopEmbeddedDb())) survivors.push('embedded-postgres');
+    } catch (err) {
+      log.error(`[db] stop failed: ${String(err)}`);
+      survivors.push('embedded-postgres');
+    }
+    this.db = null;
     this.state = 'idle';
+    if (survivors.length > 0) {
+      log.error(`[boot] shutdown incomplete — still alive: ${survivors.join(', ')}`);
+    }
+    return { clean: survivors.length === 0, survivors };
   }
 }
 

--- a/desktop/src/supervisor.ts
+++ b/desktop/src/supervisor.ts
@@ -124,6 +124,19 @@ export class Supervisor extends EventEmitter {
    */
   private static readonly KERNEL_PORT = 8769;
 
+  /**
+   * Rounds the settle loop may take before it gives up waiting.
+   *
+   * It cannot spin today: a new operation can only come from start() or
+   * restart(), and both are refused while `stopping`. But that is a
+   * guard-equivalence argument, and those have already been wrong more than
+   * once on this code - while an unbounded loop inside stop() would hang the
+   * quit forever, which is strictly worse than the leak the loop prevents.
+   * Eight is far above any legitimate chain (a restart entering its boot phase
+   * needs two).
+   */
+  private static readonly MAX_SETTLE_ROUNDS = 8;
+
   getUiUrl(): string | null {
     return this.uiUrl;
   }
@@ -321,7 +334,7 @@ export class Supervisor extends EventEmitter {
     // while we are waiting - a restart entering its boot phase does exactly
     // that - and a single `[...set]` snapshot would never see it. That gap is
     // how a boot started by a restart escaped a concurrent stop() entirely.
-    for (;;) {
+    for (let round = 0; round < Supervisor.MAX_SETTLE_ROUNDS; round += 1) {
       const pending = [...this.opsInFlight].filter((op) => op !== self);
       if (pending.length === 0) return survivors;
       await Promise.all(pending.map((op) => op.settled));
@@ -330,6 +343,21 @@ export class Supervisor extends EventEmitter {
         this.opsInFlight.delete(op);
       }
     }
+
+    // Bounded, and loud about it. Giving up quietly and reporting a clean
+    // shutdown would be the same lie in a new place: the caller would hand a
+    // live stack to the installer on the strength of it.
+    const stuck = [...this.opsInFlight].filter((op) => op !== self);
+    if (stuck.length > 0) {
+      log.error(
+        `[boot] gave up waiting for lifecycle work after ${Supervisor.MAX_SETTLE_ROUNDS} ` +
+          `rounds; still in flight: ${stuck.map((op) => op.kind).join(', ')}`,
+      );
+      survivors.push(
+        ...stuck.map((op) => (op.kind === 'boot' ? 'pending-startup' : 'pending-restart')),
+      );
+    }
+    return survivors;
   }
 
   private kernelEnv(port: number): NodeJS.ProcessEnv {

--- a/desktop/src/supervisor.ts
+++ b/desktop/src/supervisor.ts
@@ -446,7 +446,14 @@ export class Supervisor extends EventEmitter {
   private async teardownChildren(): Promise<string[]> {
     // Invalidate exit handlers + in-flight health polls before we kill anything.
     this.generation++;
-    const [uiOutcome, kernelOutcome] = await Promise.all([
+    // allSettled, not all. This runs on every real shutdown, and a kill() that
+    // throws (EPERM against a process that is already gone, for instance) used
+    // to reject the whole of stop() instead of reporting a survivor: the
+    // database teardown was then skipped, Postgres was orphaned, `state` stayed
+    // wedged at 'stopping' so the app could not start again in that session,
+    // and the quit handler's second stop() failed identically. reapOwnChildren
+    // already had this treatment; this is the path that actually matters.
+    const [uiOutcome, kernelOutcome] = await Promise.allSettled([
       stopChild(this.ui, 'web-ui', log),
       stopChild(this.kernel, 'kernel', log),
     ]);
@@ -454,8 +461,8 @@ export class Supervisor extends EventEmitter {
     this.kernel = null;
     this.uiUrl = null;
     const survivors: string[] = [];
-    if (!isConfirmedStopped(uiOutcome)) survivors.push('web-ui');
-    if (!isConfirmedStopped(kernelOutcome)) survivors.push('kernel');
+    if (!settledAndStopped(uiOutcome, 'web-ui')) survivors.push('web-ui');
+    if (!settledAndStopped(kernelOutcome, 'kernel')) survivors.push('kernel');
     return survivors;
   }
 
@@ -530,23 +537,31 @@ export class Supervisor extends EventEmitter {
     // make them bail out promptly. Waiting first would mean sitting through a
     // full 90s kernel health timeout.
     this.generation++;
-    const survivors = [...(await this.settleInFlightOps())];
-    survivors.push(...(await this.teardownChildren()));
-
-    // Reap from module state, not from `this.db`: a start() interrupted before
-    // it assigned the handle still left a live Postgres, and the old
-    // `if (this.db)` guard walked straight past it (#927).
-    survivors.push(...(await this.stopDatabase()));
-    // A boot that was inside startEmbeddedDb()'s port lookup when we
-    // invalidated it registers its server only afterwards. It has settled by
-    // now, so a database still registered here is a real leak, not a race.
-    if (isEmbeddedDbRunning()) {
-      log.warn('[db] a database was still registered after shutdown; stopping it again');
+    const survivors: string[] = [];
+    try {
+      survivors.push(...(await this.settleInFlightOps()));
+      survivors.push(...(await this.teardownChildren()));
+    } finally {
+      // In a finally so an unexpected throw above can never skip it. Skipping
+      // the database teardown is how a failed child kill orphaned Postgres
+      // while reporting nothing about it.
+      // Reap from module state, not from `this.db`: a start() interrupted
+      // before it assigned the handle still left a live Postgres, and the old
+      // `if (this.db)` guard walked straight past it (#927).
       survivors.push(...(await this.stopDatabase()));
+      // A boot that was inside startEmbeddedDb()'s port lookup when we
+      // invalidated it registers its server only afterwards. It has settled by
+      // now, so a database still registered here is a real leak, not a race.
+      if (isEmbeddedDbRunning()) {
+        log.warn('[db] a database was still registered after shutdown; stopping it again');
+        survivors.push(...(await this.stopDatabase()));
+      }
+      this.db = null;
+      // Never leave the supervisor wedged in 'stopping'. A caller that saw an
+      // exception can still legitimately try to start again, and the quit
+      // handler's own stop() must not fail for the same reason twice.
+      this.state = 'idle';
     }
-
-    this.db = null;
-    this.state = 'idle';
     // Not de-duplicated. Two survivors can legitimately share a label - a
     // superseded boot's kernel and the live generation's kernel are two
     // processes - and collapsing them understated what was actually left

--- a/desktop/src/syncedPaths.ts
+++ b/desktop/src/syncedPaths.ts
@@ -1,0 +1,108 @@
+import path from 'node:path';
+
+/**
+ * Recognising cloud-synced directories, so the wizard can warn before a live
+ * PostgreSQL cluster is put somewhere a sync client will evict, lock or
+ * duplicate its files (#934).
+ *
+ * Detection is by path shape rather than by asking the sync client, because
+ * every provider has a different (and version-dependent) way of being asked,
+ * and a wrong "no" here is worse than a wrong "maybe": the whole point is to
+ * say something before the user commits a database to iCloud Drive.
+ */
+
+interface SyncedMarker {
+  readonly provider: string;
+  /** Path segments, relative to the home directory, that identify the root. */
+  readonly relativeSegments: readonly string[];
+}
+
+const HOME_RELATIVE_MARKERS: readonly SyncedMarker[] = [
+  { provider: 'iCloud Drive', relativeSegments: ['Library', 'Mobile Documents'] },
+  { provider: 'Dropbox', relativeSegments: ['Dropbox'] },
+  { provider: 'OneDrive', relativeSegments: ['OneDrive'] },
+  { provider: 'Google Drive', relativeSegments: ['Google Drive'] },
+];
+
+/**
+ * macOS mounts third-party file providers under `~/Library/CloudStorage` as
+ * `<Provider>-<Account>` (e.g. `OneDrive-Contoso`). The provider is worth
+ * naming precisely, because "your folder is synced" is much easier to act on
+ * when it says which service is doing the syncing.
+ */
+const CLOUD_STORAGE_SEGMENTS: readonly string[] = ['Library', 'CloudStorage'];
+
+const CLOUD_STORAGE_PROVIDERS: readonly { readonly prefix: string; readonly provider: string }[] = [
+  { prefix: 'OneDrive', provider: 'OneDrive' },
+  { prefix: 'GoogleDrive', provider: 'Google Drive' },
+  { prefix: 'Dropbox', provider: 'Dropbox' },
+  { prefix: 'Box', provider: 'Box' },
+  { prefix: 'iCloudDrive', provider: 'iCloud Drive' },
+];
+
+const GENERIC_CLOUD_PROVIDER = 'a cloud storage service';
+
+/** Segments that identify a provider anywhere in the path, not just under home. */
+const ANYWHERE_MARKERS: readonly SyncedMarker[] = [
+  { provider: 'iCloud Drive', relativeSegments: ['com~apple~CloudDocs'] },
+  { provider: 'OneDrive', relativeSegments: ['OneDrive'] },
+  { provider: 'Dropbox', relativeSegments: ['Dropbox'] },
+  { provider: 'Google Drive', relativeSegments: ['GoogleDrive'] },
+];
+
+function segmentsOf(dir: string): string[] {
+  return path.resolve(dir).split(path.sep).filter((segment) => segment.length > 0);
+}
+
+function startsWithSegments(
+  segments: readonly string[],
+  prefix: readonly string[],
+): boolean {
+  if (prefix.length > segments.length) return false;
+  return prefix.every((wanted, index) => segments[index] === wanted);
+}
+
+function containsSegments(
+  segments: readonly string[],
+  wanted: readonly string[],
+): boolean {
+  for (let start = 0; start + wanted.length <= segments.length; start += 1) {
+    if (wanted.every((value, offset) => segments[start + offset] === value)) return true;
+  }
+  return false;
+}
+
+function cloudStorageProvider(mountSegment: string | undefined): string {
+  if (mountSegment === undefined) return GENERIC_CLOUD_PROVIDER;
+  const match = CLOUD_STORAGE_PROVIDERS.find((candidate) =>
+    mountSegment.startsWith(candidate.prefix),
+  );
+  return match?.provider ?? GENERIC_CLOUD_PROVIDER;
+}
+
+/**
+ * The sync provider that appears to own `dir`, or null.
+ *
+ * `homeDir` is a parameter rather than an `os.homedir()` read so this stays a
+ * pure function the tests can drive across platforms.
+ */
+export function detectSyncedLocation(dir: string, homeDir: string): string | null {
+  const segments = segmentsOf(dir);
+  const homeSegments = segmentsOf(homeDir);
+
+  if (startsWithSegments(segments, homeSegments)) {
+    const relative = segments.slice(homeSegments.length);
+    if (startsWithSegments(relative, CLOUD_STORAGE_SEGMENTS)) {
+      return cloudStorageProvider(relative[CLOUD_STORAGE_SEGMENTS.length]);
+    }
+    for (const marker of HOME_RELATIVE_MARKERS) {
+      if (startsWithSegments(relative, marker.relativeSegments)) return marker.provider;
+    }
+  }
+
+  for (const marker of ANYWHERE_MARKERS) {
+    if (containsSegments(segments, marker.relativeSegments)) return marker.provider;
+  }
+
+  return null;
+}

--- a/desktop/src/updateAttempts.ts
+++ b/desktop/src/updateAttempts.ts
@@ -34,7 +34,10 @@ function isRecord(value: unknown): value is UpdateAttemptRecord {
     candidate.version.length > 0 &&
     typeof candidate.attempts === 'number' &&
     Number.isInteger(candidate.attempts) &&
-    candidate.attempts >= 0
+    candidate.attempts >= 0 &&
+    // Validated rather than coerced: `lastAttemptAt` is typed `string`, so
+    // letting a number through here would hand callers a typed lie.
+    (candidate.lastAttemptAt === undefined || typeof candidate.lastAttemptAt === 'string')
   );
 }
 

--- a/desktop/src/updateAttempts.ts
+++ b/desktop/src/updateAttempts.ts
@@ -1,0 +1,100 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Remembering that we already handed a version to the installer (#926).
+ *
+ * `initUpdater()` runs one check per app launch, so a failing install is not a
+ * loop inside one process - it is the same first-time-looking prompt on every
+ * restart. Without a marker on disk the app cannot tell "a new version is
+ * available" from "I have already tried to install this exact version twice
+ * and I am still not running it". The tester saw the same prompt three times
+ * in nine minutes and the app never once said anything was wrong.
+ */
+
+export interface UpdateAttemptRecord {
+  readonly version: string;
+  readonly attempts: number;
+  readonly lastAttemptAt: string;
+}
+
+/**
+ * Attempts for one version before we stop prompting and explain instead. Two,
+ * not one: a single failure can be a genuine transient (a locked file, a
+ * sleeping machine), while a second one in a row is the bundle swap being
+ * structurally blocked.
+ */
+export const MAX_INSTALL_ATTEMPTS = 2;
+
+function isRecord(value: unknown): value is UpdateAttemptRecord {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Partial<UpdateAttemptRecord>;
+  return (
+    typeof candidate.version === 'string' &&
+    candidate.version.length > 0 &&
+    typeof candidate.attempts === 'number' &&
+    Number.isInteger(candidate.attempts) &&
+    candidate.attempts >= 0
+  );
+}
+
+export function readUpdateAttempts(file: string): UpdateAttemptRecord | null {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (!isRecord(parsed)) return null;
+    return {
+      version: parsed.version,
+      attempts: parsed.attempts,
+      lastAttemptAt: parsed.lastAttemptAt ?? '',
+    };
+  } catch {
+    // Absent or unreadable is the normal case (no update ever attempted), and a
+    // corrupt marker must never block an install - fall back to "no history".
+    return null;
+  }
+}
+
+export function writeUpdateAttempts(file: string, record: UpdateAttemptRecord): void {
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, `${JSON.stringify(record, null, 2)}\n`, 'utf8');
+  } catch (err) {
+    // A marker we could not persist degrades to the old behaviour (prompt
+    // again) rather than blocking the update the user asked for.
+    throw new Error(`could not record update attempt: ${String(err)}`);
+  }
+}
+
+export function clearUpdateAttempts(file: string): void {
+  try {
+    fs.rmSync(file, { force: true });
+  } catch {
+    /* best effort: a stale marker only costs one extra explanatory dialog */
+  }
+}
+
+/** The record to persist before handing `version` to the installer. */
+export function nextAttempt(
+  previous: UpdateAttemptRecord | null,
+  version: string,
+  now: Date,
+): UpdateAttemptRecord {
+  const carried = previous !== null && previous.version === version ? previous.attempts : 0;
+  return { version, attempts: carried + 1, lastAttemptAt: now.toISOString() };
+}
+
+/**
+ * True when we have already spent every attempt on this exact version and are
+ * still not running it - i.e. the install is silently not taking effect.
+ */
+export function installKeepsFailing(
+  record: UpdateAttemptRecord | null,
+  offeredVersion: string,
+  runningVersion: string,
+  max: number = MAX_INSTALL_ATTEMPTS,
+): boolean {
+  if (record === null) return false;
+  if (record.version !== offeredVersion) return false;
+  if (runningVersion === offeredVersion) return false;
+  return record.attempts >= max;
+}

--- a/desktop/src/updater.ts
+++ b/desktop/src/updater.ts
@@ -2,9 +2,17 @@ import { app, dialog, type MessageBoxOptions } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import fs from 'node:fs';
 import path from 'node:path';
-import { embeddedDbDir, snapshotDir } from './paths';
+import { embeddedDbDir, snapshotDir, updateAttemptsFile } from './paths';
 import { getActiveSupervisor } from './supervisor';
-import { log } from './log';
+import { log, logFile } from './log';
+import {
+  clearUpdateAttempts,
+  installKeepsFailing,
+  nextAttempt,
+  readUpdateAttempts,
+  writeUpdateAttempts,
+} from './updateAttempts';
+import { SNAPSHOTS_TO_KEEP, snapshotDirName, snapshotsToPrune } from './snapshotRetention';
 
 let installing = false;
 // This flag is only safe because electron-updater's own checkForUpdates()
@@ -52,6 +60,11 @@ export function initUpdater(): void {
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = false; // we control install timing (after snapshot)
 
+  // We are running, so whatever we last handed to the installer either landed
+  // (running version matches) or is stale history for a version we have since
+  // moved past. Either way the counter has done its job (#926).
+  reconcileUpdateHistory();
+
   autoUpdater.on('error', (err) => {
     log.error(`[updater] ${String(err)}`);
     if (!takeManualCheckPending()) return;
@@ -84,6 +97,31 @@ export function initUpdater(): void {
   });
   autoUpdater.on('update-downloaded', async (info) => {
     log.info(`[updater] downloaded ${info.version}`);
+
+    // Offering the same version a third time, having twice failed to apply it,
+    // is the loop the tester hit: three prompts in nine minutes, three DB
+    // snapshots, no error, and the machine still on the old build. Say what is
+    // happening once instead (#926).
+    const history = readUpdateAttempts(updateAttemptsFile());
+    if (installKeepsFailing(history, info.version, app.getVersion())) {
+      log.error(
+        `[updater] ${info.version} was handed to the installer ${history?.attempts ?? 0}x ` +
+          `and we are still on ${app.getVersion()}; not offering it again`,
+      );
+      await showUpdaterDialog({
+        type: 'warning',
+        title: 'Update could not be applied',
+        message: `omadia could not install ${info.version}.`,
+        detail:
+          `The update was downloaded and applied ${history?.attempts ?? 0} times, but omadia is ` +
+          `still running ${app.getVersion()}. Something is preventing the installed ` +
+          'application from being replaced.\n\n' +
+          `Please install ${info.version} manually from the omadia releases page, and attach ` +
+          `this log if you report it:\n${logFile()}`,
+      });
+      return;
+    }
+
     // This restart decision is intentionally unbounded: installing an update
     // without explicit user consent would be worse than waiting for it here.
     const { response } = await dialog.showMessageBox({
@@ -97,17 +135,27 @@ export function initUpdater(): void {
     });
     if (response !== 0) return;
 
-    // Quiesce the stack FIRST so the embedded DB is flushed + closed before we
-    // copy its directory — a live cpSync could capture a torn, unrestorable
-    // snapshot. Then snapshot, then hand off to the installer.
     installing = true;
-    try {
-      const sup = getActiveSupervisor();
-      if (sup) await sup.stop();
-      snapshotDbDir(info.version);
-    } catch (err) {
-      log.error(`[updater] pre-install stop/snapshot failed (installing anyway): ${String(err)}`);
+    if (!(await quiesceForInstall(info.version))) {
+      // Handing a live stack to Squirrel is what caused the loop: ShipIt cannot
+      // replace a bundle whose kernel and Postgres are still running out of it,
+      // so it waits forever and the next launch is the old version again. Stop
+      // here instead of installing "anyway" (#926/#927).
+      installing = false;
+      return;
     }
+
+    try {
+      writeUpdateAttempts(
+        updateAttemptsFile(),
+        nextAttempt(history, info.version, new Date()),
+      );
+    } catch (err) {
+      // Losing the counter only costs us the ability to notice a repeat; it must
+      // not block an update the user just approved.
+      log.warn(`[updater] ${String(err)}`);
+    }
+
     // quitAndInstall drives the app quit itself; main's before-quit checks
     // isUpdateInstalling() and steps aside so the installer isn't bypassed.
     autoUpdater.quitAndInstall();
@@ -145,12 +193,92 @@ export async function checkForUpdatesManually(): Promise<void> {
   }
 }
 
-/** Copy the embedded DB directory into a timestamp-free, version-named snapshot. */
+/**
+ * Clear a spent install marker.
+ *
+ * Running at all proves the previous handoff is history: either it succeeded
+ * (our version is the one recorded) or the recorded version is no longer what
+ * the feed offers, in which case a fresh count is the honest starting point.
+ */
+function reconcileUpdateHistory(): void {
+  const file = updateAttemptsFile();
+  const history = readUpdateAttempts(file);
+  if (history === null) return;
+  if (history.version === app.getVersion()) {
+    log.info(`[updater] ${history.version} installed successfully; clearing attempt marker`);
+    clearUpdateAttempts(file);
+  }
+}
+
+/**
+ * Bring the stack down and snapshot the database, and report whether the app
+ * bundle is actually free for the installer to replace.
+ *
+ * Quiescing FIRST matters for the snapshot too: a live cpSync could capture a
+ * torn, unrestorable copy.
+ */
+async function quiesceForInstall(version: string): Promise<boolean> {
+  try {
+    const sup = getActiveSupervisor();
+    if (sup) {
+      const outcome = await sup.stop();
+      if (!outcome.clean) {
+        log.error(
+          `[updater] aborting install of ${version}: still running - ${outcome.survivors.join(', ')}`,
+        );
+        await showUpdaterDialog({
+          type: 'error',
+          title: 'Update not applied',
+          message: `omadia could not shut down cleanly, so ${version} was not installed.`,
+          detail:
+            `These parts of omadia did not stop: ${outcome.survivors.join(', ')}.\n\n` +
+            'Your data was not changed. Quit omadia completely and try the update again. ' +
+            `If it keeps happening, attach this log:\n${logFile()}`,
+        });
+        return false;
+      }
+    }
+    snapshotDbDir(version);
+    return true;
+  } catch (err) {
+    log.error(`[updater] pre-install stop/snapshot failed for ${version}: ${String(err)}`);
+    await showUpdaterDialog({
+      type: 'error',
+      title: 'Update not applied',
+      message: `omadia could not prepare for the update, so ${version} was not installed.`,
+      detail: `${String(err)}\n\nYour data was not changed. Log:\n${logFile()}`,
+    });
+    return false;
+  }
+}
+
+/** Copy the embedded DB directory into a snapshot unique to this attempt. */
 function snapshotDbDir(version: string): void {
   const src = embeddedDbDir();
   if (!fs.existsSync(src)) return;
-  const dest = path.join(snapshotDir(), `pgdata-pre-${version}`);
-  fs.rmSync(dest, { recursive: true, force: true });
+  const root = snapshotDir();
+  // A name per attempt, not per version: the old scheme removed the existing
+  // directory and wrote the same name again, so a second attempt destroyed the
+  // backup the first had made (#934).
+  const dest = path.join(root, snapshotDirName(version, new Date()));
   fs.cpSync(src, dest, { recursive: true });
   log.info(`[updater] snapshotted DB → ${dest}`);
+  pruneOldSnapshots(root);
+}
+
+/** Keep the newest few snapshots; each is a full copy of the cluster. */
+function pruneOldSnapshots(root: string): void {
+  try {
+    const names = fs.readdirSync(root, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+    for (const stale of snapshotsToPrune(names, SNAPSHOTS_TO_KEEP)) {
+      fs.rmSync(path.join(root, stale), { recursive: true, force: true });
+      log.info(`[updater] pruned old snapshot ${stale}`);
+    }
+  } catch (err) {
+    // Pruning is housekeeping: a failure here must never abort an update that
+    // has already taken its snapshot successfully.
+    log.warn(`[updater] snapshot pruning failed: ${String(err)}`);
+  }
 }

--- a/desktop/src/updater.ts
+++ b/desktop/src/updater.ts
@@ -13,6 +13,7 @@ import {
   writeUpdateAttempts,
 } from './updateAttempts';
 import { SNAPSHOTS_TO_KEEP, snapshotDirName, snapshotsToPrune } from './snapshotRetention';
+import { prepareInstall } from './installPreflight';
 
 let installing = false;
 // This flag is only safe because electron-updater's own checkForUpdates()
@@ -194,11 +195,12 @@ export async function checkForUpdatesManually(): Promise<void> {
 }
 
 /**
- * Clear a spent install marker.
+ * Clear the marker once the version it recorded is the one we are running.
  *
- * Running at all proves the previous handoff is history: either it succeeded
- * (our version is the one recorded) or the recorded version is no longer what
- * the feed offers, in which case a fresh count is the honest starting point.
+ * Running that version at all proves the handoff finally worked, so the count
+ * has done its job. A marker for some *other* version is left in place on
+ * purpose: whether it still matters is decided later, per offer, by the version
+ * comparisons in `installKeepsFailing` and `nextAttempt`.
  */
 function reconcileUpdateHistory(): void {
   const file = updateAttemptsFile();
@@ -218,38 +220,42 @@ function reconcileUpdateHistory(): void {
  * torn, unrestorable copy.
  */
 async function quiesceForInstall(version: string): Promise<boolean> {
-  try {
-    const sup = getActiveSupervisor();
-    if (sup) {
-      const outcome = await sup.stop();
-      if (!outcome.clean) {
-        log.error(
-          `[updater] aborting install of ${version}: still running - ${outcome.survivors.join(', ')}`,
-        );
-        await showUpdaterDialog({
-          type: 'error',
-          title: 'Update not applied',
-          message: `omadia could not shut down cleanly, so ${version} was not installed.`,
-          detail:
-            `These parts of omadia did not stop: ${outcome.survivors.join(', ')}.\n\n` +
-            'Your data was not changed. Quit omadia completely and try the update again. ' +
-            `If it keeps happening, attach this log:\n${logFile()}`,
-        });
-        return false;
-      }
-    }
-    snapshotDbDir(version);
-    return true;
-  } catch (err) {
-    log.error(`[updater] pre-install stop/snapshot failed for ${version}: ${String(err)}`);
+  const sup = getActiveSupervisor();
+  const result = await prepareInstall(
+    { stop: sup ? () => sup.stop() : null, snapshot: snapshotDbDir },
+    version,
+  );
+  if (result.ok) return true;
+
+  // Both branches leave the stack down, so both have to tell the user how to
+  // get back to a working app. Saying only "your data was not changed" left
+  // them looking at a dead window.
+  const relaunch =
+    'Your data was not changed. Quit omadia completely and start it again, then retry the update.';
+
+  if (result.reason === 'unclean') {
+    log.error(
+      `[updater] aborting install of ${version}: still running - ${result.survivors.join(', ')}`,
+    );
     await showUpdaterDialog({
       type: 'error',
       title: 'Update not applied',
-      message: `omadia could not prepare for the update, so ${version} was not installed.`,
-      detail: `${String(err)}\n\nYour data was not changed. Log:\n${logFile()}`,
+      message: `omadia could not shut down cleanly, so ${version} was not installed.`,
+      detail:
+        `These parts of omadia did not stop: ${result.survivors.join(', ')}.\n\n` +
+        `${relaunch}\n\nIf it keeps happening, attach this log:\n${logFile()}`,
     });
     return false;
   }
+
+  log.error(`[updater] pre-install stop/snapshot failed for ${version}: ${result.error}`);
+  await showUpdaterDialog({
+    type: 'error',
+    title: 'Update not applied',
+    message: `omadia could not prepare for the update, so ${version} was not installed.`,
+    detail: `${result.error}\n\n${relaunch}\n\nLog:\n${logFile()}`,
+  });
+  return false;
 }
 
 /** Copy the embedded DB directory into a snapshot unique to this attempt. */
@@ -257,28 +263,42 @@ function snapshotDbDir(version: string): void {
   const src = embeddedDbDir();
   if (!fs.existsSync(src)) return;
   const root = snapshotDir();
+
+  // Prune BEFORE copying, and to one below the cap, so peak disk usage is
+  // SNAPSHOTS_TO_KEEP clusters rather than one more. Copying first meant a
+  // full disk threw ENOSPC before pruning had ever run, so nothing was
+  // reclaimed and every later update failed identically - a permanent block
+  // instead of the data-loss bug #934 removed. Both orders have to be safe.
+  pruneOldSnapshots(root, Math.max(0, SNAPSHOTS_TO_KEEP - 1));
+
   // A name per attempt, not per version: the old scheme removed the existing
   // directory and wrote the same name again, so a second attempt destroyed the
   // backup the first had made (#934).
   const dest = path.join(root, snapshotDirName(version, new Date()));
-  fs.cpSync(src, dest, { recursive: true });
+  try {
+    fs.cpSync(src, dest, { recursive: true });
+  } catch (err) {
+    // A half-copied directory is worse than no directory: it looks like a
+    // backup and would be counted as one by retention.
+    fs.rmSync(dest, { recursive: true, force: true });
+    throw err;
+  }
   log.info(`[updater] snapshotted DB → ${dest}`);
-  pruneOldSnapshots(root);
 }
 
 /** Keep the newest few snapshots; each is a full copy of the cluster. */
-function pruneOldSnapshots(root: string): void {
+function pruneOldSnapshots(root: string, keep: number): void {
   try {
     const names = fs.readdirSync(root, { withFileTypes: true })
       .filter((entry) => entry.isDirectory())
       .map((entry) => entry.name);
-    for (const stale of snapshotsToPrune(names, SNAPSHOTS_TO_KEEP)) {
+    for (const stale of snapshotsToPrune(names, keep)) {
       fs.rmSync(path.join(root, stale), { recursive: true, force: true });
       log.info(`[updater] pruned old snapshot ${stale}`);
     }
   } catch (err) {
-    // Pruning is housekeeping: a failure here must never abort an update that
-    // has already taken its snapshot successfully.
+    // Pruning is housekeeping: a failure here must never abort an update whose
+    // snapshot has already been taken.
     log.warn(`[updater] snapshot pruning failed: ${String(err)}`);
   }
 }

--- a/desktop/src/updater.ts
+++ b/desktop/src/updater.ts
@@ -1,7 +1,6 @@
 import { app, dialog, type MessageBoxOptions } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import fs from 'node:fs';
-import path from 'node:path';
 import { embeddedDbDir, snapshotDir, updateAttemptsFile } from './paths';
 import { getActiveSupervisor } from './supervisor';
 import { log, logFile } from './log';
@@ -12,7 +11,8 @@ import {
   readUpdateAttempts,
   writeUpdateAttempts,
 } from './updateAttempts';
-import { SNAPSHOTS_TO_KEEP, snapshotDirName, snapshotsToPrune } from './snapshotRetention';
+import { SNAPSHOTS_TO_KEEP } from './snapshotRetention';
+import { takeDbSnapshot, type SnapshotIo } from './dbSnapshot';
 import { prepareInstall } from './installPreflight';
 
 let installing = false;
@@ -260,45 +260,25 @@ async function quiesceForInstall(version: string): Promise<boolean> {
 
 /** Copy the embedded DB directory into a snapshot unique to this attempt. */
 function snapshotDbDir(version: string): void {
-  const src = embeddedDbDir();
-  if (!fs.existsSync(src)) return;
-  const root = snapshotDir();
-
-  // Prune BEFORE copying, and to one below the cap, so peak disk usage is
-  // SNAPSHOTS_TO_KEEP clusters rather than one more. Copying first meant a
-  // full disk threw ENOSPC before pruning had ever run, so nothing was
-  // reclaimed and every later update failed identically - a permanent block
-  // instead of the data-loss bug #934 removed. Both orders have to be safe.
-  pruneOldSnapshots(root, Math.max(0, SNAPSHOTS_TO_KEEP - 1));
-
-  // A name per attempt, not per version: the old scheme removed the existing
-  // directory and wrote the same name again, so a second attempt destroyed the
-  // backup the first had made (#934).
-  const dest = path.join(root, snapshotDirName(version, new Date()));
-  try {
-    fs.cpSync(src, dest, { recursive: true });
-  } catch (err) {
-    // A half-copied directory is worse than no directory: it looks like a
-    // backup and would be counted as one by retention.
-    fs.rmSync(dest, { recursive: true, force: true });
-    throw err;
-  }
-  log.info(`[updater] snapshotted DB → ${dest}`);
+  takeDbSnapshot(realSnapshotIo, {
+    sourceDir: embeddedDbDir(),
+    snapshotRoot: snapshotDir(),
+    version,
+    now: new Date(),
+    keep: SNAPSHOTS_TO_KEEP,
+  });
 }
 
-/** Keep the newest few snapshots; each is a full copy of the cluster. */
-function pruneOldSnapshots(root: string, keep: number): void {
-  try {
-    const names = fs.readdirSync(root, { withFileTypes: true })
+/** The real filesystem, behind the snapshot module's port. */
+const realSnapshotIo: SnapshotIo = {
+  exists: (dir) => fs.existsSync(dir),
+  listDirectories: (root) =>
+    fs
+      .readdirSync(root, { withFileTypes: true })
       .filter((entry) => entry.isDirectory())
-      .map((entry) => entry.name);
-    for (const stale of snapshotsToPrune(names, keep)) {
-      fs.rmSync(path.join(root, stale), { recursive: true, force: true });
-      log.info(`[updater] pruned old snapshot ${stale}`);
-    }
-  } catch (err) {
-    // Pruning is housekeeping: a failure here must never abort an update whose
-    // snapshot has already been taken.
-    log.warn(`[updater] snapshot pruning failed: ${String(err)}`);
-  }
-}
+      .map((entry) => entry.name),
+  copy: (source, destination) => fs.cpSync(source, destination, { recursive: true }),
+  remove: (dir) => fs.rmSync(dir, { recursive: true, force: true }),
+  info: (message) => log.info(`[updater] ${message}`),
+  error: (message) => log.warn(`[updater] ${message}`),
+};

--- a/desktop/test/childLifecycle.test.mts
+++ b/desktop/test/childLifecycle.test.mts
@@ -99,3 +99,49 @@ test('a late exit event cannot flip an already-reported deadline', async () => {
   await new Promise((resolve) => setImmediate(resolve));
   assert.equal(outcome, 'deadline');
 });
+
+test('a child that exits synchronously from kill() still resolves', async () => {
+  // A double can do this even though a real ChildProcess defers 'exit' through
+  // libuv. finish() used to run before the timer consts were initialised and
+  // rejected with a ReferenceError, which is precisely the "stopping can throw"
+  // case the rest of this module rules out.
+  class SyncExitChild extends EventEmitter implements StoppableChild {
+    exitCode: number | null = null;
+    signalCode: NodeJS.Signals | null = null;
+
+    kill(): boolean {
+      this.exitCode = 0;
+      this.emit('exit');
+      return true;
+    }
+  }
+
+  const outcome = await stopChild(new SyncExitChild(), 'kernel', silentLogger, 20);
+  assert.equal(outcome, 'exited');
+  assert.equal(isConfirmedStopped(outcome), true);
+});
+
+test('a kill() that throws resolves as kill-failed instead of rejecting', async () => {
+  class ThrowingKillChild extends EventEmitter implements StoppableChild {
+    exitCode: number | null = null;
+    signalCode: NodeJS.Signals | null = null;
+
+    kill(): boolean {
+      throw new Error('kill EPERM');
+    }
+  }
+
+  const logger = collectingLogger();
+  const started = Date.now();
+  const outcome = await stopChild(new ThrowingKillChild(), 'kernel', logger, 4_000);
+
+  assert.equal(outcome, 'kill-failed');
+  assert.equal(isConfirmedStopped(outcome), false);
+  // Resolves at once rather than leaking the escalation timers and letting the
+  // SIGKILL retry throw uncaught 4s later.
+  assert.ok(Date.now() - started < 1_000, 'must not wait out the escalation timers');
+  assert.equal(
+    logger.messages.some((m) => m.includes('SIGTERM failed')),
+    true,
+  );
+});

--- a/desktop/test/childLifecycle.test.mts
+++ b/desktop/test/childLifecycle.test.mts
@@ -1,0 +1,101 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import {
+  isConfirmedStopped,
+  stopChild,
+  type ChildStopOutcome,
+  type StoppableChild,
+} from '../src/childLifecycle.ts';
+
+/**
+ * A child process double. `exits` controls whether the fake ever emits 'exit',
+ * which is the whole point: the desktop update loop was caused by a child that
+ * never did, resolving identically to one that did (#927).
+ */
+class FakeChild extends EventEmitter implements StoppableChild {
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  readonly signals: NodeJS.Signals[] = [];
+
+  // An explicit field rather than a parameter property: node's strip-only
+  // TypeScript mode (which is what runs these tests) rejects those.
+  readonly exitOn: NodeJS.Signals | null;
+
+  constructor(exitOn: NodeJS.Signals | null) {
+    super();
+    this.exitOn = exitOn;
+  }
+
+  kill(signal: NodeJS.Signals = 'SIGTERM'): boolean {
+    this.signals.push(signal);
+    if (this.exitOn !== null && signal === this.exitOn) {
+      this.exitCode = 0;
+      setImmediate(() => this.emit('exit'));
+    }
+    return true;
+  }
+}
+
+const silentLogger = { warn: (): void => {} };
+
+function collectingLogger(): { warn: (m: string) => void; messages: string[] } {
+  const messages: string[] = [];
+  return { warn: (m: string) => messages.push(m), messages };
+}
+
+test('a null child is already gone', async () => {
+  assert.equal(await stopChild(null, 'kernel', silentLogger, 10), 'already-exited');
+});
+
+test('a child that has already exited is not signalled again', async () => {
+  const child = new FakeChild(null);
+  child.exitCode = 0;
+  assert.equal(await stopChild(child, 'kernel', silentLogger, 10), 'already-exited');
+  assert.deepEqual(child.signals, []);
+});
+
+test('a child that honours SIGTERM reports a real exit', async () => {
+  const child = new FakeChild('SIGTERM');
+  const outcome = await stopChild(child, 'kernel', silentLogger, 50);
+  assert.equal(outcome, 'exited');
+  assert.deepEqual(child.signals, ['SIGTERM']);
+  assert.equal(isConfirmedStopped(outcome), true);
+});
+
+test('a child that ignores SIGTERM is escalated to SIGKILL and still reports an exit', async () => {
+  const child = new FakeChild('SIGKILL');
+  const logger = collectingLogger();
+  const outcome = await stopChild(child, 'web-ui', logger, 20);
+  assert.equal(outcome, 'exited');
+  assert.deepEqual(child.signals, ['SIGTERM', 'SIGKILL']);
+  assert.equal(
+    logger.messages.some((m) => m.includes('did not exit on SIGTERM')),
+    true,
+  );
+});
+
+test('a child that never exits resolves as deadline, not as stopped', async () => {
+  const child = new FakeChild(null);
+  const logger = collectingLogger();
+  const outcome: ChildStopOutcome = await stopChild(child, 'kernel', logger, 20);
+  // The backstop must still fire so shutdown cannot hang forever...
+  assert.equal(outcome, 'deadline');
+  // ...but the caller must be able to tell that it did.
+  assert.equal(isConfirmedStopped(outcome), false);
+  assert.deepEqual(child.signals, ['SIGTERM', 'SIGKILL']);
+  assert.equal(
+    logger.messages.some((m) => m.includes('giving up waiting')),
+    true,
+  );
+});
+
+test('a late exit event cannot flip an already-reported deadline', async () => {
+  const child = new FakeChild(null);
+  const outcome = await stopChild(child, 'kernel', silentLogger, 20);
+  assert.equal(outcome, 'deadline');
+  child.exitCode = 0;
+  child.emit('exit');
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(outcome, 'deadline');
+});

--- a/desktop/test/dbSnapshot.test.mts
+++ b/desktop/test/dbSnapshot.test.mts
@@ -1,0 +1,123 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { takeDbSnapshot, type SnapshotIo, type SnapshotRequest } from '../src/dbSnapshot.ts';
+import { snapshotDirName } from '../src/snapshotRetention.ts';
+
+/**
+ * The ordering invariant behind the ENOSPC lockout (#934/#926): pruning must
+ * happen BEFORE the copy, and to one below the cap.
+ */
+
+interface Recorder {
+  readonly io: SnapshotIo;
+  readonly calls: string[];
+}
+
+function recorder(options: {
+  dirs?: string[];
+  exists?: boolean;
+  copyThrows?: Error;
+  removeThrows?: Error;
+} = {}): Recorder {
+  const calls: string[] = [];
+  const io: SnapshotIo = {
+    exists: () => {
+      calls.push('exists');
+      return options.exists ?? true;
+    },
+    listDirectories: () => {
+      calls.push('list');
+      return options.dirs ?? [];
+    },
+    copy: (source, destination) => {
+      calls.push(`copy(${destination.split('/').pop()})`);
+      if (options.copyThrows) throw options.copyThrows;
+    },
+    remove: (dir) => {
+      calls.push(`remove(${dir.split('/').pop()})`);
+      if (options.removeThrows) throw options.removeThrows;
+    },
+    info: () => {},
+    error: (m) => calls.push(`error(${m.slice(0, 24)})`),
+  };
+  return { io, calls };
+}
+
+const at = new Date('2026-08-28T10:11:17.000Z');
+
+function request(overrides: Partial<SnapshotRequest> = {}): SnapshotRequest {
+  return {
+    sourceDir: '/data/pgdata',
+    snapshotRoot: '/data/snapshots',
+    version: '0.140.1',
+    now: at,
+    keep: 3,
+    ...overrides,
+  };
+}
+
+test('nothing happens when there is no database to snapshot', () => {
+  const { io, calls } = recorder({ exists: false });
+  assert.equal(takeDbSnapshot(io, request()), null);
+  assert.deepEqual(calls, ['exists']);
+});
+
+test('pruning happens before the copy, not after', () => {
+  const existing = [
+    snapshotDirName('0.139.0', new Date('2026-08-25T10:00:00.000Z')),
+    snapshotDirName('0.140.0', new Date('2026-08-26T10:00:00.000Z')),
+    snapshotDirName('0.140.1', new Date('2026-08-27T10:00:00.000Z')),
+  ];
+  const { io, calls } = recorder({ dirs: existing });
+  takeDbSnapshot(io, request());
+
+  const removeIndex = calls.findIndex((c) => c.startsWith('remove('));
+  const copyIndex = calls.findIndex((c) => c.startsWith('copy('));
+  assert.notEqual(removeIndex, -1, 'the surplus snapshot should have been pruned');
+  assert.notEqual(copyIndex, -1);
+  // The regression: copying first meant ENOSPC threw before anything was ever
+  // reclaimed, so every later update attempt failed identically.
+  assert.ok(removeIndex < copyIndex, `pruning must precede the copy; got ${calls.join(' ')}`);
+});
+
+test('pruning targets one below the cap, so peak usage is the cap', () => {
+  const existing = [
+    snapshotDirName('0.139.0', new Date('2026-08-25T10:00:00.000Z')),
+    snapshotDirName('0.140.0', new Date('2026-08-26T10:00:00.000Z')),
+    snapshotDirName('0.140.1', new Date('2026-08-27T10:00:00.000Z')),
+  ];
+  const { io, calls } = recorder({ dirs: existing });
+  takeDbSnapshot(io, request({ keep: 3 }));
+  // Three existing, keep 3 => one must go before the copy, leaving 2 + the new
+  // one = 3 on disk and never 4 at once.
+  assert.equal(calls.filter((c) => c.startsWith('remove(')).length, 1);
+});
+
+test('a copy failure removes the partial directory and rethrows the real cause', () => {
+  const enospc = new Error('ENOSPC: no space left on device');
+  const { io, calls } = recorder({ copyThrows: enospc });
+  assert.throws(() => takeDbSnapshot(io, request()), /ENOSPC/);
+  const expected = snapshotDirName('0.140.1', at);
+  assert.ok(
+    calls.includes(`remove(${expected})`),
+    `the partial snapshot must be removed; got ${calls.join(' ')}`,
+  );
+});
+
+test('a failing cleanup does not mask the original copy failure', () => {
+  const enospc = new Error('ENOSPC: no space left on device');
+  const { io } = recorder({ copyThrows: enospc, removeThrows: new Error('EACCES') });
+  // The dialog has to name the cause the user can act on, not a secondary
+  // error from our own tidying up.
+  assert.throws(() => takeDbSnapshot(io, request()), /ENOSPC/);
+});
+
+test('a pruning failure does not stop the snapshot', () => {
+  const { io, calls } = recorder({
+    dirs: ['pgdata-pre-0.1.0', 'pgdata-pre-0.2.0', 'pgdata-pre-0.3.0', 'pgdata-pre-0.4.0'],
+    removeThrows: new Error('EACCES'),
+  });
+  const created = takeDbSnapshot(io, request());
+  assert.ok(created !== null, 'the snapshot itself must still be taken');
+  assert.ok(calls.some((c) => c.startsWith('copy(')));
+});

--- a/desktop/test/helpers/electron-fake.mjs
+++ b/desktop/test/helpers/electron-fake.mjs
@@ -1,0 +1,58 @@
+/**
+ * Minimal stand-in for the `electron` module, so the desktop lifecycle code can
+ * be unit-tested in plain node (#932).
+ *
+ * Only the surface the modules under test touch at import time or on the paths
+ * they exercise. Anything else throws loudly rather than returning undefined,
+ * so a test that wanders into unstubbed Electron territory fails with a clear
+ * message instead of a confusing TypeError.
+ */
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'omadia-electron-fake-'));
+
+export const app = {
+  isPackaged: false,
+  getVersion: () => '0.0.0-test',
+  getPath: (name) => {
+    const dir = path.join(root, name);
+    fs.mkdirSync(dir, { recursive: true });
+    return dir;
+  },
+  getName: () => 'omadia',
+  on: () => app,
+  quit: () => {},
+};
+
+export const safeStorage = {
+  isEncryptionAvailable: () => false,
+  encryptString: () => Buffer.from(''),
+  decryptString: () => '',
+};
+
+function unavailable(name) {
+  return new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        throw new Error(
+          `electron.${name}.${String(prop)} is not stubbed; this test should not reach Electron`,
+        );
+      },
+    },
+  );
+}
+
+export const dialog = unavailable('dialog');
+export const ipcMain = unavailable('ipcMain');
+export const Menu = unavailable('Menu');
+export const Tray = unavailable('Tray');
+export const shell = unavailable('shell');
+export const nativeImage = unavailable('nativeImage');
+export const BrowserWindow = unavailable('BrowserWindow');
+export const contextBridge = unavailable('contextBridge');
+export const ipcRenderer = unavailable('ipcRenderer');
+
+export default { app, safeStorage, dialog, ipcMain, Menu, Tray, shell, nativeImage, BrowserWindow };

--- a/desktop/test/helpers/stub-electron.mjs
+++ b/desktop/test/helpers/stub-electron.mjs
@@ -1,0 +1,43 @@
+/**
+ * Test-only module resolution shims, loaded via `node --import`.
+ *
+ * Two of them, both needed to unit-test the desktop lifecycle code in plain
+ * node (#932):
+ *
+ * 1. `import 'electron'` is redirected to a fake, because the modules under
+ *    test reach Electron at import time (`paths.ts` reads `app.isPackaged`).
+ * 2. Extensionless relative imports (`./paths`) are resolved to their `.ts`
+ *    file. The production sources are compiled by tsc in Node16/CommonJS mode
+ *    where extensionless specifiers are correct, but node's ESM resolver
+ *    requires the extension. Shimming it here keeps the shipped code idiomatic
+ *    for its own build instead of contorting it for the tests.
+ */
+import { registerHooks } from 'node:module';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const fakeElectron = pathToFileURL(path.join(import.meta.dirname, 'electron-fake.mjs')).href;
+
+const CANDIDATE_SUFFIXES = ['.ts', '.mts', '/index.ts'];
+
+function resolveExtensionless(specifier, parentURL) {
+  if (!specifier.startsWith('./') && !specifier.startsWith('../')) return null;
+  if (path.extname(specifier) !== '') return null;
+  if (parentURL === undefined) return null;
+  const parentDir = path.dirname(fileURLToPath(parentURL));
+  for (const suffix of CANDIDATE_SUFFIXES) {
+    const candidate = path.resolve(parentDir, `${specifier}${suffix}`);
+    if (fs.existsSync(candidate)) return pathToFileURL(candidate).href;
+  }
+  return null;
+}
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier === 'electron') return { url: fakeElectron, shortCircuit: true };
+    const resolved = resolveExtensionless(specifier, context.parentURL);
+    if (resolved !== null) return { url: resolved, shortCircuit: true };
+    return nextResolve(specifier, context);
+  },
+});

--- a/desktop/test/installPreflight.test.mts
+++ b/desktop/test/installPreflight.test.mts
@@ -1,0 +1,75 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { prepareInstall } from '../src/installPreflight.ts';
+import type { StopOutcome } from '../src/supervisor.ts';
+
+const clean: StopOutcome = { clean: true, survivors: [] };
+const dirty: StopOutcome = { clean: false, survivors: ['kernel', 'embedded-postgres'] };
+
+test('a clean stop plus a good snapshot clears the install', async () => {
+  const snapshotted: string[] = [];
+  const result = await prepareInstall(
+    { stop: async () => clean, snapshot: (v) => snapshotted.push(v) },
+    '0.140.1',
+  );
+  assert.deepEqual(result, { ok: true });
+  assert.deepEqual(snapshotted, ['0.140.1']);
+});
+
+test('an unclean stop blocks the install and never snapshots', async () => {
+  let snapshots = 0;
+  const result = await prepareInstall(
+    {
+      stop: async () => dirty,
+      snapshot: () => {
+        snapshots += 1;
+      },
+    },
+    '0.140.1',
+  );
+  // The whole point of #926: a stack that did not come down must not be handed
+  // to the installer, and copying the database of a live cluster is unsafe too.
+  assert.deepEqual(result, {
+    ok: false,
+    reason: 'unclean',
+    survivors: ['kernel', 'embedded-postgres'],
+  });
+  assert.equal(snapshots, 0);
+});
+
+test('a throwing snapshot blocks the install and reports the reason', async () => {
+  const result = await prepareInstall(
+    {
+      stop: async () => clean,
+      snapshot: () => {
+        throw new Error('ENOSPC: no space left on device');
+      },
+    },
+    '0.140.1',
+  );
+  assert.equal(result.ok, false);
+  assert.equal(result.reason === 'failed' && result.error.includes('ENOSPC'), true);
+});
+
+test('a throwing stop blocks the install', async () => {
+  const result = await prepareInstall(
+    {
+      stop: async () => {
+        throw new Error('supervisor exploded');
+      },
+      snapshot: () => {},
+    },
+    '0.140.1',
+  );
+  assert.deepEqual(result, { ok: false, reason: 'failed', error: 'supervisor exploded' });
+});
+
+test('with no supervisor to stop the snapshot still runs', async () => {
+  const snapshotted: string[] = [];
+  const result = await prepareInstall(
+    { stop: null, snapshot: (v) => snapshotted.push(v) },
+    '0.141.0',
+  );
+  assert.deepEqual(result, { ok: true });
+  assert.deepEqual(snapshotted, ['0.141.0']);
+});

--- a/desktop/test/snapshotRetention.test.mts
+++ b/desktop/test/snapshotRetention.test.mts
@@ -1,0 +1,70 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  SNAPSHOT_PREFIX,
+  parseSnapshotName,
+  snapshotDirName,
+  snapshotsToPrune,
+} from '../src/snapshotRetention.ts';
+
+const at = (iso: string): Date => new Date(iso);
+
+test('a snapshot name carries the version and a filesystem-safe stamp', () => {
+  const name = snapshotDirName('0.140.1', at('2026-08-28T13:05:32.119Z'));
+  assert.equal(name, `${SNAPSHOT_PREFIX}0.140.1-20260828T130532119Z`);
+  assert.equal(/[:.]/.test(name.slice(SNAPSHOT_PREFIX.length + '0.140.1'.length)), false);
+});
+
+test('two attempts on the same version get different directories', () => {
+  const first = snapshotDirName('0.140.1', at('2026-08-28T10:11:17.000Z'));
+  const second = snapshotDirName('0.140.1', at('2026-08-28T10:15:13.000Z'));
+  // The regression this guards: the old scheme wrote both to the same name and
+  // deleted the first one on the way in (#934).
+  assert.notEqual(first, second);
+});
+
+test('names round-trip through the parser, dotted versions included', () => {
+  const parsed = parseSnapshotName(snapshotDirName('1.2.3-rc.4', at('2026-01-02T03:04:05.006Z')));
+  assert.deepEqual(parsed, { version: '1.2.3-rc.4', stamp: '20260102T030405006Z' });
+});
+
+test('a legacy stampless snapshot is still recognised as a snapshot', () => {
+  assert.deepEqual(parseSnapshotName('pgdata-pre-0.139.1'), {
+    version: '0.139.1',
+    stamp: null,
+  });
+});
+
+test('unrelated directory names are not snapshots', () => {
+  assert.equal(parseSnapshotName('pgdata'), null);
+  assert.equal(parseSnapshotName('snapshots'), null);
+  assert.equal(parseSnapshotName(SNAPSHOT_PREFIX), null);
+});
+
+test('nothing is pruned while under the cap', () => {
+  const names = [
+    snapshotDirName('0.140.1', at('2026-08-28T10:00:00.000Z')),
+    snapshotDirName('0.140.2', at('2026-08-28T11:00:00.000Z')),
+  ];
+  assert.deepEqual(snapshotsToPrune(names, 3), []);
+});
+
+test('the oldest snapshots are pruned down to the cap', () => {
+  const oldest = snapshotDirName('0.139.0', at('2026-08-25T10:00:00.000Z'));
+  const older = snapshotDirName('0.140.0', at('2026-08-26T10:00:00.000Z'));
+  const newer = snapshotDirName('0.140.1', at('2026-08-27T10:00:00.000Z'));
+  const newest = snapshotDirName('0.140.2', at('2026-08-28T10:00:00.000Z'));
+  assert.deepEqual(snapshotsToPrune([newer, oldest, newest, older], 2), [older, oldest]);
+});
+
+test('stampless legacy snapshots are pruned before stamped ones', () => {
+  const legacy = 'pgdata-pre-0.130.0';
+  const stamped = snapshotDirName('0.140.2', at('2026-08-28T10:00:00.000Z'));
+  assert.deepEqual(snapshotsToPrune([legacy, stamped], 1), [legacy]);
+});
+
+test('non-snapshot directories are never proposed for deletion', () => {
+  const stamped = snapshotDirName('0.140.2', at('2026-08-28T10:00:00.000Z'));
+  const pruned = snapshotsToPrune(['pgdata', 'logs', 'platform-data', stamped], 0);
+  assert.deepEqual(pruned, [stamped]);
+});

--- a/desktop/test/snapshotRetention.test.mts
+++ b/desktop/test/snapshotRetention.test.mts
@@ -49,12 +49,14 @@ test('nothing is pruned while under the cap', () => {
   assert.deepEqual(snapshotsToPrune(names, 3), []);
 });
 
-test('the oldest snapshots are pruned down to the cap', () => {
+test('the oldest snapshots are pruned down to the cap, oldest first', () => {
   const oldest = snapshotDirName('0.139.0', at('2026-08-25T10:00:00.000Z'));
   const older = snapshotDirName('0.140.0', at('2026-08-26T10:00:00.000Z'));
   const newer = snapshotDirName('0.140.1', at('2026-08-27T10:00:00.000Z'));
   const newest = snapshotDirName('0.140.2', at('2026-08-28T10:00:00.000Z'));
-  assert.deepEqual(snapshotsToPrune([newer, oldest, newest, older], 2), [older, oldest]);
+  // Oldest first, so a caller that dies part-way through has deleted the least
+  // valuable backups and still holds the most recent one.
+  assert.deepEqual(snapshotsToPrune([newer, oldest, newest, older], 2), [oldest, older]);
 });
 
 test('stampless legacy snapshots are pruned before stamped ones', () => {

--- a/desktop/test/supervisorLifecycle.test.mts
+++ b/desktop/test/supervisorLifecycle.test.mts
@@ -1,0 +1,240 @@
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { Supervisor } from '../src/supervisor.ts';
+import { __setEmbeddedDbHooks, type EmbeddedDb } from '../src/embeddedDb.ts';
+
+/**
+ * The two #927 lifecycle transitions that the child-shutdown tests cannot
+ * reach: the shared in-flight stop() promise, and the generation race between
+ * stop() and a boot that is still starting the database.
+ *
+ * Only the database is faked. That is enough on purpose - both defects happen
+ * during the `starting-db` phase, before any child process is spawned - so the
+ * real teardown, generation and single-flight code all run unmodified.
+ */
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function deferred<T = void>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/** Lets the microtask queue drain so an in-flight boot reaches its next await. */
+const settle = async (): Promise<void> => {
+  for (let i = 0; i < 5; i += 1) await Promise.resolve();
+};
+
+function fakeHandle(stop: () => Promise<boolean>): EmbeddedDb {
+  return { databaseUrl: 'postgresql://test', port: 1, stop };
+}
+
+afterEach(() => {
+  __setEmbeddedDbHooks(null);
+});
+
+test('concurrent stop() calls share one shutdown and one outcome', async () => {
+  let stopCalls = 0;
+  const release = deferred();
+  __setEmbeddedDbHooks({
+    start: async () => fakeHandle(async () => true),
+    stop: async () => {
+      stopCalls += 1;
+      await release.promise;
+      return true;
+    },
+    isRunning: () => false,
+  });
+
+  const sup = new Supervisor();
+  const first = sup.stop();
+  const second = sup.stop();
+  await settle();
+  release.resolve();
+  const [a, b] = await Promise.all([first, second]);
+
+  // The defect: the second call used to return immediately over a shutdown that
+  // was still running, handing its caller a fulfilled promise.
+  assert.equal(stopCalls, 1);
+  assert.deepEqual(a, b);
+  assert.equal(a.clean, true);
+  assert.deepEqual(a.survivors, []);
+});
+
+test('a stop() during database startup leaves no orphaned database', async () => {
+  const portLookup = deferred();
+  let dbLive = false;
+  __setEmbeddedDbHooks({
+    // Models startEmbeddedDb(): it awaits a free port BEFORE registering the
+    // server, which is the window the old code walked straight through.
+    start: async () => {
+      await portLookup.promise;
+      dbLive = true;
+      return fakeHandle(async () => {
+        dbLive = false;
+        return true;
+      });
+    },
+    stop: async () => {
+      dbLive = false;
+      return true;
+    },
+    isRunning: () => dbLive,
+  });
+
+  const sup = new Supervisor();
+  const boot = sup.start();
+  await settle();
+  const stopping = sup.stop();
+  await settle();
+  portLookup.resolve();
+
+  await assert.rejects(boot, /boot superseded/);
+  const outcome = await stopping;
+
+  // The regression: stop() saw no registered database, reported clean, and the
+  // boot then published a live Postgres running out of the app bundle the
+  // installer was about to replace.
+  assert.equal(dbLive, false, 'the database started by the superseded boot must be stopped');
+  assert.equal(outcome.clean, true);
+});
+
+test('a boot superseded after the database started leaves no stale handle behind', async () => {
+  const portLookup = deferred();
+  let startCalls = 0;
+  __setEmbeddedDbHooks({
+    start: async () => {
+      startCalls += 1;
+      if (startCalls === 1) await portLookup.promise;
+      return fakeHandle(async () => true);
+    },
+    stop: async () => true,
+    isRunning: () => false,
+  });
+
+  const sup = new Supervisor();
+  const boot = sup.start();
+  await settle();
+  const stopping = sup.stop();
+  await settle();
+  portLookup.resolve();
+  await assert.rejects(boot, /boot superseded/);
+  await stopping;
+
+  // The next boot must start a database again. Publishing the handle of a server
+  // stop() had already killed made the next start() skip startEmbeddedDb() and
+  // wait out a 90s health timeout against a dead port.
+  await assert.rejects(sup.start());
+  assert.equal(startCalls, 2, 'the next boot must start its own database');
+});
+
+test('a survivor from a superseded boot is folded into the stop outcome', async () => {
+  const portLookup = deferred();
+  __setEmbeddedDbHooks({
+    start: async () => {
+      await portLookup.promise;
+      // This boot's own database refuses to die.
+      return fakeHandle(async () => false);
+    },
+    stop: async () => true,
+    isRunning: () => false,
+  });
+
+  const sup = new Supervisor();
+  const boot = sup.start();
+  await settle();
+  const stopping = sup.stop();
+  await settle();
+  portLookup.resolve();
+  await assert.rejects(boot, /boot superseded/);
+  const outcome = await stopping;
+
+  // stop() never used to await a superseded boot's cleanup, so a survivor it
+  // produced was invisible and the outcome was reported clean.
+  assert.equal(outcome.clean, false);
+  assert.deepEqual(outcome.survivors, ['embedded-postgres']);
+});
+
+test('stop() does not resolve before a superseded boot has finished cleaning up', async () => {
+  const portLookup = deferred();
+  const dbStopRelease = deferred();
+  const events: string[] = [];
+  __setEmbeddedDbHooks({
+    start: async () => {
+      await portLookup.promise;
+      return fakeHandle(async () => {
+        await dbStopRelease.promise;
+        events.push('boot-cleanup-done');
+        return true;
+      });
+    },
+    stop: async () => true,
+    isRunning: () => false,
+  });
+
+  const sup = new Supervisor();
+  const boot = sup.start();
+  await settle();
+  const stopping = sup.stop().then(() => events.push('stop-resolved'));
+  await settle();
+  portLookup.resolve();
+  await settle();
+
+  assert.deepEqual(events, [], 'neither should have completed while cleanup is blocked');
+  dbStopRelease.resolve();
+  await assert.rejects(boot, /boot superseded/);
+  await stopping;
+
+  assert.deepEqual(events, ['boot-cleanup-done', 'stop-resolved']);
+});
+
+test('a second database is reaped when it is registered after the first stop attempt', async () => {
+  let registered = false;
+  __setEmbeddedDbHooks({
+    start: async () => fakeHandle(async () => true),
+    stop: async () => {
+      // First call finds nothing, then something appears: the exact shape of a
+      // boot that registers its server after the stop already ran.
+      if (!registered) {
+        registered = true;
+        return true;
+      }
+      registered = false;
+      return true;
+    },
+    isRunning: () => registered,
+  });
+
+  const sup = new Supervisor();
+  const outcome = await sup.stop();
+
+  // isEmbeddedDbRunning() exists for exactly this re-check; leaving it unused
+  // was the tell that the window had been missed.
+  assert.equal(registered, false, 'the late-registered database must be stopped too');
+  assert.equal(outcome.clean, true);
+});
+
+test('restart() is refused while a full stop is in flight', async () => {
+  const release = deferred();
+  __setEmbeddedDbHooks({
+    start: async () => fakeHandle(async () => true),
+    stop: async () => {
+      await release.promise;
+      return true;
+    },
+    isRunning: () => false,
+  });
+
+  const sup = new Supervisor();
+  const stopping = sup.stop();
+  await settle();
+  await assert.rejects(sup.restart(), /Cannot restart while stopping/);
+  release.resolve();
+  await stopping;
+});

--- a/desktop/test/supervisorRestartRace.test.mts
+++ b/desktop/test/supervisorRestartRace.test.mts
@@ -36,6 +36,16 @@ const settle = async (): Promise<void> => {
   for (let i = 0; i < 30; i += 1) await Promise.resolve();
 };
 
+/** A child whose kill() throws, the way EPERM does against a vanished process. */
+class ThrowingChild extends EventEmitter {
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+
+  kill(): boolean {
+    throw new Error('kill EPERM');
+  }
+}
+
 /** A child process that exits only when its gate is opened. */
 class GatedChild extends EventEmitter {
   exitCode: number | null = null;
@@ -70,6 +80,12 @@ function pretendRunning(sup: Supervisor, kernel: GatedChild): void {
   internals.kernel = kernel;
   internals.state = 'running';
   internals.uiUrl = 'http://127.0.0.1:65535';
+}
+
+/** Read the private lifecycle fields, for failure messages only. */
+function peek(sup: Supervisor): { state: string; stopping: boolean } {
+  const internals = sup as unknown as { state: string; stopping: boolean };
+  return { state: internals.state, stopping: internals.stopping };
 }
 
 function fakeHandle(stop: () => Promise<boolean>): EmbeddedDb {
@@ -238,4 +254,115 @@ test('a boot is refused once a shutdown has begun', async () => {
   assert.equal(starts, 0, 'no database may be started while shutting down');
   dbStopRelease.resolve();
   await stopping;
+});
+
+test('a boot landing while a superseded restart has reset the state is refused', async () => {
+  // The three-actor interleaving. A restart loses to a stop at its supersession
+  // re-check and sets state = 'idle' on the way out, while `stopping` is still
+  // true and runStop() is only part-way through its own teardown. Any start()
+  // arriving in that window sees an idle-looking supervisor, and only the
+  // `stopping` guard turns it away - which is why that guard, and not the
+  // re-check beside it, is the load-bearing one.
+  //
+  // main.ts reaches start() here for real: bootExistingInstall() via
+  // app.on('activate') and via the "Re-run setup" button.
+  const kernelExit = deferred();
+  const dbStopGate = deferred();
+  const latePortLookup = deferred();
+  let dbStarts = 0;
+  let dbRegistered = false;
+  const events: string[] = [];
+
+  __setEmbeddedDbHooks({
+    start: async () => {
+      dbStarts += 1;
+      events.push(`db-start#${dbStarts}`);
+      // Models startEmbeddedDb(): the port lookup precedes registration.
+      await latePortLookup.promise;
+      dbRegistered = true;
+      events.push('db-registered');
+      return fakeHandle(async () => {
+        dbRegistered = false;
+        return true;
+      });
+    },
+    stop: async () => {
+      // stopEmbeddedDb() decides on entry: `if (!current) return true`. The
+      // snapshot here is what makes that faithful.
+      const wasRegistered = dbRegistered;
+      events.push(`module-stop(registered=${wasRegistered})`);
+      await dbStopGate.promise;
+      if (!wasRegistered) return true;
+      dbRegistered = false;
+      return true;
+    },
+    isRunning: () => dbRegistered,
+  });
+
+  const sup = new Supervisor();
+  pretendRunning(sup, new GatedChild(kernelExit.promise));
+
+  const restarting = sup.restart();
+  await settle();
+  const stopping = sup.stop();
+  await settle();
+
+  // Let the restart's teardown finish so it loses at the re-check.
+  kernelExit.resolve();
+  // Any rejection will do. Which message the restart loses with is not the
+  // point, and asserting it here would make this test fail for a wording change
+  // rather than for a safety leak.
+  await restarting.catch(() => {});
+  await settle();
+
+  const window = peek(sup);
+  events.push(`window(state=${window.state},stopping=${window.stopping})`);
+
+  // The third actor.
+  await assert.rejects(sup.start(), /Cannot start while stopping/);
+
+  dbStopGate.resolve();
+  const outcome = await stopping;
+  events.push(`stop-resolved(clean=${outcome.clean},survivors=[${outcome.survivors.join(',')}])`);
+  latePortLookup.resolve();
+  await settle();
+
+  assert.equal(
+    dbStarts,
+    0,
+    `no database may be started during a shutdown; sequence: ${events.join(' / ')}`,
+  );
+  assert.equal(
+    dbRegistered,
+    false,
+    `a database came up after stop() reported clean; sequence: ${events.join(' / ')}`,
+  );
+});
+
+test('a kill() that throws is reported as a survivor, not raised out of stop()', async () => {
+  let dbRegistered = true;
+  let dbStops = 0;
+  __setEmbeddedDbHooks({
+    start: async () => fakeHandle(async () => true),
+    stop: async () => {
+      dbStops += 1;
+      dbRegistered = false;
+      return true;
+    },
+    isRunning: () => dbRegistered,
+  });
+
+  const sup = new Supervisor();
+  pretendRunning(sup, new ThrowingChild() as unknown as GatedChild);
+
+  // Before: this rejected with the raw EPERM. The database teardown was then
+  // skipped (orphaning Postgres), `state` stayed wedged at 'stopping' so nothing
+  // could start again, and the quit handler's second stop() failed identically.
+  const outcome = await sup.stop();
+
+  assert.equal(outcome.clean, false);
+  assert.deepEqual(outcome.survivors, ['kernel']);
+  assert.equal(dbStops >= 1, true, 'the database teardown must still have run');
+  assert.equal(dbRegistered, false, 'Postgres must not be orphaned by a failed child kill');
+  assert.equal(peek(sup).state, 'idle', 'the supervisor must not stay wedged in stopping');
 });

--- a/desktop/test/supervisorRestartRace.test.mts
+++ b/desktop/test/supervisorRestartRace.test.mts
@@ -366,3 +366,51 @@ test('a kill() that throws is reported as a survivor, not raised out of stop()',
   assert.equal(dbRegistered, false, 'Postgres must not be orphaned by a failed child kill');
   assert.equal(peek(sup).state, 'idle', 'the supervisor must not stay wedged in stopping');
 });
+
+test('the settle loop is bounded, and giving up is not reported as clean', async () => {
+  __setEmbeddedDbHooks({
+    start: async () => fakeHandle(async () => true),
+    stop: async () => true,
+    isRunning: () => false,
+  });
+
+  const sup = new Supervisor();
+  const internals = sup as unknown as {
+    opsInFlight: Set<{ kind: string; settled: Promise<void>; survivors: string[] }>;
+  };
+
+  // An operation that registers a successor as it settles, so the loop always
+  // finds more work. start()/restart() cannot do this while `stopping`, which
+  // is exactly why the loop "cannot spin" - but that is a guard-equivalence
+  // argument, and an unbounded loop inside stop() would hang the quit forever.
+  // The chain is finite so that WITHOUT the cap this test fails on the
+  // assertions below rather than by hanging the suite.
+  const CHAIN_LENGTH = 40;
+  let spawned = 0;
+  const addSelfReplicating = (): void => {
+    spawned += 1;
+    let finish!: () => void;
+    const settled = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    internals.opsInFlight.add({ kind: 'boot', settled, survivors: [] });
+    setTimeout(() => {
+      // Successor first, so it is already in the set when this one settles.
+      if (spawned < CHAIN_LENGTH) addSelfReplicating();
+      finish();
+    }, 0);
+  };
+  addSelfReplicating();
+
+  const outcome = await sup.stop();
+
+  assert.equal(outcome.clean, false, 'giving up must never be reported as clean');
+  assert.ok(
+    outcome.survivors.some((survivor) => survivor.startsWith('pending-')),
+    `expected a pending-operation survivor, got [${outcome.survivors.join(', ')}]`,
+  );
+  assert.ok(
+    spawned < CHAIN_LENGTH,
+    `the loop must stop before the chain does; it ran ${spawned} rounds`,
+  );
+});

--- a/desktop/test/supervisorRestartRace.test.mts
+++ b/desktop/test/supervisorRestartRace.test.mts
@@ -1,0 +1,241 @@
+import { test, afterEach, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { Supervisor } from '../src/supervisor.ts';
+import { __setEmbeddedDbHooks, type EmbeddedDb } from '../src/embeddedDb.ts';
+
+/**
+ * The restart()/stop() race (#927, third review round).
+ *
+ * These two are separate from supervisorLifecycle.test.mts because they need a
+ * child process to gate restart()'s teardown on, which means reaching into the
+ * supervisor's private fields. Kept together and clearly labelled rather than
+ * mixed in with the tests that need no such thing.
+ */
+
+before(() => {
+  // A boot in these tests is expected to fail after the database phase. Without
+  // this it would poll a kernel that was never really started for 90 seconds.
+  process.env['OMADIA_BOOT_TIMEOUT_MS'] = '30';
+});
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function deferred<T = void>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const settle = async (): Promise<void> => {
+  for (let i = 0; i < 30; i += 1) await Promise.resolve();
+};
+
+/** A child process that exits only when its gate is opened. */
+class GatedChild extends EventEmitter {
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+
+  constructor(gate: Promise<void>) {
+    super();
+    void gate.then(() => {
+      this.exitCode = 0;
+      this.emit('exit');
+    });
+  }
+
+  kill(): boolean {
+    return true;
+  }
+}
+
+/**
+ * Put the supervisor into a "running with a kernel" state.
+ *
+ * Reaching into private fields on purpose: the alternative is a seam for child
+ * spawning, and inventing one to describe a state the class already models
+ * would be the more invasive change.
+ */
+function pretendRunning(sup: Supervisor, kernel: GatedChild): void {
+  const internals = sup as unknown as {
+    kernel: unknown;
+    state: string;
+    uiUrl: string | null;
+  };
+  internals.kernel = kernel;
+  internals.state = 'running';
+  internals.uiUrl = 'http://127.0.0.1:65535';
+}
+
+function fakeHandle(stop: () => Promise<boolean>): EmbeddedDb {
+  return { databaseUrl: 'postgresql://test', port: 1, stop };
+}
+
+afterEach(() => {
+  __setEmbeddedDbHooks(null);
+});
+
+test('stop() during a restart must not report clean and then let the restart boot', async () => {
+  const kernelExit = deferred();
+  const portLookup = deferred();
+  let dbRegistered = false;
+  const events: string[] = [];
+
+  __setEmbeddedDbHooks({
+    start: async () => {
+      events.push('db-start');
+      // Models startEmbeddedDb(): the port lookup happens BEFORE the server is
+      // registered in module state.
+      await portLookup.promise;
+      dbRegistered = true;
+      events.push('db-registered');
+      return fakeHandle(async () => {
+        dbRegistered = false;
+        return true;
+      });
+    },
+    stop: async () => {
+      events.push(`module-stop(registered=${dbRegistered})`);
+      // Faithful to stopEmbeddedDb(): nothing registered means nothing to do.
+      if (!dbRegistered) return true;
+      dbRegistered = false;
+      return true;
+    },
+    isRunning: () => dbRegistered,
+  });
+
+  const sup = new Supervisor();
+  const kernel = new GatedChild(kernelExit.promise);
+  pretendRunning(sup, kernel);
+
+  const restarting = sup.restart();
+  await settle();
+  const stopping = sup.stop();
+  await settle();
+
+  // Let restart()'s teardown finish. Its stopChild listener was registered
+  // first, so it observes the exit before the one stop() registered.
+  kernelExit.resolve();
+  const outcome = await stopping;
+  events.push(`stop-resolved(clean=${outcome.clean})`);
+
+  // Whatever the restart was doing, it may not bring a database up after stop()
+  // has already told the updater the stack is down.
+  portLookup.resolve();
+  await restarting.catch(() => {});
+  await settle();
+
+  assert.equal(
+    dbRegistered,
+    false,
+    `a database came up after stop() resolved; sequence: ${events.join(' / ')}`,
+  );
+});
+
+test('restart() waits for an in-flight boot, so its own database is not killed from behind', async () => {
+  const firstPort = deferred();
+  const secondPort = deferred();
+  let starts = 0;
+  let dbRegistered = false;
+
+  __setEmbeddedDbHooks({
+    start: async () => {
+      starts += 1;
+      await (starts === 1 ? firstPort.promise : secondPort.promise);
+      dbRegistered = true;
+      // The real toHandle().stop() delegates to stopEmbeddedDb(), i.e. it kills
+      // whatever is in module state - not necessarily the server this handle
+      // was created for. That is exactly the hazard restart() has to avoid.
+      return fakeHandle(async () => {
+        dbRegistered = false;
+        return true;
+      });
+    },
+    stop: async () => {
+      if (!dbRegistered) return true;
+      dbRegistered = false;
+      return true;
+    },
+    isRunning: () => dbRegistered,
+  });
+
+  const sup = new Supervisor();
+  const firstBoot = sup.start();
+  await settle();
+
+  const restarting = sup.restart();
+  await settle();
+
+  // Let a second boot (if the restart started one) get its database up first,
+  // then let the first, superseded boot finish and run its cleanup.
+  secondPort.resolve();
+  await settle();
+  firstPort.resolve();
+  await settle();
+
+  await firstBoot.catch(() => {});
+  await restarting.catch(() => {});
+  await settle();
+
+  assert.equal(starts, 2, 'the restart should have started its own database');
+  assert.equal(
+    dbRegistered,
+    true,
+    "the superseded boot's cleanup killed the database the restart had just started",
+  );
+});
+
+test('restart() is refused once a shutdown has begun', async () => {
+  const dbStopRelease = deferred();
+  __setEmbeddedDbHooks({
+    start: async () => fakeHandle(async () => true),
+    stop: async () => {
+      await dbStopRelease.promise;
+      return true;
+    },
+    isRunning: () => false,
+  });
+
+  const sup = new Supervisor();
+  const stopping = sup.stop();
+  await settle();
+
+  // `state` is not enough to express this on its own: a restart puts it back to
+  // 'idle' before booting, so the shared flag is what the guard has to read.
+  await assert.rejects(sup.restart(), /Cannot restart while stopping/);
+  dbStopRelease.resolve();
+  await stopping;
+
+  // And it works again afterwards.
+  await assert.rejects(sup.restart(), /^(?!Error: Cannot restart while stopping)/);
+});
+
+test('a boot is refused once a shutdown has begun', async () => {
+  const dbStopRelease = deferred();
+  let starts = 0;
+  __setEmbeddedDbHooks({
+    start: async () => {
+      starts += 1;
+      return fakeHandle(async () => true);
+    },
+    stop: async () => {
+      await dbStopRelease.promise;
+      return true;
+    },
+    isRunning: () => false,
+  });
+
+  const sup = new Supervisor();
+  const stopping = sup.stop();
+  await settle();
+
+  await assert.rejects(sup.start(), /Cannot start while stopping/);
+  assert.equal(starts, 0, 'no database may be started while shutting down');
+  dbStopRelease.resolve();
+  await stopping;
+});

--- a/desktop/test/syncedPaths.test.mts
+++ b/desktop/test/syncedPaths.test.mts
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { detectSyncedLocation } from '../src/syncedPaths.ts';
+
+const HOME = '/Users/silviolange';
+
+test('the reported iCloud Drive data dir is detected', () => {
+  // Verbatim shape from the round 3 report (#934).
+  assert.equal(
+    detectSyncedLocation(
+      `${HOME}/Library/Mobile Documents/com~apple~CloudDocs/omadia`,
+      HOME,
+    ),
+    'iCloud Drive',
+  );
+});
+
+test('a macOS CloudStorage mount is detected and names its real provider', () => {
+  assert.equal(
+    detectSyncedLocation(`${HOME}/Library/CloudStorage/OneDrive-Personal/omadia`, HOME),
+    'OneDrive',
+  );
+  assert.equal(
+    detectSyncedLocation(`${HOME}/Library/CloudStorage/GoogleDrive-me@example.com/x`, HOME),
+    'Google Drive',
+  );
+});
+
+test('an unknown CloudStorage mount still warns, generically', () => {
+  assert.equal(
+    detectSyncedLocation(`${HOME}/Library/CloudStorage/Nextcloud-home/omadia`, HOME),
+    'a cloud storage service',
+  );
+  assert.equal(
+    detectSyncedLocation(`${HOME}/Library/CloudStorage`, HOME),
+    'a cloud storage service',
+  );
+});
+
+test('Dropbox, OneDrive and Google Drive under home are detected', () => {
+  assert.equal(detectSyncedLocation(`${HOME}/Dropbox/omadia`, HOME), 'Dropbox');
+  assert.equal(detectSyncedLocation(`${HOME}/OneDrive/omadia`, HOME), 'OneDrive');
+  assert.equal(detectSyncedLocation(`${HOME}/Google Drive/omadia`, HOME), 'Google Drive');
+});
+
+test('a provider folder outside the home directory is still detected', () => {
+  assert.equal(detectSyncedLocation('/Volumes/Work/OneDrive/omadia', HOME), 'OneDrive');
+});
+
+test('an ordinary local directory is not flagged', () => {
+  assert.equal(detectSyncedLocation(`${HOME}/omadia-data`, HOME), null);
+  assert.equal(detectSyncedLocation('/opt/omadia', HOME), null);
+  assert.equal(detectSyncedLocation(`${HOME}/Library/Application Support/omadia`, HOME), null);
+});
+
+test('a name that merely contains a provider word is not flagged', () => {
+  // Segment matching, not substring matching: "MyDropboxBackups" is a normal
+  // local folder and warning about it would train the user to ignore warnings.
+  assert.equal(detectSyncedLocation(`${HOME}/MyDropboxBackups/omadia`, HOME), null);
+  assert.equal(detectSyncedLocation(`${HOME}/OneDriveArchive`, HOME), null);
+});
+
+test('the home directory itself is not flagged', () => {
+  assert.equal(detectSyncedLocation(HOME, HOME), null);
+});

--- a/desktop/test/tsconfig.json
+++ b/desktop/test/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "noEmit": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "allowImportingTsExtensions": true
+  },
+  "include": [
+    "./**/*.mts",
+    "../src/**/*.ts"
+  ]
+}

--- a/desktop/test/updateAttempts.test.mts
+++ b/desktop/test/updateAttempts.test.mts
@@ -1,0 +1,92 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  MAX_INSTALL_ATTEMPTS,
+  clearUpdateAttempts,
+  installKeepsFailing,
+  nextAttempt,
+  readUpdateAttempts,
+  writeUpdateAttempts,
+} from '../src/updateAttempts.ts';
+
+function tmpMarker(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'omadia-update-attempts-'));
+  return path.join(dir, 'update-attempts.json');
+}
+
+test('a missing marker reads as no history', () => {
+  assert.equal(readUpdateAttempts(tmpMarker()), null);
+});
+
+test('a marker round-trips', () => {
+  const file = tmpMarker();
+  writeUpdateAttempts(file, { version: '0.140.1', attempts: 1, lastAttemptAt: 'now' });
+  assert.deepEqual(readUpdateAttempts(file), {
+    version: '0.140.1',
+    attempts: 1,
+    lastAttemptAt: 'now',
+  });
+});
+
+test('a corrupt marker reads as no history instead of throwing', () => {
+  const file = tmpMarker();
+  fs.writeFileSync(file, 'not json at all', 'utf8');
+  assert.equal(readUpdateAttempts(file), null);
+});
+
+test('a structurally wrong marker reads as no history', () => {
+  const file = tmpMarker();
+  fs.writeFileSync(file, JSON.stringify({ version: 42, attempts: 'lots' }), 'utf8');
+  assert.equal(readUpdateAttempts(file), null);
+});
+
+test('clearing a marker is idempotent and safe when absent', () => {
+  const file = tmpMarker();
+  clearUpdateAttempts(file);
+  writeUpdateAttempts(file, { version: '0.140.1', attempts: 1, lastAttemptAt: '' });
+  clearUpdateAttempts(file);
+  clearUpdateAttempts(file);
+  assert.equal(readUpdateAttempts(file), null);
+});
+
+test('attempts accumulate for the same version', () => {
+  const first = nextAttempt(null, '0.140.1', new Date('2026-08-28T10:07:31Z'));
+  assert.equal(first.attempts, 1);
+  const second = nextAttempt(first, '0.140.1', new Date('2026-08-28T10:14:11Z'));
+  assert.equal(second.attempts, 2);
+  assert.equal(second.lastAttemptAt, '2026-08-28T10:14:11.000Z');
+});
+
+test('a different version starts counting again', () => {
+  const previous = { version: '0.140.1', attempts: 2, lastAttemptAt: '' };
+  assert.equal(nextAttempt(previous, '0.141.0', new Date()).attempts, 1);
+});
+
+test('no history means nothing is failing', () => {
+  assert.equal(installKeepsFailing(null, '0.140.1', '0.139.1'), false);
+});
+
+test('a single failed attempt is not yet a verdict', () => {
+  const record = { version: '0.140.1', attempts: 1, lastAttemptAt: '' };
+  assert.equal(installKeepsFailing(record, '0.140.1', '0.139.1'), false);
+});
+
+test('repeated attempts on a version we are still not running is the loop', () => {
+  // The reported case: 0.140.1 handed to the installer while the machine stayed
+  // on 0.139.1 (#926).
+  const record = { version: '0.140.1', attempts: MAX_INSTALL_ATTEMPTS, lastAttemptAt: '' };
+  assert.equal(installKeepsFailing(record, '0.140.1', '0.139.1'), true);
+});
+
+test('a successful install is never reported as failing', () => {
+  const record = { version: '0.140.1', attempts: 5, lastAttemptAt: '' };
+  assert.equal(installKeepsFailing(record, '0.140.1', '0.140.1'), false);
+});
+
+test('history for an older version does not block a newer one', () => {
+  const record = { version: '0.140.1', attempts: 5, lastAttemptAt: '' };
+  assert.equal(installKeepsFailing(record, '0.141.0', '0.139.1'), false);
+});


### PR DESCRIPTION
Cluster ALPHA of the round 3 beta-test findings (Silvio Lange, TE Printline). All four issues live in the same two files, so they are one change: #927 is the root cause and #926 is its most visible symptom, and #934's snapshot retention is the same function as #926's snapshot naming.

Closes #927
Closes #926
Closes #934
Closes #932

## Review round 3 — the restart()/stop() race

Reproduced independently before fixing. My own test's trace matches the reviewer's probe exactly:

```
db-start / module-stop(registered=false) / stop-resolved(clean=true) / db-registered
```

**The finding was right, and it was a regression I introduced.** `main` had `if (this.state === 'stopping') return;` in `stop()`, which incidentally serialized `restart()` against `stop()`. Round 1 of this branch removed that line without replacing it. `state` cannot carry the invariant on its own, because a restart deliberately sets it back to `'idle'` before booting, so a `stop()` consulting `state` alone sees an idle supervisor mid-restart.

| Fix | What it does |
|---|---|
| `stopping` flag | Set synchronously the instant a shutdown is requested; read by `start()`, `restart()` and `stop()`. |
| restart is published | `restart()` registers in the in-flight set like a boot, so `stop()` waits for the whole restart *including the boot it ends with*. |
| supersession re-check | `restart()` re-checks after its own teardown whether a shutdown took ownership. |
| looping settle | The settle no longer snapshots the set once — an operation can register another one while we wait, which is exactly how a restart's boot escaped. |

Also from this round: `reapOwnChildren` moved its database teardown into a `finally` and uses `allSettled`, so a throwing `kill()` can no longer skip teardown and record no survivor; survivors are no longer de-duplicated (two processes can share a label, and collapsing them understated what was left running); the partial-snapshot cleanup is nested so it cannot mask an ENOSPC; and the snapshot step moved behind an IO port so its *ordering* is assertable.

### Attribution — corrected in round 4

**My round-3 labelling was inverted, and the review was right.** I claimed `start()`'s `stopping` guard and `restart()`'s supersession re-check were mutually redundant defense-in-depth. They are not:

- **`start()`'s `stopping` guard is the one necessary guard.**
- `restart()`'s re-check is the redundant half.
- The looping settle and the `stopping` term in `restart()`'s own guard remain genuine defense-in-depth.

Why nine reverts could not find it: `restartOnce` falls from the re-check straight through `state = 'idle'` into `this.start()` with **no `await` between them**, so both read the same `this.stopping` in the same synchronous run. They are *provably* equivalent there — no two-actor experiment can separate them. Separating them needs a third actor, and the exploitable window is real: a losing restart sets `state = 'idle'` while `stopping` is still true and `runStop()` is only part-way through its teardown, so an arriving `start()` sees an idle-looking supervisor. `main.ts` reaches it through `bootExistingInstall()`, via `app.on('activate')` and the "Re-run setup" button.

That gap is now closed and pinned by `a boot landing while a superseded restart has reset the state is refused`.

Measured against reverts (round 4):

| Revert | Result |
|---|---|
| `start()`'s `stopping` guard | **fails the three-actor test** |
| `restart()`'s re-check | fails nothing — confirmed redundant |
| `stopChild`'s signal guard | **fails the throwing-kill test** |
| prune moved after the copy | **fails 2 ordering tests** |
| `restart()`'s settle | **fails 1 test** |
| `runStop()`'s settle | **fails 2 tests** |
| looping settle → single snapshot | fails nothing — defense-in-depth |
| `stopping` term in `restart()`'s guard | fails nothing — defense-in-depth |

The rejection in the three-actor test is asserted as *any* rejection, deliberately. Matching the message made an earlier version appear to pin both halves when it was really only matching wording.

**Discriminating-test count, calibrated.** Against the round-3 supervisor, 3 of the 6 race tests fail and 3 pass. The 3 that pass lock the observable contract without pinning a line. Round 3's claim of four discriminating tests was too generous; the review's correction was accurate.

**62 new `test()` cases**, suite total 95.

## Known follow-ups (not fixed here)

The iteration cap that was on this list is now **done** — see Round 5 below.

- `settleInFlightOps` absorbs a boot op's survivors into the restart's `self.survivors` while a concurrent `stop()` has already snapshotted that op into its own `pending`, so one leaked Postgres can report `survivors=["embedded-postgres","embedded-postgres"]`, and that string reaches the user. `clean` is correct; this is op-level double collection, orthogonal to the label-dedupe question.
- `readdirSync` throws ENOENT when `snapshotDir()` does not exist yet, so the very first update logs `snapshot pruning failed: ENOENT`. Caught, and `cpSync` creates the parent, so the snapshot still succeeds. Cosmetic.
- `dbSnapshot.ts` builds the destination with string concatenation rather than `path.join`. Works on Windows, but the test's `split('/')` would mask a later switch.

## Review round 2 — what changed

Review found three blockers, one high and three mediums. All addressed; two of them were real defects this branch introduced, not pre-existing ones.

| Finding | Resolution |
|---|---|
| **B1** DB assigned with no generation check | Handle is published only while the boot is current; a superseded boot stops the database it started. Both reported paths were reproduced and are closed. |
| **B2** prune-after-copy → ENOSPC blocks updates permanently | Prune now runs *before* the copy and to one below the cap, so peak usage is `SNAPSHOTS_TO_KEEP` not `+1`. A partial copy is removed instead of left looking like a backup. |
| **HIGH** `stop()` did not await a superseded boot's teardown | In-flight boots are tracked; generation is invalidated *first*, then they are awaited, then survivors are merged. `restart()` waits too. |
| **MED** transitions 1 and 3 untested | `Supervisor` is now reachable from `node:test`; 7 new lifecycle cases. See the honesty note below. |
| **MED** tests not typechecked | `test/tsconfig.json` + `typecheck:test`, wired into CI. |
| **MED** snapshot-failure dialog abandons the user | Both abort dialogs now carry the relaunch instruction. |
| `isRecord` did not validate `lastAttemptAt` | Validated instead of coerced. |
| `reconcileUpdateHistory` comment described absent code | Comment corrected to what it does. |
| `snapshotsToPrune` doc said "oldest first", returned newest-first | Now actually deletes oldest-first, which is the safer order mid-crash. |
| `package.json` unicode escape | Reverted. |
| Stale #941 conflict claim | Dropped; #941 arrived via the `origin/main` merge. |

On B1 specifically: the reviewer's point that it "lies in the opposite direction" was correct and is the reason it ranked above the original bug. `startEmbeddedDb()` awaits a free port before registering anything in module state, so a `stop()` inside that window found no database, reported `{clean: true}`, and the boot then published a live Postgres running out of the bundle the installer was about to replace. That is worse than the `installing anyway` warning it replaced, because it is false reassurance rather than a logged one.

The `isEmbeddedDbRunning()` export being unused was indeed the tell. It is now the end-of-shutdown re-check.

## #927 — `stop()` reports what it actually achieved

| Defect | Fix |
|---|---|
| A second `stop()` early-returned without awaiting the first | Concurrent calls share one in-flight promise and one outcome |
| `killAndWait()`'s absolute backstop resolved unconditionally | Backstop stays, but `deadline` is distinct from `exited`, logged, and returned |
| `stop()` stopped the DB only via `if (this.db)`; a superseded `start()` skipped cleanup | DB reaped from module state, gated on generation, re-checked at the end; a superseded boot tears down its own children *and* its own database |

`stop()` returns `StopOutcome { clean, survivors }`. Child-stop logic lives in `childLifecycle.ts`, the install decision in `installPreflight.ts` — both Electron-free and therefore testable.

## #926 — no install over a live stack, no re-offering a version that will not apply

- An unclean `stop()` aborts the install and names what survived.
- The attempted version is persisted; a version handed to the installer twice while the app still runs the old one is explained once, with the log path, and the marker clears when the new version boots.

## #934 — every snapshot survives, and a synced data dir gets a warning

- Per-attempt timestamped names; pruned to 3 rather than overwritten.
- A cloud-synced folder choice warns and names the provider (`Library/CloudStorage` mounts resolve to the real provider, not iCloud); "use anyway" stays available.
- Snapshots are kept outside the synced folder.

## #932 — tests, and a CI job that runs them

`desktop/src` was the only source tree with no tests and no CI job, and the only one that produced a blocker in three rounds.


Two test-only resolution shims make `Supervisor` reachable without contorting shipped code: `electron` redirected to a fake, and extensionless relative imports resolved to `.ts` (correct for the Node16/CommonJS build, invalid for node's ESM resolver). The database lifecycle gets a `__setEmbeddedDbHooks` seam, the same pattern `cliInstallService.__setCliInstallRunner` already uses.

**Honesty note on coverage.** I verified attribution by running the new tests against partial reverts rather than assuming it:

- "survivor folded into the outcome" and "stop() does not resolve before cleanup finishes" fail if *either* the generation gate or the in-flight-boot await is removed. These are the genuine regression tests for B1 and HIGH.
- "a second database is reaped when registered after the first stop attempt" fails if the `isEmbeddedDbRunning()` re-check is removed.
- "no orphaned database" and "no stale handle" **pass under every partial revert tried.** With boot-tracking in place those properties hold by construction, so they are forward guards, not proof of this fix. Flagging that rather than letting the count imply more than it does.

New `desktop` CI job: `npm ci`, `typecheck`, `typecheck:test`, `npm test`, with `ELECTRON_SKIP_BINARY_DOWNLOAD=1`.

## Verification

```
$ npx tsc -p tsconfig.json --noEmit     # PASS
$ npm run typecheck:test                # PASS
$ npm run build                         # PASS
$ npm test
# tests 95
# pass 95
# fail 0
```

`main.ts` was deliberately not touched and still compiles against the new `stop()` signature.

## Notes for the reviewer

- **Changelog deferred on purpose.** `docs/CHANGELOG.md` is the one file every parallel branch in this batch edits at the top, so it is the guaranteed conflict point. One consolidated entry lands in a separate PR for the whole round 3 batch.
- `desktop/src/embeddedDb.ts` is in the diff although it was not in the original file list. A truthful `stop()` is impossible without it: `stopProc()` had the same unconditional-resolve gap, and an orphaned Postgres needs reaping from module state. No other cluster in this batch touches it.
- **Deliberately not done:** on an aborted install the stack is left stopped and the dialog tells the user to quit and relaunch. Auto-restarting after a shutdown that just reported survivors risks double-spawning, so the safe instruction won over the convenient one.
- **Now tested:** the prune-before-copy ordering, via `dbSnapshot.ts`'s IO port. This was the open item from round 2.
- **`cfa249d1`'s subject is 87 chars** and violates AGENTS.md's <70 rule (the reviewer flagged only the newest commit; this one predates it). Not rewritten: the branch has a merge commit in range, so a reword rebase there is disproportionate risk for a message. Say the word and I will do it as an isolated operation.
- **This branch was force-pushed once** (`--force-with-lease`), to reword the over-length subject on an already-pushed commit as requested. AGENTS.md bans force-push on *shared* branches; this one has only ever been pushed by me.
- The `desktop` job is green but is not a required status check (AGENTS.md lists only `middleware`, `web-ui`, `schema`, `audit`). Left to the coordinator, who is escalating the branch-protection change.



## Round 4 additions

- `teardownChildren()` moved to `allSettled` — it runs on **every** real shutdown, and a throwing `kill()` made `stop()` reject instead of reporting a survivor: database teardown skipped, Postgres orphaned, `state` wedged at `'stopping'` so nothing could start again that session.
- Fixed at the source too: `stopChild()` routes every signal through a guard and reports `'kill-failed'` instead of throwing. This mattered more than it looked — the escalation timer's SIGKILL retry threw from inside a `setTimeout`, i.e. an **uncaught exception** four seconds later, with both timers leaked.
- `stopChild()`'s timer bindings hoisted above the `kill()`, fixing the temporal-dead-zone `ReferenceError` on a synchronous exit.
- `runStop()` puts the database teardown in a `finally` and no longer leaves `state` at `'stopping'` on the way out.
- Merged `origin/main` including #943; resolved a conflict in `updater.ts` keeping both sides, with `recordCheckReachedFeed()` placed **before** the install-attempt gate since the feed was reached either way.


## Round 5 — the settle-loop iteration cap

Bounded at 8 rounds (a legitimate chain needs 2: a restart entering its boot phase). On exhaustion it logs the kinds of work still in flight and contributes a survivor, so the outcome **reports** the situation rather than claiming `clean` — a cap that quietly gave up and said clean would be the same lie in a new place, and the updater would hand a live stack to the installer on the strength of it.

Both halves are pinned by `the settle loop is bounded, and giving up is not reported as clean`:

| Revert | Result |
|---|---|
| bound removed (loop unbounded again) | test file fails |
| bound kept, exhaustion reports `clean` | fails on `giving up must never be reported as clean` |

The test injects an operation that registers a successor as it settles — `start()`/`restart()` cannot do that while `stopping`, which is the whole reason the loop "cannot spin", hence the direct injection. The chain is deliberately finite so that without the cap the test fails on its assertions instead of hanging the suite.
