### PR TITLE
fix: tell a spawn failure apart from a failed npm install

### DIFF
--- a/middleware/src/platform/cliInstallService.ts
+++ b/middleware/src/platform/cliInstallService.ts
@@ -68,12 +68,17 @@ const MAX_PATH_DETAIL_CHARS = 512;
  *
  * A spawn failure means the OS never started npm, so there is no failed
  * install and no log to read. The two buckets are deliberately NOT merged:
- * `ENOEXEC`/`EACCES`/`EPERM`/`EISDIR` mean a file WAS found and refused
- * execution, so the operator has to look at that file; `ENOENT` means there
- * was nothing to execute, which is what `no_output` already says and what its
- * searched-PATH line already answers. Telling an operator with no npm that
- * "the npm file found is not executable" is the same class of untrue message
- * this issue was filed about.
+ * `ENOEXEC`/`EACCES`/`EPERM` mean a file WAS found and refused execution, so
+ * the operator has to look at that file; `ENOENT` means there was nothing to
+ * execute, which is what `no_output` already says and what its searched-PATH
+ * line already answers. Telling an operator with no npm that "the npm file
+ * found is not executable" is the same class of untrue message this issue was
+ * filed about.
+ *
+ * Measured on Node v22.23.2 spawning bare `npm` off a doctored PATH: a 0-byte
+ * `+x` file throws ENOEXEC synchronously; a file without `+x` AND a directory
+ * both report EACCES. `EISDIR` is mapped for completeness but is unreachable
+ * that way on POSIX, so it buys no coverage on its own.
  */
 const SPAWN_FAILURE_KINDS: Readonly<Record<string, 'unrunnable' | 'not_found'>> = {
   ENOEXEC: 'unrunnable',
@@ -217,12 +222,17 @@ export async function startCliInstall(
         if (spawnFailure?.kind === 'unrunnable') {
           job.code = 'cli_install.spawn_failed';
           job.error = spawnFailedDetail(spawnFailure, env);
+        } else if (spawnFailure?.kind === 'not_found') {
+          // Explicit rather than leaning on `logTail` being empty. It happens
+          // to be empty for npmRunner today, but a resolved ENOENT carrying
+          // any stderr would otherwise fall through to npm_failed — the exact
+          // conflation this classification exists to remove.
+          job.code = 'cli_install.no_output';
+          job.error = noOutputDetail(env, { proven: true });
         } else if (job.logTail) {
           job.code = 'cli_install.npm_failed';
           job.error = 'npm install failed — see the log tail.';
         } else {
-          // A spawn ENOENT also lands here, and correctly so: there is no npm
-          // to name, and the searched PATH is the whole diagnosis.
           job.code = 'cli_install.no_output';
           job.error = noOutputDetail(env);
         }
@@ -242,7 +252,7 @@ export async function startCliInstall(
       }
       if (spawnFailure?.kind === 'not_found') {
         job.code = 'cli_install.no_output';
-        job.error = noOutputDetail(env);
+        job.error = noOutputDetail(env, { proven: true });
         return;
       }
       // Any other thrown runner error still has a concrete failure message, so
@@ -313,11 +323,25 @@ function asSpawnFailure(failure: unknown): SpawnFailure | undefined {
   const kind = SPAWN_FAILURE_KINDS[code];
   if (!kind) return undefined;
   if (typeof syscall === 'string' && !syscall.startsWith('spawn')) return undefined;
-  return {
-    kind,
-    errno: code,
-    ...(typeof failedFile === 'string' && failedFile ? { file: failedFile } : {}),
-  };
+  const file = asNamedFile(failedFile);
+  return { kind, errno: code, ...(file ? { file } : {}) };
+}
+
+/**
+ * `err.path`, but only when it actually names a file.
+ *
+ * Node sets `path` to the spawnfile EXACTLY as passed, and `npmRunner` passes
+ * bare `npm` — so on every callback-delivered failure (EACCES, ENOENT) this is
+ * the string `'npm'`, which identifies nothing. Measured on Node v22.23.2.
+ * Accepting it would silently defeat {@link resolvedNpmFile}, which exists
+ * precisely to turn this failure into one the operator can act on, and would
+ * make the help copy's promise that the file is named untrue in the COMMON
+ * case while staying true in the rare one.
+ */
+function asNamedFile(value: unknown): string | undefined {
+  if (typeof value !== 'string' || !value) return undefined;
+  const namesAPath = path.isAbsolute(value) || value.includes(path.sep);
+  return namesAPath ? value : undefined;
 }
 
 /**
@@ -333,12 +357,10 @@ function resolvedNpmFile(env: NodeJS.ProcessEnv): string | undefined {
   for (const dir of searchedPath.split(path.delimiter)) {
     if (!dir) continue;
     for (const filename of NPM_FILENAMES) {
+      // existsSync reports false for anything it cannot stat, including an
+      // unreadable directory or a malformed name, and never throws.
       const candidate = path.join(dir, filename);
-      try {
-        if (existsSync(candidate)) return candidate;
-      } catch {
-        /* an unreadable directory is simply not a match */
-      }
+      if (existsSync(candidate)) return candidate;
     }
   }
   return undefined;
@@ -353,12 +375,18 @@ function spawnFailedDetail(failure: SpawnFailure, env: NodeJS.ProcessEnv): strin
   );
 }
 
-/** Operator-facing detail for "npm produced nothing at all" (#925). */
-function noOutputDetail(env: NodeJS.ProcessEnv): string {
-  return (
-    'npm install failed — no output at all; npm was most likely not found.' +
-    `\nSearched PATH: ${searchedPathDetail(env)}`
-  );
+/**
+ * Operator-facing detail for the "npm was not found" path (#925).
+ *
+ * `proven` is set when a spawn `ENOENT` established the absence, as opposed to
+ * it being inferred from npm having produced no output. The classifier knows
+ * the difference now, so the sentence stops hedging (#933).
+ */
+function noOutputDetail(env: NodeJS.ProcessEnv, opts?: { readonly proven: boolean }): string {
+  const cause = opts?.proven
+    ? 'npm was not found on the PATH, so it never ran.'
+    : 'no output at all; npm was most likely not found.';
+  return `npm install failed — ${cause}\nSearched PATH: ${searchedPathDetail(env)}`;
 }
 
 /** Test seams. */

--- a/middleware/src/platform/cliInstallService.ts
+++ b/middleware/src/platform/cliInstallService.ts
@@ -22,7 +22,7 @@
  * restarts. `resolveCliBin` in the detector prefers this prefix over PATH.
  */
 import { execFile } from 'node:child_process';
-import { mkdirSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
 
 import {
@@ -63,6 +63,30 @@ const LOG_TAIL_CHARS = 2000;
 /** Cap for the searched-PATH line in a no-output failure detail (#925). */
 const MAX_PATH_DETAIL_CHARS = 512;
 
+/**
+ * Spawn errno -> which help path tells the truth (#933, OM-68).
+ *
+ * A spawn failure means the OS never started npm, so there is no failed
+ * install and no log to read. The two buckets are deliberately NOT merged:
+ * `ENOEXEC`/`EACCES`/`EPERM`/`EISDIR` mean a file WAS found and refused
+ * execution, so the operator has to look at that file; `ENOENT` means there
+ * was nothing to execute, which is what `no_output` already says and what its
+ * searched-PATH line already answers. Telling an operator with no npm that
+ * "the npm file found is not executable" is the same class of untrue message
+ * this issue was filed about.
+ */
+const SPAWN_FAILURE_KINDS: Readonly<Record<string, 'unrunnable' | 'not_found'>> = {
+  ENOEXEC: 'unrunnable',
+  EACCES: 'unrunnable',
+  EPERM: 'unrunnable',
+  EISDIR: 'unrunnable',
+  ENOENT: 'not_found',
+};
+
+/** Candidate npm filenames, in the order the OS would try them. */
+const NPM_FILENAMES: readonly string[] =
+  process.platform === 'win32' ? ['npm.cmd', 'npm.exe', 'npm'] : ['npm'];
+
 interface InstallJob {
   readonly cliId: string;
   status: CliInstallState;
@@ -75,10 +99,22 @@ interface InstallJob {
 
 let current: InstallJob | undefined;
 
+interface InstallRunResult {
+  readonly ok: boolean;
+  readonly output: string;
+  /**
+   * The raw child-process failure, when there was one. Present so the caller
+   * can tell "npm ran and exited non-zero" from "the OS never started npm"
+   * (#933) — the errno and syscall live on this object and nowhere else, and
+   * discarding it is why every spawn failure used to read as a failed install.
+   */
+  readonly failure?: unknown;
+}
+
 type InstallRunner = (
   args: readonly string[],
   env: NodeJS.ProcessEnv,
-) => Promise<{ ok: boolean; output: string }>;
+) => Promise<InstallRunResult>;
 
 /** Default runner: `npm <args>` — no shell, bounded time and output. */
 const npmRunner: InstallRunner = (args, env) =>
@@ -88,7 +124,11 @@ const npmRunner: InstallRunner = (args, env) =>
       [...args],
       { timeout: INSTALL_TIMEOUT_MS, maxBuffer: MAX_OUTPUT_BYTES, env, windowsHide: true },
       (err, stdout, stderr) => {
-        resolve({ ok: !err, output: `${String(stdout ?? '')}\n${String(stderr ?? '')}` });
+        resolve({
+          ok: !err,
+          output: `${String(stdout ?? '')}\n${String(stderr ?? '')}`,
+          ...(err ? { failure: err } : {}),
+        });
       },
     );
   });
@@ -158,7 +198,7 @@ export async function startCliInstall(
   };
 
   void runner(['install', '-g', '--prefix', dir, `${pkg}@${version ?? 'latest'}`], env)
-    .then(({ ok, output }) => {
+    .then(({ ok, output, failure }) => {
       job.logTail = output.trim().slice(-LOG_TAIL_CHARS);
       job.finishedAt = Date.now();
       if (ok) {
@@ -173,22 +213,40 @@ export async function startCliInstall(
         }
       } else {
         job.status = 'failed';
-        if (job.logTail) {
+        const spawnFailure = asSpawnFailure(failure);
+        if (spawnFailure?.kind === 'unrunnable') {
+          job.code = 'cli_install.spawn_failed';
+          job.error = spawnFailedDetail(spawnFailure, env);
+        } else if (job.logTail) {
           job.code = 'cli_install.npm_failed';
           job.error = 'npm install failed — see the log tail.';
         } else {
+          // A spawn ENOENT also lands here, and correctly so: there is no npm
+          // to name, and the searched PATH is the whole diagnosis.
           job.code = 'cli_install.no_output';
-          job.error =
-            'npm install failed — no output at all; npm was most likely not found.' +
-            `\nSearched PATH: ${searchedPathDetail(env)}`;
+          job.error = noOutputDetail(env);
         }
       }
     })
     .catch((err: unknown) => {
       job.finishedAt = Date.now();
       job.status = 'failed';
-      // A thrown runner error still has a concrete failure message, so keep it
-      // on the generic npm-failed help path rather than the "no output" one.
+      const spawnFailure = asSpawnFailure(err);
+      if (spawnFailure?.kind === 'unrunnable') {
+        // npm never started, so "npm ran, but the installation failed" and
+        // "check the log details below" are both untrue — and there is no log
+        // tail to check either (#933).
+        job.code = 'cli_install.spawn_failed';
+        job.error = spawnFailedDetail(spawnFailure, env);
+        return;
+      }
+      if (spawnFailure?.kind === 'not_found') {
+        job.code = 'cli_install.no_output';
+        job.error = noOutputDetail(env);
+        return;
+      }
+      // Any other thrown runner error still has a concrete failure message, so
+      // keep it on the generic npm-failed help path.
       job.code = 'cli_install.npm_failed';
       job.error = err instanceof Error ? err.message : String(err);
     });
@@ -226,6 +284,81 @@ function searchedPathDetail(env: NodeJS.ProcessEnv): string {
   return searchedPath.length > MAX_PATH_DETAIL_CHARS
     ? `${searchedPath.slice(0, MAX_PATH_DETAIL_CHARS)}… (truncated)`
     : searchedPath;
+}
+
+/** A child process that never started, and which of the two ways it failed. */
+interface SpawnFailure {
+  readonly kind: 'unrunnable' | 'not_found';
+  readonly errno: string;
+  /** The file the OS refused, when it names one. */
+  readonly file?: string;
+}
+
+/**
+ * Recognise a failure to START the child, by shape rather than by message.
+ *
+ * Node puts `code` (the errno) and `syscall` (`spawn` / `spawn npm`) on these
+ * errors. The syscall check is what keeps an `EACCES` from some unrelated fs
+ * call inside a runner from being reported as "npm is not executable"; it is
+ * tolerated when absent, since starting the child is all the runner does.
+ */
+function asSpawnFailure(failure: unknown): SpawnFailure | undefined {
+  if (!(failure instanceof Error)) return undefined;
+  const { code, syscall, path: failedFile } = failure as Error & {
+    code?: unknown;
+    syscall?: unknown;
+    path?: unknown;
+  };
+  if (typeof code !== 'string') return undefined;
+  const kind = SPAWN_FAILURE_KINDS[code];
+  if (!kind) return undefined;
+  if (typeof syscall === 'string' && !syscall.startsWith('spawn')) return undefined;
+  return {
+    kind,
+    errno: code,
+    ...(typeof failedFile === 'string' && failedFile ? { file: failedFile } : {}),
+  };
+}
+
+/**
+ * The npm file the OS would have executed, resolved off the PATH the child was
+ * actually handed. `npmRunner` spawns bare `npm` and lets the OS resolve it, so
+ * on an `ENOEXEC` nothing in the error names the broken file — and naming it is
+ * the only thing that turns this failure into one the operator can act on
+ * (#933; the reporter's own npm-cli.js was a 0-byte file).
+ */
+function resolvedNpmFile(env: NodeJS.ProcessEnv): string | undefined {
+  const searchedPath = env['PATH'];
+  if (!searchedPath) return undefined;
+  for (const dir of searchedPath.split(path.delimiter)) {
+    if (!dir) continue;
+    for (const filename of NPM_FILENAMES) {
+      const candidate = path.join(dir, filename);
+      try {
+        if (existsSync(candidate)) return candidate;
+      } catch {
+        /* an unreadable directory is simply not a match */
+      }
+    }
+  }
+  return undefined;
+}
+
+/** Operator-facing detail for a spawn failure: the errno and the actual file. */
+function spawnFailedDetail(failure: SpawnFailure, env: NodeJS.ProcessEnv): string {
+  const file = failure.file ?? resolvedNpmFile(env);
+  return (
+    `npm could not be started (${failure.errno}) — npm never ran, so nothing was installed.` +
+    `\nnpm file: ${file ?? '(could not be resolved from PATH)'}`
+  );
+}
+
+/** Operator-facing detail for "npm produced nothing at all" (#925). */
+function noOutputDetail(env: NodeJS.ProcessEnv): string {
+  return (
+    'npm install failed — no output at all; npm was most likely not found.' +
+    `\nSearched PATH: ${searchedPathDetail(env)}`
+  );
 }
 
 /** Test seams. */

--- a/middleware/test/cliInstallService.test.ts
+++ b/middleware/test/cliInstallService.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import { strict as assert } from 'node:assert';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import type { Server } from 'node:http';
@@ -71,6 +71,18 @@ async function withPath(pathValue: string, body: () => Promise<void>): Promise<v
     if (previousPath === undefined) delete process.env['PATH'];
     else process.env['PATH'] = previousPath;
   }
+}
+
+/**
+ * A Node spawn failure, shaped the way `child_process` actually reports one:
+ * `code` carries the errno and `syscall` names the failed operation (#933).
+ */
+function spawnError(errno: string, extra: Readonly<Record<string, string>> = {}): Error {
+  return Object.assign(new Error(`spawn npm ${errno}`), {
+    code: errno,
+    syscall: 'spawn npm',
+    ...extra,
+  });
 }
 
 describe('cliInstallService', () => {
@@ -188,6 +200,103 @@ describe('cliInstallService', () => {
       assert.ok(longPath.length > 1000, 'fixture PATH must exceed the cap to be a real test');
       assert.ok(searchedLine.length < 600, `searched-PATH line unbounded: ${searchedLine.length}`);
     });
+  });
+
+  it('a spawn failure reports spawn_failed, not npm_failed, and carries no log tail', async () => {
+    // ENOEXEC means the OS never started npm: no install ran and there is no
+    // log to read, so the npm_failed copy ("npm ran" + "check the log details
+    // below") is untrue in both sentences (#933, OM-68).
+    __setCliInstallRunner(async () => {
+      throw spawnError('ENOEXEC', { path: '/opt/broken/bin/npm' });
+    });
+    await startCliInstall('codex', '1.2.3');
+    const done = await waitForTerminal('codex');
+    assert.equal(done.status, 'failed');
+    assert.equal(done.code, 'cli_install.spawn_failed');
+    assert.match(done.error ?? '', /ENOEXEC/);
+    assert.match(done.error ?? '', /npm never ran/);
+    // The offending file must be named — it is the only actionable detail.
+    assert.match(done.error ?? '', /\/opt\/broken\/bin\/npm/);
+    assert.equal(done.logTail, undefined);
+  });
+
+  it('names the npm file resolved off the handed PATH when the error carries none', async () => {
+    // `npmRunner` spawns bare `npm`, so on some platforms the error names no
+    // file. The searched PATH still identifies the one the OS would have run.
+    const binDir = mkdtempSync(path.join(tmpdir(), 'fake-npm-bin-'));
+    const fakeNpm = path.join(binDir, 'npm');
+    writeFileSync(fakeNpm, '');
+    chmodSync(fakeNpm, 0o755);
+    try {
+      await withPath(binDir, async () => {
+        __setCliInstallRunner(async () => {
+          throw spawnError('ENOEXEC');
+        });
+        await startCliInstall('codex', '1.2.3');
+        const done = await waitForTerminal('codex');
+        assert.equal(done.code, 'cli_install.spawn_failed');
+        assert.ok(
+          done.error?.includes(fakeNpm),
+          `spawn detail did not name the resolved npm file: ${done.error ?? '(no error)'}`,
+        );
+      });
+    } finally {
+      rmSync(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it('a spawn ENOENT stays on no_output — there is no file to call unrunnable', async () => {
+    // The split is the whole point: telling an operator who has no npm that
+    // "the npm file found is not executable" is the same class of untrue
+    // message this issue was filed about. ENOENT belongs to the PATH story.
+    await withPath('/sentinel/bin', async () => {
+      __setCliInstallRunner(async () => {
+        throw spawnError('ENOENT');
+      });
+      await startCliInstall('codex', '1.2.3');
+      const done = await waitForTerminal('codex');
+      assert.equal(done.code, 'cli_install.no_output');
+      assert.match(done.error ?? '', /Searched PATH: \/sentinel\/bin/);
+    });
+  });
+
+  it('classifies a spawn failure the runner resolves rather than throws', async () => {
+    // The default npmRunner resolves with ok:false and hands the raw error up;
+    // it must classify the same as the throwing shape above.
+    __setCliInstallRunner(async () => ({
+      ok: false,
+      output: '',
+      failure: spawnError('EACCES', { path: '/opt/noexec/npm' }),
+    }));
+    await startCliInstall('codex', '1.2.3');
+    const done = await waitForTerminal('codex');
+    assert.equal(done.code, 'cli_install.spawn_failed');
+    assert.match(done.error ?? '', /EACCES/);
+  });
+
+  it('leaves a non-spawn thrown error on npm_failed', async () => {
+    // Regression guard on the path this change must NOT alter.
+    __setCliInstallRunner(async () => {
+      throw new Error('runner exploded');
+    });
+    await startCliInstall('codex', '1.2.3');
+    const done = await waitForTerminal('codex');
+    assert.equal(done.code, 'cli_install.npm_failed');
+    assert.equal(done.error, 'runner exploded');
+  });
+
+  it('does not call an unrelated fs errno a spawn failure', async () => {
+    // Same errno, different syscall: an EACCES from an `open` inside a runner
+    // is not "npm is not executable", and must not borrow that copy.
+    __setCliInstallRunner(async () => {
+      throw Object.assign(new Error('EACCES: permission denied, open ...'), {
+        code: 'EACCES',
+        syscall: 'open',
+      });
+    });
+    await startCliInstall('codex', '1.2.3');
+    const done = await waitForTerminal('codex');
+    assert.equal(done.code, 'cli_install.npm_failed');
   });
 
   it('reserves the single-flight slot across the idempotency probe (no TOCTOU race)', async () => {

--- a/middleware/test/cliInstallService.test.ts
+++ b/middleware/test/cliInstallService.test.ts
@@ -74,8 +74,23 @@ async function withPath(pathValue: string, body: () => Promise<void>): Promise<v
 }
 
 /**
- * A Node spawn failure, shaped the way `child_process` actually reports one:
- * `code` carries the errno and `syscall` names the failed operation (#933).
+ * A Node spawn failure. THE SHAPES HERE ARE MEASURED, NOT ASSUMED.
+ *
+ * On Node v22.23.2, spawning bare `npm` off a doctored PATH:
+ *
+ * | scenario           | delivery      | code    | syscall      | path    |
+ * |--------------------|---------------|---------|--------------|---------|
+ * | 0-byte `+x` npm    | SYNC throw    | ENOEXEC | `spawn`      | absent  |
+ * | npm without `+x`   | callback      | EACCES  | `spawn npm`  | `'npm'` |
+ * | npm is a directory | callback      | EACCES  | `spawn npm`  | `'npm'` |
+ * | no npm at all      | callback      | ENOENT  | `spawn npm`  | `'npm'` |
+ *
+ * Two things follow, and an earlier version of this file got both wrong:
+ * ENOEXEC never carries `path`, and the failures that DO carry it carry the
+ * spawnfile as passed — the bare string `'npm'`, which names no file. So a
+ * fixture inventing an absolute `err.path` models a case this runner cannot
+ * produce, and it hid a real defect: the detail degraded to `npm file: npm`
+ * in exactly the common case while the rare one kept working.
  */
 function spawnError(errno: string, extra: Readonly<Record<string, string>> = {}): Error {
   return Object.assign(new Error(`spawn npm ${errno}`), {
@@ -83,6 +98,27 @@ function spawnError(errno: string, extra: Readonly<Record<string, string>> = {})
     syscall: 'spawn npm',
     ...extra,
   });
+}
+
+/** The measured ENOEXEC shape: thrown synchronously, `spawn`, no `path`. */
+function enoexecError(): Error {
+  return Object.assign(new Error('spawn ENOEXEC'), { code: 'ENOEXEC', syscall: 'spawn' });
+}
+
+/**
+ * Run `body` with a real (broken) `npm` file on the PATH, so the resolution
+ * that names the offending file has something truthful to find.
+ */
+async function withFakeNpm(body: (npmFile: string) => Promise<void>): Promise<void> {
+  const binDir = mkdtempSync(path.join(tmpdir(), 'fake-npm-bin-'));
+  const npmFile = path.join(binDir, 'npm');
+  writeFileSync(npmFile, '');
+  chmodSync(npmFile, 0o755);
+  try {
+    await withPath(binDir, () => body(npmFile));
+  } finally {
+    rmSync(binDir, { recursive: true, force: true });
+  }
 }
 
 describe('cliInstallService', () => {
@@ -202,47 +238,60 @@ describe('cliInstallService', () => {
     });
   });
 
-  it('a spawn failure reports spawn_failed, not npm_failed, and carries no log tail', async () => {
-    // ENOEXEC means the OS never started npm: no install ran and there is no
-    // log to read, so the npm_failed copy ("npm ran" + "check the log details
-    // below") is untrue in both sentences (#933, OM-68).
+  it('a spawn ENOEXEC reports spawn_failed and names the file, with no log tail', async () => {
+    // The reporter's own case: a 0-byte npm-cli.js with the execute bit set.
+    // Node throws this one synchronously and attaches no `path`, so the file
+    // can only come from resolving the handed PATH (#933, OM-68).
+    await withFakeNpm(async (npmFile) => {
+      __setCliInstallRunner(async () => {
+        throw enoexecError();
+      });
+      await startCliInstall('codex', '1.2.3');
+      const done = await waitForTerminal('codex');
+      assert.equal(done.status, 'failed');
+      assert.equal(done.code, 'cli_install.spawn_failed');
+      assert.match(done.error ?? '', /ENOEXEC/);
+      assert.match(done.error ?? '', /npm never ran/);
+      assert.ok(
+        done.error?.includes(npmFile),
+        `spawn detail did not name the resolved npm file: ${done.error ?? '(no error)'}`,
+      );
+      // npm never ran, so the copy must not point at log details.
+      assert.equal(done.logTail, undefined);
+    });
+  });
+
+  it('names a real file when err.path is the bare spawnfile, not the string "npm"', async () => {
+    // REGRESSION GUARD. Node sets `err.path` to the command as passed, so the
+    // EACCES/ENOENT shapes carry `'npm'`. Trusting it made the detail read
+    // `npm file: npm`, naming nothing — while the help copy promises the file
+    // IS named. The absolute-path fixtures this suite used to rely on could
+    // never have caught it, because this runner cannot produce them.
+    await withFakeNpm(async (npmFile) => {
+      __setCliInstallRunner(async () => {
+        throw spawnError('EACCES', { path: 'npm' });
+      });
+      await startCliInstall('codex', '1.2.3');
+      const done = await waitForTerminal('codex');
+      assert.equal(done.code, 'cli_install.spawn_failed');
+      assert.ok(
+        done.error?.includes(npmFile),
+        `bare err.path was trusted over PATH resolution: ${done.error ?? '(no error)'}`,
+      );
+      assert.doesNotMatch(done.error ?? '', /npm file: npm$/m);
+    });
+  });
+
+  it('uses err.path verbatim when it does name a real path', async () => {
+    // The other side of the same rule: a runner that spawns an absolute path
+    // gets a usable `err.path`, and then no PATH resolution is needed.
     __setCliInstallRunner(async () => {
-      throw spawnError('ENOEXEC', { path: '/opt/broken/bin/npm' });
+      throw spawnError('EACCES', { path: '/opt/broken/bin/npm' });
     });
     await startCliInstall('codex', '1.2.3');
     const done = await waitForTerminal('codex');
-    assert.equal(done.status, 'failed');
     assert.equal(done.code, 'cli_install.spawn_failed');
-    assert.match(done.error ?? '', /ENOEXEC/);
-    assert.match(done.error ?? '', /npm never ran/);
-    // The offending file must be named — it is the only actionable detail.
-    assert.match(done.error ?? '', /\/opt\/broken\/bin\/npm/);
-    assert.equal(done.logTail, undefined);
-  });
-
-  it('names the npm file resolved off the handed PATH when the error carries none', async () => {
-    // `npmRunner` spawns bare `npm`, so on some platforms the error names no
-    // file. The searched PATH still identifies the one the OS would have run.
-    const binDir = mkdtempSync(path.join(tmpdir(), 'fake-npm-bin-'));
-    const fakeNpm = path.join(binDir, 'npm');
-    writeFileSync(fakeNpm, '');
-    chmodSync(fakeNpm, 0o755);
-    try {
-      await withPath(binDir, async () => {
-        __setCliInstallRunner(async () => {
-          throw spawnError('ENOEXEC');
-        });
-        await startCliInstall('codex', '1.2.3');
-        const done = await waitForTerminal('codex');
-        assert.equal(done.code, 'cli_install.spawn_failed');
-        assert.ok(
-          done.error?.includes(fakeNpm),
-          `spawn detail did not name the resolved npm file: ${done.error ?? '(no error)'}`,
-        );
-      });
-    } finally {
-      rmSync(binDir, { recursive: true, force: true });
-    }
+    assert.match(done.error ?? '', /npm file: \/opt\/broken\/bin\/npm/);
   });
 
   it('a spawn ENOENT stays on no_output — there is no file to call unrunnable', async () => {
@@ -251,27 +300,50 @@ describe('cliInstallService', () => {
     // message this issue was filed about. ENOENT belongs to the PATH story.
     await withPath('/sentinel/bin', async () => {
       __setCliInstallRunner(async () => {
-        throw spawnError('ENOENT');
+        throw spawnError('ENOENT', { path: 'npm' });
       });
       await startCliInstall('codex', '1.2.3');
       const done = await waitForTerminal('codex');
       assert.equal(done.code, 'cli_install.no_output');
       assert.match(done.error ?? '', /Searched PATH: \/sentinel\/bin/);
+      // A proven absence must not hedge with "most likely".
+      assert.match(done.error ?? '', /was not found on the PATH/);
+      assert.doesNotMatch(done.error ?? '', /most likely/);
     });
   });
 
   it('classifies a spawn failure the runner resolves rather than throws', async () => {
     // The default npmRunner resolves with ok:false and hands the raw error up;
     // it must classify the same as the throwing shape above.
-    __setCliInstallRunner(async () => ({
-      ok: false,
-      output: '',
-      failure: spawnError('EACCES', { path: '/opt/noexec/npm' }),
-    }));
-    await startCliInstall('codex', '1.2.3');
-    const done = await waitForTerminal('codex');
-    assert.equal(done.code, 'cli_install.spawn_failed');
-    assert.match(done.error ?? '', /EACCES/);
+    await withFakeNpm(async (npmFile) => {
+      __setCliInstallRunner(async () => ({
+        ok: false,
+        output: '',
+        failure: spawnError('EACCES', { path: 'npm' }),
+      }));
+      await startCliInstall('codex', '1.2.3');
+      const done = await waitForTerminal('codex');
+      assert.equal(done.code, 'cli_install.spawn_failed');
+      assert.match(done.error ?? '', /EACCES/);
+      assert.ok(done.error?.includes(npmFile), done.error ?? '(no error)');
+    });
+  });
+
+  it('a resolved ENOENT carrying stderr still reports no_output, not npm_failed', async () => {
+    // Asymmetry guard. The resolve path used to reach no_output only because
+    // npmRunner's output happens to trim to empty; any stderr alongside a
+    // spawn ENOENT would have fallen through to npm_failed and claimed npm ran.
+    await withPath('/sentinel/bin', async () => {
+      __setCliInstallRunner(async () => ({
+        ok: false,
+        output: 'some wrapper noise on stderr',
+        failure: spawnError('ENOENT', { path: 'npm' }),
+      }));
+      await startCliInstall('codex', '1.2.3');
+      const done = await waitForTerminal('codex');
+      assert.equal(done.code, 'cli_install.no_output');
+      assert.match(done.error ?? '', /was not found on the PATH/);
+    });
   });
 
   it('leaves a non-spawn thrown error on npm_failed', async () => {
@@ -297,6 +369,21 @@ describe('cliInstallService', () => {
     await startCliInstall('codex', '1.2.3');
     const done = await waitForTerminal('codex');
     assert.equal(done.code, 'cli_install.npm_failed');
+  });
+
+  it('a real npm exit code is a number, so it can never look like a spawn errno', async () => {
+    // execFile puts the child's exit status on `code` as a NUMBER; only spawn
+    // failures use the string errno. The string guard is what keeps a genuine
+    // `npm install` failure off the spawn path.
+    __setCliInstallRunner(async () => ({
+      ok: false,
+      output: 'npm ERR! code E404',
+      failure: Object.assign(new Error('Command failed: npm install'), { code: 3 }),
+    }));
+    await startCliInstall('codex', '1.2.3');
+    const done = await waitForTerminal('codex');
+    assert.equal(done.code, 'cli_install.npm_failed');
+    assert.match(done.logTail ?? '', /E404/);
   });
 
   it('reserves the single-flight slot across the idempotency probe (no TOCTOU race)', async () => {

--- a/web-ui/app/_lib/__tests__/errorHelpCoverage.test.ts
+++ b/web-ui/app/_lib/__tests__/errorHelpCoverage.test.ts
@@ -71,17 +71,21 @@ const COVERED_ROUTE_FILES = [
  * codes the ingest service can emit, and a coverage guard that overclaims is
  * worse than one with an honest boundary.
  *
- * `cli_install.no_output` and `cli_install.npm_failed` are set by
- * `startCliInstall` in `middleware/src/platform/cliInstallService.ts` and
- * reach the UI on the `GET /v1/admin/cli-backends/:id/install/status` poll
- * response, not on an error envelope from a covered route file. A route scan
- * can therefore never discover them.
+ * `cli_install.no_output`, `cli_install.npm_failed` and
+ * `cli_install.spawn_failed` are set by `startCliInstall` in
+ * `middleware/src/platform/cliInstallService.ts` and reach the UI on the
+ * `GET /v1/admin/cli-backends/:id/install/status` poll response, not on an
+ * error envelope from a covered route file. A route scan can therefore never
+ * discover them. `spawn_failed` was split off `npm_failed` in #933 (OM-68):
+ * a child that the OS never started did not run an install and has no log
+ * tail, so the npm_failed copy was untrue in both of its sentences.
  */
 const NON_ROUTE_CODES = [
   'providers.key_rejected',
   'package.id_conflict_bundled',
   'cli_install.no_output',
   'cli_install.npm_failed',
+  'cli_install.spawn_failed',
 ] as const;
 
 /**

--- a/web-ui/app/_lib/errorHelp.ts
+++ b/web-ui/app/_lib/errorHelp.ts
@@ -61,6 +61,7 @@ export const ERROR_HELP_CODES = [
   // install-status poll response, not on an error envelope.
   'cli_install.no_output',
   'cli_install.npm_failed',
+  'cli_install.spawn_failed',
   // adminProviders.ts (+ providerCredentialVerifier.ts for key_rejected)
   'providers.apply_failed',
   'providers.invalid_request',

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1018,6 +1018,10 @@
       "npm_failed": {
         "what": "npm wurde ausgeführt, aber die Installation ist fehlgeschlagen.",
         "next": "Prüfe die Log-Details unten und starte die Installation danach erneut."
+      },
+      "spawn_failed": {
+        "what": "npm konnte nicht gestartet werden — das Betriebssystem hat die gefundene npm-Datei nicht ausgeführt. npm ist also nie gelaufen, und es wurde nichts installiert.",
+        "next": "Die betroffene Datei steht in den Support-Details. Prüfe, ob sie beschädigt oder nicht ausführbar ist, und installiere Node und npm im Zweifel neu."
       }
     },
     "package": {

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1018,6 +1018,10 @@
       "npm_failed": {
         "what": "npm ran, but the installation failed.",
         "next": "Check the log details below, then try the installation again."
+      },
+      "spawn_failed": {
+        "what": "npm could not be started — the operating system refused to execute the npm file it found. npm never ran, so nothing was installed.",
+        "next": "The affected file is named in the support details. Check whether it is corrupt or not executable, and reinstall Node and npm if in doubt."
       }
     },
     "package": {


### PR DESCRIPTION
Closes #933

Beta-test round 3 (OM-68), reported by Silvio Lange (TE Printline GmbH).

## The problem

A child process the OS never started was reported as `cli_install.npm_failed`, whose help copy says *"npm wurde ausgeführt, aber die Installation ist fehlgeschlagen. Prüfe die Log-Details unten…"*. Both halves are untrue for a spawn failure: npm never ran, nothing was installed, and there is no log tail to check — the support panel held only the spawn error itself.

The reporter hit it as `spawn ENOEXEC` against an npm-cli.js he had truncated to 0 bytes himself, and the issue says so. The finding stands independently of that trigger: **every** spawn failure landed in the same branch — corrupt binary, missing execute bit, wrong architecture.

## The measured error shapes

Everything below rests on this, measured on Node v22.23.2 spawning bare `npm` off a doctored PATH:

| scenario | delivery | `code` | `syscall` | `path` |
|---|---|---|---|---|
| 0-byte `+x` npm | **synchronous throw** | `ENOEXEC` | `spawn` | *absent* |
| npm without `+x` | callback | `EACCES` | `spawn npm` | `'npm'` |
| npm is a directory | callback | `EACCES` | `spawn npm` | `'npm'` |
| no npm at all | callback | `ENOENT` | `spawn npm` | `'npm'` |

Two consequences drive the design: `ENOEXEC` arrives as a *throw* with no `path`, and the failures that do carry `path` carry the **spawnfile as passed** — the bare string `'npm'`, which identifies no file.

## Two defects, not one

The `.catch` branch labelling everything `npm_failed` was only half. The other half made the first half unfixable:

```ts
(err, stdout, stderr) => {
  resolve({ ok: !err, output: … });   // `err` discarded here
}
```

`npmRunner` collapsed `execFile`'s error to a boolean and threw away the only object carrying `code` and `syscall`. The classification downstream had nothing to read, so a spawn error arriving on the *resolve* path was indistinguishable from "npm ran and exited non-zero with no output". Fixed by carrying the raw failure on the runner result (`failure?: unknown`, optional so all 17 existing test seams still compile), and classifying on **both** paths.

## How a spawn failure is distinguished

By error *shape*, not message text. The two spawn buckets stay **deliberately apart**:

| errno | code | why |
|---|---|---|
| `ENOEXEC`, `EACCES`, `EPERM` | **`cli_install.spawn_failed`** (new) | a file *was* found and refused execution, so the operator has to look at that file |
| `ENOENT` | `cli_install.no_output` (existing) | there was nothing to execute — which is what `no_output` already says, and its searched-PATH line is the right next step |

Merging them would reintroduce the same defect from the other side: telling an operator who has no npm at all that *"the npm file found is not executable"*.

Guards: a numeric `code` (a real npm exit status is `3`, not a string errno) never reaches the spawn path; and an errno with a **contradicting** syscall — `EACCES` from an `open` — is not treated as a spawn failure. Both are pinned by tests.

`EISDIR` is mapped for completeness but is unreachable this way on POSIX (a directory reports `EACCES`); the comment says so rather than implying coverage it does not add.

## Naming the file

This is where review caught a real defect in the first push. `spawnFailedDetail` did:

```ts
const file = failure.file ?? resolvedNpmFile(env);
```

Since `err.path` is `'npm'` on both callback-delivered shapes, it was truthy and short-circuited the resolution that exists precisely to name the file. The detail degraded to `npm file: npm` — naming nothing — in the **common** case, while the rarer `ENOEXEC` (no `path`) kept working. The copy promises *"Die betroffene Datei steht in den Support-Details"*, so it was untrue exactly where it mattered.

`err.path` is now trusted only when it actually looks like a path (`path.isAbsolute` or contains a separator); otherwise the PATH resolution runs. The filtering sits in `asSpawnFailure`, so `SpawnFailure.file` carries the invariant "a string that names a file" rather than "possibly a bare command".

**The fixtures are why this escaped.** They invented an absolute `err.path` on an `ENOEXEC` — a shape this runner cannot produce — so nothing in the suite exercised reality. The helper docstring now carries the measured table; one case pins the bare-`'npm'` shape and asserts a real file is named; another keeps the absolute-path case for when a runner does spawn a full path.

## Also fixed from review

- **Path asymmetry.** The resolve path reached `no_output` for `ENOENT` only because `npmRunner`'s output happens to trim to empty. A resolved `ENOENT` carrying any stderr would have fallen through to `npm_failed` and claimed npm ran — the exact conflation this PR removes, surviving in one corner. Now explicit on both paths, with a test that feeds stderr alongside an `ENOENT`.
- **`noOutputDetail` stopped hedging** when a spawn `ENOENT` *proved* the absence ("npm was not found on the PATH, so it never ran"); the inferred-from-empty-output case keeps "most likely". The original wording is byte-for-byte preserved for that path, so #941's assertion still holds.
- **Dead `try`/`catch`** around `existsSync` removed — it swallows its own errors and never throws (verified against NUL bytes, unstattable parents, over-long names).

## Copy

`errorHelp.cli_install.spawn_failed` (`what` + `next`) in **both** locales, following the neighbouring `cli_install.*` structure and tone. Registered in `ERROR_HELP_CODES` and in `errorHelpCoverage.test.ts`'s `NON_ROUTE_CODES` with a comment naming the origin. That guard fails in both directions, so both edits were required; `MIN_SCANNED_CODES` is untouched at 56 while the scanned set grew, so the guard was not weakened.

## Verification

```
middleware  npx tsc -p tsconfig.json --noEmit           my files clean
middleware  npx tsc -p test/tsconfig.json --noEmit      my files clean
middleware  npm run typecheck:test  (#573 ratchet)      zero new errors, baseline untouched
middleware  npx tsx --test test/cliInstallService.test.ts
              # tests 25  # pass 25  # fail 0       (was 16, +9)
middleware  npx eslint <changed>                        clean
web-ui      npx vitest run errorHelpCoverage errorHelp
              Test Files 2 passed | Tests 16 passed
web-ui      npx vitest run  (full suite)
              Test Files 112 passed | Tests 1014 passed
web-ui      npx tsc -p tsconfig.json --noEmit           clean
web-ui      npx eslint <changed>                        clean
```

**The regression guard was verified to actually guard.** Reverting only the `asNamedFile` filter and re-running the suite turns 2 tests red, including `names a real file when err.path is the bare spawnfile, not the string "npm"`. Restoring it returns 25/25.

**On the local typecheck baseline:** five unrelated files (`subAgentToolHydration.ts`, `operatorAgents.ts`, two `harness-orchestrator` files, `llmAdapterOpenAiResponses.test.ts`) report errors in my worktree because its `node_modules` is a symlink into a checkout whose `@omadia/orchestrator` `dist` predates #909. Verified identical on pristine `origin/main` via `git stash` — this change adds zero. CI does a real `npm ci`, so they should not appear there.

## Notes

- **Changelog deliberately deferred.** `docs/CHANGELOG.md` is untouched; a consolidated entry covers the whole beta-test-round-3 series in a separate PR, so the parallel cluster branches do not all conflict on the same file.
- **Residual, deliberately not addressed:** a runner rejecting with a *non-spawn* error still gets `npm_failed` and has no log tail, so "check the log details below" stays imprecise there. Those errors do carry a concrete message, and inventing copy for an unenumerated set would be guesswork. Imprecise rather than untrue; worth a follow-up if it shows up in the field.
