### PR TITLE
fix: promote-release could not tell gh which repository to publish

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -239,6 +239,13 @@ jobs:
       - name: Publish the draft and flag it latest
         env:
           GH_TOKEN: ${{ github.token }}
+          # This job deliberately has no actions/checkout -- it makes one API
+          # call and a checkout would be pure cost. But `gh` resolves the target
+          # repository from the git remote, so without a repo it fails with
+          # "failed to run git: fatal: not a git repository" AFTER the gate has
+          # already passed, leaving the release stuck as a draft. GH_REPO is how
+          # you tell `gh` the repository without a working tree.
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.release.outputs.new_tag }}
           MAC_FEED_PUBLISHED: ${{ needs.desktop-apps.outputs.mac_feed_published }}
           DESKTOP_RESULT: ${{ needs.desktop-apps.result }}


### PR DESCRIPTION
Hotfix for a defect I introduced in #943 (closing #928). Found by watching the first real release through the new two-phase publish, which is exactly the verification the review said would be needed.

## What happened

`v0.142.2` went out through #943's new path and wedged as a draft. The safety gate was **not** what stopped it — the gate passed:

```
MAC_FEED_PUBLISHED: true
DESKTOP_RESULT: success
```

All four builds succeeded including `macos-26-intel`, `mac-update-feed` succeeded, and the release carries all 15 assets — same count as the successfully published v0.142.1 — including the merged `latest-mac.yml`, every asset in state `uploaded`. Then the promotion itself failed:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
```

## Cause

`promote-release` deliberately has no `actions/checkout` — it makes one API call and a checkout would be pure cost. That part is right. But `gh` resolves its target repository from the git remote, so with no working tree it cannot know what to act on.

The failure lands **after** the safety gate has already passed, which is the worst possible place for it. The release stays a draft, the job goes red, and anyone reading the log sees the gate's message about a missing macOS feed — which is not what happened. A false diagnosis on top of a real failure.

`GH_REPO: ${{ github.repository }}` is how you tell `gh` the repository without a checkout. One line, plus a comment explaining why there is no checkout and why that means `GH_REPO` is required — so the next person does not "fix" it by adding a checkout.

## Audit for the same defect elsewhere

Checked every `gh` call in both workflows:

| Job | `gh` | checkout | `GH_REPO` | |
|---|---|---|---|---|
| `auto-release / release` | yes | ✅ | — | fine (needs git for tagging anyway) |
| `auto-release / desktop-apps` | — | — | — | pure `uses:` call, no steps |
| `auto-release / promote-release` | yes | no | ✅ **added** | fixed here |
| `desktop-apps / build` | yes | ✅ | — | fine |
| `desktop-apps / mac-update-feed` | yes | ✅ | — | fine |

`build` and `mac-update-feed` are the two carrying #943's new draft-inclusive release lookups, and both check out. `promote-release` was the only affected job.

## Blast radius while this was broken

Users were never at risk, because the fail-safe direction #943 was built around held: `/releases/latest` kept resolving to `v0.142.1`, which is complete and has its macOS feed, so clients kept updating to a version they could actually download. What broke is that **nothing new shipped** — two releases stranded as drafts, their notes invisible.

## Recovery of the stranded releases

Separate manual step, per the recovery documented in `auto-release.yml`:

- **v0.142.2** — complete (15 assets, `latest-mac.yml` present, all `uploaded`), so it satisfies the condition #943's own gate asserts and is safe to promote.
- **v0.142.3** — 0 assets, its desktop build had not finished. It needs its artifacts before it can be promoted, and with this fix merged the next run promotes it on its own.

## Verification

`actionlint` on the changed file reports only the two pre-existing `SC2086` info warnings, identical to `origin/main`. No new findings.

Nothing here is locally testable, and that is the honest lesson: this is a runtime property of the runner, invisible to `actionlint`, to YAML validation, and to reasoning about the job graph. The review of #943 walked the whole failure matrix correctly and could not have seen it. The first real release was the test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790524873&installation_model_id=428086&pr_number=948&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F948&signature=08bb4980a2ba2e1b733dee4bef86633cb3742163324bdce33b8bf25d158e50bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->