### PR TITLE
feat: publish agent app packages through a one-time tenant sign-in

### DIFF
--- a/middleware/src/index.ts
+++ b/middleware/src/index.ts
@@ -50,6 +50,9 @@ import { AgentTeamsIdentityStore } from './platform/agentTeamsIdentityStore.js';
 import { AgentIdentityStore } from './platform/agentIdentityStore.js';
 import { AgentTeamsInstallStore } from './platform/agentTeamsInstallStore.js';
 import { TeamsProvisioningEventStore } from './platform/teamsProvisioningEventStore.js';
+import { TeamsDelegatedTokenStore } from './platform/teamsDelegatedTokenStore.js';
+import { TeamsDelegatedSignInService } from './services/teamsDelegatedSignInService.js';
+import { createOperatorTeamsSignInRouter } from './routes/operatorTeamsSignIn.js';
 import { TeamsProvisioningJobRunner } from './services/teamsProvisioningJob.js';
 import { syncTeamsBotConfig } from './services/teamsBotsConfigSync.js';
 import {
@@ -57,6 +60,7 @@ import {
   getTeamsProvisioner,
   requireTeamsProvisioner,
   supportsTeamLookup,
+  TeamsProvisionerUnavailableError,
 } from './platform/teamsProvisionerService.js';
 import {
   CHANNEL_TEAMS_PLUGIN_ID,
@@ -1935,10 +1939,55 @@ async function main(): Promise<void> {
       'teamsProvisioningEventStore',
       teamsProvisioningEventStore,
     );
+    // #924 — custody of the TENANT's delegated Teams token set. Vault-backed
+    // (AES-256-GCM at rest), one record for the whole install, following the
+    // `@omadia/mcp-registry` namespace precedent. The catalog upload is the
+    // one provisioning step Microsoft refuses app-only, so without this an
+    // admin would have to upload a package by hand for every single agent.
+    const teamsDelegatedTokenStore = new TeamsDelegatedTokenStore(secretVault);
+    serviceRegistry.provide('teamsDelegatedTokenStore', teamsDelegatedTokenStore);
+    // The device-code flow itself. Holds the `flowHandle` — which carries the
+    // OAuth `device_code` — in this process only; nothing hands it to a
+    // browser, and the poll endpoint takes no handle at all.
+    const teamsDelegatedSignIn = new TeamsDelegatedSignInService({
+      tokens: teamsDelegatedTokenStore,
+      getProvisioner: () => getTeamsProvisioner(serviceRegistry),
+    });
+    serviceRegistry.provide('teamsDelegatedSignInService', teamsDelegatedSignIn);
     // TEAMS_PUBLIC_BASE_URL ?? PUBLIC_BASE_URL — the binding contract of
     // config.ts; resolved per call so a config reload wins over boot state.
     const teamsPublicBaseUrl = (): string =>
       config.TEAMS_PUBLIC_BASE_URL ?? config.PUBLIC_BASE_URL;
+    // Named rather than inlined into the runner options since #924: the
+    // download endpoint renders a package through the SAME loader the chain
+    // uploads through. Two loaders would be two answers to "what does this
+    // agent's package contain", and the operator would be diffing against a
+    // second implementation's opinion.
+    const loadTeamsPackageAssets = createTeamsAppPackageAssetLoader({
+      getChannelTeamsPackageRoot: () => {
+        const entry = pluginCatalog.get(CHANNEL_TEAMS_PLUGIN_ID);
+        return entry ? path.dirname(entry.source_path) : undefined;
+      },
+      getPublicBaseUrl: teamsPublicBaseUrl,
+      // #914 — the agent's authored identity feeds the manifest (name,
+      // descriptions, accent colour, package version) and the icons. Read
+      // per run, never cached: an identity edited between two runs must
+      // reach the package the second one builds.
+      loadIdentity: async (agentId) => {
+        const record = await agentIdentityStore.getByAgentId(agentId);
+        if (!record) return undefined;
+        const icons = await agentIdentityStore.getIcons(agentId);
+        return {
+          displayName: record.displayName,
+          shortDescription: record.shortDescription,
+          longDescription: record.longDescription,
+          accentColor: record.accentColor,
+          revision: record.revision,
+          icons: icons ?? null,
+        };
+      },
+    });
+    serviceRegistry.provide('teamsAppPackageAssetLoader', loadTeamsPackageAssets);
     const teamsProvisioningRunner = new TeamsProvisioningJobRunner({
       store: agentTeamsIdentityStore,
       // The runner records a binding only AFTER Graph confirmed the install,
@@ -1949,35 +1998,17 @@ async function main(): Promise<void> {
       // #915 — where the runner writes what it is doing between two chain
       // states. Best-effort by contract: a failed note never fails a run.
       events: teamsProvisioningEventStore,
+      // #924 — the tenant sign-in the catalog upload rides on. The runner
+      // feature-detects `uploadToCatalogDelegated` on the connector, so
+      // binding this against an older connector is harmless: it keeps doing
+      // the app-only upload it always did.
+      delegatedTokens: teamsDelegatedTokenStore,
       getProvisioner: () => requireTeamsProvisioner(serviceRegistry),
       // The accessor module's URL builder, bound to the public base — the
       // runner never composes the messaging endpoint itself.
       buildMessagingEndpoint: (botSlug) =>
         buildTeamsBotMessagingEndpoint(teamsPublicBaseUrl(), botSlug),
-      loadPackageAssets: createTeamsAppPackageAssetLoader({
-        getChannelTeamsPackageRoot: () => {
-          const entry = pluginCatalog.get(CHANNEL_TEAMS_PLUGIN_ID);
-          return entry ? path.dirname(entry.source_path) : undefined;
-        },
-        getPublicBaseUrl: teamsPublicBaseUrl,
-        // #914 — the agent's authored identity feeds the manifest (name,
-        // descriptions, accent colour, package version) and the icons. Read
-        // per run, never cached: an identity edited between two runs must
-        // reach the package the second one builds.
-        loadIdentity: async (agentId) => {
-          const record = await agentIdentityStore.getByAgentId(agentId);
-          if (!record) return undefined;
-          const icons = await agentIdentityStore.getIcons(agentId);
-          return {
-            displayName: record.displayName,
-            shortDescription: record.shortDescription,
-            longDescription: record.longDescription,
-            accentColor: record.accentColor,
-            revision: record.revision,
-            icons: icons ?? null,
-          };
-        },
-      }),
+      loadPackageAssets: loadTeamsPackageAssets,
       // #910 — the finishing move: after `installed`, write the identity's
       // `teams_bots` entry into the channel-teams plugin config and reactivate
       // the plugin, so the provisioned bot has an adapter and a route without
@@ -3401,6 +3432,42 @@ async function main(): Promise<void> {
           // upgraded or removed while the process runs, and the team-uninstall
           // capability (#900) has to follow it.
           getProvisioner: () => getTeamsProvisioner(serviceRegistry),
+          // #924 — the download fallback. Rendered PER REQUEST through the
+          // same asset loader and the same connector `buildAppPackage` the
+          // chain uses, so what an operator downloads is byte-for-byte what
+          // provisioning would upload. Resolved live: without a connector
+          // there is nothing to render with, and the route reports that as a
+          // capability rather than failing.
+          buildAppPackage: async (record) => {
+            const provisioner = getTeamsProvisioner(serviceRegistry);
+            if (!provisioner) {
+              throw new TeamsProvisionerUnavailableError();
+            }
+            const loader = serviceRegistry.get<
+              ReturnType<typeof createTeamsAppPackageAssetLoader>
+            >('teamsAppPackageAssetLoader');
+            if (!loader) {
+              throw new Error(
+                'teams app package asset loader is not registered — Postgres-backed agent-factory wiring did not run',
+              );
+            }
+            const assets = await loader({
+              agentId: record.agentId,
+              botSlug: record.botSlug,
+              displayName: record.displayName,
+              state: record.state as never,
+              appId: record.appId,
+              tenantId: record.tenantId,
+              teamsAppId: record.teamsAppId,
+              teamsAppExternalId: record.teamsAppExternalId,
+              lastError: record.lastError,
+            });
+            return provisioner.buildAppPackage({
+              manifestTemplate: assets.manifestTemplate,
+              params: assets.params,
+              icons: assets.icons,
+            });
+          },
         };
         // Migration 0053 (#915) — same optional posture as 0051: a middleware
         // whose migrations have not reached 0053 serves a status response
@@ -3427,6 +3494,25 @@ async function main(): Promise<void> {
   );
   console.log(
     '[middleware] operator-agents endpoints ready at /api/v1/operator/agents/* (auth-gated, incl. teams-identity provisioning)',
+  );
+
+  // #924 — the TENANT-wide Teams sign-in. A sibling of /operator/agents, not a
+  // route under it: one admin signs in once for the whole directory and every
+  // agent provisioned afterwards uses that sign-in, so hanging it off an agent
+  // slug would have said the opposite in the URL — and made "sign in before
+  // you create your first agent" unrepresentable.
+  app.use(
+    '/api/v1/operator/teams',
+    requireAuth,
+    createOperatorTeamsSignInRouter({
+      getSignIn: () =>
+        serviceRegistry.get<TeamsDelegatedSignInService>(
+          'teamsDelegatedSignInService',
+        ),
+    }),
+  );
+  console.log(
+    '[middleware] tenant Teams sign-in ready at /api/v1/operator/teams/sign-in (auth-gated, device-code flow held server-side)',
   );
 
   // Phase B+ — operator channels dashboard.

--- a/middleware/src/platform/teamsDelegatedSignIn.ts
+++ b/middleware/src/platform/teamsDelegatedSignIn.ts
@@ -1,0 +1,388 @@
+/**
+ * The DELEGATED half of `teamsProvisioner@1` — mirrored contract, byte5ai/omadia#924.
+ *
+ * WHY THIS EXISTS AT ALL. Every other step of Teams provisioning is app-only:
+ * the Entra app registration, the Azure bot, the team install. Exactly one is
+ * not — `POST /appCatalogs/teamsApps` is delegated-only at Microsoft, with
+ * Application permissions documented as "Not supported". No amount of admin
+ * consent makes an app-only token work there; a human has to have signed in.
+ *
+ * So the M365 connector (>= 0.6.0, byte5ai/omadia-m365-connector#12) publishes
+ * a device-code sign-in and a delegated catalog upload. An admin signs in ONCE
+ * PER TENANT; every agent provisioned afterwards uses the stored token set.
+ * That is the whole point of the exercise, and it is why the token set is
+ * tenant-scoped state (see `teamsDelegatedTokenStore.ts`) and not something an
+ * agent row owns.
+ *
+ * MIRRORED, NOT IMPORTED — same rule as `teamsProvisionerService.ts`, whose
+ * accessor interface these six methods hang off as OPTIONAL members. The
+ * connector is not vendored in this checkout and the middleware may be newer
+ * than the connector installed next to it, so nothing here may be called
+ * without {@link supportsDelegatedCatalogUpload} first.
+ *
+ * SECRET GRADE, SPELLED OUT. Two values in this module must never reach a
+ * log line, an error message, an API response or a progress-event `detail`:
+ *
+ *   * {@link DelegatedTokenSet.accessToken} / `.refreshToken` — bearer
+ *     credentials for the signed-in admin.
+ *   * {@link DeviceCodeStart.flowHandle} — it CARRIES the `device_code`.
+ *     Anyone holding it during the flow's lifetime can complete the sign-in
+ *     against Microsoft themselves.
+ *
+ * {@link redactDelegated} is the choke point that makes that enforceable
+ * rather than aspirational, and `teamsDelegatedRedaction.test.ts` pins it.
+ */
+
+// ---------------------------------------------------------------------------
+// Token set
+// ---------------------------------------------------------------------------
+
+/** The signed-in admin, as far as the operator UI is allowed to care. */
+export interface DelegatedAccount {
+  readonly username?: string;
+  readonly displayName?: string;
+  readonly objectId?: string;
+  readonly tenantId?: string;
+}
+
+/**
+ * One tenant's delegated credentials. BOTH tokens are secrets; the rest is
+ * metadata the operator screen renders (who, until when, which scopes).
+ */
+export interface DelegatedTokenSet {
+  /** SECRET. */
+  readonly accessToken: string;
+  /** SECRET. */
+  readonly refreshToken: string;
+  /** ISO-8601 expiry of {@link accessToken}. */
+  readonly expiresAt: string;
+  readonly scopes: readonly string[];
+  readonly clientId: string;
+  readonly tenantId: string;
+  readonly account?: DelegatedAccount;
+}
+
+// ---------------------------------------------------------------------------
+// Device-code flow
+// ---------------------------------------------------------------------------
+
+/** What `startDelegatedSignIn` hands back. */
+export interface DeviceCodeStart {
+  /** SHOW THIS. The code the admin types on the verification page. */
+  readonly userCode: string;
+  /** SHOW THIS. Where the admin types it. */
+  readonly verificationUri: string;
+  /** Microsoft's own sentence; advisory, the UI writes its own copy. */
+  readonly message?: string;
+  readonly expiresAt: string;
+  readonly intervalSeconds: number;
+  /**
+   * SECRET-GRADE — carries the `device_code`. Stays on the server; see
+   * `services/teamsDelegatedSignInService.ts` for how the poll is served
+   * without ever handing this to a browser.
+   */
+  readonly flowHandle: string;
+  readonly scopes: readonly string[];
+  /**
+   * Where an admin grants consent when the sign-in page demands it first.
+   * Shown NEXT TO the user code, before anything fails — an operator who
+   * only learns about it from an error is an operator already stuck.
+   */
+  readonly adminConsentUrl: string;
+}
+
+export type DeviceCodePollResult =
+  | { readonly status: 'pending'; readonly retryAfterSeconds: number }
+  | { readonly status: 'succeeded'; readonly tokens: DelegatedTokenSet }
+  | { readonly status: 'expired'; readonly reason?: string }
+  | { readonly status: 'declined'; readonly reason?: string };
+
+/**
+ * Synchronous verdict on a token set the caller already holds.
+ *
+ * `accessTokenStale` is NOT signed out. The refresh token outlives the access
+ * token by design; a stale access token is one silent refresh away and must
+ * never be rendered as a failure or as a prompt to sign in again.
+ */
+export interface DelegatedSignInStatus {
+  readonly signedIn: boolean;
+  readonly accessTokenStale?: boolean;
+  readonly expiresAt?: string;
+  readonly scopes?: readonly string[];
+  readonly account?: DelegatedAccount;
+  readonly tenantId?: string;
+  readonly clientId?: string;
+}
+
+export interface DelegatedRevokeResult {
+  readonly revoked: boolean;
+  readonly reason?: string;
+}
+
+export interface UploadToCatalogDelegatedInput {
+  readonly packageZip: Uint8Array;
+  readonly externalId: string;
+  readonly tokens: DelegatedTokenSet;
+}
+
+export interface CatalogTeamsAppLike {
+  readonly teamsAppId: string;
+  readonly externalId?: string;
+  readonly displayName?: string;
+  readonly version?: string;
+}
+
+export interface UploadToCatalogDelegatedResult {
+  readonly app: { readonly outcome: string; readonly value: CatalogTeamsAppLike };
+  /** Persist when {@link refreshed} is true — the connector rotated them. */
+  readonly tokens: DelegatedTokenSet;
+  readonly refreshed: boolean;
+}
+
+/**
+ * The six methods the connector gained in 0.6.0. Declared as a standalone
+ * interface so `TeamsProvisionerAccessor` can mix them in as OPTIONAL members
+ * without this file having to know about that one.
+ */
+export interface TeamsDelegatedProvisionerMethods {
+  uploadToCatalogDelegated(
+    input: UploadToCatalogDelegatedInput,
+  ): Promise<UploadToCatalogDelegatedResult>;
+  startDelegatedSignIn(input?: {
+    readonly displayName?: string;
+  }): Promise<DeviceCodeStart>;
+  pollDelegatedSignIn(input: {
+    readonly flowHandle: string;
+  }): Promise<DeviceCodePollResult>;
+  /** SYNC by contract — do not await it into a promise-typed seam. */
+  getDelegatedSignInStatus(input: {
+    readonly tokens?: DelegatedTokenSet;
+  }): DelegatedSignInStatus;
+  refreshDelegatedToken(input: {
+    readonly tokens: DelegatedTokenSet;
+  }): Promise<DelegatedTokenSet>;
+  /** SYNC by contract. */
+  revokeDelegatedSignIn(input: {
+    readonly tokens?: DelegatedTokenSet;
+  }): DelegatedRevokeResult;
+}
+
+/** Structural shape of an accessor that publishes the delegated half. */
+export type DelegatedCapableProvisioner = Partial<TeamsDelegatedProvisionerMethods>;
+
+/**
+ * Does the CURRENTLY INSTALLED connector publish the delegated catalog upload
+ * (>= 0.6.0)? Same shape and same reason as `supportsTeamUninstall` /
+ * `supportsTeamLookup`: the contract is mirrored, not imported, so a
+ * middleware newer than its connector must ASK before it calls.
+ *
+ * All six methods are checked together on purpose. They are one feature —
+ * a connector that could upload but not sign in would leave the operator with
+ * a capability they can never satisfy, and reporting it as available would
+ * light up a button that cannot work.
+ */
+export function supportsDelegatedCatalogUpload(
+  provisioner: DelegatedCapableProvisioner | undefined,
+): boolean {
+  if (provisioner === undefined) return false;
+  return (
+    typeof provisioner.uploadToCatalogDelegated === 'function' &&
+    typeof provisioner.startDelegatedSignIn === 'function' &&
+    typeof provisioner.pollDelegatedSignIn === 'function' &&
+    typeof provisioner.getDelegatedSignInStatus === 'function' &&
+    typeof provisioner.refreshDelegatedToken === 'function' &&
+    typeof provisioner.revokeDelegatedSignIn === 'function'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Error taxonomy — duck-typed guards.
+//
+// Connector errors cross the plugin boundary as plain `Error`s whose class
+// identity belongs to the plugin's module graph, so `instanceof` against a
+// local mirror never matches. Same technique as the app-only guards in
+// `teamsProvisionerService.ts`.
+//
+// FOUR ERRORS, FOUR DIFFERENT ACTIONS. That is the entire reason they are
+// separate types rather than one `DelegatedError` with a string field: the
+// operator must be told to sign in, OR to send an admin to a consent URL, OR
+// nothing at all (a refresh happens without them), OR to go look at the
+// publisher app's Conditional Access policy. Collapsing them collapses the
+// instructions.
+// ---------------------------------------------------------------------------
+
+function isStringArray(value: unknown): value is readonly string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === 'string');
+}
+
+function named(err: unknown, name: string): err is Error {
+  return err instanceof Error && err.name === name;
+}
+
+export interface DelegatedSignInRequiredLike extends Error {
+  readonly name: 'DelegatedSignInRequiredError';
+  readonly step?: string;
+  readonly requiredScopes?: readonly string[];
+}
+
+export interface DelegatedConsentRequiredLike extends Error {
+  readonly name: 'DelegatedConsentRequiredError';
+  readonly step?: string;
+  readonly requiredScopes?: readonly string[];
+  readonly adminConsentUrl?: string;
+}
+
+/** `access-token-expired` is recoverable without a human; `refresh-token-invalid` is not. */
+export type DelegatedTokenExpiredReason =
+  | 'access-token-expired'
+  | 'refresh-token-invalid';
+
+export interface DelegatedTokenExpiredLike extends Error {
+  readonly name: 'DelegatedTokenExpiredError';
+  readonly reason?: DelegatedTokenExpiredReason;
+  readonly recoverableByRefresh?: boolean;
+}
+
+export interface DeviceCodeFlowLike extends Error {
+  readonly name: 'DeviceCodeFlowError';
+  readonly oauthError?: string;
+  readonly status?: number;
+}
+
+export function isDelegatedSignInRequiredError(
+  err: unknown,
+): err is DelegatedSignInRequiredLike {
+  return named(err, 'DelegatedSignInRequiredError');
+}
+
+export function isDelegatedConsentRequiredError(
+  err: unknown,
+): err is DelegatedConsentRequiredLike {
+  return named(err, 'DelegatedConsentRequiredError');
+}
+
+export function isDelegatedTokenExpiredError(
+  err: unknown,
+): err is DelegatedTokenExpiredLike {
+  return named(err, 'DelegatedTokenExpiredError');
+}
+
+export function isDeviceCodeFlowError(err: unknown): err is DeviceCodeFlowLike {
+  return named(err, 'DeviceCodeFlowError');
+}
+
+/** Scopes named by a sign-in / consent error, `[]` when it named none. */
+export function requiredScopesOf(err: unknown): readonly string[] {
+  const scopes = (err as { requiredScopes?: unknown } | null)?.requiredScopes;
+  return isStringArray(scopes) ? scopes : [];
+}
+
+/** The step the connector was on, or `undefined` — free text, never copy. */
+export function delegatedStepOf(err: unknown): string | undefined {
+  const step = (err as { step?: unknown } | null)?.step;
+  return typeof step === 'string' && step.length > 0 ? step : undefined;
+}
+
+/**
+ * The consent URL of a `DelegatedConsentRequiredError`, when it carried one
+ * that is safe to put in front of an operator.
+ *
+ * Validated rather than trusted: only an absolute `https:` URL is returned.
+ * The value ends up in a link and in `last_error`, so a `javascript:` or a
+ * relative string arriving from another repo's error object must degrade to
+ * "no link" instead of being rendered.
+ */
+export function adminConsentUrlOf(err: unknown): string | undefined {
+  const raw = (err as { adminConsentUrl?: unknown } | null)?.adminConsentUrl;
+  if (typeof raw !== 'string' || raw.length === 0) return undefined;
+  try {
+    return new URL(raw).protocol === 'https:' ? raw : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Is a token-expiry failure fixable by a silent refresh (no human)? */
+export function isRecoverableByRefresh(err: DelegatedTokenExpiredLike): boolean {
+  if (err.recoverableByRefresh === true) return true;
+  if (err.recoverableByRefresh === false) return false;
+  // An older connector may report the reason without the boolean.
+  return err.reason === 'access-token-expired';
+}
+
+// ---------------------------------------------------------------------------
+// Redaction choke point
+// ---------------------------------------------------------------------------
+
+/**
+ * Every value in this module that must never be logged, returned or recorded.
+ *
+ * Kept as data rather than as scattered `delete` statements so the guarantee
+ * is testable in one place: `teamsDelegatedRedaction.test.ts` asserts that a
+ * payload containing each of these keys comes back without them.
+ */
+export const DELEGATED_SECRET_KEYS = [
+  'accessToken',
+  'access_token',
+  'refreshToken',
+  'refresh_token',
+  'flowHandle',
+  'flow_handle',
+  'deviceCode',
+  'device_code',
+  'idToken',
+  'id_token',
+] as const;
+
+const SECRET_KEY_SET: ReadonlySet<string> = new Set(DELEGATED_SECRET_KEYS);
+
+/** Depth bound — a cyclic or absurdly nested payload must not hang a log call. */
+const MAX_REDACT_DEPTH = 6;
+
+/**
+ * Recursively strip every secret-grade key from a value, so what is left is
+ * safe to log, to serialize into an API response, or to write into a
+ * progress-event `detail`.
+ *
+ * Total and non-throwing by construction: it is called from logging and error
+ * paths, where a redactor that could itself fail would be worse than the leak
+ * it prevents. Unknown types are passed through unchanged; only plain objects
+ * and arrays are walked.
+ */
+export function redactDelegated<T>(value: T, depth = 0): T {
+  if (depth >= MAX_REDACT_DEPTH) return undefined as unknown as T;
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactDelegated(entry, depth + 1)) as unknown as T;
+  }
+  if (value === null || typeof value !== 'object') return value;
+  if (value instanceof Date) return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (SECRET_KEY_SET.has(key)) continue;
+    out[key] = redactDelegated(entry, depth + 1);
+  }
+  return out as unknown as T;
+}
+
+/**
+ * A token set as the OPERATOR may see it: metadata only, both tokens gone.
+ * The one projection any route or UI payload is allowed to build from a
+ * {@link DelegatedTokenSet}.
+ */
+export interface DelegatedTokenSummary {
+  readonly expiresAt: string;
+  readonly scopes: readonly string[];
+  readonly clientId: string;
+  readonly tenantId: string;
+  readonly account?: DelegatedAccount;
+}
+
+export function summarizeTokenSet(tokens: DelegatedTokenSet): DelegatedTokenSummary {
+  return {
+    expiresAt: tokens.expiresAt,
+    scopes: tokens.scopes,
+    clientId: tokens.clientId,
+    tenantId: tokens.tenantId,
+    ...(tokens.account ? { account: tokens.account } : {}),
+  };
+}

--- a/middleware/src/platform/teamsDelegatedTokenStore.ts
+++ b/middleware/src/platform/teamsDelegatedTokenStore.ts
@@ -1,0 +1,266 @@
+/**
+ * Custody of the tenant's delegated Teams token set (byte5ai/omadia#924).
+ *
+ * WHERE IT LIVES, AND WHY NOT A TABLE. `agent_teams_identities` was built with
+ * "NO SECRET MATERIAL" written across its header: the bot's client secret is a
+ * ref into a vault, never a column. An access token and a refresh token are
+ * strictly more dangerous than that client secret — they are bearer
+ * credentials for a signed-in global admin — so putting them in a Postgres
+ * column would invert the posture the rest of this feature already holds.
+ *
+ * The precedent this follows is `services/mcpRegistrySecretService.ts`: a
+ * vault NAMESPACE per concern, a key inside it, and a thin typed service in
+ * front. The vault is `FileSecretVault` (AES-256-GCM at rest, master key from
+ * `VAULT_KEY`), the same one that holds MCP registry bearer tokens and MCP
+ * server config secrets. Nothing new is invented here.
+ *
+ * ONE RECORD, BECAUSE ONE TENANT. The whole point of #924 is that an admin
+ * signs in ONCE and every agent provisioned afterwards rides on that sign-in —
+ * so the record is per TENANT, emphatically not per agent. And a given omadia
+ * install provisions into ONE customer tenant: every app registration it
+ * creates is `AzureADMyOrg` single-tenant (`assertSingleTenantInput` in
+ * `platform/teamsProvisionerService.ts` enforces it), and the connector
+ * contract takes exactly one `DelegatedTokenSet` per call with no tenant
+ * selector anywhere. So there is one key. The tenant id travels INSIDE the
+ * record, which is what makes {@link TeamsDelegatedTokenStore.read} able to
+ * notice a record belonging to a different tenant instead of silently using
+ * credentials for the wrong directory.
+ *
+ * WHAT LEAVES THIS MODULE. `read` returns the full set — its only callers are
+ * the job runner (which hands it straight to the connector) and the sign-in
+ * service (which refreshes it). Everything operator-facing goes through
+ * {@link TeamsDelegatedTokenStore.describe}, which answers the question "is
+ * someone signed in, who, until when" WITHOUT the values. A route that wants
+ * to render sign-in state has no reason to touch `read`, and this is where
+ * that is made structural rather than a convention.
+ */
+
+import {
+  summarizeTokenSet,
+  type DelegatedTokenSet,
+  type DelegatedTokenSummary,
+} from './teamsDelegatedSignIn.js';
+
+/** The vault facet this store needs — satisfied by `SecretVault`. */
+export interface DelegatedTokenVault {
+  get(namespace: string, key: string): Promise<string | undefined>;
+  set(namespace: string, key: string, value: string): Promise<void>;
+  deleteKey(namespace: string, key: string): Promise<void>;
+}
+
+/** Vault namespace, mirroring `@omadia/mcp-registry`'s convention. */
+export const TEAMS_DELEGATED_VAULT_NAMESPACE = '@omadia/teams-delegated';
+
+/** The single key inside that namespace — see the module header on why one. */
+export const TEAMS_DELEGATED_VAULT_KEY = 'tenant-token-set';
+
+/**
+ * What the operator surface is allowed to know. No token, ever — not even
+ * truncated: a prefix of a bearer token is still material an attacker can
+ * search logs for.
+ */
+export interface DelegatedSignInPresence {
+  readonly signedIn: boolean;
+  /** ISO-8601 — when THIS install stored the sign-in. Not from Microsoft. */
+  readonly signedInAt?: string;
+  /** ISO-8601 expiry of the access token. */
+  readonly expiresAt?: string;
+  /**
+   * The access token is past {@link expiresAt}. NOT signed out: the refresh
+   * token outlives it and the next upload refreshes silently. Rendering this
+   * as an error is the mistake this field exists to prevent.
+   */
+  readonly accessTokenStale?: boolean;
+  readonly scopes?: readonly string[];
+  readonly tenantId?: string;
+  readonly clientId?: string;
+  readonly account?: DelegatedTokenSummary['account'];
+}
+
+export const SIGNED_OUT: DelegatedSignInPresence = { signedIn: false };
+
+/** Envelope written to the vault. Versioned so a later shape change can be
+ *  recognised rather than guessed at. */
+interface StoredEnvelope {
+  readonly version: 1;
+  readonly signedInAt: string;
+  readonly tokens: DelegatedTokenSet;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === 'string');
+}
+
+/**
+ * Narrow a decrypted blob back into a token set.
+ *
+ * Strict on the fields the connector REQUIRES (both tokens, expiry, scopes,
+ * client and tenant): a half-written record is not a usable credential, and
+ * handing the connector a set with an empty `refreshToken` would produce a
+ * confusing `DelegatedTokenExpiredError` instead of an honest "nobody is
+ * signed in". Returns `undefined` rather than throwing — the caller's honest
+ * answer for a corrupt record is the same as for an absent one.
+ */
+function parseEnvelope(raw: string): StoredEnvelope | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(parsed) || parsed.version !== 1) return undefined;
+  const tokens = parsed.tokens;
+  if (!isRecord(tokens)) return undefined;
+  const {
+    accessToken,
+    refreshToken,
+    expiresAt,
+    scopes,
+    clientId,
+    tenantId,
+    account,
+  } = tokens;
+  if (
+    typeof accessToken !== 'string' ||
+    accessToken.length === 0 ||
+    typeof refreshToken !== 'string' ||
+    refreshToken.length === 0 ||
+    typeof expiresAt !== 'string' ||
+    typeof clientId !== 'string' ||
+    typeof tenantId !== 'string' ||
+    !isStringArray(scopes)
+  ) {
+    return undefined;
+  }
+  const signedInAt =
+    typeof parsed.signedInAt === 'string' ? parsed.signedInAt : new Date(0).toISOString();
+  return {
+    version: 1,
+    signedInAt,
+    tokens: {
+      accessToken,
+      refreshToken,
+      expiresAt,
+      scopes,
+      clientId,
+      tenantId,
+      ...(isRecord(account)
+        ? {
+            account: {
+              ...(typeof account.username === 'string'
+                ? { username: account.username }
+                : {}),
+              ...(typeof account.displayName === 'string'
+                ? { displayName: account.displayName }
+                : {}),
+              ...(typeof account.objectId === 'string'
+                ? { objectId: account.objectId }
+                : {}),
+              ...(typeof account.tenantId === 'string'
+                ? { tenantId: account.tenantId }
+                : {}),
+            },
+          }
+        : {}),
+    },
+  };
+}
+
+export class TeamsDelegatedTokenStore {
+  constructor(
+    private readonly vault: DelegatedTokenVault,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  /**
+   * The stored token set, or `undefined` when nobody is signed in.
+   *
+   * TWO CALLERS ONLY — the provisioning job runner and the sign-in service.
+   * Everything that renders sign-in state uses {@link describe}.
+   */
+  async read(): Promise<DelegatedTokenSet | undefined> {
+    const raw = await this.vault.get(
+      TEAMS_DELEGATED_VAULT_NAMESPACE,
+      TEAMS_DELEGATED_VAULT_KEY,
+    );
+    if (raw === undefined) return undefined;
+    return parseEnvelope(raw)?.tokens;
+  }
+
+  /**
+   * Persist a token set — the sign-in that just succeeded, or the rotation the
+   * connector performed (`refreshed === true`).
+   *
+   * `signedInAt` is preserved across a ROTATION and reset on a fresh SIGN-IN.
+   * The distinction is what the operator screen means by "signed in since":
+   * a refresh happens without a human and must not restart that clock, or the
+   * panel would suggest someone re-authenticated when nobody did. The two
+   * cases are told apart by the account and tenant staying the same.
+   */
+  async write(tokens: DelegatedTokenSet): Promise<void> {
+    const previous = await this.readEnvelope();
+    const continuesPrevious =
+      previous !== undefined &&
+      previous.tokens.tenantId === tokens.tenantId &&
+      previous.tokens.account?.objectId === tokens.account?.objectId;
+    const envelope: StoredEnvelope = {
+      version: 1,
+      signedInAt: continuesPrevious
+        ? previous.signedInAt
+        : this.now().toISOString(),
+      tokens,
+    };
+    await this.vault.set(
+      TEAMS_DELEGATED_VAULT_NAMESPACE,
+      TEAMS_DELEGATED_VAULT_KEY,
+      JSON.stringify(envelope),
+    );
+  }
+
+  /** Forget the sign-in. Idempotent: clearing an empty vault is a no-op. */
+  async clear(): Promise<void> {
+    await this.vault.deleteKey(
+      TEAMS_DELEGATED_VAULT_NAMESPACE,
+      TEAMS_DELEGATED_VAULT_KEY,
+    );
+  }
+
+  /**
+   * Sign-in state WITHOUT the values — the projection every operator-facing
+   * caller uses.
+   *
+   * `accessTokenStale` is computed here rather than asked of the connector so
+   * the answer exists even when no connector is installed. It is deliberately
+   * NOT `signedIn: false`: an expired access token with a live refresh token
+   * is a working sign-in, and the UI is required to render it as such.
+   */
+  async describe(): Promise<DelegatedSignInPresence> {
+    const envelope = await this.readEnvelope();
+    if (envelope === undefined) return SIGNED_OUT;
+    const summary = summarizeTokenSet(envelope.tokens);
+    const expiry = Date.parse(summary.expiresAt);
+    const stale = Number.isFinite(expiry) && expiry <= this.now().getTime();
+    return {
+      signedIn: true,
+      signedInAt: envelope.signedInAt,
+      expiresAt: summary.expiresAt,
+      accessTokenStale: stale,
+      scopes: summary.scopes,
+      tenantId: summary.tenantId,
+      clientId: summary.clientId,
+      ...(summary.account ? { account: summary.account } : {}),
+    };
+  }
+
+  private async readEnvelope(): Promise<StoredEnvelope | undefined> {
+    const raw = await this.vault.get(
+      TEAMS_DELEGATED_VAULT_NAMESPACE,
+      TEAMS_DELEGATED_VAULT_KEY,
+    );
+    return raw === undefined ? undefined : parseEnvelope(raw);
+  }
+}

--- a/middleware/src/platform/teamsProvisionerService.ts
+++ b/middleware/src/platform/teamsProvisionerService.ts
@@ -60,6 +60,7 @@
  */
 
 import { KERNEL_SERVICE_CALLER, type ServiceRegistry } from './serviceRegistry.js';
+import type { TeamsDelegatedProvisionerMethods } from './teamsDelegatedSignIn.js';
 
 /** Service-registry key (bare, unversioned). */
 export const TEAMS_PROVISIONER_SERVICE_NAME = 'teamsProvisioner';
@@ -321,7 +322,8 @@ export interface UninstallFromTeamResult {
  * module doc's version-skew note. Never call it without
  * {@link supportsTeamUninstall}.
  */
-export interface TeamsProvisionerAccessor {
+export interface TeamsProvisionerAccessor
+  extends Partial<TeamsDelegatedProvisionerMethods> {
   readonly tenantMode: TenantMode;
   /** `true` when the ARM setup fields are configured (bot creation possible). */
   readonly canCreateBots: boolean;
@@ -364,6 +366,22 @@ export interface TeamsProvisionerAccessor {
    * alone.
    */
   getTeam?(input: GetTeamInput): Promise<GetTeamResult>;
+
+  /**
+   * THE DELEGATED HALF — connector >= 0.6.0 only (byte5ai/omadia#924). All six
+   * are optional together, for the same version-skew reason as the two methods
+   * above, and the ONE guard for all of them is
+   * `supportsDelegatedCatalogUpload` (`platform/teamsDelegatedSignIn.ts`).
+   *
+   * They exist because `POST /appCatalogs/teamsApps` is delegated-only at
+   * Microsoft — Application permissions are documented as "Not supported", so
+   * no amount of admin consent makes the app-only {@link uploadToCatalog}
+   * work. An admin signs in once per TENANT; every agent provisioned after
+   * that rides on the stored token set.
+   *
+   * `getDelegatedSignInStatus` and `revokeDelegatedSignIn` are SYNCHRONOUS by
+   * contract — do not await them into a promise-typed seam.
+   */
 }
 
 /** Input of the optional {@link TeamsProvisionerAccessor.getTeam}. */
@@ -405,6 +423,32 @@ export function supportsTeamLookup(
  * onto {@link getTeamsProvisioner} without a second null check: no
  * connector at all is also no uninstall.
  */
+/**
+ * The delegated surface is re-exported from this choke point so every consumer
+ * has ONE import site for `teamsProvisioner@1`, exactly as they do for the
+ * app-only half. The definitions live in `teamsDelegatedSignIn.ts` because
+ * they are a coherent feature of their own (a device-code flow, a token set,
+ * four errors) and putting them here would have pushed this module past the
+ * size where anyone reads it.
+ */
+export {
+  adminConsentUrlOf,
+  delegatedStepOf,
+  isDelegatedConsentRequiredError,
+  isDelegatedSignInRequiredError,
+  isDelegatedTokenExpiredError,
+  isDeviceCodeFlowError,
+  isRecoverableByRefresh,
+  redactDelegated,
+  requiredScopesOf,
+  summarizeTokenSet,
+  supportsDelegatedCatalogUpload,
+  type DelegatedTokenSet,
+  type DeviceCodePollResult,
+  type DeviceCodeStart,
+  type TeamsDelegatedProvisionerMethods,
+} from './teamsDelegatedSignIn.js';
+
 export function supportsTeamUninstall(
   provisioner: TeamsProvisionerAccessor | undefined,
 ): boolean {
@@ -622,8 +666,59 @@ function guardAccessor(raw: TeamsProvisionerAccessor): TeamsProvisionerAccessor 
             ),
         }
       : {}),
+    // The delegated half (#924), forwarded under the SAME conditional-spread
+    // contract as the two methods above and for the same hard-won reason: a
+    // `uploadToCatalogDelegated: (i) => raw.uploadToCatalogDelegated?.(i)`
+    // here would make every connector look capable, and turn an old one's
+    // honest absence into a silent `undefined` at the call site.
+    //
+    // Forwarded one by one rather than as a group, even though
+    // `supportsDelegatedCatalogUpload` requires all six: this wrapper's job is
+    // to report the raw provider's shape truthfully, and a half-shipped
+    // connector must read as half-shipped rather than as absent.
+    ...forwardDelegated(raw),
   };
 }
+
+/**
+ * Conditional forwarding of the six delegated methods.
+ *
+ * Its own function purely to keep {@link guardAccessor} readable; the rule it
+ * implements is identical — a method appears on the wrapper if and only if the
+ * raw provider actually has it, so `supportsDelegatedCatalogUpload` can read
+ * the WRAPPER and still get the truth about the connector behind it.
+ *
+ * NO SECRET STRIPPING HERE, deliberately. `stripCleartextSecrets` exists
+ * because the app-only contract must never hand a cleartext client secret
+ * across the boundary. The delegated contract is the opposite case: the token
+ * set IS the payload, the middleware is its custodian
+ * (`platform/teamsDelegatedTokenStore.ts`), and stripping it would break the
+ * feature. The guarantee that it never LEAKS lives at the log/response
+ * boundaries instead — `redactDelegated` in `teamsDelegatedSignIn.ts`.
+ */
+function forwardDelegated(
+  raw: TeamsProvisionerAccessor,
+): Partial<TeamsDelegatedProvisionerMethods> {
+  const out: Record<string, unknown> = {};
+  for (const name of DELEGATED_METHOD_NAMES) {
+    const method = raw[name];
+    if (typeof method !== 'function') continue;
+    out[name] = (...args: unknown[]) =>
+      (method as (...a: unknown[]) => unknown).apply(raw, args);
+  }
+  return out as Partial<TeamsDelegatedProvisionerMethods>;
+}
+
+/** The six method names of the delegated half, as data — so the forwarder
+ *  above cannot silently drift from the interface. */
+const DELEGATED_METHOD_NAMES = [
+  'uploadToCatalogDelegated',
+  'startDelegatedSignIn',
+  'pollDelegatedSignIn',
+  'getDelegatedSignInStatus',
+  'refreshDelegatedToken',
+  'revokeDelegatedSignIn',
+] as const satisfies readonly (keyof TeamsDelegatedProvisionerMethods)[];
 
 /**
  * Resolve the provisioner, or `undefined` when the connector plugin is not

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -2145,7 +2145,7 @@ export function createOperatorAgentsRouter(
       try {
         const found = await teamsIdentityRow(req, res, live, deps);
         if (!found) return;
-        const { agent, row } = found;
+        const { row } = found;
         const build = deps.buildAppPackage;
         if (!build) {
           // A capability, not a fault: this mount cannot render a package

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -354,6 +354,24 @@ export interface OperatorTeamsIdentityDeps {
    * never a precondition for reporting it.
    */
   readonly resolveTeamName?: (teamId: string) => Promise<string | null>;
+  /**
+   * Render this identity's Teams app package ON DEMAND (byte5ai/omadia#924).
+   *
+   * BUILT PER REQUEST, NEVER STORED. A package saved at provisioning time
+   * starts drifting the moment the agent's identity is edited — name,
+   * description, accent colour, avatar all feed the manifest — and the
+   * operator would be handed a zip that differs from what a re-run would
+   * upload. Since the render is pure and cheap (`loadPackageAssets` reads
+   * files, `buildAppPackage` is documented "pure, no network"), rebuilding is
+   * both the correct and the simpler answer.
+   *
+   * Optional: a mount without the connector or without the channel-teams
+   * package cannot render one, and the route says so as a capability rather
+   * than 500ing.
+   */
+  readonly buildAppPackage?: (
+    record: OperatorTeamsIdentityRecord,
+  ) => Promise<Uint8Array>;
 }
 
 /**
@@ -381,6 +399,30 @@ export interface OperatorTeamsProvisioningEventRecord {
   readonly status: string;
   readonly attempt: number | null;
   readonly detail: string | null;
+}
+
+/**
+ * Filename stem for a downloaded Teams app package (byte5ai/omadia#924).
+ *
+ * Derived from the BOT slug, because that is the name the package carries into
+ * the Teams catalogue — an operator comparing a download against what is live
+ * matches on that, not on the orchestrator's slug.
+ *
+ * Sanitised rather than trusted: the value lands in a `Content-Disposition`
+ * header, where a quote or a newline is a header-injection primitive. The bot
+ * slug is already constrained upstream (`BOT_SLUG_RE` in
+ * `platform/teamsProvisionerService.ts`), so this narrowing normally changes
+ * nothing — which is exactly the property a defence at a boundary should have.
+ */
+export function teamsPackageFilenameFor(record: {
+  readonly botSlug: string;
+}): string {
+  const safe = record.botSlug
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '')
+    .slice(0, 64);
+  return `omadia-teams-${safe.length > 0 ? safe : 'app'}`;
 }
 
 /** How many events the status endpoint publishes. A run emits roughly a
@@ -2073,6 +2115,77 @@ export function createOperatorAgentsRouter(
     }
     return { agent: { id: existing.id, slug: existing.slug }, row };
   }
+
+  /**
+   * Download this agent's Teams app package (byte5ai/omadia#924).
+   *
+   * A FALLBACK, NOT THE PATH. Provisioning uploads the package itself — since
+   * #924 through the tenant's delegated sign-in, which is what made the
+   * per-agent manual upload unnecessary. This endpoint exists for the cases
+   * that are always left over: a tenant whose policy forbids programmatic
+   * catalog writes, an admin who wants to inspect the manifest before it goes
+   * live, a support conversation. Offering it does not make it the documented
+   * route, and the UI is deliberately explicit about that.
+   *
+   * AVAILABLE WHENEVER IT IS BUILDABLE, not only after a failure. The package
+   * is a pure render of the identity, so gating it on an error state would
+   * have withheld a harmless artefact exactly from the operators calmly
+   * preparing a rollout, and handed it only to the ones already in trouble.
+   *
+   * REBUILT PER REQUEST — see `buildAppPackage` on the deps for why a stored
+   * blob would be a lie.
+   */
+  router.get(
+    '/:slug/teams-identity/package',
+    async (req: Request, res: Response) => {
+      const live = svc();
+      if (!live) return unavailable(res);
+      const deps = teamsIdentity(res);
+      if (!deps) return;
+      try {
+        const found = await teamsIdentityRow(req, res, live, deps);
+        if (!found) return;
+        const { agent, row } = found;
+        const build = deps.buildAppPackage;
+        if (!build) {
+          // A capability, not a fault: this mount cannot render a package
+          // (no connector, or no installed channel-teams package to take the
+          // manifest template and icons from).
+          res.status(501).json({
+            error: 'teams_app_package_unavailable',
+            message:
+              'This deployment cannot render a Teams app package — the M365 connector and the channel-teams plugin package must both be installed.',
+          });
+          return;
+        }
+        const zip = await build(row);
+        // The bot slug, not the agent slug: the package IS the bot, and an
+        // operator with two downloads open needs to tell them apart by the
+        // name that appears in the Teams catalogue.
+        const filename = `${teamsPackageFilenameFor(row)}.zip`;
+        res.setHeader('Content-Type', 'application/zip');
+        res.setHeader(
+          'Content-Disposition',
+          `attachment; filename="${filename}"`,
+        );
+        res.setHeader('Content-Length', String(zip.byteLength));
+        // No caching: the package is rendered from the CURRENT identity, and a
+        // cached copy is the stored-blob drift this endpoint exists to avoid.
+        res.setHeader('Cache-Control', 'no-store');
+        res.status(200).end(Buffer.from(zip));
+      } catch (err) {
+        console.warn(
+          `[operator-agents] Teams app package for '${req.params.slug ?? ''}' could not be rendered:`,
+          err,
+        );
+        res.status(500).json({
+          error: 'teams_app_package_failed',
+          message:
+            'The Teams app package could not be rendered — see the middleware log for the underlying error.',
+        });
+      }
+    },
+  );
 
   router.get('/:slug/teams', async (req: Request, res: Response) => {
     const live = svc();

--- a/middleware/src/routes/operatorTeamsSignIn.ts
+++ b/middleware/src/routes/operatorTeamsSignIn.ts
@@ -1,0 +1,182 @@
+/**
+ * The TENANT-wide Teams sign-in surface (byte5ai/omadia#924).
+ *
+ * WHY ITS OWN ROUTER, AND NOT `/:slug/...` ON `operatorAgents.ts`.
+ * The delegated sign-in is not a property of an agent. One admin signs in
+ * once for the whole directory and every agent provisioned afterwards — past,
+ * present and future — uses that one token set. Hanging it off an agent slug
+ * would have said the opposite in the URL: that each agent has its own
+ * sign-in, which is exactly the per-agent manual step #924 exists to delete.
+ * It would also have forced an arbitrary choice — WHICH agent's URL do you
+ * sign in under? — and made "sign in before you create your first agent"
+ * unrepresentable, even though that is the natural order of operations.
+ *
+ * So it mounts at `/api/v1/operator/teams`, a tenant-scoped sibling of
+ * `/api/v1/operator/agents`, auth-gated by the same `requireAuth` at the
+ * mount. The agent panel LINKS here; it does not host it.
+ *
+ * THE `flowHandle` NEVER LEAVES THE SERVER. `startDelegatedSignIn` returns a
+ * handle that carries the OAuth `device_code` — during the flow's lifetime it
+ * is as good as the credential it becomes. So:
+ *
+ *   * `POST /sign-in` answers with the user code, the verification URL, the
+ *     expiry, the poll interval and the admin-consent URL. No handle.
+ *   * `POST /sign-in/poll` takes NO body at all. The service polls the flow it
+ *     is holding in memory.
+ *
+ * A browser therefore has nothing to leak into a URL bar, a screenshot, a
+ * bug report or a proxy log, and there is no handle for this router to
+ * validate, rate-limit or accidentally echo back in an error.
+ *
+ * NO SECRET IN ANY RESPONSE. Every payload below is built from
+ * `DelegatedSignInPresence` (metadata only — see the token store) or from the
+ * public start view. Nothing here can reach a token: this module never calls
+ * `read()`. That is enforced by construction rather than by review, and pinned
+ * by `teamsDelegatedRedaction.test.ts`.
+ *
+ * ERROR SHAPE follows the house style of `operatorAgents.ts`: `{ ok: true }`
+ * on success, `{ error: '<machine_code>', message }` on failure, and the codes
+ * are a closed vocabulary the UI localizes — never English prose it parses.
+ */
+
+import { Router, type Request, type Response } from 'express';
+
+import {
+  DelegatedSignInUnavailableError,
+  type TeamsDelegatedSignInService,
+} from '../services/teamsDelegatedSignInService.js';
+
+/** Resolved late-bound, like every other operator dependency: the service
+ *  registers only once the vault and the boot wiring exist. */
+export interface OperatorTeamsSignInOptions {
+  readonly getSignIn: () => TeamsDelegatedSignInService | undefined;
+}
+
+/** The 503 this router owns — the sign-in stack is not wired in this mount. */
+const UNAVAILABLE = {
+  error: 'teams_sign_in_unavailable',
+  message:
+    'The tenant Teams sign-in is not wired in this deployment — it registers once the secret vault and the agent-factory boot wiring are available.',
+} as const;
+
+export function createOperatorTeamsSignInRouter(
+  options: OperatorTeamsSignInOptions,
+): Router {
+  const router = Router();
+
+  /** Resolve the service or answer the 503. `undefined` = response sent. */
+  function service(res: Response): TeamsDelegatedSignInService | undefined {
+    const svc = options.getSignIn();
+    if (!svc) {
+      res.status(503).json(UNAVAILABLE);
+      return undefined;
+    }
+    return svc;
+  }
+
+  /**
+   * Turn a service failure into the house error shape.
+   *
+   * A typed {@link DelegatedSignInUnavailableError} carries its own machine
+   * code and maps to 503 (the capability is missing) or 502 (Microsoft refused
+   * the flow) — both are "not the operator's fault", and the distinction is
+   * what tells "upgrade the connector" apart from "look at Conditional
+   * Access". Anything else is a 500 with a generic code: an unclassified
+   * failure must not become copy the UI pretends to understand.
+   */
+  function fail(res: Response, err: unknown): void {
+    if (err instanceof DelegatedSignInUnavailableError) {
+      const status = err.code === 'device_code_flow_failed' ? 502 : 503;
+      res.status(status).json({ error: err.code, message: err.message });
+      return;
+    }
+    console.warn('[operator-teams-signin] request failed:', err);
+    res.status(500).json({
+      error: 'teams_sign_in_failed',
+      message: 'The Teams sign-in request could not be completed.',
+    });
+  }
+
+  /**
+   * Current sign-in state — who is signed in, until when, and whether a
+   * device-code flow is waiting for someone to type the code.
+   *
+   * Also the page's ENTRY POINT after a reload: `pending` comes back
+   * populated, so an operator who refreshed mid-flow gets their code back
+   * instead of having to start over.
+   */
+  router.get('/sign-in', async (_req: Request, res: Response) => {
+    const svc = service(res);
+    if (!svc) return;
+    try {
+      const status = await svc.status();
+      res.json({ ok: true, ...status });
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  /**
+   * Begin a device-code sign-in. 202, because nothing has happened yet — a
+   * human still has to go and type the code.
+   */
+  router.post('/sign-in', async (req: Request, res: Response) => {
+    const svc = service(res);
+    if (!svc) return;
+    try {
+      // The only accepted input, and it is cosmetic: a label the connector may
+      // show on the consent screen. Anything else in the body is ignored
+      // rather than rejected — this endpoint takes no operational parameters.
+      const raw = (req.body as { display_name?: unknown } | undefined)?.display_name;
+      const displayName =
+        typeof raw === 'string' && raw.trim().length > 0
+          ? raw.trim().slice(0, MAX_DISPLAY_NAME_LENGTH)
+          : undefined;
+      const started = await svc.start(
+        displayName !== undefined ? { displayName } : undefined,
+      );
+      res.status(202).json({ ok: true, pending: started });
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  /**
+   * Poll the flow. NO BODY — see the module header: the handle stays here.
+   *
+   * Always 200 with a `status` the UI switches on, including for `declined`
+   * and `expired`: those are outcomes of a flow that worked, not transport
+   * failures, and giving them a 4xx would make a fetch wrapper treat a
+   * legitimate answer as an error.
+   */
+  router.post('/sign-in/poll', async (_req: Request, res: Response) => {
+    const svc = service(res);
+    if (!svc) return;
+    try {
+      res.json({ ok: true, poll: await svc.poll() });
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  /**
+   * Sign out. The local record is dropped even when the remote revoke fails —
+   * see the service — and `remote` reports what Microsoft said, so nothing is
+   * hidden behind a comfortable success.
+   */
+  router.delete('/sign-in', async (_req: Request, res: Response) => {
+    const svc = service(res);
+    if (!svc) return;
+    try {
+      const result = await svc.revoke();
+      res.json({ ok: true, ...result, signIn: await svc.status() });
+    } catch (err) {
+      fail(res, err);
+    }
+  });
+
+  return router;
+}
+
+/** A label on someone else's consent screen has no business being unbounded. */
+const MAX_DISPLAY_NAME_LENGTH = 120;

--- a/middleware/src/services/teamsDelegatedSignInService.ts
+++ b/middleware/src/services/teamsDelegatedSignInService.ts
@@ -1,0 +1,355 @@
+/**
+ * The tenant's delegated Teams sign-in, driven from the operator UI
+ * (byte5ai/omadia#924).
+ *
+ * ONE FLOW AT A TIME, HELD IN THIS PROCESS. `startDelegatedSignIn` returns a
+ * `flowHandle` that CARRIES the OAuth `device_code`. Anyone holding it for the
+ * flow's lifetime can complete the sign-in against Microsoft themselves, which
+ * makes it exactly as sensitive as the token it becomes. So it never leaves
+ * this process:
+ *
+ *   * `start()` keeps the handle here and returns only what a human has to
+ *     read — the user code, the verification URL, the expiry, the poll
+ *     interval and the admin-consent URL.
+ *   * `poll()` takes NO handle from the caller. It uses the one it is holding.
+ *     The browser therefore has nothing to leak, nothing to replay and nothing
+ *     to put in a URL bar.
+ *
+ * WHY IN MEMORY AND NOT IN THE VAULT. The handle is worthless after roughly
+ * fifteen minutes, and a restart mid-flow is an event the operator can see and
+ * answer with one click ("start sign-in" again). Persisting a live device code
+ * would create a durable copy of a credential to buy a convenience nobody
+ * asked for. The TOKENS that come out of the flow are persisted — that is the
+ * whole point — and they go to the vault, not here.
+ *
+ * SINGLE PENDING FLOW, DELIBERATELY. The sign-in is tenant-wide: two operators
+ * starting one concurrently want the same outcome, and a second `start()`
+ * replaces the first rather than racing it. That also bounds this map at one
+ * entry, so there is no expiry sweep to get wrong.
+ *
+ * NOTHING HERE LOGS A SECRET. Every log line and every returned error goes
+ * through `redactDelegated`; the flow handle and both tokens are named in
+ * `DELEGATED_SECRET_KEYS`.
+ */
+
+import {
+  redactDelegated,
+  supportsDelegatedCatalogUpload,
+  type DelegatedRevokeResult,
+  type DelegatedTokenSet,
+  type DeviceCodeStart,
+  type TeamsDelegatedProvisionerMethods,
+} from '../platform/teamsDelegatedSignIn.js';
+import type {
+  DelegatedSignInPresence,
+  TeamsDelegatedTokenStore,
+} from '../platform/teamsDelegatedTokenStore.js';
+
+// ---------------------------------------------------------------------------
+// Ports
+// ---------------------------------------------------------------------------
+
+/** Structural subset of the accessor — only the delegated half is needed. */
+export type DelegatedProvisionerPort = Partial<TeamsDelegatedProvisionerMethods>;
+
+/** Structural subset of {@link TeamsDelegatedTokenStore}. */
+export interface DelegatedTokenCustody {
+  read(): Promise<DelegatedTokenSet | undefined>;
+  write(tokens: DelegatedTokenSet): Promise<void>;
+  clear(): Promise<void>;
+  describe(): Promise<DelegatedSignInPresence>;
+}
+
+export interface TeamsDelegatedSignInServiceOptions {
+  readonly tokens: DelegatedTokenCustody;
+  /** Resolves the live accessor, or `undefined` when no connector is active. */
+  readonly getProvisioner: () => DelegatedProvisionerPort | undefined;
+  readonly now?: () => Date;
+  readonly log?: (msg: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Public shapes — none of them carries a secret
+// ---------------------------------------------------------------------------
+
+/** What the browser is given when a flow starts. NO `flowHandle`. */
+export interface DeviceCodePublicStart {
+  readonly userCode: string;
+  readonly verificationUri: string;
+  readonly expiresAt: string;
+  readonly intervalSeconds: number;
+  readonly scopes: readonly string[];
+  /**
+   * Shown NEXT TO the code, before anything fails. An admin whose sign-in page
+   * demands consent first and who has not been given this URL is stuck with no
+   * way forward — which is the dead end this field exists to prevent.
+   */
+  readonly adminConsentUrl: string;
+}
+
+export type DeviceCodePublicPoll =
+  | { readonly status: 'pending'; readonly retryAfterSeconds: number }
+  | { readonly status: 'succeeded'; readonly signIn: DelegatedSignInPresence }
+  | { readonly status: 'expired'; readonly reason?: string }
+  /**
+   * NOT "the admin clicked cancel". Microsoft returns the same verdict when
+   * Conditional Access, a device-compliance policy or an authentication-method
+   * requirement blocks the flow. The `reason` is what tells the two apart, so
+   * it is carried through and the UI is required to show it rather than
+   * narrating an intent nobody expressed.
+   */
+  | { readonly status: 'declined'; readonly reason?: string }
+  /** No flow is pending in this process — start one (or a restart lost it). */
+  | { readonly status: 'no_flow' };
+
+/** Why an operation could not run. Codes, never prose. */
+export type DelegatedSignInFailureCode =
+  | 'teams_provisioner_unavailable'
+  | 'delegated_sign_in_unsupported'
+  | 'device_code_flow_failed';
+
+export class DelegatedSignInUnavailableError extends Error {
+  constructor(
+    public readonly code: DelegatedSignInFailureCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'DelegatedSignInUnavailableError';
+  }
+}
+
+interface PendingFlow {
+  /** SECRET-GRADE. Never returned, never logged. */
+  readonly flowHandle: string;
+  readonly startedAt: Date;
+  readonly expiresAt: string;
+  readonly public: DeviceCodePublicStart;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class TeamsDelegatedSignInService {
+  private readonly tokens: DelegatedTokenCustody;
+  private readonly getProvisioner: () => DelegatedProvisionerPort | undefined;
+  private readonly now: () => Date;
+  private readonly log: (msg: string) => void;
+  private pending: PendingFlow | undefined;
+
+  constructor(opts: TeamsDelegatedSignInServiceOptions) {
+    this.tokens = opts.tokens;
+    this.getProvisioner = opts.getProvisioner;
+    this.now = opts.now ?? (() => new Date());
+    this.log = opts.log ?? ((m) => console.log(m));
+  }
+
+  /** Is the delegated half available RIGHT NOW? Resolved per call, never
+   *  cached: the connector can be installed or upgraded while we run. */
+  supported(): boolean {
+    return supportsDelegatedCatalogUpload(this.getProvisioner());
+  }
+
+  /**
+   * The sign-in state the operator screen renders, plus whether a device-code
+   * flow is currently waiting for someone to type the code.
+   */
+  async status(): Promise<{
+    readonly supported: boolean;
+    readonly signIn: DelegatedSignInPresence;
+    readonly pending: DeviceCodePublicStart | null;
+  }> {
+    const flow = this.livePending();
+    return {
+      supported: this.supported(),
+      signIn: await this.tokens.describe(),
+      pending: flow?.public ?? null,
+    };
+  }
+
+  /**
+   * Begin a device-code sign-in. Replaces any flow already pending — see the
+   * module header on why that is the right answer for a tenant-wide action.
+   */
+  async start(input?: { readonly displayName?: string }): Promise<DeviceCodePublicStart> {
+    const provisioner = this.requireDelegated();
+    let started: DeviceCodeStart;
+    try {
+      started = await provisioner.startDelegatedSignIn(
+        input?.displayName !== undefined ? { displayName: input.displayName } : {},
+      );
+    } catch (err) {
+      throw this.flowFailure('start', err);
+    }
+    const publicView: DeviceCodePublicStart = {
+      userCode: started.userCode,
+      verificationUri: started.verificationUri,
+      expiresAt: started.expiresAt,
+      // A zero or missing interval would turn the UI poll into a hot loop.
+      intervalSeconds:
+        Number.isFinite(started.intervalSeconds) && started.intervalSeconds > 0
+          ? Math.ceil(started.intervalSeconds)
+          : DEFAULT_POLL_INTERVAL_SECONDS,
+      scopes: started.scopes,
+      adminConsentUrl: started.adminConsentUrl,
+    };
+    this.pending = {
+      flowHandle: started.flowHandle,
+      startedAt: this.now(),
+      expiresAt: started.expiresAt,
+      public: publicView,
+    };
+    // Deliberately no identifiers: the user code is a one-time credential for
+    // the duration of the flow and has no business in a server log either.
+    this.log('[teams-delegated] device-code sign-in started');
+    return publicView;
+  }
+
+  /**
+   * Poll the flow this service is holding. Takes no handle — that is the
+   * point.
+   *
+   * A `succeeded` poll persists the tokens BEFORE it answers, so an operator
+   * who sees "signed in" is looking at a sign-in that survives a restart. The
+   * flow is dropped on every terminal verdict; a `pending` one is kept.
+   */
+  async poll(): Promise<DeviceCodePublicPoll> {
+    const flow = this.livePending();
+    if (!flow) return { status: 'no_flow' };
+    const provisioner = this.requireDelegated();
+    let result;
+    try {
+      result = await provisioner.pollDelegatedSignIn({ flowHandle: flow.flowHandle });
+    } catch (err) {
+      this.pending = undefined;
+      throw this.flowFailure('poll', err);
+    }
+    switch (result.status) {
+      case 'pending':
+        return {
+          status: 'pending',
+          retryAfterSeconds:
+            Number.isFinite(result.retryAfterSeconds) && result.retryAfterSeconds > 0
+              ? Math.ceil(result.retryAfterSeconds)
+              : flow.public.intervalSeconds,
+        };
+      case 'succeeded': {
+        this.pending = undefined;
+        await this.tokens.write(result.tokens);
+        this.log('[teams-delegated] device-code sign-in completed; token set stored');
+        return { status: 'succeeded', signIn: await this.tokens.describe() };
+      }
+      case 'expired':
+        this.pending = undefined;
+        return {
+          status: 'expired',
+          ...(result.reason !== undefined ? { reason: result.reason } : {}),
+        };
+      case 'declined':
+        this.pending = undefined;
+        return {
+          status: 'declined',
+          ...(result.reason !== undefined ? { reason: result.reason } : {}),
+        };
+    }
+  }
+
+  /**
+   * Refresh the stored access token without a human.
+   *
+   * Returns the refreshed presence, or `undefined` when nobody is signed in.
+   * Used by the runner's recovery path for `DelegatedTokenExpiredError` with
+   * `recoverableByRefresh` — a case the operator should never be shown at all.
+   */
+  async refresh(): Promise<DelegatedSignInPresence | undefined> {
+    const current = await this.tokens.read();
+    if (current === undefined) return undefined;
+    const provisioner = this.requireDelegated();
+    const refreshed = await provisioner.refreshDelegatedToken({ tokens: current });
+    await this.tokens.write(refreshed);
+    return this.tokens.describe();
+  }
+
+  /**
+   * Sign out: tell the connector, then forget the record.
+   *
+   * The local clear happens EVEN IF the remote revoke fails or is unsupported.
+   * A middleware that kept credentials it was told to drop because a network
+   * call failed would be holding a token the operator believes is gone; the
+   * remote outcome is reported alongside, so nothing is hidden.
+   */
+  async revoke(): Promise<{
+    readonly cleared: true;
+    readonly remote: DelegatedRevokeResult | null;
+  }> {
+    const current = await this.tokens.read();
+    this.pending = undefined;
+    let remote: DelegatedRevokeResult | null = null;
+    const provisioner = this.getProvisioner();
+    if (current !== undefined && typeof provisioner?.revokeDelegatedSignIn === 'function') {
+      try {
+        remote = provisioner.revokeDelegatedSignIn({ tokens: current });
+      } catch (err) {
+        this.log(
+          `[teams-delegated] remote revoke failed, clearing locally anyway: ${redactedMessage(err)}`,
+        );
+      }
+    }
+    await this.tokens.clear();
+    return { cleared: true, remote };
+  }
+
+  /** The pending flow, unless it has expired — an expired handle is dead
+   *  weight and answering `no_flow` sends the operator to the right button. */
+  private livePending(): PendingFlow | undefined {
+    const flow = this.pending;
+    if (!flow) return undefined;
+    const expiry = Date.parse(flow.expiresAt);
+    if (Number.isFinite(expiry) && expiry <= this.now().getTime()) {
+      this.pending = undefined;
+      return undefined;
+    }
+    return flow;
+  }
+
+  private requireDelegated(): TeamsDelegatedProvisionerMethods {
+    const provisioner = this.getProvisioner();
+    if (provisioner === undefined) {
+      throw new DelegatedSignInUnavailableError(
+        'teams_provisioner_unavailable',
+        'teamsProvisioner@1 is not installed — install and activate the M365 connector plugin before signing in.',
+      );
+    }
+    if (!supportsDelegatedCatalogUpload(provisioner)) {
+      throw new DelegatedSignInUnavailableError(
+        'delegated_sign_in_unsupported',
+        'the installed M365 connector does not publish the delegated Teams sign-in — upgrade it to 0.6.0 or newer.',
+      );
+    }
+    return provisioner as TeamsDelegatedProvisionerMethods;
+  }
+
+  /** Wrap a connector failure as a typed, redacted service error. */
+  private flowFailure(phase: 'start' | 'poll', err: unknown): Error {
+    const message = redactedMessage(err);
+    this.log(`[teams-delegated] device-code ${phase} failed: ${message}`);
+    return new DelegatedSignInUnavailableError('device_code_flow_failed', message);
+  }
+}
+
+/** Microsoft's own floor when the connector reports nothing usable. */
+const DEFAULT_POLL_INTERVAL_SECONDS = 5;
+
+/**
+ * An error's message with every secret-grade field stripped.
+ *
+ * The MESSAGE itself is connector prose and may name an OAuth error code —
+ * that is wanted, it is what tells "Conditional Access blocked this" apart
+ * from "the code expired". What must not travel is anything hanging off the
+ * error object, which is why the object goes through `redactDelegated` and
+ * only the message string comes out.
+ */
+function redactedMessage(err: unknown): string {
+  if (!(err instanceof Error)) return String(redactDelegated(err));
+  return err.message;
+}

--- a/middleware/src/services/teamsDelegatedSignInService.ts
+++ b/middleware/src/services/teamsDelegatedSignInService.ts
@@ -42,7 +42,6 @@ import {
 } from '../platform/teamsDelegatedSignIn.js';
 import type {
   DelegatedSignInPresence,
-  TeamsDelegatedTokenStore,
 } from '../platform/teamsDelegatedTokenStore.js';
 
 // ---------------------------------------------------------------------------
@@ -52,7 +51,7 @@ import type {
 /** Structural subset of the accessor — only the delegated half is needed. */
 export type DelegatedProvisionerPort = Partial<TeamsDelegatedProvisionerMethods>;
 
-/** Structural subset of {@link TeamsDelegatedTokenStore}. */
+/** Structural subset of `TeamsDelegatedTokenStore` (platform/teamsDelegatedTokenStore). */
 export interface DelegatedTokenCustody {
   read(): Promise<DelegatedTokenSet | undefined>;
   write(tokens: DelegatedTokenSet): Promise<void>;

--- a/middleware/src/services/teamsProvisioningJob.ts
+++ b/middleware/src/services/teamsProvisioningJob.ts
@@ -63,6 +63,17 @@ import {
   TEAMS_PROVISIONING_STATES,
   type TeamsProvisioningState,
 } from '../platform/agentTeamsIdentityStore.js';
+import {
+  adminConsentUrlOf,
+  delegatedStepOf,
+  isDelegatedConsentRequiredError,
+  isDelegatedSignInRequiredError,
+  isDelegatedTokenExpiredError,
+  isDeviceCodeFlowError,
+  isRecoverableByRefresh,
+  requiredScopesOf,
+  type DelegatedTokenSet,
+} from '../platform/teamsDelegatedSignIn.js';
 import type { TimerSeam } from '../plugins/jobScheduler.js';
 import type {
   BackgroundJob,
@@ -260,6 +271,40 @@ export const AWAITING_ENTRA_REPLICATION_DETAIL = 'awaiting_entra_replication';
  *  and its id is persisted; what follows is the wait. */
 export const REGISTRATION_CREATED_DETAIL = 'registration_created';
 
+/** `detail` of the `progress` event emitted when the catalog upload runs on
+ *  the tenant's delegated sign-in rather than app-only (#924). No token, no
+ *  account, no flow handle — just the fact, which is what an operator
+ *  watching a stalled panel actually needs. */
+export const DELEGATED_UPLOAD_DETAIL = 'delegated_upload';
+
+/** `detail` of the `progress` event for a silent token rotation. Worth a line
+ *  because it is the one moment the run pauses for a reason that is NOT a
+ *  fault and that the operator would otherwise never see. */
+export const DELEGATED_TOKEN_REFRESHED_DETAIL = 'delegated_token_refreshed';
+
+// ---------------------------------------------------------------------------
+// Delegated token custody port (#924)
+// ---------------------------------------------------------------------------
+
+/**
+ * Where the tenant's delegated token set is kept — a structural subset of
+ * `platform/teamsDelegatedTokenStore.ts`.
+ *
+ * TENANT-SCOPED, NOT AGENT-SCOPED, and that is the whole point of #924: one
+ * admin signs in once, and every agent provisioned afterwards uses that sign-in.
+ * There is deliberately no agent id in this port — adding one would re-create
+ * the per-agent manual upload the feature exists to remove.
+ *
+ * OPTIONAL ON THE RUNNER. A mount without it (and every existing test) behaves
+ * exactly as before: app-only upload, which is correct against a connector
+ * older than 0.6.0 and against a tenant that never needed the delegated path.
+ */
+export interface TeamsDelegatedTokenPort {
+  read(): Promise<DelegatedTokenSet | undefined>;
+  /** Called the instant the connector reports `refreshed === true`. */
+  write(tokens: DelegatedTokenSet): Promise<void>;
+}
+
 // ---------------------------------------------------------------------------
 // Provisioner port (structural subset of TeamsProvisionerAccessor)
 // ---------------------------------------------------------------------------
@@ -331,6 +376,34 @@ export interface TeamsProvisionerPort {
     readonly packageZip: Uint8Array;
     readonly externalId: string;
   }): Promise<Idempotent<{ readonly teamsAppId: string }>>;
+
+  /**
+   * The DELEGATED catalog upload (connector >= 0.6.0, byte5ai/omadia#924).
+   *
+   * OPTIONAL, and the runner feature-detects it exactly like every other
+   * version-skewed method: absent means an older connector, which keeps using
+   * the app-only {@link uploadToCatalog} above and keeps failing the way it
+   * always did against a tenant that requires delegated permissions.
+   *
+   * Returns the token set it used, with `refreshed` telling the caller whether
+   * it rotated — a rotation MUST be persisted immediately or the next run
+   * signs in from scratch.
+   */
+  uploadToCatalogDelegated?(input: {
+    readonly packageZip: Uint8Array;
+    readonly externalId: string;
+    readonly tokens: DelegatedTokenSet;
+  }): Promise<{
+    readonly app: { readonly value: { readonly teamsAppId: string } };
+    readonly tokens: DelegatedTokenSet;
+    readonly refreshed: boolean;
+  }>;
+
+  /** Silent token refresh (connector >= 0.6.0). Optional for the same
+   *  reason; without it an expired access token needs a human. */
+  refreshDelegatedToken?(input: {
+    readonly tokens: DelegatedTokenSet;
+  }): Promise<DelegatedTokenSet>;
 
   getCatalogApp(input: {
     readonly teamsAppExternalId: string;
@@ -533,9 +606,33 @@ export type ProvisioningRunResult =
       readonly missingSetupFields: readonly string[];
     }
   | {
+      /**
+       * #924 — the delegated catalog upload cannot proceed until a tenant
+       * admin has signed in (or consented). NOT a failure: every step already
+       * taken is real, the row keeps its state, and the run resumes from here
+       * the moment the sign-in exists. A run that fell to `failed` because
+       * nobody had signed in yet would send an operator hunting a fault that
+       * is not there — and would drop the chain's evidence with it.
+       */
+      readonly status: 'halted';
+      readonly agentId: string;
+      readonly reason:
+        | 'delegated_sign_in_required'
+        | 'delegated_consent_required'
+        | 'delegated_token_expired';
+      readonly detail: string;
+    }
+  | {
       readonly status: 'failed';
       readonly agentId: string;
-      readonly reason: 'consent_missing' | 'bot_handle_unavailable' | 'error';
+      readonly reason:
+        | 'consent_missing'
+        | 'bot_handle_unavailable'
+        /** #924 — the device-code flow itself is broken (publisher app not
+         *  configured for it, Conditional Access refusing it). Terminal:
+         *  retrying the same flow produces the same refusal. */
+        | 'device_code_flow_failed'
+        | 'error';
       readonly detail: string;
     }
   | {
@@ -617,6 +714,11 @@ export interface TeamsProvisioningJobOptions {
    * run is identical, it simply leaves no timeline behind.
    */
   readonly events?: TeamsProvisioningEventSink;
+  /**
+   * #924 — the tenant's delegated token set. Absent means app-only catalog
+   * upload, i.e. exactly the pre-0.6.0 behaviour.
+   */
+  readonly delegatedTokens?: TeamsDelegatedTokenPort;
   readonly log?: (msg: string) => void;
 }
 
@@ -650,6 +752,7 @@ export class TeamsProvisioningJobRunner {
     | ((teamId: string) => Promise<string | null>)
     | undefined;
   private readonly events: TeamsProvisioningEventSink | undefined;
+  private readonly delegatedTokens: TeamsDelegatedTokenPort | undefined;
   private readonly log: (msg: string) => void;
 
   /**
@@ -697,6 +800,7 @@ export class TeamsProvisioningJobRunner {
     this.installs = opts.installs;
     this.resolveTeamName = opts.resolveTeamName;
     this.events = opts.events;
+    this.delegatedTokens = opts.delegatedTokens;
     this.log = opts.log ?? ((m) => console.log(m));
   }
 
@@ -1007,6 +1111,62 @@ export class TeamsProvisioningJobRunner {
       return { status: 'failed', agentId, reason: 'bot_handle_unavailable', detail };
     }
 
+    // #924 — THE FOUR DELEGATED ERRORS, EACH WITH A DIFFERENT INSTRUCTION.
+    // They are classified before the throttle/deterministic paths below
+    // because none of them is a transport problem and none is fixable by
+    // retrying: three need a specific human action and the fourth needs a
+    // configuration change on the publisher app. Collapsing them into one
+    // "delegated failed" would collapse four different instructions into an
+    // operator staring at a dead end.
+    //
+    // Three of the four PARK rather than fail. The Entra app, the Azure bot
+    // and the built package all exist and are this agent's; the only thing
+    // missing is a sign-in. A row that dropped to `failed` would throw that
+    // evidence away and re-walk the chain on the next run.
+
+    if (isDelegatedSignInRequiredError(err)) {
+      const detail = delegatedSignInRequiredDetail(
+        requiredScopesOf(err),
+        delegatedStepOf(err),
+      );
+      await this.recordError(agentId, { lastError: detail });
+      return { status: 'halted', agentId, reason: 'delegated_sign_in_required', detail };
+    }
+
+    if (isDelegatedConsentRequiredError(err)) {
+      // The consent URL is the difference between an actionable message and a
+      // dead end, so it travels in `last_error` — it is a public Microsoft URL
+      // naming a tenant and a client id, not a credential. It is validated as
+      // absolute https by `adminConsentUrlOf` before it gets anywhere near a
+      // link, and it is NOT put into a progress-event detail.
+      const detail = delegatedConsentRequiredDetail(
+        requiredScopesOf(err),
+        adminConsentUrlOf(err),
+      );
+      await this.recordError(agentId, { lastError: detail });
+      return { status: 'halted', agentId, reason: 'delegated_consent_required', detail };
+    }
+
+    if (isDelegatedTokenExpiredError(err)) {
+      // The refreshable case is recovered inside `uploadPackage` and never
+      // reaches here; arriving with one means the refresh itself failed, which
+      // has the same answer as the invalid one — sign in again. Its OWN code,
+      // though, not `delegated_sign_in_required`: "your sign-in expired" and
+      // "nobody has ever signed in" send an operator to the same button for
+      // different reasons, and only one of them is worth investigating.
+      const detail = delegatedTokenExpiredDetail(err.reason);
+      await this.recordError(agentId, { lastError: detail });
+      return { status: 'halted', agentId, reason: 'delegated_token_expired', detail };
+    }
+
+    if (isDeviceCodeFlowError(err)) {
+      // TERMINAL and DETERMINISTIC: the flow is refused by configuration, not
+      // by load. Retrying it five times produces five identical refusals.
+      const detail = deviceCodeFlowFailedDetail(errorMessage(err), err.oauthError);
+      await this.recordError(agentId, { state: 'failed', lastError: detail });
+      return { status: 'failed', agentId, reason: 'device_code_flow_failed', detail };
+    }
+
     const throttle = throttleHintOf(err);
 
     if (throttle === undefined && isDeterministicRequestFailure(err)) {
@@ -1180,12 +1340,18 @@ export class TeamsProvisioningJobRunner {
         params: assets.params,
         icons: assets.icons,
       });
-      const uploaded = await provisioner.uploadToCatalog({
+      // Same upload path as the chain's step 4 — a republish that bypassed it
+      // would be the one code path still doing an app-only upload, which is
+      // precisely the call Microsoft refuses (#924).
+      const uploaded = await this.uploadPackage(
+        agentId,
+        provisioner,
         packageZip,
-        externalId: assets.externalId,
-      });
+        assets.externalId,
+      );
+      if (uploaded.kind === 'sign_in_required') return uploaded.result;
       row = await this.store.update(agentId, {
-        teamsAppId: uploaded.value.teamsAppId,
+        teamsAppId: uploaded.teamsAppId,
         teamsAppExternalId: assets.externalId,
         lastError: null,
       });
@@ -1323,11 +1489,17 @@ export class TeamsProvisioningJobRunner {
             params: assets.params,
             icons: assets.icons,
           });
-          const uploaded = await provisioner.uploadToCatalog({
+          const uploaded = await this.uploadPackage(
+            agentId,
+            provisioner,
             packageZip,
-            externalId: assets.externalId,
-          });
-          teamsAppId = uploaded.value.teamsAppId;
+            assets.externalId,
+          );
+          // PARKED, not failed: the package is built and every earlier step
+          // is real. The row keeps `package_built`, `last_error` says which
+          // human action is missing, and the next run resumes right here.
+          if (uploaded.kind === 'sign_in_required') return uploaded.result;
+          teamsAppId = uploaded.teamsAppId;
         }
       }
       row = await this.store.update(agentId, {
@@ -1376,6 +1548,113 @@ export class TeamsProvisioningJobRunner {
     // write and deliberately unable to change it.
     await this.syncTeamsBotsConfig(row);
     return { status: 'installed', agentId };
+  }
+
+  // -------------------------------------------------------------------------
+  // Catalog upload (#924)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Upload the rendered package to the tenant catalog — delegated when the
+   * connector can, app-only when it cannot.
+   *
+   * WHY THIS BRANCH EXISTS AT ALL. `POST /appCatalogs/teamsApps` is
+   * delegated-only at Microsoft; Application permissions are documented as
+   * "Not supported". So the app-only call below is the ONE step of the whole
+   * chain that a fully-consented tenant still refuses, and a connector that
+   * publishes `uploadToCatalogDelegated` (>= 0.6.0) is the only way to do it
+   * properly — on a token set a tenant admin produced by signing in once.
+   *
+   * NOT SIGNED IN IS NOT A FAILURE. It is the absence of a human action, so
+   * this parks rather than throws: it returns a `halted` result the caller
+   * turns into "keep the state, record what is missing, resume later".
+   * Letting the connector throw and classifying it downstream would work too,
+   * but it would burn the retry budget on a condition no retry can fix and
+   * make the first run of a fresh install look broken.
+   *
+   * A ROTATED TOKEN IS PERSISTED IMMEDIATELY, before the upload's result is
+   * used for anything else. Had the process died between the connector
+   * rotating and us writing, the refresh token still in the vault would
+   * already have been spent — and the tenant would be silently signed out
+   * until the next run failed and somebody investigated.
+   */
+  private async uploadPackage(
+    agentId: string,
+    provisioner: TeamsProvisionerPort,
+    packageZip: Uint8Array,
+    externalId: string,
+  ): Promise<
+    | { readonly kind: 'uploaded'; readonly teamsAppId: string }
+    | { readonly kind: 'sign_in_required'; readonly result: ProvisioningRunResult }
+  > {
+    const delegatedUpload = provisioner.uploadToCatalogDelegated;
+    const custody = this.delegatedTokens;
+    // Feature detection, not configuration: an older connector and a mount
+    // without token custody both mean "app-only", which is what this
+    // middleware did before #924 and stays correct for those deployments.
+    if (typeof delegatedUpload !== 'function' || custody === undefined) {
+      const uploaded = await provisioner.uploadToCatalog({ packageZip, externalId });
+      return { kind: 'uploaded', teamsAppId: uploaded.value.teamsAppId };
+    }
+
+    const tokens = await custody.read();
+    if (tokens === undefined) {
+      const detail = delegatedSignInRequiredDetail([]);
+      // State deliberately untouched — every step already taken is real, and
+      // the row's own rank is what makes the next run resume from here.
+      await this.recordError(agentId, { lastError: detail });
+      return {
+        kind: 'sign_in_required',
+        result: {
+          status: 'halted',
+          agentId,
+          reason: 'delegated_sign_in_required',
+          detail,
+        },
+      };
+    }
+
+    // The one honest thing the runner can say from outside another repo's
+    // call: which credential this upload rides on. No token, no account, no
+    // flow handle — this column is read by a screen.
+    await this.emit(agentId, 'catalog_uploaded', 'progress', {
+      detail: DELEGATED_UPLOAD_DETAIL,
+    });
+
+    const attemptUpload = async (set: DelegatedTokenSet): Promise<string> => {
+      const result = await delegatedUpload.call(provisioner, {
+        packageZip,
+        externalId,
+        tokens: set,
+      });
+      if (result.refreshed) {
+        await custody.write(result.tokens);
+        await this.emit(agentId, 'catalog_uploaded', 'progress', {
+          detail: DELEGATED_TOKEN_REFRESHED_DETAIL,
+        });
+      }
+      return result.app.value.teamsAppId;
+    };
+
+    try {
+      return { kind: 'uploaded', teamsAppId: await attemptUpload(tokens) };
+    } catch (err) {
+      // The ONE delegated failure an operator must never be shown: an access
+      // token past its expiry with a refresh token that is still good. It is
+      // recovered right here — refresh, retry once — because surfacing it
+      // would ask a human to fix something no human needs to touch. Anything
+      // else, INCLUDING a refresh that itself fails, travels on to
+      // {@link handleFailure}, which is where the four errors are told apart.
+      if (!isDelegatedTokenExpiredError(err) || !isRecoverableByRefresh(err)) throw err;
+      const refresh = provisioner.refreshDelegatedToken;
+      if (typeof refresh !== 'function') throw err;
+      const rotated = await refresh.call(provisioner, { tokens });
+      await custody.write(rotated);
+      await this.emit(agentId, 'catalog_uploaded', 'progress', {
+        detail: DELEGATED_TOKEN_REFRESHED_DETAIL,
+      });
+      return { kind: 'uploaded', teamsAppId: await attemptUpload(rotated) };
+    }
   }
 
   /**
@@ -1574,12 +1853,96 @@ export function configSyncFailedDetail(reason: string): string {
  *  producer and the classifier so the empty case round-trips. */
 const CONFIG_SYNC_REASON_UNSPECIFIED = 'no reason reported';
 
+// ---------------------------------------------------------------------------
+// The delegated sentences (#924)
+//
+// Four codes for four errors, because each one sends the operator somewhere
+// else: start a sign-in, send an admin to a consent URL, sign in again, or go
+// look at the publisher app's device-code / Conditional Access configuration.
+// A single `delegated_failed` code would have been shorter and would have made
+// the panel useless.
+// ---------------------------------------------------------------------------
+
+export const DELEGATED_SIGN_IN_REQUIRED_PREFIX = 'delegated_sign_in_required:';
+export const DELEGATED_CONSENT_REQUIRED_PREFIX = 'delegated_consent_required:';
+export const DELEGATED_TOKEN_EXPIRED_PREFIX = 'delegated_token_expired:';
+export const DEVICE_CODE_FLOW_FAILED_PREFIX = 'device_code_flow_failed:';
+
+/** Token carrying the admin-consent URL. Its own `key=value` rather than a
+ *  second bracket group, because a URL and a comma-split list do not mix. */
+const CONSENT_URL_TOKEN = 'consent_url=';
+
+/** Bracket filler for "the connector named no scopes", shared by producer and
+ *  classifier so the empty case round-trips to `[]`. */
+const DELEGATED_SCOPES_UNSPECIFIED = 'the delegated Teams scopes';
+
+/** Nobody is signed in for this tenant — the ordinary state of a fresh
+ *  install, and the reason the very first agent cannot reach the catalog. */
+export function delegatedSignInRequiredDetail(
+  requiredScopes: readonly string[],
+  step?: string,
+): string {
+  const scopes =
+    requiredScopes.length > 0
+      ? requiredScopes.join(', ')
+      : DELEGATED_SCOPES_UNSPECIFIED;
+  const where = step !== undefined ? ` (step: ${step.replace(/[[\]]/g, '')})` : '';
+  return `${DELEGATED_SIGN_IN_REQUIRED_PREFIX} the Teams app catalog upload is delegated-only at Microsoft, so it needs a tenant admin signed in with [${scopes}]${where} — sign in once under Teams sign-in; every agent provisioned afterwards uses it automatically`;
+}
+
+/** Signed in, but the scopes were never consented to. A DIFFERENT person may
+ *  be needed here (a global admin), which is why it is not the same code. */
+export function delegatedConsentRequiredDetail(
+  requiredScopes: readonly string[],
+  adminConsentUrl?: string,
+): string {
+  const scopes =
+    requiredScopes.length > 0
+      ? requiredScopes.join(', ')
+      : DELEGATED_SCOPES_UNSPECIFIED;
+  const link =
+    adminConsentUrl !== undefined ? ` ${CONSENT_URL_TOKEN}${adminConsentUrl}` : '';
+  return `${DELEGATED_CONSENT_REQUIRED_PREFIX} a tenant admin still has to grant consent for [${scopes}] before the delegated catalog upload is allowed — open the consent URL, approve, then re-run provisioning${link}`;
+}
+
+/**
+ * The sign-in itself is spent. The refreshable variant never reaches an
+ * operator (see `uploadPackage`), so a row carrying this sentence means the
+ * refresh token is gone — a re-sign-in, not a wait.
+ */
+export function delegatedTokenExpiredDetail(reason?: string): string {
+  const because =
+    reason === 'access-token-expired'
+      ? 'the access token expired and could not be refreshed'
+      : 'the refresh token is no longer valid';
+  return `${DELEGATED_TOKEN_EXPIRED_PREFIX} ${because} — the stored tenant sign-in cannot be used any more; sign in again under Teams sign-in, then re-run provisioning`;
+}
+
+/**
+ * The device-code flow is refused by configuration. Not the operator's tenant
+ * data — the publisher app itself, or a Conditional Access policy that will
+ * not let a device-code sign-in through.
+ */
+export function deviceCodeFlowFailedDetail(
+  message: string,
+  oauthError?: string,
+): string {
+  const safe = message.replace(/[[\]]/g, '').replace(/\s+/g, ' ').trim();
+  const code = oauthError !== undefined ? ` [${oauthError.replace(/[[\]]/g, '')}]` : '';
+  return `${DEVICE_CODE_FLOW_FAILED_PREFIX}${code} ${safe.length > 0 ? safe : 'the device-code sign-in was refused'} — check that the M365 connector's publisher app allows public-client device-code flows and that no Conditional Access policy blocks them`;
+}
+
 export type TeamsProvisioningErrorCode =
   | 'consent_missing'
   | 'arm_not_configured'
   | 'throttled'
   | 'config_sync_failed'
   | 'bot_handle_unavailable'
+  /** #924 — the four delegated codes, one per producer above. */
+  | 'delegated_sign_in_required'
+  | 'delegated_consent_required'
+  | 'delegated_token_expired'
+  | 'device_code_flow_failed'
   | 'unknown';
 
 /** Structured projection of one `last_error` sentence. `raw` is always the
@@ -1593,6 +1956,13 @@ export interface TeamsProvisioningErrorDetail {
   readonly fields?: readonly string[];
   /** Connector `Retry-After` hint in seconds (`throttled`), when it had one. */
   readonly retryAfterSeconds?: number;
+  /**
+   * Where an admin grants the delegated scopes (`delegated_consent_required`).
+   * Absolute https by construction — `adminConsentUrlOf` rejects anything
+   * else before the sentence is ever written, so a UI may render it as a link
+   * without re-validating.
+   */
+  readonly adminConsentUrl?: string;
   /** Why the automatic `teams_bots` write did not land (`config_sync_failed`).
    *  A technical sentence, shown as the argument of a localized line — never
    *  as the copy itself. */
@@ -1613,6 +1983,24 @@ function bracketList(sentence: string, sentinel?: string): readonly string[] {
     return [];
   }
   return entries;
+}
+
+/**
+ * The `consent_url=` token of a `delegated_consent_required` sentence.
+ *
+ * Re-validated as absolute https on the way OUT as well as on the way in: the
+ * sentence is a database column, and a row written by an older build (or edited
+ * by hand) must not be able to put a `javascript:` href in front of an
+ * operator. Cheap, and the only alternative is trusting stored text.
+ */
+function consentUrlOf(sentence: string): string | undefined {
+  const raw = new RegExp(`${CONSENT_URL_TOKEN}(\\S+)`).exec(sentence)?.[1];
+  if (raw === undefined) return undefined;
+  try {
+    return new URL(raw).protocol === 'https:' ? raw : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -1643,6 +2031,36 @@ export function classifyTeamsProvisioningError(
     return {
       code: 'config_sync_failed',
       reason: inner === CONFIG_SYNC_REASON_UNSPECIFIED ? '' : inner,
+      raw,
+    };
+  }
+  // #924 — the four delegated codes. Each keeps whatever the producer
+  // captured, so the panel can name the scopes and link the consent URL
+  // instead of telling the operator to "check the logs".
+  if (sentence.startsWith(DELEGATED_SIGN_IN_REQUIRED_PREFIX)) {
+    return {
+      code: 'delegated_sign_in_required',
+      scopes: bracketList(sentence, DELEGATED_SCOPES_UNSPECIFIED),
+      raw,
+    };
+  }
+  if (sentence.startsWith(DELEGATED_CONSENT_REQUIRED_PREFIX)) {
+    const url = consentUrlOf(sentence);
+    return {
+      code: 'delegated_consent_required',
+      scopes: bracketList(sentence, DELEGATED_SCOPES_UNSPECIFIED),
+      ...(url !== undefined ? { adminConsentUrl: url } : {}),
+      raw,
+    };
+  }
+  if (sentence.startsWith(DELEGATED_TOKEN_EXPIRED_PREFIX)) {
+    return { code: 'delegated_token_expired', raw };
+  }
+  if (sentence.startsWith(DEVICE_CODE_FLOW_FAILED_PREFIX)) {
+    const inner = /\[([^\]]*)\]/.exec(sentence)?.[1]?.trim() ?? '';
+    return {
+      code: 'device_code_flow_failed',
+      ...(inner !== '' ? { reason: inner } : {}),
       raw,
     };
   }

--- a/middleware/test/teamsAppPackageDownload.test.ts
+++ b/middleware/test/teamsAppPackageDownload.test.ts
@@ -1,0 +1,202 @@
+/**
+ * `GET /:slug/teams-identity/package` — the download fallback (byte5ai/omadia#924).
+ *
+ * WHAT THIS PINS:
+ *
+ *   - IT SERVES A ZIP, with the headers a browser needs to save it. A route
+ *     that answered JSON, or omitted `Content-Disposition`, would render as a
+ *     wall of binary in a tab instead of a file on disk.
+ *   - IT REBUILDS PER REQUEST. Two calls either side of an identity edit must
+ *     produce different bytes; a cached or stored blob would hand the operator
+ *     a package that differs from what provisioning would upload — the exact
+ *     drift this endpoint was designed to avoid.
+ *   - IT IS AVAILABLE WHENEVER IT IS BUILDABLE, not only after a failure. The
+ *     package is a pure render, so gating it on an error state would withhold
+ *     a harmless artefact from every operator calmly preparing a rollout.
+ *   - THE FILENAME IS SAFE. It lands in a response header, where a quote or a
+ *     newline is a header-injection primitive.
+ *   - A MOUNT THAT CANNOT RENDER SAYS SO (501), rather than 500ing.
+ */
+
+import { strict as assert } from 'node:assert';
+import { after, before, describe, it } from 'node:test';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+
+import express from 'express';
+
+import type { ConfigStore, OrchestratorRegistry } from '@omadia/orchestrator';
+
+import {
+  createOperatorAgentsRouter,
+  teamsPackageFilenameFor,
+  type OperatorTeamsIdentityRecord,
+} from '../src/routes/operatorAgents.js';
+import { listenLoopback } from './_helpers/listenLoopback.js';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeConfigStore {
+  getAgentBySlug(
+    slug: string,
+  ): Promise<{ id: string; slug: string; name: string } | undefined> {
+    return Promise.resolve(
+      slug === 'hr' ? { id: 'agent-1', slug: 'hr', name: 'HR' } : undefined,
+    );
+  }
+}
+
+const ROW: OperatorTeamsIdentityRecord = {
+  agentId: 'agent-1',
+  botSlug: 'hr',
+  displayName: 'HR Bot',
+  state: 'installed',
+  teamId: 'team-1',
+  appId: 'app-1',
+  tenantId: 'tenant-1',
+  teamsAppId: 'teams-app-1',
+  teamsAppExternalId: 'external-1',
+  lastError: null,
+};
+
+describe('#924 Teams app package download', () => {
+  let server: Server;
+  let baseUrl: string;
+  let row: OperatorTeamsIdentityRecord | undefined = ROW;
+  let canBuild = true;
+  let buildCalls = 0;
+  /** Stands in for the identity that feeds the manifest — changing it must
+   *  change the bytes, which is the whole "rebuild, never store" claim. */
+  let manifestRevision = 1;
+
+  before(async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/api/v1/operator/agents',
+      createOperatorAgentsRouter({
+        getConfigStore: () => new FakeConfigStore() as unknown as ConfigStore,
+        getRegistry: () =>
+          ({ reload: () => Promise.resolve() }) as unknown as OrchestratorRegistry,
+        getChatSessionStore: () => undefined,
+        getTeamsIdentity: () => ({
+          store: {
+            getByAgentId: () => Promise.resolve(row),
+            ensureForAgent: () => Promise.resolve(ROW),
+          },
+          runner: {
+            enqueue: () => Promise.resolve(undefined),
+            isRunning: () => false,
+            runningTeamId: () => null,
+          },
+          isProvisionerInstalled: () => true,
+          ...(canBuild
+            ? {
+                buildAppPackage: (record: OperatorTeamsIdentityRecord) => {
+                  buildCalls += 1;
+                  // A stand-in render: the bytes depend on the CURRENT
+                  // identity, exactly as the real manifest does.
+                  return Promise.resolve(
+                    new TextEncoder().encode(
+                      `PK-fake-zip:${record.botSlug}:rev${String(manifestRevision)}`,
+                    ),
+                  );
+                },
+              }
+            : {}),
+        }),
+      }),
+    );
+    server = await listenLoopback(app);
+    const addr = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${String(addr.port)}/api/v1/operator/agents`;
+  });
+
+  after(async () => {
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  it('serves the package as a saveable zip', async () => {
+    const res = await fetch(`${baseUrl}/hr/teams-identity/package`);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('content-type'), 'application/zip');
+    assert.match(
+      res.headers.get('content-disposition') ?? '',
+      /^attachment; filename="omadia-teams-hr\.zip"$/,
+    );
+    // Never cached: a cached copy is the stored-blob drift this route avoids.
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+    const body = Buffer.from(await res.arrayBuffer());
+    assert.equal(body.toString(), 'PK-fake-zip:hr:rev1');
+    assert.equal(res.headers.get('content-length'), String(body.byteLength));
+  });
+
+  it('rebuilds on every request, so an identity edit reaches the download', async () => {
+    const before = buildCalls;
+    const first = await (await fetch(`${baseUrl}/hr/teams-identity/package`)).text();
+    manifestRevision = 2; // the operator renames the agent
+    const second = await (await fetch(`${baseUrl}/hr/teams-identity/package`)).text();
+
+    assert.equal(buildCalls, before + 2, 'both requests rendered');
+    assert.notEqual(first, second, 'a stored blob would have returned stale bytes');
+    manifestRevision = 1;
+  });
+
+  it('is offered on a healthy identity, not only after a failure', async () => {
+    // ROW is `installed` with no last_error — the calm case.
+    const res = await fetch(`${baseUrl}/hr/teams-identity/package`);
+    assert.equal(res.status, 200);
+  });
+
+  it('404s for an unknown agent and for an agent without an identity row', async () => {
+    const unknownAgent = await fetch(`${baseUrl}/ghost/teams-identity/package`);
+    assert.equal(unknownAgent.status, 404);
+
+    row = undefined;
+    const noIdentity = await fetch(`${baseUrl}/hr/teams-identity/package`);
+    assert.equal(noIdentity.status, 404);
+    assert.equal(
+      ((await noIdentity.json()) as { error: string }).error,
+      'teams_identity_not_found',
+    );
+    row = ROW;
+  });
+
+  it('501s with a capability code when this mount cannot render a package', async () => {
+    canBuild = false;
+    // The dependency is resolved per request, so flipping it takes effect
+    // without rebuilding the router — same as a connector being removed.
+    const res = await fetch(`${baseUrl}/hr/teams-identity/package`);
+    assert.equal(res.status, 501);
+    assert.equal(
+      ((await res.json()) as { error: string }).error,
+      'teams_app_package_unavailable',
+    );
+    canBuild = true;
+  });
+});
+
+describe('#924 teamsPackageFilenameFor', () => {
+  it('names the file after the BOT slug — what appears in the Teams catalogue', () => {
+    assert.equal(teamsPackageFilenameFor({ botSlug: 'sales' }), 'omadia-teams-sales');
+  });
+
+  it('cannot smuggle a header break or a quote into Content-Disposition', () => {
+    const hostile = teamsPackageFilenameFor({
+      botSlug: 'a"b\r\nX-Injected: yes',
+    });
+    for (const forbidden of ['"', '\r', '\n', ':', ' ']) {
+      assert.equal(
+        hostile.includes(forbidden),
+        false,
+        `filename must not contain ${JSON.stringify(forbidden)}`,
+      );
+    }
+  });
+
+  it('falls back to a usable name rather than an empty one', () => {
+    assert.equal(teamsPackageFilenameFor({ botSlug: '---' }), 'omadia-teams-app');
+  });
+});

--- a/middleware/test/teamsDelegatedRedaction.test.ts
+++ b/middleware/test/teamsDelegatedRedaction.test.ts
@@ -1,0 +1,424 @@
+/**
+ * THE SECURITY TEST of byte5ai/omadia#924: neither token nor `flowHandle`ns
+ * ever reaches a log, an error, or an API response.
+ *
+ * This file is not "nice coverage". The feature stores bearer credentials for
+ * a signed-in global admin and, for fifteen minutes at a time, a device code
+ * that anyone holding it can redeem for those credentials. Every other test in
+ * this change proves the feature WORKS; this one proves it does not leak, and
+ * it is the one that must never be deleted to make a refactor pass.
+ *
+ * Four surfaces are checked, because those are the four ways the values could
+ * get out:
+ *
+ *   1. THE REDACTOR itself — the choke point every log and error path uses.
+ *   2. THE TOKEN STORE's operator-facing projection (`describe`), which is the
+ *      only thing routes are allowed to render.
+ *   3. THE SIGN-IN SERVICE's public surface — start, poll, status, revoke —
+ *      including its LOG OUTPUT, captured and searched.
+ *   4. THE ROUTER's actual HTTP responses, searched as raw bytes. A leak that
+ *      survives every unit-level guard still has to cross this wire, so this
+ *      is the assertion that holds even if the shapes above are refactored.
+ *
+ * The sentinels are deliberately absurd, unique strings: a substring search
+ * over serialized output cannot produce a false negative for them, and a false
+ * positive would mean the value really is there.
+ */
+
+import { strict as assert } from 'node:assert';
+import { after, before, describe, it } from 'node:test';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+
+import express from 'express';
+
+import {
+  redactDelegated,
+  summarizeTokenSet,
+  type DelegatedTokenSet,
+  type DeviceCodeStart,
+  type TeamsDelegatedProvisionerMethods,
+} from '../src/platform/teamsDelegatedSignIn.js';
+import { TeamsDelegatedTokenStore } from '../src/platform/teamsDelegatedTokenStore.js';
+import { TeamsDelegatedSignInService } from '../src/services/teamsDelegatedSignInService.js';
+import { createOperatorTeamsSignInRouter } from '../src/routes/operatorTeamsSignIn.js';
+import { listenLoopback } from './_helpers/listenLoopback.js';
+
+// ---------------------------------------------------------------------------
+// Sentinels — every one of these must be unfindable in anything we emit.
+// ---------------------------------------------------------------------------
+
+const ACCESS_TOKEN = 'SENTINEL-ACCESS-TOKEN-2f4b9c';
+const REFRESH_TOKEN = 'SENTINEL-REFRESH-TOKEN-7ad13e';
+const FLOW_HANDLE = 'SENTINEL-FLOW-HANDLE-c0ffee01';
+
+const SECRETS = [ACCESS_TOKEN, REFRESH_TOKEN, FLOW_HANDLE] as const;
+
+function tokenSet(): DelegatedTokenSet {
+  return {
+    accessToken: ACCESS_TOKEN,
+    refreshToken: REFRESH_TOKEN,
+    expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+    scopes: ['AppCatalog.Submit'],
+    clientId: 'client-1',
+    tenantId: 'tenant-1',
+    account: { username: 'admin@contoso.test', displayName: 'Ada Admin' },
+  };
+}
+
+function deviceCodeStart(): DeviceCodeStart {
+  return {
+    userCode: 'ABCD-EFGH',
+    verificationUri: 'https://microsoft.com/devicelogin',
+    expiresAt: new Date(Date.now() + 900_000).toISOString(),
+    intervalSeconds: 5,
+    flowHandle: FLOW_HANDLE,
+    scopes: ['AppCatalog.Submit'],
+    adminConsentUrl: 'https://login.microsoftonline.com/tenant-1/adminconsent',
+  };
+}
+
+/** Assert a haystack contains none of the sentinels, naming which one leaked. */
+function assertNoSecrets(haystack: string, where: string): void {
+  for (const secret of SECRETS) {
+    assert.equal(
+      haystack.includes(secret),
+      false,
+      `${where} leaked the secret ${secret}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory vault double — the same two-argument namespace/key shape the real
+// `SecretVault` exposes and `McpRegistrySecretService` already relies on.
+// ---------------------------------------------------------------------------
+
+class FakeVault {
+  public readonly entries = new Map<string, string>();
+
+  get(ns: string, key: string): Promise<string | undefined> {
+    return Promise.resolve(this.entries.get(`${ns}::${key}`));
+  }
+
+  set(ns: string, key: string, value: string): Promise<void> {
+    this.entries.set(`${ns}::${key}`, value);
+    return Promise.resolve();
+  }
+
+  deleteKey(ns: string, key: string): Promise<void> {
+    this.entries.delete(`${ns}::${key}`);
+    return Promise.resolve();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. The redactor
+// ---------------------------------------------------------------------------
+
+describe('#924 redactDelegated', () => {
+  it('strips every secret-grade key, at any depth, in both casings', () => {
+    const payload = {
+      accessToken: ACCESS_TOKEN,
+      access_token: ACCESS_TOKEN,
+      nested: {
+        tokens: { refreshToken: REFRESH_TOKEN, refresh_token: REFRESH_TOKEN },
+        list: [{ flowHandle: FLOW_HANDLE }, { device_code: FLOW_HANDLE }],
+      },
+      keep: 'this-must-survive',
+    };
+    const cleaned = redactDelegated(payload);
+    assertNoSecrets(JSON.stringify(cleaned), 'redactDelegated');
+    // A redactor that solved the problem by dropping everything would pass the
+    // assertion above and be useless.
+    assert.equal((cleaned as { keep: string }).keep, 'this-must-survive');
+  });
+
+  it('never throws on the shapes a log path actually hands it', () => {
+    for (const value of [null, undefined, 42, 'text', new Date(), [1, [2, [3]]]]) {
+      assert.doesNotThrow(() => redactDelegated(value));
+    }
+  });
+
+  it('summarizeTokenSet is a metadata-only projection', () => {
+    const summary = summarizeTokenSet(tokenSet());
+    assertNoSecrets(JSON.stringify(summary), 'summarizeTokenSet');
+    // The metadata the operator screen renders is still there — this is the
+    // projection routes use INSTEAD of the token set, so it has to be usable.
+    assert.equal(summary.tenantId, 'tenant-1');
+    assert.equal(summary.account?.username, 'admin@contoso.test');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The token store
+// ---------------------------------------------------------------------------
+
+describe('#924 TeamsDelegatedTokenStore custody', () => {
+  it('encrypts nothing into describe(): the operator projection has no token', async () => {
+    const store = new TeamsDelegatedTokenStore(new FakeVault());
+    await store.write(tokenSet());
+    const presence = await store.describe();
+    assertNoSecrets(JSON.stringify(presence), 'TeamsDelegatedTokenStore.describe');
+    assert.equal(presence.signedIn, true);
+    assert.equal(presence.account?.username, 'admin@contoso.test');
+  });
+
+  it('round-trips the token set for the two callers that legitimately read it', async () => {
+    const store = new TeamsDelegatedTokenStore(new FakeVault());
+    await store.write(tokenSet());
+    const read = await store.read();
+    assert.equal(read?.accessToken, ACCESS_TOKEN);
+    assert.equal(read?.refreshToken, REFRESH_TOKEN);
+  });
+
+  it('a rotation keeps signedInAt; a different account restarts it', async () => {
+    const vault = new FakeVault();
+    let now = new Date('2026-01-01T00:00:00.000Z');
+    const store = new TeamsDelegatedTokenStore(vault, () => now);
+    const first = { ...tokenSet(), account: { objectId: 'admin-1' } };
+    await store.write(first);
+    const initial = (await store.describe()).signedInAt;
+
+    // A silent refresh — same admin, new material. The clock must NOT restart,
+    // or the panel claims someone re-authenticated when nobody did.
+    now = new Date('2026-01-02T00:00:00.000Z');
+    await store.write({ ...first, accessToken: 'rotated' });
+    assert.equal((await store.describe()).signedInAt, initial);
+
+    // A different admin IS a new sign-in.
+    await store.write({ ...first, account: { objectId: 'admin-2' } });
+    assert.notEqual((await store.describe()).signedInAt, initial);
+  });
+
+  it('an expired access token is stale, NOT signed out', async () => {
+    const store = new TeamsDelegatedTokenStore(
+      new FakeVault(),
+      () => new Date('2030-01-01T00:00:00.000Z'),
+    );
+    await store.write(tokenSet());
+    const presence = await store.describe();
+    // The whole point: the refresh token outlives the access token, so this is
+    // a working sign-in that happens to need one silent refresh.
+    assert.equal(presence.signedIn, true);
+    assert.equal(presence.accessTokenStale, true);
+  });
+
+  it('a half-written record reads as signed out rather than as a broken credential', async () => {
+    const vault = new FakeVault();
+    await vault.set(
+      '@omadia/teams-delegated',
+      'tenant-token-set',
+      JSON.stringify({ version: 1, tokens: { accessToken: ACCESS_TOKEN } }),
+    );
+    const store = new TeamsDelegatedTokenStore(vault);
+    assert.equal(await store.read(), undefined);
+    assert.equal((await store.describe()).signedIn, false);
+  });
+
+  it('clear() forgets the record', async () => {
+    const store = new TeamsDelegatedTokenStore(new FakeVault());
+    await store.write(tokenSet());
+    await store.clear();
+    assert.equal(await store.read(), undefined);
+    assert.equal((await store.describe()).signedIn, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. + 4. The service and the wire
+// ---------------------------------------------------------------------------
+
+describe('#924 sign-in surface holds the flow handle server-side', () => {
+  let server: Server;
+  let baseUrl: string;
+  let logs: string[] = [];
+  let store: TeamsDelegatedTokenStore;
+  let service: TeamsDelegatedSignInService;
+  let pollResult: 'pending' | 'succeeded' | 'declined' = 'pending';
+  let seenHandles: string[] = [];
+
+  /** A connector double that RECORDS the handle it was given, so the test can
+   *  prove the poll used the stored one rather than something from the wire. */
+  function fakeProvisioner(): Partial<TeamsDelegatedProvisionerMethods> {
+    return {
+      uploadToCatalogDelegated: () => {
+        throw new Error('not used here');
+      },
+      startDelegatedSignIn: () => Promise.resolve(deviceCodeStart()),
+      pollDelegatedSignIn: (input) => {
+        seenHandles.push(input.flowHandle);
+        if (pollResult === 'succeeded') {
+          return Promise.resolve({ status: 'succeeded' as const, tokens: tokenSet() });
+        }
+        if (pollResult === 'declined') {
+          return Promise.resolve({
+            status: 'declined' as const,
+            // The case the UI must not narrate as "the admin cancelled".
+            reason: 'blocked by a Conditional Access policy',
+          });
+        }
+        return Promise.resolve({ status: 'pending' as const, retryAfterSeconds: 5 });
+      },
+      getDelegatedSignInStatus: () => ({ signedIn: false }),
+      refreshDelegatedToken: () => Promise.resolve(tokenSet()),
+      revokeDelegatedSignIn: () => ({ revoked: true }),
+    };
+  }
+
+  before(async () => {
+    store = new TeamsDelegatedTokenStore(new FakeVault());
+    service = new TeamsDelegatedSignInService({
+      tokens: store,
+      getProvisioner: () => fakeProvisioner(),
+      log: (m) => logs.push(m),
+    });
+    const app = express();
+    app.use(express.json());
+    app.use('/api/v1/operator/teams', createOperatorTeamsSignInRouter({
+      getSignIn: () => service,
+    }));
+    server = await listenLoopback(app);
+    const addr = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${String(addr.port)}/api/v1/operator/teams`;
+  });
+
+  after(async () => {
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  it('POST /sign-in returns the code and the consent URL, and NOT the handle', async () => {
+    logs = [];
+    const res = await fetch(`${baseUrl}/sign-in`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ display_name: 'omadia' }),
+    });
+    assert.equal(res.status, 202);
+    const text = await res.text();
+    assertNoSecrets(text, 'POST /sign-in response');
+
+    const body = JSON.parse(text) as {
+      pending: { userCode: string; adminConsentUrl: string; intervalSeconds: number };
+    };
+    // What the operator needs is all there…
+    assert.equal(body.pending.userCode, 'ABCD-EFGH');
+    assert.equal(
+      body.pending.adminConsentUrl,
+      'https://login.microsoftonline.com/tenant-1/adminconsent',
+    );
+    assert.equal(body.pending.intervalSeconds, 5);
+    // …and the field that must not be is not merely redacted, it is absent.
+    assert.equal('flowHandle' in body.pending, false);
+    assertNoSecrets(logs.join('\n'), 'sign-in start logs');
+  });
+
+  it('POST /sign-in/poll needs no handle from the caller and uses the stored one', async () => {
+    seenHandles = [];
+    // Deliberately NO body: the endpoint takes nothing, so there is nothing a
+    // browser could be tricked into sending and nothing to validate.
+    const res = await fetch(`${baseUrl}/sign-in/poll`, { method: 'POST' });
+    assert.equal(res.status, 200);
+    const text = await res.text();
+    assertNoSecrets(text, 'POST /sign-in/poll response');
+    assert.deepEqual(seenHandles, [FLOW_HANDLE]);
+  });
+
+  it('a declined poll carries its reason instead of blaming the admin', async () => {
+    pollResult = 'declined';
+    const res = await fetch(`${baseUrl}/sign-in/poll`, { method: 'POST' });
+    const body = (await res.json()) as {
+      poll: { status: string; reason?: string };
+    };
+    assert.equal(body.poll.status, 'declined');
+    // The server must FORWARD the reason — a UI cannot distinguish a cancelled
+    // sign-in from a policy-blocked one without it.
+    assert.match(body.poll.reason ?? '', /Conditional Access/);
+    pollResult = 'pending';
+  });
+
+  it('a succeeded poll stores the tokens and answers with metadata only', async () => {
+    logs = [];
+    // Fresh flow, because the declined poll above consumed the previous one.
+    await fetch(`${baseUrl}/sign-in`, { method: 'POST' });
+    pollResult = 'succeeded';
+    const res = await fetch(`${baseUrl}/sign-in/poll`, { method: 'POST' });
+    const text = await res.text();
+    assertNoSecrets(text, 'succeeded poll response');
+    const body = JSON.parse(text) as {
+      poll: { status: string; signIn: { signedIn: boolean; account?: { username?: string } } };
+    };
+    assert.equal(body.poll.status, 'succeeded');
+    assert.equal(body.poll.signIn.signedIn, true);
+    assert.equal(body.poll.signIn.account?.username, 'admin@contoso.test');
+    // Persisted, so a restart does not sign the tenant out.
+    assert.equal((await store.read())?.accessToken, ACCESS_TOKEN);
+    assertNoSecrets(logs.join('\n'), 'successful sign-in logs');
+    pollResult = 'pending';
+  });
+
+  it('GET /sign-in reports state without any token, and the pending flow without its handle', async () => {
+    const res = await fetch(`${baseUrl}/sign-in`);
+    assert.equal(res.status, 200);
+    assertNoSecrets(await res.text(), 'GET /sign-in response');
+  });
+
+  it('polling with no flow in flight says so instead of inventing one', async () => {
+    const res = await fetch(`${baseUrl}/sign-in/poll`, { method: 'POST' });
+    const body = (await res.json()) as { poll: { status: string } };
+    assert.equal(body.poll.status, 'no_flow');
+  });
+
+  it('DELETE /sign-in clears the record and leaks nothing on the way out', async () => {
+    pollResult = 'succeeded';
+    await fetch(`${baseUrl}/sign-in`, { method: 'POST' });
+    await fetch(`${baseUrl}/sign-in/poll`, { method: 'POST' });
+    assert.notEqual(await store.read(), undefined);
+
+    const res = await fetch(`${baseUrl}/sign-in`, { method: 'DELETE' });
+    assert.equal(res.status, 200);
+    assertNoSecrets(await res.text(), 'DELETE /sign-in response');
+    assert.equal(await store.read(), undefined);
+    pollResult = 'pending';
+  });
+});
+
+describe('#924 sign-in surface degrades honestly', () => {
+  it('503s with a machine code when the sign-in stack is not wired', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/api/v1/operator/teams',
+      createOperatorTeamsSignInRouter({ getSignIn: () => undefined }),
+    );
+    const server = await listenLoopback(app);
+    const addr = server.address() as AddressInfo;
+    const url = `http://127.0.0.1:${String(addr.port)}/api/v1/operator/teams/sign-in`;
+    try {
+      const res = await fetch(url);
+      assert.equal(res.status, 503);
+      const body = (await res.json()) as { error: string };
+      assert.equal(body.error, 'teams_sign_in_unavailable');
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
+  it('names the connector-too-old case separately from connector-missing', async () => {
+    const store = new TeamsDelegatedTokenStore(new FakeVault());
+    // An accessor from an older connector: present, but without the delegated
+    // half. Reporting this as "not installed" would send an operator to
+    // install a plugin they already have.
+    const service = new TeamsDelegatedSignInService({
+      tokens: store,
+      getProvisioner: () => ({}),
+      log: () => undefined,
+    });
+    assert.equal(service.supported(), false);
+    await assert.rejects(
+      () => service.start(),
+      (err: Error & { code?: string }) =>
+        err.code === 'delegated_sign_in_unsupported',
+    );
+  });
+});

--- a/middleware/test/teamsProvisioningDelegatedUpload.test.ts
+++ b/middleware/test/teamsProvisioningDelegatedUpload.test.ts
@@ -1,0 +1,594 @@
+/**
+ * The delegated catalog upload in the provisioning chain (byte5ai/omadia#924).
+ *
+ * WHAT THESE PIN, and why each is a regression no render assertion would catch:
+ *
+ *   - THE UPLOAD ACTUALLY GOES DELEGATED. `POST /appCatalogs/teamsApps` is
+ *     delegated-only at Microsoft, so a chain that quietly kept calling the
+ *     app-only `uploadToCatalog` would compile, pass every older test, and
+ *     fail in every real tenant.
+ *   - A ROTATED TOKEN IS PERSISTED. If `refreshed === true` and we do not
+ *     write, the refresh token in the vault is already spent and the tenant is
+ *     silently signed out until someone investigates a later failure.
+ *   - NOT SIGNED IN PARKS, IT DOES NOT FAIL. The Entra app, the Azure bot and
+ *     the built package are all real by then. A run that fell to `failed`
+ *     because nobody had signed in yet would throw that evidence away and send
+ *     an operator hunting a fault that does not exist.
+ *   - THE FOUR ERRORS STAY FOUR. Each one sends the operator somewhere else —
+ *     start a sign-in, send an admin to a consent URL, sign in again, or go
+ *     fix the publisher app. A collapsed code is a dead end on screen.
+ *   - THE REFRESHABLE EXPIRY NEVER REACHES A HUMAN. It is recovered in place.
+ *   - AN OLDER CONNECTOR STILL WORKS. Feature detection, not configuration.
+ *   - NO TOKEN IN THE PROGRESS LOG. The `detail` column is read by a screen.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { TimerSeam } from '../src/plugins/jobScheduler.js';
+import type { DelegatedTokenSet } from '../src/platform/teamsDelegatedSignIn.js';
+import {
+  classifyTeamsProvisioningError,
+  DELEGATED_TOKEN_REFRESHED_DETAIL,
+  DELEGATED_UPLOAD_DETAIL,
+  TeamsProvisioningJobRunner,
+  type ProvisioningRunResult,
+  type TeamsAppPackageAssets,
+  type TeamsDelegatedTokenPort,
+  type TeamsIdentityJobRecord,
+  type TeamsIdentityJobStore,
+  type TeamsIdentityJobUpdate,
+  type TeamsProvisioningEventSink,
+  type TeamsProvisionerPort,
+} from '../src/services/teamsProvisioningJob.js';
+
+// ---------------------------------------------------------------------------
+// Doubles
+// ---------------------------------------------------------------------------
+
+function immediateTimers(): TimerSeam {
+  return {
+    setTimeout(cb) {
+      cb();
+      return 0;
+    },
+    clearTimeout() {},
+    setInterval() {
+      throw new Error('runner must not use setInterval');
+    },
+    clearInterval() {},
+  };
+}
+
+class FakeStore implements TeamsIdentityJobStore {
+  public row: TeamsIdentityJobRecord;
+  public readonly patches: TeamsIdentityJobUpdate[] = [];
+
+  constructor(overrides: Partial<TeamsIdentityJobRecord> = {}) {
+    this.row = {
+      agentId: 'agent-1',
+      botSlug: 'hr',
+      displayName: 'HR Bot',
+      state: 'pending',
+      appId: null,
+      tenantId: null,
+      teamsAppId: null,
+      teamsAppExternalId: null,
+      lastError: null,
+      ...overrides,
+    };
+  }
+
+  getByAgentId(): Promise<TeamsIdentityJobRecord | undefined> {
+    return Promise.resolve(this.row);
+  }
+
+  update(
+    _agentId: string,
+    patch: TeamsIdentityJobUpdate,
+  ): Promise<TeamsIdentityJobRecord> {
+    this.patches.push(patch);
+    this.row = { ...this.row, ...patch } as TeamsIdentityJobRecord;
+    return Promise.resolve(this.row);
+  }
+}
+
+class RecordingEvents implements TeamsProvisioningEventSink {
+  public readonly written: {
+    step: string;
+    status: string;
+    detail?: string | null;
+  }[] = [];
+
+  record(input: {
+    step: string;
+    status: string;
+    detail?: string | null;
+  }): Promise<unknown> {
+    this.written.push({
+      step: input.step,
+      status: input.status,
+      detail: input.detail ?? null,
+    });
+    return Promise.resolve(undefined);
+  }
+
+  clearForAgent(): Promise<unknown> {
+    return Promise.resolve(undefined);
+  }
+}
+
+class FakeCustody implements TeamsDelegatedTokenPort {
+  public writes: DelegatedTokenSet[] = [];
+
+  constructor(private current: DelegatedTokenSet | undefined) {}
+
+  read(): Promise<DelegatedTokenSet | undefined> {
+    return Promise.resolve(this.current);
+  }
+
+  write(tokens: DelegatedTokenSet): Promise<void> {
+    this.writes.push(tokens);
+    this.current = tokens;
+    return Promise.resolve();
+  }
+}
+
+function tokens(overrides: Partial<DelegatedTokenSet> = {}): DelegatedTokenSet {
+  return {
+    accessToken: 'at',
+    refreshToken: 'rt',
+    expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+    scopes: ['AppCatalog.Submit'],
+    clientId: 'client-1',
+    tenantId: 'tenant-1',
+    ...overrides,
+  };
+}
+
+const ASSETS: TeamsAppPackageAssets = {
+  manifestTemplate: '{}',
+  params: {},
+  icons: { color: new Uint8Array([1]), outline: new Uint8Array([2]) },
+  externalId: 'external-1',
+};
+
+interface ProvisionerOverrides {
+  readonly delegated?: TeamsProvisionerPort['uploadToCatalogDelegated'];
+  readonly refresh?: TeamsProvisionerPort['refreshDelegatedToken'];
+  readonly appOnlyUploads?: string[];
+}
+
+/** A provisioner whose earlier steps always succeed, so every test below is
+ *  about the catalog step and nothing else. */
+function provisioner(overrides: ProvisionerOverrides = {}): TeamsProvisionerPort {
+  const base: TeamsProvisionerPort = {
+    createAppRegistration: () =>
+      Promise.resolve({
+        outcome: 'created',
+        value: { appId: 'app-1', registration: { tenantId: 'tenant-1' } },
+      }),
+    createBot: () =>
+      Promise.resolve({
+        kind: 'provisioned',
+        bot: { outcome: 'created', value: { botName: 'omadia-hr-app1' } },
+      }),
+    buildAppPackage: () => new Uint8Array([9, 9, 9]),
+    uploadToCatalog: ({ externalId }) => {
+      overrides.appOnlyUploads?.push(externalId);
+      return Promise.resolve({
+        outcome: 'created',
+        value: { teamsAppId: 'teams-app-app-only' },
+      });
+    },
+    getCatalogApp: () => Promise.resolve({ found: false }),
+    installToTeam: () =>
+      Promise.resolve({
+        outcome: 'created',
+        value: { teamId: 'team-1', teamsAppId: 'teams-app-1' },
+      }),
+  };
+  return {
+    ...base,
+    ...(overrides.delegated ? { uploadToCatalogDelegated: overrides.delegated } : {}),
+    ...(overrides.refresh ? { refreshDelegatedToken: overrides.refresh } : {}),
+  };
+}
+
+interface RunnerParts {
+  readonly store: FakeStore;
+  readonly events: RecordingEvents;
+  readonly custody: FakeCustody;
+  readonly run: () => Promise<ProvisioningRunResult>;
+}
+
+function makeRunner(input: {
+  readonly provisioner: TeamsProvisionerPort;
+  readonly custody?: FakeCustody;
+  readonly store?: FakeStore;
+}): RunnerParts {
+  const store = input.store ?? new FakeStore();
+  const events = new RecordingEvents();
+  const custody = input.custody ?? new FakeCustody(tokens());
+  const runner = new TeamsProvisioningJobRunner({
+    store,
+    events,
+    delegatedTokens: custody,
+    getProvisioner: () => input.provisioner,
+    buildMessagingEndpoint: (slug) => `https://omadia.test/api/teams/${slug}/messages`,
+    loadPackageAssets: () => Promise.resolve(ASSETS),
+    timers: immediateTimers(),
+    maxAttempts: 2,
+    baseRetryDelayMs: 0,
+    log: () => undefined,
+  });
+  return {
+    store,
+    events,
+    custody,
+    run: () => runner.enqueue({ agentId: 'agent-1', teamId: 'team-1' }),
+  };
+}
+
+/** Build a connector-shaped error: name + fields, no shared class — exactly
+ *  how it crosses the plugin boundary in production. */
+function connectorError(
+  name: string,
+  fields: Record<string, unknown> = {},
+  message = 'connector says no',
+): Error {
+  const err = new Error(message);
+  err.name = name;
+  return Object.assign(err, fields);
+}
+
+// ---------------------------------------------------------------------------
+// The happy path
+// ---------------------------------------------------------------------------
+
+describe('#924 the chain uploads through the tenant sign-in', () => {
+  it('calls uploadToCatalogDelegated with the stored tokens, not uploadToCatalog', async () => {
+    const appOnlyUploads: string[] = [];
+    let seen: DelegatedTokenSet | undefined;
+    const parts = makeRunner({
+      provisioner: provisioner({
+        appOnlyUploads,
+        delegated: (input) => {
+          seen = input.tokens;
+          return Promise.resolve({
+            app: { value: { teamsAppId: 'teams-app-delegated' } },
+            tokens: input.tokens,
+            refreshed: false,
+          });
+        },
+      }),
+    });
+
+    const result = await parts.run();
+    assert.equal(result.status, 'installed');
+    // The app-only call is the one Microsoft refuses — it must not have run.
+    assert.deepEqual(appOnlyUploads, []);
+    assert.equal(seen?.accessToken, 'at');
+    assert.equal(parts.store.row.teamsAppId, 'teams-app-delegated');
+  });
+
+  it('records the delegated upload in the timeline without naming a credential', async () => {
+    const parts = makeRunner({
+      provisioner: provisioner({
+        delegated: (input) =>
+          Promise.resolve({
+            app: { value: { teamsAppId: 'teams-app-delegated' } },
+            tokens: input.tokens,
+            refreshed: false,
+          }),
+      }),
+    });
+    await parts.run();
+
+    const catalog = parts.events.written.filter((e) => e.step === 'catalog_uploaded');
+    assert.ok(
+      catalog.some((e) => e.status === 'progress' && e.detail === DELEGATED_UPLOAD_DETAIL),
+      'the operator gets a line saying the upload runs on the tenant sign-in',
+    );
+    // The whole progress log, searched: a token or an account name in this
+    // column would be rendered on a screen and stored for the run's lifetime.
+    const serialized = JSON.stringify(parts.events.written);
+    for (const secret of ['"at"', 'rt', 'tenant-1', 'client-1']) {
+      assert.equal(
+        serialized.includes(`"detail":"${secret}`),
+        false,
+        `progress detail leaked ${secret}`,
+      );
+    }
+  });
+
+  it('persists a rotated token set the moment the connector reports one', async () => {
+    const rotated = tokens({ accessToken: 'at-2', refreshToken: 'rt-2' });
+    const parts = makeRunner({
+      provisioner: provisioner({
+        delegated: () =>
+          Promise.resolve({
+            app: { value: { teamsAppId: 'teams-app-delegated' } },
+            tokens: rotated,
+            refreshed: true,
+          }),
+      }),
+    });
+    await parts.run();
+
+    assert.equal(parts.custody.writes.length, 1);
+    assert.equal(parts.custody.writes[0]?.accessToken, 'at-2');
+    assert.ok(
+      parts.events.written.some(
+        (e) => e.detail === DELEGATED_TOKEN_REFRESHED_DETAIL,
+      ),
+      'a silent rotation is worth one line — it is a pause with no fault behind it',
+    );
+  });
+
+  it('an older connector keeps using the app-only upload', async () => {
+    const appOnlyUploads: string[] = [];
+    // No `uploadToCatalogDelegated` at all — the pre-0.6.0 shape.
+    const parts = makeRunner({ provisioner: provisioner({ appOnlyUploads }) });
+    const result = await parts.run();
+    assert.equal(result.status, 'installed');
+    assert.deepEqual(appOnlyUploads, ['external-1']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Parking
+// ---------------------------------------------------------------------------
+
+describe('#924 a run with nobody signed in parks, resumably', () => {
+  it('halts instead of failing, and keeps the state it reached', async () => {
+    const parts = makeRunner({
+      provisioner: provisioner({
+        delegated: () => {
+          throw new Error('must not be called without tokens');
+        },
+      }),
+      custody: new FakeCustody(undefined),
+    });
+
+    const result = await parts.run();
+    assert.equal(result.status, 'halted');
+    assert.equal(
+      result.status === 'halted' ? result.reason : null,
+      'delegated_sign_in_required',
+    );
+    // The evidence of three completed steps survives — that is what makes the
+    // next run resume here instead of re-walking the chain.
+    assert.equal(parts.store.row.state, 'package_built');
+    assert.equal(parts.store.row.appId, 'app-1');
+    // No patch anywhere in the run may have written `failed`.
+    assert.equal(
+      parts.store.patches.some((p) => p.state === 'failed'),
+      false,
+      'a missing sign-in is a missing human action, not a failure',
+    );
+  });
+
+  it('explains itself in last_error, decodable back to a code the UI switches on', async () => {
+    const parts = makeRunner({
+      provisioner: provisioner({ delegated: () => Promise.reject(new Error('x')) }),
+      custody: new FakeCustody(undefined),
+    });
+    await parts.run();
+
+    const raw = parts.store.row.lastError;
+    assert.ok(raw, 'the operator is told why nothing is moving');
+    assert.equal(
+      classifyTeamsProvisioningError(raw).code,
+      'delegated_sign_in_required',
+    );
+  });
+
+  it('resumes and completes once a sign-in exists', async () => {
+    const custody = new FakeCustody(undefined);
+    const prov = provisioner({
+      delegated: (input) =>
+        Promise.resolve({
+          app: { value: { teamsAppId: 'teams-app-delegated' } },
+          tokens: input.tokens,
+          refreshed: false,
+        }),
+    });
+    const store = new FakeStore();
+
+    const first = makeRunner({ provisioner: prov, custody, store });
+    assert.equal((await first.run()).status, 'halted');
+
+    // The admin signs in. Nothing else changes — same row, same connector.
+    await custody.write(tokens());
+    const second = makeRunner({ provisioner: prov, custody, store });
+    const result = await second.run();
+
+    assert.equal(result.status, 'installed');
+    assert.equal(store.row.state, 'installed');
+    assert.equal(store.row.lastError, null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The four errors
+// ---------------------------------------------------------------------------
+
+describe('#924 the four delegated errors stay distinguishable', () => {
+  /** Drive one connector error through the chain and report what came out. */
+  async function runWith(err: Error): Promise<{
+    readonly result: ProvisioningRunResult;
+    readonly store: FakeStore;
+  }> {
+    const parts = makeRunner({
+      provisioner: provisioner({ delegated: () => Promise.reject(err) }),
+    });
+    return { result: await parts.run(), store: parts.store };
+  }
+
+  it('DelegatedSignInRequiredError → park, "sign in"', async () => {
+    const { result, store } = await runWith(
+      connectorError('DelegatedSignInRequiredError', {
+        step: 'catalog-upload',
+        requiredScopes: ['AppCatalog.Submit'],
+      }),
+    );
+    assert.equal(result.status, 'halted');
+    const detail = classifyTeamsProvisioningError(store.row.lastError ?? '');
+    assert.equal(detail.code, 'delegated_sign_in_required');
+    // The scopes survive the round trip, so the panel can name them.
+    assert.deepEqual(detail.scopes, ['AppCatalog.Submit']);
+    assert.notEqual(store.row.state, 'failed');
+  });
+
+  it('DelegatedConsentRequiredError → park, and the consent URL comes back out', async () => {
+    const url = 'https://login.microsoftonline.com/tenant-1/adminconsent?client_id=x';
+    const { result, store } = await runWith(
+      connectorError('DelegatedConsentRequiredError', {
+        requiredScopes: ['AppCatalog.Submit'],
+        adminConsentUrl: url,
+      }),
+    );
+    assert.equal(result.status, 'halted');
+    const detail = classifyTeamsProvisioningError(store.row.lastError ?? '');
+    assert.equal(detail.code, 'delegated_consent_required');
+    // Without this the operator is told to "grant consent" with nowhere to go.
+    assert.equal(detail.adminConsentUrl, url);
+  });
+
+  it('a non-https consent URL is dropped rather than rendered as a link', async () => {
+    const { store } = await runWith(
+      connectorError('DelegatedConsentRequiredError', {
+        requiredScopes: [],
+        adminConsentUrl: 'javascript:alert(1)',
+      }),
+    );
+    const detail = classifyTeamsProvisioningError(store.row.lastError ?? '');
+    assert.equal(detail.code, 'delegated_consent_required');
+    assert.equal(detail.adminConsentUrl, undefined);
+  });
+
+  it('DelegatedTokenExpiredError (refresh-token-invalid) → park, "sign in AGAIN"', async () => {
+    const { result, store } = await runWith(
+      connectorError('DelegatedTokenExpiredError', {
+        reason: 'refresh-token-invalid',
+        recoverableByRefresh: false,
+      }),
+    );
+    assert.equal(result.status, 'halted');
+    // Its OWN code: "your sign-in expired" and "nobody ever signed in" send an
+    // operator to the same button for different reasons, and only one of them
+    // is worth investigating.
+    assert.equal(
+      classifyTeamsProvisioningError(store.row.lastError ?? '').code,
+      'delegated_token_expired',
+    );
+  });
+
+  it('DeviceCodeFlowError → terminal, "go look at the publisher app"', async () => {
+    const { result, store } = await runWith(
+      connectorError(
+        'DeviceCodeFlowError',
+        { oauthError: 'invalid_client', status: 400 },
+        'the tenant refuses device-code flows',
+      ),
+    );
+    assert.equal(result.status, 'failed');
+    assert.equal(
+      result.status === 'failed' ? result.reason : null,
+      'device_code_flow_failed',
+    );
+    // Terminal on purpose: the flow is refused by configuration, so retrying
+    // it produces the same refusal five times over.
+    assert.equal(store.row.state, 'failed');
+    const detail = classifyTeamsProvisioningError(store.row.lastError ?? '');
+    assert.equal(detail.code, 'device_code_flow_failed');
+    assert.equal(detail.reason, 'invalid_client');
+  });
+
+  it('all four classify to four different codes', async () => {
+    const codes = new Set<string>();
+    for (const err of [
+      connectorError('DelegatedSignInRequiredError'),
+      connectorError('DelegatedConsentRequiredError'),
+      connectorError('DelegatedTokenExpiredError', { recoverableByRefresh: false }),
+      connectorError('DeviceCodeFlowError'),
+    ]) {
+      const { store } = await runWith(err);
+      codes.add(classifyTeamsProvisioningError(store.row.lastError ?? '').code);
+    }
+    assert.equal(codes.size, 4, `expected four distinct codes, got ${[...codes].join(', ')}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The one error a human must never see
+// ---------------------------------------------------------------------------
+
+describe('#924 a refreshable expiry never reaches the operator', () => {
+  it('refreshes in place, retries once, and finishes installed', async () => {
+    let uploadCalls = 0;
+    let refreshCalls = 0;
+    const parts = makeRunner({
+      provisioner: provisioner({
+        delegated: (input) => {
+          uploadCalls += 1;
+          if (uploadCalls === 1) {
+            return Promise.reject(
+              connectorError('DelegatedTokenExpiredError', {
+                reason: 'access-token-expired',
+                recoverableByRefresh: true,
+              }),
+            );
+          }
+          return Promise.resolve({
+            app: { value: { teamsAppId: 'teams-app-delegated' } },
+            tokens: input.tokens,
+            refreshed: false,
+          });
+        },
+        refresh: () => {
+          refreshCalls += 1;
+          return Promise.resolve(tokens({ accessToken: 'at-refreshed' }));
+        },
+      }),
+    });
+
+    const result = await parts.run();
+    assert.equal(result.status, 'installed');
+    assert.equal(refreshCalls, 1);
+    assert.equal(uploadCalls, 2);
+    // The rotation is persisted, and the second upload used it.
+    assert.equal(parts.custody.writes.at(-1)?.accessToken, 'at-refreshed');
+    // Nothing was ever written to last_error: the operator saw no failure at all.
+    assert.equal(parts.store.row.lastError, null);
+  });
+
+  it('a refresh that itself fails becomes the visible "sign in again"', async () => {
+    const parts = makeRunner({
+      provisioner: provisioner({
+        delegated: () =>
+          Promise.reject(
+            connectorError('DelegatedTokenExpiredError', {
+              reason: 'access-token-expired',
+              recoverableByRefresh: true,
+            }),
+          ),
+        refresh: () =>
+          Promise.reject(
+            connectorError('DelegatedTokenExpiredError', {
+              reason: 'refresh-token-invalid',
+              recoverableByRefresh: false,
+            }),
+          ),
+      }),
+    });
+
+    const result = await parts.run();
+    assert.equal(result.status, 'halted');
+    assert.equal(
+      classifyTeamsProvisioningError(parts.store.row.lastError ?? '').code,
+      'delegated_token_expired',
+    );
+  });
+});

--- a/middleware/test/teamsProvisioningJob.test.ts
+++ b/middleware/test/teamsProvisioningJob.test.ts
@@ -527,8 +527,11 @@ describe('TeamsProvisioningJobRunner — connector error policy', () => {
     const { runner, store } = makeRunner({ behaviour: { createBot: 'registration-only' } });
     const result = await runner.enqueue(REQUEST);
     assert.equal(result.status, 'halted');
+    // `halted` gained a second shape with #924 (the delegated sign-in parks
+    // here too), so the reason has to be narrowed before its payload is read.
     assert.ok(
       result.status === 'halted' &&
+        result.reason === 'arm_not_configured' &&
         result.missingSetupFields.includes('azureSubscriptionId'),
     );
     assert.equal(store.row?.state, 'app_registered');

--- a/web-ui/app/_components/Nav.tsx
+++ b/web-ui/app/_components/Nav.tsx
@@ -72,6 +72,10 @@ const NAV: readonly NavItem[] = [
       // Orchestrators and Conductor moved here from the top level — they're
       // operator-facing configuration surfaces, same audience as Admin/System.
       { kind: 'link', href: '/operator/agents', key: 'agentsCluster' },
+      // #924 — the TENANT Teams sign-in. Its own entry, not a tab inside an
+      // agent: one admin signs in once and every agent provisioned afterwards
+      // uses it, so it has to be reachable BEFORE the first agent exists.
+      { kind: 'link', href: '/operator/teams', key: 'teamsSignIn' },
       { kind: 'link', href: '/conductor', key: 'conductor' },
       // #757 — persisted per-turn privacy receipts, same operator audience.
       { kind: 'link', href: '/operator/receipts', key: 'receipts' },

--- a/web-ui/app/_lib/__tests__/teamsSignIn.test.ts
+++ b/web-ui/app/_lib/__tests__/teamsSignIn.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+
+import { ApiError } from '../api';
+import {
+  parsePendingFlow,
+  parsePollResult,
+  parseSignInState,
+  parseSignInStatus,
+  parseTeamsSignInErrorCode,
+  secondsRemaining,
+  SIGNED_OUT_VIEW,
+} from '../teamsSignIn';
+
+/**
+ * The client boundary of the tenant Teams sign-in (byte5ai/omadia#924).
+ *
+ * These parsers sit between a middleware that may be older or newer than this
+ * build and a panel an operator opens precisely when something is wrong. So
+ * the contract they owe is TOTALITY: no input takes the page down, and the
+ * fallback for every unreadable shape is the one that cannot mislead.
+ *
+ * Two of the assertions here are not shape checks but POLICY:
+ *
+ *   - SIGNED OUT IS THE SAFE DEFAULT. Claiming a sign-in that does not exist
+ *     would leave an operator waiting for provisioning that will never move.
+ *     Offering a sign-in button to someone already signed in costs one click.
+ *   - `accessTokenStale` SURVIVES PARSING AS ITS OWN FIELD, separate from
+ *     `signedIn`. Collapsing the two would turn a self-healing condition into
+ *     a signed-out state and send an operator to re-authenticate for nothing.
+ */
+
+describe('parseSignInState', () => {
+  it('projects a full state', () => {
+    const state = parseSignInState({
+      signedIn: true,
+      signedInAt: '2026-08-01T09:00:00.000Z',
+      expiresAt: '2026-08-28T18:00:00.000Z',
+      accessTokenStale: false,
+      scopes: ['AppCatalog.Submit'],
+      tenantId: 'tenant-1',
+      clientId: 'client-1',
+      account: { username: 'admin@contoso.test', displayName: 'Ada Admin' },
+    });
+    expect(state.signedIn).toBe(true);
+    expect(state.account?.displayName).toBe('Ada Admin');
+    expect(state.scopes).toEqual(['AppCatalog.Submit']);
+  });
+
+  it('falls back to SIGNED OUT for anything it cannot read', () => {
+    for (const value of [null, undefined, 42, 'nope', {}, { signedIn: 'yes' }]) {
+      expect(parseSignInState(value)).toEqual(SIGNED_OUT_VIEW);
+    }
+  });
+
+  it('keeps accessTokenStale separate from signedIn', () => {
+    // A stale access token with a live refresh token is a WORKING sign-in.
+    const state = parseSignInState({ signedIn: true, accessTokenStale: true });
+    expect(state.signedIn).toBe(true);
+    expect(state.accessTokenStale).toBe(true);
+  });
+
+  it('drops an account with neither a name nor a username', () => {
+    // Rendering an empty "signed in as ―" line is worse than omitting it.
+    const state = parseSignInState({ signedIn: true, account: { objectId: 'x' } });
+    expect(state.account).toBeNull();
+  });
+
+  it('keeps only string scopes rather than rejecting the whole list', () => {
+    const state = parseSignInState({
+      signedIn: true,
+      scopes: ['AppCatalog.Submit', 7, null],
+    });
+    expect(state.scopes).toEqual(['AppCatalog.Submit']);
+  });
+});
+
+describe('parsePendingFlow', () => {
+  it('projects a usable flow', () => {
+    const flow = parsePendingFlow({
+      userCode: 'GH7K-QW2P',
+      verificationUri: 'https://microsoft.com/devicelogin',
+      expiresAt: '2026-08-28T18:00:00.000Z',
+      intervalSeconds: 5,
+      scopes: ['AppCatalog.Submit'],
+      adminConsentUrl: 'https://login.microsoftonline.com/t/adminconsent',
+    });
+    expect(flow?.userCode).toBe('GH7K-QW2P');
+    expect(flow?.adminConsentUrl).toBe(
+      'https://login.microsoftonline.com/t/adminconsent',
+    );
+  });
+
+  it('drops a flow with a code but nowhere to type it', () => {
+    // Half a flow is a dead end, not a partial success — the panel is better
+    // off offering the start button again.
+    expect(parsePendingFlow({ userCode: 'ABCD', verificationUri: '' })).toBeNull();
+    expect(
+      parsePendingFlow({ userCode: '', verificationUri: 'https://example.test' }),
+    ).toBeNull();
+    expect(parsePendingFlow(null)).toBeNull();
+  });
+
+  it('never yields a zero poll interval, which would be a hot loop', () => {
+    for (const interval of [0, -3, Number.NaN, 'soon', undefined]) {
+      const flow = parsePendingFlow({
+        userCode: 'A',
+        verificationUri: 'https://example.test',
+        intervalSeconds: interval,
+      });
+      expect(flow?.intervalSeconds).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('parseSignInStatus', () => {
+  it('treats a missing supported flag as unsupported', () => {
+    // Optimism here would light up a button that answers 503.
+    expect(parseSignInStatus({}).supported).toBe(false);
+    expect(parseSignInStatus(undefined).signIn).toEqual(SIGNED_OUT_VIEW);
+  });
+});
+
+describe('parsePollResult', () => {
+  it('narrows each verdict', () => {
+    expect(parsePollResult({ status: 'pending', retryAfterSeconds: 7 })).toEqual({
+      status: 'pending',
+      retryAfterSeconds: 7,
+    });
+    expect(parsePollResult({ status: 'expired', reason: 'code expired' })).toEqual({
+      status: 'expired',
+      reason: 'code expired',
+    });
+    expect(parsePollResult({ status: 'no_flow' }).status).toBe('no_flow');
+  });
+
+  it('carries the reason of a declined poll', () => {
+    // THE field that tells "the admin cancelled" apart from "Conditional
+    // Access blocked it". Dropping it makes the panel narrate an intent.
+    const result = parsePollResult({
+      status: 'declined',
+      reason: 'AADSTS53003: blocked by Conditional Access',
+    });
+    expect(result).toEqual({
+      status: 'declined',
+      reason: 'AADSTS53003: blocked by Conditional Access',
+    });
+  });
+
+  it('turns an unknown verdict into no_flow rather than an endless spinner', () => {
+    expect(parsePollResult({ status: 'quantum' }).status).toBe('no_flow');
+    expect(parsePollResult('nope').status).toBe('no_flow');
+  });
+});
+
+describe('secondsRemaining', () => {
+  it('counts down and clamps at zero', () => {
+    const now = Date.parse('2026-08-28T12:00:00.000Z');
+    expect(secondsRemaining('2026-08-28T12:01:00.000Z', now)).toBe(60);
+    // A countdown that runs into "-14s" reads as a bug; "expired" is honest.
+    expect(secondsRemaining('2026-08-28T11:59:00.000Z', now)).toBe(0);
+  });
+
+  it('answers null for an unusable expiry instead of NaN on screen', () => {
+    expect(secondsRemaining('', Date.now())).toBeNull();
+    expect(secondsRemaining('soon', Date.now())).toBeNull();
+  });
+});
+
+describe('parseTeamsSignInErrorCode', () => {
+  it('recognises the closed vocabulary the middleware answers with', () => {
+    const err = new ApiError(
+      503,
+      'failed',
+      JSON.stringify({ error: 'delegated_sign_in_unsupported' }),
+    );
+    expect(parseTeamsSignInErrorCode(err)).toBe('delegated_sign_in_unsupported');
+  });
+
+  it('returns null for anything else, so the panel uses its localized fallback', () => {
+    expect(parseTeamsSignInErrorCode(new Error('boom'))).toBeNull();
+    expect(
+      parseTeamsSignInErrorCode(new ApiError(500, 'failed', 'not json')),
+    ).toBeNull();
+    expect(
+      parseTeamsSignInErrorCode(
+        new ApiError(500, 'failed', JSON.stringify({ error: 'invented' })),
+      ),
+    ).toBeNull();
+  });
+});

--- a/web-ui/app/_lib/agents.ts
+++ b/web-ui/app/_lib/agents.ts
@@ -467,6 +467,15 @@ export const TEAMS_IDENTITY_LAST_ERROR_CODES = [
   // Terminal and deterministic: re-running changes nothing, the operator has
   // to rename the bot slug.
   'bot_handle_unavailable',
+  // #924 — the four delegated codes. FOUR, not one, because each sends the
+  // operator somewhere else: start a tenant sign-in, send an admin to a
+  // consent URL, sign in again, or go look at the publisher app's device-code
+  // configuration. Three of them are PARKED runs, not failures — the chain
+  // keeps everything it built and resumes once the human step is done.
+  'delegated_sign_in_required',
+  'delegated_consent_required',
+  'delegated_token_expired',
+  'device_code_flow_failed',
   'unknown',
 ] as const;
 
@@ -492,6 +501,11 @@ export interface TeamsIdentityLastErrorDetailDto {
    *  (`config_sync_failed`) — a technical sentence, rendered as the ICU
    *  argument of a localized line, never as the copy itself. */
   reason?: string;
+  /** #924 — where an admin grants the delegated scopes
+   *  (`delegated_consent_required`). Validated as absolute https server-side
+   *  before the sentence is written AND again when it is decoded, so the panel
+   *  may render it as a link without a third check. */
+  adminConsentUrl?: string;
   raw: string;
 }
 
@@ -529,11 +543,17 @@ export function parseTeamsIdentityLastErrorDetail(
   const fields = stringList(obj?.['fields']);
   const retry = obj?.['retryAfterSeconds'];
   const reason = obj?.['reason'];
+  const consentUrl = obj?.['adminConsentUrl'];
   const rawText = obj?.['raw'];
   return {
     code,
     ...(scopes ? { scopes } : {}),
     ...(fields ? { fields } : {}),
+    // Re-checked here too: this value becomes an `href`, and a row written by
+    // an older build is untrusted text as far as this boundary is concerned.
+    ...(typeof consentUrl === 'string' && consentUrl.startsWith('https://')
+      ? { adminConsentUrl: consentUrl }
+      : {}),
     ...(typeof retry === 'number' && Number.isFinite(retry)
       ? { retryAfterSeconds: retry }
       : {}),
@@ -710,6 +730,22 @@ export async function provisionAgentTeamsIdentity(
  * `detailErrors.*` / `grants.errors.*` catalogue to grow keys it never
  * renders.
  */
+/**
+ * Browser URL of the Teams app-package download (#924).
+ *
+ * A plain link rather than a fetch-and-blob: the response carries
+ * `Content-Disposition: attachment`, so the browser saves it with the right
+ * filename and streams it without the page holding the bytes in memory.
+ * Same-origin `/bot-api` proxy, so the session cookie rides along.
+ *
+ * A FALLBACK, NOT THE PATH. Provisioning uploads the package itself through
+ * the tenant sign-in; this exists for tenants that forbid programmatic
+ * catalog writes and for admins who want to read the manifest first.
+ */
+export function agentTeamsPackageUrl(slug: string): string {
+  return `/bot-api/v1/operator/agents/${encodeURIComponent(slug)}/teams-identity/package`;
+}
+
 export const TEAMS_IDENTITY_ERROR_CODES = [
   'bot_slug_taken',
   'invalid_body',

--- a/web-ui/app/_lib/teamsIdentity.ts
+++ b/web-ui/app/_lib/teamsIdentity.ts
@@ -404,6 +404,14 @@ export const TEAMS_PROVISIONING_EVENT_DETAILS = [
   'retries_exhausted',
   'team_conflict',
   'stopped',
+  // #924 — the catalog step's own intra-step notes, plus the four terminal
+  // reasons the runner classifies for the delegated upload.
+  'delegated_upload',
+  'delegated_token_refreshed',
+  'delegated_sign_in_required',
+  'delegated_consent_required',
+  'delegated_token_expired',
+  'device_code_flow_failed',
 ] as const;
 
 const EVENT_DETAIL_SET: ReadonlySet<string> = new Set(
@@ -644,12 +652,42 @@ export interface TeamsIdentityErrorLink {
 export function teamsIdentityErrorLink(
   detail: TeamsIdentityLastErrorDetailDto,
 ): TeamsIdentityErrorLink | null {
-  return detail.code === 'consent_missing'
-    ? {
-        href: ENTRA_ADMIN_CONSENT_DOCS_URL,
-        labelKey: 'errors.consent_missing.consentLink',
-      }
-    : null;
+  if (detail.code === 'consent_missing') {
+    return {
+      href: ENTRA_ADMIN_CONSENT_DOCS_URL,
+      labelKey: 'errors.consent_missing.consentLink',
+    };
+  }
+  // #924 — the TENANT's own consent URL, captured from the connector's error.
+  // Not documentation: the exact page an admin has to approve on. Without it
+  // "grant consent" is an instruction with no destination.
+  if (detail.code === 'delegated_consent_required' && detail.adminConsentUrl) {
+    return {
+      href: detail.adminConsentUrl,
+      labelKey: 'errors.delegated_consent_required.consentLink',
+    };
+  }
+  return null;
+}
+
+/**
+ * Does this failure send the operator to the TENANT sign-in page (#924)?
+ *
+ * Three of the four delegated codes do, for three different reasons — nobody
+ * has signed in, the sign-in expired, or consent is missing — and all three
+ * need the same affordance: a link out of the agent panel to
+ * `/operator/teams`. The fourth (`device_code_flow_failed`) does not: no
+ * amount of clicking sign-in fixes a publisher app that will not do
+ * device-code flows.
+ */
+export function needsTenantSignIn(
+  detail: TeamsIdentityLastErrorDetailDto,
+): boolean {
+  return (
+    detail.code === 'delegated_sign_in_required' ||
+    detail.code === 'delegated_token_expired' ||
+    detail.code === 'delegated_consent_required'
+  );
 }
 
 /**
@@ -671,11 +709,29 @@ export function teamsIdentityErrorMessages(
   const base = `errors.${detail.code}`;
   const messages: LocalizedMessage[] = [{ key: `${base}.what` }];
 
-  if (detail.code === 'consent_missing' && (detail.scopes?.length ?? 0) > 0) {
+  // #924 — the two delegated codes that name scopes use the same `.scopes`
+  // line as `consent_missing`: same shape, same argument, different sentence
+  // above it. Listing them here rather than widening the condition to "has
+  // scopes" keeps the copy an explicit, reviewable decision per code.
+  const NAMES_SCOPES: readonly TeamsIdentityLastErrorDetailDto['code'][] = [
+    'consent_missing',
+    'delegated_sign_in_required',
+    'delegated_consent_required',
+  ];
+  if (NAMES_SCOPES.includes(detail.code) && (detail.scopes?.length ?? 0) > 0) {
     const scopes = detail.scopes as readonly string[];
     messages.push({
       key: `${base}.scopes`,
       values: { scopes: scopes.join(', '), count: scopes.length },
+    });
+  }
+
+  // #924 — the connector's own OAuth code, shown as an argument on its own
+  // line. It is the difference between "Microsoft refused" and knowing WHY.
+  if (detail.code === 'device_code_flow_failed' && (detail.reason ?? '') !== '') {
+    messages.push({
+      key: `${base}.reason`,
+      values: { reason: detail.reason as string },
     });
   }
 
@@ -709,6 +765,14 @@ export function teamsIdentityErrorMessages(
   // last, where a worried operator stops reading.
   if (detail.code === 'arm_not_configured') {
     messages.push({ key: `${base}.keepsRegistration` });
+  }
+
+  // #924 — the same reassurance for the three PARKED delegated codes, and for
+  // the same reason: the run stopped without failing, and everything it built
+  // is still there. Without this line an operator reads a red box and starts
+  // cleaning up an Entra app the next run is about to reuse.
+  if (needsTenantSignIn(detail)) {
+    messages.push({ key: `${base}.keepsProgress` });
   }
 
   return messages;

--- a/web-ui/app/_lib/teamsSignIn.ts
+++ b/web-ui/app/_lib/teamsSignIn.ts
@@ -1,0 +1,344 @@
+/**
+ * Client boundary for the TENANT Teams sign-in (`/api/v1/operator/teams/*`,
+ * byte5ai/omadia#924).
+ *
+ * WHY IT IS NOT IN `teamsIdentity.ts`. That module is the view of ONE agent's
+ * provisioning identity. This one is the view of something the whole
+ * deployment shares: a single admin sign-in that every agent — including ones
+ * that do not exist yet — provisions through. Keeping them apart in the client
+ * mirrors the split the middleware already makes between
+ * `/operator/agents/:slug/...` and `/operator/teams/...`, and it stops an
+ * agent-shaped mental model from creeping into a tenant-shaped feature.
+ *
+ * NOTHING HERE CAN SEE A SECRET, and that is a property of the SERVER, not of
+ * this file: the route never sends a token, and the device-code `flowHandle`
+ * never leaves the middleware process (the poll endpoint takes no body). So
+ * there is no redaction to perform here — only parsing. What this module does
+ * owe is TOTAL parsing: an older middleware, a proxy that mangles a field, a
+ * payload shape from a future version — none of them may take the panel down,
+ * because the panel is where an operator goes to fix things.
+ *
+ * `declined` IS NOT "THE ADMIN CANCELLED". Microsoft returns that verdict for
+ * a Conditional Access block, a device-compliance failure and an
+ * authentication-method requirement just as readily as for someone pressing
+ * cancel. {@link DeviceCodePollView} therefore keeps `reason` and the UI is
+ * required to show it — a panel that narrates an intent nobody expressed sends
+ * the operator to argue with a colleague instead of with a policy.
+ */
+
+import { ApiError } from './api';
+
+// ---------------------------------------------------------------------------
+// Transport (verbatim from `_lib/agents.ts` — see its header on why inlined)
+// ---------------------------------------------------------------------------
+
+function botApi(path: string): string {
+  if (typeof window !== 'undefined') {
+    return `/bot-api${path}`;
+  }
+  const base = process.env['MIDDLEWARE_URL'] ?? 'http://localhost:3979';
+  return `${base}/api${path}`;
+}
+
+async function forwardCookieHeader(): Promise<Record<string, string>> {
+  if (typeof window !== 'undefined') return {};
+  try {
+    const mod = await import('next/headers');
+    const jar = await mod.cookies();
+    const cookieHeader = jar
+      .getAll()
+      .map((c) => `${c.name}=${c.value}`)
+      .join('; ');
+    return cookieHeader ? { cookie: cookieHeader } : {};
+  } catch {
+    return {};
+  }
+}
+
+async function callJson<T>(
+  path: string,
+  init?: RequestInit & { method?: string },
+): Promise<T> {
+  const forwarded = await forwardCookieHeader();
+  const res = await fetch(botApi(path), {
+    ...init,
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      ...forwarded,
+      ...(init?.headers ?? {}),
+    },
+    cache: 'no-store',
+    credentials: 'include',
+  });
+  if (res.status === 204) return undefined as T;
+  const text = await res.text();
+  if (!res.ok) {
+    throw new ApiError(
+      res.status,
+      `${init?.method ?? 'GET'} ${path} failed: ${String(res.status)}`,
+      text,
+    );
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return undefined as T;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error vocabulary — the closed set the middleware answers with
+// ---------------------------------------------------------------------------
+
+export const TEAMS_SIGN_IN_ERROR_CODES = [
+  /** No sign-in stack in this mount (no vault / boot wiring). */
+  'teams_sign_in_unavailable',
+  /** No M365 connector installed at all. */
+  'teams_provisioner_unavailable',
+  /** Connector installed but older than 0.6.0 — an UPGRADE, not an install. */
+  'delegated_sign_in_unsupported',
+  /** Microsoft refused the flow: publisher app or Conditional Access. */
+  'device_code_flow_failed',
+  'teams_sign_in_failed',
+] as const;
+
+export type TeamsSignInErrorCode = (typeof TEAMS_SIGN_IN_ERROR_CODES)[number];
+
+const ERROR_CODE_SET: ReadonlySet<string> = new Set(TEAMS_SIGN_IN_ERROR_CODES);
+
+/** Total; `null` for anything this build does not recognise, which the panel
+ *  renders through its localized fallback with the detail as an argument. */
+export function parseTeamsSignInErrorCode(err: unknown): TeamsSignInErrorCode | null {
+  if (!(err instanceof ApiError)) return null;
+  try {
+    const parsed = JSON.parse(err.body) as { error?: unknown };
+    return typeof parsed.error === 'string' && ERROR_CODE_SET.has(parsed.error)
+      ? (parsed.error as TeamsSignInErrorCode)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// View models
+// ---------------------------------------------------------------------------
+
+export interface DelegatedAccountView {
+  readonly username: string | null;
+  readonly displayName: string | null;
+}
+
+/** Sign-in state as the panel renders it. Metadata only, by construction. */
+export interface TeamsSignInStateView {
+  readonly signedIn: boolean;
+  /** ISO — when THIS install stored the sign-in ("signed in since"). */
+  readonly signedInAt: string | null;
+  /** ISO — when the access token expires. */
+  readonly expiresAt: string | null;
+  /**
+   * The access token is past its expiry. NOT signed out: the refresh token
+   * outlives it and the next upload refreshes silently. The panel is required
+   * to render this as a neutral note, never as an error.
+   */
+  readonly accessTokenStale: boolean;
+  readonly scopes: readonly string[];
+  readonly tenantId: string | null;
+  readonly account: DelegatedAccountView | null;
+}
+
+/** A device-code flow waiting for a human. No handle — see the module header. */
+export interface DeviceCodePendingView {
+  readonly userCode: string;
+  readonly verificationUri: string;
+  readonly expiresAt: string;
+  readonly intervalSeconds: number;
+  readonly scopes: readonly string[];
+  /** Shown BESIDE the code, before anything fails. */
+  readonly adminConsentUrl: string;
+}
+
+export interface TeamsSignInStatusView {
+  /** The installed connector publishes the delegated half (>= 0.6.0). */
+  readonly supported: boolean;
+  readonly signIn: TeamsSignInStateView;
+  readonly pending: DeviceCodePendingView | null;
+}
+
+export type DeviceCodePollView =
+  | { readonly status: 'pending'; readonly retryAfterSeconds: number }
+  | { readonly status: 'succeeded'; readonly signIn: TeamsSignInStateView }
+  | { readonly status: 'expired'; readonly reason: string | null }
+  | { readonly status: 'declined'; readonly reason: string | null }
+  | { readonly status: 'no_flow' };
+
+// ---------------------------------------------------------------------------
+// Parsing — total, defensive, never throws
+// ---------------------------------------------------------------------------
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function stringArray(value: unknown): readonly string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
+}
+
+/** Signed out is the safe default for every shape this build cannot read: it
+ *  offers the sign-in button, which is the one action that can never be
+ *  wrong here. Claiming a sign-in that does not exist would be. */
+export const SIGNED_OUT_VIEW: TeamsSignInStateView = {
+  signedIn: false,
+  signedInAt: null,
+  expiresAt: null,
+  accessTokenStale: false,
+  scopes: [],
+  tenantId: null,
+  account: null,
+};
+
+export function parseSignInState(value: unknown): TeamsSignInStateView {
+  if (!isRecord(value) || value.signedIn !== true) return SIGNED_OUT_VIEW;
+  const account = isRecord(value.account)
+    ? {
+        username: optionalString(value.account.username),
+        displayName: optionalString(value.account.displayName),
+      }
+    : null;
+  return {
+    signedIn: true,
+    signedInAt: optionalString(value.signedInAt),
+    expiresAt: optionalString(value.expiresAt),
+    accessTokenStale: value.accessTokenStale === true,
+    scopes: stringArray(value.scopes),
+    tenantId: optionalString(value.tenantId),
+    // An account object with neither field is no account at all — rendering
+    // an empty "signed in as" line is worse than omitting it.
+    account: account && (account.username ?? account.displayName) ? account : null,
+  };
+}
+
+/**
+ * A pending flow, or `null`.
+ *
+ * The user code and the verification URL are BOTH required: a code with
+ * nowhere to type it, or a page with no code, is a dead end rather than a
+ * partial success — so a payload missing either drops to "no flow pending"
+ * and the panel offers the start button again.
+ */
+export function parsePendingFlow(value: unknown): DeviceCodePendingView | null {
+  if (!isRecord(value)) return null;
+  const userCode = optionalString(value.userCode);
+  const verificationUri = optionalString(value.verificationUri);
+  if (!userCode || !verificationUri) return null;
+  const interval = value.intervalSeconds;
+  return {
+    userCode,
+    verificationUri,
+    expiresAt: optionalString(value.expiresAt) ?? '',
+    intervalSeconds:
+      typeof interval === 'number' && Number.isFinite(interval) && interval > 0
+        ? Math.ceil(interval)
+        : DEFAULT_POLL_INTERVAL_SECONDS,
+    scopes: stringArray(value.scopes),
+    adminConsentUrl: optionalString(value.adminConsentUrl) ?? '',
+  };
+}
+
+export function parseSignInStatus(value: unknown): TeamsSignInStatusView {
+  const obj = isRecord(value) ? value : {};
+  return {
+    supported: obj.supported === true,
+    signIn: parseSignInState(obj.signIn),
+    pending: parsePendingFlow(obj.pending),
+  };
+}
+
+/**
+ * Narrow a poll answer.
+ *
+ * An unrecognised status becomes `no_flow` rather than an error: the honest
+ * consequence is "there is nothing to wait for", which puts the operator back
+ * on the start button instead of on a spinner that never resolves.
+ */
+export function parsePollResult(value: unknown): DeviceCodePollView {
+  if (!isRecord(value)) return { status: 'no_flow' };
+  switch (value.status) {
+    case 'pending': {
+      const retry = value.retryAfterSeconds;
+      return {
+        status: 'pending',
+        retryAfterSeconds:
+          typeof retry === 'number' && Number.isFinite(retry) && retry > 0
+            ? Math.ceil(retry)
+            : DEFAULT_POLL_INTERVAL_SECONDS,
+      };
+    }
+    case 'succeeded':
+      return { status: 'succeeded', signIn: parseSignInState(value.signIn) };
+    case 'expired':
+      return { status: 'expired', reason: optionalString(value.reason) };
+    case 'declined':
+      return { status: 'declined', reason: optionalString(value.reason) };
+    default:
+      return { status: 'no_flow' };
+  }
+}
+
+/** Floor for the poll cadence when the server named none. */
+export const DEFAULT_POLL_INTERVAL_SECONDS = 5;
+
+/**
+ * Seconds left on a pending flow, or `null` when it carries no usable expiry.
+ *
+ * Clamped at zero rather than going negative: a countdown that runs past the
+ * deadline into "-14s" reads as a bug, and the honest statement at that point
+ * is "expired".
+ */
+export function secondsRemaining(
+  expiresAt: string,
+  now: number = Date.now(),
+): number | null {
+  const deadline = Date.parse(expiresAt);
+  if (!Number.isFinite(deadline)) return null;
+  return Math.max(0, Math.round((deadline - now) / 1000));
+}
+
+// ---------------------------------------------------------------------------
+// Calls
+// ---------------------------------------------------------------------------
+
+export async function getTeamsSignInStatus(): Promise<TeamsSignInStatusView> {
+  return parseSignInStatus(await callJson<unknown>('/v1/operator/teams/sign-in'));
+}
+
+/** 202 — nothing has happened yet; a human still has to type the code. */
+export async function startTeamsSignIn(
+  displayName?: string,
+): Promise<DeviceCodePendingView | null> {
+  const body = await callJson<{ pending?: unknown }>('/v1/operator/teams/sign-in', {
+    method: 'POST',
+    body: JSON.stringify(displayName ? { display_name: displayName } : {}),
+  });
+  return parsePendingFlow(body?.pending);
+}
+
+/** NO ARGUMENTS BY DESIGN — the device code stays on the server. */
+export async function pollTeamsSignIn(): Promise<DeviceCodePollView> {
+  const body = await callJson<{ poll?: unknown }>('/v1/operator/teams/sign-in/poll', {
+    method: 'POST',
+  });
+  return parsePollResult(body?.poll);
+}
+
+export async function revokeTeamsSignIn(): Promise<TeamsSignInStatusView> {
+  const body = await callJson<{ signIn?: unknown }>('/v1/operator/teams/sign-in', {
+    method: 'DELETE',
+  });
+  return parseSignInStatus(body?.signIn);
+}

--- a/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentity.delegated.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsIdentity.delegated.test.tsx
@@ -1,0 +1,248 @@
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithIntl } from '../../../../_lib/test-utils';
+import type { TeamsIdentityStatusDto } from '../../../../_lib/agents';
+import { AgentTeamsIdentity } from '../_components/AgentTeamsIdentity';
+
+/**
+ * The agent panel's half of byte5ai/omadia#924.
+ *
+ * The tenant sign-in lives on its own page; what the AGENT panel owes is
+ * two things, and they are what these pin:
+ *
+ *   1. THE PACKAGE DOWNLOAD IS ALWAYS THERE. Not only after a failure — the
+ *      package is a pure render of the identity, so gating it on an error
+ *      state would hand it exclusively to operators already in trouble and
+ *      hide it from the ones calmly preparing a rollout. The copy has to say
+ *      it is a FALLBACK, or offering it quietly reinstates the per-agent
+ *      manual upload this whole change removed.
+ *
+ *   2. THE FOUR DELEGATED FAILURES ARE FOUR DIFFERENT MESSAGES, and three of
+ *      them link to the page that actually fixes them. A panel that says
+ *      "sign in" without a link leaves the operator hunting for a screen they
+ *      may not know exists; a panel that collapses the four leaves them
+ *      guessing which of four unrelated actions to take.
+ *
+ * `device_code_flow_failed` deliberately does NOT get that link: no amount of
+ * clicking "sign in" fixes a publisher app that refuses device-code flows.
+ */
+
+const { mockGet, mockProvision } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockProvision: vi.fn(),
+}));
+
+// Spread the real module so the error-code parser and the `last_error_detail`
+// narrower — the contracts this UI maps to catalogue keys — stay genuine.
+vi.mock('../../../../_lib/agents', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../_lib/agents')>()),
+  getAgentTeamsIdentity: mockGet,
+  provisionAgentTeamsIdentity: mockProvision,
+}));
+
+function statusDto(
+  overrides: Partial<TeamsIdentityStatusDto> = {},
+): TeamsIdentityStatusDto {
+  return {
+    ok: true,
+    agent: 'hr',
+    state: 'installed',
+    running: false,
+    provisioner_installed: true,
+    identity: {
+      bot_slug: 'hr',
+      display_name: 'HR Bot',
+      app_id: 'app-1',
+      tenant_id: 'tenant-1',
+      teams_app_id: 'teams-app-1',
+      teams_app_external_id: 'external-1',
+      team_id: 'team-1',
+      last_error: null,
+      last_error_detail: null,
+      created_at: null,
+      updated_at: null,
+    },
+    teams_bot: null,
+    ...overrides,
+  } as TeamsIdentityStatusDto;
+}
+
+/** A parked run: the state is real progress, the error explains the wait. */
+function parked(
+  code: string,
+  detail: Record<string, unknown> = {},
+): TeamsIdentityStatusDto {
+  return statusDto({
+    state: 'package_built',
+    identity: {
+      ...statusDto().identity,
+      last_error: `${code}: something the operator has to do`,
+      last_error_detail: {
+        code,
+        raw: `${code}: something the operator has to do`,
+        ...detail,
+      },
+    },
+  } as Partial<TeamsIdentityStatusDto>);
+}
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockProvision.mockReset();
+});
+
+describe('#924 the app package download', () => {
+  it('is offered on a healthy, installed identity', async () => {
+    mockGet.mockResolvedValue(statusDto());
+    renderWithIntl(<AgentTeamsIdentity slug="hr" />, { locale: 'de' });
+
+    const link = await screen.findByTestId('teams-package-download');
+    expect(link.getAttribute('href')).toBe(
+      '/bot-api/v1/operator/agents/hr/teams-identity/package',
+    );
+    // A real download, not a fetch-and-blob: the route sets
+    // Content-Disposition and the browser streams it under the right name.
+    expect(link.hasAttribute('download')).toBe(true);
+  });
+
+  it('presents itself as a FALLBACK, not as the normal path', async () => {
+    mockGet.mockResolvedValue(statusDto());
+    renderWithIntl(<AgentTeamsIdentity slug="hr" />, { locale: 'de' });
+
+    await screen.findByTestId('teams-package-download');
+    // If this copy ever goes missing, the panel silently reinstates the
+    // per-agent manual upload that #924 exists to remove.
+    expect(screen.getByText(/Rückfallebene/i)).toBeTruthy();
+    expect(screen.getByText(/lädt dieses Paket selbst/i)).toBeTruthy();
+  });
+
+  it('escapes the slug it puts in the URL', async () => {
+    mockGet.mockResolvedValue(statusDto({ agent: 'hr/../admin' }));
+    renderWithIntl(<AgentTeamsIdentity slug="hr" />, { locale: 'de' });
+
+    const link = await screen.findByTestId('teams-package-download');
+    expect(link.getAttribute('href')).toBe(
+      '/bot-api/v1/operator/agents/hr%2F..%2Fadmin/teams-identity/package',
+    );
+  });
+});
+
+describe('#924 the four delegated failures each get their own message', () => {
+  it('delegated_sign_in_required: says sign in, links the tenant page, and says nothing is broken', async () => {
+    mockGet.mockResolvedValue(
+      parked('delegated_sign_in_required', { scopes: ['AppCatalog.Submit'] }),
+    );
+    renderWithIntl(<AgentTeamsIdentity slug="hr" />, { locale: 'de' });
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/angemeldete Tenant-Administration/i);
+    expect(alert.textContent).toMatch(/AppCatalog\.Submit/);
+    // The link is what turns "sign in" from an instruction into an action.
+    expect(
+      screen.getByTestId('teams-tenant-sign-in-link').getAttribute('href'),
+    ).toBe('/operator/teams');
+  });
+
+  it('delegated_consent_required: links the tenant CONSENT url, not documentation', async () => {
+    const consentUrl = 'https://login.microsoftonline.com/tenant-1/adminconsent';
+    mockGet.mockResolvedValue(
+      parked('delegated_consent_required', {
+        scopes: ['AppCatalog.Submit'],
+        adminConsentUrl: consentUrl,
+      }),
+    );
+    renderWithIntl(<AgentTeamsIdentity slug="hr" />, { locale: 'de' });
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/noch niemand zugestimmt/i);
+    // The exact page an admin approves on — generic docs would not do.
+    const links = Array.from(alert.querySelectorAll('a')).map((a) =>
+      a.getAttribute('href'),
+    );
+    expect(links).toContain(consentUrl);
+  });
+
+  it('a non-https consent URL never becomes a link', async () => {
+    mockGet.mockResolvedValue(
+      parked('delegated_consent_required', {
+        adminConsentUrl: 'javascript:alert(1)',
+      }),
+    );
+    renderWithIntl(<AgentTeamsIdentity slug="hr" />, { locale: 'de' });
+
+    const alert = await screen.findByRole('alert');
+    const links = Array.from(alert.querySelectorAll('a')).map((a) =>
+      a.getAttribute('href'),
+    );
+    expect(links.some((href) => href?.startsWith('javascript:'))).toBe(false);
+  });
+
+  it('delegated_token_expired: says sign in AGAIN, distinctly from never having signed in', async () => {
+    mockGet.mockResolvedValue(parked('delegated_token_expired'));
+    renderWithIntl(<AgentTeamsIdentity slug="hr" />, { locale: 'de' });
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/nicht mehr gültig/i);
+    expect(alert.textContent).toMatch(/erneut an/i);
+    expect(screen.getByTestId('teams-tenant-sign-in-link')).toBeTruthy();
+  });
+
+  it('device_code_flow_failed: points at the publisher app, and does NOT offer a sign-in link', async () => {
+    mockGet.mockResolvedValue(
+      statusDto({
+        state: 'failed',
+        identity: {
+          ...statusDto().identity,
+          last_error: 'device_code_flow_failed: [invalid_client] refused',
+          last_error_detail: {
+            code: 'device_code_flow_failed',
+            reason: 'invalid_client',
+            raw: 'device_code_flow_failed: [invalid_client] refused',
+          },
+        },
+      } as Partial<TeamsIdentityStatusDto>),
+    );
+    renderWithIntl(<AgentTeamsIdentity slug="hr" />, { locale: 'de' });
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toMatch(/Publisher-App/i);
+    expect(alert.textContent).toMatch(/Conditional-Access/i);
+    expect(alert.textContent).toMatch(/invalid_client/);
+    // Clicking "sign in" cannot fix a publisher app — offering it would send
+    // the operator round a loop that never resolves.
+    expect(screen.queryByTestId('teams-tenant-sign-in-link')).toBeNull();
+  });
+
+  it('the four render four different explanations', async () => {
+    const texts = new Set<string>();
+    for (const code of [
+      'delegated_sign_in_required',
+      'delegated_consent_required',
+      'delegated_token_expired',
+      'device_code_flow_failed',
+    ]) {
+      mockGet.mockResolvedValue(parked(code));
+      const { unmount } = renderWithIntl(<AgentTeamsIdentity slug="hr" />, {
+        locale: 'de',
+      });
+      const alert = await screen.findByRole('alert');
+      texts.add(alert.textContent ?? '');
+      unmount();
+    }
+    expect(texts.size).toBe(4);
+  });
+});
+
+describe('#924 a parked run is not presented as a failure', () => {
+  it('keeps the reached state visible and says progress is kept', async () => {
+    mockGet.mockResolvedValue(parked('delegated_sign_in_required'));
+    renderWithIntl(<AgentTeamsIdentity slug="hr" />, { locale: 'de' });
+
+    const alert = await screen.findByRole('alert');
+    // The whole point of parking: the Entra app and the bot survive, so the
+    // operator must not be told to clean anything up or start over.
+    expect(alert.textContent).toMatch(/wartet/i);
+    expect(alert.textContent).toMatch(/bleiben bestehen|weiter/i);
+  });
+});

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentity.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentity.tsx
@@ -5,6 +5,7 @@ import { useFormatter, useTranslations } from 'next-intl';
 
 import { Button } from '@/app/_components/ui/Button';
 import {
+  agentTeamsPackageUrl,
   getAgentTeamsIdentity,
   isTerminalTeamsProvisioningState,
   parseTeamsIdentityErrorCode,
@@ -412,6 +413,8 @@ function ReadyPanel(props: {
         />
       </dl>
 
+      <TeamsAppPackageDownload slug={status.agent} />
+
       <TeamsBotConfigBlock status={status} />
 
       {status.identity.updated_at && (
@@ -421,6 +424,50 @@ function ReadyPanel(props: {
           })}
         </p>
       )}
+    </div>
+  );
+}
+
+/**
+ * The Teams app package, as a download (#924).
+ *
+ * A FALLBACK, AND THE COPY SAYS SO. Since the tenant sign-in landed, the
+ * package is uploaded to the catalogue by provisioning itself — no operator
+ * uploads anything per agent any more. This stays for the cases that are
+ * always left over: a tenant whose policy forbids programmatic catalogue
+ * writes, an admin who wants to read the manifest before it goes live, a
+ * support conversation. Presenting it as the normal path would undo the very
+ * change that removed the manual step.
+ *
+ * ALWAYS OFFERED, not only after a failure. The package is a pure render of
+ * the identity, so withholding it from a healthy agent would hand it only to
+ * operators already in trouble and hide it from the ones calmly preparing a
+ * rollout.
+ *
+ * A PLAIN LINK, not a fetch-and-blob: the route answers with
+ * `Content-Disposition: attachment`, so the browser saves it under the right
+ * name and streams it without this page holding the bytes.
+ */
+function TeamsAppPackageDownload(props: {
+  readonly slug: string;
+}): React.ReactElement {
+  const t = useTranslations('operatorAgents');
+  return (
+    <div className="space-y-1">
+      <h3 className="text-sm font-medium">
+        {t('teamsIdentity.package.heading')}
+      </h3>
+      <p className="text-xs text-[color:var(--fg-muted)]">
+        {t('teamsIdentity.package.hint')}
+      </p>
+      <a
+        data-testid="teams-package-download"
+        href={agentTeamsPackageUrl(props.slug)}
+        download
+        className="inline-block text-xs text-[color:var(--accent)] underline"
+      >
+        {t('teamsIdentity.package.download')}
+      </a>
     </div>
   );
 }

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentityParts.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsIdentityParts.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useFormatter, useTranslations } from 'next-intl';
 
 import {
@@ -8,6 +9,7 @@ import {
   type TeamsProvisioningState,
 } from '../../../../_lib/agents';
 import {
+  needsTenantSignIn,
   teamsIdentityErrorLink,
   teamsIdentityErrorMessages,
   teamsIdentityErrorTechnicalDetail,
@@ -131,6 +133,20 @@ export function LastError(props: {
           >
             {t(`teamsIdentity.${link.labelKey}`)}
           </a>
+        </p>
+      )}
+      {/* #924 — three of the four delegated codes are fixed on ANOTHER page:
+          the tenant sign-in. Naming it without linking it would leave the
+          operator to find a page they may not know exists. */}
+      {needsTenantSignIn(detail) && (
+        <p className="mt-1">
+          <Link
+            href="/operator/teams"
+            data-testid="teams-tenant-sign-in-link"
+            className="underline"
+          >
+            {t('teamsIdentity.errors.tenantSignInLink')}
+          </Link>
         </p>
       )}
       <details className="mt-1">

--- a/web-ui/app/operator/teams/__tests__/TeamsTenantSignIn.test.tsx
+++ b/web-ui/app/operator/teams/__tests__/TeamsTenantSignIn.test.tsx
@@ -1,0 +1,298 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithIntl } from '../../../_lib/test-utils';
+import { TeamsTenantSignIn } from '../_components/TeamsTenantSignIn';
+
+/**
+ * The tenant Teams sign-in panel (byte5ai/omadia#924).
+ *
+ * What these pin, beyond "it renders":
+ *
+ *   - THE CODE AND THE CONSENT URL ARE BOTH ON SCREEN WHILE THE FLOW RUNS.
+ *     The code is what the admin types; the consent URL is what saves them when
+ *     the sign-in page demands approval first. An admin who meets that prompt
+ *     without the link is stuck with no way forward, and no error will ever
+ *     tell them so — which is why the link must be there BEFORE anything fails.
+ *   - `declined` IS NOT RENDERED AS "THE ADMIN CANCELLED". Microsoft returns
+ *     that verdict for Conditional Access blocks too. The copy stays neutral
+ *     and the server's `reason` is shown, because that string is the only
+ *     thing that tells the two cases apart.
+ *   - `accessTokenStale` IS NOT AN ERROR. The refresh token outlives the
+ *     access token; showing it as a failure would send an operator to fix
+ *     something that fixes itself on the next upload.
+ *   - A CONNECTOR TOO OLD IS AN UPGRADE, not a missing install — a different
+ *     sentence and a different action.
+ *   - NO SECRET IS EVER RENDERED. The panel has no access to one by
+ *     construction; this asserts the construction holds.
+ */
+
+const { mockStatus, mockStart, mockPoll, mockRevoke } = vi.hoisted(() => ({
+  mockStatus: vi.fn(),
+  mockStart: vi.fn(),
+  mockPoll: vi.fn(),
+  mockRevoke: vi.fn(),
+}));
+
+// Spread the real module so the parsers and `secondsRemaining` — the shared
+// contracts this panel renders from — stay genuine; only the four calls are
+// stubbed.
+vi.mock('../../../_lib/teamsSignIn', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../_lib/teamsSignIn')>()),
+  getTeamsSignInStatus: mockStatus,
+  startTeamsSignIn: mockStart,
+  pollTeamsSignIn: mockPoll,
+  revokeTeamsSignIn: mockRevoke,
+}));
+
+const CONSENT_URL = 'https://login.microsoftonline.com/tenant-1/adminconsent';
+
+function signedOut(overrides: Record<string, unknown> = {}) {
+  return {
+    supported: true,
+    signIn: {
+      signedIn: false,
+      signedInAt: null,
+      expiresAt: null,
+      accessTokenStale: false,
+      scopes: [],
+      tenantId: null,
+      account: null,
+    },
+    pending: null,
+    ...overrides,
+  };
+}
+
+function pendingFlow(overrides: Record<string, unknown> = {}) {
+  return {
+    userCode: 'GH7K-QW2P',
+    verificationUri: 'https://microsoft.com/devicelogin',
+    expiresAt: new Date(Date.now() + 600_000).toISOString(),
+    intervalSeconds: 5,
+    scopes: ['AppCatalog.Submit'],
+    adminConsentUrl: CONSENT_URL,
+    ...overrides,
+  };
+}
+
+function signedIn(overrides: Record<string, unknown> = {}) {
+  return {
+    signedIn: true,
+    signedInAt: '2026-08-01T09:00:00.000Z',
+    expiresAt: '2026-08-28T18:00:00.000Z',
+    accessTokenStale: false,
+    scopes: ['AppCatalog.Submit'],
+    tenantId: 'tenant-1',
+    account: { username: 'admin@contoso.test', displayName: 'Ada Admin' },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockStatus.mockReset();
+  mockStart.mockReset();
+  mockPoll.mockReset();
+  mockRevoke.mockReset();
+  mockPoll.mockResolvedValue({ status: 'pending', retryAfterSeconds: 5 });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('TeamsTenantSignIn — signed out', () => {
+  it('explains WHY this step exists before asking for anything', async () => {
+    mockStatus.mockResolvedValue(signedOut());
+    renderWithIntl(<TeamsTenantSignIn />, { locale: 'de' });
+
+    await screen.findByTestId('teams-signed-out');
+    // An operator who does not know that Microsoft refuses app-only catalogue
+    // uploads reads this whole screen as bureaucracy.
+    expect(screen.getByText(/nur im Namen einer angemeldeten Person/i)).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: /Anmeldung starten/i }),
+    ).toBeTruthy();
+  });
+
+  it('says "upgrade", not "install", when the connector is too old', async () => {
+    mockStatus.mockResolvedValue(signedOut({ supported: false }));
+    renderWithIntl(<TeamsTenantSignIn />, { locale: 'de' });
+
+    const notice = await screen.findByTestId('teams-sign-in-unsupported');
+    expect(notice.textContent).toMatch(/0\.6\.0/);
+    expect(notice.textContent).toMatch(/bereits/i);
+    // The button would answer 503 — offering it would be a lie about the state.
+    expect(
+      screen.getByRole('button', { name: /Anmeldung starten/i }),
+    ).toHaveProperty('disabled', true);
+  });
+});
+
+describe('TeamsTenantSignIn — flow running', () => {
+  it('shows the code, the verification link AND the consent URL together', async () => {
+    mockStatus.mockResolvedValue(signedOut());
+    mockStart.mockResolvedValue(pendingFlow());
+    const user = userEvent.setup();
+    renderWithIntl(<TeamsTenantSignIn />, { locale: 'de' });
+
+    await screen.findByTestId('teams-signed-out');
+    await user.click(screen.getByRole('button', { name: /Anmeldung starten/i }));
+
+    const code = await screen.findByTestId('teams-user-code');
+    expect(code.textContent).toBe('GH7K-QW2P');
+
+    expect(
+      screen.getByTestId('teams-verification-link').getAttribute('href'),
+    ).toBe('https://microsoft.com/devicelogin');
+
+    // THE dead-end guard: present while the flow runs, not only after a
+    // failure. Without it, an admin who meets a consent prompt cannot continue.
+    const consent = screen.getByTestId('teams-consent-link');
+    expect(consent.getAttribute('href')).toBe(CONSENT_URL);
+  });
+
+  it('renders a live countdown so the panel is visibly alive between polls', async () => {
+    mockStatus.mockResolvedValue(
+      signedOut({ pending: pendingFlow({ expiresAt: new Date(Date.now() + 120_000).toISOString() }) }),
+    );
+    renderWithIntl(<TeamsTenantSignIn />, { locale: 'de' });
+
+    const countdown = await screen.findByTestId('teams-code-countdown');
+    expect(countdown.textContent).toMatch(/\d+ Sekunden/);
+  });
+
+  it('a flow already running on the server comes back after a page reload', async () => {
+    // The operator refreshed mid-sign-in. Making them start over would waste a
+    // code that is still perfectly valid.
+    mockStatus.mockResolvedValue(signedOut({ pending: pendingFlow() }));
+    renderWithIntl(<TeamsTenantSignIn />, { locale: 'de' });
+
+    expect((await screen.findByTestId('teams-user-code')).textContent).toBe(
+      'GH7K-QW2P',
+    );
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  // A flow missing its verification target is dropped at the BOUNDARY, not
+  // here — `parsePendingFlow` owns that, and it is asserted in
+  // `app/_lib/__tests__/teamsSignIn.test.ts`. Asserting it through a mocked
+  // `getTeamsSignInStatus` would have proved nothing: the mock replaces the
+  // very parser under test.
+});
+
+describe('TeamsTenantSignIn — terminal verdicts', () => {
+  it('renders `declined` WITHOUT blaming the admin, and shows the reason', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockStatus.mockResolvedValue(signedOut({ pending: pendingFlow() }));
+    mockPoll.mockResolvedValue({
+      status: 'declined',
+      reason: 'AADSTS53003: blocked by a Conditional Access policy',
+    });
+    renderWithIntl(<TeamsTenantSignIn />, { locale: 'de' });
+
+    await screen.findByTestId('teams-user-code');
+    await vi.advanceTimersByTimeAsync(6000);
+
+    const notice = await screen.findByTestId('teams-sign-in-declined');
+    // Neutral copy: a policy block reaches this same branch.
+    expect(notice.textContent).toMatch(/nicht abgeschlossen/i);
+    expect(notice.textContent).not.toMatch(/abgebrochen von|hat abgebrochen/i);
+    // The one string that tells cancel and policy apart must be visible.
+    expect(notice.textContent).toMatch(/Conditional Access/);
+  });
+
+  it('renders `expired` as a harmless restart, not a failure', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockStatus.mockResolvedValue(signedOut({ pending: pendingFlow() }));
+    mockPoll.mockResolvedValue({ status: 'expired', reason: null });
+    renderWithIntl(<TeamsTenantSignIn />, { locale: 'de' });
+
+    await screen.findByTestId('teams-user-code');
+    await vi.advanceTimersByTimeAsync(6000);
+
+    const notice = await screen.findByTestId('teams-sign-in-expired');
+    expect(notice.textContent).toMatch(/nichts angelegt|nichts verändert/i);
+    // Back to a usable state rather than a dead panel.
+    await screen.findByTestId('teams-signed-out');
+  });
+});
+
+describe('TeamsTenantSignIn — signed in', () => {
+  it('shows who, since when, and until when', async () => {
+    mockStatus.mockResolvedValue(signedOut({ signIn: signedIn() }));
+    renderWithIntl(<TeamsTenantSignIn />, { locale: 'de' });
+
+    const panel = await screen.findByTestId('teams-signed-in');
+    expect(panel.textContent).toMatch(/Ada Admin/);
+    expect(panel.textContent).toMatch(/Angemeldet seit/);
+    expect(panel.textContent).toMatch(/Zugriffstoken läuft ab/);
+    expect(screen.getByRole('button', { name: /Abmelden/i })).toBeTruthy();
+  });
+
+  it('a stale access token is a neutral note, never an alert', async () => {
+    mockStatus.mockResolvedValue(
+      signedOut({ signIn: signedIn({ accessTokenStale: true }) }),
+    );
+    renderWithIntl(<TeamsTenantSignIn />, { locale: 'de' });
+
+    // Still signed in — this is the assertion the whole field exists for.
+    await screen.findByTestId('teams-signed-in');
+    const note = screen.getByTestId('teams-token-stale');
+    expect(note.getAttribute('role')).toBe('status');
+    expect(note.textContent).toMatch(/kein Fehler/i);
+    // Not an alert anywhere on the page.
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('signing out returns the panel to the signed-out state', async () => {
+    mockStatus.mockResolvedValue(signedOut({ signIn: signedIn() }));
+    mockRevoke.mockResolvedValue(signedOut());
+    const user = userEvent.setup();
+    renderWithIntl(<TeamsTenantSignIn />, { locale: 'de' });
+
+    await screen.findByTestId('teams-signed-in');
+    await user.click(screen.getByRole('button', { name: /Abmelden/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teams-signed-out')).toBeTruthy();
+    });
+    expect(mockRevoke).toHaveBeenCalledOnce();
+  });
+});
+
+describe('TeamsTenantSignIn — nothing secret is rendered', () => {
+  it('polls without arguments, so no device code can pass through the client', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockStatus.mockResolvedValue(signedOut({ pending: pendingFlow() }));
+    renderWithIntl(<TeamsTenantSignIn />, { locale: 'de' });
+
+    await screen.findByTestId('teams-user-code');
+    await vi.advanceTimersByTimeAsync(6000);
+
+    await waitFor(() => {
+      expect(mockPoll).toHaveBeenCalled();
+    });
+    // The whole point of holding the handle server-side: the client has no
+    // argument to leak, replay or put in a URL.
+    for (const call of mockPoll.mock.calls) {
+      expect(call).toHaveLength(0);
+    }
+  });
+
+  it('a token smuggled into the payload is dropped by the parser, not displayed', async () => {
+    // A hostile or buggy middleware. The parser is an allow-list, so extra
+    // fields never reach the render — this asserts that end to end.
+    mockStatus.mockResolvedValue({
+      supported: true,
+      signIn: { ...signedIn(), accessToken: 'SENTINEL-LEAK-1234' },
+      pending: { ...pendingFlow(), flowHandle: 'SENTINEL-HANDLE-5678' },
+    });
+    const { container } = renderWithIntl(<TeamsTenantSignIn />, { locale: 'de' });
+
+    await screen.findByTestId('teams-user-code');
+    expect(container.innerHTML).not.toContain('SENTINEL-LEAK-1234');
+    expect(container.innerHTML).not.toContain('SENTINEL-HANDLE-5678');
+  });
+});

--- a/web-ui/app/operator/teams/_components/TeamsTenantSignIn.tsx
+++ b/web-ui/app/operator/teams/_components/TeamsTenantSignIn.tsx
@@ -1,0 +1,519 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useFormatter, useTranslations } from 'next-intl';
+
+import { Button } from '@/app/_components/ui/Button';
+import {
+  DEFAULT_POLL_INTERVAL_SECONDS,
+  getTeamsSignInStatus,
+  parseTeamsSignInErrorCode,
+  pollTeamsSignIn,
+  revokeTeamsSignIn,
+  secondsRemaining,
+  startTeamsSignIn,
+  SIGNED_OUT_VIEW,
+  type DeviceCodePendingView,
+  type TeamsSignInStatusView,
+} from '@/app/_lib/teamsSignIn';
+
+/**
+ * The TENANT Teams sign-in (byte5ai/omadia#924).
+ *
+ * WHY THIS IS A PAGE OF ITS OWN, and not a block in the agent detail panel.
+ * One admin signs in once for the whole directory; every agent provisioned
+ * afterwards — including ones nobody has created yet — uses that sign-in.
+ * Putting it inside an agent would have said the opposite: that the sign-in
+ * belongs to that agent, which is the per-agent manual step this whole change
+ * exists to delete. It would also have made the natural first move — sign in
+ * BEFORE creating your first agent — impossible to reach.
+ *
+ * THREE STATES, THREE DIFFERENT JOBS:
+ *
+ *   NOT SIGNED IN — one sentence on why this step exists at all (an operator
+ *   who does not know that Microsoft refuses app-only catalogue uploads reads
+ *   this screen as bureaucracy), and one button.
+ *
+ *   FLOW RUNNING — the user code, big and copyable, because it is read off one
+ *   screen and typed into another; the verification link; a live countdown; and
+ *   the admin-consent URL RIGHT THERE, not hidden until something fails. An
+ *   admin whose sign-in page demands consent first and who has not been given
+ *   that URL is simply stuck.
+ *
+ *   SIGNED IN — who, since when, until when, and sign out. `accessTokenStale`
+ *   is rendered as a neutral note: the refresh token outlives the access token
+ *   and the next upload refreshes silently, so showing it in red would send an
+ *   operator to fix something that fixes itself.
+ *
+ * `declined` IS NEVER RENDERED AS "THE ADMIN CANCELLED". Microsoft returns it
+ * for Conditional Access blocks and device-compliance failures just as readily.
+ * The copy stays neutral and the server's `reason` is shown verbatim as a
+ * technical line — that string is the only thing that tells the cases apart.
+ *
+ * NO SECRET REACHES THIS COMPONENT. The device-code `flowHandle` never leaves
+ * the middleware and the poll endpoint takes no arguments — so there is nothing
+ * here to guard, which is the point of putting the guarantee in the server.
+ */
+
+/** Polling stops at this age even if the server never says `expired`, so a tab
+ *  left open overnight does not hammer the endpoint forever. */
+const MAX_FLOW_LIFETIME_MS = 20 * 60 * 1000;
+
+type Phase =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'ready' }
+  /** A terminal poll verdict, kept on screen until the operator acts. */
+  | { readonly kind: 'expired'; readonly reason: string | null }
+  | { readonly kind: 'declined'; readonly reason: string | null };
+
+export function TeamsTenantSignIn(): React.ReactElement {
+  const t = useTranslations('operatorTeamsSignIn');
+  const format = useFormatter();
+
+  const [status, setStatus] = useState<TeamsSignInStatusView>({
+    supported: false,
+    signIn: SIGNED_OUT_VIEW,
+    pending: null,
+  });
+  const [phase, setPhase] = useState<Phase>({ kind: 'loading' });
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+  const aliveRef = useRef(true);
+  const flowStartedRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  const localizeError = useCallback(
+    (err: unknown): string => {
+      const code = parseTeamsSignInErrorCode(err);
+      return code !== null
+        ? t(`errors.${code}`)
+        : t('errors.unknown', {
+            detail: err instanceof Error ? err.message : String(err),
+          });
+    },
+    [t],
+  );
+
+  const load = useCallback(async (): Promise<void> => {
+    try {
+      const next = await getTeamsSignInStatus();
+      if (!aliveRef.current) return;
+      setStatus(next);
+      setPhase({ kind: 'ready' });
+      // A flow the server already had (this page was reopened mid-sign-in)
+      // starts its lifetime clock now — losing a few minutes of budget is
+      // better than never timing out.
+      if (next.pending && flowStartedRef.current === null) {
+        flowStartedRef.current = Date.now();
+      }
+    } catch (err: unknown) {
+      if (!aliveRef.current) return;
+      setPhase({ kind: 'ready' });
+      setActionError(localizeError(err));
+    }
+  }, [localizeError]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const pending = status.pending;
+
+  // The countdown. A second ticker rather than one derived from the poll, so
+  // the number keeps moving between two polls that return identical data —
+  // which is the entire reason an operator believes the page is alive.
+  useEffect(() => {
+    if (!pending) return undefined;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [pending]);
+
+  // The live poll, at the cadence Microsoft asked for.
+  useEffect(() => {
+    if (!pending) return undefined;
+    let cancelled = false;
+    const intervalMs =
+      Math.max(pending.intervalSeconds, DEFAULT_POLL_INTERVAL_SECONDS) * 1000;
+
+    const tick = async (): Promise<void> => {
+      const started = flowStartedRef.current;
+      if (started !== null && Date.now() - started > MAX_FLOW_LIFETIME_MS) {
+        setPhase({ kind: 'expired', reason: null });
+        setStatus((prev) => ({ ...prev, pending: null }));
+        return;
+      }
+      try {
+        const result = await pollTeamsSignIn();
+        if (cancelled || !aliveRef.current) return;
+        switch (result.status) {
+          case 'succeeded':
+            flowStartedRef.current = null;
+            setStatus((prev) => ({ ...prev, signIn: result.signIn, pending: null }));
+            setPhase({ kind: 'ready' });
+            break;
+          case 'expired':
+            flowStartedRef.current = null;
+            setStatus((prev) => ({ ...prev, pending: null }));
+            setPhase({ kind: 'expired', reason: result.reason });
+            break;
+          case 'declined':
+            flowStartedRef.current = null;
+            setStatus((prev) => ({ ...prev, pending: null }));
+            setPhase({ kind: 'declined', reason: result.reason });
+            break;
+          case 'no_flow':
+            // The server forgot the flow (a restart). Say nothing dramatic —
+            // clearing the panel puts the start button back, which is the
+            // only useful move left.
+            flowStartedRef.current = null;
+            setStatus((prev) => ({ ...prev, pending: null }));
+            setPhase({ kind: 'ready' });
+            break;
+          case 'pending':
+            break;
+        }
+      } catch (err: unknown) {
+        if (cancelled || !aliveRef.current) return;
+        setActionError(localizeError(err));
+      }
+    };
+
+    const id = setInterval(() => void tick(), intervalMs);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [pending, localizeError]);
+
+  async function start(): Promise<void> {
+    setBusy(true);
+    setActionError(null);
+    setPhase({ kind: 'ready' });
+    try {
+      const started = await startTeamsSignIn();
+      if (!aliveRef.current) return;
+      flowStartedRef.current = Date.now();
+      setStatus((prev) => ({ ...prev, pending: started }));
+      setNow(Date.now());
+    } catch (err: unknown) {
+      if (aliveRef.current) setActionError(localizeError(err));
+    } finally {
+      if (aliveRef.current) setBusy(false);
+    }
+  }
+
+  async function signOut(): Promise<void> {
+    setBusy(true);
+    setActionError(null);
+    try {
+      const next = await revokeTeamsSignIn();
+      if (!aliveRef.current) return;
+      flowStartedRef.current = null;
+      setStatus(next);
+      setPhase({ kind: 'ready' });
+    } catch (err: unknown) {
+      if (aliveRef.current) setActionError(localizeError(err));
+    } finally {
+      if (aliveRef.current) setBusy(false);
+    }
+  }
+
+  const onCopyCode = useCallback(async (): Promise<void> => {
+    if (!pending) return;
+    try {
+      await navigator.clipboard.writeText(pending.userCode);
+      setCopied(true);
+    } catch {
+      // Soft failure (insecure context, denied permission). The code is right
+      // there in selectable text — not worth an error banner.
+      setCopied(false);
+    }
+  }, [pending]);
+
+  const signIn = status.signIn;
+
+  return (
+    <section className="rounded border border-[color:var(--border)] bg-[color:var(--bg-elevated)] p-4">
+      <div className="mb-1 flex flex-wrap items-center gap-2">
+        <h2 className="text-lg font-medium">{t('heading')}</h2>
+        <div className="ml-auto">
+          <Button size="sm" variant="ghost" onClick={() => void load()}>
+            {t('refresh')}
+          </Button>
+        </div>
+      </div>
+      {/* The one sentence that turns this from bureaucracy into a reason. */}
+      <p className="mb-3 text-xs text-[color:var(--fg-muted)]">{t('why')}</p>
+
+      {actionError && (
+        <div
+          role="alert"
+          className="mb-3 rounded border border-[color:var(--danger-edge)] bg-[color:var(--danger)]/8 p-3 text-sm text-[color:var(--danger)]"
+        >
+          {actionError}
+        </div>
+      )}
+
+      {phase.kind === 'loading' && (
+        <p className="text-sm text-[color:var(--fg-muted)]">{t('loading')}</p>
+      )}
+
+      {/* A connector older than 0.6.0 is an UPGRADE, not a fault — and not the
+          same message as "no connector installed". */}
+      {phase.kind !== 'loading' && !status.supported && (
+        <p
+          role="status"
+          data-testid="teams-sign-in-unsupported"
+          className="mb-3 rounded border border-[color:var(--border)] bg-[color:var(--bg-soft)]/40 p-3 text-sm text-[color:var(--fg-muted)]"
+        >
+          {t('unsupported')}
+        </p>
+      )}
+
+      {phase.kind === 'expired' && (
+        <TerminalNotice
+          testId="teams-sign-in-expired"
+          headline={t('expired.headline')}
+          body={t('expired.body')}
+          reason={phase.reason}
+          reasonLabel={t('technicalReason')}
+        />
+      )}
+
+      {/* NOT "the admin cancelled": a Conditional Access block lands here too,
+          so the copy stays neutral and the server's reason does the telling. */}
+      {phase.kind === 'declined' && (
+        <TerminalNotice
+          testId="teams-sign-in-declined"
+          headline={t('declined.headline')}
+          body={t('declined.body')}
+          reason={phase.reason}
+          reasonLabel={t('technicalReason')}
+        />
+      )}
+
+      {phase.kind !== 'loading' && pending && (
+        <PendingFlow
+          flow={pending}
+          now={now}
+          copied={copied}
+          onCopy={() => void onCopyCode()}
+        />
+      )}
+
+      {phase.kind !== 'loading' && !pending && signIn.signedIn && (
+        <div className="space-y-3" data-testid="teams-signed-in">
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <span className="rounded-full border border-[color:var(--accent)] bg-[color:var(--accent)]/10 px-2 py-0.5 text-xs text-[color:var(--accent)]">
+              {t('signedIn.badge')}
+            </span>
+            <span className="text-[color:var(--fg-strong)]">
+              {t('signedIn.as', {
+                who:
+                  signIn.account?.displayName ??
+                  signIn.account?.username ??
+                  t('signedIn.unknownAccount'),
+              })}
+            </span>
+            <div className="ml-auto">
+              <Button
+                size="sm"
+                variant="secondary"
+                busy={busy}
+                busyLabel={t('signOutBusy')}
+                onClick={() => void signOut()}
+              >
+                {t('signOut')}
+              </Button>
+            </div>
+          </div>
+          <dl className="grid gap-x-4 gap-y-1 text-xs sm:grid-cols-2">
+            {signIn.signedInAt && (
+              <Fact
+                label={t('signedIn.since')}
+                value={format.dateTime(new Date(signIn.signedInAt), {
+                  dateStyle: 'medium',
+                  timeStyle: 'short',
+                })}
+              />
+            )}
+            {signIn.expiresAt && (
+              <Fact
+                label={t('signedIn.tokenExpires')}
+                value={format.dateTime(new Date(signIn.expiresAt), {
+                  dateStyle: 'medium',
+                  timeStyle: 'short',
+                })}
+              />
+            )}
+            {signIn.tenantId && (
+              <Fact label={t('signedIn.tenant')} value={signIn.tenantId} />
+            )}
+            {signIn.scopes.length > 0 && (
+              <Fact
+                label={t('signedIn.scopes')}
+                value={signIn.scopes.join(', ')}
+              />
+            )}
+          </dl>
+          {/* Deliberately NOT an alert: the refresh token outlives the access
+              token, so this fixes itself on the next upload. */}
+          {signIn.accessTokenStale && (
+            <p
+              role="status"
+              data-testid="teams-token-stale"
+              className="text-xs text-[color:var(--fg-muted)]"
+            >
+              {t('signedIn.staleNote')}
+            </p>
+          )}
+        </div>
+      )}
+
+      {phase.kind !== 'loading' && !pending && !signIn.signedIn && (
+        <div className="space-y-3" data-testid="teams-signed-out">
+          <p className="text-sm text-[color:var(--fg-muted)]">
+            {t('signedOut.body')}
+          </p>
+          <Button
+            size="sm"
+            busy={busy}
+            disabled={!status.supported}
+            busyLabel={t('startBusy')}
+            onClick={() => void start()}
+          >
+            {t('start')}
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+/**
+ * The running flow.
+ *
+ * The code is the largest thing on the page for a literal reason: it is read
+ * off this screen and typed into another device. The consent URL sits beside
+ * it, not behind an error, because that is the difference between an admin who
+ * finishes and an admin who gets stuck on a permissions prompt.
+ */
+function PendingFlow(props: {
+  readonly flow: DeviceCodePendingView;
+  readonly now: number;
+  readonly copied: boolean;
+  readonly onCopy: () => void;
+}): React.ReactElement {
+  const t = useTranslations('operatorTeamsSignIn');
+  const remaining = secondsRemaining(props.flow.expiresAt, props.now);
+
+  return (
+    <div className="space-y-3" data-testid="teams-sign-in-pending">
+      <p className="text-sm text-[color:var(--fg-strong)]">{t('pending.instructions')}</p>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <code
+          data-testid="teams-user-code"
+          aria-label={t('pending.codeLabel')}
+          className="select-all rounded border border-[color:var(--border)] bg-[color:var(--bg-soft)]/40 px-4 py-2 font-mono text-2xl tracking-[0.25em] text-[color:var(--fg-strong)]"
+        >
+          {props.flow.userCode}
+        </code>
+        <Button size="sm" variant="ghost" onClick={props.onCopy}>
+          {props.copied ? t('pending.copied') : t('pending.copy')}
+        </Button>
+      </div>
+
+      <p className="text-sm">
+        <a
+          data-testid="teams-verification-link"
+          href={props.flow.verificationUri}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="text-[color:var(--accent)] underline"
+        >
+          {t('pending.openVerification')}
+        </a>
+      </p>
+
+      {remaining !== null && (
+        <p
+          data-testid="teams-code-countdown"
+          className="text-xs text-[color:var(--fg-muted)]"
+        >
+          {t('pending.expiresIn', { seconds: remaining })}
+        </p>
+      )}
+
+      {/* Shown UP FRONT, not after a failure. An admin who meets a consent
+          prompt without this link has no way forward from here. */}
+      {props.flow.adminConsentUrl !== '' && (
+        <div className="rounded border border-[color:var(--border)] bg-[color:var(--bg-soft)]/40 p-3">
+          <p className="text-xs text-[color:var(--fg-muted)]">
+            {t('pending.consentHint')}
+          </p>
+          <a
+            data-testid="teams-consent-link"
+            href={props.flow.adminConsentUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="text-xs text-[color:var(--accent)] underline"
+          >
+            {t('pending.consentLink')}
+          </a>
+        </div>
+      )}
+
+      <p role="status" className="text-xs text-[color:var(--fg-muted)]">
+        {t('pending.waiting')}
+      </p>
+    </div>
+  );
+}
+
+/** A terminal poll verdict: what happened, what to do, and the raw reason. */
+function TerminalNotice(props: {
+  readonly testId: string;
+  readonly headline: string;
+  readonly body: string;
+  readonly reason: string | null;
+  readonly reasonLabel: string;
+}): React.ReactElement {
+  return (
+    <div
+      role="status"
+      data-testid={props.testId}
+      className="mb-3 space-y-1 rounded border border-[color:var(--border)] bg-[color:var(--bg-soft)]/40 p-3"
+    >
+      <p className="text-sm font-medium text-[color:var(--fg-strong)]">
+        {props.headline}
+      </p>
+      <p className="text-xs text-[color:var(--fg-muted)]">{props.body}</p>
+      {props.reason !== null && (
+        <p className="text-xs text-[color:var(--fg-muted)]">
+          {props.reasonLabel} {props.reason}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function Fact(props: {
+  readonly label: string;
+  readonly value: string;
+}): React.ReactElement {
+  return (
+    <div className="flex gap-2">
+      <dt className="text-[color:var(--fg-muted)]">{props.label}</dt>
+      <dd className="break-all text-[color:var(--fg-strong)]">{props.value}</dd>
+    </div>
+  );
+}

--- a/web-ui/app/operator/teams/page.tsx
+++ b/web-ui/app/operator/teams/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+
+import { TeamsTenantSignIn } from './_components/TeamsTenantSignIn';
+
+/**
+ * The tenant-wide Teams sign-in (byte5ai/omadia#924).
+ *
+ * A page rather than a panel inside an agent, because the thing it manages is
+ * shared: `POST /appCatalogs/teamsApps` is delegated-only at Microsoft, so one
+ * admin signs in once for the whole directory and every agent provisioned
+ * afterwards — including agents that do not exist yet — rides on that sign-in.
+ * Under `/operator/agents/:slug` this would have claimed the opposite, and
+ * "sign in before creating your first agent" would have had nowhere to live.
+ *
+ * Everything is client-side: the panel drives a live device-code flow with a
+ * countdown and a poll, which is not something a server render can hold.
+ */
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('operatorTeamsSignIn');
+  return { title: t('metaTitle') };
+}
+
+export const dynamic = 'force-dynamic';
+
+export default function OperatorTeamsPage(): React.ReactElement {
+  return (
+    <main className="mx-auto w-full max-w-3xl space-y-4 p-4">
+      <TeamsTenantSignIn />
+    </main>
+  );
+}

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -444,7 +444,8 @@
     "channels": "Channels",
     "pluginsCluster": "Plugins",
     "adminCluster": "Admin",
-    "help": "Hilfe"
+    "help": "Hilfe",
+    "teamsSignIn": "Teams-Anmeldung"
   },
   "conductor": {
     "title": "Conductor",
@@ -2159,7 +2160,13 @@
           "error": "Fehler",
           "retries_exhausted": "Wiederholungen aufgebraucht — der erreichte Stand bleibt erhalten",
           "team_conflict": "Für diesen Orchestrator läuft bereits ein anderer Lauf",
-          "stopped": "durch das Herunterfahren unterbrochen"
+          "stopped": "durch das Herunterfahren unterbrochen",
+          "delegated_upload": "Katalog-Upload über die Teams-Anmeldung dieses Tenants",
+          "delegated_token_refreshed": "Zugriffstoken automatisch erneuert",
+          "delegated_sign_in_required": "Wartet auf die Teams-Anmeldung",
+          "delegated_consent_required": "Wartet auf die Zustimmung einer Administration",
+          "delegated_token_expired": "Anmeldung abgelaufen",
+          "device_code_flow_failed": "Anmeldevorgang abgelehnt"
         }
       },
       "stateSummary": "Status: {state}",
@@ -2230,6 +2237,30 @@
         "bot_handle_unavailable": {
           "what": "Microsoft hat den Bot-Namen abgelehnt: Er ist bereits für eine andere Bot-Anwendung registriert.",
           "next": "Azure-Bot-Handles teilen sich einen einzigen globalen Namensraum über alle Azure-Kunden hinweg — wie ein Domainname, nicht wie ein Name innerhalb deines Tenants. omadia qualifiziert den Handle bereits automatisch mit der ID der App-Registrierung, dieser Name ist also auch in qualifizierter Form vergeben. Vergib dem Agenten einen anderen Bot-Slug und starte das Provisioning erneut."
+        },
+        "tenantSignInLink": "Zur Teams-Anmeldung für diesen Tenant",
+        "delegated_sign_in_required": {
+          "what": "Der Katalog-Upload braucht eine angemeldete Tenant-Administration. Microsoft erlaubt diesen Schritt nur im Namen einer Person, App-Berechtigungen genügen dafür nicht.",
+          "scopes": "Benötigte Berechtigungen ({count}): {scopes}",
+          "next": "Melde dich einmal unter „Teams-Anmeldung\" an und starte das Provisioning danach erneut. Jeder weitere Agent nutzt diese Anmeldung dann automatisch.",
+          "keepsProgress": "Der Lauf ist nicht fehlgeschlagen, sondern wartet. Entra-App, Azure-Bot und das gebaute Paket bleiben bestehen — es geht genau an dieser Stelle weiter."
+        },
+        "delegated_consent_required": {
+          "what": "Die Anmeldung steht, aber den benötigten Berechtigungen hat im Tenant noch niemand zugestimmt.",
+          "scopes": "Fehlende Berechtigungen ({count}): {scopes}",
+          "next": "Lass eine Tenant-Administration auf der Zustimmungsseite zustimmen und starte das Provisioning danach erneut.",
+          "consentLink": "Zustimmungsseite für diesen Tenant öffnen",
+          "keepsProgress": "Der Lauf ist nicht fehlgeschlagen, sondern wartet. Es wurde nichts zurückgebaut."
+        },
+        "delegated_token_expired": {
+          "what": "Die gespeicherte Anmeldung dieses Tenants ist nicht mehr gültig und ließ sich nicht automatisch erneuern.",
+          "next": "Melde dich unter „Teams-Anmeldung\" erneut an und starte das Provisioning danach noch einmal.",
+          "keepsProgress": "Der Lauf ist nicht fehlgeschlagen, sondern wartet. Alles, was bereits angelegt wurde, bleibt bestehen."
+        },
+        "device_code_flow_failed": {
+          "what": "Microsoft hat den Anmeldevorgang selbst abgelehnt — nicht die Berechtigungen, sondern den Weg dorthin.",
+          "reason": "Von Microsoft gemeldet: {reason}",
+          "next": "Prüfe, ob die Publisher-App des Microsoft-365-Connectors Device-Code-Anmeldungen als öffentlicher Client erlaubt und ob eine Conditional-Access-Richtlinie sie blockiert. Ein erneuter Versuch ändert ohne diese Anpassung nichts."
         }
       },
       "teamsBot": {
@@ -2251,7 +2282,12 @@
           "unknown": "Ob diese Konfiguration bereits übernommen wurde, lässt sich gerade nicht feststellen. Vergleiche sie mit dem Teams-Channel-Plugin und füge den Block unten ein, falls er fehlt."
         }
       },
-      "rerunNeedsTeam": "Für diese Identität ist kein Ziel-Team hinterlegt, deshalb lässt sich das Provisioning hier nicht erneut starten."
+      "rerunNeedsTeam": "Für diese Identität ist kein Ziel-Team hinterlegt, deshalb lässt sich das Provisioning hier nicht erneut starten.",
+      "package": {
+        "heading": "App-Paket herunterladen",
+        "hint": "Das Provisioning lädt dieses Paket selbst in den Tenant-Katalog — ein manueller Upload pro Agent ist nicht nötig. Der Download bleibt als Rückfallebene: für Tenants, in denen programmatische Katalog-Uploads nicht erlaubt sind, oder wenn du das Manifest vorher ansehen willst. Es wird bei jeder Anfrage neu erzeugt und entspricht damit genau dem, was das Provisioning hochladen würde.",
+        "download": "Teams-App-Paket (.zip) herunterladen"
+      }
     }
   },
   "builder": {
@@ -5395,5 +5431,58 @@
     "subtitle": "Diese Ansicht stammt aus dem Plugin und läuft in einem abgeschotteten Frame.",
     "frameTitle": "Oberfläche des Plugins {pluginId}",
     "loading": "Plugin-Oberfläche wird geladen…"
+  },
+  "operatorTeamsSignIn": {
+    "metaTitle": "Teams-Anmeldung",
+    "heading": "Teams-Anmeldung für diesen Tenant",
+    "why": "Microsoft erlaubt das Hochladen einer Teams-App in den Tenant-Katalog nur im Namen einer angemeldeten Person — App-Berechtigungen sind dafür ausdrücklich nicht unterstützt. Deshalb meldet sich einmal eine Tenant-Administration an; jeder Agent, der danach provisioniert wird, nutzt diese Anmeldung automatisch.",
+    "loading": "Anmeldestatus wird geladen …",
+    "refresh": "Aktualisieren",
+    "unsupported": "Der installierte Microsoft-365-Connector kennt die delegierte Anmeldung noch nicht. Aktualisiere ihn auf Version 0.6.0 oder neuer — installiert ist er bereits.",
+    "technicalReason": "Technischer Grund:",
+    "start": "Anmeldung starten",
+    "startBusy": "Anmeldung wird gestartet",
+    "signOut": "Abmelden",
+    "signOutBusy": "Wird abgemeldet",
+    "signedOut": {
+      "body": "Für diesen Tenant ist noch niemand angemeldet. Solange das so bleibt, kommt das Provisioning bis zum Katalog-Upload und bleibt dort stehen — alles davor bleibt erhalten und läuft weiter, sobald die Anmeldung steht."
+    },
+    "pending": {
+      "instructions": "Öffne die Anmeldeseite auf einem beliebigen Gerät und gib diesen Code ein. Angemeldet werden muss eine Tenant-Administration.",
+      "codeLabel": "Anmeldecode",
+      "copy": "Code kopieren",
+      "copied": "Kopiert",
+      "openVerification": "Anmeldeseite von Microsoft öffnen",
+      "expiresIn": "Der Code läuft in {seconds} Sekunden ab.",
+      "consentHint": "Falls die Anmeldeseite zuerst eine Genehmigung verlangt: hier zustimmen, danach den Code eingeben.",
+      "consentLink": "Zustimmungsseite öffnen",
+      "waiting": "omadia wartet auf den Abschluss der Anmeldung. Diese Seite aktualisiert sich von selbst."
+    },
+    "signedIn": {
+      "badge": "Angemeldet",
+      "as": "Angemeldet als {who}",
+      "unknownAccount": "unbekanntes Konto",
+      "since": "Angemeldet seit",
+      "tokenExpires": "Zugriffstoken läuft ab",
+      "tenant": "Tenant",
+      "scopes": "Berechtigungen",
+      "staleNote": "Das Zugriffstoken ist abgelaufen. Das ist kein Fehler — omadia erneuert es beim nächsten Upload automatisch, die Anmeldung bleibt bestehen."
+    },
+    "expired": {
+      "headline": "Der Anmeldecode ist abgelaufen.",
+      "body": "Es wurde nichts angelegt und nichts verändert. Starte die Anmeldung einfach neu."
+    },
+    "declined": {
+      "headline": "Die Anmeldung wurde nicht abgeschlossen.",
+      "body": "Microsoft meldet das sowohl bei einem Abbruch als auch dann, wenn eine Richtlinie den Vorgang blockiert — etwa Conditional Access oder eine Geräteanforderung. Der technische Grund unten sagt, welcher Fall vorliegt."
+    },
+    "errors": {
+      "teams_sign_in_unavailable": "Die Teams-Anmeldung ist in diesem Deployment nicht verdrahtet.",
+      "teams_provisioner_unavailable": "Der Microsoft-365-Connector ist nicht installiert — installiere und aktiviere ihn zuerst.",
+      "delegated_sign_in_unsupported": "Der installierte Microsoft-365-Connector ist zu alt für die delegierte Anmeldung. Aktualisiere ihn auf 0.6.0 oder neuer.",
+      "device_code_flow_failed": "Microsoft hat den Anmeldevorgang abgelehnt. Prüfe, ob die Publisher-App des Connectors Device-Code-Anmeldungen als öffentlicher Client erlaubt und ob eine Conditional-Access-Richtlinie sie blockiert.",
+      "teams_sign_in_failed": "Die Teams-Anmeldung ist fehlgeschlagen.",
+      "unknown": "Die Anfrage zur Teams-Anmeldung ist fehlgeschlagen: {detail}"
+    }
   }
 }

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -444,7 +444,8 @@
     "channels": "Channels",
     "pluginsCluster": "Plugins",
     "adminCluster": "Admin",
-    "help": "Help"
+    "help": "Help",
+    "teamsSignIn": "Teams sign-in"
   },
   "conductor": {
     "title": "Conductor",
@@ -2159,7 +2160,13 @@
           "error": "error",
           "retries_exhausted": "retries exhausted — the progress reached is kept",
           "team_conflict": "another run is already in flight for this orchestrator",
-          "stopped": "interrupted by a shutdown"
+          "stopped": "interrupted by a shutdown",
+          "delegated_upload": "Catalogue upload via this tenant's Teams sign-in",
+          "delegated_token_refreshed": "Access token renewed automatically",
+          "delegated_sign_in_required": "Waiting for the Teams sign-in",
+          "delegated_consent_required": "Waiting for an admin to consent",
+          "delegated_token_expired": "Sign-in expired",
+          "device_code_flow_failed": "Sign-in flow refused"
         }
       },
       "stateSummary": "State: {state}",
@@ -2230,6 +2237,30 @@
         "bot_handle_unavailable": {
           "what": "Microsoft refused the bot name: it is already registered to another bot application.",
           "next": "Azure bot handles share one global namespace across every Azure customer — like a domain name, not a name inside your tenant. omadia already qualifies the handle automatically with the app registration's id, so this name is taken even in its qualified form. Give the agent a different bot slug and start provisioning again."
+        },
+        "tenantSignInLink": "Go to the Teams sign-in for this tenant",
+        "delegated_sign_in_required": {
+          "what": "The catalogue upload needs a signed-in tenant admin. Microsoft only allows this step on behalf of a person; application permissions are not enough for it.",
+          "scopes": "Required permissions ({count}): {scopes}",
+          "next": "Sign in once under \"Teams sign-in\", then run provisioning again. Every further agent uses that sign-in automatically.",
+          "keepsProgress": "The run did not fail, it is waiting. The Entra app, the Azure bot and the built package are all kept — it continues from exactly this point."
+        },
+        "delegated_consent_required": {
+          "what": "The sign-in is in place, but nobody in the tenant has consented to the required permissions yet.",
+          "scopes": "Missing permissions ({count}): {scopes}",
+          "next": "Have a tenant admin approve on the consent page, then run provisioning again.",
+          "consentLink": "Open the consent page for this tenant",
+          "keepsProgress": "The run did not fail, it is waiting. Nothing was rolled back."
+        },
+        "delegated_token_expired": {
+          "what": "This tenant's stored sign-in is no longer valid and could not be renewed automatically.",
+          "next": "Sign in again under \"Teams sign-in\", then run provisioning once more.",
+          "keepsProgress": "The run did not fail, it is waiting. Everything already created is kept."
+        },
+        "device_code_flow_failed": {
+          "what": "Microsoft refused the sign-in flow itself — not the permissions, but the route to them.",
+          "reason": "Reported by Microsoft: {reason}",
+          "next": "Check that the Microsoft 365 connector's publisher app allows device-code sign-ins as a public client, and that no Conditional Access policy blocks them. Retrying changes nothing without that adjustment."
         }
       },
       "teamsBot": {
@@ -2251,7 +2282,12 @@
           "unknown": "Whether this configuration is already applied cannot be determined right now. Compare it against the Teams channel plugin and paste the block below if it is missing."
         }
       },
-      "rerunNeedsTeam": "No target team is recorded for this identity, so provisioning cannot be re-run from here."
+      "rerunNeedsTeam": "No target team is recorded for this identity, so provisioning cannot be re-run from here.",
+      "package": {
+        "heading": "Download the app package",
+        "hint": "Provisioning uploads this package to the tenant catalogue itself — no manual upload per agent is needed. The download stays as a fallback: for tenants where programmatic catalogue uploads are not allowed, or when you want to inspect the manifest first. It is rendered fresh on every request, so it matches exactly what provisioning would upload.",
+        "download": "Download the Teams app package (.zip)"
+      }
     }
   },
   "builder": {
@@ -5395,5 +5431,58 @@
     "subtitle": "This screen is supplied by the plugin and runs in a sandboxed frame.",
     "frameTitle": "User interface of the plugin {pluginId}",
     "loading": "Loading the plugin interface…"
+  },
+  "operatorTeamsSignIn": {
+    "metaTitle": "Teams sign-in",
+    "heading": "Teams sign-in for this tenant",
+    "why": "Microsoft only allows uploading a Teams app to the tenant catalogue on behalf of a signed-in person — application permissions are explicitly not supported for it. So a tenant admin signs in once, and every agent provisioned afterwards uses that sign-in automatically.",
+    "loading": "Loading sign-in status …",
+    "refresh": "Refresh",
+    "unsupported": "The installed Microsoft 365 connector does not know the delegated sign-in yet. Upgrade it to 0.6.0 or newer — it is already installed.",
+    "technicalReason": "Technical reason:",
+    "start": "Start sign-in",
+    "startBusy": "Starting sign-in",
+    "signOut": "Sign out",
+    "signOutBusy": "Signing out",
+    "signedOut": {
+      "body": "Nobody is signed in for this tenant yet. Until that changes, provisioning gets as far as the catalogue upload and parks there — everything before it is kept and continues once the sign-in exists."
+    },
+    "pending": {
+      "instructions": "Open the sign-in page on any device and enter this code. The person signing in has to be a tenant admin.",
+      "codeLabel": "Sign-in code",
+      "copy": "Copy code",
+      "copied": "Copied",
+      "openVerification": "Open Microsoft's sign-in page",
+      "expiresIn": "The code expires in {seconds} seconds.",
+      "consentHint": "If the sign-in page asks for approval first: approve here, then enter the code.",
+      "consentLink": "Open the consent page",
+      "waiting": "omadia is waiting for the sign-in to finish. This page updates by itself."
+    },
+    "signedIn": {
+      "badge": "Signed in",
+      "as": "Signed in as {who}",
+      "unknownAccount": "unknown account",
+      "since": "Signed in since",
+      "tokenExpires": "Access token expires",
+      "tenant": "Tenant",
+      "scopes": "Permissions",
+      "staleNote": "The access token has expired. This is not a fault — omadia renews it automatically on the next upload, and the sign-in stays valid."
+    },
+    "expired": {
+      "headline": "The sign-in code expired.",
+      "body": "Nothing was created and nothing was changed. Just start the sign-in again."
+    },
+    "declined": {
+      "headline": "The sign-in was not completed.",
+      "body": "Microsoft reports this both when someone cancels and when a policy blocks the attempt — Conditional Access or a device requirement, for instance. The technical reason below says which case this is."
+    },
+    "errors": {
+      "teams_sign_in_unavailable": "The Teams sign-in is not wired up in this deployment.",
+      "teams_provisioner_unavailable": "The Microsoft 365 connector is not installed — install and activate it first.",
+      "delegated_sign_in_unsupported": "The installed Microsoft 365 connector is too old for the delegated sign-in. Upgrade it to 0.6.0 or newer.",
+      "device_code_flow_failed": "Microsoft refused the sign-in flow. Check that the connector's publisher app allows device-code sign-ins as a public client, and that no Conditional Access policy blocks them.",
+      "teams_sign_in_failed": "The Teams sign-in failed.",
+      "unknown": "The Teams sign-in request failed: {detail}"
+    }
   }
 }


### PR DESCRIPTION
Provisioning a Teams agent is app-only from end to end except for one step: `POST /appCatalogs/teamsApps`. Graph lists Application permissions there as **"Not supported."** — publishing to the tenant catalog is delegated-only, confirmed in the field where the catalog *lookup* succeeds and only the *upload* is refused with the role assigned. No consent fixes it (#924).

The connector can do the delegated path since 0.6.0. This is the middleware and operator side: an admin signs in **once per tenant**, and every agent after that provisions without anyone opening the admin center.

## Where the sign-in lives

A router of its own at `/api/v1/operator/teams`, and a page at `/operator/teams` — deliberately **not** under `/:slug`.

Hanging it off an agent would assert in the URL that each agent has its own sign-in, which is precisely the per-agent step this change removes. It would also make "sign in before the first agent exists" unrepresentable. The agent panel links to it; it does not host it.

## How the flow handle is protected

The `flowHandle` returned by the connector carries the `device_code` and is therefore secret-grade. It never leaves the middleware process: the start response carries the user code, verification URI, expiry, interval and consent URL — no handle — and the poll endpoint **takes no request body at all**, polling the flow the service holds.

It is held in memory rather than the vault on purpose. Persisting a live device code creates a durable copy of a credential to buy a convenience nobody asked for; the cost is that a restart during the ~15-minute window loses the flow and the UI offers to start again. That trade is documented, and the resume gap is filed as byte5ai/omadia-m365-connector#13.

The security test is provable rather than aspirational: putting the handle back into the start payload turns it red on a sentinel value.

## Token custody

A vault namespace of its own (`@omadia/teams-delegated`), following `mcpRegistrySecretService.ts` — one key, AES-256-GCM. Rotated refresh tokens are persisted when the connector reports `refreshed`, because discarding a rotation would force a pointless re-authentication months later.

Staleness is computed locally from `expiresAt` rather than asked of the connector. The panel then answers correctly even with no connector installed, instead of making a purely local question depend on a plugin being present.

## A run that cannot upload does not fail

Missing sign-in is not a crash. The run parks with its state intact and resumes once the sign-in exists — the same shape as the existing `arm_not_configured` path. Falling to `failed` would mean an admin who signs in afterwards finds a broken run rather than a waiting one.

The four connector errors stay **distinguishable** all the way into the UI, because each has a different remedy: nobody signed in (start it), consent missing (send an admin to the consent URL), access token stale (handled silently, no human), flow refused (check the publisher app or Conditional Access). That last one must not be rendered as "the admin cancelled" — a Conditional Access block returns the same discriminant, and only the reason distinguishes them.

## Package download

The generated package is downloadable wherever it can be built — not as the prescribed route, but so an operator is never locked out of their own artifact: a tenant whose policy forbids the sign-in, an admin who wants to read the manifest before it goes live, a support case needing the exact bytes. Rebuilt on demand from the recorded identity rather than stored, so it cannot drift from what provisioning would upload.

## Verification

middleware: 7933 passed, 16 skipped, 0 failed; typecheck clean; `typecheck:test` at baseline with no regressions. web-ui: 1051 passed, 0 failed; typecheck clean; `i18n:check` OK at 4212 keys; lint 0 errors. 79 new tests — 18 security and custody, 15 runner, 8 download, 38 UI.

One pre-existing `TS1354` fixed along the way. A comment of mine inside the error-code union contained a semicolon, which a cross-repo vocabulary test parses with a non-greedy regex — it silently truncated the code list and failed. The comment was reworded; the test was left strict, because it caught a real class of drift.

Refs #924, #860.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790537488&installation_model_id=428086&pr_number=949&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F949&signature=6fa5f10cae207513102d0d96e0a6c83000606f9e9148f9796fb365da12ff9d0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->