### PR TITLE
feat: install a provisioned agent into a group chat, not just a team

### DIFF
--- a/middleware/migrations/0054_agent_teams_target_kind.sql
+++ b/middleware/migrations/0054_agent_teams_target_kind.sql
@@ -1,0 +1,98 @@
+-- ── Agent factory: the install target is a TEAM *or* a CHAT ────────────────
+-- Adds `target_kind` to the two tables that address a Teams install target.
+--
+-- THE FIELD TEST THIS COMES FROM
+-- ------------------------------
+-- An operator pasted `abc8af8ec7fc471785d3b83c4d84b667` into a field labelled
+-- "Team-ID". Provisioning answered `400 teamId needs to be a valid GUID`;
+-- once migration 0051's companion fix hyphenated it, Graph answered `404 No
+-- team found with Group Id`. All 30 teams of the tenant and their channels
+-- were searched afterwards — the id was NEITHER. It was, with high
+-- probability, the stem of a GROUP CHAT id.
+--
+-- The operator had wanted the right thing all along. The schema simply had no
+-- word for it: `team_id` was the only target the stack could name, so a group
+-- chat could not be requested, could not be validated, and could only fail at
+-- the last step of an otherwise complete chain.
+--
+-- WHY A DISCRIMINATOR COLUMN AND NOT A RENAME
+-- -------------------------------------------
+-- `team_id` could have become `target_id`. It was not, for three reasons that
+-- all point the same way:
+--
+--   * there are PRODUCTION ROWS. A rename touches the primary key of
+--     `agent_teams_installs` (`(agent_id, team_id)`), the foreign key into
+--     `agent_teams_identities`, and ~100 call sites in the operator router
+--     alone. The blast radius is the whole feature, and the payoff is a
+--     better column name.
+--   * the DEFAULT backfills correctly and provably. Every row that exists
+--     today was written by a code path that could only install into a team,
+--     so `DEFAULT 'team'` is not an assumption about old data — it is the
+--     only thing old data could have meant.
+--   * a rename would still need this column. "Which Graph endpoint installed
+--     this?" is not derivable from the id in every case: a bare 32-hex target
+--     is ambiguous between a team group id and a chat stem (that is the whole
+--     bug above). Storing the kind records what omadia DID, which is the same
+--     philosophy `agent_teams_installs` was built on — "the list is what
+--     omadia did, not what Graph currently holds".
+--
+-- So `team_id` keeps its name and gains a companion that says how to read it.
+-- The name is now narrower than the contents, which is a real cost; it is
+-- paid deliberately, and `platform/teamsInstallTarget.ts` is where the wider
+-- vocabulary lives.
+--
+-- WHY BOTH TABLES
+-- ---------------
+-- `agent_teams_installs.target_kind` makes the READ MODEL honest: the operator
+-- UI can say "Gruppenchat" instead of showing a chat id under a heading that
+-- says team.
+-- `agent_teams_identities.target_kind` makes RESUME honest: the identity row
+-- carries the target of the run in flight, and a run that resumes must call
+-- the same Graph endpoint the request asked for rather than re-deriving it
+-- from a string whose ambiguity is what started all this.
+--
+-- Idempotent by construction (ADD COLUMN IF NOT EXISTS, and the constraints
+-- are added only when absent), because schema CI double-applies every file.
+
+ALTER TABLE agent_teams_identities
+  ADD COLUMN IF NOT EXISTS target_kind TEXT NOT NULL DEFAULT 'team';
+
+ALTER TABLE agent_teams_installs
+  ADD COLUMN IF NOT EXISTS target_kind TEXT NOT NULL DEFAULT 'team';
+
+-- The closed vocabulary of `platform/teamsInstallTarget.ts`. A channel is
+-- deliberately NOT in it: `19:…@thread.tacv2` is refused at the route because
+-- installing into a channel's parent team would put the app in every channel
+-- of that team — a wider blast radius than the operator asked for, produced
+-- by a guess.
+-- The existence probes below are scoped with `conrelid = <table>::regclass`,
+-- NOT with `conname` alone. Constraint names are unique per TABLE, not per
+-- database: a bare `conname` match finds the constraint in some other schema
+-- (every parallel pg test suite runs in its own) and skips adding it here,
+-- leaving a column with no CHECK behind and the migration reporting success.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'agent_teams_identities_target_kind_check'
+       AND conrelid = 'agent_teams_identities'::regclass
+  ) THEN
+    ALTER TABLE agent_teams_identities
+      ADD CONSTRAINT agent_teams_identities_target_kind_check
+      CHECK (target_kind IN ('team', 'group-chat', 'one-on-one-chat'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+     WHERE conname = 'agent_teams_installs_target_kind_check'
+       AND conrelid = 'agent_teams_installs'::regclass
+  ) THEN
+    ALTER TABLE agent_teams_installs
+      ADD CONSTRAINT agent_teams_installs_target_kind_check
+      CHECK (target_kind IN ('team', 'group-chat', 'one-on-one-chat'));
+  END IF;
+END
+$$;
+
+-- rollback: ALTER TABLE agent_teams_installs DROP COLUMN target_kind;
+-- rollback: ALTER TABLE agent_teams_identities DROP COLUMN target_kind;

--- a/middleware/src/platform/agentTeamsIdentityStore.ts
+++ b/middleware/src/platform/agentTeamsIdentityStore.ts
@@ -31,6 +31,8 @@
 
 import type { Pool } from 'pg';
 
+import type { TeamsTargetKind } from './teamsInstallTarget.js';
+
 // ---------------------------------------------------------------------------
 // State vocabulary — the CHECK constraint of migration 0049, verbatim.
 // ---------------------------------------------------------------------------
@@ -68,6 +70,13 @@ export interface AgentTeamsIdentityRecord {
   readonly state: TeamsProvisioningState;
   /** Install target of the last provisioning request — resume evidence. */
   readonly teamId: string | null;
+  /**
+   * WHICH KIND of target {@link teamId} addresses (migration 0054): a team, a
+   * group chat or a 1:1 chat. Resume evidence too — a run that picks up an
+   * interrupted chain must call the Graph endpoint the request asked for, and
+   * a bare 32-hex id cannot be classified back into one afterwards.
+   */
+  readonly targetKind: TeamsTargetKind;
   readonly appId: string | null;
   readonly tenantId: string | null;
   readonly teamsAppId: string | null;
@@ -85,6 +94,9 @@ export interface EnsureAgentTeamsIdentityInput {
    *  ensure updates on an existing row; bot_slug/display_name stay as
    *  created (one identity per agent). */
   readonly teamId?: string;
+  /** Kind of the target above. Defaults to `'team'`, which is what every
+   *  request before migration 0054 meant. */
+  readonly targetKind?: TeamsTargetKind;
 }
 
 export interface AgentTeamsIdentityUpdate {
@@ -92,6 +104,8 @@ export interface AgentTeamsIdentityUpdate {
   /** `null` clears the recorded install target — what an uninstall leaves
    *  behind (byte5ai/omadia#900). The column is nullable (migration 0049). */
   readonly teamId?: string | null;
+  /** Set together with {@link teamId} when a request re-targets the row. */
+  readonly targetKind?: TeamsTargetKind;
   readonly appId?: string;
   readonly tenantId?: string;
   readonly teamsAppId?: string;
@@ -143,7 +157,7 @@ export class AgentTeamsIdentityStateError extends Error {
 // ---------------------------------------------------------------------------
 
 const COLUMNS =
-  'agent_id, bot_slug, display_name, state, team_id, app_id, tenant_id, teams_app_id, teams_app_external_id, last_error, created_at, updated_at';
+  'agent_id, bot_slug, display_name, state, team_id, target_kind, app_id, tenant_id, teams_app_id, teams_app_external_id, last_error, created_at, updated_at';
 
 interface AgentTeamsIdentityRow {
   agent_id: string;
@@ -151,6 +165,7 @@ interface AgentTeamsIdentityRow {
   display_name: string;
   state: string;
   team_id: string | null;
+  target_kind: TeamsTargetKind;
   app_id: string | null;
   tenant_id: string | null;
   teams_app_id: string | null;
@@ -171,6 +186,7 @@ function mapRow(row: AgentTeamsIdentityRow): AgentTeamsIdentityRecord {
     displayName: row.display_name,
     state: row.state,
     teamId: row.team_id,
+    targetKind: row.target_kind,
     appId: row.app_id,
     tenantId: row.tenant_id,
     teamsAppId: row.teams_app_id,
@@ -216,13 +232,25 @@ export class AgentTeamsIdentityStore {
   ): Promise<AgentTeamsIdentityRecord> {
     try {
       const res = await this.pool.query<AgentTeamsIdentityRow>(
-        `INSERT INTO agent_teams_identities (agent_id, bot_slug, display_name, team_id)
-         VALUES ($1, $2, $3, $4)
+        `INSERT INTO agent_teams_identities (agent_id, bot_slug, display_name, team_id, target_kind)
+         VALUES ($1, $2, $3, $4, $5)
          ON CONFLICT (agent_id) DO UPDATE SET
-           team_id    = COALESCE(EXCLUDED.team_id, agent_teams_identities.team_id),
+           team_id     = COALESCE(EXCLUDED.team_id, agent_teams_identities.team_id),
+           -- Moves WITH the id: a re-target that changed the kind must not
+           -- leave the row claiming the previous endpoint.
+           target_kind = CASE
+             WHEN EXCLUDED.team_id IS NULL THEN agent_teams_identities.target_kind
+             ELSE EXCLUDED.target_kind
+           END,
            updated_at = now()
          RETURNING ${COLUMNS}`,
-        [input.agentId, input.botSlug, input.displayName, input.teamId ?? null],
+        [
+          input.agentId,
+          input.botSlug,
+          input.displayName,
+          input.teamId ?? null,
+          input.targetKind ?? 'team',
+        ],
       );
       const row = res.rows[0];
       if (row === undefined) {
@@ -262,6 +290,7 @@ export class AgentTeamsIdentityStore {
       add('state', patch.state);
     }
     if (patch.teamId !== undefined) add('team_id', patch.teamId);
+    if (patch.targetKind !== undefined) add('target_kind', patch.targetKind);
     if (patch.appId !== undefined) add('app_id', patch.appId);
     if (patch.tenantId !== undefined) add('tenant_id', patch.tenantId);
     if (patch.teamsAppId !== undefined) add('teams_app_id', patch.teamsAppId);
@@ -296,6 +325,7 @@ export class AgentTeamsIdentityStore {
     return this.update(agentId, {
       state: 'catalog_uploaded',
       teamId: null,
+      targetKind: 'team',
       lastError: null,
     });
   }

--- a/middleware/src/platform/agentTeamsInstallStore.ts
+++ b/middleware/src/platform/agentTeamsInstallStore.ts
@@ -29,10 +29,19 @@
 
 import type { Pool } from 'pg';
 
-/** One persisted `(agent, team)` binding. */
+import type { TeamsTargetKind } from './teamsInstallTarget.js';
+
+/** One persisted `(agent, target)` binding. */
 export interface AgentTeamsInstallRecord {
   readonly agentId: string;
   readonly teamId: string;
+  /**
+   * Which kind of target `teamId` addresses (migration 0054) — a team, a
+   * group chat or a 1:1 chat. Recorded rather than derived: it says which
+   * Graph endpoint actually performed this install, which a bare 32-hex id
+   * cannot tell you afterwards.
+   */
+  readonly targetKind: TeamsTargetKind;
   /** Catalog app id that was installed into THIS team. */
   readonly teamsAppId: string | null;
   /** Cached Graph display name — `null` until resolved once. */
@@ -46,6 +55,8 @@ export interface AgentTeamsInstallRecord {
 export interface RecordAgentTeamsInstallInput {
   readonly agentId: string;
   readonly teamId: string;
+  /** Defaults to `'team'` — what every caller before migration 0054 meant. */
+  readonly targetKind?: TeamsTargetKind;
   readonly teamsAppId?: string | null;
   /** Only written when provided — a re-record without a resolved name must
    *  not wipe a name resolved by an earlier run. */
@@ -53,11 +64,12 @@ export interface RecordAgentTeamsInstallInput {
 }
 
 const COLUMNS =
-  'agent_id, team_id, teams_app_id, team_display_name, display_name_synced_at, installed_at, updated_at';
+  'agent_id, team_id, target_kind, teams_app_id, team_display_name, display_name_synced_at, installed_at, updated_at';
 
 interface AgentTeamsInstallRow {
   agent_id: string;
   team_id: string;
+  target_kind: TeamsTargetKind;
   teams_app_id: string | null;
   team_display_name: string | null;
   display_name_synced_at: Date | null;
@@ -69,6 +81,7 @@ function mapRow(row: AgentTeamsInstallRow): AgentTeamsInstallRecord {
   return {
     agentId: row.agent_id,
     teamId: row.team_id,
+    targetKind: row.target_kind,
     teamsAppId: row.teams_app_id,
     teamDisplayName: row.team_display_name,
     displayNameSyncedAt: row.display_name_synced_at,
@@ -123,9 +136,10 @@ export class AgentTeamsInstallStore {
     const name = input.teamDisplayName ?? null;
     const res = await this.pool.query<AgentTeamsInstallRow>(
       `INSERT INTO agent_teams_installs
-         (agent_id, team_id, teams_app_id, team_display_name, display_name_synced_at)
-       VALUES ($1, $2, $3, $4, CASE WHEN $4::text IS NULL THEN NULL ELSE now() END)
+         (agent_id, team_id, target_kind, teams_app_id, team_display_name, display_name_synced_at)
+       VALUES ($1, $2, $5, $3, $4, CASE WHEN $4::text IS NULL THEN NULL ELSE now() END)
        ON CONFLICT (agent_id, team_id) DO UPDATE SET
+         target_kind = EXCLUDED.target_kind,
          teams_app_id = COALESCE(EXCLUDED.teams_app_id, agent_teams_installs.teams_app_id),
          team_display_name =
            COALESCE(EXCLUDED.team_display_name, agent_teams_installs.team_display_name),
@@ -135,7 +149,13 @@ export class AgentTeamsInstallStore {
          END,
          updated_at = now()
        RETURNING ${COLUMNS}`,
-      [input.agentId, input.teamId, input.teamsAppId ?? null, name],
+      [
+        input.agentId,
+        input.teamId,
+        input.teamsAppId ?? null,
+        name,
+        input.targetKind ?? 'team',
+      ],
     );
     const row = res.rows[0];
     if (row === undefined) {

--- a/middleware/src/platform/teamsInstallTarget.ts
+++ b/middleware/src/platform/teamsInstallTarget.ts
@@ -1,0 +1,225 @@
+/**
+ * What an agent's Teams app can be installed INTO — the one place that reads
+ * an operator's pasted string and decides what it addresses.
+ *
+ * WHY THIS MODULE EXISTS
+ * ----------------------
+ * An operator pasted `abc8af8ec7fc471785d3b83c4d84b667` into a field labelled
+ * "Team-ID". The chain answered `400 teamId needs to be a valid GUID`; after
+ * {@link normalizeTeamsTeamId} hyphenated it, Graph answered `404 No team
+ * found with Group Id`. All 30 teams of the tenant and their channels were
+ * then searched by hand and the id was NEITHER — it was, with high
+ * probability, the stem of a group-chat id.
+ *
+ * The operator had wanted the right thing from the beginning. The chain
+ * simply had no word for it: `team_id` was the only target the whole stack
+ * could express, so a group chat could not be asked for, could not be
+ * validated, and could only fail five steps late with a message about GUIDs.
+ *
+ * This module gives the stack that word. `teamsTeamId.ts` next door still owns
+ * the narrow question "how do I spell a team id so Graph accepts it"; this one
+ * owns the wider question "what KIND of thing is this, and can we install into
+ * it at all".
+ *
+ * THE FIVE SHAPES, AND WHY THE LAST TWO ARE NOT INSTALL TARGETS
+ * ------------------------------------------------------------
+ *   `<guid>`                  team          → POST /teams/{id}/installedApps
+ *   `19:…@thread.v2`          group chat    → POST /chats/{id}/installedApps
+ *   `19:…@unq.gbl.spaces`     1:1 chat      → POST /chats/{id}/installedApps
+ *   `19:…@thread.tacv2`       CHANNEL       → refused, with the fix named
+ *   32 bare hex               ambiguous     → see the concession below
+ *
+ * A channel is refused rather than silently redirected to its parent team.
+ * Installing into the team would succeed and the app would appear in EVERY
+ * channel of it — a wider blast radius than the operator asked for, produced
+ * by a guess. So it is named as the mistake it is and the team id is pointed
+ * at instead.
+ *
+ * THE ONE CONCESSION: BARE 32-HEX
+ * -------------------------------
+ * A bare 32-hex string is genuinely ambiguous — it is both the unhyphenated
+ * form of a team's group id AND the stem of `19:<32hex>@thread.v2`. The field
+ * test above is exactly that collision.
+ *
+ * {@link classifyTeamsInstallTarget} therefore refuses to pick: it answers
+ * `'ambiguous'` and hands back BOTH readings.
+ *
+ * {@link resolveTeamsInstallTarget} — the decision the route and the runner
+ * need — resolves it to a TEAM, and says so by setting `ambiguous: true`.
+ * That is not a shrug. `normalizeTeamsTeamId` was written because Teams itself
+ * prints a team's group id unhyphenated in the "get link to team" deep link,
+ * and refusing that form here would re-break the paste it exists to accept.
+ * The missing information is CONTEXT — the deep link has it, a bare string
+ * does not — and context lives with the human. So the ambiguity is surfaced in
+ * the UI, before the operator submits, where they can still supply it; the API
+ * keeps behaving the way the shipped fix made it behave.
+ */
+
+import { normalizeTeamsTeamId } from './teamsTeamId.js';
+
+/** A target an app can actually be installed into. */
+export type TeamsTargetKind = 'team' | 'group-chat' | 'one-on-one-chat';
+
+/** Every verdict {@link classifyTeamsInstallTarget} can reach. */
+export type TeamsTargetClassificationKind =
+  | TeamsTargetKind
+  | 'channel'
+  | 'ambiguous'
+  | 'unrecognised';
+
+interface ClassificationBase {
+  /** The input, trimmed and canonicalised for its kind. */
+  readonly id: string;
+}
+
+export type TeamsTargetClassification =
+  | (ClassificationBase & { readonly kind: TeamsTargetKind })
+  | (ClassificationBase & { readonly kind: 'channel' })
+  | (ClassificationBase & {
+      readonly kind: 'ambiguous';
+      /** The input read as a team group id (hyphenated). */
+      readonly asTeamId: string;
+      /** The input read as the stem of a group-chat thread id. */
+      readonly asGroupChatId: string;
+    })
+  | (ClassificationBase & { readonly kind: 'unrecognised' });
+
+/**
+ * Conversation-id suffixes, as Teams spells them. Matched case-insensitively
+ * because the casing varies between the client, the Graph payloads and the
+ * places an operator copies from, and none of that variation is meaningful.
+ *
+ * `thread.tacv2` MUST be tested before `thread.v2` would ever be considered —
+ * they are distinct suffixes, not a prefix pair, but keeping the channel test
+ * first makes the precedence impossible to get wrong by accident later.
+ */
+const CHANNEL_SUFFIX = /@thread\.tacv2$/i;
+const GROUP_CHAT_SUFFIX = /@thread\.v2$/i;
+const ONE_ON_ONE_SUFFIX = /@unq\.gbl\.spaces$/i;
+
+/** Every conversation id Teams hands out starts with the `19:` prefix. */
+const CONVERSATION_PREFIX = /^19:.+/;
+
+/** A hyphenated GUID in the canonical 8-4-4-4-12 form. */
+const DASHED_GUID = /^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$/;
+
+/** An unhyphenated GUID — 32 hex digits and nothing else. */
+const BARE_GUID = /^[0-9a-fA-F]{32}$/;
+
+/**
+ * One valid example per installable kind. Rendered in the operator UI so the
+ * field shows what a good answer LOOKS like instead of only saying that the
+ * last one was wrong — the cheapest fix for a field nobody can guess the
+ * format of. Exported from here so the examples cannot drift away from the
+ * patterns that accept them; the suite asserts each one classifies back.
+ */
+export const TEAMS_TARGET_EXAMPLES = {
+  team: '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c',
+  groupChat: '19:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6@thread.v2',
+  oneOnOneChat: '19:a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d_00000000-0000-0000-0000-000000000000@unq.gbl.spaces',
+} as const;
+
+/**
+ * Read a pasted string and say what it addresses — WITHOUT guessing.
+ *
+ * Never throws and never rejects: an unusable input comes back as
+ * `'unrecognised'`, which callers turn into their own actionable message.
+ */
+export function classifyTeamsInstallTarget(value: string): TeamsTargetClassification {
+  const id = value.trim();
+  if (id === '') return { kind: 'unrecognised', id };
+
+  if (CONVERSATION_PREFIX.test(id)) {
+    if (CHANNEL_SUFFIX.test(id)) return { kind: 'channel', id };
+    if (GROUP_CHAT_SUFFIX.test(id)) return { kind: 'group-chat', id };
+    if (ONE_ON_ONE_SUFFIX.test(id)) return { kind: 'one-on-one-chat', id };
+    // A `19:` id with a suffix we do not know is NOT quietly treated as a
+    // chat: Teams has more conversation kinds than this module handles, and
+    // installing into the wrong one is a real action with a real audience.
+    return { kind: 'unrecognised', id };
+  }
+
+  // Lowercased so the same team never appears under two spellings in the
+  // binding table — the primary key is the id, and `A1B2…` and `a1b2…` would
+  // otherwise be two rows for one team.
+  if (DASHED_GUID.test(id)) return { kind: 'team', id: id.toLowerCase() };
+
+  if (BARE_GUID.test(id)) {
+    return {
+      kind: 'ambiguous',
+      id,
+      asTeamId: normalizeTeamsTeamId(id),
+      asGroupChatId: `19:${id.toLowerCase()}@thread.v2`,
+    };
+  }
+
+  return { kind: 'unrecognised', id };
+}
+
+/** Why {@link resolveTeamsInstallTarget} refused. */
+export type TeamsTargetRejection = 'channel' | 'ambiguous' | 'unrecognised';
+
+export type ResolvedTeamsInstallTarget =
+  | {
+      readonly ok: true;
+      readonly kind: TeamsTargetKind;
+      /** The id in the form the Graph call for {@link kind} expects. */
+      readonly id: string;
+    }
+  | { readonly ok: false; readonly reason: 'channel' | 'unrecognised' }
+  | {
+      readonly ok: false;
+      readonly reason: 'ambiguous';
+      /** The input read as a team group id — one of the two ways out. */
+      readonly asTeamId: string;
+      /** The input read as a group-chat id — the other. */
+      readonly asGroupChatId: string;
+    };
+
+/**
+ * The decision the route and the job runner need: install into WHAT, or refuse
+ * with a reason a human can act on.
+ *
+ * AMBIGUITY IS REFUSED, NOT RESOLVED. A bare 32-hex string is both the
+ * unhyphenated form of a team's group id and the stem of
+ * `19:<32hex>@thread.v2`, and picking one silently is precisely what produced
+ * the field-test failure: the chain hyphenated a chat stem into a team GUID
+ * and spent five provisioning steps before Graph said `404 No team found with
+ * Group Id`. Guessing is cheap for us and expensive for the operator.
+ *
+ * The connector agrees: `installToChat` rejects a bare stem and requires the
+ * full `19:<hex>@thread.v2` form, so a middleware that guessed "chat" would
+ * only move the refusal one hop later.
+ *
+ * So the refusal carries BOTH readings, and the caller asks the one party who
+ * actually knows which was meant.
+ */
+export function resolveTeamsInstallTarget(value: string): ResolvedTeamsInstallTarget {
+  const classified = classifyTeamsInstallTarget(value);
+  switch (classified.kind) {
+    case 'team':
+    case 'group-chat':
+    case 'one-on-one-chat':
+      return { ok: true, kind: classified.kind, id: classified.id };
+    case 'ambiguous':
+      return {
+        ok: false,
+        reason: 'ambiguous',
+        asTeamId: classified.asTeamId,
+        asGroupChatId: classified.asGroupChatId,
+      };
+    case 'channel':
+      return { ok: false, reason: 'channel' };
+    default:
+      return { ok: false, reason: 'unrecognised' };
+  }
+}
+
+/**
+ * Does this kind install through `POST /chats/{id}/installedApps` rather than
+ * `POST /teams/{id}/installedApps`? The single predicate the runner branches
+ * on, so "which Graph endpoint" is decided once rather than at each call site.
+ */
+export function isChatTarget(kind: TeamsTargetKind): boolean {
+  return kind === 'group-chat' || kind === 'one-on-one-chat';
+}

--- a/middleware/src/platform/teamsProvisionerService.ts
+++ b/middleware/src/platform/teamsProvisionerService.ts
@@ -279,6 +279,46 @@ export interface TeamAppInstallation {
   readonly installationId?: string;
 }
 
+/**
+ * Install into a CHAT rather than a team — `POST /chats/{id}/installedApps`
+ * (connector >= 0.7.0, this change).
+ *
+ * A separate method rather than a `kind` on {@link InstallToTeamRequest}
+ * because they are separate Graph endpoints with separate permissions: the
+ * team direction needs `TeamsAppInstallation.ReadWriteForTeam.All`, this one
+ * needs `TeamsAppInstallation.ReadWriteForChat.All`. Both are Application
+ * permissions — the chat endpoint supports app-only auth, so no delegated
+ * flow is involved here (unlike the catalog upload).
+ *
+ * `chatId` is a Teams conversation id (`19:…@thread.v2` for a group chat,
+ * `19:…@unq.gbl.spaces` for a 1:1). It is NOT a GUID and must never be run
+ * through `normalizeTeamsTeamId` — see `platform/teamsInstallTarget.ts` for
+ * the classification that keeps the two apart.
+ */
+export interface InstallToChatRequest {
+  readonly chatId: string;
+  /** Catalog id (`CatalogTeamsApp.teamsAppId`). */
+  readonly teamsAppId: string;
+}
+
+export interface ChatAppInstallation {
+  readonly chatId: string;
+  readonly teamsAppId: string;
+  readonly installationId?: string;
+}
+
+/** Input for the chat uninstall — the same key `installToChat` is idempotent on. */
+export interface UninstallFromChatInput {
+  readonly chatId: string;
+  /** Catalog id (`CatalogTeamsApp.teamsAppId`) — NOT the installation id. */
+  readonly teamsAppId: string;
+}
+
+export interface UninstallFromChatResult {
+  readonly outcome: UninstallFromTeamOutcome;
+  readonly value: ChatAppInstallation;
+}
+
 /** Input for the uninstall step — the same key `installToTeam` is idempotent on. */
 export interface UninstallFromTeamInput {
   readonly teamId: string;
@@ -350,6 +390,25 @@ export interface TeamsProvisionerAccessor
   getCatalogApp(input: GetCatalogAppInput): Promise<GetCatalogAppResult>;
 
   installToTeam(input: InstallToTeamRequest): Promise<Idempotent<TeamAppInstallation>>;
+
+  /**
+   * Connector >= 0.7.0 only — ABSENT on older installs. Guard every call with
+   * {@link supportsChatInstall}.
+   *
+   * The counterpart of {@link installToTeam} for the target operators
+   * actually asked for: a GROUP CHAT. Until this arrived, `team_id` was the
+   * only target the stack could express, so an operator who wanted a chat had
+   * no way to say so and found out five provisioning steps later that Graph
+   * had never heard of their id.
+   */
+  installToChat?(input: InstallToChatRequest): Promise<Idempotent<ChatAppInstallation>>;
+
+  /**
+   * Connector >= 0.7.0 only — the counterpart of {@link installToChat}, and
+   * absent on older installs exactly like it. Guard with
+   * {@link supportsChatUninstall}.
+   */
+  uninstallFromChat?(input: UninstallFromChatInput): Promise<UninstallFromChatResult>;
 
   /**
    * Connector >= 0.4.0 only — ABSENT on older installs. Guard every call
@@ -453,6 +512,29 @@ export function supportsTeamUninstall(
   provisioner: TeamsProvisionerAccessor | undefined,
 ): boolean {
   return typeof provisioner?.uninstallFromTeam === 'function';
+}
+
+/**
+ * Does the CURRENTLY INSTALLED connector publish the chat install
+ * (connector >= 0.7.0)? Same shape and same reason as the two guards above.
+ *
+ * Read it against the WRAPPER returned by {@link getTeamsProvisioner}, which
+ * forwards `installToChat` only when the raw provider really has it — an
+ * unconditional passthrough would make this predicate lie about every older
+ * connector.
+ */
+export function supportsChatInstall(
+  provisioner: TeamsProvisionerAccessor | undefined,
+): boolean {
+  return typeof provisioner?.installToChat === 'function';
+}
+
+/** Does the CURRENTLY INSTALLED connector publish the chat uninstall
+ *  (connector >= 0.7.0)? Same contract as every guard above. */
+export function supportsChatUninstall(
+  provisioner: TeamsProvisionerAccessor | undefined,
+): boolean {
+  return typeof provisioner?.uninstallFromChat === 'function';
 }
 
 // ---------------------------------------------------------------------------
@@ -641,6 +723,28 @@ function guardAccessor(raw: TeamsProvisionerAccessor): TeamsProvisionerAccessor 
     uploadToCatalog: (input) => raw.uploadToCatalog(input),
     getCatalogApp: (input) => raw.getCatalogApp(input),
     installToTeam: (input) => raw.installToTeam(input),
+    // Same conditional-spread contract as the two below, for the same reason:
+    // `supportsChatInstall` must read the WRAPPER and still get the truth
+    // about the connector behind it. A `installToChat: (i) =>
+    // raw.installToChat?.(i)` here would make every connector look
+    // chat-capable and turn an old one's 501 into a silent `undefined`.
+    ...(typeof raw.installToChat === 'function'
+      ? {
+          installToChat: (input: InstallToChatRequest) =>
+            (raw.installToChat as NonNullable<
+              TeamsProvisionerAccessor['installToChat']
+            >).call(raw, input),
+        }
+      : {}),
+    // Same conditional-spread contract, same reason.
+    ...(typeof raw.uninstallFromChat === 'function'
+      ? {
+          uninstallFromChat: (input: UninstallFromChatInput) =>
+            (raw.uninstallFromChat as NonNullable<
+              TeamsProvisionerAccessor['uninstallFromChat']
+            >).call(raw, input),
+        }
+      : {}),
     // Forwarded ONLY when the raw provider has it, so the wrapper's own
     // shape answers `supportsTeamUninstall` truthfully. A `uninstallFromTeam:
     // (input) => raw.uninstallFromTeam?.(input)` here would make every

--- a/middleware/src/platform/teamsTeamId.ts
+++ b/middleware/src/platform/teamsTeamId.ts
@@ -1,0 +1,51 @@
+/**
+ * Teams team (group) ids, in the shape Microsoft Graph insists on
+ * (byte5ai/omadia#860).
+ *
+ * Teams shows a team's group id WITHOUT dashes in several places an operator
+ * naturally copies from — the "get link to team" deep link
+ * (`groupId=abc8af8ec7fc471785d3b83c4d84b667`), parts of the admin centre, and
+ * the Graph responses that echo a deep link back. Graph's own
+ * `/teams/{id}/installedApps` endpoint then rejects exactly that string with
+ * `BadRequest: teamId needs to be a valid GUID.` — a 400 that arrives at the
+ * LAST step of provisioning, after the Entra app, the Azure bot and the
+ * catalog upload have all succeeded.
+ *
+ * So the operator pastes something Teams itself gave them, and the chain dies
+ * at step five with a message about GUID validity. Normalising it here costs
+ * one regex and removes a class of failure nobody can be expected to diagnose.
+ *
+ * DELIBERATELY NARROW. Only the unhyphenated 32-hex form is rewritten;
+ * everything else is passed through untouched, including strings that are not
+ * group ids at all. A team can also be addressed by identifiers this module
+ * has no business reshaping (`19:...@thread.tacv2` and friends), and a
+ * validator that guessed at those would reject working input to fix a typo it
+ * was never asked about. Trimming is the only other liberty taken, because a
+ * trailing space from a copy-paste is never meaningful.
+ */
+
+/** An unhyphenated GUID: exactly 32 hex digits and nothing else. */
+const BARE_GUID = /^[0-9a-fA-F]{32}$/;
+
+/** Where the four dashes go in the canonical 8-4-4-4-12 form. */
+const GUID_SEGMENTS = [8, 12, 16, 20] as const;
+
+/**
+ * Return `value` in the form Graph accepts.
+ *
+ * A 32-hex string becomes its dashed, lowercase GUID form. Anything else —
+ * an already-dashed GUID, a thread id, a value this module does not recognise
+ * — is returned trimmed and otherwise unchanged.
+ */
+export function normalizeTeamsTeamId(value: string): string {
+  const trimmed = value.trim();
+  if (!BARE_GUID.test(trimmed)) return trimmed;
+  const lower = trimmed.toLowerCase();
+  let out = '';
+  let cut = 0;
+  for (const at of GUID_SEGMENTS) {
+    out += `${lower.slice(cut, at)}-`;
+    cut = at;
+  }
+  return out + lower.slice(cut);
+}

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -14,6 +14,7 @@ import {
   type OrchestratorRegistry,
 } from '@omadia/orchestrator';
 
+import { normalizeTeamsTeamId } from '../platform/teamsTeamId.js';
 import type { Plugin, PluginSetupField } from '../api/admin-v1.js';
 import type { PluginCatalog } from '../plugins/manifestLoader.js';
 import type { InstalledRegistry } from '../plugins/installedRegistry.js';
@@ -198,7 +199,7 @@ const ResolveChannelSchema = z.object({
  *  agent (unique agent_id), later POSTs re-run provisioning on the
  *  existing row. */
 const TeamsIdentityProvisionSchema = z.object({
-  team_id: z.string().min(1).max(200),
+  team_id: z.string().min(1).max(200).transform(normalizeTeamsTeamId),
   bot_slug: z
     .string()
     .regex(
@@ -215,7 +216,7 @@ const TeamsIdentityProvisionSchema = z.object({
  *  installed into `team_id` by resuming the provisioning chain. Creating the
  *  identity itself stays `POST /:slug/teams-identity`. */
 const TeamsInstallSchema = z.object({
-  team_id: z.string().min(1).max(200),
+  team_id: z.string().min(1).max(200).transform(normalizeTeamsTeamId),
 });
 
 // ---------------------------------------------------------------------------

--- a/middleware/src/routes/operatorAgents.ts
+++ b/middleware/src/routes/operatorAgents.ts
@@ -14,15 +14,22 @@ import {
   type OrchestratorRegistry,
 } from '@omadia/orchestrator';
 
-import { normalizeTeamsTeamId } from '../platform/teamsTeamId.js';
+import {
+  isChatTarget,
+  resolveTeamsInstallTarget,
+  TEAMS_TARGET_EXAMPLES,
+  type TeamsTargetKind,
+} from '../platform/teamsInstallTarget.js';
 import type { Plugin, PluginSetupField } from '../api/admin-v1.js';
 import type { PluginCatalog } from '../plugins/manifestLoader.js';
 import type { InstalledRegistry } from '../plugins/installedRegistry.js';
 import {
   classifyTeamsProvisioningError,
+  TEAMS_CHAT_INSTALL_MIN_CONNECTOR_VERSION,
   type TeamsProvisioningErrorDetail,
 } from '../services/teamsProvisioningJob.js';
 import {
+  supportsChatInstall,
   supportsTeamUninstall,
   type TeamsProvisionerAccessor,
 } from '../platform/teamsProvisionerService.js';
@@ -199,7 +206,13 @@ const ResolveChannelSchema = z.object({
  *  agent (unique agent_id), later POSTs re-run provisioning on the
  *  existing row. */
 const TeamsIdentityProvisionSchema = z.object({
-  team_id: z.string().min(1).max(200).transform(normalizeTeamsTeamId),
+  // NOT transformed to a GUID here any more. `team_id` may now name a group
+  // chat or a 1:1 chat as well, and `normalizeTeamsTeamId` only knows how to
+  // spell a TEAM — running it first would hyphenate the 32-hex stem of a chat
+  // id into a team GUID that Graph has never heard of, which is exactly the
+  // field-test failure. `resolveTeamsInstallTarget` decides the kind FIRST and
+  // normalises only what is actually a team.
+  team_id: z.string().min(1).max(200),
   bot_slug: z
     .string()
     .regex(
@@ -216,7 +229,8 @@ const TeamsIdentityProvisionSchema = z.object({
  *  installed into `team_id` by resuming the provisioning chain. Creating the
  *  identity itself stays `POST /:slug/teams-identity`. */
 const TeamsInstallSchema = z.object({
-  team_id: z.string().min(1).max(200).transform(normalizeTeamsTeamId),
+  /** See the note on {@link TeamsIdentityProvisionSchema.team_id}. */
+  team_id: z.string().min(1).max(200),
 });
 
 // ---------------------------------------------------------------------------
@@ -245,6 +259,10 @@ export interface OperatorTeamsIdentityRecord {
    *  for why the team read model can never be plural without a schema
    *  change. */
   readonly teamId: string | null;
+  /** Kind of the target above (migration 0054). OPTIONAL on this structural
+   *  mirror: a store predating the chat targets still satisfies the port and
+   *  its rows mean `'team'`, the only thing they could have meant. */
+  readonly targetKind?: TeamsTargetKind;
   readonly appId: string | null;
   readonly tenantId: string | null;
   readonly teamsAppId: string | null;
@@ -268,6 +286,11 @@ export interface OperatorTeamsIdentityStore {
     readonly botSlug: string;
     readonly displayName: string;
     readonly teamId?: string;
+    /** Which kind of target `teamId` addresses (migration 0054). OPTIONAL on
+     *  this structural mirror on purpose: a store that predates the chat
+     *  targets still satisfies the port, and its rows keep meaning `'team'` —
+     *  which is the only thing they could ever have meant. */
+    readonly targetKind?: TeamsTargetKind;
   }): Promise<OperatorTeamsIdentityRecord>;
   /** Optional: persist an enqueue failure into the row's last_error so the
    *  status endpoint can distinguish 'queueing failed' from 'just created,
@@ -446,6 +469,9 @@ export interface OperatorTeamsInstallStore {
 export interface OperatorTeamsInstallRecord {
   readonly agentId: string;
   readonly teamId: string;
+  /** Optional for the same structural-mirror reason as on the identity
+   *  record; absent means `'team'`. */
+  readonly targetKind?: TeamsTargetKind;
   readonly teamsAppId: string | null;
   readonly teamDisplayName: string | null;
   readonly displayNameSyncedAt?: Date | null;
@@ -563,10 +589,17 @@ async function projectProvisioningEvents(
 // doing, and `capabilities.enumerate` stays false so the UI can say so.
 // ---------------------------------------------------------------------------
 
-/** One team an agent's Teams app is known to be installed in. */
+/** One target an agent's Teams app is known to be installed in. */
 export interface InstalledTeamProjection {
-  /** Teams team (group) id. */
+  /** Teams team (group) id, or a chat conversation id — see `target_kind`. */
   readonly team_id: string;
+  /**
+   * WHICH KIND of target `team_id` addresses (migration 0054). Sent so the
+   * operator UI can label a chat as a chat instead of listing it under a
+   * heading that says team — the whole reason the field test read as a
+   * mystery rather than as a wrong-kind-of-id.
+   */
+  readonly target_kind: TeamsTargetKind;
   /**
    * Graph display name of the team, as last resolved — `null` when it was
    * never resolved (no connector, connector < 0.5.0, or the team is not
@@ -611,6 +644,10 @@ export function projectInstalledTeams(
   return [
     {
       team_id: record.teamId,
+      // The pre-0054 derivation can only ever have described a team: it is
+      // the fallback for a mount with no installs table, and no code path
+      // that wrote those rows could install anywhere else.
+      target_kind: record.targetKind ?? 'team',
       team_display_name: null,
       display_name_synced_at: null,
       teams_app_id: record.teamsAppId,
@@ -644,6 +681,7 @@ export async function readInstalledTeams(
   const named = await resolveMissingTeamNames(deps, agentId, rows);
   return named.map((row) => ({
     team_id: row.teamId,
+    target_kind: row.targetKind ?? 'team',
     team_display_name: row.teamDisplayName,
     display_name_synced_at: row.displayNameSyncedAt ?? null,
     teams_app_id: row.teamsAppId,
@@ -666,7 +704,10 @@ async function resolveMissingTeamNames(
   const installs = deps.installs;
   if (!resolve || !installs) return rows;
   const missing = rows
-    .filter((row) => row.teamDisplayName === null)
+    // `resolveTeamName` is `teamsProvisioner@1.getTeam`, which answers for a
+    // TEAM. Asking it about a chat id spends a Graph call to be told
+    // `found: false` and leaves exactly the nameless row we started with.
+    .filter((row) => row.teamDisplayName === null && (row.targetKind ?? 'team') === 'team')
     .slice(0, MAX_NAME_LOOKUPS_PER_READ);
   if (missing.length === 0) return rows;
 
@@ -708,6 +749,9 @@ export interface TeamsAssignmentCapabilities {
   readonly enumerate: boolean;
   /** Track more than one team per agent — migration 0049 stores one. */
   readonly multi_team: boolean;
+  /** Install into a GROUP CHAT or 1:1 chat — requires a connector that
+   *  publishes `installToChat` (M365 connector >= 0.7.0). */
+  readonly chat_install: boolean;
   /** Why a `false` above is false, keyed by capability. */
   readonly unsupported_reason: Readonly<Record<string, string>>;
 }
@@ -723,6 +767,11 @@ export const TEAMS_UNINSTALL_MIN_CONNECTOR_VERSION = '0.4.0';
 export const TEAMS_UNINSTALL_UNSUPPORTED_REASON =
   `the installed teamsProvisioner@1 publishes no uninstallFromTeam method — upgrade @omadia/integration-microsoft365 to >= ${TEAMS_UNINSTALL_MIN_CONNECTOR_VERSION}; until then removing the app from a team is a manual Teams-admin step.`;
 
+/** Reason text for the chat direction against a connector that predates it —
+ *  a version skew an operator can fix, so the sentence names the version. */
+export const TEAMS_CHAT_INSTALL_UNSUPPORTED_REASON =
+  `the installed teamsProvisioner@1 publishes no installToChat method — upgrade @omadia/integration-microsoft365 to >= ${TEAMS_CHAT_INSTALL_MIN_CONNECTOR_VERSION}; until then an agent can only be installed into a team, not into a group chat.`;
+
 const STRUCTURAL_UNSUPPORTED_REASONS: Readonly<Record<string, string>> = {
   enumerate:
     'teamsProvisioner@1 publishes no installation-listing method — the team list is what omadia recorded when it installed (agent_teams_installs), not a live enumeration from Graph.',
@@ -737,9 +786,10 @@ const MULTI_TEAM_UNSUPPORTED_REASON =
 /**
  * The capability block for ONE request.
  *
- * `uninstall` is the only entry that varies at runtime: it mirrors whether
- * the connector installed RIGHT NOW publishes `uninstallFromTeam`
- * (byte5ai/omadia#900). Everything else is a structural property of this
+ * `uninstall` and `chat_install` are the entries that vary at runtime: each
+ * mirrors whether the connector installed RIGHT NOW publishes the method
+ * behind it (`uninstallFromTeam`, byte5ai/omadia#900; `installToChat`, the
+ * chat targets). Everything else is a structural property of this
  * middleware's schema and the capability contract, so it stays constant.
  *
  * A `false` always ships with its reason, and the reason distinguishes the
@@ -749,15 +799,20 @@ const MULTI_TEAM_UNSUPPORTED_REASON =
 export function teamsAssignmentCapabilities(
   canUninstall: boolean,
   canMultiTeam = false,
+  canChatInstall = false,
 ): TeamsAssignmentCapabilities {
   return {
     install: true,
     uninstall: canUninstall,
     enumerate: false,
     multi_team: canMultiTeam,
+    chat_install: canChatInstall,
     unsupported_reason: {
       ...(canUninstall ? {} : { uninstall: TEAMS_UNINSTALL_UNSUPPORTED_REASON }),
       ...(canMultiTeam ? {} : { multi_team: MULTI_TEAM_UNSUPPORTED_REASON }),
+      ...(canChatInstall
+        ? {}
+        : { chat_install: TEAMS_CHAT_INSTALL_UNSUPPORTED_REASON }),
       ...STRUCTURAL_UNSUPPORTED_REASONS,
     },
   };
@@ -895,6 +950,96 @@ function rejectedRunDetail(result: unknown): string | null {
 }
 
 /**
+ * Turn the operator's pasted `team_id` into a decided install target, or
+ * answer the request with a message they can act on.
+ *
+ * THE FAILURE THIS REPLACES. A pasted id that was neither a team nor a
+ * channel used to travel all the way down the provisioning chain and die at
+ * step five against Graph — `400 teamId needs to be a valid GUID`, then
+ * `404 No team found with Group Id`. Five successful steps, an Entra app, an
+ * Azure bot and a catalog upload later, the operator learned only that
+ * something about their id was wrong. Deciding it HERE means the answer
+ * arrives in the same request, before anything is provisioned.
+ *
+ * Returns `null` when it has already answered `res`.
+ */
+function resolveInstallTargetOrRefuse(
+  res: Response,
+  raw: string,
+): { readonly id: string; readonly kind: TeamsTargetKind } | null {
+  const target = resolveTeamsInstallTarget(raw);
+  if (target.ok) return { id: target.id, kind: target.kind };
+
+  if (target.reason === 'channel') {
+    // A channel is refused rather than redirected to its parent team.
+    // Installing into the team would succeed and put the app in EVERY channel
+    // of it — a wider audience than was asked for, produced by a guess.
+    res.status(400).json({
+      error: 'teams_target_is_channel',
+      message:
+        'this is a CHANNEL id (19:…@thread.tacv2), and a channel cannot be an install target: Teams installs an app into a team or into a chat, never into a single channel. Use the id of the team that owns the channel (Teams → team → "Get link to team" → the groupId), or a group chat id (19:…@thread.v2).',
+      target_id: raw.trim(),
+    });
+    return null;
+  }
+
+  if (target.reason === 'ambiguous') {
+    // NOT guessed at. The id is both a team group id without its dashes and
+    // the stem of a group-chat id, and the only party who knows which was
+    // meant is the operator — so the refusal hands back both spellings and
+    // asks them to paste the one they mean. This is the field-test failure,
+    // answered in the first request instead of at step five.
+    res.status(400).json({
+      error: 'teams_target_ambiguous',
+      message: `'${raw.trim()}' is 32 hex digits, which is BOTH a team (group) id without its dashes AND the stem of a group chat id — omadia will not guess. Paste '${target.asTeamId}' for the team, or '${target.asGroupChatId}' for the group chat.`,
+      target_id: raw.trim(),
+      /** The two ways out, ready to paste — the UI offers them as choices. */
+      as_team_id: target.asTeamId,
+      as_group_chat_id: target.asGroupChatId,
+    });
+    return null;
+  }
+
+  res.status(400).json({
+    error: 'teams_target_unrecognised',
+    message: `'${raw.trim()}' is not a Teams install target — expected a team (group) id, a group chat id (19:…@thread.v2) or a 1:1 chat id (19:…@unq.gbl.spaces).`,
+    target_id: raw.trim(),
+    examples: {
+      team: TEAMS_TARGET_EXAMPLES.team,
+      group_chat: TEAMS_TARGET_EXAMPLES.groupChat,
+      one_on_one_chat: TEAMS_TARGET_EXAMPLES.oneOnOneChat,
+    },
+  });
+  return null;
+}
+
+/**
+ * Refuse a CHAT target the installed connector cannot reach (`installToChat`,
+ * connector >= 0.7.0).
+ *
+ * 501 rather than 400: the request is well-formed and will work verbatim once
+ * the plugin is upgraded, so the refusal names the version instead of blaming
+ * the input. Checked before anything is written, so a refused request leaves
+ * no re-targeted row behind.
+ *
+ * Returns `true` when it has answered `res`.
+ */
+function refuseUnsupportedChatTarget(
+  res: Response,
+  deps: OperatorTeamsIdentityDeps,
+  kind: TeamsTargetKind,
+): boolean {
+  if (!isChatTarget(kind)) return false;
+  if (supportsChatInstall(deps.getProvisioner?.())) return false;
+  res.status(501).json({
+    error: 'teams_chat_install_unsupported',
+    message: TEAMS_CHAT_INSTALL_UNSUPPORTED_REASON,
+    target_kind: kind,
+  });
+  return true;
+}
+
+/**
  * Start (or resume) the provisioning chain without awaiting the run.
  *
  * Fire-and-forget by design — the chain takes minutes — but NOT fire-and-
@@ -909,12 +1054,16 @@ function startProvisioningRun(
   deps: OperatorTeamsIdentityDeps,
   agent: { readonly id: string; readonly slug: string },
   teamId: string,
-  opts?: { readonly republish?: boolean },
+  opts?: { readonly republish?: boolean; readonly targetKind?: TeamsTargetKind },
 ): void {
   void Promise.resolve(
     deps.runner.enqueue({
       agentId: agent.id,
       teamId,
+      // Omitted rather than defaulted to `'team'` here: the runner owns that
+      // default, and forwarding an explicit value the caller never chose would
+      // hide a caller that forgot to pass one.
+      ...(opts?.targetKind !== undefined ? { targetKind: opts.targetKind } : {}),
       ...(opts?.republish === true ? { republish: true } : {}),
     }),
   )
@@ -1928,10 +2077,16 @@ export function createOperatorAgentsRouter(
       // same single `team_id` column the team read model publishes, so an
       // 'installed' row or an in-flight run toward another team is a 409 —
       // before any write. See refuseConflictingTeamRetarget.
+      // Decide WHAT the pasted id addresses before anything is written or
+      // compared: a channel id and an unusable string are answered here, and
+      // a team id is normalised to the form Graph accepts.
+      const target = resolveInstallTargetOrRefuse(res, body.team_id);
+      if (!target) return;
+      if (refuseUnsupportedChatTarget(res, deps, target.kind)) return;
       const current = await deps.store.getByAgentId(existing.id);
       if (
         current &&
-        refuseConflictingTeamRetarget(res, deps, existing, current, body.team_id)
+        refuseConflictingTeamRetarget(res, deps, existing, current, target.id)
       ) {
         return;
       }
@@ -1941,7 +2096,8 @@ export function createOperatorAgentsRouter(
           agentId: existing.id,
           botSlug: body.bot_slug ?? deriveBotSlug(existing.slug),
           displayName: body.display_name ?? existing.name,
-          teamId: body.team_id,
+          teamId: target.id,
+          targetKind: target.kind,
         });
       } catch (err) {
         if ((err as { code?: unknown } | null)?.code === 'bot_slug_taken') {
@@ -1954,10 +2110,12 @@ export function createOperatorAgentsRouter(
         }
         throw err;
       }
-      startProvisioningRun(deps, existing, body.team_id);
+      startProvisioningRun(deps, existing, target.id, { targetKind: target.kind });
       res.status(202).json({
         ok: true,
         agent: existing.slug,
+        team_id: target.id,
+        target_kind: target.kind,
         bot_slug: row.botSlug,
         state: row.state,
         // Honest signal: true only when the runner actually holds a run for
@@ -2207,12 +2365,17 @@ export function createOperatorAgentsRouter(
         // The recorded install TARGET while the chain has not reached
         // 'installed' — a run in flight (or a stalled one), never an install.
         pending_team_id: row.state === 'installed' ? null : row.teamId,
+        /** Kind of `pending_team_id`, so the in-flight hint can name what it
+         *  is installing into rather than calling every target a team. */
+        pending_target_kind:
+          row.state === 'installed' ? null : (row.targetKind ?? 'team'),
         consent: projectTeamsConsent(row),
         last_error: row.lastError,
         last_error_detail: projectTeamsIdentityErrorDetail(row),
         capabilities: teamsAssignmentCapabilities(
           canUninstallTeams(deps),
           deps.installs !== undefined,
+          supportsChatInstall(deps.getProvisioner?.()),
         ),
         // Same choke point as GET /:slug/teams-identity — one byte-identical
         // channel-teams `teams_bots[]` entry across every team route.
@@ -2243,6 +2406,14 @@ export function createOperatorAgentsRouter(
         });
         return;
       }
+      // Same choke point and the same ORDER as POST /:slug/teams-identity:
+      // an unknown agent (404) and an absent connector (503) are answered
+      // first, because neither depends on what the target id says. Only then
+      // is the id decided — and only then can a chat target be refused for a
+      // connector that is present but too old (501, not 503).
+      const target = resolveInstallTargetOrRefuse(res, body.team_id);
+      if (!target) return;
+      if (refuseUnsupportedChatTarget(res, deps, target.kind)) return;
       // Already installed HERE? With the bindings table that is a lookup in
       // it; without one, the identity's single `team_id` is the only record
       // and the answer degrades to the pre-0051 comparison.
@@ -2251,12 +2422,13 @@ export function createOperatorAgentsRouter(
         : row.state === 'installed' && row.teamId !== null
           ? [row.teamId]
           : [];
-      if (boundTeams.includes(body.team_id)) {
-        // Idempotent: the app is already installed in exactly this team.
+      if (boundTeams.includes(target.id)) {
+        // Idempotent: the app is already installed in exactly this target.
         res.json({
           ok: true,
           agent: agent.slug,
-          team_id: body.team_id,
+          team_id: target.id,
+          target_kind: target.kind,
           state: row.state,
           already_installed: true,
           // Honest, not assumed: a run may still be settling even though
@@ -2270,7 +2442,7 @@ export function createOperatorAgentsRouter(
       // is no longer refused (with migration 0051 bound) is installing into an
       // ADDITIONAL team: the binding gets its own row instead of overwriting
       // the previous one, which is the whole point of the table.
-      if (refuseConflictingTeamRetarget(res, deps, agent, row, body.team_id)) {
+      if (refuseConflictingTeamRetarget(res, deps, agent, row, target.id)) {
         return;
       }
       // Record the (new) target through the store's own gate, then let the
@@ -2280,13 +2452,15 @@ export function createOperatorAgentsRouter(
         agentId: agent.id,
         botSlug: row.botSlug,
         displayName: row.displayName,
-        teamId: body.team_id,
+        teamId: target.id,
+        targetKind: target.kind,
       });
-      startProvisioningRun(deps, agent, body.team_id);
+      startProvisioningRun(deps, agent, target.id, { targetKind: target.kind });
       res.status(202).json({
         ok: true,
         agent: agent.slug,
-        team_id: body.team_id,
+        team_id: target.id,
+        target_kind: target.kind,
         bot_slug: updated.botSlug,
         state: updated.state,
         already_installed: false,

--- a/middleware/src/services/teamsProvisioningJob.ts
+++ b/middleware/src/services/teamsProvisioningJob.ts
@@ -79,6 +79,7 @@ import type {
   BackgroundJob,
   BackgroundJobHandle,
 } from '../platform/backgroundJobRegistry.js';
+import { normalizeTeamsTeamId } from '../platform/teamsTeamId.js';
 
 // ---------------------------------------------------------------------------
 // State vocabulary — the CHECK constraint of agent_teams_identities
@@ -1522,7 +1523,11 @@ export class TeamsProvisioningJobRunner {
     // Step 5 — install into the team (idempotent on Graph's side).
     await this.emit(agentId, 'installed', 'started');
     await provisioner.installToTeam({
-      teamId: request.teamId,
+      // Graph rejects the unhyphenated form Teams itself hands out (see
+      // platform/teamsTeamId). Normalised here as well as at the route, so a
+      // row stored before the route did it still installs instead of dying at
+      // the last step of an otherwise complete chain.
+      teamId: normalizeTeamsTeamId(request.teamId),
       teamsAppId: row.teamsAppId as string,
     });
     // Same ordering rule as recordError (#915): the chain is finished, so the

--- a/middleware/src/services/teamsProvisioningJob.ts
+++ b/middleware/src/services/teamsProvisioningJob.ts
@@ -80,6 +80,10 @@ import type {
   BackgroundJobHandle,
 } from '../platform/backgroundJobRegistry.js';
 import { normalizeTeamsTeamId } from '../platform/teamsTeamId.js';
+import {
+  isChatTarget,
+  type TeamsTargetKind,
+} from '../platform/teamsInstallTarget.js';
 
 // ---------------------------------------------------------------------------
 // State vocabulary — the CHECK constraint of agent_teams_identities
@@ -160,6 +164,11 @@ export interface TeamsInstallJobStore {
     readonly teamId: string;
     readonly teamsAppId?: string | null;
     readonly teamDisplayName?: string | null;
+    /** Which kind of target the id addresses (migration 0054). Optional on
+     *  the port so a mount predating it still satisfies the structural type;
+     *  the store defaults it to `'team'`, which is what every pre-0054 row
+     *  means. */
+    readonly targetKind?: TeamsTargetKind;
   }): Promise<unknown>;
 }
 
@@ -414,7 +423,48 @@ export interface TeamsProvisionerPort {
     readonly teamId: string;
     readonly teamsAppId: string;
   }): Promise<Idempotent<{ readonly teamId: string; readonly teamsAppId: string }>>;
+
+  /**
+   * The CHAT direction — `POST /chats/{id}/installedApps` (connector >=
+   * 0.7.0). Optional for the same version-skew reason as every other method
+   * added after the oldest supported connector: feature-detect with
+   * `typeof === 'function'`, never call it blind.
+   *
+   * Reached only for a `group-chat` / `one-on-one-chat` target
+   * ({@link ProvisionTeamsIdentityRequest.targetKind}); a `team` target keeps
+   * using {@link installToTeam} unchanged.
+   */
+  installToChat?(input: {
+    readonly chatId: string;
+    readonly teamsAppId: string;
+  }): Promise<Idempotent<{ readonly chatId: string; readonly teamsAppId: string }>>;
 }
+
+/**
+ * The chain reached its install step with a CHAT target, against a connector
+ * that publishes no `installToChat` (< 0.7.0).
+ *
+ * A typed error rather than a crash, and raised by the runner as well as
+ * refused by the route, because the two guard different moments: the route
+ * refuses a NEW request up front (501, nothing enqueued), while a run that
+ * RESUMES an older request can meet a connector that was downgraded since —
+ * and a resumed run must fail with the same actionable sentence rather than a
+ * `TypeError: installToChat is not a function`.
+ */
+export class TeamsChatInstallUnsupportedError extends Error {
+  public readonly code = 'teams_chat_install_unsupported';
+
+  constructor() {
+    super(
+      `the installed teamsProvisioner@1 publishes no installToChat method — upgrade @omadia/integration-microsoft365 to >= ${TEAMS_CHAT_INSTALL_MIN_CONNECTOR_VERSION}; until then an agent can only be installed into a team, not into a group chat.`,
+    );
+    this.name = 'TeamsChatInstallUnsupportedError';
+  }
+}
+
+/** Minimum connector version whose `teamsProvisioner@1` installs into a chat.
+ *  Quoted in the operator-facing reason so the fix is actionable. */
+export const TEAMS_CHAT_INSTALL_MIN_CONNECTOR_VERSION = '0.7.0';
 
 /** App-package inputs for one identity; loading is bound by the wiring unit
  *  (manifest template + icons ship with the channel-teams package). */
@@ -579,8 +629,34 @@ export class TeamsProvisioningJobError extends Error {
 
 export interface ProvisionTeamsIdentityRequest {
   readonly agentId: string;
-  /** Team (group) id the generated app is installed into. */
+  /**
+   * The install TARGET id. Historically a team (group) id — hence the name,
+   * which is kept because it is also the column name and the request field on
+   * the wire — but since the chat targets of `platform/teamsInstallTarget.ts`
+   * it may equally be a chat conversation id (`19:…@thread.v2`,
+   * `19:…@unq.gbl.spaces`). {@link targetKind} says which.
+   */
   readonly teamId: string;
+  /**
+   * WHICH KIND of target {@link teamId} addresses, and therefore which Graph
+   * endpoint installs into it.
+   *
+   * The runner does NOT classify: the string arrives already decided, from
+   * `resolveTeamsInstallTarget` at the route (for a new request) or from the
+   * identity row's persisted `target_kind` (for a resume). Two reasons that
+   * both matter:
+   *
+   *   * a bare 32-hex id is genuinely ambiguous between a team group id and a
+   *     chat stem, and the context that resolves it lives with the operator,
+   *     not in the runner;
+   *   * re-deriving here would make the runner a SECOND classifier, free to
+   *     disagree with the one that validated the request — and the endpoint
+   *     it picked would then differ from the one the operator was told about.
+   *
+   * Defaults to `'team'` when absent, which is what every caller before this
+   * change meant and what every stored row records.
+   */
+  readonly targetKind?: TeamsTargetKind;
   /**
    * #914 — re-render and re-upload the app package for an identity that is
    * already `installed`. Set by the identity routes after an edit that
@@ -633,6 +709,11 @@ export type ProvisioningRunResult =
          *  configured for it, Conditional Access refusing it). Terminal:
          *  retrying the same flow produces the same refusal. */
         | 'device_code_flow_failed'
+        /** Graph refused the install because the app package's
+         *  resource-specific permissions exceed what the installing identity
+         *  may consent to. Terminal: a tenant role grant fixes it, a retry
+         *  does not. */
+        | 'rsc_permissions_mismatch'
         | 'error';
       readonly detail: string;
     }
@@ -1520,16 +1601,65 @@ export class TeamsProvisioningJobRunner {
 
     if (this.stopped) return { status: 'stopped', agentId };
 
-    // Step 5 — install into the team (idempotent on Graph's side).
+    // Step 5 — install into the target (idempotent on Graph's side).
+    //
+    // TWO ENDPOINTS, ONE STEP. A team installs through
+    // `POST /teams/{id}/installedApps`, a chat through
+    // `POST /chats/{id}/installedApps`. They are different Graph resources
+    // with different permissions, so the branch is here rather than inside
+    // the connector: the runner already knows which kind it was asked for and
+    // guessing from the id string is exactly the failure this feature exists
+    // to remove.
+    const targetKind: TeamsTargetKind = request.targetKind ?? 'team';
     await this.emit(agentId, 'installed', 'started');
-    await provisioner.installToTeam({
-      // Graph rejects the unhyphenated form Teams itself hands out (see
-      // platform/teamsTeamId). Normalised here as well as at the route, so a
-      // row stored before the route did it still installs instead of dying at
-      // the last step of an otherwise complete chain.
-      teamId: normalizeTeamsTeamId(request.teamId),
-      teamsAppId: row.teamsAppId as string,
-    });
+    try {
+      if (isChatTarget(targetKind)) {
+        const installToChat = provisioner.installToChat;
+        // Feature detection, never an optional call: an older connector must
+        // fail with the actionable sentence below rather than with a
+        // TypeError, and `installToChat?.(…)` would silently resolve to
+        // `undefined` and let the run mark itself installed without
+        // installing anything.
+        if (typeof installToChat !== 'function') {
+          throw new TeamsChatInstallUnsupportedError();
+        }
+        await installToChat.call(provisioner, {
+          // NOT normalised: a conversation id is not a GUID, and
+          // `normalizeTeamsTeamId` passes it through untouched anyway.
+          // Calling it here would only suggest a reshaping that must never
+          // happen.
+          chatId: request.teamId.trim(),
+          teamsAppId: row.teamsAppId as string,
+        });
+      } else {
+        await provisioner.installToTeam({
+          // Graph rejects the unhyphenated form Teams itself hands out (see
+          // platform/teamsTeamId). Normalised here as well as at the route,
+          // so a row stored before the route did it still installs instead of
+          // dying at the last step of an otherwise complete chain.
+          teamId: normalizeTeamsTeamId(request.teamId),
+          teamsAppId: row.teamsAppId as string,
+        });
+      }
+    } catch (err) {
+      // `400 ResourceSpecificPermissionsMismatch` is NOT a generic bad
+      // request, and reporting it as one sends the operator hunting for a
+      // wrong id that is in fact correct. It means this agent's app package
+      // declares resource-specific permissions the installing identity may not
+      // consent to — a tenant-side role grant. TERMINAL: no retry makes a
+      // missing grant appear.
+      if (isRscPermissionsMismatch(err)) {
+        const detail = rscPermissionsMismatchDetail(targetKind);
+        await this.recordError(agentId, { state: 'failed', lastError: detail });
+        return {
+          status: 'failed',
+          agentId,
+          reason: 'rsc_permissions_mismatch',
+          detail,
+        };
+      }
+      throw err;
+    }
     // Same ordering rule as recordError (#915): the chain is finished, so the
     // run stops calling itself running BEFORE the terminal state becomes
     // readable. Everything past this line — the binding write, the
@@ -1538,14 +1668,18 @@ export class TeamsProvisioningJobRunner {
     // the timeline rather than through `running`.
     this.markSettled(agentId);
     row = await this.store.update(agentId, { state: 'installed', lastError: null });
-    await this.emit(agentId, 'installed', 'succeeded');
+    // `detail` carries the TARGET KIND — a closed, localizable vocabulary
+    // ('team' | 'group-chat' | 'one-on-one-chat'), exactly like the
+    // `config_sync` step's status. Never the id: the timeline is a screen, and
+    // a chat id names the humans in that chat.
+    await this.emit(agentId, 'installed', 'succeeded', { detail: targetKind });
 
     // Step 5b (migration 0051) — PERSIST the binding. Graph has confirmed the
     // install, so this is the moment the pair becomes a fact rather than an
     // intent. Before this table existed the only trace was the identity row's
     // single `team_id`, which the next request overwrote — the reason a
     // binding never survived a re-target.
-    await this.recordInstall(agentId, request.teamId, row.teamsAppId);
+    await this.recordInstall(agentId, request.teamId, row.teamsAppId, targetKind);
 
     // Step 6 (#910) — the finishing move: write the `teams_bots` entry into
     // channel-teams and reload it, so the bot answers without an operator
@@ -1696,11 +1830,17 @@ export class TeamsProvisioningJobRunner {
     agentId: string,
     teamId: string,
     teamsAppId: string | null,
+    targetKind: TeamsTargetKind,
   ): Promise<void> {
     const installs = this.installs;
     if (!installs) return;
     let displayName: string | null = null;
-    if (this.resolveTeamName) {
+    // The name resolver is `teamsProvisioner@1.getTeam`, which answers for a
+    // TEAM only. A chat has no equivalent lookup in the mirrored contract, so
+    // a chat binding stays nameless rather than being handed an id to resolve
+    // that the connector would answer `found: false` for — a wasted Graph call
+    // whose only outcome is a misleading log line.
+    if (this.resolveTeamName && targetKind === 'team') {
       try {
         displayName = await this.resolveTeamName(teamId);
       } catch (err) {
@@ -1710,7 +1850,13 @@ export class TeamsProvisioningJobRunner {
       }
     }
     try {
-      await installs.record({ agentId, teamId, teamsAppId, teamDisplayName: displayName });
+      await installs.record({
+        agentId,
+        teamId,
+        teamsAppId,
+        teamDisplayName: displayName,
+        targetKind,
+      });
     } catch (err) {
       this.log(
         `[teams-provisioning] could not record the install of agent '${agentId}' in team '${teamId}': ${errorMessage(err)}`,
@@ -1790,6 +1936,40 @@ export class TeamsProvisioningJobRunner {
 /** Bracket filler used when the connector named no ARM field. Shared by the
  *  producer and the classifier so the empty case round-trips to `[]`. */
 const ARM_FIELDS_UNSPECIFIED = 'ARM setup fields';
+
+/**
+ * Graph answered `400 ResourceSpecificPermissionsMismatch`.
+ *
+ * NOT a generic bad request, and mis-reading it as one is exactly why this has
+ * its own code. The install call is well-formed and the target id is correct;
+ * what Graph is saying is that the RESOURCE-SPECIFIC permissions declared in
+ * the agent's app package (ours declares seven) exceed what the installing
+ * identity may consent to on the target's behalf. The fix is a tenant-side
+ * role grant, so the sentence names the role instead of sending the operator
+ * back to check an id that was never wrong.
+ */
+export const RSC_PERMISSIONS_MISMATCH_PREFIX = 'rsc_permissions_mismatch:';
+
+/** The two Graph app roles that let an install carry an app's RSC
+ *  permissions — team direction and chat direction. Named in the
+ *  operator-facing sentence so the fix is a copy-paste, not a search. */
+export const RSC_CONSENT_ROLES = {
+  team: 'TeamsAppInstallation.ReadWriteAndConsentForTeam.All',
+  chat: 'TeamsAppInstallation.ReadWriteAndConsentForChat.All',
+} as const;
+
+export function rscPermissionsMismatchDetail(targetKind: TeamsTargetKind): string {
+  const role = targetKind === 'team' ? RSC_CONSENT_ROLES.team : RSC_CONSENT_ROLES.chat;
+  return `${RSC_PERMISSIONS_MISMATCH_PREFIX} Graph refused the install because this agent's Teams app package declares resource-specific permissions the installing identity may not consent to — grant the app role ${role} to the M365 connector's Entra app and admin-consent it, then re-run provisioning. The target id is correct; this is a permission grant, not a wrong id.`;
+}
+
+/** Does this error carry Graph's ResourceSpecificPermissionsMismatch code?
+ *  Duck-typed on the message for the same reason as the connector's other
+ *  error guards: the class identity belongs to the plugin, not to us. */
+export function isRscPermissionsMismatch(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return /ResourceSpecificPermissionsMismatch/i.test(`${err.name} ${err.message}`);
+}
 
 export function consentMissingDetail(missingScopes: readonly string[]): string {
   return `consent_missing: admin consent required for scopes [${missingScopes.join(', ')}] — grant them in the customer tenant, then re-run provisioning`;
@@ -1939,6 +2119,9 @@ export function deviceCodeFlowFailedDetail(
 
 export type TeamsProvisioningErrorCode =
   | 'consent_missing'
+  /** Graph refused the install because the app package's RSC permissions
+   *  exceed what the installing identity may consent to. */
+  | 'rsc_permissions_mismatch'
   | 'arm_not_configured'
   | 'throttled'
   | 'config_sync_failed'
@@ -2030,6 +2213,9 @@ export function classifyTeamsProvisioningError(
   }
   if (sentence.startsWith(BOT_HANDLE_UNAVAILABLE_PREFIX)) {
     return { code: 'bot_handle_unavailable', raw };
+  }
+  if (sentence.startsWith(RSC_PERMISSIONS_MISMATCH_PREFIX)) {
+    return { code: 'rsc_permissions_mismatch', raw };
   }
   if (sentence.startsWith(CONFIG_SYNC_FAILED_PREFIX)) {
     const inner = /\[([^\]]*)\]/.exec(sentence)?.[1]?.trim() ?? '';

--- a/middleware/test/_helpers/stubTeamsProvisioner.ts
+++ b/middleware/test/_helpers/stubTeamsProvisioner.ts
@@ -102,6 +102,17 @@ export function createStubTeamsProvisioner(
         installationId: 'install-0000',
       },
     }),
+    // Connector >= 0.7.0 — the chat direction. Same override convention as
+    // `uninstallFromTeam` below: `{ installToChat: undefined }` models an
+    // older connector by omitting the key entirely.
+    installToChat: async (input) => ({
+      outcome: 'created',
+      value: {
+        chatId: input.chatId,
+        teamsAppId: input.teamsAppId,
+        installationId: 'install-chat-0000',
+      },
+    }),
     // Connector >= 0.4.0 (byte5ai/omadia#900). Pass
     // `{ uninstallFromTeam: undefined }` to model an OLDER connector — the
     // stub then omits the key entirely, which is what feature detection has
@@ -141,6 +152,9 @@ export function createStubTeamsProvisioner(
     uploadToCatalog: record('uploadToCatalog', merged.uploadToCatalog),
     getCatalogApp: record('getCatalogApp', merged.getCatalogApp),
     installToTeam: record('installToTeam', merged.installToTeam),
+    ...(merged.installToChat !== undefined
+      ? { installToChat: record('installToChat', merged.installToChat) }
+      : {}),
     ...(merged.uninstallFromTeam !== undefined
       ? {
           uninstallFromTeam: record('uninstallFromTeam', merged.uninstallFromTeam),

--- a/middleware/test/agentTeamsIdentityStore.pg.test.ts
+++ b/middleware/test/agentTeamsIdentityStore.pg.test.ts
@@ -40,12 +40,21 @@ const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
   timeoutMs: 1_500,
 });
 
-const MIGRATION_PATH = resolve(
+const MIGRATIONS_DIR = resolve(
   dirname(fileURLToPath(import.meta.url)),
   '..',
   'migrations',
-  '0049_agent_teams_identities.sql',
 );
+
+/** The files that build the table this store reads, in order. 0054 adds
+ *  `target_kind`, which is part of the store's SELECT list. */
+const MIGRATION_FILES = [
+  '0049_agent_teams_identities.sql',
+  // 0051 creates `agent_teams_installs`, which 0054 also alters — applying
+  // 0054 without it fails on a relation that does not exist.
+  '0051_agent_teams_installs.sql',
+  '0054_agent_teams_target_kind.sql',
+] as const;
 
 const SCHEMA = `w1a_teams_ident_${String(process.pid)}`;
 
@@ -63,16 +72,21 @@ describe('W1a AgentTeamsIdentityStore against a real Postgres', { skip: !pgAvail
       max: 2,
       options: `-c search_path=${SCHEMA}`,
     });
-    const migration = await readFile(MIGRATION_PATH, 'utf8');
-    // Applied TWICE on purpose — the migrations README requires every file
-    // to be re-applicable (the schema CI gate double-applies).
-    await pool.query(migration);
-    await pool.query(migration);
+    for (const file of MIGRATION_FILES) {
+      const migration = await readFile(resolve(MIGRATIONS_DIR, file), 'utf8');
+      // Applied TWICE on purpose — the migrations README requires every file
+      // to be re-applicable (the schema CI gate double-applies).
+      await pool.query(migration);
+      await pool.query(migration);
+    }
     store = new AgentTeamsIdentityStore(pool);
   });
 
   beforeEach(async () => {
-    await pool.query('TRUNCATE agent_teams_identities');
+    // CASCADE because `agent_teams_installs` (0051) carries a foreign key
+    // into this table — the same reason the event-store suite truncates with
+    // it.
+    await pool.query('TRUNCATE agent_teams_identities CASCADE');
   });
 
   after(async () => {

--- a/middleware/test/agentTeamsTargetKindMigration.pg.test.ts
+++ b/middleware/test/agentTeamsTargetKindMigration.pg.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Migration 0054 (`target_kind`) against a real Postgres — with rows that
+ * already exist.
+ *
+ * WHY THIS SUITE IS ABOUT EXISTING DATA. `agent_teams_identities` and
+ * `agent_teams_installs` hold PRODUCTION rows. Every one of them was written
+ * by a code path that could only install into a team, so `DEFAULT 'team'` is
+ * not an assumption about old data — it is the only thing old data could have
+ * meant. That claim is worth proving rather than asserting, because getting it
+ * wrong would silently relabel real installs.
+ *
+ * Also the double-apply proof the migrations README demands: every file in
+ * this series must be re-applicable, and schema CI applies each one twice.
+ *
+ * Runs in its own schema (search_path pinned per connection) so parallel pg
+ * suites never collide, and skips cleanly when no test Postgres is reachable.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { after, before, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { Pool } from 'pg';
+
+import { probePgTest } from './_helpers/pgTestDb.js';
+import { AgentTeamsInstallStore } from '../src/platform/agentTeamsInstallStore.js';
+
+const { url: PG_URL, reachable: pgAvailable } = await probePgTest({
+  label: 'agentTeamsTargetKind',
+  vars: ['GRAPH_PG_TEST_URL', 'MEMORY_PG_TEST_URL', 'DATABASE_URL'],
+  timeoutMs: 1_500,
+});
+
+const MIGRATIONS = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'migrations');
+const SCHEMA = `teams_target_kind_${String(process.pid)}`;
+
+async function sql(name: string): Promise<string> {
+  return readFile(resolve(MIGRATIONS, name), 'utf8');
+}
+
+describe('migration 0054 — target_kind', { skip: !pgAvailable }, () => {
+  let pool: Pool;
+
+  before(async () => {
+    const bootstrap = new Pool({ connectionString: PG_URL, max: 1 });
+    await bootstrap.query(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+    await bootstrap.query(`CREATE SCHEMA ${SCHEMA}`);
+    await bootstrap.end();
+    pool = new Pool({
+      connectionString: PG_URL,
+      max: 2,
+      options: `-c search_path=${SCHEMA}`,
+    });
+
+    // The world BEFORE 0054: schema at 0049 + 0051, with rows in it.
+    await pool.query(await sql('0049_agent_teams_identities.sql'));
+    await pool.query(await sql('0051_agent_teams_installs.sql'));
+
+    await pool.query(
+      `INSERT INTO agent_teams_identities (agent_id, bot_slug, display_name, state, team_id, teams_app_id)
+       VALUES ('legacy-agent', 'legacy-bot', 'Legacy Bot', 'installed', 'aaaaaaaa-0000-4000-8000-000000000001', 'catalog-1')`,
+    );
+    await pool.query(
+      `INSERT INTO agent_teams_installs (agent_id, team_id, teams_app_id, team_display_name)
+       VALUES ('legacy-agent', 'aaaaaaaa-0000-4000-8000-000000000001', 'catalog-1', 'Marketing')`,
+    );
+
+    // Applied TWICE on purpose — the migrations README requires every file to
+    // be re-applicable, and the schema CI gate double-applies.
+    const migration = await sql('0054_agent_teams_target_kind.sql');
+    await pool.query(migration);
+    await pool.query(migration);
+  });
+
+  after(async () => {
+    await pool.query(`DROP SCHEMA IF EXISTS ${SCHEMA} CASCADE`);
+    await pool.end();
+  });
+
+  it('labels every PRE-EXISTING identity row as a team', async () => {
+    const res = await pool.query<{ target_kind: string }>(
+      `SELECT target_kind FROM agent_teams_identities WHERE agent_id = 'legacy-agent'`,
+    );
+    assert.equal(res.rows[0]?.target_kind, 'team');
+  });
+
+  it('labels every PRE-EXISTING binding as a team, keeping its other columns', async () => {
+    const res = await pool.query<{
+      target_kind: string;
+      team_display_name: string | null;
+      teams_app_id: string | null;
+    }>(
+      `SELECT target_kind, team_display_name, teams_app_id
+         FROM agent_teams_installs WHERE agent_id = 'legacy-agent'`,
+    );
+    const row = res.rows[0];
+    assert.equal(row?.target_kind, 'team');
+    // The backfill must not disturb what was already there.
+    assert.equal(row?.team_display_name, 'Marketing');
+    assert.equal(row?.teams_app_id, 'catalog-1');
+  });
+
+  it('accepts the three installable kinds and REFUSES anything else', async () => {
+    for (const kind of ['team', 'group-chat', 'one-on-one-chat']) {
+      await pool.query(
+        `INSERT INTO agent_teams_installs (agent_id, team_id, target_kind)
+         VALUES ('legacy-agent', $1, $2)`,
+        [`target-${kind}`, kind],
+      );
+    }
+    // A channel is not an install target, so the vocabulary must not contain
+    // it — the CHECK constraint is the last line of that defence.
+    await assert.rejects(
+      pool.query(
+        `INSERT INTO agent_teams_installs (agent_id, team_id, target_kind)
+         VALUES ('legacy-agent', 'target-channel', 'channel')`,
+      ),
+      /agent_teams_installs_target_kind_check/,
+    );
+  });
+
+  it('round-trips the kind through the store the runner actually writes with', async () => {
+    const store = new AgentTeamsInstallStore(pool);
+    const written = await store.record({
+      agentId: 'legacy-agent',
+      teamId: '19:abc123@thread.v2',
+      targetKind: 'group-chat',
+      teamsAppId: 'catalog-2',
+    });
+    assert.equal(written.targetKind, 'group-chat');
+
+    const read = await store.get('legacy-agent', '19:abc123@thread.v2');
+    assert.equal(read?.targetKind, 'group-chat');
+  });
+
+  it('defaults to team when the store is called without a kind', async () => {
+    // The pre-0054 call shape, which every existing caller still uses.
+    const store = new AgentTeamsInstallStore(pool);
+    const written = await store.record({
+      agentId: 'legacy-agent',
+      teamId: 'bbbbbbbb-0000-4000-8000-000000000002',
+    });
+    assert.equal(written.targetKind, 'team');
+  });
+
+  it('re-targets a binding kind on re-record rather than keeping a stale one', async () => {
+    // An id can only be one kind, but a row rewritten after a correction must
+    // not keep claiming the endpoint that never worked.
+    const store = new AgentTeamsInstallStore(pool);
+    await store.record({
+      agentId: 'legacy-agent',
+      teamId: 'cccccccc-0000-4000-8000-000000000003',
+      targetKind: 'team',
+    });
+    const updated = await store.record({
+      agentId: 'legacy-agent',
+      teamId: 'cccccccc-0000-4000-8000-000000000003',
+      targetKind: 'group-chat',
+    });
+    assert.equal(updated.targetKind, 'group-chat');
+  });
+});

--- a/middleware/test/operatorAgentsRouter.test.ts
+++ b/middleware/test/operatorAgentsRouter.test.ts
@@ -1317,7 +1317,7 @@ describe('createOperatorAgentsRouter', () => {
         botSlug: 'sales',
         displayName: 'Sales',
         state: 'bot_created',
-        teamId: '19:team-a',
+        teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
         appId: 'app-1',
         tenantId: 'tenant-1',
         teamsAppId: null,
@@ -1411,7 +1411,7 @@ describe('createOperatorAgentsRouter', () => {
         botSlug: 'sales',
         displayName: 'Sales',
         state: 'installed',
-        teamId: '19:team-a',
+        teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
         appId: 'app-1',
         tenantId: 'tenant-1',
         teamsAppId: 'catalog-1',
@@ -1444,7 +1444,7 @@ describe('createOperatorAgentsRouter', () => {
         botSlug: 'sales',
         displayName: 'Sales',
         state: 'failed',
-        teamId: '19:team-a',
+        teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
         appId: 'app-1',
         tenantId: 'tenant-1',
         teamsAppId: null,
@@ -1476,14 +1476,14 @@ describe('createOperatorAgentsRouter', () => {
         botSlug: 'sales',
         displayName: 'Sales',
         state: 'failed',
-        teamId: '19:team-a',
+        teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
         appId: 'app-1',
         tenantId: 'tenant-1',
         teamsAppId: null,
         teamsAppExternalId: null,
         lastError: 'consent_missing: admin consent required for scopes []',
       });
-      teamsRunner.running.set(agent.id, '19:team-a');
+      teamsRunner.running.set(agent.id, 'aaaaaaaa-0000-4000-8000-000000000001');
 
       const res = await fetch(`${baseUrl}/sales/teams-identity`);
       const body = (await res.json()) as { state: string; running: boolean };
@@ -1503,7 +1503,7 @@ describe('createOperatorAgentsRouter', () => {
     const res = await fetch(`${baseUrl}/sales/teams-identity`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:team-abc' }),
+      body: JSON.stringify({ team_id: 'abcabcab-0000-4000-8000-000000000003' }),
     });
     // FakeTeamsRunner.enqueue never settles — reaching these assertions at
     // all proves the handler returned without awaiting the provisioning run.
@@ -1521,7 +1521,11 @@ describe('createOperatorAgentsRouter', () => {
     assert.equal(body.state, 'pending');
     assert.equal(body.running, true);
     assert.deepEqual(teamsRunner.enqueueCalls, [
-      { agentId: agent.id, teamId: '19:team-abc' },
+      {
+        agentId: agent.id,
+        teamId: 'abcabcab-0000-4000-8000-000000000003',
+        targetKind: 'team',
+      },
     ]);
     assert.equal(teamsStore.rows.size, 1);
     assert.deepEqual(teamsStore.ensureCalls, [
@@ -1529,7 +1533,8 @@ describe('createOperatorAgentsRouter', () => {
         agentId: agent.id,
         botSlug: 'sales',
         displayName: 'Sales Agent',
-        teamId: '19:team-abc',
+        teamId: 'abcabcab-0000-4000-8000-000000000003',
+        targetKind: 'team',
       },
     ]);
   });
@@ -1542,7 +1547,7 @@ describe('createOperatorAgentsRouter', () => {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
-          team_id: '19:t',
+          team_id: '11111111-0000-4000-8000-000000000004',
           display_name: 'Sales Bot',
         }),
       },
@@ -1558,13 +1563,13 @@ describe('createOperatorAgentsRouter', () => {
     const first = await fetch(`${baseUrl}/sales/teams-identity`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:t', bot_slug: 'sales-bot' }),
+      body: JSON.stringify({ team_id: '11111111-0000-4000-8000-000000000004', bot_slug: 'sales-bot' }),
     });
     assert.equal(first.status, 202);
     const second = await fetch(`${baseUrl}/sales/teams-identity`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:t', bot_slug: 'other-bot' }),
+      body: JSON.stringify({ team_id: '11111111-0000-4000-8000-000000000004', bot_slug: 'other-bot' }),
     });
     assert.equal(second.status, 202);
     const body = (await second.json()) as { bot_slug: string };
@@ -1578,7 +1583,7 @@ describe('createOperatorAgentsRouter', () => {
     let res = await fetch(`${baseUrl}/ghost/teams-identity`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:t' }),
+      body: JSON.stringify({ team_id: '11111111-0000-4000-8000-000000000004' }),
     });
     assert.equal(res.status, 404);
 
@@ -1599,7 +1604,7 @@ describe('createOperatorAgentsRouter', () => {
     const res = await fetch(`${baseUrl}/sales/teams-identity`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:t' }),
+      body: JSON.stringify({ team_id: '11111111-0000-4000-8000-000000000004' }),
     });
     assert.equal(res.status, 503);
     assert.equal(
@@ -1617,7 +1622,7 @@ describe('createOperatorAgentsRouter', () => {
     let res = await fetch(`${baseUrl}/ghost/teams-identity`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:t' }),
+      body: JSON.stringify({ team_id: '11111111-0000-4000-8000-000000000004' }),
     });
     assert.equal(res.status, 404);
     // Malformed body → 400, not 503.
@@ -1636,13 +1641,13 @@ describe('createOperatorAgentsRouter', () => {
     const res = await fetch(`${baseUrl}/sales/teams-identity`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:t', bot_slug: 'a'.repeat(64) }),
+      body: JSON.stringify({ team_id: '11111111-0000-4000-8000-000000000004', bot_slug: 'a'.repeat(64) }),
     });
     assert.equal(res.status, 400, 'BOT_SLUG_PATTERN allows at most 63 chars');
     const ok = await fetch(`${baseUrl}/sales/teams-identity`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:t', bot_slug: 'a'.repeat(63) }),
+      body: JSON.stringify({ team_id: '11111111-0000-4000-8000-000000000004', bot_slug: 'a'.repeat(63) }),
     });
     assert.equal(ok.status, 202);
   });
@@ -1655,7 +1660,7 @@ describe('createOperatorAgentsRouter', () => {
     const res = await fetch(`${baseUrl}/sales/teams-identity`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:t', bot_slug: 'sales-bot' }),
+      body: JSON.stringify({ team_id: '11111111-0000-4000-8000-000000000004', bot_slug: 'sales-bot' }),
     });
     assert.equal(res.status, 409);
     assert.equal(((await res.json()) as { error: string }).error, 'bot_slug_taken');
@@ -1668,7 +1673,7 @@ describe('createOperatorAgentsRouter', () => {
     const res = await fetch(`${baseUrl}/sales/teams-identity`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:t' }),
+      body: JSON.stringify({ team_id: '11111111-0000-4000-8000-000000000004' }),
     });
     assert.equal(res.status, 202);
     const body = (await res.json()) as { running: boolean };
@@ -1696,7 +1701,7 @@ describe('createOperatorAgentsRouter', () => {
       botSlug: 'sales-bot',
       displayName: 'Sales Bot',
       state: 'installed',
-      teamId: '19:team-a',
+      teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
       appId: 'app-123',
       tenantId: 'tenant-456',
       teamsAppId: 'teams-app-789',
@@ -1705,7 +1710,7 @@ describe('createOperatorAgentsRouter', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
     });
-    teamsRunner.running.set(agent.id, '19:team-a');
+    teamsRunner.running.set(agent.id, 'aaaaaaaa-0000-4000-8000-000000000001');
     const res = await fetch(`${baseUrl}/sales/teams-identity`);
     assert.equal(res.status, 200);
     const body = (await res.json()) as {
@@ -1755,7 +1760,7 @@ describe('createOperatorAgentsRouter', () => {
       botSlug: 'sales-bot',
       displayName: 'Sales Bot',
       state: 'pending',
-      teamId: '19:team-a',
+      teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
       appId: null,
       tenantId: null,
       teamsAppId: null,
@@ -1787,7 +1792,7 @@ describe('createOperatorAgentsRouter', () => {
       botSlug: 'sales-bot',
       displayName: 'Sales Bot',
       state: 'installed',
-      teamId: '19:team-a',
+      teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
       appId: 'app-123',
       tenantId: 'tenant-456',
       teamsAppId: 'teams-app-789',
@@ -1814,7 +1819,7 @@ describe('createOperatorAgentsRouter', () => {
       botSlug: 'sales-bot',
       displayName: 'Sales Bot',
       state: 'installed',
-      teamId: '19:team-a',
+      teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
       appId: 'app-123',
       tenantId: 'tenant-456',
       teamsAppId: 'teams-app-789',
@@ -1881,7 +1886,7 @@ describe('createOperatorAgentsRouter', () => {
       botSlug: 'sales-bot',
       displayName: 'Sales Bot',
       state: 'installed',
-      teamId: '19:team-a',
+      teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
       appId: 'app-123',
       tenantId: 'tenant-456',
       teamsAppId: 'teams-app-789',
@@ -1912,7 +1917,7 @@ describe('createOperatorAgentsRouter', () => {
       botSlug: 'sales-bot',
       displayName: 'Sales Bot',
       state: 'pending',
-      teamId: '19:team-a',
+      teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
       appId: null,
       tenantId: null,
       teamsAppId: null,
@@ -1948,7 +1953,7 @@ describe('createOperatorAgentsRouter', () => {
       botSlug: 'sales-bot',
       displayName: 'Sales Bot',
       state: 'installed',
-      teamId: '19:team-a',
+      teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
       appId: 'app-123',
       tenantId: 'tenant-456',
       teamsAppId: 'teams-app-789',
@@ -2003,7 +2008,7 @@ describe('createOperatorAgentsRouter', () => {
       botSlug: 'sales-bot',
       displayName: 'Sales Bot',
       state: 'app_registered',
-      teamId: '19:team-a',
+      teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
       appId: 'app-123',
       tenantId: 'tenant-456',
       teamsAppId: null,
@@ -2016,7 +2021,7 @@ describe('createOperatorAgentsRouter', () => {
     const body = (await res.json()) as { identity: { team_id: string | null } };
     // POST requires `team_id` and has no fall-back-to-stored path, so without
     // this field the UI's "Re-run provisioning" button could only ever 400.
-    assert.equal(body.identity.team_id, '19:team-a');
+    assert.equal(body.identity.team_id, 'aaaaaaaa-0000-4000-8000-000000000001');
   });
 
   it('POST /:slug/teams-identity refuses to retarget an installed row instead of rewriting team_id', async () => {
@@ -2026,7 +2031,7 @@ describe('createOperatorAgentsRouter', () => {
       botSlug: 'sales-bot',
       displayName: 'Sales Bot',
       state: 'installed',
-      teamId: '19:team-a',
+      teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
       appId: 'app-123',
       tenantId: 'tenant-456',
       teamsAppId: 'teams-app-789',
@@ -2038,16 +2043,16 @@ describe('createOperatorAgentsRouter', () => {
     const res = await fetch(`${baseUrl}/sales/teams-identity`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:team-b' }),
+      body: JSON.stringify({ team_id: 'bbbbbbbb-0000-4000-8000-000000000002' }),
     });
     assert.equal(res.status, 409);
     const body = (await res.json()) as { error: string; installed_team_id: string };
     assert.equal(body.error, 'team_install_conflict');
-    assert.equal(body.installed_team_id, '19:team-a');
+    assert.equal(body.installed_team_id, 'aaaaaaaa-0000-4000-8000-000000000001');
     // The runner returns early on an 'installed' row, so an accepted retarget
     // would rewrite team_id with NO install ever happening — and the team read
     // model would then publish team-b as installed on that column alone.
-    assert.equal(teamsStore.rows.get(agent.id)?.teamId, '19:team-a');
+    assert.equal(teamsStore.rows.get(agent.id)?.teamId, 'aaaaaaaa-0000-4000-8000-000000000001');
     assert.deepEqual(teamsStore.ensureCalls, []);
     assert.deepEqual(teamsRunner.enqueueCalls, []);
   });
@@ -2059,7 +2064,7 @@ describe('createOperatorAgentsRouter', () => {
       botSlug: 'sales-bot',
       displayName: 'Sales Bot',
       state: 'catalog_uploaded',
-      teamId: '19:team-a',
+      teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
       appId: 'app-123',
       tenantId: 'tenant-456',
       teamsAppId: 'teams-app-789',
@@ -2068,23 +2073,23 @@ describe('createOperatorAgentsRouter', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
     });
-    teamsRunner.running.set(agent.id, '19:team-a');
+    teamsRunner.running.set(agent.id, 'aaaaaaaa-0000-4000-8000-000000000001');
 
     const res = await fetch(`${baseUrl}/sales/teams`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:team-b' }),
+      body: JSON.stringify({ team_id: 'bbbbbbbb-0000-4000-8000-000000000002' }),
     });
 
     assert.equal(res.status, 409);
     const body = (await res.json()) as { error: string; pending_team_id: string };
     assert.equal(body.error, 'team_install_conflict');
-    assert.equal(body.pending_team_id, '19:team-a');
+    assert.equal(body.pending_team_id, 'aaaaaaaa-0000-4000-8000-000000000001');
     // The in-flight run installs into team-a (installToTeam uses the teamId
     // captured at enqueue) while the runner refuses the second enqueue with a
     // RESOLVED 'rejected' result the route cannot see. Writing team-b first
     // would leave the row claiming an install that never happened.
-    assert.equal(teamsStore.rows.get(agent.id)?.teamId, '19:team-a');
+    assert.equal(teamsStore.rows.get(agent.id)?.teamId, 'aaaaaaaa-0000-4000-8000-000000000001');
     assert.deepEqual(teamsStore.ensureCalls, []);
     assert.deepEqual(teamsRunner.enqueueCalls, []);
   });
@@ -2096,7 +2101,7 @@ describe('createOperatorAgentsRouter', () => {
       botSlug: 'sales-bot',
       displayName: 'Sales Bot',
       state: 'app_registered',
-      teamId: '19:team-a',
+      teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
       appId: 'app-123',
       tenantId: 'tenant-456',
       teamsAppId: null,
@@ -2111,13 +2116,13 @@ describe('createOperatorAgentsRouter', () => {
       status: 'rejected',
       agentId: agent.id,
       reason: 'team_conflict',
-      detail: 'a provisioning run targeting team 19:team-a is already in flight',
+      detail: 'a provisioning run targeting team aaaaaaaa-0000-4000-8000-000000000001 is already in flight',
     };
 
     const res = await fetch(`${baseUrl}/sales/teams-identity`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:team-a' }),
+      body: JSON.stringify({ team_id: 'aaaaaaaa-0000-4000-8000-000000000001' }),
     });
     assert.equal(res.status, 202);
 
@@ -2175,7 +2180,7 @@ describe('createOperatorAgentsRouter', () => {
       botSlug: 'sales-bot',
       displayName: 'Sales Bot',
       state: 'failed',
-      teamId: '19:team-a',
+      teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
       appId: null,
       tenantId: null,
       teamsAppId: null,
@@ -2203,7 +2208,7 @@ describe('createOperatorAgentsRouter', () => {
       botSlug: 'sales-bot',
       displayName: 'Sales Bot',
       state: 'app_registered',
-      teamId: '19:team-a',
+      teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
       appId: null,
       tenantId: null,
       teamsAppId: null,
@@ -2263,7 +2268,7 @@ describe('createOperatorAgentsRouter', () => {
       const post = await fetch(`${local}/sales/teams-identity`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ team_id: '19:t' }),
+        body: JSON.stringify({ team_id: '11111111-0000-4000-8000-000000000004' }),
       });
       assert.equal(post.status, 503);
       assert.equal(
@@ -2298,7 +2303,7 @@ describe('createOperatorAgentsRouter', () => {
       botSlug: 'sales-bot',
       displayName: 'Sales Bot',
       state: 'installed',
-      teamId: '19:team-a',
+      teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
       appId: 'app-123',
       tenantId: 'tenant-456',
       teamsAppId: 'teams-app-789',
@@ -2331,7 +2336,8 @@ describe('createOperatorAgentsRouter', () => {
     assert.equal(body.agent, 'sales');
     assert.deepEqual(body.teams, [
       {
-        team_id: '19:team-a',
+        team_id: 'aaaaaaaa-0000-4000-8000-000000000001',
+        target_kind: 'team',
         // No installs store is bound in this suite, so nothing ever resolved
         // a name — the UI shows the bare id rather than inventing one.
         team_display_name: null,
@@ -2364,7 +2370,7 @@ describe('createOperatorAgentsRouter', () => {
 
   it('GET /:slug/teams reports NO install while the chain is still running', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
-    seedIdentity(agent.id, { state: 'catalog_uploaded', teamId: '19:team-a' });
+    seedIdentity(agent.id, { state: 'catalog_uploaded', teamId: 'aaaaaaaa-0000-4000-8000-000000000001' });
     const res = await fetch(`${baseUrl}/sales/teams`);
     const body = (await res.json()) as {
       teams: unknown[];
@@ -2374,7 +2380,7 @@ describe('createOperatorAgentsRouter', () => {
     // A recorded team_id below 'installed' is the TARGET of a run, not an
     // install — claiming otherwise would invent a Teams state.
     assert.deepEqual(body.teams, []);
-    assert.equal(body.pending_team_id, '19:team-a');
+    assert.equal(body.pending_team_id, 'aaaaaaaa-0000-4000-8000-000000000001');
     // catalog_uploaded already required a consented Graph call.
     assert.equal(body.consent.status, 'granted');
   });
@@ -2384,7 +2390,7 @@ describe('createOperatorAgentsRouter', () => {
     const scopes = ['Application.ReadWrite.All', 'AppCatalog.ReadWrite.All'];
     seedIdentity(agent.id, {
       state: 'failed',
-      teamId: '19:team-a',
+      teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
       lastError: consentMissingDetail(scopes),
     });
     const res = await fetch(`${baseUrl}/sales/teams`);
@@ -2423,7 +2429,7 @@ describe('createOperatorAgentsRouter', () => {
     const res = await fetch(`${baseUrl}/sales/teams`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:team-b' }),
+      body: JSON.stringify({ team_id: 'bbbbbbbb-0000-4000-8000-000000000002' }),
     });
     assert.equal(res.status, 202);
     const body = (await res.json()) as {
@@ -2434,7 +2440,7 @@ describe('createOperatorAgentsRouter', () => {
       running: boolean;
     };
     assert.equal(body.ok, true);
-    assert.equal(body.team_id, '19:team-b');
+    assert.equal(body.team_id, 'bbbbbbbb-0000-4000-8000-000000000002');
     assert.equal(body.bot_slug, 'sales-bot');
     assert.equal(body.already_installed, false);
     assert.equal(body.running, true);
@@ -2445,24 +2451,29 @@ describe('createOperatorAgentsRouter', () => {
         agentId: agent.id,
         botSlug: 'sales-bot',
         displayName: 'Sales Bot',
-        teamId: '19:team-b',
+        teamId: 'bbbbbbbb-0000-4000-8000-000000000002',
+        targetKind: 'team',
       },
     ]);
-    assert.deepEqual(teamsStore.rows.get(agent.id)?.teamId, '19:team-b');
+    assert.deepEqual(teamsStore.rows.get(agent.id)?.teamId, 'bbbbbbbb-0000-4000-8000-000000000002');
     // Installing goes through the provisioning runner — the router never
     // calls the connector itself.
     assert.deepEqual(teamsRunner.enqueueCalls, [
-      { agentId: agent.id, teamId: '19:team-b' },
+      {
+        agentId: agent.id,
+        teamId: 'bbbbbbbb-0000-4000-8000-000000000002',
+        targetKind: 'team',
+      },
     ]);
   });
 
   it('POST /:slug/teams is idempotent for the team the agent is already installed in', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
-    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
+    seedIdentity(agent.id, { state: 'installed', teamId: 'aaaaaaaa-0000-4000-8000-000000000001' });
     const res = await fetch(`${baseUrl}/sales/teams`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:team-a' }),
+      body: JSON.stringify({ team_id: 'aaaaaaaa-0000-4000-8000-000000000001' }),
     });
     assert.equal(res.status, 200);
     const body = (await res.json()) as { already_installed: boolean; running: boolean };
@@ -2482,11 +2493,11 @@ describe('createOperatorAgentsRouter', () => {
   // the store.
   it('POST /:slug/teams → 409 for a SECOND team without an installs store, writing nothing', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
-    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
+    seedIdentity(agent.id, { state: 'installed', teamId: 'aaaaaaaa-0000-4000-8000-000000000001' });
     const res = await fetch(`${baseUrl}/sales/teams`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:team-b' }),
+      body: JSON.stringify({ team_id: 'bbbbbbbb-0000-4000-8000-000000000002' }),
     });
     assert.equal(res.status, 409);
     const body = (await res.json()) as {
@@ -2496,12 +2507,12 @@ describe('createOperatorAgentsRouter', () => {
       message: string;
     };
     assert.equal(body.error, 'team_install_conflict');
-    assert.equal(body.installed_team_id, '19:team-a');
-    assert.equal(body.requested_team_id, '19:team-b');
+    assert.equal(body.installed_team_id, 'aaaaaaaa-0000-4000-8000-000000000001');
+    assert.equal(body.requested_team_id, 'bbbbbbbb-0000-4000-8000-000000000002');
     assert.match(body.message, /agent_teams_installs/);
     // The tracked install must survive a refused re-target: overwriting the
     // single team_id would leave the team-a install with nothing recording it.
-    assert.equal(teamsStore.rows.get(agent.id)?.teamId, '19:team-a');
+    assert.equal(teamsStore.rows.get(agent.id)?.teamId, 'aaaaaaaa-0000-4000-8000-000000000001');
     assert.deepEqual(teamsStore.ensureCalls, []);
     assert.deepEqual(teamsRunner.enqueueCalls, []);
   });
@@ -2533,8 +2544,8 @@ describe('createOperatorAgentsRouter', () => {
   it('GET /:slug/teams lists EVERY persisted binding and reports multi_team', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
     seedIdentity(agent.id);
-    seedInstall(agent.id, '19:team-a', { teamDisplayName: 'Marketing' });
-    seedInstall(agent.id, '19:team-b', {
+    seedInstall(agent.id, 'aaaaaaaa-0000-4000-8000-000000000001', { teamDisplayName: 'Marketing' });
+    seedInstall(agent.id, 'bbbbbbbb-0000-4000-8000-000000000002', {
       installedAt: new Date('2026-08-03T09:00:00.000Z'),
     });
     const res = await fetch(`${baseUrl}/sales/teams`);
@@ -2546,9 +2557,9 @@ describe('createOperatorAgentsRouter', () => {
     assert.deepEqual(
       body.teams.map((team) => [team['team_id'], team['team_display_name']]),
       [
-        ['19:team-a', 'Marketing'],
+        ['aaaaaaaa-0000-4000-8000-000000000001', 'Marketing'],
         // Never resolved — the UI shows the id, it does not invent a label.
-        ['19:team-b', null],
+        ['bbbbbbbb-0000-4000-8000-000000000002', null],
       ],
     );
     // Both entries say they came from a recorded install, not a Graph listing.
@@ -2566,7 +2577,7 @@ describe('createOperatorAgentsRouter', () => {
   it('GET /:slug/teams backfills a missing team name and PERSISTS it', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
     seedIdentity(agent.id);
-    seedInstall(agent.id, '19:team-a');
+    seedInstall(agent.id, 'aaaaaaaa-0000-4000-8000-000000000001');
     const lookups: string[] = [];
     resolveTeamName = (teamId) => {
       lookups.push(teamId);
@@ -2575,46 +2586,50 @@ describe('createOperatorAgentsRouter', () => {
     const res = await fetch(`${baseUrl}/sales/teams`);
     const body = (await res.json()) as { teams: Array<Record<string, unknown>> };
     assert.equal(body.teams[0]?.['team_display_name'], 'Marketing');
-    assert.deepEqual(lookups, ['19:team-a']);
+    assert.deepEqual(lookups, ['aaaaaaaa-0000-4000-8000-000000000001']);
     // Written through, so the next read needs no lookup — and so the name
     // survives a connector that is later removed or downgraded.
     assert.deepEqual(teamsInstalls?.nameWrites, [
-      { teamId: '19:team-a', displayName: 'Marketing' },
+      { teamId: 'aaaaaaaa-0000-4000-8000-000000000001', displayName: 'Marketing' },
     ]);
   });
 
   it('GET /:slug/teams survives a failing name lookup — ids, never a 500', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
     seedIdentity(agent.id);
-    seedInstall(agent.id, '19:team-a');
+    seedInstall(agent.id, 'aaaaaaaa-0000-4000-8000-000000000001');
     resolveTeamName = () => Promise.reject(new Error('graph down'));
     const res = await fetch(`${baseUrl}/sales/teams`);
     assert.equal(res.status, 200);
     const body = (await res.json()) as { teams: Array<Record<string, unknown>> };
-    assert.equal(body.teams[0]?.['team_id'], '19:team-a');
+    assert.equal(body.teams[0]?.['team_id'], 'aaaaaaaa-0000-4000-8000-000000000001');
     assert.equal(body.teams[0]?.['team_display_name'], null);
   });
 
   it('POST /:slug/teams accepts an ADDITIONAL team once bindings persist', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
-    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
-    seedInstall(agent.id, '19:team-a');
+    seedIdentity(agent.id, { state: 'installed', teamId: 'aaaaaaaa-0000-4000-8000-000000000001' });
+    seedInstall(agent.id, 'aaaaaaaa-0000-4000-8000-000000000001');
     const res = await fetch(`${baseUrl}/sales/teams`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:team-b' }),
+      body: JSON.stringify({ team_id: 'bbbbbbbb-0000-4000-8000-000000000002' }),
     });
     assert.equal(res.status, 202);
     const body = (await res.json()) as { team_id: string; already_installed: boolean };
-    assert.equal(body.team_id, '19:team-b');
+    assert.equal(body.team_id, 'bbbbbbbb-0000-4000-8000-000000000002');
     assert.equal(body.already_installed, false);
     // The chain is resumed for the NEW team; the existing binding is untouched.
     assert.deepEqual(teamsRunner.enqueueCalls, [
-      { agentId: agent.id, teamId: '19:team-b' },
+      {
+        agentId: agent.id,
+        teamId: 'bbbbbbbb-0000-4000-8000-000000000002',
+        targetKind: 'team',
+      },
     ]);
     assert.deepEqual(
       teamsInstalls?.rows.map((row) => row.teamId),
-      ['19:team-a'],
+      ['aaaaaaaa-0000-4000-8000-000000000001'],
     );
   });
 
@@ -2622,12 +2637,12 @@ describe('createOperatorAgentsRouter', () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
     // The identity's scratch `team_id` points elsewhere on purpose: the answer
     // must come from the bindings table, which is the record of what happened.
-    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-b' });
-    seedInstall(agent.id, '19:team-a');
+    seedIdentity(agent.id, { state: 'installed', teamId: 'bbbbbbbb-0000-4000-8000-000000000002' });
+    seedInstall(agent.id, 'aaaaaaaa-0000-4000-8000-000000000001');
     const res = await fetch(`${baseUrl}/sales/teams`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:team-a' }),
+      body: JSON.stringify({ team_id: 'aaaaaaaa-0000-4000-8000-000000000001' }),
     });
     assert.equal(res.status, 200);
     assert.equal(((await res.json()) as { already_installed: boolean }).already_installed, true);
@@ -2636,32 +2651,32 @@ describe('createOperatorAgentsRouter', () => {
 
   it('DELETE /:slug/teams/:teamId drops ONE binding and leaves the rest installed', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
-    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
-    seedInstall(agent.id, '19:team-a');
-    seedInstall(agent.id, '19:team-b');
-    const res = await fetch(`${baseUrl}/sales/teams/19%3Ateam-a`, { method: 'DELETE' });
+    seedIdentity(agent.id, { state: 'installed', teamId: 'aaaaaaaa-0000-4000-8000-000000000001' });
+    seedInstall(agent.id, 'aaaaaaaa-0000-4000-8000-000000000001');
+    seedInstall(agent.id, 'bbbbbbbb-0000-4000-8000-000000000002');
+    const res = await fetch(`${baseUrl}/sales/teams/aaaaaaaa-0000-4000-8000-000000000001`, { method: 'DELETE' });
     assert.equal(res.status, 200);
     const body = (await res.json()) as {
       team_id: string;
       state: string;
       remaining_team_ids: string[];
     };
-    assert.equal(body.team_id, '19:team-a');
-    assert.deepEqual(body.remaining_team_ids, ['19:team-b']);
+    assert.equal(body.team_id, 'aaaaaaaa-0000-4000-8000-000000000001');
+    assert.deepEqual(body.remaining_team_ids, ['bbbbbbbb-0000-4000-8000-000000000002']);
     // An agent still installed somewhere is still installed — walking the
     // identity back to catalog_uploaded would report team-b as pending.
     assert.equal(body.state, 'installed');
     assert.equal(teamsStore.rows.get(agent.id)?.state, 'installed');
     assert.deepEqual(
       teamsInstalls?.rows.map((row) => row.teamId),
-      ['19:team-b'],
+      ['bbbbbbbb-0000-4000-8000-000000000002'],
     );
   });
 
   it('DELETE /:slug/teams/:teamId → 404 for a team this agent is not bound to', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
-    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
-    seedInstall(agent.id, '19:team-a');
+    seedIdentity(agent.id, { state: 'installed', teamId: 'aaaaaaaa-0000-4000-8000-000000000001' });
+    seedInstall(agent.id, 'aaaaaaaa-0000-4000-8000-000000000001');
     const res = await fetch(`${baseUrl}/sales/teams/19%3Aghost`, { method: 'DELETE' });
     assert.equal(res.status, 404);
     assert.equal(
@@ -2684,7 +2699,7 @@ describe('createOperatorAgentsRouter', () => {
     res = await fetch(`${baseUrl}/ghost/teams`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ team_id: '19:team-b' }),
+      body: JSON.stringify({ team_id: 'bbbbbbbb-0000-4000-8000-000000000002' }),
     });
     assert.equal(res.status, 404);
     assert.equal(((await res.json()) as { error: string }).error, 'not_found');
@@ -2693,7 +2708,7 @@ describe('createOperatorAgentsRouter', () => {
       res = await fetch(`${baseUrl}/sales/teams`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ team_id: '19:team-b' }),
+        body: JSON.stringify({ team_id: 'bbbbbbbb-0000-4000-8000-000000000002' }),
       });
       assert.equal(res.status, 503);
       assert.equal(
@@ -2721,10 +2736,10 @@ describe('createOperatorAgentsRouter', () => {
 
   it('DELETE /:slug/teams/:teamId removes the install and clears the row', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
-    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
+    seedIdentity(agent.id, { state: 'installed', teamId: 'aaaaaaaa-0000-4000-8000-000000000001' });
     const fake = provisioner as FakeTeamsProvisioner;
 
-    const res = await deleteTeam('sales', '19:team-a');
+    const res = await deleteTeam('sales', 'aaaaaaaa-0000-4000-8000-000000000001');
     assert.equal(res.status, 200);
     const body = (await res.json()) as {
       ok: boolean;
@@ -2736,14 +2751,14 @@ describe('createOperatorAgentsRouter', () => {
     };
     assert.equal(body.ok, true);
     assert.equal(body.agent, 'sales');
-    assert.equal(body.team_id, '19:team-a');
+    assert.equal(body.team_id, 'aaaaaaaa-0000-4000-8000-000000000001');
     assert.equal(body.outcome, 'uninstalled');
     assert.equal(body.already_absent, false);
 
     // Graph got the CATALOG app id, not the installation id — resolving the
     // latter is the connector's job.
     assert.deepEqual(fake.calls, [
-      { teamId: '19:team-a', teamsAppId: 'teams-app-789' },
+      { teamId: 'aaaaaaaa-0000-4000-8000-000000000001', teamsAppId: 'teams-app-789' },
     ]);
     // The row drops back to catalog_uploaded with no team — the app, bot and
     // catalog entry all still exist, only the install is gone.
@@ -2755,11 +2770,11 @@ describe('createOperatorAgentsRouter', () => {
 
   it('DELETE /:slug/teams/:teamId reports the idempotent already-absent outcome', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
-    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
+    seedIdentity(agent.id, { state: 'installed', teamId: 'aaaaaaaa-0000-4000-8000-000000000001' });
     const fake = provisioner as FakeTeamsProvisioner;
     fake.outcome = 'already-absent';
 
-    const res = await deleteTeam('sales', '19:team-a');
+    const res = await deleteTeam('sales', 'aaaaaaaa-0000-4000-8000-000000000001');
     assert.equal(res.status, 200, 'not installed is success, not a failure');
     const body = (await res.json()) as { outcome: string; already_absent: boolean };
     assert.equal(body.outcome, 'already-absent');
@@ -2771,11 +2786,11 @@ describe('createOperatorAgentsRouter', () => {
 
   it('DELETE /:slug/teams/:teamId → 501 when the connector is too old (no uninstallFromTeam)', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
-    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
+    seedIdentity(agent.id, { state: 'installed', teamId: 'aaaaaaaa-0000-4000-8000-000000000001' });
     // A connector < 0.4.0: the accessor simply has no such method.
     provisioner = new LegacyTeamsProvisioner();
 
-    const res = await deleteTeam('sales', '19:team-a');
+    const res = await deleteTeam('sales', 'aaaaaaaa-0000-4000-8000-000000000001');
     assert.equal(res.status, 501);
     const body = (await res.json()) as {
       error: string;
@@ -2784,13 +2799,13 @@ describe('createOperatorAgentsRouter', () => {
       team_id: string;
     };
     assert.equal(body.error, 'teams_uninstall_unsupported');
-    assert.equal(body.team_id, '19:team-a');
+    assert.equal(body.team_id, 'aaaaaaaa-0000-4000-8000-000000000001');
     assert.equal(body.min_connector_version, TEAMS_UNINSTALL_MIN_CONNECTOR_VERSION);
     // The reason names the fix, not just the refusal.
     assert.match(body.message, /upgrade @omadia\/integration-microsoft365/);
     // Above all: the row is untouched. "Forgetting" the install would leave
     // the app live in Teams with nothing recording it.
-    assert.equal(teamsStore.rows.get(agent.id)?.teamId, '19:team-a');
+    assert.equal(teamsStore.rows.get(agent.id)?.teamId, 'aaaaaaaa-0000-4000-8000-000000000001');
     assert.equal(teamsStore.rows.get(agent.id)?.state, 'installed');
     assert.deepEqual(teamsStore.clearTeamInstalls, []);
   });
@@ -2839,24 +2854,24 @@ describe('createOperatorAgentsRouter', () => {
 
   it('DELETE /:slug/teams/:teamId → 404 for a team the middleware has no install for', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
-    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
+    seedIdentity(agent.id, { state: 'installed', teamId: 'aaaaaaaa-0000-4000-8000-000000000001' });
     const fake = provisioner as FakeTeamsProvisioner;
 
-    const res = await deleteTeam('sales', '19:team-b');
+    const res = await deleteTeam('sales', 'bbbbbbbb-0000-4000-8000-000000000002');
     assert.equal(res.status, 404);
     const body = (await res.json()) as { error: string };
     assert.equal(body.error, 'team_install_not_found');
     // No Graph call for an install we never recorded.
     assert.deepEqual(fake.calls, []);
-    assert.equal(teamsStore.rows.get(agent.id)?.teamId, '19:team-a');
+    assert.equal(teamsStore.rows.get(agent.id)?.teamId, 'aaaaaaaa-0000-4000-8000-000000000001');
   });
 
   it('DELETE /:slug/teams/:teamId → 404 while the chain has not reached installed', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
-    seedIdentity(agent.id, { state: 'catalog_uploaded', teamId: '19:team-a' });
+    seedIdentity(agent.id, { state: 'catalog_uploaded', teamId: 'aaaaaaaa-0000-4000-8000-000000000001' });
     const fake = provisioner as FakeTeamsProvisioner;
 
-    const res = await deleteTeam('sales', '19:team-a');
+    const res = await deleteTeam('sales', 'aaaaaaaa-0000-4000-8000-000000000001');
     assert.equal(res.status, 404);
     // A recorded team below 'installed' is a TARGET, not an install — the
     // read model does not list it, so the route must not remove it either.
@@ -2866,11 +2881,11 @@ describe('createOperatorAgentsRouter', () => {
 
   it('DELETE /:slug/teams/:teamId → 409 while a provisioning run is in flight', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
-    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
-    teamsRunner.running.set(agent.id, '19:team-a');
+    seedIdentity(agent.id, { state: 'installed', teamId: 'aaaaaaaa-0000-4000-8000-000000000001' });
+    teamsRunner.running.set(agent.id, 'aaaaaaaa-0000-4000-8000-000000000001');
     const fake = provisioner as FakeTeamsProvisioner;
 
-    const res = await deleteTeam('sales', '19:team-a');
+    const res = await deleteTeam('sales', 'aaaaaaaa-0000-4000-8000-000000000001');
     assert.equal(res.status, 409);
     const body = (await res.json()) as { error: string };
     assert.equal(body.error, 'teams_provisioning_running');
@@ -2882,35 +2897,35 @@ describe('createOperatorAgentsRouter', () => {
 
   it('DELETE /:slug/teams/:teamId → 503 when the connector is not installed at all', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
-    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
+    seedIdentity(agent.id, { state: 'installed', teamId: 'aaaaaaaa-0000-4000-8000-000000000001' });
     provisionerInstalled = false;
     provisioner = undefined;
     try {
-      const res = await deleteTeam('sales', '19:team-a');
+      const res = await deleteTeam('sales', 'aaaaaaaa-0000-4000-8000-000000000001');
       assert.equal(res.status, 503);
       const body = (await res.json()) as { error: string };
       assert.equal(body.error, 'teams_provisioner_unavailable');
     } finally {
       provisionerInstalled = true;
     }
-    assert.equal(teamsStore.rows.get(agent.id)?.teamId, '19:team-a');
+    assert.equal(teamsStore.rows.get(agent.id)?.teamId, 'aaaaaaaa-0000-4000-8000-000000000001');
     assert.deepEqual(teamsStore.clearTeamInstalls, []);
   });
 
   it('DELETE /:slug/teams/:teamId keeps the row when the connector call fails', async () => {
     const agent = await store.createAgent({ slug: 'sales', name: 'Sales' });
-    seedIdentity(agent.id, { state: 'installed', teamId: '19:team-a' });
+    seedIdentity(agent.id, { state: 'installed', teamId: 'aaaaaaaa-0000-4000-8000-000000000001' });
     const fake = provisioner as FakeTeamsProvisioner;
     const consent = new Error('403 from graph');
     consent.name = 'ConsentMissingError';
     fake.error = consent;
 
-    const res = await deleteTeam('sales', '19:team-a');
+    const res = await deleteTeam('sales', 'aaaaaaaa-0000-4000-8000-000000000001');
     assert.notEqual(res.status, 200);
     // Graph first, row second: a failed removal must not make the middleware
     // forget an install that is still live in Teams.
     assert.deepEqual(teamsStore.clearTeamInstalls, []);
-    assert.equal(teamsStore.rows.get(agent.id)?.teamId, '19:team-a');
+    assert.equal(teamsStore.rows.get(agent.id)?.teamId, 'aaaaaaaa-0000-4000-8000-000000000001');
     assert.equal(teamsStore.rows.get(agent.id)?.state, 'installed');
   });
 
@@ -2920,7 +2935,7 @@ describe('createOperatorAgentsRouter', () => {
       botSlug: 'sales-bot',
       displayName: 'Sales Bot',
       state: 'installed',
-      teamId: '19:team-a',
+      teamId: 'aaaaaaaa-0000-4000-8000-000000000001',
       appId: 'app-123',
       tenantId: 'tenant-456',
       teamsAppId: 'teams-app-789',
@@ -2972,7 +2987,7 @@ describe('createOperatorAgentsRouter', () => {
         await fetch(`${local}/sales/teams`, {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ team_id: '19:t' }),
+          body: JSON.stringify({ team_id: '11111111-0000-4000-8000-000000000004' }),
         }),
         await fetch(`${local}/sales/teams/19:t`, { method: 'DELETE' }),
       ]) {

--- a/middleware/test/teamsInstallTarget.test.ts
+++ b/middleware/test/teamsInstallTarget.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Install-target classification — the five shapes an operator can paste, and
+ * the one decision that follows from each.
+ *
+ * WHY THIS SUITE EXISTS. An operator pasted
+ * `abc8af8ec7fc471785d3b83c4d84b667` into the team field. The chain answered
+ * `400 teamId needs to be a valid GUID`, then — once the GUID was normalised —
+ * `404 No team found with Group Id`. Every team and every channel of the
+ * tenant was searched afterwards and the id was neither: it was, with high
+ * probability, the stem of a GROUP CHAT id. The operator wanted the right
+ * thing from the start and the chain had no vocabulary for it.
+ *
+ * So the vocabulary is pinned here, once, and both the route and the runner
+ * read it from the same function.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  classifyTeamsInstallTarget,
+  resolveTeamsInstallTarget,
+  TEAMS_TARGET_EXAMPLES,
+} from '../src/platform/teamsInstallTarget.js';
+
+describe('classifyTeamsInstallTarget', () => {
+  it('reads a dashed GUID as a team', () => {
+    const result = classifyTeamsInstallTarget('2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c');
+    assert.equal(result.kind, 'team');
+    assert.equal(result.id, '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c');
+  });
+
+  it('lowercases and keeps a dashed GUID addressable', () => {
+    const result = classifyTeamsInstallTarget('2F1A9C44-1F0E-4F2C-8F1A-9C441F0E4F2C');
+    assert.equal(result.kind, 'team');
+    assert.equal(result.id, '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c');
+  });
+
+  it('reads a @thread.v2 id as a group chat', () => {
+    const result = classifyTeamsInstallTarget('19:abc123def456@thread.v2');
+    assert.equal(result.kind, 'group-chat');
+    assert.equal(result.id, '19:abc123def456@thread.v2');
+  });
+
+  it('reads a @unq.gbl.spaces id as a one-on-one chat', () => {
+    const result = classifyTeamsInstallTarget('19:user1_user2@unq.gbl.spaces');
+    assert.equal(result.kind, 'one-on-one-chat');
+    assert.equal(result.id, '19:user1_user2@unq.gbl.spaces');
+  });
+
+  it('reads a @thread.tacv2 id as a CHANNEL — never an install target', () => {
+    const result = classifyTeamsInstallTarget('19:aBcDeF@thread.tacv2');
+    assert.equal(result.kind, 'channel');
+  });
+
+  it('refuses to guess at a bare 32-hex string', () => {
+    // The field-test id. It IS 32 hex, and that is exactly the problem: it
+    // could be a team's group id or the stem of `19:<32hex>@thread.v2`.
+    const result = classifyTeamsInstallTarget('abc8af8ec7fc471785d3b83c4d84b667');
+    assert.equal(result.kind, 'ambiguous');
+    // Still carries BOTH readings, so a caller can name them without
+    // re-deriving the shapes.
+    assert.equal(result.asTeamId, 'abc8af8e-c7fc-4717-85d3-b83c4d84b667');
+    assert.equal(result.asGroupChatId, '19:abc8af8ec7fc471785d3b83c4d84b667@thread.v2');
+  });
+
+  it('calls anything else unrecognised rather than inventing a kind', () => {
+    for (const input of ['hello world', '19:nope@thread.v9', 'not-a-guid', '19:']) {
+      assert.equal(
+        classifyTeamsInstallTarget(input).kind,
+        'unrecognised',
+        `expected ${input} to be unrecognised`,
+      );
+    }
+  });
+
+  it('trims copy-paste whitespace before deciding', () => {
+    assert.equal(classifyTeamsInstallTarget('  19:x@thread.v2  ').kind, 'group-chat');
+    assert.equal(
+      classifyTeamsInstallTarget('  19:x@thread.v2  ').id,
+      '19:x@thread.v2',
+    );
+  });
+
+  it('treats an empty string as unrecognised, not as a crash', () => {
+    assert.equal(classifyTeamsInstallTarget('').kind, 'unrecognised');
+    assert.equal(classifyTeamsInstallTarget('   ').kind, 'unrecognised');
+  });
+
+  it('is case-insensitive about the thread suffixes Teams hands out', () => {
+    assert.equal(classifyTeamsInstallTarget('19:x@Thread.V2').kind, 'group-chat');
+    assert.equal(classifyTeamsInstallTarget('19:x@THREAD.TACV2').kind, 'channel');
+  });
+});
+
+describe('resolveTeamsInstallTarget', () => {
+  it('accepts a team and reports its kind', () => {
+    const result = resolveTeamsInstallTarget('2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c');
+    assert.equal(result.ok, true);
+    assert.equal(result.ok && result.kind, 'team');
+  });
+
+  it('accepts a group chat and reports its kind', () => {
+    const result = resolveTeamsInstallTarget('19:abc@thread.v2');
+    assert.equal(result.ok, true);
+    assert.equal(result.ok && result.kind, 'group-chat');
+  });
+
+  it('accepts a one-on-one chat and reports its kind', () => {
+    const result = resolveTeamsInstallTarget('19:a_b@unq.gbl.spaces');
+    assert.equal(result.ok, true);
+    assert.equal(result.ok && result.kind, 'one-on-one-chat');
+  });
+
+  it('REFUSES a channel id, and says what to use instead', () => {
+    const result = resolveTeamsInstallTarget('19:x@thread.tacv2');
+    assert.equal(result.ok, false);
+    assert.equal(result.ok === false && result.reason, 'channel');
+  });
+
+  it('refuses an unrecognised string', () => {
+    const result = resolveTeamsInstallTarget('hello');
+    assert.equal(result.ok, false);
+    assert.equal(result.ok === false && result.reason, 'unrecognised');
+  });
+
+  /**
+   * THE FIELD-TEST ID. Refused rather than guessed at, and the refusal carries
+   * both ways out — guessing "team" is what spent five provisioning steps
+   * before Graph said `404 No team found with Group Id`, and guessing "chat"
+   * would only move the refusal one hop later (the connector's `installToChat`
+   * rejects a bare stem and wants the full `19:<hex>@thread.v2` form).
+   */
+  it('REFUSES a bare 32-hex, and hands back both readings', () => {
+    const result = resolveTeamsInstallTarget('abc8af8ec7fc471785d3b83c4d84b667');
+    assert.equal(result.ok, false);
+    assert.equal(result.ok === false && result.reason, 'ambiguous');
+    assert.equal(
+      result.ok === false && result.reason === 'ambiguous' && result.asTeamId,
+      'abc8af8e-c7fc-4717-85d3-b83c4d84b667',
+    );
+    assert.equal(
+      result.ok === false && result.reason === 'ambiguous' && result.asGroupChatId,
+      '19:abc8af8ec7fc471785d3b83c4d84b667@thread.v2',
+    );
+  });
+
+  it('accepts the DISAMBIGUATED forms of that same id', () => {
+    // The two ways out the refusal names must themselves resolve — otherwise
+    // the message sends the operator somewhere that also fails.
+    const asTeam = resolveTeamsInstallTarget('abc8af8e-c7fc-4717-85d3-b83c4d84b667');
+    assert.equal(asTeam.ok && asTeam.kind, 'team');
+    const asChat = resolveTeamsInstallTarget(
+      '19:abc8af8ec7fc471785d3b83c4d84b667@thread.v2',
+    );
+    assert.equal(asChat.ok && asChat.kind, 'group-chat');
+  });
+});
+
+describe('TEAMS_TARGET_EXAMPLES', () => {
+  it('ships one valid example per installable kind, and each classifies back', () => {
+    assert.equal(classifyTeamsInstallTarget(TEAMS_TARGET_EXAMPLES.team).kind, 'team');
+    assert.equal(
+      classifyTeamsInstallTarget(TEAMS_TARGET_EXAMPLES.groupChat).kind,
+      'group-chat',
+    );
+    assert.equal(
+      classifyTeamsInstallTarget(TEAMS_TARGET_EXAMPLES.oneOnOneChat).kind,
+      'one-on-one-chat',
+    );
+  });
+});

--- a/middleware/test/teamsProvisionerService.test.ts
+++ b/middleware/test/teamsProvisionerService.test.ts
@@ -24,6 +24,7 @@ import {
   isTeamsProvisionerError,
   requireTeamsProvisioner,
   SingleTenantViolationError,
+  supportsChatInstall,
   supportsTeamUninstall,
   TEAMS_PROVISIONER_SERVICE_NAME,
   TeamsMessagingEndpointError,
@@ -157,6 +158,66 @@ describe('supportsTeamUninstall — connector version skew', () => {
   it('is false when no connector is installed at all', () => {
     assert.equal(supportsTeamUninstall(getTeamsProvisioner(new ServiceRegistry())), false);
     assert.equal(supportsTeamUninstall(undefined), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Feature detection — chat installs (group chats and 1:1 chats)
+// ---------------------------------------------------------------------------
+
+describe('supportsChatInstall — connector version skew', () => {
+  it('is true for a connector that publishes installToChat, and forwards the call', async () => {
+    const stub = createStubTeamsProvisioner();
+    const provisioner = requireTeamsProvisioner(registryWith(stub.accessor));
+
+    assert.equal(supportsChatInstall(provisioner), true);
+    const result = await provisioner.installToChat?.({
+      chatId: '19:abc@thread.v2',
+      teamsAppId: 'catalog-0000',
+    });
+    assert.equal(result?.outcome, 'created');
+    assert.equal(result?.value.chatId, '19:abc@thread.v2');
+    assert.deepEqual(
+      stub.calls.map((call) => call.method),
+      ['installToChat'],
+    );
+  });
+
+  it('is false for an older connector — and the guarded accessor OMITS the method', () => {
+    // THE BUG THIS PINS. An `installToChat: (i) => raw.installToChat?.(i)`
+    // passthrough in the wrapper would put the key on EVERY accessor, make
+    // `supportsChatInstall` answer true for a connector that cannot install
+    // into a chat, and turn the route's honest 501 into a silent `undefined`
+    // at the call site. That mistake has been made in this file before, which
+    // is why the absence is asserted rather than assumed.
+    const stub = createStubTeamsProvisioner({ installToChat: undefined });
+    const provisioner = requireTeamsProvisioner(registryWith(stub.accessor));
+
+    assert.equal(supportsChatInstall(provisioner), false);
+    assert.equal('installToChat' in provisioner, false);
+    assert.equal(provisioner.installToChat, undefined);
+  });
+
+  it('is false when no connector is installed at all', () => {
+    assert.equal(supportsChatInstall(getTeamsProvisioner(new ServiceRegistry())), false);
+    assert.equal(supportsChatInstall(undefined), false);
+  });
+
+  it('is independent of the team-uninstall capability', () => {
+    // The two arrived in different connector versions, so a connector may
+    // publish either without the other and neither guard may answer for the
+    // other.
+    const chatOnly = requireTeamsProvisioner(
+      registryWith(createStubTeamsProvisioner({ uninstallFromTeam: undefined }).accessor),
+    );
+    assert.equal(supportsChatInstall(chatOnly), true);
+    assert.equal(supportsTeamUninstall(chatOnly), false);
+
+    const uninstallOnly = requireTeamsProvisioner(
+      registryWith(createStubTeamsProvisioner({ installToChat: undefined }).accessor),
+    );
+    assert.equal(supportsChatInstall(uninstallOnly), false);
+    assert.equal(supportsTeamUninstall(uninstallOnly), true);
   });
 });
 

--- a/middleware/test/teamsProvisioningChatTarget.test.ts
+++ b/middleware/test/teamsProvisioningChatTarget.test.ts
@@ -1,0 +1,426 @@
+/**
+ * The runner installs into the KIND it was asked for — team or chat.
+ *
+ * THE FIELD TEST BEHIND THIS SUITE. An operator pasted
+ * `abc8af8ec7fc471785d3b83c4d84b667` into a field labelled "Team-ID". The
+ * chain answered `400 teamId needs to be a valid GUID`; once the id was
+ * hyphenated, Graph answered `404 No team found with Group Id`. Every team and
+ * channel in the tenant was searched by hand afterwards — it was neither. It
+ * was, with high probability, the stem of a GROUP CHAT id.
+ *
+ * `team_id` was the only target the stack could name, so a group chat could
+ * not be asked for, could not be validated, and could only fail at step five
+ * of a chain that had already created an Entra app, an Azure bot and a catalog
+ * entry. This suite pins the vocabulary that fixes it:
+ *
+ *   * a team target still goes through `installToTeam` (unchanged);
+ *   * a chat target goes through `installToChat`, with the id VERBATIM;
+ *   * a connector too old for chats fails with a sentence naming the version;
+ *   * the binding records which endpoint actually performed the install.
+ *
+ * Self-contained on purpose: it drives its own minimal store/provisioner
+ * rather than the big shared fixture, so the shape of the chat contract is
+ * readable in one file.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { TimerSeam } from '../src/plugins/jobScheduler.js';
+import {
+  TeamsProvisioningJobRunner,
+  type ProvisionTeamsIdentityRequest,
+  type TeamsAppPackageAssets,
+  type TeamsIdentityJobRecord,
+  type TeamsIdentityJobStore,
+  type TeamsIdentityJobUpdate,
+  type TeamsProvisionerPort,
+} from '../src/services/teamsProvisioningJob.js';
+
+// ---------------------------------------------------------------------------
+// Doubles
+// ---------------------------------------------------------------------------
+
+function immediateTimers(): TimerSeam {
+  return {
+    setTimeout(cb) {
+      cb();
+      return 1;
+    },
+    clearTimeout() {},
+    setInterval() {
+      throw new Error('runner must not use setInterval');
+    },
+    clearInterval() {},
+  };
+}
+
+interface MemoryStore extends TeamsIdentityJobStore {
+  row: TeamsIdentityJobRecord;
+  readonly updates: TeamsIdentityJobUpdate[];
+}
+
+function makeStore(): MemoryStore {
+  const updates: TeamsIdentityJobUpdate[] = [];
+  const store: MemoryStore = {
+    // Starts at `catalog_uploaded` so every run in this suite reaches the
+    // install step in one hop — the earlier steps have their own suite and
+    // repeating them here would only make the chat contract harder to read.
+    row: {
+      agentId: 'agent-1',
+      botSlug: 'hr-bot',
+      displayName: 'HR Bot',
+      state: 'catalog_uploaded',
+      appId: 'app-123',
+      tenantId: 'tenant-9',
+      teamsAppId: 'catalog-77',
+      teamsAppExternalId: 'external-abc',
+      lastError: null,
+    },
+    async getByAgentId(agentId) {
+      return store.row.agentId === agentId ? store.row : undefined;
+    },
+    async update(agentId, patch) {
+      assert.equal(store.row.agentId, agentId);
+      updates.push(patch);
+      store.row = {
+        ...store.row,
+        ...(patch.state !== undefined ? { state: patch.state } : {}),
+        ...(patch.teamsAppId !== undefined ? { teamsAppId: patch.teamsAppId } : {}),
+        ...(patch.lastError !== undefined ? { lastError: patch.lastError } : {}),
+      };
+      return store.row;
+    },
+    updates,
+  };
+  return store;
+}
+
+interface InstallRow {
+  readonly teamId: string;
+  readonly targetKind?: string;
+  readonly teamDisplayName?: string | null;
+}
+
+class MemoryInstallStore {
+  readonly rows: InstallRow[] = [];
+
+  get(_agentId: string, teamId: string): Promise<{ teamId: string } | undefined> {
+    const row = this.rows.find((entry) => entry.teamId === teamId);
+    return Promise.resolve(row ? { teamId: row.teamId } : undefined);
+  }
+
+  record(input: {
+    readonly agentId: string;
+    readonly teamId: string;
+    readonly teamsAppId?: string | null;
+    readonly teamDisplayName?: string | null;
+    readonly targetKind?: string;
+  }): Promise<unknown> {
+    this.rows.push({
+      teamId: input.teamId,
+      ...(input.targetKind !== undefined ? { targetKind: input.targetKind } : {}),
+      teamDisplayName: input.teamDisplayName ?? null,
+    });
+    return Promise.resolve(undefined);
+  }
+}
+
+interface StubProvisioner extends TeamsProvisionerPort {
+  readonly calls: string[];
+}
+
+/**
+ * `chatInstall: 'absent'` models a connector < 0.7.0 by OMITTING the key
+ * entirely — a present-but-undefined property would still be a key, and
+ * feature detection has to see a missing method.
+ */
+function makeProvisioner(
+  opts: { chatInstall?: 'absent'; installError?: Error } = {},
+): StubProvisioner {
+  const calls: string[] = [];
+  return {
+    calls,
+    async createAppRegistration() {
+      return {
+        outcome: 'created',
+        value: { appId: 'app-123', registration: { tenantId: 'tenant-9' } },
+      };
+    },
+    async createBot(input) {
+      return {
+        kind: 'provisioned',
+        bot: { outcome: 'created', value: { botName: input.botName } },
+      };
+    },
+    buildAppPackage() {
+      return new Uint8Array([80, 75]);
+    },
+    async uploadToCatalog() {
+      return { outcome: 'created', value: { teamsAppId: 'catalog-77' } };
+    },
+    async getCatalogApp() {
+      return { found: true, teamsAppId: 'catalog-77' };
+    },
+    async installToTeam(input) {
+      calls.push(`installToTeam:${input.teamId}`);
+      if (opts.installError) throw opts.installError;
+      return {
+        outcome: 'created',
+        value: { teamId: input.teamId, teamsAppId: input.teamsAppId },
+      };
+    },
+    ...(opts.chatInstall === 'absent'
+      ? {}
+      : {
+          async installToChat(input: {
+            readonly chatId: string;
+            readonly teamsAppId: string;
+          }) {
+            calls.push(`installToChat:${input.chatId}`);
+            if (opts.installError) throw opts.installError;
+            return {
+              outcome: 'created' as const,
+              value: { chatId: input.chatId, teamsAppId: input.teamsAppId },
+            };
+          },
+        }),
+  };
+}
+
+const ASSETS: TeamsAppPackageAssets = {
+  manifestTemplate: '{"id":"{{APP_ID}}"}',
+  params: { APP_ID: 'app-123' },
+  icons: { color: new Uint8Array([1]), outline: new Uint8Array([2]) },
+  externalId: 'external-abc',
+};
+
+function makeRunner(opts: {
+  provisioner?: StubProvisioner;
+  installs?: MemoryInstallStore;
+  resolveTeamName?: (teamId: string) => Promise<string | null>;
+} = {}): {
+  runner: TeamsProvisioningJobRunner;
+  store: MemoryStore;
+  provisioner: StubProvisioner;
+} {
+  const store = makeStore();
+  const provisioner = opts.provisioner ?? makeProvisioner();
+  const runner = new TeamsProvisioningJobRunner({
+    store,
+    getProvisioner: () => provisioner,
+    buildMessagingEndpoint: (botSlug) =>
+      `https://mw.example.com/api/teams/${botSlug}/messages`,
+    loadPackageAssets: async () => ASSETS,
+    timers: immediateTimers(),
+    maxAttempts: 1,
+    baseRetryDelayMs: 1,
+    ...(opts.installs ? { installs: opts.installs } : {}),
+    ...(opts.resolveTeamName ? { resolveTeamName: opts.resolveTeamName } : {}),
+    log: () => {},
+  });
+  return { runner, store, provisioner };
+}
+
+const TEAM_REQUEST: ProvisionTeamsIdentityRequest = {
+  agentId: 'agent-1',
+  teamId: '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c',
+};
+
+function lastErrorOf(store: MemoryStore): string {
+  const recorded = store.updates
+    .map((update) => update.lastError)
+    .filter((value): value is string => typeof value === 'string');
+  return recorded.at(-1) ?? '';
+}
+
+// ---------------------------------------------------------------------------
+
+describe('TeamsProvisioningJobRunner: team vs chat install targets', () => {
+  it('installs into a TEAM through installToTeam when no kind is given', async () => {
+    // Every caller before the chat targets meant a team and none of them
+    // passes `targetKind` — the default must keep them working verbatim.
+    const { runner, provisioner } = makeRunner();
+    const result = await runner.enqueue(TEAM_REQUEST);
+
+    assert.equal(result.status, 'installed');
+    assert.deepEqual(provisioner.calls, [
+      'installToTeam:2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c',
+    ]);
+  });
+
+  it('installs into a GROUP CHAT through installToChat', async () => {
+    const { runner, provisioner } = makeRunner();
+    const result = await runner.enqueue({
+      agentId: 'agent-1',
+      teamId: '19:abc123@thread.v2',
+      targetKind: 'group-chat',
+    });
+
+    assert.equal(result.status, 'installed');
+    assert.deepEqual(provisioner.calls, ['installToChat:19:abc123@thread.v2']);
+  });
+
+  it('installs into a 1:1 CHAT through the same chat endpoint', async () => {
+    const { runner, provisioner } = makeRunner();
+    const result = await runner.enqueue({
+      agentId: 'agent-1',
+      teamId: '19:a_b@unq.gbl.spaces',
+      targetKind: 'one-on-one-chat',
+    });
+
+    assert.equal(result.status, 'installed');
+    assert.deepEqual(provisioner.calls, ['installToChat:19:a_b@unq.gbl.spaces']);
+  });
+
+  it('does NOT reshape a chat id on its way to the connector', async () => {
+    // `normalizeTeamsTeamId` turns 32 hex digits into a team GUID. Doing that
+    // to a chat id is precisely how the field test produced its 404, so the
+    // chat direction must hand Graph the id byte for byte.
+    const chatId = '19:abc8af8ec7fc471785d3b83c4d84b667@thread.v2';
+    const { runner, provisioner } = makeRunner();
+    await runner.enqueue({
+      agentId: 'agent-1',
+      teamId: chatId,
+      targetKind: 'group-chat',
+    });
+
+    assert.deepEqual(provisioner.calls, [`installToChat:${chatId}`]);
+  });
+
+  it('fails with an ACTIONABLE sentence against a connector without installToChat', async () => {
+    const { runner, store } = makeRunner({
+      provisioner: makeProvisioner({ chatInstall: 'absent' }),
+    });
+    const result = await runner.enqueue({
+      agentId: 'agent-1',
+      teamId: '19:abc@thread.v2',
+      targetKind: 'group-chat',
+    });
+
+    // A refusal, not a crash: no `TypeError: installToChat is not a function`,
+    // and no run that calls itself installed without installing anything.
+    assert.equal(result.status, 'failed');
+    const detail = lastErrorOf(store);
+    assert.match(detail, /installToChat/);
+    // Names the version to upgrade to, so the operator can act on it.
+    assert.match(detail, /0\.7\.0/);
+  });
+
+  it('records the binding with the kind that performed the install', async () => {
+    const installs = new MemoryInstallStore();
+    const { runner } = makeRunner({ installs });
+    await runner.enqueue({
+      agentId: 'agent-1',
+      teamId: '19:abc@thread.v2',
+      targetKind: 'group-chat',
+    });
+
+    assert.deepEqual(
+      installs.rows.map((row) => [row.teamId, row.targetKind]),
+      [['19:abc@thread.v2', 'group-chat']],
+    );
+  });
+
+  it('does not spend a team-name lookup on a chat binding', async () => {
+    // `resolveTeamName` is `teamsProvisioner@1.getTeam`, which answers about
+    // TEAMS. Asking it about a chat id buys a `found: false` and a misleading
+    // log line.
+    const installs = new MemoryInstallStore();
+    const lookups: string[] = [];
+    const { runner } = makeRunner({
+      installs,
+      resolveTeamName: async (teamId) => {
+        lookups.push(teamId);
+        return 'Should Not Be Used';
+      },
+    });
+    await runner.enqueue({
+      agentId: 'agent-1',
+      teamId: '19:abc@thread.v2',
+      targetKind: 'group-chat',
+    });
+
+    assert.deepEqual(lookups, []);
+    assert.equal(installs.rows[0]?.teamDisplayName, null);
+  });
+
+  it('still resolves the name for a TEAM binding', async () => {
+    // The counterpart of the test above: the skip is scoped to chats and is
+    // not a quiet regression of the team name resolution.
+    const installs = new MemoryInstallStore();
+    const lookups: string[] = [];
+    const { runner } = makeRunner({
+      installs,
+      resolveTeamName: async (teamId) => {
+        lookups.push(teamId);
+        return 'Marketing';
+      },
+    });
+    await runner.enqueue(TEAM_REQUEST);
+
+    assert.deepEqual(lookups, ['2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c']);
+    assert.equal(installs.rows[0]?.teamDisplayName, 'Marketing');
+  });
+});
+
+describe('TeamsProvisioningJobRunner: ResourceSpecificPermissionsMismatch', () => {
+  /**
+   * Graph's `400 ResourceSpecificPermissionsMismatch` is NOT a generic bad
+   * request. The id is right and the call is well-formed; the app package's
+   * seven RSC permissions exceed what the installing identity may consent to.
+   * Reported as a plain 400 it sends the operator hunting for a wrong id that
+   * does not exist.
+   */
+  function rscError(): Error {
+    const err = new Error(
+      'Request failed: 400 ResourceSpecificPermissionsMismatch — the app requires resource-specific permissions',
+    );
+    err.name = 'GraphRequestError';
+    return err;
+  }
+
+  it('names the tenant role to grant for a TEAM target', async () => {
+    const { runner, store } = makeRunner({
+      provisioner: makeProvisioner({ installError: rscError() }),
+    });
+    const result = await runner.enqueue(TEAM_REQUEST);
+
+    assert.equal(result.status, 'failed');
+    const detail = lastErrorOf(store);
+    assert.match(detail, /^rsc_permissions_mismatch:/);
+    assert.match(detail, /ReadWriteAndConsentForTeam\.All/);
+    // Says the id is fine, so nobody re-checks a correct id.
+    assert.match(detail, /target id is correct/i);
+  });
+
+  it('names the CHAT role for a chat target', async () => {
+    const { runner, store } = makeRunner({
+      provisioner: makeProvisioner({ installError: rscError() }),
+    });
+    const result = await runner.enqueue({
+      agentId: 'agent-1',
+      teamId: '19:abc@thread.v2',
+      targetKind: 'group-chat',
+    });
+
+    assert.equal(result.status, 'failed');
+    assert.match(lastErrorOf(store), /ReadWriteAndConsentForChat\.All/);
+  });
+
+  it('leaves an unrelated install failure classified as before', async () => {
+    // The RSC branch must not swallow every 400 — a different failure keeps
+    // travelling the ordinary retry/classification path.
+    const other = new Error('Request failed: 500 InternalServerError');
+    const { runner, store } = makeRunner({
+      provisioner: makeProvisioner({ installError: other }),
+    });
+    const result = await runner.enqueue(TEAM_REQUEST);
+
+    assert.notEqual(result.status, 'installed');
+    assert.ok(
+      !lastErrorOf(store).startsWith('rsc_permissions_mismatch:'),
+      'an unrelated failure must not be reported as an RSC mismatch',
+    );
+  });
+});

--- a/middleware/test/teamsProvisioningEventStore.pg.test.ts
+++ b/middleware/test/teamsProvisioningEventStore.pg.test.ts
@@ -1,7 +1,7 @@
 /**
  * #915 — `agent_teams_provisioning_events` against a real Postgres.
  *
- * The schema is applied from the ACTUAL migration files (0049, then 0053),
+ * The schema is applied from the ACTUAL migration files (0049, 0053, 0054),
  * twice, so this suite doubles as the double-apply proof the migrations
  * README demands and pins the two things the store and the migration have to
  * agree on: the status CHECK constraint, and the foreign key that ties an
@@ -66,6 +66,11 @@ describe(
       for (const file of [
         '0049_agent_teams_identities.sql',
         '0053_agent_teams_provisioning_events.sql',
+        // 0051 + 0054: the event log has no target kind of its own, but 0054
+        // alters BOTH teams tables, so the bindings table has to exist before
+        // it runs.
+        '0051_agent_teams_installs.sql',
+        '0054_agent_teams_target_kind.sql',
       ]) {
         const sql = await readFile(resolve(MIGRATIONS_DIR, file), 'utf8');
         // Applied TWICE on purpose — the migrations README requires every

--- a/middleware/test/teamsProvisioningJob.test.ts
+++ b/middleware/test/teamsProvisioningJob.test.ts
@@ -107,6 +107,10 @@ interface StubProvisioner extends TeamsProvisionerPort {
 }
 
 interface StubBehaviour {
+  /** Model a connector < 0.7.0: the key is ABSENT, not undefined — feature
+   *  detection has to see a missing method, and a present-but-undefined
+   *  property would still be a key. */
+  noChatInstall?: boolean;
   createAppRegistration?: () => Promise<void> | void;
   createBot?: 'registration-only' | (() => Promise<void> | void);
   uploadToCatalog?: () => Promise<void> | void;
@@ -169,6 +173,20 @@ function makeProvisioner(behaviour: StubBehaviour = {}): StubProvisioner {
         value: { teamId: input.teamId, teamsAppId: input.teamsAppId },
       };
     },
+    ...(behaviour.noChatInstall === true
+      ? {}
+      : {
+          async installToChat(input: {
+            readonly chatId: string;
+            readonly teamsAppId: string;
+          }) {
+            calls.push(`installToChat:${input.chatId}:${input.teamsAppId}`);
+            return {
+              outcome: 'created' as const,
+              value: { chatId: input.chatId, teamsAppId: input.teamsAppId },
+            };
+          },
+        }),
   };
 }
 

--- a/middleware/test/teamsTeamId.test.ts
+++ b/middleware/test/teamsTeamId.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { normalizeTeamsTeamId } from '../src/platform/teamsTeamId.js';
+
+describe('normalizeTeamsTeamId (#860)', () => {
+  it('dashes the unhyphenated form Teams hands out', () => {
+    // The exact value from the first end-to-end run on the byte5 tenant: the
+    // chain completed the Entra app, the Azure bot and the catalog upload,
+    // then Graph answered `teamId needs to be a valid GUID.` on the install.
+    assert.equal(
+      normalizeTeamsTeamId('abc8af8ec7fc471785d3b83c4d84b667'),
+      'abc8af8e-c7fc-4717-85d3-b83c4d84b667',
+    );
+  });
+
+  it('leaves an already-dashed GUID alone', () => {
+    const canonical = 'abc8af8e-c7fc-4717-85d3-b83c4d84b667';
+    assert.equal(normalizeTeamsTeamId(canonical), canonical);
+  });
+
+  it('lowercases while dashing, so one team has one representation', () => {
+    assert.equal(
+      normalizeTeamsTeamId('ABC8AF8EC7FC471785D3B83C4D84B667'),
+      'abc8af8e-c7fc-4717-85d3-b83c4d84b667',
+    );
+  });
+
+  it('trims the whitespace a paste brings with it', () => {
+    assert.equal(
+      normalizeTeamsTeamId('  abc8af8ec7fc471785d3b83c4d84b667\n'),
+      'abc8af8e-c7fc-4717-85d3-b83c4d84b667',
+    );
+  });
+
+  it('passes through identifiers it has no business reshaping', () => {
+    // A conversation/thread id is a legitimate way to name a Teams
+    // destination and is not a GUID. Rewriting it — or rejecting it — would
+    // break working input to fix a problem it does not have.
+    const thread = '19:abc8af8ec7fc471785d3b83c4d84b667@thread.tacv2';
+    assert.equal(normalizeTeamsTeamId(thread), thread);
+  });
+
+  it('does not dash a hex string of the wrong length', () => {
+    // 31 and 33 digits are not GUIDs; guessing where the dashes go would
+    // invent an id that addresses nothing.
+    assert.equal(
+      normalizeTeamsTeamId('abc8af8ec7fc471785d3b83c4d84b66'),
+      'abc8af8ec7fc471785d3b83c4d84b66',
+    );
+    assert.equal(
+      normalizeTeamsTeamId('abc8af8ec7fc471785d3b83c4d84b6677'),
+      'abc8af8ec7fc471785d3b83c4d84b6677',
+    );
+  });
+
+  it('does not dash a 32-character string that is not hex', () => {
+    const notHex = 'zbc8af8ec7fc471785d3b83c4d84b667';
+    assert.equal(normalizeTeamsTeamId(notHex), notHex);
+  });
+});

--- a/web-ui/app/_lib/agents.ts
+++ b/web-ui/app/_lib/agents.ts
@@ -1,5 +1,6 @@
 import { ApiError } from './api';
 import type { LocalizedMarkdown } from './storeTypes';
+import type { TeamsTargetKind } from './teamsInstallTarget';
 
 /**
  * Typed client for the operator multi-orchestrator REST surface
@@ -476,6 +477,12 @@ export const TEAMS_IDENTITY_LAST_ERROR_CODES = [
   'delegated_consent_required',
   'delegated_token_expired',
   'device_code_flow_failed',
+  // Graph refused the install because this agent's app package declares
+  // resource-specific permissions the installing identity may not consent to
+  // — a tenant role grant, NOT a wrong target id, and worth its own code
+  // because reporting it as a generic bad request sends the operator back to
+  // re-check an id that was correct all along
+  'rsc_permissions_mismatch',
   'unknown',
 ] as const;
 
@@ -1040,6 +1047,23 @@ export interface InstalledTeamDto {
    * derivation. Neither is a live Graph enumeration.
    */
   evidence: 'identity_row' | 'install_row';
+  /**
+   * WHICH KIND of target `team_id` addresses (middleware migration 0054).
+   * Optional on the wire: a middleware predating it omits the field, and
+   * every row it could have written was a team — so
+   * {@link parseInstalledTargetKind} defaults to `'team'` rather than
+   * rendering an empty label.
+   */
+  target_kind?: TeamsTargetKind | null;
+}
+
+/** The entry's target kind, narrowed at the boundary — see the field's note
+ *  for why an absent value is `'team'` and not an error. */
+export function parseInstalledTargetKind(team: InstalledTeamDto): TeamsTargetKind {
+  const kind = team.target_kind;
+  return kind === 'group-chat' || kind === 'one-on-one-chat' || kind === 'team'
+    ? kind
+    : 'team';
 }
 
 /** The team's name, or `null` — the one place the wire's optional/nullable
@@ -1067,6 +1091,7 @@ export const TEAMS_ASSIGNMENT_CAPABILITY_KEYS = [
   'uninstall',
   'enumerate',
   'multi_team',
+  'chat_install',
 ] as const;
 
 export type TeamsAssignmentCapabilityKey =
@@ -1092,6 +1117,10 @@ export interface AgentTeamsDto {
   /** The recorded install TARGET while the chain has not reached
    *  `installed` — a run in flight (or a stalled one), never an install. */
   pending_team_id: string | null;
+  /** Kind of `pending_team_id`, so the in-flight hint can name what is being
+   *  installed into instead of calling every target a team. Optional for the
+   *  same version-skew reason as `InstalledTeamDto.target_kind`. */
+  pending_target_kind?: TeamsTargetKind | null;
   consent: TeamsConsentDto;
   last_error: string | null;
   capabilities: TeamsAssignmentCapabilitiesDto;
@@ -1105,6 +1134,7 @@ const TEAMS_ASSIGNMENT_CAPABILITIES_CLOSED: TeamsAssignmentCapabilitiesDto = {
   uninstall: false,
   enumerate: false,
   multi_team: false,
+  chat_install: false,
   unsupported_reason: {},
 };
 

--- a/web-ui/app/_lib/teamsInstallTarget.ts
+++ b/web-ui/app/_lib/teamsInstallTarget.ts
@@ -1,0 +1,111 @@
+/**
+ * What a Teams install target looks like — the browser-side half.
+ *
+ * MIRRORED, NOT IMPORTED. The authority is
+ * `middleware/src/platform/teamsInstallTarget.ts`; the web-ui is a separate
+ * npm project with no path into the middleware, exactly as the middleware
+ * itself mirrors the connector contract rather than importing it. Keep the two
+ * in step: the server re-decides every request, so a drift here can only ever
+ * mislabel the field, never install into the wrong place.
+ *
+ * WHY THE BROWSER CLASSIFIES AT ALL. The operator who triggered this feature
+ * pasted an id into a field labelled "Team-ID", got `400 teamId needs to be a
+ * valid GUID`, and — after the id was hyphenated — `404 No team found with
+ * Group Id` from the last step of a chain that had already created an Entra
+ * app, an Azure bot and a catalog entry. Every one of those answers arrived
+ * after the fact. Deciding the shape WHILE THEY TYPE turns all of it into a
+ * label under the input, before anything is provisioned.
+ */
+
+/** A target an app can actually be installed into. */
+export type TeamsTargetKind = 'team' | 'group-chat' | 'one-on-one-chat';
+
+export type TeamsTargetClassification =
+  | { readonly kind: TeamsTargetKind; readonly id: string }
+  | { readonly kind: 'channel'; readonly id: string }
+  | {
+      readonly kind: 'ambiguous';
+      readonly id: string;
+      /** The input read as a team group id — one of the two ways out. */
+      readonly asTeamId: string;
+      /** The input read as a group-chat id — the other. */
+      readonly asGroupChatId: string;
+    }
+  | { readonly kind: 'unrecognised'; readonly id: string }
+  /** Nothing typed yet — not an error, just no verdict to show. */
+  | { readonly kind: 'empty'; readonly id: '' };
+
+const CHANNEL_SUFFIX = /@thread\.tacv2$/i;
+const GROUP_CHAT_SUFFIX = /@thread\.v2$/i;
+const ONE_ON_ONE_SUFFIX = /@unq\.gbl\.spaces$/i;
+const CONVERSATION_PREFIX = /^19:.+/;
+const DASHED_GUID = /^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$/;
+const BARE_GUID = /^[0-9a-fA-F]{32}$/;
+
+/** Where the four dashes go in the canonical 8-4-4-4-12 GUID form. */
+const GUID_SEGMENTS = [8, 12, 16, 20] as const;
+
+function hyphenate(bare: string): string {
+  const lower = bare.toLowerCase();
+  let out = '';
+  let cut = 0;
+  for (const at of GUID_SEGMENTS) {
+    out += `${lower.slice(cut, at)}-`;
+    cut = at;
+  }
+  return out + lower.slice(cut);
+}
+
+/**
+ * Read what the operator typed and say what it addresses — without guessing.
+ *
+ * Total and never throws: an unusable input is `'unrecognised'`, an empty one
+ * is `'empty'`, and a 32-hex string is `'ambiguous'` WITH both readings
+ * attached rather than silently resolved to either.
+ */
+export function classifyTeamsInstallTarget(value: string): TeamsTargetClassification {
+  const id = value.trim();
+  if (id === '') return { kind: 'empty', id: '' };
+
+  if (CONVERSATION_PREFIX.test(id)) {
+    if (CHANNEL_SUFFIX.test(id)) return { kind: 'channel', id };
+    if (GROUP_CHAT_SUFFIX.test(id)) return { kind: 'group-chat', id };
+    if (ONE_ON_ONE_SUFFIX.test(id)) return { kind: 'one-on-one-chat', id };
+    // Teams has more conversation kinds than this handles, and installing
+    // into the wrong one has a real audience — so an unknown suffix is
+    // unrecognised, not "probably a chat".
+    return { kind: 'unrecognised', id };
+  }
+
+  if (DASHED_GUID.test(id)) return { kind: 'team', id: id.toLowerCase() };
+
+  if (BARE_GUID.test(id)) {
+    return {
+      kind: 'ambiguous',
+      id,
+      asTeamId: hyphenate(id),
+      asGroupChatId: `19:${id.toLowerCase()}@thread.v2`,
+    };
+  }
+
+  return { kind: 'unrecognised', id };
+}
+
+/** Can this input be submitted as-is? `false` for every verdict that needs the
+ *  operator to change something first — which is what disables the button. */
+export function isSubmittableTarget(
+  classification: TeamsTargetClassification,
+): boolean {
+  return (
+    classification.kind === 'team' ||
+    classification.kind === 'group-chat' ||
+    classification.kind === 'one-on-one-chat'
+  );
+}
+
+/** One valid example per installable kind — shown in the field so an operator
+ *  can see what a good answer looks like, not only that theirs was wrong. */
+export const TEAMS_TARGET_EXAMPLES = {
+  team: '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c',
+  groupChat: '19:a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6@thread.v2',
+} as const;

--- a/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsInstalls.test.tsx
+++ b/web-ui/app/operator/agents/[slug]/__tests__/AgentTeamsInstalls.test.tsx
@@ -60,6 +60,7 @@ function capabilities(
     uninstall: false,
     enumerate: false,
     multi_team: false,
+    chat_install: false,
     unsupported_reason: {
       uninstall:
         'the installed teamsProvisioner@1 publishes no uninstallFromTeam method',
@@ -184,7 +185,7 @@ describe('AgentTeamsInstalls (#866)', () => {
     expect(
       (await screen.findByRole('button', { name: 'Uninstall' })).hasAttribute('disabled'),
     ).toBe(true);
-    expect((screen.getByLabelText('Team ID') as HTMLInputElement).disabled).toBe(true);
+    expect((screen.getByLabelText('Target ID') as HTMLInputElement).disabled).toBe(true);
     expect((screen.getByRole('button', { name: 'Install' }) as HTMLButtonElement).disabled).toBe(
       true,
     );
@@ -196,7 +197,7 @@ describe('AgentTeamsInstalls (#866)', () => {
   it('keeps install disabled once a team is tracked and multi_team is unsupported', async () => {
     await renderPanel();
 
-    expect((screen.getByLabelText('Team ID') as HTMLInputElement).disabled).toBe(true);
+    expect((screen.getByLabelText('Target ID') as HTMLInputElement).disabled).toBe(true);
     expect(
       screen.getByText(
         'One orchestrator is tracked in one team. Assigning a second team would leave the first install untracked, so it is refused.',
@@ -211,20 +212,20 @@ describe('AgentTeamsInstalls (#866)', () => {
     mockInstall.mockResolvedValue({
       ok: true,
       agent: 'odoo',
-      team_id: 'team-new',
+      team_id: '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c',
       state: 'app_registered',
       already_installed: false,
       running: true,
     });
     const user = await renderPanel();
 
-    await user.type(await screen.findByLabelText('Team ID'), 'team-new');
+    await user.type(await screen.findByLabelText('Target ID'), '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c');
     await user.click(screen.getByRole('button', { name: 'Install' }));
 
-    await waitFor(() => expect(mockInstall).toHaveBeenCalledWith('odoo', 'team-new'));
+    await waitFor(() => expect(mockInstall).toHaveBeenCalledWith('odoo', '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c'));
     expect(
       await screen.findByText(
-        'Installing into team team-new — the provisioning run continues in the background.',
+        'Installing into team 2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c — the provisioning run continues in the background.',
       ),
     ).toBeTruthy();
     // Two loads: the mount fetch and the post-write refresh.
@@ -241,7 +242,7 @@ describe('AgentTeamsInstalls (#866)', () => {
     );
     const user = await renderPanel();
 
-    await user.type(await screen.findByLabelText('Team ID'), 'team-two');
+    await user.type(await screen.findByLabelText('Target ID'), '3e2b8d55-2a1f-4b3d-9e2b-8d552a1f4b3d');
     await user.click(screen.getByRole('button', { name: 'Install' }));
 
     expect(
@@ -449,6 +450,7 @@ describe('AgentTeamsInstalls (#866)', () => {
         teams: [],
         state: 'catalog_uploaded',
         pending_team_id: 'team-pending',
+        pending_target_kind: 'group-chat',
         running: true,
       }),
     );
@@ -456,7 +458,7 @@ describe('AgentTeamsInstalls (#866)', () => {
 
     expect(
       await screen.findByText(
-        'A provisioning run is targeting team team-pending. It counts as an install once the chain reaches the install step.',
+        'A provisioning run targets Group chat team-pending. It only counts as installed once the chain reaches the install step.',
       ),
     ).toBeTruthy();
     expect(
@@ -481,7 +483,7 @@ describe('AgentTeamsInstalls (#866)', () => {
     );
     await renderPanel();
 
-    expect(screen.getByLabelText('Team ID')).toHaveProperty('disabled', true);
+    expect(screen.getByLabelText('Target ID')).toHaveProperty('disabled', true);
     expect(screen.getByRole('button', { name: 'Install' })).toHaveProperty(
       'disabled',
       true,
@@ -508,7 +510,173 @@ describe('AgentTeamsInstalls (#866)', () => {
       await screen.findByText(/no provisioning run is active/),
     ).toBeTruthy();
     expect(
-      screen.queryByText(/A provisioning run is targeting team team-x/),
+      screen.queryByText(/A provisioning run targets .* team-x/),
     ).toBeNull();
+  });
+});
+
+/**
+ * The two inputs an operator cannot submit, and the one they can.
+ *
+ * THE FIELD TEST. Someone pasted `abc8af8ec7fc471785d3b83c4d84b667` into a
+ * field labelled "Team ID". The chain answered `400 teamId needs to be a valid
+ * GUID`, then — once hyphenated — `404 No team found with Group Id`, after an
+ * Entra app, an Azure bot and a catalog upload had all succeeded. Every one of
+ * those answers arrived too late to help. These tests pin the answers arriving
+ * BEFORE the button can be pressed.
+ */
+describe('AgentTeamsInstalls — install target classification', () => {
+  it('names a team id as a team and enables Install', async () => {
+    mockGetAgentTeams.mockResolvedValue(view({ teams: [] }));
+    const user = await renderPanel();
+
+    await user.type(
+      await screen.findByLabelText('Target ID'),
+      '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c',
+    );
+
+    expect(await screen.findByText('Detected as: Team')).toBeTruthy();
+    expect(
+      (screen.getByRole('button', { name: 'Install' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+  });
+
+  it('names a group chat id as a group chat and enables Install', async () => {
+    mockGetAgentTeams.mockResolvedValue(
+      view({ teams: [], capabilities: capabilities({ chat_install: true }) }),
+    );
+    const user = await renderPanel();
+
+    await user.type(
+      await screen.findByLabelText('Target ID'),
+      '19:abc123@thread.v2',
+    );
+
+    expect(await screen.findByText('Detected as: Group chat')).toBeTruthy();
+    expect(
+      (screen.getByRole('button', { name: 'Install' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+  });
+
+  it('refuses a CHANNEL id and says what to use instead', async () => {
+    mockGetAgentTeams.mockResolvedValue(view({ teams: [] }));
+    const user = await renderPanel();
+
+    await user.type(
+      await screen.findByLabelText('Target ID'),
+      '19:aBcDeF@thread.tacv2',
+    );
+
+    // Names the mistake AND the way out — a channel has a parent team, and
+    // that team's group id is the thing that works.
+    expect(
+      await screen.findByText(/channel id, not an install target/),
+    ).toBeTruthy();
+    expect(
+      (screen.getByRole('button', { name: 'Install' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(mockInstall).not.toHaveBeenCalled();
+  });
+
+  it('refuses a bare 32-hex id and offers BOTH readings as one click each', async () => {
+    mockGetAgentTeams.mockResolvedValue(view({ teams: [] }));
+    const user = await renderPanel();
+
+    const field = await screen.findByLabelText('Target ID');
+    await user.type(field, 'abc8af8ec7fc471785d3b83c4d84b667');
+
+    expect(await screen.findByText(/32 hex characters with no context/)).toBeTruthy();
+    expect(
+      (screen.getByRole('button', { name: 'Install' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+
+    // The way out is a click, not a re-typing exercise: choosing "team"
+    // rewrites the field to the hyphenated GUID and unblocks Install.
+    await user.click(screen.getByRole('button', { name: 'Use as team' }));
+    expect((field as HTMLInputElement).value).toBe(
+      'abc8af8e-c7fc-4717-85d3-b83c4d84b667',
+    );
+    expect(await screen.findByText('Detected as: Team')).toBeTruthy();
+  });
+
+  it('offers the group-chat reading of that same id', async () => {
+    mockGetAgentTeams.mockResolvedValue(
+      view({ teams: [], capabilities: capabilities({ chat_install: true }) }),
+    );
+    const user = await renderPanel();
+
+    const field = await screen.findByLabelText('Target ID');
+    await user.type(field, 'abc8af8ec7fc471785d3b83c4d84b667');
+    await user.click(screen.getByRole('button', { name: 'Use as group chat' }));
+
+    // The full form the connector requires — it rejects a bare stem.
+    expect((field as HTMLInputElement).value).toBe(
+      '19:abc8af8ec7fc471785d3b83c4d84b667@thread.v2',
+    );
+    expect(await screen.findByText('Detected as: Group chat')).toBeTruthy();
+  });
+
+  it('refuses an unusable string without offering a guess', async () => {
+    mockGetAgentTeams.mockResolvedValue(view({ teams: [] }));
+    const user = await renderPanel();
+
+    await user.type(await screen.findByLabelText('Target ID'), 'marketing team');
+
+    expect(
+      await screen.findByText(/not a Teams install target/),
+    ).toBeTruthy();
+    expect(
+      (screen.getByRole('button', { name: 'Install' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  it('warns about an old connector only once a CHAT is actually typed', async () => {
+    // A deployment that installs into teams all day has no reason to be told
+    // about a connector version it does not need.
+    mockGetAgentTeams.mockResolvedValue(
+      view({ teams: [], capabilities: capabilities({ chat_install: false }) }),
+    );
+    const user = await renderPanel();
+
+    const field = await screen.findByLabelText('Target ID');
+    await user.type(field, '2f1a9c44-1f0e-4f2c-8f1a-9c441f0e4f2c');
+    expect(screen.queryByText(/needs the Microsoft 365 connector 0.7.0/)).toBeNull();
+
+    await user.clear(field);
+    await user.type(field, '19:abc123@thread.v2');
+    expect(
+      await screen.findByText(/needs the Microsoft 365 connector 0.7.0/),
+    ).toBeTruthy();
+  });
+
+  it('labels an installed CHAT as a chat, not as a team', async () => {
+    mockGetAgentTeams.mockResolvedValue(
+      view({
+        teams: [
+          {
+            team_id: '19:abc123@thread.v2',
+            target_kind: 'group-chat',
+            team_display_name: null,
+            teams_app_id: 'catalog-1',
+            installed_at: null,
+            evidence: 'install_row',
+          },
+        ],
+      }),
+    );
+    await renderPanel();
+
+    expect(await screen.findByText('Group chat')).toBeTruthy();
+    // A nameless CHAT is not a failed lookup: the connector publishes no name
+    // lookup for chats, and saying "could not resolve" would send an operator
+    // chasing a connector bug that does not exist.
+    expect(
+      screen.getByText(/connector provides no name for chats/),
+    ).toBeTruthy();
   });
 });

--- a/web-ui/app/operator/agents/[slug]/_components/AgentTeamsInstalls.tsx
+++ b/web-ui/app/operator/agents/[slug]/_components/AgentTeamsInstalls.tsx
@@ -8,8 +8,14 @@ import { useFormatter, useTranslations } from 'next-intl';
 import { Button } from '@/app/_components/ui/Button';
 import { ConfirmDialog } from '@/app/_components/ConfirmDialog';
 import {
+  classifyTeamsInstallTarget,
+  isSubmittableTarget,
+  TEAMS_TARGET_EXAMPLES,
+} from '../../../../_lib/teamsInstallTarget';
+import {
   getAgentTeams,
   installAgentTeam,
+  parseInstalledTargetKind,
   parseInstalledTeamName,
   parseTeamsAssignmentCapabilities,
   parseTeamsAssignmentErrorCode,
@@ -200,6 +206,21 @@ export function AgentTeamsInstalls({
     [refresh, router, localizeError],
   );
 
+  /**
+   * What the operator has typed, read as an install target on every keystroke.
+   *
+   * THE POINT OF DOING IT HERE. The field test that produced this panel ended
+   * with `404 No team found with Group Id` after five provisioning steps had
+   * already succeeded. Every answer arrived after the fact. Classifying while
+   * they type turns the whole failure into a label under the input — and the
+   * two cases that cannot be submitted (a channel id, a bare 32-hex string)
+   * get told what to do instead of being allowed through.
+   *
+   * The server re-decides regardless; this is guidance, never authority.
+   */
+  const target = classifyTeamsInstallTarget(teamId);
+  const targetSubmittable = isSubmittableTarget(target);
+
   const installed = data?.teams ?? [];
   /**
    * A run that has not reached `installed` publishes NO team (the read model
@@ -317,6 +338,10 @@ export function AgentTeamsInstalls({
                 // it — and when no name was ever resolved the id takes the
                 // lead line rather than being paired with an empty label.
                 const name = parseInstalledTeamName(team);
+                // A chat listed under a heading that says "team" is exactly
+                // the confusion this feature removes — so every entry names
+                // its own kind.
+                const kind = parseInstalledTargetKind(team);
                 return (
                   <div
                     key={team.team_id}
@@ -337,14 +362,24 @@ export function AgentTeamsInstalls({
                           <span className="font-mono text-sm text-[color:var(--fg-strong)]">
                             {team.team_id}
                           </span>
-                          {/* Says why there is no name, so a GUID does not
-                              read as a rendering bug. */}
+                          {/* Says why there is no name, so a bare id does not
+                              read as a rendering bug. The reason differs by
+                              kind: a team COULD have been resolved and was
+                              not, while the connector publishes no name
+                              lookup for chats at all — reporting the team
+                              sentence for a chat would send an operator
+                              chasing a connector bug that does not exist. */}
                           <span className="text-[11px] text-[color:var(--fg-muted)]">
-                            {t('teamNameUnresolved')}
+                            {kind === 'team'
+                              ? t('teamNameUnresolved')
+                              : t('chatNameUnavailable')}
                           </span>
                         </>
                       )}
                     </div>
+                    <span className="rounded border border-[color:var(--border)] px-1.5 py-0.5 text-[10px] uppercase tracking-[0.08em] text-[color:var(--fg-muted)]">
+                      {t(`targetKind.${kind}`)}
+                    </span>
                     <span className="text-[11px] text-[color:var(--fg-muted)]">
                       {t('appIdLabel', {
                         appId: team.teams_app_id ?? t('appIdNone'),
@@ -388,7 +423,12 @@ export function AgentTeamsInstalls({
           {data.pending_team_id !== null ? (
             <div className="rounded-md border border-[color:var(--border)] px-3 py-2 text-[11px] text-[color:var(--fg-muted)]">
               {data.running
-                ? t('pendingHint', { teamId: data.pending_team_id })
+                ? t('pendingHintTyped', {
+                    kind: t(
+                      `targetKind.${data.pending_target_kind ?? 'team'}`,
+                    ),
+                    teamId: data.pending_team_id,
+                  })
                 : t('pendingStoppedHint', { teamId: data.pending_team_id })}
             </div>
           ) : null}
@@ -398,21 +438,79 @@ export function AgentTeamsInstalls({
               {t('installHeading')}
             </div>
             <label className="flex flex-col gap-1 text-[11px] text-[color:var(--fg-muted)]">
-              {t('fieldTeamId')}
+              {t('fieldTarget')}
               <input
                 type="text"
                 value={teamId}
                 disabled={!canInstall || inFlight}
                 onChange={(e) => setTeamId(e.target.value)}
-                aria-label={t('fieldTeamId')}
+                aria-label={t('fieldTarget')}
                 className="rounded-md border border-[color:var(--border)] bg-transparent px-2 py-1 font-mono text-sm text-[color:var(--fg-strong)]"
               />
-              <span>{t('fieldTeamIdHint')}</span>
+              <span>{t('fieldTargetHint')}</span>
+              {/* Shown BEFORE anything is submitted: what a good answer looks
+                  like beats only being told the last one was wrong. */}
+              <span className="font-mono text-[10px] opacity-70">
+                {t('targetExamples', {
+                  team: TEAMS_TARGET_EXAMPLES.team,
+                  groupChat: TEAMS_TARGET_EXAMPLES.groupChat,
+                })}
+              </span>
             </label>
+
+            {/* The verdict. A recognised target is named — "Team" or
+                "Gruppenchat" — so the operator can see the field understood
+                them; the three that cannot be installed each say what to do. */}
+            {targetSubmittable ? (
+              <div className="text-[11px] text-[color:var(--success)]">
+                {t('targetKindLabel', {
+                  kind: t(`targetKind.${target.kind}`),
+                })}
+              </div>
+            ) : null}
+            {target.kind === 'channel' ? (
+              <div role="alert" className="text-[11px] text-[color:var(--danger)]">
+                {t('targetChannel')}
+              </div>
+            ) : null}
+            {target.kind === 'unrecognised' ? (
+              <div role="alert" className="text-[11px] text-[color:var(--danger)]">
+                {t('targetUnrecognised')}
+              </div>
+            ) : null}
+            {/* THE FIELD-TEST CASE. 32 hex digits are both a team id without
+                its dashes and the stem of a group-chat id. Nothing is guessed:
+                the operator is handed the two spellings and picks one, which
+                is the only place the missing context actually exists. */}
+            {target.kind === 'ambiguous' ? (
+              <div className="flex flex-col gap-1.5 rounded-md border border-[color:var(--border)] px-3 py-2">
+                <span role="alert" className="text-[11px] text-[color:var(--fg-muted)]">
+                  {t('targetAmbiguous')}
+                </span>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={inFlight}
+                    onClick={() => setTeamId(target.asTeamId)}
+                  >
+                    {t('targetAmbiguousUseTeam')}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={inFlight}
+                    onClick={() => setTeamId(target.asGroupChatId)}
+                  >
+                    {t('targetAmbiguousUseChat')}
+                  </Button>
+                </div>
+              </div>
+            ) : null}
             <div className="flex flex-wrap items-center gap-2">
               <Button
                 size="sm"
-                disabled={!canInstall || inFlight || teamId.trim() === ''}
+                disabled={!canInstall || inFlight || !targetSubmittable}
                 busy={busy === 'install'}
                 busyLabel={t('installBusy')}
                 onClick={() =>
@@ -446,6 +544,13 @@ export function AgentTeamsInstalls({
             ) : null}
             {!data.capabilities.multi_team && installed.length > 0 ? (
               <CapabilityNote {...unsupportedReason(data, 'multi_team')} />
+            ) : null}
+            {/* Only once a CHAT is actually typed: a deployment that installs
+                into teams all day has no reason to be told about a connector
+                version it does not need. */}
+            {!data.capabilities.chat_install &&
+            (target.kind === 'group-chat' || target.kind === 'one-on-one-chat') ? (
+              <CapabilityNote {...unsupportedReason(data, 'chat_install')} />
             ) : null}
           </div>
         </>

--- a/web-ui/messages/de.json
+++ b/web-ui/messages/de.json
@@ -1995,7 +1995,8 @@
         "install": "Die Installation in ein Team ist in dieser Installation nicht verfügbar.",
         "uninstall": "Das Entfernen der App aus einem Team braucht den Microsoft-365-Connector 0.4.0 oder neuer. Der hier installierte Connector ist älter und veröffentlicht keine Deinstallation — aktualisiere das Plugin, oder lass die App von einem Teams-Admin manuell entfernen.",
         "enumerate": "Der Connector kann Installationen nicht auflisten. Diese Ansicht zeigt daher, was der Provisionierungs-Datensatz belegt, nicht den aktuellen Stand in Teams.",
-        "multi_team": "Pro Orchestrator wird ein Team geführt. Ein zweites Team würde die erste Installation ungeführt zurücklassen und wird deshalb abgelehnt."
+        "multi_team": "Pro Orchestrator wird ein Team geführt. Ein zweites Team würde die erste Installation ungeführt zurücklassen und wird deshalb abgelehnt.",
+        "chat_install": "Die Installation in einen Chat braucht den Microsoft-365-Connector 0.7.0 oder neuer. Der hier installierte Connector ist älter — aktualisiere das Plugin, oder wähle ein Team als Ziel."
       },
       "unsupportedTechnical": "Server-Begründung: {detail}",
       "notice": {
@@ -2015,9 +2016,31 @@
         "teams_provisioner_unavailable": "Die Teams-Provisioner-Fähigkeit fehlt — installiere das Microsoft-365-Connector-Plugin.",
         "teams_provisioning_running": "Für diesen Orchestrator läuft noch eine Provisionierung. Warte, bis sie fertig ist, und versuche es dann erneut.",
         "teams_uninstall_unsupported": "Der hier installierte Microsoft-365-Connector ist zu alt, um eine App aus einem Team zu entfernen. Aktualisiere ihn auf 0.4.0 oder neuer, oder lass die App von einem Teams-Admin manuell entfernen.",
-        "unknown": "Die Anfrage zur Teams-Zuordnung ist fehlgeschlagen: {detail}"
+        "unknown": "Die Anfrage zur Teams-Zuordnung ist fehlgeschlagen: {detail}",
+        "teams_target_is_channel": "Das ist die ID eines Kanals. Ein Kanal ist kein Installationsziel — nimm die Gruppen-ID des Teams oder die ID eines Gruppenchats.",
+        "teams_target_ambiguous": "Diese 32 Hex-Zeichen sind mehrdeutig — sie können eine Team-ID ohne Bindestriche oder der Rumpf einer Gruppenchat-ID sein. Gib an, was gemeint ist.",
+        "teams_target_unrecognised": "Diese Eingabe ist kein Teams-Installationsziel.",
+        "teams_chat_install_unsupported": "Der hier installierte Microsoft-365-Connector ist zu alt, um eine App in einen Chat zu installieren. Aktualisiere ihn auf 0.7.0 oder neuer, oder wähle ein Team."
       },
-      "pendingStoppedHint": "Team {teamId} ist das hinterlegte Ziel, es läuft aber kein Provisioning — die Kette ist vor dem Installationsschritt stehen geblieben. Den erfassten Fehler zeigt der Abschnitt „Teams-Identität“ oben."
+      "pendingStoppedHint": "Team {teamId} ist das hinterlegte Ziel, es läuft aber kein Provisioning — die Kette ist vor dem Installationsschritt stehen geblieben. Den erfassten Fehler zeigt der Abschnitt „Teams-Identität“ oben.",
+      "targetHeading": "Ziel wählen",
+      "fieldTarget": "Ziel-ID",
+      "fieldTargetHint": "Ein Team oder ein Chat. Team: die Gruppen-ID aus „Link zum Team abrufen“. Gruppenchat: die vollständige ID in der Form 19:…@thread.v2.",
+      "targetKind": {
+        "team": "Team",
+        "group-chat": "Gruppenchat",
+        "one-on-one-chat": "1:1-Chat"
+      },
+      "targetKindLabel": "Erkannt als: {kind}",
+      "targetExamples": "Beispiele — Team: {team} · Gruppenchat: {groupChat}",
+      "targetChannel": "Das ist die ID eines Kanals, kein Installationsziel. Teams installiert eine App in ein Team oder in einen Chat, nie in einen einzelnen Kanal. Nimm die Gruppen-ID des Teams, zu dem der Kanal gehört, oder die ID eines Gruppenchats (19:…@thread.v2).",
+      "targetAmbiguous": "32 Hex-Zeichen ohne Kontext — das kann die Gruppen-ID eines Teams ohne Bindestriche sein oder der Rumpf einer Gruppenchat-ID. Geraten wird hier nicht: wähle, was gemeint ist.",
+      "targetAmbiguousUseTeam": "Als Team einsetzen",
+      "targetAmbiguousUseChat": "Als Gruppenchat einsetzen",
+      "targetUnrecognised": "Diese Eingabe ist kein Teams-Installationsziel. Erwartet wird eine Team-Gruppen-ID, eine Gruppenchat-ID (19:…@thread.v2) oder eine 1:1-Chat-ID (19:…@unq.gbl.spaces).",
+      "chatInstallUnsupported": "Die Installation in einen Chat braucht den Microsoft-365-Connector 0.7.0 oder neuer. Der hier installierte Connector ist älter — aktualisiere das Plugin, oder wähle ein Team als Ziel.",
+      "pendingHintTyped": "Ein Provisionierungslauf zielt auf {kind} {teamId}. Als Installation zählt das erst, wenn die Kette den Installationsschritt erreicht.",
+      "chatNameUnavailable": "Für Chats liefert der Connector keinen Namen — angezeigt wird die ID."
     },
     "identity": {
       "heading": "Identität",
@@ -2261,7 +2284,8 @@
           "what": "Microsoft hat den Anmeldevorgang selbst abgelehnt — nicht die Berechtigungen, sondern den Weg dorthin.",
           "reason": "Von Microsoft gemeldet: {reason}",
           "next": "Prüfe, ob die Publisher-App des Microsoft-365-Connectors Device-Code-Anmeldungen als öffentlicher Client erlaubt und ob eine Conditional-Access-Richtlinie sie blockiert. Ein erneuter Versuch ändert ohne diese Anpassung nichts."
-        }
+        },
+        "rsc_permissions_mismatch": "Microsoft Graph hat die Installation abgelehnt: Das Teams-App-Paket dieses Orchestrators fordert ressourcenspezifische Berechtigungen, die die installierende Identität nicht erteilen darf. Die Ziel-ID ist korrekt — es fehlt eine Rolle. Weise der Entra-App des M365-Connectors die Rolle TeamsAppInstallation.ReadWriteAndConsentForTeam.All (Team) bzw. …ForChat.All (Chat) zu, erteile die Admin-Zustimmung und starte die Provisionierung erneut."
       },
       "teamsBot": {
         "heading": "Konfiguration für das Teams-Channel-Plugin",

--- a/web-ui/messages/en.json
+++ b/web-ui/messages/en.json
@@ -1995,7 +1995,8 @@
         "install": "Installing into a team is not available in this deployment.",
         "uninstall": "Removing the app from a team needs Microsoft 365 connector 0.4.0 or newer. The connector installed here is older and publishes no uninstall — upgrade the plugin, or have a Teams administrator remove the app manually.",
         "enumerate": "The connector cannot list installs, so this view reports what the provisioning record proves rather than what Teams currently holds.",
-        "multi_team": "One orchestrator is tracked in one team. Assigning a second team would leave the first install untracked, so it is refused."
+        "multi_team": "One orchestrator is tracked in one team. Assigning a second team would leave the first install untracked, so it is refused.",
+        "chat_install": "Installing into a chat needs the Microsoft 365 connector 0.7.0 or newer. The connector installed here is older — update the plugin, or choose a team as the target."
       },
       "unsupportedTechnical": "Server reason: {detail}",
       "notice": {
@@ -2015,9 +2016,31 @@
         "teams_provisioner_unavailable": "The Teams provisioner capability is missing — install the Microsoft 365 connector plugin.",
         "teams_provisioning_running": "A provisioning run is still in flight for this orchestrator. Wait for it to finish, then try again.",
         "teams_uninstall_unsupported": "The Microsoft 365 connector installed here is too old to remove an app from a team. Upgrade it to 0.4.0 or newer, or have a Teams administrator remove the app manually.",
-        "unknown": "The team assignment request failed: {detail}"
+        "unknown": "The team assignment request failed: {detail}",
+        "teams_target_is_channel": "That is a channel id. A channel is not an install target — use the team's group id, or a group chat id.",
+        "teams_target_ambiguous": "Those 32 hex characters are ambiguous — they can be a team id without its dashes, or the stem of a group chat id. Say which one you mean.",
+        "teams_target_unrecognised": "This is not a Teams install target.",
+        "teams_chat_install_unsupported": "The Microsoft 365 connector installed here is too old to install an app into a chat. Update it to 0.7.0 or newer, or choose a team."
       },
-      "pendingStoppedHint": "Team {teamId} is the recorded target, but no provisioning run is active — the chain stopped before the install step. See the Teams identity section above for the recorded error."
+      "pendingStoppedHint": "Team {teamId} is the recorded target, but no provisioning run is active — the chain stopped before the install step. See the Teams identity section above for the recorded error.",
+      "targetHeading": "Choose a target",
+      "fieldTarget": "Target ID",
+      "fieldTargetHint": "A team or a chat. Team: the group id from “Get link to team”. Group chat: the full id in the form 19:…@thread.v2.",
+      "targetKind": {
+        "team": "Team",
+        "group-chat": "Group chat",
+        "one-on-one-chat": "One-to-one chat"
+      },
+      "targetKindLabel": "Detected as: {kind}",
+      "targetExamples": "Examples — team: {team} · group chat: {groupChat}",
+      "targetChannel": "That is a channel id, not an install target. Teams installs an app into a team or into a chat, never into a single channel. Use the group id of the team the channel belongs to, or a group chat id (19:…@thread.v2).",
+      "targetAmbiguous": "32 hex characters with no context — this can be a team group id without its dashes, or the stem of a group chat id. Nothing is guessed here: pick which one you mean.",
+      "targetAmbiguousUseTeam": "Use as team",
+      "targetAmbiguousUseChat": "Use as group chat",
+      "targetUnrecognised": "This is not a Teams install target. Expected a team group id, a group chat id (19:…@thread.v2) or a one-to-one chat id (19:…@unq.gbl.spaces).",
+      "chatInstallUnsupported": "Installing into a chat needs the Microsoft 365 connector 0.7.0 or newer. The connector installed here is older — update the plugin, or choose a team as the target.",
+      "pendingHintTyped": "A provisioning run targets {kind} {teamId}. It only counts as installed once the chain reaches the install step.",
+      "chatNameUnavailable": "The connector provides no name for chats — the id is shown instead."
     },
     "identity": {
       "heading": "Identity",
@@ -2261,7 +2284,8 @@
           "what": "Microsoft refused the sign-in flow itself — not the permissions, but the route to them.",
           "reason": "Reported by Microsoft: {reason}",
           "next": "Check that the Microsoft 365 connector's publisher app allows device-code sign-ins as a public client, and that no Conditional Access policy blocks them. Retrying changes nothing without that adjustment."
-        }
+        },
+        "rsc_permissions_mismatch": "Microsoft Graph refused the install: this orchestrator’s Teams app package declares resource-specific permissions the installing identity may not consent to. The target id is correct — a role is missing. Grant the M365 connector’s Entra app the role TeamsAppInstallation.ReadWriteAndConsentForTeam.All (team) or …ForChat.All (chat), admin-consent it, then re-run provisioning."
       },
       "teamsBot": {
         "heading": "Teams channel plugin configuration",


### PR DESCRIPTION
A provisioned agent could only be installed into a **team**. Group chats are a primary use case and had no path at all. This adds them, and fixes the reason the first real run could not tell anyone what was wrong.

## What the field run exposed

An operator pasted `abc8af8ec7fc471785d3b83c4d84b667` as the install target. The chain answered `400 teamId needs to be a valid GUID`, and once the dashes were added, `404 No team found with Group Id`. A search of all 30 teams in that tenant and every one of their channels found no such id. It was almost certainly a chat — the operator had been asking for the right thing all along, and the chain could only interpret it as a team.

That string is the crux: 32 hex digits read equally well as a team GUID and as the body of a chat thread id. **Guessing is what produced the unexplainable 404.**

## Targets are classified, once

`middleware/src/platform/teamsInstallTarget.ts` turns a pasted string into one of six verdicts: `team`, `group-chat`, `one-on-one-chat`, `channel`, `ambiguous`, `unrecognised`. The route and the runner both read it; neither classifies on its own. `web-ui` carries a deliberate mirror — separate npm project, no import path, the same pattern the middleware already uses for the connector contract.

`channel` and `ambiguous` are verdicts rather than errors because they need different sentences. An app is not installed *into* a channel, so a channel id gets told to use the team id instead of "not found". An ambiguous id gets both readings offered rather than one silently chosen.

**The runner picks its endpoint from the kind it was handed**, never re-derives it from the id. `targetKind` arrives already decided, from the route or the stored row. Re-deriving would make the runner a second classifier free to disagree with the one that validated the request.

## Behaviour change worth knowing

A bare 32-hex id is now a `400` with an explanation, where the previous commit on this branch normalised it to a team GUID. An API client that pasted the unhyphenated `groupId` out of a Teams deep link will be refused. That is the cost of not guessing, and it is the right trade — the UI resolves it in one click, and the alternative is the 404 that started this.

## Migration

`0054_agent_teams_target_kind.sql` adds `target_kind` to both tables, `DEFAULT 'team'`, CHECK-constrained to the three installable kinds. `team_id` is **not** renamed: that touches a primary key, a foreign key and around a hundred call sites, and would still need this column, because "which endpoint installed this?" cannot be recovered from an ambiguous id after the fact. The default is provably right — every existing row was written by a path that could only install into a team.

## Three bugs found before merge, all by running the Postgres suites for real

1. `INSERT has more target columns than expressions` — a column added to the list without its placeholder. Invisible to the unit suite, which mocks the pool.
2. Guard ordering put a chat-capability `501` ahead of the mount-level `503` and the agent `404`, so "no connector at all" would have answered the wrong thing.
3. **A migration probed `pg_constraint` by name without scoping to the table.** Parallel suites each run in their own schema, so the probe found the constraint *elsewhere*, silently skipped creating it, and reported success — leaving a column with no CHECK. Now scoped by `conrelid`.

The third one is not confined to this change: `0053_agent_identity_persona.sql` has the same unscoped probe, and it is the one remaining Postgres failure locally. It fails identically on the base branch with these changes stashed, so it is pre-existing and filed separately rather than fixed here.

## Verification

middleware: **7997 pass, 0 fail** (16 skipped); typecheck clean; `typecheck:test` at baseline 370 with no regressions; lint 0 problems. web-ui: **1066 pass, 0 fail** across 116 files; typecheck clean; `i18n:check` OK at 4272 keys; 0 lint errors.

## Not in this change

`uninstallFromChat` is on the accessor and forwarded, but the DELETE route still only calls `uninstallFromTeam` — a chat binding cannot yet be removed through the UI.

The real target picker needs two connector methods that do not exist (`listTeams`, `listChats`); the contract has only `getTeam`, which resolves one *known* id to a name. Until then the field is freetext with live type detection, examples, and actionable messages for the channel and ambiguous cases.

Requires `@omadia/integration-microsoft365` **0.7.0**.

Refs #860, #924.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/byte5ai/codesmith/omadia/pr/950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790586903&installation_model_id=428086&pr_number=950&repository=byte5ai%2Fomadia&return_to=https%3A%2F%2Fgithub.com%2Fbyte5ai%2Fomadia%2Fpull%2F950&signature=f4ef77aef6a85bcca6536b0eab1642ba6803465be1293f75067936b513a46655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->